### PR TITLE
feat(memory): add memory prune command for garbage collection

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -99,6 +101,20 @@ Example:
 	RunE: runMemorySearch,
 }
 
+var memoryPruneCmd = &cobra.Command{
+	Use:   "prune",
+	Short: "Remove old memory entries",
+	Long: `Remove old experiences to prevent unbounded memory growth.
+
+Creates a backup before deleting. Use --dry-run to preview what would be deleted.
+
+Example:
+  bc memory prune --older-than 30d          # Remove entries older than 30 days
+  bc memory prune --older-than 7d --dry-run # Preview what would be removed
+  bc memory prune --agent engineer-01       # Prune specific agent only`,
+	RunE: runMemoryPrune,
+}
+
 var (
 	memoryOutcome     string
 	memoryTaskID      string
@@ -106,6 +122,9 @@ var (
 	memoryShowExp     bool
 	memoryShowLearn   bool
 	memorySearchAgent string
+	memoryPruneAgent  string
+	memoryPruneOlder  string
+	memoryPruneDryRun bool
 )
 
 func init() {
@@ -118,10 +137,15 @@ func init() {
 
 	memorySearchCmd.Flags().StringVar(&memorySearchAgent, "agent", "", "Search specific agent's memory")
 
+	memoryPruneCmd.Flags().StringVar(&memoryPruneAgent, "agent", "", "Prune specific agent's memory")
+	memoryPruneCmd.Flags().StringVar(&memoryPruneOlder, "older-than", "30d", "Remove entries older than duration (e.g., 7d, 30d)")
+	memoryPruneCmd.Flags().BoolVar(&memoryPruneDryRun, "dry-run", false, "Preview what would be deleted without removing")
+
 	memoryCmd.AddCommand(memoryRecordCmd)
 	memoryCmd.AddCommand(memoryLearnCmd)
 	memoryCmd.AddCommand(memoryShowCmd)
 	memoryCmd.AddCommand(memorySearchCmd)
+	memoryCmd.AddCommand(memoryPruneCmd)
 	rootCmd.AddCommand(memoryCmd)
 }
 
@@ -453,4 +477,130 @@ func scoreLearning(line, query string) int {
 	}
 
 	return score
+}
+
+func runMemoryPrune(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	// Parse duration
+	cutoff, err := parseDuration(memoryPruneOlder)
+	if err != nil {
+		return fmt.Errorf("invalid duration: %w", err)
+	}
+	cutoffTime := time.Now().Add(-cutoff)
+
+	// Determine which agents to prune
+	var agents []string
+	if memoryPruneAgent != "" {
+		agents = []string{memoryPruneAgent}
+	} else {
+		// Prune all agents with memory directories
+		memoryRoot := filepath.Join(ws.RootDir, ".bc", "memory")
+		entries, err := os.ReadDir(memoryRoot)
+		if err != nil {
+			if os.IsNotExist(err) {
+				cmd.Println("No agent memories found")
+				return nil
+			}
+			return fmt.Errorf("failed to read memory directory: %w", err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				agents = append(agents, entry.Name())
+			}
+		}
+	}
+
+	if len(agents) == 0 {
+		cmd.Println("No agent memories found")
+		return nil
+	}
+
+	totalPruned := 0
+	for _, agentID := range agents {
+		store := memory.NewStore(ws.RootDir, agentID)
+		if !store.Exists() {
+			continue
+		}
+
+		// Get experiences
+		experiences, err := store.GetExperiences()
+		if err != nil {
+			cmd.Printf("Warning: failed to read %s experiences: %v\n", agentID, err)
+			continue
+		}
+
+		// Find entries to prune
+		var toKeep []memory.Experience
+		var toPrune []memory.Experience
+		for _, exp := range experiences {
+			if exp.Timestamp.Before(cutoffTime) {
+				toPrune = append(toPrune, exp)
+			} else {
+				toKeep = append(toKeep, exp)
+			}
+		}
+
+		if len(toPrune) == 0 {
+			continue
+		}
+
+		if memoryPruneDryRun {
+			cmd.Printf("[%s] Would prune %d entries (keeping %d)\n", agentID, len(toPrune), len(toKeep))
+			for _, exp := range toPrune {
+				cmd.Printf("  - [%s] %s\n", exp.Timestamp.Format("2006-01-02"), exp.Description)
+			}
+		} else {
+			// Create backup before pruning
+			if err := store.BackupExperiences(); err != nil {
+				cmd.Printf("Warning: failed to backup %s: %v (continuing anyway)\n", agentID, err)
+			}
+
+			// Write kept experiences back
+			if err := store.WriteExperiences(toKeep); err != nil {
+				return fmt.Errorf("failed to write pruned experiences for %s: %w", agentID, err)
+			}
+
+			cmd.Printf("[%s] Pruned %d entries (kept %d)\n", agentID, len(toPrune), len(toKeep))
+			totalPruned += len(toPrune)
+		}
+	}
+
+	if memoryPruneDryRun {
+		cmd.Println("\nDry run - no changes made. Remove --dry-run to prune.")
+	} else if totalPruned > 0 {
+		cmd.Printf("\nTotal pruned: %d entries\n", totalPruned)
+	} else {
+		cmd.Printf("No entries older than %s found\n", memoryPruneOlder)
+	}
+
+	return nil
+}
+
+// parseDuration parses duration strings like "7d", "30d", "1h".
+func parseDuration(s string) (time.Duration, error) {
+	if len(s) < 2 {
+		return 0, fmt.Errorf("duration too short: %s", s)
+	}
+
+	unit := s[len(s)-1]
+	valueStr := s[:len(s)-1]
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number: %s", valueStr)
+	}
+
+	switch unit {
+	case 'd':
+		return time.Duration(value) * 24 * time.Hour, nil
+	case 'h':
+		return time.Duration(value) * time.Hour, nil
+	case 'm':
+		return time.Duration(value) * time.Minute, nil
+	default:
+		return 0, fmt.Errorf("unknown unit: %c (use d, h, or m)", unit)
+	}
 }

