### PR TITLE
feat(demon): add logs subcommand for execution history

### DIFF
--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -85,9 +86,22 @@ var demonDisableCmd = &cobra.Command{
 	RunE:  runDemonDisable,
 }
 
+var demonLogsCmd = &cobra.Command{
+	Use:   "logs <name>",
+	Short: "Show execution history for a demon",
+	Long: `Show the execution history for a demon.
+
+Example:
+  bc demon logs backup           # Show all run history
+  bc demon logs backup --tail 5  # Show last 5 runs`,
+	Args: cobra.ExactArgs(1),
+	RunE: runDemonLogs,
+}
+
 var (
 	demonSchedule string
 	demonCommand  string
+	demonTail     int
 )
 
 func init() {
@@ -96,6 +110,8 @@ func init() {
 	_ = demonCreateCmd.MarkFlagRequired("schedule")
 	_ = demonCreateCmd.MarkFlagRequired("cmd")
 
+	demonLogsCmd.Flags().IntVar(&demonTail, "tail", 0, "Show only the last N entries")
+
 	demonCmd.AddCommand(demonCreateCmd)
 	demonCmd.AddCommand(demonListCmd)
 	demonCmd.AddCommand(demonShowCmd)
@@ -103,6 +119,7 @@ func init() {
 	demonCmd.AddCommand(demonRunCmd)
 	demonCmd.AddCommand(demonEnableCmd)
 	demonCmd.AddCommand(demonDisableCmd)
+	demonCmd.AddCommand(demonLogsCmd)
 	rootCmd.AddCommand(demonCmd)
 }
 
@@ -235,14 +252,18 @@ func runDemonRun(cmd *cobra.Command, args []string) error {
 
 	cmd.Printf("Running demon %q: %s\n", name, d.Command)
 
-	// Execute the command
+	// Execute the command with timing
+	startTime := time.Now()
 	ctx := context.Background()
 	execCmd := exec.CommandContext(ctx, "sh", "-c", d.Command) //nolint:gosec // command from trusted demon config
 	execCmd.Dir = ws.RootDir
 	output, execErr := execCmd.CombinedOutput()
+	duration := time.Since(startTime)
 
 	exitCode := 0
+	success := true
 	if execErr != nil {
+		success = false
 		if exitErr, ok := execErr.(*exec.ExitError); ok {
 			exitCode = exitErr.ExitCode()
 		} else {
@@ -250,9 +271,21 @@ func runDemonRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Record the run
+	// Record the run (updates LastRun, RunCount, NextRun)
 	if recordErr := store.RecordRun(name); recordErr != nil {
 		return fmt.Errorf("command executed but failed to record: %w", recordErr)
+	}
+
+	// Record the run log (detailed execution history)
+	runLog := demon.RunLog{
+		Timestamp: startTime.UTC(),
+		Duration:  duration.Milliseconds(),
+		ExitCode:  exitCode,
+		Success:   success,
+	}
+	if logErr := store.RecordRunLog(name, runLog); logErr != nil {
+		// Log error but don't fail - the command did execute
+		cmd.PrintErrf("Warning: failed to record log: %v\n", logErr)
 	}
 
 	// Print output
@@ -309,5 +342,60 @@ func runDemonDisable(cmd *cobra.Command, args []string) error {
 	}
 
 	cmd.Printf("Disabled demon %q\n", name)
+	return nil
+}
+
+func runDemonLogs(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	name := args[0]
+	store := demon.NewStore(ws.RootDir)
+
+	// Check if demon exists
+	d, err := store.Get(name)
+	if err != nil {
+		return err
+	}
+	if d == nil {
+		return fmt.Errorf("demon %q not found", name)
+	}
+
+	logs, err := store.GetRunLogs(name, demonTail)
+	if err != nil {
+		return err
+	}
+
+	if len(logs) == 0 {
+		cmd.Printf("No execution history for demon %q\n", name)
+		cmd.Println()
+		cmd.Printf("Run with: bc demon run %s\n", name)
+		return nil
+	}
+
+	cmd.Printf("Execution history for %q (%d runs):\n\n", name, d.RunCount)
+	cmd.Printf("%-24s %-12s %-10s %s\n", "TIMESTAMP", "DURATION", "STATUS", "EXIT CODE")
+	cmd.Println("--------------------------------------------------------------------")
+
+	for _, log := range logs {
+		status := "success"
+		if !log.Success {
+			status = "failed"
+		}
+
+		duration := fmt.Sprintf("%dms", log.Duration)
+		if log.Duration >= 1000 {
+			duration = fmt.Sprintf("%.1fs", float64(log.Duration)/1000)
+		}
+
+		cmd.Printf("%-24s %-12s %-10s %d\n",
+			log.Timestamp.Local().Format("2006-01-02 15:04:05"),
+			duration,
+			status,
+			log.ExitCode)
+	}
+
 	return nil
 }

--- a/pkg/demon/demon.go
+++ b/pkg/demon/demon.go
@@ -2,6 +2,7 @@
 package demon
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -25,6 +26,14 @@ type Demon struct {
 	Description string    `json:"description,omitempty"`
 	RunCount    int       `json:"run_count,omitempty"`
 	Enabled     bool      `json:"enabled"`
+}
+
+// RunLog represents a single execution of a demon.
+type RunLog struct {
+	Timestamp time.Time `json:"timestamp"`
+	Duration  int64     `json:"duration_ms"` // Duration in milliseconds
+	ExitCode  int       `json:"exit_code"`
+	Success   bool      `json:"success"`
 }
 
 // CronSchedule represents a parsed cron expression.
@@ -227,6 +236,74 @@ func (s *Store) RecordRun(name string) error {
 			d.NextRun = cron.Next(now)
 		}
 	})
+}
+
+// RecordRunLog appends a run log entry for a demon.
+func (s *Store) RecordRunLog(name string, log RunLog) error {
+	if err := s.Init(); err != nil {
+		return err
+	}
+
+	path := s.logPath(name)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600) //nolint:gosec // path constructed from trusted demonsDir
+	if err != nil {
+		return fmt.Errorf("failed to open log file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	data, err := json.Marshal(log)
+	if err != nil {
+		return fmt.Errorf("failed to marshal log: %w", err)
+	}
+
+	if _, err := f.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("failed to write log: %w", err)
+	}
+
+	return nil
+}
+
+// GetRunLogs retrieves the run logs for a demon.
+// If limit > 0, returns only the most recent entries.
+func (s *Store) GetRunLogs(name string, limit int) ([]RunLog, error) {
+	path := s.logPath(name)
+	f, err := os.Open(path) //nolint:gosec // path constructed from trusted demonsDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to open log file: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var logs []RunLog
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var log RunLog
+		if err := json.Unmarshal(line, &log); err != nil {
+			continue // Skip malformed entries
+		}
+		logs = append(logs, log)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read log file: %w", err)
+	}
+
+	// Return most recent entries if limit is set
+	if limit > 0 && len(logs) > limit {
+		logs = logs[len(logs)-limit:]
+	}
+
+	return logs, nil
+}
+
+func (s *Store) logPath(name string) string {
+	return filepath.Join(s.demonsDir, name+".log.jsonl")
 }
 
 // SetOwner sets the owner of a demon.

