### PR TITLE
refactor(tui): Use centralized error handling in hooks

### DIFF
--- a/tui/src/hooks/useAgents.ts
+++ b/tui/src/hooks/useAgents.ts
@@ -13,6 +13,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { Agent, AgentState, BcResult } from '../types';
 import { getStatus } from '../services/bc';
 import { usePerformanceConfig } from '../config';
+import { handleApiError, logError } from '../utils';
 
 /** Debounce period for working→idle transition (in ms) */
 const WORKING_TO_IDLE_DEBOUNCE_MS = 5000;
@@ -116,7 +117,9 @@ export function useAgents(options: UseAgentsOptions = {}): UseAgentsResult {
       setWorkspace(status.workspace);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch agents');
+      const errorResult = handleApiError(err);
+      logError('useAgents', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }

--- a/tui/src/hooks/useChannels.ts
+++ b/tui/src/hooks/useChannels.ts
@@ -11,6 +11,7 @@ import type { Channel, ChannelMessage, BcResult } from '../types';
 import { getChannels, getChannelHistory, sendChannelMessage } from '../services/bc';
 import { usePerformanceConfig } from '../config';
 import { useUnread } from './UnreadContext';
+import { handleApiError, logError } from '../utils';
 
 export interface UseChannelsOptions {
   /** Polling interval in ms (default: from config) */
@@ -44,7 +45,9 @@ export function useChannels(options: UseChannelsOptions = {}): UseChannelsResult
       setData(response.channels);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch channels');
+      const errorResult = handleApiError(err);
+      logError('useChannels', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }
@@ -100,7 +103,9 @@ export function useChannelHistory(
       setData(response.messages);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch history');
+      const errorResult = handleApiError(err);
+      logError('useChannelHistory', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }

--- a/tui/src/hooks/useCosts.ts
+++ b/tui/src/hooks/useCosts.ts
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback } from 'react';
 import type { CostSummary, BcResult } from '../types';
 import { getCostSummary } from '../services/bc';
 import { usePerformanceConfig } from '../config';
+import { handleApiError, logError } from '../utils';
 
 export interface UseCostsOptions {
   /** Polling interval in ms (default: from config) */
@@ -42,7 +43,9 @@ export function useCosts(options: UseCostsOptions = {}): UseCostsResult {
       setData(summary);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch costs');
+      const errorResult = handleApiError(err);
+      logError('useCosts', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }

--- a/tui/src/hooks/useDemons.ts
+++ b/tui/src/hooks/useDemons.ts
@@ -10,6 +10,7 @@ import type { Demon, BcResult } from '../types';
 import { getDemons, getDemonLogs, enableDemon, disableDemon, runDemon } from '../services/bc';
 import type { DemonRunLog } from '../types';
 import { usePerformanceConfig } from '../config';
+import { handleApiError, logError } from '../utils';
 
 export interface UseDemonsOptions {
   /** Polling interval in ms (default: from config) */
@@ -59,7 +60,9 @@ export function useDemons(options: UseDemonsOptions = {}): UseDemonsResult {
       setEnabled(demons.filter((d) => d.enabled).length);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch demons');
+      const errorResult = handleApiError(err);
+      logError('useDemons', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }
@@ -139,7 +142,9 @@ export function useDemonLogs(
       setData(logs);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch demon logs');
+      const errorResult = handleApiError(err);
+      logError('useDemonLogs', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }

--- a/tui/src/hooks/useLogs.ts
+++ b/tui/src/hooks/useLogs.ts
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { LogEntry, BcResult } from '../types';
 import { getLogs } from '../services/bc';
 import { usePerformanceConfig } from '../config';
+import { handleApiError, logError } from '../utils';
 
 /** Log severity level derived from event type */
 export type LogSeverity = 'info' | 'warn' | 'error';
@@ -80,7 +81,9 @@ export function useLogs(options: UseLogsOptions = {}): UseLogsResult {
       setRawData(logs);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch logs');
+      const errorResult = handleApiError(err);
+      logError('useLogs', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }

--- a/tui/src/hooks/useProcesses.ts
+++ b/tui/src/hooks/useProcesses.ts
@@ -6,6 +6,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { Process, BcResult } from '../types';
 import { getProcesses, getProcessLogs } from '../services/bc';
+import { handleApiError, logError } from '../utils';
 
 export interface UseProcessesOptions {
   /** Polling interval in ms (default: 3000) */
@@ -47,7 +48,9 @@ export function useProcesses(options: UseProcessesOptions = {}): UseProcessesRes
         onUpdate();
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch processes');
+      const errorResult = handleApiError(err);
+      logError('useProcesses', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }
@@ -118,7 +121,9 @@ export function useProcessLogs(options: UseProcessLogsOptions): UseProcessLogsRe
       setData(logLines);
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch logs');
+      const errorResult = handleApiError(err);
+      logError('useProcessLogs', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }

--- a/tui/src/hooks/useStatus.ts
+++ b/tui/src/hooks/useStatus.ts
@@ -9,6 +9,7 @@ import { useState, useEffect, useCallback } from 'react';
 import type { StatusResponse, BcResult } from '../types';
 import { getStatus } from '../services/bc';
 import { usePerformanceConfig } from '../config';
+import { handleApiError, logError } from '../utils';
 
 export interface UseStatusOptions {
   /** Polling interval in ms (default: from config) */
@@ -91,7 +92,9 @@ export function useStatus(options: UseStatusOptions = {}): UseStatusResult {
       });
       setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch status');
+      const errorResult = handleApiError(err);
+      logError('useStatus', errorResult);
+      setError(errorResult.message);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Update 7 hooks to use centralized error handling utilities from #1593
- Replace inline `err instanceof Error ? err.message : 'Failed to...'` pattern
- Add error logging via `logError()` for debugging

## Changes
Updated hooks:
- `useStatus` - fetch status errors
- `useAgents` - fetch agents errors
- `useChannels` - fetch channels and history errors
- `useCosts` - fetch costs errors
- `useLogs` - fetch logs errors
- `useProcesses` - fetch processes and logs errors
- `useDemons` - fetch demons and logs errors

## Benefits
- Consistent user-friendly error messages
- Error classification (recoverable vs fatal)
- Centralized error logging for debugging
- Follows patterns established in #1593

## Test plan
- [x] All 2084 TUI tests pass
- [x] Lint passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)