### PR TITLE
fix(memory): add --learnings flag to prune command

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -111,25 +111,29 @@ are always preserved regardless of age.
 
 By default, creates a backup before pruning. Use --no-backup to skip.
 
+Use --learnings to also clear learnings (reset to header only).
+
 Example:
   bc memory prune --older-than 30d              # Remove experiences older than 30 days
   bc memory prune --older-than 7d --dry-run     # Preview what would be removed
   bc memory prune --older-than 90d --no-backup  # Prune without backup
-  bc memory prune --agent engineer-01           # Prune specific agent`,
+  bc memory prune --agent engineer-01           # Prune specific agent
+  bc memory prune --learnings                   # Also clear learnings`,
 	RunE: runMemoryPrune,
 }
 
 var (
-	memoryOutcome     string
-	memoryTaskID      string
-	memoryTaskType    string
-	memoryShowExp     bool
-	memoryShowLearn   bool
-	memorySearchAgent string
-	memoryPruneAgent  string
-	memoryOlderThan   string
-	memoryDryRun      bool
-	memoryNoBackup    bool
+	memoryOutcome          string
+	memoryTaskID           string
+	memoryTaskType         string
+	memoryShowExp          bool
+	memoryShowLearn        bool
+	memorySearchAgent      string
+	memoryPruneAgent       string
+	memoryOlderThan        string
+	memoryDryRun           bool
+	memoryNoBackup         bool
+	memoryIncludeLearnings bool
 )
 
 func init() {
@@ -146,6 +150,7 @@ func init() {
 	memoryPruneCmd.Flags().StringVar(&memoryOlderThan, "older-than", "30d", "Remove experiences older than this duration (e.g., 7d, 30d, 90d)")
 	memoryPruneCmd.Flags().BoolVar(&memoryDryRun, "dry-run", false, "Preview what would be removed without actually deleting")
 	memoryPruneCmd.Flags().BoolVar(&memoryNoBackup, "no-backup", false, "Skip creating backup before pruning")
+	memoryPruneCmd.Flags().BoolVar(&memoryIncludeLearnings, "learnings", false, "Also clear learnings (reset to header only)")
 
 	memoryCmd.AddCommand(memoryRecordCmd)
 	memoryCmd.AddCommand(memoryLearnCmd)
@@ -539,9 +544,10 @@ func runMemoryPrune(cmd *cobra.Command, args []string) error {
 		}
 
 		opts := memory.PruneOptions{
-			OlderThan: duration,
-			DryRun:    memoryDryRun,
-			Backup:    !memoryNoBackup,
+			OlderThan:        duration,
+			DryRun:           memoryDryRun,
+			Backup:           !memoryNoBackup,
+			IncludeLearnings: memoryIncludeLearnings,
 		}
 
 		result, pruneErr := store.Prune(opts)
@@ -550,7 +556,7 @@ func runMemoryPrune(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		if result.PrunedExperiences > 0 || result.PreservedPinned > 0 {
+		if result.PrunedExperiences > 0 || result.PreservedPinned > 0 || result.LearningsCleared {
 			cmd.Printf("[%s] ", agentID)
 			if memoryDryRun {
 				cmd.Printf("Would prune %d/%d experiences", result.PrunedExperiences, result.TotalExperiences)
@@ -559,6 +565,13 @@ func runMemoryPrune(cmd *cobra.Command, args []string) error {
 			}
 			if result.PreservedPinned > 0 {
 				cmd.Printf(" (preserved %d pinned)", result.PreservedPinned)
+			}
+			if result.LearningsCleared {
+				if memoryDryRun {
+					cmd.Printf(", would clear learnings")
+				} else {
+					cmd.Printf(", cleared learnings")
+				}
 			}
 			if result.BackupPath != "" {
 				cmd.Printf("\n    Backup: %s", result.BackupPath)

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -153,6 +153,15 @@ func (s *Store) GetLearnings() (string, error) {
 	return string(data), nil
 }
 
+// clearLearnings resets the learnings file to just the header.
+func (s *Store) clearLearnings() error {
+	header := fmt.Sprintf("# %s Learnings\n\nThis file contains insights and learnings accumulated by %s.\n\n", s.agentName, s.agentName)
+	if err := os.WriteFile(s.learningsPath(), []byte(header), 0600); err != nil { //nolint:gosec // path constructed from trusted memoryDir
+		return fmt.Errorf("failed to reset learnings file: %w", err)
+	}
+	return nil
+}
+
 // MemoryDir returns the path to the agent's memory directory.
 func (s *Store) MemoryDir() string {
 	return s.memoryDir
@@ -190,9 +199,10 @@ const DefaultSizeThreshold = 1024 * 1024 // 1MB
 
 // PruneOptions configures the prune operation.
 type PruneOptions struct {
-	OlderThan time.Duration // Remove experiences older than this duration
-	DryRun    bool          // If true, don't actually delete, just report
-	Backup    bool          // If true, create backup before pruning
+	OlderThan        time.Duration // Remove experiences older than this duration
+	DryRun           bool          // If true, don't actually delete, just report
+	Backup           bool          // If true, create backup before pruning
+	IncludeLearnings bool          // If true, also clear learnings (reset to header only)
 }
 
 // PruneResult contains statistics from a prune operation.
@@ -203,6 +213,7 @@ type PruneResult struct {
 	TotalExperiences  int
 	PrunedExperiences int
 	PreservedPinned   int
+	LearningsCleared  bool // True if learnings were cleared
 }
 
 // Prune removes old experiences based on the provided options.
@@ -272,6 +283,16 @@ func (s *Store) Prune(opts PruneOptions) (*PruneResult, error) {
 	// Get file size after prune
 	if info, statErr := os.Stat(s.experiencesPath()); statErr == nil {
 		result.BytesAfterPrune = info.Size()
+	}
+
+	// Clear learnings if requested
+	if opts.IncludeLearnings && !opts.DryRun {
+		if err := s.clearLearnings(); err != nil {
+			return nil, fmt.Errorf("failed to clear learnings: %w", err)
+		}
+		result.LearningsCleared = true
+	} else if opts.IncludeLearnings && opts.DryRun {
+		result.LearningsCleared = true // Would be cleared
 	}
 
 	return result, nil


### PR DESCRIPTION
## Summary
- Added `--learnings` flag to `bc memory prune` command to optionally clear learnings during prune
- Added `IncludeLearnings` field to `PruneOptions` struct
- Added `LearningsCleared` field to `PruneResult` struct
- Learnings are cleared by resetting to header only (all-or-nothing since learnings lack timestamps)

## Test plan
- [x] `make check` passes (golangci-lint 0 issues, all tests pass)
- [ ] Manual test: `bc memory prune --older-than 30d` (experiences only)
- [ ] Manual test: `bc memory prune --older-than 30d --learnings` (clears both)
- [ ] Manual test: `bc memory prune --older-than 30d --learnings --dry-run` (shows what would be cleared)

Fixes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)