### PR TITLE
fix(tui): reset ErrorBoundary on view change (#1876)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -133,7 +133,7 @@ function AppContent({ themeConfig }: AppContentProps): React.ReactElement {
 
       {/* Main content area - full width, no sidebar */}
       <Box flexDirection="column" flexGrow={1} overflow="hidden">
-        <ViewErrorBoundary viewName={currentView}>
+        <ViewErrorBoundary key={currentView} viewName={currentView}>
           <ViewContent view={currentView} />
         </ViewErrorBoundary>
       </Box>


### PR DESCRIPTION
## Summary
- Add `key={currentView}` to `ViewErrorBoundary` in app.tsx so React unmounts/remounts the boundary when switching views
- Previously, once any view crashed, the error state persisted and poisoned all other views

## Fix
1 file, 1 line changed. `key={currentView}` forces React to create a fresh ErrorBoundary instance per view.

Closes #1876

## Test plan
- [ ] Trigger a view crash (e.g., via #1874 LogsView null field)
- [ ] Switch to another view — should render normally instead of showing error
- [ ] Switch back — error boundary resets, view attempts fresh render