### PR TITLE
fix(tui): Fix message body rendering in channel history (#915)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -270,20 +270,24 @@ function ChannelHistoryView({
           setMessageBuffer('');
         }
         // 'j' to scroll down, 'k' to scroll up
+        // Note: maxMessages=3 for display, scroll bounds use same constant
         if (input === 'j' && messages) {
           setScrollOffset(Math.max(0, scrollOffset - 1));
         }
         if (input === 'k' && messages) {
-          setScrollOffset(Math.min(Math.max(0, messages.length - 10), scrollOffset + 1));
+          setScrollOffset(Math.min(Math.max(0, messages.length - 3), scrollOffset + 1));
         }
       }
     },
     { isActive: !disableInput }
   );
 
-  const displayMessages = messages ? messages.slice(Math.max(0, messages.length - 10 - scrollOffset), messages.length - scrollOffset) : [];
+  // #915 fix: Reduce max messages from 10 to 3 to fit in available space
+  // Layout math: 14 lines available / 4 lines per message = ~3 messages max
+  const maxMessages = 3;
+  const displayMessages = messages ? messages.slice(Math.max(0, messages.length - maxMessages - scrollOffset), messages.length - scrollOffset) : [];
   const hasMoreAbove = scrollOffset > 0;
-  const hasMoreBelow = messages && messages.length > 10 && scrollOffset < messages.length - 10;
+  const hasMoreBelow = messages && messages.length > maxMessages && scrollOffset < messages.length - maxMessages;
 
   return (
     <Box flexDirection="column" width="100%" height="100%">

--- a/tui/src/components/MentionText.tsx
+++ b/tui/src/components/MentionText.tsx
@@ -29,13 +29,10 @@ export const MentionText: React.FC<MentionTextProps> = ({
   let match: RegExpExecArray | null;
 
   while ((match = mentionPattern.exec(text)) !== null) {
-    // Add text before the mention
+    // Add text before the mention as plain string (not wrapped in <Text>)
+    // Wrapping in <Text> breaks Ink's width calculation for wrap="wrap"
     if (match.index > lastIndex) {
-      parts.push(
-        <Text key={`text-${String(lastIndex)}`}>
-          {text.slice(lastIndex, match.index)}
-        </Text>
-      );
+      parts.push(text.slice(lastIndex, match.index));
     }
 
     const mention = match[0];
@@ -68,13 +65,9 @@ export const MentionText: React.FC<MentionTextProps> = ({
     lastIndex = match.index + mention.length;
   }
 
-  // Add remaining text
+  // Add remaining text as plain string (not wrapped in <Text>)
   if (lastIndex < text.length) {
-    parts.push(
-      <Text key={`text-${String(lastIndex)}`}>
-        {text.slice(lastIndex)}
-      </Text>
-    );
+    parts.push(text.slice(lastIndex));
   }
 
   return <Text wrap="wrap">{parts}</Text>;


### PR DESCRIPTION
## Summary
- Fix message body not rendering in channel history view
- Root cause: MentionText.tsx wrapped plain text in nested `<Text>` elements, breaking Ink's width calculation
- Secondary issue: 10-message display exceeded available viewport space

## Changes
1. **MentionText.tsx**: Push plain strings instead of `<Text>` wrappers for non-styled text
2. **ChannelsView.tsx**: Reduce maxMessages from 10 to 3 to fit in available space

## Layout Math (per ux-01 analysis)
- 14 lines available in message area
- Each ChatMessage needs ~4 lines (header, body, spacing)
- 14 / 4 = 3.5 → 3 messages max

## Test plan
- [x] Lint passes
- [x] Build passes
- [ ] Verify message bodies now visible in channel history
- [ ] Verify scrolling still works with j/k keys

Fixes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)