### PR TITLE
test(tui): Add comprehensive edge case tests for MentionText (#915)

### DIFF
--- a/tui/src/__tests__/MentionText.test.tsx
+++ b/tui/src/__tests__/MentionText.test.tsx
@@ -52,9 +52,26 @@ describe('MentionText', () => {
     expect(lastFrame()).toContain('No mentions here');
   });
 
-  test('handles empty text', () => {
+  test('handles empty text with placeholder', () => {
     const { lastFrame } = render(<MentionText text="" />);
-    expect(lastFrame()).toBeDefined();
+    expect(lastFrame()).toContain('(empty)');
+  });
+
+  test('handles whitespace-only text with placeholder', () => {
+    const { lastFrame } = render(<MentionText text="   " />);
+    expect(lastFrame()).toContain('(empty)');
+  });
+
+  test('handles newline-only text with placeholder', () => {
+    const newlineText = "\n\n";
+    const { lastFrame } = render(<MentionText text={newlineText} />);
+    expect(lastFrame()).toContain('(empty)');
+  });
+
+  test('handles tab-only text with placeholder', () => {
+    const tabText = "\t\t";
+    const { lastFrame } = render(<MentionText text={tabText} />);
+    expect(lastFrame()).toContain('(empty)');
   });
 
   test('handles mention at start of text', () => {
@@ -69,5 +86,53 @@ describe('MentionText', () => {
     const output = lastFrame() ?? '';
     expect(output).toContain('Message for');
     expect(output).toContain('@clever-fox');
+  });
+
+  // Edge cases for #915 - ensure all empty/invalid cases show placeholder
+  test('handles undefined text gracefully', () => {
+    // TypeScript wouldn't allow this, but runtime JSON parsing might produce it
+    const { lastFrame } = render(<MentionText text={undefined as unknown as string} />);
+    expect(lastFrame()).toContain('(empty)');
+  });
+
+  test('handles null text gracefully', () => {
+    // TypeScript wouldn't allow this, but runtime JSON parsing might produce it
+    const { lastFrame } = render(<MentionText text={null as unknown as string} />);
+    expect(lastFrame()).toContain('(empty)');
+  });
+
+  test('handles mixed whitespace text with placeholder', () => {
+    const mixedWhitespace = "  \n\t  \n  ";
+    const { lastFrame } = render(<MentionText text={mixedWhitespace} />);
+    expect(lastFrame()).toContain('(empty)');
+  });
+
+  test('handles very long text without truncation', () => {
+    const longText = 'A'.repeat(500);
+    const { lastFrame } = render(<MentionText text={longText} />);
+    // Should not show (empty), should render the text
+    expect(lastFrame()).not.toContain('(empty)');
+    expect(lastFrame()).toContain('AAA');
+  });
+
+  test('handles text with special characters', () => {
+    const { lastFrame } = render(<MentionText text="Hello <script>alert('xss')</script> world" />);
+    const output = lastFrame() ?? '';
+    expect(output).toContain('Hello');
+    expect(output).toContain('world');
+  });
+
+  test('handles text with unicode/emoji', () => {
+    const { lastFrame } = render(<MentionText text="Hello 👋 world 🌍" />);
+    const output = lastFrame() ?? '';
+    expect(output).toContain('Hello');
+    expect(output).toContain('world');
+  });
+
+  test('handles multiline text', () => {
+    const { lastFrame } = render(<MentionText text="Line 1\nLine 2\nLine 3" />);
+    const output = lastFrame() ?? '';
+    expect(output).toContain('Line 1');
+    expect(output).toContain('Line 2');
   });
 });


### PR DESCRIPTION
## Summary
- Adds 10 new test cases to verify empty/whitespace handling in MentionText
- Tests verify PR #918's guard implementation
- Documents expected behavior for edge cases reported in #915

## Test Cases Added
- Empty text shows "(empty)" placeholder
- Whitespace-only (spaces, tabs, newlines) shows "(empty)"
- Null/undefined gracefully handled (runtime edge case)
- Unicode/emoji renders correctly
- Multiline text preserves content
- Very long text not truncated
- Special characters handled safely

## Test plan
- [x] All 1117 tests pass
- [x] New tests cover edge cases from #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)