### PR TITLE
feat(tui): enhance agents view with memory and queue info

### DIFF
--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -361,17 +361,20 @@ func (m *WorkspaceModel) renderAgents() string {
 		return b.String()
 	}
 
-	// Header
-	header := fmt.Sprintf("  %-15s %-12s %-10s %-12s %s",
-		"NAME", "ROLE", "STATE", "UPTIME", "TASK")
+	// Count issues per agent
+	issuesByAgent := m.countIssuesByAgent()
+
+	// Header with memory and queue columns
+	header := fmt.Sprintf("  %-15s %-12s %-10s %-3s %-6s %-10s %s",
+		"NAME", "ROLE", "STATE", "MEM", "ISSUES", "UPTIME", "TASK")
 	b.WriteString(m.styles.Bold.Render(header))
 	b.WriteString("\n")
 
-	// Fixed columns: 2(indent) + NAME(15) + ROLE(12) + STATE(10) + UPTIME(12) = 51
+	// Fixed columns: 2(indent) + NAME(15) + ROLE(12) + STATE(10) + MEM(3) + ISSUES(6) + UPTIME(10) = 58
 	// Task gets the rest of the terminal width
-	taskWidth := m.width - 51
-	if taskWidth < 20 {
-		taskWidth = 20
+	taskWidth := m.width - 58
+	if taskWidth < 15 {
+		taskWidth = 15
 	}
 
 	// Render only the visible viewport.
@@ -388,6 +391,19 @@ func (m *WorkspaceModel) renderAgents() string {
 			uptime = fmtDuration(time.Since(a.StartedAt))
 		}
 
+		// Memory status indicator
+		memStatus := "-"
+		if a.Memory != nil && a.Memory.RolePrompt != "" {
+			memStatus = "✓"
+		}
+
+		// Issues count for this agent
+		issueCount := issuesByAgent[a.Name]
+		issueStr := "-"
+		if issueCount > 0 {
+			issueStr = fmt.Sprintf("%d", issueCount)
+		}
+
 		task := a.Task
 		if task == "" {
 			task = "-"
@@ -396,8 +412,8 @@ func (m *WorkspaceModel) renderAgents() string {
 			task = task[:taskWidth-3] + "..."
 		}
 
-		line := fmt.Sprintf("  %-15s %-12s %-10s %-12s %s",
-			a.Name, a.Role, a.State, uptime, task,
+		line := fmt.Sprintf("  %-15s %-12s %-10s %-3s %-6s %-10s %s",
+			a.Name, a.Role, a.State, memStatus, issueStr, uptime, task,
 		)
 
 		if selected {
@@ -410,6 +426,17 @@ func (m *WorkspaceModel) renderAgents() string {
 
 	b.WriteString(m.renderPositionIndicator(len(m.agents)))
 	return b.String()
+}
+
+// countIssuesByAgent returns a map of agent name to assigned issue count.
+func (m *WorkspaceModel) countIssuesByAgent() map[string]int {
+	counts := make(map[string]int)
+	for _, issue := range m.issues {
+		if issue.Assignee != "" {
+			counts[issue.Assignee]++
+		}
+	}
+	return counts
 }
 
 func (m *WorkspaceModel) renderIssues() string {

--- a/internal/tui/workspace_test.go
+++ b/internal/tui/workspace_test.go
@@ -1043,6 +1043,92 @@ func TestView_ShowsStatsBar(t *testing.T) {
 	}
 }
 
+// --- Agents view enhancement tests ---
+
+func TestRenderAgents_ShowsMemoryStatus(t *testing.T) {
+	m := newTestModel()
+	m.tab = TabAgents
+	m.agents = []*agent.Agent{
+		{Name: "eng-01", Role: agent.RoleEngineer, State: agent.StateWorking, Memory: &agent.AgentMemory{RolePrompt: "test"}},
+		{Name: "eng-02", Role: agent.RoleEngineer, State: agent.StateIdle, Memory: nil},
+	}
+	m.agentStats = map[string]stats.AgentStat{}
+
+	output := m.renderAgents()
+
+	// Should have MEM column header
+	if !strings.Contains(output, "MEM") {
+		t.Errorf("expected 'MEM' column header, got: %s", output)
+	}
+	// eng-01 should show memory loaded indicator
+	if !strings.Contains(output, "✓") {
+		t.Errorf("expected memory loaded indicator '✓' for eng-01, got: %s", output)
+	}
+}
+
+func TestRenderAgents_ShowsIssuesCount(t *testing.T) {
+	m := newTestModel()
+	m.tab = TabAgents
+	m.agents = []*agent.Agent{
+		{Name: "eng-01", Role: agent.RoleEngineer, State: agent.StateWorking},
+		{Name: "eng-02", Role: agent.RoleEngineer, State: agent.StateIdle},
+	}
+	m.issues = []beads.Issue{
+		{ID: "bd-001", Title: "Issue 1", Status: "open", Assignee: "eng-01"},
+		{ID: "bd-002", Title: "Issue 2", Status: "open", Assignee: "eng-01"},
+		{ID: "bd-003", Title: "Issue 3", Status: "open", Assignee: "eng-02"},
+	}
+	m.agentStats = map[string]stats.AgentStat{}
+
+	output := m.renderAgents()
+
+	// Should have ISSUES column header
+	if !strings.Contains(output, "ISSUES") {
+		t.Errorf("expected 'ISSUES' column header, got: %s", output)
+	}
+}
+
+func TestCountIssuesByAgent(t *testing.T) {
+	m := newTestModel()
+	m.issues = []beads.Issue{
+		{ID: "bd-001", Assignee: "eng-01"},
+		{ID: "bd-002", Assignee: "eng-01"},
+		{ID: "bd-003", Assignee: "eng-02"},
+		{ID: "bd-004", Assignee: ""}, // unassigned
+	}
+
+	counts := m.countIssuesByAgent()
+
+	if counts["eng-01"] != 2 {
+		t.Errorf("eng-01 should have 2 issues, got %d", counts["eng-01"])
+	}
+	if counts["eng-02"] != 1 {
+		t.Errorf("eng-02 should have 1 issue, got %d", counts["eng-02"])
+	}
+	if counts["eng-03"] != 0 {
+		t.Errorf("eng-03 should have 0 issues, got %d", counts["eng-03"])
+	}
+}
+
+func TestRenderAgents_HeaderColumns(t *testing.T) {
+	m := newTestModel()
+	m.tab = TabAgents
+	m.agents = []*agent.Agent{
+		{Name: "eng-01", Role: agent.RoleEngineer, State: agent.StateIdle},
+	}
+	m.agentStats = map[string]stats.AgentStat{}
+
+	output := m.renderAgents()
+
+	// Verify all expected column headers
+	expectedHeaders := []string{"NAME", "ROLE", "STATE", "MEM", "ISSUES", "UPTIME", "TASK"}
+	for _, h := range expectedHeaders {
+		if !strings.Contains(output, h) {
+			t.Errorf("expected '%s' column header, got: %s", h, output)
+		}
+	}
+}
+
 // --- Queue Progress tests ---
 
 func TestRenderDashboard_QueueProgress(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds MEM column showing memory status (✓ if loaded, - otherwise)
- Adds ISSUES column showing count of issues assigned to each agent
- Adds `countIssuesByAgent()` helper method for counting issues per agent

The enhanced agents view provides at-a-glance visibility into:
- Which agents have loaded their role-specific prompts
- How many issues each agent is currently assigned

## Test plan

- [x] Added `TestRenderAgents_ShowsMemoryStatus` - verifies memory indicator
- [x] Added `TestRenderAgents_ShowsIssuesCount` - verifies issues column
- [x] Added `TestCountIssuesByAgent` - verifies counting logic
- [x] Added `TestRenderAgents_HeaderColumns` - verifies all column headers
- [x] All tests pass: `go test ./internal/tui/...`
- [x] Lint passes: `golangci-lint run ./internal/tui/...`

Fixes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)