### PR TITLE
fix(cli): Update --tool flag help text to list all 7 providers

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -298,7 +298,7 @@ var (
 
 func init() {
 	// Create flags
-	agentCreateCmd.Flags().StringVar(&agentCreateTool, "tool", "", "Agent tool (claude, cursor, codex)")
+	agentCreateCmd.Flags().StringVar(&agentCreateTool, "tool", "", "Agent tool (claude, gemini, cursor, codex, opencode, openclaw, aider)")
 	agentCreateCmd.Flags().StringVar(&agentCreateRole, "role", "", "Agent role (engineer, manager, product-manager, tech-lead, qa). Required. Use 'bc role list' to see available roles")
 	agentCreateCmd.Flags().StringVar(&agentCreateParent, "parent", "", "Parent agent ID (must have permission to create this role)")
 	agentCreateCmd.Flags().StringVar(&agentCreateTeam, "team", "", "Team name (alphanumeric)")


### PR DESCRIPTION
## Summary
- Update `--tool` flag help text to show all 7 available providers
- Previous: `(claude, cursor, codex)`
- Updated: `(claude, gemini, cursor, codex, opencode, openclaw, aider)`

## Root Cause
Help text was outdated and didn't reflect the full list of supported AI providers.

## Test plan
- [x] `bc agent create --help` now shows all 7 tools
- [x] Build passes
- [x] Lint passes

Fixes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)