### PR TITLE
fix(channel): sort channels by name for stable list ordering

### DIFF
--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -81,6 +81,17 @@ func (s *Store) Save() error {
 		channels = append(channels, ch)
 	}
 
+	// Sort by name for stable file output
+	slices.SortFunc(channels, func(a, b *Channel) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
+
 	data, err := json.MarshalIndent(channels, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal channels: %w", err)
@@ -125,7 +136,7 @@ func (s *Store) Get(name string) (*Channel, bool) {
 	return ch, exists
 }
 
-// List returns all channels.
+// List returns all channels sorted by name for stable ordering.
 func (s *Store) List() []*Channel {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -134,6 +145,18 @@ func (s *Store) List() []*Channel {
 	for _, ch := range s.channels {
 		channels = append(channels, ch)
 	}
+
+	// Sort by name for stable ordering in UI
+	slices.SortFunc(channels, func(a, b *Channel) int {
+		if a.Name < b.Name {
+			return -1
+		}
+		if a.Name > b.Name {
+			return 1
+		}
+		return 0
+	})
+
 	return channels
 }
 

--- a/pkg/channel/channel_test.go
+++ b/pkg/channel/channel_test.go
@@ -580,3 +580,40 @@ func TestConcurrentAddHistory(t *testing.T) {
 		t.Errorf("history after concurrent adds = %d, want 50", len(history))
 	}
 }
+
+// --- List Stable Ordering ---
+
+func TestListStableOrdering(t *testing.T) {
+	s := newTestStore(t)
+
+	// Create channels in random order
+	names := []string{"zebra", "alpha", "middle", "beta"}
+	for _, name := range names {
+		if _, err := s.Create(name); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// List should return channels sorted alphabetically
+	channels := s.List()
+	if len(channels) != 4 {
+		t.Fatalf("List() returned %d channels, want 4", len(channels))
+	}
+
+	expected := []string{"alpha", "beta", "middle", "zebra"}
+	for i, ch := range channels {
+		if ch.Name != expected[i] {
+			t.Errorf("List()[%d].Name = %q, want %q", i, ch.Name, expected[i])
+		}
+	}
+
+	// Call List multiple times - order should be stable
+	for iter := 0; iter < 10; iter++ {
+		channels := s.List()
+		for i, ch := range channels {
+			if ch.Name != expected[i] {
+				t.Errorf("iter %d: List()[%d].Name = %q, want %q", iter, i, ch.Name, expected[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #201 - Channel list items jump around on refresh

The channel `List()` function iterates over a map which has no guaranteed order in Go. This caused channels to jump around in the TUI when the list was refreshed.

## Changes
- Sort channels by name in `List()` for stable UI ordering
- Sort channels by name in `Save()` for consistent file output
- Add `TestListStableOrdering` to verify ordering behavior

## Root Cause
Go maps do not guarantee iteration order. Each call to `List()` could return channels in a different order, causing the cursor to point at a different channel than intended.

## Test plan
- [x] All tests pass
- [x] New test verifies stable ordering across multiple calls
- [x] golangci-lint passes

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)