### PR TITLE
fix(cli): Standardize command default behavior (#925)

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -22,7 +22,6 @@ Channels are named groups of agent members. Messages sent to a channel are
 delivered to all member tmux sessions.
 
 Examples:
-  bc channel                         # list all channels
   bc channel list                    # list all channels
   bc channel create workers          # create a channel named "workers"
   bc channel add workers worker-01   # add member to channel
@@ -32,7 +31,6 @@ Examples:
   bc channel join workers            # join a channel (current agent)
   bc channel leave workers           # leave a channel (current agent)
   bc channel history workers         # show channel message history`,
-	RunE: runChannelList,
 }
 
 var channelCreateCmd = &cobra.Command{

--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -605,7 +605,7 @@ func TestChannelListNoWorkspace(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(origDir) }()
 
-	_, _, err = executeIntegrationCmd("channel")
+	_, _, err = executeIntegrationCmd("channel", "list")
 	if err == nil {
 		t.Fatal("expected error when not in workspace, got nil")
 	}
@@ -618,7 +618,7 @@ func TestChannelListEmpty(t *testing.T) {
 	_, cleanup := setupIntegrationWorkspace(t)
 	defer cleanup()
 
-	stdout, _, err := executeIntegrationCmd("channel")
+	stdout, _, err := executeIntegrationCmd("channel", "list")
 	if err != nil {
 		t.Fatalf("channel list returned error: %v", err)
 	}

--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -30,7 +30,6 @@ Examples:
   bc role edit engineer                             # Edit engineer role in $EDITOR
   bc role delete custom                             # Delete a role
   bc role validate                                  # Validate all role files`,
-	RunE: runRoleList,
 }
 
 var roleListCmd = &cobra.Command{


### PR DESCRIPTION
## Summary
- Standardize CLI command default behavior: all now show help when no subcommand provided
- Removes inconsistency where `bc channel` and `bc role` defaulted to list while others showed help

## Changes
- `bc channel` (no subcommand): Now shows help instead of listing channels
- `bc role` (no subcommand): Now shows help instead of listing roles
- Updated tests to explicitly use `list` subcommand

## Rationale
- Follows standard CLI conventions (git, docker, kubectl, etc.)
- Explicit > implicit (users learn available subcommands)
- No breaking change risk (help is always safe)

## Before
| Command | Behavior |
|---------|----------|
| `bc channel` | Lists channels |
| `bc role` | Lists roles |
| `bc agent` | Shows help |
| `bc cost` | Shows help |

## After
| Command | Behavior |
|---------|----------|
| `bc channel` | Shows help |
| `bc role` | Shows help |
| `bc agent` | Shows help |
| `bc cost` | Shows help |

## Test plan
- [x] `bc channel` shows help with subcommand list
- [x] `bc role` shows help with subcommand list
- [x] `bc channel list` still works
- [x] `bc role list` still works
- [x] Tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)