### PR TITLE
fix(cmd): Add actionable hints to 'not found' error messages (#1081)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -617,11 +617,11 @@ func runAgentPeek(cmd *cobra.Command, args []string) error {
 
 	a := mgr.GetAgent(agentName)
 	if a == nil {
-		return fmt.Errorf("agent %q not found", agentName)
+		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentName)
 	}
 
 	if a.State == agent.StateStopped {
-		return fmt.Errorf("agent %q is stopped", agentName)
+		return fmt.Errorf("agent %q is stopped (use 'bc agent start %s' to start it)", agentName, agentName)
 	}
 
 	output, captureErr := mgr.CaptureOutput(agentName, agentPeekLines)
@@ -650,7 +650,7 @@ func runAgentShow(cmd *cobra.Command, args []string) error {
 
 	a := mgr.GetAgent(agentName)
 	if a == nil {
-		return fmt.Errorf("agent %q not found", agentName)
+		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentName)
 	}
 
 	// JSON output
@@ -750,7 +750,7 @@ func runAgentStop(cmd *cobra.Command, args []string) error {
 
 	a := mgr.GetAgent(agentName)
 	if a == nil {
-		return fmt.Errorf("agent %q not found", agentName)
+		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentName)
 	}
 
 	fmt.Printf("Stopping %s... ", agentName)
