### PR TITLE
fix(tui): Prevent channel message text bleeding (#1519)

### DIFF
--- a/tui/src/views/MessageHistory.tsx
+++ b/tui/src/views/MessageHistory.tsx
@@ -109,13 +109,14 @@ export function MessageHistory({
         </Box>
       )}
 
-      {/* Messages */}
+      {/* Messages - #1519 fix: overflow="hidden" prevents text bleeding */}
       <Box
         flexDirection="column"
         borderStyle="single"
         borderColor="gray"
         paddingX={1}
         height={visibleMessages + 2}
+        overflow="hidden"
       >
         {visibleSlice.length === 0 ? (
           <Text dimColor>No messages in this channel</Text>
@@ -172,7 +173,8 @@ const MessageItem = memo(function MessageItem({ message }: MessageItemProps) {
           {truncate(message.sender, 14)}
         </Text>
       </Box>
-      <Box flexGrow={1}>
+      {/* #1519 fix: minWidth={0} allows flexbox child to shrink below content width */}
+      <Box flexGrow={1} minWidth={0}>
         <Text wrap="truncate">{message.message}</Text>
       </Box>
     </Box>


### PR DESCRIPTION
## Summary

- Add `overflow="hidden"` to message container Box to prevent text from escaping boundaries
- Add `minWidth={0}` to flexGrow Box in MessageItem to allow proper shrinking

The root cause was that flexbox children default to `min-width: auto`, which prevents them from shrinking below their content width. Even with `wrap="truncate"`, text would overflow because the container couldn't shrink.

Fixes #1519

## Test plan

- [ ] Open Channels view with long messages
- [ ] Verify text stays within message box boundaries
- [ ] Check at different terminal widths (80, 120 cols)
- [ ] Run `bun test MessageHistory` - passes (58 tests)
- [ ] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)