### PR TITLE
fix(tui): Add Demons and Processes views to navigation (#1095, #1096)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -25,6 +25,8 @@ import { CostsView } from './components/CostsView';
 import { LogsView } from './views/LogsView';
 import { WorktreesView } from './views/WorktreesView';
 import { WorkspaceSelectorView } from './views/WorkspaceSelectorView';
+import { DemonsView } from './views/DemonsView';
+import { ProcessesView } from './views/ProcessesView';
 
 interface AppProps {
   /** Disable input handling (useful for testing) */
@@ -149,6 +151,10 @@ function ViewContent({ view, disableInput }: ViewContentProps): React.ReactEleme
       return <WorktreesView />;
     case 'workspaces':
       return <WorkspaceSelectorView />;
+    case 'demons':
+      return <DemonsView disableInput={disableInput} />;
+    case 'processes':
+      return <ProcessesView />;
     case 'help':
       return <HelpView />;
     default:

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useContext, useState, useCallback, useMemo } from
 import type { ReactNode } from 'react';
 
 // View types for navigation
-export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'help' | 'commands' | 'roles' | 'logs' | 'worktrees' | 'workspaces';
+export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'help' | 'commands' | 'roles' | 'logs' | 'worktrees' | 'workspaces' | 'demons' | 'processes';
 
 // Tab configuration
 export interface TabConfig {
@@ -28,6 +28,8 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: '7', view: 'logs', label: 'Logs', shortLabel: 'Log', shortcut: '7' },
   { key: '8', view: 'worktrees', label: 'Worktrees', shortLabel: 'Tree', shortcut: '8' },
   { key: '9', view: 'workspaces', label: 'Workspaces', shortLabel: 'Wksp', shortcut: '9' },
+  { key: '0', view: 'demons', label: 'Demons', shortLabel: 'Dmn', shortcut: '0' },
+  { key: '-', view: 'processes', label: 'Processes', shortLabel: 'Proc', shortcut: '-' },
   { key: '?', view: 'help', label: 'Help', shortLabel: '?', shortcut: '?' },
 ];
 


### PR DESCRIPTION
## Summary
- Adds Demons and Processes views to TUI navigation
- Both views existed but were inaccessible from the tab bar

## Changes
- Add 'demons' and 'processes' to View type union in NavigationContext.tsx
- Add tabs with '0' and '-' keyboard shortcuts respectively
- Import and render DemonsView and ProcessesView in app.tsx switch statement

## Keyboard Shortcuts
- `0` - Demons view (scheduled tasks)
- `-` - Processes view (managed processes)

## Test plan
- [x] TUI builds successfully
- [x] Lint passes
- [x] Views render when navigating via keyboard

Fixes #1095
Fixes #1096

🤖 Generated with [Claude Code](https://claude.com/claude-code)