### PR TITLE
feat(tui): Add tool/test commands and category filtering (#677)

### DIFF
--- a/tui/src/types/commands.ts
+++ b/tui/src/types/commands.ts
@@ -253,6 +253,77 @@ export const COMMAND_REGISTRY: CommandCategory[] = [
       },
     ],
   },
+  {
+    name: 'Tool Integrations',
+    commands: [
+      {
+        name: 'tool list',
+        category: 'Tool Integrations',
+        description: 'List all configured external tools',
+        usage: 'bc tool list',
+        readOnly: true,
+        flags: ['--json', '--enabled'],
+      },
+      {
+        name: 'tool show',
+        category: 'Tool Integrations',
+        description: 'Show details for a specific tool',
+        usage: 'bc tool show <name>',
+        readOnly: true,
+        flags: ['--json'],
+      },
+      {
+        name: 'tool enable',
+        category: 'Tool Integrations',
+        description: 'Enable a configured tool',
+        usage: 'bc tool enable <name>',
+        readOnly: false,
+      },
+      {
+        name: 'tool disable',
+        category: 'Tool Integrations',
+        description: 'Disable a configured tool',
+        usage: 'bc tool disable <name>',
+        readOnly: false,
+      },
+      {
+        name: 'tool exec',
+        category: 'Tool Integrations',
+        description: 'Execute command using a tool',
+        usage: 'bc tool exec <name> -- <args...>',
+        readOnly: false,
+      },
+    ],
+  },
+  {
+    name: 'Testing',
+    commands: [
+      {
+        name: 'test run',
+        category: 'Testing',
+        description: 'Run tests for the workspace',
+        usage: 'bc test run',
+        readOnly: true,
+        flags: ['--verbose', '--json'],
+      },
+      {
+        name: 'test tui',
+        category: 'Testing',
+        description: 'Run TUI tests',
+        usage: 'bc test tui',
+        readOnly: true,
+        flags: ['--verbose'],
+      },
+      {
+        name: 'test report',
+        category: 'Testing',
+        description: 'Generate test report',
+        usage: 'bc test report',
+        readOnly: true,
+        flags: ['--json'],
+      },
+    ],
+  },
 ];
 
 /**

--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { COMMAND_REGISTRY, searchCommands } from '../types/commands';
+import { COMMAND_REGISTRY } from '../types/commands';
 import type { BcCommand } from '../types/commands';
 import { useFocus } from '../navigation/FocusContext';
 import { execBc } from '../services/bc';
@@ -16,6 +16,9 @@ interface CommandsViewProps {
   disableInput?: boolean;
 }
 
+// Get all category names from registry
+const CATEGORY_NAMES = ['All', ...COMMAND_REGISTRY.map(cat => cat.name)];
+
 export const CommandsView: React.FC<CommandsViewProps> = ({
   onBack,
   disableInput = false,
@@ -23,6 +26,7 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searchMode, setSearchMode] = useState(false);
+  const [categoryFilter, setCategoryFilter] = useState('All');
   const { setFocus, returnFocus } = useFocus();
 
   // Command execution state
@@ -57,19 +61,30 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
     }
   }, []);
 
-  // Get filtered commands
-  const filteredCommands = searchQuery.length > 0
-    ? searchCommands(searchQuery)
-    : COMMAND_REGISTRY.flatMap(cat => cat.commands);
+  // Get filtered commands by category and search
+  const filteredCommands = React.useMemo(() => {
+    let commands = categoryFilter === 'All'
+      ? COMMAND_REGISTRY.flatMap(cat => cat.commands)
+      : COMMAND_REGISTRY.find(cat => cat.name === categoryFilter)?.commands ?? [];
+
+    if (searchQuery.length > 0) {
+      const lowerQuery = searchQuery.toLowerCase();
+      commands = commands.filter(cmd =>
+        cmd.name.toLowerCase().includes(lowerQuery) ||
+        cmd.description.toLowerCase().includes(lowerQuery)
+      );
+    }
+    return commands;
+  }, [categoryFilter, searchQuery]);
 
   // Clamp selectedIndex to valid range whenever filteredCommands changes
   const validatedIndex = Math.min(selectedIndex, Math.max(0, filteredCommands.length - 1));
   const selectedCommand = filteredCommands[validatedIndex] as typeof filteredCommands[number] | undefined;
 
-  // Reset selection when search results change
+  // Reset selection when search results or category change
   React.useEffect(() => {
     setSelectedIndex(0);
-  }, [searchQuery]);
+  }, [searchQuery, categoryFilter]);
 
   // Sync focus state with search mode
   React.useEffect(() => {
@@ -99,6 +114,11 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
       // Navigation mode
       if (input === '/') {
         setSearchMode(true);
+      } else if (key.tab) {
+        // Cycle to next category
+        const currentIdx = CATEGORY_NAMES.indexOf(categoryFilter);
+        const nextIdx = (currentIdx + 1) % CATEGORY_NAMES.length;
+        setCategoryFilter(CATEGORY_NAMES[nextIdx] ?? 'All');
       } else if (key.upArrow || input === 'k') {
         // Navigate up, clamped to valid range
         if (filteredCommands.length > 0) {
@@ -152,6 +172,13 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
           Commands
         </Text>
         <Text dimColor> ({filteredCommands.length} available)</Text>
+      </Box>
+
+      {/* Category filter bar */}
+      <Box marginBottom={1} paddingX={1}>
+        <Text dimColor>Category: </Text>
+        <Text color="cyan" bold>{categoryFilter}</Text>
+        <Text dimColor> (Tab to cycle)</Text>
       </Box>
 
       {/* Search bar */}


### PR DESCRIPTION
## Summary
- Adds Tool Integrations category with tool list/show/enable/disable/exec commands
- Adds Testing category with test run/tui/report commands
- Implements category filtering with Tab key navigation
- Shows current category in UI with filter bar

## Test plan
- [x] CommandsView tests pass (44 tests)
- [x] Lint passes (0 errors)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)