### PR TITLE
fix(memory): log warning when skipping malformed JSON lines

### DIFF
--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/rpuneet/bc/pkg/log"
 )
 
 // Experience represents a recorded task outcome.
@@ -127,13 +129,14 @@ func (s *Store) GetExperiences() ([]Experience, error) {
 
 	var experiences []Experience
 	lines := splitLines(data)
-	for _, line := range lines {
+	for i, line := range lines {
 		if len(line) == 0 {
 			continue
 		}
 		var exp Experience
 		if unmarshalErr := json.Unmarshal(line, &exp); unmarshalErr != nil {
-			continue // Skip malformed lines
+			log.Warn("skipping malformed experience entry", "line", i+1, "error", unmarshalErr)
+			continue
 		}
 		experiences = append(experiences, exp)
 	}


### PR DESCRIPTION
## Summary
- GetExperiences() now logs a warning when encountering malformed JSON lines
- Uses `log.Warn` with line number and error details
- Helps detect data corruption in experience files

## Test plan
- [x] `make check` passes (lint, vet, tests)
- [x] Verified warning logged when skipping malformed lines

Fixes #408

🤖 Generated with [Claude Code](https://claude.com/claude-code)