### PR TITLE
feat(worktree): add --orphaned filter and --with-worktrees status flag (#361)

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -14,18 +15,22 @@ import (
 	"github.com/rpuneet/bc/pkg/log"
 )
 
+var statusWithWorktrees bool
+
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show agent status",
 	Long: `Show the status of all bc agents.
 
 Examples:
-  bc status          # Show all agents
-  bc status --json   # Output as JSON`,
+  bc status                 # Show all agents
+  bc status --json          # Output as JSON
+  bc status --with-worktrees  # Include worktree status`,
 	RunE: runStatus,
 }
 
 func init() {
+	statusCmd.Flags().BoolVar(&statusWithWorktrees, "with-worktrees", false, "Include worktree status for each agent")
 	rootCmd.AddCommand(statusCmd)
 }
 
@@ -78,14 +83,39 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if w, _, err := term.GetSize(os.Stdout.Fd()); err == nil && w > 0 {
 		termWidth = w
 	}
-	// Fixed columns: AGENT(15) + ROLE(12) + STATE(10) + UPTIME(20) = 57
-	taskWidth := termWidth - 57
+
+	// Build worktree status map if requested
+	worktreeStatus := make(map[string]string)
+	if statusWithWorktrees {
+		worktreesDir := filepath.Join(ws.RootDir, ".bc", "worktrees")
+		for _, a := range agents {
+			wtDir := filepath.Join(worktreesDir, a.Name)
+			if _, statErr := os.Stat(wtDir); os.IsNotExist(statErr) {
+				worktreeStatus[a.Name] = "MISSING"
+			} else {
+				worktreeStatus[a.Name] = "OK"
+			}
+		}
+	}
+
+	// Fixed columns vary based on worktree flag
+	// Without worktrees: AGENT(15) + ROLE(12) + STATE(10) + UPTIME(20) = 57
+	// With worktrees: AGENT(15) + ROLE(12) + STATE(10) + WORKTREE(10) + UPTIME(20) = 67
+	fixedWidth := 57
+	if statusWithWorktrees {
+		fixedWidth = 67
+	}
+	taskWidth := termWidth - fixedWidth
 	if taskWidth < 20 {
 		taskWidth = 20
 	}
 
 	// Print header
-	fmt.Printf("%-15s %-12s %-10s %-20s %s\n", "AGENT", "ROLE", "STATE", "UPTIME", "TASK")
+	if statusWithWorktrees {
+		fmt.Printf("%-15s %-12s %-10s %-10s %-20s %s\n", "AGENT", "ROLE", "STATE", "WORKTREE", "UPTIME", "TASK")
+	} else {
+		fmt.Printf("%-15s %-12s %-10s %-20s %s\n", "AGENT", "ROLE", "STATE", "UPTIME", "TASK")
+	}
 	fmt.Println(strings.Repeat("-", termWidth))
 
 	// Print agents
@@ -105,13 +135,26 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 		stateStr := colorState(a.State)
 
-		fmt.Printf("%-15s %-12s %s %-20s %s\n",
-			a.Name,
-			a.Role,
-			stateStr,
-			uptime,
-			task,
-		)
+		if statusWithWorktrees {
+			wtStatus := worktreeStatus[a.Name]
+			wtStatusStr := colorWorktreeStatus(wtStatus)
+			fmt.Printf("%-15s %-12s %s %s %-20s %s\n",
+				a.Name,
+				a.Role,
+				stateStr,
+				wtStatusStr,
+				uptime,
+				task,
+			)
+		} else {
+			fmt.Printf("%-15s %-12s %s %-20s %s\n",
+				a.Name,
+				a.Role,
+				stateStr,
+				uptime,
+				task,
+			)
+		}
 	}
 
 	fmt.Println()
