### PR TITLE
feat(tui): Integrate workspace selector into navigation (#922)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -23,6 +23,7 @@ import { ChannelsView } from './components/ChannelsView';
 import { CostsView } from './components/CostsView';
 import { LogsView } from './views/LogsView';
 import { WorktreesView } from './views/WorktreesView';
+import { WorkspaceSelectorView } from './views/WorkspaceSelectorView';
 
 interface AppProps {
   /** Disable input handling (useful for testing) */
@@ -109,6 +110,8 @@ function ViewContent({ view, disableInput }: ViewContentProps): React.ReactEleme
       return <LogsView />;
     case 'worktrees':
       return <WorktreesView />;
+    case 'workspaces':
+      return <WorkspaceSelectorView />;
     case 'help':
       return <HelpView />;
     default:

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useContext, useState, useCallback, useMemo } from
 import type { ReactNode } from 'react';
 
 // View types for navigation
-export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'help' | 'commands' | 'roles' | 'logs' | 'worktrees';
+export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'help' | 'commands' | 'roles' | 'logs' | 'worktrees' | 'workspaces';
 
 // Tab configuration
 export interface TabConfig {
@@ -27,6 +27,7 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: '6', view: 'roles', label: 'Roles', shortLabel: 'Role', shortcut: '6' },
   { key: '7', view: 'logs', label: 'Logs', shortLabel: 'Log', shortcut: '7' },
   { key: '8', view: 'worktrees', label: 'Worktrees', shortLabel: 'Tree', shortcut: '8' },
+  { key: '9', view: 'workspaces', label: 'Workspaces', shortLabel: 'Wksp', shortcut: '9' },
   { key: '?', view: 'help', label: 'Help', shortLabel: '?', shortcut: '?' },
 ];
 


### PR DESCRIPTION
## Summary
- Add WorkspaceSelectorView to TUI navigation system
- New tab [9] Workspaces accessible via shortcut key 9
- Completes TUI integration for workspace discovery feature

## Changes
| File | Description |
|------|-------------|
| NavigationContext.tsx | Add 'workspaces' to View type, add tab config |
| app.tsx | Import WorkspaceSelectorView, add case in ViewContent |

## Features (already implemented in WorkspaceSelectorView)
- Lists registered and discovered workspaces
- Separates registered vs discovered workspaces visually
- Supports v2/v1 filter toggle (v key)
- Shows workspace details on Enter
- Keyboard navigation: j/k, g/G, r (refresh), q (back)

## Test plan
- [x] TUI lint passes
- [x] TUI build passes (TypeScript)
- [x] TUI tests pass (1178 pass)
- [ ] Manual: Press 9 to navigate to Workspaces tab
- [ ] Manual: Verify workspace list displays correctly
- [ ] Manual: Test keyboard navigation (j/k, Enter, q)

Fixes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)