### PR TITLE
feat(tui): add theme support with light and high-contrast options

### DIFF
--- a/pkg/tui/style/theme.go
+++ b/pkg/tui/style/theme.go
@@ -28,8 +28,27 @@ type Theme struct {
 	StatusBarBg lipgloss.Color
 }
 
+// ThemeName identifies a theme by name.
+type ThemeName string
+
+const (
+	ThemeDark         ThemeName = "dark"
+	ThemeLight        ThemeName = "light"
+	ThemeHighContrast ThemeName = "high-contrast"
+)
+
+// AvailableThemes returns the list of available theme names.
+func AvailableThemes() []ThemeName {
+	return []ThemeName{ThemeDark, ThemeLight, ThemeHighContrast}
+}
+
 // DefaultTheme returns the default Ayu-inspired dark theme.
 func DefaultTheme() Theme {
+	return DarkTheme()
+}
+
+// DarkTheme returns the Ayu-inspired dark theme.
+func DarkTheme() Theme {
 	return Theme{
 		// Base
 		Background: lipgloss.Color("#0B0E14"),
@@ -53,6 +72,79 @@ func DefaultTheme() Theme {
 		HeaderBg:    lipgloss.Color("#1C2028"),
 		StatusBarBg: lipgloss.Color("#1C2028"),
 	}
+}
+
+// LightTheme returns a light theme suitable for bright environments.
+func LightTheme() Theme {
+	return Theme{
+		// Base
+		Background: lipgloss.Color("#FAFAFA"),
+		Foreground: lipgloss.Color("#5C6166"),
+		Border:     lipgloss.Color("#D4D5D6"),
+		Muted:      lipgloss.Color("#8A9199"),
+
+		// Accent
+		Primary:   lipgloss.Color("#FF9940"),
+		Secondary: lipgloss.Color("#399EE6"),
+		Accent:    lipgloss.Color("#FA8D3E"),
+
+		// Status
+		Success: lipgloss.Color("#6CBF43"),
+		Warning: lipgloss.Color("#F2AE49"),
+		Error:   lipgloss.Color("#E65050"),
+		Info:    lipgloss.Color("#399EE6"),
+
+		// UI
+		Selection:   lipgloss.Color("#035BD6"),
+		HeaderBg:    lipgloss.Color("#E8E9EB"),
+		StatusBarBg: lipgloss.Color("#E8E9EB"),
+	}
+}
+
+// HighContrastTheme returns a high contrast theme for accessibility.
+func HighContrastTheme() Theme {
+	return Theme{
+		// Base - pure black/white for maximum contrast
+		Background: lipgloss.Color("#000000"),
+		Foreground: lipgloss.Color("#FFFFFF"),
+		Border:     lipgloss.Color("#FFFFFF"),
+		Muted:      lipgloss.Color("#AAAAAA"),
+
+		// Accent - bright, distinct colors
+		Primary:   lipgloss.Color("#FFFF00"),
+		Secondary: lipgloss.Color("#00FFFF"),
+		Accent:    lipgloss.Color("#FF00FF"),
+
+		// Status - vivid colors for clear distinction
+		Success: lipgloss.Color("#00FF00"),
+		Warning: lipgloss.Color("#FFFF00"),
+		Error:   lipgloss.Color("#FF0000"),
+		Info:    lipgloss.Color("#00FFFF"),
+
+		// UI
+		Selection:   lipgloss.Color("#0000FF"),
+		HeaderBg:    lipgloss.Color("#333333"),
+		StatusBarBg: lipgloss.Color("#333333"),
+	}
+}
+
+// GetTheme returns a theme by name. Falls back to dark theme if not found.
+func GetTheme(name ThemeName) Theme {
+	switch name {
+	case ThemeLight:
+		return LightTheme()
+	case ThemeHighContrast:
+		return HighContrastTheme()
+	case ThemeDark:
+		fallthrough
+	default:
+		return DarkTheme()
+	}
+}
+
+// GetThemeByString returns a theme by string name. Falls back to dark theme.
+func GetThemeByString(name string) Theme {
+	return GetTheme(ThemeName(name))
 }
 
 // Styles contains pre-built lipgloss styles for common elements.

--- a/pkg/tui/style/theme_test.go
+++ b/pkg/tui/style/theme_test.go
@@ -1,0 +1,143 @@
+package style
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestDefaultTheme(t *testing.T) {
+	theme := DefaultTheme()
+	if theme.Background == "" {
+		t.Error("DefaultTheme should have background color")
+	}
+	if theme.Foreground == "" {
+		t.Error("DefaultTheme should have foreground color")
+	}
+}
+
+func TestDarkTheme(t *testing.T) {
+	theme := DarkTheme()
+	// Dark theme should have dark background
+	if theme.Background != lipgloss.Color("#0B0E14") {
+		t.Errorf("DarkTheme background = %v, want #0B0E14", theme.Background)
+	}
+}
+
+func TestLightTheme(t *testing.T) {
+	theme := LightTheme()
+	// Light theme should have light background
+	if theme.Background != lipgloss.Color("#FAFAFA") {
+		t.Errorf("LightTheme background = %v, want #FAFAFA", theme.Background)
+	}
+}
+
+func TestHighContrastTheme(t *testing.T) {
+	theme := HighContrastTheme()
+	// High contrast should use pure black/white
+	if theme.Background != lipgloss.Color("#000000") {
+		t.Errorf("HighContrastTheme background = %v, want #000000", theme.Background)
+	}
+	if theme.Foreground != lipgloss.Color("#FFFFFF") {
+		t.Errorf("HighContrastTheme foreground = %v, want #FFFFFF", theme.Foreground)
+	}
+}
+
+func TestGetTheme(t *testing.T) {
+	tests := []struct {
+		name   ThemeName
+		wantBg lipgloss.Color
+	}{
+		{ThemeDark, lipgloss.Color("#0B0E14")},
+		{ThemeLight, lipgloss.Color("#FAFAFA")},
+		{ThemeHighContrast, lipgloss.Color("#000000")},
+		{"unknown", lipgloss.Color("#0B0E14")}, // Falls back to dark
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.name), func(t *testing.T) {
+			theme := GetTheme(tt.name)
+			if theme.Background != tt.wantBg {
+				t.Errorf("GetTheme(%q) background = %v, want %v", tt.name, theme.Background, tt.wantBg)
+			}
+		})
+	}
+}
+
+func TestGetThemeByString(t *testing.T) {
+	theme := GetThemeByString("light")
+	if theme.Background != lipgloss.Color("#FAFAFA") {
+		t.Errorf("GetThemeByString(light) background = %v, want #FAFAFA", theme.Background)
+	}
+}
+
+func TestAvailableThemes(t *testing.T) {
+	themes := AvailableThemes()
+	if len(themes) != 3 {
+		t.Errorf("AvailableThemes() returned %d themes, want 3", len(themes))
+	}
+
+	expected := map[ThemeName]bool{
+		ThemeDark:         false,
+		ThemeLight:        false,
+		ThemeHighContrast: false,
+	}
+	for _, theme := range themes {
+		if _, ok := expected[theme]; ok {
+			expected[theme] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("AvailableThemes() missing %q", name)
+		}
+	}
+}
+
+func TestNewStyles(t *testing.T) {
+	theme := DarkTheme()
+	styles := NewStyles(theme)
+
+	// Verify styles render without error
+	rendered := styles.Normal.Render("test")
+	if rendered == "" {
+		t.Error("Normal style should render text")
+	}
+	if styles.Theme().Background != theme.Background {
+		t.Error("Styles.Theme() should return the theme used to create it")
+	}
+}
+
+func TestDefaultStyles(t *testing.T) {
+	styles := DefaultStyles()
+	if styles.Theme().Background != DefaultTheme().Background {
+		t.Error("DefaultStyles should use DefaultTheme")
+	}
+}
+
+func TestStatusStyle(t *testing.T) {
+	styles := DefaultStyles()
+
+	tests := []struct {
+		status    string
+		wantStyle string
+	}{
+		{"success", "success"},
+		{"running", "success"},
+		{"warning", "warning"},
+		{"pending", "warning"},
+		{"error", "error"},
+		{"failed", "error"},
+		{"info", "info"},
+		{"idle", "info"},
+		{"unknown", "normal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			style := styles.StatusStyle(tt.status)
+			// Just verify we get a valid style back (non-panic)
+			_ = style.Render("test")
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add multiple TUI theme options: dark (default), light, high-contrast
- Light theme for bright environments with appropriate color contrast
- High-contrast theme for accessibility (pure black/white with vivid status colors)
- Add GetTheme(name) and AvailableThemes() for theme selection
- Comprehensive test coverage for all themes

Closes #160

## Test plan
- [ ] Run `go test ./pkg/tui/style/...` - all theme tests pass
- [ ] Themes can be selected via GetTheme() or GetThemeByString()
- [ ] All three themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)