### PR TITLE
feat(memory): auto-record experiences on task completion

### DIFF
--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/events"
 	bclog "github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/memory"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
@@ -83,7 +84,59 @@ func runReport(cmd *cobra.Command, args []string) error {
 		bclog.Warn("failed to append agent report event", "error", err)
 	}
 
+	// Auto-record experience when agent reports done
+	if state == agent.StateDone && message != "" {
+		if err := recordExperience(ws.RootDir, agentID, message, "success"); err != nil {
+			bclog.Warn("failed to auto-record experience", "error", err)
+		}
+	}
+
 	fmt.Printf("Reported: %s %s\n", state, message)
+	return nil
+}
+
+// recordExperience records a task completion experience to the agent's memory.
+// Deduplicates by checking if the exact description already exists in recent experiences.
+func recordExperience(rootDir, agentID, description, outcome string) error {
+	store := memory.NewStore(rootDir, agentID)
+
+	// Initialize memory if it doesn't exist
+	if !store.Exists() {
+		if err := store.Init(); err != nil {
+			return fmt.Errorf("failed to initialize memory: %w", err)
+		}
+	}
+
+	// Check for duplicates in recent experiences
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		return fmt.Errorf("failed to get experiences: %w", err)
+	}
+
+	// Check last 5 experiences for duplicates
+	checkCount := 5
+	if len(experiences) < checkCount {
+		checkCount = len(experiences)
+	}
+	for i := len(experiences) - checkCount; i < len(experiences); i++ {
+		if experiences[i].Description == description {
+			bclog.Debug("skipping duplicate experience", "description", description)
+			return nil // Already recorded
+		}
+	}
+
+	// Record the experience
+	exp := memory.Experience{
+		Description: description,
+		Outcome:     outcome,
+		TaskType:    "task", // Default task type for auto-recorded experiences
+	}
+
+	if err := store.RecordExperience(exp); err != nil {
+		return fmt.Errorf("failed to record experience: %w", err)
+	}
+
+	bclog.Debug("auto-recorded experience", "agent", agentID, "description", description)
 	return nil
 }
 

--- a/internal/cmd/report_test.go
+++ b/internal/cmd/report_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/rpuneet/bc/pkg/memory"
 )
 
 // --- Report Command Unit Tests ---
@@ -77,5 +79,100 @@ func TestReportCommand_AcceptsStateAndMessage(t *testing.T) {
 	err := reportCmd.Args(reportCmd, []string{"working", "test", "message"})
 	if err != nil {
 		t.Errorf("unexpected error for state + message args: %v", err)
+	}
+}
+
+// --- Auto-Record Experience Tests ---
+
+func TestRecordExperience(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	err := recordExperience(wsDir, "test-agent", "Completed task X", "success")
+	if err != nil {
+		t.Fatalf("recordExperience failed: %v", err)
+	}
+
+	// Verify experience was recorded
+	store := memory.NewStore(wsDir, "test-agent")
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+
+	if len(experiences) != 1 {
+		t.Fatalf("expected 1 experience, got %d", len(experiences))
+	}
+
+	if experiences[0].Description != "Completed task X" {
+		t.Errorf("expected 'Completed task X', got %q", experiences[0].Description)
+	}
+	if experiences[0].Outcome != "success" {
+		t.Errorf("expected 'success', got %q", experiences[0].Outcome)
+	}
+}
+
+func TestRecordExperience_Deduplication(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Record same experience twice
+	err := recordExperience(wsDir, "dedup-agent", "Fixed bug", "success")
+	if err != nil {
+		t.Fatalf("first recordExperience failed: %v", err)
+	}
+
+	err = recordExperience(wsDir, "dedup-agent", "Fixed bug", "success")
+	if err != nil {
+		t.Fatalf("second recordExperience failed: %v", err)
+	}
+
+	// Verify only 1 experience recorded (deduplicated)
+	store := memory.NewStore(wsDir, "dedup-agent")
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+
+	if len(experiences) != 1 {
+		t.Errorf("expected 1 experience after dedup, got %d", len(experiences))
+	}
+}
+
+func TestRecordExperience_DifferentDescriptions(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Record different experiences
+	if err := recordExperience(wsDir, "multi-agent", "Task A", "success"); err != nil {
+		t.Fatalf("first recordExperience failed: %v", err)
+	}
+
+	if err := recordExperience(wsDir, "multi-agent", "Task B", "success"); err != nil {
+		t.Fatalf("second recordExperience failed: %v", err)
+	}
+
+	// Verify both recorded
+	store := memory.NewStore(wsDir, "multi-agent")
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+
+	if len(experiences) != 2 {
+		t.Errorf("expected 2 experiences, got %d", len(experiences))
+	}
+}
+
+func TestRecordExperience_InitializesMemory(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Record to non-existent agent memory
+	err := recordExperience(wsDir, "new-agent", "First task", "success")
+	if err != nil {
+		t.Fatalf("recordExperience failed: %v", err)
+	}
+
+	// Verify memory was initialized
+	store := memory.NewStore(wsDir, "new-agent")
+	if !store.Exists() {
+		t.Error("memory should be initialized after recording")
 	}
 }


### PR DESCRIPTION
## Summary

- Auto-record experience when agent reports `done` with a message
- Add `recordExperience` helper function with deduplication
- Check last 5 experiences to prevent duplicate entries
- Auto-initialize memory store if it doesn't exist

## Test plan

- [x] Run `go test ./internal/cmd/... -run Record` - 10 tests pass
- [x] Run `golangci-lint run` - 0 issues
- [ ] Manual: `BC_AGENT_ID=test bc report done "Completed task"` records experience

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)