### PR TITLE
fix(tui): Fix Agent Detail View rendering corruption (#1062)

### DIFF
--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -206,8 +206,8 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
               ) : outputLines.length === 0 ? (
                 <Text dimColor>No output yet. Agent may be idle.</Text>
               ) : (
-                outputLines.map((line, idx) => (
-                  <Text key={idx} dimColor>
+                outputLines.slice(-outputHeight + 2).map((line, idx) => (
+                  <Text key={idx} dimColor wrap="truncate">
                     {line}
                   </Text>
                 ))
@@ -310,9 +310,9 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
               ) : (
                 activity.slice(0, 8).map((event, idx) => (
                   <Box key={idx}>
-                    <Text dimColor>{formatTime(event.timestamp)}</Text>
-                    <Text color="cyan"> [{event.type}] </Text>
-                    <Text>{truncateMessage(event.message, 50)}</Text>
+                    <Text dimColor wrap="truncate">{formatTime(event.timestamp)}</Text>
+                    <Text color="cyan" wrap="truncate"> [{event.type.split('.').pop()}] </Text>
+                    <Text wrap="truncate">{truncateMessage(event.message, 40)}</Text>
                   </Box>
                 ))
               )}
@@ -352,8 +352,8 @@ function DetailRow({ label, value }: DetailRowProps): React.ReactElement {
   return (
     <Box>
       <Text bold>{label}:</Text>
-      <Box marginLeft={1}>
-        <Text>{value}</Text>
+      <Box marginLeft={1} flexShrink={1}>
+        <Text wrap="truncate">{value}</Text>
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Summary

- Fix text overlap/corruption in Agent Detail View
- Long output lines and activity messages now truncate properly

## Changes

**AgentDetailView.tsx:**
- Add `wrap="truncate"` to output lines in Output tab
- Add `wrap="truncate"` to activity event messages in Metrics tab
- Limit displayed output lines to fit panel height (`outputHeight - 2`)
- Add `flexShrink={1}` to DetailRow value for proper truncation
- Shorten event type display to last segment (e.g., `state.working` → `working`)
- Reduce activity message truncation from 50 to 40 chars for better fit

## Test plan

- [x] Tests pass (13 pass, 8 skip, 0 fail)
- [x] Type check passes
- [x] Build passes
- [x] Output lines no longer overlap at 80x24
- [x] Activity events fit within panel width

Fixes #1062

Generated with Claude Code