### PR TITLE
perf(tui): Optimize rendering with React.memo and useMemo (#559)

### DIFF
--- a/tui/src/components/DataTable.tsx
+++ b/tui/src/components/DataTable.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo, useMemo } from 'react';
 import { Box, Text } from 'ink';
 
 export interface Column<T> {
@@ -16,11 +16,16 @@ export interface DataTableProps<T> {
   onSelect?: (row: T, index: number) => void;
   emptyMessage?: string;
   showHeader?: boolean;
+  maxVisibleRows?: number;
+  scrollOffset?: number;
 }
 
 /**
  * DataTable - Flexible table component for displaying structured data
- * Shared component
+ * Shared component with performance optimizations:
+ * - Memoized row components to prevent unnecessary re-renders
+ * - Optional virtualization via maxVisibleRows/scrollOffset
+ * Issue #559 - Performance optimization
  */
 export function DataTable<T extends Record<string, unknown>>({
   columns,
@@ -28,10 +33,29 @@ export function DataTable<T extends Record<string, unknown>>({
   selectedIndex,
   emptyMessage = 'No data',
   showHeader = true,
+  maxVisibleRows,
+  scrollOffset = 0,
 }: DataTableProps<T>) {
   if (data.length === 0) {
     return <Text dimColor>{emptyMessage}</Text>;
   }
+
+  // Apply virtualization if maxVisibleRows is specified
+  const visibleData = useMemo(() => {
+    if (maxVisibleRows && data.length > maxVisibleRows) {
+      return data.slice(scrollOffset, scrollOffset + maxVisibleRows);
+    }
+    return data;
+  }, [data, maxVisibleRows, scrollOffset]);
+
+  // Adjust selected index for virtualized view
+  const adjustedSelectedIndex = useMemo(() => {
+    if (selectedIndex === undefined) return undefined;
+    if (maxVisibleRows) {
+      return selectedIndex - scrollOffset;
+    }
+    return selectedIndex;
+  }, [selectedIndex, maxVisibleRows, scrollOffset]);
 
   return (
     <Box flexDirection="column">
@@ -48,36 +72,57 @@ export function DataTable<T extends Record<string, unknown>>({
         </Box>
       )}
 
-      {/* Data rows */}
-      {data.map((row, rowIndex) => {
-        const isSelected = selectedIndex === rowIndex;
-        return (
-          <Box key={rowIndex}>
-            <Text color={isSelected ? 'cyan' : undefined}>{isSelected ? '▸ ' : '  '}</Text>
-            {columns.map((col) => {
-              const value = row[col.key];
-              const content = col.render
-                ? col.render(value, row)
-                : String(value ?? '-');
+      {/* Data rows - using memoized row component */}
+      {visibleData.map((row, rowIndex) => (
+        <DataTableRow
+          key={rowIndex}
+          row={row}
+          columns={columns}
+          isSelected={adjustedSelectedIndex === rowIndex}
+        />
+      ))}
+    </Box>
+  );
+}
 
-              return (
-                <Box key={String(col.key)} width={col.width}>
-                  {typeof content === 'string' ? (
-                    <Text color={isSelected ? 'cyan' : undefined} bold={isSelected}>
-                      {truncate(content, col.width)}
-                    </Text>
-                  ) : (
-                    content
-                  )}
-                </Box>
-              );
-            })}
+/**
+ * Memoized table row component - only re-renders when row data or selection changes
+ */
+interface DataTableRowProps<T> {
+  row: T;
+  columns: Column<T>[];
+  isSelected: boolean;
+}
+
+const DataTableRow = memo(function DataTableRow<T extends Record<string, unknown>>({
+  row,
+  columns,
+  isSelected,
+}: DataTableRowProps<T>) {
+  return (
+    <Box>
+      <Text color={isSelected ? 'cyan' : undefined}>{isSelected ? '▸ ' : '  '}</Text>
+      {columns.map((col) => {
+        const value = row[col.key];
+        const content = col.render
+          ? col.render(value, row)
+          : String(value ?? '-');
+
+        return (
+          <Box key={String(col.key)} width={col.width}>
+            {typeof content === 'string' ? (
+              <Text color={isSelected ? 'cyan' : undefined} bold={isSelected}>
+                {truncate(content, col.width)}
+              </Text>
+            ) : (
+              content
+            )}
           </Box>
         );
       })}
     </Box>
   );
-}
+}) as <T extends Record<string, unknown>>(props: DataTableRowProps<T>) => React.ReactElement;
 
 function truncate(str: string, maxWidth?: number): string {
   if (!maxWidth || str.length <= maxWidth - 1) return str;

--- a/tui/src/components/Table.tsx
+++ b/tui/src/components/Table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo, useMemo } from 'react';
 import { Box, Text } from 'ink';
 
 export interface Column<T> {
@@ -13,13 +13,38 @@ interface TableProps<T> {
   columns: Column<T>[];
   selectedIndex?: number;
   onSelect?: (item: T, index: number) => void;
+  maxVisibleRows?: number;
+  scrollOffset?: number;
 }
 
+/**
+ * Table - Memoized table component with optional virtualization
+ * Issue #559 - Performance optimization
+ */
 export function Table<T>({
   data,
   columns,
   selectedIndex,
+  maxVisibleRows,
+  scrollOffset = 0,
 }: TableProps<T>) {
+  // Apply virtualization if maxVisibleRows is specified
+  const visibleData = useMemo(() => {
+    if (maxVisibleRows && data.length > maxVisibleRows) {
+      return data.slice(scrollOffset, scrollOffset + maxVisibleRows);
+    }
+    return data;
+  }, [data, maxVisibleRows, scrollOffset]);
+
+  // Adjust selected index for virtualized view
+  const adjustedSelectedIndex = useMemo(() => {
+    if (selectedIndex === undefined) return undefined;
+    if (maxVisibleRows) {
+      return selectedIndex - scrollOffset;
+    }
+    return selectedIndex;
+  }, [selectedIndex, maxVisibleRows, scrollOffset]);
+
   return (
     <Box flexDirection="column">
       {/* Header Row */}
@@ -33,24 +58,15 @@ export function Table<T>({
         ))}
       </Box>
 
-      {/* Data Rows */}
-      {data.map((item, rowIndex) => (
-        <Box
+      {/* Data Rows - using memoized row component */}
+      {visibleData.map((item, rowIndex) => (
+        <TableRow
           key={rowIndex}
-          borderStyle={selectedIndex === rowIndex ? 'double' : undefined}
-        >
-          {columns.map((col, colIndex) => (
-            <Box key={colIndex} width={col.width || 15} paddingRight={1}>
-              {col.render ? (
-                col.render(item, rowIndex)
-              ) : (
-                <Text>
-                  {String((item as Record<string, unknown>)[col.key as string] ?? '')}
-                </Text>
-              )}
-            </Box>
-          ))}
-        </Box>
+          item={item}
+          columns={columns}
+          rowIndex={rowIndex}
+          isSelected={adjustedSelectedIndex === rowIndex}
+        />
       ))}
 
       {/* Empty State */}
@@ -62,5 +78,38 @@ export function Table<T>({
     </Box>
   );
 }
+
+/**
+ * Memoized table row - only re-renders when data or selection changes
+ */
+interface TableRowProps<T> {
+  item: T;
+  columns: Column<T>[];
+  rowIndex: number;
+  isSelected: boolean;
+}
+
+const TableRow = memo(function TableRow<T>({
+  item,
+  columns,
+  rowIndex,
+  isSelected,
+}: TableRowProps<T>) {
+  return (
+    <Box borderStyle={isSelected ? 'double' : undefined}>
+      {columns.map((col, colIndex) => (
+        <Box key={colIndex} width={col.width || 15} paddingRight={1}>
+          {col.render ? (
+            col.render(item, rowIndex)
+          ) : (
+            <Text>
+              {String((item as Record<string, unknown>)[col.key as string] ?? '')}
+            </Text>
+          )}
+        </Box>
+      ))}
+    </Box>
+  );
+}) as <T>(props: TableRowProps<T>) => React.ReactElement;
 
 export default Table;

--- a/tui/src/hooks/useDashboard.ts
+++ b/tui/src/hooks/useDashboard.ts
@@ -145,9 +145,10 @@ export function useDashboard() {
     fetchData();
   }, [fetchData]);
 
-  // Auto-refresh every 10 seconds
+  // Auto-refresh every 30 seconds (optimized for performance - Issue #559)
+  // Users can manually refresh with 'r' key for immediate updates
   useEffect(() => {
-    const interval = setInterval(fetchData, 10000);
+    const interval = setInterval(fetchData, 30000);
     return () => clearInterval(interval);
   }, [fetchData]);
 

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel.js';
 import { MetricCard } from '../components/MetricCard.js';
@@ -113,7 +114,10 @@ interface HeaderProps {
   lastRefresh: Date | null;
 }
 
-function Header({ workspaceName, isLoading, lastRefresh }: HeaderProps) {
+/**
+ * Memoized header - only re-renders when props change
+ */
+const Header = memo(function Header({ workspaceName, isLoading, lastRefresh }: HeaderProps) {
   const refreshText = lastRefresh
     ? `Updated ${formatRelativeTime(lastRefresh)}`
     : '';
@@ -133,7 +137,7 @@ function Header({ workspaceName, isLoading, lastRefresh }: HeaderProps) {
       )}
     </Box>
   );
-}
+});
 
 interface SummaryCardsProps {
   total: number;
@@ -144,7 +148,10 @@ interface SummaryCardsProps {
   errorCount: number;
 }
 
-function SummaryCards({
+/**
+ * Memoized summary cards - only re-renders when counts change
+ */
+const SummaryCards = memo(function SummaryCards({
   total,
   active,
   working,
@@ -164,7 +171,7 @@ function SummaryCards({
       )}
     </Box>
   );
-}
+});
 
 interface CostSummaryProps {
   totalCostUSD: number;
@@ -172,7 +179,10 @@ interface CostSummaryProps {
   outputTokens: number;
 }
 
-function CostSummary({
+/**
+ * Memoized cost summary - only re-renders when cost data changes
+ */
+const CostSummary = memo(function CostSummary({
   totalCostUSD,
   inputTokens,
   outputTokens,
@@ -190,7 +200,7 @@ function CostSummary({
       </Text>
     </Box>
   );
-}
+});
 
 interface AgentStatsPanelProps {
   stats: {
@@ -199,7 +209,10 @@ interface AgentStatsPanelProps {
   };
 }
 
-function AgentStatsPanel({ stats }: AgentStatsPanelProps) {
+/**
+ * Memoized agent stats panel - only re-renders when stats change
+ */
+const AgentStatsPanel = memo(function AgentStatsPanel({ stats }: AgentStatsPanelProps) {
   const hasRoles = Object.keys(stats.byRole).length > 0;
 
   if (!hasRoles) return null;
@@ -221,7 +234,7 @@ function AgentStatsPanel({ stats }: AgentStatsPanelProps) {
       </Box>
     </Panel>
   );
-}
+});
 
 interface Agent {
   name: string;
@@ -237,9 +250,12 @@ interface AgentsPanelProps {
   agents: Agent[];
 }
 
-function AgentsPanel({ agents }: AgentsPanelProps) {
-  // Show only first 5 agents in dashboard view
-  const displayAgents = agents.slice(0, 5);
+/**
+ * Memoized agents panel - only re-renders when agents array changes
+ */
+const AgentsPanel = memo(function AgentsPanel({ agents }: AgentsPanelProps) {
+  // Memoize displayed agents slice
+  const displayAgents = useMemo(() => agents.slice(0, 5), [agents]);
   const hasMore = agents.length > 5;
 
   return (
@@ -272,7 +288,7 @@ function AgentsPanel({ agents }: AgentsPanelProps) {
       )}
     </Panel>
   );
-}
+});
 
 interface Channel {
   name: string;
@@ -284,14 +300,20 @@ interface ChannelsPanelProps {
   channels: Channel[];
 }
 
-function ChannelsPanel({ channels }: ChannelsPanelProps) {
+/**
+ * Memoized channels panel - only re-renders when channels array changes
+ */
+const ChannelsPanel = memo(function ChannelsPanel({ channels }: ChannelsPanelProps) {
+  // Memoize displayed channels slice
+  const displayChannels = useMemo(() => channels.slice(0, 5), [channels]);
+
   return (
     <Panel title="Channels">
       {channels.length === 0 ? (
         <Text dimColor>No channels</Text>
       ) : (
         <Box flexDirection="column">
-          {channels.slice(0, 5).map((ch) => (
+          {displayChannels.map((ch) => (
             <Box key={ch.name}>
               <Text color="cyan">#{ch.name}</Text>
               <Text> </Text>
@@ -307,7 +329,7 @@ function ChannelsPanel({ channels }: ChannelsPanelProps) {
       )}
     </Panel>
   );
-}
+});
 
 /**
  * Format large numbers with K/M suffixes

--- a/tui/src/views/MessageHistory.tsx
+++ b/tui/src/views/MessageHistory.tsx
@@ -1,7 +1,10 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, memo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { ChannelMessage } from '../types';
 import { useChannelHistory } from '../hooks';
+
+// Cache for sender colors to avoid recalculation
+const senderColorCache = new Map<string, string>();
 
 interface MessageHistoryProps {
   channelName: string;
@@ -82,7 +85,11 @@ export function MessageHistory({
     );
   }
 
-  const visibleSlice = messageList.slice(scrollOffset, scrollOffset + visibleMessages);
+  // Memoize visible slice to prevent recalculation on every render
+  const visibleSlice = useMemo(
+    () => messageList.slice(scrollOffset, scrollOffset + visibleMessages),
+    [messageList, scrollOffset, visibleMessages]
+  );
   const canScrollUp = scrollOffset > 0;
   const canScrollDown = scrollOffset < messageCount - visibleMessages;
 
@@ -149,7 +156,11 @@ interface MessageItemProps {
   isFirst?: boolean;
 }
 
-function MessageItem({ message }: MessageItemProps) {
+/**
+ * MessageItem - Memoized message row component
+ * Only re-renders when message content changes
+ */
+const MessageItem = memo(function MessageItem({ message }: MessageItemProps) {
   const timeStr = formatTimestamp(message.time);
   const senderColor = getSenderColor(message.sender);
 
@@ -168,7 +179,7 @@ function MessageItem({ message }: MessageItemProps) {
       </Box>
     </Box>
   );
-}
+});
 
 /**
  * Format timestamp for display
@@ -198,15 +209,20 @@ function formatTimestamp(isoString: string): string {
 }
 
 /**
- * Get consistent color for a sender name
+ * Get consistent color for a sender name (cached for performance)
  */
 function getSenderColor(sender: string): string {
+  const cached = senderColorCache.get(sender);
+  if (cached) return cached;
+
   const colors = ['blue', 'green', 'yellow', 'magenta', 'cyan'];
   let hash = 0;
   for (let i = 0; i < sender.length; i++) {
     hash = sender.charCodeAt(i) + ((hash << 5) - hash);
   }
-  return colors[Math.abs(hash) % colors.length];
+  const color = colors[Math.abs(hash) % colors.length];
+  senderColorCache.set(sender, color);
+  return color;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **MessageHistory**: Memoize MessageItem with React.memo, cache sender colors, useMemo for visibleSlice
- **DataTable/Table**: Add memoized row components, support virtualization via maxVisibleRows/scrollOffset
- **Dashboard**: Wrap all sub-components (Header, SummaryCards, CostSummary, AgentStatsPanel, AgentsPanel, ChannelsPanel) with React.memo
- **useDashboard**: Increase polling interval from 10s to 30s (manual refresh via 'r' key still available)

## Test plan
- [ ] Run `make build-tui` - verify compilation
- [ ] Run `make test-tui` - verify tests pass
- [ ] Manual test: Navigate between views, verify no visual regressions
- [ ] Manual test: Verify Dashboard auto-refresh at 30s intervals
- [ ] Manual test: Verify 'r' key manual refresh works in all views

Fixes #559

🤖 Generated with [Claude Code](https://claude.com/claude-code)