### PR TITLE
docs: make root help text agent-agnostic (#504)

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -27,15 +27,17 @@ func SetVersionInfo(v, c, d string) {
 var rootCmd = &cobra.Command{
 	Use:   "bc",
 	Short: "A simpler, more controllable agent orchestrator",
-	Long: `bc is a multi-agent orchestration system
-for coordinating Claude Code agents with predictable behavior and cost awareness.
+	Long: `bc is a multi-agent orchestration system for AI coding assistants.
+
+Coordinate multiple AI agents with predictable behavior and cost awareness.
+Supports Claude Code, Cursor, Codex, and other AI coding tools.
 
 Key features:
-  • Coordinate multiple Claude Code agents
-  • Persistent work tracking with git
+  • Coordinate multiple AI coding agents in parallel
+  • Isolated git worktrees per agent
   • Channel-based agent communication
-  • Cost-aware operation
-  • Predictable behavior
+  • Cost tracking and limits
+  • Hierarchical agent roles (product-manager, manager, engineer)
 
 Documentation: https://github.com/rpuneet/bc`,
 	// PersistentPreRun initializes logging based on flags


### PR DESCRIPTION
## Summary
Make the root command help text agent-agnostic by removing Claude Code-specific language.

## Changes
- Change "coordinating Claude Code agents" to "AI coding assistants"
- List supported agents: Claude Code, Cursor, Codex
- Update feature list to reflect current capabilities (worktrees, hierarchical roles)

## Before
```
bc is a multi-agent orchestration system
for coordinating Claude Code agents with predictable behavior and cost awareness.
```

## After
```
bc is a multi-agent orchestration system for AI coding assistants.

Coordinate multiple AI agents with predictable behavior and cost awareness.
Supports Claude Code, Cursor, Codex, and other AI coding tools.
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes
- [x] `bc --help` shows updated text

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)