### PR TITLE
feat(tui): add Go bridge for Ink TUI integration

### DIFF
--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rpuneet/bc/pkg/tui/runtime"
+)
+
+var homeCmd = &cobra.Command{
+	Use:   "home",
+	Short: "Open the bc TUI dashboard",
+	Long: `Open the interactive bc TUI dashboard.
+
+The TUI provides a visual interface for managing agents, viewing channels,
+monitoring costs, and more.
+
+Requirements:
+  - Bun runtime installed (bun.sh)
+  - TUI package built (make build-tui)
+
+Examples:
+  bc home              # Open TUI dashboard
+  bc home --debug      # Open with debug output`,
+	RunE: runHome,
+}
+
+var homeDebug bool
+
+func init() {
+	rootCmd.AddCommand(homeCmd)
+	homeCmd.Flags().BoolVar(&homeDebug, "debug", false, "Enable debug output")
+}
+
+func runHome(cmd *cobra.Command, args []string) error {
+	// Get workspace root
+	ws, err := getWorkspace()
+	if err != nil {
+		return fmt.Errorf("failed to get workspace: %w", err)
+	}
+
+	// Create bridge configuration
+	cfg := runtime.BridgeConfig{
+		TUIDir:        "tui",
+		EntryPoint:    "src/index.tsx",
+		WorkspaceRoot: ws.RootDir,
+	}
+
+	// Create and start the Ink bridge
+	bridge, err := runtime.NewInkBridge(cfg)
+	if err != nil {
+		return fmt.Errorf("failed to create TUI bridge: %w\n\nMake sure the TUI is built: make build-tui", err)
+	}
+
+	if err := bridge.Start(); err != nil {
+		return fmt.Errorf("failed to start TUI: %w", err)
+	}
+	defer func() { _ = bridge.Close() }()
+
+	// Handle signals for graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	// Send initial workspace state to TUI
+	initialState := map[string]interface{}{
+		"type":      "init",
+		"workspace": ws.Config.Name,
+		"rootDir":   ws.RootDir,
+	}
+	if err := bridge.SendJSON(initialState); err != nil {
+		return fmt.Errorf("failed to send initial state: %w", err)
+	}
+
+	// Event loop - handle TUI events and signals
+	done := make(chan error, 1)
+	go func() {
+		done <- bridge.Wait()
+	}()
+
+	select {
+	case sig := <-sigChan:
+		if homeDebug {
+			fmt.Fprintf(os.Stderr, "Received signal: %v\n", sig)
+		}
+		return nil
+	case err := <-done:
+		if err != nil {
+			return fmt.Errorf("TUI exited with error: %w", err)
+		}
+		return nil
+	}
+}

