### PR TITLE
feat(tui): Add timestamps and usernames to channel messages (#722)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useChannels, useChannelHistory } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
+import { ChatMessage } from './ChatMessage';
 import type { Channel } from '../types';
 
 interface ChannelsViewProps {
@@ -207,13 +208,12 @@ function ChannelHistoryView({
           <>
             {hasMoreAbove && <Text dimColor>↑ more messages above</Text>}
             {displayMessages.map((msg, index) => (
-              <Box key={index} width="100%" flexDirection="column">
-                <Box>
-                  <Text color="yellow">{msg.sender}</Text>
-                  <Text dimColor> ({formatMessageTime(msg.time)})</Text>
-                </Box>
-                <Text wrap="truncate">{msg.message}</Text>
-              </Box>
+              <ChatMessage
+                key={`${msg.time}-${index}`}
+                sender={msg.sender}
+                message={msg.message}
+                timestamp={msg.time}
+              />
             ))}
             {hasMoreBelow && <Text dimColor>↓ more messages below</Text>}
             {messages?.length === 0 && <Text dimColor>No messages yet</Text>}
@@ -240,33 +240,6 @@ function ChannelHistoryView({
       </Box>
     </Box>
   );
-}
-
-/**
- * Format message timestamp for display
- */
-function formatMessageTime(time: string): string {
-  try {
-    const date = new Date(time);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-
-    if (diffMins < 1) return 'now';
-    if (diffMins < 60) return `${String(diffMins)}m ago`;
-
-    const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${String(diffHours)}h ago`;
-
-    return date.toLocaleTimeString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  } catch {
-    return time;
-  }
 }
 
 export default ChannelsView;


### PR DESCRIPTION
## Summary
- Use existing `ChatMessage` component in `ChannelHistoryView` for consistent message rendering
- Adds role-based color coding (cyan for tech-leads, green for engineers, magenta for root)
- Adds relative timestamps (now, 5m ago, 2h ago, etc.)
- Enables @mention highlighting via MentionText component
- Removes duplicate `formatMessageTime` function (code deduplication)

## Test plan
- [x] `npx tsc --noEmit` passes (typecheck)
- [x] `bun test ChannelsView ChatMessage` - 30 tests pass
- [x] `make lint` - 0 issues
- [x] `make test` - all Go tests pass

Fixes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)