### PR TITLE
feat(tui): Add TeamsView for team management

### DIFF
--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -82,3 +82,9 @@ export {
   type UseMentionAutocompleteOptions,
   type UseMentionAutocompleteResult,
 } from './useMentionAutocomplete';
+
+export {
+  useTeams,
+  type UseTeamsOptions,
+  type UseTeamsResult,
+} from './useTeams';

--- a/tui/src/hooks/useTeams.ts
+++ b/tui/src/hooks/useTeams.ts
@@ -1,0 +1,98 @@
+/**
+ * useTeams hook - Fetch and manage teams data
+ * Issue #556 - Teams view
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import type { Team, BcResult } from '../types';
+import { getTeams, addTeamMember, removeTeamMember } from '../services/bc.js';
+
+export interface UseTeamsOptions {
+  /** Polling interval in ms (default: 10000) */
+  pollInterval?: number;
+  /** Whether to poll automatically (default: true) */
+  autoPoll?: boolean;
+}
+
+export interface UseTeamsResult extends BcResult<Team[]> {
+  /** Manually refresh team data */
+  refresh: () => Promise<void>;
+  /** Add member to a team */
+  addMember: (teamName: string, agentName: string) => Promise<void>;
+  /** Remove member from a team */
+  removeMember: (teamName: string, agentName: string) => Promise<void>;
+}
+
+/**
+ * Hook to fetch and manage teams data
+ */
+export function useTeams(options: UseTeamsOptions = {}): UseTeamsResult {
+  const { pollInterval = 10000, autoPoll = true } = options;
+
+  const [data, setData] = useState<Team[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const fetchTeams = useCallback(async () => {
+    try {
+      const response = await getTeams();
+      setData(response.teams || []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch teams');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchTeams();
+  }, [fetchTeams]);
+
+  // Polling
+  useEffect(() => {
+    if (!autoPoll) return;
+    const interval = setInterval(fetchTeams, pollInterval);
+    return () => clearInterval(interval);
+  }, [autoPoll, pollInterval, fetchTeams]);
+
+  const addMember = useCallback(
+    async (teamName: string, agentName: string) => {
+      try {
+        await addTeamMember(teamName, agentName);
+        // Refresh data after adding member
+        await fetchTeams();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to add member');
+        throw err;
+      }
+    },
+    [fetchTeams]
+  );
+
+  const removeMember = useCallback(
+    async (teamName: string, agentName: string) => {
+      try {
+        await removeTeamMember(teamName, agentName);
+        // Refresh data after removing member
+        await fetchTeams();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to remove member');
+        throw err;
+      }
+    },
+    [fetchTeams]
+  );
+
+  return {
+    data,
+    error,
+    loading,
+    refresh: fetchTeams,
+    addMember,
+    removeMember,
+  };
+}
+
+export default useTeams;

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -12,6 +12,7 @@ import type {
   Demon,
   DemonRunLog,
   ProcessListResponse,
+  TeamsResponse,
 } from '../types';
 
 /**
@@ -23,7 +24,7 @@ import type {
 export async function execBc(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     // Always add --json flag if not present and command supports it
-    const jsonCommands = ['status', 'stats', 'channel', 'cost', 'logs', 'agent', 'process', 'demon'];
+    const jsonCommands = ['status', 'stats', 'channel', 'cost', 'logs', 'agent', 'process', 'demon', 'team'];
     const hasJsonFlag = args.includes('--json');
     const command = args[0];
 
@@ -228,4 +229,35 @@ export async function getProcessLogs(
   }
   const response = await execBcJson<{ name: string; lines: string[] }>(args);
   return response.lines;
+}
+
+/**
+ * Get list of teams
+ */
+export async function getTeams(): Promise<TeamsResponse> {
+  return execBcJson<TeamsResponse>(['team', 'list']);
+}
+
+/**
+ * Add a member to a team
+ * @param teamName - Name of team
+ * @param agentName - Name of agent to add
+ */
+export async function addTeamMember(
+  teamName: string,
+  agentName: string
+): Promise<void> {
+  await execBc(['team', 'add', teamName, agentName]);
+}
+
+/**
+ * Remove a member from a team
+ * @param teamName - Name of team
+ * @param agentName - Name of agent to remove
+ */
+export async function removeTeamMember(
+  teamName: string,
+  agentName: string
+): Promise<void> {
+  await execBc(['team', 'remove', teamName, agentName]);
 }

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -157,3 +157,18 @@ export interface ProcessLogsResponse {
   name: string;
   lines: string[];
 }
+
+// Team types
+export interface Team {
+  name: string;
+  description?: string;
+  members: string[];
+  lead?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+// Response from bc team list --json
+export interface TeamsResponse {
+  teams: Team[];
+}

--- a/tui/src/views/TeamsView.tsx
+++ b/tui/src/views/TeamsView.tsx
@@ -1,0 +1,240 @@
+import { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { Panel } from '../components/Panel.js';
+import { DataTable } from '../components/DataTable.js';
+import { Footer } from '../components/Footer.js';
+import { LoadingIndicator } from '../components/LoadingIndicator.js';
+import { ErrorDisplay } from '../components/ErrorDisplay.js';
+import { useTeams } from '../hooks';
+import type { Team } from '../types';
+
+interface TeamsViewProps {
+  onBack?: () => void;
+}
+
+// Extended team type for DataTable compatibility
+interface TeamRow extends Record<string, unknown> {
+  name: string;
+  members: string[];
+  lead: string;
+  description: string;
+}
+
+/**
+ * TeamsView - Display and manage teams
+ * Issue #556 - Teams view
+ */
+export function TeamsView({ onBack }: TeamsViewProps) {
+  const { data: teams, loading, error, refresh } = useTeams();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [expandedTeam, setExpandedTeam] = useState<string | null>(null);
+
+  const teamList = teams ?? [];
+  const teamCount = teamList.length;
+
+  // Keyboard navigation
+  useInput((input, key) => {
+    // Navigation
+    if (key.upArrow || input === 'k') {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+    }
+    if (key.downArrow || input === 'j') {
+      setSelectedIndex((i) => Math.min(teamCount - 1, i + 1));
+    }
+    if (input === 'g') {
+      setSelectedIndex(0);
+    }
+    if (input === 'G') {
+      setSelectedIndex(Math.max(0, teamCount - 1));
+    }
+
+    // Actions
+    if (key.return || input === ' ') {
+      // Toggle expanded view
+      const team = teamList[selectedIndex];
+      if (team) {
+        setExpandedTeam(expandedTeam === team.name ? null : team.name);
+      }
+    }
+    if (input === 'r') {
+      refresh();
+    }
+    if (input === 'q' || key.escape) {
+      onBack?.();
+    }
+  });
+
+  if (error) {
+    return <ErrorDisplay error={error} onRetry={refresh} />;
+  }
+
+  if (loading && !teams) {
+    return <LoadingIndicator message="Loading teams..." />;
+  }
+
+  // Convert to TeamRow format for DataTable
+  const teamRows: TeamRow[] = teamList.map((t) => ({
+    name: t.name,
+    members: t.members || [],
+    lead: t.lead || '',
+    description: t.description || '',
+  }));
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      {/* Header */}
+      <Box marginBottom={1}>
+        <Text bold color="blue">
+          Teams
+        </Text>
+        <Text dimColor> ({teamCount})</Text>
+        {loading && <Text color="yellow"> (refreshing...)</Text>}
+      </Box>
+
+      {/* Teams List */}
+      <Panel title="Team List">
+        {teamCount === 0 ? (
+          <Box flexDirection="column">
+            <Text dimColor>No teams configured</Text>
+            <Text dimColor>Create a team with: bc team create {'<name>'}</Text>
+          </Box>
+        ) : (
+          <DataTable<TeamRow>
+            columns={[
+              {
+                key: 'name',
+                header: 'TEAM',
+                width: 20,
+              },
+              {
+                key: 'members',
+                header: 'MEMBERS',
+                width: 10,
+                render: (value) => (
+                  <Text>{(value as string[])?.length ?? 0}</Text>
+                ),
+              },
+              {
+                key: 'lead',
+                header: 'LEAD',
+                width: 15,
+                render: (value) => (
+                  <Text color="green">{(value as string) || '-'}</Text>
+                ),
+              },
+              {
+                key: 'description',
+                header: 'DESCRIPTION',
+                render: (value) => (
+                  <Text dimColor>{truncate((value as string) || '-', 30)}</Text>
+                ),
+              },
+            ]}
+            data={teamRows}
+            selectedIndex={selectedIndex}
+          />
+        )}
+      </Panel>
+
+      {/* Expanded Team Details */}
+      {expandedTeam && (
+        <TeamDetails team={teamList.find((t) => t.name === expandedTeam)} />
+      )}
+
+      {/* Footer with keyboard hints */}
+      <Footer
+        hints={[
+          { key: 'j/k', label: 'navigate' },
+          { key: 'Enter', label: 'expand' },
+          { key: 'r', label: 'refresh' },
+          { key: 'q', label: 'back' },
+        ]}
+      />
+    </Box>
+  );
+}
+
+interface TeamDetailsProps {
+  team?: Team;
+}
+
+function TeamDetails({ team }: TeamDetailsProps) {
+  if (!team) return null;
+
+  return (
+    <Panel title={`Team: ${team.name}`}>
+      <Box flexDirection="column">
+        {team.description && (
+          <Box marginBottom={1}>
+            <Text dimColor>Description: </Text>
+            <Text>{team.description}</Text>
+          </Box>
+        )}
+
+        {team.lead && (
+          <Box>
+            <Text dimColor>Lead: </Text>
+            <Text color="green" bold>
+              {team.lead}
+            </Text>
+          </Box>
+        )}
+
+        <Box marginTop={1}>
+          <Text dimColor>Members ({team.members?.length ?? 0}):</Text>
+        </Box>
+
+        {team.members && team.members.length > 0 ? (
+          <Box flexDirection="column" marginLeft={2}>
+            {team.members.map((member) => (
+              <Box key={member}>
+                <Text color={member === team.lead ? 'green' : 'cyan'}>
+                  {member === team.lead ? '★ ' : '• '}
+                  {member}
+                </Text>
+              </Box>
+            ))}
+          </Box>
+        ) : (
+          <Box marginLeft={2}>
+            <Text dimColor>No members</Text>
+          </Box>
+        )}
+
+        <Box marginTop={1}>
+          <Text dimColor>
+            Created: {formatDate(team.created_at)} · Updated:{' '}
+            {formatDate(team.updated_at)}
+          </Text>
+        </Box>
+      </Box>
+    </Panel>
+  );
+}
+
+/**
+ * Truncate string to max length
+ */
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 1) + '…';
+}
+
+/**
+ * Format ISO date string
+ */
+function formatDate(isoString: string | undefined): string {
+  if (!isoString) return '-';
+  try {
+    const date = new Date(isoString);
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  } catch {
+    return '-';
+  }
+}
+
+export default TeamsView;

--- a/tui/src/views/index.ts
+++ b/tui/src/views/index.ts
@@ -7,3 +7,4 @@ export { MessageHistory } from './MessageHistory';
 export { CostDashboard } from './CostDashboard';
 export { DemonsView } from './DemonsView';
 export { ProcessesView } from './ProcessesView';
+export { TeamsView } from './TeamsView';


### PR DESCRIPTION
## Summary
- Implements TeamsView component displaying all teams with members
- Team list shows name, member count, lead, and description
- Expandable team details panel with full member list
- Vim-style keyboard navigation (j/k/g/G)
- Enter/Space to toggle team details
- useTeams hook for data fetching with auto-refresh
- Service functions: getTeams, addTeamMember, removeTeamMember
- Team type definitions in types/index.ts

## Test plan
- [ ] TypeScript compiles without errors (verified locally)
- [ ] View displays teams list correctly
- [ ] Keyboard navigation works (j/k to move, Enter to expand)
- [ ] Team details panel shows members with lead highlighted
- [ ] Empty state shows appropriate message
- [ ] Auto-refresh updates data

Fixes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)