### PR TITLE
fix(tui): Fix Commands text corruption at 120x40 (#1366)

### DIFF
--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -331,19 +331,19 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
         </Box>
       )}
 
-      {/* Command preview */}
+      {/* Command preview - #1366: Slice strings to prevent text corruption at 120x40 */}
       {selectedCommand !== undefined && filteredCommands.length > 0 && !commandOutput && !commandError && !isExecuting && (
         <Box flexDirection="column" marginBottom={1} paddingX={1} borderStyle="single" borderColor="gray">
-          <Text bold color="cyan" wrap="truncate">{selectedCommand.name}</Text>
-          <Text dimColor wrap="truncate">{selectedCommand.description}</Text>
+          <Text bold color="cyan">{selectedCommand.name}</Text>
+          <Text dimColor>{selectedCommand.description.slice(0, 70)}{selectedCommand.description.length > 70 ? '…' : ''}</Text>
           <Box marginTop={1}>
-            <Text dimColor wrap="truncate">Usage: {selectedCommand.usage}</Text>
+            <Text dimColor>Usage: {selectedCommand.usage.slice(0, 60)}{selectedCommand.usage.length > 60 ? '…' : ''}</Text>
           </Box>
           {selectedCommand.flags && (
-            <Text dimColor wrap="truncate">Flags: {selectedCommand.flags.join(', ')}</Text>
+            <Text dimColor>Flags: {selectedCommand.flags.join(', ').slice(0, 60)}</Text>
           )}
           <Box marginTop={1}>
-            <Text dimColor wrap="truncate">
+            <Text dimColor>
               {selectedCommand.readOnly ? '✓ Safe (read-only) - Press Enter to run' : '⚠ Modifying command - use CLI'}
             </Text>
           </Box>
@@ -373,14 +373,19 @@ interface CommandRowProps {
 }
 
 function CommandRow({ command, selected, isFavorite }: CommandRowProps): React.ReactElement {
+  // #1366: Explicit text slicing prevents corruption at 120x40
+  // wrap='truncate' needs width constraints to work properly
+  const displayName = command.name.length > 25 ? command.name.slice(0, 24) + '…' : command.name;
+  const displayDesc = command.description.length > 45 ? command.description.slice(0, 44) + '…' : command.description;
+
   return (
-    <Box marginBottom={1}>
+    <Box marginBottom={1} flexWrap="nowrap">
       <Text color="yellow">{isFavorite ? '★ ' : '  '}</Text>
-      <Text color={selected ? 'cyan' : undefined} bold={selected} wrap="truncate">
+      <Text color={selected ? 'cyan' : undefined} bold={selected}>
         {selected ? '▸ ' : '  '}
-        {command.name}
+        {displayName}
       </Text>
-      <Text dimColor wrap="truncate"> — {command.description}</Text>
+      <Text dimColor> — {displayDesc}</Text>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
Fixes text corruption in Commands view at 120x40 terminal size.

**Root cause:** `wrap='truncate'` without width constraints causes Ink rendering bugs at certain terminal widths, resulting in corrupted text like "workspaceific tool" and "runtool".

**Fix (per ux-01 guidance):**
1. **CommandRow**: Pre-slice name (25 chars) and description (45 chars) with ellipsis, add `flexWrap='nowrap'`
2. **Detail panel**: Pre-slice description (70), usage (60), flags (60) to prevent overflow

## Test plan
- [x] 2050 tests passing
- [ ] Manual test at 120x40 - verify no text corruption in command list or detail panel

Fixes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)