### PR TITLE
feat: Add GoReleaser and release workflow (#1472)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+# Release workflow using GoReleaser
+# Issue #1472: Release Infrastructure
+#
+# Triggered on version tags (v*)
+# Creates GitHub release with binaries and Homebrew formula
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+env:
+  GO_VERSION: '1.22'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+  # Build for macOS natively (required for CGO/SQLite)
+  release-macos:
+    name: Release macOS
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Build macOS binaries
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+          # Build for macOS amd64
+          CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build \
+            -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+            -o dist/bc-darwin-amd64 ./cmd/bc
+
+          # Build for macOS arm64
+          CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build \
+            -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}" \
+            -o dist/bc-darwin-arm64 ./cmd/bc
+
+      - name: Create archives
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          cd dist
+          tar -czvf bc_${VERSION}_darwin_amd64.tar.gz bc-darwin-amd64
+          tar -czvf bc_${VERSION}_darwin_arm64.tar.gz bc-darwin-arm64
+          shasum -a 256 *.tar.gz > checksums-macos.txt
+
+      - name: Upload macOS binaries
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/bc_*.tar.gz
+            dist/checksums-macos.txt
+          fail_on_unmatched_files: false

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,142 @@
+# GoReleaser configuration for bc
+# https://goreleaser.com
+#
+# Issue #1472: Release Infrastructure
+
+version: 2
+
+project_name: bc
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
+builds:
+  - id: bc
+    main: ./cmd/bc
+    binary: bc
+    env:
+      - CGO_ENABLED=1
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    # CGO is required for SQLite, so we need to handle cross-compilation
+    # For now, we'll build natively on each platform via matrix
+    ignore:
+      # Skip cross-compilation due to CGO requirements
+      - goos: linux
+        goarch: arm64
+
+  # Windows build without CGO (limited functionality)
+  - id: bc-windows
+    main: ./cmd/bc
+    binary: bc
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+    goos:
+      - windows
+    goarch:
+      - amd64
+    tags:
+      - nosqlite
+
+archives:
+  - id: default
+    format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- .Os }}_
+      {{- .Arch }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - README.md
+      - LICENSE*
+      - CHANGELOG*
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+      - Merge pull request
+      - Merge branch
+  groups:
+    - title: Features
+      regexp: '^feat.*'
+      order: 0
+    - title: Bug Fixes
+      regexp: '^fix.*'
+      order: 1
+    - title: Refactoring
+      regexp: '^refactor.*'
+      order: 2
+    - title: Performance
+      regexp: '^perf.*'
+      order: 3
+    - title: Others
+      order: 999
+
+release:
+  github:
+    owner: rpuneet
+    name: bc
+  draft: false
+  prerelease: auto
+  mode: replace
+  header: |
+    ## bc {{ .Tag }}
+
+    Mission control for AI agents.
+  footer: |
+    ---
+
+    **Full Changelog**: https://github.com/rpuneet/bc/compare/{{ .PreviousTag }}...{{ .Tag }}
+
+brews:
+  - name: bc
+    repository:
+      owner: rpuneet
+      name: homebrew-bc
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/rpuneet/bc
+    description: Mission control for AI agents
+    license: MIT
+    skip_upload: auto
+    install: |
+      bin.install "bc"
+    test: |
+      system "#{bin}/bc", "version"
+
+# Announce releases (optional, can be configured later)
+# announce:
+#   discord:
+#     enabled: false


### PR DESCRIPTION
## Summary
Add release infrastructure for automated binary releases using GoReleaser.

## Changes

### .goreleaser.yml
- GoReleaser v2 configuration
- Cross-platform builds (darwin amd64/arm64, linux amd64, windows amd64)
- Version injection via ldflags (`main.version`, `main.commit`, `main.date`)
- Automatic changelog generation from conventional commits
- Homebrew tap publishing to `rpuneet/homebrew-bc`
- SHA256 checksums
- Archive formats: tar.gz (Unix), zip (Windows)

### .github/workflows/release.yml
- Triggered on `v*` tags
- Uses GoReleaser for Linux builds
- Native macOS builds for CGO/SQLite support (separate job)
- Uploads all binaries to GitHub release

## Implementation Notes

CGO is required for SQLite support, which means:
- Linux builds use GoReleaser on ubuntu-latest
- macOS builds run natively on macos-latest runner
- Windows builds are CGO-disabled (limited functionality)

## Test plan
- [x] GoReleaser config syntax valid
- [x] Workflow YAML valid
- [ ] Test with `v0.1.0-test` tag (manual)

## Usage
```bash
# Create a release
git tag v0.1.0
git push origin v0.1.0

# Install via Homebrew (after first release)
brew install rpuneet/bc/bc
```

Fixes #1472

🤖 Generated with [Claude Code](https://claude.com/claude-code)