### PR TITLE
feat(memory): add bc memory clear command

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -138,6 +138,24 @@ Example:
 	RunE: runMemoryList,
 }
 
+var memoryClearCmd = &cobra.Command{
+	Use:   "clear <agent>",
+	Short: "Clear an agent's memory",
+	Long: `Clear all experiences and/or learnings from an agent's memory.
+
+By default, clears both experiences and learnings.
+Use --experiences or --learnings to clear selectively.
+Requires confirmation unless --force is specified.
+
+Example:
+  bc memory clear engineer-01              # Clear all (requires confirmation)
+  bc memory clear engineer-01 --force      # Clear all without confirmation
+  bc memory clear engineer-01 --experiences  # Clear only experiences
+  bc memory clear engineer-01 --learnings    # Clear only learnings`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMemoryClear,
+}
+
 var (
 	memoryOutcome          string
 	memoryTaskID           string
@@ -153,6 +171,9 @@ var (
 	memoryListAgent        string
 	memoryListExp          bool
 	memoryListSize         bool
+	memoryClearExp         bool
+	memoryClearLearn       bool
+	memoryClearForce       bool
 )
 
 func init() {
@@ -175,12 +196,17 @@ func init() {
 	memoryListCmd.Flags().BoolVar(&memoryListExp, "experiences", false, "List experiences instead of learning topics")
 	memoryListCmd.Flags().BoolVar(&memoryListSize, "with-size", false, "Show memory usage per agent")
 
+	memoryClearCmd.Flags().BoolVar(&memoryClearExp, "experiences", false, "Clear only experiences")
+	memoryClearCmd.Flags().BoolVar(&memoryClearLearn, "learnings", false, "Clear only learnings")
+	memoryClearCmd.Flags().BoolVar(&memoryClearForce, "force", false, "Skip confirmation prompt")
+
 	memoryCmd.AddCommand(memoryRecordCmd)
 	memoryCmd.AddCommand(memoryLearnCmd)
 	memoryCmd.AddCommand(memoryShowCmd)
 	memoryCmd.AddCommand(memorySearchCmd)
 	memoryCmd.AddCommand(memoryPruneCmd)
 	memoryCmd.AddCommand(memoryListCmd)
+	memoryCmd.AddCommand(memoryClearCmd)
 	rootCmd.AddCommand(memoryCmd)
 }
 
@@ -828,4 +854,65 @@ func formatBytes(b int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
+}
+
+func runMemoryClear(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	agentID := args[0]
+	store := memory.NewStore(ws.RootDir, agentID)
+
+	if !store.Exists() {
+		return fmt.Errorf("no memory found for agent %s", agentID)
+	}
+
+	// Determine what to clear
+	clearExp := memoryClearExp || (!memoryClearExp && !memoryClearLearn)
+	clearLearn := memoryClearLearn || (!memoryClearExp && !memoryClearLearn)
+
+	// Get current counts for confirmation message
+	var expCount int
+	if clearExp {
+		experiences, _ := store.GetExperiences()
+		expCount = len(experiences)
+	}
+
+	// Confirmation prompt unless --force
+	if !memoryClearForce {
+		what := []string{}
+		if clearExp {
+			what = append(what, fmt.Sprintf("%d experience(s)", expCount))
+		}
+		if clearLearn {
+			what = append(what, "learnings")
+		}
+
+		cmd.Printf("This will clear %s for agent %s.\n", strings.Join(what, " and "), agentID)
+		cmd.Print("Are you sure? [y/N]: ")
+
+		var response string
+		if _, scanErr := fmt.Scanln(&response); scanErr != nil || (response != "y" && response != "Y") {
+			cmd.Println("Aborted.")
+			return nil
+		}
+	}
+
+	result, err := store.Clear(clearExp, clearLearn)
+	if err != nil {
+		return fmt.Errorf("failed to clear memory: %w", err)
+	}
+
+	// Report what was cleared
+	if result.ExperiencesCleared > 0 {
+		cmd.Printf("Cleared %d experience(s)\n", result.ExperiencesCleared)
+	}
+	if result.LearningsCleared {
+		cmd.Println("Cleared learnings (reset to header)")
+	}
+	cmd.Printf("Memory cleared for agent %s\n", agentID)
+
+	return nil
 }

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -193,6 +193,39 @@ func (s *Store) clearLearnings() error {
 	return nil
 }
 
+// ClearResult holds the result of a Clear operation.
+type ClearResult struct {
+	ExperiencesCleared int  // number of experiences removed
+	LearningsCleared   bool // whether learnings were cleared
+}
+
+// Clear removes all experiences and/or learnings from the agent's memory.
+// If clearExperiences is true, removes all experiences.
+// If clearLearnings is true, resets learnings to the header.
+func (s *Store) Clear(clearExperiences, clearLearningsFlag bool) (*ClearResult, error) {
+	result := &ClearResult{}
+
+	if clearExperiences {
+		// Count existing experiences before clearing
+		existing, _ := s.GetExperiences()
+		result.ExperiencesCleared = len(existing)
+
+		// Clear by writing empty experiences file
+		if err := os.WriteFile(s.experiencesPath(), []byte{}, 0600); err != nil { //nolint:gosec // path constructed from trusted memoryDir
+			return nil, fmt.Errorf("failed to clear experiences: %w", err)
+		}
+	}
+
+	if clearLearningsFlag {
+		if err := s.clearLearnings(); err != nil {
+			return nil, err
+		}
+		result.LearningsCleared = true
+	}
+
+	return result, nil
+}
+
 // MemoryDir returns the path to the agent's memory directory.
 func (s *Store) MemoryDir() string {
 	return s.memoryDir

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -900,3 +900,96 @@ func TestStore_NeedsPruning(t *testing.T) {
 		t.Error("should not need pruning with 1MB threshold")
 	}
 }
+
+func TestStore_Clear(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add some experiences
+	for i := 0; i < 3; i++ {
+		exp := Experience{Description: "Test experience"}
+		if err := store.RecordExperience(exp); err != nil {
+			t.Fatalf("failed to record experience: %v", err)
+		}
+	}
+
+	// Add a learning
+	if err := store.AddLearning("patterns", "Test learning"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+
+	// Verify data exists
+	experiences, _ := store.GetExperiences()
+	if len(experiences) != 3 {
+		t.Errorf("expected 3 experiences, got %d", len(experiences))
+	}
+
+	// Clear only experiences
+	result, err := store.Clear(true, false)
+	if err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+	if result.ExperiencesCleared != 3 {
+		t.Errorf("expected 3 experiences cleared, got %d", result.ExperiencesCleared)
+	}
+	if result.LearningsCleared {
+		t.Error("learnings should not be cleared")
+	}
+
+	// Verify experiences are cleared
+	experiences, _ = store.GetExperiences()
+	if len(experiences) != 0 {
+		t.Errorf("expected 0 experiences after clear, got %d", len(experiences))
+	}
+
+	// Learnings should still exist
+	learnings, _ := store.GetLearnings()
+	if learnings == "" {
+		t.Error("learnings should still exist after clearing only experiences")
+	}
+}
+
+func TestStore_ClearBoth(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add experience and learning
+	if err := store.RecordExperience(Experience{Description: "Test"}); err != nil {
+		t.Fatalf("failed to record: %v", err)
+	}
+	if err := store.AddLearning("tips", "Test tip"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+
+	// Clear both
+	result, err := store.Clear(true, true)
+	if err != nil {
+		t.Fatalf("Clear failed: %v", err)
+	}
+	if result.ExperiencesCleared != 1 {
+		t.Errorf("expected 1 experience cleared, got %d", result.ExperiencesCleared)
+	}
+	if !result.LearningsCleared {
+		t.Error("learnings should be cleared")
+	}
+
+	// Verify both cleared
+	experiences, _ := store.GetExperiences()
+	if len(experiences) != 0 {
+		t.Errorf("expected 0 experiences, got %d", len(experiences))
+	}
+
+	learnings, _ := store.GetLearnings()
+	// Learnings file should still have the header
+	if learnings == "" {
+		t.Error("learnings should have header after clear")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `bc memory clear <agent>` command to reset an agent's memory
- Part of the memory management command suite (#401, #402, #405)

## Changes
- New `bc memory clear <agent>` CLI command with:
  - Confirmation prompt (skip with `--force`)
  - Selective clearing with `--experiences` or `--learnings` flags
  - Both cleared by default if no flags specified
- New `Store.Clear()` method in pkg/memory
- New `ClearResult` struct to report what was cleared
- Tests for Clear functionality

## Examples
```bash
bc memory clear engineer-01              # Clear all (requires confirmation)
bc memory clear engineer-01 --force      # Clear all without confirmation
bc memory clear engineer-01 --experiences  # Clear only experiences
bc memory clear engineer-01 --learnings    # Clear only learnings
```

Closes #401

## Test plan
- [x] Run `make test` - all tests pass
- [x] Run `make lint` - no issues
- [x] New tests verify Clear functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)