### PR TITLE
test(tui): regression test for workspace loading state (#311, #325)

### DIFF
--- a/internal/tui/benchmark_test.go
+++ b/internal/tui/benchmark_test.go
@@ -300,6 +300,22 @@ func TestHomeView_Regression_NoPanic(t *testing.T) {
 	_ = m2.View()
 }
 
+// TestHomeView_Regression_WorkspaceLoadingNoPanic ensures View() does not panic when workspace is loading (#311/#325).
+func TestHomeView_Regression_WorkspaceLoadingNoPanic(t *testing.T) {
+	m := newTestHomeModel()
+	m.screen = ScreenWorkspace
+	m.workspaceLoading = true
+	m.pendingWorkspaceName = "test-project"
+	m.wsModel = nil
+	out := m.View()
+	if out == "" {
+		t.Error("workspace loading view produced empty output")
+	}
+	if !strings.Contains(out, "Loading") {
+		t.Error("workspace loading view should contain Loading")
+	}
+}
+
 // TestHomeView_Regression_ExpectedSections ensures home view output contains expected structure.
 func TestHomeView_Regression_ExpectedSections(t *testing.T) {
 	m := newTestHomeModel()


### PR DESCRIPTION
## Summary
Adds a regression test under **#311** (bc home) / **#325** (loading indicators): `TestHomeView_Regression_WorkspaceLoadingNoPanic`.

## Scope
- **Acceptance:** `View()` does not panic when `screen == ScreenWorkspace` and `workspaceLoading == true` (async workspace load path). Output contains "Loading".
- **Technical:** One new test in `internal/tui/benchmark_test.go`; no production code changes.
- **CI:** `make check` passes (build, vet, lint, tests).

## Merge
Manager merges when: **CI green** + **tech lead approved** + **QA approved**.

**Requesting QA review** when ready.

Made with [Cursor](https://cursor.com)