### PR TITLE
refactor(cmd): Migrate root command bold text to pkg/ui (#1132)

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/ui"
 )
 
 var (
@@ -165,7 +166,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 // promptInit displays an interactive prompt to initialize a new workspace.
 func promptInit(cmd *cobra.Command) error {
 	fmt.Println()
-	fmt.Println("  \033[1mbc - AI Agent Orchestration\033[0m")
+	fmt.Printf("  %s\n", ui.BoldText("bc - AI Agent Orchestration"))
 	fmt.Println()
 	fmt.Println("  No workspace found in current directory.")
 	fmt.Println()


### PR DESCRIPTION
## Summary
- Migrate the final ANSI escape code in root.go to use pkg/ui
- Uses `ui.BoldText` for the prompt header

## Changes
- root.go: Replace `\033[1m...\033[0m` with `ui.BoldText()`

This completes the pkg/ui migration for internal/cmd.

## Test plan
- [x] Build passes
- [x] Lint clean (0 issues)

Part of #1132 - CLI migration to centralized `pkg/ui` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)