### PR TITLE
feat(ide): Add VS Code extension for bc

### DIFF
--- a/ide/vscode/.eslintrc.json
+++ b/ide/vscode/.eslintrc.json
@@ -1,0 +1,22 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2022,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "rules": {
+    "@typescript-eslint/naming-convention": "warn",
+    "@typescript-eslint/semi": "warn",
+    "curly": "warn",
+    "eqeqeq": "warn",
+    "no-throw-literal": "warn",
+    "semi": "off"
+  },
+  "ignorePatterns": ["out", "node_modules"]
+}

--- a/ide/vscode/.gitignore
+++ b/ide/vscode/.gitignore
@@ -1,0 +1,4 @@
+out/
+node_modules/
+*.vsix
+.vscode-test/

--- a/ide/vscode/README.md
+++ b/ide/vscode/README.md
@@ -1,0 +1,92 @@
+# bc VS Code Extension
+
+VS Code extension for bc (AI Agent Orchestration CLI).
+
+## Features
+
+- **Agent Status Panel** - View all agents and their states in sidebar
+- **Channel Panel** - Browse and send messages to channels
+- **Status Bar Widget** - Quick view of workspace status (agent count, working)
+- **Command Palette** - Access all bc commands via `Ctrl+Shift+P`
+- **Keyboard Shortcuts** - Quick status (`Ctrl+Alt+B` / `Cmd+Alt+B`)
+- **Auto-detection** - Extension activates in bc workspaces
+
+## Requirements
+
+- VS Code 1.85+
+- bc CLI installed and in PATH
+- Project must be a bc workspace (contains `.bc` directory)
+
+## Installation
+
+### From VS Code Marketplace (Recommended)
+
+1. Open Extensions (`Ctrl+Shift+X`)
+2. Search for "bc"
+3. Click Install
+
+### Manual Installation
+
+1. Build the extension: `npm run compile`
+2. Package: `npx vsce package`
+3. Install from VSIX: Extensions → Install from VSIX
+
+## Usage
+
+### Sidebar
+
+Open the bc sidebar from the Activity Bar (robot icon):
+- **Agents** - Shows agent list with status indicators
+- **Channels** - Shows available channels
+
+### Commands
+
+Access from Command Palette (`Ctrl+Shift+P`):
+- **bc: Show Status** - Display workspace status
+- **bc: List Agents** - Show all agents in quick pick
+- **bc: Agent Health** - Check agent health
+- **bc: List Channels** - Show available channels
+- **bc: Send to Channel** - Send message to channel
+- **bc: View Logs** - Show recent bc logs
+- **bc: Refresh** - Refresh all views
+
+### Keyboard Shortcuts
+
+- `Ctrl+Alt+B` / `Cmd+Alt+B` - Quick status popup
+
+### Settings
+
+Configure at Settings → Extensions → bc:
+- **bc.binaryPath** - Path to bc binary (default: `bc`)
+- **bc.refreshInterval** - Auto-refresh interval in seconds (default: 30, 0 to disable)
+
+## Development
+
+### Building
+
+```bash
+npm install
+npm run compile
+```
+
+### Testing
+
+```bash
+npm test
+```
+
+### Running in Development
+
+1. Open this folder in VS Code
+2. Press F5 to launch Extension Development Host
+3. Open a bc workspace folder
+
+### Publishing
+
+```bash
+npx vsce publish
+```
+
+## License
+
+MIT

