### PR TITLE
fix(test): update TestBuildBootstrapPrompt_Structure to match code (#391)

### DIFF
--- a/internal/cmd/up_test.go
+++ b/internal/cmd/up_test.go
@@ -27,8 +27,8 @@ func TestBuildBootstrapPrompt_Structure(t *testing.T) {
 	}
 
 	// Verify BC commands section
-	if !strings.Contains(prompt, "=== BC COMMANDS ===") {
-		t.Error("prompt should contain BC commands section")
+	if !strings.Contains(prompt, "=== BC COMMAND REFERENCE ===") {
+		t.Error("prompt should contain BC command reference section")
 	}
 	// Check for key command categories
 	if !strings.Contains(prompt, "** Agent Operations **") {


### PR DESCRIPTION
## Summary
Fix pre-existing test failure in `TestBuildBootstrapPrompt_Structure`.

## Root Cause
Test expected `=== BC COMMANDS ===` but actual code in `buildBootstrapPrompt()` has `=== BC COMMAND REFERENCE ===`.

## Fix
Updated test assertion to match the actual implementation.

## Test plan
- [x] `go test ./internal/cmd/... -run TestBuildBootstrapPrompt_Structure` passes
- [x] All internal/cmd tests pass
- [x] Pre-commit hooks pass

Fixes #391
Part of CI fix effort

🤖 Generated with [Claude Code](https://claude.com/claude-code)