### PR TITLE
test(workspace): Improve coverage from 69.7% to 81.0% (#1236)

### DIFF
--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/BurntSushi/toml"
@@ -1373,5 +1374,62 @@ func TestUserDefaultsPath(t *testing.T) {
 	// Should contain .bcrc
 	if path != "" && !filepath.IsAbs(path) {
 		t.Error("expected absolute path or empty string")
+	}
+}
+
+func TestValidateNickname(t *testing.T) {
+	tests := []struct { //nolint:govet // test struct alignment not critical
+		name     string
+		nickname string
+		wantErr  error
+	}{
+		{"valid nickname", "@user123", nil},
+		{"valid with underscore", "@test_user", nil},
+		{"valid uppercase", "@TestUser", nil},
+		{"missing prefix", "user123", ErrNicknameMissingPrefix},
+		{"empty after @", "@", ErrNicknameInvalidChars},
+		{"too long", "@" + strings.Repeat("a", NicknameMaxLength), ErrNicknameTooLong},
+		{"invalid chars with dash", "@user-name", ErrNicknameInvalidChars},
+		{"invalid chars with dot", "@user.name", ErrNicknameInvalidChars},
+		{"invalid chars with space", "@user name", ErrNicknameInvalidChars},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateNickname(tt.nickname)
+			if err != tt.wantErr {
+				t.Errorf("ValidateNickname(%q) = %v, want %v", tt.nickname, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNormalizeNickname(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"empty returns default", "", DefaultNickname, false},
+		{"whitespace only returns default", "   ", DefaultNickname, false},
+		{"valid with prefix", "@alice", "@alice", false},
+		{"adds prefix", "bob", "@bob", false},
+		{"trims whitespace", "  @charlie  ", "@charlie", false},
+		{"invalid chars returns error", "@bad-name", "", true},
+		{"too long returns error", strings.Repeat("a", NicknameMaxLength+1), "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeNickname(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NormalizeNickname(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("NormalizeNickname(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/workspace/discover_test.go
+++ b/pkg/workspace/discover_test.go
@@ -299,3 +299,106 @@ func TestDiscoverMaxDepthRespected(t *testing.T) {
 		}
 	}
 }
+
+func TestDiscoverV1Workspace(t *testing.T) {
+	tmpDir := t.TempDir()
+	wsDir := filepath.Join(tmpDir, "v1-workspace")
+	bcDir := filepath.Join(wsDir, ".bc")
+
+	if err := os.MkdirAll(bcDir, 0750); err != nil {
+		t.Fatalf("failed to create workspace dir: %v", err)
+	}
+
+	// Create config.json (v1)
+	configPath := filepath.Join(bcDir, "config.json")
+	configContent := `{"version": 1, "name": "v1-workspace"}`
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	opts := DiscoverOptions{
+		IncludeCached: false,
+		ScanHome:      false,
+		MaxDepth:      2,
+		ScanPaths:     []string{tmpDir},
+	}
+
+	workspaces, err := Discover(opts)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	if len(workspaces) != 1 {
+		t.Fatalf("expected 1 workspace, got %d", len(workspaces))
+	}
+
+	ws := workspaces[0]
+	if ws.Name != "v1-workspace" {
+		t.Errorf("expected name 'v1-workspace', got %q", ws.Name)
+	}
+	if ws.IsV2 {
+		t.Error("expected IsV2 to be false for v1 workspace")
+	}
+}
+
+func TestDiscoverMultipleWorkspaces(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multiple workspaces
+	for i, name := range []string{"ws-alpha", "ws-beta", "ws-gamma"} {
+		wsDir := filepath.Join(tmpDir, name)
+		bcDir := filepath.Join(wsDir, ".bc")
+		if err := os.MkdirAll(bcDir, 0750); err != nil {
+			t.Fatalf("failed to create workspace %d: %v", i, err)
+		}
+		configPath := filepath.Join(bcDir, "config.toml")
+		if err := os.WriteFile(configPath, []byte("[workspace]\nname = \""+name+"\"\n"), 0600); err != nil {
+			t.Fatalf("failed to create config %d: %v", i, err)
+		}
+	}
+
+	opts := DiscoverOptions{
+		IncludeCached: false,
+		ScanHome:      false,
+		MaxDepth:      2,
+		ScanPaths:     []string{tmpDir},
+	}
+
+	workspaces, err := Discover(opts)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	if len(workspaces) != 3 {
+		t.Errorf("expected 3 workspaces, got %d", len(workspaces))
+	}
+
+	names := make(map[string]bool)
+	for _, ws := range workspaces {
+		names[ws.Name] = true
+	}
+	for _, expected := range []string{"ws-alpha", "ws-beta", "ws-gamma"} {
+		if !names[expected] {
+			t.Errorf("expected to find workspace %q", expected)
+		}
+	}
+}
+
+func TestDiscoverNonExistentPath(t *testing.T) {
+	opts := DiscoverOptions{
+		IncludeCached: false,
+		ScanHome:      false,
+		MaxDepth:      2,
+		ScanPaths:     []string{"/nonexistent/path/that/does/not/exist"},
+	}
+
+	// Should not error, just return empty
+	workspaces, err := Discover(opts)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	if len(workspaces) != 0 {
+		t.Errorf("expected 0 workspaces for non-existent path, got %d", len(workspaces))
+	}
+}

--- a/pkg/workspace/registry_test.go
+++ b/pkg/workspace/registry_test.go
@@ -191,3 +191,189 @@ func TestRegistrySaveLoad(t *testing.T) {
 		t.Errorf("Loaded active = %q, want %q", r2.Active, "fe")
 	}
 }
+
+func TestGlobalDir(t *testing.T) {
+	dir := GlobalDir()
+	if dir == "" {
+		t.Skip("no home directory available")
+	}
+
+	// Should end with .bc
+	if filepath.Base(dir) != ".bc" {
+		t.Errorf("GlobalDir should end with .bc, got %s", dir)
+	}
+}
+
+func TestRegistryPath(t *testing.T) {
+	path := RegistryPath()
+	if path == "" {
+		t.Skip("no home directory available")
+	}
+
+	// Should end with workspaces.json
+	if filepath.Base(path) != "workspaces.json" {
+		t.Errorf("RegistryPath should end with workspaces.json, got %s", path)
+	}
+}
+
+func TestLoadRegistryNotFound(t *testing.T) {
+	// Use temp HOME with no registry file
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	r, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry should not error for missing file: %v", err)
+	}
+	if r == nil {
+		t.Fatal("LoadRegistry should return empty registry")
+	}
+	if len(r.Workspaces) != 0 {
+		t.Errorf("LoadRegistry should return empty workspaces, got %d", len(r.Workspaces))
+	}
+}
+
+func TestLoadRegistryWithFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	// Create .bc directory and registry file
+	bcDir := filepath.Join(tmpDir, ".bc")
+	if err := os.MkdirAll(bcDir, 0750); err != nil {
+		t.Fatalf("failed to create .bc dir: %v", err)
+	}
+
+	registryData := `{
+		"active": "test",
+		"workspaces": [
+			{"path": "/test/path", "name": "test", "alias": ""}
+		]
+	}`
+	registryPath := filepath.Join(bcDir, "workspaces.json")
+	if err := os.WriteFile(registryPath, []byte(registryData), 0600); err != nil {
+		t.Fatalf("failed to write registry: %v", err)
+	}
+
+	r, err := LoadRegistry()
+	if err != nil {
+		t.Fatalf("LoadRegistry failed: %v", err)
+	}
+	if r == nil {
+		t.Fatal("LoadRegistry returned nil")
+	}
+	if len(r.Workspaces) != 1 {
+		t.Errorf("expected 1 workspace, got %d", len(r.Workspaces))
+	}
+	if r.Active != "test" {
+		t.Errorf("expected active 'test', got %q", r.Active)
+	}
+}
+
+func TestLoadRegistryInvalidJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	// Create .bc directory with invalid JSON
+	bcDir := filepath.Join(tmpDir, ".bc")
+	if err := os.MkdirAll(bcDir, 0750); err != nil {
+		t.Fatalf("failed to create .bc dir: %v", err)
+	}
+
+	registryPath := filepath.Join(bcDir, "workspaces.json")
+	if err := os.WriteFile(registryPath, []byte("not valid json"), 0600); err != nil {
+		t.Fatalf("failed to write registry: %v", err)
+	}
+
+	_, err := LoadRegistry()
+	if err == nil {
+		t.Error("LoadRegistry should error on invalid JSON")
+	}
+}
+
+func TestSetAliasWorkspaceNotFound(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "workspaces.json")
+
+	r := &Registry{path: registryPath}
+
+	err := r.SetAlias("/nonexistent", "alias")
+	if err == nil {
+		t.Error("SetAlias should error for nonexistent workspace")
+	}
+	if _, ok := err.(*WorkspaceNotFoundError); !ok {
+		t.Errorf("expected WorkspaceNotFoundError, got %T", err)
+	}
+}
+
+func TestRegisterWithAliasConflict(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "workspaces.json")
+
+	r := &Registry{path: registryPath}
+
+	// Register first with alias
+	err := r.RegisterWithAlias("/path1", "ws1", "myalias")
+	if err != nil {
+		t.Fatalf("first RegisterWithAlias failed: %v", err)
+	}
+
+	// Try to register second with same alias
+	err = r.RegisterWithAlias("/path2", "ws2", "myalias")
+	if err == nil {
+		t.Error("RegisterWithAlias should error on alias conflict")
+	}
+	if _, ok := err.(*AliasConflictError); !ok {
+		t.Errorf("expected AliasConflictError, got %T", err)
+	}
+}
+
+func TestRegisterWithAliasUpdate(t *testing.T) {
+	dir := t.TempDir()
+	registryPath := filepath.Join(dir, "workspaces.json")
+
+	r := &Registry{path: registryPath}
+
+	// Register workspace
+	err := r.RegisterWithAlias("/path1", "ws1", "")
+	if err != nil {
+		t.Fatalf("RegisterWithAlias failed: %v", err)
+	}
+
+	// Update same path with alias
+	err = r.RegisterWithAlias("/path1", "ws1-updated", "newalias")
+	if err != nil {
+		t.Fatalf("RegisterWithAlias update failed: %v", err)
+	}
+
+	if len(r.Workspaces) != 1 {
+		t.Errorf("expected 1 workspace after update, got %d", len(r.Workspaces))
+	}
+	if r.Workspaces[0].Name != "ws1-updated" {
+		t.Errorf("expected updated name, got %q", r.Workspaces[0].Name)
+	}
+	if r.Workspaces[0].Alias != "newalias" {
+		t.Errorf("expected alias 'newalias', got %q", r.Workspaces[0].Alias)
+	}
+}
+
+func TestAliasConflictErrorMessage(t *testing.T) {
+	err := &AliasConflictError{Alias: "test", ExistingPath: "/existing"}
+	msg := err.Error()
+	if msg == "" {
+		t.Error("AliasConflictError.Error() should return message")
+	}
+}
+
+func TestWorkspaceNotFoundErrorMessage(t *testing.T) {
+	err := &WorkspaceNotFoundError{Identifier: "test"}
+	msg := err.Error()
+	if msg == "" {
+		t.Error("WorkspaceNotFoundError.Error() should return message")
+	}
+}

