### PR TITLE
feat(cmd): add 'bc tool list' and 'bc tool check' commands

### DIFF
--- a/internal/cmd/tool.go
+++ b/internal/cmd/tool.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/rpuneet/bc/pkg/provider"
+	"github.com/rpuneet/bc/pkg/ui"
+)
+
+var toolCmd = &cobra.Command{
+	Use:   "tool",
+	Short: "Manage AI tool providers",
+	Long: `View and check AI tool providers available for agent spawning.
+
+Examples:
+  bc tool list          # Show all tools with status
+  bc tool check claude  # Detailed check for a specific tool`,
+}
+
+var toolListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all configured tools and their status",
+	Long: `Show all registered AI tool providers with installation status, version, and command.
+
+Examples:
+  bc tool list        # Table output
+  bc tool list --json # JSON output for scripting`,
+	RunE: runToolList,
+}
+
+var toolCheckCmd = &cobra.Command{
+	Use:   "check <tool>",
+	Short: "Check details for a specific tool",
+	Long: `Show detailed information about a specific AI tool provider.
+
+Examples:
+  bc tool check claude  # Check claude installation
+  bc tool check codex   # Check codex installation`,
+	Args: cobra.ExactArgs(1),
+	RunE: runToolCheck,
+}
+
+var toolListJSON bool
+
+func init() {
+	toolListCmd.Flags().BoolVar(&toolListJSON, "json", false, "Output as JSON")
+
+	toolCmd.AddCommand(toolListCmd)
+	toolCmd.AddCommand(toolCheckCmd)
+
+	toolCheckCmd.ValidArgsFunction = completeToolNames
+
+	rootCmd.AddCommand(toolCmd)
+}
+
+func completeToolNames(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	providers := provider.ListProviders()
+	names := make([]string, len(providers))
+	for i, p := range providers {
+		names[i] = p.Name()
+	}
+	sort.Strings(names)
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
+type toolInfo struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Version string `json:"version"`
+	Command string `json:"command"`
+	Path    string `json:"path,omitempty"`
+}
+
+func getToolInfo(ctx context.Context, p provider.Provider) toolInfo {
+	info := toolInfo{
+		Name:    p.Name(),
+		Command: p.Command(),
+	}
+
+	if p.IsInstalled(ctx) {
+		info.Status = "installed"
+		info.Version = p.Version(ctx)
+		if info.Version == "" {
+			info.Version = "-"
+		}
+		path, err := exec.LookPath(p.Name())
+		if err == nil {
+			info.Path = path
+		}
+	} else {
+		info.Status = "not found"
+		info.Version = "-"
+	}
+
+	return info
+}
+
+func runToolList(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	providers := provider.ListProviders()
+	sort.Slice(providers, func(i, j int) bool {
+		return providers[i].Name() < providers[j].Name()
+	})
+
+	infos := make([]toolInfo, len(providers))
+	for i, p := range providers {
+		infos[i] = getToolInfo(ctx, p)
+	}
+
+	if toolListJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(infos)
+	}
+
+	tbl := ui.NewTable("TOOL", "STATUS", "VERSION", "COMMAND")
+	for _, info := range infos {
+		status := info.Status
+		if status == "installed" {
+			status = ui.GreenText("installed")
+		} else {
+			status = ui.DimText("not found")
+		}
+		tbl.AddRow(info.Name, status, info.Version, info.Command)
+	}
+	tbl.Print()
+
+	return nil
+}
+
+func runToolCheck(cmd *cobra.Command, args []string) error {
+	ctx := cmd.Context()
+	name := args[0]
+
+	p, err := provider.GetProvider(name)
+	if err != nil {
+		return fmt.Errorf("unknown tool %q (use 'bc tool list' to see available tools)", name)
+	}
+
+	info := getToolInfo(ctx, p)
+
+	var statusDisplay string
+	if info.Status == "installed" {
+		statusDisplay = ui.GreenText("installed")
+	} else {
+		statusDisplay = ui.RedText("not found")
+	}
+
+	pathDisplay := info.Path
+	if pathDisplay == "" {
+		pathDisplay = "-"
+	}
+
+	ui.SimpleTable(
+		"Tool", info.Name,
+		"Status", statusDisplay,
+		"Version", info.Version,
+		"Command", info.Command,
+		"Path", pathDisplay,
+	)
+
+	return nil
+}

