### PR TITLE
fix(tui): Ensure React re-renders when agent task changes (#1427)

### DIFF
--- a/tui/src/hooks/useAgents.ts
+++ b/tui/src/hooks/useAgents.ts
@@ -66,19 +66,23 @@ export function useAgents(options: UseAgentsOptions = {}): UseAgentsResult {
    * Apply debounce to working→idle transitions.
    * If an agent just transitioned from working to idle within the debounce period,
    * keep showing "working" to prevent flickering.
+   *
+   * #1427: Always return new objects to ensure React detects state changes
+   * (e.g., task field updates while state remains 'working')
    */
   const applyStateDebounce = useCallback((agents: Agent[]): Agent[] => {
     const now = Date.now();
 
     return agents.map((agent) => {
       const prevState = prevStateRef.current[agent.name];
-      const lastWorkingTime = lastWorkingTimeRef.current[agent.name] || 0;
+      const lastWorkingTime = lastWorkingTimeRef.current[agent.name] ?? 0;
 
       // Update tracking: record when agent was last "working"
       if (agent.state === 'working') {
         lastWorkingTimeRef.current[agent.name] = now;
         prevStateRef.current[agent.name] = agent.state;
-        return agent;
+        // #1427: Always return a new object to trigger React re-render
+        return { ...agent };
       }
 
       // Detect working→idle transition
@@ -93,7 +97,8 @@ export function useAgents(options: UseAgentsOptions = {}): UseAgentsResult {
 
       // Update previous state tracking
       prevStateRef.current[agent.name] = agent.state;
-      return agent;
+      // #1427: Always return a new object to trigger React re-render
+      return { ...agent };
     });
   }, []);
 


### PR DESCRIPTION
## Summary
P1 fix: Agent status not updating when agent continues working.

## Root Cause
The `applyStateDebounce` function in `useAgents` hook was returning the same agent object references when state didn't change. React uses shallow comparison, so when only the `task` field changed (but not `state`), React didn't detect the update and didn't re-render.

## Fix
Always spread agent objects to create new references:
```typescript
// Before: returned same object
return agent;

// After: always create new object
return { ...agent };
```

This ensures React's shallow comparison triggers re-renders when ANY field changes, not just when state changes.

## Test Plan
- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)
- [ ] Manual test: Start agent, watch status/task updates in real-time

Fixes #1427

🤖 Generated with [Claude Code](https://claude.com/claude-code)