### PR TITLE
fix(tui): Fix Agent Distribution panel garbled text (#1065)

### DIFF
--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -358,24 +358,25 @@ interface AgentStatsPanelProps {
 
 /**
  * Memoized agent stats panel - only re-renders when stats change
+ * Fixed: Use proper Box layout to prevent text overlap (#1065)
  */
 const AgentStatsPanel = memo(function AgentStatsPanel({ stats }: AgentStatsPanelProps) {
   const hasRoles = Object.keys(stats.byRole).length > 0;
 
   if (!hasRoles) return null;
 
+  const roleEntries = Object.entries(stats.byRole);
+
   return (
     <Panel title="Agent Distribution">
-      <Box>
-        {/* By Role */}
-        <Box marginRight={4}>
-          <Text dimColor>By Role: </Text>
-          {Object.entries(stats.byRole).map(([role, count], idx, arr) => (
-            <Text key={role}>
+      <Box flexDirection="column">
+        <Text dimColor>By Role:</Text>
+        <Box flexDirection="column" marginTop={1}>
+          {roleEntries.map(([role, count]) => (
+            <Box key={role}>
               <Text color="cyan">{role}</Text>
-              <Text>:{count}</Text>
-              {idx < arr.length - 1 && <Text> · </Text>}
-            </Text>
+              <Text>: {count}</Text>
+            </Box>
           ))}
         </Box>
       </Box>


### PR DESCRIPTION
## Summary

Fixes the Agent Distribution panel showing garbled/overlapping text on the Dashboard.

## Problem

The `AgentStatsPanel` was using nested `Text` components inside another `Text`, which caused text fragments to overlap and render incorrectly on narrow terminals (80x24).

**Before:** `"Byrooengimanproductechux"` and `"Ro:1 eer:ger-managlead:2"`

## Solution

Changed from horizontal inline text to a proper vertical Box layout:
- Each role now displays on its own line
- Uses `flexDirection="column"` for proper vertical stacking
- Cleaner rendering at all terminal sizes

## Test Plan

- [x] TypeScript compiles
- [x] Pre-commit hooks pass
- [ ] Manual: Run `bc home`, verify Agent Distribution panel renders cleanly
- [ ] Manual: Test at 80x24 terminal size

🤖 Generated with [Claude Code](https://claude.com/claude-code)