### PR TITLE
perf(tui): Add debounce to search operations (#1602)

### DIFF
--- a/tui/src/hooks/__tests__/useDebounce.test.tsx
+++ b/tui/src/hooks/__tests__/useDebounce.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * Tests for useDebounce hook
+ * Issue #1602: Add debounce to expensive input operations
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test';
+import React from 'react';
+import { render, cleanup } from 'ink-testing-library';
+import { Text, Box } from 'ink';
+import {
+  useDebounce,
+  useDebouncedCallback,
+  useDebouncedSearch,
+  DEFAULT_DEBOUNCE_MS,
+} from '../useDebounce';
+
+describe('useDebounce', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('exports DEFAULT_DEBOUNCE_MS constant', () => {
+    expect(DEFAULT_DEBOUNCE_MS).toBe(300);
+  });
+
+  it('returns initial value immediately', () => {
+    const TestComponent = (): React.ReactElement => {
+      const debouncedValue = useDebounce('initial', 100);
+      return <Text>value:{debouncedValue}</Text>;
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('value:initial');
+  });
+
+  it('accepts different types', () => {
+    const TestComponentNumber = (): React.ReactElement => {
+      const debouncedValue = useDebounce(42, 100);
+      return <Text>value:{debouncedValue}</Text>;
+    };
+
+    const { lastFrame: frame1 } = render(<TestComponentNumber />);
+    expect(frame1()).toContain('value:42');
+
+    cleanup();
+
+    const TestComponentObject = (): React.ReactElement => {
+      const debouncedValue = useDebounce({ key: 'value' }, 100);
+      return <Text>value:{debouncedValue.key}</Text>;
+    };
+
+    const { lastFrame: frame2 } = render(<TestComponentObject />);
+    expect(frame2()).toContain('value:value');
+  });
+
+  it('uses default delay when not specified', () => {
+    const TestComponent = (): React.ReactElement => {
+      const debouncedValue = useDebounce('test');
+      return <Text>value:{debouncedValue}</Text>;
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('value:test');
+  });
+});
+
+describe('useDebouncedCallback', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('returns callback, cancel, flush, and isPending', () => {
+    const TestComponent = (): React.ReactElement => {
+      const result = useDebouncedCallback(() => {}, { delay: 100 });
+      return (
+        <Box flexDirection="column">
+          <Text>hasCallback:{typeof result.callback === 'function' ? 'yes' : 'no'}</Text>
+          <Text>hasCancel:{typeof result.cancel === 'function' ? 'yes' : 'no'}</Text>
+          <Text>hasFlush:{typeof result.flush === 'function' ? 'yes' : 'no'}</Text>
+          <Text>hasPending:{typeof result.isPending === 'boolean' ? 'yes' : 'no'}</Text>
+        </Box>
+      );
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('hasCallback:yes');
+    expect(lastFrame()).toContain('hasCancel:yes');
+    expect(lastFrame()).toContain('hasFlush:yes');
+    expect(lastFrame()).toContain('hasPending:yes');
+  });
+
+  it('accepts options with maxWait', () => {
+    const TestComponent = (): React.ReactElement => {
+      const { callback } = useDebouncedCallback(
+        () => {},
+        { delay: 100, maxWait: 500, leading: false, trailing: true }
+      );
+      return <Text>callback:{typeof callback}</Text>;
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('callback:function');
+  });
+
+  it('isPending is false initially', () => {
+    const TestComponent = (): React.ReactElement => {
+      const { isPending } = useDebouncedCallback(() => {}, { delay: 100 });
+      return <Text>isPending:{isPending ? 'yes' : 'no'}</Text>;
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('isPending:no');
+  });
+
+  it('uses default options when not specified', () => {
+    const TestComponent = (): React.ReactElement => {
+      const result = useDebouncedCallback(() => {});
+      return <Text>hasCallback:{typeof result.callback === 'function' ? 'yes' : 'no'}</Text>;
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('hasCallback:yes');
+  });
+});
+
+describe('useDebouncedSearch', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('returns search state and controls', () => {
+    const TestComponent = (): React.ReactElement => {
+      const result = useDebouncedSearch();
+      return (
+        <Box flexDirection="column">
+          <Text>hasQuery:{typeof result.query === 'string' ? 'yes' : 'no'}</Text>
+          <Text>hasDebouncedQuery:{typeof result.debouncedQuery === 'string' ? 'yes' : 'no'}</Text>
+          <Text>hasSetQuery:{typeof result.setQuery === 'function' ? 'yes' : 'no'}</Text>
+          <Text>hasClear:{typeof result.clear === 'function' ? 'yes' : 'no'}</Text>
+          <Text>hasIsDebouncing:{typeof result.isDebouncing === 'boolean' ? 'yes' : 'no'}</Text>
+        </Box>
+      );
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('hasQuery:yes');
+    expect(lastFrame()).toContain('hasDebouncedQuery:yes');
+    expect(lastFrame()).toContain('hasSetQuery:yes');
+    expect(lastFrame()).toContain('hasClear:yes');
+    expect(lastFrame()).toContain('hasIsDebouncing:yes');
+  });
+
+  it('uses initial query', () => {
+    const TestComponent = (): React.ReactElement => {
+      const { query, debouncedQuery } = useDebouncedSearch({ initialQuery: 'test' });
+      return (
+        <Box flexDirection="column">
+          <Text>query:{query}</Text>
+          <Text>debounced:{debouncedQuery}</Text>
+        </Box>
+      );
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('query:test');
+    expect(lastFrame()).toContain('debounced:test');
+  });
+
+  it('isDebouncing is false initially when query matches debouncedQuery', () => {
+    const TestComponent = (): React.ReactElement => {
+      const { isDebouncing } = useDebouncedSearch({ initialQuery: 'test' });
+      return <Text>isDebouncing:{isDebouncing ? 'yes' : 'no'}</Text>;
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('isDebouncing:no');
+  });
+
+  it('accepts minLength option', () => {
+    const TestComponent = (): React.ReactElement => {
+      const { query } = useDebouncedSearch({ minLength: 3 });
+      return <Text>query:{query}</Text>;
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('query:');
+  });
+
+  it('accepts onSearch callback option', () => {
+    let onSearchProvided = false;
+    const TestComponent = (): React.ReactElement => {
+      useDebouncedSearch({
+        onSearch: () => {
+          onSearchProvided = true;
+        },
+      });
+      return <Text>rendered</Text>;
+    };
+
+    render(<TestComponent />);
+    expect(onSearchProvided).toBe(false); // Not called yet since no query change
+  });
+
+  it('accepts delay option', () => {
+    const TestComponent = (): React.ReactElement => {
+      const { query } = useDebouncedSearch({ delay: 500 });
+      return <Text>query:{query}</Text>;
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('query:');
+  });
+
+  it('empty initial query by default', () => {
+    const TestComponent = (): React.ReactElement => {
+      const { query, debouncedQuery } = useDebouncedSearch();
+      return (
+        <Box flexDirection="column">
+          <Text>query:{query || 'empty'}</Text>
+          <Text>debounced:{debouncedQuery || 'empty'}</Text>
+        </Box>
+      );
+    };
+
+    const { lastFrame } = render(<TestComponent />);
+    expect(lastFrame()).toContain('query:empty');
+    expect(lastFrame()).toContain('debounced:empty');
+  });
+});

--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -220,3 +220,14 @@ export {
   useDisableInput,
   type DisableInputProviderProps,
 } from './useDisableInput';
+
+export {
+  useDebounce,
+  useDebouncedCallback,
+  useDebouncedSearch,
+  DEFAULT_DEBOUNCE_MS,
+  type UseDebouncedCallbackOptions,
+  type UseDebouncedCallbackResult,
+  type UseDebouncedSearchOptions,
+  type UseDebouncedSearchResult,
+} from './useDebounce';

--- a/tui/src/hooks/useDebounce.ts
+++ b/tui/src/hooks/useDebounce.ts
@@ -1,0 +1,303 @@
+/**
+ * useDebounce - Debounce hook for expensive operations
+ * Issue #1602: Add debounce to expensive input operations
+ *
+ * Provides utilities to debounce values and callbacks:
+ * - useDebounce: Debounce a changing value
+ * - useDebouncedCallback: Debounce a callback function
+ * - useDebouncedSearch: Specialized hook for search input patterns
+ */
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+
+/** Default debounce delay in milliseconds */
+export const DEFAULT_DEBOUNCE_MS = 300;
+
+/**
+ * Debounce a value - returns the value after the specified delay
+ * Useful for search inputs where you want to wait for user to stop typing
+ *
+ * @param value - The value to debounce
+ * @param delay - Delay in milliseconds (default: 300)
+ * @returns The debounced value
+ *
+ * @example
+ * ```tsx
+ * const [searchQuery, setSearchQuery] = useState('');
+ * const debouncedQuery = useDebounce(searchQuery, 300);
+ *
+ * useEffect(() => {
+ *   // Only runs 300ms after user stops typing
+ *   performSearch(debouncedQuery);
+ * }, [debouncedQuery]);
+ * ```
+ */
+export function useDebounce<T>(value: T, delay: number = DEFAULT_DEBOUNCE_MS): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    // Set up timeout to update debounced value after delay
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Clear timeout if value changes or component unmounts
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+/**
+ * Options for useDebouncedCallback
+ */
+export interface UseDebouncedCallbackOptions {
+  /** Delay in milliseconds (default: 300) */
+  delay?: number;
+  /** Maximum wait time before forcing execution (default: undefined = no max) */
+  maxWait?: number;
+  /** Call immediately on first invocation (default: false) */
+  leading?: boolean;
+  /** Call on trailing edge of timeout (default: true) */
+  trailing?: boolean;
+}
+
+/**
+ * Result from useDebouncedCallback
+ */
+export interface UseDebouncedCallbackResult<T extends (...args: unknown[]) => unknown> {
+  /** The debounced callback function */
+  callback: T;
+  /** Cancel any pending debounced call */
+  cancel: () => void;
+  /** Flush any pending debounced call immediately */
+  flush: () => void;
+  /** Whether a call is currently pending */
+  isPending: boolean;
+}
+
+/**
+ * Debounce a callback function
+ * More flexible than useDebounce for cases where you need to debounce actions
+ *
+ * @param callback - The callback function to debounce
+ * @param options - Debounce options
+ * @returns Object with debounced callback and control functions
+ *
+ * @example
+ * ```tsx
+ * const { callback: debouncedSearch, cancel } = useDebouncedCallback(
+ *   (query: string) => {
+ *     performSearch(query);
+ *   },
+ *   { delay: 300 }
+ * );
+ *
+ * // Call debouncedSearch on each keystroke
+ * // Actual search only runs 300ms after last call
+ * ```
+ */
+export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
+  callback: T,
+  options: UseDebouncedCallbackOptions = {}
+): UseDebouncedCallbackResult<T> {
+  const {
+    delay = DEFAULT_DEBOUNCE_MS,
+    maxWait,
+    leading = false,
+    trailing = true,
+  } = options;
+
+  const callbackRef = useRef(callback);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const maxTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastArgsRef = useRef<Parameters<T> | null>(null);
+  const lastCallTimeRef = useRef<number>(0);
+  const [isPending, setIsPending] = useState(false);
+
+  // Keep callback ref up to date
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callback]);
+
+  // Cancel any pending timers
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (maxTimerRef.current) {
+      clearTimeout(maxTimerRef.current);
+      maxTimerRef.current = null;
+    }
+    lastArgsRef.current = null;
+    setIsPending(false);
+  }, []);
+
+  // Flush pending call immediately
+  const flush = useCallback(() => {
+    if (lastArgsRef.current && trailing) {
+      callbackRef.current(...lastArgsRef.current);
+    }
+    cancel();
+  }, [cancel, trailing]);
+
+  // Create the debounced callback
+  const debouncedCallback = useCallback(
+    (...args: Parameters<T>) => {
+      const now = Date.now();
+      lastArgsRef.current = args;
+      lastCallTimeRef.current = now;
+
+      // Clear existing timer
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+
+      // Handle leading edge call
+      if (leading && !isPending) {
+        callbackRef.current(...args);
+      }
+
+      setIsPending(true);
+
+      // Set up trailing edge timer
+      timerRef.current = setTimeout(() => {
+        if (trailing && lastArgsRef.current) {
+          callbackRef.current(...lastArgsRef.current);
+        }
+        cancel();
+      }, delay);
+
+      // Set up maxWait timer if specified
+      if (maxWait && !maxTimerRef.current) {
+        maxTimerRef.current = setTimeout(() => {
+          if (lastArgsRef.current) {
+            callbackRef.current(...lastArgsRef.current);
+          }
+          cancel();
+        }, maxWait);
+      }
+    },
+    [delay, maxWait, leading, trailing, isPending, cancel]
+  ) as T;
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      cancel();
+    };
+  }, [cancel]);
+
+  return useMemo(
+    () => ({
+      callback: debouncedCallback,
+      cancel,
+      flush,
+      isPending,
+    }),
+    [debouncedCallback, cancel, flush, isPending]
+  );
+}
+
+/**
+ * Options for useDebouncedSearch
+ */
+export interface UseDebouncedSearchOptions {
+  /** Initial search query (default: '') */
+  initialQuery?: string;
+  /** Debounce delay in milliseconds (default: 300) */
+  delay?: number;
+  /** Minimum query length to trigger search (default: 0) */
+  minLength?: number;
+  /** Called when debounced query changes */
+  onSearch?: (query: string) => void;
+}
+
+/**
+ * Result from useDebouncedSearch
+ */
+export interface UseDebouncedSearchResult {
+  /** Current input value (immediate) */
+  query: string;
+  /** Debounced query value (for filtering) */
+  debouncedQuery: string;
+  /** Set the search query */
+  setQuery: (query: string) => void;
+  /** Clear the search */
+  clear: () => void;
+  /** Whether search is being debounced */
+  isDebouncing: boolean;
+}
+
+/**
+ * Specialized hook for search input patterns
+ * Combines state management with debouncing for search UX
+ *
+ * @param options - Search options
+ * @returns Search state and controls
+ *
+ * @example
+ * ```tsx
+ * const { query, debouncedQuery, setQuery, clear, isDebouncing } = useDebouncedSearch({
+ *   delay: 300,
+ *   minLength: 2,
+ *   onSearch: (q) => console.log('Searching:', q),
+ * });
+ *
+ * // Use query for display, debouncedQuery for filtering
+ * const filtered = items.filter(item =>
+ *   debouncedQuery.length >= 2 && item.name.includes(debouncedQuery)
+ * );
+ * ```
+ */
+export function useDebouncedSearch(
+  options: UseDebouncedSearchOptions = {}
+): UseDebouncedSearchResult {
+  const {
+    initialQuery = '',
+    delay = DEFAULT_DEBOUNCE_MS,
+    minLength = 0,
+    onSearch,
+  } = options;
+
+  const [query, setQueryState] = useState(initialQuery);
+  const debouncedQuery = useDebounce(query, delay);
+  const prevDebouncedRef = useRef(debouncedQuery);
+
+  // Track if we're currently debouncing
+  const isDebouncing = query !== debouncedQuery;
+
+  // Call onSearch when debounced query changes
+  useEffect(() => {
+    if (prevDebouncedRef.current !== debouncedQuery) {
+      prevDebouncedRef.current = debouncedQuery;
+      if (debouncedQuery.length >= minLength && onSearch) {
+        onSearch(debouncedQuery);
+      }
+    }
+  }, [debouncedQuery, minLength, onSearch]);
+
+  const setQuery = useCallback((newQuery: string) => {
+    setQueryState(newQuery);
+  }, []);
+
+  const clear = useCallback(() => {
+    setQueryState('');
+  }, []);
+
+  return useMemo(
+    () => ({
+      query,
+      debouncedQuery,
+      setQuery,
+      clear,
+      isDebouncing,
+    }),
+    [query, debouncedQuery, setQuery, clear, isDebouncing]
+  );
+}
+
+export default useDebounce;

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -13,7 +13,7 @@
 
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { useAgents } from '../hooks';
+import { useAgents, useDebounce } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 import { useAgentGroups } from '../hooks/useAgentGroups';
@@ -60,10 +60,13 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
   const [groupedView, setGroupedView] = useState(true);
   const [collapsedRoles, setCollapsedRoles] = useState<Set<string>>(new Set());
 
-  // Use extracted hook for grouping logic
+  // Debounce search query for filtering (issue #1602)
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
+  // Use extracted hook for grouping logic (using debounced query for performance)
   const { agentList, stateCounts, visibleItems } = useAgentGroups(
     agents ?? [],
-    searchQuery,
+    debouncedSearchQuery,
     groupedView,
     collapsedRoles
   );

--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -5,8 +5,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { useDemons } from '../hooks/useDemons';
-import { useDisableInput } from '../hooks';
+import { useDemons, useDebounce, useDisableInput } from '../hooks';
 import { StatusBadge } from '../components/StatusBadge';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
@@ -87,18 +86,21 @@ export function DemonsView(_props: DemonsViewProps = {}): React.ReactElement {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchMode, setSearchMode] = useState(false);
 
-  // Filter demons by search query
+  // Debounce search query for filtering (issue #1602)
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
+  // Filter demons by search query (using debounced query for performance)
   const filteredDemons = React.useMemo(() => {
     const list = demons ?? [];
-    if (!searchQuery) return list;
-    const query = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return list;
+    const query = debouncedSearchQuery.toLowerCase();
     return list.filter(
       (demon) =>
         demon.name.toLowerCase().includes(query) ||
         demon.command.toLowerCase().includes(query) ||
         (demon.description?.toLowerCase().includes(query) ?? false)
     );
-  }, [demons, searchQuery]);
+  }, [demons, debouncedSearchQuery]);
 
   // Auto-clear action errors after a delay
   useEffect(() => {

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -4,7 +4,7 @@
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
-import { useLogs, getSeverityColor, getSeverityIcon } from '../hooks/useLogs';
+import { useLogs, getSeverityColor, getSeverityIcon, useDebounce } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { PulseText } from '../components/AnimatedText';
 import type { LogSeverity } from '../hooks/useLogs';
@@ -109,6 +109,9 @@ export const LogsView: React.FC<LogsViewProps> = () => {
   const [timeFilter, setTimeFilter] = useState<TimeFilter>('all');
   const { setFocus } = useFocus();
 
+  // Debounce search query for filtering (issue #1602)
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
   // Get unique agents for filter
   const agents = useMemo(() => {
     if (!logs) return [];
@@ -130,9 +133,9 @@ export const LogsView: React.FC<LogsViewProps> = () => {
       result = result.filter((log) => log.agent === agentFilter);
     }
 
-    // Search filter
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
+    // Search filter (using debounced query for performance - issue #1602)
+    if (debouncedSearchQuery) {
+      const query = debouncedSearchQuery.toLowerCase();
       result = result.filter(
         (log) =>
           log.message.toLowerCase().includes(query) ||
@@ -142,7 +145,7 @@ export const LogsView: React.FC<LogsViewProps> = () => {
     }
 
     return result;
-  }, [logs, timeFilter, agentFilter, searchQuery]);
+  }, [logs, timeFilter, agentFilter, debouncedSearchQuery]);
 
   const selectedLog = filteredLogs[selectedIndex] as LogEntry | undefined;
 

--- a/tui/src/views/ProcessesView.tsx
+++ b/tui/src/views/ProcessesView.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { useProcesses, useProcessLogs } from '../hooks';
+import { useProcesses, useProcessLogs, useDebounce } from '../hooks';
 import { Table } from '../components/Table';
 import type { Column } from '../components/Table';
 import { StatusBadge } from '../components/StatusBadge';
@@ -44,18 +44,21 @@ export function ProcessesView(): React.ReactElement {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchMode, setSearchMode] = useState(false);
 
-  // Filter processes by search query
+  // Debounce search query for filtering (issue #1602)
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
+  // Filter processes by search query (using debounced query for performance)
   const processList = useMemo(() => {
     const list = processes ?? [];
-    if (!searchQuery) return list;
-    const query = searchQuery.toLowerCase();
+    if (!debouncedSearchQuery) return list;
+    const query = debouncedSearchQuery.toLowerCase();
     return list.filter(
       (proc) =>
         proc.name.toLowerCase().includes(query) ||
         proc.command.toLowerCase().includes(query) ||
         (proc.owner?.toLowerCase().includes(query) ?? false)
     );
-  }, [processes, searchQuery]);
+  }, [processes, debouncedSearchQuery]);
 
   const selectedProcess = processList[selectedIndex] as typeof processList[number] | undefined;
 

--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -9,7 +9,7 @@ import { Panel } from '../components/Panel';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
-import { useAgents, useDisableInput } from '../hooks';
+import { useAgents, useDebounce, useDisableInput } from '../hooks';
 import { truncate } from '../utils';
 import type { Role } from '../types';
 import { getRoles, getRole, deleteRole } from '../services/bc';
@@ -34,6 +34,9 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
   const [searchMode, setSearchMode] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const { setFocus } = useFocus();
+
+  // Debounce search query for filtering (issue #1602)
+  const debouncedSearchQuery = useDebounce(searchQuery, 300);
 
   // #968 fix: Fetch agents to compute accurate role counts
   // Backend's agent_count is incorrect when running from worktree
@@ -85,22 +88,22 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
     void fetchRoles();
   }, [fetchRoles]);
 
