### PR TITLE
feat(tui): Expand Help view with keyboard cheatsheet (#893)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -119,35 +119,89 @@ function ViewContent({ view, disableInput }: ViewContentProps): React.ReactEleme
 function HelpView(): React.ReactElement {
   const { theme, isDark } = useTheme();
   return (
-    <Box flexDirection="column">
-      <Text bold>Keyboard Shortcuts</Text>
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold color="cyan">KEYBOARD SHORTCUTS</Text>
+      <Text dimColor>{'─'.repeat(50)}</Text>
+
+      {/* Global shortcuts */}
       <Box marginTop={1} flexDirection="column">
-        <Text>
-          <Text color="yellow">1-8</Text>       Switch tabs
-        </Text>
-        <Text>
-          <Text color="yellow">?</Text>         Show help
-        </Text>
-        <Text>
-          <Text color="yellow">ESC</Text>       Go back / Home
-        </Text>
-        <Text>
-          <Text color="yellow">Backspace</Text> Go back in history
-        </Text>
-        <Text>
-          <Text color="yellow">q</Text>         Quit
-        </Text>
+        <Text bold>GLOBAL</Text>
+        <Box flexDirection="column" marginLeft={2}>
+          <ShortcutRow keys="1-8" desc="Switch tabs" />
+          <ShortcutRow keys="?" desc="Toggle help" />
+          <ShortcutRow keys="ESC" desc="Go back / Home" />
+          <ShortcutRow keys="Backspace" desc="History back" />
+          <ShortcutRow keys="q" desc="Quit" />
+          <ShortcutRow keys="Tab" desc="Next tab" />
+          <ShortcutRow keys="Shift+Tab" desc="Previous tab" />
+        </Box>
       </Box>
+
+      {/* Navigation */}
       <Box marginTop={1} flexDirection="column">
-        <Text bold>View-specific shortcuts:</Text>
-        <Text dimColor>Check each view for additional shortcuts</Text>
+        <Text bold>NAVIGATION</Text>
+        <Box flexDirection="column" marginLeft={2}>
+          <ShortcutRow keys="j / ↓" desc="Move down" />
+          <ShortcutRow keys="k / ↑" desc="Move up" />
+          <ShortcutRow keys="g" desc="Go to top" />
+          <ShortcutRow keys="G" desc="Go to bottom" />
+          <ShortcutRow keys="Enter" desc="Select / Drill down" />
+        </Box>
       </Box>
+
+      {/* Agents */}
       <Box marginTop={1} flexDirection="column">
-        <Text bold>Theme:</Text>
-        <Text dimColor>
-          Current: {theme.name} ({isDark ? 'dark' : 'light'} mode)
-        </Text>
+        <Text bold>AGENTS</Text>
+        <Box flexDirection="column" marginLeft={2}>
+          <ShortcutRow keys="Enter" desc="View agent details" />
+          <ShortcutRow keys="a" desc="Attach to session" />
+          <ShortcutRow keys="p" desc="Peek agent output" />
+          <ShortcutRow keys="s" desc="Start new agent" />
+          <ShortcutRow keys="/" desc="Search agents" />
+        </Box>
       </Box>
+
+      {/* Channels */}
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>CHANNELS</Text>
+        <Box flexDirection="column" marginLeft={2}>
+          <ShortcutRow keys="Enter" desc="View channel messages" />
+          <ShortcutRow keys="m" desc="Compose message" />
+          <ShortcutRow keys="j/k" desc="Scroll messages" />
+          <ShortcutRow keys="c" desc="Clear message draft" />
+        </Box>
+      </Box>
+
+      {/* Commands */}
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>COMMANDS</Text>
+        <Box flexDirection="column" marginLeft={2}>
+          <ShortcutRow keys="/" desc="Search commands" />
+          <ShortcutRow keys="Enter" desc="Copy command" />
+          <ShortcutRow keys="f" desc="Toggle favorite" />
+        </Box>
+      </Box>
+
+      {/* Theme */}
+      <Box marginTop={1} flexDirection="column">
+        <Text bold>THEME</Text>
+        <Box marginLeft={2}>
+          <Text dimColor>
+            Current: {theme.name} ({isDark ? 'dark' : 'light'} mode)
+          </Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+
+function ShortcutRow({ keys, desc }: { keys: string; desc: string }): React.ReactElement {
+  return (
+    <Box>
+      <Box width={14}>
+        <Text color="yellow">{keys}</Text>
+      </Box>
+      <Text>{desc}</Text>
     </Box>
   );
 }

--- a/tui/src/navigation/FocusContext.tsx
+++ b/tui/src/navigation/FocusContext.tsx
@@ -13,7 +13,7 @@ import React, {
   useMemo,
 } from 'react';
 
-export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal';
+export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal' | 'channel-history';
 
 interface FocusContextValue {
   /** Currently focused area */


### PR DESCRIPTION
## Summary
- Add comprehensive keyboard shortcuts reference organized by section
- Sections: Global, Navigation, Agents, Channels, Commands, Theme
- Add ShortcutRow component for consistent formatting
- Fix FocusArea type to include 'channel-history' (build fix)

## Test plan
- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)
- [ ] Verify pressing '?' shows expanded help view
- [ ] Check all keyboard shortcuts are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)