### PR TITLE
test(workspace): Add edge case tests for directory skip and deduplication

### DIFF
--- a/pkg/workspace/discover_test.go
+++ b/pkg/workspace/discover_test.go
@@ -501,3 +501,131 @@ func TestScanDirAbsPathError(t *testing.T) {
 	// Pass valid path, should not panic
 	scanDir(t.TempDir(), 1, seen, &workspaces, &mu)
 }
+
+func TestDiscoverSkipsVendorDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a vendor directory with a workspace
+	vendorDir := filepath.Join(tmpDir, "vendor")
+	vendorWsDir := filepath.Join(vendorDir, "some-dep")
+	vendorBcDir := filepath.Join(vendorWsDir, ".bc")
+
+	if err := os.MkdirAll(vendorBcDir, 0750); err != nil {
+		t.Fatalf("failed to create vendor workspace dir: %v", err)
+	}
+
+	configPath := filepath.Join(vendorBcDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte("[workspace]\nname = \"vendor-pkg\"\n"), 0600); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	opts := DiscoverOptions{
+		IncludeCached: false,
+		ScanHome:      false,
+		MaxDepth:      3,
+		ScanPaths:     []string{tmpDir},
+	}
+
+	workspaces, err := Discover(opts)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	// Should not find the vendor workspace
+	for _, ws := range workspaces {
+		if ws.Name == "vendor-pkg" {
+			t.Error("expected vendor workspace to be skipped")
+		}
+	}
+}
+
+func TestDiscoverSkipsPycacheDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a __pycache__ directory with a workspace
+	pycacheDir := filepath.Join(tmpDir, "__pycache__")
+	pycacheWsDir := filepath.Join(pycacheDir, "module")
+	pycacheBcDir := filepath.Join(pycacheWsDir, ".bc")
+
+	if err := os.MkdirAll(pycacheBcDir, 0750); err != nil {
+		t.Fatalf("failed to create __pycache__ workspace dir: %v", err)
+	}
+
+	configPath := filepath.Join(pycacheBcDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte("[workspace]\nname = \"pycache-pkg\"\n"), 0600); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	opts := DiscoverOptions{
+		IncludeCached: false,
+		ScanHome:      false,
+		MaxDepth:      3,
+		ScanPaths:     []string{tmpDir},
+	}
+
+	workspaces, err := Discover(opts)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	// Should not find the __pycache__ workspace
+	for _, ws := range workspaces {
+		if ws.Name == "pycache-pkg" {
+			t.Error("expected __pycache__ workspace to be skipped")
+		}
+	}
+}
+
+func TestDiscoverScanDirNegativeDepth(t *testing.T) {
+	tmpDir := t.TempDir()
+	seen := make(map[string]bool)
+	var workspaces []DiscoveredWorkspace
+	var mu sync.Mutex
+
+	// With negative maxDepth, scanDir should return immediately
+	scanDir(tmpDir, -1, seen, &workspaces, &mu)
+
+	if len(workspaces) != 0 {
+		t.Errorf("expected 0 workspaces with negative depth, got %d", len(workspaces))
+	}
+}
+
+func TestDiscoverDuplicatePath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a workspace
+	wsDir := filepath.Join(tmpDir, "dup-workspace")
+	bcDir := filepath.Join(wsDir, ".bc")
+	if err := os.MkdirAll(bcDir, 0750); err != nil {
+		t.Fatalf("failed to create workspace dir: %v", err)
+	}
+
+	configPath := filepath.Join(bcDir, "config.toml")
+	if err := os.WriteFile(configPath, []byte("[workspace]\nname = \"dup-workspace\"\n"), 0600); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	opts := DiscoverOptions{
+		IncludeCached: false,
+		ScanHome:      false,
+		MaxDepth:      2,
+		// Pass same path twice to test deduplication
+		ScanPaths: []string{tmpDir, tmpDir},
+	}
+
+	workspaces, err := Discover(opts)
+	if err != nil {
+		t.Fatalf("Discover failed: %v", err)
+	}
+
+	// Should find workspace only once
+	count := 0
+	for _, ws := range workspaces {
+		if ws.Name == "dup-workspace" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 workspace (deduped), got %d", count)
+	}
+}


### PR DESCRIPTION
## Summary
- Add TestDiscoverSkipsVendorDir for vendor directory skip
- Add TestDiscoverSkipsPycacheDir for __pycache__ skip
- Add TestDiscoverScanDirNegativeDepth for negative depth edge case
- Add TestDiscoverDuplicatePath for path deduplication

Coverage: 85.4% → 85.5%

## Test plan
- [x] All new tests pass
- [x] `go test -race ./pkg/workspace/...` passes
- [x] `golangci-lint run ./pkg/workspace/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)