--- a/internal/cmd/tool_test.go
+++ b/internal/cmd/tool_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/ui"
+)
+
+func TestToolList_OutputFormat(t *testing.T) {
+	// Capture UI output
+	var buf bytes.Buffer
+	ui.SetOutput(&buf)
+	defer ui.SetOutput(nil) // reset to stdout
+
+	output, err := executeCmd("tool", "list")
+	if err != nil {
+		t.Fatalf("tool list failed: %v", err)
+	}
+
+	// Table output goes through ui.Table.Print() -> ui.output
+	tableOutput := buf.String()
+
+	// Verify table headers are present
+	if !strings.Contains(tableOutput, "TOOL") {
+		t.Error("expected TOOL header in output")
+	}
+	if !strings.Contains(tableOutput, "STATUS") {
+		t.Error("expected STATUS header in output")
+	}
+	if !strings.Contains(tableOutput, "VERSION") {
+		t.Error("expected VERSION header in output")
+	}
+	if !strings.Contains(tableOutput, "COMMAND") {
+		t.Error("expected COMMAND header in output")
+	}
+
+	// Verify known providers appear
+	if !strings.Contains(tableOutput, "claude") {
+		t.Error("expected claude in tool list")
+	}
+	if !strings.Contains(tableOutput, "codex") {
+		t.Error("expected codex in tool list")
+	}
+
+	// executeCmd output should be empty for non-JSON (all goes to ui output)
+	_ = output
+}
+
+func TestToolCheck_KnownTool(t *testing.T) {
+	// Capture UI output
+	var buf bytes.Buffer
+	ui.SetOutput(&buf)
+	defer ui.SetOutput(nil)
+
+	_, err := executeCmd("tool", "check", "claude")
+	if err != nil {
+		t.Fatalf("tool check claude failed: %v", err)
+	}
+
+	tableOutput := buf.String()
+
+	if !strings.Contains(tableOutput, "claude") {
+		t.Error("expected 'claude' in check output")
+	}
+	if !strings.Contains(tableOutput, "Tool:") {
+		t.Error("expected 'Tool:' label in check output")
+	}
+	if !strings.Contains(tableOutput, "Status:") {
+		t.Error("expected 'Status:' label in check output")
+	}
+	if !strings.Contains(tableOutput, "Command:") {
+		t.Error("expected 'Command:' label in check output")
+	}
+}
+
+func TestToolCheck_UnknownTool(t *testing.T) {
+	_, err := executeCmd("tool", "check", "nonexistent-tool")
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Errorf("expected 'unknown tool' error, got %q", err.Error())
+	}
+}
+
+func TestToolListFlags(t *testing.T) {
+	f := toolListCmd.Flags().Lookup("json")
+	if f == nil {
+		t.Fatal("expected --json flag on tool list command")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("expected default value 'false', got %q", f.DefValue)
+	}
+}
+
+func TestToolCheckArgs(t *testing.T) {
+	_, err := executeCmd("tool", "check")
+	if err == nil {
+		t.Fatal("expected error when no tool name provided")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `bc tool list` — table of all registered providers showing name, status, version, and command (supports `--json`)
- Adds `bc tool check <name>` — detailed info for a single provider including binary path
- Uses `provider.DefaultRegistry` for detection, `exec.LookPath` for path resolution
- Shell completion for tool names

## Example output

```
$ bc tool list
TOOL      STATUS     VERSION                COMMAND
────────  ─────────  ─────────────────────  ─────────────────────────────────────
aider     not found  -                      aider --yes
claude    installed  2.1.63 (Claude Code)   claude --dangerously-skip-permissions
codex     installed  codex-cli 0.80.0       codex --full-auto
openclaw  installed  2026.2.21-2            openclaw --auto
opencode  installed  crush version v0.44.0  crush

$ bc tool check claude
Tool:     claude
Status:   installed
Version:  2.1.63 (Claude Code)
Command:  claude --dangerously-skip-permissions
Path:     /opt/homebrew/bin/claude
```

## Test plan
- [x] `TestToolList_OutputFormat` — verifies table headers and known providers
- [x] `TestToolCheck_KnownTool` — verifies detail output labels
- [x] `TestToolCheck_UnknownTool` — verifies error for nonexistent tool
- [x] `TestToolListFlags` — verifies `--json` flag registration
- [x] `TestToolCheckArgs` — verifies arg validation
- [x] All tests pass with `-race` detector
- [x] Lint clean (only pre-existing `demon.go` gofmt issue remains)

Closes part of #1771
Closes #1861

🤖 Generated with [Claude Code](https://claude.com/claude-code)