### PR TITLE
feat: add #reviews channel on bc up

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -482,14 +482,21 @@ func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames
 	qaMembers = append(qaMembers, "manager")
 	qaMembers = append(qaMembers, qaNames...)
 
+	// Reviews channel: tech-leads, manager, and engineers for PR review workflow
+	reviewsMembers := make([]string, 0, 1+len(techLeadNames)+len(engineerNames))
+	reviewsMembers = append(reviewsMembers, "manager")
+	reviewsMembers = append(reviewsMembers, techLeadNames...)
+	reviewsMembers = append(reviewsMembers, engineerNames...)
+
 	// Group channels + per-agent channels
-	// Preallocate: 5 group channels + 1 per agent
-	channels := make([]chanDef, 0, 5+len(allAgents))
+	// Preallocate: 6 group channels + 1 per agent
+	channels := make([]chanDef, 0, 6+len(allAgents))
 	channels = append(channels,
 		chanDef{name: "standup", description: "Daily standup channel", channelType: channel.ChannelTypeGroup, members: allAgents},
 		chanDef{name: "leadership", description: "Leadership coordination", channelType: channel.ChannelTypeGroup, members: leadershipMembers},
 		chanDef{name: "engineering", description: "Engineering team channel", channelType: channel.ChannelTypeGroup, members: engineeringMembers},
 		chanDef{name: "qa", description: "QA team channel", channelType: channel.ChannelTypeGroup, members: qaMembers},
+		chanDef{name: "reviews", description: "PR review requests and approvals", channelType: channel.ChannelTypeGroup, members: reviewsMembers},
 		chanDef{name: "all", description: "Broadcast channel for announcements", channelType: channel.ChannelTypeGroup, members: allAgents},
 	)
 
@@ -530,7 +537,7 @@ func createDefaultChannels(rootDir string, techLeadNames, engineerNames, qaNames
 	}
 
 	if created > 0 {
-		fmt.Printf("Created %d channels (%d group + %d per-agent)\n", created, min(created, 5), max(0, created-5))
+		fmt.Printf("Created %d channels (%d group + %d per-agent)\n", created, min(created, 6), max(0, created-6))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `#reviews` channel auto-creation on `bc up`
- Members include manager, tech-leads, and engineers for PR review workflow
- Part of Epic #24: Channel-based PR Workflow

## Changes
- Updated `createDefaultChannels()` to include `#reviews` channel
- Channel description: "PR review requests and approvals"
- Members: manager + tech-leads + engineers

## Test plan
- [x] Build passes: `go build ./...`
- [x] Tests pass: `go test ./internal/cmd/...`
- [x] golangci-lint passes
- [ ] Manual test: Run `bc up` and verify `#reviews` channel exists

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)