### PR TITLE
fix: Replace cooking metaphors with clearer status terms (#970)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -559,7 +559,7 @@ func runAgentList(cmd *cobra.Command, args []string) error {
 			uptime = formatDuration(time.Since(a.StartedAt))
 		}
 
-		task := a.Task
+		task := normalizeTask(a.Task)
 		if task == "" {
 			task = "-"
 		}
@@ -669,7 +669,7 @@ func runAgentShow(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Worktree: %s\n", a.WorktreeDir)
 	}
 	if a.Task != "" {
-		fmt.Printf("Task: %s\n", a.Task)
+		fmt.Printf("Task: %s\n", normalizeTask(a.Task))
 	}
 	if a.Tool != "" {
 		fmt.Printf("Tool: %s\n", a.Tool)

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -160,7 +160,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			uptime = formatDuration(time.Since(a.StartedAt))
 		}
 
-		task := a.Task
+		task := normalizeTask(a.Task)
 		if task == "" {
 			task = "-"
 		}
@@ -277,6 +277,28 @@ func formatDuration(d time.Duration) string {
 		return fmt.Sprintf("%dm %ds", m, s)
 	}
 	return fmt.Sprintf("%ds", s)
+}
+
+// normalizeTask transforms cooking metaphors in Claude Code's status line
+// to clearer terminology. Issue #970.
+func normalizeTask(task string) string {
+	// Map cooking metaphors to clear terms
+	replacements := []struct {
+		old, new string
+	}{
+		{"Sautéed", "Working"},
+		{"Sauteed", "Working"}, // ASCII fallback
+		{"Cooked", "Processed"},
+		{"Cogitated", "Thinking"},
+		{"Marinated", "Idle"},
+		{"Frolicking", "Active"},
+	}
+	for _, r := range replacements {
+		if strings.Contains(task, r.old) {
+			return strings.Replace(task, r.old, r.new, 1)
+		}
+	}
+	return task
 }
 
 func colorState(s agent.State) string {

--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -14,6 +14,28 @@ const useSafeInput = (handler: Parameters<typeof inkUseInput>[0]) => {
   }
 };
 
+/**
+ * Normalize task status by replacing cooking metaphors with clearer terms.
+ * Issue #970 - Replace cooking terminology from Claude Code status line.
+ */
+function normalizeTask(task: string | undefined): string {
+  if (!task) return '(no task)';
+  const replacements: [string, string][] = [
+    ['Sautéed', 'Working'],
+    ['Sauteed', 'Working'], // ASCII fallback
+    ['Cooked', 'Processed'],
+    ['Cogitated', 'Thinking'],
+    ['Marinated', 'Idle'],
+    ['Frolicking', 'Active'],
+  ];
+  for (const [old, replacement] of replacements) {
+    if (task.includes(old)) {
+      return task.replace(old, replacement);
+    }
+  }
+  return task;
+}
+
 interface AgentDetailViewProps {
   agent: Agent;
   onBack?: () => void;
@@ -130,7 +152,7 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
           <Box marginTop={1}>
             <Text>State: </Text>
             <StatusBadge state={agent.state} />
-            <Text dimColor> | Task: {agent.task || 'none'}</Text>
+            <Text dimColor> | Task: {normalizeTask(agent.task)}</Text>
           </Box>
         </Box>
       </Box>
@@ -210,7 +232,7 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
           <Text bold color="white">Task</Text>
         </Box>
         <Box paddingLeft={2}>
-          <Text wrap="wrap">{agent.task || '(no task)'}</Text>
+          <Text wrap="wrap">{normalizeTask(agent.task)}</Text>
         </Box>
 
         <Box marginY={1}>

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -16,6 +16,28 @@ interface AgentsViewProps {
 /** Action feedback display duration in ms */
 const ACTION_FEEDBACK_DURATION = 2500;
 
+/**
+ * Normalize task status by replacing cooking metaphors with clearer terms.
+ * Issue #970 - Replace cooking terminology from Claude Code status line.
+ */
+function normalizeTask(task: string | undefined): string {
+  if (!task) return '-';
+  const replacements: [string, string][] = [
+    ['Sautéed', 'Working'],
+    ['Sauteed', 'Working'], // ASCII fallback
+    ['Cooked', 'Processed'],
+    ['Cogitated', 'Thinking'],
+    ['Marinated', 'Idle'],
+    ['Frolicking', 'Active'],
+  ];
+  for (const [old, replacement] of replacements) {
+    if (task.includes(old)) {
+      return task.replace(old, replacement);
+    }
+  }
+  return task;
+}
+
 /** Available agent actions */
 type AgentAction = 'stop' | 'kill' | 'restart' | 'attach';
 
@@ -174,7 +196,7 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
       width: 32,
       render: (agent) => (
         <Text wrap="truncate">
-          {agent.task ? agent.task.slice(0, 30) : '-'}
+          {normalizeTask(agent.task).slice(0, 30)}
         </Text>
       ),
     },


### PR DESCRIPTION
## Summary

- Replace Claude Code's cooking terminology in task status display with clearer terms:
  - "Sautéed" → "Working"
  - "Cooked" → "Processed"
  - "Cogitated" → "Thinking"
  - "Marinated" → "Idle"
  - "Frolicking" → "Active"
- Applied consistently across CLI (`bc status`, `bc agent list`, `bc agent show`) and TUI (AgentsView, AgentDetailView)

## Test plan

- [ ] Run `bc agent list` and verify cooking terms are transformed
- [ ] Run `bc status` and verify cooking terms are transformed
- [ ] Run `bc agent show <agent>` and verify task display is normalized
- [ ] Open TUI and verify task column shows normalized terms
- [ ] Open agent detail view in TUI and verify task is normalized

Closes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)