### PR TITLE
fix(tui): change Routing shortcut from 'r' to 'R' to avoid refresh conflict

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -231,7 +231,7 @@ function HelpView(): React.ReactElement {
     { type: 'section' as const, title: 'Global', shortcuts: [
       { keys: '1-9, 0, -', desc: 'Switch views' },
       { keys: 'M', desc: 'Memory view' },
-      { keys: 'r', desc: 'Routing view' },
+      { keys: 'R', desc: 'Routing view' },
       { keys: '?', desc: 'Toggle help' },
       { keys: 'ESC', desc: 'Go back / Home' },
       { keys: 'Tab / j', desc: 'Next view' },

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -31,7 +31,7 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: '0', view: 'demons', label: 'Demons', shortLabel: 'Dmn', shortcut: '0' },
   { key: '-', view: 'processes', label: 'Processes', shortLabel: 'Proc', shortcut: '-' },
   { key: 'M', view: 'memory', label: 'Memory', shortLabel: 'Mem', shortcut: 'M' },
-  { key: 'r', view: 'routing', label: 'Routing', shortLabel: 'Rte', shortcut: 'r' },
+  { key: 'R', view: 'routing', label: 'Routing', shortLabel: 'Rte', shortcut: 'R' },
   { key: '?', view: 'help', label: 'Help', shortLabel: '?', shortcut: '?' },
 ];
 


### PR DESCRIPTION
## Summary
- Change Routing view shortcut from lowercase 'r' to uppercase 'R'
- Update help text to reflect new shortcut
- Lowercase 'r' now reserved for view-local refresh (consistent with other views)

## Root Cause
The 'r' key was bound to both:
1. Global: Navigate to Routing view (NavigationContext.tsx)
2. Local: Refresh current view (10+ views)

This caused unpredictable behavior depending on event order.

## Fix
Same pattern as 'm' → 'M' for Memory view:
- Uppercase letter for global view navigation
- Lowercase letter for view-local actions

Fixes #1324

## Test plan
- [x] TUI tests pass (2010 pass)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)