### PR TITLE
feat(memory): add relevance ranking to memory search

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -4,12 +4,23 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/memory"
 )
+
+// SearchResult represents a ranked search result.
+type SearchResult struct {
+	AgentID    string
+	Source     string // "experience" or "learning"
+	Content    string
+	Context    string // additional context (outcome, task type, etc.)
+	Score      int    // relevance score (higher = more relevant)
+	LineNumber int    // for learnings: line number in file
+}
 
 var memoryCmd = &cobra.Command{
 	Use:   "memory",
@@ -295,23 +306,31 @@ func runMemorySearch(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	found := false
+	// Collect and score all results
+	var results []SearchResult
+
 	for _, agentID := range agents {
 		store := memory.NewStore(ws.RootDir, agentID)
 
 		// Search experiences
 		experiences, _ := store.GetExperiences()
 		for _, exp := range experiences {
-			if strings.Contains(strings.ToLower(exp.Description), query) ||
-				strings.Contains(strings.ToLower(exp.Outcome), query) {
-				if !found {
-					cmd.Println("=== Search Results ===")
-					cmd.Println()
-					found = true
+			score := scoreExperience(exp, query)
+			if score > 0 {
+				context := fmt.Sprintf("Outcome: %s", exp.Outcome)
+				if exp.TaskType != "" {
+					context += fmt.Sprintf(", Type: %s", exp.TaskType)
 				}
-				cmd.Printf("[%s] Experience: %s\n", agentID, exp.Description)
-				cmd.Printf("  Outcome: %s\n", exp.Outcome)
-				cmd.Println()
+				if exp.TaskID != "" {
+					context += fmt.Sprintf(", Task: %s", exp.TaskID)
+				}
+				results = append(results, SearchResult{
+					AgentID: agentID,
+					Source:  "experience",
+					Content: exp.Description,
+					Context: context,
+					Score:   score,
+				})
 			}
 		}
 
@@ -319,21 +338,119 @@ func runMemorySearch(cmd *cobra.Command, args []string) error {
 		learnings, _ := store.GetLearnings()
 		lines := strings.Split(learnings, "\n")
 		for i, line := range lines {
-			if strings.Contains(strings.ToLower(line), query) {
-				if !found {
-					cmd.Println("=== Search Results ===")
-					cmd.Println()
-					found = true
-				}
-				// Print context: the line and surrounding lines
-				cmd.Printf("[%s] Learnings (line %d): %s\n\n", agentID, i+1, strings.TrimSpace(line))
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			score := scoreLearning(trimmed, query)
+			if score > 0 {
+				results = append(results, SearchResult{
+					AgentID:    agentID,
+					Source:     "learning",
+					Content:    trimmed,
+					LineNumber: i + 1,
+					Score:      score,
+				})
 			}
 		}
 	}
 
-	if !found {
+	if len(results) == 0 {
 		cmd.Printf("No results found for '%s'\n", args[0])
+		return nil
+	}
+
+	// Sort by score (highest first)
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+
+	// Display ranked results
+	cmd.Printf("=== Search Results for '%s' (%d found) ===\n\n", args[0], len(results))
+
+	for i, r := range results {
+		if r.Source == "experience" {
+			cmd.Printf("%d. [%s] Experience (score: %d)\n", i+1, r.AgentID, r.Score)
+			cmd.Printf("   %s\n", r.Content)
+			cmd.Printf("   %s\n\n", r.Context)
+		} else {
+			cmd.Printf("%d. [%s] Learning (score: %d, line %d)\n", i+1, r.AgentID, r.Score, r.LineNumber)
+			cmd.Printf("   %s\n\n", r.Content)
+		}
 	}
 
 	return nil
+}
+
+// scoreExperience calculates relevance score for an experience.
+// Higher score = more relevant. Returns 0 if no match.
+func scoreExperience(exp memory.Experience, query string) int {
+	score := 0
+
+	// Check description (highest weight)
+	descLower := strings.ToLower(exp.Description)
+	if strings.Contains(descLower, query) {
+		score += 10
+		// Bonus for exact word match
+		if strings.Contains(descLower, " "+query+" ") ||
+			strings.HasPrefix(descLower, query+" ") ||
+			strings.HasSuffix(descLower, " "+query) {
+			score += 5
+		}
+	}
+
+	// Check outcome
+	if strings.Contains(strings.ToLower(exp.Outcome), query) {
+		score += 3
+	}
+
+	// Check task type
+	if strings.Contains(strings.ToLower(exp.TaskType), query) {
+		score += 5
+	}
+
+	// Check task ID
+	if strings.Contains(strings.ToLower(exp.TaskID), query) {
+		score += 5
+	}
+
+	// Check learnings in experience
+	for _, learning := range exp.Learnings {
+		if strings.Contains(strings.ToLower(learning), query) {
+			score += 7
+		}
+	}
+
+	return score
+}
+
+// scoreLearning calculates relevance score for a learning line.
+// Higher score = more relevant. Returns 0 if no match.
+func scoreLearning(line, query string) int {
+	lineLower := strings.ToLower(line)
+	if !strings.Contains(lineLower, query) {
+		return 0
+	}
+
+	score := 5
+
+	// Bonus for header lines (categories)
+	if strings.HasPrefix(line, "##") {
+		score += 3
+	}
+
+	// Bonus for exact word match
+	if strings.Contains(lineLower, " "+query+" ") ||
+		strings.HasPrefix(lineLower, query+" ") ||
+		strings.HasSuffix(lineLower, " "+query) {
+		score += 5
+	}
+
+	// Bonus for multiple occurrences
+	count := strings.Count(lineLower, query)
+	if count > 1 {
+		score += count - 1
+	}
+
+	return score
 }

--- a/internal/cmd/memory_test.go
+++ b/internal/cmd/memory_test.go
@@ -266,3 +266,222 @@ func TestMemoryLearnRejectsEmptyLearning(t *testing.T) {
 		t.Errorf("error should mention empty learning: %v", err)
 	}
 }
+
+func TestMemorySearchRankedResults(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create memory with multiple experiences to test ranking
+	store := memory.NewStore(wsDir, "ranked-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Experience with auth in description (should rank higher)
+	if err := store.RecordExperience(memory.Experience{
+		Description: "Fixed authentication auth flow",
+		Outcome:     "success",
+		TaskType:    "bugfix",
+	}); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	// Experience with auth in task type only (lower rank)
+	if err := store.RecordExperience(memory.Experience{
+		Description: "Updated login page",
+		Outcome:     "success",
+		TaskType:    "auth",
+	}); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	output, err := executeCmd("memory", "search", "auth")
+	if err != nil {
+		t.Fatalf("memory search failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should show count of results
+	if !strings.Contains(output, "2 found") {
+		t.Errorf("output should show result count: %s", output)
+	}
+
+	// Should show score
+	if !strings.Contains(output, "score:") {
+		t.Errorf("output should show relevance score: %s", output)
+	}
+
+	// First result should have higher score (auth in description)
+	if !strings.Contains(output, "1. [ranked-agent]") {
+		t.Errorf("output should number results: %s", output)
+	}
+}
+
+func TestMemorySearchMultipleAgents(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create memories for two agents
+	store1 := memory.NewStore(wsDir, "agent-one")
+	if err := store1.Init(); err != nil {
+		t.Fatalf("failed to init store1: %v", err)
+	}
+	if err := store1.RecordExperience(memory.Experience{
+		Description: "Fixed auth bug in agent one",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("failed to record: %v", err)
+	}
+
+	store2 := memory.NewStore(wsDir, "agent-two")
+	if err := store2.Init(); err != nil {
+		t.Fatalf("failed to init store2: %v", err)
+	}
+	if err := store2.RecordExperience(memory.Experience{
+		Description: "Auth system redesign",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("failed to record: %v", err)
+	}
+
+	output, err := executeCmd("memory", "search", "auth")
+	if err != nil {
+		t.Fatalf("memory search failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should find results from both agents
+	if !strings.Contains(output, "agent-one") {
+		t.Errorf("output should contain agent-one: %s", output)
+	}
+	if !strings.Contains(output, "agent-two") {
+		t.Errorf("output should contain agent-two: %s", output)
+	}
+}
+
+func TestMemorySearchSpecificAgent(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create memories for two agents
+	store1 := memory.NewStore(wsDir, "target-agent")
+	if err := store1.Init(); err != nil {
+		t.Fatalf("failed to init store1: %v", err)
+	}
+	if err := store1.RecordExperience(memory.Experience{
+		Description: "Fixed bug in target",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("failed to record: %v", err)
+	}
+
+	store2 := memory.NewStore(wsDir, "other-agent")
+	if err := store2.Init(); err != nil {
+		t.Fatalf("failed to init store2: %v", err)
+	}
+	if err := store2.RecordExperience(memory.Experience{
+		Description: "Fixed bug in other",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("failed to record: %v", err)
+	}
+
+	// Search only target-agent
+	output, err := executeCmd("memory", "search", "--agent", "target-agent", "bug")
+	if err != nil {
+		t.Fatalf("memory search failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should only find target-agent
+	if !strings.Contains(output, "target-agent") {
+		t.Errorf("output should contain target-agent: %s", output)
+	}
+	if strings.Contains(output, "other-agent") {
+		t.Errorf("output should NOT contain other-agent: %s", output)
+	}
+}
+
+func TestScoreExperience(t *testing.T) {
+	tests := []struct { //nolint:govet // test struct alignment doesn't matter
+		name     string
+		exp      memory.Experience
+		query    string
+		minScore int
+	}{
+		{
+			name: "match in description",
+			exp: memory.Experience{
+				Description: "Fixed authentication bug",
+			},
+			query:    "auth",
+			minScore: 10,
+		},
+		{
+			name: "match in task type",
+			exp: memory.Experience{
+				Description: "Updated login",
+				TaskType:    "auth",
+			},
+			query:    "auth",
+			minScore: 5,
+		},
+		{
+			name: "match in outcome",
+			exp: memory.Experience{
+				Description: "Some task",
+				Outcome:     "auth failed",
+			},
+			query:    "auth",
+			minScore: 3,
+		},
+		{
+			name: "no match",
+			exp: memory.Experience{
+				Description: "Updated UI",
+			},
+			query:    "auth",
+			minScore: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := scoreExperience(tt.exp, tt.query)
+			if score < tt.minScore {
+				t.Errorf("scoreExperience() = %d, want >= %d", score, tt.minScore)
+			}
+		})
+	}
+}
+
+func TestScoreLearning(t *testing.T) {
+	tests := []struct {
+		name     string
+		line     string
+		query    string
+		minScore int
+	}{
+		{
+			name:     "simple match",
+			line:     "Always check authentication",
+			query:    "auth",
+			minScore: 5,
+		},
+		{
+			name:     "header match",
+			line:     "## Authentication Patterns",
+			query:    "auth",
+			minScore: 8, // 5 + 3 for header
+		},
+		{
+			name:     "no match",
+			line:     "Some other content",
+			query:    "auth",
+			minScore: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			score := scoreLearning(tt.line, tt.query)
+			if score < tt.minScore {
+				t.Errorf("scoreLearning() = %d, want >= %d", score, tt.minScore)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `SearchResult` struct with relevance scoring
- Score experiences by field importance (description: 10pts, task type: 5pts, outcome: 3pts)
- Score learnings with bonus for headers and exact word matches
- Sort results by relevance score (highest first)
- Display score and result count in output

## Test plan

- [x] Run `go test ./internal/cmd/... -run Memory` - 18 tests pass
- [x] Run `golangci-lint run` - 0 issues
- [ ] Manual test: `bc memory search "auth"` shows ranked results

Closes #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)