### PR TITLE
fix(cmd): handle ignored event logging errors

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -245,12 +245,14 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 		eventData["team"] = agentCreateTeam
 	}
 	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
-	_ = eventLog.Append(events.Event{
+	if err := eventLog.Append(events.Event{
 		Type:    events.AgentSpawned,
 		Agent:   agentName,
 		Message: fmt.Sprintf("created with role %s", role),
 		Data:    eventData,
-	})
+	}); err != nil {
+		log.Warn("failed to log agent spawn event", "error", err)
+	}
 
 	fmt.Println()
 	fmt.Println("Agent created successfully!")
@@ -428,11 +430,13 @@ func runAgentStop(cmd *cobra.Command, args []string) error {
 
 	// Log event
 	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
-	_ = eventLog.Append(events.Event{
+	if err := eventLog.Append(events.Event{
 		Type:    events.AgentStopped,
 		Agent:   agentName,
 		Message: "stopped via bc agent stop",
-	})
+	}); err != nil {
+		log.Warn("failed to log agent stop event", "error", err)
+	}
 
 	return nil
 }
@@ -473,14 +477,16 @@ func runAgentSend(cmd *cobra.Command, args []string) error {
 		sender = "root"
 	}
 	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
-	_ = eventLog.Append(events.Event{
+	if err := eventLog.Append(events.Event{
 		Type:    events.MessageSent,
 		Agent:   sender,
 		Message: message,
 		Data: map[string]any{
 			"recipient": agentName,
 		},
-	})
+	}); err != nil {
+		log.Warn("failed to log message sent event", "error", err)
+	}
 
 	fmt.Printf("Sent to %s: %s\n", agentName, message)
 	return nil

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -198,14 +198,16 @@ func runMerge(cmd *cobra.Command, args []string) error {
 
 	// Step 6: Log event
 	evLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
-	_ = evLog.Append(events.Event{
+	if err := evLog.Append(events.Event{
 		Type:    events.WorkCompleted,
 		Message: fmt.Sprintf("merged %s into main at %s", branch, commitHash),
 		Data: map[string]any{
 			"branch": branch,
 			"commit": commitHash,
 		},
-	})
+	}); err != nil {
+		log.Warn("failed to log merge event", "error", err)
+	}
 
 	fmt.Printf("Successfully merged %s into main\n", branch)
 	return nil

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/github"
+	"github.com/rpuneet/bc/pkg/log"
 )
 
 var prCmd = &cobra.Command{
@@ -115,7 +116,7 @@ func runPRNotify(cmd *cobra.Command, args []string) error {
 	}
 
 	// Event log
-	log := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
+	evtLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
 
 	// Post review requests
 	for _, pr := range needsReview {
@@ -128,7 +129,7 @@ func runPRNotify(cmd *cobra.Command, args []string) error {
 		}
 
 		// Log event
-		_ = log.Append(events.Event{
+		if err := evtLog.Append(events.Event{
 			Type:    events.MessageSent,
 			Agent:   "system",
 			Message: fmt.Sprintf("PR review request: #%d", pr.Number),
@@ -137,7 +138,9 @@ func runPRNotify(cmd *cobra.Command, args []string) error {
 				"pr_title":  pr.Title,
 				"channel":   "reviews",
 			},
-		})
+		}); err != nil {
+			log.Warn("failed to log PR review event", "error", err, "pr", pr.Number)
+		}
 
 		fmt.Printf("Posted review request for PR #%d: %s\n", pr.Number, pr.Title)
 	}

--- a/internal/cmd/send.go
+++ b/internal/cmd/send.go
@@ -77,14 +77,16 @@ func runSend(cmd *cobra.Command, args []string) error {
 		sender = "root"
 	}
 	evtLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
-	_ = evtLog.Append(events.Event{
+	if err := evtLog.Append(events.Event{
 		Type:    events.MessageSent,
 		Agent:   sender,
 		Message: message,
 		Data: map[string]any{
 			"recipient": agentName,
 		},
-	})
+	}); err != nil {
+		log.Warn("failed to log send event", "error", err)
+	}
 
 	fmt.Printf("Sent to %s: %s\n", agentName, message)
 	return nil

--- a/internal/cmd/spawn.go
+++ b/internal/cmd/spawn.go
@@ -102,13 +102,15 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	fmt.Printf("✓ (session: %s)\n", mgr.Tmux().SessionName(spawned.Session))
 
 	// Log event
-	log := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
-	_ = log.Append(events.Event{
+	evtLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
+	if err := evtLog.Append(events.Event{
 		Type:    events.AgentSpawned,
 		Agent:   agentName,
 		Message: fmt.Sprintf("dynamically spawned with role %s", role),
 		Data:    map[string]any{"role": string(role), "tool": toolName},
-	})
+	}); err != nil {
+		log.Warn("failed to log spawn event", "error", err)
+	}
 
 	// Print helpful info
 	fmt.Println()

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/events"
+	"github.com/rpuneet/bc/pkg/log"
 )
 
 var upCmd = &cobra.Command{
@@ -86,7 +87,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 	}
 
 	// Event log
-	log := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
+	evtLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
 
 	// Start root (acts as root agent)
 	fmt.Print("Starting root... ")
@@ -112,10 +113,12 @@ func runUp(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	_ = log.Append(events.Event{
+	if err := evtLog.Append(events.Event{
 		Type:  events.AgentSpawned,
 		Agent: "root",
-	})
+	}); err != nil {
+		log.Warn("failed to log root spawn event", "error", err)
+	}
 
 	// Wait for agent to initialize (Gemini/Claude needs time to start REPL)
 	time.Sleep(3 * time.Second)


### PR DESCRIPTION
## Summary

- Fix ignored event logging errors identified in audit (H13, H14, H16, H17, H18)
- Add proper error handling for `events.Log.Append()` calls that were previously ignored with `_ =`
- Log warnings via `pkg/log` when event logging fails (non-blocking)

## Files Changed

| File | Locations Fixed |
|------|----------------|
| agent.go | 3 |
| merge.go | 1 |
| pr.go | 1 |
| send.go | 1 |
| spawn.go | 1 |
| up.go | 1 |

## Pattern Applied

```go
// Before:
_ = evtLog.Append(events.Event{...})

// After:
if err := evtLog.Append(events.Event{...}); err != nil {
    log.Warn("failed to log event", "error", err)
}
```

Also renamed `log` variables to `evtLog` where they shadowed the `pkg/log` import.

## Test plan

- [x] All internal/cmd tests pass
- [x] Build succeeds
- [x] Pre-commit checks pass

Closes #377

🤖 Generated with [Claude Code](https://claude.com/claude-code)