### PR TITLE
feat(tui): Add vim-style g/G navigation and Ctrl+R refresh (#797)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -66,6 +66,13 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
         if ((key.downArrow || input === 'j') && channels && selectedIndex < channels.length - 1) {
           setSelectedIndex(selectedIndex + 1);
         }
+        // Vim-style top/bottom navigation
+        if (input === 'g') {
+          setSelectedIndex(0);
+        }
+        if (input === 'G' && channels) {
+          setSelectedIndex(channels.length - 1);
+        }
         // Enter channel
         if (key.return && selectedChannel) {
           setViewMode('history');

--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -11,17 +11,21 @@ export interface UseKeyboardNavigationOptions {
   disabled?: boolean;
   /** Custom quit handler (defaults to process.exit(0)) */
   onQuit?: () => void;
+  /** Global refresh handler (triggered by Ctrl+R) */
+  onRefresh?: () => void;
 }
 
 /**
  * Hook that handles global keyboard navigation
  * - Number keys (1-9) switch tabs
+ * - Tab/Shift+Tab cycles tabs
  * - ? shows help
  * - ESC goes back/home
+ * - Ctrl+R refreshes all data
  * - q quits the application
  */
 export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}): void {
-  const { disabled = false, onQuit } = options;
+  const { disabled = false, onQuit, onRefresh } = options;
   const { navigate, goHome, getTabByKey, nextTab, prevTab } = useNavigation();
   const { isFocused } = useFocus();
 
@@ -64,6 +68,14 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
       // ESC: go home
       if (key.escape) {
         goHome();
+        return;
+      }
+
+      // Ctrl+R: refresh all data
+      if (key.ctrl && input === 'r') {
+        if (onRefresh) {
+          onRefresh();
+        }
         return;
       }
 

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -32,6 +32,10 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
       setSelectedIndex((i) => Math.max(0, i - 1));
     } else if (key.downArrow || input === 'j') {
       setSelectedIndex((i) => Math.min(agentList.length - 1, i + 1));
+    } else if (input === 'g') {
+      setSelectedIndex(0);
+    } else if (input === 'G') {
+      setSelectedIndex(Math.max(0, agentList.length - 1));
     } else if (key.return) {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive check for empty list
       if (selectedAgent) {

--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -75,6 +75,14 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
         if (filteredCommands.length > 0) {
           setSelectedIndex(Math.min(filteredCommands.length - 1, validatedIndex + 1));
         }
+      } else if (input === 'g') {
+        // Go to top
+        setSelectedIndex(0);
+      } else if (input === 'G') {
+        // Go to bottom
+        if (filteredCommands.length > 0) {
+          setSelectedIndex(filteredCommands.length - 1);
+        }
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive check for empty list
       } else if (key.return && selectedCommand) {
         // TODO: Execute command or show confirmation

--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -99,6 +99,12 @@ export function DemonsView({
       if (input === 'k' || key.upArrow) {
         setSelectedIndex((prev) => Math.max(prev - 1, 0));
       }
+      if (input === 'g') {
+        setSelectedIndex(0);
+      }
+      if (input === 'G') {
+        setSelectedIndex(demons.length - 1);
+      }
 
       // Actions
       if (input === 'r') {


### PR DESCRIPTION
## Summary
- Add consistent vim-style `g` (top) and `G` (bottom) navigation keybindings across all list views
- Add `Ctrl+R` global refresh support to useKeyboardNavigation hook with onRefresh callback
- Views updated: AgentsView, DemonsView, CommandsView, ChannelsView

## Test plan
- [x] Lint passes on all modified files
- [x] All 302 tests pass
- [ ] Manual verification: press `g` to jump to top of any list
- [ ] Manual verification: press `G` to jump to bottom of any list
- [ ] Manual verification: `Ctrl+R` triggers refresh when onRefresh callback is provided

Closes #797

🤖 Generated with [Claude Code](https://claude.ai/claude-code)