### PR TITLE
fix(tui): Add consistent selection indicators for accessibility (#1599)

### DIFF
--- a/tui/src/views/FilesView.tsx
+++ b/tui/src/views/FilesView.tsx
@@ -380,7 +380,7 @@ function WorktreeSelector({
       {worktrees.map((wt, index) => (
         <Box key={wt.agent}>
           <Text color={index === selectedIndex ? theme.colors.accent : undefined}>
-            {index === selectedIndex ? '>' : ' '} {wt.agent}
+            {index === selectedIndex ? '▸' : ' '} {wt.agent}
           </Text>
           {wt.branch && <Text dimColor> ({wt.branch})</Text>}
         </Box>

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -316,7 +316,8 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
   const timeWidth = 12;
   const agentWidth = Math.min(12, Math.floor((terminalWidth - 40) * 0.2));
   const typeWidth = 10;
-  const messageWidth = terminalWidth - timeWidth - agentWidth - typeWidth - 10;
+  // -12 accounts for: selection indicator (2) + spacing (10)
+  const messageWidth = terminalWidth - timeWidth - agentWidth - typeWidth - 12;
 
   // Visible rows - dynamic based on terminal height (#80x24 support)
   // Account for: app overhead (6) + header (1) + filters (1) + table border (2) + footer (1)
@@ -361,6 +362,7 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
       <Box flexDirection="column" borderStyle="single" borderColor="gray">
         {/* Table header */}
         <Box>
+          <Text>{'  '}</Text>
           <Text bold color="gray">
             {'TIME'.padEnd(timeWidth)}
             {'AGENT'.padEnd(agentWidth)}
@@ -378,6 +380,9 @@ export const LogsView: React.FC<LogsViewProps> = ({ onBack }) => {
 
           return (
             <Box key={`${log.ts}-${String(idx)}`}>
+              <Text color={isSelected ? 'cyan' : undefined}>
+                {isSelected ? '▸ ' : '  '}
+              </Text>
               <Text
                 backgroundColor={isSelected ? 'blue' : undefined}
                 color={isSelected ? 'white' : undefined}

--- a/tui/src/views/MemoryView.tsx
+++ b/tui/src/views/MemoryView.tsx
@@ -342,7 +342,7 @@ function AgentMemoryRow({ agent, selected }: AgentMemoryRowProps): React.ReactEl
     <Box paddingX={1}>
       <Box width={20}>
         <Text color={selected ? 'cyan' : undefined} bold={selected}>
-          {selected ? '> ' : '  '}
+          {selected ? '▸ ' : '  '}
           {truncate(agent.agent, 16)}
         </Text>
       </Box>

--- a/tui/src/views/WorktreesView.tsx
+++ b/tui/src/views/WorktreesView.tsx
@@ -250,8 +250,9 @@ export const WorktreesView: React.FC<WorktreesViewProps> = ({ onBack }) => {
       <Box flexDirection="column" borderStyle="single" borderColor="gray">
         {/* Header */}
         <Box>
+          <Text>{'  '}</Text>
           <Text bold color="gray">
-            {'AGENT'.padEnd(agentWidth)}
+            {'AGENT'.padEnd(agentWidth - 2)}
             {'STATUS'.padEnd(statusWidth)}
             {'PATH'}
           </Text>
@@ -264,11 +265,14 @@ export const WorktreesView: React.FC<WorktreesViewProps> = ({ onBack }) => {
 
           return (
             <Box key={wt.path}>
+              <Text color={isSelected ? 'cyan' : undefined}>
+                {isSelected ? '▸ ' : '  '}
+              </Text>
               <Text
                 backgroundColor={isSelected ? 'blue' : undefined}
                 color={isSelected ? 'white' : 'cyan'}
               >
-                {wt.agent.slice(0, agentWidth - 1).padEnd(agentWidth)}
+                {wt.agent.slice(0, agentWidth - 3).padEnd(agentWidth - 2)}
               </Text>
               <Text
                 backgroundColor={isSelected ? 'blue' : undefined}
@@ -301,11 +305,14 @@ export const WorktreesView: React.FC<WorktreesViewProps> = ({ onBack }) => {
 
           return (
             <Box key={wt.path}>
+              <Text color={isSelected ? 'cyan' : undefined}>
+                {isSelected ? '▸ ' : '  '}
+              </Text>
               <Text
                 backgroundColor={isSelected ? 'blue' : undefined}
                 color={isSelected ? 'white' : 'yellow'}
               >
-                {(wt.agent || '(orphan)').slice(0, agentWidth - 1).padEnd(agentWidth)}
+                {(wt.agent || '(orphan)').slice(0, agentWidth - 3).padEnd(agentWidth - 2)}
               </Text>
               <Text
                 backgroundColor={isSelected ? 'blue' : undefined}


### PR DESCRIPTION
## Summary
- LogsView: Add ▸ selection indicator alongside background highlighting
- WorktreesView: Add ▸ selection indicator for active and orphaned entries
- MemoryView: Change > to ▸ for consistency with other views
- FilesView: Change > to ▸ in worktree selector

## Changes
All views now use consistent `▸` selection indicator for keyboard navigation:

**Before:**
- LogsView: Only background highlighting (hard to see)
- WorktreesView: Only background highlighting
- MemoryView: Used `> ` (different from other views)
- FilesView: Used `>` in selector

**After:**
- All views use `▸ ` indicator with cyan color when selected
- Background highlighting retained where it was used
- Consistent keyboard navigation experience

## Test plan
- [x] All 2084 TUI tests pass
- [x] Lint passes
- [ ] Manual verification of selection visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)