### PR TITLE
feat(agent): add stuck detection to health command (#359)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -141,29 +141,40 @@ An agent is considered:
   - healthy:   tmux session alive and state updated within timeout threshold
   - degraded:  tmux session alive but state is stale (not updated within threshold)
   - unhealthy: tmux session not found or agent in error state
+  - stuck:     no activity, repeated failures, or work timeout (with --detect-stuck)
+
+Stuck detection criteria (enabled with --detect-stuck):
+  - No activity: no events within activity timeout period
+  - Repeated failures: same task failed multiple times
+  - Work timeout: work started but not completed within work timeout
 
 Examples:
-  bc agent health              # Show health for all agents
-  bc agent health eng-01       # Show health for specific agent
-  bc agent health --json       # Output as JSON
-  bc agent health --timeout 2m # Use 2 minute stale threshold`,
+  bc agent health                    # Show health for all agents
+  bc agent health eng-01             # Show health for specific agent
+  bc agent health --json             # Output as JSON
+  bc agent health --timeout 2m       # Use 2 minute stale threshold
+  bc agent health --detect-stuck     # Include stuck detection analysis
+  bc agent health --detect-stuck --work-timeout 1h  # Custom work timeout`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentHealth,
 }
 
 // Flags
 var (
-	agentCreateTool    string
-	agentCreateRole    string
-	agentCreateParent  string
-	agentCreateTeam    string
-	agentListRole      string
-	agentListJSON      bool
-	agentPeekLines     int
-	agentStopForce     bool
-	agentDeleteForce   bool
-	agentHealthJSON    bool
-	agentHealthTimeout string
+	agentCreateTool      string
+	agentCreateRole      string
+	agentCreateParent    string
+	agentCreateTeam      string
+	agentListRole        string
+	agentListJSON        bool
+	agentPeekLines       int
+	agentStopForce       bool
+	agentDeleteForce     bool
+	agentHealthJSON      bool
+	agentHealthTimeout   string
+	agentHealthDetect    bool
+	agentHealthWorkTmout string
+	agentHealthMaxFail   int
 )
 
 func init() {
@@ -189,6 +200,9 @@ func init() {
 	// Health flags
 	agentHealthCmd.Flags().BoolVar(&agentHealthJSON, "json", false, "Output as JSON")
 	agentHealthCmd.Flags().StringVar(&agentHealthTimeout, "timeout", "60s", "Stale state threshold (e.g., 30s, 2m)")
+	agentHealthCmd.Flags().BoolVar(&agentHealthDetect, "detect-stuck", false, "Enable stuck detection analysis")
+	agentHealthCmd.Flags().StringVar(&agentHealthWorkTmout, "work-timeout", "30m", "Work timeout for stuck detection (e.g., 30m, 1h)")
+	agentHealthCmd.Flags().IntVar(&agentHealthMaxFail, "max-failures", 3, "Max consecutive failures before considered stuck")
 
 	// Add subcommands
 	agentCmd.AddCommand(agentCreateCmd)
@@ -620,8 +634,11 @@ type AgentHealth struct {
 	LastUpdated   string `json:"last_updated"`
 	StaleDuration string `json:"stale_duration,omitempty"`
 	ErrorMessage  string `json:"error_message,omitempty"`
+	StuckReason   string `json:"stuck_reason,omitempty"`
+	StuckDetails  string `json:"stuck_details,omitempty"`
 	TmuxAlive     bool   `json:"tmux_alive"`
 	StateFresh    bool   `json:"state_fresh"`
+	IsStuck       bool   `json:"is_stuck,omitempty"`
 }
 
 func runAgentHealth(cmd *cobra.Command, args []string) error {
@@ -634,6 +651,12 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 	timeout, parseErr := time.ParseDuration(agentHealthTimeout)
 	if parseErr != nil {
 		return fmt.Errorf("invalid timeout format: %w", parseErr)
+	}
+
+	// Parse work timeout for stuck detection
+	workTimeout, workParseErr := time.ParseDuration(agentHealthWorkTmout)
+	if workParseErr != nil {
+		return fmt.Errorf("invalid work-timeout format: %w", workParseErr)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -664,10 +687,43 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Prepare stuck detection if enabled
+	var eventLog *events.Log
+	var stuckConfig events.StuckConfig
+	if agentHealthDetect {
+		eventLog = events.NewLog(filepath.Join(ws.RootDir, ".bc", "events.jsonl"))
+		stuckConfig = events.StuckConfig{
+			ActivityTimeout: timeout,
+			WorkTimeout:     workTimeout,
+			MaxFailures:     agentHealthMaxFail,
+		}
+	}
+
 	// Compute health for each agent
 	healthResults := make([]AgentHealth, 0, len(agents))
 	for _, a := range agents {
 		health := computeAgentHealth(a, mgr, timeout)
+
+		// Add stuck detection if enabled
+		if agentHealthDetect && eventLog != nil {
+			agentEvents, readErr := eventLog.ReadByAgent(a.Name)
+			if readErr != nil {
+				log.Warn("failed to read agent events", "agent", a.Name, "error", readErr)
+			} else {
+				stuck := events.DetectStuck(agentEvents, stuckConfig)
+				if stuck.IsStuck {
+					health.IsStuck = true
+					health.StuckReason = string(stuck.Reason)
+					health.StuckDetails = stuck.Details
+					// Override status if stuck
+					if health.Status == "healthy" || health.Status == "degraded" {
+						health.Status = "stuck"
+						health.ErrorMessage = stuck.Details
+					}
+				}
+			}
+		}
+
 		healthResults = append(healthResults, health)
 	}
 
@@ -700,6 +756,8 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 			statusColor = "\033[33m" + h.Status + "\033[0m" // yellow
 		case "unhealthy":
 			statusColor = "\033[31m" + h.Status + "\033[0m" // red
+		case "stuck":
+			statusColor = "\033[35m" + h.Status + "\033[0m" // magenta
 		}
 
 		fmt.Printf("%-15s %-12s %-10s %-8s %-8s %s\n",
@@ -717,7 +775,7 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 	}
 
 	// Summary
-	var healthy, degraded, unhealthy int
+	var healthy, degraded, unhealthy, stuck int
 	for _, h := range healthResults {
 		switch h.Status {
 		case "healthy":
@@ -726,10 +784,17 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 			degraded++
 		case "unhealthy":
 			unhealthy++
+		case "stuck":
+			stuck++
 		}
 	}
-	fmt.Printf("\nSummary: %d healthy, %d degraded, %d unhealthy (threshold: %s)\n",
-		healthy, degraded, unhealthy, timeout)
+	if agentHealthDetect {
+		fmt.Printf("\nSummary: %d healthy, %d degraded, %d unhealthy, %d stuck (threshold: %s, work-timeout: %s)\n",
+			healthy, degraded, unhealthy, stuck, timeout, agentHealthWorkTmout)
+	} else {
+		fmt.Printf("\nSummary: %d healthy, %d degraded, %d unhealthy (threshold: %s)\n",
+			healthy, degraded, unhealthy, timeout)
+	}
 
 	return nil
 }

--- a/internal/cmd/agent_integration_test.go
+++ b/internal/cmd/agent_integration_test.go
@@ -402,3 +402,84 @@ func TestAgentHealthCustomTimeout(t *testing.T) {
 		t.Errorf("stale agent should be degraded or unhealthy with 1s timeout: %s", stdout)
 	}
 }
+
+func TestAgentHealthDetectStuckFlag(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed an agent
+	seedAgents(t, wsDir, map[string]*agent.Agent{
+		"test-agent": {
+			Name:      "test-agent",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateWorking,
+			Session:   "bc-test-agent",
+			StartedAt: time.Now().Add(-1 * time.Hour),
+			UpdatedAt: time.Now(),
+		},
+	})
+
+	// Test that --detect-stuck flag works (command should execute without error)
+	stdout, _, err := executeIntegrationCmd("agent", "health", "--detect-stuck")
+	if err != nil {
+		t.Fatalf("agent health --detect-stuck failed: %v\nOutput: %s", err, stdout)
+	}
+	// Command should execute and show agent
+	if !strings.Contains(stdout, "test-agent") {
+		t.Errorf("output should contain agent name: %s", stdout)
+	}
+}
+
+func TestAgentHealthDetectStuckMaxFailures(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed an agent
+	seedAgents(t, wsDir, map[string]*agent.Agent{
+		"test-agent": {
+			Name:      "test-agent",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateWorking,
+			Session:   "bc-test-agent",
+			StartedAt: time.Now().Add(-1 * time.Hour),
+			UpdatedAt: time.Now(),
+		},
+	})
+
+	// Test custom max-failures flag (command should execute without error)
+	stdout, _, err := executeIntegrationCmd("agent", "health", "--detect-stuck", "--max-failures", "5")
+	if err != nil {
+		t.Fatalf("agent health --max-failures failed: %v\nOutput: %s", err, stdout)
+	}
+	// Command should execute and show agent
+	if !strings.Contains(stdout, "test-agent") {
+		t.Errorf("output should contain agent name: %s", stdout)
+	}
+}
+
+func TestAgentHealthDetectStuckWorkTimeout(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Seed an agent
+	seedAgents(t, wsDir, map[string]*agent.Agent{
+		"test-agent": {
+			Name:      "test-agent",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateWorking,
+			Session:   "bc-test-agent",
+			StartedAt: time.Now().Add(-1 * time.Hour),
+			UpdatedAt: time.Now(),
+		},
+	})
+
+	// Test custom work-timeout flag (command should execute without error)
+	stdout, _, err := executeIntegrationCmd("agent", "health", "--detect-stuck", "--work-timeout", "1h")
+	if err != nil {
+		t.Fatalf("agent health --work-timeout failed: %v\nOutput: %s", err, stdout)
+	}
+	// Command should execute and show agent
+	if !strings.Contains(stdout, "test-agent") {
+		t.Errorf("output should contain agent name: %s", stdout)
+	}
+}

--- a/pkg/events/stuck.go
+++ b/pkg/events/stuck.go
@@ -1,0 +1,180 @@
+// Package events provides stuck detection for agents.
+package events
+
+import (
+	"time"
+)
+
+// StuckReason describes why an agent is considered stuck.
+type StuckReason string
+
+const (
+	// StuckNoActivity indicates no events in the timeout period.
+	StuckNoActivity StuckReason = "no_activity"
+	// StuckRepeatedFailures indicates the same task has failed multiple times.
+	StuckRepeatedFailures StuckReason = "repeated_failures"
+	// StuckWorkTimeout indicates work started but not completed within timeout.
+	StuckWorkTimeout StuckReason = "work_timeout"
+)
+
+// StuckDetection contains the result of analyzing an agent for stuck conditions.
+//
+//nolint:govet // JSON field order is more important than memory layout
+type StuckDetection struct {
+	LastEventTime time.Time     `json:"last_event_time,omitempty"`
+	IdleDuration  time.Duration `json:"idle_duration,omitempty"`
+	AgentName     string        `json:"agent_name"`
+	Reason        StuckReason   `json:"reason,omitempty"`
+	Details       string        `json:"details,omitempty"`
+	FailureCount  int           `json:"failure_count,omitempty"`
+	IsStuck       bool          `json:"is_stuck"`
+}
+
+// StuckConfig configures stuck detection thresholds.
+type StuckConfig struct {
+	// ActivityTimeout is how long without events before considering stuck.
+	ActivityTimeout time.Duration
+	// WorkTimeout is how long a task can run before considered stuck.
+	WorkTimeout time.Duration
+	// MaxFailures is the number of consecutive failures before considered stuck.
+	MaxFailures int
+}
+
+// DefaultStuckConfig returns sensible defaults for stuck detection.
+func DefaultStuckConfig() StuckConfig {
+	return StuckConfig{
+		ActivityTimeout: 10 * time.Minute,
+		WorkTimeout:     30 * time.Minute,
+		MaxFailures:     3,
+	}
+}
+
+// DetectStuck analyzes events to determine if an agent is stuck.
+func DetectStuck(events []Event, config StuckConfig) StuckDetection {
+	if len(events) == 0 {
+		return StuckDetection{
+			IsStuck: false,
+		}
+	}
+
+	detection := StuckDetection{
+		AgentName: events[0].Agent,
+	}
+
+	// Find the most recent event
+	var lastEvent Event
+	for _, ev := range events {
+		if ev.Timestamp.After(lastEvent.Timestamp) {
+			lastEvent = ev
+		}
+	}
+	detection.LastEventTime = lastEvent.Timestamp
+	detection.IdleDuration = time.Since(lastEvent.Timestamp)
+
+	// Check 1: No activity in timeout period
+	if detection.IdleDuration > config.ActivityTimeout {
+		detection.IsStuck = true
+		detection.Reason = StuckNoActivity
+		detection.Details = "no events in " + detection.IdleDuration.Round(time.Second).String()
+		return detection
+	}
+
+	// Check 2: Repeated failures on same task
+	failureCount := countRecentFailures(events, config.ActivityTimeout)
+	detection.FailureCount = failureCount
+	if failureCount >= config.MaxFailures {
+		detection.IsStuck = true
+		detection.Reason = StuckRepeatedFailures
+		detection.Details = "task failed " + string(rune('0'+failureCount)) + " times"
+		return detection
+	}
+
+	// Check 3: Work started but not completed within timeout
+	if workTimedOut := checkWorkTimeout(events, config.WorkTimeout); workTimedOut != "" {
+		detection.IsStuck = true
+		detection.Reason = StuckWorkTimeout
+		detection.Details = "work '" + workTimedOut + "' exceeds timeout"
+		return detection
+	}
+
+	return detection
+}
+
+// countRecentFailures counts consecutive WorkFailed events in the recent window.
+func countRecentFailures(events []Event, window time.Duration) int {
+	cutoff := time.Now().Add(-window)
+	count := 0
+	for i := len(events) - 1; i >= 0; i-- {
+		ev := events[i]
+		if ev.Timestamp.Before(cutoff) {
+			break
+		}
+		if ev.Type == WorkFailed {
+			count++
+		} else if ev.Type == WorkCompleted {
+			// Success resets the counter
+			break
+		}
+	}
+	return count
+}
+
+// checkWorkTimeout checks if any work has been running longer than the timeout.
+// Returns the task description if stuck, empty string otherwise.
+func checkWorkTimeout(events []Event, timeout time.Duration) string {
+	// Track work that started but didn't complete
+	startedWork := make(map[string]time.Time)
+
+	for _, ev := range events {
+		switch ev.Type {
+		case WorkStarted:
+			// Extract task from event data
+			task := ""
+			if ev.Message != "" {
+				task = ev.Message
+			} else if t, ok := ev.Data["task"].(string); ok {
+				task = t
+			}
+			if task != "" {
+				startedWork[task] = ev.Timestamp
+			}
+		case WorkCompleted, WorkFailed:
+			// Work finished - remove from tracking
+			task := ""
+			if ev.Message != "" {
+				task = ev.Message
+			} else if t, ok := ev.Data["task"].(string); ok {
+				task = t
+			}
+			delete(startedWork, task)
+		}
+	}
+
+	// Check if any started work has timed out
+	now := time.Now()
+	for task, startTime := range startedWork {
+		if now.Sub(startTime) > timeout {
+			return task
+		}
+	}
+
+	return ""
+}
+
+// DetectAllStuck analyzes events for multiple agents.
+func DetectAllStuck(log *Log, agentNames []string, config StuckConfig) ([]StuckDetection, error) {
+	var results []StuckDetection
+
+	for _, name := range agentNames {
+		events, err := log.ReadByAgent(name)
+		if err != nil {
+			return nil, err
+		}
+
+		detection := DetectStuck(events, config)
+		detection.AgentName = name
+		results = append(results, detection)
+	}
+
+	return results, nil
+}

--- a/pkg/events/stuck_test.go
+++ b/pkg/events/stuck_test.go
@@ -1,0 +1,144 @@
+package events
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDetectStuck_NoEvents(t *testing.T) {
+	config := DefaultStuckConfig()
+	detection := DetectStuck(nil, config)
+
+	if detection.IsStuck {
+		t.Error("expected not stuck with no events")
+	}
+}
+
+func TestDetectStuck_NoActivity(t *testing.T) {
+	// Create an old event
+	events := []Event{
+		{
+			Timestamp: time.Now().Add(-20 * time.Minute),
+			Type:      AgentReport,
+			Agent:     "test-agent",
+		},
+	}
+
+	config := StuckConfig{
+		ActivityTimeout: 10 * time.Minute,
+		WorkTimeout:     30 * time.Minute,
+		MaxFailures:     3,
+	}
+
+	detection := DetectStuck(events, config)
+
+	if !detection.IsStuck {
+		t.Error("expected stuck due to no activity")
+	}
+	if detection.Reason != StuckNoActivity {
+		t.Errorf("expected reason %s, got %s", StuckNoActivity, detection.Reason)
+	}
+}
+
+func TestDetectStuck_RepeatedFailures(t *testing.T) {
+	now := time.Now()
+	events := []Event{
+		{Timestamp: now.Add(-5 * time.Minute), Type: WorkFailed, Agent: "test-agent", Message: "task1"},
+		{Timestamp: now.Add(-4 * time.Minute), Type: WorkFailed, Agent: "test-agent", Message: "task1"},
+		{Timestamp: now.Add(-3 * time.Minute), Type: WorkFailed, Agent: "test-agent", Message: "task1"},
+		{Timestamp: now.Add(-1 * time.Minute), Type: AgentReport, Agent: "test-agent"},
+	}
+
+	config := StuckConfig{
+		ActivityTimeout: 10 * time.Minute,
+		WorkTimeout:     30 * time.Minute,
+		MaxFailures:     3,
+	}
+
+	detection := DetectStuck(events, config)
+
+	if !detection.IsStuck {
+		t.Error("expected stuck due to repeated failures")
+	}
+	if detection.Reason != StuckRepeatedFailures {
+		t.Errorf("expected reason %s, got %s", StuckRepeatedFailures, detection.Reason)
+	}
+}
+
+func TestDetectStuck_WorkTimeout(t *testing.T) {
+	now := time.Now()
+	events := []Event{
+		{Timestamp: now.Add(-45 * time.Minute), Type: WorkStarted, Agent: "test-agent", Message: "long-task"},
+		{Timestamp: now.Add(-1 * time.Minute), Type: AgentReport, Agent: "test-agent"},
+	}
+
+	config := StuckConfig{
+		ActivityTimeout: 10 * time.Minute,
+		WorkTimeout:     30 * time.Minute,
+		MaxFailures:     3,
+	}
+
+	detection := DetectStuck(events, config)
+
+	if !detection.IsStuck {
+		t.Error("expected stuck due to work timeout")
+	}
+	if detection.Reason != StuckWorkTimeout {
+		t.Errorf("expected reason %s, got %s", StuckWorkTimeout, detection.Reason)
+	}
+}
+
+func TestDetectStuck_Healthy(t *testing.T) {
+	now := time.Now()
+	events := []Event{
+		{Timestamp: now.Add(-5 * time.Minute), Type: WorkStarted, Agent: "test-agent", Message: "task1"},
+		{Timestamp: now.Add(-2 * time.Minute), Type: WorkCompleted, Agent: "test-agent", Message: "task1"},
+		{Timestamp: now.Add(-1 * time.Minute), Type: AgentReport, Agent: "test-agent"},
+	}
+
+	config := DefaultStuckConfig()
+
+	detection := DetectStuck(events, config)
+
+	if detection.IsStuck {
+		t.Errorf("expected not stuck, got reason: %s", detection.Reason)
+	}
+}
+
+func TestDetectStuck_FailureResetBySuccess(t *testing.T) {
+	now := time.Now()
+	events := []Event{
+		{Timestamp: now.Add(-10 * time.Minute), Type: WorkFailed, Agent: "test-agent", Message: "task1"},
+		{Timestamp: now.Add(-9 * time.Minute), Type: WorkFailed, Agent: "test-agent", Message: "task1"},
+		{Timestamp: now.Add(-5 * time.Minute), Type: WorkCompleted, Agent: "test-agent", Message: "task2"},
+		{Timestamp: now.Add(-4 * time.Minute), Type: WorkFailed, Agent: "test-agent", Message: "task3"},
+		{Timestamp: now.Add(-1 * time.Minute), Type: AgentReport, Agent: "test-agent"},
+	}
+
+	config := StuckConfig{
+		ActivityTimeout: 15 * time.Minute,
+		WorkTimeout:     30 * time.Minute,
+		MaxFailures:     3,
+	}
+
+	detection := DetectStuck(events, config)
+
+	// Only 1 failure after the success, should not be stuck
+	if detection.IsStuck {
+		t.Errorf("expected not stuck after success reset, got reason: %s", detection.Reason)
+	}
+}
+
+func TestDefaultStuckConfig(t *testing.T) {
+	config := DefaultStuckConfig()
+
+	if config.ActivityTimeout != 10*time.Minute {
+		t.Errorf("expected ActivityTimeout 10m, got %s", config.ActivityTimeout)
+	}
+	if config.WorkTimeout != 30*time.Minute {
+		t.Errorf("expected WorkTimeout 30m, got %s", config.WorkTimeout)
+	}
+	if config.MaxFailures != 3 {
+		t.Errorf("expected MaxFailures 3, got %d", config.MaxFailures)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `--detect-stuck` flag to `bc agent health` for automated stuck detection
- Adds `--work-timeout` flag to configure work timeout threshold (default 30m)
- Adds `--max-failures` flag to configure max consecutive failures (default 3)
- Creates `pkg/events/stuck.go` with stuck detection logic

## Stuck Detection Criteria
- **No activity**: no events within activity timeout period
- **Repeated failures**: same task failed multiple times consecutively
- **Work timeout**: work started but not completed within work timeout

## Test plan
- [x] Unit tests for DetectStuck function (7 tests)
- [x] Integration tests for health command with stuck detection flags (3 tests)
- [x] All existing tests pass
- [x] Manual testing: `bc agent health --detect-stuck`

## Examples
```bash
bc agent health --detect-stuck
bc agent health --detect-stuck --work-timeout 1h
bc agent health --detect-stuck --max-failures 5
bc agent health eng-01 --detect-stuck --json
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)