### PR TITLE
feat(tui): add memory and issue info to agents view

### DIFF
--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/events"
+	"github.com/rpuneet/bc/pkg/memory"
 	"github.com/rpuneet/bc/pkg/tui/style"
 )
 
@@ -17,18 +18,20 @@ const agentMaxRecentEvents = 10
 
 // AgentModel shows the detail view for a single agent.
 type AgentModel struct {
-	manager      *agent.Manager
-	agent        *agent.Agent
-	styles       style.Styles
-	sendMsg      string
-	wsPath       string
-	peekOutput   string
-	input        string
-	recentEvents []events.Event
-	width        int
-	height       int
-	peekActive   bool
-	sendMode     bool
+	manager         *agent.Manager
+	agent           *agent.Agent
+	styles          style.Styles
+	sendMsg         string
+	wsPath          string
+	peekOutput      string
+	input           string
+	recentEvents    []events.Event
+	width           int
+	height          int
+	experienceCount int
+	peekActive      bool
+	sendMode        bool
+	hasMemory       bool
 }
 
 // NewAgentModel creates an agent detail view.
@@ -41,6 +44,7 @@ func NewAgentModel(a *agent.Agent, mgr *agent.Manager, wsPath string, s style.St
 		wsPath:  wsPath,
 	}
 	m.loadRecentActivity()
+	m.loadMemoryInfo()
 	return m
 }
 
@@ -123,6 +127,26 @@ func (m *AgentModel) refresh() {
 		m.agent = a
 	}
 	m.loadRecentActivity()
