### PR TITLE
fix(tui): Polish #1779 - Extract UI limits to constants, add search clear hints

### DIFF
--- a/tui/src/constants/index.ts
+++ b/tui/src/constants/index.ts
@@ -9,3 +9,4 @@ export * from './timings';
 export * from './dimensions';
 export * from './cache';
 export * from './colors';
+export * from './limits';

--- a/tui/src/constants/limits.ts
+++ b/tui/src/constants/limits.ts
@@ -1,0 +1,79 @@
+/**
+ * Display limits and truncation constants for UI elements
+ *
+ * Issue #1779: Extract hardcoded UI limits to configurable constants
+ */
+
+/**
+ * Text truncation limits for display elements
+ */
+export const TRUNCATION = {
+  /** Agent/process/demon name truncation length */
+  NAME_SHORT: 12,
+  /** Role/command name truncation length */
+  NAME_MEDIUM: 22,
+  /** Command name truncation length */
+  COMMAND_NAME: 25,
+  /** Description truncation length */
+  DESCRIPTION: 45,
+  /** Message/content truncation in lists */
+  MESSAGE: 70,
+  /** Long content preview truncation */
+  PREVIEW: 100,
+  /** Prompt preview truncation */
+  PROMPT_PREVIEW: 200,
+  /** Issue body preview truncation */
+  ISSUE_BODY: 500,
+} as const;
+
+/**
+ * Maximum items to display in lists before showing "and N more"
+ */
+export const DISPLAY_LIMITS = {
+  /** Experiences shown in memory detail view */
+  EXPERIENCES: 10,
+  /** Search results shown in memory search */
+  SEARCH_RESULTS: 15,
+  /** Comments shown in issue detail */
+  ISSUE_COMMENTS: 3,
+  /** Capabilities shown in role row preview */
+  CAPABILITIES_PREVIEW: 3,
+  /** Top roles shown in dashboard */
+  TOP_ROLES: 3,
+  /** Recent activity events shown in agent detail */
+  RECENT_ACTIVITY: 8,
+  /** Orphaned worktrees shown in warning */
+  ORPHANED_WORKTREES: 5,
+  /** Performance metrics shown in dashboard */
+  TOP_METRICS: 10,
+} as const;
+
+/**
+ * Column width constants for table layouts
+ */
+export const COLUMN_WIDTHS = {
+  /** Selection indicator width (▸ + space) */
+  SELECTION: 3,
+  /** Timestamp column width */
+  TIMESTAMP: 9,
+  /** Short timestamp (HH:MM:SS) */
+  TIMESTAMP_SHORT: 8,
+  /** Date-inclusive timestamp (MM/DD HH:MM) */
+  TIMESTAMP_DATE: 12,
+  /** Agent name column */
+  AGENT_NAME: 12,
+  /** Role name column */
+  ROLE_NAME: 15,
+  /** Status column */
+  STATUS: 9,
+  /** PID column */
+  PID: 7,
+  /** Port column */
+  PORT: 6,
+  /** Uptime column */
+  UPTIME: 8,
+  /** Short command preview */
+  COMMAND_SHORT: 20,
+  /** Full command preview */
+  COMMAND_FULL: 22,
+} as const;

--- a/tui/src/views/CommandsView.tsx
+++ b/tui/src/views/CommandsView.tsx
@@ -376,7 +376,7 @@ export const CommandsView: React.FC<CommandsViewProps> = (_props = {}) => {
             ? 'c: clear output | Esc: close | q: back'
             : filteredCommands.length === 0
             ? 'No commands found | /: search | q: back'
-            : 'j/k: navigate | g/G: top/bottom | /: search | Enter: run | f: favorite | q/ESC: back'}
+            : `j/k: navigate | g/G: top/bottom | /: search${search.query ? ' | c: clear' : ''} | Enter: run | f: favorite | q/ESC: back`}
         </Text>
       </Box>
     </Box>

--- a/tui/src/views/IssuesView.tsx
+++ b/tui/src/views/IssuesView.tsx
@@ -12,6 +12,7 @@ import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { useIssues, useListNavigation } from '../hooks';
 import { truncate } from '../utils';
+import { DISPLAY_LIMITS, TRUNCATION } from '../constants';
 import type { GHIssue } from '../services/bc';
 
 // Issue type labels with color mapping
