### PR TITLE
fix(tui): Remove channel list double-wrapping

### DIFF
--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -6,7 +6,6 @@
 import { spawn } from 'child_process';
 import type {
   StatusResponse,
-  Channel,
   ChannelsResponse,
   ChannelHistory,
   CostSummary,
@@ -91,11 +90,10 @@ export async function getStatus(): Promise<StatusResponse> {
 
 /**
  * Get list of channels
- * Note: bc channel list --json returns array directly, we wrap it
+ * Note: bc channel list --json now returns {channels: [...]} format (PR #589)
  */
 export async function getChannels(): Promise<ChannelsResponse> {
-  const channels = await execBcJson<Channel[]>(['channel', 'list']);
-  return { channels };
+  return execBcJson<ChannelsResponse>(['channel', 'list']);
 }
 
 /**


### PR DESCRIPTION
## Summary
- PR #589 changed CLI to return `{channels: [...]}` format
- PR #596 was wrapping it again → `{channels: {channels: [...]}}`
- Now getChannels() returns CLI response directly

## Test plan
- [x] TUI builds
- [ ] Channels view displays channel list

## Fixes
Fixes #594

---
Generated with [Claude Code](https://claude.com/claude-code)