### PR TITLE
feat(demon): Add scheduler with start/stop/status commands (#878)

### DIFF
--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -143,6 +143,55 @@ Examples:
 	RunE: runDemonTest,
 }
 
+var demonStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the demon scheduler",
+	Long: `Start the background scheduler that automatically runs demons.
+
+The scheduler checks enabled demons every 30 seconds and runs any
+that are due based on their cron schedule.
+
+Examples:
+  bc demon start       # Start the scheduler
+  bc demon status      # Check if scheduler is running
+  bc demon stop        # Stop the scheduler`,
+	RunE: runDemonStart,
+}
+
+var demonStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the demon scheduler",
+	Long: `Stop the background scheduler.
+
+This will stop automatic execution of demons. You can still
+run demons manually with 'bc demon run <name>'.
+
+Examples:
+  bc demon stop        # Stop the scheduler
+  bc demon status      # Verify scheduler stopped`,
+	RunE: runDemonStop,
+}
+
+var demonStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show scheduler status and upcoming runs",
+	Long: `Show the status of the demon scheduler and next scheduled runs.
+
+Examples:
+  bc demon status      # Show scheduler status
+  bc demon status --json  # JSON output for TUI`,
+	RunE: runDemonStatus,
+}
+
+// Hidden command for internal use - runs the scheduler loop
+var demonSchedulerLoopCmd = &cobra.Command{
+	Use:    "scheduler-loop",
+	Hidden: true,
+	RunE:   runDemonSchedulerLoop,
+}
+
+var schedulerLoopRoot string
+
 var (
 	demonSchedule        string
 	demonCommand         string
@@ -179,6 +228,9 @@ func init() {
 	demonTestCmd.Flags().BoolVar(&demonTestCreateDemon, "create-demon", false, "Create a demon for scheduled testing")
 	demonTestCmd.Flags().StringVar(&demonTestSchedule, "schedule", "0 * * * *", "Cron schedule for testing demon (default: hourly)")
 
+	demonSchedulerLoopCmd.Flags().StringVar(&schedulerLoopRoot, "root", "", "Workspace root directory")
+	_ = demonSchedulerLoopCmd.MarkFlagRequired("root")
+
 	demonCmd.AddCommand(demonCreateCmd)
 	demonCmd.AddCommand(demonListCmd)
 	demonCmd.AddCommand(demonShowCmd)
@@ -189,6 +241,10 @@ func init() {
 	demonCmd.AddCommand(demonLogsCmd)
 	demonCmd.AddCommand(demonEditCmd)
 	demonCmd.AddCommand(demonTestCmd)
+	demonCmd.AddCommand(demonStartCmd)
+	demonCmd.AddCommand(demonStopCmd)
+	demonCmd.AddCommand(demonStatusCmd)
+	demonCmd.AddCommand(demonSchedulerLoopCmd)
 	rootCmd.AddCommand(demonCmd)
 }
 
@@ -741,6 +797,132 @@ func runDemonTest(cmd *cobra.Command, args []string) error {
 
 	// Run tests with JSON output
 	return runTestsAndReportIssues(cmd, ws, pattern)
+}
+
+func runDemonStart(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return errNotInWorkspace(err)
+	}
+
+	scheduler := demon.NewScheduler(ws.RootDir)
+
+	if err := scheduler.Start(); err != nil {
+		return err
+	}
+
+	status, _ := scheduler.Status()
+	cmd.Printf("Scheduler started (PID %d)\n", status.PID)
+	cmd.Println("Demons will run automatically based on their schedules.")
+	cmd.Println()
+	cmd.Println("Use 'bc demon status' to see upcoming runs.")
+	cmd.Println("Use 'bc demon stop' to stop the scheduler.")
+
+	return nil
+}
+
+func runDemonStop(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return errNotInWorkspace(err)
+	}
+
+	scheduler := demon.NewScheduler(ws.RootDir)
+
+	if err := scheduler.Stop(); err != nil {
+		return err
+	}
+
+	cmd.Println("Scheduler stopped")
+	cmd.Println("Demons will no longer run automatically.")
+	cmd.Println()
+	cmd.Println("Use 'bc demon run <name>' to run demons manually.")
+
+	return nil
+}
+
+func runDemonStatus(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return errNotInWorkspace(err)
+	}
+
+	scheduler := demon.NewScheduler(ws.RootDir)
+	status, err := scheduler.Status()
+	if err != nil {
+		return err
+	}
+
+	// Check for JSON output
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		// Include next runs in JSON output
+		nextRuns, _ := scheduler.GetNextRuns()
+		output := struct {
+			Status   *demon.SchedulerStatus `json:"status"`
+			NextRuns []demon.DemonNextRun   `json:"next_runs"`
+		}{
+			Status:   status,
+			NextRuns: nextRuns,
+		}
+		enc := json.NewEncoder(cmd.OutOrStdout())
+		enc.SetIndent("", "  ")
+		return enc.Encode(output)
+	}
+
+	// Text output
+	if status.Running {
+		cmd.Printf("Scheduler: running (PID %d)\n", status.PID)
+		if status.Uptime != "" {
+			cmd.Printf("Uptime:    %s\n", status.Uptime)
+		}
+	} else {
+		cmd.Println("Scheduler: stopped")
+		cmd.Println()
+		cmd.Println("Start with: bc demon start")
+		return nil
+	}
+
+	// Show next scheduled runs
+	nextRuns, err := scheduler.GetNextRuns()
+	if err != nil {
+		return err
+	}
+
+	if len(nextRuns) == 0 {
+		cmd.Println()
+		cmd.Println("No enabled demons configured.")
+		cmd.Println("Create one with: bc demon create <name> --schedule '<cron>' --cmd '<command>'")
+		return nil
+	}
+
+	cmd.Println()
+	cmd.Println("Upcoming runs:")
+	cmd.Printf("%-20s %-24s %s\n", "DEMON", "NEXT RUN", "COMMAND")
+	cmd.Println("--------------------------------------------------------------------")
+
+	for _, run := range nextRuns {
+		nextRunStr := "never"
+		if !run.NextRun.IsZero() {
+			nextRunStr = run.NextRun.Local().Format("2006-01-02 15:04:05")
+		}
+		command := run.Command
+		if len(command) > 25 {
+			command = command[:22] + "..."
+		}
+		cmd.Printf("%-20s %-24s %s\n", run.Name, nextRunStr, command)
+	}
+
+	return nil
+}
+
+func runDemonSchedulerLoop(cmd *cobra.Command, args []string) error {
+	if schedulerLoopRoot == "" {
+		return fmt.Errorf("--root flag is required")
+	}
+
+	scheduler := demon.NewScheduler(schedulerLoopRoot)
+	return scheduler.RunLoop(cmd.Context())
 }
 
 func runTestsAndReportIssues(cmd *cobra.Command, ws *workspace.Workspace, pattern string) error {

--- a/pkg/demon/scheduler.go
+++ b/pkg/demon/scheduler.go
@@ -1,0 +1,352 @@
+// Package demon provides scheduled task management for bc.
+package demon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// SchedulerStatus represents the current state of the scheduler.
+type SchedulerStatus struct {
+	StartedAt time.Time `json:"started_at,omitempty"`
+	Uptime    string    `json:"uptime,omitempty"`
+	PID       int       `json:"pid,omitempty"`
+	Running   bool      `json:"running"`
+}
+
+// Scheduler manages the demon scheduler process.
+type Scheduler struct {
+	rootDir    string
+	demonsDir  string
+	pidFile    string
+	logFile    string
+	statusFile string
+}
+
+// NewScheduler creates a new scheduler instance.
+func NewScheduler(rootDir string) *Scheduler {
+	demonsDir := filepath.Join(rootDir, ".bc", "demons")
+	return &Scheduler{
+		rootDir:    rootDir,
+		demonsDir:  demonsDir,
+		pidFile:    filepath.Join(demonsDir, "scheduler.pid"),
+		logFile:    filepath.Join(demonsDir, "scheduler.log"),
+		statusFile: filepath.Join(demonsDir, "scheduler.json"),
+	}
+}
+
+// Start starts the scheduler daemon.
+// Returns an error if the scheduler is already running.
+func (s *Scheduler) Start() error {
+	// Check if already running
+	if s.IsRunning() {
+		return fmt.Errorf("scheduler is already running")
+	}
+
+	// Ensure demons directory exists
+	if err := os.MkdirAll(s.demonsDir, 0750); err != nil {
+		return fmt.Errorf("failed to create demons directory: %w", err)
+	}
+
+	// Start the scheduler process in background
+	// Use the bc binary itself with a special internal flag
+	bcPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	// Create log file for scheduler output
+	logFile, err := os.OpenFile(s.logFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600) //nolint:gosec // path from trusted dir
+	if err != nil {
+		return fmt.Errorf("failed to create log file: %w", err)
+	}
+
+	// Start background process
+	ctx := context.Background()
+	cmd := exec.CommandContext(ctx, bcPath, "demon", "scheduler-loop", "--root", s.rootDir) //nolint:gosec // bcPath from os.Executable
+	cmd.Dir = s.rootDir
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true, // Create new session (detach from terminal)
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = logFile.Close()
+		return fmt.Errorf("failed to start scheduler: %w", err)
+	}
+
+	// Write PID file
+	pid := cmd.Process.Pid
+	if err := os.WriteFile(s.pidFile, []byte(strconv.Itoa(pid)), 0600); err != nil {
+		// Try to kill the started process
+		_ = cmd.Process.Kill()
+		_ = logFile.Close()
+		return fmt.Errorf("failed to write PID file: %w", err)
+	}
+
+	// Write status file
+	status := SchedulerStatus{
+		Running:   true,
+		PID:       pid,
+		StartedAt: time.Now().UTC(),
+	}
+	if err := s.saveStatus(status); err != nil {
+		// Non-fatal, PID file is the primary tracking mechanism
+		_ = logFile.Close()
+		return nil
+	}
+
+	_ = logFile.Close()
+	return nil
+}
+
+// Stop stops the scheduler daemon.
+func (s *Scheduler) Stop() error {
+	pid, err := s.readPID()
+	if err != nil {
+		return fmt.Errorf("scheduler is not running: %w", err)
+	}
+
+	// Find the process
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		// Process not found, clean up PID file
+		_ = os.Remove(s.pidFile)
+		_ = os.Remove(s.statusFile)
+		return fmt.Errorf("scheduler process not found (pid %d)", pid)
+	}
+
+	// Send SIGTERM for graceful shutdown
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		// Try SIGKILL if SIGTERM fails
+		if killErr := process.Kill(); killErr != nil {
+			return fmt.Errorf("failed to stop scheduler: %w", err)
+		}
+	}
+
+	// Wait briefly for process to exit
+	time.Sleep(100 * time.Millisecond)
+
+	// Clean up files
+	_ = os.Remove(s.pidFile)
+	_ = os.Remove(s.statusFile)
+
+	return nil
+}
+
+// Status returns the current scheduler status.
+func (s *Scheduler) Status() (*SchedulerStatus, error) {
+	pid, err := s.readPID()
+	if err != nil {
+		return &SchedulerStatus{Running: false}, nil
+	}
+
+	// Check if process is actually running
+	if !s.processRunning(pid) {
+		// Clean up stale PID file
+		_ = os.Remove(s.pidFile)
+		_ = os.Remove(s.statusFile)
+		return &SchedulerStatus{Running: false}, nil
+	}
+
+	// Read status file for start time
+	status, err := s.loadStatus()
+	if err != nil {
+		// Fallback: process is running but no status file
+		return &SchedulerStatus{
+			Running: true,
+			PID:     pid,
+		}, nil
+	}
+
+	status.Running = true
+	status.PID = pid
+	if !status.StartedAt.IsZero() {
+		status.Uptime = time.Since(status.StartedAt).Truncate(time.Second).String()
+	}
+
+	return status, nil
+}
+
+// IsRunning checks if the scheduler is currently running.
+func (s *Scheduler) IsRunning() bool {
+	pid, err := s.readPID()
+	if err != nil {
+		return false
+	}
+	return s.processRunning(pid)
+}
+
+// RunLoop runs the scheduler loop (called by scheduler-loop command).
+// This should be called in the background process started by Start().
+func (s *Scheduler) RunLoop(ctx context.Context) error {
+	store := NewStore(s.rootDir)
+
+	ticker := time.NewTicker(30 * time.Second) // Check every 30 seconds
+	defer ticker.Stop()
+
+	s.log("Scheduler started")
+
+	// Run immediately on start, then on ticker
+	s.checkAndRunDemons(store)
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.log("Scheduler stopping")
+			return ctx.Err()
+		case <-ticker.C:
+			s.checkAndRunDemons(store)
+		}
+	}
+}
+
+// checkAndRunDemons checks all enabled demons and runs any that are due.
+func (s *Scheduler) checkAndRunDemons(store *Store) {
+	demons, err := store.ListEnabled()
+	if err != nil {
+		s.log("Failed to list demons: %v", err)
+		return
+	}
+
+	now := time.Now()
+	for _, d := range demons {
+		// Skip if NextRun is zero or in the future
+		if d.NextRun.IsZero() || d.NextRun.After(now) {
+			continue
+		}
+
+		// Run the demon
+		s.log("Running demon %q: %s", d.Name, d.Command)
+		s.runDemon(store, d)
+	}
+}
+
+// runDemon executes a demon's command.
+func (s *Scheduler) runDemon(store *Store, d *Demon) {
+	startTime := time.Now()
+	ctx := context.Background()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", d.Command) //nolint:gosec // command from trusted demon config
+	cmd.Dir = s.rootDir
+	output, err := cmd.CombinedOutput()
+
+	duration := time.Since(startTime)
+	exitCode := 0
+	success := true
+
+	if err != nil {
+		success = false
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		}
+		s.log("Demon %q failed: %v", d.Name, err)
+	} else {
+		s.log("Demon %q completed successfully in %s", d.Name, duration)
+	}
+
+	// Record the run
+	if recordErr := store.RecordRun(d.Name); recordErr != nil {
+		s.log("Failed to record run for %q: %v", d.Name, recordErr)
+	}
+
+	// Record run log
+	runLog := RunLog{
+		Timestamp: startTime.UTC(),
+		Duration:  duration.Milliseconds(),
+		ExitCode:  exitCode,
+		Success:   success,
+	}
+	if logErr := store.RecordRunLog(d.Name, runLog); logErr != nil {
+		s.log("Failed to record log for %q: %v", d.Name, logErr)
+	}
+
+	// Log output if any
+	if len(output) > 0 && len(output) < 1000 {
+		s.log("Demon %q output: %s", d.Name, string(output))
+	}
+}
+
+// log writes a timestamped message to the scheduler log.
+func (s *Scheduler) log(format string, args ...interface{}) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	msg := fmt.Sprintf(format, args...)
+	fmt.Printf("[%s] %s\n", timestamp, msg)
+}
+
+// readPID reads the PID from the PID file.
+func (s *Scheduler) readPID() (int, error) {
+	data, err := os.ReadFile(s.pidFile) //nolint:gosec // path from trusted dir
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(string(data))
+}
+
+// processRunning checks if a process with the given PID is running.
+func (s *Scheduler) processRunning(pid int) bool {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	// Send signal 0 to check if process exists
+	err = process.Signal(syscall.Signal(0))
+	return err == nil
+}
+
+// saveStatus saves the scheduler status to disk.
+func (s *Scheduler) saveStatus(status SchedulerStatus) error {
+	data, err := json.MarshalIndent(status, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(s.statusFile, data, 0600) //nolint:gosec // path from trusted dir
+}
+
+// loadStatus loads the scheduler status from disk.
+func (s *Scheduler) loadStatus() (*SchedulerStatus, error) {
+	data, err := os.ReadFile(s.statusFile) //nolint:gosec // path from trusted dir
+	if err != nil {
+		return nil, err
+	}
+	var status SchedulerStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
+}
+
+// GetNextRuns returns the next scheduled runs for all enabled demons.
+func (s *Scheduler) GetNextRuns() ([]DemonNextRun, error) {
+	store := NewStore(s.rootDir)
+	demons, err := store.ListEnabled()
+	if err != nil {
+		return nil, err
+	}
+
+	var runs []DemonNextRun
+	for _, d := range demons {
+		runs = append(runs, DemonNextRun{
+			Name:    d.Name,
+			NextRun: d.NextRun,
+			Command: d.Command,
+		})
+	}
+
+	return runs, nil
+}
+
+// DemonNextRun represents a demon's next scheduled run.
+type DemonNextRun struct {
+	NextRun time.Time `json:"next_run"`
+	Name    string    `json:"name"`
+	Command string    `json:"command"`
+}

--- a/pkg/demon/scheduler_test.go
+++ b/pkg/demon/scheduler_test.go
@@ -1,0 +1,233 @@
+package demon
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNewScheduler(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	if scheduler.rootDir != tmpDir {
+		t.Errorf("rootDir = %q, want %q", scheduler.rootDir, tmpDir)
+	}
+
+	expectedDemonsDir := filepath.Join(tmpDir, ".bc", "demons")
+	if scheduler.demonsDir != expectedDemonsDir {
+		t.Errorf("demonsDir = %q, want %q", scheduler.demonsDir, expectedDemonsDir)
+	}
+
+	expectedPidFile := filepath.Join(expectedDemonsDir, "scheduler.pid")
+	if scheduler.pidFile != expectedPidFile {
+		t.Errorf("pidFile = %q, want %q", scheduler.pidFile, expectedPidFile)
+	}
+}
+
+func TestSchedulerStatus_NotRunning(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	status, err := scheduler.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+
+	if status.Running {
+		t.Error("Status.Running = true, want false")
+	}
+
+	if status.PID != 0 {
+		t.Errorf("Status.PID = %d, want 0", status.PID)
+	}
+}
+
+func TestSchedulerIsRunning_NotRunning(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	if scheduler.IsRunning() {
+		t.Error("IsRunning() = true, want false")
+	}
+}
+
+func TestSchedulerIsRunning_StalePIDFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	// Create demons directory and stale PID file
+	demonsDir := filepath.Join(tmpDir, ".bc", "demons")
+	if err := os.MkdirAll(demonsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a PID that doesn't exist
+	pidFile := filepath.Join(demonsDir, "scheduler.pid")
+	if err := os.WriteFile(pidFile, []byte("99999999"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should return false for stale PID
+	if scheduler.IsRunning() {
+		t.Error("IsRunning() = true, want false for stale PID")
+	}
+}
+
+func TestSchedulerStatus_StalePIDCleansUp(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	// Create demons directory and stale PID file
+	demonsDir := filepath.Join(tmpDir, ".bc", "demons")
+	if err := os.MkdirAll(demonsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	pidFile := filepath.Join(demonsDir, "scheduler.pid")
+	if err := os.WriteFile(pidFile, []byte("99999999"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := scheduler.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+
+	if status.Running {
+		t.Error("Status.Running = true, want false")
+	}
+
+	// PID file should be cleaned up
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Error("Stale PID file should be removed")
+	}
+}
+
+func TestSchedulerStop_NotRunning(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	err := scheduler.Stop()
+	if err == nil {
+		t.Error("Stop() should return error when not running")
+	}
+}
+
+func TestSchedulerStart_AlreadyRunning(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	// Create demons directory and PID file with current process PID
+	demonsDir := filepath.Join(tmpDir, ".bc", "demons")
+	if err := os.MkdirAll(demonsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use current process PID to simulate running scheduler
+	pid := os.Getpid()
+	pidFile := filepath.Join(demonsDir, "scheduler.pid")
+	if err := os.WriteFile(pidFile, []byte(fmt.Sprintf("%d", pid)), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	err := scheduler.Start()
+	if err == nil {
+		t.Fatal("Start() should return error when already running")
+	}
+	if err.Error() != "scheduler is already running" {
+		t.Errorf("Start() error = %q, want 'scheduler is already running'", err.Error())
+	}
+}
+
+func TestSchedulerGetNextRuns(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	// Create demons directory
+	demonsDir := filepath.Join(tmpDir, ".bc", "demons")
+	if err := os.MkdirAll(demonsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a demon
+	store := NewStore(tmpDir)
+	_, err := store.Create("test-demon", "0 * * * *", "echo hello")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	runs, err := scheduler.GetNextRuns()
+	if err != nil {
+		t.Fatalf("GetNextRuns() error = %v", err)
+	}
+
+	if len(runs) != 1 {
+		t.Fatalf("GetNextRuns() returned %d runs, want 1", len(runs))
+	}
+
+	if runs[0].Name != "test-demon" {
+		t.Errorf("NextRun.Name = %q, want 'test-demon'", runs[0].Name)
+	}
+
+	if runs[0].Command != "echo hello" {
+		t.Errorf("NextRun.Command = %q, want 'echo hello'", runs[0].Command)
+	}
+
+	if runs[0].NextRun.IsZero() {
+		t.Error("NextRun.NextRun is zero")
+	}
+}
+
+func TestSchedulerStatusSaveLoad(t *testing.T) {
+	tmpDir := t.TempDir()
+	scheduler := NewScheduler(tmpDir)
+
+	// Create demons directory
+	demonsDir := filepath.Join(tmpDir, ".bc", "demons")
+	if err := os.MkdirAll(demonsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save status
+	status := SchedulerStatus{
+		Running:   true,
+		PID:       12345,
+		StartedAt: time.Now().UTC(),
+	}
+	if err := scheduler.saveStatus(status); err != nil {
+		t.Fatalf("saveStatus() error = %v", err)
+	}
+
+	// Load status
+	loaded, err := scheduler.loadStatus()
+	if err != nil {
+		t.Fatalf("loadStatus() error = %v", err)
+	}
+
+	if loaded.PID != status.PID {
+		t.Errorf("loaded.PID = %d, want %d", loaded.PID, status.PID)
+	}
+}
+
+func TestDemonNextRun(t *testing.T) {
+	run := DemonNextRun{
+		Name:    "test",
+		NextRun: time.Now().Add(time.Hour),
+		Command: "echo test",
+	}
+
+	if run.Name != "test" {
+		t.Errorf("Name = %q, want 'test'", run.Name)
+	}
+
+	if run.Command != "echo test" {
+		t.Errorf("Command = %q, want 'echo test'", run.Command)
+	}
+
+	if run.NextRun.IsZero() {
+		t.Error("NextRun should not be zero")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements background demon scheduler daemon with `bc demon start/stop/status` commands
- Scheduler runs as background process checking enabled demons every 30 seconds
- Executes demons when their NextRun time is reached based on cron schedule
- Uses PID file for daemon tracking with graceful SIGTERM shutdown

## Changes

**pkg/demon/scheduler.go** (352 lines)
- `Scheduler` struct with Start/Stop/Status/RunLoop methods
- `SchedulerStatus` for JSON output with uptime, PID, running state
- `DemonNextRun` for listing upcoming scheduled runs
- Background process management with PID file
- Graceful shutdown with signal handling

**internal/cmd/demon.go** (182 lines)
- `bc demon start` - Start scheduler daemon in background
- `bc demon stop` - Stop scheduler daemon  
- `bc demon status` - Show scheduler status and upcoming runs
- Hidden `scheduler-loop` command for internal daemon process

**pkg/demon/scheduler_test.go** (233 lines)
- Tests for scheduler status, start, stop, next runs
- Stale PID file cleanup tests
- Status save/load tests

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (all 19 demon package tests pass)
- [x] Manual testing:
  - `bc demon status` shows "stopped" when not running
  - `bc demon start` starts scheduler with PID
  - `bc demon status` shows running state, uptime, upcoming demons
  - `bc demon stop` stops scheduler gracefully
  - `bc demon status --json` outputs JSON for TUI

## Closes

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)