@@ -205,8 +206,8 @@ export function IssuesView(_props: IssuesViewProps = {}): React.ReactElement {
                   marginTop={0}
                 >
                   <Text wrap="wrap">
-                    {selectedIssue.body.slice(0, 500)}
-                    {selectedIssue.body.length > 500 ? '...' : ''}
+                    {selectedIssue.body.slice(0, TRUNCATION.ISSUE_BODY)}
+                    {selectedIssue.body.length > TRUNCATION.ISSUE_BODY ? '...' : ''}
                   </Text>
                 </Box>
               </Box>
@@ -216,17 +217,17 @@ export function IssuesView(_props: IssuesViewProps = {}): React.ReactElement {
             {selectedIssue.comments && selectedIssue.comments.length > 0 && (
               <Box marginTop={1} flexDirection="column">
                 <Text dimColor>Comments ({selectedIssue.comments.length}):</Text>
-                {selectedIssue.comments.slice(0, 3).map((comment, idx) => (
+                {selectedIssue.comments.slice(0, DISPLAY_LIMITS.ISSUE_COMMENTS).map((comment, idx) => (
                   <Box key={idx} marginTop={1} flexDirection="column">
                     <Box>
                       <Text color="cyan">{comment.author.login}</Text>
                       <Text dimColor> ({formatRelativeDate(comment.createdAt)})</Text>
                     </Box>
-                    <Text wrap="wrap">{truncate(comment.body, 200)}</Text>
+                    <Text wrap="wrap">{truncate(comment.body, TRUNCATION.PROMPT_PREVIEW)}</Text>
                   </Box>
                 ))}
-                {selectedIssue.comments.length > 3 && (
-                  <Text dimColor>... +{selectedIssue.comments.length - 3} more comments</Text>
+                {selectedIssue.comments.length > DISPLAY_LIMITS.ISSUE_COMMENTS && (
+                  <Text dimColor>... +{selectedIssue.comments.length - DISPLAY_LIMITS.ISSUE_COMMENTS} more comments</Text>
                 )}
               </Box>
             )}

--- a/tui/src/views/MemoryView.tsx
+++ b/tui/src/views/MemoryView.tsx
@@ -16,6 +16,7 @@ import { useNavigation } from '../navigation/NavigationContext';
 import { useDisableInput, useListNavigation } from '../hooks';
 import { getMemoryList, getMemory, searchMemory, clearMemory } from '../services/bc';
 import { truncate } from '../utils';
+import { DISPLAY_LIMITS, TRUNCATION } from '../constants';
 import type { AgentMemorySummary, AgentMemory, MemorySearchResult } from '../types';
 
 // #1594: Using empty interface for future extensibility, props removed
@@ -459,7 +460,7 @@ function MemoryDetailView({ memory, activeTab }: MemoryDetailViewProps): React.R
             <Text dimColor>No experiences recorded</Text>
           ) : (
             <Box flexDirection="column">
-              {memory.experiences.slice(0, 10).map((exp, idx) => (
+              {memory.experiences.slice(0, DISPLAY_LIMITS.EXPERIENCES).map((exp, idx) => (
                 <Box key={exp.id || idx} marginBottom={1} flexDirection="column">
                   <Box>
                     <Text color="cyan">[{formatTime(exp.timestamp)}]</Text>
@@ -471,11 +472,11 @@ function MemoryDetailView({ memory, activeTab }: MemoryDetailViewProps): React.R
                       <Text dimColor> ({exp.category})</Text>
                     )}
                   </Box>
-                  <Text wrap="wrap">{truncate(exp.message, 70)}</Text>
+                  <Text wrap="wrap">{truncate(exp.message, TRUNCATION.MESSAGE)}</Text>
                 </Box>
               ))}
-              {memory.experiences.length > 10 && (
-                <Text dimColor>... and {memory.experiences.length - 10} more</Text>
+              {memory.experiences.length > DISPLAY_LIMITS.EXPERIENCES && (
+                <Text dimColor>... and {memory.experiences.length - DISPLAY_LIMITS.EXPERIENCES} more</Text>
               )}
             </Box>
           )
@@ -487,7 +488,7 @@ function MemoryDetailView({ memory, activeTab }: MemoryDetailViewProps): React.R
               {memory.learnings.map((learning, idx) => (
                 <Box key={learning.topic || idx} marginBottom={1} flexDirection="column">
                   <Text bold color="yellow">{learning.topic}</Text>
-                  <Text wrap="wrap">{truncate(learning.content, 100)}</Text>
+                  <Text wrap="wrap">{truncate(learning.content, TRUNCATION.PREVIEW)}</Text>
                 </Box>
               ))}
             </Box>
@@ -523,7 +524,7 @@ function SearchResultsView({ query, results }: SearchResultsViewProps): React.Re
           <Text dimColor>No results found</Text>
         ) : (
           <Box flexDirection="column">
-            {results.slice(0, 15).map((result, idx) => (
+            {results.slice(0, DISPLAY_LIMITS.SEARCH_RESULTS).map((result, idx) => (
               <Box key={idx} marginBottom={1} flexDirection="column">
                 <Box>
                   <Text color="cyan">{result.agent}</Text>
@@ -533,8 +534,8 @@ function SearchResultsView({ query, results }: SearchResultsViewProps): React.Re
                 <Text wrap="wrap">{truncate(result.content, 80)}</Text>
               </Box>
             ))}
-            {results.length > 15 && (
-              <Text dimColor>... and {results.length - 15} more</Text>
+            {results.length > DISPLAY_LIMITS.SEARCH_RESULTS && (
+              <Text dimColor>... and {results.length - DISPLAY_LIMITS.SEARCH_RESULTS} more</Text>
             )}
           </Box>
         )}

--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -13,6 +13,7 @@ import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { useAgents, useDebounce, useDisableInput, useListNavigation } from '../hooks';
 import { truncate } from '../utils';
+import { DISPLAY_LIMITS, TRUNCATION } from '../constants';
 import type { Role } from '../types';
 import { getRoles, getRole, deleteRole } from '../services/bc';
 
@@ -123,6 +124,7 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
   const customKeys = useMemo(
     () => ({
       '/': () => { setSearchMode(true); },
+      'c': () => { setSearchQuery(''); },
       'd': () => {
         // Only allow delete for non-builtin roles (checked in modal)
         setConfirmDelete(true);
@@ -330,7 +332,7 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
         <Text dimColor>
           {searchMode
             ? 'Type to search, Enter/Esc to exit'
-            : 'j/k: navigate | g/G: top/bottom | Enter: details | d: delete | r: refresh | q/ESC: back'}
+            : `j/k: navigate | g/G: top/bottom | /: search${searchQuery ? ' | c: clear' : ''} | Enter: details | d: delete | r: refresh | q/ESC: back`}
         </Text>
       </Box>
     </Box>
@@ -349,8 +351,8 @@ interface RoleRowProps {
 function RoleRow({ role, selected, agentCount, nameWidth }: RoleRowProps): React.ReactElement {
   const capabilitiesStr =
     role.capabilities.length > 0
-      ? role.capabilities.slice(0, 3).join(', ') +
-        (role.capabilities.length > 3 ? '...' : '')
+      ? role.capabilities.slice(0, DISPLAY_LIMITS.CAPABILITIES_PREVIEW).join(', ') +
+        (role.capabilities.length > DISPLAY_LIMITS.CAPABILITIES_PREVIEW ? '...' : '')
       : '-';
 
   // #971 fix: Use dynamic width, truncate with 3 chars reserved for "▸ " indicator
@@ -438,7 +440,7 @@ function RoleDetails({ role, agentCount }: RoleDetailsProps): React.ReactElement
               paddingX={1}
             >
               <Text dimColor wrap="wrap">
-                {truncate(role.prompt, 200)}
+                {truncate(role.prompt, TRUNCATION.PROMPT_PREVIEW)}
               </Text>
             </Box>
           </Box>

--- a/tui/src/views/WorktreesView.tsx
+++ b/tui/src/views/WorktreesView.tsx
@@ -11,6 +11,7 @@ import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { useListNavigation } from '../hooks';
+import { DISPLAY_LIMITS } from '../constants';
 import type { Worktree } from '../types';
 
 /**
@@ -140,11 +141,11 @@ export const WorktreesView: React.FC = () => {
         <Box marginTop={1} flexDirection="column" borderStyle="single" borderColor="yellow" padding={1}>
           <Text>This will remove {orphanedWorktrees.length} orphaned worktree(s):</Text>
           <Box marginTop={1} flexDirection="column">
-            {orphanedWorktrees.slice(0, 5).map((wt) => (
+            {orphanedWorktrees.slice(0, DISPLAY_LIMITS.ORPHANED_WORKTREES).map((wt) => (
               <Text key={wt.path} color="red">- {wt.agent}: {formatPath(wt.path)}</Text>
             ))}
-            {orphanedWorktrees.length > 5 && (
-              <Text dimColor>... and {orphanedWorktrees.length - 5} more</Text>
+            {orphanedWorktrees.length > DISPLAY_LIMITS.ORPHANED_WORKTREES && (
+              <Text dimColor>... and {orphanedWorktrees.length - DISPLAY_LIMITS.ORPHANED_WORKTREES} more</Text>
             )}
           </Box>
           <Box marginTop={1}>


### PR DESCRIPTION
## Summary
- Add `tui/src/constants/limits.ts` with TRUNCATION and DISPLAY_LIMITS constants for hardcoded UI numbers
- Update RolesView and CommandsView to show dynamic "c: clear" hint when search is active
- Add 'c' key handler to RolesView to clear search (was missing)
- Update MemoryView, IssuesView, WorktreesView to use new constants

## Changes
- **New file**: `tui/src/constants/limits.ts` with 3 constant groups:
  - `TRUNCATION`: Text truncation limits (NAME_SHORT=12, DESCRIPTION=45, ISSUE_BODY=500, etc.)
  - `DISPLAY_LIMITS`: Max items in lists (EXPERIENCES=10, SEARCH_RESULTS=15, ISSUE_COMMENTS=3, etc.)
  - `COLUMN_WIDTHS`: Table column width constants

- **RolesView**: Added `c` key handler and dynamic footer hint
- **CommandsView**: Added dynamic footer hint for search clear
- **MemoryView**: Use DISPLAY_LIMITS for experiences/search results, TRUNCATION for messages
- **IssuesView**: Use DISPLAY_LIMITS for comments, TRUNCATION for body preview
- **WorktreesView**: Use DISPLAY_LIMITS for orphaned worktrees display

## Test plan
- [x] `bun run build` - compiles without errors
- [x] `bun run lint` - passes (only pre-existing warnings)
- [x] `bun test` - 3301 pass, 5 skip (pre-existing tmux integration failures)
- [x] Specific view tests all pass (MemoryView, RolesView, IssuesView, WorktreesView, CommandsView)

Fixes #1779 (polish items)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)