### PR TITLE
Fix TUI usability: Remove backspace shortcut and debug logging

### DIFF
--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -18,11 +18,10 @@ export interface UseKeyboardNavigationOptions {
  * - ? shows help
  * - ESC goes back/home
  * - q quits the application
- * - Backspace goes back in history
  */
 export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}): void {
   const { disabled = false, onQuit } = options;
-  const { navigate, goBack, goHome, getTabByKey, canGoBack } = useNavigation();
+  const { navigate, goHome, getTabByKey } = useNavigation();
 
   useInput(
     (input, key) => {
@@ -33,21 +32,9 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
         return;
       }
 
-      // ESC: go back if possible, otherwise go home
+      // ESC: go home
       if (key.escape) {
-        if (canGoBack) {
-          goBack();
-        } else {
-          goHome();
-        }
-        return;
-      }
-
-      // Backspace: go back in history
-      if (key.backspace || key.delete) {
-        if (canGoBack) {
-          goBack();
-        }
+        goHome();
         return;
       }
 

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -105,13 +105,7 @@ export async function execBcJson<T>(args: string[]): Promise<T> {
  * Get current agent status
  */
 export async function getStatus(): Promise<StatusResponse> {
-  try {
-    return await execBcJson<StatusResponse>(['status']);
-  } catch (err) {
-    // Log error for debugging
-    console.error('getStatus error:', err);
-    throw err;
-  }
+  return execBcJson<StatusResponse>(['status']);
 }
 
 /**


### PR DESCRIPTION
## Critical UX Fixes

### Issue 1: Backspace Key Interfering with Text Input
**Problem:** Backspace shortcut was preventing character deletion in text inputs. Users couldn't delete typed characters.

**Solution:** Remove backspace key handler entirely
- ESC already provides 'go back to home' functionality
- No need for duplicate navigation shortcut
- Allows normal text input to work properly

### Issue 2: Debug Logging Polluting Output
**Problem:** console.error logging in getStatus() was visible in TUI output, polluting the user experience.

**Solution:** Remove debug console.error statements
- Errors already handled through error state
- Cleaner home experience without debug noise

## Changes Made
- Remove backspace/delete key handler from useKeyboardNavigation
- Remove console.error from getStatus function
- Simplify ESC behavior to always go home
- Update hook documentation

## Testing
```bash
make build-tui
./bin/bc home
```

Expected results:
- ✅ Backspace key works normally in text inputs
- ✅ No debug output in console
- ✅ ESC still navigates back to home
- ✅ All views load cleanly