### PR TITLE
feat(cmd): Add shell completion support for bash, zsh, fish, powershell (#1156)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -327,6 +327,16 @@ func init() {
 	agentHealthCmd.Flags().IntVar(&agentHealthMaxFail, "max-failures", 3, "Max consecutive failures before considered stuck")
 	agentHealthCmd.Flags().StringVar(&agentHealthAlert, "alert", "", "Send alert to channel when stuck agents detected (requires --detect-stuck)")
 
+	// Add shell completion for agent name arguments
+	agentAttachCmd.ValidArgsFunction = CompleteAgentNames
+	agentPeekCmd.ValidArgsFunction = CompleteAgentNames
+	agentShowCmd.ValidArgsFunction = CompleteAgentNames
+	agentStartCmd.ValidArgsFunction = CompleteAgentNames
+	agentStopCmd.ValidArgsFunction = CompleteAgentNames
+	agentSendCmd.ValidArgsFunction = CompleteAgentNames
+	agentDeleteCmd.ValidArgsFunction = CompleteAgentNames
+	agentRenameCmd.ValidArgsFunction = CompleteAgentNames
+
 	// Add subcommands
 	agentCmd.AddCommand(agentCreateCmd)
 	agentCmd.AddCommand(agentListCmd)

--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -171,6 +171,19 @@ func init() {
 	channelHistoryCmd.Flags().IntVar(&channelHistoryLimit, "limit", 50, "Maximum number of messages to show")
 	channelHistoryCmd.Flags().IntVar(&channelHistoryOffset, "offset", 0, "Number of messages to skip")
 	channelHistoryCmd.Flags().StringVar(&channelHistorySince, "since", "", "Show messages since duration (e.g., 1h, 30m)")
+
+	// Add shell completion for channel name arguments
+	channelAddCmd.ValidArgsFunction = CompleteChannelNames
+	channelRemoveCmd.ValidArgsFunction = CompleteChannelNames
+	channelSendCmd.ValidArgsFunction = CompleteChannelNames
+	channelDeleteCmd.ValidArgsFunction = CompleteChannelNames
+	channelJoinCmd.ValidArgsFunction = CompleteChannelNames
+	channelLeaveCmd.ValidArgsFunction = CompleteChannelNames
+	channelHistoryCmd.ValidArgsFunction = CompleteChannelNames
+	channelReactCmd.ValidArgsFunction = CompleteChannelNames
+	channelShowCmd.ValidArgsFunction = CompleteChannelNames
+	channelDescCmd.ValidArgsFunction = CompleteChannelNames
+
 	channelCmd.AddCommand(channelCreateCmd)
 	channelCmd.AddCommand(channelAddCmd)
 	channelCmd.AddCommand(channelRemoveCmd)

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rpuneet/bc/pkg/agent"
+	"github.com/rpuneet/bc/pkg/channel"
+	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/workspace"
+)
+
+// CompleteAgentNames returns a completion function for agent names
+func CompleteAgentNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	ws, err := getWorkspace()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
+	if loadErr := mgr.LoadState(); loadErr != nil {
+		log.Debug("completion: failed to load agent state", "error", loadErr)
+	}
+
+	agents := mgr.ListAgents()
+	names := make([]string, 0, len(agents))
+	for _, a := range agents {
+		names = append(names, a.Name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// CompleteChannelNames returns a completion function for channel names
+func CompleteChannelNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	ws, err := getWorkspace()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	store := channel.NewStore(filepath.Join(ws.StateDir(), "channels"))
+	defer func() {
+		if closeErr := store.Close(); closeErr != nil {
+			log.Debug("completion: failed to close channel store", "error", closeErr)
+		}
+	}()
+
+	channels := store.List()
+	names := make([]string, 0, len(channels))
+	for _, ch := range channels {
+		names = append(names, ch.Name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+// CompleteRoleNames returns a completion function for role names
+func CompleteRoleNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	ws, err := getWorkspace()
+	if err != nil {
+		// Return built-in roles as fallback
+		return []string{"root", "manager", "engineer", "tech-lead", "product-manager"}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	rm := workspace.NewRoleManager(ws.StateDir())
+	roles, rolesErr := rm.LoadAllRoles()
+	if rolesErr != nil {
+		log.Debug("completion: failed to list roles", "error", rolesErr)
+		return []string{"root", "manager", "engineer", "tech-lead", "product-manager"}, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	names := make([]string, 0, len(roles))
+	for _, r := range roles {
+		names = append(names, r.Metadata.Name)
+	}
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate shell completion scripts",
+	Long: `Generate shell completion scripts for bc.
+
+To load completions:
+
+Bash:
+  $ source <(bc completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ bc completion bash > /etc/bash_completion.d/bc
+  # macOS:
+  $ bc completion bash > $(brew --prefix)/etc/bash_completion.d/bc
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ bc completion zsh > "${fpath[1]}/_bc"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ bc completion fish | source
+
+  # To load completions for each session, execute once:
+  $ bc completion fish > ~/.config/fish/completions/bc.fish
+
+PowerShell:
+  PS> bc completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> bc completion powershell > bc.ps1
+  # and source this file from your PowerShell profile.
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletionWithDesc(os.Stdout)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}

--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -146,6 +146,14 @@ func init() {
 	// Register --json flag for role list command (PR #942 follow-up)
 	roleListCmd.Flags().Bool("json", false, "Output in JSON format")
 
+	// Add shell completion for role name arguments
+	roleShowCmd.ValidArgsFunction = CompleteRoleNames
+	roleEditCmd.ValidArgsFunction = CompleteRoleNames
+	roleDeleteCmd.ValidArgsFunction = CompleteRoleNames
+	roleRenameCmd.ValidArgsFunction = CompleteRoleNames
+	roleCloneCmd.ValidArgsFunction = CompleteRoleNames
+	roleDiffCmd.ValidArgsFunction = CompleteRoleNames
+
 	rootCmd.AddCommand(roleCmd)
 }
 


### PR DESCRIPTION
## Summary

- Adds `bc completion [bash|zsh|fish|powershell]` command using Cobra's built-in shell completion generation
- Custom completion functions for dynamic values:
  - `CompleteAgentNames`: Tab-complete agent names from workspace state
  - `CompleteChannelNames`: Tab-complete channel names from SQLite store
  - `CompleteRoleNames`: Tab-complete role names with built-in fallbacks
- `ValidArgsFunction` wired to relevant commands for tab completion of entity names

**Commands with completion support:**
- `agent`: attach, peek, show, start, stop, send, delete, rename
- `channel`: add, remove, send, delete, join, leave, history, react, show, desc
- `role`: show, edit, delete, rename, clone, diff

## Test plan

- [ ] Verify `bc completion bash` generates valid bash completion script
- [ ] Verify `bc completion zsh` generates valid zsh completion script
- [ ] Test agent name completion: `bc agent show <TAB>`
- [ ] Test channel name completion: `bc channel send <TAB>`
- [ ] Test role name completion: `bc role show <TAB>`
- [ ] Build and lint pass

Closes #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)