### PR TITLE
fix(cli,tui): Add JSON output support for roles command

### DIFF
--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -126,6 +127,42 @@ func runRoleList(cmd *cobra.Command, args []string) error {
 	roles, err := rm.LoadAllRoles()
 	if err != nil {
 		return fmt.Errorf("failed to load roles: %w", err)
+	}
+
+	// Check for JSON output flag
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
+		// Build JSON response matching TUI RolesResponse type
+		type jsonRole struct {
+			Name         string   `json:"name"`
+			Description  string   `json:"description,omitempty"`
+			Parent       string   `json:"parent,omitempty"`
+			Capabilities []string `json:"capabilities"`
+			AgentCount   int      `json:"agent_count"`
+		}
+		type jsonResponse struct {
+			Roles []jsonRole `json:"roles"`
+		}
+
+		resp := jsonResponse{Roles: make([]jsonRole, 0, len(roles))}
+		for name, role := range roles {
+			caps := role.Metadata.Capabilities
+			if caps == nil {
+				caps = []string{}
+			}
+			parent := ""
+			if len(role.Metadata.ParentRoles) > 0 {
+				parent = role.Metadata.ParentRoles[0]
+			}
+			resp.Roles = append(resp.Roles, jsonRole{
+				Name:         name,
+				Description:  role.Description(),
+				Capabilities: caps,
+				Parent:       parent,
+				AgentCount:   0, // TODO: Count agents with this role
+			})
+		}
+		return json.NewEncoder(os.Stdout).Encode(resp)
 	}
 
 	if len(roles) == 0 {

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -28,7 +28,7 @@ import type {
 export async function execBc(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     // Always add --json flag if not present and command supports it
-    const jsonCommands = ['status', 'stats', 'channel', 'cost', 'logs', 'agent', 'process', 'demon', 'team'];
+    const jsonCommands = ['status', 'stats', 'channel', 'cost', 'logs', 'agent', 'process', 'demon', 'team', 'role', 'worktree'];
     const hasJsonFlag = args.includes('--json');
     const command = args[0];
 


### PR DESCRIPTION
## Summary
Fixes Roles tab showing 0 roles in TUI.

**CLI Fix (internal/cmd/role.go):**
- bc role list --json now outputs JSON format

**TUI Fix (tui/src/services/bc.ts):**
- Added role and worktree to jsonCommands list

## Test plan
- bc role list --json returns valid JSON
- TUI Roles/Worktrees views show data

Generated with Claude Code