### PR TITLE
feat: add auto-recovery for root agent on bc up

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -80,6 +80,36 @@ func runUp(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Check for existing root state and handle recovery
+	rootStore := agent.NewRootStateStore(ws.StateDir())
+	recovery, err := rootStore.CheckRecovery(mgr.Tmux())
+	if err != nil {
+		return fmt.Errorf("failed to check root state: %w", err)
+	}
+
+	if recovery.IsRunning {
+		// Root is already running
+		fmt.Println("Root agent already running!")
+		fmt.Printf("  Session: %s\n", recovery.State.Session)
+		fmt.Printf("  State: %s\n", recovery.State.State)
+		if len(recovery.State.Children) > 0 {
+			fmt.Printf("  Children: %s\n", strings.Join(recovery.State.Children, ", "))
+		}
+		fmt.Println()
+		fmt.Println("Use 'bc attach coordinator' to attach or 'bc down' first to restart.")
+		return nil
+	}
+
+	if recovery.NeedsRecover {
+		// Root state exists but session is dead - recover
+		fmt.Println("Recovering crashed root agent...")
+		fmt.Printf("  Previous session: %s\n", recovery.State.Session)
+		if len(recovery.State.Children) > 0 {
+			fmt.Printf("  Children to preserve: %s\n", strings.Join(recovery.State.Children, ", "))
+		}
+		fmt.Println()
+	}
+
 	// Determine agent counts (--workers is deprecated, use --engineers)
 	numEngineers := upEngineers
 	numTechLeads := upTechLeads
@@ -123,7 +153,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	// Start coordinator
+	// Start coordinator (acts as root agent)
 	fmt.Print("Starting coordinator... ")
 	coord, err := mgr.SpawnAgent("coordinator", agent.RoleCoordinator, ws.RootDir)
 	if err != nil {
@@ -131,6 +161,21 @@ func runUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to start coordinator: %w", err)
 	}
 	fmt.Printf("✓ (session: %s)\n", mgr.Tmux().SessionName(coord.Session))
+
+	// Create or update root state
+	if recovery.NeedsCreate || recovery.NeedsRecover {
+		if recovery.NeedsCreate {
+			// Create new root state
+			_, createErr := rootStore.Create("root", agent.RoleCoordinator, "claude")
+			if createErr != nil && createErr != agent.ErrRootExists {
+				fmt.Printf("  Warning: failed to create root state: %v\n", createErr)
+			}
+		}
+		// Update session in root state
+		if updateErr := rootStore.MarkRecovered(coord.Session); updateErr != nil {
+			fmt.Printf("  Warning: failed to update root session: %v\n", updateErr)
+		}
+	}
 
 	_ = log.Append(events.Event{
 		Type:  events.AgentSpawned,
@@ -147,6 +192,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println("✓")
 	_ = log.Append(events.Event{Type: events.AgentSpawned, Agent: "product-manager"})
+	_ = rootStore.AddChild("product-manager")
 	time.Sleep(300 * time.Millisecond)
 
 	// Start manager
@@ -158,6 +204,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println("✓")
 	_ = log.Append(events.Event{Type: events.AgentSpawned, Agent: "manager"})
+	_ = rootStore.AddChild("manager")
 	time.Sleep(300 * time.Millisecond)
 
 	// Start tech-leads
@@ -179,6 +226,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 			Type:  events.AgentSpawned,
 			Agent: name,
 		})
+		_ = rootStore.AddChild(name)
 
 		time.Sleep(300 * time.Millisecond)
 	}
@@ -202,6 +250,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 			Type:  events.AgentSpawned,
 			Agent: name,
 		})
+		_ = rootStore.AddChild(name)
 
 		time.Sleep(300 * time.Millisecond)
 	}
@@ -225,6 +274,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 			Type:  events.AgentSpawned,
 			Agent: name,
 		})
+		_ = rootStore.AddChild(name)
 
 		time.Sleep(300 * time.Millisecond)
 	}

--- a/pkg/agent/root.go
+++ b/pkg/agent/root.go
@@ -254,3 +254,66 @@ func (s *RootStateStore) UpdateSession(session string) error {
 	state.Session = session
 	return s.Save(state)
 }
