### PR TITLE
feat(cli): Smart bc command and user nickname (#1082)

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/channel"
+	"github.com/rpuneet/bc/pkg/workspace"
 )
 
 var channelCmd = &cobra.Command{
@@ -394,10 +395,7 @@ func runChannelSend(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add to channel history
-	sender := os.Getenv("BC_AGENT_ID")
-	if sender == "" {
-		sender = "cli"
-	}
+	sender := getUserSender()
 	if err := store.AddHistory(channelName, sender, message); err != nil {
 		fmt.Printf("Warning: failed to record history: %v\n", err)
 	}
@@ -661,10 +659,7 @@ func runChannelReact(cmd *cobra.Command, args []string) error {
 	emoji := args[2]
 
 	// Get user identity
-	user := os.Getenv("BC_AGENT_ID")
-	if user == "" {
-		user = "cli"
-	}
+	user := getUserSender()
 
 	added, err := store.ToggleReaction(channelName, messageIndex, emoji, user)
 	if err != nil {
@@ -821,4 +816,25 @@ func runChannelDesc(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Updated description for channel %q: %s\n", channelName, description)
 	return nil
+}
+
+// getUserSender returns the sender identity for channel messages.
+// If running as an agent, returns BC_AGENT_ID.
+// Otherwise, returns the user's configured nickname from workspace config.
+func getUserSender() string {
+	// Check if running as an agent
+	if agentID := os.Getenv("BC_AGENT_ID"); agentID != "" {
+		return agentID
+	}
+
+	// Try to get nickname from workspace config (v2)
+	ws, err := getWorkspace()
+	if err == nil && ws != nil && ws.V2Config != nil {
+		if ws.V2Config.User.Nickname != "" {
+			return ws.V2Config.User.Nickname
+		}
+	}
+
+	// Fallback to default nickname
+	return workspace.DefaultNickname
 }

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -180,4 +182,130 @@ func errNotInWorkspace(err error) error {
 		return fmt.Errorf("not in a bc workspace (run 'bc init' to initialize one): %w", err)
 	}
 	return fmt.Errorf("not in a bc workspace. Run 'bc init' in your project directory to create one")
+}
+
+// runInitInteractive runs an interactive workspace initialization with nickname prompt.
+func runInitInteractive(_ *cobra.Command, dir string) error {
+	log.Debug("interactive init started", "dir", dir)
+
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve directory: %w", err)
+	}
+
+	// Check for existing workspaces
+	if isV2Workspace(absDir) {
+		return fmt.Errorf("workspace already initialized in %s", absDir)
+	}
+	if isV1Workspace(absDir) {
+		fmt.Fprintln(os.Stderr, "Warning: Existing v1 workspace detected.")
+		fmt.Fprintln(os.Stderr, "Run 'bc init' after removing .bc/ directory to migrate.")
+		return fmt.Errorf("cannot initialize: v1 workspace exists")
+	}
+
+	// Prompt for nickname
+	nickname, err := promptNickname()
+	if err != nil {
+		return err
+	}
+
+	// Initialize workspace with nickname
+	return initV2WorkspaceWithNickname(absDir, nickname)
+}
+
+// promptNickname prompts the user for their display name.
+func promptNickname() (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Printf("  Your nickname [%s]: ", workspace.DefaultNickname)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(input)
+
+	// Normalize and validate
+	nickname, err := workspace.NormalizeNickname(input)
+	if err != nil {
+		// Show helpful error
+		fmt.Printf("  \033[31mError: %s\033[0m\n", err)
+		fmt.Printf("  Using default: %s\n", workspace.DefaultNickname)
+		return workspace.DefaultNickname, nil
+	}
+
+	// Show auto-correction if @ was added
+	if input != "" && !strings.HasPrefix(input, "@") {
+		fmt.Printf("  → Auto-corrected to %s\n", nickname)
+	}
+
+	return nickname, nil
+}
+
+// initV2WorkspaceWithNickname creates a new v2 workspace with a custom nickname.
+func initV2WorkspaceWithNickname(rootDir string, nickname string) error {
+	stateDir := filepath.Join(rootDir, ".bc")
+
+	// Create state directory
+	if err := os.MkdirAll(stateDir, 0750); err != nil {
+		return fmt.Errorf("failed to create .bc directory: %w", err)
+	}
+
+	// Create agents directory
+	agentsDir := filepath.Join(stateDir, "agents")
+	if err := os.MkdirAll(agentsDir, 0750); err != nil {
+		return fmt.Errorf("failed to create agents directory: %w", err)
+	}
+
+	// Create and save v2 config with nickname
+	name := filepath.Base(rootDir)
+	cfg := workspace.DefaultV2Config(name)
+	cfg.User.Nickname = nickname
+	configPath := workspace.ConfigPath(rootDir)
+
+	if err := cfg.Save(configPath); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	// Create roles directory and default root.md
+	roleMgr := workspace.NewRoleManager(stateDir)
+	created, err := roleMgr.EnsureDefaultRoot()
+	if err != nil {
+		return fmt.Errorf("failed to create role files: %w", err)
+	}
+
+	// Initialize channel database
+	channelStore := channel.NewSQLiteStore(rootDir)
+	if openErr := channelStore.Open(); openErr != nil {
+		return fmt.Errorf("failed to initialize channel database: %w", openErr)
+	}
+	_ = channelStore.Close()
+
+	// Register in global registry
+	reg, regErr := workspace.LoadRegistry()
+	if regErr == nil {
+		reg.Register(rootDir, name)
+		_ = reg.Save()
+	}
+
+	// Print success message
+	fmt.Println()
+	fmt.Printf("  \033[32m✓\033[0m Workspace initialized at %s\n", rootDir)
+	fmt.Printf("  \033[32m✓\033[0m Nickname set to %s\n", nickname)
+	fmt.Println()
+	fmt.Println("  Created:")
+	fmt.Println("    .bc/config.toml     # Workspace configuration")
+	fmt.Println("    .bc/agents/         # Agent state directory")
+	fmt.Println("    .bc/roles/          # Role definitions")
+	if created {
+		fmt.Println("    .bc/roles/root.md   # Root agent role")
+	}
+	fmt.Println("    .bc/channels.db     # Channel database")
+	fmt.Println()
+	fmt.Println("  Next steps:")
+	fmt.Println("    bc          # Open the dashboard")
+	fmt.Println("    bc up       # Start agents")
+	fmt.Println("    bc status   # Check agent status")
+
+	return nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -2,8 +2,12 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
+	"strings"
 
+	"github.com/charmbracelet/x/term"
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/log"
@@ -55,15 +59,8 @@ Documentation: https://github.com/rpuneet/bc`,
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		stopProfiling()
 	},
-	// Run with no args shows help
-	Run: func(cmd *cobra.Command, args []string) {
-		showVersion, err := cmd.Flags().GetBool("version")
-		if err == nil && showVersion {
-			versionCmd.Run(cmd, args)
-			return
-		}
-		_ = cmd.Help()
-	},
+	// Run with no args: open home if initialized, else prompt for init
+	RunE: runRoot,
 }
 
 // versionCmd shows version information.
@@ -103,4 +100,77 @@ func Execute() error {
 // Root returns the root command for testing and extension.
 func Root() *cobra.Command {
 	return rootCmd
+}
+
+// runRoot handles the default bc command (no subcommand).
+// If workspace is initialized → open TUI home
+// If not initialized → prompt to init
+// In non-interactive mode → show help
+func runRoot(cmd *cobra.Command, args []string) error {
+	// Check for version flag
+	showVersion, err := cmd.Flags().GetBool("version")
+	if err == nil && showVersion {
+		versionCmd.Run(cmd, args)
+		return nil
+	}
+
+	// Check if running in an interactive terminal
+	// If not (e.g., piped input, test environment), show help
+	if !term.IsTerminal(os.Stdin.Fd()) {
+		return cmd.Help()
+	}
+
+	// Try to find workspace
+	ws, err := getWorkspace()
+	if err == nil && ws != nil {
+		// Workspace exists - open TUI home
+		log.Debug("workspace found, opening home", "root", ws.RootDir)
+		return runHome(cmd, args)
+	}
+
+	// No workspace - prompt to initialize
+	return promptInit(cmd)
+}
+
+// promptInit displays an interactive prompt to initialize a new workspace.
+func promptInit(cmd *cobra.Command) error {
+	fmt.Println()
+	fmt.Println("  \033[1mbc - AI Agent Orchestration\033[0m")
+	fmt.Println()
+	fmt.Println("  No workspace found in current directory.")
+	fmt.Println()
+	fmt.Print("  Would you like to initialize a new workspace? [Y/n]: ")
+
+	reader := bufio.NewReader(os.Stdin)
+	input, err := reader.ReadString('\n')
+	if err != nil {
+		return fmt.Errorf("failed to read input: %w", err)
+	}
+
+	input = strings.TrimSpace(strings.ToLower(input))
+
+	// Default to yes if empty or 'y'
+	if input == "" || input == "y" || input == "yes" {
+		return runInteractiveInit(cmd)
+	}
+
+	// User said no - show help
+	fmt.Println()
+	return cmd.Help()
+}
+
+// runInteractiveInit runs an interactive workspace initialization.
+func runInteractiveInit(cmd *cobra.Command) error {
+	fmt.Println()
+	fmt.Println("  Initializing bc workspace...")
+	fmt.Println()
+
+	// Get current directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current directory: %w", err)
+	}
+
+	// Run init with interactive nickname prompt
+	return runInitInteractive(cmd, cwd)
 }

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -18,11 +20,17 @@ type V2Config struct {
 	Tools       ToolsConfig       `toml:"tools"`
 	Memory      MemoryConfig      `toml:"memory"`
 	TUI         TUIConfig         `toml:"tui"`
+	User        UserConfig        `toml:"user"`
 	Workspace   WorkspaceConfig   `toml:"workspace"`
 	Worktrees   WorktreesConfig   `toml:"worktrees"`
 	Channels    ChannelsConfig    `toml:"channels"`
 	Performance PerformanceConfig `toml:"performance"`
 	Roster      RosterConfig      `toml:"roster"`
+}
+
+// UserConfig holds user identity settings.
+type UserConfig struct {
+	Nickname string `toml:"nickname"` // User's display name for channel messages (e.g., "@puneet")
 }
 
 // WorkspaceConfig holds core workspace settings.
@@ -111,6 +119,14 @@ var ValidThemes = []string{"dark", "light", "matrix", "synthwave", "high-contras
 // Valid theme modes.
 var ValidModes = []string{"auto", "dark", "light"}
 
+// User nickname limits.
+const (
+	NicknameMaxLength = 15 // Maximum nickname length including @ prefix
+)
+
+// DefaultNickname is the default user nickname.
+const DefaultNickname = "@bc"
+
 // Roster limits.
 const (
 	RosterMinPerRole = 0  // Minimum agents per role
@@ -141,6 +157,9 @@ var (
 	ErrCacheTTLRange             = errors.New("cache TTL must be between 100ms and 60000ms")
 	ErrInvalidTheme              = errors.New("tui.theme must be one of: dark, light, matrix, synthwave, high-contrast")
 	ErrInvalidThemeMode          = errors.New("tui.mode must be one of: auto, dark, light")
+	ErrNicknameTooLong           = errors.New("user.nickname must be 15 characters or less")
+	ErrNicknameMissingPrefix     = errors.New("user.nickname must start with @")
+	ErrNicknameInvalidChars      = errors.New("user.nickname must contain only letters, numbers, and underscores")
 )
 
 // DefaultV2Config returns sensible defaults for a new v2 workspace.
@@ -171,6 +190,9 @@ func DefaultV2Config(name string) V2Config {
 		},
 		Channels: ChannelsConfig{
 			Default: []string{"general", "engineering"},
+		},
+		User: UserConfig{
+			Nickname: DefaultNickname,
 		},
 		Roster: RosterConfig{
 			ProductManager: 0,
@@ -274,6 +296,11 @@ func (c *V2Config) Validate() error {
 		return err
 	}
 
+	// User validation (only validate if nickname is set)
+	if err := c.validateUser(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -352,6 +379,68 @@ func isValidMode(mode string) bool {
 		}
 	}
 	return false
+}
+
+// validateUser validates user config values.
+// Empty values are acceptable (will use default @bc).
+func (c *V2Config) validateUser() error {
+	u := c.User
+
+	// Empty nickname is ok (uses default)
+	if u.Nickname == "" {
+		return nil
+	}
+
+	// Validate nickname format
+	return ValidateNickname(u.Nickname)
+}
+
+// nicknameRegex matches valid nickname characters (after @ prefix).
+var nicknameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
+// ValidateNickname validates a nickname and returns an error if invalid.
+func ValidateNickname(nickname string) error {
+	// Must start with @
+	if !strings.HasPrefix(nickname, "@") {
+		return ErrNicknameMissingPrefix
+	}
+
+	// Check length
+	if len(nickname) > NicknameMaxLength {
+		return ErrNicknameTooLong
+	}
+
+	// Check characters after @
+	body := nickname[1:]
+	if body == "" || !nicknameRegex.MatchString(body) {
+		return ErrNicknameInvalidChars
+	}
+
+	return nil
+}
+
+// NormalizeNickname ensures a nickname has the @ prefix and is valid.
+// Returns the normalized nickname or an error.
+func NormalizeNickname(nickname string) (string, error) {
+	// Trim whitespace
+	nickname = strings.TrimSpace(nickname)
+
+	// Empty means use default
+	if nickname == "" {
+		return DefaultNickname, nil
+	}
+
+	// Add @ prefix if missing
+	if !strings.HasPrefix(nickname, "@") {
+		nickname = "@" + nickname
+	}
+
+	// Validate
+	if err := ValidateNickname(nickname); err != nil {
+		return "", err
+	}
+
+	return nickname, nil
 }
 
 // hasToolDefined checks if a tool is configured.


### PR DESCRIPTION
## Summary
- Smart default `bc` command: opens TUI home if workspace initialized, prompts to init otherwise
- User nickname system with @prefix validation (max 15 chars)
- Interactive init flow with nickname prompt
- Channel messages show nickname instead of "cli"

## Test plan
- [ ] Run `bc` in initialized workspace → opens TUI home
- [ ] Run `bc` in new directory → prompts to initialize
- [ ] Run `bc` with piped input → shows help (non-interactive mode)
- [ ] Initialize with nickname → saved in config.toml
- [ ] Send channel message → shows @nickname instead of "cli"
- [ ] Verify tests pass: `go test ./internal/cmd/... ./pkg/workspace/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)