### PR TITLE
feat(merge): add conflict notification to agents (#257)

### DIFF
--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/agent"
+	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
 )
@@ -117,6 +119,12 @@ func runMerge(cmd *cobra.Command, args []string) error {
 		for _, f := range conflicts {
 			fmt.Printf("  - %s\n", f)
 		}
+
+		// Notify the responsible agent about the conflicts
+		if notifyErr := notifyConflicts(rootDir, branch, conflicts); notifyErr != nil {
+			log.Warn("failed to send conflict notification", "error", notifyErr)
+		}
+
 		if mergeDryRun {
 			return fmt.Errorf("dry-run: branch %s has %d conflicting file(s) with main", branch, len(conflicts))
 		}
@@ -429,4 +437,111 @@ func rebaseBranchOntoMain(worktreeDir string) error {
 	}
 
 	return nil
+}
+
+// notifyConflicts sends a notification to the agent responsible for the conflicts.
+// It identifies the agent from the branch name and sends a channel notification
+// with conflict details and resolution steps.
+func notifyConflicts(rootDir, branch string, conflicts []string) error {
+	// Get the branch head commit for context
+	branchHead, err := gitRevParse(rootDir, branch)
+	if err != nil {
+		branchHead = "unknown"
+	}
+
+	mainHead, err := gitRevParse(rootDir, "main")
+	if err != nil {
+		mainHead = "unknown"
+	}
+
+	// Identify the agent from the branch name (e.g., engineer-01/issue-123/feature)
+	responsibleAgent := extractAgentFromBranch(branch)
+
+	// Build notification message
+	var sb strings.Builder
+	sb.WriteString("⚠️ **Merge Conflict Detected**\n\n")
+	sb.WriteString(fmt.Sprintf("Branch `%s` has conflicts with `main`.\n\n", branch))
+	sb.WriteString("**Conflicting files:**\n")
+	for _, f := range conflicts {
+		sb.WriteString(fmt.Sprintf("  - `%s`\n", f))
+	}
+	sb.WriteString("\n**Commit details:**\n")
+	sb.WriteString(fmt.Sprintf("  - Branch HEAD: `%s`\n", truncateSHA(branchHead)))
+	sb.WriteString(fmt.Sprintf("  - Main HEAD: `%s`\n", truncateSHA(mainHead)))
+	sb.WriteString("\n**Resolution steps:**\n")
+	sb.WriteString("1. `git fetch origin main`\n")
+	sb.WriteString("2. `git rebase origin/main`\n")
+	sb.WriteString("3. Resolve conflicts in listed files\n")
+	sb.WriteString("4. `git add .`\n")
+	sb.WriteString("5. `git rebase --continue`\n")
+	sb.WriteString("6. `git push --force-with-lease`\n")
+
+	message := sb.String()
+
+	// Load channel store and send notification
+	store := channel.NewStore(rootDir)
+	if err := store.Load(); err != nil {
+		return fmt.Errorf("failed to load channel store: %w", err)
+	}
+
+	// Determine which channel to notify
+	// Priority: engineering channel if available, otherwise all channel
+	notifyChannel := "engineering"
+	if _, exists := store.Get(notifyChannel); !exists {
+		notifyChannel = "all"
+		if _, exists := store.Get(notifyChannel); !exists {
+			// Create all channel if it doesn't exist
+			if _, err := store.Create("all"); err != nil {
+				return fmt.Errorf("failed to create all channel: %w", err)
+			}
+		}
+	}
+
+	// Add message to channel history
+	sender := "merge-bot"
+	if envSender := os.Getenv("BC_AGENT_ID"); envSender != "" {
+		sender = envSender
+	}
+
+	if err := store.AddHistory(notifyChannel, sender, message); err != nil {
+		return fmt.Errorf("failed to add conflict notification to history: %w", err)
+	}
+
+	if err := store.Save(); err != nil {
+		return fmt.Errorf("failed to save channel store: %w", err)
+	}
+
+	fmt.Printf("  Conflict notification sent to #%s", notifyChannel)
+	if responsibleAgent != "" {
+		fmt.Printf(" (responsible: @%s)", responsibleAgent)
+	}
+	fmt.Println()
+
+	return nil
+}
+
+// extractAgentFromBranch extracts the agent name from a branch name.
+// Branch naming convention: agent-name/issue-XXX/description
+func extractAgentFromBranch(branch string) string {
+	parts := strings.SplitN(branch, "/", 2)
+	if len(parts) > 0 {
+		// Check if the first part looks like an agent name
+		agentName := parts[0]
+		if strings.HasPrefix(agentName, "engineer-") ||
+			strings.HasPrefix(agentName, "tech-lead-") ||
+			strings.HasPrefix(agentName, "qa-") ||
+			agentName == "coordinator" ||
+			agentName == "manager" {
+			return agentName
+		}
+	}
+	return ""
+}
+
+// truncateSHA returns the first 12 characters of a SHA, or the full string if shorter.
+func truncateSHA(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
 }

--- a/internal/cmd/merge_test.go
+++ b/internal/cmd/merge_test.go
@@ -521,3 +521,158 @@ func TestIsBranchStale_BehindMain(t *testing.T) {
 		t.Errorf("expected 1 commit behind, got %d", count)
 	}
 }
