### PR TITLE
docs(tui): Add view structure pattern documentation (#1605)

### DIFF
--- a/tui/src/views/README.md
+++ b/tui/src/views/README.md
@@ -1,0 +1,86 @@
+# Views Directory Structure
+
+This document describes the standard organization pattern for TUI view components.
+
+## Issue #1605
+
+## Overview
+
+Views are organized in two patterns depending on complexity:
+
+### Simple Views (< 200 lines)
+Single file in `views/` directory:
+```
+views/
+├── SimpleView.tsx        # Self-contained view
+```
+
+### Complex Views (> 200 lines)
+Directory with extracted components:
+```
+views/
+├── ComplexView/
+│   ├── index.ts              # Re-exports main view
+│   ├── ComplexView.tsx       # Container/orchestrator
+│   └── components/           # Extracted sub-components
+│       ├── FeatureA.tsx
+│       └── FeatureB.tsx
+```
+
+## Current Structure
+
+### Already Following Pattern
+- `agents/` - AgentCard, AgentList, AgentActions, etc.
+- `components/channels/` - ChannelRow, ChannelHistoryView
+
+### Single File Views (appropriate size)
+- `ActivityView.tsx` (~130 lines) - Activity timeline
+- `DemonsView.tsx` (~350 lines) - Could be split
+- `ProcessesView.tsx` (~200 lines)
+- `RoutingView.tsx` (~290 lines)
+- `RolesView.tsx` (~460 lines) - Could be split
+- `MemoryView.tsx` (~400 lines) - Could be split
+
+### Views That Could Be Refactored
+Large views that would benefit from extraction:
+- `AgentsView.tsx` (643 lines) - Has agents/ but container is large
+- `FilesView.tsx` (583 lines) - Would benefit from split
+- `Dashboard.tsx` (529 lines) - Would benefit from split
+
+## Guidelines
+
+### When to Extract Components
+1. Component is > 100 lines
+2. Component has distinct responsibility
+3. Component could be reused
+4. Testing would be easier with isolation
+
+### Naming Conventions
+- View directories: PascalCase (`AgentsView/`)
+- Component files: PascalCase (`AgentCard.tsx`)
+- Index files: lowercase (`index.ts`)
+- Hooks: camelCase with `use` prefix (`useAgentState.ts`)
+
+### Export Pattern
+```typescript
+// views/ViewName/index.ts
+export { ViewName } from './ViewName';
+export { SubComponent } from './components/SubComponent';
+```
+
+```typescript
+// views/index.ts (main barrel file)
+export { ViewName } from './ViewName';  // Directory export
+export { SimpleView } from './SimpleView';  // Direct file export
+```
+
+## Migration Steps
+
+When refactoring a large view:
+
+1. Create directory: `views/[ViewName]/`
+2. Move main file: `[ViewName].tsx` -> `[ViewName]/[ViewName].tsx`
+3. Create `index.ts` re-exporting the main view
+4. Extract components to `[ViewName]/components/`
+5. Update imports in the main view
+6. Update `views/index.ts` to use directory export

--- a/tui/src/views/index.ts
+++ b/tui/src/views/index.ts
@@ -1,14 +1,38 @@
-// Views for bc TUI
+/**
+ * Views barrel export for bc TUI
+ *
+ * Issue #1605: Establish consistent view component structure
+ *
+ * Views are organized in two patterns:
+ * - Simple views: Direct file export (./ViewName.tsx)
+ * - Complex views: Directory export (./ViewName/index.ts)
+ *
+ * See README.md for the complete structure pattern.
+ */
 
-export { AgentsView } from './AgentsView';
+// Workspace views
 export { Dashboard } from './Dashboard';
+export { AgentsView } from './AgentsView';
 export { AgentDetailView } from './AgentDetailView';
-export { DemonsView } from './DemonsView';
-export { ProcessesView } from './ProcessesView';
-export { TeamsView } from './TeamsView';
-export { RolesView } from './RolesView';
+export { FilesView } from './FilesView';
+export { CommandsView } from './CommandsView';
+
+// Monitoring views
 export { LogsView } from './LogsView';
+export { ActivityView } from './ActivityView';
+export { ProcessesView } from './ProcessesView';
+export { DemonsView } from './DemonsView';
+
+// System views
+export { RolesView } from './RolesView';
+export { TeamsView } from './TeamsView';
 export { WorktreesView } from './WorktreesView';
 export { WorkspaceSelectorView } from './WorkspaceSelectorView';
+export { MemoryView } from './MemoryView';
+export { RoutingView } from './RoutingView';
+
+// Setup & utilities
 export { SetupWizard } from './SetupWizard';
-export { FilesView } from './FilesView';
+
+// Re-export sub-components from complex views
+export * from './agents';


### PR DESCRIPTION
## Summary
- Add `README.md` documenting view component organization patterns
- Update `index.ts` with organized exports by category (Workspace, Monitoring, System)
- Re-export agents/ sub-components from barrel file
- Add missing view exports (ActivityView, CommandsView, MemoryView, RoutingView)

## Documentation Added
The README documents:
- Simple views pattern (single file < 200 lines)
- Complex views pattern (directory with extracted components)
- Naming conventions
- Export patterns
- Migration steps for refactoring large views

## Existing Pattern Examples
- `views/agents/` - Already follows directory pattern
- `components/channels/` - Already extracted

## Test plan
- [x] All views tests pass (417 pass, 0 fail)
- [x] Lint passes (only pre-existing warnings)
- [x] Exports verified to compile

Note: 5 tmux integration test failures are pre-existing and unrelated to these changes.

Fixes #1605

🤖 Generated with [Claude Code](https://claude.com/claude-code)