### PR TITLE
Channel bubble UI fixes and UX review (#304, #314, #287)

### DIFF
--- a/internal/tui/channel.go
+++ b/internal/tui/channel.go
@@ -958,6 +958,10 @@ func (m *ChannelModel) View() string {
 		var lastDate time.Time
 		recentHistory := m.channel.History[recentStart:]
 		selectedIdx := m.selectedMessageIndex()
+		listWrapWidth := m.width - 12
+		if listWrapWidth < 20 {
+			listWrapWidth = 20
+		}
 		for i, entry := range recentHistory {
 			// Add date separator if this is a new day
 			if i == 0 || !isSameDay(entry.Time, lastDate) {
@@ -974,35 +978,58 @@ func (m *ChannelModel) View() string {
 			msgTypeStr := string(msgType)
 			icon := m.styles.MessageTypeIcon(msgTypeStr)
 			relTime := formatRelativeTime(entry.Time)
+			ts := m.styles.Muted.Render(relTime)
 
-			var line string
-			if entry.Sender != "" {
-				line = fmt.Sprintf("  %s%s  [%s] %s", icon, relTime, entry.Sender, entry.Message)
-			} else {
-				line = fmt.Sprintf("  %s%s  %s", icon, relTime, entry.Message)
-			}
-			if selected {
-				b.WriteString(m.styles.Selected.Render(line))
-			} else {
-				ts := m.styles.Muted.Render(relTime)
-				highlightedMsg := m.highlightMessage(entry.Message)
-				if entry.Sender != "" {
-					// Use role-specific color for sender
-					role := style.RoleFromAgentName(entry.Sender)
-					senderStyle := m.styles.RoleStyle(role)
-					sender := senderStyle.Render("[" + entry.Sender + "]")
-					line = fmt.Sprintf("  %s%s  %s %s", icon, ts, sender, highlightedMsg)
+			// Wrap long messages so they don't overflow terminal width (#304)
+			wrappedMsg := wrapText(entry.Message, listWrapWidth)
+			const continuationIndent = "             "
+			for lineIdx, msgLine := range wrappedMsg {
+				highlighted := m.highlightMessage(msgLine)
+				var line string
+				if lineIdx == 0 {
+					if entry.Sender != "" {
+						line = fmt.Sprintf("  %s%s  [%s] %s", icon, relTime, entry.Sender, msgLine)
+					} else {
+						line = fmt.Sprintf("  %s%s  %s", icon, relTime, msgLine)
+					}
 				} else {
-					line = fmt.Sprintf("  %s%s  %s", icon, ts, highlightedMsg)
+					line = continuationIndent + msgLine
 				}
-				b.WriteString(line)
+				if selected {
+					b.WriteString(m.styles.Selected.Render(line))
+				} else {
+					if lineIdx == 0 {
+						if entry.Sender != "" {
+							role := style.RoleFromAgentName(entry.Sender)
+							senderStyle := m.styles.RoleStyle(role)
+							sender := senderStyle.Render("[" + entry.Sender + "]")
+							b.WriteString("  ")
+							b.WriteString(icon)
+							b.WriteString(ts)
+							b.WriteString("  ")
+							b.WriteString(sender)
+							b.WriteString(" ")
+							b.WriteString(highlighted)
+						} else {
+							b.WriteString("  ")
+							b.WriteString(icon)
+							b.WriteString(ts)
+							b.WriteString("  ")
+							b.WriteString(highlighted)
+						}
+					} else {
+						b.WriteString(m.styles.Muted.Render(continuationIndent))
+						b.WriteString(highlighted)
+					}
+				}
+				b.WriteString("\n")
 			}
-			// Display reactions inline if any
+			// Display reactions inline if any (after last message line)
 			if reactionStr := m.formatReactions(entry.Reactions); reactionStr != "" {
 				b.WriteString("  ")
 				b.WriteString(reactionStr)
+				b.WriteString("\n")
 			}
-			b.WriteString("\n")
 		}
 	}
 
@@ -1076,23 +1103,40 @@ func (m *ChannelModel) formatReactions(reactions map[string][]string) string {
 	return m.styles.Reaction.Render(strings.Join(parts, "  "))
 }
 
-// wrapText splits text into lines of at most width characters, breaking at spaces.
+// wrapText splits text into lines of at most width runes, breaking at spaces when possible.
+// Long words are broken at width to avoid splitting UTF-8 runes mid-character (#304).
 func wrapText(text string, width int) []string {
-	if width <= 0 || len(text) <= width {
+	if width <= 0 {
+		return []string{text}
+	}
+	runes := []rune(text)
+	if len(runes) <= width {
 		return []string{text}
 	}
 	var lines []string
-	for len(text) > width {
-		// Find last space within width
-		i := strings.LastIndex(text[:width], " ")
-		if i <= 0 {
-			i = width
+	for len(runes) > width {
+		chunk := runes[:width]
+		// Find last space in chunk
+		lastSpace := -1
+		for i := len(chunk) - 1; i >= 0; i-- {
+			if chunk[i] == ' ' {
+				lastSpace = i
+				break
+			}
 		}
-		lines = append(lines, text[:i])
-		text = strings.TrimLeft(text[i:], " ")
+		splitAt := width
+		if lastSpace > 0 {
+			splitAt = lastSpace
+		}
+		lines = append(lines, string(runes[:splitAt]))
+		runes = runes[splitAt:]
+		// Trim leading spaces from remainder
+		for len(runes) > 0 && runes[0] == ' ' {
+			runes = runes[1:]
+		}
 	}
-	if text != "" {
-		lines = append(lines, text)
+	if len(runes) > 0 {
+		lines = append(lines, string(runes))
 	}
 	return lines
 }

--- a/internal/tui/channel_test.go
+++ b/internal/tui/channel_test.go
@@ -648,6 +648,31 @@ func TestWrapText_ZeroWidth(t *testing.T) {
 	}
 }
 
+// TestWrapText_LongWordNoSpaces ensures long words break at width without splitting runes (#304).
+func TestWrapText_LongWordNoSpaces(t *testing.T) {
+	text := "abcdefghij"
+	lines := wrapText(text, 3)
+	if len(lines) != 4 {
+		t.Errorf("expected 4 lines for 10-char word width 3, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "abc" || lines[3] != "j" {
+		t.Errorf("expected first 'abc' and last 'j', got %q, %q", lines[0], lines[3])
+	}
+}
+
+// TestWrapText_UnicodeRunes ensures we don't split multi-byte runes (#304).
+func TestWrapText_UnicodeRunes(t *testing.T) {
+	// "café" = c a f é (4 runes). Width 2 should give "ca" and "fé" (not split é).
+	text := "café"
+	lines := wrapText(text, 2)
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %v", len(lines), lines)
+	}
+	if lines[0] != "ca" || lines[1] != "fé" {
+		t.Errorf("expected ['ca','fé'], got %q", lines)
+	}
+}
+
 // --- View tests ---
 
 func TestChannelView_NoMessages(t *testing.T) {


### PR DESCRIPTION
## Summary
Implements fixes and UX improvements for channel message bubbles (epic #314, bug #287).

## Changes

### wrapText (rune-safe)
- **Before:** Byte-based split could cut multi-byte UTF-8 runes mid-character.
- **After:** Operate on runes; break at last space within width, or at width for long words. No rune splitting.

### Recent Messages section
- Long messages no longer overflow terminal width.
- Messages wrap at `width - 12` with continuation lines indented (13 spaces) for readability.
- First line shows timestamp + sender; wrapped lines aligned under message content.

### Tests
- `TestWrapText_LongWordNoSpaces`: long word without spaces breaks at width.
- `TestWrapText_UnicodeRunes`: multi-byte runes (e.g. café) not split.

## Verification
- `make check` passes (gen, fmt, vet, lint, test).
- Existing channel/view tests pass.

**Requesting review from tech lead and QA.**

Made with [Cursor](https://cursor.com)