### PR TITLE
fix(tui): Add windowing to Commands View to prevent overflow (#1460)

### DIFF
--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -68,6 +68,11 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
   const { goHome } = useNavigation();
   const { stdout } = useStdout();
   const terminalWidth = stdout.columns;
+  const terminalHeight = stdout.rows;
+
+  // #1460: Calculate visible command count to prevent overflow
+  // Reserve space for: header(2) + category(2) + search(3) + preview(8) + footer(2) = 17 lines
+  const visibleCommandCount = Math.max(3, terminalHeight - 17);
 
   // Favorites state - persisted to disk
   const [favorites, setFavorites] = useState<Set<string>>(() => loadFavorites());
@@ -273,7 +278,7 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
         )}
       </Box>
 
-      {/* Command list */}
+      {/* Command list - #1460: Windowed to prevent overflow */}
       <Box flexDirection="column" marginBottom={1} paddingX={1}>
         {filteredCommands.length === 0 ? (
           <Box flexDirection="column">
@@ -285,14 +290,31 @@ export const CommandsView: React.FC<CommandsViewProps> = ({
             )}
           </Box>
         ) : (
-          filteredCommands.map((cmd, idx) => (
-            <CommandRow
-              key={`${cmd.category}-${cmd.name}`}
-              command={cmd}
-              selected={idx === validatedIndex}
-              isFavorite={favorites.has(cmd.name)}
-            />
-          ))
+          (() => {
+            // #1460: Window the visible commands around selection
+            const start = Math.max(0, Math.min(
+              validatedIndex - Math.floor(visibleCommandCount / 2),
+              filteredCommands.length - visibleCommandCount
+            ));
+            const visibleCommands = filteredCommands.slice(start, start + visibleCommandCount);
+
+            return (
+              <>
+                {start > 0 && <Text dimColor>↑ {start} more above</Text>}
+                {visibleCommands.map((cmd, idx) => (
+                  <CommandRow
+                    key={`${cmd.category}-${cmd.name}`}
+                    command={cmd}
+                    selected={start + idx === validatedIndex}
+                    isFavorite={favorites.has(cmd.name)}
+                  />
+                ))}
+                {start + visibleCommandCount < filteredCommands.length && (
+                  <Text dimColor>↓ {filteredCommands.length - start - visibleCommandCount} more below</Text>
+                )}
+              </>
+            );
+          })()
         )}
       </Box>
 


### PR DESCRIPTION
## Summary
Fixes rendering artifacts at bottom of Commands View by adding windowing/virtualization to the command list.

## Problem
Commands View rendered all commands without height limits, causing text to overflow and corrupt the preview panel and footer when many commands were displayed.

## Solution
- Calculate visible command count based on terminal height (reserving space for header, search, preview, footer)
- Window the command list around the selected item
- Show scroll indicators ("↑ N more above" / "↓ N more below")

## Test plan
- [x] Build passes
- [ ] Run `bc home`, press 6 (Commands View)
- [ ] Verify no text corruption at bottom
- [ ] Verify scroll indicators appear when list is long
- [ ] Navigate with j/k and verify window follows selection

Fixes #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)