### PR TITLE
feat(workspace): Add multi-workspace registry commands (#1218)

### DIFF
--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -55,6 +56,51 @@ Examples:
 	RunE: runWorkspaceDiscover,
 }
 
+// workspaceAddCmd manually adds a workspace to the registry
+// Issue #1218: Multi-workspace orchestration
+var workspaceAddCmd = &cobra.Command{
+	Use:   "add <path>",
+	Short: "Add a workspace to the registry",
+	Long: `Register a workspace in the global registry for quick access.
+
+Examples:
+  bc workspace add .                        # Add current directory
+  bc workspace add ~/projects/frontend      # Add by path
+  bc workspace add . --alias fe             # Add with short alias
+  bc workspace add ~/api --alias backend    # Add with alias`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWorkspaceAdd,
+}
+
+// workspaceRemoveCmd removes a workspace from the registry
+var workspaceRemoveCmd = &cobra.Command{
+	Use:   "remove <alias|path>",
+	Short: "Remove a workspace from the registry",
+	Long: `Unregister a workspace from the global registry.
+
+This does not delete the workspace, just removes it from the registry.
+
+Examples:
+  bc workspace remove fe                    # Remove by alias
+  bc workspace remove ~/projects/frontend   # Remove by path`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWorkspaceRemove,
+}
+
+// workspaceSwitchCmd sets the active workspace
+var workspaceSwitchCmd = &cobra.Command{
+	Use:   "switch <alias|path>",
+	Short: "Switch active workspace",
+	Long: `Set the active workspace for cross-workspace operations.
+
+Examples:
+  bc workspace switch fe                    # Switch by alias
+  bc workspace switch ~/projects/frontend   # Switch by path
+  bc workspace switch --clear               # Clear active workspace`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runWorkspaceSwitch,
+}
+
 func init() {
 	// List command flags
 	workspaceListCmd.Flags().StringSlice("scan", nil, "Additional paths to scan")
@@ -65,9 +111,18 @@ func init() {
 	workspaceDiscoverCmd.Flags().StringSlice("scan", nil, "Additional paths to scan")
 	workspaceDiscoverCmd.Flags().Int("depth", 3, "Maximum scan depth")
 
+	// Add command flags (#1218)
+	workspaceAddCmd.Flags().String("alias", "", "Short alias for quick access")
+
+	// Switch command flags (#1218)
+	workspaceSwitchCmd.Flags().Bool("clear", false, "Clear active workspace")
+
 	// Add subcommands
 	workspaceCmd.AddCommand(workspaceListCmd)
 	workspaceCmd.AddCommand(workspaceDiscoverCmd)
+	workspaceCmd.AddCommand(workspaceAddCmd)
+	workspaceCmd.AddCommand(workspaceRemoveCmd)
+	workspaceCmd.AddCommand(workspaceSwitchCmd)
 
 	// Register with root
 	rootCmd.AddCommand(workspaceCmd)
@@ -158,5 +213,166 @@ func runWorkspaceDiscover(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Registered %d new workspace(s)\n", newCount)
 	}
 
+	return nil
+}
+
+// runWorkspaceAdd handles the workspace add command.
+// Issue #1218: Multi-workspace orchestration.
+func runWorkspaceAdd(cmd *cobra.Command, args []string) error {
+	path := args[0]
+	alias, _ := cmd.Flags().GetString("alias")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+
+	// Resolve to absolute path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("invalid path: %w", err)
+	}
+
+	// Verify it's a workspace
+	if !workspace.IsWorkspace(absPath) {
+		return fmt.Errorf("not a bc workspace: %s (no .bc directory found)", absPath)
+	}
+
+	// Load workspace to get name
+	ws, err := workspace.Load(absPath)
+	if err != nil {
+		return fmt.Errorf("failed to load workspace: %w", err)
+	}
+	name := ws.Config.Name
+
+	// Load registry and add
+	reg, err := workspace.LoadRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to load registry: %w", err)
+	}
+
+	if err := reg.RegisterWithAlias(absPath, name, alias); err != nil {
+		return err
+	}
+
+	if err := reg.Save(); err != nil {
+		return fmt.Errorf("failed to save registry: %w", err)
+	}
+
+	if jsonOutput {
+		output := struct {
+			Path  string `json:"path"`
+			Name  string `json:"name"`
+			Alias string `json:"alias,omitempty"`
+		}{
+			Path:  absPath,
+			Name:  name,
+			Alias: alias,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		return enc.Encode(output)
+	}
+
+	if alias != "" {
+		fmt.Printf("Added workspace '%s' (%s) as '%s'\n", name, absPath, alias)
+	} else {
+		fmt.Printf("Added workspace '%s' (%s)\n", name, absPath)
+	}
+
+	return nil
+}
+
+// runWorkspaceRemove handles the workspace remove command.
+func runWorkspaceRemove(cmd *cobra.Command, args []string) error {
+	identifier := args[0]
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+
+	reg, err := workspace.LoadRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to load registry: %w", err)
+	}
+
+	entry := reg.FindByNameOrAlias(identifier)
+	if entry == nil {
+		return fmt.Errorf("workspace not found: %s", identifier)
+	}
+
+	// Store info before removal
+	removedPath := entry.Path
+	removedName := entry.Name
+
+	reg.Unregister(entry.Path)
+
+	// Clear active if this was the active workspace
+	if active := reg.GetActive(); active != nil && active.Path == removedPath {
+		_ = reg.SetActive("")
+	}
+
+	if err := reg.Save(); err != nil {
+		return fmt.Errorf("failed to save registry: %w", err)
+	}
+
+	if jsonOutput {
+		output := struct {
+			Removed string `json:"removed"`
+			Name    string `json:"name"`
+		}{
+			Removed: removedPath,
+			Name:    removedName,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		return enc.Encode(output)
+	}
+
+	fmt.Printf("Removed workspace '%s' from registry\n", removedName)
+	return nil
+}
+
+// runWorkspaceSwitch handles the workspace switch command.
+func runWorkspaceSwitch(cmd *cobra.Command, args []string) error {
+	clearActive, _ := cmd.Flags().GetBool("clear")
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+
+	reg, err := workspace.LoadRegistry()
+	if err != nil {
+		return fmt.Errorf("failed to load registry: %w", err)
+	}
+
+	if clearActive || len(args) == 0 {
+		if err := reg.SetActive(""); err != nil {
+			return err
+		}
+		if err := reg.Save(); err != nil {
+			return fmt.Errorf("failed to save registry: %w", err)
+		}
+		if jsonOutput {
+			fmt.Println("{\"active\": null}")
+		} else {
+			fmt.Println("Cleared active workspace")
+		}
+		return nil
+	}
+
+	identifier := args[0]
+	if err := reg.SetActive(identifier); err != nil {
+		return err
+	}
+
+	if err := reg.Save(); err != nil {
+		return fmt.Errorf("failed to save registry: %w", err)
+	}
+
+	active := reg.GetActive()
+	if jsonOutput {
+		output := struct {
+			Active string `json:"active"`
+			Path   string `json:"path"`
+			Name   string `json:"name"`
+		}{
+			Active: reg.Active,
+			Path:   active.Path,
+			Name:   active.Name,
+		}
+		enc := json.NewEncoder(os.Stdout)
+		return enc.Encode(output)
+	}
+
+	fmt.Printf("Switched to workspace '%s' (%s)\n", active.Name, active.Path)
 	return nil
 }

