### PR TITLE
fix(team): Add bc team cleanup command for orphaned members

### DIFF
--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -90,6 +90,20 @@ Examples:
 	RunE: runTeamRename,
 }
 
+var teamCleanupCmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Find and remove orphaned team members",
+	Long: `Find and remove team members that reference non-existent agents.
+
+By default, performs a dry-run showing what would be removed.
+Use --fix to actually remove the orphaned members.
+
+Examples:
+  bc team cleanup           # Dry-run: show orphaned members
+  bc team cleanup --fix     # Remove orphaned members`,
+	RunE: runTeamCleanup,
+}
+
 func init() {
 	teamCmd.AddCommand(teamCreateCmd)
 	teamCmd.AddCommand(teamListCmd)
@@ -98,6 +112,8 @@ func init() {
 	teamCmd.AddCommand(teamAddCmd)
 	teamCmd.AddCommand(teamRemoveCmd)
 	teamCmd.AddCommand(teamRenameCmd)
+	teamCmd.AddCommand(teamCleanupCmd)
+	teamCleanupCmd.Flags().Bool("fix", false, "Actually remove orphaned members (default: dry-run)")
 	rootCmd.AddCommand(teamCmd)
 }
 
@@ -331,6 +347,61 @@ func runTeamRename(cmd *cobra.Command, args []string) error {
 		cmd.Printf("  Members: %d\n", len(oldTeam.Members))
 		if oldTeam.Lead != "" {
 			cmd.Printf("  Lead: %s\n", oldTeam.Lead)
+		}
+	}
+
+	return nil
+}
+
+func runTeamCleanup(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return errNotInWorkspace(err)
+	}
+
+	fix, _ := cmd.Flags().GetBool("fix")
+
+	// Set up agent existence check
+	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
+	_ = mgr.LoadState() //nolint:errcheck // continue even if state doesn't load
+
+	agentExists := func(name string) bool {
+		return mgr.GetAgent(name) != nil
+	}
+
+	store := team.NewStore(ws.RootDir)
+
+	if fix {
+		// Actually remove orphaned members
+		removed, cleanupErr := store.CleanupOrphanedMembers(agentExists)
+		if cleanupErr != nil {
+			return cleanupErr
+		}
+		if removed == 0 {
+			cmd.Println("No orphaned members found")
+		} else {
+			cmd.Printf("Removed %d orphaned member(s)\n", removed)
+		}
+	} else {
+		// Dry-run: just show orphaned members
+		orphans, findErr := store.FindOrphanedMembers(agentExists)
+		if findErr != nil {
+			return findErr
+		}
+		if len(orphans) == 0 {
+			cmd.Println("No orphaned members found")
+		} else {
+			cmd.Printf("Found %d orphaned member(s):\n", len(orphans))
+			cmd.Println()
+			for _, o := range orphans {
+				role := "member"
+				if o.IsLead {
+					role = "lead"
+				}
+				cmd.Printf("  %-20s %s (%s)\n", o.TeamName, o.MemberName, role)
+			}
+			cmd.Println()
+			cmd.Println("Run with --fix to remove these orphaned members")
 		}
 	}
 

--- a/pkg/team/team.go
+++ b/pkg/team/team.go
@@ -232,3 +232,70 @@ func (s *Store) save(team *Team) error {
 func (s *Store) teamPath(name string) string {
 	return filepath.Join(s.teamsDir, name+".json")
 }
+
+// OrphanedMember represents a member that references a non-existent agent.
+type OrphanedMember struct {
+	TeamName   string
+	MemberName string
+	IsLead     bool
+}
+
+// FindOrphanedMembers finds all team members that reference non-existent agents.
+// The agentExists function is called to check if each agent exists.
+func (s *Store) FindOrphanedMembers(agentExists func(name string) bool) ([]OrphanedMember, error) {
+	teams, err := s.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var orphans []OrphanedMember
+	for _, t := range teams {
+		// Check members
+		for _, member := range t.Members {
+			if !agentExists(member) {
+				orphans = append(orphans, OrphanedMember{
+					TeamName:   t.Name,
+					MemberName: member,
+					IsLead:     false,
+				})
+			}
+		}
+		// Check lead
+		if t.Lead != "" && !agentExists(t.Lead) {
+			orphans = append(orphans, OrphanedMember{
+				TeamName:   t.Name,
+				MemberName: t.Lead,
+				IsLead:     true,
+			})
+		}
+	}
+
+	return orphans, nil
+}
+
+// CleanupOrphanedMembers removes all team members that reference non-existent agents.
+// Returns the number of orphaned members removed.
+func (s *Store) CleanupOrphanedMembers(agentExists func(name string) bool) (int, error) {
+	orphans, err := s.FindOrphanedMembers(agentExists)
+	if err != nil {
+		return 0, err
+	}
+
+	removed := 0
+	for _, orphan := range orphans {
+		if orphan.IsLead {
+			if err := s.SetLead(orphan.TeamName, ""); err != nil {
+				return removed, fmt.Errorf("failed to clear orphaned lead %s from team %s: %w",
+					orphan.MemberName, orphan.TeamName, err)
+			}
+		} else {
+			if err := s.RemoveMember(orphan.TeamName, orphan.MemberName); err != nil {
+				return removed, fmt.Errorf("failed to remove orphaned member %s from team %s: %w",
+					orphan.MemberName, orphan.TeamName, err)
+			}
+		}
+		removed++
+	}
+
+	return removed, nil
+}

--- a/pkg/team/team_test.go
+++ b/pkg/team/team_test.go
@@ -398,3 +398,138 @@ func TestStoreRemoveAgentFromAllTeams_AgentNotInAnyTeam(t *testing.T) {
 		t.Errorf("team-a members = %v, want [eng-02]", team.Members)
 	}
 }
