### PR TITLE
refactor(tui): Extract UI limits to constants - Part 2 (#1779)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -16,6 +16,7 @@ import {
 import { useTheme } from './theme';
 import { UnreadProvider, useKeybindingHints, useResponsiveLayout, HintsProvider, useHintsContext, DisableInputProvider, useDisableInput } from './hooks';
 import { useThemeConfig } from './config';
+import { UI_ELEMENTS } from './constants';
 import { RootProvider } from './providers';
 import { Dashboard } from './views/Dashboard';
 import { AgentsView } from './views/AgentsView';
@@ -171,8 +172,11 @@ function AppContent({ themeConfig }: AppContentProps): React.ReactElement {
   const terminalWidth = stdout.columns;
 
   // #1611 fix: Calculate responsive margins for command palette overlay
-  // Center the palette horizontally with minimum margin of 4
-  const commandPaletteMarginLeft = Math.max(4, Math.floor((terminalWidth - 60) / 2));
+  // Center the palette horizontally with minimum margin
+  const commandPaletteMarginLeft = Math.max(
+    UI_ELEMENTS.COMMAND_PALETTE_MIN_MARGIN,
+    Math.floor((terminalWidth - UI_ELEMENTS.COMMAND_PALETTE_WIDTH) / 2)
+  );
 
   return (
     <Box flexDirection="column" padding={1} width={terminalWidth} height={terminalHeight} overflow="hidden">

--- a/tui/src/components/ActivityFeed.tsx
+++ b/tui/src/components/ActivityFeed.tsx
@@ -8,6 +8,7 @@ import { Box, Text, useStdout } from 'ink';
 import { Panel } from './Panel';
 import { useLogs, getSeverityColor, getSeverityIcon } from '../hooks';
 import { truncate } from '../utils';
+import { DATA_LIMITS, POLL_INTERVALS } from '../constants';
 import type { LogSeverity } from '../hooks';
 import type { LogEntry } from '../types';
 
@@ -110,8 +111,8 @@ export function ActivityFeed({
   const terminalWidth = stdout.columns || 80;
 
   const { data: logs, loading, severityFilter: currentFilter } = useLogs({
-    tail: 50,
-    pollInterval: 3000,
+    tail: DATA_LIMITS.ACTIVITY_TAIL,
+    pollInterval: POLL_INTERVALS.DEFAULT,
   });
 
   // Apply local severity filter or use hook filter

--- a/tui/src/components/CommandPalette.tsx
+++ b/tui/src/components/CommandPalette.tsx
@@ -6,6 +6,7 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { searchCommands, getAllCommands, groupCommandsByCategory, type BcCommand } from '../types/commands';
+import { UI_ELEMENTS } from '../constants';
 
 export interface CommandPaletteProps {
   /** Whether the palette is visible */
@@ -173,7 +174,7 @@ export function CommandPalette({
 
       {/* Divider */}
       <Box>
-        <Text dimColor>{'─'.repeat(40)}</Text>
+        <Text dimColor>{'─'.repeat(UI_ELEMENTS.DIVIDER_WIDTH)}</Text>
       </Box>
 
       {/* Results */}

--- a/tui/src/components/PerformanceDebugPanel.tsx
+++ b/tui/src/components/PerformanceDebugPanel.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { usePerformanceOptional } from '../hooks';
+import { UI_ELEMENTS } from '../constants';
 
 interface PerformanceDebugPanelProps {
   /** Maximum number of metrics to display */
@@ -69,7 +70,7 @@ export function PerformanceDebugPanel({
       </Box>
 
       <Box marginTop={0}>
-        <Text dimColor>{'─'.repeat(50)}</Text>
+        <Text dimColor>{'─'.repeat(UI_ELEMENTS.DIVIDER_WIDTH_WIDE)}</Text>
       </Box>
 
       {/* Header */}

--- a/tui/src/constants/dimensions.ts
+++ b/tui/src/constants/dimensions.ts
@@ -107,3 +107,50 @@ export const SPACING = {
   /** Large spacing */
   LG: 8,
 } as const;
+
+/**
+ * Terminal fallback dimensions
+ * Used when stdout dimensions are unavailable
+ */
+export const TERMINAL_DEFAULTS = {
+  /** Default terminal rows (standard 80x24) */
+  ROWS: 24,
+  /** Default terminal columns (standard 80x24) */
+  COLS: 80,
+  /** Minimum usable height for views */
+  MIN_VIEW_HEIGHT: 10,
+  /** Reserved lines for header/footer/hints */
+  RESERVED_LINES: 6,
+} as const;
+
+/**
+ * UI element dimensions
+ * For dividers, separators, and decorative elements
+ */
+export const UI_ELEMENTS = {
+  /** Standard divider width */
+  DIVIDER_WIDTH: 40,
+  /** Narrow divider width (for compact views) */
+  DIVIDER_WIDTH_NARROW: 30,
+  /** Wide divider width (for full-width views) */
+  DIVIDER_WIDTH_WIDE: 50,
+  /** Command palette width */
+  COMMAND_PALETTE_WIDTH: 60,
+  /** Command palette minimum margin */
+  COMMAND_PALETTE_MIN_MARGIN: 4,
+} as const;
+
+/**
+ * Data fetch limits
+ * For tail, pagination, and batch sizes
+ */
+export const DATA_LIMITS = {
+  /** Default log tail limit */
+  LOG_TAIL: 100,
+  /** Activity feed tail limit */
+  ACTIVITY_TAIL: 50,
+  /** Process output lines */
+  PROCESS_LINES: 50,
+  /** Maximum file size to preview (100KB) */
+  MAX_PREVIEW_SIZE: 100 * 1024,
+} as const;

--- a/tui/src/views/FilesView.tsx
+++ b/tui/src/views/FilesView.tsx
@@ -18,6 +18,7 @@ import { ErrorDisplay } from '../components/ErrorDisplay';
 import type { Worktree } from '../types';
 import { useTheme } from '../theme';
 import { useFileTree, useGitStatus, useResponsiveLayout, useListNavigation, type FileTreeEntry, type GitFileStatus } from '../hooks';
+import { DATA_LIMITS, UI_ELEMENTS } from '../constants';
 import * as fs from 'fs';
 
 // Focus areas within the view
@@ -552,9 +553,9 @@ function FilePreview({ path, maxHeight }: FilePreviewProps): React.ReactElement 
     try {
       const stats = fs.statSync(path);
 
-      // Don't preview files larger than 100KB
-      if (stats.size > 100 * 1024) {
-        setError('File too large to preview (>100KB)');
+      // Don't preview files larger than max preview size
+      if (stats.size > DATA_LIMITS.MAX_PREVIEW_SIZE) {
+        setError(`File too large to preview (>${String(DATA_LIMITS.MAX_PREVIEW_SIZE / 1024)}KB)`);
         setLoading(false);
         return;
       }
@@ -600,7 +601,7 @@ function FilePreview({ path, maxHeight }: FilePreviewProps): React.ReactElement 
   return (
     <Box flexDirection="column" marginTop={1}>
       <Text dimColor>{path}</Text>
-      <Text dimColor>{'─'.repeat(30)}</Text>
+      <Text dimColor>{'─'.repeat(UI_ELEMENTS.DIVIDER_WIDTH_NARROW)}</Text>
       {visibleLines.map((line, idx) => (
         <Text key={idx} wrap="truncate">
           {line}

--- a/tui/src/views/HelpView.tsx
+++ b/tui/src/views/HelpView.tsx
@@ -8,6 +8,7 @@ import React, { useState, useMemo, memo } from 'react';
 import { Box, Text, useStdout, useInput } from 'ink';
 import { useTheme } from '../theme';
 import { useDisableInput } from '../hooks';
+import { TERMINAL_DEFAULTS, UI_ELEMENTS } from '../constants';
 
 interface ShortcutSection {
   type: 'section';
@@ -111,8 +112,11 @@ export function HelpView(): React.ReactElement {
     return acc + 1 + section.shortcuts.length + 1; // title + shortcuts + margin
   }, 0);
 
-  // Available height for content (reserve 4 lines for header/footer/hints)
-  const availableHeight = Math.max(10, (stdout.rows || 24) - 6);
+  // Available height for content (reserve lines for header/footer/hints)
+  const availableHeight = Math.max(
+    TERMINAL_DEFAULTS.MIN_VIEW_HEIGHT,
+    (stdout.rows || TERMINAL_DEFAULTS.ROWS) - TERMINAL_DEFAULTS.RESERVED_LINES
+  );
   const needsScroll = totalLines > availableHeight;
   const maxScroll = Math.max(0, totalLines - availableHeight);
 
@@ -143,7 +147,7 @@ export function HelpView(): React.ReactElement {
       if (currentLine >= scrollOffset && currentLine < scrollOffset + availableHeight) {
         visibleContent.push(
           <Text key="title" bold color="cyan">KEYBOARD SHORTCUTS</Text>,
-          <Text key="divider" dimColor>{'─'.repeat(40)}</Text>
+          <Text key="divider" dimColor>{'─'.repeat(UI_ELEMENTS.DIVIDER_WIDTH)}</Text>
         );
       }
       currentLine += 2;
@@ -151,7 +155,7 @@ export function HelpView(): React.ReactElement {
       if (currentLine >= scrollOffset && currentLine < scrollOffset + availableHeight) {
         visibleContent.push(
           <Box key="footer" marginTop={1} flexDirection="column">
-            <Text dimColor>{'─'.repeat(40)}</Text>
+            <Text dimColor>{'─'.repeat(UI_ELEMENTS.DIVIDER_WIDTH)}</Text>
             <Text dimColor>
               Theme: {theme.name} ({isDark ? 'dark' : 'light'} mode)
             </Text>

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -10,6 +10,8 @@ import { useLogs, getSeverityColor, getSeverityIcon, useDebounce, useListNavigat
 import { useFocus } from '../navigation/FocusContext';
 import { PulseText } from '../components/AnimatedText';
 import { ErrorDisplay } from '../components/ErrorDisplay';
+import { DATA_LIMITS } from '../constants';
+import { POLL_INTERVALS } from '../constants/timings';
 import type { LogSeverity } from '../hooks/useLogs';
 import type { LogEntry } from '../types';
 
@@ -137,9 +139,9 @@ export const LogsView: React.FC<LogsViewProps> = () => {
   const terminalWidth = stdout.columns;
 
   const { data: logs, loading, error, refresh, filterBySeverity, severityFilter } = useLogs({
-    tail: 100,
+    tail: DATA_LIMITS.LOG_TAIL,
     autoPoll: true,
-    pollInterval: 5000,
+    pollInterval: POLL_INTERVALS.LOGS,
   });
 
   // #1601: UI state consolidated with useReducer

--- a/tui/src/views/ProcessesView.tsx
+++ b/tui/src/views/ProcessesView.tsx
@@ -13,6 +13,7 @@ import type { Column } from '../components/Table';
 import { StatusBadge } from '../components/StatusBadge';
 import { HeaderBar } from '../components/HeaderBar';
 import { ViewWrapper } from '../components/ViewWrapper';
+import { DATA_LIMITS } from '../constants';
 import type { Process } from '../types';
 
 /**
@@ -256,7 +257,7 @@ interface ProcessLogViewerProps {
 function ProcessLogViewer({ process, onBack }: ProcessLogViewerProps) {
   const { data: logs, loading, error, refresh } = useProcessLogs({
     name: process.name,
-    lines: 50,
+    lines: DATA_LIMITS.PROCESS_LINES,
   });
   const [scrollOffset, setScrollOffset] = useState(0);
   const maxVisibleLines = 15;


### PR DESCRIPTION
## Summary
Complementary to #1814 - this PR extracts a different set of hardcoded UI values to centralized constants.

**New constant groups in `dimensions.ts`:**
- `TERMINAL_DEFAULTS`: Default rows (24), cols (80), min view height, reserved lines
- `UI_ELEMENTS`: Divider widths (standard/narrow/wide), command palette dimensions
- `DATA_LIMITS`: Log tail (100), activity tail (50), process lines (50), max preview size (100KB)

**Updated components:**
- HelpView: terminal defaults, divider width
- LogsView: log tail, poll interval
- ActivityFeed: activity tail, poll interval  
- CommandPalette: divider width
- FilesView: max preview size, divider width
- ProcessesView: process lines
- PerformanceDebugPanel: divider width
- app.tsx: command palette dimensions

## Relation to #1814
#1814 (eng-05) handles TRUNCATION, DISPLAY_LIMITS, COLUMN_WIDTHS and search clear hints.
This PR handles TERMINAL_DEFAULTS, UI_ELEMENTS, DATA_LIMITS - completely different constants and views.
Both PRs are needed for full constants coverage.

## Test plan
- [x] `bun run lint` - passes (0 errors)
- [x] `bun test` - 3301 pass (pre-existing AgentDetailView failures unrelated)
- [x] Specific view tests pass: HelpView (70), LogsView (35)

Addresses #1779 (polish: hardcoded UI limits)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)