### PR TITLE
test(integrations): Add unit tests for GitHub integration (#1081)

### DIFF
--- a/pkg/integrations/github.go
+++ b/pkg/integrations/github.go
@@ -10,9 +10,14 @@ import (
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
+// CommandFunc is the function signature for creating exec.Cmd.
+// Used for testing to inject mock commands.
+type CommandFunc func(ctx context.Context, name string, args ...string) *exec.Cmd
+
 // GitHubIntegration wraps GitHub CLI (gh) operations.
 type GitHubIntegration struct {
-	command string
+	execCommand CommandFunc
+	command     string
 }
 
 // NewGitHubIntegration creates a new GitHub integration from workspace config.
@@ -27,14 +32,16 @@ func NewGitHubIntegration(ws *workspace.Workspace) (*GitHubIntegration, error) {
 	if !ghConfig.Enabled {
 		return nil, fmt.Errorf("github tool is disabled in config.toml")
 	}
-	return &GitHubIntegration{command: ghConfig.Command}, nil
+	return &GitHubIntegration{
+		command:     ghConfig.Command,
+		execCommand: exec.CommandContext,
+	}, nil
 }
 
 // CheckAuth verifies gh authentication status.
 // Returns error if gh is not authenticated.
 func (g *GitHubIntegration) CheckAuth(ctx context.Context) error {
-	//nolint:gosec // g.command comes from trusted config
-	cmd := exec.CommandContext(ctx, g.command, "auth", "status")
+	cmd := g.execCommand(ctx, g.command, "auth", "status")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("gh not authenticated - run 'gh auth login': %w", err)
 	}
@@ -50,8 +57,7 @@ func (g *GitHubIntegration) CreateIssue(ctx context.Context, title, body string,
 		args = append(args, "-l", label)
 	}
 
-	//nolint:gosec // g.command comes from trusted config
-	cmd := exec.CommandContext(ctx, g.command, args...)
+	cmd := g.execCommand(ctx, g.command, args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to create issue: %w - %s", err, strings.TrimSpace(string(output)))
@@ -63,8 +69,7 @@ func (g *GitHubIntegration) CreateIssue(ctx context.Context, title, body string,
 // FindIssue searches for an existing issue by query.
 // Returns the issue number if found, empty string if not found.
 func (g *GitHubIntegration) FindIssue(ctx context.Context, searchQuery string) (string, error) {
-	//nolint:gosec // g.command comes from trusted config
-	cmd := exec.CommandContext(ctx, g.command, "issue", "list",
+	cmd := g.execCommand(ctx, g.command, "issue", "list",
 		"--search", searchQuery,
 		"--json", "number",
 		"--jq", ".[0].number")

--- a/pkg/integrations/github_test.go
+++ b/pkg/integrations/github_test.go
@@ -2,10 +2,37 @@ package integrations
 
 import (
 	"context"
+	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/rpuneet/bc/pkg/workspace"
 )
+
+// mockCmd creates a mock command that returns the given output and exit code.
+func mockCmd(stdout string, exitCode int) CommandFunc {
+	return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		cs := []string{"-test.run=TestHelperProcess", "--", stdout}
+		cmd := exec.CommandContext(ctx, os.Args[0], cs...) //nolint:gosec // test helper
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			"MOCK_EXIT_CODE="+string(rune('0'+exitCode)),
+			"MOCK_STDOUT="+stdout,
+		)
+		return cmd
+	}
+}
+
+// TestHelperProcess is used by mockCmd to simulate command execution.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	stdout := os.Getenv("MOCK_STDOUT")
+	exitCode := int(os.Getenv("MOCK_EXIT_CODE")[0] - '0')
+	os.Stdout.WriteString(stdout) //nolint:errcheck
+	os.Exit(exitCode)
+}
 
 func TestNewGitHubIntegrationDisabled(t *testing.T) {
 	// Test when GitHub tool is disabled
@@ -62,133 +89,138 @@ func TestNewGitHubIntegrationEnabled(t *testing.T) {
 	}
 }
 
-func TestCheckAuth(t *testing.T) {
-	// Note: This test requires 'gh' to be installed and authenticated
-	// It will be skipped in CI if gh is not available
-	t.Skip("Integration test - requires gh to be installed and authenticated")
-
-	ws := &workspace.Workspace{
-		V2Config: &workspace.V2Config{
-			Tools: workspace.ToolsConfig{
-				GitHub: &workspace.ToolConfig{
-					Command: "gh",
-					Enabled: true,
-				},
-			},
-		},
-	}
-
-	gh, err := NewGitHubIntegration(ws)
-	if err != nil {
-		t.Fatalf("NewGitHubIntegration failed: %v", err)
+func TestCheckAuthSuccess(t *testing.T) {
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd("", 0),
 	}
 
 	ctx := context.Background()
-	// If gh is available and authenticated, this should work
-	err = gh.CheckAuth(ctx)
+	err := gh.CheckAuth(ctx)
 	if err != nil {
-		t.Logf("gh auth check failed (expected in some environments): %v", err)
+		t.Errorf("CheckAuth should succeed: %v", err)
 	}
 }
 
-func TestCreateIssue(t *testing.T) {
-	// This is an integration test that requires gh and GitHub access
-	// Skipped by default as it modifies state
-	t.Skip("Integration test - requires gh and GitHub access")
+func TestCheckAuthFailure(t *testing.T) {
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd("not logged in", 1),
+	}
 
 	ctx := context.Background()
-	ws := &workspace.Workspace{
-		V2Config: &workspace.V2Config{
-			Tools: workspace.ToolsConfig{
-				GitHub: &workspace.ToolConfig{
-					Command: "gh",
-					Enabled: true,
-				},
-			},
-		},
+	err := gh.CheckAuth(ctx)
+	if err == nil {
+		t.Error("CheckAuth should fail when not authenticated")
+	}
+}
+
+func TestCreateIssueSuccess(t *testing.T) {
+	expectedURL := "https://github.com/test/repo/issues/123"
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd(expectedURL, 0),
 	}
 
-	gh, err := NewGitHubIntegration(ws)
-	if err != nil {
-		t.Fatalf("NewGitHubIntegration failed: %v", err)
-	}
-
-	title := "[test] automated issue creation"
-	body := "This is a test issue created by bc integration test"
-	labels := []string{"test", "automated"}
-
-	url, err := gh.CreateIssue(ctx, title, body, labels)
+	ctx := context.Background()
+	url, err := gh.CreateIssue(ctx, "Test Issue", "Test body", []string{"bug"})
 	if err != nil {
 		t.Fatalf("CreateIssue failed: %v", err)
 	}
-
-	if url == "" {
-		t.Error("expected non-empty issue URL")
+	if url != expectedURL {
+		t.Errorf("url: got %q, want %q", url, expectedURL)
 	}
-
-	t.Logf("Created issue: %s", url)
 }
 
-func TestFindIssue(t *testing.T) {
-	// This is an integration test that requires gh and GitHub access
-	t.Skip("Integration test - requires gh and GitHub access")
+func TestCreateIssueFailure(t *testing.T) {
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd("error: not found", 1),
+	}
 
 	ctx := context.Background()
-	ws := &workspace.Workspace{
-		V2Config: &workspace.V2Config{
-			Tools: workspace.ToolsConfig{
-				GitHub: &workspace.ToolConfig{
-					Command: "gh",
-					Enabled: true,
-				},
-			},
-		},
+	_, err := gh.CreateIssue(ctx, "Test Issue", "Test body", nil)
+	if err == nil {
+		t.Error("CreateIssue should fail")
+	}
+}
+
+func TestFindIssueFound(t *testing.T) {
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd("42", 0),
 	}
 
-	gh, err := NewGitHubIntegration(ws)
-	if err != nil {
-		t.Fatalf("NewGitHubIntegration failed: %v", err)
-	}
-
-	// Search for a test issue (won't find anything, but tests the query mechanism)
-	issueNum, err := gh.FindIssue(ctx, "nonexistent-test-issue-12345")
+	ctx := context.Background()
+	issueNum, err := gh.FindIssue(ctx, "test query")
 	if err != nil {
 		t.Fatalf("FindIssue failed: %v", err)
 	}
-
-	// Should return empty string if not found
-	if issueNum != "" {
-		t.Logf("Found issue: %s", issueNum)
+	if issueNum != "42" {
+		t.Errorf("issueNum: got %q, want %q", issueNum, "42")
 	}
 }
 
-func TestIssueExists(t *testing.T) {
-	// This is an integration test that requires gh and GitHub access
-	t.Skip("Integration test - requires gh and GitHub access")
+func TestFindIssueNotFound(t *testing.T) {
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd("null", 0),
+	}
 
 	ctx := context.Background()
-	ws := &workspace.Workspace{
-		V2Config: &workspace.V2Config{
-			Tools: workspace.ToolsConfig{
-				GitHub: &workspace.ToolConfig{
-					Command: "gh",
-					Enabled: true,
-				},
-			},
-		},
-	}
-
-	gh, err := NewGitHubIntegration(ws)
+	issueNum, err := gh.FindIssue(ctx, "nonexistent")
 	if err != nil {
-		t.Fatalf("NewGitHubIntegration failed: %v", err)
+		t.Fatalf("FindIssue failed: %v", err)
+	}
+	if issueNum != "" {
+		t.Errorf("issueNum should be empty for not found, got %q", issueNum)
+	}
+}
+
+func TestFindIssueEmpty(t *testing.T) {
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd("", 0),
 	}
 
-	exists, err := gh.IssueExists(ctx, "nonexistent-test-issue-12345")
+	ctx := context.Background()
+	issueNum, err := gh.FindIssue(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("FindIssue failed: %v", err)
+	}
+	if issueNum != "" {
+		t.Errorf("issueNum should be empty, got %q", issueNum)
+	}
+}
+
+func TestIssueExistsTrue(t *testing.T) {
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd("42", 0),
+	}
+
+	ctx := context.Background()
+	exists, err := gh.IssueExists(ctx, "test query")
 	if err != nil {
 		t.Fatalf("IssueExists failed: %v", err)
 	}
+	if !exists {
+		t.Error("IssueExists should return true when issue is found")
+	}
+}
 
+func TestIssueExistsFalse(t *testing.T) {
+	gh := &GitHubIntegration{
+		command:     "gh",
+		execCommand: mockCmd("null", 0),
+	}
+
+	ctx := context.Background()
+	exists, err := gh.IssueExists(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("IssueExists failed: %v", err)
+	}
 	if exists {
-		t.Error("expected nonexistent issue to return false")
+		t.Error("IssueExists should return false when issue is not found")
 	}
 }


### PR DESCRIPTION
## Summary
- Add command injection support for testing
- Add unit tests with mocked commands
- Increase coverage from 21% to 90%

## Changes
- Add `CommandFunc` type and `execCommand` field to `GitHubIntegration`
- Add `mockCmd` helper using TestHelperProcess pattern
- Add tests: `TestCheckAuth{Success,Failure}`, `TestCreateIssue{Success,Failure}`, `TestFindIssue{Found,NotFound,Empty}`, `TestIssueExists{True,False}`

## Test plan
- [x] `go test -cover ./pkg/integrations/...` shows 90.9% coverage
- [x] All 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)