### PR TITLE
docs: remove outdated references to bead, TUI, and dashboard

### DIFF
--- a/docs/audit-config-build.md
+++ b/docs/audit-config-build.md
@@ -29,7 +29,6 @@ make gen
 - `Costs` - Cost tracking settings (enabled, limits, thresholds)
 - `Roles` - Role definitions with prompts and permissions
 - `Tmux` - Session prefix settings
-- `Tui` - Refresh interval and theme
 - `Workspace` - State directory and max workers
 
 ### Issues

--- a/docs/audits/pkg-agent-audit.md
+++ b/docs/audits/pkg-agent-audit.md
@@ -2,7 +2,6 @@
 
 **Date:** 2026-02-05
 **Auditor:** worker-01
-**Bead:** bc-34b.1
 **Files Reviewed:** `pkg/agent/agent.go`, `pkg/tmux/session.go`
 
 ---
@@ -221,7 +220,7 @@ if live := m.captureLiveTask(name); live != "" {
 // If live == "", old a.Task persists
 ```
 
-**Impact:** Dashboard shows stale task information, misleading operators.
+**Impact:** Status output shows stale task information, misleading operators.
 
 **Recommendation:** Clear task when nothing is captured:
 ```go

--- a/docs/audits/pkg-events-audit.md
+++ b/docs/audits/pkg-events-audit.md
@@ -3,7 +3,6 @@
 **Package:** `pkg/events/events.go`
 **Auditor:** worker-03
 **Date:** 2026-02-05
-**Work Item:** work-008, bead bc-34b.3
 
 ## Summary
 
@@ -122,8 +121,7 @@ func (l *Log) Read() ([]Event, error) {
 ```
 
 **Usage Pattern (from codebase):**
-- `internal/cmd/logs.go:43` - reads all events
-- `internal/cmd/dashboard.go:51` - reads events for display
+- `internal/cmd/logs.go` - reads all events for display
 
 **Risk:**
 After extended use, the log file could grow to GB size, causing:


### PR DESCRIPTION
## Summary
Clean up outdated references found during docs review (Phase 2 of comprehensive review directive).

## Changes
- **docs/audit-config-build.md**: Remove Tui config section reference
- **docs/audits/pkg-agent-audit.md**: Remove bead reference, update "Dashboard" to "Status output"
- **docs/audits/pkg-events-audit.md**: Remove bead/work-item reference, update dashboard.go to logs.go

## Review Findings
All other docs are current:
- `channel-conventions.md` - Current PR workflow docs
- `hierarchical-agents.md` - Current agent hierarchy docs
- `memory-system.md` - Current memory system docs
- `roles-responsibilities.md` - Current role boundary docs

## Test plan
- [x] Verified no other outdated references in docs
- [x] golangci-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)