### PR TITLE
fix(ux): Improve error message for agent start (#685)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -707,7 +707,7 @@ func runAgentStart(cmd *cobra.Command, args []string) error {
 
 	// Check if agent is in stopped state
 	if a.State != agent.StateStopped {
-		return fmt.Errorf("agent %q is not stopped (current state: %s) - cannot start", agentName, a.State)
+		return fmt.Errorf("agent %q is already running (state: %s). Stop it first with: bc agent stop %s", agentName, a.State, agentName)
 	}
 
 	fmt.Printf("Starting %s (%s)... ", agentName, a.Role)

--- a/internal/cmd/agent_integration_test.go
+++ b/internal/cmd/agent_integration_test.go
@@ -561,8 +561,8 @@ func TestAgentStartNotStopped(t *testing.T) {
 		t.Fatalf("agent start should fail for running agent, got: %s", stdout)
 	}
 	output := stderr + stdout
-	if !strings.Contains(output, "not stopped") && !strings.Contains(output, "current state") {
-		t.Errorf("error message should indicate agent is not stopped: %s", output)
+	if !strings.Contains(output, "already running") && !strings.Contains(output, "state:") {
+		t.Errorf("error message should indicate agent is already running: %s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Improve error message when trying to start an already-running agent
- Old: `agent 'X' is not stopped (current state: idle) - cannot start`
- New: `agent 'X' is already running (state: idle). Stop it first with: bc agent stop X`

The new message:
- Uses clearer "already running" phrasing instead of "not stopped"
- Provides actionable command to fix the issue

## Test plan
- [x] Test: `TestAgentStartNotStopped` passes
- [x] Lint passes

Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)