### PR TITLE
fix(cmd): Clear BC_WORKSPACE in TestReportValidStates, TestStatusNoWorkspace

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -224,6 +224,8 @@ func TestReportNoWorkspace(t *testing.T) {
 }
 
 func TestReportValidStates(t *testing.T) {
+	t.Setenv("BC_WORKSPACE", "") // Clear to avoid agent session pollution
+
 	validStates := []string{"idle", "working", "done", "stuck", "error"}
 
 	for _, state := range validStates {
@@ -265,6 +267,8 @@ func TestReportRequiresArgs(t *testing.T) {
 // --- Status command tests ---
 
 func TestStatusNoWorkspace(t *testing.T) {
+	t.Setenv("BC_WORKSPACE", "") // Clear to avoid agent session pollution
+
 	origDir, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed to get cwd: %v", err)


### PR DESCRIPTION
## Summary
- Fixes test isolation issue where BC_WORKSPACE leaks from agent sessions
- Similar to PR #1276 fix, but these tests were not included

## Changes
- Added `t.Setenv("BC_WORKSPACE", "")` to TestReportValidStates
- Added `t.Setenv("BC_WORKSPACE", "")` to TestStatusNoWorkspace

## Test plan
- [x] TestReportValidStates passes
- [x] TestStatusNoWorkspace passes
- [x] All tests pass with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)