### PR TITLE
feat(provider): add OpenClaw provider integration

### DIFF
--- a/pkg/provider/openclaw.go
+++ b/pkg/provider/openclaw.go
@@ -1,0 +1,129 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// OpenClawProvider implements the Provider interface for OpenClaw CLI.
+// OpenClaw is an open-source AI coding assistant.
+//
+// Issue #1478: OpenClaw CLI Provider Integration
+type OpenClawProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewOpenClawProvider creates a new OpenClaw provider.
+func NewOpenClawProvider() *OpenClawProvider {
+	return &OpenClawProvider{
+		name:        "openclaw",
+		description: "OpenClaw AI Coding Assistant",
+		command:     "openclaw --auto",
+		binary:      "openclaw",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *OpenClawProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *OpenClawProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *OpenClawProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *OpenClawProvider) IsInstalled(ctx context.Context) bool {
+	return checkBinaryExists(ctx, p.binary)
+}
+
+// Version returns the installed version.
+func (p *OpenClawProvider) Version(ctx context.Context) string {
+	return getBinaryVersion(ctx, p.binary, "--version")
+}
+
+// DetectState analyzes output to determine agent state.
+// OpenClaw uses specific output patterns for state detection.
+func (p *OpenClawProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	// Check last few lines for state indicators
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+		lineLower := strings.ToLower(line)
+
+		// Working indicators - OpenClaw spinner and activity patterns
+		if strings.HasPrefix(line, "⠋") ||
+			strings.HasPrefix(line, "⠙") ||
+			strings.HasPrefix(line, "⠹") ||
+			strings.HasPrefix(line, "⠸") ||
+			strings.HasPrefix(line, "⠼") ||
+			strings.HasPrefix(line, "⠴") ||
+			strings.HasPrefix(line, "🔍") ||
+			strings.HasPrefix(line, "🔧") ||
+			strings.Contains(lineLower, "analyzing") ||
+			strings.Contains(lineLower, "thinking") ||
+			strings.Contains(lineLower, "processing") ||
+			strings.Contains(lineLower, "working") ||
+			strings.Contains(lineLower, "searching") {
+			return StateWorking
+		}
+
+		// Done indicators
+		if strings.Contains(line, "✓") ||
+			strings.Contains(line, "✔") ||
+			strings.Contains(line, "🎉") ||
+			strings.Contains(lineLower, "complete") ||
+			strings.Contains(lineLower, "finished") ||
+			strings.Contains(lineLower, "done") ||
+			strings.Contains(lineLower, "success") {
+			return StateDone
+		}
+
+		// Stuck indicators - check before error since some stuck messages contain "error"
+		if strings.Contains(lineLower, "timeout") ||
+			strings.Contains(lineLower, "rate limit") ||
+			strings.Contains(lineLower, "quota") ||
+			strings.Contains(lineLower, "connection refused") ||
+			strings.Contains(lineLower, "network error") {
+			return StateStuck
+		}
+
+		// Error indicators
+		if strings.Contains(lineLower, "error") ||
+			strings.Contains(lineLower, "failed") ||
+			strings.Contains(lineLower, "exception") ||
+			strings.Contains(line, "✗") ||
+			strings.Contains(line, "✖") ||
+			strings.Contains(line, "❌") {
+			return StateError
+		}
+
+		// Idle/prompt indicators
+		if strings.HasPrefix(line, ">") ||
+			strings.HasPrefix(line, "$") ||
+			strings.HasPrefix(line, "openclaw>") ||
+			strings.HasPrefix(line, "claw>") ||
+			strings.Contains(lineLower, "ready") ||
+			strings.Contains(lineLower, "awaiting input") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure OpenClawProvider implements Provider interface.
+var _ Provider = (*OpenClawProvider)(nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -95,6 +95,7 @@ func init() {
 	DefaultRegistry.Register(NewOpenCodeProvider())
 	DefaultRegistry.Register(NewClaudeProvider())
 	DefaultRegistry.Register(NewCodexProvider())
+	DefaultRegistry.Register(NewOpenClawProvider())
 }
 
 // checkBinaryExists checks if a binary exists in PATH.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -64,6 +64,9 @@ func TestDefaultRegistryHasProviders(t *testing.T) {
 	if _, ok := DefaultRegistry.Get("codex"); !ok {
 		t.Error("expected codex provider in default registry")
 	}
+	if _, ok := DefaultRegistry.Get("openclaw"); !ok {
+		t.Error("expected openclaw provider in default registry")
+	}
 }
 
 func TestGetProvider(t *testing.T) {
@@ -314,7 +317,131 @@ func TestCodexDetectState(t *testing.T) {
 
 func TestListProviders(t *testing.T) {
 	providers := ListProviders()
-	if len(providers) < 3 {
-		t.Errorf("expected at least 3 providers, got %d", len(providers))
+	if len(providers) < 4 {
+		t.Errorf("expected at least 4 providers, got %d", len(providers))
+	}
+}
+
+func TestOpenClawProvider(t *testing.T) {
+	p := NewOpenClawProvider()
+
+	if p.Name() != "openclaw" {
+		t.Errorf("expected name 'openclaw', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() == "" {
+		t.Error("expected non-empty command")
+	}
+}
+
+func TestOpenClawDetectState(t *testing.T) {
+	p := NewOpenClawProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{
+			name:   "working spinner",
+			output: "⠋ Analyzing codebase...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working search emoji",
+			output: "🔍 Searching for files\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working tool emoji",
+			output: "🔧 Applying changes\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working thinking",
+			output: "thinking about your request\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working searching",
+			output: "Searching for relevant code...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "done checkmark",
+			output: "✓ Changes applied\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done celebration",
+			output: "🎉 Task completed successfully\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done finished",
+			output: "Task finished successfully\n",
+			want:   StateDone,
+		},
+		{
+			name:   "error",
+			output: "error: cannot read file\n",
+			want:   StateError,
+		},
+		{
+			name:   "error cross",
+			output: "❌ Failed to compile\n",
+			want:   StateError,
+		},
+		{
+			name:   "stuck timeout",
+			output: "Connection timeout\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "stuck rate limit",
+			output: "Rate limit exceeded\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "stuck network",
+			output: "Network error: connection refused\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "idle prompt",
+			output: "openclaw> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "idle claw prompt",
+			output: "claw> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "idle ready",
+			output: "Ready for input\n",
+			want:   StateIdle,
+		},
+		{
+			name:   "unknown",
+			output: "some random output\n",
+			want:   StateUnknown,
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add OpenClaw AI coding assistant as a provider in bc's multi-agent system
- Implement full Provider interface with state detection
- Support for detecting working, done, error, stuck, and idle states
- 18 comprehensive state detection tests

## Details
- Created `pkg/provider/openclaw.go` with complete implementation
- Registered provider in DefaultRegistry initialization
- State detection handles emoji indicators (🔍, 🔧, 🎉, ❌)
- Detects stuck states: network errors, timeouts, rate limits, quotas

## Test plan
- [x] All 43 provider tests pass
- [x] Lint passes with no issues
- [x] Pre-commit hooks pass

Closes #1478

Part of Epic #1429: Multi-Agent Integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)