### PR TITLE
fix(#649): Prevent global keybinds from triggering in message input

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -2,9 +2,10 @@
  * ChannelsView - Channel list and message history component
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useChannels, useChannelHistory } from '../hooks';
+import { useFocus } from '../navigation/FocusContext';
 import type { Channel } from '../types';
 
 interface ChannelsViewProps {
@@ -117,6 +118,16 @@ function ChannelHistoryView({
   const [inputMode, setInputMode] = useState(false);
   const [messageBuffer, setMessageBuffer] = useState('');
   const [scrollOffset, setScrollOffset] = useState(0);
+  const { setFocus, returnFocus } = useFocus();
+
+  // Manage focus when entering/exiting input mode
+  useEffect(() => {
+    if (inputMode) {
+      setFocus('input');
+    } else {
+      returnFocus();
+    }
+  }, [inputMode, setFocus, returnFocus]);
 
   useInput(
     (input, key) => {

--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -4,6 +4,7 @@
 
 import { useInput } from 'ink';
 import { useNavigation } from './NavigationContext';
+import { useFocus } from './FocusContext';
 
 export interface UseKeyboardNavigationOptions {
   /** Disable keyboard handling (useful for testing or when another component captures input) */
@@ -22,9 +23,15 @@ export interface UseKeyboardNavigationOptions {
 export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}): void {
   const { disabled = false, onQuit } = options;
   const { navigate, goHome, getTabByKey } = useNavigation();
+  const { isFocused } = useFocus();
 
   useInput(
     (input, key) => {
+      // Don't handle global keys when input is focused
+      if (isFocused('input')) {
+        return;
+      }
+
       // Tab navigation with number keys (1-9) and ?
       const tab = getTabByKey(input);
       if (tab) {


### PR DESCRIPTION
## Issue
#649 - Global keybinds (q, 1-9, ?) were triggering while typing in message composition.

## Root Cause
FocusContext system existed but wasn't wired to global keybind handlers.

## Solution
- ChannelHistoryView: Added setFocus('input') on compose, returnFocus() on cancel
- useKeyboardNavigation: Added isFocused('input') checks before global keybind handlers

## Testing
✅ TypeScript compilation passes
✅ Code follows existing patterns
✅ FocusContext properly integrated
✅ Local testing: typing 'q', '1-9', '?' in messages works without triggering global actions

## Files Changed
- tui/src/components/ChannelsView.tsx
- tui/src/navigation/useKeyboardNavigation.ts