### PR TITLE
fix: Reject positional args in bc agent list with guidance (#689)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -64,6 +64,12 @@ Examples:
   bc agent list          # List all agents
   bc agent list --json   # Output as JSON
   bc agent list --role engineer  # Filter by role`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 0 {
+			return fmt.Errorf("unexpected argument %q. To filter by role, use: bc agent list --role %s", args[0], args[0])
+		}
+		return nil
+	},
 	RunE: runAgentList,
 }
 

--- a/internal/cmd/agent_e2e_test.go
+++ b/internal/cmd/agent_e2e_test.go
@@ -62,6 +62,24 @@ func TestAgentLifecycle_ListInvalidRole(t *testing.T) {
 	}
 }
 
+func TestAgentLifecycle_ListPositionalArg(t *testing.T) {
+	setupTestWorkspace(t)
+	resetAgentFlags()
+	defer resetAgentFlags()
+
+	// Positional args should error with helpful message
+	_, err := executeCmd("agent", "list", "engineer")
+	if err == nil {
+		t.Error("expected error for positional argument")
+	}
+	if !strings.Contains(err.Error(), "unexpected argument") {
+		t.Errorf("expected 'unexpected argument' error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--role") {
+		t.Errorf("error should suggest --role flag, got: %v", err)
+	}
+}
+
 func TestAgentLifecycle_CreateNoWorkspace(t *testing.T) {
 	origDir, _ := os.Getwd()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary
- `bc agent list engineer` now shows helpful error instead of silently ignoring the argument
- Error message suggests the correct syntax: `bc agent list --role engineer`

## Example
Before:
```
$ bc agent list engineer
# Shows all agents (ignores argument)
```

After:
```
$ bc agent list engineer
Error: unexpected argument "engineer". To filter by role, use: bc agent list --role engineer
```

## Test plan
- [ ] `bc agent list engineer` shows error with --role suggestion
- [ ] Tests pass: `go test ./internal/cmd/... -run "AgentList"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)