### PR TITLE
feat(channel): add message bubble layout with grouping (#204)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -691,49 +691,68 @@ func (m *ChannelModel) View() string {
 			}
 			lastDate = entry.Time
 
-			if i > 0 {
-				b.WriteString("\n")
-			}
-
 			// Infer message type for styling
 			msgType := channel.InferMessageType(entry.Message)
 			msgTypeStr := string(msgType)
 
-			// Sender and timestamp line with relative time
+			// Sender info
 			sender := entry.Sender
 			if sender == "" {
 				sender = "system"
 			}
-			relTime := formatRelativeTime(entry.Time)
-			b.WriteString("  ")
 
-			// Add message type icon if not a regular text message
-			icon := m.styles.MessageTypeIcon(msgTypeStr)
-			if icon != "" {
-				b.WriteString(icon)
-			}
+			// Check if this is a continuation from the same sender (message grouping)
+			isGrouped := i > 0 && visibleHistory[i-1].Sender == entry.Sender && isSameDay(entry.Time, visibleHistory[i-1].Time)
 
-			// Render sender with role-specific color
-			role := style.RoleFromAgentName(sender)
-			senderStyle := m.styles.RoleStyle(role)
-			b.WriteString(senderStyle.Render(sender))
+			if !isGrouped {
+				// Add spacing between different senders
+				if i > 0 {
+					b.WriteString("\n")
+				}
 
-			// Add role badge
-			if role != sender && role != "" {
-				b.WriteString(" ")
-				b.WriteString(m.styles.RoleBadge(role).Render(role))
-			}
-
-			b.WriteString("  ")
-			b.WriteString(m.styles.Muted.Render(relTime))
-			b.WriteString("\n")
-
-			// Message content — wrap long lines with type-specific styling and highlighting
-			lines := wrapText(entry.Message, msgWidth)
-			for _, line := range lines {
+				// Sender and timestamp header
+				relTime := formatRelativeTime(entry.Time)
 				b.WriteString("  ")
+
+				// Add message type icon if not a regular text message
+				icon := m.styles.MessageTypeIcon(msgTypeStr)
+				if icon != "" {
+					b.WriteString(icon)
+				}
+
+				// Render sender with role-specific color
+				role := style.RoleFromAgentName(sender)
+				senderStyle := m.styles.RoleStyle(role)
+				b.WriteString(senderStyle.Render(sender))
+
+				// Add role badge
+				if role != sender && role != "" {
+					b.WriteString(" ")
+					b.WriteString(m.styles.RoleBadge(role).Render(role))
+				}
+
+				b.WriteString("  ")
+				b.WriteString(m.styles.Muted.Render(relTime))
+				b.WriteString("\n")
+			}
+
+			// Message content with subtle background — wrap long lines with highlighting
+			msgStyle := m.styles.MessageTypeStyle(msgTypeStr)
+			lines := wrapText(entry.Message, msgWidth-4)
+			var content strings.Builder
+			for j, line := range lines {
+				if j > 0 {
+					content.WriteString("\n")
+				}
 				highlightedLine := m.highlightMessage(line)
-				b.WriteString("  " + highlightedLine)
+				content.WriteString(highlightedLine)
+			}
+
+			// Render message with subtle background bubble
+			bubble := m.styles.MessageBubble.Width(msgWidth).Inherit(msgStyle).Render(content.String())
+			for _, line := range strings.Split(bubble, "\n") {
+				b.WriteString("  ")
+				b.WriteString(line)
 				b.WriteString("\n")
 			}
 

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -695,3 +695,57 @@ func TestChannelView_RelativeTimestamps(t *testing.T) {
 		t.Errorf("expected '5m ago' in output, got: %s", output)
 	}
 }
+
+// --- Message grouping tests ---
+
+func TestChannelView_MessageGrouping(t *testing.T) {
+	m := newTestChannelModel()
+	now := time.Now()
+
+	// Add consecutive messages from the same sender
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "engineer-01", Message: "first message", Time: now.Add(-2 * time.Minute)},
+		{Sender: "engineer-01", Message: "second message", Time: now.Add(-1 * time.Minute)},
+		{Sender: "engineer-02", Message: "different sender", Time: now},
+	}
+
+	output := m.View()
+
+	// All messages should be in output
+	if !strings.Contains(output, "first message") {
+		t.Error("expected 'first message' in output")
+	}
+	if !strings.Contains(output, "second message") {
+		t.Error("expected 'second message' in output")
+	}
+	if !strings.Contains(output, "different sender") {
+		t.Error("expected 'different sender' in output")
+	}
+
+	// Both senders should be present (grouping reduces headers, not removes them)
+	if !strings.Contains(output, "engineer-01") {
+		t.Error("expected engineer-01 in output")
+	}
+	if !strings.Contains(output, "engineer-02") {
+		t.Error("expected engineer-02 in output")
+	}
+}
+
+func TestChannelView_MessageBubbleRendering(t *testing.T) {
+	m := newTestChannelModel()
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "engineer-01", Message: "test bubble content", Time: time.Now()},
+	}
+
+	output := m.View()
+
+	// Verify the message content is rendered
+	if !strings.Contains(output, "test bubble content") {
+		t.Error("expected message content in output")
+	}
+
+	// Verify sender is rendered
+	if !strings.Contains(output, "engineer-01") {
+		t.Error("expected sender name in output")
+	}
+}

--- a/pkg/tui/style/theme.go
+++ b/pkg/tui/style/theme.go
@@ -204,6 +204,9 @@ type Styles struct {
 	// Reaction style for emoji reactions on messages
 	Reaction lipgloss.Style
 
+	// Message bubble style (subtle background tint)
+	MessageBubble lipgloss.Style
+
 	theme Theme
 }
 
@@ -276,7 +279,11 @@ func NewStyles(theme Theme) Styles {
 			Underline(true),
 
 		Reaction: lipgloss.NewStyle().
-			Foreground(theme.Muted).
+			Foreground(theme.Muted),
+
+		// Message bubble with subtle background tint (not heavy borders)
+		MessageBubble: lipgloss.NewStyle().
+			Background(theme.HeaderBg).
 			Padding(0, 1),
 	}
 }

--- a/pkg/tui/style/theme_test.go
+++ b/pkg/tui/style/theme_test.go
@@ -1,6 +1,7 @@
 package style
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/charmbracelet/lipgloss"
@@ -336,5 +337,19 @@ func TestThemeHasRoleColors(t *testing.T) {
 				t.Error("Theme should have RolePM color")
 			}
 		})
+	}
+}
+
+func TestMessageBubbleStyle(t *testing.T) {
+	styles := DefaultStyles()
+
+	// Verify MessageBubble style renders
+	rendered := styles.MessageBubble.Render("test message")
+	if rendered == "" {
+		t.Error("MessageBubble style should render text")
+	}
+	// Verify it contains the message content
+	if !strings.Contains(rendered, "test message") {
+		t.Errorf("MessageBubble should contain message, got: %s", rendered)
 	}
 }


### PR DESCRIPTION
## Summary
- Add subtle background message bubbles (HeaderBg tint per UX feedback)
- Group consecutive messages from same sender (skip redundant headers)
- Add MessageBubble style to theme
- Add isSameDay helper for grouping logic

**UX Change:** Replaced heavy RoundedBorder with subtle background tint per UX review feedback on PR #225.

Supersedes PR #225 (had merge conflicts).

Implements Epic #203 issue #204.

## Test plan
- [x] New tests for MessageBubble style rendering
- [x] New tests for message grouping logic
- [x] All existing channel tests pass
- [x] Pre-commit checks pass (build, vet, lint)

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)