### PR TITLE
fix(tui): Add key prop to ChannelHistoryView for proper remount (#911)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -108,6 +108,7 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
   if (viewMode === 'history' && selectedChannel) {
     return (
       <ChannelHistoryView
+        key={selectedChannel.name}
         channel={selectedChannel}
         disableInput={disableInput}
         onBack={() => { setViewMode('list'); }}


### PR DESCRIPTION
## Summary
- **P0 FIX #911**: Fixes channel selection always showing #all

## Root Cause
Without a `key` prop, React may reuse the `ChannelHistoryView` component instance when switching channels. This causes the internal state (and useChannelHistory hook state) to not reset, showing stale data from the previous channel.

## Fix
Add `key={selectedChannel.name}` to ChannelHistoryView. This forces React to unmount and remount the component when the channel changes, ensuring:
- Fresh internal state
- New useChannelHistory hook with correct channel name
- Correct data fetch

## Test plan
- [x] `bun run build` passes
- [x] All 1107 tests pass
- [ ] Manual: Navigate to different channels, verify correct channel opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)