### PR TITLE
fix: Add comprehensive validation to demon commands (#710)

### DIFF
--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -202,6 +202,18 @@ func validIdentifier(s string) bool {
 	return pattern.MatchString(s)
 }
 
+// validateDemonName validates a demon name and returns an error if invalid.
+func validateDemonName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("demon name cannot be empty")
+	}
+	if !validIdentifier(name) {
+		return fmt.Errorf("demon name %q must start with a letter or underscore and contain only letters, numbers, dashes, and underscores", name)
+	}
+	return nil
+}
+
 func runDemonCreate(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
@@ -209,11 +221,13 @@ func runDemonCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	name := strings.TrimSpace(args[0])
-	if name == "" {
-		return fmt.Errorf("demon name cannot be empty")
+	if nameErr := validateDemonName(name); nameErr != nil {
+		return nameErr
 	}
-	if !validIdentifier(name) {
-		return fmt.Errorf("demon name must contain only letters, numbers, dashes, and underscores")
+
+	// Validate command is not empty
+	if strings.TrimSpace(demonCommand) == "" {
+		return fmt.Errorf("demon command cannot be empty")
 	}
 
 	store := demon.NewStore(ws.RootDir)
@@ -294,6 +308,10 @@ func runDemonShow(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	if nameErr := validateDemonName(name); nameErr != nil {
+		return nameErr
+	}
+
 	store := demon.NewStore(ws.RootDir)
 
 	d, err := store.Get(name)
@@ -327,6 +345,10 @@ func runDemonDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	if nameErr := validateDemonName(name); nameErr != nil {
+		return nameErr
+	}
+
 	store := demon.NewStore(ws.RootDir)
 
 	if err := store.Delete(name); err != nil {
@@ -344,6 +366,10 @@ func runDemonRun(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	if nameErr := validateDemonName(name); nameErr != nil {
+		return nameErr
+	}
+
 	store := demon.NewStore(ws.RootDir)
 
 	d, err := store.Get(name)
@@ -417,6 +443,10 @@ func runDemonEnable(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	if nameErr := validateDemonName(name); nameErr != nil {
+		return nameErr
+	}
+
 	store := demon.NewStore(ws.RootDir)
 
 	if err := store.Enable(name); err != nil {
@@ -439,6 +469,10 @@ func runDemonDisable(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	if nameErr := validateDemonName(name); nameErr != nil {
+		return nameErr
+	}
+
 	store := demon.NewStore(ws.RootDir)
 
 	if err := store.Disable(name); err != nil {
@@ -456,6 +490,10 @@ func runDemonLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	if nameErr := validateDemonName(name); nameErr != nil {
+		return nameErr
+	}
+
 	store := demon.NewStore(ws.RootDir)
 
 	// Check if demon exists
@@ -511,6 +549,10 @@ func runDemonEdit(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	if nameErr := validateDemonName(name); nameErr != nil {
+		return nameErr
+	}
+
 	store := demon.NewStore(ws.RootDir)
 
 	// Check if demon exists
@@ -537,6 +579,18 @@ func runDemonEdit(cmd *cobra.Command, args []string) error {
 }
 
 func updateDemonWithFlags(cmd *cobra.Command, store *demon.Store, name string) error {
+	// Validate schedule if provided
+	if demonEditSchedule != "" {
+		if _, err := demon.ParseCron(demonEditSchedule); err != nil {
+			return fmt.Errorf("invalid cron schedule %q: %w", demonEditSchedule, err)
+		}
+	}
+
+	// Validate command if provided (not empty)
+	if demonEditCommand != "" && strings.TrimSpace(demonEditCommand) == "" {
+		return fmt.Errorf("demon command cannot be empty")
+	}
+
 	var changes []string
 
 	err := store.Update(name, func(d *demon.Demon) {

--- a/internal/cmd/demon_test.go
+++ b/internal/cmd/demon_test.go
@@ -289,3 +289,173 @@ func TestDemonDisableNotFound(t *testing.T) {
 		t.Errorf("error should mention not found: %v", err)
 	}
 }
+
+// --- Demon Name Validation Tests ---
+
+func TestDemonCreateInvalidName(t *testing.T) {
+	setupTestWorkspace(t)
+
+	tests := []struct {
+		name    string
+		wantErr string
+	}{
+		{"123-starts-with-digit", "must start with a letter"},
+		{"has spaces", "must start with a letter"},
+		{"has@special", "must start with a letter"},
+		{"has.dot", "must start with a letter"},
+		{"", "cannot be empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := executeCmd("demon", "create", tt.name, "--schedule", "0 * * * *", "--cmd", "echo hello")
+			if err == nil {
+				t.Errorf("expected error for name %q", tt.name)
+				return
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDemonShowInvalidName(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "show", "123-invalid")
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+	if !strings.Contains(err.Error(), "must start with a letter") {
+		t.Errorf("error should mention invalid format: %v", err)
+	}
+}
+
+func TestDemonDeleteInvalidName(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "delete", "123invalid")
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+	if !strings.Contains(err.Error(), "must start with a letter") {
+		t.Errorf("error should mention invalid format: %v", err)
+	}
+}
+
+func TestDemonRunInvalidName(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "run", "has spaces")
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+	if !strings.Contains(err.Error(), "must start with a letter") {
+		t.Errorf("error should mention invalid format: %v", err)
+	}
+}
+
+func TestDemonEnableInvalidName(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "enable", "@invalid")
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+	if !strings.Contains(err.Error(), "must start with a letter") {
+		t.Errorf("error should mention invalid format: %v", err)
+	}
+}
+
+func TestDemonDisableInvalidName(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "disable", "123bad")
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+	if !strings.Contains(err.Error(), "must start with a letter") {
+		t.Errorf("error should mention invalid format: %v", err)
+	}
+}
+
+func TestDemonLogsInvalidName(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "logs", "bad name")
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+	if !strings.Contains(err.Error(), "must start with a letter") {
+		t.Errorf("error should mention invalid format: %v", err)
+	}
+}
+
+func TestDemonEditInvalidName(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "edit", "123badname", "--schedule", "0 * * * *")
+	if err == nil {
+		t.Error("expected error for invalid name")
+	}
+	if !strings.Contains(err.Error(), "must start with a letter") {
+		t.Errorf("error should mention invalid format: %v", err)
+	}
+}
+
+// --- Demon Create Empty Command Test ---
+
+func TestDemonCreateEmptyCommand(t *testing.T) {
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("demon", "create", "test-demon", "--schedule", "0 * * * *", "--cmd", "")
+	if err == nil {
+		t.Error("expected error for empty command")
+	}
+	if !strings.Contains(err.Error(), "command cannot be empty") {
+		t.Errorf("error should mention empty command: %v", err)
+	}
+}
+
+// --- Demon Edit Schedule Validation Test ---
+
+func TestDemonEditInvalidSchedule(t *testing.T) {
+	wsDir := setupTestWorkspace(t)
+
+	// Create a valid demon first
+	store := demon.NewStore(wsDir)
+	_, _ = store.Create("edit-sched", "0 * * * *", "echo hello")
+
+	// Try to edit with invalid schedule
+	_, err := executeCmd("demon", "edit", "edit-sched", "--schedule", "invalid-cron")
+	if err == nil {
+		t.Error("expected error for invalid schedule")
+	}
+	if !strings.Contains(err.Error(), "invalid cron") {
+		t.Errorf("error should mention invalid cron: %v", err)
+	}
+}
+
+func TestDemonCreateValidNames(t *testing.T) {
+	setupTestWorkspace(t)
+
+	validNames := []string{
+		"my-demon",
+		"my_demon",
+		"MyDemon",
+		"_private",
+		"backup",
+		"test123",
+		"a",
+	}
+
+	for _, name := range validNames {
+		t.Run(name, func(t *testing.T) {
+			_, err := executeCmd("demon", "create", name, "--schedule", "0 * * * *", "--cmd", "echo hello")
+			if err != nil {
+				t.Errorf("valid name %q should succeed: %v", name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `validateDemonName` helper for consistent name validation
- Validate demon names in all commands: show, delete, run, enable, disable, logs, edit
- Add empty command validation in create
- Add schedule validation in edit (when --schedule flag provided)
- Clear error messages that explain valid name format

## Test plan
- [x] All 30 demon tests pass
- [x] Linter passes with no issues
- [x] Tested invalid names: digits, special chars, spaces
- [x] Tested valid names: letters, underscores, hyphens

Fixes #710

🤖 Generated with [Claude Code](https://claude.com/claude-code)