### PR TITLE
feat(telemetry): Add observability hooks package (#1661)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/names"
 	"github.com/rpuneet/bc/pkg/team"
+	"github.com/rpuneet/bc/pkg/telemetry"
 	"github.com/rpuneet/bc/pkg/ui"
 )
 
@@ -737,9 +738,17 @@ func runAgentStart(cmd *cobra.Command, args []string) error {
 	spawned, spawnErr := mgr.SpawnAgentWithOptions(agentName, a.Role, ws.RootDir, a.ParentID, a.Tool)
 	if spawnErr != nil {
 		fmt.Println("✗")
+		// #1661: Emit telemetry for agent error
+		telemetry.AgentError(cmd.Context(), agentName, spawnErr, "start")
 		return fmt.Errorf("failed to start %s: %w", agentName, spawnErr)
 	}
 	fmt.Printf("✓ (session: %s)\n", mgr.Tmux().SessionName(spawned.Session))
+
+	// #1661: Emit telemetry for agent spawn
+	telemetry.AgentSpawn(cmd.Context(), agentName, string(a.Role), map[string]any{
+		"session": spawned.Session,
+		"action":  "restart",
+	})
 
 	// Log event
 	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))
@@ -775,9 +784,14 @@ func runAgentStop(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Stopping %s... ", agentName)
 	if stopErr := mgr.StopAgent(agentName); stopErr != nil {
 		fmt.Println("✗")
+		// #1661: Emit telemetry for agent error
+		telemetry.AgentError(cmd.Context(), agentName, stopErr, "stop")
 		return fmt.Errorf("failed to stop %s: %w", agentName, stopErr)
 	}
 	fmt.Println("✓")
+
+	// #1661: Emit telemetry for agent stop
+	telemetry.AgentStop(cmd.Context(), agentName, "user_requested")
 
 	// Log event
 	eventLog := events.NewLog(filepath.Join(ws.StateDir(), "events.jsonl"))

--- a/pkg/telemetry/helpers.go
+++ b/pkg/telemetry/helpers.go
@@ -1,0 +1,223 @@
+package telemetry
+
+import (
+	"context"
+	"time"
+)
+
+// Helper functions for emitting common telemetry events.
+// These provide type-safe, convenient APIs for instrumentation.
+
+// AgentSpawn emits an agent spawn event.
+func AgentSpawn(ctx context.Context, agent, role string, data map[string]any) {
+	if data == nil {
+		data = make(map[string]any)
+	}
+	data["role"] = role
+	Emit(ctx, Event{
+		Type:    EventAgentSpawn,
+		Agent:   agent,
+		Message: "agent spawned",
+		Data:    data,
+	})
+}
+
+// AgentStop emits an agent stop event.
+func AgentStop(ctx context.Context, agent string, reason string) {
+	Emit(ctx, Event{
+		Type:    EventAgentStop,
+		Agent:   agent,
+		Message: "agent stopped",
+		Data:    map[string]any{"reason": reason},
+	})
+}
+
+// AgentStateChange emits an agent state change event.
+func AgentStateChange(ctx context.Context, agent, fromState, toState string) {
+	Emit(ctx, Event{
+		Type:    EventAgentStateChange,
+		Agent:   agent,
+		Message: "agent state changed",
+		Data: map[string]any{
+			"from_state": fromState,
+			"to_state":   toState,
+		},
+	})
+}
+
+// AgentError emits an agent error event.
+func AgentError(ctx context.Context, agent string, err error, operation string) {
+	Emit(ctx, Event{
+		Type:    EventAgentError,
+		Agent:   agent,
+		Message: "agent error",
+		Error:   err,
+		Data:    map[string]any{"operation": operation},
+	})
+}
+
+// ChannelSend emits a channel send event.
+func ChannelSend(ctx context.Context, channel, sender, message string) {
+	Emit(ctx, Event{
+		Type:    EventChannelSend,
+		Agent:   sender,
+		Message: "message sent",
+		Data: map[string]any{
+			"channel":        channel,
+			"message_length": len(message),
+		},
+	})
+}
+
+// ChannelReceive emits a channel receive event.
+func ChannelReceive(ctx context.Context, channel, receiver string, messageCount int) {
+	Emit(ctx, Event{
+		Type:    EventChannelReceive,
+		Agent:   receiver,
+		Message: "messages received",
+		Data: map[string]any{
+			"channel":       channel,
+			"message_count": messageCount,
+		},
+	})
+}
+
+// CostRecord emits a cost record event.
+func CostRecord(ctx context.Context, agent, model string, inputTokens, outputTokens int, costUSD float64) {
+	Emit(ctx, Event{
+		Type:    EventCostRecord,
+		Agent:   agent,
+		Message: "cost recorded",
+		Data: map[string]any{
+			"model":         model,
+			"input_tokens":  inputTokens,
+			"output_tokens": outputTokens,
+			"cost_usd":      costUSD,
+		},
+	})
+}
+
+// CostAlert emits a cost budget alert event.
+func CostAlert(ctx context.Context, scope string, currentSpend, budgetLimit float64, percentUsed float64) {
+	Emit(ctx, Event{
+		Type:    EventCostAlert,
+		Message: "budget alert",
+		Data: map[string]any{
+			"scope":         scope,
+			"current_spend": currentSpend,
+			"budget_limit":  budgetLimit,
+			"percent_used":  percentUsed,
+		},
+	})
+}
+
+// CostExceeded emits a cost budget exceeded event.
+func CostExceeded(ctx context.Context, scope string, currentSpend, budgetLimit float64) {
+	Emit(ctx, Event{
+		Type:    EventCostExceeded,
+		Message: "budget exceeded",
+		Data: map[string]any{
+			"scope":         scope,
+			"current_spend": currentSpend,
+			"budget_limit":  budgetLimit,
+		},
+	})
+}
+
+// HealthCheck emits a health check event.
+func HealthCheck(ctx context.Context, agent, status string, details map[string]any) {
+	if details == nil {
+		details = make(map[string]any)
+	}
+	details["status"] = status
+	Emit(ctx, Event{
+		Type:    EventHealthCheck,
+		Agent:   agent,
+		Message: "health check",
+		Data:    details,
+	})
+}
+
+// HealthUnhealthy emits an unhealthy status event.
+func HealthUnhealthy(ctx context.Context, agent, reason string) {
+	Emit(ctx, Event{
+		Type:    EventHealthUnhealthy,
+		Agent:   agent,
+		Message: "agent unhealthy",
+		Data:    map[string]any{"reason": reason},
+	})
+}
+
+// HealthRecovered emits a health recovered event.
+func HealthRecovered(ctx context.Context, agent string, downtime time.Duration) {
+	Emit(ctx, Event{
+		Type:    EventHealthRecovered,
+		Agent:   agent,
+		Message: "agent recovered",
+		Data:    map[string]any{"downtime_seconds": downtime.Seconds()},
+	})
+}
+
+// WorkAssigned emits a work assigned event.
+func WorkAssigned(ctx context.Context, agent, task string, data map[string]any) {
+	if data == nil {
+		data = make(map[string]any)
+	}
+	data["task"] = task
+	Emit(ctx, Event{
+		Type:    EventWorkAssigned,
+		Agent:   agent,
+		Message: "work assigned",
+		Data:    data,
+	})
+}
+
+// WorkStarted emits a work started event.
+func WorkStarted(ctx context.Context, agent, task string) {
+	Emit(ctx, Event{
+		Type:    EventWorkStarted,
+		Agent:   agent,
+		Message: "work started",
+		Data:    map[string]any{"task": task},
+	})
+}
+
+// WorkCompleted emits a work completed event.
+func WorkCompleted(ctx context.Context, agent, task string, duration time.Duration) {
+	Emit(ctx, Event{
+		Type:     EventWorkCompleted,
+		Agent:    agent,
+		Message:  "work completed",
+		Duration: duration,
+		Data:     map[string]any{"task": task},
+	})
+}
+
+// WorkFailed emits a work failed event.
+func WorkFailed(ctx context.Context, agent, task string, err error) {
+	Emit(ctx, Event{
+		Type:    EventWorkFailed,
+		Agent:   agent,
+		Message: "work failed",
+		Error:   err,
+		Data:    map[string]any{"task": task},
+	})
+}
+
+// Span creates a simple timing span for operations.
+// Usage:
+//
+//	done := telemetry.Span(ctx, "operation_name", agent)
+//	defer done()
+func Span(ctx context.Context, operation, agent string) func() {
+	start := time.Now()
+	return func() {
+		duration := time.Since(start)
+		Emit(ctx, Event{
+			Type:     EventType("span." + operation),
+			Agent:    agent,
+			Message:  operation + " completed",
+			Duration: duration,
+		})
+	}
+}

--- a/pkg/telemetry/observers.go
+++ b/pkg/telemetry/observers.go
@@ -1,0 +1,177 @@
+package telemetry
+
+import (
+	"context"
+
+	"github.com/rpuneet/bc/pkg/log"
+)
+
+// LogObserver logs telemetry events using the log package.
+type LogObserver struct {
+	// Verbose enables debug-level logging
+	Verbose bool
+}
+
+// NewLogObserver creates a new logging observer.
+func NewLogObserver(verbose bool) *LogObserver {
+	return &LogObserver{Verbose: verbose}
+}
+
+// OnEvent logs the telemetry event.
+func (o *LogObserver) OnEvent(_ context.Context, event Event) {
+	// Build attributes from event data
+	attrs := []any{
+		"type", string(event.Type),
+	}
+
+	if event.Agent != "" {
+		attrs = append(attrs, "agent", event.Agent)
+	}
+
+	if event.Duration > 0 {
+		attrs = append(attrs, "duration_ms", event.Duration.Milliseconds())
+	}
+
+	if event.Error != nil {
+		attrs = append(attrs, "error", event.Error.Error())
+	}
+
+	// Add data fields
+	for k, v := range event.Data {
+		attrs = append(attrs, k, v)
+	}
+
+	// Log based on event type
+	switch {
+	case event.Error != nil:
+		log.Error(event.Message, attrs...)
+	case isErrorEvent(event.Type):
+		log.Warn(event.Message, attrs...)
+	case o.Verbose:
+		log.Debug(event.Message, attrs...)
+	default:
+		log.Info(event.Message, attrs...)
+	}
+}
+
+// isErrorEvent returns true if the event type indicates an error condition.
+func isErrorEvent(t EventType) bool {
+	switch t {
+	case EventAgentError, EventWorkFailed, EventHealthUnhealthy, EventHealthDegraded, EventCostExceeded:
+		return true
+	default:
+		return false
+	}
+}
+
+// FilterObserver wraps an observer and only passes events matching the filter.
+type FilterObserver struct {
+	inner  Observer
+	filter func(Event) bool
+}
+
+// NewFilterObserver creates a filtered observer.
+func NewFilterObserver(inner Observer, filter func(Event) bool) *FilterObserver {
+	return &FilterObserver{inner: inner, filter: filter}
+}
+
+// OnEvent passes the event to the inner observer if it matches the filter.
+func (o *FilterObserver) OnEvent(ctx context.Context, event Event) {
+	if o.filter(event) {
+		o.inner.OnEvent(ctx, event)
+	}
+}
+
+// TypeFilter returns a filter function that matches specific event types.
+func TypeFilter(types ...EventType) func(Event) bool {
+	typeSet := make(map[EventType]struct{}, len(types))
+	for _, t := range types {
+		typeSet[t] = struct{}{}
+	}
+	return func(e Event) bool {
+		_, ok := typeSet[e.Type]
+		return ok
+	}
+}
+
+// AgentFilter returns a filter function that matches events for specific agents.
+func AgentFilter(agents ...string) func(Event) bool {
+	agentSet := make(map[string]struct{}, len(agents))
+	for _, a := range agents {
+		agentSet[a] = struct{}{}
+	}
+	return func(e Event) bool {
+		_, ok := agentSet[e.Agent]
+		return ok
+	}
+}
+
+// ErrorFilter returns a filter function that matches error events.
+func ErrorFilter() func(Event) bool {
+	return func(e Event) bool {
+		return e.Error != nil || isErrorEvent(e.Type)
+	}
+}
+
+// BufferedObserver collects events in a buffer for batch processing.
+//
+//nolint:govet // fieldalignment: logical field grouping preferred
+type BufferedObserver struct {
+	mu     chan struct{} // mutex channel
+	events []Event
+	maxLen int
+	onFull func([]Event)
+}
+
+// NewBufferedObserver creates a buffered observer.
+// When the buffer reaches maxLen, onFull is called with the events and the buffer is cleared.
+func NewBufferedObserver(maxLen int, onFull func([]Event)) *BufferedObserver {
+	return &BufferedObserver{
+		mu:     make(chan struct{}, 1),
+		events: make([]Event, 0, maxLen),
+		maxLen: maxLen,
+		onFull: onFull,
+	}
+}
+
+// OnEvent adds the event to the buffer.
+func (o *BufferedObserver) OnEvent(_ context.Context, event Event) {
+	o.mu <- struct{}{}
+	defer func() { <-o.mu }()
+
+	o.events = append(o.events, event)
+	if len(o.events) >= o.maxLen {
+		events := o.events
+		o.events = make([]Event, 0, o.maxLen)
+		if o.onFull != nil {
+			go o.onFull(events)
+		}
+	}
+}
+
+// Flush processes any remaining buffered events.
+func (o *BufferedObserver) Flush() []Event {
+	o.mu <- struct{}{}
+	defer func() { <-o.mu }()
+
+	events := o.events
+	o.events = make([]Event, 0, o.maxLen)
+	return events
+}
+
+// MultiObserver dispatches events to multiple observers.
+type MultiObserver struct {
+	observers []Observer
+}
+
+// NewMultiObserver creates an observer that dispatches to multiple observers.
+func NewMultiObserver(observers ...Observer) *MultiObserver {
+	return &MultiObserver{observers: observers}
+}
+
+// OnEvent dispatches to all inner observers.
+func (o *MultiObserver) OnEvent(ctx context.Context, event Event) {
+	for _, obs := range o.observers {
+		obs.OnEvent(ctx, event)
+	}
+}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,202 @@
+// Package telemetry provides observability hooks for bc operations.
+//
+// The telemetry package implements an observer pattern that allows
+// multiple observers to receive notifications about key operations:
+//   - Agent lifecycle (spawn, stop, state changes)
+//   - Channel operations (send, receive)
+//   - Cost events (API calls, budget alerts)
+//   - Health events (checks, failures, recoveries)
+//
+// Observers can be used for:
+//   - Structured logging
+//   - Metrics collection
+//   - Plugin hooks
+//   - Future OpenTelemetry integration
+//
+// Issue #1661: Add telemetry/observability hooks
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// EventType identifies the category of telemetry event.
+type EventType string
+
+// Agent lifecycle events
+const (
+	EventAgentSpawn       EventType = "agent.spawn"
+	EventAgentStop        EventType = "agent.stop"
+	EventAgentStateChange EventType = "agent.state_change"
+	EventAgentError       EventType = "agent.error"
+)
+
+// Channel events
+const (
+	EventChannelSend    EventType = "channel.send"
+	EventChannelReceive EventType = "channel.receive"
+	EventChannelCreate  EventType = "channel.create"
+	EventChannelDelete  EventType = "channel.delete"
+)
+
+// Cost events
+const (
+	EventCostRecord   EventType = "cost.record"
+	EventCostBudget   EventType = "cost.budget"
+	EventCostAlert    EventType = "cost.alert"
+	EventCostExceeded EventType = "cost.exceeded"
+)
+
+// Health events
+const (
+	EventHealthCheck     EventType = "health.check"
+	EventHealthDegraded  EventType = "health.degraded"
+	EventHealthUnhealthy EventType = "health.unhealthy"
+	EventHealthRecovered EventType = "health.recovered"
+)
+
+// Work events
+const (
+	EventWorkAssigned  EventType = "work.assigned"
+	EventWorkStarted   EventType = "work.started"
+	EventWorkCompleted EventType = "work.completed"
+	EventWorkFailed    EventType = "work.failed"
+)
+
+// Event represents a telemetry event with metadata.
+//
+//nolint:govet // fieldalignment: logical field grouping preferred over memory optimization
+type Event struct {
+	// Type identifies the event category
+	Type EventType
+	// Timestamp when the event occurred
+	Timestamp time.Time
+	// Agent name if applicable
+	Agent string
+	// Message is a human-readable description
+	Message string
+	// Data contains event-specific structured data
+	Data map[string]any
+	// Duration for timed operations (optional)
+	Duration time.Duration
+	// Error if the event represents a failure
+	Error error
+	// TraceID for distributed tracing (optional)
+	TraceID string
+	// SpanID for distributed tracing (optional)
+	SpanID string
+}
+
+// Observer receives telemetry events.
+type Observer interface {
+	// OnEvent is called when a telemetry event occurs.
+	// Implementations should be non-blocking.
+	OnEvent(ctx context.Context, event Event)
+}
+
+// ObserverFunc is a function adapter for Observer.
+type ObserverFunc func(ctx context.Context, event Event)
+
+// OnEvent implements Observer.
+func (f ObserverFunc) OnEvent(ctx context.Context, event Event) {
+	f(ctx, event)
+}
+
+// Registry manages telemetry observers.
+//
+//nolint:govet // fieldalignment: struct is small, readability preferred
+type Registry struct {
+	mu        sync.RWMutex
+	observers []Observer
+	enabled   bool
+}
+
+// global is the default global registry.
+var global = &Registry{enabled: true}
+
+// Register adds an observer to the global registry.
+func Register(observer Observer) {
+	global.Register(observer)
+}
+
+// Emit sends an event to all registered observers.
+func Emit(ctx context.Context, event Event) {
+	global.Emit(ctx, event)
+}
+
+// EmitAsync sends an event to all registered observers asynchronously.
+func EmitAsync(ctx context.Context, event Event) {
+	global.EmitAsync(ctx, event)
+}
+
+// SetEnabled enables or disables telemetry globally.
+func SetEnabled(enabled bool) {
+	global.SetEnabled(enabled)
+}
+
+// Register adds an observer to this registry.
+func (r *Registry) Register(observer Observer) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.observers = append(r.observers, observer)
+}
+
+// Emit sends an event to all registered observers synchronously.
+func (r *Registry) Emit(ctx context.Context, event Event) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if !r.enabled {
+		return
+	}
+
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+
+	for _, obs := range r.observers {
+		obs.OnEvent(ctx, event)
+	}
+}
+
+// EmitAsync sends an event to all registered observers asynchronously.
+// Each observer is called in its own goroutine.
+func (r *Registry) EmitAsync(ctx context.Context, event Event) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if !r.enabled {
+		return
+	}
+
+	if event.Timestamp.IsZero() {
+		event.Timestamp = time.Now()
+	}
+
+	for _, obs := range r.observers {
+		go obs.OnEvent(ctx, event)
+	}
+}
+
+// SetEnabled enables or disables this registry.
+func (r *Registry) SetEnabled(enabled bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.enabled = enabled
+}
+
+// Clear removes all observers from this registry.
+func (r *Registry) Clear() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.observers = nil
+}
+
+// ObserverCount returns the number of registered observers.
+func (r *Registry) ObserverCount() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.observers)
+}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -1,0 +1,208 @@
+package telemetry
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRegistry(t *testing.T) {
+	r := &Registry{enabled: true}
+
+	var received []Event
+	var mu sync.Mutex
+
+	r.Register(ObserverFunc(func(_ context.Context, e Event) {
+		mu.Lock()
+		received = append(received, e)
+		mu.Unlock()
+	}))
+
+	ctx := context.Background()
+	r.Emit(ctx, Event{Type: EventAgentSpawn, Agent: "test-agent"})
+	r.Emit(ctx, Event{Type: EventAgentStop, Agent: "test-agent"})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 2 {
+		t.Errorf("expected 2 events, got %d", len(received))
+	}
+	if received[0].Type != EventAgentSpawn {
+		t.Errorf("expected EventAgentSpawn, got %s", received[0].Type)
+	}
+}
+
+func TestRegistry_Disabled(t *testing.T) {
+	r := &Registry{enabled: false}
+
+	var count int
+	r.Register(ObserverFunc(func(_ context.Context, _ Event) {
+		count++
+	}))
+
+	r.Emit(context.Background(), Event{Type: EventAgentSpawn})
+
+	if count != 0 {
+		t.Errorf("expected 0 events when disabled, got %d", count)
+	}
+}
+
+func TestRegistry_EmitAsync(t *testing.T) {
+	r := &Registry{enabled: true}
+
+	var count atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	r.Register(ObserverFunc(func(_ context.Context, _ Event) {
+		count.Add(1)
+		wg.Done()
+	}))
+
+	ctx := context.Background()
+	r.EmitAsync(ctx, Event{Type: EventAgentSpawn})
+	r.EmitAsync(ctx, Event{Type: EventAgentStop})
+
+	wg.Wait()
+
+	if count.Load() != 2 {
+		t.Errorf("expected 2 async events, got %d", count.Load())
+	}
+}
+
+func TestRegistry_Clear(t *testing.T) {
+	r := &Registry{enabled: true}
+	r.Register(ObserverFunc(func(_ context.Context, _ Event) {}))
+	r.Register(ObserverFunc(func(_ context.Context, _ Event) {}))
+
+	if r.ObserverCount() != 2 {
+		t.Errorf("expected 2 observers, got %d", r.ObserverCount())
+	}
+
+	r.Clear()
+
+	if r.ObserverCount() != 0 {
+		t.Errorf("expected 0 observers after clear, got %d", r.ObserverCount())
+	}
+}
+
+func TestEvent_TimestampAutoSet(t *testing.T) {
+	r := &Registry{enabled: true}
+
+	var received Event
+	r.Register(ObserverFunc(func(_ context.Context, e Event) {
+		received = e
+	}))
+
+	before := time.Now()
+	r.Emit(context.Background(), Event{Type: EventAgentSpawn})
+	after := time.Now()
+
+	if received.Timestamp.Before(before) || received.Timestamp.After(after) {
+		t.Errorf("timestamp not auto-set correctly")
+	}
+}
+
+func TestFilterObserver(t *testing.T) {
+	var received []Event
+	inner := ObserverFunc(func(_ context.Context, e Event) {
+		received = append(received, e)
+	})
+
+	filtered := NewFilterObserver(inner, TypeFilter(EventAgentSpawn, EventAgentStop))
+
+	ctx := context.Background()
+	filtered.OnEvent(ctx, Event{Type: EventAgentSpawn})
+	filtered.OnEvent(ctx, Event{Type: EventChannelSend})
+	filtered.OnEvent(ctx, Event{Type: EventAgentStop})
+
+	if len(received) != 2 {
+		t.Errorf("expected 2 filtered events, got %d", len(received))
+	}
+}
+
+func TestAgentFilter(t *testing.T) {
+	var received []Event
+	inner := ObserverFunc(func(_ context.Context, e Event) {
+		received = append(received, e)
+	})
+
+	filtered := NewFilterObserver(inner, AgentFilter("agent-1", "agent-2"))
+
+	ctx := context.Background()
+	filtered.OnEvent(ctx, Event{Agent: "agent-1"})
+	filtered.OnEvent(ctx, Event{Agent: "agent-3"})
+	filtered.OnEvent(ctx, Event{Agent: "agent-2"})
+
+	if len(received) != 2 {
+		t.Errorf("expected 2 filtered events, got %d", len(received))
+	}
+}
+
+func TestBufferedObserver(t *testing.T) {
+	var flushed []Event
+	var mu sync.Mutex
+
+	bo := NewBufferedObserver(3, func(events []Event) {
+		mu.Lock()
+		flushed = append(flushed, events...)
+		mu.Unlock()
+	})
+
+	ctx := context.Background()
+	bo.OnEvent(ctx, Event{Type: "1"})
+	bo.OnEvent(ctx, Event{Type: "2"})
+
+	// Not full yet
+	mu.Lock()
+	if len(flushed) != 0 {
+		t.Errorf("expected 0 flushed events, got %d", len(flushed))
+	}
+	mu.Unlock()
+
+	bo.OnEvent(ctx, Event{Type: "3"})
+
+	// Give async callback time to run
+	time.Sleep(10 * time.Millisecond)
+
+	mu.Lock()
+	if len(flushed) != 3 {
+		t.Errorf("expected 3 flushed events, got %d", len(flushed))
+	}
+	mu.Unlock()
+}
+
+func TestBufferedObserver_Flush(t *testing.T) {
+	bo := NewBufferedObserver(10, nil)
+
+	ctx := context.Background()
+	bo.OnEvent(ctx, Event{Type: "1"})
+	bo.OnEvent(ctx, Event{Type: "2"})
+
+	events := bo.Flush()
+	if len(events) != 2 {
+		t.Errorf("expected 2 flushed events, got %d", len(events))
+	}
+
+	// Buffer should be empty now
+	events = bo.Flush()
+	if len(events) != 0 {
+		t.Errorf("expected 0 events after second flush, got %d", len(events))
+	}
+}
+
+func TestMultiObserver(t *testing.T) {
+	var count1, count2 int
+
+	obs1 := ObserverFunc(func(_ context.Context, _ Event) { count1++ })
+	obs2 := ObserverFunc(func(_ context.Context, _ Event) { count2++ })
+
+	multi := NewMultiObserver(obs1, obs2)
+	multi.OnEvent(context.Background(), Event{Type: EventAgentSpawn})
+
+	if count1 != 1 || count2 != 1 {
+		t.Errorf("expected both observers called once, got %d and %d", count1, count2)
+	}
+}


