### PR TITLE
perf(log): add benchmark tests for structured logging

### DIFF
--- a/pkg/log/benchmark_test.go
+++ b/pkg/log/benchmark_test.go
@@ -1,0 +1,140 @@
+package log
+
+import (
+	"io"
+	"testing"
+)
+
+// BenchmarkInfo measures Info logging performance.
+func BenchmarkInfo(b *testing.B) {
+	// Discard output to avoid I/O overhead
+	SetOutput(io.Discard)
+	defer SetOutput(io.Discard) // Reset after test
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Info("test message")
+	}
+}
+
+// BenchmarkInfoWithArgs measures Info logging with arguments.
+func BenchmarkInfoWithArgs(b *testing.B) {
+	SetOutput(io.Discard)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Info("test message", "key1", "value1", "key2", 42)
+	}
+}
+
+// BenchmarkDebugDisabled measures Debug logging when verbose is off.
+func BenchmarkDebugDisabled(b *testing.B) {
+	SetOutput(io.Discard)
+	SetVerbose(false)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Debug("test message", "key", "value")
+	}
+}
+
+// BenchmarkDebugEnabled measures Debug logging when verbose is on.
+func BenchmarkDebugEnabled(b *testing.B) {
+	SetVerbose(true)
+	SetOutput(io.Discard) // Must be after SetVerbose as SetVerbose recreates logger
+	defer SetVerbose(false)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Debug("test message", "key", "value")
+	}
+}
+
+// BenchmarkWarn measures Warn logging performance.
+func BenchmarkWarn(b *testing.B) {
+	SetOutput(io.Discard)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Warn("warning message", "error", "something went wrong")
+	}
+}
+
+// BenchmarkError measures Error logging performance.
+func BenchmarkError(b *testing.B) {
+	SetOutput(io.Discard)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		Error("error message", "error", "fatal error occurred")
+	}
+}
+
+// BenchmarkWith measures creating a child logger with attributes.
+func BenchmarkWith(b *testing.B) {
+	SetOutput(io.Discard)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = With("component", "test", "request_id", "abc123")
+	}
+}
+
+// BenchmarkLogger measures getting the underlying logger.
+func BenchmarkLogger(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = Logger()
+	}
+}
+
+// BenchmarkSetVerbose measures toggling verbose mode.
+func BenchmarkSetVerbose(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SetVerbose(i%2 == 0)
+	}
+}
+
+// BenchmarkSetOutput measures changing output destination.
+func BenchmarkSetOutput(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		SetOutput(io.Discard)
+	}
+}
+
+// BenchmarkConcurrentInfo measures concurrent logging.
+func BenchmarkConcurrentInfo(b *testing.B) {
+	SetOutput(io.Discard)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			Info("concurrent message", "goroutine", "test")
+		}
+	})
+}
+
+// BenchmarkConcurrentMixed measures mixed concurrent operations.
+func BenchmarkConcurrentMixed(b *testing.B) {
+	SetOutput(io.Discard)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			switch i % 4 {
+			case 0:
+				Info("info message")
+			case 1:
+				Debug("debug message")
+			case 2:
+				Warn("warn message")
+			case 3:
+				Error("error message")
+			}
+			i++
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add benchmark tests for pkg/log structured logging
- Establishes performance baselines for logging operations

### Benchmarks included:

| Benchmark | Description |
|-----------|-------------|
| BenchmarkInfo | Info level logging |
| BenchmarkInfoWithArgs | Info with key-value args |
| BenchmarkDebugDisabled | Debug when verbose=false |
| BenchmarkDebugEnabled | Debug when verbose=true |
| BenchmarkWarn | Warning logging |
| BenchmarkError | Error logging |
| BenchmarkWith | Child logger creation |
| BenchmarkLogger | Get underlying logger |
| BenchmarkSetVerbose | Toggle verbose mode |
| BenchmarkSetOutput | Change output destination |
| BenchmarkConcurrent* | Parallel logging |

### Sample results (M4 Pro):
```
BenchmarkInfo-12                166858       688ns/op
BenchmarkDebugDisabled-12      9373657        13ns/op
BenchmarkDebugEnabled-12        148214       804ns/op
BenchmarkConcurrentInfo-12      320712       365ns/op
```

### Key insights
- Debug when disabled is very fast (~13ns, level check only)
- All enabled log levels are ~700-1000ns
- Concurrent logging scales well under contention

## Test plan
- [x] Benchmarks pass: `go test -bench=. ./pkg/log/`
- [x] Lint passes: `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)