### PR TITLE
fix(tui): Restore channel message body display (#887)

### DIFF
--- a/tui/src/components/ChatMessage.tsx
+++ b/tui/src/components/ChatMessage.tsx
@@ -121,8 +121,10 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
           </Box>
 
           {/* Message body with @mentions */}
-          <Box width="100%" overflow="hidden">
-            <MentionText text={message} currentUser={currentUser} />
+          <Box width="100%">
+            <Text wrap="wrap">
+              <MentionText text={message} currentUser={currentUser} />
+            </Text>
           </Box>
 
           {/* Reactions */}


### PR DESCRIPTION
## Summary
P0 BLOCKER fix - Channel message bodies were not displaying.

## Root Cause
The `overflow="hidden"` property on the message body Box was causing
height collapse, making the message content invisible.

## Fix
Replaced `overflow="hidden"` with proper `Text wrap="wrap"` to maintain
content visibility while keeping text properly contained.

## Test plan
- [x] All tests pass (1107)
- [x] No lint errors
- [ ] Manual verification - message bodies should now display

Fixes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)