### PR TITLE
bc home: add TickMsg regression test (#311, #312)

### DIFF
--- a/internal/tui/home_test.go
+++ b/internal/tui/home_test.go
@@ -698,3 +698,29 @@ func TestUpdate_WindowSizeMsg_AllModels(t *testing.T) {
 		t.Errorf("issueModel width = %d, want 150", m.issueModel.width)
 	}
 }
+
+// TestUpdate_TickMsg_NoPanic guards #303/#311: TickMsg must be handled without panic (refreshLight
+// path, not full refresh). With no drill-down models, Update(TickMsg) returns model + tickCmd; View() still renders.
+func TestUpdate_TickMsg_NoPanic(t *testing.T) {
+	m := newTestHomeModel()
+	// No wsModel/agentModel so refreshLight is not invoked (would need manager set); we still verify TickMsg handling.
+
+	model, cmd := m.Update(TickMsg{})
+	if model == nil {
+		t.Fatal("Update(TickMsg) returned nil model")
+	}
+	if _, ok := model.(*HomeModel); !ok {
+		t.Errorf("Update(TickMsg) returned wrong model type")
+	}
+	if cmd == nil {
+		t.Error("Update(TickMsg) should return tick Cmd")
+	}
+
+	out := m.View()
+	if out == "" {
+		t.Error("View() after TickMsg returned empty string")
+	}
+	if !strings.Contains(out, "bc") {
+		t.Error("View() after TickMsg should contain header")
+	}
+}


### PR DESCRIPTION
## Summary
Plan order (3) #311 — bc home task. Adds a regression test that guards #303 behavior (lightweight tick, no full refresh on TickMsg).

## Changes
- **TestUpdate_TickMsg_NoPanic** in `internal/tui/home_test.go`: Ensures `HomeModel.Update(TickMsg)` does not panic, returns model + tick Cmd, and `View()` still renders. Guards against regressing to full `refresh()` on tick.

## Scope
- **Epic:** #311 (bc home performance and reliability)
- **Related:** #303 (fix slowness/crashes), #312 (bench/regression tests)
- **Acceptance:** `go test ./internal/tui/ -run TestUpdate_TickMsg_NoPanic` passes; all tui tests pass.

## QA
Please run `bc home` and confirm TUI still updates on the 2s tick (agent/workspace state) without freezing; manual smoke OK.

Part of #311

Made with [Cursor](https://cursor.com)