### PR TITLE
fix(config): add claude agent so CI passes (#336)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,6 +52,11 @@ command = "codex --full-auto"
 description = "OpenAI Codex"
 
 [[agents]]
+name = "claude"
+command = "claude"
+description = "Claude CLI agent"
+
+[[agents]]
 name = "server"
 command = "claude mcp serve"
 description = "Claude MCP Server"

--- a/config/config.go
+++ b/config/config.go
@@ -66,6 +66,11 @@ var (
 			Name:        "codex",
 		},
 		{
+			Command:     "claude",
+			Description: "Claude CLI agent",
+			Name:        "claude",
+		},
+		{
 			Command:     "claude mcp serve",
 			Description: "Claude MCP Server",
 			Name:        "server",


### PR DESCRIPTION
## Summary
Fixes #336 — CI on main was red due to `config` test failure.

## Cause
`TestAgentsContainsClaude` expects `Agents` to contain an entry with `Name == "claude"`. The default config had `cursor-agent`, `cursor`, `codex`, and `server` but no `claude` entry.

## Change
- **config.toml**: Added `[[agents]]` with `name = "claude"`, `command = "claude"`, `description = "Claude CLI agent"`.
- **config/config.go**: Regenerated via `make gen`.

## Verification
- `go build ./...` ✅
- `go test ./...` ✅ (all packages including config)
- `make test` ✅ (with -race)
- `make coverage` ✅
- `golangci-lint run ./...` ✅

CI should be green on this PR. Requesting tech lead + QA approval; merge only when CI passes and approvals are in.

Made with [Cursor](https://cursor.com)