### PR TITLE
fix: Add verbose flag consistency to agent list, logs, memory show (#709)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -469,6 +469,8 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 }
 
 func runAgentList(cmd *cobra.Command, args []string) error {
+	log.Debug("agent list command started", "role", agentListRole, "json", agentListJSON)
+
 	ws, err := getWorkspace()
 	if err != nil {
 		return fmt.Errorf("not in a bc workspace: %w", err)
@@ -499,6 +501,8 @@ func runAgentList(cmd *cobra.Command, args []string) error {
 		}
 		agents = filtered
 	}
+
+	log.Debug("agents loaded", "count", len(agents))
 
 	if agentListJSON {
 		enc := json.NewEncoder(os.Stdout)

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/events"
+	"github.com/rpuneet/bc/pkg/log"
 )
 
 var logsCmd = &cobra.Command{
@@ -78,10 +79,12 @@ func runLogs(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a bc workspace: %w", err)
 	}
 
-	log := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
+	log.Debug("logs command started", "agent", logsAgent, "type", logsType, "since", logsSince, "tail", logsTail)
+
+	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
 
 	// Read all events, then filter in sequence
-	evts, err := log.Read()
+	evts, err := eventLog.Read()
 	if err != nil {
 		return fmt.Errorf("failed to read events: %w", err)
 	}
@@ -127,6 +130,8 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	if logsTail > 0 && len(evts) > logsTail {
 		evts = evts[len(evts)-logsTail:]
 	}
+
+	log.Debug("events filtered", "count", len(evts))
 
 	if len(evts) == 0 {
 		fmt.Println("No events found")

--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/memory"
 )
 
@@ -370,6 +371,8 @@ func runMemoryLearn(cmd *cobra.Command, args []string) error {
 }
 
 func runMemoryShow(cmd *cobra.Command, args []string) error {
+	log.Debug("memory show command started")
+
 	ws, err := getWorkspace()
 	if err != nil {
 		return fmt.Errorf("not in a bc workspace: %w", err)
@@ -386,6 +389,7 @@ func runMemoryShow(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	log.Debug("loading memory", "agent", agentID)
 	store := memory.NewStore(ws.RootDir, agentID)
 	if !store.Exists() {
 		cmd.Printf("No memory found for agent %s\n", agentID)


### PR DESCRIPTION
## Summary
- Added debug logging to `bc agent list`, `bc logs`, and `bc memory show` commands
- These commands now produce debug output when using `-v/--verbose` flag
- Fixes inconsistency where some commands supported verbose and others didn't

## Test plan
- [ ] Run `bc agent list -v` and verify debug output shows role/json options and count
- [ ] Run `bc logs -v` and verify debug output shows filter params and event count
- [ ] Run `bc memory show <agent> -v` and verify debug output shows agent being loaded
- [ ] Tests pass: `go test ./internal/cmd/... -run "Agent|Logs|Memory"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)