### PR TITLE
fix(cli): Accept 'list' as argument for bc tutorial (#1532)

### DIFF
--- a/internal/cmd/tutorial.go
+++ b/internal/cmd/tutorial.go
@@ -189,8 +189,8 @@ func init() {
 }
 
 func runTutorial(cmd *cobra.Command, args []string) error {
-	// List tutorials if --list flag is set
-	if tutorialList {
+	// List tutorials if --list flag is set or "list" argument is provided (#1532)
+	if tutorialList || (len(args) > 0 && args[0] == "list") {
 		return listTutorials()
 	}
 


### PR DESCRIPTION
## Summary
- Accept 'list' as a valid argument for `bc tutorial`
- When user runs `bc tutorial list`, show available tutorials directly
- No longer shows "Unknown tutorial: list" error before the list

## Before
```
$ bc tutorial list
Unknown tutorial: list

  Available Tutorials
  ...
```

## After
```
$ bc tutorial list

  Available Tutorials
  ...
```

Issue #1532

## Test plan
- [x] Lint passes
- [x] Build succeeds
- [x] `bc tutorial list` shows tutorials without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)