### PR TITLE
test(tui): Add 42 extended component tests (#682)

### DIFF
--- a/tui/src/__tests__/components/MetricCard.extended.test.tsx
+++ b/tui/src/__tests__/components/MetricCard.extended.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * MetricCard component extended tests
+ * Issue #682 - Component Testing
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect } from 'bun:test';
+import { MetricCard } from '../../components/MetricCard';
+
+describe('MetricCard - Extended Tests', () => {
+  describe('value display', () => {
+    it('renders zero value', () => {
+      const { lastFrame } = render(<MetricCard value={0} label="Count" />);
+      expect(lastFrame()).toContain('0');
+    });
+
+    it('renders positive integer', () => {
+      const { lastFrame } = render(<MetricCard value={42} label="Count" />);
+      expect(lastFrame()).toContain('42');
+    });
+
+    it('renders large number', () => {
+      const { lastFrame } = render(<MetricCard value={1000000} label="Count" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders negative number', () => {
+      const { lastFrame } = render(<MetricCard value={-5} label="Delta" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders decimal number', () => {
+      const { lastFrame } = render(<MetricCard value={3.14} label="Pi" />);
+      expect(lastFrame()).toBeDefined();
+    });
+  });
+
+  describe('label display', () => {
+    it('renders short label', () => {
+      const { lastFrame } = render(<MetricCard value={1} label="A" />);
+      expect(lastFrame()).toContain('A');
+    });
+
+    it('renders long label', () => {
+      const longLabel = 'Very Long Label Name';
+      const { lastFrame } = render(<MetricCard value={1} label={longLabel} />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders label with spaces', () => {
+      const { lastFrame } = render(<MetricCard value={1} label="Active Agents" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders label with special characters', () => {
+      const { lastFrame } = render(<MetricCard value={1} label="Cost ($)" />);
+      expect(lastFrame()).toBeDefined();
+    });
+  });
+
+  describe('color variations', () => {
+    it('renders with green color', () => {
+      const { lastFrame } = render(<MetricCard value={5} label="Active" color="green" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with red color', () => {
+      const { lastFrame } = render(<MetricCard value={2} label="Errors" color="red" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with yellow color', () => {
+      const { lastFrame } = render(<MetricCard value={3} label="Warnings" color="yellow" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with cyan color', () => {
+      const { lastFrame } = render(<MetricCard value={10} label="Working" color="cyan" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with gray color', () => {
+      const { lastFrame } = render(<MetricCard value={0} label="Idle" color="gray" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with default color (no color prop)', () => {
+      const { lastFrame } = render(<MetricCard value={7} label="Total" />);
+      expect(lastFrame()).toBeDefined();
+    });
+  });
+
+  describe('layout', () => {
+    it('renders without crashing', () => {
+      expect(() => {
+        render(<MetricCard value={1} label="Test" />);
+      }).not.toThrow();
+    });
+
+    it('produces consistent output', () => {
+      const { lastFrame: frame1 } = render(<MetricCard value={42} label="Count" />);
+      const { lastFrame: frame2 } = render(<MetricCard value={42} label="Count" />);
+      expect(frame1()).toBe(frame2());
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty label', () => {
+      const { lastFrame } = render(<MetricCard value={1} label="" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('handles very large values', () => {
+      const { lastFrame } = render(<MetricCard value={Number.MAX_SAFE_INTEGER} label="Max" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('handles Infinity', () => {
+      const { lastFrame } = render(<MetricCard value={Infinity} label="Inf" />);
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('handles NaN gracefully', () => {
+      const { lastFrame } = render(<MetricCard value={NaN} label="NaN" />);
+      expect(lastFrame()).toBeDefined();
+    });
+  });
+});

--- a/tui/src/__tests__/components/Panel.extended.test.tsx
+++ b/tui/src/__tests__/components/Panel.extended.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Panel component extended tests
+ * Issue #682 - Component Testing
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { describe, it, expect } from 'bun:test';
+import { Panel } from '../../components/Panel';
+
+describe('Panel - Extended Tests', () => {
+  describe('title variations', () => {
+    it('renders without title', () => {
+      const { lastFrame } = render(
+        <Panel>
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toContain('Content');
+    });
+
+    it('renders with short title', () => {
+      const { lastFrame } = render(
+        <Panel title="Hi">
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toContain('Hi');
+    });
+
+    it('renders with long title', () => {
+      const longTitle = 'A'.repeat(50);
+      const { lastFrame } = render(
+        <Panel title={longTitle}>
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toContain('A');
+    });
+
+    it('renders with special characters in title', () => {
+      const { lastFrame } = render(
+        <Panel title="Test: Special!@#$%">
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with unicode title', () => {
+      const { lastFrame } = render(
+        <Panel title="测试 🎉">
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toContain('测试');
+    });
+
+    it('renders with empty string title', () => {
+      const { lastFrame } = render(
+        <Panel title="">
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toContain('Content');
+    });
+  });
+
+  describe('border styles', () => {
+    it('renders with default border color', () => {
+      const { lastFrame } = render(
+        <Panel title="Test">
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with custom border color', () => {
+      const { lastFrame } = render(
+        <Panel title="Test" borderColor="red">
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders when focused', () => {
+      const { lastFrame } = render(
+        <Panel title="Test" focused>
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders when not focused', () => {
+      const { lastFrame } = render(
+        <Panel title="Test" focused={false}>
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+  });
+
+  describe('dimensions', () => {
+    it('renders with fixed width', () => {
+      const { lastFrame } = render(
+        <Panel title="Test" width={50}>
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with fixed height', () => {
+      const { lastFrame } = render(
+        <Panel title="Test" height={10}>
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with both fixed dimensions', () => {
+      const { lastFrame } = render(
+        <Panel title="Test" width={50} height={10}>
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with percentage width', () => {
+      const { lastFrame } = render(
+        <Panel title="Test" width="50%">
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with small width', () => {
+      const { lastFrame } = render(
+        <Panel title="Test" width={10}>
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+  });
+
+  describe('children content', () => {
+    it('renders single child', () => {
+      const { lastFrame } = render(
+        <Panel title="Test">
+          <Text>Single child</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toContain('Single child');
+    });
+
+    it('renders multiple children', () => {
+      const { lastFrame } = render(
+        <Panel title="Test">
+          <Text>Child 1</Text>
+          <Text>Child 2</Text>
+          <Text>Child 3</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toContain('Child 1');
+      expect(lastFrame()).toContain('Child 2');
+      expect(lastFrame()).toContain('Child 3');
+    });
+
+    it('renders nested panels', () => {
+      const { lastFrame } = render(
+        <Panel title="Outer">
+          <Panel title="Inner">
+            <Text>Nested content</Text>
+          </Panel>
+        </Panel>
+      );
+      expect(lastFrame()).toContain('Outer');
+      expect(lastFrame()).toContain('Inner');
+    });
+
+    it('renders with no children', () => {
+      const { lastFrame } = render(<Panel title="Empty" children={null} />);
+      expect(lastFrame()).toContain('Empty');
+    });
+
+    it('renders with complex children', () => {
+      const { lastFrame } = render(
+        <Panel title="Complex">
+          <Text bold>Bold text</Text>
+          <Text color="red">Red text</Text>
+          <Text dimColor>Dim text</Text>
+        </Panel>
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+  });
+
+  describe('consistency', () => {
+    it('produces consistent output', () => {
+      const { lastFrame: frame1 } = render(
+        <Panel title="Test">
+          <Text>Content</Text>
+        </Panel>
+      );
+      const { lastFrame: frame2 } = render(
+        <Panel title="Test">
+          <Text>Content</Text>
+        </Panel>
+      );
+      expect(frame1()).toBe(frame2());
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 42 extended component tests for Panel and MetricCard
- Part of Phase 2-Subtask 3: Component & View Testing
- Total test count now at 663 (exceeds 400 goal)

## Test Coverage

| Component | Tests | Coverage Areas |
|-----------|-------|----------------|
| Panel | 21 | Titles, borders, dimensions, children |
| MetricCard | 21 | Values, labels, colors, edge cases |

## Test plan
- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] `bun test` - 663 tests pass (6 pre-existing failures)

Contributes to #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)