### PR TITLE
feat(beads): improve error handling with proper error returns

### DIFF
--- a/internal/tui/workspace.go
+++ b/internal/tui/workspace.go
@@ -742,7 +742,7 @@ func (m *WorkspaceModel) loadQueue() {
 	m.queueItems = nil
 
 	// Load work queue items from ready issues
-	readyIssues := beads.ReadyIssues(m.info.Entry.Path)
+	readyIssues, _ := beads.ReadyIssues(m.info.Entry.Path) // Ignore error - no beads is OK
 	for _, issue := range readyIssues {
 		m.queueItems = append(m.queueItems, QueueItem{
 			ID:       issue.ID,
@@ -1213,7 +1213,7 @@ func (m *WorkspaceModel) computeStats() {
 	}
 
 	// Count ready issues (unblocked and available for work)
-	readyIssues := beads.ReadyIssues(m.info.Entry.Path)
+	readyIssues, _ := beads.ReadyIssues(m.info.Entry.Path) // Ignore error - no beads is OK
 	m.stats.ReadyIssues = len(readyIssues)
 
 	for _, a := range m.agents {

--- a/pkg/beads/beads.go
+++ b/pkg/beads/beads.go
@@ -114,21 +114,22 @@ func AddIssue(workspacePath, title, description string) error {
 }
 
 // ReadyIssues returns issues that are unblocked and ready for work.
-func ReadyIssues(workspacePath string) []Issue {
+// Returns ErrNoBeadsDir if the workspace has no .beads directory.
+func ReadyIssues(workspacePath string) ([]Issue, error) {
 	if !HasBeads(workspacePath) {
-		return nil
+		return nil, ErrNoBeadsDir
 	}
 
 	cmd := exec.CommandContext(context.Background(), "bd", "ready", "--json")
 	cmd.Dir = workspacePath
 	output, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("bd ready failed: %w", err)
 	}
 
 	var issues []Issue
 	if err := json.Unmarshal(output, &issues); err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to parse ready issues: %w", err)
 	}
 
 	// Tag source and filter out epics
@@ -140,7 +141,7 @@ func ReadyIssues(workspacePath string) []Issue {
 		}
 	}
 
-	return filtered
+	return filtered, nil
 }
 
 // AssignIssue assigns an issue to an agent.

--- a/pkg/beads/beads_test.go
+++ b/pkg/beads/beads_test.go
@@ -195,7 +195,10 @@ func TestListIssuesNoBeadsDir(t *testing.T) {
 
 func TestReadyIssuesNoBeadsDir(t *testing.T) {
 	dir := t.TempDir()
-	issues := ReadyIssues(dir)
+	issues, err := ReadyIssues(dir)
+	if !errors.Is(err, ErrNoBeadsDir) {
+		t.Errorf("ReadyIssues without .beads should return ErrNoBeadsDir, got %v", err)
+	}
 	if issues != nil {
 		t.Errorf("ReadyIssues without .beads should return nil, got %d issues", len(issues))
 	}
@@ -361,7 +364,10 @@ func TestReadyIssuesFiltersEpics(t *testing.T) {
 	mockBd := createMockBd(t, string(data))
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := ReadyIssues(dir)
+	result, err := ReadyIssues(dir)
+	if err != nil {
+		t.Fatalf("ReadyIssues unexpected error: %v", err)
+	}
 
 	if len(result) != 1 {
 		t.Fatalf("ReadyIssues returned %d issues, want 1 (epic filtered)", len(result))
@@ -383,9 +389,12 @@ func TestReadyIssuesEmptyResult(t *testing.T) {
 	mockBd := createMockBd(t, "[]")
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := ReadyIssues(dir)
-	if result != nil {
-		t.Errorf("ReadyIssues with empty array returned %v, want nil", result)
+	result, err := ReadyIssues(dir)
+	if err != nil {
+		t.Fatalf("ReadyIssues unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("ReadyIssues with empty array returned %d issues, want 0", len(result))
 	}
 }
 
@@ -544,8 +553,11 @@ func TestIssueJSONOmitsEmpty(t *testing.T) {
 
 func TestGetIssueNoBeadsDir(t *testing.T) {
 	dir := t.TempDir()
-	// No .beads directory — should return nil
-	result := GetIssue(dir, "bc-123")
+	// No .beads directory — should return ErrNoBeadsDir
+	result, err := GetIssue(dir, "bc-123")
+	if !errors.Is(err, ErrNoBeadsDir) {
+		t.Errorf("GetIssue without .beads should return ErrNoBeadsDir, got %v", err)
+	}
 	if result != nil {
 		t.Errorf("GetIssue without .beads should return nil, got %+v", result)
 	}
@@ -560,7 +572,10 @@ func TestGetIssueBdFails(t *testing.T) {
 	mockBd := createMockBdFailing(t)
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := GetIssue(dir, "bc-123")
+	result, err := GetIssue(dir, "bc-123")
+	if err == nil {
+		t.Error("GetIssue when bd fails should return an error")
+	}
 	if result != nil {
 		t.Errorf("GetIssue when bd fails should return nil, got %+v", result)
 	}
@@ -575,7 +590,10 @@ func TestGetIssueMalformedJSON(t *testing.T) {
 	mockBd := createMockBd(t, "this is not json")
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := GetIssue(dir, "bc-123")
+	result, err := GetIssue(dir, "bc-123")
+	if err == nil {
+		t.Error("GetIssue with malformed JSON should return an error")
+	}
 	if result != nil {
 		t.Errorf("GetIssue with malformed JSON should return nil, got %+v", result)
 	}
@@ -590,7 +608,10 @@ func TestGetIssueEmptyArray(t *testing.T) {
 	mockBd := createMockBd(t, "[]")
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := GetIssue(dir, "bc-123")
+	result, err := GetIssue(dir, "bc-123")
+	if !errors.Is(err, ErrIssueNotFound) {
+		t.Errorf("GetIssue with empty array should return ErrIssueNotFound, got %v", err)
+	}
 	if result != nil {
 		t.Errorf("GetIssue with empty array should return nil, got %+v", result)
 	}
@@ -613,7 +634,10 @@ func TestGetIssueSuccess(t *testing.T) {
 	mockBd := createMockBd(t, string(data))
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := GetIssue(dir, "bc-42")
+	result, err := GetIssue(dir, "bc-42")
+	if err != nil {
+		t.Fatalf("GetIssue unexpected error: %v", err)
+	}
 	if result == nil {
 		t.Fatal("GetIssue should return an issue, got nil")
 	}
@@ -649,7 +673,10 @@ func TestGetIssueReturnsFirst(t *testing.T) {
 	mockBd := createMockBd(t, string(data))
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := GetIssue(dir, "bc-1")
+	result, err := GetIssue(dir, "bc-1")
+	if err != nil {
+		t.Fatalf("GetIssue unexpected error: %v", err)
+	}
 	if result == nil {
 		t.Fatal("GetIssue should return an issue, got nil")
 	}
@@ -671,7 +698,10 @@ func TestGetIssueEmptyID(t *testing.T) {
 	mockBd := createMockBd(t, "[]")
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := GetIssue(dir, "")
+	result, err := GetIssue(dir, "")
+	if !errors.Is(err, ErrIssueNotFound) {
+		t.Errorf("GetIssue with empty ID should return ErrIssueNotFound, got %v", err)
+	}
 	if result != nil {
 		t.Errorf("GetIssue with empty ID should return nil, got %+v", result)
 	}
@@ -757,7 +787,10 @@ func TestReadyIssuesBdFails(t *testing.T) {
 	mockBd := createMockBdFailing(t)
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := ReadyIssues(dir)
+	result, err := ReadyIssues(dir)
+	if err == nil {
+		t.Error("ReadyIssues when bd fails should return an error")
+	}
 	if result != nil {
 		t.Errorf("ReadyIssues when bd fails should return nil, got %d issues", len(result))
 	}
@@ -772,7 +805,10 @@ func TestReadyIssuesMalformedJSON(t *testing.T) {
 	mockBd := createMockBd(t, "not valid json")
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := ReadyIssues(dir)
+	result, err := ReadyIssues(dir)
+	if err == nil {
+		t.Error("ReadyIssues with malformed JSON should return an error")
+	}
 	if result != nil {
 		t.Errorf("ReadyIssues with malformed JSON should return nil, got %d issues", len(result))
 	}
@@ -796,9 +832,12 @@ func TestReadyIssuesAllEpics(t *testing.T) {
 	mockBd := createMockBd(t, string(data))
 	t.Setenv("PATH", filepath.Dir(mockBd)+":"+os.Getenv("PATH"))
 
-	result := ReadyIssues(dir)
-	if result != nil {
-		t.Errorf("ReadyIssues with only epics should return nil, got %d issues", len(result))
+	result, err := ReadyIssues(dir)
+	if err != nil {
+		t.Fatalf("ReadyIssues unexpected error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("ReadyIssues with only epics should return empty, got %d issues", len(result))
 	}
 }
 

--- a/pkg/beads/get.go
+++ b/pkg/beads/get.go
@@ -3,31 +3,37 @@ package beads
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os/exec"
 )
 
+// ErrIssueNotFound indicates the requested issue was not found.
+var ErrIssueNotFound = errors.New("issue not found")
+
 // GetIssue returns details for a single beads issue by ID.
-// Returns nil if the issue is not found or bd is unavailable.
-func GetIssue(workspacePath, issueID string) *Issue {
+// Returns ErrNoBeadsDir if the workspace has no .beads directory.
+// Returns ErrIssueNotFound if the issue does not exist.
+func GetIssue(workspacePath, issueID string) (*Issue, error) {
 	if !HasBeads(workspacePath) {
-		return nil
+		return nil, ErrNoBeadsDir
 	}
 
 	cmd := exec.CommandContext(context.Background(), "bd", "show", issueID, "--json")
 	cmd.Dir = workspacePath
 	output, err := cmd.Output()
 	if err != nil {
-		return nil
+		return nil, fmt.Errorf("bd show failed: %w", err)
 	}
 
 	var issues []Issue
 	if err := json.Unmarshal(output, &issues); err != nil {
-		return nil
+		return nil, fmt.Errorf("failed to parse issue: %w", err)
 	}
 	if len(issues) == 0 {
-		return nil
+		return nil, ErrIssueNotFound
 	}
 
 	issues[0].Source = "beads"
-	return &issues[0]
+	return &issues[0], nil
 }


### PR DESCRIPTION
## Summary
- Update `ReadyIssues` to return `([]Issue, error)` with proper error handling
- Update `GetIssue` to return `(*Issue, error)` with proper error handling
- Add `ErrIssueNotFound` sentinel error for when issue is not found
- Update callers in `internal/tui/workspace.go` to handle error returns
- Update all tests to verify new error behavior

## Changes
| File | Change |
|------|--------|
| `pkg/beads/beads.go` | `ReadyIssues` returns `([]Issue, error)` |
| `pkg/beads/get.go` | `GetIssue` returns `(*Issue, error)`, add `ErrIssueNotFound` |
| `pkg/beads/beads_test.go` | Update all tests for new signatures |
| `internal/tui/workspace.go` | Handle error returns (ignore - no beads is OK) |

## Test plan
- [x] All pkg/beads tests pass
- [x] internal/tui tests pass
- [x] Build succeeds
- [ ] CI green

Fixes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)