### PR TITLE
fix(workspace): add validation for roster product_manager and manager fields

### DIFF
--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -86,15 +86,17 @@ const (
 
 // Validation errors.
 var (
-	ErrMissingWorkspaceName = errors.New("workspace.name is required")
-	ErrInvalidVersion       = errors.New("workspace.version must be 2")
-	ErrMissingDefaultTool   = errors.New("tools.default is required")
-	ErrDefaultToolNotFound  = errors.New("tools.default references undefined tool")
-	ErrMissingMemoryBackend = errors.New("memory.backend is required")
-	ErrMissingMemoryPath    = errors.New("memory.path is required")
-	ErrRosterEngineersRange = errors.New("roster.engineers must be between 0 and 10")
-	ErrRosterTechLeadsRange = errors.New("roster.tech_leads must be between 0 and 10")
-	ErrRosterQARange        = errors.New("roster.qa must be between 0 and 10")
+	ErrMissingWorkspaceName      = errors.New("workspace.name is required")
+	ErrInvalidVersion            = errors.New("workspace.version must be 2")
+	ErrMissingDefaultTool        = errors.New("tools.default is required")
+	ErrDefaultToolNotFound       = errors.New("tools.default references undefined tool")
+	ErrMissingMemoryBackend      = errors.New("memory.backend is required")
+	ErrMissingMemoryPath         = errors.New("memory.path is required")
+	ErrRosterProductManagerRange = errors.New("roster.product_manager must be between 0 and 10")
+	ErrRosterManagerRange        = errors.New("roster.manager must be between 0 and 10")
+	ErrRosterEngineersRange      = errors.New("roster.engineers must be between 0 and 10")
+	ErrRosterTechLeadsRange      = errors.New("roster.tech_leads must be between 0 and 10")
+	ErrRosterQARange             = errors.New("roster.qa must be between 0 and 10")
 )
 
 // DefaultV2Config returns sensible defaults for a new v2 workspace.
@@ -187,6 +189,12 @@ func (c *V2Config) Validate() error {
 	}
 
 	// Roster validation
+	if c.Roster.ProductManager < RosterMinPerRole || c.Roster.ProductManager > RosterMaxPerRole {
+		return ErrRosterProductManagerRange
+	}
+	if c.Roster.Manager < RosterMinPerRole || c.Roster.Manager > RosterMaxPerRole {
+		return ErrRosterManagerRange
+	}
 	if c.Roster.Engineers < RosterMinPerRole || c.Roster.Engineers > RosterMaxPerRole {
 		return ErrRosterEngineersRange
 	}

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -207,6 +207,42 @@ func TestV2ConfigValidation(t *testing.T) {
 			cfg:     DefaultV2Config("test"),
 		},
 		{
+			name:    "roster product_manager too high",
+			wantErr: ErrRosterProductManagerRange,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.ProductManager = 11
+				return cfg
+			}(),
+		},
+		{
+			name:    "roster product_manager negative",
+			wantErr: ErrRosterProductManagerRange,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.ProductManager = -1
+				return cfg
+			}(),
+		},
+		{
+			name:    "roster manager too high",
+			wantErr: ErrRosterManagerRange,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.Manager = 11
+				return cfg
+			}(),
+		},
+		{
+			name:    "roster manager negative",
+			wantErr: ErrRosterManagerRange,
+			cfg: func() V2Config {
+				cfg := DefaultV2Config("test")
+				cfg.Roster.Manager = -1
+				return cfg
+			}(),
+		},
+		{
 			name:    "roster engineers too high",
 			wantErr: ErrRosterEngineersRange,
 			cfg: func() V2Config {
@@ -247,6 +283,8 @@ func TestV2ConfigValidation(t *testing.T) {
 			wantErr: nil,
 			cfg: func() V2Config {
 				cfg := DefaultV2Config("test")
+				cfg.Roster.ProductManager = 0
+				cfg.Roster.Manager = 0
 				cfg.Roster.Engineers = 0
 				cfg.Roster.TechLeads = 0
 				cfg.Roster.QA = 0


### PR DESCRIPTION
## Summary
- Adds missing range validation for `roster.product_manager` and `roster.manager` fields in V2Config
- Both fields now validate against RosterMinPerRole (0) and RosterMaxPerRole (10)

Closes #419

## Test plan
- [x] All tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)