### PR TITLE
fix(tui): P1 design system — symbols, borders, footer hints (#1847)

### DIFF
--- a/tui/src/components/Panel.tsx
+++ b/tui/src/components/Panel.tsx
@@ -1,5 +1,6 @@
-import React, { memo } from 'react';
+import React, { memo, useContext } from 'react';
 import { Box, Text } from 'ink';
+import ThemeContext from '../theme/ThemeContext';
 
 export interface PanelProps {
   title?: string;
@@ -31,11 +32,15 @@ export const Panel = memo(function Panel({
   // Default minHeight ensures title + at least 1 line of content is visible
   const effectiveMinHeight = minHeight ?? (title ? 4 : 3);
 
+  // #1847 P1b: Use theme's borderFocused color instead of hardcoded 'blue'
+  const themeContext = useContext(ThemeContext);
+  const focusedColor = themeContext ? themeContext.theme.colors.borderFocused : 'cyan';
+
   return (
     <Box
       flexDirection="column"
       borderStyle="single"
-      borderColor={focused ? 'blue' : borderColor}
+      borderColor={focused ? focusedColor : borderColor}
       width={width}
       height={height}
       minHeight={effectiveMinHeight}

--- a/tui/src/theme/StatusColors.ts
+++ b/tui/src/theme/StatusColors.ts
@@ -26,7 +26,7 @@ export type StatusColor = keyof typeof STATUS_COLORS;
  * Status symbols (for accessibility - symbol + color combination)
  */
 export const STATUS_SYMBOLS = {
-  working: '⊙',  // Filled circle - actively working
+  working: '●',  // Filled circle - actively working
   idle: '○',     // Empty circle - not working
   done: '✓',     // Checkmark - completed
   error: '✗',    // X mark - failed

--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -8,6 +8,7 @@ import { LoadingIndicator } from '../components/LoadingIndicator';
 import { useFocus } from '../navigation/FocusContext';
 import { useAgentDetails } from '../hooks/useAgentDetails';
 import { MetricCard } from '../components/MetricCard';
+import { Footer } from '../components/Footer';
 
 // Safe wrapper for useInput that handles test environments
 const useSafeInput = (handler: Parameters<typeof inkUseInput>[0]) => {
@@ -509,16 +510,29 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
       </Box>
 
       {/* Footer with keybindings */}
-      <Box marginTop={1} paddingX={1}>
-        <Text dimColor wrap="truncate">
-          {inputMode
-            ? 'Enter: send | Esc: cancel'
-            : activeTab === 'live'
-              ? '1-4: tabs | j/k: scroll | g/G: top/bottom | f: follow | a: attach | q/ESC: back'
-              : '1-4: tabs | i: message | a: attach | r: refresh | q/ESC: back'}
-        </Text>
-        {loading && <Text color="gray"> (refreshing...)</Text>}
-      </Box>
+      {inputMode ? (
+        <Footer hints={[
+          { key: 'Enter', label: 'send' },
+          { key: 'Esc', label: 'cancel' },
+        ]} />
+      ) : activeTab === 'live' ? (
+        <Footer hints={[
+          { key: '1-4', label: 'tabs' },
+          { key: 'j/k', label: 'scroll' },
+          { key: 'g/G', label: 'top/bottom' },
+          { key: 'f', label: 'follow' },
+          { key: 'a', label: 'attach' },
+          { key: 'q/Esc', label: 'back' },
+        ]} />
+      ) : (
+        <Footer hints={[
+          { key: '1-4', label: 'tabs' },
+          { key: 'i', label: 'message' },
+          { key: 'a', label: 'attach' },
+          { key: 'r', label: 'refresh' },
+          { key: 'q/Esc', label: 'back' },
+        ]} />
+      )}
     </Box>
   );
 };

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -24,6 +24,7 @@ import { execBc } from '../services/bc';
 import type { Agent } from '../types';
 
 // Import extracted components
+import { Footer } from '../components/Footer';
 import {
   AgentList,
   AgentActions,
@@ -386,11 +387,16 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
       )}
 
       {/* Footer */}
-      <Box marginTop={1}>
-        <Text color="gray" wrap="truncate">
-          j/k: nav | Enter: attach | d: detail | v: {groupedView ? 'flat' : 'grouped'} | /: search{search.query ? ' | c: clear' : ''} | p: peek | r: refresh | q: back
-        </Text>
-      </Box>
+      <Footer hints={[
+        { key: 'j/k', label: 'nav' },
+        { key: 'Enter', label: 'attach' },
+        { key: 'd', label: 'detail' },
+        { key: 'v', label: groupedView ? 'flat' : 'grouped' },
+        { key: '/', label: 'search' },
+        ...(search.query ? [{ key: 'c', label: 'clear' }] : []),
+        { key: 'p', label: 'peek' },
+        { key: 'r', label: 'refresh' },
+      ]} />
     </Box>
   );
 };

--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -9,6 +9,7 @@ import { Box, Text, useInput, useStdout } from 'ink';
 import { useLogs, getSeverityColor, getSeverityIcon, useDebounce, useListNavigation } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { ErrorDisplay } from '../components/ErrorDisplay';
+import { Footer } from '../components/Footer';
 import { DATA_LIMITS } from '../constants';
 import { POLL_INTERVALS } from '../constants/timings';
 import type { LogSeverity } from '../hooks/useLogs';
@@ -459,11 +460,17 @@ export const LogsView: React.FC<LogsViewProps> = () => {
       </Box>
 
       {/* Footer - view-specific hints only, global hints (Tab/q/?) in app footer */}
-      <Box marginTop={1}>
-        <Text dimColor wrap="truncate">
-          j/k: nav | g/G: top/bottom | Enter: details | /: search | s: severity | a: agent | t: time | c: clear | r: refresh
-        </Text>
-      </Box>
+      <Footer hints={[
+        { key: 'j/k', label: 'nav' },
+        { key: 'g/G', label: 'top/bottom' },
+        { key: 'Enter', label: 'details' },
+        { key: '/', label: 'search' },
+        { key: 's', label: 'severity' },
+        { key: 'a', label: 'agent' },
+        { key: 't', label: 'time' },
+        { key: 'c', label: 'clear' },
+        { key: 'r', label: 'refresh' },
+      ]} />
     </Box>
   );
 };

--- a/tui/src/views/RolesView.tsx
+++ b/tui/src/views/RolesView.tsx
@@ -9,6 +9,7 @@ import { Box, Text, useInput } from 'ink';
 import { Panel } from '../components/Panel';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { HeaderBar } from '../components/HeaderBar';
+import { Footer } from '../components/Footer';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { useAgents, useDebounce, useDisableInput, useListNavigation } from '../hooks';
@@ -328,13 +329,21 @@ export function RolesView(_props: RolesViewProps = {}): React.ReactElement {
       )}
 
       {/* Footer */}
-      <Box>
-        <Text dimColor wrap="truncate">
-          {searchMode
-            ? 'Type to search, Enter/Esc to exit'
-            : `j/k: navigate | g/G: top/bottom | /: search${searchQuery ? ' | c: clear' : ''} | Enter: details | d: delete | r: refresh | q/ESC: back`}
-        </Text>
-      </Box>
+      {searchMode ? (
+        <Footer hints={[
+          { key: 'Enter/Esc', label: 'exit search' },
+        ]} />
+      ) : (
+        <Footer hints={[
+          { key: 'j/k', label: 'nav' },
+          { key: 'g/G', label: 'top/bottom' },
+          { key: '/', label: 'search' },
+          ...(searchQuery ? [{ key: 'c', label: 'clear' }] : []),
+          { key: 'Enter', label: 'details' },
+          { key: 'd', label: 'delete' },
+          { key: 'r', label: 'refresh' },
+        ]} />
+      )}
     </Box>
   );
 }