+
+// TmuxChecker interface for checking tmux session status.
+// This allows for easier testing without real tmux.
+type TmuxChecker interface {
+	HasSession(name string) bool
+}
+
+// RootRecoveryResult describes the outcome of a root recovery check.
+type RootRecoveryResult struct {
+	State        *RootAgentState
+	NeedsCreate  bool // No root state exists
+	NeedsRecover bool // Root state exists but session dead
+	IsRunning    bool // Root is running normally
+}
+
+// CheckRecovery checks if root needs to be created or recovered.
+// This is the first step in `bc up` to determine what action to take.
+func (s *RootStateStore) CheckRecovery(tmux TmuxChecker) (*RootRecoveryResult, error) {
+	state, err := s.Load()
+	if errors.Is(err, ErrRootNotFound) {
+		return &RootRecoveryResult{NeedsCreate: true}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to load root state: %w", err)
+	}
+
+	// Check if tmux session is alive
+	if state.Session != "" && tmux.HasSession(state.Session) {
+		return &RootRecoveryResult{
+			State:     state,
+			IsRunning: true,
+		}, nil
+	}
+
+	// Session dead or missing - needs recovery
+	return &RootRecoveryResult{
+		State:        state,
+		NeedsRecover: true,
+	}, nil
+}
+
+// MarkRecovered updates root state after successful recovery.
+func (s *RootStateStore) MarkRecovered(session string) error {
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+
+	state.Session = session
+	state.State = StateIdle
+	state.UpdatedAt = time.Now()
+
+	return s.Save(state)
+}
+
+// GetChildren returns the list of child agent names.
+func (s *RootStateStore) GetChildren() ([]string, error) {
+	state, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+	return state.Children, nil
+}

--- a/pkg/agent/root_test.go
+++ b/pkg/agent/root_test.go
@@ -338,3 +338,219 @@ func TestRootAgentState_InheritsAgentState(t *testing.T) {
 		t.Errorf("Children count = %d, want 2", len(state.Children))
 	}
 }
