### PR TITLE
Channel bubble UI fixes (#307)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -784,18 +784,25 @@ func (m *ChannelModel) View() string {
 
 			// Message content with subtle background — wrap long lines with highlighting
 			msgStyle := m.styles.MessageTypeStyle(msgTypeStr)
-			lines := wrapText(entry.Message, msgWidth-4)
 			var content strings.Builder
-			for j, line := range lines {
-				if j > 0 {
-					content.WriteString("\n")
+			if entry.Message == "" {
+				content.WriteString(m.styles.Muted.Render("(empty)"))
+			} else {
+				lines := wrapText(entry.Message, msgWidth-4)
+				for j, line := range lines {
+					if j > 0 {
+						content.WriteString("\n")
+					}
+					content.WriteString(m.highlightMessage(line))
 				}
-				highlightedLine := m.highlightMessage(line)
-				content.WriteString(highlightedLine)
 			}
 
-			// Render message with subtle background bubble
-			bubble := m.styles.MessageBubble.Width(msgWidth).Inherit(msgStyle).Render(content.String())
+			// Choose bubble style: own messages use distinct tint when BC_AGENT_ID matches sender
+			bubbleStyle := m.styles.MessageBubble
+			if entry.Sender != "" && entry.Sender == os.Getenv("BC_AGENT_ID") {
+				bubbleStyle = m.styles.MessageBubbleOwn
+			}
+			bubble := bubbleStyle.Width(msgWidth).Inherit(msgStyle).Render(content.String())
 			for _, line := range strings.Split(bubble, "\n") {
 				b.WriteString("  ")
 				b.WriteString(line)

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -774,5 +775,46 @@ func TestChannelView_MessageBubbleRendering(t *testing.T) {
 	// Verify sender is rendered
 	if !strings.Contains(output, "engineer-01") {
 		t.Error("expected sender name in output")
+	}
+}
+
+func TestChannelView_EmptyMessageShowsPlaceholder(t *testing.T) {
+	m := newTestChannelModel()
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "engineer-01", Message: "", Time: time.Now()},
+	}
+
+	output := m.View()
+
+	if !strings.Contains(output, "(empty)") {
+		t.Error("expected (empty) placeholder for empty message, got output without it")
+	}
+	if !strings.Contains(output, "engineer-01") {
+		t.Error("expected sender name in output")
+	}
+}
+
+func TestChannelView_OwnMessageUsesDistinctBubble(t *testing.T) {
+	prev := os.Getenv("BC_AGENT_ID")
+	defer func() { _ = os.Setenv("BC_AGENT_ID", prev) }()
+	_ = os.Setenv("BC_AGENT_ID", "engineer-02")
+
+	m := newTestChannelModel()
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "engineer-02", Message: "my own message", Time: time.Now()},
+		{Sender: "engineer-01", Message: "other message", Time: time.Now()},
+	}
+
+	output := m.View()
+
+	// Both messages must appear; own message uses MessageBubbleOwn (we can't assert ANSI, just content)
+	if !strings.Contains(output, "my own message") {
+		t.Error("expected own message in output")
+	}
+	if !strings.Contains(output, "other message") {
+		t.Error("expected other message in output")
+	}
+	if !strings.Contains(output, "engineer-02") || !strings.Contains(output, "engineer-01") {
+		t.Error("expected both senders in output")
 	}
 }

