### PR TITLE
chore: add deprecation notices to queue and beads packages

### DIFF
--- a/pkg/beads/beads.go
+++ b/pkg/beads/beads.go
@@ -1,5 +1,9 @@
 // Package beads provides integration with the beads (bd) issue tracker.
 //
+// NOTE: This package is being phased out. Use GitHub Issues for task tracking
+// and pkg/channel for work routing. The beads system is no longer used in bc v2.
+// This package will be removed in a future release.
+//
 // Beads is a distributed, git-backed graph issue tracker for AI agents.
 // Issues are stored as JSONL in .beads/ directories. This package wraps
 // the bd CLI to query and manage issues.

--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -1,5 +1,9 @@
 // Package queue manages the work queue for bc.
 //
+// NOTE: This package is being phased out in favor of pkg/channel which provides
+// SQLite-backed message persistence with typed messages for work routing.
+// Use pkg/channel for new code. This package will be removed in a future release.
+//
 // Work items are persisted to .bc/queue.json. Items flow from beads issues
 // to agents: pending → assigned → working → done/failed.
 package queue


### PR DESCRIPTION
## Summary
- Mark pkg/queue and pkg/beads as being phased out
- pkg/queue: superseded by pkg/channel for SQLite-backed messaging
- pkg/beads: superseded by GitHub Issues for task tracking
- Added deprecation notes to package docs

## Part of Epic #26 (Channels Infrastructure)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (full test suite)
- [x] Pre-commit hooks (golangci-lint) pass

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)