### PR TITLE
refactor(tui): remove prop drilling with DisableInputContext (#1594)

### DIFF
--- a/tui/src/__tests__/ChannelsView.test.tsx
+++ b/tui/src/__tests__/ChannelsView.test.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'bun:test';
 import { ChannelsView } from '../components/ChannelsView';
+import { DisableInputProvider } from '../hooks';
+
+// #1594: Helper to wrap with DisableInputProvider
+const renderWithProvider = (ui: React.ReactElement) => {
+  return render(
+    <DisableInputProvider disabled>{ui}</DisableInputProvider>
+  );
+};
 
 /**
  * Issue #1039 - Loading Indicators with PulseText
@@ -57,30 +65,30 @@ describe('ChannelsView Loading Indicators (Issue #1039)', () => {
 describe('ChannelsView', () => {
   describe('basic rendering', () => {
     it('renders without crashing', () => {
-      const { lastFrame } = render(<ChannelsView />);
+      const { lastFrame } = renderWithProvider(<ChannelsView />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('renders with disableInput prop false', () => {
-      const { lastFrame } = render(<ChannelsView disableInput={false} />);
+      const { lastFrame } = renderWithProvider(<ChannelsView />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('renders with disableInput prop true', () => {
-      const { lastFrame } = render(<ChannelsView disableInput={true} />);
+      const { lastFrame } = renderWithProvider(<ChannelsView />);
       expect(lastFrame()).toBeDefined();
     });
   });
 
   describe('input handling', () => {
     it('handles input when enabled', () => {
-      const { lastFrame } = render(<ChannelsView disableInput={false} />);
+      const { lastFrame } = renderWithProvider(<ChannelsView />);
       const frame = lastFrame();
       expect(frame).toBeDefined();
     });
 
     it('disables input when requested', () => {
-      const { lastFrame } = render(<ChannelsView disableInput={true} />);
+      const { lastFrame } = renderWithProvider(<ChannelsView />);
       const frame = lastFrame();
       expect(frame).toBeDefined();
     });
@@ -88,12 +96,12 @@ describe('ChannelsView', () => {
 
   describe('view modes', () => {
     it('renders in default state', () => {
-      const { lastFrame } = render(<ChannelsView />);
+      const { lastFrame } = renderWithProvider(<ChannelsView />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('renders with loading state handling', () => {
-      const { lastFrame } = render(<ChannelsView />);
+      const { lastFrame } = renderWithProvider(<ChannelsView />);
       const frame = lastFrame();
       // Should handle loading gracefully
       expect(frame).toBeDefined();
@@ -109,7 +117,7 @@ describe('ChannelsView', () => {
     });
 
     it('handles Escape key to exit input mode', () => {
-      const { lastFrame } = render(<ChannelsView />);
+      const { lastFrame } = renderWithProvider(<ChannelsView />);
       expect(lastFrame()).toBeDefined();
     });
 

--- a/tui/src/__tests__/CostsView.test.tsx
+++ b/tui/src/__tests__/CostsView.test.tsx
@@ -15,13 +15,8 @@ describe('CostsView', () => {
       expect(lastFrame()).toBeDefined();
     });
 
-    it('renders with disableInput prop false', () => {
-      const { lastFrame } = render(<CostsView disableInput={false} />);
-      expect(lastFrame()).toBeDefined();
-    });
-
-    it('renders with disableInput prop true', () => {
-      const { lastFrame } = render(<CostsView disableInput={true} />);
+    it('renders consistently', () => {
+      const { lastFrame } = render(<CostsView />);
       expect(lastFrame()).toBeDefined();
     });
   });
@@ -80,12 +75,12 @@ describe('CostsView', () => {
 
   describe('input handling', () => {
     it('respects disableInput prop', () => {
-      const { lastFrame } = render(<CostsView disableInput={true} />);
+      const { lastFrame } = render(<CostsView />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('allows input when enabled', () => {
-      const { lastFrame } = render(<CostsView disableInput={false} />);
+      const { lastFrame } = render(<CostsView />);
       expect(lastFrame()).toBeDefined();
     });
   });

--- a/tui/src/__tests__/MemoryView.test.tsx
+++ b/tui/src/__tests__/MemoryView.test.tsx
@@ -9,7 +9,7 @@ import { render } from 'ink-testing-library';
 import { Text, Box } from 'ink';
 import { MemoryView } from '../views/MemoryView';
 import { FocusProvider } from '../navigation/FocusContext';
-import { HintsProvider, useHintsContext } from '../hooks/useHintsContext';
+import { HintsProvider, useHintsContext, DisableInputProvider } from '../hooks';
 import * as bc from '../services/bc';
 
 // Helper to display hints from context
@@ -35,12 +35,15 @@ jest.mock('../services/bc', () => ({
 const mockGetMemoryList = bc.getMemoryList as jest.Mock;
 const mockGetMemory = bc.getMemory as jest.Mock;
 
+// #1594: Use DisableInputProvider instead of prop
 function renderMemoryView(props = {}, withHintsDisplay = false) {
   return render(
     <HintsProvider>
       <FocusProvider>
-        <MemoryView disableInput {...props} />
-        {withHintsDisplay && <HintsDisplay />}
+        <DisableInputProvider disabled>
+          <MemoryView {...props} />
+          {withHintsDisplay && <HintsDisplay />}
+        </DisableInputProvider>
       </FocusProvider>
     </HintsProvider>
   );

--- a/tui/src/__tests__/RoutingView.test.tsx
+++ b/tui/src/__tests__/RoutingView.test.tsx
@@ -9,7 +9,7 @@ import { render } from 'ink-testing-library';
 import { Text, Box } from 'ink';
 import { RoutingView } from '../views/RoutingView';
 import { FocusProvider } from '../navigation/FocusContext';
-import { HintsProvider, useHintsContext } from '../hooks/useHintsContext';
+import { HintsProvider, useHintsContext, DisableInputProvider } from '../hooks';
 import * as useAgentsHook from '../hooks/useAgents';
 
 // Helper to display hints from context
@@ -31,12 +31,15 @@ jest.mock('../hooks/useAgents', () => ({
 
 const mockUseAgents = useAgentsHook.useAgents as jest.Mock;
 
+// #1594: Use DisableInputProvider instead of prop
 function renderRoutingView(props = {}, withHintsDisplay = false) {
   return render(
     <HintsProvider>
       <FocusProvider>
-        <RoutingView disableInput {...props} />
-        {withHintsDisplay && <HintsDisplay />}
+        <DisableInputProvider disabled>
+          <RoutingView {...props} />
+          {withHintsDisplay && <HintsDisplay />}
+        </DisableInputProvider>
       </FocusProvider>
     </HintsProvider>
   );

--- a/tui/src/__tests__/utils/testUtils.tsx
+++ b/tui/src/__tests__/utils/testUtils.tsx
@@ -14,6 +14,7 @@ import { render as inkRender } from 'ink-testing-library';
 import { ThemeProvider } from '../../theme/ThemeContext';
 import { FocusProvider } from '../../navigation/FocusContext';
 import { NavigationProvider } from '../../navigation/NavigationContext';
+import { DisableInputProvider } from '../../hooks';
 import type { ThemeConfig } from '../../theme/types';
 import type { FocusArea } from '../../navigation/FocusContext';
 
@@ -38,11 +39,14 @@ export function renderWithProviders(
     disableInput?: boolean;
   }
 ) {
+  // #1594: Include DisableInputProvider in test wrapper
   const Wrapper = ({ children }: { children: React.ReactNode }) => (
     <ThemeProvider config={options?.themeConfig}>
       <FocusProvider initialFocus={options?.initialFocus ?? 'main'}>
         <NavigationProvider>
-          {children}
+          <DisableInputProvider disabled={options?.disableInput ?? true}>
+            {children}
+          </DisableInputProvider>
         </NavigationProvider>
       </FocusProvider>
     </ThemeProvider>

--- a/tui/src/__tests__/views/RolesView.test.tsx
+++ b/tui/src/__tests__/views/RolesView.test.tsx
@@ -10,12 +10,15 @@ import { describe, it, expect, vi, beforeEach, mock } from 'bun:test';
 import { RolesView } from '../../views/RolesView';
 import { FocusProvider } from '../../navigation/FocusContext';
 import { ConfigProvider } from '../../config';
+import { DisableInputProvider } from '../../hooks';
 
-// Helper to wrap component with required providers
+// #1594: Helper to wrap component with required providers including DisableInputProvider
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
     <ConfigProvider>
-      <FocusProvider>{ui}</FocusProvider>
+      <FocusProvider>
+        <DisableInputProvider disabled>{ui}</DisableInputProvider>
+      </FocusProvider>
     </ConfigProvider>
   );
 };
@@ -64,18 +67,18 @@ describe('RolesView', () => {
 
   describe('basic rendering', () => {
     it('renders without crashing', () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('renders loading state initially', () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       // Initial state shows loading
       expect(lastFrame()).toBeDefined();
     });
 
     it('renders with disableInput prop', () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       expect(lastFrame()).toBeDefined();
     });
 
@@ -83,21 +86,21 @@ describe('RolesView', () => {
 
   describe('role list display', () => {
     it('shows role names after loading', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('engineer');
     });
 
     it('shows manager role', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('manager');
     });
 
     it('shows tech-lead role', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('tech-lead');
@@ -106,28 +109,28 @@ describe('RolesView', () => {
 
   describe('table headers', () => {
     it('shows NAME column', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('NAME');
     });
 
     it('shows CAPABILITIES column', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('CAPABILITIES');
     });
 
     it('shows AGENTS column', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('AGENTS');
     });
 
     it('shows DESCRIPTION column', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('DESCRIPTION');
@@ -136,14 +139,14 @@ describe('RolesView', () => {
 
   describe('search bar', () => {
     it('shows search hint', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('search');
     });
 
     it('shows navigation hint', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('j/k');
@@ -152,28 +155,28 @@ describe('RolesView', () => {
 
   describe('footer', () => {
     it('shows navigate hint', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('navigate');
     });
 
     it('shows Enter hint for details', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('details');
     });
 
     it('shows refresh hint', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('refresh');
     });
 
     it('shows back hint', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('back');
@@ -182,7 +185,7 @@ describe('RolesView', () => {
 
   describe('role count', () => {
     it('shows total role count', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       // Should show (3) for 3 roles
@@ -192,7 +195,7 @@ describe('RolesView', () => {
 
   describe('capabilities display', () => {
     it('shows capabilities in row', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       expect(output).toContain('implement');
@@ -201,7 +204,7 @@ describe('RolesView', () => {
 
   describe('selection indicator', () => {
     it('shows selection marker', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame();
       // First item should be selected with marker
@@ -212,7 +215,7 @@ describe('RolesView', () => {
   // #971 fix: Dynamic name column width tests
   describe('dynamic name column width', () => {
     it('shows full role name without truncation for short names', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame() ?? '';
       // 'tech-lead' is 9 chars, should not be truncated
@@ -221,7 +224,7 @@ describe('RolesView', () => {
     });
 
     it('shows role name without ellipsis when within bounds', async () => {
-      const { lastFrame } = renderWithFocus(<RolesView disableInput />);
+      const { lastFrame } = renderWithFocus(<RolesView />);
       await new Promise((r) => setTimeout(r, 150));
       const output = lastFrame() ?? '';
       // 'engineer' and 'manager' are short, should not have ellipsis

--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -14,7 +14,7 @@ import {
   type View,
 } from './navigation';
 import { ThemeProvider, useTheme, type ThemeMode } from './theme';
-import { UnreadProvider, useKeybindingHints, useResponsiveLayout, HintsProvider, useHintsContext } from './hooks';
+import { UnreadProvider, useKeybindingHints, useResponsiveLayout, HintsProvider, useHintsContext, DisableInputProvider, useDisableInput } from './hooks';
 import { ConfigProvider, useThemeConfig } from './config';
 import { Dashboard } from './views/Dashboard';
 import { AgentsView } from './views/AgentsView';
@@ -80,7 +80,10 @@ function AppWithTheme({
         <FocusProvider>
           <UnreadProvider>
             <HintsProvider>
-              <AppContent disableInput={disableInput} themeConfig={themeConfig} />
+              {/* #1594: DisableInputProvider eliminates prop drilling */}
+              <DisableInputProvider disabled={disableInput}>
+                <AppContent themeConfig={themeConfig} />
+              </DisableInputProvider>
             </HintsProvider>
           </UnreadProvider>
         </FocusProvider>
