### PR TITLE
fix(tui): Abbreviate log types in LogsView (#1364)

### DIFF
--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -66,6 +66,32 @@ function filterByTime(logs: LogEntry[], timeFilter: TimeFilter): LogEntry[] {
   });
 }
 
+/**
+ * Abbreviate log type for compact display (#1364)
+ * agent.report → report, channel.message → msg, etc.
+ */
+function abbreviateType(type: string): string {
+  // Extract action from type (after last dot)
+  const parts = type.split('.');
+  const action = parts[parts.length - 1];
+
+  // Common abbreviations
+  const abbreviations: Record<string, string> = {
+    'message': 'msg',
+    'report': 'report',
+    'working': 'work',
+    'error': 'error',
+    'warning': 'warn',
+    'stuck': 'stuck',
+    'done': 'done',
+    'idle': 'idle',
+    'starting': 'start',
+    'stopping': 'stop',
+  };
+
+  return abbreviations[action] ?? action;
+}
+
 export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
   const { stdout } = useStdout();
   const terminalWidth = stdout.columns;
@@ -368,7 +394,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
                 backgroundColor={isSelected ? 'blue' : undefined}
                 color={isSelected ? 'white' : severityColor}
               >
-                {severityIcon} {log.type.slice(0, typeWidth - 3).padEnd(typeWidth - 2)}
+                {severityIcon} {abbreviateType(log.type).slice(0, typeWidth - 3).padEnd(typeWidth - 2)}
               </Text>
               <Text
                 backgroundColor={isSelected ? 'blue' : undefined}


### PR DESCRIPTION
## Summary
Fixes log type truncation in LogsView by showing just the action part after the dot.

**Before:** `agent.r` | `agent.rworking:` | `channel.`
**After:** `report` | `work` | `msg`

## Changes
- Add `abbreviateType()` function to extract action from log type
- Map common actions to abbreviations (message→msg, working→work)
- Apply to log table type column

## Test plan
- [x] Lint passes (0 errors)
- [x] Build passes (tsc)
- [x] Tests pass (2045/2050 - same as main)
- [ ] Manual: verify log types are readable at all widths

Fixes #1364 Issue 4 (Logs View Type Truncation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)