### PR TITLE
P0 Fix: Plugin path creating nested .bc/.bc/plugins directory

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -42,7 +42,8 @@ const (
 const DefaultRegistry = "https://plugins.bc.dev"
 
 // DefaultDirectory is the default plugin installation directory
-const DefaultDirectory = ".bc/plugins"
+// Note: This is relative to the state directory (.bc/), not workspace root
+const DefaultDirectory = "plugins"
 
 // Manifest describes a plugin's metadata and capabilities
 type Manifest struct {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -8,11 +8,13 @@ import (
 )
 
 func TestNewManager(t *testing.T) {
-	mgr := NewManager("/tmp/test-workspace")
+	// NewManager is called with the state directory (.bc), not workspace root
+	mgr := NewManager("/tmp/test-workspace/.bc")
 	if mgr == nil {
 		t.Fatal("NewManager returned nil")
 	}
 
+	// Should create plugins dir inside state dir
 	expectedDir := "/tmp/test-workspace/.bc/plugins"
 	if mgr.pluginsDir != expectedDir {
 		t.Errorf("pluginsDir = %q, want %q", mgr.pluginsDir, expectedDir)
@@ -28,7 +30,7 @@ func TestNewManager(t *testing.T) {
 }
 
 func TestManagerList(t *testing.T) {
-	mgr := NewManager("/tmp/test-workspace")
+	mgr := NewManager("/tmp/test-workspace/.bc")
 
 	// Empty list initially
 	plugins := mgr.List()
@@ -38,7 +40,7 @@ func TestManagerList(t *testing.T) {
 }
 
 func TestManagerGet(t *testing.T) {
-	mgr := NewManager("/tmp/test-workspace")
+	mgr := NewManager("/tmp/test-workspace/.bc")
 
 	// Plugin not found
 	_, ok := mgr.Get("nonexistent")
@@ -284,7 +286,7 @@ entrypoint = "main.go"
 }
 
 func TestManagerEnabled(t *testing.T) {
-	mgr := NewManager("/tmp/test-workspace")
+	mgr := NewManager("/tmp/test-workspace/.bc")
 
 	// Empty list initially
 	enabled := mgr.Enabled("")
@@ -329,7 +331,7 @@ func TestDefaultConstants(t *testing.T) {
 	if DefaultRegistry != "https://plugins.bc.dev" {
 		t.Errorf("DefaultRegistry = %q, want %q", DefaultRegistry, "https://plugins.bc.dev")
 	}
-	if DefaultDirectory != ".bc/plugins" {
-		t.Errorf("DefaultDirectory = %q, want %q", DefaultDirectory, ".bc/plugins")
+	if DefaultDirectory != "plugins" {
+		t.Errorf("DefaultDirectory = %q, want %q", DefaultDirectory, "plugins")
 	}
 }


### PR DESCRIPTION
## Summary
- **P0 CRITICAL FIX** - Blocks all bc commands from worktrees
- Fix `DefaultDirectory` in plugin.go from `.bc/plugins` to `plugins`
- Since `NewManager` is called with `StateDir()` (which is `.bc/`), the path was doubling up

## Root Cause
```go
// Before: Creates .bc/.bc/plugins
const DefaultDirectory = ".bc/plugins"

// After: Creates .bc/plugins  
const DefaultDirectory = "plugins"
```

## Changes
- `pkg/plugin/plugin.go`: Changed DefaultDirectory constant
- `pkg/plugin/plugin_test.go`: Updated tests to match correct usage

## Test plan
- [x] Plugin tests pass (`go test ./pkg/plugin/...`)
- [x] Lint passes (0 issues)
- [ ] Verify bc commands work from worktrees after merge
- [ ] Manual: `bc plugin list` creates correct directory

Fixes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)