### PR TITLE
feat: per-agent DM channels with SQLite

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -1724,20 +1724,26 @@ func TestCreateDefaultChannelsIntegration(t *testing.T) {
 		t.Errorf("expected creation message, got: %s", output)
 	}
 
-	// Verify channels were created
-	store := channel.NewStore(tmpDir)
-	if err := store.Load(); err != nil {
-		t.Fatalf("failed to load channels: %v", err)
+	// Verify channels were created in SQLite store
+	store := channel.NewSQLiteStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open channel store: %v", err)
 	}
+	defer func() { _ = store.Close() }()
 
 	// Check required channels exist
 	for _, name := range []string{"standup", "leadership", "engineering", "qa", "all"} {
-		ch, exists := store.Get(name)
-		if !exists {
+		ch, getErr := store.GetChannel(name)
+		if getErr != nil {
+			t.Errorf("error getting channel %q: %v", name, getErr)
+			continue
+		}
+		if ch == nil {
 			t.Errorf("expected channel %q to exist", name)
 			continue
 		}
-		if len(ch.Members) == 0 {
+		members, _ := store.GetMembers(name)
+		if len(members) == 0 {
 			t.Errorf("channel %q should have members", name)
 		}
 	}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/rpuneet/bc/pkg/agent"
+	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/queue"
 )
@@ -349,21 +350,26 @@ func TestCreateDefaultChannels(t *testing.T) {
 	_ = w.Close()
 	os.Stdout = oldStdout
 
-	// Verify channels file was created at .bc/channels.json
-	channelsFile := filepath.Join(dir, ".bc", "channels.json")
-	if _, statErr := os.Stat(channelsFile); os.IsNotExist(statErr) {
-		t.Fatal("channels.json not created")
+	// Verify channels database was created at .bc/channels.db
+	channelsDB := filepath.Join(dir, ".bc", "channels.db")
+	if _, statErr := os.Stat(channelsDB); os.IsNotExist(statErr) {
+		t.Fatal("channels.db not created")
 	}
 
-	data, err := os.ReadFile(channelsFile) //nolint:gosec // G304: test file reads from test-created path
-	if err != nil {
-		t.Fatal(err)
+	// Verify channels exist in SQLite store
+	store := channel.NewSQLiteStore(dir)
+	if openErr := store.Open(); openErr != nil {
+		t.Fatalf("failed to open channel store: %v", openErr)
 	}
-	content := string(data)
+	defer func() { _ = store.Close() }()
 
-	for _, ch := range []string{"standup", "leadership", "engineering", "qa", "all"} {
-		if !strings.Contains(content, ch) {
-			t.Errorf("channels.json missing channel %q", ch)
+	for _, chName := range []string{"standup", "leadership", "engineering", "qa", "all"} {
+		ch, getErr := store.GetChannel(chName)
+		if getErr != nil {
+			t.Errorf("error getting channel %q: %v", chName, getErr)
+		}
+		if ch == nil {
+			t.Errorf("channel %q not created", chName)
 		}
 	}
 }
@@ -390,18 +396,28 @@ func TestCreateDefaultChannels_PerAgentChannels(t *testing.T) {
 	_ = w.Close()
 	os.Stdout = oldStdout
 
-	// Verify channels file was created
-	channelsFile := filepath.Join(dir, ".bc", "channels.json")
-	data, err := os.ReadFile(channelsFile) //nolint:gosec // test file
-	if err != nil {
-		t.Fatal(err)
+	// Verify channels database was created
+	channelsDB := filepath.Join(dir, ".bc", "channels.db")
+	if _, statErr := os.Stat(channelsDB); os.IsNotExist(statErr) {
+		t.Fatal("channels.db not created")
 	}
-	content := string(data)
 
-	// Verify per-agent channels are created
+	// Verify per-agent channels exist in SQLite store
+	store := channel.NewSQLiteStore(dir)
+	if openErr := store.Open(); openErr != nil {
+		t.Fatalf("failed to open channel store: %v", openErr)
+	}
+	defer func() { _ = store.Close() }()
+
 	for _, agentName := range all {
-		if !strings.Contains(content, fmt.Sprintf(`"name": "%s"`, agentName)) {
-			t.Errorf("channels.json missing per-agent channel for %q", agentName)
+		ch, getErr := store.GetChannel(agentName)
+		if getErr != nil {
+			t.Errorf("error getting channel %q: %v", agentName, getErr)
+		}
+		if ch == nil {
+			t.Errorf("per-agent channel %q not created", agentName)
+		} else if ch.Type != channel.ChannelTypeDirect {
+			t.Errorf("per-agent channel %q has type %q, expected %q", agentName, ch.Type, channel.ChannelTypeDirect)
 		}
 	}
 }
@@ -428,15 +444,25 @@ func TestCreateDefaultChannels_NoDuplicatesOnRestart(t *testing.T) {
 	_ = w.Close()
 	os.Stdout = oldStdout
 
-	// Read and count channel occurrences
-	channelsFile := filepath.Join(dir, ".bc", "channels.json")
-	data, err := os.ReadFile(channelsFile) //nolint:gosec // test file
+	// Verify channels in SQLite store - should not have duplicates
+	store := channel.NewSQLiteStore(dir)
+	if openErr := store.Open(); openErr != nil {
+		t.Fatalf("failed to open channel store: %v", openErr)
+	}
+	defer func() { _ = store.Close() }()
+
+	// List all channels and count engineer-01 occurrences
+	channels, err := store.ListChannels()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to list channels: %v", err)
 	}
 
-	// Count occurrences of "engineer-01" channel name
-	count := strings.Count(string(data), `"name": "engineer-01"`)
+	count := 0
+	for _, ch := range channels {
+		if ch.Name == "engineer-01" {
+			count++
+		}
+	}
 	if count != 1 {
 		t.Errorf("expected 1 engineer-01 channel, got %d (duplicate channels created)", count)
 	}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -494,14 +494,19 @@ func buildBootstrapPrompt(agentNames []string, items []queue.WorkItem, rootDir s
 // #engineering (manager, tech-leads, engineers), #qa (manager, qa), #all (everyone).
 // Also creates per-agent channels (#agent-name) for direct messaging.
 func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames, allAgents []string) {
-	store := channel.NewStore(rootDir)
-	if err := store.Load(); err != nil {
-		fmt.Printf("  Warning: failed to load channels: %v\n", err)
+	// Use SQLite store for channels (v2)
+	store := channel.NewSQLiteStore(rootDir)
+	if err := store.Open(); err != nil {
+		fmt.Printf("  Warning: failed to open channel store: %v\n", err)
+		return
 	}
+	defer func() { _ = store.Close() }()
 
 	type chanDef struct {
-		name    string
-		members []string
+		name        string
+		description string
+		channelType channel.ChannelType
+		members     []string
 	}
 
 	// Leadership includes tech-leads
@@ -523,40 +528,50 @@ func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames
 	// Preallocate: 5 group channels + 1 per agent
 	channels := make([]chanDef, 0, 5+len(allAgents))
 	channels = append(channels,
-		chanDef{"standup", allAgents},
-		chanDef{"leadership", leadershipMembers},
-		chanDef{"engineering", engineeringMembers},
-		chanDef{"qa", qaMembers},
-		chanDef{"all", allAgents},
+		chanDef{name: "standup", description: "Daily standup channel", channelType: channel.ChannelTypeGroup, members: allAgents},
+		chanDef{name: "leadership", description: "Leadership coordination", channelType: channel.ChannelTypeGroup, members: leadershipMembers},
+		chanDef{name: "engineering", description: "Engineering team channel", channelType: channel.ChannelTypeGroup, members: engineeringMembers},
+		chanDef{name: "qa", description: "QA team channel", channelType: channel.ChannelTypeGroup, members: qaMembers},
+		chanDef{name: "all", description: "Broadcast channel for announcements", channelType: channel.ChannelTypeGroup, members: allAgents},
 	)
 
 	// Per-agent channels for direct messaging
-	// Each agent gets their own channel and is auto-subscribed
+	// Each agent gets their own channel with type "direct"
 	for _, agentName := range allAgents {
-		channels = append(channels, chanDef{agentName, []string{agentName}})
+		channels = append(channels, chanDef{
+			name:        agentName,
+			channelType: channel.ChannelTypeDirect,
+			members:     []string{agentName},
+			description: fmt.Sprintf("Direct channel for %s", agentName),
+		})
 	}
 
 	created := 0
 	for _, ch := range channels {
-		// Create channel if it doesn't already exist
-		if _, exists := store.Get(ch.name); !exists {
-			if _, createErr := store.Create(ch.name); createErr != nil {
-				fmt.Printf("  Warning: failed to create channel #%s: %v\n", ch.name, createErr)
-				continue
+		// Check if channel already exists
+		existing, _ := store.GetChannel(ch.name)
+		if existing != nil {
+			// Channel exists, just ensure members are added
+			for _, member := range ch.members {
+				_ = store.AddMember(ch.name, member)
 			}
-			created++
+			continue
 		}
-		// Add members (skip if already present)
+
+		// Create channel with proper type
+		if _, createErr := store.CreateChannel(ch.name, ch.channelType, ch.description); createErr != nil {
+			fmt.Printf("  Warning: failed to create channel #%s: %v\n", ch.name, createErr)
+			continue
+		}
+		created++
+
+		// Add members
 		for _, member := range ch.members {
 			_ = store.AddMember(ch.name, member)
 		}
 	}
 
 	if created > 0 {
-		if err := store.Save(); err != nil {
-			fmt.Printf("  Warning: failed to save channels: %v\n", err)
-			return
-		}
 		fmt.Printf("Created %d channels (%d group + %d per-agent)\n", created, min(created, 5), max(0, created-5))
 	}
 }


### PR DESCRIPTION
## Summary

- Updates `createDefaultChannels` to use SQLiteStore instead of JSON Store
- Sets channel type to "direct" for per-agent DM channels
- Sets channel type to "group" for team channels (standup, leadership, etc.)
- Adds descriptions to all channels for better discoverability

## Dependencies

⚠️ **Depends on PR #86** (SQLite channel backend) - must be merged first

## Test plan

- [x] All createDefaultChannels tests pass
- [x] TestCreateDefaultChannels verifies channels.db creation
- [x] TestCreateDefaultChannels_PerAgentChannels verifies direct type
- [x] TestCreateDefaultChannels_NoDuplicatesOnRestart uses SQLite API
- [x] golangci-lint passes with 0 issues

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)