### PR TITLE
feat: add per-agent state files with atomic writes

### DIFF
--- a/pkg/agent/state.go
+++ b/pkg/agent/state.go
@@ -1,0 +1,299 @@
+// Package agent provides agent lifecycle management.
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/queue"
+)
+
+// AgentState represents the persistent state of an agent.
+// This is stored as a per-agent JSON file in .bc/agents/<name>.json
+type AgentState struct {
+	StartedAt  time.Time        `json:"started_at"`
+	UpdatedAt  time.Time        `json:"updated_at"`
+	Name       string           `json:"name"`
+	Tool       string           `json:"tool,omitempty"`
+	Team       string           `json:"team,omitempty"`
+	Parent     string           `json:"parent,omitempty"`
+	Worktree   string           `json:"worktree,omitempty"`
+	Session    string           `json:"session,omitempty"`
+	Role       Role             `json:"role"`
+	State      State            `json:"state"`
+	WorkQueue  []queue.WorkItem `json:"work_queue,omitempty"`
+	MergeQueue []queue.WorkItem `json:"merge_queue,omitempty"`
+}
+
+// StateStore manages per-agent state files in .bc/agents/
+type StateStore struct {
+	agentsDir string
+	mu        sync.RWMutex
+}
+
+// NewStateStore creates a new state store for the given .bc directory.
+func NewStateStore(bcDir string) *StateStore {
+	return &StateStore{
+		agentsDir: filepath.Join(bcDir, "agents"),
+	}
+}
+
+// agentFilePath returns the path for an agent's state file.
+func (s *StateStore) agentFilePath(name string) string {
+	return filepath.Join(s.agentsDir, name+".json")
+}
+
+// tempFilePath returns a temporary file path for atomic writes.
+func (s *StateStore) tempFilePath(name string) string {
+	return filepath.Join(s.agentsDir, "."+name+".json.tmp")
+}
+
+// EnsureDir creates the agents directory if it doesn't exist.
+func (s *StateStore) EnsureDir() error {
+	return os.MkdirAll(s.agentsDir, 0750)
+}
+
+// Save persists an agent's state to disk atomically.
+// It writes to a temp file first, then renames to ensure atomic updates.
+func (s *StateStore) Save(state *AgentState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.EnsureDir(); err != nil {
+		return fmt.Errorf("failed to create agents directory: %w", err)
+	}
+
+	// Update timestamp
+	state.UpdatedAt = time.Now()
+
+	// Marshal to JSON with indentation for readability
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal agent state: %w", err)
+	}
+
+	// Write to temp file first
+	tempPath := s.tempFilePath(state.Name)
+	if err := os.WriteFile(tempPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	// Atomic rename
+	targetPath := s.agentFilePath(state.Name)
+	if err := os.Rename(tempPath, targetPath); err != nil {
+		// Clean up temp file on failure
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	return nil
+}
+
+// Load reads an agent's state from disk.
+// Returns nil, nil if the agent file doesn't exist.
+func (s *StateStore) Load(name string) (*AgentState, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	path := s.agentFilePath(name)
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from known agents dir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read agent state: %w", err)
+	}
+
+	var state AgentState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal agent state: %w", err)
+	}
+
+	return &state, nil
+}
+
+// Delete removes an agent's state file.
+func (s *StateStore) Delete(name string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := s.agentFilePath(name)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete agent state: %w", err)
+	}
+	return nil
+}
+
+// List returns the names of all agents with state files.
+func (s *StateStore) List() ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := os.ReadDir(s.agentsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read agents directory: %w", err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		// Only include .json files, skip temp files
+		if filepath.Ext(name) == ".json" && name[0] != '.' {
+			names = append(names, name[:len(name)-5]) // strip .json
+		}
+	}
+	return names, nil
+}
+
+// LoadAll reads all agent states from disk.
+func (s *StateStore) LoadAll() ([]*AgentState, error) {
+	names, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var states []*AgentState
+	for _, name := range names {
+		state, err := s.Load(name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load agent %s: %w", name, err)
+		}
+		if state != nil {
+			states = append(states, state)
+		}
+	}
+	return states, nil
+}
+
+// Exists checks if an agent state file exists.
+func (s *StateStore) Exists(name string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, err := os.Stat(s.agentFilePath(name))
+	return err == nil
+}
+
+// AddToWorkQueue adds a work item to an agent's work queue.
+func (s *StateStore) AddToWorkQueue(name string, item queue.WorkItem) error {
+	state, err := s.Load(name)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	state.WorkQueue = append(state.WorkQueue, item)
+	return s.Save(state)
+}
+
+// AddToMergeQueue adds a work item to an agent's merge queue.
+func (s *StateStore) AddToMergeQueue(name string, item queue.WorkItem) error {
+	state, err := s.Load(name)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	state.MergeQueue = append(state.MergeQueue, item)
+	return s.Save(state)
+}
+
+// RemoveFromWorkQueue removes a work item from an agent's work queue by ID.
+func (s *StateStore) RemoveFromWorkQueue(name, itemID string) error {
+	state, err := s.Load(name)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	filtered := make([]queue.WorkItem, 0, len(state.WorkQueue))
+	for _, item := range state.WorkQueue {
+		if item.ID != itemID {
+			filtered = append(filtered, item)
+		}
+	}
+	state.WorkQueue = filtered
+	return s.Save(state)
+}
+
+// RemoveFromMergeQueue removes a work item from an agent's merge queue by ID.
+func (s *StateStore) RemoveFromMergeQueue(name, itemID string) error {
+	state, err := s.Load(name)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	filtered := make([]queue.WorkItem, 0, len(state.MergeQueue))
+	for _, item := range state.MergeQueue {
+		if item.ID != itemID {
+			filtered = append(filtered, item)
+		}
+	}
+	state.MergeQueue = filtered
+	return s.Save(state)
+}
+
+// UpdateState updates an agent's state field.
+func (s *StateStore) UpdateState(name string, newState State) error {
+	state, err := s.Load(name)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	state.State = newState
+	return s.Save(state)
+}
+
+// ToAgentState converts an Agent to an AgentState for persistence.
+func ToAgentState(a *Agent) *AgentState {
+	return &AgentState{
+		Name:      a.Name,
+		Role:      a.Role,
+		Tool:      a.Tool,
+		Parent:    a.ParentID,
+		State:     a.State,
+		Worktree:  a.WorktreeDir,
+		Session:   a.Session,
+		StartedAt: a.StartedAt,
+		UpdatedAt: a.UpdatedAt,
+	}
+}
+
+// ToAgent converts an AgentState back to an Agent.
+func (s *AgentState) ToAgent(workspace string) *Agent {
+	return &Agent{
+		Name:        s.Name,
+		ID:          s.Name, // Use name as ID for v2
+		Role:        s.Role,
+		Tool:        s.Tool,
+		ParentID:    s.Parent,
+		State:       s.State,
+		WorktreeDir: s.Worktree,
+		Session:     s.Session,
+		Workspace:   workspace,
+		StartedAt:   s.StartedAt,
+		UpdatedAt:   s.UpdatedAt,
+	}
+}

