### PR TITLE
fix(tui): Fix 80x24 text corruption in AgentStatsPanel (#1338)

### DIFF
--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -374,17 +374,28 @@ const AgentStatsPanel = memo(function AgentStatsPanel({ stats }: AgentStatsPanel
 
   const roleEntries = Object.entries(stats.byRole);
 
+  // #1338: Truncate role names at narrow widths to prevent text corruption
+  // Max role display: 12 chars + ": " + count (2-3 chars) = ~17 chars per line
+  const MAX_ROLE_LEN = 12;
+
   return (
     <Panel title="Agent Distribution">
       <Box flexDirection="column">
         <Text dimColor>By Role:</Text>
         <Box flexDirection="column" marginTop={1}>
-          {roleEntries.map(([role, count]) => (
-            <Box key={role}>
-              <Text color="cyan">{role}</Text>
-              <Text>: {count}</Text>
-            </Box>
-          ))}
+          {roleEntries.map(([role, count]) => {
+            // Truncate long role names to prevent overflow at narrow widths
+            const displayRole = role.length > MAX_ROLE_LEN
+              ? role.slice(0, MAX_ROLE_LEN - 1) + '…'
+              : role;
+            // #1338: Use single Text with wrap="truncate" to prevent text corruption
+            // Avoid nested Box which causes layout issues at 80x24
+            return (
+              <Text key={role} wrap="truncate">
+                {displayRole}: {count}
+              </Text>
+            );
+          })}
         </Box>
       </Box>
     </Panel>


### PR DESCRIPTION
## Summary
- Fix text corruption in AgentStatsPanel at narrow terminal widths
- Use single Text element per role entry with wrap="truncate"
- Truncate long role names to 12 chars max
- Avoid nested Box layout that caused corruption

## Root Cause
Role entries used nested Box components which caused layout issues at 80x24:
- Text would overflow and merge with adjacent lines
- Example: "tech-lead: 2ger: 1" (merged "tech-lead: 2" + "manager: 1")

## Test plan
- [x] Run TUI tests (2040 pass)
- [x] Verify role entries render cleanly at 80x24
- [x] Verify long role names truncate properly

Fixes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)