### PR TITLE
feat(errors): Add structured error types package (#1653)

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,190 @@
+// Package errors provides structured error types for bc.
+//
+// This package defines sentinel errors for common failure modes and typed
+// error structs that wrap underlying errors with additional context.
+// Using these types enables consistent error handling with errors.Is() and
+// errors.As() throughout the codebase.
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors for common failure modes.
+// Use errors.Is(err, ErrNotFound) to check for these conditions.
+var (
+	// ErrNotFound indicates a requested resource was not found.
+	ErrNotFound = errors.New("not found")
+
+	// ErrAlreadyExists indicates a resource already exists.
+	ErrAlreadyExists = errors.New("already exists")
+
+	// ErrInvalidInput indicates invalid input was provided.
+	ErrInvalidInput = errors.New("invalid input")
+
+	// ErrPermission indicates a permission/authorization failure.
+	ErrPermission = errors.New("permission denied")
+
+	// ErrTimeout indicates an operation timed out.
+	ErrTimeout = errors.New("operation timeout")
+
+	// ErrNotInWorkspace indicates the command was run outside a bc workspace.
+	ErrNotInWorkspace = errors.New("not in a bc workspace")
+
+	// ErrInvalidState indicates an operation was attempted in an invalid state.
+	ErrInvalidState = errors.New("invalid state")
+
+	// ErrCanceled indicates an operation was canceled.
+	ErrCanceled = errors.New("operation canceled")
+)
+
+// AgentError represents an error related to an agent operation.
+type AgentError struct {
+	Err   error  // Underlying error
+	Agent string // Agent name or ID
+	Op    string // Operation that failed (e.g., "start", "stop", "attach")
+}
+
+// Error returns the error message.
+func (e *AgentError) Error() string {
+	if e.Agent == "" {
+		return fmt.Sprintf("agent: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("agent %q: %s: %v", e.Agent, e.Op, e.Err)
+}
+
+// Unwrap returns the underlying error for errors.Is/As support.
+func (e *AgentError) Unwrap() error { return e.Err }
+
+// NewAgentError creates a new AgentError.
+func NewAgentError(agent, op string, err error) *AgentError {
+	return &AgentError{Agent: agent, Op: op, Err: err}
+}
+
+// AgentNotFoundError creates an AgentError with ErrNotFound.
+func AgentNotFoundError(agent string) *AgentError {
+	return &AgentError{Agent: agent, Op: "lookup", Err: ErrNotFound}
+}
+
+// ChannelError represents an error related to a channel operation.
+type ChannelError struct {
+	Err     error  // Underlying error
+	Channel string // Channel name
+	Op      string // Operation that failed
+}
+
+// Error returns the error message.
+func (e *ChannelError) Error() string {
+	if e.Channel == "" {
+		return fmt.Sprintf("channel: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("channel %q: %s: %v", e.Channel, e.Op, e.Err)
+}
+
+// Unwrap returns the underlying error for errors.Is/As support.
+func (e *ChannelError) Unwrap() error { return e.Err }
+
+// NewChannelError creates a new ChannelError.
+func NewChannelError(channel, op string, err error) *ChannelError {
+	return &ChannelError{Channel: channel, Op: op, Err: err}
+}
+
+// WorkspaceError represents an error related to workspace operations.
+type WorkspaceError struct {
+	Err  error  // Underlying error
+	Path string // Workspace path
+	Op   string // Operation that failed
+}
+
+// Error returns the error message.
+func (e *WorkspaceError) Error() string {
+	if e.Path == "" {
+		return fmt.Sprintf("workspace: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("workspace %q: %s: %v", e.Path, e.Op, e.Err)
+}
+
+// Unwrap returns the underlying error for errors.Is/As support.
+func (e *WorkspaceError) Unwrap() error { return e.Err }
+
+// NewWorkspaceError creates a new WorkspaceError.
+func NewWorkspaceError(path, op string, err error) *WorkspaceError {
+	return &WorkspaceError{Path: path, Op: op, Err: err}
+}
+
+// ConfigError represents an error related to configuration.
+type ConfigError struct {
+	Err error  // Underlying error
+	Key string // Config key or section
+	Op  string // Operation that failed
+}
+
+// Error returns the error message.
+func (e *ConfigError) Error() string {
+	if e.Key == "" {
+		return fmt.Sprintf("config: %s: %v", e.Op, e.Err)
+	}
+	return fmt.Sprintf("config %q: %s: %v", e.Key, e.Op, e.Err)
+}
+
+// Unwrap returns the underlying error for errors.Is/As support.
+func (e *ConfigError) Unwrap() error { return e.Err }
+
+// NewConfigError creates a new ConfigError.
+func NewConfigError(key, op string, err error) *ConfigError {
+	return &ConfigError{Key: key, Op: op, Err: err}
+}
+
+// ValidationError represents a validation failure with details.
+type ValidationError struct {
+	Field   string // Field that failed validation
+	Value   any    // The invalid value
+	Message string // Human-readable validation message
+}
+
+// Error returns the error message.
+func (e *ValidationError) Error() string {
+	if e.Field == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("validation error on %q: %s", e.Field, e.Message)
+}
+
+// Unwrap returns ErrInvalidInput for errors.Is support.
+func (e *ValidationError) Unwrap() error { return ErrInvalidInput }
+
+// NewValidationError creates a new ValidationError.
+func NewValidationError(field string, value any, message string) *ValidationError {
+	return &ValidationError{Field: field, Value: value, Message: message}
+}
+
+// Is reports whether any error in err's chain matches target.
+// This is a convenience re-export of errors.Is.
+func Is(err, target error) bool {
+	return errors.Is(err, target)
+}
+
+// As finds the first error in err's chain that matches target.
+// This is a convenience re-export of errors.As.
+func As(err error, target any) bool {
+	return errors.As(err, target)
+}
+
+// Wrap wraps an error with additional context.
+// Returns nil if err is nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
+}
+
+// Wrapf wraps an error with formatted context.
+// Returns nil if err is nil.
+func Wrapf(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
+}

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -1,0 +1,290 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestSentinelErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"ErrNotFound", ErrNotFound, "not found"},
+		{"ErrAlreadyExists", ErrAlreadyExists, "already exists"},
+		{"ErrInvalidInput", ErrInvalidInput, "invalid input"},
+		{"ErrPermission", ErrPermission, "permission denied"},
+		{"ErrTimeout", ErrTimeout, "operation timeout"},
+		{"ErrNotInWorkspace", ErrNotInWorkspace, "not in a bc workspace"},
+		{"ErrInvalidState", ErrInvalidState, "invalid state"},
+		{"ErrCanceled", ErrCanceled, "operation canceled"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentError(t *testing.T) {
+	t.Run("with agent name", func(t *testing.T) {
+		err := &AgentError{Agent: "eng-01", Op: "start", Err: ErrTimeout}
+		want := `agent "eng-01": start: operation timeout`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without agent name", func(t *testing.T) {
+		err := &AgentError{Op: "list", Err: ErrPermission}
+		want := "agent: list: permission denied"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unwrap", func(t *testing.T) {
+		err := &AgentError{Agent: "eng-01", Op: "start", Err: ErrNotFound}
+		if !errors.Is(err, ErrNotFound) {
+			t.Error("errors.Is should match ErrNotFound")
+		}
+	})
+
+	t.Run("as", func(t *testing.T) {
+		err := fmt.Errorf("wrapped: %w", &AgentError{Agent: "eng-01", Op: "start", Err: ErrNotFound})
+		var agentErr *AgentError
+		if !errors.As(err, &agentErr) {
+			t.Error("errors.As should match AgentError")
+		}
+		if agentErr.Agent != "eng-01" {
+			t.Errorf("Agent = %q, want %q", agentErr.Agent, "eng-01")
+		}
+	})
+}
+
+func TestNewAgentError(t *testing.T) {
+	err := NewAgentError("test-agent", "attach", ErrTimeout)
+	if err.Agent != "test-agent" {
+		t.Errorf("Agent = %q, want %q", err.Agent, "test-agent")
+	}
+	if err.Op != "attach" {
+		t.Errorf("Op = %q, want %q", err.Op, "attach")
+	}
+	if !errors.Is(err, ErrTimeout) {
+		t.Error("should wrap ErrTimeout")
+	}
+}
+
+func TestAgentNotFoundError(t *testing.T) {
+	err := AgentNotFoundError("missing-agent")
+	if err.Agent != "missing-agent" {
+		t.Errorf("Agent = %q, want %q", err.Agent, "missing-agent")
+	}
+	if !errors.Is(err, ErrNotFound) {
+		t.Error("should wrap ErrNotFound")
+	}
+}
+
+func TestChannelError(t *testing.T) {
+	t.Run("with channel name", func(t *testing.T) {
+		err := &ChannelError{Channel: "broadcast", Op: "send", Err: ErrPermission}
+		want := `channel "broadcast": send: permission denied`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without channel name", func(t *testing.T) {
+		err := &ChannelError{Op: "create", Err: ErrAlreadyExists}
+		want := "channel: create: already exists"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unwrap", func(t *testing.T) {
+		err := NewChannelError("test", "read", ErrTimeout)
+		if !errors.Is(err, ErrTimeout) {
+			t.Error("errors.Is should match ErrTimeout")
+		}
+	})
+}
+
+func TestWorkspaceError(t *testing.T) {
+	t.Run("with path", func(t *testing.T) {
+		err := &WorkspaceError{Path: "/home/user/project", Op: "init", Err: ErrAlreadyExists}
+		want := `workspace "/home/user/project": init: already exists`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without path", func(t *testing.T) {
+		err := &WorkspaceError{Op: "load", Err: ErrNotInWorkspace}
+		want := "workspace: load: not in a bc workspace"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unwrap", func(t *testing.T) {
+		err := NewWorkspaceError("/path", "save", ErrPermission)
+		if !errors.Is(err, ErrPermission) {
+			t.Error("errors.Is should match ErrPermission")
+		}
+	})
+}
+
+func TestConfigError(t *testing.T) {
+	t.Run("with key", func(t *testing.T) {
+		err := &ConfigError{Key: "tui.theme", Op: "parse", Err: ErrInvalidInput}
+		want := `config "tui.theme": parse: invalid input`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without key", func(t *testing.T) {
+		err := &ConfigError{Op: "load", Err: ErrNotFound}
+		want := "config: load: not found"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unwrap", func(t *testing.T) {
+		err := NewConfigError("key", "set", ErrInvalidInput)
+		if !errors.Is(err, ErrInvalidInput) {
+			t.Error("errors.Is should match ErrInvalidInput")
+		}
+	})
+}
+
+func TestValidationError(t *testing.T) {
+	t.Run("with field", func(t *testing.T) {
+		err := &ValidationError{Field: "name", Value: "", Message: "cannot be empty"}
+		want := `validation error on "name": cannot be empty`
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("without field", func(t *testing.T) {
+		err := &ValidationError{Message: "invalid configuration"}
+		want := "invalid configuration"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unwrap to ErrInvalidInput", func(t *testing.T) {
+		err := NewValidationError("age", -1, "must be positive")
+		if !errors.Is(err, ErrInvalidInput) {
+			t.Error("errors.Is should match ErrInvalidInput")
+		}
+	})
+
+	t.Run("value preserved", func(t *testing.T) {
+		err := NewValidationError("count", 42, "too large")
+		if err.Value != 42 {
+			t.Errorf("Value = %v, want 42", err.Value)
+		}
+	})
+}
+
+func TestIs(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", ErrNotFound)
+	if !Is(err, ErrNotFound) {
+		t.Error("Is should return true for wrapped ErrNotFound")
+	}
+	if Is(err, ErrTimeout) {
+		t.Error("Is should return false for non-matching error")
+	}
+}
+
+func TestAs(t *testing.T) {
+	original := &AgentError{Agent: "test", Op: "run", Err: ErrTimeout}
+	err := fmt.Errorf("outer: %w", original)
+
+	var agentErr *AgentError
+	if !As(err, &agentErr) {
+		t.Error("As should match AgentError")
+	}
+	if agentErr.Agent != "test" {
+		t.Errorf("Agent = %q, want %q", agentErr.Agent, "test")
+	}
+}
+
+func TestWrap(t *testing.T) {
+	t.Run("wraps error", func(t *testing.T) {
+		err := Wrap(ErrNotFound, "loading agent")
+		want := "loading agent: not found"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+		if !errors.Is(err, ErrNotFound) {
+			t.Error("wrapped error should match ErrNotFound")
+		}
+	})
+
+	t.Run("nil error returns nil", func(t *testing.T) {
+		if err := Wrap(nil, "context"); err != nil {
+			t.Errorf("Wrap(nil) = %v, want nil", err)
+		}
+	})
+}
+
+func TestWrapf(t *testing.T) {
+	t.Run("wraps with format", func(t *testing.T) {
+		err := Wrapf(ErrTimeout, "agent %s after %d seconds", "eng-01", 30)
+		want := "agent eng-01 after 30 seconds: operation timeout"
+		if got := err.Error(); got != want {
+			t.Errorf("Error() = %q, want %q", got, want)
+		}
+		if !errors.Is(err, ErrTimeout) {
+			t.Error("wrapped error should match ErrTimeout")
+		}
+	})
+
+	t.Run("nil error returns nil", func(t *testing.T) {
+		if err := Wrapf(nil, "format %s", "arg"); err != nil {
+			t.Errorf("Wrapf(nil) = %v, want nil", err)
+		}
+	})
+}
+
+func TestErrorChaining(t *testing.T) {
+	// Test deep error chain: ValidationError -> AgentError -> ErrNotFound
+	validationErr := &ValidationError{
+		Field:   "agent",
+		Message: "agent not found",
+	}
+	agentErr := &AgentError{
+		Agent: "eng-01",
+		Op:    "validate",
+		Err:   validationErr,
+	}
+	wrapped := fmt.Errorf("command failed: %w", agentErr)
+
+	// Should be able to extract AgentError
+	var extractedAgent *AgentError
+	if !errors.As(wrapped, &extractedAgent) {
+		t.Error("should extract AgentError from chain")
+	}
+
+	// Should be able to extract ValidationError
+	var extractedValidation *ValidationError
+	if !errors.As(wrapped, &extractedValidation) {
+		t.Error("should extract ValidationError from chain")
+	}
+
+	// ValidationError wraps ErrInvalidInput
+	if !errors.Is(wrapped, ErrInvalidInput) {
+		t.Error("chain should match ErrInvalidInput via ValidationError")
+	}
+}


### PR DESCRIPTION
## Summary

Introduces a new `pkg/errors` package with structured error types for consistent error handling across the codebase.

**Sentinel errors:**
- `ErrNotFound`, `ErrAlreadyExists`, `ErrInvalidInput`
- `ErrPermission`, `ErrTimeout`, `ErrNotInWorkspace`
- `ErrInvalidState`, `ErrCanceled`

**Typed error structs** (all implement `Unwrap()` for `errors.Is/As`):
- `AgentError`: agent operation failures
- `ChannelError`: channel operation failures
- `WorkspaceError`: workspace operation failures
- `ConfigError`: configuration failures
- `ValidationError`: input validation failures (wraps `ErrInvalidInput`)

**Utility functions:**
- `Is/As`: convenience re-exports of `errors.Is/As`
- `Wrap/Wrapf`: wrap errors with context

**Benefits:**
- Consistent error handling across packages
- Better testability with `errors.Is()` and `errors.As()`
- Machine-readable error types for API consumers
- Clearer, structured error messages

## Test plan

- [x] 15 test cases covering all error types and utilities
- [x] Tests verify `errors.Is()` and `errors.As()` work correctly
- [x] Tests verify error chaining works through multiple layers
- [x] `go vet` passes
- [x] `golangci-lint` passes with 0 issues

Fixes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)