### PR TITLE
fix(tui): Fix channel names hidden at 80x24 (#1528)

### DIFF
--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -215,9 +215,10 @@ function ChannelRow({ channel, selected, unreadCount }: ChannelRowProps): React.
   const textColor = selected ? 'cyan' : unreadCount > 0 ? 'yellow' : undefined;
 
   // #1171 fix: Remove explicit width="100%" to avoid nested width calculation issues at 80x24
-  // The parent Box already has width="100%", inner Box inherits flexbox width naturally
+  // #1528 fix: Add flexGrow={1} to ensure Box takes available width for wrap="truncate" to work
+  // The parent Box already has width="100%", inner Box needs flexGrow to claim its share
   return (
-    <Box flexDirection="column">
+    <Box flexDirection="column" flexGrow={1}>
       {/* Name row: single Text for proper truncation at narrow widths */}
       <Text
         wrap="truncate"


### PR DESCRIPTION
## Summary
- Add `flexGrow={1}` to ChannelRow Box to ensure it claims available width
- Fixes `wrap="truncate"` not working correctly at narrow terminal widths
- Ink requires parent Box to have determinable width for text truncation

## Root Cause
At 80x24, the ChannelRow Box had no width constraint, causing `wrap="truncate"` 
on channel name Text to not function correctly. Adding `flexGrow={1}` ensures 
the Box claims its share of available width from the parent flexbox.

Issue #1528

## Test plan
- [x] TUI tests pass (22 tests)
- [x] Lint clean
- [x] Verified channel names visible at 80 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)