### PR TITLE
feat(tui): Add MembersPanel component (#847)

### DIFF
--- a/tui/src/__tests__/components/MembersPanel.test.tsx
+++ b/tui/src/__tests__/components/MembersPanel.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * MembersPanel component tests
+ * Issue #847 - Channel member list + description
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { describe, it, expect } from 'bun:test';
+import { MembersPanel, MemberCountBadge } from '../../components/MembersPanel';
+import type { MemberInfo } from '../../components/MembersPanel';
+
+const mockMembers: string[] = ['eng-01', 'eng-02', 'tl-01', 'mgr-01'];
+
+const mockMembersWithInfo: MemberInfo[] = [
+  { name: 'eng-01', role: 'engineer', state: 'working' },
+  { name: 'eng-02', role: 'engineer', state: 'idle' },
+  { name: 'tl-01', role: 'tech-lead', state: 'working' },
+];
+
+describe('MembersPanel', () => {
+  describe('basic rendering', () => {
+    it('renders member list', () => {
+      const { lastFrame } = render(<MembersPanel members={mockMembers} />);
+      const output = lastFrame();
+      expect(output).toContain('eng-01');
+      expect(output).toContain('eng-02');
+    });
+
+    it('shows member count in title', () => {
+      const { lastFrame } = render(<MembersPanel members={mockMembers} />);
+      const output = lastFrame();
+      expect(output).toContain('(4)');
+    });
+
+    it('renders with custom title', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={mockMembers} title="Channel Members" />
+      );
+      const output = lastFrame();
+      expect(output).toContain('Channel Members');
+    });
+
+    it('renders empty list', () => {
+      const { lastFrame } = render(<MembersPanel members={[]} />);
+      const output = lastFrame();
+      expect(output).toContain('(0)');
+    });
+  });
+
+  describe('member info display', () => {
+    it('renders string members', () => {
+      const { lastFrame } = render(<MembersPanel members={mockMembers} />);
+      const output = lastFrame();
+      expect(output).toContain('eng-01');
+      expect(output).toContain('tl-01');
+    });
+
+    it('renders members with role info', () => {
+      const { lastFrame } = render(<MembersPanel members={mockMembersWithInfo} />);
+      const output = lastFrame();
+      expect(output).toContain('eng-01');
+      expect(output).toContain('engineer');
+    });
+
+    it('renders members with state info', () => {
+      const { lastFrame } = render(<MembersPanel members={mockMembersWithInfo} />);
+      const output = lastFrame();
+      expect(output).toContain('working');
+    });
+  });
+
+  describe('collapsible behavior', () => {
+    it('renders expanded by default', () => {
+      const { lastFrame } = render(<MembersPanel members={mockMembers} />);
+      const output = lastFrame();
+      expect(output).toContain('eng-01');
+    });
+
+    it('renders collapsed when defaultCollapsed is true', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={mockMembers} defaultCollapsed />
+      );
+      const output = lastFrame();
+      expect(output).toContain('expand');
+    });
+
+    it('shows collapse hint when collapsible', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={mockMembers} collapsible />
+      );
+      const output = lastFrame();
+      expect(output).toContain('collapse');
+    });
+
+    it('hides collapse hint when not collapsible', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={mockMembers} collapsible={false} />
+      );
+      const output = lastFrame();
+      expect(output).not.toContain('Press space');
+    });
+  });
+
+  describe('maxVisible limit', () => {
+    const manyMembers = Array.from({ length: 20 }, (_, i) => `member-${String(i + 1)}`);
+
+    it('limits visible members', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={manyMembers} maxVisible={5} />
+      );
+      const output = lastFrame();
+      expect(output).toContain('member-1');
+      expect(output).toContain('member-5');
+      expect(output).toContain('and 15 more');
+    });
+
+    it('shows all members when under limit', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={mockMembers} maxVisible={10} />
+      );
+      const output = lastFrame();
+      expect(output).not.toContain('more');
+    });
+
+    it('handles exact limit', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={mockMembers} maxVisible={4} />
+      );
+      const output = lastFrame();
+      expect(output).not.toContain('more');
+    });
+  });
+
+  describe('focus state', () => {
+    it('renders without focus', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={mockMembers} focused={false} />
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+
+    it('renders with focus', () => {
+      const { lastFrame } = render(
+        <MembersPanel members={mockMembers} focused />
+      );
+      expect(lastFrame()).toBeDefined();
+    });
+  });
+});
+
+describe('MemberCountBadge', () => {
+  it('renders count', () => {
+    const { lastFrame } = render(<MemberCountBadge count={5} />);
+    const output = lastFrame();
+    expect(output).toContain('[5]');
+  });
+
+  it('renders zero count', () => {
+    const { lastFrame } = render(<MemberCountBadge count={0} />);
+    const output = lastFrame();
+    expect(output).toContain('[0]');
+  });
+
+  it('renders large count', () => {
+    const { lastFrame } = render(<MemberCountBadge count={100} />);
+    const output = lastFrame();
+    expect(output).toContain('[100]');
+  });
+
+  it('renders with custom color', () => {
+    const { lastFrame } = render(<MemberCountBadge count={3} color="green" />);
+    expect(lastFrame()).toBeDefined();
+  });
+
+  it('renders with default color', () => {
+    const { lastFrame } = render(<MemberCountBadge count={3} />);
+    expect(lastFrame()).toBeDefined();
+  });
+});

