### PR TITLE
fix(agent): Preserve error/stuck/done states in bc status (#699)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1156,16 +1156,22 @@ func (m *Manager) RefreshState() error {
 			// Sync state with task symbols:
 			// - Spinner symbols (✻ ✳ ✽ ·) → working
 			// - Prompt symbol (❯) or pause (⏺) → idle (waiting for input)
+			//
+			// IMPORTANT: Preserve error, stuck, and done states - these are explicitly
+			// reported by agents and should not be overwritten by tmux activity detection.
+			// Only toggle between working and idle for agents in "normal" states.
 			if strings.HasPrefix(live, "✻") ||
 				strings.HasPrefix(live, "✳") ||
 				strings.HasPrefix(live, "✽") ||
 				strings.HasPrefix(live, "·") {
-				if a.State != StateWorking {
+				// Only change to working from idle/starting - preserve error/stuck/done
+				if a.State == StateIdle || a.State == StateStarting {
 					a.State = StateWorking
 					a.UpdatedAt = time.Now()
 				}
 			} else if strings.HasPrefix(live, "❯") ||
 				strings.HasPrefix(live, "⏺") {
+				// Only change to idle from working - preserve error/stuck/done
 				if a.State == StateWorking {
 					a.State = StateIdle
 					a.UpdatedAt = time.Now()


### PR DESCRIPTION
## Summary
When `RefreshState()` detects tmux activity (spinner/prompt symbols), it only toggles between working and idle states now. Error, stuck, and done states are explicitly reported by agents via `bc report` and should not be overwritten by automatic tmux detection.

**Before:**
```
Agent reports error → RefreshState sees tmux spinner → state becomes working → shows as idle
```

**After:**
```
Agent reports error → state remains error (preserved and shown correctly)
```

Fixes #699

## Test plan
- [ ] `bc report error "test error"` → Agent state becomes error
- [ ] `bc status` → Shows agent in red error state (not idle)
- [ ] `bc agent show <agent>` → Shows State: error
- [ ] Agent working normally → State toggles between working/idle as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)