### PR TITLE
feat(tui): add queue view tab with work and merge queues

### DIFF
--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -25,11 +26,33 @@ const (
 	TabAgents Tab = iota
 	TabIssues
 	TabChannels
+	TabQueue
 	TabDashboard
 	TabStats
 
-	tabCount = 5
+	tabCount = 6
 )
+
+// QueueFilter defines the filter mode for the queue view.
+type QueueFilter int
+
+const (
+	QueueFilterAll QueueFilter = iota
+	QueueFilterReady
+	QueueFilterInProgress
+	QueueFilterByAgent
+)
+
+// QueueItem represents an item in the work or merge queue.
+type QueueItem struct {
+	ID       string
+	Title    string
+	Status   string
+	Assignee string
+	Type     string // "work" or "merge"
+	Agent    string // Associated agent name
+	Branch   string // Branch name for merge queue
+}
 
 // WorkspaceStats holds aggregated statistics for the workspace.
 type WorkspaceStats struct {
@@ -38,6 +61,11 @@ type WorkspaceStats struct {
 	OpenIssues   int
 	ClosedIssues int
 	EpicsCount   int
+
+	// Queue stats
+	ReadyIssues      int // Issues unblocked and ready for work
+	InProgressIssues int // Issues currently being worked on
+	AssignedIssues   int // Issues assigned to agents
 
 	// Agent stats by state
 	IdleAgents    int
@@ -48,33 +76,44 @@ type WorkspaceStats struct {
 
 // WorkspaceModel shows the detail view for a single workspace.
 type WorkspaceModel struct {
-	// Data
-	agents       []*agent.Agent
-	channels     []*channel.Channel
-	issues       []beads.Issue
-	recentEvents []events.Event
+	// Data - slices (24 bytes each)
+	agents        []*agent.Agent
+	channels      []*channel.Channel
+	issues        []beads.Issue
+	recentEvents  []events.Event
+	queueItems    []QueueItem
+	filteredQueue []QueueItem
 
-	// Per-agent stats from pkg/stats
+	// Per-agent stats from pkg/stats - map (8 bytes)
 	agentStats map[string]stats.AgentStat
 
-	manager   *agent.Manager
-	pkgStats  *stats.Stats
+	// Pointers (8 bytes each)
+	manager  *agent.Manager
+	pkgStats *stats.Stats
+
+	// Error interface (16 bytes)
 	issuesErr error
 
+	// Structs
 	styles style.Styles
 	info   WorkspaceInfo
 	stats  WorkspaceStats
 
+	// Ints (8 bytes each on 64-bit)
 	width        int
 	height       int
 	cursor       int
 	scrollOffset int // first visible item index for current tab
-	tab          Tab
 
-	// Loaded flags
+	// Small types
+	tab         Tab         // int
+	queueFilter QueueFilter // int
+
+	// Bools (1 byte each, but padded)
 	agentsLoaded   bool
 	issuesLoaded   bool
 	channelsLoaded bool
+	queueLoaded    bool
 }
 
 // NewWorkspaceModel creates a workspace detail view.
@@ -107,6 +146,9 @@ func NewWorkspaceModel(info WorkspaceInfo, s style.Styles) *WorkspaceModel {
 
 	// Load recent events for activity feed
 	m.loadRecentEvents()
+
+	// Load queue data
+	m.loadQueue()
 
 	// Compute dashboard stats
 	m.computeStats()
@@ -152,6 +194,12 @@ func (m *WorkspaceModel) HandleKey(msg tea.KeyMsg) Action {
 	case "r":
 		m.refresh()
 		return NoAction
+	case "f":
+		// Cycle queue filter when on queue tab
+		if m.tab == TabQueue {
+			m.cycleQueueFilter()
+			return NoAction
+		}
 	}
 	if isEnterKey(msg) {
 		return m.selectCurrent()
@@ -165,6 +213,7 @@ func (m *WorkspaceModel) refresh() {
 	m.agents = m.manager.ListAgents()
 	m.issues, m.issuesErr = beads.ListIssues(m.info.Entry.Path)
 	m.loadChannels()
+	m.loadQueue()
 	m.loadRecentEvents()
 	m.computeStats()
 	m.loadPkgStats()
@@ -181,6 +230,114 @@ func (m *WorkspaceModel) loadAgentStats() {
 	}
 	for _, as := range s.Agents.AgentStats {
 		m.agentStats[as.Name] = as
+	}
+}
+
+// loadQueue loads work queue and merge queue items.
+func (m *WorkspaceModel) loadQueue() {
+	m.queueItems = nil
+
+	// Load work queue items from ready issues
+	readyIssues := beads.ReadyIssues(m.info.Entry.Path)
+	for _, issue := range readyIssues {
+		m.queueItems = append(m.queueItems, QueueItem{
+			ID:       issue.ID,
+			Title:    issue.Title,
+			Status:   issue.Status,
+			Assignee: issue.Assignee,
+			Type:     "work",
+		})
+	}
+
+	// Load merge queue items from agents with active branches
+	for _, a := range m.agents {
+		if a.State == agent.StateWorking || a.State == agent.StateDone {
+			branch := ""
+			if a.WorktreeDir != "" {
+				// Try to get the current branch from the agent's worktree
+				branch = m.getAgentBranch(a)
+			}
+			if branch != "" && branch != "main" && branch != "master" {
+				m.queueItems = append(m.queueItems, QueueItem{
+					ID:     a.Name,
+					Title:  a.Task,
+					Status: string(a.State),
+					Agent:  a.Name,
+					Branch: branch,
+					Type:   "merge",
+				})
+			}
+		}
+	}
+
+	m.queueLoaded = true
+	m.applyQueueFilter()
+}
+
+// getAgentBranch returns the current branch for an agent's worktree.
+func (m *WorkspaceModel) getAgentBranch(a *agent.Agent) string {
+	if a.WorktreeDir == "" {
+		return ""
+	}
+	// Use git to get current branch
+	cmd := exec.CommandContext(context.Background(), "git", "-C", a.WorktreeDir, "rev-parse", "--abbrev-ref", "HEAD") //nolint:gosec // WorktreeDir is from trusted agent data
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// cycleQueueFilter cycles through the available queue filters.
+func (m *WorkspaceModel) cycleQueueFilter() {
+	m.queueFilter = (m.queueFilter + 1) % 4 // 4 filter modes
+	m.applyQueueFilter()
+	m.cursor = 0
+	m.scrollOffset = 0
+}
+
+// applyQueueFilter applies the current filter to the queue items.
+func (m *WorkspaceModel) applyQueueFilter() {
+	switch m.queueFilter {
+	case QueueFilterAll:
+		m.filteredQueue = m.queueItems
+	case QueueFilterReady:
+		m.filteredQueue = nil
+		for _, item := range m.queueItems {
+			if item.Type == "work" {
+				m.filteredQueue = append(m.filteredQueue, item)
+			}
+		}
+	case QueueFilterInProgress:
+		m.filteredQueue = nil
+		for _, item := range m.queueItems {
+			if item.Type == "merge" {
+				m.filteredQueue = append(m.filteredQueue, item)
+			}
+		}
+	case QueueFilterByAgent:
+		m.filteredQueue = nil
+		for _, item := range m.queueItems {
+			if item.Assignee != "" || item.Agent != "" {
+				m.filteredQueue = append(m.filteredQueue, item)
+			}
+		}
+	}
+}
+
+// queueFilterLabel returns a display label for the current queue filter.
+func (m *WorkspaceModel) queueFilterLabel() string {
+	switch m.queueFilter {
+	case QueueFilterAll:
+		return "All"
+	case QueueFilterReady:
+		return "Work Queue"
+	case QueueFilterInProgress:
+		return "Merge Queue"
+	case QueueFilterByAgent:
+		return "Assigned"
+	default:
+		return "All"
 	}
 }
 
@@ -215,6 +372,10 @@ func (m *WorkspaceModel) maxCursor() int {
 	case TabChannels:
 		if len(m.channels) > 0 {
 			return len(m.channels) - 1
+		}
+	case TabQueue:
+		if len(m.filteredQueue) > 0 {
+			return len(m.filteredQueue) - 1
 		}
 	case TabDashboard:
 		return 0
@@ -307,6 +468,8 @@ func (m *WorkspaceModel) View() string {
 		b.WriteString(m.renderIssues())
 	case TabChannels:
 		b.WriteString(m.renderChannels())
+	case TabQueue:
+		b.WriteString(m.renderQueue())
 	case TabDashboard:
 		b.WriteString(m.renderDashboard())
 	case TabStats:
@@ -325,6 +488,7 @@ func (m *WorkspaceModel) renderTabBar() string {
 		{"Agents", TabAgents, len(m.agents)},
 		{"Issues", TabIssues, len(m.issues)},
 		{"Channels", TabChannels, len(m.channels)},
+		{"Queue", TabQueue, len(m.filteredQueue)},
 		{"Dashboard", TabDashboard, m.stats.OpenIssues},
 		{"Stats", TabStats, -1},
 	}
@@ -572,6 +736,65 @@ func (m *WorkspaceModel) renderChannels() string {
 	return b.String()
 }
 
+func (m *WorkspaceModel) renderQueue() string {
+	var b strings.Builder
+
+	// Filter indicator
+	filterLabel := m.queueFilterLabel()
+	b.WriteString(m.styles.Muted.Render(fmt.Sprintf("  Filter: %s (press 'f' to cycle)", filterLabel)))
+	b.WriteString("\n\n")
+
+	if len(m.filteredQueue) == 0 {
+		b.WriteString(m.styles.Muted.Render("  No items in queue."))
+		b.WriteString("\n")
+		return b.String()
+	}
+
+	// Header
+	header := fmt.Sprintf("  %-12s %-8s %-12s %-15s %s", "ID", "TYPE", "STATUS", "AGENT", "TITLE/BRANCH")
+	b.WriteString(m.styles.Bold.Render(header))
+	b.WriteString("\n")
+
+	start, end := m.viewportRange(len(m.filteredQueue))
+	for i := start; i < end; i++ {
+		item := m.filteredQueue[i]
+		selected := i == m.cursor
+
+		// Format title/branch
+		titleOrBranch := item.Title
+		if item.Type == "merge" && item.Branch != "" {
+			titleOrBranch = item.Branch
+		}
+		if len(titleOrBranch) > 35 {
+			titleOrBranch = titleOrBranch[:32] + "..."
+		}
+
+		agentName := item.Assignee
+		if agentName == "" {
+			agentName = item.Agent
+		}
+		if agentName == "" {
+			agentName = "-"
+		}
+
+		line := fmt.Sprintf("  %-12s %-8s %-12s %-15s %s",
+			item.ID, item.Type, item.Status, agentName, titleOrBranch,
+		)
+
+		if selected {
+			b.WriteString(m.styles.Selected.Render(line))
+		} else if item.Type == "merge" {
+			b.WriteString(m.styles.Success.Render(line))
+		} else {
+			b.WriteString(m.styles.Normal.Render(line))
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString(m.renderPositionIndicator(len(m.filteredQueue)))
+	return b.String()
+}
+
 func (m *WorkspaceModel) loadPkgStats() {
 	stateDir := filepath.Join(m.info.Entry.Path, ".bc")
 	s, err := stats.Load(stateDir)
@@ -800,12 +1023,23 @@ func (m *WorkspaceModel) computeStats() {
 			m.stats.EpicsCount++
 		}
 		switch issue.Status {
-		case "open", "pending", "in_progress":
+		case "open", "pending":
 			m.stats.OpenIssues++
+		case "in_progress":
+			m.stats.OpenIssues++
+			m.stats.InProgressIssues++
 		case "closed", "done", "resolved":
 			m.stats.ClosedIssues++
 		}
+		if issue.Assignee != "" {
+			m.stats.AssignedIssues++
+		}
 	}
+
+	// Count ready issues
+	readyIssues := beads.ReadyIssues(m.info.Entry.Path)
+	m.stats.ReadyIssues = len(readyIssues)
+
 	for _, a := range m.agents {
 		switch a.State {
 		case agent.StateIdle:

--- a/internal/tui/workspace_test.go
+++ b/internal/tui/workspace_test.go
@@ -1042,3 +1042,199 @@ func TestView_ShowsStatsBar(t *testing.T) {
 		t.Errorf("expected stats bar with 'Issues:', got: %s", output)
 	}
 }
+
+// --- Queue view tests ---
+
+func TestRenderQueue_Empty(t *testing.T) {
+	m := newTestModel()
+	m.tab = TabQueue
+	m.queueFilter = QueueFilterAll
+	m.applyQueueFilter()
+
+	output := m.renderQueue()
+
+	if !strings.Contains(output, "No items in queue") {
+		t.Errorf("expected 'No items in queue', got: %s", output)
+	}
+	if !strings.Contains(output, "Filter: All") {
+		t.Errorf("expected 'Filter: All', got: %s", output)
+	}
+}
+
+func TestRenderQueue_WithWorkItems(t *testing.T) {
+	m := newTestModel()
+	m.tab = TabQueue
+	m.queueItems = []QueueItem{
+		{ID: "bd-001", Title: "Fix bug", Status: "open", Type: "work"},
+		{ID: "bd-002", Title: "Add feature", Status: "open", Type: "work", Assignee: "eng-01"},
+	}
+	m.queueFilter = QueueFilterAll
+	m.applyQueueFilter()
+
+	output := m.renderQueue()
+
+	if !strings.Contains(output, "bd-001") {
+		t.Errorf("expected 'bd-001' in queue, got: %s", output)
+	}
+	if !strings.Contains(output, "work") {
+		t.Errorf("expected 'work' type in queue, got: %s", output)
+	}
+}
+
+func TestRenderQueue_WithMergeItems(t *testing.T) {
+	m := newTestModel()
+	m.tab = TabQueue
+	m.queueItems = []QueueItem{
+		{ID: "eng-01", Title: "PR work", Status: "working", Type: "merge", Agent: "eng-01", Branch: "feat/new-feature"},
+	}
+	m.queueFilter = QueueFilterAll
+	m.applyQueueFilter()
+
+	output := m.renderQueue()
+
+	if !strings.Contains(output, "eng-01") {
+		t.Errorf("expected 'eng-01' in queue, got: %s", output)
+	}
+	if !strings.Contains(output, "merge") {
+		t.Errorf("expected 'merge' type in queue, got: %s", output)
+	}
+	if !strings.Contains(output, "feat/new-feature") {
+		t.Errorf("expected branch name in queue, got: %s", output)
+	}
+}
+
+func TestQueueFilter_ReadyOnly(t *testing.T) {
+	m := newTestModel()
+	m.queueItems = []QueueItem{
+		{ID: "bd-001", Type: "work"},
+		{ID: "eng-01", Type: "merge"},
+	}
+	m.queueFilter = QueueFilterReady
+	m.applyQueueFilter()
+
+	if len(m.filteredQueue) != 1 {
+		t.Errorf("expected 1 item with Ready filter, got %d", len(m.filteredQueue))
+	}
+	if m.filteredQueue[0].Type != "work" {
+		t.Errorf("expected work item, got %s", m.filteredQueue[0].Type)
+	}
+}
+
+func TestQueueFilter_InProgressOnly(t *testing.T) {
+	m := newTestModel()
+	m.queueItems = []QueueItem{
+		{ID: "bd-001", Type: "work"},
+		{ID: "eng-01", Type: "merge"},
+	}
+	m.queueFilter = QueueFilterInProgress
+	m.applyQueueFilter()
+
+	if len(m.filteredQueue) != 1 {
+		t.Errorf("expected 1 item with InProgress filter, got %d", len(m.filteredQueue))
+	}
+	if m.filteredQueue[0].Type != "merge" {
+		t.Errorf("expected merge item, got %s", m.filteredQueue[0].Type)
+	}
+}
+
+func TestQueueFilter_ByAgent(t *testing.T) {
+	m := newTestModel()
+	m.queueItems = []QueueItem{
+		{ID: "bd-001", Type: "work"},
+		{ID: "bd-002", Type: "work", Assignee: "eng-01"},
+		{ID: "eng-01", Type: "merge", Agent: "eng-01"},
+	}
+	m.queueFilter = QueueFilterByAgent
+	m.applyQueueFilter()
+
+	if len(m.filteredQueue) != 2 {
+		t.Errorf("expected 2 items with ByAgent filter, got %d", len(m.filteredQueue))
+	}
+}
+
+func TestCycleQueueFilter(t *testing.T) {
+	m := newTestModel()
+	m.queueFilter = QueueFilterAll
+
+	m.cycleQueueFilter()
+	if m.queueFilter != QueueFilterReady {
+		t.Errorf("expected Ready after first cycle, got %d", m.queueFilter)
+	}
+
+	m.cycleQueueFilter()
+	if m.queueFilter != QueueFilterInProgress {
+		t.Errorf("expected InProgress after second cycle, got %d", m.queueFilter)
+	}
+
+	m.cycleQueueFilter()
+	if m.queueFilter != QueueFilterByAgent {
+		t.Errorf("expected ByAgent after third cycle, got %d", m.queueFilter)
+	}
+
+	m.cycleQueueFilter()
+	if m.queueFilter != QueueFilterAll {
+		t.Errorf("expected All after fourth cycle (wrap), got %d", m.queueFilter)
+	}
+}
+
+func TestQueueFilterLabel(t *testing.T) {
+	m := newTestModel()
+
+	m.queueFilter = QueueFilterAll
+	if label := m.queueFilterLabel(); label != "All" {
+		t.Errorf("expected 'All', got %s", label)
+	}
+
+	m.queueFilter = QueueFilterReady
+	if label := m.queueFilterLabel(); label != "Work Queue" {
+		t.Errorf("expected 'Work Queue', got %s", label)
+	}
+
+	m.queueFilter = QueueFilterInProgress
+	if label := m.queueFilterLabel(); label != "Merge Queue" {
+		t.Errorf("expected 'Merge Queue', got %s", label)
+	}
+
+	m.queueFilter = QueueFilterByAgent
+	if label := m.queueFilterLabel(); label != "Assigned" {
+		t.Errorf("expected 'Assigned', got %s", label)
+	}
+}
+
+func TestMaxCursor_Queue(t *testing.T) {
+	m := newTestModel()
+	m.tab = TabQueue
+	m.filteredQueue = []QueueItem{
+		{ID: "1"}, {ID: "2"}, {ID: "3"},
+	}
+
+	max := m.maxCursor()
+	if max != 2 {
+		t.Errorf("maxCursor for 3 queue items = %d, want 2", max)
+	}
+}
+
+func TestRenderTabBar_Shows6Tabs(t *testing.T) {
+	m := newTestModel()
+	output := m.renderTabBar()
+
+	// Should have all 6 tabs including Queue
+	if !strings.Contains(output, "Agents") {
+		t.Error("expected 'Agents' tab")
+	}
+	if !strings.Contains(output, "Issues") {
+		t.Error("expected 'Issues' tab")
+	}
+	if !strings.Contains(output, "Channels") {
+		t.Error("expected 'Channels' tab")
+	}
+	if !strings.Contains(output, "Queue") {
+		t.Error("expected 'Queue' tab")
+	}
+	if !strings.Contains(output, "Dashboard") {
+		t.Error("expected 'Dashboard' tab")
+	}
+	if !strings.Contains(output, "Stats") {
+		t.Error("expected 'Stats' tab")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds new Queue tab to the TUI workspace view
- Work queue shows ready issues from beads (unblocked and available for work)
- Merge queue shows agents with active branches that could be merged
- Filter cycling with 'f' key: All → Work Queue → Merge Queue → Assigned
- Displays item ID, type, status, agent/assignee, and title/branch
- Adds queue-related stats: ReadyIssues, InProgressIssues, AssignedIssues

## Test plan

- [x] Added `TestRenderQueue_Empty` - verifies empty queue message
- [x] Added `TestRenderQueue_WithWorkItems` - verifies work queue rendering
- [x] Added `TestRenderQueue_WithMergeItems` - verifies merge queue rendering
- [x] Added `TestQueueFilter_ReadyOnly` - verifies work queue filter
- [x] Added `TestQueueFilter_InProgressOnly` - verifies merge queue filter
- [x] Added `TestQueueFilter_ByAgent` - verifies assigned filter
- [x] Added `TestCycleQueueFilter` - verifies filter cycling
- [x] Added `TestQueueFilterLabel` - verifies filter labels
- [x] Added `TestMaxCursor_Queue` - verifies cursor bounds
- [x] Added `TestRenderTabBar_Shows6Tabs` - verifies tab bar includes Queue
- [x] All tests pass: `go test ./internal/tui/...`
- [x] Lint passes: `golangci-lint run ./internal/tui/...`

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)