### PR TITLE
feat(tui): Implement unread message indicators (#1129)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
-import { useChannels, useChannelHistory, useUnread, useMentionAutocomplete } from '../hooks';
+import { useChannelsWithUnread, useChannelHistory, useUnread, useMentionAutocomplete } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { PulseText } from './AnimatedText';
@@ -34,11 +34,11 @@ interface ChannelsViewProps {
 }
 
 export function ChannelsView({ disableInput = false }: ChannelsViewProps): React.ReactElement {
-  const { data: channels, loading: channelsLoading, error: channelsError } = useChannels();
+  // #1129: Use useChannelsWithUnread for proper unread message tracking
+  const { channels, loading: channelsLoading, error: channelsError } = useChannelsWithUnread();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [viewMode, setViewMode] = useState<'list' | 'history'>('list');
   const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
-  const { getLastViewed } = useUnread();
   const { setFocus } = useFocus();
 
   // Update breadcrumbs and focus when view mode changes
@@ -53,13 +53,6 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
       setFocus('main');
     }
   }, [viewMode, channels, selectedIndex, setBreadcrumbs, clearBreadcrumbs, setFocus]);
-
-  // Calculate unread status for each channel (new = never viewed)
-  const getChannelUnread = (channelName: string): number => {
-    const lastViewed = getLastViewed(channelName);
-    // If never viewed, show as "new" (1 indicates new)
-    return lastViewed === null ? 1 : 0;
-  };
 
   useInput(
     (input, key) => {
@@ -133,7 +126,7 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
             key={channel.name}
             channel={channel}
             selected={index === selectedIndex}
-            unreadCount={getChannelUnread(channel.name)}
+            unreadCount={channel.unread}
           />
         ))}
         {(!channels || channels.length === 0) && (
@@ -152,23 +145,33 @@ interface ChannelRowProps {
 
 function ChannelRow({ channel, selected, unreadCount }: ChannelRowProps): React.ReactElement {
   // #981 fix: Build name row as single truncated text to ensure visibility at 80 cols
+  // #1129: Highlight channels with unread messages
   // Priority: name > unread indicator > member count > description
   const namePrefix = selected ? '▸ ' : '  ';
   const channelName = `#${channel.name}`;
   const memberInfo = ` (${String(channel.members.length)})`;
-  const unreadInfo = unreadCount > 0 ? ` [${unreadCount > 99 ? '99+' : String(unreadCount)} new]` : '';
+
+  // Format unread badge: "●" for 1 unread, count for multiple
+  const unreadBadge = unreadCount > 0
+    ? unreadCount === 1
+      ? ' ●'
+      : ` (${unreadCount > 99 ? '99+' : String(unreadCount)})`
+    : '';
 
   // Build single text line to avoid nested Text truncation issues on narrow terminals
   // Issue #981: Nested Text elements break rendering at 80x24 width
-  const nameLineText = `${namePrefix}${channelName}${unreadInfo}${memberInfo}`;
+  const nameLineText = `${namePrefix}${channelName}${unreadBadge}${memberInfo}`;
+
+  // Determine text color: cyan if selected, yellow if has unread, default otherwise
+  const textColor = selected ? 'cyan' : unreadCount > 0 ? 'yellow' : undefined;
 
   return (
     <Box width="100%" flexDirection="column">
       {/* Name row: single Text for proper truncation at narrow widths */}
       <Text
         wrap="truncate"
-        color={selected ? 'cyan' : undefined}
-        bold={selected}
+        color={textColor}
+        bold={selected || unreadCount > 0}
       >
         {nameLineText}
       </Text>

--- a/tui/src/hooks/useChannels.ts
+++ b/tui/src/hooks/useChannels.ts
@@ -1,14 +1,16 @@
 /**
  * useChannels hook - Fetch and manage channel data
  * Issue #1004: Performance configuration tunables (Phase 5)
+ * Issue #1129: Unread message indicators
  *
  * Poll interval is configurable via workspace config [performance] section.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Channel, ChannelMessage, BcResult } from '../types';
 import { getChannels, getChannelHistory, sendChannelMessage } from '../services/bc';
 import { usePerformanceConfig } from '../config';
+import { useUnread } from './UnreadContext';
 
 export interface UseChannelsOptions {
   /** Polling interval in ms (default: from config) */
@@ -156,32 +158,105 @@ export function useUnreadCount(
 
 /**
  * Hook to get all channels with their unread counts
+ * #1129: Implements proper unread message tracking using UnreadContext
+ *
+ * Fetches message counts for each channel and uses UnreadContext to calculate
+ * unread messages based on when the user last viewed each channel.
  */
 export function useChannelsWithUnread(options?: UseChannelsOptions): {
-  channels: (Channel & { unread: number })[] | null;
+  channels: (Channel & { unread: number; messageCount: number })[] | null;
   loading: boolean;
   error: string | null;
+  refresh: () => Promise<void>;
 } {
-  const { data: channels, loading: channelsLoading, error } = useChannels(options);
+  const { data: channels, loading: channelsLoading, error, refresh: refreshChannels } = useChannels(options);
+  const { getUnread } = useUnread();
   const [channelsWithUnread, setChannelsWithUnread] = useState<
-    (Channel & { unread: number })[] | null
+    (Channel & { unread: number; messageCount: number })[] | null
   >(null);
+  const [messageCounts, setMessageCounts] = useState<Record<string, number>>({});
+  const [countsLoading, setCountsLoading] = useState(true);
 
+  // Track channel list to detect changes (avoid refetching on every render)
+  const channelNamesRef = useRef<string>('');
+
+  // Fetch message counts for each channel
+  // Uses limit=100 as a reasonable cap - UnreadContext caps display at 99+ anyway
+  useEffect(() => {
+    if (!channels || channels.length === 0) {
+      setCountsLoading(false);
+      return;
+    }
+
+    // Check if channel list changed
+    const newChannelNames = channels.map(c => c.name).sort().join(',');
+    if (newChannelNames === channelNamesRef.current) {
+      // Channel list unchanged, skip refetch
+      return;
+    }
+    channelNamesRef.current = newChannelNames;
+
+    let cancelled = false;
+
+    const fetchCounts = async () => {
+      setCountsLoading(true);
+      const counts: Record<string, number> = {};
+
+      // Fetch counts in parallel for efficiency
+      await Promise.all(
+        channels.map(async (ch) => {
+          try {
+            const history = await getChannelHistory(ch.name, 100);
+            if (!cancelled) {
+              counts[ch.name] = history.messages.length;
+            }
+          } catch {
+            if (!cancelled) {
+              counts[ch.name] = 0;
+            }
+          }
+        })
+      );
+
+      if (!cancelled) {
+        setMessageCounts(counts);
+        setCountsLoading(false);
+      }
+    };
+
+    void fetchCounts();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [channels]);
+
+  // Calculate unread for each channel using UnreadContext
   useEffect(() => {
     if (!channels) return;
 
-    // For now, set unread to 0 - actual implementation would track per-channel
-    // This is a placeholder until we have proper unread tracking
-    const withUnread = channels.map((ch) => ({
-      ...ch,
-      unread: 0,
-    }));
+    const withUnread = channels.map((ch) => {
+      const currentCount = messageCounts[ch.name] ?? 0;
+      // Use UnreadContext to calculate unread based on stored lastMessageCount
+      const unread = getUnread(ch.name, currentCount);
+
+      return {
+        ...ch,
+        messageCount: currentCount,
+        unread,
+      };
+    });
     setChannelsWithUnread(withUnread);
-  }, [channels]);
+  }, [channels, messageCounts, getUnread]);
+
+  const refresh = useCallback(async () => {
+    await refreshChannels();
+  }, [refreshChannels]);
 
   return {
     channels: channelsWithUnread,
-    loading: channelsLoading,
+    loading: channelsLoading || countsLoading,
     error,
+    refresh,
   };
 }


### PR DESCRIPTION
## Summary
- Enhanced `useChannelsWithUnread` hook to fetch actual message counts and calculate unread using `UnreadContext`
- Updated `ChannelsView` to show proper unread badges with yellow highlighting
- Unread indicator shows "●" for 1 unread or "(N)" for multiple (capped at 99+)
- Indicator clears when user views channel via existing `markViewed` mechanism

## Test plan
- [x] TUI tests pass (16 ChannelsView tests)
- [x] Build passes
- [x] Lint passes
- [ ] Manual test: View channels list, enter channel, return - unread should clear
- [ ] Manual test: Receive new message, channel should show yellow highlight with count

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)