### PR TITLE
fix(cli): Validate tool binary exists before agent creation (#1531)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -415,6 +415,10 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 	if ws.Config.AgentCommand != "" && toolName == "" {
 		mgr.SetAgentCommand(ws.Config.AgentCommand)
 	} else if toolName != "" {
+		// #1531: Validate tool binary is installed before creating agent
+		if err := agent.ValidateToolBinary(toolName); err != nil {
+			return err
+		}
 		if !mgr.SetAgentByName(toolName) {
 			return fmt.Errorf("unknown tool %q (available: %v)", toolName, agent.ListAvailableTools())
 		}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -406,6 +406,30 @@ func (m *Manager) SetAgentByName(name string) bool {
 	return false
 }
 
+// ValidateToolBinary checks if the binary for a named tool is available.
+// Returns nil if the tool exists and its binary is installed.
+// Returns error if the tool is unknown or its binary is not found.
+// Issue #1531: Validate before agent creation to avoid broken agents.
+func ValidateToolBinary(name string) error {
+	for _, a := range config.Agents {
+		if a.Name == name {
+			// Extract binary name (first word of command)
+			parts := strings.Fields(a.Command)
+			if len(parts) == 0 {
+				return fmt.Errorf("tool %q has empty command in config", name)
+			}
+			binary := parts[0]
+
+			// Check if binary exists in PATH
+			if _, err := exec.LookPath(binary); err != nil {
+				return fmt.Errorf("tool %q requires %q which is not installed. Install it or configure a different tool", name, binary)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown tool %q (available: %v)", name, ListAvailableTools())
+}
+
 // SetBootstrapDelay sets the delay before sending bootstrap prompts.
 func (m *Manager) SetBootstrapDelay(d time.Duration) {
 	m.mu.Lock()

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -225,6 +225,55 @@ func TestSetAgentByName(t *testing.T) {
 	})
 }
 
+func TestValidateToolBinary(t *testing.T) {
+	// Save original config and restore after test
+	origAgents := config.Agents
+	defer func() { config.Agents = origAgents }()
+
+	config.Agents = []config.AgentsItem{
+		{Name: "git-tool", Command: "git status", Description: "Git (should be installed)"},
+		{Name: "missing-tool", Command: "nonexistent-binary-xyz --flag", Description: "Missing binary"},
+		{Name: "empty-cmd", Command: "", Description: "Empty command"},
+	}
+
+	t.Run("binary exists", func(t *testing.T) {
+		// git should be installed on test systems
+		if err := ValidateToolBinary("git-tool"); err != nil {
+			t.Errorf("ValidateToolBinary(git-tool) = %v, want nil", err)
+		}
+	})
+
+	t.Run("binary missing", func(t *testing.T) {
+		err := ValidateToolBinary("missing-tool")
+		if err == nil {
+			t.Error("expected error for missing binary")
+		}
+		if !strings.Contains(err.Error(), "not installed") {
+			t.Errorf("error should mention 'not installed': %v", err)
+		}
+	})
+
+	t.Run("unknown tool", func(t *testing.T) {
+		err := ValidateToolBinary("unknown-tool")
+		if err == nil {
+			t.Error("expected error for unknown tool")
+		}
+		if !strings.Contains(err.Error(), "unknown tool") {
+			t.Errorf("error should mention 'unknown tool': %v", err)
+		}
+	})
+
+	t.Run("empty command", func(t *testing.T) {
+		err := ValidateToolBinary("empty-cmd")
+		if err == nil {
+			t.Error("expected error for empty command")
+		}
+		if !strings.Contains(err.Error(), "empty command") {
+			t.Errorf("error should mention 'empty command': %v", err)
+		}
+	})
+}
+
 func TestGetAgentCommand(t *testing.T) {
 	origAgents := config.Agents
 	defer func() { config.Agents = origAgents }()


### PR DESCRIPTION
## Summary
- Add `ValidateToolBinary` function to check if tool binary is installed
- Validates before agent creation to prevent broken agents
- Clear error message: "tool X requires Y which is not installed"

## Before
```
$ bc agent create test-opencode --tool opencode --role engineer
Creating test-opencode (engineer)... 
level=WARN msg="failed to send bootstrap prompt" error="session not found"
✓ (session: bc-9018a3-test-opencode)
Agent created successfully!
```
Agent appears to be created but is broken.

## After
```
$ bc agent create test-opencode --tool opencode --role engineer
Error: tool "opencode" requires "crush" which is not installed. Install it or configure a different tool
```
Clear failure with actionable message.

Issue #1531

## Test plan
- [x] Unit tests added for all scenarios
- [x] Lint passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)