### PR TITLE
Channel scroll: clamp on resize (#299) — #314

### DIFF
--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -97,6 +97,31 @@ func TestChannelHandleKey_SendMode(t *testing.T) {
 	}
 }
 
+func TestChannelClampScroll_KeepsScrollInBounds(t *testing.T) {
+	m := newTestChannelModel()
+	// Few messages: maxScroll is small or 0
+	for i := 0; i < 5; i++ {
+		m.channel.History = append(m.channel.History, channel.HistoryEntry{
+			Sender: "u", Message: "m", Time: time.Now(),
+		})
+	}
+	m.scroll = 999 // out of bounds
+	m.clampScroll()
+	maxScroll := len(m.channel.History) - m.visibleMsgCount()
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if m.scroll != maxScroll {
+		t.Errorf("after clampScroll scroll = %d, want %d (maxScroll)", m.scroll, maxScroll)
+	}
+	// Negative scroll
+	m.scroll = -1
+	m.clampScroll()
+	if m.scroll < 0 {
+		t.Errorf("scroll should be >= 0 after clampScroll, got %d", m.scroll)
+	}
+}
+
 func TestChannelHandleKey_HomeEnd(t *testing.T) {
 	m := newTestChannelModel()
 	// Add enough history to scroll

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -122,6 +122,7 @@ func (m *HomeModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.channelModel != nil {
 			m.channelModel.width = msg.Width
 			m.channelModel.height = msg.Height
+			m.channelModel.clampScroll()
 		}
 		if m.issueModel != nil {
 			m.issueModel.width = msg.Width


### PR DESCRIPTION
## Summary
#314 channel redesign: **#299** (Channel scrolling) follow-up.

- **#299** on main already has j/k, g/G, mouse wheel, `clampScroll` (PR #318). This PR adds **clamp on window resize**: when `WindowSizeMsg` is applied we call `channelModel.clampScroll()` so scroll stays in `[0, maxScroll]` and the view never shows an invalid range after resize.
- **#304** (Channel bubble UI/UX): already addressed by #307 (bubble own/others, empty placeholder). No change in this PR.

## Changes
- `internal/tui/home.go`: call `m.channelModel.clampScroll()` after setting width/height on `WindowSizeMsg`.
- `internal/tui/channel_test.go`: `TestChannelClampScroll_KeepsScrollInBounds` (scroll clamped when past max or negative).

## Verification
- `make check` passes.

**Requesting review from:** tech lead, QA (per process).

Made with [Cursor](https://cursor.com)