--- a/pkg/workspace/registry.go
+++ b/pkg/workspace/registry.go
@@ -13,11 +13,14 @@ type RegistryEntry struct {
 	LastAccessed time.Time `json:"last_accessed"`
 	Path         string    `json:"path"`
 	Name         string    `json:"name"`
+	Alias        string    `json:"alias,omitempty"` // Short alias for quick access (#1218)
 }
 
 // Registry manages the global list of workspaces at ~/.bc/workspaces.json.
+// Issue #1218: Multi-workspace orchestration support.
 type Registry struct {
 	path       string
+	Active     string          `json:"active,omitempty"` // Path or alias of active workspace
 	Workspaces []RegistryEntry `json:"workspaces"`
 }
 
@@ -72,22 +75,41 @@ func (r *Registry) Save() error {
 
 // Register adds or updates a workspace in the registry.
 func (r *Registry) Register(path, name string) {
+	_ = r.RegisterWithAlias(path, name, "") //nolint:errcheck // legacy function, alias conflict not possible with empty alias
+}
+
+// RegisterWithAlias adds or updates a workspace with an optional alias.
+// Issue #1218: Multi-workspace orchestration.
+func (r *Registry) RegisterWithAlias(path, name, alias string) error {
 	now := time.Now()
+
+	// Check alias conflict if setting one
+	if alias != "" {
+		existing := r.FindByAlias(alias)
+		if existing != nil && existing.Path != path {
+			return &AliasConflictError{Alias: alias, ExistingPath: existing.Path}
+		}
+	}
 
 	for i, w := range r.Workspaces {
 		if w.Path == path {
 			r.Workspaces[i].Name = name
 			r.Workspaces[i].LastAccessed = now
-			return
+			if alias != "" {
+				r.Workspaces[i].Alias = alias
+			}
+			return nil
 		}
 	}
 
 	r.Workspaces = append(r.Workspaces, RegistryEntry{
 		Path:         path,
 		Name:         name,
+		Alias:        alias,
 		CreatedAt:    now,
 		LastAccessed: now,
 	})
+	return nil
 }
 
 // Unregister removes a workspace from the registry.
@@ -138,4 +160,97 @@ func (r *Registry) Find(path string) *RegistryEntry {
 		}
 	}
 	return nil
