### PR TITLE
fix(tui): add error boundaries to prevent app crashes (#1585)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -31,6 +31,7 @@ import { ProcessesView } from './views/ProcessesView';
 import { MemoryView } from './views/MemoryView';
 import { RoutingView } from './views/RoutingView';
 import { CommandPalette } from './components/CommandPalette';
+import { ViewErrorBoundary } from './components/ErrorBoundary';
 import { type BcCommand } from './types/commands';
 
 interface AppProps {
@@ -167,12 +168,14 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
           {/* Breadcrumb navigation (shows path when navigated deep) */}
           <Breadcrumb />
 
-          {/* Main content area */}
+          {/* Main content area - wrapped with error boundary (#1585) */}
           <Box flexDirection="column" flexGrow={1}>
-            <ViewContent
-              view={currentView}
-              disableInput={disableInput}
-            />
+            <ViewErrorBoundary viewName={currentView}>
+              <ViewContent
+                view={currentView}
+                disableInput={disableInput}
+              />
+            </ViewErrorBoundary>
           </Box>
         </Box>
       </Box>

--- a/tui/src/components/ErrorBoundary.tsx
+++ b/tui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,110 @@
+/**
+ * ErrorBoundary - Catches React errors and displays fallback UI
+ *
+ * Issue #1585: Prevent TUI crashes from component errors
+ *
+ * React error boundaries must be class components to use
+ * componentDidCatch and getDerivedStateFromError lifecycle methods.
+ */
+
+import React, { Component, type ReactNode } from 'react';
+import { Box, Text } from 'ink';
+
+export interface ErrorBoundaryProps {
+  /** Content to render */
+  children: ReactNode;
+  /** Name of the view/component being wrapped (for error messages) */
+  viewName?: string;
+  /** Custom fallback UI (optional) */
+  fallback?: ReactNode;
+  /** Callback when an error is caught */
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * ViewErrorBoundary wraps views to catch and display errors gracefully.
+ * Instead of crashing the entire TUI, shows an error message for the
+ * affected view while keeping the rest of the app functional.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    // Log error for debugging
+    // eslint-disable-next-line no-console
+    console.error(`[ErrorBoundary] Error in ${this.props.viewName ?? 'component'}:`, error);
+    // eslint-disable-next-line no-console
+    console.error('[ErrorBoundary] Component stack:', errorInfo.componentStack);
+
+    // Call optional error handler
+    this.props.onError?.(error, errorInfo);
+  }
+
+  override render(): ReactNode {
+    if (this.state.hasError) {
+      // Custom fallback if provided
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      // Default error UI
+      return (
+        <Box
+          flexDirection="column"
+          padding={1}
+          borderStyle="single"
+          borderColor="red"
+        >
+          <Text color="red" bold>
+            Error in {this.props.viewName ?? 'view'}
+          </Text>
+          <Box marginTop={1}>
+            <Text color="yellow">
+              {this.state.error?.message ?? 'An unexpected error occurred'}
+            </Text>
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>
+              Press Tab to switch to another view, or q to quit.
+            </Text>
+          </Box>
+        </Box>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+/**
+ * ViewErrorBoundary - Convenience wrapper for views with view name
+ */
+export interface ViewErrorBoundaryProps {
+  children: ReactNode;
+  viewName: string;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+export function ViewErrorBoundary({
+  children,
+  viewName,
+  onError,
+}: ViewErrorBoundaryProps): React.ReactElement {
+  return (
+    <ErrorBoundary viewName={viewName} onError={onError}>
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/tui/src/components/index.ts
+++ b/tui/src/components/index.ts
@@ -116,3 +116,7 @@ export type { CommandPaletteProps } from './CommandPalette';
 // ViewWrapper for consistent view layout (#1419)
 export { ViewWrapper } from './ViewWrapper';
 export type { ViewWrapperProps } from './ViewWrapper';
+
+// Error boundary for graceful error handling (#1585)
+export { ErrorBoundary, ViewErrorBoundary } from './ErrorBoundary';
+export type { ErrorBoundaryProps, ViewErrorBoundaryProps } from './ErrorBoundary';


### PR DESCRIPTION
## Summary
P0 Critical fix: Add React error boundaries to prevent TUI crashes from component errors.

## Problem
- Any uncaught error in React tree crashes the entire TUI
- User loses all state and must restart
- No graceful degradation

## Solution
- Create `ErrorBoundary` class component that catches errors
- Create `ViewErrorBoundary` convenience wrapper for views
- Wrap `ViewContent` in `app.tsx` with error boundary
- Display fallback error UI instead of crashing

## Changes
- `src/components/ErrorBoundary.tsx` (new) - Error boundary component
- `src/components/index.ts` - Export error boundary
- `src/app.tsx` - Wrap ViewContent with ViewErrorBoundary

## Behavior After Fix
- Errors in views are caught and display error message in a bordered box
- User can navigate away using Tab to other views
- Rest of app continues functioning
- Error details logged to console for debugging

## Test plan
- [x] `bun run build` passes
- [x] `bun run lint` passes (only warnings in test files)
- [x] `bun test` passes (2076 tests)
- [x] Pre-commit hooks pass

Closes #1585

🤖 Generated with [Claude Code](https://claude.ai/claude-code)