### PR TITLE
feat(tui): add color-coded agent names and role badges (#205)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -298,7 +298,17 @@ func (m *ChannelModel) View() string {
 				b.WriteString(icon)
 			}
 
-			b.WriteString(m.styles.Info.Render(sender))
+			// Render sender with role-specific color
+			role := style.RoleFromAgentName(sender)
+			senderStyle := m.styles.RoleStyle(role)
+			b.WriteString(senderStyle.Render(sender))
+
+			// Add role badge
+			if role != sender && role != "" {
+				b.WriteString(" ")
+				b.WriteString(m.styles.RoleBadge(role).Render(role))
+			}
+
 			b.WriteString("  ")
 			b.WriteString(m.styles.Muted.Render(ts))
 			b.WriteString("\n")
@@ -358,7 +368,10 @@ func (m *ChannelModel) View() string {
 				msgStyle := m.styles.MessageTypeStyle(msgTypeStr)
 				msg := msgStyle.Render(entry.Message)
 				if entry.Sender != "" {
-					sender := m.styles.Info.Render("[" + entry.Sender + "]")
+					// Use role-specific color for sender
+					role := style.RoleFromAgentName(entry.Sender)
+					senderStyle := m.styles.RoleStyle(role)
+					sender := senderStyle.Render("[" + entry.Sender + "]")
 					line = fmt.Sprintf("  %s%s  %s %s", icon, ts, sender, msg)
 				} else {
 					line = fmt.Sprintf("  %s%s  %s", icon, ts, msg)

--- a/pkg/tui/style/theme.go
+++ b/pkg/tui/style/theme.go
@@ -26,6 +26,13 @@ type Theme struct {
 	Selection   lipgloss.Color
 	HeaderBg    lipgloss.Color
 	StatusBarBg lipgloss.Color
+
+	// Agent role colors
+	RoleCoordinator lipgloss.Color
+	RoleEngineer    lipgloss.Color
+	RoleQA          lipgloss.Color
+	RoleTechLead    lipgloss.Color
+	RolePM          lipgloss.Color
 }
 
 // ThemeName identifies a theme by name.
@@ -71,6 +78,13 @@ func DarkTheme() Theme {
 		Selection:   lipgloss.Color("#409FFF"),
 		HeaderBg:    lipgloss.Color("#1C2028"),
 		StatusBarBg: lipgloss.Color("#1C2028"),
+
+		// Agent roles (muted/pastel for dark theme)
+		RoleCoordinator: lipgloss.Color("#6B9FD4"), // Blue
+		RoleEngineer:    lipgloss.Color("#7BC96F"), // Green
+		RoleQA:          lipgloss.Color("#B48EAD"), // Purple
+		RoleTechLead:    lipgloss.Color("#EBCB8B"), // Orange
+		RolePM:          lipgloss.Color("#88C0D0"), // Teal
 	}
 }
 
@@ -98,6 +112,13 @@ func LightTheme() Theme {
 		Selection:   lipgloss.Color("#035BD6"),
 		HeaderBg:    lipgloss.Color("#E8E9EB"),
 		StatusBarBg: lipgloss.Color("#E8E9EB"),
+
+		// Agent roles (saturated for light theme)
+		RoleCoordinator: lipgloss.Color("#2563EB"), // Blue
+		RoleEngineer:    lipgloss.Color("#16A34A"), // Green
+		RoleQA:          lipgloss.Color("#9333EA"), // Purple
+		RoleTechLead:    lipgloss.Color("#EA580C"), // Orange
+		RolePM:          lipgloss.Color("#0891B2"), // Teal
 	}
 }
 
