### PR TITLE
fix: Validation gaps - P0/P1 critical issues (#731)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/names"
+	"github.com/rpuneet/bc/pkg/team"
 )
 
 // agentCmd is the parent command for all agent operations
@@ -390,10 +391,28 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Validate team name if specified (do this before role validation)
+	if agentCreateTeam != "" {
+		if !isValidTeamName(agentCreateTeam) {
+			return fmt.Errorf("team name must be alphanumeric with optional hyphens/underscores")
+		}
+
+		// Validate team exists
+		teamStore := team.NewStore(filepath.Join(ws.StateDir(), "teams"))
+		if !teamStore.Exists(agentCreateTeam) {
+			return fmt.Errorf("team %q does not exist. Create it first with: bc team create %s", agentCreateTeam, agentCreateTeam)
+		}
+	}
+
 	// Parse role
 	role, roleErr := parseRole(agentCreateRole)
 	if roleErr != nil {
 		return roleErr
+	}
+
+	// Prevent root agent creation via this command
+	if role == agent.RoleRoot {
+		return fmt.Errorf("cannot create root agent via 'bc agent create'. Use 'bc up' to initialize the root agent")
 	}
 
 	// Validate role exists in workspace (unless it's the special "null" role)
@@ -401,13 +420,6 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 		roleFile := filepath.Join(ws.RolesDir(), string(role)+".md")
 		if _, err := os.Stat(roleFile); err != nil {
 			return fmt.Errorf("role %q not found - create it first or use an existing role", role)
-		}
-	}
-
-	// Validate team name if specified
-	if agentCreateTeam != "" {
-		if !isValidTeamName(agentCreateTeam) {
-			return fmt.Errorf("team name must be alphanumeric with optional hyphens/underscores")
 		}
 	}
 

--- a/internal/cmd/agent_test.go
+++ b/internal/cmd/agent_test.go
@@ -862,3 +862,49 @@ func TestAgentRename_RunEValidation(t *testing.T) {
 		t.Errorf("expected 'same' in error, got: %v", err)
 	}
 }
