### PR TITLE
feat(tui): follow-aware polling for Live tab (#1855)

### DIFF
--- a/tui/src/__tests__/AgentDetailView.test.tsx
+++ b/tui/src/__tests__/AgentDetailView.test.tsx
@@ -412,6 +412,27 @@ describe('AgentDetailView - follow mode', () => {
   });
 });
 
+describe('AgentDetailView - follow-aware polling (#1855)', () => {
+  // #1855: Polling should only run when both live tab is active AND following
+  function shouldPoll(activeTab: string, isFollowing: boolean): boolean {
+    return activeTab === 'live' && isFollowing;
+  }
+
+  test('polls when live tab active and following', () => {
+    expect(shouldPoll('live', true)).toBe(true);
+  });
+
+  test('does not poll when live tab active but paused', () => {
+    expect(shouldPoll('live', false)).toBe(false);
+  });
+
+  test('does not poll on other tabs', () => {
+    expect(shouldPoll('output', true)).toBe(false);
+    expect(shouldPoll('details', true)).toBe(false);
+    expect(shouldPoll('metrics', true)).toBe(false);
+  });
+});
+
 describe('AgentDetailView - output slicing', () => {
   function getVisibleLines(lines: string[], offset: number, visible = 20): string[] {
     return lines.slice(offset, offset + visible);

--- a/tui/src/views/AgentDetailView.tsx
+++ b/tui/src/views/AgentDetailView.tsx
@@ -216,17 +216,22 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
     return () => { clearInterval(interval); };
   }, [fetchAgentOutput]);
 
-  // Live mode: faster polling (500ms) when tab is active
+  // #1855: Live mode polls at 2.5s only when following; stops when paused.
+  // Proper cleanup on tab switch or follow toggle to avoid stale timers.
   useEffect(() => {
-    if (activeTab === 'live') {
+    if (activeTab !== 'live') return undefined;
+
+    // Always fetch once when entering live tab
+    void fetchLiveOutput();
+
+    // Only poll continuously when following
+    if (!isFollowing) return undefined;
+
+    const interval = setInterval(() => {
       void fetchLiveOutput();
-      const interval = setInterval(() => {
-        void fetchLiveOutput();
-      }, 500);
-      return () => { clearInterval(interval); };
-    }
-    return undefined;
-  }, [activeTab, fetchLiveOutput]);
+    }, 2500);
+    return () => { clearInterval(interval); };
+  }, [activeTab, isFollowing, fetchLiveOutput]);
 
   const sendMessage = useCallback(async (message: string) => {
     if (!message.trim()) return;
@@ -273,7 +278,12 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
       } else if (input === 'q' || key.escape) {
         onBack?.();
       } else if (input === 'r') {
-        void fetchAgentOutput();
+        // Refresh: fetch output for current tab
+        if (activeTab === 'live') {
+          void fetchLiveOutput();
+        } else {
+          void fetchAgentOutput();
+        }
       } else if (input === '1') {
         setActiveTab('output');
       } else if (input === '2') {
@@ -420,13 +430,13 @@ export const AgentDetailView: React.FC<AgentDetailViewProps> = ({
           >
             <Box marginBottom={1}>
               <Text color="cyan" bold>LIVE OUTPUT</Text>
-              <Text dimColor> - 500ms refresh | </Text>
+              <Text dimColor> | </Text>
               {isFollowing ? (
-                <Text color="green">FOLLOWING</Text>
+                <><Text color="green">FOLLOWING</Text><Text dimColor> (2.5s)</Text></>
               ) : (
-                <Text color="yellow">PAUSED</Text>
+                <><Text color="yellow">PAUSED</Text><Text dimColor> (r: refresh)</Text></>
               )}
-              <Text dimColor> | f: toggle follow</Text>
+              <Text dimColor> | f: toggle</Text>
             </Box>
             <Box flexDirection="column" height={outputHeight + 2} overflow="hidden">
               {liveLines.length === 0 ? (


### PR DESCRIPTION
## Summary
- Refactor Live tab polling to integrate with go-3's peek --follow backend (#1855)
- Poll at 2.5s only when `isFollowing` is active (down from 500ms always-on)
- Stop polling entirely when paused — user can manually refresh with `r` key
- Proper `useEffect` cleanup on tab switch and follow toggle to avoid stale timers
- Updated Live tab header: shows `FOLLOWING (2.5s)` or `PAUSED (r: refresh)`
- `r` key now refreshes the active tab context (live or output)

Integrates with: #1855 (go-3 peek --follow backend)
Follows up: #1857 (tui-3 log streaming integration)

## Test plan
- [x] `bun test` — 58 unit tests pass (+3 new follow-aware polling tests)
- [x] `tsc --noEmit` — typecheck clean
- [x] `eslint` — no warnings/errors in changed files
- [ ] Manual: verify Live tab polls at ~2.5s when following
- [ ] Manual: verify polling stops when pressing `f` to pause
- [ ] Manual: verify `r` refreshes output when paused
- [ ] Manual: verify no stale timers when switching tabs rapidly

🤖 Generated with [Claude Code](https://claude.com/claude-code)