### PR TITLE
feat(memory): add prune command for memory cleanup (#242)

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -99,6 +101,24 @@ Example:
 	RunE: runMemorySearch,
 }
 
+var memoryPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove old experiences from memory",
+	Long: `Prune old experiences from agent memory to prevent unbounded growth.
+
+Removes experiences older than the specified duration. Pinned experiences
+are always preserved regardless of age.
+
+By default, creates a backup before pruning. Use --no-backup to skip.
+
+Example:
+  bc memory prune --older-than 30d              # Remove experiences older than 30 days
+  bc memory prune --older-than 7d --dry-run     # Preview what would be removed
+  bc memory prune --older-than 90d --no-backup  # Prune without backup
+  bc memory prune --agent engineer-01           # Prune specific agent`,
+	RunE: runMemoryPrune,
+}
+
 var (
 	memoryOutcome     string
 	memoryTaskID      string
@@ -106,6 +126,10 @@ var (
 	memoryShowExp     bool
 	memoryShowLearn   bool
 	memorySearchAgent string
+	memoryPruneAgent  string
+	memoryOlderThan   string
+	memoryDryRun      bool
+	memoryNoBackup    bool
 )
 
 func init() {
@@ -118,10 +142,16 @@ func init() {
 
 	memorySearchCmd.Flags().StringVar(&memorySearchAgent, "agent", "", "Search specific agent's memory")
 
+	memoryPruneCmd.Flags().StringVar(&memoryPruneAgent, "agent", "", "Prune specific agent's memory (default: all agents)")
+	memoryPruneCmd.Flags().StringVar(&memoryOlderThan, "older-than", "30d", "Remove experiences older than this duration (e.g., 7d, 30d, 90d)")
+	memoryPruneCmd.Flags().BoolVar(&memoryDryRun, "dry-run", false, "Preview what would be removed without actually deleting")
+	memoryPruneCmd.Flags().BoolVar(&memoryNoBackup, "no-backup", false, "Skip creating backup before pruning")
+
 	memoryCmd.AddCommand(memoryRecordCmd)
 	memoryCmd.AddCommand(memoryLearnCmd)
 	memoryCmd.AddCommand(memoryShowCmd)
 	memoryCmd.AddCommand(memorySearchCmd)
+	memoryCmd.AddCommand(memoryPruneCmd)
 	rootCmd.AddCommand(memoryCmd)
 }
 
@@ -453,4 +483,141 @@ func scoreLearning(line, query string) int {
 	}
 
 	return score
+}
+
+func runMemoryPrune(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	// Parse the duration
+	duration, err := parseDuration(memoryOlderThan)
+	if err != nil {
+		return fmt.Errorf("invalid duration '%s': %w", memoryOlderThan, err)
+	}
+
+	// Determine which agents to prune
+	var agents []string
+	if memoryPruneAgent != "" {
+		agents = []string{memoryPruneAgent}
+	} else {
+		// Prune all agents with memory directories
+		memoryRoot := filepath.Join(ws.RootDir, ".bc", "memory")
+		entries, readErr := os.ReadDir(memoryRoot)
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				cmd.Println("No agent memories found")
+				return nil
+			}
+			return fmt.Errorf("failed to read memory directory: %w", readErr)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				agents = append(agents, entry.Name())
+			}
+		}
+	}
+
+	if len(agents) == 0 {
+		cmd.Println("No agent memories found")
+		return nil
+	}
+
+	if memoryDryRun {
+		cmd.Println("=== Dry Run (no changes will be made) ===")
+		cmd.Println()
+	}
+
+	totalPruned := 0
+	totalPreserved := 0
+
+	for _, agentID := range agents {
+		store := memory.NewStore(ws.RootDir, agentID)
+		if !store.Exists() {
+			continue
+		}
+
+		opts := memory.PruneOptions{
+			OlderThan: duration,
+			DryRun:    memoryDryRun,
+			Backup:    !memoryNoBackup,
+		}
+
+		result, pruneErr := store.Prune(opts)
+		if pruneErr != nil {
+			cmd.Printf("Error pruning %s: %v\n", agentID, pruneErr)
+			continue
+		}
+
+		if result.PrunedExperiences > 0 || result.PreservedPinned > 0 {
+			cmd.Printf("[%s] ", agentID)
+			if memoryDryRun {
+				cmd.Printf("Would prune %d/%d experiences", result.PrunedExperiences, result.TotalExperiences)
+			} else {
+				cmd.Printf("Pruned %d/%d experiences", result.PrunedExperiences, result.TotalExperiences)
+			}
+			if result.PreservedPinned > 0 {
+				cmd.Printf(" (preserved %d pinned)", result.PreservedPinned)
+			}
+			if result.BackupPath != "" {
+				cmd.Printf("\n    Backup: %s", result.BackupPath)
+			}
+			if result.BytesBeforePrune > 0 && !memoryDryRun {
+				saved := result.BytesBeforePrune - result.BytesAfterPrune
+				cmd.Printf("\n    Freed: %s", formatBytes(saved))
+			}
+			cmd.Println()
+		}
+
+		totalPruned += result.PrunedExperiences
+		totalPreserved += result.PreservedPinned
+	}
+
+	cmd.Println()
+	if memoryDryRun {
+		cmd.Printf("Summary: Would prune %d experiences across %d agent(s)\n", totalPruned, len(agents))
+	} else {
+		if totalPruned > 0 {
+			cmd.Printf("Summary: Pruned %d experiences across %d agent(s)\n", totalPruned, len(agents))
+		} else {
+			cmd.Println("No experiences older than", memoryOlderThan, "found")
+		}
+	}
+
+	return nil
+}
+
+// parseDuration parses a duration string like "30d", "7d", "24h".
+func parseDuration(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+
+	// Check for day suffix (Go's time.ParseDuration doesn't support "d")
+	if strings.HasSuffix(s, "d") {
+		days, err := strconv.Atoi(strings.TrimSuffix(s, "d"))
+		if err != nil {
+			return 0, fmt.Errorf("invalid day count: %w", err)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+
+	// Try standard Go duration parsing for h, m, s
+	return time.ParseDuration(s)
+}
+
+// formatBytes formats a byte count as a human-readable string.
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
 }

--- a/internal/cmd/memory_test.go
+++ b/internal/cmd/memory_test.go
@@ -485,3 +485,125 @@ func TestScoreLearning(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantD   string // expected duration as string for comparison
+		wantErr bool
+	}{
+		{
+			name:    "30 days",
+			input:   "30d",
+			wantErr: false,
+			wantD:   "720h0m0s", // 30 * 24 hours
+		},
+		{
+			name:    "7 days",
+			input:   "7d",
+			wantErr: false,
+			wantD:   "168h0m0s", // 7 * 24 hours
+		},
+		{
+			name:    "24 hours",
+			input:   "24h",
+			wantErr: false,
+			wantD:   "24h0m0s",
+		},
+		{
+			name:    "1 hour",
+			input:   "1h",
+			wantErr: false,
+			wantD:   "1h0m0s",
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "invalid",
+			input:   "abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := parseDuration(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if d.String() != tt.wantD {
+				t.Errorf("parseDuration(%q) = %s, want %s", tt.input, d.String(), tt.wantD)
+			}
+		})
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct { //nolint:govet // test struct alignment doesn't matter
+		bytes int64
+		name  string
+		want  string
+	}{
+		{0, "zero", "0 B"},
+		{500, "bytes", "500 B"},
+		{1500, "kilobytes", "1.5 KB"},
+		{1500000, "megabytes", "1.4 MB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatBytes(tt.bytes)
+			if got != tt.want {
+				t.Errorf("formatBytes(%d) = %q, want %q", tt.bytes, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMemoryPruneCmdExists(t *testing.T) {
+	if memoryPruneCmd == nil {
+		t.Fatal("memoryPruneCmd should not be nil")
+	}
+	if memoryPruneCmd.Use != "prune" {
+		t.Errorf("memoryPruneCmd.Use = %q, want %q", memoryPruneCmd.Use, "prune")
+	}
+}
+
+func TestMemoryPruneFlags(t *testing.T) {
+	// Check older-than flag
+	flag := memoryPruneCmd.Flags().Lookup("older-than")
+	if flag == nil {
+		t.Fatal("expected 'older-than' flag to exist")
+	}
+	if flag.DefValue != "30d" {
+		t.Errorf("older-than default = %q, want %q", flag.DefValue, "30d")
+	}
+
+	// Check dry-run flag
+	flag = memoryPruneCmd.Flags().Lookup("dry-run")
+	if flag == nil {
+		t.Fatal("expected 'dry-run' flag to exist")
+	}
+
+	// Check no-backup flag
+	flag = memoryPruneCmd.Flags().Lookup("no-backup")
+	if flag == nil {
+		t.Fatal("expected 'no-backup' flag to exist")
+	}
+
+	// Check agent flag
+	flag = memoryPruneCmd.Flags().Lookup("agent")
+	if flag == nil {
+		t.Fatal("expected 'agent' flag to exist")
+	}
+}

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -19,6 +19,7 @@ type Experience struct {
 	Description string         `json:"description"`
 	Outcome     string         `json:"outcome"`
 	Learnings   []string       `json:"learnings,omitempty"`
+	Pinned      bool           `json:"pinned,omitempty"`
 }
 
 // Store provides memory storage for an agent.
@@ -183,6 +184,159 @@ func splitLines(data []byte) [][]byte {
 
 // DefaultMemoryLimit is the default number of recent experiences to include.
 const DefaultMemoryLimit = 10
+
+// DefaultSizeThreshold is the default size in bytes before automatic cleanup triggers.
+const DefaultSizeThreshold = 1024 * 1024 // 1MB
+
+// PruneOptions configures the prune operation.
+type PruneOptions struct {
+	OlderThan time.Duration // Remove experiences older than this duration
+	DryRun    bool          // If true, don't actually delete, just report
+	Backup    bool          // If true, create backup before pruning
+}
+
+// PruneResult contains statistics from a prune operation.
+type PruneResult struct {
+	BackupPath        string
+	BytesBeforePrune  int64
+	BytesAfterPrune   int64
+	TotalExperiences  int
+	PrunedExperiences int
+	PreservedPinned   int
+}
+
+// Prune removes old experiences based on the provided options.
+// Pinned experiences are always preserved regardless of age.
+func (s *Store) Prune(opts PruneOptions) (*PruneResult, error) {
+	result := &PruneResult{}
+
+	// Get current experiences
+	experiences, err := s.GetExperiences()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get experiences: %w", err)
+	}
+	result.TotalExperiences = len(experiences)
+
+	// Get file size before prune
+	if info, statErr := os.Stat(s.experiencesPath()); statErr == nil {
+		result.BytesBeforePrune = info.Size()
+	}
+
+	// Determine cutoff time
+	cutoff := time.Now().Add(-opts.OlderThan)
+
+	// Filter experiences to keep
+	var kept []Experience
+	for _, exp := range experiences {
+		// Always keep pinned experiences
+		if exp.Pinned {
+			kept = append(kept, exp)
+			result.PreservedPinned++
+			continue
+		}
+
+		// Keep if newer than cutoff
+		if exp.Timestamp.After(cutoff) || exp.Timestamp.Equal(cutoff) {
+			kept = append(kept, exp)
+			continue
+		}
+
+		// This experience will be pruned
+		result.PrunedExperiences++
+	}
+
+	// If dry run, just return the result
+	if opts.DryRun {
+		return result, nil
+	}
+
+	// If nothing to prune, return early
+	if result.PrunedExperiences == 0 {
+		return result, nil
+	}
+
+	// Create backup if requested
+	if opts.Backup {
+		backupPath, backupErr := s.createBackup()
+		if backupErr != nil {
+			return nil, fmt.Errorf("failed to create backup: %w", backupErr)
+		}
+		result.BackupPath = backupPath
+	}
+
+	// Write the filtered experiences back
+	if err := s.writeExperiences(kept); err != nil {
+		return nil, fmt.Errorf("failed to write pruned experiences: %w", err)
+	}
+
+	// Get file size after prune
+	if info, statErr := os.Stat(s.experiencesPath()); statErr == nil {
+		result.BytesAfterPrune = info.Size()
+	}
+
+	return result, nil
+}
+
+// GetSize returns the total size of memory files in bytes.
+func (s *Store) GetSize() (int64, error) {
+	var total int64
+
+	paths := []string{s.experiencesPath(), s.learningsPath()}
+	for _, path := range paths {
+		if info, err := os.Stat(path); err == nil {
+			total += info.Size()
+		}
+	}
+
+	return total, nil
+}
+
+// NeedsPruning checks if the memory store exceeds the size threshold.
+func (s *Store) NeedsPruning(threshold int64) (bool, int64, error) {
+	size, err := s.GetSize()
+	if err != nil {
+		return false, 0, err
+	}
+	return size > threshold, size, nil
+}
+
+// createBackup creates a timestamped backup of the experiences file.
+func (s *Store) createBackup() (string, error) {
+	timestamp := time.Now().Format("20060102-150405")
+	backupPath := filepath.Join(s.memoryDir, fmt.Sprintf("experiences.%s.backup.jsonl", timestamp))
+
+	src, err := os.ReadFile(s.experiencesPath())
+	if err != nil {
+		return "", fmt.Errorf("failed to read experiences file: %w", err)
+	}
+
+	if err := os.WriteFile(backupPath, src, 0600); err != nil { //nolint:gosec // backup path in trusted memory dir
+		return "", fmt.Errorf("failed to write backup: %w", err)
+	}
+
+	return backupPath, nil
+}
+
+// writeExperiences overwrites the experiences file with the given experiences.
+func (s *Store) writeExperiences(experiences []Experience) error {
+	f, err := os.Create(s.experiencesPath()) //nolint:gosec // path constructed from trusted memoryDir
+	if err != nil {
+		return fmt.Errorf("failed to create experiences file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	for _, exp := range experiences {
+		data, marshalErr := json.Marshal(exp)
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal experience: %w", marshalErr)
+		}
+		if _, writeErr := f.Write(append(data, '\n')); writeErr != nil {
+			return fmt.Errorf("failed to write experience: %w", writeErr)
+		}
+	}
+
+	return nil
+}
 
 // GetMemoryContext returns formatted memories suitable for prompt injection.
 // It loads the most recent experiences (up to limit) and all learnings,

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -550,3 +550,298 @@ func TestStore_GetMemoryContext_NonExistent(t *testing.T) {
 		t.Errorf("expected empty context for nonexistent agent, got %q", ctx)
 	}
 }
+
+func TestStore_Prune_DryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add old experience (45 days ago)
+	oldExp := Experience{
+		Timestamp:   time.Now().Add(-45 * 24 * time.Hour),
+		Description: "Old task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(oldExp); err != nil {
+		t.Fatalf("failed to record old experience: %v", err)
+	}
+
+	// Add recent experience
+	recentExp := Experience{
+		Timestamp:   time.Now().Add(-5 * 24 * time.Hour),
+		Description: "Recent task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(recentExp); err != nil {
+		t.Fatalf("failed to record recent experience: %v", err)
+	}
+
+	// Prune with dry run (30 day threshold)
+	result, err := store.Prune(PruneOptions{
+		OlderThan: 30 * 24 * time.Hour,
+		DryRun:    true,
+	})
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+
+	if result.TotalExperiences != 2 {
+		t.Errorf("expected 2 total experiences, got %d", result.TotalExperiences)
+	}
+	if result.PrunedExperiences != 1 {
+		t.Errorf("expected 1 pruned experience, got %d", result.PrunedExperiences)
+	}
+
+	// Verify nothing was actually deleted (dry run)
+	experiences, _ := store.GetExperiences()
+	if len(experiences) != 2 {
+		t.Errorf("dry run should not delete, but got %d experiences", len(experiences))
+	}
+}
+
+func TestStore_Prune_ActualDeletion(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add old experience (45 days ago)
+	oldExp := Experience{
+		Timestamp:   time.Now().Add(-45 * 24 * time.Hour),
+		Description: "Old task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(oldExp); err != nil {
+		t.Fatalf("failed to record old experience: %v", err)
+	}
+
+	// Add recent experience
+	recentExp := Experience{
+		Timestamp:   time.Now().Add(-5 * 24 * time.Hour),
+		Description: "Recent task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(recentExp); err != nil {
+		t.Fatalf("failed to record recent experience: %v", err)
+	}
+
+	// Prune without dry run (30 day threshold, no backup)
+	result, err := store.Prune(PruneOptions{
+		OlderThan: 30 * 24 * time.Hour,
+		DryRun:    false,
+		Backup:    false,
+	})
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+
+	if result.PrunedExperiences != 1 {
+		t.Errorf("expected 1 pruned experience, got %d", result.PrunedExperiences)
+	}
+
+	// Verify old experience was deleted
+	experiences, _ := store.GetExperiences()
+	if len(experiences) != 1 {
+		t.Errorf("expected 1 experience after prune, got %d", len(experiences))
+	}
+	if experiences[0].Description != "Recent task" {
+		t.Errorf("wrong experience kept: %s", experiences[0].Description)
+	}
+}
+
+func TestStore_Prune_PreservesPinned(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add old pinned experience (should be preserved)
+	pinnedExp := Experience{
+		Timestamp:   time.Now().Add(-60 * 24 * time.Hour),
+		Description: "Important pinned task",
+		Outcome:     "success",
+		Pinned:      true,
+	}
+	if err := store.RecordExperience(pinnedExp); err != nil {
+		t.Fatalf("failed to record pinned experience: %v", err)
+	}
+
+	// Add old non-pinned experience (should be pruned)
+	oldExp := Experience{
+		Timestamp:   time.Now().Add(-45 * 24 * time.Hour),
+		Description: "Old non-pinned task",
+		Outcome:     "success",
+		Pinned:      false,
+	}
+	if err := store.RecordExperience(oldExp); err != nil {
+		t.Fatalf("failed to record old experience: %v", err)
+	}
+
+	// Prune
+	result, err := store.Prune(PruneOptions{
+		OlderThan: 30 * 24 * time.Hour,
+		DryRun:    false,
+		Backup:    false,
+	})
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+
+	if result.PreservedPinned != 1 {
+		t.Errorf("expected 1 preserved pinned, got %d", result.PreservedPinned)
+	}
+	if result.PrunedExperiences != 1 {
+		t.Errorf("expected 1 pruned, got %d", result.PrunedExperiences)
+	}
+
+	// Verify pinned was kept
+	experiences, _ := store.GetExperiences()
+	if len(experiences) != 1 {
+		t.Errorf("expected 1 experience after prune, got %d", len(experiences))
+	}
+	if !experiences[0].Pinned {
+		t.Error("remaining experience should be pinned")
+	}
+}
+
+func TestStore_Prune_WithBackup(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add old experience
+	oldExp := Experience{
+		Timestamp:   time.Now().Add(-45 * 24 * time.Hour),
+		Description: "Old task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(oldExp); err != nil {
+		t.Fatalf("failed to record old experience: %v", err)
+	}
+
+	// Prune with backup
+	result, err := store.Prune(PruneOptions{
+		OlderThan: 30 * 24 * time.Hour,
+		DryRun:    false,
+		Backup:    true,
+	})
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+
+	if result.BackupPath == "" {
+		t.Error("expected backup path to be set")
+	}
+
+	// Verify backup file exists
+	if _, err := os.Stat(result.BackupPath); os.IsNotExist(err) {
+		t.Error("backup file should exist")
+	}
+}
+
+func TestStore_Prune_NothingToPrune(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add only recent experience
+	recentExp := Experience{
+		Timestamp:   time.Now().Add(-5 * 24 * time.Hour),
+		Description: "Recent task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(recentExp); err != nil {
+		t.Fatalf("failed to record recent experience: %v", err)
+	}
+
+	// Prune
+	result, err := store.Prune(PruneOptions{
+		OlderThan: 30 * 24 * time.Hour,
+		DryRun:    false,
+		Backup:    true,
+	})
+	if err != nil {
+		t.Fatalf("Prune failed: %v", err)
+	}
+
+	if result.PrunedExperiences != 0 {
+		t.Errorf("expected 0 pruned, got %d", result.PrunedExperiences)
+	}
+	if result.BackupPath != "" {
+		t.Error("backup should not be created when nothing to prune")
+	}
+}
+
+func TestStore_GetSize(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add some content
+	for i := 0; i < 10; i++ {
+		exp := Experience{
+			Description: "Task with some description content " + string(rune('A'+i)),
+			Outcome:     "success",
+		}
+		if err := store.RecordExperience(exp); err != nil {
+			t.Fatalf("failed to record experience: %v", err)
+		}
+	}
+
+	size, err := store.GetSize()
+	if err != nil {
+		t.Fatalf("GetSize failed: %v", err)
+	}
+
+	if size <= 0 {
+		t.Errorf("expected positive size, got %d", size)
+	}
+}
+
+func TestStore_NeedsPruning(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add some content
+	exp := Experience{
+		Description: "A task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(exp); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	// With very low threshold, should need pruning
+	needs, size, err := store.NeedsPruning(1) // 1 byte threshold
+	if err != nil {
+		t.Fatalf("NeedsPruning failed: %v", err)
+	}
+	if !needs {
+		t.Error("should need pruning with 1 byte threshold")
+	}
+	if size <= 0 {
+		t.Errorf("expected positive size, got %d", size)
+	}
+
+	// With high threshold, should not need pruning
+	needs, _, err = store.NeedsPruning(1024 * 1024) // 1MB threshold
+	if err != nil {
+		t.Fatalf("NeedsPruning failed: %v", err)
+	}
+	if needs {
+		t.Error("should not need pruning with 1MB threshold")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `bc memory prune` command to remove old experiences and prevent unbounded growth
- Adds `Pinned` field to Experience struct - pinned experiences are preserved regardless of age
- Creates backup before pruning (use `--no-backup` to skip)
- Supports `--dry-run` for previewing what would be deleted
- Adds `GetSize()` and `NeedsPruning()` methods for programmatic size checking

## Usage
```bash
bc memory prune --older-than 30d              # Remove experiences older than 30 days
bc memory prune --older-than 7d --dry-run     # Preview what would be removed
bc memory prune --older-than 90d --no-backup  # Prune without backup
bc memory prune --agent engineer-01           # Prune specific agent only
```

## Test plan
- [x] `TestStore_Prune_DryRun` - verifies dry-run doesn't delete
- [x] `TestStore_Prune_ActualDeletion` - verifies old experiences are removed
- [x] `TestStore_Prune_PreservesPinned` - verifies pinned experiences are kept
- [x] `TestStore_Prune_WithBackup` - verifies backup file is created
- [x] `TestStore_Prune_NothingToPrune` - verifies no-op when all recent
- [x] `TestParseDuration` - verifies duration parsing (30d, 7d, 24h)
- [x] `TestFormatBytes` - verifies human-readable byte formatting
- [x] `TestMemoryPruneCmdExists` / `TestMemoryPruneFlags` - command registration

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)