### PR TITLE
feat: add approval and merge notification message parsing

### DIFF
--- a/pkg/channel/approval_message.go
+++ b/pkg/channel/approval_message.go
@@ -1,0 +1,257 @@
+// Package channel - approval_message.go provides PR approval message parsing and formatting.
+package channel
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ApprovalStatus represents the status of a PR review.
+type ApprovalStatus string
+
+const (
+	// StatusApproved indicates the PR was approved.
+	StatusApproved ApprovalStatus = "approved"
+
+	// StatusChangesRequested indicates changes are needed.
+	StatusChangesRequested ApprovalStatus = "changes_requested"
+
+	// StatusCommented indicates a comment without approval/rejection.
+	StatusCommented ApprovalStatus = "commented"
+)
+
+// ApprovalMessage represents a parsed PR approval/review message.
+type ApprovalMessage struct {
+	// Reviewer is the name of the reviewer
+	Reviewer string `json:"reviewer,omitempty"`
+
+	// Comment is any additional comment
+	Comment string `json:"comment,omitempty"`
+
+	// Raw is the original message content
+	Raw string `json:"raw"`
+
+	// Status is the approval status
+	Status ApprovalStatus `json:"status"`
+
+	// PRNumber is the pull request number
+	PRNumber int `json:"pr_number"`
+}
+
+// approvalPatterns matches approval keywords
+var approvalPatterns = []string{
+	"approved",
+	"lgtm",
+	"looks good",
+	"ship it",
+	"✅",
+	"👍",
+}
+
+// changesPatterns matches change request keywords
+var changesPatterns = []string{
+	"needs changes",
+	"changes requested",
+	"please fix",
+	"needs work",
+	"❌",
+	"👎",
+}
+
+// ParseApprovalMessage parses an approval/review message.
+// Expected formats:
+//   - "PR #123 approved ✓"
+//   - "LGTM PR #456"
+//   - "PR #789 needs changes: please fix X"
+//
+// Returns nil if the message doesn't appear to be an approval message.
+func ParseApprovalMessage(content string) *ApprovalMessage {
+	lower := strings.ToLower(content)
+
+	// Try to extract PR number first
+	prMatch := prNumberRegex.FindStringSubmatch(content)
+	if prMatch == nil {
+		return nil
+	}
+
+	prNumber, err := strconv.Atoi(prMatch[1])
+	if err != nil {
+		return nil
+	}
+
+	msg := &ApprovalMessage{
+		PRNumber: prNumber,
+		Raw:      content,
+		Status:   StatusCommented, // Default
+	}
+
+	// Check for approval patterns
+	for _, pattern := range approvalPatterns {
+		if strings.Contains(lower, pattern) {
+			msg.Status = StatusApproved
+			break
+		}
+	}
+
+	// Check for changes requested patterns (takes precedence)
+	for _, pattern := range changesPatterns {
+		if strings.Contains(lower, pattern) {
+			msg.Status = StatusChangesRequested
+			break
+		}
+	}
+
+	// Only return if it's actually an approval-related message
+	if msg.Status == StatusCommented {
+		// Check if it has any review-related context
+		if !strings.Contains(lower, "review") &&
+			!strings.Contains(lower, "pr") &&
+			!strings.Contains(lower, "comment") {
+			return nil
+		}
+	}
+
+	// Extract reviewer from @mention
+	mentions := mentionRegex.FindAllStringSubmatch(content, -1)
+	if len(mentions) > 0 {
+		msg.Reviewer = mentions[0][1]
+	}
+
+	return msg
+}
+
+// FormatApprovalMessage creates a standardized approval message.
+// Format: "PR #<number> approved ✓"
+func FormatApprovalMessage(prNumber int, status ApprovalStatus) string {
+	switch status {
+	case StatusApproved:
+		return fmt.Sprintf("PR #%d approved ✓", prNumber)
+	case StatusChangesRequested:
+		return fmt.Sprintf("PR #%d needs changes", prNumber)
+	default:
+		return fmt.Sprintf("PR #%d reviewed", prNumber)
+	}
+}
+
+// FormatApprovalWithComment includes a comment with the approval.
+func FormatApprovalWithComment(prNumber int, status ApprovalStatus, comment string) string {
+	base := FormatApprovalMessage(prNumber, status)
+	if comment == "" {
+		return base
+	}
+	return fmt.Sprintf("%s: %s", base, comment)
+}
+
+// NewApprovalMessage creates a TypedMessage for an approval.
+func NewApprovalMessage(prNumber int, status ApprovalStatus, sender string) *TypedMessage {
+	content := FormatApprovalMessage(prNumber, status)
+	msg := NewTypedMessage(content, TypeApproval, sender)
+	msg.WithMetadata("pr_number", strconv.Itoa(prNumber))
+	msg.WithMetadata("status", string(status))
+	return msg
+}
+
+// IsApprovalMessage checks if a message content looks like an approval.
+func IsApprovalMessage(content string) bool {
+	return ParseApprovalMessage(content) != nil
+}
+
+// IsApproved checks if a message indicates PR approval.
+func IsApproved(content string) bool {
+	msg := ParseApprovalMessage(content)
+	return msg != nil && msg.Status == StatusApproved
+}
+
+// IsChangesRequested checks if a message indicates changes are needed.
+func IsChangesRequested(content string) bool {
+	msg := ParseApprovalMessage(content)
+	return msg != nil && msg.Status == StatusChangesRequested
+}
+
+// MergeNotification represents a parsed merge notification message.
+type MergeNotification struct {
+	// Branch is the target branch (e.g., "main")
+	Branch string `json:"branch,omitempty"`
+
+	// MergedBy is who performed the merge
+	MergedBy string `json:"merged_by,omitempty"`
+
+	// Raw is the original message content
+	Raw string `json:"raw"`
+
+	// PRNumber is the pull request number
+	PRNumber int `json:"pr_number"`
+}
+
+// mergePatterns matches merge-related keywords
+var mergePatterns = regexp.MustCompile(`(?i)(?:merged|merge(?:d)?(?:\s+to)?|pushed to)`)
+
+// ParseMergeNotification parses a merge notification message.
+// Expected formats:
+//   - "PR #123 merged to main"
+//   - "Merged PR #456"
+//   - "#789 pushed to main"
+//
+// Returns nil if the message doesn't appear to be a merge notification.
+func ParseMergeNotification(content string) *MergeNotification {
+	// Must contain merge-related keywords
+	if !mergePatterns.MatchString(content) {
+		return nil
+	}
+
+	// Try to extract PR number
+	prMatch := prNumberRegex.FindStringSubmatch(content)
+	if prMatch == nil {
+		return nil
+	}
+
+	prNumber, err := strconv.Atoi(prMatch[1])
+	if err != nil {
+		return nil
+	}
+
+	msg := &MergeNotification{
+		PRNumber: prNumber,
+		Raw:      content,
+	}
+
+	// Extract target branch
+	branchMatch := regexp.MustCompile(`(?i)(?:to|into)\s+(\w+)`).FindStringSubmatch(content)
+	if branchMatch != nil {
+		msg.Branch = branchMatch[1]
+	}
+
+	// Extract who merged from @mention
+	mentions := mentionRegex.FindAllStringSubmatch(content, -1)
+	if len(mentions) > 0 {
+		msg.MergedBy = mentions[0][1]
+	}
+
+	return msg
+}
+
+// FormatMergeNotification creates a standardized merge notification.
+func FormatMergeNotification(prNumber int, branch string) string {
+	if branch == "" {
+		branch = "main"
+	}
+	return fmt.Sprintf("PR #%d merged to %s", prNumber, branch)
+}
+
+// NewMergeNotificationMessage creates a TypedMessage for a merge.
+func NewMergeNotificationMessage(prNumber int, branch, sender string) *TypedMessage {
+	content := FormatMergeNotification(prNumber, branch)
+	msg := NewTypedMessage(content, TypeMerge, sender)
+	msg.WithMetadata("pr_number", strconv.Itoa(prNumber))
+	if branch != "" {
+		msg.WithMetadata("branch", branch)
+	}
+	return msg
+}
+
+// IsMergeNotification checks if a message looks like a merge notification.
+func IsMergeNotification(content string) bool {
+	return ParseMergeNotification(content) != nil
+}

