### PR TITLE
fix(tui): Handle non-TTY stdin gracefully in bc home

### DIFF
--- a/tui/src/index.tsx
+++ b/tui/src/index.tsx
@@ -1,7 +1,26 @@
 #!/usr/bin/env node
 import { render } from 'ink';
+import process from 'node:process';
 import { App } from './app.js';
 
 // Entry point for bc TUI
 // Renders the main App component using Ink
+
+// Check if stdin is a TTY - Ink requires raw mode which only works with TTY
+if (!process.stdin.isTTY) {
+  console.error('Error: bc home requires an interactive terminal.');
+  console.error('');
+  console.error('The TUI dashboard needs a terminal that supports interactive input.');
+  console.error('This error occurs when:');
+  console.error('  - Running in a non-interactive shell (e.g., piped input)');
+  console.error('  - Running inside a script without TTY allocation');
+  console.error('  - SSH without -t flag (use: ssh -t host "bc home")');
+  console.error('');
+  console.error('Alternatives:');
+  console.error('  bc status       # View agent status (non-interactive)');
+  console.error('  bc agent list   # List agents');
+  console.error('  bc channel list # List channels');
+  process.exit(1);
+}
+
 render(<App />);


### PR DESCRIPTION
## Summary
- Fixes crash when running `bc home` in non-TTY environments
- Detects non-TTY stdin before Ink tries to enable raw mode
- Shows clear error message with alternatives

## Problem
Running `bc home` in environments where stdin is not a TTY (piped input, scripts, SSH without -t) would crash with:
```
Raw mode is not supported on the current process.stdin
```

## Solution
Check `process.stdin.isTTY` before rendering and provide a helpful error message:
```
Error: bc home requires an interactive terminal.

The TUI dashboard needs a terminal that supports interactive input.
This error occurs when:
  - Running in a non-interactive shell (e.g., piped input)
  - Running inside a script without TTY allocation
  - SSH without -t flag (use: ssh -t host "bc home")

Alternatives:
  bc status       # View agent status (non-interactive)
  bc agent list   # List agents
  bc channel list # List channels
```

## Test plan
- [x] Verified fix works with piped input: `echo "" | bun run tui/dist/index.js`
- [x] TUI still works normally in TTY environment
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)