### PR TITLE
fix(tui): Standardize IssuesView selection indicator to use ▸ (#1779)

### DIFF
--- a/tui/src/views/IssuesView.tsx
+++ b/tui/src/views/IssuesView.tsx
@@ -351,7 +351,7 @@ function IssueRow({ issue, selected }: IssueRowProps): React.ReactElement {
     <Box paddingX={1}>
       <Box width={8}>
         <Text color={selected ? 'cyan' : undefined} bold={selected}>
-          {selected ? '> ' : '  '}#{issue.number}
+          {selected ? '▸ ' : '  '}#{issue.number}
         </Text>
       </Box>
       <Box width={50}>


### PR DESCRIPTION
## Summary
- Fix IssuesView selection indicator from `>` to `▸` for consistency with all other list views

This addresses one of the remaining UI pattern items in #1779.

## Test plan
- [x] Build passes
- [x] Lint passes (0 errors)
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)