### PR TITLE
fix(tui): Remove Tab key conflicts to allow global view navigation

### DIFF
--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -207,14 +207,9 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
         setActiveTab('details');
       } else if (input === '3') {
         setActiveTab('metrics');
-      } else if (key.tab) {
-        // Cycle through tabs
-        setActiveTab(prev => {
-          if (prev === 'output') return 'details';
-          if (prev === 'details') return 'metrics';
-          return 'output';
-        });
       }
+      // Note: Tab removed to allow global view navigation (#1520)
+      // Use 1/2/3 to switch tabs within this view
     }
   });
 

--- a/tui/src/views/FilesView.tsx
+++ b/tui/src/views/FilesView.tsx
@@ -121,21 +121,21 @@ export function FilesView({ onBack }: FilesViewProps): React.ReactElement {
       return;
     }
 
-    // Tab: cycle focus areas
-    if (key.tab) {
-      if (!key.shift) {
-        setFocusArea(prev => {
-          if (prev === 'worktree') return 'tree';
-          if (prev === 'tree') return 'preview';
-          return 'worktree';
-        });
-      } else {
-        setFocusArea(prev => {
-          if (prev === 'worktree') return 'preview';
-          if (prev === 'tree') return 'worktree';
-          return 'tree';
-        });
-      }
+    // f/F: cycle focus areas (Tab reserved for global view navigation #1520)
+    if (input === 'f') {
+      setFocusArea(prev => {
+        if (prev === 'worktree') return 'tree';
+        if (prev === 'tree') return 'preview';
+        return 'worktree';
+      });
+      return;
+    }
+    if (input === 'F') {
+      setFocusArea(prev => {
+        if (prev === 'worktree') return 'preview';
+        if (prev === 'tree') return 'worktree';
+        return 'tree';
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Fix P1 navigation trapped issue where Tab doesn't switch views
- Views were consuming Tab for local functionality

## Root Cause
Multiple views registered `useInput` hooks that consume Tab before global `useKeyboardNavigation` could receive it:

- `AgentDetailView.tsx`: Used Tab to cycle internal tabs
- `FilesView.tsx`: Used Tab to cycle focus areas

## Fix
- AgentDetailView: Remove Tab handling (1/2/3 already works for tabs)
- FilesView: Change Tab to f/F for focus area cycling

Tab is now reserved for global view navigation.

## Test plan
- [x] TUI tests pass (13 pass, 8 skip, 0 fail)
- [x] Lint passes
- [x] Manual: Tab now switches between views globally

Fixes #1520

🤖 Generated with [Claude Code](https://claude.com/claude-code)