### PR TITLE
feat(tui): Add git status indicators to FilesView

### DIFF
--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -187,3 +187,12 @@ export {
   type UseFileTreeOptions,
   type UseFileTreeResult,
 } from './useFileTree';
+
+export {
+  useGitStatus,
+  type GitFileStatus,
+  type GitStatusEntry,
+  type GitStatusSummary,
+  type UseGitStatusOptions,
+  type UseGitStatusResult,
+} from './useGitStatus';

--- a/tui/src/hooks/useGitStatus.ts
+++ b/tui/src/hooks/useGitStatus.ts
@@ -1,0 +1,304 @@
+/**
+ * useGitStatus hook - Git status for file explorer
+ *
+ * RFC 002: File Explorer for TUI
+ * Provides git status information for files in a worktree.
+ *
+ * Features:
+ * - Parses `git status --porcelain` output
+ * - Returns file-level modification status
+ * - Supports caching with configurable TTL
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { execSync } from 'child_process';
+
+/** Git file status */
+export type GitFileStatus = 'modified' | 'added' | 'deleted' | 'renamed' | 'untracked' | 'ignored';
+
+/** Git status entry for a file */
+export interface GitStatusEntry {
+  path: string;
+  status: GitFileStatus;
+  staged: boolean;
+}
+
+/** Summary of git status */
+export interface GitStatusSummary {
+  modified: number;
+  added: number;
+  deleted: number;
+  untracked: number;
+  total: number;
+}
+
+export interface UseGitStatusOptions {
+  /** Working directory path */
+  workingDir: string;
+  /** Auto-refresh interval in ms (0 to disable) */
+  refreshInterval?: number;
+  /** Cache TTL in ms */
+  cacheTTL?: number;
+}
+
+export interface UseGitStatusResult {
+  /** Map of file path to status */
+  statusMap: Map<string, GitStatusEntry>;
+  /** Summary counts */
+  summary: GitStatusSummary;
+  /** Loading state */
+  loading: boolean;
+  /** Error message if any */
+  error: string | null;
+  /** Get status for a specific file */
+  getStatus: (filePath: string) => GitStatusEntry | null;
+  /** Check if a file is modified */
+  isModified: (filePath: string) => boolean;
+  /** Manually refresh status */
+  refresh: () => void;
+}
+
+/**
+ * Parse git status --porcelain output
+ * Format: XY PATH or XY ORIG_PATH -> NEW_PATH
+ */
+function parseGitStatusLine(line: string): GitStatusEntry | null {
+  if (line.length < 3) return null;
+
+  const indexStatus = line[0];
+  const workTreeStatus = line[1];
+  let path = line.slice(3);
+
+  // Handle renamed files (R PATH -> NEWPATH)
+  if (path.includes(' -> ')) {
+    path = path.split(' -> ')[1];
+  }
+
+  // Determine status based on index and worktree status
+  let status: GitFileStatus;
+  let staged = false;
+
+  // Untracked
+  if (indexStatus === '?' && workTreeStatus === '?') {
+    status = 'untracked';
+  }
+  // Ignored
+  else if (indexStatus === '!' && workTreeStatus === '!') {
+    status = 'ignored';
+  }
+  // Added (staged)
+  else if (indexStatus === 'A') {
+    status = 'added';
+    staged = true;
+  }
+  // Deleted
+  else if (indexStatus === 'D' || workTreeStatus === 'D') {
+    status = 'deleted';
+    staged = indexStatus === 'D';
+  }
+  // Renamed
+  else if (indexStatus === 'R') {
+    status = 'renamed';
+    staged = true;
+  }
+  // Modified
+  else if (indexStatus === 'M' || workTreeStatus === 'M') {
+    status = 'modified';
+    staged = indexStatus === 'M';
+  }
+  // Default to modified for any other status
+  else {
+    status = 'modified';
+  }
+
+  return { path, status, staged };
+}
+
+/**
+ * Execute git status and parse output
+ */
+function getGitStatus(workingDir: string): {
+  entries: GitStatusEntry[];
+  error: string | null;
+} {
+  try {
+    const output = execSync('git status --porcelain', {
+      cwd: workingDir,
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+
+    const entries: GitStatusEntry[] = [];
+    const lines = output.split('\n').filter((line) => line.length > 0);
+
+    for (const line of lines) {
+      const entry = parseGitStatusLine(line);
+      if (entry) {
+        entries.push(entry);
+      }
+    }
+
+    return { entries, error: null };
+  } catch (err) {
+    return {
+      entries: [],
+      error: err instanceof Error ? err.message : 'Failed to get git status',
+    };
+  }
+}
+
+/**
+ * Hook to get git status for files in a worktree
+ */
+export function useGitStatus(options: UseGitStatusOptions): UseGitStatusResult {
+  const { workingDir, refreshInterval = 5000, cacheTTL = 2000 } = options;
+
+  const [statusMap, setStatusMap] = useState<Map<string, GitStatusEntry>>(
+    new Map()
+  );
+  const [summary, setSummary] = useState<GitStatusSummary>({
+    modified: 0,
+    added: 0,
+    deleted: 0,
+    untracked: 0,
+    total: 0,
+  });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Cache tracking
+  const lastFetchRef = useRef<number>(0);
+  const cacheRef = useRef<Map<string, GitStatusEntry>>(new Map());
+
+  /**
+   * Fetch git status and update state
+   */
+  const fetchStatus = useCallback(() => {
+    if (!workingDir) {
+      setStatusMap(new Map());
+      setSummary({ modified: 0, added: 0, deleted: 0, untracked: 0, total: 0 });
+      setLoading(false);
+      return;
+    }
+
+    // Check cache
+    const now = Date.now();
+    if (now - lastFetchRef.current < cacheTTL && cacheRef.current.size > 0) {
+      return;
+    }
+
+    setLoading(true);
+    const { entries, error: gitError } = getGitStatus(workingDir);
+
+    if (gitError) {
+      setError(gitError);
+      setLoading(false);
+      return;
+    }
+
+    // Build status map
+    const newMap = new Map<string, GitStatusEntry>();
+    let modified = 0;
+    let added = 0;
+    let deleted = 0;
+    let untracked = 0;
+
+    for (const entry of entries) {
+      newMap.set(entry.path, entry);
+      switch (entry.status) {
+        case 'modified':
+          modified++;
+          break;
+        case 'added':
+          added++;
+          break;
+        case 'deleted':
+          deleted++;
+          break;
+        case 'untracked':
+          untracked++;
+          break;
+      }
+    }
+
+    // Update state
+    setStatusMap(newMap);
+    setSummary({
+      modified,
+      added,
+      deleted,
+      untracked,
+      total: entries.length,
+    });
+    setError(null);
+    setLoading(false);
+
+    // Update cache
+    lastFetchRef.current = now;
+    cacheRef.current = newMap;
+  }, [workingDir, cacheTTL]);
+
+  // Fetch on mount and when workingDir changes
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Set up auto-refresh
+  useEffect(() => {
+    if (refreshInterval <= 0) return;
+
+    const interval = setInterval(fetchStatus, refreshInterval);
+    return () => { clearInterval(interval); };
+  }, [fetchStatus, refreshInterval]);
+
+  /**
+   * Get status for a specific file
+   */
+  const getStatus = useCallback(
+    (filePath: string): GitStatusEntry | null => {
+      // Try exact match first
+      if (statusMap.has(filePath)) {
+        return statusMap.get(filePath) ?? null;
+      }
+
+      // Try relative path
+      const relativePath = filePath.replace(workingDir + '/', '');
+      if (statusMap.has(relativePath)) {
+        return statusMap.get(relativePath) ?? null;
+      }
+
+      return null;
+    },
+    [statusMap, workingDir]
+  );
+
+  /**
+   * Check if a file is modified (any non-clean status)
+   */
+  const isModified = useCallback(
+    (filePath: string): boolean => {
+      return getStatus(filePath) !== null;
+    },
+    [getStatus]
+  );
+
+  /**
+   * Manual refresh
+   */
+  const refresh = useCallback(() => {
+    lastFetchRef.current = 0; // Invalidate cache
+    fetchStatus();
+  }, [fetchStatus]);
+
+  return {
+    statusMap,
+    summary,
+    loading,
+    error,
+    getStatus,
+    isModified,
+    refresh,
+  };
+}
+
+export default useGitStatus;

--- a/tui/src/views/FilesView.tsx
+++ b/tui/src/views/FilesView.tsx
@@ -16,7 +16,7 @@ import { Box, Text, useInput, useStdout } from 'ink';
 import { getWorktrees } from '../services/bc';
 import type { Worktree } from '../types';
 import { useTheme } from '../theme';
-import { useFileTree, type FileTreeEntry } from '../hooks';
+import { useFileTree, useGitStatus, type FileTreeEntry, type GitFileStatus } from '../hooks';
 import * as fs from 'fs';
 
 export interface FilesViewProps {
@@ -48,6 +48,15 @@ export function FilesView({ onBack }: FilesViewProps): React.ReactElement {
     collapseDirectory,
   } = useFileTree({
     rootPath: selectedWorktree?.path ?? '',
+  });
+
+  // Git status for the selected worktree
+  const {
+    getStatus: getGitStatus,
+    summary: gitSummary,
+    loading: gitLoading,
+  } = useGitStatus({
+    workingDir: selectedWorktree?.path ?? '',
   });
 
   // Navigation state
@@ -231,6 +240,17 @@ export function FilesView({ onBack }: FilesViewProps): React.ReactElement {
           isOpen={worktreeSelectorOpen}
           onToggle={() => { setWorktreeSelectorOpen(prev => !prev); }}
         />
+        {/* Git status summary */}
+        {!gitLoading && gitSummary.total > 0 && (
+          <Box marginLeft={2}>
+            <Text dimColor>[</Text>
+            {gitSummary.modified > 0 && <Text color="yellow">~{gitSummary.modified}</Text>}
+            {gitSummary.added > 0 && <Text color="green"> +{gitSummary.added}</Text>}
+            {gitSummary.deleted > 0 && <Text color="red"> -{gitSummary.deleted}</Text>}
+            {gitSummary.untracked > 0 && <Text dimColor> ?{gitSummary.untracked}</Text>}
+            <Text dimColor>]</Text>
+          </Box>
+        )}
       </Box>
 
       {/* Main content: tree + preview */}
@@ -261,6 +281,7 @@ export function FilesView({ onBack }: FilesViewProps): React.ReactElement {
               flatTree={flatTree}
               selectedIndex={treeIndex}
               maxHeight={terminalHeight - 10}
+              getGitStatus={getGitStatus}
             />
           )}
         </Box>
@@ -339,17 +360,39 @@ function WorktreeSelector({
   );
 }
 
+// Git status indicator helper
+function getGitStatusIndicator(status: GitFileStatus | undefined): { icon: string; color: string } {
+  switch (status) {
+    case 'modified':
+      return { icon: '✱', color: 'yellow' };
+    case 'added':
+      return { icon: '+', color: 'green' };
+    case 'deleted':
+      return { icon: '−', color: 'red' };
+    case 'renamed':
+      return { icon: '→', color: 'blue' };
+    case 'untracked':
+      return { icon: '?', color: 'gray' };
+    case 'ignored':
+      return { icon: '!', color: 'gray' };
+    default:
+      return { icon: ' ', color: '' };
+  }
+}
+
 // FileTreeDisplay component
 interface FileTreeDisplayProps {
   flatTree: { entry: FileTreeEntry; depth: number }[];
   selectedIndex: number;
   maxHeight: number;
+  getGitStatus?: (filePath: string) => { status: GitFileStatus; staged: boolean } | null;
 }
 
 function FileTreeDisplay({
   flatTree,
   selectedIndex,
   maxHeight,
+  getGitStatus,
 }: FileTreeDisplayProps): React.ReactElement {
   const { theme } = useTheme();
 
@@ -368,11 +411,19 @@ function FileTreeDisplay({
           ? (item.entry.expanded ? '[-]' : '[+]')
           : '   ';
 
+        // Get git status for the file
+        const gitStatus = getGitStatus?.(item.entry.path);
+        const statusIndicator = getGitStatusIndicator(gitStatus?.status);
+
         return (
           <Text key={item.entry.path}>
             <Text color={isSelected ? theme.colors.accent : undefined} bold={isSelected}>
               {indent}{icon} {item.entry.name}
             </Text>
+            {statusIndicator.icon !== ' ' && (
+              <Text color={statusIndicator.color}> {statusIndicator.icon}</Text>
+            )}
+            {gitStatus?.staged && <Text color="green">*</Text>}
           </Text>
         );
       })}


### PR DESCRIPTION
## Summary
- Implements RFC 002 Phase 1 Milestone 4: Git Status indicators
- Adds `useGitStatus` hook that parses `git status --porcelain` output
- Displays visual git status indicators next to files in FileTree

## Features
- Status icons: ✱ modified, + added, − deleted, → renamed, ? untracked
- Staged indicator: * suffix for staged files
- Header summary: Shows counts like `[~3 +1 -0 ?2]`
- Configurable caching (2s TTL default) and auto-refresh (5s interval)

## Test plan
- [x] Lint passes (no new errors)
- [ ] Manual test in agent worktree with uncommitted changes
- [ ] Verify indicators appear for modified/added/deleted files
- [ ] Verify summary counts update after file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)