### PR TITLE
chore(config): add OpenClaw and Aider to agent definitions

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -204,3 +204,13 @@ description = "OpenAI Codex"
 name = "opencode"
 command = "crush"
 description = "OpenCode/Crush AI coding assistant"
+
+[[agents]]
+name = "openclaw"
+command = "openclaw --auto"
+description = "OpenClaw AI Coding Assistant"
+
+[[agents]]
+name = "aider"
+command = "aider --yes"
+description = "Aider AI Pair Programming"

--- a/config/config.go
+++ b/config/config.go
@@ -156,6 +156,16 @@ var (
 			Description: "OpenCode/Crush AI coding assistant",
 			Name:        "opencode",
 		},
+		{
+			Command:     "openclaw --auto",
+			Description: "OpenClaw AI Coding Assistant",
+			Name:        "openclaw",
+		},
+		{
+			Command:     "aider --yes",
+			Description: "Aider AI Pair Programming",
+			Name:        "aider",
+		},
 	}
 	Channels = ChannelsConfig{
 		Default: []string{"general", "engineering"},


### PR DESCRIPTION
## Summary
Add the newly implemented OpenClaw and Aider providers to the agent definitions in config.toml.

## Details
This adds the providers to the existing config system so they can be used with:
```bash
bc agent create worker-01 --tool openclaw
bc agent create worker-01 --tool aider
```

## Agent definitions added
- **openclaw**: `openclaw --auto` - OpenClaw AI Coding Assistant
- **aider**: `aider --yes` - Aider AI Pair Programming

## Note
This integrates with the existing config.toml agent system, not the new provider package.

Part of Epic #1429: Multi-Agent Integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)