### PR TITLE
feat(tui): Add ViewWrapper component for consistent view layout (#1419)

### DIFF
--- a/tui/src/__tests__/ViewWrapper.test.tsx
+++ b/tui/src/__tests__/ViewWrapper.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * ViewWrapper component tests
+ * Issue #1419: TUI Production Polish
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { render } from 'ink-testing-library';
+import React from 'react';
+import { Text } from 'ink';
+import { ViewWrapper } from '../components/ViewWrapper';
+
+describe('ViewWrapper', () => {
+  test('renders children', () => {
+    const { lastFrame } = render(
+      <ViewWrapper>
+        <Text>Test Content</Text>
+      </ViewWrapper>
+    );
+    expect(lastFrame()).toContain('Test Content');
+  });
+
+  test('renders title when provided', () => {
+    const { lastFrame } = render(
+      <ViewWrapper title="Test Title">
+        <Text>Content</Text>
+      </ViewWrapper>
+    );
+    expect(lastFrame()).toContain('Test Title');
+  });
+
+  test('shows loading indicator when loading with no children', () => {
+    const { lastFrame } = render(
+      <ViewWrapper loading loadingMessage="Loading data...">
+        {null}
+      </ViewWrapper>
+    );
+    expect(lastFrame()).toContain('Loading data');
+  });
+
+  test('shows error display when error is set', () => {
+    const { lastFrame } = render(
+      <ViewWrapper error="Something went wrong">
+        <Text>Content</Text>
+      </ViewWrapper>
+    );
+    expect(lastFrame()).toContain('Something went wrong');
+  });
+
+  test('renders footer with hints', () => {
+    const { lastFrame } = render(
+      <ViewWrapper
+        hints={[
+          { key: 'j/k', label: 'nav' },
+          { key: 'q', label: 'quit' },
+        ]}
+      >
+        <Text>Content</Text>
+      </ViewWrapper>
+    );
+    const output = lastFrame() ?? '';
+    expect(output).toContain('j/k');
+    expect(output).toContain('nav');
+    expect(output).toContain('q');
+    expect(output).toContain('quit');
+  });
+
+  test('hides footer when hideFooter is true', () => {
+    const { lastFrame } = render(
+      <ViewWrapper
+        hideFooter
+        hints={[{ key: 'q', label: 'quit' }]}
+      >
+        <Text>Content</Text>
+      </ViewWrapper>
+    );
+    expect(lastFrame()).not.toContain('quit');
+  });
+
+  test('shows refreshing indicator when loading with content', () => {
+    const { lastFrame } = render(
+      <ViewWrapper title="Test" loading>
+        <Text>Existing Content</Text>
+      </ViewWrapper>
+    );
+    const output = lastFrame() ?? '';
+    expect(output).toContain('refreshing');
+    expect(output).toContain('Existing Content');
+  });
+
+  test('error state takes precedence over loading', () => {
+    const { lastFrame } = render(
+      <ViewWrapper loading error="Error occurred">
+        <Text>Content</Text>
+      </ViewWrapper>
+    );
+    const output = lastFrame() ?? '';
+    expect(output).toContain('Error occurred');
+    expect(output).not.toContain('Loading');
+  });
+
+  test('renders custom footer when provided', () => {
+    const { lastFrame } = render(
+      <ViewWrapper footer={<Text>Custom Footer</Text>}>
+        <Text>Content</Text>
+      </ViewWrapper>
+    );
+    expect(lastFrame()).toContain('Custom Footer');
+  });
+
+  test('renders with renderWithLayout prop', () => {
+    const { lastFrame } = render(
+      <ViewWrapper
+        renderWithLayout={(layout) => (
+          <Text>Width: {layout.width}</Text>
+        )}
+      />
+    );
+    // Default ink test width is 80
+    expect(lastFrame()).toContain('Width:');
+  });
+});
+
+describe('ViewWrapper with Panel', () => {
+  test('wraps content in Panel when usePanel is true', () => {
+    const { lastFrame } = render(
+      <ViewWrapper usePanel title="Panel Title">
+        <Text>Panel Content</Text>
+      </ViewWrapper>
+    );
+    const output = lastFrame() ?? '';
+    // Panel has border characters
+    expect(output).toContain('Panel Title');
+    expect(output).toContain('Panel Content');
+    // Check for border characters (single border style uses these)
+    expect(output).toMatch(/[│┌┐└┘─]/);
+  });
+
+  test('Panel respects borderColor prop', () => {
+    const { lastFrame } = render(
+      <ViewWrapper usePanel borderColor="cyan" title="Colored">
+        <Text>Content</Text>
+      </ViewWrapper>
+    );
+    // Just verify it renders without error
+    expect(lastFrame()).toContain('Colored');
+  });
+});

--- a/tui/src/components/ViewWrapper.tsx
+++ b/tui/src/components/ViewWrapper.tsx
@@ -1,0 +1,160 @@
+/**
+ * ViewWrapper - Consistent wrapper for all TUI views
+ * Issue #1419: TUI Production Polish - Standardize view layout
+ *
+ * Provides:
+ * - Consistent padding and layout structure
+ * - Optional Panel border with title
+ * - Responsive layout context
+ * - Standard loading and error states
+ * - Footer with keybinding hints
+ */
+
+import React, { memo } from 'react';
+import { Box, Text } from 'ink';
+import { Panel } from './Panel';
+import { Footer, type HintItem } from './Footer';
+import { LoadingIndicator } from './LoadingIndicator';
+import { ErrorDisplay } from './ErrorDisplay';
+import { useResponsiveLayout, type ResponsiveLayoutState } from '../hooks/useResponsiveLayout';
+
+export interface ViewWrapperProps {
+  /** View children to render */
+  children: React.ReactNode;
+  /** Optional panel title (if set, wraps content in Panel) */
+  title?: string;
+  /** Whether to wrap content in a bordered Panel */
+  usePanel?: boolean;
+  /** Panel border color */
+  borderColor?: string;
+  /** Whether this view is focused */
+  focused?: boolean;
+  /** Loading state - shows LoadingIndicator */
+  loading?: boolean;
+  /** Loading message */
+  loadingMessage?: string;
+  /** Error state - shows ErrorDisplay */
+  error?: string | null;
+  /** Error retry callback */
+  onRetry?: () => void;
+  /** Footer keybinding hints */
+  hints?: HintItem[];
+  /** Custom footer content (overrides hints) */
+  footer?: React.ReactNode;
+  /** Hide footer entirely */
+  hideFooter?: boolean;
+  /** Padding around content (default: 1) */
+  padding?: number;
+  /** Additional responsive layout render prop */
+  renderWithLayout?: (layout: ResponsiveLayoutState) => React.ReactNode;
+}
+
+/**
+ * ViewWrapper - Standardized wrapper for TUI views
+ *
+ * @example Basic usage with title
+ * ```tsx
+ * <ViewWrapper title="Processes" loading={isLoading} hints={[{ key: 'j/k', label: 'nav' }]}>
+ *   <ProcessList />
+ * </ViewWrapper>
+ * ```
+ *
+ * @example With Panel border
+ * ```tsx
+ * <ViewWrapper usePanel title="Agent Details" borderColor="cyan">
+ *   <AgentInfo />
+ * </ViewWrapper>
+ * ```
+ *
+ * @example With responsive layout access
+ * ```tsx
+ * <ViewWrapper
+ *   title="Dashboard"
+ *   renderWithLayout={({ canMultiColumn }) => (
+ *     canMultiColumn ? <TwoColumnLayout /> : <SingleColumnLayout />
+ *   )}
+ * />
+ * ```
+ */
+export const ViewWrapper = memo(function ViewWrapper({
+  children,
+  title,
+  usePanel = false,
+  borderColor = 'gray',
+  focused = false,
+  loading = false,
+  loadingMessage = 'Loading...',
+  error,
+  onRetry,
+  hints,
+  footer,
+  hideFooter = false,
+  padding = 1,
+  renderWithLayout,
+}: ViewWrapperProps): React.ReactElement {
+  const layout = useResponsiveLayout();
+
+  // Error state takes precedence
+  if (error) {
+    return (
+      <Box flexDirection="column" padding={padding}>
+        <ErrorDisplay error={error} onRetry={onRetry} />
+      </Box>
+    );
+  }
+
+  // Loading state (only when no content yet)
+  if (loading && !children && !renderWithLayout) {
+    return (
+      <Box flexDirection="column" padding={padding}>
+        <LoadingIndicator message={loadingMessage} />
+      </Box>
+    );
+  }
+
+  // Determine content to render
+  const content = renderWithLayout ? renderWithLayout(layout) : children;
+
+  // Wrap in Panel if requested
+  const wrappedContent = usePanel ? (
+    <Panel
+      title={title}
+      borderColor={borderColor}
+      focused={focused}
+    >
+      {content}
+    </Panel>
+  ) : (
+    <>
+      {title && (
+        <Box marginBottom={1}>
+          <Text bold>{title}</Text>
+          {loading && <Text dimColor> (refreshing...)</Text>}
+        </Box>
+      )}
+      {content}
+    </>
+  );
+
+  return (
+    <Box flexDirection="column" padding={padding} flexGrow={1}>
+      {/* Main content */}
+      <Box flexDirection="column" flexGrow={1}>
+        {wrappedContent}
+      </Box>
+
+      {/* Footer with hints */}
+      {!hideFooter && (footer || hints) && (
+        footer ?? <Footer hints={hints ?? []} />
+      )}
+    </Box>
+  );
+});
+
+/**
+ * Hook to access responsive layout within ViewWrapper
+ * Re-exported for convenience
+ */
+export { useResponsiveLayout };
+
+export default ViewWrapper;

--- a/tui/src/components/index.ts
+++ b/tui/src/components/index.ts
@@ -119,3 +119,7 @@ export {
   COMPACT_HEIGHT,
 } from './DetailPane';
 export type { DetailPaneProps, DetailItem, DetailField } from './DetailPane';
+
+// ViewWrapper for consistent view layout (#1419)
+export { ViewWrapper } from './ViewWrapper';
+export type { ViewWrapperProps } from './ViewWrapper';


### PR DESCRIPTION
## Summary

- Adds ViewWrapper component for standardized view layout
- Optional Panel border with title
- Consistent padding and structure  
- Standard loading and error states
- Footer with keybinding hints
- Responsive layout context via `renderWithLayout` prop

## Usage

```tsx
<ViewWrapper
  title="Processes"
  loading={isLoading}
  hints={[{ key: 'j/k', label: 'nav' }]}
>
  <ProcessList />
</ViewWrapper>
```

## Test plan
- [x] 12 unit tests passing
- [x] Build passes
- [x] Lint passes

Part of #1419 UI Polish initiative (PR 2/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)