### PR TITLE
feat: add bc process CLI commands

### DIFF
--- a/internal/cmd/process.go
+++ b/internal/cmd/process.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rpuneet/bc/pkg/process"
+)
+
+var processCmd = &cobra.Command{
+	Use:   "process",
+	Short: "Manage background processes",
+	Long: `Manage background processes running in the workspace.
+
+Example:
+  bc process start server --cmd 'npm start' --port 3000
+  bc process list
+  bc process stop server`,
+}
+
+var processStartCmd = &cobra.Command{
+	Use:   "start <name>",
+	Short: "Start a background process",
+	Long: `Start a named background process.
+
+Example:
+  bc process start web --cmd 'npm start'
+  bc process start api --cmd 'go run main.go' --port 8080
+  bc process start db --cmd 'docker run -d postgres'`,
+	Args: cobra.ExactArgs(1),
+	RunE: runProcessStart,
+}
+
+var processListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all processes",
+	RunE:  runProcessList,
+}
+
+var processStopCmd = &cobra.Command{
+	Use:   "stop <name>",
+	Short: "Stop a running process",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProcessStop,
+}
+
+var processShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Show process details",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runProcessShow,
+}
+
+var (
+	processCommand string
+	processPort    int
+)
+
+func init() {
+	processStartCmd.Flags().StringVar(&processCommand, "cmd", "", "Command to execute (required)")
+	processStartCmd.Flags().IntVar(&processPort, "port", 0, "Port the process will listen on")
+	_ = processStartCmd.MarkFlagRequired("cmd")
+
+	processCmd.AddCommand(processStartCmd)
+	processCmd.AddCommand(processListCmd)
+	processCmd.AddCommand(processStopCmd)
+	processCmd.AddCommand(processShowCmd)
+	rootCmd.AddCommand(processCmd)
+}
+
+func runProcessStart(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	registry := process.NewRegistry(ws.RootDir)
+	if err := registry.Init(); err != nil {
+		return fmt.Errorf("failed to initialize registry: %w", err)
+	}
+
+	// Check if process already exists
+	if existing := registry.Get(name); existing != nil && existing.Running {
+		return fmt.Errorf("process %q is already running (PID %d)", name, existing.PID)
+	}
+
+	// Check port conflict
+	if processPort > 0 {
+		if conflicting := registry.GetByPort(processPort); conflicting != nil {
+			return fmt.Errorf("port %d is already in use by process %q", processPort, conflicting.Name)
+		}
+	}
+
+	// Get agent ID if available
+	owner := os.Getenv("BC_AGENT_ID")
+
+	// Start the process
+	ctx := context.Background()
+	execCmd := exec.CommandContext(ctx, "sh", "-c", processCommand) //nolint:gosec // command from user input
+	execCmd.Dir = ws.RootDir
+	execCmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true, // Create new process group
+	}
+
+	if err := execCmd.Start(); err != nil {
+		return fmt.Errorf("failed to start process: %w", err)
+	}
+
+	pid := execCmd.Process.Pid
+
+	// Register the process
+	p := &process.Process{
+		Name:    name,
+		Command: processCommand,
+		PID:     pid,
+		Port:    processPort,
+		Owner:   owner,
+		WorkDir: ws.RootDir,
+	}
+
+	if err := registry.Register(p); err != nil {
+		// Try to kill the process if registration fails
+		_ = execCmd.Process.Kill()
+		return fmt.Errorf("failed to register process: %w", err)
+	}
+
+	fmt.Printf("Started process %q (PID %d)\n", name, pid)
+	fmt.Printf("  Command: %s\n", processCommand)
+	if processPort > 0 {
+		fmt.Printf("  Port:    %d\n", processPort)
+	}
+
+	return nil
+}
+
+func runProcessList(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	registry := process.NewRegistry(ws.RootDir)
+	if err := registry.Init(); err != nil {
+		return fmt.Errorf("failed to initialize registry: %w", err)
+	}
+
+	processes := registry.List()
+	if len(processes) == 0 {
+		fmt.Println("No processes registered")
+		fmt.Println()
+		fmt.Println("Start one with: bc process start <name> --cmd '<command>'")
+		return nil
+	}
+
+	fmt.Printf("%-15s %-8s %-8s %-15s %s\n", "NAME", "PID", "PORT", "STATUS", "COMMAND")
+	fmt.Println("----------------------------------------------------------------------")
+	for _, p := range processes {
+		status := "stopped"
+		pid := "-"
+		if p.Running {
+			status = "running"
+			pid = fmt.Sprintf("%d", p.PID)
+			// Check if process is actually running
+			if !isProcessRunning(p.PID) {
+				status = "dead"
+			}
+		}
+		port := "-"
+		if p.Port > 0 {
+			port = fmt.Sprintf("%d", p.Port)
+		}
+		command := p.Command
+		if len(command) > 25 {
+			command = command[:22] + "..."
+		}
+		fmt.Printf("%-15s %-8s %-8s %-15s %s\n", p.Name, pid, port, status, command)
+	}
+
+	return nil
+}
+
+func runProcessStop(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	registry := process.NewRegistry(ws.RootDir)
+	if initErr := registry.Init(); initErr != nil {
+		return fmt.Errorf("failed to initialize registry: %w", initErr)
+	}
+
+	p := registry.Get(name)
+	if p == nil {
+		return fmt.Errorf("process %q not found", name)
+	}
+
+	if !p.Running {
+		fmt.Printf("Process %q is already stopped\n", name)
+		return nil
+	}
+
+	// Try to kill the process
+	proc, err := os.FindProcess(p.PID)
+	if err == nil {
+		// Send SIGTERM first
+		if termErr := proc.Signal(syscall.SIGTERM); termErr != nil {
+			// Process may already be dead
+			fmt.Printf("Process %q (PID %d) not found, cleaning up registry\n", name, p.PID)
+		} else {
+			fmt.Printf("Stopped process %q (PID %d)\n", name, p.PID)
+		}
+	}
+
+	// Mark as stopped in registry
+	if err := registry.MarkStopped(name); err != nil {
+		return fmt.Errorf("failed to update registry: %w", err)
+	}
+
+	return nil
+}
+
+func runProcessShow(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	registry := process.NewRegistry(ws.RootDir)
+	if err := registry.Init(); err != nil {
+		return fmt.Errorf("failed to initialize registry: %w", err)
+	}
+
+	p := registry.Get(name)
+	if p == nil {
+		return fmt.Errorf("process %q not found", name)
+	}
+
+	status := "stopped"
+	if p.Running {
+		status = "running"
+		if !isProcessRunning(p.PID) {
+			status = "dead (not responding)"
+		}
+	}
+
+	fmt.Printf("Name:      %s\n", p.Name)
+	fmt.Printf("Command:   %s\n", p.Command)
+	fmt.Printf("PID:       %d\n", p.PID)
+	fmt.Printf("Status:    %s\n", status)
+	if p.Port > 0 {
+		fmt.Printf("Port:      %d\n", p.Port)
+	}
+	if p.Owner != "" {
+		fmt.Printf("Owner:     %s\n", p.Owner)
+	}
+	if p.WorkDir != "" {
+		fmt.Printf("WorkDir:   %s\n", p.WorkDir)
+	}
+	if !p.StartedAt.IsZero() {
+		fmt.Printf("Started:   %s\n", p.StartedAt.Format("2006-01-02 15:04:05"))
+	}
+
+	return nil
+}
+
+// isProcessRunning checks if a process with the given PID is running.
+func isProcessRunning(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// On Unix, FindProcess always succeeds. Use Signal(0) to check.
+	err = proc.Signal(syscall.Signal(0))
+	return err == nil
+}

