### PR TITLE
feat(cmd): add bc cost dashboard command

### DIFF
--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -47,6 +46,17 @@ Example:
 	RunE: runCostSummary,
 }
 
+var costDashboardCmd = &cobra.Command{
+	Use:   "dashboard",
+	Short: "Show cost dashboard with full breakdown",
+	Long: `Display a comprehensive cost dashboard with workspace totals,
+per-agent breakdown, and team aggregation.
+
+Example:
+  bc cost dashboard`,
+	RunE: runCostDashboard,
+}
+
 var (
 	costTeamFlag      string
 	costAgentFlag     string
@@ -65,6 +75,7 @@ func init() {
 
 	costCmd.AddCommand(costShowCmd)
 	costCmd.AddCommand(costSummaryCmd)
+	costCmd.AddCommand(costDashboardCmd)
 	rootCmd.AddCommand(costCmd)
 }
 
@@ -102,11 +113,11 @@ func runCostShow(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(records) == 0 {
-		fmt.Println("No cost records found")
+		cmd.Println("No cost records found")
 		return nil
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "TIMESTAMP\tAGENT\tMODEL\tINPUT\tOUTPUT\tTOTAL\tCOST")
 
 	for _, r := range records {
@@ -131,13 +142,20 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 	}
 	defer func() { _ = store.Close() }()
 
+	out := cmd.OutOrStdout()
+
 	// Specific agent summary
 	if costAgentFlag != "" {
 		summary, summaryErr := store.AgentSummary(costAgentFlag)
 		if summaryErr != nil {
 			return fmt.Errorf("failed to get agent summary: %w", summaryErr)
 		}
-		printSingleSummary("Agent", costAgentFlag, summary)
+		_, _ = fmt.Fprintf(out, "Agent: %s\n", costAgentFlag)
+		_, _ = fmt.Fprintf(out, "  Records:      %d\n", summary.RecordCount)
+		_, _ = fmt.Fprintf(out, "  Input Tokens: %d\n", summary.InputTokens)
+		_, _ = fmt.Fprintf(out, "  Output Tokens: %d\n", summary.OutputTokens)
+		_, _ = fmt.Fprintf(out, "  Total Tokens: %d\n", summary.TotalTokens)
+		_, _ = fmt.Fprintf(out, "  Total Cost:   $%.4f\n", summary.TotalCostUSD)
 		return nil
 	}
 
@@ -147,7 +165,12 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 		if summaryErr != nil {
 			return fmt.Errorf("failed to get team summary: %w", summaryErr)
 		}
-		printSingleSummary("Team", costTeamFlag, summary)
+		_, _ = fmt.Fprintf(out, "Team: %s\n", costTeamFlag)
+		_, _ = fmt.Fprintf(out, "  Records:      %d\n", summary.RecordCount)
+		_, _ = fmt.Fprintf(out, "  Input Tokens: %d\n", summary.InputTokens)
+		_, _ = fmt.Fprintf(out, "  Output Tokens: %d\n", summary.OutputTokens)
+		_, _ = fmt.Fprintf(out, "  Total Tokens: %d\n", summary.TotalTokens)
+		_, _ = fmt.Fprintf(out, "  Total Cost:   $%.4f\n", summary.TotalCostUSD)
 		return nil
 	}
 
@@ -157,7 +180,22 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 		if summaryErr != nil {
 			return fmt.Errorf("failed to get model summary: %w", summaryErr)
 		}
-		printModelSummary(summaries)
+		if len(summaries) == 0 {
+			_, _ = fmt.Fprintln(out, "No cost records found")
+			return nil
+		}
+		_, _ = fmt.Fprintln(out, "Cost by Model")
+		_, _ = fmt.Fprintln(out, "=============")
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "MODEL\tCALLS\tINPUT\tOUTPUT\tTOTAL\tCOST")
+		var totalCost float64
+		for _, s := range summaries {
+			_, _ = fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t$%.4f\n",
+				s.Model, s.RecordCount, s.InputTokens, s.OutputTokens, s.TotalTokens, s.TotalCostUSD)
+			totalCost += s.TotalCostUSD
+		}
+		_ = w.Flush()
+		_, _ = fmt.Fprintf(out, "\nTotal: $%.4f\n", totalCost)
 		return nil
 	}
 
@@ -167,13 +205,25 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 		if summaryErr != nil {
 			return fmt.Errorf("failed to get workspace summary: %w", summaryErr)
 		}
