### PR TITLE
fix(test): Clear BC_WORKSPACE in report and status tests

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -229,6 +229,7 @@ func TestReportValidStates(t *testing.T) {
 	for _, state := range validStates {
 		t.Run(state, func(t *testing.T) {
 			t.Setenv("BC_AGENT_ID", "test-agent")
+			t.Setenv("BC_WORKSPACE", "") // Clear workspace env to test cwd-based discovery
 
 			// State validation happens before workspace lookup, but
 			// invalid states are rejected. Valid states proceed to
@@ -265,6 +266,8 @@ func TestReportRequiresArgs(t *testing.T) {
 // --- Status command tests ---
 
 func TestStatusNoWorkspace(t *testing.T) {
+	t.Setenv("BC_WORKSPACE", "") // Clear workspace env to test cwd-based discovery
+
 	origDir, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed to get cwd: %v", err)


### PR DESCRIPTION
## Summary
Fix test isolation issue where BC_WORKSPACE env var leaks into tests.

Tests that expect workspace lookup to fail based on cwd need to clear BC_WORKSPACE env var, as getWorkspace() checks it first.

## Changes
- Add `t.Setenv("BC_WORKSPACE", "")` to TestReportValidStates
- Add `t.Setenv("BC_WORKSPACE", "")` to TestStatusNoWorkspace

Similar to fix in #1276 for agent tests.

## Test plan
- [x] TestReportValidStates passes
- [x] TestStatusNoWorkspace passes
- [x] `go test -race ./internal/cmd/...` passes

Fixes test isolation bug reported by @ux-01

🤖 Generated with [Claude Code](https://claude.com/claude-code)