### PR TITLE
docs: Add missing CLI subcommands to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,21 @@ bc down
 | `bc agent list` | List all agents |
 | `bc agent show <name>` | Show agent details |
 | `bc agent send <name> <msg>` | Send message to agent |
+| `bc agent broadcast <msg>` | Send message to all agents |
+| `bc agent send-to-role <role> <msg>` | Send to all agents of a role |
+| `bc agent send-pattern <pat> <msg>` | Send to agents matching pattern |
 | `bc agent attach <name>` | Attach to agent session |
 | `bc agent peek <name>` | Show recent output |
+| `bc agent health` | Show agent health status |
 | `bc agent stop <name>` | Stop an agent |
 | `bc agent delete <name>` | Delete an agent |
 | `bc agent rename <old> <new>` | Rename an agent |
+
+### Agent Reporting
+
+| Command | Description |
+|---------|-------------|
+| `bc report <state> [msg]` | Report agent state (idle, working, done, stuck, error) |
 
 ### Communication
 
@@ -79,8 +89,15 @@ bc down
 |---------|-------------|
 | `bc channel create <name>` | Create a channel |
 | `bc channel list` | List channels |
-| `bc channel send <ch> <msg>` | Send to channel |
 | `bc channel show <name>` | Show channel details |
+| `bc channel send <ch> <msg>` | Send to channel |
+| `bc channel add <ch> <agent>` | Add member to channel |
+| `bc channel remove <ch> <agent>` | Remove member from channel |
+| `bc channel join <ch>` | Join channel (current agent) |
+| `bc channel leave <ch>` | Leave channel (current agent) |
+| `bc channel history <ch>` | Show channel message history |
+| `bc channel react <ch> <msg-id>` | React to a channel message |
+| `bc channel delete <name>` | Delete a channel |
 
 ### Teams
 
@@ -92,6 +109,7 @@ bc down
 | `bc team add <team> <agent>` | Add agent to team |
 | `bc team remove <team> <agent>` | Remove agent from team |
 | `bc team rename <old> <new>` | Rename a team |
+| `bc team delete <name>` | Delete a team |
 
 ### Roles
 
@@ -102,6 +120,7 @@ bc down
 | `bc role show <name>` | Show role details |
 | `bc role edit <name>` | Edit role in $EDITOR |
 | `bc role delete <name>` | Delete a role |
+| `bc role validate` | Validate all role files |
 
 ### Scheduled Tasks (Demons)
 
@@ -132,11 +151,16 @@ bc down
 
 | Command | Description |
 |---------|-------------|
-| `bc memory show` | Show agent memory |
+| `bc memory show [agent]` | Show agent memory |
+| `bc memory list` | List all agent memories |
 | `bc memory record <desc>` | Record an experience |
 | `bc memory learn <cat> <text>` | Add a learning |
+| `bc memory forget <topic>` | Remove a learning topic |
 | `bc memory search <query>` | Search memories |
 | `bc memory prune` | Remove old entries |
+| `bc memory clear [agent]` | Clear agent memory |
+| `bc memory export [agent]` | Export memory to JSON |
+| `bc memory import <file>` | Import memories from file |
 
 ### Configuration
 
@@ -145,18 +169,46 @@ bc down
 | `bc config show` | Show configuration |
 | `bc config get <key>` | Get config value |
 | `bc config set <key> <val>` | Set config value |
+| `bc config list` | List all config keys |
 | `bc config edit` | Edit config in $EDITOR |
+| `bc config validate` | Validate config file |
+| `bc config reset` | Reset to defaults |
+
+### Cost Tracking
+
+| Command | Description |
+|---------|-------------|
+| `bc cost show [agent]` | Show cost records |
+| `bc cost summary` | Show cost summary |
+| `bc cost by-agent` | Show costs grouped by agent |
+| `bc cost budget` | Manage cost budgets |
+| `bc cost dashboard` | Show comprehensive cost dashboard |
+| `bc cost project` | Project future costs |
+| `bc cost trends` | Show spending trends |
+
+### Worktrees
+
+| Command | Description |
+|---------|-------------|
+| `bc worktree list` | List agent worktrees |
+| `bc worktree check` | Verify agent's worktree |
+| `bc worktree prune` | Remove orphaned worktrees |
+
+### Event Log
+
+| Command | Description |
+|---------|-------------|
+| `bc logs` | View event log |
+| `bc logs --agent <name>` | Filter by agent |
+| `bc logs --type <type>` | Filter by event type |
+| `bc logs --since <dur>` | Events since duration |
 
 ### Other
 
 | Command | Description |
 |---------|-------------|
-| `bc worktree list` | List agent worktrees |
-| `bc worktree prune` | Remove orphaned worktrees |
-| `bc cost show` | Show cost records |
-| `bc cost summary` | Show cost summary |
-| `bc logs` | View event log |
 | `bc version` | Show version |
+| `bc help` | Show help |
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for all 28 missing CLI subcommands
- Add new `bc report` command documentation
- Reorganize sections for better clarity (Worktrees, Event Log, Cost Tracking)

## Commands Added

| Category | Commands Added |
|----------|---------------|
| Agent | broadcast, send-to-role, send-pattern, health |
| Channel | add, remove, delete, join, leave, history, react |
| Config | list, reset, validate |
| Cost | budget, by-agent, dashboard, project, trends |
| Memory | list, clear, export, import, forget |
| Role | validate |
| Team | delete |
| Worktree | check |
| New | `bc report` command |

## Test plan
- [x] All documented commands verified against `bc <cmd> --help`
- [x] Command syntax matches actual CLI
- [x] Markdown tables render correctly

Fixes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)