### PR TITLE
chore: remove bc completion command

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -65,6 +65,9 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
+	// Disable auto-generated completion command
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
 	// Global flags
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().Bool("json", false, "Output in JSON format")


### PR DESCRIPTION
## Summary

Remove Cobra's auto-generated `bc completion` command by disabling it in root.go.

**Change:**
```go
rootCmd.CompletionOptions.DisableDefaultCmd = true
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes
- [x] `bc --help` no longer shows completion command
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)