### PR TITLE
fix(tui): Fix footer quit/back label (#1462)

### DIFF
--- a/tui/src/hooks/useKeybindings.ts
+++ b/tui/src/hooks/useKeybindings.ts
@@ -175,9 +175,10 @@ export function getStatusBarHints(
     }
 
     // Add global hints at end
+    // #1462: Show 'back' for non-dashboard views, 'quit' only on dashboard
     hints.push(
       { key: '?', label: 'help', priority: 10 },
-      { key: 'q', label: 'quit', priority: 11 },
+      { key: 'q', label: view === 'dashboard' ? 'quit' : 'back', priority: 11 },
     );
   }
 


### PR DESCRIPTION
## Summary
- Fixes misleading footer label: shows 'back' instead of 'quit' for non-dashboard views
- Also converts HintItem from type to interface per lint rules

## Problem
Footer shows `[q] quit` on all views, but pressing `q` actually goes **back** to dashboard (not quitting the app).

## Solution
- Show `[q] back` on non-dashboard views
- Show `[q] quit` only on dashboard where it actually quits

## Test plan
- [x] Build passes
- [ ] Navigate to any view (Agents, Channels, etc.)
- [ ] Verify footer shows `[q] back` not `[q] quit`
- [ ] On Dashboard, verify footer shows `[q] quit`

Fixes #1462

🤖 Generated with [Claude Code](https://claude.com/claude-code)