### PR TITLE
feat(tui): add :memory/:mem command for memory view navigation

### DIFF
--- a/tui/src/navigation/__tests__/viewCommands.test.ts
+++ b/tui/src/navigation/__tests__/viewCommands.test.ts
@@ -17,7 +17,15 @@ describe('viewCommands', () => {
     test('resolves aliases', () => {
       expect(resolveCommand('dash')).toBe('dashboard');
       expect(resolveCommand('ag')).toBe('agents');
+      expect(resolveCommand('mem')).toBe('memory');
+      expect(resolveCommand('m')).toBe('memory');
       expect(resolveCommand('?')).toBe('help');
+    });
+
+    test('resolves :memory and :mem to memory view', () => {
+      expect(resolveCommand('memory')).toBe('memory');
+      expect(resolveCommand('mem')).toBe('memory');
+      expect(resolveCommand('m')).toBe('memory');
     });
 
     test('returns null for unknown commands', () => {

--- a/tui/src/navigation/viewCommands.ts
+++ b/tui/src/navigation/viewCommands.ts
@@ -31,6 +31,7 @@ export const VIEW_COMMANDS: ViewCommand[] = [
   { command: 'channels', aliases: ['ch', 'c'], view: 'channels', section: 'CORE' },
   { command: 'costs', aliases: ['co', 'cost'], view: 'costs', section: 'CORE' },
   { command: 'logs', aliases: ['log', 'l'], view: 'logs', section: 'CORE' },
+  { command: 'memory', aliases: ['mem', 'm'], view: 'memory', section: 'CORE' },
   { command: 'roles', aliases: ['ro', 'r'], view: 'roles', section: 'SYSTEM' },
   { command: 'worktrees', aliases: ['wt', 'w'], view: 'worktrees', section: 'SYSTEM' },
   { command: 'help', aliases: ['?', 'h'], view: 'help', section: 'CORE' },


### PR DESCRIPTION
## Summary
- Register memory view in `viewCommands.ts` with command `:memory` and aliases `:mem`, `:m`
- Enables command bar navigation to MemoryView (merged in #1858)

Follow-up to #1858 (tui-1's MemoryView).

## Test plan
- [x] `bun test` — 16 viewCommands tests pass (+1 new for :memory/:mem)
- [x] `tsc --noEmit` — typecheck clean
- [x] `eslint` — no warnings/errors
- [ ] Manual: type `:memory` or `:mem` in command bar → navigates to Memory view

🤖 Generated with [Claude Code](https://claude.com/claude-code)