### PR TITLE
feat: add team and parent flags for agent create

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -117,18 +117,22 @@ Examples:
 
 // Flags
 var (
-	agentCreateTool string
-	agentCreateRole string
-	agentListRole   string
-	agentListJSON   bool
-	agentPeekLines  int
-	agentStopForce  bool
+	agentCreateTool   string
+	agentCreateRole   string
+	agentCreateParent string
+	agentCreateTeam   string
+	agentListRole     string
+	agentListJSON     bool
+	agentPeekLines    int
+	agentStopForce    bool
 )
 
 func init() {
 	// Create flags
 	agentCreateCmd.Flags().StringVar(&agentCreateTool, "tool", "", "Agent tool (claude, cursor, codex)")
 	agentCreateCmd.Flags().StringVar(&agentCreateRole, "role", "worker", "Agent role (worker, engineer, manager, product-manager, tech-lead, qa)")
+	agentCreateCmd.Flags().StringVar(&agentCreateParent, "parent", "", "Parent agent ID (creates hierarchical relationship)")
+	agentCreateCmd.Flags().StringVar(&agentCreateTeam, "team", "", "Team name for organizational grouping")
 
 	// List flags
 	agentListCmd.Flags().StringVar(&agentListRole, "role", "", "Filter by role")
@@ -209,22 +213,54 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 		return roleErr
 	}
 
-	// Spawn the agent
+	// Validate parent if specified
+	if agentCreateParent != "" {
+		parent := mgr.GetAgent(agentCreateParent)
+		if parent == nil {
+			return fmt.Errorf("parent agent %q not found", agentCreateParent)
+		}
+		if !agent.CanCreateRole(parent.Role, role) {
+			return fmt.Errorf("agent %q (role %s) cannot create child with role %s", agentCreateParent, parent.Role, role)
+		}
+	}
+
+	// Validate team name if specified (alphanumeric with hyphens/underscores)
+	if agentCreateTeam != "" {
+		if !isValidTeamName(agentCreateTeam) {
+			return fmt.Errorf("invalid team name %q: must be alphanumeric (hyphens and underscores allowed)", agentCreateTeam)
+		}
+	}
+
+	// Spawn the agent with parent if specified
 	fmt.Printf("Creating %s (%s)... ", agentName, role)
-	spawned, spawnErr := mgr.SpawnAgentWithTool(agentName, role, ws.RootDir, toolName)
+	spawned, spawnErr := mgr.SpawnAgentWithOptions(agentName, role, ws.RootDir, agentCreateParent, toolName)
 	if spawnErr != nil {
 		fmt.Println("✗")
 		return fmt.Errorf("failed to create %s: %w", agentName, spawnErr)
 	}
 	fmt.Printf("✓ (session: %s)\n", mgr.Tmux().SessionName(spawned.Session))
 
+	// Set team if specified
+	if agentCreateTeam != "" {
+		if teamErr := mgr.SetAgentTeam(agentName, agentCreateTeam); teamErr != nil {
+			log.Warn("failed to set team", "error", teamErr)
+		}
+	}
+
 	// Log event
+	eventData := map[string]any{"role": string(role), "tool": toolName}
+	if agentCreateParent != "" {
+		eventData["parent"] = agentCreateParent
+	}
+	if agentCreateTeam != "" {
+		eventData["team"] = agentCreateTeam
+	}
 	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
 	_ = eventLog.Append(events.Event{
 		Type:    events.AgentSpawned,
 		Agent:   agentName,
 		Message: fmt.Sprintf("created with role %s", role),
-		Data:    map[string]any{"role": string(role), "tool": toolName},
+		Data:    eventData,
 	})
 
 	fmt.Println()
@@ -452,4 +488,31 @@ func runAgentSend(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Sent to %s: %s\n", agentName, message)
 	return nil
+}
+
+// isValidTeamName checks if a team name is valid (alphanumeric with hyphens/underscores).
+func isValidTeamName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i, r := range name {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= 'A' && r <= 'Z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		if r == '-' || r == '_' {
+			// Hyphens and underscores not allowed at start
+			if i == 0 {
+				return false
+			}
+			continue
+		}
+		return false
+	}
+	return true
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -263,6 +263,36 @@ func TestParseRole(t *testing.T) {
 	}
 }
 
