### PR TITLE
fix(tui): Handle empty message text in MentionText (#915)

### DIFF
--- a/tui/src/components/MentionText.tsx
+++ b/tui/src/components/MentionText.tsx
@@ -17,6 +17,11 @@ export const MentionText: React.FC<MentionTextProps> = ({
   text,
   currentUser,
 }) => {
+  // Handle empty, missing, or whitespace-only text
+  if (!text || text.trim().length === 0) {
+    return <Text dimColor>(empty)</Text>;
+  }
+
   // Pattern to match @mentions
   const mentionPattern = /@(\w+[-\w]*)/g;
   const parts: React.ReactNode[] = [];


### PR DESCRIPTION
## Summary
- **P1 FIX #915**: Handles empty/whitespace-only message text that caused empty bubbles

## Root Cause
When message text is empty or whitespace-only, MentionText's regex parsing produces an empty parts array, rendering nothing. This causes the message bubble to appear without a body.

## Fix
Add early return check for empty/falsy/whitespace-only text, showing "(empty)" placeholder in dim text.

## Test plan
- [x] `bun run build` passes
- [x] All 1107 tests pass
- [ ] Manual: Messages with empty body now show "(empty)" placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)