--- a/ide/vscode/package.json
+++ b/ide/vscode/package.json
@@ -1,0 +1,128 @@
+{
+  "name": "bc-vscode",
+  "displayName": "bc - AI Agent Orchestration",
+  "description": "VS Code extension for bc (AI Agent Orchestration CLI)",
+  "version": "0.1.0",
+  "publisher": "bc",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rpuneet/bc"
+  },
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "keywords": [
+    "ai",
+    "agents",
+    "orchestration",
+    "cli",
+    "bc"
+  ],
+  "activationEvents": [
+    "workspaceContains:.bc"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "bc.status",
+        "title": "bc: Show Status"
+      },
+      {
+        "command": "bc.agentList",
+        "title": "bc: List Agents"
+      },
+      {
+        "command": "bc.agentHealth",
+        "title": "bc: Agent Health"
+      },
+      {
+        "command": "bc.channelList",
+        "title": "bc: List Channels"
+      },
+      {
+        "command": "bc.channelSend",
+        "title": "bc: Send to Channel"
+      },
+      {
+        "command": "bc.logs",
+        "title": "bc: View Logs"
+      },
+      {
+        "command": "bc.refresh",
+        "title": "bc: Refresh"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "bc-explorer",
+          "title": "bc Agents",
+          "icon": "resources/bc-icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "bc-explorer": [
+        {
+          "id": "bc-agents",
+          "name": "Agents"
+        },
+        {
+          "id": "bc-channels",
+          "name": "Channels"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "bc.refresh",
+          "when": "view == bc-agents || view == bc-channels",
+          "group": "navigation"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "bc",
+      "properties": {
+        "bc.binaryPath": {
+          "type": "string",
+          "default": "bc",
+          "description": "Path to bc binary"
+        },
+        "bc.refreshInterval": {
+          "type": "number",
+          "default": 30,
+          "description": "Auto-refresh interval in seconds (0 to disable)"
+        }
+      }
+    },
+    "keybindings": [
+      {
+        "command": "bc.status",
+        "key": "ctrl+alt+b",
+        "mac": "cmd+alt+b"
+      }
+    ]
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "eslint src --ext ts",
+    "test": "node ./out/test/runTest.js"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "eslint": "^8.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/ide/vscode/resources/bc-icon.svg
+++ b/ide/vscode/resources/bc-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="11" width="18" height="10" rx="2" ry="2"/>
+  <circle cx="8.5" cy="16" r="1.5"/>
+  <circle cx="15.5" cy="16" r="1.5"/>
+  <path d="M9 11V7a3 3 0 0 1 6 0v4"/>
+  <path d="M5 11V9a7 7 0 0 1 14 0v2"/>
+</svg>

--- a/ide/vscode/src/extension.ts
+++ b/ide/vscode/src/extension.ts
@@ -1,0 +1,178 @@
+import * as vscode from 'vscode';
+import { BcService } from './services/bcService';
+import { AgentsTreeProvider } from './views/agentsTreeProvider';
+import { ChannelsTreeProvider } from './views/channelsTreeProvider';
+import { StatusBar } from './views/statusBar';
+
+let bcService: BcService;
+let statusBar: StatusBar;
+let refreshInterval: NodeJS.Timeout | undefined;
+
+export function activate(context: vscode.ExtensionContext) {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    if (!workspaceFolder) {
+        return;
+    }
+
+    bcService = new BcService(workspaceFolder.uri.fsPath);
+
+    if (!bcService.isWorkspace()) {
+        return;
+    }
+
+    console.log('bc extension activated');
+
+    // Create tree providers
+    const agentsProvider = new AgentsTreeProvider(bcService);
+    const channelsProvider = new ChannelsTreeProvider(bcService);
+
+    // Register tree views
+    vscode.window.registerTreeDataProvider('bc-agents', agentsProvider);
+    vscode.window.registerTreeDataProvider('bc-channels', channelsProvider);
+
+    // Create status bar
+    statusBar = new StatusBar(bcService);
+    context.subscriptions.push(statusBar);
+
+    // Register commands
+    context.subscriptions.push(
+        vscode.commands.registerCommand('bc.status', () => showStatus()),
+        vscode.commands.registerCommand('bc.agentList', () => showAgentList()),
+        vscode.commands.registerCommand('bc.agentHealth', () => showAgentHealth()),
+        vscode.commands.registerCommand('bc.channelList', () => showChannelList()),
+        vscode.commands.registerCommand('bc.channelSend', () => sendToChannel()),
+        vscode.commands.registerCommand('bc.logs', () => showLogs()),
+        vscode.commands.registerCommand('bc.refresh', () => {
+            agentsProvider.refresh();
+            channelsProvider.refresh();
+            statusBar.refresh();
+        })
+    );
+
+    // Set up auto-refresh
+    const config = vscode.workspace.getConfiguration('bc');
+    const interval = config.get<number>('refreshInterval', 30);
+    if (interval > 0) {
+        refreshInterval = setInterval(() => {
+            agentsProvider.refresh();
+            channelsProvider.refresh();
+            statusBar.refresh();
+        }, interval * 1000);
+    }
+
+    // Initial refresh
+    statusBar.refresh();
+}
+
+export function deactivate() {
+    if (refreshInterval) {
+        clearInterval(refreshInterval);
+    }
+}
+
+async function showStatus() {
+    const status = await bcService.getStatus();
+    if (status) {
+        vscode.window.showInformationMessage(
+            `bc: ${status.workspace} | Agents: ${status.agentCount} | Active: ${status.activeCount} | Working: ${status.workingCount}`
+        );
+    } else {
+        vscode.window.showWarningMessage('Failed to get bc status');
+    }
+}
+
+async function showAgentList() {
+    const agents = await bcService.listAgents();
+    if (agents.length === 0) {
+        vscode.window.showInformationMessage('No agents found');
+        return;
+    }
+
+    const items = agents.map(a => ({
+        label: a.name,
+        description: `${a.role} - ${a.state}`,
+        detail: a.task || undefined
+    }));
+
+    const selected = await vscode.window.showQuickPick(items, {
+        placeHolder: 'Select an agent'
+    });
+
+    if (selected) {
+        vscode.window.showInformationMessage(`Agent: ${selected.label}`);
+    }
+}
+
+async function showAgentHealth() {
+    const output = await bcService.execute('agent', 'health');
+    if (output) {
+        const doc = await vscode.workspace.openTextDocument({
+            content: output,
+            language: 'plaintext'
+        });
+        vscode.window.showTextDocument(doc);
+    }
+}
+
+async function showChannelList() {
+    const channels = await bcService.listChannels();
+    if (channels.length === 0) {
+        vscode.window.showInformationMessage('No channels found');
+        return;
+    }
+
+    const selected = await vscode.window.showQuickPick(channels, {
+        placeHolder: 'Select a channel'
+    });
+
+    if (selected) {
+        const history = await bcService.getChannelHistory(selected);
+        const content = history.map(m => `[${m.timestamp}] ${m.sender}: ${m.message}`).join('\n');
+        const doc = await vscode.workspace.openTextDocument({
+            content: content || 'No messages',
+            language: 'plaintext'
+        });
+        vscode.window.showTextDocument(doc);
+    }
+}
+
+async function sendToChannel() {
+    const channels = await bcService.listChannels();
+    if (channels.length === 0) {
+        vscode.window.showWarningMessage('No channels available');
+        return;
+    }
+
+    const channel = await vscode.window.showQuickPick(channels, {
+        placeHolder: 'Select channel'
+    });
+
+    if (!channel) {
+        return;
+    }
+
+    const message = await vscode.window.showInputBox({
+        prompt: `Message for #${channel}`,
+        placeHolder: 'Enter message'
+    });
+
+    if (message) {
+        const success = await bcService.sendToChannel(channel, message);
+        if (success) {
+            vscode.window.showInformationMessage(`Sent to #${channel}`);
+        } else {
+            vscode.window.showErrorMessage('Failed to send message');
+        }
+    }
+}
+
+async function showLogs() {
+    const logs = await bcService.getLogs();
+    if (logs) {
+        const doc = await vscode.workspace.openTextDocument({
+            content: logs,
+            language: 'plaintext'
+        });
+        vscode.window.showTextDocument(doc);
+    }
+}

--- a/ide/vscode/src/services/bcService.ts
+++ b/ide/vscode/src/services/bcService.ts
@@ -1,0 +1,174 @@
+import { execSync, exec } from 'child_process';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as vscode from 'vscode';
+
+export interface BcStatus {
+    workspace: string;
+    agentCount: number;
+    activeCount: number;
+    workingCount: number;
+}
+
+export interface Agent {
+    name: string;
+    role: string;
+    state: string;
+    uptime: string;
+    task: string;
+}
+
+export interface ChannelMessage {
+    timestamp: string;
+    sender: string;
+    message: string;
+}
+
+export class BcService {
+    private workspacePath: string;
+    private bcPath: string;
+    private _isWorkspace: boolean;
+
+    constructor(workspacePath: string) {
+        this.workspacePath = workspacePath;
+        this.bcPath = vscode.workspace.getConfiguration('bc').get('binaryPath', 'bc');
+        this._isWorkspace = this.detectWorkspace();
+    }
+
+    private detectWorkspace(): boolean {
+        const bcDir = path.join(this.workspacePath, '.bc');
+        return fs.existsSync(bcDir) && fs.statSync(bcDir).isDirectory();
+    }
+
+    isWorkspace(): boolean {
+        return this._isWorkspace;
+    }
+
+    async execute(...args: string[]): Promise<string | null> {
+        if (!this._isWorkspace) {
+            return null;
+        }
+
+        return new Promise((resolve) => {
+            const cmd = `${this.bcPath} ${args.join(' ')}`;
+            exec(cmd, {
+                cwd: this.workspacePath,
+                env: { ...process.env, NO_COLOR: '1' },
+                timeout: 30000
+            }, (error, stdout) => {
+                if (error) {
+                    console.warn(`bc command failed: ${args.join(' ')}`, error);
+                    resolve(null);
+                } else {
+                    resolve(stdout);
+                }
+            });
+        });
+    }
+
+    async getStatus(): Promise<BcStatus | null> {
+        const output = await this.execute('status', '--json');
+        if (!output) {
+            return null;
+        }
+
+        try {
+            const data = JSON.parse(output);
+            return {
+                workspace: data.workspace || 'unknown',
+                agentCount: data.agent_count || 0,
+                activeCount: data.active_count || 0,
+                workingCount: data.working_count || 0
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    async listAgents(): Promise<Agent[]> {
+        const output = await this.execute('agent', 'list', '--json');
+        if (!output) {
+            return [];
+        }
+
+        try {
+            const data = JSON.parse(output);
+            if (Array.isArray(data)) {
+                return data.map((a: Record<string, unknown>) => ({
+                    name: String(a.name || ''),
+                    role: String(a.role || ''),
+                    state: String(a.state || ''),
+                    uptime: String(a.uptime || '-'),
+                    task: String(a.task || '')
+                }));
+            }
+        } catch {
+            // Parse table output as fallback
+            return this.parseAgentTable(output);
+        }
+        return [];
+    }
+
+    private parseAgentTable(output: string): Agent[] {
+        return output.split('\n')
+            .filter(line => line.includes('engineer') || line.includes('manager') || line.includes('root'))
+            .map(line => {
+                const parts = line.split(/\s{2,}/).map(p => p.trim());
+                if (parts.length >= 4) {
+                    return {
+                        name: parts[0],
+                        role: parts[1],
+                        state: parts[2],
+                        uptime: parts[3] || '-',
+                        task: parts[4] || ''
+                    };
+                }
+                return null;
+            })
+            .filter((a): a is Agent => a !== null);
+    }
+
+    async listChannels(): Promise<string[]> {
+        const output = await this.execute('channel', 'list');
+        if (!output) {
+            return [];
+        }
+
+        return output.split('\n')
+            .map(line => line.trim())
+            .filter(line => line.length > 0 && !line.startsWith('CHANNEL'));
+    }
+
+    async getChannelHistory(channel: string, limit: number = 20): Promise<ChannelMessage[]> {
+        const output = await this.execute('channel', 'history', channel, '--limit', String(limit));
+        if (!output) {
+            return [];
+        }
+
+        const messages: ChannelMessage[] = [];
+        const regex = /\[(\d+)\]\s*\[([^\]]+)\]\s*([^:]+):\s*(.*)/;
+
+        for (const line of output.split('\n')) {
+            const match = regex.exec(line);
+            if (match) {
+                messages.push({
+                    timestamp: match[2],
+                    sender: match[3].trim(),
+                    message: match[4].trim()
+                });
+            }
+        }
+
+        return messages;
+    }
+
+    async sendToChannel(channel: string, message: string): Promise<boolean> {
+        const output = await this.execute('channel', 'send', channel, message);
+        return output !== null;
+    }
+
+    async getLogs(limit: number = 50): Promise<string> {
+        const output = await this.execute('logs', '--tail', String(limit));
+        return output || '';
+    }
+}

--- a/ide/vscode/src/views/agentsTreeProvider.ts
+++ b/ide/vscode/src/views/agentsTreeProvider.ts
@@ -1,0 +1,54 @@
+import * as vscode from 'vscode';
+import { BcService, Agent } from '../services/bcService';
+
+export class AgentsTreeProvider implements vscode.TreeDataProvider<AgentItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<AgentItem | undefined | null | void> = new vscode.EventEmitter<AgentItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<AgentItem | undefined | null | void> = this._onDidChangeTreeData.event;
+
+    private agents: Agent[] = [];
+
+    constructor(private bcService: BcService) {}
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: AgentItem): vscode.TreeItem {
+        return element;
+    }
+
+    async getChildren(): Promise<AgentItem[]> {
+        this.agents = await this.bcService.listAgents();
+        return this.agents.map(agent => new AgentItem(agent));
+    }
+}
+
+class AgentItem extends vscode.TreeItem {
+    constructor(agent: Agent) {
+        super(agent.name, vscode.TreeItemCollapsibleState.None);
+
+        this.description = `${agent.role} - ${agent.state}`;
+        this.tooltip = agent.task || `${agent.name} (${agent.role})`;
+
+        // Set icon based on state
+        const iconColor = this.getIconColor(agent.state);
+        this.iconPath = new vscode.ThemeIcon('circle-filled', iconColor);
+
+        this.contextValue = 'agent';
+    }
+
+    private getIconColor(state: string): vscode.ThemeColor {
+        switch (state.toLowerCase()) {
+            case 'working':
+                return new vscode.ThemeColor('testing.iconPassed');
+            case 'active':
+                return new vscode.ThemeColor('charts.green');
+            case 'idle':
+                return new vscode.ThemeColor('charts.yellow');
+            case 'stopped':
+                return new vscode.ThemeColor('charts.red');
+            default:
+                return new vscode.ThemeColor('foreground');
+        }
+    }
+}

--- a/ide/vscode/src/views/channelsTreeProvider.ts
+++ b/ide/vscode/src/views/channelsTreeProvider.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+import { BcService } from '../services/bcService';
+
+export class ChannelsTreeProvider implements vscode.TreeDataProvider<ChannelItem> {
+    private _onDidChangeTreeData: vscode.EventEmitter<ChannelItem | undefined | null | void> = new vscode.EventEmitter<ChannelItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<ChannelItem | undefined | null | void> = this._onDidChangeTreeData.event;
+
+    private channels: string[] = [];
+
+    constructor(private bcService: BcService) {}
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    getTreeItem(element: ChannelItem): vscode.TreeItem {
+        return element;
+    }
+
+    async getChildren(): Promise<ChannelItem[]> {
+        this.channels = await this.bcService.listChannels();
+        return this.channels.map(channel => new ChannelItem(channel, this.bcService));
+    }
+}
+
+class ChannelItem extends vscode.TreeItem {
+    constructor(channel: string, private bcService: BcService) {
+        super(`#${channel}`, vscode.TreeItemCollapsibleState.None);
+
+        this.tooltip = `Channel: ${channel}`;
+        this.iconPath = new vscode.ThemeIcon('comment-discussion');
+        this.contextValue = 'channel';
+
+        this.command = {
+            command: 'bc.channelSend',
+            title: 'Send Message',
+            arguments: [channel]
+        };
+    }
+}

--- a/ide/vscode/src/views/statusBar.ts
+++ b/ide/vscode/src/views/statusBar.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+import { BcService } from '../services/bcService';
+
+export class StatusBar implements vscode.Disposable {
+    private statusBarItem: vscode.StatusBarItem;
+    private bcService: BcService;
+
+    constructor(bcService: BcService) {
+        this.bcService = bcService;
+        this.statusBarItem = vscode.window.createStatusBarItem(
+            vscode.StatusBarAlignment.Left,
+            100
+        );
+        this.statusBarItem.command = 'bc.status';
+        this.statusBarItem.tooltip = 'bc workspace status';
+        this.statusBarItem.show();
+    }
+
+    async refresh(): Promise<void> {
+        const status = await this.bcService.getStatus();
+        if (status) {
+            const working = status.workingCount > 0 ? `$(sync~spin) ${status.workingCount}` : '';
+            this.statusBarItem.text = `$(robot) bc: ${status.activeCount}/${status.agentCount} ${working}`;
+        } else {
+            this.statusBarItem.text = '$(robot) bc';
+        }
+    }
+
+    dispose(): void {
+        this.statusBarItem.dispose();
+    }
+}

--- a/ide/vscode/tsconfig.json
+++ b/ide/vscode/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "outDir": "out",
+    "lib": ["ES2022"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary
- Add VS Code extension mirroring JetBrains plugin features
- Agent status panel in sidebar
- Channel panel with send capability
- Status bar widget showing agent count
- Command palette integration (bc: commands)
- Auto-detection of bc workspaces
- Keyboard shortcut (Ctrl+Alt+B / Cmd+Alt+B)
- Configurable refresh interval

## Test plan
- [ ] Build extension with `npm install && npm run compile`
- [ ] Run in dev mode (F5 in VS Code)
- [ ] Verify sidebar shows agents/channels
- [ ] Verify status bar updates
- [ ] Test commands from palette

Implements Phase 4 Ecosystem from epic #1076.

🤖 Generated with [Claude Code](https://claude.com/claude-code)