### PR TITLE
feat(tui): Add colorblind-friendly severity icons (#1220)

### DIFF
--- a/tui/src/components/ActivityFeed.tsx
+++ b/tui/src/components/ActivityFeed.tsx
@@ -6,7 +6,7 @@
 import React, { memo, useMemo } from 'react';
 import { Box, Text, useStdout } from 'ink';
 import { Panel } from './Panel';
-import { useLogs, getSeverityColor } from '../hooks';
+import { useLogs, getSeverityColor, getSeverityIcon } from '../hooks';
 import type { LogSeverity } from '../hooks';
 import type { LogEntry } from '../types';
 
@@ -154,6 +154,7 @@ interface ActivityEntryProps {
 // Layout constants for message width calculation
 const TIMESTAMP_WIDTH = 9; // HH:MM:SS + space
 const AGENT_WIDTH = 11;    // 10 chars + space
+const ICON_WIDTH = 2;      // icon + space (colorblind accessibility)
 const EVENT_WIDTH = 13;    // 12 chars + space
 const MIN_MSG_WIDTH = 20;  // Minimum message width
 
@@ -163,11 +164,12 @@ const ActivityEntry = memo(function ActivityEntry({
   terminalWidth = 80,
 }: ActivityEntryProps): React.ReactElement {
   const severityColor = getSeverityColor(entry.type);
+  const severityIcon = getSeverityIcon(entry.type);
   const eventLabel = formatEventType(entry.type);
 
   // Calculate dynamic message width based on terminal size
-  // Layout: [timestamp] agent event message
-  const fixedWidth = (compact ? 0 : TIMESTAMP_WIDTH) + AGENT_WIDTH + EVENT_WIDTH;
+  // Layout: [timestamp] agent icon event message
+  const fixedWidth = (compact ? 0 : TIMESTAMP_WIDTH) + AGENT_WIDTH + ICON_WIDTH + EVENT_WIDTH;
   const availableWidth = terminalWidth - fixedWidth - 4; // 4 for panel borders/padding
   const maxMsgLen = Math.max(MIN_MSG_WIDTH, availableWidth);
 
@@ -177,6 +179,7 @@ const ActivityEntry = memo(function ActivityEntry({
         <Text dimColor>{formatTime(entry.ts)} </Text>
       )}
       <Text color="cyan">{entry.agent.padEnd(10)} </Text>
+      <Text color={severityColor}>{severityIcon} </Text>
       <Text color={severityColor}>{eventLabel.padEnd(12)} </Text>
       <Text>{truncateMessage(entry.message, maxMsgLen)}</Text>
     </Box>

--- a/tui/src/hooks/__tests__/useLogs.test.tsx
+++ b/tui/src/hooks/__tests__/useLogs.test.tsx
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect } from 'bun:test';
-import { getSeverityColor } from '../useLogs';
+import { getSeverityColor, getSeverityIcon } from '../useLogs';
 import type { UseLogsOptions, UseLogsResult, LogSeverity } from '../useLogs';
 
 describe('useLogs - Severity Color Mapping', () => {
@@ -147,5 +147,33 @@ describe('useLogs - Edge Cases', () => {
     expect(getSeverityColor(longError)).toBe('red');
     expect(getSeverityColor(longWarn)).toBe('yellow');
     expect(getSeverityColor(longInfo)).toBe('gray');
+  });
+});
+
+describe('useLogs - Severity Icon Mapping (#1220)', () => {
+  describe('getSeverityIcon', () => {
+    it('returns ✗ for error types', () => {
+      expect(getSeverityIcon('error')).toBe('✗');
+      expect(getSeverityIcon('AGENT_ERROR')).toBe('✗');
+      expect(getSeverityIcon('FAIL')).toBe('✗');
+    });
+
+    it('returns ⚠ for warning types', () => {
+      expect(getSeverityIcon('warning')).toBe('⚠');
+      expect(getSeverityIcon('AGENT_STUCK')).toBe('⚠');
+      expect(getSeverityIcon('warn')).toBe('⚠');
+    });
+
+    it('returns · for info types', () => {
+      expect(getSeverityIcon('agent_started')).toBe('·');
+      expect(getSeverityIcon('message_sent')).toBe('·');
+      expect(getSeverityIcon('info')).toBe('·');
+    });
+
+    it('handles case insensitivity', () => {
+      expect(getSeverityIcon('Error')).toBe('✗');
+      expect(getSeverityIcon('WARNING')).toBe('⚠');
+      expect(getSeverityIcon('Info')).toBe('·');
+    });
   });
 });

--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -98,6 +98,7 @@ export {
 export {
   useLogs,
   getSeverityColor,
+  getSeverityIcon,
   type UseLogsOptions,
   type UseLogsResult,
   type LogSeverity,

--- a/tui/src/hooks/useLogs.ts
+++ b/tui/src/hooks/useLogs.ts
@@ -138,3 +138,19 @@ export function getSeverityColor(type: string): string {
       return 'gray';
   }
 }
+
+/**
+ * Get severity icon for log entry
+ * Issue #1220: Colorblind-friendly visual cues
+ */
+export function getSeverityIcon(type: string): string {
+  const severity = getSeverity(type);
+  switch (severity) {
+    case 'error':
+      return '✗';
+    case 'warn':
+      return '⚠';
+    default:
+      return '·';
+  }
+}

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
-import { useLogs, getSeverityColor } from '../hooks/useLogs';
+import { useLogs, getSeverityColor, getSeverityIcon } from '../hooks/useLogs';
 import { useFocus } from '../navigation/FocusContext';
 import { PulseText } from '../components/AnimatedText';
 import type { LogSeverity } from '../hooks/useLogs';
@@ -236,7 +236,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
           </Box>
           <Box>
             <Text bold>Type: </Text>
-            <Text color={getSeverityColor(selectedLog.type)}>{selectedLog.type}</Text>
+            <Text color={getSeverityColor(selectedLog.type)}>{getSeverityIcon(selectedLog.type)} {selectedLog.type}</Text>
           </Box>
           <Box marginTop={1} flexDirection="column">
             <Text bold>Message:</Text>
@@ -348,6 +348,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
           const actualIdx = startIdx + idx;
           const isSelected = actualIdx === selectedIndex;
           const severityColor = getSeverityColor(log.type);
+          const severityIcon = getSeverityIcon(log.type);
 
           return (
             <Box key={`${log.ts}-${String(idx)}`}>
@@ -367,7 +368,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
                 backgroundColor={isSelected ? 'blue' : undefined}
                 color={isSelected ? 'white' : severityColor}
               >
-                {log.type.slice(0, typeWidth - 1).padEnd(typeWidth)}
+                {severityIcon} {log.type.slice(0, typeWidth - 3).padEnd(typeWidth - 2)}
               </Text>
               <Text
                 backgroundColor={isSelected ? 'blue' : undefined}


### PR DESCRIPTION
## Summary
- Add `getSeverityIcon()` function to useLogs hook
- Icons: Error ✗, Warning ⚠, Info ·
- Update ActivityFeed to show icons alongside severity colors  
- Update LogsView to show icons in log list and details
- Comprehensive tests for icon mapping

## Purpose
Provide secondary visual cues beyond color for colorblind users.
Per Product Vision TUI Standards: "Never color alone"

## Test plan
- [ ] Build TUI: `cd tui && bun run build`
- [ ] Run tests: `cd tui && bun test src/hooks/__tests__/useLogs.test.tsx`
- [ ] Verify ActivityFeed shows icons (✗/⚠/·) before event types
- [ ] Verify LogsView shows icons in table and detail views

Closes #1220

🤖 Generated with [Claude Code](https://claude.ai/code)