### PR TITLE
fix(vscode): Fix parseAgentList test skipping Workspace header (#1488)

### DIFF
--- a/vscode-bc/src/test/extension.test.ts
+++ b/vscode-bc/src/test/extension.test.ts
@@ -22,7 +22,8 @@ function parseAgentList(output: string): Agent[] {
 
     for (const line of lines) {
         const match = line.match(/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.*)$/);
-        if (match && !line.startsWith('AGENT') && !line.startsWith('-')) {
+        // Skip header lines: "AGENT...", "---...", "───...", "Workspace:..."
+        if (match && !line.startsWith('AGENT') && !line.startsWith('-') && !line.startsWith('─') && !line.startsWith('Workspace')) {
             const [, name, role, state, uptime, task] = match;
             if (name && role && state) {
                 agents.push({


### PR DESCRIPTION
## Summary
The parseAgentList function was incorrectly matching the "Workspace:..." header line because it matched the regex pattern and didn't start with "AGENT" or "-".

## Changes
- Added skip for lines starting with "Workspace" 
- Added skip for lines starting with unicode box-drawing horizontal characters "─"

## Test plan
- [x] VS Code extension tests pass (9/9)
- [x] All other tests unaffected

Fixes #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)