+
+func TestFindOrphanedMembers(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Create teams with mix of valid and orphaned members
+	_, _ = store.Create("team-a")
+	_ = store.AddMember("team-a", "eng-01")   // valid
+	_ = store.AddMember("team-a", "orphan-1") // orphaned
+
+	_, _ = store.Create("team-b")
+	_ = store.AddMember("team-b", "orphan-2")  // orphaned
+	_ = store.SetLead("team-b", "orphan-lead") // orphaned lead
+
+	// agentExists returns true only for eng-01
+	agentExists := func(name string) bool {
+		return name == "eng-01"
+	}
+
+	orphans, err := store.FindOrphanedMembers(agentExists)
+	if err != nil {
+		t.Fatalf("FindOrphanedMembers failed: %v", err)
+	}
+
+	// Should find 3 orphans: orphan-1, orphan-2, and orphan-lead
+	if len(orphans) != 3 {
+		t.Errorf("FindOrphanedMembers returned %d orphans, want 3", len(orphans))
+	}
+
+	// Verify orphan-lead is marked as lead
+	foundLead := false
+	for _, o := range orphans {
+		if o.MemberName == "orphan-lead" && o.IsLead {
+			foundLead = true
+		}
+	}
+	if !foundLead {
+		t.Error("orphan-lead should be marked as IsLead=true")
+	}
+}
+
+func TestFindOrphanedMembers_NoOrphans(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, _ = store.Create("team-a")
+	_ = store.AddMember("team-a", "eng-01")
+	_ = store.AddMember("team-a", "eng-02")
+
+	// All agents exist
+	agentExists := func(name string) bool {
+		return name == "eng-01" || name == "eng-02"
+	}
+
+	orphans, err := store.FindOrphanedMembers(agentExists)
+	if err != nil {
+		t.Fatalf("FindOrphanedMembers failed: %v", err)
+	}
+
+	if len(orphans) != 0 {
+		t.Errorf("FindOrphanedMembers returned %d orphans, want 0", len(orphans))
+	}
+}
+
+func TestCleanupOrphanedMembers(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	// Create teams with orphaned members
+	_, _ = store.Create("team-a")
+	_ = store.AddMember("team-a", "eng-01")   // valid
+	_ = store.AddMember("team-a", "orphan-1") // orphaned
+
+	_, _ = store.Create("team-b")
+	_ = store.AddMember("team-b", "orphan-2")  // orphaned
+	_ = store.SetLead("team-b", "orphan-lead") // orphaned lead
+
+	// agentExists returns true only for eng-01
+	agentExists := func(name string) bool {
+		return name == "eng-01"
+	}
+
+	removed, err := store.CleanupOrphanedMembers(agentExists)
+	if err != nil {
+		t.Fatalf("CleanupOrphanedMembers failed: %v", err)
+	}
+
+	if removed != 3 {
+		t.Errorf("CleanupOrphanedMembers removed %d, want 3", removed)
+	}
+
+	// Verify team-a still has eng-01 but not orphan-1
+	teamA, _ := store.Get("team-a")
+	if len(teamA.Members) != 1 || teamA.Members[0] != "eng-01" {
+		t.Errorf("team-a members = %v, want [eng-01]", teamA.Members)
+	}
+
+	// Verify team-b has no members and no lead
+	teamB, _ := store.Get("team-b")
+	if len(teamB.Members) != 0 {
+		t.Errorf("team-b members = %v, want []", teamB.Members)
+	}
+	if teamB.Lead != "" {
+		t.Errorf("team-b lead = %q, want empty", teamB.Lead)
+	}
+}
+
+func TestCleanupOrphanedMembers_NoOrphans(t *testing.T) {
+	tmpDir := t.TempDir()
+	store := NewStore(tmpDir)
+
+	_, _ = store.Create("team-a")
+	_ = store.AddMember("team-a", "eng-01")
+	_ = store.AddMember("team-a", "eng-02")
+
+	// All agents exist
+	agentExists := func(name string) bool {
+		return name == "eng-01" || name == "eng-02"
+	}
+
+	removed, err := store.CleanupOrphanedMembers(agentExists)
+	if err != nil {
+		t.Fatalf("CleanupOrphanedMembers failed: %v", err)
+	}
+
+	if removed != 0 {
+		t.Errorf("CleanupOrphanedMembers removed %d, want 0", removed)
+	}
+
+	// Verify team unchanged
+	team, _ := store.Get("team-a")
+	if len(team.Members) != 2 {
+		t.Errorf("team-a members = %v, want [eng-01, eng-02]", team.Members)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `bc team cleanup` command to detect and remove orphaned team members
- Orphaned members are team references to agents that no longer exist
- Follows worktree prune pattern: dry-run by default, --fix to actually remove

## Changes
- Add `OrphanedMember` struct to represent orphaned references
- Add `FindOrphanedMembers()` to detect orphaned members and leads
- Add `CleanupOrphanedMembers()` to remove orphaned references
- Add `bc team cleanup` command with `--fix` flag
- Add 4 unit tests for new functionality

## Usage
```bash
bc team cleanup           # Dry-run: show orphaned members
bc team cleanup --fix     # Remove orphaned members
```

## Test plan
- [x] Run `go test ./pkg/team/...` - all 26 tests pass
- [x] Run `make lint` - 0 issues
- [x] Verify pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)