### PR TITLE
fix(tui): Fix tab keys blocked in Channels view (#888, #902)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -213,7 +213,7 @@ function ChannelHistoryView({
    * When user enters input mode (presses 'm'), we set focus to 'input' area.
    * This prevents global keybinds (q, 1-9, ESC) from triggering during message typing.
    *
-   * When user exits input mode (presses Enter or Escape), we set focus to 'channel-history'
+   * When user exits input mode (presses Enter or Escape), we set focus to 'view'
    * to keep global navigation disabled while in channel history view. This ensures that
    * ESC navigates back to channel list (via onBack) rather than to Dashboard.
    *
@@ -226,8 +226,8 @@ function ChannelHistoryView({
     if (inputMode) {
       setFocus('input');
     } else {
-      // Keep focus on channel-history to prevent global ESC from going to Dashboard
-      setFocus('channel-history');
+      // Keep focus on 'view' to prevent global ESC from going to Dashboard
+      setFocus('view');
     }
   }, [inputMode, setFocus]);
 

--- a/tui/src/navigation/FocusContext.tsx
+++ b/tui/src/navigation/FocusContext.tsx
@@ -13,7 +13,7 @@ import React, {
   useMemo,
 } from 'react';
 
-export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal';
+export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal' | 'view';
 
 interface FocusContextValue {
   /** Currently focused area */

--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -44,11 +44,13 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
        *
        * This fixes issue #653: Keybinds not being re-enabled after typing in channels.
        */
+      // Skip ALL global keybinds when user is in input mode (typing)
       if (isFocused('input')) {
         return;
       }
 
       // Tab navigation with number keys (1-9) and ?
+      // These should work even when a local view has focus
       const tab = getTabByKey(input);
       if (tab) {
         navigate(tab.view);
@@ -65,8 +67,8 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
         return;
       }
 
-      // ESC: go home
-      if (key.escape) {
+      // ESC: go home (skip when local view handles ESC)
+      if (key.escape && !isFocused('view')) {
         goHome();
         return;
       }


### PR DESCRIPTION
## Summary
- Add 'view' to FocusArea type (generic for any view with local input handling)
- Change ChannelHistoryView focus from invalid 'channel-history' to 'view'
- Update useKeyboardNavigation to skip only ESC when focus is 'view'
- Number keys (1-8) still work globally for tab switching

Fixes #888 (tab keys not working in Channels) and #902 (build break from invalid FocusArea).

## Why 'view' instead of 'channel-history'?
'view' is more generic and reusable. Any view that needs local input handling (ESC, etc.) can set focus to 'view' without adding a new FocusArea for each component.

## Test plan
- [x] Build passes (`bun run build`)
- [x] All 1107 tests pass (`bun test`)
- [ ] Manual: Navigate to Channels, press 1-8 to switch tabs
- [ ] Manual: Enter channel history, press ESC - goes to channel list (not Dashboard)
- [ ] Manual: Enter channel history, press '1' - goes to Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)