### PR TITLE
feat(tui): integrate log streaming backend (#1844)

### DIFF
--- a/tui/src/__tests__/AgentDetailView.test.tsx
+++ b/tui/src/__tests__/AgentDetailView.test.tsx
@@ -57,8 +57,62 @@ describe('AgentDetailView - normalizeTask', () => {
   });
 });
 
+describe('AgentDetailView - ANSI detection (#1844)', () => {
+  // eslint-disable-next-line no-control-regex
+  const ANSI_REGEX = /\x1b\[[0-9;]*m/;
+
+  function hasAnsiCodes(line: string): boolean {
+    return ANSI_REGEX.test(line);
+  }
+
+  test('detects SGR color codes', () => {
+    expect(hasAnsiCodes('\x1b[31mred text\x1b[0m')).toBe(true);
+    expect(hasAnsiCodes('\x1b[1;32mbold green\x1b[0m')).toBe(true);
+  });
+
+  test('returns false for plain text', () => {
+    expect(hasAnsiCodes('just plain text')).toBe(false);
+    expect(hasAnsiCodes('Error: something failed')).toBe(false);
+  });
+
+  test('detects reset codes', () => {
+    expect(hasAnsiCodes('\x1b[0m')).toBe(true);
+  });
+});
+
+describe('AgentDetailView - peek header stripping (#1844)', () => {
+  function isPeekHeader(line: string): boolean {
+    return /^=== .+ \(last \d+ lines\) ===$/.test(line.trim());
+  }
+
+  test('detects standard peek header', () => {
+    expect(isPeekHeader('=== eng-01 (last 50 lines) ===')).toBe(true);
+    expect(isPeekHeader('=== my-agent (last 200 lines) ===')).toBe(true);
+  });
+
+  test('does not match normal output lines', () => {
+    expect(isPeekHeader('some normal output')).toBe(false);
+    expect(isPeekHeader('=== not a header ===')).toBe(false);
+    expect(isPeekHeader('Error: failed')).toBe(false);
+  });
+
+  test('filters headers from output', () => {
+    const raw = '=== eng-01 (last 50 lines) ===\nline 1\nline 2\n';
+    const lines = raw.split('\n').filter(line => line.trim() && !isPeekHeader(line));
+    expect(lines).toEqual(['line 1', 'line 2']);
+  });
+});
+
 describe('AgentDetailView - colorizeOutputLine patterns', () => {
-  function getLineType(line: string): 'error' | 'warning' | 'success' | 'command' | 'default' {
+  // eslint-disable-next-line no-control-regex
+  const ANSI_REGEX = /\x1b\[[0-9;]*m/;
+
+  function getLineType(line: string): 'error' | 'warning' | 'success' | 'command' | 'ansi' | 'default' {
+    // #1844: Lines with ANSI codes pass through without semantic coloring
+    if (ANSI_REGEX.test(line)) {
+      return 'ansi';
+    }
+
     const trimmed = line.trim().toLowerCase();
 
     if (
@@ -146,6 +200,11 @@ describe('AgentDetailView - colorizeOutputLine patterns', () => {
 
   test('returns default for normal text', () => {
     expect(getLineType('Just some text')).toBe('default');
+  });
+
+  test('returns ansi for lines with ANSI codes (#1844)', () => {
+    expect(getLineType('\x1b[31mError: failed\x1b[0m')).toBe('ansi');
+    expect(getLineType('\x1b[32m✓ All tests passed\x1b[0m')).toBe('ansi');
   });
 });
 

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -41,6 +41,7 @@ export interface Agent {
   workspace: string;
   worktree_dir: string;
   memory_dir: string;
+  log_file?: string;
   started_at: string;
   updated_at: string;
   memory?: AgentMemory;

--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -40,14 +40,40 @@ function normalizeTask(task: string | undefined): string {
   return task;
 }
 
+// ANSI escape code regex - detects SGR (Select Graphic Rendition) sequences
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[[0-9;]*m/;
+
+/**
+ * Check if a line contains ANSI escape codes.
+ * #1844: Log streaming backend preserves ANSI codes in output.
+ */
+function hasAnsiCodes(line: string): boolean {
+  return ANSI_REGEX.test(line);
+}
+
+/**
+ * Check if a line is a peek header (e.g., "=== agent-name (last 50 lines) ===").
+ * #1844: Strip these headers from displayed output.
+ */
+function isPeekHeader(line: string): boolean {
+  return /^=== .+ \(last \d+ lines\) ===$/.test(line.trim());
+}
+
 /**
  * Colorize output line based on content patterns.
  * #1161: Apply semantic colors to agent output for better readability.
+ * #1844: Pass through lines that already contain ANSI escape codes from log streaming.
  *
- * This provides basic highlighting since Ink doesn't render ANSI codes directly.
  * Patterns: errors (red), warnings (yellow), success (green), info (cyan)
  */
 function colorizeOutputLine(line: string): React.ReactElement {
+  // #1844: If line already has ANSI codes from log streaming, render as-is.
+  // Ink 4.x renders embedded ANSI escape sequences in Text content.
+  if (hasAnsiCodes(line)) {
+    return <Text>{line}</Text>;
+  }
+
   const trimmed = line.trim().toLowerCase();
 
   // Error patterns
@@ -147,7 +173,8 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
   const fetchAgentOutput = useCallback(async () => {
     try {
       const output = await execBc(['agent', 'peek', agent.name, '--lines', '50']);
-      const lines = output.split('\n').filter(line => line.trim());
+      // #1844: Strip peek headers and empty lines from output
+      const lines = output.split('\n').filter(line => line.trim() && !isPeekHeader(line));
       setOutputLines(lines);
       setError(null);
     } catch (err) {
@@ -160,7 +187,8 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
   const fetchLiveOutput = useCallback(async () => {
     try {
       const output = await execBc(['agent', 'peek', agent.name, '--lines', '200']);
-      const lines = output.split('\n').filter(line => line.trim());
+      // #1844: Strip peek headers and empty lines from output
+      const lines = output.split('\n').filter(line => line.trim() && !isPeekHeader(line));
       setLiveLines(prevLines => {
         // Auto-scroll to bottom if following and new content arrived
         if (isFollowing && lines.length > prevLines.length) {
@@ -446,6 +474,7 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
             <DetailRow label="Workspace" value={agent.workspace} />
             <DetailRow label="Worktree" value={agent.worktree_dir} />
             <DetailRow label="Memory" value={agent.memory_dir} />
+            {agent.log_file && <DetailRow label="Log File" value={agent.log_file} />}
 
             <Box marginY={1}>
               <Text bold color="white">Timestamps</Text>

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -223,7 +223,10 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
     dispatch({ type: 'SET_PEEK_LOADING', loading: true });
     try {
       const output = await execBc(['agent', 'peek', agentName, '--lines', '8']);
-      const lines = output.split('\n').filter((line: string) => line.trim());
+      // #1844: Strip peek headers and empty lines
+      const lines = output.split('\n').filter((line: string) =>
+        line.trim() && !/^=== .+ \(last \d+ lines\) ===$/.test(line.trim())
+      );
       dispatch({ type: 'SET_PEEK_OUTPUT', output: lines.slice(-6) });
     } catch {
       dispatch({ type: 'SET_PEEK_OUTPUT', output: ['(No output available)'] });

--- a/tui/src/views/__tests__/AgentDetailView.test.tsx
+++ b/tui/src/views/__tests__/AgentDetailView.test.tsx
@@ -123,6 +123,15 @@ describe('AgentDetailView Component', () => {
     expect(agentNoRole.role).toBeUndefined();
   });
 
+  test('handles agent with log_file (#1844)', () => {
+    const agentWithLog = { ...mockAgent, log_file: '/workspace/.bc/logs/test-agent.log' };
+    expect(agentWithLog.log_file).toBe('/workspace/.bc/logs/test-agent.log');
+  });
+
+  test('handles agent without log_file (#1844)', () => {
+    expect(mockAgent.log_file).toBeUndefined();
+  });
+
   test.skip('renders with different agent states', () => {
     const states: Agent['state'][] = ['running', 'idle', 'working', 'stopped'];
     states.forEach(state => {

--- a/tui/src/views/agents/AgentPeekPanel.tsx
+++ b/tui/src/views/agents/AgentPeekPanel.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Box, Text, useStdout } from 'ink';
 import type { Agent } from '../../types';
 
+// eslint-disable-next-line no-control-regex
+const ANSI_REGEX = /\x1b\[[0-9;]*m/;
+
 export interface AgentPeekPanelProps {
   agent: Agent;
   output: string[];
@@ -16,6 +19,7 @@ export interface AgentPeekPanelProps {
  *
  * Issue #1689: Fixed text cutoff by using full terminal width
  * and proper text wrapping instead of truncation.
+ * #1844: Preserve ANSI codes from log streaming; only dim plain text lines.
  */
 export function AgentPeekPanel({
   agent,
@@ -46,9 +50,13 @@ export function AgentPeekPanel({
         <Text dimColor>Loading...</Text>
       ) : (
         <Box flexDirection="column" width={contentWidth}>
-          {output.map((line, idx) => (
-            <Text key={idx} wrap="wrap" dimColor>{line}</Text>
-          ))}
+          {output.map((line, idx) =>
+            ANSI_REGEX.test(line) ? (
+              <Text key={idx} wrap="wrap">{line}</Text>
+            ) : (
+              <Text key={idx} wrap="wrap" dimColor>{line}</Text>
+            )
+          )}
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## Summary
- Add `log_file?: string` to Agent type to surface log file path from #1844 backend
- ANSI color passthrough: lines with escape codes from log streaming render natively in Ink, bypassing semantic coloring
- Strip `=== agent (last N lines) ===` peek headers from output in AgentDetailView, live tab, and AgentsView peek panel
- Show `log_file` in agent Details tab when present
- AgentPeekPanel preserves ANSI colors on lines that have them, dims plain text lines

Integrates with: #1844 (go-eng log streaming backend)
Blocked follow-on: live streaming via `peek --follow` (#1851)

## Test plan
- [x] `bun test` — 55 unit tests pass (ANSI detection, peek header stripping, colorize passthrough)
- [x] `tsc --noEmit` — typecheck clean
- [x] `eslint` — no new warnings/errors in changed files
- [x] `bun run build` — compiles successfully
- [ ] Manual: verify ANSI-colored output renders correctly in agent peek
- [ ] Manual: verify peek headers no longer show in Output/Live tabs
- [ ] Manual: verify log_file appears in Details tab for agents with log streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)