### PR TITLE
docs: Add GitHub Pages documentation site (#1416)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material pymdown-extensions
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,50 @@
+# bc Documentation
+
+Welcome to the bc documentation. **bc** is a CLI-first orchestration system for coordinating teams of AI agents in software development.
+
+## What is bc?
+
+bc enables you to:
+
+- **Orchestrate AI agents** - Manage teams of Claude Code, Cursor, or other AI assistants
+- **Coordinate work** - Assign tasks, track progress, communicate between agents
+- **Isolate workspaces** - Each agent gets its own git worktree for parallel development
+- **Track costs** - Monitor API usage and set budgets per agent or team
+
+## Quick Start
+
+```bash
+# Initialize a bc workspace
+bc init
+
+# Start the AI agent team
+bc up
+
+# View the dashboard
+bc home
+
+# Check status
+bc status
+```
+
+## Philosophy
+
+- **CLI-First**: Every feature is scriptable via the command line
+- **Agent Agnostic**: Works with Claude Code, Cursor, Codex, Gemini, or any terminal AI
+- **Organic Growth**: Start with one agent, grow conversationally
+- **Persistent Memory**: Agents learn and accumulate knowledge
+- **Isolated Workspaces**: Each agent gets its own git worktree
+
+## Documentation Overview
+
+| Section | Description |
+|---------|-------------|
+| [Quick Start](QUICKSTART.md) | 5-minute setup guide |
+| [Commands Reference](COMMANDS.md) | Complete CLI reference |
+| [Architecture](ARCHITECTURE.md) | System design and data flow |
+| [Troubleshooting](TROUBLESHOOTING.md) | Common issues and solutions |
+
+## Support
+
+- **GitHub Issues**: [rpuneet/bc/issues](https://github.com/rpuneet/bc/issues)
+- **Source Code**: [rpuneet/bc](https://github.com/rpuneet/bc)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,88 @@
+site_name: bc Documentation
+site_description: Multi-agent AI orchestration CLI
+site_author: bc contributors
+site_url: https://rpuneet.github.io/bc
+
+repo_name: rpuneet/bc
+repo_url: https://github.com/rpuneet/bc
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Quick Start: QUICKSTART.md
+    - Commands: COMMANDS.md
+    - Troubleshooting: TROUBLESHOOTING.md
+  - Concepts:
+    - Architecture: ARCHITECTURE.md
+    - Diagrams: architecture/README.md
+    - Roles & Responsibilities: roles-responsibilities.md
+    - Memory System: memory-system.md
+    - Channel Conventions: channel-conventions.md
+    - Hierarchical Agents: hierarchical-agents.md
+  - Integrations:
+    - MCP Integration: MCP.md
+    - Plugins: PLUGINS.md
+  - RFCs:
+    - RFC 001 - Plugin Ecosystem: rfcs/001-plugin-ecosystem.md
+    - RFC 002a - File Explorer: rfcs/002-file-explorer.md
+    - RFC 002b - LSP Integration: rfcs/002-lsp-integration.md
+    - RFC 003 - Message Passing: rfcs/003-message-passing-orchestration.md
+  - Development:
+    - Competitive Analysis: COMPETITIVE.md
+    - Enhancements: ENHANCEMENTS.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/rpuneet/bc


### PR DESCRIPTION
## Summary
- Add MkDocs Material configuration for documentation site
- Add GitHub Actions workflow for automatic deployment to GitHub Pages
- Add docs/index.md as site home page
- Configure navigation for all existing docs and RFCs

## Setup
- **Theme**: Material for MkDocs with dark/light mode toggle
- **Features**: Search, code copy, edit on GitHub, Mermaid diagrams
- **Navigation**: Organized by Getting Started, Concepts, Integrations, RFCs

## Files Added
- `mkdocs.yml` - MkDocs configuration
- `docs/index.md` - Site home page
- `.github/workflows/docs.yml` - Auto-deployment workflow

## Test Plan
- [x] mkdocs.yml valid YAML
- [x] Navigation matches existing docs structure
- [ ] Manual: After merge, verify site at https://rpuneet.github.io/bc

## Next Steps (after merge)
1. Enable GitHub Pages in repo settings (Source: GitHub Actions)
2. Verify deployment at https://rpuneet.github.io/bc

Fixes #1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)