### PR TITLE
test(cmd): add stats and status command unit tests

### DIFF
--- a/internal/cmd/stats_test.go
+++ b/internal/cmd/stats_test.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"testing"
+)
+
+// resetStatsFlags resets stats command flags between tests.
+func resetStatsFlags() {
+	statsJSON = false
+	statsSave = false
+}
+
+// --- Stats Command Unit Tests ---
+
+func TestStats_Basic(t *testing.T) {
+	setupTestWorkspace(t)
+	resetStatsFlags()
+	defer resetStatsFlags()
+
+	// Stats should work in a workspace (even with no data)
+	_, err := executeCmd("stats")
+	if err != nil {
+		t.Fatalf("stats error: %v", err)
+	}
+}
+
+func TestStats_JSON(t *testing.T) {
+	setupTestWorkspace(t)
+	resetStatsFlags()
+	defer resetStatsFlags()
+
+	// Stats --json should work
+	_, err := executeCmd("stats", "--json")
+	if err != nil {
+		t.Fatalf("stats --json error: %v", err)
+	}
+}
+
+func TestStats_Save(t *testing.T) {
+	setupTestWorkspace(t)
+	resetStatsFlags()
+	defer resetStatsFlags()
+
+	// Stats --save should work
+	_, err := executeCmd("stats", "--save")
+	if err != nil {
+		t.Fatalf("stats --save error: %v", err)
+	}
+}
+
+func TestStats_JSONAndSave(t *testing.T) {
+	setupTestWorkspace(t)
+	resetStatsFlags()
+	defer resetStatsFlags()
+
+	// Both flags together should work
+	_, err := executeCmd("stats", "--json", "--save")
+	if err != nil {
+		t.Fatalf("stats --json --save error: %v", err)
+	}
+}
+
+// --- Stats Command Flags Tests ---
+
+func TestStatsCommandFlags(t *testing.T) {
+	flags := statsCmd.Flags()
+
+	if flags.Lookup("json") == nil {
+		t.Error("expected --json flag on stats")
+	}
+	if flags.Lookup("save") == nil {
+		t.Error("expected --save flag on stats")
+	}
+}

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"testing"
+)
+
+// --- Status Command Unit Tests ---
+
+func TestStatus_Basic(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Status should work in a workspace (even with no agents)
+	_, err := executeCmd("status")
+	if err != nil {
+		t.Fatalf("status error: %v", err)
+	}
+}
+
+func TestStatus_JSON(t *testing.T) {
+	setupTestWorkspace(t)
+
+	// Status --json should work
+	_, err := executeCmd("status", "--json")
+	if err != nil {
+		t.Fatalf("status --json error: %v", err)
+	}
+}
+
+func TestStatus_CommandFlags(t *testing.T) {
+	flags := statusCmd.Flags()
+
+	if flags.Lookup("json") == nil {
+		t.Error("expected --json flag on status")
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit tests for stats command (basic, JSON, save flags)
- Add unit tests for status command (basic, JSON output)
- Coverage maintained at 64.1%

## Tests Added
- `TestStats_Basic` - basic stats output
- `TestStats_JSON` - JSON format output
- `TestStats_Save` - save to disk
- `TestStats_JSONAndSave` - both flags together
- `TestStatsCommandFlags` - verify flags
- `TestStatus_Basic` - basic status output
- `TestStatus_JSON` - JSON format output
- `TestStatus_CommandFlags` - verify flags

## Test plan
- [x] All tests pass
- [x] golangci-lint passes

Part of #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)