### PR TITLE
feat(tui): Add futuristic theme options (#795)

### DIFF
--- a/tui/src/theme/ThemeContext.tsx
+++ b/tui/src/theme/ThemeContext.tsx
@@ -16,7 +16,8 @@ import React, {
   useMemo,
 } from 'react';
 import type { Theme, ThemeMode, ThemeColors, ThemeConfig } from './types';
-import { darkTheme, lightTheme, applyOverrides } from './themes';
+import { darkTheme, lightTheme, applyOverrides, getTheme } from './themes';
+import type { ThemeName } from './themes';
 import { detectColorScheme } from './detectColorScheme';
 
 interface ThemeContextValue {
@@ -24,10 +25,18 @@ interface ThemeContextValue {
   theme: Theme;
   /** Current theme mode */
   mode: ThemeMode;
+  /** Current theme name */
+  themeName: ThemeName;
+  /** Available theme names */
+  availableThemes: ThemeName[];
   /** Detected terminal color scheme */
   detectedScheme: 'dark' | 'light';
   /** Switch theme mode */
   setMode: (mode: ThemeMode) => void;
+  /** Set specific theme by name */
+  setThemeName: (name: ThemeName) => void;
+  /** Cycle to next theme */
+  cycleTheme: () => void;
   /** Toggle between dark and light */
   toggleTheme: () => void;
   /** Get a specific color from the theme */
@@ -44,6 +53,9 @@ interface ThemeProviderProps {
   config?: ThemeConfig;
 }
 
+/** List of available theme names for cycling */
+const availableThemes: ThemeName[] = ['dark', 'light', 'matrix', 'synthwave', 'high-contrast'];
+
 /**
  * ThemeProvider - Wrap your app to enable theming
  */
@@ -52,9 +64,10 @@ export function ThemeProvider({
   config,
 }: ThemeProviderProps): React.ReactElement {
   const [mode, setModeState] = useState<ThemeMode>(config?.mode ?? 'auto');
+  const [themeName, setThemeNameState] = useState<ThemeName>('dark');
   const [detectedScheme] = useState<'dark' | 'light'>(() => detectColorScheme());
 
-  // Determine effective theme based on mode
+  // Determine effective theme based on mode or explicit theme name
   const effectiveMode = useMemo((): 'dark' | 'light' => {
     if (mode === 'auto') {
       return detectedScheme;
@@ -64,15 +77,46 @@ export function ThemeProvider({
 
   // Build the theme with any overrides
   const theme = useMemo((): Theme => {
+    // If using a named theme (matrix, synthwave, high-contrast), use it directly
+    if (themeName !== 'dark' && themeName !== 'light') {
+      const baseTheme = getTheme(themeName);
+      if (config?.overrides) {
+        return applyOverrides(baseTheme, config.overrides);
+      }
+      return baseTheme;
+    }
+    // Otherwise use dark/light based on mode
     const baseTheme = effectiveMode === 'light' ? lightTheme : darkTheme;
     if (config?.overrides) {
       return applyOverrides(baseTheme, config.overrides);
     }
     return baseTheme;
-  }, [effectiveMode, config?.overrides]);
+  }, [themeName, effectiveMode, config?.overrides]);
 
   const setMode = useCallback((newMode: ThemeMode) => {
     setModeState(newMode);
+    // Reset to dark/light when changing mode
+    if (newMode === 'dark') setThemeNameState('dark');
+    if (newMode === 'light') setThemeNameState('light');
+  }, []);
+
+  const setThemeName = useCallback((name: ThemeName) => {
+    setThemeNameState(name);
+    // Update mode to match theme
+    const selectedTheme = getTheme(name);
+    setModeState(selectedTheme.mode);
+  }, []);
+
+  const cycleTheme = useCallback(() => {
+    setThemeNameState((current) => {
+      const currentIndex = availableThemes.indexOf(current);
+      const nextIndex = (currentIndex + 1) % availableThemes.length;
+      const nextTheme = availableThemes[nextIndex];
+      // Update mode to match
+      const selectedTheme = getTheme(nextTheme);
+      setModeState(selectedTheme.mode);
+      return nextTheme;
+    });
   }, []);
 
   const toggleTheme = useCallback(() => {
@@ -82,6 +126,12 @@ export function ThemeProvider({
         return detectedScheme === 'dark' ? 'light' : 'dark';
       }
       return current === 'dark' ? 'light' : 'dark';
+    });
+    // Also update theme name for dark/light toggle
+    setThemeNameState((current) => {
+      if (current === 'dark') return 'light';
+      if (current === 'light') return 'dark';
+      return current; // Keep special themes
     });
   }, [detectedScheme]);
 
@@ -96,13 +146,17 @@ export function ThemeProvider({
     (): ThemeContextValue => ({
       theme,
       mode,
+      themeName,
+      availableThemes,
       detectedScheme,
       setMode,
+      setThemeName,
+      cycleTheme,
       toggleTheme,
       color,
-      isDark: effectiveMode === 'dark',
+      isDark: theme.mode === 'dark',
     }),
-    [theme, mode, detectedScheme, setMode, toggleTheme, color, effectiveMode]
+    [theme, mode, themeName, detectedScheme, setMode, setThemeName, cycleTheme, toggleTheme, color]
   );
 
   return (

--- a/tui/src/theme/index.ts
+++ b/tui/src/theme/index.ts
@@ -5,7 +5,7 @@
  * - Auto-detection of terminal dark/light mode
  * - ThemeProvider for React context
  * - useTheme hook for accessing colors
- * - Pre-defined dark and light themes
+ * - Pre-defined themes: dark, light, matrix, synthwave, high-contrast
  */
 
 // Types
@@ -26,7 +26,17 @@ export {
 } from './ThemeContext';
 
 // Themes
-export { darkTheme, lightTheme, getTheme, applyOverrides } from './themes';
+export {
+  darkTheme,
+  lightTheme,
+  matrixTheme,
+  synthwaveTheme,
+  highContrastTheme,
+  themes,
+  getTheme,
+  applyOverrides,
+} from './themes';
+export type { ThemeName } from './themes';
 
 // Detection utilities
 export {

--- a/tui/src/theme/themes.ts
+++ b/tui/src/theme/themes.ts
@@ -93,10 +93,154 @@ export const lightTheme: Theme = {
 };
 
 /**
+ * Matrix theme - Classic green terminal aesthetic
+ * Inspired by The Matrix with phosphor green accents
+ */
+export const matrixTheme: Theme = {
+  name: 'matrix',
+  mode: 'dark',
+  colors: {
+    // Primary colors - all green variants
+    primary: 'green',
+    secondary: 'greenBright',
+    accent: 'greenBright',
+
+    // Text colors
+    text: 'green',
+    textMuted: 'gray',
+    textInverse: 'black',
+
+    // Status colors
+    success: 'greenBright',
+    warning: 'yellow',
+    error: 'red',
+    info: 'green',
+
+    // Agent state colors
+    agentIdle: 'gray',
+    agentWorking: 'greenBright',
+    agentDone: 'green',
+    agentStuck: 'yellow',
+    agentError: 'red',
+
+    // UI element colors
+    border: 'green',
+    borderFocused: 'greenBright',
+    selection: 'greenBright',
+    highlight: 'greenBright',
+
+    // Component-specific
+    headerTitle: 'greenBright',
+    footerText: 'green',
+    badge: 'greenBright',
+  },
+};
+
+/**
+ * Synthwave theme - Retro-futuristic cyberpunk aesthetics
+ * Purple, pink, and cyan neon colors
+ */
+export const synthwaveTheme: Theme = {
+  name: 'synthwave',
+  mode: 'dark',
+  colors: {
+    // Primary colors - neon palette
+    primary: 'magenta',
+    secondary: 'cyan',
+    accent: 'magentaBright',
+
+    // Text colors
+    text: 'white',
+    textMuted: 'gray',
+    textInverse: 'black',
+
+    // Status colors
+    success: 'cyanBright',
+    warning: 'yellow',
+    error: 'redBright',
+    info: 'magenta',
+
+    // Agent state colors
+    agentIdle: 'gray',
+    agentWorking: 'cyanBright',
+    agentDone: 'cyan',
+    agentStuck: 'yellow',
+    agentError: 'redBright',
+
+    // UI element colors
+    border: 'magenta',
+    borderFocused: 'magentaBright',
+    selection: 'cyan',
+    highlight: 'magentaBright',
+
+    // Component-specific
+    headerTitle: 'magentaBright',
+    footerText: 'magenta',
+    badge: 'cyanBright',
+  },
+};
+
+/**
+ * High contrast theme - Accessibility-focused
+ * Bold, clear colors for maximum readability
+ */
+export const highContrastTheme: Theme = {
+  name: 'high-contrast',
+  mode: 'dark',
+  colors: {
+    // Primary colors - bright and bold
+    primary: 'whiteBright',
+    secondary: 'cyanBright',
+    accent: 'yellowBright',
+
+    // Text colors
+    text: 'whiteBright',
+    textMuted: 'white',
+    textInverse: 'black',
+
+    // Status colors - high visibility
+    success: 'greenBright',
+    warning: 'yellowBright',
+    error: 'redBright',
+    info: 'cyanBright',
+
+    // Agent state colors
+    agentIdle: 'white',
+    agentWorking: 'cyanBright',
+    agentDone: 'greenBright',
+    agentStuck: 'yellowBright',
+    agentError: 'redBright',
+
+    // UI element colors
+    border: 'whiteBright',
+    borderFocused: 'yellowBright',
+    selection: 'yellowBright',
+    highlight: 'yellowBright',
+
+    // Component-specific
+    headerTitle: 'whiteBright',
+    footerText: 'white',
+    badge: 'cyanBright',
+  },
+};
+
+/** Available theme names */
+export type ThemeName = 'dark' | 'light' | 'matrix' | 'synthwave' | 'high-contrast';
+
+/** All available themes */
+export const themes: Record<ThemeName, Theme> = {
+  dark: darkTheme,
+  light: lightTheme,
+  matrix: matrixTheme,
+  synthwave: synthwaveTheme,
+  'high-contrast': highContrastTheme,
+};
+
+/**
  * Get theme by name
  */
-export function getTheme(name: 'dark' | 'light'): Theme {
-  return name === 'light' ? lightTheme : darkTheme;
+export function getTheme(name: ThemeName): Theme {
+  return themes[name];
 }
 
 /**


### PR DESCRIPTION
## Summary
Add three new themes for the TUI command center aesthetic:

- **Matrix theme**: Classic green phosphor terminal look
- **Synthwave theme**: Retro-futuristic purple/pink/cyan neon colors  
- **High contrast theme**: Bold, accessible colors for maximum readability

## Changes
- Add `matrixTheme`, `synthwaveTheme`, `highContrastTheme` to themes.ts
- Add `ThemeName` type for all available themes
- Update ThemeContext with theme switching capabilities:
  - `setThemeName(name)` - select specific theme
  - `cycleTheme()` - cycle through all themes
  - `availableThemes` - list of theme options
  - `themeName` - current theme name

## Usage
```typescript
const { themeName, setThemeName, cycleTheme, availableThemes } = useTheme();

// Set specific theme
setThemeName('matrix');
setThemeName('synthwave');
setThemeName('high-contrast');

// Cycle through themes
cycleTheme(); // dark -> light -> matrix -> synthwave -> high-contrast -> dark
```

## Test plan
- [x] `bun run build` - TypeScript compiles
- [x] `bun run lint` - no new errors in theme files
- [ ] Manual testing: verify theme colors in TUI

Fixes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)