### PR TITLE
fix(cli): Skip invalid demons with empty names in list output (#1534)

### DIFF
--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -343,6 +343,10 @@ func runDemonList(cmd *cobra.Command, args []string) error {
 	cmd.Printf("%-20s %-20s %-10s %s\n", "NAME", "SCHEDULE", "ENABLED", "COMMAND")
 	cmd.Println("--------------------------------------------------------------------")
 	for _, d := range demons {
+		// #1534 fix: Skip invalid demons with empty names (corrupted data)
+		if d.Name == "" {
+			continue
+		}
 		enabled := "yes"
 		if !d.Enabled {
 			enabled = "no"

--- a/pkg/demon/demon.go
+++ b/pkg/demon/demon.go
@@ -154,7 +154,8 @@ func (s *Store) List() ([]*Demon, error) {
 			if err != nil {
 				continue // Skip invalid entries
 			}
-			if demon != nil {
+			// #1534 fix: Skip demons with empty names (corrupted data)
+			if demon != nil && demon.Name != "" {
 				demons = append(demons, demon)
 			}
 		}


### PR DESCRIPTION
## Summary

- Skip demons with empty names in `Store.List()` (root cause fix)
- Add defense-in-depth check in `runDemonList()` output loop

The `bc demon list` output was showing a spurious "no" on a separate line
when corrupted demon data files with empty names existed. This fix prevents
malformed demon entries from causing table formatting issues.

Fixes #1534

## Test plan

- [ ] Run `go test ./pkg/demon/...` - passes
- [ ] Run `go test -run Demon ./internal/cmd/...` - passes
- [ ] Create a demon, verify list output is correct
- [ ] Verify no formatting issues with `bc demon list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)