### PR TITLE
fix(tui): Wire onSelectItem to ChannelsView and AgentsView (#1418)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -228,15 +228,14 @@ interface ViewContentProps {
 }
 
 // Main content router
-// Note: _onSelectItem callback will be wired up per-view in future iterations
-function ViewContent({ view, disableInput, onSelectItem: _onSelectItem }: ViewContentProps): React.ReactElement {
+function ViewContent({ view, disableInput, onSelectItem }: ViewContentProps): React.ReactElement {
   switch (view) {
     case 'dashboard':
       return <Dashboard />;
     case 'agents':
-      return <AgentsView />;
+      return <AgentsView onSelectItem={onSelectItem} />;
     case 'channels':
-      return <ChannelsView disableInput={disableInput} />;
+      return <ChannelsView disableInput={disableInput} onSelectItem={onSelectItem} />;
     case 'costs':
       return <CostsView disableInput={disableInput} />;
     case 'commands':

--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -10,6 +10,7 @@ import { useNavigation } from '../navigation/NavigationContext';
 import { PulseText } from './AnimatedText';
 import { ChatMessage } from './ChatMessage';
 import { MentionAutocomplete } from './MentionAutocomplete';
+import type { DetailItem } from './DetailPane';
 import type { Channel } from '../types';
 
 /** Duration in ms to show send errors before auto-clearing */
@@ -31,9 +32,11 @@ function calculateInputHeight(messageLength: number, terminalWidth: number): num
 interface ChannelsViewProps {
   /** Disable input handling (useful for testing) */
   disableInput?: boolean;
+  /** Callback when channel selection changes (#1418) */
+  onSelectItem?: (item: DetailItem | null) => void;
 }
 
-export function ChannelsView({ disableInput = false }: ChannelsViewProps): React.ReactElement {
+export function ChannelsView({ disableInput = false, onSelectItem }: ChannelsViewProps): React.ReactElement {
   // #1129: Use useChannelsWithUnread for proper unread message tracking
   const { channels, loading: channelsLoading, error: channelsError } = useChannelsWithUnread();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -53,6 +56,29 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
       setFocus('main');
     }
   }, [viewMode, channels, selectedIndex, setBreadcrumbs, clearBreadcrumbs, setFocus]);
+
+  // #1418: Update DetailPane when channel selection changes
+  useEffect(() => {
+    if (viewMode !== 'list') {
+      // Don't update detail when in history view
+      onSelectItem?.(null);
+      return;
+    }
+    const channel = channels?.[selectedIndex];
+    if (channel) {
+      onSelectItem?.({
+        title: `#${channel.name}`,
+        type: 'channel',
+        description: channel.description,
+        fields: [
+          { label: 'Members', value: String(channel.members.length) },
+          { label: 'Unread', value: String(channel.unread || 0), color: channel.unread ? 'yellow' : undefined },
+        ],
+      });
+    } else {
+      onSelectItem?.(null);
+    }
+  }, [selectedIndex, channels, viewMode, onSelectItem]);
 
   // Track if we should start in compose mode when entering history view
   const [startCompose, setStartCompose] = useState(false);

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -10,9 +10,12 @@ import { PulseText } from '../components/AnimatedText';
 import { AgentDetailView } from './AgentDetailView';
 import { execBc } from '../services/bc';
 import type { Agent } from '../types';
+import type { DetailItem } from '../components/DetailPane';
 
 interface AgentsViewProps {
   onBack?: () => void;
+  /** Callback when agent selection changes (#1418) */
+  onSelectItem?: (item: DetailItem | null) => void;
 }
 
 /** Action feedback display duration in ms */
@@ -140,6 +143,7 @@ interface ActionState {
 
 export const AgentsView: React.FC<AgentsViewProps> = ({
   onBack,
+  onSelectItem,
 }) => {
   const { data: agents, loading, error, refresh } = useAgents();
   const { isCompact, isMinimal } = useResponsiveLayout();
@@ -207,6 +211,28 @@ export const AgentsView: React.FC<AgentsViewProps> = ({
     return undefined;
   }, [visibleItems, selectedIndex]);
   const { setFocus } = useFocus();
+
+  // #1418: Update DetailPane when agent selection changes
+  useEffect(() => {
+    if (showDetail) {
+      // Don't update detail when in detail view
+      onSelectItem?.(null);
+      return;
+    }
+    if (selectedAgent) {
+      onSelectItem?.({
+        title: selectedAgent.name,
+        type: 'agent',
+        fields: [
+          { label: 'Role', value: selectedAgent.role },
+          { label: 'Status', value: selectedAgent.state, color: selectedAgent.state === 'working' ? 'green' : selectedAgent.state === 'error' ? 'red' : undefined },
+          { label: 'Task', value: selectedAgent.task || '-' },
+        ],
+      });
+    } else {
+      onSelectItem?.(null);
+    }
+  }, [selectedAgent, showDetail, onSelectItem]);
 
   // Manage focus state for nested view navigation
   // When showing detail view, set focus='view' to prevent global ESC from firing


### PR DESCRIPTION
## P1 Fix - DetailPane Empty

**Root Cause:** `onSelectItem` callback was not passed from ViewContent to child views.

## Changes

1. **app.tsx**: Pass `onSelectItem` to ChannelsView and AgentsView (removed `_` prefix)
2. **ChannelsView**: Accept `onSelectItem` prop, call on selection change with channel details
3. **AgentsView**: Accept `onSelectItem` prop, call on selection change with agent details

## DetailPane Now Shows

**For Channels:**
- Title: `#channel-name`
- Members count
- Unread count (highlighted if > 0)

**For Agents:**
- Title: agent name
- Role
- Status (color-coded)
- Current task

## Test Plan

- [x] Lint passes (0 errors)
- [x] All 2050 tests pass
- [ ] Manual test: Navigate to Channels, verify detail pane shows channel info
- [ ] Manual test: Navigate to Agents, verify detail pane shows agent info
- [ ] Manual test: Press 'i' to toggle detail pane visibility

Fixes #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)