### PR TITLE
feat: add crash handling for root agent

### DIFF
--- a/pkg/agent/root.go
+++ b/pkg/agent/root.go
@@ -22,10 +22,15 @@ var ErrRootNotFound = errors.New("root agent not found")
 
 // RootAgentState extends AgentState with root-specific fields.
 // The root agent is special: it's the singleton entry point created by `bc up`.
+//
+//nolint:govet // embedding AgentState causes unavoidable alignment padding
 type RootAgentState struct {
 	AgentState
-	Children    []string `json:"children,omitempty"`
-	IsSingleton bool     `json:"is_singleton"`
+	Children      []string   `json:"children,omitempty"`
+	LastCrashTime *time.Time `json:"last_crash_time,omitempty"`
+	RecoveredFrom string     `json:"recovered_from,omitempty"` // session that crashed
+	CrashCount    int        `json:"crash_count,omitempty"`
+	IsSingleton   bool       `json:"is_singleton"`
 }
 
 // RootStateStore manages the root agent state file at .bc/agents/root.json
@@ -316,4 +321,90 @@ func (s *RootStateStore) GetChildren() ([]string, error) {
 		return nil, err
 	}
 	return state.Children, nil
+}
+
+// RecordCrash marks that the root agent has crashed.
+// It preserves the existing state (including children and queues) while
+// recording crash metadata for diagnostics and recovery.
+func (s *RootStateStore) RecordCrash(deadSession string) error {
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	state.State = StateStopped
+	state.CrashCount++
+	state.LastCrashTime = &now
+	state.RecoveredFrom = deadSession
+
+	return s.Save(state)
+}
+
+// RecoverFromCrash updates the root state after recovering from a crash.
+// It creates a new session while preserving existing children and work state.
+func (s *RootStateStore) RecoverFromCrash(newSession string) error {
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+
+	state.Session = newSession
+	state.State = StateIdle
+	state.UpdatedAt = time.Now()
+	// Keep CrashCount and LastCrashTime for diagnostics
+	// Clear RecoveredFrom since we've now recovered
+	state.RecoveredFrom = ""
+
+	return s.Save(state)
+}
+
+// GetCrashInfo returns crash statistics for the root agent.
+func (s *RootStateStore) GetCrashInfo() (*CrashInfo, error) {
+	state, err := s.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	return &CrashInfo{
+		CrashCount:    state.CrashCount,
+		LastCrashTime: state.LastCrashTime,
+		RecoveredFrom: state.RecoveredFrom,
+	}, nil
+}
+
+// CrashInfo contains crash statistics for the root agent.
+type CrashInfo struct {
+	LastCrashTime *time.Time
+	RecoveredFrom string
+	CrashCount    int
+}
+
+// HasCrashed returns true if the root has crashed at least once.
+func (c *CrashInfo) HasCrashed() bool {
+	return c.CrashCount > 0
+}
+
+// TimeSinceLastCrash returns the duration since the last crash.
+// Returns 0 if no crash has occurred.
+func (c *CrashInfo) TimeSinceLastCrash() time.Duration {
+	if c.LastCrashTime == nil {
+		return 0
+	}
+	return time.Since(*c.LastCrashTime)
+}
+
+// ClearCrashHistory resets crash statistics.
+// This can be called after a period of stability.
+func (s *RootStateStore) ClearCrashHistory() error {
+	state, err := s.Load()
+	if err != nil {
+		return err
+	}
+
+	state.CrashCount = 0
+	state.LastCrashTime = nil
+	state.RecoveredFrom = ""
+
+	return s.Save(state)
 }