--- a/internal/cmd/memory_test.go
+++ b/internal/cmd/memory_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rpuneet/bc/pkg/memory"
 )
@@ -483,5 +484,177 @@ func TestScoreLearning(t *testing.T) {
 				t.Errorf("scoreLearning() = %d, want >= %d", score, tt.minScore)
 			}
 		})
+	}
+}
+
+// --- Memory Prune Tests ---
+
+func TestParseDuration(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected time.Duration
+		wantErr  bool
+	}{
+		{"7d", 7 * 24 * time.Hour, false},
+		{"30d", 30 * 24 * time.Hour, false},
+		{"1h", 1 * time.Hour, false},
+		{"60m", 60 * time.Minute, false},
+		{"x", 0, true},   // too short
+		{"abc", 0, true}, // invalid number
+		{"7x", 0, true},  // unknown unit
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseDuration(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("parseDuration(%q) expected error", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseDuration(%q) error: %v", tt.input, err)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("parseDuration(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMemoryPruneDryRun(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Reset flags (they persist between tests)
+	memoryPruneDryRun = false
+	memoryPruneAgent = ""
+	memoryPruneOlder = "30d"
+
+	// Create memory with old experience
+	store := memory.NewStore(wsDir, "prune-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Record an old experience (manually set timestamp in the past)
+	oldExp := memory.Experience{
+		Timestamp:   time.Now().Add(-60 * 24 * time.Hour), // 60 days ago
+		Description: "Old task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(oldExp); err != nil {
+		t.Fatalf("failed to record old experience: %v", err)
+	}
+
+	// Record a recent experience
+	newExp := memory.Experience{
+		Description: "Recent task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(newExp); err != nil {
+		t.Fatalf("failed to record new experience: %v", err)
+	}
+
+	output, err := executeCmd("memory", "prune", "--agent", "prune-agent", "--older-than", "30d", "--dry-run")
+	if err != nil {
+		t.Fatalf("memory prune failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should mention dry run
+	if !strings.Contains(output, "Dry run") {
+		t.Errorf("output should mention dry run: %s", output)
+	}
+
+	// Should still have both experiences (dry run doesn't delete)
+	experiences, _ := store.GetExperiences()
+	if len(experiences) != 2 {
+		t.Errorf("expected 2 experiences after dry run, got %d", len(experiences))
+	}
+}
+
+func TestMemoryPruneActual(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Reset flags via Cobra (they persist between tests)
+	_ = memoryPruneCmd.Flags().Set("dry-run", "false")
+
+	// Create memory with old experience
+	store := memory.NewStore(wsDir, "prune-real")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Record an old experience
+	oldExp := memory.Experience{
+		Timestamp:   time.Now().Add(-60 * 24 * time.Hour), // 60 days ago
+		Description: "Old task to prune",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(oldExp); err != nil {
+		t.Fatalf("failed to record old experience: %v", err)
+	}
+
+	// Record a recent experience
+	newExp := memory.Experience{
+		Description: "Recent task to keep",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(newExp); err != nil {
+		t.Fatalf("failed to record new experience: %v", err)
+	}
+
+	output, err := executeCmd("memory", "prune", "--agent", "prune-real", "--older-than", "30d", "--dry-run=false")
+	if err != nil {
+		t.Fatalf("memory prune failed: %v\nOutput: %s", err, output)
+	}
+
+	// Should report pruning
+	if !strings.Contains(output, "Pruned") {
+		t.Errorf("output should report pruning: %s", output)
+	}
+
+	// Should only have 1 experience now
+	experiences, _ := store.GetExperiences()
+	if len(experiences) != 1 {
+		t.Errorf("expected 1 experience after prune, got %d", len(experiences))
+	}
+	if experiences[0].Description != "Recent task to keep" {
+		t.Errorf("wrong experience kept: %s", experiences[0].Description)
+	}
+}
+
+func TestMemoryPruneCreatesBackup(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Reset flags via Cobra (they persist between tests)
+	_ = memoryPruneCmd.Flags().Set("dry-run", "false")
+
+	// Create memory with old experience
+	store := memory.NewStore(wsDir, "backup-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Record an old experience
+	oldExp := memory.Experience{
+		Timestamp:   time.Now().Add(-60 * 24 * time.Hour),
+		Description: "Old task",
+		Outcome:     "success",
+	}
+	if err := store.RecordExperience(oldExp); err != nil {
+		t.Fatalf("failed to record experience: %v", err)
+	}
+
+	_, err := executeCmd("memory", "prune", "--agent", "backup-agent", "--older-than", "30d", "--dry-run=false")
+	if err != nil {
+		t.Fatalf("memory prune failed: %v", err)
+	}
+
+	// Check backup was created
+	backupPath := filepath.Join(store.MemoryDir(), "experiences.jsonl.bak")
+	if _, statErr := os.Stat(backupPath); os.IsNotExist(statErr) {
+		t.Error("backup file should exist after prune")
 	}
 }

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -165,6 +165,51 @@ func (s *Store) learningsPath() string {
 	return filepath.Join(s.memoryDir, "learnings.md")
 }
 
+// BackupExperiences creates a backup of the experiences file.
+// Backup is stored as experiences.jsonl.bak in the same directory.
+func (s *Store) BackupExperiences() error {
+	srcPath := s.experiencesPath()
+	dstPath := srcPath + ".bak"
+
+	data, err := os.ReadFile(srcPath) //nolint:gosec // srcPath constructed from trusted memoryDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Nothing to backup
+		}
+		return fmt.Errorf("failed to read experiences: %w", err)
+	}
+
+	if err := os.WriteFile(dstPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write backup: %w", err)
+	}
+
+	return nil
+}
+
+// WriteExperiences overwrites the experiences file with the given experiences.
+// This is used for pruning/cleanup operations.
+func (s *Store) WriteExperiences(experiences []Experience) error {
+	path := s.experiencesPath()
+
+	f, err := os.Create(path) //nolint:gosec // path constructed from trusted memoryDir
+	if err != nil {
+		return fmt.Errorf("failed to create experiences file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	for _, exp := range experiences {
+		data, marshalErr := json.Marshal(exp)
+		if marshalErr != nil {
+			return fmt.Errorf("failed to marshal experience: %w", marshalErr)
+		}
+		if _, writeErr := f.Write(append(data, '\n')); writeErr != nil {
+			return fmt.Errorf("failed to write experience: %w", writeErr)
+		}
+	}
+
+	return nil
+}
+
 // splitLines splits byte data into lines.
 func splitLines(data []byte) [][]byte {
 	var lines [][]byte


### PR DESCRIPTION
## Summary

- Add `bc memory prune` command to remove old experiences
- `--older-than` flag (e.g., 30d, 7d, 1h)
- `--dry-run` flag to preview deletions
- `--agent` flag to prune specific agent
- Creates backup before pruning (experiences.jsonl.bak)
- Add BackupExperiences and WriteExperiences to Store

## Test plan

- [x] Run `go test ./internal/cmd/... -run Prune` - 4 tests pass
- [x] Run `golangci-lint run` - 0 issues
- [ ] Manual: `bc memory prune --older-than 30d --dry-run`

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)