### PR TITLE
fix(tui): Responsive layout for 80-column terminals (#794)

### DIFF
--- a/tui/src/components/Table.tsx
+++ b/tui/src/components/Table.tsx
@@ -1,10 +1,14 @@
 import React, { memo, useMemo } from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 
 export interface Column<T> {
   key: keyof T | string;
   header: string;
   width?: number;
+  /** Minimum width for flex columns (default: 10) */
+  minWidth?: number;
+  /** If true, this column will flex to fill remaining space */
+  flex?: boolean;
   render?: (item: T, index: number) => React.ReactNode;
 }
 
@@ -20,6 +24,7 @@ interface TableProps<T> {
 /**
  * Table - Memoized table component with optional virtualization
  * Issue #559 - Performance optimization
+ * Issue #794 - Responsive layout
  */
 export function Table<T>({
   data,
@@ -28,6 +33,40 @@ export function Table<T>({
   maxVisibleRows,
   scrollOffset = 0,
 }: TableProps<T>) {
+  const { stdout } = useStdout();
+  const terminalWidth = stdout?.columns ?? 80;
+
+  // Calculate responsive column widths
+  const responsiveColumns = useMemo(() => {
+    // Reserve space for borders (2), padding (2 per column), selection indicator (2)
+    const reservedWidth = 4 + columns.length * 2;
+    const availableWidth = Math.max(40, terminalWidth - reservedWidth);
+
+    // Calculate total fixed width and count flex columns
+    let fixedWidth = 0;
+    let flexCount = 0;
+
+    for (const col of columns) {
+      if (col.flex) {
+        flexCount++;
+      } else {
+        fixedWidth += col.width ?? 15;
+      }
+    }
+
+    // Calculate flex column width
+    const remainingWidth = Math.max(10, availableWidth - fixedWidth);
+    const flexWidth = flexCount > 0 ? Math.floor(remainingWidth / flexCount) : 0;
+
+    // Return columns with calculated widths
+    return columns.map((col) => ({
+      ...col,
+      calculatedWidth: col.flex
+        ? Math.max(col.minWidth ?? 10, flexWidth)
+        : Math.min(col.width ?? 15, availableWidth),
+    }));
+  }, [columns, terminalWidth]);
+
   // Apply virtualization if maxVisibleRows is specified
   const visibleData = useMemo(() => {
     if (maxVisibleRows && data.length > maxVisibleRows) {
@@ -46,11 +85,11 @@ export function Table<T>({
   }, [selectedIndex, maxVisibleRows, scrollOffset]);
 
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" width={terminalWidth - 2}>
       {/* Header Row */}
       <Box borderStyle="single" borderBottom={false}>
-        {columns.map((col, i) => (
-          <Box key={i} width={col.width || 15} paddingRight={1}>
+        {responsiveColumns.map((col, i) => (
+          <Box key={i} width={col.calculatedWidth} paddingRight={1}>
             <Text bold color="cyan">
               {col.header}
             </Text>
@@ -63,7 +102,7 @@ export function Table<T>({
         <TableRow
           key={rowIndex}
           item={item}
-          columns={columns}
+          columns={responsiveColumns}
           rowIndex={rowIndex}
           isSelected={adjustedSelectedIndex === rowIndex}
         />
@@ -82,9 +121,13 @@ export function Table<T>({
 /**
  * Memoized table row - only re-renders when data or selection changes
  */
+interface ResponsiveColumn<T> extends Column<T> {
+  calculatedWidth: number;
+}
+
 interface TableRowProps<T> {
   item: T;
-  columns: Column<T>[];
+  columns: ResponsiveColumn<T>[];
   rowIndex: number;
   isSelected: boolean;
 }
@@ -98,12 +141,15 @@ const TableRow = memo(function TableRow<T>({
   return (
     <Box borderStyle={isSelected ? 'double' : undefined}>
       {columns.map((col, colIndex) => (
-        <Box key={colIndex} width={col.width || 15} paddingRight={1}>
+        <Box key={colIndex} width={col.calculatedWidth} paddingRight={1}>
           {col.render ? (
             col.render(item, rowIndex)
           ) : (
-            <Text>
-              {String((item as Record<string, unknown>)[col.key as string] ?? '')}
+            <Text wrap="truncate">
+              {truncateText(
+                String((item as Record<string, unknown>)[col.key as string] ?? ''),
+                col.calculatedWidth - 1
+              )}
             </Text>
           )}
         </Box>
@@ -111,5 +157,14 @@ const TableRow = memo(function TableRow<T>({
     </Box>
   );
 }) as <T>(props: TableRowProps<T>) => React.ReactElement;
+
+/**
+ * Truncate text to fit within a given width
+ */
+function truncateText(text: string, maxWidth: number): string {
+  if (text.length <= maxWidth) return text;
+  if (maxWidth <= 3) return text.slice(0, maxWidth);
+  return text.slice(0, maxWidth - 3) + '...';
+}
 
 export default Table;

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -57,26 +57,27 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
     {
       key: 'name',
       header: 'Name',
-      width: 18,
+      width: 15,
     },
     {
       key: 'role',
       header: 'Role',
-      width: 12,
+      width: 10,
     },
     {
       key: 'state',
       header: 'State',
-      width: 12,
+      width: 10,
       render: (agent) => <StatusBadge state={agent.state} />,
     },
     {
       key: 'task',
       header: 'Task',
-      width: 40,
+      flex: true,
+      minWidth: 15,
       render: (agent) => (
         <Text wrap="truncate">
-          {agent.task.slice(0, 38) || '-'}
+          {agent.task || '-'}
         </Text>
       ),
     },

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -269,15 +269,15 @@ const AgentsPanel = memo(function AgentsPanel({ agents }: AgentsPanelProps) {
         <>
           <DataTable
             columns={[
-              { key: 'name', header: 'AGENT', width: 15 },
-              { key: 'role', header: 'ROLE', width: 12 },
+              { key: 'name', header: 'AGENT', width: 12 },
+              { key: 'role', header: 'ROLE', width: 10 },
               {
                 key: 'state',
                 header: 'STATE',
-                width: 10,
+                width: 8,
                 render: (value) => <StatusBadge state={value as string} />,
               },
-              { key: 'updatedAt', header: 'UPDATED', width: 10 },
+              { key: 'updatedAt', header: 'UPDATED', width: 8 },
               { key: 'task', header: 'TASK' },
             ]}
             data={displayAgents}

--- a/tui/src/views/ProcessesView.tsx
+++ b/tui/src/views/ProcessesView.tsx
@@ -77,12 +77,12 @@ export function ProcessesView({ onBack }: ProcessesViewProps) {
     {
       key: 'name',
       header: 'Name',
-      width: 20,
+      width: 12,
     },
     {
       key: 'running',
       header: 'Status',
-      width: 10,
+      width: 8,
       render: (proc) => (
         <StatusBadge state={proc.running ? 'working' : 'stopped'} />
       ),
@@ -90,19 +90,19 @@ export function ProcessesView({ onBack }: ProcessesViewProps) {
     {
       key: 'pid',
       header: 'PID',
-      width: 8,
+      width: 7,
       render: (proc) => <Text>{proc.pid > 0 ? proc.pid : '-'}</Text>,
     },
     {
       key: 'port',
       header: 'Port',
-      width: 8,
+      width: 6,
       render: (proc) => <Text>{proc.port || '-'}</Text>,
     },
     {
       key: 'started_at',
       header: 'Uptime',
-      width: 10,
+      width: 8,
       render: (proc) => (
         <Text>{proc.running ? formatUptime(proc.started_at) : '-'}</Text>
       ),
@@ -110,9 +110,10 @@ export function ProcessesView({ onBack }: ProcessesViewProps) {
     {
       key: 'command',
       header: 'Command',
-      width: 30,
+      flex: true,
+      minWidth: 15,
       render: (proc) => (
-        <Text wrap="truncate">{proc.command.slice(0, 28) || '-'}</Text>
+        <Text wrap="truncate">{proc.command || '-'}</Text>
       ),
     },
   ];

--- a/tui/src/views/TeamsView.tsx
+++ b/tui/src/views/TeamsView.tsx
@@ -104,12 +104,12 @@ export function TeamsView({ onBack }: TeamsViewProps) {
               {
                 key: 'name',
                 header: 'TEAM',
-                width: 20,
+                width: 15,
               },
               {
                 key: 'members',
-                header: 'MEMBERS',
-                width: 10,
+                header: '#',
+                width: 4,
                 render: (value) => (
                   <Text>{(value as string[]).length ?? 0}</Text>
                 ),
@@ -117,7 +117,7 @@ export function TeamsView({ onBack }: TeamsViewProps) {
               {
                 key: 'lead',
                 header: 'LEAD',
-                width: 15,
+                width: 12,
                 render: (value) => (
                   <Text color="green">{(value as string) || '-'}</Text>
                 ),
@@ -126,7 +126,7 @@ export function TeamsView({ onBack }: TeamsViewProps) {
                 key: 'description',
                 header: 'DESCRIPTION',
                 render: (value) => (
-                  <Text dimColor>{truncate((value as string) || '-', 30)}</Text>
+                  <Text dimColor wrap="truncate">{(value as string) || '-'}</Text>
                 ),
               },
             ]}
@@ -210,14 +210,6 @@ function TeamDetails({ team }: TeamDetailsProps) {
       </Box>
     </Panel>
   );
-}
-
-/**
- * Truncate string to max length
- */
-function truncate(str: string, maxLen: number): string {
-  if (str.length <= maxLen) return str;
-  return str.slice(0, maxLen - 1) + '…';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Make Table component responsive with dynamic column width calculation
- Add flex column support for columns that should fill remaining space
- Reduce fixed column widths across all views to fit 80-column terminals
- Add content truncation to prevent overflow

## Changes
1. **Table.tsx**: Calculate responsive column widths based on terminal width
2. **AgentsView.tsx**: Reduced column widths, task column is now flex
3. **Dashboard.tsx**: Reduced DataTable column widths
4. **TeamsView.tsx**: Reduced column widths, description uses wrap="truncate"
5. **ProcessesView.tsx**: Reduced widths, command column is now flex

Closes #794

## Test plan
- [x] Build passes (`bun run build`)
- [x] Views should fit within 80-column terminal
- [ ] Manual testing: resize terminal and verify no horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)