### PR TITLE
feat(tui): Add consistent breadcrumb navigation across views (#1604)

### DIFF
--- a/tui/src/__tests__/MemoryView.test.tsx
+++ b/tui/src/__tests__/MemoryView.test.tsx
@@ -9,6 +9,7 @@ import { render } from 'ink-testing-library';
 import { Text, Box } from 'ink';
 import { MemoryView } from '../views/MemoryView';
 import { FocusProvider } from '../navigation/FocusContext';
+import { NavigationProvider } from '../navigation/NavigationContext';
 import { HintsProvider, useHintsContext, DisableInputProvider } from '../hooks';
 import * as bc from '../services/bc';
 
@@ -36,15 +37,18 @@ const mockGetMemoryList = bc.getMemoryList as jest.Mock;
 const mockGetMemory = bc.getMemory as jest.Mock;
 
 // #1594: Use DisableInputProvider instead of prop
+// #1604: Add NavigationProvider for breadcrumb context
 function renderMemoryView(props = {}, withHintsDisplay = false) {
   return render(
     <HintsProvider>
-      <FocusProvider>
-        <DisableInputProvider disabled>
-          <MemoryView {...props} />
-          {withHintsDisplay && <HintsDisplay />}
-        </DisableInputProvider>
-      </FocusProvider>
+      <NavigationProvider>
+        <FocusProvider>
+          <DisableInputProvider disabled>
+            <MemoryView {...props} />
+            {withHintsDisplay && <HintsDisplay />}
+          </DisableInputProvider>
+        </FocusProvider>
+      </NavigationProvider>
     </HintsProvider>
   );
 }

--- a/tui/src/__tests__/RoutingView.test.tsx
+++ b/tui/src/__tests__/RoutingView.test.tsx
@@ -9,6 +9,7 @@ import { render } from 'ink-testing-library';
 import { Text, Box } from 'ink';
 import { RoutingView } from '../views/RoutingView';
 import { FocusProvider } from '../navigation/FocusContext';
+import { NavigationProvider } from '../navigation/NavigationContext';
 import { HintsProvider, useHintsContext, DisableInputProvider } from '../hooks';
 import * as useAgentsHook from '../hooks/useAgents';
 
@@ -32,15 +33,18 @@ jest.mock('../hooks/useAgents', () => ({
 const mockUseAgents = useAgentsHook.useAgents as jest.Mock;
 
 // #1594: Use DisableInputProvider instead of prop
+// #1604: Add NavigationProvider for breadcrumb context
 function renderRoutingView(props = {}, withHintsDisplay = false) {
   return render(
     <HintsProvider>
-      <FocusProvider>
-        <DisableInputProvider disabled>
-          <RoutingView {...props} />
-          {withHintsDisplay && <HintsDisplay />}
-        </DisableInputProvider>
-      </FocusProvider>
+      <NavigationProvider>
+        <FocusProvider>
+          <DisableInputProvider disabled>
+            <RoutingView {...props} />
+            {withHintsDisplay && <HintsDisplay />}
+          </DisableInputProvider>
+        </FocusProvider>
+      </NavigationProvider>
     </HintsProvider>
   );
 }

--- a/tui/src/__tests__/views/RolesView.test.tsx
+++ b/tui/src/__tests__/views/RolesView.test.tsx
@@ -9,16 +9,20 @@ import { render } from 'ink-testing-library';
 import { describe, it, expect, vi, beforeEach, mock } from 'bun:test';
 import { RolesView } from '../../views/RolesView';
 import { FocusProvider } from '../../navigation/FocusContext';
+import { NavigationProvider } from '../../navigation/NavigationContext';
 import { ConfigProvider } from '../../config';
 import { DisableInputProvider } from '../../hooks';
 
 // #1594: Helper to wrap component with required providers including DisableInputProvider
+// #1604: Add NavigationProvider for breadcrumb context
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
     <ConfigProvider>
-      <FocusProvider>
-        <DisableInputProvider disabled>{ui}</DisableInputProvider>
-      </FocusProvider>
+      <NavigationProvider>
+        <FocusProvider>
+          <DisableInputProvider disabled>{ui}</DisableInputProvider>
+        </FocusProvider>
+      </NavigationProvider>
     </ConfigProvider>
   );
 };

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -15,6 +15,7 @@ import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useAgents, useDebounce } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
+import { useNavigation } from '../navigation/NavigationContext';
 import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 import { useAgentGroups } from '../hooks/useAgentGroups';
 import { PulseText } from '../components/AnimatedText';
@@ -82,15 +83,18 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
   }, [visibleItems, selectedIndex]);
 
   const { setFocus } = useFocus();