@@ -125,6 +146,13 @@ func HighContrastTheme() Theme {
 		Selection:   lipgloss.Color("#0000FF"),
 		HeaderBg:    lipgloss.Color("#333333"),
 		StatusBarBg: lipgloss.Color("#333333"),
+
+		// Agent roles (high contrast, distinct colors)
+		RoleCoordinator: lipgloss.Color("#00BFFF"), // Blue
+		RoleEngineer:    lipgloss.Color("#00FF00"), // Green
+		RoleQA:          lipgloss.Color("#FF00FF"), // Purple
+		RoleTechLead:    lipgloss.Color("#FFA500"), // Orange
+		RolePM:          lipgloss.Color("#00FFFF"), // Teal
 	}
 }
 
@@ -289,4 +317,79 @@ func (s Styles) MessageTypeIcon(msgType string) string {
 	default:
 		return ""
 	}
+}
+
+// RoleColor returns the color for an agent role.
+// Recognized roles: coordinator, engineer, qa, tech-lead, product-manager (or pm)
+func (s Styles) RoleColor(role string) lipgloss.Color {
+	switch role {
+	case "coordinator":
+		return s.theme.RoleCoordinator
+	case "engineer":
+		return s.theme.RoleEngineer
+	case "qa":
+		return s.theme.RoleQA
+	case "tech-lead":
+		return s.theme.RoleTechLead
+	case "product-manager", "pm":
+		return s.theme.RolePM
+	default:
+		return s.theme.Foreground
+	}
+}
+
+// RoleStyle returns a lipgloss style with the role's color.
+func (s Styles) RoleStyle(role string) lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(s.RoleColor(role))
+}
+
+// RoleBadge returns a pill-shaped badge style for the given role.
+// The badge has the role color as background with contrasting text.
+func (s Styles) RoleBadge(role string) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Background(s.RoleColor(role)).
+		Foreground(s.theme.Background).
+		Padding(0, 1).
+		Bold(true)
+}
+
+// RoleFromAgentName extracts the role from an agent name.
+// Agent names follow the pattern: role-NN (e.g., "engineer-01", "tech-lead-02")
+func RoleFromAgentName(agentName string) string {
+	// Handle special cases
+	switch agentName {
+	case "coordinator":
+		return "coordinator"
+	case "manager":
+		return "coordinator"
+	case "product-manager":
+		return "product-manager"
+	}
+
+	// Extract role prefix from names like "engineer-01", "tech-lead-02", "qa-01"
+	// Find the last dash followed by digits
+	for i := len(agentName) - 1; i >= 0; i-- {
+		if agentName[i] == '-' {
+			suffix := agentName[i+1:]
+			if isNumeric(suffix) {
+				return agentName[:i]
+			}
+		}
+	}
+
+	// No numeric suffix found, return the whole name as role
+	return agentName
+}
+
+// isNumeric checks if a string contains only digits.
+func isNumeric(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/tui/style/theme_test.go
+++ b/pkg/tui/style/theme_test.go
@@ -194,3 +194,147 @@ func TestMessageTypeIcon(t *testing.T) {
 		})
 	}
 }
