### PR TITLE
fix(tui): Fix TypeScript build errors in bc.ts (#1089)

### DIFF
--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -58,8 +58,9 @@ type SpawnFn = (
 /**
  * Injectable spawn function - defaults to node's spawn
  * Tests can override this via _setSpawnForTesting()
+ * Cast required because nodeSpawn has complex overloads with optional args
  */
-let spawn: SpawnFn = nodeSpawn;
+let spawn: SpawnFn = nodeSpawn as unknown as SpawnFn;
 
 /**
  * Set a custom spawn function for testing
@@ -212,11 +213,11 @@ export async function execBc(args: string[]): Promise<string> {
       }
     }, 30000);
 
-    proc.stdout.on('data', (data: Buffer) => {
+    proc.stdout?.on('data', (data: Buffer) => {
       stdout += data.toString();
     });
 
-    proc.stderr.on('data', (data: Buffer) => {
+    proc.stderr?.on('data', (data: Buffer) => {
       stderr += data.toString();
     });
 


### PR DESCRIPTION
## Summary
- **P1 Hotfix** for build blocker introduced after PR #1085 merge
- Fix SpawnFn type compatibility with node's spawn complex overloads
- Add null safety for proc.stdout/stderr with optional chaining

## Test plan
- [x] `bun run build` compiles successfully
- [x] `bun run lint` passes for bc.ts
- [x] Pre-existing tests still pass

Fixes #1089

🤖 Generated with [Claude Code](https://claude.com/claude-code)