### PR TITLE
feat: add root agent state with singleton validation

### DIFF
--- a/pkg/agent/root.go
+++ b/pkg/agent/root.go
@@ -1,0 +1,256 @@
+// Package agent provides agent lifecycle management.
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// RootFileName is the filename for root agent state.
+const RootFileName = "root.json"
+
+// ErrRootExists is returned when attempting to create a root when one already exists.
+var ErrRootExists = errors.New("root agent already exists")
+
+// ErrRootNotFound is returned when the root agent state file doesn't exist.
+var ErrRootNotFound = errors.New("root agent not found")
+
+// RootAgentState extends AgentState with root-specific fields.
+// The root agent is special: it's the singleton entry point created by `bc up`.
+type RootAgentState struct {
+	AgentState
+	Children    []string `json:"children,omitempty"`
+	IsSingleton bool     `json:"is_singleton"`
+}
+
+// RootStateStore manages the root agent state file at .bc/agents/root.json
+type RootStateStore struct {
+	agentsDir string
+	mu        sync.RWMutex
+}
+
+// NewRootStateStore creates a new root state store for the given .bc directory.
+func NewRootStateStore(bcDir string) *RootStateStore {
+	return &RootStateStore{
+		agentsDir: filepath.Join(bcDir, "agents"),
+	}
+}
+
+// rootFilePath returns the path to root.json.
+func (s *RootStateStore) rootFilePath() string {
+	return filepath.Join(s.agentsDir, RootFileName)
+}
+
+// tempFilePath returns a temporary file path for atomic writes.
+func (s *RootStateStore) tempFilePath() string {
+	return filepath.Join(s.agentsDir, "."+RootFileName+".tmp")
+}
+
+// ensureDir creates the agents directory if it doesn't exist.
+func (s *RootStateStore) ensureDir() error {
+	return os.MkdirAll(s.agentsDir, 0750)
+}
+
+// Exists checks if a root agent state file exists.
+func (s *RootStateStore) Exists() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, err := os.Stat(s.rootFilePath())
+	return err == nil
+}
+
+// Load reads the root agent state from disk.
+// Returns ErrRootNotFound if the file doesn't exist.
+func (s *RootStateStore) Load() (*RootAgentState, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	path := s.rootFilePath()
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from known agents dir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrRootNotFound
+		}
+		return nil, fmt.Errorf("failed to read root state: %w", err)
+	}
+
+	var state RootAgentState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal root state: %w", err)
+	}
+
+	return &state, nil
+}
+
+// Save persists the root agent state to disk atomically.
+// It writes to a temp file first, then renames to ensure atomic updates.
+func (s *RootStateStore) Save(state *RootAgentState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.ensureDir(); err != nil {
+		return fmt.Errorf("failed to create agents directory: %w", err)
+	}
+
+	// Ensure singleton flag is set
+	state.IsSingleton = true
+
+	// Update timestamp
+	state.UpdatedAt = time.Now()
+
+	// Marshal to JSON with indentation for readability
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal root state: %w", err)
+	}
+
+	// Write to temp file first
+	tempPath := s.tempFilePath()
+	if err := os.WriteFile(tempPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	// Atomic rename
+	targetPath := s.rootFilePath()
+	if err := os.Rename(tempPath, targetPath); err != nil {
+		// Clean up temp file on failure
+		_ = os.Remove(tempPath)
+		return fmt.Errorf("failed to rename temp file: %w", err)
+	}
+
+	return nil
+}
+
+// Delete removes the root agent state file.
+func (s *RootStateStore) Delete() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := s.rootFilePath()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to delete root state: %w", err)
+	}
+	return nil
+}
+
+// EnsureSingleton validates that only one root agent exists.
+// If a root already exists, returns ErrRootExists.
+// This should be called before creating a new root agent.
+func (s *RootStateStore) EnsureSingleton() error {
+	if s.Exists() {
+		return ErrRootExists
+	}
+	return nil
+}
+
+// Create creates a new root agent state if one doesn't exist.
+// Returns ErrRootExists if a root already exists.
+func (s *RootStateStore) Create(name string, role Role, tool string) (*RootAgentState, error) {
+	if err := s.EnsureSingleton(); err != nil {
+		return nil, err
+	}
+
+	state := &RootAgentState{
+		AgentState: AgentState{
+			Name:      name,
+			Role:      role,
+			Tool:      tool,
+			State:     StateIdle,
+			StartedAt: time.Now(),
+		},
+		IsSingleton: true,
+		Children:    []string{},
+	}
+
+	if err := s.Save(state); err != nil {
+		return nil, err
+	}
+
+	return state, nil
+}
+
+// GetOrCreate returns the existing root state or creates a new one.
+// This is the primary method for `bc up` to use.
+func (s *RootStateStore) GetOrCreate(name string, role Role, tool string) (*RootAgentState, bool, error) {
+	// Try to load existing
+	state, err := s.Load()
+	if err == nil {
+		return state, false, nil // existing root, not created
+	}
+
+	if !errors.Is(err, ErrRootNotFound) {
+		return nil, false, err // unexpected error
+	}
+
+	// Create new root
+	state, err = s.Create(name, role, tool)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return state, true, nil // new root created
+}
+
+// AddChild adds a child agent name to the root's children list.
+func (s *RootStateStore) AddChild(childName string) error {
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+
+	// Check if already a child
+	for _, c := range state.Children {
+		if c == childName {
+			return nil // already exists
+		}
+	}
+
+	state.Children = append(state.Children, childName)
+	return s.Save(state)
+}
+
+// RemoveChild removes a child agent name from the root's children list.
+func (s *RootStateStore) RemoveChild(childName string) error {
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+
+	filtered := make([]string, 0, len(state.Children))
+	for _, c := range state.Children {
+		if c != childName {
+			filtered = append(filtered, c)
+		}
+	}
+
+	state.Children = filtered
+	return s.Save(state)
+}
+
+// UpdateState updates the root agent's state field.
+func (s *RootStateStore) UpdateState(newState State) error {
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+
+	state.State = newState
+	return s.Save(state)
+}
+
+// UpdateSession updates the root agent's session field.
+func (s *RootStateStore) UpdateSession(session string) error {
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+
+	state.Session = session
+	return s.Save(state)
+}

