### PR TITLE
chore(cmd): deprecate TUI commands (#453)

### DIFF
--- a/internal/cmd/example.go
+++ b/internal/cmd/example.go
@@ -8,9 +8,13 @@ import (
 
 // exampleCmd demonstrates the TUI builder.
 var exampleCmd = &cobra.Command{
-	Use:   "example",
-	Short: "Run an example TUI to demonstrate the builder",
+	Use:        "example",
+	Short:      "Run an example TUI to demonstrate the builder (deprecated)",
+	Deprecated: "TUI is being rebuilt with Ink. This command will be removed in a future version.",
 	Long: `Launches an example TUI showing the declarative builder pattern.
+
+DEPRECATED: This command is deprecated and will be removed in a future version.
+The TUI is being rebuilt with Ink.
 
 This demonstrates how AI agents can generate predictable TUI code:
 

--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -14,9 +14,13 @@ import (
 )
 
 var homeCmd = &cobra.Command{
-	Use:   "home",
-	Short: "Open the bc home screen TUI",
+	Use:        "home",
+	Short:      "Open the bc home screen TUI (deprecated)",
+	Deprecated: "TUI is being rebuilt with Ink. Use 'bc agent list' and 'bc status' instead.",
 	Long: `Open the interactive home screen showing all workspaces and agents.
+
+DEPRECATED: This command is deprecated and will be removed in a future version.
+The TUI is being rebuilt with Ink. Use 'bc agent list' and 'bc status' instead.
 
 The TUI updates in real-time as agents start, stop, and report progress.
 You can drill into workspaces, view agents/issues/PRs, and peek at output.

--- a/internal/cmd/ui.go
+++ b/internal/cmd/ui.go
@@ -14,10 +14,14 @@ import (
 
 // uiCmd runs the streaming TUI runtime.
 var uiCmd = &cobra.Command{
-	Use:   "ui",
-	Short: "Run the streaming TUI runtime",
+	Use:        "ui",
+	Short:      "Run the streaming TUI runtime (deprecated)",
+	Deprecated: "TUI is being rebuilt with Ink. This command will be removed in a future version.",
 	Long: `Runs the TUI in runtime mode where it receives UI specs from stdin
 and sends user events to stdout.
+
+DEPRECATED: This command is deprecated and will be removed in a future version.
+The TUI is being rebuilt with Ink.
 
 This allows an AI to dynamically control the interface:
 


### PR DESCRIPTION
## Summary

- Mark `bc home`, `bc ui`, and `bc example` commands as deprecated
- Add deprecation warnings via Cobra's `Deprecated` field
- Add DEPRECATED notice in Long description text
- Commands are hidden from main help output (Cobra default behavior)

## Deprecation Message

```
Command "home" is deprecated, TUI is being rebuilt with Ink. Use 'bc agent list' and 'bc status' instead.
```

## Alternatives

The TUI is being rebuilt with Ink. In the meantime, users should use:
- `bc agent list` - for agent overview
- `bc status` - for workspace status

## Test plan

- [x] `bc home --help` shows deprecation warning
- [x] `bc ui --help` shows deprecation warning
- [x] `bc example --help` shows deprecation warning
- [x] Deprecated commands hidden from `bc --help` output
- [x] All tests pass
- [x] Lint clean

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)