### PR TITLE
fix(config): rename CoordinatorName from 'coordinator' to 'root' (#214)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ max_workers = 3                # Maximum number of worker agents
 # Then bc send and Enter will work; agents run non-interactively with all permissions.
 [agent]
 command = "cursor-agent --force --print"
-coordinator_name = "coordinator"                    # Name for the coordinator agent
+coordinator_name = "root"                           # Name for the coordinator agent
 worker_prefix = "worker"                           # Prefix for worker agent names
 
 # Tmux settings

--- a/config/config.go
+++ b/config/config.go
@@ -46,7 +46,7 @@ type WorkspaceConfig struct {
 var (
 	Agent = AgentConfig{
 		Command:         "cursor-agent --force --print",
-		CoordinatorName: "coordinator",
+		CoordinatorName: "root",
 		WorkerPrefix:    "worker",
 	}
 	Agents = []AgentsItem{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -39,8 +39,8 @@ func TestAgentDefaults(t *testing.T) {
 	if Agent.Command == "" {
 		t.Error("Agent.Command should not be empty")
 	}
-	if Agent.CoordinatorName != "coordinator" {
-		t.Errorf("Agent.CoordinatorName = %q, want %q", Agent.CoordinatorName, "coordinator")
+	if Agent.CoordinatorName != "root" {
+		t.Errorf("Agent.CoordinatorName = %q, want %q", Agent.CoordinatorName, "root")
 	}
 	if Agent.WorkerPrefix != "worker" {
 		t.Errorf("Agent.WorkerPrefix = %q, want %q", Agent.WorkerPrefix, "worker")


### PR DESCRIPTION
## Summary
- Change `CoordinatorName` default from `"coordinator"` to `"root"` in config/config.go
- Update test to expect the new value

Fixes #214

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./config/...` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)