### PR TITLE
feat(cmd): add bc process restart command (#458)

### DIFF
--- a/internal/cmd/process.go
+++ b/internal/cmd/process.go
@@ -94,6 +94,18 @@ Examples:
 	RunE: runProcessShow,
 }
 
+var processRestartCmd = &cobra.Command{
+	Use:   "restart <name>",
+	Short: "Restart a process",
+	Long: `Restart a process by stopping it gracefully and starting it again with the same configuration.
+
+Examples:
+  bc process restart web
+  bc process restart api`,
+	Args: cobra.ExactArgs(1),
+	RunE: runProcessRestart,
+}
+
 var (
 	processCommand  string
 	processPort     int
@@ -115,6 +127,7 @@ func init() {
 	processCmd.AddCommand(processLogsCmd)
 	processCmd.AddCommand(processAttachCmd)
 	processCmd.AddCommand(processShowCmd)
+	processCmd.AddCommand(processRestartCmd)
 	rootCmd.AddCommand(processCmd)
 }
 
@@ -390,4 +403,121 @@ func statusStr(running bool) string {
 		return "running"
 	}
 	return "stopped"
+}
+
+func runProcessRestart(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	reg, err := getProcessRegistry()
+	if err != nil {
+		return err
+	}
+
+	proc := reg.Get(name)
+	if proc == nil {
+		return fmt.Errorf("process %q not found", name)
+	}
+
+	// Store config before stopping
+	savedCommand := proc.Command
+	savedPort := proc.Port
+	savedWorkDir := proc.WorkDir
+	savedOwner := proc.Owner
+
+	// Stop the process if running
+	if proc.Running && proc.PID > 0 {
+		fmt.Printf("Stopping process %q (PID %d)...\n", name, proc.PID)
+
+		p, findErr := os.FindProcess(proc.PID)
+		if findErr == nil {
+			// Try graceful shutdown first (SIGTERM)
+			if sigErr := p.Signal(syscall.SIGTERM); sigErr == nil {
+				// Wait for process to exit (with timeout)
+				done := make(chan struct{})
+				go func() {
+					_, _ = p.Wait()
+					close(done)
+				}()
+
+				select {
+				case <-done:
+					// Process exited gracefully
+				case <-time.After(5 * time.Second):
+					// Force kill after timeout
+					fmt.Println("Process did not exit gracefully, forcing...")
+					_ = p.Kill()
+				}
+			} else {
+				// If SIGTERM fails, try SIGKILL
+				_ = p.Kill()
+			}
+		}
+
+		// Mark as stopped in registry
+		if stopErr := reg.MarkStopped(name); stopErr != nil {
+			return fmt.Errorf("failed to update registry: %w", stopErr)
+		}
+	}
+
+	// Small delay to ensure cleanup
+	time.Sleep(100 * time.Millisecond)
+
+	// Parse command string into command and args
+	parts := strings.Fields(savedCommand)
+	if len(parts) == 0 {
+		return fmt.Errorf("no command stored for process %q", name)
+	}
+
+	command := parts[0]
+	cmdArgs := parts[1:]
+
+	// Use saved workdir or current directory
+	workDir := savedWorkDir
+	if workDir == "" {
+		workDir, _ = os.Getwd()
+	}
+
+	// Create log file
+	logFile, logErr := reg.CreateLogFile(name)
+	if logErr != nil {
+		return fmt.Errorf("failed to create log file: %w", logErr)
+	}
+
+	// Start the process with output captured to log file
+	execCmd := exec.CommandContext(context.Background(), command, cmdArgs...) //nolint:gosec // user-provided command
+	execCmd.Dir = workDir
+	execCmd.Stdout = logFile
+	execCmd.Stderr = logFile
+
+	fmt.Printf("Starting process %q...\n", name)
+	if startErr := execCmd.Start(); startErr != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("failed to start process: %w", startErr)
+	}
+
+	// Close log file in background after process exits
+	go func() {
+		_ = execCmd.Wait()
+		_ = logFile.Close()
+	}()
+
+	// Register the process with same config
+	newProc := &process.Process{
+		Name:    name,
+		Command: savedCommand,
+		Owner:   savedOwner,
+		WorkDir: workDir,
+		LogFile: reg.LogPath(name),
+		PID:     execCmd.Process.Pid,
+		Port:    savedPort,
+	}
+
+	if regErr := reg.Register(newProc); regErr != nil {
+		// Kill the process if we can't register it
+		_ = execCmd.Process.Kill()
+		return fmt.Errorf("failed to register process: %w", regErr)
+	}
+
+	fmt.Printf("Restarted process %q (PID %d)\n", name, newProc.PID)
+	return nil
 }

--- a/internal/cmd/process_test.go
+++ b/internal/cmd/process_test.go
@@ -442,3 +442,55 @@ func TestProcessStopNotRunning(t *testing.T) {
 		t.Errorf("expected 'not running' error, got: %v", err)
 	}
 }
+
+func TestProcessRestartNotFound(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("process", "restart", "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing process, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestProcessRestartNoWorkspace(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err = os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	_, _, err = executeIntegrationCmd("process", "restart", "test")
+	if err == nil {
+		t.Fatal("expected error when not in workspace, got nil")
+	}
+	if !strings.Contains(err.Error(), "not in a bc workspace") {
+		t.Errorf("expected workspace error, got: %v", err)
+	}
+}
+
+func TestProcessRestartCommandExists(t *testing.T) {
+	// Verify the restart command is registered
+	restartCmd := processCmd.Commands()
+	found := false
+	for _, cmd := range restartCmd {
+		if cmd.Use == "restart <name>" {
+			found = true
+			if cmd.Short != "Restart a process" {
+				t.Errorf("unexpected short description: %s", cmd.Short)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("restart command not found in process subcommands")
+	}
+}


### PR DESCRIPTION
## Summary

Add `bc process restart <name>` command that:
- Stops the process gracefully (SIGTERM with 5s timeout, then SIGKILL)
- Waits for termination
- Restarts with the same configuration (command, port, workdir, owner)

## Usage

```bash
bc process restart web
bc process restart api
```

## Implementation

- Graceful shutdown: SIGTERM first, 5s timeout, then SIGKILL if needed
- Preserves config: command, port, workdir, owner all restored
- New log file created on restart

## Test plan

- [x] `bc process restart nonexistent` returns "not found" error
- [x] `bc process restart` outside workspace returns workspace error
- [x] Restart command registered in process subcommands
- [x] All tests pass
- [x] Lint clean

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)