### PR TITLE
fix(tui): remove obsolete number shortcuts from Help view

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -277,13 +277,12 @@ function HelpView(): React.ReactElement {
   const helpSections = useMemo(() => [
     { type: 'header' as const },
     { type: 'section' as const, title: 'Global', shortcuts: [
-      { keys: '1-9, 0, -', desc: 'Switch views' },
+      { keys: 'Tab', desc: 'Open drawer / Next view' },
+      { keys: 'Shift+Tab', desc: 'Previous view' },
       { keys: 'M', desc: 'Memory view' },
       { keys: 'R', desc: 'Routing view' },
       { keys: '?', desc: 'Toggle help' },
       { keys: 'ESC', desc: 'Go back / Home' },
-      { keys: 'Tab', desc: 'Next view' },
-      { keys: 'Shift+Tab', desc: 'Previous view' },
       { keys: 'Ctrl+R', desc: 'Refresh current view' },
       { keys: 'q', desc: 'Quit' },
     ]},

--- a/tui/src/navigation/TabBar.tsx
+++ b/tui/src/navigation/TabBar.tsx
@@ -6,6 +6,10 @@
  * - Short (100-119 cols): [1] Dash [2] Agt ... (~105 cols needed)
  * - Minimal (<100 cols): [1] [2] [3] ... (~55 cols needed, fits 80x24)
  *
+ * Note: Numbers in brackets are position indicators only, not keyboard shortcuts.
+ * Navigation uses Tab key to open drawer, then j/k + Enter to select views.
+ * See Issue #1467 for navigation change details.
+ *
  * Issue #1109: Fixed 80x24 display by using minimal mode at <100 cols
  */
 


### PR DESCRIPTION
## Summary
- Remove obsolete "1-9, 0, -" shortcut hint from Help view
- Update TabBar documentation to clarify numbers are position indicators

## Problem
PR #1482 changed navigation from number keys (1-9) to drawer-based navigation (Tab + j/k + Enter), but the Help view still showed the old shortcuts, causing user confusion.

## Changes
- `app.tsx`: Remove "1-9, 0, - Switch views" from Help shortcuts
- `app.tsx`: Reorder hints to put Tab first (primary navigation method)
- `TabBar.tsx`: Add comment clarifying numbers are position indicators only

## Test plan
- [x] TUI tests pass (1 pass, 4 skip - TTY deps)
- [x] Lint clean (warnings only in unrelated test file)
- [x] Help view now shows correct navigation shortcuts

Fixes #1518, #1514

🤖 Generated with [Claude Code](https://claude.com/claude-code)