### PR DESCRIPTION
## Summary
Introduces a new `pkg/telemetry` package with an observer pattern for instrumenting bc operations.

## Changes

### Core Components
- **telemetry.go**: Registry with `Register`/`Emit`/`EmitAsync` for observers
- **helpers.go**: Type-safe event emitters (`AgentSpawn`, `AgentStop`, `ChannelSend`, etc.)
- **observers.go**: Built-in observers (`LogObserver`, `FilterObserver`, `BufferedObserver`, `MultiObserver`)
- **telemetry_test.go**: Comprehensive test coverage (10 tests)

### Event Categories
| Category | Events |
|----------|--------|
| Agent | spawn, stop, state_change, error |
| Channel | send, receive, create, delete |
| Cost | record, budget, alert, exceeded |
| Health | check, degraded, unhealthy, recovered |
| Work | assigned, started, completed, failed |

### Initial Integration
- Agent `start` and `stop` commands now emit telemetry events
- `Span` helper for timing operations

### Benefits
- Extensible observer pattern for metrics, tracing, logging
- Async emit option for non-blocking instrumentation
- Filter and buffer observers for selective processing
- Foundation for future OpenTelemetry integration

## Test plan
- [x] `make lint` passes (0 issues)
- [x] `go test ./pkg/telemetry/...` passes (10 tests)
- [x] Pre-commit hooks pass
- [ ] Manual testing: Run `bc agent start/stop` and verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)