### PR TITLE
feat(merge): add merge queue status display (#259)

### DIFF
--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -2,24 +2,29 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/workspace"
 )
 
 var (
 	mergeSkipTests bool
+	mergeStatus    bool
 )
 
 var mergeCmd = &cobra.Command{
-	Use:   "merge <agent-name|branch>",
+	Use:   "merge [agent-name|branch]",
 	Short: "Merge an agent branch into main after validation",
 	Long: `Merge an agent's work branch into main after running build, test, and vet checks.
 
@@ -28,26 +33,40 @@ The merge command:
   2. Runs go build, go test, go vet in the agent worktree
   3. Merges the branch into main (fast-forward or merge commit)
 
+Use --status to view pending merges and their state.
+
 Examples:
   bc merge engineer-01
-  bc merge fix/enter-submit-reliability --skip-tests`,
-	Args: cobra.ExactArgs(1),
+  bc merge fix/enter-submit-reliability --skip-tests
+  bc merge --status              # Show merge queue status
+  bc merge --status --json       # JSON output`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runMerge,
 }
 
 func init() {
 	mergeCmd.Flags().BoolVar(&mergeSkipTests, "skip-tests", false, "Skip build/test/vet validation")
+	mergeCmd.Flags().BoolVar(&mergeStatus, "status", false, "Show merge queue status")
 	rootCmd.AddCommand(mergeCmd)
 }
 
 func runMerge(cmd *cobra.Command, args []string) error {
-	target := args[0]
-
 	ws, err := getWorkspace()
 	if err != nil {
 		return fmt.Errorf("not in a bc workspace: %w", err)
 	}
 
+	// Handle --status flag
+	if mergeStatus {
+		return runMergeStatus(cmd, ws)
+	}
+
+	// Require target for actual merge
+	if len(args) == 0 {
+		return fmt.Errorf("requires agent-name or branch argument (use --status to view queue)")
+	}
+
+	target := args[0]
 	rootDir := ws.RootDir
 
 	// Determine the branch to merge. If target matches an agent name,
@@ -330,5 +349,114 @@ func rollbackMerge(repoDir, restorePoint string) error {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("update-ref failed: %s", strings.TrimSpace(string(out)))
 	}
+	return nil
+}
+
+// MergeQueueItem represents a pending or in-progress merge.
+type MergeQueueItem struct {
+	StartedAt   time.Time `json:"started_at,omitempty"`
+	Agent       string    `json:"agent"`
+	Branch      string    `json:"branch"`
+	Target      string    `json:"target"`
+	State       string    `json:"state"` // pending, in-progress, blocked
+	HasConflict bool      `json:"has_conflict,omitempty"`
+}
+
+// runMergeStatus displays the merge queue status.
+func runMergeStatus(cmd *cobra.Command, ws *workspace.Workspace) error {
+	rootDir := ws.RootDir
+	agentsDir := ws.AgentsDir()
+
+	// Load agents
+	mgr := agent.NewWorkspaceManager(agentsDir, rootDir)
+	if err := mgr.LoadState(); err != nil {
+		log.Warn("failed to load agent state", "error", err)
+	}
+
+	agents := mgr.ListAgents()
+	var items []MergeQueueItem
+
+	// Check each agent for mergeable branches
+	for _, a := range agents {
+		if a.State == agent.StateStopped || a.State == agent.StateError {
+			continue
+		}
+
+		// Get agent's worktree directory
+		wDir := a.WorktreeDir
+		if wDir == "" {
+			wDir = filepath.Join(rootDir, ".bc", "worktrees", a.Name)
+		}
+
+		// Check if worktree exists
+		if _, err := os.Stat(wDir); os.IsNotExist(err) {
+			continue
+		}
+
+		// Get current branch
+		branch, err := gitCurrentBranch(wDir)
+		if err != nil {
+			continue
+		}
+
+		// Skip if on main
+		if branch == "main" {
+			continue
+		}
+
+		// Check for conflicts
+		conflicts, err := checkMergeConflicts(rootDir, branch)
+		hasConflict := err == nil && len(conflicts) > 0
+
+		state := "pending"
+		if hasConflict {
+			state = "blocked"
+		}
+		if a.State == agent.StateWorking {
+			state = "in-progress"
+		}
+
+		items = append(items, MergeQueueItem{
+			Agent:       a.Name,
+			Branch:      branch,
+			Target:      "main",
+			State:       state,
+			HasConflict: hasConflict,
+		})
+	}
+
+	// Check for JSON output
+	jsonOutput, err := cmd.Flags().GetBool("json")
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(items)
+	}
+
+	// Display table format
+	if len(items) == 0 {
+		fmt.Println("No pending merges")
+		return nil
+	}
+
+	fmt.Printf("%-15s %-40s %-10s %s\n", "AGENT", "BRANCH", "TARGET", "STATE")
+	fmt.Println(strings.Repeat("-", 75))
+
+	for _, item := range items {
+		branch := item.Branch
+		if len(branch) > 38 {
+			branch = branch[:35] + "..."
+		}
+		stateDisplay := item.State
+		if item.HasConflict {
+			stateDisplay = "blocked (conflicts)"
+		}
+		fmt.Printf("%-15s %-40s %-10s %s\n", item.Agent, branch, item.Target, stateDisplay)
+	}
+
 	return nil
 }

