### PR TITLE
fix(channel): Include reactions in GetHistory output (#688)

### DIFF
--- a/pkg/channel/channel.go
+++ b/pkg/channel/channel.go
@@ -331,7 +331,12 @@ func (s *Store) GetHistory(channelName string) ([]HistoryEntry, error) {
 		}
 		out := make([]HistoryEntry, 0, len(msgs))
 		for _, m := range msgs {
-			out = append(out, HistoryEntry{Time: m.CreatedAt, Sender: m.Sender, Message: m.Content})
+			entry := HistoryEntry{Time: m.CreatedAt, Sender: m.Sender, Message: m.Content}
+			// Fetch reactions for this message
+			if reactions, reactErr := s.sqlite.GetReactions(m.ID); reactErr == nil && len(reactions) > 0 {
+				entry.Reactions = reactions
+			}
+			out = append(out, entry)
 		}
 		return out, nil
 	}

--- a/pkg/channel/channel_test.go
+++ b/pkg/channel/channel_test.go
@@ -411,6 +411,40 @@ func TestGetHistoryEmpty(t *testing.T) {
 	}
 }
 
+func TestGetHistoryIncludesReactions(t *testing.T) {
+	s := newTestStore(t)
+	if _, err := s.Create("ch"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddHistory("ch", "alice", "hello"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a reaction to the message
+	if err := s.AddReaction("ch", 0, "👍", "bob"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get history and verify reaction is included
+	history, err := s.GetHistory("ch")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(history) != 1 {
+		t.Fatalf("history len = %d, want 1", len(history))
+	}
+
+	// Check reactions are populated
+	if history[0].Reactions == nil {
+		t.Fatal("expected Reactions to be populated, got nil")
+	}
+	if users, ok := history[0].Reactions["👍"]; !ok {
+		t.Error("expected 👍 reaction to be present")
+	} else if len(users) != 1 || users[0] != "bob" {
+		t.Errorf("expected [bob] for 👍, got %v", users)
+	}
+}
+
 // --- Load / Save round-trip ---
 
 func TestSaveAndLoad(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fix `GetHistory` function to fetch and include reactions for each message when using SQLite backend
- Reactions were being stored correctly but not returned in history queries
- `bc channel history` now displays reactions below messages as expected

## Test plan
- [x] Unit test: `TestGetHistoryIncludesReactions` passes
- [x] All channel tests pass
- [x] Lint passes

Closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)