--- a/pkg/tui/runtime/bridge.go
+++ b/pkg/tui/runtime/bridge.go
@@ -1,0 +1,252 @@
+// Package runtime provides the Go-side bridge for the Ink TUI.
+package runtime
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+)
+
+// InkBridge manages communication between Go and the Ink TUI process.
+type InkBridge struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	stderr io.ReadCloser
+	reader *bufio.Reader
+
+	tuiDir     string
+	entryPoint string
+
+	mu     sync.Mutex
+	closed bool
+}
+
+// BridgeConfig holds configuration for the Ink bridge.
+type BridgeConfig struct {
+	// TUIDir is the directory containing the TUI package (default: "tui")
+	TUIDir string
+	// EntryPoint is the entry script (default: "src/index.tsx")
+	EntryPoint string
+	// WorkspaceRoot is the bc workspace root directory
+	WorkspaceRoot string
+}
+
+// DefaultConfig returns the default bridge configuration.
+func DefaultConfig() BridgeConfig {
+	return BridgeConfig{
+		TUIDir:     "tui",
+		EntryPoint: "src/index.tsx",
+	}
+}
+
+// NewInkBridge creates a new Ink bridge with the given configuration.
+func NewInkBridge(cfg BridgeConfig) (*InkBridge, error) {
+	if cfg.TUIDir == "" {
+		cfg.TUIDir = "tui"
+	}
+	if cfg.EntryPoint == "" {
+		cfg.EntryPoint = "src/index.tsx"
+	}
+
+	// Resolve TUI directory path
+	tuiDir := cfg.TUIDir
+	if cfg.WorkspaceRoot != "" {
+		tuiDir = filepath.Join(cfg.WorkspaceRoot, cfg.TUIDir)
+	}
+
+	// Check if TUI directory exists
+	if _, err := os.Stat(tuiDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("TUI directory not found: %s", tuiDir)
+	}
+
+	entryPath := filepath.Join(tuiDir, cfg.EntryPoint)
+	if _, err := os.Stat(entryPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("TUI entry point not found: %s", entryPath)
+	}
+
+	return &InkBridge{
+		tuiDir:     tuiDir,
+		entryPoint: cfg.EntryPoint,
+	}, nil
+}
+
+// Start launches the Ink TUI process.
+func (b *InkBridge) Start() error {
+	return b.StartWithContext(context.Background())
+}
+
+// StartWithContext launches the Ink TUI process with the given context.
+func (b *InkBridge) StartWithContext(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return fmt.Errorf("bridge is closed")
+	}
+
+	// Create command to run Bun with the TUI entry point
+	// #nosec G204 - entryPoint is validated in NewInkBridge
+	b.cmd = exec.CommandContext(ctx, "bun", "run", b.entryPoint)
+	b.cmd.Dir = b.tuiDir
+	b.cmd.Env = append(os.Environ(), "BC_BRIDGE_MODE=1")
+
+	var err error
+
+	// Setup stdin pipe for sending specs to TUI
+	b.stdin, err = b.cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdin pipe: %w", err)
+	}
+
+	// Setup stdout pipe for reading events from TUI
+	b.stdout, err = b.cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
+	}
+	b.reader = bufio.NewReader(b.stdout)
+
+	// Setup stderr pipe for error output
+	b.stderr, err = b.cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("failed to create stderr pipe: %w", err)
+	}
+
+	// Start the process
+	if err := b.cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start TUI process: %w", err)
+	}
+
+	return nil
+}
+
+// SendSpec sends a JSON spec to the TUI for rendering.
+func (b *InkBridge) SendSpec(spec []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return fmt.Errorf("bridge is closed")
+	}
+
+	if b.stdin == nil {
+		return fmt.Errorf("bridge not started")
+	}
+
+	// Write spec followed by newline delimiter
+	if _, err := b.stdin.Write(spec); err != nil {
+		return fmt.Errorf("failed to write spec: %w", err)
+	}
+	if _, err := b.stdin.Write([]byte("\n")); err != nil {
+		return fmt.Errorf("failed to write delimiter: %w", err)
+	}
+
+	return nil
+}
+
+// SendJSON marshals the given value to JSON and sends it to the TUI.
+func (b *InkBridge) SendJSON(v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("failed to marshal spec: %w", err)
+	}
+	return b.SendSpec(data)
+}
+
+// ReadEvent reads the next event from the TUI.
+// Events are newline-delimited JSON messages.
+func (b *InkBridge) ReadEvent() ([]byte, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return nil, fmt.Errorf("bridge is closed")
+	}
+
+	if b.reader == nil {
+		return nil, fmt.Errorf("bridge not started")
+	}
+
+	line, err := b.reader.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+
+	// Trim newline
+	if len(line) > 0 && line[len(line)-1] == '\n' {
+		line = line[:len(line)-1]
+	}
+
+	return line, nil
+}
+
+// ReadEventJSON reads and unmarshals the next event into the given value.
+func (b *InkBridge) ReadEventJSON(v any) error {
+	data, err := b.ReadEvent()
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, v)
+}
+
+// Close shuts down the Ink TUI process.
+func (b *InkBridge) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return nil
+	}
+	b.closed = true
+
+	var errs []error
+
+	if b.stdin != nil {
+		if err := b.stdin.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to close stdin: %w", err))
+		}
+	}
+
+	if b.cmd != nil && b.cmd.Process != nil {
+		if err := b.cmd.Process.Kill(); err != nil {
+			errs = append(errs, fmt.Errorf("failed to kill process: %w", err))
+		}
+		_ = b.cmd.Wait() // Clean up zombie process
+	}
+
+	if len(errs) > 0 {
+		return errs[0]
+	}
+	return nil
+}
+
+// Wait waits for the TUI process to exit and returns its exit error.
+func (b *InkBridge) Wait() error {
+	if b.cmd == nil {
+		return fmt.Errorf("bridge not started")
+	}
+	return b.cmd.Wait()
+}
+
+// IsRunning returns true if the TUI process is running.
+func (b *InkBridge) IsRunning() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed || b.cmd == nil || b.cmd.Process == nil {
+		return false
+	}
+
+	// Check if process has exited
+	if b.cmd.ProcessState != nil {
+		return false
+	}
+
+	return true
+}

