### PR TITLE
feat(tui): add queue progress indicators to dashboard

### DIFF
--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -39,6 +39,11 @@ type WorkspaceStats struct {
 	ClosedIssues int
 	EpicsCount   int
 
+	// Queue stats
+	ReadyIssues      int // Issues unblocked and ready for work
+	InProgressIssues int // Issues currently being worked on
+	AssignedIssues   int // Issues assigned to agents
+
 	// Agent stats by state
 	IdleAgents    int
 	WorkingAgents int
@@ -670,6 +675,57 @@ func (m *WorkspaceModel) renderDashboard() string {
 	b.WriteString(m.styles.Muted.Render(totalLine))
 	b.WriteString("\n\n")
 
+	// --- Queue Progress section ---
+	b.WriteString(m.styles.Bold.Render("  QUEUE PROGRESS"))
+	b.WriteString("\n")
+
+	ready := m.stats.ReadyIssues
+	inProgress := m.stats.InProgressIssues
+	assigned := m.stats.AssignedIssues
+	openIssues := m.stats.OpenIssues
+
+	// Progress through open issues
+	if openIssues > 0 {
+		// Progress bar for in-progress vs total open
+		progressFilled := 0
+		if openIssues > 0 {
+			progressFilled = int(float64(barWidth) * float64(inProgress) / float64(openIssues))
+		}
+		progressBar := strings.Repeat("█", progressFilled) + strings.Repeat("░", barWidth-progressFilled)
+		progressPct := float64(inProgress) / float64(openIssues) * 100
+		b.WriteString(fmt.Sprintf("  In Progress: %s %5.1f%% (%d/%d)\n", m.styles.Info.Render(progressBar), progressPct, inProgress, openIssues))
+	}
+
+	queueItems := []struct {
+		label string
+		style string
+		count int
+	}{
+		{"Ready (unblocked)", "ok", ready},
+		{"In Progress", "info", inProgress},
+		{"Assigned", "", assigned},
+		{"Total Open", "", openIssues},
+	}
+
+	for _, q := range queueItems {
+		countBar := ""
+		if openIssues > 0 && q.count > 0 {
+			w := int(float64(barWidth) * float64(q.count) / float64(openIssues))
+			if w == 0 {
+				w = 1
+			}
+			countBar = strings.Repeat("█", w)
+		}
+		line := fmt.Sprintf("  %-18s %3d  %s", q.label, q.count, countBar)
+		if q.style != "" {
+			b.WriteString(m.styles.StatusStyle(q.style).Render(line))
+		} else {
+			b.WriteString(m.styles.Muted.Render(line))
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+
 	// --- Per-agent health table ---
 	b.WriteString(m.styles.Bold.Render("  AGENT HEALTH"))
 	b.WriteString("\n")
@@ -800,12 +856,23 @@ func (m *WorkspaceModel) computeStats() {
 			m.stats.EpicsCount++
 		}
 		switch issue.Status {
-		case "open", "pending", "in_progress":
+		case "open", "pending":
 			m.stats.OpenIssues++
+		case "in_progress":
+			m.stats.OpenIssues++
+			m.stats.InProgressIssues++
 		case "closed", "done", "resolved":
 			m.stats.ClosedIssues++
 		}
+		if issue.Assignee != "" {
+			m.stats.AssignedIssues++
+		}
 	}
+
+	// Count ready issues (unblocked and available for work)
+	readyIssues := beads.ReadyIssues(m.info.Entry.Path)
+	m.stats.ReadyIssues = len(readyIssues)
+
 	for _, a := range m.agents {
 		switch a.State {
 		case agent.StateIdle:

--- a/internal/tui/workspace_test.go
+++ b/internal/tui/workspace_test.go
@@ -1042,3 +1042,85 @@ func TestView_ShowsStatsBar(t *testing.T) {
 		t.Errorf("expected stats bar with 'Issues:', got: %s", output)
 	}
 }
+
+// --- Queue Progress tests ---
+
+func TestRenderDashboard_QueueProgress(t *testing.T) {
+	m := newTestModel()
+	m.issues = []beads.Issue{
+		{ID: "bd-001", Title: "Ready task", Status: "open"},
+		{ID: "bd-002", Title: "In progress task", Status: "in_progress"},
+		{ID: "bd-003", Title: "Assigned task", Status: "open", Assignee: "eng-01"},
+		{ID: "bd-004", Title: "Closed task", Status: "closed"},
+	}
+	m.computeStats()
+
+	output := m.renderDashboard()
+
+	// Should show queue progress section
+	if !strings.Contains(output, "QUEUE PROGRESS") {
+		t.Errorf("expected 'QUEUE PROGRESS' section header, got: %s", output)
+	}
+	// Should show in progress count (1 in_progress)
+	if !strings.Contains(output, "In Progress") {
+		t.Errorf("expected 'In Progress' in queue stats, got: %s", output)
+	}
+	// Should show assigned count
+	if !strings.Contains(output, "Assigned") {
+		t.Errorf("expected 'Assigned' in queue stats, got: %s", output)
+	}
+	// Should show total open count (open + pending + in_progress = 3)
+	if !strings.Contains(output, "Total Open") {
+		t.Errorf("expected 'Total Open' in queue stats, got: %s", output)
+	}
+}
+
+func TestComputeStats_QueueStats(t *testing.T) {
+	m := newTestModel()
+	m.issues = []beads.Issue{
+		{ID: "bd-001", Title: "Open task", Status: "open"},
+		{ID: "bd-002", Title: "In progress task", Status: "in_progress"},
+		{ID: "bd-003", Title: "Pending task", Status: "pending"},
+		{ID: "bd-004", Title: "Assigned open", Status: "open", Assignee: "eng-01"},
+		{ID: "bd-005", Title: "Assigned in progress", Status: "in_progress", Assignee: "eng-02"},
+		{ID: "bd-006", Title: "Closed", Status: "closed"},
+	}
+	m.computeStats()
+
+	// In progress count should be 2 (both in_progress issues)
+	if m.stats.InProgressIssues != 2 {
+		t.Errorf("InProgressIssues = %d, want 2", m.stats.InProgressIssues)
+	}
+	// Assigned count should be 2 (issues with assignee set)
+	if m.stats.AssignedIssues != 2 {
+		t.Errorf("AssignedIssues = %d, want 2", m.stats.AssignedIssues)
+	}
+	// Open count should be 5 (open + pending + in_progress)
+	if m.stats.OpenIssues != 5 {
+		t.Errorf("OpenIssues = %d, want 5", m.stats.OpenIssues)
+	}
+	// Closed count should be 1
+	if m.stats.ClosedIssues != 1 {
+		t.Errorf("ClosedIssues = %d, want 1", m.stats.ClosedIssues)
+	}
+}
+
+func TestRenderDashboard_QueueProgressBar(t *testing.T) {
+	m := newTestModel()
+	m.issues = []beads.Issue{
+		{ID: "bd-001", Title: "Open task", Status: "open"},
+		{ID: "bd-002", Title: "In progress", Status: "in_progress"},
+	}
+	m.computeStats()
+
+	output := m.renderDashboard()
+
+	// Should show progress bar with percentage
+	if !strings.Contains(output, "In Progress:") {
+		t.Errorf("expected 'In Progress:' progress bar, got: %s", output)
+	}
+	// Should contain progress percentage (50% = 1 in progress / 2 open)
+	if !strings.Contains(output, "50.0%") {
+		t.Errorf("expected '50.0%%' in progress bar, got: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds Queue Progress section to the TUI Dashboard view with visual indicators
- Shows progress bar for in-progress issues vs total open issues
- Displays queue stats: Ready (unblocked), In Progress, Assigned, Total Open
- Adds queue-related fields to WorkspaceStats struct (ReadyIssues, InProgressIssues, AssignedIssues)
- Uses `beads.ReadyIssues()` to get count of unblocked issues ready for work

## Test plan

- [x] Added `TestRenderDashboard_QueueProgress` - verifies queue progress section headers
- [x] Added `TestComputeStats_QueueStats` - verifies queue stats calculations
- [x] Added `TestRenderDashboard_QueueProgressBar` - verifies progress bar rendering
- [x] All tests pass: `go test ./internal/tui/...`
- [x] Lint passes: `golangci-lint run ./internal/tui/...`

Fixes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)