### PR TITLE
fix(tui): Update ResponsiveGrid LayoutMode values

### DIFF
--- a/tui/src/components/ResponsiveGrid.tsx
+++ b/tui/src/components/ResponsiveGrid.tsx
@@ -42,8 +42,8 @@ function calculateColumns(
   maxColumns: number,
   mode: LayoutMode
 ): number {
-  // Force single column on narrow terminals
-  if (mode === 'minimal' || mode === 'compact') {
+  // Force single column on narrow terminals (xs/sm breakpoints)
+  if (mode === 'xs' || mode === 'sm') {
     return 1;
   }
 


### PR DESCRIPTION
## Summary

Quick fix for build break after PR #1354.

PR #1354 changed LayoutMode enum values:
- Before: `'minimal' | 'compact' | 'medium' | 'wide'`
- After: `'xs' | 'sm' | 'md' | 'lg' | 'xl'`

ResponsiveGrid.tsx line 46 still used old values, causing TypeScript error.

## Test plan

- [x] Build passes (`bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)