### PR TITLE
feat(cmd): add bc queue command with list, add, and JSON support (#219-#222)

### DIFF
--- a/internal/cmd/queue.go
+++ b/internal/cmd/queue.go
@@ -1,0 +1,229 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rpuneet/bc/pkg/github"
+)
+
+var queueCmd = &cobra.Command{
+	Use:   "queue",
+	Short: "Manage work queue",
+	Long: `Manage the work queue for tracking tasks and epics.
+
+The work queue displays GitHub issues labeled as 'task' or 'epic'.
+Use this command to view, add, and manage work items.
+
+Examples:
+  bc queue                    # list all work items
+  bc queue list               # list all work items
+  bc queue add "Fix bug"      # add a task to the queue
+  bc queue add "New feature" --epic  # add an epic`,
+	RunE: runQueueList,
+}
+
+var queueListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List work queue items",
+	Long:  `List all work items (tasks and epics) from GitHub Issues.`,
+	RunE:  runQueueList,
+}
+
+var queueAddCmd = &cobra.Command{
+	Use:   "add <title>",
+	Short: "Add a work item to the queue",
+	Long: `Add a new task or epic to the work queue.
+
+Creates a GitHub issue with the 'task' label (or 'epic' if --epic is specified).
+
+Examples:
+  bc queue add "Fix login bug"
+  bc queue add "Fix login bug" -d "Users can't login with SSO"
+  bc queue add "New auth system" --epic
+  bc queue add "Add tests" --label priority-high`,
+	Args: cobra.ExactArgs(1),
+	RunE: runQueueAdd,
+}
+
+func init() {
+	// Add subcommands
+	queueCmd.AddCommand(queueListCmd)
+	queueCmd.AddCommand(queueAddCmd)
+
+	// Add flags to queue add command
+	queueAddCmd.Flags().StringP("description", "d", "", "Description/body for the work item")
+	queueAddCmd.Flags().Bool("epic", false, "Create as an epic instead of a task")
+	queueAddCmd.Flags().StringSlice("label", nil, "Additional labels to apply")
+
+	// Register with root command
+	rootCmd.AddCommand(queueCmd)
+}
+
+// QueueItem represents a work item in the queue.
+type QueueItem struct {
+	Title  string   `json:"title"`
+	Type   string   `json:"type"` // "epic" or "task"
+	State  string   `json:"state"`
+	URL    string   `json:"url,omitempty"`
+	Labels []string `json:"labels,omitempty"`
+	Number int      `json:"number"`
+}
+
+func runQueueList(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	issues, err := github.ListIssues(ws.RootDir)
+	if err != nil {
+		return fmt.Errorf("failed to list issues: %w", err)
+	}
+
+	// Filter to only epic and task labels
+	var items []QueueItem
+	for _, issue := range issues {
+		itemType := getItemType(issue)
+		if itemType == "" {
+			continue // Not a task or epic
+		}
+		items = append(items, QueueItem{
+			Number: issue.Number,
+			Title:  issue.Title,
+			Type:   itemType,
+			State:  issue.State,
+			Labels: issue.Labels,
+		})
+	}
+
+	// Sort by number (newest first)
+	slices.SortFunc(items, func(a, b QueueItem) int {
+		return b.Number - a.Number
+	})
+
+	// Check for JSON output
+	jsonOutput, err := cmd.Flags().GetBool("json")
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(items)
+	}
+
+	// Display table format
+	if len(items) == 0 {
+		fmt.Println("No work items in queue")
+		fmt.Println()
+		fmt.Println("Run 'bc queue add <title>' to add a task")
+		fmt.Println("Run 'bc queue add <title> --epic' to add an epic")
+		return nil
+	}
+
+	// Table header
+	fmt.Printf("%-6s %-6s %-50s %s\n", "ID", "TYPE", "TITLE", "STATE")
+	fmt.Println(strings.Repeat("-", 80))
+
+	for _, item := range items {
+		title := item.Title
+		if len(title) > 48 {
+			title = title[:45] + "..."
+		}
+		fmt.Printf("#%-5d %-6s %-50s %s\n", item.Number, item.Type, title, item.State)
+	}
+
+	return nil
+}
+
+func runQueueAdd(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	title := args[0]
+
+	description, err := cmd.Flags().GetString("description")
+	if err != nil {
+		return err
+	}
+
+	isEpic, err := cmd.Flags().GetBool("epic")
+	if err != nil {
+		return err
+	}
+
+	extraLabels, err := cmd.Flags().GetStringSlice("label")
+	if err != nil {
+		return err
+	}
+
+	// Build labels
+	var labels []string
+	if isEpic {
+		labels = append(labels, "epic")
+	} else {
+		labels = append(labels, "task")
+	}
+	labels = append(labels, extraLabels...)
+
+	// Create the issue
+	if err := createIssueWithLabels(ws.RootDir, title, description, labels); err != nil {
+		return fmt.Errorf("failed to create issue: %w", err)
+	}
+
+	itemType := "task"
+	if isEpic {
+		itemType = "epic"
+	}
+	fmt.Printf("Created %s: %s\n", itemType, title)
+
+	return nil
+}
+
+// getItemType returns "epic", "task", or "" based on issue labels and title.
+// Epic takes precedence over task when both labels are present.
+func getItemType(issue github.Issue) string {
+	// Check epic first so it takes precedence
+	for _, label := range issue.Labels {
+		if label == "epic" {
+			return "epic"
+		}
+	}
+	for _, label := range issue.Labels {
+		if label == "task" {
+			return "task"
+		}
+	}
+	// Fallback: check for [EPIC] prefix in title
+	if strings.HasPrefix(issue.Title, "[EPIC]") || strings.HasPrefix(issue.Title, "[Epic]") {
+		return "epic"
+	}
+	return ""
+}
+
+// createIssueWithLabels creates a GitHub issue with the specified labels.
+func createIssueWithLabels(workspacePath, title, body string, labels []string) error {
+	args := []string{"issue", "create", "--title", title}
+	if body != "" {
+		args = append(args, "--body", body)
+	}
+	for _, label := range labels {
+		args = append(args, "--label", label)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "gh", args...) //nolint:gosec // gh command with trusted args
+	cmd.Dir = workspacePath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/cmd/queue_test.go
+++ b/internal/cmd/queue_test.go
@@ -1,0 +1,161 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/github"
+)
+
+func TestGetItemType(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		issue    github.Issue
+	}{
+		{
+			name: "task label",
+			issue: github.Issue{
+				Title:  "Fix bug",
+				Labels: []string{"task"},
+			},
+			expected: "task",
+		},
+		{
+			name: "epic label",
+			issue: github.Issue{
+				Title:  "New feature",
+				Labels: []string{"epic"},
+			},
+			expected: "epic",
+		},
+		{
+			name: "EPIC prefix in title",
+			issue: github.Issue{
+				Title:  "[EPIC] Big feature",
+				Labels: []string{},
+			},
+			expected: "epic",
+		},
+		{
+			name: "Epic prefix in title",
+			issue: github.Issue{
+				Title:  "[Epic] Another feature",
+				Labels: []string{},
+			},
+			expected: "epic",
+		},
+		{
+			name: "no task or epic label",
+			issue: github.Issue{
+				Title:  "Random issue",
+				Labels: []string{"bug", "priority-high"},
+			},
+			expected: "",
+		},
+		{
+			name: "task label with others",
+			issue: github.Issue{
+				Title:  "Do something",
+				Labels: []string{"priority-high", "task", "v2"},
+			},
+			expected: "task",
+		},
+		{
+			name: "epic takes precedence",
+			issue: github.Issue{
+				Title:  "Both labels",
+				Labels: []string{"task", "epic"},
+			},
+			expected: "epic",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getItemType(tt.issue)
+			if result != tt.expected {
+				t.Errorf("getItemType() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestQueueCmdExists(t *testing.T) {
+	if queueCmd == nil {
+		t.Fatal("queueCmd should not be nil")
+	}
+	if queueCmd.Use != "queue" {
+		t.Errorf("queueCmd.Use = %q, want %q", queueCmd.Use, "queue")
+	}
+}
+
+func TestQueueListCmdExists(t *testing.T) {
+	if queueListCmd == nil {
+		t.Fatal("queueListCmd should not be nil")
+	}
+	if queueListCmd.Use != "list" {
+		t.Errorf("queueListCmd.Use = %q, want %q", queueListCmd.Use, "list")
+	}
+}
+
+func TestQueueAddCmdExists(t *testing.T) {
+	if queueAddCmd == nil {
+		t.Fatal("queueAddCmd should not be nil")
+	}
+	if queueAddCmd.Use != "add <title>" {
+		t.Errorf("queueAddCmd.Use = %q, want %q", queueAddCmd.Use, "add <title>")
+	}
+}
+
+func TestQueueAddCmdFlags(t *testing.T) {
+	// Check description flag
+	descFlag := queueAddCmd.Flags().Lookup("description")
+	if descFlag == nil {
+		t.Fatal("expected 'description' flag to exist")
+	}
+	if descFlag.Shorthand != "d" {
+		t.Errorf("description shorthand = %q, want %q", descFlag.Shorthand, "d")
+	}
+
+	// Check epic flag
+	epicFlag := queueAddCmd.Flags().Lookup("epic")
+	if epicFlag == nil {
+		t.Fatal("expected 'epic' flag to exist")
+	}
+
+	// Check label flag
+	labelFlag := queueAddCmd.Flags().Lookup("label")
+	if labelFlag == nil {
+		t.Fatal("expected 'label' flag to exist")
+	}
+}
+
+func TestQueueItemStruct(t *testing.T) {
+	item := QueueItem{
+		Number: 123,
+		Title:  "Test item",
+		Type:   "task",
+		State:  "OPEN",
+		Labels: []string{"task", "priority-high"},
+		URL:    "https://github.com/owner/repo/issues/123",
+	}
+
+	if item.Number != 123 {
+		t.Errorf("Number = %d, want 123", item.Number)
+	}
+	if item.Title != "Test item" {
+		t.Errorf("Title = %q, want %q", item.Title, "Test item")
+	}
+	if item.Type != "task" {
+		t.Errorf("Type = %q, want %q", item.Type, "task")
+	}
+	if item.State != "OPEN" {
+		t.Errorf("State = %q, want %q", item.State, "OPEN")
+	}
+	if len(item.Labels) != 2 {
+		t.Errorf("Labels length = %d, want 2", len(item.Labels))
+	}
+	if item.URL != "https://github.com/owner/repo/issues/123" {
+		t.Errorf("URL = %q, want %q", item.URL, "https://github.com/owner/repo/issues/123")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `bc queue` command for managing work queue items (tasks/epics)
- Lists GitHub Issues filtered by 'task' or 'epic' labels
- Supports `bc queue add <title>` to create new work items
- Flags: `--description/-d`, `--epic`, `--label`, `--json`

## Implementation Details

- Epic labels take precedence over task labels when both present
- Fallback detection for `[EPIC]` or `[Epic]` title prefix
- Uses GitHub Issues as backing store via `gh` CLI
- Follows existing patterns from `internal/cmd/channel.go`

## Features Implemented

### Issue #219 - Command Infrastructure
- Created `internal/cmd/queue.go` with cobra command structure
- `queueCmd` defaults to list behavior
- Registered with root command

### Issue #220 - Queue List
- `bc queue` and `bc queue list` display work items
- Table format: ID, TYPE, TITLE, STATE
- Sorted by number (newest first)
- Empty state message when no items

### Issue #221 - Queue Add
- `bc queue add "title"` creates GitHub issue with 'task' label
- `-d/--description` for issue body
- `--epic` flag creates with 'epic' label instead
- `--label` for additional labels

### Issue #222 - JSON Output
- `bc queue --json` outputs JSON array
- Includes: number, title, type, state, labels
- Pretty-printed with indentation

## Test Plan

- [x] Unit tests for `getItemType` function (7 test cases)
- [x] Tests for command existence and flags
- [x] Tests for QueueItem struct fields
- [x] All tests passing
- [x] Linter passing

Fixes #219, #220, #221, #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)