--- a/pkg/demon/demon_test.go
+++ b/pkg/demon/demon_test.go
@@ -531,3 +531,114 @@ func TestDemonOwnerField(t *testing.T) {
 		t.Errorf("Owner after reload = %q, want %q", got.Owner, "engineer-01")
 	}
 }
+
+func TestRecordRunLog(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Create a demon first
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Record a successful run
+	log1 := RunLog{
+		Timestamp: time.Now().UTC(),
+		Duration:  150,
+		ExitCode:  0,
+		Success:   true,
+	}
+	if recordErr := store.RecordRunLog("test-demon", log1); recordErr != nil {
+		t.Fatalf("RecordRunLog failed: %v", recordErr)
+	}
+
+	// Record a failed run
+	log2 := RunLog{
+		Timestamp: time.Now().UTC(),
+		Duration:  2500,
+		ExitCode:  1,
+		Success:   false,
+	}
+	if recordErr := store.RecordRunLog("test-demon", log2); recordErr != nil {
+		t.Fatalf("RecordRunLog failed: %v", recordErr)
+	}
+
+	// Get all logs
+	logs, err := store.GetRunLogs("test-demon", 0)
+	if err != nil {
+		t.Fatalf("GetRunLogs failed: %v", err)
+	}
+
+	if len(logs) != 2 {
+		t.Errorf("Expected 2 logs, got %d", len(logs))
+	}
+
+	// Verify first log
+	if logs[0].Duration != 150 {
+		t.Errorf("First log duration = %d, want 150", logs[0].Duration)
+	}
+	if !logs[0].Success {
+		t.Error("First log should be successful")
+	}
+
+	// Verify second log
+	if logs[1].ExitCode != 1 {
+		t.Errorf("Second log exit code = %d, want 1", logs[1].ExitCode)
+	}
+	if logs[1].Success {
+		t.Error("Second log should be failed")
+	}
+}
+
+func TestGetRunLogsWithLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Record 5 runs
+	for i := 0; i < 5; i++ {
+		log := RunLog{
+			Timestamp: time.Now().UTC(),
+			Duration:  int64(i * 100),
+			ExitCode:  0,
+			Success:   true,
+		}
+		if recordErr := store.RecordRunLog("test-demon", log); recordErr != nil {
+			t.Fatalf("RecordRunLog failed: %v", recordErr)
+		}
+	}
+
+	// Get with limit
+	logs, err := store.GetRunLogs("test-demon", 3)
+	if err != nil {
+		t.Fatalf("GetRunLogs failed: %v", err)
+	}
+
+	if len(logs) != 3 {
+		t.Errorf("Expected 3 logs with limit, got %d", len(logs))
+	}
+
+	// Should be the most recent ones (200ms, 300ms, 400ms)
+	if logs[0].Duration != 200 {
+		t.Errorf("First limited log duration = %d, want 200", logs[0].Duration)
+	}
+}
+
+func TestGetRunLogsNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Get logs for non-existent demon (no log file)
+	logs, err := store.GetRunLogs("nonexistent", 0)
+	if err != nil {
+		t.Errorf("GetRunLogs should not error for nonexistent: %v", err)
+	}
+	if logs != nil {
+		t.Errorf("Expected nil logs, got %v", logs)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `bc demon logs <name>` command to view execution history
- Stores run logs in JSONL format (.bc/demons/<name>.log.jsonl)
- Records timestamp, duration, exit code, and success status
- Supports `--tail` flag to limit output to recent entries
- Updated `runDemonRun` to record detailed run logs with timing

## Usage
```bash
bc demon logs backup           # Show all run history
bc demon logs backup --tail 5  # Show last 5 runs
```

## Output Example
```
Execution history for "backup" (5 runs):

TIMESTAMP                DURATION     STATUS     EXIT CODE
--------------------------------------------------------------------
2026-02-12 10:30:00      1.5s         success    0
2026-02-12 11:30:00      1.8s         success    0
2026-02-12 12:30:00      0.2s         failed     1
```

## Test plan
- [x] Added tests for RecordRunLog and GetRunLogs
- [x] Test limit functionality
- [x] All existing demon tests pass

Fixes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)