### PR TITLE
Add error handling for health event logging

### DIFF
--- a/pkg/agent/health.go
+++ b/pkg/agent/health.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rpuneet/bc/pkg/events"
+	"github.com/rpuneet/bc/pkg/log"
 )
 
 const (
@@ -227,7 +228,7 @@ func (h *HealthChecker) emitHealthEvent(result *HealthCheckResult) {
 		eventType = events.HealthCheck
 	}
 
-	_ = h.eventLog.Append(events.Event{
+	if err := h.eventLog.Append(events.Event{
 		Type:    eventType,
 		Agent:   "root",
 		Message: result.ErrorMessage,
@@ -237,5 +238,7 @@ func (h *HealthChecker) emitHealthEvent(result *HealthCheckResult) {
 			"state_fresh":  result.StateFresh,
 			"last_updated": result.LastUpdated.Format(time.RFC3339),
 		},
-	})
+	}); err != nil {
+		log.Warn("failed to log health event", "error", err)
+	}
 }


### PR DESCRIPTION
## Summary
- Handle errors from `eventLog.Append` in `pkg/agent/health.go` instead of discarding them with `_`
- Uses `log.Warn` to report failures without interrupting the health check flow
- Follows the same pattern established in #396

## Test plan
- [x] All health tests pass (`go test ./pkg/agent/... -run Health`)
- [x] Pre-commit checks pass (build, vet, golangci-lint)

Fixes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)