--- a/pkg/tui/style/theme.go
+++ b/pkg/tui/style/theme.go
@@ -23,9 +23,10 @@ type Theme struct {
 	Info    lipgloss.Color
 
 	// UI element colors
-	Selection   lipgloss.Color
-	HeaderBg    lipgloss.Color
-	StatusBarBg lipgloss.Color
+	Selection    lipgloss.Color
+	HeaderBg     lipgloss.Color
+	StatusBarBg  lipgloss.Color
+	OwnMessageBg lipgloss.Color // Background for messages sent by current user
 
 	// Agent role colors
 	RoleCoordinator lipgloss.Color
@@ -75,9 +76,10 @@ func DarkTheme() Theme {
 		Info:    lipgloss.Color("#59C2FF"),
 
 		// UI
-		Selection:   lipgloss.Color("#409FFF"),
-		HeaderBg:    lipgloss.Color("#1C2028"),
-		StatusBarBg: lipgloss.Color("#1C2028"),
+		Selection:    lipgloss.Color("#409FFF"),
+		HeaderBg:     lipgloss.Color("#1C2028"),
+		StatusBarBg:  lipgloss.Color("#1C2028"),
+		OwnMessageBg: lipgloss.Color("#252D3A"), // Slightly warmer tint for own messages
 
 		// Agent roles (muted/pastel for dark theme)
 		RoleCoordinator: lipgloss.Color("#6B9FD4"), // Blue
@@ -109,9 +111,10 @@ func LightTheme() Theme {
 		Info:    lipgloss.Color("#399EE6"),
 
 		// UI
-		Selection:   lipgloss.Color("#035BD6"),
-		HeaderBg:    lipgloss.Color("#E8E9EB"),
-		StatusBarBg: lipgloss.Color("#E8E9EB"),
+		Selection:    lipgloss.Color("#035BD6"),
+		HeaderBg:     lipgloss.Color("#E8E9EB"),
+		StatusBarBg:  lipgloss.Color("#E8E9EB"),
+		OwnMessageBg: lipgloss.Color("#D4E4F0"), // Light blue tint for own messages
 
 		// Agent roles (saturated for light theme)
 		RoleCoordinator: lipgloss.Color("#2563EB"), // Blue
@@ -143,9 +146,10 @@ func HighContrastTheme() Theme {
 		Info:    lipgloss.Color("#00FFFF"),
 
 		// UI
-		Selection:   lipgloss.Color("#0000FF"),
-		HeaderBg:    lipgloss.Color("#333333"),
-		StatusBarBg: lipgloss.Color("#333333"),
+		Selection:    lipgloss.Color("#0000FF"),
+		HeaderBg:     lipgloss.Color("#333333"),
+		StatusBarBg:  lipgloss.Color("#333333"),
+		OwnMessageBg: lipgloss.Color("#1A1A3A"), // Distinct tint for own messages
 
 		// Agent roles (high contrast, distinct colors)
 		RoleCoordinator: lipgloss.Color("#00BFFF"), // Blue
@@ -204,8 +208,9 @@ type Styles struct {
 	// Reaction style for emoji reactions on messages
 	Reaction lipgloss.Style
 
-	// Message bubble style (subtle background tint)
-	MessageBubble lipgloss.Style
+	// Message bubble styles (subtle background tint)
+	MessageBubble    lipgloss.Style // Others' messages
+	MessageBubbleOwn lipgloss.Style // Current user's messages
 
 	theme Theme
 }
@@ -284,6 +289,9 @@ func NewStyles(theme Theme) Styles {
 		// Message bubble with subtle background tint (not heavy borders)
 		MessageBubble: lipgloss.NewStyle().
 			Background(theme.HeaderBg).
+			Padding(0, 1),
+		MessageBubbleOwn: lipgloss.NewStyle().
+			Background(theme.OwnMessageBg).
 			Padding(0, 1),
 	}
 }

--- a/pkg/tui/style/theme_test.go
+++ b/pkg/tui/style/theme_test.go
@@ -353,3 +353,23 @@ func TestMessageBubbleStyle(t *testing.T) {
 		t.Errorf("MessageBubble should contain message, got: %s", rendered)
 	}
 }
+
+func TestMessageBubbleOwnStyle(t *testing.T) {
+	styles := DefaultStyles()
+	rendered := styles.MessageBubbleOwn.Render("my message")
+	if rendered == "" {
+		t.Error("MessageBubbleOwn style should render text")
+	}
+	if !strings.Contains(rendered, "my message") {
+		t.Errorf("MessageBubbleOwn should contain message, got: %s", rendered)
+	}
+}
+
+func TestAllThemesHaveOwnMessageBg(t *testing.T) {
+	for _, name := range AvailableThemes() {
+		theme := GetTheme(name)
+		if theme.OwnMessageBg == "" {
+			t.Errorf("theme %q has no OwnMessageBg", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Implements **#307** Channel bubble UI fixes, part of P1 channel epic **#314**. Aligns with #304 UX review.

## Changes
- **Own vs others**: Messages from the current user (`BC_AGENT_ID`) use a distinct bubble style (`MessageBubbleOwn`) with a subtle tint so "my" messages are visually distinct in dark, light, and high-contrast themes.
- **Empty messages**: Empty message bodies now show a muted `(empty)` placeholder instead of a blank bubble.
- **Theme**: Added `OwnMessageBg` and `MessageBubbleOwn` to all three themes.

## Tests
- `TestMessageBubbleOwnStyle`, `TestAllThemesHaveOwnMessageBg` (style)
- `TestChannelView_EmptyMessageShowsPlaceholder`, `TestChannelView_OwnMessageUsesDistinctBubble` (channel view)

All tests pass (config `TestAgentsContainsClaude` failure is pre-existing).

Made with [Cursor](https://cursor.com)