### PR TITLE
feat: add process registry and storage

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,0 +1,220 @@
+// Package process provides process management for bc.
+package process
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Process represents a managed process.
+type Process struct {
+	StartedAt time.Time `json:"started_at"`
+	Name      string    `json:"name"`
+	Command   string    `json:"command"`
+	Owner     string    `json:"owner,omitempty"` // Agent that started the process
+	WorkDir   string    `json:"work_dir,omitempty"`
+	PID       int       `json:"pid"`
+	Port      int       `json:"port,omitempty"`
+	Running   bool      `json:"running"`
+}
+
+// Registry manages running processes.
+type Registry struct {
+	processes    map[string]*Process
+	processesDir string
+	mu           sync.RWMutex
+}
+
+// NewRegistry creates a new process registry.
+func NewRegistry(rootDir string) *Registry {
+	return &Registry{
+		processes:    make(map[string]*Process),
+		processesDir: filepath.Join(rootDir, ".bc", "processes"),
+	}
+}
+
+// Init creates the processes directory and loads existing state.
+func (r *Registry) Init() error {
+	if err := os.MkdirAll(r.processesDir, 0750); err != nil {
+		return fmt.Errorf("failed to create processes directory: %w", err)
+	}
+	return r.load()
+}
+
+// Register adds a process to the registry.
+func (r *Registry) Register(p *Process) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.processes[p.Name]; exists {
+		return fmt.Errorf("process %q already registered", p.Name)
+	}
+
+	if p.StartedAt.IsZero() {
+		p.StartedAt = time.Now().UTC()
+	}
+	p.Running = true
+
+	r.processes[p.Name] = p
+	return r.persist()
+}
+
+// Unregister removes a process from the registry.
+func (r *Registry) Unregister(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, exists := r.processes[name]; !exists {
+		return fmt.Errorf("process %q not found", name)
+	}
+
+	delete(r.processes, name)
+	return r.persist()
+}
+
+// Get retrieves a process by name.
+func (r *Registry) Get(name string) *Process {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.processes[name]
+}
+
+// List returns all registered processes.
+func (r *Registry) List() []*Process {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]*Process, 0, len(r.processes))
+	for _, p := range r.processes {
+		result = append(result, p)
+	}
+
+	// Sort by name for consistent ordering
+	slices.SortFunc(result, func(a, b *Process) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	return result
+}
+
+// ListByOwner returns all processes owned by a specific agent.
+func (r *Registry) ListByOwner(owner string) []*Process {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var result []*Process
+	for _, p := range r.processes {
+		if p.Owner == owner {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// MarkStopped marks a process as stopped without removing it.
+func (r *Registry) MarkStopped(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	p, exists := r.processes[name]
+	if !exists {
+		return fmt.Errorf("process %q not found", name)
+	}
+
+	p.Running = false
+	p.PID = 0
+	return r.persist()
+}
+
+// UpdatePID updates the PID of a running process.
+func (r *Registry) UpdatePID(name string, pid int) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	p, exists := r.processes[name]
+	if !exists {
+		return fmt.Errorf("process %q not found", name)
+	}
+
+	p.PID = pid
+	return r.persist()
+}
+
+// IsPortInUse checks if a port is used by any registered process.
+func (r *Registry) IsPortInUse(port int) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, p := range r.processes {
+		if p.Running && p.Port == port {
+			return true
+		}
+	}
+	return false
+}
+
+// GetByPort returns the process using a specific port.
+func (r *Registry) GetByPort(port int) *Process {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, p := range r.processes {
+		if p.Running && p.Port == port {
+			return p
+		}
+	}
+	return nil
+}
+
+// Clear removes all processes from the registry.
+func (r *Registry) Clear() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.processes = make(map[string]*Process)
+	return r.persist()
+}
+
+// persist saves the registry state to disk.
+func (r *Registry) persist() error {
+	data, err := json.MarshalIndent(r.processes, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal processes: %w", err)
+	}
+
+	path := filepath.Join(r.processesDir, "registry.json")
+	if err := os.WriteFile(path, data, 0600); err != nil { //nolint:gosec // path constructed from trusted dir
+		return fmt.Errorf("failed to write registry: %w", err)
+	}
+
+	return nil
+}
+
+// load reads the registry state from disk.
+func (r *Registry) load() error {
+	path := filepath.Join(r.processesDir, "registry.json")
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from trusted dir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No existing registry
+		}
+		return fmt.Errorf("failed to read registry: %w", err)
+	}
+
+	if err := json.Unmarshal(data, &r.processes); err != nil {
+		return fmt.Errorf("failed to parse registry: %w", err)
+	}
+
+	return nil
+}
+
+// ProcessesDir returns the path to the processes directory.
+func (r *Registry) ProcessesDir() string {
+	return r.processesDir
+}

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -1,0 +1,367 @@
+package process
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewRegistry(t *testing.T) {
+	reg := NewRegistry("/tmp/test")
+	if reg == nil {
+		t.Fatal("NewRegistry returned nil")
+	}
+	expected := filepath.Join("/tmp/test", ".bc", "processes")
+	if reg.processesDir != expected {
+		t.Errorf("processesDir = %q, want %q", reg.processesDir, expected)
+	}
+}
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	p := &Process{
+		Name:    "test-proc",
+		Command: "echo hello",
+		PID:     1234,
+		Owner:   "engineer-01",
+		Port:    8080,
+	}
+
+	if err := reg.Register(p); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	got := reg.Get("test-proc")
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.Name != "test-proc" {
+		t.Errorf("Name = %q, want %q", got.Name, "test-proc")
+	}
+	if got.Command != "echo hello" {
+		t.Errorf("Command = %q, want %q", got.Command, "echo hello")
+	}
+	if got.PID != 1234 {
+		t.Errorf("PID = %d, want %d", got.PID, 1234)
+	}
+	if got.Owner != "engineer-01" {
+		t.Errorf("Owner = %q, want %q", got.Owner, "engineer-01")
+	}
+	if got.Port != 8080 {
+		t.Errorf("Port = %d, want %d", got.Port, 8080)
+	}
+	if !got.Running {
+		t.Error("Running should be true")
+	}
+	if got.StartedAt.IsZero() {
+		t.Error("StartedAt should be set")
+	}
+}
+
+func TestRegistryRegisterDuplicate(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	p := &Process{Name: "dup-proc", Command: "echo one"}
+	if err := reg.Register(p); err != nil {
+		t.Fatalf("First Register failed: %v", err)
+	}
+
+	p2 := &Process{Name: "dup-proc", Command: "echo two"}
+	if err := reg.Register(p2); err == nil {
+		t.Error("Expected error for duplicate registration")
+	}
+}
+
+func TestRegistryUnregister(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	p := &Process{Name: "delete-proc", Command: "echo hello"}
+	if err := reg.Register(p); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	if err := reg.Unregister("delete-proc"); err != nil {
+		t.Fatalf("Unregister failed: %v", err)
+	}
+
+	if got := reg.Get("delete-proc"); got != nil {
+		t.Error("Get should return nil after Unregister")
+	}
+}
+
+func TestRegistryUnregisterNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	if err := reg.Unregister("nonexistent"); err == nil {
+		t.Error("Expected error for nonexistent process")
+	}
+}
+
+func TestRegistryList(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	_ = reg.Register(&Process{Name: "proc-b", Command: "b"})
+	_ = reg.Register(&Process{Name: "proc-a", Command: "a"})
+	_ = reg.Register(&Process{Name: "proc-c", Command: "c"})
+
+	procs := reg.List()
+	if len(procs) != 3 {
+		t.Fatalf("List returned %d processes, want 3", len(procs))
+	}
+
+	// Should be sorted by name
+	if procs[0].Name != "proc-a" {
+		t.Errorf("procs[0].Name = %q, want %q", procs[0].Name, "proc-a")
+	}
+	if procs[1].Name != "proc-b" {
+		t.Errorf("procs[1].Name = %q, want %q", procs[1].Name, "proc-b")
+	}
+	if procs[2].Name != "proc-c" {
+		t.Errorf("procs[2].Name = %q, want %q", procs[2].Name, "proc-c")
+	}
+}
+
+func TestRegistryListByOwner(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	_ = reg.Register(&Process{Name: "proc1", Command: "a", Owner: "engineer-01"})
+	_ = reg.Register(&Process{Name: "proc2", Command: "b", Owner: "engineer-02"})
+	_ = reg.Register(&Process{Name: "proc3", Command: "c", Owner: "engineer-01"})
+
+	procs := reg.ListByOwner("engineer-01")
+	if len(procs) != 2 {
+		t.Fatalf("ListByOwner returned %d processes, want 2", len(procs))
+	}
+}
+
+func TestRegistryMarkStopped(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	p := &Process{Name: "stop-proc", Command: "echo", PID: 1234}
+	if err := reg.Register(p); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	if err := reg.MarkStopped("stop-proc"); err != nil {
+		t.Fatalf("MarkStopped failed: %v", err)
+	}
+
+	got := reg.Get("stop-proc")
+	if got.Running {
+		t.Error("Running should be false after MarkStopped")
+	}
+	if got.PID != 0 {
+		t.Errorf("PID should be 0 after MarkStopped, got %d", got.PID)
+	}
+}
+
+func TestRegistryUpdatePID(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	p := &Process{Name: "pid-proc", Command: "echo"}
+	if err := reg.Register(p); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	if err := reg.UpdatePID("pid-proc", 5678); err != nil {
+		t.Fatalf("UpdatePID failed: %v", err)
+	}
+
+	got := reg.Get("pid-proc")
+	if got.PID != 5678 {
+		t.Errorf("PID = %d, want 5678", got.PID)
+	}
+}
+
+func TestRegistryIsPortInUse(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	_ = reg.Register(&Process{Name: "web", Command: "server", Port: 8080})
+
+	if !reg.IsPortInUse(8080) {
+		t.Error("Port 8080 should be in use")
+	}
+	if reg.IsPortInUse(8081) {
+		t.Error("Port 8081 should not be in use")
+	}
+}
+
+func TestRegistryGetByPort(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	_ = reg.Register(&Process{Name: "web", Command: "server", Port: 8080})
+
+	got := reg.GetByPort(8080)
+	if got == nil {
+		t.Fatal("GetByPort returned nil")
+	}
+	if got.Name != "web" {
+		t.Errorf("Name = %q, want %q", got.Name, "web")
+	}
+
+	if reg.GetByPort(8081) != nil {
+		t.Error("GetByPort(8081) should return nil")
+	}
+}
+
+func TestRegistryClear(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	_ = reg.Register(&Process{Name: "proc1", Command: "a"})
+	_ = reg.Register(&Process{Name: "proc2", Command: "b"})
+
+	if err := reg.Clear(); err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+
+	procs := reg.List()
+	if len(procs) != 0 {
+		t.Errorf("List returned %d processes after Clear, want 0", len(procs))
+	}
+}
+
+func TestRegistryPersistence(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create and populate registry
+	reg1 := NewRegistry(tmpDir)
+	if err := reg1.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	p := &Process{
+		Name:      "persist-proc",
+		Command:   "echo",
+		PID:       1234,
+		Port:      3000,
+		Owner:     "test",
+		StartedAt: now,
+	}
+	if err := reg1.Register(p); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	// Create new registry and load from disk
+	reg2 := NewRegistry(tmpDir)
+	if err := reg2.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	got := reg2.Get("persist-proc")
+	if got == nil {
+		t.Fatal("Process not found after reload")
+	}
+	if got.Name != "persist-proc" {
+		t.Errorf("Name = %q, want %q", got.Name, "persist-proc")
+	}
+	if got.PID != 1234 {
+		t.Errorf("PID = %d, want 1234", got.PID)
+	}
+	if got.Port != 3000 {
+		t.Errorf("Port = %d, want 3000", got.Port)
+	}
+}
+
+func TestRegistryGetNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	reg := NewRegistry(tmpDir)
+	if err := reg.Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	if got := reg.Get("nonexistent"); got != nil {
+		t.Error("Get should return nil for nonexistent process")
+	}
+}
+
+func TestProcessStruct(t *testing.T) {
+	p := Process{
+		Name:      "test",
+		Command:   "echo hello",
+		PID:       123,
+		Port:      8080,
+		Owner:     "owner",
+		WorkDir:   "/tmp",
+		Running:   true,
+		StartedAt: time.Now(),
+	}
+
+	if p.Name != "test" {
+		t.Errorf("Name = %q, want %q", p.Name, "test")
+	}
+	if p.Command != "echo hello" {
+		t.Errorf("Command = %q, want %q", p.Command, "echo hello")
+	}
+	if p.PID != 123 {
+		t.Errorf("PID = %d, want 123", p.PID)
+	}
+	if p.Port != 8080 {
+		t.Errorf("Port = %d, want 8080", p.Port)
+	}
+	if p.Owner != "owner" {
+		t.Errorf("Owner = %q, want %q", p.Owner, "owner")
+	}
+	if p.WorkDir != "/tmp" {
+		t.Errorf("WorkDir = %q, want %q", p.WorkDir, "/tmp")
+	}
+	if !p.Running {
+		t.Error("Running should be true")
+	}
+	if p.StartedAt.IsZero() {
+		t.Error("StartedAt should not be zero")
+	}
+}
+
+func TestRegistryProcessesDir(t *testing.T) {
+	reg := NewRegistry("/home/user/project")
+	expected := filepath.Join("/home/user/project", ".bc", "processes")
+	if got := reg.ProcessesDir(); got != expected {
+		t.Errorf("ProcessesDir() = %q, want %q", got, expected)
+	}
+}


### PR DESCRIPTION
Closes #131

## Summary
- Add `Process` struct with name, command, pid, owner, port, started_at, work_dir, running
- Add `Registry` for tracking running processes with thread-safe operations
- Implement persistence to `.bc/processes/registry.json` for restart survival
- Add port conflict detection (`IsPortInUse`, `GetByPort`)
- Add `ListByOwner` for querying processes by agent

## API
```go
reg := process.NewRegistry(rootDir)
reg.Init()

// Register a process
reg.Register(&process.Process{
    Name: "web-server",
    Command: "npm start",
    PID: 1234,
    Port: 3000,
    Owner: "engineer-01",
})

// Query processes
procs := reg.List()
myProcs := reg.ListByOwner("engineer-01")
inUse := reg.IsPortInUse(3000)

// Update/stop
reg.MarkStopped("web-server")
reg.Unregister("web-server")
```

## Test plan
- [x] All 16 tests pass
- [x] Linter passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)