-		printWorkspaceSummary(summary)
+		_, _ = fmt.Fprintln(out, "Workspace Summary")
+		_, _ = fmt.Fprintln(out, "=================")
+		_, _ = fmt.Fprintf(out, "  API Calls:    %d\n", summary.RecordCount)
+		_, _ = fmt.Fprintf(out, "  Input Tokens: %d\n", summary.InputTokens)
+		_, _ = fmt.Fprintf(out, "  Output Tokens: %d\n", summary.OutputTokens)
+		_, _ = fmt.Fprintf(out, "  Total Tokens: %d\n", summary.TotalTokens)
+		_, _ = fmt.Fprintf(out, "  Total Cost:   $%.4f\n", summary.TotalCostUSD)
 
 		// Also show per-agent breakdown
 		agentSummaries, agentErr := store.SummaryByAgent()
 		if agentErr == nil && len(agentSummaries) > 0 {
-			fmt.Println("\nBy Agent:")
-			printCostAgentSummary(agentSummaries)
+			_, _ = fmt.Fprintln(out, "\nBy Agent:")
+			w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "  AGENT\tCALLS\tTOKENS\tCOST")
+			for _, s := range agentSummaries {
+				_, _ = fmt.Fprintf(w, "  %s\t%d\t%d\t$%.4f\n",
+					s.AgentID, s.RecordCount, s.TotalTokens, s.TotalCostUSD)
+			}
+			_ = w.Flush()
 		}
 
 		return nil
