### PR TITLE
feat(tui): Render markdown in channel messages (#972)

### DIFF
--- a/tui/src/__tests__/MentionText.test.tsx
+++ b/tui/src/__tests__/MentionText.test.tsx
@@ -135,4 +135,85 @@ describe('MentionText', () => {
     expect(output).toContain('Line 1');
     expect(output).toContain('Line 2');
   });
+
+  // #972: Markdown rendering tests
+  describe('markdown rendering', () => {
+    test('renders **bold** text', () => {
+      const { lastFrame } = render(<MentionText text="This is **bold** text" />);
+      const output = lastFrame() ?? '';
+      expect(output).toContain('This is');
+      expect(output).toContain('bold');
+      expect(output).toContain('text');
+      // Should NOT contain the asterisks
+      expect(output).not.toContain('**');
+    });
+
+    test('renders __bold__ text (underscore style)', () => {
+      const { lastFrame } = render(<MentionText text="This is __bold__ text" />);
+      const output = lastFrame() ?? '';
+      expect(output).toContain('bold');
+      expect(output).not.toContain('__');
+    });
+
+    test('renders *italic* text', () => {
+      const { lastFrame } = render(<MentionText text="This is *italic* text" />);
+      const output = lastFrame() ?? '';
+      expect(output).toContain('italic');
+      // Single asterisks should be removed
+      expect(output).not.toMatch(/\*italic\*/);
+    });
+
+    test('renders _italic_ text (underscore style)', () => {
+      const { lastFrame } = render(<MentionText text="This is _italic_ text" />);
+      const output = lastFrame() ?? '';
+      expect(output).toContain('italic');
+      expect(output).not.toContain('_italic_');
+    });
+
+    test('renders `code` text', () => {
+      const { lastFrame } = render(<MentionText text="Run `npm install` first" />);
+      const output = lastFrame() ?? '';
+      expect(output).toContain('npm install');
+      expect(output).not.toContain('`');
+    });
+
+    test('renders mixed markdown and mentions', () => {
+      const { lastFrame } = render(
+        <MentionText text="@eng-01 please **review** the `code`" />
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('@eng-01');
+      expect(output).toContain('review');
+      expect(output).toContain('code');
+      expect(output).not.toContain('**');
+      expect(output).not.toContain('`');
+    });
+
+    test('renders multiple markdown elements', () => {
+      const { lastFrame } = render(
+        <MentionText text="**Bold** and *italic* and `code`" />
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Bold');
+      expect(output).toContain('italic');
+      expect(output).toContain('code');
+    });
+
+    test('handles markdown with self-mention', () => {
+      const { lastFrame } = render(
+        <MentionText text="**Important:** @eng-03 needs to fix this" currentUser="eng-03" />
+      );
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Important');
+      expect(output).toContain('@eng-03');
+    });
+
+    test('handles unmatched markdown gracefully', () => {
+      // Single asterisk without closing should be treated as plain text
+      const { lastFrame } = render(<MentionText text="5 * 3 = 15" />);
+      const output = lastFrame() ?? '';
+      expect(output).toContain('5');
+      expect(output).toContain('15');
+    });
+  });
 });

--- a/tui/src/components/MentionText.tsx
+++ b/tui/src/components/MentionText.tsx
@@ -7,10 +7,103 @@ export interface MentionTextProps {
 }
 
 /**
- * Text component that highlights @mentions
+ * Token types for markdown/mention parsing
+ */
+type TokenType = 'text' | 'bold' | 'italic' | 'code' | 'mention' | 'broadcast' | 'self-mention';
+
+interface Token {
+  type: TokenType;
+  content: string;
+  index: number;
+}
+
+/**
+ * Parse text into tokens for markdown and mentions
+ * #972 fix: Added markdown rendering support
  *
+ * Supports:
+ * - **bold** or __bold__
+ * - *italic* or _italic_
+ * - `code`
+ * - @mentions
+ */
+function parseFormattedText(text: string, currentUser?: string): Token[] {
+  const tokens: Token[] = [];
+
+  // Combined pattern for all formatting
+  // Order matters: longer patterns first to avoid partial matches
+  const pattern = /(\*\*[^*]+\*\*|__[^_]+__|`[^`]+`|\*[^*]+\*|_[^_]+_|@\w+[-\w]*)/g;
+
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    // Add plain text before this match
+    if (match.index > lastIndex) {
+      tokens.push({
+        type: 'text',
+        content: text.slice(lastIndex, match.index),
+        index: lastIndex,
+      });
+    }
+
+    const matched = match[0];
+    let type: TokenType = 'text';
+    let content = matched;
+
+    if (matched.startsWith('**') && matched.endsWith('**')) {
+      type = 'bold';
+      content = matched.slice(2, -2);
+    } else if (matched.startsWith('__') && matched.endsWith('__')) {
+      type = 'bold';
+      content = matched.slice(2, -2);
+    } else if (matched.startsWith('`') && matched.endsWith('`')) {
+      type = 'code';
+      content = matched.slice(1, -1);
+    } else if ((matched.startsWith('*') && matched.endsWith('*')) ||
+               (matched.startsWith('_') && matched.endsWith('_'))) {
+      type = 'italic';
+      content = matched.slice(1, -1);
+    } else if (matched.startsWith('@')) {
+      const username = matched.slice(1);
+      if (username === 'all' || username === 'everyone') {
+        type = 'broadcast';
+      } else if (currentUser && username === currentUser) {
+        type = 'self-mention';
+      } else {
+        type = 'mention';
+      }
+      content = matched;
+    }
+
+    tokens.push({ type, content, index: match.index });
+    lastIndex = match.index + matched.length;
+  }
+
+  // Add remaining text
+  if (lastIndex < text.length) {
+    tokens.push({
+      type: 'text',
+      content: text.slice(lastIndex),
+      index: lastIndex,
+    });
+  }
+
+  return tokens;
+}
+
+/**
+ * Text component that renders markdown and @mentions
+ * #972 fix: Added markdown rendering support
+ *
+ * Markdown:
+ * - **bold** or __bold__: Bold text
+ * - *italic* or _italic_: Dim text
+ * - `code`: Magenta colored text
+ *
+ * Mentions:
  * - @username: Cyan color
- * - @currentUser: Bold cyan (self-mention)
+ * - @currentUser: Bold cyan inverse (self-mention)
  * - @all/@everyone: Yellow (broadcast)
  */
 export const MentionText: React.FC<MentionTextProps> = ({
@@ -22,52 +115,59 @@ export const MentionText: React.FC<MentionTextProps> = ({
     return <Text dimColor>(empty)</Text>;
   }
 
-  // Pattern to match @mentions
-  const mentionPattern = /@(\w+[-\w]*)/g;
+  const tokens = parseFormattedText(text, currentUser);
   const parts: React.ReactNode[] = [];
-  let lastIndex = 0;
-  let match: RegExpExecArray | null;
 
-  while ((match = mentionPattern.exec(text)) !== null) {
-    // Add text before the mention as plain string (not wrapped in <Text>)
-    // Wrapping in <Text> breaks Ink's width calculation for wrap="wrap"
-    if (match.index > lastIndex) {
-      parts.push(text.slice(lastIndex, match.index));
+  for (const token of tokens) {
+    const key = `token-${String(token.index)}`;
+
+    switch (token.type) {
+      case 'bold':
+        parts.push(
+          <Text key={key} bold>
+            {token.content}
+          </Text>
+        );
+        break;
+      case 'italic':
+        parts.push(
+          <Text key={key} dimColor>
+            {token.content}
+          </Text>
+        );
+        break;
+      case 'code':
+        parts.push(
+          <Text key={key} color="magenta">
+            {token.content}
+          </Text>
+        );
+        break;
+      case 'broadcast':
+        parts.push(
+          <Text key={key} color="yellow" bold>
+            {token.content}
+          </Text>
+        );
+        break;
+      case 'self-mention':
+        parts.push(
+          <Text key={key} color="cyan" bold inverse>
+            {token.content}
+          </Text>
+        );
+        break;
+      case 'mention':
+        parts.push(
+          <Text key={key} color="cyan">
+            {token.content}
+          </Text>
+        );
+        break;
+      default:
+        // Plain text - add as string without wrapping
+        parts.push(token.content);
     }
-
-    const mention = match[0];
-    const username = match[1];
-
-    // Determine mention type and styling
-    const isSelfMention = currentUser && username === currentUser;
-    const isBroadcast = username === 'all' || username === 'everyone';
-
-    if (isBroadcast) {
-      parts.push(
-        <Text key={`mention-${String(match.index)}`} color="yellow" bold>
-          {mention}
-        </Text>
-      );
-    } else if (isSelfMention) {
-      parts.push(
-        <Text key={`mention-${String(match.index)}`} color="cyan" bold inverse>
-          {mention}
-        </Text>
-      );
-    } else {
-      parts.push(
-        <Text key={`mention-${String(match.index)}`} color="cyan">
-          {mention}
-        </Text>
-      );
-    }
-
-    lastIndex = match.index + mention.length;
-  }
-
-  // Add remaining text as plain string (not wrapped in <Text>)
-  if (lastIndex < text.length) {
-    parts.push(text.slice(lastIndex));
   }
 
   return <Text wrap="wrap">{parts}</Text>;


### PR DESCRIPTION
## Summary
Channel messages now render markdown formatting instead of showing raw syntax like `**bold**`.

**Supported markdown:**
| Syntax | Rendering |
|--------|-----------|
| `**bold**` or `__bold__` | Bold text |
| `*italic*` or `_italic_` | Dim text |
| \`code\` | Magenta text |

## Changes
- Added `parseFormattedText()` function with token-based parsing
- Extended MentionText to render markdown alongside @mentions
- Both markdown and mentions work together: `@eng-01 please **review** the \`code\``

## Test plan
- [x] TUI lint passes
- [x] TUI tests pass (1187 pass, +9 new markdown tests)
- [ ] Manual test: send message with markdown formatting
- [ ] Verify bold, italic, and code render correctly
- [ ] Verify @mentions still work alongside markdown

Fixes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)