### PR TITLE
chore: remove unused costs and roles config sections

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -128,12 +128,6 @@ session_prefix = "bc-"
 refresh_interval = "2s"
 theme = "ayu-dark"  # Options: ayu-dark, nord, gruvbox
 
-# Cost tracking
-[costs]
-enabled = true
-warn_threshold = 10.0   # Warn when session cost exceeds this (USD)
-limit = 100.0           # Hard limit per session (USD), 0 = no limit
-
 # =============================================================================
 # Agent Type Definitions (for reference)
 # =============================================================================
@@ -172,38 +166,3 @@ name = "server"
 command = "claude mcp serve"
 description = "Claude MCP Server"
 
-# =============================================================================
-# Role Definitions
-# =============================================================================
-# Prompts are stored in .bc/prompts/ and copied from root prompts/ on init.
-# This allows per-workspace customization of role prompts.
-
-[[roles]]
-name = "product_manager"
-prompt_file = ".bc/prompts/product_manager.md"
-description = "Defines product vision, creates epics, reviews proposals"
-permissions = ["queue.add", "queue.view", "send", "report"]
-
-[[roles]]
-name = "manager"
-prompt_file = ".bc/prompts/manager.md"
-description = "Breaks down epics, spawns engineers, assigns work, reviews code"
-permissions = ["queue.add", "queue.assign", "queue.complete", "spawn", "send", "report", "git.merge"]
-
-[[roles]]
-name = "engineer"
-prompt_file = ".bc/prompts/engineer.md"
-description = "Implements assigned tasks, writes code and tests"
-permissions = ["queue.view", "report", "git.branch", "git.commit"]
-
-[[roles]]
-name = "tech_lead"
-prompt_file = ".bc/prompts/tech_lead.md"
-description = "Reviews code, coordinates engineers, ensures quality"
-permissions = ["queue.view", "queue.assign", "report", "git.branch", "git.commit", "spawn"]
-
-[[roles]]
-name = "qa"
-prompt_file = ".bc/prompts/qa.md"
-description = "Tests features, verifies quality, reports bugs"
-permissions = ["queue.view", "queue.add", "report", "git.branch"]

--- a/config/config.go
+++ b/config/config.go
@@ -25,22 +25,9 @@ type ChannelsConfig struct {
 	Default []string
 }
 
