### PR TITLE
fix(tui): Fix LogsView using wrong property name (timestamp -> ts)

### DIFF
--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -202,7 +202,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
         <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor="gray" padding={1}>
           <Box>
             <Text bold>Timestamp: </Text>
-            <Text>{selectedLog.timestamp}</Text>
+            <Text>{selectedLog.ts}</Text>
           </Box>
           <Box>
             <Text bold>Agent: </Text>


### PR DESCRIPTION
## Summary
Fix TypeScript compilation error in LogsView.tsx where `selectedLog.timestamp` was referenced but `LogEntry` type uses `ts` field.

## Bug
- LogEntry type defines `ts: string` for timestamp
- LogsView.tsx line 205 used `selectedLog.timestamp` (doesn't exist)
- Caused build failure

## Fix
Changed `selectedLog.timestamp` to `selectedLog.ts`

## Test plan
- [x] TypeScript compiles successfully
- [x] All 1072 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)