### PR TITLE
fix(tui): Add stricter TypeScript types for TUIConfig (#1615)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -72,7 +72,7 @@ function AppWithTheme({
   // If a named theme is set (matrix, synthwave, etc), use 'auto' mode to let theme system handle it
   const effectiveMode: ThemeMode = themeConfig.theme !== 'dark' && themeConfig.theme !== 'light'
     ? 'auto'
-    : (themeConfig.mode as ThemeMode);
+    : themeConfig.mode;
 
   return (
     <ThemeProvider config={{ mode: effectiveMode }}>

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -3,6 +3,8 @@
  * Auto-generated from bc CLI output structures
  */
 
+import type { ThemeName, ThemeMode } from '../theme';
+
 // Agent states matching pkg/agent/agent.go
 export type AgentState =
   | 'idle'
@@ -255,8 +257,8 @@ export interface PerformanceConfig {
 // TUI theme configuration for appearance and theming
 // Matches workspace.TUIConfig in Go
 export interface TUIConfig {
-  theme: string; // Theme name: "dark", "light", "matrix", "synthwave", "high-contrast"
-  mode: string; // Color mode: "auto", "dark", "light"
+  theme: ThemeName;
+  mode: ThemeMode;
 }
 
 // Memory types for agent memory system


### PR DESCRIPTION
## Summary
- Import `ThemeName` and `ThemeMode` from theme module into types/index.ts
- Update `TUIConfig` interface to use proper type unions instead of `string`:
  - `theme: ThemeName` - validates against `'dark' | 'light' | 'matrix' | 'synthwave' | 'high-contrast' | 'futuristic'`
  - `mode: ThemeMode` - validates against `'auto' | 'dark' | 'light'`
- Remove unnecessary type assertion in app.tsx (now redundant with proper types)

## Benefits
- Compile-time validation of theme configuration values
- Better IDE autocomplete for theme/mode options
- Catches typos and invalid values at build time

## Files Changed
- `src/types/index.ts` - Import theme types, update TUIConfig interface
- `src/app.tsx` - Remove redundant type assertion

## Test plan
- [x] All 2029 tests pass
- [x] Lint passes (no errors)
- [x] Type checking validates defaults in ConfigContext.tsx

Closes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)