### PR TITLE
feat: add history query API for channels

### DIFF
--- a/pkg/channel/query.go
+++ b/pkg/channel/query.go
@@ -1,0 +1,199 @@
+// Package channel - query.go provides query APIs for message history.
+package channel
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// QueryOptions configures message query parameters.
+type QueryOptions struct {
+	Before *time.Time // Messages before this time
+	After  *time.Time // Messages after this time
+	Sender string     // Filter by sender
+	Limit  int        // Max messages to return (default: 50, max: 100)
+	Offset int        // Skip first N messages (for pagination)
+}
+
+// DefaultQueryOptions returns sensible defaults.
+func DefaultQueryOptions() QueryOptions {
+	return QueryOptions{
+		Limit: 50,
+	}
+}
+
+// QueryResult contains paginated query results.
+type QueryResult struct {
+	Messages   []HistoryEntry `json:"messages"`
+	Total      int            `json:"total"`       // Total matching messages
+	HasMore    bool           `json:"has_more"`    // More messages available
+	NextOffset int            `json:"next_offset"` // Offset for next page
+}
+
+// Query returns messages matching the given options.
+func (s *Store) Query(channelName string, opts QueryOptions) (*QueryResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ch, exists := s.channels[channelName]
+	if !exists {
+		return nil, fmt.Errorf("channel %q not found", channelName)
+	}
+
+	// Apply defaults
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 100 {
+		opts.Limit = 100
+	}
+
+	// Filter messages
+	filtered := make([]HistoryEntry, 0)
+	for _, entry := range ch.History {
+		if !matchesQuery(entry, opts) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+
+	total := len(filtered)
+
+	// Apply offset
+	if opts.Offset > 0 {
+		if opts.Offset >= len(filtered) {
+			filtered = []HistoryEntry{}
+		} else {
+			filtered = filtered[opts.Offset:]
+		}
+	}
+
+	// Apply limit
+	hasMore := false
+	if len(filtered) > opts.Limit {
+		filtered = filtered[:opts.Limit]
+		hasMore = true
+	}
+
+	return &QueryResult{
+		Messages:   filtered,
+		Total:      total,
+		HasMore:    hasMore,
+		NextOffset: opts.Offset + len(filtered),
+	}, nil
+}
+
+// matchesQuery checks if a history entry matches query options.
+func matchesQuery(entry HistoryEntry, opts QueryOptions) bool {
+	// Time filters
+	if opts.Before != nil && !entry.Time.Before(*opts.Before) {
+		return false
+	}
+	if opts.After != nil && !entry.Time.After(*opts.After) {
+		return false
+	}
+
+	// Sender filter
+	if opts.Sender != "" && entry.Sender != opts.Sender {
+		return false
+	}
+
+	return true
+}
+
+// SearchOptions configures full-text search.
+type SearchOptions struct {
+	Since    *time.Time // Only messages after this time
+	Channels []string   // Limit to specific channels (empty = all)
+	Limit    int        // Max results (default: 50)
+}
+
+// SearchResult contains search results.
+type SearchResult struct {
+	Channel string       `json:"channel"`
+	Entry   HistoryEntry `json:"entry"`
+}
+
+// Search performs a simple text search across channels.
+// Note: This is a basic implementation. For production use with large
+// datasets, use the SQLite FTS5 backend when available.
+func (s *Store) Search(query string, opts SearchOptions) ([]SearchResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+
+	query = strings.ToLower(query)
+	results := make([]SearchResult, 0)
+
+	for name, ch := range s.channels {
+		// Check if channel is in filter list
+		if len(opts.Channels) > 0 {
+			found := false
+			for _, c := range opts.Channels {
+				if c == name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		for _, entry := range ch.History {
+			// Time filter
+			if opts.Since != nil && !entry.Time.After(*opts.Since) {
+				continue
+			}
+
+			// Simple text match
+			if strings.Contains(strings.ToLower(entry.Message), query) ||
+				strings.Contains(strings.ToLower(entry.Sender), query) {
+				results = append(results, SearchResult{
+					Channel: name,
+					Entry:   entry,
+				})
+
+				if len(results) >= opts.Limit {
+					return results, nil
+				}
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// GetMentions returns messages mentioning an agent.
+func (s *Store) GetMentions(agent string, limit int) ([]SearchResult, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if limit <= 0 {
+		limit = 50
+	}
+
+	mention := "@" + agent
+	results := make([]SearchResult, 0)
+
+	for name, ch := range s.channels {
+		for _, entry := range ch.History {
+			if strings.Contains(entry.Message, mention) {
+				results = append(results, SearchResult{
+					Channel: name,
+					Entry:   entry,
+				})
+
+				if len(results) >= limit {
+					return results, nil
+				}
+			}
+		}
+	}
+
+	return results, nil
+}

--- a/pkg/channel/query_test.go
+++ b/pkg/channel/query_test.go
@@ -1,0 +1,200 @@
+package channel
+
+import (
+	"testing"
+	"time"
+)
+
+func TestQuery(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add some test messages
+	for i := 0; i < 10; i++ {
+		if err := s.AddHistory("test", "user", "message"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	result, err := s.Query("test", QueryOptions{Limit: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 5 {
+		t.Errorf("expected 5 messages, got %d", len(result.Messages))
+	}
+	if result.Total != 10 {
+		t.Errorf("expected total 10, got %d", result.Total)
+	}
+	if !result.HasMore {
+		t.Error("expected HasMore=true")
+	}
+}
+
+func TestQueryPagination(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add 15 messages
+	for i := 0; i < 15; i++ {
+		if err := s.AddHistory("test", "user", "msg"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// First page
+	result1, err := s.Query("test", QueryOptions{Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result1.Messages) != 10 {
+		t.Errorf("page 1: expected 10, got %d", len(result1.Messages))
+	}
+	if !result1.HasMore {
+		t.Error("page 1: expected HasMore=true")
+	}
+
+	// Second page
+	result2, err := s.Query("test", QueryOptions{Limit: 10, Offset: result1.NextOffset})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result2.Messages) != 5 {
+		t.Errorf("page 2: expected 5, got %d", len(result2.Messages))
+	}
+	if result2.HasMore {
+		t.Error("page 2: expected HasMore=false")
+	}
+}
+
+func TestQueryBySender(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = s.AddHistory("test", "alice", "hello")
+	_ = s.AddHistory("test", "bob", "hi")
+	_ = s.AddHistory("test", "alice", "goodbye")
+
+	result, err := s.Query("test", QueryOptions{Sender: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 2 {
+		t.Errorf("expected 2 messages from alice, got %d", len(result.Messages))
+	}
+}
+
+func TestQueryByTime(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = s.AddHistory("test", "user", "old")
+	time.Sleep(10 * time.Millisecond)
+	midpoint := time.Now()
+	time.Sleep(10 * time.Millisecond)
+	_ = s.AddHistory("test", "user", "new")
+
+	// Messages after midpoint
+	result, err := s.Query("test", QueryOptions{After: &midpoint})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Errorf("expected 1 message after midpoint, got %d", len(result.Messages))
+	}
+}
+
+func TestQueryChannelNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.Query("nonexistent", QueryOptions{})
+	if err == nil {
+		t.Error("expected error for nonexistent channel")
+	}
+}
+
+func TestSearch(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("general"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Create("dev"); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = s.AddHistory("general", "alice", "hello world")
+	_ = s.AddHistory("general", "bob", "goodbye world")
+	_ = s.AddHistory("dev", "charlie", "hello dev")
+
+	results, err := s.Search("hello", SearchOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 results for 'hello', got %d", len(results))
+	}
+}
+
+func TestSearchByChannel(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("general"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Create("dev"); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = s.AddHistory("general", "alice", "test message")
+	_ = s.AddHistory("dev", "bob", "test message")
+
+	results, err := s.Search("test", SearchOptions{Channels: []string{"general"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("expected 1 result in general, got %d", len(results))
+	}
+	if results[0].Channel != "general" {
+		t.Errorf("expected channel 'general', got %q", results[0].Channel)
+	}
+}
+
+func TestGetMentions(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	_ = s.AddHistory("test", "manager", "Hey @alice please review")
+	_ = s.AddHistory("test", "bob", "Hello everyone")
+	_ = s.AddHistory("test", "manager", "@alice and @bob check this")
+
+	results, err := s.GetMentions("alice", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 2 {
+		t.Errorf("expected 2 mentions of alice, got %d", len(results))
+	}
+}
+
+func TestDefaultQueryOptions(t *testing.T) {
+	opts := DefaultQueryOptions()
+	if opts.Limit != 50 {
+		t.Errorf("expected default limit 50, got %d", opts.Limit)
+	}
+}


### PR DESCRIPTION
## Summary
- Add paginated history queries with offset/limit
- Filter messages by sender and time range
- Full-text search across channels
- @mention queries for agents

## API
```go
// Paginated query
result, _ := store.Query("channel", QueryOptions{
    Limit:  50,
    Offset: 0,
    Sender: "alice",
    After:  &startTime,
})

// Search
results, _ := store.Search("keyword", SearchOptions{
    Channels: []string{"general"},
    Limit:    10,
})

// Mention queries
mentions, _ := store.GetMentions("alice", 10)
```

## Part of Epic #26 (Channels Infrastructure)

## Note
FTS5 full-text search and unread tracking require SQLite backend (#73).
This implementation works with current JSON storage.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/channel/...` passes (all query tests)
- [x] `go test ./...` passes (full test suite)
- [x] Pre-commit hooks pass

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)