### PR TITLE
fix(tui): Use consistent selection indicator in IssuesView (#1779)

### DIFF
--- a/tui/src/views/IssuesView.tsx
+++ b/tui/src/views/IssuesView.tsx
@@ -351,7 +351,7 @@ function IssueRow({ issue, selected }: IssueRowProps): React.ReactElement {
     <Box paddingX={1}>
       <Box width={8}>
         <Text color={selected ? 'cyan' : undefined} bold={selected}>
-          {selected ? '> ' : '  '}#{issue.number}
+          {selected ? '▸ ' : '  '}#{issue.number}
         </Text>
       </Box>
       <Box width={50}>


### PR DESCRIPTION
## Summary
- Changed `'>'` to `'▸'` in IssuesView to match all other TUI views for UX consistency
- Part of #1779 UX improvements

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] Visual verification: IssuesView now uses `▸` like all other views

🤖 Generated with [Claude Code](https://claude.com/claude-code)