### PR TITLE
fix(tui): Fix Channel View layout at 80x24 terminal (#1483)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -158,11 +158,13 @@ export function ChannelsView({ disableInput = false, onSelectItem }: ChannelsVie
     );
   }
 
+  // #1483 fix: Remove nested width="100%" to fix layout at 80x24
+  // Let flexbox naturally fill available space instead of explicit width calculations
   return (
-    <Box flexDirection="column" width="100%">
+    <Box flexDirection="column" flexGrow={1} overflow="hidden">
       <Text bold>Channels</Text>
-      <Text dimColor>↑/↓ navigate, Enter to view messages, ESC to go back</Text>
-      <Box marginTop={1} flexDirection="column" width="100%" borderStyle="single" borderColor="gray" paddingX={2}>
+      <Text dimColor wrap="truncate">j/k navigate · Enter view · m compose · ESC back</Text>
+      <Box marginTop={1} flexDirection="column" flexGrow={1} borderStyle="single" borderColor="gray" paddingX={1} overflow="hidden">
         {channels?.map((channel, index) => (
           <ChannelRow
             key={channel.name}


### PR DESCRIPTION
## Summary
Fixes Channel View layout issues at 80x24 (minimum supported terminal size).

## Problem
At 80 columns, the Channel View had:
- Missing 'Channels' header
- Channel names not showing (only descriptions visible)
- Garbled/cut off content

## Root Cause
Nested `width="100%"` attributes caused flex calculation issues with Ink at narrow terminal widths.

## Solution
- Remove nested `width="100%"` and use `flexGrow={1}` for natural flexbox sizing
- Add `overflow="hidden"` to prevent content from bleeding between elements
- Reduce `paddingX` from 2 to 1 character to give more space for content
- Shorten help text to fit narrow terminals

## Test plan
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [ ] Resize terminal to 80x24
- [ ] Verify 'Channels' header is visible
- [ ] Verify channel names display correctly
- [ ] Verify no garbled/cut off content

Fixes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)