### PR TITLE
fix(tui): Constrain layout to terminal viewport (#630)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -3,7 +3,7 @@
  */
 
 import React from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import {
   NavigationProvider,
   useNavigation,
@@ -46,12 +46,17 @@ interface AppContentProps {
 
 function AppContent({ disableInput }: AppContentProps): React.ReactElement {
   const { currentView } = useNavigation();
+  const { stdout } = useStdout();
 
   // Handle global keyboard navigation
   useKeyboardNavigation({ disabled: disableInput });
 
+  // Get terminal dimensions - constrain to actual terminal height
+  const terminalHeight = stdout?.rows ?? 24;
+  const terminalWidth = stdout?.columns ?? 80;
+
   return (
-    <Box flexDirection="column" padding={1} width={100} height={100}>
+    <Box flexDirection="column" padding={1} width={terminalWidth} height={terminalHeight}>
       {/* Header with tab bar */}
       <TabBar />
 
@@ -129,7 +134,7 @@ function HelpView(): React.ReactElement {
 function Footer(): React.ReactElement {
   const { theme } = useTheme();
   return (
-    <Box marginTop={1} justifyContent="space-between" width={100}>
+    <Box marginTop={1} justifyContent="space-between">
       <Text dimColor>Press [?] for help, [q] to quit</Text>
       <Text dimColor>Theme: {theme.name}</Text>
     </Box>


### PR DESCRIPTION
## Summary
- Uses `useStdout` hook to get actual terminal dimensions
- Constrains TUI container to terminal rows/columns
- Prevents footer from appearing below viewport

## Problem
The TUI footer was appearing way below the main dashboard, requiring users to scroll up to see data.

## Solution
Get terminal dimensions from `stdout.rows` and `stdout.columns` and use them to constrain the container size, keeping everything within the visible terminal viewport.

## Testing
```bash
make build-tui
./bin/bc home
```

Footer should now appear at the bottom of the visible terminal, not below it.

Fixes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)