### PR TITLE
fix(tui): Force single-column layout at narrow widths (#1318)

### DIFF
--- a/tui/src/navigation/Drawer.tsx
+++ b/tui/src/navigation/Drawer.tsx
@@ -17,8 +17,9 @@ import { useFocus } from './FocusContext';
 
 /** Fixed width for drawer panel */
 const DRAWER_WIDTH = 14;
-/** Shrunk width for narrow terminals */
-const DRAWER_SHRUNK_WIDTH = 10;
+/** Shrunk width for narrow terminals (80-99 cols) */
+/** #1318: Reduced from 10 to 8 to give more space to content at 80x24 */
+const DRAWER_SHRUNK_WIDTH = 8;
 
 export interface DrawerProps {
   /** Title displayed at top of drawer */

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -94,30 +94,25 @@ export function Dashboard({ onNavigate: _onNavigate }: DashboardProps) {
       />
 
       {/* Metrics panels - Optimized for all terminal sizes (Issue #1041, #1184) */}
-      {/* At 80 cols: single column stack to prevent text garbling */}
-      {/* At 81-99 cols: 2-column layout with adjusted widths */}
+      {/* #1318: Force single column at narrow widths (<100 cols) to prevent text garbling */}
+      {/* Available content width = terminalWidth - drawer - padding is too narrow for side-by-side */}
       {!canMultiColumn && (
-        <Box marginTop={1} flexDirection={terminalWidth <= 80 ? 'column' : 'row'} width="100%">
-          {/* Left/Top: System Health + Cost */}
-          <Box flexDirection="column" flexGrow={1} marginRight={terminalWidth > 80 ? 1 : 0}>
-            <SystemHealthPanel
-              working={summary.working}
-              idle={summary.idle}
-              stuck={summary.stuck}
-              errorCount={summary.error}
-              total={summary.total}
-            />
-            <CostPanel
-              totalCostUSD={summary.totalCostUSD}
-              inputTokens={summary.inputTokens}
-              outputTokens={summary.outputTokens}
-            />
-          </Box>
-
-          {/* Right/Bottom: Agent Distribution */}
-          <Box flexDirection="column" width={terminalWidth <= 80 ? '100%' : Math.max(20, Math.floor(terminalWidth * 0.35))}>
-            <AgentStatsPanel stats={agentStats} />
-          </Box>
+        <Box marginTop={1} flexDirection="column" width="100%">
+          {/* System Health + Cost - always stacked at narrow widths */}
+          <SystemHealthPanel
+            working={summary.working}
+            idle={summary.idle}
+            stuck={summary.stuck}
+            errorCount={summary.error}
+            total={summary.total}
+          />
+          <CostPanel
+            totalCostUSD={summary.totalCostUSD}
+            inputTokens={summary.inputTokens}
+            outputTokens={summary.outputTokens}
+          />
+          {/* Agent Distribution */}
+          <AgentStatsPanel stats={agentStats} />
         </Box>
       )}
 


### PR DESCRIPTION
## Summary

Architectural fix for 80x24 rendering issues that persisted after PR #1343.

### Root Cause
At narrow terminals (80-99 cols), the Dashboard was still attempting side-by-side panel layout which caused text overflow. The available content width after drawer + padding was too narrow.

### Changes
1. **Drawer width reduction**: Reduced shrunk drawer from 10 to 8 chars, freeing 2 more columns for content
2. **Force single-column**: Dashboard now uses single-column layout for ALL narrow widths (<100 cols), not just exactly 80 cols

### Before/After
**Before (80 cols):**
- Drawer: 10 chars
- Content: 68 chars (too narrow for side-by-side at 81-99)

**After (80 cols):**
- Drawer: 8 chars
- Content: 70 chars, single-column stacked

## Test plan

- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)
- [x] Tests pass (2040 pass, 0 fail)
- [ ] Manual: Verify 80x24 terminal has no text overlap
- [ ] Manual: Verify 100x30 terminal shows proper multi-column layout

Fixes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)