+  const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
-  // Manage focus state for nested view navigation
+  // Manage focus state and breadcrumbs for nested view navigation (#1604)
   useEffect(() => {
-    if (showDetail) {
+    if (showDetail && selectedAgent) {
       setFocus('view');
+      setBreadcrumbs([{ label: selectedAgent.name }]);
     } else {
       setFocus('main');
+      clearBreadcrumbs();
     }
-  }, [showDetail, setFocus]);
+  }, [showDetail, selectedAgent, setFocus, setBreadcrumbs, clearBreadcrumbs]);
 
   // Clear action feedback after delay
   const showActionFeedback = useCallback((action: AgentAction, target: string, status: 'success' | 'error', message: string) => {

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -6,6 +6,7 @@ import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { useLogs, getSeverityColor, getSeverityIcon, useDebounce } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
+import { useNavigation } from '../navigation/NavigationContext';
 import { PulseText } from '../components/AnimatedText';
 import type { LogSeverity } from '../hooks/useLogs';
 import type { LogEntry } from '../types';
@@ -108,6 +109,7 @@ export const LogsView: React.FC<LogsViewProps> = () => {
   const [agentFilter, setAgentFilter] = useState<string | null>(null);
   const [timeFilter, setTimeFilter] = useState<TimeFilter>('all');
   const { setFocus } = useFocus();
+  const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   // Debounce search query for filtering (issue #1602)
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
@@ -149,14 +151,16 @@ export const LogsView: React.FC<LogsViewProps> = () => {
 
   const selectedLog = filteredLogs[selectedIndex] as LogEntry | undefined;
 
-  // Manage focus state for nested view navigation
+  // Manage focus state and breadcrumbs for nested view navigation (#1604)
   useEffect(() => {
-    if (showDetail) {
+    if (showDetail && selectedLog) {
       setFocus('view');
+      setBreadcrumbs([{ label: `${selectedLog.agent}: ${abbreviateType(selectedLog.type)}` }]);
     } else {
       setFocus('main');
+      clearBreadcrumbs();
     }
-  }, [showDetail, setFocus]);
+  }, [showDetail, selectedLog, setFocus, setBreadcrumbs, clearBreadcrumbs]);
 
   // Cycle through severity filters
   const cycleSeverity = useCallback(() => {

--- a/tui/src/views/MemoryView.tsx
+++ b/tui/src/views/MemoryView.tsx
@@ -9,6 +9,7 @@ import { Panel } from '../components/Panel';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
 import { useFocus } from '../navigation/FocusContext';
+import { useNavigation } from '../navigation/NavigationContext';
 import { useDisableInput } from '../hooks';
 import { getMemoryList, getMemory, searchMemory, clearMemory } from '../services/bc';
 import { truncate } from '../utils';
@@ -41,15 +42,23 @@ export function MemoryView(_props: MemoryViewProps = {}): React.ReactElement {
   const [confirmClear, setConfirmClear] = useState(false);
   const [detailTab, setDetailTab] = useState<'experiences' | 'learnings'>('experiences');
   const { setFocus } = useFocus();
+  const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
-  // Manage focus for nested views
+  // Manage focus and breadcrumbs for nested views (#1604)
   useEffect(() => {
-    if (viewMode === 'detail' || searchMode) {
+    if (viewMode === 'detail' && selectedMemory) {
+      setFocus('view');
+      setBreadcrumbs([{ label: selectedMemory.agent }]);
+    } else if (viewMode === 'search') {
+      setFocus('view');
+      setBreadcrumbs([{ label: 'Search' }]);
+    } else if (searchMode) {
       setFocus('view');
     } else {
       setFocus('main');
+      clearBreadcrumbs();
     }
-  }, [viewMode, searchMode, setFocus]);
+  }, [viewMode, searchMode, selectedMemory, setFocus, setBreadcrumbs, clearBreadcrumbs]);
 
   // Fetch agent memory list
   const fetchMemoryList = useCallback(async () => {

--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -9,6 +9,7 @@ import { Panel } from '../components/Panel';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
+import { useNavigation } from '../navigation/NavigationContext';
 import { useAgents, useDebounce, useDisableInput } from '../hooks';
 import { truncate } from '../utils';
 import type { Role } from '../types';
@@ -34,6 +35,7 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
   const [searchMode, setSearchMode] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const { setFocus } = useFocus();
+  const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   // Debounce search query for filtering (issue #1602)
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
@@ -60,15 +62,17 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
     return Math.min(25, Math.max(15, maxNameLen + 3));
   }, [roles]);
 
-  // Manage focus state for nested view navigation
+  // Manage focus state and breadcrumbs for nested view navigation (#1604)
   // When showing details, set focus='view' to prevent global ESC from firing
   useEffect(() => {
-    if (showDetails) {
+    if (showDetails && selectedRole) {
       setFocus('view');
+      setBreadcrumbs([{ label: selectedRole.name }]);
     } else {
       setFocus('main');
+      clearBreadcrumbs();
     }
-  }, [showDetails, setFocus]);
+  }, [showDetails, selectedRole, setFocus, setBreadcrumbs, clearBreadcrumbs]);
 
   // Fetch roles
   const fetchRoles = useCallback(async () => {

--- a/tui/src/views/RoutingView.tsx
+++ b/tui/src/views/RoutingView.tsx
@@ -3,11 +3,13 @@
  * Issue #1231 - Add additional TUI views
  */
 
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
+import { useFocus } from '../navigation/FocusContext';
+import { useNavigation } from '../navigation/NavigationContext';
 import { useAgents, useDisableInput } from '../hooks';
 import { truncate } from '../utils';
 
@@ -52,6 +54,8 @@ export function RoutingView(_props: RoutingViewProps = {}): React.ReactElement {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [showDetails, setShowDetails] = useState(false);
   const agents = useAgents();
+  const { setFocus } = useFocus();
+  const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   // Count agents by role
   const agentCountByRole = useMemo(() => {
@@ -77,6 +81,17 @@ export function RoutingView(_props: RoutingViewProps = {}): React.ReactElement {
 
   const validIndex = Math.min(selectedIndex, ROUTING_RULES.length - 1);
   const currentRule = ROUTING_RULES[validIndex] as typeof ROUTING_RULES[0] | undefined;
+
+  // Manage focus state and breadcrumbs for nested view navigation (#1604)
+  useEffect(() => {
+    if (showDetails && currentRule) {
+      setFocus('view');
+      setBreadcrumbs([{ label: currentRule.taskType }]);
+    } else {
+      setFocus('main');
+      clearBreadcrumbs();
+    }
+  }, [showDetails, currentRule, setFocus, setBreadcrumbs, clearBreadcrumbs]);
 
   // Keyboard handling
   useInput(

--- a/tui/src/views/WorkspaceSelectorView.tsx
+++ b/tui/src/views/WorkspaceSelectorView.tsx
@@ -31,7 +31,7 @@ export const WorkspaceSelectorView: React.FC<WorkspaceSelectorViewProps> = ({
   const { stdout } = useStdout();
   const terminalWidth = stdout.columns;
   const { setFocus } = useFocus();
-  const { goHome } = useNavigation();
+  const { goHome, setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   const [workspaces, setWorkspaces] = useState<DiscoveredWorkspace[]>([]);
   const [loading, setLoading] = useState(true);
@@ -80,6 +80,15 @@ export const WorkspaceSelectorView: React.FC<WorkspaceSelectorViewProps> = ({
 
   const selectedWorkspace = filteredWorkspaces[selectedIndex] as DiscoveredWorkspace | undefined;
   const v2Count = workspaces.filter((ws) => ws.is_v2).length;
+
+  // Manage breadcrumbs for nested view navigation (#1604)
+  useEffect(() => {
+    if (showDetail && selectedWorkspace) {
+      setBreadcrumbs([{ label: selectedWorkspace.name }]);
+    } else {
+      clearBreadcrumbs();
+    }
+  }, [showDetail, selectedWorkspace, setBreadcrumbs, clearBreadcrumbs]);
 
   // Keyboard navigation
   useInput((input, key) => {

--- a/tui/src/views/WorktreesView.tsx
+++ b/tui/src/views/WorktreesView.tsx
@@ -8,6 +8,7 @@ import { getWorktrees, pruneWorktrees } from '../services/bc';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
+import { useNavigation } from '../navigation/NavigationContext';
 import type { Worktree } from '../types';
 
 /**
@@ -32,15 +33,7 @@ export const WorktreesView: React.FC = () => {
   const [pruneResult, setPruneResult] = useState<string | null>(null);
   const [showOrphanedOnly, setShowOrphanedOnly] = useState(false);
   const { setFocus } = useFocus();
-
-  // Manage focus state for nested view navigation
-  useEffect(() => {
-    if (showDetail) {
-      setFocus('view');
-    } else {
-      setFocus('main');
-    }
-  }, [showDetail, setFocus]);
+  const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   const fetchWorktrees = useCallback(async () => {
     try {
@@ -77,6 +70,17 @@ export const WorktreesView: React.FC = () => {
 
   const selectedWorktree = filteredWorktrees[selectedIndex] as Worktree | undefined;
   const hasOrphans = orphanedWorktrees.length > 0;
+
+  // Manage focus state and breadcrumbs for nested view navigation (#1604)
+  useEffect(() => {
+    if (showDetail && selectedWorktree) {
+      setFocus('view');
+      setBreadcrumbs([{ label: selectedWorktree.agent }]);
+    } else {
+      setFocus('main');
+      clearBreadcrumbs();
+    }
+  }, [showDetail, selectedWorktree, setFocus, setBreadcrumbs, clearBreadcrumbs]);
 
   // Handle prune action
   const handlePrune = useCallback(async () => {


### PR DESCRIPTION
## Summary
Add breadcrumb navigation to all multi-level views for consistent user experience.

## Changes
Views updated with breadcrumb support:
| View | Breadcrumb Label |
|------|-----------------|
| AgentsView | Agent name (e.g., "eng-02") |
| RolesView | Role name (e.g., "engineer") |
| WorktreesView | Worktree agent (e.g., "eng-01") |
| LogsView | Agent + type (e.g., "eng-02: report") |
| RoutingView | Task type (e.g., "code") |
| MemoryView | Agent name or "Search" |
| WorkspaceSelectorView | Workspace name |

### Pattern Applied
```tsx
// Set breadcrumbs when entering detail view
useEffect(() => {
  if (showDetail && selectedItem) {
    setBreadcrumbs([{ label: selectedItem.name }]);
  } else {
    clearBreadcrumbs();
  }
}, [showDetail, selectedItem, setBreadcrumbs, clearBreadcrumbs]);
```

## Test plan
- [x] `bun run lint` - 0 errors
- [x] `bun test` - 2059 pass, 5 fail (tmux e2e - unrelated)
- [x] Updated test wrappers with NavigationProvider

Closes #1604

🤖 Generated with [Claude Code](https://claude.com/claude-code)