### PR TITLE
fix(tui): Responsive tab bar for 80-column terminals (#982)

### DIFF
--- a/tui/src/__tests__/TabBar.test.tsx
+++ b/tui/src/__tests__/TabBar.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * TabBar responsive display mode tests for #982
+ *
+ * Verifies:
+ * - Display mode logic returns correct mode for terminal widths
+ * - TabBar renders properly with terminalWidth prop controlling display mode
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { TabBar } from '../navigation/TabBar';
+import { NavigationProvider } from '../navigation/NavigationContext';
+
+/** Wrapper to provide navigation context */
+function renderTabBar(terminalWidth: number) {
+  return render(
+    <NavigationProvider>
+      <TabBar terminalWidth={terminalWidth} />
+    </NavigationProvider>
+  );
+}
+
+describe('TabBar display mode logic', () => {
+  // Note: ink-testing-library renders at fixed 80 cols, so we test the logic
+  // indirectly by checking that the terminalWidth prop affects what labels are used
+
+  test('at 140 cols (full mode), uses full label "Dashboard"', () => {
+    const { lastFrame } = renderTabBar(140);
+    const output = lastFrame() ?? '';
+
+    // Full mode shows full labels - but rendering may truncate at 80 cols
+    // We verify by checking that Dashboard is attempted (even if truncated)
+    expect(output).toContain('Dashboar'); // May be truncated by 80-col renderer
+    expect(output).toContain('[1]');
+  });
+
+  test('at 100 cols (short mode), uses short labels', () => {
+    const { lastFrame } = renderTabBar(100);
+    const output = lastFrame() ?? '';
+
+    // Short mode uses abbreviated labels
+    expect(output).toContain('Dash');
+    expect(output).toContain('Agt');
+    expect(output).toContain('[1]');
+    expect(output).toContain('[2]');
+  });
+
+  test('at 60 cols (minimal mode), shows keys only', () => {
+    const { lastFrame } = renderTabBar(60);
+    const output = lastFrame() ?? '';
+
+    // Minimal mode shows only keys, no labels
+    expect(output).toContain('[1]');
+    expect(output).toContain('[2]');
+    expect(output).toContain('[3]');
+    expect(output).toContain('[?]');
+
+    // Should NOT contain any labels (not even short ones)
+    expect(output).not.toContain('Dash');
+    expect(output).not.toContain('Agt');
+  });
+
+  test('boundary: 120 cols triggers full mode', () => {
+    const { lastFrame } = renderTabBar(120);
+    const output = lastFrame() ?? '';
+
+    // At exactly 120, should be full mode
+    // Check for "Dashboar" which indicates full "Dashboard" was attempted
+    expect(output).toContain('Dashboar');
+  });
+
+  test('boundary: 119 cols triggers short mode', () => {
+    const { lastFrame } = renderTabBar(119);
+    const output = lastFrame() ?? '';
+
+    // At 119, should be short mode - look for short labels
+    expect(output).toContain('Dash');
+    // Full "Dashboard" should NOT appear (even truncated would be different)
+    expect(output).not.toContain('Dashboar');
+  });
+
+  test('boundary: 80 cols triggers short mode', () => {
+    const { lastFrame } = renderTabBar(80);
+    const output = lastFrame() ?? '';
+
+    // At 80, still short mode
+    expect(output).toContain('Dash');
+  });
+
+  test('boundary: 79 cols triggers minimal mode', () => {
+    const { lastFrame } = renderTabBar(79);
+    const output = lastFrame() ?? '';
+
+    // At 79, minimal mode - no labels
+    expect(output).toContain('[1]');
+    expect(output).not.toContain('Dash');
+  });
+});
+
+describe('TabBar structure', () => {
+  test('renders title "bc" prefix', () => {
+    const { lastFrame } = renderTabBar(100);
+    const output = lastFrame() ?? '';
+
+    // Title should be visible
+    expect(output).toContain('bc');
+    expect(output).toContain('|');
+  });
+
+  test('all tab keys are present at every display mode', () => {
+    const keys = ['[1]', '[2]', '[3]', '[4]', '[5]', '[6]', '[7]', '[8]', '[?]'];
+
+    // Test each display mode
+    for (const width of [60, 100, 140]) {
+      const { lastFrame } = renderTabBar(width);
+      const output = lastFrame() ?? '';
+
+      for (const key of keys) {
+        expect(output).toContain(key);
+      }
+    }
+  });
+
+  test('short labels map correctly', () => {
+    const { lastFrame } = renderTabBar(100);
+    const output = lastFrame() ?? '';
+
+    // Verify short labels are used in short mode
+    expect(output).toContain('[1] Dash');
+    expect(output).toContain('[2] Agt');
+    expect(output).toContain('[3] Chan');
+    expect(output).toContain('[4] Cost');
+    expect(output).toContain('[5] Cmd');
+    expect(output).toContain('[6] Role');
+    expect(output).toContain('[7] Log');
+    expect(output).toContain('[8] Tree');
+  });
+});
+
+describe('TabBar accessibility', () => {
+  test('keyboard navigation keys always visible', () => {
+    // Even in minimal mode, all keys should be visible for keyboard navigation
+    const { lastFrame } = renderTabBar(60);
+    const output = lastFrame() ?? '';
+
+    expect(output).toContain('[1]');
+    expect(output).toContain('[2]');
+    expect(output).toContain('[3]');
+    expect(output).toContain('[4]');
+    expect(output).toContain('[5]');
+    expect(output).toContain('[6]');
+    expect(output).toContain('[7]');
+    expect(output).toContain('[8]');
+    expect(output).toContain('[?]');
+  });
+});

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -13,19 +13,21 @@ export interface TabConfig {
   key: string;
   view: View;
   label: string;
+  /** Short label for narrow terminals (80-119 cols) */
+  shortLabel?: string;
   shortcut?: string;
 }
 
 export const DEFAULT_TABS: TabConfig[] = [
-  { key: '1', view: 'dashboard', label: 'Dashboard', shortcut: '1' },
-  { key: '2', view: 'agents', label: 'Agents', shortcut: '2' },
-  { key: '3', view: 'channels', label: 'Channels', shortcut: '3' },
-  { key: '4', view: 'costs', label: 'Costs', shortcut: '4' },
-  { key: '5', view: 'commands', label: 'Commands', shortcut: '5' },
-  { key: '6', view: 'roles', label: 'Roles', shortcut: '6' },
-  { key: '7', view: 'logs', label: 'Logs', shortcut: '7' },
-  { key: '8', view: 'worktrees', label: 'Worktrees', shortcut: '8' },
-  { key: '?', view: 'help', label: 'Help', shortcut: '?' },
+  { key: '1', view: 'dashboard', label: 'Dashboard', shortLabel: 'Dash', shortcut: '1' },
+  { key: '2', view: 'agents', label: 'Agents', shortLabel: 'Agt', shortcut: '2' },
+  { key: '3', view: 'channels', label: 'Channels', shortLabel: 'Chan', shortcut: '3' },
+  { key: '4', view: 'costs', label: 'Costs', shortLabel: 'Cost', shortcut: '4' },
+  { key: '5', view: 'commands', label: 'Commands', shortLabel: 'Cmd', shortcut: '5' },
+  { key: '6', view: 'roles', label: 'Roles', shortLabel: 'Role', shortcut: '6' },
+  { key: '7', view: 'logs', label: 'Logs', shortLabel: 'Log', shortcut: '7' },
+  { key: '8', view: 'worktrees', label: 'Worktrees', shortLabel: 'Tree', shortcut: '8' },
+  { key: '?', view: 'help', label: 'Help', shortLabel: '?', shortcut: '?' },
 ];
 
 // Breadcrumb item for showing navigation path

--- a/tui/src/navigation/TabBar.tsx
+++ b/tui/src/navigation/TabBar.tsx
@@ -1,51 +1,98 @@
 /**
- * TabBar - Navigation tab bar component
+ * TabBar - Responsive navigation tab bar component
+ *
+ * Display modes based on terminal width:
+ * - Full (>=120 cols): [1] Dashboard [2] Agents ...
+ * - Short (80-119 cols): [1] Dash [2] Agt ...
+ * - Minimal (<80 cols): [1] [2] [3] ...
  */
 
-import React from 'react';
-import { Box, Text } from 'ink';
+import React, { useMemo } from 'react';
+import { Box, Text, useStdout } from 'ink';
 import { useNavigation } from './NavigationContext';
+
+/** Terminal width thresholds for display modes */
+const FULL_WIDTH_THRESHOLD = 120;
+const SHORT_WIDTH_THRESHOLD = 80;
+
+/** Display mode for tab labels */
+type DisplayMode = 'full' | 'short' | 'minimal';
+
+/**
+ * Determine display mode based on terminal width
+ */
+function getDisplayMode(width: number): DisplayMode {
+  if (width >= FULL_WIDTH_THRESHOLD) return 'full';
+  if (width >= SHORT_WIDTH_THRESHOLD) return 'short';
+  return 'minimal';
+}
 
 export interface TabBarProps {
   /** Show app title before tabs */
   showTitle?: boolean;
   /** App title text */
   title?: string;
+  /** Override terminal width (for testing) */
+  terminalWidth?: number;
 }
 
 export function TabBar({
   showTitle = true,
   title = 'bc',
+  terminalWidth: overrideWidth,
 }: TabBarProps): React.ReactElement {
   const { currentView, tabs, canGoBack } = useNavigation();
+  const { stdout } = useStdout();
+
+  // Use override width for testing, otherwise use actual terminal width
+  const terminalWidth = overrideWidth ?? stdout.columns;
+  const displayMode = useMemo(() => getDisplayMode(terminalWidth), [terminalWidth]);
+
+  /**
+   * Get tab label based on display mode
+   */
+  const getTabLabel = (tab: { key: string; label: string; shortLabel?: string }): string => {
+    switch (displayMode) {
+      case 'full':
+        return tab.label;
+      case 'short':
+        return tab.shortLabel ?? tab.label;
+      case 'minimal':
+        return ''; // Just show key in minimal mode
+    }
+  };
 
   return (
     <Box flexShrink={0}>
       {showTitle && (
         <>
           <Text bold color="cyan">
-            {title}{' '}
+            {title}
           </Text>
-          <Text dimColor>|</Text>
+          <Text dimColor> |</Text>
         </>
       )}
-      {tabs.map((tab, index) => (
-        <React.Fragment key={tab.view}>
-          <Text> </Text>
-          <Text
-            bold={currentView === tab.view}
-            color={currentView === tab.view ? 'green' : undefined}
-            dimColor={currentView !== tab.view}
-          >
-            [{tab.key}] {tab.label}
-          </Text>
-          {index < tabs.length - 1 && <Text dimColor> </Text>}
-        </React.Fragment>
-      ))}
+      {tabs.map((tab) => {
+        const isActive = currentView === tab.view;
+        const label = getTabLabel(tab);
+
+        return (
+          <React.Fragment key={tab.view}>
+            <Text> </Text>
+            <Text
+              bold={isActive}
+              color={isActive ? 'green' : undefined}
+              dimColor={!isActive}
+            >
+              [{tab.key}]{label ? ` ${label}` : ''}
+            </Text>
+          </React.Fragment>
+        );
+      })}
       {canGoBack && (
         <>
-          <Text dimColor> | </Text>
-          <Text dimColor>[←] Back</Text>
+          <Text dimColor> |</Text>
+          <Text dimColor> [←]{displayMode !== 'minimal' ? ' Back' : ''}</Text>
         </>
       )}
     </Box>


### PR DESCRIPTION
## Summary
- Add responsive display modes to TabBar based on terminal width
- Full mode (>=120 cols): Full tab labels
- Short mode (80-119 cols): Abbreviated labels (Dash, Agt, Chan, etc.)
- Minimal mode (<80 cols): Keys only ([1] [2] [3]...)

## Changes
- `TabBar.tsx`: Add terminalWidth prop, getDisplayMode() logic, responsive rendering
- `NavigationContext.tsx`: Add shortLabel field to TabConfig with abbreviated labels
- `TabBar.test.tsx`: 11 tests covering display modes, boundaries, accessibility

## Test plan
- [x] Tests pass: `bun test TabBar.test.tsx` - 11 tests
- [x] Lint passes: `bun run lint`
- [x] Build passes: `bun run build`
- [ ] Manual: Resize terminal to 80 cols, verify tabs show abbreviated labels
- [ ] Manual: Resize to <80 cols, verify only keys shown

Fixes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)