### PR TITLE
feat: add roster config to config.toml

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -19,15 +19,23 @@ import (
 var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Start bc agents",
-	Long: `Start the bc agent system with the default roster.
+	Long: `Start the bc agent system with the configured roster.
 
-Default roster:
+Default roster (configurable in .bc/config.toml [roster]):
   - coordinator (orchestrates work)
   - product-manager (creates epics)
   - manager (assigns tasks)
   - tech-lead-01, tech-lead-02 (technical leadership, code review)
   - engineer-01, engineer-02, engineer-03 (implement tasks)
   - qa-01, qa-02 (test implementations)
+
+Roster configuration in .bc/config.toml:
+  [roster]
+  engineers = 4   # Number of engineers (0-10)
+  tech_leads = 2  # Number of tech-leads (0-10)
+  qa = 2          # Number of QA agents (0-10)
+
+CLI flags override config.toml values.
 
 This will:
 1. Start all agents in the roster
@@ -36,10 +44,10 @@ This will:
 4. Send bootstrap prompts to all agents
 
 Example:
-  bc up                      # Start with default roster (2 tech-leads, 3 engineers, 2 QA)
-  bc up --engineers 5        # Start with 5 engineers
-  bc up --tech-leads 3       # Start with 3 tech-lead agents
-  bc up --qa 3               # Start with 3 QA agents
+  bc up                      # Start with roster from config.toml
+  bc up --engineers 5        # Override engineers count
+  bc up --tech-leads 3       # Override tech-leads count
+  bc up --qa 3               # Override QA count
   bc up --agent cursor       # Use Cursor AI for all agents`,
 	RunE: runUp,
 }
@@ -110,12 +118,40 @@ func runUp(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 	}
 
-	// Determine agent counts (--workers is deprecated, use --engineers)
+	// Determine agent counts from config, with CLI flag overrides
+	// Priority: CLI flags > config.toml > hardcoded defaults
 	numEngineers := upEngineers
 	numTechLeads := upTechLeads
 	numQA := upQA
+
+	// Read roster from config if V2Config is available
+	if ws.V2Config != nil {
+		roster := ws.V2Config.Roster
+		// Use config values as base (only if not zero, indicating it was set)
+		if roster.Engineers > 0 || roster.Engineers == 0 {
+			numEngineers = roster.Engineers
+		}
+		if roster.TechLeads > 0 || roster.TechLeads == 0 {
+			numTechLeads = roster.TechLeads
+		}
+		if roster.QA > 0 || roster.QA == 0 {
+			numQA = roster.QA
+		}
+	}
+
+	// CLI flags override config values (check if flag was explicitly set)
+	if cmd.Flags().Changed("engineers") {
+		numEngineers = upEngineers
+	}
+	if cmd.Flags().Changed("tech-leads") {
+		numTechLeads = upTechLeads
+	}
+	if cmd.Flags().Changed("qa") {
+		numQA = upQA
+	}
+
+	// Legacy: if --workers is set, use it for engineers (deprecated)
 	if upWorkers > 0 {
-		// Legacy: if --workers is set, use it for engineers
 		numEngineers = upWorkers
 	}
 

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -21,6 +21,7 @@ type V2Config struct {
 	Memory    MemoryConfig    `toml:"memory"`
 	Beads     BeadsConfig     `toml:"beads"`
 	Channels  ChannelsConfig  `toml:"channels"`
+	Roster    RosterConfig    `toml:"roster"`
 }
 
 // WorkspaceConfig holds core workspace settings.
@@ -67,6 +68,19 @@ type ChannelsConfig struct {
 	Default []string `toml:"default"`
 }
 
+// RosterConfig configures the default agent roster for bc up.
+type RosterConfig struct {
+	Engineers int `toml:"engineers"`  // Number of engineer agents (default: 4)
+	TechLeads int `toml:"tech_leads"` // Number of tech-lead agents (default: 2)
+	QA        int `toml:"qa"`         // Number of QA agents (default: 2)
+}
+
+// Roster limits.
+const (
+	RosterMinPerRole = 0  // Minimum agents per role
+	RosterMaxPerRole = 10 // Maximum agents per role
+)
+
 // Validation errors.
 var (
 	ErrMissingWorkspaceName = errors.New("workspace.name is required")
@@ -75,6 +89,9 @@ var (
 	ErrDefaultToolNotFound  = errors.New("tools.default references undefined tool")
 	ErrMissingMemoryBackend = errors.New("memory.backend is required")
 	ErrMissingMemoryPath    = errors.New("memory.path is required")
+	ErrRosterEngineersRange = errors.New("roster.engineers must be between 0 and 10")
+	ErrRosterTechLeadsRange = errors.New("roster.tech_leads must be between 0 and 10")
+	ErrRosterQARange        = errors.New("roster.qa must be between 0 and 10")
 )
 
 // DefaultV2Config returns sensible defaults for a new v2 workspace.
@@ -105,6 +122,11 @@ func DefaultV2Config(name string) V2Config {
 		},
 		Channels: ChannelsConfig{
 			Default: []string{"general", "engineering"},
+		},
+		Roster: RosterConfig{
+			Engineers: 4,
+			TechLeads: 2,
+			QA:        2,
 		},
 	}
 }
