### PR TITLE
fix(tui): Handle Enter key in autocomplete to complete mention (#1124)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -278,8 +278,8 @@ function ChannelHistoryView({
             autocomplete.moveDown();
             return;
           }
-          if (key.tab) {
-            // Complete the mention
+          // Complete mention with Tab or Enter
+          if (key.tab || key.return) {
             const completed = autocomplete.complete();
             setMessageBuffer(completed);
             return;


### PR DESCRIPTION
## Summary
- When autocomplete dropdown is active, Enter key now completes the selected mention
- Previously, Enter would send the incomplete message (e.g., "@en" instead of "@eng-01")
- Tab key also continues to work for completion

## Root Cause
The Enter key handler for sending messages was reached before the autocomplete Enter handler due to missing `key.return` in the autocomplete condition.

## Fix
Added `key.return` to the autocomplete completion condition alongside `key.tab`:
```typescript
// Before
if (key.tab) {
  const completed = autocomplete.complete();
  ...
}

// After
if (key.tab || key.return) {
  const completed = autocomplete.complete();
  ...
}
```

## Test plan
- [x] `bun run build` compiles successfully
- [x] `bun run lint` - 0 errors
- [ ] Manual: Type "@en", select with arrow keys, press Enter - mention should complete, not send

Fixes #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)