### PR TITLE
fix(tui): Pass bc binary path to TUI via BC_BIN env

### DIFF
--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -99,8 +99,11 @@ func runHome(cmd *cobra.Command, args []string) error {
 	tuiCmd.Stderr = os.Stderr
 
 	// Set environment for bc CLI path
+	// Get the current executable path so TUI can call bc
+	bcBin, _ := os.Executable()
 	tuiCmd.Env = append(os.Environ(),
 		fmt.Sprintf("BC_ROOT=%s", ws.RootDir),
+		fmt.Sprintf("BC_BIN=%s", bcBin),
 	)
 
 	return tuiCmd.Run()

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -34,7 +34,10 @@ export async function execBc(args: string[]): Promise<string> {
       finalArgs.push('--json');
     }
 
-    const proc = spawn('bc', finalArgs, {
+    // Use BC_BIN if set, otherwise fall back to 'bc' in PATH
+    const bcBin = process.env.BC_BIN || 'bc';
+
+    const proc = spawn(bcBin, finalArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 


### PR DESCRIPTION
## Summary
- Fixed TUI not finding bc binary when spawned from `bc home`
- `bc home` now sets `BC_BIN` env var to current executable path
- TUI uses `BC_BIN` if set, falls back to `bc` in PATH

## Root Cause
When `bc home` spawns the TUI, the TUI calls `spawn('bc', ...)` to fetch data.
If bc isn't in PATH (e.g., running `./bin/bc home`), the TUI couldn't find it.

## Test plan
- [x] Build passes
- [x] TUI builds
- [ ] `./bin/bc home` shows Dashboard with data
- [ ] Agents view shows agent list

## Fixes
Fixes #592, #593
Part of EPIC #591

---
Generated with [Claude Code](https://claude.com/claude-code)