### PR TITLE
refactor(tui): Apply HeaderBar to RolesView and WorktreesView (#1447)

### DIFF
--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel';
 import { LoadingIndicator } from '../components/LoadingIndicator';
+import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
 import { useAgents } from '../hooks';
 import type { Role } from '../types';
@@ -252,14 +253,13 @@ export function RolesView({
   // Main list view
   return (
     <Box flexDirection="column" width="100%">
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color="cyan">
-          Roles
-        </Text>
-        <Text dimColor> ({String(filteredRoles.length)})</Text>
-        {loading && <Text color="yellow"> ↻</Text>}
-      </Box>
+      {/* Header - using shared HeaderBar component (#1419) */}
+      <HeaderBar
+        title="Roles"
+        count={filteredRoles.length}
+        loading={loading}
+        color="cyan"
+      />
 
       {/* Search bar */}
       <Box

--- a/tui/src/views/WorktreesView.tsx
+++ b/tui/src/views/WorktreesView.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { getWorktrees, pruneWorktrees } from '../services/bc';
 import { LoadingIndicator } from '../components/LoadingIndicator';
+import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
 import type { Worktree } from '../types';
 
@@ -213,18 +214,21 @@ export const WorktreesView: React.FC<WorktreesViewProps> = ({ onBack }) => {
   const statusWidth = 10;
   const pathWidth = Math.min(50, terminalWidth - agentWidth - statusWidth - 10);
 
+  // Build subtitle with stats
+  const worktreeSubtitle = orphanedWorktrees.length > 0
+    ? `${String(orphanedWorktrees.length)} orphaned`
+    : undefined;
+
   return (
     <Box flexDirection="column">
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color="blue">Worktrees</Text>
-        <Text dimColor> ({activeWorktrees.length} active</Text>
-        {orphanedWorktrees.length > 0 && (
-          <Text color="yellow">, {orphanedWorktrees.length} orphaned</Text>
-        )}
-        <Text dimColor>)</Text>
-        {loading && <Text color="gray"> (refreshing...)</Text>}
-      </Box>
+      {/* Header - using shared HeaderBar component (#1419) */}
+      <HeaderBar
+        title="Worktrees"
+        count={activeWorktrees.length}
+        loading={loading}
+        color="blue"
+        subtitle={worktreeSubtitle}
+      />
 
       {/* Filter indicator */}
       {showOrphanedOnly && (


### PR DESCRIPTION
## Summary

Apply HeaderBar component to additional views:

**RolesView:**
- Replaced custom header with `<HeaderBar title="Roles" count={...} loading={...} />`

**WorktreesView:**
- Replaced custom header with `<HeaderBar title="Worktrees" count={...} loading={...} />`
- Orphaned count shown in subtitle

## Test plan
- [x] Build passes
- [x] Pre-commit checks pass
- [ ] Visual inspection of views

Part of #1419 UI Polish / #1447 HeaderBar application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)