### PR TITLE
fix(cmd): Fix integration tests after pkg/ui migration

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/cost"
 	"github.com/rpuneet/bc/pkg/events"
+	"github.com/rpuneet/bc/pkg/ui"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
@@ -64,6 +65,10 @@ func executeIntegrationCmd(args ...string) (string, string, error) {
 		return "", "", pipeErr
 	}
 	os.Stdout = w
+
+	// Also redirect pkg/ui output which uses its own writer
+	ui.SetOutput(w)
+	defer ui.SetOutput(os.Stdout)
 
 	stderr := new(bytes.Buffer)
 	rootCmd.SetOut(w)


### PR DESCRIPTION
## Summary
- Redirect pkg/ui output in `executeIntegrationCmd` so integration tests can capture output from commands that use the pkg/ui package

## Background
PR #1142 migrated CLI commands to use pkg/ui for consistent formatting. However, integration tests only redirect `os.Stdout` but pkg/ui uses its own internal `output` writer. This caused 6 tests to fail because their output assertions saw empty strings.

## Fix
Call `ui.SetOutput(w)` in `executeIntegrationCmd` to redirect pkg/ui output to the same pipe used for stdout capture.

## Tests Fixed
- TestAgentListEmptyIntegration
- TestAgentListWithAgents
- TestAgentListFilterByRole
- TestAgentShowWithAgent
- TestChannelListEmpty
- TestChannelListWithChannels

## Test plan
- [x] All 6 previously failing tests now pass
- [x] Full `internal/cmd` test suite passes
- [x] Pre-commit hooks pass (build, vet, lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)