### PR TITLE
feat(tui): Show 'N/A (manual entry)' for cost tokens (P3)

### DIFF
--- a/tui/src/components/CostsView.tsx
+++ b/tui/src/components/CostsView.tsx
@@ -57,11 +57,19 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
         </Box>
         <Box>
           <Text>Input Tokens: </Text>
-          <Text>{costs.total_input_tokens.toLocaleString()}</Text>
+          {costs.total_input_tokens === 0 && costs.total_cost > 0 ? (
+            <Text dimColor>N/A (manual entry)</Text>
+          ) : (
+            <Text>{costs.total_input_tokens.toLocaleString()}</Text>
+          )}
         </Box>
         <Box>
           <Text>Output Tokens: </Text>
-          <Text>{costs.total_output_tokens.toLocaleString()}</Text>
+          {costs.total_output_tokens === 0 && costs.total_cost > 0 ? (
+            <Text dimColor>N/A (manual entry)</Text>
+          ) : (
+            <Text>{costs.total_output_tokens.toLocaleString()}</Text>
+          )}
         </Box>
       </Panel>
 


### PR DESCRIPTION
## Summary
- Shows "N/A (manual entry)" instead of "0" for token counts when cost > 0 but tokens = 0
- This occurs when costs are manually entered via `bc cost manual`
- Improves UX clarity by indicating why tokens are not available

## Background
During #969 investigation, it was found that showing "0" tokens for manual entries was confusing. This P3 enhancement clarifies the display.

## Test plan
- [x] Lint passes
- [x] Unit tests pass
- [ ] Manual verification in TUI cost view

🤖 Generated with [Claude Code](https://claude.com/claude-code)