### PR TITLE
feat: Add curl installer and Homebrew formula template (#1381)

### DIFF
--- a/scripts/homebrew/bc.rb
+++ b/scripts/homebrew/bc.rb
@@ -1,0 +1,45 @@
+# Homebrew formula for bc
+# To use: brew tap rpuneet/tap && brew install bc
+# Or copy this file to your homebrew-tap repository
+
+class Bc < Formula
+  desc "CLI-first orchestration system for AI agent teams"
+  homepage "https://github.com/rpuneet/bc"
+  version "0.1.0"
+  license "MIT"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/rpuneet/bc/releases/download/v#{version}/bc-darwin-amd64"
+      sha256 "PLACEHOLDER_SHA256_DARWIN_AMD64"
+    end
+
+    on_arm do
+      url "https://github.com/rpuneet/bc/releases/download/v#{version}/bc-darwin-arm64"
+      sha256 "PLACEHOLDER_SHA256_DARWIN_ARM64"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/rpuneet/bc/releases/download/v#{version}/bc-linux-amd64"
+      sha256 "PLACEHOLDER_SHA256_LINUX_AMD64"
+    end
+
+    on_arm do
+      url "https://github.com/rpuneet/bc/releases/download/v#{version}/bc-linux-arm64"
+      sha256 "PLACEHOLDER_SHA256_LINUX_ARM64"
+    end
+  end
+
+  depends_on "tmux"
+
+  def install
+    binary_name = "bc-#{OS.kernel_name.downcase}-#{Hardware::CPU.arch == :arm64 ? "arm64" : "amd64"}"
+    bin.install binary_name => "bc"
+  end
+
+  test do
+    assert_match "bc version", shell_output("#{bin}/bc version")
+  end
+end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# bc installer script
+# Usage: curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash
+
+set -e
+
+# Configuration
+REPO="rpuneet/bc"
+INSTALL_DIR="${BC_INSTALL_DIR:-/usr/local/bin}"
+BINARY_NAME="bc"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Print with arrow prefix
+info() {
+    echo -e "${CYAN}→${NC} $1"
+}
+
+success() {
+    echo -e "${GREEN}✓${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}⚠${NC} $1"
+}
+
+error() {
+    echo -e "${RED}✗${NC} $1"
+    exit 1
+}
+
+# Detect OS and architecture
+detect_platform() {
+    OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    ARCH="$(uname -m)"
+
+    case "$OS" in
+        linux)
+            OS="linux"
+            ;;
+        darwin)
+            OS="darwin"
+            ;;
+        mingw*|msys*|cygwin*)
+            OS="windows"
+            ;;
+        *)
+            error "Unsupported operating system: $OS"
+            ;;
+    esac
+
+    case "$ARCH" in
+        x86_64|amd64)
+            ARCH="amd64"
+            ;;
+        arm64|aarch64)
+            ARCH="arm64"
+            ;;
+        *)
+            error "Unsupported architecture: $ARCH"
+            ;;
+    esac
+
+    PLATFORM="${OS}-${ARCH}"
+    info "Detecting OS... ${OS} ${ARCH}"
+}
+
+# Get latest release version
+get_latest_version() {
+    info "Fetching latest version..."
+    VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+
+    if [ -z "$VERSION" ]; then
+        error "Failed to fetch latest version. Check your network connection."
+    fi
+
+    info "Latest version: ${VERSION}"
+}
+
+# Download and install binary
+download_and_install() {
+    BINARY_SUFFIX=""
+    if [ "$OS" = "windows" ]; then
+        BINARY_SUFFIX=".exe"
+    fi
+
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/bc-${PLATFORM}${BINARY_SUFFIX}"
+    TMP_DIR=$(mktemp -d)
+    TMP_FILE="${TMP_DIR}/bc${BINARY_SUFFIX}"
+
+    info "Downloading bc ${VERSION}..."
+
+    if ! curl -fsSL "$DOWNLOAD_URL" -o "$TMP_FILE"; then
+        rm -rf "$TMP_DIR"
+        error "Failed to download bc. Check if release exists for ${PLATFORM}."
+    fi
+
+    chmod +x "$TMP_FILE"
+
+    info "Installing to ${INSTALL_DIR}..."
+
+    # Check if we need sudo
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "$TMP_FILE" "${INSTALL_DIR}/${BINARY_NAME}"
+    else
+        warn "Need elevated permissions to install to ${INSTALL_DIR}"
+        sudo mv "$TMP_FILE" "${INSTALL_DIR}/${BINARY_NAME}"
+    fi
+
+    rm -rf "$TMP_DIR"
+}
+
+# Verify installation
+verify_installation() {
+    info "Verifying installation..."
+
+    if ! command -v bc &> /dev/null; then
+        # bc might not be in PATH yet
+        if [ -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then
+            success "bc installed successfully!"
+            echo ""
+            echo "Add ${INSTALL_DIR} to your PATH if not already:"
+            echo "  export PATH=\"\$PATH:${INSTALL_DIR}\""
+        else
+            error "Installation failed. Binary not found."
+        fi
+    else
+        success "bc installed successfully!"
+    fi
+}
+
+# Check dependencies
+check_dependencies() {
+    if ! command -v tmux &> /dev/null; then
+        warn "tmux is not installed (required for bc agents)"
+        echo ""
+        case "$OS" in
+            darwin)
+                echo "  Install with: brew install tmux"
+                ;;
+            linux)
+                echo "  Install with: apt install tmux  # or your package manager"
+                ;;
+        esac
+        echo ""
+    fi
+}
+
+# Print next steps
+print_next_steps() {
+    echo ""
+    echo "Run 'bc' to get started."
+    echo ""
+    echo "Quick start:"
+    echo "  bc init       # Initialize a new workspace"
+    echo "  bc up         # Start the root agent"
+    echo "  bc home       # Open the TUI dashboard"
+    echo ""
+    echo "Documentation: https://github.com/${REPO}#readme"
+}
+
+# Main
+main() {
+    echo ""
+    echo "bc Installer"
+    echo "============"
+    echo ""
+
+    detect_platform
+    get_latest_version
+    download_and_install
+    verify_installation
+    check_dependencies
+    print_next_steps
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- **scripts/install.sh**: Cross-platform curl installer
  - Detects OS/arch (darwin, linux, windows + amd64, arm64)
  - Downloads from GitHub releases
  - Handles sudo elevation for /usr/local/bin
  - Checks for tmux dependency
  - Colorful output with progress indicators (per ux-01 spec)

- **scripts/homebrew/bc.rb**: Homebrew formula template
  - Multi-platform support (darwin + linux, amd64 + arm64)
  - SHA256 placeholders (fill in after first release)
  - Depends on tmux

## Usage

```bash
# Curl installer (after first release)
curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash
```

## Installer Output (per UX spec)

```
bc Installer
============

→ Detecting OS... darwin arm64
→ Fetching latest version...
→ Latest version: v0.1.0
→ Downloading bc v0.1.0...
→ Installing to /usr/local/bin...
→ Verifying installation...
✓ bc installed successfully!

Run 'bc' to get started.
```

## Test plan

- [ ] Verify install.sh syntax passes `bash -n`
- [ ] Test installer on macOS (darwin-arm64)
- [ ] Test installer on Linux (linux-amd64)
- [ ] Verify Homebrew formula syntax

## Notes

- Release workflow already exists in ci.yml
- SHA256 values in Homebrew formula are placeholders
- Homebrew tap repo setup is separate infrastructure task

Fixes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)