+	m.loadMemoryInfo()
+}
+
+func (m *AgentModel) loadMemoryInfo() {
+	if m.wsPath == "" {
+		return
+	}
+	store := memory.NewStore(m.wsPath, m.agent.Name)
+	if !store.Exists() {
+		m.hasMemory = false
+		m.experienceCount = 0
+		return
+	}
+	m.hasMemory = true
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		m.experienceCount = 0
+		return
+	}
+	m.experienceCount = len(experiences)
 }
 
 func (m *AgentModel) loadPeek() {
@@ -205,6 +229,11 @@ func (m *AgentModel) renderInfo() string {
 
 	if m.agent.Task != "" {
 		fields = append(fields, field{"Task", m.agent.Task, ""})
+	}
+
+	// Add memory info
+	if m.hasMemory {
+		fields = append(fields, field{"Experiences", fmt.Sprintf("%d", m.experienceCount), ""})
 	}
 
 	for _, f := range fields {

--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rpuneet/bc/pkg/beads"
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/events"
+	"github.com/rpuneet/bc/pkg/memory"
 	"github.com/rpuneet/bc/pkg/stats"
 	"github.com/rpuneet/bc/pkg/tui/style"
 )
@@ -62,6 +63,12 @@ type WorkspaceModel struct {
 	// Per-agent stats from pkg/stats
 	agentStats map[string]stats.AgentStat
 
+	// Per-agent issue counts
+	issuesByAgent map[string]int
+
+	// Per-agent memory experience counts
+	experiencesByAgent map[string]int
+
 	manager   *agent.Manager
 	pkgStats  *stats.Stats
 	issuesErr error
@@ -109,6 +116,9 @@ func NewWorkspaceModel(info WorkspaceInfo, s style.Styles) *WorkspaceModel {
 
 	// Load per-agent stats from pkg/stats
 	m.loadAgentStats()
+
+	// Load per-agent memory info
+	m.loadMemoryInfo()
 
 	// Load recent events for activity feed
 	m.loadRecentEvents()
@@ -170,6 +180,7 @@ func (m *WorkspaceModel) refresh() {
 	m.agents = m.manager.ListAgents()
 	m.issues, m.issuesErr = beads.ListIssues(m.info.Entry.Path)
 	m.loadChannels()
+	m.loadMemoryInfo()
 	m.loadRecentEvents()
 	m.computeStats()
 	m.loadPkgStats()
@@ -186,6 +197,21 @@ func (m *WorkspaceModel) loadAgentStats() {
 	}
 	for _, as := range s.Agents.AgentStats {
 		m.agentStats[as.Name] = as
+	}
+}
+
+func (m *WorkspaceModel) loadMemoryInfo() {
+	m.experiencesByAgent = make(map[string]int)
+	for _, a := range m.agents {
+		store := memory.NewStore(m.info.Entry.Path, a.Name)
+		if !store.Exists() {
+			continue
+		}
+		experiences, err := store.GetExperiences()
+		if err != nil {
+			continue
+		}
+		m.experiencesByAgent[a.Name] = len(experiences)
 	}
 }
 
@@ -361,15 +387,15 @@ func (m *WorkspaceModel) renderAgents() string {
 		return b.String()
 	}
 
-	// Header
-	header := fmt.Sprintf("  %-15s %-12s %-10s %-12s %s",
-		"NAME", "ROLE", "STATE", "UPTIME", "TASK")
+	// Header with ISSUES and MEM columns for queue/memory info
+	header := fmt.Sprintf("  %-15s %-12s %-10s %-8s %-6s %-12s %s",
+		"NAME", "ROLE", "STATE", "ISSUES", "MEM", "UPTIME", "TASK")
 	b.WriteString(m.styles.Bold.Render(header))
 	b.WriteString("\n")
 
-	// Fixed columns: 2(indent) + NAME(15) + ROLE(12) + STATE(10) + UPTIME(12) = 51
+	// Fixed columns: 2(indent) + NAME(15) + ROLE(12) + STATE(10) + ISSUES(8) + MEM(6) + UPTIME(12) = 65
 	// Task gets the rest of the terminal width
-	taskWidth := m.width - 51
+	taskWidth := m.width - 65
 	if taskWidth < 20 {
 		taskWidth = 20
 	}
@@ -388,6 +414,20 @@ func (m *WorkspaceModel) renderAgents() string {
 			uptime = fmtDuration(time.Since(a.StartedAt))
 		}
 
+		// Get issues count for this agent
+		issues := m.issuesByAgent[a.Name]
+		issuesStr := "-"
+		if issues > 0 {
+			issuesStr = fmt.Sprintf("%d", issues)
+		}
+
+		// Get experience count for this agent (memory info)
+		experiences := m.experiencesByAgent[a.Name]
+		memStr := "-"
+		if experiences > 0 {
+			memStr = fmt.Sprintf("%d", experiences)
+		}
+
 		task := a.Task
 		if task == "" {
 			task = "-"
@@ -396,8 +436,8 @@ func (m *WorkspaceModel) renderAgents() string {
 			task = task[:taskWidth-3] + "..."
 		}
 
-		line := fmt.Sprintf("  %-15s %-12s %-10s %-12s %s",
-			a.Name, a.Role, a.State, uptime, task,
+		line := fmt.Sprintf("  %-15s %-12s %-10s %-8s %-6s %-12s %s",
+			a.Name, a.Role, a.State, issuesStr, memStr, uptime, task,
 		)
 
 		if selected {
@@ -850,6 +890,7 @@ func (m *WorkspaceModel) getRecentlyClosedIssues() []beads.Issue {
 
 func (m *WorkspaceModel) computeStats() {
 	m.stats = WorkspaceStats{}
+	m.issuesByAgent = make(map[string]int)
 	for _, issue := range m.issues {
 		m.stats.TotalIssues++
 		if issue.Type == "epic" {
@@ -866,6 +907,7 @@ func (m *WorkspaceModel) computeStats() {
 		}
 		if issue.Assignee != "" {
 			m.stats.AssignedIssues++
+			m.issuesByAgent[issue.Assignee]++
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add ISSUES column showing assigned issues per agent in agents list view
- Add MEM column showing experience count (memory) per agent
- Show experience count in agent details panel when memory exists

## Changes
- `workspace.go`: Add `issuesByAgent` and `experiencesByAgent` maps, update `renderAgents()` to show new columns
- `agent.go`: Add `loadMemoryInfo()` method, show experience count in agent info

## Test plan
- [x] All TUI tests pass
- [x] golangci-lint passes
- [ ] Verify agents list shows ISSUES and MEM columns
- [ ] Verify agent details shows experiences when memory exists

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)