### PR TITLE
test(cmd): add integration test suite for cost and process commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ make lint
 
 2. **Context Propagation**: Pass `context.Context` through all call chains.
 
-3. **Testing**: Write tests for new functionality. Use table-driven tests where appropriate.
+3. **Testing**: Write tests for new functionality. Use table-driven tests where appropriate. See [Testing Guide](#testing-guide) below.
 
 4. **Documentation**: Document exported functions and types.
 
@@ -136,6 +136,77 @@ Include:
 - Steps to reproduce (for bugs)
 - Expected vs actual behavior
 - Environment details
+
+## Testing Guide
+
+### Running Tests
+
+```bash
+# Run all tests
+make test
+
+# Run tests with race detector and verbose output
+go test -race -v ./...
+
+# Run integration tests only (CLI commands)
+make test-integration
+
+# Run tests with coverage
+make coverage
+
+# Run specific test
+go test -v ./internal/cmd/... -run TestCostDashboard
+
+# Run tests for a specific package
+go test -v ./pkg/cost/...
+```
+
+### Test Structure
+
+Tests are organized by package:
+
+- `internal/cmd/*_test.go` - CLI command tests
+- `pkg/*_test.go` - Package unit tests
+
+### Writing CLI Command Tests
+
+For CLI commands, use the helper functions in `cmd_test.go`:
+
+```go
+func TestMyCommand(t *testing.T) {
+    // Set up temporary workspace
+    wsDir := setupTestWorkspace(t)
+
+    // Execute command
+    output, err := executeCmd("mycommand", "arg1", "--flag", "value")
+    if err != nil {
+        t.Fatalf("expected no error, got: %v", err)
+    }
+
+    // Verify output
+    if !strings.Contains(output, "expected text") {
+        t.Errorf("expected 'expected text', got: %s", output)
+    }
+}
+```
+
+### Test Output Capture
+
+For command output to be captured in tests, use:
+- `cmd.Printf()` instead of `fmt.Printf()`
+- `cmd.Println()` instead of `fmt.Println()`
+- `tabwriter.NewWriter(cmd.OutOrStdout(), ...)` instead of `tabwriter.NewWriter(os.Stdout, ...)`
+
+### Coverage
+
+Coverage reports are generated in `coverage.out` and uploaded to Codecov in CI.
+
+To view coverage locally:
+
+```bash
+make coverage
+go tool cover -html=coverage.out
+```
 
 ## Questions?
 

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,22 @@
-.PHONY: dev build build-release build-all clean gen test coverage bench fmt vet lint check deps help
+.PHONY: dev build build-release build-all clean gen test test-integration coverage bench fmt vet lint check deps help
 
 help:
 	@echo "Available targets:"
-	@echo "  dev           - Run in development mode"
-	@echo "  build         - Build the binary"
-	@echo "  build-release - Build optimized release binary"
-	@echo "  build-all     - Cross-compile for all platforms to dist/"
-	@echo "  clean         - Remove build artifacts"
-	@echo "  gen           - Generate config code from config.toml"
-	@echo "  test          - Run tests"
-	@echo "  coverage      - Run tests with coverage report"
-	@echo "  bench         - Run benchmarks"
-	@echo "  fmt           - Format code"
-	@echo "  vet           - Run go vet"
-	@echo "  lint          - Run golangci-lint"
-	@echo "  check         - Run all checks (gen + fmt + vet + lint + test)"
-	@echo "  deps          - Download and tidy dependencies"
+	@echo "  dev              - Run in development mode"
+	@echo "  build            - Build the binary"
+	@echo "  build-release    - Build optimized release binary"
+	@echo "  build-all        - Cross-compile for all platforms to dist/"
+	@echo "  clean            - Remove build artifacts"
+	@echo "  gen              - Generate config code from config.toml"
+	@echo "  test             - Run tests"
+	@echo "  test-integration - Run integration tests only"
+	@echo "  coverage         - Run tests with coverage report"
+	@echo "  bench            - Run benchmarks"
+	@echo "  fmt              - Format code"
+	@echo "  vet              - Run go vet"
+	@echo "  lint             - Run golangci-lint"
+	@echo "  check            - Run all checks (gen + fmt + vet + lint + test)"
+	@echo "  deps             - Download and tidy dependencies"
 
 dev:
 	go run ./cmd/bc
@@ -42,6 +43,9 @@ gen:
 
 test:
 	go test -race ./...
+
+test-integration:
+	go test -race -v ./internal/cmd/...
 
 coverage: gen
 	go test -coverprofile=coverage.out ./...

--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -119,11 +118,11 @@ func runCostShow(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(records) == 0 {
-		fmt.Println("No cost records found")
+		cmd.Println("No cost records found")
 		return nil
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "TIMESTAMP\tAGENT\tMODEL\tINPUT\tOUTPUT\tTOTAL\tCOST")
 
 	for _, r := range records {
@@ -154,7 +153,7 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 		if summaryErr != nil {
 			return fmt.Errorf("failed to get agent summary: %w", summaryErr)
 		}
-		printSingleSummary("Agent", costAgentFlag, summary)
+		printSingleSummary(cmd, "Agent", costAgentFlag, summary)
 		return nil
 	}
 
@@ -164,7 +163,7 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 		if summaryErr != nil {
 			return fmt.Errorf("failed to get team summary: %w", summaryErr)
 		}
-		printSingleSummary("Team", costTeamFlag, summary)
+		printSingleSummary(cmd, "Team", costTeamFlag, summary)
 		return nil
 	}
 
@@ -174,7 +173,7 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 		if summaryErr != nil {
 			return fmt.Errorf("failed to get model summary: %w", summaryErr)
 		}
-		printModelSummary(summaries)
+		printModelSummary(cmd, summaries)
 		return nil
 	}
 
