### PR TITLE
fix(tui): Add 'channel-history' to FocusArea type (#902)

### DIFF
--- a/tui/src/navigation/FocusContext.tsx
+++ b/tui/src/navigation/FocusContext.tsx
@@ -13,7 +13,7 @@ import React, {
   useMemo,
 } from 'react';
 
-export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal';
+export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal' | 'channel-history';
 
 interface FocusContextValue {
   /** Currently focused area */


### PR DESCRIPTION
## P0 BUILD FIX

Adds missing 'channel-history' to FocusArea type union.

**Root Cause**: PR #895 introduced `setFocus('channel-history')` in ChannelsView.tsx but didn't add the type to FocusArea union in FocusContext.tsx.

**Fix**: Single line change to add 'channel-history' to the FocusArea type.

## Closes

Closes #902
Fixes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)