### PR TITLE
feat(cost): add cost tracking data model and storage

### DIFF
--- a/pkg/cost/cost.go
+++ b/pkg/cost/cost.go
@@ -1,0 +1,405 @@
+// Package cost provides cost tracking and reporting for bc.
+package cost
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Record represents a cost entry for an API call.
+type Record struct {
+	Timestamp    time.Time `json:"timestamp"`
+	AgentID      string    `json:"agent_id"`
+	Model        string    `json:"model"`
+	TeamID       string    `json:"team_id,omitempty"`
+	ID           int64     `json:"id"`
+	InputTokens  int64     `json:"input_tokens"`
+	OutputTokens int64     `json:"output_tokens"`
+	TotalTokens  int64     `json:"total_tokens"`
+	CostUSD      float64   `json:"cost_usd"`
+}
+
+// Summary represents aggregated cost data.
+type Summary struct {
+	AgentID      string  `json:"agent_id,omitempty"`
+	TeamID       string  `json:"team_id,omitempty"`
+	Model        string  `json:"model,omitempty"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalTokens  int64   `json:"total_tokens"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	RecordCount  int64   `json:"record_count"`
+}
+
+// Store provides SQLite-backed cost tracking.
+type Store struct {
+	db   *sql.DB
+	path string
+}
+
+// NewStore creates a new cost store for the given workspace.
+func NewStore(workspacePath string) *Store {
+	return &Store{
+		path: filepath.Join(workspacePath, ".bc", "costs.db"),
+	}
+}
+
+// Open initializes the SQLite database.
+func (s *Store) Open() error {
+	if err := os.MkdirAll(filepath.Dir(s.path), 0750); err != nil {
+		return fmt.Errorf("failed to create database directory: %w", err)
+	}
+
+	db, err := sql.Open("sqlite3", s.path+"?_foreign_keys=on")
+	if err != nil {
+		return fmt.Errorf("failed to open database: %w", err)
+	}
+
+	if err := s.initSchema(db); err != nil {
+		_ = db.Close()
+		return fmt.Errorf("failed to initialize schema: %w", err)
+	}
+
+	s.db = db
+	return nil
+}
+
+// initSchema creates the database tables.
+func (s *Store) initSchema(db *sql.DB) error {
+	ctx := context.Background()
+
+	schema := `
+		CREATE TABLE IF NOT EXISTS cost_records (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			agent_id      TEXT NOT NULL,
+			team_id       TEXT,
+			model         TEXT NOT NULL,
+			input_tokens  INTEGER NOT NULL DEFAULT 0,
+			output_tokens INTEGER NOT NULL DEFAULT 0,
+			total_tokens  INTEGER NOT NULL DEFAULT 0,
+			cost_usd      REAL NOT NULL DEFAULT 0,
+			timestamp     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+		);
+		CREATE INDEX IF NOT EXISTS idx_cost_records_agent ON cost_records(agent_id);
+		CREATE INDEX IF NOT EXISTS idx_cost_records_team ON cost_records(team_id);
+		CREATE INDEX IF NOT EXISTS idx_cost_records_model ON cost_records(model);
+		CREATE INDEX IF NOT EXISTS idx_cost_records_timestamp ON cost_records(timestamp DESC);
+	`
+
+	if _, err := db.ExecContext(ctx, schema); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close closes the database connection.
+func (s *Store) Close() error {
+	if s.db != nil {
+		return s.db.Close()
+	}
+	return nil
+}
+
+// DB returns the underlying database connection.
+func (s *Store) DB() *sql.DB {
+	return s.db
+}
+
+// Record adds a new cost record.
+func (s *Store) Record(agentID, teamID, model string, inputTokens, outputTokens int64, costUSD float64) (*Record, error) {
+	ctx := context.Background()
+	totalTokens := inputTokens + outputTokens
+
+	var teamPtr *string
+	if teamID != "" {
+		teamPtr = &teamID
+	}
+
+	result, err := s.db.ExecContext(ctx,
+		`INSERT INTO cost_records (agent_id, team_id, model, input_tokens, output_tokens, total_tokens, cost_usd)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		agentID, teamPtr, model, inputTokens, outputTokens, totalTokens, costUSD,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to record cost: %w", err)
+	}
+
+	id, _ := result.LastInsertId()
+	return s.GetByID(id)
+}
+
+// GetByID returns a cost record by ID.
+func (s *Store) GetByID(id int64) (*Record, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx,
+		`SELECT id, agent_id, team_id, model, input_tokens, output_tokens, total_tokens, cost_usd, timestamp
+		 FROM cost_records WHERE id = ?`,
+		id,
+	)
+	return s.scanRecord(row)
+}
+
+func (s *Store) scanRecord(row *sql.Row) (*Record, error) {
+	var r Record
+	var timestamp string
+	var teamID sql.NullString
+
+	err := row.Scan(&r.ID, &r.AgentID, &teamID, &r.Model, &r.InputTokens, &r.OutputTokens, &r.TotalTokens, &r.CostUSD, &timestamp)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan record: %w", err)
+	}
+
+	r.TeamID = teamID.String
+	r.Timestamp, _ = time.Parse(time.RFC3339, timestamp)
+	return &r, nil
+}
+
+// GetByAgent returns all cost records for an agent.
+func (s *Store) GetByAgent(agentID string, limit int) ([]*Record, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, agent_id, team_id, model, input_tokens, output_tokens, total_tokens, cost_usd, timestamp
+		 FROM cost_records WHERE agent_id = ? ORDER BY timestamp DESC LIMIT ?`,
+		agentID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get records by agent: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return s.scanRecords(rows)
+}
+
+// GetByTeam returns all cost records for a team.
+func (s *Store) GetByTeam(teamID string, limit int) ([]*Record, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, agent_id, team_id, model, input_tokens, output_tokens, total_tokens, cost_usd, timestamp
+		 FROM cost_records WHERE team_id = ? ORDER BY timestamp DESC LIMIT ?`,
+		teamID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get records by team: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return s.scanRecords(rows)
+}
+
+// GetAll returns all cost records.
+func (s *Store) GetAll(limit int) ([]*Record, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, agent_id, team_id, model, input_tokens, output_tokens, total_tokens, cost_usd, timestamp
+		 FROM cost_records ORDER BY timestamp DESC LIMIT ?`,
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get all records: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return s.scanRecords(rows)
+}
+
+func (s *Store) scanRecords(rows *sql.Rows) ([]*Record, error) {
+	var records []*Record
+	for rows.Next() {
+		var r Record
+		var timestamp string
+		var teamID sql.NullString
+
+		if err := rows.Scan(&r.ID, &r.AgentID, &teamID, &r.Model, &r.InputTokens, &r.OutputTokens, &r.TotalTokens, &r.CostUSD, &timestamp); err != nil {
+			return nil, fmt.Errorf("failed to scan record: %w", err)
+		}
+
+		r.TeamID = teamID.String
+		r.Timestamp, _ = time.Parse(time.RFC3339, timestamp)
+		records = append(records, &r)
+	}
+	return records, rows.Err()
+}
+
+// SummaryByAgent returns aggregated costs per agent.
+func (s *Store) SummaryByAgent() ([]*Summary, error) {
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT agent_id, SUM(input_tokens), SUM(output_tokens), SUM(total_tokens), SUM(cost_usd), COUNT(*)
+		 FROM cost_records GROUP BY agent_id ORDER BY SUM(cost_usd) DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get summary by agent: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var summaries []*Summary
+	for rows.Next() {
+		var sum Summary
+		if err := rows.Scan(&sum.AgentID, &sum.InputTokens, &sum.OutputTokens, &sum.TotalTokens, &sum.TotalCostUSD, &sum.RecordCount); err != nil {
+			return nil, fmt.Errorf("failed to scan summary: %w", err)
+		}
+		summaries = append(summaries, &sum)
+	}
+	return summaries, rows.Err()
+}
+
+// SummaryByTeam returns aggregated costs per team.
+func (s *Store) SummaryByTeam() ([]*Summary, error) {
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT team_id, SUM(input_tokens), SUM(output_tokens), SUM(total_tokens), SUM(cost_usd), COUNT(*)
+		 FROM cost_records WHERE team_id IS NOT NULL GROUP BY team_id ORDER BY SUM(cost_usd) DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get summary by team: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var summaries []*Summary
+	for rows.Next() {
+		var sum Summary
+		var teamID sql.NullString
+		if err := rows.Scan(&teamID, &sum.InputTokens, &sum.OutputTokens, &sum.TotalTokens, &sum.TotalCostUSD, &sum.RecordCount); err != nil {
+			return nil, fmt.Errorf("failed to scan summary: %w", err)
+		}
+		sum.TeamID = teamID.String
+		summaries = append(summaries, &sum)
+	}
+	return summaries, rows.Err()
+}
+
+// SummaryByModel returns aggregated costs per model.
+func (s *Store) SummaryByModel() ([]*Summary, error) {
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT model, SUM(input_tokens), SUM(output_tokens), SUM(total_tokens), SUM(cost_usd), COUNT(*)
+		 FROM cost_records GROUP BY model ORDER BY SUM(cost_usd) DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get summary by model: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var summaries []*Summary
+	for rows.Next() {
+		var sum Summary
+		if err := rows.Scan(&sum.Model, &sum.InputTokens, &sum.OutputTokens, &sum.TotalTokens, &sum.TotalCostUSD, &sum.RecordCount); err != nil {
+			return nil, fmt.Errorf("failed to scan summary: %w", err)
+		}
+		summaries = append(summaries, &sum)
+	}
+	return summaries, rows.Err()
+}
+
+// WorkspaceSummary returns the total cost summary for the entire workspace.
+func (s *Store) WorkspaceSummary() (*Summary, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx,
+		`SELECT SUM(input_tokens), SUM(output_tokens), SUM(total_tokens), SUM(cost_usd), COUNT(*)
+		 FROM cost_records`,
+	)
+
+	var sum Summary
+	var inputTokens, outputTokens, totalTokens sql.NullInt64
+	var costUSD sql.NullFloat64
+	var recordCount sql.NullInt64
+
+	if err := row.Scan(&inputTokens, &outputTokens, &totalTokens, &costUSD, &recordCount); err != nil {
+		return nil, fmt.Errorf("failed to scan workspace summary: %w", err)
+	}
+
+	sum.InputTokens = inputTokens.Int64
+	sum.OutputTokens = outputTokens.Int64
+	sum.TotalTokens = totalTokens.Int64
+	sum.TotalCostUSD = costUSD.Float64
+	sum.RecordCount = recordCount.Int64
+
+	return &sum, nil
+}
+
+// AgentSummary returns the cost summary for a specific agent.
+func (s *Store) AgentSummary(agentID string) (*Summary, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx,
+		`SELECT SUM(input_tokens), SUM(output_tokens), SUM(total_tokens), SUM(cost_usd), COUNT(*)
+		 FROM cost_records WHERE agent_id = ?`,
+		agentID,
+	)
+
+	var sum Summary
+	var inputTokens, outputTokens, totalTokens sql.NullInt64
+	var costUSD sql.NullFloat64
+	var recordCount sql.NullInt64
+
+	if err := row.Scan(&inputTokens, &outputTokens, &totalTokens, &costUSD, &recordCount); err != nil {
+		return nil, fmt.Errorf("failed to scan agent summary: %w", err)
+	}
+
+	sum.AgentID = agentID
+	sum.InputTokens = inputTokens.Int64
+	sum.OutputTokens = outputTokens.Int64
+	sum.TotalTokens = totalTokens.Int64
+	sum.TotalCostUSD = costUSD.Float64
+	sum.RecordCount = recordCount.Int64
+
+	return &sum, nil
+}
+
+// TeamSummary returns the cost summary for a specific team.
+func (s *Store) TeamSummary(teamID string) (*Summary, error) {
+	ctx := context.Background()
+	row := s.db.QueryRowContext(ctx,
+		`SELECT SUM(input_tokens), SUM(output_tokens), SUM(total_tokens), SUM(cost_usd), COUNT(*)
+		 FROM cost_records WHERE team_id = ?`,
+		teamID,
+	)
+
+	var sum Summary
+	var inputTokens, outputTokens, totalTokens sql.NullInt64
+	var costUSD sql.NullFloat64
+	var recordCount sql.NullInt64
+
+	if err := row.Scan(&inputTokens, &outputTokens, &totalTokens, &costUSD, &recordCount); err != nil {
+		return nil, fmt.Errorf("failed to scan team summary: %w", err)
+	}
+
+	sum.TeamID = teamID
+	sum.InputTokens = inputTokens.Int64
+	sum.OutputTokens = outputTokens.Int64
+	sum.TotalTokens = totalTokens.Int64
+	sum.TotalCostUSD = costUSD.Float64
+	sum.RecordCount = recordCount.Int64
+
+	return &sum, nil
+}
+
+// Clear removes all cost records.
+func (s *Store) Clear() error {
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx, "DELETE FROM cost_records")
+	if err != nil {
+		return fmt.Errorf("failed to clear cost records: %w", err)
+	}
+	return nil
+}

