### PR TITLE
feat(cmd): add memory edit and delete CLI subcommands

### DIFF
--- a/internal/cmd/demon.go
+++ b/internal/cmd/demon.go
@@ -881,4 +881,3 @@ func runDemonSchedulerLoop(cmd *cobra.Command, args []string) error {
 	scheduler := demon.NewScheduler(schedulerLoopRoot)
 	return scheduler.RunLoop(shutdown.Context())
 }
-

--- a/internal/cmd/memory.go
+++ b/internal/cmd/memory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -160,18 +161,42 @@ Example:
 
 // Export/Import commands moved to memory_io.go
 
-var memoryDeleteCmd = &cobra.Command{
-	Use:   "delete <agent> <index>",
-	Short: "Delete a specific experience",
-	Long: `Delete a specific experience from an agent's memory by its index.
+var memoryEditCmd = &cobra.Command{
+	Use:   "edit <agent>",
+	Short: "Edit agent memory files in $EDITOR",
+	Long: `Open an agent's memory file in your default editor.
 
-Use 'bc memory show <agent> --experiences' to see experience indices.
-Indices are 1-based (first experience is 1, not 0).
+Specify which file to edit with one of the flags:
+  --learnings      Open learnings.md
+  --experiences    Open experiences.jsonl
+  --role-prompt    Open role_prompt.md
+
+Uses $EDITOR environment variable, falls back to vi.
 
 Example:
-  bc memory delete engineer-01 3     # Delete the 3rd experience
-  bc memory delete engineer-01 1     # Delete the first (oldest) experience`,
-	Args: cobra.ExactArgs(2),
+  bc memory edit engineer-01 --learnings      # Edit learnings
+  bc memory edit engineer-01 --experiences    # Edit experiences
+  bc memory edit engineer-01 --role-prompt    # Edit role prompt`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMemoryEdit,
+}
+
+var memoryDeleteCmd = &cobra.Command{
+	Use:   "delete <agent>",
+	Short: "Delete a specific experience or learning",
+	Long: `Delete a specific item from an agent's memory.
+
+Use --experience to delete an experience by index.
+Use --learning to delete a learning by category and index.
+
+Use 'bc memory show <agent>' to see indices.
+Indices are 1-based (first item is 1, not 0).
+
+Example:
+  bc memory delete engineer-01 --experience 3              # Delete 3rd experience
+  bc memory delete engineer-01 --learning patterns 2       # Delete 2nd learning in "patterns"
+  bc memory delete engineer-01 --experience 1 --force      # Delete without confirmation`,
+	Args: cobra.MinimumNArgs(1),
 	RunE: runMemoryDelete,
 }
 
