### PR TITLE
feat(tui): Add Tab/Shift+Tab for cycling through tabs (#766)

### DIFF
--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -47,6 +47,8 @@ export interface NavigationContextValue {
   goBack: () => void;
   goForward: () => void;
   goHome: () => void;
+  nextTab: () => void;
+  prevTab: () => void;
 
   // Utilities
   isActive: (view: View) => boolean;
@@ -129,6 +131,33 @@ export function NavigationProvider({
     navigate('dashboard');
   }, [navigate]);
 
+  // Get main tabs (exclude help '?')
+  const mainTabs = useMemo(() => tabs.filter(t => t.key !== '?'), [tabs]);
+
+  const nextTab = useCallback(() => {
+    const currentIndex = mainTabs.findIndex(t => t.view === state.currentView);
+    if (currentIndex === -1) {
+      // If not on a main tab, go to first
+      navigate(mainTabs[0]?.view ?? 'dashboard');
+    } else {
+      // Wrap around to first tab after last
+      const nextIndex = (currentIndex + 1) % mainTabs.length;
+      navigate(mainTabs[nextIndex]?.view ?? 'dashboard');
+    }
+  }, [mainTabs, state.currentView, navigate]);
+
+  const prevTab = useCallback(() => {
+    const currentIndex = mainTabs.findIndex(t => t.view === state.currentView);
+    if (currentIndex === -1) {
+      // If not on a main tab, go to last
+      navigate(mainTabs[mainTabs.length - 1]?.view ?? 'dashboard');
+    } else {
+      // Wrap around to last tab before first
+      const prevIndex = (currentIndex - 1 + mainTabs.length) % mainTabs.length;
+      navigate(mainTabs[prevIndex]?.view ?? 'dashboard');
+    }
+  }, [mainTabs, state.currentView, navigate]);
+
   const isActive = useCallback(
     (view: View) => state.currentView === view,
     [state.currentView]
@@ -155,11 +184,13 @@ export function NavigationProvider({
       goBack,
       goForward,
       goHome,
+      nextTab,
+      prevTab,
       isActive,
       getTabByKey,
       getTabByView,
     }),
-    [state, tabs, navigate, goBack, goForward, goHome, isActive, getTabByKey, getTabByView]
+    [state, tabs, navigate, goBack, goForward, goHome, nextTab, prevTab, isActive, getTabByKey, getTabByView]
   );
 
   return (

--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -22,7 +22,7 @@ export interface UseKeyboardNavigationOptions {
  */
 export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}): void {
   const { disabled = false, onQuit } = options;
-  const { navigate, goHome, getTabByKey } = useNavigation();
+  const { navigate, goHome, getTabByKey, nextTab, prevTab } = useNavigation();
   const { isFocused } = useFocus();
 
   useInput(
@@ -48,6 +48,16 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
       const tab = getTabByKey(input);
       if (tab) {
         navigate(tab.view);
+        return;
+      }
+
+      // Tab key: next tab, Shift+Tab: previous tab
+      if (key.tab) {
+        if (key.shift) {
+          prevTab();
+        } else {
+          nextTab();
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- Tab key cycles to next tab (wrapping 5 → 1)
- Shift+Tab cycles to previous tab (wrapping 1 → 5)
- Excludes help tab from cycle (only main tabs 1-5)

## Changes
- `NavigationContext.tsx`: Add `nextTab()` and `prevTab()` functions
- `useKeyboardNavigation.ts`: Handle `key.tab` with shift detection

## Test Results
- 281/302 tests passing (8 failures pre-existing)
- Build passes

Fixes #766

---
Generated with [Claude Code](https://claude.com/claude-code)