### PR TITLE
fix(cli): Simplify --role flag help text to avoid outdated role list

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -299,7 +299,7 @@ var (
 func init() {
 	// Create flags
 	agentCreateCmd.Flags().StringVar(&agentCreateTool, "tool", "", "Agent tool (claude, gemini, cursor, codex, opencode, openclaw, aider)")
-	agentCreateCmd.Flags().StringVar(&agentCreateRole, "role", "", "Agent role (engineer, manager, product-manager, tech-lead, qa). Required. Use 'bc role list' to see available roles")
+	agentCreateCmd.Flags().StringVar(&agentCreateRole, "role", "", "Agent role (required). Use 'bc role list' to see available roles")
 	agentCreateCmd.Flags().StringVar(&agentCreateParent, "parent", "", "Parent agent ID (must have permission to create this role)")
 	agentCreateCmd.Flags().StringVar(&agentCreateTeam, "team", "", "Team name (alphanumeric)")
 	_ = agentCreateCmd.MarkFlagRequired("role")


### PR DESCRIPTION
## Summary
- Simplify `--role` flag help text to avoid listing roles that may not exist
- Reference `bc role list` command instead of hardcoding role names

## Root Cause
Help text listed `(engineer, manager, product-manager, tech-lead, qa)` but actual available roles vary by workspace (could include `root`, `ux-tester`, `ux`, etc. and may not include `qa`).

## Fix
Changed from:
```
Agent role (engineer, manager, product-manager, tech-lead, qa). Required. Use 'bc role list' to see available roles
```

To:
```
Agent role (required). Use 'bc role list' to see available roles
```

## Test plan
- [x] `bc agent create --help` shows simplified text
- [x] Build passes
- [x] Lint passes

Fixes #1535

🤖 Generated with [Claude Code](https://claude.com/claude-code)