--- a/pkg/agent/root_test.go
+++ b/pkg/agent/root_test.go
@@ -1,0 +1,340 @@
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestRootStateStore_CreateAndLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Create root
+	state, err := store.Create("manager", RoleManager, "claude")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if state.Name != "manager" {
+		t.Errorf("Name = %q, want manager", state.Name)
+	}
+	if state.Role != RoleManager {
+		t.Errorf("Role = %q, want %q", state.Role, RoleManager)
+	}
+	if !state.IsSingleton {
+		t.Error("IsSingleton should be true")
+	}
+
+	// Verify file exists
+	path := filepath.Join(tmpDir, "agents", RootFileName)
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("Root file not created: %v", statErr)
+	}
+
+	// Load
+	loaded, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if loaded.Name != state.Name {
+		t.Errorf("Loaded Name = %q, want %q", loaded.Name, state.Name)
+	}
+	if loaded.Tool != "claude" {
+		t.Errorf("Loaded Tool = %q, want claude", loaded.Tool)
+	}
+}
+
+func TestRootStateStore_EnsureSingleton(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// First call should succeed
+	if err := store.EnsureSingleton(); err != nil {
+		t.Errorf("First EnsureSingleton should succeed: %v", err)
+	}
+
+	// Create root
+	if _, err := store.Create("manager", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Second call should fail
+	err := store.EnsureSingleton()
+	if !errors.Is(err, ErrRootExists) {
+		t.Errorf("Second EnsureSingleton should return ErrRootExists, got: %v", err)
+	}
+}
+
+func TestRootStateStore_CreateDuplicate(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// First create succeeds
+	if _, err := store.Create("manager", RoleManager, "claude"); err != nil {
+		t.Fatalf("First Create failed: %v", err)
+	}
+
+	// Second create fails
+	_, err := store.Create("manager2", RoleManager, "claude")
+	if !errors.Is(err, ErrRootExists) {
+		t.Errorf("Second Create should return ErrRootExists, got: %v", err)
+	}
+}
+
+func TestRootStateStore_LoadNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	_, err := store.Load()
+	if !errors.Is(err, ErrRootNotFound) {
+		t.Errorf("Load on empty should return ErrRootNotFound, got: %v", err)
+	}
+}
+
+func TestRootStateStore_Exists(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if store.Exists() {
+		t.Error("Exists should return false before creation")
+	}
+
+	if _, err := store.Create("manager", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if !store.Exists() {
+		t.Error("Exists should return true after creation")
+	}
+}
+
+func TestRootStateStore_Delete(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, err := store.Create("manager", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if !store.Exists() {
+		t.Fatal("Root should exist after create")
+	}
+
+	if err := store.Delete(); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	if store.Exists() {
+		t.Error("Root should not exist after delete")
+	}
+}
+
+func TestRootStateStore_DeleteNonexistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Delete of nonexistent should not error
+	if err := store.Delete(); err != nil {
+		t.Errorf("Delete of nonexistent should not error: %v", err)
+	}
+}
+
+func TestRootStateStore_GetOrCreate_New(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	state, created, err := store.GetOrCreate("manager", RoleManager, "claude")
+	if err != nil {
+		t.Fatalf("GetOrCreate failed: %v", err)
+	}
+
+	if !created {
+		t.Error("Should indicate root was created")
+	}
+	if state.Name != "manager" {
+		t.Errorf("Name = %q, want manager", state.Name)
+	}
+}
+
+func TestRootStateStore_GetOrCreate_Existing(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Create first
+	original, err := store.Create("original", RoleManager, "claude")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// GetOrCreate should return existing
+	state, created, err := store.GetOrCreate("different", RoleEngineer, "codex")
+	if err != nil {
+		t.Fatalf("GetOrCreate failed: %v", err)
+	}
+
+	if created {
+		t.Error("Should indicate root was NOT created")
+	}
+	if state.Name != original.Name {
+		t.Errorf("Should return original root, got Name = %q", state.Name)
+	}
+}
+
+func TestRootStateStore_Children(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, err := store.Create("manager", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Add children
+	if err := store.AddChild("engineer-01"); err != nil {
+		t.Fatalf("AddChild failed: %v", err)
+	}
+	if err := store.AddChild("engineer-02"); err != nil {
+		t.Fatalf("AddChild failed: %v", err)
+	}
+
+	// Verify
+	state, _ := store.Load()
+	if len(state.Children) != 2 {
+		t.Errorf("Children count = %d, want 2", len(state.Children))
+	}
+
+	// Add duplicate (should not add again)
+	if err := store.AddChild("engineer-01"); err != nil {
+		t.Fatalf("AddChild duplicate failed: %v", err)
+	}
+	state, _ = store.Load()
+	if len(state.Children) != 2 {
+		t.Errorf("Children count after duplicate = %d, want 2", len(state.Children))
+	}
+
+	// Remove one
+	if err := store.RemoveChild("engineer-01"); err != nil {
+		t.Fatalf("RemoveChild failed: %v", err)
+	}
+	state, _ = store.Load()
+	if len(state.Children) != 1 {
+		t.Errorf("Children count after remove = %d, want 1", len(state.Children))
+	}
+	if state.Children[0] != "engineer-02" {
+		t.Errorf("Remaining child = %q, want engineer-02", state.Children[0])
+	}
+}
+
+func TestRootStateStore_UpdateState(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, err := store.Create("manager", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if err := store.UpdateState(StateWorking); err != nil {
+		t.Fatalf("UpdateState failed: %v", err)
+	}
+
+	state, _ := store.Load()
+	if state.State != StateWorking {
+		t.Errorf("State = %q, want %q", state.State, StateWorking)
+	}
+}
+
+func TestRootStateStore_UpdateSession(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, err := store.Create("manager", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if err := store.UpdateSession("bc-manager-123"); err != nil {
+		t.Fatalf("UpdateSession failed: %v", err)
+	}
+
+	state, _ := store.Load()
+	if state.Session != "bc-manager-123" {
+		t.Errorf("Session = %q, want bc-manager-123", state.Session)
+	}
+}
+
+func TestRootStateStore_AtomicWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, err := store.Create("manager", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Verify no temp file left behind
+	tempPath := filepath.Join(tmpDir, "agents", "."+RootFileName+".tmp")
+	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
+		t.Error("Temp file should not exist after successful save")
+	}
+
+	// Verify actual file exists
+	realPath := filepath.Join(tmpDir, "agents", RootFileName)
+	if _, err := os.Stat(realPath); err != nil {
+		t.Errorf("Real file should exist: %v", err)
+	}
+}
+
+func TestRootStateStore_UpdatedAtTimestamp(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	state, err := store.Create("manager", RoleManager, "claude")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	originalUpdated := state.UpdatedAt
+
+	// Wait a bit and update
+	time.Sleep(10 * time.Millisecond)
+	if err := store.UpdateState(StateWorking); err != nil {
+		t.Fatalf("UpdateState failed: %v", err)
+	}
+
+	loaded, _ := store.Load()
+	if !loaded.UpdatedAt.After(originalUpdated) {
+		t.Error("UpdatedAt should be updated after save")
+	}
+}
+
+func TestRootAgentState_InheritsAgentState(t *testing.T) {
+	state := &RootAgentState{
+		AgentState: AgentState{
+			Name:    "root",
+			Role:    RoleManager,
+			Tool:    "claude",
+			State:   StateWorking,
+			Session: "bc-root",
+		},
+		IsSingleton: true,
+		Children:    []string{"child1", "child2"},
+	}
+
+	// Verify embedded fields are accessible
+	if state.Name != "root" {
+		t.Errorf("Name = %q, want root", state.Name)
+	}
+	if state.Role != RoleManager {
+		t.Errorf("Role = %q, want %q", state.Role, RoleManager)
+	}
+	if state.Session != "bc-root" {
+		t.Errorf("Session = %q, want bc-root", state.Session)
+	}
+	if !state.IsSingleton {
+		t.Error("IsSingleton should be true")
+	}
+	if len(state.Children) != 2 {
+		t.Errorf("Children count = %d, want 2", len(state.Children))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds RootAgentState struct with singleton validation
- Implements RootStateStore for root agent persistence
- Uses `.bc/agents/root.json` for state file
- Includes singleton enforcement

Part of Epic 1.2: Root Agent Singleton (#7)
fixes #10

## Test plan
- [x] Unit tests in root_test.go
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)