@@ -184,13 +183,13 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 		if summaryErr != nil {
 			return fmt.Errorf("failed to get workspace summary: %w", summaryErr)
 		}
-		printWorkspaceSummary(summary)
+		printWorkspaceSummary(cmd, summary)
 
 		// Also show per-agent breakdown
 		agentSummaries, agentErr := store.SummaryByAgent()
 		if agentErr == nil && len(agentSummaries) > 0 {
-			fmt.Println("\nBy Agent:")
-			printCostAgentSummary(agentSummaries)
+			cmd.Println("\nBy Agent:")
+			printCostAgentSummary(cmd, agentSummaries)
 		}
 
 		return nil
@@ -199,27 +198,27 @@ func runCostSummary(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func printSingleSummary(label, name string, s *cost.Summary) {
-	fmt.Printf("%s: %s\n", label, name)
-	fmt.Printf("  Records:      %d\n", s.RecordCount)
-	fmt.Printf("  Input Tokens: %d\n", s.InputTokens)
-	fmt.Printf("  Output Tokens: %d\n", s.OutputTokens)
-	fmt.Printf("  Total Tokens: %d\n", s.TotalTokens)
-	fmt.Printf("  Total Cost:   $%.4f\n", s.TotalCostUSD)
+func printSingleSummary(cmd *cobra.Command, label, name string, s *cost.Summary) {
+	cmd.Printf("%s: %s\n", label, name)
+	cmd.Printf("  Records:      %d\n", s.RecordCount)
+	cmd.Printf("  Input Tokens: %d\n", s.InputTokens)
+	cmd.Printf("  Output Tokens: %d\n", s.OutputTokens)
+	cmd.Printf("  Total Tokens: %d\n", s.TotalTokens)
+	cmd.Printf("  Total Cost:   $%.4f\n", s.TotalCostUSD)
 }
 
-func printWorkspaceSummary(s *cost.Summary) {
-	fmt.Println("Workspace Summary")
-	fmt.Println("=================")
-	fmt.Printf("  API Calls:    %d\n", s.RecordCount)
-	fmt.Printf("  Input Tokens: %d\n", s.InputTokens)
-	fmt.Printf("  Output Tokens: %d\n", s.OutputTokens)
-	fmt.Printf("  Total Tokens: %d\n", s.TotalTokens)
-	fmt.Printf("  Total Cost:   $%.4f\n", s.TotalCostUSD)
+func printWorkspaceSummary(cmd *cobra.Command, s *cost.Summary) {
+	cmd.Println("Workspace Summary")
+	cmd.Println("=================")
+	cmd.Printf("  API Calls:    %d\n", s.RecordCount)
+	cmd.Printf("  Input Tokens: %d\n", s.InputTokens)
+	cmd.Printf("  Output Tokens: %d\n", s.OutputTokens)
+	cmd.Printf("  Total Tokens: %d\n", s.TotalTokens)
+	cmd.Printf("  Total Cost:   $%.4f\n", s.TotalCostUSD)
 }
 
-func printCostAgentSummary(summaries []*cost.Summary) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+func printCostAgentSummary(cmd *cobra.Command, summaries []*cost.Summary) {
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "  AGENT\tCALLS\tTOKENS\tCOST")
 
 	for _, s := range summaries {
@@ -233,16 +232,16 @@ func printCostAgentSummary(summaries []*cost.Summary) {
 	_ = w.Flush()
 }
 
-func printModelSummary(summaries []*cost.Summary) {
+func printModelSummary(cmd *cobra.Command, summaries []*cost.Summary) {
 	if len(summaries) == 0 {
-		fmt.Println("No cost records found")
+		cmd.Println("No cost records found")
 		return
 	}
 
-	fmt.Println("Cost by Model")
-	fmt.Println("=============")
+	cmd.Println("Cost by Model")
+	cmd.Println("=============")
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "MODEL\tCALLS\tINPUT\tOUTPUT\tTOTAL\tCOST")
 
 	var totalCost float64
@@ -258,7 +257,7 @@ func printModelSummary(summaries []*cost.Summary) {
 		totalCost += s.TotalCostUSD
 	}
 	_ = w.Flush()
-	fmt.Printf("\nTotal: $%.4f\n", totalCost)
+	cmd.Printf("\nTotal: $%.4f\n", totalCost)
 }
 
 func runCostDashboard(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/cost_test.go
+++ b/internal/cmd/cost_test.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/cost"
+)
+
+func TestCostShowEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	output, err := executeCmd("cost", "show")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "No cost records found") {
+		t.Errorf("expected 'No cost records found', got: %s", output)
+	}
+}
+
+func TestCostShowWithRecords(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Seed cost data
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open cost store: %v", err)
+	}
+	_, err := store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	if err != nil {
+		t.Fatalf("failed to record cost: %v", err)
+	}
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "show")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "engineer-01") {
+		t.Errorf("expected output to contain 'engineer-01', got: %s", output)
+	}
+	if !strings.Contains(output, "claude-3-opus") {
+		t.Errorf("expected output to contain 'claude-3-opus', got: %s", output)
+	}
+}
+
+func TestCostShowByAgent(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Seed cost data for two agents
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open cost store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	_, _ = store.Record("engineer-02", "", "claude-3-sonnet", 2000, 1000, 0.03)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "show", "engineer-01")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "engineer-01") {
+		t.Errorf("expected output to contain 'engineer-01', got: %s", output)
+	}
+	if strings.Contains(output, "engineer-02") {
+		t.Errorf("expected output NOT to contain 'engineer-02', got: %s", output)
+	}
+}
+
+func TestCostSummaryWorkspace(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Reset flags
+	costAgentFlag = ""
+	costTeamFlag = ""
+	costModelFlag = false
+	costWorkspaceFlag = false
+
+	// Seed cost data
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open cost store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	_, _ = store.Record("engineer-02", "", "claude-3-sonnet", 2000, 1000, 0.03)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "summary", "--workspace")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "Workspace Summary") {
+		t.Errorf("expected 'Workspace Summary', got: %s", output)
+	}
+	if !strings.Contains(output, "API Calls") {
+		t.Errorf("expected 'API Calls', got: %s", output)
+	}
+}
+
+func TestCostSummaryByAgent(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Reset flags
+	costAgentFlag = ""
+	costTeamFlag = ""
+	costModelFlag = false
+	costWorkspaceFlag = false
+
+	// Seed cost data
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open cost store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "summary", "--agent", "engineer-01")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "Agent: engineer-01") {
+		t.Errorf("expected 'Agent: engineer-01', got: %s", output)
+	}
+}
+
+func TestCostSummaryByTeam(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Reset flags
+	costAgentFlag = ""
+	costTeamFlag = ""
+	costModelFlag = false
+	costWorkspaceFlag = false
+
+	// Seed cost data with team
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open cost store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "engineering", "claude-3-opus", 1000, 500, 0.05)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "summary", "--team", "engineering")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "Team: engineering") {
+		t.Errorf("expected 'Team: engineering', got: %s", output)
+	}
+}
+
+func TestCostSummaryByModel(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Reset flags
+	costAgentFlag = ""
+	costTeamFlag = ""
+	costModelFlag = false
+	costWorkspaceFlag = false
+
+	// Seed cost data
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open cost store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	_, _ = store.Record("engineer-02", "", "claude-3-sonnet", 2000, 1000, 0.03)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "summary", "--model")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "Cost by Model") {
+		t.Errorf("expected 'Cost by Model', got: %s", output)
+	}
+	if !strings.Contains(output, "claude-3-opus") {
+		t.Errorf("expected 'claude-3-opus', got: %s", output)
+	}
+	if !strings.Contains(output, "claude-3-sonnet") {
+		t.Errorf("expected 'claude-3-sonnet', got: %s", output)
+	}
+}
+
+func TestCostDashboard(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Seed cost data
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open cost store: %v", err)
+	}
+	_, _ = store.Record("engineer-01", "engineering", "claude-3-opus", 1000, 500, 0.05)
+	_, _ = store.Record("engineer-02", "engineering", "claude-3-sonnet", 2000, 1000, 0.03)
+	_ = store.Close()
+
+	output, err := executeCmd("cost", "dashboard")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "COST DASHBOARD") {
+		t.Errorf("expected 'COST DASHBOARD', got: %s", output)
+	}
+	if !strings.Contains(output, "WORKSPACE TOTALS") {
+		t.Errorf("expected 'WORKSPACE TOTALS', got: %s", output)
+	}
+	if !strings.Contains(output, "BY AGENT") {
+		t.Errorf("expected 'BY AGENT', got: %s", output)
+	}
+	if !strings.Contains(output, "BY MODEL") {
+		t.Errorf("expected 'BY MODEL', got: %s", output)
+	}
+}
+
+func TestCostDashboardEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	output, err := executeCmd("cost", "dashboard")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "COST DASHBOARD") {
+		t.Errorf("expected 'COST DASHBOARD', got: %s", output)
+	}
+	// Should still display with zero values
+	if !strings.Contains(output, "$0.0000") {
+		t.Errorf("expected '$0.0000' for empty dashboard, got: %s", output)
+	}
+}
+
+func TestCostNoWorkspace(t *testing.T) {
+	// Run outside a workspace
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
+
+	_, err := executeCmd("cost", "show")
+	if err == nil {
+		t.Fatal("expected error when not in workspace")
+	}
+
+	if !strings.Contains(err.Error(), "not in a bc workspace") {
+		t.Errorf("expected 'not in a bc workspace' error, got: %v", err)
+	}
+}
+
+func TestCostShowLimit(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Seed multiple cost records
+	store := cost.NewStore(wsDir)
+	if err := store.Open(); err != nil {
+		t.Fatalf("failed to open cost store: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		_, _ = store.Record("engineer-01", "", "claude-3-opus", 1000, 500, 0.05)
+	}
+	_ = store.Close()
+
+	// Reset the limit flag
+	costLimitFlag = 20
+
+	output, err := executeCmd("cost", "show", "-n", "5")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	// Count lines (header + 5 records = 6 lines minus empty trailing)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// Should have header line + exactly 5 data lines
+	if len(lines) != 6 {
+		t.Errorf("expected 6 lines (header + 5 records), got %d:\n%s", len(lines), output)
+	}
+}

--- a/internal/cmd/process.go
+++ b/internal/cmd/process.go
@@ -209,9 +209,9 @@ func runProcessStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to register process: %w", regErr)
 	}
 
