### PR TITLE
fix(tui): Fix agent peek using wrong flag --tail vs --lines (#848)

### DIFF
--- a/tui/src/types/commands.ts
+++ b/tui/src/types/commands.ts
@@ -44,7 +44,7 @@ export const COMMAND_REGISTRY: CommandCategory[] = [
         description: 'Show recent output from agent session',
         usage: 'bc agent peek <agent-name>',
         readOnly: true,
-        flags: ['--tail', '--json'],
+        flags: ['--lines', '--json'],
       },
       {
         name: 'agent send',

--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -31,7 +31,7 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
 
   const fetchAgentOutput = useCallback(async () => {
     try {
-      const output = await execBc(['agent', 'peek', agent.name, '--tail', '50']);
+      const output = await execBc(['agent', 'peek', agent.name, '--lines', '50']);
       const lines = output.split('\n').filter(line => line.trim());
       setOutputLines(lines);
       setError(null);


### PR DESCRIPTION
## Summary

- Fix P1 bug where TUI agent peek fails with "unknown flag: --tail"
- Change `--tail` to `--lines` to match CLI agent peek command

## Problem

When pressing Enter on an agent in TUI to view their session output, the peek feature was broken:
```
Error: unknown flag: --tail
Usage: bc agent peek <agent> [flags]
Flags: --lines int (default 50)
```

## Root Cause

TUI was calling `bc agent peek <name> --tail 50` but the correct flag is `--lines 50`.

## Fix

- `AgentDetailView.tsx`: Change `--tail` to `--lines` in execBc call
- `commands.ts`: Update command documentation to show correct flags

## Test Plan

- [x] Tests pass (21 AgentDetailView tests)
- [x] Verified flag change matches CLI help output

Fixes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)