### PR TITLE
fix(tui): ESLint fixes for useDashboard and bc.ts (#792)

### DIFF
--- a/tui/src/hooks/useDashboard.ts
+++ b/tui/src/hooks/useDashboard.ts
@@ -122,7 +122,7 @@ export function useDashboard() {
         error: null,
       });
     } else {
-      const error = channelsResult.reason;
+      const error: unknown = channelsResult.reason;
       setChannels({
         data: [],
         isLoading: false,
@@ -220,10 +220,10 @@ function formatTime(isoString: string | undefined): string {
     const diffMins = Math.floor(diffMs / 60000);
 
     if (diffMins < 1) return 'now';
-    if (diffMins < 60) return `${diffMins}m ago`;
+    if (diffMins < 60) return `${String(diffMins)}m ago`;
 
     const diffHours = Math.floor(diffMins / 60);
-    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffHours < 24) return `${String(diffHours)}h ago`;
 
     return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
   } catch {

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -72,7 +72,7 @@ export async function execBc(args: string[]): Promise<string> {
       if (code === 0) {
         resolve(stdout.trim());
       } else {
-        reject(new Error(stderr || `bc command failed with code ${code}`));
+        reject(new Error(stderr || `bc command failed with code ${String(code ?? 'unknown')}`));
       }
     });
 


### PR DESCRIPTION
## Summary
- Add type annotation for error variable in useDashboard.ts (no-unsafe-assignment)
- Convert template literal numbers to String() in useDashboard.ts and bc.ts (restrict-template-expressions)

Reduces ESLint errors from 28 to 24.

## Test plan
- [x] `bun run lint` passes with reduced error count

🤖 Generated with [Claude Code](https://claude.com/claude-code)