### PR TITLE
fix(channel): add Store.Close() to prevent SQLite connection leaks (#403)

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -133,6 +133,7 @@ func runChannelList(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	channels := store.List()
 
@@ -179,6 +180,7 @@ func runChannelCreate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	name := strings.TrimSpace(args[0])
 	if name == "" {
@@ -206,6 +208,7 @@ func runChannelAdd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	channelName := args[0]
 	members := args[1:]
@@ -237,6 +240,7 @@ func runChannelRemove(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	channelName := args[0]
 	member := args[1]
@@ -263,6 +267,7 @@ func runChannelSend(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	channelName := args[0]
 	message := strings.Join(args[1:], " ")
@@ -348,6 +353,7 @@ func runChannelDelete(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	name := args[0]
 	if err := store.Delete(name); err != nil {
@@ -377,6 +383,7 @@ func runChannelJoin(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	channelName := args[0]
 	if err := store.AddMember(channelName, agentID); err != nil {
@@ -406,6 +413,7 @@ func runChannelLeave(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	channelName := args[0]
 	if err := store.RemoveMember(channelName, agentID); err != nil {
@@ -430,6 +438,7 @@ func runChannelHistory(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer func() { _ = store.Close() }()
 
 	channelName := args[0]
 	history, err := store.GetHistory(channelName)

--- a/internal/cmd/merge.go
+++ b/internal/cmd/merge.go
@@ -503,6 +503,7 @@ func notifyConflicts(rootDir, branch string, conflicts []string) error {
 	if err != nil {
 		store = channel.NewStore(rootDir)
 	}
+	defer func() { _ = store.Close() }()
 	if err := store.Load(); err != nil {
 		return fmt.Errorf("failed to load channel store: %w", err)
 	}

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -138,6 +138,15 @@ func (s *Store) Save() error {
 	return nil
 }
 
+// Close closes the underlying database connection.
+// Safe to call on JSON-backed stores (no-op).
+func (s *Store) Close() error {
+	if s.sqlite != nil {
+		return s.sqlite.Close()
+	}
+	return nil
+}
+
 // Create creates a new channel with the given name.
 func (s *Store) Create(name string) (*Channel, error) {
 	if s.sqlite != nil {


### PR DESCRIPTION
## Summary
- Add `Close()` method to `Store` struct that delegates to `SQLiteStore.Close()`
- Update all callers in `internal/cmd/channel.go` (8 locations) to defer close
- Update `internal/cmd/merge.go` (1 location) to defer close

## Test plan
- [x] `make check` passes (lint, vet, tests)
- [x] Verified Close() method added to pkg/channel/channel.go
- [x] All 9 call sites updated with `defer func() { _ = store.Close() }()`

## Issue
Fixes #403 (HIGH severity - SQLite connection leak)

## Found by
eng-04 channel audit (part of #368 Core Stability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)