### PR TITLE
fix(github): return errors from ListIssues and ListPRs (#229)

### DIFF
--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -50,7 +50,10 @@ func runPRNotify(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get open PRs from GitHub
-	prs := github.ListPRs(ws.RootDir)
+	prs, err := github.ListPRs(ws.RootDir)
+	if err != nil {
+		return fmt.Errorf("failed to list PRs: %w", err)
+	}
 
 	if len(prs) == 0 {
 		fmt.Println("No open PRs found.")

--- a/pkg/github/github.go
+++ b/pkg/github/github.go
@@ -7,6 +7,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os/exec"
 )
 
@@ -54,11 +55,14 @@ func HasGitRemote(workspacePath string) bool {
 	return cmd.Run() == nil
 }
 
+// ErrNoGitRemote indicates no git remote is configured.
+var ErrNoGitRemote = fmt.Errorf("no git remote configured")
+
 // ListIssues returns GitHub issues for the workspace's repo.
-// Falls back to empty list if gh is not available or no remote exists.
-func ListIssues(workspacePath string) []Issue {
+// Returns ErrNoGitRemote if no remote is configured.
+func ListIssues(workspacePath string) ([]Issue, error) {
 	if !HasGitRemote(workspacePath) {
-		return nil
+		return nil, ErrNoGitRemote
 	}
 
 	cmd := exec.CommandContext(context.Background(), "gh", "issue", "list",
@@ -68,12 +72,12 @@ func ListIssues(workspacePath string) []Issue {
 	cmd.Dir = workspacePath
 	output, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to list GitHub issues: %w", err)
 	}
 
 	var raw []ghIssue
 	if err := json.Unmarshal(output, &raw); err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to parse GitHub issues: %w", err)
 	}
 
 	issues := make([]Issue, 0, len(raw))
@@ -91,13 +95,14 @@ func ListIssues(workspacePath string) []Issue {
 		})
 	}
 
-	return issues
+	return issues, nil
 }
 
 // ListPRs returns GitHub pull requests for the workspace's repo.
-func ListPRs(workspacePath string) []PR {
+// Returns ErrNoGitRemote if no remote is configured.
+func ListPRs(workspacePath string) ([]PR, error) {
 	if !HasGitRemote(workspacePath) {
-		return nil
+		return nil, ErrNoGitRemote
 	}
 
 	cmd := exec.CommandContext(context.Background(), "gh", "pr", "list",
@@ -107,12 +112,12 @@ func ListPRs(workspacePath string) []PR {
 	cmd.Dir = workspacePath
 	output, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to list GitHub PRs: %w", err)
 	}
 
 	var raw []ghPR
 	if err := json.Unmarshal(output, &raw); err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to parse GitHub PRs: %w", err)
 	}
 
 	prs := make([]PR, 0, len(raw))
@@ -120,7 +125,7 @@ func ListPRs(workspacePath string) []PR {
 		prs = append(prs, PR(r))
 	}
 
-	return prs
+	return prs, nil
 }
 
 // CreateIssue creates a GitHub issue.

--- a/pkg/github/github_test.go
+++ b/pkg/github/github_test.go
@@ -55,9 +55,12 @@ func TestHasGitRemoteWithOrigin(t *testing.T) {
 
 func TestListIssuesNoRemote(t *testing.T) {
 	dir := t.TempDir()
-	issues := ListIssues(dir)
+	issues, err := ListIssues(dir)
+	if err != ErrNoGitRemote {
+		t.Errorf("ListIssues without remote should return ErrNoGitRemote, got %v", err)
+	}
 	if issues != nil {
-		t.Errorf("ListIssues without remote should return nil, got %d issues", len(issues))
+		t.Errorf("ListIssues without remote should return nil issues, got %d issues", len(issues))
 	}
 }
 
@@ -73,7 +76,10 @@ func TestListIssuesWithMockGh(t *testing.T) {
 	mockGh := createMockCLI(t, "gh", string(data))
 	t.Setenv("PATH", filepath.Dir(mockGh)+":"+os.Getenv("PATH"))
 
-	issues := ListIssues(dir)
+	issues, err := ListIssues(dir)
+	if err != nil {
+		t.Fatalf("ListIssues returned error: %v", err)
+	}
 	if len(issues) != 3 {
 		t.Fatalf("ListIssues returned %d issues, want 3", len(issues))
 	}
@@ -104,7 +110,10 @@ func TestListIssuesEmptyResult(t *testing.T) {
 	mockGh := createMockCLI(t, "gh", "[]")
 	t.Setenv("PATH", filepath.Dir(mockGh)+":"+os.Getenv("PATH"))
 
-	issues := ListIssues(dir)
+	issues, err := ListIssues(dir)
+	if err != nil {
+		t.Errorf("ListIssues returned error: %v", err)
+	}
 	if len(issues) != 0 {
 		t.Errorf("ListIssues with empty array returned %d issues, want 0", len(issues))
 	}
@@ -115,7 +124,10 @@ func TestListIssuesMalformedOutput(t *testing.T) {
 	mockGh := createMockCLI(t, "gh", "not json")
 	t.Setenv("PATH", filepath.Dir(mockGh)+":"+os.Getenv("PATH"))
 
-	issues := ListIssues(dir)
+	issues, err := ListIssues(dir)
+	if err == nil {
+		t.Error("ListIssues with malformed output should return error")
+	}
 	if issues != nil {
 		t.Errorf("ListIssues with malformed output should return nil, got %d", len(issues))
 	}
@@ -125,7 +137,10 @@ func TestListIssuesMalformedOutput(t *testing.T) {
 
 func TestListPRsNoRemote(t *testing.T) {
 	dir := t.TempDir()
-	prs := ListPRs(dir)
+	prs, err := ListPRs(dir)
+	if err != ErrNoGitRemote {
+		t.Errorf("ListPRs without remote should return ErrNoGitRemote, got %v", err)
+	}
 	if prs != nil {
 		t.Errorf("ListPRs without remote should return nil, got %d PRs", len(prs))
 	}
@@ -141,7 +156,10 @@ func TestListPRsWithMockGh(t *testing.T) {
 	mockGh := createMockCLI(t, "gh", data)
 	t.Setenv("PATH", filepath.Dir(mockGh)+":"+os.Getenv("PATH"))
 
-	prs := ListPRs(dir)
+	prs, err := ListPRs(dir)
+	if err != nil {
+		t.Fatalf("ListPRs returned error: %v", err)
+	}
 	if len(prs) != 2 {
 		t.Fatalf("ListPRs returned %d PRs, want 2", len(prs))
 	}
@@ -165,7 +183,10 @@ func TestListPRsEmptyResult(t *testing.T) {
 	mockGh := createMockCLI(t, "gh", "[]")
 	t.Setenv("PATH", filepath.Dir(mockGh)+":"+os.Getenv("PATH"))
 
-	prs := ListPRs(dir)
+	prs, err := ListPRs(dir)
+	if err != nil {
+		t.Errorf("ListPRs returned error: %v", err)
+	}
 	if len(prs) != 0 {
 		t.Errorf("ListPRs with empty array returned %d PRs, want 0", len(prs))
 	}


### PR DESCRIPTION
## Summary
- Change `ListIssues` to return `([]Issue, error)` instead of `[]Issue`
- Change `ListPRs` to return `([]PR, error)` instead of `[]PR`
- Add `ErrNoGitRemote` sentinel error for explicit error checking
- Update caller in `internal/cmd/pr.go` to handle errors properly

## Context
Part of Epic #216 - Critical Quality Fixes.

The audit identified that these functions silently return `nil` on error, making it impossible to distinguish between "no results" and "command failed". This change makes error handling explicit.

## Test plan
- [x] All existing tests pass with updated assertions
- [x] Tests verify error returns for no remote, malformed output
- [x] `go test ./pkg/github/...` passes
- [x] `go build ./...` succeeds

Fixes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)