### PR TITLE
fix(tui): Dashboard rendering - metric cards and table width (#763)

### DIFF
--- a/tui/src/components/DataTable.tsx
+++ b/tui/src/components/DataTable.tsx
@@ -60,8 +60,11 @@ export function DataTable<T extends Record<string, unknown>>({
     return selectedIndex;
   }, [selectedIndex, maxVisibleRows, scrollOffset]);
 
+  // Calculate available width accounting for border (2 chars) and padding (2 chars)
+  const tableWidth = Math.max(40, terminalWidth - 4);
+
   return (
-    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} width={terminalWidth}>
+    <Box flexDirection="column" borderStyle="single" borderColor="gray" paddingX={1} width={tableWidth}>
       {/* Header row */}
       {showHeader && (
         <Box>

--- a/tui/src/components/MetricCard.tsx
+++ b/tui/src/components/MetricCard.tsx
@@ -20,11 +20,11 @@ export function MetricCard({
   suffix = '',
 }: MetricCardProps) {
   return (
-    <Box flexDirection="column" paddingX={2} borderStyle="single" borderColor="gray">
+    <Box flexDirection="column" paddingX={1} borderStyle="single" borderColor="gray" minHeight={4}>
+      <Text dimColor>{label}</Text>
       <Text bold color={color}>
         {prefix}{value}{suffix}
       </Text>
-      <Text dimColor>{label}</Text>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
- Fixes metric cards showing only label without value and missing top borders
- Fixes DataTable causing line wrapping with extra │ characters

## Changes
- **MetricCard**: Swap order to show label first then value (conventional)
- **MetricCard**: Add `minHeight=4` to ensure full border rendering
- **DataTable**: Subtract 4 from terminalWidth for border/padding overhead

## Test Results
- 15/15 DataTable tests passing
- TUI builds successfully

Fixes #763

---
Generated with [Claude Code](https://claude.com/claude-code)