### PR TITLE
refactor(cmd): rename process info to show (#452)

### DIFF
--- a/internal/cmd/process.go
+++ b/internal/cmd/process.go
@@ -83,15 +83,15 @@ Examples:
 	RunE: runProcessAttach,
 }
 
-var processInfoCmd = &cobra.Command{
-	Use:   "info <name>",
+var processShowCmd = &cobra.Command{
+	Use:   "show <name>",
 	Short: "Show process details",
 	Long: `Show detailed information about a process.
 
 Examples:
-  bc process info web`,
+  bc process show web`,
 	Args: cobra.ExactArgs(1),
-	RunE: runProcessInfo,
+	RunE: runProcessShow,
 }
 
 var (
@@ -114,7 +114,7 @@ func init() {
 	processCmd.AddCommand(processStopCmd)
 	processCmd.AddCommand(processLogsCmd)
 	processCmd.AddCommand(processAttachCmd)
-	processCmd.AddCommand(processInfoCmd)
+	processCmd.AddCommand(processShowCmd)
 	rootCmd.AddCommand(processCmd)
 }
 
@@ -315,7 +315,7 @@ func runProcessLogs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runProcessInfo(cmd *cobra.Command, args []string) error {
+func runProcessShow(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
 	reg, err := getProcessRegistry()

--- a/internal/cmd/process_test.go
+++ b/internal/cmd/process_test.go
@@ -79,11 +79,11 @@ func TestProcessLogsNotFound(t *testing.T) {
 	}
 }
 
-func TestProcessInfoNotFound(t *testing.T) {
+func TestProcessShowNotFound(t *testing.T) {
 	_, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 
-	_, _, err := executeIntegrationCmd("process", "info", "nonexistent")
+	_, _, err := executeIntegrationCmd("process", "show", "nonexistent")
 	if err == nil {
 		t.Fatal("expected error for missing process, got nil")
 	}
@@ -210,7 +210,7 @@ func seedProcess(t *testing.T, wsDir string, proc *process.Process) {
 	seedProcesses(t, wsDir, []*process.Process{proc})
 }
 
-func TestProcessInfoWithData(t *testing.T) {
+func TestProcessShowWithData(t *testing.T) {
 	wsDir, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 
@@ -227,9 +227,9 @@ func TestProcessInfoWithData(t *testing.T) {
 	}
 	seedProcess(t, wsDir, proc)
 
-	stdout, _, err := executeIntegrationCmd("process", "info", "test-server")
+	stdout, _, err := executeIntegrationCmd("process", "show", "test-server")
 	if err != nil {
-		t.Fatalf("process info error: %v", err)
+		t.Fatalf("process show error: %v", err)
 	}
 
 	// Check expected output fields
@@ -250,7 +250,7 @@ func TestProcessInfoWithData(t *testing.T) {
 	}
 }
 
-func TestProcessInfoWithoutOptionalFields(t *testing.T) {
+func TestProcessShowWithoutOptionalFields(t *testing.T) {
 	wsDir, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 
@@ -263,9 +263,9 @@ func TestProcessInfoWithoutOptionalFields(t *testing.T) {
 	}
 	seedProcess(t, wsDir, proc)
 
-	stdout, _, err := executeIntegrationCmd("process", "info", "minimal-proc")
+	stdout, _, err := executeIntegrationCmd("process", "show", "minimal-proc")
 	if err != nil {
-		t.Fatalf("process info error: %v", err)
+		t.Fatalf("process show error: %v", err)
 	}
 
 	if !strings.Contains(stdout, "minimal-proc") {


### PR DESCRIPTION
## Summary
- Renames `bc process info` command to `bc process show` for naming consistency
- Part of CLI audit #448 (Task 4 - Naming Standardization)
- Updates command definition, run function, and tests

## Changes
- `processInfoCmd` → `processShowCmd`
- `runProcessInfo` → `runProcessShow`  
- `Use: "info <name>"` → `Use: "show <name>"`
- Updated example in help text
- Renamed 3 test functions to match

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/... -run "Process.*Show"` passes
- [x] `golangci-lint run ./internal/cmd/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)