### PR TITLE
feat(cli): Add -o shorthand for bc worktree list --orphaned

### DIFF
--- a/internal/cmd/worktree.go
+++ b/internal/cmd/worktree.go
@@ -89,7 +89,7 @@ func init() {
 	worktreeCmd.AddCommand(worktreeCheckCmd)
 	worktreeCmd.AddCommand(worktreeListCmd)
 	worktreeCmd.AddCommand(worktreePruneCmd)
-	worktreeListCmd.Flags().BoolVar(&worktreeListOrphan, "orphaned", false, "Show only orphaned worktrees")
+	worktreeListCmd.Flags().BoolVarP(&worktreeListOrphan, "orphaned", "o", false, "Show only orphaned worktrees")
 	worktreePruneCmd.Flags().BoolVarP(&worktreePruneForce, "force", "f", false, "Actually remove orphaned worktrees (default is dry-run)")
 }
 


### PR DESCRIPTION
## Summary
- Adds `-o` shorthand flag for `bc worktree list --orphaned`
- Improves CLI ergonomics with consistent flag patterns

**Before:** `bc worktree list --orphaned`
**After:** `bc worktree list -o` (or `--orphaned`)

## Test plan
- [x] Build passes
- [x] `bc worktree list --help` shows `-o, --orphaned`
- [x] `bc worktree list -o` works correctly
- [x] All worktree tests pass

P3 enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)