### PR TITLE
fix(cli): Roles view shows correct agent counts (#968)

### DIFF
--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -171,13 +171,17 @@ func runRoleList(cmd *cobra.Command, args []string) error {
 	}
 
 	// Load agents to count per role
+	// #968 fix: Must call RefreshState() to sync with tmux sessions,
+	// otherwise agent list is empty/stale (same pattern as runStatus)
 	agentCounts := make(map[string]int)
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
 	if loadErr := mgr.LoadState(); loadErr == nil {
-		agents := mgr.ListAgents()
-		for _, ag := range agents {
-			agentRole := string(ag.Role)
-			agentCounts[agentRole]++
+		if refreshErr := mgr.RefreshState(); refreshErr == nil {
+			agents := mgr.ListAgents()
+			for _, ag := range agents {
+				agentRole := string(ag.Role)
+				agentCounts[agentRole]++
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Fix Roles view showing 0 agents for all roles
- Add `RefreshState()` call to sync with tmux sessions before counting

## Root Cause
`bc role list` only called `LoadState()` but not `RefreshState()`, resulting in empty/stale agent list. Dashboard showed correct counts because it computes them client-side from `bc status` response (which DOES call RefreshState).

## Changes
- `role.go`: Add `RefreshState()` call after `LoadState()`, matching pattern from `runStatus()`

## Test Plan
- [x] Go build passes
- [x] Role-related tests pass
- [ ] Manual: Run `bc role list --json` - verify agent_count values match running agents

Fixes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)