### PR TITLE
fix(tui): Isolate config.test.tsx to prevent mock pollution (#1066)

### DIFF
--- a/tui/package.json
+++ b/tui/package.json
@@ -10,7 +10,7 @@
     "start": "bun run dist/index.js",
     "lint": "bun run eslint src",
     "typecheck": "bun run tsc --noEmit",
-    "test": "bun test src/__tests__ src/hooks/__tests__ src/components/__tests__ src/views/__tests__ && bun test src/services/__tests__/bc.test.ts",
+    "test": "bun test src/__tests__ src/hooks/__tests__ src/components/__tests__ src/views/__tests__ && bun test src/services/__tests__/bc.test.ts && bun test src/config/__tests__/config.test.tsx",
     "test:watch": "bun test --watch",
     "test:bc": "bun test src/services/__tests__/bc.test.ts",
     "test:ui": "bun test src/__tests__ src/hooks/__tests__ src/components/__tests__ src/views/__tests__"

--- a/tui/src/config/__tests__/config.test.tsx
+++ b/tui/src/config/__tests__/config.test.tsx
@@ -14,11 +14,12 @@ import {
   useThemeConfig,
   DEFAULT_PERFORMANCE_CONFIG,
   DEFAULT_TUI_CONFIG,
-} from '../config';
-import type { PerformanceConfig, TUIConfig } from '../types';
+} from '..';
+import type { PerformanceConfig, TUIConfig } from '../../types';
 
 // Mock bc service
-jest.mock('../services/bc', () => ({
+// NOTE: This file is isolated to prevent mock pollution (#1066)
+jest.mock('../../services/bc', () => ({
   execBcJson: jest.fn().mockResolvedValue({}),
 }));
 


### PR DESCRIPTION
## Summary
- Move config.test.tsx to src/config/__tests__/
- Run config tests in isolation to prevent jest.mock() pollution
- Fixes 15 test failures in bc.test.ts when running full suite

## Root Cause
config.test.tsx uses `jest.mock('../services/bc')` which globally affects module state, causing bc.test.ts tests to fail.

## Test plan
- [x] `bun run test` passes all stages
- [x] Main suite: 1496 pass, 0 fail
- [x] bc.test.ts: 19 pass, 0 fail
- [x] config.test.tsx: 15 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)