### PR TITLE
fix(ux): Remove technical implementation details from error messages (#701)

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -78,16 +78,16 @@ var channelDeleteCmd = &cobra.Command{
 
 var channelJoinCmd = &cobra.Command{
 	Use:   "join <channel>",
-	Short: "Join a channel (uses BC_AGENT_ID)",
-	Long:  `Add yourself to a channel. Uses the BC_AGENT_ID environment variable to identify the current agent.`,
+	Short: "Join a channel (for agents)",
+	Long:  `Add yourself to a channel. This command must be run from within an agent session.`,
 	Args:  cobra.ExactArgs(1),
 	RunE:  runChannelJoin,
 }
 
 var channelLeaveCmd = &cobra.Command{
 	Use:   "leave <channel>",
-	Short: "Leave a channel (uses BC_AGENT_ID)",
-	Long:  `Remove yourself from a channel. Uses the BC_AGENT_ID environment variable to identify the current agent.`,
+	Short: "Leave a channel (for agents)",
+	Long:  `Remove yourself from a channel. This command must be run from within an agent session.`,
 	Args:  cobra.ExactArgs(1),
 	RunE:  runChannelLeave,
 }

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -171,5 +171,5 @@ func errorAgentNotRunning(commandUsage string) error {
 
 // errorWorktreeNotSet returns an error message for commands that require BC_AGENT_WORKTREE.
 func errorWorktreeNotSet() error {
-	return fmt.Errorf("this command requires running in an agent's isolated worktree. Ensure BC_AGENT_WORKTREE and BC_AGENT_ID are set")
+	return fmt.Errorf("this command must run inside an agent session. Attach to an agent with 'bc agent attach <name>' first")
 }

--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -48,12 +48,12 @@ var memoryRecordCmd = &cobra.Command{
 	Short: "Record an experience to memory",
 	Long: `Record a task outcome or experience to the agent's memory.
 
-Requires BC_AGENT_ID environment variable to be set.
+This command is typically run from within an agent session, or use --agent to specify which agent's memory to update.
 
 Examples:
   bc memory record "Fixed auth bug - used JWT tokens"
   bc memory record --outcome success "Implemented feature X"
-  bc memory record --task-id TASK-123 "Completed task"`,
+  bc memory record --agent eng-01 "Completed task"`,
 	Args: cobra.ExactArgs(1),
 	RunE: runMemoryRecord,
 }
@@ -63,14 +63,14 @@ var memoryLearnCmd = &cobra.Command{
 	Short: "Add a learning to memory",
 	Long: `Add an insight or learning to the agent's memory.
 
-Requires BC_AGENT_ID environment variable to be set.
+This command is typically run from within an agent session, or use --agent to specify which agent's memory to update.
 
 Categories: patterns, anti-patterns, tips, gotchas
 
 Examples:
   bc memory learn patterns "Always check error returns"
   bc memory learn tips "Use context for cancellation"
-  bc memory learn anti-patterns "Don't ignore errors"`,
+  bc memory learn --agent eng-01 anti-patterns "Don't ignore errors"`,
 	Args: cobra.ExactArgs(2),
 	RunE: runMemoryLearn,
 }
@@ -80,7 +80,7 @@ var memoryShowCmd = &cobra.Command{
 	Short: "Show agent memory",
 	Long: `Display the memory contents for an agent.
 
-If no agent is specified, uses BC_AGENT_ID environment variable.
+If no agent is specified, shows memory for the current agent session.
 
 Examples:
   bc memory show                # Show current agent's memory
@@ -385,7 +385,7 @@ func runMemoryShow(cmd *cobra.Command, args []string) error {
 	} else {
 		agentID = os.Getenv("BC_AGENT_ID")
 		if agentID == "" {
-			return fmt.Errorf("specify an agent name or set BC_AGENT_ID")
+			return fmt.Errorf("specify an agent name with --agent, or run this command from within an agent session")
 		}
 	}
 

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -18,7 +18,7 @@ import (
 var reportCmd = &cobra.Command{
 	Use:   "report <state> [message]",
 	Short: "Report agent state (called by agents)",
-	Long: `Report the calling agent's current state. Uses BC_AGENT_ID env var.
+	Long: `Report the calling agent's current state. This command must be run from within an agent session.
 
 Valid states: idle, working, done, stuck, error
 
@@ -168,8 +168,10 @@ func checkWorktreeWarning(agentID string, ws *workspace.Workspace) {
 	}
 
 	// Agent is outside its worktree — warn but don't block
-	fmt.Fprintf(os.Stderr, "WARNING: %s is reporting from outside its worktree (cwd: %s, expected: %s)\n",
-		agentID, cwdAbs, worktreeAbs)
+	fmt.Fprintf(os.Stderr, "WARNING: Agent %s is running outside its assigned directory\n", agentID)
+	fmt.Fprintf(os.Stderr, "  Current:  %s\n", cwdAbs)
+	fmt.Fprintf(os.Stderr, "  Expected: %s\n", worktreeAbs)
+	fmt.Fprintf(os.Stderr, "  (Use 'cd %s' to return to your workspace)\n", worktreeAbs)
 
 	// Log to events
 	log := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))


### PR DESCRIPTION
## Summary
- Replace references to environment variables (BC_AGENT_ID, BC_AGENT_WORKTREE) in error messages with user-friendly guidance
- Improve worktree warning message to be multi-line with actionable `cd` command
- Update help text for memory, channel, and report commands to not expose implementation details

## Changes
- **init.go**: `errorWorktreeNotSet()` now says "Attach to an agent with 'bc agent attach <name>' first"
- **report.go**: Clearer multi-line warning with actionable guidance when agent is outside worktree
- **memory.go**: Help text says "run from agent session" instead of "set BC_AGENT_ID"
- **channel.go**: join/leave help text simplified to "for agents" without env var mention
- **report.go**: Help text updated to not reference env var

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Error messages are now user-friendly and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)