### PR TITLE
fix(tui): Use correct --lines flag for agent peek (#848)

### DIFF
--- a/tui/src/types/commands.ts
+++ b/tui/src/types/commands.ts
@@ -44,7 +44,7 @@ export const COMMAND_REGISTRY: CommandCategory[] = [
         description: 'Show recent output from agent session',
         usage: 'bc agent peek <agent-name>',
         readOnly: true,
-        flags: ['--tail', '--json'],
+        flags: ['--lines', '--json'],
       },
       {
         name: 'agent send',

--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -31,7 +31,7 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
 
   const fetchAgentOutput = useCallback(async () => {
     try {
-      const output = await execBc(['agent', 'peek', agent.name, '--tail', '50']);
+      const output = await execBc(['agent', 'peek', agent.name, '--lines', '50']);
       const lines = output.split('\n').filter(line => line.trim());
       setOutputLines(lines);
       setError(null);


### PR DESCRIPTION
## Summary
- Fixed P1 bug where TUI agent peek used `--tail` flag instead of correct `--lines` flag
- Updated command registry to document correct flag

## Changes
- `AgentDetailView.tsx`: Changed `--tail` to `--lines` in execBc call
- `types/commands.ts`: Updated flags array from `['--tail', '--json']` to `['--lines', '--json']`

## Test plan
- [x] All existing tests pass (884 tests)
- [x] Verified correct flag with `bc agent peek --help`

Fixes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)