### PR TITLE
fix(tui): Fix last 2 no-unnecessary-condition errors in AgentDetailView

### DIFF
--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -109,7 +109,7 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
           <Box marginTop={1}>
             <Text>State: </Text>
             <StatusBadge state={agent.state} />
-            <Text dimColor> | Task: {agent.task ?? 'none'}</Text>
+            <Text dimColor> | Task: {agent.task || 'none'}</Text>
           </Box>
         </Box>
       </Box>
@@ -189,7 +189,7 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
           <Text bold color="white">Task</Text>
         </Box>
         <Box paddingLeft={2}>
-          <Text wrap="wrap">{agent.task ?? '(no task)'}</Text>
+          <Text wrap="wrap">{agent.task || '(no task)'}</Text>
         </Box>
 
         <Box marginY={1}>


### PR DESCRIPTION
## Summary
Fixes the last 2 `no-unnecessary-condition` ESLint errors in AgentDetailView.tsx

- Changed `agent.task ?? 'none'` to `agent.task || 'none'` 
- Changed `agent.task ?? '(no task)'` to `agent.task || '(no task)'`

The `task` field is typed as `string` (never null/undefined), but the intent is to show a fallback when the task is empty string. Using `||` handles both null/undefined AND empty string.

## Test plan
- [x] `bun run lint` - 0 errors, 5 warnings (all warnings are react-hooks/exhaustive-deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)