### PR TITLE
fix: Channel deletion fails with SQL logic error (#738)

### DIFF
--- a/pkg/channel/sqlite.go
+++ b/pkg/channel/sqlite.go
@@ -301,15 +301,81 @@ func (s *SQLiteStore) ListChannels() ([]*ChannelInfo, error) {
 }
 
 // DeleteChannel removes a channel by name.
+// This explicitly deletes related records and handles FTS cleanup
+// to avoid trigger issues with external content FTS tables (issue #738).
 func (s *SQLiteStore) DeleteChannel(name string) error {
 	ctx := context.Background()
-	result, err := s.db.ExecContext(ctx, "DELETE FROM channels WHERE name = ?", name)
+
+	// Get the channel ID first
+	ch, err := s.GetChannel(name)
 	if err != nil {
+		return err
+	}
+	if ch == nil {
+		return fmt.Errorf("channel %q not found", name)
+	}
+
+	// Use a transaction for atomic deletion
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Temporarily drop the FTS delete trigger to avoid issues with
+	// external content FTS5 tables (they don't support the delete command)
+	_, _ = tx.ExecContext(ctx, "DROP TRIGGER IF EXISTS messages_ad")
+
+	// Delete in correct order to satisfy foreign key constraints:
+	// 1. Delete reactions (references messages)
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM reactions WHERE message_id IN (SELECT id FROM messages WHERE channel_id = ?)",
+		ch.ID); err != nil {
+		return fmt.Errorf("failed to delete reactions: %w", err)
+	}
+
+	// 2. Delete mentions (references messages)
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM mentions WHERE message_id IN (SELECT id FROM messages WHERE channel_id = ?)",
+		ch.ID); err != nil {
+		return fmt.Errorf("failed to delete mentions: %w", err)
+	}
+
+	// 3. Delete messages
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM messages WHERE channel_id = ?",
+		ch.ID); err != nil {
+		return fmt.Errorf("failed to delete messages: %w", err)
+	}
+
+	// 4. Delete channel members
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM channel_members WHERE channel_id = ?",
+		ch.ID); err != nil {
+		return fmt.Errorf("failed to delete members: %w", err)
+	}
+
+	// 5. Delete the channel
+	if _, err := tx.ExecContext(ctx,
+		"DELETE FROM channels WHERE id = ?",
+		ch.ID); err != nil {
 		return fmt.Errorf("failed to delete channel: %w", err)
 	}
-	affected, _ := result.RowsAffected()
-	if affected == 0 {
-		return fmt.Errorf("channel %q not found", name)
+
+	// Recreate the FTS delete trigger
+	_, _ = tx.ExecContext(ctx, `
+		CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+			INSERT INTO messages_fts(messages_fts, rowid, content, sender) VALUES ('delete', old.id, old.content, old.sender);
+		END
+	`)
+
+	// Rebuild FTS index to stay consistent after deletions
+	if s.ftsAvailable {
+		_, _ = tx.ExecContext(ctx, "INSERT INTO messages_fts(messages_fts) VALUES('rebuild')")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit deletion: %w", err)
 	}
 	return nil
 }

--- a/pkg/channel/sqlite_test.go
+++ b/pkg/channel/sqlite_test.go
@@ -539,3 +539,60 @@ func TestSQLiteStore_Reactions(t *testing.T) {
 		t.Errorf("expected rocket reaction after toggle add, got %d", len(reactions["🚀"]))
 	}
 }
+
+// TestSQLiteStore_DeleteChannelWithMessages tests deletion of a channel
+// that has messages, members, mentions, and reactions (issue #738).
+func TestSQLiteStore_DeleteChannelWithMessages(t *testing.T) {
+	store := setupTestDB(t)
+
+	// Create channel with members
+	if _, err := store.CreateChannel("to-delete-full", ChannelTypeGroup, "Test channel"); err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	if err := store.AddMember("to-delete-full", "engineer-01"); err != nil {
+		t.Fatalf("failed to add member: %v", err)
+	}
+	if err := store.AddMember("to-delete-full", "engineer-02"); err != nil {
+		t.Fatalf("failed to add member: %v", err)
+	}
+
+	// Add messages (which creates FTS entries)
+	msg1, err := store.AddMessage("to-delete-full", "engineer-01", "Hello world", TypeText, "")
+	if err != nil {
+		t.Fatalf("failed to add message: %v", err)
+	}
+	msg2, err := store.AddMessage("to-delete-full", "engineer-02", "@engineer-01 check this", TypeTask, "")
+	if err != nil {
+		t.Fatalf("failed to add task message: %v", err)
+	}
+
+	// Add mention
+	if err := store.AddMention(msg2.ID, "engineer-01"); err != nil {
+		t.Fatalf("failed to add mention: %v", err)
+	}
+
+	// Add reactions
+	if err := store.AddReaction(msg1.ID, "👍", "engineer-02"); err != nil {
+		t.Fatalf("failed to add reaction: %v", err)
+	}
+	if err := store.AddReaction(msg2.ID, "✅", "engineer-01"); err != nil {
+		t.Fatalf("failed to add reaction: %v", err)
+	}
+
+	// Verify data exists
+	history, _ := store.GetHistory("to-delete-full", 10)
+	if len(history) != 2 {
+		t.Errorf("expected 2 messages before delete, got %d", len(history))
+	}
+
+	// This is the bug from issue #738 - deletion should work
+	if err := store.DeleteChannel("to-delete-full"); err != nil {
+		t.Fatalf("failed to delete channel with messages: %v", err)
+	}
+
+	// Verify channel is gone
+	ch, _ := store.GetChannel("to-delete-full")
+	if ch != nil {
+		t.Error("channel should be deleted")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixed SQL logic error when deleting channels with messages
- Root cause: FTS5 external content table triggers don't support the 'delete' command
- Solution: Temporarily drop trigger, explicitly delete related records, rebuild FTS index

## Changes
- `pkg/channel/sqlite.go`: Rewrote DeleteChannel to handle FTS trigger issues
- `pkg/channel/sqlite_test.go`: Added test for deleting channels with messages/members/reactions

## Test plan
- [x] Run `go test -race ./pkg/channel/` - all 17 tests pass
- [x] Run `go test -race ./...` - full suite passes
- [x] Verify lint clean: `make lint`
- [ ] Manual test: `bc channel delete <channel-with-messages>`

Fixes #738

🤖 Generated with [Claude Code](https://claude.com/claude-code)