--- a/internal/cmd/merge_test.go
+++ b/internal/cmd/merge_test.go
@@ -423,3 +423,79 @@ func TestRollbackMerge_InvalidRestorePoint(t *testing.T) {
 		t.Error("expected error for invalid restore point")
 	}
 }
+
+// --- MergeQueueItem tests ---
+
+func TestMergeQueueItem_Struct(t *testing.T) {
+	item := MergeQueueItem{
+		Agent:       "engineer-01",
+		Branch:      "engineer-01/issue-123/fix-bug",
+		Target:      "main",
+		State:       "pending",
+		HasConflict: false,
+	}
+
+	if item.Agent != "engineer-01" {
+		t.Errorf("Agent = %q, want %q", item.Agent, "engineer-01")
+	}
+	if item.Branch != "engineer-01/issue-123/fix-bug" {
+		t.Errorf("Branch = %q, want %q", item.Branch, "engineer-01/issue-123/fix-bug")
+	}
+	if item.Target != "main" {
+		t.Errorf("Target = %q, want %q", item.Target, "main")
+	}
+	if item.State != "pending" {
+		t.Errorf("State = %q, want %q", item.State, "pending")
+	}
+	if item.HasConflict {
+		t.Error("HasConflict should be false")
+	}
+}
+
+func TestMergeQueueItem_JSON(t *testing.T) {
+	item := MergeQueueItem{
+		Agent:       "engineer-02",
+		Branch:      "feature/test",
+		Target:      "main",
+		State:       "blocked",
+		HasConflict: true,
+	}
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var decoded MergeQueueItem
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	if decoded.Agent != item.Agent {
+		t.Errorf("Agent = %q, want %q", decoded.Agent, item.Agent)
+	}
+	if decoded.HasConflict != item.HasConflict {
+		t.Errorf("HasConflict = %v, want %v", decoded.HasConflict, item.HasConflict)
+	}
+}
+
+func TestMergeStatus_NoWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err = os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	_, err = executeCmd("merge", "--status")
+	if err == nil {
+		t.Fatal("expected error when not in workspace")
+	}
+	if !strings.Contains(err.Error(), "not in a bc workspace") {
+		t.Errorf("expected workspace error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--status` flag to `bc merge` command
- Shows pending merges with agent, branch, target, and state
- Detects conflicts and marks merges as "blocked"
- Supports `--json` flag for machine-readable output

## Usage
```bash
bc merge --status              # Show merge queue status
bc merge --status --json       # JSON output
```

## Output Example
```
AGENT           BRANCH                                   TARGET     STATE
---------------------------------------------------------------------------
engineer-01     engineer-01/issue-123/fix-bug            main       pending
engineer-02     engineer-02/feature-xyz                  main       blocked (conflicts)
```

## Test plan
- [x] `TestMergeQueueItem_Struct` - verifies struct fields
- [x] `TestMergeQueueItem_JSON` - verifies JSON serialization
- [x] `TestMergeStatus_NoWorkspace` - verifies error handling
- [x] All existing merge tests still pass

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)