### PR TITLE
feat: add v2 TOML config schema with validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.1
 tool github.com/gomantics/cfgx/cmd/cfgx
 
 require (
+	github.com/BurntSushi/toml v1.5.0
 	github.com/charmbracelet/bubbles v0.21.1
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -14,7 +15,6 @@ require (
 )
 
 require (
-	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/ansi v0.11.5 // indirect

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -1,0 +1,228 @@
+// Package workspace provides workspace/project management.
+package workspace
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// ConfigVersion is the current config schema version.
+const ConfigVersion = 2
+
+// V2Config represents the TOML-based workspace configuration for bc v2.
+type V2Config struct {
+	Workspace WorkspaceConfig `toml:"workspace"`
+	Worktrees WorktreesConfig `toml:"worktrees"`
+	Tools     ToolsConfig     `toml:"tools"`
+	Memory    MemoryConfig    `toml:"memory"`
+	Beads     BeadsConfig     `toml:"beads"`
+	Channels  ChannelsConfig  `toml:"channels"`
+}
+
+// WorkspaceConfig holds core workspace settings.
+type WorkspaceConfig struct {
+	Name    string `toml:"name"`
+	Version int    `toml:"version"`
+}
+
+// WorktreesConfig configures git worktree management.
+type WorktreesConfig struct {
+	Path        string `toml:"path"`
+	AutoCleanup bool   `toml:"auto_cleanup"`
+}
+
+// ToolsConfig configures available AI tools.
+type ToolsConfig struct {
+	Custom  map[string]ToolConfig `toml:"-"`
+	Claude  *ToolConfig           `toml:"claude,omitempty"`
+	Cursor  *ToolConfig           `toml:"cursor,omitempty"`
+	Codex   *ToolConfig           `toml:"codex,omitempty"`
+	Default string                `toml:"default"`
+}
+
+// ToolConfig defines a single tool's configuration.
+type ToolConfig struct {
+	Command string `toml:"command"`
+	Enabled bool   `toml:"enabled"`
+}
+
+// MemoryConfig configures agent memory/context persistence.
+type MemoryConfig struct {
+	Backend string `toml:"backend"` // "file", "sqlite", etc.
+	Path    string `toml:"path"`
+}
+
+// BeadsConfig configures beads issue tracker integration.
+type BeadsConfig struct {
+	IssuesDir string `toml:"issues_dir"`
+	Enabled   bool   `toml:"enabled"`
+}
+
+// ChannelsConfig configures communication channels.
+type ChannelsConfig struct {
+	Default []string `toml:"default"`
+}
+
+// Validation errors.
+var (
+	ErrMissingWorkspaceName = errors.New("workspace.name is required")
+	ErrInvalidVersion       = errors.New("workspace.version must be 2")
+	ErrMissingDefaultTool   = errors.New("tools.default is required")
+	ErrDefaultToolNotFound  = errors.New("tools.default references undefined tool")
+	ErrMissingMemoryBackend = errors.New("memory.backend is required")
+	ErrMissingMemoryPath    = errors.New("memory.path is required")
+)
+
+// DefaultV2Config returns sensible defaults for a new v2 workspace.
+func DefaultV2Config(name string) V2Config {
+	return V2Config{
+		Workspace: WorkspaceConfig{
+			Name:    name,
+			Version: ConfigVersion,
+		},
+		Worktrees: WorktreesConfig{
+			Path:        ".bc/worktrees",
+			AutoCleanup: true,
+		},
+		Tools: ToolsConfig{
+			Default: "claude",
+			Claude: &ToolConfig{
+				Command: "claude --dangerously-skip-permissions",
+				Enabled: true,
+			},
+		},
+		Memory: MemoryConfig{
+			Backend: "file",
+			Path:    ".bc/memory",
+		},
+		Beads: BeadsConfig{
+			Enabled:   true,
+			IssuesDir: ".beads/issues",
+		},
+		Channels: ChannelsConfig{
+			Default: []string{"general", "engineering"},
+		},
+	}
+}
+
+// LoadV2Config reads and parses a TOML config file.
+func LoadV2Config(path string) (*V2Config, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path provided by caller
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config: %w", err)
+	}
+
+	return ParseV2Config(data)
+}
+
+// ParseV2Config parses TOML data into a V2Config.
+func ParseV2Config(data []byte) (*V2Config, error) {
+	var cfg V2Config
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+
+	return &cfg, nil
+}
+
+// Validate checks the config for required fields and consistency.
+func (c *V2Config) Validate() error {
+	// Workspace validation
+	if c.Workspace.Name == "" {
+		return ErrMissingWorkspaceName
+	}
+	if c.Workspace.Version != ConfigVersion {
+		return ErrInvalidVersion
+	}
+
+	// Tools validation
+	if c.Tools.Default == "" {
+		return ErrMissingDefaultTool
+	}
+	if !c.hasToolDefined(c.Tools.Default) {
+		return ErrDefaultToolNotFound
+	}
+
+	// Memory validation
+	if c.Memory.Backend == "" {
+		return ErrMissingMemoryBackend
+	}
+	if c.Memory.Path == "" {
+		return ErrMissingMemoryPath
+	}
+
+	return nil
+}
+
+// hasToolDefined checks if a tool is configured.
+func (c *V2Config) hasToolDefined(name string) bool {
+	switch name {
+	case "claude":
+		return c.Tools.Claude != nil
+	case "cursor":
+		return c.Tools.Cursor != nil
+	case "codex":
+		return c.Tools.Codex != nil
+	default:
+		_, ok := c.Tools.Custom[name]
+		return ok
+	}
+}
+
+// GetTool returns the configuration for a named tool.
+func (c *V2Config) GetTool(name string) *ToolConfig {
+	switch name {
+	case "claude":
+		return c.Tools.Claude
+	case "cursor":
+		return c.Tools.Cursor
+	case "codex":
+		return c.Tools.Codex
+	default:
+		if cfg, ok := c.Tools.Custom[name]; ok {
+			return &cfg
+		}
+		return nil
+	}
+}
+
+// GetDefaultTool returns the default tool configuration.
+func (c *V2Config) GetDefaultTool() *ToolConfig {
+	return c.GetTool(c.Tools.Default)
+}
+
+// Save writes the config to a TOML file.
+func (c *V2Config) Save(path string) error {
+	// Ensure parent directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+
+	f, err := os.Create(path) //nolint:gosec // path provided by caller
+	if err != nil {
+		return fmt.Errorf("failed to create config file: %w", err)
+	}
+
+	encoder := toml.NewEncoder(f)
+	encodeErr := encoder.Encode(c)
+	closeErr := f.Close()
+
+	if encodeErr != nil {
+		return fmt.Errorf("failed to encode config: %w", encodeErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("failed to close config file: %w", closeErr)
+	}
+
+	return nil
+}
+
+// ConfigPath returns the standard config file path for a workspace root.
+func ConfigPath(rootDir string) string {
+	return filepath.Join(rootDir, ".bc", "config.toml")
+}

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -1,0 +1,251 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultV2Config(t *testing.T) {
+	cfg := DefaultV2Config("test-project")
+
+	if cfg.Workspace.Name != "test-project" {
+		t.Errorf("expected name 'test-project', got %q", cfg.Workspace.Name)
+	}
+	if cfg.Workspace.Version != ConfigVersion {
+		t.Errorf("expected version %d, got %d", ConfigVersion, cfg.Workspace.Version)
+	}
+	if cfg.Tools.Default != "claude" {
+		t.Errorf("expected default tool 'claude', got %q", cfg.Tools.Default)
+	}
+	if cfg.Tools.Claude == nil {
+		t.Error("expected claude tool to be configured")
+	}
+	if cfg.Memory.Backend != "file" {
+		t.Errorf("expected memory backend 'file', got %q", cfg.Memory.Backend)
+	}
+}
+
+func TestParseV2Config(t *testing.T) {
+	tomlData := []byte(`
+[workspace]
+name = "my-project"
+version = 2
+
+[worktrees]
+path = ".bc/worktrees"
+auto_cleanup = true
+
+[tools]
+default = "claude"
+
+[tools.claude]
+command = "claude --dangerously-skip-permissions"
+enabled = true
+
+[memory]
+backend = "file"
+path = ".bc/memory"
+
+[beads]
+enabled = true
+issues_dir = ".beads/issues"
+
+[channels]
+default = ["general", "engineering"]
+`)
+
+	cfg, err := ParseV2Config(tomlData)
+	if err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	if cfg.Workspace.Name != "my-project" {
+		t.Errorf("expected name 'my-project', got %q", cfg.Workspace.Name)
+	}
+	if cfg.Workspace.Version != 2 {
+		t.Errorf("expected version 2, got %d", cfg.Workspace.Version)
+	}
+	if cfg.Worktrees.Path != ".bc/worktrees" {
+		t.Errorf("expected worktrees path '.bc/worktrees', got %q", cfg.Worktrees.Path)
+	}
+	if !cfg.Worktrees.AutoCleanup {
+		t.Error("expected auto_cleanup to be true")
+	}
+	if cfg.Tools.Default != "claude" {
+		t.Errorf("expected default tool 'claude', got %q", cfg.Tools.Default)
+	}
+	if cfg.Tools.Claude == nil {
+		t.Fatal("expected claude tool config")
+	}
+	if cfg.Tools.Claude.Command != "claude --dangerously-skip-permissions" {
+		t.Errorf("unexpected claude command: %q", cfg.Tools.Claude.Command)
+	}
+	if !cfg.Tools.Claude.Enabled {
+		t.Error("expected claude to be enabled")
+	}
+	if cfg.Memory.Backend != "file" {
+		t.Errorf("expected memory backend 'file', got %q", cfg.Memory.Backend)
+	}
+	if cfg.Memory.Path != ".bc/memory" {
+		t.Errorf("expected memory path '.bc/memory', got %q", cfg.Memory.Path)
+	}
+	if !cfg.Beads.Enabled {
+		t.Error("expected beads to be enabled")
+	}
+	if cfg.Beads.IssuesDir != ".beads/issues" {
+		t.Errorf("expected beads issues_dir '.beads/issues', got %q", cfg.Beads.IssuesDir)
+	}
+	if len(cfg.Channels.Default) != 2 {
+		t.Errorf("expected 2 default channels, got %d", len(cfg.Channels.Default))
+	}
+}
+
+func TestV2ConfigValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr error
+		cfg     V2Config
+	}{
+		{
+			name:    "missing workspace name",
+			wantErr: ErrMissingWorkspaceName,
+			cfg:     V2Config{Workspace: WorkspaceConfig{Version: 2}},
+		},
+		{
+			name:    "invalid version",
+			wantErr: ErrInvalidVersion,
+			cfg: V2Config{
+				Workspace: WorkspaceConfig{Name: "test", Version: 1},
+			},
+		},
+		{
+			name:    "missing default tool",
+			wantErr: ErrMissingDefaultTool,
+			cfg: V2Config{
+				Workspace: WorkspaceConfig{Name: "test", Version: 2},
+			},
+		},
+		{
+			name:    "default tool not defined",
+			wantErr: ErrDefaultToolNotFound,
+			cfg: V2Config{
+				Workspace: WorkspaceConfig{Name: "test", Version: 2},
+				Tools:     ToolsConfig{Default: "nonexistent"},
+			},
+		},
+		{
+			name:    "missing memory backend",
+			wantErr: ErrMissingMemoryBackend,
+			cfg: V2Config{
+				Workspace: WorkspaceConfig{Name: "test", Version: 2},
+				Tools:     ToolsConfig{Default: "claude", Claude: &ToolConfig{Enabled: true}},
+			},
+		},
+		{
+			name:    "missing memory path",
+			wantErr: ErrMissingMemoryPath,
+			cfg: V2Config{
+				Workspace: WorkspaceConfig{Name: "test", Version: 2},
+				Tools:     ToolsConfig{Default: "claude", Claude: &ToolConfig{Enabled: true}},
+				Memory:    MemoryConfig{Backend: "file"},
+			},
+		},
+		{
+			name:    "valid config",
+			wantErr: nil,
+			cfg:     DefaultV2Config("test"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if err != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestV2ConfigGetTool(t *testing.T) {
+	cfg := DefaultV2Config("test")
+
+	// Test getting claude (default)
+	tool := cfg.GetTool("claude")
+	if tool == nil {
+		t.Fatal("expected claude tool config")
+	}
+	if tool.Command != "claude --dangerously-skip-permissions" {
+		t.Errorf("unexpected command: %q", tool.Command)
+	}
+
+	// Test getting non-existent tool
+	tool = cfg.GetTool("nonexistent")
+	if tool != nil {
+		t.Error("expected nil for nonexistent tool")
+	}
+
+	// Test GetDefaultTool
+	tool = cfg.GetDefaultTool()
+	if tool == nil {
+		t.Fatal("expected default tool config")
+	}
+}
+
+func TestV2ConfigSaveAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".bc", "config.toml")
+
+	// Create and save config
+	cfg := DefaultV2Config("save-test")
+	cfg.Beads.Enabled = false
+	cfg.Channels.Default = []string{"custom-channel"}
+
+	if err := cfg.Save(configPath); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+
+	// Load and verify
+	loaded, err := LoadV2Config(configPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	if loaded.Workspace.Name != "save-test" {
+		t.Errorf("expected name 'save-test', got %q", loaded.Workspace.Name)
+	}
+	if loaded.Beads.Enabled {
+		t.Error("expected beads to be disabled")
+	}
+	if len(loaded.Channels.Default) != 1 || loaded.Channels.Default[0] != "custom-channel" {
+		t.Errorf("unexpected channels: %v", loaded.Channels.Default)
+	}
+}
+
+func TestConfigPath(t *testing.T) {
+	path := ConfigPath("/home/user/project")
+	expected := "/home/user/project/.bc/config.toml"
+	if path != expected {
+		t.Errorf("expected %q, got %q", expected, path)
+	}
+}
+
+func TestLoadV2ConfigNotFound(t *testing.T) {
+	_, err := LoadV2Config("/nonexistent/path/config.toml")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestParseV2ConfigInvalid(t *testing.T) {
+	_, err := ParseV2Config([]byte("invalid toml {{{"))
+	if err == nil {
+		t.Error("expected error for invalid TOML")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds V2Config struct with full TOML configuration support
- Implements workspace, worktrees, tools, memory, beads, and channels sections
- Adds validation for required fields
- Includes load/save/parse functions

Part of Epic 1.1: Workspace Restructure (bc-m3p)
Closes: bc-m3p.1

## Test plan
- [x] Unit tests in config_test.go
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)