### PR TITLE
fix(agent): make bootstrap delay configurable

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -219,6 +219,11 @@ func LoadRoleMemory(workspacePath string, role Role) *AgentMemory {
 	}
 }
 
+// DefaultBootstrapDelay is the default time to wait before sending bootstrap
+// prompts after starting an agent. Different AI tools have different startup
+// times, so this can be configured per-manager.
+const DefaultBootstrapDelay = 3 * time.Second
+
 // Manager handles agent lifecycle.
 type Manager struct {
 	agents map[string]*Agent
@@ -231,6 +236,10 @@ type Manager struct {
 
 	// Workspace path for env vars
 	workspacePath string
+
+	// BootstrapDelay is the time to wait before sending bootstrap prompts.
+	// If zero, DefaultBootstrapDelay is used.
+	BootstrapDelay time.Duration
 
 	mu sync.RWMutex
 }
@@ -275,6 +284,21 @@ func (m *Manager) SetAgentByName(name string) bool {
 		}
 	}
 	return false
+}
+
+// SetBootstrapDelay sets the delay before sending bootstrap prompts.
+func (m *Manager) SetBootstrapDelay(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.BootstrapDelay = d
+}
+
+// getBootstrapDelay returns the configured bootstrap delay or the default.
+func (m *Manager) getBootstrapDelay() time.Duration {
+	if m.BootstrapDelay > 0 {
+		return m.BootstrapDelay
+	}
+	return DefaultBootstrapDelay
 }
 
 // GetAgentCommand returns the command for a tool name from config.
@@ -521,7 +545,7 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 	// Send bootstrap prompt if we have content
 	if len(promptParts) > 0 {
 		// Wait for agent to initialize (Gemini/Claude needs time to start REPL)
-		time.Sleep(3 * time.Second)
+		time.Sleep(m.getBootstrapDelay())
 
 		prompt := strings.Join(promptParts, "\n\n---\n\n")
 		prompt += fmt.Sprintf("\n\n---\n\nWorkspace: %s\nAgent ID: %s\n", workspace, name)

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1793,6 +1793,30 @@ func TestConcurrentRunningCount(t *testing.T) {
 	wg.Wait()
 }
 
+func TestBootstrapDelay(t *testing.T) {
+	m := newTestManager(t)
+
+	// Default should be 3 seconds
+	if d := m.getBootstrapDelay(); d != DefaultBootstrapDelay {
+		t.Errorf("default bootstrap delay: got %v, want %v", d, DefaultBootstrapDelay)
+	}
+	if d := m.getBootstrapDelay(); d != 3*time.Second {
+		t.Errorf("default bootstrap delay: got %v, want 3s", d)
+	}
+
+	// Setting custom delay should work
+	m.SetBootstrapDelay(5 * time.Second)
+	if d := m.getBootstrapDelay(); d != 5*time.Second {
+		t.Errorf("custom bootstrap delay: got %v, want 5s", d)
+	}
+
+	// Setting to 0 should revert to default
+	m.SetBootstrapDelay(0)
+	if d := m.getBootstrapDelay(); d != DefaultBootstrapDelay {
+		t.Errorf("zero bootstrap delay should use default: got %v, want %v", d, DefaultBootstrapDelay)
+	}
+}
+
 // --- Git wrapper tests ---
 
 func TestEnsureGitWrapper_CreatesFile(t *testing.T) {


### PR DESCRIPTION
## Summary
- Makes the 3-second bootstrap delay configurable via `Manager.SetBootstrapDelay()`
- Different AI tools (Claude, Gemini, etc.) have different startup times
- Allows callers to set appropriate delay for their tool

## Changes
- Add `DefaultBootstrapDelay` constant (3 seconds)
- Add `BootstrapDelay` field to Manager struct
- Add `SetBootstrapDelay()` method for configuration
- Replace hardcoded `time.Sleep(3 * time.Second)` with configurable delay
- Add test for bootstrap delay functionality

Closes #421

## Test plan
- [x] Run `make test` - all tests pass
- [x] Run `make lint` - no issues
- [x] New test verifies default and custom delay behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)