+}
+
+// FindByAlias returns the entry for a given alias, or nil if not found.
+// Issue #1218: Multi-workspace orchestration.
+func (r *Registry) FindByAlias(alias string) *RegistryEntry {
+	for i, w := range r.Workspaces {
+		if w.Alias == alias {
+			return &r.Workspaces[i]
+		}
+	}
+	return nil
+}
+
+// FindByNameOrAlias returns the entry matching name, alias, or path.
+// Tries alias first, then name, then path.
+func (r *Registry) FindByNameOrAlias(identifier string) *RegistryEntry {
+	// Check alias first (most specific)
+	if entry := r.FindByAlias(identifier); entry != nil {
+		return entry
+	}
+	// Check name
+	for i, w := range r.Workspaces {
+		if w.Name == identifier {
+			return &r.Workspaces[i]
+		}
+	}
+	// Check path last
+	return r.Find(identifier)
+}
+
+// SetAlias sets or clears the alias for a workspace.
+func (r *Registry) SetAlias(path, alias string) error {
+	// Check if alias is already in use by another workspace
+	if alias != "" {
+		existing := r.FindByAlias(alias)
+		if existing != nil && existing.Path != path {
+			return &AliasConflictError{Alias: alias, ExistingPath: existing.Path}
+		}
+	}
+
+	for i, w := range r.Workspaces {
+		if w.Path == path {
+			r.Workspaces[i].Alias = alias
+			return nil
+		}
+	}
+	return &WorkspaceNotFoundError{Identifier: path}
+}
+
+// GetActive returns the active workspace entry, or nil if none set.
+func (r *Registry) GetActive() *RegistryEntry {
+	if r.Active == "" {
+		return nil
+	}
+	return r.FindByNameOrAlias(r.Active)
+}
+
+// SetActive sets the active workspace by path, alias, or name.
+func (r *Registry) SetActive(identifier string) error {
+	if identifier == "" {
+		r.Active = ""
+		return nil
+	}
+	entry := r.FindByNameOrAlias(identifier)
+	if entry == nil {
+		return &WorkspaceNotFoundError{Identifier: identifier}
+	}
+	// Store the alias if available, otherwise the path
+	if entry.Alias != "" {
+		r.Active = entry.Alias
+	} else {
+		r.Active = entry.Path
+	}
+	return nil
+}
+
+// AliasConflictError indicates the alias is already in use.
+type AliasConflictError struct {
+	Alias        string
+	ExistingPath string
+}
+
+func (e *AliasConflictError) Error() string {
+	return "alias '" + e.Alias + "' is already in use by workspace at " + e.ExistingPath
+}
+
+// WorkspaceNotFoundError indicates the workspace was not found.
+type WorkspaceNotFoundError struct {
+	Identifier string
+}
+
+func (e *WorkspaceNotFoundError) Error() string {
+	return "workspace not found: " + e.Identifier
 }

