### PR TITLE
fix(tui): Collapse Dashboard panels at 80 cols (#1184)

### DIFF
--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -91,12 +91,13 @@ export function Dashboard({ onNavigate: _onNavigate }: DashboardProps) {
         errorCount={summary.error}
       />
 
-      {/* Metrics panels - Optimized for all terminal sizes (Issue #1041) */}
-      {/* On narrow terminals: 2x2 grid at top, on wide: side-by-side with activity feed */}
+      {/* Metrics panels - Optimized for all terminal sizes (Issue #1041, #1184) */}
+      {/* At 80 cols: single column stack to prevent text garbling */}
+      {/* At 81-99 cols: 2-column layout with adjusted widths */}
       {!canMultiColumn && (
-        <Box marginTop={1} flexDirection="row" width="100%">
-          {/* Left column: System Health + Cost */}
-          <Box flexDirection="column" flexGrow={1} marginRight={1}>
+        <Box marginTop={1} flexDirection={terminalWidth <= 80 ? 'column' : 'row'} width="100%">
+          {/* Left/Top: System Health + Cost */}
+          <Box flexDirection="column" flexGrow={1} marginRight={terminalWidth > 80 ? 1 : 0}>
             <SystemHealthPanel
               working={summary.working}
               idle={summary.idle}
@@ -111,8 +112,8 @@ export function Dashboard({ onNavigate: _onNavigate }: DashboardProps) {
             />
           </Box>
 
-          {/* Right column: Agent Distribution */}
-          <Box flexDirection="column" width={Math.max(20, Math.floor(terminalWidth * 0.35))}>
+          {/* Right/Bottom: Agent Distribution */}
+          <Box flexDirection="column" width={terminalWidth <= 80 ? '100%' : Math.max(20, Math.floor(terminalWidth * 0.35))}>
             <AgentStatsPanel stats={agentStats} />
           </Box>
         </Box>


### PR DESCRIPTION
## Summary
- At 80 columns, switch to single-column (stacked) layout instead of two-column side-by-side
- Root cause: Two-column layout at 80 cols causes panels to be too narrow (26 chars content area), leading to text bleeding/overlap

## Changes
- At <=80 cols: Stack panels vertically (`flexDirection="column"`)
- At 81-99 cols: Keep 2-column layout with row direction
- Full width panels eliminate truncation/garbling issues

## Root Cause Analysis
Ink's `overflow:hidden` doesn't properly isolate flex children at very narrow widths. When panels are only 26 chars wide (80 total - borders - padding - margins), text from adjacent elements bleeds together:
- 'By Role:stribution' = 'By Role:' + 'Distribution' bleeding
- '58% healthyth' = extra chars from adjacent element

## Test plan
- [x] All 80x24 tests pass (29 tests)
- [x] All Dashboard tests pass (97 tests)
- [x] Lint passes
- [ ] Manual verification at 80x24 terminal size

Fixes #1184

🤖 Generated with [Claude Code](https://claude.com/claude-code)