### PR TITLE
TUI per-screen: defer or lazy-load heavy data (#324, #322)

### DIFF
--- a/internal/tui/PROFILE.md
+++ b/internal/tui/PROFILE.md
@@ -44,3 +44,9 @@
 
 - **Startup**: Show TUI immediately with “Loading…” and load workspaces in a goroutine, then send an update message (e.g. `WorkspacesLoaded`).
 - **Throttle captureLiveTask**: Run tmux capture less often or only for the focused agent; or run captures in parallel.
+
+## Fixes applied (per-screen lazy-load, #324 / #322)
+
+- **Workspace open**: `NewWorkspaceModel` now does minimal work for first paint (Agents tab only): manager, `LoadState`, `RefreshState`, agents, `loadAgentStats`, `computeStatsFromAgentsOnly`. Issues, channels, queue, recent events, memory, and pkg stats are not loaded.
+- **Tab focus load**: `ensureTabDataLoaded(tab)` loads data for the focused tab when the user switches tabs (tab / shift+tab). Issues tab loads `beads.ListIssues` + `computeStats`; Channels loads `loadChannels`; Queue loads `loadQueue`; Dashboard loads issues + `loadRecentEvents`; Stats loads issues + `loadPkgStats`. Each dataset is loaded at most once and then cached.
+- **Refresh**: Explicit `r` still runs full `refresh()` and marks all data loaded so subsequent tab switches use cache.

--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -110,12 +110,13 @@ type WorkspaceModel struct {
 	queueFilter  QueueFilter
 
 	// Loaded flags (lazy-load per tab / on focus; see ensureTabDataLoaded)
-	agentsLoaded     bool
-	issuesLoaded     bool
-	channelsLoaded   bool
-	queueLoaded      bool
-	agentStatsLoaded bool
-	pkgStatsLoaded   bool
+	agentsLoaded       bool
+	issuesLoaded       bool
+	channelsLoaded     bool
+	queueLoaded        bool
+	agentStatsLoaded   bool
+	recentEventsLoaded bool
+	pkgStatsLoaded     bool
 }
 
 // NewWorkspaceModel creates a workspace detail view.
@@ -128,7 +129,7 @@ func NewWorkspaceModel(info WorkspaceInfo, s style.Styles) *WorkspaceModel {
 		tab:    TabAgents,
 	}
 
-	// Only load agent data so the Agents tab can render immediately.
+	// Minimal load for first paint (Agents tab): manager + agents + agent stats only
 	m.manager = agent.NewWorkspaceManager(
 		info.Entry.Path+"/.bc/agents",
 		info.Entry.Path,
@@ -137,9 +138,10 @@ func NewWorkspaceModel(info WorkspaceInfo, s style.Styles) *WorkspaceModel {
 	_ = m.manager.RefreshState()
 	m.agents = m.manager.ListAgents()
 	m.agentsLoaded = true
-
-	// Stats bar uses m.stats; computeStats will run when issues (or dashboard) are loaded.
 	m.issuesByAgent = make(map[string]int)
+	m.loadAgentStats()
+	m.computeStatsFromAgentsOnly()
+	// Issues, channels, queue, events, memory, pkg stats loaded on tab focus via ensureTabDataLoaded
 
 	return m
 }
@@ -153,11 +155,13 @@ func (m *WorkspaceModel) HandleKey(msg tea.KeyMsg) Action {
 		m.tab = (m.tab + 1) % tabCount
 		m.cursor = 0
 		m.scrollOffset = 0
+		m.ensureTabDataLoaded(m.tab)
 		return NoAction
 	case "shift+tab":
 		m.tab = (m.tab + tabCount - 1) % tabCount
 		m.cursor = 0
 		m.scrollOffset = 0
+		m.ensureTabDataLoaded(m.tab)
 		return NoAction
 	case "j", "down":
 		m.cursor++
@@ -203,10 +207,11 @@ func (m *WorkspaceModel) refresh() {
 	m.issues, m.issuesErr = beads.ListIssues(m.info.Entry.Path)
 	m.issuesLoaded = true
 	m.loadChannels()
-	m.loadMemoryInfo()
 	m.loadQueue()
 	m.queueLoaded = true
+	m.loadMemoryInfo()
 	m.loadRecentEvents()
+	m.recentEventsLoaded = true
 	m.computeStats()
 	m.loadAgentStats()
 	m.agentStatsLoaded = true
@@ -388,15 +393,20 @@ func (m *WorkspaceModel) ensureTabDataLoaded(tab Tab) {
 		if !m.issuesLoaded {
 			m.issues, m.issuesErr = beads.ListIssues(m.info.Entry.Path)
 			m.issuesLoaded = true
+			m.computeStats()
 		}
 		if !m.channelsLoaded {
 			m.loadChannels()
+			m.channelsLoaded = true
 		}
 		if !m.queueLoaded {
 			m.loadQueue()
 			m.queueLoaded = true
 		}
-		m.loadRecentEvents()
+		if !m.recentEventsLoaded {
+			m.loadRecentEvents()
+			m.recentEventsLoaded = true
+		}
 		m.loadMemoryInfo()
 		if !m.agentStatsLoaded {
 			m.loadAgentStats()
@@ -1157,6 +1167,23 @@ func (m *WorkspaceModel) getRecentlyClosedIssues() []beads.Issue {
 		}
 	}
 	return closed
+}
+
+// computeStatsFromAgentsOnly sets only agent state counts; used for fast first paint before issues/queue are loaded.
+func (m *WorkspaceModel) computeStatsFromAgentsOnly() {
+	m.issuesByAgent = make(map[string]int)
+	for _, a := range m.agents {
+		switch a.State {
+		case agent.StateIdle:
+			m.stats.IdleAgents++
+		case agent.StateWorking:
+			m.stats.WorkingAgents++
+		case agent.StateStuck:
+			m.stats.StuckAgents++
+		case agent.StateStopped:
+			m.stats.StoppedAgents++
+		}
+	}
 }
 
 func (m *WorkspaceModel) computeStats() {

--- a/internal/tui/workspace_test.go
+++ b/internal/tui/workspace_test.go
@@ -35,6 +35,33 @@ func newTestModel() *WorkspaceModel {
 	}
 }
 
+// --- Lazy-load / computeStatsFromAgentsOnly (#324) ---
+
+func TestComputeStatsFromAgentsOnly(t *testing.T) {
+	m := newTestModel()
+	m.agents = []*agent.Agent{
+		{Name: "a", State: agent.StateWorking},
+		{Name: "b", State: agent.StateIdle},
+		{Name: "c", State: agent.StateStopped},
+	}
+	m.computeStatsFromAgentsOnly()
+	if m.stats.WorkingAgents != 1 || m.stats.IdleAgents != 1 || m.stats.StoppedAgents != 1 {
+		t.Errorf("agent counts: working=1 idle=1 stopped=1, got working=%d idle=%d stopped=%d",
+			m.stats.WorkingAgents, m.stats.IdleAgents, m.stats.StoppedAgents)
+	}
+	if m.stats.TotalIssues != 0 || m.stats.OpenIssues != 0 {
+		t.Errorf("issue stats should be zero, got total=%d open=%d", m.stats.TotalIssues, m.stats.OpenIssues)
+	}
+}
+
+func TestEnsureTabDataLoaded_NoPanic(t *testing.T) {
+	m := newTestModel()
+	// ensureTabDataLoaded should not panic for any tab (may load or no-op)
+	for tab := TabAgents; tab < tabCount; tab++ {
+		m.ensureTabDataLoaded(tab)
+	}
+}
+
 // --- Dashboard rendering tests ---
 
 func TestRenderDashboard_NoData(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes #324. Part of epic #322 (TUI and workspace performance).

**Problem**: Opening a workspace did a full load (issues, channels, queue, events, memory, pkg stats) before first paint; tab switch could refetch; heavy first paint.

**Approach**: Lazy-load/cache workspace data on open; defer issues/channels/queue when entering workspace; load on tab/screen focus.

## Changes

### Workspace open (fast first paint)
- `NewWorkspaceModel` now loads only what the **Agents** tab needs: manager, `LoadState`, `RefreshState`, agents, `loadAgentStats`, `computeStatsFromAgentsOnly`.
- Issues, channels, queue, recent events, memory, and pkg stats are **not** loaded until the user focuses that tab.

### Tab focus load
- `ensureTabDataLoaded(tab)` runs when the user switches tabs (tab / shift+tab).
- **Issues**: `beads.ListIssues` + `computeStats`.
- **Channels**: `loadChannels`.
- **Queue**: `loadQueue` (and `applyQueueFilter`).
- **Dashboard**: issues (if not loaded) + `loadRecentEvents`.
- **Stats**: issues (if not loaded) + `loadPkgStats`.
- Data is loaded at most once per tab and then cached.

### Helpers
- `computeStatsFromAgentsOnly()`: sets only agent state counts (Idle/Working/Stuck/Stopped); used before issues exist so the stats bar shows 0 for issues/epics until the Issues tab is visited.
- `refresh()` (explicit `r`): still does full reload and sets all `*Loaded` flags so subsequent tab switches use cache.

### Tests
- `TestComputeStatsFromAgentsOnly`: agent counts set, issue stats stay zero.
- `TestEnsureTabDataLoaded_NoPanic`: `ensureTabDataLoaded` for every tab does not panic.

### Docs
- `internal/tui/PROFILE.md`: document per-screen lazy-load fixes.

## Testing
- `go test ./internal/tui/... ./internal/cmd/...` — all pass.

Made with [Cursor](https://cursor.com)