### PR TITLE
feat(pkg/ui): Add centralized CLI output formatting package (#1131)

### DIFF
--- a/pkg/ui/color.go
+++ b/pkg/ui/color.go
@@ -1,0 +1,122 @@
+// Package ui provides consistent CLI output formatting utilities.
+package ui
+
+import (
+	"os"
+
+	"github.com/charmbracelet/x/term"
+)
+
+// ANSI color codes
+const (
+	Reset  = "\033[0m"
+	Bold   = "\033[1m"
+	Dim    = "\033[2m"
+	Italic = "\033[3m"
+	Under  = "\033[4m"
+
+	// Foreground colors
+	Black   = "\033[30m"
+	Red     = "\033[31m"
+	Green   = "\033[32m"
+	Yellow  = "\033[33m"
+	Blue    = "\033[34m"
+	Magenta = "\033[35m"
+	Cyan    = "\033[36m"
+	White   = "\033[37m"
+
+	// Bright foreground colors
+	BrightBlack   = "\033[90m"
+	BrightRed     = "\033[91m"
+	BrightGreen   = "\033[92m"
+	BrightYellow  = "\033[93m"
+	BrightBlue    = "\033[94m"
+	BrightMagenta = "\033[95m"
+	BrightCyan    = "\033[96m"
+	BrightWhite   = "\033[97m"
+)
+
+// colorEnabled caches whether colors should be used.
+var colorEnabled = checkColorSupport()
+
+// checkColorSupport determines if the terminal supports colors.
+func checkColorSupport() bool {
+	// Respect NO_COLOR environment variable
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	// Check if stdout is a terminal
+	return term.IsTerminal(os.Stdout.Fd())
+}
+
+// SetColorEnabled overrides automatic color detection.
+func SetColorEnabled(enabled bool) {
+	colorEnabled = enabled
+}
+
+// ColorEnabled returns whether colors are enabled.
+func ColorEnabled() bool {
+	return colorEnabled
+}
+
+// Color wraps text in the given color code if colors are enabled.
+func Color(text, color string) string {
+	if !colorEnabled {
+		return text
+	}
+	return color + text + Reset
+}
+
+// Colorize applies color to text.
+func Colorize(text string, codes ...string) string {
+	if !colorEnabled || len(codes) == 0 {
+		return text
+	}
+	var prefix string
+	for _, c := range codes {
+		prefix += c
+	}
+	return prefix + text + Reset
+}
+
+// Style helpers for common formatting patterns.
+
+// BoldText makes text bold.
+func BoldText(text string) string {
+	return Color(text, Bold)
+}
+
+// DimText makes text dim.
+func DimText(text string) string {
+	return Color(text, Dim)
+}
+
+// RedText colors text red.
+func RedText(text string) string {
+	return Color(text, Red)
+}
+
+// GreenText colors text green.
+func GreenText(text string) string {
+	return Color(text, Green)
+}
+
+// YellowText colors text yellow.
+func YellowText(text string) string {
+	return Color(text, Yellow)
+}
+
+// BlueText colors text blue.
+func BlueText(text string) string {
+	return Color(text, Blue)
+}
+
+// CyanText colors text cyan.
+func CyanText(text string) string {
+	return Color(text, Cyan)
+}
+
+// MagentaText colors text magenta.
+func MagentaText(text string) string {
+	return Color(text, Magenta)
+}

--- a/pkg/ui/list.go
+++ b/pkg/ui/list.go
@@ -1,0 +1,89 @@
+//nolint:errcheck // UI output errors to stdout are not recoverable
+package ui
+
+import (
+	"fmt"
+)
+
+// ListItem represents an item in a list.
+type ListItem struct {
+	Text   string
+	Detail string
+}
+
+// List prints a bulleted list.
+func List(items ...string) {
+	for _, item := range items {
+		if colorEnabled {
+			fmt.Fprintf(output, "  %s•%s %s\n", Dim, Reset, item)
+		} else {
+			fmt.Fprintf(output, "  • %s\n", item)
+		}
+	}
+}
+
+// NumberedList prints a numbered list.
+func NumberedList(items ...string) {
+	for i, item := range items {
+		if colorEnabled {
+			fmt.Fprintf(output, "  %s%d.%s %s\n", Dim, i+1, Reset, item)
+		} else {
+			fmt.Fprintf(output, "  %d. %s\n", i+1, item)
+		}
+	}
+}
+
+// CheckList prints a list with checkmarks.
+func CheckList(items ...ListItem) {
+	for _, item := range items {
+		if item.Detail != "" {
+			if colorEnabled {
+				fmt.Fprintf(output, "  %s✓%s %s %s(%s)%s\n",
+					Green, Reset, item.Text, Dim, item.Detail, Reset)
+			} else {
+				fmt.Fprintf(output, "  ✓ %s (%s)\n", item.Text, item.Detail)
+			}
+		} else {
+			if colorEnabled {
+				fmt.Fprintf(output, "  %s✓%s %s\n", Green, Reset, item.Text)
+			} else {
+				fmt.Fprintf(output, "  ✓ %s\n", item.Text)
+			}
+		}
+	}
+}
+
+// IndentedList prints a list with custom indent.
+func IndentedList(indent int, items ...string) {
+	prefix := ""
+	for range indent {
+		prefix += "  "
+	}
+	for _, item := range items {
+		if colorEnabled {
+			fmt.Fprintf(output, "%s%s•%s %s\n", prefix, Dim, Reset, item)
+		} else {
+			fmt.Fprintf(output, "%s• %s\n", prefix, item)
+		}
+	}
+}
+
+// KeyValueList prints a list of key-value pairs.
+func KeyValueList(pairs map[string]string) {
+	// Find max key length
+	maxLen := 0
+	for k := range pairs {
+		if len(k) > maxLen {
+			maxLen = len(k)
+		}
+	}
+
+	for k, v := range pairs {
+		if colorEnabled {
+			fmt.Fprintf(output, "  %s%s:%s %s\n",
+				Bold, padRight(k, maxLen), Reset, v)
+		} else {
+			fmt.Fprintf(output, "  %s: %s\n", padRight(k, maxLen), v)
+		}
+	}
+}

--- a/pkg/ui/message.go
+++ b/pkg/ui/message.go
@@ -1,0 +1,132 @@
+//nolint:errcheck // UI output errors to stdout are not recoverable
+package ui
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Default output writer (can be overridden for testing).
+var output io.Writer = os.Stdout
+
+// SetOutput sets the output writer for all messages.
+func SetOutput(w io.Writer) {
+	output = w
+}
+
+// Message prefixes with colors.
+const (
+	successPrefix = "✓"
+	errorPrefix   = "✗"
+	warningPrefix = "!"
+	infoPrefix    = "→"
+	debugPrefix   = "·"
+)
+
+// Success prints a success message with green checkmark.
+func Success(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if colorEnabled {
+		fmt.Fprintf(output, "%s%s%s %s\n", Green, successPrefix, Reset, msg)
+	} else {
+		fmt.Fprintf(output, "%s %s\n", successPrefix, msg)
+	}
+}
+
+// Successf is an alias for Success.
+func Successf(format string, args ...any) {
+	Success(format, args...)
+}
+
+// Error prints an error message with red X.
+func Error(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if colorEnabled {
+		fmt.Fprintf(output, "%s%s%s %s\n", Red, errorPrefix, Reset, msg)
+	} else {
+		fmt.Fprintf(output, "%s %s\n", errorPrefix, msg)
+	}
+}
+
+// Errorf is an alias for Error.
+func Errorf(format string, args ...any) {
+	Error(format, args...)
+}
+
+// Warning prints a warning message with yellow exclamation.
+func Warning(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if colorEnabled {
+		fmt.Fprintf(output, "%s%s%s %s\n", Yellow, warningPrefix, Reset, msg)
+	} else {
+		fmt.Fprintf(output, "%s %s\n", warningPrefix, msg)
+	}
+}
+
+// Warningf is an alias for Warning.
+func Warningf(format string, args ...any) {
+	Warning(format, args...)
+}
+
+// Info prints an info message with blue arrow.
+func Info(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if colorEnabled {
+		fmt.Fprintf(output, "%s%s%s %s\n", Blue, infoPrefix, Reset, msg)
+	} else {
+		fmt.Fprintf(output, "%s %s\n", infoPrefix, msg)
+	}
+}
+
+// Infof is an alias for Info.
+func Infof(format string, args ...any) {
+	Info(format, args...)
+}
+
+// Debug prints a debug message with dim dot (only when verbose).
+func Debug(format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	if colorEnabled {
+		fmt.Fprintf(output, "%s%s %s%s\n", Dim, debugPrefix, msg, Reset)
+	} else {
+		fmt.Fprintf(output, "%s %s\n", debugPrefix, msg)
+	}
+}
+
+// Debugf is an alias for Debug.
+func Debugf(format string, args ...any) {
+	Debug(format, args...)
+}
+
+// Print prints plain text.
+func Print(format string, args ...any) {
+	fmt.Fprintf(output, format, args...)
+}
+
+// Println prints plain text with newline.
+func Println(format string, args ...any) {
+	fmt.Fprintf(output, format+"\n", args...)
+}
+
+// Header prints a bold header line.
+func Header(text string) {
+	if colorEnabled {
+		fmt.Fprintf(output, "%s%s%s\n", Bold, text, Reset)
+	} else {
+		fmt.Fprintf(output, "%s\n", text)
+	}
+}
+
+// Divider prints a horizontal divider line.
+func Divider(width int) {
+	for range width {
+		fmt.Fprint(output, "─")
+	}
+	fmt.Fprintln(output)
+}
+
+// BlankLine prints an empty line.
+func BlankLine() {
+	fmt.Fprintln(output)
+}

--- a/pkg/ui/table.go
+++ b/pkg/ui/table.go
@@ -1,0 +1,126 @@
+//nolint:errcheck // UI output errors to stdout are not recoverable
+package ui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Table represents a formatted table for CLI output.
+type Table struct {
+	headers []string
+	rows    [][]string
+	widths  []int
+}
+
+// NewTable creates a new table with the given headers.
+func NewTable(headers ...string) *Table {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	return &Table{
+		headers: headers,
+		rows:    make([][]string, 0),
+		widths:  widths,
+	}
+}
+
+// AddRow adds a row to the table.
+func (t *Table) AddRow(values ...string) {
+	// Ensure row has correct number of columns
+	row := make([]string, len(t.headers))
+	for i := 0; i < len(t.headers) && i < len(values); i++ {
+		row[i] = values[i]
+		if len(values[i]) > t.widths[i] {
+			t.widths[i] = len(values[i])
+		}
+	}
+	t.rows = append(t.rows, row)
+}
+
+// String renders the table as a string.
+func (t *Table) String() string {
+	var sb strings.Builder
+
+	// Render header
+	t.renderRow(&sb, t.headers, true)
+
+	// Render separator
+	t.renderSeparator(&sb)
+
+	// Render rows
+	for _, row := range t.rows {
+		t.renderRow(&sb, row, false)
+	}
+
+	return sb.String()
+}
+
+// Print renders and prints the table.
+func (t *Table) Print() {
+	fmt.Fprint(output, t.String())
+}
+
+// renderRow renders a single row.
+func (t *Table) renderRow(sb *strings.Builder, values []string, isHeader bool) {
+	for i, val := range values {
+		if i > 0 {
+			sb.WriteString("  ")
+		}
+		padded := padRight(val, t.widths[i])
+		if isHeader && colorEnabled {
+			sb.WriteString(Bold)
+			sb.WriteString(padded)
+			sb.WriteString(Reset)
+		} else {
+			sb.WriteString(padded)
+		}
+	}
+	sb.WriteString("\n")
+}
+
+// renderSeparator renders a separator line.
+func (t *Table) renderSeparator(sb *strings.Builder) {
+	for i, w := range t.widths {
+		if i > 0 {
+			sb.WriteString("  ")
+		}
+		sb.WriteString(strings.Repeat("─", w))
+	}
+	sb.WriteString("\n")
+}
+
+// padRight pads a string to the right with spaces.
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+// SimpleTable prints a simple key-value table.
+func SimpleTable(pairs ...string) {
+	if len(pairs)%2 != 0 {
+		return
+	}
+
+	// Find max key width
+	maxWidth := 0
+	for i := 0; i < len(pairs); i += 2 {
+		if len(pairs[i]) > maxWidth {
+			maxWidth = len(pairs[i])
+		}
+	}
+
+	// Print rows
+	for i := 0; i < len(pairs); i += 2 {
+		key := pairs[i]
+		val := pairs[i+1]
+		if colorEnabled {
+			fmt.Fprintf(output, "%s%s%s  %s\n", Dim, padRight(key+":", maxWidth+1), Reset, val)
+		} else {
+			fmt.Fprintf(output, "%s  %s\n", padRight(key+":", maxWidth+1), val)
+		}
+	}
+}

--- a/pkg/ui/ui_test.go
+++ b/pkg/ui/ui_test.go
@@ -1,0 +1,272 @@
+package ui
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestColor(t *testing.T) {
+	// Enable colors for testing
+	SetColorEnabled(true)
+
+	tests := []struct {
+		name     string
+		text     string
+		color    string
+		contains string
+	}{
+		{"red text", "error", Red, "\033[31m"},
+		{"green text", "success", Green, "\033[32m"},
+		{"yellow text", "warning", Yellow, "\033[33m"},
+		{"blue text", "info", Blue, "\033[34m"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := Color(tc.text, tc.color)
+			if !strings.Contains(result, tc.contains) {
+				t.Errorf("Color(%q, %q) = %q, want contains %q", tc.text, tc.color, result, tc.contains)
+			}
+			if !strings.Contains(result, tc.text) {
+				t.Errorf("Color(%q, %q) = %q, want contains %q", tc.text, tc.color, result, tc.text)
+			}
+			if !strings.HasSuffix(result, Reset) {
+				t.Errorf("Color(%q, %q) = %q, want suffix %q", tc.text, tc.color, result, Reset)
+			}
+		})
+	}
+}
+
+func TestColorDisabled(t *testing.T) {
+	SetColorEnabled(false)
+	defer SetColorEnabled(true)
+
+	result := Color("test", Red)
+	if result != "test" {
+		t.Errorf("Color with colors disabled = %q, want %q", result, "test")
+	}
+}
+
+func TestColorize(t *testing.T) {
+	SetColorEnabled(true)
+
+	result := Colorize("test", Bold, Red)
+	if !strings.Contains(result, Bold) {
+		t.Errorf("Colorize should contain Bold code")
+	}
+	if !strings.Contains(result, Red) {
+		t.Errorf("Colorize should contain Red code")
+	}
+}
+
+func TestStyleHelpers(t *testing.T) {
+	SetColorEnabled(true)
+
+	tests := []struct {
+		name     string
+		fn       func(string) string
+		contains string
+	}{
+		{"BoldText", BoldText, Bold},
+		{"DimText", DimText, Dim},
+		{"RedText", RedText, Red},
+		{"GreenText", GreenText, Green},
+		{"YellowText", YellowText, Yellow},
+		{"BlueText", BlueText, Blue},
+		{"CyanText", CyanText, Cyan},
+		{"MagentaText", MagentaText, Magenta},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.fn("test")
+			if !strings.Contains(result, tc.contains) {
+				t.Errorf("%s should contain %q", tc.name, tc.contains)
+			}
+		})
+	}
+}
+
+func TestMessages(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	defer SetOutput(nil)
+	SetColorEnabled(false)
+
+	tests := []struct { //nolint:govet // test struct alignment not critical
+		args     []any
+		fn       func(string, ...any)
+		name     string
+		prefix   string
+		format   string
+		contains string
+	}{
+		{[]any{"task"}, Success, "Success", "✓", "done %s", "done task"},
+		{[]any{"op"}, Error, "Error", "✗", "failed %s", "failed op"},
+		{[]any{42}, Warning, "Warning", "!", "warn %d", "warn 42"},
+		{[]any{true}, Info, "Info", "→", "info %v", "info true"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			buf.Reset()
+			tc.fn(tc.format, tc.args...)
+			result := buf.String()
+			if !strings.Contains(result, tc.prefix) {
+				t.Errorf("%s output should contain prefix %q, got %q", tc.name, tc.prefix, result)
+			}
+			if !strings.Contains(result, tc.contains) {
+				t.Errorf("%s output should contain %q, got %q", tc.name, tc.contains, result)
+			}
+		})
+	}
+}
+
+func TestHeader(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	defer SetOutput(nil)
+	SetColorEnabled(false)
+
+	Header("Test Header")
+	result := buf.String()
+	if !strings.Contains(result, "Test Header") {
+		t.Errorf("Header should contain text, got %q", result)
+	}
+}
+
+func TestDivider(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	defer SetOutput(nil)
+
+	Divider(5)
+	result := buf.String()
+	if !strings.Contains(result, "─────") {
+		t.Errorf("Divider(5) should have 5 dashes, got %q", result)
+	}
+}
+
+func TestTable(t *testing.T) {
+	SetColorEnabled(false)
+
+	table := NewTable("Name", "Value")
+	table.AddRow("foo", "bar")
+	table.AddRow("longer", "x")
+
+	result := table.String()
+
+	// Should contain headers
+	if !strings.Contains(result, "Name") {
+		t.Error("Table should contain Name header")
+	}
+	if !strings.Contains(result, "Value") {
+		t.Error("Table should contain Value header")
+	}
+
+	// Should contain rows
+	if !strings.Contains(result, "foo") {
+		t.Error("Table should contain foo")
+	}
+	if !strings.Contains(result, "bar") {
+		t.Error("Table should contain bar")
+	}
+
+	// Should contain separator
+	if !strings.Contains(result, "──") {
+		t.Error("Table should contain separator")
+	}
+}
+
+func TestSimpleTable(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	defer SetOutput(nil)
+	SetColorEnabled(false)
+
+	SimpleTable("Name", "Alice", "Age", "30")
+	result := buf.String()
+
+	if !strings.Contains(result, "Name:") {
+		t.Error("SimpleTable should contain Name:")
+	}
+	if !strings.Contains(result, "Alice") {
+		t.Error("SimpleTable should contain Alice")
+	}
+	if !strings.Contains(result, "Age:") {
+		t.Error("SimpleTable should contain Age:")
+	}
+}
+
+func TestList(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	defer SetOutput(nil)
+	SetColorEnabled(false)
+
+	List("item1", "item2", "item3")
+	result := buf.String()
+
+	if !strings.Contains(result, "•") {
+		t.Error("List should contain bullet")
+	}
+	if !strings.Contains(result, "item1") {
+		t.Error("List should contain item1")
+	}
+	if strings.Count(result, "•") != 3 {
+		t.Errorf("List should have 3 bullets, got %d", strings.Count(result, "•"))
+	}
+}
+
+func TestNumberedList(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	defer SetOutput(nil)
+	SetColorEnabled(false)
+
+	NumberedList("first", "second")
+	result := buf.String()
+
+	if !strings.Contains(result, "1.") {
+		t.Error("NumberedList should contain 1.")
+	}
+	if !strings.Contains(result, "2.") {
+		t.Error("NumberedList should contain 2.")
+	}
+}
+
+func TestCheckList(t *testing.T) {
+	var buf bytes.Buffer
+	SetOutput(&buf)
+	defer SetOutput(nil)
+	SetColorEnabled(false)
+
+	CheckList(
+		ListItem{Text: "task1"},
+		ListItem{Text: "task2", Detail: "done"},
+	)
+	result := buf.String()
+
+	if !strings.Contains(result, "✓") {
+		t.Error("CheckList should contain checkmark")
+	}
+	if !strings.Contains(result, "task1") {
+		t.Error("CheckList should contain task1")
+	}
+	if !strings.Contains(result, "(done)") {
+		t.Error("CheckList should contain detail")
+	}
+}
+
+func TestColorEnabled(t *testing.T) {
+	SetColorEnabled(true)
+	if !ColorEnabled() {
+		t.Error("ColorEnabled should return true")
+	}
+
+	SetColorEnabled(false)
+	if ColorEnabled() {
+		t.Error("ColorEnabled should return false")
+	}
+}


### PR DESCRIPTION
## Summary
Create pkg/ui package for consistent CLI output formatting:
- `color.go`: ANSI colors, style helpers, NO_COLOR environment variable support
- `message.go`: Success/Error/Warning/Info/Debug message formatting with prefixes
- `table.go`: Table formatting with auto-column widths, key-value tables
- `list.go`: Bulleted, numbered, checklist, and indented list formatting
- `ui_test.go`: 13 unit tests

## Components
```
pkg/ui/
├── color.go      # ANSI colors, style helpers
├── message.go    # Success/error/warning messages
├── table.go      # Table formatting
├── list.go       # List formatting
└── ui_test.go    # Unit tests
```

## Test plan
- [x] `go test ./pkg/ui/...` passes (13 tests)
- [x] `golangci-lint run ./pkg/ui/...` clean

Implements #1131 for #678 Phase 4 CLI Improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)