### PR TITLE
feat(tui): Auto-expand message input for long text (#721)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -2,12 +2,25 @@
  * ChannelsView - Channel list and message history component
  */
 
-import React, { useState, useEffect } from 'react';
-import { Box, Text, useInput } from 'ink';
+import React, { useState, useEffect, useMemo } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
 import { useChannels, useChannelHistory } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { ChatMessage } from './ChatMessage';
 import type { Channel } from '../types';
+
+/**
+ * Calculate input box height based on message length
+ * Height expands from 3 (min) to 10 (max) lines based on content
+ */
+function calculateInputHeight(messageLength: number, terminalWidth: number): number {
+  const MIN_HEIGHT = 3;
+  const MAX_HEIGHT = 10;
+  // Account for border (2) + prompt "> " (2) + cursor (1)
+  const availableWidth = Math.max(terminalWidth - 5, 20);
+  const lines = Math.ceil(messageLength / availableWidth) + 1;
+  return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, lines));
+}
 
 interface ChannelsViewProps {
   /** Disable input handling (useful for testing) */
@@ -125,6 +138,16 @@ function ChannelHistoryView({
   const [messageBuffer, setMessageBuffer] = useState('');
   const [scrollOffset, setScrollOffset] = useState(0);
   const { setFocus, returnFocus } = useFocus();
+  const { stdout } = useStdout();
+
+  // Calculate dynamic input height based on message length
+  const terminalWidth = stdout?.columns ?? 80;
+  const inputHeight = useMemo(
+    () => calculateInputHeight(messageBuffer.length, terminalWidth),
+    [messageBuffer.length, terminalWidth]
+  );
+  // Message area adjusts as input expands (base 14 + extra from input growth)
+  const messageAreaHeight = 14 + (3 - inputHeight);
 
   /**
    * Synchronize focus state with input mode
@@ -200,11 +223,11 @@ function ChannelHistoryView({
         <Text dimColor>ESC to go back, m to compose, j/k to scroll</Text>
       </Box>
 
-      {/* Message area - fixed height to prevent overflow below input */}
+      {/* Message area - dynamic height adjusts as input expands */}
       <Box
         marginBottom={1}
         flexDirection="column"
-        height={14}
+        height={messageAreaHeight}
         borderStyle="single"
         borderColor="gray"
         paddingX={1}
@@ -229,8 +252,8 @@ function ChannelHistoryView({
         )}
       </Box>
 
-      {/* Input area - fixed height with proper separation */}
-      <Box height={3} flexDirection="column" marginBottom={1} borderStyle="single" borderColor={inputMode ? 'cyan' : 'gray'} paddingX={1}>
+      {/* Input area - auto-expands based on message length (3-10 lines) */}
+      <Box height={inputHeight} flexDirection="column" marginBottom={1} borderStyle="single" borderColor={inputMode ? 'cyan' : 'gray'} paddingX={1}>
         {inputMode ? (
           <Text>
             <Text color="cyan">{'> '}</Text>


### PR DESCRIPTION
## Summary
- Add dynamic height calculation for channel message input box
- Input expands from 3 to 10 lines as user types longer messages
- Message area shrinks proportionally to make room
- Uses terminal width for accurate line wrapping calculation
- Memoized height calculation for performance

**Note:** This is a clean implementation. PR #737 exists but has merge conflicts.

## Test plan
- [x] `npx tsc --noEmit` passes (typecheck)
- [x] `bun test ChannelsView` - 11 tests pass
- [x] `make lint` - 0 issues
- [x] Pre-commit hooks pass

Fixes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)