### PR TITLE
test(cmd): add tests for spawn, ui, and home commands

### DIFF
--- a/internal/cmd/channel_test.go
+++ b/internal/cmd/channel_test.go
@@ -340,6 +340,44 @@ func TestChannelDelete_RequiresArg(t *testing.T) {
 	}
 }
 
-// Note: TestChannelCommandStructure and TestChannelListFlags are in channel_e2e_test.go
+// --- Command Structure Tests ---
+
+func TestChannelCommandSubcommands(t *testing.T) {
+	subcommands := channelCmd.Commands()
+
+	expectedCmds := map[string]bool{
+		"list":    false,
+		"create":  false,
+		"delete":  false,
+		"add":     false,
+		"remove":  false,
+		"send":    false,
+		"join":    false,
+		"leave":   false,
+		"history": false,
+	}
+
+	for _, cmd := range subcommands {
+		if _, ok := expectedCmds[cmd.Name()]; ok {
+			expectedCmds[cmd.Name()] = true
+		}
+	}
+
+	for name, found := range expectedCmds {
+		if !found {
+			t.Errorf("expected subcommand %q not found", name)
+		}
+	}
+}
+
+func TestChannelHistoryNoFlags(t *testing.T) {
+	// Verify history command exists and has no special flags
+	flags := channelHistoryCmd.Flags()
+
+	// History command currently has no flags
+	if flags.Lookup("limit") != nil {
+		t.Log("--limit flag is available for history")
+	}
+}
 
 // seedAgents helper is defined in cmd_integration_test.go

--- a/internal/cmd/home_test.go
+++ b/internal/cmd/home_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestHomeCmd_Usage(t *testing.T) {
+	if homeCmd.Use != "home" {
+		t.Errorf("unexpected usage: %s", homeCmd.Use)
+	}
+	if homeCmd.Short == "" {
+		t.Error("home command should have short description")
+	}
+}
+
+func TestHomeCmd_LongDescription(t *testing.T) {
+	if homeCmd.Long == "" {
+		t.Error("home command should have long description")
+	}
+	// Should document navigation keys
+	long := homeCmd.Long
+	if !containsAll(long, []string{"j/k", "Enter", "Tab", "Esc", "q"}) {
+		t.Errorf("long description should document navigation keys, got: %s", long)
+	}
+}
+
+func containsAll(s string, substrs []string) bool {
+	for _, sub := range substrs {
+		found := false
+		for i := 0; i <= len(s)-len(sub); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cmd/spawn_test.go
+++ b/internal/cmd/spawn_test.go
@@ -120,3 +120,40 @@ func searchString(s, substr string) bool {
 	}
 	return false
 }
+
+// --- Spawn command tests ---
+
+func TestSpawnCmd_NoArgs(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("spawn")
+	if err == nil {
+		t.Error("spawn without args should fail")
+	}
+}
+
+func TestSpawnCmd_Flags(t *testing.T) {
+	// Verify expected flags exist
+	toolFlag := spawnCmd.Flags().Lookup("tool")
+	if toolFlag == nil {
+		t.Fatal("expected --tool flag")
+	}
+	if toolFlag.DefValue != "" {
+		t.Errorf("tool default should be empty, got: %s", toolFlag.DefValue)
+	}
+
+	roleFlag := spawnCmd.Flags().Lookup("role")
+	if roleFlag == nil {
+		t.Fatal("expected --role flag")
+	}
+	if roleFlag.DefValue != "worker" {
+		t.Errorf("role default should be 'worker', got: %s", roleFlag.DefValue)
+	}
+}
+
+func TestSpawnCmd_DeprecationMessage(t *testing.T) {
+	if spawnCmd.Deprecated == "" {
+		t.Error("spawn should have deprecation message")
+	}
+}

--- a/internal/cmd/ui_test.go
+++ b/internal/cmd/ui_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestUICmd_Flags(t *testing.T) {
+	demoFlag := uiCmd.Flags().Lookup("demo")
+	if demoFlag == nil {
+		t.Fatal("expected --demo flag")
+	}
+	if demoFlag.DefValue != "false" {
+		t.Errorf("demo default should be 'false', got: %s", demoFlag.DefValue)
+	}
+}
+
+func TestUICmd_Usage(t *testing.T) {
+	if uiCmd.Use != "ui" {
+		t.Errorf("unexpected usage: %s", uiCmd.Use)
+	}
+	if uiCmd.Short == "" {
+		t.Error("ui command should have short description")
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit tests for CLI commands that previously lacked test coverage
- spawn_test.go: Add command-level tests for flags and deprecation message
- ui_test.go: Add tests for command usage and flags
- home_test.go: Add tests for command usage and navigation documentation
- Fix duplicate test function name in channel_test.go

Part of #165

## Test plan
- [ ] Run `go test ./internal/cmd/...` - all tests pass
- [ ] Run `golangci-lint run ./internal/cmd/...` - no lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)