### PR TITLE
feat: update bc init for v2 workspace structure

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -1642,7 +1642,7 @@ func TestInitNewDirectory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("init returned error: %v", err)
 	}
-	if !strings.Contains(stdout, "Initialized bc workspace") {
+	if !strings.Contains(stdout, "Initialized bc v2 workspace") {
 		t.Errorf("expected initialization message, got: %s", stdout)
 	}
 
@@ -1653,6 +1653,7 @@ func TestInitNewDirectory(t *testing.T) {
 }
 
 func TestInitAlreadyInitialized(t *testing.T) {
+	// setupIntegrationWorkspace creates a v1 workspace, which triggers v1 detection
 	_, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 
@@ -1660,8 +1661,9 @@ func TestInitAlreadyInitialized(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for already initialized workspace, got nil")
 	}
-	if !strings.Contains(err.Error(), "already initialized") {
-		t.Errorf("expected 'already initialized' error, got: %v", err)
+	// v1 workspace detection returns specific error
+	if !strings.Contains(err.Error(), "v1 workspace exists") {
+		t.Errorf("expected 'v1 workspace exists' error, got: %v", err)
 	}
 }
 

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -11,10 +12,17 @@ import (
 
 var initCmd = &cobra.Command{
 	Use:   "init [directory]",
-	Short: "Initialize a new bc workspace",
-	Long: `Initialize a new bc workspace in the specified directory (or current directory).
+	Short: "Initialize a new bc v2 workspace",
+	Long: `Initialize a new bc v2 workspace in the specified directory (or current directory).
 
-This creates a .bc directory with configuration for managing agents.
+This creates a .bc directory with v2 configuration for managing agents.
+
+v2 workspace structure:
+  .bc/
+    config.toml    # Workspace configuration
+    roles/         # Agent role definitions
+      root.md      # Root agent role
+    agents/        # Per-agent state files
 
 Example:
   bc init                    # Initialize current directory
@@ -23,11 +31,22 @@ Example:
 	RunE: runInit,
 }
 
-var initMaxWorkers int
-
 func init() {
-	initCmd.Flags().IntVar(&initMaxWorkers, "max-workers", 3, "Maximum number of worker agents")
 	rootCmd.AddCommand(initCmd)
+}
+
+// isV1Workspace checks if a directory has a v1 workspace (config.json).
+func isV1Workspace(dir string) bool {
+	configPath := filepath.Join(dir, ".bc", "config.json")
+	_, err := os.Stat(configPath)
+	return err == nil
+}
+
+// isV2Workspace checks if a directory has a v2 workspace (config.toml).
+func isV2Workspace(dir string) bool {
+	configPath := filepath.Join(dir, ".bc", "config.toml")
+	_, err := os.Stat(configPath)
+	return err == nil
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -36,45 +55,93 @@ func runInit(cmd *cobra.Command, args []string) error {
 		dir = args[0]
 	}
 
-	// Check if already initialized
-	if workspace.IsWorkspace(dir) {
-		return fmt.Errorf("workspace already initialized in %s", dir)
-	}
-
-	// Initialize workspace
-	ws, err := workspace.Init(dir)
+	absDir, err := filepath.Abs(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to resolve directory: %w", err)
 	}
 
-	// Apply flags
-	ws.Config.MaxWorkers = initMaxWorkers
-
-	if err = ws.Save(); err != nil {
-		return err
+	// Check for existing v2 workspace
+	if isV2Workspace(absDir) {
+		return fmt.Errorf("v2 workspace already initialized in %s", absDir)
 	}
 
-	// Ensure directories exist
-	if err = ws.EnsureDirs(); err != nil {
-		return err
+	// Check for existing v1 workspace
+	if isV1Workspace(absDir) {
+		fmt.Fprintln(os.Stderr, "Warning: Existing v1 workspace detected.")
+		fmt.Fprintln(os.Stderr, "bc v2 is a clean break - v1 data will not be migrated.")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "To proceed:")
+		fmt.Fprintln(os.Stderr, "  - Backup .bc/ if needed")
+		fmt.Fprintln(os.Stderr, "  - Remove .bc/ directory")
+		fmt.Fprintln(os.Stderr, "  - Run bc init again")
+		return fmt.Errorf("cannot initialize: v1 workspace exists")
+	}
+
+	// Initialize v2 workspace
+	return initV2Workspace(absDir)
+}
+
+// initV2Workspace creates a new v2 workspace structure.
+func initV2Workspace(rootDir string) error {
+	stateDir := filepath.Join(rootDir, ".bc")
+
+	// Create state directory
+	if err := os.MkdirAll(stateDir, 0750); err != nil {
+		return fmt.Errorf("failed to create .bc directory: %w", err)
+	}
+
+	// Create agents directory
+	agentsDir := filepath.Join(stateDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0750); err != nil {
+		return fmt.Errorf("failed to create agents directory: %w", err)
+	}
+
+	// Create and save v2 config
+	name := filepath.Base(rootDir)
+	cfg := workspace.DefaultV2Config(name)
+	configPath := workspace.ConfigPath(rootDir)
+
+	if err := cfg.Save(configPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	// Create roles directory and default root.md
+	roleMgr := workspace.NewRoleManager(stateDir)
+	created, err := roleMgr.EnsureDefaultRoot()
+	if err != nil {
+		return fmt.Errorf("failed to create role files: %w", err)
 	}
 
 	// Register in global registry
 	reg, err := workspace.LoadRegistry()
 	if err == nil {
-		reg.Register(ws.RootDir, ws.Config.Name)
+		reg.Register(rootDir, name)
 		_ = reg.Save()
 	}
 
-	fmt.Printf("Initialized bc workspace in %s\n", ws.RootDir)
-	fmt.Printf("  State directory: %s\n", ws.StateDir())
-	fmt.Printf("  Max workers: %d\n", ws.Config.MaxWorkers)
-	fmt.Printf("  Agents run with full permissions\n")
+	// Print success message
+	fmt.Printf("Initialized bc v2 workspace in %s\n", rootDir)
+	fmt.Printf("\n")
+	fmt.Printf("  Created:\n")
+	fmt.Printf("    .bc/config.toml     # Workspace configuration\n")
+	fmt.Printf("    .bc/agents/         # Agent state directory\n")
+	fmt.Printf("    .bc/roles/          # Role definitions\n")
+	if created {
+		fmt.Printf("    .bc/roles/root.md   # Root agent role\n")
+	}
+	fmt.Printf("\n")
+	fmt.Printf("  Default tool: %s\n", cfg.Tools.Default)
+	fmt.Printf("  Memory: %s (%s)\n", cfg.Memory.Backend, cfg.Memory.Path)
+	fmt.Printf("\n")
+	fmt.Printf("Next steps:\n")
+	fmt.Printf("  bc up       # Start agents\n")
+	fmt.Printf("  bc home     # Open dashboard\n")
 
 	return nil
 }
 
 // getWorkspace finds the current workspace.
+// Supports both v1 (config.json) and v2 (config.toml) workspaces.
 func getWorkspace() (*workspace.Workspace, error) {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/workspace"
+)
+
+func TestIsV1Workspace(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Not a workspace
+	if isV1Workspace(tmpDir) {
+		t.Error("empty dir should not be v1 workspace")
+	}
+
+	// Create v1 structure
+	bcDir := filepath.Join(tmpDir, ".bc")
+	if err := os.MkdirAll(bcDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bcDir, "config.json"), []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isV1Workspace(tmpDir) {
+		t.Error("dir with .bc/config.json should be v1 workspace")
+	}
+}
+
+func TestIsV2Workspace(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Not a workspace
+	if isV2Workspace(tmpDir) {
+		t.Error("empty dir should not be v2 workspace")
+	}
+
+	// Create v2 structure
+	bcDir := filepath.Join(tmpDir, ".bc")
+	if err := os.MkdirAll(bcDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bcDir, "config.toml"), []byte("[workspace]\nname = \"test\"\nversion = 2\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isV2Workspace(tmpDir) {
+		t.Error("dir with .bc/config.toml should be v2 workspace")
+	}
+}
+
+func TestInitV2Workspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "test-project")
+	if err := os.MkdirAll(projectDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize v2 workspace
+	if err := initV2Workspace(projectDir); err != nil {
+		t.Fatalf("initV2Workspace failed: %v", err)
+	}
+
+	// Verify .bc directory exists
+	bcDir := filepath.Join(projectDir, ".bc")
+	if _, err := os.Stat(bcDir); err != nil {
+		t.Errorf(".bc directory not created: %v", err)
+	}
+
+	// Verify config.toml exists and is valid
+	configPath := filepath.Join(bcDir, "config.toml")
+	cfg, err := workspace.LoadV2Config(configPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	if cfg.Workspace.Name != "test-project" {
+		t.Errorf("expected name 'test-project', got %q", cfg.Workspace.Name)
+	}
+	if cfg.Workspace.Version != 2 {
+		t.Errorf("expected version 2, got %d", cfg.Workspace.Version)
+	}
+	if validateErr := cfg.Validate(); validateErr != nil {
+		t.Errorf("config validation failed: %v", validateErr)
+	}
+
+	// Verify agents directory exists
+	agentsDir := filepath.Join(bcDir, "agents")
+	if _, statErr := os.Stat(agentsDir); statErr != nil {
+		t.Errorf("agents directory not created: %v", statErr)
+	}
+
+	// Verify roles directory exists
+	rolesDir := filepath.Join(bcDir, "roles")
+	if _, statErr := os.Stat(rolesDir); statErr != nil {
+		t.Errorf("roles directory not created: %v", statErr)
+	}
+
+	// Verify root.md exists
+	rootPath := filepath.Join(rolesDir, "root.md")
+	if _, statErr := os.Stat(rootPath); statErr != nil {
+		t.Errorf("root.md not created: %v", statErr)
+	}
+
+	// Verify root.md content
+	rootContent, err := os.ReadFile(rootPath) //nolint:gosec // test file path
+	if err != nil {
+		t.Fatalf("failed to read root.md: %v", err)
+	}
+	if !strings.Contains(string(rootContent), "name: root") {
+		t.Error("root.md missing 'name: root' in frontmatter")
+	}
+	if !strings.Contains(string(rootContent), "is_singleton: true") {
+		t.Error("root.md missing 'is_singleton: true' in frontmatter")
+	}
+}
+
+func TestInitV2WorkspaceIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "test-project")
+	if err := os.MkdirAll(projectDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// First init
+	if err := initV2Workspace(projectDir); err != nil {
+		t.Fatalf("first init failed: %v", err)
+	}
+
+	// Second init should fail (already initialized)
+	if isV2Workspace(projectDir) == false {
+		t.Error("workspace should be detected as v2 after init")
+	}
+}
+
+func TestRunInitV1Detection(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create v1 structure
+	bcDir := filepath.Join(tmpDir, ".bc")
+	if err := os.MkdirAll(bcDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(bcDir, "config.json"), []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run init - should fail with v1 warning
+	err := runInit(nil, []string{tmpDir})
+	if err == nil {
+		t.Error("expected error when v1 workspace exists")
+	}
+	if !strings.Contains(err.Error(), "v1 workspace exists") {
+		t.Errorf("error should mention v1 workspace: %v", err)
+	}
+}
+
+func TestRunInitV2AlreadyInitialized(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "test-project")
+	if err := os.MkdirAll(projectDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// First init should succeed
+	if err := initV2Workspace(projectDir); err != nil {
+		t.Fatalf("first init failed: %v", err)
+	}
+
+	// Second init should fail
+	err := runInit(nil, []string{projectDir})
+	if err == nil {
+		t.Error("expected error when already initialized")
+	}
+	if !strings.Contains(err.Error(), "already initialized") {
+		t.Errorf("error should mention already initialized: %v", err)
+	}
+}
+
+func TestRunInitFreshDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	projectDir := filepath.Join(tmpDir, "fresh-project")
+	if err := os.MkdirAll(projectDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Init should succeed on fresh directory
+	err := runInit(nil, []string{projectDir})
+	if err != nil {
+		t.Fatalf("init on fresh directory failed: %v", err)
+	}
+
+	// Verify workspace was created
+	if !isV2Workspace(projectDir) {
+		t.Error("workspace should exist after init")
+	}
+}


### PR DESCRIPTION
## Summary
Updates `bc init` command to create v2 workspace structure.

- Detect existing v1 workspace and show migration warning
- Create v2 structure: `.bc/config.toml`, `.bc/roles/`, `.bc/agents/`
- Use `V2Config` for TOML-based configuration
- Use `RoleManager` to create default `root.md` role

## Test plan
- [x] `TestIsV1Workspace` / `TestIsV2Workspace` - version detection
- [x] `TestInitV2Workspace` - full structure verification
- [x] `TestRunInitV1Detection` - v1 warning message
- [x] `TestRunInitV2AlreadyInitialized` - already initialized error
- [x] Updated existing integration tests for v2 output

fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)