### PR TITLE
fix(tui): Add error boundaries to prevent app crashes (#1585)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -35,6 +35,7 @@ import {
   DetailPane,
   type DetailItem,
 } from './components/DetailPane';
+import { ViewErrorBoundary } from './components/ErrorBoundary';
 import { type BcCommand } from './types/commands';
 
 interface AppProps {
@@ -186,13 +187,15 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
           {/* Breadcrumb navigation (shows path when navigated deep) */}
           <Breadcrumb />
 
-          {/* Main content area */}
+          {/* Main content area - wrapped with error boundary (#1585) */}
           <Box flexDirection="column" flexGrow={1}>
-            <ViewContent
-              view={currentView}
-              disableInput={disableInput}
-              onSelectItem={setSelectedItem}
-            />
+            <ViewErrorBoundary viewName={currentView}>
+              <ViewContent
+                view={currentView}
+                disableInput={disableInput}
+                onSelectItem={setSelectedItem}
+              />
+            </ViewErrorBoundary>
           </Box>
         </Box>
 

--- a/tui/src/components/ErrorBoundary.tsx
+++ b/tui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,118 @@
+import React, { Component, type ErrorInfo, type ReactNode } from 'react';
+import { Box, Text } from 'ink';
+
+export interface ErrorBoundaryProps {
+  /** The view name for context in error messages */
+  viewName?: string;
+  /** Children to render */
+  children: ReactNode;
+  /** Custom fallback component */
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+  errorInfo: ErrorInfo | null;
+}
+
+/**
+ * ErrorBoundary - Catches errors in child components
+ *
+ * Prevents a single component error from crashing the entire TUI.
+ * Displays an error message with recovery options.
+ */
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return { hasError: true, error };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    this.setState({ errorInfo });
+    // Log error for debugging
+    // eslint-disable-next-line no-console
+    console.error(`[ErrorBoundary] Error in ${this.props.viewName ?? 'component'}:`, error);
+    // eslint-disable-next-line no-console
+    console.error('[ErrorBoundary] Component stack:', errorInfo.componentStack);
+  }
+
+  handleReset = (): void => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+    });
+  };
+
+  override render(): ReactNode {
+    const { hasError, error } = this.state;
+    const { children, viewName, fallback } = this.props;
+
+    if (hasError) {
+      if (fallback) {
+        return fallback;
+      }
+
+      return (
+        <Box
+          flexDirection="column"
+          borderStyle="single"
+          borderColor="red"
+          padding={1}
+        >
+          <Text color="red" bold>
+            Error{viewName ? ` in ${viewName}` : ''}
+          </Text>
+          <Box marginTop={1}>
+            <Text color="red">
+              {error?.message ?? 'An unexpected error occurred'}
+            </Text>
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>
+              The rest of the application should continue to work.
+            </Text>
+          </Box>
+          <Box marginTop={1}>
+            <Text dimColor>
+              Use navigation keys to switch to another view.
+            </Text>
+          </Box>
+        </Box>
+      );
+    }
+
+    return children;
+  }
+}
+
+/**
+ * ViewErrorBoundary - Error boundary specifically for views
+ *
+ * Wraps a view component and catches any rendering errors.
+ * Shows a friendly error message without crashing the app.
+ */
+export function ViewErrorBoundary({
+  viewName,
+  children,
+}: {
+  viewName: string;
+  children: ReactNode;
+}): React.ReactElement {
+  return (
+    <ErrorBoundary viewName={viewName}>
+      {children}
+    </ErrorBoundary>
+  );
+}
+
+export default ErrorBoundary;

