### PR TITLE
fix(tui): P2 design system — selection style, confirm borders (#1847)

### DIFF
--- a/tui/src/views/LogsView.tsx
+++ b/tui/src/views/LogsView.tsx
@@ -423,27 +423,17 @@ export const LogsView: React.FC<LogsViewProps> = () => {
               <Text color={isSelected ? 'cyan' : undefined}>
                 {isSelected ? '▸ ' : '  '}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : undefined}
-              >
+              <Text color={isSelected ? 'cyan' : undefined}>
                 {formatTime(log.ts).padEnd(timeWidth)}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : 'cyan'}
-              >
+              <Text color={isSelected ? 'cyan' : 'cyan'}>
                 {log.agent.slice(0, agentWidth - 1).padEnd(agentWidth)}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : severityColor}
-              >
+              <Text color={isSelected ? 'cyan' : severityColor}>
                 {severityIcon} {abbreviateType(log.type).slice(0, typeWidth - 3).padEnd(typeWidth - 2)}
               </Text>
               <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : undefined}
+                color={isSelected ? 'cyan' : undefined}
                 wrap="truncate"
               >
                 {log.message.slice(0, messageWidth)}

--- a/tui/src/views/WorktreesView.tsx
+++ b/tui/src/views/WorktreesView.tsx
@@ -259,23 +259,13 @@ export const WorktreesView: React.FC = () => {
               <Text color={isSelected ? 'cyan' : undefined}>
                 {isSelected ? '▸ ' : '  '}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : 'cyan'}
-              >
+              <Text color={isSelected ? 'cyan' : 'cyan'}>
                 {wt.agent.slice(0, agentWidth - 3).padEnd(agentWidth - 2)}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : 'green'}
-              >
+              <Text color={isSelected ? 'cyan' : 'green'}>
                 {wt.status.padEnd(statusWidth)}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : undefined}
-                wrap="truncate"
-              >
+              <Text color={isSelected ? 'cyan' : undefined} wrap="truncate">
                 {formatPath(wt.path).slice(0, pathWidth)}
               </Text>
             </Box>
@@ -299,23 +289,13 @@ export const WorktreesView: React.FC = () => {
               <Text color={isSelected ? 'cyan' : undefined}>
                 {isSelected ? '▸ ' : '  '}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : 'yellow'}
-              >
+              <Text color={isSelected ? 'cyan' : 'yellow'}>
                 {(wt.agent || '(orphan)').slice(0, agentWidth - 3).padEnd(agentWidth - 2)}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : 'red'}
-              >
+              <Text color={isSelected ? 'cyan' : 'red'}>
                 {wt.status.padEnd(statusWidth)}
               </Text>
-              <Text
-                backgroundColor={isSelected ? 'blue' : undefined}
-                color={isSelected ? 'white' : undefined}
-                wrap="truncate"
-              >
+              <Text color={isSelected ? 'cyan' : undefined} wrap="truncate">
                 {formatPath(wt.path).slice(0, pathWidth)}
               </Text>
             </Box>

--- a/tui/src/views/agents/AgentConfirmDialog.tsx
+++ b/tui/src/views/agents/AgentConfirmDialog.tsx
@@ -36,14 +36,18 @@ export function AgentConfirmDialog({
     }
   };
 
+  // #1847 P2b: destructive actions (kill) use red, caution actions (stop/restart) use yellow
+  const isDestructive = action === 'kill';
+  const borderColor = isDestructive ? 'red' : 'yellow';
+
   return (
     <Box
       marginBottom={1}
       paddingX={isNarrow ? 0 : 1}
       borderStyle={isNarrow ? undefined : 'round'}
-      borderColor="yellow"
+      borderColor={borderColor}
     >
-      <Text color="yellow">{getMessage()} </Text>
+      <Text color={borderColor}>{getMessage()} </Text>
       <Text color="green">[y]es</Text>
       <Text color="gray"> / </Text>
       <Text color="red">[n]o</Text>


### PR DESCRIPTION
## Summary

Two P2 fixes from design audit #1847:

- **P2a — Standardize selection style**: Removed `backgroundColor="blue"` + `color="white"` from LogsView and WorktreesView. Both now use the standard `▸` prefix + cyan text pattern, matching AgentsView, RolesView, ChannelsView, and DataTable.

- **P2b — Confirm dialog border convention**: AgentConfirmDialog now uses red border for destructive `kill` (force-terminate) and yellow for cautionary `stop`/`restart`. Establishes a clear rule:
  - **Red border** = destructive/irreversible (kill agent, delete role)
  - **Yellow border** = cautionary/reversible (stop, restart, prune orphans)

## Changed files

| File | P2 | Change |
|------|-----|--------|
| `views/LogsView.tsx` | a | Remove `backgroundColor="blue"`, use `▸` + cyan |
| `views/WorktreesView.tsx` | a | Remove `backgroundColor="blue"` from both active and orphaned sections |
| `views/agents/AgentConfirmDialog.tsx` | b | Dynamic border: red for `kill`, yellow for stop/restart |

## Before / After (selection)

**Before** (LogsView/WorktreesView):
```
▸ 14:23:01  eng-02  ✓ done  Completed task    ← blue background, white text
```

**After** (matches all other views):
```
▸ 14:23:01  eng-02  ✓ done  Completed task    ← cyan text, no background
```

## Border convention established

| Dialog | Border | Rationale |
|--------|--------|-----------|
| Kill agent | red | Force-terminate is destructive |
| Stop/restart agent | yellow | Graceful, reversible |
| Delete role | red | Already correct — destructive |
| Prune worktrees | yellow | Already correct — cautionary cleanup |

## Test plan
- [x] `bun run build` — compiles clean
- [ ] Visual: verify LogsView selected row uses `▸` + cyan (no blue background)
- [ ] Visual: verify WorktreesView selected row uses `▸` + cyan (no blue background)
- [ ] Visual: verify `kill` confirm shows red border, `stop` shows yellow

🤖 Generated with [Claude Code](https://claude.com/claude-code)