### PR TITLE
feat: add bc demon CLI for scheduled tasks

### DIFF
--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rpuneet/bc/pkg/demon"
+)
+
+var demonCmd = &cobra.Command{
+	Use:   "demon",
+	Short: "Manage scheduled tasks (demons)",
+	Long: `Manage scheduled background tasks.
+
+Demons are scheduled tasks that run at specified intervals using cron syntax.
+
+Example:
+  bc demon create backup --schedule '0 * * * *' --cmd 'bc backup'
+  bc demon list
+  bc demon show backup
+  bc demon delete backup`,
+}
+
+var demonCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create a scheduled demon",
+	Long: `Create a new scheduled demon with cron syntax.
+
+Cron format: minute hour day-of-month month day-of-week
+
+Examples:
+  bc demon create hourly-check --schedule '0 * * * *' --cmd 'bc status'
+  bc demon create daily-backup --schedule '0 9 * * *' --cmd 'bc backup'
+  bc demon create every-5min --schedule '*/5 * * * *' --cmd 'bc health'
+  bc demon create weekday-report --schedule '0 17 * * 1-5' --cmd 'bc report'`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDemonCreate,
+}
+
+var demonListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all demons",
+	RunE:  runDemonList,
+}
+
+var demonShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Show demon details",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDemonShow,
+}
+
+var demonDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a demon",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDemonDelete,
+}
+
+var (
+	demonSchedule string
+	demonCommand  string
+)
+
+func init() {
+	demonCreateCmd.Flags().StringVar(&demonSchedule, "schedule", "", "Cron schedule (required)")
+	demonCreateCmd.Flags().StringVar(&demonCommand, "cmd", "", "Command to execute (required)")
+	_ = demonCreateCmd.MarkFlagRequired("schedule")
+	_ = demonCreateCmd.MarkFlagRequired("cmd")
+
+	demonCmd.AddCommand(demonCreateCmd)
+	demonCmd.AddCommand(demonListCmd)
+	demonCmd.AddCommand(demonShowCmd)
+	demonCmd.AddCommand(demonDeleteCmd)
+	rootCmd.AddCommand(demonCmd)
+}
+
+func runDemonCreate(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	store := demon.NewStore(ws.RootDir)
+
+	d, err := store.Create(name, demonSchedule, demonCommand)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Created demon %q\n", d.Name)
+	fmt.Printf("  Schedule: %s\n", d.Schedule)
+	fmt.Printf("  Command:  %s\n", d.Command)
+	if !d.NextRun.IsZero() {
+		fmt.Printf("  Next run: %s\n", d.NextRun.Format("2006-01-02 15:04:05"))
+	}
+
+	return nil
+}
+
+func runDemonList(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	store := demon.NewStore(ws.RootDir)
+	demons, err := store.List()
+	if err != nil {
+		return err
+	}
+
+	if len(demons) == 0 {
+		fmt.Println("No demons configured")
+		fmt.Println()
+		fmt.Println("Create one with: bc demon create <name> --schedule '<cron>' --cmd '<command>'")
+		return nil
+	}
+
+	fmt.Printf("%-20s %-20s %-10s %s\n", "NAME", "SCHEDULE", "ENABLED", "COMMAND")
+	fmt.Println("--------------------------------------------------------------------")
+	for _, d := range demons {
+		enabled := "yes"
+		if !d.Enabled {
+			enabled = "no"
+		}
+		command := d.Command
+		if len(command) > 30 {
+			command = command[:27] + "..."
+		}
+		fmt.Printf("%-20s %-20s %-10s %s\n", d.Name, d.Schedule, enabled, command)
+	}
+
+	return nil
+}
+
+func runDemonShow(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	store := demon.NewStore(ws.RootDir)
+
+	d, err := store.Get(name)
+	if err != nil {
+		return err
+	}
+	if d == nil {
+		return fmt.Errorf("demon %q not found", name)
+	}
+
+	fmt.Printf("Name:      %s\n", d.Name)
+	fmt.Printf("Schedule:  %s\n", d.Schedule)
+	fmt.Printf("Command:   %s\n", d.Command)
+	fmt.Printf("Enabled:   %t\n", d.Enabled)
+	fmt.Printf("Created:   %s\n", d.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Updated:   %s\n", d.UpdatedAt.Format("2006-01-02 15:04:05"))
+	if !d.LastRun.IsZero() {
+		fmt.Printf("Last run:  %s\n", d.LastRun.Format("2006-01-02 15:04:05"))
+	}
+	if !d.NextRun.IsZero() {
+		fmt.Printf("Next run:  %s\n", d.NextRun.Format("2006-01-02 15:04:05"))
+	}
+
+	return nil
+}
+
+func runDemonDelete(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	store := demon.NewStore(ws.RootDir)
+
+	if err := store.Delete(name); err != nil {
+		return err
+	}
+
+	fmt.Printf("Deleted demon %q\n", name)
+	return nil
+}

--- a/internal/cmd/demon_test.go
+++ b/internal/cmd/demon_test.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/demon"
+)
+
+func TestDemonCreate(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	output, err := executeCmd("demon", "create", "test-demon", "--schedule", "0 * * * *", "--cmd", "echo hello")
+	if err != nil {
+		t.Fatalf("demon create failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Created demon") {
+		t.Errorf("expected confirmation message, got: %s", output)
+	}
+	if !strings.Contains(output, "test-demon") {
+		t.Errorf("output should contain demon name: %s", output)
+	}
+
+	// Verify demon was created
+	store := demon.NewStore(wsDir)
+	d, err := store.Get("test-demon")
+	if err != nil {
+		t.Fatalf("failed to get demon: %v", err)
+	}
+	if d == nil {
+		t.Fatal("demon not found after creation")
+	}
+	if d.Schedule != "0 * * * *" {
+		t.Errorf("unexpected schedule: %s", d.Schedule)
+	}
+	if d.Command != "echo hello" {
+		t.Errorf("unexpected command: %s", d.Command)
+	}
+}
+
+func TestDemonCreateInvalidCron(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "create", "bad-demon", "--schedule", "invalid", "--cmd", "echo hello")
+	if err == nil {
+		t.Error("expected error for invalid cron syntax")
+	}
+	if !strings.Contains(err.Error(), "invalid cron") {
+		t.Errorf("error should mention invalid cron: %v", err)
+	}
+}
+
+func TestDemonCreateDuplicate(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "create", "dup-demon", "--schedule", "0 * * * *", "--cmd", "echo first")
+	if err != nil {
+		t.Fatalf("first demon create failed: %v", err)
+	}
+
+	_, err = executeCmd("demon", "create", "dup-demon", "--schedule", "0 * * * *", "--cmd", "echo second")
+	if err == nil {
+		t.Error("expected error for duplicate demon")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention already exists: %v", err)
+	}
+}
+
+func TestDemonList(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create some demons
+	store := demon.NewStore(wsDir)
+	_, _ = store.Create("demon1", "0 * * * *", "echo one")
+	_, _ = store.Create("demon2", "*/5 * * * *", "echo two")
+
+	output, err := executeCmd("demon", "list")
+	if err != nil {
+		t.Fatalf("demon list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "demon1") {
+		t.Errorf("output should contain demon1: %s", output)
+	}
+	if !strings.Contains(output, "demon2") {
+		t.Errorf("output should contain demon2: %s", output)
+	}
+	if !strings.Contains(output, "NAME") {
+		t.Errorf("output should contain header: %s", output)
+	}
+}
+
+func TestDemonListEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	output, err := executeCmd("demon", "list")
+	if err != nil {
+		t.Fatalf("demon list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "No demons configured") {
+		t.Errorf("output should indicate no demons: %s", output)
+	}
+}
+
+func TestDemonShow(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a demon
+	store := demon.NewStore(wsDir)
+	_, _ = store.Create("show-demon", "0 9 * * 1-5", "bc backup")
+
+	output, err := executeCmd("demon", "show", "show-demon")
+	if err != nil {
+		t.Fatalf("demon show failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "show-demon") {
+		t.Errorf("output should contain demon name: %s", output)
+	}
+	if !strings.Contains(output, "0 9 * * 1-5") {
+		t.Errorf("output should contain schedule: %s", output)
+	}
+	if !strings.Contains(output, "bc backup") {
+		t.Errorf("output should contain command: %s", output)
+	}
+}
+
+func TestDemonShowNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "show", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent demon")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}
+
+func TestDemonDelete(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a demon
+	store := demon.NewStore(wsDir)
+	_, _ = store.Create("delete-demon", "0 * * * *", "echo hello")
+
+	output, err := executeCmd("demon", "delete", "delete-demon")
+	if err != nil {
+		t.Fatalf("demon delete failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Deleted demon") {
+		t.Errorf("output should confirm deletion: %s", output)
+	}
+
+	// Verify deletion
+	if store.Exists("delete-demon") {
+		t.Error("demon should not exist after deletion")
+	}
+}
+
+func TestDemonDeleteNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "delete", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent demon")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}

--- a/pkg/demon/demon.go
+++ b/pkg/demon/demon.go
@@ -1,0 +1,308 @@
+// Package demon provides scheduled task management for bc.
+package demon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Demon represents a scheduled task.
+type Demon struct {
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	LastRun   time.Time `json:"last_run,omitempty"`
+	NextRun   time.Time `json:"next_run,omitempty"`
+	Name      string    `json:"name"`
+	Schedule  string    `json:"schedule"` // Cron expression (5-field)
+	Command   string    `json:"command"`  // Command to execute
+	Enabled   bool      `json:"enabled"`
+}
+
+// CronSchedule represents a parsed cron expression.
+type CronSchedule struct {
+	Minute     []int // 0-59
+	Hour       []int // 0-23
+	DayOfMonth []int // 1-31
+	Month      []int // 1-12
+	DayOfWeek  []int // 0-6 (0 = Sunday)
+}
+
+// Store manages demon configurations.
+type Store struct {
+	demonsDir string
+}
+
+// NewStore creates a new demon store.
+func NewStore(rootDir string) *Store {
+	return &Store{
+		demonsDir: filepath.Join(rootDir, ".bc", "demons"),
+	}
+}
+
+// Init creates the demons directory if it doesn't exist.
+func (s *Store) Init() error {
+	return os.MkdirAll(s.demonsDir, 0750)
+}
+
+// Create creates a new demon configuration.
+func (s *Store) Create(name, schedule, command string) (*Demon, error) {
+	// Validate cron schedule
+	if _, err := ParseCron(schedule); err != nil {
+		return nil, fmt.Errorf("invalid cron schedule: %w", err)
+	}
+
+	// Check if demon already exists
+	if s.Exists(name) {
+		return nil, fmt.Errorf("demon %q already exists", name)
+	}
+
+	now := time.Now().UTC()
+	demon := &Demon{
+		Name:      name,
+		Schedule:  schedule,
+		Command:   command,
+		Enabled:   true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	// Calculate next run
+	if cron, err := ParseCron(schedule); err == nil {
+		demon.NextRun = cron.Next(now)
+	}
+
+	if err := s.save(demon); err != nil {
+		return nil, err
+	}
+
+	return demon, nil
+}
+
+// Get retrieves a demon by name.
+func (s *Store) Get(name string) (*Demon, error) {
+	path := s.demonPath(name)
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from trusted demonsDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read demon: %w", err)
+	}
+
+	var demon Demon
+	if err := json.Unmarshal(data, &demon); err != nil {
+		return nil, fmt.Errorf("failed to parse demon: %w", err)
+	}
+
+	return &demon, nil
+}
+
+// List returns all demons.
+func (s *Store) List() ([]*Demon, error) {
+	entries, err := os.ReadDir(s.demonsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read demons dir: %w", err)
+	}
+
+	var demons []*Demon
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			name := strings.TrimSuffix(entry.Name(), ".json")
+			demon, err := s.Get(name)
+			if err != nil {
+				continue // Skip invalid entries
+			}
+			if demon != nil {
+				demons = append(demons, demon)
+			}
+		}
+	}
+
+	return demons, nil
+}
+
+// Delete removes a demon.
+func (s *Store) Delete(name string) error {
+	path := s.demonPath(name)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("demon %q not found", name)
+		}
+		return fmt.Errorf("failed to delete demon: %w", err)
+	}
+	return nil
+}
+
+// Exists checks if a demon exists.
+func (s *Store) Exists(name string) bool {
+	_, err := os.Stat(s.demonPath(name))
+	return err == nil
+}
+
+func (s *Store) save(demon *Demon) error {
+	if err := s.Init(); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(demon, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal demon: %w", err)
+	}
+
+	path := s.demonPath(demon.Name)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write demon: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) demonPath(name string) string {
+	return filepath.Join(s.demonsDir, name+".json")
+}
+
+// ParseCron parses a 5-field cron expression.
+// Format: minute hour day-of-month month day-of-week
+// Example: "0 * * * *" = every hour
+//
+//	"*/5 * * * *" = every 5 minutes
+//	"0 9 * * 1-5" = 9am weekdays
+func ParseCron(expr string) (*CronSchedule, error) {
+	fields := strings.Fields(expr)
+	if len(fields) != 5 {
+		return nil, fmt.Errorf("cron expression must have 5 fields, got %d", len(fields))
+	}
+
+	schedule := &CronSchedule{}
+	var err error
+
+	schedule.Minute, err = parseField(fields[0], 0, 59)
+	if err != nil {
+		return nil, fmt.Errorf("invalid minute field: %w", err)
+	}
+
+	schedule.Hour, err = parseField(fields[1], 0, 23)
+	if err != nil {
+		return nil, fmt.Errorf("invalid hour field: %w", err)
+	}
+
+	schedule.DayOfMonth, err = parseField(fields[2], 1, 31)
+	if err != nil {
+		return nil, fmt.Errorf("invalid day-of-month field: %w", err)
+	}
+
+	schedule.Month, err = parseField(fields[3], 1, 12)
+	if err != nil {
+		return nil, fmt.Errorf("invalid month field: %w", err)
+	}
+
+	schedule.DayOfWeek, err = parseField(fields[4], 0, 6)
+	if err != nil {
+		return nil, fmt.Errorf("invalid day-of-week field: %w", err)
+	}
+
+	return schedule, nil
+}
+
+// parseField parses a single cron field.
+// Supports: *, */n, n, n-m, n,m,o
+func parseField(field string, min, max int) ([]int, error) {
+	if field == "*" {
+		return rangeSlice(min, max), nil
+	}
+
+	// Handle */n (step values)
+	if strings.HasPrefix(field, "*/") {
+		step, err := strconv.Atoi(field[2:])
+		if err != nil || step <= 0 {
+			return nil, fmt.Errorf("invalid step value: %s", field)
+		}
+		var values []int
+		for i := min; i <= max; i += step {
+			values = append(values, i)
+		}
+		return values, nil
+	}
+
+	// Handle comma-separated values
+	if strings.Contains(field, ",") {
+		parts := strings.Split(field, ",")
+		var values []int
+		for _, part := range parts {
+			v, err := strconv.Atoi(strings.TrimSpace(part))
+			if err != nil || v < min || v > max {
+				return nil, fmt.Errorf("invalid value: %s", part)
+			}
+			values = append(values, v)
+		}
+		return values, nil
+	}
+
+	// Handle ranges (n-m)
+	if strings.Contains(field, "-") {
+		parts := strings.Split(field, "-")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid range: %s", field)
+		}
+		start, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+		end, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err1 != nil || err2 != nil || start < min || end > max || start > end {
+			return nil, fmt.Errorf("invalid range: %s", field)
+		}
+		return rangeSlice(start, end), nil
+	}
+
+	// Single value
+	v, err := strconv.Atoi(field)
+	if err != nil || v < min || v > max {
+		return nil, fmt.Errorf("invalid value: %s (must be %d-%d)", field, min, max)
+	}
+	return []int{v}, nil
+}
+
+func rangeSlice(min, max int) []int {
+	result := make([]int, max-min+1)
+	for i := range result {
+		result[i] = min + i
+	}
+	return result
+}
+
+// Next calculates the next run time after the given time.
+func (c *CronSchedule) Next(after time.Time) time.Time {
+	// Start from the next minute
+	t := after.Add(time.Minute).Truncate(time.Minute)
+
+	// Try up to 4 years (enough for any valid cron)
+	maxIterations := 60 * 24 * 366 * 4
+	for range maxIterations {
+		if c.matches(t) {
+			return t
+		}
+		t = t.Add(time.Minute)
+	}
+
+	// Should never happen with valid cron
+	return time.Time{}
+}
+
+func (c *CronSchedule) matches(t time.Time) bool {
+	return contains(c.Minute, t.Minute()) &&
+		contains(c.Hour, t.Hour()) &&
+		contains(c.DayOfMonth, t.Day()) &&
+		contains(c.Month, int(t.Month())) &&
+		contains(c.DayOfWeek, int(t.Weekday()))
+}
+
+func contains(slice []int, val int) bool {
+	return slices.Contains(slice, val)
+}