-	fmt.Printf("Started process %q (PID %d)\n", name, proc.PID)
+	cmd.Printf("Started process %q (PID %d)\n", name, proc.PID)
 	if processPort > 0 {
-		fmt.Printf("  Port: %d\n", processPort)
+		cmd.Printf("  Port: %d\n", processPort)
 	}
 
 	return nil
@@ -225,11 +225,11 @@ func runProcessList(cmd *cobra.Command, args []string) error {
 
 	procs := reg.List()
 	if len(procs) == 0 {
-		fmt.Println("No processes")
+		cmd.Println("No processes")
 		return nil
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "NAME\tSTATUS\tPID\tPORT\tOWNER\tSTARTED")
 
 	for _, p := range procs {
@@ -283,7 +283,7 @@ func runProcessStop(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to update registry: %w", stopErr)
 	}
 
-	fmt.Printf("Stopped process %q\n", name)
+	cmd.Printf("Stopped process %q\n", name)
 	return nil
 }
 
@@ -307,11 +307,11 @@ func runProcessLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	if logs == "" {
-		fmt.Printf("No logs available for process %q\n", name)
+		cmd.Printf("No logs available for process %q\n", name)
 		return nil
 	}
 
-	fmt.Print(logs)
+	cmd.Print(logs)
 	return nil
 }
 