-type CostsConfig struct {
-	Enabled       bool
-	Limit         float64
-	WarnThreshold float64
-}
-
 type MemoryConfig struct {
 	Backend string
 	Path    string
-}
-
-type RolesItem struct {
-	Description string
-	Name        string
-	Permissions []string
-	PromptFile  string
 }
 
 type RosterConfig struct {
@@ -153,46 +140,9 @@ var (
 	Channels = ChannelsConfig{
 		Default: []string{"general", "engineering"},
 	}
-	Costs = CostsConfig{
-		Enabled:       true,
-		Limit:         100,
-		WarnThreshold: 10,
-	}
 	Memory = MemoryConfig{
 		Backend: "file",
 		Path:    ".bc/memory",
-	}
-	Roles = []RolesItem{
-		{
-			Description: "Defines product vision, creates epics, reviews proposals",
-			Name:        "product_manager",
-			Permissions: []string{"queue.add", "queue.view", "send", "report"},
-			PromptFile:  ".bc/prompts/product_manager.md",
-		},
-		{
-			Description: "Breaks down epics, spawns engineers, assigns work, reviews code",
-			Name:        "manager",
-			Permissions: []string{"queue.add", "queue.assign", "queue.complete", "spawn", "send", "report", "git.merge"},
-			PromptFile:  ".bc/prompts/manager.md",
-		},
-		{
-			Description: "Implements assigned tasks, writes code and tests",
-			Name:        "engineer",
-			Permissions: []string{"queue.view", "report", "git.branch", "git.commit"},
-			PromptFile:  ".bc/prompts/engineer.md",
-		},
-		{
-			Description: "Reviews code, coordinates engineers, ensures quality",
-			Name:        "tech_lead",
-			Permissions: []string{"queue.view", "queue.assign", "report", "git.branch", "git.commit", "spawn"},
-			PromptFile:  ".bc/prompts/tech_lead.md",
-		},
-		{
-			Description: "Tests features, verifies quality, reports bugs",
-			Name:        "qa",
-			Permissions: []string{"queue.view", "queue.add", "report", "git.branch"},
-			PromptFile:  ".bc/prompts/qa.md",
-		},
 	}
 	Roster = RosterConfig{
 		Engineers:     4,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -53,20 +53,6 @@ func TestTuiDefaults(t *testing.T) {
 	}
 }
 
-// --- CostsConfig ---
-
-func TestCostsDefaults(t *testing.T) {
-	if !Costs.Enabled {
-		t.Error("Costs.Enabled should be true by default")
-	}
-	if Costs.Limit != 100 {
-		t.Errorf("Costs.Limit = %f, want %f", Costs.Limit, 100.0)
-	}
-	if Costs.WarnThreshold != 10 {
-		t.Errorf("Costs.WarnThreshold = %f, want %f", Costs.WarnThreshold, 10.0)
-	}
-}
-
 // --- Agents list ---
 
 func TestAgentsNotEmpty(t *testing.T) {
@@ -112,87 +98,6 @@ func TestAgentsNamesUnique(t *testing.T) {
 	}
 }
 
-// --- Roles list ---
-
-func TestRolesNotEmpty(t *testing.T) {
-	if len(Roles) == 0 {
-		t.Fatal("Roles list should not be empty")
-	}
-}
-
-func TestRolesHaveRequiredFields(t *testing.T) {
-	for i, r := range Roles {
-		if r.Name == "" {
-			t.Errorf("Roles[%d].Name is empty", i)
-		}
-		if r.Description == "" {
-			t.Errorf("Roles[%d].Description is empty (name=%q)", i, r.Name)
-		}
-		if len(r.Permissions) == 0 {
-			t.Errorf("Roles[%d].Permissions is empty (name=%q)", i, r.Name)
-		}
-	}
-}
-
-func TestRolesContainsExpectedRoles(t *testing.T) {
-	expected := map[string]bool{
-		"product_manager": false,
-		"manager":         false,
-		"engineer":        false,
-	}
-	for _, r := range Roles {
-		if _, ok := expected[r.Name]; ok {
-			expected[r.Name] = true
-		}
-	}
-	for name, found := range expected {
-		if !found {
-			t.Errorf("expected role %q not found in Roles", name)
-		}
-	}
-}
-
-func TestRolesNamesUnique(t *testing.T) {
-	seen := make(map[string]bool)
-	for _, r := range Roles {
-		if seen[r.Name] {
-			t.Errorf("duplicate role name: %q", r.Name)
-		}
-		seen[r.Name] = true
-	}
-}
-
-func TestManagerRoleHasSpawnPermission(t *testing.T) {
-	for _, r := range Roles {
-		if r.Name == "manager" {
-			for _, p := range r.Permissions {
-				if p == "spawn" {
-					return
-				}
-			}
-			t.Error("manager role should have 'spawn' permission")
-		}
-	}
-}
-
-func TestEngineerRoleHasGitPermissions(t *testing.T) {
-	for _, r := range Roles {
-		if r.Name == "engineer" {
-			perms := make(map[string]bool)
-			for _, p := range r.Permissions {
-				perms[p] = true
-			}
-			if !perms["git.branch"] {
-				t.Error("engineer role should have 'git.branch' permission")
-			}
-			if !perms["git.commit"] {
-				t.Error("engineer role should have 'git.commit' permission")
-			}
-			return
-		}
-	}
-}
-
 // --- Struct zero-value / mutability tests ---
 
 func TestAgentLegacyConfigZeroValue(t *testing.T) {
@@ -202,16 +107,6 @@ func TestAgentLegacyConfigZeroValue(t *testing.T) {
 	}
 	if ac.CoordinatorName != "" {
 		t.Error("zero-value AgentLegacyConfig.CoordinatorName should be empty")
-	}
-}
-
-func TestCostsConfigZeroValue(t *testing.T) {
-	var cc CostsConfig
-	if cc.Enabled {
-		t.Error("zero-value CostsConfig.Enabled should be false")
-	}
-	if cc.Limit != 0 {
-		t.Error("zero-value CostsConfig.Limit should be 0")
 	}
 }
 


### PR DESCRIPTION
Remove [costs] and [[roles]] sections from config.toml - not used anywhere. 196 lines of dead code removed. Part of #469 cleanup.