--- a/pkg/agent/state_test.go
+++ b/pkg/agent/state_test.go
@@ -1,0 +1,397 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/queue"
+)
+
+func TestStateStore_SaveAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	state := &AgentState{
+		Name:      "engineer-01",
+		Role:      RoleEngineer,
+		Tool:      "claude",
+		Team:      "backend",
+		Parent:    "manager-01",
+		State:     StateWorking,
+		Worktree:  ".bc/worktrees/engineer-01",
+		StartedAt: time.Now().Truncate(time.Second),
+	}
+
+	// Save
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify file exists
+	path := filepath.Join(tmpDir, "agents", "engineer-01.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("State file not created: %v", err)
+	}
+
+	// Load
+	loaded, err := store.Load("engineer-01")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load returned nil")
+	}
+
+	// Verify fields
+	if loaded.Name != state.Name {
+		t.Errorf("Name = %q, want %q", loaded.Name, state.Name)
+	}
+	if loaded.Role != state.Role {
+		t.Errorf("Role = %q, want %q", loaded.Role, state.Role)
+	}
+	if loaded.Tool != state.Tool {
+		t.Errorf("Tool = %q, want %q", loaded.Tool, state.Tool)
+	}
+	if loaded.Team != state.Team {
+		t.Errorf("Team = %q, want %q", loaded.Team, state.Team)
+	}
+	if loaded.Parent != state.Parent {
+		t.Errorf("Parent = %q, want %q", loaded.Parent, state.Parent)
+	}
+	if loaded.State != state.State {
+		t.Errorf("State = %q, want %q", loaded.State, state.State)
+	}
+}
+
+func TestStateStore_LoadNonexistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	loaded, err := store.Load("nonexistent")
+	if err != nil {
+		t.Fatalf("Load should not error for nonexistent: %v", err)
+	}
+	if loaded != nil {
+		t.Error("Load should return nil for nonexistent agent")
+	}
+}
+
+func TestStateStore_Delete(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	state := &AgentState{
+		Name:      "to-delete",
+		Role:      RoleEngineer,
+		StartedAt: time.Now(),
+	}
+
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if !store.Exists("to-delete") {
+		t.Fatal("Agent should exist after save")
+	}
+
+	if err := store.Delete("to-delete"); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	if store.Exists("to-delete") {
+		t.Error("Agent should not exist after delete")
+	}
+}
+
+func TestStateStore_List(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	// Create several agents
+	agents := []string{"engineer-01", "engineer-02", "manager-01"}
+	for _, name := range agents {
+		state := &AgentState{
+			Name:      name,
+			Role:      RoleEngineer,
+			StartedAt: time.Now(),
+		}
+		if err := store.Save(state); err != nil {
+			t.Fatalf("Save %s failed: %v", name, err)
+		}
+	}
+
+	// List
+	names, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+
+	if len(names) != len(agents) {
+		t.Errorf("List returned %d agents, want %d", len(names), len(agents))
+	}
+
+	// Verify all agents are listed
+	nameSet := make(map[string]bool)
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	for _, expected := range agents {
+		if !nameSet[expected] {
+			t.Errorf("Agent %q not in list", expected)
+		}
+	}
+}
+
+func TestStateStore_LoadAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	// Create several agents
+	for i, name := range []string{"agent-a", "agent-b", "agent-c"} {
+		state := &AgentState{
+			Name:      name,
+			Role:      RoleEngineer,
+			State:     State([]string{"idle", "working", "done"}[i]),
+			StartedAt: time.Now(),
+		}
+		if err := store.Save(state); err != nil {
+			t.Fatalf("Save %s failed: %v", name, err)
+		}
+	}
+
+	// LoadAll
+	states, err := store.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll failed: %v", err)
+	}
+
+	if len(states) != 3 {
+		t.Errorf("LoadAll returned %d states, want 3", len(states))
+	}
+}
+
+func TestStateStore_WithQueues(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	state := &AgentState{
+		Name:      "engineer-01",
+		Role:      RoleEngineer,
+		StartedAt: time.Now(),
+		WorkQueue: []queue.WorkItem{
+			{ID: "work-1", Title: "Fix bug", Status: queue.StatusWorking},
+			{ID: "work-2", Title: "Add feature", Status: queue.StatusPending},
+		},
+		MergeQueue: []queue.WorkItem{
+			{ID: "merge-1", Title: "PR #123", Status: queue.StatusDone},
+		},
+	}
+
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := store.Load("engineer-01")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if len(loaded.WorkQueue) != 2 {
+		t.Errorf("WorkQueue has %d items, want 2", len(loaded.WorkQueue))
+	}
+	if len(loaded.MergeQueue) != 1 {
+		t.Errorf("MergeQueue has %d items, want 1", len(loaded.MergeQueue))
+	}
+	if loaded.WorkQueue[0].ID != "work-1" {
+		t.Errorf("First work item ID = %q, want work-1", loaded.WorkQueue[0].ID)
+	}
+}
+
+func TestStateStore_AddToWorkQueue(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	// Create agent
+	state := &AgentState{
+		Name:      "engineer-01",
+		Role:      RoleEngineer,
+		StartedAt: time.Now(),
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Add work item
+	item := queue.WorkItem{ID: "work-new", Title: "New task", Status: queue.StatusPending}
+	if err := store.AddToWorkQueue("engineer-01", item); err != nil {
+		t.Fatalf("AddToWorkQueue failed: %v", err)
+	}
+
+	// Verify
+	loaded, _ := store.Load("engineer-01")
+	if len(loaded.WorkQueue) != 1 {
+		t.Errorf("WorkQueue has %d items, want 1", len(loaded.WorkQueue))
+	}
+	if loaded.WorkQueue[0].ID != "work-new" {
+		t.Errorf("Work item ID = %q, want work-new", loaded.WorkQueue[0].ID)
+	}
+}
+
+func TestStateStore_RemoveFromWorkQueue(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	state := &AgentState{
+		Name:      "engineer-01",
+		Role:      RoleEngineer,
+		StartedAt: time.Now(),
+		WorkQueue: []queue.WorkItem{
+			{ID: "keep", Title: "Keep this"},
+			{ID: "remove", Title: "Remove this"},
+		},
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if err := store.RemoveFromWorkQueue("engineer-01", "remove"); err != nil {
+		t.Fatalf("RemoveFromWorkQueue failed: %v", err)
+	}
+
+	loaded, _ := store.Load("engineer-01")
+	if len(loaded.WorkQueue) != 1 {
+		t.Errorf("WorkQueue has %d items, want 1", len(loaded.WorkQueue))
+	}
+	if loaded.WorkQueue[0].ID != "keep" {
+		t.Errorf("Remaining item ID = %q, want keep", loaded.WorkQueue[0].ID)
+	}
+}
+
+func TestStateStore_UpdateState(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	state := &AgentState{
+		Name:      "engineer-01",
+		Role:      RoleEngineer,
+		State:     StateIdle,
+		StartedAt: time.Now(),
+	}
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if err := store.UpdateState("engineer-01", StateWorking); err != nil {
+		t.Fatalf("UpdateState failed: %v", err)
+	}
+
+	loaded, _ := store.Load("engineer-01")
+	if loaded.State != StateWorking {
+		t.Errorf("State = %q, want %q", loaded.State, StateWorking)
+	}
+}
+
+func TestStateStore_AtomicWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	state := &AgentState{
+		Name:      "atomic-test",
+		Role:      RoleEngineer,
+		StartedAt: time.Now(),
+	}
+
+	if err := store.Save(state); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	// Verify no temp file left behind
+	tempPath := filepath.Join(tmpDir, "agents", ".atomic-test.json.tmp")
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Error("Temp file should not exist after successful save")
+	}
+
+	// Verify actual file exists
+	realPath := filepath.Join(tmpDir, "agents", "atomic-test.json")
+	if _, err := os.Stat(realPath); err != nil {
+		t.Errorf("Real file should exist: %v", err)
+	}
+}
+
+func TestToAgentState_Conversion(t *testing.T) {
+	agent := &Agent{
+		Name:        "test-agent",
+		ID:          "test-agent",
+		Role:        RoleEngineer,
+		Tool:        "claude",
+		ParentID:    "manager-01",
+		State:       StateWorking,
+		WorktreeDir: ".bc/worktrees/test-agent",
+		Session:     "bc-test-agent",
+		StartedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	state := ToAgentState(agent)
+
+	if state.Name != agent.Name {
+		t.Errorf("Name = %q, want %q", state.Name, agent.Name)
+	}
+	if state.Role != agent.Role {
+		t.Errorf("Role = %q, want %q", state.Role, agent.Role)
+	}
+	if state.Parent != agent.ParentID {
+		t.Errorf("Parent = %q, want %q", state.Parent, agent.ParentID)
+	}
+}
+
+func TestAgentState_ToAgent(t *testing.T) {
+	state := &AgentState{
+		Name:      "test-agent",
+		Role:      RoleEngineer,
+		Tool:      "claude",
+		Parent:    "manager-01",
+		State:     StateWorking,
+		Worktree:  ".bc/worktrees/test-agent",
+		Session:   "bc-test-agent",
+		StartedAt: time.Now(),
+	}
+
+	agent := state.ToAgent("/workspace")
+
+	if agent.Name != state.Name {
+		t.Errorf("Name = %q, want %q", agent.Name, state.Name)
+	}
+	if agent.Workspace != "/workspace" {
+		t.Errorf("Workspace = %q, want /workspace", agent.Workspace)
+	}
+	if agent.ParentID != state.Parent {
+		t.Errorf("ParentID = %q, want %q", agent.ParentID, state.Parent)
+	}
+}
+
+func TestStateStore_ListEmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	// List on non-existent directory should return empty, not error
+	names, err := store.List()
+	if err != nil {
+		t.Fatalf("List on empty dir should not error: %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("List on empty dir should return empty slice, got %d items", len(names))
+	}
+}
+
+func TestStateStore_DeleteNonexistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStateStore(tmpDir)
+
+	// Delete of nonexistent should not error
+	if err := store.Delete("nonexistent"); err != nil {
+		t.Errorf("Delete of nonexistent should not error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds StateStore for per-agent JSON state files
- Implements atomic writes with temp file + rename
- Adds mutex-protected CRUD operations
- Includes queue management helpers (AddToWorkQueue, RemoveFromWorkQueue, etc.)
- Supports dual queue foundation (work_queue and merge_queue)

Part of Epic 1.1: Workspace Restructure (bc-m3p)
Closes: bc-m3p.3

## Test plan
- [x] Unit tests in state_test.go
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)