### PR TITLE
feat(tui): Add unread message tracking (#707)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -14,6 +14,7 @@ import {
   type View,
 } from './navigation';
 import { ThemeProvider, useTheme, type ThemeMode } from './theme';
+import { UnreadProvider } from './hooks';
 import { Dashboard } from './views/Dashboard';
 import { AgentsView } from './views/AgentsView';
 import { CommandsView } from './views/CommandsView';
@@ -38,7 +39,9 @@ export function App({
     <ThemeProvider config={{ mode: themeMode }}>
       <NavigationProvider initialView={initialView}>
         <FocusProvider>
-          <AppContent disableInput={disableInput} />
+          <UnreadProvider>
+            <AppContent disableInput={disableInput} />
+          </UnreadProvider>
         </FocusProvider>
       </NavigationProvider>
     </ThemeProvider>

--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
-import { useChannels, useChannelHistory } from '../hooks';
+import { useChannels, useChannelHistory, useUnread } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { ChatMessage } from './ChatMessage';
@@ -33,6 +33,7 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [viewMode, setViewMode] = useState<'list' | 'history'>('list');
   const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
+  const { getLastViewed } = useUnread();
 
   const selectedChannel = channels?.[selectedIndex];
 
@@ -44,6 +45,13 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
       clearBreadcrumbs();
     }
   }, [viewMode, selectedChannel, setBreadcrumbs, clearBreadcrumbs]);
