### PR TITLE
feat(demon): Add heartbeat health monitoring for scheduler daemon (#1688)

### DIFF
--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rpuneet/bc/pkg/demon"
 	"github.com/rpuneet/bc/pkg/integrations"
+	"github.com/rpuneet/bc/pkg/shutdown"
 	testpkg "github.com/rpuneet/bc/pkg/testing"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
@@ -880,6 +881,14 @@ func runDemonStatus(cmd *cobra.Command, args []string) error {
 		if status.Uptime != "" {
 			cmd.Printf("Uptime:    %s\n", status.Uptime)
 		}
+		if status.Healthy {
+			cmd.Println("Health:    healthy")
+		} else {
+			cmd.Println("Health:    unhealthy (no recent heartbeat)")
+		}
+		if !status.LastHeartbeat.IsZero() {
+			cmd.Printf("Heartbeat: %s ago\n", time.Since(status.LastHeartbeat).Truncate(time.Second))
+		}
 	} else {
 		cmd.Println("Scheduler: stopped")
 		cmd.Println()
@@ -925,8 +934,11 @@ func runDemonSchedulerLoop(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--root flag is required")
 	}
 
+	// Use shutdown package for proper signal handling (#1688)
+	shutdown.Start()
+
 	scheduler := demon.NewScheduler(schedulerLoopRoot)
-	return scheduler.RunLoop(cmd.Context())
+	return scheduler.RunLoop(shutdown.Context())
 }
 
 func runTestsAndReportIssues(cmd *cobra.Command, ws *workspace.Workspace, pattern string) error {

--- a/pkg/demon/scheduler.go
+++ b/pkg/demon/scheduler.go
@@ -15,30 +15,34 @@ import (
 
 // SchedulerStatus represents the current state of the scheduler.
 type SchedulerStatus struct {
-	StartedAt time.Time `json:"started_at,omitempty"`
-	Uptime    string    `json:"uptime,omitempty"`
-	PID       int       `json:"pid,omitempty"`
-	Running   bool      `json:"running"`
+	StartedAt     time.Time `json:"started_at,omitempty"`
+	LastHeartbeat time.Time `json:"last_heartbeat,omitempty"`
+	Uptime        string    `json:"uptime,omitempty"`
+	PID           int       `json:"pid,omitempty"`
+	Running       bool      `json:"running"`
+	Healthy       bool      `json:"healthy"`
 }
 
 // Scheduler manages the demon scheduler process.
 type Scheduler struct {
-	rootDir    string
-	demonsDir  string
-	pidFile    string
-	logFile    string
-	statusFile string
+	rootDir       string
+	demonsDir     string
+	pidFile       string
+	logFile       string
+	statusFile    string
+	heartbeatFile string
 }
 
 // NewScheduler creates a new scheduler instance.
 func NewScheduler(rootDir string) *Scheduler {
 	demonsDir := filepath.Join(rootDir, ".bc", "demons")
 	return &Scheduler{
-		rootDir:    rootDir,
-		demonsDir:  demonsDir,
-		pidFile:    filepath.Join(demonsDir, "scheduler.pid"),
-		logFile:    filepath.Join(demonsDir, "scheduler.log"),
-		statusFile: filepath.Join(demonsDir, "scheduler.json"),
+		rootDir:       rootDir,
+		demonsDir:     demonsDir,
+		pidFile:       filepath.Join(demonsDir, "scheduler.pid"),
+		logFile:       filepath.Join(demonsDir, "scheduler.log"),
+		statusFile:    filepath.Join(demonsDir, "scheduler.json"),
+		heartbeatFile: filepath.Join(demonsDir, "scheduler.heartbeat"),
 	}
 }
 
@@ -138,6 +142,7 @@ func (s *Scheduler) Stop() error {
 	// Clean up files
 	_ = os.Remove(s.pidFile)
 	_ = os.Remove(s.statusFile)
+	_ = os.Remove(s.heartbeatFile)
 
 	return nil
 }
@@ -146,7 +151,7 @@ func (s *Scheduler) Stop() error {
 func (s *Scheduler) Status() (*SchedulerStatus, error) {
 	pid, err := s.readPID()
 	if err != nil {
-		return &SchedulerStatus{Running: false}, nil
+		return &SchedulerStatus{Running: false, Healthy: false}, nil
 	}
 
 	// Check if process is actually running
@@ -154,17 +159,15 @@ func (s *Scheduler) Status() (*SchedulerStatus, error) {
 		// Clean up stale PID file
 		_ = os.Remove(s.pidFile)
 		_ = os.Remove(s.statusFile)
-		return &SchedulerStatus{Running: false}, nil
+		_ = os.Remove(s.heartbeatFile)
+		return &SchedulerStatus{Running: false, Healthy: false}, nil
 	}
 
 	// Read status file for start time
 	status, err := s.loadStatus()
 	if err != nil {
 		// Fallback: process is running but no status file
-		return &SchedulerStatus{
-			Running: true,
-			PID:     pid,
-		}, nil
+		status = &SchedulerStatus{}
 	}
 
 	status.Running = true
@@ -173,7 +176,28 @@ func (s *Scheduler) Status() (*SchedulerStatus, error) {
 		status.Uptime = time.Since(status.StartedAt).Truncate(time.Second).String()
 	}
 
+	// Check heartbeat for health status
+	status.LastHeartbeat, status.Healthy = s.readHeartbeat()
+
 	return status, nil
+}
+
+// readHeartbeat reads the heartbeat file and returns the timestamp and health status.
+// The scheduler is considered healthy if the heartbeat is less than 60 seconds old.
+func (s *Scheduler) readHeartbeat() (time.Time, bool) {
+	data, err := os.ReadFile(s.heartbeatFile) //nolint:gosec // path from trusted dir
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	timestamp, err := time.Parse(time.RFC3339, string(data))
+	if err != nil {
+		return time.Time{}, false
+	}
+
+	// Healthy if heartbeat is less than 60 seconds old (2x the 30-second tick)
+	healthy := time.Since(timestamp) < 60*time.Second
+	return timestamp, healthy
 }
 
 // IsRunning checks if the scheduler is currently running.
@@ -196,17 +220,28 @@ func (s *Scheduler) RunLoop(ctx context.Context) error {
 	s.log("Scheduler started")
 
 	// Run immediately on start, then on ticker
+	s.writeHeartbeat()
 	s.checkAndRunDemons(store)
 
 	for {
 		select {
 		case <-ctx.Done():
 			s.log("Scheduler stopping")
+			// Clean up heartbeat file on graceful shutdown
+			_ = os.Remove(s.heartbeatFile)
 			return ctx.Err()
 		case <-ticker.C:
+			s.writeHeartbeat()
 			s.checkAndRunDemons(store)
 		}
 	}
+}
+
+// writeHeartbeat writes the current timestamp to the heartbeat file.
+// This allows external tools to verify the scheduler is actively running.
+func (s *Scheduler) writeHeartbeat() {
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	_ = os.WriteFile(s.heartbeatFile, []byte(timestamp), 0600) //nolint:errcheck,gosec // best-effort heartbeat
 }
 
 // checkAndRunDemons checks all enabled demons and runs any that are due.


### PR DESCRIPTION
## Summary
- Integrate shutdown package for proper SIGTERM/SIGINT signal handling in scheduler-loop command
- Add heartbeat mechanism to verify scheduler is actively running (not just process alive)
- Update `bc demon status` to display health status and last heartbeat time

## Changes
- **pkg/demon/scheduler.go**: Added heartbeatFile field, writeHeartbeat/readHeartbeat methods, updated SchedulerStatus with LastHeartbeat and Healthy fields
- **internal/cmd/demon.go**: Use shutdown.Context() for signal handling, display health info in status output

## How it works
The scheduler writes a heartbeat file (timestamp) every 30 seconds on each tick. Health is determined by the heartbeat being less than 60 seconds old (2x the tick interval). This allows external tools to verify the scheduler is actively running and responsive, not just that the process exists.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/demon/...` passes
- [x] Pre-commit hooks pass (go build, go vet, golangci-lint)

Closes #1688

🤖 Generated with [Claude Code](https://claude.com/claude-code)