### PR TITLE
refactor(cmd): Add workspace loading helpers (#1651)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -515,87 +515,79 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 func runAgentList(cmd *cobra.Command, args []string) error {
 	log.Debug("agent list command started", "role", agentListRole, "json", agentListJSON)
 
-	ws, err := getWorkspace()
-	if err != nil {
-		return errNotInWorkspace(err)
-	}
-
-	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
-	if loadErr := mgr.LoadState(); loadErr != nil {
-		log.Warn("failed to load agent state", "error", loadErr)
-	}
-
-	if refreshErr := mgr.RefreshState(); refreshErr != nil {
-		log.Warn("failed to refresh agent state", "error", refreshErr)
-	}
-
-	agents := mgr.ListAgents()
-
-	// Filter by role if specified
-	if agentListRole != "" {
-		filterRole, roleErr := parseRole(agentListRole)
-		if roleErr != nil {
-			return roleErr
+	return withAgentManager(func(ctx *WorkspaceContext) error {
+		if refreshErr := ctx.Manager.RefreshState(); refreshErr != nil {
+			log.Warn("failed to refresh agent state", "error", refreshErr)
 		}
-		filtered := make([]*agent.Agent, 0, len(agents))
-		for _, a := range agents {
-			if a.Role == filterRole {
-				filtered = append(filtered, a)
-			}
-		}
-		agents = filtered
-	}
 
-	log.Debug("agents loaded", "count", len(agents))
+		agents := ctx.Manager.ListAgents()
 
-	if agentListJSON {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(agents)
-	}
-
-	if len(agents) == 0 {
-		ui.Warning("No agents found")
+		// Filter by role if specified
 		if agentListRole != "" {
-			fmt.Printf("(filtered by role: %s)\n", agentListRole)
+			filterRole, roleErr := parseRole(agentListRole)
+			if roleErr != nil {
+				return roleErr
+			}
+			filtered := make([]*agent.Agent, 0, len(agents))
+			for _, a := range agents {
+				if a.Role == filterRole {
+					filtered = append(filtered, a)
+				}
+			}
+			agents = filtered
 		}
+
+		log.Debug("agents loaded", "count", len(agents))
+
+		if agentListJSON {
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(agents)
+		}
+
+		if len(agents) == 0 {
+			ui.Warning("No agents found")
+			if agentListRole != "" {
+				fmt.Printf("(filtered by role: %s)\n", agentListRole)
+			}
+			return nil
+		}
+
+		// Determine terminal width for task truncation
+		termWidth := 80
+		if w, _, termErr := term.GetSize(os.Stdout.Fd()); termErr == nil && w > 0 {
+			termWidth = w
+		}
+		taskWidth := termWidth - 57
+		if taskWidth < 20 {
+			taskWidth = 20
+		}
+
+		// Use pkg/ui table for consistent formatting
+		table := ui.NewTable("AGENT", "ROLE", "STATE", "UPTIME", "TASK")
+
+		for _, a := range agents {
+			uptime := "-"
+			if a.State != agent.StateStopped {
+				uptime = formatDuration(time.Since(a.StartedAt))
+			}
+
+			task := normalizeTask(a.Task)
+			if task == "" {
+				task = "-"
+			}
+			if len(task) > taskWidth {
+				task = task[:taskWidth-3] + "..."
+			}
+
+			stateStr := colorState(a.State)
+
+			table.AddRow(a.Name, string(a.Role), stateStr, uptime, task)
+		}
+
+		table.Print()
 		return nil
-	}
-
-	// Determine terminal width for task truncation
-	termWidth := 80
-	if w, _, termErr := term.GetSize(os.Stdout.Fd()); termErr == nil && w > 0 {
-		termWidth = w
-	}
-	taskWidth := termWidth - 57
-	if taskWidth < 20 {
-		taskWidth = 20
-	}
-
-	// Use pkg/ui table for consistent formatting
-	table := ui.NewTable("AGENT", "ROLE", "STATE", "UPTIME", "TASK")
-
-	for _, a := range agents {
-		uptime := "-"
-		if a.State != agent.StateStopped {
-			uptime = formatDuration(time.Since(a.StartedAt))
-		}
-
-		task := normalizeTask(a.Task)
-		if task == "" {
-			task = "-"
-		}
-		if len(task) > taskWidth {
-			task = task[:taskWidth-3] + "..."
-		}
-
-		stateStr := colorState(a.State)
-
-		table.AddRow(a.Name, string(a.Role), stateStr, uptime, task)
-	}
-
-	table.Print()
-	return nil
+	})
 }
 
 func runAgentAttach(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/ui"
@@ -216,6 +217,54 @@ func errNotInWorkspace(err error) error {
 		return fmt.Errorf("not in a bc workspace (run 'bc init' to initialize one): %w", err)
 	}
 	return fmt.Errorf("not in a bc workspace. Run 'bc init' in your project directory to create one")
+}
+
+// requireWorkspace returns the current workspace or an actionable error.
+// This is a convenience wrapper around getWorkspace() with standard error handling.
+func requireWorkspace() (*workspace.Workspace, error) {
+	ws, err := getWorkspace()
+	if err != nil {
+		return nil, errNotInWorkspace(err)
+	}
+	return ws, nil
+}
+
+// WorkspaceContext holds workspace and agent manager for command handlers.
+// Use withWorkspace() or withAgentManager() to create instances.
+type WorkspaceContext struct {
+	Workspace *workspace.Workspace
+	Manager   *agent.Manager
+}
+
+// withWorkspace executes fn with the current workspace.
+// Returns errNotInWorkspace if not in a bc workspace.
+// Used by commands that only need workspace access (config, stats, etc.).
+func withWorkspace(fn func(ws *workspace.Workspace) error) error { //nolint:unused // Will be used as commands migrate to this pattern
+	ws, err := requireWorkspace()
+	if err != nil {
+		return err
+	}
+	return fn(ws)
+}
+
+// withAgentManager executes fn with workspace and initialized agent manager.
+// The agent manager state is loaded before fn is called.
+// Any state loading errors are logged as warnings (non-fatal).
+func withAgentManager(fn func(ctx *WorkspaceContext) error) error {
+	ws, err := requireWorkspace()
+	if err != nil {
+		return err
+	}
+
+	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
+	if loadErr := mgr.LoadState(); loadErr != nil {
+		log.Warn("failed to load agent state", "error", loadErr)
+	}
+
+	return fn(&WorkspaceContext{
+		Workspace: ws,
+		Manager:   mgr,
+	})
 }
 
 // runInitInteractive runs an interactive workspace initialization with nickname prompt.


### PR DESCRIPTION
## Summary

Adds helper functions to reduce the duplicated workspace loading pattern found in 90+ command handlers:

- `requireWorkspace()`: returns workspace or actionable error
- `withWorkspace()`: wraps commands that only need workspace access
- `withAgentManager()`: wraps commands needing workspace + agent manager
- `WorkspaceContext`: struct holding workspace and manager for handlers

**Refactored `runAgentList` as demonstration:**

Before (9 lines):
```go
ws, err := getWorkspace()
if err != nil {
    return errNotInWorkspace(err)
}
mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
if loadErr := mgr.LoadState(); loadErr != nil {
    log.Warn("failed to load agent state", "error", loadErr)
}
```

After (1 line):
```go
return withAgentManager(func(ctx *WorkspaceContext) error {
```

**Benefits:**
- Reduces code duplication
- Ensures consistent error handling
- Centralizes workspace initialization logic
- Easier to modify workspace loading behavior globally

## Test plan

- [x] All existing tests pass
- [x] `go build ./...` passes
- [x] `golangci-lint` passes with 0 issues
- [x] Pre-commit hooks pass

Fixes #1651

🤖 Generated with [Claude Code](https://claude.com/claude-code)