+// --- isValidTeamName tests ---
+
+func TestIsValidTeamName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"valid simple", "platform", true},
+		{"valid with hyphen", "back-end", true},
+		{"valid with underscore", "front_end", true},
+		{"valid alphanumeric", "team1", true},
+		{"valid mixed", "team-1_alpha", true},
+		{"empty", "", false},
+		{"starts with hyphen", "-team", false},
+		{"starts with underscore", "_team", false},
+		{"contains space", "team one", false},
+		{"contains special char", "team@one", false},
+		{"contains dot", "team.one", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidTeamName(tt.input)
+			if got != tt.want {
+				t.Errorf("isValidTeamName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // --- loadRolePrompt tests ---
 
 func TestLoadRolePrompt(t *testing.T) {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -181,6 +181,7 @@ type Agent struct {
 	Session     string       `json:"session"`
 	Tool        string       `json:"tool,omitempty"`
 	ParentID    string       `json:"parent_id,omitempty"`
+	Team        string       `json:"team,omitempty"`
 	HookedWork  string       `json:"hooked_work,omitempty"`
 	WorktreeDir string       `json:"worktree_dir,omitempty"`
 	Role        Role         `json:"role"`
@@ -978,6 +979,23 @@ func (m *Manager) UpdateAgentState(name string, state State, task string) error 
 
 	agent.State = state
 	agent.Task = task
+	agent.UpdatedAt = time.Now()
+
+	_ = m.saveState() //nolint:errcheck // best-effort state persistence
+	return nil
+}
+
+// SetAgentTeam sets the team for an agent.
+func (m *Manager) SetAgentTeam(name, team string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	agent, exists := m.agents[name]
+	if !exists {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	agent.Team = team
 	agent.UpdatedAt = time.Now()
 
 	_ = m.saveState() //nolint:errcheck // best-effort state persistence

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1969,3 +1969,35 @@ func TestEnforceRootSingleton_RootErrorAllows(t *testing.T) {
 		t.Error("old root state should be deleted after allowing respawn")
 	}
 }
+
+func TestSetAgentTeam(t *testing.T) {
+	m := NewManager(t.TempDir())
+	m.agentCmd = "echo test"
+
+	// Create a mock agent directly
+	m.mu.Lock()
+	m.agents["eng-01"] = &Agent{
+		ID:    "eng-01",
+		Name:  "eng-01",
+		Role:  RoleEngineer,
+		State: StateIdle,
+	}
+	m.mu.Unlock()
+
+	// Test setting team
+	err := m.SetAgentTeam("eng-01", "platform")
+	if err != nil {
+		t.Fatalf("SetAgentTeam failed: %v", err)
+	}
+
+	agent := m.GetAgent("eng-01")
+	if agent.Team != "platform" {
+		t.Errorf("expected team 'platform', got %q", agent.Team)
+	}
+
+	// Test setting team on non-existent agent
+	err = m.SetAgentTeam("nonexistent", "team")
+	if err == nil {
+		t.Error("expected error for non-existent agent")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `--parent` flag to create hierarchical agent relationships
- Add `--team` flag for organizational grouping
- Validates parent exists and has permission to create child role
- Validates team name format (alphanumeric with hyphens/underscores)

## Usage
```bash
bc agent create eng-01 --role engineer --parent manager
bc agent create qa-01 --role qa --team platform
```

## Changes
- `internal/cmd/agent.go`: Add flags and validation logic
- `pkg/agent/agent.go`: Add Team field to Agent struct, SetAgentTeam method
- Tests for isValidTeamName and SetAgentTeam

## Part of Epic #20 (Agent CRUD Refactor)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/agent/... -run TestSetAgentTeam` passes
- [x] `go test ./internal/cmd/... -run TestIsValidTeamName` passes
- [x] Pre-commit hooks (golangci-lint) pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)