### PR TITLE
feat(tui): Add chat bubble styling with left/right alignment (#723)

### DIFF
--- a/tui/src/__tests__/ChatMessage.test.tsx
+++ b/tui/src/__tests__/ChatMessage.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
-import { describe, it, expect, beforeEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { ChatMessage } from '../components/ChatMessage';
 
 describe('ChatMessage', () => {
@@ -169,6 +169,85 @@ describe('ChatMessage', () => {
         <ChatMessage {...baseProps} message="Line 1\nLine 2\nLine 3" />
       );
       expect(lastFrame()).toContain('Line 1');
+    });
+  });
+
+  describe('bubble styling and alignment', () => {
+    it('shows "(you)" indicator for own messages', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="eng-01" currentUser="eng-01" />
+      );
+      expect(lastFrame()).toContain('(you)');
+    });
+
+    it('does not show "(you)" for other users messages', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="eng-02" currentUser="eng-01" />
+      );
+      expect(lastFrame()).not.toContain('(you)');
+    });
+
+    it('renders message without "(you)" when no currentUser provided', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="eng-01" />
+      );
+      expect(lastFrame()).not.toContain('(you)');
+    });
+
+    it('renders own message with bubble border', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="eng-01" currentUser="eng-01" />
+      );
+      // Should render with round border (indicated by border characters)
+      expect(lastFrame()).toContain('eng-01');
+      expect(lastFrame()).toContain('(you)');
+    });
+
+    it('renders other user message with bubble border', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="eng-02" currentUser="eng-01" />
+      );
+      // Should render with round border (gray for others)
+      expect(lastFrame()).toContain('eng-02');
+      expect(lastFrame()).not.toContain('(you)');
+    });
+
+    it('applies custom maxBubbleWidth', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} maxBubbleWidth={40} />
+      );
+      // Should render without errors with custom width
+      expect(lastFrame()).toContain('eng-01');
+    });
+  });
+
+  describe('role colors for additional roles', () => {
+    it('renders tl- prefix sender (tech lead)', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="tl-01" />
+      );
+      expect(lastFrame()).toContain('tl-01');
+    });
+
+    it('renders mgr- prefix sender (manager)', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="mgr-01" />
+      );
+      expect(lastFrame()).toContain('mgr-01');
+    });
+
+    it('renders pm- prefix sender (product manager)', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="pm-01" />
+      );
+      expect(lastFrame()).toContain('pm-01');
+    });
+
+    it('renders ux- prefix sender', () => {
+      const { lastFrame } = render(
+        <ChatMessage {...baseProps} sender="ux-01" />
+      );
+      expect(lastFrame()).toContain('ux-01');
     });
   });
 });

--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -221,6 +221,7 @@ function ChannelHistoryView({
                 sender={msg.sender}
                 message={msg.message}
                 timestamp={msg.time}
+                currentUser={process.env.BC_AGENT_ID}
               />
             ))}
             {hasMoreBelow && <Text dimColor>↓ more messages below</Text>}

