### PR TITLE
feat(provider): add Aider AI pair programming provider

### DIFF
--- a/pkg/provider/aider.go
+++ b/pkg/provider/aider.go
@@ -1,0 +1,126 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// AiderProvider implements the Provider interface for Aider.
+// Aider is a terminal-based AI pair programming tool.
+//
+// Issue #1477: Aider Provider Integration
+type AiderProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewAiderProvider creates a new Aider provider.
+func NewAiderProvider() *AiderProvider {
+	return &AiderProvider{
+		name:        "aider",
+		description: "Aider AI Pair Programming",
+		command:     "aider --yes",
+		binary:      "aider",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *AiderProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *AiderProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *AiderProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *AiderProvider) IsInstalled(ctx context.Context) bool {
+	return checkBinaryExists(ctx, p.binary)
+}
+
+// Version returns the installed version.
+func (p *AiderProvider) Version(ctx context.Context) string {
+	return getBinaryVersion(ctx, p.binary, "--version")
+}
+
+// DetectState analyzes output to determine agent state.
+// Aider uses specific output patterns for state detection.
+func (p *AiderProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	// Check last few lines for state indicators
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+		lineLower := strings.ToLower(line)
+
+		// Working indicators - Aider shows activity patterns
+		if strings.Contains(lineLower, "thinking") ||
+			strings.Contains(lineLower, "sending") ||
+			strings.Contains(lineLower, "editing") ||
+			strings.Contains(lineLower, "running") ||
+			strings.Contains(lineLower, "applying") ||
+			strings.Contains(lineLower, "streaming") ||
+			strings.Contains(lineLower, "analyzing") ||
+			strings.HasPrefix(line, "⠋") ||
+			strings.HasPrefix(line, "⠙") ||
+			strings.HasPrefix(line, "⠹") ||
+			strings.HasPrefix(line, "⠸") {
+			return StateWorking
+		}
+
+		// Done indicators - Aider completion patterns
+		if strings.Contains(lineLower, "applied edit") ||
+			strings.Contains(lineLower, "wrote") ||
+			strings.Contains(lineLower, "committed") ||
+			strings.Contains(lineLower, "added to git") ||
+			strings.Contains(line, "✓") ||
+			strings.Contains(line, "✔") {
+			return StateDone
+		}
+
+		// Stuck indicators - check before error
+		if strings.Contains(lineLower, "rate limit") ||
+			strings.Contains(lineLower, "quota") ||
+			strings.Contains(lineLower, "timeout") ||
+			strings.Contains(lineLower, "connection error") ||
+			strings.Contains(lineLower, "api key") ||
+			strings.Contains(lineLower, "authentication") {
+			return StateStuck
+		}
+
+		// Error indicators
+		if strings.Contains(lineLower, "error") ||
+			strings.Contains(lineLower, "failed") ||
+			strings.Contains(lineLower, "exception") ||
+			strings.Contains(lineLower, "traceback") ||
+			strings.Contains(line, "✗") ||
+			strings.Contains(line, "❌") {
+			return StateError
+		}
+
+		// Idle/prompt indicators - Aider prompt patterns
+		if strings.HasPrefix(line, ">") ||
+			strings.HasPrefix(line, "aider>") ||
+			strings.Contains(lineLower, "enter to send") ||
+			strings.Contains(lineLower, "waiting for input") ||
+			strings.HasSuffix(lineLower, "? ") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure AiderProvider implements Provider interface.
+var _ Provider = (*AiderProvider)(nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -96,6 +96,7 @@ func init() {
 	DefaultRegistry.Register(NewClaudeProvider())
 	DefaultRegistry.Register(NewCodexProvider())
 	DefaultRegistry.Register(NewOpenClawProvider())
+	DefaultRegistry.Register(NewAiderProvider())
 }
 
 // checkBinaryExists checks if a binary exists in PATH.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -67,6 +67,9 @@ func TestDefaultRegistryHasProviders(t *testing.T) {
 	if _, ok := DefaultRegistry.Get("openclaw"); !ok {
 		t.Error("expected openclaw provider in default registry")
 	}
+	if _, ok := DefaultRegistry.Get("aider"); !ok {
+		t.Error("expected aider provider in default registry")
+	}
 }
 
 func TestGetProvider(t *testing.T) {
@@ -317,8 +320,8 @@ func TestCodexDetectState(t *testing.T) {
 
 func TestListProviders(t *testing.T) {
 	providers := ListProviders()
-	if len(providers) < 4 {
-		t.Errorf("expected at least 4 providers, got %d", len(providers))
+	if len(providers) < 5 {
+		t.Errorf("expected at least 5 providers, got %d", len(providers))
 	}
 }
 
@@ -422,6 +425,140 @@ func TestOpenClawDetectState(t *testing.T) {
 		{
 			name:   "idle ready",
 			output: "Ready for input\n",
+			want:   StateIdle,
+		},
+		{
+			name:   "unknown",
+			output: "some random output\n",
+			want:   StateUnknown,
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAiderProvider(t *testing.T) {
+	p := NewAiderProvider()
+
+	if p.Name() != "aider" {
+		t.Errorf("expected name 'aider', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() == "" {
+		t.Error("expected non-empty command")
+	}
+}
+
+func TestAiderDetectState(t *testing.T) {
+	p := NewAiderProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{
+			name:   "working thinking",
+			output: "thinking about your request...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working sending",
+			output: "Sending request to API...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working editing",
+			output: "Editing file.py\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working streaming",
+			output: "Streaming response...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working spinner",
+			output: "⠋ Processing...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "done applied edit",
+			output: "Applied edit to main.py\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done wrote",
+			output: "Wrote 150 lines to file.py\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done committed",
+			output: "Committed changes: feat: add feature\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done checkmark",
+			output: "✓ Changes saved\n",
+			want:   StateDone,
+		},
+		{
+			name:   "stuck rate limit",
+			output: "Rate limit exceeded, please wait\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "stuck api key",
+			output: "Invalid API key provided\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "stuck timeout",
+			output: "Connection timeout\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "error",
+			output: "Error: file not found\n",
+			want:   StateError,
+		},
+		{
+			name:   "error traceback",
+			output: "Traceback (most recent call last):\n",
+			want:   StateError,
+		},
+		{
+			name:   "error failed",
+			output: "Failed to apply changes\n",
+			want:   StateError,
+		},
+		{
+			name:   "idle prompt",
+			output: "> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "idle aider prompt",
+			output: "aider> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "idle enter to send",
+			output: "Press Enter to send message\n",
 			want:   StateIdle,
 		},
 		{


### PR DESCRIPTION
## Summary
- Add Aider as a provider in bc's multi-agent integration system
- Aider is a popular terminal-based AI pair programming tool (41k+ GitHub stars)
- Full state detection for Aider-specific output patterns

## Details
- Created `pkg/provider/aider.go` with complete implementation
- Registered provider in DefaultRegistry initialization
- 20 comprehensive state detection tests
- Detects working states: thinking, sending, editing, streaming
- Detects done states: applied edit, wrote, committed
- Detects stuck states: rate limit, API key issues, timeout
- Detects error states: traceback, failed, generic errors
- Detects idle states: prompt, enter to send

## Test plan
- [x] All 64 provider tests pass
- [x] Lint passes with no issues
- [x] Pre-commit hooks pass

Closes #1477

Part of Epic #1429: Multi-Agent Integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)