### PR TITLE
feat: add #reviews channel on bc up

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -1732,7 +1732,7 @@ func TestCreateDefaultChannelsIntegration(t *testing.T) {
 	defer func() { _ = store.Close() }()
 
 	// Check required channels exist
-	for _, name := range []string{"standup", "leadership", "engineering", "qa", "all"} {
+	for _, name := range []string{"standup", "leadership", "engineering", "qa", "reviews", "all"} {
 		ch, getErr := store.GetChannel(name)
 		if getErr != nil {
 			t.Errorf("error getting channel %q: %v", name, getErr)

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -363,7 +363,7 @@ func TestCreateDefaultChannels(t *testing.T) {
 	}
 	defer func() { _ = store.Close() }()
 
-	for _, chName := range []string{"standup", "leadership", "engineering", "qa", "all"} {
+	for _, chName := range []string{"standup", "leadership", "engineering", "qa", "reviews", "all"} {
 		ch, getErr := store.GetChannel(chName)
 		if getErr != nil {
 			t.Errorf("error getting channel %q: %v", chName, getErr)

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -524,14 +524,21 @@ func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames
 	qaMembers = append(qaMembers, "manager")
 	qaMembers = append(qaMembers, qaNames...)
 
+	// Reviews channel: tech-leads, manager, and engineers can post review requests
+	reviewsMembers := make([]string, 0, 1+len(techLeadNames)+len(engineerNames))
+	reviewsMembers = append(reviewsMembers, "manager")
+	reviewsMembers = append(reviewsMembers, techLeadNames...)
+	reviewsMembers = append(reviewsMembers, engineerNames...)
+
 	// Group channels + per-agent channels
-	// Preallocate: 5 group channels + 1 per agent
-	channels := make([]chanDef, 0, 5+len(allAgents))
+	// Preallocate: 6 group channels + 1 per agent
+	channels := make([]chanDef, 0, 6+len(allAgents))
 	channels = append(channels,
 		chanDef{name: "standup", description: "Daily standup channel", channelType: channel.ChannelTypeGroup, members: allAgents},
 		chanDef{name: "leadership", description: "Leadership coordination", channelType: channel.ChannelTypeGroup, members: leadershipMembers},
 		chanDef{name: "engineering", description: "Engineering team channel", channelType: channel.ChannelTypeGroup, members: engineeringMembers},
 		chanDef{name: "qa", description: "QA team channel", channelType: channel.ChannelTypeGroup, members: qaMembers},
+		chanDef{name: "reviews", description: "Code review requests and discussions", channelType: channel.ChannelTypeGroup, members: reviewsMembers},
 		chanDef{name: "all", description: "Broadcast channel for announcements", channelType: channel.ChannelTypeGroup, members: allAgents},
 	)
 


### PR DESCRIPTION
## Summary
- Create #reviews channel automatically when workspace starts
- Members: tech-leads, manager, and all engineers
- Engineers can post review requests, tech-leads respond

Closes #96

## Test plan
- [x] Build passes
- [x] Tests pass (TestCreateDefaultChannels_GroupChannels updated)
- [ ] Verify #reviews channel created on bc up

🤖 Generated with [Claude Code](https://claude.ai/code)