### PR TITLE
fix(cmd): Memory list JSON output to stdout instead of stderr (#1817)

### DIFF
--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -843,7 +843,7 @@ type MemoryListResponse struct {
 }
 
 // listMemoryJSON outputs agent memory summaries as JSON for TUI integration.
-func listMemoryJSON(cmd *cobra.Command, rootDir string, agents []string) error {
+func listMemoryJSON(_ *cobra.Command, rootDir string, agents []string) error {
 	var summaries []AgentMemorySummary
 
 	for _, agentID := range agents {
@@ -881,13 +881,10 @@ func listMemoryJSON(cmd *cobra.Command, rootDir string, agents []string) error {
 	}
 
 	response := MemoryListResponse{Agents: summaries}
-	data, err := json.Marshal(response)
-	if err != nil {
-		return fmt.Errorf("failed to marshal response: %w", err)
-	}
-
-	cmd.Println(string(data))
-	return nil
+	// #1817: Use json.NewEncoder with os.Stdout directly (like status.go)
+	// to ensure JSON goes to stdout, not stderr via cmd.Println
+	enc := json.NewEncoder(os.Stdout)
+	return enc.Encode(response)
 }
 
 // listExperiences lists all experiences across agents.


### PR DESCRIPTION
## Summary

- Fix P2 bug where TUI Memory view showed 0 agents despite memories existing
- Root cause: `bc memory list --json` was writing JSON to stderr instead of stdout
- The TUI reads stdout, so it received empty data and returned `{ agents: [] }`
- Fix: Use `json.NewEncoder(os.Stdout).Encode()` directly, matching the pattern in status.go

## Root Cause Analysis

When spawning `bc memory list --json` via Node.js:
- Exit code: 0 (success)
- Stdout length: 0 (empty!)
- Stderr: contains the JSON

The `cmd.Println()` was somehow routing output to stderr. Using direct stdout write fixes this.

## Test plan

- [x] `bc memory list --json` now outputs to stdout
- [x] TUI simulation correctly parses 55 agents
- [x] go vet passes
- [x] go test -race passes
- [x] golangci-lint passes (0 issues)

Fixes #1817

🤖 Generated with [Claude Code](https://claude.com/claude-code)