### PR TITLE
feat(channel): add bc channel show command (#457)

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -115,6 +115,19 @@ Examples:
 	RunE: runChannelReact,
 }
 
+var channelShowCmd = &cobra.Command{
+	Use:   "show <channel>",
+	Short: "Show detailed information about a channel",
+	Long: `Display detailed information about a channel including members,
+description, and message history statistics.
+
+Examples:
+  bc channel show engineering    # Show engineering channel details
+  bc channel show standup --json # Output as JSON`,
+	Args: cobra.ExactArgs(1),
+	RunE: runChannelShow,
+}
+
 func init() {
 	channelCmd.AddCommand(channelCreateCmd)
 	channelCmd.AddCommand(channelAddCmd)
@@ -126,6 +139,7 @@ func init() {
 	channelCmd.AddCommand(channelLeaveCmd)
 	channelCmd.AddCommand(channelHistoryCmd)
 	channelCmd.AddCommand(channelReactCmd)
+	channelCmd.AddCommand(channelShowCmd)
 	rootCmd.AddCommand(channelCmd)
 }
 
@@ -538,5 +552,102 @@ func runChannelReact(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("Removed %s reaction from message %d in #%s\n", emoji, messageIndex, channelName)
 	}
+	return nil
+}
+
+// ChannelInfo represents detailed channel information for JSON output.
+type ChannelInfo struct {
+	Name         string   `json:"name"`
+	Description  string   `json:"description,omitempty"`
+	Members      []string `json:"members"`
+	MemberCount  int      `json:"member_count"`
+	HistoryCount int      `json:"history_count"`
+}
+
+func runChannelShow(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace: %w", err)
+	}
+
+	store, err := loadChannelStore(ws.RootDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = store.Close() }()
+
+	channelName := args[0]
+
+	// Get channel
+	ch, exists := store.Get(channelName)
+	if !exists {
+		return fmt.Errorf("channel %q not found", channelName)
+	}
+
+	// Get members
+	members, err := store.GetMembers(channelName)
+	if err != nil {
+		return fmt.Errorf("failed to get members: %w", err)
+	}
+
+	// Get history for count
+	history, err := store.GetHistory(channelName)
+	if err != nil {
+		return fmt.Errorf("failed to get history: %w", err)
+	}
+
+	// Get description
+	description, _ := store.GetDescription(channelName)
+
+	jsonOutput, err := cmd.Flags().GetBool("json")
+	if err != nil {
+		return err
+	}
+
+	if jsonOutput {
+		info := ChannelInfo{
+			Name:         ch.Name,
+			Description:  description,
+			Members:      members,
+			MemberCount:  len(members),
+			HistoryCount: len(history),
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(info)
+	}
+
+	// Text output
+	fmt.Printf("Channel: #%s\n", ch.Name)
+	fmt.Println(strings.Repeat("-", 40))
+
+	if description != "" {
+		fmt.Printf("Description: %s\n", description)
+	}
+
+	fmt.Printf("Members (%d):\n", len(members))
+	if len(members) == 0 {
+		fmt.Println("  (none)")
+	} else {
+		for _, m := range members {
+			fmt.Printf("  • %s\n", m)
+		}
+	}
+
+	fmt.Printf("\nMessage History: %d messages\n", len(history))
+
+	if len(history) > 0 {
+		fmt.Println("\nRecent Messages (last 5):")
+		start := 0
+		if len(history) > 5 {
+			start = len(history) - 5
+		}
+		for i := start; i < len(history); i++ {
+			entry := history[i]
+			msg := strings.ReplaceAll(entry.Message, "\n", " ")
+			fmt.Printf("  [%s] %s: %s\n", entry.Time.Format("15:04"), entry.Sender, truncateMessage(msg, 50))
+		}
+	}
+
 	return nil
 }