--- a/pkg/demon/demon_test.go
+++ b/pkg/demon/demon_test.go
@@ -1,0 +1,295 @@
+package demon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestParseCron(t *testing.T) {
+	tests := []struct {
+		name    string
+		expr    string
+		wantErr bool
+	}{
+		{"every minute", "* * * * *", false},
+		{"every hour", "0 * * * *", false},
+		{"daily at 9am", "0 9 * * *", false},
+		{"every 5 minutes", "*/5 * * * *", false},
+		{"weekdays at 5pm", "0 17 * * 1-5", false},
+		{"specific minutes", "0,15,30,45 * * * *", false},
+		{"too few fields", "* * * *", true},
+		{"too many fields", "* * * * * *", true},
+		{"invalid minute", "60 * * * *", true},
+		{"invalid hour", "0 24 * * *", true},
+		{"invalid day", "0 0 32 * *", true},
+		{"invalid month", "0 0 * 13 *", true},
+		{"invalid weekday", "0 0 * * 7", true},
+		{"invalid step", "*/0 * * * *", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseCron(tt.expr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseCron(%q) error = %v, wantErr %v", tt.expr, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCronScheduleNext(t *testing.T) {
+	// Test "every hour at minute 0"
+	cron, err := ParseCron("0 * * * *")
+	if err != nil {
+		t.Fatalf("ParseCron failed: %v", err)
+	}
+
+	// From 2024-01-15 10:30:00, next should be 2024-01-15 11:00:00
+	after := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	next := cron.Next(after)
+	expected := time.Date(2024, 1, 15, 11, 0, 0, 0, time.UTC)
+
+	if !next.Equal(expected) {
+		t.Errorf("Next() = %v, want %v", next, expected)
+	}
+}
+
+func TestCronScheduleNextEvery5Min(t *testing.T) {
+	cron, err := ParseCron("*/5 * * * *")
+	if err != nil {
+		t.Fatalf("ParseCron failed: %v", err)
+	}
+
+	// From 10:32, next should be 10:35
+	after := time.Date(2024, 1, 15, 10, 32, 0, 0, time.UTC)
+	next := cron.Next(after)
+	expected := time.Date(2024, 1, 15, 10, 35, 0, 0, time.UTC)
+
+	if !next.Equal(expected) {
+		t.Errorf("Next() = %v, want %v", next, expected)
+	}
+}
+
+func TestCronScheduleNextWeekday(t *testing.T) {
+	// Weekdays at 9am (Monday-Friday)
+	cron, err := ParseCron("0 9 * * 1-5")
+	if err != nil {
+		t.Fatalf("ParseCron failed: %v", err)
+	}
+
+	// Saturday 2024-01-13 at 10am, next should be Monday 2024-01-15 at 9am
+	after := time.Date(2024, 1, 13, 10, 0, 0, 0, time.UTC) // Saturday
+	next := cron.Next(after)
+	expected := time.Date(2024, 1, 15, 9, 0, 0, 0, time.UTC) // Monday
+
+	if !next.Equal(expected) {
+		t.Errorf("Next() = %v, want %v", next, expected)
+	}
+}
+
+func TestStoreCreateAndGet(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	demon, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if demon.Name != "test-demon" {
+		t.Errorf("Name = %q, want %q", demon.Name, "test-demon")
+	}
+	if demon.Schedule != "0 * * * *" {
+		t.Errorf("Schedule = %q, want %q", demon.Schedule, "0 * * * *")
+	}
+	if demon.Command != "echo hello" {
+		t.Errorf("Command = %q, want %q", demon.Command, "echo hello")
+	}
+	if !demon.Enabled {
+		t.Error("Enabled should be true")
+	}
+	if demon.NextRun.IsZero() {
+		t.Error("NextRun should be set")
+	}
+
+	// Get the demon
+	got, err := store.Get("test-demon")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.Name != demon.Name {
+		t.Errorf("Got Name = %q, want %q", got.Name, demon.Name)
+	}
+}
+
+func TestStoreCreateDuplicate(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("First Create failed: %v", err)
+	}
+
+	_, err = store.Create("test-demon", "0 * * * *", "echo world")
+	if err == nil {
+		t.Error("Expected error for duplicate demon")
+	}
+}
+
+func TestStoreCreateInvalidCron(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "invalid", "echo hello")
+	if err == nil {
+		t.Error("Expected error for invalid cron")
+	}
+}
+
+func TestStoreList(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Create some demons
+	_, _ = store.Create("demon1", "0 * * * *", "echo one")
+	_, _ = store.Create("demon2", "*/5 * * * *", "echo two")
+
+	demons, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(demons) != 2 {
+		t.Errorf("List returned %d demons, want 2", len(demons))
+	}
+}
+
+func TestStoreListEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	demons, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(demons) != 0 {
+		t.Errorf("List returned %d demons, want 0", len(demons))
+	}
+}
+
+func TestStoreDelete(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if !store.Exists("test-demon") {
+		t.Error("Demon should exist before delete")
+	}
+
+	err = store.Delete("test-demon")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	if store.Exists("test-demon") {
+		t.Error("Demon should not exist after delete")
+	}
+}
+
+func TestStoreDeleteNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	err := store.Delete("nonexistent")
+	if err == nil {
+		t.Error("Expected error for deleting nonexistent demon")
+	}
+}
+
+func TestStoreGetNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	got, err := store.Get("nonexistent")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got != nil {
+		t.Error("Get should return nil for nonexistent demon")
+	}
+}
+
+func TestDemonPath(t *testing.T) {
+	store := NewStore("/tmp/test")
+	expected := filepath.Join("/tmp/test", ".bc", "demons", "my-demon.json")
+	got := store.demonPath("my-demon")
+	if got != expected {
+		t.Errorf("demonPath = %q, want %q", got, expected)
+	}
+}
+
+func TestParseFieldSingleValue(t *testing.T) {
+	vals, err := parseField("5", 0, 59)
+	if err != nil {
+		t.Fatalf("parseField failed: %v", err)
+	}
+	if len(vals) != 1 || vals[0] != 5 {
+		t.Errorf("parseField(\"5\") = %v, want [5]", vals)
+	}
+}
+
+func TestParseFieldRange(t *testing.T) {
+	vals, err := parseField("1-5", 0, 10)
+	if err != nil {
+		t.Fatalf("parseField failed: %v", err)
+	}
+	expected := []int{1, 2, 3, 4, 5}
+	if len(vals) != len(expected) {
+		t.Fatalf("parseField(\"1-5\") len = %d, want %d", len(vals), len(expected))
+	}
+	for i, v := range vals {
+		if v != expected[i] {
+			t.Errorf("parseField(\"1-5\")[%d] = %d, want %d", i, v, expected[i])
+		}
+	}
+}
+
+func TestParseFieldComma(t *testing.T) {
+	vals, err := parseField("0,15,30,45", 0, 59)
+	if err != nil {
+		t.Fatalf("parseField failed: %v", err)
+	}
+	expected := []int{0, 15, 30, 45}
+	if len(vals) != len(expected) {
+		t.Fatalf("parseField len = %d, want %d", len(vals), len(expected))
+	}
+	for i, v := range vals {
+		if v != expected[i] {
+			t.Errorf("parseField[%d] = %d, want %d", i, v, expected[i])
+		}
+	}
+}
+
+func TestInit(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	err := store.Init()
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	demonsDir := filepath.Join(tmpDir, ".bc", "demons")
+	if _, err := os.Stat(demonsDir); os.IsNotExist(err) {
+		t.Errorf("Demons directory not created: %s", demonsDir)
+	}
+}


### PR DESCRIPTION
Closes #121

## Summary
- Add `pkg/demon` package with Demon struct and Store for config persistence
- Implement 5-field cron expression parser (minute, hour, day-of-month, month, day-of-week)
- Add `bc demon create/list/show/delete` CLI commands
- Store demon configs in `.bc/demons/<name>.json`
- Calculate next run time from cron schedule

## Commands
```bash
bc demon create backup --schedule '0 * * * *' --cmd 'bc backup'
bc demon list
bc demon show backup
bc demon delete backup
```

## Test plan
- [x] All 18 pkg/demon tests pass
- [x] All 9 CLI tests pass
- [x] Linter passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)