### PR TITLE
feat: implement PR review request message format and parser

### DIFF
--- a/pkg/channel/review_request.go
+++ b/pkg/channel/review_request.go
@@ -1,0 +1,150 @@
+// Package channel - review_request.go provides PR review request parsing and formatting.
+package channel
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ReviewRequest represents a parsed PR review request message.
+type ReviewRequest struct {
+	// Target is the mentioned agent or role (e.g., "tech-lead-01")
+	Target string `json:"target,omitempty"`
+
+	// Title is the optional PR title
+	Title string `json:"title,omitempty"`
+
+	// URL is the GitHub PR URL (if determinable)
+	URL string `json:"url,omitempty"`
+
+	// Branch is the source branch name
+	Branch string `json:"branch,omitempty"`
+
+	// Author is who requested the review
+	Author string `json:"author,omitempty"`
+
+	// Raw is the original message content
+	Raw string `json:"raw"`
+
+	// PRNumber is the pull request number (e.g., 123)
+	PRNumber int `json:"pr_number"`
+}
+
+// prNumberRegex matches PR references like "PR #123", "PR 123", "#123"
+// Must have "PR" prefix or "#" prefix to avoid matching agent numbers
+var prNumberRegex = regexp.MustCompile(`(?i)(?:pr\s*#?|#)(\d+)`)
+
+// mentionRegex matches @mentions like "@tech-lead-01"
+var mentionRegex = regexp.MustCompile(`@([a-zA-Z0-9_-]+)`)
+
+// ParseReviewRequest parses a review request message.
+// Expected formats:
+//   - "@tech-lead PR #123 ready for review"
+//   - "@tech-lead-01 please review PR #456"
+//   - "PR #789 ready for review @tech-lead"
+//
+// Returns nil if the message doesn't appear to be a review request.
+func ParseReviewRequest(content string) *ReviewRequest {
+	lower := strings.ToLower(content)
+
+	// Must contain review-related keywords
+	if !strings.Contains(lower, "review") {
+		return nil
+	}
+
+	// Try to extract PR number
+	prMatch := prNumberRegex.FindStringSubmatch(content)
+	if prMatch == nil {
+		return nil
+	}
+
+	prNumber, err := strconv.Atoi(prMatch[1])
+	if err != nil {
+		return nil
+	}
+
+	req := &ReviewRequest{
+		PRNumber: prNumber,
+		Raw:      content,
+	}
+
+	// Extract @mentions
+	mentions := mentionRegex.FindAllStringSubmatch(content, -1)
+	if len(mentions) > 0 {
+		req.Target = mentions[0][1]
+	}
+
+	return req
+}
+
+// FormatReviewRequest creates a standardized review request message.
+// Format: "@<target> PR #<number> ready for review"
+func FormatReviewRequest(prNumber int, target string) string {
+	if target == "" {
+		target = "tech-lead"
+	}
+	return fmt.Sprintf("@%s PR #%d ready for review", target, prNumber)
+}
+
+// FormatReviewRequestWithTitle includes the PR title.
+// Format: "@<target> PR #<number> ready for review: <title>"
+func FormatReviewRequestWithTitle(prNumber int, target, title string) string {
+	if target == "" {
+		target = "tech-lead"
+	}
+	if title == "" {
+		return FormatReviewRequest(prNumber, target)
+	}
+	return fmt.Sprintf("@%s PR #%d ready for review: %s", target, prNumber, title)
+}
+
+// FormatReviewRequestWithURL includes the full GitHub URL.
+// Format: "@<target> PR #<number> ready for review: <url>"
+func FormatReviewRequestWithURL(prNumber int, target, url string) string {
+	if target == "" {
+		target = "tech-lead"
+	}
+	return fmt.Sprintf("@%s PR #%d ready for review: %s", target, prNumber, url)
+}
+
+// NewReviewRequestMessage creates a TypedMessage for a review request.
+func NewReviewRequestMessage(prNumber int, target, sender string) *TypedMessage {
+	content := FormatReviewRequest(prNumber, target)
+	msg := NewTypedMessage(content, TypeReview, sender)
+	msg.WithMetadata("pr_number", strconv.Itoa(prNumber))
+	if target != "" {
+		msg.WithMetadata("target", target)
+	}
+	return msg
+}
+
+// IsReviewRequest checks if a message content looks like a review request.
+func IsReviewRequest(content string) bool {
+	return ParseReviewRequest(content) != nil
+}
+
+// ExtractPRNumber extracts just the PR number from a message.
+// Returns 0 if no PR number found.
+func ExtractPRNumber(content string) int {
+	match := prNumberRegex.FindStringSubmatch(content)
+	if match == nil {
+		return 0
+	}
+	num, err := strconv.Atoi(match[1])
+	if err != nil {
+		return 0
+	}
+	return num
+}
+
+// ExtractMentions returns all @mentions from a message.
+func ExtractMentions(content string) []string {
+	matches := mentionRegex.FindAllStringSubmatch(content, -1)
+	mentions := make([]string, 0, len(matches))
+	for _, m := range matches {
+		mentions = append(mentions, m[1])
+	}
+	return mentions
+}