@@ -182,64 +232,119 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printSingleSummary(label, name string, s *cost.Summary) {
-	fmt.Printf("%s: %s\n", label, name)
-	fmt.Printf("  Records:      %d\n", s.RecordCount)
-	fmt.Printf("  Input Tokens: %d\n", s.InputTokens)
-	fmt.Printf("  Output Tokens: %d\n", s.OutputTokens)
-	fmt.Printf("  Total Tokens: %d\n", s.TotalTokens)
-	fmt.Printf("  Total Cost:   $%.4f\n", s.TotalCostUSD)
-}
-
-func printWorkspaceSummary(s *cost.Summary) {
-	fmt.Println("Workspace Summary")
-	fmt.Println("=================")
-	fmt.Printf("  API Calls:    %d\n", s.RecordCount)
-	fmt.Printf("  Input Tokens: %d\n", s.InputTokens)
-	fmt.Printf("  Output Tokens: %d\n", s.OutputTokens)
-	fmt.Printf("  Total Tokens: %d\n", s.TotalTokens)
-	fmt.Printf("  Total Cost:   $%.4f\n", s.TotalCostUSD)
-}
-
-func printCostAgentSummary(summaries []*cost.Summary) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "  AGENT\tCALLS\tTOKENS\tCOST")
-
-	for _, s := range summaries {
-		_, _ = fmt.Fprintf(w, "  %s\t%d\t%d\t$%.4f\n",
-			s.AgentID,
-			s.RecordCount,
-			s.TotalTokens,
-			s.TotalCostUSD,
-		)
+func runCostDashboard(cmd *cobra.Command, args []string) error {
+	store, err := getCostStore()
+	if err != nil {
+		return err
 	}
-	_ = w.Flush()
-}
+	defer func() { _ = store.Close() }()
 
-func printModelSummary(summaries []*cost.Summary) {
-	if len(summaries) == 0 {
-		fmt.Println("No cost records found")
-		return
+	// Workspace totals
+	wsSummary, wsErr := store.WorkspaceSummary()
+	if wsErr != nil {
+		return fmt.Errorf("failed to get workspace summary: %w", wsErr)
 	}
 
-	fmt.Println("Cost by Model")
-	fmt.Println("=============")
+	cmd.Println("╔══════════════════════════════════════════════════════════════╗")
+	cmd.Println("║                     COST DASHBOARD                           ║")
+	cmd.Println("╚══════════════════════════════════════════════════════════════╝")
+	cmd.Println()
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "MODEL\tCALLS\tINPUT\tOUTPUT\tTOTAL\tCOST")
+	// Workspace Summary
+	cmd.Println("WORKSPACE TOTALS")
+	cmd.Println("────────────────")
+	cmd.Printf("  Total API Calls:   %d\n", wsSummary.RecordCount)
+	cmd.Printf("  Input Tokens:      %d\n", wsSummary.InputTokens)
+	cmd.Printf("  Output Tokens:     %d\n", wsSummary.OutputTokens)
+	cmd.Printf("  Total Tokens:      %d\n", wsSummary.TotalTokens)
+	cmd.Printf("  Total Cost:        $%.4f\n", wsSummary.TotalCostUSD)
+	cmd.Println()
 
-	var totalCost float64
-	for _, s := range summaries {
-		_, _ = fmt.Fprintf(w, "%s\t%d\t%d\t%d\t%d\t$%.4f\n",
-			s.Model,
-			s.RecordCount,
-			s.InputTokens,
-			s.OutputTokens,
-			s.TotalTokens,
-			s.TotalCostUSD,
-		)
-		totalCost += s.TotalCostUSD
+	// Per-agent breakdown
+	agentSummaries, agentErr := store.SummaryByAgent()
+	if agentErr != nil {
+		return fmt.Errorf("failed to get agent summaries: %w", agentErr)
 	}
-	_ = w.Flush()
-	fmt.Printf("\nTotal: $%.4f\n", totalCost)
+
+	if len(agentSummaries) > 0 {
+		cmd.Println("BY AGENT")
+		cmd.Println("────────")
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "  AGENT\tCALLS\tTOKENS\tCOST\t% OF TOTAL")
+
+		for _, s := range agentSummaries {
+			pct := 0.0
+			if wsSummary.TotalCostUSD > 0 {
+				pct = (s.TotalCostUSD / wsSummary.TotalCostUSD) * 100
+			}
+			_, _ = fmt.Fprintf(w, "  %s\t%d\t%d\t$%.4f\t%.1f%%\n",
+				s.AgentID,
+				s.RecordCount,
+				s.TotalTokens,
+				s.TotalCostUSD,
+				pct,
+			)
+		}
+		_ = w.Flush()
+		cmd.Println()
+	}
+
+	// Team aggregation
+	teamSummaries, teamErr := store.SummaryByTeam()
+	if teamErr != nil {
+		return fmt.Errorf("failed to get team summaries: %w", teamErr)
+	}
+
+	if len(teamSummaries) > 0 {
+		cmd.Println("BY TEAM")
+		cmd.Println("───────")
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "  TEAM\tCALLS\tTOKENS\tCOST\t% OF TOTAL")
+
+		for _, s := range teamSummaries {
+			pct := 0.0
+			if wsSummary.TotalCostUSD > 0 {
+				pct = (s.TotalCostUSD / wsSummary.TotalCostUSD) * 100
+			}
+			_, _ = fmt.Fprintf(w, "  %s\t%d\t%d\t$%.4f\t%.1f%%\n",
+				s.TeamID,
+				s.RecordCount,
+				s.TotalTokens,
+				s.TotalCostUSD,
+				pct,
+			)
+		}
+		_ = w.Flush()
+		cmd.Println()
+	}
+
+	// Model breakdown
+	modelSummaries, modelErr := store.SummaryByModel()
+	if modelErr != nil {
+		return fmt.Errorf("failed to get model summaries: %w", modelErr)
+	}
+
+	if len(modelSummaries) > 0 {
+		cmd.Println("BY MODEL")
+		cmd.Println("────────")
+		w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "  MODEL\tCALLS\tTOKENS\tCOST\t% OF TOTAL")
+
+		for _, s := range modelSummaries {
+			pct := 0.0
+			if wsSummary.TotalCostUSD > 0 {
+				pct = (s.TotalCostUSD / wsSummary.TotalCostUSD) * 100
+			}
+			_, _ = fmt.Fprintf(w, "  %s\t%d\t%d\t$%.4f\t%.1f%%\n",
+				s.Model,
+				s.RecordCount,
+				s.TotalTokens,
+				s.TotalCostUSD,
+				pct,
+			)
+		}
+		_ = w.Flush()
+	}
+
+	return nil
 }

