### PR TITLE
fix(roles): Add capabilities to default role templates (#1067)

### DIFF
--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -837,7 +837,7 @@ const engineerTemplate = `---
 name: engineer
 capabilities:
   - implement_tasks
-  - write_code
+  - test_work
 parent_roles: []
 is_singleton: false
 ---

--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -55,6 +55,11 @@ type RoleManager struct {
 const DefaultRootRole = `---
 name: root
 is_singleton: true
+capabilities:
+  - create_agents
+  - assign_work
+  - create_epics
+  - review_work
 ---
 
 # Root Agent


### PR DESCRIPTION
## Summary
- Add capabilities to `DefaultRootRole` constant (`create_agents`, `assign_work`, `create_epics`, `review_work`)
- Fix `engineerTemplate` to use valid capability `test_work` instead of invalid `write_code`

## Root Cause
The TUI Roles view was showing '-' for all capabilities because:
1. The `DefaultRootRole` constant in `roles.go` didn't have capabilities defined
2. The `engineerTemplate` had an invalid capability `write_code` (not in the valid capabilities list)

Valid capabilities are: `create_agents`, `assign_work`, `create_epics`, `implement_tasks`, `review_work`, `test_work` (defined in `pkg/agent/agent.go`)

## Test plan
- [x] `make lint` passes (0 issues)
- [x] `make test` passes for role-related tests
- [x] `bc role list --json` shows capabilities for all roles
- [ ] UX validation: TUI Roles view should show capabilities instead of '-'

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)