### PR TITLE
fix(agent): Reject null/empty role when spawning agents (#687)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -383,6 +383,11 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 		return nil, fmt.Errorf("agent name %q contains invalid characters (use letters, numbers, dash, underscore)", name)
 	}
 
+	// Validate role is not empty or null-like
+	if role == "" || role == "null" || role == "<nil>" {
+		return nil, fmt.Errorf("role is required and cannot be empty or null")
+	}
+
 	// Enforce root singleton constraint
 	if role == RoleRoot {
 		if err := m.enforceRootSingleton(workspace); err != nil {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1005,6 +1006,31 @@ func TestSpawnAgentWithOptions_ParentCantCreate(t *testing.T) {
 	_, err := m.SpawnAgentWithOptions("eng-2", Role("engineer"), "/tmp", "eng-1", "")
 	if err == nil {
 		t.Error("expected error when parent can't create child role")
+	}
+}
+
+func TestSpawnAgentWithOptions_NullRole(t *testing.T) {
+	m := newTestManager(t)
+
+	tests := []struct {
+		name string
+		role Role
+	}{
+		{"empty role", Role("")},
+		{"null string", Role("null")},
+		{"nil-like string", Role("<nil>")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := m.SpawnAgentWithOptions("test-agent", tt.role, "/tmp", "", "")
+			if err == nil {
+				t.Errorf("expected error for %s, got nil", tt.name)
+			}
+			if !strings.Contains(err.Error(), "role is required") {
+				t.Errorf("expected 'role is required' error, got: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add validation to `SpawnAgentWithOptions` to reject empty, "null", and "<nil>" roles
- Prevents agents from being created in invalid state with null role
- Adds comprehensive test cases for the validation

## Test plan
- [x] Unit test: `TestSpawnAgentWithOptions_NullRole` passes
- [x] All existing agent tests pass
- [x] Lint passes

Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)