### PR TITLE
fix(cmd): Clear env vars in report tests to fix workspace detection (#1668)

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -212,6 +212,9 @@ func TestReportNoWorkspace(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(origDir) }()
 
+	// Clear workspace env vars to ensure workspace lookup fails (#1668)
+	t.Setenv("BC_WORKSPACE", "")
+	t.Setenv("BC_AGENT_WORKTREE", "")
 	t.Setenv("BC_AGENT_ID", "test-agent")
 
 	_, _, err = executeIntegrationCmd("report", "working", "testing")
@@ -229,7 +232,8 @@ func TestReportValidStates(t *testing.T) {
 	for _, state := range validStates {
 		t.Run(state, func(t *testing.T) {
 			t.Setenv("BC_AGENT_ID", "test-agent")
-			t.Setenv("BC_WORKSPACE", "") // Clear workspace env to test cwd-based discovery
+			t.Setenv("BC_WORKSPACE", "")      // Clear workspace env to test cwd-based discovery
+			t.Setenv("BC_AGENT_WORKTREE", "") // Clear worktree env to avoid spurious warnings (#1668)
 
 			// State validation happens before workspace lookup, but
 			// invalid states are rejected. Valid states proceed to


### PR DESCRIPTION
## Summary
- Fix TestReportNoWorkspace failing because BC_WORKSPACE env var was inherited
- Clear BC_WORKSPACE and BC_AGENT_WORKTREE env vars in report tests
- Ensures getWorkspace() properly fails when not in a workspace

## Test plan
- [x] `go test -run TestReportNoWorkspace ./internal/cmd/...` passes
- [x] `go test -run TestReportValidStates ./internal/cmd/...` passes  
- [x] All report-related tests pass
- [x] `make lint` passes

Fixes #1668

🤖 Generated with [Claude Code](https://claude.com/claude-code)