### PR TITLE
fix(cli): Add proper JSON output for TUI integration

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -173,9 +173,13 @@ func runChannelList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if jsonOutput {
-		enc := json.NewEncoder(os.Stdout)
+		// Wrap in object for TUI compatibility
+		response := struct {
+			Channels []*channel.Channel `json:"channels"`
+		}{Channels: channels}
+		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(channels)
+		return enc.Encode(response)
 	}
 
 	if len(channels) == 0 {
@@ -482,9 +486,14 @@ func runChannelHistory(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if jsonOutput {
-		enc := json.NewEncoder(os.Stdout)
+		// Wrap in object for TUI compatibility
+		response := struct {
+			Channel  string                 `json:"channel"`
+			Messages []channel.HistoryEntry `json:"messages"`
+		}{Channel: channelName, Messages: history}
+		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(history)
+		return enc.Encode(response)
 	}
 
 	if len(history) == 0 {
@@ -612,7 +621,7 @@ func runChannelShow(cmd *cobra.Command, args []string) error {
 			MemberCount:  len(members),
 			HistoryCount: len(history),
 		}
-		enc := json.NewEncoder(os.Stdout)
+		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
 		return enc.Encode(info)
 	}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -23,6 +23,15 @@ func executeCmd(args ...string) (string, error) {
 	rootCmd.SetArgs(args)
 
 	// Reset flags to prevent leaking state
+	// Reset root persistent flags first
+	rootCmd.PersistentFlags().VisitAll(func(f *pflag.Flag) {
+		f.Changed = false
+		// Also reset value to default for boolean flags
+		if f.Value.Type() == "bool" {
+			_ = f.Value.Set("false")
+		}
+	})
+	// Reset subcommand flags
 	for _, sub := range rootCmd.Commands() {
 		sub.Flags().VisitAll(func(f *pflag.Flag) { f.Changed = false })
 	}

--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"text/tabwriter"
@@ -256,6 +257,45 @@ func runCostShow(cmd *cobra.Command, args []string) error {
 
 	if err != nil {
 		return fmt.Errorf("failed to get cost records: %w", err)
+	}
+
+	// Check for JSON output
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		// Build a summary for TUI compatibility
+		var totalCost, totalInput, totalOutput float64
+		byAgent := make(map[string]float64)
+		byTeam := make(map[string]float64)
+		byModel := make(map[string]float64)
+
+		for _, r := range records {
+			totalCost += r.CostUSD
+			totalInput += float64(r.InputTokens)
+			totalOutput += float64(r.OutputTokens)
+			byAgent[r.AgentID] += r.CostUSD
+			byTeam[r.TeamID] += r.CostUSD
+			byModel[r.Model] += r.CostUSD
+		}
+
+		response := struct {
+			ByAgent           map[string]float64 `json:"by_agent"`
+			ByTeam            map[string]float64 `json:"by_team"`
+			ByModel           map[string]float64 `json:"by_model"`
+			TotalInputTokens  int64              `json:"total_input_tokens"`
+			TotalOutputTokens int64              `json:"total_output_tokens"`
+			TotalCost         float64            `json:"total_cost"`
+		}{
+			ByAgent:           byAgent,
+			ByTeam:            byTeam,
+			ByModel:           byModel,
+			TotalInputTokens:  int64(totalInput),
+			TotalOutputTokens: int64(totalOutput),
+			TotalCost:         totalCost,
+		}
+
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(response)
 	}
 
 	if len(records) == 0 {

--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -192,6 +192,18 @@ func runDemonList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Check for JSON output
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		// Return empty array if no demons, for TUI compatibility
+		if demons == nil {
+			demons = []*demon.Demon{}
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(demons)
+	}
+
 	if len(demons) == 0 {
 		cmd.Println("No demons configured")
 		cmd.Println()

--- a/internal/cmd/process.go
+++ b/internal/cmd/process.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -239,6 +240,22 @@ func runProcessList(cmd *cobra.Command, args []string) error {
 	}
 
 	procs := reg.List()
+
+	// Check for JSON output
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		// Wrap in object for TUI compatibility
+		if procs == nil {
+			procs = []*process.Process{}
+		}
+		response := struct {
+			Processes []*process.Process `json:"processes"`
+		}{Processes: procs}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(response)
+	}
+
 	if len(procs) == 0 {
 		fmt.Println("No processes")
 		return nil

--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -127,6 +128,21 @@ func runTeamList(cmd *cobra.Command, args []string) error {
 	teams, err := store.List()
 	if err != nil {
 		return err
+	}
+
+	// Check for JSON output
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		// Wrap in object for TUI compatibility
+		if teams == nil {
+			teams = []*team.Team{}
+		}
+		response := struct {
+			Teams []*team.Team `json:"teams"`
+		}{Teams: teams}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(response)
 	}
 
 	if len(teams) == 0 {


### PR DESCRIPTION
## Summary
Fixes JSON output format for TUI integration - Issue #587

The TUI expects specific JSON response formats that differed from the CLI's actual output. This PR aligns CLI output with TUI type definitions.

## Changes

### JSON Format Fixes
| Command | Before | After |
|---------|--------|-------|
| `bc channel list --json` | `[...]` | `{ "channels": [...] }` |
| `bc channel history --json` | `[...]` | `{ "channel": "...", "messages": [...] }` |
| `bc cost show --json` | Text (no JSON) | `{ "total_cost": ..., "by_agent": {...}, ... }` |
| `bc demon list --json` | Text (no JSON) | `[...]` |
| `bc process list --json` | Text (no JSON) | `{ "processes": [...] }` |
| `bc team list --json` | Text (no JSON) | `{ "teams": [...] }` |

### Test Fix
- Fixed test helper to properly reset persistent flags between tests
- Prevents `--json` flag state leaking between tests

## Files Changed
- `internal/cmd/channel.go` - Fixed channel list and history JSON format
- `internal/cmd/cost.go` - Added JSON support to cost show
- `internal/cmd/demon.go` - Added JSON support to demon list
- `internal/cmd/process.go` - Added JSON support to process list
- `internal/cmd/team.go` - Added JSON support to team list
- `internal/cmd/cmd_test.go` - Fixed persistent flag reset

## Test plan
- [x] All Go tests pass
- [x] All TUI tests pass (67 tests)
- [x] Verified JSON output matches TUI type definitions
- [x] Build passes

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)