@@ -153,6 +175,17 @@ func (c *V2Config) Validate() error {
 	}
 	if c.Memory.Path == "" {
 		return ErrMissingMemoryPath
+	}
+
+	// Roster validation
+	if c.Roster.Engineers < RosterMinPerRole || c.Roster.Engineers > RosterMaxPerRole {
+		return ErrRosterEngineersRange
+	}
+	if c.Roster.TechLeads < RosterMinPerRole || c.Roster.TechLeads > RosterMaxPerRole {
+		return ErrRosterTechLeadsRange
+	}
+	if c.Roster.QA < RosterMinPerRole || c.Roster.QA > RosterMaxPerRole {
+		return ErrRosterQARange
 	}
 
 	return nil

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -24,6 +24,16 @@ func TestDefaultV2Config(t *testing.T) {
 	if cfg.Memory.Backend != "file" {
 		t.Errorf("expected memory backend 'file', got %q", cfg.Memory.Backend)
 	}
+	// Test default roster values
+	if cfg.Roster.Engineers != 4 {
+		t.Errorf("expected roster.engineers = 4, got %d", cfg.Roster.Engineers)
+	}
+	if cfg.Roster.TechLeads != 2 {
+		t.Errorf("expected roster.tech_leads = 2, got %d", cfg.Roster.TechLeads)
+	}
+	if cfg.Roster.QA != 2 {
+		t.Errorf("expected roster.qa = 2, got %d", cfg.Roster.QA)
+	}
 }
 
 func TestParseV2Config(t *testing.T) {
@@ -101,6 +111,45 @@ default = ["general", "engineering"]
 	}
 }
 
+func TestParseV2ConfigWithRoster(t *testing.T) {
+	tomlData := []byte(`
+[workspace]
+name = "roster-project"
+version = 2
+
+[tools]
+default = "claude"
+
+[tools.claude]
+command = "claude"
+enabled = true
+
+[memory]
+backend = "file"
+path = ".bc/memory"
+
+[roster]
+engineers = 5
+tech_leads = 3
+qa = 1
+`)
+
+	cfg, err := ParseV2Config(tomlData)
+	if err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	if cfg.Roster.Engineers != 5 {
+		t.Errorf("expected roster.engineers = 5, got %d", cfg.Roster.Engineers)
+	}
+	if cfg.Roster.TechLeads != 3 {
+		t.Errorf("expected roster.tech_leads = 3, got %d", cfg.Roster.TechLeads)
+	}
+	if cfg.Roster.QA != 1 {
+		t.Errorf("expected roster.qa = 1, got %d", cfg.Roster.QA)
+	}
+}
+
 func TestV2ConfigValidation(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -155,6 +204,53 @@ func TestV2ConfigValidation(t *testing.T) {
 			name:    "valid config",
 			wantErr: nil,
 			cfg:     DefaultV2Config("test"),
+		},
+		{
+			name:    "roster engineers too high",
+			wantErr: ErrRosterEngineersRange,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.Engineers = 11
+				return cfg
+			}(),
+		},
+		{
+			name:    "roster engineers negative",
+			wantErr: ErrRosterEngineersRange,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.Engineers = -1
+				return cfg
+			}(),
+		},
+		{
+			name:    "roster tech_leads too high",
+			wantErr: ErrRosterTechLeadsRange,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.TechLeads = 11
+				return cfg
+			}(),
+		},
+		{
+			name:    "roster qa too high",
+			wantErr: ErrRosterQARange,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.QA = 11
+				return cfg
+			}(),
+		},
+		{
+			name:    "roster zero values valid",
+			wantErr: nil,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.Engineers = 0
+				cfg.Roster.TechLeads = 0
+				cfg.Roster.QA = 0
+				return cfg
+			}(),
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Add `[roster]` section to `.bc/config.toml` for configuring agent counts
- Roster config supports `engineers`, `tech_leads`, and `qa` fields
- CLI flags (`--engineers`, `--tech-leads`, `--qa`) override config values
- Add validation ensuring values are within 0-10 range

## Changes
- `pkg/workspace/config.go`: Add `RosterConfig` struct and validation
- `internal/cmd/up.go`: Read roster from config with CLI flag overrides
- `pkg/workspace/config_test.go`: Add tests for roster config

## Config Example
```toml
[roster]
engineers = 4   # Number of engineers (0-10)
tech_leads = 2  # Number of tech-leads (0-10)
qa = 2          # Number of QA agents (0-10)
```

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test ./pkg/workspace/...` passes (all roster tests)
- [x] `go test ./...` passes (full test suite)
- [x] Pre-commit hooks (golangci-lint) pass

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)