### PR TITLE
feat(tui): Add drawer navigation layout and fix 'm' key conflict

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -8,7 +8,7 @@ import {
   NavigationProvider,
   useNavigation,
   useKeyboardNavigation,
-  TabBar,
+  Drawer,
   Breadcrumb,
   FocusProvider,
   type View,
@@ -145,15 +145,21 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
 
   return (
     <Box flexDirection="column" padding={1} width={terminalWidth} height={terminalHeight}>
-      {/* Header with tab bar */}
-      <TabBar />
+      {/* Main layout: drawer + content */}
+      <Box flexDirection="row" flexGrow={1}>
+        {/* Left drawer navigation */}
+        <Drawer disabled={disableInput || showCommandPalette} />
 
-      {/* Breadcrumb navigation (shows path when navigated deep) */}
-      <Breadcrumb />
+        {/* Right content area */}
+        <Box flexDirection="column" flexGrow={1} paddingLeft={1}>
+          {/* Breadcrumb navigation (shows path when navigated deep) */}
+          <Breadcrumb />
 
-      {/* Main content area - grows to fill available space */}
-      <Box flexDirection="column" marginTop={1} flexGrow={1}>
-        <ViewContent view={currentView} disableInput={disableInput} />
+          {/* Main content area */}
+          <Box flexDirection="column" flexGrow={1}>
+            <ViewContent view={currentView} disableInput={disableInput} />
+          </Box>
+        </Box>
       </Box>
 
       {/* Footer with navigation hints - anchored to bottom */}
@@ -161,7 +167,7 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
 
       {/* Command palette overlay */}
       {showCommandPalette && (
-        <Box position="absolute" marginTop={2} marginLeft={10}>
+        <Box position="absolute" marginTop={2} marginLeft={16}>
           <CommandPalette
             isOpen={showCommandPalette}
             onClose={() => { setShowCommandPalette(false); }}
@@ -223,17 +229,19 @@ function HelpView(): React.ReactElement {
   const helpSections = useMemo(() => [
     { type: 'header' as const },
     { type: 'section' as const, title: 'Global', shortcuts: [
-      { keys: '1-8', desc: 'Switch tabs' },
+      { keys: '1-9, 0, -', desc: 'Switch views' },
+      { keys: 'M', desc: 'Memory view' },
+      { keys: 'r', desc: 'Routing view' },
       { keys: '?', desc: 'Toggle help' },
       { keys: 'ESC', desc: 'Go back / Home' },
-      { keys: 'Tab / j', desc: 'Next tab' },
-      { keys: 'Shift+Tab / k', desc: 'Previous tab' },
+      { keys: 'Tab / j', desc: 'Next view' },
+      { keys: 'Shift+Tab / k', desc: 'Previous view' },
       { keys: 'Ctrl+R', desc: 'Refresh current view' },
       { keys: 'q', desc: 'Quit' },
     ]},
-    { type: 'section' as const, title: 'Navigation', shortcuts: [
-      { keys: 'j / ↓', desc: 'Move down' },
-      { keys: 'k / ↑', desc: 'Move up' },
+    { type: 'section' as const, title: 'Navigation (Drawer & Lists)', shortcuts: [
+      { keys: 'j / ↓', desc: 'Move down in drawer/list' },
+      { keys: 'k / ↑', desc: 'Move up in drawer/list' },
       { keys: 'g', desc: 'Jump to top' },
       { keys: 'G', desc: 'Jump to bottom' },
       { keys: 'Enter', desc: 'Select / Drill down' },
@@ -397,7 +405,7 @@ function Footer(): React.ReactElement {
   const { theme } = useTheme();
   return (
     <Box marginTop={1} justifyContent="space-between">
-      <Text dimColor>Press [?] for help, [q] to quit</Text>
+      <Text dimColor>[j/k] navigate  [Enter] select  [?] help  [q] quit</Text>
       <Text dimColor>Theme: {theme.name}</Text>
     </Box>
   );

--- a/tui/src/navigation/Drawer.tsx
+++ b/tui/src/navigation/Drawer.tsx
@@ -1,0 +1,153 @@
+/**
+ * Drawer - Vertical navigation drawer component
+ *
+ * A 14-character fixed-width left panel with:
+ * - j/k for vim-style navigation
+ * - Enter to select
+ * - Number keys for quick jump
+ * - Active view indicator (triangular marker)
+ *
+ * Issue #1289: TUI revamp with drawer layout
+ */
+
+import React, { useState } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { useNavigation, type TabConfig } from './NavigationContext';
+import { useFocus } from './FocusContext';
+
+/** Fixed width for drawer panel */
+const DRAWER_WIDTH = 14;
+
+export interface DrawerProps {
+  /** Title displayed at top of drawer */
+  title?: string;
+  /** Disable keyboard handling */
+  disabled?: boolean;
+}
+
+export function Drawer({
+  title = 'bc v2',
+  disabled = false,
+}: DrawerProps): React.ReactElement {
+  const { currentView, tabs, navigate } = useNavigation();
+  const { isFocused } = useFocus();
+  const [highlightedIndex, setHighlightedIndex] = useState(() =>
+    tabs.findIndex(t => t.view === currentView)
+  );
+
+  // Handle keyboard navigation within drawer
+  useInput(
+    (input, key) => {
+      // Don't handle keys when in input mode
+      if (isFocused('input')) {
+        return;
+      }
+
+      // j or down arrow: move highlight down
+      if (input === 'j' || key.downArrow) {
+        setHighlightedIndex(prev => Math.min(prev + 1, tabs.length - 1));
+        return;
+      }
+
+      // k or up arrow: move highlight up
+      if (input === 'k' || key.upArrow) {
+        setHighlightedIndex(prev => Math.max(prev - 1, 0));
+        return;
+      }
+
+      // g: jump to first
+      if (input === 'g') {
+        setHighlightedIndex(0);
+        return;
+      }
+
+      // G: jump to last
+      if (input === 'G') {
+        setHighlightedIndex(tabs.length - 1);
+        return;
+      }
+
+      // Enter: select highlighted item
+      if (key.return) {
+        navigate(tabs[highlightedIndex].view);
+        return;
+      }
+    },
+    { isActive: !disabled && tabs.length > 0 }
+  );
+
+  // Sync highlight with current view when navigation happens externally
+  React.useEffect(() => {
+    const idx = tabs.findIndex(t => t.view === currentView);
+    if (idx >= 0 && idx !== highlightedIndex) {
+      setHighlightedIndex(idx);
+    }
+  }, [currentView, tabs, highlightedIndex]);
+
+  return (
+    <Box
+      flexDirection="column"
+      width={DRAWER_WIDTH}
+      borderStyle="single"
+      borderRight
+      borderTop={false}
+      borderBottom={false}
+      borderLeft={false}
+      paddingRight={1}
+    >
+      {/* Drawer title */}
+      <Box marginBottom={1}>
+        <Text bold color="cyan">{title}</Text>
+      </Box>
+      <Box>
+        <Text dimColor>{'─'.repeat(DRAWER_WIDTH - 2)}</Text>
+      </Box>
+
+      {/* Navigation items */}
+      <Box flexDirection="column" marginTop={1}>
+        {tabs.map((tab, index) => (
+          <DrawerItem
+            key={tab.view}
+            tab={tab}
+            isActive={currentView === tab.view}
+            isHighlighted={index === highlightedIndex}
+          />
+        ))}
+      </Box>
+    </Box>
+  );
+}
+
+interface DrawerItemProps {
+  tab: TabConfig;
+  isActive: boolean;
+  isHighlighted: boolean;
+}
+
+function DrawerItem({ tab, isActive, isHighlighted }: DrawerItemProps): React.ReactElement {
+  // Use triangular marker for active view
+  const marker = isActive ? '▸' : ' ';
+
+  // Short label for compact display
+  const label = tab.shortLabel ?? tab.label;
+
+  // Determine text styling
+  const textColor = isActive ? 'green' : isHighlighted ? 'yellow' : undefined;
+  const isBold = isActive || isHighlighted;
+  const isDim = !isActive && !isHighlighted;
+
+  return (
+    <Box>
+      <Text color={isActive ? 'green' : undefined}>{marker}</Text>
+      <Text
+        bold={isBold}
+        color={textColor}
+        dimColor={isDim}
+      >
+        {label}
+      </Text>
+    </Box>
+  );
+}
+
+export default Drawer;

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -30,7 +30,7 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: '9', view: 'workspaces', label: 'Workspaces', shortLabel: 'Wksp', shortcut: '9' },
   { key: '0', view: 'demons', label: 'Demons', shortLabel: 'Dmn', shortcut: '0' },
   { key: '-', view: 'processes', label: 'Processes', shortLabel: 'Proc', shortcut: '-' },
-  { key: 'm', view: 'memory', label: 'Memory', shortLabel: 'Mem', shortcut: 'm' },
+  { key: 'M', view: 'memory', label: 'Memory', shortLabel: 'Mem', shortcut: 'M' },
   { key: 'r', view: 'routing', label: 'Routing', shortLabel: 'Rte', shortcut: 'r' },
   { key: '?', view: 'help', label: 'Help', shortLabel: '?', shortcut: '?' },
 ];

--- a/tui/src/navigation/index.ts
+++ b/tui/src/navigation/index.ts
@@ -24,6 +24,8 @@ export {
 
 export { TabBar, type TabBarProps } from './TabBar';
 
+export { Drawer, type DrawerProps } from './Drawer';
+
 export {
   FocusProvider,
   useFocus,


### PR DESCRIPTION
## Summary

- **Change Memory shortcut from 'm' to 'M'** - Resolves key conflict where pressing 'm' in Channels list view navigated to Memory instead of composing a message
- **Add new Drawer component** - 14-character fixed-width left panel for navigation
- **j/k vim-style navigation in drawer** - Navigate through views using vim keybindings
- **Update layout** - Replace horizontal TabBar with drawer + content layout
- **Update help and footer** - Reflect new navigation shortcuts

## Test plan

- [x] All TUI tests pass (2026 pass, 0 fail)
- [x] Lint passes (0 errors)
- [ ] Manual test: Press 'm' in Channels view should compose message (not navigate to Memory)
- [ ] Manual test: Press 'M' anywhere should navigate to Memory view
- [ ] Manual test: j/k navigation in drawer works
- [ ] Manual test: Enter selects highlighted view in drawer

Fixes #1299
Fixes #1300
Closes #1289

🤖 Generated with [Claude Code](https://claude.com/claude-code)