--- a/tui/src/components/MembersPanel.tsx
+++ b/tui/src/components/MembersPanel.tsx
@@ -1,0 +1,134 @@
+/**
+ * MembersPanel - Display channel members with collapsible view
+ * Issue #847 - Channel member list + description in TUI
+ */
+
+import React, { memo, useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { Panel } from './Panel';
+
+export interface MemberInfo {
+  name: string;
+  role?: string;
+  state?: string;
+}
+
+export interface MembersPanelProps {
+  /** List of members to display */
+  members: MemberInfo[] | string[];
+  /** Panel title */
+  title?: string;
+  /** Whether panel is collapsible */
+  collapsible?: boolean;
+  /** Initial collapsed state */
+  defaultCollapsed?: boolean;
+  /** Maximum members to show before "and X more" */
+  maxVisible?: number;
+  /** Whether this panel has focus */
+  focused?: boolean;
+}
+
+/**
+ * Format member for display
+ */
+function formatMember(member: MemberInfo | string): { name: string; detail?: string } {
+  if (typeof member === 'string') {
+    return { name: member };
+  }
+  const details: string[] = [];
+  if (member.role) details.push(member.role);
+  if (member.state) details.push(member.state);
+  return {
+    name: member.name,
+    detail: details.length > 0 ? details.join(' · ') : undefined,
+  };
+}
+
+/**
+ * MembersPanel component - Displays list of channel members
+ */
+export const MembersPanel = memo(function MembersPanel({
+  members,
+  title = 'Members',
+  collapsible = true,
+  defaultCollapsed = false,
+  maxVisible = 10,
+  focused = false,
+}: MembersPanelProps): React.ReactElement {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
+
+  // Handle keyboard input for collapse toggle
+  useInput(
+    (input) => {
+      if (collapsible && (input === ' ' || input === 'c')) {
+        setCollapsed((prev) => !prev);
+      }
+    },
+    { isActive: focused }
+  );
+
+  const memberCount = members.length;
+  const displayTitle = `${title} (${String(memberCount)})`;
+
+  // Collapsed view
+  if (collapsed) {
+    return (
+      <Panel title={displayTitle} focused={focused}>
+        <Box>
+          <Text dimColor>
+            {collapsible ? 'Press space to expand' : `${String(memberCount)} members`}
+          </Text>
+        </Box>
+      </Panel>
+    );
+  }
+
+  // Calculate visible members
+  const visibleMembers = members.slice(0, maxVisible);
+  const hiddenCount = memberCount - maxVisible;
+
+  return (
+    <Panel title={displayTitle} focused={focused}>
+      <Box flexDirection="column">
+        {visibleMembers.map((member, idx) => {
+          const { name, detail } = formatMember(member);
+          return (
+            <Box key={`${name}-${String(idx)}`}>
+              <Text color="cyan">{name}</Text>
+              {detail && <Text dimColor> ({detail})</Text>}
+            </Box>
+          );
+        })}
+        {hiddenCount > 0 && (
+          <Text dimColor>... and {String(hiddenCount)} more</Text>
+        )}
+        {collapsible && (
+          <Text dimColor italic>
+            {'\n'}Press space to collapse
+          </Text>
+        )}
+      </Box>
+    </Panel>
+  );
+});
+
+/**
+ * Compact member count badge for channel list
+ */
+export interface MemberCountBadgeProps {
+  count: number;
+  color?: string;
+}
+
+export const MemberCountBadge = memo(function MemberCountBadge({
+  count,
+  color = 'gray',
+}: MemberCountBadgeProps): React.ReactElement {
+  return (
+    <Text color={color}>
+      [{String(count)}]
+    </Text>
+  );
+});
+
+export default MembersPanel;

--- a/tui/src/components/index.ts
+++ b/tui/src/components/index.ts
@@ -46,3 +46,7 @@ export type { MentionAutocompleteProps } from './MentionAutocomplete';
 // Activity feed (eng-01 #796)
 export { ActivityFeed } from './ActivityFeed';
 export type { ActivityFeedProps } from './ActivityFeed';
+
+// Members panel (eng-01 #847)
+export { MembersPanel, MemberCountBadge } from './MembersPanel';
+export type { MembersPanelProps, MemberInfo, MemberCountBadgeProps } from './MembersPanel';


### PR DESCRIPTION
## Summary
- Adds MembersPanel component for displaying channel members
- Adds MemberCountBadge for compact member count display
- 21 tests for component functionality

## Components

### MembersPanel
- Displays member list with name, role, state
- Collapsible with keyboard toggle (space/c)
- maxVisible limit with overflow indicator
- Focus state for navigation

### MemberCountBadge
- Compact [count] display
- Configurable color

## Test plan
- [x] `bun run build` passes
- [x] `bun test` - 21 new tests pass
- [x] Component exported from index

Contributes to #847

🤖 Generated with [Claude Code](https://claude.com/claude-code)