### PR TITLE
fix(security): Validate env var keys to prevent shell injection #715

### DIFF
--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -18,6 +19,11 @@ import (
 
 	"github.com/rpuneet/bc/pkg/log"
 )
+
+// validEnvVarName matches valid POSIX environment variable names:
+// Must start with letter or underscore, followed by letters, digits, or underscores.
+// This prevents shell injection through malicious key names.
+var validEnvVarName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // Session represents a tmux session.
 type Session struct {
@@ -120,12 +126,18 @@ func (m *Manager) CreateSessionWithCommand(name, dir, command string) error {
 }
 
 // CreateSessionWithEnv creates a session with env vars baked into the shell command.
+// Environment variable keys are validated to prevent shell injection attacks.
+// Keys must match POSIX standards: start with letter/underscore, contain only alphanumerics/underscores.
 func (m *Manager) CreateSessionWithEnv(name, dir, command string, env map[string]string) error {
 	fullName := m.SessionName(name)
 
 	// Build shell command with env vars prefixed
 	parts := make([]string, 0, len(env)+1)
 	for k, v := range env {
+		// Validate env var key to prevent shell injection
+		if !validEnvVarName.MatchString(k) {
+			return fmt.Errorf("invalid environment variable name %q: must match [A-Za-z_][A-Za-z0-9_]*", k)
+		}
 		parts = append(parts, fmt.Sprintf("export %s=%q;", k, v))
 	}
 	parts = append(parts, command)
@@ -374,7 +386,13 @@ func (m *Manager) KillServer() error {
 }
 
 // SetEnvironment sets an environment variable in a session.
+// Environment variable key is validated to prevent shell injection attacks.
+// Key must match POSIX standards: start with letter/underscore, contain only alphanumerics/underscores.
 func (m *Manager) SetEnvironment(name, key, value string) error {
+	// Validate env var key to prevent shell injection
+	if !validEnvVarName.MatchString(key) {
+		return fmt.Errorf("invalid environment variable name %q: must match [A-Za-z_][A-Za-z0-9_]*", key)
+	}
 	fullName := m.SessionName(name)
 	cmd := m.command("tmux", "set-environment", "-t", fullName, key, value)
 	output, err := cmd.CombinedOutput()

--- a/pkg/tmux/session_test.go
+++ b/pkg/tmux/session_test.go
@@ -1048,6 +1048,128 @@ func TestSetEnvironment_Error(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Environment variable key validation tests (security fix #715)
+// ---------------------------------------------------------------------------
+
+func TestCreateSessionWithEnv_ValidKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"simple lowercase", "foo"},
+		{"simple uppercase", "FOO"},
+		{"mixed case", "FooBar"},
+		{"with underscore", "FOO_BAR"},
+		{"starts with underscore", "_FOO"},
+		{"with numbers", "FOO123"},
+		{"underscore and numbers", "_FOO_123_BAR"},
+		{"single letter", "X"},
+		{"single underscore", "_"},
+		{"path style", "BC_AGENT_WORKTREE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestManager("bc-", mockCmd("", "", 0))
+			env := map[string]string{tt.key: "value"}
+			err := m.CreateSessionWithEnv("agent1", "/workspace", "echo", env)
+			if err != nil {
+				t.Errorf("expected valid key %q to be accepted, got error: %v", tt.key, err)
+			}
+		})
+	}
+}
+
+func TestCreateSessionWithEnv_InvalidKeys_ShellInjection(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"shell injection semicolon", "FOO;rm -rf /;X"},
+		{"shell injection backtick", "FOO`whoami`"},
+		{"shell injection dollar", "FOO$(whoami)"},
+		{"shell injection newline", "FOO\nBAR"},
+		{"shell injection pipe", "FOO|cat"},
+		{"shell injection ampersand", "FOO&&echo"},
+		{"shell injection redirect", "FOO>file"},
+		{"starts with number", "123FOO"},
+		{"contains space", "FOO BAR"},
+		{"contains hyphen", "FOO-BAR"},
+		{"contains dot", "FOO.BAR"},
+		{"empty string", ""},
+		{"equals sign", "FOO=BAR"},
+		{"quotes", "FOO\"BAR"},
+		{"single quote", "FOO'BAR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestManager("bc-", mockCmd("", "", 0))
+			env := map[string]string{tt.key: "value"}
+			err := m.CreateSessionWithEnv("agent1", "/workspace", "echo", env)
+			if err == nil {
+				t.Errorf("expected invalid key %q to be rejected", tt.key)
+			}
+			if err != nil && !strings.Contains(err.Error(), "invalid environment variable name") {
+				t.Errorf("expected validation error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSetEnvironment_ValidKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"simple lowercase", "foo"},
+		{"simple uppercase", "FOO"},
+		{"with underscore", "FOO_BAR"},
+		{"starts with underscore", "_FOO"},
+		{"with numbers", "FOO123"},
+		{"bc agent vars", "BC_AGENT_ID"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestManager("bc-", mockCmd("", "", 0))
+			err := m.SetEnvironment("agent1", tt.key, "value")
+			if err != nil {
+				t.Errorf("expected valid key %q to be accepted, got error: %v", tt.key, err)
+			}
+		})
+	}
+}
+
+func TestSetEnvironment_InvalidKeys_ShellInjection(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"shell injection semicolon", "FOO;rm -rf /;X"},
+		{"shell injection backtick", "FOO`id`"},
+		{"shell injection dollar", "$(id)"},
+		{"contains hyphen", "FOO-BAR"},
+		{"starts with number", "1FOO"},
+		{"empty string", ""},
+		{"space", "FOO BAR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestManager("bc-", mockCmd("", "", 0))
+			err := m.SetEnvironment("agent1", tt.key, "value")
+			if err == nil {
+				t.Errorf("expected invalid key %q to be rejected", tt.key)
+			}
+			if err != nil && !strings.Contains(err.Error(), "invalid environment variable name") {
+				t.Errorf("expected validation error, got: %v", err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Prefix isolation test
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
**SECURITY FIX (P0)**: Environment variable keys were not validated before being embedded into shell commands in `CreateSessionWithEnv` and `SetEnvironment`. This allowed shell injection attacks via malicious key names.

**Attack example**: Key `FOO;rm -rf /;X` would result in:
```bash
export FOO;rm -rf /;X="value";
```

**Fix**:
- Add regex validation for POSIX env var names: `[A-Za-z_][A-Za-z0-9_]*`
- Reject keys that don't match the pattern
- Applied to both `CreateSessionWithEnv()` and `SetEnvironment()`

## Test plan
- [x] Tests pass: `go test -race ./pkg/tmux/...` (all 64 tests)
- [x] Build passes: `make build`
- [x] Lint passes: `make lint` (0 issues)
- [x] Valid key acceptance tests (10 cases)
- [x] Invalid key rejection tests including shell injection (15 cases)

Fixes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)