### PR TITLE
feat(agent): add bc agent delete command

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -115,6 +115,22 @@ Examples:
 	RunE: runAgentSend,
 }
 
+// agentDeleteCmd permanently removes an agent
+var agentDeleteCmd = &cobra.Command{
+	Use:   "delete <agent>",
+	Short: "Permanently delete an agent",
+	Long: `Permanently delete an agent from the workspace.
+
+This removes the agent's tmux session, git worktree, memory directory,
+and all state. This action cannot be undone.
+
+Examples:
+  bc agent delete eng-01       # Delete eng-01
+  bc agent delete eng-01 --force  # Delete without confirmation`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAgentDelete,
+}
+
 // Flags
 var (
 	agentCreateTool   string
@@ -125,6 +141,7 @@ var (
 	agentListJSON     bool
 	agentPeekLines    int
 	agentStopForce    bool
+	agentDeleteForce  bool
 )
 
 func init() {
@@ -144,6 +161,9 @@ func init() {
 	// Stop flags
 	agentStopCmd.Flags().BoolVar(&agentStopForce, "force", false, "Force stop without cleanup")
 
+	// Delete flags
+	agentDeleteCmd.Flags().BoolVar(&agentDeleteForce, "force", false, "Delete without confirmation")
+
 	// Add subcommands
 	agentCmd.AddCommand(agentCreateCmd)
 	agentCmd.AddCommand(agentListCmd)
@@ -151,6 +171,7 @@ func init() {
 	agentCmd.AddCommand(agentPeekCmd)
 	agentCmd.AddCommand(agentStopCmd)
 	agentCmd.AddCommand(agentSendCmd)
+	agentCmd.AddCommand(agentDeleteCmd)
 
 	// Add parent command to root
 	rootCmd.AddCommand(agentCmd)
@@ -483,6 +504,61 @@ func runAgentSend(cmd *cobra.Command, args []string) error {
 	})
 
 	fmt.Printf("Sent to %s: %s\n", agentName, message)
+	return nil
+}
+
+func runAgentDelete(cmd *cobra.Command, args []string) error {
+	agentName := args[0]
+
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
+	if loadErr := mgr.LoadState(); loadErr != nil {
+		log.Warn("failed to load agent state", "error", loadErr)
+	}
+
+	a := mgr.GetAgent(agentName)
+	if a == nil {
+		return fmt.Errorf("agent '%s' not found", agentName)
+	}
+
+	// Confirm deletion unless --force is used
+	if !agentDeleteForce {
+		fmt.Printf("Delete agent '%s'? This will remove:\n", agentName)
+		fmt.Println("  - tmux session")
+		fmt.Println("  - git worktree")
+		fmt.Println("  - memory directory")
+		fmt.Println("  - agent state")
+		fmt.Print("\nType 'yes' to confirm: ")
+
+		var response string
+		if _, scanErr := fmt.Scanln(&response); scanErr != nil {
+			return fmt.Errorf("deletion canceled")
+		}
+		if response != "yes" {
+			return fmt.Errorf("deletion canceled")
+		}
+	}
+
+	fmt.Printf("Deleting %s... ", agentName)
+	if delErr := mgr.DeleteAgent(agentName); delErr != nil {
+		fmt.Println("✗")
+		return fmt.Errorf("failed to delete %s: %w", agentName, delErr)
+	}
+	fmt.Println("✓")
+
+	// Log event
+	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
+	_ = eventLog.Append(events.Event{
+		Type:    events.AgentStopped,
+		Agent:   agentName,
+		Message: "deleted via bc agent delete",
+	})
+
+	fmt.Printf("Agent '%s' has been permanently deleted.\n", agentName)
 	return nil
 }
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -781,6 +781,47 @@ func (m *Manager) stopAgentTreeLocked(name string) error {
 	return nil
 }
 
+// DeleteAgent permanently removes an agent from the workspace.
+// This stops the agent, removes its worktree, memory directory, and state.
+func (m *Manager) DeleteAgent(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	log.Debug("deleting agent", "name", name)
+
+	agent, exists := m.agents[name]
+	if !exists {
+		return fmt.Errorf("agent %s not found", name)
+	}
+
+	// Kill tmux session (ignore error - session might already be dead)
+	_ = m.tmux.KillSession(name)
+
+	// Clean up per-agent git worktree
+	if agent.WorktreeDir != "" && agent.WorktreeDir != agent.Workspace {
+		removeWorktree(agent.Workspace, agent.WorktreeDir)
+	}
+
+	// Clean up per-agent memory directory
+	if agent.MemoryDir != "" {
+		if err := os.RemoveAll(agent.MemoryDir); err != nil {
+			log.Warn("failed to remove memory dir", "dir", agent.MemoryDir, "error", err)
+		} else {
+			log.Debug("removed memory dir", "dir", agent.MemoryDir)
+		}
+	}
+
+	// Remove from parent's children list
+	m.removeFromParent(name)
+
+	// Delete from state
+	delete(m.agents, name)
+
+	_ = m.saveState() //nolint:errcheck // best-effort state persistence
+
+	return nil
+}
+
 // StopAll stops all agents.
 func (m *Manager) StopAll() error {
 	m.mu.Lock()


### PR DESCRIPTION
## Summary
- Added `bc agent delete <agent>` command to permanently remove agents
- Removes tmux session, git worktree, memory directory, and state
- Added `--force` flag to skip confirmation prompt
- Added `DeleteAgent` method to `pkg/agent/agent.go`

## Test plan
- [x] `make check` passes (0 lint issues, all tests pass)
- [ ] Manual test: `bc agent delete <agent>` (with confirmation)
- [ ] Manual test: `bc agent delete <agent> --force` (no confirmation)
- [ ] Verify worktree, memory dir, and state are removed

Fixes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)