### PR TITLE
fix(tui): Remove redundant Text wrap around MentionText (#887)

### DIFF
--- a/tui/src/components/ChatMessage.tsx
+++ b/tui/src/components/ChatMessage.tsx
@@ -122,9 +122,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
 
           {/* Message body with @mentions */}
           <Box width="100%">
-            <Text wrap="wrap">
-              <MentionText text={message} currentUser={currentUser} />
-            </Text>
+            <MentionText text={message} currentUser={currentUser} />
           </Box>
 
           {/* Reactions */}


### PR DESCRIPTION
## Summary
- **P0 FIX #887**: Removes redundant Text wrap that was causing message body to not render

## Root Cause
ChatMessage.tsx was wrapping MentionText in `<Text wrap="wrap">`, but MentionText already returns a Text element with `wrap="wrap"`. 

This double-wrapping (Text nested inside Text) caused the message body to collapse/not render in Ink.

## Fix
Remove the outer `<Text wrap="wrap">` wrapper since MentionText already handles text wrapping.

**Before:**
```tsx
<Box width="100%">
  <Text wrap="wrap">
    <MentionText text={message} currentUser={currentUser} />
  </Text>
</Box>
```

**After:**
```tsx
<Box width="100%">
  <MentionText text={message} currentUser={currentUser} />
</Box>
```

## Test plan
- [x] `bun run build` passes
- [x] All 1107 tests pass
- [ ] Manual: Verify channel messages display body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)