### PR TITLE
fix(tui): Update Help and Footer to reflect drawer navigation (#1518, #1514)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -277,13 +277,12 @@ function HelpView(): React.ReactElement {
   const helpSections = useMemo(() => [
     { type: 'header' as const },
     { type: 'section' as const, title: 'Global', shortcuts: [
-      { keys: '1-9, 0, -', desc: 'Switch views' },
+      { keys: 'Tab', desc: 'Next view' },
+      { keys: 'Shift+Tab', desc: 'Previous view' },
       { keys: 'M', desc: 'Memory view' },
       { keys: 'R', desc: 'Routing view' },
       { keys: '?', desc: 'Toggle help' },
       { keys: 'ESC', desc: 'Go back / Home' },
-      { keys: 'Tab', desc: 'Next view' },
-      { keys: 'Shift+Tab', desc: 'Previous view' },
       { keys: 'Ctrl+R', desc: 'Refresh current view' },
       { keys: 'q', desc: 'Quit' },
     ]},

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -143,12 +143,12 @@ export function Dashboard({ onNavigate: _onNavigate }: DashboardProps) {
       {/* Performance Debug Panel - toggled with Ctrl+P or F12 (Phase 3) */}
       {showDebugPanel && <PerformanceDebugPanel compact={!isWide} forceShow />}
 
-      {/* Footer with keyboard hints - use numbers for views (#1319) */}
+      {/* Footer with keyboard hints - Issue #1514: use drawer navigation (#1467) */}
       <Footer
         hints={[
-          { key: '2', label: 'agents' },
-          { key: '3', label: 'channels' },
-          { key: '4', label: 'costs' },
+          { key: 'Tab', label: 'views' },
+          { key: 'j/k', label: 'drawer' },
+          { key: 'Enter', label: 'select' },
           { key: 'r', label: 'refresh' },
           ...(showDebugPanel ? [{ key: 'Ctrl+P', label: 'hide perf' }] : [{ key: 'Ctrl+P', label: 'perf' }]),
           { key: 'q', label: 'quit' },

--- a/tui/src/views/__tests__/Dashboard.test.tsx
+++ b/tui/src/views/__tests__/Dashboard.test.tsx
@@ -172,12 +172,13 @@ describe('Dashboard Phase 3 Integration', () => {
   });
 
   describe('Footer Hints', () => {
+    // Issue #1514: Updated hints to reflect drawer navigation (#1467)
     test('Footer hints include performance overlay toggle', () => {
       const showDebugPanel = true;
       const hints = [
-        { key: 'a', label: 'agents' },
-        { key: 'c', label: 'channels' },
-        { key: '$', label: 'costs' },
+        { key: 'Tab', label: 'views' },
+        { key: 'j/k', label: 'drawer' },
+        { key: 'Enter', label: 'select' },
         { key: 'r', label: 'refresh' },
         ...(showDebugPanel ? [{ key: 'Ctrl+P', label: 'hide perf' }] : [{ key: 'Ctrl+P', label: 'perf' }]),
         { key: 'q', label: 'quit' },
@@ -191,9 +192,9 @@ describe('Dashboard Phase 3 Integration', () => {
     test('Footer hints show "perf" when overlay is hidden', () => {
       const showDebugPanel = false;
       const hints = [
-        { key: 'a', label: 'agents' },
-        { key: 'c', label: 'channels' },
-        { key: '$', label: 'costs' },
+        { key: 'Tab', label: 'views' },
+        { key: 'j/k', label: 'drawer' },
+        { key: 'Enter', label: 'select' },
         { key: 'r', label: 'refresh' },
         ...(showDebugPanel ? [{ key: 'Ctrl+P', label: 'hide perf' }] : [{ key: 'Ctrl+P', label: 'perf' }]),
         { key: 'q', label: 'quit' },
@@ -207,9 +208,9 @@ describe('Dashboard Phase 3 Integration', () => {
     test('Footer contains all required hints', () => {
       const showDebugPanel = false;
       const hints = [
-        { key: 'a', label: 'agents' },
-        { key: 'c', label: 'channels' },
-        { key: '$', label: 'costs' },
+        { key: 'Tab', label: 'views' },
+        { key: 'j/k', label: 'drawer' },
+        { key: 'Enter', label: 'select' },
         { key: 'r', label: 'refresh' },
         ...(showDebugPanel ? [{ key: 'Ctrl+P', label: 'hide perf' }] : [{ key: 'Ctrl+P', label: 'perf' }]),
         { key: 'q', label: 'quit' },
@@ -218,9 +219,9 @@ describe('Dashboard Phase 3 Integration', () => {
       expect(hints.length).toBeGreaterThan(5);
 
       const keys = hints.map(h => h.key);
-      expect(keys).toContain('a');
-      expect(keys).toContain('c');
-      expect(keys).toContain('$');
+      expect(keys).toContain('Tab');
+      expect(keys).toContain('j/k');
+      expect(keys).toContain('Enter');
       expect(keys).toContain('r');
       expect(keys).toContain('Ctrl+P');
       expect(keys).toContain('q');


### PR DESCRIPTION
## Summary
PR #1482 changed navigation from 1-9 number shortcuts to j/k + Enter drawer navigation, but Help view and Dashboard footer still showed the old number shortcuts, causing user confusion.

## Changes
- **Help view (app.tsx)**: Remove '1-9, 0, -' shortcut hint, move Tab/Shift+Tab to top of Global section
- **Dashboard footer (Dashboard.tsx)**: Change from `[2] agents [3] channels [4] costs` to `[Tab] views [j/k] drawer [Enter] select`
- **Dashboard tests**: Update to match new hints

## Test plan
- [x] `bun test` passes (2076 pass, 124 skip, 0 fail)
- [x] `bun run build` passes
- [x] Help view no longer shows number shortcuts
- [x] Dashboard footer shows correct navigation hints

Fixes #1518, #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)