### PR TITLE
feat(tui): Add @mention autocomplete support

### DIFF
--- a/tui/src/components/MentionAutocomplete.tsx
+++ b/tui/src/components/MentionAutocomplete.tsx
@@ -1,0 +1,120 @@
+/**
+ * MentionAutocomplete - Dropdown for @mention suggestions
+ *
+ * Shows filtered list of agent names when typing @
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import type { MentionSuggestion } from '../hooks/useMentionAutocomplete';
+
+export interface MentionAutocompleteProps {
+  /** List of filtered suggestions */
+  suggestions: MentionSuggestion[];
+  /** Currently selected index */
+  selectedIndex: number;
+  /** Whether the autocomplete is visible */
+  visible: boolean;
+  /** The query being typed (for highlighting) */
+  query?: string;
+}
+
+/**
+ * Get color for agent state
+ */
+function getStateColor(state?: string): string | undefined {
+  switch (state) {
+    case 'working':
+      return 'green';
+    case 'idle':
+      return 'yellow';
+    case 'stuck':
+      return 'red';
+    case 'error':
+      return 'red';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Get icon for role
+ */
+function getRoleIcon(role?: string): string {
+  switch (role) {
+    case 'broadcast':
+      return '@';
+    case 'root':
+      return '#';
+    case 'manager':
+      return '*';
+    case 'tech-lead':
+      return '+';
+    case 'engineer':
+      return '-';
+    default:
+      return ' ';
+  }
+}
+
+export const MentionAutocomplete: React.FC<MentionAutocompleteProps> = ({
+  suggestions,
+  selectedIndex,
+  visible,
+  query = '',
+}) => {
+  if (!visible || suggestions.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="cyan"
+      paddingX={1}
+      marginBottom={1}
+    >
+      <Box marginBottom={1}>
+        <Text color="cyan" bold>
+          @{query}
+        </Text>
+        <Text color="gray"> - Tab to complete</Text>
+      </Box>
+
+      {suggestions.map((suggestion, index) => {
+        const isSelected = index === selectedIndex;
+        const icon = getRoleIcon(suggestion.role);
+        const stateColor = getStateColor(suggestion.state);
+
+        return (
+          <Box key={suggestion.name}>
+            <Text
+              color={isSelected ? 'cyan' : undefined}
+              bold={isSelected}
+              inverse={isSelected}
+            >
+              {isSelected ? '> ' : '  '}
+              <Text>{icon} </Text>
+              <Text bold={isSelected}>@{suggestion.name}</Text>
+              {suggestion.role && suggestion.role !== 'broadcast' && (
+                <Text color="gray"> ({suggestion.role})</Text>
+              )}
+              {suggestion.state && (
+                <Text color={stateColor}> [{suggestion.state}]</Text>
+              )}
+            </Text>
+          </Box>
+        );
+      })}
+
+      <Box marginTop={1}>
+        <Text color="gray" dimColor>
+          ↑/↓: select | Tab: complete | Esc: close
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default MentionAutocomplete;

--- a/tui/src/components/MessageInput.tsx
+++ b/tui/src/components/MessageInput.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
 import TextInput from 'ink-text-input';
+import { MentionAutocomplete } from './MentionAutocomplete';
+import { useMentionAutocomplete } from '../hooks/useMentionAutocomplete';
 
 interface MessageInputProps {
   /** Placeholder text when input is empty */
@@ -16,11 +18,16 @@ interface MessageInputProps {
 }
 
 /**
- * Message input component with keyboard mode toggle.
+ * Message input component with keyboard mode toggle and @mention autocomplete.
  *
  * Modes:
  * - Navigation mode (default): j/k navigation, i to enter input mode
  * - Input mode: Type message, Enter to submit, Escape to exit
+ *
+ * Features:
+ * - @mention autocomplete: Type @ to see agent suggestions
+ * - Tab to complete selected mention
+ * - Up/Down arrows to navigate suggestions
  */
 export const MessageInput: React.FC<MessageInputProps> = ({
   placeholder = 'Type a message...',
@@ -32,6 +39,12 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const [value, setValue] = useState('');
   const [isInputMode, setIsInputMode] = useState(false);
 
+  // Mention autocomplete
+  const autocomplete = useMentionAutocomplete({
+    input: value,
+    cursorPosition: value.length,
+  });
+
   const enterInputMode = useCallback(() => {
     if (!disabled) {
       setIsInputMode(true);
@@ -42,22 +55,46 @@ export const MessageInput: React.FC<MessageInputProps> = ({
   const exitInputMode = useCallback(() => {
     setIsInputMode(false);
     onModeChange?.(false);
-  }, [onModeChange]);
+    autocomplete.reset();
+  }, [onModeChange, autocomplete]);
 
   const handleSubmit = useCallback((text: string) => {
     if (text.trim()) {
       onSubmit?.(text.trim());
       setValue('');
+      autocomplete.reset();
     }
     // Stay in input mode after submit for quick follow-up messages
-  }, [onSubmit]);
+  }, [onSubmit, autocomplete]);
 
   // Handle keyboard input based on mode
   useInput((input, key) => {
     if (isInputMode) {
+      // Handle autocomplete navigation when active
+      if (autocomplete.isActive) {
+        if (key.upArrow) {
+          autocomplete.moveUp();
+          return;
+        }
+        if (key.downArrow) {
+          autocomplete.moveDown();
+          return;
+        }
+        if (key.tab) {
+          // Complete the mention
+          const completed = autocomplete.complete();
+          setValue(completed);
+          return;
+        }
+      }
+
       // In input mode, Escape exits
       if (key.escape) {
-        exitInputMode();
+        if (autocomplete.isActive) {
+          autocomplete.reset();
+        } else {
+          exitInputMode();
+        }
       }
     } else {
       // In navigation mode, 'i' or Enter enters input mode
@@ -77,6 +114,16 @@ export const MessageInput: React.FC<MessageInputProps> = ({
 
   return (
     <Box flexDirection="column">
+      {/* Mention autocomplete dropdown */}
+      {isInputMode && (
+        <MentionAutocomplete
+          suggestions={autocomplete.suggestions}
+          selectedIndex={autocomplete.selectedIndex}
+          visible={autocomplete.isActive}
+          query={autocomplete.query}
+        />
+      )}
+
       {/* Input area */}
       <Box borderStyle="single" borderColor={isInputMode ? 'green' : 'gray'} paddingX={1}>
         {isInputMode ? (
@@ -101,7 +148,9 @@ export const MessageInput: React.FC<MessageInputProps> = ({
       <Box>
         <Text color="gray" dimColor>
           {isInputMode
-            ? 'Type message, Enter to send, Escape to exit'
+            ? autocomplete.isActive
+              ? '↑/↓: select mention | Tab: complete | Esc: close'
+              : 'Type message, Enter to send, @ for mentions, Escape to exit'
             : 'i: input mode | j/k: scroll'}
         </Text>
       </Box>

--- a/tui/src/components/index.ts
+++ b/tui/src/components/index.ts
@@ -39,3 +39,6 @@ export type { MentionTextProps } from './MentionText';
 
 export { ChatMessage } from './ChatMessage';
 export type { ChatMessageProps } from './ChatMessage';
+
+export { MentionAutocomplete } from './MentionAutocomplete';
+export type { MentionAutocompleteProps } from './MentionAutocomplete';

--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -75,3 +75,10 @@ export {
   type UseProcessLogsOptions,
   type UseProcessLogsResult,
 } from './useProcesses';
+
+export {
+  useMentionAutocomplete,
+  type MentionSuggestion,
+  type UseMentionAutocompleteOptions,
+  type UseMentionAutocompleteResult,
+} from './useMentionAutocomplete';

--- a/tui/src/hooks/useMentionAutocomplete.ts
+++ b/tui/src/hooks/useMentionAutocomplete.ts
@@ -1,0 +1,181 @@
+/**
+ * useMentionAutocomplete - Hook for @mention autocomplete
+ *
+ * Provides:
+ * - Detection of @ trigger in input
+ * - Filtered list of matching agent names
+ * - Navigation through suggestions
+ */
+
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useAgents } from './useAgents';
+
+export interface MentionSuggestion {
+  name: string;
+  role?: string;
+  state?: string;
+}
+
+export interface UseMentionAutocompleteOptions {
+  /** Current input text */
+  input: string;
+  /** Cursor position in input */
+  cursorPosition?: number;
+  /** Maximum suggestions to show */
+  maxSuggestions?: number;
+}
+
+export interface UseMentionAutocompleteResult {
+  /** Whether autocomplete should be shown */
+  isActive: boolean;
+  /** Filtered suggestions */
+  suggestions: MentionSuggestion[];
+  /** Currently selected suggestion index */
+  selectedIndex: number;
+  /** The partial mention being typed (without @) */
+  query: string;
+  /** Start position of the mention in input */
+  mentionStart: number;
+  /** Move selection up */
+  moveUp: () => void;
+  /** Move selection down */
+  moveDown: () => void;
+  /** Get selected suggestion */
+  getSelected: () => MentionSuggestion | null;
+  /** Complete the mention with selected suggestion */
+  complete: () => string;
+  /** Reset autocomplete state */
+  reset: () => void;
+}
+
+/**
+ * Extract the partial mention being typed at cursor position
+ */
+function extractMentionQuery(
+  input: string,
+  cursorPosition: number
+): { query: string; start: number } | null {
+  // Look backwards from cursor for @
+  const textBeforeCursor = input.slice(0, cursorPosition);
+  const lastAtIndex = textBeforeCursor.lastIndexOf('@');
+
+  if (lastAtIndex === -1) {
+    return null;
+  }
+
+  // Check if there's a space between @ and cursor (mention complete)
+  const textAfterAt = textBeforeCursor.slice(lastAtIndex + 1);
+  if (textAfterAt.includes(' ')) {
+    return null;
+  }
+
+  // @ at start or after space
+  if (lastAtIndex === 0 || input[lastAtIndex - 1] === ' ') {
+    return {
+      query: textAfterAt.toLowerCase(),
+      start: lastAtIndex,
+    };
+  }
+
+  return null;
+}
+
+export function useMentionAutocomplete(
+  options: UseMentionAutocompleteOptions
+): UseMentionAutocompleteResult {
+  const { input, cursorPosition = input.length, maxSuggestions = 5 } = options;
+
+  const { data: agents } = useAgents();
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Extract mention query from input
+  const mentionData = useMemo(
+    () => extractMentionQuery(input, cursorPosition),
+    [input, cursorPosition]
+  );
+
+  // Get all available names (agents + special mentions)
+  const allNames = useMemo(() => {
+    const names: MentionSuggestion[] = [
+      { name: 'all', role: 'broadcast' },
+      { name: 'everyone', role: 'broadcast' },
+    ];
+
+    if (agents) {
+      for (const agent of agents) {
+        names.push({
+          name: agent.name,
+          role: agent.role,
+          state: agent.state,
+        });
+      }
+    }
+
+    return names;
+  }, [agents]);
+
+  // Filter suggestions based on query
+  const suggestions = useMemo(() => {
+    if (!mentionData) return [];
+
+    const { query } = mentionData;
+    if (query === '') {
+      return allNames.slice(0, maxSuggestions);
+    }
+
+    return allNames
+      .filter((s) => s.name.toLowerCase().startsWith(query))
+      .slice(0, maxSuggestions);
+  }, [mentionData, allNames, maxSuggestions]);
+
+  // Reset selection when suggestions change
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [suggestions.length]);
+
+  const moveUp = useCallback(() => {
+    setSelectedIndex((i) => (i > 0 ? i - 1 : suggestions.length - 1));
+  }, [suggestions.length]);
+
+  const moveDown = useCallback(() => {
+    setSelectedIndex((i) => (i < suggestions.length - 1 ? i + 1 : 0));
+  }, [suggestions.length]);
+
+  const getSelected = useCallback((): MentionSuggestion | null => {
+    return suggestions[selectedIndex] || null;
+  }, [suggestions, selectedIndex]);
+
+  const complete = useCallback((): string => {
+    if (!mentionData || suggestions.length === 0) {
+      return input;
+    }
+
+    const selected = suggestions[selectedIndex];
+    if (!selected) return input;
+
+    const { start } = mentionData;
+    const before = input.slice(0, start);
+    const after = input.slice(cursorPosition);
+
+    return `${before}@${selected.name} ${after}`;
+  }, [mentionData, suggestions, selectedIndex, input, cursorPosition]);
+
+  const reset = useCallback(() => {
+    setSelectedIndex(0);
+  }, []);
+
+  return {
+    isActive: mentionData !== null && suggestions.length > 0,
+    suggestions,
+    selectedIndex,
+    query: mentionData?.query || '',
+    mentionStart: mentionData?.start || 0,
+    moveUp,
+    moveDown,
+    getSelected,
+    complete,
+    reset,
+  };
+}
+
+export default useMentionAutocomplete;


### PR DESCRIPTION
## Summary
Add @mention autocomplete for the message input component (Phase 3.5).

## Features
- **useMentionAutocomplete hook**: Detects @ trigger, filters agent names
- **MentionAutocomplete component**: Displays suggestions dropdown
- **MessageInput integration**: Tab to complete, arrows to navigate

## Components Added
- `tui/src/hooks/useMentionAutocomplete.ts` - Autocomplete logic
- `tui/src/components/MentionAutocomplete.tsx` - Dropdown UI

## Modified
- `tui/src/components/MessageInput.tsx` - Integrated autocomplete
- `tui/src/components/index.ts` - Added export
- `tui/src/hooks/index.ts` - Added export

## Test plan
- [x] `make build-tui` - TypeScript compiles
- [x] `make test-tui` - 15 tests pass

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)