### PR TITLE
refactor(cmd): Migrate init and agent health colors to pkg/ui (#1132)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -1445,13 +1445,13 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 		statusColor := h.Status
 		switch h.Status {
 		case "healthy":
-			statusColor = "\033[32m" + h.Status + "\033[0m" // green
+			statusColor = ui.GreenText(h.Status)
 		case "degraded":
-			statusColor = "\033[33m" + h.Status + "\033[0m" // yellow
+			statusColor = ui.YellowText(h.Status)
 		case "unhealthy":
-			statusColor = "\033[31m" + h.Status + "\033[0m" // red
+			statusColor = ui.RedText(h.Status)
 		case "stuck":
-			statusColor = "\033[35m" + h.Status + "\033[0m" // magenta
+			statusColor = ui.MagentaText(h.Status)
 		}
 
 		fmt.Printf("%-15s %-12s %-10s %-8s %-8s %s\n",

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/ui"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
@@ -229,7 +230,7 @@ func promptNickname() (string, error) {
 	nickname, err := workspace.NormalizeNickname(input)
 	if err != nil {
 		// Show helpful error
-		fmt.Printf("  \033[31mError: %s\033[0m\n", err)
+		fmt.Printf("  %s\n", ui.RedText(fmt.Sprintf("Error: %s", err)))
 		fmt.Printf("  Using default: %s\n", workspace.DefaultNickname)
 		return workspace.DefaultNickname, nil
 	}
@@ -290,8 +291,8 @@ func initV2WorkspaceWithNickname(rootDir string, nickname string) error {
 
 	// Print success message
 	fmt.Println()
-	fmt.Printf("  \033[32m✓\033[0m Workspace initialized at %s\n", rootDir)
-	fmt.Printf("  \033[32m✓\033[0m Nickname set to %s\n", nickname)
+	fmt.Printf("  %s Workspace initialized at %s\n", ui.GreenText("✓"), rootDir)
+	fmt.Printf("  %s Nickname set to %s\n", ui.GreenText("✓"), nickname)
 	fmt.Println()
 	fmt.Println("  Created:")
 	fmt.Println("    .bc/config.toml     # Workspace configuration")


### PR DESCRIPTION
## Summary
- Migrate remaining ANSI escape codes in init.go and agent.go to pkg/ui
- Completes color function migration for #1132

## Changes
- **init.go**: Use `ui.RedText` for error, `ui.GreenText` for success checkmarks
- **agent.go**: Use color helpers for health status (healthy/degraded/unhealthy/stuck)

## Test plan
- [x] Build passes
- [x] Tests pass
- [x] Lint clean (0 issues)

Part of #1132 - CLI migration to centralized `pkg/ui` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)