### PR TITLE
fix(tui): Remove unnecessary nullish coalescing in ActivityFeed

### DIFF
--- a/tui/src/components/ActivityFeed.tsx
+++ b/tui/src/components/ActivityFeed.tsx
@@ -222,7 +222,7 @@ const ActivityEntry = memo(function ActivityEntry({
   const maxMsgLen = Math.max(MIN_MSG_WIDTH, availableWidth);
 
   // Shorten paths in message (#1368)
-  const displayMessage = shortenPath(entry.message ?? '');
+  const displayMessage = shortenPath(entry.message);
 
   return (
     <Box>


### PR DESCRIPTION
## Summary

Fix ESLint error in ActivityFeed.tsx:
- Remove `?? ''` from `entry.message` since LogEntry.message is typed as `string` (not optional)
- Fixes @typescript-eslint/no-unnecessary-condition lint error

## Context

This was introduced in PR #1386 (ActivityFeed path shortening). TypeScript knows `message` can never be null/undefined based on the type definition.

## Test plan

- [x] ESLint passes (0 errors)
- [x] All 2050 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)