### PR TITLE
test(cmd): update parseRole tests for custom roles

### DIFF
--- a/internal/cmd/agent_integration_test.go
+++ b/internal/cmd/agent_integration_test.go
@@ -198,15 +198,17 @@ func TestAgentSendToStoppedAgent(t *testing.T) {
 }
 
 func TestAgentCreateInvalidRole(t *testing.T) {
+	// Only truly invalid role names (format) should error
+	// Any alphanumeric name with hyphens is valid (roles are custom)
 	_, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 
-	_, _, err := executeIntegrationCmd("agent", "create", "test-agent", "--role", "invalid-role")
+	_, _, err := executeIntegrationCmd("agent", "create", "test-agent", "--role", "role@invalid")
 	if err == nil {
-		t.Error("expected error for invalid role")
+		t.Error("expected error for invalid role format")
 	}
-	if err != nil && !strings.Contains(err.Error(), "unknown role") {
-		t.Errorf("error should mention unknown role: %v", err)
+	if err != nil && !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("error should mention invalid: %v", err)
 	}
 }
 

--- a/internal/cmd/agent_test.go
+++ b/internal/cmd/agent_test.go
@@ -71,42 +71,49 @@ func TestAgentCreate_ValidRole(t *testing.T) {
 }
 
 func TestAgentCreate_InvalidRole(t *testing.T) {
-	invalidRoles := []string{
-		"invalid",
-		"admin",
-		"superuser",
-		"",
+	// Only truly invalid role names should error (format validation)
+	// Any alphanumeric name is valid (roles are custom)
+	invalidRoles := []struct {
+		role string
+		desc string
+	}{
+		{"role@invalid", "contains @ symbol"},
+		{"role with space", "contains space"},
 	}
 
-	for _, role := range invalidRoles {
-		t.Run(role, func(t *testing.T) {
-			_, err := parseRole(role)
+	for _, tt := range invalidRoles {
+		t.Run(tt.desc, func(t *testing.T) {
+			_, err := parseRole(tt.role)
 			if err == nil {
-				t.Errorf("parseRole(%q) expected error, got nil", role)
+				t.Errorf("parseRole(%q) expected error, got nil", tt.role)
 			}
 		})
 	}
 }
 
-func TestAgentCreate_RoleAliases(t *testing.T) {
+func TestAgentCreate_CustomRoles(t *testing.T) {
+	// All roles are custom now - any valid alphanumeric name is accepted
+	// Legacy aliases ('pm', 'coord', 'tl') are returned as-is
 	tests := []struct {
-		alias    string
+		input    string
 		wantRole agent.Role
 	}{
-		{"pm", agent.Role("product-manager")},
-		{"coord", agent.RoleRoot},
-		{"tl", agent.Role("tech-lead")},
+		{"pm", agent.Role("pm")},       // No expansion
+		{"coord", agent.Role("coord")}, // No expansion
+		{"tl", agent.Role("tl")},       // No expansion
+		{"custom-role", agent.Role("custom-role")},
+		{"admin", agent.Role("admin")},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.alias, func(t *testing.T) {
-			role, err := parseRole(tt.alias)
+		t.Run(tt.input, func(t *testing.T) {
+			role, err := parseRole(tt.input)
 			if err != nil {
-				t.Errorf("parseRole(%q) error = %v", tt.alias, err)
+				t.Errorf("parseRole(%q) error = %v", tt.input, err)
 				return
 			}
 			if role != tt.wantRole {
-				t.Errorf("parseRole(%q) = %v, want %v", tt.alias, role, tt.wantRole)
+				t.Errorf("parseRole(%q) = %v, want %v", tt.input, role, tt.wantRole)
 			}
 		})
 	}
@@ -437,8 +444,10 @@ func TestAgentListWithRoleFilter(t *testing.T) {
 func TestAgentListInvalidRole(t *testing.T) {
 	setupTestWorkspace(t)
 
-	_, err := executeCmd("agent", "list", "--role", "invalid-role")
+	// Only truly invalid role names (format) should error
+	// "invalid-role" is valid now (all roles are custom)
+	_, err := executeCmd("agent", "list", "--role", "role@invalid")
 	if err == nil {
-		t.Error("expected error for invalid role filter")
+		t.Error("expected error for invalid role filter format")
 	}
 }

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -164,6 +164,9 @@ func TestStateIcon(t *testing.T) {
 // --- parseRole tests ---
 
 func TestParseRole(t *testing.T) {
+	// All roles are custom now - parseRole accepts any valid alphanumeric name
+	// No alias expansion (pm, coord, tl are returned as-is)
+	// Empty defaults to root
 	tests := []struct {
 		input   string
 		want    agent.Role
@@ -173,14 +176,16 @@ func TestParseRole(t *testing.T) {
 		{"engineer", agent.Role("engineer"), false},
 		{"manager", agent.Role("manager"), false},
 		{"product-manager", agent.Role("product-manager"), false},
-		{"pm", agent.Role("product-manager"), false},
-		{"coordinator", agent.RoleRoot, false},
-		{"coord", agent.RoleRoot, false},
+		{"pm", agent.Role("pm"), false}, // No expansion, returned as-is
+		{"coordinator", agent.Role("coordinator"), false},
+		{"coord", agent.Role("coord"), false}, // No expansion, returned as-is
 		{"qa", agent.Role("qa"), false},
-		{"WORKER", agent.Role("worker"), false},     // case insensitive
-		{"Engineer", agent.Role("engineer"), false}, // case insensitive
-		{"invalid", "", true},
-		{"", "", true},
+		{"WORKER", agent.Role("worker"), false},           // case insensitive (lowercased)
+		{"Engineer", agent.Role("engineer"), false},       // case insensitive (lowercased)
+		{"custom-role", agent.Role("custom-role"), false}, // Custom roles accepted
+		{"", agent.RoleRoot, false},                       // Empty defaults to root
+		{"role@invalid", "", true},                        // Format error (contains @)
+		{"role with space", "", true},                     // Format error (contains space)
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/internal/cmd/spawn_test.go
+++ b/internal/cmd/spawn_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestParseRole_ValidRoles(t *testing.T) {
+	// All roles are custom now - parseRole accepts any valid role name
 	tests := []struct {
 		input string
 		want  agent.Role
@@ -15,8 +16,9 @@ func TestParseRole_ValidRoles(t *testing.T) {
 		{"engineer", agent.Role("engineer")},
 		{"manager", agent.Role("manager")},
 		{"product-manager", agent.Role("product-manager")},
-		{"coordinator", agent.RoleRoot},
+		{"coordinator", agent.Role("coordinator")}, // No special handling
 		{"qa", agent.Role("qa")},
+		{"custom-role", agent.Role("custom-role")}, // Any valid name accepted
 	}
 
 	for _, tt := range tests {
@@ -32,13 +34,16 @@ func TestParseRole_ValidRoles(t *testing.T) {
 	}
 }
 
-func TestParseRole_Aliases(t *testing.T) {
+func TestParseRole_NoAliases(t *testing.T) {
+	// Legacy aliases are no longer supported - roles are custom now
+	// Input is returned as-is (lowercased)
 	tests := []struct {
 		input string
 		want  agent.Role
 	}{
-		{"pm", agent.Role("product-manager")},
-		{"coord", agent.RoleRoot},
+		{"pm", agent.Role("pm")},       // No expansion to product-manager
+		{"coord", agent.Role("coord")}, // No expansion to root
+		{"tl", agent.Role("tl")},       // Any short name is valid
 	}
 
 	for _, tt := range tests {
@@ -55,6 +60,7 @@ func TestParseRole_Aliases(t *testing.T) {
 }
 
 func TestParseRole_CaseInsensitive(t *testing.T) {
+	// Input is lowercased
 	tests := []struct {
 		input string
 		want  agent.Role
@@ -63,8 +69,8 @@ func TestParseRole_CaseInsensitive(t *testing.T) {
 		{"ENGINEER", agent.Role("engineer")},
 		{"Manager", agent.Role("manager")},
 		{"Product-Manager", agent.Role("product-manager")},
-		{"PM", agent.Role("product-manager")},
-		{"COORD", agent.RoleRoot},
+		{"PM", agent.Role("pm")},       // No alias expansion, just lowercase
+		{"COORD", agent.Role("coord")}, // No alias expansion, just lowercase
 		{"QA", agent.Role("qa")},
 		{"Qa", agent.Role("qa")},
 	}
@@ -83,42 +89,60 @@ func TestParseRole_CaseInsensitive(t *testing.T) {
 }
 
 func TestParseRole_Invalid(t *testing.T) {
-	invalid := []string{
-		"",
-		"admin",
-		"supervisor",
-		"developer",
-		"tester",
-		"unknown",
-		"work",
-		"eng",
+	// Only truly invalid role names should error (format validation)
+	// Any alphanumeric name with hyphens is valid (roles are custom)
+	invalid := []struct {
+		input string
+		desc  string
+	}{
+		{"role@invalid", "contains @ symbol"},
+		{"role with spaces", "contains spaces"},
+		{"role!name", "contains exclamation"},
 	}
 
-	for _, input := range invalid {
-		t.Run(input, func(t *testing.T) {
-			_, err := parseRole(input)
+	for _, tt := range invalid {
+		t.Run(tt.desc, func(t *testing.T) {
+			_, err := parseRole(tt.input)
 			if err == nil {
-				t.Fatalf("parseRole(%q) should have returned error", input)
-			}
-			// Error message should mention "unknown role"
-			if got := err.Error(); !contains(got, "unknown role") {
-				t.Errorf("error should mention 'unknown role', got: %s", got)
+				t.Fatalf("parseRole(%q) should have returned error", tt.input)
 			}
 		})
 	}
 }
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
+func TestParseRole_EmptyDefaultsToRoot(t *testing.T) {
+	// Empty role defaults to root
+	got, err := parseRole("")
+	if err != nil {
+		t.Fatalf("parseRole(\"\") returned error: %v", err)
+	}
+	if got != agent.RoleRoot {
+		t.Errorf("parseRole(\"\") = %q, want %q", got, agent.RoleRoot)
+	}
 }
 
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+func TestParseRole_ValidCustomRoles(t *testing.T) {
+	// Any valid alphanumeric name is accepted (roles are custom)
+	custom := []string{
+		"admin",
+		"supervisor",
+		"developer",
+		"tester",
+		"my-custom-role",
+		"role123",
 	}
-	return false
+
+	for _, input := range custom {
+		t.Run(input, func(t *testing.T) {
+			got, err := parseRole(input)
+			if err != nil {
+				t.Fatalf("parseRole(%q) should succeed for custom role, got error: %v", input, err)
+			}
+			if got != agent.Role(input) {
+				t.Errorf("parseRole(%q) = %q, want %q", input, got, input)
+			}
+		})
+	}
 }
 
 // --- Spawn command tests ---


### PR DESCRIPTION
## Summary
- Update parseRole tests to match new custom roles behavior
- Remove alias expansion expectations (pm, coord, tl returned as-is)
- Change invalid role tests to only validate format (@ and spaces)
- Empty role defaults to root

## Files Updated
- `spawn_test.go`: Updated all `TestParseRole_*` tests
- `agent_test.go`: Updated `TestAgentCreate_InvalidRole`, `TestAgentCreate_CustomRoles`
- `agent_integration_test.go`: `TestAgentCreateInvalidRole` uses `role@invalid`
- `cmd_test.go`: `TestParseRole` uses new expectations

## Test plan
- [x] All parseRole tests pass
- [x] All role-related tests pass
- [ ] CI green

Note: `TestBuildBootstrapPrompt_Structure` failure is pre-existing on main (verified by checking out origin/main).

Fixes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)