### PR TITLE
feat(tui): Apply borderless compact layout to CostsView and AgentsView

### DIFF
--- a/tui/src/components/CostsView.tsx
+++ b/tui/src/components/CostsView.tsx
@@ -1,11 +1,13 @@
 /**
  * CostsView - Cost dashboard component
+ * Issue #1346: Borderless compact layout for 80x24 terminals
  */
 
 import React from 'react';
 import { Box, Text, useStdout } from 'ink';
 import { Panel } from './Panel';
 import { useCosts } from '../hooks';
+import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 
 interface CostsViewProps {
   /** Disable input handling (useful for testing) */
@@ -15,12 +17,14 @@ interface CostsViewProps {
 export function CostsView({ disableInput: _disableInput = false }: CostsViewProps): React.ReactElement {
   const { stdout } = useStdout();
   const terminalWidth = stdout.columns;
+  const { canMultiColumn, isCompact, isMinimal } = useResponsiveLayout();
+  const isNarrow = isCompact || isMinimal;
 
   const { data: costs, loading, error } = useCosts();
 
   if (loading) {
     return (
-      <Box flexDirection="column" width={terminalWidth}>
+      <Box flexDirection="column">
         <Text bold>Costs</Text>
         <Text dimColor>Loading cost data...</Text>
       </Box>
@@ -29,7 +33,7 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
 
   if (error) {
     return (
-      <Box flexDirection="column" width={terminalWidth}>
+      <Box flexDirection="column">
         <Text bold>Costs</Text>
         <Text color="red">Error: {error}</Text>
       </Box>
@@ -38,19 +42,81 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
 
   if (!costs) {
     return (
-      <Box flexDirection="column" width={terminalWidth}>
+      <Box flexDirection="column">
         <Text bold>Costs</Text>
         <Text dimColor>No cost data available</Text>
       </Box>
     );
   }
 
+  // #1346: Compact borderless layout for narrow terminals (<100 cols)
+  if (isNarrow) {
+    const agentEntries = Object.entries(costs.by_agent ?? {})
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 5);
+    const modelEntries = Object.entries(costs.by_model ?? {})
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 3);
+
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text bold>Cost Dashboard</Text>
+
+        {/* Inline Summary */}
+        <Box marginTop={1}>
+          <Text dimColor>Total: </Text>
+          <Text color="yellow" bold>${costs.total_cost.toFixed(4)}</Text>
+          {costs.total_input_tokens > 0 && (
+            <>
+              <Text> · </Text>
+              <Text dimColor>{costs.total_input_tokens.toLocaleString()} in</Text>
+              <Text> / </Text>
+              <Text dimColor>{costs.total_output_tokens.toLocaleString()} out</Text>
+            </>
+          )}
+        </Box>
+
+        {/* Inline By Agent */}
+        {agentEntries.length > 0 && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold dimColor>By Agent:</Text>
+            {agentEntries.map(([agent, cost]) => (
+              <Text key={agent}>
+                <Text color="green">{agent.length > 12 ? agent.slice(0, 11) + '…' : agent}</Text>
+                <Text dimColor>: </Text>
+                <Text>${cost.toFixed(4)}</Text>
+              </Text>
+            ))}
+            {Object.keys(costs.by_agent ?? {}).length > 5 && (
+              <Text dimColor>+{Object.keys(costs.by_agent ?? {}).length - 5} more</Text>
+            )}
+          </Box>
+        )}
+
+        {/* Inline By Model */}
+        {modelEntries.length > 0 && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold dimColor>By Model:</Text>
+            {modelEntries.map(([model, cost]) => (
+              <Text key={model}>
+                <Text color="magenta">{model.length > 15 ? model.slice(0, 14) + '…' : model}</Text>
+                <Text dimColor>: </Text>
+                <Text>${cost.toFixed(4)}</Text>
+              </Text>
+            ))}
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  // Standard bordered Panel layout for wider terminals
   return (
-    <Box flexDirection="column" width={terminalWidth} padding={1}>
+    <Box flexDirection="column" padding={1}>
       <Text bold>Cost Dashboard</Text>
 
       {/* Summary */}
-      <Panel title="Summary" width={terminalWidth - 2}>
+      <Panel title="Summary" width={canMultiColumn ? terminalWidth - 2 : undefined}>
         <Box>
           <Text>Total Cost: </Text>
           <Text color="yellow" bold>${costs.total_cost.toFixed(4)}</Text>
@@ -74,7 +140,7 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
       </Panel>
 
       {/* By Agent */}
-      <Panel title="By Agent" width={terminalWidth - 2}>
+      <Panel title="By Agent" width={canMultiColumn ? terminalWidth - 2 : undefined}>
         {Object.entries(costs.by_agent ?? {}).length === 0 ? (
           <Text dimColor>No agent costs recorded</Text>
         ) : (
@@ -91,7 +157,7 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
       </Panel>
 
       {/* By Model */}
-      <Panel title="By Model" width={terminalWidth - 2}>
+      <Panel title="By Model" width={canMultiColumn ? terminalWidth - 2 : undefined}>
         {Object.entries(costs.by_model ?? {}).length === 0 ? (
           <Text dimColor>No model costs recorded</Text>
         ) : (
@@ -108,7 +174,7 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
 
       {/* By Team */}
       {Object.keys(costs.by_team ?? {}).length > 0 && (
-        <Panel title="By Team" width={terminalWidth - 2}>
+        <Panel title="By Team" width={canMultiColumn ? terminalWidth - 2 : undefined}>
           {Object.entries(costs.by_team ?? {})
             .sort(([, a], [, b]) => b - a)
             .map(([team, cost]) => (

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useAgents } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
+import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 import { Table } from '../components/Table';
 import type { Column } from '../components/Table';
 import { StatusBadge } from '../components/StatusBadge';
@@ -82,6 +83,8 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
   onBack,
 }) => {
   const { data: agents, loading, error, refresh } = useAgents();
+  const { isCompact, isMinimal } = useResponsiveLayout();
+  const isNarrow = isCompact || isMinimal; // #1346: Borderless at <100 cols
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showDetail, setShowDetail] = useState(false);
   const [confirmAction, setConfirmAction] = useState<AgentAction | null>(null);
@@ -299,11 +302,12 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
   ];
 
   // Search mode overlay
+  // #1346: Borderless at narrow widths
   if (searchMode) {
     return (
       <Box flexDirection="column" padding={1}>
         <Text bold>Search Agents</Text>
-        <Box marginTop={1} borderStyle="single" borderColor="cyan" paddingX={1}>
+        <Box marginTop={1} borderStyle={isNarrow ? undefined : 'single'} borderColor="cyan" paddingX={1}>
           <Text color="cyan">{'> '}</Text>
           <Text>{searchQuery}</Text>
           <Text color="cyan">|</Text>
@@ -363,12 +367,12 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
         </Box>
       )}
 
-      {/* Peek output panel (#1331) */}
+      {/* Peek output panel (#1331, #1346: Borderless at <100 cols) */}
       {peekOutput && selectedAgent && (
         <Box
           marginBottom={1}
-          paddingX={1}
-          borderStyle="single"
+          paddingX={isNarrow ? 0 : 1}
+          borderStyle={isNarrow ? undefined : 'single'}
           borderColor="cyan"
           flexDirection="column"
         >
@@ -386,9 +390,9 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
         </Box>
       )}
 
-      {/* Confirmation dialog */}
+      {/* Confirmation dialog (#1346: Borderless at <100 cols) */}
       {confirmAction && selectedAgent && (
-        <Box marginBottom={1} paddingX={1} borderStyle="round" borderColor="yellow">
+        <Box marginBottom={1} paddingX={isNarrow ? 0 : 1} borderStyle={isNarrow ? undefined : 'round'} borderColor="yellow">
           <Text color="yellow">
             {confirmAction === 'start' && `Start agent "${selectedAgent.name}" as ${selectedAgent.role}?`}
             {confirmAction === 'stop' && `Stop agent "${selectedAgent.name}"?`}


### PR DESCRIPTION
## Summary
- Apply borderless compact layout to CostsView for 80x24 terminals (#1346)
- Apply borderless treatment to AgentsView peek panel, confirmation dialog, and search box
- Uses same pattern as Dashboard PR #1355

## Changes
**CostsView.tsx:**
- Import `useResponsiveLayout` hook
- Add `isNarrow` detection (`isCompact || isMinimal`)
- Render inline text summary at <100 cols without Panel borders
- Show bordered Panel layout at >=100 cols
- Truncate agent/model names to prevent text corruption

**AgentsView.tsx:**
- Import `useResponsiveLayout` hook
- Add `isNarrow` detection
- Remove `borderStyle` from peek panel at narrow widths
- Remove `borderStyle` from confirmation dialog at narrow widths
- Remove `borderStyle` from search mode box at narrow widths

## Test plan
- [x] TypeScript builds successfully
- [x] All 2050 TUI tests pass
- [ ] Manual test at 80x24: CostsView shows inline summary without borders
- [ ] Manual test at 80x24: AgentsView peek panel renders without borders
- [ ] Manual test at 120+ cols: Both views show normal bordered panels

Fixes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)