--- a/internal/cmd/cost_test.go
+++ b/internal/cmd/cost_test.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/cost"
+)
+
+func TestCostDashboard(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create some cost records
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "team-a", "claude-3-opus", 1000, 500, 0.05)
+	_, _ = store.Record("engineer-02", "team-a", "claude-3-sonnet", 500, 250, 0.01)
+	_, _ = store.Record("engineer-03", "team-b", "claude-3-opus", 2000, 1000, 0.10)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "dashboard")
+	if err != nil {
+		t.Fatalf("cost dashboard failed: %v\nOutput: %s", err, output)
+	}
+
+	// Check workspace totals section
+	if !strings.Contains(output, "COST DASHBOARD") {
+		t.Errorf("output should contain dashboard header: %s", output)
+	}
+	if !strings.Contains(output, "WORKSPACE TOTALS") {
+		t.Errorf("output should contain workspace totals: %s", output)
+	}
+
+	// Check agent breakdown
+	if !strings.Contains(output, "BY AGENT") {
+		t.Errorf("output should contain agent breakdown: %s", output)
+	}
+	if !strings.Contains(output, "engineer-01") {
+		t.Errorf("output should contain agent engineer-01: %s", output)
+	}
+
+	// Check team aggregation
+	if !strings.Contains(output, "BY TEAM") {
+		t.Errorf("output should contain team breakdown: %s", output)
+	}
+	if !strings.Contains(output, "team-a") {
+		t.Errorf("output should contain team-a: %s", output)
+	}
+
+	// Check model breakdown
+	if !strings.Contains(output, "BY MODEL") {
+		t.Errorf("output should contain model breakdown: %s", output)
+	}
+}
+
+func TestCostDashboardEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	output, err := executeCmd("cost", "dashboard")
+	if err != nil {
+		t.Fatalf("cost dashboard failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should still show header and workspace totals (zeros)
+	if !strings.Contains(output, "COST DASHBOARD") {
+		t.Errorf("output should contain dashboard header: %s", output)
+	}
+	if !strings.Contains(output, "WORKSPACE TOTALS") {
+		t.Errorf("output should contain workspace totals: %s", output)
+	}
+}
+
+func TestCostShow(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a cost record
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "show")
+	if err != nil {
+		t.Fatalf("cost show failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "engineer-01") {
+		t.Errorf("output should contain agent: %s", output)
+	}
+	if !strings.Contains(output, "claude-3-opus") {
+		t.Errorf("output should contain model: %s", output)
+	}
+}
+
+func TestCostShowAgent(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create cost records for multiple agents
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	_, _ = store.Record("engineer-02", "", "claude-3-sonnet", 500, 250, 0.01)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "show", "engineer-01")
+	if err != nil {
+		t.Fatalf("cost show failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "engineer-01") {
+		t.Errorf("output should contain engineer-01: %s", output)
+	}
+	// Should NOT contain engineer-02
+	if strings.Contains(output, "engineer-02") {
+		t.Errorf("output should NOT contain engineer-02 when filtered: %s", output)
+	}
+}
+
+func TestCostShowEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	output, err := executeCmd("cost", "show")
+	if err != nil {
+		t.Fatalf("cost show failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "No cost records") {
+		t.Errorf("output should indicate no records: %s", output)
+	}
+}
+
+func TestCostSummary(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create cost records
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	_, _ = store.Record("engineer-02", "", "claude-3-sonnet", 500, 250, 0.01)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "summary")
+	if err != nil {
+		t.Fatalf("cost summary failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Workspace Summary") {
+		t.Errorf("output should contain workspace summary: %s", output)
+	}
+	if !strings.Contains(output, "By Agent") {
+		t.Errorf("output should contain agent breakdown: %s", output)
+	}
+}
+
+func TestCostSummaryAgent(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "summary", "--agent", "engineer-01")
+	if err != nil {
+		t.Fatalf("cost summary failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Agent: engineer-01") {
+		t.Errorf("output should contain agent summary: %s", output)
+	}
+}
+
+func TestCostSummaryModel(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Reset flags from previous tests
+	costAgentFlag = ""
+	costTeamFlag = ""
+	costModelFlag = false
+	costWorkspaceFlag = false
+
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open store: %v", err)
+	}
+	_, _ = store.Record("agent-1", "", "claude-3-opus", 1000, 500, 0.05)
+	_, _ = store.Record("agent-2", "", "claude-3-sonnet", 500, 250, 0.01)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "summary", "--model")
+	if err != nil {
+		t.Fatalf("cost summary failed: %v\nOutput: %s", err, output)
+	}
+
+	if !strings.Contains(output, "Cost by Model") {
+		t.Errorf("output should contain model summary: %s", output)
+	}
+	if !strings.Contains(output, "claude-3-opus") {
+		t.Errorf("output should contain opus: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `bc cost dashboard` command for comprehensive cost visualization
- Shows workspace totals, per-agent breakdown, team aggregation, and model breakdown
- Includes percentage of total for easy cost attribution
- Fixes cost.go to use cmd.OutOrStdout() for proper test output capture

## Features
- **WORKSPACE TOTALS**: Total API calls, tokens, and cost
- **BY AGENT**: Per-agent breakdown with percentage of total
- **BY TEAM**: Team aggregation with percentage of total  
- **BY MODEL**: Model breakdown with percentage of total

## Test plan
- [x] 8 new cost command tests added
- [x] All tests pass
- [x] Linter clean

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)