### PR TITLE
feat(tui): Add command palette with Ctrl+K (#1098)

### DIFF
--- a/tui/src/__tests__/components/CommandPalette.test.tsx
+++ b/tui/src/__tests__/components/CommandPalette.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * CommandPalette.test.tsx - Tests for command palette component
+ * Issue #1098: Command palette implementation
+ */
+
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { CommandPalette } from '../../components/CommandPalette';
+import { getAllCommands, type BcCommand } from '../../types/commands';
+
+describe('CommandPalette', () => {
+  describe('rendering', () => {
+    it('should not render when isOpen is false', () => {
+      const { lastFrame } = render(
+        <CommandPalette isOpen={false} onClose={() => {}} disableInput />
+      );
+
+      expect(lastFrame()).toBe('');
+    });
+
+    it('should render when isOpen is true', () => {
+      const { lastFrame } = render(
+        <CommandPalette isOpen={true} onClose={() => {}} disableInput />
+      );
+
+      expect(lastFrame()).toContain('>');
+      expect(lastFrame()).toContain('navigate');
+    });
+
+    it('should show command results', () => {
+      const { lastFrame } = render(
+        <CommandPalette isOpen={true} onClose={() => {}} disableInput />
+      );
+
+      // Should show some commands from the registry
+      const commands = getAllCommands();
+      expect(commands.length).toBeGreaterThan(0);
+      // First command should be visible (at least part of its name)
+      expect(lastFrame()).toBeTruthy();
+    });
+
+    it('should show footer hints', () => {
+      const { lastFrame } = render(
+        <CommandPalette isOpen={true} onClose={() => {}} disableInput />
+      );
+
+      expect(lastFrame()).toContain('↑/↓');
+      expect(lastFrame()).toContain('Enter');
+      expect(lastFrame()).toContain('Esc');
+    });
+  });
+
+  describe('recent commands', () => {
+    it('should mark recent commands with asterisk', () => {
+      const { lastFrame } = render(
+        <CommandPalette
+          isOpen={true}
+          onClose={() => {}}
+          recentCommands={['agent status']}
+          disableInput
+        />
+      );
+
+      expect(lastFrame()).toContain('*');
+    });
+
+    it('should show recent commands first', () => {
+      const { lastFrame } = render(
+        <CommandPalette
+          isOpen={true}
+          onClose={() => {}}
+          recentCommands={['logs']}
+          disableInput
+        />
+      );
+
+      // logs should appear (it's in the recent list)
+      expect(lastFrame()).toContain('logs');
+    });
+  });
+
+  describe('max results', () => {
+    it('should respect maxResults prop', () => {
+      const { lastFrame } = render(
+        <CommandPalette
+          isOpen={true}
+          onClose={() => {}}
+          maxResults={3}
+          disableInput
+        />
+      );
+
+      // Should show limited results
+      const frame = lastFrame() ?? '';
+      // Count the number of command rows (lines with command names)
+      const lines = frame.split('\n').filter(l => l.includes(' - '));
+      expect(lines.length).toBeLessThanOrEqual(3);
+    });
+  });
+
+  describe('search input', () => {
+    it('should show cursor indicator', () => {
+      const { lastFrame } = render(
+        <CommandPalette isOpen={true} onClose={() => {}} disableInput />
+      );
+
+      expect(lastFrame()).toContain('|'); // Cursor
+    });
+
+    it('should display divider', () => {
+      const { lastFrame } = render(
+        <CommandPalette isOpen={true} onClose={() => {}} disableInput />
+      );
+
+      expect(lastFrame()).toContain('─');
+    });
+  });
+
+  describe('command row', () => {
+    it('should show command name and description', () => {
+      const { lastFrame } = render(
+        <CommandPalette isOpen={true} onClose={() => {}} disableInput />
+      );
+
+      // Should contain the separator between name and description
+      expect(lastFrame()).toContain(' - ');
+    });
+  });
+
+  describe('empty state', () => {
+    // This test would require simulating typing a query that matches nothing
+    // For now, we test that the component handles the empty case gracefully
+    it('should handle empty commands gracefully', () => {
+      // The component relies on getAllCommands which always returns commands
+      // So we just verify it renders without error
+      const { lastFrame } = render(
+        <CommandPalette isOpen={true} onClose={() => {}} disableInput />
+      );
+
+      expect(lastFrame()).toBeTruthy();
+    });
+  });
+
+  describe('props', () => {
+    it('should accept onSelect callback', () => {
+      let selectedCommand: BcCommand | undefined;
+      const onSelect = (cmd: BcCommand) => { selectedCommand = cmd; };
+
+      const { lastFrame } = render(
+        <CommandPalette
+          isOpen={true}
+          onClose={() => {}}
+          onSelect={onSelect}
+          disableInput
+        />
+      );
+
+      // Component renders without error
+      expect(lastFrame()).toBeTruthy();
+      // Initially no command selected via callback
+      expect(selectedCommand).toBeUndefined();
+    });
+
+    it('should call onClose when closed', () => {
+      let closeCalled = false;
+      const onClose = () => { closeCalled = true; };
+
+      // Just verify it accepts the callback
+      const { lastFrame } = render(
+        <CommandPalette
+          isOpen={true}
+          onClose={onClose}
+          disableInput
+        />
+      );
+
+      expect(lastFrame()).toBeTruthy();
+    });
+  });
+});

--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -27,6 +27,8 @@ import { WorktreesView } from './views/WorktreesView';
 import { WorkspaceSelectorView } from './views/WorkspaceSelectorView';
 import { DemonsView } from './views/DemonsView';
 import { ProcessesView } from './views/ProcessesView';
+import { CommandPalette } from './components/CommandPalette';
+import { type BcCommand } from './types/commands';
 
 interface AppProps {
   /** Disable input handling (useful for testing) */
@@ -87,9 +89,10 @@ interface AppContentProps {
 }
 
 function AppContent({ disableInput, themeConfig }: AppContentProps): React.ReactElement {
-  const { currentView } = useNavigation();
+  const { currentView, navigate } = useNavigation();
   const { stdout } = useStdout();
   const { setThemeName } = useTheme();
+  const [showCommandPalette, setShowCommandPalette] = useState(false);
 
   // Apply configured theme on mount or when config changes
   React.useEffect(() => {
@@ -99,8 +102,37 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
     }
   }, [themeConfig.theme, setThemeName]);
 
+  // Handle command palette selection - navigate to view if applicable
+  const handleCommandSelect = (command: BcCommand): void => {
+    // Map command names to views
+    const viewMap: Record<string, View> = {
+      'agent status': 'agents',
+      'agent list': 'agents',
+      'agent peek': 'agents',
+      'channel list': 'channels',
+      'channel history': 'channels',
+      'cost show': 'costs',
+      'logs': 'logs',
+      'status': 'dashboard',
+      'stats': 'dashboard',
+      'process list': 'processes',
+      'demon list': 'demons',
+      'role list': 'roles',
+      'help': 'help',
+    };
+
+    const targetView = viewMap[command.name] as View | undefined;
+    if (targetView !== undefined) {
+      navigate(targetView);
+    }
+    setShowCommandPalette(false);
+  };
+
   // Handle global keyboard navigation
-  useKeyboardNavigation({ disabled: disableInput });
+  useKeyboardNavigation({
+    disabled: disableInput || showCommandPalette,
+    onCommandPalette: () => { setShowCommandPalette(true); },
+  });
 
   // Get terminal dimensions - constrain to actual terminal height
   const terminalHeight = stdout.rows;
@@ -121,6 +153,17 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
 
       {/* Footer with navigation hints - anchored to bottom */}
       <Footer />
+
+      {/* Command palette overlay */}
+      {showCommandPalette && (
+        <Box position="absolute" marginTop={2} marginLeft={10}>
+          <CommandPalette
+            isOpen={showCommandPalette}
+            onClose={() => { setShowCommandPalette(false); }}
+            onSelect={handleCommandSelect}
+          />
+        </Box>
+      )}
     </Box>
   );
 }

