### PR TITLE
feat(plugin): Improve search command error message (#1537)

### DIFF
--- a/internal/cmd/plugin_test.go
+++ b/internal/cmd/plugin_test.go
@@ -131,8 +131,8 @@ func TestPluginSearchNotImplemented(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unimplemented search, got nil")
 	}
-	if !strings.Contains(err.Error(), "not yet implemented") {
-		t.Errorf("expected 'not yet implemented' error, got: %v", err)
+	if !strings.Contains(err.Error(), "plugin registry coming soon") {
+		t.Errorf("expected 'plugin registry coming soon' error, got: %v", err)
 	}
 }
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -320,8 +320,8 @@ func (m *Manager) Disable(name string) error {
 
 // Search searches for plugins in registries
 func (m *Manager) Search(_ context.Context, _ string) ([]SearchResult, error) {
-	// TODO: Implement registry search
-	return nil, fmt.Errorf("registry search not yet implemented")
+	// TODO: Implement registry search when plugin registry is available
+	return nil, fmt.Errorf("plugin registry coming soon. For now, install plugins from local paths or GitHub URLs:\n  bc plugin install ./my-plugin\n  bc plugin install github.com/user/plugin")
 }
 
 // validateManifest validates a plugin manifest

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -348,8 +349,8 @@ func TestManagerSearch(t *testing.T) {
 	if results != nil {
 		t.Errorf("Search() results should be nil, got %v", results)
 	}
-	if err != nil && err.Error() != "registry search not yet implemented" {
-		t.Errorf("Search() error = %q, want 'registry search not yet implemented'", err.Error())
+	if err != nil && !strings.Contains(err.Error(), "plugin registry coming soon") {
+		t.Errorf("Search() error = %q, want 'plugin registry coming soon...'", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Updates `bc plugin search` to show a helpful message instead of generic "not yet implemented"
- New message: "Plugin registry coming soon. For now, install plugins from local paths or GitHub URLs"
- Includes install examples so users know how to proceed

## Test plan
- [x] `make lint` passes
- [x] `go test -race ./pkg/plugin/... -run Search` passes
- [x] Updated tests verify new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)