--- a/pkg/channel/approval_message_test.go
+++ b/pkg/channel/approval_message_test.go
@@ -1,0 +1,339 @@
+package channel
+
+import (
+	"testing"
+)
+
+func TestParseApprovalMessage(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantStatus ApprovalStatus
+		wantPR     int
+		wantNil    bool
+	}{
+		{
+			name:       "approved with checkmark",
+			input:      "PR #123 approved ✓",
+			wantPR:     123,
+			wantStatus: StatusApproved,
+		},
+		{
+			name:       "lgtm",
+			input:      "LGTM PR #456",
+			wantPR:     456,
+			wantStatus: StatusApproved,
+		},
+		{
+			name:       "looks good",
+			input:      "PR #789 looks good to me",
+			wantPR:     789,
+			wantStatus: StatusApproved,
+		},
+		{
+			name:       "needs changes",
+			input:      "PR #100 needs changes: fix the tests",
+			wantPR:     100,
+			wantStatus: StatusChangesRequested,
+		},
+		{
+			name:       "please fix",
+			input:      "PR #200 please fix the formatting",
+			wantPR:     200,
+			wantStatus: StatusChangesRequested,
+		},
+		{
+			name:       "emoji approval",
+			input:      "PR #300 ✅",
+			wantPR:     300,
+			wantStatus: StatusApproved,
+		},
+		{
+			name:    "not an approval",
+			input:   "Hello world",
+			wantNil: true,
+		},
+		{
+			name:    "no PR number",
+			input:   "LGTM on this change",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := ParseApprovalMessage(tt.input)
+			if tt.wantNil {
+				if msg != nil {
+					t.Errorf("expected nil, got %+v", msg)
+				}
+				return
+			}
+			if msg == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if msg.PRNumber != tt.wantPR {
+				t.Errorf("PRNumber = %d, want %d", msg.PRNumber, tt.wantPR)
+			}
+			if msg.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", msg.Status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestFormatApprovalMessage(t *testing.T) {
+	tests := []struct {
+		name     string
+		want     string
+		status   ApprovalStatus
+		prNumber int
+	}{
+		{
+			name:     "approved",
+			prNumber: 123,
+			status:   StatusApproved,
+			want:     "PR #123 approved ✓",
+		},
+		{
+			name:     "changes requested",
+			prNumber: 456,
+			status:   StatusChangesRequested,
+			want:     "PR #456 needs changes",
+		},
+		{
+			name:     "commented",
+			prNumber: 789,
+			status:   StatusCommented,
+			want:     "PR #789 reviewed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatApprovalMessage(tt.prNumber, tt.status)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatApprovalWithComment(t *testing.T) {
+	got := FormatApprovalWithComment(123, StatusApproved, "Great work!")
+	want := "PR #123 approved ✓: Great work!"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// Empty comment
+	got = FormatApprovalWithComment(456, StatusChangesRequested, "")
+	want = "PR #456 needs changes"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestNewApprovalMessage(t *testing.T) {
+	msg := NewApprovalMessage(123, StatusApproved, "tech-lead-01")
+
+	if msg.Type != TypeApproval {
+		t.Errorf("Type = %v, want %v", msg.Type, TypeApproval)
+	}
+	if msg.Sender != "tech-lead-01" {
+		t.Errorf("Sender = %q, want %q", msg.Sender, "tech-lead-01")
+	}
+	if msg.Metadata["pr_number"] != "123" {
+		t.Errorf("pr_number metadata = %q, want %q", msg.Metadata["pr_number"], "123")
+	}
+	if msg.Metadata["status"] != string(StatusApproved) {
+		t.Errorf("status metadata = %q, want %q", msg.Metadata["status"], string(StatusApproved))
+	}
+}
+
+func TestIsApproved(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"PR #123 approved ✓", true},
+		{"LGTM PR #456", true},
+		{"PR #789 needs changes", false},
+		{"Hello world", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := IsApproved(tt.input); got != tt.want {
+				t.Errorf("IsApproved(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsChangesRequested(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"PR #123 needs changes", true},
+		{"PR #456 please fix the tests", true},
+		{"PR #789 approved ✓", false},
+		{"Hello world", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := IsChangesRequested(tt.input); got != tt.want {
+				t.Errorf("IsChangesRequested(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMergeNotification(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantBranch string
+		wantPR     int
+		wantNil    bool
+	}{
+		{
+			name:       "merged to main",
+			input:      "PR #123 merged to main",
+			wantPR:     123,
+			wantBranch: "main",
+		},
+		{
+			name:       "merged PR",
+			input:      "Merged PR #456",
+			wantPR:     456,
+			wantBranch: "",
+		},
+		{
+			name:       "pushed to develop",
+			input:      "PR #789 pushed to develop",
+			wantPR:     789,
+			wantBranch: "develop",
+		},
+		{
+			name:    "not a merge",
+			input:   "PR #100 approved",
+			wantNil: true,
+		},
+		{
+			name:    "no PR number",
+			input:   "Merged to main",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := ParseMergeNotification(tt.input)
+			if tt.wantNil {
+				if msg != nil {
+					t.Errorf("expected nil, got %+v", msg)
+				}
+				return
+			}
+			if msg == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if msg.PRNumber != tt.wantPR {
+				t.Errorf("PRNumber = %d, want %d", msg.PRNumber, tt.wantPR)
+			}
+			if msg.Branch != tt.wantBranch {
+				t.Errorf("Branch = %q, want %q", msg.Branch, tt.wantBranch)
+			}
+		})
+	}
+}
+
+func TestFormatMergeNotification(t *testing.T) {
+	tests := []struct {
+		branch   string
+		want     string
+		prNumber int
+	}{
+		{"main", "PR #123 merged to main", 123},
+		{"develop", "PR #456 merged to develop", 456},
+		{"", "PR #789 merged to main", 789}, // default to main
+	}
+
+	for _, tt := range tests {
+		got := FormatMergeNotification(tt.prNumber, tt.branch)
+		if got != tt.want {
+			t.Errorf("FormatMergeNotification(%d, %q) = %q, want %q",
+				tt.prNumber, tt.branch, got, tt.want)
+		}
+	}
+}
+
+func TestNewMergeNotificationMessage(t *testing.T) {
+	msg := NewMergeNotificationMessage(123, "main", "manager")
+
+	if msg.Type != TypeMerge {
+		t.Errorf("Type = %v, want %v", msg.Type, TypeMerge)
+	}
+	if msg.Sender != "manager" {
+		t.Errorf("Sender = %q, want %q", msg.Sender, "manager")
+	}
+	if msg.Metadata["pr_number"] != "123" {
+		t.Errorf("pr_number metadata = %q, want %q", msg.Metadata["pr_number"], "123")
+	}
+	if msg.Metadata["branch"] != "main" {
+		t.Errorf("branch metadata = %q, want %q", msg.Metadata["branch"], "main")
+	}
+}
+
+func TestIsMergeNotification(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"PR #123 merged to main", true},
+		{"Merged PR #456", true},
+		{"PR #789 approved ✓", false},
+		{"Hello world", false},
+	}
+
+	for _, tt := range tests {
+		if got := IsMergeNotification(tt.input); got != tt.want {
+			t.Errorf("IsMergeNotification(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestApprovalRoundTrip(t *testing.T) {
+	// Format a message, then parse it back
+	formatted := FormatApprovalMessage(123, StatusApproved)
+	parsed := ParseApprovalMessage(formatted)
+
+	if parsed == nil {
+		t.Fatal("failed to parse formatted approval")
+	}
+	if parsed.PRNumber != 123 {
+		t.Errorf("PRNumber = %d, want 123", parsed.PRNumber)
+	}
+	if parsed.Status != StatusApproved {
+		t.Errorf("Status = %v, want %v", parsed.Status, StatusApproved)
+	}
+}
+
+func TestMergeRoundTrip(t *testing.T) {
+	// Format a message, then parse it back
+	formatted := FormatMergeNotification(456, "main")
+	parsed := ParseMergeNotification(formatted)
+
+	if parsed == nil {
+		t.Fatal("failed to parse formatted merge notification")
+	}
+	if parsed.PRNumber != 456 {
+		t.Errorf("PRNumber = %d, want 456", parsed.PRNumber)
+	}
+	if parsed.Branch != "main" {
+		t.Errorf("Branch = %q, want %q", parsed.Branch, "main")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/channel/approval_message.go` for approval and merge message parsing
- Completes more of Epic #24: Channel-based PR Workflow
- Extends the PR workflow message format capabilities

## Features
### Approval Messages
- **ParseApprovalMessage()** - Detects approvals and change requests
- **FormatApprovalMessage()** - Creates standardized approval messages
- **IsApproved()** / **IsChangesRequested()** - Quick status checks
- Supports patterns: "LGTM", "approved ✓", "looks good", "needs changes"

### Merge Notifications
- **ParseMergeNotification()** - Detects merge notifications
- **FormatMergeNotification()** - Creates standardized merge messages
- **IsMergeNotification()** - Quick check
- Supports patterns: "merged to main", "Merged PR #X"

## Test plan
- [x] All approval parsing tests pass
- [x] All merge notification tests pass
- [x] Round-trip tests pass (format → parse → verify)
- [x] golangci-lint passes
- [x] Full test suite passes

Part of Epic #24: Channel-based PR Workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)