--- a/internal/cmd/channel_test.go
+++ b/internal/cmd/channel_test.go
@@ -417,6 +417,7 @@ func TestChannelCommandSubcommands(t *testing.T) {
 		"join":    false,
 		"leave":   false,
 		"history": false,
+		"show":    false,
 	}
 
 	for _, cmd := range subcommands {
@@ -439,6 +440,134 @@ func TestChannelHistoryNoFlags(t *testing.T) {
 	// History command currently has no flags
 	if flags.Lookup("limit") != nil {
 		t.Log("--limit flag is available for history")
+	}
+}
+
+// --- Channel Show Tests ---
+
+func TestChannelShow_RequiresName(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("channel", "show")
+	if err == nil {
+		t.Fatal("expected error for missing name, got nil")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Errorf("expected arg count error, got: %v", err)
+	}
+}
+
+func TestChannelShow_NoWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err = os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	_, _, err = executeIntegrationCmd("channel", "show", "test-channel")
+	if err == nil {
+		t.Fatal("expected error when not in workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in a bc workspace") {
+		t.Errorf("expected workspace error, got: %v", err)
+	}
+}
+
+func TestChannelShow_NonexistentChannel(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("channel", "show", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent channel, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestChannelShow_ExistingChannel(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Create a channel using the store directly
+	store := channel.NewStore(wsDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("failed to load store: %v", err)
+	}
+	if _, err := store.Create("test-channel"); err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	if err := store.AddMember("test-channel", "agent-01"); err != nil {
+		t.Fatalf("failed to add member: %v", err)
+	}
+	if err := store.AddMember("test-channel", "agent-02"); err != nil {
+		t.Fatalf("failed to add member: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("failed to save store: %v", err)
+	}
+
+	stdout, _, err := executeIntegrationCmd("channel", "show", "test-channel")
+	if err != nil {
+		t.Fatalf("channel show error: %v", err)
+	}
+
+	// Should show channel name
+	if !strings.Contains(stdout, "#test-channel") {
+		t.Errorf("expected channel name in output, got: %s", stdout)
+	}
+
+	// Should show member count
+	if !strings.Contains(stdout, "Members (2)") {
+		t.Errorf("expected 'Members (2)' in output, got: %s", stdout)
+	}
+
+	// Should show members
+	if !strings.Contains(stdout, "agent-01") {
+		t.Errorf("expected 'agent-01' in output, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "agent-02") {
+		t.Errorf("expected 'agent-02' in output, got: %s", stdout)
+	}
+}
+
+func TestChannelShow_JSON(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Create a channel using the store directly
+	store := channel.NewStore(wsDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("failed to load store: %v", err)
+	}
+	if _, err := store.Create("json-test"); err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	if err := store.AddMember("json-test", "agent-01"); err != nil {
+		t.Fatalf("failed to add member: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("failed to save store: %v", err)
+	}
+
+	stdout, _, err := executeIntegrationCmd("channel", "show", "json-test", "--json")
+	if err != nil {
+		t.Fatalf("channel show --json error: %v", err)
+	}
+
+	// Should be valid JSON with expected fields
+	if !strings.Contains(stdout, `"name": "json-test"`) {
+		t.Errorf("expected JSON name field, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, `"member_count": 1`) {
+		t.Errorf("expected JSON member_count field, got: %s", stdout)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `bc channel show <name>` command for detailed channel information
- Display channel name, description, members, and message history
- Support `--json` flag for programmatic output
- Show recent messages preview (last 5)

## Usage

```bash
bc channel show engineering          # Show channel details
bc channel show standup --json       # JSON output
```

## Output Example

```
Channel: #engineering
----------------------------------------
Members (6):
  • clever-fox
  • eng-01
  • eng-02
  • eng-03
  • eng-04
  • sharp-eagle

Message History: 42 messages

Recent Messages (last 5):
  [17:30] eng-03: PR #462 ready for review...
  [17:35] sharp-eagle: LGTM! Clean documentation...
```

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] All tests pass
- [x] Added tests for show command (no workspace, nonexistent channel, existing channel, JSON output)

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)