### PR TITLE
feat: add message type field for work routing

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -58,9 +58,24 @@ var channelRemoveCmd = &cobra.Command{
 var channelSendCmd = &cobra.Command{
 	Use:   "send <channel> <message>",
 	Short: "Send a message to all channel members",
-	Args:  cobra.MinimumNArgs(2),
-	RunE:  runChannelSend,
+	Long: `Send a message to all members of a channel.
+
+Message types:
+  message   - Regular chat message (default)
+  task      - Work assignment
+  review    - PR review request
+  approval  - PR approval notification
+  merge     - Merge request
+
+Examples:
+  bc channel send engineering "deploy complete"
+  bc channel send engineering --type=task "implement feature X"
+  bc channel send engineering --type=review "please review PR #42"`,
+	Args: cobra.MinimumNArgs(2),
+	RunE: runChannelSend,
 }
+
+var channelSendType string
 
 var channelListCmd = &cobra.Command{
 	Use:   "list",
@@ -94,10 +109,24 @@ var channelLeaveCmd = &cobra.Command{
 var channelHistoryCmd = &cobra.Command{
 	Use:   "history <channel>",
 	Short: "Show channel message history",
-	Long:  `Display the history of messages sent to a channel.`,
-	Args:  cobra.ExactArgs(1),
-	RunE:  runChannelHistory,
+	Long: `Display the history of messages sent to a channel.
+
+Use --type to filter by message type:
+  message   - Regular chat messages
+  task      - Work assignments
+  review    - PR review requests
+  approval  - PR approvals
+  merge     - Merge requests
+
+Examples:
+  bc channel history engineering
+  bc channel history engineering --type=task
+  bc channel history engineering --type=review`,
+	Args: cobra.ExactArgs(1),
+	RunE: runChannelHistory,
 }
+
+var channelHistoryType string
 
 func init() {
 	channelCmd.AddCommand(channelCreateCmd)
@@ -110,6 +139,14 @@ func init() {
 	channelCmd.AddCommand(channelLeaveCmd)
 	channelCmd.AddCommand(channelHistoryCmd)
 	rootCmd.AddCommand(channelCmd)
+
+	// Add --type flag for send command
+	channelSendCmd.Flags().StringVar(&channelSendType, "type", "message",
+		"Message type: message, task, review, approval, merge")
+
+	// Add --type flag for history command (filter)
+	channelHistoryCmd.Flags().StringVar(&channelHistoryType, "type", "",
+		"Filter by message type: message, task, review, approval, merge")
 }
 
 func loadChannelStore(rootDir string) (*channel.Store, error) {
@@ -264,6 +301,12 @@ func runChannelSend(cmd *cobra.Command, args []string) error {
 	channelName := args[0]
 	message := strings.Join(args[1:], " ")
 
+	// Validate message type
+	if !channel.IsValidMessageType(channelSendType) {
+		return fmt.Errorf("invalid message type %q (valid: message, task, review, approval, merge)", channelSendType)
+	}
+	msgType := channel.MessageType(channelSendType)
+
 	members, err := store.GetMembers(channelName)
 	if err != nil {
 		return err
@@ -280,12 +323,12 @@ func runChannelSend(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Warning: failed to load agent state: %v\n", err)
 	}
 
-	// Add to channel history
+	// Add to channel history with type
 	sender := os.Getenv("BC_AGENT_ID")
 	if sender == "" {
 		sender = "cli"
 	}
-	if err := store.AddHistory(channelName, sender, message); err != nil {
+	if err := store.AddHistoryWithType(channelName, sender, message, msgType); err != nil {
 		fmt.Printf("Warning: failed to record history: %v\n", err)
 	}
 	if err := store.Save(); err != nil {
@@ -418,7 +461,17 @@ func runChannelHistory(cmd *cobra.Command, args []string) error {
 	}
 
 	channelName := args[0]
-	history, err := store.GetHistory(channelName)
+
+	var history []channel.HistoryEntry
+	if channelHistoryType != "" {
+		// Filter by type
+		if !channel.IsValidMessageType(channelHistoryType) {
+			return fmt.Errorf("invalid message type %q (valid: message, task, review, approval, merge)", channelHistoryType)
+		}
+		history, err = store.GetHistoryByType(channelName, channel.MessageType(channelHistoryType))
+	} else {
+		history, err = store.GetHistory(channelName)
+	}
 	if err != nil {
 		return err
 	}
@@ -434,17 +487,29 @@ func runChannelHistory(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(history) == 0 {
-		fmt.Printf("No message history for channel %q\n", channelName)
+		if channelHistoryType != "" {
+			fmt.Printf("No %s messages for channel %q\n", channelHistoryType, channelName)
+		} else {
+			fmt.Printf("No message history for channel %q\n", channelName)
+		}
 		return nil
 	}
 
-	fmt.Printf("Message history for #%s:\n", channelName)
+	if channelHistoryType != "" {
+		fmt.Printf("Message history for #%s (type: %s):\n", channelName, channelHistoryType)
+	} else {
+		fmt.Printf("Message history for #%s:\n", channelName)
+	}
 	fmt.Println(strings.Repeat("-", 60))
 	for _, entry := range history {
+		typeTag := ""
+		if entry.Type != "" && entry.Type != channel.TypeMessage {
+			typeTag = fmt.Sprintf("[%s] ", entry.Type)
+		}
 		if entry.Sender != "" {
-			fmt.Printf("[%s] %s: %s\n", entry.Time.Format("15:04:05"), entry.Sender, entry.Message)
+			fmt.Printf("[%s] %s%s: %s\n", entry.Time.Format("15:04:05"), typeTag, entry.Sender, entry.Message)
 		} else {
-			fmt.Printf("[%s] %s\n", entry.Time.Format("15:04:05"), entry.Message)
+			fmt.Printf("[%s] %s%s\n", entry.Time.Format("15:04:05"), typeTag, entry.Message)
 		}
 	}
 

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -14,11 +14,43 @@ import (
 	"time"
 )
 
+// MessageType defines the type of message for routing and filtering.
+type MessageType string
+
+const (
+	// TypeMessage is a regular chat message (default).
+	TypeMessage MessageType = "message"
+	// TypeTask is a work assignment.
+	TypeTask MessageType = "task"
+	// TypeReview is a PR review request.
+	TypeReview MessageType = "review"
+	// TypeApproval is a PR approval notification.
+	TypeApproval MessageType = "approval"
+	// TypeMerge is a merge request.
+	TypeMerge MessageType = "merge"
+)
+
+// ValidMessageTypes returns all valid message types.
+func ValidMessageTypes() []MessageType {
+	return []MessageType{TypeMessage, TypeTask, TypeReview, TypeApproval, TypeMerge}
+}
+
+// IsValidMessageType checks if a string is a valid message type.
+func IsValidMessageType(t string) bool {
+	for _, valid := range ValidMessageTypes() {
+		if string(valid) == t {
+			return true
+		}
+	}
+	return false
+}
+
 // HistoryEntry represents a message in channel history.
 type HistoryEntry struct {
-	Time    time.Time `json:"time"`
-	Sender  string    `json:"sender,omitempty"`
-	Message string    `json:"message"`
+	Time    time.Time   `json:"time"`
+	Sender  string      `json:"sender,omitempty"`
+	Message string      `json:"message"`
+	Type    MessageType `json:"type,omitempty"`
 }
 
 // Channel represents a named communication channel with a list of members.
@@ -205,7 +237,13 @@ func (s *Store) GetMembers(channelName string) ([]string, error) {
 }
 
 // AddHistory adds a message to the channel's history.
+// Deprecated: Use AddHistoryWithType instead.
 func (s *Store) AddHistory(channelName, sender, message string) error {
+	return s.AddHistoryWithType(channelName, sender, message, TypeMessage)
+}
+
+// AddHistoryWithType adds a typed message to the channel's history.
+func (s *Store) AddHistoryWithType(channelName, sender, message string, msgType MessageType) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -214,10 +252,16 @@ func (s *Store) AddHistory(channelName, sender, message string) error {
 		return fmt.Errorf("channel %q not found", channelName)
 	}
 
+	// Default to TypeMessage if empty
+	if msgType == "" {
+		msgType = TypeMessage
+	}
+
 	entry := HistoryEntry{
 		Time:    time.Now(),
 		Sender:  sender,
 		Message: message,
+		Type:    msgType,
 	}
 	ch.History = append(ch.History, entry)
 
@@ -243,4 +287,30 @@ func (s *Store) GetHistory(channelName string) ([]HistoryEntry, error) {
 	history := make([]HistoryEntry, len(ch.History))
 	copy(history, ch.History)
 	return history, nil
+}
+
+// GetHistoryByType returns messages filtered by type.
+func (s *Store) GetHistoryByType(channelName string, msgType MessageType) ([]HistoryEntry, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ch, exists := s.channels[channelName]
+	if !exists {
+		return nil, fmt.Errorf("channel %q not found", channelName)
+	}
+
+	// Filter by type
+	filtered := make([]HistoryEntry, 0)
+	for _, entry := range ch.History {
+		// Match type (empty type matches TypeMessage for backward compatibility)
+		entryType := entry.Type
+		if entryType == "" {
+			entryType = TypeMessage
+		}
+		if entryType == msgType {
+			filtered = append(filtered, entry)
+		}
+	}
+
+	return filtered, nil
 }

--- a/pkg/channel/channel_test.go
+++ b/pkg/channel/channel_test.go
@@ -580,3 +580,158 @@ func TestConcurrentAddHistory(t *testing.T) {
 		t.Errorf("history after concurrent adds = %d, want 50", len(history))
 	}
 }
+
+// --- Message Types ---
+
+func TestValidMessageTypes(t *testing.T) {
+	types := ValidMessageTypes()
+	if len(types) != 5 {
+		t.Errorf("ValidMessageTypes() returned %d types, want 5", len(types))
+	}
+
+	expected := []MessageType{TypeMessage, TypeTask, TypeReview, TypeApproval, TypeMerge}
+	for _, e := range expected {
+		found := false
+		for _, mt := range types {
+			if mt == e {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("ValidMessageTypes() missing %q", e)
+		}
+	}
+}
+
+func TestIsValidMessageType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"message", true},
+		{"task", true},
+		{"review", true},
+		{"approval", true},
+		{"merge", true},
+		{"invalid", false},
+		{"", false},
+		{"MESSAGE", false}, // case sensitive
+	}
+
+	for _, tt := range tests {
+		got := IsValidMessageType(tt.input)
+		if got != tt.want {
+			t.Errorf("IsValidMessageType(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestAddHistoryWithType(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("ch"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.AddHistoryWithType("ch", "user", "task message", TypeTask); err != nil {
+		t.Fatalf("AddHistoryWithType: %v", err)
+	}
+
+	history, err := s.GetHistory("ch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("history len = %d, want 1", len(history))
+	}
+	if history[0].Type != TypeTask {
+		t.Errorf("Type = %q, want %q", history[0].Type, TypeTask)
+	}
+}
+
+func TestAddHistoryWithTypeDefaultsToMessage(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("ch"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.AddHistoryWithType("ch", "user", "msg", ""); err != nil {
+		t.Fatalf("AddHistoryWithType: %v", err)
+	}
+
+	history, err := s.GetHistory("ch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if history[0].Type != TypeMessage {
+		t.Errorf("Type = %q, want %q", history[0].Type, TypeMessage)
+	}
+}
+
+func TestGetHistoryByType(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("ch"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add messages of different types
+	_ = s.AddHistoryWithType("ch", "user", "msg1", TypeMessage)
+	_ = s.AddHistoryWithType("ch", "user", "task1", TypeTask)
+	_ = s.AddHistoryWithType("ch", "user", "task2", TypeTask)
+	_ = s.AddHistoryWithType("ch", "user", "review1", TypeReview)
+
+	// Filter by task
+	tasks, err := s.GetHistoryByType("ch", TypeTask)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("GetHistoryByType(task) = %d, want 2", len(tasks))
+	}
+
+	// Filter by review
+	reviews, err := s.GetHistoryByType("ch", TypeReview)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reviews) != 1 {
+		t.Errorf("GetHistoryByType(review) = %d, want 1", len(reviews))
+	}
+
+	// Filter by message
+	messages, err := s.GetHistoryByType("ch", TypeMessage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 {
+		t.Errorf("GetHistoryByType(message) = %d, want 1", len(messages))
+	}
+}
+
+func TestGetHistoryByTypeBackwardCompatibility(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("ch"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use old AddHistory (no type) - should default to message
+	_ = s.AddHistory("ch", "user", "old message")
+
+	// Filter by message should include it
+	messages, err := s.GetHistoryByType("ch", TypeMessage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(messages) != 1 {
+		t.Errorf("GetHistoryByType(message) = %d, want 1 (backward compat)", len(messages))
+	}
+}
+
+func TestGetHistoryByTypeChannelNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.GetHistoryByType("nonexistent", TypeTask)
+	if err == nil {
+		t.Fatal("GetHistoryByType nonexistent: expected error, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Add message type enum to distinguish work items from regular messages
- Enable type-based routing and filtering of channel messages
- Add CLI flags for typed message sending and filtering

## Message Types
- `message` (default) - regular chat
- `task` - work assignment
- `review` - PR review request
- `approval` - PR approval notification
- `merge` - merge request

## Changes
- `pkg/channel/channel.go`: Add `MessageType` enum, `AddHistoryWithType`, `GetHistoryByType`
- `internal/cmd/channel.go`: Add `--type` flag to `send` and `history` commands
- `pkg/channel/channel_test.go`: Tests for message type functionality

## Part of Epic #26 (Channels Infrastructure)

## Usage
```bash
# Send typed message
bc channel send engineering --type=task "implement feature X"
bc channel send engineering --type=review "please review PR #42"

# Filter history by type
bc channel history engineering --type=task
```

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/channel/...` passes (all message type tests)
- [x] `go test ./...` passes (full test suite)
- [x] Pre-commit hooks (golangci-lint) pass

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)