### PR TITLE
fix(tui): Add 'channel-history' to FocusArea type (#902)

### DIFF
--- a/tui/src/navigation/FocusContext.tsx
+++ b/tui/src/navigation/FocusContext.tsx
@@ -13,7 +13,7 @@ import React, {
   useMemo,
 } from 'react';
 
-export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal';
+export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal' | 'channel-history';
 
 interface FocusContextValue {
   /** Currently focused area */


### PR DESCRIPTION
## P0 Build Fix

Adds missing 'channel-history' variant to FocusArea type.

## Changes
- `FocusContext.tsx`: Added 'channel-history' to FocusArea union type

## Test
- [x] `bun run build` passes

Fixes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)