### PR TITLE
test: add agent command integration tests

### DIFF
--- a/internal/cmd/agent_integration_test.go
+++ b/internal/cmd/agent_integration_test.go
@@ -12,7 +12,7 @@ import (
 // Agent command integration tests that don't require actual tmux sessions.
 // These tests seed agent state files directly to test display/query functionality.
 
-func TestAgentListEmpty(t *testing.T) {
+func TestAgentListEmptyIntegration(t *testing.T) {
 	_, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 
@@ -98,7 +98,7 @@ func TestAgentListFilterByRole(t *testing.T) {
 	// Note: The filter might still show QA in the summary count, just not in the filtered list
 }
 
-func TestAgentListJSON(t *testing.T) {
+func TestAgentListJSONIntegration(t *testing.T) {
 	wsDir, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 


### PR DESCRIPTION
## Summary
- Add 12 integration tests for agent CLI commands
- Tests cover list, stop, peek, attach, send, create error handling
- Uses seeded agent state files to test without tmux dependency
- Improves test coverage for agent.go functions

## Test plan
- [x] All agent tests pass: `go test ./internal/cmd/... -run 'TestAgent' -v`
- [x] Full test suite passes: `go test ./...`
- [x] Lint passes: `golangci-lint run ./...`

Part of #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)