### PR TITLE
debug(tui): Add execBc debug logging for #592/#593

### DIFF
--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -35,10 +35,16 @@ export async function execBc(args: string[]): Promise<string> {
 
     // Use BC_BIN if set, otherwise fall back to 'bc' in PATH
     const bcBin = process.env.BC_BIN || 'bc';
+    const bcRoot = process.env.BC_ROOT || process.cwd();
+
+    // DEBUG: Log environment and command
+    console.error('[DEBUG execBc] BC_BIN:', bcBin);
+    console.error('[DEBUG execBc] BC_ROOT:', bcRoot);
+    console.error('[DEBUG execBc] Command:', finalArgs.join(' '));
 
     const proc = spawn(bcBin, finalArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
-      cwd: process.env.BC_ROOT || process.cwd(),
+      cwd: bcRoot,
     });
 
     let stdout = '';
@@ -63,6 +69,11 @@ export async function execBc(args: string[]): Promise<string> {
     });
 
     proc.on('close', (code: number | null) => {
+      // DEBUG: Log results
+      console.error('[DEBUG execBc] Exit code:', code);
+      console.error('[DEBUG execBc] stdout length:', stdout.length);
+      console.error('[DEBUG execBc] stderr:', stderr || '(empty)');
+
       if (finished) return;
       finished = true;
       clearTimeout(timeout);
@@ -74,6 +85,7 @@ export async function execBc(args: string[]): Promise<string> {
     });
 
     proc.on('error', (err: Error) => {
+      console.error('[DEBUG execBc] Spawn error:', err.message);
       if (finished) return;
       finished = true;
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary
Adds debug logging to `execBc()` to help diagnose why Dashboard and Agents views are stuck loading.

## Debug output
Logs to stderr:
- `BC_BIN` and `BC_ROOT` environment variables
- Command being executed
- Exit code and stdout length
- Any spawn errors

## Purpose
Help identify why `bc status` fails while `bc channel list` works (both use same execBc function).

## Test
```bash
make build-tui
./bin/bc home
# Watch stderr for debug output
```

## Note
This is temporary debug logging - should be removed once #592/#593 are fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)