### PR TITLE
refactor(cmd): Migrate logs command to pkg/ui (#1132)

### DIFF
--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/ui"
 )
 
 var logsCmd = &cobra.Command{
@@ -151,7 +152,7 @@ func runLogs(cmd *cobra.Command, args []string) error {
 	log.Debug("events filtered", "count", len(evts))
 
 	if len(evts) == 0 {
-		fmt.Println("No events found")
+		ui.Warning("No events found")
 		return nil
 	}
 

--- a/internal/cmd/logs_test.go
+++ b/internal/cmd/logs_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/rpuneet/bc/pkg/events"
+	"github.com/rpuneet/bc/pkg/ui"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
@@ -69,6 +70,10 @@ func runLogsCmd(t *testing.T, args ...string) (string, error) {
 		t.Fatalf("failed to create pipe: %v", pipeErr)
 	}
 	os.Stdout = w
+
+	// Also redirect pkg/ui output which uses its own writer
+	ui.SetOutput(w)
+	defer ui.SetOutput(os.Stdout)
 
 	rootCmd.SetOut(w)
 	rootCmd.SetErr(w)


### PR DESCRIPTION
## Summary
- Use `ui.Warning` for "No events found" empty state message in logs command
- Update `logs_test.go` to redirect pkg/ui output via `ui.SetOutput`

## Changes
| File | Change |
|------|--------|
| logs.go | Use `ui.Warning()` instead of `fmt.Println()` for empty state |
| logs_test.go | Add `ui.SetOutput(w)` to capture pkg/ui output in tests |

## Test plan
- [x] All logs tests pass including empty state tests
- [x] Full `internal/cmd` test suite passes
- [x] Pre-commit hooks pass (build, vet, lint)

Part of #1132 - Migrate CLI commands to pkg/ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)