### PR TITLE
feat(memory): load and inject agent memories at spawn

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rpuneet/bc/config"
 	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/memory"
 	"github.com/rpuneet/bc/pkg/tmux"
 )
 
@@ -507,10 +508,32 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 	agent.UpdatedAt = time.Now()
 	m.agents[name] = agent
 
-	// Send role prompt as bootstrap if memory was loaded
+	// Build bootstrap prompt with role prompt and agent memories
+	var promptParts []string
+
+	// Add role prompt if available
 	if agent.Memory != nil && agent.Memory.RolePrompt != "" {
-		// Append workspace info to the prompt
-		prompt := agent.Memory.RolePrompt + fmt.Sprintf("\n\n---\n\nWorkspace: %s\nAgent ID: %s\n", workspace, name)
+		promptParts = append(promptParts, agent.Memory.RolePrompt)
+	}
+
+	// Load and inject agent memories from .bc/memory/<agent-name>/
+	if agent.MemoryDir != "" {
+		memStore := memory.NewStore(workspace, name)
+		if memStore.Exists() {
+			memCtx, memErr := memStore.GetMemoryContext(memory.DefaultMemoryLimit)
+			if memErr != nil {
+				log.Warn("failed to load agent memories", "agent", name, "error", memErr)
+			} else if memCtx != "" {
+				promptParts = append(promptParts, memCtx)
+				log.Debug("injected agent memories", "agent", name)
+			}
+		}
+	}
+
+	// Send bootstrap prompt if we have content
+	if len(promptParts) > 0 {
+		prompt := strings.Join(promptParts, "\n\n---\n\n")
+		prompt += fmt.Sprintf("\n\n---\n\nWorkspace: %s\nAgent ID: %s\n", workspace, name)
 		if err := m.tmux.SendKeys(name, prompt); err != nil {
 			log.Warn("failed to send bootstrap prompt", "agent", name, "error", err)
 		}

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -178,4 +179,64 @@ func splitLines(data []byte) [][]byte {
 		lines = append(lines, data[start:])
 	}
 	return lines
+}
+
+// DefaultMemoryLimit is the default number of recent experiences to include.
+const DefaultMemoryLimit = 10
+
+// GetMemoryContext returns formatted memories suitable for prompt injection.
+// It loads the most recent experiences (up to limit) and all learnings,
+// formatting them for inclusion in an agent's context.
+// Returns empty string if no memories exist (new agent).
+func (s *Store) GetMemoryContext(limit int) (string, error) {
+	if limit <= 0 {
+		limit = DefaultMemoryLimit
+	}
+
+	var parts []string
+
+	// Load experiences (most recent first)
+	experiences, err := s.GetExperiences()
+	if err != nil {
+		return "", fmt.Errorf("failed to load experiences: %w", err)
+	}
+
+	if len(experiences) > 0 {
+		// Get the most recent experiences
+		start := 0
+		if len(experiences) > limit {
+			start = len(experiences) - limit
+		}
+		recentExperiences := experiences[start:]
+
+		parts = append(parts, "## Recent Experiences\n")
+		for _, exp := range recentExperiences {
+			entry := fmt.Sprintf("- **%s** (%s): %s",
+				exp.TaskType, exp.Outcome, exp.Description)
+			if len(exp.Learnings) > 0 {
+				entry += "\n  Learnings: " + exp.Learnings[0]
+			}
+			parts = append(parts, entry)
+		}
+		parts = append(parts, "")
+	}
+
+	// Load learnings
+	learnings, err := s.GetLearnings()
+	if err != nil {
+		return "", fmt.Errorf("failed to load learnings: %w", err)
+	}
+
+	// Only include learnings if there's meaningful content beyond the header
+	if learnings != "" && len(learnings) > 100 {
+		parts = append(parts, "## Key Learnings\n")
+		parts = append(parts, learnings)
+	}
+
+	if len(parts) == 0 {
+		return "", nil // No memories - new agent
+	}
+
+	header := "# Agent Memory\n\nThe following is your accumulated experience and learnings from previous tasks:\n\n"
+	return header + strings.Join(parts, "\n"), nil
 }

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -387,3 +387,166 @@ func containsHelper(s, substr string) bool {
 	}
 	return false
 }
