### PR TITLE
feat(tui): Add breadcrumb navigation (#762)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -9,6 +9,7 @@ import {
   useNavigation,
   useKeyboardNavigation,
   TabBar,
+  Breadcrumb,
   FocusProvider,
   type View,
 } from './navigation';
@@ -63,6 +64,9 @@ function AppContent({ disableInput }: AppContentProps): React.ReactElement {
     <Box flexDirection="column" padding={1} width={terminalWidth} height={terminalHeight}>
       {/* Header with tab bar */}
       <TabBar />
+
+      {/* Breadcrumb navigation (shows path when navigated deep) */}
+      <Breadcrumb />
 
       {/* Main content area - grows to fill available space */}
       <Box flexDirection="column" marginTop={1} flexGrow={1}>

--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { useChannels, useChannelHistory } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
+import { useNavigation } from '../navigation/NavigationContext';
 import { ChatMessage } from './ChatMessage';
 import type { Channel } from '../types';
 
@@ -31,8 +32,18 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
   const { data: channels, loading: channelsLoading, error: channelsError } = useChannels();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [viewMode, setViewMode] = useState<'list' | 'history'>('list');
+  const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   const selectedChannel = channels?.[selectedIndex];
+
+  // Update breadcrumbs when view mode or selected channel changes
+  useEffect(() => {
+    if (viewMode === 'history' && selectedChannel) {
+      setBreadcrumbs([{ label: `#${selectedChannel.name}` }]);
+    } else {
+      clearBreadcrumbs();
+    }
+  }, [viewMode, selectedChannel, setBreadcrumbs, clearBreadcrumbs]);
 
   useInput(
     (input, key) => {

--- a/tui/src/navigation/Breadcrumb.tsx
+++ b/tui/src/navigation/Breadcrumb.tsx
@@ -1,0 +1,38 @@
+/**
+ * Breadcrumb - Navigation breadcrumb component
+ * Shows current location path in the navigation hierarchy
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { useNavigation } from './NavigationContext';
+
+export function Breadcrumb(): React.ReactElement | null {
+  const { breadcrumbs, currentView, getTabByView } = useNavigation();
+
+  // Don't show breadcrumb if empty or only has one item
+  if (breadcrumbs.length === 0) {
+    return null;
+  }
+
+  // Get current tab label as base
+  const currentTab = getTabByView(currentView);
+  const basePath = currentTab?.label ?? currentView;
+
+  return (
+    <Box>
+      <Text dimColor>{'> '}</Text>
+      <Text color="cyan">{basePath}</Text>
+      {breadcrumbs.map((item, index) => (
+        <React.Fragment key={index}>
+          <Text dimColor> {'>'} </Text>
+          <Text color={index === breadcrumbs.length - 1 ? 'white' : 'cyan'}>
+            {item.label}
+          </Text>
+        </React.Fragment>
+      ))}
+    </Box>
+  );
+}
+
+export default Breadcrumb;

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -25,12 +25,19 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: '?', view: 'help', label: 'Help', shortcut: '?' },
 ];
 
+// Breadcrumb item for showing navigation path
+export interface BreadcrumbItem {
+  label: string;
+  view?: View;
+}
+
 // Navigation state
 export interface NavigationState {
   currentView: View;
   previousView: View | null;
   history: View[];
   historyIndex: number;
+  breadcrumbs: BreadcrumbItem[];
 }
 
 // Navigation context value
@@ -41,6 +48,7 @@ export interface NavigationContextValue {
   tabs: TabConfig[];
   canGoBack: boolean;
   canGoForward: boolean;
+  breadcrumbs: BreadcrumbItem[];
 
   // Actions
   navigate: (view: View) => void;
@@ -49,6 +57,8 @@ export interface NavigationContextValue {
   goHome: () => void;
   nextTab: () => void;
   prevTab: () => void;
+  setBreadcrumbs: (items: BreadcrumbItem[]) => void;
+  clearBreadcrumbs: () => void;
 
   // Utilities
   isActive: (view: View) => boolean;
@@ -74,6 +84,7 @@ export function NavigationProvider({
     previousView: null,
     history: [initialView],
     historyIndex: 0,
+    breadcrumbs: [],
   });
 
   const navigate = useCallback((view: View) => {
@@ -89,6 +100,7 @@ export function NavigationProvider({
         previousView: prev.currentView,
         history: newHistory,
         historyIndex: newHistory.length - 1,
+        breadcrumbs: [], // Clear breadcrumbs on navigation
       };
     });
   }, []);
@@ -158,6 +170,14 @@ export function NavigationProvider({
     }
   }, [mainTabs, state.currentView, navigate]);
 
+  const setBreadcrumbs = useCallback((items: BreadcrumbItem[]) => {
+    setState((prev) => ({ ...prev, breadcrumbs: items }));
+  }, []);
+
+  const clearBreadcrumbs = useCallback(() => {
+    setState((prev) => ({ ...prev, breadcrumbs: [] }));
+  }, []);
+
   const isActive = useCallback(
     (view: View) => state.currentView === view,
     [state.currentView]
@@ -180,17 +200,20 @@ export function NavigationProvider({
       tabs,
       canGoBack: state.historyIndex > 0,
       canGoForward: state.historyIndex < state.history.length - 1,
+      breadcrumbs: state.breadcrumbs,
       navigate,
       goBack,
       goForward,
       goHome,
       nextTab,
       prevTab,
+      setBreadcrumbs,
+      clearBreadcrumbs,
       isActive,
       getTabByKey,
       getTabByView,
     }),
-    [state, tabs, navigate, goBack, goForward, goHome, nextTab, prevTab, isActive, getTabByKey, getTabByView]
+    [state, tabs, navigate, goBack, goForward, goHome, nextTab, prevTab, setBreadcrumbs, clearBreadcrumbs, isActive, getTabByKey, getTabByView]
   );
 
   return (

--- a/tui/src/navigation/index.ts
+++ b/tui/src/navigation/index.ts
@@ -12,7 +12,10 @@ export {
   type NavigationState,
   type NavigationContextValue,
   type NavigationProviderProps,
+  type BreadcrumbItem,
 } from './NavigationContext';
+
+export { Breadcrumb } from './Breadcrumb';
 
 export {
   useKeyboardNavigation,


### PR DESCRIPTION
## Summary
- Adds breadcrumb navigation below TabBar when navigated deep
- Shows path like: > Channels > #general

## Changes
- `NavigationContext`: Add breadcrumbs state + setBreadcrumbs/clearBreadcrumbs
- `Breadcrumb.tsx`: New component showing navigation path
- `app.tsx`: Display Breadcrumb below TabBar
- `ChannelsView.tsx`: Set breadcrumb when entering channel

## Test Results
- 11/11 ChannelsView tests passing
- Build passes

Fixes #762

---
Generated with [Claude Code](https://claude.com/claude-code)