### PR TITLE
fix(tui): Fix agent peek display text cutoff (#1689)

### DIFF
--- a/tui/src/views/agents/AgentPeekPanel.tsx
+++ b/tui/src/views/agents/AgentPeekPanel.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Text } from 'ink';
+import { Box, Text, useStdout } from 'ink';
 import type { Agent } from '../../types';
 
 export interface AgentPeekPanelProps {
@@ -13,6 +13,9 @@ export interface AgentPeekPanelProps {
  * AgentPeekPanel - Shows recent output from an agent
  * Displays the last few lines of agent output.
  * Extracted from AgentsView (#1592).
+ *
+ * Issue #1689: Fixed text cutoff by using full terminal width
+ * and proper text wrapping instead of truncation.
  */
 export function AgentPeekPanel({
   agent,
@@ -20,6 +23,12 @@ export function AgentPeekPanel({
   loading,
   isNarrow,
 }: AgentPeekPanelProps): React.ReactElement {
+  const { stdout } = useStdout();
+  // Use full terminal width, accounting for padding and borders
+  const terminalWidth = stdout.columns || 80;
+  // Border (2) + paddingX (1 each side when not narrow) = 4
+  const contentWidth = isNarrow ? terminalWidth : terminalWidth - 4;
+
   return (
     <Box
       marginBottom={1}
@@ -27,6 +36,7 @@ export function AgentPeekPanel({
       borderStyle={isNarrow ? undefined : 'single'}
       borderColor="cyan"
       flexDirection="column"
+      width={terminalWidth}
     >
       <Box marginBottom={1}>
         <Text bold color="cyan">Peek: {agent.name}</Text>
@@ -35,9 +45,11 @@ export function AgentPeekPanel({
       {loading ? (
         <Text dimColor>Loading...</Text>
       ) : (
-        output.map((line, idx) => (
-          <Text key={idx} wrap="truncate" dimColor>{line}</Text>
-        ))
+        <Box flexDirection="column" width={contentWidth}>
+          {output.map((line, idx) => (
+            <Text key={idx} wrap="wrap" dimColor>{line}</Text>
+          ))}
+        </Box>
       )}
     </Box>
   );


### PR DESCRIPTION
## Summary

Fixes text cutoff issue in the agent peek panel where output was being truncated mid-line instead of using full terminal width.

**Root cause:**
- `wrap="truncate"` was cutting text at container width
- Container Box didn't have explicit width set to use full terminal

**Fix:**
- Added `useStdout()` to get actual terminal width
- Set explicit width on the outer Box container
- Changed `wrap="truncate"` to `wrap="wrap"` for proper text wrapping
- Wrapped output lines in a Box with calculated content width (accounting for padding/borders)

## Before
```
agent eng-01: Starting implementatio...
```

## After
```
agent eng-01: Starting implementation of the new feature
according to the specification provided...
```

## Test plan

- [x] `bun run build` passes
- [x] `bun run lint` passes (0 errors)
- [x] Pre-commit hooks pass
- [ ] Manual test: `bc ui` → select agent → press `p` to peek

Fixes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)