### PR TITLE
fix(tui): Add width constraint to Commands detail panel (#1366)

### DIFF
--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useState, useCallback, useEffect } from 'react';
-import { Box, Text, useInput } from 'ink';
+import { Box, Text, useInput, useStdout } from 'ink';
 import { COMMAND_REGISTRY } from '../types/commands';
 import type { BcCommand } from '../types/commands';
 import { useFocus } from '../navigation/FocusContext';
@@ -60,6 +60,8 @@ const CATEGORY_NAMES = ['All', ...COMMAND_REGISTRY.map(cat => cat.name)];
 export const CommandsView: React.FC<CommandsViewProps> = ({
   disableInput = false,
 }) => {
+  const { stdout } = useStdout();
+  const terminalWidth = stdout.columns;
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searchMode, setSearchMode] = useState(false);
@@ -331,19 +333,19 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
         </Box>
       )}
 
-      {/* Command preview - #1366: Slice strings to prevent text corruption at 120x40 */}
+      {/* Command preview - #1366: Width constraint + wrap='truncate' prevents text bleeding */}
       {selectedCommand !== undefined && filteredCommands.length > 0 && !commandOutput && !commandError && !isExecuting && (
-        <Box flexDirection="column" marginBottom={1} paddingX={1} borderStyle="single" borderColor="gray">
-          <Text bold color="cyan">{selectedCommand.name}</Text>
-          <Text dimColor>{selectedCommand.description.slice(0, 70)}{selectedCommand.description.length > 70 ? '…' : ''}</Text>
+        <Box flexDirection="column" marginBottom={1} paddingX={1} borderStyle="single" borderColor="gray" width={Math.min(terminalWidth - 4, 80)}>
+          <Text bold color="cyan" wrap="truncate">{selectedCommand.name}</Text>
+          <Text dimColor wrap="truncate">{selectedCommand.description}</Text>
           <Box marginTop={1}>
-            <Text dimColor>Usage: {selectedCommand.usage.slice(0, 60)}{selectedCommand.usage.length > 60 ? '…' : ''}</Text>
+            <Text dimColor wrap="truncate">Usage: {selectedCommand.usage}</Text>
           </Box>
           {selectedCommand.flags && (
-            <Text dimColor>Flags: {selectedCommand.flags.join(', ').slice(0, 60)}</Text>
+            <Text dimColor wrap="truncate">Flags: {selectedCommand.flags.join(', ')}</Text>
           )}
           <Box marginTop={1}>
-            <Text dimColor>
+            <Text dimColor wrap="truncate">
               {selectedCommand.readOnly ? '✓ Safe (read-only) - Press Enter to run' : '⚠ Modifying command - use CLI'}
             </Text>
           </Box>


### PR DESCRIPTION
## Summary
Follow-up fix for Commands text bleeding/corruption at 120x40.

**Root cause:** `wrap='truncate'` needs explicit width constraint. Without it, Ink renders all text then overflows, causing adjacent Text components to merge ("workspaceific" instead of "workspace-specific").

**Fix:**
- Add `width={Math.min(terminalWidth - 4, 80)}` to detail panel Box
- Add `wrap='truncate'` to all Text elements
- Import `useStdout` for terminal width

## Test plan
- [x] 2045 TUI tests passing (5 flaky tmux integration tests unrelated)
- [ ] Manual test at 120x40 - verify no text corruption

Fixes #1366

🤖 Generated with [Claude Code](https://claude.com/claude-code)