### PR TITLE
feat(channel): redesign channel header with description and member info

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -226,22 +226,59 @@ func (m *ChannelModel) visibleMsgCount() int {
 func (m *ChannelModel) View() string {
 	var b strings.Builder
 
-	// Channel header
-	b.WriteString(m.styles.Title.Render("#" + m.channel.Name))
-
-	// Inline members
-	if len(m.channel.Members) > 0 {
-		memberList := strings.Join(m.channel.Members, ", ")
-		b.WriteString("  ")
-		b.WriteString(m.styles.Muted.Render(fmt.Sprintf("(%d members: %s)", len(m.channel.Members), memberList)))
-	}
-	b.WriteString("\n")
-
-	// Divider
+	// Calculate widths
 	divWidth := m.width - 2
 	if divWidth < 20 {
 		divWidth = 20
 	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// CHANNEL HEADER
+	// ═══════════════════════════════════════════════════════════════════════
+
+	// Channel name prominently displayed
+	b.WriteString(m.styles.Title.Render("  # " + m.channel.Name))
+	b.WriteString("\n")
+
+	// Description/topic (if set)
+	if m.channel.Description != "" {
+		b.WriteString(m.styles.Muted.Render("  " + m.channel.Description))
+		b.WriteString("\n")
+	}
+
+	// Member count with online/active indicators
+	totalMembers := len(m.channel.Members)
+	activeCount := 0
+	if m.manager != nil {
+		for _, member := range m.channel.Members {
+			if a := m.manager.GetAgent(member); a != nil && a.State != agent.StateStopped {
+				activeCount++
+			}
+		}
+	}
+
+	// Member stats line
+	b.WriteString("  ")
+	if activeCount > 0 {
+		b.WriteString(m.styles.Success.Render(fmt.Sprintf("● %d online", activeCount)))
+		b.WriteString(m.styles.Muted.Render(fmt.Sprintf(" / %d members", totalMembers)))
+	} else {
+		b.WriteString(m.styles.Muted.Render(fmt.Sprintf("○ %d members", totalMembers)))
+	}
+
+	// Quick actions hint
+	b.WriteString(m.styles.Muted.Render("  │  "))
+	b.WriteString(m.styles.Info.Render("[s]"))
+	b.WriteString(m.styles.Muted.Render("end  "))
+	b.WriteString(m.styles.Info.Render("[r]"))
+	b.WriteString(m.styles.Muted.Render("efresh  "))
+	b.WriteString(m.styles.Info.Render("[i]"))
+	b.WriteString(m.styles.Muted.Render("ssue  "))
+	b.WriteString(m.styles.Info.Render("[esc]"))
+	b.WriteString(m.styles.Muted.Render("back"))
+	b.WriteString("\n")
+
+	// Header divider
 	b.WriteString(m.styles.Muted.Render("  " + strings.Repeat("─", divWidth)))
 	b.WriteString("\n")
 
@@ -355,13 +392,12 @@ func (m *ChannelModel) View() string {
 		prompt := m.styles.Info.Render("  > ")
 		b.WriteString(prompt)
 		b.WriteString(m.styles.Normal.Render(m.input))
-		b.WriteString(m.styles.Muted.Render("_"))
+		b.WriteString(m.styles.Muted.Render("█"))
+		b.WriteString("  ")
+		b.WriteString(m.styles.Muted.Render("Enter to send • Esc to cancel"))
 		b.WriteString("\n")
 	} else if m.sendMsg != "" {
-		b.WriteString(m.styles.Success.Render("  " + m.sendMsg))
-		b.WriteString("\n")
-	} else {
-		b.WriteString(m.styles.Muted.Render("  [s]end  [j/k]scroll  [r]efresh  [esc]back"))
+		b.WriteString(m.styles.Success.Render("  ✓ " + m.sendMsg))
 		b.WriteString("\n")
 	}
 

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -290,7 +290,7 @@ func TestChannelView_NoMessages(t *testing.T) {
 	m.channel.History = nil
 
 	output := m.View()
-	if !strings.Contains(output, "#standup") {
+	if !strings.Contains(output, "# standup") {
 		t.Errorf("expected channel name, got: %s", output)
 	}
 	if !strings.Contains(output, "No messages") {
@@ -302,7 +302,7 @@ func TestChannelView_WithMessages(t *testing.T) {
 	m := newTestChannelModel()
 
 	output := m.View()
-	if !strings.Contains(output, "#standup") {
+	if !strings.Contains(output, "# standup") {
 		t.Errorf("expected channel name, got: %s", output)
 	}
 	if !strings.Contains(output, "eng-01") {
@@ -346,6 +346,42 @@ func TestChannelView_NoSender(t *testing.T) {
 	output := m.View()
 	if !strings.Contains(output, "system") {
 		t.Errorf("expected 'system' for empty sender, got: %s", output)
+	}
+}
+
+func TestChannelView_WithDescription(t *testing.T) {
+	m := newTestChannelModel()
+	m.channel.Description = "Team standup updates"
+
+	output := m.View()
+	if !strings.Contains(output, "Team standup updates") {
+		t.Errorf("expected description in header, got: %s", output)
+	}
+}
+
+func TestChannelView_OnlineIndicator(t *testing.T) {
+	m := newTestChannelModel()
+
+	output := m.View()
+	// Should show member count with online indicator
+	if !strings.Contains(output, "members") {
+		t.Errorf("expected member count in header, got: %s", output)
+	}
+}
+
+func TestChannelView_QuickActions(t *testing.T) {
+	m := newTestChannelModel()
+
+	output := m.View()
+	// Should show quick action hints in header
+	if !strings.Contains(output, "[s]") {
+		t.Errorf("expected send action hint, got: %s", output)
+	}
+	if !strings.Contains(output, "[r]") {
+		t.Errorf("expected refresh action hint, got: %s", output)
+	}
+	if !strings.Contains(output, "[esc]") {
+		t.Errorf("expected back action hint, got: %s", output)
 	}
 }
 

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -23,9 +23,10 @@ type HistoryEntry struct {
 
 // Channel represents a named communication channel with a list of members.
 type Channel struct {
-	Name    string         `json:"name"`
-	Members []string       `json:"members"`
-	History []HistoryEntry `json:"history,omitempty"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Members     []string       `json:"members"`
+	History     []HistoryEntry `json:"history,omitempty"`
 }
 
 // Store manages channel persistence and operations.
@@ -266,4 +267,31 @@ func (s *Store) GetHistory(channelName string) ([]HistoryEntry, error) {
 	history := make([]HistoryEntry, len(ch.History))
 	copy(history, ch.History)
 	return history, nil
+}
+
+// SetDescription sets the description for a channel.
+func (s *Store) SetDescription(channelName, description string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ch, exists := s.channels[channelName]
+	if !exists {
+		return fmt.Errorf("channel %q not found", channelName)
+	}
+
+	ch.Description = description
+	return nil
+}
+
+// GetDescription returns the description for a channel.
+func (s *Store) GetDescription(channelName string) (string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ch, exists := s.channels[channelName]
+	if !exists {
+		return "", fmt.Errorf("channel %q not found", channelName)
+	}
+
+	return ch.Description, nil
 }

--- a/pkg/channel/channel_test.go
+++ b/pkg/channel/channel_test.go
@@ -617,3 +617,94 @@ func TestListStableOrdering(t *testing.T) {
 		}
 	}
 }
+
+// --- Description ---
+
+func TestSetDescription(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.Create("general"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.SetDescription("general", "Main discussion channel"); err != nil {
+		t.Fatalf("SetDescription: unexpected error: %v", err)
+	}
+
+	ch, ok := s.Get("general")
+	if !ok {
+		t.Fatal("Get: channel not found")
+	}
+	if ch.Description != "Main discussion channel" {
+		t.Errorf("Description = %q, want %q", ch.Description, "Main discussion channel")
+	}
+}
+
+func TestSetDescriptionNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	err := s.SetDescription("nonexistent", "test")
+	if err == nil {
+		t.Fatal("SetDescription: expected error for nonexistent channel")
+	}
+}
+
+func TestGetDescription(t *testing.T) {
+	s := newTestStore(t)
+
+	if _, err := s.Create("general"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetDescription("general", "Team channel"); err != nil {
+		t.Fatal(err)
+	}
+
+	desc, err := s.GetDescription("general")
+	if err != nil {
+		t.Fatalf("GetDescription: unexpected error: %v", err)
+	}
+	if desc != "Team channel" {
+		t.Errorf("GetDescription = %q, want %q", desc, "Team channel")
+	}
+}
+
+func TestGetDescriptionNotFound(t *testing.T) {
+	s := newTestStore(t)
+
+	_, err := s.GetDescription("nonexistent")
+	if err == nil {
+		t.Fatal("GetDescription: expected error for nonexistent channel")
+	}
+}
+
+func TestDescriptionPersistence(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bc"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create store, set description, save
+	s1 := NewStore(dir)
+	if _, err := s1.Create("general"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s1.SetDescription("general", "Persisted description"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s1.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create new store, load, verify description persisted
+	s2 := NewStore(dir)
+	if err := s2.Load(); err != nil {
+		t.Fatal(err)
+	}
+	ch, ok := s2.Get("general")
+	if !ok {
+		t.Fatal("Get: channel not found after reload")
+	}
+	if ch.Description != "Persisted description" {
+		t.Errorf("Description after reload = %q, want %q", ch.Description, "Persisted description")
+	}
+}


### PR DESCRIPTION
## Summary
- Add Description field to Channel struct for topic/description support
- Redesign TUI header with channel name prominently displayed
- Display online member count with active/inactive indicators
- Move quick action hints to header for better discoverability

## Changes
- **pkg/channel/channel.go**: Add Description field, SetDescription/GetDescription methods
- **internal/tui/channel.go**: Redesigned header with description, member stats, quick actions
- **Tests**: Comprehensive tests for new functionality

## Test plan
- [x] Unit tests pass for new Description methods
- [x] TUI view tests updated and passing
- [x] Build passes with no lint errors
- [ ] Manual testing in `bc home` TUI

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)