### PR TITLE
feat(tui): add ToolsView for bc tool list (#1866)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -26,6 +26,7 @@ import { LogsView } from './views/LogsView';
 import { WorktreesView } from './views/WorktreesView';
 import { MemoryView } from './views/MemoryView';
 import { HelpView } from './views/HelpView';
+import { ToolsView } from './views/ToolsView';
 import { CommandBar } from './components/CommandBar';
 import { FilterBar } from './components/FilterBar';
 import { FilterProvider } from './hooks/useFilter';
@@ -180,6 +181,8 @@ const ViewContent = memo(function ViewContent({ view }: ViewContentProps): React
       return <WorktreesView />;
     case 'memory':
       return <MemoryView />;
+    case 'tools':
+      return <ToolsView />;
     case 'help':
       return <HelpView />;
     default:

--- a/tui/src/hooks/useKeybindings.ts
+++ b/tui/src/hooks/useKeybindings.ts
@@ -89,6 +89,7 @@ export const DEFAULT_VIEW_NUMBERS: Record<string, View> = {
   '6': 'logs',
   '7': 'worktrees',
   '8': 'memory',
+  '9': 'tools',
 };
 
 /** Status bar hint for a keybinding */

--- a/tui/src/navigation/NavigationContext.tsx
+++ b/tui/src/navigation/NavigationContext.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useContext, useState, useCallback, useMemo } from
 import type { ReactNode } from 'react';
 
 // View types for navigation - trimmed to 8 core views
-export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'logs' | 'roles' | 'worktrees' | 'memory' | 'help';
+export type View = 'dashboard' | 'agents' | 'channels' | 'costs' | 'logs' | 'roles' | 'worktrees' | 'memory' | 'tools' | 'help';
 
 // Tab configuration
 export interface TabConfig {
@@ -27,6 +27,7 @@ export const DEFAULT_TABS: TabConfig[] = [
   { key: 'ro', view: 'roles', label: 'Roles', shortLabel: 'Role' },
   { key: 'wt', view: 'worktrees', label: 'Worktrees', shortLabel: 'Tree' },
   { key: 'mem', view: 'memory', label: 'Memory', shortLabel: 'Mem' },
+  { key: 'tl', view: 'tools', label: 'Tools', shortLabel: 'Tool' },
   { key: '?', view: 'help', label: 'Help', shortLabel: '?' },
 ];
 

--- a/tui/src/navigation/viewCommands.ts
+++ b/tui/src/navigation/viewCommands.ts
@@ -32,6 +32,7 @@ export const VIEW_COMMANDS: ViewCommand[] = [
   { command: 'costs', aliases: ['co', 'cost'], view: 'costs', section: 'CORE' },
   { command: 'logs', aliases: ['log', 'l'], view: 'logs', section: 'CORE' },
   { command: 'memory', aliases: ['mem', 'm'], view: 'memory', section: 'CORE' },
+  { command: 'tools', aliases: ['tool', 't'], view: 'tools', section: 'SYSTEM' },
   { command: 'roles', aliases: ['ro', 'r'], view: 'roles', section: 'SYSTEM' },
   { command: 'worktrees', aliases: ['wt', 'w'], view: 'worktrees', section: 'SYSTEM' },
   { command: 'help', aliases: ['?', 'h'], view: 'help', section: 'CORE' },

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -25,6 +25,7 @@ import type {
   AgentMemory,
   MemoryListResponse,
   MemorySearchResult,
+  ToolInfo,
 } from '../types';
 
 // ============================================================================
@@ -230,7 +231,7 @@ export async function execBc(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
     // Always add --json flag if not present and command supports it
     // #1756: Added 'memory' to fix Memory tab showing nothing
-    const jsonCommands = ['status', 'stats', 'channel', 'cost', 'logs', 'agent', 'process', 'demon', 'team', 'role', 'worktree', 'memory'];
+    const jsonCommands = ['status', 'stats', 'channel', 'cost', 'logs', 'agent', 'process', 'demon', 'team', 'role', 'worktree', 'memory', 'tool'];
     const hasJsonFlag = args.includes('--json');
     const command = args[0];
 
@@ -771,6 +772,22 @@ export async function clearMemory(agentName: string): Promise<void> {
  */
 export async function exportMemory(agentName: string): Promise<string> {
   return await execBc(['memory', 'export', agentName]);
+}
+
+// ============================================================================
+// Tool Commands (#1866 - Tools View)
+// ============================================================================
+
+/**
+ * Get list of installed tools/providers
+ * #1866: Returns array of tool info objects
+ */
+export async function getToolList(): Promise<ToolInfo[]> {
+  try {
+    return await execBcJsonCached<ToolInfo[]>(['tool', 'list'], 30000);
+  } catch {
+    return [];
+  }
 }
 
 // ============================================================================

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -316,6 +316,17 @@ export interface RoutingConfig {
   rules: RoutingRule[];
 }
 
+// Tool types for Tools view (#1866)
+export type ToolStatus = 'installed' | 'not found';
+
+export interface ToolInfo {
+  name: string;
+  status: ToolStatus;
+  version: string;
+  command: string;
+  path?: string;
+}
+
 // GitHub Issue types for Issues view (#1754)
 export type IssueState = 'OPEN' | 'CLOSED';
 

--- a/tui/src/views/ToolsView.tsx
+++ b/tui/src/views/ToolsView.tsx
@@ -1,0 +1,167 @@
+/**
+ * ToolsView - Display installed tools and their status
+ * Issue #1866 - Tools view for bc tool list
+ */
+
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { Box, Text } from 'ink';
+import { LoadingIndicator } from '../components/LoadingIndicator';
+import { HeaderBar } from '../components/HeaderBar';
+import { Footer } from '../components/Footer';
+import { useDisableInput, useListNavigation } from '../hooks';
+import { truncate } from '../utils';
+import type { ToolInfo } from '../types';
+import { getToolList } from '../services/bc';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface ToolsViewProps {}
+
+export function ToolsView(_props: ToolsViewProps = {}): React.ReactElement {
+  const { isDisabled: disableInput } = useDisableInput();
+  const [tools, setTools] = useState<ToolInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTools = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await getToolList();
+      setTools(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch tools');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchTools();
+  }, [fetchTools]);
+
+  const customKeys = useMemo(
+    () => ({
+      'r': () => { void fetchTools(); },
+    }),
+    [fetchTools]
+  );
+
+  const { selectedIndex } = useListNavigation({
+    items: tools,
+    disabled: disableInput,
+    customKeys,
+  });
+
+  // Dynamic name column width
+  const nameWidth = useMemo(() => {
+    if (tools.length === 0) return 15;
+    const maxLen = Math.max(...tools.map((t) => t.name.length));
+    return Math.min(25, Math.max(15, maxLen + 3));
+  }, [tools]);
+
+  if (loading && tools.length === 0) {
+    return <LoadingIndicator message="Loading tools..." />;
+  }
+
+  if (error && tools.length === 0) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="red">Error: {error}</Text>
+        <Text dimColor>Press r to retry, q to go back</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width="100%" overflow="hidden">
+      <HeaderBar
+        title="Tools"
+        count={tools.length}
+        loading={loading}
+        color="cyan"
+      />
+
+      {/* Table header */}
+      <Box flexDirection="column" marginBottom={1}>
+        <Box paddingX={1}>
+          <Box width={nameWidth}>
+            <Text bold dimColor>NAME</Text>
+          </Box>
+          <Box width={14}>
+            <Text bold dimColor>STATUS</Text>
+          </Box>
+          <Box width={16}>
+            <Text bold dimColor>VERSION</Text>
+          </Box>
+          <Box flexGrow={1}>
+            <Text bold dimColor>COMMAND</Text>
+          </Box>
+        </Box>
+
+        {tools.length === 0 ? (
+          <Box paddingX={1} marginTop={1}>
+            <Text dimColor>No tools found.</Text>
+          </Box>
+        ) : (
+          tools.map((tool, idx) => (
+            <ToolRow
+              key={tool.name}
+              tool={tool}
+              selected={idx === selectedIndex}
+              nameWidth={nameWidth}
+            />
+          ))
+        )}
+      </Box>
+
+      {error && (
+        <Box marginBottom={1} paddingX={1}>
+          <Text color="red">Error: {error}</Text>
+        </Box>
+      )}
+
+      <Footer hints={[
+        { key: 'j/k', label: 'nav' },
+        { key: 'g/G', label: 'top/bottom' },
+        { key: 'r', label: 'refresh' },
+      ]} />
+    </Box>
+  );
+}
+
+interface ToolRowProps {
+  tool: ToolInfo;
+  selected: boolean;
+  nameWidth: number;
+}
+
+function ToolRow({ tool, selected, nameWidth }: ToolRowProps): React.ReactElement {
+  const isInstalled = tool.status === 'installed';
+  const statusColor = isInstalled ? 'green' : 'red';
+  const statusIcon = isInstalled ? '✓' : '✗';
+  const truncateLen = nameWidth - 3;
+
+  return (
+    <Box paddingX={1}>
+      <Box width={nameWidth}>
+        <Text color={selected ? 'cyan' : undefined} bold={selected}>
+          {selected ? '▸ ' : '  '}
+          {truncate(tool.name, truncateLen)}
+        </Text>
+      </Box>
+      <Box width={14}>
+        <Text color={statusColor}>
+          {statusIcon} {tool.status}
+        </Text>
+      </Box>
+      <Box width={16}>
+        <Text dimColor>{truncate(tool.version || '-', 14)}</Text>
+      </Box>
+      <Box flexGrow={1}>
+        <Text dimColor>{truncate(tool.command, 40)}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export default ToolsView;

--- a/tui/src/views/index.ts
+++ b/tui/src/views/index.ts
@@ -12,5 +12,6 @@ export { LogsView } from './LogsView';
 export { RolesView } from './RolesView';
 export { WorktreesView } from './WorktreesView';
 export { MemoryView } from './MemoryView';
+export { ToolsView } from './ToolsView';
 export { HelpView } from './HelpView';
 


### PR DESCRIPTION
## Summary
- Adds **ToolsView** displaying installed tools from `bc tool list --json` with name, status (✓/✗), version, and command columns
- Adds `ToolInfo` types, `getToolList()` service with 30s stale-while-revalidate cache
- Registers tools in navigation: View type union, tab config (`tl`), `:tools/:tool/:t` command bar, number key `9`
- Follows existing patterns: HeaderBar, cyan `▸` selection via `useListNavigation`, Footer hints, `r` to refresh

## Files Changed
- `tui/src/types/index.ts` — `ToolStatus`, `ToolInfo` types
- `tui/src/services/bc.ts` — `getToolList()` + `'tool'` in jsonCommands
- `tui/src/navigation/NavigationContext.tsx` — `'tools'` in View type + tab config
- `tui/src/navigation/viewCommands.ts` — `:tools` command entry
- `tui/src/hooks/useKeybindings.ts` — `'9': 'tools'` mapping
- `tui/src/views/ToolsView.tsx` — **NEW** — main view component
- `tui/src/app.tsx` — ViewContent case + import
- `tui/src/views/index.ts` — barrel export

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] No new lint errors (all errors pre-existing in other files)
- [x] No new test failures (2823 pass, failures are pre-existing)
- [ ] Manual: `bc tui` → press `9` or `:tools` to verify view renders
- [ ] Manual: verify tool list with ✓/✗ status indicators
- [ ] Manual: j/k navigation with cyan selection, `r` refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)