### PR TITLE
test: add findTechLeads unit test for PR command

### DIFF
--- a/internal/cmd/pr_test.go
+++ b/internal/cmd/pr_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/github"
 )
 
@@ -49,6 +50,76 @@ func TestFormatReviewRequest(t *testing.T) {
 			for _, part := range tt.wantParts {
 				if !strings.Contains(got, part) {
 					t.Errorf("formatReviewRequest() = %q, missing %q", got, part)
+				}
+			}
+		})
+	}
+}
+
+func TestFindTechLeads(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    []string
+		members []string
+	}{
+		{
+			name:    "no members",
+			members: nil,
+			want:    nil,
+		},
+		{
+			name:    "no tech-leads",
+			members: []string{"engineer-01", "qa-01"},
+			want:    nil,
+		},
+		{
+			name:    "single tech-lead",
+			members: []string{"engineer-01", "tech-lead-01", "qa-01"},
+			want:    []string{"tech-lead-01"},
+		},
+		{
+			name:    "multiple tech-leads",
+			members: []string{"tech-lead-01", "engineer-01", "tech-lead-02"},
+			want:    []string{"tech-lead-01", "tech-lead-02"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			store := channel.NewSQLiteStore(tmpDir)
+			if err := store.Open(); err != nil {
+				t.Fatalf("failed to open store: %v", err)
+			}
+			defer func() { _ = store.Close() }()
+
+			// Check if engineering channel exists (may be created by default)
+			ch, _ := store.GetChannel("engineering")
+			if ch == nil {
+				// Create engineering channel if it doesn't exist
+				_, err := store.CreateChannel("engineering", channel.ChannelTypeGroup, "Engineering team")
+				if err != nil {
+					t.Fatalf("failed to create channel: %v", err)
+				}
+			}
+
+			// Add members to channel
+			for _, member := range tt.members {
+				if addErr := store.AddMember("engineering", member); addErr != nil {
+					t.Fatalf("failed to add member: %v", addErr)
+				}
+			}
+
+			got := findTechLeads(store)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("findTechLeads() = %v, want %v", got, tt.want)
+				return
+			}
+
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("findTechLeads()[%d] = %q, want %q", i, got[i], tt.want[i])
 				}
 			}
 		})


### PR DESCRIPTION
## Summary
- Add table-driven unit test for `findTechLeads` helper function in pr.go
- Tests cover various edge cases (no members, no tech-leads, single tech-lead, multiple tech-leads)
- Uses SQLiteStore for realistic channel testing
- Improves test coverage for PR command

**Note:** This PR is based on #188 (build fix) and should be merged after it.

## Test plan
- [x] Run `go test -v -run TestFindTechLeads ./internal/cmd/...`
- [x] Verify `golangci-lint run ./internal/cmd/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)