### PR TITLE
fix(build): inject version info via ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-.PHONY: dev build build-release build-all clean gen test coverage bench fmt vet lint check deps help
+.PHONY: dev build build-release build-all clean gen test coverage bench fmt vet lint check deps help version
+
+# Version information
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# ldflags for version injection
+LDFLAGS_VERSION = -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
 help:
 	@echo "Available targets:"
 	@echo "  dev           - Run in development mode"
-	@echo "  build         - Build the binary"
-	@echo "  build-release - Build optimized release binary"
+	@echo "  build         - Build the binary with version info"
+	@echo "  build-release - Build optimized release binary with version info"
 	@echo "  build-all     - Cross-compile for all platforms to dist/"
 	@echo "  clean         - Remove build artifacts"
 	@echo "  gen           - Generate config code from config.toml"
@@ -16,23 +24,34 @@ help:
 	@echo "  lint          - Run golangci-lint"
 	@echo "  check         - Run all checks (gen + fmt + vet + lint + test)"
 	@echo "  deps          - Download and tidy dependencies"
+	@echo "  version       - Show version info that will be embedded"
+	@echo ""
+	@echo "Version variables (can be overridden):"
+	@echo "  VERSION=$(VERSION)"
+	@echo "  COMMIT=$(COMMIT)"
+	@echo "  DATE=$(DATE)"
+
+version:
+	@echo "Version: $(VERSION)"
+	@echo "Commit:  $(COMMIT)"
+	@echo "Date:    $(DATE)"
 
 dev:
 	go run ./cmd/bc
 
 build: gen
-	go build -o bin/bc ./cmd/bc
+	go build -ldflags="$(LDFLAGS_VERSION)" -o bin/bc ./cmd/bc
 
 build-release: gen
-	go build -ldflags="-s -w" -o bin/bc ./cmd/bc
+	go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o bin/bc ./cmd/bc
 
 build-all: gen
 	@mkdir -p dist
-	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/bc-darwin-amd64 ./cmd/bc
-	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/bc-darwin-arm64 ./cmd/bc
-	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/bc-linux-amd64 ./cmd/bc
-	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o dist/bc-linux-arm64 ./cmd/bc
-	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o dist/bc-windows-amd64.exe ./cmd/bc
+	GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o dist/bc-darwin-amd64 ./cmd/bc
+	GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o dist/bc-darwin-arm64 ./cmd/bc
+	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o dist/bc-linux-amd64 ./cmd/bc
+	GOOS=linux GOARCH=arm64 go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o dist/bc-linux-arm64 ./cmd/bc
+	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o dist/bc-windows-amd64.exe ./cmd/bc
 
 clean:
 	rm -rf bin/ dist/


### PR DESCRIPTION
## Summary
- Fixed `bc version` showing "dev", "none", "unknown" instead of actual build info
- Added VERSION, COMMIT, DATE variables extracted from git at build time
- Applied ldflags injection to all build targets (build, build-release, build-all)
- Added `make version` helper target

## Before
```
bc dev
  commit: none
  built:  unknown
```

## After
```
bc f431350
  commit: f431350
  built:  2026-02-08T08:20:08Z
```

When git tags exist (e.g., `v1.0.0`), version will show the tag.

## Test plan
- [x] `make build && ./bin/bc version` shows proper version info
- [x] All tests pass (`make test`)
- [x] Pre-commit hooks pass

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)