### PR TITLE
fix(tui): Add 'channel-history' to FocusArea type (#902)

### DIFF
--- a/tui/src/navigation/FocusContext.tsx
+++ b/tui/src/navigation/FocusContext.tsx
@@ -13,7 +13,7 @@ import React, {
   useMemo,
 } from 'react';
 
-export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal';
+export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal' | 'channel-history';
 
 interface FocusContextValue {
   /** Currently focused area */


### PR DESCRIPTION
## Summary
- Adds 'channel-history' to FocusArea union type in FocusContext.tsx
- Fixes P0 build break caused by PR #895

## Root Cause
PR #895 (ESC navigation fix) added `setFocus('channel-history')` in ChannelsView.tsx:230 but did not update the FocusArea type definition.

## Changes
```diff
- export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal';
+ export type FocusArea = 'sidebar' | 'main' | 'detail' | 'input' | 'modal' | 'channel-history';
```

## Test plan
- [x] `bun run build` passes
- [x] `bun test` passes (1107 pass, 0 fail)

Fixes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)