### PR TITLE
Channel bubble UI fixes and UX review (#304)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -903,11 +903,20 @@ func (m *ChannelModel) View() string {
 				content.WriteString(m.styles.Muted.Render("(empty)"))
 			} else {
 				lines := wrapText(entry.Message, msgWidth-4)
+				const maxBubbleLines = 15 // cap to avoid flooding the view
+				truncated := len(lines) > maxBubbleLines
+				if truncated {
+					lines = lines[:maxBubbleLines]
+				}
 				for j, line := range lines {
 					if j > 0 {
 						content.WriteString("\n")
 					}
 					content.WriteString(m.highlightMessage(line))
+				}
+				if truncated {
+					content.WriteString("\n")
+					content.WriteString(m.styles.Muted.Render("(…)"))
 				}
 			}
 

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -1010,6 +1010,23 @@ func TestChannelView_EmptyMessageShowsPlaceholder(t *testing.T) {
 	}
 }
 
+func TestChannelView_LongMessageTruncatedInBubble(t *testing.T) {
+	// Message that wraps to more than maxBubbleLines (15) so we show (…)
+	m := newTestChannelModel()
+	longMsg := strings.Repeat("word ", 400) // wraps to 16+ lines so bubble truncates with (…)
+	m.channel.History = []channel.HistoryEntry{
+		{Sender: "eng-01", Message: longMsg, Time: time.Now()},
+	}
+
+	output := m.View()
+	if !strings.Contains(output, "(…)") {
+		t.Error("expected long message to be truncated with (…) in bubble")
+	}
+	if !strings.Contains(output, "word") {
+		t.Error("expected start of message content in output")
+	}
+}
+
 func TestChannelView_OwnMessageUsesDistinctBubble(t *testing.T) {
 	prev := os.Getenv("BC_AGENT_ID")
 	defer func() { _ = os.Setenv("BC_AGENT_ID", prev) }()


### PR DESCRIPTION
## Summary
Implements #304 (part of #314 channel redesign). Bubble UI fixes and UX review.

## Changes
- **Long messages:** Cap message bubble at 15 lines; show `(…)` when truncated so the view isn’t flooded by pastes or long replies.
- **Empty messages:** Unchanged — already show `(empty)` placeholder.
- **Own message styling:** Unchanged — `MessageBubbleOwn` for current user.
- **Test:** `TestChannelView_LongMessageTruncatedInBubble` added.

## Verification
`make check` passes (gen, fmt, vet, lint, test).

---
**Review:** Requesting tech lead and QA approval. Merge when CI green + tech lead approved + QA approved.

Made with [Cursor](https://cursor.com)