### PR TITLE
fix(memory): reject empty experiences and learnings

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -115,6 +115,11 @@ func init() {
 }
 
 func runMemoryRecord(cmd *cobra.Command, args []string) error {
+	description := strings.TrimSpace(args[0])
+	if description == "" {
+		return fmt.Errorf("experience cannot be empty")
+	}
+
 	agentID := os.Getenv("BC_AGENT_ID")
 	if agentID == "" {
 		return fmt.Errorf("BC_AGENT_ID not set (this command is meant to be called by agents)")
@@ -133,7 +138,7 @@ func runMemoryRecord(cmd *cobra.Command, args []string) error {
 	}
 
 	exp := memory.Experience{
-		Description: args[0],
+		Description: description,
 		Outcome:     memoryOutcome,
 		TaskID:      memoryTaskID,
 		TaskType:    memoryTaskType,
@@ -143,11 +148,20 @@ func runMemoryRecord(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to record experience: %w", err)
 	}
 
-	cmd.Printf("Recorded experience: %s\n", args[0])
+	cmd.Printf("Recorded experience: %s\n", description)
 	return nil
 }
 
 func runMemoryLearn(cmd *cobra.Command, args []string) error {
+	category := strings.TrimSpace(args[0])
+	if category == "" {
+		return fmt.Errorf("category cannot be empty")
+	}
+	learning := strings.TrimSpace(args[1])
+	if learning == "" {
+		return fmt.Errorf("learning cannot be empty")
+	}
+
 	agentID := os.Getenv("BC_AGENT_ID")
 	if agentID == "" {
 		return fmt.Errorf("BC_AGENT_ID not set (this command is meant to be called by agents)")
@@ -157,9 +171,6 @@ func runMemoryLearn(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("not in a bc workspace: %w", err)
 	}
-
-	category := args[0]
-	learning := args[1]
 
 	store := memory.NewStore(ws.RootDir, agentID)
 	if !store.Exists() {

--- a/internal/cmd/memory_test.go
+++ b/internal/cmd/memory_test.go
@@ -206,3 +206,63 @@ func TestMemoryShowNoMemory(t *testing.T) {
 		t.Errorf("output should indicate no memory: %s", output)
 	}
 }
+
+func TestMemoryRecordRejectsEmpty(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_ = os.Setenv("BC_AGENT_ID", "test-agent")
+	defer func() { _ = os.Unsetenv("BC_AGENT_ID") }()
+
+	_, err := executeCmd("memory", "record", "")
+	if err == nil {
+		t.Error("expected error for empty experience")
+	}
+	if !strings.Contains(err.Error(), "experience cannot be empty") {
+		t.Errorf("error should mention empty experience: %v", err)
+	}
+}
+
+func TestMemoryRecordRejectsWhitespace(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_ = os.Setenv("BC_AGENT_ID", "test-agent")
+	defer func() { _ = os.Unsetenv("BC_AGENT_ID") }()
+
+	_, err := executeCmd("memory", "record", "   ")
+	if err == nil {
+		t.Error("expected error for whitespace-only experience")
+	}
+	if !strings.Contains(err.Error(), "experience cannot be empty") {
+		t.Errorf("error should mention empty experience: %v", err)
+	}
+}
+
+func TestMemoryLearnRejectsEmptyCategory(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_ = os.Setenv("BC_AGENT_ID", "test-agent")
+	defer func() { _ = os.Unsetenv("BC_AGENT_ID") }()
+
+	_, err := executeCmd("memory", "learn", "", "some learning")
+	if err == nil {
+		t.Error("expected error for empty category")
+	}
+	if !strings.Contains(err.Error(), "category cannot be empty") {
+		t.Errorf("error should mention empty category: %v", err)
+	}
+}
+
+func TestMemoryLearnRejectsEmptyLearning(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_ = os.Setenv("BC_AGENT_ID", "test-agent")
+	defer func() { _ = os.Unsetenv("BC_AGENT_ID") }()
+
+	_, err := executeCmd("memory", "learn", "patterns", "")
+	if err == nil {
+		t.Error("expected error for empty learning")
+	}
+	if !strings.Contains(err.Error(), "learning cannot be empty") {
+		t.Errorf("error should mention empty learning: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds validation to reject empty or whitespace-only input in memory commands
- `bc memory record ""` now returns error: "experience cannot be empty"
- `bc memory learn "" "..."` returns error: "category cannot be empty"  
- `bc memory learn "..." ""` returns error: "learning cannot be empty"

## Test plan
- [x] `TestMemoryRecordRejectsEmpty` - verifies empty string rejected
- [x] `TestMemoryRecordRejectsWhitespace` - verifies whitespace-only rejected
- [x] `TestMemoryLearnRejectsEmptyCategory` - verifies empty category rejected
- [x] `TestMemoryLearnRejectsEmptyLearning` - verifies empty learning rejected
- [x] All existing memory tests still pass

Fixes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)