### PR TITLE
fix(tui): Fix test isolation issue causing 22 tests to fail (#1151)

### DIFF
--- a/tui/src/__tests__/components/ActivityFeed.test.tsx
+++ b/tui/src/__tests__/components/ActivityFeed.test.tsx
@@ -8,7 +8,8 @@ import { render } from 'ink-testing-library';
 import { describe, it, expect, vi, beforeEach } from 'bun:test';
 import { ActivityFeed } from '../../components/ActivityFeed';
 
-// Mock only useLogs, not getSeverityColor (which is a pure function)
+// Mock useLogs hook with correct getSeverityColor implementation
+// IMPORTANT: Must match the real implementation's case-insensitivity
 vi.mock('../../hooks/useLogs', () => ({
   useLogs: vi.fn(() => ({
     data: [
@@ -37,9 +38,11 @@ vi.mock('../../hooks/useLogs', () => ({
     filterBySeverity: vi.fn(),
     refresh: vi.fn(),
   })),
+  // Fix: use toLowerCase() to match real implementation (issue #1151)
   getSeverityColor: (type: string) => {
-    if (type.includes('error')) return 'red';
-    if (type.includes('stuck')) return 'yellow';
+    const lower = type.toLowerCase();
+    if (lower.includes('error') || lower.includes('fail')) return 'red';
+    if (lower.includes('warn') || lower.includes('stuck')) return 'yellow';
     return 'gray';
   },
 }));

--- a/tui/src/__tests__/keybind-focus-integration.test.tsx
+++ b/tui/src/__tests__/keybind-focus-integration.test.tsx
@@ -11,6 +11,7 @@
 
 import React from 'react';
 import { render } from 'ink-testing-library';
+import { describe, test, expect, mock } from 'bun:test';
 import { FocusProvider, useFocus } from '../navigation/FocusContext';
 import { useKeyboardNavigation } from '../navigation/useKeyboardNavigation';
 import { useInput } from 'ink';
@@ -78,7 +79,7 @@ const TestChannelsComponent = ({
 
 describe('Keybind Focus State Fix (Issue #653 EPIC 2)', () => {
   test.skip('Global keybinds should be disabled while in input mode', () => {
-    const onGlobalKeyPress = jest.fn();
+    const onGlobalKeyPress = mock();
     const { lastFrame } = render(
       <FocusProvider>
         <TestChannelsComponent onGlobalKeyPress={onGlobalKeyPress} />
@@ -97,8 +98,10 @@ describe('Keybind Focus State Fix (Issue #653 EPIC 2)', () => {
     // expect(onGlobalKeyPress).not.toHaveBeenCalled();
   });
 
-  test('Global keybinds should be re-enabled after exiting input mode', () => {
-    // Similar test for exiting input mode
+  test.skip('Global keybinds should be re-enabled after exiting input mode', () => {
+    // TODO: Implement test for exiting input mode
+    // Similar pattern to above test, but verify keybinds work after ESC/Enter
+    expect(true).toBe(true);
   });
 });
 
@@ -180,11 +183,11 @@ describe('FocusContext behavior for keybind management', () => {
  */
 describe('ChannelHistoryView focus synchronization (the actual fix)', () => {
   test('useEffect should call setFocus when inputMode changes to true', () => {
-    const mockSetFocus = jest.fn();
+    const mockSetFocus = mock();
 
     const TestComponent = (): React.ReactElement => {
       const [inputMode, setInputMode] = React.useState(false);
-      const mockFocus = { setFocus: mockSetFocus, returnFocus: jest.fn() };
+      const mockFocus = { setFocus: mockSetFocus, returnFocus: mock() };
 
       React.useEffect(() => {
         if (inputMode) {

--- a/tui/src/__tests__/theme.test.tsx
+++ b/tui/src/__tests__/theme.test.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { Text } from 'ink';
+import { spyOn, describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import {
   ThemeProvider,
   useTheme,
@@ -70,8 +71,7 @@ describe('useTheme', () => {
   it('throws when used outside provider', () => {
     // Note: In ink-testing-library, the error is caught differently
     // The hook should throw, but the error may be caught by React's error boundary
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const consoleError = spyOn(console, 'error').mockImplementation(() => {});
     try {
       render(<ThemeConsumer />);
     } catch (error) {

--- a/tui/src/config/__tests__/config.test.tsx
+++ b/tui/src/config/__tests__/config.test.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { Text } from 'ink';
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
 import {
   ConfigProvider,
   useConfig,
@@ -17,11 +18,13 @@ import {
 } from '..';
 import type { PerformanceConfig, TUIConfig } from '../../types';
 
-// Mock bc service
-// NOTE: This file is isolated to prevent mock pollution (#1066)
-jest.mock('../../services/bc', () => ({
-  execBcJson: jest.fn().mockResolvedValue({}),
-}));
+// NOTE: Issue #1151 - Do NOT use vi.mock on services/bc as it pollutes
+// the module cache and breaks bc.test.ts which needs the real module.
+// Instead, ConfigProvider handles errors gracefully when execBcJson fails,
+// so we don't need to mock it for these tests.
+//
+// The ConfigProvider already catches errors and returns default config,
+// which is what we're testing anyway.
 
 // Test component that uses config
 function ConfigConsumer() {
@@ -74,7 +77,7 @@ describe('ConfigProvider', () => {
 describe('useConfig', () => {
   it('throws when used outside provider', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const consoleError = spyOn(console, 'error').mockImplementation();
     try {
       render(<ConfigConsumer />);
     } catch (error) {
@@ -107,7 +110,7 @@ describe('usePerformanceConfig', () => {
 
   it('throws when used outside provider', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const consoleError = spyOn(console, 'error').mockImplementation();
     try {
       render(<PerformanceConsumer />);
     } catch (error) {
@@ -144,7 +147,7 @@ describe('useThemeConfig', () => {
 
   it('throws when used outside provider', () => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+    const consoleError = spyOn(console, 'error').mockImplementation();
     try {
       render(<ThemeConsumer />);
     } catch (error) {


### PR DESCRIPTION
## Summary
- Fix test isolation issue where 22 TUI tests fail when run together but pass individually
- Root cause: Jest API usage and vi.mock() polluting module state for parallel test runs

## Changes
- **ActivityFeed.test.tsx**: Add `toLowerCase()` to `getSeverityColor` mock to match real implementation
- **keybind-focus-integration.test.tsx**: Replace `jest.fn()` with `mock()` from bun:test, skip empty test
- **theme.test.tsx**: Replace `jest.spyOn` with `spyOn` from bun:test
- **config.test.tsx**: Remove `vi.mock()` on services/bc to prevent module cache pollution

## Root Cause Analysis
1. `getSeverityColor` mock was case-sensitive (`type.includes('error')`) while real impl uses `toLowerCase()`
2. Jest APIs (`jest.fn()`, `jest.spyOn()`) are undefined in Bun test runner
3. `vi.mock()` permanently replaces modules in cache, polluting state for bc.test.ts

## Test plan
- [x] All 2053 TUI tests pass (was 22 failing)
- [x] `bun test` runs clean
- [x] `bun run lint` passes (0 errors)
- [x] Verified useLogs tests pass with ActivityFeed tests

Closes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)