### PR TITLE
fix(cmd): log sender correctly for agent send events

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -467,12 +467,19 @@ func runAgentSend(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to send to %s: %w", agentName, sendErr)
 	}
 
-	// Log event
+	// Log event - Agent field is the sender, recipient goes in Data
+	sender := os.Getenv("BC_AGENT_ID")
+	if sender == "" {
+		sender = "root"
+	}
 	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
 	_ = eventLog.Append(events.Event{
 		Type:    events.MessageSent,
-		Agent:   agentName,
+		Agent:   sender,
 		Message: message,
+		Data: map[string]any{
+			"recipient": agentName,
+		},
 	})
 
 	fmt.Printf("Sent to %s: %s\n", agentName, message)

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -149,6 +149,12 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		if ev.Agent != "" {
 			agentStr = fmt.Sprintf(" [%s]", ev.Agent)
 		}
+		// For message.sent, show sender → recipient
+		if ev.Type == events.MessageSent && ev.Data != nil {
+			if recipient, ok := ev.Data["recipient"].(string); ok && recipient != "" {
+				agentStr = fmt.Sprintf(" [%s] → [%s]", ev.Agent, recipient)
+			}
+		}
 		msg := ""
 		if ev.Message != "" {
 			m := ev.Message

--- a/internal/cmd/send.go
+++ b/internal/cmd/send.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -70,12 +71,19 @@ func runSend(cmd *cobra.Command, args []string) error {
 	}
 	log.Debug("message sent successfully", "agent", agentName)
 
-	// Log event
+	// Log event - Agent field is the sender, recipient goes in Data
+	sender := os.Getenv("BC_AGENT_ID")
+	if sender == "" {
+		sender = "root"
+	}
 	evtLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
 	_ = evtLog.Append(events.Event{
 		Type:    events.MessageSent,
-		Agent:   agentName,
+		Agent:   sender,
 		Message: message,
+		Data: map[string]any{
+			"recipient": agentName,
+		},
 	})
 
 	fmt.Printf("Sent to %s: %s\n", agentName, message)


### PR DESCRIPTION
## Summary
- Fix `bc agent send` logging to use sender as Agent field, not recipient
- Add recipient to Data["recipient"] for proper audit trail
- Update `bc logs` display to show "sender → recipient" format

## Problem
When running `bc agent send <target> <message>`, the event log was using the target agent name in the `agent` field. This caused logs to display messages as if sent BY the target, rather than TO the target.

Example before fix:
```
18:31:08 message.sent         [creative-cat] I see you're stuck...
```
Even though `creative-cat` was the recipient, not the sender.

## Solution
- Determine sender from `BC_AGENT_ID` env var (or "root" if not set)
- Set `Agent` field to sender (who sent the message)
- Add `recipient` to the `Data` map

Example after fix:
```
18:31:08 message.sent         [root] → [creative-cat] I see you're stuck...
```

## Files Changed
- `internal/cmd/agent.go`: Fix event logging in `bc agent send`
- `internal/cmd/send.go`: Fix event logging in deprecated `bc send`
- `internal/cmd/logs.go`: Display sender → recipient for message.sent events

## Test plan
- [x] Build succeeds
- [x] Send/Logs tests pass
- [ ] CI green

Fixes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)