### PR TITLE
feat: add --team and --parent flags to agent create

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -113,18 +113,22 @@ Examples:
 
 // Flags
 var (
-	agentCreateTool string
-	agentCreateRole string
-	agentListRole   string
-	agentListJSON   bool
-	agentPeekLines  int
-	agentStopForce  bool
+	agentCreateTool   string
+	agentCreateRole   string
+	agentCreateParent string
+	agentCreateTeam   string
+	agentListRole     string
+	agentListJSON     bool
+	agentPeekLines    int
+	agentStopForce    bool
 )
 
 func init() {
 	// Create flags
 	agentCreateCmd.Flags().StringVar(&agentCreateTool, "tool", "", "Agent tool (claude, cursor, codex)")
 	agentCreateCmd.Flags().StringVar(&agentCreateRole, "role", "worker", "Agent role (worker, engineer, manager, product-manager, tech-lead, qa)")
+	agentCreateCmd.Flags().StringVar(&agentCreateParent, "parent", "", "Parent agent ID (must have permission to create this role)")
+	agentCreateCmd.Flags().StringVar(&agentCreateTeam, "team", "", "Team name (alphanumeric)")
 
 	// List flags
 	agentListCmd.Flags().StringVar(&agentListRole, "role", "", "Filter by role")
@@ -191,22 +195,43 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 		return roleErr
 	}
 
-	// Spawn the agent
+	// Validate team name if specified
+	if agentCreateTeam != "" {
+		if !isValidTeamName(agentCreateTeam) {
+			return fmt.Errorf("team name must be alphanumeric with optional hyphens/underscores")
+		}
+	}
+
+	// Spawn the agent (with parent if specified)
 	fmt.Printf("Creating %s (%s)... ", agentName, role)
-	spawned, spawnErr := mgr.SpawnAgentWithTool(agentName, role, ws.RootDir, toolName)
+	spawned, spawnErr := mgr.SpawnAgentWithOptions(agentName, role, ws.RootDir, agentCreateParent, toolName)
 	if spawnErr != nil {
 		fmt.Println("✗")
 		return fmt.Errorf("failed to create %s: %w", agentName, spawnErr)
 	}
 	fmt.Printf("✓ (session: %s)\n", mgr.Tmux().SessionName(spawned.Session))
 
+	// Set team if specified
+	if agentCreateTeam != "" {
+		if teamErr := mgr.SetAgentTeam(agentName, agentCreateTeam); teamErr != nil {
+			log.Warn("failed to set team", "error", teamErr)
+		}
+	}
+
 	// Log event
+	eventData := map[string]any{"role": string(role), "tool": toolName}
+	if agentCreateParent != "" {
+		eventData["parent"] = agentCreateParent
+	}
+	if agentCreateTeam != "" {
+		eventData["team"] = agentCreateTeam
+	}
 	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
 	_ = eventLog.Append(events.Event{
 		Type:    events.AgentSpawned,
 		Agent:   agentName,
 		Message: fmt.Sprintf("created with role %s", role),
-		Data:    map[string]any{"role": string(role), "tool": toolName},
+		Data:    eventData,
 	})
 
 	fmt.Println()
