### PR TITLE
fix(tests): Clear BC_WORKSPACE in integration tests

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -228,6 +228,7 @@ func TestReportValidStates(t *testing.T) {
 
 	for _, state := range validStates {
 		t.Run(state, func(t *testing.T) {
+			t.Setenv("BC_WORKSPACE", "") // Clear to ensure workspace lookup fails
 			t.Setenv("BC_AGENT_ID", "test-agent")
 
 			// State validation happens before workspace lookup, but
@@ -265,6 +266,8 @@ func TestReportRequiresArgs(t *testing.T) {
 // --- Status command tests ---
 
 func TestStatusNoWorkspace(t *testing.T) {
+	t.Setenv("BC_WORKSPACE", "") // Clear to ensure workspace lookup fails
+
 	origDir, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("failed to get cwd: %v", err)


### PR DESCRIPTION
## Summary
- Fix test isolation issue where BC_WORKSPACE env var leaks from agent session
- Add t.Setenv("BC_WORKSPACE", "") to TestReportValidStates and TestStatusNoWorkspace
- Follow-up to PR #1276 for issue #1273

## Root cause
Tests that chdir to temp dir expect getWorkspace() to fail, but getWorkspace() checks BC_WORKSPACE env var first, which leaks from the agent session.

## Test plan
- [x] TestReportValidStates passes
- [x] TestStatusNoWorkspace passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)