### PR TITLE
feat(channel): add visual distinction for message types

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -280,6 +280,10 @@ func (m *ChannelModel) View() string {
 				b.WriteString("\n")
 			}
 
+			// Infer message type for styling
+			msgType := channel.InferMessageType(entry.Message)
+			msgTypeStr := string(msgType)
+
 			// Sender and timestamp line
 			sender := entry.Sender
 			if sender == "" {
@@ -287,16 +291,24 @@ func (m *ChannelModel) View() string {
 			}
 			ts := entry.Time.Format("15:04:05")
 			b.WriteString("  ")
+
+			// Add message type icon if not a regular text message
+			icon := m.styles.MessageTypeIcon(msgTypeStr)
+			if icon != "" {
+				b.WriteString(icon)
+			}
+
 			b.WriteString(m.styles.Info.Render(sender))
 			b.WriteString("  ")
 			b.WriteString(m.styles.Muted.Render(ts))
 			b.WriteString("\n")
 
-			// Message content — wrap long lines
+			// Message content — wrap long lines with type-specific styling
+			msgStyle := m.styles.MessageTypeStyle(msgTypeStr)
 			lines := wrapText(entry.Message, msgWidth)
 			for _, line := range lines {
 				b.WriteString("  ")
-				b.WriteString(m.styles.Normal.Render("  " + line))
+				b.WriteString(msgStyle.Render("  " + line))
 				b.WriteString("\n")
 			}
 		}
@@ -327,22 +339,29 @@ func (m *ChannelModel) View() string {
 		}
 		for i, entry := range m.channel.History[start:] {
 			selected := i == m.cursor
+
+			// Infer message type for styling
+			msgType := channel.InferMessageType(entry.Message)
+			msgTypeStr := string(msgType)
+			icon := m.styles.MessageTypeIcon(msgTypeStr)
+
 			var line string
 			if entry.Sender != "" {
-				line = fmt.Sprintf("  %s  [%s] %s", entry.Time.Format("15:04:05"), entry.Sender, entry.Message)
+				line = fmt.Sprintf("  %s%s  [%s] %s", icon, entry.Time.Format("15:04:05"), entry.Sender, entry.Message)
 			} else {
-				line = fmt.Sprintf("  %s  %s", entry.Time.Format("15:04:05"), entry.Message)
+				line = fmt.Sprintf("  %s%s  %s", icon, entry.Time.Format("15:04:05"), entry.Message)
 			}
 			if selected {
 				b.WriteString(m.styles.Selected.Render(line))
 			} else {
 				ts := m.styles.Muted.Render(entry.Time.Format("15:04:05"))
-				msg := m.styles.Normal.Render(entry.Message)
+				msgStyle := m.styles.MessageTypeStyle(msgTypeStr)
+				msg := msgStyle.Render(entry.Message)
 				if entry.Sender != "" {
 					sender := m.styles.Info.Render("[" + entry.Sender + "]")
-					line = fmt.Sprintf("  %s  %s %s", ts, sender, msg)
+					line = fmt.Sprintf("  %s%s  %s %s", icon, ts, sender, msg)
 				} else {
-					line = fmt.Sprintf("  %s  %s", ts, msg)
+					line = fmt.Sprintf("  %s%s  %s", icon, ts, msg)
 				}
 				b.WriteString(line)
 			}

--- a/pkg/tui/style/theme.go
+++ b/pkg/tui/style/theme.go
@@ -253,3 +253,40 @@ func (s Styles) StatusStyle(status string) lipgloss.Style {
 		return s.Normal
 	}
 }
+
+// MessageTypeStyle returns the appropriate style for a channel message type.
+// Message types: text, task, review, approval, merge, status
+func (s Styles) MessageTypeStyle(msgType string) lipgloss.Style {
+	switch msgType {
+	case "task":
+		return s.Warning // Orange/yellow for tasks that need attention
+	case "review":
+		return s.Info // Blue for review requests
+	case "approval":
+		return s.Success // Green for approvals
+	case "merge":
+		return lipgloss.NewStyle().Foreground(s.theme.Accent) // Accent color for merge
+	case "status":
+		return s.Muted // Muted for status updates
+	default:
+		return s.Normal // Default for regular text messages
+	}
+}
+
+// MessageTypeIcon returns an icon/emoji prefix for a channel message type.
+func (s Styles) MessageTypeIcon(msgType string) string {
+	switch msgType {
+	case "task":
+		return "📋 "
+	case "review":
+		return "👀 "
+	case "approval":
+		return "✅ "
+	case "merge":
+		return "🔀 "
+	case "status":
+		return "📊 "
+	default:
+		return ""
+	}
+}

--- a/pkg/tui/style/theme_test.go
+++ b/pkg/tui/style/theme_test.go
@@ -141,3 +141,56 @@ func TestStatusStyle(t *testing.T) {
 		})
 	}
 }
+
+func TestMessageTypeStyle(t *testing.T) {
+	styles := DefaultStyles()
+
+	tests := []struct {
+		msgType string
+	}{
+		{"text"},
+		{"task"},
+		{"review"},
+		{"approval"},
+		{"merge"},
+		{"status"},
+		{"unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msgType, func(t *testing.T) {
+			style := styles.MessageTypeStyle(tt.msgType)
+			// Verify we get a valid style back (non-panic)
+			rendered := style.Render("test message")
+			if rendered == "" {
+				t.Errorf("MessageTypeStyle(%q) should render text", tt.msgType)
+			}
+		})
+	}
+}
+
+func TestMessageTypeIcon(t *testing.T) {
+	styles := DefaultStyles()
+
+	tests := []struct {
+		msgType  string
+		wantIcon string
+	}{
+		{"task", "📋 "},
+		{"review", "👀 "},
+		{"approval", "✅ "},
+		{"merge", "🔀 "},
+		{"status", "📊 "},
+		{"text", ""},
+		{"unknown", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.msgType, func(t *testing.T) {
+			icon := styles.MessageTypeIcon(tt.msgType)
+			if icon != tt.wantIcon {
+				t.Errorf("MessageTypeIcon(%q) = %q, want %q", tt.msgType, icon, tt.wantIcon)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add color-coded styling and icons for different message types in channel chatroom UI
- Task messages (📋), review requests (👀), approvals (✅), merge notifications (🔀), and status updates (📊) now have distinct visual styling
- Uses automatic type inference from message content via `InferMessageType()`

## Test plan
- [x] All existing tests pass
- [x] New tests added for `MessageTypeStyle()` and `MessageTypeIcon()` functions
- [ ] Manual testing: view channel with mixed message types to verify styling

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)