### PR TITLE
feat(tui): Dashboard inline summary for scannability (#1346)

### DIFF
--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -1,7 +1,6 @@
 import { memo, useState } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { Panel } from '../components/Panel.js';
-import { MetricCard } from '../components/MetricCard.js';
 import { Footer } from '../components/Footer.js';
 import { LoadingIndicator } from '../components/LoadingIndicator.js';
 import { ErrorDisplay } from '../components/ErrorDisplay.js';
@@ -207,26 +206,39 @@ interface SummaryCardsProps {
 }
 
 /**
- * Memoized summary cards - only re-renders when counts change
- * Wraps to multiple lines on narrow terminals
+ * Memoized summary line - inline format for scannability (#1346)
+ * Shows: ● 5 working · ○ 7 idle · ⚠ 1 stuck
  */
 const SummaryCards = memo(function SummaryCards({
   total,
-  active,
+  active: _active,
   working,
   idle,
   stuck,
   errorCount,
 }: SummaryCardsProps) {
   return (
-    <Box flexWrap="wrap">
-      <MetricCard value={total} label="Total" />
-      <MetricCard value={active} label="Active" color="green" />
-      <MetricCard value={working} label="Working" color="cyan" />
-      <MetricCard value={idle} label="Idle" color="gray" />
-      {stuck > 0 && <MetricCard value={stuck} label="Stuck" color="yellow" />}
+    <Box>
+      <Text>{total} agents</Text>
+      <Text dimColor> · </Text>
+      <Text color="cyan">●</Text>
+      <Text color="cyan"> {working} working</Text>
+      <Text dimColor> · </Text>
+      <Text dimColor>○</Text>
+      <Text dimColor> {idle} idle</Text>
+      {stuck > 0 && (
+        <>
+          <Text dimColor> · </Text>
+          <Text color="yellow">⚠</Text>
+          <Text color="yellow"> {stuck} stuck</Text>
+        </>
+      )}
       {errorCount > 0 && (
-        <MetricCard value={errorCount} label="Error" color="red" />
+        <>
+          <Text dimColor> · </Text>
+          <Text color="red">✕</Text>
+          <Text color="red"> {errorCount} error</Text>
+        </>
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary

Replace Dashboard MetricCards with inline text summary per #1346 Content & Layout Overhaul:

**Before (bordered boxes):**
```
┌───────┐┌────────┐┌─────────┐
│ Total ││ Active ││ Working │
│ 13    ││ 3      ││ 2       │
└───────┘└────────┘└─────────┘
```

**After (inline):**
```
13 agents · ● 5 working · ○ 7 idle · ⚠ 1 stuck
```

### Benefits
- More scannable at a glance
- Saves horizontal space (no borders)
- Visual indicators match drawer style (● ○ ⚠)
- Reduces visual clutter

**Note:** May overlap with PR #1355 - coordinate merge order.

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] Tests pass (2040 pass)
- [ ] Verify inline summary renders correctly

Part of #1346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)