### PR TITLE
test(cmd): add integration tests for agent CLI commands

### DIFF
--- a/internal/cmd/agent_test.go
+++ b/internal/cmd/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rpuneet/bc/pkg/agent"
@@ -356,5 +357,88 @@ func TestAgentStopFlags(t *testing.T) {
 
 	if flags.Lookup("force") == nil {
 		t.Error("expected --force flag")
+	}
+}
+
+// --- Integration Tests using executeCmd ---
+
+func TestAgentListEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Command should succeed even with no agents
+	_, err := executeCmd("agent", "list")
+	if err != nil {
+		t.Fatalf("agent list failed: %v", err)
+	}
+}
+
+func TestAgentListJSON(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Command should succeed with --json flag
+	_, err := executeCmd("agent", "list", "--json")
+	if err != nil {
+		t.Fatalf("agent list --json failed: %v", err)
+	}
+}
+
+func TestAgentStopNonexistent(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("agent", "stop", "nonexistent-agent")
+	if err == nil {
+		t.Error("expected error for stopping nonexistent agent")
+	}
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found': %v", err)
+	}
+}
+
+func TestAgentSendNonexistent(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("agent", "send", "nonexistent-agent", "hello")
+	if err == nil {
+		t.Error("expected error for sending to nonexistent agent")
+	}
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention 'not found': %v", err)
+	}
+}
+
+func TestAgentPeekNonexistent(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("agent", "peek", "nonexistent-agent")
+	if err == nil {
+		t.Error("expected error for peeking nonexistent agent")
+	}
+}
+
+func TestAgentAttachNonexistent(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("agent", "attach", "nonexistent-agent")
+	if err == nil {
+		t.Error("expected error for attaching to nonexistent agent")
+	}
+}
+
+func TestAgentListWithRoleFilter(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Should succeed with valid role filter
+	_, err := executeCmd("agent", "list", "--role", "engineer")
+	if err != nil {
+		t.Fatalf("agent list --role failed: %v", err)
+	}
+}
+
+func TestAgentListInvalidRole(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("agent", "list", "--role", "invalid-role")
+	if err == nil {
+		t.Error("expected error for invalid role filter")
 	}
 }


### PR DESCRIPTION
## Summary
- Add integration tests for agent list (empty workspace, JSON output, role filter)
- Add error handling tests for agent stop/send/peek/attach on nonexistent agents
- Add test for invalid role filter validation

## Test Coverage
- **Before:** 50.3%
- **After:** 52.5%

## Related
Part of #165 (CLI integration tests)

## Test plan
- [x] All tests pass
- [x] golangci-lint passes
- [x] Tests exercise agent list/stop/send/peek/attach commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)