### PR TITLE
fix(tui): Account for container overhead in bubble width calc (#1681)

### DIFF
--- a/tui/src/components/channels/ChannelHistoryView.tsx
+++ b/tui/src/components/channels/ChannelHistoryView.tsx
@@ -98,8 +98,10 @@ export function ChannelHistoryView({
   const layoutOverhead = 4 + inputHeight + 1 + 1 + 4 + 2; // = 12 + inputHeight
   const messageAreaHeight = Math.max(8, terminalHeight - layoutOverhead);
 
-  // Dynamic bubble width: 80% of terminal width, min 50, max 140
-  const maxBubbleWidth = Math.min(140, Math.max(50, Math.floor(terminalWidth * 0.8)));
+  // Dynamic bubble width: 80% of available width, min 40, max 140
+  // #1681 fix: Account for container overhead (8 cols: view border/padding + bubble border/padding)
+  const containerOverhead = 8;
+  const maxBubbleWidth = Math.min(140, Math.max(40, Math.floor((terminalWidth - containerOverhead) * 0.8)));
 
   // Dynamic message count: ~4 lines per message bubble
   const maxMessages = Math.max(3, Math.floor(messageAreaHeight / 4));

--- a/tui/src/components/channels/__tests__/ChannelHistoryView.test.tsx
+++ b/tui/src/components/channels/__tests__/ChannelHistoryView.test.tsx
@@ -82,22 +82,27 @@ describe('ChannelHistoryView Message Display', () => {
   });
 
   describe('Bubble width calculation', () => {
+    // #1681 fix: Account for container overhead (8 cols)
+    const containerOverhead = 8;
+
     it('calculates bubble width at 80 columns', () => {
       const terminalWidth = 80;
-      const maxBubbleWidth = Math.min(140, Math.max(50, Math.floor(terminalWidth * 0.8)));
-      expect(maxBubbleWidth).toBe(64);
+      const maxBubbleWidth = Math.min(140, Math.max(40, Math.floor((terminalWidth - containerOverhead) * 0.8)));
+      // (80 - 8) * 0.8 = 57.6 = 57
+      expect(maxBubbleWidth).toBe(57);
     });
 
     it('caps bubble width at 140', () => {
       const terminalWidth = 200;
-      const maxBubbleWidth = Math.min(140, Math.max(50, Math.floor(terminalWidth * 0.8)));
+      const maxBubbleWidth = Math.min(140, Math.max(40, Math.floor((terminalWidth - containerOverhead) * 0.8)));
       expect(maxBubbleWidth).toBe(140);
     });
 
-    it('ensures minimum bubble width of 50', () => {
+    it('ensures minimum bubble width of 40', () => {
       const terminalWidth = 40;
-      const maxBubbleWidth = Math.min(140, Math.max(50, Math.floor(terminalWidth * 0.8)));
-      expect(maxBubbleWidth).toBe(50);
+      const maxBubbleWidth = Math.min(140, Math.max(40, Math.floor((terminalWidth - containerOverhead) * 0.8)));
+      // (40 - 8) * 0.8 = 25.6 = 25, but min is 40
+      expect(maxBubbleWidth).toBe(40);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Fixed message bubble text bleeding at 80x24 terminal size
- Root cause: Bubble width calculation didn't account for container overhead

## Root Cause
At 80 columns, the old calculation gave a 64-char bubble width, but:
- View borders (2) + padding (2) = 4 cols overhead
- Bubble border (2) + padding (2) = 4 cols overhead
- Total: 8 cols overhead

## Fix
Account for container overhead (8 cols) before calculating 80% width:
```typescript
const containerOverhead = 8;
const maxBubbleWidth = Math.min(140, Math.max(40, Math.floor((terminalWidth - containerOverhead) * 0.8)));
```

**Results at 80 columns:**
- Old: `80 * 0.8 = 64` (too wide)
- New: `(80 - 8) * 0.8 = 57` (safer)

## Test plan
- [x] ChannelHistoryView tests pass (33 pass)
- [x] TUI lint passes (0 errors)
- [x] TUI build succeeds
- [ ] Manual test: Resize terminal to 80x24, view channel messages - no text bleeding

Fixes #1681

🤖 Generated with [Claude Code](https://claude.com/claude-code)