### PR TITLE
fix(tui): Constrain channel message text to prevent overflow (#767)

### DIFF
--- a/tui/src/components/ChatMessage.tsx
+++ b/tui/src/components/ChatMessage.tsx
@@ -121,7 +121,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
           </Box>
 
           {/* Message body with @mentions */}
-          <Box>
+          <Box width="100%" overflow="hidden">
             <MentionText text={message} currentUser={currentUser} />
           </Box>
 


### PR DESCRIPTION
## Summary
- Fixed P1 bug where channel message text fragments were overlapping across lines
- Added proper width and overflow constraints to the message body container

## Root Cause
The message body `<Box>` inside ChatMessage didn't constrain its width, allowing text to potentially overflow and cause terminal rendering artifacts where text fragments merged.

## Fix
Added `width="100%"` and `overflow="hidden"` to the message body Box to ensure text is properly contained within the message bubble.

## Test plan
- [x] All existing tests pass (905 tests)
- [x] No lint errors in ChatMessage.tsx
- [ ] Manual verification in TUI needed

Fixes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)