### PR TITLE
fix(tui): Centralize polling configuration in useDashboard (#1606)

### DIFF
--- a/tui/src/config/ConfigContext.tsx
+++ b/tui/src/config/ConfigContext.tsx
@@ -20,6 +20,7 @@ const DEFAULT_PERFORMANCE_CONFIG: PerformanceConfig = {
   poll_interval_logs: 3000,
   poll_interval_teams: 10000,
   poll_interval_demons: 5000,
+  poll_interval_dashboard: 30000, // Dashboard aggregates data, uses slower interval
   cache_ttl_tmux: 2000,
   cache_ttl_commands: 5000,
   adaptive_fast_interval: 1000,

--- a/tui/src/hooks/useDashboard.ts
+++ b/tui/src/hooks/useDashboard.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { getStatus, getChannels, getCostSummary } from '../services/bc.js';
+import { usePerformanceConfig } from '../config';
 import type { StatusResponse, ChannelsResponse, CostSummary, Agent } from '../types';
 
 interface UseDataResult<T> {
@@ -50,6 +51,10 @@ interface DashboardChannel {
  * Integrates with bc CLI via service layer for real-time workspace data.
  */
 export function useDashboard() {
+  // Get poll interval from centralized config (#1606)
+  const perfConfig = usePerformanceConfig();
+  const pollInterval = perfConfig.poll_interval_dashboard;
+
   const [agents, setAgents] = useState<UseDataResult<DashboardAgent[]>>({
     data: null,
     isLoading: true,
@@ -154,12 +159,12 @@ export function useDashboard() {
     void fetchData();
   }, [fetchData]);
 
-  // Auto-refresh every 30 seconds (optimized for performance - Issue #559)
+  // Auto-refresh using centralized config interval (#1606)
   // Users can manually refresh with 'r' key for immediate updates
   useEffect(() => {
-    const interval = setInterval(() => { void fetchData(); }, 30000);
+    const interval = setInterval(() => { void fetchData(); }, pollInterval);
     return () => { clearInterval(interval); };
-  }, [fetchData]);
+  }, [fetchData, pollInterval]);
 
   // Compute agent stats breakdown
   const agentStats = useMemo<AgentStats>(() => {

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -244,6 +244,7 @@ export interface PerformanceConfig {
   poll_interval_logs: number;
   poll_interval_teams: number;
   poll_interval_demons: number;
+  poll_interval_dashboard: number;
   cache_ttl_tmux: number;
   cache_ttl_commands: number;
   adaptive_fast_interval: number;


### PR DESCRIPTION
## Summary
- Add `poll_interval_dashboard` to PerformanceConfig type
- Add 30000ms default in ConfigContext
- Update useDashboard to use centralized config instead of hardcoded interval

## Problem
The `useDashboard` hook was using a hardcoded 30-second polling interval while all other hooks used the centralized `usePerformanceConfig()` hook.

## Solution
Now all polling intervals are centralized in ConfigContext and configurable via workspace config:
- `useAgents` → `poll_interval_agents` ✅
- `useChannels` → `poll_interval_channels` ✅
- `useCosts` → `poll_interval_costs` ✅
- `useDashboard` → `poll_interval_dashboard` ✅ (NEW)
- etc.

## Test plan
- [x] `bun run lint` - 0 errors
- [x] `bun test` - 2049 pass, 0 fail
- [x] Dashboard polling now uses configurable interval

Closes #1606

🤖 Generated with [Claude Code](https://claude.com/claude-code)