### PR TITLE
fix(tui): Add cwd and timeout to bc spawn for reliable execution

### DIFF
--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -35,13 +35,26 @@ export async function execBc(args: string[]): Promise<string> {
 
     // Use BC_BIN if set, otherwise fall back to 'bc' in PATH
     const bcBin = process.env.BC_BIN || 'bc';
+    // Use BC_ROOT as working directory to ensure bc finds the workspace
+    const bcRoot = process.env.BC_ROOT;
 
     const proc = spawn(bcBin, finalArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
+      cwd: bcRoot || undefined,
     });
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
+
+    // Timeout to prevent hangs (30 seconds)
+    const timeout = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        proc.kill();
+        reject(new Error(`bc command timed out: ${args.join(' ')}`));
+      }
+    }, 30000);
 
     proc.stdout.on('data', (data: Buffer) => {
       stdout += data.toString();
@@ -52,6 +65,10 @@ export async function execBc(args: string[]): Promise<string> {
     });
 
     proc.on('close', (code: number | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+
       if (code === 0) {
         resolve(stdout.trim());
       } else {
@@ -60,6 +77,9 @@ export async function execBc(args: string[]): Promise<string> {
     });
 
     proc.on('error', (err: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
       reject(new Error(`Failed to spawn bc: ${err.message}`));
     });
   });


### PR DESCRIPTION
## Summary
- Fixes #592 (Dashboard stuck on loading)
- Fixes #593 (Agents view stuck on loading)

## Root Cause
TUI spawn of `bc` commands didn't set the working directory, causing `bc` to fail to find the workspace when executing commands with larger outputs (like `bc status` with 48KB response).

## Changes
- Set `cwd` to `BC_ROOT` when spawning bc commands to ensure workspace discovery
- Add 30-second timeout to prevent infinite hangs
- Add `settled` flag to prevent race conditions in spawn callbacks

## Test plan
- [x] `make build-tui` passes
- [x] `make test-tui` passes (67 tests)
- [x] `make lint` passes
- [ ] Manual test: `bc home` shows Dashboard with agent data
- [ ] Manual test: `bc home` → press `2` shows Agents view with data

🤖 Generated with [Claude Code](https://claude.com/claude-code)