### PR TITLE
feat(provider): add Gemini and Cursor provider implementations

### DIFF
--- a/pkg/provider/cursor.go
+++ b/pkg/provider/cursor.go
@@ -1,0 +1,114 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// CursorProvider implements the Provider interface for Cursor Agent.
+type CursorProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewCursorProvider creates a new Cursor provider.
+func NewCursorProvider() *CursorProvider {
+	return &CursorProvider{
+		name:        "cursor",
+		description: "Cursor Agent CLI",
+		command:     "cursor-agent --force --print",
+		binary:      "cursor-agent",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *CursorProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *CursorProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *CursorProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *CursorProvider) IsInstalled(ctx context.Context) bool {
+	return checkBinaryExists(ctx, p.binary)
+}
+
+// Version returns the installed version.
+func (p *CursorProvider) Version(ctx context.Context) string {
+	return getBinaryVersion(ctx, p.binary, "--version")
+}
+
+// DetectState analyzes output to determine agent state.
+// Cursor Agent uses specific output patterns for state detection.
+func (p *CursorProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+		lineLower := strings.ToLower(line)
+
+		// Done indicators (check before working to avoid keyword overlap)
+		if strings.Contains(line, "✓") ||
+			strings.Contains(line, "✔") ||
+			strings.Contains(lineLower, "complete") ||
+			strings.Contains(lineLower, "finished") ||
+			strings.Contains(lineLower, "applied") {
+			return StateDone
+		}
+
+		// Stuck indicators (check before working/error)
+		if strings.Contains(lineLower, "rate limit") ||
+			strings.Contains(lineLower, "quota") ||
+			strings.Contains(lineLower, "timeout") ||
+			strings.Contains(lineLower, "connection refused") {
+			return StateStuck
+		}
+
+		// Error indicators (check before working)
+		if strings.Contains(lineLower, "error") ||
+			strings.Contains(lineLower, "failed") ||
+			strings.Contains(line, "✗") ||
+			strings.Contains(line, "❌") {
+			return StateError
+		}
+
+		// Working indicators — Cursor activity patterns
+		if strings.HasPrefix(line, "⠋") ||
+			strings.HasPrefix(line, "⠙") ||
+			strings.HasPrefix(line, "⠹") ||
+			strings.HasPrefix(line, "⠸") ||
+			strings.Contains(lineLower, "thinking") ||
+			strings.Contains(lineLower, "generating") ||
+			strings.Contains(lineLower, "processing") ||
+			strings.Contains(lineLower, "applying") {
+			return StateWorking
+		}
+
+		// Idle/prompt indicators
+		if strings.HasPrefix(line, ">") ||
+			strings.HasPrefix(line, "$") ||
+			strings.HasPrefix(line, "cursor>") ||
+			strings.Contains(lineLower, "ready") ||
+			strings.Contains(lineLower, "awaiting") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure CursorProvider implements Provider interface.
+var _ Provider = (*CursorProvider)(nil)

--- a/pkg/provider/gemini.go
+++ b/pkg/provider/gemini.go
@@ -1,0 +1,113 @@
+package provider
+
+import (
+	"context"
+	"strings"
+)
+
+// GeminiProvider implements the Provider interface for Google Gemini CLI.
+type GeminiProvider struct {
+	name        string
+	description string
+	command     string
+	binary      string
+}
+
+// NewGeminiProvider creates a new Gemini provider.
+func NewGeminiProvider() *GeminiProvider {
+	return &GeminiProvider{
+		name:        "gemini",
+		description: "Google Gemini CLI",
+		command:     "gemini --yolo",
+		binary:      "gemini",
+	}
+}
+
+// Name returns the provider's unique identifier.
+func (p *GeminiProvider) Name() string {
+	return p.name
+}
+
+// Description returns a human-readable description.
+func (p *GeminiProvider) Description() string {
+	return p.description
+}
+
+// Command returns the shell command to start this provider.
+func (p *GeminiProvider) Command() string {
+	return p.command
+}
+
+// IsInstalled checks if the provider binary is available.
+func (p *GeminiProvider) IsInstalled(ctx context.Context) bool {
+	return checkBinaryExists(ctx, p.binary)
+}
+
+// Version returns the installed version.
+func (p *GeminiProvider) Version(ctx context.Context) string {
+	return getBinaryVersion(ctx, p.binary, "--version")
+}
+
+// DetectState analyzes output to determine agent state.
+// Gemini CLI uses specific output patterns for state detection.
+func (p *GeminiProvider) DetectState(output string) State {
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 {
+		return StateUnknown
+	}
+
+	for i := len(lines) - 1; i >= 0 && i >= len(lines)-5; i-- {
+		line := strings.TrimSpace(lines[i])
+		lineLower := strings.ToLower(line)
+
+		// Done indicators (check before working to avoid "finished" matching "processing")
+		if strings.Contains(line, "✓") ||
+			strings.Contains(line, "✔") ||
+			strings.Contains(lineLower, "complete") ||
+			strings.Contains(lineLower, "finished") ||
+			strings.Contains(lineLower, "done") {
+			return StateDone
+		}
+
+		// Stuck indicators (check before working/error)
+		if strings.Contains(lineLower, "rate limit") ||
+			strings.Contains(lineLower, "quota") ||
+			strings.Contains(lineLower, "timeout") {
+			return StateStuck
+		}
+
+		// Error indicators (check before working)
+		if strings.Contains(lineLower, "error") ||
+			strings.Contains(lineLower, "failed") ||
+			strings.Contains(line, "✗") ||
+			strings.Contains(line, "✖") {
+			return StateError
+		}
+
+		// Working indicators — Gemini spinner and activity patterns
+		if strings.HasPrefix(line, "⠋") ||
+			strings.HasPrefix(line, "⠙") ||
+			strings.HasPrefix(line, "⠹") ||
+			strings.HasPrefix(line, "⠸") ||
+			strings.Contains(lineLower, "thinking") ||
+			strings.Contains(lineLower, "generating") ||
+			strings.Contains(lineLower, "processing") ||
+			strings.Contains(lineLower, "searching") {
+			return StateWorking
+		}
+
+		// Idle/prompt indicators
+		if strings.HasPrefix(line, ">") ||
+			strings.HasPrefix(line, "$") ||
+			strings.HasPrefix(line, "gemini>") ||
+			strings.Contains(lineLower, "ready") ||
+			strings.Contains(lineLower, "awaiting") {
+			return StateIdle
+		}
+	}
+
+	return StateUnknown
+}
+
+// Ensure GeminiProvider implements Provider interface.
+var _ Provider = (*GeminiProvider)(nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -97,6 +97,8 @@ func init() {
 	DefaultRegistry.Register(NewCodexProvider())
 	DefaultRegistry.Register(NewOpenClawProvider())
 	DefaultRegistry.Register(NewAiderProvider())
+	DefaultRegistry.Register(NewGeminiProvider())
+	DefaultRegistry.Register(NewCursorProvider())
 }
 
 // checkBinaryExists checks if a binary exists in PATH.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -70,6 +70,12 @@ func TestDefaultRegistryHasProviders(t *testing.T) {
 	if _, ok := DefaultRegistry.Get("aider"); !ok {
 		t.Error("expected aider provider in default registry")
 	}
+	if _, ok := DefaultRegistry.Get("gemini"); !ok {
+		t.Error("expected gemini provider in default registry")
+	}
+	if _, ok := DefaultRegistry.Get("cursor"); !ok {
+		t.Error("expected cursor provider in default registry")
+	}
 }
 
 func TestGetProvider(t *testing.T) {
@@ -690,6 +696,107 @@ func TestAiderDetectState(t *testing.T) {
 			output: "",
 			want:   StateUnknown,
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGeminiProvider(t *testing.T) {
+	p := NewGeminiProvider()
+
+	if p.Name() != "gemini" {
+		t.Errorf("expected name 'gemini', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() != "gemini --yolo" {
+		t.Errorf("expected command 'gemini --yolo', got %q", p.Command())
+	}
+}
+
+func TestGeminiDetectState(t *testing.T) {
+	p := NewGeminiProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{"working spinner", "⠋ Loading model...\n", StateWorking},
+		{"working thinking", "thinking about your question\n", StateWorking},
+		{"working generating", "generating response\n", StateWorking},
+		{"working searching", "searching for information\n", StateWorking},
+		{"done check", "✓ Response complete\n", StateDone},
+		{"done finished", "finished processing\n", StateDone},
+		{"stuck rate limit", "rate limit exceeded\n", StateStuck},
+		{"stuck quota", "quota exceeded for today\n", StateStuck},
+		{"stuck timeout", "request timeout\n", StateStuck},
+		{"error", "error: model not found\n", StateError},
+		{"error failed", "failed to generate\n", StateError},
+		{"idle prompt", "> ", StateIdle},
+		{"idle gemini prompt", "gemini> ", StateIdle},
+		{"idle ready", "ready for input\n", StateIdle},
+		{"unknown", "some random output\n", StateUnknown},
+		{"empty", "", StateUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.DetectState(tt.output)
+			if got != tt.want {
+				t.Errorf("DetectState() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCursorProvider(t *testing.T) {
+	p := NewCursorProvider()
+
+	if p.Name() != "cursor" {
+		t.Errorf("expected name 'cursor', got %q", p.Name())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.Command() != "cursor-agent --force --print" {
+		t.Errorf("expected command 'cursor-agent --force --print', got %q", p.Command())
+	}
+}
+
+func TestCursorDetectState(t *testing.T) {
+	p := NewCursorProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		want   State
+	}{
+		{"working spinner", "⠙ Processing request...\n", StateWorking},
+		{"working thinking", "thinking about changes\n", StateWorking},
+		{"working applying", "applying edits to file\n", StateWorking},
+		{"done check", "✔ Changes applied\n", StateDone},
+		{"done applied", "applied changes to 3 files\n", StateDone},
+		{"done complete", "edit complete\n", StateDone},
+		{"stuck rate limit", "rate limit hit, retrying\n", StateStuck},
+		{"stuck connection", "connection refused\n", StateStuck},
+		{"stuck timeout", "request timeout\n", StateStuck},
+		{"error", "error: file not found\n", StateError},
+		{"error failed", "failed to apply edit\n", StateError},
+		{"error emoji", "❌ Operation failed\n", StateError},
+		{"idle prompt", "> ", StateIdle},
+		{"idle cursor prompt", "cursor> ", StateIdle},
+		{"idle ready", "ready\n", StateIdle},
+		{"unknown", "some output text\n", StateUnknown},
+		{"empty", "", StateUnknown},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Adds `GeminiProvider` (gemini.go) and `CursorProvider` (cursor.go) implementing the full `Provider` interface
- Both use priority-ordered state detection: done > stuck > error > working > idle (avoids keyword overlap issues like "finished processing")
- Registered in `DefaultRegistry` — all 7 configured tools now have provider implementations
- `bc tool list` and agent spawn validation now cover gemini and cursor

Closes #1868

## Test plan
- [x] `TestGeminiProvider` — name, description, command validation
- [x] `TestGeminiDetectState` — 16 subtests covering all states + edge cases
- [x] `TestCursorProvider` — name, description, command validation
- [x] `TestCursorDetectState` — 17 subtests covering all states + edge cases
- [x] `TestDefaultRegistryHasProviders` — updated to verify gemini + cursor in registry
- [x] All tests pass with `-race` detector
- [x] `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)