### PR TITLE
Remove bc completion command

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -65,6 +65,9 @@ var versionCmd = &cobra.Command{
 }
 
 func init() {
+	// Disable auto-generated completion command
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
 	// Global flags
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().Bool("json", false, "Output in JSON format")


### PR DESCRIPTION
## Summary
- Disable Cobra's auto-generated `completion` command
- Simplifies CLI by removing unnecessary shell completion feature

## Changes
- Add `rootCmd.CompletionOptions.DisableDefaultCmd = true` in root.go init()

## Verification
```bash
$ bc completion
Error: unknown command "completion" for "bc"
```

```bash
$ bc --help
# No longer shows "completion" in Available Commands
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes
- [x] `bc --help` no longer lists completion
- [x] `bc completion` returns "unknown command" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)