### PR TITLE
fix(tui): Fix ChatMessage body not rendering (#915)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -281,9 +281,11 @@ function ChannelHistoryView({
     { isActive: !disableInput }
   );
 
-  const displayMessages = messages ? messages.slice(Math.max(0, messages.length - 10 - scrollOffset), messages.length - scrollOffset) : [];
+  // Show 5 messages max to fit in message area (14 lines / 2-3 lines per message)
+  const maxMessages = 5;
+  const displayMessages = messages ? messages.slice(Math.max(0, messages.length - maxMessages - scrollOffset), messages.length - scrollOffset) : [];
   const hasMoreAbove = scrollOffset > 0;
-  const hasMoreBelow = messages && messages.length > 10 && scrollOffset < messages.length - 10;
+  const hasMoreBelow = messages && messages.length > maxMessages && scrollOffset < messages.length - maxMessages;
 
   return (
     <Box flexDirection="column" width="100%" height="100%">

--- a/tui/src/components/MentionText.tsx
+++ b/tui/src/components/MentionText.tsx
@@ -29,19 +29,15 @@ export const MentionText: React.FC<MentionTextProps> = ({
   let match: RegExpExecArray | null;
 
   while ((match = mentionPattern.exec(text)) !== null) {
-    // Add text before the mention
+    // Add text before the mention as plain string (not nested Text)
     if (match.index > lastIndex) {
-      parts.push(
-        <Text key={`text-${String(lastIndex)}`}>
-          {text.slice(lastIndex, match.index)}
-        </Text>
-      );
+      parts.push(text.slice(lastIndex, match.index));
     }
 
     const mention = match[0];
     const username = match[1];
 
-    // Determine mention type and styling
+    // Determine mention type and styling - these need Text for color
     const isSelfMention = currentUser && username === currentUser;
     const isBroadcast = username === 'all' || username === 'everyone';
 
@@ -68,13 +64,9 @@ export const MentionText: React.FC<MentionTextProps> = ({
     lastIndex = match.index + mention.length;
   }
 
-  // Add remaining text
+  // Add remaining text as plain string (not nested Text)
   if (lastIndex < text.length) {
-    parts.push(
-      <Text key={`text-${String(lastIndex)}`}>
-        {text.slice(lastIndex)}
-      </Text>
-    );
+    parts.push(text.slice(lastIndex));
   }
 
   return <Text wrap="wrap">{parts}</Text>;


### PR DESCRIPTION
## Summary
- Fix ChatMessage body not rendering in ChannelsView
- Three-part fix addressing layout and rendering issues

## Changes
1. **ChatMessage.tsx**: Change Box from `width="100%"` to `flexGrow={1} minHeight={1}` to allow vertical expansion for wrapped text

2. **MentionText.tsx**: Use plain strings for non-styled text segments instead of nested Text elements, fixing Ink's wrap calculation

3. **ChannelsView.tsx**: Reduce displayed messages from 10 to 5 to fit within the 14-line message area (each bubble is 2-3 lines)

## Root Cause
- Nested Text components confused Ink's wrap width calculation
- Layout math (14 lines / 10 messages with 2-3 line bubbles) left no room for message content

## Test plan
- [ ] Open Channels view
- [ ] Navigate to a channel with messages
- [ ] Verify message bodies render (not just headers)
- [ ] Verify long messages wrap correctly
- [ ] Verify @mentions highlight properly

Fixes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)