### PR TITLE
fix(tui): Address P1 UX audit issues (#1362)

### DIFF
--- a/tui/src/components/CostsView.tsx
+++ b/tui/src/components/CostsView.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { Box, Text, useStdout } from 'ink';
+import { Box, Text } from 'ink';
 import { Panel } from './Panel';
 import { useCosts } from '../hooks';
 import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
@@ -15,10 +15,9 @@ interface CostsViewProps {
 }
 
 export function CostsView({ disableInput: _disableInput = false }: CostsViewProps): React.ReactElement {
-  const { stdout } = useStdout();
-  const terminalWidth = stdout.columns;
-  const { canMultiColumn, isCompact, isMinimal } = useResponsiveLayout();
-  const isNarrow = isCompact || isMinimal;
+  const { isCompact, isMinimal, isMD } = useResponsiveLayout();
+  // #1365: Extend borderless to 100-120 cols (isMD) to prevent box fragmentation
+  const isNarrow = isCompact || isMinimal || isMD;
 
   const { data: costs, loading, error } = useCosts();
 
@@ -116,7 +115,7 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
       <Text bold>Cost Dashboard</Text>
 
       {/* Summary */}
-      <Panel title="Summary" width={canMultiColumn ? terminalWidth - 2 : undefined}>
+      <Panel title="Summary">
         <Box>
           <Text>Total Cost: </Text>
           <Text color="yellow" bold>${costs.total_cost.toFixed(4)}</Text>
@@ -140,7 +139,7 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
       </Panel>
 
       {/* By Agent */}
-      <Panel title="By Agent" width={canMultiColumn ? terminalWidth - 2 : undefined}>
+      <Panel title="By Agent">
         {Object.entries(costs.by_agent ?? {}).length === 0 ? (
           <Text dimColor>No agent costs recorded</Text>
         ) : (
@@ -157,7 +156,7 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
       </Panel>
 
       {/* By Model */}
-      <Panel title="By Model" width={canMultiColumn ? terminalWidth - 2 : undefined}>
+      <Panel title="By Model">
         {Object.entries(costs.by_model ?? {}).length === 0 ? (
           <Text dimColor>No model costs recorded</Text>
         ) : (
@@ -174,7 +173,7 @@ export function CostsView({ disableInput: _disableInput = false }: CostsViewProp
 
       {/* By Team */}
       {Object.keys(costs.by_team ?? {}).length > 0 && (
-        <Panel title="By Team" width={canMultiColumn ? terminalWidth - 2 : undefined}>
+        <Panel title="By Team">
           {Object.entries(costs.by_team ?? {})
             .sort(([, a], [, b]) => b - a)
             .map(([team, cost]) => (

--- a/tui/src/components/Footer.tsx
+++ b/tui/src/components/Footer.tsx
@@ -30,6 +30,7 @@ export interface FooterProps {
  * Shared component
  *
  * Memoized for performance - Issue #1003 Phase 3 optimization.
+ * Issue #1362: Use flexWrap to prevent truncation of keybindings
  */
 export const Footer = memo(function Footer({ hints }: FooterProps) {
   return (
@@ -41,6 +42,7 @@ export const Footer = memo(function Footer({ hints }: FooterProps) {
       borderRight={false}
       paddingX={1}
       marginTop={1}
+      flexWrap="wrap"
     >
       {hints.map((h) => (
         <KeyHint key={h.key} keyChar={h.key} label={h.label} />

--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -42,11 +42,17 @@ function formatSchedule(schedule: string): string {
 
 /**
  * Format relative time for last/next run
+ * Issue #1362: Fix invalid date calculation (739667d ago bug)
  */
 function formatRelativeTime(timestamp?: string): string {
-  if (!timestamp) return '-';
+  if (!timestamp || timestamp === '0' || timestamp === '') return '-';
   try {
     const date = new Date(timestamp);
+    // Validate the parsed date - NaN check and sanity check for epoch/invalid dates
+    if (isNaN(date.getTime())) return '-';
+    // If date is before year 2000, it's likely invalid (epoch or parse error)
+    if (date.getFullYear() < 2000) return '-';
+
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffMins = Math.floor(Math.abs(diffMs) / 60000);
@@ -59,9 +65,11 @@ function formatRelativeTime(timestamp?: string): string {
     if (diffMins < 1) return 'now';
     if (diffMins < 60) return `${prefix}${String(diffMins)}m${suffix}`;
     if (diffHours < 24) return `${prefix}${String(diffHours)}h${suffix}`;
+    // Cap days at 365 to avoid absurd values
+    if (diffDays > 365) return diffMs < 0 ? '>1y' : '>1y ago';
     return `${prefix}${String(diffDays)}d${suffix}`;
   } catch {
-    return timestamp;
+    return '-';
   }
 }
 


### PR DESCRIPTION
## Summary
Addresses multiple issues from the UX audit at 120x40 (#1362):

- **CostsView (#1365)**: Extend borderless to <140 cols (isMD) to fix box fragmentation at 120x40 - at 120 cols with 14-char drawer, only 104 cols remain for content
- **DemonsView (#1367)**: Fix invalid date calculation (739667d ago bug) - validate timestamps, reject pre-2000 dates, cap at >1y for absurd values  
- **Footer (P2)**: Add flexWrap to prevent keybinding truncation ('j/k]' instead of '[j/k]')

## Test plan
- [x] All 2050 TUI tests passing
- [x] Lint passes
- [ ] Manual test at 120x40 terminal

Fixes #1365, #1367
Partial #1362

🤖 Generated with [Claude Code](https://claude.com/claude-code)