### PR TITLE
test: add process command integration tests with seeded data

### DIFF
--- a/internal/cmd/process_test.go
+++ b/internal/cmd/process_test.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/process"
 )
 
 // resetProcessFlags resets process command flags between tests
@@ -178,5 +182,215 @@ func TestStatusStr(t *testing.T) {
 				t.Errorf("statusStr(%v) = %q, want %q", tt.running, got, tt.want)
 			}
 		})
+	}
+}
+
+// seedProcesses creates process records in the workspace registry.
+// Note: Register() always sets Running=true, so stopped processes can't be seeded this way.
+func seedProcesses(t *testing.T, wsDir string, procs []*process.Process) {
+	t.Helper()
+
+	// Ensure processes directory exists
+	procDir := filepath.Join(wsDir, ".bc", "processes")
+	if err := os.MkdirAll(procDir, 0750); err != nil {
+		t.Fatalf("failed to create processes dir: %v", err)
+	}
+
+	reg := process.NewRegistry(wsDir)
+	for _, proc := range procs {
+		if err := reg.Register(proc); err != nil {
+			t.Fatalf("failed to register process %s: %v", proc.Name, err)
+		}
+	}
+}
+
+// seedProcess is a helper for single process seeding.
+func seedProcess(t *testing.T, wsDir string, proc *process.Process) {
+	seedProcesses(t, wsDir, []*process.Process{proc})
+}
+
+func TestProcessInfoWithData(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed a process record
+	proc := &process.Process{
+		Name:      "test-server",
+		Command:   "python -m http.server 8080",
+		PID:       12345,
+		Port:      8080,
+		Owner:     "engineer-01",
+		WorkDir:   "/tmp/test",
+		StartedAt: time.Now().Add(-1 * time.Hour),
+		Running:   true,
+	}
+	seedProcess(t, wsDir, proc)
+
+	stdout, _, err := executeIntegrationCmd("process", "info", "test-server")
+	if err != nil {
+		t.Fatalf("process info error: %v", err)
+	}
+
+	// Check expected output fields
+	if !strings.Contains(stdout, "test-server") {
+		t.Errorf("output should contain process name, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "python -m http.server") {
+		t.Errorf("output should contain command, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "12345") {
+		t.Errorf("output should contain PID, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "8080") {
+		t.Errorf("output should contain port, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "engineer-01") {
+		t.Errorf("output should contain owner, got: %s", stdout)
+	}
+}
+
+func TestProcessInfoWithoutOptionalFields(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed a minimal process record (no port, owner, workdir)
+	proc := &process.Process{
+		Name:      "minimal-proc",
+		Command:   "sleep 100",
+		PID:       99999,
+		StartedAt: time.Now(),
+	}
+	seedProcess(t, wsDir, proc)
+
+	stdout, _, err := executeIntegrationCmd("process", "info", "minimal-proc")
+	if err != nil {
+		t.Fatalf("process info error: %v", err)
+	}
+
+	if !strings.Contains(stdout, "minimal-proc") {
+		t.Errorf("output should contain process name, got: %s", stdout)
+	}
+	// Registry.Register() always sets Running=true
+	if !strings.Contains(stdout, "running") {
+		t.Errorf("output should show running status, got: %s", stdout)
+	}
+	// Optional fields should not appear
+	if strings.Contains(stdout, "Port:") {
+		t.Errorf("output should not contain Port when not set, got: %s", stdout)
+	}
+	if strings.Contains(stdout, "Owner:") {
+		t.Errorf("output should not contain Owner when not set, got: %s", stdout)
+	}
+}
+
+func TestProcessListWithData(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed multiple processes using single registry instance
+	procs := []*process.Process{
+		{
+			Name:      "web-server",
+			Command:   "node server.js",
+			PID:       1001,
+			Port:      3000,
+			StartedAt: time.Now(),
+		},
+		{
+			Name:      "worker",
+			Command:   "python worker.py",
+			PID:       1002,
+			StartedAt: time.Now().Add(-2 * time.Hour),
+		},
+	}
+
+	seedProcesses(t, wsDir, procs)
+
+	stdout, _, err := executeIntegrationCmd("process", "list")
+	if err != nil {
+		t.Fatalf("process list error: %v", err)
+	}
+
+	if !strings.Contains(stdout, "web-server") {
+		t.Errorf("output should contain web-server, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "worker") {
+		t.Errorf("output should contain worker, got: %s", stdout)
+	}
+}
+
+func TestProcessLogsEmpty(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Create process logs directory (logs are in .bc/processes/logs/)
+	logsDir := filepath.Join(wsDir, ".bc", "processes", "logs")
+	if err := os.MkdirAll(logsDir, 0750); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+
+	// Create empty log file
+	logPath := filepath.Join(logsDir, "empty-proc.log")
+	if err := os.WriteFile(logPath, []byte{}, 0600); err != nil {
+		t.Fatalf("failed to create log file: %v", err)
+	}
+
+	// Seed process
+	proc := &process.Process{
+		Name:      "empty-proc",
+		Command:   "echo hello",
+		PID:       5555,
+		StartedAt: time.Now(),
+		Running:   true,
+	}
+	seedProcess(t, wsDir, proc)
+
+	stdout, _, err := executeIntegrationCmd("process", "logs", "empty-proc")
+	if err != nil {
+		t.Fatalf("process logs error: %v", err)
+	}
+
+	if !strings.Contains(stdout, "No logs") {
+		t.Errorf("expected 'No logs' message for empty log, got: %s", stdout)
+	}
+}
+
+func TestProcessLogsWithContent(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Create process logs directory
+	logsDir := filepath.Join(wsDir, ".bc", "processes", "logs")
+	if err := os.MkdirAll(logsDir, 0750); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+
+	// Create log file with content
+	logPath := filepath.Join(logsDir, "logging-proc.log")
+	logContent := "Starting server...\nListening on port 8080\nConnection accepted\n"
+	if err := os.WriteFile(logPath, []byte(logContent), 0600); err != nil {
+		t.Fatalf("failed to create log file: %v", err)
+	}
+
+	// Seed process
+	proc := &process.Process{
+		Name:      "logging-proc",
+		Command:   "node app.js",
+		PID:       6666,
+		StartedAt: time.Now(),
+		Running:   true,
+	}
+	seedProcess(t, wsDir, proc)
+
+	stdout, _, err := executeIntegrationCmd("process", "logs", "logging-proc")
+	if err != nil {
+		t.Fatalf("process logs error: %v", err)
+	}
+
+	if !strings.Contains(stdout, "Starting server") {
+		t.Errorf("output should contain log content, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "port 8080") {
+		t.Errorf("output should contain log content, got: %s", stdout)
 	}
 }


### PR DESCRIPTION
## Summary
- Add comprehensive tests for process list, info, and logs commands
- Tests use seeded process data for realistic scenarios

## Coverage Improvements
| Function | Before | After |
|----------|--------|-------|
| runProcessList | 36.8% | 100.0% |
| runProcessLogs | 40.0% | 86.7% |
| runProcessInfo | 28.6% | 90.5% |
| **Overall cmd** | 65.9% | 67.2% |

## Test Cases Added
- Process list with multiple registered processes
- Process info with all optional fields (port, owner, workdir)
- Process info without optional fields
- Process logs with content
- Process logs empty file handling

## Test plan
- [x] All tests pass
- [x] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)