### PR TITLE
fix(agent): Preserve agents on bc up and worktrees on bc stop

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -47,6 +47,11 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Create workspace-scoped agent manager
 	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
 
+	// Load existing agent state to preserve other agents when starting root
+	if loadErr := mgr.LoadState(); loadErr != nil {
+		log.Warn("failed to load agent state", "error", loadErr)
+	}
+
 	// Use custom agent command: workspace config > --agent flag > default
 	if ws.Config.AgentCommand != "" {
 		mgr.SetAgentCommand(ws.Config.AgentCommand)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -822,11 +822,8 @@ func (m *Manager) StopAgent(name string) error {
 	// Kill tmux session (ignore error - session might already be dead)
 	_ = m.tmux.KillSession(name)
 
-	// Clean up per-agent git worktree
-	if agent.WorktreeDir != "" && agent.WorktreeDir != agent.Workspace {
-		removeWorktree(agent.Workspace, agent.WorktreeDir)
-		agent.WorktreeDir = ""
-	}
+	// Note: Worktree is intentionally preserved on stop so agents can resume work.
+	// Only DeleteAgent removes the worktree permanently.
 
 	agent.State = StateStopped
 	agent.UpdatedAt = time.Now()

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -793,15 +793,16 @@ func TestStopAgent_WithWorktree(t *testing.T) {
 		Children:    []string{},
 	}
 
-	// Stop should succeed even with worktree (removeWorktree will fail gracefully)
+	// Stop should succeed and preserve worktree for later restart
 	if err := m.StopAgent("eng-1"); err != nil {
 		t.Fatalf("StopAgent with worktree failed: %v", err)
 	}
 	if m.agents["eng-1"].State != StateStopped {
 		t.Errorf("agent state = %s, want %s", m.agents["eng-1"].State, StateStopped)
 	}
-	if m.agents["eng-1"].WorktreeDir != "" {
-		t.Error("worktree dir should be cleared after stop")
+	// Worktree should be preserved (not cleared) so agent can resume work on restart
+	if m.agents["eng-1"].WorktreeDir != "/tmp/workspace/.bc/worktrees/eng-1" {
+		t.Error("worktree dir should be preserved after stop, not cleared")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two critical bugs in agent lifecycle management:

- **BUG 1: `bc up` deleting existing agents** - When starting root, `bc up` didn't call `LoadState()` first, so when `saveState()` ran it overwrote `agents.json` with only the root agent, effectively deleting all other agents
- **BUG 2: `bc stop` removing worktrees** - `StopAgent()` was calling `removeWorktree()` which deletes the agent's work directory. Stopping should preserve the worktree so agents can resume their work on restart

## Changes

1. **internal/cmd/up.go** - Added `mgr.LoadState()` before spawning root to preserve existing agent state
2. **pkg/agent/agent.go** - Removed worktree cleanup from `StopAgent()`. Worktrees are now only removed by `DeleteAgent()`
3. **pkg/agent/agent_test.go** - Updated test to verify worktree preservation behavior

## Test plan

- [x] All existing tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] `TestStopAgent_WithWorktree` updated to verify worktree is preserved
- [ ] Manual: Run `bc up` with existing agents, verify they persist
- [ ] Manual: Run `bc agent stop X`, verify worktree still exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)