### PR TITLE
fix(tui): Add text wrapping to prevent message overlap (#767)

### DIFF
--- a/tui/src/components/MentionText.tsx
+++ b/tui/src/components/MentionText.tsx
@@ -72,7 +72,7 @@ export const MentionText: React.FC<MentionTextProps> = ({
     );
   }
 
-  return <Text>{parts}</Text>;
+  return <Text wrap="wrap">{parts}</Text>;
 };
 
 export default MentionText;


### PR DESCRIPTION
## Summary
- Added `wrap="wrap"` to MentionText component
- Prevents message text from overlapping across lines

## Changes
- `tui/src/components/MentionText.tsx`: Add wrap property

## Test plan
- [x] Build passes: `bun run build`
- [ ] Manual test: View channel with long messages

Fixes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)