--- a/tui/src/components/CommandPalette.tsx
+++ b/tui/src/components/CommandPalette.tsx
@@ -1,0 +1,182 @@
+/**
+ * CommandPalette - Quick command search and execution (Ctrl+K)
+ * Issue #1098: Implement command palette for quick navigation
+ */
+
+import React, { useState, useMemo, useCallback } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { searchCommands, getAllCommands, type BcCommand } from '../types/commands';
+
+export interface CommandPaletteProps {
+  /** Whether the palette is visible */
+  isOpen: boolean;
+  /** Called when palette should close */
+  onClose: () => void;
+  /** Called when a command is selected */
+  onSelect?: (command: BcCommand) => void;
+  /** Recently used commands (stored externally) */
+  recentCommands?: string[];
+  /** Maximum results to show */
+  maxResults?: number;
+  /** Disable input handling (for testing) */
+  disableInput?: boolean;
+}
+
+/**
+ * Command palette with fuzzy search
+ */
+export function CommandPalette({
+  isOpen,
+  onClose,
+  onSelect,
+  recentCommands = [],
+  maxResults = 8,
+  disableInput = false,
+}: CommandPaletteProps): React.ReactElement | null {
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  // Get filtered commands based on query
+  const results = useMemo(() => {
+    if (!query.trim()) {
+      // Show recent commands first, then all commands
+      const allCommands = getAllCommands();
+      const recent = recentCommands
+        .map(name => allCommands.find(c => c.name === name))
+        .filter((c): c is BcCommand => c !== undefined);
+
+      // Dedupe and limit
+      const seen = new Set(recent.map(c => c.name));
+      const rest = allCommands.filter(c => !seen.has(c.name));
+      return [...recent, ...rest].slice(0, maxResults);
+    }
+    return searchCommands(query).slice(0, maxResults);
+  }, [query, recentCommands, maxResults]);
+
+  // Reset selection when results change
+  const handleQueryChange = useCallback((newQuery: string) => {
+    setQuery(newQuery);
+    setSelectedIndex(0);
+  }, []);
+
+  // Handle keyboard input
+  useInput(
+    (input, key) => {
+      if (!isOpen) return;
+
+      // Close on Escape
+      if (key.escape) {
+        setQuery('');
+        setSelectedIndex(0);
+        onClose();
+        return;
+      }
+
+      // Navigate results
+      if (key.upArrow) {
+        setSelectedIndex(i => (i > 0 ? i - 1 : results.length - 1));
+        return;
+      }
+      if (key.downArrow) {
+        setSelectedIndex(i => (i < results.length - 1 ? i + 1 : 0));
+        return;
+      }
+
+      // Select command
+      if (key.return && results[selectedIndex]) {
+        const selected = results[selectedIndex];
+        setQuery('');
+        setSelectedIndex(0);
+        onSelect?.(selected);
+        onClose();
+        return;
+      }
+
+      // Backspace
+      if (key.backspace || key.delete) {
+        handleQueryChange(query.slice(0, -1));
+        return;
+      }
+
+      // Type character
+      if (input && !key.ctrl && !key.meta) {
+        handleQueryChange(query + input);
+      }
+    },
+    { isActive: isOpen && !disableInput }
+  );
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor="cyan"
+      paddingX={1}
+      paddingY={0}
+    >
+      {/* Search input */}
+      <Box>
+        <Text color="cyan" bold>{'> '}</Text>
+        <Text>{query}</Text>
+        <Text color="cyan">|</Text>
+      </Box>
+
+      {/* Divider */}
+      <Box>
+        <Text dimColor>{'─'.repeat(40)}</Text>
+      </Box>
+
+      {/* Results */}
+      {results.length === 0 ? (
+        <Box>
+          <Text dimColor>No commands found</Text>
+        </Box>
+      ) : (
+        results.map((cmd, index) => (
+          <CommandRow
+            key={cmd.name}
+            command={cmd}
+            isSelected={index === selectedIndex}
+            isRecent={recentCommands.includes(cmd.name)}
+          />
+        ))
+      )}
+
+      {/* Footer hints */}
+      <Box marginTop={1}>
+        <Text dimColor>
+          ↑/↓: navigate  Enter: select  Esc: close
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+interface CommandRowProps {
+  command: BcCommand;
+  isSelected: boolean;
+  isRecent: boolean;
+}
+
+function CommandRow({ command, isSelected, isRecent }: CommandRowProps): React.ReactElement {
+  return (
+    <Box>
+      <Text
+        color={isSelected ? 'cyan' : undefined}
+        bold={isSelected}
+        inverse={isSelected}
+      >
+        {isSelected ? '> ' : '  '}
+        {isRecent && <Text color="yellow">* </Text>}
+        <Text bold={isSelected}>{command.name}</Text>
+        <Text dimColor> - {command.description.slice(0, 35)}</Text>
+      </Text>
+    </Box>
+  );
+}
+
+export default CommandPalette;

--- a/tui/src/components/index.ts
+++ b/tui/src/components/index.ts
@@ -104,3 +104,7 @@ export type {
   MiniBarChartProps,
   DistributionChartProps,
 } from './BarChart';
+
+// Command palette (#1098)
+export { CommandPalette } from './CommandPalette';
+export type { CommandPaletteProps } from './CommandPalette';

--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -13,6 +13,8 @@ export interface UseKeyboardNavigationOptions {
   onQuit?: () => void;
   /** Global refresh handler (triggered by Ctrl+R) */
   onRefresh?: () => void;
+  /** Command palette handler (triggered by Ctrl+K) */
+  onCommandPalette?: () => void;
 }
 
 /**
@@ -25,7 +27,7 @@ export interface UseKeyboardNavigationOptions {
  * - q quits the application
  */
 export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}): void {
-  const { disabled = false, onQuit, onRefresh } = options;
+  const { disabled = false, onQuit, onRefresh, onCommandPalette } = options;
   const { navigate, goHome, getTabByKey, nextTab, prevTab } = useNavigation();
   const { isFocused } = useFocus();
 
@@ -77,6 +79,14 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
       if (key.ctrl && input === 'r') {
         if (onRefresh) {
           onRefresh();
+        }
+        return;
+      }
+
+      // Ctrl+K: open command palette
+      if (key.ctrl && input === 'k') {
+        if (onCommandPalette) {
+          onCommandPalette();
         }
         return;
       }


### PR DESCRIPTION
## Summary
- Add CommandPalette component with fuzzy search for bc commands
- Add Ctrl+K keyboard handler to open command palette globally
- Navigate to matching views when commands are selected (e.g., "agent list" → Agents view)
- Add 13 tests for CommandPalette component

## Features
- Fuzzy search across all bc commands
- Recent commands shown first (marked with *)
- Up/Down arrow navigation, Enter to select, Esc to close
- Maps commands to TUI views where applicable

## Test plan
- [x] `bun run build` - compiles successfully
- [x] `bun run lint` - no errors (8 pre-existing warnings)
- [x] `bun test CommandPalette` - 13 tests pass
- [ ] Manual: Press Ctrl+K, type to search, select command

Closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)