### PR TITLE
fix(tui): Add 'memory' to jsonCommands for proper JSON output (#1756)

### DIFF
--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -229,7 +229,8 @@ function getTtlForCommand(args: string[]): number {
 export async function execBc(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     // Always add --json flag if not present and command supports it
-    const jsonCommands = ['status', 'stats', 'channel', 'cost', 'logs', 'agent', 'process', 'demon', 'team', 'role', 'worktree'];
+    // #1756: Added 'memory' to fix Memory tab showing nothing
+    const jsonCommands = ['status', 'stats', 'channel', 'cost', 'logs', 'agent', 'process', 'demon', 'team', 'role', 'worktree', 'memory'];
     const hasJsonFlag = args.includes('--json');
     const command = args[0];
 


### PR DESCRIPTION
## Summary
- Add 'memory' to the `jsonCommands` array in `execBc()` to fix Memory tab showing "No agent memories found"

## Root Cause
The `execBc()` function in `services/bc.ts` automatically adds `--json` flag for commands in the `jsonCommands` array. The `memory` command was missing from this list.

When `bc memory list` ran without `--json`:
1. CLI returned human-readable text (not JSON)
2. `execBcJson()` failed to parse the text
3. `getMemoryList()` catch block returned `{ agents: [] }`
4. Memory tab displayed "No agent memories found"

## Fix
Add `'memory'` to the `jsonCommands` array so `--json` flag is automatically appended to all memory commands.

## Test plan
- [x] Build passes
- [x] Lint passes (no new errors)
- [x] All 2102 tests pass
- [ ] Manual test: Open TUI Memory tab - should show agent memories

🤖 Generated with [Claude Code](https://claude.com/claude-code)