### PR TITLE
Channel scrolling: fix scrolling through messages (#299)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -1023,7 +1023,7 @@ func (m *ChannelModel) View() string {
 		b.WriteString(m.styles.Success.Render("  ✓ " + m.sendMsg))
 		b.WriteString("\n")
 	} else {
-		b.WriteString(m.styles.Muted.Render("  [s]end  [e]moji  [j/k]scroll  [r]efresh  [esc]back"))
+		b.WriteString(m.styles.Muted.Render("  [s]end  [e]moji  [j/k]scroll  [g/G]oldest/newest  [r]efresh  [esc]back"))
 		b.WriteString("\n")
 	}
 

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -121,6 +121,75 @@ func TestChannelHandleKey_HomeEnd(t *testing.T) {
 	}
 }
 
+// TestChannelFullHistoryScroll_299 ensures full-history scroll works (j/k, g/G, wheel) — regression for #299.
+func TestChannelFullHistoryScroll_299(t *testing.T) {
+	m := newTestChannelModel()
+	const totalMsg = 25
+	m.channel.History = make([]channel.HistoryEntry, 0, totalMsg)
+	for i := 0; i < totalMsg; i++ {
+		m.channel.History = append(m.channel.History, channel.HistoryEntry{
+			Sender: "u", Message: "m", Time: time.Now(),
+		})
+	}
+	visible := m.visibleMsgCount()
+	if visible >= totalMsg {
+		t.Skip("height too large for this test; need scrollable history")
+	}
+	maxScroll := totalMsg - visible
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+
+	// Start at newest (scroll=0)
+	if m.scroll != 0 {
+		t.Errorf("initial scroll want 0, got %d", m.scroll)
+	}
+	start, end := m.visibleWindow()
+	if start != totalMsg-visible || end != totalMsg {
+		t.Errorf("initial window want [%d,%d), got [%d,%d)", totalMsg-visible, totalMsg, start, end)
+	}
+
+	// k: scroll toward older (scroll increases)
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if m.scroll != 2 {
+		t.Errorf("after 2×k scroll want 2, got %d", m.scroll)
+	}
+	// j: scroll toward newer (scroll decreases)
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if m.scroll != 1 {
+		t.Errorf("after j scroll want 1, got %d", m.scroll)
+	}
+
+	// g: jump to oldest (scroll = maxScroll)
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	if m.scroll != maxScroll {
+		t.Errorf("g (oldest) scroll want %d, got %d", maxScroll, m.scroll)
+	}
+	start, end = m.visibleWindow()
+	if start != 0 || end != visible {
+		t.Errorf("at oldest window want [0,%d), got [%d,%d)", visible, start, end)
+	}
+
+	// G: jump to newest (scroll = 0)
+	m.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	if m.scroll != 0 {
+		t.Errorf("G (newest) scroll want 0, got %d", m.scroll)
+	}
+
+	// Wheel: up = older (scroll++), down = newer (scroll--)
+	m.scroll = 3
+	m.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelUp})
+	if m.scroll != 4 {
+		t.Errorf("wheel up (older) want scroll 4, got %d", m.scroll)
+	}
+	m.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	m.HandleMouse(tea.MouseMsg{Button: tea.MouseButtonWheelDown})
+	if m.scroll != 2 {
+		t.Errorf("wheel down×2 (newer) want scroll 2, got %d", m.scroll)
+	}
+}
+
 // TestClampScroll_KeepsScrollInBounds ensures scroll is clamped after history shrinks or view changes.
 func TestClampScroll_KeepsScrollInBounds(t *testing.T) {
 	m := newTestChannelModel()


### PR DESCRIPTION
## Summary
- **Epic:** #314, #287 | **Issue:** #299

Full-history channel scroll was already implemented (visibleWindow, clampScroll, j/k, g/G, wheel). This PR:
1. **Help hint:** status line now shows `[g/G]oldest/newest` so users know they can jump to top/bottom.
2. **Regression test:** `TestChannelFullHistoryScroll_299` exercises j, k, g, G and mouse wheel so full-history scroll is covered by tests.

`make check` passes.

**Requesting review from tech lead and QA** (please assign reviewers as appropriate).