### PR TITLE
fix(tui): Fix Ctrl+P performance metrics toggle (#1094)

### DIFF
--- a/tui/src/components/PerformanceDebugPanel.tsx
+++ b/tui/src/components/PerformanceDebugPanel.tsx
@@ -12,6 +12,8 @@ interface PerformanceDebugPanelProps {
   maxMetrics?: number;
   /** Show compact view (single line) */
   compact?: boolean;
+  /** Force show panel regardless of debugEnabled state (for Ctrl+P toggle) */
+  forceShow?: boolean;
 }
 
 /**
@@ -21,11 +23,17 @@ interface PerformanceDebugPanelProps {
 export function PerformanceDebugPanel({
   maxMetrics = 5,
   compact = false,
+  forceShow = false,
 }: PerformanceDebugPanelProps): React.ReactElement | null {
   const perf = usePerformanceOptional();
 
-  // Don't render if not in debug mode or no performance context
-  if (!perf?.debugEnabled) {
+  // Don't render if no performance context available
+  if (!perf) {
+    return null;
+  }
+
+  // Don't render if not in debug mode (unless forceShow from Ctrl+P toggle)
+  if (!forceShow && !perf.debugEnabled) {
     return null;
   }
 

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -151,7 +151,7 @@ export function Dashboard({ onNavigate: _onNavigate }: DashboardProps) {
       </Box>
 
       {/* Performance Debug Panel - toggled with Ctrl+P or F12 (Phase 3) */}
-      {showDebugPanel && <PerformanceDebugPanel compact={!isWide} />}
+      {showDebugPanel && <PerformanceDebugPanel compact={!isWide} forceShow />}
 
       {/* Footer with keyboard hints */}
       <Footer


### PR DESCRIPTION
## Summary
- Fix Ctrl+P not showing performance metrics panel
- Add `forceShow` prop to PerformanceDebugPanel to bypass `debugEnabled` check
- Dashboard passes `forceShow` when toggled via Ctrl+P

## Root Cause
PerformanceDebugPanel required `BC_TUI_DEBUG=1` env var even when explicitly toggled via Ctrl+P, making the toggle ineffective.

## Test plan
- [x] Build passes
- [x] Lint clean
- [ ] Manual test: Ctrl+P should now show/hide performance panel without env var

Fixes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)