### PR TITLE
feat: tmux log streaming, peek refactor, role prompt persistence

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -79,6 +79,20 @@ enabled = false
 # enabled = true
 
 # =============================================================================
+# Session Logging
+# =============================================================================
+[logs]
+# Directory for persistent session logs (relative to workspace root)
+# Each agent gets a log file streamed via tmux pipe-pane
+path = ".bc/logs"
+
+# Maximum log file size in bytes before lazy truncation (keeps last half)
+max_bytes = 1048576  # 1MB
+
+# Preserve ANSI escape codes in log files (for colored output in peek/TUI)
+preserve_ansi = true
+
+# =============================================================================
 # Agent Memory System
 # =============================================================================
 [memory]

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,12 @@ type ChannelsConfig struct {
 	Default []string
 }
 
+type LogsConfig struct {
+	MaxBytes     int64
+	Path         string
+	PreserveAnsi bool
+}
+
 type MemoryConfig struct {
 	Backend string
 	Path    string
@@ -169,6 +175,11 @@ var (
 	}
 	Channels = ChannelsConfig{
 		Default: []string{"general", "engineering"},
+	}
+	Logs = LogsConfig{
+		MaxBytes:     1048576,
+		Path:         ".bc/logs",
+		PreserveAnsi: true,
 	}
 	Memory = MemoryConfig{
 		Backend: "file",

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -327,6 +327,7 @@ type Agent struct {
 	HookedWork  string       `json:"hooked_work,omitempty"`
 	WorktreeDir string       `json:"worktree_dir,omitempty"`
 	MemoryDir   string       `json:"memory_dir,omitempty"`
+	LogFile     string       `json:"log_file,omitempty"`
 	Team        string       `json:"team,omitempty"`
 	Role        Role         `json:"role"`
 	State       State        `json:"state"`
@@ -620,6 +621,21 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 			if err := m.tmux.CreateSessionWithEnv(context.TODO(), name, sessionDir, agentCmd, env); err != nil {
 				return nil, fmt.Errorf("failed to recreate tmux session: %w", err)
 			}
+
+			// Resume log streaming if log file was set
+			if existing.LogFile != "" {
+				truncateLogFile(existing.LogFile, config.Logs.MaxBytes)
+				if pipeErr := m.tmux.PipePane(context.TODO(), name, existing.LogFile); pipeErr != nil {
+					log.Warn("failed to resume pipe-pane", "agent", name, "error", pipeErr)
+				}
+			} else {
+				// Set up new log pipe for agents that didn't have one
+				existing.LogFile = m.setupLogPipe(name, workspace)
+			}
+
+			// Inject bootstrap prompt on respawn (role + memories)
+			go m.sendRespawnBootstrap(name, existing, workspace)
+
 			existing.UpdatedAt = time.Now()
 			if err := m.saveState(); err != nil {
 				log.Warn("failed to save agent state", "error", err)
@@ -723,8 +739,19 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 		return nil, fmt.Errorf("failed to create tmux session: %w", err)
 	}
 
+	// Start log streaming via pipe-pane
+	agent.LogFile = m.setupLogPipe(name, workspace)
+
 	// Load role memory from prompts/<role>.md
 	agent.Memory = LoadRoleMemory(workspace, role)
+
+	// Persist role prompt in agent memory for respawn
+	if agent.Memory != nil && agent.Memory.RolePrompt != "" && agent.MemoryDir != "" {
+		memStore := memory.NewStore(workspace, name)
+		if err := memStore.SaveRolePrompt(agent.Memory.RolePrompt); err != nil {
+			log.Warn("failed to persist role prompt", "agent", name, "error", err)
+		}
+	}
 
 	// Update state
 	agent.State = StateIdle
@@ -779,6 +806,107 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 	}
 
 	return agent, nil
+}
+
+// sendRespawnBootstrap sends the role prompt and memories to a respawned agent.
+// Runs in a goroutine since it needs to wait for the agent to initialize.
+func (m *Manager) sendRespawnBootstrap(name string, agent *Agent, workspace string) {
+	time.Sleep(m.getBootstrapDelay())
+
+	var promptParts []string
+
+	// Add role prompt from memory store if available
+	if agent.MemoryDir != "" {
+		memStore := memory.NewStore(workspace, name)
+		rolePrompt, err := memStore.GetRolePrompt()
+		if err != nil {
+			log.Warn("failed to load stored role prompt", "agent", name, "error", err)
+		} else if rolePrompt != "" {
+			promptParts = append(promptParts, rolePrompt)
+		}
+	}
+
+	// Fall back to loading from role files if no stored prompt
+	if len(promptParts) == 0 && agent.Memory != nil && agent.Memory.RolePrompt != "" {
+		promptParts = append(promptParts, agent.Memory.RolePrompt)
+	}
+
+	// Load agent memories
+	if agent.MemoryDir != "" {
+		memStore := memory.NewStore(workspace, name)
+		if memStore.Exists() {
+			memCtx, memErr := memStore.GetMemoryContext(memory.DefaultMemoryLimit)
+			if memErr != nil {
+				log.Warn("failed to load agent memories for respawn", "agent", name, "error", memErr)
+			} else if memCtx != "" {
+				promptParts = append(promptParts, memCtx)
+			}
+		}
+	}
+
+	if len(promptParts) > 0 {
+		prompt := strings.Join(promptParts, "\n\n---\n\n")
+		prompt += fmt.Sprintf("\n\n---\n\nWorkspace: %s\nAgent ID: %s\n(Respawned session — continuing previous work)\n", workspace, name)
+		if err := m.tmux.SendKeys(context.TODO(), name, prompt); err != nil {
+			log.Warn("failed to send respawn bootstrap", "agent", name, "error", err)
+		}
+	}
+}
+
+// setupLogPipe creates the logs directory and starts pipe-pane for the agent.
+// Returns the log file path.
+func (m *Manager) setupLogPipe(name, workspace string) string {
+	logsDir := filepath.Join(workspace, ".bc", "logs")
+	if err := os.MkdirAll(logsDir, 0750); err != nil {
+		log.Warn("failed to create logs dir", "error", err)
+		return ""
+	}
+
+	logPath := filepath.Join(logsDir, name+".log")
+
+	// Truncate if over max size
+	truncateLogFile(logPath, config.Logs.MaxBytes)
+
+	if err := m.tmux.PipePane(context.TODO(), name, logPath); err != nil {
+		log.Warn("failed to start pipe-pane", "agent", name, "error", err)
+		return ""
+	}
+
+	log.Debug("started log streaming", "agent", name, "path", logPath)
+	return logPath
+}
+
+// truncateLogFile truncates a log file if it exceeds maxBytes.
+// Keeps the last half of the file to preserve recent output.
+func truncateLogFile(path string, maxBytes int64) {
+	if maxBytes <= 0 {
+		return
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || info.Size() <= maxBytes {
+		return
+	}
+
+	data, err := os.ReadFile(path) //nolint:gosec // path constructed from trusted workspace root
+	if err != nil {
+		log.Warn("failed to read log for truncation", "path", path, "error", err)
+		return
+	}
+
+	// Keep last half
+	half := len(data) / 2
+	// Find next newline to avoid cutting mid-line
+	for half < len(data) && data[half] != '\n' {
+		half++
+	}
+	if half < len(data) {
+		half++ // skip the newline
+	}
+
+	if err := os.WriteFile(path, data[half:], 0600); err != nil { //nolint:gosec // path constructed from trusted workspace root
+		log.Warn("failed to truncate log", "path", path, "error", err)
+	}
 }
 
 // createWorktree creates a per-agent git worktree so agents don't clobber each other.
@@ -1451,8 +1579,59 @@ func (m *Manager) SendToAgent(name, message string) error {
 }
 
 // CaptureOutput captures recent output from an agent's session.
+// Reads from the agent's log file first (includes full history with ANSI).
+// Falls back to tmux capture-pane if log file is not available.
 func (m *Manager) CaptureOutput(name string, lines int) (string, error) {
+	m.mu.RLock()
+	agent := m.agents[name]
+	m.mu.RUnlock()
+
+	// Try log file first
+	if agent != nil && agent.LogFile != "" {
+		output, err := tailFile(agent.LogFile, lines)
+		if err == nil && output != "" {
+			return output, nil
+		}
+		log.Debug("log file read failed, falling back to capture-pane", "agent", name, "error", err)
+	}
+
+	// Fall back to tmux capture-pane
 	return m.tmux.Capture(context.TODO(), name, lines)
+}
+
+// tailFile reads the last N lines from a file.
+func tailFile(path string, lines int) (string, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path from trusted agent state
+	if err != nil {
+		return "", err
+	}
+
+	if len(data) == 0 {
+		return "", nil
+	}
+
+	// Find last N lines by scanning backward
+	count := 0
+	pos := len(data) - 1
+	// Skip trailing newline
+	if pos >= 0 && data[pos] == '\n' {
+		pos--
+	}
+	for pos >= 0 {
+		if data[pos] == '\n' {
+			count++
+			if count >= lines {
+				pos++
+				break
+			}
+		}
+		pos--
+	}
+	if pos < 0 {
+		pos = 0
+	}
+
+	return string(data[pos:]), nil
 }
 
 // AttachToAgent returns the command to attach to an agent's session.

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3275,3 +3275,181 @@ func TestRemoveFromParent_AgentNotFound(t *testing.T) {
 	// Should not panic
 	m.removeFromParent("nonexistent")
 }
+
+func TestTailFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	content := "line1\nline2\nline3\nline4\nline5\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	tests := []struct { //nolint:govet // test struct alignment not critical
+		name     string
+		lines    int
+		contains []string
+	}{
+		{"last 2 lines", 2, []string{"line4", "line5"}},
+		{"last 5 lines", 5, []string{"line1", "line2", "line3", "line4", "line5"}},
+		{"more than available", 10, []string{"line1", "line2", "line3", "line4", "line5"}},
+		{"last 1 line", 1, []string{"line5"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := tailFile(path, tt.lines)
+			if err != nil {
+				t.Fatalf("tailFile failed: %v", err)
+			}
+			for _, want := range tt.contains {
+				if !strings.Contains(output, want) {
+					t.Errorf("expected output to contain %q, got %q", want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestTailFile_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.log")
+	if err := os.WriteFile(path, []byte{}, 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	output, err := tailFile(path, 10)
+	if err != nil {
+		t.Fatalf("tailFile failed: %v", err)
+	}
+	if output != "" {
+		t.Errorf("expected empty output, got %q", output)
+	}
+}
+
+func TestTailFile_NotFound(t *testing.T) {
+	_, err := tailFile("/nonexistent/path/file.log", 10)
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestTruncateLogFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	// Create a file with known content
+	var content strings.Builder
+	for i := range 100 {
+		fmt.Fprintf(&content, "line %d: some log output here\n", i)
+	}
+	if err := os.WriteFile(path, []byte(content.String()), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	info, _ := os.Stat(path)
+	originalSize := info.Size()
+
+	// Truncate with max = half of original size (should trigger truncation)
+	truncateLogFile(path, originalSize/2)
+
+	info, _ = os.Stat(path)
+	if info.Size() >= originalSize {
+		t.Errorf("expected truncated size < %d, got %d", originalSize, info.Size())
+	}
+	// Should be roughly half
+	if info.Size() > originalSize*3/4 {
+		t.Errorf("expected roughly half size, got %d (original %d)", info.Size(), originalSize)
+	}
+}
+
+func TestTruncateLogFile_BelowThreshold(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "small.log")
+
+	content := "small log\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// File is below threshold — should not be modified
+	truncateLogFile(path, 1048576)
+
+	data, _ := os.ReadFile(path) //nolint:gosec // test file path from t.TempDir
+	if string(data) != content {
+		t.Errorf("file should not have changed, got %q", string(data))
+	}
+}
+
+func TestTruncateLogFile_ZeroMaxBytes(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.log")
+
+	content := "some content\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	// Zero maxBytes means no truncation
+	truncateLogFile(path, 0)
+
+	data, _ := os.ReadFile(path) //nolint:gosec // test file path from t.TempDir
+	if string(data) != content {
+		t.Errorf("file should not have changed with maxBytes=0")
+	}
+}
+
+func TestTruncateLogFile_FileNotFound(t *testing.T) {
+	// Should not panic on nonexistent file
+	truncateLogFile("/nonexistent/path/file.log", 1024)
+}
+
+func TestCaptureOutputFromLogFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a manager with mock tmux
+	m := newTestManager(t)
+
+	// Create a log file
+	logsDir := filepath.Join(dir, "logs")
+	if err := os.MkdirAll(logsDir, 0750); err != nil {
+		t.Fatalf("failed to create logs dir: %v", err)
+	}
+	logPath := filepath.Join(logsDir, "test-agent.log")
+	logContent := "log line 1\nlog line 2\nlog line 3\n"
+	if err := os.WriteFile(logPath, []byte(logContent), 0600); err != nil {
+		t.Fatalf("failed to write log: %v", err)
+	}
+
+	// Add agent with LogFile set
+	m.agents["test-agent"] = &Agent{
+		Name:    "test-agent",
+		LogFile: logPath,
+		State:   StateIdle,
+	}
+
+	output, err := m.CaptureOutput("test-agent", 10)
+	if err != nil {
+		t.Fatalf("CaptureOutput failed: %v", err)
+	}
+
+	if !strings.Contains(output, "log line 1") {
+		t.Errorf("expected output to contain log content, got %q", output)
+	}
+}
+
+func TestCaptureOutputFallback(t *testing.T) {
+	// When agent has no LogFile, should fall through to tmux capture
+	m := newTestManager(t)
+	m.agents["test-agent"] = &Agent{
+		Name:  "test-agent",
+		State: StateIdle,
+		// No LogFile set
+	}
+
+	// This will call tmux.Capture which will fail since there's no real session,
+	// but we're testing the fallback path
+	_, err := m.CaptureOutput("test-agent", 10)
+	// Error is expected since the mock tmux won't have the session
+	_ = err
+}

--- a/pkg/memory/memory.go
+++ b/pkg/memory/memory.go
@@ -226,6 +226,29 @@ func (s *Store) Clear(clearExperiences, clearLearningsFlag bool) (*ClearResult, 
 	return result, nil
 }
 
+// SaveRolePrompt persists the role prompt for later retrieval (e.g., on respawn).
+func (s *Store) SaveRolePrompt(prompt string) error {
+	if err := os.MkdirAll(s.memoryDir, 0750); err != nil {
+		return fmt.Errorf("failed to create memory directory: %w", err)
+	}
+	if err := os.WriteFile(s.rolePromptPath(), []byte(prompt), 0600); err != nil { //nolint:gosec // trusted path
+		return fmt.Errorf("failed to save role prompt: %w", err)
+	}
+	return nil
+}
+
+// GetRolePrompt reads the stored role prompt. Returns empty string if not found.
+func (s *Store) GetRolePrompt() (string, error) {
+	data, err := os.ReadFile(s.rolePromptPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read role prompt: %w", err)
+	}
+	return string(data), nil
+}
+
 // MemoryDir returns the path to the agent's memory directory.
 func (s *Store) MemoryDir() string {
 	return s.memoryDir
@@ -237,6 +260,10 @@ func (s *Store) experiencesPath() string {
 
 func (s *Store) learningsPath() string {
 	return filepath.Join(s.memoryDir, "learnings.md")
+}
+
+func (s *Store) rolePromptPath() string {
+	return filepath.Join(s.memoryDir, "role_prompt.md")
 }
 
 // splitLines splits byte data into lines.
@@ -593,8 +620,8 @@ func parseLearningsByTopic(content string) map[string][]string {
 }
 
 // GetMemoryContext returns formatted memories suitable for prompt injection.
-// It loads the most recent experiences (up to limit) and all learnings,
-// formatting them for inclusion in an agent's context.
+// It loads the stored role prompt, most recent experiences (up to limit),
+// and all learnings, formatting them for inclusion in an agent's context.
 // Returns empty string if no memories exist (new agent).
 func (s *Store) GetMemoryContext(limit int) (string, error) {
 	if limit <= 0 {
@@ -602,6 +629,14 @@ func (s *Store) GetMemoryContext(limit int) (string, error) {
 	}
 
 	var parts []string
+
+	// Load stored role prompt
+	rolePrompt, err := s.GetRolePrompt()
+	if err != nil {
+		log.Warn("failed to load role prompt for context", "error", err)
+	} else if rolePrompt != "" {
+		parts = append(parts, "## Role\n\n"+rolePrompt)
+	}
 
 	// Load experiences (most recent first)
 	experiences, err := s.GetExperiences()

--- a/pkg/memory/memory_test.go
+++ b/pkg/memory/memory_test.go
@@ -1800,6 +1800,100 @@ func TestStore_MergeLearnings_EmptySource(t *testing.T) {
 	}
 }
 
+func TestStore_SaveRolePrompt(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, "test-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	prompt := "You are an engineer. Implement features and write tests."
+	if err := store.SaveRolePrompt(prompt); err != nil {
+		t.Fatalf("save role prompt failed: %v", err)
+	}
+
+	// Verify file exists
+	data, err := os.ReadFile(filepath.Join(dir, ".bc", "memory", "test-agent", "role_prompt.md")) //nolint:gosec // test file path from t.TempDir
+	if err != nil {
+		t.Fatalf("failed to read role prompt file: %v", err)
+	}
+	if string(data) != prompt {
+		t.Errorf("expected prompt %q, got %q", prompt, string(data))
+	}
+}
+
+func TestStore_GetRolePrompt(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, "test-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	prompt := "You are a QA engineer."
+	if err := store.SaveRolePrompt(prompt); err != nil {
+		t.Fatalf("save failed: %v", err)
+	}
+
+	got, err := store.GetRolePrompt()
+	if err != nil {
+		t.Fatalf("get role prompt failed: %v", err)
+	}
+	if got != prompt {
+		t.Errorf("expected %q, got %q", prompt, got)
+	}
+}
+
+func TestStore_GetRolePromptMissing(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, "test-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	got, err := store.GetRolePrompt()
+	if err != nil {
+		t.Fatalf("get role prompt failed: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string for missing prompt, got %q", got)
+	}
+}
+
+func TestStore_GetMemoryContextIncludesRolePrompt(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir, "test-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Save a role prompt
+	prompt := "You are an engineer specializing in Go backend development."
+	if err := store.SaveRolePrompt(prompt); err != nil {
+		t.Fatalf("save role prompt failed: %v", err)
+	}
+
+	// Add some experiences to ensure we get output
+	if err := store.RecordExperience(Experience{
+		TaskType:    "implementation",
+		Description: "built log streaming",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("record experience failed: %v", err)
+	}
+
+	ctx, err := store.GetMemoryContext(10)
+	if err != nil {
+		t.Fatalf("get memory context failed: %v", err)
+	}
+
+	if !strings.Contains(ctx, "## Role") {
+		t.Error("expected memory context to contain '## Role' section")
+	}
+	if !strings.Contains(ctx, prompt) {
+		t.Error("expected memory context to include role prompt content")
+	}
+}
+
 func TestParseLearningsByTopic(t *testing.T) {
 	content := `# Agent Learnings
 

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -565,6 +565,32 @@ func (m *Manager) SetEnvironment(ctx context.Context, name, key, value string) e
 	return nil
 }
 
+// PipePane starts or stops streaming a session's output to a log file.
+// If logPath is non-empty, starts piping output via "cat >> logPath".
+// If logPath is empty, stops any existing pipe.
+func (m *Manager) PipePane(ctx context.Context, name, logPath string) error {
+	fullName := m.SessionName(name)
+
+	if logPath == "" {
+		// Stop pipe
+		cmd := m.command(ctx, "tmux", "pipe-pane", "-t", fullName)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to stop pipe-pane for %s: %w (%s)", fullName, err, string(output))
+		}
+		return nil
+	}
+
+	// Start pipe: stream output to log file with append
+	pipeCmd := fmt.Sprintf("cat >> %s", logPath)
+	cmd := m.command(ctx, "tmux", "pipe-pane", "-t", fullName, pipeCmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start pipe-pane for %s: %w (%s)", fullName, err, string(output))
+	}
+	return nil
+}
+
 // generateBufferName creates a unique buffer name for tmux operations.
 // This prevents race conditions when multiple goroutines send keys concurrently.
 func generateBufferName() string {

--- a/pkg/tmux/session_test.go
+++ b/pkg/tmux/session_test.go
@@ -1724,3 +1724,75 @@ func TestCache_KillServerInvalidatesCache(t *testing.T) {
 		t.Errorf("expected %d calls after KillServer, got %d", expectedCalls, callCount)
 	}
 }
+
+func TestPipePane(t *testing.T) {
+	mock, records := recordingMock("")
+	m := &Manager{
+		SessionPrefix:   "bc-",
+		execCommand:     mock,
+		hasSessionCache: make(map[string]bool),
+	}
+
+	err := m.PipePane(testCtx(), "agent1", "/tmp/test.log")
+	if err != nil {
+		t.Fatalf("PipePane failed: %v", err)
+	}
+
+	// Verify the tmux command was called with correct args
+	found := false
+	for _, r := range *records {
+		if r.name == "tmux" && len(r.args) >= 4 && r.args[0] == "pipe-pane" {
+			found = true
+			if r.args[3] != "cat >> /tmp/test.log" {
+				t.Errorf("expected pipe command 'cat >> /tmp/test.log', got %q", r.args[3])
+			}
+		}
+	}
+	if !found {
+		t.Error("expected tmux pipe-pane call")
+	}
+}
+
+func TestPipePaneStop(t *testing.T) {
+	mock, records := recordingMock("")
+	m := &Manager{
+		SessionPrefix:   "bc-",
+		execCommand:     mock,
+		hasSessionCache: make(map[string]bool),
+	}
+
+	// Empty logPath stops the pipe
+	err := m.PipePane(testCtx(), "agent1", "")
+	if err != nil {
+		t.Fatalf("PipePane stop failed: %v", err)
+	}
+
+	// Verify pipe-pane was called without a command (stops pipe)
+	found := false
+	for _, r := range *records {
+		if r.name == "tmux" && len(r.args) >= 1 && r.args[0] == "pipe-pane" {
+			found = true
+			// Should not have a pipe command arg (just -t and session name)
+			if len(r.args) > 3 {
+				t.Errorf("expected no pipe command for stop, got %d args", len(r.args))
+			}
+		}
+	}
+	if !found {
+		t.Error("expected tmux pipe-pane call")
+	}
+}
+
+func TestPipePaneError(t *testing.T) {
+	mock := mockCmd("", "no session", 1)
+	m := &Manager{
+		SessionPrefix:   "bc-",
+		execCommand:     mock,
+		hasSessionCache: make(map[string]bool),
+	}
+
+	err := m.PipePane(testCtx(), "agent1", "/tmp/test.log")
+	if err == nil {
+		t.Error("expected error from PipePane with failed session")
+	}
+}

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -16,23 +16,27 @@ import (
 const ConfigVersion = 2
 
 // V2Config represents the TOML-based workspace configuration for bc v2.
+// Field order is optimized by fieldalignment for minimal struct padding.
 type V2Config struct {
-	// New config sections (Issue #1771)
-	Providers ProvidersConfig `toml:"providers"`
-	Services  ServicesConfig  `toml:"services"`
-
-	// Legacy config section (deprecated, use Providers/Services instead)
-	Tools ToolsConfig `toml:"tools"`
-
-	// Other config sections
+	Services    ServicesConfig    `toml:"services"`
+	Providers   ProvidersConfig   `toml:"providers"`
+	Tools       ToolsConfig       `toml:"tools"`
 	Memory      MemoryConfig      `toml:"memory"`
 	TUI         TUIConfig         `toml:"tui"`
 	User        UserConfig        `toml:"user"`
 	Workspace   WorkspaceConfig   `toml:"workspace"`
 	Worktrees   WorktreesConfig   `toml:"worktrees"`
 	Channels    ChannelsConfig    `toml:"channels"`
+	Logs        LogsConfig        `toml:"logs"`
 	Performance PerformanceConfig `toml:"performance"`
 	Roster      RosterConfig      `toml:"roster"`
+}
+
+// LogsConfig configures persistent session log streaming.
+type LogsConfig struct {
+	Path         string `toml:"path"`
+	MaxBytes     int64  `toml:"max_bytes"`
+	PreserveAnsi bool   `toml:"preserve_ansi"`
 }
 
 // UserConfig holds user identity settings.
@@ -229,6 +233,11 @@ func DefaultV2Config(name string) V2Config {
 				Command: "gemini --yolo",
 				Enabled: true,
 			},
+		},
+		Logs: LogsConfig{
+			Path:         ".bc/logs",
+			MaxBytes:     1048576, // 1MB
+			PreserveAnsi: true,
 		},
 		Memory: MemoryConfig{
 			Backend: "file",

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -38,6 +38,82 @@ func TestDefaultV2Config(t *testing.T) {
 	if cfg.Roster.QA != 0 {
 		t.Errorf("expected roster.qa = 0, got %d", cfg.Roster.QA)
 	}
+	// Logs config defaults
+	if cfg.Logs.Path != ".bc/logs" {
+		t.Errorf("expected logs.path '.bc/logs', got %q", cfg.Logs.Path)
+	}
+	if cfg.Logs.MaxBytes != 1048576 {
+		t.Errorf("expected logs.max_bytes 1048576, got %d", cfg.Logs.MaxBytes)
+	}
+	if !cfg.Logs.PreserveAnsi {
+		t.Error("expected logs.preserve_ansi true")
+	}
+}
+
+func TestParseV2ConfigWithLogs(t *testing.T) {
+	tomlData := []byte(`
+[workspace]
+name = "test"
+version = 2
+
+[tools]
+default = "claude"
+
+[tools.claude]
+command = "claude"
+enabled = true
+
+[memory]
+backend = "file"
+path = ".bc/memory"
+
+[logs]
+path = ".bc/custom-logs"
+max_bytes = 2097152
+preserve_ansi = false
+`)
+	cfg, err := ParseV2Config(tomlData)
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+	if cfg.Logs.Path != ".bc/custom-logs" {
+		t.Errorf("expected logs.path '.bc/custom-logs', got %q", cfg.Logs.Path)
+	}
+	if cfg.Logs.MaxBytes != 2097152 {
+		t.Errorf("expected logs.max_bytes 2097152, got %d", cfg.Logs.MaxBytes)
+	}
+	if cfg.Logs.PreserveAnsi {
+		t.Error("expected logs.preserve_ansi false")
+	}
+}
+
+func TestLogsConfigSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := DefaultV2Config("test")
+	cfg.Logs.Path = ".bc/my-logs"
+	cfg.Logs.MaxBytes = 512000
+	cfg.Logs.PreserveAnsi = false
+
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	loaded, err := LoadV2Config(path)
+	if err != nil {
+		t.Fatalf("failed to load: %v", err)
+	}
+
+	if loaded.Logs.Path != ".bc/my-logs" {
+		t.Errorf("expected path '.bc/my-logs', got %q", loaded.Logs.Path)
+	}
+	if loaded.Logs.MaxBytes != 512000 {
+		t.Errorf("expected max_bytes 512000, got %d", loaded.Logs.MaxBytes)
+	}
+	if loaded.Logs.PreserveAnsi {
+		t.Error("expected preserve_ansi false")
+	}
 }
 
 func TestParseV2Config(t *testing.T) {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -326,6 +326,9 @@ func (w *Workspace) AgentsDir() string {
 
 // LogsDir returns the logs directory.
 func (w *Workspace) LogsDir() string {
+	if w.V2Config != nil && w.V2Config.Logs.Path != "" {
+		return filepath.Join(w.RootDir, w.V2Config.Logs.Path)
+	}
 	return filepath.Join(w.Config.StateDir, "logs")
 }
 


### PR DESCRIPTION
## Summary

- **Tmux log streaming** (#1838): Add `[logs]` config section and `pipe-pane` integration — each agent gets persistent `.bc/logs/<name>.log` with lazy truncation at configurable max_bytes
- **Peek refactor** (#1840 backend): `CaptureOutput` reads from stored log file first (with ANSI colors), falls back to `tmux capture-pane` for backward compat
- **Role prompt persistence** (#1841): Role prompts saved to `.bc/memory/<name>/role_prompt.md` on spawn, injected into memory context on respawn

## Changes

| Package | What |
|---------|------|
| `config.toml` + `config/config.go` | `[logs]` section: path, max_bytes, preserve_ansi |
| `pkg/workspace/config.go` | `LogsConfig` struct, defaults in `DefaultV2Config` |
| `pkg/workspace/workspace.go` | `LogsDir()` respects v2 config path |
| `pkg/tmux/session.go` | `PipePane()` method for streaming/stopping |
| `pkg/agent/agent.go` | `LogFile` field, `setupLogPipe`, `truncateLogFile`, `tailFile`, `sendRespawnBootstrap`, refactored `CaptureOutput` |
| `pkg/memory/memory.go` | `SaveRolePrompt`, `GetRolePrompt`, `GetMemoryContext` includes role |

## Test plan

- [x] 20+ new tests across 4 packages (workspace, tmux, agent, memory)
- [x] `make lint` — 0 issues
- [x] `go test -race ./pkg/...` — all pass
- [ ] Manual: `bc agent create test-01 --role engineer` → verify `.bc/logs/test-01.log` created
- [ ] Manual: `bc agent peek test-01` → verify output from log file with ANSI colors
- [ ] Manual: verify `.bc/memory/test-01/role_prompt.md` exists

## TUI impact

- `Agent` JSON type gains `log_file` field (optional)
- Peek output now includes ANSI codes — TUI should handle/render them

Closes #1838, closes #1841, closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)