--- a/pkg/agent/root_test.go
+++ b/pkg/agent/root_test.go
@@ -937,3 +937,218 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+// --- Crash Handling Tests ---
+
+func TestRootStateStore_RecordCrash(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Create root with a session
+	state, createErr := store.Create("root", RoleManager, "claude")
+	if createErr != nil {
+		t.Fatalf("Create failed: %v", createErr)
+	}
+	state.Session = "old-session"
+	if saveErr := store.Save(state); saveErr != nil {
+		t.Fatalf("Save failed: %v", saveErr)
+	}
+
+	// Record a crash
+	if crashErr := store.RecordCrash("old-session"); crashErr != nil {
+		t.Fatalf("RecordCrash failed: %v", crashErr)
+	}
+
+	// Verify crash was recorded
+	loaded, loadErr := store.Load()
+	if loadErr != nil {
+		t.Fatalf("Load failed: %v", loadErr)
+	}
+
+	if loaded.CrashCount != 1 {
+		t.Errorf("CrashCount = %d, want 1", loaded.CrashCount)
+	}
+	if loaded.LastCrashTime == nil {
+		t.Error("LastCrashTime should be set")
+	}
+	if loaded.RecoveredFrom != "old-session" {
+		t.Errorf("RecoveredFrom = %q, want old-session", loaded.RecoveredFrom)
+	}
+	if loaded.State != StateStopped {
+		t.Errorf("State = %q, want %q", loaded.State, StateStopped)
+	}
+}
+
+func TestRootStateStore_RecordCrash_MultipleCrashes(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, err := store.Create("root", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Record multiple crashes
+	for i := 0; i < 3; i++ {
+		if err := store.RecordCrash("session-" + string(rune('a'+i))); err != nil {
+			t.Fatalf("RecordCrash %d failed: %v", i, err)
+		}
+	}
+
+	loaded, loadErr := store.Load()
+	if loadErr != nil {
+		t.Fatalf("Load failed: %v", loadErr)
+	}
+
+	if loaded.CrashCount != 3 {
+		t.Errorf("CrashCount = %d, want 3", loaded.CrashCount)
+	}
+}
+
+func TestRootStateStore_RecoverFromCrash(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	// Create root and simulate crash
+	if _, err := store.Create("root", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if err := store.RecordCrash("crashed-session"); err != nil {
+		t.Fatalf("RecordCrash failed: %v", err)
+	}
+
+	// Recover with new session
+	if err := store.RecoverFromCrash("new-session"); err != nil {
+		t.Fatalf("RecoverFromCrash failed: %v", err)
+	}
+
+	loaded, loadErr := store.Load()
+	if loadErr != nil {
+		t.Fatalf("Load failed: %v", loadErr)
+	}
+
+	if loaded.Session != "new-session" {
+		t.Errorf("Session = %q, want new-session", loaded.Session)
+	}
+	if loaded.State != StateIdle {
+		t.Errorf("State = %q, want %q", loaded.State, StateIdle)
+	}
+	if loaded.RecoveredFrom != "" {
+		t.Errorf("RecoveredFrom should be cleared, got %q", loaded.RecoveredFrom)
+	}
+	// CrashCount should be preserved for diagnostics
+	if loaded.CrashCount != 1 {
+		t.Errorf("CrashCount = %d, want 1 (should be preserved)", loaded.CrashCount)
+	}
+}
+
+func TestRootStateStore_GetCrashInfo(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, createErr := store.Create("root", RoleManager, "claude"); createErr != nil {
+		t.Fatalf("Create failed: %v", createErr)
+	}
+
+	// No crashes yet
+	info, infoErr := store.GetCrashInfo()
+	if infoErr != nil {
+		t.Fatalf("GetCrashInfo failed: %v", infoErr)
+	}
+	if info.HasCrashed() {
+		t.Error("HasCrashed should be false initially")
+	}
+	if info.TimeSinceLastCrash() != 0 {
+		t.Error("TimeSinceLastCrash should be 0 with no crashes")
+	}
+
+	// Record a crash
+	if crashErr := store.RecordCrash("session-1"); crashErr != nil {
+		t.Fatalf("RecordCrash failed: %v", crashErr)
+	}
+
+	info, infoErr = store.GetCrashInfo()
+	if infoErr != nil {
+		t.Fatalf("GetCrashInfo failed: %v", infoErr)
+	}
+	if !info.HasCrashed() {
+		t.Error("HasCrashed should be true after crash")
+	}
+	if info.CrashCount != 1 {
+		t.Errorf("CrashCount = %d, want 1", info.CrashCount)
+	}
+	if info.TimeSinceLastCrash() <= 0 {
+		t.Error("TimeSinceLastCrash should be positive after crash")
+	}
+}
+
+func TestRootStateStore_ClearCrashHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, err := store.Create("root", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Record crashes
+	for i := 0; i < 5; i++ {
+		if err := store.RecordCrash("session"); err != nil {
+			t.Fatalf("RecordCrash failed: %v", err)
+		}
+	}
+
+	// Clear history
+	if err := store.ClearCrashHistory(); err != nil {
+		t.Fatalf("ClearCrashHistory failed: %v", err)
+	}
+
+	info, infoErr := store.GetCrashInfo()
+	if infoErr != nil {
+		t.Fatalf("GetCrashInfo failed: %v", infoErr)
+	}
+	if info.HasCrashed() {
+		t.Error("HasCrashed should be false after clearing history")
+	}
+	if info.CrashCount != 0 {
+		t.Errorf("CrashCount = %d, want 0", info.CrashCount)
+	}
+}
+
+func TestRootStateStore_CrashPreservesChildren(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewRootStateStore(tmpDir)
+
+	if _, err := store.Create("root", RoleManager, "claude"); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Add children
+	children := []string{"engineer-01", "engineer-02", "qa-01"}
+	for _, child := range children {
+		if err := store.AddChild(child); err != nil {
+			t.Fatalf("AddChild(%s) failed: %v", child, err)
+		}
+	}
+
+	// Crash and recover
+	if err := store.RecordCrash("old-session"); err != nil {
+		t.Fatalf("RecordCrash failed: %v", err)
+	}
+	if err := store.RecoverFromCrash("new-session"); err != nil {
+		t.Fatalf("RecoverFromCrash failed: %v", err)
+	}
+
+	// Verify children preserved
+	loaded, loadErr := store.Load()
+	if loadErr != nil {
+		t.Fatalf("Load failed: %v", loadErr)
+	}
+
+	if len(loaded.Children) != len(children) {
+		t.Errorf("Children count = %d, want %d", len(loaded.Children), len(children))
+	}
+	for i, child := range children {
+		if loaded.Children[i] != child {
+			t.Errorf("Children[%d] = %q, want %q", i, loaded.Children[i], child)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `CrashCount`, `LastCrashTime`, `RecoveredFrom` fields to `RootAgentState`
- `RecordCrash()` marks crash state while preserving children and work queues
- `RecoverFromCrash()` restores root with new session after recovery
- `GetCrashInfo()` returns crash statistics for diagnostics
- `ClearCrashHistory()` resets counters after stability period
- Children and work state preserved across crash/recovery cycles

## Test plan
- [x] Test single crash recording
- [x] Test multiple crash accumulation  
- [x] Test recovery from crash
- [x] Test crash info retrieval
- [x] Test crash history clearing
- [x] Test children preservation across crash/recovery
- [x] All existing tests pass

Part of Task 1.2.5 (Handle Root Crash Scenarios)
Implements work-196

🤖 Generated with [Claude Code](https://claude.com/claude-code)