### PR TITLE
fix(tui): Remove double-wrapping of channel list response

### DIFF
--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -16,6 +16,21 @@ import type {
 } from '../types';
 
 /**
+ * Get the bc command path.
+ * Uses BC_ROOT env var if set (set by bc home command), otherwise assumes bc is in PATH.
+ */
+function getBcPath(): string {
+  const bcRoot = process.env.BC_ROOT;
+  if (bcRoot) {
+    // When launched via `bc home`, BC_ROOT points to workspace root
+    // bc binary is at ./bin/bc relative to workspace
+    return `${bcRoot}/bin/bc`;
+  }
+  // Fallback to PATH
+  return 'bc';
+}
+
+/**
  * Execute a bc command and return the raw output
  * @param args - Command arguments (e.g., ['status', '--json'])
  * @returns Promise resolving to stdout string
@@ -33,7 +48,8 @@ export async function execBc(args: string[]): Promise<string> {
       finalArgs.push('--json');
     }
 
-    const proc = spawn('bc', finalArgs, {
+    const bcPath = getBcPath();
+    const proc = spawn(bcPath, finalArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 


### PR DESCRIPTION
## Summary
Fixes multiple TUI data display issues.

### Fix 1: Channel list double-wrapping (#594)
PR #589 updated CLI to return `{channels: [...]}` format, but PR #596 wrapped it again → `{channels: {channels: [...]}}`.

**Fix:** Removed redundant wrapping in `getChannels()`.

### Fix 2: bc binary not found (#592, #593)
When TUI is launched via `bc home`, the bc binary might not be in PATH.

**Fix:** TUI now uses BC_ROOT env var (set by bc home) to find bc at `$BC_ROOT/bin/bc`.

## Test plan
- [x] `make build-tui` passes
- [x] `make test-tui` passes (67 tests)
- [x] `make lint` passes
- [ ] Dashboard displays data
- [ ] Agents view displays data
- [ ] Channels view displays data

## Fixes
- Fixes #592 (Dashboard stuck on loading)
- Fixes #593 (Agents view stuck on loading)
- Fixes #594 (Channels shows no data)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)