### PR TITLE
fix(tui): Remove debug logging from execBc (fixes #615)

### DIFF
--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -37,11 +37,6 @@ export async function execBc(args: string[]): Promise<string> {
     const bcBin = process.env.BC_BIN || 'bc';
     const bcRoot = process.env.BC_ROOT || process.cwd();
 
-    // DEBUG: Log environment and command
-    console.error('[DEBUG execBc] BC_BIN:', bcBin);
-    console.error('[DEBUG execBc] BC_ROOT:', bcRoot);
-    console.error('[DEBUG execBc] Command:', finalArgs.join(' '));
-
     const proc = spawn(bcBin, finalArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: bcRoot,
@@ -69,11 +64,6 @@ export async function execBc(args: string[]): Promise<string> {
     });
 
     proc.on('close', (code: number | null) => {
-      // DEBUG: Log results
-      console.error('[DEBUG execBc] Exit code:', code);
-      console.error('[DEBUG execBc] stdout length:', stdout.length);
-      console.error('[DEBUG execBc] stderr:', stderr || '(empty)');
-
       if (finished) return;
       finished = true;
       clearTimeout(timeout);
@@ -85,7 +75,6 @@ export async function execBc(args: string[]): Promise<string> {
     });
 
     proc.on('error', (err: Error) => {
-      console.error('[DEBUG execBc] Spawn error:', err.message);
       if (finished) return;
       finished = true;
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary
Removes temporary debug logging that was polluting TUI output with `[DEBUG execBc]` messages.

## Issue
PR #608 added console.error debug statements to diagnose #592/#593:
- [DEBUG execBc] BC_BIN
- [DEBUG execBc] BC_ROOT
- [DEBUG execBc] Command
- Exit code/stdout length messages

These were visible in the TUI and created noise during user testing.

## Fix
Remove all console.error calls from `execBc()` function. The real issue (#592/#593) needs different investigation approach.

## Testing
- make build-tui ✅
- make test-tui ✅ (65 pass, 2 pre-existing fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)