### PR TITLE
feat(provider): Add Gemini CLI provider integration (#1476)

### DIFF
--- a/pkg/provider/gemini.go
+++ b/pkg/provider/gemini.go
@@ -1,0 +1,135 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// GeminiProvider implements the Provider interface for Google Gemini CLI.
+// Gemini CLI is Google's AI coding assistant for the terminal.
+// See: https://github.com/google-gemini/gemini-cli
+//
+// Issue #1476: Gemini Provider Integration
+type GeminiProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewGeminiProvider creates a new Gemini provider.
+func NewGeminiProvider() *GeminiProvider {
+	return &GeminiProvider{
+		name:        "gemini",
+		description: "Google Gemini CLI",
+		command:     "gemini --yolo",
+		binary:      "gemini",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *GeminiProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *GeminiProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *GeminiProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *GeminiProvider) IsInstalled(ctx context.Context) bool {
+	return checkBinaryExists(ctx, p.binary)
+}
+
+// Version returns the installed version.
+func (p *GeminiProvider) Version(ctx context.Context) string {
+	return getBinaryVersion(ctx, p.binary, "--version")
+}
+
+// DetectState analyzes output to determine agent state.
+// Gemini CLI uses various indicators for different states.
+func (p *GeminiProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	// Check last few lines for state indicators
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+		lineLower := strings.ToLower(line)
+
+		// Working indicators - Gemini's thinking/processing patterns
+		if strings.Contains(lineLower, "thinking") ||
+			strings.Contains(lineLower, "processing") ||
+			strings.Contains(lineLower, "generating") ||
+			strings.Contains(lineLower, "analyzing") ||
+			strings.Contains(lineLower, "reading") ||
+			strings.Contains(lineLower, "writing") ||
+			strings.Contains(lineLower, "searching") {
+			return StateWorking
+		}
+
+		// Spinner indicators (common unicode spinners)
+		if strings.HasPrefix(line, "⠋") ||
+			strings.HasPrefix(line, "⠙") ||
+			strings.HasPrefix(line, "⠹") ||
+			strings.HasPrefix(line, "⠸") ||
+			strings.HasPrefix(line, "⠼") ||
+			strings.HasPrefix(line, "⠴") ||
+			strings.HasPrefix(line, "⠦") ||
+			strings.HasPrefix(line, "⠧") ||
+			strings.HasPrefix(line, "⠇") ||
+			strings.HasPrefix(line, "⠏") ||
+			strings.HasPrefix(line, "◐") ||
+			strings.HasPrefix(line, "◓") ||
+			strings.HasPrefix(line, "◑") ||
+			strings.HasPrefix(line, "◒") {
+			return StateWorking
+		}
+
+		// Done indicators
+		if strings.Contains(line, "✓") ||
+			strings.Contains(lineLower, "done") ||
+			strings.Contains(lineLower, "complete") ||
+			strings.Contains(lineLower, "finished") ||
+			strings.Contains(lineLower, "success") {
+			return StateDone
+		}
+
+		// Error indicators
+		if strings.Contains(lineLower, "error") ||
+			strings.Contains(lineLower, "failed") ||
+			strings.Contains(lineLower, "exception") ||
+			strings.Contains(line, "✗") ||
+			strings.Contains(line, "✘") {
+			return StateError
+		}
+
+		// Stuck indicators
+		if strings.Contains(lineLower, "stuck") ||
+			strings.Contains(lineLower, "timeout") ||
+			strings.Contains(lineLower, "timed out") ||
+			strings.Contains(lineLower, "rate limit") {
+			return StateStuck
+		}
+
+		// Idle/prompt indicators - Gemini uses ">" for prompts
+		if strings.HasPrefix(line, ">") ||
+			strings.HasPrefix(line, "❯") ||
+			strings.HasPrefix(line, "gemini>") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure GeminiProvider implements Provider interface.
+var _ Provider = (*GeminiProvider)(nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -96,6 +96,7 @@ func init() {
 	DefaultRegistry.Register(NewClaudeProvider())
 	DefaultRegistry.Register(NewCodexProvider())
 	DefaultRegistry.Register(NewOpenClawProvider())
+	DefaultRegistry.Register(NewGeminiProvider())
 }
 
 // checkBinaryExists checks if a binary exists in PATH.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -67,6 +67,9 @@ func TestDefaultRegistryHasProviders(t *testing.T) {
 	if _, ok := DefaultRegistry.Get("openclaw"); !ok {
 		t.Error("expected openclaw provider in default registry")
 	}
+	if _, ok := DefaultRegistry.Get("gemini"); !ok {
+		t.Error("expected gemini provider in default registry")
+	}
 }
 
 func TestGetProvider(t *testing.T) {
@@ -317,8 +320,8 @@ func TestCodexDetectState(t *testing.T) {
 
 func TestListProviders(t *testing.T) {
 	providers := ListProviders()
-	if len(providers) < 4 {
-		t.Errorf("expected at least 4 providers, got %d", len(providers))
+	if len(providers) < 5 {
+		t.Errorf("expected at least 5 providers, got %d", len(providers))
 	}
 }
 
@@ -422,6 +425,130 @@ func TestOpenClawDetectState(t *testing.T) {
 		{
 			name:   "idle ready",
 			output: "Ready for input\n",
+			want:   StateIdle,
+		},
+		{
+			name:   "unknown",
+			output: "some random output\n",
+			want:   StateUnknown,
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeminiProvider(t *testing.T) {
+	p := NewGeminiProvider()
+
+	if p.Name() != "gemini" {
+		t.Errorf("expected name 'gemini', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() == "" {
+		t.Error("expected non-empty command")
+	}
+}
+
+func TestGeminiDetectState(t *testing.T) {
+	p := NewGeminiProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{
+			name:   "working thinking",
+			output: "Thinking about your request...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working processing",
+			output: "Processing files...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working generating",
+			output: "Generating code...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working analyzing",
+			output: "Analyzing codebase\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working spinner",
+			output: "⠋ Working on task\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working spinner 2",
+			output: "◐ Loading...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "done checkmark",
+			output: "✓ Task completed\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done success",
+			output: "Operation success\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done finished",
+			output: "Task finished\n",
+			want:   StateDone,
+		},
+		{
+			name:   "error",
+			output: "Error: file not found\n",
+			want:   StateError,
+		},
+		{
+			name:   "error failed",
+			output: "Operation failed\n",
+			want:   StateError,
+		},
+		{
+			name:   "error x mark",
+			output: "✗ Build failed\n",
+			want:   StateError,
+		},
+		{
+			name:   "stuck timeout",
+			output: "Request timed out\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "stuck rate limit",
+			output: "Rate limit exceeded\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "idle prompt",
+			output: "> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "idle gemini prompt",
+			output: "gemini> ",
 			want:   StateIdle,
 		},
 		{


### PR DESCRIPTION
## Summary
- Add GeminiProvider for Google's Gemini CLI integration
- Implements Provider interface for state detection from terminal output
- Register Gemini in DefaultRegistry for `bc agent create --tool gemini`
- 20 comprehensive tests covering all state detection patterns

## Changes
- `pkg/provider/gemini.go`: GeminiProvider implementation
- `pkg/provider/provider.go`: Register Gemini in init()
- `pkg/provider/provider_test.go`: Test coverage for Gemini

## Test plan
- [x] `go test ./pkg/provider/...` - All 20+ tests pass
- [x] `make lint` - 0 issues
- [x] Pre-commit hooks pass

## Usage
```bash
bc agent create --tool gemini --name gem-01
bc agent send gem-01 'Implement feature X'
```

Part of Epic #1429: Multi-Agent Integration
Closes #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)