### PR TITLE
fix(tui): Update tests for HintsContext pattern (#1497)

### DIFF
--- a/tui/src/__tests__/MemoryView.test.tsx
+++ b/tui/src/__tests__/MemoryView.test.tsx
@@ -1,13 +1,28 @@
 /**
  * MemoryView tests
  * Issue #1231 - Additional TUI views
+ * Issue #1497 - Updated for HintsContext pattern
  */
 
 import React from 'react';
 import { render } from 'ink-testing-library';
+import { Text, Box } from 'ink';
 import { MemoryView } from '../views/MemoryView';
 import { FocusProvider } from '../navigation/FocusContext';
+import { HintsProvider, useHintsContext } from '../hooks/useHintsContext';
 import * as bc from '../services/bc';
+
+// Helper to display hints from context
+function HintsDisplay(): React.ReactElement {
+  const { viewHints } = useHintsContext();
+  return (
+    <Box>
+      {viewHints.map((h) => (
+        <Text key={h.key}>[{h.key}] {h.label}</Text>
+      ))}
+    </Box>
+  );
+}
 
 // Mock the bc service
 jest.mock('../services/bc', () => ({
@@ -20,11 +35,14 @@ jest.mock('../services/bc', () => ({
 const mockGetMemoryList = bc.getMemoryList as jest.Mock;
 const mockGetMemory = bc.getMemory as jest.Mock;
 
-function renderMemoryView(props = {}) {
+function renderMemoryView(props = {}, withHintsDisplay = false) {
   return render(
-    <FocusProvider>
-      <MemoryView disableInput {...props} />
-    </FocusProvider>
+    <HintsProvider>
+      <FocusProvider>
+        <MemoryView disableInput {...props} />
+        {withHintsDisplay && <HintsDisplay />}
+      </FocusProvider>
+    </HintsProvider>
   );
 }
 
@@ -70,11 +88,12 @@ describe('MemoryView', () => {
   });
 
   test('displays keyboard hints', async () => {
+    // Issue #1497: Hints now go to global footer via HintsContext
     mockGetMemoryList.mockResolvedValue({
       agents: [{ agent: 'eng-01', experience_count: 1, learning_count: 1 }],
     });
 
-    const { lastFrame } = renderMemoryView();
+    const { lastFrame } = renderMemoryView({}, true);
     await new Promise(resolve => setTimeout(resolve, 100));
 
     const output = lastFrame() ?? '';

--- a/tui/src/__tests__/RoutingView.test.tsx
+++ b/tui/src/__tests__/RoutingView.test.tsx
@@ -1,13 +1,28 @@
 /**
  * RoutingView tests
  * Issue #1231 - Additional TUI views
+ * Issue #1497 - Updated for HintsContext pattern
  */
 
 import React from 'react';
 import { render } from 'ink-testing-library';
+import { Text, Box } from 'ink';
 import { RoutingView } from '../views/RoutingView';
 import { FocusProvider } from '../navigation/FocusContext';
+import { HintsProvider, useHintsContext } from '../hooks/useHintsContext';
 import * as useAgentsHook from '../hooks/useAgents';
+
+// Helper to display hints from context
+function HintsDisplay(): React.ReactElement {
+  const { viewHints } = useHintsContext();
+  return (
+    <Box>
+      {viewHints.map((h) => (
+        <Text key={h.key}>[{h.key}] {h.label}</Text>
+      ))}
+    </Box>
+  );
+}
 
 // Mock the useAgents hook
 jest.mock('../hooks/useAgents', () => ({
@@ -16,11 +31,14 @@ jest.mock('../hooks/useAgents', () => ({
 
 const mockUseAgents = useAgentsHook.useAgents as jest.Mock;
 
-function renderRoutingView(props = {}) {
+function renderRoutingView(props = {}, withHintsDisplay = false) {
   return render(
-    <FocusProvider>
-      <RoutingView disableInput {...props} />
-    </FocusProvider>
+    <HintsProvider>
+      <FocusProvider>
+        <RoutingView disableInput {...props} />
+        {withHintsDisplay && <HintsDisplay />}
+      </FocusProvider>
+    </HintsProvider>
   );
 }
 
@@ -73,8 +91,10 @@ describe('RoutingView', () => {
     expect(output).toContain('Role Summary');
   });
 
-  test('shows keyboard hints', () => {
-    const { lastFrame } = renderRoutingView();
+  test('shows keyboard hints', async () => {
+    // Issue #1497: Hints now go to global footer via HintsContext
+    const { lastFrame } = renderRoutingView({}, true);
+    await new Promise((r) => setTimeout(r, 50));
     const output = lastFrame() ?? '';
 
     expect(output).toContain('j/k');

--- a/tui/src/__tests__/ViewWrapper.test.tsx
+++ b/tui/src/__tests__/ViewWrapper.test.tsx
@@ -1,13 +1,27 @@
 /**
  * ViewWrapper component tests
  * Issue #1419: TUI Production Polish
+ * Issue #1497: Updated for HintsContext pattern
  */
 
 import { describe, expect, test } from 'bun:test';
 import { render } from 'ink-testing-library';
 import React from 'react';
-import { Text } from 'ink';
+import { Text, Box } from 'ink';
 import { ViewWrapper } from '../components/ViewWrapper';
+import { HintsProvider, useHintsContext } from '../hooks/useHintsContext';
+
+// Helper to render with HintsProvider and display hints
+function HintsDisplay(): React.ReactElement {
+  const { viewHints } = useHintsContext();
+  return (
+    <Box>
+      {viewHints.map((h) => (
+        <Text key={h.key}>[{h.key}] {h.label}</Text>
+      ))}
+    </Box>
+  );
+}
 
 describe('ViewWrapper', () => {
   test('renders children', () => {
@@ -46,17 +60,22 @@ describe('ViewWrapper', () => {
     expect(lastFrame()).toContain('Something went wrong');
   });
 
-  test('renders footer with hints', () => {
+  test('renders footer with hints', async () => {
+    // Issue #1497: Hints now go to global footer via HintsContext
     const { lastFrame } = render(
-      <ViewWrapper
-        hints={[
-          { key: 'j/k', label: 'nav' },
-          { key: 'q', label: 'quit' },
-        ]}
-      >
-        <Text>Content</Text>
-      </ViewWrapper>
+      <HintsProvider>
+        <ViewWrapper
+          hints={[
+            { key: 'j/k', label: 'nav' },
+            { key: 'q', label: 'quit' },
+          ]}
+        >
+          <Text>Content</Text>
+        </ViewWrapper>
+        <HintsDisplay />
+      </HintsProvider>
     );
+    await new Promise((r) => setTimeout(r, 50));
     const output = lastFrame() ?? '';
     expect(output).toContain('j/k');
     expect(output).toContain('nav');


### PR DESCRIPTION
## Summary

Tests were expecting hints to render directly in views, but HintsContext now centralizes hint management via React context.

## Changes

| File | Change |
|------|--------|
| ViewWrapper.test.tsx | Wrap in HintsProvider, add HintsDisplay helper |
| RoutingView.test.tsx | Wrap in HintsProvider, add HintsDisplay helper |
| MemoryView.test.tsx | Wrap in HintsProvider, add HintsDisplay helper |

## Test plan

- [x] `bun test` - 2076 pass, 0 fail
- [x] All 3 previously failing tests now pass

Fixes #1497

---
Generated with [Claude Code](https://claude.com/claude-code)