### PR TITLE
fix(tui): Fix ChannelsView channel names missing at 80x24 (#1171)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -165,8 +165,10 @@ function ChannelRow({ channel, selected, unreadCount }: ChannelRowProps): React.
   // Determine text color: cyan if selected, yellow if has unread, default otherwise
   const textColor = selected ? 'cyan' : unreadCount > 0 ? 'yellow' : undefined;
 
+  // #1171 fix: Remove explicit width="100%" to avoid nested width calculation issues at 80x24
+  // The parent Box already has width="100%", inner Box inherits flexbox width naturally
   return (
-    <Box width="100%" flexDirection="column">
+    <Box flexDirection="column">
       {/* Name row: single Text for proper truncation at narrow widths */}
       <Text
         wrap="truncate"


### PR DESCRIPTION
## Summary

- Remove explicit `width="100%"` from inner ChannelRow Box to avoid nested width calculation issues
- At 80x24, nested percentage width was causing channel names to be hidden while descriptions remained visible
- Parent Box already has `width="100%"`, inner Box inherits flexbox width naturally

## Test plan

- [x] All 1991 TUI tests pass
- [x] Lint passes (4 warnings in benchmark file only)
- [ ] Manual verification at 80x24 terminal - channel names visible

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)