### PR TITLE
fix(tui): Add error feedback for silent catch handlers (#706)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -10,6 +10,9 @@ import { useNavigation } from '../navigation/NavigationContext';
 import { ChatMessage } from './ChatMessage';
 import type { Channel } from '../types';
 
+/** Duration in ms to show send errors before auto-clearing */
+const SEND_ERROR_DISPLAY_DURATION = 3000;
+
 /**
  * Calculate input box height based on message length
  * Height expands from 3 (min) to 10 (max) lines based on content
@@ -148,7 +151,15 @@ function ChannelHistoryView({
   const [inputMode, setInputMode] = useState(false);
   const [messageBuffer, setMessageBuffer] = useState('');
   const [scrollOffset, setScrollOffset] = useState(0);
+  const [sendError, setSendError] = useState<string | null>(null);
   const { setFocus, returnFocus } = useFocus();
+
+  // Auto-clear send errors after a delay
+  useEffect(() => {
+    if (!sendError) return;
+    const timer = setTimeout(() => setSendError(null), SEND_ERROR_DISPLAY_DURATION);
+    return () => clearTimeout(timer);
+  }, [sendError]);
   const { stdout } = useStdout();
 
   // Calculate dynamic input height based on message length
@@ -188,8 +199,8 @@ function ChannelHistoryView({
       if (inputMode) {
         if (key.return) {
           if (messageBuffer.trim()) {
-            send(messageBuffer.trim()).catch(() => {
-              // Error handled by hook
+            send(messageBuffer.trim()).catch((err: Error) => {
+              setSendError(`Send failed: ${err.message}`);
             });
             setMessageBuffer('');
           }
@@ -263,6 +274,13 @@ function ChannelHistoryView({
           </>
         )}
       </Box>
+
+      {/* Send error feedback */}
+      {sendError && (
+        <Box marginBottom={1}>
+          <Text color="red">{sendError}</Text>
+        </Box>
+      )}
 
       {/* Input area - auto-expands based on message length (3-10 lines) */}
       <Box height={inputHeight} flexDirection="column" marginBottom={1} borderStyle="single" borderColor={inputMode ? 'cyan' : 'gray'} paddingX={1}>

--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -3,7 +3,7 @@
  * Issue #554 - Demons list view
  */
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useDemons } from '../hooks/useDemons';
 import { StatusBadge } from '../components/StatusBadge';
@@ -11,6 +11,9 @@ import { Footer } from '../components/Footer';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { ErrorDisplay } from '../components/ErrorDisplay';
 import type { Demon } from '../types';
+
+/** Duration in ms to show action errors before auto-clearing */
+const ERROR_DISPLAY_DURATION = 3000;
 
 export interface DemonsViewProps {
   /** Callback when exiting the view */
@@ -76,6 +79,14 @@ export function DemonsView({
 }: DemonsViewProps): React.ReactElement {
   const { data: demons, loading, error, total, enabled, refresh, enable, disable, run } = useDemons();
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Auto-clear action errors after a delay
+  useEffect(() => {
+    if (!actionError) return;
+    const timer = setTimeout(() => setActionError(null), ERROR_DISPLAY_DURATION);
+    return () => clearTimeout(timer);
+  }, [actionError]);
 
   useInput(
     (input, key) => {
@@ -102,15 +113,21 @@ export function DemonsView({
       if (selectedDemon) {
         if (input === 'e') {
           // Enable demon
-          enable(selectedDemon.name).catch(() => {});
+          enable(selectedDemon.name).catch((err: Error) => {
+            setActionError(`Enable failed: ${err.message}`);
+          });
         }
         if (input === 'd') {
           // Disable demon
-          disable(selectedDemon.name).catch(() => {});
+          disable(selectedDemon.name).catch((err: Error) => {
+            setActionError(`Disable failed: ${err.message}`);
+          });
         }
         if (input === 'x') {
           // Execute demon
-          run(selectedDemon.name).catch(() => {});
+          run(selectedDemon.name).catch((err: Error) => {
+            setActionError(`Run failed: ${err.message}`);
+          });
         }
       }
     },
@@ -135,6 +152,13 @@ export function DemonsView({
         <Text dimColor> · </Text>
         <Text color={enabled > 0 ? 'green' : 'gray'}>{enabled} enabled</Text>
       </Box>
+
+      {/* Action error feedback */}
+      {actionError && (
+        <Box marginBottom={1}>
+          <Text color="red">{actionError}</Text>
+        </Box>
+      )}
 
       {/* Demon list */}
       {demons && demons.length > 0 ? (


### PR DESCRIPTION
## Summary
- Replace silent `.catch(() => {})` with proper error state and display
- DemonsView: Show errors for enable/disable/run demon operations
- ChannelsView: Show errors for message send failures
- Auto-clear errors after 3 seconds

## Test plan
- [x] TypeScript compiles without errors
- [x] All 25 component tests pass
- [ ] Manual test: trigger demon enable/disable/run error
- [ ] Manual test: trigger message send error

Fixes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)