### PR TITLE
docs: enhance worktree command help text (#506)

### DIFF
--- a/internal/cmd/worktree.go
+++ b/internal/cmd/worktree.go
@@ -17,6 +17,20 @@ import (
 var worktreeCmd = &cobra.Command{
 	Use:   "worktree",
 	Short: "Worktree management commands",
+	Long: `Manage git worktrees for bc agents.
+
+Each agent operates in its own git worktree, providing isolated working
+directories while sharing the same repository. This enables parallel
+development without branch conflicts.
+
+Worktree locations: .bc/worktrees/<agent-name>/
+
+Examples:
+  bc worktree list              # List all worktrees and their status
+  bc worktree list --orphaned   # Show only orphaned worktrees
+  bc worktree prune             # Dry-run: show what would be cleaned
+  bc worktree prune --force     # Remove orphaned worktrees
+  bc worktree check             # Verify current agent's worktree`,
 }
 
 var worktreeCheckCmd = &cobra.Command{


### PR DESCRIPTION
## Summary
Enhance the `bc worktree` parent command help text to be more informative.

**Before:**
```
Worktree management commands
```

**After:**
```
Manage git worktrees for bc agents.

Each agent operates in its own git worktree, providing isolated working
directories while sharing the same repository. This enables parallel
development without branch conflicts.

Worktree locations: .bc/worktrees/<agent-name>/

Examples:
  bc worktree list              # List all worktrees and their status
  bc worktree list --orphaned   # Show only orphaned worktrees
  bc worktree prune             # Dry-run: show what would be cleaned
  bc worktree prune --force     # Remove orphaned worktrees
  bc worktree check             # Verify current agent's worktree
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes
- [x] `bc worktree --help` shows enhanced help

Fixes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)