### PR TITLE
fix(tui): Fix TypeScript type constraint in useDebouncedCallback

### DIFF
--- a/tui/src/hooks/useDebounce.ts
+++ b/tui/src/hooks/useDebounce.ts
@@ -99,7 +99,7 @@ export interface UseDebouncedCallbackResult<T extends (...args: unknown[]) => un
  * // Actual search only runs 300ms after last call
  * ```
  */
-export function useDebouncedCallback<T extends (...args: never[]) => unknown>(
+export function useDebouncedCallback<T extends (...args: unknown[]) => unknown>(
   callback: T,
   options: UseDebouncedCallbackOptions = {}
 ): UseDebouncedCallbackResult<T> {


### PR DESCRIPTION
## Summary
- Fix TypeScript build error in `useDebouncedCallback` function
- The type constraint `T extends (...args: never[]) => unknown` was incompatible with the return type's constraint `(...args: unknown[]) => unknown`
- Changed to `T extends (...args: unknown[]) => unknown` to match the interface definition

## Test plan
- [x] `bun run build` completes successfully
- [x] All 2064 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)