--- a/pkg/workspace/userconfig_test.go
+++ b/pkg/workspace/userconfig_test.go
@@ -148,3 +148,273 @@ func TestHasTool(t *testing.T) {
 		t.Error("expected unknown-tool to not be available")
 	}
 }
+
+func TestHasToolAllTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		cfg      V2Config
+		want     bool
+	}{
+		{
+			name:     "claude enabled",
+			toolName: "claude",
+			cfg: V2Config{
+				Tools: ToolsConfig{Claude: &ToolConfig{Enabled: true}},
+			},
+			want: true,
+		},
+		{
+			name:     "claude-code enabled",
+			toolName: "claude-code",
+			cfg: V2Config{
+				Tools: ToolsConfig{Claude: &ToolConfig{Enabled: true}},
+			},
+			want: true,
+		},
+		{
+			name:     "claude disabled",
+			toolName: "claude",
+			cfg: V2Config{
+				Tools: ToolsConfig{Claude: &ToolConfig{Enabled: false}},
+			},
+			want: false,
+		},
+		{
+			name:     "cursor enabled",
+			toolName: "cursor",
+			cfg: V2Config{
+				Tools: ToolsConfig{Cursor: &ToolConfig{Enabled: true}},
+			},
+			want: true,
+		},
+		{
+			name:     "cursor disabled",
+			toolName: "cursor",
+			cfg: V2Config{
+				Tools: ToolsConfig{Cursor: &ToolConfig{Enabled: false}},
+			},
+			want: false,
+		},
+		{
+			name:     "codex enabled",
+			toolName: "codex",
+			cfg: V2Config{
+				Tools: ToolsConfig{Codex: &ToolConfig{Enabled: true}},
+			},
+			want: true,
+		},
+		{
+			name:     "gemini enabled",
+			toolName: "gemini",
+			cfg: V2Config{
+				Tools: ToolsConfig{Gemini: &ToolConfig{Enabled: true}},
+			},
+			want: true,
+		},
+		{
+			name:     "custom tool enabled",
+			toolName: "my-tool",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					Custom: map[string]ToolConfig{
+						"my-tool": {Enabled: true},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name:     "custom tool disabled still exists",
+			toolName: "my-tool",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					Custom: map[string]ToolConfig{
+						"my-tool": {Enabled: false},
+					},
+				},
+			},
+			want: true, // custom tools check existence only, not Enabled
+		},
+		{
+			name:     "custom tool not in map",
+			toolName: "my-tool",
+			cfg: V2Config{
+				Tools: ToolsConfig{Custom: map[string]ToolConfig{}},
+			},
+			want: false,
+		},
+		{
+			name:     "nil tools",
+			toolName: "claude",
+			cfg:      V2Config{},
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.HasTool(tt.toolName)
+			if got != tt.want {
+				t.Errorf("HasTool(%q) = %v, want %v", tt.toolName, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUserRCExists(t *testing.T) {
+	// Test with temp directory
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	// Initially should not exist
+	if UserRCExists() {
+		t.Error("UserRCExists should return false when .bcrc doesn't exist")
+	}
+
+	// Create .bcrc file
+	rcPath := filepath.Join(tmpDir, ".bcrc")
+	if err := os.WriteFile(rcPath, []byte("[user]\nnickname = \"@test\""), 0600); err != nil {
+		t.Fatalf("failed to create .bcrc: %v", err)
+	}
+
+	// Now should exist
+	if !UserRCExists() {
+		t.Error("UserRCExists should return true when .bcrc exists")
+	}
+}
+
+func TestGetPreferredTool(t *testing.T) {
+	tests := []struct { //nolint:govet // test struct alignment not critical
+		name     string
+		cfg      V2Config
+		rc       *UserRCConfig
+		expected string
+	}{
+		{
+			name: "nil rc returns default",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					Default: "claude",
+					Claude:  &ToolConfig{Enabled: true},
+				},
+			},
+			rc:       nil,
+			expected: "claude",
+		},
+		{
+			name: "empty preferred list returns default",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					Default: "claude",
+					Claude:  &ToolConfig{Enabled: true},
+				},
+			},
+			rc:       &UserRCConfig{},
+			expected: "claude",
+		},
+		{
+			name: "first preferred tool available",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					Default: "claude",
+					Claude:  &ToolConfig{Enabled: true},
+					Cursor:  &ToolConfig{Enabled: true},
+				},
+			},
+			rc: &UserRCConfig{
+				Tools: UserRCToolsConfig{
+					Preferred: []string{"cursor", "claude"},
+				},
+			},
+			expected: "cursor",
+		},
+		{
+			name: "skip unavailable tool",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					Default: "claude",
+					Claude:  &ToolConfig{Enabled: true},
+				},
+			},
+			rc: &UserRCConfig{
+				Tools: UserRCToolsConfig{
+					Preferred: []string{"cursor", "claude"},
+				},
+			},
+			expected: "claude",
+		},
+		{
+			name: "no preferred tools available",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					Default: "gemini",
+					Gemini:  &ToolConfig{Enabled: true},
+				},
+			},
+			rc: &UserRCConfig{
+				Tools: UserRCToolsConfig{
+					Preferred: []string{"cursor", "claude"},
+				},
+			},
+			expected: "gemini",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.GetPreferredTool(tt.rc)
+			if got != tt.expected {
+				t.Errorf("GetPreferredTool() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLoadUserRCConfigNotFound(t *testing.T) {
+	// Test with temp directory that has no .bcrc
+	tmpDir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	t.Setenv("HOME", tmpDir)
+	defer func() { _ = os.Setenv("HOME", oldHome) }()
+
+	cfg, err := LoadUserRCConfig()
+	if err != nil {
+		t.Errorf("LoadUserRCConfig should not error for missing file: %v", err)
+	}
+	if cfg != nil {
+		t.Error("LoadUserRCConfig should return nil for missing file")
+	}
+}
+
+func TestMergeWithUserRCNil(t *testing.T) {
+	cfg := DefaultV2Config("test")
+	originalNickname := cfg.User.Nickname
+
+	// Merge with nil should not change anything
+	cfg.MergeWithUserRC(nil)
+
+	if cfg.User.Nickname != originalNickname {
+		t.Errorf("MergeWithUserRC(nil) changed nickname from %q to %q", originalNickname, cfg.User.Nickname)
+	}
+}
+
+func TestMergeWithUserRCPreserveWorkspace(t *testing.T) {
+	cfg := DefaultV2Config("test")
+	cfg.User.Nickname = "@workspace-user"
+
+	rc := &UserRCConfig{
+		User: UserRCUserConfig{
+			Nickname: "@rc-user",
+		},
+	}
+
+	cfg.MergeWithUserRC(rc)
+
+	// Workspace nickname should be preserved
+	if cfg.User.Nickname != "@workspace-user" {
+		t.Errorf("MergeWithUserRC changed workspace nickname to %q", cfg.User.Nickname)
+	}
+}

--- a/pkg/workspace/workspace_test.go
+++ b/pkg/workspace/workspace_test.go
@@ -994,3 +994,221 @@ func TestWorkspaceDefaultChannels(t *testing.T) {
 		t.Errorf("DefaultChannels len = %d, want 2", len(channels))
 	}
 }