@@ -792,11 +792,11 @@ func runAgentSend(cmd *cobra.Command, args []string) error {
 
 	a := mgr.GetAgent(agentName)
 	if a == nil {
-		return fmt.Errorf("agent %q not found", agentName)
+		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentName)
 	}
 
 	if a.State == agent.StateStopped {
-		return fmt.Errorf("agent %q is stopped", agentName)
+		return fmt.Errorf("agent %q is stopped (use 'bc agent start %s' to start it)", agentName, agentName)
 	}
 
 	if sendErr := mgr.SendToAgent(agentName, message); sendErr != nil {
@@ -839,7 +839,7 @@ func runAgentDelete(cmd *cobra.Command, args []string) error {
 
 	a := mgr.GetAgent(agentName)
 	if a == nil {
-		return fmt.Errorf("agent %q not found", agentName)
+		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentName)
 	}
 
 	// Check if agent is running - require --force
@@ -948,7 +948,7 @@ func runAgentRename(cmd *cobra.Command, args []string) error {
 	// Check if agent exists
 	a := mgr.GetAgent(oldName)
 	if a == nil {
-		return fmt.Errorf("agent %q not found", oldName)
+		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", oldName)
 	}
 
 	// Check if new name already exists
@@ -1360,7 +1360,7 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 		// Check specific agent
 		a := mgr.GetAgent(args[0])
 		if a == nil {
-			return fmt.Errorf("agent %q not found", args[0])
+			return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", args[0])
 		}
 		agents = []*agent.Agent{a}
 	} else {

--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -723,7 +723,7 @@ func runChannelShow(cmd *cobra.Command, args []string) error {
 	// Get channel
 	ch, exists := store.Get(channelName)
 	if !exists {
-		return fmt.Errorf("channel %q not found", channelName)
+		return fmt.Errorf("channel %q not found (use 'bc channel list' to see available channels)", channelName)
 	}
 
 	// Get members

--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -375,7 +375,7 @@ func runDemonShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if d == nil {
-		return fmt.Errorf("demon %q not found", name)
+		return fmt.Errorf("demon %q not found (use 'bc demon list' to see available demons)", name)
 	}
 
 	cmd.Printf("Name:      %s\n", d.Name)
@@ -433,7 +433,7 @@ func runDemonRun(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if d == nil {
-		return fmt.Errorf("demon %q not found", name)
+		return fmt.Errorf("demon %q not found (use 'bc demon list' to see available demons)", name)
 	}
 
 	cmd.Printf("Running demon %q: %s\n", name, d.Command)
@@ -558,7 +558,7 @@ func runDemonLogs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if d == nil {
-		return fmt.Errorf("demon %q not found", name)
+		return fmt.Errorf("demon %q not found (use 'bc demon list' to see available demons)", name)
 	}
 
 	logs, err := store.GetRunLogs(name, demonTail)
@@ -617,7 +617,7 @@ func runDemonEdit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if d == nil {
-		return fmt.Errorf("demon %q not found", name)
+		return fmt.Errorf("demon %q not found (use 'bc demon list' to see available demons)", name)
 	}
 
 	// Check if any flags were provided

--- a/internal/cmd/process.go
+++ b/internal/cmd/process.go
@@ -291,7 +291,7 @@ func runProcessStop(cmd *cobra.Command, args []string) error {
 
 	proc := reg.Get(name)
 	if proc == nil {
-		return fmt.Errorf("process %q not found", name)
+		return fmt.Errorf("process %q not found (use 'bc process list' to see available processes)", name)
 	}
 
 	if !proc.Running {
@@ -329,7 +329,7 @@ func runProcessLogs(cmd *cobra.Command, args []string) error {
 
 	proc := reg.Get(name)
 	if proc == nil {
-		return fmt.Errorf("process %q not found", name)
+		return fmt.Errorf("process %q not found (use 'bc process list' to see available processes)", name)
 	}
 
 	// Read logs
@@ -357,7 +357,7 @@ func runProcessShow(cmd *cobra.Command, args []string) error {
 
 	proc := reg.Get(name)
 	if proc == nil {
-		return fmt.Errorf("process %q not found", name)
+		return fmt.Errorf("process %q not found (use 'bc process list' to see available processes)", name)
 	}
 
 	fmt.Printf("Process: %s\n", proc.Name)
@@ -390,7 +390,7 @@ func runProcessAttach(cmd *cobra.Command, args []string) error {
 
 	proc := reg.Get(name)
 	if proc == nil {
-		return fmt.Errorf("process %q not found", name)
+		return fmt.Errorf("process %q not found (use 'bc process list' to see available processes)", name)
 	}
 
 	if !proc.Running {
@@ -434,7 +434,7 @@ func runProcessRestart(cmd *cobra.Command, args []string) error {
 
 	proc := reg.Get(name)
 	if proc == nil {
-		return fmt.Errorf("process %q not found", name)
+		return fmt.Errorf("process %q not found (use 'bc process list' to see available processes)", name)
 	}
 
 	if !proc.Running {

--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -477,7 +477,7 @@ func runRoleDelete(cmd *cobra.Command, args []string) error {
 
 	// Check if role exists
 	if !rm.HasRole(roleName) {
-		return fmt.Errorf("role %q not found", roleName)
+		return fmt.Errorf("role %q not found (use 'bc role list' to see available roles)", roleName)
 	}
 
 	if !roleForce {
@@ -551,7 +551,7 @@ func runRoleRename(cmd *cobra.Command, args []string) error {
 
 	// Check source exists
 	if !rm.HasRole(oldName) {
-		return fmt.Errorf("role %q not found", oldName)
+		return fmt.Errorf("role %q not found (use 'bc role list' to see available roles)", oldName)
 	}
 
 	// Check destination doesn't exist
@@ -599,7 +599,7 @@ func runRoleClone(cmd *cobra.Command, args []string) error {
 
 	// Check source exists
 	if !rm.HasRole(srcName) {
-		return fmt.Errorf("source role %q not found", srcName)
+		return fmt.Errorf("source role %q not found (use 'bc role list' to see available roles)", srcName)
 	}
 
 	// Check destination doesn't exist

--- a/internal/cmd/team.go
+++ b/internal/cmd/team.go
@@ -203,7 +203,7 @@ func runTeamShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if t == nil {
-		return fmt.Errorf("team %q not found", name)
+		return fmt.Errorf("team %q not found (use 'bc team list' to see available teams)", name)
 	}
 
 	cmd.Printf("Name:        %s\n", t.Name)
@@ -284,7 +284,7 @@ func runTeamRemove(cmd *cobra.Command, args []string) error {
 
 	// Validate team exists
 	if !store.Exists(teamName) {
-		return fmt.Errorf("team %q not found", teamName)
+		return fmt.Errorf("team %q not found (use 'bc team list' to see available teams)", teamName)
 	}
 
 	if err := store.RemoveMember(teamName, agentName); err != nil {
@@ -311,7 +311,7 @@ func runTeamRename(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if oldTeam == nil {
-		return fmt.Errorf("team %q not found", oldName)
+		return fmt.Errorf("team %q not found (use 'bc team list' to see available teams)", oldName)
 	}
 
 	// Check new name doesn't exist


### PR DESCRIPTION
## Summary
- Improves user experience by providing helpful hints when resources are not found
- 25 error messages updated across 6 files in internal/cmd/

**Changes:**
- `agent not found` → `agent %q not found (use 'bc agent list' to see available agents)`
- `channel not found` → adds channel list hint
- `demon not found` → adds demon list hint
- `process not found` → adds process list hint
- `role not found` → adds role list hint
- `team not found` → adds team list hint
- `agent is stopped` → adds start command hint

## Test plan
- [x] Build passes
- [x] Lint passes (0 issues)
- [ ] Manual testing: verify error messages show hints

Part of #1081 Q1 Cleanup - Error message consistency audit (medium scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)