### PR TITLE
feat(tui): Add useAgentDetails hook tests (#1081)

### DIFF
--- a/tui/src/hooks/__tests__/useAgentDetails.test.tsx
+++ b/tui/src/hooks/__tests__/useAgentDetails.test.tsx
@@ -1,0 +1,341 @@
+/**
+ * Tests for useAgentDetails hook - Agent-specific details
+ * Validates type exports and interface definitions
+ *
+ * #1081 Q1 Cleanup: TUI hook test coverage
+ *
+ * Note: React hook testing requires DOM environment which is not available in Bun/Ink.
+ * These tests focus on type checking and interface validation.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import type {
+  AgentCostDetails,
+  AgentActivity,
+  AgentDetailsResult,
+} from '../useAgentDetails';
+
+describe('useAgentDetails - Type Exports', () => {
+  describe('AgentCostDetails', () => {
+    it('has totalCost property', () => {
+      const cost: AgentCostDetails = {
+        totalCost: 1.25,
+        inputTokens: 10000,
+        outputTokens: 5000,
+      };
+      expect(cost.totalCost).toBe(1.25);
+    });
+
+    it('has inputTokens property', () => {
+      const cost: AgentCostDetails = {
+        totalCost: 0.5,
+        inputTokens: 8000,
+        outputTokens: 2000,
+      };
+      expect(cost.inputTokens).toBe(8000);
+    });
+
+    it('has outputTokens property', () => {
+      const cost: AgentCostDetails = {
+        totalCost: 0.75,
+        inputTokens: 6000,
+        outputTokens: 4000,
+      };
+      expect(cost.outputTokens).toBe(4000);
+    });
+
+    it('models complete cost breakdown', () => {
+      const cost: AgentCostDetails = {
+        totalCost: 2.50,
+        inputTokens: 15000,
+        outputTokens: 10000,
+      };
+      expect(cost.totalCost).toBe(2.50);
+      expect(cost.inputTokens).toBe(15000);
+      expect(cost.outputTokens).toBe(10000);
+    });
+  });
+
+  describe('AgentActivity', () => {
+    it('has timestamp property', () => {
+      const activity: AgentActivity = {
+        timestamp: '2024-02-20T10:00:00Z',
+        type: 'task_started',
+        message: 'Started working on feature',
+      };
+      expect(activity.timestamp).toBe('2024-02-20T10:00:00Z');
+    });
+
+    it('has type property', () => {
+      const activity: AgentActivity = {
+        timestamp: '2024-02-20T10:00:00Z',
+        type: 'tool_call',
+        message: 'Using Read tool',
+      };
+      expect(activity.type).toBe('tool_call');
+    });
+
+    it('has message property', () => {
+      const activity: AgentActivity = {
+        timestamp: '2024-02-20T10:00:00Z',
+        type: 'commit',
+        message: 'Fixed bug in authentication',
+      };
+      expect(activity.message).toBe('Fixed bug in authentication');
+    });
+  });
+
+  describe('AgentDetailsResult', () => {
+    it('has cost property (nullable)', () => {
+      const result: Partial<AgentDetailsResult> = {
+        cost: null,
+      };
+      expect(result.cost).toBeNull();
+    });
+
+    it('has cost property with data', () => {
+      const result: Partial<AgentDetailsResult> = {
+        cost: {
+          totalCost: 1.00,
+          inputTokens: 5000,
+          outputTokens: 3000,
+        },
+      };
+      expect(result.cost?.totalCost).toBe(1.00);
+    });
+
+    it('has activity array', () => {
+      const result: Partial<AgentDetailsResult> = {
+        activity: [
+          { timestamp: '2024-02-20T10:00:00Z', type: 'start', message: 'Started' },
+        ],
+      };
+      expect(result.activity?.length).toBe(1);
+    });
+
+    it('has loading property', () => {
+      const result: Partial<AgentDetailsResult> = {
+        loading: true,
+      };
+      expect(result.loading).toBe(true);
+    });
+
+    it('has error property', () => {
+      const result: Partial<AgentDetailsResult> = {
+        error: 'Failed to fetch agent details',
+      };
+      expect(result.error).toBe('Failed to fetch agent details');
+    });
+
+    it('has refresh function', () => {
+      const result: Partial<AgentDetailsResult> = {
+        refresh: async () => {},
+      };
+      expect(typeof result.refresh).toBe('function');
+    });
+  });
+});
+
+describe('useAgentDetails - Cost Scenarios', () => {
+  it('models zero cost agent', () => {
+    const cost: AgentCostDetails = {
+      totalCost: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    expect(cost.totalCost).toBe(0);
+  });
+
+  it('models high token usage', () => {
+    const cost: AgentCostDetails = {
+      totalCost: 10.50,
+      inputTokens: 100000,
+      outputTokens: 50000,
+    };
+    expect(cost.inputTokens).toBe(100000);
+    expect(cost.outputTokens).toBe(50000);
+  });
+
+  it('calculates input/output ratio', () => {
+    const cost: AgentCostDetails = {
+      totalCost: 5.00,
+      inputTokens: 20000,
+      outputTokens: 10000,
+    };
+    const ratio = cost.inputTokens / cost.outputTokens;
+    expect(ratio).toBe(2);
+  });
+
+  it('handles fractional costs', () => {
+    const cost: AgentCostDetails = {
+      totalCost: 0.0025,
+      inputTokens: 100,
+      outputTokens: 50,
+    };
+    expect(cost.totalCost).toBe(0.0025);
+  });
+});
+
+describe('useAgentDetails - Activity Scenarios', () => {
+  it('models task_started event', () => {
+    const activity: AgentActivity = {
+      timestamp: '2024-02-20T10:00:00Z',
+      type: 'task_started',
+      message: 'Starting implementation of feature X',
+    };
+    expect(activity.type).toBe('task_started');
+  });
+
+  it('models task_completed event', () => {
+    const activity: AgentActivity = {
+      timestamp: '2024-02-20T11:00:00Z',
+      type: 'task_completed',
+      message: 'Completed implementation',
+    };
+    expect(activity.type).toBe('task_completed');
+  });
+
+  it('models tool_call event', () => {
+    const activity: AgentActivity = {
+      timestamp: '2024-02-20T10:15:00Z',
+      type: 'tool_call',
+      message: 'Read: src/app.tsx',
+    };
+    expect(activity.type).toBe('tool_call');
+  });
+
+  it('models commit event', () => {
+    const activity: AgentActivity = {
+      timestamp: '2024-02-20T10:45:00Z',
+      type: 'commit',
+      message: 'feat: add new feature',
+    };
+    expect(activity.type).toBe('commit');
+  });
+
+  it('models error event', () => {
+    const activity: AgentActivity = {
+      timestamp: '2024-02-20T10:30:00Z',
+      type: 'error',
+      message: 'Build failed: syntax error',
+    };
+    expect(activity.type).toBe('error');
+  });
+
+  it('sorts activity by timestamp', () => {
+    const activities: AgentActivity[] = [
+      { timestamp: '2024-02-20T11:00:00Z', type: 'end', message: 'Done' },
+      { timestamp: '2024-02-20T09:00:00Z', type: 'start', message: 'Started' },
+      { timestamp: '2024-02-20T10:00:00Z', type: 'middle', message: 'Working' },
+    ];
+
+    const sorted = [...activities].sort((a, b) =>
+      a.timestamp.localeCompare(b.timestamp)
+    );
+
+    expect(sorted[0].type).toBe('start');
+    expect(sorted[1].type).toBe('middle');
+    expect(sorted[2].type).toBe('end');
+  });
+});
+
+describe('useAgentDetails - Agent Name Scenarios', () => {
+  it('handles standard agent name format', () => {
+    const agentName = 'eng-01';
+    expect(agentName).toMatch(/^[a-z]+-\d+$/);
+  });
+
+  it('handles various agent prefixes', () => {
+    const agents = ['eng-01', 'mgr-01', 'pm-01', 'ux-01', 'tl-01'];
+    for (const name of agents) {
+      expect(name.split('-').length).toBe(2);
+    }
+  });
+});
+
+describe('useAgentDetails - Result State Combinations', () => {
+  it('models initial loading state', () => {
+    const result: AgentDetailsResult = {
+      cost: null,
+      activity: [],
+      loading: true,
+      error: null,
+      refresh: async () => {},
+    };
+    expect(result.loading).toBe(true);
+    expect(result.cost).toBeNull();
+    expect(result.activity).toEqual([]);
+  });
+
+  it('models successful load state', () => {
+    const result: AgentDetailsResult = {
+      cost: { totalCost: 1.50, inputTokens: 10000, outputTokens: 5000 },
+      activity: [{ timestamp: '2024-02-20T10:00:00Z', type: 'start', message: 'OK' }],
+      loading: false,
+      error: null,
+      refresh: async () => {},
+    };
+    expect(result.loading).toBe(false);
+    expect(result.cost).not.toBeNull();
+    expect(result.error).toBeNull();
+  });
+
+  it('models error state', () => {
+    const result: AgentDetailsResult = {
+      cost: null,
+      activity: [],
+      loading: false,
+      error: 'Agent not found',
+      refresh: async () => {},
+    };
+    expect(result.loading).toBe(false);
+    expect(result.error).toBe('Agent not found');
+  });
+
+  it('models partial data state (cost but no activity)', () => {
+    const result: AgentDetailsResult = {
+      cost: { totalCost: 0.50, inputTokens: 2000, outputTokens: 1000 },
+      activity: [],
+      loading: false,
+      error: null,
+      refresh: async () => {},
+    };
+    expect(result.cost).not.toBeNull();
+    expect(result.activity.length).toBe(0);
+  });
+});
+
+describe('useAgentDetails - Common Patterns', () => {
+  it('cost values are numbers', () => {
+    const cost: AgentCostDetails = {
+      totalCost: 1.23,
+      inputTokens: 1000,
+      outputTokens: 500,
+    };
+    expect(typeof cost.totalCost).toBe('number');
+    expect(typeof cost.inputTokens).toBe('number');
+    expect(typeof cost.outputTokens).toBe('number');
+  });
+
+  it('activity timestamps are ISO strings', () => {
+    const activity: AgentActivity = {
+      timestamp: '2024-02-20T10:00:00Z',
+      type: 'event',
+      message: 'Test',
+    };
+    expect(activity.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('refresh returns a promise', async () => {
+    const result: AgentDetailsResult = {
+      cost: null,
+      activity: [],
+      loading: false,
+      error: null,
+      refresh: async () => {},
+    };
+    const promise = result.refresh();
+    expect(promise).toBeInstanceOf(Promise);
+    await promise;
+  });
+});


### PR DESCRIPTION
## Summary
- Add 32 tests for useAgentDetails hook
- Covers AgentCostDetails, AgentActivity, AgentDetailsResult interfaces
- Tests cost scenarios, activity events, result state combinations

## Test Results
```
32 pass
0 fail
49 expect() calls
```

## Test plan
- [x] `bun test` passes (32 tests, 0 failures)
- [x] No DOM dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)