### PR TITLE
refactor(tui): Apply HeaderBar to MemoryView and RoutingView (#1419)

### DIFF
--- a/tui/src/components/Footer.tsx
+++ b/tui/src/components/Footer.tsx
@@ -21,8 +21,11 @@ export const KeyHint = memo(function KeyHint({ keyChar, label }: KeyHintProps) {
   );
 });
 
-/** Type for keybinding hint items */
-export type HintItem = { key: string; label: string };
+/** Interface for keybinding hint items */
+export interface HintItem {
+  key: string;
+  label: string;
+}
 
 export interface FooterProps {
   hints: HintItem[];

--- a/tui/src/views/MemoryView.tsx
+++ b/tui/src/views/MemoryView.tsx
@@ -9,6 +9,7 @@ import { Panel } from '../components/Panel';
 import { Footer } from '../components/Footer';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { ErrorDisplay } from '../components/ErrorDisplay';
+import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
 import { getMemoryList, getMemory, searchMemory, clearMemory } from '../services/bc';
 import type { AgentMemorySummary, AgentMemory, MemorySearchResult } from '../types';
@@ -247,12 +248,13 @@ export function MemoryView({
   // Main list view
   return (
     <Box flexDirection="column" width="100%">
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color="magenta">Agent Memories</Text>
-        <Text dimColor> ({String(agents.length)} agents)</Text>
-        {loading && <Text color="yellow"> (refreshing...)</Text>}
-      </Box>
+      {/* Header - using shared HeaderBar component (#1419) */}
+      <HeaderBar
+        title="Agent Memories"
+        count={agents.length}
+        loading={loading}
+        color="magenta"
+      />
 
       {/* Search bar */}
       <Box

--- a/tui/src/views/RoutingView.tsx
+++ b/tui/src/views/RoutingView.tsx
@@ -7,6 +7,7 @@ import React, { useState, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel';
 import { Footer } from '../components/Footer';
+import { HeaderBar } from '../components/HeaderBar';
 import { useAgents } from '../hooks';
 
 interface RoutingViewProps {
@@ -167,11 +168,12 @@ export function RoutingView({
   // Main list view
   return (
     <Box flexDirection="column" width="100%">
-      {/* Header */}
-      <Box marginBottom={1}>
-        <Text bold color="blue">Task Routing</Text>
-        <Text dimColor> ({String(ROUTING_RULES.length)} rules)</Text>
-      </Box>
+      {/* Header - using shared HeaderBar component (#1419) */}
+      <HeaderBar
+        title="Task Routing"
+        count={ROUTING_RULES.length}
+        color="blue"
+      />
 
       {/* Description */}
       <Box marginBottom={1} paddingX={1} borderStyle="single" borderColor="gray">


### PR DESCRIPTION
## Summary
- Add HeaderBar component to MemoryView replacing custom header
- Add HeaderBar component to RoutingView replacing custom header  
- Fix ESLint error: change HintItem from type to interface in Footer

This completes the HeaderBar standardization across all remaining TUI views as part of the UI polish work from issue #1419.

## Test plan
- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)
- [x] Verify MemoryView renders with consistent header
- [x] Verify RoutingView renders with consistent header

Closes part of #1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)