### PR TITLE
tui: add BenchmarkHomeView_WorkspaceLoading for bc home (#311, #312)

### DIFF
--- a/internal/tui/benchmark_test.go
+++ b/internal/tui/benchmark_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
+
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/beads"
 	"github.com/rpuneet/bc/pkg/channel"
@@ -46,6 +48,26 @@ func BenchmarkHomeView_WithWorkspaces(b *testing.B) {
 // async workspace load (#323): TUI shows "Loading workspaces..." immediately.
 func BenchmarkHomeView_AsyncLoadFirstFrame(b *testing.B) {
 	m := NewHomeModel(nil, 5, true)
+	m.width = 120
+	m.height = 40
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.View()
+	}
+}
+
+// BenchmarkHomeView_WorkspaceLoading measures the drill-down loading state:
+// user pressed Enter on a workspace; spinner and "Loading workspace…" are shown.
+func BenchmarkHomeView_WorkspaceLoading(b *testing.B) {
+	m := newTestHomeModel()
+	m.screen = ScreenWorkspace
+	m.wsModel = nil
+	m.workspaceLoading = true
+	m.pendingWorkspaceName = "project-a"
+	m.loadingSpinner = spinner.New(
+		spinner.WithSpinner(spinner.Dot),
+		spinner.WithStyle(m.styles.Muted),
+	)
 	m.width = 120
 	m.height = 40
 	b.ResetTimer()


### PR DESCRIPTION
## Summary
Adds a benchmark for the bc home TUI drill-down loading state: when the user presses Enter on a workspace, the UI shows a spinner and "Loading workspace…" until `workspaceLoadedMsg` is received.

## Changes
- `BenchmarkHomeView_WorkspaceLoading`: measures View() for `ScreenWorkspace` with `workspaceLoading=true`, `wsModel=nil`, and spinner initialized (covers `renderWorkspaceLoading` path).

## Verification
- `make check` passes (gen, fmt, vet, lint, test).
- `go test -bench=BenchmarkHomeView_WorkspaceLoading -benchmem ./internal/tui/...` runs successfully.

Part of #311 bc home / #312 bench tests.

Made with [Cursor](https://cursor.com)