### PR TITLE
feat: add team management package and CLI commands

### DIFF
--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rpuneet/bc/pkg/team"
+)
+
+var teamCmd = &cobra.Command{
+	Use:   "team",
+	Short: "Manage teams",
+	Long: `Manage organizational teams.
+
+Teams group agents together for collaboration and organization.
+
+Example:
+  bc team create engineering
+  bc team list
+  bc team show engineering
+  bc team delete engineering`,
+}
+
+var teamCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create a team",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTeamCreate,
+}
+
+var teamListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all teams",
+	RunE:  runTeamList,
+}
+
+var teamShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "Show team details",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTeamShow,
+}
+
+var teamDeleteCmd = &cobra.Command{
+	Use:   "delete <name>",
+	Short: "Delete a team",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTeamDelete,
+}
+
+func init() {
+	teamCmd.AddCommand(teamCreateCmd)
+	teamCmd.AddCommand(teamListCmd)
+	teamCmd.AddCommand(teamShowCmd)
+	teamCmd.AddCommand(teamDeleteCmd)
+	rootCmd.AddCommand(teamCmd)
+}
+
+func runTeamCreate(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	store := team.NewStore(ws.RootDir)
+
+	t, err := store.Create(name)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Created team %q\n", t.Name)
+	return nil
+}
+
+func runTeamList(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	store := team.NewStore(ws.RootDir)
+	teams, err := store.List()
+	if err != nil {
+		return err
+	}
+
+	if len(teams) == 0 {
+		fmt.Println("No teams configured")
+		fmt.Println()
+		fmt.Println("Create one with: bc team create <name>")
+		return nil
+	}
+
+	fmt.Printf("%-20s %-10s %-20s %s\n", "NAME", "MEMBERS", "LEAD", "DESCRIPTION")
+	fmt.Println("--------------------------------------------------------------------")
+	for _, t := range teams {
+		lead := t.Lead
+		if lead == "" {
+			lead = "-"
+		}
+		desc := t.Description
+		if len(desc) > 25 {
+			desc = desc[:22] + "..."
+		}
+		if desc == "" {
+			desc = "-"
+		}
+		fmt.Printf("%-20s %-10d %-20s %s\n", t.Name, len(t.Members), lead, desc)
+	}
+
+	return nil
+}
+
+func runTeamShow(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	store := team.NewStore(ws.RootDir)
+
+	t, err := store.Get(name)
+	if err != nil {
+		return err
+	}
+	if t == nil {
+		return fmt.Errorf("team %q not found", name)
+	}
+
+	fmt.Printf("Name:        %s\n", t.Name)
+	if t.Description != "" {
+		fmt.Printf("Description: %s\n", t.Description)
+	}
+	if t.Lead != "" {
+		fmt.Printf("Lead:        %s\n", t.Lead)
+	}
+	fmt.Printf("Members:     %d\n", len(t.Members))
+	if len(t.Members) > 0 {
+		for _, m := range t.Members {
+			fmt.Printf("  - %s\n", m)
+		}
+	}
+	fmt.Printf("Created:     %s\n", t.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("Updated:     %s\n", t.UpdatedAt.Format("2006-01-02 15:04:05"))
+
+	return nil
+}
+
+func runTeamDelete(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	store := team.NewStore(ws.RootDir)
+
+	if err := store.Delete(name); err != nil {
+		return err
+	}
+
+	fmt.Printf("Deleted team %q\n", name)
+	return nil
+}

--- a/internal/cmd/team_test.go
+++ b/internal/cmd/team_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/team"
+)
+
+func TestTeamCreate(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	output, err := executeCmd("team", "create", "engineering")
+	if err != nil {
+		t.Fatalf("team create failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Created team") {
+		t.Errorf("expected confirmation message, got: %s", output)
+	}
+	if !strings.Contains(output, "engineering") {
+		t.Errorf("output should contain team name: %s", output)
+	}
+
+	// Verify team was created
+	store := team.NewStore(wsDir)
+	tm, getErr := store.Get("engineering")
+	if getErr != nil {
+		t.Fatalf("failed to get team: %v", getErr)
+	}
+	if tm == nil {
+		t.Fatal("team not found after creation")
+	}
+}
+
+func TestTeamCreateDuplicate(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("team", "create", "dup-team")
+	if err != nil {
+		t.Fatalf("first team create failed: %v", err)
+	}
+
+	_, err = executeCmd("team", "create", "dup-team")
+	if err == nil {
+		t.Error("expected error for duplicate team")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention already exists: %v", err)
+	}
+}
+
+func TestTeamList(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create some teams
+	store := team.NewStore(wsDir)
+	_, _ = store.Create("team1")
+	_, _ = store.Create("team2")
+
+	output, err := executeCmd("team", "list")
+	if err != nil {
+		t.Fatalf("team list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "team1") {
+		t.Errorf("output should contain team1: %s", output)
+	}
+	if !strings.Contains(output, "team2") {
+		t.Errorf("output should contain team2: %s", output)
+	}
+	if !strings.Contains(output, "NAME") {
+		t.Errorf("output should contain header: %s", output)
+	}
+}
+
+func TestTeamListEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	output, err := executeCmd("team", "list")
+	if err != nil {
+		t.Fatalf("team list failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "No teams configured") {
+		t.Errorf("output should indicate no teams: %s", output)
+	}
+}
+
+func TestTeamShow(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a team with members
+	store := team.NewStore(wsDir)
+	_, _ = store.Create("engineering")
+	_ = store.SetDescription("engineering", "The engineering team")
+	_ = store.SetLead("engineering", "tech-lead-01")
+	_ = store.AddMember("engineering", "engineer-01")
+	_ = store.AddMember("engineering", "engineer-02")
+
+	output, err := executeCmd("team", "show", "engineering")
+	if err != nil {
+		t.Fatalf("team show failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "engineering") {
+		t.Errorf("output should contain team name: %s", output)
+	}
+	if !strings.Contains(output, "The engineering team") {
+		t.Errorf("output should contain description: %s", output)
+	}
+	if !strings.Contains(output, "tech-lead-01") {
+		t.Errorf("output should contain lead: %s", output)
+	}
+	if !strings.Contains(output, "engineer-01") {
+		t.Errorf("output should contain member: %s", output)
+	}
+}
+
+func TestTeamShowNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("team", "show", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent team")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}
+
+func TestTeamDelete(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a team
+	store := team.NewStore(wsDir)
+	_, _ = store.Create("deletable")
+
+	output, err := executeCmd("team", "delete", "deletable")
+	if err != nil {
+		t.Fatalf("team delete failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Deleted team") {
+		t.Errorf("output should confirm deletion: %s", output)
+	}
+
+	// Verify deletion
+	if store.Exists("deletable") {
+		t.Error("team should not exist after deletion")
+	}
+}
+
+func TestTeamDeleteNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("team", "delete", "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent team")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -1,0 +1,208 @@
+// Package team provides team management for bc.
+// Teams are organizational units that group agents together.
+package team
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Team represents an organizational team of agents.
+//
+//nolint:govet // fieldalignment: minor 8 byte difference not worth reordering for JSON readability
+type Team struct {
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	Members     []string  `json:"members,omitempty"` // Agent names
+	Lead        string    `json:"lead,omitempty"`    // Team lead agent
+}
+
+// Store manages team configurations.
+type Store struct {
+	teamsDir string
+}
+
+// NewStore creates a new team store.
+func NewStore(rootDir string) *Store {
+	return &Store{
+		teamsDir: filepath.Join(rootDir, ".bc", "teams"),
+	}
+}
+
+// Init creates the teams directory if it doesn't exist.
+func (s *Store) Init() error {
+	return os.MkdirAll(s.teamsDir, 0750)
+}
+
+// Create creates a new team.
+func (s *Store) Create(name string) (*Team, error) {
+	if name == "" {
+		return nil, fmt.Errorf("team name cannot be empty")
+	}
+
+	// Check if team already exists
+	if s.Exists(name) {
+		return nil, fmt.Errorf("team %q already exists", name)
+	}
+
+	now := time.Now().UTC()
+	team := &Team{
+		Name:      name,
+		Members:   []string{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := s.save(team); err != nil {
+		return nil, err
+	}
+
+	return team, nil
+}
+
+// Get retrieves a team by name.
+func (s *Store) Get(name string) (*Team, error) {
+	path := s.teamPath(name)
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from trusted teamsDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read team: %w", err)
+	}
+
+	var team Team
+	if err := json.Unmarshal(data, &team); err != nil {
+		return nil, fmt.Errorf("failed to parse team: %w", err)
+	}
+
+	return &team, nil
+}
+
+// List returns all teams.
+func (s *Store) List() ([]*Team, error) {
+	entries, err := os.ReadDir(s.teamsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read teams dir: %w", err)
+	}
+
+	var teams []*Team
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".json") {
+			name := strings.TrimSuffix(entry.Name(), ".json")
+			team, err := s.Get(name)
+			if err != nil {
+				continue // Skip invalid entries
+			}
+			if team != nil {
+				teams = append(teams, team)
+			}
+		}
+	}
+
+	return teams, nil
+}
+
+// Delete removes a team.
+func (s *Store) Delete(name string) error {
+	path := s.teamPath(name)
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("team %q not found", name)
+		}
+		return fmt.Errorf("failed to delete team: %w", err)
+	}
+	return nil
+}
+
+// Exists checks if a team exists.
+func (s *Store) Exists(name string) bool {
+	_, err := os.Stat(s.teamPath(name))
+	return err == nil
+}
+
+// Update modifies an existing team using the provided update function.
+func (s *Store) Update(name string, updateFn func(*Team)) error {
+	team, err := s.Get(name)
+	if err != nil {
+		return err
+	}
+	if team == nil {
+		return fmt.Errorf("team %q not found", name)
+	}
+
+	updateFn(team)
+	team.UpdatedAt = time.Now().UTC()
+
+	return s.save(team)
+}
+
+// AddMember adds an agent to a team.
+func (s *Store) AddMember(teamName, agentName string) error {
+	return s.Update(teamName, func(t *Team) {
+		// Check if already a member
+		if slices.Contains(t.Members, agentName) {
+			return
+		}
+		t.Members = append(t.Members, agentName)
+	})
+}
+
+// RemoveMember removes an agent from a team.
+func (s *Store) RemoveMember(teamName, agentName string) error {
+	return s.Update(teamName, func(t *Team) {
+		filtered := make([]string, 0, len(t.Members))
+		for _, m := range t.Members {
+			if m != agentName {
+				filtered = append(filtered, m)
+			}
+		}
+		t.Members = filtered
+	})
+}
+
+// SetLead sets the team lead.
+func (s *Store) SetLead(teamName, agentName string) error {
+	return s.Update(teamName, func(t *Team) {
+		t.Lead = agentName
+	})
+}
+
+// SetDescription sets the team description.
+func (s *Store) SetDescription(teamName, description string) error {
+	return s.Update(teamName, func(t *Team) {
+		t.Description = description
+	})
+}
+
+func (s *Store) save(team *Team) error {
+	if err := s.Init(); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(team, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal team: %w", err)
+	}
+
+	path := s.teamPath(team.Name)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write team: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Store) teamPath(name string) string {
+	return filepath.Join(s.teamsDir, name+".json")
+}

--- a/pkg/team/team_test.go
+++ b/pkg/team/team_test.go
@@ -1,0 +1,318 @@
+package team
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewStore(t *testing.T) {
+	store := NewStore("/tmp/test")
+	if store == nil {
+		t.Fatal("NewStore returned nil")
+	}
+	expected := filepath.Join("/tmp/test", ".bc", "teams")
+	if store.teamsDir != expected {
+		t.Errorf("teamsDir = %q, want %q", store.teamsDir, expected)
+	}
+}
+
+func TestInit(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	err := store.Init()
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	teamsDir := filepath.Join(tmpDir, ".bc", "teams")
+	if _, statErr := os.Stat(teamsDir); os.IsNotExist(statErr) {
+		t.Errorf("Teams directory not created: %s", teamsDir)
+	}
+}
+
+func TestStoreCreate(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	team, err := store.Create("engineering")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if team.Name != "engineering" {
+		t.Errorf("Name = %q, want %q", team.Name, "engineering")
+	}
+	if team.CreatedAt.IsZero() {
+		t.Error("CreatedAt should be set")
+	}
+	if len(team.Members) != 0 {
+		t.Errorf("Members should be empty, got %v", team.Members)
+	}
+}
+
+func TestStoreCreateEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("")
+	if err == nil {
+		t.Error("Expected error for empty name")
+	}
+}
+
+func TestStoreCreateDuplicate(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("engineering")
+	if err != nil {
+		t.Fatalf("First Create failed: %v", err)
+	}
+
+	_, err = store.Create("engineering")
+	if err == nil {
+		t.Error("Expected error for duplicate team")
+	}
+}
+
+func TestStoreGet(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-team")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	got, err := store.Get("test-team")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.Name != "test-team" {
+		t.Errorf("Name = %q, want %q", got.Name, "test-team")
+	}
+}
+
+func TestStoreGetNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	got, err := store.Get("nonexistent")
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if got != nil {
+		t.Error("Expected nil for nonexistent team")
+	}
+}
+
+func TestStoreList(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, _ = store.Create("team1")
+	_, _ = store.Create("team2")
+	_, _ = store.Create("team3")
+
+	teams, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(teams) != 3 {
+		t.Errorf("List returned %d teams, want 3", len(teams))
+	}
+}
+
+func TestStoreListEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	teams, err := store.List()
+	if err != nil {
+		t.Fatalf("List failed: %v", err)
+	}
+	if len(teams) != 0 {
+		t.Errorf("List returned %d teams, want 0", len(teams))
+	}
+}
+
+func TestStoreDelete(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("deletable")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	if !store.Exists("deletable") {
+		t.Error("Team should exist before delete")
+	}
+
+	err = store.Delete("deletable")
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	if store.Exists("deletable") {
+		t.Error("Team should not exist after delete")
+	}
+}
+
+func TestStoreDeleteNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	err := store.Delete("nonexistent")
+	if err == nil {
+		t.Error("Expected error for nonexistent team")
+	}
+}
+
+func TestStoreUpdate(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("updatable")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	err = store.Update("updatable", func(t *Team) {
+		t.Description = "test description"
+	})
+	if err != nil {
+		t.Fatalf("Update failed: %v", err)
+	}
+
+	got, _ := store.Get("updatable")
+	if got.Description != "test description" {
+		t.Errorf("Description = %q, want %q", got.Description, "test description")
+	}
+}
+
+func TestStoreUpdateNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	err := store.Update("nonexistent", func(t *Team) {
+		t.Description = "test"
+	})
+	if err == nil {
+		t.Error("Expected error for nonexistent team")
+	}
+}
+
+func TestStoreAddMember(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("engineering")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	err = store.AddMember("engineering", "engineer-01")
+	if err != nil {
+		t.Fatalf("AddMember failed: %v", err)
+	}
+
+	got, _ := store.Get("engineering")
+	if len(got.Members) != 1 {
+		t.Fatalf("Members len = %d, want 1", len(got.Members))
+	}
+	if got.Members[0] != "engineer-01" {
+		t.Errorf("Members[0] = %q, want %q", got.Members[0], "engineer-01")
+	}
+
+	// Add same member again - should not duplicate
+	err = store.AddMember("engineering", "engineer-01")
+	if err != nil {
+		t.Fatalf("Second AddMember failed: %v", err)
+	}
+
+	got, _ = store.Get("engineering")
+	if len(got.Members) != 1 {
+		t.Errorf("Members len = %d, want 1 (no duplicate)", len(got.Members))
+	}
+}
+
+func TestStoreRemoveMember(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("engineering")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	_ = store.AddMember("engineering", "engineer-01")
+	_ = store.AddMember("engineering", "engineer-02")
+
+	err = store.RemoveMember("engineering", "engineer-01")
+	if err != nil {
+		t.Fatalf("RemoveMember failed: %v", err)
+	}
+
+	got, _ := store.Get("engineering")
+	if len(got.Members) != 1 {
+		t.Fatalf("Members len = %d, want 1", len(got.Members))
+	}
+	if got.Members[0] != "engineer-02" {
+		t.Errorf("Members[0] = %q, want %q", got.Members[0], "engineer-02")
+	}
+}
+
+func TestStoreSetLead(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("engineering")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	err = store.SetLead("engineering", "tech-lead-01")
+	if err != nil {
+		t.Fatalf("SetLead failed: %v", err)
+	}
+
+	got, _ := store.Get("engineering")
+	if got.Lead != "tech-lead-01" {
+		t.Errorf("Lead = %q, want %q", got.Lead, "tech-lead-01")
+	}
+}
+
+func TestStoreSetDescription(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("engineering")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	err = store.SetDescription("engineering", "The engineering team")
+	if err != nil {
+		t.Fatalf("SetDescription failed: %v", err)
+	}
+
+	got, _ := store.Get("engineering")
+	if got.Description != "The engineering team" {
+		t.Errorf("Description = %q, want %q", got.Description, "The engineering team")
+	}
+}
+
+func TestTeamPath(t *testing.T) {
+	store := NewStore("/tmp/test")
+	expected := filepath.Join("/tmp/test", ".bc", "teams", "my-team.json")
+	got := store.teamPath("my-team")
+	if got != expected {
+		t.Errorf("teamPath = %q, want %q", got, expected)
+	}
+}


### PR DESCRIPTION
## Summary

Add team management for bc:

**pkg/team package:**
- Team struct with name, description, members, lead
- CRUD operations: Create, Get, List, Delete, Update
- Member management: AddMember, RemoveMember
- Configuration: SetLead, SetDescription
- JSON storage in .bc/teams/

**CLI commands:**
- `bc team create <name>` - create a new team
- `bc team list` - list all teams with member count
- `bc team show <name>` - show team details including members
- `bc team delete <name>` - delete a team

## Test plan

- [x] pkg/team tests with 86.8% coverage
- [x] CLI tests for all commands
- [x] Error cases tested (duplicate, not found)
- [x] golangci-lint passes

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)