### PR TITLE
refactor(tui): Standardize error display across views (#1779)

### DIFF
--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -19,6 +19,7 @@ import { useNavigation } from '../navigation/NavigationContext';
 import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 import { useAgentGroups } from '../hooks/useAgentGroups';
 import { PulseText } from '../components/AnimatedText';
+import { ErrorDisplay } from '../components/ErrorDisplay';
 import { AgentDetailView } from './AgentDetailView';
 import { execBc } from '../services/bc';
 import type { Agent } from '../types';
@@ -304,11 +305,7 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
   }
 
   if (error) {
-    return (
-      <Box padding={1}>
-        <Text color="red">Error: {error}</Text>
-      </Box>
-    );
+    return <ErrorDisplay error={error} onRetry={() => { void refresh(); }} />;
   }
 
   return (

--- a/tui/src/views/ChannelsView.tsx
+++ b/tui/src/views/ChannelsView.tsx
@@ -13,6 +13,7 @@ import { useChannelsWithUnread, useDisableInput, useListNavigation } from '../ho
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { PulseText } from '../components/AnimatedText';
+import { ErrorDisplay } from '../components/ErrorDisplay';
 import { ChannelRow, ChannelHistoryView } from '../components/channels';
 import type { Channel } from '../types';
 
@@ -36,7 +37,7 @@ export function ChannelsView(_props: ChannelsViewProps = {}): React.ReactElement
   // #1594: Use context instead of prop drilling
   const { isDisabled: disableInput } = useDisableInput();
   // #1129: Use useChannelsWithUnread for proper unread message tracking
-  const { channels, loading: channelsLoading, error: channelsError } = useChannelsWithUnread();
+  const { channels, loading: channelsLoading, error: channelsError, refresh } = useChannelsWithUnread();
   const [viewMode, setViewMode] = useState<'list' | 'history'>('list');
   const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
   const { setFocus } = useFocus();
@@ -98,12 +99,7 @@ export function ChannelsView(_props: ChannelsViewProps = {}): React.ReactElement
   }
 
   if (channelsError) {
-    return (
-      <Box flexDirection="column">
-        <Text bold>Channels</Text>
-        <Text color="red">Error: {channelsError}</Text>
-      </Box>
-    );
+    return <ErrorDisplay error={channelsError} onRetry={() => { void refresh(); }} />;
   }
 
   if (viewMode === 'history' && selectedChannel) {

--- a/tui/src/views/CostsView.tsx
+++ b/tui/src/views/CostsView.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { Box, Text } from 'ink';
 import { Panel } from '../components/Panel';
+import { ErrorDisplay } from '../components/ErrorDisplay';
 import { useCosts } from '../hooks';
 import { useResponsiveLayout } from '../hooks/useResponsiveLayout';
 
@@ -19,7 +20,7 @@ export function CostsView(_props: CostsViewProps = {}): React.ReactElement {
   // #1365: Extend borderless to 100-120 cols (isMD) to prevent box fragmentation
   const isNarrow = isCompact || isMinimal || isMD;
 
-  const { data: costs, loading, error } = useCosts();
+  const { data: costs, loading, error, refresh } = useCosts();
 
   if (loading) {
     return (
@@ -31,12 +32,7 @@ export function CostsView(_props: CostsViewProps = {}): React.ReactElement {
   }
 
   if (error) {
-    return (
-      <Box flexDirection="column">
-        <Text bold>Costs</Text>
-        <Text color="red">Error: {error}</Text>
-      </Box>
-    );
+    return <ErrorDisplay error={error} onRetry={() => { void refresh(); }} />;
   }
 
   if (!costs) {

--- a/tui/src/views/FilesView.tsx
+++ b/tui/src/views/FilesView.tsx
@@ -14,6 +14,7 @@
 import React, { useState, useEffect, useCallback, useMemo, useReducer } from 'react';
 import { Box, Text, useInput } from 'ink';
 import { getWorktrees } from '../services/bc';
+import { ErrorDisplay } from '../components/ErrorDisplay';
 import type { Worktree } from '../types';
 import { useTheme } from '../theme';
 import { useFileTree, useGitStatus, useResponsiveLayout, useListNavigation, type FileTreeEntry, type GitFileStatus } from '../hooks';
@@ -119,28 +120,29 @@ export function FilesView(): React.ReactNode {
     workingDir: selectedWorktree?.path ?? '',
   });
 
+  // Load worktrees - extracted for retry support (#1779)
+  const loadWorktrees = useCallback(async (): Promise<void> => {
+    try {
+      setWorktreesLoading(true);
+      setWorktreesError(null);
+      const wts = await getWorktrees();
+      // Filter to only OK worktrees
+      const activeWorktrees = wts.filter(w => w.status === 'OK');
+      setWorktrees(activeWorktrees);
+      if (activeWorktrees.length > 0) {
+        setSelectedWorktree(activeWorktrees[0]);
+      }
+    } catch (err) {
+      setWorktreesError(err instanceof Error ? err.message : 'Failed to load worktrees');
+    } finally {
+      setWorktreesLoading(false);
+    }
+  }, []);
+
   // Load worktrees on mount
   useEffect(() => {
-    const loadWorktrees = async (): Promise<void> => {
-      try {
-        setWorktreesLoading(true);
-        setWorktreesError(null);
-        const wts = await getWorktrees();
-        // Filter to only OK worktrees
-        const activeWorktrees = wts.filter(w => w.status === 'OK');
-        setWorktrees(activeWorktrees);
-        if (activeWorktrees.length > 0) {
-          setSelectedWorktree(activeWorktrees[0]);
-        }
-      } catch (err) {
-        setWorktreesError(err instanceof Error ? err.message : 'Failed to load worktrees');
-      } finally {
-        setWorktreesLoading(false);
-      }
-    };
-
     void loadWorktrees();
-  }, []);
+  }, [loadWorktrees]);
 
   // Reset tree index when worktree changes
   useEffect(() => {
@@ -261,12 +263,7 @@ export function FilesView(): React.ReactNode {
   }
 
   if (worktreesError) {
-    return (
-      <Box flexDirection="column" padding={1}>
-        <Text color="cyan">Files</Text>
-        <Text color="red">Error: {worktreesError}</Text>
-      </Box>
-    );
+    return <ErrorDisplay error={worktreesError} onRetry={() => { void loadWorktrees(); }} />;
   }
 
   if (worktrees.length === 0) {

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -9,6 +9,7 @@ import { Box, Text, useInput, useStdout } from 'ink';
 import { useLogs, getSeverityColor, getSeverityIcon, useDebounce, useListNavigation } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { PulseText } from '../components/AnimatedText';
+import { ErrorDisplay } from '../components/ErrorDisplay';
 import type { LogSeverity } from '../hooks/useLogs';
 import type { LogEntry } from '../types';
 
@@ -345,11 +346,7 @@ export const LogsView: React.FC<LogsViewProps> = () => {
   }
 
   if (error) {
-    return (
-      <Box padding={1}>
-        <Text color="red">Error: {error}</Text>
-      </Box>
-    );
+    return <ErrorDisplay error={error} onRetry={() => { void refresh(); }} />;
   }
 
   // Calculate column widths based on terminal width

--- a/tui/src/views/WorkspaceSelectorView.tsx
+++ b/tui/src/views/WorkspaceSelectorView.tsx
@@ -6,6 +6,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { getWorkspaces } from '../services/bc';
 import { LoadingIndicator } from '../components/LoadingIndicator';
+import { ErrorDisplay } from '../components/ErrorDisplay';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { useDisableInput, useListNavigation } from '../hooks';
@@ -168,11 +169,7 @@ export const WorkspaceSelectorView: React.FC<WorkspaceSelectorViewProps> = ({
   }
 
   if (error) {
-    return (
-      <Box padding={1}>
-        <Text color="red">Error: {error}</Text>
-      </Box>
-    );
+    return <ErrorDisplay error={error} onRetry={() => { void fetchWorkspaces(); }} />;
   }
 
   // Calculate column widths

--- a/tui/src/views/WorktreesView.tsx
+++ b/tui/src/views/WorktreesView.tsx
@@ -7,6 +7,7 @@ import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { Box, Text, useInput, useStdout } from 'ink';
 import { getWorktrees, pruneWorktrees } from '../services/bc';
 import { LoadingIndicator } from '../components/LoadingIndicator';
+import { ErrorDisplay } from '../components/ErrorDisplay';
 import { HeaderBar } from '../components/HeaderBar';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
@@ -194,11 +195,7 @@ export const WorktreesView: React.FC = () => {
   }
 
   if (error) {
-    return (
-      <Box padding={1}>
-        <Text color="red">Error: {error}</Text>
-      </Box>
-    );
+    return <ErrorDisplay error={error} onRetry={() => { void fetchWorktrees(); }} />;
   }
 
   // Calculate column widths


### PR DESCRIPTION
## Summary

- Migrate 7 views from inline `<Text color="red">Error: ...</Text>` to `<ErrorDisplay>` component
- All full-screen blocking errors now show consistent red border + "Error" heading + retry hint
- ProcessesView already uses ViewWrapper which handles errors correctly (no change needed)

## Views Updated

| View | Change |
|------|--------|
| AgentsView | ErrorDisplay + refresh |
| ChannelsView | ErrorDisplay + refresh |
| CostsView | Add refresh, ErrorDisplay |
| FilesView | Extract loadWorktrees, ErrorDisplay |
| LogsView | ErrorDisplay + refresh |
| WorkspaceSelectorView | ErrorDisplay + fetchWorkspaces |
| WorktreesView | ErrorDisplay + fetchWorktrees |

## Test plan

- [x] Run `bun test` - all 3306 tests pass
- [x] Run `bun run lint` - no new errors
- [ ] Manual test error state by disconnecting network

Part of #1779 UX consistency audit.

🤖 Generated with [Claude Code](https://claude.ai/code)