### PR TITLE
feat(role): Add descriptions to role list output (#694)

### DIFF
--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -132,20 +133,58 @@ func runRoleList(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Println("Workspace Roles")
-	fmt.Println(strings.Repeat("=", 60))
-	for name, role := range roles {
-		fmt.Printf("\n%s\n", name)
-		if role.Metadata.IsSingleton {
-			fmt.Println("  [singleton]")
-		}
-		if len(role.Metadata.Capabilities) > 0 {
-			fmt.Printf("  capabilities: %s\n", strings.Join(role.Metadata.Capabilities, ", "))
-		}
-		if len(role.Metadata.ParentRoles) > 0 {
-			fmt.Printf("  parent roles: %s\n", strings.Join(role.Metadata.ParentRoles, ", "))
-		}
+	// Collect role data and calculate column widths
+	type roleRow struct {
+		name         string
+		description  string
+		flags        string
+		capabilities int
 	}
+	rows := make([]roleRow, 0, len(roles))
+	maxNameLen := 4  // "ROLE"
+	maxDescLen := 11 // "DESCRIPTION"
+
+	for name, role := range roles {
+		if len(name) > maxNameLen {
+			maxNameLen = len(name)
+		}
+
+		desc := role.Description()
+		if len(desc) > 40 {
+			desc = desc[:37] + "..."
+		}
+		if len(desc) > maxDescLen {
+			maxDescLen = len(desc)
+		}
+
+		flags := ""
+		if role.Metadata.IsSingleton {
+			flags = "[singleton]"
+		}
+
+		rows = append(rows, roleRow{
+			name:         name,
+			capabilities: len(role.Metadata.Capabilities),
+			description:  desc,
+			flags:        flags,
+		})
+	}
+
+	// Sort roles alphabetically
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].name < rows[j].name
+	})
+
+	// Print table header
+	fmt.Printf("%-*s  %-4s  %-*s  %s\n", maxNameLen, "ROLE", "CAPS", maxDescLen, "DESCRIPTION", "FLAGS")
+	fmt.Println(strings.Repeat("-", maxNameLen+maxDescLen+20))
+
+	// Print rows
+	for _, r := range rows {
+		fmt.Printf("%-*s  %-4d  %-*s  %s\n", maxNameLen, r.name, r.capabilities, maxDescLen, r.description, r.flags)
+	}
+
+	fmt.Printf("\n%d role(s) defined\n", len(rows))
 
 	return nil
 }

--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -14,6 +14,7 @@ import (
 // RoleMetadata contains the parsed frontmatter from a role file.
 type RoleMetadata struct {
 	Name         string   `yaml:"name"`
+	Description  string   `yaml:"description,omitempty"`
 	Capabilities []string `yaml:"capabilities,omitempty"`
 	ParentRoles  []string `yaml:"parent_roles,omitempty"`
 	IsSingleton  bool     `yaml:"is_singleton,omitempty"`
@@ -24,6 +25,24 @@ type Role struct {
 	FilePath string       // Path to the role file
 	Prompt   string       // Markdown body after frontmatter
 	Metadata RoleMetadata // Parsed YAML frontmatter
+}
+
+// Description returns a brief description for the role.
+// Uses Metadata.Description if set, otherwise extracts from the first heading in Prompt.
+func (r *Role) Description() string {
+	if r.Metadata.Description != "" {
+		return r.Metadata.Description
+	}
+
+	// Extract from first heading in prompt
+	lines := strings.Split(r.Prompt, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "# ") {
+			return strings.TrimPrefix(line, "# ")
+		}
+	}
+	return ""
 }
 
 // RoleManager handles role file operations for a workspace.

--- a/pkg/workspace/roles_test.go
+++ b/pkg/workspace/roles_test.go
@@ -336,6 +336,46 @@ func TestRoleManager_WriteRole_NoName(t *testing.T) {
 	}
 }
 
+func TestRole_Description(t *testing.T) {
+	// Test metadata description takes precedence
+	t.Run("uses metadata description", func(t *testing.T) {
+		role := Role{
+			Metadata: RoleMetadata{Description: "Custom description"},
+			Prompt:   "# Heading\n\nContent",
+		}
+		if got := role.Description(); got != "Custom description" {
+			t.Errorf("Description() = %q, want %q", got, "Custom description")
+		}
+	})
+
+	// Test extracts from first heading
+	t.Run("extracts from heading", func(t *testing.T) {
+		role := Role{Prompt: "# Engineer Agent\n\nYou are an engineer."}
+		if got := role.Description(); got != "Engineer Agent" {
+			t.Errorf("Description() = %q, want %q", got, "Engineer Agent")
+		}
+	})
+
+	// Test handles no heading gracefully
+	t.Run("handles no heading", func(t *testing.T) {
+		role := Role{Prompt: "Just some content"}
+		if got := role.Description(); got != "" {
+			t.Errorf("Description() = %q, want empty string", got)
+		}
+	})
+
+	// Test metadata takes precedence over prompt heading
+	t.Run("metadata takes precedence", func(t *testing.T) {
+		role := Role{
+			Metadata: RoleMetadata{Description: "Metadata wins"},
+			Prompt:   "# Prompt heading",
+		}
+		if got := role.Description(); got != "Metadata wins" {
+			t.Errorf("Description() = %q, want %q", got, "Metadata wins")
+		}
+	})
+}
+
 func TestFormatRoleFile(t *testing.T) {
 	role := &Role{
 		Metadata: RoleMetadata{


### PR DESCRIPTION
## Summary
- Add `Description` field to `RoleMetadata` for explicit role descriptions
- Add `Role.Description()` method that returns metadata description or extracts from first prompt heading
- Update `bc role list` to show table format with:
  - ROLE: role name
  - CAPS: capability count
  - DESCRIPTION: role description (truncated to 40 chars)
  - FLAGS: singleton indicator
- Sort roles alphabetically for consistent output

## Example output
```
ROLE           CAPS  DESCRIPTION                  FLAGS
engineer       3     Engineer Agent
manager        2     Manager Agent                [singleton]
tech-lead      4     Technical Leadership
```

## Test plan
- [x] Unit test: `TestRole_Description` passes
- [x] All workspace and cmd tests pass
- [x] Lint passes

Closes #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)