@@ -211,6 +236,12 @@ var (
 	memoryClearExp         bool
 	memoryClearLearn       bool
 	memoryClearForce       bool
+	memoryEditLearnings    bool
+	memoryEditExperiences  bool
+	memoryEditRolePrompt   bool
+	memoryDeleteExperience int
+	memoryDeleteLearning   string
+	memoryDeleteForce      bool
 )
 
 func init() {
@@ -241,6 +272,15 @@ func init() {
 	memoryClearCmd.Flags().BoolVar(&memoryClearLearn, "learnings", false, "Clear only learnings")
 	memoryClearCmd.Flags().BoolVar(&memoryClearForce, "force", false, "Skip confirmation prompt")
 
+	memoryEditCmd.Flags().BoolVar(&memoryEditLearnings, "learnings", false, "Edit learnings.md")
+	memoryEditCmd.Flags().BoolVar(&memoryEditExperiences, "experiences", false, "Edit experiences.jsonl")
+	memoryEditCmd.Flags().BoolVar(&memoryEditRolePrompt, "role-prompt", false, "Edit role_prompt.md")
+	memoryEditCmd.MarkFlagsMutuallyExclusive("learnings", "experiences", "role-prompt")
+
+	memoryDeleteCmd.Flags().IntVar(&memoryDeleteExperience, "experience", 0, "Delete experience at this index (1-based)")
+	memoryDeleteCmd.Flags().StringVar(&memoryDeleteLearning, "learning", "", "Delete learning from this category (index as next arg)")
+	memoryDeleteCmd.Flags().BoolVar(&memoryDeleteForce, "force", false, "Skip confirmation prompt")
+
 	// I/O flags (in memory_io.go)
 	initMemoryIOFlags()
 
@@ -251,6 +291,7 @@ func init() {
 	memoryCmd.AddCommand(memoryPruneCmd)
 	memoryCmd.AddCommand(memoryListCmd)
 	memoryCmd.AddCommand(memoryClearCmd)
+	memoryCmd.AddCommand(memoryEditCmd)
 	memoryCmd.AddCommand(memoryDeleteCmd)
 	memoryCmd.AddCommand(memoryMergeCmd)
 	rootCmd.AddCommand(memoryCmd)
@@ -1039,6 +1080,57 @@ func runMemoryClear(cmd *cobra.Command, args []string) error {
 
 // Export/Import/Forget functions moved to memory_io.go
 
+func runMemoryEdit(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return errNotInWorkspace(err)
+	}
+
+	agentID := args[0]
+	store := memory.NewStore(ws.RootDir, agentID)
+	if !store.Exists() {
+		return fmt.Errorf("no memory found for agent %s", agentID)
+	}
+
+	// Determine which file to edit
+	var filePath string
+	switch {
+	case memoryEditLearnings:
+		filePath = filepath.Join(store.MemoryDir(), "learnings.md")
+	case memoryEditExperiences:
+		filePath = filepath.Join(store.MemoryDir(), "experiences.jsonl")
+	case memoryEditRolePrompt:
+		filePath = filepath.Join(store.MemoryDir(), "role_prompt.md")
+	default:
+		return fmt.Errorf("specify which file to edit: --learnings, --experiences, or --role-prompt")
+	}
+
+	// Check file exists
+	if _, statErr := os.Stat(filePath); os.IsNotExist(statErr) {
+		return fmt.Errorf("file does not exist: %s", filePath)
+	}
+
+	// Get editor from $EDITOR, fall back to vi
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vi"
+	}
+
+	// Open editor with inherited terminal
+	ctx := cmd.Context()
+	editorCmd := exec.CommandContext(ctx, editor, filePath) //nolint:gosec // editor is user-controlled via $EDITOR
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
+
+	if runErr := editorCmd.Run(); runErr != nil {
+		return fmt.Errorf("editor exited with error: %w", runErr)
+	}
+
+	cmd.Printf("Edited %s for agent %s\n", filepath.Base(filePath), agentID)
+	return nil
+}
+
 func runMemoryDelete(cmd *cobra.Command, args []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
@@ -1046,20 +1138,53 @@ func runMemoryDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	agentID := args[0]
-	indexStr := args[1]
-
-	// Parse index
-	index, parseErr := strconv.Atoi(indexStr)
-	if parseErr != nil {
-		return fmt.Errorf("invalid index %q: must be a number", indexStr)
-	}
-
 	store := memory.NewStore(ws.RootDir, agentID)
 	if !store.Exists() {
 		return fmt.Errorf("no memory found for agent %s", agentID)
 	}
 
-	// Delete the experience
+	switch {
+	case memoryDeleteExperience > 0:
+		return deleteExperience(cmd, store, agentID, memoryDeleteExperience)
+	case memoryDeleteLearning != "":
+		// Index is the next positional arg after agent
+		if len(args) < 2 {
+			return fmt.Errorf("missing index: usage: bc memory delete <agent> --learning <category> <index>")
+		}
+		index, parseErr := strconv.Atoi(args[1])
+		if parseErr != nil {
+			return fmt.Errorf("invalid index %q: must be a number", args[1])
+		}
+		return deleteLearning(cmd, store, agentID, memoryDeleteLearning, index)
+	default:
+		return fmt.Errorf("specify what to delete: --experience <index> or --learning <category> <index>")
+	}
+}
+
+func deleteExperience(cmd *cobra.Command, store *memory.Store, agentID string, index int) error {
+	// Show the item for confirmation
+	experiences, err := store.GetExperiences()
+	if err != nil {
+		return fmt.Errorf("failed to get experiences: %w", err)
+	}
+	idx := index - 1
+	if idx < 0 || idx >= len(experiences) {
+		return fmt.Errorf("index %d out of range (1-%d)", index, len(experiences))
+	}
+
+	exp := experiences[idx]
+	if !memoryDeleteForce {
+		cmd.Printf("Delete experience #%d from %s?\n", index, agentID)
+		cmd.Printf("  [%s] %s\n", exp.Outcome, exp.Description)
+		cmd.Print("Are you sure? [y/N]: ")
+
+		var response string
+		if _, scanErr := fmt.Scanln(&response); scanErr != nil || (response != "y" && response != "Y") {
+			cmd.Println("Aborted.")
+			return nil
+		}
+	}
+
 	deleted, err := store.DeleteExperience(index)
 	if err != nil {
 		return fmt.Errorf("failed to delete experience: %w", err)
@@ -1070,7 +1195,28 @@ func runMemoryDelete(cmd *cobra.Command, args []string) error {
 	if !deleted.Timestamp.IsZero() {
 		cmd.Printf("  Time: %s\n", deleted.Timestamp.Format("2006-01-02 15:04:05"))
 	}
+	return nil
+}
 
+func deleteLearning(cmd *cobra.Command, store *memory.Store, agentID, category string, index int) error {
+	if !memoryDeleteForce {
+		cmd.Printf("Delete learning #%d from category %q for %s?\n", index, category, agentID)
+		cmd.Print("Are you sure? [y/N]: ")
+
+		var response string
+		if _, scanErr := fmt.Scanln(&response); scanErr != nil || (response != "y" && response != "Y") {
+			cmd.Println("Aborted.")
+			return nil
+		}
+	}
+
+	deleted, err := store.DeleteLearning(category, index)
+	if err != nil {
+		return fmt.Errorf("failed to delete learning: %w", err)
+	}
+
+	cmd.Printf("Deleted learning #%d from %s [%s]:\n", index, agentID, category)
+	cmd.Printf("  %s\n", deleted)
 	return nil
 }
 

--- a/internal/cmd/memory_test.go
+++ b/internal/cmd/memory_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
+
 	"github.com/rpuneet/bc/pkg/memory"
 )
 
@@ -726,5 +728,354 @@ func TestMemoryImportFileNotFound(t *testing.T) {
 	_, err := executeCmd("memory", "import", "test-agent", "/nonexistent/file.json")
 	if err == nil {
 		t.Error("expected error for non-existent file")
+	}
+}
+
+// resetMemoryEditDeleteFlags resets package-level flag vars and Cobra flag state
+// that leak between tests. executeCmd only resets flags on rootCmd's direct
+// children, not grandchildren like memoryEditCmd and memoryDeleteCmd.
+func resetMemoryEditDeleteFlags(t *testing.T) {
+	t.Helper()
+	memoryEditLearnings = false
+	memoryEditExperiences = false
+	memoryEditRolePrompt = false
+	memoryDeleteExperience = 0
+	memoryDeleteLearning = ""
+	memoryDeleteForce = false
+
+	// Reset Cobra flag Changed state on grandchild commands
+	for _, sub := range memoryCmd.Commands() {
+		sub.Flags().VisitAll(func(f *pflag.Flag) {
+			f.Changed = false
+			if f.Value.Type() == "bool" {
+				_ = f.Value.Set("false")
+			} else if f.Value.Type() == "int" {
+				_ = f.Value.Set("0")
+			} else if f.Value.Type() == "string" {
+				_ = f.Value.Set(f.DefValue)
+			}
+		})
+	}
+}
+
+// --- Memory Edit Tests ---
+
+func TestMemoryEditResolvesLearningsPath(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "edit-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	_ = os.Setenv("EDITOR", "true")
+	defer func() { _ = os.Unsetenv("EDITOR") }()
+
+	output, err := executeCmd("memory", "edit", "edit-agent", "--learnings")
+	if err != nil {
+		t.Fatalf("memory edit --learnings failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "learnings.md") {
+		t.Errorf("expected output to mention learnings.md, got: %s", output)
+	}
+}
+
+func TestMemoryEditResolvesExperiencesPath(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "edit-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	_ = os.Setenv("EDITOR", "true")
+	defer func() { _ = os.Unsetenv("EDITOR") }()
+
+	output, err := executeCmd("memory", "edit", "edit-agent", "--experiences")
+	if err != nil {
+		t.Fatalf("memory edit --experiences failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "experiences.jsonl") {
+		t.Errorf("expected output to mention experiences.jsonl, got: %s", output)
+	}
+}
+
+func TestMemoryEditResolvesRolePromptPath(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "edit-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	rpPath := filepath.Join(store.MemoryDir(), "role_prompt.md")
+	if err := os.WriteFile(rpPath, []byte("# Role\n"), 0600); err != nil {
+		t.Fatalf("failed to create role_prompt.md: %v", err)
+	}
+
+	_ = os.Setenv("EDITOR", "true")
+	defer func() { _ = os.Unsetenv("EDITOR") }()
+
+	output, err := executeCmd("memory", "edit", "edit-agent", "--role-prompt")
+	if err != nil {
+		t.Fatalf("memory edit --role-prompt failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "role_prompt.md") {
+		t.Errorf("expected output to mention role_prompt.md, got: %s", output)
+	}
+}
+
+func TestMemoryEditRequiresFlag(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "edit-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	_, err := executeCmd("memory", "edit", "edit-agent")
+	if err == nil {
+		t.Error("expected error when no file flag specified")
+	}
+	if !strings.Contains(err.Error(), "specify which file") {
+		t.Errorf("error should mention specifying a file flag: %v", err)
+	}
+}
+
+func TestMemoryEditMissingAgent(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	setupTestWorkspace(t)
+
+	_ = os.Setenv("EDITOR", "true")
+	defer func() { _ = os.Unsetenv("EDITOR") }()
+
+	_, err := executeCmd("memory", "edit", "nonexistent-agent", "--learnings")
+	if err == nil {
+		t.Error("expected error for missing agent")
+	}
+	if !strings.Contains(err.Error(), "no memory found") {
+		t.Errorf("error should mention no memory found: %v", err)
+	}
+}
+
+func TestMemoryEditEditorFallback(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "edit-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	_ = os.Setenv("EDITOR", "true")
+	defer func() { _ = os.Unsetenv("EDITOR") }()
+
+	output, err := executeCmd("memory", "edit", "edit-agent", "--learnings")
+	if err != nil {
+		t.Fatalf("memory edit failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Edited") {
+		t.Errorf("expected confirmation message, got: %s", output)
+	}
+}
+
+// --- Memory Delete Tests ---
+
+func TestMemoryDeleteExperience(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "del-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	for _, desc := range []string{"first task", "second task", "third task"} {
+		if err := store.RecordExperience(memory.Experience{
+			Description: desc,
+			Outcome:     "success",
+		}); err != nil {
+			t.Fatalf("failed to record: %v", err)
+		}
+	}
+
+	output, err := executeCmd("memory", "delete", "del-agent", "--experience", "2", "--force")
+	if err != nil {
+		t.Fatalf("delete experience failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Deleted experience #2") {
+		t.Errorf("expected deletion confirmation, got: %s", output)
+	}
+	if !strings.Contains(output, "second task") {
+		t.Errorf("expected deleted item description, got: %s", output)
+	}
+
+	exps, err := store.GetExperiences()
+	if err != nil {
+		t.Fatalf("failed to get experiences: %v", err)
+	}
+	if len(exps) != 2 {
+		t.Fatalf("expected 2 experiences, got %d", len(exps))
+	}
+	if exps[0].Description != "first task" {
+		t.Errorf("expected 'first task', got %q", exps[0].Description)
+	}
+	if exps[1].Description != "third task" {
+		t.Errorf("expected 'third task', got %q", exps[1].Description)
+	}
+}
+
+func TestMemoryDeleteExperienceInvalidIndex(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "del-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+	if err := store.RecordExperience(memory.Experience{
+		Description: "only task",
+		Outcome:     "success",
+	}); err != nil {
+		t.Fatalf("failed to record: %v", err)
+	}
+
+	_, err := executeCmd("memory", "delete", "del-agent", "--experience", "5", "--force")
+	if err == nil {
+		t.Error("expected error for out of range index")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("error should mention out of range: %v", err)
+	}
+}
+
+func TestMemoryDeleteLearning(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "del-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	for _, l := range []string{"first insight", "second insight", "third insight"} {
+		if err := store.AddLearning("patterns", l); err != nil {
+			t.Fatalf("failed to add learning: %v", err)
+		}
+	}
+
+	output, err := executeCmd("memory", "delete", "del-agent", "--learning", "patterns", "2", "--force")
+	if err != nil {
+		t.Fatalf("delete learning failed: %v\nOutput: %s", err, output)
+	}
+	if !strings.Contains(output, "Deleted learning #2") {
+		t.Errorf("expected deletion confirmation, got: %s", output)
+	}
+	if !strings.Contains(output, "patterns") {
+		t.Errorf("expected category name in output, got: %s", output)
+	}
+
+	learnings, err := store.GetLearnings()
+	if err != nil {
+		t.Fatalf("failed to get learnings: %v", err)
+	}
+	count := strings.Count(learnings, "- ")
+	if count != 2 {
+		t.Errorf("expected 2 learning entries, got %d", count)
+	}
+}
+
+func TestMemoryDeleteLearningInvalidIndex(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "del-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+	if err := store.AddLearning("patterns", "only one"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+
+	_, err := executeCmd("memory", "delete", "del-agent", "--learning", "patterns", "5", "--force")
+	if err == nil {
+		t.Error("expected error for out of range index")
+	}
+	if !strings.Contains(err.Error(), "out of range") {
+		t.Errorf("error should mention out of range: %v", err)
+	}
+}
+
+func TestMemoryDeleteLearningMissingCategory(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "del-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+	if err := store.AddLearning("tips", "something"); err != nil {
+		t.Fatalf("failed to add learning: %v", err)
+	}
+
+	_, err := executeCmd("memory", "delete", "del-agent", "--learning", "nonexistent", "1", "--force")
+	if err == nil {
+		t.Error("expected error for missing category")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}
+
+func TestMemoryDeleteLearningMissingIndex(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "del-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	_, err := executeCmd("memory", "delete", "del-agent", "--learning", "patterns")
+	if err == nil {
+		t.Error("expected error for missing index")
+	}
+	if !strings.Contains(err.Error(), "missing index") {
+		t.Errorf("error should mention missing index: %v", err)
+	}
+}
+
+func TestMemoryDeleteRequiresMode(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	wsDir := setupTestWorkspace(t)
+
+	store := memory.NewStore(wsDir, "del-agent")
+	if err := store.Init(); err != nil {
+		t.Fatalf("failed to init store: %v", err)
+	}
+
+	_, err := executeCmd("memory", "delete", "del-agent")
+	if err == nil {
+		t.Error("expected error when no mode flag specified")
+	}
+	if !strings.Contains(err.Error(), "specify what to delete") {
+		t.Errorf("error should mention specifying mode: %v", err)
+	}
+}
+
+func TestMemoryDeleteMissingAgent(t *testing.T) {
+	resetMemoryEditDeleteFlags(t)
+	setupTestWorkspace(t)
+
+	_, err := executeCmd("memory", "delete", "nonexistent", "--experience", "1", "--force")
+	if err == nil {
+		t.Error("expected error for missing agent")
+	}
+	if !strings.Contains(err.Error(), "no memory found") {
+		t.Errorf("error should mention no memory found: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `bc memory edit <agent>` subcommand with `--learnings`, `--experiences`, `--role-prompt` flags (mutually exclusive) to open memory files in `$EDITOR` (falls back to `vi`)
- Refactors `bc memory delete` to support both `--experience <index>` and `--learning <category> <index>` deletion modes with confirmation prompt (`--force` to skip)
- Calls `pkg/memory.DeleteLearning()` from #1854 for learning deletion

Closes #1850

## Test plan
- [x] `TestMemoryEditResolvesLearningsPath` — opens learnings.md via `EDITOR=true`
- [x] `TestMemoryEditResolvesExperiencesPath` — opens experiences.jsonl
- [x] `TestMemoryEditResolvesRolePromptPath` — opens role_prompt.md
- [x] `TestMemoryEditRequiresFlag` — errors without `--learnings/--experiences/--role-prompt`
- [x] `TestMemoryEditMissingAgent` — errors for nonexistent agent
- [x] `TestMemoryEditEditorFallback` — confirms editor invocation
- [x] `TestMemoryDeleteExperience` — deletes by index, verifies remaining
- [x] `TestMemoryDeleteExperienceInvalidIndex` — out of range returns error
- [x] `TestMemoryDeleteLearning` — deletes by category + index, verifies remaining
- [x] `TestMemoryDeleteLearningInvalidIndex` — out of range returns error
- [x] `TestMemoryDeleteLearningMissingCategory` — missing category returns error
- [x] `TestMemoryDeleteLearningMissingIndex` — missing index arg returns error
- [x] `TestMemoryDeleteRequiresMode` — errors without `--experience/--learning`
- [x] `TestMemoryDeleteMissingAgent` — errors for nonexistent agent
- [x] All tests pass with `-race` detector
- [x] `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)