### PR TITLE
fix(tui): Add focus management to AgentsView for ESC hierarchy (#910)

### DIFF
--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useAgents } from '../hooks';
+import { useFocus } from '../navigation/FocusContext';
 import { Table } from '../components/Table';
 import type { Column } from '../components/Table';
 import { StatusBadge } from '../components/StatusBadge';
@@ -35,6 +36,19 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
   const [actionState, setActionState] = useState<ActionState | null>(null);
   const agentList = agents ?? [];
   const selectedAgent = agentList[selectedIndex] as typeof agentList[number] | undefined;
+  const { setFocus } = useFocus();
+
+  // Manage focus state for nested view navigation
+  // When showing detail view, set focus='view' to prevent global ESC from firing
+  // This fixes ESC hierarchy: agent detail → ESC → agent list (not Dashboard)
+  useEffect(() => {
+    if (showDetail) {
+      setFocus('view');
+    } else {
+      // Restore focus to 'main' when returning to list view
+      setFocus('main');
+    }
+  }, [showDetail, setFocus]);
 
   // Clear action feedback after delay
   const showActionFeedback = useCallback((action: AgentAction, target: string, status: 'success' | 'error', message: string) => {


### PR DESCRIPTION
## Summary
- Apply the same focus pattern used in ChannelsView to AgentsView
- Set focus='view' when showing AgentDetailView to prevent global ESC handler
- Reset focus to 'main' when returning to agent list

## Problem
AgentsView has a nested view pattern (list → detail) but didn't use focus management, causing ESC from agent detail to potentially go to Dashboard instead of agent list.

## Solution
Add useEffect to manage focus state based on `showDetail`:
- `showDetail=true` → `setFocus('view')` (blocks global ESC)
- `showDetail=false` → `setFocus('main')` (allows global ESC)

This ensures consistent ESC navigation hierarchy across all views.

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] AgentsView tests pass (24 tests)
- [ ] Manual verification: Agents → Enter → Detail → ESC → Agent list

🤖 Generated with [Claude Code](https://claude.com/claude-code)