### PR TITLE
fix(tmux): populate Session.Windows field in ListSessions

### DIFF
--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -322,11 +323,13 @@ func (m *Manager) ListSessions() ([]Session, error) {
 			continue
 		}
 
+		windows, _ := strconv.Atoi(parts[3])
 		sessions = append(sessions, Session{
 			Name:      strings.TrimPrefix(name, fullPrefix),
 			Created:   parts[1],
-			Attached:  parts[2] == "1",
 			Directory: parts[4],
+			Windows:   windows,
+			Attached:  parts[2] == "1",
 		})
 	}
 

--- a/pkg/tmux/session_test.go
+++ b/pkg/tmux/session_test.go
@@ -858,6 +858,12 @@ func TestListSessions_Success(t *testing.T) {
 	if sessions[0].Directory != "/workspace" {
 		t.Errorf("sessions[0].Directory = %q, want %q", sessions[0].Directory, "/workspace")
 	}
+	if sessions[0].Windows != 1 {
+		t.Errorf("sessions[0].Windows = %d, want %d", sessions[0].Windows, 1)
+	}
+	if sessions[1].Windows != 2 {
+		t.Errorf("sessions[1].Windows = %d, want %d", sessions[1].Windows, 2)
+	}
 }
 
 func TestListSessions_WorkspaceIsolation(t *testing.T) {


### PR DESCRIPTION
Fixes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)