### PR TITLE
bc home: add bench tests for TUI/dashboard (#312, #311)

### DIFF
--- a/internal/tui/benchmark_test.go
+++ b/internal/tui/benchmark_test.go
@@ -1,20 +1,28 @@
-// Package tui: benchmarks and regression tests for bc home TUI/dashboard.
-// Run benchmarks: go test -bench=. -benchmem ./internal/tui/...
-// Or: make bench
-// Regression tests run with the rest of the suite (go test ./... / make test).
+// Package tui: benchmarks and regression tests for bc home TUI/dashboard (#311, #312).
+//
+// Run benchmarks:
+//
+//	go test -bench=. -benchmem ./internal/tui/...
+//	make bench
+//
+// Benchmarks cover: home (empty, loading, with workspaces, each screen), workspace
+// (all tabs, first-paint lazy, many agents), and regression tests for no-panic and structure.
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/beads"
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/events"
+	"github.com/rpuneet/bc/pkg/workspace"
 )
 
-// --- Benchmarks: critical TUI/dashboard paths ---
+// --- Benchmarks: critical TUI/dashboard paths (#312) ---
 
 func BenchmarkHomeView_Empty(b *testing.B) {
 	m := NewHomeModel(nil, 0)
@@ -130,6 +138,129 @@ func BenchmarkWorkspaceView_Stats(b *testing.B) {
 	}
 }
 
