### PR TITLE
feat(config): Add performance configuration tunables (#1004)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -113,6 +113,31 @@ qa = 2
 session_prefix = "bc-"
 
 # =============================================================================
+# Performance Settings (Phase 5 - Epic #962)
+# =============================================================================
+[performance]
+# TUI polling intervals in milliseconds (min: 500ms)
+# Lower values = more responsive but higher CPU usage
+poll_interval_agents = 2000      # Agent status updates
+poll_interval_channels = 3000    # Channel message polling
+poll_interval_costs = 5000       # Cost data refresh
+poll_interval_status = 2000      # Dashboard status
+poll_interval_logs = 3000        # Log viewer refresh
+poll_interval_teams = 10000      # Team data refresh
+poll_interval_demons = 5000      # Scheduled tasks refresh
+
+# Cache TTLs in milliseconds
+# Higher values = less subprocess calls but potentially stale data
+cache_ttl_tmux = 2000            # Tmux session state cache
+cache_ttl_commands = 5000        # CLI command result cache
+
+# Adaptive polling thresholds (for useAdaptivePolling hook)
+adaptive_fast_interval = 1000    # When agents are actively working
+adaptive_normal_interval = 2000  # Normal operation
+adaptive_slow_interval = 4000    # Low activity period
+adaptive_max_interval = 8000     # Maximum backoff interval
+
+# =============================================================================
 # Agent Defaults (internal use)
 # =============================================================================
 [agent_legacy]

--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,22 @@ type MemoryConfig struct {
 	Path    string
 }
 
+type PerformanceConfig struct {
+	AdaptiveFastInterval   int64
+	AdaptiveMaxInterval    int64
+	AdaptiveNormalInterval int64
+	AdaptiveSlowInterval   int64
+	CacheTtlCommands       int64
+	CacheTtlTmux           int64
+	PollIntervalAgents     int64
+	PollIntervalChannels   int64
+	PollIntervalCosts      int64
+	PollIntervalDemons     int64
+	PollIntervalLogs       int64
+	PollIntervalStatus     int64
+	PollIntervalTeams      int64
+}
+
 type RosterConfig struct {
 	Engineers int64
 	Qa        int64
@@ -119,6 +135,21 @@ var (
 	Memory = MemoryConfig{
 		Backend: "file",
 		Path:    ".bc/memory",
+	}
+	Performance = PerformanceConfig{
+		AdaptiveFastInterval:   1000,
+		AdaptiveMaxInterval:    8000,
+		AdaptiveNormalInterval: 2000,
+		AdaptiveSlowInterval:   4000,
+		CacheTtlCommands:       5000,
+		CacheTtlTmux:           2000,
+		PollIntervalAgents:     2000,
+		PollIntervalChannels:   3000,
+		PollIntervalCosts:      5000,
+		PollIntervalDemons:     5000,
+		PollIntervalLogs:       3000,
+		PollIntervalStatus:     2000,
+		PollIntervalTeams:      10000,
 	}
 	Roster = RosterConfig{
 		Engineers: 4,

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -574,6 +574,22 @@ func printConfig(cfg *workspace.V2Config) {
 	fmt.Printf("  engineers: %d\n", cfg.Roster.Engineers)
 	fmt.Printf("  tech_leads: %d\n", cfg.Roster.TechLeads)
 	fmt.Printf("  qa: %d\n", cfg.Roster.QA)
+	fmt.Println()
+
+	fmt.Println("[performance]")
+	fmt.Printf("  poll_interval_agents: %d\n", cfg.Performance.PollIntervalAgents)
+	fmt.Printf("  poll_interval_channels: %d\n", cfg.Performance.PollIntervalChannels)
+	fmt.Printf("  poll_interval_costs: %d\n", cfg.Performance.PollIntervalCosts)
+	fmt.Printf("  poll_interval_status: %d\n", cfg.Performance.PollIntervalStatus)
+	fmt.Printf("  poll_interval_logs: %d\n", cfg.Performance.PollIntervalLogs)
+	fmt.Printf("  poll_interval_teams: %d\n", cfg.Performance.PollIntervalTeams)
+	fmt.Printf("  poll_interval_demons: %d\n", cfg.Performance.PollIntervalDemons)
+	fmt.Printf("  cache_ttl_tmux: %d\n", cfg.Performance.CacheTTLTmux)
+	fmt.Printf("  cache_ttl_commands: %d\n", cfg.Performance.CacheTTLCommands)
+	fmt.Printf("  adaptive_fast_interval: %d\n", cfg.Performance.AdaptiveFastInterval)
+	fmt.Printf("  adaptive_normal_interval: %d\n", cfg.Performance.AdaptiveNormalInterval)
+	fmt.Printf("  adaptive_slow_interval: %d\n", cfg.Performance.AdaptiveSlowInterval)
+	fmt.Printf("  adaptive_max_interval: %d\n", cfg.Performance.AdaptiveMaxInterval)
 }
 
 func printValue(key string, value any, indent int) error {

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -15,12 +15,13 @@ const ConfigVersion = 2
 
 // V2Config represents the TOML-based workspace configuration for bc v2.
 type V2Config struct {
-	Workspace WorkspaceConfig `toml:"workspace"`
-	Worktrees WorktreesConfig `toml:"worktrees"`
-	Tools     ToolsConfig     `toml:"tools"`
-	Memory    MemoryConfig    `toml:"memory"`
-	Channels  ChannelsConfig  `toml:"channels"`
-	Roster    RosterConfig    `toml:"roster"`
+	Workspace   WorkspaceConfig   `toml:"workspace"`
+	Worktrees   WorktreesConfig   `toml:"worktrees"`
+	Tools       ToolsConfig       `toml:"tools"`
+	Memory      MemoryConfig      `toml:"memory"`
+	Channels    ChannelsConfig    `toml:"channels"`
+	Roster      RosterConfig      `toml:"roster"`
+	Performance PerformanceConfig `toml:"performance"`
 }
 
 // WorkspaceConfig holds core workspace settings.
@@ -74,10 +75,40 @@ type RosterConfig struct {
 	QA             int `toml:"qa"`              // Number of QA agents (default: 2)
 }
 
+// PerformanceConfig configures TUI polling intervals and cache TTLs.
+// All values are in milliseconds. Minimum poll interval is 500ms.
+type PerformanceConfig struct {
+	// TUI polling intervals (min: 500ms)
+	PollIntervalAgents   int64 `toml:"poll_interval_agents"`   // Agent status updates (default: 2000)
+	PollIntervalChannels int64 `toml:"poll_interval_channels"` // Channel message polling (default: 3000)
+	PollIntervalCosts    int64 `toml:"poll_interval_costs"`    // Cost data refresh (default: 5000)
+	PollIntervalStatus   int64 `toml:"poll_interval_status"`   // Dashboard status (default: 2000)
+	PollIntervalLogs     int64 `toml:"poll_interval_logs"`     // Log viewer refresh (default: 3000)
+	PollIntervalTeams    int64 `toml:"poll_interval_teams"`    // Team data refresh (default: 10000)
+	PollIntervalDemons   int64 `toml:"poll_interval_demons"`   // Scheduled tasks refresh (default: 5000)
+
+	// Cache TTLs
+	CacheTTLTmux     int64 `toml:"cache_ttl_tmux"`     // Tmux session state cache (default: 2000)
+	CacheTTLCommands int64 `toml:"cache_ttl_commands"` // CLI command result cache (default: 5000)
+
+	// Adaptive polling thresholds (for useAdaptivePolling hook)
+	AdaptiveFastInterval   int64 `toml:"adaptive_fast_interval"`   // When agents are actively working (default: 1000)
+	AdaptiveNormalInterval int64 `toml:"adaptive_normal_interval"` // Normal operation (default: 2000)
+	AdaptiveSlowInterval   int64 `toml:"adaptive_slow_interval"`   // Low activity period (default: 4000)
+	AdaptiveMaxInterval    int64 `toml:"adaptive_max_interval"`    // Maximum backoff interval (default: 8000)
+}
+
 // Roster limits.
 const (
 	RosterMinPerRole = 0  // Minimum agents per role
 	RosterMaxPerRole = 10 // Maximum agents per role
+)
+
+// Performance limits.
+const (
+	PollIntervalMin = 500   // Minimum poll interval in ms
+	CacheTTLMin     = 100   // Minimum cache TTL in ms
+	CacheTTLMax     = 60000 // Maximum cache TTL in ms (1 minute)
 )
 
 // Validation errors.
@@ -93,6 +124,8 @@ var (
 	ErrRosterEngineersRange      = errors.New("roster.engineers must be between 0 and 10")
 	ErrRosterTechLeadsRange      = errors.New("roster.tech_leads must be between 0 and 10")
 	ErrRosterQARange             = errors.New("roster.qa must be between 0 and 10")
+	ErrPollIntervalTooLow        = errors.New("poll intervals must be at least 500ms")
+	ErrCacheTTLRange             = errors.New("cache TTL must be between 100ms and 60000ms")
 )
 
 // DefaultV2Config returns sensible defaults for a new v2 workspace.
@@ -130,6 +163,21 @@ func DefaultV2Config(name string) V2Config {
 			Engineers:      0,
 			TechLeads:      0,
 			QA:             0,
+		},
+		Performance: PerformanceConfig{
+			PollIntervalAgents:     2000,
+			PollIntervalChannels:   3000,
+			PollIntervalCosts:      5000,
+			PollIntervalStatus:     2000,
+			PollIntervalLogs:       3000,
+			PollIntervalTeams:      10000,
+			PollIntervalDemons:     5000,
+			CacheTTLTmux:           2000,
+			CacheTTLCommands:       5000,
+			AdaptiveFastInterval:   1000,
+			AdaptiveNormalInterval: 2000,
+			AdaptiveSlowInterval:   4000,
+			AdaptiveMaxInterval:    8000,
 		},
 	}
 }
@@ -195,6 +243,50 @@ func (c *V2Config) Validate() error {
 	}
 	if c.Roster.QA < RosterMinPerRole || c.Roster.QA > RosterMaxPerRole {
 		return ErrRosterQARange
+	}
+
+	// Performance validation (only validate if non-zero values are set)
+	if err := c.validatePerformance(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validatePerformance validates performance config values.
+// Zero values are acceptable (will use defaults).
+func (c *V2Config) validatePerformance() error {
+	p := c.Performance
+
+	// Validate poll intervals (must be >= 500ms if set)
+	pollIntervals := []int64{
+		p.PollIntervalAgents, p.PollIntervalChannels, p.PollIntervalCosts,
+		p.PollIntervalStatus, p.PollIntervalLogs, p.PollIntervalTeams,
+		p.PollIntervalDemons,
+	}
+	for _, interval := range pollIntervals {
+		if interval > 0 && interval < PollIntervalMin {
+			return ErrPollIntervalTooLow
+		}
+	}
+
+	// Validate adaptive intervals (must be >= 500ms if set)
+	adaptiveIntervals := []int64{
+		p.AdaptiveFastInterval, p.AdaptiveNormalInterval,
+		p.AdaptiveSlowInterval, p.AdaptiveMaxInterval,
+	}
+	for _, interval := range adaptiveIntervals {
+		if interval > 0 && interval < PollIntervalMin {
+			return ErrPollIntervalTooLow
+		}
+	}
+
+	// Validate cache TTLs
+	cacheTTLs := []int64{p.CacheTTLTmux, p.CacheTTLCommands}
+	for _, ttl := range cacheTTLs {
+		if ttl > 0 && (ttl < CacheTTLMin || ttl > CacheTTLMax) {
+			return ErrCacheTTLRange
+		}
 	}
 
 	return nil

--- a/tui/src/__tests__/testUtils.tsx
+++ b/tui/src/__tests__/testUtils.tsx
@@ -1,0 +1,37 @@
+/**
+ * Test utilities for TUI components
+ * Issue #1004: Provides test wrappers with necessary providers
+ */
+
+import React from 'react';
+import { render, type RenderOptions } from 'ink-testing-library';
+import { ConfigProvider } from '../config';
+import { ThemeProvider } from '../theme';
+import { FocusProvider } from '../navigation';
+
+/**
+ * Wrapper component that provides all necessary context providers for tests
+ */
+export function TestProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider config={{ mode: 'dark' }}>
+      <ConfigProvider>
+        <FocusProvider>
+          {children}
+        </FocusProvider>
+      </ConfigProvider>
+    </ThemeProvider>
+  );
+}
+
+/**
+ * Custom render function that wraps components with providers
+ */
+export function renderWithProviders(
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) {
+  return render(<TestProviders>{ui}</TestProviders>, options);
+}
+
+export { render };

--- a/tui/src/__tests__/views/RolesView.test.tsx
+++ b/tui/src/__tests__/views/RolesView.test.tsx
@@ -1,6 +1,7 @@
 /**
  * RolesView component tests
  * Issue #859 - Add Roles tab
+ * Issue #1004 - Updated to include ConfigProvider
  */
 
 import React from 'react';
@@ -8,11 +9,19 @@ import { render } from 'ink-testing-library';
 import { describe, it, expect, vi, beforeEach, mock } from 'bun:test';
 import { RolesView } from '../../views/RolesView';
 import { FocusProvider } from '../../navigation/FocusContext';
+import { ConfigProvider } from '../../config';
 
-// Helper to wrap component with FocusProvider
-const renderWithFocus = (ui: React.ReactElement) => {
-  return render(<FocusProvider>{ui}</FocusProvider>);
+// Helper to wrap component with required providers
+const renderWithProviders = (ui: React.ReactElement) => {
+  return render(
+    <ConfigProvider>
+      <FocusProvider>{ui}</FocusProvider>
+    </ConfigProvider>
+  );
 };
+
+// Legacy alias for backward compatibility
+const renderWithFocus = renderWithProviders;
 
 // Mock the bc service
 mock.module('../../services/bc', () => ({

--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -15,6 +15,7 @@ import {
 } from './navigation';
 import { ThemeProvider, useTheme, type ThemeMode } from './theme';
 import { UnreadProvider } from './hooks';
+import { ConfigProvider } from './config';
 import { Dashboard } from './views/Dashboard';
 import { AgentsView } from './views/AgentsView';
 import { CommandsView } from './views/CommandsView';
@@ -41,13 +42,15 @@ export function App({
 }: AppProps): React.ReactElement {
   return (
     <ThemeProvider config={{ mode: themeMode }}>
-      <NavigationProvider initialView={initialView}>
-        <FocusProvider>
-          <UnreadProvider>
-            <AppContent disableInput={disableInput} />
-          </UnreadProvider>
-        </FocusProvider>
-      </NavigationProvider>
+      <ConfigProvider>
+        <NavigationProvider initialView={initialView}>
+          <FocusProvider>
+            <UnreadProvider>
+              <AppContent disableInput={disableInput} />
+            </UnreadProvider>
+          </FocusProvider>
+        </NavigationProvider>
+      </ConfigProvider>
     </ThemeProvider>
   );
 }

--- a/tui/src/config/ConfigContext.tsx
+++ b/tui/src/config/ConfigContext.tsx
@@ -1,0 +1,116 @@
+/**
+ * ConfigContext - Provides workspace performance configuration to TUI components
+ * Issue #1004: Phase 5 - Performance configuration tunables
+ *
+ * Fetches performance config from `bc config show performance --json` and makes
+ * it available to all hooks via React context.
+ */
+
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import type { PerformanceConfig } from '../types';
+import { execBcJson } from '../services/bc';
+
+// Default performance config values (matches Go defaults)
+const DEFAULT_PERFORMANCE_CONFIG: PerformanceConfig = {
+  poll_interval_agents: 2000,
+  poll_interval_channels: 3000,
+  poll_interval_costs: 5000,
+  poll_interval_status: 2000,
+  poll_interval_logs: 3000,
+  poll_interval_teams: 10000,
+  poll_interval_demons: 5000,
+  cache_ttl_tmux: 2000,
+  cache_ttl_commands: 5000,
+  adaptive_fast_interval: 1000,
+  adaptive_normal_interval: 2000,
+  adaptive_slow_interval: 4000,
+  adaptive_max_interval: 8000,
+};
+
+interface ConfigContextValue {
+  /** Performance configuration from workspace config */
+  performance: PerformanceConfig;
+  /** Whether config is still loading */
+  loading: boolean;
+  /** Error if config fetch failed */
+  error: string | null;
+  /** Refresh config from workspace */
+  refresh: () => Promise<void>;
+}
+
+const ConfigContext = createContext<ConfigContextValue | null>(null);
+
+interface ConfigProviderProps {
+  children: React.ReactNode;
+}
+
+/**
+ * ConfigProvider - Provides workspace configuration context to children
+ */
+export function ConfigProvider({ children }: ConfigProviderProps): React.ReactElement {
+  const [performance, setPerformance] = useState<PerformanceConfig>(DEFAULT_PERFORMANCE_CONFIG);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchConfig = async () => {
+    try {
+      // Fetch performance section from workspace config
+      const response = await execBcJson<PerformanceConfig>(['config', 'show', 'performance']);
+
+      // Merge with defaults to handle missing values
+      setPerformance({
+        ...DEFAULT_PERFORMANCE_CONFIG,
+        ...response,
+      });
+      setError(null);
+    } catch (err) {
+      // On error, use defaults - config may not exist yet
+      setPerformance(DEFAULT_PERFORMANCE_CONFIG);
+      setError(err instanceof Error ? err.message : 'Failed to load config');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Fetch config on mount
+  useEffect(() => {
+    void fetchConfig();
+  }, []);
+
+  const value: ConfigContextValue = {
+    performance,
+    loading,
+    error,
+    refresh: fetchConfig,
+  };
+
+  return (
+    <ConfigContext.Provider value={value}>
+      {children}
+    </ConfigContext.Provider>
+  );
+}
+
+/**
+ * useConfig - Hook to access workspace configuration
+ * @throws Error if used outside of ConfigProvider
+ */
+export function useConfig(): ConfigContextValue {
+  const context = useContext(ConfigContext);
+  if (!context) {
+    throw new Error('useConfig must be used within a ConfigProvider');
+  }
+  return context;
+}
+
+/**
+ * usePerformanceConfig - Hook to access performance configuration only
+ * Returns the performance config object directly
+ */
+export function usePerformanceConfig(): PerformanceConfig {
+  const { performance } = useConfig();
+  return performance;
+}
+
+export { DEFAULT_PERFORMANCE_CONFIG };
+export default ConfigProvider;

--- a/tui/src/config/index.ts
+++ b/tui/src/config/index.ts
@@ -1,0 +1,7 @@
+// Config module exports
+export {
+  ConfigProvider,
+  useConfig,
+  usePerformanceConfig,
+  DEFAULT_PERFORMANCE_CONFIG,
+} from './ConfigContext';

--- a/tui/src/hooks/useAdaptivePolling.ts
+++ b/tui/src/hooks/useAdaptivePolling.ts
@@ -1,18 +1,17 @@
 /**
  * useAdaptivePolling - Adaptive polling with state-aware intervals
  * Issue #979: Optimize agent polling with adaptive intervals
+ * Issue #1004: Performance configuration tunables (Phase 5)
  *
  * Reduces CPU usage by slowing down polling when agents are idle
  * and speeding up when activity is detected.
+ *
+ * Interval values are configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { usePerformanceConfig } from '../config';
 
-/** Polling interval constants */
-const FAST_INTERVAL = 1000;    // 1s when agents are actively working
-const NORMAL_INTERVAL = 2000;  // 2s default
-const SLOW_INTERVAL = 4000;    // 4s when agents are idle
-const MAX_INTERVAL = 8000;     // 8s max backoff during extended quiet periods
 const BACKOFF_FACTOR = 1.5;    // Exponential backoff multiplier
 const IDLE_THRESHOLD_MS = 10000; // 10s without changes = idle state
 
@@ -63,14 +62,23 @@ export interface UseAdaptivePollingResult {
  * Adaptive polling hook that adjusts intervals based on activity
  *
  * Modes:
- * - fast: 1s interval - when agents are actively working
- * - normal: 2s interval - default state
- * - slow: 4s interval - when agents have been idle for a while
- * - backoff: 4-8s interval - exponential backoff during extended quiet
+ * - fast: configurable interval - when agents are actively working
+ * - normal: configurable interval - default state
+ * - slow: configurable interval - when agents have been idle for a while
+ * - backoff: up to max interval - exponential backoff during extended quiet
+ *
+ * Intervals are configured via workspace [performance] section.
  */
 export function useAdaptivePolling(
   options: UseAdaptivePollingOptions = {}
 ): UseAdaptivePollingResult {
+  // Get configurable intervals from workspace config
+  const perfConfig = usePerformanceConfig();
+  const FAST_INTERVAL = perfConfig.adaptive_fast_interval;
+  const NORMAL_INTERVAL = perfConfig.adaptive_normal_interval;
+  const SLOW_INTERVAL = perfConfig.adaptive_slow_interval;
+  const MAX_INTERVAL = perfConfig.adaptive_max_interval;
+
   const {
     initialInterval = NORMAL_INTERVAL,
     adaptiveEnabled = true,

--- a/tui/src/hooks/useAgents.ts
+++ b/tui/src/hooks/useAgents.ts
@@ -1,14 +1,18 @@
 /**
  * useAgents hook - Fetch and poll agent status
+ * Issue #1004: Performance configuration tunables (Phase 5)
  *
  * Includes debounce for working→idle transitions to prevent flickering.
  * When an agent transitions from 'working' to 'idle', the display state
  * remains 'working' for a debounce period before showing 'idle'.
+ *
+ * Poll interval is configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Agent, AgentState, BcResult } from '../types';
 import { getStatus } from '../services/bc';
+import { usePerformanceConfig } from '../config';
 
 /** Debounce period for working→idle transition (in ms) */
 const WORKING_TO_IDLE_DEBOUNCE_MS = 5000;
@@ -39,7 +43,11 @@ export interface UseAgentsResult extends BcResult<Agent[]> {
  * @returns Agent list with metadata and loading state
  */
 export function useAgents(options: UseAgentsOptions = {}): UseAgentsResult {
-  const { pollInterval = 2000, autoPoll = true } = options;
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultPollInterval = perfConfig.poll_interval_agents;
+
+  const { pollInterval = defaultPollInterval, autoPoll = true } = options;
 
   const [data, setData] = useState<Agent[] | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/tui/src/hooks/useChannels.ts
+++ b/tui/src/hooks/useChannels.ts
@@ -1,13 +1,17 @@
 /**
  * useChannels hook - Fetch and manage channel data
+ * Issue #1004: Performance configuration tunables (Phase 5)
+ *
+ * Poll interval is configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import type { Channel, ChannelMessage, BcResult } from '../types';
 import { getChannels, getChannelHistory, sendChannelMessage } from '../services/bc';
+import { usePerformanceConfig } from '../config';
 
 export interface UseChannelsOptions {
-  /** Polling interval in ms (default: 3000) */
+  /** Polling interval in ms (default: from config) */
   pollInterval?: number;
   /** Whether to poll automatically (default: true) */
   autoPoll?: boolean;
@@ -22,7 +26,11 @@ export interface UseChannelsResult extends BcResult<Channel[]> {
  * Hook to fetch and poll channel list
  */
 export function useChannels(options: UseChannelsOptions = {}): UseChannelsResult {
-  const { pollInterval = 3000, autoPoll = true } = options;
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultPollInterval = perfConfig.poll_interval_channels;
+
+  const { pollInterval = defaultPollInterval, autoPoll = true } = options;
 
   const [data, setData] = useState<Channel[] | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/tui/src/hooks/useCosts.ts
+++ b/tui/src/hooks/useCosts.ts
@@ -1,13 +1,17 @@
 /**
  * useCosts hook - Fetch and poll cost data
+ * Issue #1004: Performance configuration tunables (Phase 5)
+ *
+ * Poll interval is configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import type { CostSummary, BcResult } from '../types';
 import { getCostSummary } from '../services/bc';
+import { usePerformanceConfig } from '../config';
 
 export interface UseCostsOptions {
-  /** Polling interval in ms (default: 5000) */
+  /** Polling interval in ms (default: from config) */
   pollInterval?: number;
   /** Whether to poll automatically (default: true) */
   autoPoll?: boolean;
@@ -22,7 +26,11 @@ export interface UseCostsResult extends BcResult<CostSummary> {
  * Hook to fetch and optionally poll cost data
  */
 export function useCosts(options: UseCostsOptions = {}): UseCostsResult {
-  const { pollInterval = 5000, autoPoll = true } = options;
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultPollInterval = perfConfig.poll_interval_costs;
+
+  const { pollInterval = defaultPollInterval, autoPoll = true } = options;
 
   const [data, setData] = useState<CostSummary | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/tui/src/hooks/useDemons.ts
+++ b/tui/src/hooks/useDemons.ts
@@ -1,14 +1,18 @@
 /**
  * useDemons hook - Fetch and poll demon status
+ * Issue #1004: Performance configuration tunables (Phase 5)
+ *
+ * Poll interval is configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import type { Demon, BcResult } from '../types';
 import { getDemons, getDemonLogs, enableDemon, disableDemon, runDemon } from '../services/bc';
 import type { DemonRunLog } from '../types';
+import { usePerformanceConfig } from '../config';
 
 export interface UseDemonsOptions {
-  /** Polling interval in ms (default: 5000) */
+  /** Polling interval in ms (default: from config) */
   pollInterval?: number;
   /** Whether to poll automatically (default: true) */
   autoPoll?: boolean;
@@ -35,7 +39,11 @@ export interface UseDemonsResult extends BcResult<Demon[]> {
  * @returns Demon list with metadata and loading state
  */
 export function useDemons(options: UseDemonsOptions = {}): UseDemonsResult {
-  const { pollInterval = 5000, autoPoll = true } = options;
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultPollInterval = perfConfig.poll_interval_demons;
+
+  const { pollInterval = defaultPollInterval, autoPoll = true } = options;
 
   const [data, setData] = useState<Demon[] | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/tui/src/hooks/useLogs.ts
+++ b/tui/src/hooks/useLogs.ts
@@ -1,16 +1,20 @@
 /**
  * useLogs hook - Fetch and poll event logs for live activity feed
+ * Issue #1004: Performance configuration tunables (Phase 5)
+ *
+ * Poll interval is configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { LogEntry, BcResult } from '../types';
 import { getLogs } from '../services/bc';
+import { usePerformanceConfig } from '../config';
 
 /** Log severity level derived from event type */
 export type LogSeverity = 'info' | 'warn' | 'error';
 
 export interface UseLogsOptions {
-  /** Polling interval in ms (default: 3000) */
+  /** Polling interval in ms (default: from config) */
   pollInterval?: number;
   /** Whether to poll automatically (default: true) */
   autoPoll?: boolean;
@@ -53,8 +57,12 @@ function getSeverity(eventType: string): LogSeverity {
  * @returns Log entries with loading state and filtering
  */
 export function useLogs(options: UseLogsOptions = {}): UseLogsResult {
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultPollInterval = perfConfig.poll_interval_logs;
+
   const {
-    pollInterval = 3000,
+    pollInterval = defaultPollInterval,
     autoPoll = true,
     tail = 50,
     agent,

--- a/tui/src/hooks/usePolling.ts
+++ b/tui/src/hooks/usePolling.ts
@@ -1,14 +1,18 @@
 /**
  * usePolling - Enhanced polling hooks for real-time updates
  * Issue #551: Real-time polling with incremental fetch
+ * Issue #1004: Performance configuration tunables (Phase 5)
+ *
+ * Poll intervals are configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { ChannelMessage, Agent, BcResult } from '../types';
 import { getChannelHistory, getStatus } from '../services/bc';
+import { usePerformanceConfig } from '../config';
 
 export interface UsePollingOptions {
-  /** Polling interval in ms (default: 2000) */
+  /** Polling interval in ms (default: from config) */
   interval?: number;
   /** Whether to poll automatically (default: true) */
   enabled?: boolean;
@@ -47,9 +51,13 @@ export interface UseMessagePollingResult extends BcResult<ChannelMessage[]> {
 export function useMessagePolling(
   options: UseMessagePollingOptions
 ): UseMessagePollingResult {
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultInterval = perfConfig.poll_interval_channels;
+
   const {
     channel,
-    interval = 2000,
+    interval = defaultInterval,
     enabled = true,
     limit = 50,
     onNewMessages,
@@ -174,7 +182,11 @@ export interface UseAgentPollingResult extends BcResult<Agent[]> {
 export function useAgentPolling(
   options: UseAgentPollingOptions = {}
 ): UseAgentPollingResult {
-  const { interval = 2000, enabled = true, onStateChange, onUpdate } = options;
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultInterval = perfConfig.poll_interval_agents;
+
+  const { interval = defaultInterval, enabled = true, onStateChange, onUpdate } = options;
 
   const [data, setData] = useState<Agent[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -293,7 +305,11 @@ export interface UseCoordinatedPollingOptions {
 }
 
 export function useCoordinatedPolling(options: UseCoordinatedPollingOptions = {}) {
-  const { interval = 2000, enabled = true } = options;
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultInterval = perfConfig.poll_interval_status;
+
+  const { interval = defaultInterval, enabled = true } = options;
   const [tick, setTick] = useState(0);
   const [isPaused, setIsPaused] = useState(!enabled);
 

--- a/tui/src/hooks/useStatus.ts
+++ b/tui/src/hooks/useStatus.ts
@@ -1,13 +1,17 @@
 /**
  * useStatus hook - Workspace status and summary
+ * Issue #1004: Performance configuration tunables (Phase 5)
+ *
+ * Poll interval is configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import type { StatusResponse, BcResult } from '../types';
 import { getStatus } from '../services/bc';
+import { usePerformanceConfig } from '../config';
 
 export interface UseStatusOptions {
-  /** Polling interval in ms (default: 2000) */
+  /** Polling interval in ms (default: from config) */
   pollInterval?: number;
   /** Whether to poll automatically (default: true) */
   autoPoll?: boolean;
@@ -47,7 +51,11 @@ export interface UseStatusResult extends BcResult<WorkspaceStatus> {
  * @returns Workspace status with agent counts by state
  */
 export function useStatus(options: UseStatusOptions = {}): UseStatusResult {
-  const { pollInterval = 2000, autoPoll = true } = options;
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultPollInterval = perfConfig.poll_interval_status;
+
+  const { pollInterval = defaultPollInterval, autoPoll = true } = options;
 
   const [rawResponse, setRawResponse] = useState<StatusResponse | null>(null);
   const [data, setData] = useState<WorkspaceStatus | null>(null);

--- a/tui/src/hooks/useTeams.ts
+++ b/tui/src/hooks/useTeams.ts
@@ -1,14 +1,18 @@
 /**
  * useTeams hook - Fetch and manage teams data
  * Issue #556 - Teams view
+ * Issue #1004: Performance configuration tunables (Phase 5)
+ *
+ * Poll interval is configurable via workspace config [performance] section.
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import type { Team, BcResult } from '../types';
 import { getTeams, addTeamMember, removeTeamMember } from '../services/bc.js';
+import { usePerformanceConfig } from '../config';
 
 export interface UseTeamsOptions {
-  /** Polling interval in ms (default: 10000) */
+  /** Polling interval in ms (default: from config) */
   pollInterval?: number;
   /** Whether to poll automatically (default: true) */
   autoPoll?: boolean;
@@ -27,7 +31,11 @@ export interface UseTeamsResult extends BcResult<Team[]> {
  * Hook to fetch and manage teams data
  */
 export function useTeams(options: UseTeamsOptions = {}): UseTeamsResult {
-  const { pollInterval = 10000, autoPoll = true } = options;
+  // Get configurable poll interval from workspace config
+  const perfConfig = usePerformanceConfig();
+  const defaultPollInterval = perfConfig.poll_interval_teams;
+
+  const { pollInterval = defaultPollInterval, autoPoll = true } = options;
 
   const [data, setData] = useState<Team[] | null>(null);
   const [error, setError] = useState<string | null>(null);

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -233,3 +233,21 @@ export interface DiscoveredWorkspace {
 export interface WorkspacesResponse {
   workspaces: DiscoveredWorkspace[];
 }
+
+// Performance configuration for polling intervals and cache TTLs
+// Matches workspace.PerformanceConfig in Go
+export interface PerformanceConfig {
+  poll_interval_agents: number;
+  poll_interval_channels: number;
+  poll_interval_costs: number;
+  poll_interval_status: number;
+  poll_interval_logs: number;
+  poll_interval_teams: number;
+  poll_interval_demons: number;
+  cache_ttl_tmux: number;
+  cache_ttl_commands: number;
+  adaptive_fast_interval: number;
+  adaptive_normal_interval: number;
+  adaptive_slow_interval: number;
+  adaptive_max_interval: number;
+}

--- a/tui/src/views/__tests__/AgentDetailView.test.tsx
+++ b/tui/src/views/__tests__/AgentDetailView.test.tsx
@@ -3,18 +3,21 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import { AgentDetailView } from '../AgentDetailView';
 import { FocusProvider } from '../../navigation/FocusContext';
+import { ConfigProvider } from '../../config';
 import type { Agent } from '../../types';
 
 // NOTE: useInput tests require TTY stdin, so they're skipped in non-TTY test environments
 // These should be tested manually with: bc home -> select an agent -> verify detail view
 // The component rendering tests below verify the UI structure without useInput hook
 
-// Helper to wrap AgentDetailView with required providers
+// Helper to wrap AgentDetailView with required providers (Issue #1004 - added ConfigProvider)
 function renderAgentDetailView(agent: Agent, onBack?: () => void) {
   return render(
-    <FocusProvider>
-      <AgentDetailView agent={agent} onBack={onBack} />
-    </FocusProvider>
+    <ConfigProvider>
+      <FocusProvider>
+        <AgentDetailView agent={agent} onBack={onBack} />
+      </FocusProvider>
+    </ConfigProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

Phase 5 of Performance Epic #962: Add configurable polling intervals, cache TTLs, and adaptive polling thresholds.

**Backend changes:**
- Add `PerformanceConfig` struct to `V2Config` in `pkg/workspace/config.go`
- Add `[performance]` section to `config.toml` with tunables:
  - Poll intervals: `poll_interval_agents`, `channels`, `costs`, `status`, `logs`, `teams`, `demons`
  - Cache TTLs: `cache_ttl_tmux`, `cache_ttl_commands`
  - Adaptive thresholds: `adaptive_fast/normal/slow/max_interval`
- Add validation (min 500ms poll intervals, cache TTL range 100ms-60000ms)
- Update `bc config show` to display performance settings

**TUI changes:**
- Create `ConfigProvider` context in `tui/src/config/ConfigContext.tsx`
- Wire all polling hooks to use config values:
  - `useAgents`, `useChannels`, `useCosts`, `useLogs`
  - `useStatus`, `useTeams`, `useDemons`
  - `useAdaptivePolling`, `usePolling`
- Add `PerformanceConfig` type to `types/index.ts`
- Update tests with ConfigProvider wrapper

**Integration:**
Ready for Phase 3 integration with eng-03's command caching (#1006) for configurable cache TTLs.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/workspace/...` passes
- [x] TUI builds (`bun run build`)
- [x] TUI tests pass (1204 passing)
- [ ] Verify `bc config show performance` displays settings
- [ ] Verify changing config values affects TUI polling behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)