--- a/internal/cmd/process_test.go
+++ b/internal/cmd/process_test.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/process"
+)
+
+func TestProcessStart(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	output, err := executeCmd("process", "start", "test-proc", "--cmd", "sleep 60")
+	if err != nil {
+		t.Fatalf("process start failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Started process") {
+		t.Errorf("expected confirmation message, got: %s", output)
+	}
+	if !strings.Contains(output, "test-proc") {
+		t.Errorf("output should contain process name: %s", output)
+	}
+	if !strings.Contains(output, "PID") {
+		t.Errorf("output should contain PID: %s", output)
+	}
+
+	// Verify process was registered
+	registry := process.NewRegistry(wsDir)
+	_ = registry.Init()
+	p := registry.Get("test-proc")
+	if p == nil {
+		t.Fatal("process not found in registry")
+	}
+	if p.Command != "sleep 60" {
+		t.Errorf("unexpected command: %s", p.Command)
+	}
+	if !p.Running {
+		t.Error("process should be marked as running")
+	}
+
+	// Cleanup: stop the process
+	_, _ = executeCmd("process", "stop", "test-proc")
+}
+
+func TestProcessStartWithPort(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	output, err := executeCmd("process", "start", "port-proc", "--cmd", "sleep 60", "--port", "8080")
+	if err != nil {
+		t.Fatalf("process start failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Port:") {
+		t.Errorf("output should show port: %s", output)
+	}
+
+	// Verify port was recorded
+	registry := process.NewRegistry(wsDir)
+	_ = registry.Init()
+	p := registry.Get("port-proc")
+	if p.Port != 8080 {
+		t.Errorf("port = %d, want 8080", p.Port)
+	}
+
+	// Cleanup
+	_, _ = executeCmd("process", "stop", "port-proc")
+}
+
+func TestProcessStartDuplicate(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Start first process
+	_, err := executeCmd("process", "start", "dup-proc", "--cmd", "sleep 60")
+	if err != nil {
+		t.Fatalf("first start failed: %v", err)
+	}
+
+	// Try to start duplicate
+	_, err = executeCmd("process", "start", "dup-proc", "--cmd", "sleep 60")
+	if err == nil {
+		t.Error("expected error for duplicate process")
+	}
+	if !strings.Contains(err.Error(), "already running") {
+		t.Errorf("error should mention already running: %v", err)
+	}
+
+	// Cleanup
+	_, _ = executeCmd("process", "stop", "dup-proc")
+}
+
+func TestProcessStartPortConflict(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Start first process with port
+	_, err := executeCmd("process", "start", "port1", "--cmd", "sleep 60", "--port", "9000")
+	if err != nil {
+		t.Fatalf("first start failed: %v", err)
+	}
+
+	// Try to start another with same port
+	_, err = executeCmd("process", "start", "port2", "--cmd", "sleep 60", "--port", "9000")
+	if err == nil {
+		t.Error("expected error for port conflict")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("error should mention port in use: %v", err)
+	}
+
+	// Cleanup
+	_, _ = executeCmd("process", "stop", "port1")
+}
+
+func TestProcessList(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Register some processes
+	registry := process.NewRegistry(wsDir)
+	_ = registry.Init()
+	_ = registry.Register(&process.Process{
+		Name:    "proc1",
+		Command: "echo one",
+		PID:     1001,
+	})
+	_ = registry.Register(&process.Process{
+		Name:    "proc2",
+		Command: "echo two",
+		PID:     1002,
+		Port:    8080,
+	})
+
+	output, err := executeCmd("process", "list")
+	if err != nil {
+		t.Fatalf("process list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "proc1") {
+		t.Errorf("output should contain proc1: %s", output)
+	}
+	if !strings.Contains(output, "proc2") {
+		t.Errorf("output should contain proc2: %s", output)
+	}
+	if !strings.Contains(output, "NAME") {
+		t.Errorf("output should contain header: %s", output)
+	}
+}
+
+func TestProcessListEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	output, err := executeCmd("process", "list")
+	if err != nil {
+		t.Fatalf("process list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "No processes registered") {
+		t.Errorf("output should indicate no processes: %s", output)
+	}
+}
+
+func TestProcessStop(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Start a process
+	_, err := executeCmd("process", "start", "stop-proc", "--cmd", "sleep 60")
+	if err != nil {
+		t.Fatalf("start failed: %v", err)
+	}
+
+	// Give it a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Stop it
+	output, err := executeCmd("process", "stop", "stop-proc")
+	if err != nil {
+		t.Fatalf("process stop failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Stopped") || !strings.Contains(output, "stop-proc") {
+		t.Errorf("output should confirm stop: %s", output)
+	}
+
+	// Verify it's marked as stopped
+	registry := process.NewRegistry(wsDir)
+	_ = registry.Init()
+	p := registry.Get("stop-proc")
+	if p.Running {
+		t.Error("process should be marked as stopped")
+	}
+}
+
+func TestProcessStopNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("process", "stop", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent process")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}
+
+func TestProcessShow(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Register a process
+	registry := process.NewRegistry(wsDir)
+	_ = registry.Init()
+	_ = registry.Register(&process.Process{
+		Name:    "show-proc",
+		Command: "echo hello",
+		PID:     1234,
+		Port:    3000,
+		Owner:   "test-agent",
+	})
+
+	output, err := executeCmd("process", "show", "show-proc")
+	if err != nil {
+		t.Fatalf("process show failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "show-proc") {
+		t.Errorf("output should contain name: %s", output)
+	}
+	if !strings.Contains(output, "echo hello") {
+		t.Errorf("output should contain command: %s", output)
+	}
+	if !strings.Contains(output, "1234") {
+		t.Errorf("output should contain PID: %s", output)
+	}
+	if !strings.Contains(output, "3000") {
+		t.Errorf("output should contain port: %s", output)
+	}
+	if !strings.Contains(output, "test-agent") {
+		t.Errorf("output should contain owner: %s", output)
+	}
+}
+
+func TestProcessShowNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("process", "show", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent process")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #123

## Summary
Implement process management CLI commands:
- `bc process start <name> --cmd '<command>' [--port <port>]`
- `bc process list` - show all registered processes
- `bc process stop <name>` - stop a running process
- `bc process show <name>` - show process details

## Features
- Background process execution with proper process group management
- Port conflict detection before starting
- Process status tracking (running/stopped/dead)
- Owner tracking via `BC_AGENT_ID` environment variable

## Usage
```bash
# Start a process
bc process start web --cmd 'npm start' --port 3000

# List processes
bc process list
# NAME            PID      PORT     STATUS          COMMAND
# ----------------------------------------------------------------------
# web             1234     3000     running         npm start

# Show details
bc process show web

# Stop process
bc process stop web
```

## Test plan
- [x] All 10 CLI tests pass
- [x] Linter passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)