### PR TITLE
feat(provider): Add OpenCode/Crush provider integration (#1451)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,6 +52,12 @@ enabled = false
 command = "codex --full-auto"
 enabled = false
 
+# OpenCode/Crush - Charmbracelet's AI coding assistant
+# Note: OpenCode was archived, Crush is the successor
+[tools.opencode]
+command = "crush"
+enabled = false
+
 # GitHub integration - for issue tracking and PR management
 [tools.github]
 command = "gh"
@@ -193,3 +199,8 @@ description = "Cursor Agent"
 name = "codex"
 command = "codex --full-auto"
 description = "OpenAI Codex"
+
+[[agents]]
+name = "opencode"
+command = "crush"
+description = "OpenCode/Crush AI coding assistant"

--- a/config/config.go
+++ b/config/config.go
@@ -58,14 +58,15 @@ type ToolsCodexConfig struct {
 }
 
 type ToolsConfig struct {
-	Claude  ToolsClaudeConfig
-	Codex   ToolsCodexConfig
-	Cursor  ToolsCursorConfig
-	Default string
-	Gemini  ToolsGeminiConfig
-	Github  ToolsGithubConfig
-	Gitlab  ToolsGitlabConfig
-	Jira    ToolsJiraConfig
+	Claude   ToolsClaudeConfig
+	Codex    ToolsCodexConfig
+	Cursor   ToolsCursorConfig
+	Default  string
+	Gemini   ToolsGeminiConfig
+	Github   ToolsGithubConfig
+	Gitlab   ToolsGitlabConfig
+	Jira     ToolsJiraConfig
+	Opencode ToolsOpencodeConfig
 }
 
 type ToolsCursorConfig struct {
@@ -89,6 +90,11 @@ type ToolsGitlabConfig struct {
 }
 
 type ToolsJiraConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ToolsOpencodeConfig struct {
 	Command string
 	Enabled bool
 }
@@ -144,6 +150,11 @@ var (
 			Command:     "codex --full-auto",
 			Description: "OpenAI Codex",
 			Name:        "codex",
+		},
+		{
+			Command:     "crush",
+			Description: "OpenCode/Crush AI coding assistant",
+			Name:        "opencode",
 		},
 	}
 	Channels = ChannelsConfig{
@@ -204,6 +215,10 @@ var (
 		},
 		Jira: ToolsJiraConfig{
 			Command: "jira",
+			Enabled: false,
+		},
+		Opencode: ToolsOpencodeConfig{
+			Command: "crush",
 			Enabled: false,
 		},
 	}

--- a/pkg/provider/claude.go
+++ b/pkg/provider/claude.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// ClaudeProvider implements the Provider interface for Claude Code.
+// Claude Code is the Anthropic CLI for Claude.
+type ClaudeProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewClaudeProvider creates a new Claude provider.
+func NewClaudeProvider() *ClaudeProvider {
+	return &ClaudeProvider{
+		name:        "claude",
+		description: "Anthropic Claude Code CLI",
+		command:     "claude --dangerously-skip-permissions",
+		binary:      "claude",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *ClaudeProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *ClaudeProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *ClaudeProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *ClaudeProvider) IsInstalled(ctx context.Context) bool {
+	return checkBinaryExists(ctx, p.binary)
+}
+
+// Version returns the installed version.
+func (p *ClaudeProvider) Version(ctx context.Context) string {
+	return getBinaryVersion(ctx, p.binary, "--version")
+}
+
+// DetectState analyzes output to determine agent state.
+// Claude uses specific spinner and prompt symbols.
+func (p *ClaudeProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	// Check last few lines for state indicators
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+
+		// Working indicators - Claude's spinner symbols
+		if strings.HasPrefix(line, "✻") ||
+			strings.HasPrefix(line, "✳") ||
+			strings.HasPrefix(line, "✽") ||
+			strings.HasPrefix(line, "·") {
+			return StateWorking
+		}
+
+		// Tool call indicator
+		if strings.HasPrefix(line, "⏺") {
+			return StateWorking
+		}
+
+		// Idle/prompt indicator
+		if strings.HasPrefix(line, "❯") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure ClaudeProvider implements Provider interface.
+var _ Provider = (*ClaudeProvider)(nil)

--- a/pkg/provider/opencode.go
+++ b/pkg/provider/opencode.go
@@ -1,0 +1,123 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// OpenCodeProvider implements the Provider interface for OpenCode/Crush.
+// OpenCode was originally github.com/opencode-ai/opencode, now archived.
+// Crush (github.com/charmbracelet/crush) is the successor.
+//
+// Issue #1451: OpenCode Provider Integration
+type OpenCodeProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewOpenCodeProvider creates a new OpenCode provider.
+func NewOpenCodeProvider() *OpenCodeProvider {
+	return &OpenCodeProvider{
+		name:        "opencode",
+		description: "OpenCode/Crush AI coding assistant",
+		command:     "crush",
+		binary:      "crush",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *OpenCodeProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *OpenCodeProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *OpenCodeProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *OpenCodeProvider) IsInstalled(ctx context.Context) bool {
+	// Check for crush (successor) first
+	if checkBinaryExists(ctx, "crush") {
+		return true
+	}
+	// Fall back to opencode (legacy)
+	return checkBinaryExists(ctx, "opencode")
+}
+
+// Version returns the installed version.
+func (p *OpenCodeProvider) Version(ctx context.Context) string {
+	// Try crush first
+	if checkBinaryExists(ctx, "crush") {
+		return getBinaryVersion(ctx, "crush", "--version")
+	}
+	// Fall back to opencode
+	if checkBinaryExists(ctx, "opencode") {
+		return getBinaryVersion(ctx, "opencode", "--version")
+	}
+	return ""
+}
+
+// DetectState analyzes output to determine agent state.
+// Crush/OpenCode uses similar spinner patterns to Claude.
+func (p *OpenCodeProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	// Check last few lines for state indicators
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+
+		// Working indicators - spinner symbols
+		if strings.HasPrefix(line, "⠋") ||
+			strings.HasPrefix(line, "⠙") ||
+			strings.HasPrefix(line, "⠹") ||
+			strings.HasPrefix(line, "⠸") ||
+			strings.HasPrefix(line, "⠼") ||
+			strings.HasPrefix(line, "⠴") ||
+			strings.HasPrefix(line, "⠦") ||
+			strings.HasPrefix(line, "⠧") ||
+			strings.HasPrefix(line, "⠇") ||
+			strings.HasPrefix(line, "⠏") ||
+			strings.Contains(line, "thinking") ||
+			strings.Contains(line, "processing") {
+			return StateWorking
+		}
+
+		// Done indicators
+		if strings.Contains(line, "✓") ||
+			strings.Contains(line, "done") ||
+			strings.Contains(line, "complete") ||
+			strings.Contains(line, "finished") {
+			return StateDone
+		}
+
+		// Error indicators
+		if strings.Contains(line, "error") ||
+			strings.Contains(line, "failed") ||
+			strings.Contains(line, "✗") {
+			return StateError
+		}
+
+		// Idle/prompt indicators
+		if strings.HasPrefix(line, ">") ||
+			strings.HasPrefix(line, "❯") ||
+			strings.HasPrefix(line, "$") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure OpenCodeProvider implements Provider interface.
+var _ Provider = (*OpenCodeProvider)(nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,0 +1,136 @@
+// Package provider implements AI agent provider integrations.
+// Issue #1451: OpenCode support
+// Issue #1452: Cursor Agent support
+// Epic #1429: Multi-Agent Integration
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Provider represents an AI agent provider that can run in a bc workspace.
+type Provider interface {
+	// Name returns the provider's unique identifier (e.g., "opencode", "cursor")
+	Name() string
+
+	// Description returns a human-readable description
+	Description() string
+
+	// Command returns the shell command to start this provider
+	Command() string
+
+	// IsInstalled checks if the provider binary is available on the system
+	IsInstalled(ctx context.Context) bool
+
+	// Version returns the installed version, or empty string if not installed
+	Version(ctx context.Context) string
+
+	// DetectState analyzes output to determine agent state (working, idle, done, etc.)
+	DetectState(output string) State
+}
+
+// State represents the detected state of a provider's agent.
+type State string
+
+const (
+	StateUnknown State = "unknown"
+	StateIdle    State = "idle"
+	StateWorking State = "working"
+	StateDone    State = "done"
+	StateError   State = "error"
+	StateStuck   State = "stuck"
+)
+
+// Registry holds all registered providers.
+type Registry struct {
+	providers map[string]Provider
+}
+
+// NewRegistry creates a new provider registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		providers: make(map[string]Provider),
+	}
+}
+
+// Register adds a provider to the registry.
+func (r *Registry) Register(p Provider) {
+	r.providers[p.Name()] = p
+}
+
+// Get returns a provider by name.
+func (r *Registry) Get(name string) (Provider, bool) {
+	p, ok := r.providers[name]
+	return p, ok
+}
+
+// List returns all registered providers.
+func (r *Registry) List() []Provider {
+	providers := make([]Provider, 0, len(r.providers))
+	for _, p := range r.providers {
+		providers = append(providers, p)
+	}
+	return providers
+}
+
+// ListInstalled returns all installed providers.
+func (r *Registry) ListInstalled(ctx context.Context) []Provider {
+	var installed []Provider
+	for _, p := range r.providers {
+		if p.IsInstalled(ctx) {
+			installed = append(installed, p)
+		}
+	}
+	return installed
+}
+
+// DefaultRegistry is the global provider registry with all built-in providers.
+var DefaultRegistry = NewRegistry()
+
+func init() {
+	// Register built-in providers
+	DefaultRegistry.Register(NewOpenCodeProvider())
+	DefaultRegistry.Register(NewClaudeProvider())
+}
+
+// checkBinaryExists checks if a binary exists in PATH.
+func checkBinaryExists(_ context.Context, name string) bool {
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+// getBinaryVersion runs a command and returns the first line of output.
+func getBinaryVersion(ctx context.Context, name string, args ...string) string {
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // args are trusted provider names
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	if len(lines) > 0 {
+		return lines[0]
+	}
+	return ""
+}
+
+// GetProvider returns a provider by name from the default registry.
+func GetProvider(name string) (Provider, error) {
+	p, ok := DefaultRegistry.Get(name)
+	if !ok {
+		return nil, fmt.Errorf("unknown provider: %s", name)
+	}
+	return p, nil
+}
+
+// ListProviders returns all registered providers.
+func ListProviders() []Provider {
+	return DefaultRegistry.List()
+}
+
+// ListInstalledProviders returns all installed providers.
+func ListInstalledProviders(ctx context.Context) []Provider {
+	return DefaultRegistry.ListInstalled(ctx)
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,223 @@
+package provider
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewRegistry(t *testing.T) {
+	r := NewRegistry()
+	if r == nil {
+		t.Fatal("expected non-nil registry")
+	}
+	if len(r.providers) != 0 {
+		t.Errorf("expected empty registry, got %d providers", len(r.providers))
+	}
+}
+
+func TestRegistryRegisterAndGet(t *testing.T) {
+	r := NewRegistry()
+	p := NewOpenCodeProvider()
+	r.Register(p)
+
+	got, ok := r.Get("opencode")
+	if !ok {
+		t.Fatal("expected to find registered provider")
+	}
+	if got.Name() != "opencode" {
+		t.Errorf("expected name 'opencode', got %q", got.Name())
+	}
+}
+
+func TestRegistryGetNotFound(t *testing.T) {
+	r := NewRegistry()
+	_, ok := r.Get("nonexistent")
+	if ok {
+		t.Error("expected not to find unregistered provider")
+	}
+}
+
+func TestRegistryList(t *testing.T) {
+	r := NewRegistry()
+	r.Register(NewOpenCodeProvider())
+	r.Register(NewClaudeProvider())
+
+	list := r.List()
+	if len(list) != 2 {
+		t.Errorf("expected 2 providers, got %d", len(list))
+	}
+}
+
+func TestDefaultRegistryHasProviders(t *testing.T) {
+	// Default registry should have built-in providers
+	if len(DefaultRegistry.providers) == 0 {
+		t.Error("expected default registry to have providers")
+	}
+
+	// Check for expected providers
+	if _, ok := DefaultRegistry.Get("opencode"); !ok {
+		t.Error("expected opencode provider in default registry")
+	}
+	if _, ok := DefaultRegistry.Get("claude"); !ok {
+		t.Error("expected claude provider in default registry")
+	}
+}
+
+func TestGetProvider(t *testing.T) {
+	p, err := GetProvider("opencode")
+	if err != nil {
+		t.Fatalf("GetProvider failed: %v", err)
+	}
+	if p.Name() != "opencode" {
+		t.Errorf("expected name 'opencode', got %q", p.Name())
+	}
+}
+
+func TestGetProviderNotFound(t *testing.T) {
+	_, err := GetProvider("nonexistent")
+	if err == nil {
+		t.Error("expected error for unknown provider")
+	}
+}
+
+func TestOpenCodeProvider(t *testing.T) {
+	p := NewOpenCodeProvider()
+
+	if p.Name() != "opencode" {
+		t.Errorf("expected name 'opencode', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() == "" {
+		t.Error("expected non-empty command")
+	}
+}
+
+func TestOpenCodeDetectState(t *testing.T) {
+	p := NewOpenCodeProvider()
+	ctx := context.Background()
+	_ = ctx // unused in DetectState but keeps pattern consistent
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{
+			name:   "working spinner",
+			output: "⠋ Processing files...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working thinking",
+			output: "thinking about your request\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "done checkmark",
+			output: "✓ Task complete\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done finished",
+			output: "Task finished successfully\n",
+			want:   StateDone,
+		},
+		{
+			name:   "error",
+			output: "error: file not found\n",
+			want:   StateError,
+		},
+		{
+			name:   "idle prompt",
+			output: "> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "unknown",
+			output: "some random output\n",
+			want:   StateUnknown,
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClaudeProvider(t *testing.T) {
+	p := NewClaudeProvider()
+
+	if p.Name() != "claude" {
+		t.Errorf("expected name 'claude', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() == "" {
+		t.Error("expected non-empty command")
+	}
+}
+
+func TestClaudeDetectState(t *testing.T) {
+	p := NewClaudeProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{
+			name:   "working spinner 1",
+			output: "✻ Reading file...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working spinner 2",
+			output: "✳ Analyzing code\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working tool",
+			output: "⏺ Running bash command\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "idle prompt",
+			output: "❯ ",
+			want:   StateIdle,
+		},
+		{
+			name:   "unknown",
+			output: "some output\n",
+			want:   StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListProviders(t *testing.T) {
+	providers := ListProviders()
+	if len(providers) < 2 {
+		t.Errorf("expected at least 2 providers, got %d", len(providers))
+	}
+}


### PR DESCRIPTION
## Summary
Add provider package with abstraction layer for AI agent providers.
This enables bc to support multiple AI coding assistants.

## Changes
- `pkg/provider/provider.go`: Provider interface and registry
- `pkg/provider/opencode.go`: OpenCode/Crush implementation  
- `pkg/provider/claude.go`: Claude Code implementation
- `pkg/provider/provider_test.go`: 12 comprehensive tests
- `config.toml`: Add opencode to tools and agents sections

## Provider Interface
```go
type Provider interface {
    Name() string
    Description() string
    Command() string
    IsInstalled(ctx context.Context) bool
    Version(ctx context.Context) string
    DetectState(output string) State
}
```

## Usage
```bash
bc agent create --tool opencode --name oc-01
bc agent send oc-01 'Implement feature X'
```

## Test Plan
- [x] Lint passes
- [x] 12 provider tests pass with race detector
- [x] Config regenerated successfully
- [ ] Integration test with actual crush binary (if installed)

Part of Epic #1429: Multi-Agent Integration
Fixes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)