### PR TITLE
fix(tmux): Improve session error messages for better UX (#696)

### DIFF
--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -60,6 +60,32 @@ func (m *Manager) command(name string, args ...string) *exec.Cmd {
 	return exec.CommandContext(context.Background(), name, args...)
 }
 
+// userFriendlyTmuxError converts raw tmux error output to a user-friendly message.
+// It detects common error patterns and returns clearer, actionable messages.
+func userFriendlyTmuxError(output string) string {
+	output = strings.TrimSpace(output)
+	outputLower := strings.ToLower(output)
+
+	switch {
+	case strings.Contains(outputLower, "can't find pane"):
+		return "session not found (may have terminated)"
+	case strings.Contains(outputLower, "can't find session"):
+		return "session not found (may have terminated)"
+	case strings.Contains(outputLower, "no server running"):
+		return "tmux server not running"
+	case strings.Contains(outputLower, "session not found"):
+		return "session not found (may have terminated)"
+	case strings.Contains(outputLower, "can't find window"):
+		return "session window not found"
+	default:
+		// For other errors, return a shortened version without internal session IDs
+		if len(output) > 50 {
+			return output[:50] + "..."
+		}
+		return output
+	}
+}
+
 // NewManager creates a new tmux manager with the given prefix.
 func NewManager(prefix string) *Manager {
 	return &Manager{
@@ -224,7 +250,7 @@ func (m *Manager) SendKeysWithSubmit(name, keys, submitKey string) error {
 		cmd := m.command("tmux", "send-keys", "-t", fullName, "-l", keys)
 		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("failed to send keys to %s: %w (%s)", fullName, err, string(output))
+			return fmt.Errorf("failed to send message: %s", userFriendlyTmuxError(string(output)))
 		}
 	} else {
 		// Long message: use temp file + load-buffer + paste-buffer with named buffer
@@ -264,7 +290,7 @@ func (m *Manager) SendKeysWithSubmit(name, keys, submitKey string) error {
 		if output, err := pasteCmd.CombinedOutput(); err != nil {
 			// Clean up buffer on error
 			_ = m.command("tmux", "delete-buffer", "-b", bufferName).Run() //nolint:errcheck // best-effort cleanup
-			return fmt.Errorf("failed to paste buffer to %s: %w (%s)", fullName, err, string(output))
+			return fmt.Errorf("failed to send message: %s", userFriendlyTmuxError(string(output)))
 		}
 	}
 

--- a/pkg/tmux/session_test.go
+++ b/pkg/tmux/session_test.go
@@ -146,6 +146,34 @@ func sliceContains(strs []string, target string) bool {
 }
 
 // ---------------------------------------------------------------------------
+// userFriendlyTmuxError tests
+// ---------------------------------------------------------------------------
+
+func TestUserFriendlyTmuxError(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"can't find pane: foo", "session not found (may have terminated)"},
+		{"Can't find pane xyz", "session not found (may have terminated)"},
+		{"can't find session: bar", "session not found (may have terminated)"},
+		{"session not found", "session not found (may have terminated)"},
+		{"no server running on /tmp/tmux", "tmux server not running"},
+		{"can't find window: 0", "session window not found"},
+		{"short error", "short error"},
+		{"", ""},
+		{strings.Repeat("x", 100), strings.Repeat("x", 50) + "..."},
+	}
+
+	for _, tc := range tests {
+		result := userFriendlyTmuxError(tc.input)
+		if result != tc.expected {
+			t.Errorf("userFriendlyTmuxError(%q) = %q, want %q", tc.input, result, tc.expected)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Constructor tests
 // ---------------------------------------------------------------------------
 
@@ -707,7 +735,7 @@ func TestSendKeysWithSubmit_ShortMessageError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error")
 	}
-	if !strings.Contains(err.Error(), "failed to send keys") {
+	if !strings.Contains(err.Error(), "failed to send message") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -750,7 +778,7 @@ func TestSendKeysWithSubmit_PasteBufferError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error on paste-buffer failure")
 	}
-	if !strings.Contains(err.Error(), "failed to paste buffer") {
+	if !strings.Contains(err.Error(), "failed to send message") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `userFriendlyTmuxError()` helper to convert raw tmux error output to user-friendly messages
- "can't find pane/session" → "session not found (may have terminated)"
- "no server running" → "tmux server not running"
- Long errors truncated to 50 chars with "..."

Closes #696

## Test plan
- [x] Run `go test ./pkg/tmux/...` - all tests pass
- [x] New test `TestUserFriendlyTmuxError` validates error message transformations
- [x] Updated existing tests to expect new error format

🤖 Generated with [Claude Code](https://claude.com/claude-code)