--- a/pkg/channel/review_request_test.go
+++ b/pkg/channel/review_request_test.go
@@ -1,0 +1,244 @@
+package channel
+
+import (
+	"testing"
+)
+
+func TestParseReviewRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantTarget string
+		wantPR     int
+		wantNil    bool
+	}{
+		{
+			name:       "standard format",
+			input:      "@tech-lead PR #123 ready for review",
+			wantPR:     123,
+			wantTarget: "tech-lead",
+		},
+		{
+			name:       "with agent number",
+			input:      "@tech-lead-01 please review PR #456",
+			wantPR:     456,
+			wantTarget: "tech-lead-01",
+		},
+		{
+			name:       "mention at end",
+			input:      "PR #789 ready for review @tech-lead",
+			wantPR:     789,
+			wantTarget: "tech-lead",
+		},
+		{
+			name:       "lowercase",
+			input:      "@tech-lead pr #100 ready for review",
+			wantPR:     100,
+			wantTarget: "tech-lead",
+		},
+		{
+			name:       "no hash",
+			input:      "@tech-lead PR 200 ready for review",
+			wantPR:     200,
+			wantTarget: "tech-lead",
+		},
+		{
+			name:       "no mention",
+			input:      "PR #300 is ready for review",
+			wantPR:     300,
+			wantTarget: "",
+		},
+		{
+			name:    "not a review request",
+			input:   "Hello everyone!",
+			wantNil: true,
+		},
+		{
+			name:    "has PR but no review",
+			input:   "PR #123 is broken",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := ParseReviewRequest(tt.input)
+			if tt.wantNil {
+				if req != nil {
+					t.Errorf("expected nil, got %+v", req)
+				}
+				return
+			}
+			if req == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if req.PRNumber != tt.wantPR {
+				t.Errorf("PRNumber = %d, want %d", req.PRNumber, tt.wantPR)
+			}
+			if req.Target != tt.wantTarget {
+				t.Errorf("Target = %q, want %q", req.Target, tt.wantTarget)
+			}
+		})
+	}
+}
+
+func TestFormatReviewRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		want     string
+		prNumber int
+	}{
+		{
+			name:     "basic",
+			prNumber: 123,
+			target:   "tech-lead",
+			want:     "@tech-lead PR #123 ready for review",
+		},
+		{
+			name:     "with agent number",
+			prNumber: 456,
+			target:   "tech-lead-01",
+			want:     "@tech-lead-01 PR #456 ready for review",
+		},
+		{
+			name:     "empty target defaults",
+			prNumber: 789,
+			target:   "",
+			want:     "@tech-lead PR #789 ready for review",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatReviewRequest(tt.prNumber, tt.target)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatReviewRequestWithTitle(t *testing.T) {
+	got := FormatReviewRequestWithTitle(123, "tech-lead", "Add new feature")
+	want := "@tech-lead PR #123 ready for review: Add new feature"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// Empty title should fall back to basic format
+	got = FormatReviewRequestWithTitle(456, "tech-lead", "")
+	want = "@tech-lead PR #456 ready for review"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFormatReviewRequestWithURL(t *testing.T) {
+	got := FormatReviewRequestWithURL(123, "tech-lead", "https://github.com/owner/repo/pull/123")
+	want := "@tech-lead PR #123 ready for review: https://github.com/owner/repo/pull/123"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNewReviewRequestMessage(t *testing.T) {
+	msg := NewReviewRequestMessage(123, "tech-lead-01", "engineer-01")
+
+	if msg.Type != TypeReview {
+		t.Errorf("Type = %v, want %v", msg.Type, TypeReview)
+	}
+	if msg.Sender != "engineer-01" {
+		t.Errorf("Sender = %q, want %q", msg.Sender, "engineer-01")
+	}
+	if msg.Metadata["pr_number"] != "123" {
+		t.Errorf("pr_number metadata = %q, want %q", msg.Metadata["pr_number"], "123")
+	}
+	if msg.Metadata["target"] != "tech-lead-01" {
+		t.Errorf("target metadata = %q, want %q", msg.Metadata["target"], "tech-lead-01")
+	}
+}
+
+func TestIsReviewRequest(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"@tech-lead PR #123 ready for review", true},
+		{"please review PR #456", true},
+		{"Hello world", false},
+		{"PR #123 is broken", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := IsReviewRequest(tt.input); got != tt.want {
+				t.Errorf("IsReviewRequest(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractPRNumber(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"PR #123", 123},
+		{"pr 456", 456},
+		{"#789", 789},
+		{"no pr here", 0},
+		{"multiple #1 and #2", 1}, // returns first match
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ExtractPRNumber(tt.input); got != tt.want {
+				t.Errorf("ExtractPRNumber(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractMentions(t *testing.T) {
+	tests := []struct {
+		input string
+		want  []string
+	}{
+		{"@tech-lead review please", []string{"tech-lead"}},
+		{"@alice and @bob please review", []string{"alice", "bob"}},
+		{"no mentions here", []string{}},
+		{"@user_name with underscore", []string{"user_name"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := ExtractMentions(tt.input)
+			if len(got) != len(tt.want) {
+				t.Errorf("ExtractMentions(%q) = %v, want %v", tt.input, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ExtractMentions(%q)[%d] = %q, want %q", tt.input, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestReviewRequestRoundTrip(t *testing.T) {
+	// Format a request, then parse it back
+	formatted := FormatReviewRequest(123, "tech-lead-01")
+	parsed := ParseReviewRequest(formatted)
+
+	if parsed == nil {
+		t.Fatal("failed to parse formatted request")
+	}
+	if parsed.PRNumber != 123 {
+		t.Errorf("PRNumber = %d, want 123", parsed.PRNumber)
+	}
+	if parsed.Target != "tech-lead-01" {
+		t.Errorf("Target = %q, want %q", parsed.Target, "tech-lead-01")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/channel/review_request.go` with PR review request parsing and formatting
- Implement `ReviewRequest` struct for parsed messages
- Add parsing and formatting functions for standardized review workflow

## Features
- **ParseReviewRequest()** - Extracts PR number and target from review request messages
- **FormatReviewRequest()** - Generates standardized review request messages
- **ExtractPRNumber()** - Helper to extract PR number from any message
- **ExtractMentions()** - Helper to extract @mentions from messages
- **NewReviewRequestMessage()** - Creates typed messages for the channel system

## Supported Formats
- `@tech-lead PR #123 ready for review`
- `@tech-lead-01 please review PR #456`
- `PR #789 ready for review @tech-lead`
- `pr 100 ready for review` (case-insensitive)

## Test plan
- [x] All review request parsing tests pass
- [x] Format generation tests pass
- [x] Round-trip test (format → parse → verify)
- [x] golangci-lint passes
- [x] Full test suite passes

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)