### PR TITLE
fix(tui): Use explicit undefined check in ViewWrapper (#1419)

### DIFF
--- a/tui/src/components/ViewWrapper.tsx
+++ b/tui/src/components/ViewWrapper.tsx
@@ -144,7 +144,7 @@ export const ViewWrapper = memo(function ViewWrapper({
       </Box>
 
       {/* Footer with hints */}
-      {!hideFooter && (footer || hints) && (
+      {!hideFooter && (footer !== undefined || hints !== undefined) && (
         footer ?? <Footer hints={hints ?? []} />
       )}
     </Box>


### PR DESCRIPTION
## Summary

Fix ESLint error in ViewWrapper component:
- Replace `(footer || hints)` with explicit undefined checks
- Satisfies `@typescript-eslint/prefer-nullish-coalescing` rule

## Test plan
- [x] Lint passes (0 errors)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)