### PR TITLE
TUI per-screen: defer or lazy-load heavy data (#324, epic #322)

### DIFF
--- a/internal/tui/PROFILE.md
+++ b/internal/tui/PROFILE.md
@@ -34,6 +34,12 @@
 2. **Documentation**  
    This file records root causes and the above fixes for future profiling work.
 
+3. **Per-screen lazy-load (#324 / epic #322)**  
+   - **Workspace**: `NewWorkspaceModel` loads only manager + agents. Issues, channels, queue, events, stats load on first focus of each tab via `ensureTabDataLoaded(tab)` in `View()`. Stats bar shows zeros until Issues or Dashboard is loaded; full reload on 'r' sets all flags.  
+   - **Agent**: `NewAgentModel` no longer calls `loadRecentActivity()` / `loadMemoryInfo()`; `ensureHeavyDataLoaded()` runs on first `View()`.  
+   - **Channel**: `store.Load()` is deferred from home drill-down to first `ChannelModel.View()`; first paint loads store and refreshes channel.  
+   Effect: Opening a workspace shows Agents tab immediately; heavy data loads when user switches to that tab or screen.
+
 ## Possible follow-ups
 
 - **Startup**: Show TUI immediately with “Loading…” and load workspaces in a goroutine, then send an update message (e.g. `WorkspacesLoaded`).

--- a/internal/tui/agent.go
+++ b/internal/tui/agent.go
@@ -32,20 +32,20 @@ type AgentModel struct {
 	peekActive      bool
 	sendMode        bool
 	hasMemory       bool
+	// Lazy-loaded: recent activity and memory loaded on first View (#324).
+	heavyDataLoaded bool
 }
 
 // NewAgentModel creates an agent detail view.
 // wsPath is the workspace root path for loading event data.
+// Heavy data (recent activity, memory) is deferred until first View (#324).
 func NewAgentModel(a *agent.Agent, mgr *agent.Manager, wsPath string, s style.Styles) *AgentModel {
-	m := &AgentModel{
+	return &AgentModel{
 		agent:   a,
 		manager: mgr,
 		styles:  s,
 		wsPath:  wsPath,
 	}
-	m.loadRecentActivity()
-	m.loadMemoryInfo()
-	return m
 }
 
 // HandleKey processes a key event and returns an action for the parent.
@@ -187,7 +187,19 @@ func (m *AgentModel) loadRecentActivity() {
 }
 
 // View renders the agent detail screen.
+// ensureHeavyDataLoaded loads recent activity and memory on first paint (#324).
+func (m *AgentModel) ensureHeavyDataLoaded() {
+	if m.heavyDataLoaded {
+		return
+	}
+	m.loadRecentActivity()
+	m.loadMemoryInfo()
+	m.heavyDataLoaded = true
+}
+
 func (m *AgentModel) View() string {
+	m.ensureHeavyDataLoaded()
+
 	var b strings.Builder
 
 	b.WriteString(m.styles.Title.Render(m.agent.Name))

--- a/internal/tui/benchmark_test.go
+++ b/internal/tui/benchmark_test.go
@@ -43,6 +43,7 @@ func BenchmarkWorkspaceView_Agents(b *testing.B) {
 		{Name: "eng-03", State: agent.StateStopped},
 	}
 	m.agentsLoaded = true
+	m.agentStatsLoaded = true
 	m.computeStats()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -89,6 +90,7 @@ func BenchmarkWorkspaceView_Queue(b *testing.B) {
 		{ID: "bd-2", Title: "Task two", Status: "in_progress", Assignee: "eng-01", Type: "work"},
 	}
 	m.filteredQueue = m.queueItems
+	m.queueLoaded = true
 	m.computeStats()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -108,6 +110,10 @@ func BenchmarkWorkspaceView_Dashboard(b *testing.B) {
 		{Type: events.WorkCompleted, Agent: "engineer-01", Message: "Done"},
 	}
 	m.issuesLoaded = true
+	m.channelsLoaded = true
+	m.queueLoaded = true
+	m.agentStatsLoaded = true
+	m.pkgStatsLoaded = true
 	m.computeStats()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -123,6 +129,8 @@ func BenchmarkWorkspaceView_Stats(b *testing.B) {
 		{Name: "eng-02", State: agent.StateIdle},
 	}
 	m.agentsLoaded = true
+	m.agentStatsLoaded = true
+	m.pkgStatsLoaded = true
 	m.computeStats()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -53,6 +53,8 @@ type ChannelModel struct {
 	autocompleteType AutocompleteType
 	sendMode         bool
 	reactionMode     bool // Show reaction picker for selected message
+	// storeLoaded: defer store.Load() until first View (#324).
+	storeLoaded bool
 }
 
 // NewChannelModel creates a channel detail view.
@@ -602,6 +604,14 @@ func (m *ChannelModel) visibleMsgCount() int {
 
 // View renders the channel detail screen.
 func (m *ChannelModel) View() string {
+	// Defer store load until first paint (#324).
+	if !m.storeLoaded {
+		if m.store != nil {
+			m.reloadChannel()
+		}
+		m.storeLoaded = true
+	}
+
 	var b strings.Builder
 
 	// Calculate widths

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -252,7 +252,7 @@ func (m *HomeModel) handleWorkspaceKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		case ActionDrillChannel:
 			if ch, ok := action.Data.(*channel.Channel); ok {
 				store := channel.NewStore(m.wsModel.info.Entry.Path)
-				_ = store.Load()
+				// Defer store.Load() until first channel View (#324).
 				m.channelModel = NewChannelModel(ch, store, m.wsModel.manager, m.wsModel.info.Entry.Path, m.styles)
 				m.channelModel.width = m.width
 				m.channelModel.height = m.height

--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -109,13 +109,18 @@ type WorkspaceModel struct {
 	tab          Tab
 	queueFilter  QueueFilter
 
-	// Loaded flags
-	agentsLoaded   bool
-	issuesLoaded   bool
-	channelsLoaded bool
+	// Loaded flags (lazy-load per tab / on focus; see ensureTabDataLoaded)
+	agentsLoaded     bool
+	issuesLoaded     bool
+	channelsLoaded   bool
+	queueLoaded      bool
+	agentStatsLoaded bool
+	pkgStatsLoaded   bool
 }
 
 // NewWorkspaceModel creates a workspace detail view.
+// Heavy data (issues, channels, queue, events, stats) is deferred until the user
+// focuses the relevant tab; see ensureTabDataLoaded (epic #322 / #324).
 func NewWorkspaceModel(info WorkspaceInfo, s style.Styles) *WorkspaceModel {
 	m := &WorkspaceModel{
 		info:   info,
@@ -123,7 +128,7 @@ func NewWorkspaceModel(info WorkspaceInfo, s style.Styles) *WorkspaceModel {
 		tab:    TabAgents,
 	}
 
-	// Load agent data
+	// Only load agent data so the Agents tab can render immediately.
 	m.manager = agent.NewWorkspaceManager(
 		info.Entry.Path+"/.bc/agents",
 		info.Entry.Path,
@@ -133,28 +138,8 @@ func NewWorkspaceModel(info WorkspaceInfo, s style.Styles) *WorkspaceModel {
 	m.agents = m.manager.ListAgents()
 	m.agentsLoaded = true
 
-	// Load beads issues
-	m.issues, m.issuesErr = beads.ListIssues(info.Entry.Path)
-	m.issuesLoaded = true
-
-	// Load channels
-	m.loadChannels()
-
-	// Load per-agent stats from pkg/stats
-	m.loadAgentStats()
-
-	// Load per-agent memory info
-	m.loadMemoryInfo()
-
-	// Load queue data
-	m.loadQueue()
-
-	// Load recent events for activity feed
-	m.loadRecentEvents()
-
-	// Compute dashboard stats
-	m.computeStats()
-	m.loadPkgStats()
+	// Stats bar uses m.stats; computeStats will run when issues (or dashboard) are loaded.
+	m.issuesByAgent = make(map[string]int)
 
 	return m
 }
@@ -216,12 +201,17 @@ func (m *WorkspaceModel) refresh() {
 	_ = m.manager.RefreshState()
 	m.agents = m.manager.ListAgents()
 	m.issues, m.issuesErr = beads.ListIssues(m.info.Entry.Path)
+	m.issuesLoaded = true
 	m.loadChannels()
 	m.loadMemoryInfo()
 	m.loadQueue()
+	m.queueLoaded = true
 	m.loadRecentEvents()
 	m.computeStats()
+	m.loadAgentStats()
+	m.agentStatsLoaded = true
 	m.loadPkgStats()
+	m.pkgStatsLoaded = true
 	m.clampCursor()
 	m.ensureCursorVisible()
 }
@@ -370,8 +360,70 @@ func (m *WorkspaceModel) renderPositionIndicator(total int) string {
 	return m.styles.Muted.Render(fmt.Sprintf("  %d-%d of %d", start+1, end, total)) + "\n"
 }
 
+// ensureTabDataLoaded loads heavy data for the given tab on first focus (lazy-load per #324).
+func (m *WorkspaceModel) ensureTabDataLoaded(tab Tab) {
+	switch tab {
+	case TabAgents:
+		if !m.agentStatsLoaded {
+			m.loadAgentStats()
+			m.agentStatsLoaded = true
+		}
+		m.loadMemoryInfo()
+	case TabIssues:
+		if !m.issuesLoaded {
+			m.issues, m.issuesErr = beads.ListIssues(m.info.Entry.Path)
+			m.issuesLoaded = true
+			m.computeStats()
+		}
+	case TabChannels:
+		if !m.channelsLoaded {
+			m.loadChannels()
+		}
+	case TabQueue:
+		if !m.queueLoaded {
+			m.loadQueue()
+			m.queueLoaded = true
+		}
+	case TabDashboard:
+		if !m.issuesLoaded {
+			m.issues, m.issuesErr = beads.ListIssues(m.info.Entry.Path)
+			m.issuesLoaded = true
+		}
+		if !m.channelsLoaded {
+			m.loadChannels()
+		}
+		if !m.queueLoaded {
+			m.loadQueue()
+			m.queueLoaded = true
+		}
+		m.loadRecentEvents()
+		m.loadMemoryInfo()
+		if !m.agentStatsLoaded {
+			m.loadAgentStats()
+			m.agentStatsLoaded = true
+		}
+		m.computeStats()
+		if !m.pkgStatsLoaded {
+			m.loadPkgStats()
+			m.pkgStatsLoaded = true
+		}
+	case TabStats:
+		if !m.agentStatsLoaded {
+			m.loadAgentStats()
+			m.agentStatsLoaded = true
+		}
+		if !m.pkgStatsLoaded {
+			m.loadPkgStats()
+			m.pkgStatsLoaded = true
+		}
+	}
+}
+
 // View renders the workspace detail screen.
 func (m *WorkspaceModel) View() string {
+	// Lazy-load heavy data for the active tab on first focus (#324).
+	m.ensureTabDataLoaded(m.tab)
+
 	var b strings.Builder
 
 	// Workspace summary stats bar (above tab bar)


### PR DESCRIPTION
## Summary
Implements #324 (P1 for epic #322): defer or lazy-load heavy data on workspace/agent/channel so opening a workspace and drilling to agent/channel does not block on full load.

## Changes
- **Workspace**: `NewWorkspaceModel` loads only manager + agents. Issues, channels, queue, events, and stats load on first focus of each tab via `ensureTabDataLoaded(tab)` in `View()`. Stats bar shows 0 until data is loaded; full reload on `r` sets all flags.
- **Agent**: `NewAgentModel` no longer calls `loadRecentActivity()` / `loadMemoryInfo()` in constructor; `ensureHeavyDataLoaded()` runs on first `View()`.
- **Channel**: `store.Load()` deferred from home drill-down to first `ChannelModel.View()`; guard for nil store in tests.
- **Benchmarks**: Set `queueLoaded` / `agentStatsLoaded` / `pkgStatsLoaded` so `ensureTabDataLoaded` does not overwrite or trigger I/O.
- **PROFILE.md**: Document per-screen lazy-load.

## Acceptance
- [x] Workspace opens with Agents tab immediately; other tab data loads on first focus.
- [x] Agent screen defers recent activity and memory until first paint.
- [x] Channel screen defers store load until first paint.
- [x] `go build` and `go test ./internal/tui/` pass; pre-commit (gofmt, vet, golangci-lint) pass.

Closes #324

Made with [Cursor](https://cursor.com)