### PR TITLE
docs: remove queue/TUI refs, add cron format (#477, #478, #482)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,13 +81,11 @@ bc/
 ├── cmd/bc/              # CLI entry point
 ├── config/              # Generated config (cfgx)
 ├── internal/
-│   ├── cmd/             # Cobra command implementations
-│   └── tui/             # Application-specific TUI views
+│   └── cmd/             # Cobra command implementations
 ├── pkg/                 # Reusable packages
 │   ├── agent/           # Agent lifecycle management
 │   ├── workspace/       # Workspace configuration
-│   ├── queue/           # Work queue
-│   ├── tui/             # Generic TUI components
+│   ├── channel/         # Communication channels
 │   └── ...
 ├── prompts/             # Default role prompts
 └── .ctx/                # Architecture documentation

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 `bc` is a CLI-first orchestration system for coordinating teams of AI agents to work on software development projects. It provides a structured, observable, and persistent environment for AI-driven engineering, emphasizing developer control and predictable behavior.
 
-Drawing inspiration from `k9s` for Kubernetes, `bc` treats the Terminal User Interface (TUI) as a powerful visualization and navigation layer on top of a robust set of command-line tools.
+Drawing inspiration from `k9s` for Kubernetes, `bc` provides a powerful CLI with channel-based communication on top of a robust set of command-line tools.
 
 ## Core Philosophy
 
 *   **Organic Growth**: Start with a single `root` agent and conversationally grow your team. The system is designed to be flexible, without enforcing a rigid, predefined structure.
-*   **CLI-First**: Every feature is accessible and scriptable through the `bc` command line. The `bc home` TUI provides a real-time dashboard for observation and interaction.
+*   **CLI-First**: Every feature is accessible and scriptable through the `bc` command line.
 *   **Agent Agnostic**: `bc` is designed to work with any AI agent that can run in a terminal. It has built-in support for Claude Code, Cursor, and OpenAI Codex, with easy configuration for custom tools.
 *   **Persistent Memory**: Agents learn from their experiences. `bc` includes a memory system that allows agents to record task outcomes and accumulate knowledge, improving their effectiveness over time.
 *   **Isolated Workspaces**: To prevent conflicts and enable parallel development, each agent operates within its own dedicated `git worktree`.
@@ -15,7 +15,7 @@ Drawing inspiration from `k9s` for Kubernetes, `bc` treats the Terminal User Int
 ## Features
 
 -   **Hierarchical Agent System**: A `root` agent manages the project and can create a team of agents with various roles (`engineer`, `qa`, `manager`, etc.). Roles are customizable via simple Markdown files.
--   **TUI Dashboard (`bc home`)**: An interactive, real-time dashboard for visualizing workspaces, agent status, communication channels, work queues, and running processes.
+-   **Dashboard (`bc dashboard`)**: View workspace statistics, agent status, and activity summaries.
 -   **Real-Time Communication (`bc channel`)**: Agents collaborate through Slack-like channels, with support for message history and agent-to-agent communication.
 -   **Persistent Memory (`bc memory`)**: Agents can record experiences and learnings, search their memory, and improve over time.
 -   **Scheduled Tasks (`bc demon`)**: Automate recurring tasks like daily builds, nightly tests, or health checks using cron-based scheduling.
@@ -56,10 +56,11 @@ make install
     ```
     *Note: `bc up` can also be used to start a default team of agents, configurable in `.bc/config.toml`.*
 
-3.  **Open the TUI Dashboard**:
-    Use the TUI to get a real-time overview of your workspace.
+3.  **Check System Status**:
+    View your workspace status and agent states.
     ```bash
-    bc home
+    bc status
+    bc dashboard
     ```
 
 4.  **Create a New Agent**:
@@ -95,7 +96,6 @@ make install
 | `init` | Initialize a new `bc` workspace in the current directory. |
 | `up` | Start the `root` agent and the configured agent roster. |
 | `down` | Stop all running agents and processes. |
-| `home` | Open the interactive TUI dashboard. |
 | `status` | Show the status of all agents. |
 | `dashboard`| Show a summary of workspace stats. |
 | **Agent Management** | |
@@ -108,7 +108,6 @@ make install
 | **Collaboration & Workflow** | |
 | `channel` | Manage communication channels for agents. |
 | `team` | Organize agents into teams. |
-| `queue` | Manage the work queue (integrates with GitHub Issues). |
 | `merge` | Merge an agent's work branch into main after validation checks. |
 | `role` | Manage custom agent roles and their prompt templates. |
 | **Automation & Tooling** | |

--- a/examples/demo-project/DEMO_WALKTHROUGH.md
+++ b/examples/demo-project/DEMO_WALKTHROUGH.md
@@ -45,7 +45,6 @@ ls -la .bc/
 ```
 .bc/
 ├── agents.json      # Agent state
-├── queue.json       # Work queue
 ├── channels.json    # Communication channels
 └── worktrees/       # Per-agent git worktrees
 ```
@@ -94,21 +93,19 @@ cat src/greeting.go
 bc send product-manager "There's a typo bug in greeting.go - it says 'Helo' instead of 'Hello'. Please create a work item to fix it."
 ```
 
-**What happens:** PM analyzes and creates a work item in the queue.
+**What happens:** PM analyzes and creates a GitHub Issue for tracking.
 
 ```bash
-# After ~30 seconds, check the queue
-bc queue
+# After ~30 seconds, check the issues
+gh issue list
 ```
 
 **Expected output:**
 ```
-ID        STATUS    ASSIGNED  TITLE
-──────────────────────────────────────────
-work-001  pending   -         Fix greeting typo: Helo → Hello
+#1  Fix greeting typo: Helo → Hello   bug   OPEN
 ```
 
-**Key point:** "The PM understood the bug and created a structured work item."
+**Key point:** "The PM understood the bug and created a structured issue."
 
 ---
 
@@ -118,17 +115,17 @@ work-001  pending   -         Fix greeting typo: Helo → Hello
 
 ```bash
 # Manager assigns the work
-bc send manager "Please assign work-001 to an available engineer."
+bc send manager "Please assign issue #1 to an available engineer."
 
-# Wait for assignment, then check queue
-bc queue
+# Wait for assignment, then check status
+bc status
 ```
 
 **Expected output:**
 ```
-ID        STATUS    ASSIGNED      TITLE
-──────────────────────────────────────────────
-work-001  working   engineer-01   Fix greeting typo: Helo → Hello
+AGENT           ROLE       STATE    TASK
+─────────────────────────────────────────────
+engineer-01     engineer   working  Fix greeting typo
 ```
 
 **Key point:** "Work is now assigned. The engineer will work in their own isolated worktree."
@@ -156,12 +153,13 @@ bc attach engineer-01
 ```bash
 # Check status after fix
 bc status
-bc queue
+gh issue list
 ```
 
 **Expected output:**
 ```
-work-001  done   engineer-01   Fix greeting typo: Helo → Hello
+AGENT         ROLE      STATE  TASK
+engineer-01   engineer  idle   -
 ```
 
 **Key point:** "The engineer worked in isolation. Main branch is untouched until merge."
@@ -230,9 +228,6 @@ def5678 Previous commit...
 # Show all agents idle, work complete
 bc status
 
-# Show queue history
-bc queue
-
 # Show the fixed code
 cat src/greeting.go
 ```
@@ -263,8 +258,8 @@ Throughout the demo, emphasize these differentiators:
 
 ### 3. Real-Time Visibility
 - `bc status` shows all agent states
-- `bc attach` lets you watch any agent
-- `bc queue` tracks all work items
+- `bc agent attach` lets you watch any agent
+- `gh issue list` tracks work items
 
 ### 4. Structured Communication
 - Channels for broadcast messages
@@ -296,11 +291,11 @@ bc send <agent> "Please continue with your current task."
 
 ### Work item not appearing
 ```bash
-# Force queue refresh
-bc queue
+# Check GitHub issues
+gh issue list
 
-# Check if beads sync is needed
-bc queue load
+# Verify GitHub CLI is authenticated
+gh auth status
 ```
 
 ### Can't attach to agent

--- a/examples/demo-project/README.md
+++ b/examples/demo-project/README.md
@@ -20,11 +20,11 @@ bc init
 # Start the orchestration
 bc up
 
-# Assign the fix task
-bc add "Fix the greeting bug - greet() should return 'Welcome' instead of 'Hello'. Run tests to verify."
+# Create a GitHub issue for the fix task
+gh issue create -t "Fix greeting bug" -b "greet() should return 'Welcome' instead of 'Hello'. Run tests to verify."
 
-# Watch the agents work
-bc home
+# Check agent status
+bc status
 ```
 
 ## Expected Outcome

--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -18,6 +18,12 @@ var demonCmd = &cobra.Command{
 
 Demons are scheduled tasks that run at specified intervals using cron syntax.
 
+Cron format: minute hour day-of-month month day-of-week
+  0 * * * *     = every hour
+  */5 * * * *   = every 5 minutes
+  0 9 * * *     = daily at 9am
+  0 17 * * 1-5  = weekdays at 5pm
+
 Examples:
   bc demon create backup --schedule '0 * * * *' --cmd 'bc backup'
   bc demon list

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -33,7 +33,7 @@ for coordinating Claude Code agents with predictable behavior and cost awareness
 Key features:
   • Coordinate multiple Claude Code agents
   • Persistent work tracking with git
-  • Simple TUI for visualization
+  • Channel-based agent communication
   • Cost-aware operation
   • Predictable behavior
 

--- a/prompts/engineer.md
+++ b/prompts/engineer.md
@@ -16,7 +16,6 @@ You are an **Engineer** in the bc multi-agent orchestration system. Your role is
 When you start, check what's assigned to you:
 
 ```bash
-bc queue                    # See all work items
 bc status                   # See your status
 echo $BC_AGENT_ID          # Your agent name
 ```

--- a/prompts/manager.md
+++ b/prompts/manager.md
@@ -14,17 +14,17 @@ You are a **Manager** in the bc multi-agent orchestration system. Your role is t
 
 ### Breaking Down Epics
 
-When you receive an epic, create tasks for it:
+When you receive an epic, create tasks as GitHub Issues:
 
 ```bash
-# View the epic
-bc queue
+# View open issues
+gh issue list
 
-# Create tasks (they auto-link if epic ID is mentioned)
-bc queue add "Implement user login API endpoint" -d "Part of auth epic. POST /api/auth/login with email/password."
-bc queue add "Add password hashing with bcrypt" -d "Part of auth epic. Use cost factor 12."
-bc queue add "Create login form component" -d "Part of auth epic. React form with validation."
-bc queue add "Write auth integration tests" -d "Part of auth epic. Test login flow end-to-end."
+# Create tasks as GitHub Issues
+gh issue create -t "Implement user login API endpoint" -b "Part of auth epic. POST /api/auth/login with email/password."
+gh issue create -t "Add password hashing with bcrypt" -b "Part of auth epic. Use cost factor 12."
+gh issue create -t "Create login form component" -b "Part of auth epic. React form with validation."
+gh issue create -t "Write auth integration tests" -b "Part of auth epic. Test login flow end-to-end."
 ```
 
 ### Spawning Engineers
@@ -39,12 +39,7 @@ bc spawn engineer charlie
 
 ### Assigning Work
 
-Assign tasks to engineers:
-
-```bash
-bc queue assign work-001 alice
-bc queue assign work-002 bob
-```
+Assign issues to engineers by sending them tasks via channels or direct messages:
 
 Then send them detailed instructions:
 
@@ -67,9 +62,9 @@ When done: bc report done 'login API implemented'"
 
 ```bash
 bc status              # See all agents and their states
-bc queue               # See work item status
+gh issue list          # See work item status
 bc logs --agent alice  # See Alice's activity
-bc attach alice        # Attach to Alice's session (Ctrl+b d to detach)
+bc agent attach alice  # Attach to Alice's session (Ctrl+b d to detach)
 ```
 
 ### Reviewing Work
@@ -84,8 +79,8 @@ git diff main..feature/auth-login-api
 # Run tests
 go test ./pkg/auth/...
 
-# If good, mark task complete
-bc queue complete work-001
+# If good, close the issue
+gh issue close <issue-number>
 
 # If needs changes, send feedback
 bc send alice "Good progress! Please also add rate limiting to the login endpoint."
@@ -168,7 +163,7 @@ When done: bc report done 'password reset implemented'"
 
 1. Read and understand the epic fully
 2. Identify the discrete pieces of work
-3. Create tasks in the queue
+3. Create tasks as GitHub Issues
 4. Propose the breakdown to product manager (if needed)
 5. Once approved, spawn engineers and assign work
 

--- a/prompts/product_manager.md
+++ b/prompts/product_manager.md
@@ -13,18 +13,18 @@ You are a **Product Manager** in the bc multi-agent orchestration system. Your r
 
 ### Creating Epics
 
-Create epics using the queue command with an `[EPIC]` prefix:
+Create epics as GitHub Issues with an `[EPIC]` prefix:
 
 ```bash
-bc queue add "[EPIC] User authentication system"
-bc queue add "[EPIC] Dashboard performance improvements" -d "Users report slow load times on the main dashboard. Need to optimize queries and add caching."
+gh issue create -t "[EPIC] User authentication system" -b "User authentication system epic"
+gh issue create -t "[EPIC] Dashboard performance improvements" -b "Users report slow load times on the main dashboard. Need to optimize queries and add caching."
 ```
 
 ### Viewing Work
 
 ```bash
-bc queue              # View all work items
-bc queue --json       # View as JSON for detailed analysis
+gh issue list         # View all work items
+gh issue list --json  # View as JSON for detailed analysis
 bc status             # Check agent status
 bc logs               # View recent activity
 ```
@@ -72,13 +72,13 @@ Any constraints, dependencies, or context for the team.
 
 ```bash
 # Good epic - outcome focused
-bc queue add "[EPIC] Reduce dashboard load time to under 2 seconds" -d "Users are abandoning the dashboard due to 8+ second load times. Target: p95 < 2s."
+gh issue create -t "[EPIC] Reduce dashboard load time to under 2 seconds" -b "Users are abandoning the dashboard due to 8+ second load times. Target: p95 < 2s."
 
 # Good epic - user value clear
-bc queue add "[EPIC] Enable team collaboration on projects" -d "Users need to share projects with teammates. Must support view/edit permissions."
+gh issue create -t "[EPIC] Enable team collaboration on projects" -b "Users need to share projects with teammates. Must support view/edit permissions."
 
 # Bad epic - too implementation focused
-# bc queue add "[EPIC] Add Redis caching"  # Don't do this - focus on outcome instead
+# gh issue create -t "[EPIC] Add Redis caching"  # Don't do this - focus on outcome instead
 ```
 
 ## Workflow
@@ -86,7 +86,7 @@ bc queue add "[EPIC] Enable team collaboration on projects" -d "Users need to sh
 ### Daily Routine
 
 1. Review overnight activity: `bc logs --tail 50`
-2. Check work queue status: `bc queue`
+2. Check work status: `gh issue list`
 3. Review any pending manager proposals
 4. Prioritize and create new epics as needed
 5. Communicate decisions to managers
@@ -142,4 +142,4 @@ Your session has these variables set:
 - Epics should be user-value focused, not implementation focused
 - Trust your managers to break down work appropriately
 - Be responsive to questions and blockers
-- Keep the work queue prioritized and healthy
+- Keep work items prioritized and healthy

--- a/prompts/qa.md
+++ b/prompts/qa.md
@@ -14,8 +14,8 @@ You are a **QA Engineer** in the bc multi-agent orchestration system. Your role 
 ### Checking Your Assignment
 
 ```bash
-bc queue                    # See all work items
 bc status                   # See agent states
+gh issue list               # See work items
 echo $BC_AGENT_ID          # Your agent name
 ```
 
@@ -40,7 +40,6 @@ go build -o bc ./cmd/bc
 
 # Test basic commands
 ./bc status
-./bc queue
 ./bc logs
 ./bc home
 ```
@@ -54,18 +53,13 @@ Test all bc commands work correctly:
 ```bash
 # Status and monitoring
 ./bc status
-./bc queue
 ./bc logs
 ./bc logs --tail 20
 
 # Agent management
 ./bc up --help
 ./bc down --help
-./bc attach --help
-
-# Work queue
-./bc queue add "Test item"
-./bc queue --json
+./bc agent attach --help
 
 # Channels
 ./bc channel
@@ -94,13 +88,11 @@ Test edge cases and error conditions:
 ```bash
 # Invalid inputs
 ./bc send nonexistent "test"
-./bc attach nonexistent
-./bc queue assign work-999 agent-999
+./bc agent attach nonexistent
 
 # Empty states
-# (in workspace with no agents, no queue items, etc.)
+# (in workspace with no agents, etc.)
 ./bc status
-./bc queue
 ```
 
 ### 3. Searching for Existing Issues
@@ -113,7 +105,7 @@ bd search "keyword"
 bd list
 
 # Check if there's already a fix in progress
-./bc queue | grep -i "keyword"
+gh issue list | grep -i "keyword"
 ```
 
 ### 4. Creating Bug Issues
@@ -157,7 +149,7 @@ bc report working "Starting test cycle"
 go build -o bc ./cmd/bc
 
 # Smoke test
-./bc status && ./bc queue && echo "Smoke tests pass"
+./bc status && echo "Smoke tests pass"
 
 # Deep test (pick an area each cycle)
 bc report working "Testing TUI navigation"
@@ -176,13 +168,7 @@ bc report done "Test cycle complete - 1 bug found"
 - [ ] `bc up` starts all agents
 - [ ] `bc down` stops all agents
 - [ ] `bc status` shows correct states
-- [ ] `bc attach <agent>` works
-
-### Work Queue
-- [ ] `bc queue` lists items
-- [ ] `bc queue add` creates items
-- [ ] `bc queue assign` assigns to agents
-- [ ] Queue persists across restarts
+- [ ] `bc agent attach <agent>` works
 
 ### Communication
 - [ ] `bc send <agent> <msg>` delivers message

--- a/prompts/ux.md
+++ b/prompts/ux.md
@@ -15,8 +15,8 @@ You are a **UX Testing Agent** in the bc multi-agent orchestration system. Your 
 ### Checking Your Assignment
 
 ```bash
-bc queue                    # See all work items
 bc status                   # See agent states
+gh issue list               # See work items
 echo $BC_AGENT_ID          # Your agent name
 ```
 
@@ -38,7 +38,7 @@ bc report done "Test cycle complete — 3 issues filed"
 go build -o bc ./cmd/bc
 
 # Sanity check — these must all succeed
-./bc status && ./bc queue && echo "Build OK"
+./bc status && echo "Build OK"
 ```
 
 ### 2. Test Cycle Structure
@@ -52,14 +52,12 @@ Test every bc command for correct behavior, helpful errors, and edge cases:
 ```bash
 # Core commands — do they work and give useful output?
 ./bc status
-./bc queue
 ./bc logs
 ./bc logs --tail 10
 
 # Agent management
 ./bc up --help
 ./bc down --help
-./bc spawn --help
 
 # Communication
 ./bc send <agent> "test message"
@@ -68,8 +66,7 @@ Test every bc command for correct behavior, helpful errors, and edge cases:
 # Edge cases — bad input, missing args, empty state
 ./bc send "" "test"
 ./bc send nonexistent "test"
-./bc queue add ""
-./bc attach nonexistent
+./bc agent attach nonexistent
 ```
 
 #### Cycle B: TUI Navigation and Display
@@ -89,10 +86,9 @@ Test systematically:
 
 #### Cycle C: Data Display and Consistency
 
-Check that TUI displays match CLI output:
-- Agent count in tab label matches `bc status` output
-- Queue counts match `bc queue` output
-- Issue counts match `bd list` output
+Check that CLI outputs are consistent:
+- Agent count matches `bc status` output
+- Issue counts match `gh issue list` output
 - Status colors are correct (green=working, cyan=idle, red=error/stuck, orange=warning)
 - No truncation hiding critical information
 
@@ -102,19 +98,15 @@ Test complete workflows that a real user would perform:
 
 ```bash
 # Flow 1: Create and track work
-./bc queue add "Test task" -d "Description"
-./bc queue                        # Verify it appears
-# Check TUI Queue tab shows new item
-./bc home
+gh issue create -t "Test task" -b "Description"
+gh issue list                     # Verify it appears
 
 # Flow 2: Agent communication
 ./bc send engineer-01 "status update please"
-# Check Channels tab shows message
 ./bc channel history standup
 
 # Flow 3: Monitor progress
 ./bc status                       # CLI view
-./bc home                         # TUI view — do they agree?
 ./bc logs --tail 20               # Recent activity
 ```
 
@@ -126,8 +118,8 @@ Not every issue is a bug. Categorize findings:
 |----------|-------------|---------|
 | **Bug** | Something is broken | Crash on Enter, wrong data displayed |
 | **UX Issue** | Works but confusing/unhelpful | No feedback after action, unclear labels |
-| **Inconsistency** | Behavior varies unexpectedly | CLI shows 8 agents, TUI shows 7 |
-| **Missing Feature** | Expected capability absent | Can't filter queue by status |
+| **Inconsistency** | Behavior varies unexpectedly | Commands show different counts |
+| **Missing Feature** | Expected capability absent | Can't filter issues by status |
 | **Visual** | Rendering or layout problem | Text overlaps, colors wrong, alignment off |
 
 ### 4. Filing Issues
@@ -143,16 +135,15 @@ bd create --type bug --title "UX: <category> — <brief description>" --body "$(
 <P0: Broken/crash | P1: Wrong behavior | P2: Confusing | P3: Polish>
 
 ## Steps to Reproduce
-1. Run `bc home`
-2. Navigate to Queue tab
-3. Press Enter on a queue item
-4. Observe: nothing happens
+1. Run `bc status`
+2. Run `bc agent show <agent>`
+3. Observe the output
 
 ## Expected Behavior
-Detail view opens showing queue item details.
+Agent details are displayed correctly.
 
 ## Actual Behavior
-No response to Enter keypress. Cursor stays on the same item.
+Describe what actually happens.
 
 ## Screenshot / Output
 <paste terminal output or describe what you see>


### PR DESCRIPTION
## Summary
- Remove queue command references from prompts/*.md (5 files)
- Remove TUI references from README.md, CONTRIBUTING.md, root.go
- Update demo examples (DEMO_WALKTHROUGH.md, README.md)
- Add cron format explanation to demon --help (#482)

## Files Changed (11 files, -31 lines net)
- `prompts/*.md` - queue → gh CLI
- `README.md` - removed TUI dashboard
- `CONTRIBUTING.md` - updated project structure
- `internal/cmd/root.go` - TUI → channel communication
- `internal/cmd/demon.go` - added cron format explanation
- `examples/demo-project/*.md` - updated demo walkthrough

## Related Issues
- Fixes #477 (Documentation Audit)
- Fixes #478 (Remove TUI from help text)
- Fixes #482 (Add cron format to demon help)
- Part of #469 codebase cleanup

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)