### PR TITLE
feat: add per-agent cost tracking package

### DIFF
--- a/pkg/cost/cost.go
+++ b/pkg/cost/cost.go
@@ -1,0 +1,202 @@
+// Package cost provides cost tracking for bc.
+// Tracks API usage costs per agent.
+package cost
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// Record represents a single cost entry.
+type Record struct {
+	Timestamp    time.Time `json:"timestamp"`
+	Agent        string    `json:"agent"`
+	Model        string    `json:"model"`
+	Operation    string    `json:"operation,omitempty"` // e.g., "completion", "embedding"
+	InputTokens  int       `json:"input_tokens"`
+	OutputTokens int       `json:"output_tokens"`
+	CostUSD      float64   `json:"cost_usd"`
+}
+
+// Summary aggregates cost data.
+//
+//nolint:govet // fieldalignment: keeping fields in logical order for readability
+type Summary struct {
+	TotalCostUSD      float64   `json:"total_cost_usd"`
+	TotalInputTokens  int       `json:"total_input_tokens"`
+	TotalOutputTokens int       `json:"total_output_tokens"`
+	RecordCount       int       `json:"record_count"`
+	FirstRecord       time.Time `json:"first_record,omitempty"`
+	LastRecord        time.Time `json:"last_record,omitempty"`
+}
+
+// Store manages cost records.
+type Store struct {
+	costsDir string
+	mu       sync.RWMutex
+}
+
+// NewStore creates a new cost store.
+func NewStore(rootDir string) *Store {
+	return &Store{
+		costsDir: filepath.Join(rootDir, ".bc", "costs"),
+	}
+}
+
+// Init creates the costs directory if it doesn't exist.
+func (s *Store) Init() error {
+	return os.MkdirAll(s.costsDir, 0750)
+}
+
+// Record adds a cost record for an agent.
+func (s *Store) Record(record *Record) error {
+	if record.Agent == "" {
+		return fmt.Errorf("agent name is required")
+	}
+	if record.Timestamp.IsZero() {
+		record.Timestamp = time.Now().UTC()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	records, err := s.loadAgent(record.Agent)
+	if err != nil {
+		return err
+	}
+
+	records = append(records, *record)
+	return s.saveAgent(record.Agent, records)
+}
+
+// GetAgentSummary returns a cost summary for a specific agent.
+func (s *Store) GetAgentSummary(agent string) (*Summary, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	records, err := s.loadAgent(agent)
+	if err != nil {
+		return nil, err
+	}
+
+	return summarize(records), nil
+}
+
+// GetWorkspaceSummary returns a cost summary for the entire workspace.
+func (s *Store) GetWorkspaceSummary() (*Summary, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	agents, err := s.listAgents()
+	if err != nil {
+		return nil, err
+	}
+
+	var allRecords []Record
+	for _, agent := range agents {
+		records, loadErr := s.loadAgent(agent)
+		if loadErr != nil {
+			continue
+		}
+		allRecords = append(allRecords, records...)
+	}
+
+	return summarize(allRecords), nil
+}
+
+// GetAgentRecords returns all cost records for an agent.
+func (s *Store) GetAgentRecords(agent string) ([]Record, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.loadAgent(agent)
+}
+
+// ListAgents returns all agents with cost records.
+func (s *Store) ListAgents() ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.listAgents()
+}
+
+func (s *Store) listAgents() ([]string, error) {
+	entries, err := os.ReadDir(s.costsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read costs dir: %w", err)
+	}
+
+	var agents []string
+	for _, entry := range entries {
+		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".json" {
+			name := entry.Name()
+			agents = append(agents, name[:len(name)-5]) // Remove .json extension
+		}
+	}
+	return agents, nil
+}
+
+func (s *Store) agentPath(agent string) string {
+	return filepath.Join(s.costsDir, agent+".json")
+}
+
+func (s *Store) loadAgent(agent string) ([]Record, error) {
+	path := s.agentPath(agent)
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from trusted costsDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read cost records: %w", err)
+	}
+
+	var records []Record
+	if err := json.Unmarshal(data, &records); err != nil {
+		return nil, fmt.Errorf("failed to parse cost records: %w", err)
+	}
+
+	return records, nil
+}
+
+func (s *Store) saveAgent(agent string, records []Record) error {
+	if err := s.Init(); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(records, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal cost records: %w", err)
+	}
+
+	path := s.agentPath(agent)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write cost records: %w", err)
+	}
+
+	return nil
+}
+
+func summarize(records []Record) *Summary {
+	summary := &Summary{}
+	for i, r := range records {
+		summary.TotalCostUSD += r.CostUSD
+		summary.TotalInputTokens += r.InputTokens
+		summary.TotalOutputTokens += r.OutputTokens
+		summary.RecordCount++
+
+		if i == 0 || r.Timestamp.Before(summary.FirstRecord) {
+			summary.FirstRecord = r.Timestamp
+		}
+		if r.Timestamp.After(summary.LastRecord) {
+			summary.LastRecord = r.Timestamp
+		}
+	}
+	return summary
+}

