### PR TITLE
feat(tui): Add performance metrics infrastructure (#965)

### DIFF
--- a/tui/src/components/PerformanceDebugPanel.tsx
+++ b/tui/src/components/PerformanceDebugPanel.tsx
@@ -1,0 +1,163 @@
+/**
+ * PerformanceDebugPanel - Debug overlay for performance metrics
+ * Issue #965: Display performance metrics when BC_TUI_DEBUG=1
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { usePerformanceOptional } from '../hooks';
+
+interface PerformanceDebugPanelProps {
+  /** Maximum number of metrics to display */
+  maxMetrics?: number;
+  /** Show compact view (single line) */
+  compact?: boolean;
+}
+
+/**
+ * Debug panel showing performance metrics
+ * Only renders when debug mode is enabled (BC_TUI_DEBUG=1)
+ */
+export function PerformanceDebugPanel({
+  maxMetrics = 5,
+  compact = false,
+}: PerformanceDebugPanelProps): React.ReactElement | null {
+  const perf = usePerformanceOptional();
+
+  // Don't render if not in debug mode or no performance context
+  if (!perf?.debugEnabled) {
+    return null;
+  }
+
+  const metrics = perf.getAllMetrics().slice(0, maxMetrics);
+  const uptime = perf.getUptime();
+
+  if (compact) {
+    // Single line compact view
+    const summaryParts = metrics.map((m) => `${m.name}:${m.average.toFixed(0)}ms`);
+    return (
+      <Box>
+        <Text dimColor>
+          [PERF] {summaryParts.join(' | ')} | uptime:{Math.floor(uptime)}s | samples:{perf.totalMeasurements}
+        </Text>
+      </Box>
+    );
+  }
+
+  // Full debug panel
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="single"
+      borderColor="yellow"
+      paddingX={1}
+      marginTop={1}
+    >
+      <Box justifyContent="space-between">
+        <Text bold color="yellow">PERFORMANCE DEBUG</Text>
+        <Text dimColor>
+          uptime: {Math.floor(uptime)}s | samples: {perf.totalMeasurements}
+        </Text>
+      </Box>
+
+      <Box marginTop={0}>
+        <Text dimColor>{'─'.repeat(50)}</Text>
+      </Box>
+
+      {/* Header */}
+      <Box>
+        <Text bold>
+          {'METRIC'.padEnd(25)}
+          {'AVG'.padStart(8)}
+          {'MIN'.padStart(8)}
+          {'MAX'.padStart(8)}
+          {'CNT'.padStart(6)}
+        </Text>
+      </Box>
+
+      {/* Metrics rows */}
+      {metrics.map((metric) => (
+        <MetricRow key={metric.name} metric={metric} />
+      ))}
+
+      {metrics.length === 0 && (
+        <Text dimColor>No metrics recorded yet...</Text>
+      )}
+
+      <Box marginTop={0}>
+        <Text dimColor>Press d to toggle debug | c to clear metrics</Text>
+      </Box>
+    </Box>
+  );
+}
+
+interface MetricRowProps {
+  metric: {
+    name: string;
+    average: number;
+    min: number;
+    max: number;
+    count: number;
+  };
+}
+
+function MetricRow({ metric }: MetricRowProps): React.ReactElement {
+  // Color code based on average time
+  const getColor = (avgMs: number): string => {
+    if (avgMs < 50) return 'green';
+    if (avgMs < 200) return 'yellow';
+    return 'red';
+  };
+
+  const color = getColor(metric.average);
+
+  return (
+    <Box>
+      <Text>
+        {metric.name.slice(0, 24).padEnd(25)}
+      </Text>
+      <Text color={color}>
+        {`${metric.average.toFixed(1)}ms`.padStart(8)}
+      </Text>
+      <Text dimColor>
+        {`${metric.min.toFixed(1)}ms`.padStart(8)}
+        {`${metric.max.toFixed(1)}ms`.padStart(8)}
+        {String(metric.count).padStart(6)}
+      </Text>
+    </Box>
+  );
+}
+
+/**
+ * Compact footer-style metrics display
+ * Shows key metrics in a single line
+ */
+export function PerformanceFooter(): React.ReactElement | null {
+  const perf = usePerformanceOptional();
+
+  if (!perf?.debugEnabled) {
+    return null;
+  }
+
+  const metrics = perf.getAllMetrics();
+  const pollMetrics = metrics.filter((m) => m.name.startsWith('poll:'));
+  const cmdMetrics = metrics.filter((m) => m.name.startsWith('cmd:'));
+
+  // Calculate averages
+  const avgPoll = pollMetrics.length > 0
+    ? pollMetrics.reduce((sum, m) => sum + m.average, 0) / pollMetrics.length
+    : 0;
+  const avgCmd = cmdMetrics.length > 0
+    ? cmdMetrics.reduce((sum, m) => sum + m.average, 0) / cmdMetrics.length
+    : 0;
+
+  return (
+    <Box marginTop={0}>
+      <Text dimColor>
+        [PERF] poll:{avgPoll.toFixed(0)}ms cmd:{avgCmd.toFixed(0)}ms samples:{perf.totalMeasurements}
+      </Text>
+    </Box>
+  );
+}
+
+export default PerformanceDebugPanel;

