### PR TITLE
fix(tui): Fix dot-notation lint errors (#1068)

### DIFF
--- a/tui/src/hooks/__tests__/useDashboard.test.ts
+++ b/tui/src/hooks/__tests__/useDashboard.test.ts
@@ -184,9 +184,9 @@ describe('useDashboard - Summary Calculations (Unit Logic)', () => {
         byRole[agent.role] = (byRole[agent.role] || 0) + 1;
       }
 
-      expect(byRole['engineer']).toBe(2);
-      expect(byRole['manager']).toBe(1);
-      expect(byRole['root']).toBe(1);
+      expect(byRole.engineer).toBe(2);
+      expect(byRole.manager).toBe(1);
+      expect(byRole.root).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fix 3 ESLint dot-notation errors in useDashboard.test.ts
- Changes bracket notation to dot notation for object property access

## Test plan
- [x] `bun run lint` shows 0 errors (down from 3)
- [x] Only 8 warnings remain (React hooks exhaustive-deps, not actionable)

Part of #1081 Q1 Cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)