+
+// --- extractAgentFromBranch tests ---
+
+func TestExtractAgentFromBranch(t *testing.T) {
+	tests := []struct {
+		name     string
+		branch   string
+		expected string
+	}{
+		{
+			name:     "engineer branch",
+			branch:   "engineer-01/issue-123/feature",
+			expected: "engineer-01",
+		},
+		{
+			name:     "tech-lead branch",
+			branch:   "tech-lead-02/issue-456/fix",
+			expected: "tech-lead-02",
+		},
+		{
+			name:     "qa branch",
+			branch:   "qa-01/issue-789/test",
+			expected: "qa-01",
+		},
+		{
+			name:     "coordinator branch",
+			branch:   "coordinator/issue-100/update",
+			expected: "coordinator",
+		},
+		{
+			name:     "manager branch",
+			branch:   "manager/issue-200/config",
+			expected: "manager",
+		},
+		{
+			name:     "feature branch without agent",
+			branch:   "feature/add-login",
+			expected: "",
+		},
+		{
+			name:     "fix branch without agent",
+			branch:   "fix/bug-123",
+			expected: "",
+		},
+		{
+			name:     "simple branch name",
+			branch:   "main",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractAgentFromBranch(tt.branch)
+			if result != tt.expected {
+				t.Errorf("extractAgentFromBranch(%q) = %q, want %q", tt.branch, result, tt.expected)
+			}
+		})
+	}
+}
+
+// --- truncateSHA tests ---
+
+func TestTruncateSHA(t *testing.T) {
+	tests := []struct {
+		name     string
+		sha      string
+		expected string
+	}{
+		{
+			name:     "full SHA",
+			sha:      "abc123def456789012345678901234567890",
+			expected: "abc123def456",
+		},
+		{
+			name:     "short SHA",
+			sha:      "abc123",
+			expected: "abc123",
+		},
+		{
+			name:     "exactly 12 chars",
+			sha:      "abc123def456",
+			expected: "abc123def456",
+		},
+		{
+			name:     "empty",
+			sha:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := truncateSHA(tt.sha)
+			if result != tt.expected {
+				t.Errorf("truncateSHA(%q) = %q, want %q", tt.sha, result, tt.expected)
+			}
+		})
+	}
+}
+
+// --- notifyConflicts tests ---
+
+func TestNotifyConflicts_CreatesChannelMessage(t *testing.T) {
+	// Create a temp directory with workspace structure
+	tmpDir := t.TempDir()
+	bcDir := filepath.Join(tmpDir, ".bc")
+	if err := os.MkdirAll(bcDir, 0750); err != nil {
+		t.Fatalf("failed to create .bc dir: %v", err)
+	}
+
+	// Initialize a git repo for gitRevParse to work
+	cmds := [][]string{
+		{"git", "init", "-b", "main", tmpDir},
+		{"git", "-C", tmpDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", tmpDir, "config", "user.name", "Test"},
+		{"git", "-C", tmpDir, "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...) //nolint:gosec,noctx // G204: test helper
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s failed: %v (%s)", strings.Join(args, " "), err, out)
+		}
+	}
+
+	// Create a feature branch
+	exec.Command("git", "-C", tmpDir, "checkout", "-b", "engineer-04/issue-257/conflict-notify").Run() //nolint:errcheck,gosec,noctx
+	exec.Command("git", "-C", tmpDir, "commit", "--allow-empty", "-m", "feature").Run()                //nolint:errcheck,gosec,noctx
+	exec.Command("git", "-C", tmpDir, "checkout", "main").Run()                                        //nolint:errcheck,gosec,noctx
+
+	// Call notifyConflicts
+	conflicts := []string{"pkg/merge/merge.go", "internal/cmd/merge.go"}
+	err := notifyConflicts(tmpDir, "engineer-04/issue-257/conflict-notify", conflicts)
+	if err != nil {
+		t.Fatalf("notifyConflicts failed: %v", err)
+	}
+
+	// Verify channel file was created with notification
+	channelFile := filepath.Join(bcDir, "channels.json")
+	data, err := os.ReadFile(channelFile) //nolint:gosec // G304: test file with controlled path
+	if err != nil {
+		t.Fatalf("failed to read channels file: %v", err)
+	}
+
+	// Check that the notification message is in the file
+	if !strings.Contains(string(data), "Merge Conflict Detected") {
+		t.Error("expected 'Merge Conflict Detected' in channel history")
+	}
+	if !strings.Contains(string(data), "pkg/merge/merge.go") {
+		t.Error("expected conflicting file in channel history")
+	}
+	if !strings.Contains(string(data), "Resolution steps") {
+		t.Error("expected resolution steps in channel history")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `notifyConflicts` function to send channel notifications when merge conflicts are detected
- Identifies responsible agent from branch naming convention (e.g., `engineer-01/issue-XXX/description`)
- Includes conflicting files, commit SHAs, and step-by-step resolution instructions in notification
- Sends to `#engineering` channel (falls back to `#all` if not available)

## Test plan
- [x] Run `go test ./internal/cmd/... -run "Extract|Truncate|Notify"` - all pass
- [x] `TestExtractAgentFromBranch` - 8 test cases for agent name extraction
- [x] `TestTruncateSHA` - 4 test cases for SHA truncation
- [x] `TestNotifyConflicts_CreatesChannelMessage` - integration test verifying channel notification

Closes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)