### PR TITLE
feat(tui): Add I shortcut for Issues view (#1779)

### DIFF
--- a/tui/src/navigation/useKeyboardNavigation.ts
+++ b/tui/src/navigation/useKeyboardNavigation.ts
@@ -22,6 +22,7 @@ export interface UseKeyboardNavigationOptions {
  * - Tab/Shift+Tab cycles views
  * - ? shows help
  * - M goes to Memory view
+ * - I goes to Issues view
  * - ESC goes back/home
  * - Ctrl+R refreshes all data
  * - q quits the application
@@ -30,6 +31,7 @@ export interface UseKeyboardNavigationOptions {
  * Navigation now uses j/k + Enter in Drawer component.
  * Issue #1686: Added M shortcut for Memory view.
  * Issue #1765: Removed Routing tab (unused static data).
+ * Issue #1779: Added I shortcut for Issues view.
  */
 export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}): void {
   const { disabled = false, onQuit, onRefresh, onCommandPalette } = options;
@@ -58,7 +60,7 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
 
       // Issue #1467: Removed 1-9 number shortcuts
       // Navigation now uses j/k + Enter in Drawer component
-      // Global shortcuts: ? (help), M (memory)
+      // Global shortcuts: ? (help), M (memory), I (issues)
       if (input === '?') {
         const helpTab = getTabByKey('?');
         if (helpTab) {
@@ -72,6 +74,15 @@ export function useKeyboardNavigation(options: UseKeyboardNavigationOptions = {}
         const memoryTab = getTabByKey('M');
         if (memoryTab) {
           navigate(memoryTab.view);
+          return;
+        }
+      }
+
+      // I: go to Issues view (#1779)
+      if (input === 'I') {
+        const issuesTab = getTabByKey('I');
+        if (issuesTab) {
+          navigate(issuesTab.view);
           return;
         }
       }


### PR DESCRIPTION
## Summary
- Add global 'I' keyboard shortcut to navigate directly to Issues view
- Matches existing 'M' shortcut pattern for Memory view

## Context
PR #1782 updated HelpView to document the 'I' shortcut, but the actual
handler was not included before merge. This PR adds the missing handler.

## Changes
- `tui/src/navigation/useKeyboardNavigation.ts`: Add 'I' key handler

## Test plan
- [ ] Press 'I' from any view to navigate to Issues view
- [ ] Verify shortcut works like 'M' for Memory

Partially addresses #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)