### PR TITLE
feat(workspace): migrate ToolsConfig to ProvidersConfig/ServicesConfig

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,60 @@ path = ".bc/worktrees"
 auto_cleanup = true
 
 # =============================================================================
-# AI Tools Configuration
+# AI Providers (preferred — use this for new configs)
+# =============================================================================
+[providers]
+# Default provider for new agents
+default = "claude"
+
+[providers.claude]
+command = "claude --dangerously-skip-permissions"
+enabled = true
+
+[providers.gemini]
+command = "gemini --yolo"
+enabled = true
+
+[providers.cursor]
+command = "cursor-agent --force --print"
+enabled = false
+
+[providers.codex]
+command = "codex --full-auto"
+enabled = false
+
+[providers.opencode]
+command = "crush"
+enabled = false
+
+[providers.openclaw]
+command = "openclaw --auto"
+enabled = false
+
+[providers.aider]
+command = "aider --yes"
+enabled = false
+
+# =============================================================================
+# External Services
+# =============================================================================
+[services]
+
+[services.github]
+command = "gh"
+enabled = false
+
+[services.gitlab]
+command = "glab"
+enabled = false
+
+[services.jira]
+command = "jira"
+enabled = false
+
+# =============================================================================
+# AI Tools Configuration (DEPRECATED — use [providers] and [services] above)
+# Kept for backward compatibility with existing configs
 # =============================================================================
 [tools]
 # Default tool to use when spawning agents (must be defined below)

--- a/config/config.go
+++ b/config/config.go
@@ -43,10 +43,77 @@ type PerformanceConfig struct {
 	PollIntervalTeams      int64
 }
 
