### PR TITLE
test(agent): add benchmark tests for hot paths

### DIFF
--- a/pkg/agent/benchmark_test.go
+++ b/pkg/agent/benchmark_test.go
@@ -1,0 +1,131 @@
+package agent
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkGetAgent measures single agent lookup performance.
+func BenchmarkGetAgent(b *testing.B) {
+	m := NewManager("/tmp/benchmark-agents")
+
+	// Setup: create test agents
+	for i := 0; i < 100; i++ {
+		m.agents[fmt.Sprintf("agent-%03d", i)] = &Agent{
+			Name:  fmt.Sprintf("agent-%03d", i),
+			Role:  Role("engineer"),
+			State: StateIdle,
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.GetAgent("agent-050")
+	}
+}
+
+// BenchmarkListAgents measures listing all agents.
+func BenchmarkListAgents(b *testing.B) {
+	sizes := []int{10, 50, 100, 500}
+
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("agents-%d", size), func(b *testing.B) {
+			m := NewManager("/tmp/benchmark-agents")
+
+			// Setup: create test agents
+			for i := 0; i < size; i++ {
+				m.agents[fmt.Sprintf("agent-%03d", i)] = &Agent{
+					Name:  fmt.Sprintf("agent-%03d", i),
+					Role:  Role("engineer"),
+					State: StateIdle,
+				}
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = m.ListAgents()
+			}
+		})
+	}
+}
+
+// BenchmarkAgentsByState measures filtering agents by state.
+func BenchmarkAgentsByState(b *testing.B) {
+	m := NewManager("/tmp/benchmark-agents")
+
+	// Setup: create mixed state agents
+	states := []State{StateIdle, StateWorking, StateStopped, StateStarting}
+	numStates := len(states)
+	for i := 0; i < 100; i++ {
+		state := states[i%numStates] //nolint:gosec // index is bounded by numStates
+		m.agents[fmt.Sprintf("agent-%03d", i)] = &Agent{
+			Name:  fmt.Sprintf("agent-%03d", i),
+			Role:  Role("engineer"),
+			State: state,
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Manual filter by state (simulates common pattern)
+		var working []*Agent
+		for _, a := range m.agents {
+			if a.State == StateWorking {
+				working = append(working, a)
+			}
+		}
+		_ = working
+	}
+}
+
+// BenchmarkManagerCreation measures manager initialization overhead.
+func BenchmarkManagerCreation(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = NewManager("/tmp/benchmark-agents")
+	}
+}
+
+// BenchmarkAgentMapOperations measures map access patterns.
+func BenchmarkAgentMapOperations(b *testing.B) {
+	b.Run("insert", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			m := NewManager("/tmp/benchmark-agents")
+			for j := 0; j < 100; j++ {
+				m.agents[fmt.Sprintf("agent-%03d", j)] = &Agent{
+					Name: fmt.Sprintf("agent-%03d", j),
+				}
+			}
+		}
+	})
+
+	b.Run("lookup", func(b *testing.B) {
+		m := NewManager("/tmp/benchmark-agents")
+		for j := 0; j < 100; j++ {
+			m.agents[fmt.Sprintf("agent-%03d", j)] = &Agent{
+				Name: fmt.Sprintf("agent-%03d", j),
+			}
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_ = m.agents["agent-050"]
+		}
+	})
+
+	b.Run("iterate", func(b *testing.B) {
+		m := NewManager("/tmp/benchmark-agents")
+		for j := 0; j < 100; j++ {
+			m.agents[fmt.Sprintf("agent-%03d", j)] = &Agent{
+				Name: fmt.Sprintf("agent-%03d", j),
+			}
+		}
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			count := 0
+			for range m.agents {
+				count++
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Add benchmark tests for pkg/agent to establish performance baselines per eng-05's profiling recommendations.

## Benchmark Results (Apple M4 Pro)
```
BenchmarkGetAgent-12              	17212866	    63.74 ns/op
BenchmarkListAgents/agents-10-12  	 1453220	   783.3 ns/op
BenchmarkListAgents/agents-50-12  	  275665	  4306 ns/op
BenchmarkListAgents/agents-100-12 	  115120	 10821 ns/op
BenchmarkListAgents/agents-500-12 	   14412	 78764 ns/op
BenchmarkAgentsByState-12         	 1494927	   777.4 ns/op
BenchmarkManagerCreation-12       	72913608	    15.95 ns/op
BenchmarkAgentMapOperations/lookup-12  224578231	 5.370 ns/op
BenchmarkAgentMapOperations/iterate-12  2542706	   467.8 ns/op
```

## Key Findings
- GetAgent lookup: 64ns (very fast)
- ListAgents: O(n) scaling confirmed (per eng-05's finding)
- Map operations: 5ns lookup, 468ns iteration

## Test Plan
- [x] Benchmarks run successfully
- [x] Lint passes
- [x] Pre-commit hooks pass

Part of performance baseline initiative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)