### PR TITLE
chore: remove beads config from workspace configuration

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -566,11 +566,6 @@ func printConfig(cfg *workspace.V2Config) {
 	fmt.Printf("  path: %s\n", cfg.Memory.Path)
 	fmt.Println()
 
-	fmt.Println("[beads]")
-	fmt.Printf("  enabled: %v\n", cfg.Beads.Enabled)
-	fmt.Printf("  issues_dir: %s\n", cfg.Beads.IssuesDir)
-	fmt.Println()
-
 	fmt.Println("[channels]")
 	fmt.Printf("  default: %v\n", cfg.Channels.Default)
 	fmt.Println()

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -23,7 +23,6 @@ func TestConfigShow(t *testing.T) {
 		"[worktrees]",
 		"[tools]",
 		"[memory]",
-		"[beads]",
 		"[channels]",
 		"[roster]",
 	}

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -19,7 +19,6 @@ type V2Config struct {
 	Worktrees WorktreesConfig `toml:"worktrees"`
 	Tools     ToolsConfig     `toml:"tools"`
 	Memory    MemoryConfig    `toml:"memory"`
-	Beads     BeadsConfig     `toml:"beads"`
 	Channels  ChannelsConfig  `toml:"channels"`
 	Roster    RosterConfig    `toml:"roster"`
 }
@@ -56,12 +55,6 @@ type ToolConfig struct {
 type MemoryConfig struct {
 	Backend string `toml:"backend"` // "file", "sqlite", etc.
 	Path    string `toml:"path"`
-}
-
-// BeadsConfig configures beads issue tracker integration.
-type BeadsConfig struct {
-	IssuesDir string `toml:"issues_dir"`
-	Enabled   bool   `toml:"enabled"`
 }
 
 // ChannelsConfig configures communication channels.
@@ -124,10 +117,6 @@ func DefaultV2Config(name string) V2Config {
 		Memory: MemoryConfig{
 			Backend: "file",
 			Path:    ".bc/memory",
-		},
-		Beads: BeadsConfig{
-			Enabled:   true,
-			IssuesDir: ".beads/issues",
 		},
 		Channels: ChannelsConfig{
 			Default: []string{"general", "engineering"},

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -58,10 +58,6 @@ enabled = true
 backend = "file"
 path = ".bc/memory"
 
-[beads]
-enabled = true
-issues_dir = ".beads/issues"
-
 [channels]
 default = ["general", "engineering"]
 `)
@@ -100,12 +96,6 @@ default = ["general", "engineering"]
 	}
 	if cfg.Memory.Path != ".bc/memory" {
 		t.Errorf("expected memory path '.bc/memory', got %q", cfg.Memory.Path)
-	}
-	if !cfg.Beads.Enabled {
-		t.Error("expected beads to be enabled")
-	}
-	if cfg.Beads.IssuesDir != ".beads/issues" {
-		t.Errorf("expected beads issues_dir '.beads/issues', got %q", cfg.Beads.IssuesDir)
 	}
 	if len(cfg.Channels.Default) != 2 {
 		t.Errorf("expected 2 default channels, got %d", len(cfg.Channels.Default))
@@ -334,7 +324,6 @@ func TestV2ConfigSaveAndLoad(t *testing.T) {
 
 	// Create and save config
 	cfg := DefaultV2Config("save-test")
-	cfg.Beads.Enabled = false
 	cfg.Channels.Default = []string{"custom-channel"}
 
 	if err := cfg.Save(configPath); err != nil {
@@ -354,9 +343,6 @@ func TestV2ConfigSaveAndLoad(t *testing.T) {
 
 	if loaded.Workspace.Name != "save-test" {
 		t.Errorf("expected name 'save-test', got %q", loaded.Workspace.Name)
-	}
-	if loaded.Beads.Enabled {
-		t.Error("expected beads to be disabled")
 	}
 	if len(loaded.Channels.Default) != 1 || loaded.Channels.Default[0] != "custom-channel" {
 		t.Errorf("unexpected channels: %v", loaded.Channels.Default)

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -409,14 +409,6 @@ func (w *Workspace) DefaultToolCommand() string {
 	return "claude --dangerously-skip-permissions"
 }
 
-// BeadsEnabled returns whether beads integration is enabled.
-func (w *Workspace) BeadsEnabled() bool {
-	if w.V2Config != nil {
-		return w.V2Config.Beads.Enabled
-	}
-	return true // Default to enabled for v1
-}
-
 // DefaultChannels returns the default channel names.
 func (w *Workspace) DefaultChannels() []string {
 	if w.V2Config != nil {

--- a/pkg/workspace/workspace_test.go
+++ b/pkg/workspace/workspace_test.go
@@ -981,19 +981,6 @@ func TestWorkspaceV1GetRoleError(t *testing.T) {
 	}
 }
 
-func TestWorkspaceBeadsEnabled(t *testing.T) {
-	dir := t.TempDir()
-
-	ws, err := InitV2(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if !ws.BeadsEnabled() {
-		t.Error("BeadsEnabled should default to true")
-	}
-}
-
 func TestWorkspaceDefaultChannels(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Remove BeadsConfig struct and field from V2Config
- Remove BeadsEnabled() method from Workspace  
- Remove [beads] section display from config show command
- Update tests to reflect removed beads configuration

**Note:** pkg/beads directory is retained as it's still used by TUI code. It will be removed after PR #496 (TUI removal) merges.

## Test plan
- [x] Build passes: `go build ./...`
- [x] Tests pass: `go test ./...`
- [x] Pre-commit hooks pass (build, vet, golangci-lint)

Addresses part of #469 (codebase cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)