### PR TITLE
feat: add role file management with YAML frontmatter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.2
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
 golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -1,0 +1,290 @@
+// Package workspace provides workspace/project management.
+package workspace
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// RoleMetadata contains the parsed frontmatter from a role file.
+type RoleMetadata struct {
+	Name         string   `yaml:"name"`
+	Capabilities []string `yaml:"capabilities,omitempty"`
+	ParentRoles  []string `yaml:"parent_roles,omitempty"`
+	IsSingleton  bool     `yaml:"is_singleton,omitempty"`
+}
+
+// Role represents a parsed role file with metadata and prompt content.
+type Role struct {
+	FilePath string       // Path to the role file
+	Prompt   string       // Markdown body after frontmatter
+	Metadata RoleMetadata // Parsed YAML frontmatter
+}
+
+// RoleManager handles role file operations for a workspace.
+type RoleManager struct {
+	roles    map[string]*Role
+	rolesDir string
+}
+
+// DefaultRootRole returns the default content for root.md.
+const DefaultRootRole = `---
+name: root
+is_singleton: true
+---
+
+# Root Agent
+
+You are the root agent for this bc workspace.
+
+## Responsibilities
+- Oversee all workspace operations
+- Coordinate top-level agents
+- Handle merge queue for the main branch
+- Ensure workspace integrity
+
+## Guidelines
+1. You are the singleton root - only one instance exists
+2. Delegate work to child agents (managers, engineers)
+3. Review and merge completed work
+4. Monitor workspace health
+`
+
+// NewRoleManager creates a new role manager for the given workspace state directory.
+func NewRoleManager(stateDir string) *RoleManager {
+	return &RoleManager{
+		rolesDir: filepath.Join(stateDir, "roles"),
+		roles:    make(map[string]*Role),
+	}
+}
+
+// RolesDir returns the roles directory path.
+func (rm *RoleManager) RolesDir() string {
+	return rm.rolesDir
+}
+
+// EnsureRolesDir creates the roles directory if it doesn't exist.
+func (rm *RoleManager) EnsureRolesDir() error {
+	return os.MkdirAll(rm.rolesDir, 0750)
+}
+
+// EnsureDefaultRoot creates the default root.md if it doesn't exist.
+// Returns true if the file was created, false if it already existed.
+func (rm *RoleManager) EnsureDefaultRoot() (bool, error) {
+	rootPath := filepath.Join(rm.rolesDir, "root.md")
+
+	// Check if file exists
+	if _, err := os.Stat(rootPath); err == nil {
+		return false, nil // Already exists
+	} else if !os.IsNotExist(err) {
+		return false, fmt.Errorf("failed to check root.md: %w", err)
+	}
+
+	// Create roles directory if needed
+	if err := rm.EnsureRolesDir(); err != nil {
+		return false, err
+	}
+
+	// Write default root.md
+	if err := os.WriteFile(rootPath, []byte(DefaultRootRole), 0600); err != nil {
+		return false, fmt.Errorf("failed to create root.md: %w", err)
+	}
+
+	return true, nil
+}
+
+// LoadRole loads and parses a single role file.
+func (rm *RoleManager) LoadRole(name string) (*Role, error) {
+	// Check cache first
+	if role, ok := rm.roles[name]; ok {
+		return role, nil
+	}
+
+	filePath := filepath.Join(rm.rolesDir, name+".md")
+	return rm.loadRoleFromPath(filePath)
+}
+
+// loadRoleFromPath loads a role from a specific file path.
+func (rm *RoleManager) loadRoleFromPath(filePath string) (*Role, error) {
+	data, err := os.ReadFile(filePath) //nolint:gosec // path constructed from known roles dir
+	if err != nil {
+		return nil, fmt.Errorf("failed to read role file: %w", err)
+	}
+
+	role, err := ParseRoleFile(data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse role file %s: %w", filePath, err)
+	}
+
+	role.FilePath = filePath
+
+	// Cache the role
+	rm.roles[role.Metadata.Name] = role
+
+	return role, nil
+}
+
+// LoadAllRoles loads all role files from the roles directory.
+func (rm *RoleManager) LoadAllRoles() (map[string]*Role, error) {
+	// Ensure default root exists
+	if _, err := rm.EnsureDefaultRoot(); err != nil {
+		return nil, err
+	}
+
+	entries, err := os.ReadDir(rm.rolesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return rm.roles, nil // Empty roles directory
+		}
+		return nil, fmt.Errorf("failed to read roles directory: %w", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+
+		filePath := filepath.Join(rm.rolesDir, name)
+		if _, err := rm.loadRoleFromPath(filePath); err != nil {
+			return nil, err
+		}
+	}
+
+	return rm.roles, nil
+}
+
+// GetRole returns a cached role by name.
+func (rm *RoleManager) GetRole(name string) (*Role, bool) {
+	role, ok := rm.roles[name]
+	return role, ok
+}
+
+// HasRole checks if a role exists (either cached or on disk).
+func (rm *RoleManager) HasRole(name string) bool {
+	// Check cache
+	if _, ok := rm.roles[name]; ok {
+		return true
+	}
+
+	// Check disk
+	filePath := filepath.Join(rm.rolesDir, name+".md")
+	_, err := os.Stat(filePath)
+	return err == nil
+}
+
+// ParseRoleFile parses a role file with YAML frontmatter and markdown body.
+// The frontmatter is delimited by --- on its own lines.
+func ParseRoleFile(data []byte) (*Role, error) {
+	content := string(data)
+
+	// Check for frontmatter delimiter
+	if !strings.HasPrefix(content, "---\n") && !strings.HasPrefix(content, "---\r\n") {
+		// No frontmatter - treat entire content as prompt
+		return &Role{
+			Metadata: RoleMetadata{},
+			Prompt:   strings.TrimSpace(content),
+		}, nil
+	}
+
+	// Find the closing delimiter
+	// Skip the opening "---\n"
+	rest := content[4:]
+	endIdx := strings.Index(rest, "\n---")
+	if endIdx == -1 {
+		// No closing delimiter - treat as no frontmatter
+		return &Role{
+			Metadata: RoleMetadata{},
+			Prompt:   strings.TrimSpace(content),
+		}, nil
+	}
+
+	// Extract frontmatter and body
+	frontmatter := rest[:endIdx]
+	body := rest[endIdx+4:] // Skip "\n---"
+
+	// Skip any trailing newline after closing delimiter
+	if strings.HasPrefix(body, "\n") {
+		body = body[1:]
+	} else if strings.HasPrefix(body, "\r\n") {
+		body = body[2:]
+	}
+
+	// Parse YAML frontmatter
+	var metadata RoleMetadata
+	decoder := yaml.NewDecoder(bytes.NewReader([]byte(frontmatter)))
+	if err := decoder.Decode(&metadata); err != nil {
+		return nil, fmt.Errorf("invalid YAML frontmatter: %w", err)
+	}
+
+	return &Role{
+		Metadata: metadata,
+		Prompt:   strings.TrimSpace(body),
+	}, nil
+}
+
+// WriteRole writes a role to the roles directory.
+func (rm *RoleManager) WriteRole(role *Role) error {
+	if err := rm.EnsureRolesDir(); err != nil {
+		return err
+	}
+
+	name := role.Metadata.Name
+	if name == "" {
+		return fmt.Errorf("role name is required")
+	}
+
+	filePath := filepath.Join(rm.rolesDir, name+".md")
+
+	// Generate file content
+	content, err := FormatRoleFile(role)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(filePath, []byte(content), 0600); err != nil {
+		return fmt.Errorf("failed to write role file: %w", err)
+	}
+
+	// Update cache
+	role.FilePath = filePath
+	rm.roles[name] = role
+
+	return nil
+}
+
+// FormatRoleFile formats a role as a markdown file with YAML frontmatter.
+func FormatRoleFile(role *Role) (string, error) {
+	var buf bytes.Buffer
+
+	// Write frontmatter
+	buf.WriteString("---\n")
+
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(role.Metadata); err != nil {
+		return "", fmt.Errorf("failed to encode metadata: %w", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return "", fmt.Errorf("failed to close encoder: %w", err)
+	}
+
+	buf.WriteString("---\n\n")
+
+	// Write prompt body
+	buf.WriteString(role.Prompt)
+	if !strings.HasSuffix(role.Prompt, "\n") {
+		buf.WriteString("\n")
+	}
+
+	return buf.String(), nil
+}

--- a/pkg/workspace/roles_test.go
+++ b/pkg/workspace/roles_test.go
@@ -1,0 +1,390 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseRoleFile_WithFrontmatter(t *testing.T) {
+	content := `---
+name: engineer
+capabilities:
+  - implement_tasks
+  - write_tests
+parent_roles:
+  - manager
+---
+
+# Engineer Role
+
+You are an engineer agent.
+`
+
+	role, err := ParseRoleFile([]byte(content))
+	if err != nil {
+		t.Fatalf("ParseRoleFile failed: %v", err)
+	}
+
+	if role.Metadata.Name != "engineer" {
+		t.Errorf("Name = %q, want %q", role.Metadata.Name, "engineer")
+	}
+
+	if len(role.Metadata.Capabilities) != 2 {
+		t.Errorf("Capabilities len = %d, want 2", len(role.Metadata.Capabilities))
+	}
+
+	if role.Metadata.Capabilities[0] != "implement_tasks" {
+		t.Errorf("Capabilities[0] = %q, want %q", role.Metadata.Capabilities[0], "implement_tasks")
+	}
+
+	if len(role.Metadata.ParentRoles) != 1 || role.Metadata.ParentRoles[0] != "manager" {
+		t.Errorf("ParentRoles = %v, want [manager]", role.Metadata.ParentRoles)
+	}
+
+	expectedPrompt := "# Engineer Role\n\nYou are an engineer agent."
+	if role.Prompt != expectedPrompt {
+		t.Errorf("Prompt = %q, want %q", role.Prompt, expectedPrompt)
+	}
+}
+
+func TestParseRoleFile_WithSingleton(t *testing.T) {
+	content := `---
+name: root
+is_singleton: true
+---
+
+# Root Agent
+`
+
+	role, err := ParseRoleFile([]byte(content))
+	if err != nil {
+		t.Fatalf("ParseRoleFile failed: %v", err)
+	}
+
+	if !role.Metadata.IsSingleton {
+		t.Error("IsSingleton should be true")
+	}
+}
+
+func TestParseRoleFile_NoFrontmatter(t *testing.T) {
+	content := `# Simple Role
+
+Just a markdown file without frontmatter.
+`
+
+	role, err := ParseRoleFile([]byte(content))
+	if err != nil {
+		t.Fatalf("ParseRoleFile failed: %v", err)
+	}
+
+	if role.Metadata.Name != "" {
+		t.Errorf("Name should be empty, got %q", role.Metadata.Name)
+	}
+
+	if role.Prompt == "" {
+		t.Error("Prompt should not be empty")
+	}
+}
+
+func TestParseRoleFile_InvalidYAML(t *testing.T) {
+	content := `---
+name: [invalid yaml
+---
+
+Body
+`
+
+	_, err := ParseRoleFile([]byte(content))
+	if err == nil {
+		t.Error("ParseRoleFile should fail on invalid YAML")
+	}
+}
+
+func TestParseRoleFile_UnclosedFrontmatter(t *testing.T) {
+	content := `---
+name: test
+
+No closing delimiter, treat as plain markdown.
+`
+
+	role, err := ParseRoleFile([]byte(content))
+	if err != nil {
+		t.Fatalf("ParseRoleFile should handle unclosed frontmatter: %v", err)
+	}
+
+	// Should treat entire content as prompt
+	if role.Metadata.Name != "" {
+		t.Errorf("Name should be empty for unclosed frontmatter, got %q", role.Metadata.Name)
+	}
+}
+
+func TestRoleManager_EnsureDefaultRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, ".bc")
+
+	rm := NewRoleManager(stateDir)
+
+	// First call should create
+	created, err := rm.EnsureDefaultRoot()
+	if err != nil {
+		t.Fatalf("EnsureDefaultRoot failed: %v", err)
+	}
+	if !created {
+		t.Error("First call should report created=true")
+	}
+
+	// Verify file exists
+	rootPath := filepath.Join(rm.RolesDir(), "root.md")
+	if _, statErr := os.Stat(rootPath); statErr != nil {
+		t.Errorf("root.md should exist: %v", statErr)
+	}
+
+	// Second call should not create
+	created, err = rm.EnsureDefaultRoot()
+	if err != nil {
+		t.Fatalf("Second EnsureDefaultRoot failed: %v", err)
+	}
+	if created {
+		t.Error("Second call should report created=false")
+	}
+}
+
+func TestRoleManager_LoadRole(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, ".bc")
+	rolesDir := filepath.Join(stateDir, "roles")
+
+	if err := os.MkdirAll(rolesDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a test role
+	roleContent := `---
+name: qa
+capabilities:
+  - run_tests
+  - validate_fixes
+---
+
+# QA Role
+
+You are a QA agent.
+`
+	if err := os.WriteFile(filepath.Join(rolesDir, "qa.md"), []byte(roleContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	rm := NewRoleManager(stateDir)
+
+	role, err := rm.LoadRole("qa")
+	if err != nil {
+		t.Fatalf("LoadRole failed: %v", err)
+	}
+
+	if role.Metadata.Name != "qa" {
+		t.Errorf("Name = %q, want %q", role.Metadata.Name, "qa")
+	}
+
+	if len(role.Metadata.Capabilities) != 2 {
+		t.Errorf("Capabilities len = %d, want 2", len(role.Metadata.Capabilities))
+	}
+
+	// Should be cached
+	role2, ok := rm.GetRole("qa")
+	if !ok {
+		t.Error("Role should be cached")
+	}
+	if role2 != role {
+		t.Error("Cached role should be same pointer")
+	}
+}
+
+func TestRoleManager_LoadAllRoles(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, ".bc")
+	rolesDir := filepath.Join(stateDir, "roles")
+
+	if err := os.MkdirAll(rolesDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create multiple roles
+	roles := map[string]string{
+		"engineer.md": `---
+name: engineer
+---
+
+Engineer prompt.
+`,
+		"manager.md": `---
+name: manager
+---
+
+Manager prompt.
+`,
+	}
+
+	for name, content := range roles {
+		if err := os.WriteFile(filepath.Join(rolesDir, name), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rm := NewRoleManager(stateDir)
+
+	loadedRoles, err := rm.LoadAllRoles()
+	if err != nil {
+		t.Fatalf("LoadAllRoles failed: %v", err)
+	}
+
+	// Should have engineer, manager, and auto-generated root
+	if len(loadedRoles) != 3 {
+		t.Errorf("Should have 3 roles (engineer, manager, root), got %d", len(loadedRoles))
+	}
+
+	if _, ok := loadedRoles["engineer"]; !ok {
+		t.Error("Should have engineer role")
+	}
+	if _, ok := loadedRoles["manager"]; !ok {
+		t.Error("Should have manager role")
+	}
+	if _, ok := loadedRoles["root"]; !ok {
+		t.Error("Should have root role (auto-generated)")
+	}
+}
+
+func TestRoleManager_HasRole(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, ".bc")
+	rolesDir := filepath.Join(stateDir, "roles")
+
+	if err := os.MkdirAll(rolesDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create one role file
+	if err := os.WriteFile(filepath.Join(rolesDir, "test.md"), []byte("---\nname: test\n---\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	rm := NewRoleManager(stateDir)
+
+	if !rm.HasRole("test") {
+		t.Error("HasRole should return true for existing role")
+	}
+
+	if rm.HasRole("nonexistent") {
+		t.Error("HasRole should return false for nonexistent role")
+	}
+}
+
+func TestRoleManager_WriteRole(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, ".bc")
+
+	rm := NewRoleManager(stateDir)
+
+	role := &Role{
+		Metadata: RoleMetadata{
+			Name:         "custom",
+			Capabilities: []string{"custom_capability"},
+			ParentRoles:  []string{"root"},
+		},
+		Prompt: "# Custom Role\n\nCustom prompt content.",
+	}
+
+	if err := rm.WriteRole(role); err != nil {
+		t.Fatalf("WriteRole failed: %v", err)
+	}
+
+	// Verify file exists
+	filePath := filepath.Join(rm.RolesDir(), "custom.md")
+	if _, err := os.Stat(filePath); err != nil {
+		t.Errorf("Role file should exist: %v", err)
+	}
+
+	// Reload and verify
+	rm2 := NewRoleManager(stateDir)
+	loaded, err := rm2.LoadRole("custom")
+	if err != nil {
+		t.Fatalf("Failed to reload role: %v", err)
+	}
+
+	if loaded.Metadata.Name != "custom" {
+		t.Errorf("Name = %q, want %q", loaded.Metadata.Name, "custom")
+	}
+
+	if len(loaded.Metadata.Capabilities) != 1 {
+		t.Errorf("Capabilities len = %d, want 1", len(loaded.Metadata.Capabilities))
+	}
+}
+
+func TestRoleManager_WriteRole_NoName(t *testing.T) {
+	tmpDir := t.TempDir()
+	stateDir := filepath.Join(tmpDir, ".bc")
+
+	rm := NewRoleManager(stateDir)
+
+	role := &Role{
+		Prompt: "No name provided",
+	}
+
+	err := rm.WriteRole(role)
+	if err == nil {
+		t.Error("WriteRole should fail without name")
+	}
+}
+
+func TestFormatRoleFile(t *testing.T) {
+	role := &Role{
+		Metadata: RoleMetadata{
+			Name:         "test",
+			Capabilities: []string{"cap1", "cap2"},
+			IsSingleton:  true,
+		},
+		Prompt: "# Test Role\n\nTest content.",
+	}
+
+	content, err := FormatRoleFile(role)
+	if err != nil {
+		t.Fatalf("FormatRoleFile failed: %v", err)
+	}
+
+	// Should be parseable
+	parsed, err := ParseRoleFile([]byte(content))
+	if err != nil {
+		t.Fatalf("Failed to parse formatted content: %v", err)
+	}
+
+	if parsed.Metadata.Name != role.Metadata.Name {
+		t.Errorf("Round-trip Name = %q, want %q", parsed.Metadata.Name, role.Metadata.Name)
+	}
+
+	if !parsed.Metadata.IsSingleton {
+		t.Error("Round-trip IsSingleton should be true")
+	}
+
+	if len(parsed.Metadata.Capabilities) != 2 {
+		t.Errorf("Round-trip Capabilities len = %d, want 2", len(parsed.Metadata.Capabilities))
+	}
+}
+
+func TestDefaultRootRole_Parseable(t *testing.T) {
+	role, err := ParseRoleFile([]byte(DefaultRootRole))
+	if err != nil {
+		t.Fatalf("DefaultRootRole should be parseable: %v", err)
+	}
+
+	if role.Metadata.Name != "root" {
+		t.Errorf("Name = %q, want %q", role.Metadata.Name, "root")
+	}
+
+	if !role.Metadata.IsSingleton {
+		t.Error("IsSingleton should be true")
+	}
+
+	if role.Prompt == "" {
+		t.Error("Prompt should not be empty")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds RoleManager for handling role file operations
- Implements YAML frontmatter parsing with gopkg.in/yaml.v3
- Auto-generates default root.md if missing
- Caches loaded roles for performance

Part of Epic 1.1: Workspace Restructure (bc-m3p)
Closes: bc-m3p.2

## Test plan
- [x] Unit tests in roles_test.go
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)