### PR TITLE
feat(provider): Add Cursor Agent provider integration (#1452)

### DIFF
--- a/pkg/provider/cursor.go
+++ b/pkg/provider/cursor.go
@@ -1,0 +1,145 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// CursorProvider implements the Provider interface for Cursor Agent.
+// Cursor is an AI-powered code editor that can run in terminal mode.
+// https://cursor.sh
+//
+// Issue #1452: Cursor Agent Integration
+type CursorProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewCursorProvider creates a new Cursor provider.
+func NewCursorProvider() *CursorProvider {
+	return &CursorProvider{
+		name:        "cursor",
+		description: "Cursor AI-powered code editor",
+		command:     "cursor-agent --force --print",
+		binary:      "cursor-agent",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *CursorProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *CursorProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *CursorProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *CursorProvider) IsInstalled(ctx context.Context) bool {
+	// Check for cursor-agent (terminal mode) first
+	if checkBinaryExists(ctx, "cursor-agent") {
+		return true
+	}
+	// Fall back to cursor CLI
+	return checkBinaryExists(ctx, "cursor")
+}
+
+// Version returns the installed version.
+func (p *CursorProvider) Version(ctx context.Context) string {
+	// Try cursor-agent first
+	if checkBinaryExists(ctx, "cursor-agent") {
+		return getBinaryVersion(ctx, "cursor-agent", "--version")
+	}
+	// Fall back to cursor
+	if checkBinaryExists(ctx, "cursor") {
+		return getBinaryVersion(ctx, "cursor", "--version")
+	}
+	return ""
+}
+
+// DetectState analyzes output to determine agent state.
+// Cursor Agent uses terminal output patterns similar to other AI agents.
+func (p *CursorProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	// Check last few lines for state indicators
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+		lineLower := strings.ToLower(line)
+
+		// Working indicators - Cursor's spinner and status patterns
+		if strings.HasPrefix(line, "⠋") ||
+			strings.HasPrefix(line, "⠙") ||
+			strings.HasPrefix(line, "⠹") ||
+			strings.HasPrefix(line, "⠸") ||
+			strings.HasPrefix(line, "⠼") ||
+			strings.HasPrefix(line, "⠴") ||
+			strings.HasPrefix(line, "⠦") ||
+			strings.HasPrefix(line, "⠧") ||
+			strings.HasPrefix(line, "⠇") ||
+			strings.HasPrefix(line, "⠏") ||
+			strings.HasPrefix(line, "◐") ||
+			strings.HasPrefix(line, "◓") ||
+			strings.HasPrefix(line, "◑") ||
+			strings.HasPrefix(line, "◒") ||
+			strings.Contains(lineLower, "thinking") ||
+			strings.Contains(lineLower, "generating") ||
+			strings.Contains(lineLower, "analyzing") ||
+			strings.Contains(lineLower, "processing") ||
+			strings.Contains(lineLower, "editing") ||
+			strings.Contains(lineLower, "applying") {
+			return StateWorking
+		}
+
+		// Done indicators
+		if strings.Contains(line, "✓") ||
+			strings.Contains(line, "✔") ||
+			strings.Contains(lineLower, "done") ||
+			strings.Contains(lineLower, "complete") ||
+			strings.Contains(lineLower, "finished") ||
+			strings.Contains(lineLower, "applied") {
+			return StateDone
+		}
+
+		// Error indicators
+		if strings.Contains(lineLower, "error") ||
+			strings.Contains(lineLower, "failed") ||
+			strings.Contains(line, "✗") ||
+			strings.Contains(line, "✖") {
+			return StateError
+		}
+
+		// Stuck indicators
+		if strings.Contains(lineLower, "stuck") ||
+			strings.Contains(lineLower, "timeout") ||
+			strings.Contains(lineLower, "timed out") {
+			return StateStuck
+		}
+
+		// Idle/prompt indicators
+		if strings.HasPrefix(line, ">") ||
+			strings.HasPrefix(line, "❯") ||
+			strings.HasPrefix(line, "$") ||
+			strings.HasPrefix(line, "cursor>") ||
+			strings.Contains(lineLower, "ready") ||
+			strings.Contains(lineLower, "waiting for input") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure CursorProvider implements Provider interface.
+var _ Provider = (*CursorProvider)(nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -96,6 +96,7 @@ func init() {
 	DefaultRegistry.Register(NewClaudeProvider())
 	DefaultRegistry.Register(NewCodexProvider())
 	DefaultRegistry.Register(NewOpenClawProvider())
+	DefaultRegistry.Register(NewCursorProvider())
 }
 
 // checkBinaryExists checks if a binary exists in PATH.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -67,6 +67,9 @@ func TestDefaultRegistryHasProviders(t *testing.T) {
 	if _, ok := DefaultRegistry.Get("openclaw"); !ok {
 		t.Error("expected openclaw provider in default registry")
 	}
+	if _, ok := DefaultRegistry.Get("cursor"); !ok {
+		t.Error("expected cursor provider in default registry")
+	}
 }
 
 func TestGetProvider(t *testing.T) {
@@ -315,13 +318,6 @@ func TestCodexDetectState(t *testing.T) {
 	}
 }
 
-func TestListProviders(t *testing.T) {
-	providers := ListProviders()
-	if len(providers) < 4 {
-		t.Errorf("expected at least 4 providers, got %d", len(providers))
-	}
-}
-
 func TestOpenClawProvider(t *testing.T) {
 	p := NewOpenClawProvider()
 
@@ -443,5 +439,141 @@ func TestOpenClawDetectState(t *testing.T) {
 				t.Errorf("DetectState() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCursorProvider(t *testing.T) {
+	p := NewCursorProvider()
+
+	if p.Name() != "cursor" {
+		t.Errorf("expected name 'cursor', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() == "" {
+		t.Error("expected non-empty command")
+	}
+}
+
+func TestCursorDetectState(t *testing.T) {
+	p := NewCursorProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{
+			name:   "working spinner",
+			output: "⠋ Processing files...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working spinner 2",
+			output: "◐ Analyzing code\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working thinking",
+			output: "Thinking about your request\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working generating",
+			output: "Generating code...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working editing",
+			output: "Editing file main.go\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "working applying",
+			output: "Applying changes...\n",
+			want:   StateWorking,
+		},
+		{
+			name:   "done checkmark",
+			output: "✓ Changes applied\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done checkmark 2",
+			output: "✔ Task complete\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done finished",
+			output: "Task finished successfully\n",
+			want:   StateDone,
+		},
+		{
+			name:   "done applied",
+			output: "Changes applied to 3 files\n",
+			want:   StateDone,
+		},
+		{
+			name:   "error",
+			output: "Error: file not found\n",
+			want:   StateError,
+		},
+		{
+			name:   "error failed",
+			output: "Operation failed\n",
+			want:   StateError,
+		},
+		{
+			name:   "error cross",
+			output: "✗ Build failed\n",
+			want:   StateError,
+		},
+		{
+			name:   "stuck timeout",
+			output: "Request timed out\n",
+			want:   StateStuck,
+		},
+		{
+			name:   "idle prompt",
+			output: "> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "idle cursor prompt",
+			output: "cursor> ",
+			want:   StateIdle,
+		},
+		{
+			name:   "idle ready",
+			output: "Ready for input\n",
+			want:   StateIdle,
+		},
+		{
+			name:   "unknown",
+			output: "some random output\n",
+			want:   StateUnknown,
+		},
+		{
+			name:   "empty",
+			output: "",
+			want:   StateUnknown,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListProviders(t *testing.T) {
+	providers := ListProviders()
+	if len(providers) < 5 {
+		t.Errorf("expected at least 5 providers, got %d", len(providers))
 	}
 }


### PR DESCRIPTION
## Summary

Add Cursor as an AI agent provider for bc orchestration, completing the multi-provider integration epic.

## Changes

| File | Change |
|------|--------|
| `pkg/provider/cursor.go` | New Cursor provider implementation |
| `pkg/provider/provider.go` | Register Cursor in default registry |
| `pkg/provider/provider_test.go` | Add 19 Cursor state detection tests |

## Features

- **Binary detection**: Checks for `cursor-agent` and `cursor` binaries
- **Version check**: Returns installed version
- **State detection**: Detects working/idle/done/error/stuck states from terminal output
- **Command**: Uses `cursor-agent --force --print`

## State Detection Patterns

| State | Patterns |
|-------|----------|
| Working | Spinners (⠋⠙⠹...), "thinking", "generating", "editing", "applying" |
| Done | ✓, ✔, "done", "complete", "finished", "applied" |
| Error | "error", "failed", ✗, ✖ |
| Stuck | "stuck", "timeout", "timed out" |
| Idle | ">", "❯", "$", "cursor>", "ready" |

## Test plan

- [x] `go test ./pkg/provider/...` - All tests pass
- [x] `make lint` - 0 issues
- [x] 19 state detection test cases

Fixes #1452

---
Generated with [Claude Code](https://claude.com/claude-code)