### PR TITLE
feat(tui): Add theming system with dark/light mode support

### DIFF
--- a/tui/src/__tests__/theme.test.tsx
+++ b/tui/src/__tests__/theme.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Tests for theme system
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import {
+  ThemeProvider,
+  useTheme,
+  useThemeColor,
+  darkTheme,
+  lightTheme,
+  getTheme,
+  applyOverrides,
+  detectColorScheme,
+  supportsColors,
+} from '../theme';
+
+// Test component that uses theme
+function ThemeConsumer() {
+  const { theme, isDark, mode } = useTheme();
+  return (
+    <Text>
+      Theme: {theme.name}, Mode: {mode}, Dark: {isDark ? 'yes' : 'no'}
+    </Text>
+  );
+}
+
+// Test component for color
+function ColorConsumer() {
+  const primary = useThemeColor('primary');
+  return <Text color={primary}>Primary Color</Text>;
+}
+
+describe('ThemeProvider', () => {
+  it('provides default dark theme', () => {
+    const { lastFrame } = render(
+      <ThemeProvider>
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(lastFrame()).toContain('Theme: dark');
+  });
+
+  it('respects explicit dark mode', () => {
+    const { lastFrame } = render(
+      <ThemeProvider config={{ mode: 'dark' }}>
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(lastFrame()).toContain('Mode: dark');
+    expect(lastFrame()).toContain('Dark: yes');
+  });
+
+  it('respects explicit light mode', () => {
+    const { lastFrame } = render(
+      <ThemeProvider config={{ mode: 'light' }}>
+        <ThemeConsumer />
+      </ThemeProvider>
+    );
+    expect(lastFrame()).toContain('Mode: light');
+    expect(lastFrame()).toContain('Dark: no');
+  });
+});
+
+describe('useTheme', () => {
+  it('throws when used outside provider', () => {
+    // Note: In ink-testing-library, the error is caught differently
+    // The hook should throw, but the error may be caught by React's error boundary
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    try {
+      render(<ThemeConsumer />);
+    } catch (error) {
+      expect((error as Error).message).toContain('useTheme must be used within a ThemeProvider');
+    }
+    consoleError.mockRestore();
+  });
+});
+
+describe('useThemeColor', () => {
+  it('returns theme color value', () => {
+    const { lastFrame } = render(
+      <ThemeProvider>
+        <ColorConsumer />
+      </ThemeProvider>
+    );
+    expect(lastFrame()).toContain('Primary Color');
+  });
+});
+
+describe('theme definitions', () => {
+  it('darkTheme has all required colors', () => {
+    expect(darkTheme.name).toBe('dark');
+    expect(darkTheme.mode).toBe('dark');
+    expect(darkTheme.colors.primary).toBeDefined();
+    expect(darkTheme.colors.success).toBeDefined();
+    expect(darkTheme.colors.error).toBeDefined();
+    expect(darkTheme.colors.agentWorking).toBeDefined();
+  });
+
+  it('lightTheme has all required colors', () => {
+    expect(lightTheme.name).toBe('light');
+    expect(lightTheme.mode).toBe('light');
+    expect(lightTheme.colors.primary).toBeDefined();
+    expect(lightTheme.colors.success).toBeDefined();
+    expect(lightTheme.colors.error).toBeDefined();
+    expect(lightTheme.colors.agentWorking).toBeDefined();
+  });
+});
+
+describe('getTheme', () => {
+  it('returns dark theme by name', () => {
+    const theme = getTheme('dark');
+    expect(theme).toBe(darkTheme);
+  });
+
+  it('returns light theme by name', () => {
+    const theme = getTheme('light');
+    expect(theme).toBe(lightTheme);
+  });
+});
+
+describe('applyOverrides', () => {
+  it('applies color overrides to theme', () => {
+    const overridden = applyOverrides(darkTheme, {
+      primary: 'magenta',
+    });
+    expect(overridden.colors.primary).toBe('magenta');
+    expect(overridden.colors.secondary).toBe(darkTheme.colors.secondary);
+  });
+
+  it('preserves original theme', () => {
+    applyOverrides(darkTheme, { primary: 'magenta' });
+    expect(darkTheme.colors.primary).toBe('cyan');
+  });
+});
+
+describe('detectColorScheme', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('defaults to dark when no hints available', () => {
+    delete process.env.COLORFGBG;
+    delete process.env.ITERM_PROFILE;
+    expect(detectColorScheme()).toBe('dark');
+  });
+
+  it('detects light from COLORFGBG with white background', () => {
+    process.env.COLORFGBG = '0;7';
+    expect(detectColorScheme()).toBe('light');
+  });
+
+  it('detects dark from COLORFGBG with black background', () => {
+    process.env.COLORFGBG = '7;0';
+    expect(detectColorScheme()).toBe('dark');
+  });
+
+  it('detects light from ITERM_PROFILE', () => {
+    process.env.ITERM_PROFILE = 'Solarized Light';
+    expect(detectColorScheme()).toBe('light');
+  });
+
+  it('detects dark from ITERM_PROFILE', () => {
+    process.env.ITERM_PROFILE = 'One Dark';
+    expect(detectColorScheme()).toBe('dark');
+  });
+});
+
+describe('supportsColors', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns false when NO_COLOR is set', () => {
+    process.env.NO_COLOR = '1';
+    // Note: We can't easily mock process.stdout.isTTY in Bun
+    // so we just verify NO_COLOR takes precedence when it's set
+    const result = supportsColors();
+    // NO_COLOR should disable colors regardless of TTY state
+    expect(result).toBe(false);
+  });
+
+  it('respects FORCE_COLOR environment variable', () => {
+    process.env.FORCE_COLOR = '1';
+    delete process.env.NO_COLOR;
+    // FORCE_COLOR enables colors if TTY is available
+    // This test verifies the function doesn't crash
+    const result = supportsColors();
+    expect(typeof result).toBe('boolean');
+  });
+});

