### PR TITLE
fix(tui): Update Help view to match actual keyboard shortcuts

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -277,13 +277,12 @@ function HelpView(): React.ReactElement {
   const helpSections = useMemo(() => [
     { type: 'header' as const },
     { type: 'section' as const, title: 'Global', shortcuts: [
-      { keys: '1-9, 0, -', desc: 'Switch views' },
+      { keys: 'Tab', desc: 'Switch views (next)' },
+      { keys: 'Shift+Tab', desc: 'Switch views (previous)' },
       { keys: 'M', desc: 'Memory view' },
       { keys: 'R', desc: 'Routing view' },
       { keys: '?', desc: 'Toggle help' },
       { keys: 'ESC', desc: 'Go back / Home' },
-      { keys: 'Tab', desc: 'Next view' },
-      { keys: 'Shift+Tab', desc: 'Previous view' },
       { keys: 'Ctrl+R', desc: 'Refresh current view' },
       { keys: 'q', desc: 'Quit' },
     ]},


### PR DESCRIPTION
## Summary
- Remove outdated '1-9, 0, -' number shortcuts from Help view
- These shortcuts were removed in #1467 but Help wasn't updated

## Root Cause
PR #1467 removed number key shortcuts from `useKeyboardNavigation.ts` to simplify navigation, but the Help section in `app.tsx` wasn't updated.

## Fix
Updated Help view to show actual navigation:
- Tab/Shift+Tab to switch views
- j/k to navigate drawer/lists  
- Enter to select

## Test plan
- [x] TUI tests pass
- [x] Lint passes
- [x] Manual verification: Help now shows accurate shortcuts

Fixes #1518, fixes #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)