### PR TITLE
fix(tui): Fix Channels view layout at 80x24 terminal width (#1483)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -158,11 +158,14 @@ export function ChannelsView({ disableInput = false, onSelectItem }: ChannelsVie
     );
   }
 
+  // #1483 fix: Remove width="100%" to avoid layout overflow at 80 columns
+  // Ink's layout calculates width incorrectly when width="100%" + padding + border
+  // Let flexbox handle width naturally through flexGrow
   return (
-    <Box flexDirection="column" width="100%">
+    <Box flexDirection="column" flexGrow={1}>
       <Text bold>Channels</Text>
       <Text dimColor>↑/↓ navigate, Enter to view messages, ESC to go back</Text>
-      <Box marginTop={1} flexDirection="column" width="100%" borderStyle="single" borderColor="gray" paddingX={2}>
+      <Box marginTop={1} flexDirection="column" flexGrow={1} borderStyle="single" borderColor="gray" paddingX={1}>
         {channels?.map((channel, index) => (
           <ChannelRow
             key={channel.name}


### PR DESCRIPTION
## Summary
- Fixes Channels view rendering issues at 80-column terminal width
- Removes `width="100%"` which causes Ink layout miscalculation with padding/borders
- Reduces paddingX from 2 to 1 to save horizontal space at narrow widths

## Problem
At 80x24 (minimum supported terminal size), the Channels view had:
- Missing 'Channels' header
- Channel names not showing (only descriptions visible)
- Garbled/cut off content

## Root Cause
Ink's layout engine incorrectly calculates width when combining:
- `width="100%"` on nested containers
- `borderStyle="single"` (adds 2 chars)
- `paddingX={2}` (adds 4 chars)

The total exceeds available width causing overflow.

## Fix
- Replace `width="100%"` with `flexGrow={1}` for natural flexbox sizing
- Reduce `paddingX` from 2 to 1 to recover 2 chars
- Document the fix pattern in comments

## Test plan
- [x] Lint passes
- [x] ChannelsView.test.tsx passes (16 tests)
- [x] ChannelsViewEnter.test.tsx passes (6 tests)
- [ ] Manual test at 80x24 terminal size

Fixes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)