### PR TITLE
fix(plugin): Use workspace root for plugin directory path (#1239)

### DIFF
--- a/internal/cmd/plugin.go
+++ b/internal/cmd/plugin.go
@@ -149,7 +149,7 @@ func getPluginManager() (*plugin.Manager, error) {
 		return nil, errNotInWorkspace(err)
 	}
 
-	mgr := plugin.NewManager(ws.StateDir())
+	mgr := plugin.NewManager(ws.RootDir)
 	if err := mgr.Load(context.Background()); err != nil {
 		return nil, fmt.Errorf("failed to load plugins: %w", err)
 	}


### PR DESCRIPTION
## P0 Critical Fix

**Bug:** `bc plugin` commands created nested `.bc/.bc/plugins` directory, which caused `workspace.Find()` to detect the wrong directory as a workspace, breaking ALL bc commands from agent worktrees.

**Root Cause:**
```go
// internal/cmd/plugin.go:152
mgr := plugin.NewManager(ws.StateDir())  // StateDir() = ".bc"

// pkg/plugin/plugin.go:45,108
const DefaultDirectory = ".bc/plugins"
pluginsDir = filepath.Join(workspaceDir, DefaultDirectory)
// Result: filepath.Join(".bc", ".bc/plugins") = ".bc/.bc/plugins" (WRONG!)
```

**Fix:** Pass `ws.RootDir` instead of `ws.StateDir()`:
```go
mgr := plugin.NewManager(ws.RootDir)
// Result: filepath.Join("/path/to/workspace", ".bc/plugins") = "/path/to/workspace/.bc/plugins" (CORRECT!)
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/plugin/...` passes (12 tests)
- [x] Pre-commit hooks pass (build, vet, lint)
- [ ] Manual test: `bc plugin list` from worktree

Fixes #1239

🤖 Generated with [Claude Code](https://claude.com/claude-code)