### PR TITLE
fix(ux): Add agent error hint and responsive ActivityFeed (#1196)

### DIFF
--- a/internal/cmd/send.go
+++ b/internal/cmd/send.go
@@ -57,7 +57,7 @@ func runSend(cmd *cobra.Command, args []string) error {
 	// Check agent exists
 	a := mgr.GetAgent(agentName)
 	if a == nil {
-		return fmt.Errorf("agent %q not found", agentName)
+		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentName)
 	}
 	log.Debug("agent found", "agent", agentName, "state", a.State)
 

--- a/tui/src/components/ActivityFeed.tsx
+++ b/tui/src/components/ActivityFeed.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import { Panel } from './Panel';
 import { useLogs, getSeverityColor } from '../hooks';
 import type { LogSeverity } from '../hooks';
@@ -64,6 +64,7 @@ function truncateMessage(msg: string, maxLen: number): string {
 
 /**
  * ActivityFeed component - Real-time log stream
+ * #1196: Responsive message truncation based on terminal width
  */
 export function ActivityFeed({
   maxEntries = 8,
@@ -73,10 +74,26 @@ export function ActivityFeed({
   compact = false,
   showFilterHints = true,
 }: ActivityFeedProps): React.ReactElement {
+  const { stdout } = useStdout();
+  const terminalWidth = stdout.columns;
+
   const { data: logs, loading, severityFilter: currentFilter } = useLogs({
     tail: 50,
     pollInterval: 3000,
   });
+
+  // #1196: Calculate responsive message length based on terminal width
+  // Layout: [timestamp 9] [agent 11] [event 13] [message]
+  // Compact: [agent 11] [event 13] [message]
+  const maxMsgLen = useMemo(() => {
+    const timestampWidth = compact ? 0 : 9;
+    const agentWidth = 11; // padEnd(10) + space
+    const eventWidth = 13; // padEnd(12) + space
+    const panelOverhead = 6; // borders, padding, margin
+    const available = terminalWidth - timestampWidth - agentWidth - eventWidth - panelOverhead;
+    // Clamp between 20 and 100
+    return Math.max(20, Math.min(100, available));
+  }, [terminalWidth, compact]);
 
   // Apply local severity filter or use hook filter
   const activeFilter = severityFilter ?? currentFilter;
@@ -129,7 +146,7 @@ export function ActivityFeed({
       ) : (
         <Box flexDirection="column">
           {displayLogs.map((entry, idx) => (
-            <ActivityEntry key={`${entry.ts}-${String(idx)}`} entry={entry} compact={compact} />
+            <ActivityEntry key={`${entry.ts}-${String(idx)}`} entry={entry} compact={compact} maxMsgLen={maxMsgLen} />
           ))}
         </Box>
       )}
@@ -139,19 +156,21 @@ export function ActivityFeed({
 
 /**
  * Individual activity entry - memoized for performance
+ * #1196: Now accepts maxMsgLen prop for responsive truncation
  */
 interface ActivityEntryProps {
   entry: LogEntry;
   compact?: boolean;
+  maxMsgLen: number;
 }
 
 const ActivityEntry = memo(function ActivityEntry({
   entry,
   compact = false,
+  maxMsgLen,
 }: ActivityEntryProps): React.ReactElement {
   const severityColor = getSeverityColor(entry.type);
   const eventLabel = formatEventType(entry.type);
-  const maxMsgLen = compact ? 40 : 60;
 
   return (
     <Box>


### PR DESCRIPTION
## Summary
Additional UX polish improvements from component audit.
Complements eng-01's PR #1207 (channel error hints).

## Changes

### 1. CLI: Agent error hint in send.go
**Before:**
```
Error: agent "nonexistent" not found
```

**After:**
```
Error: agent "nonexistent" not found (use 'bc agent list' to see available agents)
```

### 2. TUI: ActivityFeed responsive message truncation
- Calculate `maxMsgLen` based on terminal width instead of hardcoded 40/60 values
- Layout: `[timestamp 9] [agent 11] [event 13] [message]`
- Clamps message length between 20-100 chars based on available space
- Improves display on both narrow (80-col) and wide terminals

## Test plan
- [x] Build passes (Go + TUI)
- [x] Lint passes (0 errors)
- [x] TUI compiles successfully
- [ ] Manual testing at different terminal widths

Partial fix for #1196

🤖 Generated with [Claude Code](https://claude.com/claude-code)