### PR TITLE
feat(tui): Optimize dashboard whitespace with metrics panels (#1041)

### DIFF
--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -90,6 +90,33 @@ export function Dashboard({ onNavigate: _onNavigate }: DashboardProps) {
         errorCount={summary.error}
       />
 
+      {/* Metrics panels - Optimized for all terminal sizes (Issue #1041) */}
+      {/* On narrow terminals: 2x2 grid at top, on wide: side-by-side with activity feed */}
+      {!canMultiColumn && (
+        <Box marginTop={1} flexDirection="row" width="100%">
+          {/* Left column: System Health + Cost */}
+          <Box flexDirection="column" flexGrow={1} marginRight={1}>
+            <SystemHealthPanel
+              working={summary.working}
+              idle={summary.idle}
+              stuck={summary.stuck}
+              errorCount={summary.error}
+              total={summary.total}
+            />
+            <CostPanel
+              totalCostUSD={summary.totalCostUSD}
+              inputTokens={summary.inputTokens}
+              outputTokens={summary.outputTokens}
+            />
+          </Box>
+
+          {/* Right column: Agent Distribution */}
+          <Box flexDirection="column" width={Math.max(20, Math.floor(terminalWidth * 0.35))}>
+            <AgentStatsPanel stats={agentStats} />
+          </Box>
+        </Box>
+      )}
+
       {/* Main Content - Uses responsive layout for flexible column arrangement */}
       <Box marginTop={1} flexDirection={canMultiColumn ? 'row' : 'column'}>
         {/* Activity Feed - primary focus */}


### PR DESCRIPTION
## Problem

Dashboard has excessive empty space at narrow terminals (80x24) with metrics panels only visible in multi-column mode (100+ columns).

## Solution

Show optimized 2x2 grid of metrics panels on narrow terminals before activity feed:

**Narrow (80x24):**
```
┌─ System Health ─┬─ Agent Distribution ─┐
│ 89% healthy     │ engineer: ⊙⊙⊙⊙       │
│ ⊙ 4 working     │ manager: ⊙             │
└─────────────────┴──────────────────────┘
┌─ Recent Activity ────────────────────────┐
│ 12:06 eng-03 working (10 min)           │
└─────────────────────────────────────────┘
```

**Wide (120x40):** Original optimized layout preserved

## Implementation

Added conditional metrics grid for narrow terminals:
- System Health + Cost panels (left column)
- Agent Distribution panel (right column)
- Responsive width allocation based on terminal size
- Activity Feed below metrics
- All panels reuse existing components

## Benefits

- Better whitespace utilization at all terminal sizes
- Metrics visible immediately on dashboard load
- Responsive layout adapts gracefully to available space
- No loss of existing functionality
- Maintains animation/theming from Phase 3

## Testing

✅ TypeScript compilation passes
✅ Tests: 1353/1353 passing
✅ Manual: Layout responsive at 60x20, 80x24, 120x40+

## Changes

**tui/src/views/Dashboard.tsx:**
- Add metrics grid for narrow terminals (!canMultiColumn)
- Dynamic width allocation
- Flex layout for responsive adaptation
- Reuses existing SystemHealthPanel, CostPanel, AgentStatsPanel

## Impact

- **Scope:** Dashboard view only
- **Backward Compatibility:** ✅ Full
- **Breaking Changes:** None
- **Performance:** No degradation

Closes #1041

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>