### PR TITLE
docs: Rebrand from 'Mission Control' to 'Orchestration for AI agents'

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -114,7 +114,7 @@ release:
   header: |
     ## bc {{ .Tag }}
 
-    Mission control for AI agents.
+    Orchestration for AI agents.
   footer: |
     ---
 
@@ -128,7 +128,7 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
     homepage: https://github.com/rpuneet/bc
-    description: Mission control for AI agents
+    description: Orchestration for AI agents
     license: MIT
     skip_upload: auto
     install: |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Version](https://img.shields.io/badge/go-1.22+-blue.svg)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-> **Mission control for AI agents.** Coordinate teams of AI agents working together on your codebase.
+> **Orchestration for AI agents.** Coordinate teams of AI agents working together on your codebase.
 
 `bc` is a CLI-first orchestration system for coordinating teams of AI agents to work on software development projects. It provides a structured, observable, and persistent environment for AI-driven engineering.
 


### PR DESCRIPTION
## Summary
- Updated tagline from "Mission control for AI agents" to "Orchestration for AI agents" across:
  - README.md hero section
  - .goreleaser.yml release header
  - .goreleaser.yml Homebrew description

## Test plan
- [x] Verified README.md renders correctly
- [x] Verified .goreleaser.yml syntax is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)