### PR TITLE
feat(tui): loading indicators and reduce perceived wait (#325, epic #322)

### DIFF
--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
@@ -31,6 +32,11 @@ const (
 // TickMsg triggers a periodic refresh.
 type TickMsg struct{}
 
+// workspaceLoadedMsg is sent when async workspace load completes.
+type workspaceLoadedMsg struct {
+	Model *WorkspaceModel
+}
+
 // WorkspaceInfo holds summary data for a workspace in the home view.
 type WorkspaceInfo struct {
 	Entry      workspace.RegistryEntry
@@ -43,19 +49,22 @@ type WorkspaceInfo struct {
 
 // HomeModel is the root TUI model for bc home.
 type HomeModel struct {
-	wsModel      *WorkspaceModel
-	agentModel   *AgentModel
-	channelModel *ChannelModel
-	issueModel   *IssueModel
-	styles       style.Styles
-	statusMsg    string
-	workspaces   []WorkspaceInfo
-	screen       Screen
-	maxWorkers   int
-	width        int
-	height       int
-	homeCursor   int
-	helpActive   bool
+	wsModel              *WorkspaceModel
+	agentModel           *AgentModel
+	channelModel         *ChannelModel
+	issueModel           *IssueModel
+	styles               style.Styles
+	statusMsg            string
+	pendingWorkspaceName string // workspace name shown in header while loading
+	workspaces           []WorkspaceInfo
+	loadingSpinner       spinner.Model // spinner shown during workspace load
+	screen               Screen
+	maxWorkers           int
+	width                int
+	height               int
+	homeCursor           int
+	helpActive           bool
+	workspaceLoading     bool // true while workspace is loading after Enter
 }
 
 // NewHomeModel creates the root TUI model. maxWorkers is the configured agent limit (0 = no limit).
@@ -72,6 +81,13 @@ func tickCmd() tea.Cmd {
 	return tea.Tick(config.Tui.RefreshInterval, func(time.Time) tea.Msg {
 		return TickMsg{}
 	})
+}
+
+// loadWorkspaceCmd runs NewWorkspaceModel in the background and sends workspaceLoadedMsg when done.
+func loadWorkspaceCmd(ws WorkspaceInfo, s style.Styles) tea.Cmd {
+	return func() tea.Msg {
+		return workspaceLoadedMsg{Model: NewWorkspaceModel(ws, s)}
+	}
 }
 
 // Init implements tea.Model.
@@ -111,6 +127,23 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.agentModel.refreshLight()
 		}
 		return m, tickCmd()
+
+	case workspaceLoadedMsg:
+		m.wsModel = msg.Model
+		m.wsModel.width = m.width
+		m.wsModel.height = m.height
+		m.workspaceLoading = false
+		m.pendingWorkspaceName = ""
+		m.statusMsg = ""
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.workspaceLoading {
+			var cmd tea.Cmd
+			m.loadingSpinner, cmd = m.loadingSpinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
 
 	case tea.KeyMsg:
 		return m.handleKey(msg)
@@ -211,11 +244,18 @@ func (m *HomeModel) handleHomeKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if isEnterKey(msg) {
 		if m.homeCursor < len(m.workspaces) {
 			ws := m.workspaces[m.homeCursor]
-			m.wsModel = NewWorkspaceModel(ws, m.styles)
-			m.wsModel.width = m.width
-			m.wsModel.height = m.height
 			m.screen = ScreenWorkspace
-			m.statusMsg = ""
+			m.workspaceLoading = true
+			m.pendingWorkspaceName = ws.Entry.Name
+			m.wsModel = nil
+			m.loadingSpinner = spinner.New(
+				spinner.WithSpinner(spinner.Dot),
+				spinner.WithStyle(m.styles.Muted),
+			)
+			return m, tea.Batch(
+				loadWorkspaceCmd(ws, m.styles),
+				tea.Tick(80*time.Millisecond, func(time.Time) tea.Msg { return m.loadingSpinner.Tick() }),
+			)
 		}
 	}
 	return m, nil
@@ -228,6 +268,8 @@ func (m *HomeModel) handleWorkspaceKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "esc":
 		m.screen = ScreenHome
 		m.wsModel = nil
+		m.workspaceLoading = false
+		m.pendingWorkspaceName = ""
 		m.statusMsg = ""
 		return m, nil
 	}
@@ -374,7 +416,9 @@ func (m *HomeModel) View() string {
 		case ScreenHome:
 			sections = append(sections, m.renderHomeScreen())
 		case ScreenWorkspace:
-			if m.wsModel != nil {
+			if m.workspaceLoading {
+				sections = append(sections, m.renderWorkspaceLoading())
+			} else if m.wsModel != nil {
 				sections = append(sections, m.wsModel.View())
 			}
 		case ScreenAgent:
@@ -409,6 +453,8 @@ func (m *HomeModel) renderHeader() string {
 	case ScreenWorkspace:
 		if m.wsModel != nil {
 			parts = append(parts, sep, m.styles.Info.Render(m.wsModel.info.Entry.Name))
+		} else if m.pendingWorkspaceName != "" {
+			parts = append(parts, sep, m.styles.Muted.Render(m.pendingWorkspaceName+" (loading…)"))
 		}
 	case ScreenAgent:
 		if m.wsModel != nil {
@@ -434,6 +480,19 @@ func (m *HomeModel) renderHeader() string {
 	}
 
 	return strings.Join(parts, "")
+}
+
+// renderWorkspaceLoading shows a spinner and message while workspace data loads.
+func (m *HomeModel) renderWorkspaceLoading() string {
+	var b strings.Builder
+	b.WriteString("\n\n  ")
+	b.WriteString(m.loadingSpinner.View())
+	b.WriteString(" ")
+	b.WriteString(m.styles.Muted.Render("Loading workspace…"))
+	b.WriteString("\n\n")
+	b.WriteString(m.styles.Muted.Render("  Agents, issues, and channels are being loaded."))
+	b.WriteString("\n")
+	return b.String()
 }
 
 func (m *HomeModel) renderHomeScreen() string {

--- a/internal/tui/home_test.go
+++ b/internal/tui/home_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/rpuneet/bc/pkg/agent"
@@ -81,6 +82,35 @@ func TestRenderHeader_WorkspaceScreen(t *testing.T) {
 	output := m.renderHeader()
 	if !strings.Contains(output, "test-project") {
 		t.Errorf("expected workspace name in header, got: %s", output)
+	}
+}
+
+func TestRenderHeader_WorkspaceLoading(t *testing.T) {
+	m := newTestHomeModel()
+	m.screen = ScreenWorkspace
+	m.workspaceLoading = true
+	m.pendingWorkspaceName = "my-workspace"
+
+	output := m.renderHeader()
+	if !strings.Contains(output, "my-workspace") {
+		t.Errorf("expected workspace name in header while loading, got: %s", output)
+	}
+	if !strings.Contains(output, "loading") {
+		t.Errorf("expected loading indicator in header, got: %s", output)
+	}
+}
+
+func TestRenderWorkspaceLoading(t *testing.T) {
+	m := newTestHomeModel()
+	m.workspaceLoading = true
+	m.loadingSpinner = spinner.New(spinner.WithSpinner(spinner.Dot))
+
+	output := m.renderWorkspaceLoading()
+	if !strings.Contains(output, "Loading workspace") {
+		t.Errorf("expected loading message, got: %s", output)
+	}
+	if !strings.Contains(output, "Agents") {
+		t.Errorf("expected hint about agents/issues, got: %s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements **#325** (TUI usability: loading indicators and reduce perceived wait) for epic **#322** (P1 TUI perf).

## Changes
- **Loading indicator**: When user presses Enter on a workspace from home, the UI immediately switches to the workspace screen and shows an animated spinner with "Loading workspace…" and a short hint ("Agents, issues, and channels are being loaded").
- **Async workspace load**: Workspace data (agents, issues, channels, queue, stats, etc.) is loaded in the background via a `tea.Cmd` so the TUI stays responsive and the user sees the loading state instead of a frozen screen.
- **Header**: Breadcrumb shows workspace name + "(loading…)" while loading.
- **Esc**: Cancels loading and returns to home (clears loading state).

## Testing
- `go test ./internal/tui/...` passes.
- New tests: `TestRenderHeader_WorkspaceLoading`, `TestRenderWorkspaceLoading`.

Closes #325 (when merged). Part of epic #322.

Made with [Cursor](https://cursor.com)