### PR TITLE
fix(tui): Update ResponsiveGrid to use new LayoutMode values

### DIFF
--- a/tui/src/components/ResponsiveGrid.tsx
+++ b/tui/src/components/ResponsiveGrid.tsx
@@ -35,6 +35,7 @@ export interface ResponsiveGridProps {
 
 /**
  * Calculate optimal column count based on width and constraints
+ * Updated for 5-tier breakpoint system (#1326)
  */
 function calculateColumns(
   width: number,
@@ -42,8 +43,8 @@ function calculateColumns(
   maxColumns: number,
   mode: LayoutMode
 ): number {
-  // Force single column on narrow terminals
-  if (mode === 'minimal' || mode === 'compact') {
+  // Force single column on narrow terminals (XS, SM, MD)
+  if (mode === 'xs' || mode === 'sm' || mode === 'md') {
     return 1;
   }
 


### PR DESCRIPTION
## Summary

**URGENT BUILD FIX** - PR #1354 changed LayoutMode from `'minimal'|'compact'|'medium'|'wide'` to `'xs'|'sm'|'md'|'lg'|'xl'` but ResponsiveGrid.tsx was not updated.

### Error
```
src/components/ResponsiveGrid.tsx(46,7): error TS2367: This comparison appears to be unintentional because the types 'LayoutMode' and '"minimal"' have no overlap.
```

### Fix
```typescript
// Before:
if (mode === 'minimal' || mode === 'compact')

// After:  
if (mode === 'xs' || mode === 'sm' || mode === 'md')
```

## Test plan
- [x] TypeScript build passes
- [x] All responsive layout tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)