### PR TITLE
fix(tui): Prevent tab header truncation at wide terminals (#929)

### DIFF
--- a/tui/src/navigation/TabBar.tsx
+++ b/tui/src/navigation/TabBar.tsx
@@ -20,7 +20,7 @@ export function TabBar({
   const { currentView, tabs, canGoBack } = useNavigation();
 
   return (
-    <Box>
+    <Box flexShrink={0}>
       {showTitle && (
         <>
           <Text bold color="cyan">


### PR DESCRIPTION
## Summary
- Fix tab header text being truncated at 120+ column terminal widths
- One-line fix: add `flexShrink={0}` to TabBar's outer Box

## Problem
At wider terminal widths (120+ columns), tab labels were truncated:
- "Dashboard" → "Dashboar"
- "Costs" → "Cost"
- "Commands" → "Command"

## Root Cause
The TabBar's outer Box had no flex properties, allowing the flex container to shrink it during layout calculations.

## Solution
Add `flexShrink={0}` to prevent the TabBar from being compressed by flex layout.

## Test plan
- [ ] Set terminal to 120x40
- [ ] Run `bc dashboard`
- [ ] Verify all tab labels are complete (Dashboard, Agents, Channels, etc.)
- [ ] Test at various widths (80, 120, 160 columns)

Fixes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)