### PR TITLE
feat(agent): add health check command (#418)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -131,17 +131,39 @@ Examples:
 	RunE: runAgentDelete,
 }
 
+// agentHealthCmd shows agent health status
+var agentHealthCmd = &cobra.Command{
+	Use:   "health [agent]",
+	Short: "Show agent health status",
+	Long: `Show health status for agents, including tmux session status and state freshness.
+
+An agent is considered:
+  - healthy:   tmux session alive and state updated within timeout threshold
+  - degraded:  tmux session alive but state is stale (not updated within threshold)
+  - unhealthy: tmux session not found or agent in error state
+
+Examples:
+  bc agent health              # Show health for all agents
+  bc agent health eng-01       # Show health for specific agent
+  bc agent health --json       # Output as JSON
+  bc agent health --timeout 2m # Use 2 minute stale threshold`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runAgentHealth,
+}
+
 // Flags
 var (
-	agentCreateTool   string
-	agentCreateRole   string
-	agentCreateParent string
-	agentCreateTeam   string
-	agentListRole     string
-	agentListJSON     bool
-	agentPeekLines    int
-	agentStopForce    bool
-	agentDeleteForce  bool
+	agentCreateTool    string
+	agentCreateRole    string
+	agentCreateParent  string
+	agentCreateTeam    string
+	agentListRole      string
+	agentListJSON      bool
+	agentPeekLines     int
+	agentStopForce     bool
+	agentDeleteForce   bool
+	agentHealthJSON    bool
+	agentHealthTimeout string
 )
 
 func init() {
@@ -164,6 +186,10 @@ func init() {
 	// Delete flags
 	agentDeleteCmd.Flags().BoolVar(&agentDeleteForce, "force", false, "Delete without confirmation")
 
+	// Health flags
+	agentHealthCmd.Flags().BoolVar(&agentHealthJSON, "json", false, "Output as JSON")
+	agentHealthCmd.Flags().StringVar(&agentHealthTimeout, "timeout", "60s", "Stale state threshold (e.g., 30s, 2m)")
+
 	// Add subcommands
 	agentCmd.AddCommand(agentCreateCmd)
 	agentCmd.AddCommand(agentListCmd)
@@ -172,6 +198,7 @@ func init() {
 	agentCmd.AddCommand(agentStopCmd)
 	agentCmd.AddCommand(agentSendCmd)
 	agentCmd.AddCommand(agentDeleteCmd)
+	agentCmd.AddCommand(agentHealthCmd)
 
 	// Add parent command to root
 	rootCmd.AddCommand(agentCmd)
@@ -583,4 +610,164 @@ func isValidTeamName(name string) bool {
 		}
 	}
 	return true
+}
+
+// AgentHealth represents the health status of an agent.
+type AgentHealth struct {
+	Name          string `json:"name"`
+	Role          string `json:"role"`
+	Status        string `json:"status"`
+	LastUpdated   string `json:"last_updated"`
+	StaleDuration string `json:"stale_duration,omitempty"`
+	ErrorMessage  string `json:"error_message,omitempty"`
+	TmuxAlive     bool   `json:"tmux_alive"`
+	StateFresh    bool   `json:"state_fresh"`
+}
+
+func runAgentHealth(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	// Parse timeout duration
+	timeout, parseErr := time.ParseDuration(agentHealthTimeout)
+	if parseErr != nil {
+		return fmt.Errorf("invalid timeout format: %w", parseErr)
+	}
+
+	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
+	if loadErr := mgr.LoadState(); loadErr != nil {
+		log.Warn("failed to load agent state", "error", loadErr)
+	}
+
+	if refreshErr := mgr.RefreshState(); refreshErr != nil {
+		log.Warn("failed to refresh agent state", "error", refreshErr)
+	}
+
+	// Get agents to check
+	var agents []*agent.Agent
+	if len(args) > 0 {
+		// Check specific agent
+		a := mgr.GetAgent(args[0])
+		if a == nil {
+			return fmt.Errorf("agent '%s' not found", args[0])
+		}
+		agents = []*agent.Agent{a}
+	} else {
+		// Check all agents
+		agents = mgr.ListAgents()
+	}
+
+	if len(agents) == 0 {
+		fmt.Println("No agents found")
+		return nil
+	}
+
+	// Compute health for each agent
+	healthResults := make([]AgentHealth, 0, len(agents))
+	for _, a := range agents {
+		health := computeAgentHealth(a, mgr, timeout)
+		healthResults = append(healthResults, health)
+	}
+
+	// Output
+	if agentHealthJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(healthResults)
+	}
+
+	// Table output
+	fmt.Printf("%-15s %-12s %-10s %-8s %-8s %s\n", "AGENT", "ROLE", "STATUS", "TMUX", "FRESH", "LAST UPDATED")
+	fmt.Println(strings.Repeat("-", 75))
+
+	for _, h := range healthResults {
+		tmuxStr := "✗"
+		if h.TmuxAlive {
+			tmuxStr = "✓"
+		}
+		freshStr := "✗"
+		if h.StateFresh {
+			freshStr = "✓"
+		}
+
+		statusColor := h.Status
+		switch h.Status {
+		case "healthy":
+			statusColor = "\033[32m" + h.Status + "\033[0m" // green
+		case "degraded":
+			statusColor = "\033[33m" + h.Status + "\033[0m" // yellow
+		case "unhealthy":
+			statusColor = "\033[31m" + h.Status + "\033[0m" // red
+		}
+
+		fmt.Printf("%-15s %-12s %-10s %-8s %-8s %s\n",
+			h.Name,
+			h.Role,
+			statusColor,
+			tmuxStr,
+			freshStr,
+			h.LastUpdated,
+		)
+
+		if h.ErrorMessage != "" {
+			fmt.Printf("  └─ %s\n", h.ErrorMessage)
+		}
+	}
+
+	// Summary
+	var healthy, degraded, unhealthy int
+	for _, h := range healthResults {
+		switch h.Status {
+		case "healthy":
+			healthy++
+		case "degraded":
+			degraded++
+		case "unhealthy":
+			unhealthy++
+		}
+	}
+	fmt.Printf("\nSummary: %d healthy, %d degraded, %d unhealthy (threshold: %s)\n",
+		healthy, degraded, unhealthy, timeout)
+
+	return nil
+}
+
+func computeAgentHealth(a *agent.Agent, mgr *agent.Manager, timeout time.Duration) AgentHealth {
+	health := AgentHealth{
+		Name:        a.Name,
+		Role:        string(a.Role),
+		LastUpdated: a.UpdatedAt.Format(time.RFC3339),
+	}
+
+	// Check tmux session
+	health.TmuxAlive = mgr.Tmux().HasSession(a.Name)
+
+	// Check state freshness
+	staleDuration := time.Since(a.UpdatedAt)
+	health.StateFresh = staleDuration < timeout
+	if !health.StateFresh {
+		health.StaleDuration = staleDuration.Round(time.Second).String()
+	}
+
+	// Determine overall status
+	switch {
+	case a.State == agent.StateStopped:
+		health.Status = "unhealthy"
+		health.ErrorMessage = "agent stopped"
+	case a.State == agent.StateError:
+		health.Status = "unhealthy"
+		health.ErrorMessage = "agent in error state"
+	case !health.TmuxAlive:
+		health.Status = "unhealthy"
+		health.ErrorMessage = "tmux session not found"
+	case !health.StateFresh:
+		health.Status = "degraded"
+		health.ErrorMessage = fmt.Sprintf("state stale (%s since last update)", health.StaleDuration)
+	default:
+		health.Status = "healthy"
+	}
+
+	return health
 }

