### PR TITLE
fix(tui): Fix test mock property names to match ChannelMessage type (#915)

### DIFF
--- a/tui/src/__tests__/dataLayer.advanced.test.ts
+++ b/tui/src/__tests__/dataLayer.advanced.test.ts
@@ -202,7 +202,7 @@ describe.skip('Advanced: Concurrent Operations and Race Conditions', () => {
       channels: [{ name: 'eng', members: [] }],
     });
     mockBcService.getChannelHistory.mockResolvedValue({
-      messages: [{ sender: 'test', text: 'msg', timestamp: 1000 }],
+      messages: [{ sender: 'test', message: 'msg', time: '2024-01-15T10:00:00Z' }],
     });
     mockBcService.sendChannelMessage.mockResolvedValue(undefined);
 

--- a/tui/src/__tests__/dataLayer.integration.test.ts
+++ b/tui/src/__tests__/dataLayer.integration.test.ts
@@ -88,8 +88,8 @@ describe.skip('Data Layer - Channel communication workflow', () => {
     // Step 2: Get history of first channel
     const historyData = {
       messages: [
-        { sender: 'eng-01', text: 'Hi everyone', timestamp: 1000 },
-        { sender: 'tl-01', text: 'Welcome!', timestamp: 1100 },
+        { sender: 'eng-01', message: 'Hi everyone', time: '2024-01-15T10:00:00Z' },
+        { sender: 'tl-01', message: 'Welcome!', time: '2024-01-15T10:01:00Z' },
       ],
     };
     mockBcService.getChannelHistory.mockResolvedValue(historyData);
@@ -104,7 +104,7 @@ describe.skip('Data Layer - Channel communication workflow', () => {
 
     // Step 4: Refresh history
     mockBcService.getChannelHistory.mockResolvedValue({
-      messages: [...historyData.messages, { sender: 'eng-01', text: 'Just finished implementation', timestamp: 1200 }],
+      messages: [...historyData.messages, { sender: 'eng-01', message: 'Just finished implementation', time: '2024-01-15T10:02:00Z' }],
     });
 
     const updatedHistory = await bcService.getChannelHistory('eng');

--- a/tui/src/hooks/__tests__/useChannels.test.tsx
+++ b/tui/src/hooks/__tests__/useChannels.test.tsx
@@ -15,9 +15,9 @@ const mockChannels: Channel[] = [
 ];
 
 const mockMessages: ChannelMessage[] = [
-  { id: '1', sender: 'eng-01', text: 'Hello team', time: '2024-01-15T10:00:00Z', channel: 'eng' },
-  { id: '2', sender: 'eng-02', text: 'Hi there', time: '2024-01-15T10:01:00Z', channel: 'eng' },
-  { id: '3', sender: 'eng-03', text: 'Good morning', time: '2024-01-15T10:02:00Z', channel: 'eng' },
+  { sender: 'eng-01', message: 'Hello team', time: '2024-01-15T10:00:00Z' },
+  { sender: 'eng-02', message: 'Hi there', time: '2024-01-15T10:01:00Z' },
+  { sender: 'eng-03', message: 'Good morning', time: '2024-01-15T10:02:00Z' },
 ];
 
 describe('useChannels Hook Logic', () => {
@@ -155,16 +155,16 @@ describe('useChannelHistory Hook Logic', () => {
 
     test('message has required properties', () => {
       const msg = mockMessages[0];
-      expect(msg).toHaveProperty('id');
       expect(msg).toHaveProperty('sender');
-      expect(msg).toHaveProperty('text');
+      expect(msg).toHaveProperty('message');
       expect(msg).toHaveProperty('time');
-      expect(msg).toHaveProperty('channel');
     });
 
-    test('messages are from correct channel', () => {
+    test('messages have required fields', () => {
       mockMessages.forEach(msg => {
-        expect(msg.channel).toBe('eng');
+        expect(msg.sender).toBeTruthy();
+        expect(msg.message).toBeDefined();
+        expect(msg.time).toBeTruthy();
       });
     });
 
@@ -286,10 +286,10 @@ describe('Channel Data Validation', () => {
 });
 
 describe('Message Data Validation', () => {
-  test('message id is unique', () => {
-    const ids = mockMessages.map(m => m.id);
-    const uniqueIds = new Set(ids);
-    expect(uniqueIds.size).toBe(ids.length);
+  test('messages are distinguishable by time', () => {
+    const times = mockMessages.map(m => m.time);
+    const uniqueTimes = new Set(times);
+    expect(uniqueTimes.size).toBe(times.length);
   });
 
   test('sender is non-empty', () => {
@@ -298,15 +298,13 @@ describe('Message Data Validation', () => {
     });
   });
 
-  test('text can be empty', () => {
+  test('message can be empty', () => {
     const msg: ChannelMessage = {
-      id: '4',
       sender: 'test',
-      text: '',
+      message: '',
       time: new Date().toISOString(),
-      channel: 'test',
     };
-    expect(msg.text).toBe('');
+    expect(msg.message).toBe('');
   });
 
   test('time is valid date string', () => {

--- a/tui/src/services/__tests__/bc.test.ts
+++ b/tui/src/services/__tests__/bc.test.ts
@@ -266,7 +266,7 @@ describe('Command wrapper functions - Status and channels', () => {
     const mockProc = mockProcessorFactory();
     mockSpawnImpl = mock(() => mockProc);
 
-    const historyData = { messages: [{ sender: 'eng-01', text: 'Hello', timestamp: 123456 }] };
+    const historyData = { messages: [{ sender: 'eng-01', message: 'Hello', time: '2024-01-15T10:00:00Z' }] };
 
     setTimeout(() => {
       const stdoutCalls = (mockProc.stdout.on as ReturnType<typeof mock>).mock.calls;


### PR DESCRIPTION
## Summary
- Fixed test mock property names to match actual ChannelMessage type
- `text` → `message`
- `timestamp` → `time`
- Removed non-existent `id` and `channel` properties from mocks

## Context
Found by eng-03 during #915 investigation. Test mocks were using incorrect property names that don't match the actual ChannelMessage type interface.

## Files changed
- tui/src/__tests__/dataLayer.integration.test.ts
- tui/src/__tests__/dataLayer.advanced.test.ts
- tui/src/hooks/__tests__/useChannels.test.tsx
- tui/src/services/__tests__/bc.test.ts

## Test plan
- [x] Run `bun test` - affected tests now pass
- [x] Verify ChannelMessage type matches Go CLI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)