### PR TITLE
feat: enforce singleton constraint for root agent

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -22,6 +22,9 @@ import (
 type Role string
 
 const (
+	// Root role (singleton)
+	RoleRoot Role = "root" // Singleton root agent - only one can exist
+
 	// Legacy roles (for backward compatibility)
 	RoleCoordinator Role = "coordinator"
 	RoleWorker      Role = "worker"
@@ -47,6 +50,7 @@ const (
 
 // RoleCapabilities defines what each role can do.
 var RoleCapabilities = map[Role][]Capability{
+	RoleRoot:           {CapCreateAgents, CapAssignWork, CapCreateEpics, CapReviewWork}, // Root can do everything
 	RoleProductManager: {CapCreateAgents, CapAssignWork, CapCreateEpics, CapReviewWork},
 	RoleManager:        {CapCreateAgents, CapAssignWork, CapReviewWork},
 	RoleEngineer:       {CapImplementTasks},
@@ -58,6 +62,7 @@ var RoleCapabilities = map[Role][]Capability{
 
 // RoleHierarchy defines which roles can create which child roles.
 var RoleHierarchy = map[Role][]Role{
+	RoleRoot:           {RoleProductManager, RoleManager, RoleEngineer, RoleQA}, // Root can create all
 	RoleProductManager: {RoleManager},
 	RoleManager:        {RoleEngineer, RoleQA},
 	RoleEngineer:       {}, // Cannot create children
@@ -98,6 +103,8 @@ func HasCapability(role Role, cap Capability) bool {
 // RoleLevel returns the hierarchy level (0 = top, higher = lower in hierarchy).
 func RoleLevel(role Role) int {
 	switch role {
+	case RoleRoot:
+		return -1 // Root is above all
 	case RoleProductManager, RoleCoordinator:
 		return 0
 	case RoleManager:
@@ -322,6 +329,13 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 	defer m.mu.Unlock()
 
 	log.Debug("spawning agent", "name", name, "role", role, "workspace", workspace, "parentID", parentID, "tool", tool)
+
+	// Enforce root singleton constraint
+	if role == RoleRoot {
+		if err := m.enforceRootSingleton(workspace); err != nil {
+			return nil, err
+		}
+	}
 
 	// Validate parent relationship if specified
 	if parentID != "" {
@@ -1028,4 +1042,36 @@ func (m *Manager) LoadState() error {
 // Tmux returns the underlying tmux manager.
 func (m *Manager) Tmux() *tmux.Manager {
 	return m.tmux
+}
+
+// enforceRootSingleton checks if a root agent can be spawned.
+// Returns ErrRootExists if a root already exists and is running.
+// Allows respawn if root is stopped or in error state.
+func (m *Manager) enforceRootSingleton(workspace string) error {
+	bcDir := filepath.Join(workspace, ".bc")
+	rootStore := NewRootStateStore(bcDir)
+
+	// Check if root state exists
+	rootState, err := rootStore.Load()
+	if err != nil {
+		if err == ErrRootNotFound {
+			// No root exists - allow creation
+			return nil
+		}
+		return fmt.Errorf("failed to check root state: %w", err)
+	}
+
+	// Root exists - check if it's in a terminal state that allows respawn
+	switch rootState.State {
+	case StateStopped, StateError:
+		// Terminal state - allow respawn by deleting old state
+		log.Debug("root in terminal state, allowing respawn", "state", rootState.State)
+		if delErr := rootStore.Delete(); delErr != nil {
+			log.Warn("failed to delete old root state", "error", delErr)
+		}
+		return nil
+	default:
+		// Root is active (idle, working, stuck, etc.) - deny new spawn
+		return fmt.Errorf("%w: existing root is in state %q", ErrRootExists, rootState.State)
+	}
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1761,3 +1761,211 @@ func TestEnsureGitWrapper_CreatesBinDir(t *testing.T) {
 		t.Error(".bc/bin is not a directory")
 	}
 }
+
+// --- RoleRoot tests ---
+
+func TestRoleRoot_Capabilities(t *testing.T) {
+	caps, ok := RoleCapabilities[RoleRoot]
+	if !ok {
+		t.Fatal("RoleRoot should have capabilities defined")
+	}
+
+	expected := []Capability{CapCreateAgents, CapAssignWork, CapCreateEpics, CapReviewWork}
+	for _, cap := range expected {
+		found := false
+		for _, c := range caps {
+			if c == cap {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("RoleRoot should have capability %s", cap)
+		}
+	}
+}
+
+func TestRoleRoot_Hierarchy(t *testing.T) {
+	children, ok := RoleHierarchy[RoleRoot]
+	if !ok {
+		t.Fatal("RoleRoot should have hierarchy defined")
+	}
+
+	expected := []Role{RoleProductManager, RoleManager, RoleEngineer, RoleQA}
+	for _, role := range expected {
+		found := false
+		for _, r := range children {
+			if r == role {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("RoleRoot should be able to create %s", role)
+		}
+	}
+}
+
+func TestRoleRoot_Level(t *testing.T) {
+	level := RoleLevel(RoleRoot)
+	if level != -1 {
+		t.Errorf("RoleRoot level = %d, want -1", level)
+	}
+
+	// Root should be above all other roles
+	if level >= RoleLevel(RoleProductManager) {
+		t.Error("RoleRoot should be above RoleProductManager")
+	}
+	if level >= RoleLevel(RoleManager) {
+		t.Error("RoleRoot should be above RoleManager")
+	}
+}
+
+func TestRoleRoot_CanCreateRole(t *testing.T) {
+	tests := []struct {
+		child    Role
+		expected bool
+	}{
+		{RoleProductManager, true},
+		{RoleManager, true},
+		{RoleEngineer, true},
+		{RoleQA, true},
+		{RoleRoot, false}, // Cannot create another root
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.child), func(t *testing.T) {
+			got := CanCreateRole(RoleRoot, tc.child)
+			if got != tc.expected {
+				t.Errorf("CanCreateRole(RoleRoot, %s) = %v, want %v", tc.child, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRoleRoot_HasCapability(t *testing.T) {
+	tests := []struct {
+		cap      Capability
+		expected bool
+	}{
+		{CapCreateAgents, true},
+		{CapAssignWork, true},
+		{CapCreateEpics, true},
+		{CapReviewWork, true},
+		{CapImplementTasks, false}, // Root delegates, doesn't implement
+		{CapTestWork, false},       // Root delegates, doesn't test
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.cap), func(t *testing.T) {
+			got := HasCapability(RoleRoot, tc.cap)
+			if got != tc.expected {
+				t.Errorf("HasCapability(RoleRoot, %s) = %v, want %v", tc.cap, got, tc.expected)
+			}
+		})
+	}
+}
+
+// --- Singleton enforcement tests ---
+
+func TestEnforceRootSingleton_NoRootExists(t *testing.T) {
+	workspace := t.TempDir()
+	m := newTestManager(t)
+
+	// No root exists - should allow creation
+	if err := m.enforceRootSingleton(workspace); err != nil {
+		t.Errorf("enforceRootSingleton should allow creation when no root exists: %v", err)
+	}
+}
+
+func TestEnforceRootSingleton_RootActiveBlocks(t *testing.T) {
+	workspace := t.TempDir()
+	m := newTestManager(t)
+
+	// Create root in active state (idle)
+	bcDir := filepath.Join(workspace, ".bc")
+	store := NewRootStateStore(bcDir)
+	if _, err := store.Create("root", RoleRoot, "claude"); err != nil {
+		t.Fatalf("failed to create root: %v", err)
+	}
+
+	// Active root should block new spawn
+	err := m.enforceRootSingleton(workspace)
+	if err == nil {
+		t.Error("enforceRootSingleton should block when active root exists")
+	}
+	if err != nil && err.Error() == "" {
+		t.Error("error message should not be empty")
+	}
+}
+
+func TestEnforceRootSingleton_RootWorkingBlocks(t *testing.T) {
+	workspace := t.TempDir()
+	m := newTestManager(t)
+
+	// Create root in working state
+	bcDir := filepath.Join(workspace, ".bc")
+	store := NewRootStateStore(bcDir)
+	if _, err := store.Create("root", RoleRoot, "claude"); err != nil {
+		t.Fatalf("failed to create root: %v", err)
+	}
+	if err := store.UpdateState(StateWorking); err != nil {
+		t.Fatalf("failed to update state: %v", err)
+	}
+
+	// Working root should block new spawn
+	err := m.enforceRootSingleton(workspace)
+	if err == nil {
+		t.Error("enforceRootSingleton should block when working root exists")
+	}
+}
+
+func TestEnforceRootSingleton_RootStoppedAllows(t *testing.T) {
+	workspace := t.TempDir()
+	m := newTestManager(t)
+
+	// Create root in stopped state
+	bcDir := filepath.Join(workspace, ".bc")
+	store := NewRootStateStore(bcDir)
+	if _, err := store.Create("root", RoleRoot, "claude"); err != nil {
+		t.Fatalf("failed to create root: %v", err)
+	}
+	if err := store.UpdateState(StateStopped); err != nil {
+		t.Fatalf("failed to update state: %v", err)
+	}
+
+	// Stopped root should allow respawn
+	if err := m.enforceRootSingleton(workspace); err != nil {
+		t.Errorf("enforceRootSingleton should allow respawn when root is stopped: %v", err)
+	}
+
+	// Verify old root state was deleted
+	if store.Exists() {
+		t.Error("old root state should be deleted after allowing respawn")
+	}
+}
+
+func TestEnforceRootSingleton_RootErrorAllows(t *testing.T) {
+	workspace := t.TempDir()
+	m := newTestManager(t)
+
+	// Create root in error state
+	bcDir := filepath.Join(workspace, ".bc")
+	store := NewRootStateStore(bcDir)
+	if _, err := store.Create("root", RoleRoot, "claude"); err != nil {
+		t.Fatalf("failed to create root: %v", err)
+	}
+	if err := store.UpdateState(StateError); err != nil {
+		t.Fatalf("failed to update state: %v", err)
+	}
+
+	// Error state should allow respawn
+	if err := m.enforceRootSingleton(workspace); err != nil {
+		t.Errorf("enforceRootSingleton should allow respawn when root is in error: %v", err)
+	}
+
+	// Verify old root state was deleted
+	if store.Exists() {
+		t.Error("old root state should be deleted after allowing respawn")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `RoleRoot` constant with full management capabilities (create agents, assign work, create epics, review work)
- Add singleton check in `SpawnAgentWithOptions` that blocks spawn if root is active (idle, working, stuck)
- Allow respawn when root is in terminal state (stopped, error) by cleaning up old state
- Add comprehensive tests for RoleRoot capabilities, hierarchy, and singleton enforcement

## Requirements from #16
- ✅ Check if root already exists before spawn
- ✅ Return error if root exists and is running
- ✅ Allow respawn if root is stopped/crashed
- ✅ Update SpawnAgent to handle root specially

## Test plan
- [x] `TestRoleRoot_Capabilities` - Verifies root has management capabilities
- [x] `TestRoleRoot_Hierarchy` - Verifies root can create all child roles
- [x] `TestRoleRoot_Level` - Verifies root is level -1 (above all)
- [x] `TestRoleRoot_CanCreateRole` - Verifies role hierarchy works
- [x] `TestRoleRoot_HasCapability` - Verifies capability checks work
- [x] `TestEnforceRootSingleton_NoRootExists` - Allows spawn when no root
- [x] `TestEnforceRootSingleton_RootActiveBlocks` - Blocks when root idle
- [x] `TestEnforceRootSingleton_RootWorkingBlocks` - Blocks when root working
- [x] `TestEnforceRootSingleton_RootStoppedAllows` - Allows respawn when stopped
- [x] `TestEnforceRootSingleton_RootErrorAllows` - Allows respawn when error

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)