+type ProvidersAiderConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ProvidersClaudeConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ProvidersCodexConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ProvidersConfig struct {
+	Aider    ProvidersAiderConfig
+	Claude   ProvidersClaudeConfig
+	Codex    ProvidersCodexConfig
+	Cursor   ProvidersCursorConfig
+	Default  string
+	Gemini   ProvidersGeminiConfig
+	Openclaw ProvidersOpenclawConfig
+	Opencode ProvidersOpencodeConfig
+}
+
+type ProvidersCursorConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ProvidersGeminiConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ProvidersOpenclawConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ProvidersOpencodeConfig struct {
+	Command string
+	Enabled bool
+}
+
 type RosterConfig struct {
 	Engineers int64
 	Qa        int64
 	TechLeads int64
+}
+
+type ServicesConfig struct {
+	Github ServicesGithubConfig
+	Gitlab ServicesGitlabConfig
+	Jira   ServicesJiraConfig
+}
+
+type ServicesGithubConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ServicesGitlabConfig struct {
+	Command string
+	Enabled bool
+}
+
+type ServicesJiraConfig struct {
+	Command string
+	Enabled bool
 }
 
 type TmuxConfig struct {
@@ -200,10 +267,55 @@ var (
 		PollIntervalStatus:     2000,
 		PollIntervalTeams:      10000,
 	}
+	Providers = ProvidersConfig{
+		Aider: ProvidersAiderConfig{
+			Command: "aider --yes",
+			Enabled: false,
+		},
+		Claude: ProvidersClaudeConfig{
+			Command: "claude --dangerously-skip-permissions",
+			Enabled: true,
+		},
+		Codex: ProvidersCodexConfig{
+			Command: "codex --full-auto",
+			Enabled: false,
+		},
+		Cursor: ProvidersCursorConfig{
+			Command: "cursor-agent --force --print",
+			Enabled: false,
+		},
+		Default: "claude",
+		Gemini: ProvidersGeminiConfig{
+			Command: "gemini --yolo",
+			Enabled: true,
+		},
+		Openclaw: ProvidersOpenclawConfig{
+			Command: "openclaw --auto",
+			Enabled: false,
+		},
+		Opencode: ProvidersOpencodeConfig{
+			Command: "crush",
+			Enabled: false,
+		},
+	}
 	Roster = RosterConfig{
 		Engineers: 4,
 		Qa:        2,
 		TechLeads: 2,
+	}
+	Services = ServicesConfig{
+		Github: ServicesGithubConfig{
+			Command: "gh",
+			Enabled: false,
+		},
+		Gitlab: ServicesGitlabConfig{
+			Command: "glab",
+			Enabled: false,
+		},
+		Jira: ServicesJiraConfig{
+			Command: "jira",
+			Enabled: false,
+		},
 	}
 	Tmux = TmuxConfig{
 		SessionPrefix: "bc-",

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -487,6 +487,20 @@ func GetAgentCommand(toolName string) (string, bool) {
 	return "", false
 }
 
+// GetAgentCommandFromConfig returns the command for a tool name,
+// checking workspace ProvidersConfig first, then falling back to global config.
+// This enables per-workspace tool customization.
+func GetAgentCommandFromConfig(toolName string, wsCfg *workspace.V2Config) (string, bool) {
+	// Check workspace ProvidersConfig first
+	if wsCfg != nil {
+		if p := wsCfg.GetProvider(toolName); p != nil && p.Command != "" {
+			return p.Command, true
+		}
+	}
+	// Fall back to global config
+	return GetAgentCommand(toolName)
+}
+
 // ListAvailableTools returns a list of configured tool names.
 func ListAvailableTools() []string {
 	tools := make([]string, 0, len(config.Agents))

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rpuneet/bc/config"
 	"github.com/rpuneet/bc/pkg/provider"
 	"github.com/rpuneet/bc/pkg/tmux"
+	"github.com/rpuneet/bc/pkg/workspace"
 )
 
 func TestMain(m *testing.M) {
@@ -3717,5 +3718,60 @@ func TestDetectAgentState_ProviderUnknownFallsThrough(t *testing.T) {
 	got := m.detectAgentState("testtool", "✻ Working on task")
 	if got != StateWorking {
 		t.Errorf("expected StateWorking from symbol fallback, got %q", got)
+	}
+}
+
+func TestGetAgentCommandFromConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		tool    string
+		cfg     *workspace.V2Config
+		wantCmd string
+		wantOk  bool
+	}{
+		{
+			name: "workspace config takes precedence",
+			tool: "claude",
+			cfg: &workspace.V2Config{
+				Providers: workspace.ProvidersConfig{
+					Claude: &workspace.ProviderConfig{Command: "claude --workspace", Enabled: true},
+				},
+			},
+			wantCmd: "claude --workspace",
+			wantOk:  true,
+		},
+		{
+			name:    "falls back to global config",
+			tool:    "claude",
+			cfg:     &workspace.V2Config{},
+			wantCmd: "claude --dangerously-skip-permissions",
+			wantOk:  true,
+		},
+		{
+			name:    "nil workspace config uses global",
+			tool:    "claude",
+			cfg:     nil,
+			wantCmd: "claude --dangerously-skip-permissions",
+			wantOk:  true,
+		},
+		{
+			name:    "unknown tool returns false",
+			tool:    "nonexistent",
+			cfg:     nil,
+			wantCmd: "",
+			wantOk:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, ok := GetAgentCommandFromConfig(tt.tool, tt.cfg)
+			if ok != tt.wantOk {
+				t.Errorf("GetAgentCommandFromConfig() ok = %v, want %v", ok, tt.wantOk)
+			}
+			if cmd != tt.wantCmd {
+				t.Errorf("GetAgentCommandFromConfig() cmd = %q, want %q", cmd, tt.wantCmd)
+			}
+		})
 	}
 }

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -223,6 +223,17 @@ func DefaultV2Config(name string) V2Config {
 			Path:        ".bc/worktrees",
 			AutoCleanup: true,
 		},
