### PR TITLE
feat: add bc memory CLI commands

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -1,0 +1,328 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rpuneet/bc/pkg/memory"
+)
+
+var memoryCmd = &cobra.Command{
+	Use:   "memory",
+	Short: "Manage agent memory (experiences and learnings)",
+	Long: `Commands for managing per-agent memory storage.
+
+Each agent has a memory directory at .bc/memory/<agent-name>/ containing:
+  - experiences.jsonl: Recorded task outcomes
+  - learnings.md: Accumulated insights
+
+Example:
+  bc memory record "Fixed auth bug"         # Record experience
+  bc memory learn "patterns" "Always test"  # Add learning
+  bc memory show                            # Show memory for current agent
+  bc memory show engineer-01                # Show specific agent's memory
+  bc memory search "auth"                   # Search memories`,
+}
+
+var memoryRecordCmd = &cobra.Command{
+	Use:   "record <description>",
+	Short: "Record an experience to memory",
+	Long: `Record a task outcome or experience to the agent's memory.
+
+Requires BC_AGENT_ID environment variable to be set.
+
+Example:
+  bc memory record "Fixed auth bug - used JWT tokens"
+  bc memory record --outcome success "Implemented feature X"
+  bc memory record --task-id TASK-123 "Completed task"`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMemoryRecord,
+}
+
+var memoryLearnCmd = &cobra.Command{
+	Use:   "learn <category> <learning>",
+	Short: "Add a learning to memory",
+	Long: `Add an insight or learning to the agent's memory.
+
+Requires BC_AGENT_ID environment variable to be set.
+
+Categories: patterns, anti-patterns, tips, gotchas
+
+Example:
+  bc memory learn patterns "Always check error returns"
+  bc memory learn tips "Use context for cancellation"
+  bc memory learn anti-patterns "Don't ignore errors"`,
+	Args: cobra.ExactArgs(2),
+	RunE: runMemoryLearn,
+}
+
+var memoryShowCmd = &cobra.Command{
+	Use:   "show [agent]",
+	Short: "Show agent memory",
+	Long: `Display the memory contents for an agent.
+
+If no agent is specified, uses BC_AGENT_ID environment variable.
+
+Example:
+  bc memory show                # Show current agent's memory
+  bc memory show engineer-01    # Show specific agent's memory
+  bc memory show --experiences  # Show only experiences
+  bc memory show --learnings    # Show only learnings`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runMemoryShow,
+}
+
+var memorySearchCmd = &cobra.Command{
+	Use:   "search <query>",
+	Short: "Search agent memories",
+	Long: `Search through experiences and learnings for matching content.
+
+Example:
+  bc memory search "auth"
+  bc memory search --agent engineer-01 "bug"`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMemorySearch,
+}
+
+var (
+	memoryOutcome     string
+	memoryTaskID      string
+	memoryTaskType    string
+	memoryShowExp     bool
+	memoryShowLearn   bool
+	memorySearchAgent string
+)
+
+func init() {
+	memoryRecordCmd.Flags().StringVar(&memoryOutcome, "outcome", "success", "Outcome of the task (success, failure, partial)")
+	memoryRecordCmd.Flags().StringVar(&memoryTaskID, "task-id", "", "Task ID for the experience")
+	memoryRecordCmd.Flags().StringVar(&memoryTaskType, "task-type", "", "Task type (code, review, qa, etc.)")
+
+	memoryShowCmd.Flags().BoolVar(&memoryShowExp, "experiences", false, "Show only experiences")
+	memoryShowCmd.Flags().BoolVar(&memoryShowLearn, "learnings", false, "Show only learnings")
+
+	memorySearchCmd.Flags().StringVar(&memorySearchAgent, "agent", "", "Search specific agent's memory")
+
+	memoryCmd.AddCommand(memoryRecordCmd)
+	memoryCmd.AddCommand(memoryLearnCmd)
+	memoryCmd.AddCommand(memoryShowCmd)
+	memoryCmd.AddCommand(memorySearchCmd)
+	rootCmd.AddCommand(memoryCmd)
+}
+
+func runMemoryRecord(cmd *cobra.Command, args []string) error {
+	agentID := os.Getenv("BC_AGENT_ID")
+	if agentID == "" {
+		return fmt.Errorf("BC_AGENT_ID not set (this command is meant to be called by agents)")
+	}
+
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	store := memory.NewStore(ws.RootDir, agentID)
+	if !store.Exists() {
+		if initErr := store.Init(); initErr != nil {
+			return fmt.Errorf("failed to initialize memory: %w", initErr)
+		}
+	}
+
+	exp := memory.Experience{
+		Description: args[0],
+		Outcome:     memoryOutcome,
+		TaskID:      memoryTaskID,
+		TaskType:    memoryTaskType,
+	}
+
+	if err := store.RecordExperience(exp); err != nil {
+		return fmt.Errorf("failed to record experience: %w", err)
+	}
+
+	fmt.Printf("Recorded experience: %s\n", args[0])
+	return nil
+}
+
+func runMemoryLearn(cmd *cobra.Command, args []string) error {
+	agentID := os.Getenv("BC_AGENT_ID")
+	if agentID == "" {
+		return fmt.Errorf("BC_AGENT_ID not set (this command is meant to be called by agents)")
+	}
+
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	category := args[0]
+	learning := args[1]
+
+	store := memory.NewStore(ws.RootDir, agentID)
+	if !store.Exists() {
+		if initErr := store.Init(); initErr != nil {
+			return fmt.Errorf("failed to initialize memory: %w", initErr)
+		}
+	}
+
+	if err := store.AddLearning(category, learning); err != nil {
+		return fmt.Errorf("failed to add learning: %w", err)
+	}
+
+	fmt.Printf("Added learning (%s): %s\n", category, learning)
+	return nil
+}
+
+func runMemoryShow(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	// Determine which agent's memory to show
+	agentID := ""
+	if len(args) > 0 {
+		agentID = args[0]
+	} else {
+		agentID = os.Getenv("BC_AGENT_ID")
+		if agentID == "" {
+			return fmt.Errorf("specify an agent name or set BC_AGENT_ID")
+		}
+	}
+
+	store := memory.NewStore(ws.RootDir, agentID)
+	if !store.Exists() {
+		fmt.Printf("No memory found for agent %s\n", agentID)
+		return nil
+	}
+
+	showBoth := !memoryShowExp && !memoryShowLearn
+
+	// Show experiences
+	if showBoth || memoryShowExp {
+		experiences, err := store.GetExperiences()
+		if err != nil {
+			return fmt.Errorf("failed to get experiences: %w", err)
+		}
+
+		fmt.Printf("=== %s Experiences ===\n\n", agentID)
+		if len(experiences) == 0 {
+			fmt.Println("No experiences recorded.")
+			fmt.Println()
+		} else {
+			for i, exp := range experiences {
+				fmt.Printf("%d. [%s] %s\n", i+1, exp.Outcome, exp.Description)
+				if exp.TaskID != "" {
+					fmt.Printf("   Task: %s", exp.TaskID)
+					if exp.TaskType != "" {
+						fmt.Printf(" (%s)", exp.TaskType)
+					}
+					fmt.Println()
+				}
+				if !exp.Timestamp.IsZero() {
+					fmt.Printf("   Time: %s\n", exp.Timestamp.Format("2006-01-02 15:04:05"))
+				}
+			}
+			fmt.Println()
+		}
+	}
+
+	// Show learnings
+	if showBoth || memoryShowLearn {
+		learnings, err := store.GetLearnings()
+		if err != nil {
+			return fmt.Errorf("failed to get learnings: %w", err)
+		}
+
+		fmt.Printf("=== %s Learnings ===\n\n", agentID)
+		if learnings == "" {
+			fmt.Println("No learnings recorded.")
+			fmt.Println()
+		} else {
+			fmt.Println(learnings)
+		}
+	}
+
+	return nil
+}
+
+func runMemorySearch(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	query := strings.ToLower(args[0])
+
+	// Determine which agents to search
+	var agents []string
+	if memorySearchAgent != "" {
+		agents = []string{memorySearchAgent}
+	} else {
+		// Search all agents with memory directories
+		memoryRoot := filepath.Join(ws.RootDir, ".bc", "memory")
+		entries, err := os.ReadDir(memoryRoot)
+		if err != nil {
+			if os.IsNotExist(err) {
+				fmt.Println("No agent memories found")
+				return nil
+			}
+			return fmt.Errorf("failed to read memory directory: %w", err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				agents = append(agents, entry.Name())
+			}
+		}
+	}
+
+	if len(agents) == 0 {
+		fmt.Println("No agent memories found")
+		return nil
+	}
+
+	found := false
+	for _, agentID := range agents {
+		store := memory.NewStore(ws.RootDir, agentID)
+
+		// Search experiences
+		experiences, _ := store.GetExperiences()
+		for _, exp := range experiences {
+			if strings.Contains(strings.ToLower(exp.Description), query) ||
+				strings.Contains(strings.ToLower(exp.Outcome), query) {
+				if !found {
+					fmt.Println("=== Search Results ===")
+					fmt.Println()
+					found = true
+				}
+				fmt.Printf("[%s] Experience: %s\n", agentID, exp.Description)
+				fmt.Printf("  Outcome: %s\n", exp.Outcome)
+				fmt.Println()
+			}
+		}
+
+		// Search learnings
+		learnings, _ := store.GetLearnings()
+		lines := strings.Split(learnings, "\n")
+		for i, line := range lines {
+			if strings.Contains(strings.ToLower(line), query) {
+				if !found {
+					fmt.Println("=== Search Results ===")
+					fmt.Println()
+					found = true
+				}
+				// Print context: the line and surrounding lines
+				fmt.Printf("[%s] Learnings (line %d): %s\n\n", agentID, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+
+	if !found {
+		fmt.Printf("No results found for '%s'\n", args[0])
+	}
+
+	return nil
+}

--- a/internal/cmd/memory_test.go
+++ b/internal/cmd/memory_test.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/memory"
+)
+
+func TestMemoryRecord(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Set agent ID
+	_ = os.Setenv("BC_AGENT_ID", "test-agent")
+	defer func() { _ = os.Unsetenv("BC_AGENT_ID") }()
+
+	output, err := executeCmd("memory", "record", "--outcome", "success", "Fixed a bug")
+	if err != nil {
+		t.Fatalf("memory record failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Recorded experience") {
+		t.Errorf("expected confirmation message, got: %s", output)
+	}
+
+	// Verify experience was recorded
+	store := memory.NewStore(wsDir, "test-agent")
+	exps, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+	if len(exps) != 1 {
+		t.Fatalf("expected 1 experience, got %d", len(exps))
+	}
+	if exps[0].Description != "Fixed a bug" {
+		t.Errorf("unexpected description: %s", exps[0].Description)
+	}
+	if exps[0].Outcome != "success" {
+		t.Errorf("unexpected outcome: %s", exps[0].Outcome)
+	}
+}
+
+func TestMemoryLearn(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Set agent ID
+	_ = os.Setenv("BC_AGENT_ID", "test-agent")
+	defer func() { _ = os.Unsetenv("BC_AGENT_ID") }()
+
+	output, err := executeCmd("memory", "learn", "patterns", "Always check errors")
+	if err != nil {
+		t.Fatalf("memory learn failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Added learning") {
+		t.Errorf("expected confirmation message, got: %s", output)
+	}
+
+	// Verify learning was added
+	store := memory.NewStore(wsDir, "test-agent")
+	learnings, err := store.GetLearnings()
+	if err != nil {
+		t.Fatalf("failed to get learnings: %v", err)
+	}
+	if !strings.Contains(learnings, "patterns") {
+		t.Errorf("learnings should contain category 'patterns': %s", learnings)
+	}
+	if !strings.Contains(learnings, "Always check errors") {
+		t.Errorf("learnings should contain the learning: %s", learnings)
+	}
+}
+
+func TestMemoryShow(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Set agent ID
+	_ = os.Setenv("BC_AGENT_ID", "test-agent")
+	defer func() { _ = os.Unsetenv("BC_AGENT_ID") }()
+
+	// Initialize memory with some content
+	store := memory.NewStore(wsDir, "test-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+	if err := store.RecordExperience(memory.Experience{
+		Description: "Test experience",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+	if err := store.AddLearning("tips", "Test tip"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+
+	output, err := executeCmd("memory", "show")
+	if err != nil {
+		t.Fatalf("memory show failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Experiences") {
+		t.Errorf("output should contain 'Experiences': %s", output)
+	}
+	if !strings.Contains(output, "Test experience") {
+		t.Errorf("output should contain the experience: %s", output)
+	}
+	if !strings.Contains(output, "Learnings") {
+		t.Errorf("output should contain 'Learnings': %s", output)
+	}
+}
+
+func TestMemoryShowSpecificAgent(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create memory for a specific agent
+	store := memory.NewStore(wsDir, "other-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+	if err := store.RecordExperience(memory.Experience{
+		Description: "Other agent experience",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	output, err := executeCmd("memory", "show", "other-agent")
+	if err != nil {
+		t.Fatalf("memory show failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "other-agent") {
+		t.Errorf("output should reference the agent: %s", output)
+	}
+	if !strings.Contains(output, "Other agent experience") {
+		t.Errorf("output should contain the experience: %s", output)
+	}
+}
+
+func TestMemorySearch(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create memory with searchable content
+	store := memory.NewStore(wsDir, "search-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+	if err := store.RecordExperience(memory.Experience{
+		Description: "Fixed authentication bug",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	output, err := executeCmd("memory", "search", "authentication")
+	if err != nil {
+		t.Fatalf("memory search failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "authentication") {
+		t.Errorf("output should contain search result: %s", output)
+	}
+}
+
+func TestMemorySearchNoResults(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create empty memory
+	store := memory.NewStore(wsDir, "empty-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	output, err := executeCmd("memory", "search", "nonexistent")
+	if err != nil {
+		t.Fatalf("memory search failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "No results found") {
+		t.Errorf("output should indicate no results: %s", output)
+	}
+}
+
+func TestMemoryRecordRequiresAgentID(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Ensure BC_AGENT_ID is not set
+	_ = os.Unsetenv("BC_AGENT_ID")
+
+	_, err := executeCmd("memory", "record", "Test")
+	if err == nil {
+		t.Error("expected error when BC_AGENT_ID not set")
+	}
+	if !strings.Contains(err.Error(), "BC_AGENT_ID") {
+		t.Errorf("error should mention BC_AGENT_ID: %v", err)
+	}
+}
+
+func TestMemoryShowNoMemory(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Ensure the memory directory doesn't exist
+	memoryDir := filepath.Join(wsDir, ".bc", "memory", "nonexistent-agent")
+	_ = os.RemoveAll(memoryDir)
+
+	output, err := executeCmd("memory", "show", "nonexistent-agent")
+	if err != nil {
+		t.Fatalf("memory show failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "No memory found") {
+		t.Errorf("output should indicate no memory: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary
Implement memory CLI for per-agent memory management:
- `bc memory record <description>`: Record experience to experiences.jsonl
- `bc memory learn <category> <learning>`: Add learning to learnings.md
- `bc memory show [agent]`: Show agent memory contents
- `bc memory search <query>`: Search across agent memories

Closes #112

## Test plan
- [x] Build passes
- [x] All tests pass (8 new tests)
- [ ] Verify CLI help text
- [ ] Test with real agent ID

🤖 Generated with [Claude Code](https://claude.ai/code)