--- a/tui/src/hooks/PerformanceContext.tsx
+++ b/tui/src/hooks/PerformanceContext.tsx
@@ -1,0 +1,92 @@
+/**
+ * PerformanceContext - Global performance metrics provider
+ * Issue #965: Provide performance metrics across TUI components
+ */
+
+import React, { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { usePerformanceMetrics, type PerformanceMetric } from './usePerformanceMetrics';
+
+interface PerformanceContextValue {
+  /** All tracked metrics */
+  metrics: Map<string, PerformanceMetric>;
+  /** Total number of measurements */
+  totalMeasurements: number;
+  /** Whether debug mode is enabled */
+  debugEnabled: boolean;
+  /** Start timing an operation */
+  startTimer: (name: string) => string;
+  /** End timing an operation */
+  endTimer: (timerId: string, name: string) => number;
+  /** Record a metric value directly */
+  recordMetric: (name: string, value: number) => void;
+  /** Time an async operation */
+  timeAsync: <T>(name: string, fn: () => Promise<T>) => Promise<T>;
+  /** Time a sync operation */
+  timeSync: <T>(name: string, fn: () => T) => T;
+  /** Get a specific metric */
+  getMetric: (name: string) => PerformanceMetric | undefined;
+  /** Get all metrics as array */
+  getAllMetrics: () => PerformanceMetric[];
+  /** Get uptime in seconds */
+  getUptime: () => number;
+  /** Clear all metrics */
+  clearMetrics: () => void;
+  /** Toggle debug mode */
+  toggleDebug: () => void;
+}
+
+const PerformanceContext = createContext<PerformanceContextValue | null>(null);
+
+interface PerformanceProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Performance metrics provider component
+ * Wrap your app with this to enable performance tracking
+ */
+export function PerformanceProvider({ children }: PerformanceProviderProps): React.ReactElement {
+  const perf = usePerformanceMetrics();
+
+  const value = useMemo<PerformanceContextValue>(() => ({
+    metrics: perf.metrics,
+    totalMeasurements: perf.totalMeasurements,
+    debugEnabled: perf.debugEnabled,
+    startTimer: perf.startTimer,
+    endTimer: perf.endTimer,
+    recordMetric: perf.recordMetric,
+    timeAsync: perf.timeAsync,
+    timeSync: perf.timeSync,
+    getMetric: perf.getMetric,
+    getAllMetrics: perf.getAllMetrics,
+    getUptime: perf.getUptime,
+    clearMetrics: perf.clearMetrics,
+    toggleDebug: perf.toggleDebug,
+  }), [perf]);
+
+  return (
+    <PerformanceContext.Provider value={value}>
+      {children}
+    </PerformanceContext.Provider>
+  );
+}
+
+/**
+ * Hook to access performance metrics context
+ * Must be used within PerformanceProvider
+ */
+export function usePerformance(): PerformanceContextValue {
+  const context = useContext(PerformanceContext);
+  if (!context) {
+    throw new Error('usePerformance must be used within PerformanceProvider');
+  }
+  return context;
+}
+
+/**
+ * Hook to conditionally access performance metrics
+ * Returns null if not within PerformanceProvider (safe for optional usage)
+ */
+export function usePerformanceOptional(): PerformanceContextValue | null {
+  return useContext(PerformanceContext);
+}

--- a/tui/src/hooks/__tests__/usePerformanceMetrics.test.tsx
+++ b/tui/src/hooks/__tests__/usePerformanceMetrics.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Tests for usePerformanceMetrics hook
+ * Issue #965: TUI Performance Metrics
+ */
+
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { createPerformanceTracker } from '../usePerformanceMetrics';
+
+describe('Performance Metrics Tracker', () => {
+  let tracker: ReturnType<typeof createPerformanceTracker>;
+
+  beforeEach(() => {
+    tracker = createPerformanceTracker();
+  });
+
+  describe('Timer Operations', () => {
+    test('startTimer returns unique timer ID', () => {
+      const id1 = tracker.startTimer('test');
+      const id2 = tracker.startTimer('test');
+      expect(id1).not.toBe(id2);
+      expect(id1).toContain('test-');
+      expect(id2).toContain('test-');
+    });
+
+    test('endTimer returns duration in ms', () => {
+      const timerId = tracker.startTimer('duration:test');
+      const duration = tracker.endTimer(timerId, 'duration:test');
+      expect(duration).toBeGreaterThanOrEqual(0);
+    });
+
+    test('endTimer with invalid timerId returns 0', () => {
+      const duration = tracker.endTimer('invalid-id', 'test');
+      expect(duration).toBe(0);
+    });
+
+    test('endTimer records metric', () => {
+      const timerId = tracker.startTimer('record:test');
+      tracker.endTimer(timerId, 'record:test');
+
+      const metric = tracker.getMetric('record:test');
+      expect(metric).not.toBeNull();
+      expect(metric?.name).toBe('record:test');
+      expect(metric?.count).toBe(1);
+    });
+  });
+
+  describe('Metric Calculations', () => {
+    test('calculates correct average', () => {
+      // Record multiple values by timing operations
+      for (let i = 0; i < 4; i++) {
+        const timerId = tracker.startTimer('avg:test');
+        tracker.endTimer(timerId, 'avg:test');
+      }
+
+      const metric = tracker.getMetric('avg:test');
+      expect(metric).not.toBeNull();
+      expect(metric?.count).toBe(4);
+      expect(metric?.average).toBeGreaterThanOrEqual(0);
+    });
+
+    test('tracks min value correctly', () => {
+      // First measurement
+      let timerId = tracker.startTimer('min:test');
+      tracker.endTimer(timerId, 'min:test');
+      const firstMetric = tracker.getMetric('min:test');
+      const firstMin = firstMetric?.min ?? Infinity;
+
+      // Second measurement
+      timerId = tracker.startTimer('min:test');
+      tracker.endTimer(timerId, 'min:test');
+      const secondMetric = tracker.getMetric('min:test');
+
+      expect(secondMetric?.min).toBeLessThanOrEqual(firstMin);
+    });
+
+    test('tracks max value correctly', () => {
+      const timerId = tracker.startTimer('max:test');
+      tracker.endTimer(timerId, 'max:test');
+
+      const metric = tracker.getMetric('max:test');
+      expect(metric?.max).toBeGreaterThanOrEqual(metric?.min ?? 0);
+    });
+
+    test('increments count on each measurement', () => {
+      for (let i = 1; i <= 5; i++) {
+        const timerId = tracker.startTimer('count:test');
+        tracker.endTimer(timerId, 'count:test');
+        const metric = tracker.getMetric('count:test');
+        expect(metric?.count).toBe(i);
+      }
+    });
+  });
+
+  describe('Metric Retrieval', () => {
+    test('getMetric returns null for unknown metric', () => {
+      const metric = tracker.getMetric('nonexistent');
+      expect(metric).toBeNull();
+    });
+
+    test('getMetric returns metric after recording', () => {
+      const timerId = tracker.startTimer('get:test');
+      tracker.endTimer(timerId, 'get:test');
+
+      const metric = tracker.getMetric('get:test');
+      expect(metric).not.toBeNull();
+      expect(metric?.name).toBe('get:test');
+    });
+
+    test('getAllMetrics returns empty array initially', () => {
+      const freshTracker = createPerformanceTracker();
+      const metrics = freshTracker.getAllMetrics();
+      expect(metrics).toEqual([]);
+    });
+
+    test('getAllMetrics returns all recorded metrics', () => {
+      tracker.endTimer(tracker.startTimer('a'), 'a');
+      tracker.endTimer(tracker.startTimer('b'), 'b');
+      tracker.endTimer(tracker.startTimer('c'), 'c');
+
+      const metrics = tracker.getAllMetrics();
+      expect(metrics.length).toBe(3);
+    });
+
+    test('getAllMetrics returns metrics sorted by name', () => {
+      tracker.endTimer(tracker.startTimer('zebra'), 'zebra');
+      tracker.endTimer(tracker.startTimer('apple'), 'apple');
+      tracker.endTimer(tracker.startTimer('mango'), 'mango');
+
+      const metrics = tracker.getAllMetrics();
+      expect(metrics[0].name).toBe('apple');
+      expect(metrics[1].name).toBe('mango');
+      expect(metrics[2].name).toBe('zebra');
+    });
+  });
+
+  describe('Clear Operations', () => {
+    test('clear removes all metrics', () => {
+      tracker.endTimer(tracker.startTimer('test1'), 'test1');
+      tracker.endTimer(tracker.startTimer('test2'), 'test2');
+      expect(tracker.getAllMetrics().length).toBe(2);
+
+      tracker.clear();
+      expect(tracker.getAllMetrics().length).toBe(0);
+    });
+
+    test('can record after clear', () => {
+      tracker.endTimer(tracker.startTimer('before'), 'before');
+      tracker.clear();
+      tracker.endTimer(tracker.startTimer('after'), 'after');
+
+      const metrics = tracker.getAllMetrics();
+      expect(metrics.length).toBe(1);
+      expect(metrics[0].name).toBe('after');
+    });
+  });
+
+  describe('Metric Names', () => {
+    test('supports poll: prefix for polling metrics', () => {
+      tracker.endTimer(tracker.startTimer('poll:agents'), 'poll:agents');
+      tracker.endTimer(tracker.startTimer('poll:channels'), 'poll:channels');
+
+      const metrics = tracker.getAllMetrics();
+      const pollMetrics = metrics.filter((m) => m.name.startsWith('poll:'));
+      expect(pollMetrics.length).toBe(2);
+    });
+
+    test('supports cmd: prefix for command metrics', () => {
+      tracker.endTimer(tracker.startTimer('cmd:status'), 'cmd:status');
+      tracker.endTimer(tracker.startTimer('cmd:list'), 'cmd:list');
+
+      const metrics = tracker.getAllMetrics();
+      const cmdMetrics = metrics.filter((m) => m.name.startsWith('cmd:'));
+      expect(cmdMetrics.length).toBe(2);
+    });
+
+    test('supports render: prefix for render metrics', () => {
+      tracker.endTimer(tracker.startTimer('render:dashboard'), 'render:dashboard');
+
+      const metric = tracker.getMetric('render:dashboard');
+      expect(metric).not.toBeNull();
+    });
+  });
+
+  describe('Metric Structure', () => {
+    test('metric has all required fields', () => {
+      tracker.endTimer(tracker.startTimer('structure:test'), 'structure:test');
+
+      const metric = tracker.getMetric('structure:test')!;
+      expect(metric).toHaveProperty('name');
+      expect(metric).toHaveProperty('value');
+      expect(metric).toHaveProperty('average');
+      expect(metric).toHaveProperty('min');
+      expect(metric).toHaveProperty('max');
+      expect(metric).toHaveProperty('count');
+      expect(metric).toHaveProperty('lastUpdated');
+    });
+
+    test('lastUpdated is a Date object', () => {
+      tracker.endTimer(tracker.startTimer('date:test'), 'date:test');
+
+      const metric = tracker.getMetric('date:test');
+      expect(metric?.lastUpdated).toBeInstanceOf(Date);
+    });
+
+    test('value equals last recorded duration', () => {
+      tracker.endTimer(tracker.startTimer('value:test'), 'value:test');
+      const first = tracker.getMetric('value:test')?.value;
+
+      tracker.endTimer(tracker.startTimer('value:test'), 'value:test');
+      const second = tracker.getMetric('value:test')?.value;
+
+      // Second value should be updated (may or may not equal first)
+      expect(second).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
+describe('Multiple Trackers', () => {
+  test('trackers are independent', () => {
+    const tracker1 = createPerformanceTracker();
+    const tracker2 = createPerformanceTracker();
+
+    tracker1.endTimer(tracker1.startTimer('tracker1:metric'), 'tracker1:metric');
+    tracker2.endTimer(tracker2.startTimer('tracker2:metric'), 'tracker2:metric');
+
+    expect(tracker1.getMetric('tracker2:metric')).toBeNull();
+    expect(tracker2.getMetric('tracker1:metric')).toBeNull();
+  });
+});

--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -102,3 +102,17 @@ export {
   type UseLogsResult,
   type LogSeverity,
 } from './useLogs';
+
+export {
+  usePerformanceMetrics,
+  createPerformanceTracker,
+  globalPerformanceTracker,
+  type PerformanceMetric,
+  type PerformanceMetrics,
+} from './usePerformanceMetrics';
+
+export {
+  PerformanceProvider,
+  usePerformance,
+  usePerformanceOptional,
+} from './PerformanceContext';

--- a/tui/src/hooks/usePerformanceMetrics.ts
+++ b/tui/src/hooks/usePerformanceMetrics.ts
@@ -1,0 +1,337 @@
+/**
+ * usePerformanceMetrics - TUI Performance Metrics Hook
+ * Issue #965: Track render cycles, command latency, and poll times
+ */
+
+import { useState, useCallback, useRef } from 'react';
+
+export interface PerformanceMetric {
+  /** Metric name */
+  name: string;
+  /** Latest value in ms */
+  value: number;
+  /** Average value in ms */
+  average: number;
+  /** Minimum value in ms */
+  min: number;
+  /** Maximum value in ms */
+  max: number;
+  /** Number of samples */
+  count: number;
+  /** Timestamp of last update */
+  lastUpdated: Date;
+}
+
+export interface PerformanceMetrics {
+  /** All tracked metrics */
+  metrics: Map<string, PerformanceMetric>;
+  /** Total number of measurements */
+  totalMeasurements: number;
+  /** Time since metrics started */
+  uptime: number;
+  /** Whether debug mode is enabled */
+  debugEnabled: boolean;
+}
+
+interface MetricData {
+  values: number[];
+  min: number;
+  max: number;
+  sum: number;
+  lastUpdated: Date;
+}
+
+const MAX_SAMPLES = 100; // Keep last 100 samples for average calculation
+
+/**
+ * Hook for tracking TUI performance metrics
+ * Provides timing functions for render cycles, commands, and polls
+ */
+export function usePerformanceMetrics() {
+  const [metrics, setMetrics] = useState<Map<string, PerformanceMetric>>(new Map());
+  const [totalMeasurements, setTotalMeasurements] = useState(0);
+  const [debugEnabled, setDebugEnabled] = useState(() => {
+    // Check for debug mode via env var
+    return process.env.BC_TUI_DEBUG === '1' || process.env.BC_TUI_DEBUG === 'true';
+  });
+
+  const startTimeRef = useRef(Date.now());
+  const dataRef = useRef<Map<string, MetricData>>(new Map());
+  const pendingTimersRef = useRef<Map<string, number>>(new Map());
+
+  /**
+   * Start timing an operation
+   * @param name - Unique name for this metric (e.g., "poll:agents", "render:dashboard")
+   * @returns Timer ID for use with endTimer
+   */
+  const startTimer = useCallback((name: string): string => {
+    const timerId = `${name}-${String(Date.now())}-${Math.random().toString(36).slice(2, 9)}`;
+    pendingTimersRef.current.set(timerId, performance.now());
+    return timerId;
+  }, []);
+
+  /**
+   * End timing an operation and record the metric
+   * @param timerId - Timer ID from startTimer
+   * @param name - Metric name (must match startTimer name for consistency)
+   */
+  const endTimer = useCallback((timerId: string, name: string): number => {
+    const startTime = pendingTimersRef.current.get(timerId);
+    if (startTime === undefined) {
+      return 0;
+    }
+
+    const duration = performance.now() - startTime;
+    pendingTimersRef.current.delete(timerId);
+
+    // Update internal data
+    let data = dataRef.current.get(name);
+    if (!data) {
+      data = { values: [], min: Infinity, max: -Infinity, sum: 0, lastUpdated: new Date() };
+      dataRef.current.set(name, data);
+    }
+
+    // Add new value, maintain max samples
+    data.values.push(duration);
+    if (data.values.length > MAX_SAMPLES) {
+      const removed = data.values.shift();
+      if (removed !== undefined) {
+        data.sum -= removed;
+      }
+    }
+    data.sum += duration;
+    data.min = Math.min(data.min, duration);
+    data.max = Math.max(data.max, duration);
+    data.lastUpdated = new Date();
+
+    // Update metrics state
+    const metric: PerformanceMetric = {
+      name,
+      value: duration,
+      average: data.sum / data.values.length,
+      min: data.min,
+      max: data.max,
+      count: data.values.length,
+      lastUpdated: data.lastUpdated,
+    };
+
+    setMetrics((prev) => new Map(prev).set(name, metric));
+    setTotalMeasurements((prev) => prev + 1);
+
+    return duration;
+  }, []);
+
+  /**
+   * Record a metric value directly (for external timing)
+   * @param name - Metric name
+   * @param value - Duration in ms
+   */
+  const recordMetric = useCallback((name: string, value: number): void => {
+    let data = dataRef.current.get(name);
+    if (!data) {
+      data = { values: [], min: Infinity, max: -Infinity, sum: 0, lastUpdated: new Date() };
+      dataRef.current.set(name, data);
+    }
+
+    data.values.push(value);
+    if (data.values.length > MAX_SAMPLES) {
+      const removed = data.values.shift();
+      if (removed !== undefined) {
+        data.sum -= removed;
+      }
+    }
+    data.sum += value;
+    data.min = Math.min(data.min, value);
+    data.max = Math.max(data.max, value);
+    data.lastUpdated = new Date();
+
+    const metric: PerformanceMetric = {
+      name,
+      value,
+      average: data.sum / data.values.length,
+      min: data.min,
+      max: data.max,
+      count: data.values.length,
+      lastUpdated: data.lastUpdated,
+    };
+
+    setMetrics((prev) => new Map(prev).set(name, metric));
+    setTotalMeasurements((prev) => prev + 1);
+  }, []);
+
+  /**
+   * Time an async operation
+   * @param name - Metric name
+   * @param fn - Async function to time
+   * @returns Result of the function
+   */
+  const timeAsync = useCallback(async <T>(name: string, fn: () => Promise<T>): Promise<T> => {
+    const timerId = startTimer(name);
+    try {
+      return await fn();
+    } finally {
+      endTimer(timerId, name);
+    }
+  }, [startTimer, endTimer]);
+
+  /**
+   * Time a sync operation
+   * @param name - Metric name
+   * @param fn - Sync function to time
+   * @returns Result of the function
+   */
+  const timeSync = useCallback(<T>(name: string, fn: () => T): T => {
+    const timerId = startTimer(name);
+    try {
+      return fn();
+    } finally {
+      endTimer(timerId, name);
+    }
+  }, [startTimer, endTimer]);
+
+  /**
+   * Get a specific metric by name
+   */
+  const getMetric = useCallback((name: string): PerformanceMetric | undefined => {
+    return metrics.get(name);
+  }, [metrics]);
+
+  /**
+   * Get all metrics as an array, sorted by name
+   */
+  const getAllMetrics = useCallback((): PerformanceMetric[] => {
+    return Array.from(metrics.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [metrics]);
+
+  /**
+   * Clear all metrics
+   */
+  const clearMetrics = useCallback((): void => {
+    setMetrics(new Map());
+    setTotalMeasurements(0);
+    dataRef.current.clear();
+    startTimeRef.current = Date.now();
+  }, []);
+
+  /**
+   * Toggle debug mode
+   */
+  const toggleDebug = useCallback((): void => {
+    setDebugEnabled((prev) => !prev);
+  }, []);
+
+  /**
+   * Get uptime in seconds
+   */
+  const getUptime = useCallback((): number => {
+    return (Date.now() - startTimeRef.current) / 1000;
+  }, []);
+
+  return {
+    // State
+    metrics,
+    totalMeasurements,
+    debugEnabled,
+
+    // Timing functions
+    startTimer,
+    endTimer,
+    recordMetric,
+    timeAsync,
+    timeSync,
+
+    // Accessors
+    getMetric,
+    getAllMetrics,
+    getUptime,
+
+    // Control
+    clearMetrics,
+    toggleDebug,
+  };
+}
+
+/**
+ * Create a global performance metrics instance for use outside React
+ */
+export function createPerformanceTracker() {
+  const data = new Map<string, MetricData>();
+  const pendingTimers = new Map<string, number>();
+
+  return {
+    startTimer(name: string): string {
+      const timerId = `${name}-${String(Date.now())}-${Math.random().toString(36).slice(2, 9)}`;
+      pendingTimers.set(timerId, performance.now());
+      return timerId;
+    },
+
+    endTimer(timerId: string, name: string): number {
+      const startTime = pendingTimers.get(timerId);
+      if (startTime === undefined) return 0;
+
+      const duration = performance.now() - startTime;
+      pendingTimers.delete(timerId);
+
+      let metricData = data.get(name);
+      if (!metricData) {
+        metricData = { values: [], min: Infinity, max: -Infinity, sum: 0, lastUpdated: new Date() };
+        data.set(name, metricData);
+      }
+
+      metricData.values.push(duration);
+      if (metricData.values.length > MAX_SAMPLES) {
+        const removed = metricData.values.shift();
+        if (removed !== undefined) {
+          metricData.sum -= removed;
+        }
+      }
+      metricData.sum += duration;
+      metricData.min = Math.min(metricData.min, duration);
+      metricData.max = Math.max(metricData.max, duration);
+      metricData.lastUpdated = new Date();
+
+      return duration;
+    },
+
+    getMetric(name: string): PerformanceMetric | null {
+      const metricData = data.get(name);
+      if (!metricData || metricData.values.length === 0) return null;
+
+      return {
+        name,
+        value: metricData.values[metricData.values.length - 1],
+        average: metricData.sum / metricData.values.length,
+        min: metricData.min,
+        max: metricData.max,
+        count: metricData.values.length,
+        lastUpdated: metricData.lastUpdated,
+      };
+    },
+
+    getAllMetrics(): PerformanceMetric[] {
+      const metrics: PerformanceMetric[] = [];
+      for (const [name, metricData] of data) {
+        if (metricData.values.length > 0) {
+          metrics.push({
+            name,
+            value: metricData.values[metricData.values.length - 1],
+            average: metricData.sum / metricData.values.length,
+            min: metricData.min,
+            max: metricData.max,
+            count: metricData.values.length,
+            lastUpdated: metricData.lastUpdated,
+          });
+        }
+      }
+      return metrics.sort((a, b) => a.name.localeCompare(b.name));
+    },
+
+    clear(): void {
+      data.clear();
+      pendingTimers.clear();
+    },
+  };
+}
+
+// Global tracker for use in service layer
+export const globalPerformanceTracker = createPerformanceTracker();


### PR DESCRIPTION
## Summary
- Adds TUI performance tracking infrastructure for Sprint 12 Phase 1
- Enables tracking of render cycles, command latency, and poll times
- Provides debug mode for performance visibility (BC_TUI_DEBUG=1)

## Components
- **usePerformanceMetrics** hook: Track render cycles, command latency
- **PerformanceContext**: Global metrics provider
- **PerformanceDebugPanel**: Debug overlay component
- **createPerformanceTracker**: Standalone tracker for service layer

## Features
- Timer-based metric recording (startTimer/endTimer)
- Direct metric recording (recordMetric)
- Async/sync timing helpers (timeAsync/timeSync)
- Rolling averages with min/max tracking
- Debug mode toggle via BC_TUI_DEBUG=1

## Usage
```typescript
// In hook/component
const { startTimer, endTimer, recordMetric } = usePerformance();

// Time a poll operation
const timerId = startTimer('poll:agents');
await fetchAgents();
endTimer(timerId, 'poll:agents');

// Or use timeAsync helper
await timeAsync('cmd:status', () => getStatus());
```

## Test plan
- [x] 22 new unit tests for performance tracker
- [x] All 1139 TUI tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)