+
+func TestWorkspaceDefaultToolV1(t *testing.T) {
+	dir := t.TempDir()
+
+	ws, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// V1 default tool is claude
+	if ws.DefaultTool() != "claude" {
+		t.Errorf("DefaultTool v1 = %q, want claude", ws.DefaultTool())
+	}
+
+	// V1 default command
+	if ws.DefaultToolCommand() != "claude --dangerously-skip-permissions" {
+		t.Errorf("DefaultToolCommand v1 = %q, want default claude command", ws.DefaultToolCommand())
+	}
+}
+
+func TestWorkspaceDefaultToolV1WithConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	ws, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set custom tool in v1 config
+	ws.Config.Tool = "cursor"
+	ws.Config.AgentCommand = "cursor --wait"
+
+	if ws.DefaultTool() != "cursor" {
+		t.Errorf("DefaultTool v1 custom = %q, want cursor", ws.DefaultTool())
+	}
+
+	if ws.DefaultToolCommand() != "cursor --wait" {
+		t.Errorf("DefaultToolCommand v1 custom = %q, want cursor --wait", ws.DefaultToolCommand())
+	}
+}
+
+func TestWorkspaceDefaultChannelsV1(t *testing.T) {
+	dir := t.TempDir()
+
+	ws, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	channels := ws.DefaultChannels()
+	if len(channels) != 2 {
+		t.Errorf("DefaultChannels v1 len = %d, want 2", len(channels))
+	}
+	if channels[0] != "general" {
+		t.Errorf("First channel = %q, want general", channels[0])
+	}
+	if channels[1] != "engineering" {
+		t.Errorf("Second channel = %q, want engineering", channels[1])
+	}
+}
+
+func TestWorkspaceMemoryDir(t *testing.T) {
+	dir := t.TempDir()
+
+	ws, err := InitV2(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	memDir := ws.MemoryDir()
+	if memDir == "" {
+		t.Error("MemoryDir should not be empty")
+	}
+
+	// Should contain .bc/memory
+	expected := filepath.Join(dir, ".bc", "memory")
+	if memDir != expected {
+		t.Errorf("MemoryDir = %q, want %q", memDir, expected)
+	}
+}
+
+func TestWorkspaceWorktreesDir(t *testing.T) {
+	dir := t.TempDir()
+
+	ws, err := InitV2(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtDir := ws.WorktreesDir()
+	if wtDir == "" {
+		t.Error("WorktreesDir should not be empty")
+	}
+
+	// Should contain .bc/worktrees
+	expected := filepath.Join(dir, ".bc", "worktrees")
+	if wtDir != expected {
+		t.Errorf("WorktreesDir = %q, want %q", wtDir, expected)
+	}
+}
+
+func TestWorkspaceMemoryDirV1(t *testing.T) {
+	dir := t.TempDir()
+
+	ws, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	memDir := ws.MemoryDir()
+	// V1 should still return a memory dir path
+	if memDir == "" {
+		t.Error("MemoryDir should not be empty for v1")
+	}
+}
+
+func TestWorkspaceWorktreesDirV1(t *testing.T) {
+	dir := t.TempDir()
+
+	ws, err := Init(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtDir := ws.WorktreesDir()
+	// V1 should still return a worktrees dir path
+	if wtDir == "" {
+		t.Error("WorktreesDir should not be empty for v1")
+	}
+}
+
+func TestCopyDefaultPrompts(t *testing.T) {
+	// Create source directory with prompts
+	rootDir := t.TempDir()
+	sourceDir := filepath.Join(rootDir, "prompts")
+	if err := os.MkdirAll(sourceDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a test prompt file
+	testPrompt := "This is a test prompt."
+	if err := os.WriteFile(filepath.Join(sourceDir, "test.md"), []byte(testPrompt), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create state directory and prompts subdirectory
+	stateDir := filepath.Join(rootDir, ".bc")
+	destDir := filepath.Join(stateDir, "prompts")
+	if err := os.MkdirAll(destDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy prompts
+	if err := copyDefaultPrompts(rootDir, stateDir); err != nil {
+		t.Fatalf("copyDefaultPrompts: %v", err)
+	}
+
+	// Verify prompt was copied
+	destPath := filepath.Join(stateDir, "prompts", "test.md")
+	data, err := os.ReadFile(destPath) //nolint:gosec // test file path
+	if err != nil {
+		t.Fatalf("copied file not found: %v", err)
+	}
+	if string(data) != testPrompt {
+		t.Errorf("copied content = %q, want %q", string(data), testPrompt)
+	}
+}
+
+func TestCopyDefaultPromptsNoSource(t *testing.T) {
+	// When no prompts directory exists, should silently succeed
+	rootDir := t.TempDir()
+	stateDir := filepath.Join(rootDir, ".bc")
+	if err := os.MkdirAll(stateDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not error
+	if err := copyDefaultPrompts(rootDir, stateDir); err != nil {
+		t.Errorf("copyDefaultPrompts without source should not error: %v", err)
+	}
+}
+
+func TestCopyDefaultPromptsExistingDest(t *testing.T) {
+	// Create source directory with prompts
+	rootDir := t.TempDir()
+	sourceDir := filepath.Join(rootDir, "prompts")
+	if err := os.MkdirAll(sourceDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sourceDir, "test.md"), []byte("source content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create state directory with existing prompts
+	stateDir := filepath.Join(rootDir, ".bc")
+	destDir := filepath.Join(stateDir, "prompts")
+	if err := os.MkdirAll(destDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Create existing file with different content
+	if err := os.WriteFile(filepath.Join(destDir, "test.md"), []byte("existing content"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Copy should skip existing files (not overwrite)
+	if err := copyDefaultPrompts(rootDir, stateDir); err != nil {
+		t.Fatalf("copyDefaultPrompts: %v", err)
+	}
+
+	// Verify existing content was preserved
+	data, err := os.ReadFile(filepath.Join(destDir, "test.md")) //nolint:gosec // test file path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "existing content" {
+		t.Errorf("existing file was overwritten, got %q", string(data))
+	}
+}


### PR DESCRIPTION
## Summary
- Improve pkg/workspace test coverage from 69.7% to 81.0%, exceeding the 80% target
- Add comprehensive tests for Registry, Config, Discover, UserConfig, and Workspace functions

## Test Coverage Improvements

| Area | Tests Added |
|------|-------------|
| Registry | GlobalDir, RegistryPath, LoadRegistry (with/without file, invalid JSON), SetAlias errors, RegisterWithAlias conflicts, error message tests |
| Config | ValidateNickname, NormalizeNickname |
| Discover | V1 workspaces, multiple workspaces, non-existent paths |
| UserConfig | HasTool (all tool types), UserRCExists, GetPreferredTool, LoadUserRCConfigNotFound, MergeWithUserRC (nil, preserve workspace) |
| Workspace | DefaultTool, DefaultChannels, MemoryDir, WorktreesDir, copyDefaultPrompts (with source, no source, existing dest) |

## Test plan
- [x] All new tests pass
- [x] Lint passes (`golangci-lint run ./pkg/workspace/...`)
- [x] Coverage verified at 81.0% (target: 80%)

Closes part of #1236

🤖 Generated with [Claude Code](https://claude.ai/claude-code)