--- a/tui/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/tui/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'bun:test';
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { ErrorBoundary, ViewErrorBoundary } from '../ErrorBoundary';
+import { Text } from 'ink';
+
+// Component that throws an error for testing
+function ErrorThrowingComponent(): React.ReactElement {
+  throw new Error('Test error from component');
+}
+
+// Component that works normally
+function WorkingComponent(): React.ReactElement {
+  return <Text>Working content</Text>;
+}
+
+describe('ErrorBoundary', () => {
+  // Suppress console.error during tests
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders children when no error occurs', () => {
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <WorkingComponent />
+      </ErrorBoundary>
+    );
+
+    expect(lastFrame()).toContain('Working content');
+  });
+
+  it('renders error message when child throws', () => {
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <ErrorThrowingComponent />
+      </ErrorBoundary>
+    );
+
+    const frame = lastFrame();
+    expect(frame).toContain('Error');
+    expect(frame).toContain('Test error from component');
+  });
+
+  it('includes view name in error message when provided', () => {
+    const { lastFrame } = render(
+      <ErrorBoundary viewName="Dashboard">
+        <ErrorThrowingComponent />
+      </ErrorBoundary>
+    );
+
+    expect(lastFrame()).toContain('Error in Dashboard');
+  });
+
+  it('shows navigation hint in error state', () => {
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <ErrorThrowingComponent />
+      </ErrorBoundary>
+    );
+
+    expect(lastFrame()).toContain('navigation keys');
+  });
+
+  it('renders custom fallback when provided', () => {
+    const { lastFrame } = render(
+      <ErrorBoundary fallback={<Text>Custom fallback</Text>}>
+        <ErrorThrowingComponent />
+      </ErrorBoundary>
+    );
+
+    expect(lastFrame()).toContain('Custom fallback');
+    expect(lastFrame()).not.toContain('Error in');
+  });
+
+  it('logs error to console', () => {
+    render(
+      <ErrorBoundary viewName="TestView">
+        <ErrorThrowingComponent />
+      </ErrorBoundary>
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const calls = consoleErrorSpy.mock.calls;
+    const hasErrorLog = calls.some(
+      (call) => typeof call[0] === 'string' && call[0].includes('ErrorBoundary')
+    );
+    expect(hasErrorLog).toBe(true);
+  });
+});
+
+describe('ViewErrorBoundary', () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders children when no error', () => {
+    const { lastFrame } = render(
+      <ViewErrorBoundary viewName="agents">
+        <WorkingComponent />
+      </ViewErrorBoundary>
+    );
+
+    expect(lastFrame()).toContain('Working content');
+  });
+
+  it('catches errors with view name', () => {
+    const { lastFrame } = render(
+      <ViewErrorBoundary viewName="agents">
+        <ErrorThrowingComponent />
+      </ViewErrorBoundary>
+    );
+
+    expect(lastFrame()).toContain('Error in agents');
+    expect(lastFrame()).toContain('Test error from component');
+  });
+});

--- a/tui/src/components/index.ts
+++ b/tui/src/components/index.ts
@@ -127,3 +127,7 @@ export type { DetailPaneProps, DetailItem, DetailField } from './DetailPane';
 // ViewWrapper for consistent view layout (#1419)
 export { ViewWrapper } from './ViewWrapper';
 export type { ViewWrapperProps } from './ViewWrapper';
+
+// Error boundary for view-level error catching (#1585)
+export { ErrorBoundary, ViewErrorBoundary } from './ErrorBoundary';
+export type { ErrorBoundaryProps } from './ErrorBoundary';


### PR DESCRIPTION
## Summary
- Add ErrorBoundary class component for catching React errors
- Add ViewErrorBoundary functional wrapper for views
- Wrap ViewContent in app.tsx with error boundary
- Export from components index

Fixes #1585

## Changes
- **tui/src/components/ErrorBoundary.tsx** - New error boundary component
- **tui/src/app.tsx** - Wrap view content with error boundary
- **tui/src/components/index.ts** - Export ErrorBoundary
- **tui/src/components/__tests__/ErrorBoundary.test.tsx** - 8 unit tests

## Behavior
When a view component throws an error:
1. Error is caught by the boundary
2. Error message is displayed with view name
3. User can navigate to other views
4. Rest of app continues working

## Test plan
- [x] Build passes
- [x] 8 new tests pass
- [x] All 2076 TUI tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)