### PR TITLE
fix(tui): prevent global keybinds from triggering during text input

### DIFF
--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -122,7 +122,13 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *HomeModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 
-	// Global keys
+	// Check if a child view is in input mode - if so, skip global keybinds
+	// and pass directly to the view handler
+	if m.isInputActive() {
+		return m.dispatchToScreen(msg)
+	}
+
+	// Global keys (only processed when NOT in input mode)
 	switch key {
 	case "ctrl+c", "q":
 		if m.helpActive {
@@ -146,7 +152,26 @@ func (m *HomeModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Dispatch to active screen
+	return m.dispatchToScreen(msg)
+}
+
+// isInputActive returns true if a child view has an active text input field
+func (m *HomeModel) isInputActive() bool {
+	switch m.screen {
+	case ScreenChannel:
+		if m.channelModel != nil {
+			return m.channelModel.sendMode
+		}
+	case ScreenAgent:
+		if m.agentModel != nil {
+			return m.agentModel.sendMode
+		}
+	}
+	return false
+}
+
+// dispatchToScreen sends a key event to the appropriate screen handler
+func (m *HomeModel) dispatchToScreen(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.screen {
 	case ScreenHome:
 		return m.handleHomeKey(msg)
@@ -159,7 +184,6 @@ func (m *HomeModel) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case ScreenIssue:
 		return m.handleIssueKey(msg)
 	}
-
 	return m, nil
 }
 

--- a/internal/tui/home_test.go
+++ b/internal/tui/home_test.go
@@ -325,6 +325,114 @@ func TestHandleKey_AnyKeyClosesHelp(t *testing.T) {
 	}
 }
 
+// --- Input mode tests (Bug #175: keybinds while typing) ---
+
+func TestHandleKey_InputModeBlocksQuit(t *testing.T) {
+	// When in sendMode (typing a message), 'q' should NOT quit the TUI
+	m := newTestHomeModel()
+	m.screen = ScreenChannel
+	m.channelModel = &ChannelModel{
+		channel:  &channel.Channel{Name: "test"},
+		styles:   m.styles,
+		sendMode: true, // User is typing a message
+	}
+
+	// Press 'q' while in send mode - should NOT quit
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd != nil {
+		t.Error("'q' should not trigger quit when in input mode")
+	}
+}
+
+func TestHandleKey_InputModeAllowsTyping(t *testing.T) {
+	// Typing letters like 'u', 'i', 't' should work in send mode
+	m := newTestHomeModel()
+	m.screen = ScreenChannel
+	m.channelModel = &ChannelModel{
+		channel:  &channel.Channel{Name: "test"},
+		styles:   m.styles,
+		sendMode: true,
+		input:    "",
+	}
+
+	// Type 'quit' - all letters should be captured, not trigger actions
+	for _, r := range "quit" {
+		m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+
+	if m.channelModel.input != "quit" {
+		t.Errorf("expected input 'quit', got %q", m.channelModel.input)
+	}
+}
+
+func TestHandleKey_AgentSendModeBlocksQuit(t *testing.T) {
+	// Same test for agent screen
+	m := newTestHomeModel()
+	m.screen = ScreenAgent
+	m.agentModel = &AgentModel{
+		agent:    &agent.Agent{Name: "test-agent"},
+		styles:   m.styles,
+		sendMode: true,
+	}
+
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd != nil {
+		t.Error("'q' should not trigger quit when in agent send mode")
+	}
+}
+
+func TestIsInputActive_ChannelSendMode(t *testing.T) {
+	m := newTestHomeModel()
+	m.screen = ScreenChannel
+	m.channelModel = &ChannelModel{
+		channel:  &channel.Channel{Name: "test"},
+		sendMode: false,
+	}
+
+	if m.isInputActive() {
+		t.Error("isInputActive should be false when sendMode is false")
+	}
+
+	m.channelModel.sendMode = true
+	if !m.isInputActive() {
+		t.Error("isInputActive should be true when sendMode is true")
+	}
+}
+
+func TestIsInputActive_AgentSendMode(t *testing.T) {
+	m := newTestHomeModel()
+	m.screen = ScreenAgent
+	m.agentModel = &AgentModel{
+		agent:    &agent.Agent{Name: "test"},
+		sendMode: false,
+	}
+
+	if m.isInputActive() {
+		t.Error("isInputActive should be false when sendMode is false")
+	}
+
+	m.agentModel.sendMode = true
+	if !m.isInputActive() {
+		t.Error("isInputActive should be true when sendMode is true")
+	}
+}
+
+func TestIsInputActive_OtherScreens(t *testing.T) {
+	m := newTestHomeModel()
+
+	// Home screen should never have input active
+	m.screen = ScreenHome
+	if m.isInputActive() {
+		t.Error("isInputActive should be false for home screen")
+	}
+
+	// Workspace screen should never have input active
+	m.screen = ScreenWorkspace
+	if m.isInputActive() {
+		t.Error("isInputActive should be false for workspace screen")
+	}
+}
+
 // --- handleHomeKey tests ---
 
 func TestHandleHomeKey_CursorDown(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes bug where global keybinds like 'q' (quit) trigger while typing in channel or agent send mode
- Adds `isInputActive()` method to detect when child views are in text input mode
- Adds `dispatchToScreen()` method for cleaner screen-specific key routing
- Modifies `handleKey()` to skip global keybinds when input is active

## Test plan

- [x] Added `TestHandleKey_InputModeBlocksQuit` - verifies 'q' doesn't quit when typing
- [x] Added `TestHandleKey_InputModeAllowsTyping` - verifies characters are passed through in input mode
- [x] Added `TestHandleKey_AgentSendModeBlocksQuit` - verifies agent send mode also blocks quit
- [x] Added `TestIsInputActive_ChannelSendMode` - verifies channel sendMode detection
- [x] Added `TestIsInputActive_AgentSendMode` - verifies agent sendMode detection
- [x] Added `TestIsInputActive_OtherScreens` - verifies home screen returns false
- [x] All tests pass: `go test ./internal/tui/...`
- [x] Lint passes: `golangci-lint run ./internal/tui/...`

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)