### PR TITLE
feat: create per-agent channels on bc up

### DIFF
--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -368,6 +368,80 @@ func TestCreateDefaultChannels(t *testing.T) {
 	}
 }
 
+func TestCreateDefaultChannels_PerAgentChannels(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bc"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	techLeads := []string{"tech-lead-01"}
+	engineers := []string{"engineer-01", "engineer-02"}
+	qa := []string{"qa-01"}
+	all := []string{"coordinator", "product-manager", "manager", "tech-lead-01", "engineer-01", "engineer-02", "qa-01"}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	_, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	createDefaultChannels(dir, techLeads, engineers, qa, all)
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	// Verify channels file was created
+	channelsFile := filepath.Join(dir, ".bc", "channels.json")
+	data, err := os.ReadFile(channelsFile) //nolint:gosec // test file
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+
+	// Verify per-agent channels are created
+	for _, agentName := range all {
+		if !strings.Contains(content, fmt.Sprintf(`"name": "%s"`, agentName)) {
+			t.Errorf("channels.json missing per-agent channel for %q", agentName)
+		}
+	}
+}
+
+func TestCreateDefaultChannels_NoDuplicatesOnRestart(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bc"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	engineers := []string{"engineer-01"}
+	qa := []string{"qa-01"}
+	all := []string{"coordinator", "manager", "engineer-01", "qa-01"}
+
+	// Suppress stdout
+	oldStdout := os.Stdout
+	_, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Run twice to simulate restart
+	createDefaultChannels(dir, []string{}, engineers, qa, all)
+	createDefaultChannels(dir, []string{}, engineers, qa, all)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+
+	// Read and count channel occurrences
+	channelsFile := filepath.Join(dir, ".bc", "channels.json")
+	data, err := os.ReadFile(channelsFile) //nolint:gosec // test file
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Count occurrences of "engineer-01" channel name
+	count := strings.Count(string(data), `"name": "engineer-01"`)
+	if count != 1 {
+		t.Errorf("expected 1 engineer-01 channel, got %d (duplicate channels created)", count)
+	}
+}
+
 // --- Init command tests ---
 
 func TestInitCommand(t *testing.T) {

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -492,6 +492,7 @@ func buildBootstrapPrompt(agentNames []string, items []queue.WorkItem, rootDir s
 // createDefaultChannels sets up the default communication channels.
 // Channels: #standup (all), #leadership (coordinator, pm, manager, tech-leads),
 // #engineering (manager, tech-leads, engineers), #qa (manager, qa), #all (everyone).
+// Also creates per-agent channels (#agent-name) for direct messaging.
 func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames, allAgents []string) {
 	store := channel.NewStore(rootDir)
 	if err := store.Load(); err != nil {
@@ -518,12 +519,21 @@ func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames
 	qaMembers = append(qaMembers, "manager")
 	qaMembers = append(qaMembers, qaNames...)
 
-	channels := []chanDef{
-		{"standup", allAgents},
-		{"leadership", leadershipMembers},
-		{"engineering", engineeringMembers},
-		{"qa", qaMembers},
-		{"all", allAgents},
+	// Group channels + per-agent channels
+	// Preallocate: 5 group channels + 1 per agent
+	channels := make([]chanDef, 0, 5+len(allAgents))
+	channels = append(channels,
+		chanDef{"standup", allAgents},
+		chanDef{"leadership", leadershipMembers},
+		chanDef{"engineering", engineeringMembers},
+		chanDef{"qa", qaMembers},
+		chanDef{"all", allAgents},
+	)
+
+	// Per-agent channels for direct messaging
+	// Each agent gets their own channel and is auto-subscribed
+	for _, agentName := range allAgents {
+		channels = append(channels, chanDef{agentName, []string{agentName}})
 	}
 
 	created := 0
@@ -534,12 +544,12 @@ func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames
 				fmt.Printf("  Warning: failed to create channel #%s: %v\n", ch.name, createErr)
 				continue
 			}
+			created++
 		}
 		// Add members (skip if already present)
 		for _, member := range ch.members {
 			_ = store.AddMember(ch.name, member)
 		}
-		created++
 	}
 
 	if created > 0 {
@@ -547,6 +557,22 @@ func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames
 			fmt.Printf("  Warning: failed to save channels: %v\n", err)
 			return
 		}
-		fmt.Printf("Created %d default channels\n", created)
+		fmt.Printf("Created %d channels (%d group + %d per-agent)\n", created, min(created, 5), max(0, created-5))
 	}
+}
+
+// min returns the smaller of two integers.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// max returns the larger of two integers.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }


### PR DESCRIPTION
## Summary
- Create per-agent channels (#agent-name) for each agent on `bc up`
- Enables direct messaging to specific agents (e.g., #engineer-01, #qa-02)
- Each agent is auto-subscribed to their own channel
- Idempotent: no duplicate channels on restart

## Changes
- `internal/cmd/up.go`: Modified `createDefaultChannels` to create per-agent channels
- `internal/cmd/cmd_test.go`: Added tests for per-agent channel creation

## Part of Epic #26 (Channels Infrastructure)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/cmd/... -run TestCreateDefaultChannels` passes
- [x] `go test ./...` passes (full test suite)
- [x] Pre-commit hooks (golangci-lint) pass

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)