### PR TITLE
fix: Improve channel send feedback when no other members (#693)

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -424,9 +424,13 @@ func runChannelSend(cmd *cobra.Command, args []string) error {
 	}
 
 	totalTargets := len(members) - skipped
-	fmt.Printf("\nResult: %d/%d members received message\n", sent, totalTargets)
-	if failed > 0 {
-		fmt.Printf("Warning: %d delivery failed\n", failed)
+	if totalTargets == 0 {
+		fmt.Printf("\nMessage recorded to channel (no other members to deliver to)\n")
+	} else {
+		fmt.Printf("\nResult: %d/%d members received message\n", sent, totalTargets)
+		if failed > 0 {
+			fmt.Printf("Warning: %d delivery failed\n", failed)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Improved output when sending to a channel with only the sender as member
- Old output: "Result: 0/0 members received message" (confusing)
- New output: "Message recorded to channel (no other members to deliver to)"

## Test plan
- [ ] `bc channel send general "test"` when alone in channel shows new message
- [ ] Tests pass: `go test ./internal/cmd/... -run "Channel"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)