@@ -90,14 +93,15 @@ function AppWithTheme({
 }
 
 interface AppContentProps {
-  disableInput: boolean;
   themeConfig: ReturnType<typeof useThemeConfig>;
 }
 
-function AppContent({ disableInput, themeConfig }: AppContentProps): React.ReactElement {
+function AppContent({ themeConfig }: AppContentProps): React.ReactElement {
   const { currentView, navigate } = useNavigation();
   const { stdout } = useStdout();
   const { setThemeName } = useTheme();
+  // #1594: Use context instead of prop drilling
+  const { isDisabled: disableInput } = useDisableInput();
   const [showCommandPalette, setShowCommandPalette] = useState(false);
 
   // #1326: Use centralized responsive layout system
@@ -185,10 +189,8 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
           {/* Main content area - wrapped with error boundary (#1585) */}
           <Box flexDirection="column" flexGrow={1}>
             <ViewErrorBoundary viewName={currentView}>
-              <ViewContent
-                view={currentView}
-                disableInput={disableInput}
-              />
+              {/* #1594: Views use useDisableInput hook instead of props */}
+              <ViewContent view={currentView} />
             </ViewErrorBoundary>
           </Box>
         </Box>
@@ -213,26 +215,25 @@ function AppContent({ disableInput, themeConfig }: AppContentProps): React.React
 
 interface ViewContentProps {
   view: View;
-  disableInput: boolean;
 }
 
-// Main content router - #1596: Memoized to prevent unnecessary re-renders
-const ViewContent = memo(function ViewContent({ view, disableInput }: ViewContentProps): React.ReactElement {
+// Main content router - #1596: Memoized, #1594: views use context
+const ViewContent = memo(function ViewContent({ view }: ViewContentProps): React.ReactElement {
   switch (view) {
     case 'dashboard':
       return <Dashboard />;
     case 'agents':
       return <AgentsView />;
     case 'channels':
-      return <ChannelsView disableInput={disableInput} />;
+      return <ChannelsView />;
     case 'files':
       return <FilesView />;
     case 'costs':
-      return <CostsView disableInput={disableInput} />;
+      return <CostsView />;
     case 'commands':
-      return <CommandsView disableInput={disableInput} />;
+      return <CommandsView />;
     case 'roles':
-      return <RolesView disableInput={disableInput} />;
+      return <RolesView />;
     case 'logs':
       return <LogsView />;
     case 'worktrees':
@@ -240,13 +241,13 @@ const ViewContent = memo(function ViewContent({ view, disableInput }: ViewConten
     case 'workspaces':
       return <WorkspaceSelectorView />;
     case 'demons':
-      return <DemonsView disableInput={disableInput} />;
+      return <DemonsView />;
     case 'processes':
       return <ProcessesView />;
     case 'memory':
-      return <MemoryView disableInput={disableInput} />;
+      return <MemoryView />;
     case 'routing':
-      return <RoutingView disableInput={disableInput} />;
+      return <RoutingView />;
     case 'help':
       return <HelpView />;
     default:

--- a/tui/src/components/ChannelsView.tsx
+++ b/tui/src/components/ChannelsView.tsx
@@ -9,16 +9,15 @@
 
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { useChannelsWithUnread } from '../hooks';
+import { useChannelsWithUnread, useDisableInput } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { PulseText } from './AnimatedText';
 import { ChannelRow, ChannelHistoryView } from './channels';
 
-interface ChannelsViewProps {
-  /** Disable input handling (useful for testing) */
-  disableInput?: boolean;
-}
+// #1594: Using empty interface for future extensibility, props removed
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ChannelsViewProps {}
 
 /**
  * ChannelsView - Main channel list component
@@ -29,7 +28,9 @@ interface ChannelsViewProps {
  * - Enter channel to view history
  * - Press 'm' to jump to compose
  */
-export function ChannelsView({ disableInput = false }: ChannelsViewProps): React.ReactElement {
+export function ChannelsView(_props: ChannelsViewProps = {}): React.ReactElement {
+  // #1594: Use context instead of prop drilling
+  const { isDisabled: disableInput } = useDisableInput();
   // #1129: Use useChannelsWithUnread for proper unread message tracking
   const { channels, loading: channelsLoading, error: channelsError } = useChannelsWithUnread();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -115,7 +116,6 @@ export function ChannelsView({ disableInput = false }: ChannelsViewProps): React
       <ChannelHistoryView
         key={selectedChannel.name}
         channel={selectedChannel}
-        disableInput={disableInput}
         startInComposeMode={startCompose}
         onBack={() => {
           setViewMode('list');

--- a/tui/src/components/CostsView.tsx
+++ b/tui/src/components/CostsView.tsx
@@ -9,12 +9,12 @@ import { Panel } from './Panel';
 import { useCosts } from '../hooks';
 import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 
-interface CostsViewProps {
-  /** Disable input handling (useful for testing) */
-  disableInput?: boolean;
-}
+// #1594: Using empty interface for future extensibility, props removed
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface CostsViewProps {}
 
-export function CostsView({ disableInput: _disableInput = false }: CostsViewProps): React.ReactElement {
+export function CostsView(_props: CostsViewProps = {}): React.ReactElement {
+  // Note: disableInput available via useDisableInput() if needed in future
   const { isCompact, isMinimal, isMD } = useResponsiveLayout();
   // #1365: Extend borderless to 100-120 cols (isMD) to prevent box fragmentation
   const isNarrow = isCompact || isMinimal || isMD;

--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -214,3 +214,9 @@ export {
   type RoleGroup,
   type GroupedItem,
 } from './useAgentGroups';
+
+export {
+  DisableInputProvider,
+  useDisableInput,
+  type DisableInputProviderProps,
+} from './useDisableInput';

--- a/tui/src/hooks/useDisableInput.tsx
+++ b/tui/src/hooks/useDisableInput.tsx
@@ -1,0 +1,59 @@
+/**
+ * useDisableInput - Context for disabling input handling
+ * Issue #1594: Remove prop drilling by using React Context
+ *
+ * Provides a centralized way to disable input handling across the app,
+ * eliminating the need to pass disableInput prop through multiple layers.
+ */
+
+import React, { createContext, useContext, useMemo } from 'react';
+
+interface DisableInputContextValue {
+  /** Whether input handling is disabled */
+  isDisabled: boolean;
+}
+
+const DisableInputContext = createContext<DisableInputContextValue>({
+  isDisabled: false,
+});
+
+export interface DisableInputProviderProps {
+  /** Whether to disable input handling */
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+/**
+ * Provider component for disable input context
+ */
+export function DisableInputProvider({
+  disabled = false,
+  children,
+}: DisableInputProviderProps): React.ReactElement {
+  const value = useMemo(() => ({
+    isDisabled: disabled,
+  }), [disabled]);
+
+  return (
+    <DisableInputContext.Provider value={value}>
+      {children}
+    </DisableInputContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the disable input state
+ *
+ * @returns Object with isDisabled boolean
+ *
+ * @example
+ * function MyComponent() {
+ *   const { isDisabled } = useDisableInput();
+ *   useInput((input, key) => {
+ *     // handle input
+ *   }, { isActive: !isDisabled });
+ * }
+ */
+export function useDisableInput(): DisableInputContextValue {
+  return useContext(DisableInputContext);
+}

--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -11,6 +11,7 @@ import { COMMAND_REGISTRY } from '../types/commands';
 import type { BcCommand } from '../types/commands';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
+import { useDisableInput } from '../hooks';
 import { execBc } from '../services/bc';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -50,16 +51,16 @@ function saveFavorites(favorites: Set<string>): void {
   }
 }
 
-interface CommandsViewProps {
-  disableInput?: boolean;
-}
+// #1594: Using empty interface for future extensibility, props removed
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface CommandsViewProps {}
 
 // Get all category names from registry
 const CATEGORY_NAMES = ['All', ...COMMAND_REGISTRY.map(cat => cat.name)];
 
-export const CommandsView: React.FC<CommandsViewProps> = ({
-  disableInput = false,
-}) => {
+export const CommandsView: React.FC<CommandsViewProps> = (_props = {}) => {
+  // #1594: Use context instead of prop drilling
+  const { isDisabled: disableInput } = useDisableInput();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searchMode, setSearchMode] = useState(false);

--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useDemons } from '../hooks/useDemons';
+import { useDisableInput } from '../hooks';
 import { StatusBadge } from '../components/StatusBadge';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
@@ -14,10 +15,9 @@ import type { Demon } from '../types';
 /** Duration in ms to show action errors before auto-clearing */
 const ERROR_DISPLAY_DURATION = 3000;
 
-export interface DemonsViewProps {
-  /** Disable input handling (useful for testing) */
-  disableInput?: boolean;
-}
+// #1594: Using empty interface for future extensibility, props removed
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DemonsViewProps {}
 
 /**
  * Format cron schedule to human-readable string
@@ -78,9 +78,9 @@ function formatRelativeTime(timestamp?: string): string {
  * - Show schedule, status, run history
  * - Keyboard navigation (j/k, e/d to enable/disable, r to run)
  */
-export function DemonsView({
-  disableInput = false,
-}: DemonsViewProps): React.ReactElement {
+export function DemonsView(_props: DemonsViewProps = {}): React.ReactElement {
+  // #1594: Use context instead of prop drilling
+  const { isDisabled: disableInput } = useDisableInput();
   const { data: demons, loading, error, enabled, refresh, enable, disable, run } = useDemons();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [actionError, setActionError] = useState<string | null>(null);

--- a/tui/src/views/MemoryView.tsx
+++ b/tui/src/views/MemoryView.tsx
@@ -9,22 +9,23 @@ import { Panel } from '../components/Panel';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
 import { useFocus } from '../navigation/FocusContext';
+import { useDisableInput } from '../hooks';
 import { getMemoryList, getMemory, searchMemory, clearMemory } from '../services/bc';
 import { truncate } from '../utils';
 import type { AgentMemorySummary, AgentMemory, MemorySearchResult } from '../types';
 
-interface MemoryViewProps {
-  disableInput?: boolean;
-}
+// #1594: Using empty interface for future extensibility, props removed
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface MemoryViewProps {}
 
 type ViewMode = 'list' | 'detail' | 'search';
 
 /**
  * MemoryView - Display and manage agent memories
  */
-export function MemoryView({
-  disableInput = false,
-}: MemoryViewProps): React.ReactElement {
+export function MemoryView(_props: MemoryViewProps = {}): React.ReactElement {
+  // #1594: Use context instead of prop drilling
+  const { isDisabled: disableInput } = useDisableInput();
   // Data state
   const [agents, setAgents] = useState<AgentMemorySummary[]>([]);
   const [selectedMemory, setSelectedMemory] = useState<AgentMemory | null>(null);

--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -9,21 +9,21 @@ import { Panel } from '../components/Panel';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
-import { useAgents } from '../hooks';
+import { useAgents, useDisableInput } from '../hooks';
 import { truncate } from '../utils';
 import type { Role } from '../types';
 import { getRoles, getRole, deleteRole } from '../services/bc';
 
-interface RolesViewProps {
-  disableInput?: boolean;
-}
+// #1594: Using empty interface for future extensibility, props removed
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface RolesViewProps {}
 
 /**
  * RolesView - Display and manage workspace roles
  */
-export function RolesView({
-  disableInput = false,
-}: RolesViewProps): React.ReactElement {
+export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
+  // #1594: Use context instead of prop drilling
+  const { isDisabled: disableInput } = useDisableInput();
   const [roles, setRoles] = useState<Role[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/tui/src/views/RoutingView.tsx
+++ b/tui/src/views/RoutingView.tsx
@@ -8,12 +8,12 @@ import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
-import { useAgents } from '../hooks';
+import { useAgents, useDisableInput } from '../hooks';
 import { truncate } from '../utils';
 
-interface RoutingViewProps {
-  disableInput?: boolean;
-}
+// #1594: Using empty interface for future extensibility, props removed
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface RoutingViewProps {}
 
 // Static routing rules from pkg/routing/routing.go
 const ROUTING_RULES = [
@@ -46,9 +46,9 @@ const ROUTING_RULES = [
 /**
  * RoutingView - Display and explain task routing rules
  */
-export function RoutingView({
-  disableInput = false,
-}: RoutingViewProps): React.ReactElement {
+export function RoutingView(_props: RoutingViewProps = {}): React.ReactElement {
+  // #1594: Use context instead of prop drilling
+  const { isDisabled: disableInput } = useDisableInput();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showDetails, setShowDetails] = useState(false);
   const agents = useAgents();


### PR DESCRIPTION
## Summary
- Create `DisableInputContext` and `useDisableInput` hook to eliminate prop drilling
- Wrap app with `DisableInputProvider` in `AppWithTheme`
- Update 7 view components to use context hook instead of prop:
  - ChannelsView, CommandsView, CostsView, DemonsView, MemoryView, RolesView, RoutingView
- Update test utilities to include `DisableInputProvider` wrapper
- Remove unused `disableInput` prop from `ViewContent` interface

## Test plan
- [x] All 1969 TUI tests pass
- [x] Lint passes
- [x] Components correctly use context to get disabled state
- [x] Tests wrapped with provider to provide context value

Fixes #1594

🤖 Generated with [Claude Code](https://claude.com/claude-code)