### PR TITLE
fix: Clean up team memberships when agent is deleted (#730)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -860,6 +860,13 @@ func runAgentDelete(cmd *cobra.Command, args []string) error {
 		_ = channelStore.Close()
 	}
 
+	// Remove from all teams (issue #730)
+	teamStore := team.NewStore(ws.RootDir)
+	if teamErr := teamStore.RemoveAgentFromAllTeams(agentName); teamErr != nil {
+		// Log warning but don't fail deletion
+		fmt.Printf("Warning: failed to clean up team memberships: %v\n", teamErr)
+	}
+
 	// Delete agent with options
 	fmt.Printf("Deleting %s... ", agentName)
 	deleteOpts := agent.DeleteOptions{

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -185,6 +185,32 @@ func (s *Store) SetDescription(teamName, description string) error {
 	})
 }
 
+// RemoveAgentFromAllTeams removes an agent from all teams they belong to.
+// This should be called when an agent is deleted to maintain data integrity.
+func (s *Store) RemoveAgentFromAllTeams(agentName string) error {
+	teams, err := s.List()
+	if err != nil {
+		return err
+	}
+
+	for _, team := range teams {
+		// Check if agent is a member
+		if slices.Contains(team.Members, agentName) {
+			if err := s.RemoveMember(team.Name, agentName); err != nil {
+				return fmt.Errorf("failed to remove %s from team %s: %w", agentName, team.Name, err)
+			}
+		}
+		// Also clear lead if this agent was the lead
+		if team.Lead == agentName {
+			if err := s.SetLead(team.Name, ""); err != nil {
+				return fmt.Errorf("failed to clear lead for team %s: %w", team.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
 func (s *Store) save(team *Team) error {
 	if err := s.Init(); err != nil {
 		return err

--- a/pkg/team/team_test.go
+++ b/pkg/team/team_test.go
@@ -316,3 +316,85 @@ func TestTeamPath(t *testing.T) {
 		t.Errorf("teamPath = %q, want %q", got, expected)
 	}
 }
+
+func TestStoreRemoveAgentFromAllTeams(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Create multiple teams
+	_, _ = store.Create("team-a")
+	_, _ = store.Create("team-b")
+	_, _ = store.Create("team-c")
+
+	// Add agent to multiple teams
+	_ = store.AddMember("team-a", "eng-01")
+	_ = store.AddMember("team-a", "eng-02")
+	_ = store.AddMember("team-b", "eng-01")
+	_ = store.AddMember("team-c", "eng-03")
+
+	// Set eng-01 as lead of team-b
+	_ = store.SetLead("team-b", "eng-01")
+
+	// Remove eng-01 from all teams
+	err := store.RemoveAgentFromAllTeams("eng-01")
+	if err != nil {
+		t.Fatalf("RemoveAgentFromAllTeams failed: %v", err)
+	}
+
+	// Verify team-a no longer has eng-01
+	teamA, _ := store.Get("team-a")
+	for _, m := range teamA.Members {
+		if m == "eng-01" {
+			t.Error("team-a should not contain eng-01")
+		}
+	}
+	if len(teamA.Members) != 1 || teamA.Members[0] != "eng-02" {
+		t.Errorf("team-a members = %v, want [eng-02]", teamA.Members)
+	}
+
+	// Verify team-b no longer has eng-01 and lead is cleared
+	teamB, _ := store.Get("team-b")
+	if len(teamB.Members) != 0 {
+		t.Errorf("team-b members = %v, want []", teamB.Members)
+	}
+	if teamB.Lead != "" {
+		t.Errorf("team-b lead = %q, want empty (cleared)", teamB.Lead)
+	}
+
+	// Verify team-c unchanged
+	teamC, _ := store.Get("team-c")
+	if len(teamC.Members) != 1 || teamC.Members[0] != "eng-03" {
+		t.Errorf("team-c members = %v, want [eng-03]", teamC.Members)
+	}
+}
+
+func TestStoreRemoveAgentFromAllTeams_NoTeams(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Should not error when no teams exist
+	err := store.RemoveAgentFromAllTeams("eng-01")
+	if err != nil {
+		t.Fatalf("RemoveAgentFromAllTeams with no teams failed: %v", err)
+	}
+}
+
+func TestStoreRemoveAgentFromAllTeams_AgentNotInAnyTeam(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, _ = store.Create("team-a")
+	_ = store.AddMember("team-a", "eng-02")
+
+	// Remove agent that doesn't exist in any team
+	err := store.RemoveAgentFromAllTeams("eng-01")
+	if err != nil {
+		t.Fatalf("RemoveAgentFromAllTeams failed: %v", err)
+	}
+
+	// Verify team unchanged
+	team, _ := store.Get("team-a")
+	if len(team.Members) != 1 || team.Members[0] != "eng-02" {
+		t.Errorf("team-a members = %v, want [eng-02]", team.Members)
+	}
+}


### PR DESCRIPTION
## Summary
- Auto-remove agent from all teams when deleted
- Clear team lead if deleted agent was lead
- Prevents orphaned team memberships

## Changes
- `pkg/team/team.go`: Add `RemoveAgentFromAllTeams` function
- `internal/cmd/agent.go`: Call team cleanup on agent delete
- `pkg/team/team_test.go`: Add 3 tests

## Test plan
- [x] `go test -race ./pkg/team/` - all pass
- [x] `go test -race ./internal/cmd/` - all pass
- [x] `make lint` - 0 issues

Fixes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)