### PR TITLE
feat(tui): drawer navigation changes per root directive (#1467)

### DIFF
--- a/tui/src/navigation/Drawer.tsx
+++ b/tui/src/navigation/Drawer.tsx
@@ -234,8 +234,9 @@ interface DrawerItemProps {
 }
 
 function DrawerItem({ tab, isActive, isHighlighted, useShortLabel = false }: DrawerItemProps): React.ReactElement {
-  // Visual indicators: ● selected, ○ unselected
-  const indicator = isActive ? '●' : '○';
+  // Issue #1467: Visual indicators with highlight arrow
+  // ▶ highlighted (yellow), ● selected (green), ○ inactive (dim)
+  const indicator = isHighlighted ? '▶' : isActive ? '●' : '○';
 
   // Determine text styling
   const textColor = isActive ? 'green' : isHighlighted ? 'yellow' : undefined;
@@ -247,7 +248,7 @@ function DrawerItem({ tab, isActive, isHighlighted, useShortLabel = false }: Dra
 
   return (
     <Box>
-      <Text color={isActive ? 'green' : isHighlighted ? 'yellow' : undefined}>{indicator}</Text>
+      <Text color={isHighlighted ? 'yellow' : isActive ? 'green' : undefined}>{indicator}</Text>
       <Text
         bold={isBold}
         color={textColor}
@@ -255,10 +256,6 @@ function DrawerItem({ tab, isActive, isHighlighted, useShortLabel = false }: Dra
       >
         {' '}{label}
       </Text>
-      {/* Show shortcut key */}
-      {tab.shortcut && !isActive && (
-        <Text dimColor> {tab.shortcut}</Text>
-      )}
     </Box>
   );
 }
@@ -270,15 +267,16 @@ interface DrawerItemShrunkProps {
 }
 
 function DrawerItemShrunk({ tab, isActive, isHighlighted }: DrawerItemShrunkProps): React.ReactElement {
-  const indicator = isActive ? '●' : '○';
+  // Issue #1467: Use arrow indicator for highlighted items
+  const indicator = isHighlighted ? '▶' : isActive ? '●' : '○';
   const textColor = isActive ? 'green' : isHighlighted ? 'yellow' : undefined;
 
-  // Use shortcut key as minimal label
-  const label = tab.shortcut ?? tab.label.charAt(0);
+  // Use first letter as minimal label (number shortcuts removed)
+  const label = tab.label.charAt(0);
 
   return (
     <Box>
-      <Text color={textColor}>{indicator}</Text>
+      <Text color={isHighlighted ? 'yellow' : isActive ? 'green' : undefined}>{indicator}</Text>
       <Text color={textColor} dimColor={!isActive && !isHighlighted}>{label}</Text>
     </Box>
   );

--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -19,14 +19,14 @@ export interface UseKeyboardNavigationOptions {
 
 /**
  * Hook that handles global keyboard navigation
- * - Number keys (1-9) switch views
  * - Tab/Shift+Tab cycles views
  * - ? shows help
  * - ESC goes back/home
  * - Ctrl+R refreshes all data
  * - q quits the application
  *
- * Note: j/k are handled by Drawer for list navigation, not here.
+ * Issue #1467: Removed 1-9 number shortcuts.
+ * Navigation now uses j/k + Enter in Drawer component.
  */
 export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}): void {
   const { disabled = false, onQuit, onRefresh, onCommandPalette } = options;
@@ -53,12 +53,15 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
         return;
       }
 
-      // Tab navigation with number keys (1-9) and ?
-      // These should work even when a local view has focus
-      const tab = getTabByKey(input);
-      if (tab) {
-        navigate(tab.view);
-        return;
+      // Issue #1467: Removed 1-9 number shortcuts
+      // Navigation now uses j/k + Enter in Drawer component
+      // Only ? for help remains as a global shortcut
+      if (input === '?') {
+        const helpTab = getTabByKey('?');
+        if (helpTab) {
+          navigate(helpTab.view);
+          return;
+        }
       }
 
       // Tab key: next view, Shift+Tab: previous view


### PR DESCRIPTION
## Summary
Implement drawer navigation changes per root directive:

1. **Remove 1-9 number shortcuts** from global keyboard navigation
   - Only `?` for help remains as global shortcut
   - Tab/Shift+Tab still cycles views
   - Navigation now uses j/k + Enter in Drawer

2. **Add ▶ arrow indicator** for highlighted items in Drawer
   - `▶` (yellow): highlighted item (cursor position)
   - `●` (green): currently selected/active view
   - `○` (dim): inactive items

3. **Update shrunk drawer mode** with same indicators

## Visual Change
```
Before:              After:
○ Dashboard          ○ Dashboard
● Agents (yellow)    ▶ Agents      ← arrow shows highlight
○ Channels           ○ Channels
```

## Testing
- [x] `bun run build` passes
- [x] `bun test` passes (2068 pass)
- [x] Pre-commit hooks pass

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)