### PR TITLE
fix(cli): Make bc agent default to list for consistency (#925)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -34,7 +34,10 @@ Examples:
   bc agent stop eng-01                   # Stop agent
   bc agent broadcast "check status"      # Send to all agents
   bc agent send-to-role engineer "test"  # Send to all engineers
+  bc agent                               # List all agents (same as bc agent list)
   bc agent send-pattern "eng-*" "hello"  # Send to matching agents`,
+	// #925: Default to list for consistency with bc channel
+	RunE: runAgentList,
 }
 
 // agentCreateCmd creates a new agent (replaces bc spawn)


### PR DESCRIPTION
## Summary

- Make `bc agent` (without subcommand) equivalent to `bc agent list`
- Consistent with existing `bc channel` behavior

## Before/After

| Command | Before | After |
|---------|--------|-------|
| `bc agent` | "Error: requires subcommand" | Lists all agents |
| `bc channel` | Lists all channels | Lists all channels |

## Test plan

- [x] `bc agent` now shows agent list
- [x] `bc agent list` still works as before
- [x] Linter passes
- [x] Tests pass

Fixes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)