### PR TITLE
fix(tui): Remove debug console.error logging (#615)

### DIFF
--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -37,11 +37,6 @@ export async function execBc(args: string[]): Promise<string> {
     const bcBin = process.env.BC_BIN || 'bc';
     const bcRoot = process.env.BC_ROOT || process.cwd();
 
-    // DEBUG: Log environment and command
-    console.error('[DEBUG execBc] BC_BIN:', bcBin);
-    console.error('[DEBUG execBc] BC_ROOT:', bcRoot);
-    console.error('[DEBUG execBc] Command:', finalArgs.join(' '));
-
     const proc = spawn(bcBin, finalArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
       cwd: bcRoot,
@@ -69,11 +64,6 @@ export async function execBc(args: string[]): Promise<string> {
     });
 
     proc.on('close', (code: number | null) => {
-      // DEBUG: Log results
-      console.error('[DEBUG execBc] Exit code:', code);
-      console.error('[DEBUG execBc] stdout length:', stdout.length);
-      console.error('[DEBUG execBc] stderr:', stderr || '(empty)');
-
       if (finished) return;
       finished = true;
       clearTimeout(timeout);
@@ -85,7 +75,6 @@ export async function execBc(args: string[]): Promise<string> {
     });
 
     proc.on('error', (err: Error) => {
-      console.error('[DEBUG execBc] Spawn error:', err.message);
       if (finished) return;
       finished = true;
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary
Debug logging from PR #608 uses console.error which pollutes TUI output with `[DEBUG execBc]` messages.

This PR removes all console.error calls from bc.ts service layer.

## Root Cause
PR #608 added debug logging using `console.error()` to help diagnose #592/#593. However, console.error output is captured by the TUI renderer and displayed as UI text, which pollutes the dashboard.

## Solution
Remove all console.error debug statements. Debug logging can be re-added later using proper infrastructure (file-based logging, environment variable checks, etc).

## Test plan
- [ ] `make build-tui` passes
- [ ] `make test-tui` passes
- [ ] Run `./bin/bc home` - no debug messages in TUI output

## Investigation Notes
Removing debug logging will help us see if there are actual UI rendering issues once the noise is gone. This may also reveal if the Dashboard component itself needs error handling improvements.

Fixes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)