### PR TITLE
feat: add TaskType enum to work queue

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -38,12 +38,23 @@ const (
 	MergeConflict MergeStatus = "conflict"
 )
 
+// TaskType distinguishes between different kinds of work items.
+type TaskType string
+
+const (
+	TaskTypeCode   TaskType = "code"   // Implementation work (default)
+	TaskTypeReview TaskType = "review" // PR review work
+	TaskTypeMerge  TaskType = "merge"  // Merge approved PRs
+	TaskTypeQA     TaskType = "qa"     // Testing/validation work
+)
+
 // WorkItem is a unit of work in the queue.
 type WorkItem struct {
 	ID          string     `json:"id"`
 	BeadsID     string     `json:"beads_id,omitempty"`
 	Title       string     `json:"title"`
 	Description string     `json:"description,omitempty"`
+	Type        TaskType   `json:"type,omitempty"` // Defaults to TaskTypeCode if empty
 	Status      ItemStatus `json:"status"`
 	AssignedTo  string     `json:"assigned_to,omitempty"`
 	CreatedAt   time.Time  `json:"created_at"`
@@ -54,6 +65,14 @@ type WorkItem struct {
 	Merge       MergeStatus `json:"merge,omitempty"`
 	MergedAt    time.Time   `json:"merged_at,omitempty"`
 	MergeCommit string      `json:"merge_commit,omitempty"`
+}
+
+// EffectiveType returns the task type, defaulting to TaskTypeCode if not set.
+func (w *WorkItem) EffectiveType() TaskType {
+	if w.Type == "" {
+		return TaskTypeCode
+	}
+	return w.Type
 }
 
 // Stats summarizes queue state.
@@ -109,7 +128,13 @@ func (q *Queue) Save() error {
 }
 
 // Add creates a new work item with an auto-generated ID.
+// The item defaults to TaskTypeCode.
 func (q *Queue) Add(title, description, beadsID string) *WorkItem {
+	return q.AddWithType(title, description, beadsID, TaskTypeCode)
+}
+
+// AddWithType creates a new work item with the specified type.
+func (q *Queue) AddWithType(title, description, beadsID string, taskType TaskType) *WorkItem {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -120,6 +145,7 @@ func (q *Queue) Add(title, description, beadsID string) *WorkItem {
 		BeadsID:     beadsID,
 		Title:       title,
 		Description: description,
+		Type:        taskType,
 		Status:      StatusPending,
 		CreatedAt:   now,
 		UpdatedAt:   now,
@@ -217,6 +243,21 @@ func (q *Queue) ListByStatus(s ItemStatus) []WorkItem {
 	var out []WorkItem
 	for _, item := range q.items {
 		if item.Status == s {
+			out = append(out, item)
+		}
+	}
+	return out
+}
+
+// ListByType returns items with the given task type.
+// Items with empty Type are treated as TaskTypeCode.
+func (q *Queue) ListByType(t TaskType) []WorkItem {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	var out []WorkItem
+	for _, item := range q.items {
+		if item.EffectiveType() == t {
 			out = append(out, item)
 		}
 	}

--- a/pkg/queue/queue_test.go
+++ b/pkg/queue/queue_test.go
@@ -456,3 +456,147 @@ func TestDedupByTitlePreventsDoubleAdd(t *testing.T) {
 		t.Error("HasBeadsID should return true after linking")
 	}
 }
+
+// --- TaskType Tests ---
+
+func TestTaskTypeConstants(t *testing.T) {
+	// Verify all task type constants are defined
+	types := []TaskType{TaskTypeCode, TaskTypeReview, TaskTypeMerge, TaskTypeQA}
+	expected := []string{"code", "review", "merge", "qa"}
+
+	for i, tt := range types {
+		if string(tt) != expected[i] {
+			t.Errorf("TaskType %d = %q, want %q", i, tt, expected[i])
+		}
+	}
+}
+
+func TestAddDefaultsToCodeType(t *testing.T) {
+	q := New(filepath.Join(t.TempDir(), "q.json"))
+	item := q.Add("Test task", "desc", "")
+
+	if item.Type != TaskTypeCode {
+		t.Errorf("Type = %q, want %q", item.Type, TaskTypeCode)
+	}
+	if item.EffectiveType() != TaskTypeCode {
+		t.Errorf("EffectiveType = %q, want %q", item.EffectiveType(), TaskTypeCode)
+	}
+}
+
+func TestAddWithType(t *testing.T) {
+	q := New(filepath.Join(t.TempDir(), "q.json"))
+
+	tests := []struct {
+		taskType TaskType
+	}{
+		{TaskTypeCode},
+		{TaskTypeReview},
+		{TaskTypeMerge},
+		{TaskTypeQA},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.taskType), func(t *testing.T) {
+			item := q.AddWithType("Task", "desc", "", tt.taskType)
+			if item.Type != tt.taskType {
+				t.Errorf("Type = %q, want %q", item.Type, tt.taskType)
+			}
+		})
+	}
+}
+
+func TestEffectiveTypeDefaultsToCode(t *testing.T) {
+	// Test that empty Type defaults to TaskTypeCode
+	item := &WorkItem{Type: ""}
+	if item.EffectiveType() != TaskTypeCode {
+		t.Errorf("EffectiveType for empty = %q, want %q", item.EffectiveType(), TaskTypeCode)
+	}
+
+	// Test that explicit type is returned
+	item.Type = TaskTypeReview
+	if item.EffectiveType() != TaskTypeReview {
+		t.Errorf("EffectiveType = %q, want %q", item.EffectiveType(), TaskTypeReview)
+	}
+}
+
+func TestListByType(t *testing.T) {
+	q := New(filepath.Join(t.TempDir(), "q.json"))
+
+	// Add items with different types
+	q.AddWithType("Code task 1", "", "", TaskTypeCode)
+	q.AddWithType("Review task 1", "", "", TaskTypeReview)
+	q.AddWithType("Code task 2", "", "", TaskTypeCode)
+	q.AddWithType("QA task 1", "", "", TaskTypeQA)
+	q.AddWithType("Merge task 1", "", "", TaskTypeMerge)
+
+	tests := []struct {
+		taskType TaskType
+		want     int
+	}{
+		{TaskTypeCode, 2},
+		{TaskTypeReview, 1},
+		{TaskTypeMerge, 1},
+		{TaskTypeQA, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.taskType), func(t *testing.T) {
+			items := q.ListByType(tt.taskType)
+			if len(items) != tt.want {
+				t.Errorf("ListByType(%q) = %d items, want %d", tt.taskType, len(items), tt.want)
+			}
+		})
+	}
+}
+
+func TestListByTypeIncludesEmptyAsCode(t *testing.T) {
+	q := New(filepath.Join(t.TempDir(), "q.json"))
+
+	// Add item with empty type (simulating legacy items)
+	q.mu.Lock()
+	q.items = append(q.items, WorkItem{
+		ID:    "legacy-001",
+		Title: "Legacy task",
+		Type:  "", // Empty type
+	})
+	q.mu.Unlock()
+
+	// Add explicit code task
+	q.AddWithType("Code task", "", "", TaskTypeCode)
+
+	// ListByType(TaskTypeCode) should include both
+	items := q.ListByType(TaskTypeCode)
+	if len(items) != 2 {
+		t.Errorf("ListByType(code) = %d items, want 2 (including legacy)", len(items))
+	}
+}
+
+func TestTaskTypePersistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "q.json")
+	q := New(path)
+
+	q.AddWithType("Review PR #42", "", "", TaskTypeReview)
+	q.AddWithType("Merge approved", "", "", TaskTypeMerge)
+
+	if err := q.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Load into new queue
+	q2 := New(path)
+	if err := q2.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	items := q2.ListAll()
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(items))
+	}
+
+	if items[0].Type != TaskTypeReview {
+		t.Errorf("items[0].Type = %q, want review", items[0].Type)
+	}
+	if items[1].Type != TaskTypeMerge {
+		t.Errorf("items[1].Type = %q, want merge", items[1].Type)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `TaskType` enum to distinguish different work types in the queue
- 4 task types: `code`, `review`, `merge`, `qa`
- Backward compatible: existing items with empty Type treated as `code`

## Changes
- `pkg/queue/queue.go`:
  - Add `TaskType` enum with 4 constants
  - Add `Type` field to `WorkItem` struct
  - Add `EffectiveType()` method (defaults empty to `TaskTypeCode`)
  - Add `AddWithType()` for explicit type creation
  - Add `ListByType()` for filtering
- `pkg/queue/queue_test.go`: Comprehensive tests for all new functionality

## Usage
```go
// Create tasks with specific types
q.Add("Fix bug", "desc", "")                    // Defaults to code
q.AddWithType("Review PR", "", "", TaskTypeReview)
q.AddWithType("Merge #42", "", "", TaskTypeMerge)
q.AddWithType("Test feature", "", "", TaskTypeQA)

// Filter by type
reviews := q.ListByType(TaskTypeReview)
```

## Test plan
- [x] All tests pass: `go test ./pkg/queue/...`
- [x] Full test suite passes: `go test ./...`
- [x] golangci-lint passes
- [x] Backward compatible with existing queue items

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)