### PR TITLE
fix(tui): Add missing Logs and Worktrees tabs to navigation (#883)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -21,6 +21,8 @@ import { CommandsView } from './views/CommandsView';
 import { RolesView } from './views/RolesView';
 import { ChannelsView } from './components/ChannelsView';
 import { CostsView } from './components/CostsView';
+import { LogsView } from './views/LogsView';
+import { WorktreesView } from './views/WorktreesView';
 
 interface AppProps {
   /** Disable input handling (useful for testing) */
@@ -103,6 +105,10 @@ function ViewContent({ view, disableInput }: ViewContentProps): React.ReactEleme
       return <CommandsView disableInput={disableInput} />;
     case 'roles':
       return <RolesView disableInput={disableInput} />;
+    case 'logs':
+      return <LogsView />;
+    case 'worktrees':
+      return <WorktreesView />;
     case 'help':
       return <HelpView />;
     default:
@@ -117,7 +123,7 @@ function HelpView(): React.ReactElement {
       <Text bold>Keyboard Shortcuts</Text>
       <Box marginTop={1} flexDirection="column">
         <Text>
-          <Text color="yellow">1-6</Text>       Switch tabs
+          <Text color="yellow">1-8</Text>       Switch tabs
         </Text>
         <Text>
           <Text color="yellow">?</Text>         Show help

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useContext, useState, useCallback, useMemo } from
 import type { ReactNode } from 'react';
 
 // View types for navigation
-export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'help' | 'commands' | 'roles';
+export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'help' | 'commands' | 'roles' | 'logs' | 'worktrees';
 
 // Tab configuration
 export interface TabConfig {
@@ -23,6 +23,8 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: '4', view: 'costs', label: 'Costs', shortcut: '4' },
   { key: '5', view: 'commands', label: 'Commands', shortcut: '5' },
   { key: '6', view: 'roles', label: 'Roles', shortcut: '6' },
+  { key: '7', view: 'logs', label: 'Logs', shortcut: '7' },
+  { key: '8', view: 'worktrees', label: 'Worktrees', shortcut: '8' },
   { key: '?', view: 'help', label: 'Help', shortcut: '?' },
 ];
 

--- a/tui/src/views/index.ts
+++ b/tui/src/views/index.ts
@@ -9,3 +9,5 @@ export { DemonsView } from './DemonsView';
 export { ProcessesView } from './ProcessesView';
 export { TeamsView } from './TeamsView';
 export { RolesView } from './RolesView';
+export { LogsView } from './LogsView';
+export { WorktreesView } from './WorktreesView';


### PR DESCRIPTION
## Summary
- Add 'logs' and 'worktrees' to View type in NavigationContext
- Add Logs tab at key '7' and Worktrees tab at key '8' to DEFAULT_TABS
- Import and route LogsView and WorktreesView in app.tsx
- Update HelpView shortcuts from 1-6 to 1-8

Fixes #883 - Logs and Worktrees tabs were not visible in navigation despite having working views.

## Test plan
- [x] Build passes (`bun run build`)
- [x] All 1107 tests pass (`bun test`)
- [ ] Manual: Press '7' to navigate to Logs tab
- [ ] Manual: Press '8' to navigate to Worktrees tab
- [ ] Manual: Verify Help view shows "1-8" for shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)