### PR TITLE
fix(tui): Fix TypeScript errors in Footer and LogsView (#1419)

### DIFF
--- a/tui/src/components/Footer.tsx
+++ b/tui/src/components/Footer.tsx
@@ -21,8 +21,11 @@ export const KeyHint = memo(function KeyHint({ keyChar, label }: KeyHintProps) {
   );
 });
 
+/** Type for keybinding hint items */
+export type HintItem = { key: string; label: string };
+
 export interface FooterProps {
-  hints: { key: string; label: string }[];
+  hints: HintItem[];
 }
 
 /**

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -129,24 +129,6 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack, onSelectItem }) => {
     }
   }, [showDetail, setFocus]);
 
-  // #1419: Update detail pane when selection changes
-  useEffect(() => {
-    if (selectedLog && !showDetail && onSelectItem) {
-      onSelectItem({
-        title: selectedLog.agent,
-        type: 'log',
-        fields: [
-          { label: 'Time', value: formatTime(selectedLog.ts) },
-          { label: 'Type', value: selectedLog.type, color: getSeverityColor(selectedLog.type) },
-          { label: 'Agent', value: selectedLog.agent, color: 'cyan' },
-        ],
-        description: selectedLog.message.slice(0, 100),
-      });
-    } else if (onSelectItem && (showDetail || !selectedLog)) {
-      onSelectItem(null);
-    }
-  }, [selectedLog, showDetail, onSelectItem]);
-
   // Get unique agents for filter
   const agents = useMemo(() => {
     if (!logs) return [];
@@ -183,6 +165,24 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack, onSelectItem }) => {
   }, [logs, timeFilter, agentFilter, searchQuery]);
 
   const selectedLog = filteredLogs[selectedIndex] as LogEntry | undefined;
+
+  // #1419: Update detail pane when selection changes
+  useEffect(() => {
+    if (selectedLog && !showDetail && onSelectItem) {
+      onSelectItem({
+        title: selectedLog.agent,
+        type: 'log',
+        fields: [
+          { label: 'Time', value: formatTime(selectedLog.ts) },
+          { label: 'Type', value: selectedLog.type, color: getSeverityColor(selectedLog.type) },
+          { label: 'Agent', value: selectedLog.agent, color: 'cyan' },
+        ],
+        description: selectedLog.message.slice(0, 100),
+      });
+    } else if (onSelectItem && (showDetail || !selectedLog)) {
+      onSelectItem(null);
+    }
+  }, [selectedLog, showDetail, onSelectItem]);
 
   // Cycle through severity filters
   const cycleSeverity = useCallback(() => {


### PR DESCRIPTION
## Summary

Fix two TypeScript errors that broke the build:

1. **Footer.tsx** - Export `HintItem` type for ViewWrapper import
2. **LogsView.tsx** - Move `selectedLog` useEffect after variable declaration

## Test plan
- [x] Build passes (`bun run build`)
- [x] Pre-commit checks pass

Unblocks PR #1453 and other pending work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)