### PR TITLE
feat(ide): Add JetBrains plugin for bc integration (#1233)

### DIFF
--- a/ide/jetbrains/.gitignore
+++ b/ide/jetbrains/.gitignore
@@ -1,0 +1,10 @@
+# Gradle
+.gradle/
+build/
+
+# IDE
+.idea/
+*.iml
+
+# Local
+local.properties

--- a/ide/jetbrains/README.md
+++ b/ide/jetbrains/README.md
@@ -1,0 +1,97 @@
+# bc JetBrains Plugin
+
+JetBrains IDE plugin for bc (AI Agent Orchestration CLI).
+
+## Features
+
+- **Agent Status Panel** - View all agents and their states in real-time
+- **Channel Messages Panel** - Send and receive inter-agent messages
+- **Status Bar Widget** - Quick view of workspace status
+- **bc Commands Menu** - Access all bc commands from Tools menu
+- **Keyboard Shortcuts** - Quick access (Ctrl+Alt+B for status)
+- **Auto-detection** - Plugin activates in bc workspaces
+
+## Requirements
+
+- JetBrains IDE 2023.3+
+- bc CLI installed and in PATH
+- Project must be a bc workspace (contains `.bc` directory)
+
+## Installation
+
+### From JetBrains Marketplace (Recommended)
+
+1. Open IDE Settings → Plugins
+2. Search for "bc"
+3. Click Install
+
+### Manual Installation
+
+1. Build the plugin: `./gradlew buildPlugin`
+2. Open IDE Settings → Plugins → Install Plugin from Disk
+3. Select `build/distributions/bc-jetbrains-*.zip`
+
+## Usage
+
+### Tool Windows
+
+Open tool windows from View → Tool Windows:
+- **bc Agents** - Shows agent status table
+- **bc Channels** - Channel messages with send capability
+
+### Commands
+
+Access from Tools → bc menu:
+- **Show Status** - Display workspace status
+- **List Agents** - Show all agents
+- **Agent Health** - Check agent health
+- **List Channels** - Show available channels
+- **Send to Channel** - Send message to channel
+- **View Logs** - Show recent bc logs
+- **Refresh** - Refresh status
+
+### Keyboard Shortcuts
+
+- `Ctrl+Alt+B` - Quick status popup
+
+### Settings
+
+Configure at Settings → Tools → bc:
+- **bc binary path** - Path to bc binary (default: `bc`)
+
+## Development
+
+### Building
+
+```bash
+./gradlew buildPlugin
+```
+
+Output: `build/distributions/bc-jetbrains-*.zip`
+
+### Testing
+
+```bash
+./gradlew runIde
+```
+
+Opens a sandboxed IDE instance with the plugin installed.
+
+### Publishing
+
+```bash
+export PUBLISH_TOKEN=<your-token>
+./gradlew publishPlugin
+```
+
+## Compatibility
+
+- IntelliJ IDEA Community/Ultimate 2023.3+
+- WebStorm 2023.3+
+- GoLand 2023.3+
+- PyCharm 2023.3+
+- All other JetBrains IDEs 2023.3+
+
+## License
+
+MIT

--- a/ide/jetbrains/build.gradle.kts
+++ b/ide/jetbrains/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    id("java")
+    id("org.jetbrains.kotlin.jvm") version "1.9.21"
+    id("org.jetbrains.intellij") version "1.16.1"
+}
+
+group = "com.bc"
+version = "1.0.0"
+
+repositories {
+    mavenCentral()
+}
+
+intellij {
+    version.set("2023.3")
+    type.set("IC") // IntelliJ IDEA Community Edition
+    plugins.set(listOf("terminal"))
+}
+
+tasks {
+    withType<JavaCompile> {
+        sourceCompatibility = "17"
+        targetCompatibility = "17"
+    }
+
+    withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions.jvmTarget = "17"
+    }
+
+    patchPluginXml {
+        sinceBuild.set("233")
+        untilBuild.set("243.*")
+    }
+
+    signPlugin {
+        certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
+        privateKey.set(System.getenv("PRIVATE_KEY"))
+        password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
+    }
+
+    publishPlugin {
+        token.set(System.getenv("PUBLISH_TOKEN"))
+    }
+}