@@ -169,6 +212,28 @@ func colorState(s agent.State) string {
 	case agent.StateError:
 		return red + padded + reset
 	case agent.StateStopped:
+		return yellow + padded + reset
+	default:
+		return padded
+	}
+}
+
+func colorWorktreeStatus(s string) string {
+	const (
+		reset  = "\033[0m"
+		green  = "\033[32m"
+		yellow = "\033[33m"
+		red    = "\033[31m"
+	)
+
+	padded := fmt.Sprintf("%-10s", s)
+
+	switch s {
+	case "OK":
+		return green + padded + reset
+	case "MISSING":
+		return red + padded + reset
+	case "ORPHANED":
 		return yellow + padded + reset
 	default:
 		return padded

--- a/internal/cmd/worktree.go
+++ b/internal/cmd/worktree.go
@@ -48,7 +48,10 @@ Also detects orphaned worktree directories that don't belong to any agent.`,
 	RunE: runWorktreeList,
 }
 
-var worktreePruneForce bool
+var (
+	worktreePruneForce bool
+	worktreeListOrphan bool
+)
 
 var worktreePruneCmd = &cobra.Command{
 	Use:   "prune",
@@ -72,6 +75,7 @@ func init() {
 	worktreeCmd.AddCommand(worktreeCheckCmd)
 	worktreeCmd.AddCommand(worktreeListCmd)
 	worktreeCmd.AddCommand(worktreePruneCmd)
+	worktreeListCmd.Flags().BoolVar(&worktreeListOrphan, "orphaned", false, "Show only orphaned worktrees")
 	worktreePruneCmd.Flags().BoolVarP(&worktreePruneForce, "force", "f", false, "Actually remove orphaned worktrees (default is dry-run)")
 }
 
@@ -216,6 +220,17 @@ func runWorktreeList(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Filter to orphaned only if requested
+	if worktreeListOrphan {
+		var filtered []WorktreeListEntry
+		for _, e := range entries {
+			if e.Status == "ORPHANED" {
+				filtered = append(filtered, e)
+			}
+		}
+		entries = filtered
+	}
+
 	jsonOutput, err := cmd.Flags().GetBool("json")
 	if err != nil {
 		return err
@@ -226,25 +241,38 @@ func runWorktreeList(cmd *cobra.Command, args []string) error {
 		return enc.Encode(entries)
 	}
 
+	if len(entries) == 0 {
+		if worktreeListOrphan {
+			fmt.Println("No orphaned worktrees found.")
+		} else {
+			fmt.Println("No worktrees found.")
+		}
+		return nil
+	}
+
 	// Table output
 	fmt.Printf("%-20s %-10s %s\n", "AGENT", "STATUS", "PATH")
 	for _, e := range entries {
 		fmt.Printf("%-20s %-10s %s\n", e.Agent, e.Status, e.Path)
 	}
 
-	// Summary
-	ok, missing, orphaned := 0, 0, 0
-	for _, e := range entries {
-		switch e.Status {
-		case "OK":
-			ok++
-		case "MISSING":
-			missing++
-		case "ORPHANED":
-			orphaned++
+	// Summary (only when not filtering)
+	if !worktreeListOrphan {
+		ok, missing, orphaned := 0, 0, 0
+		for _, e := range entries {
+			switch e.Status {
+			case "OK":
+				ok++
+			case "MISSING":
+				missing++
+			case "ORPHANED":
+				orphaned++
+			}
 		}
+		fmt.Printf("\nTotal: %d  OK: %d  Missing: %d  Orphaned: %d\n", len(entries), ok, missing, orphaned)
+	} else {
+		fmt.Printf("\nOrphaned: %d\n", len(entries))
 	}
-	fmt.Printf("\nTotal: %d  OK: %d  Missing: %d  Orphaned: %d\n", len(entries), ok, missing, orphaned)
 
 	return nil
 }

--- a/internal/cmd/worktree_test.go
+++ b/internal/cmd/worktree_test.go
@@ -558,3 +558,57 @@ func TestIsDetachedHead_DetachedWithChanges(t *testing.T) {
 		t.Error("expected false (has uncommitted changes), got true")
 	}
 }
+
+func TestWorktreeListOrphanedFlag(t *testing.T) {
+	// Create a workspace with agents and worktrees, plus an orphaned worktree
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	worktreesDir := filepath.Join(wsDir, ".bc", "worktrees")
+	agentsDir := filepath.Join(wsDir, ".bc", "agents")
+
+	// Register agents via agents.json
+	agents := map[string]*agent.Agent{
+		"eng-01": {Name: "eng-01", Role: agent.Role("engineer"), State: agent.StateIdle},
+		"eng-02": {Name: "eng-02", Role: agent.Role("engineer"), State: agent.StateIdle},
+	}
+	data, err := json.Marshal(agents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if writeErr := os.WriteFile(filepath.Join(agentsDir, "agents.json"), data, 0o600); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+
+	// Create worktrees for registered agents
+	_ = os.MkdirAll(filepath.Join(worktreesDir, "eng-01"), 0750)
+	_ = os.MkdirAll(filepath.Join(worktreesDir, "eng-02"), 0750)
+
+	// Create orphaned worktree (no agent registration)
+	_ = os.MkdirAll(filepath.Join(worktreesDir, "orphan-01"), 0750)
+	_ = os.MkdirAll(filepath.Join(worktreesDir, "orphan-02"), 0750)
+
+	// Test with --orphaned flag
+	stdout, _, err := executeIntegrationCmd("worktree", "list", "--orphaned")
+	if err != nil {
+		t.Fatalf("worktree list --orphaned failed: %v", err)
+	}
+
+	// Should only show orphaned worktrees
+	if !strings.Contains(stdout, "orphan-01") {
+		t.Error("expected orphan-01 in output")
+	}
+	if !strings.Contains(stdout, "orphan-02") {
+		t.Error("expected orphan-02 in output")
+	}
+	// eng-01 and eng-02 have worktrees and are registered, so they should NOT appear
+	lines := strings.Split(stdout, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "eng-01") && strings.Contains(line, "OK") {
+			t.Error("eng-01 with OK status should not appear when --orphaned is used")
+		}
+		if strings.Contains(line, "eng-02") && strings.Contains(line, "OK") {
+			t.Error("eng-02 with OK status should not appear when --orphaned is used")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--orphaned` flag to `bc worktree list` to show only orphaned worktrees
- Adds `--with-worktrees` flag to `bc status` to include worktree status per agent
- Includes test for --orphaned flag functionality

## Examples
```bash
# Show only orphaned worktrees
bc worktree list --orphaned

# Show agent status with worktree info
bc status --with-worktrees
```

## Test plan
- [x] Unit test for --orphaned flag
- [x] All existing worktree tests pass
- [x] golangci-lint passes
- [ ] Manual testing: `bc worktree list --orphaned`
- [ ] Manual testing: `bc status --with-worktrees`

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)