### PR TITLE
fix(tui): ESC from channel history returns to list, not Dashboard (#884)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -106,7 +106,13 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
   }
 
   if (viewMode === 'history' && selectedChannel) {
-    return <ChannelHistoryView channel={selectedChannel} disableInput={disableInput} />;
+    return (
+      <ChannelHistoryView
+        channel={selectedChannel}
+        disableInput={disableInput}
+        onBack={() => { setViewMode('list'); }}
+      />
+    );
   }
 
   return (
@@ -159,11 +165,13 @@ function ChannelRow({ channel, selected, unreadCount }: ChannelRowProps): React.
 interface ChannelHistoryViewProps {
   channel: Channel;
   disableInput?: boolean;
+  onBack?: () => void;
 }
 
 function ChannelHistoryView({
   channel,
   disableInput = false,
+  onBack,
 }: ChannelHistoryViewProps): React.ReactElement {
   const { data: messages, loading, error, send } = useChannelHistory(channel.name, {
     limit: 50,
@@ -205,22 +213,23 @@ function ChannelHistoryView({
    * When user enters input mode (presses 'm'), we set focus to 'input' area.
    * This prevents global keybinds (q, 1-9, ESC) from triggering during message typing.
    *
-   * When user exits input mode (presses Enter or Escape), we restore focus to the
-   * previous area, which re-enables global navigation keybinds.
-   *
-   * The useKeyboardNavigation hook checks isFocused('input') before handling global
-   * keybinds, so focus state acts as the guard that disables/enables them.
+   * When user exits input mode (presses Enter or Escape), we set focus to 'channel-history'
+   * to keep global navigation disabled while in channel history view. This ensures that
+   * ESC navigates back to channel list (via onBack) rather than to Dashboard.
    *
    * This fixes issue #653: "After typing a message in a channel, the keybinds to
    * q, 1,2,3... are not re-enabled"
+   * This also fixes issue #884: "ESC from channel history goes to Dashboard instead
+   * of Channels list"
    */
   useEffect(() => {
     if (inputMode) {
       setFocus('input');
     } else {
-      returnFocus();
+      // Keep focus on channel-history to prevent global ESC from going to Dashboard
+      setFocus('channel-history');
     }
-  }, [inputMode, setFocus, returnFocus]);
+  }, [inputMode, setFocus]);
 
   useInput(
     (input, key) => {
@@ -244,6 +253,11 @@ function ChannelHistoryView({
           setMessageBuffer(messageBuffer + input);
         }
       } else {
+        // ESC to go back to channel list
+        if (key.escape) {
+          returnFocus(); // Restore focus before navigating back
+          onBack?.();
+        }
         // 'm' to compose message
         if (input === 'm') {
           setInputMode(true);


### PR DESCRIPTION
## Summary

- Fixes ESC navigation in ChannelHistoryView to return to Channels list instead of Dashboard
- Adds `onBack` callback prop for proper parent-child navigation control
- Uses focus management to prevent global ESC handler from triggering

## Changes

**tui/src/components/ChannelsView.tsx**
- Add `onBack` prop to `ChannelHistoryView` interface
- Pass `onBack={() => { setViewMode('list'); }}` from parent `ChannelsView`
- Handle ESC in non-input mode to call `onBack()`
- Use `setFocus('channel-history')` instead of `returnFocus()` when not in input mode
- Call `returnFocus()` before `onBack()` to clean up focus state

## Root Cause

The issue was caused by:
1. `ChannelHistoryView` not handling ESC when not in input mode
2. `returnFocus()` being called when exiting input mode, which re-enabled global keybinds
3. Global ESC handler taking over and navigating to Dashboard

## Fix Approach

1. Keep focus on 'channel-history' when not in input mode (prevents global ESC)
2. Explicitly handle ESC key to call parent's `onBack` callback
3. Restore focus before navigating back for proper cleanup

## Test plan

- [x] TUI lint passes (0 errors, 5 warnings - pre-existing)
- [x] ChannelsView tests pass (11/11)
- [x] Manual testing:
  - Press 3 to go to Channels tab
  - Press Enter to view channel history
  - Press ESC → returns to Channels list (not Dashboard)
  - Press ESC again → returns to Dashboard (expected)

## Closes

Closes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)