### PR TITLE
TUI channel view: virtualize message list for long history (#326)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -90,6 +90,7 @@ func (m *ChannelModel) HandleKey(msg tea.KeyMsg) Action {
 		if m.cursor < m.visibleCount()-1 {
 			m.cursor++
 		}
+		m.clampCursor()
 		return NoAction
 	case "k", "up":
 		maxScroll := len(m.channel.History) - m.visibleMsgCount()
@@ -102,6 +103,7 @@ func (m *ChannelModel) HandleKey(msg tea.KeyMsg) Action {
 		if m.cursor > 0 {
 			m.cursor--
 		}
+		m.clampCursor()
 		return NoAction
 	case "s":
 		m.sendMode = true
@@ -123,9 +125,11 @@ func (m *ChannelModel) HandleKey(msg tea.KeyMsg) Action {
 			maxScroll = 0
 		}
 		m.scroll = maxScroll
+		m.clampCursor()
 		return NoAction
 	case "G", "end":
 		m.scroll = 0
+		m.clampCursor()
 		return NoAction
 	case "i":
 		if entry, ok := m.selectedMessage(); ok {
@@ -160,48 +164,48 @@ func (m *ChannelModel) HandleMouse(msg tea.MouseMsg) {
 		}
 	}
 	m.clampScroll()
+	m.clampCursor()
 }
 
-// visibleCount returns the number of messages currently displayed.
+// visibleCount returns the number of messages currently displayed (window size).
 func (m *ChannelModel) visibleCount() int {
-	n := len(m.channel.History)
-	if n > 20 {
-		return 20
-	}
-	return n
+	start, end := m.visibleWindow()
+	return end - start
 }
 
-// selectedMessage returns the currently selected history entry.
+// selectedMessage returns the currently selected history entry from the visible window.
 func (m *ChannelModel) selectedMessage() (channel.HistoryEntry, bool) {
-	n := len(m.channel.History)
-	if n == 0 {
+	start, end := m.visibleWindow()
+	n := end - start
+	if n == 0 || m.cursor < 0 || m.cursor >= n {
 		return channel.HistoryEntry{}, false
 	}
-	start := 0
-	if n > 20 {
-		start = n - 20
-	}
-	visible := m.channel.History[start:]
-	if m.cursor < 0 || m.cursor >= len(visible) {
-		return channel.HistoryEntry{}, false
-	}
-	return visible[m.cursor], true
+	return m.channel.History[start+m.cursor], true
 }
 
 // selectedMessageIndex returns the index of the selected message in the full history.
 func (m *ChannelModel) selectedMessageIndex() int {
-	n := len(m.channel.History)
-	if n == 0 {
-		return -1
-	}
-	start := 0
-	if n > 20 {
-		start = n - 20
-	}
-	if m.cursor < 0 || m.cursor >= n-start {
+	start, end := m.visibleWindow()
+	n := end - start
+	if n == 0 || m.cursor < 0 || m.cursor >= n {
 		return -1
 	}
 	return start + m.cursor
+}
+
+// clampCursor keeps cursor within the current visible window (e.g. after scroll or resize).
+func (m *ChannelModel) clampCursor() {
+	n := m.visibleCount()
+	if n <= 0 {
+		m.cursor = 0
+		return
+	}
+	if m.cursor >= n {
+		m.cursor = n - 1
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
 }
 
 func (m *ChannelModel) handleReactionKey(msg tea.KeyMsg) Action {
@@ -623,6 +627,29 @@ func (m *ChannelModel) clampScroll() {
 	}
 }
 
+// visibleWindow returns the [start, end) index range of the message list that is
+// currently visible (windowed for long history). Same logic as View() so cursor and
+// selection stay consistent with what is drawn.
+func (m *ChannelModel) visibleWindow() (start, end int) {
+	total := len(m.channel.History)
+	if total == 0 {
+		return 0, 0
+	}
+	visible := m.visibleMsgCount()
+	end = total - m.scroll
+	start = end - visible
+	if start < 0 {
+		start = 0
+	}
+	if end < 0 {
+		end = 0
+	}
+	if end > total {
+		end = total
+	}
+	return start, end
+}
+
 // visibleMsgCount returns how many messages fit in the visible area.
 func (m *ChannelModel) visibleMsgCount() int {
 	// Reserve lines: title(1) + summary(0 or more) + member stats(1) + member list(1+)
@@ -757,18 +784,7 @@ func (m *ChannelModel) View() string {
 		b.WriteString("\n")
 	} else {
 		m.clampScroll()
-		visible := m.visibleMsgCount()
-		total := len(m.channel.History)
-
-		// Calculate visible window based on scroll offset from end
-		end := total - m.scroll
-		start := end - visible
-		if start < 0 {
-			start = 0
-		}
-		if end < 0 {
-			end = 0
-		}
+		start, end := m.visibleWindow()
 
 		// Scroll indicator (top)
 		if start > 0 {
@@ -896,13 +912,14 @@ func (m *ChannelModel) View() string {
 		b.WriteString(m.styles.Muted.Render("  No messages"))
 		b.WriteString("\n")
 	} else {
-		// Show last 20 messages
-		start := 0
+		// Show last 20 messages (windowed for long history)
+		recentStart := 0
 		if len(m.channel.History) > 20 {
-			start = len(m.channel.History) - 20
+			recentStart = len(m.channel.History) - 20
 		}
 		var lastDate time.Time
-		recentHistory := m.channel.History[start:]
+		recentHistory := m.channel.History[recentStart:]
+		selectedIdx := m.selectedMessageIndex()
 		for i, entry := range recentHistory {
 			// Add date separator if this is a new day
 			if i == 0 || !isSameDay(entry.Time, lastDate) {
@@ -912,7 +929,7 @@ func (m *ChannelModel) View() string {
 			}
 			lastDate = entry.Time
 
-			selected := i == m.cursor
+			selected := (recentStart + i) == selectedIdx
 
 			// Infer message type for styling
 			msgType := channel.InferMessageType(entry.Message)

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -231,9 +231,66 @@ func TestVisibleCount_Large(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		m.channel.History = append(m.channel.History, channel.HistoryEntry{Sender: "a", Message: "msg"})
 	}
+	// visibleCount is the window size (virtualized), not a fixed 20 cap
+	got := m.visibleCount()
+	want := m.visibleMsgCount()
+	if got != want {
+		t.Errorf("visibleCount = %d, want window size visibleMsgCount() = %d", got, want)
+	}
+	if got > 50 || got <= 0 {
+		t.Errorf("visibleCount = %d, want in (0, 50] for 50 messages", got)
+	}
+}
 
-	if m.visibleCount() != 20 {
-		t.Errorf("visibleCount = %d, want 20 (max)", m.visibleCount())
+// --- visibleWindow / virtualization tests (#326) ---
+
+func TestVisibleWindow_LongHistory(t *testing.T) {
+	m := newTestChannelModel()
+	m.channel.History = nil
+	for i := 0; i < 100; i++ {
+		m.channel.History = append(m.channel.History, channel.HistoryEntry{
+			Sender:  "u",
+			Message: "msg",
+			Time:    time.Now(),
+		})
+	}
+	start, end := m.visibleWindow()
+	windowSize := end - start
+	if windowSize != m.visibleMsgCount() {
+		t.Errorf("at scroll=0 window size = %d, want visibleMsgCount() = %d", windowSize, m.visibleMsgCount())
+	}
+	if end != 100 {
+		t.Errorf("end = %d, want 100", end)
+	}
+	// Scroll up (older messages)
+	m.scroll = 50
+	start, end = m.visibleWindow()
+	if start < 0 || end > 100 || end <= start {
+		t.Errorf("visibleWindow [%d,%d) invalid for 100 messages", start, end)
+	}
+	if end-start != windowSize && end-start != 100-start {
+		t.Errorf("window size changed unexpectedly to %d", end-start)
+	}
+}
+
+func TestSelectedMessageIndex_LongHistory(t *testing.T) {
+	m := newTestChannelModel()
+	for i := 0; i < 50; i++ {
+		m.channel.History = append(m.channel.History, channel.HistoryEntry{
+			Sender:  "u",
+			Message: "msg",
+			Time:    time.Now(),
+		})
+	}
+	m.cursor = 2
+	idx := m.selectedMessageIndex()
+	start, _ := m.visibleWindow()
+	if idx != start+2 {
+		t.Errorf("selectedMessageIndex = %d, want start+cursor = %d", idx, start+2)
+	}
+	_, ok := m.selectedMessage()
+	if !ok {
+		t.Fatal("selectedMessage should be ok")
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements #326 (epic #322): virtualize/window the channel message list so long history works correctly. Previously `visibleCount()`, `selectedMessage()`, and `selectedMessageIndex()` used a hardcoded 20-message cap, so cursor and selection were wrong with 20+ messages.

## Changes
- **visibleWindow()**: Returns `(start, end)` for the current visible message range using the same logic as `View()` (single source of truth).
- **visibleCount()**: Now returns `end - start` (window size) instead of `min(n, 20)`.
- **selectedMessage()** / **selectedMessageIndex()**: Index into the visible window so selection matches what is drawn (correct for create-issue, reactions, etc.).
- **clampCursor()**: Called after j/k/g/G so cursor stays within the visible window.
- **View()**: Uses `visibleWindow()` for the main message area; Recent Messages section uses `selectedMessageIndex()` for the selection highlight when scrolled.

## Testing
- `go test ./internal/tui/...` passes.
- New tests: `TestVisibleWindow_LongHistory`, `TestSelectedMessageIndex_LongHistory`; `TestVisibleCount_Large` updated for windowed semantics.

Closes #326.

Made with [Cursor](https://cursor.com)