### PR TITLE
feat(tui): Add Performance/Monitor tab for system health (#1759)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -31,6 +31,7 @@ import { DemonsView } from './views/DemonsView';
 import { ProcessesView } from './views/ProcessesView';
 import { MemoryView } from './views/MemoryView';
 import { RoutingView } from './views/RoutingView';
+import { PerformanceView } from './views/PerformanceView';
 import { HelpView } from './views/HelpView';
 import { CommandPalette } from './components/CommandPalette';
 import { ViewErrorBoundary } from './components/ErrorBoundary';
@@ -253,6 +254,8 @@ const ViewContent = memo(function ViewContent({ view }: ViewContentProps): React
       return <MemoryView />;
     case 'routing':
       return <RoutingView />;
+    case 'performance':
+      return <PerformanceView />;
     case 'help':
       return <HelpView />;
     default:

--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -231,3 +231,11 @@ export {
   type UseDebouncedSearchOptions,
   type UseDebouncedSearchResult,
 } from './useDebounce';
+
+export {
+  useSystemHealth,
+  type SystemHealthData,
+  type SystemHealthSummary,
+  type UseSystemHealthOptions,
+  type UseSystemHealthResult,
+} from './useSystemHealth';

--- a/tui/src/hooks/useSystemHealth.ts
+++ b/tui/src/hooks/useSystemHealth.ts
@@ -1,0 +1,118 @@
+/**
+ * useSystemHealth - Hook for fetching system health/observability data
+ * Issue #1759: Performance/Monitor tab
+ */
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { getAgentHealth, getStats, getCostSummary } from '../services/bc';
+import type { AgentHealth, StatsResponse, CostSummary } from '../types';
+
+export interface SystemHealthData {
+  health: AgentHealth[];
+  stats: StatsResponse | null;
+  costs: CostSummary | null;
+}
+
+export interface SystemHealthSummary {
+  totalAgents: number;
+  healthyAgents: number;
+  degradedAgents: number;
+  stuckAgents: number;
+  errorAgents: number;
+  totalCost: number;
+  costToday: number;
+}
+
+export interface UseSystemHealthOptions {
+  /** Auto-refresh interval in ms (default: 30000) */
+  pollInterval?: number;
+  /** Whether to auto-poll (default: true) */
+  autoPoll?: boolean;
+}
+
+export interface UseSystemHealthResult {
+  data: SystemHealthData;
+  summary: SystemHealthSummary;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  lastRefresh: Date | null;
+}
+
+export function useSystemHealth(options: UseSystemHealthOptions = {}): UseSystemHealthResult {
+  const { pollInterval = 30000, autoPoll = true } = options;
+
+  const [health, setHealth] = useState<AgentHealth[]>([]);
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+  const [costs, setCosts] = useState<CostSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastRefresh, setLastRefresh] = useState<Date | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const [healthData, statsData, costData] = await Promise.all([
+        getAgentHealth(),
+        getStats(),
+        getCostSummary(),
+      ]);
+
+      setHealth(healthData);
+      setStats(statsData);
+      setCosts(costData);
+      setLastRefresh(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch performance data');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Initial load
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Auto-poll
+  useEffect(() => {
+    if (!autoPoll) return;
+
+    const interval = setInterval(() => {
+      void refresh();
+    }, pollInterval);
+
+    return () => { clearInterval(interval); };
+  }, [autoPoll, pollInterval, refresh]);
+
+  // Compute summary
+  const summary = useMemo<SystemHealthSummary>(() => {
+    const healthyCount = health.filter(h => h.status === 'healthy').length;
+    const degradedCount = health.filter(h => h.status === 'degraded').length;
+    const stuckCount = health.filter(h => h.status === 'stuck').length;
+    const errorCount = health.filter(h => h.status === 'error').length;
+
+    return {
+      totalAgents: health.length,
+      healthyAgents: healthyCount,
+      degradedAgents: degradedCount,
+      stuckAgents: stuckCount,
+      errorAgents: errorCount,
+      totalCost: costs?.total_cost ?? 0,
+      costToday: 0, // TODO: Add daily cost tracking
+    };
+  }, [health, costs]);
+
+  return {
+    data: { health, stats, costs },
+    summary,
+    loading,
+    error,
+    refresh,
+    lastRefresh,
+  };
+}
+
+export default useSystemHealth;

--- a/tui/src/navigation/Drawer.tsx
+++ b/tui/src/navigation/Drawer.tsx
@@ -35,7 +35,7 @@ const DRAWER_SECTIONS: DrawerSection[] = [
   },
   {
     title: 'MONITOR',
-    views: ['logs', 'costs', 'processes', 'demons'],
+    views: ['logs', 'costs', 'processes', 'demons', 'performance'],
   },
   {
     title: 'SYSTEM',

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useContext, useState, useCallback, useMemo } from
 import type { ReactNode } from 'react';
 
 // View types for navigation
-export type View = 'dashboard' | 'agents' | 'channels' | 'files' | 'costs' | 'help' | 'commands' | 'roles' | 'logs' | 'worktrees' | 'workspaces' | 'demons' | 'processes' | 'memory' | 'routing';
+export type View = 'dashboard' | 'agents' | 'channels' | 'files' | 'costs' | 'help' | 'commands' | 'roles' | 'logs' | 'worktrees' | 'workspaces' | 'demons' | 'processes' | 'memory' | 'routing' | 'performance';
 
 // Tab configuration
 export interface TabConfig {
@@ -34,6 +34,7 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: '7', view: 'costs', label: 'Costs', shortLabel: 'Cost', shortcut: '7' },
   { key: '8', view: 'processes', label: 'Processes', shortLabel: 'Proc', shortcut: '8' },
   { key: '9', view: 'demons', label: 'Demons', shortLabel: 'Dmn', shortcut: '9' },
+  { key: 'P', view: 'performance', label: 'Performance', shortLabel: 'Perf', shortcut: 'P' },
   // SYSTEM section
   { key: '0', view: 'roles', label: 'Roles', shortLabel: 'Role', shortcut: '0' },
   { key: '-', view: 'worktrees', label: 'Worktrees', shortLabel: 'Tree', shortcut: '-' },

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -772,3 +772,33 @@ export async function clearMemory(agentName: string): Promise<void> {
 export async function exportMemory(agentName: string): Promise<string> {
   return await execBc(['memory', 'export', agentName]);
 }
+
+// ============================================================================
+// Performance / Observability (#1759)
+// ============================================================================
+
+import type { AgentHealth, StatsResponse } from '../types';
+
+/**
+ * Get agent health status
+ * @returns Array of agent health status objects
+ */
+export async function getAgentHealth(): Promise<AgentHealth[]> {
+  try {
+    return await execBcJsonCached<AgentHealth[]>(['agent', 'health'], 10000);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Get workspace stats
+ * @returns Stats response with agent stats
+ */
+export async function getStats(): Promise<StatsResponse | null> {
+  try {
+    return await execBcJsonCached<StatsResponse>(['stats'], 10000);
+  } catch {
+    return null;
+  }
+}

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -314,3 +314,35 @@ export interface RoutingRule {
 export interface RoutingConfig {
   rules: RoutingRule[];
 }
+
+// Agent health status from bc agent health --json
+export interface AgentHealth {
+  name: string;
+  role: string;
+  status: 'healthy' | 'degraded' | 'stuck' | 'error';
+  last_updated: string;
+  tmux_alive: boolean;
+  state_fresh: boolean;
+  stale_duration?: string;
+  error_message?: string;
+  is_stuck?: boolean;
+  stuck_reason?: string;
+  stuck_details?: string;
+}
+
+// Agent stats from bc stats --json
+export interface AgentStats {
+  name: string;
+  role: string;
+  state: AgentState;
+  uptime: number;
+}
+
+// Stats response from bc stats --json
+export interface StatsResponse {
+  collected_at: string;
+  workspace_path: string;
+  agents: {
+    agent_stats: AgentStats[];
+  };
+}

--- a/tui/src/views/PerformanceView.tsx
+++ b/tui/src/views/PerformanceView.tsx
@@ -1,0 +1,271 @@
+/**
+ * PerformanceView - System observability and performance monitoring
+ * Issue #1759: Performance/Monitor tab for system health
+ *
+ * Displays:
+ * - Agent health status (healthy, degraded, stuck, error)
+ * - System stats (uptime, state distribution)
+ * - Cost metrics
+ */
+
+import React, { useMemo, useCallback } from 'react';
+import { Box, Text } from 'ink';
+import { Panel } from '../components/Panel';
+import { HeaderBar } from '../components/HeaderBar';
+import { Footer } from '../components/Footer';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { ErrorDisplay } from '../components/ErrorDisplay';
+import { useSystemHealth, useListNavigation, useResponsiveLayout } from '../hooks';
+import type { AgentHealth } from '../types';
+
+/**
+ * Get status color based on health status
+ */
+function getStatusColor(status: string): string {
+  switch (status) {
+    case 'healthy':
+      return 'green';
+    case 'degraded':
+      return 'yellow';
+    case 'stuck':
+      return 'red';
+    case 'error':
+      return 'red';
+    default:
+      return 'gray';
+  }
+}
+
+/**
+ * Get status icon based on health status
+ */
+function getStatusIcon(status: string): string {
+  switch (status) {
+    case 'healthy':
+      return '●';
+    case 'degraded':
+      return '◐';
+    case 'stuck':
+      return '■';
+    case 'error':
+      return '✗';
+    default:
+      return '○';
+  }
+}
+
+/**
+ * Format uptime in human-readable form
+ */
+function formatUptime(nanoseconds: number): string {
+  const seconds = Math.floor(nanoseconds / 1e9);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) {
+    return `${String(days)}d ${String(hours % 24)}h`;
+  } else if (hours > 0) {
+    return `${String(hours)}h ${String(minutes % 60)}m`;
+  } else if (minutes > 0) {
+    return `${String(minutes)}m`;
+  } else {
+    return `${String(seconds)}s`;
+  }
+}
+
+export function PerformanceView(): React.ReactElement {
+  const { data, summary, loading, error, refresh, lastRefresh } = useSystemHealth();
+  const { isCompact, isXS } = useResponsiveLayout();
+
+  // Sort health by status (errors first, then stuck, then degraded, then healthy)
+  const sortedHealth = useMemo((): AgentHealth[] => {
+    const statusOrder: Record<string, number> = { error: 0, stuck: 1, degraded: 2, healthy: 3 };
+    const healthList: AgentHealth[] = data.health;
+    return [...healthList].sort((a: AgentHealth, b: AgentHealth) => {
+      const orderA = statusOrder[a.status] ?? 4;
+      const orderB = statusOrder[b.status] ?? 4;
+      return orderA - orderB;
+    });
+  }, [data.health]);
+
+  // Handle detail view for an agent
+  const handleSelect = useCallback((_agent: AgentHealth) => {
+    // Future: Show detailed agent health view
+  }, []);
+
+  // Custom keys for performance view
+  const customKeys = useMemo(
+    () => ({
+      r: () => { void refresh(); },
+    }),
+    [refresh]
+  );
+
+  // #1759: Use useListNavigation for vim-style navigation
+  const { selectedIndex } = useListNavigation({
+    items: sortedHealth,
+    onSelect: handleSelect,
+    customKeys,
+  });
+
+  if (loading && sortedHealth.length === 0) {
+    return <LoadingIndicator message="Loading performance data..." />;
+  }
+
+  if (error && sortedHealth.length === 0) {
+    return <ErrorDisplay error={error} onRetry={() => { void refresh(); }} />;
+  }
+
+  // Compact layout for narrow terminals
+  const isNarrow = isCompact || isXS;
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      {/* Header */}
+      <HeaderBar
+        title="Performance"
+        count={summary.totalAgents}
+        loading={loading}
+        color="magenta"
+      />
+
+      {/* Summary Panel */}
+      <Panel title="System Health">
+        <Box flexDirection={isNarrow ? 'column' : 'row'} gap={isNarrow ? 0 : 2}>
+          {/* Agent Health Summary */}
+          <Box flexDirection="column">
+            <Box>
+              <Text color="green">● Healthy: </Text>
+              <Text bold>{summary.healthyAgents}</Text>
+            </Box>
+            <Box>
+              <Text color="yellow">◐ Degraded: </Text>
+              <Text bold>{summary.degradedAgents}</Text>
+            </Box>
+            <Box>
+              <Text color="red">■ Stuck: </Text>
+              <Text bold>{summary.stuckAgents}</Text>
+            </Box>
+            <Box>
+              <Text color="red">✗ Error: </Text>
+              <Text bold>{summary.errorAgents}</Text>
+            </Box>
+          </Box>
+
+          {/* Cost Summary */}
+          {!isNarrow && (
+            <Box flexDirection="column" marginLeft={4}>
+              <Box>
+                <Text dimColor>Total Cost: </Text>
+                <Text bold color="yellow">${summary.totalCost.toFixed(4)}</Text>
+              </Box>
+              {lastRefresh && (
+                <Box>
+                  <Text dimColor>Last Update: </Text>
+                  <Text>{lastRefresh.toLocaleTimeString()}</Text>
+                </Box>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Panel>
+
+      {/* Agent Health List */}
+      <Panel title="Agent Health">
+        {sortedHealth.length === 0 ? (
+          <Text dimColor>No agents found</Text>
+        ) : (
+          <Box flexDirection="column">
+            {/* Header row */}
+            <Box marginBottom={1}>
+              <Box width={3}><Text dimColor> </Text></Box>
+              <Box width={15}><Text bold dimColor>AGENT</Text></Box>
+              <Box width={10}><Text bold dimColor>STATUS</Text></Box>
+              <Box width={12}><Text bold dimColor>ROLE</Text></Box>
+              {!isNarrow && (
+                <>
+                  <Box width={6}><Text bold dimColor>TMUX</Text></Box>
+                  <Box flexGrow={1}><Text bold dimColor>MESSAGE</Text></Box>
+                </>
+              )}
+            </Box>
+
+            {/* Agent rows */}
+            {sortedHealth.map((agent, idx) => {
+              const isSelected = idx === selectedIndex;
+              const statusColor = getStatusColor(agent.status);
+              const statusIcon = getStatusIcon(agent.status);
+
+              return (
+                <Box key={agent.name}>
+                  <Box width={3}>
+                    <Text color={isSelected ? 'cyan' : undefined}>
+                      {isSelected ? '▸ ' : '  '}
+                    </Text>
+                  </Box>
+                  <Box width={15}>
+                    <Text color={isSelected ? 'cyan' : undefined} bold={isSelected}>
+                      {agent.name.length > 13 ? agent.name.slice(0, 12) + '…' : agent.name}
+                    </Text>
+                  </Box>
+                  <Box width={10}>
+                    <Text color={statusColor}>
+                      {statusIcon} {agent.status}
+                    </Text>
+                  </Box>
+                  <Box width={12}>
+                    <Text dimColor>{agent.role}</Text>
+                  </Box>
+                  {!isNarrow && (
+                    <>
+                      <Box width={6}>
+                        <Text color={agent.tmux_alive ? 'green' : 'red'}>
+                          {agent.tmux_alive ? '✓' : '✗'}
+                        </Text>
+                      </Box>
+                      <Box flexGrow={1}>
+                        <Text dimColor wrap="truncate">
+                          {agent.error_message ?? agent.stuck_details ?? '-'}
+                        </Text>
+                      </Box>
+                    </>
+                  )}
+                </Box>
+              );
+            })}
+          </Box>
+        )}
+      </Panel>
+
+      {/* Stats Panel - Uptime info */}
+      {data.stats && (
+        <Panel title="Agent Stats">
+          <Box flexDirection="row" flexWrap="wrap" gap={2}>
+            {data.stats.agents.agent_stats.slice(0, isNarrow ? 4 : 8).map((stat) => (
+              <Box key={stat.name}>
+                <Text color="cyan">{stat.name.slice(0, 8)}</Text>
+                <Text dimColor>: </Text>
+                <Text>{formatUptime(stat.uptime)}</Text>
+              </Box>
+            ))}
+            {data.stats.agents.agent_stats.length > (isNarrow ? 4 : 8) && (
+              <Text dimColor>+{data.stats.agents.agent_stats.length - (isNarrow ? 4 : 8)} more</Text>
+            )}
+          </Box>
+        </Panel>
+      )}
+
+      {/* Footer */}
+      <Footer
+        hints={[
+          { key: 'j/k', label: 'navigate' },
+          { key: 'r', label: 'refresh' },
+          { key: 'q/ESC', label: 'back' },
+        ]}
+      />
+    </Box>
+  );
+}
+
+export default PerformanceView;

--- a/tui/src/views/index.ts
+++ b/tui/src/views/index.ts
@@ -32,6 +32,7 @@ export { WorktreesView } from './WorktreesView';
 export { WorkspaceSelectorView } from './WorkspaceSelectorView';
 export { MemoryView } from './MemoryView';
 export { RoutingView } from './RoutingView';
+export { PerformanceView } from './PerformanceView';
 
 // Setup & utilities
 export { SetupWizard } from './SetupWizard';


### PR DESCRIPTION
## Summary
- Add new Performance view displaying agent health status (healthy, degraded, stuck, error)
- New useSystemHealth hook for fetching health/stats/costs data
- Vim-style navigation with useListNavigation
- Responsive layout for narrow terminals

## Changes
- `tui/src/hooks/useSystemHealth.ts` - New hook for system health data
- `tui/src/views/PerformanceView.tsx` - New Performance view component
- `tui/src/types/index.ts` - AgentHealth, StatsResponse types
- `tui/src/services/bc.ts` - getAgentHealth, getStats service functions
- `tui/src/navigation/` - Added 'performance' to View type and MONITOR section

## Test plan
- [ ] Verify Performance view loads with agent health data
- [ ] Test j/k navigation through agent list
- [ ] Test r key for refresh
- [ ] Verify responsive layout on narrow terminals

Closes #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)