### PR TITLE
fix(tui): Use --lines instead of --tail for agent peek (#848)

### DIFF
--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -31,7 +31,7 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
 
   const fetchAgentOutput = useCallback(async () => {
     try {
-      const output = await execBc(['agent', 'peek', agent.name, '--tail', '50']);
+      const output = await execBc(['agent', 'peek', agent.name, '--lines', '50']);
       const lines = output.split('\n').filter(line => line.trim());
       setOutputLines(lines);
       setError(null);


### PR DESCRIPTION
## Summary
Fix P1 bug where TUI agent detail view was using `--tail` flag which doesn't exist for `bc agent peek` command.

## Root Cause
TUI was calling `bc agent peek <name> --tail 50` but the correct flag is `--lines 50`.

## Fix
Changed `--tail` to `--lines` in AgentDetailView.tsx.

## Test plan
- [x] Verified `bc agent peek --help` shows `--lines` flag
- [x] Build passes

Fixes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)