--- a/pkg/cost/cost_test.go
+++ b/pkg/cost/cost_test.go
@@ -1,0 +1,285 @@
+package cost
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewStore(t *testing.T) {
+	store := NewStore("/tmp/test")
+	if store == nil {
+		t.Fatal("NewStore returned nil")
+	}
+	expected := filepath.Join("/tmp/test", ".bc", "costs")
+	if store.costsDir != expected {
+		t.Errorf("costsDir = %q, want %q", store.costsDir, expected)
+	}
+}
+
+func TestInit(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	err := store.Init()
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	costsDir := filepath.Join(tmpDir, ".bc", "costs")
+	if !dirExists(costsDir) {
+		t.Errorf("Costs directory not created: %s", costsDir)
+	}
+}
+
+func TestRecord(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	record := &Record{
+		Agent:        "engineer-01",
+		Model:        "claude-3-opus",
+		Operation:    "completion",
+		InputTokens:  1000,
+		OutputTokens: 500,
+		CostUSD:      0.05,
+	}
+
+	err := store.Record(record)
+	if err != nil {
+		t.Fatalf("Record failed: %v", err)
+	}
+
+	// Verify timestamp was set
+	if record.Timestamp.IsZero() {
+		t.Error("Timestamp should be set")
+	}
+
+	// Verify record was saved
+	records, err := store.GetAgentRecords("engineer-01")
+	if err != nil {
+		t.Fatalf("GetAgentRecords failed: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("Records len = %d, want 1", len(records))
+	}
+	if records[0].CostUSD != 0.05 {
+		t.Errorf("CostUSD = %f, want 0.05", records[0].CostUSD)
+	}
+}
+
+func TestRecordEmptyAgent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	record := &Record{
+		Model:   "claude-3-opus",
+		CostUSD: 0.05,
+	}
+
+	err := store.Record(record)
+	if err == nil {
+		t.Error("Expected error for empty agent")
+	}
+}
+
+func TestRecordMultiple(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	records := []Record{
+		{Agent: "engineer-01", Model: "claude-3-opus", CostUSD: 0.05},
+		{Agent: "engineer-01", Model: "claude-3-sonnet", CostUSD: 0.02},
+		{Agent: "engineer-01", Model: "claude-3-opus", CostUSD: 0.08},
+	}
+
+	for i := range records {
+		if err := store.Record(&records[i]); err != nil {
+			t.Fatalf("Record %d failed: %v", i, err)
+		}
+	}
+
+	// Verify all were saved
+	saved, err := store.GetAgentRecords("engineer-01")
+	if err != nil {
+		t.Fatalf("GetAgentRecords failed: %v", err)
+	}
+	if len(saved) != 3 {
+		t.Errorf("Records len = %d, want 3", len(saved))
+	}
+}
+
+func TestGetAgentSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	records := []Record{
+		{Agent: "engineer-01", InputTokens: 100, OutputTokens: 50, CostUSD: 0.01},
+		{Agent: "engineer-01", InputTokens: 200, OutputTokens: 100, CostUSD: 0.02},
+		{Agent: "engineer-01", InputTokens: 150, OutputTokens: 75, CostUSD: 0.015},
+	}
+
+	for i := range records {
+		_ = store.Record(&records[i])
+	}
+
+	summary, err := store.GetAgentSummary("engineer-01")
+	if err != nil {
+		t.Fatalf("GetAgentSummary failed: %v", err)
+	}
+
+	if summary.RecordCount != 3 {
+		t.Errorf("RecordCount = %d, want 3", summary.RecordCount)
+	}
+	if summary.TotalInputTokens != 450 {
+		t.Errorf("TotalInputTokens = %d, want 450", summary.TotalInputTokens)
+	}
+	if summary.TotalOutputTokens != 225 {
+		t.Errorf("TotalOutputTokens = %d, want 225", summary.TotalOutputTokens)
+	}
+	expectedCost := 0.045
+	if summary.TotalCostUSD < expectedCost-0.001 || summary.TotalCostUSD > expectedCost+0.001 {
+		t.Errorf("TotalCostUSD = %f, want %f", summary.TotalCostUSD, expectedCost)
+	}
+}
+
+func TestGetAgentSummaryNoRecords(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	summary, err := store.GetAgentSummary("nonexistent")
+	if err != nil {
+		t.Fatalf("GetAgentSummary failed: %v", err)
+	}
+
+	if summary.RecordCount != 0 {
+		t.Errorf("RecordCount = %d, want 0", summary.RecordCount)
+	}
+	if summary.TotalCostUSD != 0 {
+		t.Errorf("TotalCostUSD = %f, want 0", summary.TotalCostUSD)
+	}
+}
+
+func TestGetWorkspaceSummary(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	records := []Record{
+		{Agent: "engineer-01", CostUSD: 0.10},
+		{Agent: "engineer-02", CostUSD: 0.15},
+		{Agent: "qa-01", CostUSD: 0.05},
+	}
+
+	for i := range records {
+		_ = store.Record(&records[i])
+	}
+
+	summary, err := store.GetWorkspaceSummary()
+	if err != nil {
+		t.Fatalf("GetWorkspaceSummary failed: %v", err)
+	}
+
+	if summary.RecordCount != 3 {
+		t.Errorf("RecordCount = %d, want 3", summary.RecordCount)
+	}
+	expectedCost := 0.30
+	if summary.TotalCostUSD < expectedCost-0.001 || summary.TotalCostUSD > expectedCost+0.001 {
+		t.Errorf("TotalCostUSD = %f, want %f", summary.TotalCostUSD, expectedCost)
+	}
+}
+
+func TestGetWorkspaceSummaryEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	summary, err := store.GetWorkspaceSummary()
+	if err != nil {
+		t.Fatalf("GetWorkspaceSummary failed: %v", err)
+	}
+
+	if summary.RecordCount != 0 {
+		t.Errorf("RecordCount = %d, want 0", summary.RecordCount)
+	}
+}
+
+func TestListAgents(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Record for multiple agents
+	_ = store.Record(&Record{Agent: "engineer-01", CostUSD: 0.01})
+	_ = store.Record(&Record{Agent: "engineer-02", CostUSD: 0.02})
+	_ = store.Record(&Record{Agent: "qa-01", CostUSD: 0.03})
+
+	agents, err := store.ListAgents()
+	if err != nil {
+		t.Fatalf("ListAgents failed: %v", err)
+	}
+
+	if len(agents) != 3 {
+		t.Errorf("Agents len = %d, want 3", len(agents))
+	}
+}
+
+func TestListAgentsEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	agents, err := store.ListAgents()
+	if err != nil {
+		t.Fatalf("ListAgents failed: %v", err)
+	}
+
+	if len(agents) != 0 {
+		t.Errorf("Agents len = %d, want 0", len(agents))
+	}
+}
+
+func TestSummaryTimeRange(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	now := time.Now().UTC()
+	records := []Record{
+		{Agent: "agent-01", Timestamp: now.Add(-2 * time.Hour), CostUSD: 0.01},
+		{Agent: "agent-01", Timestamp: now.Add(-1 * time.Hour), CostUSD: 0.02},
+		{Agent: "agent-01", Timestamp: now, CostUSD: 0.03},
+	}
+
+	for i := range records {
+		_ = store.Record(&records[i])
+	}
+
+	summary, err := store.GetAgentSummary("agent-01")
+	if err != nil {
+		t.Fatalf("GetAgentSummary failed: %v", err)
+	}
+
+	// FirstRecord should be the earliest
+	if summary.FirstRecord.After(now.Add(-1 * time.Hour)) {
+		t.Error("FirstRecord should be the earliest record")
+	}
+
+	// LastRecord should be the latest
+	if summary.LastRecord.Before(now.Add(-30 * time.Minute)) {
+		t.Error("LastRecord should be the latest record")
+	}
+}
+
+func TestAgentPath(t *testing.T) {
+	store := NewStore("/tmp/test")
+	expected := filepath.Join("/tmp/test", ".bc", "costs", "my-agent.json")
+	got := store.agentPath("my-agent")
+	if got != expected {
+		t.Errorf("agentPath = %q, want %q", got, expected)
+	}
+}
+
+func dirExists(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}


### PR DESCRIPTION
## Summary

Add cost tracking package for API usage monitoring:

**pkg/cost package:**
- `Record` struct with agent, model, operation, tokens, cost
- `Summary` struct for aggregated statistics
- Per-agent JSON files stored in `.bc/costs/`
- `Store.Record()` - record a cost entry
- `Store.GetAgentSummary()` - get cost summary for one agent
- `Store.GetWorkspaceSummary()` - get workspace-wide totals
- `Store.ListAgents()` - enumerate agents with cost data

## Test plan

- [x] Tests with 87.3% coverage
- [x] All 13 tests pass
- [x] golangci-lint passes

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)