@@ -434,4 +459,21 @@ func runAgentSend(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Sent to %s: %s\n", agentName, message)
 	return nil
+}
+
+// isValidTeamName validates that a team name is alphanumeric with optional hyphens/underscores.
+func isValidTeamName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, c := range name {
+		isLower := c >= 'a' && c <= 'z'
+		isUpper := c >= 'A' && c <= 'Z'
+		isDigit := c >= '0' && c <= '9'
+		isAllowed := isLower || isUpper || isDigit || c == '-' || c == '_'
+		if !isAllowed {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/cmd/agent_test.go
+++ b/internal/cmd/agent_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/agent"
+)
+
+// --- isValidTeamName Tests ---
+
+func TestIsValidTeamName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"alphanumeric", "platform", true},
+		{"with numbers", "team123", true},
+		{"with hyphen", "core-team", true},
+		{"with underscore", "core_team", true},
+		{"mixed", "Platform-Team_01", true},
+		{"uppercase", "PLATFORM", true},
+		{"empty", "", false},
+		{"with space", "core team", false},
+		{"with special chars", "team@123", false},
+		{"with dot", "team.name", false},
+		{"with slash", "team/name", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isValidTeamName(tt.input); got != tt.want {
+				t.Errorf("isValidTeamName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- Agent Create Flags Tests ---
+
+func TestAgentCreateHasParentFlag(t *testing.T) {
+	flags := agentCreateCmd.Flags()
+	if flags.Lookup("parent") == nil {
+		t.Error("expected --parent flag on agent create")
+	}
+}
+
+func TestAgentCreateHasTeamFlag(t *testing.T) {
+	flags := agentCreateCmd.Flags()
+	if flags.Lookup("team") == nil {
+		t.Error("expected --team flag on agent create")
+	}
+}
+
+// --- Agent Role Hierarchy Tests ---
+
+func TestCanCreateRole_TechLeadCanCreateEngineer(t *testing.T) {
+	if !agent.CanCreateRole(agent.RoleTechLead, agent.RoleEngineer) {
+		t.Error("tech-lead should be able to create engineer")
+	}
+}
+
+func TestCanCreateRole_EngineerCannotCreateEngineer(t *testing.T) {
+	if agent.CanCreateRole(agent.RoleEngineer, agent.RoleEngineer) {
+		t.Error("engineer should not be able to create engineer")
+	}
+}
+
+func TestCanCreateRole_ManagerCanCreateEngineer(t *testing.T) {
+	if !agent.CanCreateRole(agent.RoleManager, agent.RoleEngineer) {
+		t.Error("manager should be able to create engineer")
+	}
+}
+
+func TestCanCreateRole_ManagerCanCreateQA(t *testing.T) {
+	if !agent.CanCreateRole(agent.RoleManager, agent.RoleQA) {
+		t.Error("manager should be able to create qa")
+	}
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -183,6 +183,7 @@ type Agent struct {
 	ParentID    string       `json:"parent_id,omitempty"`
 	HookedWork  string       `json:"hooked_work,omitempty"`
 	WorktreeDir string       `json:"worktree_dir,omitempty"`
+	Team        string       `json:"team,omitempty"`
 	Role        Role         `json:"role"`
 	State       State        `json:"state"`
 	Children    []string     `json:"children,omitempty"`
@@ -978,6 +979,23 @@ func (m *Manager) UpdateAgentState(name string, state State, task string) error 
 
 	agent.State = state
 	agent.Task = task
+	agent.UpdatedAt = time.Now()
+
+	_ = m.saveState() //nolint:errcheck // best-effort state persistence
+	return nil
+}
+
+// SetAgentTeam assigns an agent to a team.
+func (m *Manager) SetAgentTeam(name, team string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	agent, exists := m.agents[name]
+	if !exists {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	agent.Team = team
 	agent.UpdatedAt = time.Now()
 
 	_ = m.saveState() //nolint:errcheck // best-effort state persistence


### PR DESCRIPTION
## Summary
- Add `--parent <agent-id>` flag to create agent as child of specified parent
- Add `--team <team-name>` flag to assign agent to a team
- Parent validation uses existing RoleHierarchy (e.g., manager can create engineer, engineer cannot create engineer)
- Team name validation: alphanumeric with hyphens/underscores

## Usage
```bash
bc agent create eng-01 --role engineer --parent manager
bc agent create qa-01 --role qa --team platform
bc agent create eng-02 --role engineer --parent tech-lead-01 --team backend
```

## Changes
- `internal/cmd/agent.go`: Add `--parent` and `--team` flags, validation logic
- `pkg/agent/agent.go`: Add `Team` field to Agent struct, `SetAgentTeam` method
- `internal/cmd/agent_test.go`: Tests for isValidTeamName, flag presence, role hierarchy

## Test plan
- [x] All tests pass: `go test ./...`
- [x] golangci-lint passes
- [x] Team validation tests cover valid/invalid names
- [x] Role hierarchy tests verify permissions

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)