### PR TITLE
fix(tui): Add Logs and Roles tabs to navigation (#883)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -18,6 +18,7 @@ import { UnreadProvider } from './hooks';
 import { Dashboard } from './views/Dashboard';
 import { AgentsView } from './views/AgentsView';
 import { CommandsView } from './views/CommandsView';
+import { LogsView } from './views/LogsView';
 import { RolesView } from './views/RolesView';
 import { ChannelsView } from './components/ChannelsView';
 import { CostsView } from './components/CostsView';
@@ -101,6 +102,8 @@ function ViewContent({ view, disableInput }: ViewContentProps): React.ReactEleme
       return <CostsView disableInput={disableInput} />;
     case 'commands':
       return <CommandsView disableInput={disableInput} />;
+    case 'logs':
+      return <LogsView disableInput={disableInput} />;
     case 'roles':
       return <RolesView disableInput={disableInput} />;
     case 'help':
@@ -117,7 +120,7 @@ function HelpView(): React.ReactElement {
       <Text bold>Keyboard Shortcuts</Text>
       <Box marginTop={1} flexDirection="column">
         <Text>
-          <Text color="yellow">1-6</Text>       Switch tabs
+          <Text color="yellow">1-7</Text>       Switch tabs
         </Text>
         <Text>
           <Text color="yellow">?</Text>         Show help

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useContext, useState, useCallback, useMemo } from
 import type { ReactNode } from 'react';
 
 // View types for navigation
-export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'help' | 'commands' | 'roles';
+export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'help' | 'commands' | 'logs' | 'roles';
 
 // Tab configuration
 export interface TabConfig {
@@ -22,7 +22,8 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: '3', view: 'channels', label: 'Channels', shortcut: '3' },
   { key: '4', view: 'costs', label: 'Costs', shortcut: '4' },
   { key: '5', view: 'commands', label: 'Commands', shortcut: '5' },
-  { key: '6', view: 'roles', label: 'Roles', shortcut: '6' },
+  { key: '6', view: 'logs', label: 'Logs', shortcut: '6' },
+  { key: '7', view: 'roles', label: 'Roles', shortcut: '7' },
   { key: '?', view: 'help', label: 'Help', shortcut: '?' },
 ];
 


### PR DESCRIPTION
## Summary

- Adds missing Logs tab to navigation (key '6')
- Ensures Roles tab is visible (moved to key '7')
- Both LogsView and RolesView are now accessible via tab bar

## Changes

**tui/src/navigation/NavigationContext.tsx**
- Add 'logs' to View type union
- Add Logs tab with key '6' to DEFAULT_TABS
- Move Roles tab from key '6' to key '7'

**tui/src/app.tsx**
- Import LogsView component
- Add 'logs' case to ViewContent switch
- Update Help view to show "1-7" for tab switching

## Tab Order

1. Dashboard
2. Agents
3. Channels
4. Costs
5. Commands
6. Logs (NEW)
7. Roles
?: Help

## Test plan

- [x] TUI lint passes (0 errors, 5 warnings - pre-existing)
- [x] Tests pass (1107 pass, 5 fail - pre-existing)
- [x] Manual testing:
  - Press '6' → shows Logs view
  - Press '7' → shows Roles view
  - Tab bar displays all 7 tabs + Help

## Closes

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)