+
+func TestStore_GetMemoryContext_Empty(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// New agent with no memories should return empty string
+	ctx, err := store.GetMemoryContext(DefaultMemoryLimit)
+	if err != nil {
+		t.Fatalf("GetMemoryContext failed: %v", err)
+	}
+
+	if ctx != "" {
+		t.Errorf("expected empty context for new agent, got %q", ctx)
+	}
+}
+
+func TestStore_GetMemoryContext_WithExperiences(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add some experiences
+	for i := 0; i < 3; i++ {
+		exp := Experience{
+			TaskType:    "code",
+			Description: "Implemented feature " + string(rune('A'+i)),
+			Outcome:     "success",
+			Learnings:   []string{"Learning " + string(rune('A'+i))},
+		}
+		if err := store.RecordExperience(exp); err != nil {
+			t.Fatalf("failed to record experience: %v", err)
+		}
+	}
+
+	ctx, err := store.GetMemoryContext(DefaultMemoryLimit)
+	if err != nil {
+		t.Fatalf("GetMemoryContext failed: %v", err)
+	}
+
+	// Should contain header
+	if !contains(ctx, "# Agent Memory") {
+		t.Error("context should contain header")
+	}
+
+	// Should contain experiences section
+	if !contains(ctx, "## Recent Experiences") {
+		t.Error("context should contain experiences section")
+	}
+
+	// Should contain experience content
+	if !contains(ctx, "Implemented feature A") {
+		t.Error("context should contain experience description")
+	}
+}
+
+func TestStore_GetMemoryContext_Limit(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add 15 experiences
+	for i := 0; i < 15; i++ {
+		exp := Experience{
+			TaskType:    "code",
+			Description: "Task " + string(rune('A'+i)),
+			Outcome:     "success",
+		}
+		if err := store.RecordExperience(exp); err != nil {
+			t.Fatalf("failed to record experience: %v", err)
+		}
+	}
+
+	// With limit of 5, should only include last 5 experiences
+	ctx, err := store.GetMemoryContext(5)
+	if err != nil {
+		t.Fatalf("GetMemoryContext failed: %v", err)
+	}
+
+	// Should contain later experiences (K, L, M, N, O)
+	if !contains(ctx, "Task O") {
+		t.Error("context should contain most recent task (O)")
+	}
+
+	// Should NOT contain early experiences (A, B, C)
+	if contains(ctx, "Task A") {
+		t.Error("context should NOT contain old task (A) when limited")
+	}
+}
+
+func TestStore_GetMemoryContext_WithLearnings(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add substantial learnings
+	for i := 0; i < 5; i++ {
+		if err := store.AddLearning("Category "+string(rune('A'+i)), "Important learning about topic "+string(rune('A'+i))); err != nil {
+			t.Fatalf("failed to add learning: %v", err)
+		}
+	}
+
+	ctx, err := store.GetMemoryContext(DefaultMemoryLimit)
+	if err != nil {
+		t.Fatalf("GetMemoryContext failed: %v", err)
+	}
+
+	// Should contain learnings section
+	if !contains(ctx, "## Key Learnings") {
+		t.Error("context should contain learnings section")
+	}
+}
+
+func TestStore_GetMemoryContext_DefaultLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add an experience
+	exp := Experience{
+		TaskType:    "code",
+		Description: "Test task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(exp); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	// Passing 0 should use default limit
+	ctx, err := store.GetMemoryContext(0)
+	if err != nil {
+		t.Fatalf("GetMemoryContext failed: %v", err)
+	}
+
+	if !contains(ctx, "Test task") {
+		t.Error("context should contain the experience with default limit")
+	}
+}
+
+func TestStore_GetMemoryContext_NonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "nonexistent-agent")
+
+	// Store doesn't exist - should return empty without error
+	ctx, err := store.GetMemoryContext(DefaultMemoryLimit)
+	if err != nil {
+		t.Fatalf("GetMemoryContext should not error for nonexistent store: %v", err)
+	}
+
+	if ctx != "" {
+		t.Errorf("expected empty context for nonexistent agent, got %q", ctx)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `GetMemoryContext(limit int)` function to memory package that formats recent experiences and learnings for prompt injection
- Integrate with agent spawn flow to automatically inject memories when an agent is created
- Configurable limit to avoid context bloat (default: 10 recent experiences)
- Works for new agents (returns empty string if no memories exist)

## Test plan

- [x] Run `go test ./pkg/memory/...` - 21 tests pass
- [x] Run `go test ./pkg/agent/...` - all tests pass
- [x] Run `golangci-lint run` - 0 issues
- [ ] Manual test: spawn an agent, verify memories are injected in prompt

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)