--- a/tui/src/components/ChatMessage.tsx
+++ b/tui/src/components/ChatMessage.tsx
@@ -12,6 +12,8 @@ export interface ChatMessageProps {
   reactions?: Array<{ type: ReactionType; count: number; isOwn?: boolean }>;
   isRead?: boolean;
   isSelected?: boolean;
+  /** Maximum width for message bubbles (default: 60) */
+  maxBubbleWidth?: number;
 }
 
 const formatRelativeTime = (timestamp: string): string => {
@@ -40,17 +42,21 @@ const formatRelativeTime = (timestamp: string): string => {
 
 const getRoleColor = (sender: string): string => {
   if (sender === 'root') return 'magenta';
-  if (sender.startsWith('tech-lead') || sender.includes('fox') || sender.includes('eagle')) {
+  if (sender.startsWith('tech-lead') || sender.startsWith('tl-') || sender.includes('fox') || sender.includes('eagle')) {
     return 'cyan';
   }
   if (sender.startsWith('eng-') || sender.includes('falcon')) return 'green';
+  if (sender.startsWith('mgr-') || sender.startsWith('pm-')) return 'yellow';
+  if (sender.startsWith('ux-')) return 'blue';
   return 'white';
 };
 
 /**
- * Dense chat message component with futuristic design
+ * Chat message component with bubble styling
  *
  * Features:
+ * - Message bubbles with visual distinction
+ * - Own messages aligned right, others aligned left
  * - Colored sender by role
  * - Time in compact format
  * - @mention highlighting
@@ -65,42 +71,68 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
   reactions = [],
   isRead = true,
   isSelected = false,
+  maxBubbleWidth = 60,
 }) => {
   const time = formatRelativeTime(timestamp);
   const senderColor = getRoleColor(sender);
+  const isOwnMessage = currentUser !== undefined && sender === currentUser;
+
+  // Bubble styling based on ownership
+  const bubbleBorderColor = isOwnMessage ? 'cyan' : 'gray';
+  const bubbleAlignment = isOwnMessage ? 'flex-end' : 'flex-start';
 
   return (
     <Box
       flexDirection="column"
-      paddingX={1}
-      borderStyle={isSelected ? 'single' : undefined}
-      borderColor={isSelected ? 'cyan' : undefined}
+      width="100%"
+      marginY={0}
     >
-      {/* Header: time | sender | read status */}
-      <Box>
-        <Text color="gray" dimColor>
-          {time}
-        </Text>
-        <Text> </Text>
-        <Text color={senderColor} bold>
-          {sender}
-        </Text>
-        {!isRead && (
-          <Text color="blue"> ●</Text>
-        )}
-      </Box>
+      {/* Message container with alignment */}
+      <Box
+        justifyContent={bubbleAlignment}
+        width="100%"
+      >
+        {/* Message bubble */}
+        <Box
+          flexDirection="column"
+          borderStyle={isSelected ? 'double' : 'round'}
+          borderColor={isSelected ? 'yellow' : bubbleBorderColor}
+          paddingX={1}
+          width={maxBubbleWidth}
+        >
+          {/* Header: sender | time | read status */}
+          <Box justifyContent="space-between">
+            <Box>
+              <Text color={senderColor} bold>
+                {sender}
+              </Text>
+              {isOwnMessage && (
+                <Text dimColor> (you)</Text>
+              )}
+            </Box>
+            <Box>
+              <Text color="gray" dimColor>
+                {time}
+              </Text>
+              {!isRead && (
+                <Text color="blue"> ●</Text>
+              )}
+            </Box>
+          </Box>
 
-      {/* Message body with @mentions */}
-      <Box paddingLeft={2}>
-        <MentionText text={message} currentUser={currentUser} />
-      </Box>
+          {/* Message body with @mentions */}
+          <Box>
+            <MentionText text={message} currentUser={currentUser} />
+          </Box>
 
-      {/* Reactions */}
-      {reactions.length > 0 && (
-        <Box paddingLeft={2}>
-          <ReactionBar reactions={reactions} />
+          {/* Reactions */}
+          {reactions.length > 0 && (
+            <Box marginTop={0}>
+              <ReactionBar reactions={reactions} />
+            </Box>
+          )}
         </Box>
-      )}
+      </Box>
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- Implements message bubbles with visual distinction for channel messages
- Own messages (sender === currentUser) align right with cyan border
- Other users' messages align left with gray border
- Shows "(you)" indicator for own messages
- Added role-based sender colors for tl-, mgr-, pm-, ux- prefixes

## Changes
- Updated `ChatMessage.tsx` with bubble styling using Ink's Box borders
- Updated `ChannelsView.tsx` to use `ChatMessage` component with `currentUser` prop
- Added 10 new tests for bubble styling and alignment features

## Test Results
- 40/40 tests passing for ChatMessage and ChannelsView components
- Build passes with no TypeScript errors
- Lint passes (pre-existing issues in other files not affected)

## Visual Design
- Round borders for message bubbles
- Cyan border for own messages (right-aligned)
- Gray border for others' messages (left-aligned)
- Consistent with existing theme system

Fixes #723

---
Generated with [Claude Code](https://claude.com/claude-code)