@@ -328,23 +328,23 @@ func runProcessInfo(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("process %q not found", name)
 	}
 
-	fmt.Printf("Process: %s\n", proc.Name)
-	fmt.Printf("Command: %s\n", proc.Command)
-	fmt.Printf("Status: %s\n", statusStr(proc.Running))
-	fmt.Printf("PID: %d\n", proc.PID)
+	cmd.Printf("Process: %s\n", proc.Name)
+	cmd.Printf("Command: %s\n", proc.Command)
+	cmd.Printf("Status: %s\n", statusStr(proc.Running))
+	cmd.Printf("PID: %d\n", proc.PID)
 	if proc.Port > 0 {
-		fmt.Printf("Port: %d\n", proc.Port)
+		cmd.Printf("Port: %d\n", proc.Port)
 	}
 	if proc.Owner != "" {
-		fmt.Printf("Owner: %s\n", proc.Owner)
+		cmd.Printf("Owner: %s\n", proc.Owner)
 	}
 	if proc.WorkDir != "" {
-		fmt.Printf("WorkDir: %s\n", proc.WorkDir)
+		cmd.Printf("WorkDir: %s\n", proc.WorkDir)
 	}
 	if proc.LogFile != "" {
-		fmt.Printf("LogFile: %s\n", proc.LogFile)
+		cmd.Printf("LogFile: %s\n", proc.LogFile)
 	}
