### PR TITLE
feat(channel): add emoji reactions on messages (#207)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -51,6 +52,7 @@ type ChannelModel struct {
 	// Small types last
 	autocompleteType AutocompleteType
 	sendMode         bool
+	reactionMode     bool // Show reaction picker for selected message
 }
 
 // NewChannelModel creates a channel detail view.
@@ -70,6 +72,10 @@ func (m *ChannelModel) HandleKey(msg tea.KeyMsg) Action {
 
 	if m.sendMode {
 		return m.handleSendKey(msg)
+	}
+
+	if m.reactionMode {
+		return m.handleReactionKey(msg)
 	}
 
 	switch key {
@@ -99,6 +105,12 @@ func (m *ChannelModel) HandleKey(msg tea.KeyMsg) Action {
 		m.sendMode = true
 		m.input = ""
 		m.sendMsg = ""
+		return NoAction
+	case "e": // Open reaction picker
+		if len(m.channel.History) > 0 {
+			m.reactionMode = true
+			m.sendMsg = ""
+		}
 		return NoAction
 	case "r":
 		m.reloadChannel()
@@ -147,6 +159,77 @@ func (m *ChannelModel) selectedMessage() (channel.HistoryEntry, bool) {
 		return channel.HistoryEntry{}, false
 	}
 	return visible[m.cursor], true
+}
+
+// selectedMessageIndex returns the index of the selected message in the full history.
+func (m *ChannelModel) selectedMessageIndex() int {
+	n := len(m.channel.History)
+	if n == 0 {
+		return -1
+	}
+	start := 0
+	if n > 20 {
+		start = n - 20
+	}
+	if m.cursor < 0 || m.cursor >= n-start {
+		return -1
+	}
+	return start + m.cursor
+}
+
+func (m *ChannelModel) handleReactionKey(msg tea.KeyMsg) Action {
+	key := msg.String()
+
+	switch key {
+	case "esc":
+		m.reactionMode = false
+		return NoAction
+	case "1":
+		m.addReactionToSelected("👍")
+		return NoAction
+	case "2":
+		m.addReactionToSelected("👎")
+		return NoAction
+	case "3":
+		m.addReactionToSelected("❤️")
+		return NoAction
+	case "4":
+		m.addReactionToSelected("🎉")
+		return NoAction
+	case "5":
+		m.addReactionToSelected("👀")
+		return NoAction
+	case "6":
+		m.addReactionToSelected("🚀")
+		return NoAction
+	}
+
+	return NoAction
+}
+
+func (m *ChannelModel) addReactionToSelected(emoji string) {
+	idx := m.selectedMessageIndex()
+	if idx < 0 {
+		return
+	}
+
+	user := os.Getenv("BC_AGENT_ID")
+	if user == "" {
+		user = "anonymous"
+	}
+
+	added, err := m.store.ToggleReaction(m.channel.Name, idx, emoji, user)
+	if err != nil {
+		m.sendMsg = "Error: " + err.Error()
+	} else if added {
+		m.sendMsg = fmt.Sprintf("Added %s reaction", emoji)
+	} else {
+		m.sendMsg = fmt.Sprintf("Removed %s reaction", emoji)
+	}
+
+	_ = m.store.Save()
+	m.reloadChannel()
+	m.reactionMode = false
 }
 
 func (m *ChannelModel) handleSendKey(msg tea.KeyMsg) Action {
@@ -653,6 +736,13 @@ func (m *ChannelModel) View() string {
 				b.WriteString("  " + highlightedLine)
 				b.WriteString("\n")
 			}
+
+			// Display reactions if any
+			if reactionStr := m.formatReactions(entry.Reactions); reactionStr != "" {
+				b.WriteString("    ")
+				b.WriteString(reactionStr)
+				b.WriteString("\n")
+			}
 		}
 
 		// Scroll indicator (bottom)
@@ -720,11 +810,16 @@ func (m *ChannelModel) View() string {
 				}
 				b.WriteString(line)
 			}
+			// Display reactions inline if any
+			if reactionStr := m.formatReactions(entry.Reactions); reactionStr != "" {
+				b.WriteString("  ")
+				b.WriteString(reactionStr)
+			}
 			b.WriteString("\n")
 		}
 	}
 
