### PR TITLE
fix(tui): Set focus to 'input' during search mode (#1692)

### DIFF
--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -178,15 +178,19 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
   const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   // Manage focus state and breadcrumbs for nested view navigation (#1604)
+  // When in search mode, set focus='input' to allow typing special chars (#1692)
   useEffect(() => {
     if (showDetail && selectedAgent) {
       setFocus('view');
       setBreadcrumbs([{ label: selectedAgent.name }]);
+    } else if (searchMode) {
+      setFocus('input');
+      clearBreadcrumbs();
     } else {
       setFocus('main');
       clearBreadcrumbs();
     }
-  }, [showDetail, selectedAgent, setFocus, setBreadcrumbs, clearBreadcrumbs]);
+  }, [showDetail, selectedAgent, searchMode, setFocus, setBreadcrumbs, clearBreadcrumbs]);
 
   // Clear action feedback after delay
   const showActionFeedback = useCallback((action: AgentAction, target: string, status: 'success' | 'error', message: string) => {

--- a/tui/src/views/DemonsView.tsx
+++ b/tui/src/views/DemonsView.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useDemons, useDebounce, useDisableInput } from '../hooks';
+import { useFocus } from '../navigation/FocusContext';
 import { StatusBadge } from '../components/StatusBadge';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
@@ -81,6 +82,7 @@ export function DemonsView(_props: DemonsViewProps = {}): React.ReactElement {
   // #1594: Use context instead of prop drilling
   const { isDisabled: disableInput } = useDisableInput();
   const { data: demons, loading, error, enabled, refresh, enable, disable, run } = useDemons();
+  const { setFocus } = useFocus();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [actionError, setActionError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
@@ -88,6 +90,16 @@ export function DemonsView(_props: DemonsViewProps = {}): React.ReactElement {
 
   // Debounce search query for filtering (issue #1602)
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
+  // Manage focus state for search mode (#1692)
+  // When in search mode, set focus='input' to allow typing special chars
+  useEffect(() => {
+    if (searchMode) {
+      setFocus('input');
+    } else {
+      setFocus('main');
+    }
+  }, [searchMode, setFocus]);
 
   // Filter demons by search query (using debounced query for performance)
   const filteredDemons = React.useMemo(() => {

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -220,13 +220,16 @@ export const LogsView: React.FC<LogsViewProps> = () => {
   const selectedLog = filteredLogs[selectedIndex] as LogEntry | undefined;
 
   // Manage focus state for nested view navigation
+  // When in search mode, set focus='input' to allow typing special chars (#1692)
   useEffect(() => {
     if (showDetail) {
       setFocus('view');
+    } else if (searchMode) {
+      setFocus('input');
     } else {
       setFocus('main');
     }
-  }, [showDetail, setFocus]);
+  }, [showDetail, searchMode, setFocus]);
 
   // Cycle through severity filters
   const cycleSeverity = useCallback(() => {

--- a/tui/src/views/MemoryView.tsx
+++ b/tui/src/views/MemoryView.tsx
@@ -119,6 +119,7 @@ export function MemoryView(_props: MemoryViewProps = {}): React.ReactElement {
   const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   // Manage focus and breadcrumbs for nested views (#1604)
+  // When in search mode, set focus='input' to allow typing special chars (#1692)
   useEffect(() => {
     if (viewMode === 'detail' && selectedMemory) {
       setFocus('view');
@@ -127,7 +128,8 @@ export function MemoryView(_props: MemoryViewProps = {}): React.ReactElement {
       setFocus('view');
       setBreadcrumbs([{ label: 'Search' }]);
     } else if (searchMode) {
-      setFocus('view');
+      setFocus('input');
+      clearBreadcrumbs();
     } else {
       setFocus('main');
       clearBreadcrumbs();

--- a/tui/src/views/ProcessesView.tsx
+++ b/tui/src/views/ProcessesView.tsx
@@ -3,9 +3,10 @@
  * Issue #555: Processes view with list, details, and log viewer
  */
 
-import { useState, useMemo, useReducer } from 'react';
+import { useState, useMemo, useReducer, useEffect } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { useProcesses, useProcessLogs, useDebounce } from '../hooks';
+import { useFocus } from '../navigation/FocusContext';
 import { Table } from '../components/Table';
 import type { Column } from '../components/Table';
 import { StatusBadge } from '../components/StatusBadge';
@@ -96,6 +97,7 @@ function formatUptime(startedAt: string): string {
 
 export function ProcessesView(): React.ReactElement {
   const { data: processes, loading, error, refresh } = useProcesses();
+  const { setFocus } = useFocus();
 
   // #1601: UI state consolidated with useReducer
   const [ui, dispatch] = useReducer(uiReducer, initialUIState);
@@ -103,6 +105,18 @@ export function ProcessesView(): React.ReactElement {
 
   // Debounce search query for filtering (issue #1602)
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
+
+  // Manage focus state for nested view navigation (#1692)
+  // When in search mode, set focus='input' to allow typing special chars
+  useEffect(() => {
+    if (showLogs) {
+      setFocus('view');
+    } else if (searchMode) {
+      setFocus('input');
+    } else {
+      setFocus('main');
+    }
+  }, [showLogs, searchMode, setFocus]);
 
   // Filter processes by search query (using debounced query for performance)
   const processList = useMemo(() => {

--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -64,15 +64,19 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
 
   // Manage focus state and breadcrumbs for nested view navigation (#1604)
   // When showing details, set focus='view' to prevent global ESC from firing
+  // When in search mode, set focus='input' to allow typing special chars (#1692)
   useEffect(() => {
     if (showDetails && selectedRole) {
       setFocus('view');
       setBreadcrumbs([{ label: selectedRole.name }]);
+    } else if (searchMode) {
+      setFocus('input');
+      clearBreadcrumbs();
     } else {
       setFocus('main');
       clearBreadcrumbs();
     }
-  }, [showDetails, selectedRole, setFocus, setBreadcrumbs, clearBreadcrumbs]);
+  }, [showDetails, selectedRole, searchMode, setFocus, setBreadcrumbs, clearBreadcrumbs]);
 
   // Fetch roles
   const fetchRoles = useCallback(async () => {


### PR DESCRIPTION
## Summary
- Fixed 6 views that didn't properly set focus='input' during search mode
- When `searchMode` is true, the `useKeyboardNavigation` hook needs to skip global keybindings (like `?` for help)
- This is controlled by focus state - when focus is 'input', global keybindings are disabled

## Changes
- **RolesView**: Added `searchMode` check to useEffect for focus management
- **LogsView**: Added `searchMode` check to useEffect for focus management  
- **MemoryView**: Changed `setFocus('view')` to `setFocus('input')` when searchMode is true
- **AgentsView**: Added `searchMode` check to useEffect for focus management
- **ProcessesView**: Added `useFocus` import and focus management useEffect
- **DemonsView**: Added `useFocus` import and focus management useEffect

## Test plan
- [x] TUI lint passes (0 errors)
- [x] TUI tests pass (2064 pass, 0 fail)
- [x] TUI build succeeds
- [ ] Manual test: Open TUI, press `/` to search, type `?` - should appear in search input

Fixes #1692

🤖 Generated with [Claude Code](https://claude.com/claude-code)