### PR TITLE
fix(cli): Improve error message when bc cost add amount is 0 (#713)

### DIFF
--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -927,7 +927,14 @@ func runCostAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate that we have either amount or token counts
+	amountProvided := cmd.Flags().Changed("amount")
 	if addCostAmountFlag <= 0 && (addCostInputTokens == 0 && addCostOutputTokens == 0) {
+		if amountProvided && addCostAmountFlag == 0 {
+			return fmt.Errorf("--amount must be greater than 0 (got 0)")
+		}
+		if amountProvided && addCostAmountFlag < 0 {
+			return fmt.Errorf("--amount cannot be negative (got %.4f)", addCostAmountFlag)
+		}
 		return fmt.Errorf("either --amount or --tokens-in/--tokens-out must be provided")
 	}
 


### PR DESCRIPTION
## Summary
- Improve error message when user provides `--amount 0`
- Now shows: `--amount must be greater than 0 (got 0)`
- Previously showed confusing: `either --amount or --tokens-in/--tokens-out must be provided`
- Also handles negative amounts with clear message

## Test plan
- [x] `make lint` - 0 issues
- [x] `go test ./internal/cmd/... -run TestCost -race` passes

Fixes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)