### PR TITLE
feat(tui): Vim-style :q/:q! quit commands in CommandBar (#1836)

### DIFF
--- a/tui/src/components/CommandBar.tsx
+++ b/tui/src/components/CommandBar.tsx
@@ -8,7 +8,7 @@
 import React, { useState } from 'react';
 import { Box, Text, useInput } from 'ink';
 import type { View } from '../navigation/NavigationContext';
-import { searchCommands, resolveCommand, type MatchedCommand } from '../navigation/viewCommands';
+import { searchCommands, resolveCommand, resolveAction, type MatchedCommand } from '../navigation/viewCommands';
 
 interface CommandBarProps {
   onSelect: (view: View) => void;
@@ -30,11 +30,18 @@ export function CommandBar({ onSelect, onClose }: CommandBarProps): React.ReactE
     }
 
     if (key.return) {
-      // Try exact resolve first, then use selected suggestion
+      // #1836: Check action commands first (:q, :q!, :quit)
+      const action = resolveAction(input);
+      if (action === 'quit' || action === 'force-quit') {
+        process.exit(0);
+        return;
+      }
+
+      // Try exact view resolve first, then use selected suggestion
       const resolved = resolveCommand(input);
       if (resolved) {
         onSelect(resolved);
-      } else if (matches.length > 0) {
+      } else if (matches.length > 0 && matches[selectedIndex].command.view) {
         onSelect(matches[selectedIndex].command.view);
       }
       return;

--- a/tui/src/navigation/__tests__/viewCommands.test.ts
+++ b/tui/src/navigation/__tests__/viewCommands.test.ts
@@ -1,0 +1,90 @@
+/**
+ * viewCommands tests
+ * #1836: Vim-style command mode — :q, :q!, action commands
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { searchCommands, resolveCommand, resolveAction } from '../viewCommands';
+
+describe('viewCommands', () => {
+  describe('resolveCommand (view navigation)', () => {
+    test('resolves full command names', () => {
+      expect(resolveCommand('dashboard')).toBe('dashboard');
+      expect(resolveCommand('agents')).toBe('agents');
+      expect(resolveCommand('help')).toBe('help');
+    });
+
+    test('resolves aliases', () => {
+      expect(resolveCommand('dash')).toBe('dashboard');
+      expect(resolveCommand('ag')).toBe('agents');
+      expect(resolveCommand('?')).toBe('help');
+    });
+
+    test('returns null for unknown commands', () => {
+      expect(resolveCommand('unknown')).toBeNull();
+      expect(resolveCommand('')).toBeNull();
+    });
+
+    test('is case-insensitive', () => {
+      expect(resolveCommand('Dashboard')).toBe('dashboard');
+      expect(resolveCommand('AGENTS')).toBe('agents');
+    });
+  });
+
+  describe('resolveAction (#1836)', () => {
+    test('resolves :q to quit', () => {
+      expect(resolveAction('q')).toBe('quit');
+    });
+
+    test('resolves :quit to quit', () => {
+      expect(resolveAction('quit')).toBe('quit');
+    });
+
+    test('resolves :q! to force-quit', () => {
+      expect(resolveAction('q!')).toBe('force-quit');
+    });
+
+    test('resolves :quit! to force-quit', () => {
+      expect(resolveAction('quit!')).toBe('force-quit');
+    });
+
+    test('returns null for non-action commands', () => {
+      expect(resolveAction('dashboard')).toBeNull();
+      expect(resolveAction('agents')).toBeNull();
+      expect(resolveAction('')).toBeNull();
+    });
+
+    test('does not conflict with view commands', () => {
+      // 'q' is an action, not a view
+      expect(resolveCommand('q')).toBeNull();
+      expect(resolveAction('q')).toBe('quit');
+    });
+  });
+
+  describe('searchCommands', () => {
+    test('returns all commands when query is empty', () => {
+      const results = searchCommands('');
+      expect(results.length).toBeGreaterThan(0);
+    });
+
+    test('finds commands by prefix', () => {
+      const results = searchCommands('dash');
+      expect(results.some(r => r.command.command === 'dashboard')).toBe(true);
+    });
+
+    test('finds commands by alias', () => {
+      const results = searchCommands('ag');
+      expect(results.some(r => r.command.command === 'agents')).toBe(true);
+    });
+
+    test('includes action commands in search results (#1836)', () => {
+      const results = searchCommands('q');
+      expect(results.some(r => r.command.command === 'quit')).toBe(true);
+    });
+
+    test('ranks exact matches higher', () => {
+      const results = searchCommands('help');
+      expect(results[0].command.command).toBe('help');
+    });
+  });
+});

--- a/tui/src/navigation/viewCommands.ts
+++ b/tui/src/navigation/viewCommands.ts
@@ -1,5 +1,6 @@
 /**
  * View command registry for k9s-style :command navigation
+ * #1836: Extended with action commands (:q, :q!)
  */
 
 import type { View } from './NavigationContext';
@@ -10,6 +11,19 @@ export interface ViewCommand {
   view: View;
   section: string;
 }
+
+/** Action commands that perform an operation instead of navigating */
+export interface ActionCommand {
+  command: string;
+  aliases: string[];
+  action: string;
+  section: string;
+}
+
+export const ACTION_COMMANDS: ActionCommand[] = [
+  { command: 'quit', aliases: ['q'], action: 'quit', section: 'ACTION' },
+  { command: 'quit!', aliases: ['q!'], action: 'force-quit', section: 'ACTION' },
+];
 
 export const VIEW_COMMANDS: ViewCommand[] = [
   { command: 'dashboard', aliases: ['dash', 'd'], view: 'dashboard', section: 'CORE' },
@@ -56,7 +70,8 @@ export interface MatchedCommand {
 }
 
 /**
- * Search view commands with fuzzy matching
+ * Search view and action commands with fuzzy matching
+ * #1836: Includes action commands in results
  */
 export function searchCommands(query: string): MatchedCommand[] {
   if (!query) {
@@ -82,6 +97,24 @@ export function searchCommands(query: string): MatchedCommand[] {
     }
   }
 
+  // #1836: Also search action commands
+  for (const cmd of ACTION_COMMANDS) {
+    let bestScore = fuzzyScore(query, cmd.command);
+    for (const alias of cmd.aliases) {
+      const aliasScore = fuzzyScore(query, alias);
+      if (aliasScore > bestScore) {
+        bestScore = aliasScore;
+      }
+    }
+    if (bestScore > 0) {
+      // Wrap action as MatchedCommand with a placeholder view for display
+      results.push({
+        command: { command: cmd.command, aliases: cmd.aliases, view: '' as View, section: cmd.section },
+        score: bestScore,
+      });
+    }
+  }
+
   return results.sort((a, b) => b.score - a.score);
 }
 
@@ -93,6 +126,20 @@ export function resolveCommand(input: string): View | null {
   for (const cmd of VIEW_COMMANDS) {
     if (cmd.command === q || cmd.aliases.includes(q)) {
       return cmd.view;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a command string to an action (exact match or alias)
+ * #1836: Supports :q, :q!, :quit, :quit!
+ */
+export function resolveAction(input: string): string | null {
+  const q = input.trim();
+  for (const cmd of ACTION_COMMANDS) {
+    if (cmd.command === q || cmd.aliases.includes(q)) {
+      return cmd.action;
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- Add action command support to CommandBar alongside existing view navigation
- `:q` and `:q!` (or `:quit`/`:quit!`) now exit the TUI from command mode
- Action commands appear in fuzzy search suggestions when typing `:`

## Changes
- `tui/src/navigation/viewCommands.ts`: `ActionCommand` type, `ACTION_COMMANDS` registry, `resolveAction()`, action commands included in `searchCommands()`
- `tui/src/components/CommandBar.tsx`: Check action commands before view resolution on Enter
- `tui/src/navigation/__tests__/viewCommands.test.ts`: 15 new tests

## Test plan
- [x] `:q` resolves to quit action
- [x] `:q!` resolves to force-quit action
- [x] `:quit` and `:quit!` resolve correctly
- [x] Action commands don't conflict with view commands
- [x] Existing view navigation (`:agents`, `:dash`, etc.) still works
- [x] Fuzzy search includes action commands in results
- [x] 15 new tests, all passing

Fixes #1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)