### PR TITLE
feat: add random name generation for agents

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/names"
 )
 
 // agentCmd is the parent command for all agent operations
@@ -33,15 +34,18 @@ Examples:
 
 // agentCreateCmd creates a new agent (replaces bc spawn)
 var agentCreateCmd = &cobra.Command{
-	Use:   "create <name>",
+	Use:   "create [name]",
 	Short: "Create a new agent",
 	Long: `Create and start a new agent.
 
+If no name is provided, a random memorable name is generated (e.g., swift-falcon).
+
 Examples:
-  bc agent create worker-01                    # Create with default role/tool
+  bc agent create --role engineer              # Create with random name
+  bc agent create worker-01                    # Create with explicit name
   bc agent create eng-01 --role engineer       # Create engineer
   bc agent create qa-01 --role qa --tool cursor # Create QA with Cursor`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentCreate,
 }
 
@@ -149,11 +153,6 @@ func init() {
 }
 
 func runAgentCreate(cmd *cobra.Command, args []string) error {
-	agentName := strings.TrimSpace(args[0])
-	if agentName == "" {
-		return fmt.Errorf("agent name cannot be empty")
-	}
-
 	ws, err := getWorkspace()
 	if err != nil {
 		return fmt.Errorf("not in a bc workspace: %w", err)
@@ -162,6 +161,25 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
 	if loadErr := mgr.LoadState(); loadErr != nil {
 		log.Warn("failed to load agent state", "error", loadErr)
+	}
+
+	// Determine agent name: use provided name or generate one
+	var agentName string
+	if len(args) > 0 && strings.TrimSpace(args[0]) != "" {
+		agentName = strings.TrimSpace(args[0])
+	} else {
+		// Generate unique name
+		existingAgents := mgr.ListAgents()
+		existingNames := make([]string, len(existingAgents))
+		for i, a := range existingAgents {
+			existingNames[i] = a.Name
+		}
+		generatedName, genErr := names.GenerateUniqueFromList(existingNames, 100)
+		if genErr != nil {
+			return fmt.Errorf("failed to generate agent name: %w", genErr)
+		}
+		agentName = generatedName
+		fmt.Printf("Generated name: %s\n", agentName)
 	}
 
 	// Check if agent already exists

--- a/pkg/names/generator.go
+++ b/pkg/names/generator.go
@@ -1,0 +1,109 @@
+// Package names provides random name generation for agents.
+package names
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+)
+
+// Adjectives for name generation (positive, memorable)
+var adjectives = []string{
+	"swift", "clever", "bright", "keen", "bold",
+	"calm", "eager", "fair", "glad", "kind",
+	"lively", "merry", "neat", "prime", "quick",
+	"ready", "sharp", "smart", "steady", "sure",
+	"true", "vivid", "warm", "wise", "zesty",
+	"agile", "brave", "crisp", "deft", "epic",
+	"fresh", "grand", "happy", "ideal", "jolly",
+	"lucid", "noble", "polar", "rapid", "sleek",
+	"tidy", "ultra", "vital", "witty", "young",
+	"zen", "azure", "coral", "dusky", "frost",
+}
+
+// Animals for name generation (distinctive, easy to type)
+var animals = []string{
+	"falcon", "otter", "panda", "tiger", "eagle",
+	"dolphin", "jaguar", "koala", "lemur", "meerkat",
+	"narwhal", "osprey", "panther", "quail", "raven",
+	"salmon", "toucan", "urchin", "viper", "walrus",
+	"xerus", "yak", "zebra", "badger", "condor",
+	"dingo", "ermine", "ferret", "gecko", "heron",
+	"impala", "jackal", "kiwi", "lobster", "marten",
+	"newt", "ocelot", "puffin", "quokka", "raccoon",
+	"serval", "tapir", "urial", "vulture", "wombat",
+	"axolotl", "bison", "crane", "duck", "elk",
+}
+
+// Generator creates random agent names.
+type Generator struct {
+	rng *rand.Rand
+}
+
+// New creates a new name generator.
+func New() *Generator {
+	return &Generator{
+		rng: rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec // not for crypto
+	}
+}
+
+// Generate creates a random adjective-animal name.
+func (g *Generator) Generate() string {
+	adj := adjectives[g.rng.Intn(len(adjectives))]
+	animal := animals[g.rng.Intn(len(animals))]
+	return fmt.Sprintf("%s-%s", adj, animal)
+}
+
+// GenerateUnique creates a random name that doesn't exist in the given set.
+// Returns error if unable to generate unique name after maxAttempts.
+func (g *Generator) GenerateUnique(existing map[string]bool, maxAttempts int) (string, error) {
+	if maxAttempts <= 0 {
+		maxAttempts = 100
+	}
+
+	for i := 0; i < maxAttempts; i++ {
+		name := g.Generate()
+		if !existing[name] {
+			return name, nil
+		}
+	}
+
+	// Fallback: add numeric suffix
+	base := g.Generate()
+	for i := 1; i <= 999; i++ {
+		name := fmt.Sprintf("%s-%d", base, i)
+		if !existing[name] {
+			return name, nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to generate unique name after %d attempts", maxAttempts)
+}
+
+// GenerateUniqueFromList creates a random name not in the given list.
+func (g *Generator) GenerateUniqueFromList(existingNames []string, maxAttempts int) (string, error) {
+	existing := make(map[string]bool, len(existingNames))
+	for _, name := range existingNames {
+		existing[strings.ToLower(name)] = true
+	}
+	return g.GenerateUnique(existing, maxAttempts)
+}
+
+// DefaultGenerator is a package-level generator for convenience.
+var DefaultGenerator = New()
+
+// Generate creates a random name using the default generator.
+func Generate() string {
+	return DefaultGenerator.Generate()
+}
+
+// GenerateUnique creates a unique random name using the default generator.
+func GenerateUnique(existing map[string]bool, maxAttempts int) (string, error) {
+	return DefaultGenerator.GenerateUnique(existing, maxAttempts)
+}
+
+// GenerateUniqueFromList creates a unique random name using the default generator.
+func GenerateUniqueFromList(existingNames []string, maxAttempts int) (string, error) {
+	return DefaultGenerator.GenerateUniqueFromList(existingNames, maxAttempts)
+}

--- a/pkg/names/generator_test.go
+++ b/pkg/names/generator_test.go
@@ -1,0 +1,136 @@
+package names
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerate(t *testing.T) {
+	g := New()
+
+	for i := 0; i < 100; i++ {
+		name := g.Generate()
+
+		// Check format: adjective-animal
+		parts := strings.Split(name, "-")
+		if len(parts) != 2 {
+			t.Errorf("expected adjective-animal format, got %q", name)
+		}
+
+		// Check lowercase
+		if name != strings.ToLower(name) {
+			t.Errorf("expected lowercase, got %q", name)
+		}
+
+		// Check non-empty parts
+		if parts[0] == "" || parts[1] == "" {
+			t.Errorf("expected non-empty parts, got %q", name)
+		}
+	}
+}
+
+func TestGenerateUnique(t *testing.T) {
+	g := New()
+
+	existing := map[string]bool{
+		"swift-falcon": true,
+		"clever-otter": true,
+	}
+
+	name, err := g.GenerateUnique(existing, 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if existing[name] {
+		t.Errorf("generated name %q already exists", name)
+	}
+}
+
+func TestGenerateUniqueFromList(t *testing.T) {
+	g := New()
+
+	existingList := []string{"swift-falcon", "clever-otter", "BOLD-EAGLE"}
+
+	name, err := g.GenerateUniqueFromList(existingList, 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check not in list (case-insensitive)
+	nameLower := strings.ToLower(name)
+	for _, existing := range existingList {
+		if strings.ToLower(existing) == nameLower {
+			t.Errorf("generated name %q already exists in list", name)
+		}
+	}
+}
+
+func TestGenerateUniqueFallback(t *testing.T) {
+	g := New()
+
+	// Create a map with all possible combinations
+	existing := make(map[string]bool)
+	for _, adj := range adjectives {
+		for _, animal := range animals {
+			existing[adj+"-"+animal] = true
+		}
+	}
+
+	// Should fall back to numeric suffix
+	name, err := g.GenerateUnique(existing, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have numeric suffix
+	parts := strings.Split(name, "-")
+	if len(parts) != 3 {
+		t.Errorf("expected numeric suffix, got %q", name)
+	}
+}
+
+func TestDefaultGenerator(t *testing.T) {
+	// Test package-level functions
+	name := Generate()
+	if name == "" {
+		t.Error("expected non-empty name")
+	}
+
+	existing := map[string]bool{name: true}
+	unique, err := GenerateUnique(existing, 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if unique == name {
+		t.Error("expected different name")
+	}
+}
+
+func TestWordListSizes(t *testing.T) {
+	// Ensure we have enough variety
+	if len(adjectives) < 50 {
+		t.Errorf("expected at least 50 adjectives, got %d", len(adjectives))
+	}
+	if len(animals) < 50 {
+		t.Errorf("expected at least 50 animals, got %d", len(animals))
+	}
+
+	// Check for duplicates in adjectives
+	adjSet := make(map[string]bool)
+	for _, adj := range adjectives {
+		if adjSet[adj] {
+			t.Errorf("duplicate adjective: %s", adj)
+		}
+		adjSet[adj] = true
+	}
+
+	// Check for duplicates in animals
+	animalSet := make(map[string]bool)
+	for _, animal := range animals {
+		if animalSet[animal] {
+			t.Errorf("duplicate animal: %s", animal)
+		}
+		animalSet[animal] = true
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/names` package with adjective-animal name generator
- Make name optional in `bc agent create` - auto-generates if not provided
- ~2500 unique name combinations with collision detection

## Usage
```bash
bc agent create --role engineer    # Creates "swift-falcon" or similar
bc agent create my-agent           # Uses explicit name
```

## Changes
- `pkg/names/generator.go`: Name generator with 50 adjectives + 50 animals
- `pkg/names/generator_test.go`: Comprehensive tests
- `internal/cmd/agent.go`: Optional name argument with auto-generation

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/names/...` passes (6 tests)
- [x] `go test ./internal/cmd/...` passes
- [x] `bc agent create --help` shows optional name

Closes #51
Part of Epic #20: Agent CRUD Refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)