### PR TITLE
feat(provider): Add Codex CLI provider integration (#1479)

### DIFF
--- a/pkg/provider/codex.go
+++ b/pkg/provider/codex.go
@@ -1,0 +1,121 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// CodexProvider implements the Provider interface for OpenAI Codex CLI.
+// Codex is OpenAI's code generation model.
+//
+// Issue #1479: Codex CLI Provider Integration
+type CodexProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewCodexProvider creates a new Codex provider.
+func NewCodexProvider() *CodexProvider {
+	return &CodexProvider{
+		name:        "codex",
+		description: "OpenAI Codex CLI",
+		command:     "codex --full-auto",
+		binary:      "codex",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *CodexProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *CodexProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *CodexProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *CodexProvider) IsInstalled(ctx context.Context) bool {
+	return checkBinaryExists(ctx, p.binary)
+}
+
+// Version returns the installed version.
+func (p *CodexProvider) Version(ctx context.Context) string {
+	return getBinaryVersion(ctx, p.binary, "--version")
+}
+
+// DetectState analyzes output to determine agent state.
+// Codex uses specific output patterns for state detection.
+func (p *CodexProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	// Check last few lines for state indicators
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+		lineLower := strings.ToLower(line)
+
+		// Working indicators - Codex spinner patterns
+		if strings.HasPrefix(line, "⠋") ||
+			strings.HasPrefix(line, "⠙") ||
+			strings.HasPrefix(line, "⠹") ||
+			strings.HasPrefix(line, "⠸") ||
+			strings.HasPrefix(line, "⠼") ||
+			strings.HasPrefix(line, "⠴") ||
+			strings.Contains(lineLower, "generating") ||
+			strings.Contains(lineLower, "thinking") ||
+			strings.Contains(lineLower, "processing") ||
+			strings.Contains(lineLower, "executing") {
+			return StateWorking
+		}
+
+		// Done indicators
+		if strings.Contains(line, "✓") ||
+			strings.Contains(line, "✔") ||
+			strings.Contains(lineLower, "complete") ||
+			strings.Contains(lineLower, "finished") ||
+			strings.Contains(lineLower, "done") ||
+			strings.Contains(lineLower, "success") {
+			return StateDone
+		}
+
+		// Error indicators
+		if strings.Contains(lineLower, "error") ||
+			strings.Contains(lineLower, "failed") ||
+			strings.Contains(lineLower, "exception") ||
+			strings.Contains(line, "✗") ||
+			strings.Contains(line, "✖") {
+			return StateError
+		}
+
+		// Stuck indicators
+		if strings.Contains(lineLower, "timeout") ||
+			strings.Contains(lineLower, "rate limit") ||
+			strings.Contains(lineLower, "quota exceeded") {
+			return StateStuck
+		}
+
+		// Idle/prompt indicators
+		if strings.HasPrefix(line, ">") ||
+			strings.HasPrefix(line, "$") ||
+			strings.HasPrefix(line, "codex>") ||
+			strings.Contains(lineLower, "ready") ||
+			strings.Contains(lineLower, "awaiting") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure CodexProvider implements Provider interface.
+var _ Provider = (*CodexProvider)(nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -94,6 +94,7 @@ func init() {
 	// Register built-in providers
 	DefaultRegistry.Register(NewOpenCodeProvider())
 	DefaultRegistry.Register(NewClaudeProvider())
+	DefaultRegistry.Register(NewCodexProvider())
 }
 
 // checkBinaryExists checks if a binary exists in PATH.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -61,6 +61,9 @@ func TestDefaultRegistryHasProviders(t *testing.T) {
 	if _, ok := DefaultRegistry.Get("claude"); !ok {
 		t.Error("expected claude provider in default registry")
 	}
+	if _, ok := DefaultRegistry.Get("codex"); !ok {
+		t.Error("expected codex provider in default registry")
+	}
 }
 
 func TestGetProvider(t *testing.T) {
@@ -215,9 +218,103 @@ func TestClaudeDetectState(t *testing.T) {
 	}
 }
 
+func TestCodexProvider(t *testing.T) {
+	p := NewCodexProvider()
+
+	if p.Name() != "codex" {
+		t.Errorf("expected name 'codex', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() == "" {
+		t.Error("expected non-empty command")
+	}
+}
+
+func TestCodexDetectState(t *testing.T) {
+	p := NewCodexProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{
+			name:   "working spinner",
+			output: "⠋ Generating code...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working thinking",
+			output: "thinking about your request\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working executing",
+			output: "Executing command...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "done checkmark",
+			output: "✓ Code generated\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done success",
+			output: "Operation completed with success\n",
+			want:   StateDone,
+		},
+		{
+			name:   "error",
+			output: "Error: API call failed\n",
+			want:   StateError,
+		},
+		{
+			name:   "error exception",
+			output: "Exception occurred during generation\n",
+			want:   StateError,
+		},
+		{
+			name:   "stuck rate limit",
+			output: "Rate limit exceeded\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "stuck quota",
+			output: "Quota exceeded for API\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "idle prompt",
+			output: "codex> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "idle ready",
+			output: "Ready for input\n",
+			want:   StateIdle,
+		},
+		{
+			name:   "unknown",
+			output: "some random output\n",
+			want:   StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestListProviders(t *testing.T) {
 	providers := ListProviders()
-	if len(providers) < 2 {
-		t.Errorf("expected at least 2 providers, got %d", len(providers))
+	if len(providers) < 3 {
+		t.Errorf("expected at least 3 providers, got %d", len(providers))
 	}
 }


### PR DESCRIPTION
## Summary
Add Codex CLI provider to the provider package for bc multi-agent support.

## Changes
- `pkg/provider/codex.go`: OpenAI Codex CLI implementation
- `pkg/provider/provider.go`: Register Codex in default registry
- `pkg/provider/provider_test.go`: 14 Codex-specific tests

## Codex Provider Features
- Binary detection for `codex` command
- State detection patterns:
  - Working: spinners, "generating", "thinking", "executing"
  - Done: checkmarks, "complete", "success"
  - Error: "error", "failed", "exception"
  - Stuck: "timeout", "rate limit", "quota exceeded"
  - Idle: prompts, "ready", "awaiting"
- Version checking

## Usage
```bash
bc agent create --tool codex --name cdx-01
bc agent send cdx-01 'Generate function X'
```

## Test Plan
- [x] Lint passes
- [x] 14 Codex provider tests pass with race detector
- [x] All 25 provider tests pass

Part of Epic #1429: Multi-Agent Integration
Fixes #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)