--- a/pkg/workspace/registry_test.go
+++ b/pkg/workspace/registry_test.go
@@ -1,0 +1,193 @@
+package workspace
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRegistryAlias tests the alias functionality (#1218)
+func TestRegistryAlias(t *testing.T) {
+	// Create temp directory for test registry
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "workspaces.json")
+
+	r := &Registry{path: registryPath}
+
+	// Register workspace without alias
+	err := r.RegisterWithAlias("/projects/frontend", "frontend", "")
+	if err != nil {
+		t.Fatalf("RegisterWithAlias: %v", err)
+	}
+
+	// Register workspace with alias
+	err = r.RegisterWithAlias("/projects/backend", "backend", "be")
+	if err != nil {
+		t.Fatalf("RegisterWithAlias with alias: %v", err)
+	}
+
+	// FindByAlias should work
+	entry := r.FindByAlias("be")
+	if entry == nil {
+		t.Fatal("FindByAlias: expected entry, got nil")
+	}
+	if entry.Path != "/projects/backend" {
+		t.Errorf("FindByAlias Path = %q, want %q", entry.Path, "/projects/backend")
+	}
+
+	// FindByAlias for non-existent alias should return nil
+	entry = r.FindByAlias("nonexistent")
+	if entry != nil {
+		t.Errorf("FindByAlias for nonexistent: expected nil, got %v", entry)
+	}
+
+	// SetAlias should work
+	err = r.SetAlias("/projects/frontend", "fe")
+	if err != nil {
+		t.Fatalf("SetAlias: %v", err)
+	}
+	entry = r.FindByAlias("fe")
+	if entry == nil || entry.Path != "/projects/frontend" {
+		t.Error("SetAlias: alias not set correctly")
+	}
+
+	// SetAlias with conflicting alias should error
+	err = r.SetAlias("/projects/frontend", "be")
+	if err == nil {
+		t.Error("SetAlias with conflicting alias: expected error, got nil")
+	}
+	if _, ok := err.(*AliasConflictError); !ok {
+		t.Errorf("SetAlias with conflicting alias: expected AliasConflictError, got %T", err)
+	}
+}
+
+// TestRegistryActiveWorkspace tests the active workspace functionality (#1218)
+func TestRegistryActiveWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "workspaces.json")
+
+	r := &Registry{path: registryPath}
+
+	// Register workspaces
+	_ = r.RegisterWithAlias("/projects/frontend", "frontend", "fe")
+	_ = r.RegisterWithAlias("/projects/backend", "backend", "be")
+
+	// GetActive should return nil initially
+	if active := r.GetActive(); active != nil {
+		t.Errorf("GetActive initially: expected nil, got %v", active)
+	}
+
+	// SetActive by alias
+	err := r.SetActive("fe")
+	if err != nil {
+		t.Fatalf("SetActive by alias: %v", err)
+	}
+	active := r.GetActive()
+	if active == nil || active.Path != "/projects/frontend" {
+		t.Error("SetActive by alias: active workspace not set correctly")
+	}
+	// Active should be stored as alias
+	if r.Active != "fe" {
+		t.Errorf("Active stored = %q, want %q", r.Active, "fe")
+	}
+
+	// SetActive by path
+	err = r.SetActive("/projects/backend")
+	if err != nil {
+		t.Fatalf("SetActive by path: %v", err)
+	}
+	active = r.GetActive()
+	if active == nil || active.Path != "/projects/backend" {
+		t.Error("SetActive by path: active workspace not set correctly")
+	}
+
+	// SetActive for non-existent workspace should error
+	err = r.SetActive("nonexistent")
+	if err == nil {
+		t.Error("SetActive for nonexistent: expected error, got nil")
+	}
+
+	// SetActive with empty clears active
+	err = r.SetActive("")
+	if err != nil {
+		t.Fatalf("SetActive empty: %v", err)
+	}
+	if r.GetActive() != nil {
+		t.Error("SetActive empty: expected nil active")
+	}
+}
+
+// TestRegistryFindByNameOrAlias tests the combined lookup (#1218)
+func TestRegistryFindByNameOrAlias(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "workspaces.json")
+
+	r := &Registry{path: registryPath}
+	_ = r.RegisterWithAlias("/projects/frontend", "frontend", "fe")
+
+	// Find by alias
+	entry := r.FindByNameOrAlias("fe")
+	if entry == nil || entry.Path != "/projects/frontend" {
+		t.Error("FindByNameOrAlias by alias: not found")
+	}
+
+	// Find by name
+	entry = r.FindByNameOrAlias("frontend")
+	if entry == nil || entry.Path != "/projects/frontend" {
+		t.Error("FindByNameOrAlias by name: not found")
+	}
+
+	// Find by path
+	entry = r.FindByNameOrAlias("/projects/frontend")
+	if entry == nil || entry.Path != "/projects/frontend" {
+		t.Error("FindByNameOrAlias by path: not found")
+	}
+
+	// Not found
+	entry = r.FindByNameOrAlias("nonexistent")
+	if entry != nil {
+		t.Error("FindByNameOrAlias nonexistent: expected nil")
+	}
+}
+
+// TestRegistrySaveLoad tests persistence (#1218)
+func TestRegistrySaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "workspaces.json")
+
+	// Create and save registry
+	r := &Registry{path: registryPath}
+	_ = r.RegisterWithAlias("/projects/frontend", "frontend", "fe")
+	_ = r.SetActive("fe")
+
+	if err := r.Save(); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Verify file exists
+	if _, err := os.Stat(registryPath); err != nil {
+		t.Fatalf("Registry file not created: %v", err)
+	}
+
+	// Load and verify
+	// Note: LoadRegistry uses GlobalDir(), so we test Save/Load manually
+	r2 := &Registry{path: registryPath}
+	data, err := os.ReadFile(registryPath) //nolint:gosec // test file path
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if err := json.Unmarshal(data, r2); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	if len(r2.Workspaces) != 1 {
+		t.Errorf("Loaded workspaces count = %d, want 1", len(r2.Workspaces))
+	}
+	if r2.Workspaces[0].Alias != "fe" {
+		t.Errorf("Loaded alias = %q, want %q", r2.Workspaces[0].Alias, "fe")
+	}
+	if r2.Active != "fe" {
+		t.Errorf("Loaded active = %q, want %q", r2.Active, "fe")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `bc workspace add <path> [--alias]` command to register workspaces with optional short aliases
- Add `bc workspace remove <alias|path>` command to unregister workspaces
- Add `bc workspace switch <alias|path>` command to set active workspace for cross-workspace operations
- Extend Registry with alias support and active workspace tracking
- Add comprehensive tests for new registry functionality

## Implementation Details
**Registry enhancements:**
- `Alias` field on RegistryEntry for quick workspace access (e.g., "fe" for frontend)
- `Active` field to track currently active workspace
- `FindByAlias`, `FindByNameOrAlias`, `SetAlias` methods
- `GetActive`, `SetActive` methods
- Error types: `AliasConflictError`, `WorkspaceNotFoundError`

**CLI commands:**
```bash
bc workspace add .                        # Add current directory
bc workspace add ~/projects/frontend --alias fe  # Add with alias
bc workspace remove fe                    # Remove by alias
bc workspace switch fe                    # Set active workspace
bc workspace switch --clear               # Clear active
```

## Test plan
- [x] Run `go test ./pkg/workspace/...` - all tests pass
- [x] Run `make lint` - no errors
- [ ] Manual test: `bc workspace add . --alias test`
- [ ] Manual test: `bc workspace list` shows alias
- [ ] Manual test: `bc workspace switch test`
- [ ] Manual test: `bc workspace remove test`

## Next Steps (not in this PR)
- Cross-workspace agent operations (`--workspace` flag)
- Workspace linking for agent sharing
- Multi-workspace TUI view

Partial implementation of #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)