### PR TITLE
Channel UI: fix scrolling through messages (#302/#314)

### DIFF
--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -79,7 +79,7 @@ func runHome(cmd *cobra.Command, args []string) error {
 
 	// Run the Bubble Tea TUI
 	model := itui.NewHomeModel(workspaces, int(config.Workspace.MaxWorkers))
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	_, err = p.Run()
 	return err
 }

--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -135,6 +135,31 @@ func (m *ChannelModel) HandleKey(msg tea.KeyMsg) Action {
 	return NoAction
 }
 
+// HandleMouse processes a mouse event (e.g. wheel). Used when channel screen is active.
+// Wheel up = scroll toward older messages; wheel down = toward newer.
+func (m *ChannelModel) HandleMouse(msg tea.MouseMsg) {
+	if m.sendMode || m.reactionMode {
+		return
+	}
+	switch msg.Button {
+	case tea.MouseButtonWheelUp:
+		// See older messages
+		maxScroll := len(m.channel.History) - m.visibleMsgCount()
+		if maxScroll < 0 {
+			maxScroll = 0
+		}
+		if m.scroll < maxScroll {
+			m.scroll++
+		}
+	case tea.MouseButtonWheelDown:
+		// See newer messages
+		if m.scroll > 0 {
+			m.scroll--
+		}
+	}
+	m.clampScroll()
+}
+
 // visibleCount returns the number of messages currently displayed.
 func (m *ChannelModel) visibleCount() int {
 	n := len(m.channel.History)
@@ -570,6 +595,22 @@ func (m *ChannelModel) reloadChannel() {
 	if ch, ok := m.store.Get(m.channel.Name); ok {
 		m.channel = ch
 	}
+	m.clampScroll()
+}
+
+// clampScroll keeps scroll in [0, maxScroll] so the view never shows invalid range.
+// Call after reload, resize, or any change that can make scroll out of bounds.
+func (m *ChannelModel) clampScroll() {
+	maxScroll := len(m.channel.History) - m.visibleMsgCount()
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.scroll > maxScroll {
+		m.scroll = maxScroll
+	}
+	if m.scroll < 0 {
+		m.scroll = 0
+	}
 }
 
 // visibleMsgCount returns how many messages fit in the visible area.
@@ -697,6 +738,7 @@ func (m *ChannelModel) View() string {
 		b.WriteString(m.styles.Muted.Render("  No messages yet. Press 's' to send a message."))
 		b.WriteString("\n")
 	} else {
+		m.clampScroll()
 		visible := m.visibleMsgCount()
 		total := len(m.channel.History)
 

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -88,6 +88,78 @@ func TestChannelHandleKey_HomeEnd(t *testing.T) {
 	}
 }
 
+// TestClampScroll_KeepsScrollInBounds ensures scroll is clamped after history shrinks or view changes.
+func TestClampScroll_KeepsScrollInBounds(t *testing.T) {
+	m := newTestChannelModel()
+	for i := 0; i < 50; i++ {
+		m.channel.History = append(m.channel.History, channel.HistoryEntry{
+			Sender: "u", Message: "m", Time: time.Now(),
+		})
+	}
+	m.scroll = 1000 // out of bounds
+	m.clampScroll()
+	maxScroll := len(m.channel.History) - m.visibleMsgCount()
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.scroll != maxScroll {
+		t.Errorf("clampScroll: scroll should be %d, got %d", maxScroll, m.scroll)
+	}
+}
+
+// TestClampScroll_ZeroStaysZero ensures scroll 0 is not changed when valid.
+func TestClampScroll_ZeroStaysZero(t *testing.T) {
+	m := newTestChannelModel()
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "a", Message: "hi", Time: time.Now()},
+	}
+	m.scroll = 0
+	m.clampScroll()
+	if m.scroll != 0 {
+		t.Errorf("scroll should stay 0, got %d", m.scroll)
+	}
+}
+
+func TestChannelHandleMouse_WheelDown(t *testing.T) {
+	m := newTestChannelModel()
+	for i := 0; i < 25; i++ {
+		m.channel.History = append(m.channel.History, channel.HistoryEntry{Sender: "u", Message: "m", Time: time.Now()})
+	}
+	m.scroll = 10
+	m.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	if m.scroll != 9 {
+		t.Errorf("wheel down should decrease scroll to 9, got %d", m.scroll)
+	}
+	m.scroll = 0
+	m.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	if m.scroll != 0 {
+		t.Errorf("wheel down at 0 should stay 0, got %d", m.scroll)
+	}
+}
+
+func TestChannelHandleMouse_WheelUp(t *testing.T) {
+	m := newTestChannelModel()
+	for i := 0; i < 25; i++ {
+		m.channel.History = append(m.channel.History, channel.HistoryEntry{Sender: "u", Message: "m", Time: time.Now()})
+	}
+	m.scroll = 5
+	m.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	if m.scroll != 6 {
+		t.Errorf("wheel up should increase scroll to 6, got %d", m.scroll)
+	}
+	maxScroll := len(m.channel.History) - m.visibleMsgCount()
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	for m.scroll < maxScroll {
+		m.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	}
+	m.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	if m.scroll != maxScroll {
+		t.Errorf("wheel up at max should stay %d, got %d", maxScroll, m.scroll)
+	}
+}
+
 func TestChannelHandleKey_CreateIssue(t *testing.T) {
 	m := newTestChannelModel()
 	m.cursor = 0

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -114,6 +114,12 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		return m.handleKey(msg)
+
+	case tea.MouseMsg:
+		if m.screen == ScreenChannel && m.channelModel != nil {
+			m.channelModel.HandleMouse(msg)
+		}
+		return m, nil
 	}
 
 	return m, nil


### PR DESCRIPTION
## P1: Channel scrolling (#302 / #314)

Part of channel redesign #287. Fixes scrolling through channel messages so users can scroll full history reliably.

### Changes
- **Scroll clamping**: `clampScroll()` keeps scroll in bounds; called after `reloadChannel()` and in View so position stays valid when history or window size changes. Prevents stuck scroll and wrong "older/newer messages" indicators.
- **Mouse wheel**: Wheel up = older messages, wheel down = newer. Home Update forwards `tea.MouseMsg` to channel when channel screen is active.
- **Mouse enabled**: `tea.WithMouseCellMotion()` in `bc home` so wheel events are received.
- **Tests**: `TestClampScroll_KeepsScrollInBounds`, `TestClampScroll_ZeroStaysZero`, `TestChannelHandleMouse_WheelDown`, `TestChannelHandleMouse_WheelUp`.

### Acceptance
- [x] Can scroll through full message history (j/k, g/G, mouse wheel)
- [x] No stuck or broken scroll behavior
- [x] Scroll position stable when history reloads (clamped)

Ready for tech lead review → QA review → merge.

Made with [Cursor](https://cursor.com)

Closes #302