### PR TITLE
feat(tui): Add helpful empty state messages (#1607)

### DIFF
--- a/tui/src/views/ChannelsView.tsx
+++ b/tui/src/views/ChannelsView.tsx
@@ -142,7 +142,10 @@ export function ChannelsView(_props: ChannelsViewProps = {}): React.ReactElement
           />
         ))}
         {(!channels || channels.length === 0) && (
-          <Text dimColor>No channels found</Text>
+          <Box flexDirection="column">
+            <Text dimColor>No channels yet.</Text>
+            <Text dimColor>Create one with: bc channel create &lt;name&gt;</Text>
+          </Box>
         )}
       </Box>
     </Box>

--- a/tui/src/views/ProcessesView.tsx
+++ b/tui/src/views/ProcessesView.tsx
@@ -282,8 +282,9 @@ export function ProcessesView(): React.ReactElement {
         color="blue"
       />
       {processList.length === 0 ? (
-        <Box padding={1}>
-          <Text dimColor>{searchQuery ? 'No processes match search' : 'No processes running'}</Text>
+        <Box padding={1} flexDirection="column">
+          <Text dimColor>{searchQuery ? 'No processes match search' : 'No processes running.'}</Text>
+          {!searchQuery && <Text dimColor>Start one with: bc process start &lt;name&gt; &lt;command&gt;</Text>}
         </Box>
       ) : (
         <>

--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -307,12 +307,15 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
 
         {/* Role rows */}
         {filteredRoles.length === 0 ? (
-          <Box paddingX={1} marginTop={1}>
+          <Box paddingX={1} marginTop={1} flexDirection="column">
             <Text dimColor>
               {searchQuery.length > 0
                 ? `No roles match "${searchQuery}"`
-                : 'No roles defined'}
+                : 'No roles defined.'}
             </Text>
+            {searchQuery.length === 0 && (
+              <Text dimColor>Create one at: .bc/roles/&lt;name&gt;.md</Text>
+            )}
           </Box>
         ) : (
           filteredRoles.map((role, idx) => (

--- a/tui/src/views/WorktreesView.tsx
+++ b/tui/src/views/WorktreesView.tsx
@@ -330,8 +330,9 @@ export const WorktreesView: React.FC = () => {
         })}
 
         {filteredWorktrees.length === 0 && (
-          <Box padding={1}>
-            <Text dimColor>No worktrees found</Text>
+          <Box padding={1} flexDirection="column">
+            <Text dimColor>No worktrees found.</Text>
+            <Text dimColor>Worktrees are created automatically when agents start.</Text>
           </Box>
         )}
       </Box>

--- a/tui/src/views/agents/AgentList.tsx
+++ b/tui/src/views/agents/AgentList.tsx
@@ -67,12 +67,31 @@ export function AgentList({
   ];
 
   if (!groupedView) {
+    // Show helpful empty state message (#1607)
+    if (agents.length === 0) {
+      return (
+        <Box flexDirection="column" padding={1}>
+          <Text dimColor>No agents yet.</Text>
+          <Text dimColor>Create one with: bc agent create --role &lt;role&gt;</Text>
+        </Box>
+      );
+    }
     return (
       <Table
         data={agents}
         columns={columns}
         selectedIndex={selectedIndex}
       />
+    );
+  }
+
+  // Show helpful empty state for grouped view (#1607)
+  if (items.length === 0) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text dimColor>No agents yet.</Text>
+        <Text dimColor>Create one with: bc agent create --role &lt;role&gt;</Text>
+      </Box>
     );
   }
 


### PR DESCRIPTION
## Summary
- Add helpful guidance messages to empty state displays across TUI views
- Improves UX for fresh/empty workspaces by showing clear next steps

## Changes
- **ChannelsView.tsx**: "No channels yet. Create one with: bc channel create <name>"
- **ProcessesView.tsx**: "No processes running. Start one with: bc process start <name> <command>"
- **RolesView.tsx**: "No roles defined. Create one at: .bc/roles/<name>.md"
- **WorktreesView.tsx**: "No worktrees found. Worktrees are created automatically when agents start."
- **AgentList.tsx**: "No agents yet. Create one with: bc agent create --role <role>"

## Test plan
- [x] `bun run build` passes
- [x] `bun test` passes (2064 tests)
- [x] Pre-commit hooks pass

Closes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)