### PR TITLE
fix(tui): Allow j/k scrolling in nested views like ChannelHistory (#1680)

### DIFF
--- a/tui/src/navigation/Drawer.tsx
+++ b/tui/src/navigation/Drawer.tsx
@@ -82,8 +82,9 @@ export function Drawer({
   // Handle keyboard navigation within drawer
   useInput(
     (input, key) => {
-      // Don't handle keys when in input mode
-      if (isFocused('input')) {
+      // Don't handle keys when in input mode or view mode (#1680)
+      // When focus is 'view', a nested view (like ChannelHistoryView) handles j/k
+      if (isFocused('input') || isFocused('view')) {
         return;
       }
 


### PR DESCRIPTION
## Summary
- Fixed j/k scrolling not working in ChannelHistoryView
- Root cause: Drawer component intercepted j/k keys when focus was 'view'

## Root Cause
When entering a channel to view history, `ChannelHistoryView` sets focus to 'view' (to prevent global ESC from going to Dashboard). However, `Drawer` only checked for `isFocused('input')` before handling j/k, so it was intercepting the keys meant for the nested view.

## Fix
Added `isFocused('view')` check to Drawer's useInput guard:
```typescript
if (isFocused('input') || isFocused('view')) {
  return;
}
```

When focus is 'view', nested views handle their own j/k navigation.

## Test plan
- [x] TUI lint passes (0 errors)
- [x] TUI build succeeds
- [x] Go CLI build succeeds
- [ ] Manual test: Open TUI, go to Channels, enter a channel, press j/k - should scroll messages

Fixes #1680

🤖 Generated with [Claude Code](https://claude.com/claude-code)