--- a/pkg/tui/runtime/bridge_test.go
+++ b/pkg/tui/runtime/bridge_test.go
@@ -1,0 +1,226 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.TUIDir != "tui" {
+		t.Errorf("TUIDir = %q, want %q", cfg.TUIDir, "tui")
+	}
+	if cfg.EntryPoint != "src/index.tsx" {
+		t.Errorf("EntryPoint = %q, want %q", cfg.EntryPoint, "src/index.tsx")
+	}
+}
+
+func TestNewInkBridge_MissingTUIDir(t *testing.T) {
+	cfg := BridgeConfig{
+		TUIDir:        "/nonexistent/path",
+		WorkspaceRoot: "",
+	}
+
+	_, err := NewInkBridge(cfg)
+	if err == nil {
+		t.Error("expected error for missing TUI directory")
+	}
+}
+
+func TestNewInkBridge_MissingEntryPoint(t *testing.T) {
+	// Create a temp directory without entry point
+	tmpDir := t.TempDir()
+	tuiDir := filepath.Join(tmpDir, "tui")
+	if err := os.MkdirAll(tuiDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BridgeConfig{
+		TUIDir:        "tui",
+		EntryPoint:    "src/index.tsx",
+		WorkspaceRoot: tmpDir,
+	}
+
+	_, err := NewInkBridge(cfg)
+	if err == nil {
+		t.Error("expected error for missing entry point")
+	}
+}
+
+func TestNewInkBridge_ValidSetup(t *testing.T) {
+	// Create a temp directory with entry point
+	tmpDir := t.TempDir()
+	tuiDir := filepath.Join(tmpDir, "tui")
+	srcDir := filepath.Join(tuiDir, "src")
+	if err := os.MkdirAll(srcDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	entryPoint := filepath.Join(srcDir, "index.tsx")
+	if err := os.WriteFile(entryPoint, []byte("// placeholder"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BridgeConfig{
+		TUIDir:        "tui",
+		EntryPoint:    "src/index.tsx",
+		WorkspaceRoot: tmpDir,
+	}
+
+	bridge, err := NewInkBridge(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if bridge == nil {
+		t.Fatal("expected non-nil bridge")
+	}
+
+	// cmd is nil until Start() is called
+	if bridge.tuiDir == "" {
+		t.Error("expected non-empty tuiDir")
+	}
+	if bridge.entryPoint == "" {
+		t.Error("expected non-empty entryPoint")
+	}
+}
+
+func TestInkBridge_CloseWithoutStart(t *testing.T) {
+	tmpDir := t.TempDir()
+	tuiDir := filepath.Join(tmpDir, "tui", "src")
+	if err := os.MkdirAll(tuiDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tuiDir, "index.tsx"), []byte("//"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BridgeConfig{
+		TUIDir:        "tui",
+		WorkspaceRoot: tmpDir,
+	}
+
+	bridge, err := NewInkBridge(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Close should not error even if not started
+	if err := bridge.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+}
+
+func TestInkBridge_DoubleClose(t *testing.T) {
+	tmpDir := t.TempDir()
+	tuiDir := filepath.Join(tmpDir, "tui", "src")
+	if err := os.MkdirAll(tuiDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tuiDir, "index.tsx"), []byte("//"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BridgeConfig{
+		TUIDir:        "tui",
+		WorkspaceRoot: tmpDir,
+	}
+
+	bridge, err := NewInkBridge(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First close
+	if err := bridge.Close(); err != nil {
+		t.Errorf("first Close() error = %v", err)
+	}
+
+	// Second close should be safe
+	if err := bridge.Close(); err != nil {
+		t.Errorf("second Close() error = %v", err)
+	}
+}
+
+func TestInkBridge_SendSpecWithoutStart(t *testing.T) {
+	tmpDir := t.TempDir()
+	tuiDir := filepath.Join(tmpDir, "tui", "src")
+	if err := os.MkdirAll(tuiDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tuiDir, "index.tsx"), []byte("//"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BridgeConfig{
+		TUIDir:        "tui",
+		WorkspaceRoot: tmpDir,
+	}
+
+	bridge, err := NewInkBridge(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = bridge.Close() }()
+
+	err = bridge.SendSpec([]byte(`{"test": true}`))
+	if err == nil {
+		t.Error("expected error when sending spec without start")
+	}
+}
+
+func TestInkBridge_ReadEventWithoutStart(t *testing.T) {
+	tmpDir := t.TempDir()
+	tuiDir := filepath.Join(tmpDir, "tui", "src")
+	if err := os.MkdirAll(tuiDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tuiDir, "index.tsx"), []byte("//"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BridgeConfig{
+		TUIDir:        "tui",
+		WorkspaceRoot: tmpDir,
+	}
+
+	bridge, err := NewInkBridge(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = bridge.Close() }()
+
+	_, err = bridge.ReadEvent()
+	if err == nil {
+		t.Error("expected error when reading event without start")
+	}
+}
+
+func TestInkBridge_IsRunning(t *testing.T) {
+	tmpDir := t.TempDir()
+	tuiDir := filepath.Join(tmpDir, "tui", "src")
+	if err := os.MkdirAll(tuiDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tuiDir, "index.tsx"), []byte("//"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := BridgeConfig{
+		TUIDir:        "tui",
+		WorkspaceRoot: tmpDir,
+	}
+
+	bridge, err := NewInkBridge(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = bridge.Close() }()
+
+	// Should not be running before start
+	if bridge.IsRunning() {
+		t.Error("expected IsRunning() = false before Start()")
+	}
+}


### PR DESCRIPTION
## Summary

Implement the Go-side bridge for communication with the Ink TUI process.

### pkg/tui/runtime/bridge.go
- `InkBridge` struct for managing TUI subprocess
- `BridgeConfig` for configuration
- `Start()`/`StartWithContext()` to launch Bun/Ink process
- `SendSpec`/`SendJSON` for Go → TUI communication
- `ReadEvent`/`ReadEventJSON` for TUI → Go communication
- `Close()` for graceful shutdown
- `IsRunning()` for process status

### internal/cmd/home.go
- `bc home` command to launch TUI dashboard
- Workspace integration
- Signal handling for graceful shutdown
- Initial state sending to TUI

## Test plan
- [x] 9 unit tests for bridge functionality
- [x] Config validation tests
- [x] Error handling verification
- [x] `go build ./...` passes
- [x] `go test ./pkg/tui/runtime/...` passes
- [x] golangci-lint passes (0 issues)

## Dependencies
- Requires TUI (tui/) to be set up by eng-01/eng-02 for full integration testing
- Bridge ready to receive Ink process when Foundation is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)