### PR TITLE
fix(tui): Remove trivially inferred type annotation (#1026)

### DIFF
--- a/tui/src/__tests__/benchmarks/render-performance.test.tsx
+++ b/tui/src/__tests__/benchmarks/render-performance.test.tsx
@@ -55,7 +55,7 @@ function measureRenderTime(element: React.ReactElement): { time: number; output:
 // Utility to measure multiple renders and get statistics
 function benchmarkRender(
   element: React.ReactElement,
-  iterations: number = 10
+  iterations = 10
 ): { avg: number; min: number; max: number; p95: number } {
   const times: number[] = [];
 


### PR DESCRIPTION
## Summary
- Remove `: number` type annotation from `benchmarkRender` parameter in render-performance.test.tsx
- Type is trivially inferred from default value `= 10`

Fixes #1026

## Test plan
- [x] `bun run lint` passes (0 errors, 8 warnings)
- [x] Tests pass (1235)

🤖 Generated with [Claude Code](https://claude.com/claude-code)