### PR TITLE
feat(cmd): Add all provider tool checks to bc doctor (#1536)

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -40,9 +40,14 @@ Required dependencies:
   tmux    Terminal multiplexer for agent sessions
   git     Version control for worktrees
 
-Optional dependencies:
-  claude  Anthropic Claude CLI
-  cursor  Cursor editor
+Optional dependencies (AI coding tools):
+  claude    Anthropic Claude CLI
+  gemini    Google Gemini CLI
+  cursor    Cursor editor
+  codex     OpenAI Codex CLI
+  opencode  OpenCode CLI
+  openclaw  OpenClaw CLI
+  aider     Aider AI pair programmer
 
 Examples:
   bc doctor           # Run all checks
@@ -64,7 +69,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 
 	ctx := cmd.Context()
-	checks := make([]check, 0, 5)
+	checks := make([]check, 0, 10)
 	allRequired := true
 
 	// Required: tmux
@@ -76,8 +81,23 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Optional: claude CLI
 	checks = append(checks, checkCommand(ctx, "claude", false, "npx -y @anthropic-ai/claude-code"))
 
+	// Optional: gemini CLI
+	checks = append(checks, checkCommand(ctx, "gemini", false, "pip install google-generativeai"))
+
 	// Optional: cursor
 	checks = append(checks, checkCommand(ctx, "cursor", false, "https://cursor.sh"))
+
+	// Optional: codex CLI
+	checks = append(checks, checkCommand(ctx, "codex", false, "npm install -g @openai/codex"))
+
+	// Optional: opencode CLI
+	checks = append(checks, checkCommand(ctx, "opencode", false, "go install github.com/opencode-ai/opencode@latest"))
+
+	// Optional: openclaw CLI
+	checks = append(checks, checkCommand(ctx, "openclaw", false, "pip install openclaw"))
+
+	// Optional: aider
+	checks = append(checks, checkCommand(ctx, "aider", false, "pip install aider-chat"))
 
 	// Check ANTHROPIC_API_KEY
 	checks = append(checks, checkEnvVar("ANTHROPIC_API_KEY", false))
@@ -172,8 +192,18 @@ func getVersion(ctx context.Context, name string) string {
 		cmd = exec.CommandContext(ctx, "git", "--version")
 	case "claude":
 		cmd = exec.CommandContext(ctx, "claude", "--version")
+	case "gemini":
+		cmd = exec.CommandContext(ctx, "gemini", "--version")
 	case "cursor":
 		cmd = exec.CommandContext(ctx, "cursor", "--version")
+	case "codex":
+		cmd = exec.CommandContext(ctx, "codex", "--version")
+	case "opencode":
+		cmd = exec.CommandContext(ctx, "opencode", "--version")
+	case "openclaw":
+		cmd = exec.CommandContext(ctx, "openclaw", "--version")
+	case "aider":
+		cmd = exec.CommandContext(ctx, "aider", "--version")
 	default:
 		return ""
 	}


### PR DESCRIPTION
## Summary
- Expands `bc doctor` to check for all 7 supported AI coding tools: claude, gemini, cursor, codex, opencode, openclaw, aider
- Each tool shows version info when found, or provides install instructions when missing
- Aligns doctor checks with the `--tool` flag options in `bc agent create`

## Test plan
- [x] `make lint` passes
- [x] `make build` succeeds
- [x] `bc doctor` shows all tools with correct version detection
- [x] Missing tools show fix instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)