### PR TITLE
fix(tui): Fix Enter key not working in Channels view (#1064)

### DIFF
--- a/tui/src/__tests__/ChannelsViewEnter.test.tsx
+++ b/tui/src/__tests__/ChannelsViewEnter.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * ChannelsView Enter Key Tests
+ * Issue #1064: Enter key doesn't open channel messages
+ *
+ * Tests the stale closure fix where selectedChannel must be computed
+ * inside the useInput callback to get the latest value.
+ */
+
+import { describe, it, expect } from 'bun:test';
+
+/**
+ * Test the stale closure fix logic
+ *
+ * The bug was: selectedChannel was computed outside useInput callback,
+ * so when channels loaded after initial render, the callback still had
+ * the old undefined value captured in closure.
+ *
+ * The fix: compute currentChannel inside the callback.
+ */
+describe('Enter key stale closure fix (Issue #1064)', () => {
+  describe('closure capture behavior', () => {
+    it('captures current value when computed inside callback', () => {
+      // Simulate the fixed pattern: compute inside callback
+      let channels: string[] | null = null;
+      const selectedIndex = 0;
+
+      // This is what the callback does now (fixed)
+      const getChannelInCallback = () => {
+        const currentChannel = channels?.[selectedIndex];
+        return currentChannel;
+      };
+
+      // Initially null
+      expect(getChannelInCallback()).toBeUndefined();
+
+      // Channels load
+      channels = ['#eng', '#pr', '#general'];
+
+      // Now callback gets the loaded value
+      expect(getChannelInCallback()).toBe('#eng');
+    });
+
+    it('captures stale value when computed outside callback (old bug)', () => {
+      // Simulate the old broken pattern
+      let channels: string[] | null = null;
+      const selectedIndex = 0;
+
+      // OLD: computed outside, captured in closure
+      const selectedChannel = channels?.[selectedIndex];
+
+      // The callback captures selectedChannel at creation time
+      const checkChannel = () => selectedChannel;
+
+      // Initially undefined
+      expect(checkChannel()).toBeUndefined();
+
+      // Channels load - but selectedChannel is STILL undefined (stale!)
+      channels = ['#eng', '#pr', '#general'];
+
+      // This is the bug - callback still has undefined
+      expect(checkChannel()).toBeUndefined();
+      // The fix makes this work (tested in previous test)
+    });
+  });
+
+  describe('Enter key conditions', () => {
+    it('Enter works when channels are loaded', () => {
+      const channels = [{ name: 'eng' }, { name: 'pr' }];
+      const selectedIndex = 0;
+      const keyReturn = true;
+
+      // Fixed pattern: compute inside callback
+      const currentChannel = channels?.[selectedIndex];
+      const shouldOpenChannel = keyReturn && currentChannel;
+
+      expect(shouldOpenChannel).toBeTruthy();
+    });
+
+    it('Enter is blocked when channels not loaded', () => {
+      const channels: Array<{ name: string }> | null = null;
+      const selectedIndex = 0;
+      const keyReturn = true;
+
+      const currentChannel = channels?.[selectedIndex];
+      const shouldOpenChannel = keyReturn && currentChannel;
+
+      expect(shouldOpenChannel).toBeFalsy();
+    });
+
+    it('Enter is blocked when channel list is empty', () => {
+      const channels: Array<{ name: string }> = [];
+      const selectedIndex = 0;
+      const keyReturn = true;
+
+      const currentChannel = channels?.[selectedIndex];
+      const shouldOpenChannel = keyReturn && currentChannel;
+
+      expect(shouldOpenChannel).toBeFalsy();
+    });
+
+    it('Enter works with different selected index', () => {
+      const channels = [{ name: 'eng' }, { name: 'pr' }, { name: 'general' }];
+      const selectedIndex = 2; // Third channel
+      const keyReturn = true;
+
+      const currentChannel = channels?.[selectedIndex];
+      const shouldOpenChannel = keyReturn && currentChannel;
+
+      expect(shouldOpenChannel).toBeTruthy();
+      expect(currentChannel?.name).toBe('general');
+    });
+  });
+});

--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -40,19 +40,18 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
   const { getLastViewed } = useUnread();
   const { setFocus } = useFocus();
 
-  const selectedChannel = channels?.[selectedIndex];
-
   // Update breadcrumbs and focus when view mode changes
   useEffect(() => {
-    if (viewMode === 'history' && selectedChannel) {
-      setBreadcrumbs([{ label: `#${selectedChannel.name}` }]);
+    const channel = channels?.[selectedIndex];
+    if (viewMode === 'history' && channel) {
+      setBreadcrumbs([{ label: `#${channel.name}` }]);
     } else {
       clearBreadcrumbs();
       // Restore focus to 'main' when returning to list view
       // This must happen AFTER global ESC handler has checked focus
       setFocus('main');
     }
-  }, [viewMode, selectedChannel, setBreadcrumbs, clearBreadcrumbs, setFocus]);
+  }, [viewMode, channels, selectedIndex, setBreadcrumbs, clearBreadcrumbs, setFocus]);
 
   // Calculate unread status for each channel (new = never viewed)
   const getChannelUnread = (channelName: string): number => {
@@ -78,8 +77,10 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
         if (input === 'G' && channels) {
           setSelectedIndex(channels.length - 1);
         }
-        // Enter channel - set focus to 'view' BEFORE changing mode to prevent race
-        if (key.return && selectedChannel) {
+        // Enter channel - get current channel inside callback to avoid stale closure
+        // This fixes #1064: Enter key not working when channels load after initial render
+        const currentChannel = channels?.[selectedIndex];
+        if (key.return && currentChannel) {
           setFocus('view');
           setViewMode('history');
         }
@@ -88,6 +89,9 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
     },
     { isActive: !disableInput }
   );
+
+  // Get currently selected channel for rendering
+  const selectedChannel = channels?.[selectedIndex];
 
   if (channelsLoading) {
     return (


### PR DESCRIPTION
## Summary
Fixes #1064 - Enter key not opening channel messages in the Channels view.

## Root Cause
**Stale closure bug**: `selectedChannel` was computed outside the `useInput` callback and captured at initial render time. When channels loaded after the initial render (async fetch), the callback still had the old `undefined` value captured in its closure.

## Fix
Compute `currentChannel` **inside** the `useInput` callback to always get the latest value from the `channels` array:

```jsx
// OLD (stale closure)
const selectedChannel = channels?.[selectedIndex];
useInput((input, key) => {
  if (key.return && selectedChannel) { // selectedChannel captured at render time!
    // ...
  }
});

// NEW (fixed)
useInput((input, key) => {
  const currentChannel = channels?.[selectedIndex]; // computed inside callback
  if (key.return && currentChannel) {
    // ...
  }
});
```

## Changes
- `ChannelsView.tsx`: Move channel lookup inside useInput callback
- `ChannelsViewEnter.test.tsx`: Add 6 tests for the stale closure fix pattern

## Test plan
- [x] TypeScript compiles without errors
- [x] ESLint clean
- [x] 6 new tests pass (closure behavior + Enter key conditions)
- [x] All existing ChannelsView tests pass (16 tests)

## Note for UX validation
This fix addresses the stale closure issue. UX team should verify:
1. Navigate to Channels view (`3` key)
2. Wait for channels to load
3. Press arrow keys to select a channel
4. Press Enter - should open channel messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)