--- a/pkg/cost/cost_test.go
+++ b/pkg/cost/cost_test.go
@@ -1,0 +1,453 @@
+package cost
+
+import (
+	"testing"
+)
+
+func TestNewStore(t *testing.T) {
+	store := NewStore("/tmp/test")
+	if store == nil {
+		t.Fatal("NewStore returned nil")
+	}
+	if store.path != "/tmp/test/.bc/costs.db" {
+		t.Errorf("path = %q, want %q", store.path, "/tmp/test/.bc/costs.db")
+	}
+}
+
+func TestStoreOpenClose(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+
+	if store.DB() == nil {
+		t.Error("DB() should not be nil after Open")
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+}
+
+func TestStoreRecord(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	record, err := store.Record("engineer-01", "team-a", "claude-3-opus", 1000, 500, 0.05)
+	if err != nil {
+		t.Fatalf("Record failed: %v", err)
+	}
+
+	if record.AgentID != "engineer-01" {
+		t.Errorf("AgentID = %q, want %q", record.AgentID, "engineer-01")
+	}
+	if record.TeamID != "team-a" {
+		t.Errorf("TeamID = %q, want %q", record.TeamID, "team-a")
+	}
+	if record.Model != "claude-3-opus" {
+		t.Errorf("Model = %q, want %q", record.Model, "claude-3-opus")
+	}
+	if record.InputTokens != 1000 {
+		t.Errorf("InputTokens = %d, want %d", record.InputTokens, 1000)
+	}
+	if record.OutputTokens != 500 {
+		t.Errorf("OutputTokens = %d, want %d", record.OutputTokens, 500)
+	}
+	if record.TotalTokens != 1500 {
+		t.Errorf("TotalTokens = %d, want %d", record.TotalTokens, 1500)
+	}
+	if record.CostUSD != 0.05 {
+		t.Errorf("CostUSD = %f, want %f", record.CostUSD, 0.05)
+	}
+	if record.ID == 0 {
+		t.Error("ID should not be 0")
+	}
+	if record.Timestamp.IsZero() {
+		t.Error("Timestamp should not be zero")
+	}
+}
+
+func TestStoreRecordNoTeam(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	record, err := store.Record("engineer-01", "", "claude-3-sonnet", 500, 250, 0.01)
+	if err != nil {
+		t.Fatalf("Record failed: %v", err)
+	}
+
+	if record.TeamID != "" {
+		t.Errorf("TeamID = %q, want empty", record.TeamID)
+	}
+}
+
+func TestStoreGetByID(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	record, _ := store.Record("engineer-01", "team-a", "claude-3-opus", 1000, 500, 0.05)
+
+	got, err := store.GetByID(record.ID)
+	if err != nil {
+		t.Fatalf("GetByID failed: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetByID returned nil")
+	}
+	if got.AgentID != "engineer-01" {
+		t.Errorf("AgentID = %q, want %q", got.AgentID, "engineer-01")
+	}
+}
+
+func TestStoreGetByIDNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	got, err := store.GetByID(999)
+	if err != nil {
+		t.Fatalf("GetByID should not error: %v", err)
+	}
+	if got != nil {
+		t.Error("GetByID should return nil for non-existent ID")
+	}
+}
+
+func TestStoreGetByAgent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("engineer-01", "", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("engineer-01", "", "model-b", 200, 100, 0.02)
+	_, _ = store.Record("engineer-02", "", "model-a", 300, 150, 0.03)
+
+	records, err := store.GetByAgent("engineer-01", 10)
+	if err != nil {
+		t.Fatalf("GetByAgent failed: %v", err)
+	}
+	if len(records) != 2 {
+		t.Errorf("len(records) = %d, want 2", len(records))
+	}
+}
+
+func TestStoreGetByTeam(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("engineer-01", "team-a", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("engineer-02", "team-a", "model-a", 200, 100, 0.02)
+	_, _ = store.Record("engineer-03", "team-b", "model-a", 300, 150, 0.03)
+
+	records, err := store.GetByTeam("team-a", 10)
+	if err != nil {
+		t.Fatalf("GetByTeam failed: %v", err)
+	}
+	if len(records) != 2 {
+		t.Errorf("len(records) = %d, want 2", len(records))
+	}
+}
+
+func TestStoreGetAll(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("agent-1", "", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("agent-2", "", "model-a", 200, 100, 0.02)
+	_, _ = store.Record("agent-3", "", "model-a", 300, 150, 0.03)
+
+	records, err := store.GetAll(10)
+	if err != nil {
+		t.Fatalf("GetAll failed: %v", err)
+	}
+	if len(records) != 3 {
+		t.Errorf("len(records) = %d, want 3", len(records))
+	}
+}
+
+func TestStoreSummaryByAgent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("engineer-01", "", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("engineer-01", "", "model-a", 200, 100, 0.02)
+	_, _ = store.Record("engineer-02", "", "model-a", 300, 150, 0.03)
+
+	summaries, err := store.SummaryByAgent()
+	if err != nil {
+		t.Fatalf("SummaryByAgent failed: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("len(summaries) = %d, want 2", len(summaries))
+	}
+
+	// Find engineer-01 summary
+	var eng01 *Summary
+	for _, s := range summaries {
+		if s.AgentID == "engineer-01" {
+			eng01 = s
+			break
+		}
+	}
+	if eng01 == nil {
+		t.Fatal("engineer-01 not found in summaries")
+	}
+	if eng01.InputTokens != 300 {
+		t.Errorf("InputTokens = %d, want 300", eng01.InputTokens)
+	}
+	if eng01.TotalCostUSD != 0.03 {
+		t.Errorf("TotalCostUSD = %f, want 0.03", eng01.TotalCostUSD)
+	}
+	if eng01.RecordCount != 2 {
+		t.Errorf("RecordCount = %d, want 2", eng01.RecordCount)
+	}
+}
+
+func TestStoreSummaryByTeam(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("agent-1", "team-a", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("agent-2", "team-a", "model-a", 200, 100, 0.02)
+	_, _ = store.Record("agent-3", "team-b", "model-a", 300, 150, 0.03)
+	_, _ = store.Record("agent-4", "", "model-a", 400, 200, 0.04) // No team
+
+	summaries, err := store.SummaryByTeam()
+	if err != nil {
+		t.Fatalf("SummaryByTeam failed: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Errorf("len(summaries) = %d, want 2 (records without team should be excluded)", len(summaries))
+	}
+}
+
+func TestStoreSummaryByModel(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("agent-1", "", "claude-3-opus", 1000, 500, 0.10)
+	_, _ = store.Record("agent-2", "", "claude-3-opus", 2000, 1000, 0.20)
+	_, _ = store.Record("agent-3", "", "claude-3-sonnet", 500, 250, 0.01)
+
+	summaries, err := store.SummaryByModel()
+	if err != nil {
+		t.Fatalf("SummaryByModel failed: %v", err)
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("len(summaries) = %d, want 2", len(summaries))
+	}
+
+	// Should be sorted by cost DESC
+	if summaries[0].Model != "claude-3-opus" {
+		t.Errorf("First model = %q, want claude-3-opus (highest cost)", summaries[0].Model)
+	}
+}
+
+func TestStoreWorkspaceSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("agent-1", "", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("agent-2", "", "model-b", 200, 100, 0.02)
+	_, _ = store.Record("agent-3", "", "model-c", 300, 150, 0.03)
+
+	summary, err := store.WorkspaceSummary()
+	if err != nil {
+		t.Fatalf("WorkspaceSummary failed: %v", err)
+	}
+
+	if summary.InputTokens != 600 {
+		t.Errorf("InputTokens = %d, want 600", summary.InputTokens)
+	}
+	if summary.OutputTokens != 300 {
+		t.Errorf("OutputTokens = %d, want 300", summary.OutputTokens)
+	}
+	if summary.TotalTokens != 900 {
+		t.Errorf("TotalTokens = %d, want 900", summary.TotalTokens)
+	}
+	if summary.TotalCostUSD != 0.06 {
+		t.Errorf("TotalCostUSD = %f, want 0.06", summary.TotalCostUSD)
+	}
+	if summary.RecordCount != 3 {
+		t.Errorf("RecordCount = %d, want 3", summary.RecordCount)
+	}
+}
+
+func TestStoreWorkspaceSummaryEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	summary, err := store.WorkspaceSummary()
+	if err != nil {
+		t.Fatalf("WorkspaceSummary failed: %v", err)
+	}
+
+	if summary.TotalCostUSD != 0 {
+		t.Errorf("TotalCostUSD = %f, want 0", summary.TotalCostUSD)
+	}
+	if summary.RecordCount != 0 {
+		t.Errorf("RecordCount = %d, want 0", summary.RecordCount)
+	}
+}
+
+func TestStoreAgentSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("engineer-01", "", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("engineer-01", "", "model-b", 200, 100, 0.02)
+	_, _ = store.Record("engineer-02", "", "model-a", 300, 150, 0.03)
+
+	summary, err := store.AgentSummary("engineer-01")
+	if err != nil {
+		t.Fatalf("AgentSummary failed: %v", err)
+	}
+
+	if summary.AgentID != "engineer-01" {
+		t.Errorf("AgentID = %q, want engineer-01", summary.AgentID)
+	}
+	if summary.InputTokens != 300 {
+		t.Errorf("InputTokens = %d, want 300", summary.InputTokens)
+	}
+	if summary.TotalCostUSD != 0.03 {
+		t.Errorf("TotalCostUSD = %f, want 0.03", summary.TotalCostUSD)
+	}
+	if summary.RecordCount != 2 {
+		t.Errorf("RecordCount = %d, want 2", summary.RecordCount)
+	}
+}
+
+func TestStoreTeamSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("agent-1", "team-a", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("agent-2", "team-a", "model-a", 200, 100, 0.02)
+	_, _ = store.Record("agent-3", "team-b", "model-a", 300, 150, 0.03)
+
+	summary, err := store.TeamSummary("team-a")
+	if err != nil {
+		t.Fatalf("TeamSummary failed: %v", err)
+	}
+
+	if summary.TeamID != "team-a" {
+		t.Errorf("TeamID = %q, want team-a", summary.TeamID)
+	}
+	if summary.InputTokens != 300 {
+		t.Errorf("InputTokens = %d, want 300", summary.InputTokens)
+	}
+	if summary.TotalCostUSD != 0.03 {
+		t.Errorf("TotalCostUSD = %f, want 0.03", summary.TotalCostUSD)
+	}
+	if summary.RecordCount != 2 {
+		t.Errorf("RecordCount = %d, want 2", summary.RecordCount)
+	}
+}
+
+func TestStoreClear(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	_, _ = store.Record("agent-1", "", "model-a", 100, 50, 0.01)
+	_, _ = store.Record("agent-2", "", "model-a", 200, 100, 0.02)
+
+	if err := store.Clear(); err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+
+	records, err := store.GetAll(100)
+	if err != nil {
+		t.Fatalf("GetAll failed: %v", err)
+	}
+	if len(records) != 0 {
+		t.Errorf("len(records) = %d, want 0 after Clear", len(records))
+	}
+}
+
+func TestRecordStruct(t *testing.T) {
+	r := Record{
+		ID:          1,
+		TotalTokens: 1500,
+	}
+
+	if r.ID != 1 {
+		t.Errorf("ID = %d, want 1", r.ID)
+	}
+	if r.TotalTokens != 1500 {
+		t.Errorf("TotalTokens = %d, want 1500", r.TotalTokens)
+	}
+}
+
+func TestSummaryStruct(t *testing.T) {
+	s := Summary{
+		AgentID:     "agent-1",
+		RecordCount: 10,
+	}
+
+	if s.AgentID != "agent-1" {
+		t.Errorf("AgentID = %q, want agent-1", s.AgentID)
+	}
+	if s.RecordCount != 10 {
+		t.Errorf("RecordCount = %d, want 10", s.RecordCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Implements Issue #146: Cost tracking data model
- Add `Record` struct for individual cost entries (agent, tokens, model, timestamp, cost)
- Add `Summary` struct for aggregated cost data
- SQLite-backed storage with `.bc/costs.db`
- CRUD operations for cost records
- Aggregation queries:
  - `SummaryByAgent()` - costs grouped by agent
  - `SummaryByTeam()` - costs grouped by team
  - `SummaryByModel()` - costs grouped by model
  - `WorkspaceSummary()` - total workspace costs
  - `AgentSummary(id)` - single agent costs
  - `TeamSummary(id)` - single team costs

## Test plan
- [x] 19 tests covering all CRUD operations
- [x] Tests for aggregation queries
- [x] Tests for empty results
- [x] golangci-lint passes

Closes #146
Part of Epic #35 (Cost Dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)