### PR TITLE
fix(tui): Add text labels to compact status indicators (#1779)

### DIFF
--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -268,15 +268,15 @@ const SystemHealthPanel = memo(function SystemHealthPanel({
           <Text color={healthColor} bold>{healthPercent}%</Text>
           <Text> · </Text>
           <PulseText color={STATUS_COLORS.working} enabled={working > 0} interval={1500}>●</PulseText>
-          <Text>{working}</Text>
+          <Text>W:{working}</Text>
           <Text> · </Text>
           <Text color={STATUS_COLORS.idle}>●</Text>
-          <Text>{idle}</Text>
+          <Text>I:{idle}</Text>
           {stuck > 0 && (
             <>
               <Text> · </Text>
               <Text color={STATUS_COLORS.warning}>●</Text>
-              <Text>{stuck}</Text>
+              <Text>S:{stuck}</Text>
             </>
           )}
         </Box>


### PR DESCRIPTION
## Summary
- Add abbreviated labels (W:/I:/S:) to compact dashboard status indicators for accessibility

This helps colorblind users understand agent status without relying solely on color:

**Before:** `●{working} · ●{idle} · ●{stuck}`
**After:**  `●W:{working} · ●I:{idle} · ●S:{stuck}`

Addresses #1779 accessibility item: "Color-only status indicators need text labels for colorblind users"

## Test plan
- [x] Build passes
- [x] Lint passes (0 errors)
- [x] All 2664 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)