### PR TITLE
fix(tui): wire DetailPane selection for Channels and Agents views (#1418)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -228,15 +228,14 @@ interface ViewContentProps {
 }
 
 // Main content router
-// Note: _onSelectItem callback will be wired up per-view in future iterations
-function ViewContent({ view, disableInput, onSelectItem: _onSelectItem }: ViewContentProps): React.ReactElement {
+function ViewContent({ view, disableInput, onSelectItem }: ViewContentProps): React.ReactElement {
   switch (view) {
     case 'dashboard':
       return <Dashboard />;
     case 'agents':
-      return <AgentsView />;
+      return <AgentsView onSelectItem={onSelectItem} />;
     case 'channels':
-      return <ChannelsView disableInput={disableInput} />;
+      return <ChannelsView disableInput={disableInput} onSelectItem={onSelectItem} />;
     case 'costs':
       return <CostsView disableInput={disableInput} />;
     case 'commands':

--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -28,18 +28,47 @@ function calculateInputHeight(messageLength: number, terminalWidth: number): num
   return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, lines));
 }
 
+/** Detail item for DetailPane integration */
+interface DetailItem {
+  title: string;
+  type: string;
+  fields: { label: string; value: string; color?: string }[];
+  description?: string;
+}
+
 interface ChannelsViewProps {
   /** Disable input handling (useful for testing) */
   disableInput?: boolean;
+  /** Callback when selection changes (for DetailPane) */
+  onSelectItem?: (item: DetailItem | null) => void;
 }
 
-export function ChannelsView({ disableInput = false }: ChannelsViewProps): React.ReactElement {
+export function ChannelsView({ disableInput = false, onSelectItem }: ChannelsViewProps): React.ReactElement {
   // #1129: Use useChannelsWithUnread for proper unread message tracking
   const { channels, loading: channelsLoading, error: channelsError } = useChannelsWithUnread();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [viewMode, setViewMode] = useState<'list' | 'history'>('list');
   const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
   const { setFocus } = useFocus();
+
+  // #1418: Update detail pane when selection changes
+  useEffect(() => {
+    const channel = channels?.[selectedIndex];
+    if (channel && viewMode === 'list' && onSelectItem) {
+      onSelectItem({
+        title: `#${channel.name}`,
+        type: 'channel',
+        fields: [
+          { label: 'Members', value: String(channel.members.length), color: 'cyan' },
+          { label: 'Unread', value: channel.unread > 0 ? String(channel.unread) : 'None', color: channel.unread > 0 ? 'yellow' : undefined },
+        ],
+        description: channel.description ?? 'No description',
+      });
+    } else if (onSelectItem && viewMode === 'history') {
+      // Clear detail when viewing history (channel shown in header)
+      onSelectItem(null);
+    }
+  }, [channels, selectedIndex, viewMode, onSelectItem]);
 
   // Update breadcrumbs and focus when view mode changes
   useEffect(() => {

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -11,8 +11,18 @@ import { AgentDetailView } from './AgentDetailView';
 import { execBc } from '../services/bc';
 import type { Agent } from '../types';
 
+/** Detail item for DetailPane integration */
+interface DetailItem {
+  title: string;
+  type: string;
+  fields: { label: string; value: string; color?: string }[];
+  description?: string;
+}
+
 interface AgentsViewProps {
   onBack?: () => void;
+  /** Callback when selection changes (for DetailPane) */
+  onSelectItem?: (item: DetailItem | null) => void;
 }
 
 /** Action feedback display duration in ms */
@@ -140,6 +150,7 @@ interface ActionState {
 
 export const AgentsView: React.FC<AgentsViewProps> = ({
   onBack,
+  onSelectItem,
 }) => {
   const { data: agents, loading, error, refresh } = useAgents();
   const { isCompact, isMinimal } = useResponsiveLayout();
@@ -219,6 +230,25 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
       setFocus('main');
     }
   }, [showDetail, setFocus]);
+
+  // #1418: Update detail pane when selection changes
+  useEffect(() => {
+    if (selectedAgent && !showDetail && onSelectItem) {
+      onSelectItem({
+        title: selectedAgent.name,
+        type: 'agent',
+        fields: [
+          { label: 'Status', value: selectedAgent.state, color: selectedAgent.state === 'working' ? 'green' : selectedAgent.state === 'stuck' ? 'red' : selectedAgent.state === 'idle' ? 'yellow' : undefined },
+          { label: 'Role', value: selectedAgent.role, color: 'cyan' },
+          { label: 'Task', value: normalizeTask(selectedAgent.task) },
+        ],
+        description: selectedAgent.worktree_dir ? `Worktree: ${selectedAgent.worktree_dir}` : undefined,
+      });
+    } else if (onSelectItem && (showDetail || !selectedAgent)) {
+      // Clear detail when viewing agent detail (info shown in detail view)
+      onSelectItem(null);
+    }
+  }, [selectedAgent, showDetail, onSelectItem]);
 
   // Clear action feedback after delay
   const showActionFeedback = useCallback((action: AgentAction, target: string, status: 'success' | 'error', message: string) => {


### PR DESCRIPTION
## Summary
- Pass `onSelectItem` callback from `ViewContent` to child views (AgentsView, ChannelsView)
- ChannelsView: Populate `DetailItem` on channel selection with members count, unread status
- AgentsView: Populate `DetailItem` on agent selection with status, role, task, worktree
- 'i' toggle now shows populated detail pane on terminals >= 120 cols

## Root Cause
`app.tsx:232` - ViewContent received `onSelectItem` but renamed it to `_onSelectItem` and never passed to child views.

## Changes
- `app.tsx`: Wire `onSelectItem` to AgentsView and ChannelsView
- `ChannelsView.tsx`: Accept `onSelectItem` prop, call on selection change
- `AgentsView.tsx`: Accept `onSelectItem` prop, call on selection change

## Test Plan
- [x] Build passes (`bun run build`)
- [x] All 2050 tests pass (`bun test`)
- [x] Lint passes (`bun run lint`)
- [ ] Manual test: Run `bc home`, navigate to Channels, press 'i' to toggle detail pane

Fixes #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)