### PR TITLE
fix(tui): Guard against undefined message/agent in ActivityFeed

### DIFF
--- a/tui/src/__tests__/components/ActivityFeed.test.tsx
+++ b/tui/src/__tests__/components/ActivityFeed.test.tsx
@@ -106,4 +106,53 @@ describe('ActivityFeed', () => {
 
     expect(output).toContain('(i/w/e/*)');
   });
+
+  it('handles entries with undefined message without crashing', async () => {
+    const { useLogs } = await import('../../hooks/useLogs');
+    (useLogs as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: [
+        {
+          ts: '2026-02-16T10:00:00Z',
+          type: 'agent.start',
+          agent: 'eng-04',
+          // message intentionally omitted — Go omitempty drops empty strings
+        },
+      ],
+      loading: false,
+      error: null,
+      severityFilter: null,
+      filterBySeverity: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    const { lastFrame } = render(<ActivityFeed />);
+    const output = lastFrame();
+
+    expect(output).toContain('eng-04');
+    expect(output).toBeDefined();
+  });
+
+  it('handles entries with undefined agent and message without crashing', async () => {
+    const { useLogs } = await import('../../hooks/useLogs');
+    (useLogs as ReturnType<typeof vi.fn>).mockReturnValue({
+      data: [
+        {
+          ts: '2026-02-16T10:00:00Z',
+          type: 'agent.start',
+          // both agent and message omitted — Go omitempty drops empty strings
+        },
+      ],
+      loading: false,
+      error: null,
+      severityFilter: null,
+      filterBySeverity: vi.fn(),
+      refresh: vi.fn(),
+    });
+
+    const { lastFrame } = render(<ActivityFeed />);
+    const output = lastFrame();
+
+    expect(output).toContain('Activity');
+    expect(output).toBeDefined();
+  });
 });

--- a/tui/src/components/ActivityFeed.tsx
+++ b/tui/src/components/ActivityFeed.tsx
@@ -61,6 +61,7 @@ function formatEventType(type: string): string {
  * /Users/username/Projects/bc-v2 → ~/Projects/bc-v2
  */
 function shortenPath(msg: string): string {
+  if (!msg) return '';
   // Replace home directory with ~
   const homeDir = process.env.HOME ?? '/Users';
   return msg.replace(new RegExp(homeDir, 'g'), '~');
@@ -222,7 +223,7 @@ const ActivityEntry = memo(function ActivityEntry({
       {!compact && (
         <Text dimColor>{formatTime(entry.ts)} </Text>
       )}
-      <Text color="cyan">{entry.agent.padEnd(10)} </Text>
+      <Text color="cyan">{(entry.agent ?? '').padEnd(10)} </Text>
       <Text color={severityColor}>{severityIcon} </Text>
       <Text color={severityColor}>{eventLabel.padEnd(12)} </Text>
       <Text>{truncate(displayMessage, maxMsgLen)}</Text>


### PR DESCRIPTION
## Summary
- **P0 fix**: Dashboard crashed with `undefined is not an object (evaluating 'msg.replace')` when Go backend emitted events with `omitempty` fields
- Added null guard in `shortenPath()` — handles undefined `message` from `json:"message,omitempty"`
- Added null coalesce on `entry.agent` render — handles undefined `agent` from `json:"agent,omitempty"`

## Changes
- `tui/src/components/ActivityFeed.tsx`: 2 null guards (lines 64, 226)
- `tui/src/__tests__/components/ActivityFeed.test.tsx`: 2 new test cases for undefined message and undefined agent+message

## Test plan
- [x] `bun test` — 944 pass, 0 fail across all component/view tests
- [x] New test: entry with undefined message renders without crash
- [x] New test: entry with undefined agent + message renders without crash
- [x] Existing ActivityFeed tests still pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)