### PR TITLE
feat(errors): Add structured error types package (#1653)

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,197 @@
+// Package errors provides structured error types for bc CLI.
+//
+// This package defines sentinel errors and typed error structs for consistent
+// error handling across the codebase. Use errors.Is() to check for sentinel
+// errors and errors.As() to extract typed error details.
+//
+// # Sentinel Errors
+//
+// Sentinel errors represent common failure categories:
+//
+//	if errors.Is(err, bcerrors.ErrNotFound) {
+//	    // Handle not found case
+//	}
+//
+// # Typed Errors
+//
+// Typed errors provide additional context for specific operations:
+//
+//	var agentErr *bcerrors.AgentError
+//	if errors.As(err, &agentErr) {
+//	    fmt.Printf("agent %s failed: %s\n", agentErr.Agent, agentErr.Op)
+//	}
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for common failure modes.
+// Use errors.Is() to check for these errors.
+var (
+	// ErrNotFound indicates a requested resource was not found.
+	ErrNotFound = errors.New("not found")
+
+	// ErrAlreadyExists indicates a resource already exists.
+	ErrAlreadyExists = errors.New("already exists")
+
+	// ErrInvalidInput indicates invalid input was provided.
+	ErrInvalidInput = errors.New("invalid input")
+
+	// ErrPermission indicates a permission error.
+	ErrPermission = errors.New("permission denied")
+
+	// ErrTimeout indicates an operation timed out.
+	ErrTimeout = errors.New("operation timeout")
+
+	// ErrNotInWorkspace indicates the command was run outside a bc workspace.
+	ErrNotInWorkspace = errors.New("not in a bc workspace")
+
+	// ErrSessionNotFound indicates a tmux session was not found.
+	ErrSessionNotFound = errors.New("session not found")
+
+	// ErrAgentStopped indicates an agent has stopped.
+	ErrAgentStopped = errors.New("agent stopped")
+
+	// ErrChannelNotFound indicates a channel was not found.
+	ErrChannelNotFound = errors.New("channel not found")
+
+	// ErrRoleNotFound indicates a role was not found.
+	ErrRoleNotFound = errors.New("role not found")
+)
+
+// AgentError represents an error related to agent operations.
+type AgentError struct {
+	Err   error  // Underlying error
+	Agent string // Agent name
+	Op    string // Operation that failed (e.g., "start", "stop", "send")
+}
+
+func (e *AgentError) Error() string {
+	if e.Agent == "" {
+		return fmt.Sprintf("agent: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("agent %q: %s: %v", e.Agent, e.Op, e.Err)
+}
+
+func (e *AgentError) Unwrap() error { return e.Err }
+
+// NewAgentError creates a new AgentError.
+func NewAgentError(agent, op string, err error) *AgentError {
+	return &AgentError{Agent: agent, Op: op, Err: err}
+}
+
+// WorkspaceError represents an error related to workspace operations.
+type WorkspaceError struct {
+	Err  error  // Underlying error
+	Path string // Workspace path
+	Op   string // Operation that failed
+}
+
+func (e *WorkspaceError) Error() string {
+	if e.Path == "" {
+		return fmt.Sprintf("workspace: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("workspace %q: %s: %v", e.Path, e.Op, e.Err)
+}
+
+func (e *WorkspaceError) Unwrap() error { return e.Err }
+
+// NewWorkspaceError creates a new WorkspaceError.
+func NewWorkspaceError(path, op string, err error) *WorkspaceError {
+	return &WorkspaceError{Path: path, Op: op, Err: err}
+}
+
+// ChannelError represents an error related to channel operations.
+type ChannelError struct {
+	Err     error  // Underlying error
+	Channel string // Channel name
+	Op      string // Operation that failed
+}
+
+func (e *ChannelError) Error() string {
+	if e.Channel == "" {
+		return fmt.Sprintf("channel: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("channel %q: %s: %v", e.Channel, e.Op, e.Err)
+}
+
+func (e *ChannelError) Unwrap() error { return e.Err }
+
+// NewChannelError creates a new ChannelError.
+func NewChannelError(channel, op string, err error) *ChannelError {
+	return &ChannelError{Channel: channel, Op: op, Err: err}
+}
+
+// TmuxError represents an error related to tmux operations.
+type TmuxError struct {
+	Err     error  // Underlying error
+	Session string // Session name (if applicable)
+	Op      string // Operation that failed
+}
+
+func (e *TmuxError) Error() string {
+	if e.Session == "" {
+		return fmt.Sprintf("tmux: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("tmux session %q: %s: %v", e.Session, e.Op, e.Err)
+}
+
+func (e *TmuxError) Unwrap() error { return e.Err }
+
+// NewTmuxError creates a new TmuxError.
+func NewTmuxError(session, op string, err error) *TmuxError {
+	return &TmuxError{Session: session, Op: op, Err: err}
+}
+
+// RoleError represents an error related to role operations.
+type RoleError struct {
+	Err  error  // Underlying error
+	Role string // Role name
+	Op   string // Operation that failed
+}
+
+func (e *RoleError) Error() string {
+	if e.Role == "" {
+		return fmt.Sprintf("role: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("role %q: %s: %v", e.Role, e.Op, e.Err)
+}
+
+func (e *RoleError) Unwrap() error { return e.Err }
+
+// NewRoleError creates a new RoleError.
+func NewRoleError(role, op string, err error) *RoleError {
+	return &RoleError{Role: role, Op: op, Err: err}
+}
+
+// Is reports whether any error in err's tree matches target.
+// This is a convenience wrapper around errors.Is.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// As finds the first error in err's tree that matches target.
+// This is a convenience wrapper around errors.As.
+func As(err error, target any) bool {
+	return errors.As(err, target)
+}
+
+// Wrap returns an error annotating err with a message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}
+
+// Wrapf returns an error annotating err with a formatted message.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,203 @@
+package errors
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSentinelErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"ErrNotFound", ErrNotFound, "not found"},
+		{"ErrAlreadyExists", ErrAlreadyExists, "already exists"},
+		{"ErrInvalidInput", ErrInvalidInput, "invalid input"},
+		{"ErrPermission", ErrPermission, "permission denied"},
+		{"ErrTimeout", ErrTimeout, "operation timeout"},
+		{"ErrNotInWorkspace", ErrNotInWorkspace, "not in a bc workspace"},
+		{"ErrSessionNotFound", ErrSessionNotFound, "session not found"},
+		{"ErrAgentStopped", ErrAgentStopped, "agent stopped"},
+		{"ErrChannelNotFound", ErrChannelNotFound, "channel not found"},
+		{"ErrRoleNotFound", ErrRoleNotFound, "role not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("%s.Error() = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentError(t *testing.T) {
+	t.Run("with agent name", func(t *testing.T) {
+		err := NewAgentError("eng-01", "start", ErrTimeout)
+		want := `agent "eng-01": start: operation timeout`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without agent name", func(t *testing.T) {
+		err := NewAgentError("", "list", ErrNotFound)
+		want := "agent: list: not found"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Unwrap", func(t *testing.T) {
+		err := NewAgentError("test", "op", ErrTimeout)
+		if !errors.Is(err, ErrTimeout) {
+			t.Error("errors.Is() should return true for wrapped error")
+		}
+	})
+
+	t.Run("errors.As", func(t *testing.T) {
+		err := NewAgentError("eng-01", "stop", ErrAgentStopped)
+		var agentErr *AgentError
+		if !errors.As(err, &agentErr) {
+			t.Error("errors.As() should return true for AgentError")
+		}
+		if agentErr.Agent != "eng-01" {
+			t.Errorf("Agent = %q, want %q", agentErr.Agent, "eng-01")
+		}
+	})
+}
+
+func TestWorkspaceError(t *testing.T) {
+	t.Run("with path", func(t *testing.T) {
+		err := NewWorkspaceError("/path/to/ws", "load", ErrNotFound)
+		want := `workspace "/path/to/ws": load: not found`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without path", func(t *testing.T) {
+		err := NewWorkspaceError("", "init", ErrAlreadyExists)
+		want := "workspace: init: already exists"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Unwrap", func(t *testing.T) {
+		err := NewWorkspaceError("/ws", "op", ErrNotInWorkspace)
+		if !errors.Is(err, ErrNotInWorkspace) {
+			t.Error("errors.Is() should return true for wrapped error")
+		}
+	})
+}
+
+func TestChannelError(t *testing.T) {
+	t.Run("with channel name", func(t *testing.T) {
+		err := NewChannelError("#general", "send", ErrPermission)
+		want := `channel "#general": send: permission denied`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without channel name", func(t *testing.T) {
+		err := NewChannelError("", "list", ErrTimeout)
+		want := "channel: list: operation timeout"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestTmuxError(t *testing.T) {
+	t.Run("with session name", func(t *testing.T) {
+		err := NewTmuxError("bc-eng-01", "create", ErrAlreadyExists)
+		want := `tmux session "bc-eng-01": create: already exists`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without session name", func(t *testing.T) {
+		err := NewTmuxError("", "list-sessions", ErrTimeout)
+		want := "tmux: list-sessions: operation timeout"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestRoleError(t *testing.T) {
+	t.Run("with role name", func(t *testing.T) {
+		err := NewRoleError("engineer", "validate", ErrInvalidInput)
+		want := `role "engineer": validate: invalid input`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without role name", func(t *testing.T) {
+		err := NewRoleError("", "list", ErrNotFound)
+		want := "role: list: not found"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestIs(t *testing.T) {
+	err := Wrap(ErrNotFound, "agent lookup failed")
+	if !Is(err, ErrNotFound) {
+		t.Error("Is() should return true for wrapped error")
+	}
+	if Is(err, ErrTimeout) {
+		t.Error("Is() should return false for different error")
+	}
+}
+
+func TestAs(t *testing.T) {
+	err := NewAgentError("test", "op", ErrNotFound)
+	var agentErr *AgentError
+	if !As(err, &agentErr) {
+		t.Error("As() should return true for AgentError")
+	}
+
+	var channelErr *ChannelError
+	if As(err, &channelErr) {
+		t.Error("As() should return false for wrong error type")
+	}
+}
+
+func TestWrap(t *testing.T) {
+	t.Run("wraps error with message", func(t *testing.T) {
+		err := Wrap(ErrNotFound, "agent lookup failed")
+		want := "agent lookup failed: not found"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns nil for nil error", func(t *testing.T) {
+		if err := Wrap(nil, "message"); err != nil {
+			t.Errorf("Wrap(nil, ...) = %v, want nil", err)
+		}
+	})
+}
+
+func TestWrapf(t *testing.T) {
+	t.Run("wraps error with formatted message", func(t *testing.T) {
+		err := Wrapf(ErrNotFound, "agent %q lookup failed", "eng-01")
+		want := `agent "eng-01" lookup failed: not found`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("returns nil for nil error", func(t *testing.T) {
+		if err := Wrapf(nil, "message %d", 42); err != nil {
+			t.Errorf("Wrapf(nil, ...) = %v, want nil", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Create pkg/errors with sentinel errors and typed error structs for consistent error handling across the codebase.

## Sentinel Errors
- `ErrNotFound`, `ErrAlreadyExists`, `ErrInvalidInput`
- `ErrPermission`, `ErrTimeout`, `ErrNotInWorkspace`
- `ErrSessionNotFound`, `ErrAgentStopped`
- `ErrChannelNotFound`, `ErrRoleNotFound`

## Typed Errors (with Unwrap support)
- `AgentError`: agent operations (start, stop, send, etc.)
- `WorkspaceError`: workspace operations (load, init, etc.)
- `ChannelError`: channel operations (send, join, etc.)
- `TmuxError`: tmux session operations (create, kill, etc.)
- `RoleError`: role operations (validate, load, etc.)

## Helper Functions
- `Is`/`As`: wrappers for `errors.Is`/`errors.As`
- `Wrap`/`Wrapf`: error wrapping with messages

## Usage Examples
```go
// Check sentinel errors
if errors.Is(err, bcerrors.ErrNotFound) {
    // Handle not found
}

// Extract typed error details
var agentErr *bcerrors.AgentError
if errors.As(err, &agentErr) {
    fmt.Printf("agent %s: %s failed\n", agentErr.Agent, agentErr.Op)
}

// Create typed errors
return bcerrors.NewAgentError("eng-01", "start", bcerrors.ErrTimeout)
```

## Benefits
- Consistent error handling with `errors.Is()` and `errors.As()`
- Machine-readable error types for better testing
- Clear error messages with operation context
- Proper error unwrapping for root cause analysis

## Test plan
- [x] All tests pass (17 test cases)
- [x] Lint passes (0 issues)
- [x] Full test suite passes

Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)