### PR TITLE
fix(cost): Add warning logs for time.Parse errors (#1656)

### DIFF
--- a/pkg/cost/cost.go
+++ b/pkg/cost/cost.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/rpuneet/bc/pkg/log"
 )
 
 // BudgetPeriod represents the time period for a budget.
@@ -221,7 +223,11 @@ func (s *Store) scanRecord(row *sql.Row) (*Record, error) {
 	}
 
 	r.TeamID = teamID.String
-	r.Timestamp, _ = time.Parse(time.RFC3339, timestamp)
+	var parseErr error
+	r.Timestamp, parseErr = time.Parse(time.RFC3339, timestamp)
+	if parseErr != nil {
+		log.Warn("invalid timestamp in cost record", "id", r.ID, "raw", timestamp, "error", parseErr)
+	}
 	return &r, nil
 }
 
@@ -297,7 +303,11 @@ func (s *Store) scanRecords(rows *sql.Rows) ([]*Record, error) {
 		}
 
 		r.TeamID = teamID.String
-		r.Timestamp, _ = time.Parse(time.RFC3339, timestamp)
+		var parseErr error
+		r.Timestamp, parseErr = time.Parse(time.RFC3339, timestamp)
+		if parseErr != nil {
+			log.Warn("invalid timestamp in cost record", "id", r.ID, "raw", timestamp, "error", parseErr)
+		}
 		records = append(records, &r)
 	}
 	return records, rows.Err()
@@ -505,7 +515,11 @@ func (s *Store) GetBudget(scope string) (*Budget, error) {
 	}
 
 	b.HardStop = hardStop == 1
-	b.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+	var parseErr error
+	b.UpdatedAt, parseErr = time.Parse(time.RFC3339, updatedAt)
+	if parseErr != nil {
+		log.Warn("invalid timestamp in budget", "scope", b.Scope, "raw", updatedAt, "error", parseErr)
+	}
 	return &b, nil
 }
 
@@ -532,7 +546,11 @@ func (s *Store) GetAllBudgets() ([]*Budget, error) {
 		}
 
 		b.HardStop = hardStop == 1
-		b.UpdatedAt, _ = time.Parse(time.RFC3339, updatedAt)
+		var parseErr error
+		b.UpdatedAt, parseErr = time.Parse(time.RFC3339, updatedAt)
+		if parseErr != nil {
+			log.Warn("invalid timestamp in budget", "scope", b.Scope, "raw", updatedAt, "error", parseErr)
+		}
 		budgets = append(budgets, &b)
 	}
 	return budgets, rows.Err()


### PR DESCRIPTION
## Summary

- Fix silently ignored `time.Parse` errors in 4 locations in the cost package
- Add warning logs with context (record ID, budget scope, raw timestamp, error) when parsing fails
- Makes data corruption issues visible for debugging while maintaining backward compatibility

**Locations fixed:**
- `scanRecord`: parsing cost record timestamp
- `scanRecords`: parsing cost record timestamps  
- `GetBudget`: parsing budget updated_at timestamp
- `GetAllBudgets`: parsing budget updated_at timestamps

## Test plan

- [x] All existing cost package tests pass (50 tests)
- [x] `go vet` passes
- [x] `golangci-lint` passes with 0 issues
- [x] Pre-commit hooks pass

Fixes #1656

🤖 Generated with [Claude Code](https://claude.com/claude-code)