### PR TITLE
perf(bc home): reduce CLI memory by deferring workspace load (#310, #311, #296)

### DIFF
--- a/internal/cmd/MEMORY.md
+++ b/internal/cmd/MEMORY.md
@@ -3,7 +3,7 @@
 ## Profile summary
 
 - **TUI benchmarks** (`go test -bench=. -benchmem ./internal/tui/...`): Dashboard tab view is the heaviest path (~10 KB/op, ~248 allocs/op per render). Other tabs and home view are in the 3–7 KB/op range. See `internal/tui/benchmark_test.go`.
-- **CLI entry points**: `bc home` builds a workspace list (one Manager per workspace); `bc status` / `bc dashboard` load one Manager and agents once. `pkg/agent.ListAgents()` returns copies for thread safety and already pre-allocates the slice.
+- **CLI entry points**: `bc home` builds a minimal workspace list (no Manager/agent load at startup; TUI fills counts on first tick). `bc status` / `bc dashboard` load one Manager and agents once. `pkg/agent.ListAgents()` returns copies for thread safety and already pre-allocates the slice.
 - **Config**: Loaded once at init (global vars in `config` package). No per-command config reload.
 
 ## Reductions applied
@@ -14,11 +14,14 @@
 2. **internal/cmd/agent.go**  
    Pre-allocate the filtered agent list when filtering by role: `filtered := make([]*agent.Agent, 0, len(agents))` to avoid reallocations.
 
+3. **internal/cmd/home.go + internal/tui/home.go (#310)**  
+   Defer workspace agent/beads loading: `runHome` no longer creates a Manager per workspace or calls `LoadState()`/`RefreshState()` at CLI startup. It builds the workspace list with only `Entry` and `MaxWorkers` (zero counts). The TUI populates agent/issue counts on the first tick via `refreshWorkspaces()` when on the home screen (`homeWorkspacesRefreshed` ensures this runs once). Effect: lower memory and no blocking I/O before the TUI appears; counts show after the first refresh interval (~2s) or on manual `r` refresh.
+
 ## Hotspots (documented, not changed)
 
 - **ListAgents copies**: `pkg/agent.Manager.ListAgents()` allocates a new slice and agent copies by design to avoid data races. Callers should not hold large references longer than needed.
 - **Dashboard view**: `WorkspaceModel.View()` for TabDashboard does more formatting and allocations than other tabs; acceptable for interactive use. Further reduction would require refactoring render helpers.
-- **runHome workspace loop**: One Manager per workspace is created and discarded after counting; could be revisited if many workspaces cause high memory (e.g. lazy or pooled loading).
+- **refreshWorkspaces**: Still creates one Manager per workspace when run (on first tick or on `r`); runs only when on home screen, once per session plus manual refresh.
 
 ## Verification
 

--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/rpuneet/bc/config"
 	itui "github.com/rpuneet/bc/internal/tui"
-	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
@@ -53,28 +52,15 @@ func runHome(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Build workspace info for each registered workspace (pre-allocate to reduce allocations)
+	// Build workspace list with zero counts; TUI will fill counts on first tick (#310).
+	// This avoids N Manager loads and RefreshState() at CLI startup, reducing memory and improving TUI appearance time.
 	list := reg.List()
 	workspaces := make([]itui.WorkspaceInfo, 0, len(list))
 	for _, entry := range list {
-		info := itui.WorkspaceInfo{
+		workspaces = append(workspaces, itui.WorkspaceInfo{
 			Entry:      entry,
 			MaxWorkers: int(config.Workspace.MaxWorkers),
-		}
-
-		// Count running agents
-		mgr := agent.NewWorkspaceManager(
-			entry.Path+"/.bc/agents",
-			entry.Path,
-		)
-		_ = mgr.LoadState()
-		_ = mgr.RefreshState()
-		info.Total = mgr.AgentCount()
-		info.Running = mgr.RunningCount()
-
-		// Note: Issue tracking now uses GitHub Issues (beads removed)
-
-		workspaces = append(workspaces, info)
+		})
 	}
 
 	// Run the Bubble Tea TUI

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -49,22 +49,23 @@ type WorkspaceInfo struct {
 
 // HomeModel is the root TUI model for bc home.
 type HomeModel struct {
-	wsModel              *WorkspaceModel
-	agentModel           *AgentModel
-	channelModel         *ChannelModel
-	issueModel           *IssueModel
-	styles               style.Styles
-	statusMsg            string
-	pendingWorkspaceName string // workspace name shown in header while loading
-	workspaces           []WorkspaceInfo
-	loadingSpinner       spinner.Model // spinner shown during workspace load
-	screen               Screen
-	maxWorkers           int
-	width                int
-	height               int
-	homeCursor           int
-	helpActive           bool
-	workspaceLoading     bool // true while workspace is loading after Enter
+	wsModel                 *WorkspaceModel
+	agentModel              *AgentModel
+	channelModel            *ChannelModel
+	issueModel              *IssueModel
+	styles                  style.Styles
+	statusMsg               string
+	pendingWorkspaceName    string // workspace name shown in header while loading
+	workspaces              []WorkspaceInfo
+	loadingSpinner          spinner.Model // spinner shown during workspace load
+	screen                  Screen
+	maxWorkers              int
+	width                   int
+	height                  int
+	homeCursor              int
+	helpActive              bool // true when help overlay is shown
+	workspaceLoading        bool // true while workspace is loading after Enter
+	homeWorkspacesRefreshed bool // true after first tick on home (populates counts deferred from CLI)
 }
 
 // NewHomeModel creates the root TUI model. maxWorkers is the configured agent limit (0 = no limit).
@@ -120,6 +121,11 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case TickMsg:
+		// Populate workspace counts once on first tick when CLI deferred loading (#310)
+		if m.screen == ScreenHome && !m.homeWorkspacesRefreshed {
+			m.refreshWorkspaces()
+			m.homeWorkspacesRefreshed = true
+		}
 		if m.wsModel != nil {
 			m.wsModel.refreshLight()
 		}


### PR DESCRIPTION
## Summary
Implements **#310** (bc home: reduce CLI memory usage) for epic **#311** (bc home) / bug **#296**.

## Changes
- **runHome**: No longer creates a Manager per workspace or calls `LoadState()`/`RefreshState()` at CLI startup. Builds the workspace list with only `Entry` and `MaxWorkers` (Running/Total/Issues/HasBeads left at zero).
- **TUI**: On the first tick when the user is on the home screen, `refreshWorkspaces()` runs once (`homeWorkspacesRefreshed` flag) to populate agent/issue counts. User can also press `r` to refresh anytime.
- **Effect**: Lower memory at startup, no blocking I/O before the TUI appears; workspace counts show after the first refresh interval (~2s) or immediately on manual `r` refresh.

## Docs
- `internal/cmd/MEMORY.md` updated with reduction #3 and hotspot note.

Closes #310. Part of epic #311.

Made with [Cursor](https://cursor.com)