### PR TITLE
fix(agent): Validate tool command exists in PATH before spawning (#1531)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -596,6 +596,16 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 		}
 	}
 
+	// #1531 fix: Verify the command binary exists in PATH before spawning
+	if agentCmd != "" {
+		parts := strings.Fields(agentCmd)
+		if len(parts) > 0 {
+			if _, err := exec.LookPath(parts[0]); err != nil {
+				return nil, fmt.Errorf("tool %q command %q not found in PATH. Install it or configure a different tool in config.toml", tool, parts[0])
+			}
+		}
+	}
+
 	// Create agent
 	agent := &Agent{
 		ID:        name,


### PR DESCRIPTION
## Summary

Add `exec.LookPath` check to verify the tool's binary is available in PATH before creating an agent. This prevents agents from appearing to create successfully but actually being in a broken state.

**Before:** Agent created with warning but bootstrap prompt fails silently
```
Creating test-opencode (engineer)... level=WARN msg="failed to send bootstrap prompt" ...
✓ (session: bc-9018a3-test-opencode)
Agent created successfully!
```

**After:** Clear error with actionable guidance
```
Creating test-opencode (engineer)... ✗
Error: failed to create test-opencode: tool "opencode" command "crush" not found in PATH. Install it or configure a different tool in config.toml
```

Fixes #1531

## Test plan

- [ ] Run `go test ./pkg/agent/...` - passes
- [ ] Create agent with installed tool (e.g., claude) - works
- [ ] Create agent with uninstalled tool (e.g., opencode/crush) - clear error
- [ ] Error message includes tool name and command name

🤖 Generated with [Claude Code](https://claude.com/claude-code)