### PR TITLE
fix(make): exclude .bc/worktrees from gofmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ bench:
 	go test -bench=. -benchmem ./...
 
 fmt:
-	gofmt -s -w .
+	gofmt -s -w $(shell find . -name '*.go' -not -path './.bc/*')
 
 vet:
 	go vet ./...


### PR DESCRIPTION
## Summary
- Fix gofmt target to exclude .bc/worktrees directories
- Prevents CI failures when agent worktrees contain broken code

## Problem
The `fmt:` target ran `gofmt -s -w .` which included files in `.bc/worktrees/` directories. When any worktree had syntax errors (common during development), the entire CI would fail.

## Solution
Use find with exclusion pattern: `find . -name '*.go' -not -path './.bc/*'`

## Test plan
- [x] `make fmt` runs successfully without touching .bc/ files
- [x] Pre-commit hooks pass

Fixes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)