### PR TITLE
feat(workspace): Add .bcrc user config support (#1160)

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -134,6 +134,58 @@ Examples:
 	RunE: runConfigReset,
 }
 
+// #1160: User-level config (.bcrc) commands
+
+var configUserCmd = &cobra.Command{
+	Use:   "user",
+	Short: "Manage user-level configuration (~/.bcrc)",
+	Long: `Manage user-level configuration stored in ~/.bcrc.
+
+User configuration provides defaults that apply across all bc workspaces:
+  - Your nickname for channel messages
+  - Default role for new agents
+  - Preferred AI tools
+
+Workspace config (.bc/config.toml) takes precedence over user config.
+
+Examples:
+  bc config user init   # Create ~/.bcrc with guided prompts
+  bc config user show   # Show user config
+  bc config user path   # Show user config path`,
+	RunE: runConfigUserShow,
+}
+
+var configUserInitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Create user configuration file (~/.bcrc)",
+	Long: `Create a new ~/.bcrc file with guided prompts.
+
+Examples:
+  bc config user init          # Interactive setup
+  bc config user init --quick  # Use defaults without prompts`,
+	RunE: runConfigUserInit,
+}
+
+var configUserShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "Show user configuration",
+	Long: `Display the current user configuration from ~/.bcrc.
+
+Examples:
+  bc config user show`,
+	RunE: runConfigUserShow,
+}
+
+var configUserPathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Show user configuration file path",
+	Long: `Display the path to the user configuration file.
+
+Examples:
+  bc config user path`,
+	RunE: runConfigUserPath,
+}
+
 // Flags
 var (
 	configForce bool
@@ -148,7 +200,14 @@ func init() {
 	configCmd.AddCommand(configValidateCmd)
 	configCmd.AddCommand(configResetCmd)
 
+	// #1160: User config subcommands
+	configCmd.AddCommand(configUserCmd)
+	configUserCmd.AddCommand(configUserInitCmd)
+	configUserCmd.AddCommand(configUserShowCmd)
+	configUserCmd.AddCommand(configUserPathCmd)
+
 	configResetCmd.Flags().BoolVar(&configForce, "force", false, "Skip confirmation prompt")
+	configUserInitCmd.Flags().Bool("quick", false, "Use defaults without prompts")
 
 	rootCmd.AddCommand(configCmd)
 }
@@ -645,4 +704,151 @@ func formatValue(value any) string {
 	default:
 		return fmt.Sprintf("%v", value)
 	}
+}
+
+// #1160: User config command implementations
+
+func runConfigUserInit(cmd *cobra.Command, _ []string) error {
+	quick, _ := cmd.Flags().GetBool("quick")
+
+	path := workspace.UserRCConfigPath()
+	if path == "" {
+		return fmt.Errorf("could not determine home directory")
+	}
+
+	// Check if already exists
+	if workspace.UserRCExists() {
+		fmt.Printf("⚠️  User config already exists at %s\n", path)
+		fmt.Print("Overwrite? [y/N]: ")
+
+		var response string
+		if _, err := fmt.Scanln(&response); err != nil {
+			// Handle scan error or empty input
+			fmt.Println("Canceled")
+			return nil
+		}
+		response = strings.ToLower(strings.TrimSpace(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Canceled")
+			return nil
+		}
+	}
+
+	var cfg workspace.UserRCConfig
+
+	if quick {
+		// Quick mode: use defaults
+		cfg = workspace.DefaultUserRCConfig()
+	} else {
+		// Interactive mode
+		var err error
+		cfg, err = runConfigUserInitWizard()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Save the config
+	if err := cfg.Save(); err != nil {
+		return err
+	}
+
+	fmt.Printf("✓ Created %s\n", path)
+	fmt.Println()
+	fmt.Println("Your user config:")
+	printUserRCConfig(&cfg)
+
+	return nil
+}
+
+func runConfigUserInitWizard() (workspace.UserRCConfig, error) {
+	cfg := workspace.DefaultUserRCConfig()
+
+	fmt.Println()
+	fmt.Println("bc - User Configuration Setup")
+	fmt.Println(strings.Repeat("-", 40))
+	fmt.Println()
+
+	// Nickname
+	fmt.Printf("Your nickname [%s]: ", workspace.DefaultNickname)
+	var input string
+	if _, err := fmt.Scanln(&input); err == nil && input != "" {
+		nickname, err := workspace.NormalizeNickname(input)
+		if err != nil {
+			fmt.Printf("⚠️  %s, using default\n", err)
+		} else {
+			cfg.User.Nickname = nickname
+		}
+	}
+
+	// Default role
+	fmt.Printf("Default role for new agents [engineer]: ")
+	if _, err := fmt.Scanln(&input); err == nil && input != "" {
+		cfg.Defaults.DefaultRole = input
+	}
+
+	// Auto-start root
+	fmt.Printf("Auto-start root agent on 'bc up'? [Y/n]: ")
+	if _, err := fmt.Scanln(&input); err == nil {
+		input = strings.ToLower(strings.TrimSpace(input))
+		cfg.Defaults.AutoStartRoot = input != "n" && input != "no"
+	}
+
+	// Preferred tools
+	fmt.Printf("Preferred tools (comma-separated) [claude-code, gemini]: ")
+	if _, err := fmt.Scanln(&input); err == nil && input != "" {
+		tools := strings.Split(input, ",")
+		for i := range tools {
+			tools[i] = strings.TrimSpace(tools[i])
+		}
+		cfg.Tools.Preferred = tools
+	}
+
+	return cfg, nil
+}
+
+func runConfigUserShow(_ *cobra.Command, _ []string) error {
+	cfg, err := workspace.LoadUserRCConfig()
+	if err != nil {
+		return err
+	}
+
+	if cfg == nil {
+		path := workspace.UserRCConfigPath()
+		fmt.Printf("No user config found at %s\n", path)
+		fmt.Println("Run 'bc config user init' to create one.")
+		return nil
+	}
+
+	fmt.Println("# User Config (~/.bcrc)")
+	fmt.Println()
+	printUserRCConfig(cfg)
+
+	return nil
+}
+
+func runConfigUserPath(_ *cobra.Command, _ []string) error {
+	path := workspace.UserRCConfigPath()
+	exists := workspace.UserRCExists()
+
+	fmt.Printf("User config: %s", path)
+	if exists {
+		fmt.Println(" (exists)")
+	} else {
+		fmt.Println(" (not found)")
+	}
+
+	return nil
+}
+
+func printUserRCConfig(cfg *workspace.UserRCConfig) {
+	fmt.Println("[user]")
+	fmt.Printf("  nickname = %q\n", cfg.User.Nickname)
+	fmt.Println()
+	fmt.Println("[defaults]")
+	fmt.Printf("  default_role = %q\n", cfg.Defaults.DefaultRole)
+	fmt.Printf("  auto_start_root = %v\n", cfg.Defaults.AutoStartRoot)
+	fmt.Println()
+	fmt.Println("[tools]")
+	fmt.Printf("  preferred = %v\n", cfg.Tools.Preferred)
 }

--- a/pkg/workspace/userconfig.go
+++ b/pkg/workspace/userconfig.go
@@ -1,0 +1,178 @@
+// Package workspace provides workspace/project management.
+package workspace
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// UserRCConfigPath returns the path to the user's .bcrc file.
+// Default: ~/.bcrc
+func UserRCConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".bcrc")
+}
+
+// UserRCConfig represents user-level defaults stored in ~/.bcrc.
+// These values are merged with workspace config when loading.
+type UserRCConfig struct {
+	User     UserRCUserConfig     `toml:"user"`
+	Defaults UserRCDefaultsConfig `toml:"defaults"`
+	Tools    UserRCToolsConfig    `toml:"tools"`
+}
+
+// UserRCUserConfig holds user identity settings.
+type UserRCUserConfig struct {
+	Nickname string `toml:"nickname,omitempty"` // Default nickname for new workspaces
+}
+
+// UserRCDefaultsConfig holds default behavior settings.
+type UserRCDefaultsConfig struct {
+	DefaultRole   string `toml:"default_role,omitempty"`    // Default role for new agents
+	AutoStartRoot bool   `toml:"auto_start_root,omitempty"` // Auto-start root agent on bc up
+}
+
+// UserRCToolsConfig holds tool preferences.
+type UserRCToolsConfig struct {
+	Preferred []string `toml:"preferred,omitempty"` // Preferred tools in order
+}
+
+// DefaultUserRCConfig returns sensible defaults for a new .bcrc file.
+func DefaultUserRCConfig() UserRCConfig {
+	return UserRCConfig{
+		User: UserRCUserConfig{
+			Nickname: DefaultNickname,
+		},
+		Defaults: UserRCDefaultsConfig{
+			DefaultRole:   "engineer",
+			AutoStartRoot: true,
+		},
+		Tools: UserRCToolsConfig{
+			Preferred: []string{"claude-code", "gemini"},
+		},
+	}
+}
+
+// LoadUserRCConfig loads the user's .bcrc file.
+// Returns nil if the file doesn't exist.
+func LoadUserRCConfig() (*UserRCConfig, error) {
+	path := UserRCConfigPath()
+	if path == "" {
+		return nil, nil
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // path from UserHomeDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // No .bcrc file is fine
+		}
+		return nil, fmt.Errorf("failed to read .bcrc: %w", err)
+	}
+
+	return ParseUserRCConfig(data)
+}
+
+// ParseUserRCConfig parses TOML data into a UserRCConfig.
+func ParseUserRCConfig(data []byte) (*UserRCConfig, error) {
+	var cfg UserRCConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse .bcrc: %w", err)
+	}
+	return &cfg, nil
+}
+
+// Save writes the user config to the .bcrc file.
+func (c *UserRCConfig) Save() error {
+	path := UserRCConfigPath()
+	if path == "" {
+		return fmt.Errorf("could not determine home directory")
+	}
+
+	f, err := os.Create(path) //nolint:gosec // path from UserHomeDir
+	if err != nil {
+		return fmt.Errorf("failed to create .bcrc: %w", err)
+	}
+	defer f.Close() //nolint:errcheck // defer close
+
+	encoder := toml.NewEncoder(f)
+	if err := encoder.Encode(c); err != nil {
+		return fmt.Errorf("failed to write .bcrc: %w", err)
+	}
+
+	return nil
+}
+
+// UserRCExists returns true if ~/.bcrc exists.
+func UserRCExists() bool {
+	path := UserRCConfigPath()
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// MergeWithUserRC merges user-level defaults from .bcrc into a workspace config.
+// Workspace config takes precedence over user config for all explicitly set values.
+// This function only fills in unset values from .bcrc.
+func (c *V2Config) MergeWithUserRC(rc *UserRCConfig) {
+	if rc == nil {
+		return
+	}
+
+	// Merge user identity (only if not set in workspace)
+	if c.User.Nickname == "" || c.User.Nickname == DefaultNickname {
+		if rc.User.Nickname != "" {
+			c.User.Nickname = rc.User.Nickname
+		}
+	}
+
+	// Note: Other settings like default_role and preferred tools are used
+	// by commands at runtime, not merged into workspace config
+}
+
+// GetPreferredTool returns the first available preferred tool from .bcrc,
+// or the workspace default if no preference is set.
+func (c *V2Config) GetPreferredTool(rc *UserRCConfig) string {
+	if rc == nil || len(rc.Tools.Preferred) == 0 {
+		return c.Tools.Default
+	}
+
+	// Check if any preferred tool is available in workspace
+	for _, tool := range rc.Tools.Preferred {
+		if c.HasTool(tool) {
+			return tool
+		}
+	}
+
+	return c.Tools.Default
+}
+
+// HasTool checks if a tool is configured in the workspace.
+func (c *V2Config) HasTool(name string) bool {
+	switch name {
+	case "claude", "claude-code":
+		return c.Tools.Claude != nil && c.Tools.Claude.Enabled
+	case "cursor":
+		return c.Tools.Cursor != nil && c.Tools.Cursor.Enabled
+	case "codex":
+		return c.Tools.Codex != nil && c.Tools.Codex.Enabled
+	case "gemini":
+		return c.Tools.Gemini != nil && c.Tools.Gemini.Enabled
+	case "github":
+		return c.Tools.GitHub != nil && c.Tools.GitHub.Enabled
+	case "gitlab":
+		return c.Tools.GitLab != nil && c.Tools.GitLab.Enabled
+	case "jira":
+		return c.Tools.Jira != nil && c.Tools.Jira.Enabled
+	default:
+		_, ok := c.Tools.Custom[name]
+		return ok
+	}
+}

--- a/pkg/workspace/userconfig_test.go
+++ b/pkg/workspace/userconfig_test.go
@@ -1,0 +1,150 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestUserRCConfigPath(t *testing.T) {
+	path := UserRCConfigPath()
+	if path == "" {
+		t.Skip("no home directory available")
+	}
+
+	if !filepath.IsAbs(path) {
+		t.Errorf("expected absolute path, got: %s", path)
+	}
+
+	if filepath.Base(path) != ".bcrc" {
+		t.Errorf("expected .bcrc filename, got: %s", filepath.Base(path))
+	}
+}
+
+func TestDefaultUserRCConfig(t *testing.T) {
+	cfg := DefaultUserRCConfig()
+
+	if cfg.User.Nickname != DefaultNickname {
+		t.Errorf("expected default nickname %s, got: %s", DefaultNickname, cfg.User.Nickname)
+	}
+
+	if cfg.Defaults.DefaultRole != "engineer" {
+		t.Errorf("expected default role 'engineer', got: %s", cfg.Defaults.DefaultRole)
+	}
+
+	if !cfg.Defaults.AutoStartRoot {
+		t.Error("expected auto_start_root to be true by default")
+	}
+
+	if len(cfg.Tools.Preferred) == 0 {
+		t.Error("expected preferred tools to be set")
+	}
+}
+
+func TestParseUserRCConfig(t *testing.T) {
+	data := []byte(`
+[user]
+nickname = "@alice"
+
+[defaults]
+default_role = "manager"
+auto_start_root = false
+
+[tools]
+preferred = ["cursor", "claude-code"]
+`)
+
+	cfg, err := ParseUserRCConfig(data)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	if cfg.User.Nickname != "@alice" {
+		t.Errorf("expected nickname '@alice', got: %s", cfg.User.Nickname)
+	}
+
+	if cfg.Defaults.DefaultRole != "manager" {
+		t.Errorf("expected default role 'manager', got: %s", cfg.Defaults.DefaultRole)
+	}
+
+	if cfg.Defaults.AutoStartRoot {
+		t.Error("expected auto_start_root to be false")
+	}
+
+	if len(cfg.Tools.Preferred) != 2 {
+		t.Errorf("expected 2 preferred tools, got: %d", len(cfg.Tools.Preferred))
+	}
+}
+
+func TestUserRCConfigSaveAndLoad(t *testing.T) {
+	// Create a temp directory to use as home
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	// Create and save a config
+	cfg := DefaultUserRCConfig()
+	cfg.User.Nickname = "@testuser"
+
+	err := cfg.Save()
+	if err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	// Verify file exists
+	path := filepath.Join(tmpDir, ".bcrc")
+	if _, statErr := os.Stat(path); statErr != nil {
+		t.Fatalf("config file not created: %v", statErr)
+	}
+
+	// Load and verify
+	loaded, err := LoadUserRCConfig()
+	if err != nil {
+		t.Fatalf("load failed: %v", err)
+	}
+
+	if loaded == nil {
+		t.Fatal("loaded config is nil")
+	}
+
+	if loaded.User.Nickname != "@testuser" {
+		t.Errorf("expected nickname '@testuser', got: %s", loaded.User.Nickname)
+	}
+}
+
+func TestMergeWithUserRC(t *testing.T) {
+	// Create a workspace config with default nickname
+	wsCfg := DefaultV2Config("test")
+
+	// Create a user config with custom nickname
+	rcCfg := &UserRCConfig{
+		User: UserRCUserConfig{
+			Nickname: "@custom",
+		},
+	}
+
+	// Merge
+	wsCfg.MergeWithUserRC(rcCfg)
+
+	// User RC nickname should be used since workspace has default
+	if wsCfg.User.Nickname != "@custom" {
+		t.Errorf("expected merged nickname '@custom', got: %s", wsCfg.User.Nickname)
+	}
+}
+
+func TestHasTool(t *testing.T) {
+	cfg := DefaultV2Config("test")
+
+	if !cfg.HasTool("gemini") {
+		t.Error("expected gemini to be available")
+	}
+
+	if !cfg.HasTool("claude") {
+		t.Error("expected claude to be available")
+	}
+
+	if cfg.HasTool("unknown-tool") {
+		t.Error("expected unknown-tool to not be available")
+	}
+}


### PR DESCRIPTION
## Summary
Add code infrastructure for user-level configuration file (~/.bcrc).

This complements PR #1178 which added example configurations. This PR adds the actual code to:
- Load and parse ~/.bcrc files
- Merge user defaults with workspace config
- Provide `bc config user` CLI commands

## Changes

### New Files
- **pkg/workspace/userconfig.go** - UserRCConfig struct and functions
- **pkg/workspace/userconfig_test.go** - Comprehensive tests

### Modified Files
- **internal/cmd/config.go** - Add "bc config user" subcommands

## Features

### UserRCConfig Structure
```toml
[user]
nickname = "@alice"

[defaults]
default_role = "engineer"
auto_start_root = true

[tools]
preferred = ["claude-code", "gemini"]
```

### CLI Commands
- `bc config user init` - Create ~/.bcrc with guided prompts
- `bc config user init --quick` - Use defaults without prompts
- `bc config user show` - Show user config
- `bc config user path` - Show user config path

## Test plan
- [x] Unit tests for userconfig.go (all pass)
- [x] Linting passes
- [x] Build passes

Related to #1160 (complements PR #1178)

🤖 Generated with [Claude Code](https://claude.com/claude-code)