### PR TITLE
test(workspace): update tests to expect gemini default (#385)

### DIFF
--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -15,24 +15,25 @@ func TestDefaultV2Config(t *testing.T) {
 	if cfg.Workspace.Version != ConfigVersion {
 		t.Errorf("expected version %d, got %d", ConfigVersion, cfg.Workspace.Version)
 	}
-	if cfg.Tools.Default != "claude" {
-		t.Errorf("expected default tool 'claude', got %q", cfg.Tools.Default)
+	// Default tool is gemini (minimal root-only startup)
+	if cfg.Tools.Default != "gemini" {
+		t.Errorf("expected default tool 'gemini', got %q", cfg.Tools.Default)
 	}
-	if cfg.Tools.Claude == nil {
-		t.Error("expected claude tool to be configured")
+	if cfg.Tools.Gemini == nil {
+		t.Error("expected gemini tool to be configured")
 	}
 	if cfg.Memory.Backend != "file" {
 		t.Errorf("expected memory backend 'file', got %q", cfg.Memory.Backend)
 	}
-	// Test default roster values
-	if cfg.Roster.Engineers != 4 {
-		t.Errorf("expected roster.engineers = 4, got %d", cfg.Roster.Engineers)
+	// Minimal startup: roster values default to 0
+	if cfg.Roster.Engineers != 0 {
+		t.Errorf("expected roster.engineers = 0, got %d", cfg.Roster.Engineers)
 	}
-	if cfg.Roster.TechLeads != 2 {
-		t.Errorf("expected roster.tech_leads = 2, got %d", cfg.Roster.TechLeads)
+	if cfg.Roster.TechLeads != 0 {
+		t.Errorf("expected roster.tech_leads = 0, got %d", cfg.Roster.TechLeads)
 	}
-	if cfg.Roster.QA != 2 {
-		t.Errorf("expected roster.qa = 2, got %d", cfg.Roster.QA)
+	if cfg.Roster.QA != 0 {
+		t.Errorf("expected roster.qa = 0, got %d", cfg.Roster.QA)
 	}
 }
 

--- a/pkg/workspace/workspace_test.go
+++ b/pkg/workspace/workspace_test.go
@@ -923,19 +923,19 @@ func TestWorkspaceGetRolePrompt(t *testing.T) {
 func TestWorkspaceDefaultTool(t *testing.T) {
 	dir := t.TempDir()
 
-	// v2 workspace
+	// v2 workspace - default tool is gemini (minimal root-only startup)
 	ws, err := InitV2(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if ws.DefaultTool() != "claude" {
-		t.Errorf("DefaultTool = %q, want %q", ws.DefaultTool(), "claude")
+	if ws.DefaultTool() != "gemini" {
+		t.Errorf("DefaultTool = %q, want %q", ws.DefaultTool(), "gemini")
 	}
 
 	cmd := ws.DefaultToolCommand()
-	if cmd != "claude --dangerously-skip-permissions" {
-		t.Errorf("DefaultToolCommand = %q, want claude command", cmd)
+	if cmd != "gemini --yolo" {
+		t.Errorf("DefaultToolCommand = %q, want %q", cmd, "gemini --yolo")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Update workspace config tests to match new defaults (gemini + minimal roster)

## Changes
- **config_test.go**: Update TestDefaultV2Config to expect 'gemini' default and 0 roster values
- **workspace_test.go**: Update TestWorkspaceDefaultTool to expect 'gemini --yolo'

## Context
The default tool was intentionally changed to gemini with minimal root-only startup.
Tests were outdated and expected old defaults ('claude', roster counts of 4/2/2).

## Additional Issue Found
internal/cmd parseRole tests also failing - separate design question (roles are now custom).
Workspace tests fixed here, parseRole issue needs separate discussion.

Part of CI fix for #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)