### PR TITLE
fix(tui): Remove unused React import in ChatMessage (#1009)

### DIFF
--- a/tui/src/components/ChatMessage.tsx
+++ b/tui/src/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import { memo } from 'react';
 import { Box, Text } from 'ink';
 import { MentionText } from './MentionText';
 import { ReactionBar } from './Reaction';


### PR DESCRIPTION
## Summary

- P0 hotfix for build failure caused by PR #1008
- Removes unused `React` import from ChatMessage.tsx
- Only `memo` is used, React namespace not needed

## Test plan

- [x] TUI lint passes (0 errors)
- [x] TUI tests pass (1204 pass, 0 fail)

Closes #1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)