-	fmt.Printf("Started: %s\n", proc.StartedAt.Format(time.RFC3339))
+	cmd.Printf("Started: %s\n", proc.StartedAt.Format(time.RFC3339))
 	return nil
 }
 
@@ -366,10 +366,10 @@ func runProcessAttach(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print process info header
-	fmt.Printf("=== Attached to %s (PID %d) ===\n", proc.Name, proc.PID)
-	fmt.Printf("Command: %s\n", proc.Command)
-	fmt.Printf("Log file: %s\n", reg.LogPath(name))
-	fmt.Println("---")
+	cmd.Printf("=== Attached to %s (PID %d) ===\n", proc.Name, proc.PID)
+	cmd.Printf("Command: %s\n", proc.Command)
+	cmd.Printf("Log file: %s\n", reg.LogPath(name))
+	cmd.Println("---")
 
 	// Show recent logs
 	logs, readErr := reg.ReadLogs(name, 50)
@@ -378,10 +378,10 @@ func runProcessAttach(cmd *cobra.Command, args []string) error {
 	}
 
 	if logs != "" {
-		fmt.Print(logs)
+		cmd.Print(logs)
 	}
 
-	fmt.Println("\n(Detached - process continues in background)")
+	cmd.Println("\n(Detached - process continues in background)")
 	return nil
 }
 

--- a/internal/cmd/process_test.go
+++ b/internal/cmd/process_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestProcessListEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	output, err := executeCmd("process", "list")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !strings.Contains(output, "No processes") {
+		t.Errorf("expected 'No processes', got: %s", output)
+	}
+}
+
+func TestProcessStopNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("process", "stop", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent process")
+	}
+
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessLogsNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("process", "logs", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent process")
+	}
+
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessInfoNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("process", "info", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent process")
+	}
+
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessAttachNotFound(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("process", "attach", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent process")
+	}
+
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessNoWorkspace(t *testing.T) {
+	// Run outside a workspace
+	origDir, _ := os.Getwd()
+	tmpDir := t.TempDir()
+	_ = os.Chdir(tmpDir)
+	defer func() { _ = os.Chdir(origDir) }()
+
+	_, err := executeCmd("process", "list")
+	if err == nil {
+		t.Fatal("expected error when not in workspace")
+	}
+
+	if !strings.Contains(err.Error(), "not in a bc workspace") {
+		t.Errorf("expected 'not in a bc workspace' error, got: %v", err)
+	}
+}
+
+func TestProcessStartRequiresCmd(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Reset flag
+	processCommand = ""
+
+	_, err := executeCmd("process", "start", "test")
+	if err == nil {
+		t.Fatal("expected error when --cmd not provided")
+	}
+
+	if !strings.Contains(err.Error(), "required") {
+		t.Errorf("expected 'required' error, got: %v", err)
+	}
+}
+
+func TestStatusStr(t *testing.T) {
+	tests := []struct {
+		want    string
+		running bool
+	}{
+		{"running", true},
+		{"stopped", false},
+	}
+
+	for _, tc := range tests {
+		got := statusStr(tc.running)
+		if got != tc.want {
+			t.Errorf("statusStr(%v) = %q, want %q", tc.running, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add 11 tests for cost commands (show, summary, dashboard)
- Add 7 tests for process commands (list, stop, logs, info, attach)
- Fix cost.go to use cmd.Printf for test output capture
- Fix process.go to use cmd.Printf for test output capture  
- Add `make test-integration` target to Makefile
- Add Testing Guide section to CONTRIBUTING.md

Closes #162

## Test plan
- [x] All cost tests pass
- [x] All process tests pass
- [x] Lint clean
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)