### PR TITLE
fix(tui): Add missing React hook dependencies in useAdaptivePolling

### DIFF
--- a/tui/src/hooks/useAdaptivePolling.ts
+++ b/tui/src/hooks/useAdaptivePolling.ts
@@ -111,7 +111,7 @@ export function useAdaptivePolling(
     // Immediately switch to fast mode
     setMode('fast');
     setIntervalMs(FAST_INTERVAL);
-  }, [adaptiveEnabled]);
+  }, [adaptiveEnabled, FAST_INTERVAL]);
 
   // Report idle - allows backoff
   const reportIdle = useCallback(() => {
@@ -142,7 +142,7 @@ export function useAdaptivePolling(
       setMode('normal');
       setIntervalMs(NORMAL_INTERVAL);
     }
-  }, [adaptiveEnabled, mode]);
+  }, [adaptiveEnabled, mode, MAX_INTERVAL, NORMAL_INTERVAL, SLOW_INTERVAL]);
 
   // Update idle time periodically
   useEffect(() => {
@@ -190,7 +190,7 @@ export function useAdaptivePolling(
     setIntervalMs(NORMAL_INTERVAL);
     lastActivityRef.current = Date.now();
     backoffCountRef.current = 0;
-  }, []);
+  }, [NORMAL_INTERVAL]);
 
   const setModeManual = useCallback((newMode: PollingMode) => {
     setMode(newMode);
@@ -208,7 +208,7 @@ export function useAdaptivePolling(
         setIntervalMs(MAX_INTERVAL);
         break;
     }
-  }, []);
+  }, [FAST_INTERVAL, MAX_INTERVAL, NORMAL_INTERVAL, SLOW_INTERVAL]);
 
   const state = useMemo<AdaptivePollingState>(() => ({
     mode,


### PR DESCRIPTION
## Summary
- Fix 4 eslint warnings for react-hooks/exhaustive-deps in useAdaptivePolling.ts
- Add interval config values to useCallback dependency arrays

## Changes
- reportActivity: Add FAST_INTERVAL to deps
- reportIdle: Add MAX_INTERVAL, NORMAL_INTERVAL, SLOW_INTERVAL to deps
- resume: Add NORMAL_INTERVAL to deps
- setModeManual: Add FAST_INTERVAL, MAX_INTERVAL, NORMAL_INTERVAL, SLOW_INTERVAL to deps

## Test plan
- [x] All 28 useAdaptivePolling tests pass
- [x] Lint warnings reduced from 8 to 4 (remaining 4 are expected console.log in benchmarks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)