### PR TITLE
TUI/agent: throttle captureLiveTask to one agent per RefreshState (epic #322)

### DIFF
--- a/internal/tui/PROFILE.md
+++ b/internal/tui/PROFILE.md
@@ -50,7 +50,7 @@ go test -bench=BenchmarkHomeView_AsyncLoadFirstFrame -benchmem ./internal/tui/..
 
 ## Possible follow-ups
 
-- **Throttle captureLiveTask**: Run tmux capture less often or only for the focused agent; or run captures in parallel.
+- ~~**Throttle captureLiveTask**~~: Done (epic #322). Manager now captures live task for one agent per `RefreshState` (round-robin) instead of all agents, reducing tmux.Capture calls when many agents run.
 
 ## Fixes applied (non-blocking startup, #303 / #311)
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -232,6 +232,10 @@ type Manager struct {
 	// Workspace path for env vars
 	workspacePath string
 
+	// captureRotate is used to throttle captureLiveTask: only one agent per RefreshState (round-robin).
+	// Reduces tmux.Capture calls when many agents are running (epic #322).
+	captureRotate int
+
 	mu sync.RWMutex
 }
 
@@ -949,7 +953,8 @@ func (m *Manager) RefreshState() error {
 		active[s.Name] = true
 	}
 
-	// Update agent states and capture live tasks
+	// Update agent states
+	var activeNames []string
 	for name, a := range m.agents {
 		if !active[name] && a.State != StateStopped {
 			a.State = StateStopped
@@ -959,10 +964,20 @@ func (m *Manager) RefreshState() error {
 		if !active[name] {
 			continue
 		}
+		activeNames = append(activeNames, name)
+	}
+	sort.Strings(activeNames)
 
-		// Capture live task from tmux pane
-		if live := m.captureLiveTask(name); live != "" {
-			a.Task = live
+	// Throttle: capture live task for only one agent per RefreshState (round-robin).
+	// With N agents this does 1 tmux.Capture per tick instead of N (epic #322).
+	if len(activeNames) > 0 {
+		idx := m.captureRotate % len(activeNames)
+		m.captureRotate++
+		name := activeNames[idx]
+		if a := m.agents[name]; a != nil {
+			if live := m.captureLiveTask(name); live != "" {
+				a.Task = live
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
Implements PROFILE.md follow-up: **Throttle captureLiveTask** (epic #322). Reduces tmux.Capture load when many agents are running.

## Changes
- **pkg/agent**: `Manager` gains `captureRotate`; `RefreshState()` now calls `captureLiveTask` for **one** agent per call (round-robin over active agents) instead of every agent. With N agents this is 1 `tmux.Capture` per 2s tick instead of N.
- **internal/tui/PROFILE.md**: Mark throttle follow-up as done.

## Why
`RefreshState()` is invoked every TUI tick (2s). Previously it ran `captureLiveTask(name)` (and thus `tmux.Capture`) for every running agent, which blocks and scales with agent count. Throttling to one capture per tick keeps the TUI responsive while still rotating live task updates across agents.

## Testing
- `make check` passes (gen, fmt, vet, lint, test).
- Existing `pkg/agent` tests pass (including `TestRefreshState`).

**Merge when:** CI green + tech lead approval + QA approval.

Made with [Cursor](https://cursor.com)