+
+// --- Agent Create Validation Tests ---
+
+func TestAgentCreate_RejectsRootRole(t *testing.T) {
+	// Test that root role cannot be created via bc agent create
+	setupTestWorkspace(t)
+
+	// Reset flags to prevent leaking state from previous tests
+	agentCreateTeam = ""
+	agentCreateParent = ""
+	agentCreateTool = ""
+	agentCreateRole = "worker"
+
+	_, err := executeCmd("agent", "create", "my-root", "--role", "root")
+	if err == nil {
+		t.Error("expected error when creating root agent via agent create")
+	}
+	if !strings.Contains(err.Error(), "cannot create root agent") {
+		t.Errorf("error should mention cannot create root agent: %v", err)
+	}
+	if !strings.Contains(err.Error(), "bc up") {
+		t.Errorf("error should mention 'bc up': %v", err)
+	}
+}
+
+func TestAgentCreate_NonExistentTeam(t *testing.T) {
+	// Test that agent create fails if team doesn't exist
+	wsDir := setupTestWorkspace(t)
+
+	// Create engineer role file first
+	rolesDir := filepath.Join(wsDir, ".bc", "roles")
+	if err := os.MkdirAll(rolesDir, 0750); err != nil {
+		t.Fatalf("failed to create roles dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rolesDir, "engineer.md"), []byte("# Engineer Role"), 0600); err != nil {
+		t.Fatalf("failed to create engineer role: %v", err)
+	}
+
+	_, err := executeCmd("agent", "create", "eng-01", "--role", "engineer", "--team", "nonexistent-team")
+	if err == nil {
+		t.Error("expected error when creating agent with non-existent team")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error should mention team does not exist: %v", err)
+	}
+}

--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -299,6 +299,11 @@ func getCostStore() (*cost.Store, error) {
 }
 
 func runCostShow(cmd *cobra.Command, args []string) error {
+	// Validate limit parameter
+	if cmd.Flags().Changed("limit") && costLimitFlag <= 0 {
+		return fmt.Errorf("limit must be a positive number")
+	}
+
 	store, err := getCostStore()
 	if err != nil {
 		return err

--- a/internal/cmd/cost_test.go
+++ b/internal/cmd/cost_test.go
@@ -482,3 +482,35 @@ func TestCostPeekBothFlags(t *testing.T) {
 		t.Fatal("expected error when both flags provided")
 	}
 }
+
+// TestCostShowNegativeLimit tests that negative limits are rejected
+func TestCostShowNegativeLimit(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+	resetCostFlags()
+	defer resetCostFlags()
+
+	_, _, err := executeIntegrationCmd("cost", "show", "--limit", "-5")
+	if err == nil {
+		t.Error("expected error for negative limit")
+	}
+	if !strings.Contains(err.Error(), "must be a positive number") {
+		t.Errorf("error should mention positive number: %v", err)
+	}
+}
+
+// TestCostShowZeroLimit tests that zero limit is rejected
+func TestCostShowZeroLimit(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+	resetCostFlags()
+	defer resetCostFlags()
+
+	_, _, err := executeIntegrationCmd("cost", "show", "--limit", "0")
+	if err == nil {
+		t.Error("expected error for zero limit")
+	}
+	if !strings.Contains(err.Error(), "must be a positive number") {
+		t.Errorf("error should mention positive number: %v", err)
+	}
+}

--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/team"
 )
 
@@ -235,6 +236,18 @@ func runTeamAdd(cmd *cobra.Command, args []string) error {
 	agentName := args[1]
 	store := team.NewStore(ws.RootDir)
 
+	// Validate team exists
+	if !store.Exists(teamName) {
+		return fmt.Errorf("team %q not found. Create it first with: bc team create %s", teamName, teamName)
+	}
+
+	// Validate agent exists
+	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
+	_ = mgr.LoadState() // nolint:errcheck - continue even if state doesn't load
+	if mgr.GetAgent(agentName) == nil {
+		return fmt.Errorf("agent %q does not exist. Create it first with: bc agent create %s", agentName, agentName)
+	}
+
 	if err := store.AddMember(teamName, agentName); err != nil {
 		return err
 	}
@@ -252,6 +265,11 @@ func runTeamRemove(cmd *cobra.Command, args []string) error {
 	teamName := args[0]
 	agentName := args[1]
 	store := team.NewStore(ws.RootDir)
+
+	// Validate team exists
+	if !store.Exists(teamName) {
+		return fmt.Errorf("team %q not found", teamName)
+	}
 
 	if err := store.RemoveMember(teamName, agentName); err != nil {
 		return err

--- a/internal/cmd/team_test.go
+++ b/internal/cmd/team_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/team"
 )
 
@@ -165,6 +166,21 @@ func TestTeamAdd(t *testing.T) {
 	store := team.NewStore(wsDir)
 	_, _ = store.Create("engineering")
 
+	// Create an agent first (required by validation)
+	// Use seedAgents to properly create the agent in the state
+	agents := map[string]*agent.Agent{
+		"engineer-01": {
+			Name:      "engineer-01",
+			Role:      agent.Role("engineer"),
+			State:     agent.StateIdle,
+			Tool:      "claude",
+			Session:   "test-session",
+			Workspace: wsDir,
+			ID:        "eng-01-id",
+		},
+	}
+	seedAgents(t, wsDir, agents)
+
 	output, err := executeCmd("team", "add", "engineering", "engineer-01")
 	if err != nil {
 		t.Fatalf("team add failed: %v\nOutput: %s", err, output)
@@ -237,5 +253,21 @@ func TestTeamRemoveTeamNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("error should mention not found: %v", err)
+	}
+}
+
+func TestTeamAddAgentNotFound(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a team but don't create the agent
+	store := team.NewStore(wsDir)
+	_, _ = store.Create("engineering")
+
+	_, err := executeCmd("team", "add", "engineering", "nonexistent-agent")
+	if err == nil {
+		t.Error("expected error for nonexistent agent")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("error should mention agent does not exist: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
Fixes 4 critical validation gaps preventing data integrity issues:

1. **Prevent root agent creation via CLI** - Root agent is singleton, should only exist via `bc up`
2. **Validate team existence in operations** - Prevents silent failures when team doesn't exist
3. **Validate agent existence in team operations** - Prevents phantom agents in team membership
4. **Validate --team flag in agent create** - Ensures referenced team exists
5. **Prevent negative limits in cost show** - Validates limit parameters

## Changes
- `internal/cmd/agent.go`: Root role rejection, team existence check
- `internal/cmd/team.go`: Team/agent existence validation
- `internal/cmd/cost.go`: Negative limit validation
- `internal/cmd/agent_test.go`: 2 new tests (root rejection, non-existent team)
- `internal/cmd/team_test.go`: Updated TestTeamAdd + TestTeamAddAgentNotFound
- `internal/cmd/cost_test.go`: 2 new tests (negative/zero limit)

## Testing
All tests passing:
- TestAgentCreate_RejectsRootRole
- TestAgentCreate_NonExistentTeam
- TestTeamAdd (updated with seedAgents)
- TestTeamAddAgentNotFound
- TestCostShowNegativeLimit
- TestCostShowZeroLimit

## Backwards Compatibility
✅ Changes add validation only - no behavior changes for valid inputs
✅ Clear error messages guide users to correct actions

Fixes #731

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>