### PR TITLE
test: add flag handling tests for up.go

### DIFF
--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -161,3 +161,173 @@ func TestBuildBootstrapPrompt_CoordinatorRole(t *testing.T) {
 		t.Error("prompt should identify the coordinator role")
 	}
 }
+
+// Flag parsing tests for upCmd
+
+func TestUpCmd_EngineersFlag(t *testing.T) {
+	// Reset flag values before test
+	upEngineers = 3
+	upTechLeads = 2
+	upQA = 2
+	upWorkers = 0
+	upAgent = ""
+
+	// Parse --engineers flag
+	if err := upCmd.ParseFlags([]string{"--engineers", "5"}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+
+	if upEngineers != 5 {
+		t.Errorf("--engineers flag: got %d, want 5", upEngineers)
+	}
+}
+
+func TestUpCmd_QAFlag(t *testing.T) {
+	// Reset flag values before test
+	upEngineers = 3
+	upTechLeads = 2
+	upQA = 2
+	upWorkers = 0
+	upAgent = ""
+
+	// Parse --qa flag
+	if err := upCmd.ParseFlags([]string{"--qa", "4"}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+
+	if upQA != 4 {
+		t.Errorf("--qa flag: got %d, want 4", upQA)
+	}
+}
+
+func TestUpCmd_TechLeadsFlag(t *testing.T) {
+	// Reset flag values before test
+	upEngineers = 3
+	upTechLeads = 2
+	upQA = 2
+	upWorkers = 0
+	upAgent = ""
+
+	// Parse --tech-leads flag
+	if err := upCmd.ParseFlags([]string{"--tech-leads", "3"}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+
+	if upTechLeads != 3 {
+		t.Errorf("--tech-leads flag: got %d, want 3", upTechLeads)
+	}
+}
+
+func TestUpCmd_AgentFlag(t *testing.T) {
+	// Reset flag values before test
+	upEngineers = 3
+	upTechLeads = 2
+	upQA = 2
+	upWorkers = 0
+	upAgent = ""
+
+	// Parse --agent flag
+	if err := upCmd.ParseFlags([]string{"--agent", "cursor"}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+
+	if upAgent != "cursor" {
+		t.Errorf("--agent flag: got %q, want %q", upAgent, "cursor")
+	}
+}
+
+func TestUpCmd_WorkersDeprecatedFlag(t *testing.T) {
+	// Reset flag values before test
+	upEngineers = 3
+	upTechLeads = 2
+	upQA = 2
+	upWorkers = 0
+	upAgent = ""
+
+	// Parse deprecated --workers flag
+	if err := upCmd.ParseFlags([]string{"--workers", "7"}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+
+	if upWorkers != 7 {
+		t.Errorf("--workers flag: got %d, want 7", upWorkers)
+	}
+}
+
+func TestUpCmd_MultipleFlags(t *testing.T) {
+	// Reset flag values before test
+	upEngineers = 3
+	upTechLeads = 2
+	upQA = 2
+	upWorkers = 0
+	upAgent = ""
+
+	// Parse multiple flags together
+	if err := upCmd.ParseFlags([]string{
+		"--engineers", "6",
+		"--tech-leads", "4",
+		"--qa", "3",
+		"--agent", "codex",
+	}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+
+	if upEngineers != 6 {
+		t.Errorf("--engineers flag: got %d, want 6", upEngineers)
+	}
+	if upTechLeads != 4 {
+		t.Errorf("--tech-leads flag: got %d, want 4", upTechLeads)
+	}
+	if upQA != 3 {
+		t.Errorf("--qa flag: got %d, want 3", upQA)
+	}
+	if upAgent != "codex" {
+		t.Errorf("--agent flag: got %q, want %q", upAgent, "codex")
+	}
+}
+
+func TestUpCmd_DefaultValues(t *testing.T) {
+	// Check that flags have the expected default values
+	// Note: We check the flag definitions, not the current values
+	// since ParseFlags may have been called earlier in the test suite
+
+	engFlag := upCmd.Flags().Lookup("engineers")
+	if engFlag == nil {
+		t.Fatal("engineers flag not found")
+	}
+	if engFlag.DefValue != "3" {
+		t.Errorf("engineers default: got %q, want %q", engFlag.DefValue, "3")
+	}
+
+	qaFlag := upCmd.Flags().Lookup("qa")
+	if qaFlag == nil {
+		t.Fatal("qa flag not found")
+	}
+	if qaFlag.DefValue != "2" {
+		t.Errorf("qa default: got %q, want %q", qaFlag.DefValue, "2")
+	}
+
+	tlFlag := upCmd.Flags().Lookup("tech-leads")
+	if tlFlag == nil {
+		t.Fatal("tech-leads flag not found")
+	}
+	if tlFlag.DefValue != "2" {
+		t.Errorf("tech-leads default: got %q, want %q", tlFlag.DefValue, "2")
+	}
+
+	agentFlag := upCmd.Flags().Lookup("agent")
+	if agentFlag == nil {
+		t.Fatal("agent flag not found")
+	}
+	if agentFlag.DefValue != "" {
+		t.Errorf("agent default: got %q, want empty string", agentFlag.DefValue)
+	}
+
+	workersFlag := upCmd.Flags().Lookup("workers")
+	if workersFlag == nil {
+		t.Fatal("workers flag not found")
+	}
+	if workersFlag.DefValue != "0" {
+		t.Errorf("workers default: got %q, want %q", workersFlag.DefValue, "0")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds tests for `bc up` command flag parsing
- Tests `--engineers`, `--qa`, `--tech-leads`, `--agent`, and deprecated `--workers` flags
- Validates flag default values

## Test plan
- [x] `go test ./internal/cmd/... -run TestUpCmd` passes
- [ ] CI passes

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)