+
+func TestRoleColor(t *testing.T) {
+	styles := DefaultStyles()
+	theme := DarkTheme()
+
+	tests := []struct {
+		role      string
+		wantColor lipgloss.Color
+	}{
+		{"coordinator", theme.RoleCoordinator},
+		{"engineer", theme.RoleEngineer},
+		{"qa", theme.RoleQA},
+		{"tech-lead", theme.RoleTechLead},
+		{"product-manager", theme.RolePM},
+		{"pm", theme.RolePM},
+		{"unknown", theme.Foreground},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			color := styles.RoleColor(tt.role)
+			if color != tt.wantColor {
+				t.Errorf("RoleColor(%q) = %v, want %v", tt.role, color, tt.wantColor)
+			}
+		})
+	}
+}
+
+func TestRoleStyle(t *testing.T) {
+	styles := DefaultStyles()
+
+	roles := []string{"coordinator", "engineer", "qa", "tech-lead", "product-manager"}
+
+	for _, role := range roles {
+		t.Run(role, func(t *testing.T) {
+			style := styles.RoleStyle(role)
+			// Verify we get a valid style back (non-panic)
+			rendered := style.Render("test")
+			if rendered == "" {
+				t.Errorf("RoleStyle(%q) should render text", role)
+			}
+		})
+	}
+}
+
+func TestRoleBadge(t *testing.T) {
+	styles := DefaultStyles()
+
+	roles := []string{"coordinator", "engineer", "qa", "tech-lead", "product-manager"}
+
+	for _, role := range roles {
+		t.Run(role, func(t *testing.T) {
+			badge := styles.RoleBadge(role)
+			// Verify we get a valid style back (non-panic)
+			rendered := badge.Render(role)
+			if rendered == "" {
+				t.Errorf("RoleBadge(%q) should render badge", role)
+			}
+		})
+	}
+}
+
+func TestRoleFromAgentName(t *testing.T) {
+	tests := []struct {
+		agentName string
+		wantRole  string
+	}{
+		{"engineer-01", "engineer"},
+		{"engineer-02", "engineer"},
+		{"tech-lead-01", "tech-lead"},
+		{"tech-lead-02", "tech-lead"},
+		{"qa-01", "qa"},
+		{"qa-02", "qa"},
+		{"coordinator", "coordinator"},
+		{"manager", "coordinator"},
+		{"product-manager", "product-manager"},
+		{"unknown-agent", "unknown-agent"},
+		{"simple", "simple"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.agentName, func(t *testing.T) {
+			role := RoleFromAgentName(tt.agentName)
+			if role != tt.wantRole {
+				t.Errorf("RoleFromAgentName(%q) = %q, want %q", tt.agentName, role, tt.wantRole)
+			}
+		})
+	}
+}
+
+func TestIsNumeric(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{"01", true},
+		{"123", true},
+		{"0", true},
+		{"", false},
+		{"abc", false},
+		{"12a", false},
+		{"a12", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			got := isNumeric(tt.s)
+			if got != tt.want {
+				t.Errorf("isNumeric(%q) = %v, want %v", tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestThemeHasRoleColors(t *testing.T) {
+	themes := []struct {
+		name  string
+		theme Theme
+	}{
+		{"dark", DarkTheme()},
+		{"light", LightTheme()},
+		{"high-contrast", HighContrastTheme()},
+	}
+
+	for _, tt := range themes {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.theme.RoleCoordinator == "" {
+				t.Error("Theme should have RoleCoordinator color")
+			}
+			if tt.theme.RoleEngineer == "" {
+				t.Error("Theme should have RoleEngineer color")
+			}
+			if tt.theme.RoleQA == "" {
+				t.Error("Theme should have RoleQA color")
+			}
+			if tt.theme.RoleTechLead == "" {
+				t.Error("Theme should have RoleTechLead color")
+			}
+			if tt.theme.RolePM == "" {
+				t.Error("Theme should have RolePM color")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add role-specific colors for agent types (coordinator=blue, engineer=green, qa=purple, tech-lead=orange, pm=teal)
- Display role badges inline with sender names in message headers
- Theme-adaptive colors: muted/pastel for dark theme, saturated for light theme
- Extract role from agent name pattern (e.g., "engineer-01" -> "engineer")

## Implementation Details
- Extended `Theme` struct with role color fields (RoleCoordinator, RoleEngineer, RoleQA, RoleTechLead, RolePM)
- Added `RoleColor()`, `RoleStyle()`, `RoleBadge()` methods to Styles
- Added `RoleFromAgentName()` helper to extract role from agent name patterns
- Updated channel view to use role-specific colors and badges for sender names
- Colors are adaptive across dark, light, and high-contrast themes

## Test plan
- [x] All existing tests pass
- [x] New tests for RoleColor, RoleStyle, RoleBadge functions
- [x] New tests for RoleFromAgentName helper
- [x] Tests verify all themes have role colors
- [ ] Manual testing in TUI for visual verification

Part of Epic #203 - Channel Chatroom UI Redesign

🤖 Generated with [Claude Code](https://claude.com/claude-code)