### PR TITLE
feat: per-agent memory directory structure

### DIFF
--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -1,0 +1,181 @@
+// Package memory provides per-agent memory storage for experiences and learnings.
+package memory
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Experience represents a recorded task outcome.
+type Experience struct {
+	Timestamp   time.Time      `json:"timestamp"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	TaskID      string         `json:"task_id,omitempty"`
+	TaskType    string         `json:"task_type,omitempty"`
+	Description string         `json:"description"`
+	Outcome     string         `json:"outcome"`
+	Learnings   []string       `json:"learnings,omitempty"`
+}
+
+// Store provides memory storage for an agent.
+type Store struct {
+	agentName string
+	memoryDir string
+}
+
+// NewStore creates a new memory store for an agent.
+func NewStore(rootDir, agentName string) *Store {
+	return &Store{
+		agentName: agentName,
+		memoryDir: filepath.Join(rootDir, ".bc", "memory", agentName),
+	}
+}
+
+// Init creates the memory directory structure for an agent.
+// Creates:
+//   - .bc/memory/<agent-name>/
+//   - .bc/memory/<agent-name>/experiences.jsonl
+//   - .bc/memory/<agent-name>/learnings.md
+func (s *Store) Init() error {
+	// Create memory directory
+	if err := os.MkdirAll(s.memoryDir, 0750); err != nil {
+		return fmt.Errorf("failed to create memory directory: %w", err)
+	}
+
+	// Initialize experiences.jsonl if it doesn't exist
+	experiencesPath := s.experiencesPath()
+	if _, err := os.Stat(experiencesPath); os.IsNotExist(err) {
+		f, createErr := os.Create(experiencesPath) //nolint:gosec // path constructed from trusted memoryDir
+		if createErr != nil {
+			return fmt.Errorf("failed to create experiences file: %w", createErr)
+		}
+		_ = f.Close()
+	}
+
+	// Initialize learnings.md if it doesn't exist
+	learningsPath := s.learningsPath()
+	if _, err := os.Stat(learningsPath); os.IsNotExist(err) {
+		initialContent := fmt.Sprintf("# %s Learnings\n\nThis file contains insights and learnings accumulated by %s.\n\n", s.agentName, s.agentName)
+		if writeErr := os.WriteFile(learningsPath, []byte(initialContent), 0600); writeErr != nil { //nolint:gosec // path constructed from trusted memoryDir
+			return fmt.Errorf("failed to create learnings file: %w", writeErr)
+		}
+	}
+
+	return nil
+}
+
+// Exists checks if the memory directory exists for this agent.
+func (s *Store) Exists() bool {
+	_, err := os.Stat(s.memoryDir)
+	return err == nil
+}
+
+// RecordExperience appends an experience to the experiences.jsonl file.
+func (s *Store) RecordExperience(exp Experience) error {
+	if exp.Timestamp.IsZero() {
+		exp.Timestamp = time.Now().UTC()
+	}
+
+	f, err := os.OpenFile(s.experiencesPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) //nolint:gosec // path constructed from trusted memoryDir
+	if err != nil {
+		return fmt.Errorf("failed to open experiences file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, marshalErr := json.Marshal(exp)
+	if marshalErr != nil {
+		return fmt.Errorf("failed to marshal experience: %w", marshalErr)
+	}
+
+	if _, writeErr := f.Write(append(data, '\n')); writeErr != nil {
+		return fmt.Errorf("failed to write experience: %w", writeErr)
+	}
+
+	return nil
+}
+
+// AddLearning appends a learning to the learnings.md file.
+func (s *Store) AddLearning(category, learning string) error {
+	f, err := os.OpenFile(s.learningsPath(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) //nolint:gosec // path constructed from trusted memoryDir
+	if err != nil {
+		return fmt.Errorf("failed to open learnings file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	entry := fmt.Sprintf("\n## %s\n\n- %s\n", category, learning)
+	if _, writeErr := f.WriteString(entry); writeErr != nil {
+		return fmt.Errorf("failed to write learning: %w", writeErr)
+	}
+
+	return nil
+}
+
+// GetExperiences reads all experiences from the experiences.jsonl file.
+func (s *Store) GetExperiences() ([]Experience, error) {
+	data, err := os.ReadFile(s.experiencesPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read experiences: %w", err)
+	}
+
+	var experiences []Experience
+	lines := splitLines(data)
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var exp Experience
+		if unmarshalErr := json.Unmarshal(line, &exp); unmarshalErr != nil {
+			continue // Skip malformed lines
+		}
+		experiences = append(experiences, exp)
+	}
+
+	return experiences, nil
+}
+
+// GetLearnings reads the learnings.md file content.
+func (s *Store) GetLearnings() (string, error) {
+	data, err := os.ReadFile(s.learningsPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read learnings: %w", err)
+	}
+	return string(data), nil
+}
+
+// MemoryDir returns the path to the agent's memory directory.
+func (s *Store) MemoryDir() string {
+	return s.memoryDir
+}
+
+func (s *Store) experiencesPath() string {
+	return filepath.Join(s.memoryDir, "experiences.jsonl")
+}
+
+func (s *Store) learningsPath() string {
+	return filepath.Join(s.memoryDir, "learnings.md")
+}
+
+// splitLines splits byte data into lines.
+func splitLines(data []byte) [][]byte {
+	var lines [][]byte
+	start := 0
+	for i, b := range data {
+		if b == '\n' {
+			lines = append(lines, data[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		lines = append(lines, data[start:])
+	}
+	return lines
+}

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -1,0 +1,240 @@
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStore_Init(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Check directory exists
+	if !store.Exists() {
+		t.Error("memory directory should exist after Init")
+	}
+
+	// Check experiences.jsonl exists
+	experiencesPath := filepath.Join(store.MemoryDir(), "experiences.jsonl")
+	if _, err := os.Stat(experiencesPath); os.IsNotExist(err) {
+		t.Error("experiences.jsonl should exist after Init")
+	}
+
+	// Check learnings.md exists
+	learningsPath := filepath.Join(store.MemoryDir(), "learnings.md")
+	if _, err := os.Stat(learningsPath); os.IsNotExist(err) {
+		t.Error("learnings.md should exist after Init")
+	}
+
+	// Check learnings.md has initial content
+	content, err := os.ReadFile(learningsPath) //nolint:gosec // test file path
+	if err != nil {
+		t.Fatalf("failed to read learnings.md: %v", err)
+	}
+	if len(content) == 0 {
+		t.Error("learnings.md should have initial content")
+	}
+}
+
+func TestStore_InitIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+
+	// Init twice should not fail
+	if err := store.Init(); err != nil {
+		t.Fatalf("first init failed: %v", err)
+	}
+	if err := store.Init(); err != nil {
+		t.Fatalf("second init failed: %v", err)
+	}
+}
+
+func TestStore_RecordExperience(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	exp := Experience{
+		TaskID:      "work-123",
+		TaskType:    "code",
+		Description: "Implemented feature X",
+		Outcome:     "success",
+		Learnings:   []string{"Use context for cancellation"},
+	}
+
+	if err := store.RecordExperience(exp); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	// Read back
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+
+	if len(experiences) != 1 {
+		t.Fatalf("expected 1 experience, got %d", len(experiences))
+	}
+
+	if experiences[0].TaskID != "work-123" {
+		t.Errorf("expected task ID 'work-123', got %q", experiences[0].TaskID)
+	}
+	if experiences[0].Outcome != "success" {
+		t.Errorf("expected outcome 'success', got %q", experiences[0].Outcome)
+	}
+}
+
+func TestStore_RecordMultipleExperiences(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		exp := Experience{
+			TaskID:      "task-" + string(rune('A'+i)),
+			Description: "Task description",
+			Outcome:     "success",
+		}
+		if err := store.RecordExperience(exp); err != nil {
+			t.Fatalf("failed to record experience %d: %v", i, err)
+		}
+	}
+
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+
+	if len(experiences) != 3 {
+		t.Errorf("expected 3 experiences, got %d", len(experiences))
+	}
+}
+
+func TestStore_AddLearning(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	if err := store.AddLearning("Testing", "Always write tests first"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+
+	content, err := store.GetLearnings()
+	if err != nil {
+		t.Fatalf("failed to get learnings: %v", err)
+	}
+
+	if !contains(content, "Testing") {
+		t.Error("learnings should contain 'Testing'")
+	}
+	if !contains(content, "Always write tests first") {
+		t.Error("learnings should contain the learning text")
+	}
+}
+
+func TestStore_ExperienceTimestamp(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	before := time.Now().UTC().Add(-time.Second)
+
+	exp := Experience{
+		Description: "Test task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(exp); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	after := time.Now().UTC().Add(time.Second)
+
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+
+	if len(experiences) != 1 {
+		t.Fatalf("expected 1 experience, got %d", len(experiences))
+	}
+
+	ts := experiences[0].Timestamp
+	if ts.Before(before) || ts.After(after) {
+		t.Errorf("timestamp %v should be between %v and %v", ts, before, after)
+	}
+}
+
+func TestStore_Exists(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+
+	if store.Exists() {
+		t.Error("store should not exist before Init")
+	}
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	if !store.Exists() {
+		t.Error("store should exist after Init")
+	}
+}
+
+func TestStore_GetExperiencesEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+
+	if len(experiences) != 0 {
+		t.Errorf("expected 0 experiences, got %d", len(experiences))
+	}
+}
+
+func TestStore_GetExperiencesNonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "nonexistent")
+
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("should not error for nonexistent: %v", err)
+	}
+
+	if experiences != nil {
+		t.Errorf("expected nil experiences, got %v", experiences)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Adds `pkg/memory` package for per-agent memory storage:
- `Store` type for managing agent memory
- `Experience` struct for task outcomes (JSONL format)
- `learnings.md` for accumulated insights
- Directory structure: `.bc/memory/<agent-name>/`

## Features

- `Init()` - Creates memory directory on agent spawn
- `RecordExperience()` - Appends task outcomes to experiences.jsonl
- `AddLearning()` - Appends insights to learnings.md
- `GetExperiences()` / `GetLearnings()` - Retrieval methods
- Idempotent initialization

## Test plan

- [x] 9 tests covering all operations
- [x] golangci-lint passes with 0 issues
- [x] All existing tests pass

Part of Epic #27 (Agent Memory System)
Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)