### PR TITLE
fix(tui): Add M and R keyboard shortcuts for Memory/Routing views (#1686)

### DIFF
--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -21,12 +21,15 @@ export interface UseKeyboardNavigationOptions {
  * Hook that handles global keyboard navigation
  * - Tab/Shift+Tab cycles views
  * - ? shows help
+ * - M goes to Memory view
+ * - R goes to Routing view (when not in view mode)
  * - ESC goes back/home
  * - Ctrl+R refreshes all data
  * - q quits the application
  *
  * Issue #1467: Removed 1-9 number shortcuts.
  * Navigation now uses j/k + Enter in Drawer component.
+ * Issue #1686: Added M and R shortcuts for Memory/Routing views.
  */
 export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}): void {
   const { disabled = false, onQuit, onRefresh, onCommandPalette } = options;
@@ -55,11 +58,30 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
 
       // Issue #1467: Removed 1-9 number shortcuts
       // Navigation now uses j/k + Enter in Drawer component
-      // Only ? for help remains as a global shortcut
+      // Global shortcuts: ? (help), M (memory), R (routing)
       if (input === '?') {
         const helpTab = getTabByKey('?');
         if (helpTab) {
           navigate(helpTab.view);
+          return;
+        }
+      }
+
+      // M: go to Memory view (#1686)
+      if (input === 'M') {
+        const memoryTab = getTabByKey('M');
+        if (memoryTab) {
+          navigate(memoryTab.view);
+          return;
+        }
+      }
+
+      // R: go to Routing view (skip when local view handles it) (#1686)
+      // Note: Some views use 'r' for refresh, so we use uppercase 'R'
+      if (input === 'R' && !isFocused('view')) {
+        const routingTab = getTabByKey('R');
+        if (routingTab) {
+          navigate(routingTab.view);
           return;
         }
       }


### PR DESCRIPTION
## Summary
- Implemented M and R keyboard shortcuts for Memory and Routing views
- These shortcuts were defined in `NavigationContext` but not implemented in `useKeyboardNavigation`

## Changes
- Added M shortcut: Navigate to Memory view (global shortcut)
- Added R shortcut: Navigate to Routing view (skips when `isFocused('view')` to avoid conflicts with local 'r' refresh handlers)
- Updated hook documentation to reflect new shortcuts

## Test plan
- [x] TUI lint passes (0 errors)
- [x] TUI build succeeds
- [ ] Manual test: Open TUI, press M - should navigate to Memory view
- [ ] Manual test: Open TUI, press R - should navigate to Routing view

Fixes #1686

🤖 Generated with [Claude Code](https://claude.com/claude-code)