### PR TITLE
fix: Rename tmux session when renaming agent (#697)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -962,7 +962,18 @@ func runAgentRename(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Println("✓")
 
-	// Step 2: Update channel memberships
+	// Step 2: Rename tmux session if exists
+	if mgr.Tmux().HasSession(oldName) {
+		fmt.Print("  Renaming tmux session... ")
+		if renameErr := mgr.Tmux().RenameSession(oldName, newName); renameErr != nil {
+			fmt.Println("✗")
+			log.Warn("failed to rename tmux session", "error", renameErr)
+		} else {
+			fmt.Println("✓")
+		}
+	}
+
+	// Step 3: Update channel memberships (renumber after adding tmux step)
 	fmt.Print("  Updating channel memberships... ")
 	channelStore := channel.NewStore(filepath.Join(ws.StateDir(), "channels"))
 	if err := channelStore.Load(); err != nil {

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -169,6 +169,19 @@ func (m *Manager) KillSession(name string) error {
 	return nil
 }
 
+// RenameSession renames a tmux session.
+func (m *Manager) RenameSession(oldName, newName string) error {
+	oldFullName := m.SessionName(oldName)
+	newFullName := m.SessionName(newName)
+	log.Debug("renaming tmux session", "old", oldFullName, "new", newFullName)
+	cmd := m.command("tmux", "rename-session", "-t", oldFullName, newFullName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to rename session %s to %s: %w (%s)", oldFullName, newFullName, err, string(output))
+	}
+	return nil
+}
+
 // getSessionLock returns a mutex for the given session name, creating one if needed.
 // This serializes concurrent SendKeys calls to the same session.
 func (m *Manager) getSessionLock(sessionName string) *sync.Mutex {


### PR DESCRIPTION
## Summary
- Added `RenameSession` function to tmux.Manager
- `bc agent rename` now also renames the tmux session
- Fixes state inconsistency where renamed agents couldn't receive messages

## Changes
1. `pkg/tmux/session.go`: Added `RenameSession(oldName, newName)` method
2. `internal/cmd/agent.go`: Call `RenameSession` during agent rename (new step 2)

## Test plan
- [ ] `bc agent rename old-name new-name` renames tmux session
- [ ] `bc agent send new-name "test"` works after rename
- [ ] Tests pass: `go test ./... -run "Rename"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)