### PR TITLE
feat(tui): add Demons list view for scheduled tasks (#554)

### DIFF
--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -40,6 +40,15 @@ export {
 export { useDashboard } from './useDashboard';
 
 export {
+  useDemons,
+  useDemonLogs,
+  type UseDemonsOptions,
+  type UseDemonsResult,
+  type UseDemonLogsOptions,
+  type UseDemonLogsResult,
+} from './useDemons';
+
+export {
   useMessagePolling,
   useAgentPolling,
   useCoordinatedPolling,

--- a/tui/src/hooks/useDemons.ts
+++ b/tui/src/hooks/useDemons.ts
@@ -1,0 +1,157 @@
+/**
+ * useDemons hook - Fetch and poll demon status
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import type { Demon, BcResult } from '../types';
+import { getDemons, getDemonLogs, enableDemon, disableDemon, runDemon } from '../services/bc';
+import type { DemonRunLog } from '../types';
+
+export interface UseDemonsOptions {
+  /** Polling interval in ms (default: 5000) */
+  pollInterval?: number;
+  /** Whether to poll automatically (default: true) */
+  autoPoll?: boolean;
+}
+
+export interface UseDemonsResult extends BcResult<Demon[]> {
+  /** Total number of demons */
+  total: number;
+  /** Number of enabled demons */
+  enabled: number;
+  /** Manually refresh demons */
+  refresh: () => Promise<void>;
+  /** Enable a demon */
+  enable: (name: string) => Promise<void>;
+  /** Disable a demon */
+  disable: (name: string) => Promise<void>;
+  /** Run a demon manually */
+  run: (name: string) => Promise<void>;
+}
+
+/**
+ * Hook to fetch and optionally poll demon status
+ * @param options - Configuration options
+ * @returns Demon list with metadata and loading state
+ */
+export function useDemons(options: UseDemonsOptions = {}): UseDemonsResult {
+  const { pollInterval = 5000, autoPoll = true } = options;
+
+  const [data, setData] = useState<Demon[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [enabled, setEnabled] = useState(0);
+
+  const fetchDemons = useCallback(async () => {
+    try {
+      const demons = await getDemons();
+      setData(demons);
+      setTotal(demons.length);
+      setEnabled(demons.filter((d) => d.enabled).length);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch demons');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleEnable = useCallback(async (name: string) => {
+    await enableDemon(name);
+    await fetchDemons();
+  }, [fetchDemons]);
+
+  const handleDisable = useCallback(async (name: string) => {
+    await disableDemon(name);
+    await fetchDemons();
+  }, [fetchDemons]);
+
+  const handleRun = useCallback(async (name: string) => {
+    await runDemon(name);
+    await fetchDemons();
+  }, [fetchDemons]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchDemons();
+  }, [fetchDemons]);
+
+  // Polling
+  useEffect(() => {
+    if (!autoPoll) return;
+
+    const interval = setInterval(fetchDemons, pollInterval);
+    return () => clearInterval(interval);
+  }, [autoPoll, pollInterval, fetchDemons]);
+
+  return {
+    data,
+    error,
+    loading,
+    total,
+    enabled,
+    refresh: fetchDemons,
+    enable: handleEnable,
+    disable: handleDisable,
+    run: handleRun,
+  };
+}
+
+export interface UseDemonLogsOptions {
+  /** Number of recent entries to fetch (default: 10) */
+  limit?: number;
+  /** Polling interval in ms (default: 5000) */
+  pollInterval?: number;
+  /** Whether to poll automatically (default: false) */
+  autoPoll?: boolean;
+}
+
+export interface UseDemonLogsResult extends BcResult<DemonRunLog[]> {
+  /** Manually refresh logs */
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Hook to fetch run logs for a specific demon
+ */
+export function useDemonLogs(
+  name: string,
+  options: UseDemonLogsOptions = {}
+): UseDemonLogsResult {
+  const { limit = 10, pollInterval = 5000, autoPoll = false } = options;
+
+  const [data, setData] = useState<DemonRunLog[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchLogs = useCallback(async () => {
+    try {
+      const logs = await getDemonLogs(name, limit);
+      setData(logs);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch demon logs');
+    } finally {
+      setLoading(false);
+    }
+  }, [name, limit]);
+
+  useEffect(() => {
+    fetchLogs();
+  }, [fetchLogs]);
+
+  useEffect(() => {
+    if (!autoPoll) return;
+
+    const interval = setInterval(fetchLogs, pollInterval);
+    return () => clearInterval(interval);
+  }, [autoPoll, pollInterval, fetchLogs]);
+
+  return {
+    data,
+    error,
+    loading,
+    refresh: fetchLogs,
+  };
+}

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -9,6 +9,8 @@ import type {
   ChannelsResponse,
   ChannelHistory,
   CostSummary,
+  Demon,
+  DemonRunLog,
 } from '../types';
 
 /**
@@ -133,4 +135,72 @@ export async function reportState(
   message: string
 ): Promise<void> {
   await execBc(['report', state, message]);
+}
+
+/**
+ * Get list of demons (scheduled tasks)
+ */
+export async function getDemons(): Promise<Demon[]> {
+  try {
+    return await execBcJson<Demon[]>(['demon', 'list']);
+  } catch {
+    // If no demons exist, bc returns text not JSON
+    return [];
+  }
+}
+
+/**
+ * Get demon details
+ * @param name - Demon name
+ */
+export async function getDemon(name: string): Promise<Demon | null> {
+  try {
+    return await execBcJson<Demon>(['demon', 'show', name]);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get demon run logs
+ * @param name - Demon name
+ * @param tail - Number of recent entries (optional)
+ */
+export async function getDemonLogs(
+  name: string,
+  tail?: number
+): Promise<DemonRunLog[]> {
+  try {
+    const args = ['demon', 'logs', name];
+    if (tail) {
+      args.push('--tail', String(tail));
+    }
+    return await execBcJson<DemonRunLog[]>(args);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Enable a demon
+ * @param name - Demon name
+ */
+export async function enableDemon(name: string): Promise<void> {
+  await execBc(['demon', 'enable', name]);
+}
+
+/**
+ * Disable a demon
+ * @param name - Demon name
+ */
+export async function disableDemon(name: string): Promise<void> {
+  await execBc(['demon', 'disable', name]);
+}
+
+/**
+ * Manually run a demon
+ * @param name - Demon name
+ */
+export async function runDemon(name: string): Promise<void> {
+  await execBc(['demon', 'run', name]);
 }

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -111,3 +111,25 @@ export interface BcEvent {
   message: string;
   data?: Record<string, unknown>;
 }
+
+// Demon (scheduled task) types
+export interface Demon {
+  name: string;
+  schedule: string;
+  command: string;
+  description?: string;
+  owner?: string;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+  last_run?: string;
+  next_run?: string;
+  run_count: number;
+}
+
+export interface DemonRunLog {
+  timestamp: string;
+  duration_ms: number;
+  exit_code: number;
+  success: boolean;
+}

--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -1,0 +1,248 @@
+/**
+ * DemonsView - Scheduled tasks list view
+ * Issue #554 - Demons list view
+ */
+
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { useDemons } from '../hooks/useDemons';
+import { StatusBadge } from '../components/StatusBadge';
+import { Footer } from '../components/Footer';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { ErrorDisplay } from '../components/ErrorDisplay';
+import type { Demon } from '../types';
+
+export interface DemonsViewProps {
+  /** Callback when exiting the view */
+  onExit?: () => void;
+  /** Disable input handling (useful for testing) */
+  disableInput?: boolean;
+}
+
+/**
+ * Format cron schedule to human-readable string
+ */
+function formatSchedule(schedule: string): string {
+  // Common patterns
+  if (schedule === '* * * * *') return 'every minute';
+  if (schedule === '0 * * * *') return 'every hour';
+  if (schedule.startsWith('*/')) {
+    const match = schedule.match(/^\*\/(\d+) \* \* \* \*$/);
+    if (match) return `every ${match[1]} min`;
+  }
+  if (schedule.match(/^0 \d+ \* \* \*$/)) {
+    const hour = schedule.split(' ')[1];
+    return `daily at ${hour}:00`;
+  }
+  return schedule;
+}
+
+/**
+ * Format relative time for last/next run
+ */
+function formatRelativeTime(timestamp?: string): string {
+  if (!timestamp) return '-';
+  try {
+    const date = new Date(timestamp);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(Math.abs(diffMs) / 60000);
+    const diffHours = Math.floor(diffMins / 60);
+    const diffDays = Math.floor(diffHours / 24);
+
+    const prefix = diffMs < 0 ? 'in ' : '';
+    const suffix = diffMs >= 0 ? ' ago' : '';
+
+    if (diffMins < 1) return 'now';
+    if (diffMins < 60) return `${prefix}${diffMins}m${suffix}`;
+    if (diffHours < 24) return `${prefix}${diffHours}h${suffix}`;
+    return `${prefix}${diffDays}d${suffix}`;
+  } catch {
+    return timestamp;
+  }
+}
+
+/**
+ * DemonsView - Display list of scheduled tasks (demons)
+ *
+ * Features:
+ * - List all configured demons
+ * - Show schedule, status, run history
+ * - Keyboard navigation (j/k, e/d to enable/disable, r to run)
+ */
+export function DemonsView({
+  onExit,
+  disableInput = false,
+}: DemonsViewProps): React.ReactElement {
+  const { data: demons, loading, error, total, enabled, refresh, enable, disable, run } = useDemons();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  useInput(
+    (input, key) => {
+      if (!demons || demons.length === 0) return;
+
+      // Navigation
+      if (input === 'j' || key.downArrow) {
+        setSelectedIndex((prev) => Math.min(prev + 1, demons.length - 1));
+      }
+      if (input === 'k' || key.upArrow) {
+        setSelectedIndex((prev) => Math.max(prev - 1, 0));
+      }
+
+      // Actions
+      if (input === 'r') {
+        refresh();
+      }
+      if (input === 'q' && onExit) {
+        onExit();
+      }
+
+      // Demon-specific actions
+      const selectedDemon = demons[selectedIndex];
+      if (selectedDemon) {
+        if (input === 'e') {
+          // Enable demon
+          enable(selectedDemon.name).catch(() => {});
+        }
+        if (input === 'd') {
+          // Disable demon
+          disable(selectedDemon.name).catch(() => {});
+        }
+        if (input === 'x') {
+          // Execute demon
+          run(selectedDemon.name).catch(() => {});
+        }
+      }
+    },
+    { isActive: !disableInput }
+  );
+
+  if (error) {
+    return <ErrorDisplay error={error} onRetry={refresh} />;
+  }
+
+  if (loading && !demons) {
+    return <LoadingIndicator message="Loading demons..." />;
+  }
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      {/* Header */}
+      <Box marginBottom={1}>
+        <Text bold color="magenta">Demons</Text>
+        <Text> · </Text>
+        <Text dimColor>{total} total</Text>
+        <Text dimColor> · </Text>
+        <Text color={enabled > 0 ? 'green' : 'gray'}>{enabled} enabled</Text>
+      </Box>
+
+      {/* Demon list */}
+      {demons && demons.length > 0 ? (
+        <Box flexDirection="column">
+          {/* Header row */}
+          <Box marginBottom={1}>
+            <Box width={3}><Text> </Text></Box>
+            <Box width={18}><Text bold dimColor>NAME</Text></Box>
+            <Box width={16}><Text bold dimColor>SCHEDULE</Text></Box>
+            <Box width={10}><Text bold dimColor>STATUS</Text></Box>
+            <Box width={10}><Text bold dimColor>RUNS</Text></Box>
+            <Box width={12}><Text bold dimColor>LAST RUN</Text></Box>
+            <Box width={12}><Text bold dimColor>NEXT RUN</Text></Box>
+          </Box>
+
+          {/* Demon rows */}
+          {demons.map((demon, index) => (
+            <DemonRow
+              key={demon.name}
+              demon={demon}
+              selected={index === selectedIndex}
+            />
+          ))}
+        </Box>
+      ) : (
+        <Box flexDirection="column" paddingY={2}>
+          <Text dimColor>No demons configured</Text>
+          <Text dimColor>Create one with: bc demon create {'<name>'} --schedule {'\'<cron>\''} --cmd {'\'<command>\''}</Text>
+        </Box>
+      )}
+
+      {/* Selected demon details */}
+      {demons && demons.length > 0 && demons[selectedIndex] && (
+        <Box marginTop={1} borderStyle="single" borderColor="gray" padding={1} flexDirection="column">
+          <Text bold>{demons[selectedIndex].name}</Text>
+          <Box marginTop={1}>
+            <Text dimColor>Command: </Text>
+            <Text>{demons[selectedIndex].command}</Text>
+          </Box>
+          {demons[selectedIndex].description && (
+            <Box>
+              <Text dimColor>Description: </Text>
+              <Text>{demons[selectedIndex].description}</Text>
+            </Box>
+          )}
+          {demons[selectedIndex].owner && (
+            <Box>
+              <Text dimColor>Owner: </Text>
+              <Text>{demons[selectedIndex].owner}</Text>
+            </Box>
+          )}
+        </Box>
+      )}
+
+      {/* Footer */}
+      <Footer
+        hints={[
+          { key: 'j/k', label: 'navigate' },
+          { key: 'e', label: 'enable' },
+          { key: 'd', label: 'disable' },
+          { key: 'x', label: 'run' },
+          { key: 'r', label: 'refresh' },
+          { key: 'q', label: 'back' },
+        ]}
+      />
+    </Box>
+  );
+}
+
+interface DemonRowProps {
+  demon: Demon;
+  selected: boolean;
+}
+
+function DemonRow({ demon, selected }: DemonRowProps): React.ReactElement {
+  const statusText = demon.enabled ? 'enabled' : 'disabled';
+
+  return (
+    <Box>
+      <Box width={3}>
+        <Text color={selected ? 'cyan' : undefined}>
+          {selected ? '▸ ' : '  '}
+        </Text>
+      </Box>
+      <Box width={18}>
+        <Text color={selected ? 'cyan' : undefined} bold={selected}>
+          {demon.name.length > 16 ? demon.name.slice(0, 14) + '..' : demon.name}
+        </Text>
+      </Box>
+      <Box width={16}>
+        <Text dimColor>{formatSchedule(demon.schedule)}</Text>
+      </Box>
+      <Box width={10}>
+        <StatusBadge state={statusText} showIcon={false} />
+      </Box>
+      <Box width={10}>
+        <Text>{demon.run_count}</Text>
+      </Box>
+      <Box width={12}>
+        <Text dimColor>{formatRelativeTime(demon.last_run)}</Text>
+      </Box>
+      <Box width={12}>
+        <Text color={demon.enabled ? 'yellow' : 'gray'}>
+          {formatRelativeTime(demon.next_run)}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+export default DemonsView;

--- a/tui/src/views/index.ts
+++ b/tui/src/views/index.ts
@@ -5,3 +5,4 @@ export { Dashboard } from './Dashboard';
 export { AgentDetailView } from './AgentDetailView';
 export { MessageHistory } from './MessageHistory';
 export { CostDashboard } from './CostDashboard';
+export { DemonsView } from './DemonsView';


### PR DESCRIPTION
## Summary
- Add DemonsView component to display scheduled tasks (demons) with table layout
- Add useDemons and useDemonLogs hooks for fetching and managing demons
- Add demon service functions (enable/disable/run) to bc.ts
- Support keyboard navigation (j/k), enable/disable (e/d), manual run (x), and refresh (r)

## Test plan
- [ ] Run `make build-tui` - should compile without errors
- [ ] Run `make test-tui` - all tests should pass
- [ ] Verify DemonsView renders demon list with proper formatting
- [ ] Test keyboard navigation (j/k) and actions (e/d/x/r)

Fixes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)