### PR TITLE
feat(tui): Add futuristic theme and update stuck state colors (#1349)

### DIFF
--- a/tui/src/theme/index.ts
+++ b/tui/src/theme/index.ts
@@ -5,7 +5,7 @@
  * - Auto-detection of terminal dark/light mode
  * - ThemeProvider for React context
  * - useTheme hook for accessing colors
- * - Pre-defined themes: dark, light, matrix, synthwave, high-contrast
+ * - Pre-defined themes: dark, light, matrix, synthwave, high-contrast, futuristic
  */
 
 // Types
@@ -32,6 +32,7 @@ export {
   matrixTheme,
   synthwaveTheme,
   highContrastTheme,
+  futuristicTheme,
   themes,
   getTheme,
   applyOverrides,

--- a/tui/src/theme/themes.ts
+++ b/tui/src/theme/themes.ts
@@ -33,7 +33,7 @@ export const darkTheme: Theme = {
     agentIdle: 'gray',
     agentWorking: 'blue',
     agentDone: 'green',
-    agentStuck: 'red',
+    agentStuck: 'yellow', // Warning color for stuck (#1331, #1349)
     agentError: 'red',
 
     // UI element colors
@@ -76,7 +76,7 @@ export const lightTheme: Theme = {
     agentIdle: 'gray',
     agentWorking: 'blue',
     agentDone: 'green',
-    agentStuck: 'red',
+    agentStuck: 'yellow', // Warning color for stuck (#1331, #1349)
     agentError: 'red',
 
     // UI element colors
@@ -208,7 +208,7 @@ export const highContrastTheme: Theme = {
     agentIdle: 'white',
     agentWorking: 'cyanBright',
     agentDone: 'greenBright',
-    agentStuck: 'yellowBright',
+    agentStuck: 'yellowBright', // Warning color for stuck
     agentError: 'redBright',
 
     // UI element colors
@@ -224,8 +224,53 @@ export const highContrastTheme: Theme = {
   },
 };
 
+/**
+ * Futuristic theme - Modern, clean, professional (#1349)
+ * Inspired by GitHub dark theme with blue accents
+ * Optimized for readability and clear visual hierarchy
+ */
+export const futuristicTheme: Theme = {
+  name: 'futuristic',
+  mode: 'dark',
+  colors: {
+    // Primary colors - blue accent palette
+    primary: 'blueBright',
+    secondary: 'cyan',
+    accent: 'blueBright',
+
+    // Text colors - high contrast
+    text: 'whiteBright',
+    textMuted: 'gray',
+    textInverse: 'black',
+
+    // Status colors - clear hierarchy
+    success: 'greenBright',
+    warning: 'yellow',
+    error: 'redBright',
+    info: 'blueBright',
+
+    // Agent state colors - distinct and accessible
+    agentIdle: 'gray',
+    agentWorking: 'greenBright',
+    agentDone: 'cyanBright',
+    agentStuck: 'yellow', // Warning color for stuck (#1331)
+    agentError: 'redBright',
+
+    // UI element colors - subtle borders, clear focus
+    border: 'gray',
+    borderFocused: 'blueBright',
+    selection: 'blueBright',
+    highlight: 'cyanBright',
+
+    // Component-specific
+    headerTitle: 'blueBright',
+    footerText: 'gray',
+    badge: 'cyanBright',
+  },
+};
+
 /** Available theme names */
-export type ThemeName = 'dark' | 'light' | 'matrix' | 'synthwave' | 'high-contrast';
+export type ThemeName = 'dark' | 'light' | 'matrix' | 'synthwave' | 'high-contrast' | 'futuristic';
 
 /** All available themes */
 export const themes: Record<ThemeName, Theme> = {
@@ -234,6 +279,7 @@ export const themes: Record<ThemeName, Theme> = {
   matrix: matrixTheme,
   synthwave: synthwaveTheme,
   'high-contrast': highContrastTheme,
+  futuristic: futuristicTheme,
 };
 
 /**


### PR DESCRIPTION
## Summary
Implements UX spec #1349 for improved color and theme system.

## Changes

### New Futuristic Theme
A modern, professional theme with blue accents:
- Blue primary/accent colors (blueBright)
- High contrast text (whiteBright)
- Clear visual hierarchy

### Stuck State Color Update
Changed `agentStuck` from red to yellow across all themes:
- **Why**: Better aligns with warning semantics
- **Hierarchy**: working (green) → stuck (yellow) → error (red)
- **Consistency**: Matches StatusBadge update from #1331

### Available Themes
| Theme | Style | Use Case |
|-------|-------|----------|
| dark | Standard dark | Default |
| light | Light background | Light terminals |
| matrix | Green phosphor | Classic terminal |
| synthwave | Neon purple/cyan | Retro-futuristic |
| high-contrast | Bold white/yellow | Accessibility |
| **futuristic** | Blue accent | Modern/professional |

## Test plan
- [x] All TUI tests pass (2040 pass)
- [x] Lint passes
- [x] Theme exports correctly

## Related
- Follows #1331 Agent Hub (stuck indicator update)
- Part of #1349 UX design spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)