### PR TITLE
feat(interfaces): Add interface abstractions for testability (#1654)

### DIFF
--- a/pkg/agent/interfaces.go
+++ b/pkg/agent/interfaces.go
@@ -1,0 +1,78 @@
+// Package agent provides agent lifecycle management.
+package agent
+
+import (
+	"io/fs"
+	"os"
+	"os/exec"
+
+	"github.com/rpuneet/bc/pkg/tmux"
+)
+
+// FileSystem abstracts file system operations for testability.
+// This allows tests to run without touching the real file system.
+type FileSystem interface {
+	// Stat returns the FileInfo for the file at path.
+	Stat(path string) (fs.FileInfo, error)
+	// ReadFile reads the file at path and returns its contents.
+	ReadFile(path string) ([]byte, error)
+	// WriteFile writes data to the file at path with the given permissions.
+	WriteFile(path string, data []byte, perm fs.FileMode) error
+	// MkdirAll creates a directory along with any necessary parents.
+	MkdirAll(path string, perm fs.FileMode) error
+	// RemoveAll removes the path and any children it contains.
+	RemoveAll(path string) error
+}
+
+// OSFileSystem implements FileSystem using the os package.
+type OSFileSystem struct{}
+
+// Stat implements FileSystem.
+func (OSFileSystem) Stat(path string) (fs.FileInfo, error) {
+	return os.Stat(path)
+}
+
+// ReadFile implements FileSystem.
+func (OSFileSystem) ReadFile(path string) ([]byte, error) {
+	//nolint:gosec // path comes from trusted internal sources (workspace, config)
+	return os.ReadFile(path)
+}
+
+// WriteFile implements FileSystem.
+func (OSFileSystem) WriteFile(path string, data []byte, perm fs.FileMode) error {
+	return os.WriteFile(path, data, perm)
+}
+
+// MkdirAll implements FileSystem.
+func (OSFileSystem) MkdirAll(path string, perm fs.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+// RemoveAll implements FileSystem.
+func (OSFileSystem) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+// DefaultFileSystem returns an OSFileSystem.
+func DefaultFileSystem() FileSystem {
+	return OSFileSystem{}
+}
+
+// TmuxManager abstracts tmux session operations for testability.
+// This interface matches the subset of tmux.Manager methods used by the agent package.
+type TmuxManager interface {
+	// HasSession checks if a session exists.
+	HasSession(name string) bool
+	// CreateSessionWithEnv creates a session with env vars baked into the shell command.
+	CreateSessionWithEnv(name, dir, command string, env map[string]string) error
+	// KillSession kills a tmux session.
+	KillSession(name string) error
+	// SendKeys sends keys to a session.
+	SendKeys(name, keys string) error
+	// Capture captures the current pane content.
+	Capture(name string, lines int) (string, error)
+	// ListSessions lists all sessions with our prefix.
+	ListSessions() ([]tmux.Session, error)
+	// AttachCmd returns an exec.Cmd to attach to a session.
+	AttachCmd(name string) *exec.Cmd
+}

--- a/pkg/agent/interfaces_test.go
+++ b/pkg/agent/interfaces_test.go
@@ -1,0 +1,199 @@
+package agent
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestOSFileSystem_Stat(t *testing.T) {
+	fs := OSFileSystem{}
+
+	// Test existing file
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(tmpFile, []byte("test"), 0600); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	info, err := fs.Stat(tmpFile)
+	if err != nil {
+		t.Errorf("Stat() error = %v, want nil", err)
+	}
+	if info.Name() != "test.txt" {
+		t.Errorf("Stat() name = %v, want test.txt", info.Name())
+	}
+
+	// Test non-existing file
+	_, err = fs.Stat(filepath.Join(tmpDir, "nonexistent.txt"))
+	if err == nil {
+		t.Error("Stat() error = nil for non-existing file, want error")
+	}
+}
+
+func TestOSFileSystem_ReadFile(t *testing.T) {
+	fs := OSFileSystem{}
+
+	// Test existing file
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+	content := []byte("hello world")
+	if err := os.WriteFile(tmpFile, content, 0600); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	got, err := fs.ReadFile(tmpFile)
+	if err != nil {
+		t.Errorf("ReadFile() error = %v, want nil", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("ReadFile() = %v, want %v", string(got), string(content))
+	}
+
+	// Test non-existing file
+	_, err = fs.ReadFile(filepath.Join(tmpDir, "nonexistent.txt"))
+	if err == nil {
+		t.Error("ReadFile() error = nil for non-existing file, want error")
+	}
+}
+
+func TestOSFileSystem_WriteFile(t *testing.T) {
+	osFS := OSFileSystem{}
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test.txt")
+	content := []byte("hello world")
+
+	err := osFS.WriteFile(tmpFile, content, 0600)
+	if err != nil {
+		t.Errorf("WriteFile() error = %v, want nil", err)
+	}
+
+	// Verify content
+	got, err := os.ReadFile(tmpFile) //nolint:gosec // test file path is safe
+	if err != nil {
+		t.Fatalf("failed to read test file: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("WriteFile() wrote %v, want %v", string(got), string(content))
+	}
+}
+
+func TestOSFileSystem_MkdirAll(t *testing.T) {
+	osFS := OSFileSystem{}
+	tmpDir := t.TempDir()
+	newDir := filepath.Join(tmpDir, "a", "b", "c")
+
+	err := osFS.MkdirAll(newDir, 0750)
+	if err != nil {
+		t.Errorf("MkdirAll() error = %v, want nil", err)
+	}
+
+	// Verify directory exists
+	info, err := os.Stat(newDir)
+	if err != nil {
+		t.Errorf("MkdirAll() directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("MkdirAll() created a file, want directory")
+	}
+}
+
+func TestOSFileSystem_RemoveAll(t *testing.T) {
+	osFS := OSFileSystem{}
+	tmpDir := t.TempDir()
+	newDir := filepath.Join(tmpDir, "toremove")
+
+	// Create directory with file
+	if err := os.MkdirAll(newDir, 0750); err != nil {
+		t.Fatalf("failed to create test dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(newDir, "file.txt"), []byte("test"), 0600); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+
+	err := osFS.RemoveAll(newDir)
+	if err != nil {
+		t.Errorf("RemoveAll() error = %v, want nil", err)
+	}
+
+	// Verify directory is gone
+	_, err = os.Stat(newDir)
+	if err == nil {
+		t.Error("RemoveAll() directory still exists, want removed")
+	}
+}
+
+func TestDefaultFileSystem(t *testing.T) {
+	fs := DefaultFileSystem()
+	if fs == nil {
+		t.Error("DefaultFileSystem() = nil, want non-nil")
+	}
+	if _, ok := fs.(OSFileSystem); !ok {
+		t.Error("DefaultFileSystem() type is not OSFileSystem")
+	}
+}
+
+// MockFileSystem is a test double for FileSystem.
+type MockFileSystem struct {
+	StatFunc      func(path string) (fs.FileInfo, error)
+	ReadFileFunc  func(path string) ([]byte, error)
+	WriteFileFunc func(path string, data []byte, perm fs.FileMode) error
+	MkdirAllFunc  func(path string, perm fs.FileMode) error
+	RemoveAllFunc func(path string) error
+}
+
+func (m *MockFileSystem) Stat(path string) (fs.FileInfo, error) {
+	if m.StatFunc != nil {
+		return m.StatFunc(path)
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *MockFileSystem) ReadFile(path string) ([]byte, error) {
+	if m.ReadFileFunc != nil {
+		return m.ReadFileFunc(path)
+	}
+	return nil, os.ErrNotExist
+}
+
+func (m *MockFileSystem) WriteFile(path string, data []byte, perm fs.FileMode) error {
+	if m.WriteFileFunc != nil {
+		return m.WriteFileFunc(path, data, perm)
+	}
+	return nil
+}
+
+func (m *MockFileSystem) MkdirAll(path string, perm fs.FileMode) error {
+	if m.MkdirAllFunc != nil {
+		return m.MkdirAllFunc(path, perm)
+	}
+	return nil
+}
+
+func (m *MockFileSystem) RemoveAll(path string) error {
+	if m.RemoveAllFunc != nil {
+		return m.RemoveAllFunc(path)
+	}
+	return nil
+}
+
+func TestMockFileSystem(t *testing.T) {
+	// Verify MockFileSystem implements FileSystem
+	var _ FileSystem = &MockFileSystem{}
+
+	// Test with custom implementations
+	mock := &MockFileSystem{
+		ReadFileFunc: func(path string) ([]byte, error) {
+			return []byte("mocked content"), nil
+		},
+	}
+
+	content, err := mock.ReadFile("/any/path")
+	if err != nil {
+		t.Errorf("MockFileSystem.ReadFile() error = %v, want nil", err)
+	}
+	if string(content) != "mocked content" {
+		t.Errorf("MockFileSystem.ReadFile() = %v, want mocked content", string(content))
+	}
+}

--- a/pkg/tmux/interfaces.go
+++ b/pkg/tmux/interfaces.go
@@ -1,0 +1,64 @@
+// Package tmux provides tmux session management for agent orchestration.
+package tmux
+
+import (
+	"os/exec"
+)
+
+// CommandExecutor abstracts command execution for testability.
+// This allows tests to mock exec.Command calls without actually running processes.
+type CommandExecutor interface {
+	// Command creates an exec.Cmd for the given command and arguments.
+	Command(name string, arg ...string) *exec.Cmd
+}
+
+// execCommandFunc adapts a function to the CommandExecutor interface.
+type execCommandFunc func(name string, arg ...string) *exec.Cmd
+
+// Command implements CommandExecutor.
+func (f execCommandFunc) Command(name string, arg ...string) *exec.Cmd {
+	return f(name, arg...)
+}
+
+// DefaultExecutor returns a CommandExecutor using exec.Command.
+func DefaultExecutor() CommandExecutor {
+	return execCommandFunc(exec.Command)
+}
+
+// Session interface abstracts tmux session operations for testability.
+// This allows agent code to work with mock implementations in tests.
+type SessionManager interface {
+	// HasSession checks if a session exists.
+	HasSession(name string) bool
+	// CreateSession creates a new tmux session.
+	CreateSession(name, dir string) error
+	// CreateSessionWithCommand creates a session and runs a command.
+	CreateSessionWithCommand(name, dir, command string) error
+	// CreateSessionWithEnv creates a session with env vars baked into the shell command.
+	CreateSessionWithEnv(name, dir, command string, env map[string]string) error
+	// KillSession kills a tmux session.
+	KillSession(name string) error
+	// RenameSession renames a tmux session.
+	RenameSession(oldName, newName string) error
+	// SendKeys sends keys to a session with Enter as submit key.
+	SendKeys(name, keys string) error
+	// SendKeysWithSubmit sends keys to a session with a specified submit key.
+	SendKeysWithSubmit(name, keys, submitKey string) error
+	// Capture captures the current pane content.
+	Capture(name string, lines int) (string, error)
+	// ListSessions lists all sessions with our prefix.
+	ListSessions() ([]Session, error)
+	// AttachCmd returns an exec.Cmd to attach to a session.
+	AttachCmd(name string) *exec.Cmd
+	// IsRunning checks if tmux server is running.
+	IsRunning() bool
+	// KillServer kills the tmux server (all sessions).
+	KillServer() error
+	// SetEnvironment sets an environment variable in a session.
+	SetEnvironment(name, key, value string) error
+	// SessionName returns the full session name with prefix.
+	SessionName(name string) string
+}
+
+// Ensure Manager implements SessionManager.
+var _ SessionManager = (*Manager)(nil)

--- a/pkg/tmux/interfaces_test.go
+++ b/pkg/tmux/interfaces_test.go
@@ -1,0 +1,247 @@
+package tmux
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+func TestDefaultExecutor(t *testing.T) {
+	executor := DefaultExecutor()
+	if executor == nil {
+		t.Fatal("DefaultExecutor() = nil, want non-nil")
+	}
+
+	// Test that it creates a command
+	cmd := executor.Command("echo", "hello")
+	if cmd == nil {
+		t.Fatal("DefaultExecutor.Command() = nil, want non-nil")
+	}
+	if cmd.Path == "" {
+		t.Error("DefaultExecutor.Command() path is empty")
+	}
+}
+
+func TestExecCommandFunc(t *testing.T) {
+	called := false
+	var capturedName string
+	var capturedArgs []string
+
+	f := execCommandFunc(func(name string, arg ...string) *exec.Cmd {
+		called = true
+		capturedName = name
+		capturedArgs = arg
+		return exec.CommandContext(context.Background(), name, arg...)
+	})
+
+	cmd := f.Command("test", "arg1", "arg2")
+	if !called {
+		t.Error("execCommandFunc.Command() did not call the function")
+	}
+	if capturedName != "test" {
+		t.Errorf("execCommandFunc.Command() name = %v, want test", capturedName)
+	}
+	if len(capturedArgs) != 2 || capturedArgs[0] != "arg1" || capturedArgs[1] != "arg2" {
+		t.Errorf("execCommandFunc.Command() args = %v, want [arg1 arg2]", capturedArgs)
+	}
+	if cmd == nil {
+		t.Error("execCommandFunc.Command() = nil, want non-nil")
+	}
+}
+
+func TestManagerImplementsSessionManager(t *testing.T) {
+	// Verify Manager implements SessionManager
+	var _ SessionManager = (*Manager)(nil)
+}
+
+// MockCommandExecutor is a test double for CommandExecutor.
+type MockCommandExecutor struct {
+	CommandFunc func(name string, arg ...string) *exec.Cmd
+}
+
+func (m *MockCommandExecutor) Command(name string, arg ...string) *exec.Cmd {
+	if m.CommandFunc != nil {
+		return m.CommandFunc(name, arg...)
+	}
+	return exec.CommandContext(context.Background(), name, arg...)
+}
+
+func TestMockCommandExecutor(t *testing.T) {
+	// Verify MockCommandExecutor implements CommandExecutor
+	var _ CommandExecutor = &MockCommandExecutor{}
+
+	// Test with custom implementation
+	mock := &MockCommandExecutor{
+		CommandFunc: func(name string, arg ...string) *exec.Cmd {
+			// Return a simple echo command regardless of input
+			return exec.CommandContext(context.Background(), "echo", "mocked")
+		},
+	}
+
+	cmd := mock.Command("anything", "ignored")
+	if cmd == nil {
+		t.Fatal("MockCommandExecutor.Command() = nil, want non-nil")
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		t.Errorf("MockCommandExecutor command execution failed: %v", err)
+	}
+	if string(output) != "mocked\n" {
+		t.Errorf("MockCommandExecutor output = %v, want mocked\\n", string(output))
+	}
+}
+
+// MockSessionManager is a test double for SessionManager.
+type MockSessionManager struct {
+	HasSessionFunc           func(name string) bool
+	CreateSessionFunc        func(name, dir string) error
+	CreateSessionWithCmdFunc func(name, dir, command string) error
+	CreateSessionWithEnvFunc func(name, dir, command string, env map[string]string) error
+	KillSessionFunc          func(name string) error
+	RenameSessionFunc        func(oldName, newName string) error
+	SendKeysFunc             func(name, keys string) error
+	SendKeysWithSubmitFunc   func(name, keys, submitKey string) error
+	CaptureFunc              func(name string, lines int) (string, error)
+	ListSessionsFunc         func() ([]Session, error)
+	AttachCmdFunc            func(name string) *exec.Cmd
+	IsRunningFunc            func() bool
+	KillServerFunc           func() error
+	SetEnvironmentFunc       func(name, key, value string) error
+	SessionNameFunc          func(name string) string
+}
+
+func (m *MockSessionManager) HasSession(name string) bool {
+	if m.HasSessionFunc != nil {
+		return m.HasSessionFunc(name)
+	}
+	return false
+}
+
+func (m *MockSessionManager) CreateSession(name, dir string) error {
+	if m.CreateSessionFunc != nil {
+		return m.CreateSessionFunc(name, dir)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) CreateSessionWithCommand(name, dir, command string) error {
+	if m.CreateSessionWithCmdFunc != nil {
+		return m.CreateSessionWithCmdFunc(name, dir, command)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) CreateSessionWithEnv(name, dir, command string, env map[string]string) error {
+	if m.CreateSessionWithEnvFunc != nil {
+		return m.CreateSessionWithEnvFunc(name, dir, command, env)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) KillSession(name string) error {
+	if m.KillSessionFunc != nil {
+		return m.KillSessionFunc(name)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) RenameSession(oldName, newName string) error {
+	if m.RenameSessionFunc != nil {
+		return m.RenameSessionFunc(oldName, newName)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) SendKeys(name, keys string) error {
+	if m.SendKeysFunc != nil {
+		return m.SendKeysFunc(name, keys)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) SendKeysWithSubmit(name, keys, submitKey string) error {
+	if m.SendKeysWithSubmitFunc != nil {
+		return m.SendKeysWithSubmitFunc(name, keys, submitKey)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) Capture(name string, lines int) (string, error) {
+	if m.CaptureFunc != nil {
+		return m.CaptureFunc(name, lines)
+	}
+	return "", nil
+}
+
+func (m *MockSessionManager) ListSessions() ([]Session, error) {
+	if m.ListSessionsFunc != nil {
+		return m.ListSessionsFunc()
+	}
+	return nil, nil
+}
+
+func (m *MockSessionManager) AttachCmd(name string) *exec.Cmd {
+	if m.AttachCmdFunc != nil {
+		return m.AttachCmdFunc(name)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) IsRunning() bool {
+	if m.IsRunningFunc != nil {
+		return m.IsRunningFunc()
+	}
+	return false
+}
+
+func (m *MockSessionManager) KillServer() error {
+	if m.KillServerFunc != nil {
+		return m.KillServerFunc()
+	}
+	return nil
+}
+
+func (m *MockSessionManager) SetEnvironment(name, key, value string) error {
+	if m.SetEnvironmentFunc != nil {
+		return m.SetEnvironmentFunc(name, key, value)
+	}
+	return nil
+}
+
+func (m *MockSessionManager) SessionName(name string) string {
+	if m.SessionNameFunc != nil {
+		return m.SessionNameFunc(name)
+	}
+	return name
+}
+
+func TestMockSessionManager(t *testing.T) {
+	// Verify MockSessionManager implements SessionManager
+	var _ SessionManager = &MockSessionManager{}
+
+	// Test with custom implementations
+	mock := &MockSessionManager{
+		HasSessionFunc: func(name string) bool {
+			return name == "exists"
+		},
+		CaptureFunc: func(name string, lines int) (string, error) {
+			return "captured output", nil
+		},
+	}
+
+	if !mock.HasSession("exists") {
+		t.Error("MockSessionManager.HasSession(exists) = false, want true")
+	}
+	if mock.HasSession("notexists") {
+		t.Error("MockSessionManager.HasSession(notexists) = true, want false")
+	}
+
+	output, err := mock.Capture("test", 10)
+	if err != nil {
+		t.Errorf("MockSessionManager.Capture() error = %v, want nil", err)
+	}
+	if output != "captured output" {
+		t.Errorf("MockSessionManager.Capture() = %v, want captured output", output)
+	}
+}


### PR DESCRIPTION
## Summary

- Introduces interface abstractions to improve testability and reduce coupling to external dependencies
- **pkg/tmux**: `CommandExecutor` and `SessionManager` interfaces with mock implementations
- **pkg/agent**: `FileSystem` and `TmuxManager` interfaces with default and mock implementations
- Enables unit testing without tmux subprocess calls or file system access

## Changes

| Package | Interface | Purpose |
|---------|-----------|---------|
| pkg/tmux | `CommandExecutor` | Abstracts exec.Command for mocking |
| pkg/tmux | `SessionManager` | Interface for tmux session operations |
| pkg/agent | `FileSystem` | Abstracts os file operations |
| pkg/agent | `TmuxManager` | Interface for tmux operations used by agent |

## Test plan

- [x] Interface tests pass with race detector
- [x] Mock implementations verify interface compliance
- [x] Pre-commit hooks pass (go build, go vet, golangci-lint)
- [x] Existing tests continue to pass

Closes #1654

🤖 Generated with [Claude Code](https://claude.com/claude-code)