### PR TITLE
fix(queue): reject unknown subcommands (#264)

### DIFF
--- a/internal/cmd/queue.go
+++ b/internal/cmd/queue.go
@@ -27,6 +27,7 @@ Examples:
   bc queue list               # list all work items
   bc queue add "Fix bug"      # add a task to the queue
   bc queue add "New feature" --epic  # add an epic`,
+	Args: cobra.NoArgs,
 	RunE: runQueueList,
 }
 

--- a/internal/cmd/queue_test.go
+++ b/internal/cmd/queue_test.go
@@ -159,3 +159,16 @@ func TestQueueItemStruct(t *testing.T) {
 		t.Errorf("URL = %q, want %q", item.URL, "https://github.com/owner/repo/issues/123")
 	}
 }
+
+func TestQueueCmdRejectsUnknownSubcommands(t *testing.T) {
+	// queueCmd should have Args: cobra.NoArgs to reject unknown subcommands
+	if queueCmd.Args == nil {
+		t.Fatal("queueCmd should have Args validator set")
+	}
+
+	// Test that Args rejects extra arguments
+	err := queueCmd.Args(queueCmd, []string{"foobar"})
+	if err == nil {
+		t.Error("expected error for unknown subcommand 'foobar', got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `Args: cobra.NoArgs` to `queueCmd` to reject unknown subcommands
- Previously `bc queue foobar` silently ran `bc queue list`
- Now correctly shows error for unknown commands

## Test plan
- [x] Added test for Args validator
- [x] `go test ./internal/cmd/... -run Queue` passes
- [x] `go build ./...` passes

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)