### PR TITLE
refactor(tui): Consolidate truncate functions to shared utility

### DIFF
--- a/tui/src/components/ActivityFeed.tsx
+++ b/tui/src/components/ActivityFeed.tsx
@@ -7,6 +7,7 @@ import React, { memo, useMemo } from 'react';
 import { Box, Text, useStdout } from 'ink';
 import { Panel } from './Panel';
 import { useLogs, getSeverityColor, getSeverityIcon } from '../hooks';
+import { truncate } from '../utils';
 import type { LogSeverity } from '../hooks';
 import type { LogEntry } from '../types';
 
@@ -52,15 +53,6 @@ function formatEventType(type: string): string {
     return parts[parts.length - 1];
   }
   return type;
-}
-
-/**
- * Truncate message to fit in compact display
- */
-function truncateMessage(msg: string | undefined | null, maxLen: number): string {
-  if (!msg) return '';
-  if (msg.length <= maxLen) return msg;
-  return msg.slice(0, maxLen - 3) + '...';
 }
 
 /**
@@ -232,7 +224,7 @@ const ActivityEntry = memo(function ActivityEntry({
       <Text color="cyan">{entry.agent.padEnd(10)} </Text>
       <Text color={severityColor}>{severityIcon} </Text>
       <Text color={severityColor}>{eventLabel.padEnd(12)} </Text>
-      <Text>{truncateMessage(displayMessage, maxMsgLen)}</Text>
+      <Text>{truncate(displayMessage, maxMsgLen)}</Text>
       {count > 1 && (
         <Text dimColor> (x{count})</Text>
       )}

--- a/tui/src/utils/formatting.ts
+++ b/tui/src/utils/formatting.ts
@@ -61,11 +61,12 @@ export function formatDuration(ms: number): string {
 /**
  * Truncate a string to a maximum length with ellipsis
  *
- * @param str - String to truncate
+ * @param str - String to truncate (handles null/undefined)
  * @param maxLength - Maximum length including ellipsis
  * @returns Truncated string
  */
-export function truncate(str: string, maxLength: number): string {
+export function truncate(str: string | null | undefined, maxLength: number): string {
+  if (!str) return '';
   if (str.length <= maxLength) return str;
   return str.slice(0, maxLength - 3) + '...';
 }

--- a/tui/src/views/MemoryView.tsx
+++ b/tui/src/views/MemoryView.tsx
@@ -10,6 +10,7 @@ import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
 import { useFocus } from '../navigation/FocusContext';
 import { getMemoryList, getMemory, searchMemory, clearMemory } from '../services/bc';
+import { truncate } from '../utils';
 import type { AgentMemorySummary, AgentMemory, MemorySearchResult } from '../types';
 
 interface MemoryViewProps {
@@ -505,14 +506,6 @@ function formatTime(timestamp: string): string {
   } catch {
     return timestamp;
   }
-}
-
-/**
- * Truncate string to max length
- */
-function truncate(str: string, maxLen: number): string {
-  if (str.length <= maxLen) return str;
-  return str.slice(0, maxLen - 1) + '...';
 }
 
 export default MemoryView;

--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -10,6 +10,7 @@ import { LoadingIndicator } from '../components/LoadingIndicator';
 import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
 import { useAgents } from '../hooks';
+import { truncate } from '../utils';
 import type { Role } from '../types';
 import { getRoles, getRole, deleteRole } from '../services/bc';
 
@@ -451,14 +452,6 @@ function RoleDetails({ role, agentCount }: RoleDetailsProps): React.ReactElement
 function isBuiltinRole(name: string): boolean {
   const builtinRoles = ['root', 'manager', 'engineer', 'tech-lead', 'product-manager'];
   return builtinRoles.includes(name);
-}
-
-/**
- * Truncate string to max length
- */
-function truncate(str: string, maxLen: number): string {
-  if (str.length <= maxLen) return str;
-  return str.slice(0, maxLen - 1) + '…';
 }
 
 export default RolesView;

--- a/tui/src/views/RoutingView.tsx
+++ b/tui/src/views/RoutingView.tsx
@@ -9,6 +9,7 @@ import { Panel } from '../components/Panel';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
 import { useAgents } from '../hooks';
+import { truncate } from '../utils';
 
 interface RoutingViewProps {
   disableInput?: boolean;
@@ -276,14 +277,6 @@ function RoutingRuleRow({
       </Box>
     </Box>
   );
-}
-
-/**
- * Truncate string to max length
- */
-function truncate(str: string, maxLen: number): string {
-  if (str.length <= maxLen) return str;
-  return str.slice(0, maxLen - 1) + '...';
 }
 
 export default RoutingView;

--- a/tui/src/views/TeamsView.tsx
+++ b/tui/src/views/TeamsView.tsx
@@ -6,6 +6,7 @@ import { Footer } from '../components/Footer.js';
 import { LoadingIndicator } from '../components/LoadingIndicator.js';
 import { ErrorDisplay } from '../components/ErrorDisplay.js';
 import { useTeams } from '../hooks';
+import { truncate } from '../utils';
 import type { Team } from '../types';
 
 // Extended team type for DataTable compatibility
@@ -204,14 +205,6 @@ function TeamDetails({ team }: TeamDetailsProps) {
       </Box>
     </Panel>
   );
-}
-
-/**
- * Truncate string to max length
- */
-function truncate(str: string, maxLen: number): string {
-  if (str.length <= maxLen) return str;
-  return str.slice(0, maxLen - 1) + '…';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Enhanced shared `truncate()` in utils/formatting.ts to handle null/undefined
- Replaced 5 duplicate truncate implementations with shared utility
- Fixed truncation bugs in MemoryView and RoutingView where `maxLen-1` with 3-char ellipsis could exceed maxLen
- Net -35 lines of duplicated code

## Files Changed
- `src/utils/formatting.ts` - Enhanced truncate to handle null/undefined
- `src/views/MemoryView.tsx` - Use shared truncate
- `src/views/TeamsView.tsx` - Use shared truncate
- `src/views/RolesView.tsx` - Use shared truncate
- `src/views/RoutingView.tsx` - Use shared truncate
- `src/components/ActivityFeed.tsx` - Use shared truncate (replaces truncateMessage)

## Test plan
- [x] All 2029 tests pass
- [x] Lint passes
- [x] Verify truncation behavior matches expected output

🤖 Generated with [Claude Code](https://claude.com/claude-code)