### PR TITLE
feat(tui): Improve CommandPalette UX (#1603)

### DIFF
--- a/tui/src/__tests__/components/CommandPalette.test.tsx
+++ b/tui/src/__tests__/components/CommandPalette.test.tsx
@@ -51,7 +51,7 @@ describe('CommandPalette', () => {
   });
 
   describe('recent commands', () => {
-    it('should mark recent commands with asterisk', () => {
+    it('should mark recent commands with star', () => {
       const { lastFrame } = render(
         <CommandPalette
           isOpen={true}
@@ -61,7 +61,8 @@ describe('CommandPalette', () => {
         />
       );
 
-      expect(lastFrame()).toContain('*');
+      // #1603: Changed asterisk to star symbol
+      expect(lastFrame()).toContain('★');
     });
 
     it('should show recent commands first', () => {
@@ -92,8 +93,8 @@ describe('CommandPalette', () => {
 
       // Should show limited results
       const frame = lastFrame() ?? '';
-      // Count the number of command rows (lines with command names)
-      const lines = frame.split('\n').filter(l => l.includes(' - '));
+      // #1603: Count the number of command rows (lines with em dash separator)
+      const lines = frame.split('\n').filter(l => l.includes(' — '));
       expect(lines.length).toBeLessThanOrEqual(3);
     });
   });
@@ -122,8 +123,9 @@ describe('CommandPalette', () => {
         <CommandPalette isOpen={true} onClose={() => {}} disableInput />
       );
 
+      // #1603: Changed separator to em dash
       // Should contain the separator between name and description
-      expect(lastFrame()).toContain(' - ');
+      expect(lastFrame()).toContain(' — ');
     });
   });
 

--- a/tui/src/components/CommandPalette.tsx
+++ b/tui/src/components/CommandPalette.tsx
@@ -5,7 +5,7 @@
 
 import React, { useState, useMemo, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
-import { searchCommands, getAllCommands, type BcCommand } from '../types/commands';
+import { searchCommands, getAllCommands, groupCommandsByCategory, type BcCommand } from '../types/commands';
 
 export interface CommandPaletteProps {
   /** Whether the palette is visible */
@@ -20,6 +20,15 @@ export interface CommandPaletteProps {
   maxResults?: number;
   /** Disable input handling (for testing) */
   disableInput?: boolean;
+  /** #1603: Show results grouped by category */
+  showCategories?: boolean;
+}
+
+/** #1603: Render item in command list - can be command or category header */
+interface RenderItem {
+  type: 'command' | 'category';
+  command?: BcCommand;
+  category?: string;
 }
 
 /**
@@ -32,6 +41,7 @@ export function CommandPalette({
   recentCommands = [],
   maxResults = 8,
   disableInput = false,
+  showCategories = true,
 }: CommandPaletteProps): React.ReactElement | null {
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -53,6 +63,37 @@ export function CommandPalette({
     return searchCommands(query).slice(0, maxResults);
   }, [query, recentCommands, maxResults]);
 
+  // #1603: Build render items with category headers when showing categories
+  const renderItems = useMemo((): RenderItem[] => {
+    if (!showCategories || query.trim()) {
+      // Don't show categories when searching
+      return results.map(cmd => ({ type: 'command', command: cmd }));
+    }
+
+    // Group by category
+    const grouped = groupCommandsByCategory(results);
+    const items: RenderItem[] = [];
+
+    for (const [category, commands] of grouped) {
+      items.push({ type: 'category', category });
+      for (const command of commands) {
+        items.push({ type: 'command', command });
+      }
+    }
+
+    return items;
+  }, [results, showCategories, query]);
+
+  // Get selectable indices (only commands, not category headers)
+  const selectableIndices = useMemo(() => {
+    return renderItems
+      .map((item, idx) => (item.type === 'command' ? idx : -1))
+      .filter(idx => idx >= 0);
+  }, [renderItems]);
+
+  // Map selectedIndex to actual render index
+  const selectedRenderIndex = selectableIndices[selectedIndex] ?? 0;
+
   // Reset selection when results change
   const handleQueryChange = useCallback((newQuery: string) => {
     setQuery(newQuery);
@@ -72,19 +113,21 @@ export function CommandPalette({
         return;
       }
 
-      // Navigate results
+      // Navigate selectable items (skip category headers)
+      const maxIdx = selectableIndices.length - 1;
       if (key.upArrow) {
-        setSelectedIndex(i => (i > 0 ? i - 1 : results.length - 1));
+        setSelectedIndex(i => (i > 0 ? i - 1 : maxIdx));
         return;
       }
       if (key.downArrow) {
-        setSelectedIndex(i => (i < results.length - 1 ? i + 1 : 0));
+        setSelectedIndex(i => (i < maxIdx ? i + 1 : 0));
         return;
       }
 
       // Select command
-      if (key.return && results[selectedIndex]) {
-        const selected = results[selectedIndex];
+      const selectedItem = renderItems[selectedRenderIndex] as RenderItem | undefined;
+      if (key.return && selectedItem && selectedItem.type === 'command' && selectedItem.command) {
+        const selected = selectedItem.command;
         setQuery('');
         setSelectedIndex(0);
         onSelect?.(selected);
@@ -103,7 +146,7 @@ export function CommandPalette({
         handleQueryChange(query + input);
       }
     },
-    [isOpen, onClose, results, selectedIndex, onSelect, handleQueryChange, query]
+    [isOpen, onClose, selectableIndices, selectedRenderIndex, renderItems, onSelect, handleQueryChange, query]
   );
 
   // Handle keyboard input
@@ -134,19 +177,28 @@ export function CommandPalette({
       </Box>
 
       {/* Results */}
-      {results.length === 0 ? (
+      {renderItems.length === 0 ? (
         <Box>
           <Text dimColor>No commands found</Text>
         </Box>
       ) : (
-        results.map((cmd, index) => (
-          <CommandRow
-            key={cmd.name}
-            command={cmd}
-            isSelected={index === selectedIndex}
-            isRecent={recentCommands.includes(cmd.name)}
-          />
-        ))
+        renderItems.map((item, index) => {
+          if (item.type === 'category') {
+            return (
+              <CategoryHeader key={`cat-${item.category ?? ''}`} name={item.category ?? ''} />
+            );
+          }
+          const cmd = item.command;
+          if (!cmd) return null;
+          return (
+            <CommandRow
+              key={cmd.name}
+              command={cmd}
+              isSelected={index === selectedRenderIndex}
+              isRecent={recentCommands.includes(cmd.name)}
+            />
+          );
+        })
       )}
 
       {/* Footer hints */}
@@ -159,6 +211,19 @@ export function CommandPalette({
   );
 }
 
+/** #1603: Category header for grouped results */
+interface CategoryHeaderProps {
+  name: string;
+}
+
+const CategoryHeader = React.memo(function CategoryHeader({ name }: CategoryHeaderProps): React.ReactElement {
+  return (
+    <Box marginTop={1}>
+      <Text dimColor bold>{name}</Text>
+    </Box>
+  );
+});
+
 interface CommandRowProps {
   command: BcCommand;
   isSelected: boolean;
@@ -166,7 +231,14 @@ interface CommandRowProps {
 }
 
 /** #1596: Memoized command row to prevent re-renders when unrelated state changes */
+/** #1603: Show keyboard shortcuts next to command name */
 const CommandRow = React.memo(function CommandRow({ command, isSelected, isRecent }: CommandRowProps): React.ReactElement {
+  // #1603: Truncate description to fit with shortcut
+  const maxDescLen = command.shortcut ? 28 : 35;
+  const desc = command.description.length > maxDescLen
+    ? command.description.slice(0, maxDescLen - 1) + '…'
+    : command.description;
+
   return (
     <Box>
       <Text
@@ -175,9 +247,12 @@ const CommandRow = React.memo(function CommandRow({ command, isSelected, isRecen
         inverse={isSelected}
       >
         {isSelected ? '> ' : '  '}
-        {isRecent && <Text color="yellow">* </Text>}
+        {isRecent && <Text color="yellow">★ </Text>}
         <Text bold={isSelected}>{command.name}</Text>
-        <Text dimColor> - {command.description.slice(0, 35)}</Text>
+        {command.shortcut && (
+          <Text color="magenta" dimColor={!isSelected}> [{command.shortcut}]</Text>
+        )}
+        <Text dimColor> — {desc}</Text>
       </Text>
     </Box>
   );

--- a/tui/src/types/commands.ts
+++ b/tui/src/types/commands.ts
@@ -10,6 +10,7 @@ export interface BcCommand {
   usage: string;          // Command usage (e.g., 'bc agent list')
   readOnly: boolean;      // Safe to execute in TUI
   flags?: string[];       // Common flags
+  shortcut?: string;      // #1603: Keyboard shortcut (e.g., 'a' for agents view)
 }
 
 export interface CommandCategory {
@@ -334,15 +335,64 @@ export function getAllCommands(): BcCommand[] {
 }
 
 /**
- * Filter commands by search query
+ * #1603: Calculate fuzzy match score (higher = better match)
+ * Returns -1 if no match, 0-100 for match quality
+ */
+export function fuzzyMatchScore(text: string, query: string): number {
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+
+  // Exact match gets highest score
+  if (lowerText === lowerQuery) return 100;
+
+  // Starts with query gets high score
+  if (lowerText.startsWith(lowerQuery)) return 90;
+
+  // Contains query gets medium score
+  if (lowerText.includes(lowerQuery)) return 70;
+
+  // Fuzzy match: all query chars must appear in order
+  let queryIdx = 0;
+  let consecutive = 0;
+  let maxConsecutive = 0;
+
+  for (let i = 0; i < lowerText.length && queryIdx < lowerQuery.length; i++) {
+    if (lowerText[i] === lowerQuery[queryIdx]) {
+      queryIdx++;
+      consecutive++;
+      maxConsecutive = Math.max(maxConsecutive, consecutive);
+    } else {
+      consecutive = 0;
+    }
+  }
+
+  // All chars matched?
+  if (queryIdx < lowerQuery.length) return -1;
+
+  // Score based on consecutive matches
+  return 30 + Math.min(40, maxConsecutive * 10);
+}
+
+/**
+ * Filter commands by search query with fuzzy matching (#1603)
  */
 export function searchCommands(query: string): BcCommand[] {
-  const lowerQuery = query.toLowerCase();
-  return getAllCommands().filter(cmd =>
-    cmd.name.toLowerCase().includes(lowerQuery) ||
-    cmd.description.toLowerCase().includes(lowerQuery) ||
-    cmd.category.toLowerCase().includes(lowerQuery)
-  );
+  const lowerQuery = query.toLowerCase().trim();
+  if (!lowerQuery) return getAllCommands();
+
+  const scored = getAllCommands()
+    .map(cmd => {
+      // Score multiple fields, take best match
+      const nameScore = fuzzyMatchScore(cmd.name, lowerQuery);
+      const descScore = fuzzyMatchScore(cmd.description, lowerQuery);
+      const catScore = fuzzyMatchScore(cmd.category, lowerQuery);
+      const score = Math.max(nameScore, descScore * 0.8, catScore * 0.6);
+      return { cmd, score };
+    })
+    .filter(({ score }) => score > 0)
+    .sort((a, b) => b.score - a.score);
+
+  return scored.map(({ cmd }) => cmd);
 }
 
 /**
@@ -350,4 +400,24 @@ export function searchCommands(query: string): BcCommand[] {
  */
 export function getCommandsByCategory(category: string): BcCommand[] {
   return COMMAND_REGISTRY.find(cat => cat.name === category)?.commands ?? [];
+}
+
+/**
+ * #1603: Get all category names
+ */
+export function getCategoryNames(): string[] {
+  return COMMAND_REGISTRY.map(cat => cat.name);
+}
+
+/**
+ * #1603: Group commands by category
+ */
+export function groupCommandsByCategory(commands: BcCommand[]): Map<string, BcCommand[]> {
+  const groups = new Map<string, BcCommand[]>();
+  for (const cmd of commands) {
+    const existing = groups.get(cmd.category) ?? [];
+    existing.push(cmd);
+    groups.set(cmd.category, existing);
+  }
+  return groups;
 }


### PR DESCRIPTION
## Summary
- Add fuzzy matching for search with character-by-character matching and scoring
- Group results by category with visual headers (when not searching)
- Improve visual polish:
  - Changed separator from hyphen to em dash
  - Changed recent command indicator from asterisk to star symbol
- Add `shortcut` field to BcCommand interface for future keyboard shortcut display
- Update tests for new formatting

## Changes
1. **Fuzzy search** - Commands now match when all query characters appear in order, not just substring matches. Results are scored by match quality.
2. **Category grouping** - When showing all commands (no search query), results are grouped by category with headers
3. **Visual improvements** - Better typography with em dash and star symbol

## Test plan
- [x] All 2049 TUI tests pass
- [x] Lint passes (only pre-existing warnings)
- [x] CommandPalette renders with category headers
- [x] Fuzzy search finds commands like "al" → "agent list"

Fixes #1603

🤖 Generated with [Claude Code](https://claude.com/claude-code)