### PR TITLE
refactor(tui): Apply HeaderBar to ProcessesView and DemonsView (#1419)

### DIFF
--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -10,6 +10,7 @@ import { StatusBadge } from '../components/StatusBadge';
 import { Footer } from '../components/Footer';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { ErrorDisplay } from '../components/ErrorDisplay';
+import { HeaderBar } from '../components/HeaderBar';
 import type { Demon } from '../types';
 
 /** Duration in ms to show action errors before auto-clearing */
@@ -96,7 +97,7 @@ export function DemonsView({
   disableInput = false,
   onSelectItem,
 }: DemonsViewProps): React.ReactElement {
-  const { data: demons, loading, error, total, enabled, refresh, enable, disable, run } = useDemons();
+  const { data: demons, loading, error, enabled, refresh, enable, disable, run } = useDemons();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [actionError, setActionError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -259,19 +260,21 @@ export function DemonsView({
     return <LoadingIndicator message="Loading demons..." />;
   }
 
+  // Build subtitle with stats
+  const subtitle = [
+    `${String(enabled)} enabled`,
+    searchQuery ? `Search: "${searchQuery}"` : null,
+  ].filter(Boolean).join(' · ');
+
   return (
     <Box flexDirection="column" padding={1}>
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color="magenta">Demons</Text>
-        <Text> · </Text>
-        <Text dimColor>{filteredDemons.length}{searchQuery ? `/${String(total)}` : ''} total</Text>
-        <Text dimColor> · </Text>
-        <Text color={enabled > 0 ? 'green' : 'gray'}>{enabled} enabled</Text>
-        {searchQuery && (
-          <Text color="cyan"> [/] &quot;{searchQuery}&quot;</Text>
-        )}
-      </Box>
+      {/* Header - using shared HeaderBar component (#1419) */}
+      <HeaderBar
+        title="Demons"
+        count={filteredDemons.length}
+        color="magenta"
+        subtitle={subtitle.length > 0 ? subtitle : undefined}
+      />
 
       {/* Action error feedback */}
       {actionError && (

--- a/tui/src/views/ProcessesView.tsx
+++ b/tui/src/views/ProcessesView.tsx
@@ -10,6 +10,7 @@ import { Table } from '../components/Table';
 import type { Column } from '../components/Table';
 import { StatusBadge } from '../components/StatusBadge';
 import { LoadingIndicator } from '../components/LoadingIndicator';
+import { HeaderBar } from '../components/HeaderBar';
 import type { Process } from '../types';
 
 /** Detail item for DetailPane integration (#1419) */
@@ -229,16 +230,14 @@ export function ProcessesView({ onBack, onSelectItem }: ProcessesViewProps) {
 
   return (
     <Box flexDirection="column">
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color="magenta">
-          Processes ({processList.length})
-        </Text>
-        {searchQuery && (
-          <Text color="cyan"> [/] &quot;{searchQuery}&quot;</Text>
-        )}
-        {loading && <Text color="gray"> (refreshing...)</Text>}
-      </Box>
+      {/* Header - using shared HeaderBar component (#1419) */}
+      <HeaderBar
+        title="Processes"
+        count={processList.length}
+        loading={loading}
+        color="magenta"
+        subtitle={searchQuery ? `Search: "${searchQuery}"` : undefined}
+      />
 
       {processList.length === 0 ? (
         <Box padding={1}>


### PR DESCRIPTION
## Summary

Apply the shared HeaderBar component to ProcessesView and DemonsView for UI consistency:

**ProcessesView:**
- Replaced custom header with `<HeaderBar title="Processes" count={...} loading={...} />`
- Search query shown in subtitle

**DemonsView:**
- Replaced custom header with `<HeaderBar title="Demons" count={...} />`
- Enabled count shown in subtitle

## Test plan
- [x] Build passes
- [x] Lint passes (with existing warnings)
- [ ] Visual inspection of views

Part of #1419 UI Polish initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)