+
+  // Calculate unread status for each channel (new = never viewed)
+  const getChannelUnread = (channelName: string): number => {
+    const lastViewed = getLastViewed(channelName);
+    // If never viewed, show as "new" (1 indicates new)
+    return lastViewed === null ? 1 : 0;
+  };
 
   useInput(
     (input, key) => {
@@ -101,6 +109,7 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
             key={channel.name}
             channel={channel}
             selected={index === selectedIndex}
+            unreadCount={getChannelUnread(channel.name)}
           />
         ))}
         {(!channels || channels.length === 0) && (
@@ -114,9 +123,10 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
 interface ChannelRowProps {
   channel: Channel;
   selected: boolean;
+  unreadCount: number;
 }
 
-function ChannelRow({ channel, selected }: ChannelRowProps): React.ReactElement {
+function ChannelRow({ channel, selected, unreadCount }: ChannelRowProps): React.ReactElement {
   return (
     <Box width="100%" flexDirection="column">
       <Box width="100%">
@@ -125,6 +135,9 @@ function ChannelRow({ channel, selected }: ChannelRowProps): React.ReactElement 
           #{channel.name}
         </Text>
         <Text dimColor> ({channel.members.length} members)</Text>
+        {unreadCount > 0 && (
+          <Text color="yellow" bold> [{unreadCount > 99 ? '99+' : unreadCount} new]</Text>
+        )}
       </Box>
       {channel.description && (
         <Text dimColor wrap="truncate">{channel.description}</Text>
@@ -150,6 +163,14 @@ function ChannelHistoryView({
   const [scrollOffset, setScrollOffset] = useState(0);
   const { setFocus, returnFocus } = useFocus();
   const { stdout } = useStdout();
+  const { markViewed } = useUnread();
+
+  // Mark channel as viewed when messages load
+  useEffect(() => {
+    if (messages && messages.length >= 0) {
+      markViewed(channel.name, messages.length);
+    }
+  }, [channel.name, messages, markViewed]);
 
   // Calculate dynamic input height based on message length
   const terminalWidth = stdout?.columns ?? 80;

--- a/tui/src/hooks/UnreadContext.tsx
+++ b/tui/src/hooks/UnreadContext.tsx
@@ -1,0 +1,136 @@
+/**
+ * UnreadContext - Global unread message tracking
+ *
+ * Tracks when user last viewed each channel to calculate unread counts.
+ * Persists data to ~/.bc/tui-unread.json for cross-session tracking.
+ */
+
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
+import type { ReactNode } from 'react';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+// Storage file location
+const STORAGE_DIR = join(homedir(), '.bc');
+const STORAGE_FILE = join(STORAGE_DIR, 'tui-unread.json');
+
+interface UnreadData {
+  /** Last viewed timestamp per channel (ISO string) */
+  lastViewed: Record<string, string>;
+  /** Last known message count per channel */
+  lastMessageCount: Record<string, number>;
+}
+
+/**
+ * Load unread tracking data from disk
+ */
+function loadUnreadData(): UnreadData {
+  try {
+    if (existsSync(STORAGE_FILE)) {
+      const content = readFileSync(STORAGE_FILE, 'utf-8');
+      return JSON.parse(content);
+    }
+  } catch {
+    // Ignore read errors, start fresh
+  }
+  return {
+    lastViewed: {},
+    lastMessageCount: {},
+  };
+}
+
+/**
+ * Save unread tracking data to disk
+ */
+function saveUnreadData(data: UnreadData): void {
+  try {
+    if (!existsSync(STORAGE_DIR)) {
+      mkdirSync(STORAGE_DIR, { recursive: true });
+    }
+    writeFileSync(STORAGE_FILE, JSON.stringify(data, null, 2));
+  } catch {
+    // Ignore write errors
+  }
+}
+
+interface UnreadContextValue {
+  /** Get unread count for a channel */
+  getUnread: (channel: string, currentMessageCount: number) => number;
+  /** Mark a channel as viewed with current message count */
+  markViewed: (channel: string, messageCount: number) => void;
+  /** Get last viewed time for a channel */
+  getLastViewed: (channel: string) => Date | null;
+}
+
+const UnreadContext = createContext<UnreadContextValue | null>(null);
+
+export interface UnreadProviderProps {
+  children: ReactNode;
+}
+
+export function UnreadProvider({ children }: UnreadProviderProps): React.ReactElement {
+  const [data, setData] = useState<UnreadData>(loadUnreadData);
+  const dataRef = useRef(data);
+
+  // Keep ref in sync for callbacks
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
+
+  // Save to disk when data changes
+  useEffect(() => {
+    saveUnreadData(data);
+  }, [data]);
+
+  const getUnread = useCallback((channel: string, currentMessageCount: number): number => {
+    const lastCount = dataRef.current.lastMessageCount[channel];
+    if (lastCount === undefined) {
+      // Never viewed - all messages are "unread" but cap at a reasonable number
+      return Math.min(currentMessageCount, 99);
+    }
+    // Unread = current - last viewed count
+    return Math.max(0, currentMessageCount - lastCount);
+  }, []);
+
+  const markViewed = useCallback((channel: string, messageCount: number) => {
+    setData((prev) => ({
+      ...prev,
+      lastViewed: {
+        ...prev.lastViewed,
+        [channel]: new Date().toISOString(),
+      },
+      lastMessageCount: {
+        ...prev.lastMessageCount,
+        [channel]: messageCount,
+      },
+    }));
+  }, []);
+
+  const getLastViewed = useCallback((channel: string): Date | null => {
+    const timestamp = dataRef.current.lastViewed[channel];
+    return timestamp ? new Date(timestamp) : null;
+  }, []);
+
+  const value: UnreadContextValue = {
+    getUnread,
+    markViewed,
+    getLastViewed,
+  };
+
+  return (
+    <UnreadContext.Provider value={value}>{children}</UnreadContext.Provider>
+  );
+}
+
+/**
+ * Hook to access unread tracking
+ * @throws Error if used outside UnreadProvider
+ */
+export function useUnread(): UnreadContextValue {
+  const context = useContext(UnreadContext);
+  if (!context) {
+    throw new Error('useUnread must be used within an UnreadProvider');
+  }
+  return context;
+}

--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -88,3 +88,9 @@ export {
   type UseTeamsOptions,
   type UseTeamsResult,
 } from './useTeams';
+
+export {
+  UnreadProvider,
+  useUnread,
+  type UnreadProviderProps,
+} from './UnreadContext';


### PR DESCRIPTION
## Summary
- Adds UnreadContext for persistent unread state tracking
- Stores last-viewed timestamp per channel in ~/.bc/tui-unread.json
- Shows [new] badge for channels never viewed
- Marks channels as viewed when entering history view

Fixes #707

## Test plan
- [ ] Open TUI, navigate to Channels
- [ ] Verify channels not yet viewed show [new] badge
- [ ] Enter a channel, then go back to list
- [ ] Verify the viewed channel no longer shows [new]
- [ ] Close TUI, reopen, verify viewed state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)