### PR TITLE
fix(cmd): accept 'list' as argument to bc tutorial command

### DIFF
--- a/internal/cmd/tutorial.go
+++ b/internal/cmd/tutorial.go
@@ -189,8 +189,8 @@ func init() {
 }
 
 func runTutorial(cmd *cobra.Command, args []string) error {
-	// List tutorials if --list flag is set
-	if tutorialList {
+	// List tutorials if --list flag is set or "list" argument
+	if tutorialList || (len(args) > 0 && args[0] == "list") {
 		return listTutorials()
 	}
 


### PR DESCRIPTION
## Summary

- Accept `list` as an argument to `bc tutorial` command
- Removes confusing "Unknown tutorial: list" error message

### Problem
```bash
$ bc tutorial list
Unknown tutorial: list

  Available Tutorials
  ...
```

### Solution
```bash
$ bc tutorial list

  Available Tutorials
  ...
```

Now both forms work:
- `bc tutorial --list` (flag)
- `bc tutorial list` (argument)

Fixes #1532

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] `bc tutorial list` shows tutorials without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)