### PR TITLE
feat(channel): add relative timestamps and date separators

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -275,7 +276,22 @@ func (m *ChannelModel) View() string {
 			msgWidth = 30
 		}
 
-		for i, entry := range m.channel.History[start:end] {
+		var lastDate time.Time
+		visibleHistory := m.channel.History[start:end]
+		for i, entry := range visibleHistory {
+			// Add date separator if this is a new day
+			if i == 0 || !isSameDay(entry.Time, lastDate) {
+				if i > 0 {
+					b.WriteString("\n")
+				}
+				dateSep := formatDateSeparator(entry.Time)
+				sepLine := fmt.Sprintf("── %s ──", dateSep)
+				b.WriteString("  ")
+				b.WriteString(m.styles.Muted.Render(sepLine))
+				b.WriteString("\n")
+			}
+			lastDate = entry.Time
+
 			if i > 0 {
 				b.WriteString("\n")
 			}
@@ -284,12 +300,12 @@ func (m *ChannelModel) View() string {
 			msgType := channel.InferMessageType(entry.Message)
 			msgTypeStr := string(msgType)
 
-			// Sender and timestamp line
+			// Sender and timestamp line with relative time
 			sender := entry.Sender
 			if sender == "" {
 				sender = "system"
 			}
-			ts := entry.Time.Format("15:04:05")
+			relTime := formatRelativeTime(entry.Time)
 			b.WriteString("  ")
 
 			// Add message type icon if not a regular text message
@@ -300,7 +316,7 @@ func (m *ChannelModel) View() string {
 
 			b.WriteString(m.styles.Info.Render(sender))
 			b.WriteString("  ")
-			b.WriteString(m.styles.Muted.Render(ts))
+			b.WriteString(m.styles.Muted.Render(relTime))
 			b.WriteString("\n")
 
 			// Message content — wrap long lines with type-specific styling
@@ -337,24 +353,35 @@ func (m *ChannelModel) View() string {
 		if len(m.channel.History) > 20 {
 			start = len(m.channel.History) - 20
 		}
-		for i, entry := range m.channel.History[start:] {
+		var lastDate time.Time
+		recentHistory := m.channel.History[start:]
+		for i, entry := range recentHistory {
+			// Add date separator if this is a new day
+			if i == 0 || !isSameDay(entry.Time, lastDate) {
+				dateSep := formatDateSeparator(entry.Time)
+				b.WriteString(m.styles.Muted.Render(fmt.Sprintf("  ─── %s ───", dateSep)))
+				b.WriteString("\n")
+			}
+			lastDate = entry.Time
+
 			selected := i == m.cursor
 
 			// Infer message type for styling
 			msgType := channel.InferMessageType(entry.Message)
 			msgTypeStr := string(msgType)
 			icon := m.styles.MessageTypeIcon(msgTypeStr)
+			relTime := formatRelativeTime(entry.Time)
 
 			var line string
 			if entry.Sender != "" {
-				line = fmt.Sprintf("  %s%s  [%s] %s", icon, entry.Time.Format("15:04:05"), entry.Sender, entry.Message)
+				line = fmt.Sprintf("  %s%s  [%s] %s", icon, relTime, entry.Sender, entry.Message)
 			} else {
-				line = fmt.Sprintf("  %s%s  %s", icon, entry.Time.Format("15:04:05"), entry.Message)
+				line = fmt.Sprintf("  %s%s  %s", icon, relTime, entry.Message)
 			}
 			if selected {
 				b.WriteString(m.styles.Selected.Render(line))
 			} else {
-				ts := m.styles.Muted.Render(entry.Time.Format("15:04:05"))
+				ts := m.styles.Muted.Render(relTime)
 				msgStyle := m.styles.MessageTypeStyle(msgTypeStr)
 				msg := msgStyle.Render(entry.Message)
 				if entry.Sender != "" {
@@ -406,4 +433,56 @@ func wrapText(text string, width int) []string {
 		lines = append(lines, text)
 	}
 	return lines
+}
+
+// formatRelativeTime returns a human-readable relative time string.
+// For times within the last hour, shows minutes (e.g., "5m ago").
+// For times within the last day, shows hours (e.g., "3h ago").
+// For older times, shows the absolute time (e.g., "15:04").
+func formatRelativeTime(t time.Time) string {
+	return formatRelativeTimeFrom(t, time.Now())
+}
+
+// formatRelativeTimeFrom returns a relative time string compared to a reference time.
+// This is useful for testing with a fixed reference time.
+func formatRelativeTimeFrom(t, now time.Time) string {
+	diff := now.Sub(t)
+
+	switch {
+	case diff < time.Minute:
+		return "now"
+	case diff < time.Hour:
+		mins := int(diff.Minutes())
+		return fmt.Sprintf("%dm ago", mins)
+	case diff < 24*time.Hour:
+		hours := int(diff.Hours())
+		return fmt.Sprintf("%dh ago", hours)
+	case diff < 48*time.Hour:
+		return "yesterday " + t.Format("15:04")
+	default:
+		return t.Format("Jan 2 15:04")
+	}
+}
+
+// isSameDay returns true if two times are on the same calendar day.
+func isSameDay(t1, t2 time.Time) bool {
+	y1, m1, d1 := t1.Date()
+	y2, m2, d2 := t2.Date()
+	return y1 == y2 && m1 == m2 && d1 == d2
+}
+
+// formatDateSeparator returns a formatted date separator string.
+func formatDateSeparator(t time.Time) string {
+	return formatDateSeparatorFrom(t, time.Now())
+}
+
+// formatDateSeparatorFrom returns a formatted date separator compared to a reference time.
+func formatDateSeparatorFrom(t, now time.Time) string {
+	if isSameDay(t, now) {
+		return "Today"
+	}
+	if isSameDay(t, now.AddDate(0, 0, -1)) {
+		return "Yesterday"
+	}
+	return t.Format("Monday, Jan 2, 2006")
 }

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -360,3 +360,129 @@ func TestVisibleMsgCount(t *testing.T) {
 		t.Errorf("visibleMsgCount should be positive, got %d", count)
 	}
 }
+
+// --- formatRelativeTime tests ---
+
+func TestFormatRelativeTime_Now(t *testing.T) {
+	now := time.Now()
+	result := formatRelativeTimeFrom(now, now)
+	if result != "now" {
+		t.Errorf("expected 'now', got %q", result)
+	}
+}
+
+func TestFormatRelativeTime_Minutes(t *testing.T) {
+	now := time.Now()
+	msgTime := now.Add(-5 * time.Minute)
+	result := formatRelativeTimeFrom(msgTime, now)
+	if result != "5m ago" {
+		t.Errorf("expected '5m ago', got %q", result)
+	}
+}
+
+func TestFormatRelativeTime_Hours(t *testing.T) {
+	now := time.Now()
+	msgTime := now.Add(-3 * time.Hour)
+	result := formatRelativeTimeFrom(msgTime, now)
+	if result != "3h ago" {
+		t.Errorf("expected '3h ago', got %q", result)
+	}
+}
+
+func TestFormatRelativeTime_Yesterday(t *testing.T) {
+	now := time.Now()
+	msgTime := now.Add(-30 * time.Hour)
+	result := formatRelativeTimeFrom(msgTime, now)
+	if !strings.HasPrefix(result, "yesterday") {
+		t.Errorf("expected result to start with 'yesterday', got %q", result)
+	}
+}
+
+func TestFormatRelativeTime_OlderDate(t *testing.T) {
+	now := time.Now()
+	msgTime := now.Add(-72 * time.Hour) // 3 days ago
+	result := formatRelativeTimeFrom(msgTime, now)
+	// Should contain the month abbreviation
+	if !strings.Contains(result, msgTime.Format("Jan")) {
+		t.Errorf("expected date format with month, got %q", result)
+	}
+}
+
+// --- isSameDay tests ---
+
+func TestIsSameDay_Same(t *testing.T) {
+	t1 := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 15, 23, 59, 0, 0, time.UTC)
+	if !isSameDay(t1, t2) {
+		t.Error("same day should return true")
+	}
+}
+
+func TestIsSameDay_Different(t *testing.T) {
+	t1 := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	t2 := time.Date(2024, 1, 16, 10, 30, 0, 0, time.UTC)
+	if isSameDay(t1, t2) {
+		t.Error("different days should return false")
+	}
+}
+
+// --- formatDateSeparator tests ---
+
+func TestFormatDateSeparator_Today(t *testing.T) {
+	now := time.Now()
+	result := formatDateSeparatorFrom(now, now)
+	if result != "Today" {
+		t.Errorf("expected 'Today', got %q", result)
+	}
+}
+
+func TestFormatDateSeparator_Yesterday(t *testing.T) {
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1)
+	result := formatDateSeparatorFrom(yesterday, now)
+	if result != "Yesterday" {
+		t.Errorf("expected 'Yesterday', got %q", result)
+	}
+}
+
+func TestFormatDateSeparator_OlderDate(t *testing.T) {
+	now := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	oldDate := time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC)
+	result := formatDateSeparatorFrom(oldDate, now)
+	// Should include day name and date
+	if !strings.Contains(result, "Wednesday") || !strings.Contains(result, "Jan 10") {
+		t.Errorf("expected 'Wednesday, Jan 10, 2024', got %q", result)
+	}
+}
+
+// --- View tests with date separators ---
+
+func TestChannelView_DateSeparators(t *testing.T) {
+	m := newTestChannelModel()
+	now := time.Now()
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "eng-01", Message: "old message", Time: now.AddDate(0, 0, -2)},
+		{Sender: "eng-02", Message: "yesterday message", Time: now.AddDate(0, 0, -1)},
+		{Sender: "eng-03", Message: "today message", Time: now},
+	}
+
+	output := m.View()
+	if !strings.Contains(output, "Today") {
+		t.Errorf("expected 'Today' separator in output")
+	}
+	if !strings.Contains(output, "Yesterday") {
+		t.Errorf("expected 'Yesterday' separator in output")
+	}
+}
+
+func TestChannelView_RelativeTimestamps(t *testing.T) {
+	m := newTestChannelModel()
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "eng-01", Message: "recent message", Time: time.Now().Add(-5 * time.Minute)},
+	}
+
+	output := m.View()
+	if !strings.Contains(output, "5m ago") {
+		t.Errorf("expected '5m ago' in output, got: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- Add human-readable relative timestamps (e.g., "5m ago", "2h ago", "yesterday 14:30")
- Add date separators between messages from different days ("Today", "Yesterday", "Monday, Jan 15, 2024")
- Applied to both main message view and Recent Messages section
- Improves message scannability for channel chatroom UI

## Changes
- `formatRelativeTime()` - formats time as relative ("5m ago") or absolute ("Jan 2 15:04")
- `formatDateSeparator()` - returns "Today", "Yesterday", or full date
- `isSameDay()` - helper to detect day boundaries
- Updated `View()` to render date separators and relative timestamps

## Test plan
- [x] All existing tests pass
- [x] New tests added for `formatRelativeTimeFrom()`, `isSameDay()`, `formatDateSeparatorFrom()`
- [x] View tests for date separators and relative timestamps
- [ ] Manual testing: view channel with messages from different times/days

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)