### PR TITLE
refactor(cmd): Migrate status command color functions to pkg/ui (#1132)

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/ui"
 )
 
 var (
@@ -319,51 +320,36 @@ func normalizeTask(task string) string {
 }
 
 func colorState(s agent.State) string {
-	const (
-		reset  = "\033[0m"
-		green  = "\033[32m"
-		yellow = "\033[33m"
-		red    = "\033[31m"
-		cyan   = "\033[36m"
-	)
-
 	padded := fmt.Sprintf("%-10s", s)
 
 	switch s {
 	case agent.StateIdle:
-		return cyan + padded + reset
+		return ui.CyanText(padded)
 	case agent.StateWorking:
-		return green + padded + reset
+		return ui.GreenText(padded)
 	case agent.StateDone:
-		return green + padded + reset
+		return ui.GreenText(padded)
 	case agent.StateStuck:
-		return red + padded + reset
+		return ui.RedText(padded)
 	case agent.StateError:
-		return red + padded + reset
+		return ui.RedText(padded)
 	case agent.StateStopped:
-		return yellow + padded + reset
+		return ui.YellowText(padded)
 	default:
 		return padded
 	}
 }
 
 func colorWorktreeStatus(s string) string {
-	const (
-		reset  = "\033[0m"
-		green  = "\033[32m"
-		yellow = "\033[33m"
-		red    = "\033[31m"
-	)
-
 	padded := fmt.Sprintf("%-10s", s)
 
 	switch s {
 	case "OK":
-		return green + padded + reset
+		return ui.GreenText(padded)
 	case "MISSING":
-		return red + padded + reset
+		return ui.RedText(padded)
 	case "ORPHANED":
-		return yellow + padded + reset
+		return ui.YellowText(padded)
 	default:
 		return padded
 	}


### PR DESCRIPTION
## Summary
- Migrates `colorState` and `colorWorktreeStatus` functions in status.go to use centralized `pkg/ui` helpers
- Replaces inline ANSI escape code definitions with `ui.CyanText`, `ui.GreenText`, `ui.RedText`, `ui.YellowText`
- Removes 14 lines of duplicate ANSI constant definitions

This complements PR #1142 which migrated table formatting. This PR specifically addresses color utility functions.

## Changes
- status.go: Replace inline ANSI codes with pkg/ui color helpers

## Test plan
- [x] All existing status tests pass
- [x] Lint passes with 0 issues
- [ ] Manual verification of colored output in terminal

Part of #1132 - CLI migration to centralized `pkg/ui` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)