+// --- Home view: drill-down screens and stress (#312) ---
+
+func BenchmarkHomeView_WorkspaceScreen(b *testing.B) {
+	m := newTestHomeModel()
+	m.screen = ScreenWorkspace
+	m.wsModel = newTestModel()
+	m.wsModel.tab = TabAgents
+	m.wsModel.agents = []*agent.Agent{
+		{Name: "eng-01", State: agent.StateWorking},
+		{Name: "eng-02", State: agent.StateIdle},
+	}
+	m.wsModel.agentsLoaded = true
+	m.wsModel.computeStats()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
+func BenchmarkHomeView_AgentScreen(b *testing.B) {
+	m := newTestHomeModel()
+	m.screen = ScreenAgent
+	m.wsModel = newTestModel()
+	m.agentModel = &AgentModel{
+		agent:  &agent.Agent{Name: "engineer-01", State: agent.StateWorking, Task: "Implement login"},
+		styles: m.styles,
+		width:  120,
+		height: 40,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
+func BenchmarkHomeView_ChannelScreen(b *testing.B) {
+	m := newTestHomeModel()
+	m.screen = ScreenChannel
+	m.wsModel = newTestModel()
+	m.channelModel = &ChannelModel{
+		channel: &channel.Channel{Name: "standup", History: []channel.HistoryEntry{
+			{Sender: "eng-01", Message: "Starting work", Time: time.Now()},
+			{Sender: "eng-02", Message: "Tests passing", Time: time.Now()},
+		}},
+		styles: newTestModel().styles,
+		width:  120,
+		height: 40,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
+func BenchmarkHomeView_HelpActive(b *testing.B) {
+	m := newTestHomeModel()
+	m.helpActive = true
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
+func BenchmarkHomeView_ManyWorkspaces(b *testing.B) {
+	workspaces := make([]WorkspaceInfo, 0, 25)
+	for i := 0; i < 25; i++ {
+		workspaces = append(workspaces, WorkspaceInfo{
+			Entry:      workspace.RegistryEntry{Name: fmt.Sprintf("project-%d", i), Path: fmt.Sprintf("/path/%d", i)},
+			Running:    i % 4,
+			Total:      5,
+			MaxWorkers: 10,
+			Issues:     i * 2,
+			HasBeads:   i%2 == 0,
+		})
+	}
+	m := NewHomeModel(workspaces, 10)
+	m.width = 120
+	m.height = 40
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
+// --- Workspace: minimal agents (fast path) and stress (#312) ---
+
+func BenchmarkWorkspaceView_FirstPaintLazy(b *testing.B) {
+	// Minimal agent list and stats (no issues/channels); fast first-paint path.
+	m := newTestModel()
+	m.tab = TabAgents
+	m.agents = []*agent.Agent{
+		{Name: "eng-01", State: agent.StateWorking},
+		{Name: "eng-02", State: agent.StateIdle},
+		{Name: "eng-03", State: agent.StateStopped},
+	}
+	m.agentsLoaded = true
+	m.issues = nil
+	m.computeStats()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
+func BenchmarkWorkspaceView_AgentsMany(b *testing.B) {
+	m := newTestModel()
+	m.tab = TabAgents
+	m.agents = make([]*agent.Agent, 0, 30)
+	for i := 0; i < 30; i++ {
+		m.agents = append(m.agents, &agent.Agent{
+			Name:  fmt.Sprintf("engineer-%02d", i),
+			State: agent.StateWorking,
+			Task:  "Implementing feature X",
+		})
+	}
+	m.agentsLoaded = true
+	m.computeStats()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
 // --- Regression tests: catch perf/behavior regressions ---
 
 // TestHomeView_Regression_NoPanic ensures HomeModel.View() does not panic for common states.
@@ -201,5 +332,52 @@ func TestHomeView_Regression_AllTabsRender(t *testing.T) {
 	}
 	if !strings.Contains(out, "test-project") {
 		t.Error("workspace name should appear in view")
+	}
+}
+
+// TestHomeView_Regression_AllScreensNoPanic ensures View() does not panic for every home screen (matches bench coverage).
+func TestHomeView_Regression_AllScreensNoPanic(t *testing.T) {
+	screens := []struct {
+		init func() *HomeModel
+		name string
+	}{
+		{func() *HomeModel {
+			m := newTestHomeModel()
+			m.screen = ScreenWorkspace
+			m.wsModel = newTestModel()
+			m.wsModel.computeStats()
+			return m
+		}, "WorkspaceScreen"},
+		{func() *HomeModel {
+			m := newTestHomeModel()
+			m.screen = ScreenAgent
+			m.wsModel = newTestModel()
+			m.agentModel = &AgentModel{agent: &agent.Agent{Name: "eng-01"}, styles: m.styles}
+			return m
+		}, "AgentScreen"},
+		{func() *HomeModel {
+			m := newTestHomeModel()
+			m.screen = ScreenChannel
+			m.wsModel = newTestModel()
+			m.channelModel = &ChannelModel{
+				channel: &channel.Channel{Name: "standup"},
+				styles:  m.styles,
+			}
+			return m
+		}, "ChannelScreen"},
+		{func() *HomeModel {
+			m := newTestHomeModel()
+			m.helpActive = true
+			return m
+		}, "HelpActive"},
+	}
+	for _, sc := range screens {
+		t.Run(sc.name, func(t *testing.T) {
+			m := sc.init()
+			out := m.View()
+			if out == "" {
+				t.Error("view produced empty output")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #312. Part of P1 epic #311 (bc home performance and reliability) and bug #296.

Adds benchmark and regression coverage for bc home TUI/dashboard so we can catch perf and behavior regressions.

## New benchmarks

**Home view**
- `BenchmarkHomeView_WorkspaceScreen` — home with workspace drill-down (Agents tab)
- `BenchmarkHomeView_AgentScreen` — home with agent detail
- `BenchmarkHomeView_ChannelScreen` — home with channel view
- `BenchmarkHomeView_HelpActive` — help overlay
- `BenchmarkHomeView_ManyWorkspaces` — 25 workspaces (stress list)

**Workspace view**
- `BenchmarkWorkspaceView_FirstPaintLazy` — minimal agents, no issues/channels (fast first-paint path)
- `BenchmarkWorkspaceView_AgentsMany` — 30 agents (stress Agents tab)

## New regression test
- `TestHomeView_Regression_AllScreensNoPanic` — View() for WorkspaceScreen, AgentScreen, ChannelScreen, HelpActive (matches new bench paths).

## How to run
```
go test -bench=. -benchmem ./internal/tui/...
make bench
```

Package doc updated to reference #311/#312 and describe coverage.

Made with [Cursor](https://cursor.com)