### PR TITLE
feat(tui): Enhance Dashboard with stats components and real data

### DIFF
--- a/tui/src/hooks/useDashboard.ts
+++ b/tui/src/hooks/useDashboard.ts
@@ -1,39 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
-
-// Types matching bc CLI --json output
-interface Agent {
-  name: string;
-  role: string;
-  state: string;
-  task: string;
-  uptime: string;
-  startedAt: string;
-  updatedAt: string;
-  [key: string]: unknown;
-}
-
-interface Channel {
-  name: string;
-  members: string[];
-  description?: string;
-}
-
-// StatusResponse type for future bc CLI integration
-// interface StatusResponse {
-//   workspace: string;
-//   total: number;
-//   active: number;
-//   working: number;
-//   agents: Agent[];
-// }
-
-interface CostSummary {
-  totalCostUSD: number;
-  recordCount: number;
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-}
+import { getStatus, getChannels, getCostSummary } from '../services/bc.js';
+import type { StatusResponse, ChannelsResponse, CostSummary, Agent } from '../types';
 
 interface UseDataResult<T> {
   data: T | null;
@@ -46,25 +13,50 @@ interface DashboardSummary {
   total: number;
   active: number;
   working: number;
+  idle: number;
+  stuck: number;
+  error: number;
   totalCostUSD: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+interface AgentStats {
+  byState: Record<string, number>;
+  byRole: Record<string, number>;
+}
+
+interface DashboardAgent {
+  name: string;
+  role: string;
+  state: string;
+  task: string;
+  uptime: string;
+  startedAt: string;
+  updatedAt: string;
+  [key: string]: unknown;
+}
+
+interface DashboardChannel {
+  name: string;
+  members: string[];
+  description?: string;
 }
 
 /**
  * useDashboard - Aggregates data from multiple bc CLI commands
- * Hook for Dashboard view (Issue #543)
+ * Hook for Dashboard view (Issues #543, #544)
  *
- * Note: This is a skeleton that will be connected to the service layer
- * once eng-02's PRs (#537, #538, #539) are merged.
+ * Integrates with bc CLI via service layer for real-time workspace data.
  */
 export function useDashboard() {
-  // Placeholder state - will be replaced with actual hooks from eng-02
-  const [agents, setAgents] = useState<UseDataResult<Agent[]>>({
+  const [agents, setAgents] = useState<UseDataResult<DashboardAgent[]>>({
     data: null,
     isLoading: true,
     error: null,
   });
 
-  const [channels, setChannels] = useState<UseDataResult<Channel[]>>({
+  const [channels, setChannels] = useState<UseDataResult<DashboardChannel[]>>({
     data: null,
     isLoading: true,
     error: null,
@@ -76,51 +68,119 @@ export function useDashboard() {
     error: null,
   });
 
-  const [workspaceName] = useState('bc');
+  const [workspaceName, setWorkspaceName] = useState('bc');
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
 
-  // Fetch data on mount
-  useEffect(() => {
-    // TODO: Replace with actual service calls when available
-    // For now, simulate loading completion with empty data
-    const timer = setTimeout(() => {
-      setAgents({ data: [], isLoading: false, error: null });
-      setChannels({ data: [], isLoading: false, error: null });
-      setCost({
-        data: { totalCostUSD: 0, recordCount: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0 },
-        isLoading: false,
-        error: null,
-      });
-    }, 100);
-
-    return () => clearTimeout(timer);
-  }, []);
-
-  // Compute summary from data
-  const summary = useMemo<DashboardSummary>(() => ({
-    workspaceName,
-    total: agents.data?.length ?? 0,
-    active: agents.data?.filter((a) => a.state !== 'stopped').length ?? 0,
-    working: agents.data?.filter((a) => a.state === 'working').length ?? 0,
-    totalCostUSD: cost.data?.totalCostUSD ?? 0,
-  }), [workspaceName, agents.data, cost.data]);
-
-  const refresh = useCallback(() => {
-    // TODO: Implement refresh when service layer is available
+  // Fetch all data
+  const fetchData = useCallback(async () => {
     setAgents((prev) => ({ ...prev, isLoading: true }));
     setChannels((prev) => ({ ...prev, isLoading: true }));
     setCost((prev) => ({ ...prev, isLoading: true }));
 
-    // Simulate refresh
-    setTimeout(() => {
-      setAgents({ data: [], isLoading: false, error: null });
-      setChannels({ data: [], isLoading: false, error: null });
-      setCost({
-        data: { totalCostUSD: 0, recordCount: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+    // Fetch status (agents)
+    try {
+      const statusResponse: StatusResponse = await getStatus();
+      setWorkspaceName(statusResponse.workspace || 'bc');
+      setAgents({
+        data: statusResponse.agents.map((a: Agent) => ({
+          name: a.name,
+          role: a.role,
+          state: a.state,
+          task: a.task || '',
+          uptime: '',
+          startedAt: formatTime(a.started_at),
+          updatedAt: formatTime(a.updated_at),
+        })),
         isLoading: false,
         error: null,
       });
-    }, 500);
+    } catch (err) {
+      setAgents({
+        data: [],
+        isLoading: false,
+        error: err instanceof Error ? err : new Error('Failed to fetch agents'),
+      });
+    }
+
+    // Fetch channels
+    try {
+      const channelsResponse: ChannelsResponse = await getChannels();
+      setChannels({
+        data: channelsResponse.channels.map((c) => ({
+          name: c.name,
+          members: c.members,
+        })),
+        isLoading: false,
+        error: null,
+      });
+    } catch (err) {
+      setChannels({
+        data: [],
+        isLoading: false,
+        error: err instanceof Error ? err : new Error('Failed to fetch channels'),
+      });
+    }
+
+    // Fetch costs
+    try {
+      const costResponse: CostSummary = await getCostSummary();
+      setCost({
+        data: costResponse,
+        isLoading: false,
+        error: null,
+      });
+    } catch (err) {
+      setCost({
+        data: null,
+        isLoading: false,
+        error: err instanceof Error ? err : new Error('Failed to fetch costs'),
+      });
+    }
+
+    setLastRefresh(new Date());
   }, []);
+
+  // Initial fetch on mount
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Auto-refresh every 10 seconds
+  useEffect(() => {
+    const interval = setInterval(fetchData, 10000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  // Compute agent stats breakdown
+  const agentStats = useMemo<AgentStats>(() => {
+    const agentList = agents.data ?? [];
+    const byState: Record<string, number> = {};
+    const byRole: Record<string, number> = {};
+
+    for (const agent of agentList) {
+      byState[agent.state] = (byState[agent.state] || 0) + 1;
+      byRole[agent.role] = (byRole[agent.role] || 0) + 1;
+    }
+
+    return { byState, byRole };
+  }, [agents.data]);
+
+  // Compute summary from data
+  const summary = useMemo<DashboardSummary>(() => {
+    const agentList = agents.data ?? [];
+    return {
+      workspaceName,
+      total: agentList.length,
+      active: agentList.filter((a) => a.state !== 'stopped' && a.state !== 'idle').length,
+      working: agentList.filter((a) => a.state === 'working').length,
+      idle: agentList.filter((a) => a.state === 'idle').length,
+      stuck: agentList.filter((a) => a.state === 'stuck').length,
+      error: agentList.filter((a) => a.state === 'error').length,
+      totalCostUSD: cost.data?.total_cost ?? 0,
+      inputTokens: cost.data?.total_input_tokens ?? 0,
+      outputTokens: cost.data?.total_output_tokens ?? 0,
+    };
+  }, [workspaceName, agents.data, cost.data]);
 
   const isLoading = agents.isLoading || channels.isLoading || cost.isLoading;
   const error = agents.error || channels.error || cost.error;
@@ -130,10 +190,35 @@ export function useDashboard() {
     agents,
     channels,
     cost,
+    agentStats,
     isLoading,
     error,
-    refresh,
+    refresh: fetchData,
+    lastRefresh,
   };
+}
+
+/**
+ * Format ISO timestamp to relative time string
+ */
+function formatTime(isoString: string | undefined): string {
+  if (!isoString) return '-';
+  try {
+    const date = new Date(isoString);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+
+    if (diffMins < 1) return 'now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  } catch {
+    return '-';
+  }
 }
 
 export default useDashboard;

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel.js';
 import { MetricCard } from '../components/MetricCard.js';
 import { DataTable } from '../components/DataTable.js';
@@ -8,15 +8,47 @@ import { LoadingIndicator } from '../components/LoadingIndicator.js';
 import { ErrorDisplay } from '../components/ErrorDisplay.js';
 import { useDashboard } from '../hooks/useDashboard.js';
 
+interface DashboardProps {
+  onNavigate?: (view: string) => void;
+}
+
 /**
  * Dashboard view - main overview of bc workspace
- * Issue #543 - Dashboard layout
+ * Issues #543 (layout), #544 (stats components)
  */
-export function Dashboard() {
-  const { summary, agents, channels, isLoading, error, refresh } = useDashboard();
+export function Dashboard({ onNavigate }: DashboardProps) {
+  const {
+    summary,
+    agents,
+    channels,
+    agentStats,
+    isLoading,
+    error,
+    refresh,
+    lastRefresh,
+  } = useDashboard();
+
+  // Keyboard navigation
+  useInput((input, key) => {
+    if (input === 'a') {
+      onNavigate?.('agents');
+    }
+    if (input === 'c') {
+      onNavigate?.('channels');
+    }
+    if (input === '$') {
+      onNavigate?.('costs');
+    }
+    if (input === 'r') {
+      refresh();
+    }
+    if (input === 'q' || key.escape) {
+      onNavigate?.('quit');
+    }
+  });
 
   if (error) {
-    return <ErrorDisplay error={error} onRetry={refresh} />;
+    return <ErrorDisplay error={error.message} onRetry={refresh} />;
   }
 
   if (isLoading && !agents.data) {
@@ -25,19 +57,35 @@ export function Dashboard() {
 
   return (
     <Box flexDirection="column" padding={1}>
-      {/* Header */}
-      <Header workspaceName={summary.workspaceName} />
+      {/* Header with activity indicator */}
+      <Header
+        workspaceName={summary.workspaceName}
+        isLoading={isLoading}
+        lastRefresh={lastRefresh}
+      />
 
-      {/* Summary Cards */}
+      {/* Summary Cards - Agent counts */}
       <SummaryCards
         total={summary.total}
         active={summary.active}
         working={summary.working}
+        idle={summary.idle}
+        stuck={summary.stuck}
+        errorCount={summary.error}
+      />
+
+      {/* Cost Summary */}
+      <CostSummary
         totalCostUSD={summary.totalCostUSD}
+        inputTokens={summary.inputTokens}
+        outputTokens={summary.outputTokens}
       />
 
       {/* Main Content */}
       <Box flexDirection="column" marginTop={1}>
+        {/* Agent Stats by Role */}
+        <AgentStatsPanel stats={agentStats} />
+
         {/* Agents Panel */}
         <AgentsPanel agents={agents.data ?? []} />
 
@@ -50,6 +98,7 @@ export function Dashboard() {
         hints={[
           { key: 'a', label: 'agents' },
           { key: 'c', label: 'channels' },
+          { key: '$', label: 'costs' },
           { key: 'r', label: 'refresh' },
           { key: 'q', label: 'quit' },
         ]}
@@ -60,14 +109,28 @@ export function Dashboard() {
 
 interface HeaderProps {
   workspaceName: string;
+  isLoading: boolean;
+  lastRefresh: Date | null;
 }
 
-function Header({ workspaceName }: HeaderProps) {
+function Header({ workspaceName, isLoading, lastRefresh }: HeaderProps) {
+  const refreshText = lastRefresh
+    ? `Updated ${formatRelativeTime(lastRefresh)}`
+    : '';
+
   return (
     <Box marginBottom={1}>
-      <Text bold color="blue">bc</Text>
+      <Text bold color="blue">
+        bc
+      </Text>
       <Text> · </Text>
       <Text>{workspaceName}</Text>
+      <Box flexGrow={1} />
+      {isLoading ? (
+        <Text color="yellow">↻ refreshing...</Text>
+      ) : (
+        <Text dimColor>{refreshText}</Text>
+      )}
     </Box>
   );
 }
@@ -76,17 +139,87 @@ interface SummaryCardsProps {
   total: number;
   active: number;
   working: number;
-  totalCostUSD: number;
+  idle: number;
+  stuck: number;
+  errorCount: number;
 }
 
-function SummaryCards({ total, active, working, totalCostUSD }: SummaryCardsProps) {
+function SummaryCards({
+  total,
+  active,
+  working,
+  idle,
+  stuck,
+  errorCount,
+}: SummaryCardsProps) {
   return (
     <Box>
-      <MetricCard value={total} label="Agents" />
+      <MetricCard value={total} label="Total" />
       <MetricCard value={active} label="Active" color="green" />
       <MetricCard value={working} label="Working" color="cyan" />
-      <MetricCard value={totalCostUSD.toFixed(2)} label="Cost" prefix="$" />
+      <MetricCard value={idle} label="Idle" color="gray" />
+      {stuck > 0 && <MetricCard value={stuck} label="Stuck" color="yellow" />}
+      {errorCount > 0 && (
+        <MetricCard value={errorCount} label="Error" color="red" />
+      )}
     </Box>
+  );
+}
+
+interface CostSummaryProps {
+  totalCostUSD: number;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+function CostSummary({
+  totalCostUSD,
+  inputTokens,
+  outputTokens,
+}: CostSummaryProps) {
+  const totalTokens = inputTokens + outputTokens;
+
+  return (
+    <Box marginTop={1}>
+      <Text bold>Cost: </Text>
+      <Text color="yellow">${totalCostUSD.toFixed(4)}</Text>
+      <Text> · </Text>
+      <Text dimColor>
+        {formatNumber(totalTokens)} tokens ({formatNumber(inputTokens)} in /{' '}
+        {formatNumber(outputTokens)} out)
+      </Text>
+    </Box>
+  );
+}
+
+interface AgentStatsPanelProps {
+  stats: {
+    byState: Record<string, number>;
+    byRole: Record<string, number>;
+  };
+}
+
+function AgentStatsPanel({ stats }: AgentStatsPanelProps) {
+  const hasRoles = Object.keys(stats.byRole).length > 0;
+
+  if (!hasRoles) return null;
+
+  return (
+    <Panel title="Agent Distribution">
+      <Box>
+        {/* By Role */}
+        <Box marginRight={4}>
+          <Text dimColor>By Role: </Text>
+          {Object.entries(stats.byRole).map(([role, count], idx, arr) => (
+            <Text key={role}>
+              <Text color="cyan">{role}</Text>
+              <Text>:{count}</Text>
+              {idx < arr.length - 1 && <Text> · </Text>}
+            </Text>
+          ))}
+        </Box>
+      </Box>
+    </Panel>
   );
 }
 
@@ -105,26 +238,37 @@ interface AgentsPanelProps {
 }
 
 function AgentsPanel({ agents }: AgentsPanelProps) {
+  // Show only first 5 agents in dashboard view
+  const displayAgents = agents.slice(0, 5);
+  const hasMore = agents.length > 5;
+
   return (
     <Panel title="Agents">
       {agents.length === 0 ? (
         <Text dimColor>No agents running</Text>
       ) : (
-        <DataTable
-          columns={[
-            { key: 'name', header: 'AGENT', width: 15 },
-            { key: 'role', header: 'ROLE', width: 12 },
-            {
-              key: 'state',
-              header: 'STATE',
-              width: 10,
-              render: (value) => <StatusBadge state={value as string} />,
-            },
-            { key: 'startedAt', header: 'STARTED', width: 10 },
-            { key: 'task', header: 'TASK' },
-          ]}
-          data={agents}
-        />
+        <>
+          <DataTable
+            columns={[
+              { key: 'name', header: 'AGENT', width: 15 },
+              { key: 'role', header: 'ROLE', width: 12 },
+              {
+                key: 'state',
+                header: 'STATE',
+                width: 10,
+                render: (value) => <StatusBadge state={value as string} />,
+              },
+              { key: 'updatedAt', header: 'UPDATED', width: 10 },
+              { key: 'task', header: 'TASK' },
+            ]}
+            data={displayAgents}
+          />
+          {hasMore && (
+            <Text dimColor>
+              ... and {agents.length - 5} more (press 'a' to view all)
+            </Text>
+          )}
+        </>
       )}
     </Panel>
   );
@@ -147,17 +291,55 @@ function ChannelsPanel({ channels }: ChannelsPanelProps) {
         <Text dimColor>No channels</Text>
       ) : (
         <Box flexDirection="column">
-          {channels.map((ch) => (
+          {channels.slice(0, 5).map((ch) => (
             <Box key={ch.name}>
               <Text color="cyan">#{ch.name}</Text>
               <Text> </Text>
               <Text dimColor>{ch.members.length} members</Text>
             </Box>
           ))}
+          {channels.length > 5 && (
+            <Text dimColor>
+              ... and {channels.length - 5} more (press 'c' to view all)
+            </Text>
+          )}
         </Box>
       )}
     </Panel>
   );
+}
+
+/**
+ * Format large numbers with K/M suffixes
+ */
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(1)}K`;
+  }
+  return n.toString();
+}
+
+/**
+ * Format date to relative time string
+ */
+function formatRelativeTime(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+
+  if (diffSecs < 5) return 'just now';
+  if (diffSecs < 60) return `${diffSecs}s ago`;
+
+  const diffMins = Math.floor(diffSecs / 60);
+  if (diffMins < 60) return `${diffMins}m ago`;
+
+  return date.toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }
 
 export default Dashboard;


### PR DESCRIPTION
## Summary
- Connects useDashboard hook to real bc CLI services (getStatus, getChannels, getCostSummary)
- Adds detailed agent stats: total, active, working, idle, stuck, error counts
- Adds cost summary panel with token breakdown (input/output)
- Adds agent distribution panel showing counts by role
- Adds activity indicator showing refresh status and last update time
- Auto-refresh every 10 seconds for real-time updates
- Keyboard shortcuts: a (agents), c (channels), $ (costs), r (refresh), q (quit)

## Test plan
- [ ] TypeScript compiles without errors (verified locally)
- [ ] Dashboard shows real agent data from bc status
- [ ] Dashboard shows real cost data from bc cost show
- [ ] Auto-refresh updates data every 10 seconds
- [ ] Activity indicator shows "refreshing..." during fetch
- [ ] Keyboard shortcuts navigate to correct views

Fixes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)