### PR TITLE
fix(tui): anchor channel messages above input field (#1425)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -409,7 +409,7 @@ function ChannelHistoryView({
   const hasMoreBelow = messages && messages.length > maxMessages && scrollOffset < messages.length - maxMessages;
 
   return (
-    <Box flexDirection="column" width="100%" height="100%">
+    <Box flexDirection="column" width="100%">
       {/* Header section - fixed height */}
       <Box flexDirection="column" height={3} marginBottom={1}>
         <Box>
@@ -419,11 +419,13 @@ function ChannelHistoryView({
         <Text dimColor>ESC: back  m: compose  ↑/↓ or j/k: scroll</Text>
       </Box>
 
-      {/* Message area - dynamic height adjusts as input expands */}
+      {/* Message area - fills available space, messages anchor to bottom */}
+      {/* #1425: flexGrow={1} fills space, justifyContent="flex-end" anchors messages above input */}
       <Box
         marginBottom={1}
         flexDirection="column"
-        height={messageAreaHeight}
+        justifyContent="flex-end"
+        flexGrow={1}
         borderStyle="single"
         borderColor="gray"
         paddingX={1}


### PR DESCRIPTION
## Summary
- Remove `height="100%"` from outer Box (was causing overflow)
- Use `flexGrow={1}` for message area to fill available space
- Add `justifyContent="flex-end"` to anchor messages at bottom
- Messages now appear directly above input field as expected

## Root Cause
The outer Box had `height="100%"` which combined with fixed heights for header, input, and footer was causing the message area to overflow. Additionally, messages were rendering from top-down instead of bottom-up.

## Fix
1. Removed `height="100%"` from container
2. Changed message area from fixed `height={messageAreaHeight}` to `flexGrow={1}` 
3. Added `justifyContent="flex-end"` to stack messages at bottom

## Test Plan
- [x] Build passes
- [ ] Manual test at 80x24 terminal
- [ ] Manual test at 120x40 terminal
- [x] Verify messages appear above input field

Fixes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)