### PR TITLE
test: add integration tests for down and process commands

### DIFF
--- a/internal/cmd/down_test.go
+++ b/internal/cmd/down_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/agent"
+)
+
+func TestDownNoWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err = os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	_, _, err = executeIntegrationCmd("down")
+	if err == nil {
+		t.Fatal("expected error when not in workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in a bc workspace") {
+		t.Errorf("expected workspace error, got: %v", err)
+	}
+}
+
+func TestDownEmptyWorkspace(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Create agents dir
+	if err := os.MkdirAll(filepath.Join(wsDir, ".bc", "agents"), 0750); err != nil {
+		t.Fatalf("failed to create agents dir: %v", err)
+	}
+
+	stdout, _, err := executeIntegrationCmd("down")
+	if err != nil {
+		t.Fatalf("down returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "No agents running") {
+		t.Errorf("expected 'No agents running', got: %s", stdout)
+	}
+}
+
+func TestDownWithAgents(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed some agents (already stopped, so StopAgent will just mark them)
+	seedAgents(t, wsDir, map[string]*agent.Agent{
+		"coordinator": {
+			Name:      "coordinator",
+			Role:      agent.RoleCoordinator,
+			State:     agent.StateStopped,
+			Session:   "bc-coord",
+			StartedAt: time.Now().Add(-1 * time.Hour),
+		},
+		"worker-01": {
+			Name:      "worker-01",
+			Role:      agent.RoleWorker,
+			State:     agent.StateStopped,
+			Session:   "bc-worker-01",
+			StartedAt: time.Now().Add(-30 * time.Minute),
+		},
+	})
+
+	stdout, _, err := executeIntegrationCmd("down")
+	if err != nil {
+		t.Fatalf("down returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "Stopping") {
+		t.Errorf("expected 'Stopping' message, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "All agents stopped") {
+		t.Errorf("expected 'All agents stopped', got: %s", stdout)
+	}
+}
+
+func TestDownForceFlag(t *testing.T) {
+	// Reset flag before test
+	downForce = false
+	defer func() { downForce = false }()
+
+	// Parse --force flag
+	if err := downCmd.ParseFlags([]string{"--force"}); err != nil {
+		t.Fatalf("ParseFlags failed: %v", err)
+	}
+
+	if !downForce {
+		t.Error("--force flag should set downForce to true")
+	}
+}
+
+func TestDownFlagDefault(t *testing.T) {
+	forceFlag := downCmd.Flags().Lookup("force")
+	if forceFlag == nil {
+		t.Fatal("force flag not found")
+	}
+	if forceFlag.DefValue != "false" {
+		t.Errorf("force default: got %q, want %q", forceFlag.DefValue, "false")
+	}
+}

--- a/internal/cmd/process_test.go
+++ b/internal/cmd/process_test.go
@@ -1,0 +1,162 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// resetProcessFlags resets process command flags between tests
+func resetProcessFlags() {
+	processCommand = ""
+	processPort = 0
+	processWorkDir = ""
+	processLogLines = 50
+}
+
+func TestProcessListNoWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err = os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	_, _, err = executeIntegrationCmd("process", "list")
+	if err == nil {
+		t.Fatal("expected error when not in workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in a bc workspace") {
+		t.Errorf("expected workspace error, got: %v", err)
+	}
+}
+
+func TestProcessListEmpty(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	stdout, _, err := executeIntegrationCmd("process", "list")
+	if err != nil {
+		t.Fatalf("process list returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "No processes") {
+		t.Errorf("expected 'No processes', got: %s", stdout)
+	}
+}
+
+func TestProcessStopNotFound(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("process", "stop", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing process, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessLogsNotFound(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("process", "logs", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing process, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessInfoNotFound(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("process", "info", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing process, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessAttachNotFound(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("process", "attach", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing process, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessStartRequiresCmd(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+	resetProcessFlags()
+	defer resetProcessFlags()
+
+	_, _, err := executeIntegrationCmd("process", "start", "test-proc")
+	if err == nil {
+		t.Fatal("expected error for missing --cmd flag, got nil")
+	}
+	// The error message varies by Cobra version but should indicate missing flag
+	if !strings.Contains(err.Error(), "required") && !strings.Contains(err.Error(), "cmd") {
+		t.Errorf("expected flag requirement error, got: %v", err)
+	}
+}
+
+func TestProcessFlagDefaults(t *testing.T) {
+	// Check process list flag defaults
+	linesFlag := processLogsCmd.Flags().Lookup("lines")
+	if linesFlag == nil {
+		t.Fatal("lines flag not found")
+	}
+	if linesFlag.DefValue != "50" {
+		t.Errorf("lines default: got %q, want %q", linesFlag.DefValue, "50")
+	}
+
+	// Check process start flag defaults
+	portFlag := processStartCmd.Flags().Lookup("port")
+	if portFlag == nil {
+		t.Fatal("port flag not found")
+	}
+	if portFlag.DefValue != "0" {
+		t.Errorf("port default: got %q, want %q", portFlag.DefValue, "0")
+	}
+}
+
+func TestProcessStartNoWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err = os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	resetProcessFlags()
+	processCommand = "echo hello"
+	defer resetProcessFlags()
+
+	_, _, err = executeIntegrationCmd("process", "start", "test", "--cmd", "echo hello")
+	if err == nil {
+		t.Fatal("expected error when not in workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in a bc workspace") {
+		t.Errorf("expected workspace error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add comprehensive tests for `bc down` command (5 tests)
- Add comprehensive tests for `bc process` command (9 tests)
- Tests cover workspace detection, error handling, and flag defaults

## Test plan
- [x] All new tests pass locally
- [x] Linter passes with 0 issues
- [x] Pre-commit hooks pass

Partial fix for #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)