### PR TITLE
fix(tui): Fix 80x24 terminal garbled rendering (#1318)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -168,8 +168,9 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
     detailPaneVisible
   );
 
-  // Shrink drawer when terminal is narrow but not at compact size
-  const drawerShrunk = terminalWidth < MIN_WIDTH_FOR_DETAIL && terminalWidth > 80;
+  // Shrink drawer when terminal is narrow but not at minimal size
+  // #1318: Fix off-by-one: include 80 cols in shrunk mode
+  const drawerShrunk = terminalWidth < MIN_WIDTH_FOR_DETAIL && terminalWidth >= 80;
 
   return (
     <Box flexDirection="column" padding={1} width={terminalWidth} height={terminalHeight}>

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -72,8 +72,10 @@ export function Dashboard({ onNavigate: _onNavigate }: DashboardProps) {
     return <LoadingIndicator message="Loading workspace data..." />;
   }
 
+  // #1318: Don't set explicit width - parent flexGrow handles it
+  // Setting width={terminalWidth} caused overflow when nested inside drawer layout
   return (
-    <Box flexDirection="column" padding={1} width={terminalWidth}>
+    <Box flexDirection="column" padding={1}>
       {/* Header with activity indicator */}
       <Header
         workspaceName={summary.workspaceName}


### PR DESCRIPTION
## Summary
- Fix drawer shrink condition to include 80 cols (>= instead of >)
- Remove explicit width on Dashboard that caused content overflow

## Test plan
- [x] Verify 80x24 terminal shows clean layout
- [x] Verify Dashboard panels render without garbled text
- [x] Verify "By Role:" and distribution labels show correctly
- [x] Run TUI tests (2040 pass, 0 fail)

Fixes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)