### PR TITLE
feat(agent): wire provider registry into agent spawning

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -66,6 +66,7 @@ import (
 	"github.com/rpuneet/bc/config"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/memory"
+	"github.com/rpuneet/bc/pkg/provider"
 	"github.com/rpuneet/bc/pkg/tmux"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
@@ -397,8 +398,9 @@ const DefaultBootstrapDelay = 3 * time.Second
 
 // Manager handles agent lifecycle.
 type Manager struct {
-	agents map[string]*Agent
-	tmux   *tmux.Manager
+	agents           map[string]*Agent
+	tmux             *tmux.Manager
+	providerRegistry *provider.Registry
 
 	stateDir string
 
@@ -418,10 +420,11 @@ type Manager struct {
 // NewManager creates a new agent manager with workspace-scoped tmux sessions.
 func NewManager(stateDir string) *Manager {
 	return &Manager{
-		agents:   make(map[string]*Agent),
-		tmux:     tmux.NewManager(config.Tmux.SessionPrefix),
-		stateDir: stateDir,
-		agentCmd: config.AgentLegacy.Command,
+		agents:           make(map[string]*Agent),
+		tmux:             tmux.NewManager(config.Tmux.SessionPrefix),
+		providerRegistry: provider.DefaultRegistry,
+		stateDir:         stateDir,
+		agentCmd:         config.AgentLegacy.Command,
 	}
 }
 
@@ -429,11 +432,12 @@ func NewManager(stateDir string) *Manager {
 // Tmux session names will be unique per workspace to avoid collisions.
 func NewWorkspaceManager(stateDir, workspacePath string) *Manager {
 	return &Manager{
-		agents:        make(map[string]*Agent),
-		tmux:          tmux.NewWorkspaceManager(config.Tmux.SessionPrefix, workspacePath),
-		stateDir:      stateDir,
-		agentCmd:      config.AgentLegacy.Command,
-		workspacePath: workspacePath,
+		agents:           make(map[string]*Agent),
+		tmux:             tmux.NewWorkspaceManager(config.Tmux.SessionPrefix, workspacePath),
+		providerRegistry: provider.DefaultRegistry,
+		stateDir:         stateDir,
+		agentCmd:         config.AgentLegacy.Command,
+		workspacePath:    workspacePath,
 	}
 }
 
@@ -662,8 +666,24 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 		}
 	}
 
-	// #1531 fix: Verify the command binary exists in PATH before spawning
-	if agentCmd != "" {
+	// Validate tool binary exists before spawning.
+	// Use provider registry for known tools (richer validation + version logging),
+	// fall back to PATH check for custom/unknown tools.
+	providerValidated := false
+	if tool != "" && m.providerRegistry != nil {
+		if p, ok := m.providerRegistry.Get(tool); ok {
+			ctx := context.TODO()
+			if !p.IsInstalled(ctx) {
+				return nil, fmt.Errorf("tool %q is not installed. Install %s or configure a different tool in config.toml", tool, p.Name())
+			}
+			if v := p.Version(ctx); v != "" {
+				log.Debug("provider validated", "tool", tool, "version", v)
+			}
+			providerValidated = true
+		}
+	}
+
+	if !providerValidated && agentCmd != "" {
 		parts := strings.Fields(agentCmd)
 		if len(parts) > 0 {
 			if _, err := exec.LookPath(parts[0]); err != nil {
@@ -1433,25 +1453,19 @@ func (m *Manager) RefreshState() error {
 		if live := m.captureLiveTask(name); live != "" {
 			a.Task = live
 
-			// Sync state with task symbols:
-			// - Spinner symbols (✻ ✳ ✽ ·) → working
-			// - Prompt symbol (❯) or pause (⏺) → idle (waiting for input)
-			//
+			// Use provider-based state detection if available for richer state inference
+			newState := m.detectAgentState(a.Tool, live)
+
 			// IMPORTANT: Preserve error, stuck, and done states - these are explicitly
-			// reported by agents and should not be overwritten by tmux activity detection.
+			// reported by agents and should not be overwritten by activity detection.
 			// Only toggle between working and idle for agents in "normal" states.
-			if strings.HasPrefix(live, "✻") ||
-				strings.HasPrefix(live, "✳") ||
-				strings.HasPrefix(live, "✽") ||
-				strings.HasPrefix(live, "·") {
-				// Only change to working from idle/starting - preserve error/stuck/done
+			switch newState {
+			case StateWorking:
 				if a.State == StateIdle || a.State == StateStarting {
 					a.State = StateWorking
 					a.UpdatedAt = time.Now()
 				}
-			} else if strings.HasPrefix(live, "❯") ||
-				strings.HasPrefix(live, "⏺") {
-				// Only change to idle from working - preserve error/stuck/done
+			case StateIdle:
 				if a.State == StateWorking {
 					a.State = StateIdle
 					a.UpdatedAt = time.Now()
@@ -1464,6 +1478,44 @@ func (m *Manager) RefreshState() error {
 }
 
 // captureLiveTask extracts a one-line activity summary from an agent's tmux pane.
+// detectAgentState determines agent state from output, using provider-based
+// detection when available or falling back to symbol-based heuristics.
+func (m *Manager) detectAgentState(tool, output string) State {
+	// Try provider-based detection if tool is known
+	if tool != "" && m.providerRegistry != nil {
+		if p, ok := m.providerRegistry.Get(tool); ok {
+			ps := p.DetectState(output)
+			switch ps {
+			case provider.StateWorking:
+				return StateWorking
+			case provider.StateIdle:
+				return StateIdle
+			case provider.StateDone:
+				return StateDone
+			case provider.StateError:
+				return StateError
+			case provider.StateStuck:
+				return StateStuck
+			}
+			// provider.StateUnknown — fall through to symbol detection
+		}
+	}
+
+	// Fall back to symbol-based detection (works for all tools)
+	if strings.HasPrefix(output, "✻") ||
+		strings.HasPrefix(output, "✳") ||
+		strings.HasPrefix(output, "✽") ||
+		strings.HasPrefix(output, "·") {
+		return StateWorking
+	}
+	if strings.HasPrefix(output, "❯") ||
+		strings.HasPrefix(output, "⏺") {
+		return StateIdle
+	}
+
+	return ""
+}
+
 func (m *Manager) captureLiveTask(name string) string {
 	output, err := m.tmux.Capture(context.TODO(), name, 15)
 	if err != nil {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/rpuneet/bc/config"
+	"github.com/rpuneet/bc/pkg/provider"
 	"github.com/rpuneet/bc/pkg/tmux"
 )
 
@@ -3546,5 +3547,175 @@ func TestFollowOutput_AgentNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected 'not found' error, got %q", err.Error())
+	}
+}
+
+// --- Provider integration tests ---
+
+// mockProvider implements provider.Provider for testing.
+type mockProvider struct {
+	detectState provider.State
+	name        string
+	version     string
+	installed   bool
+}
+
+func (m mockProvider) Name() string                        { return m.name }
+func (m mockProvider) Description() string                 { return "mock " + m.name }
+func (m mockProvider) Command() string                     { return m.name }
+func (m mockProvider) IsInstalled(_ context.Context) bool  { return m.installed }
+func (m mockProvider) Version(_ context.Context) string    { return m.version }
+func (m mockProvider) DetectState(_ string) provider.State { return m.detectState }
+
+func newTestManagerWithProvider(t *testing.T, p provider.Provider) *Manager {
+	t.Helper()
+	reg := provider.NewRegistry()
+	reg.Register(p)
+	return &Manager{
+		agents:           make(map[string]*Agent),
+		tmux:             tmux.NewManager(fmt.Sprintf("bctest-%d-", time.Now().UnixNano())),
+		providerRegistry: reg,
+		stateDir:         t.TempDir(),
+		agentCmd:         "/bin/true",
+	}
+}
+
+func TestSpawnWithProvider_Installed(t *testing.T) {
+	// Register a mock provider that reports as installed
+	mp := mockProvider{name: "testcli", installed: true, version: "1.2.3"}
+	m := newTestManagerWithProvider(t, mp)
+
+	// Configure tool in config so GetAgentCommand finds it
+	config.Agents = append(config.Agents, config.AgentsItem{Name: "testcli", Command: "/bin/true"})
+	defer func() { config.Agents = config.Agents[:len(config.Agents)-1] }()
+
+	ag, err := m.SpawnAgentWithTool("test-agent", Role("engineer"), t.TempDir(), "testcli")
+	if err != nil {
+		t.Fatalf("expected spawn to succeed with installed provider, got: %v", err)
+	}
+	if ag == nil {
+		t.Fatal("expected non-nil agent")
+	}
+	if ag.Tool != "testcli" {
+		t.Errorf("expected tool 'testcli', got %q", ag.Tool)
+	}
+
+	// Clean up tmux session
+	_ = m.tmux.KillSession(context.Background(), "test-agent")
+}
+
+func TestSpawnWithProvider_NotInstalled(t *testing.T) {
+	// Register a mock provider that reports as NOT installed
+	mp := mockProvider{name: "missingtool", installed: false}
+	m := newTestManagerWithProvider(t, mp)
+
+	// Configure tool in config
+	config.Agents = append(config.Agents, config.AgentsItem{Name: "missingtool", Command: "missingtool"})
+	defer func() { config.Agents = config.Agents[:len(config.Agents)-1] }()
+
+	_, err := m.SpawnAgentWithTool("test-agent", Role("engineer"), t.TempDir(), "missingtool")
+	if err == nil {
+		t.Fatal("expected error for uninstalled provider")
+	}
+	if !strings.Contains(err.Error(), "is not installed") {
+		t.Errorf("expected 'is not installed' error, got %q", err.Error())
+	}
+}
+
+func TestSpawnWithProvider_CustomToolFallback(t *testing.T) {
+	// Manager has a registry but the tool is NOT registered in it
+	reg := provider.NewRegistry()
+	// Only register "sometool" — "customtool" is unknown
+	reg.Register(mockProvider{name: "sometool", installed: true})
+
+	m := &Manager{
+		agents:           make(map[string]*Agent),
+		tmux:             tmux.NewManager(fmt.Sprintf("bctest-%d-", time.Now().UnixNano())),
+		providerRegistry: reg,
+		stateDir:         t.TempDir(),
+		agentCmd:         "/bin/true",
+	}
+
+	// Configure custom tool that exists as a binary
+	config.Agents = append(config.Agents, config.AgentsItem{Name: "customtool", Command: "true"})
+	defer func() { config.Agents = config.Agents[:len(config.Agents)-1] }()
+
+	// Should succeed because "true" exists in PATH (falls back to exec.LookPath)
+	ag, err := m.SpawnAgentWithTool("test-agent", Role("engineer"), t.TempDir(), "customtool")
+	if err != nil {
+		t.Fatalf("expected spawn to succeed for unknown tool with valid binary, got: %v", err)
+	}
+	if ag == nil {
+		t.Fatal("expected non-nil agent")
+	}
+
+	// Clean up
+	_ = m.tmux.KillSession(context.Background(), "test-agent")
+}
+
+func TestDetectAgentState_WithProvider(t *testing.T) {
+	tests := []struct {
+		name          string
+		providerState provider.State
+		output        string
+		expected      State
+	}{
+		{"provider detects working", provider.StateWorking, "thinking...", StateWorking},
+		{"provider detects idle", provider.StateIdle, "> ready", StateIdle},
+		{"provider detects done", provider.StateDone, "✓ complete", StateDone},
+		{"provider detects error", provider.StateError, "error: failed", StateError},
+		{"provider detects stuck", provider.StateStuck, "rate limit exceeded", StateStuck},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mp := mockProvider{name: "testtool", detectState: tc.providerState}
+			m := newTestManagerWithProvider(t, mp)
+
+			got := m.detectAgentState("testtool", tc.output)
+			if got != tc.expected {
+				t.Errorf("detectAgentState(%q, %q) = %q, want %q", "testtool", tc.output, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDetectAgentState_FallbackSymbols(t *testing.T) {
+	// Manager with empty registry — no providers match
+	m := &Manager{
+		providerRegistry: provider.NewRegistry(),
+	}
+
+	tests := []struct {
+		name     string
+		output   string
+		expected State
+	}{
+		{"spinner working", "✻ Reading file...", StateWorking},
+		{"dot working", "· Processing...", StateWorking},
+		{"prompt idle", "❯ ", StateIdle},
+		{"pause idle", "⏺ Bash", StateIdle},
+		{"unknown output", "some random text", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := m.detectAgentState("unknowntool", tc.output)
+			if got != tc.expected {
+				t.Errorf("detectAgentState(%q, %q) = %q, want %q", "unknowntool", tc.output, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestDetectAgentState_ProviderUnknownFallsThrough(t *testing.T) {
+	// Provider returns StateUnknown — should fall through to symbol detection
+	mp := mockProvider{name: "testtool", detectState: provider.StateUnknown}
+	m := newTestManagerWithProvider(t, mp)
+
+	// Symbol-based: spinner should detect as working even when provider returns unknown
+	got := m.detectAgentState("testtool", "✻ Working on task")
+	if got != StateWorking {
+		t.Errorf("expected StateWorking from symbol fallback, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Wires `pkg/provider` registry into `pkg/agent` for pre-spawn tool validation and richer state detection
- `SpawnAgentWithOptions()` now looks up provider via `provider.DefaultRegistry`, calls `IsInstalled()` for validation and `Version()` for debug logging before creating tmux sessions
- `RefreshState()` uses new `detectAgentState()` helper that delegates to provider's `DetectState()` when available, falling back to existing symbol-based heuristics
- Custom/unregistered tools fall back to existing `exec.LookPath` behavior — no breaking changes

Closes #1860

## Test plan
- [x] `TestSpawnWithProvider_Installed` — mock provider reports installed, spawn succeeds
- [x] `TestSpawnWithProvider_NotInstalled` — mock provider reports not installed, clear error
- [x] `TestSpawnWithProvider_CustomToolFallback` — unknown tool skips provider, falls back to PATH check
- [x] `TestDetectAgentState_WithProvider` — 5 subtests (working/idle/done/error/stuck)
- [x] `TestDetectAgentState_FallbackSymbols` — 5 subtests (spinner/dot/prompt/pause/unknown)
- [x] `TestDetectAgentState_ProviderUnknownFallsThrough` — provider returns unknown, symbol detection takes over
- [x] All tests pass with `-race` detector
- [x] `golangci-lint` clean on `pkg/agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)