--- a/tui/src/views/WorktreesView.tsx
+++ b/tui/src/views/WorktreesView.tsx
@@ -9,6 +9,7 @@ import { getWorktrees, pruneWorktrees } from '../services/bc';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { ErrorDisplay } from '../components/ErrorDisplay';
 import { HeaderBar } from '../components/HeaderBar';
+import { Footer } from '../components/Footer';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { useListNavigation } from '../hooks';
@@ -330,12 +331,14 @@ export const WorktreesView: React.FC = () => {
       </Box>
 
       {/* Footer */}
-      <Box marginTop={1}>
-        <Text dimColor wrap="truncate">
-          j/k: nav | g/G: top/bottom | Enter: details | o: {showOrphanedOnly ? 'show all' : 'orphans only'}
-          {hasOrphans ? ' | p: prune' : ''} | r: refresh | q/ESC: back
-        </Text>
-      </Box>
+      <Footer hints={[
+        { key: 'j/k', label: 'nav' },
+        { key: 'g/G', label: 'top/bottom' },
+        { key: 'Enter', label: 'details' },
+        { key: 'o', label: showOrphanedOnly ? 'show all' : 'orphans only' },
+        ...(hasOrphans ? [{ key: 'p', label: 'prune' }] : []),
+        { key: 'r', label: 'refresh' },
+      ]} />
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

Three P1 fixes from design audit #1847, bundled per PM direction (one PR per priority level):

- **P1a — Unify working symbol**: `STATUS_SYMBOLS.working` changed from `⊙` to `●` to match `StatusBadge.stateSymbols`. Eliminates the inconsistency where "working" agents showed different symbols depending on code path.

- **P1b — Theme-aware Panel borders**: `Panel.tsx` now reads `theme.borderFocused` (cyan in dark, blue in light) instead of hardcoding `blue`. Uses defensive `useContext` pattern for test compatibility.

- **P1c — Standardize footer hints**: Migrated 5 views from inline `<Text dimColor>key: label | ...</Text>` to the shared `<Footer>` component with consistent `[key] label` format.

## Changed files

| File | P1 | Change |
|------|-----|--------|
| `theme/StatusColors.ts` | a | `⊙` → `●` for working symbol |
| `components/Panel.tsx` | b | Focused border reads theme instead of hardcoded `blue` |
| `views/AgentsView.tsx` | c | Inline footer → `<Footer>` component |
| `views/LogsView.tsx` | c | Inline footer → `<Footer>` component |
| `views/WorktreesView.tsx` | c | Inline footer → `<Footer>` component |
| `views/RolesView.tsx` | c | Inline footer → `<Footer>` component |
| `views/AgentDetailView.tsx` | c | Inline footer → `<Footer>` component (3 states: input/live/default) |

## Before / After (footer hints)

**Before** (inline dimColor text):
```
j/k: nav | Enter: attach | d: detail | v: flat | /: search | p: peek | r: refresh | q: back
```

**After** (`<Footer>` component):
```
─────────────────────────────────────────────────
[j/k] nav  [Enter] attach  [d] detail  [v] flat  [/] search  [p] peek  [r] refresh
```

## Test plan
- [x] `bun run build` — compiles clean
- [ ] Visual: verify `●` symbol for working agents in all views
- [ ] Visual: verify Panel focused border is cyan (dark theme) / blue (light theme)
- [ ] Visual: verify all views show `[key] label` footer format

🤖 Generated with [Claude Code](https://claude.com/claude-code)