### PR TITLE
fix(tui): Fix TypeScript compilation errors (#626)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -23,10 +23,10 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
     (_input, key) => {
       if (viewMode === 'list') {
         // Navigate channel list
-        if ((key.upArrow || input === 'k') && selectedIndex > 0) {
+        if ((key.upArrow || _input === 'k') && selectedIndex > 0) {
           setSelectedIndex(selectedIndex - 1);
         }
-        if ((key.downArrow || input === 'j') && channels && selectedIndex < channels.length - 1) {
+        if ((key.downArrow || _input === 'j') && channels && selectedIndex < channels.length - 1) {
           setSelectedIndex(selectedIndex + 1);
         }
         // Enter channel

--- a/tui/src/hooks/useDashboard.ts
+++ b/tui/src/hooks/useDashboard.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { getStatus, getChannels, getCostSummary } from '../services/bc.js';
-import type { StatusResponse, ChannelsResponse, CostSummary, Agent } from '../types';
+import type { CostSummary, Agent } from '../types';
 
 interface UseDataResult<T> {
   data: T | null;


### PR DESCRIPTION
## Summary
Fixes blocking TypeScript compilation errors preventing TUI build.

## Issues Fixed
1. **ChannelsView.tsx** - Variable name mismatch
   - useInput callback parameter: `_input`
   - Code referenced: `input` (without underscore)
   - Lines 26, 29: Changed to use correct `_input` for j/k navigation

2. **useDashboard.ts** - Unused type imports
   - Removed unused: `StatusResponse`, `ChannelsResponse`
   - Only `CostSummary` and `Agent` are actually used
   - Satisfies TypeScript strict mode

## Verification
- ✅ make build-tui passes
- ✅ Pre-commit checks pass
- ✅ No TypeScript compilation errors

## Impact
Unblocks swift-tester testing - TUI now builds successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)