### PR TITLE
fix(workspace): Derive role name from filename when frontmatter missing

### DIFF
--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -142,6 +142,12 @@ func (rm *RoleManager) loadRoleFromPath(filePath string) (*Role, error) {
 
 	role.FilePath = filePath
 
+	// If role name is empty (no frontmatter or missing name field),
+	// derive it from the filename as a fallback
+	if role.Metadata.Name == "" {
+		role.Metadata.Name = strings.TrimSuffix(filepath.Base(filePath), ".md")
+	}
+
 	// Cache the role
 	rm.roles[role.Metadata.Name] = role
 


### PR DESCRIPTION
## Summary
- Fix `bc role list` showing empty name when role file has no YAML frontmatter
- Derive role name from filename (strip .md extension) as fallback

## Root Cause
File `ux-tester.md` had no YAML frontmatter, causing `ParseRoleFile` to return empty `RoleMetadata{}`.

## Changes
- In `loadRoleFromPath()`, after parsing, if `Metadata.Name` is empty, derive from filename

## Test plan
- [x] `bc role list` now shows `ux-tester` instead of empty name
- [x] All role tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)