### PR TITLE
feat(tui): apply ViewWrapper to MemoryView and RoutingView (#1445)

### DIFF
--- a/tui/src/views/MemoryView.tsx
+++ b/tui/src/views/MemoryView.tsx
@@ -6,9 +6,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel';
-import { Footer } from '../components/Footer';
-import { LoadingIndicator } from '../components/LoadingIndicator';
-import { ErrorDisplay } from '../components/ErrorDisplay';
+import { ViewWrapper } from '../components/ViewWrapper';
 import { useFocus } from '../navigation/FocusContext';
 import { getMemoryList, getMemory, searchMemory, clearMemory } from '../services/bc';
 import type { AgentMemorySummary, AgentMemory, MemorySearchResult } from '../types';
@@ -195,14 +193,24 @@ export function MemoryView({
     { isActive: !disableInput }
   );
 
-  // Loading state
-  if (loading && agents.length === 0) {
-    return <LoadingIndicator message="Loading agent memories..." />;
-  }
-
-  // Error state
-  if (error && agents.length === 0) {
-    return <ErrorDisplay error={error} onRetry={() => { void fetchMemoryList(); }} />;
+  // Loading/error states handled by ViewWrapper for initial load
+  if ((loading || error) && agents.length === 0) {
+    return (
+      <ViewWrapper
+        title="Agent Memories"
+        loading={loading}
+        loadingMessage="Loading agent memories..."
+        error={error}
+        onRetry={() => { void fetchMemoryList(); }}
+        hints={[
+          { key: 'j/k', label: 'navigate' },
+          { key: 'Enter', label: 'details' },
+          { key: 'q', label: 'back' },
+        ]}
+      >
+        {null}
+      </ViewWrapper>
+    );
   }
 
   // Clear confirmation modal
@@ -246,85 +254,79 @@ export function MemoryView({
 
   // Main list view
   return (
-    <Box flexDirection="column" width="100%">
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color="magenta">Agent Memories</Text>
-        <Text dimColor> ({String(agents.length)} agents)</Text>
-        {loading && <Text color="yellow"> (refreshing...)</Text>}
-      </Box>
-
-      {/* Search bar */}
-      <Box
-        marginBottom={1}
-        paddingX={1}
-        borderStyle="single"
-        borderColor={searchMode ? 'cyan' : 'gray'}
-      >
-        {searchMode ? (
-          <Box>
-            <Text color="cyan">{'/ '}</Text>
-            <Text>{searchQuery}</Text>
-            <Text color="cyan">|</Text>
-          </Box>
-        ) : (
-          <Text dimColor>Press / to search memories, Enter for details</Text>
-        )}
-      </Box>
-
-      {/* Agent memory table */}
-      <Panel title="Agents">
-        {agents.length === 0 ? (
-          <Text dimColor>No agent memories found</Text>
-        ) : (
-          <Box flexDirection="column">
-            {/* Header row */}
-            <Box paddingX={1}>
-              <Box width={20}>
-                <Text bold dimColor>AGENT</Text>
-              </Box>
-              <Box width={15}>
-                <Text bold dimColor>EXPERIENCES</Text>
-              </Box>
-              <Box width={12}>
-                <Text bold dimColor>LEARNINGS</Text>
-              </Box>
-              <Box flexGrow={1}>
-                <Text bold dimColor>LAST UPDATED</Text>
-              </Box>
-            </Box>
-
-            {/* Agent rows */}
-            {agents.map((agent, idx) => (
-              <AgentMemoryRow
-                key={agent.agent}
-                agent={agent}
-                selected={idx === validIndex}
-              />
-            ))}
-          </Box>
-        )}
-      </Panel>
-
-      {/* Error display */}
-      {error && (
-        <Box marginTop={1}>
-          <Text color="red">Error: {error}</Text>
+    <ViewWrapper
+      title="Agent Memories"
+      loading={loading}
+      error={error}
+      onRetry={() => { void fetchMemoryList(); }}
+      hints={[
+        { key: 'j/k', label: 'navigate' },
+        { key: 'Enter', label: 'details' },
+        { key: '/', label: 'search' },
+        { key: 'c', label: 'clear' },
+        { key: 'R', label: 'refresh' },
+        { key: 'q', label: 'back' },
+      ]}
+    >
+      <Box flexDirection="column" width="100%">
+        {/* Subtitle with count */}
+        <Box marginBottom={1}>
+          <Text dimColor>({String(agents.length)} agents)</Text>
         </Box>
-      )}
 
-      {/* Footer */}
-      <Footer
-        hints={[
-          { key: 'j/k', label: 'navigate' },
-          { key: 'Enter', label: 'details' },
-          { key: '/', label: 'search' },
-          { key: 'c', label: 'clear' },
-          { key: 'R', label: 'refresh' },
-          { key: 'q', label: 'back' },
-        ]}
-      />
-    </Box>
+        {/* Search bar */}
+        <Box
+          marginBottom={1}
+          paddingX={1}
+          borderStyle="single"
+          borderColor={searchMode ? 'cyan' : 'gray'}
+        >
+          {searchMode ? (
+            <Box>
+              <Text color="cyan">{'/ '}</Text>
+              <Text>{searchQuery}</Text>
+              <Text color="cyan">|</Text>
+            </Box>
+          ) : (
+            <Text dimColor>Press / to search memories, Enter for details</Text>
+          )}
+        </Box>
+
+        {/* Agent memory table */}
+        <Panel title="Agents">
+          {agents.length === 0 ? (
+            <Text dimColor>No agent memories found</Text>
+          ) : (
+            <Box flexDirection="column">
+              {/* Header row */}
+              <Box paddingX={1}>
+                <Box width={20}>
+                  <Text bold dimColor>AGENT</Text>
+                </Box>
+                <Box width={15}>
+                  <Text bold dimColor>EXPERIENCES</Text>
+                </Box>
+                <Box width={12}>
+                  <Text bold dimColor>LEARNINGS</Text>
+                </Box>
+                <Box flexGrow={1}>
+                  <Text bold dimColor>LAST UPDATED</Text>
+                </Box>
+              </Box>
+
+              {/* Agent rows */}
+              {agents.map((agent, idx) => (
+                <AgentMemoryRow
+                  key={agent.agent}
+                  agent={agent}
+                  selected={idx === validIndex}
+                />
+              ))}
+            </Box>
+          )}
+        </Panel>
+      </Box>
+    </ViewWrapper>
   );
 }
 

--- a/tui/src/views/RoutingView.tsx
+++ b/tui/src/views/RoutingView.tsx
@@ -6,7 +6,7 @@
 import React, { useState, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel';
-import { Footer } from '../components/Footer';
+import { ViewWrapper } from '../components/ViewWrapper';
 import { useAgents } from '../hooks';
 
 interface RoutingViewProps {
@@ -166,80 +166,79 @@ export function RoutingView({
 
   // Main list view
   return (
-    <Box flexDirection="column" width="100%">
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color="blue">Task Routing</Text>
-        <Text dimColor> ({String(ROUTING_RULES.length)} rules)</Text>
-      </Box>
-
-      {/* Description */}
-      <Box marginBottom={1} paddingX={1} borderStyle="single" borderColor="gray">
-        <Text dimColor wrap="wrap">
-          Task routing determines which agent role handles different types of work.
-          The router uses round-robin selection among available agents of the target role.
-        </Text>
-      </Box>
-
-      {/* Routing rules table */}
-      <Panel title="Routing Rules">
-        <Box flexDirection="column">
-          {/* Header row */}
-          <Box paddingX={1}>
-            <Box width={12}>
-              <Text bold dimColor>TASK TYPE</Text>
-            </Box>
-            <Box width={15}>
-              <Text bold dimColor>TARGET ROLE</Text>
-            </Box>
-            <Box width={10}>
-              <Text bold dimColor>AGENTS</Text>
-            </Box>
-            <Box width={12}>
-              <Text bold dimColor>AVAILABLE</Text>
-            </Box>
-            <Box flexGrow={1}>
-              <Text bold dimColor>DESCRIPTION</Text>
-            </Box>
-          </Box>
-
-          {/* Rule rows */}
-          {ROUTING_RULES.map((rule, idx) => (
-            <RoutingRuleRow
-              key={rule.taskType}
-              rule={rule}
-              selected={idx === validIndex}
-              agentCount={agentCountByRole[rule.targetRole] ?? 0}
-              availableCount={availableByRole[rule.targetRole] ?? 0}
-            />
-          ))}
+    <ViewWrapper
+      title="Task Routing"
+      hints={[
+        { key: 'j/k', label: 'navigate' },
+        { key: 'Enter', label: 'details' },
+        { key: 'q', label: 'back' },
+      ]}
+    >
+      <Box flexDirection="column" width="100%">
+        {/* Subtitle with count */}
+        <Box marginBottom={1}>
+          <Text dimColor>({String(ROUTING_RULES.length)} rules)</Text>
         </Box>
-      </Panel>
 
-      {/* Agent Summary */}
-      <Panel title="Role Summary">
-        <Box flexDirection="row" flexWrap="wrap">
-          {Object.entries(agentCountByRole)
-            .sort((a, b) => b[1] - a[1])
-            .map(([role, count]) => (
-              <Box key={role} marginRight={3}>
-                <Text color="cyan">{role}: </Text>
-                <Text>{String(count)}</Text>
-                <Text dimColor> ({String(availableByRole[role] ?? 0)} avail)</Text>
+        {/* Description */}
+        <Box marginBottom={1} paddingX={1} borderStyle="single" borderColor="gray">
+          <Text dimColor wrap="wrap">
+            Task routing determines which agent role handles different types of work.
+            The router uses round-robin selection among available agents of the target role.
+          </Text>
+        </Box>
+
+        {/* Routing rules table */}
+        <Panel title="Routing Rules">
+          <Box flexDirection="column">
+            {/* Header row */}
+            <Box paddingX={1}>
+              <Box width={12}>
+                <Text bold dimColor>TASK TYPE</Text>
               </Box>
-            ))}
-        </Box>
-      </Panel>
+              <Box width={15}>
+                <Text bold dimColor>TARGET ROLE</Text>
+              </Box>
+              <Box width={10}>
+                <Text bold dimColor>AGENTS</Text>
+              </Box>
+              <Box width={12}>
+                <Text bold dimColor>AVAILABLE</Text>
+              </Box>
+              <Box flexGrow={1}>
+                <Text bold dimColor>DESCRIPTION</Text>
+              </Box>
+            </Box>
 
-      {/* Footer */}
-      <Footer
-        hints={[
-          { key: 'j/k', label: 'navigate' },
-          { key: 'Enter', label: 'details' },
-          { key: 'q', label: 'back' },
-        ]}
-      />
-    </Box>
+            {/* Rule rows */}
+            {ROUTING_RULES.map((rule, idx) => (
+              <RoutingRuleRow
+                key={rule.taskType}
+                rule={rule}
+                selected={idx === validIndex}
+                agentCount={agentCountByRole[rule.targetRole] ?? 0}
+                availableCount={availableByRole[rule.targetRole] ?? 0}
+              />
+            ))}
+          </Box>
+        </Panel>
+
+        {/* Agent Summary */}
+        <Panel title="Role Summary">
+          <Box flexDirection="row" flexWrap="wrap">
+            {Object.entries(agentCountByRole)
+              .sort((a, b) => b[1] - a[1])
+              .map(([role, count]) => (
+                <Box key={role} marginRight={3}>
+                  <Text color="cyan">{role}: </Text>
+                  <Text>{String(count)}</Text>
+                  <Text dimColor> ({String(availableByRole[role] ?? 0)} avail)</Text>
+                </Box>
+              ))}
+          </Box>
+        </Panel>
+      </Box>
+    </ViewWrapper>
   );
 }
 


### PR DESCRIPTION
## Summary
Apply ViewWrapper component to MemoryView and RoutingView for UI consistency.

## Changes
- **MemoryView**: Wrap with ViewWrapper for consistent loading/error states and footer hints
- **RoutingView**: Wrap with ViewWrapper, move title to wrapper prop, use hints for footer

## Testing
- [x] `bun run build` passes
- [x] `bun test` passes (2068 pass)
- [x] Pre-commit hooks pass

## Related Issues
- Part of #1445 (ViewWrapper application)
- Part of #1419 (UI Polish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)