### PR TITLE
test(cmd): add agent create unknown tool test

### DIFF
--- a/internal/cmd/agent_integration_test.go
+++ b/internal/cmd/agent_integration_test.go
@@ -223,6 +223,19 @@ func TestAgentCreateInvalidTeam(t *testing.T) {
 	}
 }
 
+func TestAgentCreateUnknownTool(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("agent", "create", "test-agent", "--role", "engineer", "--tool", "nonexistent-tool")
+	if err == nil {
+		t.Error("expected error for unknown tool")
+	}
+	if err != nil && !strings.Contains(err.Error(), "unknown tool") {
+		t.Errorf("error should mention unknown tool: %v", err)
+	}
+}
+
 func TestAgentNoWorkspace(t *testing.T) {
 	origDir, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add test for agent create with unknown tool flag

## Tests Added
- `TestAgentCreateUnknownTool` - verifies "unknown tool" error

## Coverage
- cmd package: 67.8% -> 67.9%

## Test plan
- [x] All tests pass
- [x] golangci-lint passes

Part of #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)