### PR TITLE
fix(plugin): Fix nested .bc/.bc/plugins path bug (#1239)

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -42,7 +42,8 @@ const (
 const DefaultRegistry = "https://plugins.bc.dev"
 
 // DefaultDirectory is the default plugin installation directory
-const DefaultDirectory = ".bc/plugins"
+// Note: This is relative to the workspace state directory (.bc/)
+const DefaultDirectory = "plugins"
 
 // Manifest describes a plugin's metadata and capabilities
 type Manifest struct {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -13,7 +13,8 @@ func TestNewManager(t *testing.T) {
 		t.Fatal("NewManager returned nil")
 	}
 
-	expectedDir := "/tmp/test-workspace/.bc/plugins"
+	// NewManager joins workspaceDir (state dir, typically .bc/) with DefaultDirectory (plugins)
+	expectedDir := "/tmp/test-workspace/plugins"
 	if mgr.pluginsDir != expectedDir {
 		t.Errorf("pluginsDir = %q, want %q", mgr.pluginsDir, expectedDir)
 	}
@@ -329,7 +330,8 @@ func TestDefaultConstants(t *testing.T) {
 	if DefaultRegistry != "https://plugins.bc.dev" {
 		t.Errorf("DefaultRegistry = %q, want %q", DefaultRegistry, "https://plugins.bc.dev")
 	}
-	if DefaultDirectory != ".bc/plugins" {
-		t.Errorf("DefaultDirectory = %q, want %q", DefaultDirectory, ".bc/plugins")
+	// DefaultDirectory is relative to workspace state dir (.bc/), not workspace root
+	if DefaultDirectory != "plugins" {
+		t.Errorf("DefaultDirectory = %q, want %q", DefaultDirectory, "plugins")
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes P0 #1239: Plugin system creating nested `.bc/.bc/plugins` directory
- Root cause: `DefaultDirectory` was `.bc/plugins` but `NewManager()` already receives `.bc/` as input
- Fix: Change `DefaultDirectory` from `.bc/plugins` to `plugins`

## Root Cause Analysis

```go
// Before (bug):
const DefaultDirectory = ".bc/plugins"
mgr := plugin.NewManager(ws.StateDir())  // StateDir() = .bc/
// Result: .bc/ + .bc/plugins = .bc/.bc/plugins (WRONG)

// After (fix):
const DefaultDirectory = "plugins"
// Result: .bc/ + plugins = .bc/plugins (CORRECT)
```

This nested directory broke workspace detection for agents running from worktrees, as `Find()` would detect `.bc/.bc/` as a workspace root.

## Test plan

- [x] `go test ./pkg/plugin/...` - all 14 tests pass
- [x] `go build ./...` - builds successfully
- [x] Pre-commit hooks pass (go vet, golangci-lint)
- [x] Verified fix prevents `.bc/.bc/plugins` creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)