### PR TITLE
fix(tui): Set focus synchronously when entering channel history (#910)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -37,6 +37,7 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
   const [viewMode, setViewMode] = useState<'list' | 'history'>('list');
   const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
   const { getLastViewed } = useUnread();
+  const { setFocus, returnFocus } = useFocus();
 
   const selectedChannel = channels?.[selectedIndex];
 
@@ -73,13 +74,15 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
         if (input === 'G' && channels) {
           setSelectedIndex(channels.length - 1);
         }
-        // Enter channel
+        // Enter channel - set focus to 'view' BEFORE changing mode to prevent race
         if (key.return && selectedChannel) {
+          setFocus('view');
           setViewMode('history');
         }
       } else {
-        // Back to list
+        // Back to list - restore focus before leaving history
         if (key.escape) {
+          returnFocus();
           setViewMode('list');
         }
       }


### PR DESCRIPTION
## Summary

Fix ESC navigation race condition by setting focus synchronously in parent.

## Root Cause

Focus was set in `useEffect` (after render) in ChannelHistoryView, creating a window where global ESC handler could fire before focus was set to 'view'.

## Fix

Set `setFocus('view')` synchronously when pressing Enter to enter channel history, and `returnFocus()` when pressing ESC to leave. This happens in the parent ChannelsView BEFORE the child renders.

## Changes

**tui/src/components/ChannelsView.tsx**
- Add `useFocus` hook to parent ChannelsView
- Call `setFocus('view')` before `setViewMode('history')` (line 78)
- Call `returnFocus()` before `setViewMode('list')` (line 84)

## Test plan

- [x] Lint passes
- [x] Manual test: Dashboard → Channels (3) → Enter channel → ESC → returns to Channels list (not Dashboard)

## Closes

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)