### PR TITLE
fix(tui): Fix message flow below input box #720

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -199,8 +199,16 @@ function ChannelHistoryView({
         <Text dimColor>ESC to go back, m to compose, j/k to scroll</Text>
       </Box>
 
-      {/* Message area - flex grow to fill available space */}
-      <Box marginBottom={1} flexDirection="column" flexGrow={1}>
+      {/* Message area - fixed height to prevent overflow below input */}
+      <Box
+        marginBottom={1}
+        flexDirection="column"
+        height={14}
+        borderStyle="single"
+        borderColor="gray"
+        paddingX={1}
+        overflow="hidden"
+      >
         {loading && <Text dimColor>Loading messages...</Text>}
         {error && <Text color="red">Error: {error}</Text>}
         {!loading && !error && (


### PR DESCRIPTION
## Summary
- Fix channel message area overflowing below input box
- Add explicit height constraint (14 rows) to message container
- Add border and padding for visual separation
- Messages now stay properly contained above input

## Test plan
- [x] Build passes: `cd tui && bun run build`
- [x] ChannelsView tests pass: `bun test src/__tests__/ChannelsView.test.tsx` (11/11)
- [ ] Manual verify: Open channel history, messages stay above input

Fixes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)