### PR TITLE
docs(cmd): clarify that status symbols appear in TASK column

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -115,7 +115,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println()
-	fmt.Println("Symbols:")
+	fmt.Println("Symbols (in TASK column):")
 	fmt.Println("  ✻ ✳ ✽ ·  Thinking (agent is processing)")
 	fmt.Println("  ⏺        Tool call (agent is running a tool)")
 	fmt.Println("  ❯        Prompt (agent is waiting for input)")


### PR DESCRIPTION
## Summary
Clarify in the `bc status` symbols legend that the symbols appear in the TASK column.

The symbols (✻ ✳ ✽ · ⏺ ❯) are captured from the agent's terminal output and displayed in the TASK column. The existing legend was accurate but didn't make clear WHERE the symbols appear.

## Change
```diff
-Symbols:
+Symbols (in TASK column):
```

## Context
The symbols come from Claude Code's terminal UI:
- `✻ ✳ ✽ ·` - Thinking animations
- `⏺` - Tool call indicator
- `❯` - Prompt waiting for input

These are already visible in bc status output, the legend just needed clarification.

## Test plan
- [x] Build passes
- [x] Tests pass
- [ ] CI green

Fixes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)