### PR TITLE
fix(tui): add dynamic width + wrap=truncate to Commands panel #1366

### DIFF
--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useStdout } from 'ink';
 import { COMMAND_REGISTRY } from '../types/commands';
 import type { BcCommand } from '../types/commands';
 import { useFocus } from '../navigation/FocusContext';
@@ -66,6 +66,8 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
   const [categoryFilter, setCategoryFilter] = useState('All');
   const { setFocus } = useFocus();
   const { goHome } = useNavigation();
+  const { stdout } = useStdout();
+  const terminalWidth = stdout.columns;
 
   // Favorites state - persisted to disk
   const [favorites, setFavorites] = useState<Set<string>>(() => loadFavorites());
@@ -331,20 +333,20 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
         </Box>
       )}
 
-      {/* Command preview - #1366: Slice strings to prevent text corruption at 120x40 */}
+      {/* Command preview - #1366: Dynamic width constraint + wrap=truncate to prevent text corruption */}
       {selectedCommand !== undefined && filteredCommands.length > 0 && !commandOutput && !commandError && !isExecuting && (
-        <Box flexDirection="column" marginBottom={1} paddingX={1} borderStyle="single" borderColor="gray">
-          <Text bold color="cyan">{selectedCommand.name}</Text>
-          <Text dimColor>{selectedCommand.description.slice(0, 70)}{selectedCommand.description.length > 70 ? '…' : ''}</Text>
+        <Box flexDirection="column" marginBottom={1} paddingX={1} borderStyle="single" borderColor="gray" width={Math.min(terminalWidth - 4, 100)}>
+          <Text bold color="cyan" wrap="truncate">{selectedCommand.name}</Text>
+          <Text dimColor wrap="truncate">{selectedCommand.description}</Text>
           <Box marginTop={1}>
-            <Text dimColor>Usage: {selectedCommand.usage.slice(0, 60)}{selectedCommand.usage.length > 60 ? '…' : ''}</Text>
+            <Text dimColor wrap="truncate">Usage: {selectedCommand.usage}</Text>
           </Box>
           {selectedCommand.flags && (
-            <Text dimColor>Flags: {selectedCommand.flags.join(', ').slice(0, 60)}</Text>
+            <Text dimColor wrap="truncate">Flags: {selectedCommand.flags.join(', ')}</Text>
           )}
           <Box marginTop={1}>
-            <Text dimColor>
-              {selectedCommand.readOnly ? '✓ Safe (read-only) - Press Enter to run' : '⚠ Modifying command - use CLI'}
+            <Text dimColor wrap="truncate">
+              {selectedCommand.readOnly ? '✓ Read-only - Enter to run' : '⚠ Modifying - use CLI'}
             </Text>
           </Box>
         </Box>


### PR DESCRIPTION
## Summary
Follow-up fix for Commands text corruption (character loss) at 120x40.

**Changes:**
- Add `useStdout` to get terminal width dynamically
- Set preview panel `width={Math.min(terminalWidth - 4, 100)}`
- Add `wrap="truncate"` to all Text elements in preview panel
- Remove string slicing (width constraint handles overflow properly)

**Root cause:** Ink rendering bug when text components nearly fill line width without explicit width constraints causes character loss/merging (e.g., 'workspace-specific' → 'workspaceific').

## Test plan
- [x] `bun test ./src/views/__tests__/CommandsView.test.tsx` - 59 pass
- [x] `bun run lint` - 0 errors
- [ ] Manual test at 120x40 - verify no text corruption

Closes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)