### PR TITLE
feat(tui): add message bubble layout with grouping (#204)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -275,28 +275,46 @@ func (m *ChannelModel) View() string {
 			msgWidth = 30
 		}
 
-		for i, entry := range m.channel.History[start:end] {
-			if i > 0 {
-				b.WriteString("\n")
-			}
-
-			// Sender and timestamp line
+		// Group consecutive messages from the same sender
+		messages := m.channel.History[start:end]
+		for i, entry := range messages {
 			sender := entry.Sender
 			if sender == "" {
 				sender = "system"
 			}
-			ts := entry.Time.Format("15:04:05")
-			b.WriteString("  ")
-			b.WriteString(m.styles.Info.Render(sender))
-			b.WriteString("  ")
-			b.WriteString(m.styles.Muted.Render(ts))
-			b.WriteString("\n")
 
-			// Message content — wrap long lines
-			lines := wrapText(entry.Message, msgWidth)
-			for _, line := range lines {
+			// Check if this is a continuation from the same sender
+			isGrouped := i > 0 && messages[i-1].Sender == entry.Sender
+
+			if !isGrouped {
+				// Add spacing between different senders
+				if i > 0 {
+					b.WriteString("\n")
+				}
+				// Sender and timestamp header
+				ts := entry.Time.Format("15:04:05")
 				b.WriteString("  ")
-				b.WriteString(m.styles.Normal.Render("  " + line))
+				b.WriteString(m.styles.Info.Render(sender))
+				b.WriteString("  ")
+				b.WriteString(m.styles.Muted.Render(ts))
+				b.WriteString("\n")
+			}
+
+			// Message content in bubble — wrap long lines
+			lines := wrapText(entry.Message, msgWidth-4)
+			var content strings.Builder
+			for j, line := range lines {
+				if j > 0 {
+					content.WriteString("\n")
+				}
+				content.WriteString(line)
+			}
+
+			// Render message bubble
+			bubble := m.styles.MessageBubble.Width(msgWidth).Render(content.String())
+			for _, line := range strings.Split(bubble, "\n") {
+				b.WriteString("  ")
+				b.WriteString(line)
 				b.WriteString("\n")
 			}
 		}

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -360,3 +360,55 @@ func TestVisibleMsgCount(t *testing.T) {
 		t.Errorf("visibleMsgCount should be positive, got %d", count)
 	}
 }
+
+// --- Message grouping tests ---
+
+func TestChannelView_MessageGrouping(t *testing.T) {
+	m := newTestChannelModel()
+	now := time.Now()
+	// Consecutive messages from same sender
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "eng-01", Message: "first message", Time: now.Add(-5 * time.Minute)},
+		{Sender: "eng-01", Message: "second message", Time: now.Add(-4 * time.Minute)},
+		{Sender: "eng-02", Message: "different sender", Time: now.Add(-3 * time.Minute)},
+		{Sender: "eng-02", Message: "another from eng-02", Time: now.Add(-2 * time.Minute)},
+	}
+
+	output := m.View()
+
+	// Should contain all messages
+	if !strings.Contains(output, "first message") {
+		t.Errorf("expected 'first message', got: %s", output)
+	}
+	if !strings.Contains(output, "second message") {
+		t.Errorf("expected 'second message', got: %s", output)
+	}
+	if !strings.Contains(output, "different sender") {
+		t.Errorf("expected 'different sender', got: %s", output)
+	}
+
+	// Sender names should appear (for first message in each group)
+	if !strings.Contains(output, "eng-01") {
+		t.Errorf("expected 'eng-01', got: %s", output)
+	}
+	if !strings.Contains(output, "eng-02") {
+		t.Errorf("expected 'eng-02', got: %s", output)
+	}
+}
+
+func TestChannelView_MessageBubbleRendering(t *testing.T) {
+	m := newTestChannelModel()
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "eng-01", Message: "test bubble", Time: time.Now()},
+	}
+
+	output := m.View()
+
+	// Bubble should have rounded border characters
+	if !strings.Contains(output, "╭") || !strings.Contains(output, "╮") {
+		t.Errorf("expected rounded border characters in bubble, got: %s", output)
+	}
+	if !strings.Contains(output, "test bubble") {
+		t.Errorf("expected message content in bubble, got: %s", output)
+	}
+}

--- a/pkg/tui/style/theme.go
+++ b/pkg/tui/style/theme.go
@@ -168,6 +168,9 @@ type Styles struct {
 	Selected  lipgloss.Style
 	Title     lipgloss.Style
 
+	// Message bubble styles
+	MessageBubble lipgloss.Style
+
 	theme Theme
 }
 
@@ -224,6 +227,12 @@ func NewStyles(theme Theme) Styles {
 		Title: lipgloss.NewStyle().
 			Foreground(theme.Primary).
 			Bold(true).
+			MarginBottom(1),
+
+		MessageBubble: lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(theme.Border).
+			Padding(0, 1).
 			MarginBottom(1),
 	}
 }

--- a/pkg/tui/style/theme_test.go
+++ b/pkg/tui/style/theme_test.go
@@ -141,3 +141,29 @@ func TestStatusStyle(t *testing.T) {
 		})
 	}
 }
+
+func TestMessageBubbleStyle(t *testing.T) {
+	styles := DefaultStyles()
+
+	// Verify MessageBubble style renders with rounded borders
+	rendered := styles.MessageBubble.Render("test message")
+	if rendered == "" {
+		t.Error("MessageBubble style should render text")
+	}
+	// Check for rounded border characters
+	if !containsRoundedBorder(rendered) {
+		t.Error("MessageBubble should have rounded border")
+	}
+}
+
+func containsRoundedBorder(s string) bool {
+	// Check for any of the rounded border characters
+	for _, c := range []rune{'╭', '╮', '╰', '╯'} {
+		for _, r := range s {
+			if r == c {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add rounded corner message bubbles using lipgloss RoundedBorder style
- Group consecutive messages from the same sender (header only shown once per group)
- Add proper spacing between message groups for better visual separation
- Add MessageBubble style to the theme system for consistent styling

## Implementation Details
- Modified `internal/tui/channel.go` to render messages in bubbles with sender grouping
- Added `MessageBubble` style to `pkg/tui/style/theme.go` with rounded borders and padding
- Added tests for bubble rendering and message grouping functionality

## Test plan
- [x] All existing tests pass
- [x] New tests for message grouping behavior
- [x] New test for MessageBubble style rendering
- [ ] Manual testing in TUI for visual verification

Part of Epic #203 - Channel Chatroom UI Redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)