### PR TITLE
feat(db): Add unified SQLite database management package (#1662)

### DIFF
--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -1,0 +1,235 @@
+// Package db provides unified SQLite database management for bc CLI.
+//
+// This package consolidates SQLite connection management, ensuring consistent
+// configuration across all database operations. It provides:
+//
+//   - Connection pooling optimized for SQLite's single-writer model
+//   - Consistent pragma settings for WAL mode and performance
+//   - Automatic directory creation for database files
+//   - Graceful shutdown handling
+//
+// # Usage
+//
+//	db, err := db.Open("/path/to/database.db")
+//	if err != nil {
+//	    return err
+//	}
+//	defer db.Close()
+//
+// # Configuration
+//
+// All connections use these settings:
+//   - WAL journal mode for better concurrency
+//   - Foreign keys enabled
+//   - 5 second busy timeout
+//   - Single connection pool (SQLite limitation)
+//   - Optimized cache and synchronous settings
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3" // SQLite driver
+)
+
+// DefaultBusyTimeout is the default timeout for SQLite busy handling.
+const DefaultBusyTimeout = 5000 // milliseconds
+
+// DefaultCacheSize is the default SQLite page cache size in KB.
+const DefaultCacheSize = 2000
+
+// Config holds database configuration options.
+type Config struct {
+	// BusyTimeout is the SQLite busy timeout in milliseconds.
+	// Default: 5000 (5 seconds)
+	BusyTimeout int
+
+	// CacheSize is the SQLite page cache size in KB.
+	// Default: 2000 (2MB)
+	CacheSize int
+
+	// ReadOnly opens the database in read-only mode.
+	ReadOnly bool
+}
+
+// DefaultConfig returns the default database configuration.
+func DefaultConfig() Config {
+	return Config{
+		BusyTimeout: DefaultBusyTimeout,
+		CacheSize:   DefaultCacheSize,
+		ReadOnly:    false,
+	}
+}
+
+// DB wraps a sql.DB with bc-specific functionality.
+type DB struct {
+	*sql.DB
+	path   string
+	config Config
+}
+
+// Open opens a SQLite database at the given path with default configuration.
+// The directory containing the database file is created if it doesn't exist.
+func Open(path string) (*DB, error) {
+	return OpenWithConfig(path, DefaultConfig())
+}
+
+// OpenWithConfig opens a SQLite database with custom configuration.
+func OpenWithConfig(path string, cfg Config) (*DB, error) {
+	// Create directory if needed
+	if !cfg.ReadOnly {
+		if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+			return nil, fmt.Errorf("create database directory: %w", err)
+		}
+	}
+
+	// Build connection string with pragmas
+	connStr := buildConnectionString(path, cfg)
+
+	db, err := sql.Open("sqlite3", connStr)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+
+	// Configure connection pool for SQLite's single-writer model
+	// SQLite only allows one writer at a time, so limit connections
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(time.Hour)
+	db.SetConnMaxIdleTime(10 * time.Minute)
+
+	// Apply performance pragmas
+	if err := applyPragmas(db, cfg); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("apply pragmas: %w", err)
+	}
+
+	return &DB{
+		DB:     db,
+		path:   path,
+		config: cfg,
+	}, nil
+}
+
+// Path returns the database file path.
+func (d *DB) Path() string {
+	return d.path
+}
+
+// buildConnectionString constructs the SQLite connection string with pragmas.
+func buildConnectionString(path string, cfg Config) string {
+	params := fmt.Sprintf("?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=%d",
+		cfg.BusyTimeout)
+
+	if cfg.ReadOnly {
+		params += "&mode=ro"
+	}
+
+	return path + params
+}
+
+// applyPragmas applies performance pragmas to the database.
+func applyPragmas(db *sql.DB, cfg Config) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pragmas := fmt.Sprintf(`
+		PRAGMA synchronous = NORMAL;
+		PRAGMA cache_size = -%d;
+		PRAGMA temp_store = MEMORY;
+		PRAGMA mmap_size = 268435456;
+	`, cfg.CacheSize)
+
+	_, err := db.ExecContext(ctx, pragmas)
+	return err
+}
+
+// Registry manages multiple named database connections.
+// Use this when you need to share connections across packages.
+type Registry struct {
+	dbs   map[string]*DB
+	paths map[string]string // Maps name to path
+	mu    sync.RWMutex
+}
+
+// NewRegistry creates a new database registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		dbs:   make(map[string]*DB),
+		paths: make(map[string]string),
+	}
+}
+
+// Register registers a database path with a name.
+// The database is not opened until Get is called.
+func (r *Registry) Register(name, path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.paths[name] = path
+}
+
+// Get returns a database connection by name, opening it if needed.
+func (r *Registry) Get(name string) (*DB, error) {
+	r.mu.RLock()
+	if db, ok := r.dbs[name]; ok {
+		r.mu.RUnlock()
+		return db, nil
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if db, ok := r.dbs[name]; ok {
+		return db, nil
+	}
+
+	path, ok := r.paths[name]
+	if !ok {
+		return nil, fmt.Errorf("database %q not registered", name)
+	}
+
+	db, err := Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open database %q: %w", name, err)
+	}
+
+	r.dbs[name] = db
+	return db, nil
+}
+
+// Close closes all open database connections.
+func (r *Registry) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var firstErr error
+	for name, db := range r.dbs {
+		if err := db.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close database %q: %w", name, err)
+		}
+	}
+	r.dbs = make(map[string]*DB)
+	return firstErr
+}
+
+// CloseOne closes a specific database connection by name.
+func (r *Registry) CloseOne(name string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	db, ok := r.dbs[name]
+	if !ok {
+		return nil // Not open
+	}
+
+	delete(r.dbs, name)
+	return db.Close()
+}

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -1,0 +1,215 @@
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOpen(t *testing.T) {
+	t.Run("creates directory and opens database", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "subdir", "test.db")
+
+		db, err := Open(dbPath)
+		if err != nil {
+			t.Fatalf("Open() error = %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+
+		// Verify directory was created
+		if _, err := os.Stat(filepath.Dir(dbPath)); os.IsNotExist(err) {
+			t.Error("expected directory to be created")
+		}
+
+		// Verify database is accessible
+		ctx := context.Background()
+		if err := db.PingContext(ctx); err != nil {
+			t.Errorf("PingContext() error = %v", err)
+		}
+	})
+
+	t.Run("returns path", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "test.db")
+
+		db, err := Open(dbPath)
+		if err != nil {
+			t.Fatalf("Open() error = %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+
+		if got := db.Path(); got != dbPath {
+			t.Errorf("Path() = %q, want %q", got, dbPath)
+		}
+	})
+}
+
+func TestOpenWithConfig(t *testing.T) {
+	t.Run("applies custom config", func(t *testing.T) {
+		dir := t.TempDir()
+		dbPath := filepath.Join(dir, "test.db")
+
+		cfg := Config{
+			BusyTimeout: 10000,
+			CacheSize:   4000,
+			ReadOnly:    false,
+		}
+
+		db, err := OpenWithConfig(dbPath, cfg)
+		if err != nil {
+			t.Fatalf("OpenWithConfig() error = %v", err)
+		}
+		t.Cleanup(func() { _ = db.Close() })
+
+		// Verify database works
+		ctx := context.Background()
+		_, err = db.ExecContext(ctx, "CREATE TABLE test (id INTEGER PRIMARY KEY)")
+		if err != nil {
+			t.Errorf("ExecContext() error = %v", err)
+		}
+	})
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.BusyTimeout != DefaultBusyTimeout {
+		t.Errorf("BusyTimeout = %d, want %d", cfg.BusyTimeout, DefaultBusyTimeout)
+	}
+	if cfg.CacheSize != DefaultCacheSize {
+		t.Errorf("CacheSize = %d, want %d", cfg.CacheSize, DefaultCacheSize)
+	}
+	if cfg.ReadOnly {
+		t.Error("ReadOnly should be false by default")
+	}
+}
+
+func TestRegistry(t *testing.T) {
+	t.Run("register and get", func(t *testing.T) {
+		dir := t.TempDir()
+		registry := NewRegistry()
+		t.Cleanup(func() { _ = registry.Close() })
+
+		dbPath := filepath.Join(dir, "test.db")
+		registry.Register("test", dbPath)
+
+		db, err := registry.Get("test")
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+
+		// Verify same instance is returned
+		db2, err := registry.Get("test")
+		if err != nil {
+			t.Fatalf("Get() second call error = %v", err)
+		}
+
+		if db != db2 {
+			t.Error("expected same database instance")
+		}
+	})
+
+	t.Run("get unregistered returns error", func(t *testing.T) {
+		registry := NewRegistry()
+		t.Cleanup(func() { _ = registry.Close() })
+
+		_, err := registry.Get("nonexistent")
+		if err == nil {
+			t.Error("expected error for unregistered database")
+		}
+	})
+
+	t.Run("close all", func(t *testing.T) {
+		dir := t.TempDir()
+		registry := NewRegistry()
+
+		registry.Register("db1", filepath.Join(dir, "db1.db"))
+		registry.Register("db2", filepath.Join(dir, "db2.db"))
+
+		// Open both
+		_, err := registry.Get("db1")
+		if err != nil {
+			t.Fatalf("Get(db1) error = %v", err)
+		}
+		_, err = registry.Get("db2")
+		if err != nil {
+			t.Fatalf("Get(db2) error = %v", err)
+		}
+
+		// Close all
+		if err := registry.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	t.Run("close one", func(t *testing.T) {
+		dir := t.TempDir()
+		registry := NewRegistry()
+		t.Cleanup(func() { _ = registry.Close() })
+
+		registry.Register("test", filepath.Join(dir, "test.db"))
+
+		_, err := registry.Get("test")
+		if err != nil {
+			t.Fatalf("Get() error = %v", err)
+		}
+
+		closeErr := registry.CloseOne("test")
+		if closeErr != nil {
+			t.Errorf("CloseOne() error = %v", closeErr)
+		}
+
+		// Getting again should reopen
+		_, err = registry.Get("test")
+		if err != nil {
+			t.Errorf("Get() after CloseOne error = %v", err)
+		}
+	})
+
+	t.Run("close one not open is no-op", func(t *testing.T) {
+		registry := NewRegistry()
+		t.Cleanup(func() { _ = registry.Close() })
+
+		registry.Register("test", "/tmp/test.db")
+
+		// Close without opening - should not error
+		if err := registry.CloseOne("test"); err != nil {
+			t.Errorf("CloseOne() error = %v", err)
+		}
+	})
+}
+
+func TestPragmasApplied(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "test.db")
+
+	db, err := Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+
+	// Check WAL mode
+	var journalMode string
+	err = db.QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&journalMode)
+	if err != nil {
+		t.Fatalf("PRAGMA journal_mode error = %v", err)
+	}
+	if journalMode != "wal" {
+		t.Errorf("journal_mode = %q, want %q", journalMode, "wal")
+	}
+
+	// Check foreign keys
+	var foreignKeys int
+	err = db.QueryRowContext(ctx, "PRAGMA foreign_keys").Scan(&foreignKeys)
+	if err != nil {
+		t.Fatalf("PRAGMA foreign_keys error = %v", err)
+	}
+	if foreignKeys != 1 {
+		t.Errorf("foreign_keys = %d, want 1", foreignKeys)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `pkg/db` package for consolidated SQLite connection management
- Connection pooling optimized for SQLite's single-writer model (1 connection max)
- WAL journal mode with foreign keys enabled by default
- Configurable busy timeout (5s default) and cache size (2MB default)
- Registry for managing multiple named database connections with lazy opening
- Automatic directory creation for database files
- Comprehensive test coverage

## API

```go
// Simple open with defaults
db, err := db.Open("/path/to/database.db")

// Custom configuration
cfg := db.Config{
    BusyTimeout: 10000,
    CacheSize:   4000,
    ReadOnly:    false,
}
db, err := db.OpenWithConfig("/path/to/database.db", cfg)

// Registry for shared connections
registry := db.NewRegistry()
registry.Register("main", "/path/to/main.db")
registry.Register("cache", "/path/to/cache.db")
mainDB, err := registry.Get("main")
```

Closes #1662

## Test plan

- [x] Run db package tests: `go test ./pkg/db/... -v`
- [x] Run with race detector: `go test ./pkg/db/... -race`
- [x] Verify lint passes: `golangci-lint run ./pkg/db/...`
- [ ] Verify full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)