### PR TITLE
feat(tui): Add Logs tab with filtering and search (#866)

### DIFF
--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -1,0 +1,370 @@
+/**
+ * LogsView - Event logs tab with filtering and search (#866)
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import { useLogs, getSeverityColor } from '../hooks/useLogs';
+import type { LogSeverity } from '../hooks/useLogs';
+import type { LogEntry } from '../types';
+
+interface LogsViewProps {
+  onBack?: () => void;
+}
+
+type TimeFilter = '1h' | '6h' | '24h' | 'all';
+
+/**
+ * Format timestamp for display
+ */
+function formatTime(timestamp: string): string {
+  try {
+    const date = new Date(timestamp);
+    return date.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+    });
+  } catch {
+    return timestamp.slice(0, 8);
+  }
+}
+
+/**
+ * Filter logs by time range
+ */
+function filterByTime(logs: LogEntry[], timeFilter: TimeFilter): LogEntry[] {
+  if (timeFilter === 'all') return logs;
+
+  const now = Date.now();
+  const hours = timeFilter === '1h' ? 1 : timeFilter === '6h' ? 6 : 24;
+  const cutoff = now - hours * 60 * 60 * 1000;
+
+  return logs.filter((log) => {
+    try {
+      return new Date(log.ts).getTime() >= cutoff;
+    } catch {
+      return true;
+    }
+  });
+}
+
+export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
+  const { stdout } = useStdout();
+  const terminalWidth = stdout.columns;
+
+  const { data: logs, loading, error, refresh, filterBySeverity, severityFilter } = useLogs({
+    tail: 100,
+    autoPoll: true,
+    pollInterval: 5000,
+  });
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [showDetail, setShowDetail] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchMode, setSearchMode] = useState(false);
+  const [agentFilter, setAgentFilter] = useState<string | null>(null);
+  const [timeFilter, setTimeFilter] = useState<TimeFilter>('all');
+
+  // Get unique agents for filter
+  const agents = useMemo(() => {
+    if (!logs) return [];
+    const agentSet = new Set(logs.map((log) => log.agent));
+    return Array.from(agentSet).sort();
+  }, [logs]);
+
+  // Apply all filters
+  const filteredLogs = useMemo(() => {
+    if (!logs) return [];
+
+    let result = logs;
+
+    // Time filter
+    result = filterByTime(result, timeFilter);
+
+    // Agent filter
+    if (agentFilter) {
+      result = result.filter((log) => log.agent === agentFilter);
+    }
+
+    // Search filter
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      result = result.filter(
+        (log) =>
+          log.message.toLowerCase().includes(query) ||
+          log.agent.toLowerCase().includes(query) ||
+          log.type.toLowerCase().includes(query)
+      );
+    }
+
+    return result;
+  }, [logs, timeFilter, agentFilter, searchQuery]);
+
+  const selectedLog = filteredLogs[selectedIndex] as LogEntry | undefined;
+
+  // Cycle through severity filters
+  const cycleSeverity = useCallback(() => {
+    const severities: (LogSeverity | null)[] = [null, 'info', 'warn', 'error'];
+    const currentIdx = severities.indexOf(severityFilter);
+    const nextIdx = (currentIdx + 1) % severities.length;
+    filterBySeverity(severities[nextIdx]);
+  }, [severityFilter, filterBySeverity]);
+
+  // Cycle through time filters
+  const cycleTimeFilter = useCallback(() => {
+    const times: TimeFilter[] = ['all', '1h', '6h', '24h'];
+    const currentIdx = times.indexOf(timeFilter);
+    const nextIdx = (currentIdx + 1) % times.length;
+    setTimeFilter(times[nextIdx]);
+    setSelectedIndex(0);
+  }, [timeFilter]);
+
+  // Cycle through agent filters
+  const cycleAgentFilter = useCallback(() => {
+    if (agents.length === 0) return;
+    if (agentFilter === null) {
+      setAgentFilter(agents[0]);
+    } else {
+      const currentIdx = agents.indexOf(agentFilter);
+      if (currentIdx === agents.length - 1) {
+        setAgentFilter(null);
+      } else {
+        setAgentFilter(agents[currentIdx + 1]);
+      }
+    }
+    setSelectedIndex(0);
+  }, [agentFilter, agents]);
+
+  // Keyboard navigation
+  useInput((input, key) => {
+    if (searchMode) {
+      // Search mode input
+      if (key.return || key.escape) {
+        setSearchMode(false);
+      } else if (key.backspace || key.delete) {
+        setSearchQuery(searchQuery.slice(0, -1));
+      } else if (input && !key.ctrl && !key.meta) {
+        setSearchQuery(searchQuery + input);
+      }
+      return;
+    }
+
+    if (showDetail) {
+      // Detail view - any key returns to list
+      if (key.escape || input === 'q' || key.return) {
+        setShowDetail(false);
+      }
+      return;
+    }
+
+    // List view navigation
+    if (key.upArrow || input === 'k') {
+      setSelectedIndex((i) => Math.max(0, i - 1));
+    } else if (key.downArrow || input === 'j') {
+      setSelectedIndex((i) => Math.min(filteredLogs.length - 1, i + 1));
+    } else if (input === 'g') {
+      setSelectedIndex(0);
+    } else if (input === 'G') {
+      setSelectedIndex(Math.max(0, filteredLogs.length - 1));
+    } else if (key.return) {
+      if (selectedLog) {
+        setShowDetail(true);
+      }
+    } else if (input === '/') {
+      setSearchMode(true);
+    } else if (input === 's') {
+      cycleSeverity();
+    } else if (input === 'a') {
+      cycleAgentFilter();
+    } else if (input === 't') {
+      cycleTimeFilter();
+    } else if (input === 'c') {
+      // Clear all filters
+      setSearchQuery('');
+      setAgentFilter(null);
+      setTimeFilter('all');
+      filterBySeverity(null);
+      setSelectedIndex(0);
+    } else if (input === 'r') {
+      void refresh();
+    } else if (input === 'q' || key.escape) {
+      onBack?.();
+    }
+  });
+
+  // Show detail view
+  if (showDetail && selectedLog) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text bold color="cyan">Log Details</Text>
+        <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor="gray" padding={1}>
+          <Box>
+            <Text bold>Timestamp: </Text>
+            <Text>{selectedLog.timestamp}</Text>
+          </Box>
+          <Box>
+            <Text bold>Agent: </Text>
+            <Text color="cyan">{selectedLog.agent}</Text>
+          </Box>
+          <Box>
+            <Text bold>Type: </Text>
+            <Text color={getSeverityColor(selectedLog.type)}>{selectedLog.type}</Text>
+          </Box>
+          <Box marginTop={1} flexDirection="column">
+            <Text bold>Message:</Text>
+            <Box paddingLeft={2} marginTop={1}>
+              <Text wrap="wrap">{selectedLog.message}</Text>
+            </Box>
+          </Box>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Press any key to return</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // Search mode overlay
+  if (searchMode) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text bold>Search Logs</Text>
+        <Box marginTop={1} borderStyle="single" borderColor="cyan" paddingX={1}>
+          <Text color="cyan">{'> '}</Text>
+          <Text>{searchQuery}</Text>
+          <Text color="cyan">|</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Enter to confirm, Esc to cancel</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (loading && !logs) {
+    return (
+      <Box padding={1}>
+        <Text color="yellow">Loading logs...</Text>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box padding={1}>
+        <Text color="red">Error: {error}</Text>
+      </Box>
+    );
+  }
+
+  // Calculate column widths based on terminal width
+  const timeWidth = 10;
+  const agentWidth = Math.min(12, Math.floor((terminalWidth - 40) * 0.2));
+  const typeWidth = 10;
+  const messageWidth = terminalWidth - timeWidth - agentWidth - typeWidth - 10;
+
+  // Visible rows (account for header, filters, footer)
+  const visibleRows = 12;
+  const startIdx = Math.max(0, selectedIndex - Math.floor(visibleRows / 2));
+  const visibleLogs = filteredLogs.slice(startIdx, startIdx + visibleRows);
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Box marginBottom={1}>
+        <Text bold color="magenta">Logs</Text>
+        <Text dimColor> ({filteredLogs.length} entries)</Text>
+        {loading && <Text color="gray"> (refreshing...)</Text>}
+      </Box>
+
+      {/* Filters */}
+      <Box marginBottom={1}>
+        <Text dimColor>Filters: </Text>
+        <Text color={severityFilter ? 'cyan' : 'gray'}>
+          [s] {severityFilter ?? 'All'}
+        </Text>
+        <Text> </Text>
+        <Text color={agentFilter ? 'cyan' : 'gray'}>
+          [a] {agentFilter ?? 'All agents'}
+        </Text>
+        <Text> </Text>
+        <Text color={timeFilter !== 'all' ? 'cyan' : 'gray'}>
+          [t] {timeFilter === 'all' ? 'All time' : `Last ${timeFilter}`}
+        </Text>
+        {searchQuery && (
+          <>
+            <Text> </Text>
+            <Text color="cyan">[/] &quot;{searchQuery}&quot;</Text>
+          </>
+        )}
+      </Box>
+
+      {/* Log table */}
+      <Box flexDirection="column" borderStyle="single" borderColor="gray">
+        {/* Table header */}
+        <Box>
+          <Text bold color="gray">
+            {'TIME'.padEnd(timeWidth)}
+            {'AGENT'.padEnd(agentWidth)}
+            {'TYPE'.padEnd(typeWidth)}
+            {'MESSAGE'}
+          </Text>
+        </Box>
+
+        {/* Table rows */}
+        {visibleLogs.map((log, idx) => {
+          const actualIdx = startIdx + idx;
+          const isSelected = actualIdx === selectedIndex;
+          const severityColor = getSeverityColor(log.type);
+
+          return (
+            <Box key={`${log.ts}-${String(idx)}`}>
+              <Text
+                backgroundColor={isSelected ? 'blue' : undefined}
+                color={isSelected ? 'white' : undefined}
+              >
+                {formatTime(log.ts).padEnd(timeWidth)}
+              </Text>
+              <Text
+                backgroundColor={isSelected ? 'blue' : undefined}
+                color={isSelected ? 'white' : 'cyan'}
+              >
+                {log.agent.slice(0, agentWidth - 1).padEnd(agentWidth)}
+              </Text>
+              <Text
+                backgroundColor={isSelected ? 'blue' : undefined}
+                color={isSelected ? 'white' : severityColor}
+              >
+                {log.type.slice(0, typeWidth - 1).padEnd(typeWidth)}
+              </Text>
+              <Text
+                backgroundColor={isSelected ? 'blue' : undefined}
+                color={isSelected ? 'white' : undefined}
+                wrap="truncate"
+              >
+                {log.message.slice(0, messageWidth)}
+              </Text>
+            </Box>
+          );
+        })}
+
+        {filteredLogs.length === 0 && (
+          <Box padding={1}>
+            <Text dimColor>No logs match filters</Text>
+          </Box>
+        )}
+      </Box>
+
+      {/* Footer */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          j/k: nav | Enter: details | /: search | s: severity | a: agent | t: time | c: clear | r: refresh | q: back
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default LogsView;


### PR DESCRIPTION
## Summary
New LogsView component for dedicated event log viewing and analysis.

## Features
- **Real-time polling**: 5-second refresh interval
- **Severity filter**: Cycle through info/warn/error with `s`
- **Agent filter**: Filter by specific agent with `a`
- **Time filter**: 1h/6h/24h/all time ranges with `t`
- **Search**: Full-text search with `/`
- **Log details**: View full message with Enter
- **Color coding**: Errors red, warnings yellow, info gray

## Layout
```
Logs (245 entries)

Filters: [s] error  [a] eng-01  [t] Last 1h  [/] "auth"
┌──────────────────────────────────────────────────────────────────┐
│ TIME        AGENT      TYPE      MESSAGE                        │
├──────────────────────────────────────────────────────────────────┤
│ 12:34:56    eng-01     error     Build failed: missing dep      │
│ 12:34:45    mgr-01     report    working: Sprint planning       │
└──────────────────────────────────────────────────────────────────┘

j/k: nav | Enter: details | /: search | s: severity | a: agent | t: time | c: clear
```

## Test plan
- [x] All tests pass (1048)
- [x] No lint errors
- [ ] Manual verification needed

Fixes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)