### PR TITLE
fix(tui): CommandsView q-key handling - use setFocus('view')

### DIFF
--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -155,13 +155,13 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
   }, [searchQuery, categoryFilter]);
 
   // Sync focus state with search mode
-  // Use setFocus('main') instead of returnFocus() to avoid restoring stale focus
-  // (e.g., 'input' from previous ChannelsView session which would block global keybinds)
+  // Use setFocus('view') to enable local q/ESC handling via !isFocused('view') guard
+  // This prevents global q-key handler from quitting while in CommandsView
   React.useEffect(() => {
     if (searchMode) {
       setFocus('input');
     } else {
-      setFocus('main');
+      setFocus('view');
     }
   }, [searchMode, setFocus]);
 


### PR DESCRIPTION
## Summary
- Follow-up fix for #930 (PR #939 incomplete)
- CommandsView was using `setFocus('main')` instead of `setFocus('view')`
- The q-key guard `!isFocused('view')` only works when views call `setFocus('view')`
- This caused 'q' to quit the app instead of navigating back from Commands view

## Changes
- Change `setFocus('main')` → `setFocus('view')` in CommandsView.tsx
- Update comment to explain the focus pattern for q/ESC handling

## Test plan
- [ ] Navigate to Commands view (press 6 or click Commands tab)
- [ ] Press 'q' - should navigate back to Dashboard (NOT quit app)
- [ ] Press '/' to search, then ESC - should exit search mode
- [ ] Press 'q' again - should navigate back (NOT quit app)

Fixes #930

🤖 Generated with [Claude Code](https://claude.com/claude-code)