### PR TITLE
fix: Add actionable error messages for workspace errors (#702)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -340,7 +340,7 @@ func init() {
 func runAgentCreate(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -489,7 +489,7 @@ func runAgentList(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -580,7 +580,7 @@ func runAgentAttach(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -598,7 +598,7 @@ func runAgentPeek(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -631,7 +631,7 @@ func runAgentShow(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -685,7 +685,7 @@ func runAgentStart(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -731,7 +731,7 @@ func runAgentStop(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -773,7 +773,7 @@ func runAgentSend(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -820,7 +820,7 @@ func runAgentDelete(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -928,7 +928,7 @@ func runAgentRename(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -1031,7 +1031,7 @@ func runAgentBroadcast(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -1104,7 +1104,7 @@ func runAgentSendRole(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -1188,7 +1188,7 @@ func runAgentSendPattern(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
@@ -1305,7 +1305,7 @@ type AgentHealth struct {
 func runAgentHealth(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Parse timeout duration

--- a/internal/cmd/agent_e2e_test.go
+++ b/internal/cmd/agent_e2e_test.go
@@ -71,7 +71,8 @@ func TestAgentLifecycle_CreateNoWorkspace(t *testing.T) {
 	resetAgentFlags()
 	defer resetAgentFlags()
 
-	_, err := executeCmd("agent", "create", "test-agent")
+	// Include --role flag so validation passes and we reach workspace check
+	_, err := executeCmd("agent", "create", "test-agent", "--role", "engineer")
 	if err == nil {
 		t.Error("expected error for missing workspace")
 	}

--- a/internal/cmd/attach.go
+++ b/internal/cmd/attach.go
@@ -36,7 +36,7 @@ func runAttach(cmd *cobra.Command, args []string) error {
 	// Find workspace
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Create agent manager

--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -185,7 +185,7 @@ func loadChannelStore(rootDir string) (*channel.Store, error) {
 func runChannelList(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -236,7 +236,7 @@ func runChannelList(cmd *cobra.Command, args []string) error {
 func runChannelCreate(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -279,7 +279,7 @@ func runChannelCreate(cmd *cobra.Command, args []string) error {
 func runChannelAdd(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -315,7 +315,7 @@ func runChannelAdd(cmd *cobra.Command, args []string) error {
 func runChannelRemove(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -346,7 +346,7 @@ func runChannelRemove(cmd *cobra.Command, args []string) error {
 func runChannelSend(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -434,7 +434,7 @@ func runChannelSend(cmd *cobra.Command, args []string) error {
 func runChannelDelete(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -463,7 +463,7 @@ func runChannelDelete(cmd *cobra.Command, args []string) error {
 func runChannelJoin(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	agentID := os.Getenv("BC_AGENT_ID")
@@ -497,7 +497,7 @@ func runChannelJoin(cmd *cobra.Command, args []string) error {
 func runChannelLeave(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	agentID := os.Getenv("BC_AGENT_ID")
@@ -531,7 +531,7 @@ func runChannelLeave(cmd *cobra.Command, args []string) error {
 func runChannelHistory(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -621,7 +621,7 @@ func runChannelHistory(cmd *cobra.Command, args []string) error {
 func runChannelReact(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -676,7 +676,7 @@ type ChannelInfo struct {
 func runChannelShow(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)
@@ -768,7 +768,7 @@ func runChannelShow(cmd *cobra.Command, args []string) error {
 func runChannelDesc(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store, err := loadChannelStore(ws.RootDir)

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -310,7 +310,7 @@ func runConfigValidate(cmd *cobra.Command, args []string) error {
 func runConfigReset(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	configPath := workspace.ConfigPath(ws.RootDir)

--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -217,7 +217,7 @@ func validateDemonName(name string) error {
 func runDemonCreate(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := strings.TrimSpace(args[0])
@@ -256,7 +256,7 @@ func runDemonCreate(cmd *cobra.Command, args []string) error {
 func runDemonList(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store := demon.NewStore(ws.RootDir)
@@ -304,7 +304,7 @@ func runDemonList(cmd *cobra.Command, args []string) error {
 func runDemonShow(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -341,7 +341,7 @@ func runDemonShow(cmd *cobra.Command, args []string) error {
 func runDemonDelete(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -362,7 +362,7 @@ func runDemonDelete(cmd *cobra.Command, args []string) error {
 func runDemonRun(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -439,7 +439,7 @@ func runDemonRun(cmd *cobra.Command, args []string) error {
 func runDemonEnable(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -465,7 +465,7 @@ func runDemonEnable(cmd *cobra.Command, args []string) error {
 func runDemonDisable(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -486,7 +486,7 @@ func runDemonDisable(cmd *cobra.Command, args []string) error {
 func runDemonLogs(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -545,7 +545,7 @@ func runDemonLogs(cmd *cobra.Command, args []string) error {
 func runDemonEdit(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -718,7 +718,7 @@ func runDemonTest(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Check GitHub integration enabled

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -35,7 +35,7 @@ func runDown(cmd *cobra.Command, args []string) error {
 	// Find workspace
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	fmt.Printf("Stopping bc agents in %s\n\n", ws.RootDir)

--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -48,7 +48,7 @@ func runHome(cmd *cobra.Command, args []string) error {
 	// Find workspace
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Find TUI directory

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -173,3 +173,11 @@ func errorAgentNotRunning(commandUsage string) error {
 func errorWorktreeNotSet() error {
 	return fmt.Errorf("this command requires running in an agent's isolated worktree. Ensure BC_AGENT_WORKTREE and BC_AGENT_ID are set")
 }
+
+// errNotInWorkspace returns an actionable error for commands that require a bc workspace.
+func errNotInWorkspace(err error) error {
+	if err != nil {
+		return fmt.Errorf("not in a bc workspace (run 'bc init' to initialize one): %w", err)
+	}
+	return fmt.Errorf("not in a bc workspace. Run 'bc init' in your project directory to create one")
+}

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -76,7 +76,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	log.Debug("logs command started", "agent", logsAgent, "type", logsType, "since", logsSince, "tail", logsTail)

--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -306,7 +306,7 @@ func runMemoryRecord(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store := memory.NewStore(ws.RootDir, agentID)
@@ -352,7 +352,7 @@ func runMemoryLearn(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store := memory.NewStore(ws.RootDir, agentID)
@@ -375,7 +375,7 @@ func runMemoryShow(cmd *cobra.Command, args []string) error {
 
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Determine which agent's memory to show
@@ -449,7 +449,7 @@ func runMemoryShow(cmd *cobra.Command, args []string) error {
 func runMemorySearch(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	query := strings.ToLower(args[0])
@@ -633,7 +633,7 @@ func scoreLearning(line, query string) int {
 func runMemoryPrune(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Parse the duration
@@ -744,7 +744,7 @@ func runMemoryPrune(cmd *cobra.Command, args []string) error {
 func runMemoryList(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Determine which agents to list
@@ -949,7 +949,7 @@ func formatBytes(b int64) string {
 func runMemoryClear(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	agentID := args[0]
@@ -1020,7 +1020,7 @@ type MemoryExport struct {
 func runMemoryExport(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	agentID := args[0]
@@ -1080,7 +1080,7 @@ func runMemoryExport(cmd *cobra.Command, args []string) error {
 func runMemoryForget(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	agentID := args[0]
@@ -1119,7 +1119,7 @@ type MemoryImport struct {
 func runMemoryImport(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	agentID := args[0]

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -58,7 +58,7 @@ func runReport(cmd *cobra.Command, args []string) error {
 	// Find workspace
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Worktree validation: warn if agent is outside its assigned worktree

--- a/internal/cmd/send.go
+++ b/internal/cmd/send.go
@@ -45,7 +45,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 	// Find workspace
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	// Create workspace-scoped agent manager

--- a/internal/cmd/spawn.go
+++ b/internal/cmd/spawn.go
@@ -53,7 +53,7 @@ func runSpawn(cmd *cobra.Command, args []string) error {
 	// Find workspace
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 	log.Debug("workspace found", "root", ws.RootDir)
 

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -37,7 +37,7 @@ func init() {
 func runStats(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	s, err := stats.Load(ws.StateDir())

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -46,7 +46,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	// Find workspace
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 	log.Debug("workspace found", "root", ws.RootDir)
 

--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -104,7 +104,7 @@ func init() {
 func runTeamCreate(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -122,7 +122,7 @@ func runTeamCreate(cmd *cobra.Command, args []string) error {
 func runTeamList(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	store := team.NewStore(ws.RootDir)
@@ -176,7 +176,7 @@ func runTeamList(cmd *cobra.Command, args []string) error {
 func runTeamShow(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -212,7 +212,7 @@ func runTeamShow(cmd *cobra.Command, args []string) error {
 func runTeamDelete(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	name := args[0]
@@ -229,7 +229,7 @@ func runTeamDelete(cmd *cobra.Command, args []string) error {
 func runTeamAdd(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	teamName := args[0]
@@ -259,7 +259,7 @@ func runTeamAdd(cmd *cobra.Command, args []string) error {
 func runTeamRemove(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	teamName := args[0]
@@ -282,7 +282,7 @@ func runTeamRemove(cmd *cobra.Command, args []string) error {
 func runTeamRename(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	oldName := args[0]

--- a/internal/cmd/worktree.go
+++ b/internal/cmd/worktree.go
@@ -184,7 +184,7 @@ type WorktreeListEntry struct {
 func runWorktreeList(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	worktreesDir := filepath.Join(ws.RootDir, ".bc", "worktrees")
@@ -308,7 +308,7 @@ type PruneResult struct {
 func runWorktreePrune(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace: %w", err)
+		return errNotInWorkspace(err)
 	}
 
 	worktreesDir := filepath.Join(ws.RootDir, ".bc", "worktrees")


### PR DESCRIPTION
## Summary
- Add `errNotInWorkspace` helper that provides actionable guidance: "run 'bc init' to initialize one"
- Update 60+ error sites across 18 command files
- Consistent error format across all commands
- Updated test to account for --role requirement

## Test plan
- [x] All cmd tests pass (10 seconds)
- [x] Linter passes with 0 issues
- [x] Error message now guides users to fix the problem

Before:
```
Error: not in a bc workspace: <technical error>
```

After:
```
Error: not in a bc workspace (run 'bc init' to initialize one): <technical error>
```

Fixes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)