-	// Send mode or status
+	// Send mode, reaction mode, or status
 	if m.sendMode {
 		// Render autocomplete popup if active
 		if m.autocompleteType != AutocompleteNone && len(m.autocompleteSuggestions) > 0 {
@@ -733,8 +828,15 @@ func (m *ChannelModel) View() string {
 
 		// Render multi-line input area
 		b.WriteString(m.renderInputArea())
+	} else if m.reactionMode {
+		b.WriteString(m.styles.Info.Render("  React: "))
+		b.WriteString("[1]👍  [2]👎  [3]❤️  [4]🎉  [5]👀  [6]🚀  [esc]cancel")
+		b.WriteString("\n")
 	} else if m.sendMsg != "" {
 		b.WriteString(m.styles.Success.Render("  ✓ " + m.sendMsg))
+		b.WriteString("\n")
+	} else {
+		b.WriteString(m.styles.Muted.Render("  [s]end  [e]moji  [j/k]scroll  [r]efresh  [esc]back"))
 		b.WriteString("\n")
 	}
 
@@ -758,6 +860,33 @@ func (m *ChannelModel) highlightMessage(message string) string {
 		}
 		return s.Render(text)
 	})
+}
+
+// formatReactions formats a reactions map for display.
+func (m *ChannelModel) formatReactions(reactions map[string][]string) string {
+	if len(reactions) == 0 {
+		return ""
+	}
+
+	var parts []string
+	// Sort emojis for consistent display
+	for _, emoji := range channel.CommonReactions {
+		if users, ok := reactions[emoji]; ok && len(users) > 0 {
+			parts = append(parts, fmt.Sprintf("%s %d", emoji, len(users)))
+		}
+	}
+	// Add any other emojis not in CommonReactions
+	for emoji, users := range reactions {
+		if !slices.Contains(channel.CommonReactions, emoji) && len(users) > 0 {
+			parts = append(parts, fmt.Sprintf("%s %d", emoji, len(users)))
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	return m.styles.Reaction.Render(strings.Join(parts, "  "))
 }
 
 // wrapText splits text into lines of at most width characters, breaking at spaces.

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -16,9 +16,10 @@ import (
 
 // HistoryEntry represents a message in channel history.
 type HistoryEntry struct {
-	Time    time.Time `json:"time"`
-	Sender  string    `json:"sender,omitempty"`
-	Message string    `json:"message"`
+	Reactions map[string][]string `json:"reactions,omitempty"` // emoji -> list of users
+	Time      time.Time           `json:"time"`
+	Sender    string              `json:"sender,omitempty"`
+	Message   string              `json:"message"`
 }
 
 // Channel represents a named communication channel with a list of members.
@@ -294,4 +295,138 @@ func (s *Store) GetDescription(channelName string) (string, error) {
 	}
 
 	return ch.Description, nil
+}
+
+// CommonReactions provides a set of commonly used emoji reactions.
+var CommonReactions = []string{"👍", "👎", "❤️", "🎉", "👀", "🚀"}
+
+// AddReaction adds an emoji reaction to a message.
+// The messageIndex is the index into the channel's history.
+func (s *Store) AddReaction(channelName string, messageIndex int, emoji, user string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ch, exists := s.channels[channelName]
+	if !exists {
+		return fmt.Errorf("channel %q not found", channelName)
+	}
+
+	if messageIndex < 0 || messageIndex >= len(ch.History) {
+		return fmt.Errorf("message index %d out of range", messageIndex)
+	}
+
+	entry := &ch.History[messageIndex]
+	if entry.Reactions == nil {
+		entry.Reactions = make(map[string][]string)
+	}
+
+	// Check if user already reacted with this emoji
+	users := entry.Reactions[emoji]
+	if slices.Contains(users, user) {
+		return nil // Already reacted
+	}
+
+	entry.Reactions[emoji] = append(users, user)
+	return nil
+}
+
+// RemoveReaction removes an emoji reaction from a message.
+func (s *Store) RemoveReaction(channelName string, messageIndex int, emoji, user string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ch, exists := s.channels[channelName]
+	if !exists {
+		return fmt.Errorf("channel %q not found", channelName)
+	}
+
+	if messageIndex < 0 || messageIndex >= len(ch.History) {
+		return fmt.Errorf("message index %d out of range", messageIndex)
+	}
+
+	entry := &ch.History[messageIndex]
+	if entry.Reactions == nil {
+		return nil // No reactions
+	}
+
+	users := entry.Reactions[emoji]
+	idx := slices.Index(users, user)
+	if idx == -1 {
+		return nil // User hasn't reacted
+	}
+
+	entry.Reactions[emoji] = slices.Delete(users, idx, idx+1)
+
+	// Clean up empty reaction
+	if len(entry.Reactions[emoji]) == 0 {
+		delete(entry.Reactions, emoji)
+	}
+
+	return nil
+}
+
+// ToggleReaction toggles an emoji reaction on a message.
+// Returns true if the reaction was added, false if removed.
+func (s *Store) ToggleReaction(channelName string, messageIndex int, emoji, user string) (added bool, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ch, exists := s.channels[channelName]
+	if !exists {
+		return false, fmt.Errorf("channel %q not found", channelName)
+	}
+
+	if messageIndex < 0 || messageIndex >= len(ch.History) {
+		return false, fmt.Errorf("message index %d out of range", messageIndex)
+	}
+
+	entry := &ch.History[messageIndex]
+	if entry.Reactions == nil {
+		entry.Reactions = make(map[string][]string)
+	}
+
+	users := entry.Reactions[emoji]
+	idx := slices.Index(users, user)
+
+	if idx == -1 {
+		// Add reaction
+		entry.Reactions[emoji] = append(users, user)
+		return true, nil
+	}
+
+	// Remove reaction
+	entry.Reactions[emoji] = slices.Delete(users, idx, idx+1)
+	if len(entry.Reactions[emoji]) == 0 {
+		delete(entry.Reactions, emoji)
+	}
+	return false, nil
+}
+
+// GetReactions returns all reactions for a message.
+func (s *Store) GetReactions(channelName string, messageIndex int) (map[string][]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ch, exists := s.channels[channelName]
+	if !exists {
+		return nil, fmt.Errorf("channel %q not found", channelName)
+	}
+
+	if messageIndex < 0 || messageIndex >= len(ch.History) {
+		return nil, fmt.Errorf("message index %d out of range", messageIndex)
+	}
+
+	entry := ch.History[messageIndex]
+	if entry.Reactions == nil {
+		return nil, nil
+	}
+
+	// Return a copy
+	result := make(map[string][]string)
+	for emoji, users := range entry.Reactions {
+		usersCopy := make([]string, len(users))
+		copy(usersCopy, users)
+		result[emoji] = usersCopy
+	}
+	return result, nil
 }

--- a/pkg/channel/reaction_test.go
+++ b/pkg/channel/reaction_test.go
@@ -1,0 +1,276 @@
+package channel
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestAddReaction(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	// Create a channel with a message
+	_, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	err = store.AddHistory("test", "alice", "Hello world")
+	if err != nil {
+		t.Fatalf("failed to add history: %v", err)
+	}
+
+	// Add a reaction
+	err = store.AddReaction("test", 0, "👍", "bob")
+	if err != nil {
+		t.Fatalf("failed to add reaction: %v", err)
+	}
+
+	// Verify reaction was added
+	reactions, err := store.GetReactions("test", 0)
+	if err != nil {
+		t.Fatalf("failed to get reactions: %v", err)
+	}
+
+	if len(reactions) != 1 {
+		t.Errorf("expected 1 reaction type, got %d", len(reactions))
+	}
+
+	users := reactions["👍"]
+	if len(users) != 1 || users[0] != "bob" {
+		t.Errorf("expected [bob], got %v", users)
+	}
+}
+
+func TestAddReactionDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	err = store.AddHistory("test", "alice", "Hello world")
+	if err != nil {
+		t.Fatalf("failed to add history: %v", err)
+	}
+
+	// Add same reaction twice
+	_ = store.AddReaction("test", 0, "👍", "bob")
+	_ = store.AddReaction("test", 0, "👍", "bob")
+
+	reactions, _ := store.GetReactions("test", 0)
+	users := reactions["👍"]
+	if len(users) != 1 {
+		t.Errorf("expected 1 user after duplicate add, got %d", len(users))
+	}
+}
+
+func TestRemoveReaction(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	err = store.AddHistory("test", "alice", "Hello world")
+	if err != nil {
+		t.Fatalf("failed to add history: %v", err)
+	}
+
+	// Add and then remove a reaction
+	_ = store.AddReaction("test", 0, "👍", "bob")
+	err = store.RemoveReaction("test", 0, "👍", "bob")
+	if err != nil {
+		t.Fatalf("failed to remove reaction: %v", err)
+	}
+
+	reactions, _ := store.GetReactions("test", 0)
+	if len(reactions) > 0 {
+		t.Errorf("expected no reactions after removal, got %v", reactions)
+	}
+}
+
+func TestToggleReaction(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	err = store.AddHistory("test", "alice", "Hello world")
+	if err != nil {
+		t.Fatalf("failed to add history: %v", err)
+	}
+
+	// Toggle on
+	added, err := store.ToggleReaction("test", 0, "👍", "bob")
+	if err != nil {
+		t.Fatalf("failed to toggle reaction: %v", err)
+	}
+	if !added {
+		t.Errorf("expected reaction to be added")
+	}
+
+	reactions, _ := store.GetReactions("test", 0)
+	if len(reactions["👍"]) != 1 {
+		t.Errorf("expected 1 user after toggle on")
+	}
+
+	// Toggle off
+	added, err = store.ToggleReaction("test", 0, "👍", "bob")
+	if err != nil {
+		t.Fatalf("failed to toggle reaction: %v", err)
+	}
+	if added {
+		t.Errorf("expected reaction to be removed")
+	}
+
+	reactions, _ = store.GetReactions("test", 0)
+	if len(reactions) > 0 {
+		t.Errorf("expected no reactions after toggle off")
+	}
+}
+
+func TestMultipleReactions(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	err = store.AddHistory("test", "alice", "Great work!")
+	if err != nil {
+		t.Fatalf("failed to add history: %v", err)
+	}
+
+	// Multiple users react with different emojis
+	_ = store.AddReaction("test", 0, "👍", "bob")
+	_ = store.AddReaction("test", 0, "👍", "charlie")
+	_ = store.AddReaction("test", 0, "🎉", "david")
+	_ = store.AddReaction("test", 0, "❤️", "bob")
+
+	reactions, err := store.GetReactions("test", 0)
+	if err != nil {
+		t.Fatalf("failed to get reactions: %v", err)
+	}
+
+	if len(reactions["👍"]) != 2 {
+		t.Errorf("expected 2 users for 👍, got %d", len(reactions["👍"]))
+	}
+	if len(reactions["🎉"]) != 1 {
+		t.Errorf("expected 1 user for 🎉, got %d", len(reactions["🎉"]))
+	}
+	if len(reactions["❤️"]) != 1 {
+		t.Errorf("expected 1 user for ❤️, got %d", len(reactions["❤️"]))
+	}
+}
+
+func TestReactionInvalidChannel(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	err := store.AddReaction("nonexistent", 0, "👍", "bob")
+	if err == nil {
+		t.Error("expected error for nonexistent channel")
+	}
+}
+
+func TestReactionInvalidMessageIndex(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+
+	err = store.AddReaction("test", 0, "👍", "bob")
+	if err == nil {
+		t.Error("expected error for invalid message index")
+	}
+
+	err = store.AddReaction("test", -1, "👍", "bob")
+	if err == nil {
+		t.Error("expected error for negative message index")
+	}
+}
+
+func TestReactionsPersistence(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	err = store.AddHistory("test", "alice", "Hello world")
+	if err != nil {
+		t.Fatalf("failed to add history: %v", err)
+	}
+
+	_ = store.AddReaction("test", 0, "👍", "bob")
+	_ = store.Save()
+
+	// Create a new store and load
+	store2 := NewStore(dir)
+	err = store2.Load()
+	if err != nil {
+		t.Fatalf("failed to load store: %v", err)
+	}
+
+	reactions, err := store2.GetReactions("test", 0)
+	if err != nil {
+		t.Fatalf("failed to get reactions: %v", err)
+	}
+
+	if len(reactions["👍"]) != 1 || reactions["👍"][0] != "bob" {
+		t.Errorf("reaction not persisted correctly: %v", reactions)
+	}
+}
+
+func TestCommonReactions(t *testing.T) {
+	expected := []string{"👍", "👎", "❤️", "🎉", "👀", "🚀"}
+	if len(CommonReactions) != len(expected) {
+		t.Errorf("expected %d common reactions, got %d", len(expected), len(CommonReactions))
+	}
+
+	for i, emoji := range expected {
+		if CommonReactions[i] != emoji {
+			t.Errorf("common reaction %d: expected %s, got %s", i, emoji, CommonReactions[i])
+		}
+	}
+}
+
+func TestGetReactionsReturnsNilForNoReactions(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, err := store.Create("test")
+	if err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	err = store.AddHistory("test", "alice", "Hello world")
+	if err != nil {
+		t.Fatalf("failed to add history: %v", err)
+	}
+
+	reactions, err := store.GetReactions("test", 0)
+	if err != nil {
+		t.Fatalf("failed to get reactions: %v", err)
+	}
+
+	if reactions != nil {
+		t.Errorf("expected nil for no reactions, got %v", reactions)
+	}
+}
+
+func TestStorePathCorrect(t *testing.T) {
+	store := NewStore("/workspace")
+	expected := filepath.Join("/workspace", ".bc", "channels.json")
+	if store.path != expected {
+		t.Errorf("expected path %s, got %s", expected, store.path)
+	}
+}

--- a/pkg/tui/style/theme.go
+++ b/pkg/tui/style/theme.go
@@ -201,6 +201,9 @@ type Styles struct {
 	Channel lipgloss.Style // #channel references
 	Link    lipgloss.Style // GitHub issue/PR links
 
+	// Reaction style for emoji reactions on messages
+	Reaction lipgloss.Style
+
 	theme Theme
 }
 
@@ -271,6 +274,10 @@ func NewStyles(theme Theme) Styles {
 		Link: lipgloss.NewStyle().
 			Foreground(theme.Accent).
 			Underline(true),
+
+		Reaction: lipgloss.NewStyle().
+			Foreground(theme.Muted).
+			Padding(0, 1),
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add emoji reactions to channel messages with keyboard shortcuts
- Toggle reactions (press same emoji again to remove)
- Display reaction counts inline with messages
- Support 6 common reactions: 👍 👎 ❤️ 🎉 👀 🚀

## Usage
1. Navigate to a message using j/k keys
2. Press `e` to open the reaction picker
3. Press `1-6` to add/toggle a reaction:
   - `1` = 👍 (thumbs up)
   - `2` = 👎 (thumbs down)
   - `3` = ❤️ (heart)
   - `4` = 🎉 (party)
   - `5` = 👀 (eyes)
   - `6` = 🚀 (rocket)
4. Press `esc` to cancel

## Implementation
- Extended `HistoryEntry` struct with `Reactions map[string][]string`
- Added `Store` methods: `AddReaction`, `RemoveReaction`, `ToggleReaction`, `GetReactions`
- Updated TUI with reaction mode and `formatReactions` helper
- Added `Reaction` style to theme.go
- Reactions persist to `channels.json`

## Test plan
- [x] All existing tests pass
- [x] New unit tests for reaction CRUD operations
- [x] Tests for edge cases (duplicate, invalid index, persistence)
- [ ] Manual testing: add/remove reactions on messages

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)