### PR TITLE
docs: Add shell completion documentation (#1393)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ make build
 make install
 ```
 
+### Shell Completions
+
+Enable tab completion for bc commands, agent names, and channel names:
+
+```bash
+# Bash
+bc completion bash > /etc/bash_completion.d/bc
+# or on macOS with Homebrew:
+bc completion bash > $(brew --prefix)/etc/bash_completion.d/bc
+
+# Zsh (add to fpath)
+bc completion zsh > "${fpath[1]}/_bc"
+# or for Oh My Zsh:
+bc completion zsh > ~/.oh-my-zsh/completions/_bc
+
+# Fish
+bc completion fish > ~/.config/fish/completions/bc.fish
+```
+
 ## Quick Start
 
 ```bash

--- a/scripts/homebrew/bc.rb
+++ b/scripts/homebrew/bc.rb
@@ -37,6 +37,27 @@ class Bc < Formula
   def install
     binary_name = "bc-#{OS.kernel_name.downcase}-#{Hardware::CPU.arch == :arm64 ? "arm64" : "amd64"}"
     bin.install binary_name => "bc"
+
+    # Generate and install shell completions
+    generate_completions_from_executable(bin/"bc", "completion")
+  end
+
+  def caveats
+    <<~EOS
+      Shell completions have been installed.
+
+      To enable completions, you may need to:
+
+      Bash:
+        Add to ~/.bash_profile:
+          [[ -r "$(brew --prefix)/etc/profile.d/bash_completion.sh" ]] && . "$(brew --prefix)/etc/profile.d/bash_completion.sh"
+
+      Zsh:
+        Completions are installed to #{HOMEBREW_PREFIX}/share/zsh/site-functions
+
+      Fish:
+        Completions are installed to #{HOMEBREW_PREFIX}/share/fish/vendor_completions.d
+    EOS
   end
 
   test do


### PR DESCRIPTION
## Summary

The `bc completion` command already exists with dynamic completions for agent names, channel names, and role names. This PR adds the missing documentation:

- **README.md**: Add shell completion section with bash/zsh/fish examples
- **Homebrew formula**: Auto-generate completions on install with caveats

## Features Already Implemented

- `bc completion bash|zsh|fish|powershell` command
- Dynamic agent name completion for `bc agent send <TAB>`
- Dynamic channel name completion for `bc channel send <TAB>`
- Dynamic role name completion for `bc role show <TAB>`

## Changes

### README addition
```bash
# Bash
bc completion bash > /etc/bash_completion.d/bc

# Zsh
bc completion zsh > "${fpath[1]}/_bc"

# Fish
bc completion fish > ~/.config/fish/completions/bc.fish
```

### Homebrew formula
- `generate_completions_from_executable` for auto-install
- Caveats with shell-specific setup instructions

## Test plan

- [x] Verify `bc completion bash` outputs valid script
- [ ] Verify README renders correctly
- [ ] Verify Homebrew formula syntax

Fixes #1393

🤖 Generated with [Claude Code](https://claude.com/claude-code)