### PR TITLE
feat: add team member management CLI commands

### DIFF
--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -49,11 +49,27 @@ var teamDeleteCmd = &cobra.Command{
 	RunE:  runTeamDelete,
 }
 
+var teamAddCmd = &cobra.Command{
+	Use:   "add <team> <agent>",
+	Short: "Add an agent to a team",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runTeamAdd,
+}
+
+var teamRemoveCmd = &cobra.Command{
+	Use:   "remove <team> <agent>",
+	Short: "Remove an agent from a team",
+	Args:  cobra.ExactArgs(2),
+	RunE:  runTeamRemove,
+}
+
 func init() {
 	teamCmd.AddCommand(teamCreateCmd)
 	teamCmd.AddCommand(teamListCmd)
 	teamCmd.AddCommand(teamShowCmd)
 	teamCmd.AddCommand(teamDeleteCmd)
+	teamCmd.AddCommand(teamAddCmd)
+	teamCmd.AddCommand(teamRemoveCmd)
 	rootCmd.AddCommand(teamCmd)
 }
 
@@ -164,5 +180,41 @@ func runTeamDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Deleted team %q\n", name)
+	return nil
+}
+
+func runTeamAdd(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	teamName := args[0]
+	agentName := args[1]
+	store := team.NewStore(ws.RootDir)
+
+	if err := store.AddMember(teamName, agentName); err != nil {
+		return err
+	}
+
+	fmt.Printf("Added %q to team %q\n", agentName, teamName)
+	return nil
+}
+
+func runTeamRemove(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	teamName := args[0]
+	agentName := args[1]
+	store := team.NewStore(ws.RootDir)
+
+	if err := store.RemoveMember(teamName, agentName); err != nil {
+		return err
+	}
+
+	fmt.Printf("Removed %q from team %q\n", agentName, teamName)
 	return nil
 }

--- a/internal/cmd/team_test.go
+++ b/internal/cmd/team_test.go
@@ -157,3 +157,85 @@ func TestTeamDeleteNotFound(t *testing.T) {
 		t.Errorf("error should mention not found: %v", err)
 	}
 }
+
+func TestTeamAdd(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a team
+	store := team.NewStore(wsDir)
+	_, _ = store.Create("engineering")
+
+	output, err := executeCmd("team", "add", "engineering", "engineer-01")
+	if err != nil {
+		t.Fatalf("team add failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Added") {
+		t.Errorf("output should confirm addition: %s", output)
+	}
+	if !strings.Contains(output, "engineer-01") {
+		t.Errorf("output should contain agent name: %s", output)
+	}
+
+	// Verify member was added
+	tm, _ := store.Get("engineering")
+	if len(tm.Members) != 1 {
+		t.Fatalf("Members len = %d, want 1", len(tm.Members))
+	}
+	if tm.Members[0] != "engineer-01" {
+		t.Errorf("Members[0] = %q, want %q", tm.Members[0], "engineer-01")
+	}
+}
+
+func TestTeamAddTeamNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("team", "add", "nonexistent", "agent-01")
+	if err == nil {
+		t.Error("expected error for nonexistent team")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}
+
+func TestTeamRemove(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a team with a member
+	store := team.NewStore(wsDir)
+	_, _ = store.Create("engineering")
+	_ = store.AddMember("engineering", "engineer-01")
+	_ = store.AddMember("engineering", "engineer-02")
+
+	output, err := executeCmd("team", "remove", "engineering", "engineer-01")
+	if err != nil {
+		t.Fatalf("team remove failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Removed") {
+		t.Errorf("output should confirm removal: %s", output)
+	}
+	if !strings.Contains(output, "engineer-01") {
+		t.Errorf("output should contain agent name: %s", output)
+	}
+
+	// Verify member was removed
+	tm, _ := store.Get("engineering")
+	if len(tm.Members) != 1 {
+		t.Fatalf("Members len = %d, want 1", len(tm.Members))
+	}
+	if tm.Members[0] != "engineer-02" {
+		t.Errorf("Members[0] = %q, want %q", tm.Members[0], "engineer-02")
+	}
+}
+
+func TestTeamRemoveTeamNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("team", "remove", "nonexistent", "agent-01")
+	if err == nil {
+		t.Error("expected error for nonexistent team")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Add CLI commands for team membership management:
- `bc team add <team> <agent>` - add an agent to a team
- `bc team remove <team> <agent>` - remove an agent from a team

## Dependencies

⚠️ **Depends on #143** (team create/list) which adds the pkg/team package and base CLI.

## Test plan

- [x] Tests for add/remove commands
- [x] Error cases tested (team not found)
- [x] All team tests pass
- [x] golangci-lint passes

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)