### PR TITLE
fix(cmd): standardize CLI help to use Examples: consistently (#370)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -70,7 +70,7 @@ var agentAttachCmd = &cobra.Command{
 
 Use Ctrl+b d to detach and return to your shell.
 
-Example:
+Examples:
   bc agent attach eng-01   # Attach to eng-01`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentAttach,

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -18,7 +18,7 @@ var attachCmd = &cobra.Command{
 This opens the tmux session where the agent (Claude) is running.
 Use Ctrl+b d to detach and return to your shell.
 
-Example:
+Examples:
   bc attach coordinator   # Attach to coordinator
   bc attach worker-01     # Attach to worker 1`,
 	Args: cobra.ExactArgs(1),

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -100,7 +100,7 @@ var configEditCmd = &cobra.Command{
 
 Uses $EDITOR environment variable, falls back to 'nano' if not set.
 
-Example:
+Examples:
   bc config edit`,
 	RunE: runConfigEdit,
 }
@@ -116,7 +116,7 @@ Checks for:
   - Valid values and types
   - Tool references exist
 
-Example:
+Examples:
   bc config validate`,
 	RunE: runConfigValidate,
 }
@@ -128,7 +128,7 @@ var configResetCmd = &cobra.Command{
 
 WARNING: This will overwrite your current config. Back up first if needed.
 
-Example:
+Examples:
   bc config reset
   bc config reset --force         # Skip confirmation`,
 	RunE: runConfigReset,

--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -15,7 +15,7 @@ var costCmd = &cobra.Command{
 	Short: "View cost information",
 	Long: `Commands for viewing API cost information.
 
-Example:
+Examples:
   bc cost show
   bc cost show engineer-01
   bc cost summary --workspace
@@ -27,7 +27,7 @@ var costShowCmd = &cobra.Command{
 	Short: "Show cost records",
 	Long: `Show cost records, optionally filtered by agent.
 
-Example:
+Examples:
   bc cost show
   bc cost show engineer-01`,
 	Args: cobra.MaximumNArgs(1),
@@ -39,7 +39,7 @@ var costSummaryCmd = &cobra.Command{
 	Short: "Show cost summary",
 	Long: `Show aggregated cost summary.
 
-Example:
+Examples:
   bc cost summary --workspace
   bc cost summary --team engineering
   bc cost summary --agent engineer-01
@@ -58,7 +58,7 @@ Shows:
   - Per-team breakdown
   - Per-model breakdown
 
-Example:
+Examples:
   bc cost dashboard`,
 	RunE: runCostDashboard,
 }
@@ -68,7 +68,7 @@ var costBudgetCmd = &cobra.Command{
 	Short: "Manage cost budgets",
 	Long: `Commands for managing cost budgets and limits.
 
-Example:
+Examples:
   bc cost budget show
   bc cost budget set 100.00
   bc cost budget set 50.00 --agent engineer-01

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -21,7 +21,7 @@ var dashboardCmd = &cobra.Command{
 	Long: `Show a dashboard with workspace stats including agent status
 and recent activity.
 
-Example:
+Examples:
   bc dashboard          # Show dashboard
   bc dashboard --json   # Output as JSON`,
 	RunE: runDashboard,

--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -18,7 +18,7 @@ var demonCmd = &cobra.Command{
 
 Demons are scheduled tasks that run at specified intervals using cron syntax.
 
-Example:
+Examples:
   bc demon create backup --schedule '0 * * * *' --cmd 'bc backup'
   bc demon list
   bc demon show backup
@@ -66,7 +66,7 @@ var demonRunCmd = &cobra.Command{
 	Short: "Manually trigger a demon",
 	Long: `Execute a demon's command immediately.
 
-Example:
+Examples:
   bc demon run backup`,
 	Args: cobra.ExactArgs(1),
 	RunE: runDemonRun,
@@ -91,7 +91,7 @@ var demonLogsCmd = &cobra.Command{
 	Short: "Show execution history for a demon",
 	Long: `Show the execution history for a demon.
 
-Example:
+Examples:
   bc demon logs backup           # Show all run history
   bc demon logs backup --tail 5  # Show last 5 runs`,
 	Args: cobra.ExactArgs(1),

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -16,7 +16,7 @@ var downCmd = &cobra.Command{
 
 This will gracefully stop all agent tmux sessions.
 
-Example:
+Examples:
   bc down          # Stop all agents
   bc down --force  # Force kill without cleanup`,
 	RunE: runDown,

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -25,7 +25,7 @@ v2 workspace structure:
       root.md      # Root agent role
     agents/        # Per-agent state files
 
-Example:
+Examples:
   bc init                    # Initialize current directory
   bc init ~/Projects/myapp   # Initialize specific directory`,
 	Args: cobra.MaximumNArgs(1),

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -17,7 +17,7 @@ var logsCmd = &cobra.Command{
 	Short: "View the event log",
 	Long: `View the bc event log showing agent spawns, stops, work assignments, and reports.
 
-Example:
+Examples:
   bc logs                    # all events
   bc logs --agent worker-01  # filter by agent
   bc logs --type agent.report # filter by event type

--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -33,7 +33,7 @@ Each agent has a memory directory at .bc/memory/<agent-name>/ containing:
   - experiences.jsonl: Recorded task outcomes
   - learnings.md: Accumulated insights
 
-Example:
+Examples:
   bc memory record "Fixed auth bug"         # Record experience
   bc memory learn "patterns" "Always test"  # Add learning
   bc memory show                            # Show memory for current agent
@@ -48,7 +48,7 @@ var memoryRecordCmd = &cobra.Command{
 
 Requires BC_AGENT_ID environment variable to be set.
 
-Example:
+Examples:
   bc memory record "Fixed auth bug - used JWT tokens"
   bc memory record --outcome success "Implemented feature X"
   bc memory record --task-id TASK-123 "Completed task"`,
@@ -65,7 +65,7 @@ Requires BC_AGENT_ID environment variable to be set.
 
 Categories: patterns, anti-patterns, tips, gotchas
 
-Example:
+Examples:
   bc memory learn patterns "Always check error returns"
   bc memory learn tips "Use context for cancellation"
   bc memory learn anti-patterns "Don't ignore errors"`,
@@ -80,7 +80,7 @@ var memoryShowCmd = &cobra.Command{
 
 If no agent is specified, uses BC_AGENT_ID environment variable.
 
-Example:
+Examples:
   bc memory show                # Show current agent's memory
   bc memory show engineer-01    # Show specific agent's memory
   bc memory show --experiences  # Show only experiences
@@ -94,7 +94,7 @@ var memorySearchCmd = &cobra.Command{
 	Short: "Search agent memories",
 	Long: `Search through experiences and learnings for matching content.
 
-Example:
+Examples:
   bc memory search "auth"
   bc memory search --agent engineer-01 "bug"`,
 	Args: cobra.ExactArgs(1),
@@ -113,7 +113,7 @@ By default, creates a backup before pruning. Use --no-backup to skip.
 
 Use --learnings to also clear learnings (reset to header only).
 
-Example:
+Examples:
   bc memory prune --older-than 30d              # Remove experiences older than 30 days
   bc memory prune --older-than 7d --dry-run     # Preview what would be removed
   bc memory prune --older-than 90d --no-backup  # Prune without backup
@@ -130,7 +130,7 @@ var memoryListCmd = &cobra.Command{
 By default, lists all learning topics (categories) across all agents.
 Use flags to customize the output.
 
-Example:
+Examples:
   bc memory list                    # List all learning topics
   bc memory list --experiences      # List all experiences
   bc memory list --with-size        # Show memory usage per agent

--- a/internal/cmd/pr.go
+++ b/internal/cmd/pr.go
@@ -30,7 +30,7 @@ This command:
 3. Posts review requests to #reviews channel
 4. Notifies tech-leads via @mentions
 
-Example:
+Examples:
   bc pr notify              # Notify about all PRs needing review
   bc pr notify --pr 123     # Notify about specific PR`,
 	RunE: runPRNotify,

--- a/internal/cmd/process.go
+++ b/internal/cmd/process.go
@@ -20,7 +20,7 @@ var processCmd = &cobra.Command{
 	Short: "Manage background processes",
 	Long: `Commands for managing background processes in the workspace.
 
-Example:
+Examples:
   bc process start web --cmd 'npm run dev'
   bc process list
   bc process logs web
@@ -32,7 +32,7 @@ var processStartCmd = &cobra.Command{
 	Short: "Start a background process",
 	Long: `Start a named background process.
 
-Example:
+Examples:
   bc process start web --cmd 'npm run dev'
   bc process start api --cmd 'go run ./cmd/server' --port 8080`,
 	Args: cobra.ExactArgs(1),
@@ -44,7 +44,7 @@ var processListCmd = &cobra.Command{
 	Short: "List processes",
 	Long: `List all managed processes.
 
-Example:
+Examples:
   bc process list`,
 	RunE: runProcessList,
 }
@@ -54,7 +54,7 @@ var processStopCmd = &cobra.Command{
 	Short: "Stop a process",
 	Long: `Stop a running process.
 
-Example:
+Examples:
   bc process stop web`,
 	Args: cobra.ExactArgs(1),
 	RunE: runProcessStop,
@@ -65,7 +65,7 @@ var processLogsCmd = &cobra.Command{
 	Short: "View process logs",
 	Long: `View logs for a process.
 
-Example:
+Examples:
   bc process logs web
   bc process logs web -n 100`,
 	Args: cobra.ExactArgs(1),
@@ -77,7 +77,7 @@ var processAttachCmd = &cobra.Command{
 	Short: "Attach to a running process",
 	Long: `Attach to a running process to view its output in real-time.
 
-Example:
+Examples:
   bc process attach web`,
 	Args: cobra.ExactArgs(1),
 	RunE: runProcessAttach,
@@ -88,7 +88,7 @@ var processInfoCmd = &cobra.Command{
 	Short: "Show process details",
 	Long: `Show detailed information about a process.
 
-Example:
+Examples:
   bc process info web`,
 	Args: cobra.ExactArgs(1),
 	RunE: runProcessInfo,

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -22,7 +22,7 @@ var reportCmd = &cobra.Command{
 
 Valid states: idle, working, done, stuck, error
 
-Example:
+Examples:
   bc report working "fixing auth bug"
   bc report done "auth bug fixed"
   bc report stuck "need database credentials"`,

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -16,7 +16,7 @@ var statsCmd = &cobra.Command{
 	Long: `Display statistics about the current workspace including work item
 metrics, agent utilization, and completion rates.
 
-Example:
+Examples:
   bc stats             # human-readable summary
   bc stats --json      # JSON output for scripting
   bc stats --save      # save stats snapshot to .bc/stats.json`,

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -19,7 +19,7 @@ var statusCmd = &cobra.Command{
 	Short: "Show agent status",
 	Long: `Show the status of all bc agents.
 
-Example:
+Examples:
   bc status          # Show all agents
   bc status --json   # Output as JSON`,
 	RunE: runStatus,

--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -15,7 +15,7 @@ var teamCmd = &cobra.Command{
 
 Teams group agents together for collaboration and organization.
 
-Example:
+Examples:
   bc team create engineering
   bc team list
   bc team show engineering

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -22,7 +22,7 @@ var upCmd = &cobra.Command{
 By default, this only starts the root agent which orchestrates the workspace.
 Other agents can be created or started as needed by the root agent.
 
-Example:
+Examples:
   bc up                      # Start root agent
   bc up --agent cursor       # Use Cursor AI for root agent`,
 	RunE: runUp,


### PR DESCRIPTION
## Summary
Standardize all CLI help text to use "Examples:" (plural) instead of mixed usage of "Example:" and "Examples:". This provides a consistent UX across all commands.

## Changes
- 17 files updated
- All standalone "Example:" headers changed to "Examples:"
- No functional changes - help text only

## Before
Some commands used `Example:` (singular), others used `Examples:` (plural)

## After  
All commands consistently use `Examples:` (plural)

## Test plan
- [x] `go build ./...` passes
- [x] Verified help output shows "Examples:" consistently
- [x] Pre-commit hooks pass

Fixes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)