### PR TITLE
fix(tui): Agents view garbled text at 80 columns (#985)

### DIFF
--- a/tui/src/components/Table.tsx
+++ b/tui/src/components/Table.tsx
@@ -47,8 +47,10 @@ export function Table<T>({
 
   return (
     <Box flexDirection="column">
-      {/* Header Row */}
-      <Box borderStyle="single" borderBottom={false}>
+      {/* Header Row - #985 fix: removed borderStyle to avoid width issues at 80 cols */}
+      <Box>
+        {/* Match data row selection indicator space */}
+        <Text>{'  '}</Text>
         {columns.map((col, i) => (
           <Box key={i} width={col.width ?? 15} paddingRight={1}>
             <Text bold color="cyan">
@@ -95,14 +97,19 @@ const TableRow = memo(function TableRow<T>({
   rowIndex,
   isSelected,
 }: TableRowProps<T>) {
+  // #985 fix: Use color highlighting instead of borderStyle="double" which causes
+  // garbled text on some terminals at 80 columns. Selection indicator uses arrow
+  // prefix and cyan color for visibility without adding border width.
   return (
-    <Box borderStyle={isSelected ? 'double' : undefined}>
+    <Box>
+      {/* Selection indicator - fixed width arrow */}
+      <Text color={isSelected ? 'cyan' : undefined}>{isSelected ? '▸ ' : '  '}</Text>
       {columns.map((col, colIndex) => (
         <Box key={colIndex} width={col.width ?? 15} paddingRight={1}>
           {col.render ? (
             col.render(item, rowIndex)
           ) : (
-            <Text>
+            <Text color={isSelected ? 'cyan' : undefined}>
               {String((item as Record<string, unknown>)[col.key as string] ?? '')}
             </Text>
           )}


### PR DESCRIPTION
## Summary
- **P1 FIX**: Agents view no longer displays garbled text at 80-column terminal width
- Removed `borderStyle="double"` which caused Unicode box-drawing issues
- Replaced with arrow selection indicator (▸) and cyan color highlighting
- Removed header border for consistent width calculation

## Test plan
- [x] TUI lint passes
- [x] TUI tests pass (1139 pass, 147 skip, 0 fail)
- [ ] Manual test at 80x24 terminal - verify no garbled text
- [ ] Verify selection is clearly visible with arrow indicator

Fixes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)