+		Providers: ProvidersConfig{
+			Default: "gemini",
+			Claude: &ProviderConfig{
+				Command: "claude --dangerously-skip-permissions",
+				Enabled: true,
+			},
+			Gemini: &ProviderConfig{
+				Command: "gemini --yolo",
+				Enabled: true,
+			},
+		},
 		Tools: ToolsConfig{
 			Default: "gemini",
 			Claude: &ToolConfig{
@@ -661,6 +672,98 @@ func (c *V2Config) HasProviderDefined(name string) bool {
 // HasServiceDefined checks if an external service is configured.
 func (c *V2Config) HasServiceDefined(name string) bool {
 	return c.GetService(name) != nil
+}
+
+// ListProviders returns the names of all enabled AI providers.
+// Checks ProvidersConfig first, then falls back to legacy ToolsConfig.
+func (c *V2Config) ListProviders() []string {
+	seen := make(map[string]bool)
+	var names []string
+
+	// Check new ProvidersConfig
+	providerFields := []struct {
+		cfg  *ProviderConfig
+		name string
+	}{
+		{c.Providers.Claude, "claude"},
+		{c.Providers.Gemini, "gemini"},
+		{c.Providers.Cursor, "cursor"},
+		{c.Providers.Codex, "codex"},
+		{c.Providers.OpenCode, "opencode"},
+		{c.Providers.OpenClaw, "openclaw"},
+		{c.Providers.Aider, "aider"},
+	}
+	for _, pf := range providerFields {
+		if pf.cfg != nil && pf.cfg.Enabled {
+			names = append(names, pf.name)
+			seen[pf.name] = true
+		}
+	}
+	for name, cfg := range c.Providers.Custom {
+		if cfg.Enabled && !seen[name] {
+			names = append(names, name)
+			seen[name] = true
+		}
+	}
+
+	// Fall back to legacy ToolsConfig for providers not already found
+	legacyProviders := []struct {
+		cfg  *ToolConfig
+		name string
+	}{
+		{c.Tools.Claude, "claude"},
+		{c.Tools.Gemini, "gemini"},
+		{c.Tools.Cursor, "cursor"},
+		{c.Tools.Codex, "codex"},
+	}
+	for _, lp := range legacyProviders {
+		if lp.cfg != nil && lp.cfg.Enabled && !seen[lp.name] {
+			names = append(names, lp.name)
+			seen[lp.name] = true
+		}
+	}
+
+	return names
+}
+
+// ListServices returns the names of all enabled external services.
+// Checks ServicesConfig first, then falls back to legacy ToolsConfig.
+func (c *V2Config) ListServices() []string {
+	seen := make(map[string]bool)
+	var names []string
+
+	// Check new ServicesConfig
+	serviceFields := []struct {
+		cfg  *ServiceConfig
+		name string
+	}{
+		{c.Services.GitHub, "github"},
+		{c.Services.GitLab, "gitlab"},
+		{c.Services.Jira, "jira"},
+	}
+	for _, sf := range serviceFields {
+		if sf.cfg != nil && sf.cfg.Enabled {
+			names = append(names, sf.name)
+			seen[sf.name] = true
+		}
+	}
+
+	// Fall back to legacy ToolsConfig for services not already found
+	legacyServices := []struct {
+		cfg  *ToolConfig
+		name string
+	}{
+		{c.Tools.GitHub, "github"},
+		{c.Tools.GitLab, "gitlab"},
+		{c.Tools.Jira, "jira"},
+	}
+	for _, ls := range legacyServices {
+		if ls.cfg != nil && ls.cfg.Enabled && !seen[ls.name] {
+			names = append(names, ls.name)
+		}
+	}
+
+	return names
 }
 
 // GetDefaultTool returns the default tool configuration.

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -1764,3 +1764,182 @@ func TestGetDefaultProvider(t *testing.T) {
 		})
 	}
 }