--- a/ide/jetbrains/gradle.properties
+++ b/ide/jetbrains/gradle.properties
@@ -1,0 +1,8 @@
+# IntelliJ Platform Plugin Configuration
+pluginGroup = com.bc
+pluginName = bc
+pluginVersion = 1.0.0
+
+# Gradle settings
+org.gradle.jvmargs = -Xmx2048m
+kotlin.stdlib.default.dependency = false

--- a/ide/jetbrains/gradlew
+++ b/ide/jetbrains/gradlew
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+#
+# Gradle wrapper script for bc-jetbrains plugin
+#
+
+# Resolve links and find GRADLE_HOME
+PRG="$0"
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
+
+# Use system gradle or download
+if command -v gradle >/dev/null 2>&1; then
+    exec gradle "$@"
+else
+    echo "Gradle not found. Please install Gradle or use the Gradle Wrapper."
+    echo "Download from: https://gradle.org/install/"
+    exit 1
+fi

--- a/ide/jetbrains/settings.gradle.kts
+++ b/ide/jetbrains/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "bc-jetbrains"

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/AgentHealthAction.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/AgentHealthAction.kt
@@ -1,0 +1,27 @@
+package com.bc.plugin.actions
+
+import com.bc.plugin.services.BcService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.ui.Messages
+
+/**
+ * Action to check agent health.
+ */
+class AgentHealthAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val service = BcService.getInstance(project)
+
+        val output = service.executeAndGetOutput("agent", "health")
+        val message = output ?: "Unable to check agent health."
+
+        Messages.showInfoMessage(project, message, "bc Agent Health")
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabledAndVisible = project != null &&
+            BcService.getInstance(project).isWorkspace()
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/AgentListAction.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/AgentListAction.kt
@@ -1,0 +1,33 @@
+package com.bc.plugin.actions
+
+import com.bc.plugin.services.BcService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.ui.Messages
+
+/**
+ * Action to list all agents.
+ */
+class AgentListAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val service = BcService.getInstance(project)
+
+        val agents = service.listAgents()
+        val message = if (agents.isNotEmpty()) {
+            agents.joinToString("\n") { agent ->
+                "${agent.name} (${agent.role}): ${agent.state}"
+            }
+        } else {
+            "No agents found."
+        }
+
+        Messages.showInfoMessage(project, message, "bc Agents")
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabledAndVisible = project != null &&
+            BcService.getInstance(project).isWorkspace()
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/ChannelListAction.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/ChannelListAction.kt
@@ -1,0 +1,31 @@
+package com.bc.plugin.actions
+
+import com.bc.plugin.services.BcService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.ui.Messages
+
+/**
+ * Action to list all channels.
+ */
+class ChannelListAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val service = BcService.getInstance(project)
+
+        val channels = service.listChannels()
+        val message = if (channels.isNotEmpty()) {
+            channels.joinToString("\n") { "# $it" }
+        } else {
+            "No channels found."
+        }
+
+        Messages.showInfoMessage(project, message, "bc Channels")
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabledAndVisible = project != null &&
+            BcService.getInstance(project).isWorkspace()
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/ChannelSendAction.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/ChannelSendAction.kt
@@ -1,0 +1,53 @@
+package com.bc.plugin.actions
+
+import com.bc.plugin.services.BcService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.ui.Messages
+
+/**
+ * Action to send a message to a channel.
+ */
+class ChannelSendAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val service = BcService.getInstance(project)
+
+        val channels = service.listChannels()
+        if (channels.isEmpty()) {
+            Messages.showWarningDialog(project, "No channels available.", "bc")
+            return
+        }
+
+        val channel = Messages.showEditableChooseDialog(
+            "Select channel:",
+            "Send to Channel",
+            Messages.getQuestionIcon(),
+            channels.toTypedArray(),
+            channels.first(),
+            null
+        ) ?: return
+
+        val message = Messages.showInputDialog(
+            project,
+            "Message:",
+            "Send to #$channel",
+            null
+        ) ?: return
+
+        if (message.isBlank()) return
+
+        val success = service.sendToChannel(channel, message)
+        if (success) {
+            Messages.showInfoMessage(project, "Message sent to #$channel", "bc")
+        } else {
+            Messages.showErrorDialog(project, "Failed to send message.", "bc")
+        }
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabledAndVisible = project != null &&
+            BcService.getInstance(project).isWorkspace()
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/LogsAction.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/LogsAction.kt
@@ -1,0 +1,49 @@
+package com.bc.plugin.actions
+
+import com.bc.plugin.services.BcService
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import java.awt.Dimension
+import javax.swing.JComponent
+
+/**
+ * Action to view bc logs.
+ */
+class LogsAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val service = BcService.getInstance(project)
+
+        val logs = service.getLogs(100)
+
+        LogsDialog(logs).show()
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabledAndVisible = project != null &&
+            BcService.getInstance(project).isWorkspace()
+    }
+}
+
+class LogsDialog(private val logs: String) : DialogWrapper(true) {
+    init {
+        title = "bc Logs"
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val textArea = JBTextArea(logs).apply {
+            isEditable = false
+            lineWrap = true
+            wrapStyleWord = true
+        }
+
+        return JBScrollPane(textArea).apply {
+            preferredSize = Dimension(800, 500)
+        }
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/RefreshAction.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/RefreshAction.kt
@@ -1,0 +1,36 @@
+package com.bc.plugin.actions
+
+import com.bc.plugin.services.BcService
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+/**
+ * Action to refresh bc status.
+ */
+class RefreshAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val service = BcService.getInstance(project)
+
+        service.detectWorkspace()
+        val status = service.getStatus()
+
+        val message = if (status != null) {
+            "Refreshed: ${status.workingCount}/${status.agentCount} agents working"
+        } else {
+            "bc status refreshed"
+        }
+
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("bc.Notifications")
+            .createNotification(message, NotificationType.INFORMATION)
+            .notify(project)
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabledAndVisible = project != null
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/StatusAction.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/actions/StatusAction.kt
@@ -1,0 +1,40 @@
+package com.bc.plugin.actions
+
+import com.bc.plugin.services.BcService
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+
+/**
+ * Action to show bc workspace status.
+ */
+class StatusAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val service = BcService.getInstance(project)
+
+        val status = service.getStatus()
+        val message = if (status != null) {
+            """
+            Workspace: ${status.workspace}
+            Agents: ${status.agentCount}
+            Active: ${status.activeCount}
+            Working: ${status.workingCount}
+            """.trimIndent()
+        } else {
+            "Unable to get bc status. Make sure bc is installed and this is a bc workspace."
+        }
+
+        NotificationGroupManager.getInstance()
+            .getNotificationGroup("bc.Notifications")
+            .createNotification("bc Status", message, NotificationType.INFORMATION)
+            .notify(project)
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        e.presentation.isEnabledAndVisible = project != null &&
+            BcService.getInstance(project).isWorkspace()
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/services/BcService.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/services/BcService.kt
@@ -1,0 +1,195 @@
+package com.bc.plugin.services
+
+import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.OSProcessHandler
+import com.intellij.execution.process.ProcessOutput
+import com.intellij.execution.util.ExecUtil
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import java.io.File
+
+/**
+ * Service for interacting with the bc CLI.
+ */
+@Service(Service.Level.PROJECT)
+class BcService(private val project: Project) {
+    private val logger = Logger.getInstance(BcService::class.java)
+
+    private var bcPath: String = "bc"
+    private var isWorkspace: Boolean = false
+
+    init {
+        detectWorkspace()
+    }
+
+    /**
+     * Check if the project is a bc workspace (has .bc directory)
+     */
+    fun detectWorkspace(): Boolean {
+        val basePath = project.basePath ?: return false
+        val bcDir = File(basePath, ".bc")
+        isWorkspace = bcDir.exists() && bcDir.isDirectory
+        return isWorkspace
+    }
+
+    fun isWorkspace(): Boolean = isWorkspace
+
+    /**
+     * Execute a bc command and return the output
+     */
+    fun execute(vararg args: String): ProcessOutput? {
+        if (!isWorkspace) return null
+
+        return try {
+            val commandLine = GeneralCommandLine(bcPath)
+                .withParameters(*args)
+                .withWorkDirectory(project.basePath)
+                .withEnvironment("NO_COLOR", "1")
+
+            ExecUtil.execAndGetOutput(commandLine, 30000)
+        } catch (e: Exception) {
+            logger.warn("Failed to execute bc command: ${args.joinToString(" ")}", e)
+            null
+        }
+    }
+
+    /**
+     * Execute bc command and return stdout
+     */
+    fun executeAndGetOutput(vararg args: String): String? {
+        val output = execute(*args) ?: return null
+        return if (output.exitCode == 0) output.stdout else null
+    }
+
+    /**
+     * Get workspace status
+     */
+    fun getStatus(): BcStatus? {
+        val output = executeAndGetOutput("status", "--json") ?: return null
+        return parseStatus(output)
+    }
+
+    /**
+     * List all agents
+     */
+    fun listAgents(): List<Agent> {
+        val output = executeAndGetOutput("agent", "list", "--json") ?: return emptyList()
+        return parseAgents(output)
+    }
+
+    /**
+     * List all channels
+     */
+    fun listChannels(): List<String> {
+        val output = executeAndGetOutput("channel", "list") ?: return emptyList()
+        return output.lines()
+            .filter { it.isNotBlank() }
+            .map { it.trim() }
+    }
+
+    /**
+     * Get channel history
+     */
+    fun getChannelHistory(channel: String, limit: Int = 20): List<ChannelMessage> {
+        val output = executeAndGetOutput("channel", "history", channel, "--limit", limit.toString())
+            ?: return emptyList()
+        return parseChannelHistory(output)
+    }
+
+    /**
+     * Send message to channel
+     */
+    fun sendToChannel(channel: String, message: String): Boolean {
+        val output = execute("channel", "send", channel, message)
+        return output?.exitCode == 0
+    }
+
+    /**
+     * Get recent logs
+     */
+    fun getLogs(limit: Int = 50): String {
+        return executeAndGetOutput("logs", "--tail", limit.toString()) ?: ""
+    }
+
+    fun setBcPath(path: String) {
+        bcPath = path
+    }
+
+    fun getBcPath(): String = bcPath
+
+    // Data classes
+    data class BcStatus(
+        val workspace: String,
+        val agentCount: Int,
+        val activeCount: Int,
+        val workingCount: Int
+    )
+
+    data class Agent(
+        val name: String,
+        val role: String,
+        val state: String,
+        val uptime: String,
+        val task: String
+    )
+
+    data class ChannelMessage(
+        val timestamp: String,
+        val sender: String,
+        val message: String
+    )
+
+    // Parsers
+    private fun parseStatus(json: String): BcStatus? {
+        // Simple parsing - in production would use kotlinx.serialization
+        return try {
+            val workspace = Regex(""""workspace":\s*"([^"]+)"""").find(json)?.groupValues?.get(1) ?: "unknown"
+            val agentCount = Regex(""""agent_count":\s*(\d+)""").find(json)?.groupValues?.get(1)?.toInt() ?: 0
+            val activeCount = Regex(""""active_count":\s*(\d+)""").find(json)?.groupValues?.get(1)?.toInt() ?: 0
+            val workingCount = Regex(""""working_count":\s*(\d+)""").find(json)?.groupValues?.get(1)?.toInt() ?: 0
+            BcStatus(workspace, agentCount, activeCount, workingCount)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun parseAgents(json: String): List<Agent> {
+        // Simple line-based parsing for table output
+        return json.lines()
+            .filter { it.contains("engineer") || it.contains("manager") || it.contains("root") }
+            .mapNotNull { line ->
+                val parts = line.split(Regex("\\s{2,}")).map { it.trim() }
+                if (parts.size >= 4) {
+                    Agent(
+                        name = parts[0],
+                        role = parts[1],
+                        state = parts[2],
+                        uptime = parts.getOrElse(3) { "-" },
+                        task = parts.getOrElse(4) { "" }
+                    )
+                } else null
+            }
+    }
+
+    private fun parseChannelHistory(output: String): List<ChannelMessage> {
+        return output.lines()
+            .filter { it.contains("[") && it.contains("]") }
+            .mapNotNull { line ->
+                val match = Regex("""\[(\d+)\]\s*\[([^\]]+)\]\s*([^:]+):\s*(.*)""").find(line)
+                if (match != null) {
+                    ChannelMessage(
+                        timestamp = match.groupValues[2],
+                        sender = match.groupValues[3].trim(),
+                        message = match.groupValues[4].trim()
+                    )
+                } else null
+            }
+    }
+
+    companion object {
+        fun getInstance(project: Project): BcService {
+            return project.getService(BcService::class.java)
+        }
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/services/BcStartupActivity.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/services/BcStartupActivity.kt
@@ -1,0 +1,20 @@
+package com.bc.plugin.services
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+/**
+ * Startup activity to detect bc workspace and initialize plugin.
+ */
+class BcStartupActivity : ProjectActivity {
+    private val logger = Logger.getInstance(BcStartupActivity::class.java)
+
+    override suspend fun execute(project: Project) {
+        val service = BcService.getInstance(project)
+
+        if (service.detectWorkspace()) {
+            logger.info("bc workspace detected in project: ${project.name}")
+        }
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/services/BcStatusWidgetFactory.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/services/BcStatusWidgetFactory.kt
@@ -1,0 +1,83 @@
+package com.bc.plugin.services
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+import com.intellij.util.Consumer
+import java.awt.event.MouseEvent
+import javax.swing.Timer
+
+/**
+ * Status bar widget factory showing bc workspace status.
+ */
+class BcStatusWidgetFactory : StatusBarWidgetFactory {
+    override fun getId(): String = "BcStatusWidget"
+
+    override fun getDisplayName(): String = "bc Status"
+
+    override fun isAvailable(project: Project): Boolean {
+        return BcService.getInstance(project).isWorkspace()
+    }
+
+    override fun createWidget(project: Project): StatusBarWidget {
+        return BcStatusWidget(project)
+    }
+
+    override fun disposeWidget(widget: StatusBarWidget) {
+        Disposer.dispose(widget)
+    }
+
+    override fun canBeEnabledOn(statusBar: StatusBar): Boolean = true
+}
+
+class BcStatusWidget(private val project: Project) : StatusBarWidget, StatusBarWidget.TextPresentation {
+    private var statusBar: StatusBar? = null
+    private var statusText = "bc: ..."
+    private val refreshTimer: Timer
+
+    init {
+        refreshTimer = Timer(5000) { updateStatus() }
+        refreshTimer.isRepeats = true
+        refreshTimer.start()
+        updateStatus()
+    }
+
+    override fun ID(): String = "BcStatusWidget"
+
+    override fun getPresentation(): StatusBarWidget.WidgetPresentation = this
+
+    override fun install(statusBar: StatusBar) {
+        this.statusBar = statusBar
+    }
+
+    override fun dispose() {
+        refreshTimer.stop()
+    }
+
+    override fun getText(): String = statusText
+
+    override fun getAlignment(): Float = 0f
+
+    override fun getTooltipText(): String = "bc AI Agent Orchestration - Click to refresh"
+
+    override fun getClickConsumer(): Consumer<MouseEvent>? {
+        return Consumer { updateStatus() }
+    }
+
+    private fun updateStatus() {
+        val service = BcService.getInstance(project)
+        val status = service.getStatus()
+
+        statusText = if (status != null) {
+            "bc: ${status.workingCount}/${status.agentCount} working"
+        } else if (service.isWorkspace()) {
+            "bc: offline"
+        } else {
+            "bc: not a workspace"
+        }
+
+        statusBar?.updateWidget(ID())
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/settings/BcSettingsConfigurable.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/settings/BcSettingsConfigurable.kt
@@ -1,0 +1,78 @@
+package com.bc.plugin.settings
+
+import com.bc.plugin.services.BcService
+import com.intellij.openapi.options.Configurable
+import com.intellij.openapi.project.Project
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBTextField
+import com.intellij.util.ui.FormBuilder
+import java.awt.BorderLayout
+import javax.swing.JButton
+import javax.swing.JComponent
+import javax.swing.JPanel
+
+/**
+ * Settings panel for bc plugin configuration.
+ */
+class BcSettingsConfigurable(private val project: Project) : Configurable {
+    private var bcPathField: JBTextField? = null
+    private var panel: JPanel? = null
+
+    override fun getDisplayName(): String = "bc"
+
+    override fun createComponent(): JComponent {
+        bcPathField = JBTextField()
+
+        val testButton = JButton("Test Connection").apply {
+            addActionListener { testConnection() }
+        }
+
+        val pathPanel = JPanel(BorderLayout()).apply {
+            add(bcPathField!!, BorderLayout.CENTER)
+            add(testButton, BorderLayout.EAST)
+        }
+
+        panel = FormBuilder.createFormBuilder()
+            .addLabeledComponent(JBLabel("bc binary path:"), pathPanel)
+            .addComponentFillVertically(JPanel(), 0)
+            .panel
+
+        return panel!!
+    }
+
+    override fun isModified(): Boolean {
+        val service = BcService.getInstance(project)
+        return bcPathField?.text != service.getBcPath()
+    }
+
+    override fun apply() {
+        val service = BcService.getInstance(project)
+        bcPathField?.text?.let { service.setBcPath(it) }
+    }
+
+    override fun reset() {
+        val service = BcService.getInstance(project)
+        bcPathField?.text = service.getBcPath()
+    }
+
+    private fun testConnection() {
+        val service = BcService.getInstance(project)
+        val path = bcPathField?.text ?: "bc"
+        service.setBcPath(path)
+
+        val status = service.getStatus()
+        val message = if (status != null) {
+            "Connection successful!\nWorkspace: ${status.workspace}\nAgents: ${status.agentCount}"
+        } else {
+            "Connection failed. Check bc path and ensure this is a bc workspace."
+        }
+
+        javax.swing.JOptionPane.showMessageDialog(
+            panel,
+            message,
+            "bc Connection Test",
+            if (status != null) javax.swing.JOptionPane.INFORMATION_MESSAGE
+            else javax.swing.JOptionPane.ERROR_MESSAGE
+        )
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/toolwindow/AgentsToolWindowFactory.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/toolwindow/AgentsToolWindowFactory.kt
@@ -1,0 +1,89 @@
+package com.bc.plugin.toolwindow
+
+import com.bc.plugin.services.BcService
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.content.ContentFactory
+import com.intellij.ui.table.JBTable
+import java.awt.BorderLayout
+import javax.swing.*
+import javax.swing.table.DefaultTableModel
+
+/**
+ * Tool window showing bc agents status.
+ */
+class AgentsToolWindowFactory : ToolWindowFactory, DumbAware {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = AgentsPanel(project)
+        val content = ContentFactory.getInstance().createContent(panel, "Agents", false)
+        toolWindow.contentManager.addContent(content)
+    }
+
+    override fun shouldBeAvailable(project: Project): Boolean {
+        return BcService.getInstance(project).isWorkspace()
+    }
+}
+
+class AgentsPanel(private val project: Project) : JPanel(BorderLayout()) {
+    private val tableModel = DefaultTableModel(
+        arrayOf("Agent", "Role", "State", "Uptime", "Task"),
+        0
+    )
+    private val table = JBTable(tableModel)
+    private val refreshTimer: Timer
+
+    init {
+        // Header with refresh button
+        val toolbar = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.X_AXIS)
+            add(JLabel("bc Agents"))
+            add(Box.createHorizontalGlue())
+            add(JButton("Refresh").apply {
+                addActionListener { refreshAgents() }
+            })
+        }
+
+        // Configure table
+        table.apply {
+            setShowGrid(true)
+            autoResizeMode = JTable.AUTO_RESIZE_LAST_COLUMN
+            columnModel.getColumn(0).preferredWidth = 100
+            columnModel.getColumn(1).preferredWidth = 80
+            columnModel.getColumn(2).preferredWidth = 60
+            columnModel.getColumn(3).preferredWidth = 80
+            columnModel.getColumn(4).preferredWidth = 200
+        }
+
+        add(toolbar, BorderLayout.NORTH)
+        add(JBScrollPane(table), BorderLayout.CENTER)
+
+        // Auto-refresh every 10 seconds
+        refreshTimer = Timer(10000) { refreshAgents() }
+        refreshTimer.isRepeats = true
+        refreshTimer.start()
+
+        // Initial load
+        refreshAgents()
+    }
+
+    private fun refreshAgents() {
+        SwingUtilities.invokeLater {
+            val service = BcService.getInstance(project)
+            val agents = service.listAgents()
+
+            tableModel.rowCount = 0
+            agents.forEach { agent ->
+                tableModel.addRow(arrayOf(
+                    agent.name,
+                    agent.role,
+                    agent.state,
+                    agent.uptime,
+                    agent.task
+                ))
+            }
+        }
+    }
+}

--- a/ide/jetbrains/src/main/kotlin/com/bc/plugin/toolwindow/ChannelsToolWindowFactory.kt
+++ b/ide/jetbrains/src/main/kotlin/com/bc/plugin/toolwindow/ChannelsToolWindowFactory.kt
@@ -1,0 +1,126 @@
+package com.bc.plugin.toolwindow
+
+import com.bc.plugin.services.BcService
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBList
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import com.intellij.ui.content.ContentFactory
+import java.awt.BorderLayout
+import java.awt.Dimension
+import javax.swing.*
+
+/**
+ * Tool window for bc channel communication.
+ */
+class ChannelsToolWindowFactory : ToolWindowFactory, DumbAware {
+    override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
+        val panel = ChannelsPanel(project)
+        val content = ContentFactory.getInstance().createContent(panel, "Channels", false)
+        toolWindow.contentManager.addContent(content)
+    }
+
+    override fun shouldBeAvailable(project: Project): Boolean {
+        return BcService.getInstance(project).isWorkspace()
+    }
+}
+
+class ChannelsPanel(private val project: Project) : JPanel(BorderLayout()) {
+    private val channelList = JBList<String>()
+    private val messagesArea = JBTextArea()
+    private val messageInput = JTextField()
+    private var selectedChannel: String? = null
+    private val refreshTimer: Timer
+
+    init {
+        // Left panel - channel list
+        val channelPanel = JPanel(BorderLayout()).apply {
+            preferredSize = Dimension(150, 0)
+            add(JLabel("Channels"), BorderLayout.NORTH)
+            add(JBScrollPane(channelList), BorderLayout.CENTER)
+        }
+
+        channelList.addListSelectionListener {
+            if (!it.valueIsAdjusting) {
+                selectedChannel = channelList.selectedValue
+                refreshMessages()
+            }
+        }
+
+        // Right panel - messages
+        messagesArea.apply {
+            isEditable = false
+            lineWrap = true
+            wrapStyleWord = true
+        }
+
+        val inputPanel = JPanel(BorderLayout()).apply {
+            add(messageInput, BorderLayout.CENTER)
+            add(JButton("Send").apply {
+                addActionListener { sendMessage() }
+            }, BorderLayout.EAST)
+        }
+
+        messageInput.addActionListener { sendMessage() }
+
+        val messagePanel = JPanel(BorderLayout()).apply {
+            add(JBScrollPane(messagesArea), BorderLayout.CENTER)
+            add(inputPanel, BorderLayout.SOUTH)
+        }
+
+        // Split pane
+        val splitPane = JSplitPane(JSplitPane.HORIZONTAL_SPLIT, channelPanel, messagePanel).apply {
+            dividerLocation = 150
+        }
+
+        add(splitPane, BorderLayout.CENTER)
+
+        // Auto-refresh
+        refreshTimer = Timer(5000) { refreshMessages() }
+        refreshTimer.isRepeats = true
+        refreshTimer.start()
+
+        // Initial load
+        refreshChannels()
+    }
+
+    private fun refreshChannels() {
+        SwingUtilities.invokeLater {
+            val service = BcService.getInstance(project)
+            val channels = service.listChannels()
+            channelList.setListData(channels.toTypedArray())
+        }
+    }
+
+    private fun refreshMessages() {
+        val channel = selectedChannel ?: return
+        SwingUtilities.invokeLater {
+            val service = BcService.getInstance(project)
+            val messages = service.getChannelHistory(channel)
+
+            messagesArea.text = messages.joinToString("\n") { msg ->
+                "[${msg.timestamp}] ${msg.sender}: ${msg.message}"
+            }
+
+            // Scroll to bottom
+            messagesArea.caretPosition = messagesArea.document.length
+        }
+    }
+
+    private fun sendMessage() {
+        val channel = selectedChannel ?: return
+        val message = messageInput.text.trim()
+        if (message.isEmpty()) return
+
+        SwingUtilities.invokeLater {
+            val service = BcService.getInstance(project)
+            if (service.sendToChannel(channel, message)) {
+                messageInput.text = ""
+                refreshMessages()
+            }
+        }
+    }
+}

--- a/ide/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/ide/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -1,0 +1,118 @@
+<idea-plugin>
+    <id>com.bc.plugin</id>
+    <name>bc - AI Agent Orchestration</name>
+    <vendor email="support@bc.dev" url="https://github.com/rpuneet/bc">bc</vendor>
+
+    <description><![CDATA[
+    Integrates bc (AI Agent Orchestration CLI) into JetBrains IDEs.
+
+    <b>Features:</b>
+    <ul>
+        <li>Agent status panel showing all agents and their states</li>
+        <li>Channel messages panel for inter-agent communication</li>
+        <li>Quick actions for common bc commands</li>
+        <li>Status bar widget showing workspace status</li>
+        <li>Auto-detection of .bc workspaces</li>
+    </ul>
+
+    <b>Requirements:</b>
+    <ul>
+        <li>bc CLI installed and in PATH</li>
+        <li>Project must be a bc workspace (contains .bc directory)</li>
+    </ul>
+    ]]></description>
+
+    <depends>com.intellij.modules.platform</depends>
+    <depends>org.jetbrains.plugins.terminal</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <!-- Notification Group -->
+        <notificationGroup id="bc.Notifications"
+                           displayType="BALLOON"
+                           isLogByDefault="true"/>
+        <!-- Tool Windows -->
+        <toolWindow id="bc Agents"
+                    secondary="true"
+                    icon="AllIcons.Nodes.Plugin"
+                    anchor="right"
+                    factoryClass="com.bc.plugin.toolwindow.AgentsToolWindowFactory"/>
+
+        <toolWindow id="bc Channels"
+                    secondary="true"
+                    icon="AllIcons.Nodes.Plugin"
+                    anchor="right"
+                    factoryClass="com.bc.plugin.toolwindow.ChannelsToolWindowFactory"/>
+
+        <!-- Services -->
+        <projectService serviceImplementation="com.bc.plugin.services.BcService"/>
+
+        <!-- Settings -->
+        <projectConfigurable
+                parentId="tools"
+                instance="com.bc.plugin.settings.BcSettingsConfigurable"
+                id="com.bc.plugin.settings"
+                displayName="bc"/>
+
+        <!-- Status Bar Widget -->
+        <statusBarWidgetFactory
+                id="BcStatusWidget"
+                implementation="com.bc.plugin.services.BcStatusWidgetFactory"/>
+
+        <!-- Startup Activity -->
+        <postStartupActivity implementation="com.bc.plugin.services.BcStartupActivity"/>
+    </extensions>
+
+    <actions>
+        <group id="bc.MainMenu" text="bc" popup="true">
+            <add-to-group group-id="ToolsMenu" anchor="last"/>
+
+            <action id="bc.Status"
+                    class="com.bc.plugin.actions.StatusAction"
+                    text="Show Status"
+                    description="Show bc workspace status"
+                    icon="AllIcons.General.Information"/>
+
+            <action id="bc.AgentList"
+                    class="com.bc.plugin.actions.AgentListAction"
+                    text="List Agents"
+                    description="List all agents in workspace"/>
+
+            <action id="bc.AgentHealth"
+                    class="com.bc.plugin.actions.AgentHealthAction"
+                    text="Agent Health"
+                    description="Check agent health status"/>
+
+            <separator/>
+
+            <action id="bc.ChannelList"
+                    class="com.bc.plugin.actions.ChannelListAction"
+                    text="List Channels"
+                    description="List all channels"/>
+
+            <action id="bc.ChannelSend"
+                    class="com.bc.plugin.actions.ChannelSendAction"
+                    text="Send to Channel..."
+                    description="Send message to a channel"/>
+
+            <separator/>
+
+            <action id="bc.Logs"
+                    class="com.bc.plugin.actions.LogsAction"
+                    text="View Logs"
+                    description="View recent bc logs"/>
+
+            <action id="bc.RefreshStatus"
+                    class="com.bc.plugin.actions.RefreshAction"
+                    text="Refresh"
+                    description="Refresh bc status"
+                    icon="AllIcons.Actions.Refresh"/>
+        </group>
+
+        <!-- Keyboard shortcuts -->
+        <action id="bc.QuickStatus"
+                class="com.bc.plugin.actions.StatusAction"
+                text="bc Quick Status">
+            <keyboard-shortcut keymap="$default" first-keystroke="ctrl alt B"/>
+        </action>
+    </actions>
+</idea-plugin>


### PR DESCRIPTION
## Summary
- Add JetBrains IDE plugin (IntelliJ, WebStorm, GoLand, PyCharm 2023.3+)
- Tool windows: Agents status table, Channels messages panel
- Status bar widget showing workspace status
- bc commands menu in Tools with keyboard shortcuts
- Settings panel for bc binary path configuration
- Auto-detection of bc workspaces (.bc directory)

## Files Added
- `ide/jetbrains/` - Complete Kotlin plugin structure
- 20 files, +1168 lines

## Test plan
- [ ] Build plugin with `./gradlew buildPlugin`
- [ ] Test in sandboxed IDE with `./gradlew runIde`
- [ ] Verify tool windows appear in bc workspaces
- [ ] Verify status bar widget updates
- [ ] Test bc commands from Tools menu

Fixes #1233

🤖 Generated with [Claude Code](https://claude.com/claude-code)