### PR TITLE
feat: remove beads package from cmd layer

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -324,7 +324,7 @@ func TestQueueCompleteSuccess(t *testing.T) {
 	}
 }
 
-func TestQueueLoadNoBeads(t *testing.T) {
+func TestQueueLoadDeprecated(t *testing.T) {
 	_, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 
@@ -332,8 +332,11 @@ func TestQueueLoadNoBeads(t *testing.T) {
 	if err != nil {
 		t.Fatalf("queue load returned error: %v", err)
 	}
-	if !strings.Contains(stdout, "No beads issues found") {
-		t.Errorf("expected no beads message, got: %s", stdout)
+	if !strings.Contains(stdout, "deprecated") {
+		t.Errorf("expected deprecation message, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "GitHub Issues") {
+		t.Errorf("expected GitHub Issues reference, got: %s", stdout)
 	}
 }
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -296,25 +296,16 @@ func TestLoadRolePrompt(t *testing.T) {
 
 func TestBuildBootstrapPrompt(t *testing.T) {
 	agents := []string{"coordinator", "manager", "engineer-01"}
-	items := []queue.WorkItem{
-		{ID: "work-001", Title: "Fix auth", Description: "Fix the authentication bug", BeadsID: "bc-123"},
-		{ID: "work-002", Title: "Add tests", BeadsID: ""},
-	}
 
-	result := buildBootstrapPrompt(agents, items, "/test/workspace")
+	result := buildBootstrapPrompt(agents, "/test/workspace")
 
 	checks := []string{
 		"coordinator",
 		"manager",
 		"engineer-01",
 		"/test/workspace",
-		"work-001",
-		"Fix auth",
-		"Fix the authentication bug",
-		"bc-123",
-		"work-002",
-		"Add tests",
-		"WORK QUEUE",
+		"WORK TRACKING",
+		"gh issue list",
 		"YOUR WORKFLOW",
 		"BC COMMANDS",
 	}
@@ -1646,17 +1637,20 @@ func TestChannelHistory_WithMessages(t *testing.T) {
 	}
 }
 
-// --- Queue load (no beads) ---
+// --- Queue load (deprecated) ---
 
-func TestQueueLoad_NoBeads(t *testing.T) {
+func TestQueueLoad_Deprecated(t *testing.T) {
 	setupTestWorkspace(t)
 
 	output, err := executeCmd("queue", "load")
 	if err != nil {
 		t.Fatalf("queue load failed: %v\nOutput: %s", err, output)
 	}
-	if !strings.Contains(output, "No beads") && !strings.Contains(output, "Loaded 0") {
-		t.Errorf("queue load should indicate no beads or 0 loaded, got: %s", output)
+	if !strings.Contains(output, "deprecated") {
+		t.Errorf("queue load should indicate deprecation, got: %s", output)
+	}
+	if !strings.Contains(output, "GitHub Issues") {
+		t.Errorf("queue load should reference GitHub Issues, got: %s", output)
 	}
 }
 

--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rpuneet/bc/config"
 	itui "github.com/rpuneet/bc/internal/tui"
 	"github.com/rpuneet/bc/pkg/agent"
-	"github.com/rpuneet/bc/pkg/beads"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
@@ -60,7 +59,6 @@ func runHome(cmd *cobra.Command, args []string) error {
 		info := itui.WorkspaceInfo{
 			Entry:      entry,
 			MaxWorkers: int(config.Workspace.MaxWorkers),
-			HasBeads:   beads.HasBeads(entry.Path),
 		}
 
 		// Count running agents
@@ -73,12 +71,7 @@ func runHome(cmd *cobra.Command, args []string) error {
 		info.Total = mgr.AgentCount()
 		info.Running = mgr.RunningCount()
 
-		// Count beads issues
-		if info.HasBeads {
-			if issues, listErr := beads.ListIssues(entry.Path); listErr == nil {
-				info.Issues = len(issues)
-			}
-		}
+		// Note: Issue tracking now uses GitHub Issues (beads removed)
 
 		workspaces = append(workspaces, info)
 	}

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -10,7 +10,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/agent"
-	"github.com/rpuneet/bc/pkg/beads"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/queue"
@@ -368,7 +367,7 @@ func mergeBranch(repoDir, branch string) (string, error) {
 	return mergeCommit[:12], nil
 }
 
-// markQueueDone marks a queue item as done and closes its beads issue.
+// markQueueDone marks a queue item as done.
 func markQueueDone(stateDir, rootDir, workID string) error {
 	q := queue.New(filepath.Join(stateDir, "queue.json"))
 	if err := q.Load(); err != nil {
@@ -384,10 +383,6 @@ func markQueueDone(stateDir, rootDir, workID string) error {
 	if err := q.Save(); err != nil {
 		return err
 	}
-	if item.BeadsID != "" {
-		if err := beads.CloseIssue(rootDir, item.BeadsID); err != nil {
-			log.Warn("failed to close beads issue", "id", item.BeadsID, "error", err)
-		}
-	}
+	// Note: Issue tracking now uses GitHub Issues (beads removed)
 	return nil
 }

--- a/internal/cmd/queue.go
+++ b/internal/cmd/queue.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rpuneet/bc/pkg/beads"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/queue"
 )
@@ -217,24 +216,9 @@ func runQueueDetail(cmd *cobra.Command, itemID string) error {
 		fmt.Printf("\nDescription:\n  %s\n", strings.ReplaceAll(item.Description, "\n", "\n  "))
 	}
 
-	// Show bead metadata if linked
+	// Note: Issue details now come from GitHub Issues (beads removed)
 	if item.BeadsID != "" {
-		issue := beads.GetIssue(ws.RootDir, item.BeadsID)
-		if issue != nil {
-			fmt.Printf("\nBead (%s):\n", item.BeadsID)
-			if issue.Type != "" {
-				fmt.Printf("  Type:         %s\n", issue.Type)
-			}
-			if issue.Priority != nil {
-				fmt.Printf("  Priority:     %v\n", issue.Priority)
-			}
-			if issue.Status != "" {
-				fmt.Printf("  Bead Status:  %s\n", issue.Status)
-			}
-			if len(issue.Dependencies) > 0 {
-				fmt.Printf("  Dependencies: %s\n", strings.Join(issue.Dependencies, ", "))
-			}
-		}
+		fmt.Printf("\nLegacy Bead ID: %s\n", item.BeadsID)
 	}
 
 	return nil
@@ -299,80 +283,19 @@ func runQueueAssign(cmd *cobra.Command, args []string) error {
 		Data:  map[string]any{"work_id": itemID},
 	})
 
-	// Sync assignment to beads if linked
-	if item.BeadsID != "" {
-		if err := beads.AssignIssue(ws.RootDir, item.BeadsID, agentName); err != nil {
-			// Log but don't fail - beads sync is best-effort
-			_ = log.Append(events.Event{
-				Type:    events.AgentReport,
-				Agent:   agentName,
-				Message: fmt.Sprintf("warning: failed to assign beads issue %s: %v", item.BeadsID, err),
-			})
-		}
-	}
+	// Note: Issue tracking now uses GitHub Issues (beads removed)
 
 	fmt.Printf("Assigned %s to %s\n", itemID, agentName)
 	return nil
 }
 
 func runQueueLoad(cmd *cobra.Command, args []string) error {
-	ws, err := getWorkspace()
-	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
-	}
-
-	q, err := loadQueue(ws)
-	if err != nil {
-		return err
-	}
-
-	// Try ready issues first, fall back to all issues
-	issues := beads.ReadyIssues(ws.RootDir)
-	if len(issues) == 0 {
-		issues, _ = beads.ListIssues(ws.RootDir) //nolint:errcheck // best-effort fallback
-	}
-
-	if len(issues) == 0 {
-		fmt.Println("No beads issues found")
-		return nil
-	}
-
-	added := 0
-	linked := 0
-	for _, issue := range issues {
-		if q.HasBeadsID(issue.ID) {
-			continue
-		}
-		// Check if a work item with the same title already exists (added manually)
-		if existing := q.FindByTitle(issue.Title); existing != nil {
-			// Link the beads ID to the existing item so future syncs skip it
-			if existing.BeadsID == "" {
-				_ = q.LinkBeadsID(existing.ID, issue.ID)
-				linked++
-			}
-			continue
-		}
-		q.Add(issue.Title, issue.Description, issue.ID)
-		added++
-	}
-
-	if err := q.Save(); err != nil {
-		return fmt.Errorf("failed to save queue: %w", err)
-	}
-
-	// Log event
-	log := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
-	_ = log.Append(events.Event{
-		Type:    events.QueueLoaded,
-		Message: fmt.Sprintf("loaded %d items from beads", added),
-		Data:    map[string]any{"added": added, "linked": linked, "total_issues": len(issues)},
-	})
-
-	fmt.Printf("Loaded %d new items from beads (%d already in queue", added, len(issues)-added-linked)
-	if linked > 0 {
-		fmt.Printf(", %d linked to existing items", linked)
-	}
-	fmt.Println(")")
+	// Note: beads package has been deprecated. Use GitHub Issues for task tracking.
+	fmt.Println("The 'bc queue load' command is deprecated.")
+	fmt.Println("Work items are now tracked via GitHub Issues.")
+	fmt.Println()
+	fmt.Println("To view issues:  gh issue list --state open")
+	fmt.Println("To create:       gh issue create --title '<title>'")
 	return nil
 }
 
@@ -406,14 +329,7 @@ func runQueueComplete(cmd *cobra.Command, args []string) error {
 		Data:    map[string]any{"work_id": itemID},
 	})
 
-	if item.BeadsID != "" {
-		if err := beads.CloseIssue(ws.RootDir, item.BeadsID); err != nil {
-			_ = log.Append(events.Event{
-				Type:    events.AgentReport,
-				Message: fmt.Sprintf("warning: failed to close beads issue %s: %v", item.BeadsID, err),
-			})
-		}
-	}
+	// Note: Issue tracking now uses GitHub Issues (beads removed)
 
 	fmt.Printf("Marked %s done", itemID)
 	if item.BeadsID != "" {

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/agent"
-	"github.com/rpuneet/bc/pkg/beads"
 	"github.com/rpuneet/bc/pkg/events"
 	bclog "github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/queue"
@@ -110,19 +109,7 @@ itemLoop:
 				}); err != nil {
 					bclog.Warn("failed to append work completed event", "error", err)
 				}
-				// Close linked beads issue if present
-				if item.BeadsID != "" {
-					if err := beads.CloseIssue(ws.RootDir, item.BeadsID); err != nil {
-						// Log but don't fail - beads sync is best-effort
-						if appendErr := log.Append(events.Event{
-							Type:    events.AgentReport,
-							Agent:   agentID,
-							Message: fmt.Sprintf("warning: failed to close beads issue %s: %v", item.BeadsID, err),
-						}); appendErr != nil {
-							bclog.Warn("failed to append beads close warning event", "error", appendErr)
-						}
-					}
-				}
+				// Note: Issue tracking now uses GitHub Issues (beads removed)
 				break itemLoop // Only complete the first working item
 			}
 		}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -10,10 +10,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/agent"
-	"github.com/rpuneet/bc/pkg/beads"
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/events"
-	"github.com/rpuneet/bc/pkg/queue"
 )
 
 var upCmd = &cobra.Command{
@@ -39,9 +37,8 @@ CLI flags override config.toml values.
 
 This will:
 1. Start all agents in the roster
-2. Load beads issues into the work queue
-3. Send role prompts from prompts/ directory
-4. Send bootstrap prompts to all agents
+2. Send role prompts from prompts/ directory
+3. Send bootstrap prompts to all agents
 
 Example:
   bc up                      # Start with roster from config.toml
@@ -157,37 +154,6 @@ func runUp(cmd *cobra.Command, args []string) error {
 
 	// Event log
 	log := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
-
-	// Load beads issues into queue
-	q := queue.New(filepath.Join(ws.StateDir(), "queue.json"))
-	if err = q.Load(); err != nil {
-		return fmt.Errorf("failed to load queue: %w", err)
-	}
-
-	issues := beads.ReadyIssues(ws.RootDir)
-	if len(issues) == 0 {
-		issues, _ = beads.ListIssues(ws.RootDir) //nolint:errcheck // best-effort fallback
-	}
-
-	added := 0
-	for _, issue := range issues {
-		if q.HasBeadsID(issue.ID) {
-			continue
-		}
-		q.Add(issue.Title, issue.Description, issue.ID)
-		added++
-	}
-	if added > 0 {
-		if err = q.Save(); err != nil {
-			return fmt.Errorf("failed to save queue: %w", err)
-		}
-		fmt.Printf("Loaded %d items into work queue from beads\n", added)
-		_ = log.Append(events.Event{
-			Type:    events.QueueLoaded,
-			Message: fmt.Sprintf("loaded %d items from beads", added),
-			Data:    map[string]any{"added": added},
-		})
-	}
 
 	// Start coordinator (acts as root agent)
 	fmt.Print("Starting coordinator... ")
@@ -375,12 +341,10 @@ func runUp(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build and send bootstrap prompts
-	queueItems := q.ListAll()
-
-	// Coordinator: full bootstrap with queue and all agent names (reuse allAgents from above)
-	if len(queueItems) > 0 && len(allAgents) > 0 {
+	// Coordinator: bootstrap with team info (uses GitHub Issues for work tracking)
+	if len(allAgents) > 0 {
 		fmt.Print("\nSending bootstrap prompt to coordinator... ")
-		prompt := buildBootstrapPrompt(allAgents, queueItems, ws.RootDir)
+		prompt := buildBootstrapPrompt(allAgents, ws.RootDir)
 		if err := mgr.SendToAgent("coordinator", prompt); err != nil {
 			fmt.Println("✗")
 			fmt.Printf("  Warning: failed to send bootstrap prompt: %v\n", err)
@@ -440,48 +404,42 @@ func loadRolePrompt(rootDir, role string) string {
 	return string(data)
 }
 
-func buildBootstrapPrompt(agentNames []string, items []queue.WorkItem, rootDir string) string {
+func buildBootstrapPrompt(agentNames []string, rootDir string) string {
 	var b strings.Builder
 
 	b.WriteString("You are the coordinator agent for a bc workspace.\n\n")
 	b.WriteString(fmt.Sprintf("Workspace: %s\n", rootDir))
 	b.WriteString(fmt.Sprintf("Team: %s\n\n", strings.Join(agentNames, ", ")))
 
-	b.WriteString("=== WORK QUEUE ===\n")
-	for _, item := range items {
-		b.WriteString(fmt.Sprintf("\n[%s] %s (beads: %s)\n", item.ID, item.Title, item.BeadsID))
-		if item.Description != "" {
-			b.WriteString(item.Description)
-			b.WriteString("\n")
-		}
-	}
+	b.WriteString("=== WORK TRACKING ===\n")
+	b.WriteString("Work is tracked via GitHub Issues:\n")
+	b.WriteString("  gh issue list --state open     # View open issues\n")
+	b.WriteString("  gh issue view <number>         # View issue details\n\n")
 
-	b.WriteString("\n=== YOUR WORKFLOW ===\n\n")
+	b.WriteString("=== YOUR WORKFLOW ===\n\n")
 
 	b.WriteString("Phase 1 — ASSIGN:\n")
-	b.WriteString("  For each work item, pick a worker and send instructions:\n")
-	b.WriteString("    bc queue assign <work-id> <worker>\n")
-	b.WriteString("    bc send <worker> \"<detailed instructions>\"\n")
-	b.WriteString("  Distribute work evenly across workers.\n\n")
+	b.WriteString("  Review GitHub Issues and assign work to team members:\n")
+	b.WriteString("    gh issue list --state open\n")
+	b.WriteString("    bc send <agent> \"Work on issue #<number>: <instructions>\"\n")
+	b.WriteString("  Distribute work evenly across engineers.\n\n")
 
 	b.WriteString("Phase 2 — REVIEW:\n")
-	b.WriteString("  After workers report done, review their branches (named by bead ID):\n")
-	b.WriteString("    git log <bead-id> --oneline  # e.g. git log bc-34b.5\n")
-	b.WriteString("    git diff main..<bead-id>\n")
-	b.WriteString("  Verify the implementation matches the task description.\n")
-	b.WriteString("  If a worker's branch needs fixes, send feedback via bc send.\n\n")
+	b.WriteString("  After engineers report done, review their branches:\n")
+	b.WriteString("    gh pr list --author <agent>\n")
+	b.WriteString("    git diff main..<branch>\n")
+	b.WriteString("  Verify the implementation matches the issue requirements.\n")
+	b.WriteString("  If a branch needs fixes, send feedback via bc send.\n\n")
 
 	b.WriteString("Phase 3 — INTEGRATE:\n")
-	b.WriteString("  Create an integrate branch and merge all approved worker branches:\n")
-	b.WriteString("    git checkout -b integrate main\n")
-	b.WriteString("    git merge <branch1> <branch2> ...\n")
+	b.WriteString("  Merge approved PRs via GitHub:\n")
+	b.WriteString("    gh pr merge <number> --squash\n")
 	b.WriteString("  Build and test: go build ./... && go test ./...\n")
 	b.WriteString("  Report done: bc report done \"all tasks integrated\"\n\n")
 
 	b.WriteString("=== BC COMMANDS ===\n")
 	b.WriteString("  bc status          # View agent states\n")
-	b.WriteString("  bc queue           # View work queue\n")
-	b.WriteString("  bc queue assign    # Assign work to agent\n")
+	b.WriteString("  bc agent list      # List all agents\n")
 	b.WriteString("  bc send <a> <msg>  # Send message to agent\n")
 	b.WriteString("  bc report <state>  # Report your state\n")
 	b.WriteString("  bc logs            # View event log")

--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/rpuneet/bc/pkg/queue"
 )
 
 func TestLoadRolePrompt_ExistingFile(t *testing.T) {
@@ -61,12 +59,8 @@ func TestLoadRolePrompt_EmptyFile(t *testing.T) {
 
 func TestBuildBootstrapPrompt_Structure(t *testing.T) {
 	agents := []string{"coordinator", "engineer-01", "qa-01"}
-	items := []queue.WorkItem{
-		{ID: "work-001", Title: "Fix auth bug", BeadsID: "bc-1a.1", Description: "Auth is broken"},
-		{ID: "work-002", Title: "Add dark mode", BeadsID: "bc-2b.1"},
-	}
 
-	prompt := buildBootstrapPrompt(agents, items, "/test/workspace")
+	prompt := buildBootstrapPrompt(agents, "/test/workspace")
 
 	// Verify workspace info
 	if !strings.Contains(prompt, "/test/workspace") {
@@ -78,26 +72,12 @@ func TestBuildBootstrapPrompt_Structure(t *testing.T) {
 		t.Error("prompt should contain team listing")
 	}
 
-	// Verify work queue header
-	if !strings.Contains(prompt, "=== WORK QUEUE ===") {
-		t.Error("prompt should contain work queue header")
+	// Verify work tracking section (now uses GitHub Issues)
+	if !strings.Contains(prompt, "=== WORK TRACKING ===") {
+		t.Error("prompt should contain work tracking header")
 	}
-
-	// Verify work items
-	if !strings.Contains(prompt, "[work-001]") {
-		t.Error("prompt should contain work-001 ID")
-	}
-	if !strings.Contains(prompt, "Fix auth bug") {
-		t.Error("prompt should contain work item title")
-	}
-	if !strings.Contains(prompt, "bc-1a.1") {
-		t.Error("prompt should contain beads ID")
-	}
-	if !strings.Contains(prompt, "Auth is broken") {
-		t.Error("prompt should contain description")
-	}
-	if !strings.Contains(prompt, "[work-002]") {
-		t.Error("prompt should contain work-002 ID")
+	if !strings.Contains(prompt, "gh issue list") {
+		t.Error("prompt should reference gh issue list command")
 	}
 
 	// Verify workflow sections
@@ -118,44 +98,26 @@ func TestBuildBootstrapPrompt_Structure(t *testing.T) {
 	if !strings.Contains(prompt, "bc status") {
 		t.Error("prompt should reference bc status command")
 	}
-	if !strings.Contains(prompt, "bc queue assign") {
-		t.Error("prompt should reference bc queue assign command")
-	}
 }
 
-func TestBuildBootstrapPrompt_EmptyItems(t *testing.T) {
+func TestBuildBootstrapPrompt_MinimalAgents(t *testing.T) {
 	agents := []string{"coordinator"}
-	items := []queue.WorkItem{}
 
-	prompt := buildBootstrapPrompt(agents, items, "/test")
+	prompt := buildBootstrapPrompt(agents, "/test")
 
-	// Should still have structure even with no items
-	if !strings.Contains(prompt, "=== WORK QUEUE ===") {
-		t.Error("prompt should contain work queue header even when empty")
+	// Should still have structure with single agent
+	if !strings.Contains(prompt, "=== WORK TRACKING ===") {
+		t.Error("prompt should contain work tracking header")
 	}
 	if !strings.Contains(prompt, "=== YOUR WORKFLOW ===") {
 		t.Error("prompt should contain workflow section")
 	}
 }
 
-func TestBuildBootstrapPrompt_ItemWithoutDescription(t *testing.T) {
-	agents := []string{"coordinator"}
-	items := []queue.WorkItem{
-		{ID: "work-001", Title: "Simple task", BeadsID: "bc-1a.1"},
-	}
-
-	prompt := buildBootstrapPrompt(agents, items, "/test")
-
-	if !strings.Contains(prompt, "Simple task") {
-		t.Error("prompt should contain item title")
-	}
-}
-
 func TestBuildBootstrapPrompt_CoordinatorRole(t *testing.T) {
 	agents := []string{"coordinator"}
-	items := []queue.WorkItem{}
 
-	prompt := buildBootstrapPrompt(agents, items, "/test")
+	prompt := buildBootstrapPrompt(agents, "/test")
 
 	if !strings.Contains(prompt, "You are the coordinator agent") {
 		t.Error("prompt should identify the coordinator role")


### PR DESCRIPTION
## Summary
- Remove beads import and calls from cmd layer (up.go, report.go, merge.go, home.go, queue.go)
- Deprecate `bc queue load` command with message directing to GitHub Issues
- Update buildBootstrapPrompt to reference GitHub Issues workflow instead of beads
- Update tests to reflect deprecation message changes

Closes #65

## Test plan
- [x] Build passes
- [x] Tests pass
- [ ] Verify queue load shows deprecation message

🤖 Generated with [Claude Code](https://claude.ai/code)