-  // Filter roles by search
+  // Filter roles by search (using debounced query for performance - issue #1602)
   const filteredRoles = useMemo(() => {
-    if (searchQuery.length === 0) return roles;
-    const lower = searchQuery.toLowerCase();
+    if (debouncedSearchQuery.length === 0) return roles;
+    const lower = debouncedSearchQuery.toLowerCase();
     return roles.filter(
       (r) =>
         r.name.toLowerCase().includes(lower) ||
         (r.description?.toLowerCase().includes(lower) ?? false) ||
         r.capabilities.some((c) => c.toLowerCase().includes(lower))
     );
-  }, [roles, searchQuery]);
+  }, [roles, debouncedSearchQuery]);
 
   // Reset index when filtered results change
   useEffect(() => {
     setSelectedIndex(0);
-  }, [searchQuery]);
+  }, [debouncedSearchQuery]);
 
   // Get valid index
   const validIndex = Math.min(selectedIndex, Math.max(0, filteredRoles.length - 1));


### PR DESCRIPTION
## Summary
- Add `useDebounce` hook with three utilities for debouncing expensive operations:
  - `useDebounce` - Debounce a changing value (300ms default delay)
  - `useDebouncedCallback` - Debounce callback functions with cancel/flush controls
  - `useDebouncedSearch` - Specialized hook for search input patterns
- Apply debounce to search filtering in 5 views for improved performance:
  - LogsView, AgentsView, DemonsView, ProcessesView, RolesView
- Search query state updates immediately for responsive UI display
- Filtering operations use debounced query (300ms delay) to reduce re-renders

## Test plan
- [x] All 2082 TUI tests pass
- [x] 15 new tests for useDebounce hooks
- [x] Lint passes with no errors

Closes #1602

🤖 Generated with [Claude Code](https://claude.com/claude-code)