### PR TITLE
fix(test): clear BC_WORKSPACE in integration tests (#1273)

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -25,7 +25,7 @@ func durationFromSeconds(s int) time.Duration {
 
 // setupIntegrationWorkspace creates a temporary bc workspace and changes into it.
 // Returns the workspace root path and a cleanup function that restores
-// the original working directory and removes the temp directory.
+// the original working directory and BC_WORKSPACE env var.
 func setupIntegrationWorkspace(t *testing.T) (string, func()) {
 	t.Helper()
 
@@ -33,6 +33,11 @@ func setupIntegrationWorkspace(t *testing.T) (string, func()) {
 	if err != nil {
 		t.Fatalf("failed to get cwd: %v", err)
 	}
+
+	// Clear BC_WORKSPACE to ensure tests use the temp workspace, not outer workspace.
+	// This is critical when running tests in an active bc workspace.
+	origBCWorkspace := os.Getenv("BC_WORKSPACE")
+	_ = os.Unsetenv("BC_WORKSPACE")
 
 	tmpDir := t.TempDir()
 
@@ -51,6 +56,9 @@ func setupIntegrationWorkspace(t *testing.T) (string, func()) {
 
 	return tmpDir, func() {
 		_ = os.Chdir(origDir)
+		if origBCWorkspace != "" {
+			_ = os.Setenv("BC_WORKSPACE", origBCWorkspace)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes integration tests that fail when run in an active bc workspace
- Root cause: BC_WORKSPACE env var was set, causing commands to use active workspace instead of temp test workspace
- Fix: Clear BC_WORKSPACE at start of setupIntegrationWorkspace and restore in cleanup

## Test plan
- [x] Run previously failing tests: `go test ./internal/cmd -run "TestAgentListFilterByRole|TestAgentCreateInvalidRole|TestAgentHealthEmpty"`
- [x] All integration tests pass: `go test ./internal/cmd -run "Integration"`
- [x] Pre-commit hooks pass

Closes #1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)