### PR TITLE
feat(tui): Wire DetailPane to CostsView, LogsView, DemonsView, ProcessesView (#1419)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -240,21 +240,21 @@ function ViewContent({ view, disableInput, onSelectItem }: ViewContentProps): Re
     case 'files':
       return <FilesView />;
     case 'costs':
-      return <CostsView disableInput={disableInput} />;
+      return <CostsView disableInput={disableInput} onSelectItem={onSelectItem} />;
     case 'commands':
       return <CommandsView disableInput={disableInput} />;
     case 'roles':
       return <RolesView disableInput={disableInput} />;
     case 'logs':
-      return <LogsView />;
+      return <LogsView onSelectItem={onSelectItem} />;
     case 'worktrees':
       return <WorktreesView />;
     case 'workspaces':
       return <WorkspaceSelectorView />;
     case 'demons':
-      return <DemonsView disableInput={disableInput} />;
+      return <DemonsView disableInput={disableInput} onSelectItem={onSelectItem} />;
     case 'processes':
-      return <ProcessesView />;
+      return <ProcessesView onSelectItem={onSelectItem} />;
     case 'memory':
       return <MemoryView disableInput={disableInput} />;
     case 'routing':

--- a/tui/src/components/CostsView.tsx
+++ b/tui/src/components/CostsView.tsx
@@ -1,25 +1,59 @@
 /**
  * CostsView - Cost dashboard component
  * Issue #1346: Borderless compact layout for 80x24 terminals
+ * Issue #1419: DetailPane integration
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Box, Text } from 'ink';
 import { Panel } from './Panel';
 import { useCosts } from '../hooks';
 import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 
+/** Detail item for DetailPane integration (#1419) */
+interface DetailItem {
+  title: string;
+  type: string;
+  fields: { label: string; value: string; color?: string }[];
+  description?: string;
+}
+
 interface CostsViewProps {
   /** Disable input handling (useful for testing) */
   disableInput?: boolean;
+  /** Callback when selection changes (for DetailPane) */
+  onSelectItem?: (item: DetailItem | null) => void;
 }
 
-export function CostsView({ disableInput: _disableInput = false }: CostsViewProps): React.ReactElement {
+export function CostsView({ disableInput: _disableInput = false, onSelectItem }: CostsViewProps): React.ReactElement {
   const { isCompact, isMinimal, isMD } = useResponsiveLayout();
   // #1365: Extend borderless to 100-120 cols (isMD) to prevent box fragmentation
   const isNarrow = isCompact || isMinimal || isMD;
 
   const { data: costs, loading, error } = useCosts();
+
+  // #1419: Update detail pane with cost summary
+  useEffect(() => {
+    if (costs && onSelectItem) {
+      const agentEntries = Object.entries(costs.by_agent ?? {}).sort(([, a], [, b]) => b - a);
+      const modelEntries = Object.entries(costs.by_model ?? {}).sort(([, a], [, b]) => b - a);
+      const topAgent = agentEntries.length > 0 ? agentEntries[0] : null;
+      const topModel = modelEntries.length > 0 ? modelEntries[0] : null;
+      onSelectItem({
+        title: 'Cost Summary',
+        type: 'costs',
+        fields: [
+          { label: 'Total', value: `$${costs.total_cost.toFixed(4)}`, color: 'yellow' },
+          { label: 'Input', value: costs.total_input_tokens.toLocaleString() },
+          { label: 'Output', value: costs.total_output_tokens.toLocaleString() },
+          ...(topAgent !== null ? [{ label: 'Top Agent', value: `${topAgent[0]}: $${topAgent[1].toFixed(2)}` }] : []),
+        ],
+        description: topModel !== null ? `Top model: ${topModel[0]}` : undefined,
+      });
+    } else if (onSelectItem && !costs) {
+      onSelectItem(null);
+    }
+  }, [costs, onSelectItem]);
 
   if (loading) {
     return (

--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -15,11 +15,21 @@ import type { Demon } from '../types';
 /** Duration in ms to show action errors before auto-clearing */
 const ERROR_DISPLAY_DURATION = 3000;
 
+/** Detail item for DetailPane integration (#1419) */
+interface DetailItem {
+  title: string;
+  type: string;
+  fields: { label: string; value: string; color?: string }[];
+  description?: string;
+}
+
 export interface DemonsViewProps {
   /** Callback when exiting the view */
   onExit?: () => void;
   /** Disable input handling (useful for testing) */
   disableInput?: boolean;
+  /** Callback when selection changes (for DetailPane) */
+  onSelectItem?: (item: DetailItem | null) => void;
 }
 
 /**
@@ -84,6 +94,7 @@ function formatRelativeTime(timestamp?: string): string {
 export function DemonsView({
   onExit,
   disableInput = false,
+  onSelectItem,
 }: DemonsViewProps): React.ReactElement {
   const { data: demons, loading, error, total, enabled, refresh, enable, disable, run } = useDemons();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -110,6 +121,26 @@ export function DemonsView({
     const timer = setTimeout(() => { setActionError(null); }, ERROR_DISPLAY_DURATION);
     return () => { clearTimeout(timer); };
   }, [actionError]);
+
+  // #1419: Update detail pane when selection changes
+  const selectedDemon = filteredDemons[selectedIndex] as Demon | undefined;
+  useEffect(() => {
+    if (selectedDemon && onSelectItem) {
+      onSelectItem({
+        title: selectedDemon.name,
+        type: 'demon',
+        fields: [
+          { label: 'Status', value: selectedDemon.enabled ? 'enabled' : 'disabled', color: selectedDemon.enabled ? 'green' : 'gray' },
+          { label: 'Schedule', value: formatSchedule(selectedDemon.schedule) },
+          { label: 'Runs', value: String(selectedDemon.run_count) },
+          { label: 'Last Run', value: formatRelativeTime(selectedDemon.last_run) },
+        ],
+        description: selectedDemon.description ?? selectedDemon.command,
+      });
+    } else if (onSelectItem) {
+      onSelectItem(null);
+    }
+  }, [selectedDemon, onSelectItem]);
 
   useInput(
     (input, key) => {

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -10,8 +10,18 @@ import { PulseText } from '../components/AnimatedText';
 import type { LogSeverity } from '../hooks/useLogs';
 import type { LogEntry } from '../types';
 
+/** Detail item for DetailPane integration (#1419) */
+interface DetailItem {
+  title: string;
+  type: string;
+  fields: { label: string; value: string; color?: string }[];
+  description?: string;
+}
+
 interface LogsViewProps {
   onBack?: () => void;
+  /** Callback when selection changes (for DetailPane) */
+  onSelectItem?: (item: DetailItem | null) => void;
 }
 
 type TimeFilter = '1h' | '6h' | '24h' | 'all';
@@ -92,7 +102,7 @@ function abbreviateType(type: string): string {
   return abbreviations[action] ?? action;
 }
 
-export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
+export const LogsView: React.FC<LogsViewProps> = ({ onBack, onSelectItem }) => {
   const { stdout } = useStdout();
   const terminalWidth = stdout.columns;
 
@@ -118,6 +128,24 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
       setFocus('main');
     }
   }, [showDetail, setFocus]);
+
+  // #1419: Update detail pane when selection changes
+  useEffect(() => {
+    if (selectedLog && !showDetail && onSelectItem) {
+      onSelectItem({
+        title: selectedLog.agent,
+        type: 'log',
+        fields: [
+          { label: 'Time', value: formatTime(selectedLog.ts) },
+          { label: 'Type', value: selectedLog.type, color: getSeverityColor(selectedLog.type) },
+          { label: 'Agent', value: selectedLog.agent, color: 'cyan' },
+        ],
+        description: selectedLog.message.slice(0, 100),
+      });
+    } else if (onSelectItem && (showDetail || !selectedLog)) {
+      onSelectItem(null);
+    }
+  }, [selectedLog, showDetail, onSelectItem]);
 
   // Get unique agents for filter
   const agents = useMemo(() => {

--- a/tui/src/views/ProcessesView.tsx
+++ b/tui/src/views/ProcessesView.tsx
@@ -3,7 +3,7 @@
  * Issue #555: Processes view with list, details, and log viewer
  */
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useProcesses, useProcessLogs } from '../hooks';
 import { Table } from '../components/Table';
@@ -11,8 +11,18 @@ import type { Column } from '../components/Table';
 import { StatusBadge } from '../components/StatusBadge';
 import type { Process } from '../types';
 
+/** Detail item for DetailPane integration (#1419) */
+interface DetailItem {
+  title: string;
+  type: string;
+  fields: { label: string; value: string; color?: string }[];
+  description?: string;
+}
+
 interface ProcessesViewProps {
   onBack?: () => void;
+  /** Callback when selection changes (for DetailPane) */
+  onSelectItem?: (item: DetailItem | null) => void;
 }
 
 /**
@@ -39,7 +49,7 @@ function formatUptime(startedAt: string): string {
   }
 }
 
-export function ProcessesView({ onBack }: ProcessesViewProps) {
+export function ProcessesView({ onBack, onSelectItem }: ProcessesViewProps) {
   const { data: processes, loading, error, refresh } = useProcesses();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showLogs, setShowLogs] = useState(false);
@@ -60,6 +70,25 @@ export function ProcessesView({ onBack }: ProcessesViewProps) {
   }, [processes, searchQuery]);
 
   const selectedProcess = processList[selectedIndex] as typeof processList[number] | undefined;
+
+  // #1419: Update detail pane when selection changes
+  useEffect(() => {
+    if (selectedProcess && !showLogs && onSelectItem) {
+      onSelectItem({
+        title: selectedProcess.name,
+        type: 'process',
+        fields: [
+          { label: 'Status', value: selectedProcess.running ? 'running' : 'stopped', color: selectedProcess.running ? 'green' : 'gray' },
+          { label: 'PID', value: selectedProcess.pid > 0 ? String(selectedProcess.pid) : '-' },
+          { label: 'Port', value: selectedProcess.port ? String(selectedProcess.port) : '-' },
+          { label: 'Uptime', value: selectedProcess.running ? formatUptime(selectedProcess.started_at) : '-' },
+        ],
+        description: selectedProcess.command || undefined,
+      });
+    } else if (onSelectItem && (showLogs || !selectedProcess)) {
+      onSelectItem(null);
+    }
+  }, [selectedProcess, showLogs, onSelectItem]);
 
   // Keyboard navigation
   useInput((input, key) => {


### PR DESCRIPTION
## Summary
- Wire DetailPane (`onSelectItem` callback) to remaining views per #1419 UI Polish audit
- LogsView: Show selected log entry details (time, type, agent, message preview)
- DemonsView: Show selected demon details (status, schedule, run count, last run)
- ProcessesView: Show selected process details (status, PID, port, uptime, command)
- CostsView: Show cost summary (total, input/output tokens, top agent/model)

## Test plan
- [x] Lint passes (`bun run lint`)
- [x] Tests pass (5 failures are pre-existing TabBar issues from FilesView change)
- [ ] Manual test: Navigate to each view, select items, press 'i' to toggle detail pane
- [ ] Verify detail pane shows correct info for each view

Fixes part of #1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)