### PR TITLE
feat(channel): Add SQLite reactions and init integration

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
@@ -117,6 +118,13 @@ func initV2Workspace(rootDir string) error {
 		return fmt.Errorf("failed to create role files: %w", err)
 	}
 
+	// Initialize channel database
+	channelStore := channel.NewSQLiteStore(rootDir)
+	if openErr := channelStore.Open(); openErr != nil {
+		return fmt.Errorf("failed to initialize channel database: %w", openErr)
+	}
+	_ = channelStore.Close()
+
 	// Register in global registry
 	reg, err := workspace.LoadRegistry()
 	if err == nil {
@@ -134,6 +142,7 @@ func initV2Workspace(rootDir string) error {
 	if created {
 		fmt.Printf("    .bc/roles/root.md   # Root agent role\n")
 	}
+	fmt.Printf("    .bc/channels.db     # Channel database\n")
 	fmt.Printf("\n")
 	fmt.Printf("  Default tool: %s\n", cfg.Tools.Default)
 	fmt.Printf("  Memory: %s (%s)\n", cfg.Memory.Backend, cfg.Memory.Path)

--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -449,10 +449,16 @@ func (s *Store) RemoveReaction(channelName string, messageIndex int, emoji, user
 
 // ToggleReaction toggles an emoji reaction on a message.
 // Returns true if the reaction was added, false if removed.
-// When using SQLite backend, reactions are not persisted (no-op).
 func (s *Store) ToggleReaction(channelName string, messageIndex int, emoji, user string) (added bool, err error) {
 	if s.sqlite != nil {
-		return false, nil // reactions not stored in SQLite schema
+		msgs, err := s.sqlite.GetHistory(channelName, 100)
+		if err != nil {
+			return false, err
+		}
+		if messageIndex < 0 || messageIndex >= len(msgs) {
+			return false, fmt.Errorf("message index %d out of range", messageIndex)
+		}
+		return s.sqlite.ToggleReaction(msgs[messageIndex].ID, emoji, user)
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -488,10 +494,16 @@ func (s *Store) ToggleReaction(channelName string, messageIndex int, emoji, user
 }
 
 // GetReactions returns all reactions for a message.
-// When using SQLite backend, returns nil (reactions not stored).
 func (s *Store) GetReactions(channelName string, messageIndex int) (map[string][]string, error) {
 	if s.sqlite != nil {
-		return nil, nil
+		msgs, err := s.sqlite.GetHistory(channelName, 100)
+		if err != nil {
+			return nil, err
+		}
+		if messageIndex < 0 || messageIndex >= len(msgs) {
+			return nil, fmt.Errorf("message index %d out of range", messageIndex)
+		}
+		return s.sqlite.GetReactions(msgs[messageIndex].ID)
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/pkg/channel/sqlite.go
+++ b/pkg/channel/sqlite.go
@@ -138,6 +138,17 @@ func (s *SQLiteStore) initSchema(db *sql.DB) error {
 		CREATE INDEX IF NOT EXISTS idx_mentions_agent ON mentions(agent_id, acknowledged);
 		CREATE INDEX IF NOT EXISTS idx_mentions_message ON mentions(message_id);
 
+		CREATE TABLE IF NOT EXISTS reactions (
+			id          INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id  INTEGER NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+			emoji       TEXT NOT NULL,
+			user_id     TEXT NOT NULL,
+			created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+			UNIQUE(message_id, emoji, user_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id);
+		CREATE INDEX IF NOT EXISTS idx_reactions_user ON reactions(user_id);
+
 		INSERT OR IGNORE INTO channels (name, type, description) VALUES
 			('general', 'group', 'General discussion for all agents'),
 			('engineering', 'group', 'Engineering team coordination'),
@@ -693,6 +704,87 @@ func (s *SQLiteStore) AcknowledgeMentions(agentID string) error {
 		return fmt.Errorf("failed to acknowledge mentions: %w", err)
 	}
 	return nil
+}
+
+// AddReaction adds a reaction to a message.
+func (s *SQLiteStore) AddReaction(messageID int64, emoji, userID string) error {
+	ctx := context.Background()
+	_, err := s.db.ExecContext(ctx,
+		"INSERT OR IGNORE INTO reactions (message_id, emoji, user_id) VALUES (?, ?, ?)",
+		messageID, emoji, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to add reaction: %w", err)
+	}
+	return nil
+}
+
+// RemoveReaction removes a reaction from a message.
+func (s *SQLiteStore) RemoveReaction(messageID int64, emoji, userID string) error {
+	ctx := context.Background()
+	result, err := s.db.ExecContext(ctx,
+		"DELETE FROM reactions WHERE message_id = ? AND emoji = ? AND user_id = ?",
+		messageID, emoji, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to remove reaction: %w", err)
+	}
+	affected, _ := result.RowsAffected()
+	if affected == 0 {
+		return nil // Reaction didn't exist, not an error
+	}
+	return nil
+}
+
+// ToggleReaction toggles a reaction on a message. Returns true if added, false if removed.
+func (s *SQLiteStore) ToggleReaction(messageID int64, emoji, userID string) (added bool, err error) {
+	ctx := context.Background()
+	// Check if reaction exists
+	var count int
+	err = s.db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM reactions WHERE message_id = ? AND emoji = ? AND user_id = ?",
+		messageID, emoji, userID,
+	).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("failed to check reaction: %w", err)
+	}
+
+	if count > 0 {
+		// Remove existing reaction
+		if err := s.RemoveReaction(messageID, emoji, userID); err != nil {
+			return false, err
+		}
+		return false, nil
+	}
+
+	// Add new reaction
+	if err := s.AddReaction(messageID, emoji, userID); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// GetReactions returns all reactions for a message as emoji -> []userID.
+func (s *SQLiteStore) GetReactions(messageID int64) (map[string][]string, error) {
+	ctx := context.Background()
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT emoji, user_id FROM reactions WHERE message_id = ? ORDER BY created_at",
+		messageID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get reactions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[string][]string)
+	for rows.Next() {
+		var emoji, userID string
+		if err := rows.Scan(&emoji, &userID); err != nil {
+			return nil, err
+		}
+		result[emoji] = append(result[emoji], userID)
+	}
+	return result, rows.Err()
 }
 
 // MigrateFromJSON migrates data from the legacy JSON store.

--- a/pkg/channel/sqlite_test.go
+++ b/pkg/channel/sqlite_test.go
@@ -465,3 +465,77 @@ func TestSQLiteStore_Timestamps(t *testing.T) {
 		}
 	}
 }
+
+func TestSQLiteStore_Reactions(t *testing.T) {
+	store := setupTestDB(t)
+
+	if _, err := store.CreateChannel("reaction-test", ChannelTypeGroup, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := store.AddMessage("reaction-test", "user1", "Great work!", TypeText, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add reactions
+	err = store.AddReaction(msg.ID, "👍", "user2")
+	if err != nil {
+		t.Fatalf("failed to add reaction: %v", err)
+	}
+	err = store.AddReaction(msg.ID, "👍", "user3")
+	if err != nil {
+		t.Fatalf("failed to add second reaction: %v", err)
+	}
+	err = store.AddReaction(msg.ID, "🎉", "user2")
+	if err != nil {
+		t.Fatalf("failed to add different emoji: %v", err)
+	}
+
+	// Get reactions
+	reactions, err := store.GetReactions(msg.ID)
+	if err != nil {
+		t.Fatalf("failed to get reactions: %v", err)
+	}
+
+	if len(reactions["👍"]) != 2 {
+		t.Errorf("expected 2 thumbsup reactions, got %d", len(reactions["👍"]))
+	}
+	if len(reactions["🎉"]) != 1 {
+		t.Errorf("expected 1 party reaction, got %d", len(reactions["🎉"]))
+	}
+
+	// Remove reaction
+	err = store.RemoveReaction(msg.ID, "👍", "user2")
+	if err != nil {
+		t.Fatalf("failed to remove reaction: %v", err)
+	}
+
+	reactions, _ = store.GetReactions(msg.ID)
+	if len(reactions["👍"]) != 1 {
+		t.Errorf("expected 1 thumbsup after removal, got %d", len(reactions["👍"]))
+	}
+
+	// Toggle reaction (remove)
+	added, err := store.ToggleReaction(msg.ID, "👍", "user3")
+	if err != nil {
+		t.Fatalf("toggle failed: %v", err)
+	}
+	if added {
+		t.Error("expected toggle to remove, not add")
+	}
+
+	// Toggle reaction (add)
+	added, err = store.ToggleReaction(msg.ID, "🚀", "user4")
+	if err != nil {
+		t.Fatalf("toggle failed: %v", err)
+	}
+	if !added {
+		t.Error("expected toggle to add, not remove")
+	}
+
+	reactions, _ = store.GetReactions(msg.ID)
+	if len(reactions["🚀"]) != 1 {
+		t.Errorf("expected rocket reaction after toggle add, got %d", len(reactions["🚀"]))
+	}
+}


### PR DESCRIPTION
## Summary
- Add reactions table to SQLite schema for persistent emoji reactions
- Add reaction CRUD methods to SQLiteStore
- Update Store.ToggleReaction/GetReactions to use SQLite backend
- Initialize channel database during `bc init` (not just `bc up`)

## Changes
1. **pkg/channel/sqlite.go**: Added reactions table and CRUD methods
2. **pkg/channel/channel.go**: Updated ToggleReaction/GetReactions to use SQLite
3. **internal/cmd/init.go**: Initialize channels.db during workspace init
4. **pkg/channel/sqlite_test.go**: Added reaction tests

## Test plan
- [x] `go test ./pkg/channel/...` - all tests pass
- [x] `go test ./...` - full test suite passes
- [x] `golangci-lint run ./...` - 0 issues

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)