### PR TITLE
fix(tui): Add text labels to symbolic status indicators for accessibility (#1779)

### DIFF
--- a/tui/src/components/channels/ChannelRow.tsx
+++ b/tui/src/components/channels/ChannelRow.tsx
@@ -34,11 +34,11 @@ export function ChannelRow({ channel, selected, unreadCount }: ChannelRowProps):
   const memberInfo = ` ${String(channel.members.length)}m`;
 
   // Format unread badge with 'new' label to clarify meaning (#1364)
-  // "●" for 1 unread, "N new" for multiple
+  // #1779: Always include text label alongside symbol for accessibility
   const unreadBadge = unreadCount > 0
     ? unreadCount === 1
-      ? ' ●'
-      : ` ${unreadCount > 99 ? '99+' : String(unreadCount)} new`
+      ? ' ● 1 new'
+      : ` ● ${unreadCount > 99 ? '99+' : String(unreadCount)} new`
     : '';
 
   // Build single text line to avoid nested Text truncation issues on narrow terminals

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -260,6 +260,7 @@ const SystemHealthPanel = memo(function SystemHealthPanel({
   const healthColor = healthPercent >= 80 ? HEALTH_COLORS.healthy : healthPercent >= 50 ? HEALTH_COLORS.warning : HEALTH_COLORS.critical;
 
   // #1352: Compact borderless layout for narrow terminals
+  // #1779: Use full text labels for accessibility (screen reader support)
   if (isNarrow) {
     return (
       <Box flexDirection="column" marginBottom={1}>
@@ -268,15 +269,15 @@ const SystemHealthPanel = memo(function SystemHealthPanel({
           <Text color={healthColor} bold>{healthPercent}%</Text>
           <Text> · </Text>
           <PulseText color={STATUS_COLORS.working} enabled={working > 0} interval={1500}>●</PulseText>
-          <Text>W:{working}</Text>
+          <Text> {working} working</Text>
           <Text> · </Text>
-          <Text color={STATUS_COLORS.idle}>●</Text>
-          <Text>I:{idle}</Text>
+          <Text color={STATUS_COLORS.idle}>○</Text>
+          <Text> {idle} idle</Text>
           {stuck > 0 && (
             <>
               <Text> · </Text>
-              <Text color={STATUS_COLORS.warning}>●</Text>
-              <Text>S:{stuck}</Text>
+              <Text color={STATUS_COLORS.warning}>⚠</Text>
+              <Text> {stuck} stuck</Text>
             </>
           )}
         </Box>


### PR DESCRIPTION
## Summary

- Add text labels alongside symbolic indicators (●, ⚠, ✗) at narrow terminal widths for screen reader accessibility
- Dashboard `SystemHealthPanel`: Change abbreviated `W:`/`I:`/`S:` to full "working"/"idle"/"stuck" labels
- ChannelRow: Change standalone `●` for single unread to `● 1 new` for consistent text labeling

## Test plan

- [x] Run `bun test` - all 3306 tests pass
- [x] Run `bun run lint` - no new errors
- [ ] Manual test at 80x24 terminal width to verify text fits
- [ ] Screen reader testing (optional)

Fixes remaining accessibility item from #1779.

🤖 Generated with [Claude Code](https://claude.ai/code)