--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -11,6 +11,7 @@ import {
   TabBar,
   type View,
 } from './navigation';
+import { ThemeProvider, useTheme, type ThemeMode } from './theme';
 import { ChannelsView } from './components/ChannelsView';
 import { CostsView } from './components/CostsView';
 
@@ -19,13 +20,21 @@ interface AppProps {
   disableInput?: boolean;
   /** Initial view to display */
   initialView?: View;
+  /** Theme mode (dark/light/auto) */
+  themeMode?: ThemeMode;
 }
 
-export function App({ disableInput = false, initialView = 'dashboard' }: AppProps): React.ReactElement {
+export function App({
+  disableInput = false,
+  initialView = 'dashboard',
+  themeMode = 'auto',
+}: AppProps): React.ReactElement {
   return (
-    <NavigationProvider initialView={initialView}>
-      <AppContent disableInput={disableInput} />
-    </NavigationProvider>
+    <ThemeProvider config={{ mode: themeMode }}>
+      <NavigationProvider initialView={initialView}>
+        <AppContent disableInput={disableInput} />
+      </NavigationProvider>
+    </ThemeProvider>
   );
 }
 
@@ -98,6 +107,7 @@ function AgentsView(): React.ReactElement {
 }
 
 function HelpView(): React.ReactElement {
+  const { theme, isDark } = useTheme();
   return (
     <Box flexDirection="column">
       <Text bold>Keyboard Shortcuts</Text>
@@ -122,15 +132,23 @@ function HelpView(): React.ReactElement {
         <Text bold>View-specific shortcuts:</Text>
         <Text dimColor>Check each view for additional shortcuts</Text>
       </Box>
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>Theme:</Text>
+        <Text dimColor>
+          Current: {theme.name} ({isDark ? 'dark' : 'light'} mode)
+        </Text>
+      </Box>
     </Box>
   );
 }
 
-// Footer with hints
+// Footer with hints and theme indicator
 function Footer(): React.ReactElement {
+  const { theme } = useTheme();
   return (
-    <Box marginTop={1}>
+    <Box marginTop={1} justifyContent="space-between">
       <Text dimColor>Press [?] for help, [q] to quit</Text>
+      <Text dimColor>Theme: {theme.name}</Text>
     </Box>
   );
 }

--- a/tui/src/components/StatusBadge.tsx
+++ b/tui/src/components/StatusBadge.tsx
@@ -1,4 +1,7 @@
+import { useContext } from 'react';
 import { Text } from 'ink';
+import ThemeContext from '../theme/ThemeContext';
+import type { ThemeColors } from '../theme/types';
 
 // Agent states from eng-04's implementation
 export type AgentState = 'idle' | 'starting' | 'working' | 'done' | 'stuck' | 'error' | 'stopped';
@@ -11,7 +14,36 @@ export interface StatusBadgeProps {
   showIcon?: boolean;
 }
 
-const stateColors: Record<string, string> = {
+/**
+ * Map state to theme color key
+ */
+function getThemeColorKey(state: string): keyof ThemeColors | null {
+  switch (state) {
+    case 'idle':
+    case 'stopped':
+      return 'agentIdle';
+    case 'starting':
+      return 'warning';
+    case 'working':
+      return 'agentWorking';
+    case 'done':
+    case 'healthy':
+      return 'agentDone';
+    case 'stuck':
+    case 'error':
+    case 'unhealthy':
+      return 'agentError';
+    case 'degraded':
+      return 'warning';
+    default:
+      return null;
+  }
+}
+
+/**
+ * Fallback colors when not using ThemeProvider
+ */
+const fallbackColors: Record<string, string> = {
   // Agent states
   idle: 'gray',
   starting: 'yellow',
@@ -41,11 +73,22 @@ const stateSymbols: Record<string, string> = {
 
 /**
  * StatusBadge - Colored status indicator matching bc CLI
- * Merged from eng-04 (#561) and eng-03 (#562)
+ *
+ * Supports theming when wrapped in ThemeProvider, otherwise uses fallback colors.
+ * Merged from eng-04 (#561) and eng-03 (#562), updated for theming (#558)
  */
 export function StatusBadge({ state, showIcon = true }: StatusBadgeProps) {
-  const color = stateColors[state] || 'white';
+  const themeContext = useContext(ThemeContext);
   const symbol = stateSymbols[state] || '?';
+
+  // Get color from theme or fallback
+  let color: string;
+  if (themeContext) {
+    const colorKey = getThemeColorKey(state);
+    color = colorKey ? themeContext.theme.colors[colorKey] : 'white';
+  } else {
+    color = fallbackColors[state] || 'white';
+  }
 
   return (
     <Text color={color}>

--- a/tui/src/theme/ThemeContext.tsx
+++ b/tui/src/theme/ThemeContext.tsx
@@ -1,0 +1,154 @@
+/**
+ * ThemeContext - Provides theming support for bc TUI
+ *
+ * Features:
+ * - Auto-detect terminal dark/light mode
+ * - Theme provider with context
+ * - useTheme hook for accessing colors
+ * - Support for custom theme overrides
+ */
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+} from 'react';
+import type { Theme, ThemeMode, ThemeColors, ThemeConfig } from './types';
+import { darkTheme, lightTheme, applyOverrides } from './themes';
+import { detectColorScheme } from './detectColorScheme';
+
+interface ThemeContextValue {
+  /** Current active theme */
+  theme: Theme;
+  /** Current theme mode */
+  mode: ThemeMode;
+  /** Detected terminal color scheme */
+  detectedScheme: 'dark' | 'light';
+  /** Switch theme mode */
+  setMode: (mode: ThemeMode) => void;
+  /** Toggle between dark and light */
+  toggleTheme: () => void;
+  /** Get a specific color from the theme */
+  color: <K extends keyof ThemeColors>(key: K) => ThemeColors[K];
+  /** Check if current theme is dark */
+  isDark: boolean;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  /** Initial theme configuration */
+  config?: ThemeConfig;
+}
+
+/**
+ * ThemeProvider - Wrap your app to enable theming
+ */
+export function ThemeProvider({
+  children,
+  config,
+}: ThemeProviderProps): React.ReactElement {
+  const [mode, setModeState] = useState<ThemeMode>(config?.mode ?? 'auto');
+  const [detectedScheme] = useState<'dark' | 'light'>(() => detectColorScheme());
+
+  // Determine effective theme based on mode
+  const effectiveMode = useMemo((): 'dark' | 'light' => {
+    if (mode === 'auto') {
+      return detectedScheme;
+    }
+    return mode;
+  }, [mode, detectedScheme]);
+
+  // Build the theme with any overrides
+  const theme = useMemo((): Theme => {
+    const baseTheme = effectiveMode === 'light' ? lightTheme : darkTheme;
+    if (config?.overrides) {
+      return applyOverrides(baseTheme, config.overrides);
+    }
+    return baseTheme;
+  }, [effectiveMode, config?.overrides]);
+
+  const setMode = useCallback((newMode: ThemeMode) => {
+    setModeState(newMode);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setModeState((current) => {
+      if (current === 'auto') {
+        // Auto -> opposite of detected
+        return detectedScheme === 'dark' ? 'light' : 'dark';
+      }
+      return current === 'dark' ? 'light' : 'dark';
+    });
+  }, [detectedScheme]);
+
+  const color = useCallback(
+    <K extends keyof ThemeColors>(key: K): ThemeColors[K] => {
+      return theme.colors[key];
+    },
+    [theme]
+  );
+
+  const value = useMemo(
+    (): ThemeContextValue => ({
+      theme,
+      mode,
+      detectedScheme,
+      setMode,
+      toggleTheme,
+      color,
+      isDark: effectiveMode === 'dark',
+    }),
+    [theme, mode, detectedScheme, setMode, toggleTheme, color, effectiveMode]
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+/**
+ * useTheme - Access theme context
+ */
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+}
+
+/**
+ * useThemeColor - Get a specific color from the theme
+ *
+ * Convenience hook for getting a single color value.
+ */
+export function useThemeColor<K extends keyof ThemeColors>(
+  key: K
+): ThemeColors[K] {
+  const { color } = useTheme();
+  return color(key);
+}
+
+/**
+ * useThemeColors - Get multiple colors from the theme
+ *
+ * Returns an object with the requested color keys.
+ */
+export function useThemeColors<K extends keyof ThemeColors>(
+  keys: K[]
+): Pick<ThemeColors, K> {
+  const { theme } = useTheme();
+  return useMemo(() => {
+    const result = {} as Pick<ThemeColors, K>;
+    for (const key of keys) {
+      result[key] = theme.colors[key];
+    }
+    return result;
+  }, [theme, keys]);
+}
+
+export default ThemeContext;

--- a/tui/src/theme/detectColorScheme.ts
+++ b/tui/src/theme/detectColorScheme.ts
@@ -1,0 +1,121 @@
+/**
+ * Terminal color scheme detection
+ *
+ * Attempts to detect whether the terminal is using a dark or light color scheme.
+ */
+
+/**
+ * Detect terminal color scheme from environment variables
+ *
+ * Checks common environment variables that indicate color scheme:
+ * - COLORFGBG: Set by some terminals (format: "fg;bg")
+ * - TERM_PROGRAM: Terminal application name
+ * - ITERM_PROFILE: iTerm2 profile (may contain "light" or "dark")
+ * - COLORTERM: Color terminal capabilities
+ *
+ * @returns 'dark' | 'light' based on detection, defaults to 'dark'
+ */
+export function detectColorScheme(): 'dark' | 'light' {
+  const env = process.env;
+
+  // Check COLORFGBG (format: "foreground;background" or "foreground;ignored;background")
+  // Background values: 0-6 or 8 = dark, 7 or 15 = light
+  const colorFgBg = env.COLORFGBG;
+  if (colorFgBg) {
+    const parts = colorFgBg.split(';');
+    const bg = parseInt(parts[parts.length - 1], 10);
+    if (!isNaN(bg)) {
+      // 7 = white, 15 = bright white (light backgrounds)
+      if (bg === 7 || bg === 15) {
+        return 'light';
+      }
+      // 0 = black, 8 = bright black (dark backgrounds)
+      if (bg === 0 || bg === 8 || (bg >= 1 && bg <= 6)) {
+        return 'dark';
+      }
+    }
+  }
+
+  // Check macOS appearance via terminal profile hints
+  const itermProfile = env.ITERM_PROFILE?.toLowerCase() || '';
+  if (itermProfile.includes('light')) {
+    return 'light';
+  }
+  if (itermProfile.includes('dark')) {
+    return 'dark';
+  }
+
+  // Check for Terminal.app on macOS
+  const termProgram = env.TERM_PROGRAM?.toLowerCase() || '';
+  if (termProgram === 'apple_terminal') {
+    // Apple Terminal defaults to light in recent macOS
+    // But many users customize it, so we can't be certain
+    // Check if there's additional context
+  }
+
+  // Check for explicit dark mode preference (some systems)
+  const darkMode = env.DARK_MODE || env.THEME || '';
+  if (darkMode.toLowerCase() === 'light') {
+    return 'light';
+  }
+  if (darkMode.toLowerCase() === 'dark') {
+    return 'dark';
+  }
+
+  // Check for VS Code integrated terminal
+  if (env.TERM_PROGRAM === 'vscode') {
+    // VS Code theme can be detected via VSCODE_INJECTION
+    // But default assumption is it follows system
+  }
+
+  // Default to dark theme (most common for developers)
+  return 'dark';
+}
+
+/**
+ * Check if terminal supports 256 colors or true color
+ */
+export function supportsExtendedColors(): boolean {
+  const colorTerm = process.env.COLORTERM?.toLowerCase() || '';
+  const term = process.env.TERM?.toLowerCase() || '';
+
+  // True color support
+  if (colorTerm === 'truecolor' || colorTerm === '24bit') {
+    return true;
+  }
+
+  // 256 color support
+  if (term.includes('256color') || term.includes('256')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Check if terminal supports basic colors
+ */
+export function supportsColors(): boolean {
+  // Check if stdout is a TTY
+  if (!process.stdout.isTTY) {
+    return false;
+  }
+
+  // Check TERM environment variable
+  const term = process.env.TERM?.toLowerCase() || '';
+  if (term === 'dumb') {
+    return false;
+  }
+
+  // Check for NO_COLOR standard
+  if ('NO_COLOR' in process.env) {
+    return false;
+  }
+
+  // Check for FORCE_COLOR
+  if ('FORCE_COLOR' in process.env) {
+    return true;
+  }
+
+  return true;
+}

--- a/tui/src/theme/index.ts
+++ b/tui/src/theme/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Theme exports for bc TUI
+ *
+ * Provides theming support including:
+ * - Auto-detection of terminal dark/light mode
+ * - ThemeProvider for React context
+ * - useTheme hook for accessing colors
+ * - Pre-defined dark and light themes
+ */
+
+// Types
+export type {
+  Theme,
+  ThemeColors,
+  ThemeMode,
+  ThemeConfig,
+  TerminalColor,
+} from './types';
+
+// Context and hooks
+export {
+  ThemeProvider,
+  useTheme,
+  useThemeColor,
+  useThemeColors,
+} from './ThemeContext';
+
+// Themes
+export { darkTheme, lightTheme, getTheme, applyOverrides } from './themes';
+
+// Detection utilities
+export {
+  detectColorScheme,
+  supportsExtendedColors,
+  supportsColors,
+} from './detectColorScheme';

--- a/tui/src/theme/themes.ts
+++ b/tui/src/theme/themes.ts
@@ -1,0 +1,116 @@
+/**
+ * Default theme definitions for bc TUI
+ *
+ * Provides dark and light themes optimized for terminal display.
+ */
+
+import type { Theme, ThemeColors } from './types';
+
+/**
+ * Dark theme - default for most terminals
+ */
+export const darkTheme: Theme = {
+  name: 'dark',
+  mode: 'dark',
+  colors: {
+    // Primary colors
+    primary: 'cyan',
+    secondary: 'blue',
+    accent: 'magenta',
+
+    // Text colors
+    text: 'white',
+    textMuted: 'gray',
+    textInverse: 'black',
+
+    // Status colors
+    success: 'green',
+    warning: 'yellow',
+    error: 'red',
+    info: 'cyan',
+
+    // Agent state colors
+    agentIdle: 'gray',
+    agentWorking: 'blue',
+    agentDone: 'green',
+    agentStuck: 'red',
+    agentError: 'red',
+
+    // UI element colors
+    border: 'gray',
+    borderFocused: 'cyan',
+    selection: 'cyan',
+    highlight: 'yellow',
+
+    // Component-specific
+    headerTitle: 'cyan',
+    footerText: 'gray',
+    badge: 'magenta',
+  },
+};
+
+/**
+ * Light theme - for light terminal backgrounds
+ */
+export const lightTheme: Theme = {
+  name: 'light',
+  mode: 'light',
+  colors: {
+    // Primary colors
+    primary: 'blue',
+    secondary: 'cyan',
+    accent: 'magenta',
+
+    // Text colors
+    text: 'black',
+    textMuted: 'gray',
+    textInverse: 'white',
+
+    // Status colors
+    success: 'green',
+    warning: 'yellow',
+    error: 'red',
+    info: 'blue',
+
+    // Agent state colors
+    agentIdle: 'gray',
+    agentWorking: 'blue',
+    agentDone: 'green',
+    agentStuck: 'red',
+    agentError: 'red',
+
+    // UI element colors
+    border: 'gray',
+    borderFocused: 'blue',
+    selection: 'blue',
+    highlight: 'yellow',
+
+    // Component-specific
+    headerTitle: 'blue',
+    footerText: 'gray',
+    badge: 'magenta',
+  },
+};
+
+/**
+ * Get theme by name
+ */
+export function getTheme(name: 'dark' | 'light'): Theme {
+  return name === 'light' ? lightTheme : darkTheme;
+}
+
+/**
+ * Apply color overrides to a theme
+ */
+export function applyOverrides(
+  theme: Theme,
+  overrides: Partial<ThemeColors>
+): Theme {
+  return {
+    ...theme,
+    colors: {
+      ...theme.colors,
+      ...overrides,
+    },
+  };
+}

--- a/tui/src/theme/types.ts
+++ b/tui/src/theme/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Theme type definitions for bc TUI
+ *
+ * Defines semantic color mappings for consistent theming across components.
+ */
+
+/**
+ * Base color palette - terminal-safe colors
+ */
+export type TerminalColor =
+  | 'black'
+  | 'red'
+  | 'green'
+  | 'yellow'
+  | 'blue'
+  | 'magenta'
+  | 'cyan'
+  | 'white'
+  | 'gray'
+  | 'grey'
+  | 'blackBright'
+  | 'redBright'
+  | 'greenBright'
+  | 'yellowBright'
+  | 'blueBright'
+  | 'magentaBright'
+  | 'cyanBright'
+  | 'whiteBright';
+
+/**
+ * Semantic color definitions for UI elements
+ */
+export interface ThemeColors {
+  // Primary colors
+  primary: TerminalColor;
+  secondary: TerminalColor;
+  accent: TerminalColor;
+
+  // Text colors
+  text: TerminalColor;
+  textMuted: TerminalColor;
+  textInverse: TerminalColor;
+
+  // Status colors
+  success: TerminalColor;
+  warning: TerminalColor;
+  error: TerminalColor;
+  info: TerminalColor;
+
+  // Agent state colors
+  agentIdle: TerminalColor;
+  agentWorking: TerminalColor;
+  agentDone: TerminalColor;
+  agentStuck: TerminalColor;
+  agentError: TerminalColor;
+
+  // UI element colors
+  border: TerminalColor;
+  borderFocused: TerminalColor;
+  selection: TerminalColor;
+  highlight: TerminalColor;
+
+  // Component-specific
+  headerTitle: TerminalColor;
+  footerText: TerminalColor;
+  badge: TerminalColor;
+}
+
+/**
+ * Theme mode
+ */
+export type ThemeMode = 'dark' | 'light' | 'auto';
+
+/**
+ * Complete theme definition
+ */
+export interface Theme {
+  name: string;
+  mode: 'dark' | 'light';
+  colors: ThemeColors;
+}
+
+/**
+ * Theme configuration options
+ */
+export interface ThemeConfig {
+  /** Preferred theme mode */
+  mode: ThemeMode;
+  /** Custom theme overrides */
+  overrides?: Partial<ThemeColors>;
+}


### PR DESCRIPTION
## Summary
- Implements theming system for TUI with dark/light mode support (Issue #558)
- Auto-detects terminal color scheme from environment variables
- Provides ThemeProvider context and useTheme/useThemeColor hooks
- Includes dark and light theme presets with semantic color definitions
- Updates StatusBadge component to use theme colors (backward compatible)
- Adds theme indicator to footer and help view

## Changes
- **tui/src/theme/types.ts** - Theme type definitions
- **tui/src/theme/themes.ts** - Dark and light theme presets
- **tui/src/theme/ThemeContext.tsx** - ThemeProvider and hooks
- **tui/src/theme/detectColorScheme.ts** - Terminal color scheme detection
- **tui/src/components/StatusBadge.tsx** - Updated to use theme colors
- **tui/src/app.tsx** - Wrapped with ThemeProvider
- **tui/src/__tests__/theme.test.tsx** - Test coverage

## Test plan
- [x] Build passes
- [x] All 67 tests pass
- [x] Theme auto-detection works (COLORFGBG, ITERM_PROFILE)
- [x] StatusBadge works with and without ThemeProvider

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)