### PR TITLE
chore: deprecate queue and beads packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,12 @@ linters:
         linters:
           - gochecknoglobals
 
+      # Allow importing deprecated queue/beads packages during migration
+      # TODO: Remove this exclusion once migration to channels is complete
+      - linters:
+          - staticcheck
+        text: "SA1019.*pkg/(queue|beads)"
+
 formatters:
   enable:
     - gofmt

--- a/pkg/beads/beads.go
+++ b/pkg/beads/beads.go
@@ -1,5 +1,9 @@
 // Package beads provides integration with the beads (bd) issue tracker.
 //
+// Deprecated: This package is deprecated and will be removed in a future version.
+// Use GitHub Issues for task tracking and the channels package for work routing.
+// See pkg/channel for the new implementation.
+//
 // Beads is a distributed, git-backed graph issue tracker for AI agents.
 // Issues are stored as JSONL in .beads/ directories. This package wraps
 // the bd CLI to query and manage issues.

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,5 +1,9 @@
 // Package queue manages the work queue for bc.
 //
+// Deprecated: This package is deprecated and will be removed in a future version.
+// Use the channels package for message-based work routing instead.
+// See pkg/channel for the new implementation.
+//
 // Work items are persisted to .bc/queue.json. Items flow from beads issues
 // to agents: pending → assigned → working → done/failed.
 package queue


### PR DESCRIPTION
## Summary
- Mark `pkg/queue` and `pkg/beads` as deprecated
- Update golangci-lint config to allow imports during migration
- Packages remain functional for backward compatibility

## Deprecation Path
- `pkg/queue` → Use `pkg/channel` for message-based work routing
- `pkg/beads` → Use GitHub Issues for task tracking

## Changes
- `pkg/queue/queue.go`: Added deprecation notice in package doc
- `pkg/beads/beads.go`: Added deprecation notice in package doc
- `.golangci.yml`: Added exclusion for SA1019 during migration

## Part of Epic #26 (Channels Infrastructure)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] Pre-commit hooks pass

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)