### PR TITLE
feat(memory): add forget command for selective topic removal (#355)

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -173,6 +173,20 @@ Example:
 	RunE: runMemoryExport,
 }
 
+var memoryForgetCmd = &cobra.Command{
+	Use:   "forget <agent> <topic>",
+	Short: "Remove a learning topic from memory",
+	Long: `Remove a specific learning topic and all its entries from an agent's memory.
+
+Use 'bc memory list' to see available topics.
+
+Example:
+  bc memory forget engineer-01 patterns      # Remove "patterns" topic
+  bc memory forget engineer-01 anti-patterns # Remove "anti-patterns" topic`,
+	Args: cobra.ExactArgs(2),
+	RunE: runMemoryForget,
+}
+
 var (
 	memoryOutcome          string
 	memoryTaskID           string
@@ -232,6 +246,7 @@ func init() {
 	memoryCmd.AddCommand(memoryListCmd)
 	memoryCmd.AddCommand(memoryClearCmd)
 	memoryCmd.AddCommand(memoryExportCmd)
+	memoryCmd.AddCommand(memoryForgetCmd)
 	rootCmd.AddCommand(memoryCmd)
 }
 
@@ -1009,5 +1024,38 @@ func runMemoryExport(cmd *cobra.Command, args []string) error {
 		cmd.Println(string(data))
 	}
 
+	return nil
+}
+
+func runMemoryForget(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	agentID := args[0]
+	topic := args[1]
+
+	store := memory.NewStore(ws.RootDir, agentID)
+	if !store.Exists() {
+		return fmt.Errorf("no memory found for agent %s", agentID)
+	}
+
+	// List available topics to help user
+	topics, listErr := store.ListTopics()
+	if listErr != nil {
+		return fmt.Errorf("failed to list topics: %w", listErr)
+	}
+
+	entriesRemoved, err := store.ForgetTopic(topic)
+	if err != nil {
+		// If topic not found, show available topics
+		if len(topics) > 0 {
+			cmd.Printf("Available topics for %s: %s\n", agentID, strings.Join(topics, ", "))
+		}
+		return err
+	}
+
+	cmd.Printf("Removed topic %q from %s (%d entries deleted)\n", topic, agentID, entriesRemoved)
 	return nil
 }

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -362,6 +362,84 @@ func (s *Store) Prune(opts PruneOptions) (*PruneResult, error) {
 	return result, nil
 }
 
+// ForgetTopic removes a specific learning topic and all its entries.
+// Returns the number of entries removed, or an error if the topic doesn't exist.
+func (s *Store) ForgetTopic(topic string) (int, error) {
+	content, err := s.GetLearnings()
+	if err != nil {
+		return 0, fmt.Errorf("failed to read learnings: %w", err)
+	}
+
+	topicHeader := "## " + topic
+	if !strings.Contains(content, topicHeader) {
+		return 0, fmt.Errorf("topic %q not found", topic)
+	}
+
+	// Find the topic section
+	lines := strings.Split(content, "\n")
+	var newLines []string
+	inTopic := false
+	entriesRemoved := 0
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Check if this is the target topic header
+		if trimmed == topicHeader {
+			inTopic = true
+			continue
+		}
+
+		// Check if we've reached the next topic (end of target topic)
+		if inTopic && strings.HasPrefix(trimmed, "## ") {
+			inTopic = false
+		}
+
+		if inTopic {
+			// Count removed entries (lines starting with -)
+			if strings.HasPrefix(trimmed, "- ") {
+				entriesRemoved++
+			}
+			continue
+		}
+
+		newLines = append(newLines, line)
+	}
+
+	// Write the updated content
+	newContent := strings.Join(newLines, "\n")
+	// Clean up any double blank lines that may result
+	for strings.Contains(newContent, "\n\n\n") {
+		newContent = strings.ReplaceAll(newContent, "\n\n\n", "\n\n")
+	}
+
+	if err := os.WriteFile(s.learningsPath(), []byte(newContent), 0600); err != nil { //nolint:gosec // path constructed from trusted memoryDir
+		return 0, fmt.Errorf("failed to write learnings: %w", err)
+	}
+
+	return entriesRemoved, nil
+}
+
+// ListTopics returns all learning topic names.
+func (s *Store) ListTopics() ([]string, error) {
+	content, err := s.GetLearnings()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read learnings: %w", err)
+	}
+
+	var topics []string
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "## ") {
+			topic := strings.TrimPrefix(trimmed, "## ")
+			topics = append(topics, topic)
+		}
+	}
+
+	return topics, nil
+}
+
 // GetSize returns the total size of memory files in bytes.
 func (s *Store) GetSize() (int64, error) {
 	var total int64

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -991,5 +992,103 @@ func TestStore_ClearBoth(t *testing.T) {
 	// Learnings file should still have the header
 	if learnings == "" {
 		t.Error("learnings should have header after clear")
+	}
+}
+
+func TestStore_ListTopics(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add learnings in different topics
+	if err := store.AddLearning("patterns", "Use context"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+	if err := store.AddLearning("tips", "Check errors"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+	if err := store.AddLearning("gotchas", "Watch for nil"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+
+	topics, err := store.ListTopics()
+	if err != nil {
+		t.Fatalf("ListTopics failed: %v", err)
+	}
+
+	if len(topics) != 3 {
+		t.Errorf("expected 3 topics, got %d", len(topics))
+	}
+
+	// Check topics exist
+	topicMap := make(map[string]bool)
+	for _, topic := range topics {
+		topicMap[topic] = true
+	}
+	if !topicMap["patterns"] || !topicMap["tips"] || !topicMap["gotchas"] {
+		t.Errorf("expected patterns, tips, gotchas; got %v", topics)
+	}
+}
+
+func TestStore_ForgetTopic(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	// Add learnings in different topics
+	if err := store.AddLearning("patterns", "Use context"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+	if err := store.AddLearning("patterns", "Use interfaces"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+	if err := store.AddLearning("tips", "Check errors"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+
+	// Forget patterns topic
+	removed, err := store.ForgetTopic("patterns")
+	if err != nil {
+		t.Fatalf("ForgetTopic failed: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("expected 2 entries removed, got %d", removed)
+	}
+
+	// Verify patterns is gone
+	topics, _ := store.ListTopics()
+	for _, topic := range topics {
+		if topic == "patterns" {
+			t.Error("patterns topic should be removed")
+		}
+	}
+
+	// Verify tips is still there
+	learnings, _ := store.GetLearnings()
+	if !strings.Contains(learnings, "## tips") {
+		t.Error("tips topic should still exist")
+	}
+	if !strings.Contains(learnings, "Check errors") {
+		t.Error("tips learning should still exist")
+	}
+}
+
+func TestStore_ForgetTopic_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir, "engineer-01")
+
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	_, err := store.ForgetTopic("nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent topic")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `bc memory forget <agent> <topic>` command to remove specific learning topics
- Adds `ForgetTopic` and `ListTopics` methods to the memory store
- Includes tests for the new functionality

## Test plan
- [x] Unit tests for ForgetTopic (success and not found cases)
- [x] Unit tests for ListTopics
- [x] golangci-lint passes
- [ ] Manual testing: `bc memory forget engineer-01 patterns`

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)