+
+// mockTmuxChecker implements TmuxChecker for testing.
+type mockTmuxChecker struct {
+	sessions map[string]bool
+}
+
+func (m *mockTmuxChecker) HasSession(name string) bool {
+	return m.sessions[name]
+}
+
+func TestRootStateStore_CheckRecovery_NoRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+	mock := &mockTmuxChecker{sessions: map[string]bool{}}
+
+	result, err := store.CheckRecovery(mock)
+	if err != nil {
+		t.Fatalf("CheckRecovery failed: %v", err)
+	}
+
+	if !result.NeedsCreate {
+		t.Error("NeedsCreate should be true when no root exists")
+	}
+	if result.NeedsRecover {
+		t.Error("NeedsRecover should be false")
+	}
+	if result.IsRunning {
+		t.Error("IsRunning should be false")
+	}
+	if result.State != nil {
+		t.Error("State should be nil")
+	}
+}
+
+func TestRootStateStore_CheckRecovery_Running(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Create root with session
+	state, err := store.Create("root", RoleCoordinator, "claude")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if updateErr := store.UpdateSession("bc-root-session"); updateErr != nil {
+		t.Fatalf("UpdateSession failed: %v", updateErr)
+	}
+
+	// Mock tmux says session is alive
+	mock := &mockTmuxChecker{sessions: map[string]bool{"bc-root-session": true}}
+
+	result, err := store.CheckRecovery(mock)
+	if err != nil {
+		t.Fatalf("CheckRecovery failed: %v", err)
+	}
+
+	if result.NeedsCreate {
+		t.Error("NeedsCreate should be false")
+	}
+	if result.NeedsRecover {
+		t.Error("NeedsRecover should be false")
+	}
+	if !result.IsRunning {
+		t.Error("IsRunning should be true when tmux session is alive")
+	}
+	if result.State == nil {
+		t.Error("State should not be nil")
+	}
+	if result.State.Name != state.Name {
+		t.Errorf("State.Name = %q, want %q", result.State.Name, state.Name)
+	}
+}
+
+func TestRootStateStore_CheckRecovery_NeedsRecovery(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Create root with session and children
+	if _, err := store.Create("root", RoleCoordinator, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if err := store.UpdateSession("bc-dead-session"); err != nil {
+		t.Fatalf("UpdateSession failed: %v", err)
+	}
+	if err := store.AddChild("engineer-01"); err != nil {
+		t.Fatalf("AddChild failed: %v", err)
+	}
+	if err := store.AddChild("engineer-02"); err != nil {
+		t.Fatalf("AddChild failed: %v", err)
+	}
+
+	// Mock tmux says session is dead
+	mock := &mockTmuxChecker{sessions: map[string]bool{}}
+
+	result, err := store.CheckRecovery(mock)
+	if err != nil {
+		t.Fatalf("CheckRecovery failed: %v", err)
+	}
+
+	if result.NeedsCreate {
+		t.Error("NeedsCreate should be false")
+	}
+	if !result.NeedsRecover {
+		t.Error("NeedsRecover should be true when tmux session is dead")
+	}
+	if result.IsRunning {
+		t.Error("IsRunning should be false")
+	}
+	if result.State == nil {
+		t.Error("State should not be nil")
+	}
+	if len(result.State.Children) != 2 {
+		t.Errorf("Children count = %d, want 2", len(result.State.Children))
+	}
+}
+
+func TestRootStateStore_MarkRecovered(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Create root with error state
+	if _, err := store.Create("root", RoleCoordinator, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if err := store.UpdateState(StateError); err != nil {
+		t.Fatalf("UpdateState failed: %v", err)
+	}
+
+	// Mark as recovered with new session
+	if err := store.MarkRecovered("bc-new-session"); err != nil {
+		t.Fatalf("MarkRecovered failed: %v", err)
+	}
+
+	// Verify state
+	state, err := store.Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if state.Session != "bc-new-session" {
+		t.Errorf("Session = %q, want bc-new-session", state.Session)
+	}
+	if state.State != StateIdle {
+		t.Errorf("State = %q, want %q", state.State, StateIdle)
+	}
+}
+
+func TestRootStateStore_GetChildren(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// No root - should error
+	_, noRootErr := store.GetChildren()
+	if !errors.Is(noRootErr, ErrRootNotFound) {
+		t.Errorf("GetChildren without root should return ErrRootNotFound, got: %v", noRootErr)
+	}
+
+	// Create root with children
+	if _, createErr := store.Create("root", RoleCoordinator, "claude"); createErr != nil {
+		t.Fatalf("Create failed: %v", createErr)
+	}
+	if addErr := store.AddChild("engineer-01"); addErr != nil {
+		t.Fatalf("AddChild failed: %v", addErr)
+	}
+	if addErr := store.AddChild("qa-01"); addErr != nil {
+		t.Fatalf("AddChild failed: %v", addErr)
+	}
+
+	children, err := store.GetChildren()
+	if err != nil {
+		t.Fatalf("GetChildren failed: %v", err)
+	}
+
+	if len(children) != 2 {
+		t.Errorf("Children count = %d, want 2", len(children))
+	}
+	// Verify children names
+	hasEngineer := false
+	hasQA := false
+	for _, c := range children {
+		if c == "engineer-01" {
+			hasEngineer = true
+		}
+		if c == "qa-01" {
+			hasQA = true
+		}
+	}
+	if !hasEngineer || !hasQA {
+		t.Errorf("Children = %v, want [engineer-01, qa-01]", children)
+	}
+}
+
+func TestRootStateStore_CheckRecovery_EmptySession(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Create root without setting session
+	if _, err := store.Create("root", RoleCoordinator, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Mock tmux - doesn't matter, session is empty
+	mock := &mockTmuxChecker{sessions: map[string]bool{"anything": true}}
+
+	result, err := store.CheckRecovery(mock)
+	if err != nil {
+		t.Fatalf("CheckRecovery failed: %v", err)
+	}
+
+	// Empty session should trigger recovery
+	if !result.NeedsRecover {
+		t.Error("NeedsRecover should be true when session is empty")
+	}
+	if result.IsRunning {
+		t.Error("IsRunning should be false when session is empty")
+	}
+}


### PR DESCRIPTION
## Summary
- Detect existing root agent state when running `bc up`
- Check if tmux session is alive using TmuxChecker interface
- Show status and suggest `bc attach`/`bc down` if already running
- Respawn with preserved children list if session is dead
- Register all children (coordinator, product-manager, manager, tech-leads, engineers, QA) as they're spawned

## Changes
- **pkg/agent/root.go**: Add `RootRecoveryResult`, `CheckRecovery()`, `MarkRecovered()`, `GetChildren()`, `TmuxChecker` interface
- **internal/cmd/up.go**: Add recovery check before spawning, child registration after each spawn
- **pkg/agent/root_test.go**: 6 new tests for recovery functionality

## Test plan
- [x] Run `go test ./pkg/agent/...` - all tests pass
- [x] Run `go test ./internal/cmd/...` - all tests pass
- [x] Run `golangci-lint run` - 0 issues
- [x] Pre-commit hooks pass

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)