--- a/internal/cmd/agent_integration_test.go
+++ b/internal/cmd/agent_integration_test.go
@@ -258,3 +258,147 @@ func TestAgentNoWorkspace(t *testing.T) {
 		t.Errorf("expected workspace error, got: %v", execErr)
 	}
 }
+
+func TestAgentHealthEmpty(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	stdout, _, err := executeIntegrationCmd("agent", "health")
+	if err != nil {
+		t.Fatalf("agent health failed: %v\nOutput: %s", err, stdout)
+	}
+	if !strings.Contains(stdout, "No agents") {
+		t.Errorf("expected 'No agents' message, got: %s", stdout)
+	}
+}
+
+func TestAgentHealthWithAgents(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed agents
+	seedAgents(t, wsDir, map[string]*agent.Agent{
+		"engineer-01": {
+			Name:      "engineer-01",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateWorking,
+			Session:   "bc-engineer-01",
+			StartedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+		"stuck-agent": {
+			Name:      "stuck-agent",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateError,
+			Session:   "bc-stuck-agent",
+			StartedAt: time.Now().Add(-2 * time.Hour),
+			UpdatedAt: time.Now().Add(-2 * time.Hour), // stale
+		},
+	})
+
+	stdout, _, err := executeIntegrationCmd("agent", "health")
+	if err != nil {
+		t.Fatalf("agent health failed: %v\nOutput: %s", err, stdout)
+	}
+	if !strings.Contains(stdout, "engineer-01") {
+		t.Errorf("output should contain engineer-01: %s", stdout)
+	}
+	if !strings.Contains(stdout, "stuck-agent") {
+		t.Errorf("output should contain stuck-agent: %s", stdout)
+	}
+	if !strings.Contains(stdout, "Summary:") {
+		t.Errorf("output should contain summary: %s", stdout)
+	}
+}
+
+func TestAgentHealthSpecificAgent(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	seedAgents(t, wsDir, map[string]*agent.Agent{
+		"engineer-01": {
+			Name:      "engineer-01",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateWorking,
+			Session:   "bc-engineer-01",
+			StartedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	})
+
+	stdout, _, err := executeIntegrationCmd("agent", "health", "engineer-01")
+	if err != nil {
+		t.Fatalf("agent health failed: %v\nOutput: %s", err, stdout)
+	}
+	if !strings.Contains(stdout, "engineer-01") {
+		t.Errorf("output should contain engineer-01: %s", stdout)
+	}
+}
+
+func TestAgentHealthNotFound(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("agent", "health", "nonexistent-agent")
+	if err == nil {
+		t.Error("expected error for nonexistent agent")
+	}
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}
+
+func TestAgentHealthJSONOutput(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	seedAgents(t, wsDir, map[string]*agent.Agent{
+		"engineer-01": {
+			Name:      "engineer-01",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateIdle,
+			Session:   "bc-engineer-01",
+			StartedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	})
+
+	stdout, _, err := executeIntegrationCmd("agent", "health", "--json")
+	if err != nil {
+		t.Fatalf("agent health --json failed: %v\nOutput: %s", err, stdout)
+	}
+	// Output should be valid JSON (starts with [)
+	trimmed := strings.TrimSpace(stdout)
+	if !strings.HasPrefix(trimmed, "[") {
+		t.Errorf("output should be JSON array, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "engineer-01") {
+		t.Errorf("JSON should contain agent name: %s", stdout)
+	}
+}
+
+func TestAgentHealthCustomTimeout(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed an agent with stale state
+	seedAgents(t, wsDir, map[string]*agent.Agent{
+		"stale-agent": {
+			Name:      "stale-agent",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateWorking,
+			Session:   "bc-stale-agent",
+			StartedAt: time.Now().Add(-5 * time.Minute),
+			UpdatedAt: time.Now().Add(-5 * time.Minute),
+		},
+	})
+
+	// With short timeout, should show degraded
+	stdout, _, err := executeIntegrationCmd("agent", "health", "--timeout", "1s")
+	if err != nil {
+		t.Fatalf("agent health --timeout failed: %v\nOutput: %s", err, stdout)
+	}
+	if !strings.Contains(stdout, "degraded") && !strings.Contains(stdout, "unhealthy") {
+		t.Errorf("stale agent should be degraded or unhealthy with 1s timeout: %s", stdout)
+	}
+}

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -122,6 +122,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Println("Commands:")
 	fmt.Println("  bc attach <agent>  # Attach to agent's session")
+	fmt.Println("  bc agent health    # Check agent health status")
 	fmt.Println("  bc down            # Stop all agents")
 
 	return nil


### PR DESCRIPTION
## Summary
- Add `bc agent health` command to check agent health status
- Shows tmux session alive status and state freshness
- Supports `--timeout` flag for configurable stale threshold (default 60s)
- Supports `--json` flag for machine-readable output
- Color-coded status: healthy (green), degraded (yellow), unhealthy (red)

## Health status logic
- **healthy**: tmux session alive and state updated within threshold
- **degraded**: tmux session alive but state is stale
- **unhealthy**: tmux session not found or agent in error/stopped state

## Changes
- `internal/cmd/agent.go`: Add `agentHealthCmd` and `runAgentHealth` with `AgentHealth` struct
- `internal/cmd/agent_integration_test.go`: Add 6 tests for health command
- `internal/cmd/status.go`: Add reference to health command in output

## Test plan
- [x] All agent tests pass
- [x] New health tests pass (empty, with agents, specific agent, not found, JSON, custom timeout)
- [x] Build succeeds with no lint errors

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)