+
+// TestListProviders tests the ListProviders method (Issue #1869)
+func TestListProviders(t *testing.T) {
+	tests := []struct { //nolint:govet // test struct alignment not critical
+		name string
+		cfg  V2Config
+		want []string
+	}{
+		{
+			name: "providers from new config",
+			cfg: V2Config{
+				Providers: ProvidersConfig{
+					Claude: &ProviderConfig{Command: "claude", Enabled: true},
+					Gemini: &ProviderConfig{Command: "gemini", Enabled: true},
+					Codex:  &ProviderConfig{Command: "codex", Enabled: false},
+				},
+			},
+			want: []string{"claude", "gemini"},
+		},
+		{
+			name: "fallback to legacy tools",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					Claude: &ToolConfig{Command: "claude", Enabled: true},
+					Cursor: &ToolConfig{Command: "cursor", Enabled: true},
+				},
+			},
+			want: []string{"claude", "cursor"},
+		},
+		{
+			name: "new config takes precedence, no duplicates",
+			cfg: V2Config{
+				Providers: ProvidersConfig{
+					Claude: &ProviderConfig{Command: "claude --new", Enabled: true},
+				},
+				Tools: ToolsConfig{
+					Claude: &ToolConfig{Command: "claude --old", Enabled: true},
+					Gemini: &ToolConfig{Command: "gemini", Enabled: true},
+				},
+			},
+			want: []string{"claude", "gemini"},
+		},
+		{
+			name: "empty config returns nil",
+			cfg:  V2Config{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.ListProviders()
+			if len(got) != len(tt.want) {
+				t.Fatalf("ListProviders() returned %d items %v, want %d items %v", len(got), got, len(tt.want), tt.want)
+			}
+			for _, w := range tt.want {
+				found := false
+				for _, g := range got {
+					if g == w {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("ListProviders() missing %q, got %v", w, got)
+				}
+			}
+		})
+	}
+}
+
+// TestListServices tests the ListServices method (Issue #1869)
+func TestListServices(t *testing.T) {
+	tests := []struct { //nolint:govet // test struct alignment not critical
+		name string
+		cfg  V2Config
+		want []string
+	}{
+		{
+			name: "services from new config",
+			cfg: V2Config{
+				Services: ServicesConfig{
+					GitHub: &ServiceConfig{Command: "gh", Enabled: true},
+					Jira:   &ServiceConfig{Command: "jira", Enabled: false},
+				},
+			},
+			want: []string{"github"},
+		},
+		{
+			name: "fallback to legacy tools",
+			cfg: V2Config{
+				Tools: ToolsConfig{
+					GitHub: &ToolConfig{Command: "gh", Enabled: true},
+					GitLab: &ToolConfig{Command: "glab", Enabled: true},
+				},
+			},
+			want: []string{"github", "gitlab"},
+		},
+		{
+			name: "no duplicates when both defined",
+			cfg: V2Config{
+				Services: ServicesConfig{
+					GitHub: &ServiceConfig{Command: "gh", Enabled: true},
+				},
+				Tools: ToolsConfig{
+					GitHub: &ToolConfig{Command: "gh-old", Enabled: true},
+					GitLab: &ToolConfig{Command: "glab", Enabled: true},
+				},
+			},
+			want: []string{"github", "gitlab"},
+		},
+		{
+			name: "empty config returns nil",
+			cfg:  V2Config{},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.ListServices()
+			if len(got) != len(tt.want) {
+				t.Fatalf("ListServices() returned %d items %v, want %d items %v", len(got), got, len(tt.want), tt.want)
+			}
+			for _, w := range tt.want {
+				found := false
+				for _, g := range got {
+					if g == w {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("ListServices() missing %q, got %v", w, got)
+				}
+			}
+		})
+	}
+}
+
+// TestHasTool_ChecksProviders tests that hasToolDefined checks providers first (Issue #1869)
+func TestHasTool_ChecksProviders(t *testing.T) {
+	cfg := V2Config{
+		Providers: ProvidersConfig{
+			OpenCode: &ProviderConfig{Command: "crush", Enabled: true},
+		},
+	}
+
+	// opencode is only in Providers, not in legacy Tools
+	if !cfg.hasToolDefined("opencode") {
+		t.Error("hasToolDefined('opencode') should return true when defined in ProvidersConfig")
+	}
+
+	// unknown should return false
+	if cfg.hasToolDefined("nonexistent") {
+		t.Error("hasToolDefined('nonexistent') should return false")
+	}
+}
+
+// TestDefaultV2Config_PopulatesProviders tests that defaults include ProvidersConfig (Issue #1869)
+func TestDefaultV2Config_PopulatesProviders(t *testing.T) {
+	cfg := DefaultV2Config("test")
+
+	// ProvidersConfig should have defaults
+	if cfg.Providers.Default == "" {
+		t.Error("DefaultV2Config should set Providers.Default")
+	}
+	if cfg.Providers.Claude == nil {
+		t.Error("DefaultV2Config should set Providers.Claude")
+	}
+	if cfg.Providers.Gemini == nil {
+		t.Error("DefaultV2Config should set Providers.Gemini")
+	}
+
+	// Should match Tools defaults
+	if cfg.Providers.Default != cfg.Tools.Default {
+		t.Errorf("Providers.Default (%q) should match Tools.Default (%q)", cfg.Providers.Default, cfg.Tools.Default)
+	}
+}


### PR DESCRIPTION
## Summary
- `DefaultV2Config()` now populates `ProvidersConfig` with defaults matching `ToolsConfig` (backward compat preserved)
- Add `ListProviders()` and `ListServices()` methods to `V2Config` — return enabled names with fallback to legacy `ToolsConfig`
- Add `[providers]` and `[services]` sections to `config.toml` with full coverage (7 providers, 3 services)
- Add `GetAgentCommandFromConfig()` in `pkg/agent` — checks workspace `ProvidersConfig` before falling back to global `config.Agents`

## Test plan
- [x] `TestListProviders` — 4 cases: new config, legacy fallback, dedup, empty
- [x] `TestListServices` — 4 cases: new config, legacy fallback, dedup, empty
- [x] `TestHasTool_ChecksProviders` — provider-first lookup
- [x] `TestDefaultV2Config_PopulatesProviders` — defaults match Tools
- [x] `TestGetAgentCommandFromConfig` — 4 cases: workspace override, global fallback, nil config, unknown tool
- [x] All tests pass with `-race` detector
- [x] Lint clean (only pre-existing `demon.go` gofmt issue)

Closes #1869
Closes part of #1771

🤖 Generated with [Claude Code](https://claude.com/claude-code)