### PR TITLE
fix(tui): Fix sidebar label rendering artifacts at 120+ cols (#1501)

### DIFF
--- a/tui/src/navigation/Drawer.tsx
+++ b/tui/src/navigation/Drawer.tsx
@@ -183,8 +183,8 @@ export function Drawer({
 
           return (
             <Box key={section.title} flexDirection="column" marginBottom={1}>
-              {/* Section header */}
-              <Text dimColor bold>{section.title}</Text>
+              {/* Section header - #1501 fix: truncate to prevent overflow */}
+              <Text dimColor bold wrap="truncate">{section.title}</Text>
               {/* Section items */}
               {sectionTabs.map(tab => {
                 const globalIndex = mainTabs.findIndex(t => t.view === tab.view);
@@ -246,6 +246,7 @@ function DrawerItem({ tab, isActive, isHighlighted, useShortLabel = false }: Dra
   // Use shortLabel when width is constrained (#1364)
   const label = useShortLabel && tab.shortLabel ? tab.shortLabel : tab.label;
 
+  // #1501 fix: Use wrap="truncate" to prevent text overflow and rendering artifacts
   return (
     <Box>
       <Text color={isHighlighted ? 'yellow' : isActive ? 'green' : undefined}>{indicator}</Text>
@@ -253,6 +254,7 @@ function DrawerItem({ tab, isActive, isHighlighted, useShortLabel = false }: Dra
         bold={isBold}
         color={textColor}
         dimColor={isDim}
+        wrap="truncate"
       >
         {' '}{label}
       </Text>


### PR DESCRIPTION
## Summary
- Fix sidebar label rendering artifacts at 120+ column terminals
- Add `wrap="truncate"` to Drawer text elements

## Problem
At 120+ col terminals, sidebar showed:
- Extra characters appearing ('Filess', 'Logss')
- Labels splitting across lines ('Process'/'es')
- Rendering buffer overflow artifacts

## Solution
Add explicit text truncation to prevent overflow when full labels are displayed.

## Test plan
- [ ] Verify sidebar renders correctly at 120x30 terminal
- [ ] Verify 80x24 and 100x24 still work
- [ ] Check section headers and item labels

Fixes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)