### PR TITLE
feat: add Owner tracking and convenience methods to demon package

### DIFF
--- a/pkg/demon/demon.go
+++ b/pkg/demon/demon.go
@@ -14,14 +14,17 @@ import (
 
 // Demon represents a scheduled task.
 type Demon struct {
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
-	LastRun   time.Time `json:"last_run,omitempty"`
-	NextRun   time.Time `json:"next_run,omitempty"`
-	Name      string    `json:"name"`
-	Schedule  string    `json:"schedule"` // Cron expression (5-field)
-	Command   string    `json:"command"`  // Command to execute
-	Enabled   bool      `json:"enabled"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	LastRun     time.Time `json:"last_run,omitempty"`
+	NextRun     time.Time `json:"next_run,omitempty"`
+	Name        string    `json:"name"`
+	Schedule    string    `json:"schedule"` // Cron expression (5-field)
+	Command     string    `json:"command"`  // Command to execute
+	Owner       string    `json:"owner,omitempty"`
+	Description string    `json:"description,omitempty"`
+	RunCount    int       `json:"run_count,omitempty"`
+	Enabled     bool      `json:"enabled"`
 }
 
 // CronSchedule represents a parsed cron expression.
@@ -146,6 +149,98 @@ func (s *Store) Delete(name string) error {
 func (s *Store) Exists(name string) bool {
 	_, err := os.Stat(s.demonPath(name))
 	return err == nil
+}
+
+// Update modifies an existing demon using the provided update function.
+func (s *Store) Update(name string, updateFn func(*Demon)) error {
+	demon, err := s.Get(name)
+	if err != nil {
+		return err
+	}
+	if demon == nil {
+		return fmt.Errorf("demon %q not found", name)
+	}
+
+	updateFn(demon)
+	demon.UpdatedAt = time.Now().UTC()
+
+	return s.save(demon)
+}
+
+// ListByOwner returns all demons owned by a specific agent.
+func (s *Store) ListByOwner(owner string) ([]*Demon, error) {
+	demons, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*Demon
+	for _, d := range demons {
+		if d.Owner == owner {
+			result = append(result, d)
+		}
+	}
+
+	return result, nil
+}
+
+// ListEnabled returns all enabled demons.
+func (s *Store) ListEnabled() ([]*Demon, error) {
+	demons, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*Demon
+	for _, d := range demons {
+		if d.Enabled {
+			result = append(result, d)
+		}
+	}
+
+	return result, nil
+}
+
+// Enable enables a demon.
+func (s *Store) Enable(name string) error {
+	return s.Update(name, func(d *Demon) {
+		d.Enabled = true
+	})
+}
+
+// Disable disables a demon.
+func (s *Store) Disable(name string) error {
+	return s.Update(name, func(d *Demon) {
+		d.Enabled = false
+	})
+}
+
+// RecordRun updates the demon after a successful run.
+func (s *Store) RecordRun(name string) error {
+	return s.Update(name, func(d *Demon) {
+		now := time.Now().UTC()
+		d.LastRun = now
+		d.RunCount++
+
+		// Calculate next run time
+		if cron, err := ParseCron(d.Schedule); err == nil {
+			d.NextRun = cron.Next(now)
+		}
+	})
+}
+
+// SetOwner sets the owner of a demon.
+func (s *Store) SetOwner(name, owner string) error {
+	return s.Update(name, func(d *Demon) {
+		d.Owner = owner
+	})
+}
+
+// SetDescription sets the description of a demon.
+func (s *Store) SetDescription(name, description string) error {
+	return s.Update(name, func(d *Demon) {
+		d.Description = description
+	})
 }
 
 func (s *Store) save(demon *Demon) error {

--- a/pkg/demon/demon_test.go
+++ b/pkg/demon/demon_test.go
@@ -293,3 +293,241 @@ func TestInit(t *testing.T) {
 		t.Errorf("Demons directory not created: %s", demonsDir)
 	}
 }
+
+func TestStoreUpdate(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	err = store.Update("test-demon", func(d *Demon) {
+		d.Command = "echo updated"
+		d.Description = "test description"
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	got, err := store.Get("test-demon")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got.Command != "echo updated" {
+		t.Errorf("Command = %q, want %q", got.Command, "echo updated")
+	}
+	if got.Description != "test description" {
+		t.Errorf("Description = %q, want %q", got.Description, "test description")
+	}
+}
+
+func TestStoreUpdateNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	err := store.Update("nonexistent", func(d *Demon) {
+		d.Command = "test"
+	})
+	if err == nil {
+		t.Error("Expected error for updating nonexistent demon")
+	}
+}
+
+func TestStoreListByOwner(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Create demons with different owners
+	d1, _ := store.Create("demon1", "0 * * * *", "echo one")
+	_ = store.SetOwner(d1.Name, "engineer-01")
+
+	d2, _ := store.Create("demon2", "*/5 * * * *", "echo two")
+	_ = store.SetOwner(d2.Name, "engineer-01")
+
+	d3, _ := store.Create("demon3", "0 0 * * *", "echo three")
+	_ = store.SetOwner(d3.Name, "qa-01")
+
+	// List by owner
+	eng01Demons, err := store.ListByOwner("engineer-01")
+	if err != nil {
+		t.Fatalf("ListByOwner failed: %v", err)
+	}
+	if len(eng01Demons) != 2 {
+		t.Errorf("ListByOwner(engineer-01) len = %d, want 2", len(eng01Demons))
+	}
+
+	qa01Demons, err := store.ListByOwner("qa-01")
+	if err != nil {
+		t.Fatalf("ListByOwner failed: %v", err)
+	}
+	if len(qa01Demons) != 1 {
+		t.Errorf("ListByOwner(qa-01) len = %d, want 1", len(qa01Demons))
+	}
+
+	// No demons for this owner
+	noneDemon, err := store.ListByOwner("unknown")
+	if err != nil {
+		t.Fatalf("ListByOwner failed: %v", err)
+	}
+	if len(noneDemon) != 0 {
+		t.Errorf("ListByOwner(unknown) len = %d, want 0", len(noneDemon))
+	}
+}
+
+func TestStoreListEnabled(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, _ = store.Create("enabled1", "0 * * * *", "echo one")
+	_, _ = store.Create("enabled2", "*/5 * * * *", "echo two")
+	d3, _ := store.Create("disabled1", "0 0 * * *", "echo three")
+	_ = store.Disable(d3.Name)
+
+	enabled, err := store.ListEnabled()
+	if err != nil {
+		t.Fatalf("ListEnabled failed: %v", err)
+	}
+	if len(enabled) != 2 {
+		t.Errorf("ListEnabled len = %d, want 2", len(enabled))
+	}
+
+	// All should be enabled
+	for _, d := range enabled {
+		if !d.Enabled {
+			t.Errorf("Demon %q should be enabled", d.Name)
+		}
+	}
+}
+
+func TestStoreEnableDisable(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Disable
+	err = store.Disable("test-demon")
+	if err != nil {
+		t.Fatalf("Disable failed: %v", err)
+	}
+	got, _ := store.Get("test-demon")
+	if got.Enabled {
+		t.Error("Demon should be disabled")
+	}
+
+	// Enable
+	err = store.Enable("test-demon")
+	if err != nil {
+		t.Fatalf("Enable failed: %v", err)
+	}
+	got, _ = store.Get("test-demon")
+	if !got.Enabled {
+		t.Error("Demon should be enabled")
+	}
+}
+
+func TestStoreRecordRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Record a run
+	err = store.RecordRun("test-demon")
+	if err != nil {
+		t.Fatalf("RecordRun failed: %v", err)
+	}
+
+	got, _ := store.Get("test-demon")
+	if got.RunCount != 1 {
+		t.Errorf("RunCount = %d, want 1", got.RunCount)
+	}
+	if got.LastRun.IsZero() {
+		t.Error("LastRun should be set")
+	}
+	if got.NextRun.IsZero() {
+		t.Error("NextRun should be set")
+	}
+
+	// Record another run
+	err = store.RecordRun("test-demon")
+	if err != nil {
+		t.Fatalf("Second RecordRun failed: %v", err)
+	}
+	got, _ = store.Get("test-demon")
+	if got.RunCount != 2 {
+		t.Errorf("RunCount = %d, want 2", got.RunCount)
+	}
+}
+
+func TestStoreSetOwner(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	err = store.SetOwner("test-demon", "engineer-01")
+	if err != nil {
+		t.Fatalf("SetOwner failed: %v", err)
+	}
+
+	got, _ := store.Get("test-demon")
+	if got.Owner != "engineer-01" {
+		t.Errorf("Owner = %q, want %q", got.Owner, "engineer-01")
+	}
+}
+
+func TestStoreSetDescription(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	err = store.SetDescription("test-demon", "This is a test demon")
+	if err != nil {
+		t.Fatalf("SetDescription failed: %v", err)
+	}
+
+	got, _ := store.Get("test-demon")
+	if got.Description != "This is a test demon" {
+		t.Errorf("Description = %q, want %q", got.Description, "This is a test demon")
+	}
+}
+
+func TestDemonOwnerField(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	demon, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Initially no owner
+	if demon.Owner != "" {
+		t.Errorf("Initial Owner = %q, want empty", demon.Owner)
+	}
+
+	// Set owner
+	_ = store.SetOwner("test-demon", "engineer-01")
+
+	// Verify persistence
+	got, _ := store.Get("test-demon")
+	if got.Owner != "engineer-01" {
+		t.Errorf("Owner after reload = %q, want %q", got.Owner, "engineer-01")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `Owner`, `Description`, and `RunCount` fields to Demon struct for agent ownership tracking
- Add `Update` method for generic updates with callback function
- Add `ListByOwner` to filter demons by owning agent
- Add `ListEnabled` to filter only enabled demons
- Add `Enable/Disable` convenience toggle methods
- Add `RecordRun` to update run stats and calculate next run time
- Add `SetOwner/SetDescription` field setters

This is a follow-up to merged #133 which implemented the demon package. That PR had cron parsing; this adds the owner tracking needed for multi-agent demon management.

## Test plan

- [x] All new methods have unit tests
- [x] 90% test coverage maintained
- [x] All 27 tests pass
- [x] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)