### PR TITLE
fix(tui): Normalize agent status verbs (#1364 Issue 3)

### DIFF
--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -94,13 +94,16 @@ function groupAgentsByRole(agents: Agent[]): RoleGroup[] {
  */
 function normalizeTask(task: string | undefined): string {
   if (!task) return '-';
+  // #1364 Issue 3: Normalize cooking/quirky terms to clear status verbs
   const replacements: [string, string][] = [
     ['Sautéed', 'Working'],
     ['Sauteed', 'Working'], // ASCII fallback
+    ['Brewed', 'Done'],
     ['Cooked', 'Processed'],
     ['Cogitated', 'Thinking'],
     ['Marinated', 'Idle'],
     ['Frolicking', 'Active'],
+    ['Grooving', 'Active'],
   ];
   for (const [old, replacement] of replacements) {
     if (task.includes(old)) {


### PR DESCRIPTION
## Summary
Add missing cooking term replacements to `normalizeTask()` in AgentsView.

## Changes
- 'Brewed' → 'Done'
- 'Grooving' → 'Active'

## Context
Claude Code uses quirky cooking-themed status verbs. This normalizes them to standard terms for clarity.

Existing mappings preserved:
- 'Sautéed'/'Sauteed' → 'Working'
- 'Cooked' → 'Processed'
- 'Cogitated' → 'Thinking'
- 'Marinated' → 'Idle'
- 'Frolicking' → 'Active'

## Test plan
- [x] TypeScript builds
- [x] All 2050 tests pass

Fixes #1364 Issue 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)