### PR TITLE
feat(tui): redesign CostsView with horizontal bars and agent drill-down

### DIFF
--- a/tui/src/hooks/useDashboard.ts
+++ b/tui/src/hooks/useDashboard.ts
@@ -20,6 +20,8 @@ interface DashboardSummary {
   totalCostUSD: number;
   inputTokens: number;
   outputTokens: number;
+  burnRate?: number;
+  topAgents?: { name: string; cost: number }[];
 }
 
 interface AgentStats {
@@ -183,6 +185,12 @@ export function useDashboard() {
   // Compute summary from data
   const summary = useMemo<DashboardSummary>(() => {
     const agentList = agents.data ?? [];
+    // #1882: Compute top agents from by_agent cost data
+    const byAgent = cost.data?.by_agent ?? {};
+    const topAgents = Object.entries(byAgent)
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 4)
+      .map(([name, agentCost]) => ({ name, cost: agentCost }));
     return {
       workspaceName,
       total: agentList.length,
@@ -194,6 +202,8 @@ export function useDashboard() {
       totalCostUSD: cost.data?.total_cost ?? 0,
       inputTokens: cost.data?.total_input_tokens ?? 0,
       outputTokens: cost.data?.total_output_tokens ?? 0,
+      burnRate: cost.data?.burn_rate,
+      topAgents,
     };
   }, [workspaceName, agents.data, cost.data]);
 

--- a/tui/src/services/bc.ts
+++ b/tui/src/services/bc.ts
@@ -418,6 +418,10 @@ export async function getCostSummary(): Promise<CostSummary> {
       by_agent: {},
       by_team: {},
       by_model: {},
+      cache_hit_rate: 0,
+      burn_rate: 0,
+      projected_total: 0,
+      billing_window_spent: 0,
     };
   }
 }

--- a/tui/src/types/index.ts
+++ b/tui/src/types/index.ts
@@ -107,6 +107,11 @@ export interface CostSummary {
   by_agent?: Record<string, number>;
   by_team?: Record<string, number>;
   by_model?: Record<string, number>;
+  // ccusage integration fields (#1882)
+  cache_hit_rate?: number;
+  burn_rate?: number;
+  projected_total?: number;
+  billing_window_spent?: number;
 }
 
 // Generic bc command result

--- a/tui/src/views/CostsView.tsx
+++ b/tui/src/views/CostsView.tsx
@@ -1,41 +1,127 @@
 /**
- * CostsView - Cost dashboard component
+ * CostsView - Cost dashboard with horizontal bars and agent drill-down
+ * Issue #1882: Cost dashboard design with ccusage integration
  * Issue #1346: Borderless compact layout for 80x24 terminals
  * Issue #1816: Add keybinding hints
  */
 
-import React, { useCallback } from 'react';
-import { Box, Text, useInput } from 'ink';
+import React, { useState, useCallback, useEffect, useMemo, memo } from 'react';
+import { Box, Text, useInput, useStdout } from 'ink';
+import { InlineProgressBar } from '../components/ProgressBar';
 import { Panel } from '../components/Panel';
 import { ErrorDisplay } from '../components/ErrorDisplay';
 import { Footer } from '../components/Footer';
-import { useCosts, useDisableInput } from '../hooks';
+import { useCosts, useDisableInput, useListNavigation } from '../hooks';
+import { useFocus } from '../navigation/FocusContext';
+import { useNavigation } from '../navigation/NavigationContext';
+import { getCostIndicator, type CostStatus } from '../theme/StatusColors';
+import { getColorForName } from '../constants/colors';
 
-// #1594: Using empty interface for future extensibility, props removed
+type SortMode = 'cost' | 'name' | 'percent';
+
+interface AgentEntry {
+  name: string;
+  cost: number;
+  percent: number;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface CostsViewProps {}
 
 export function CostsView(_props: CostsViewProps = {}): React.ReactElement {
   const { isDisabled: disableInput } = useDisableInput();
-  const isNarrow = false;
+  const { setFocus } = useFocus();
+  const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
+  const { stdout } = useStdout();
+  const terminalWidth = stdout.columns;
+  const isWide = terminalWidth >= 120;
 
   const { data: costs, loading, error, refresh } = useCosts();
 
-  // #1816: Handle keyboard shortcuts
+  const [showDetail, setShowDetail] = useState(false);
+  const [sortMode, setSortMode] = useState<SortMode>('cost');
+
+  // Build sorted agent entries
+  const agentEntries = useMemo<AgentEntry[]>(() => {
+    if (!costs?.by_agent) return [];
+    const total = costs.total_cost || 1;
+    const entries = Object.entries(costs.by_agent).map(([name, cost]) => ({
+      name,
+      cost,
+      percent: Math.round((cost / total) * 100),
+    }));
+
+    switch (sortMode) {
+      case 'name':
+        return entries.sort((a, b) => a.name.localeCompare(b.name));
+      case 'percent':
+      case 'cost':
+      default:
+        return entries.sort((a, b) => b.cost - a.cost);
+    }
+  }, [costs, sortMode]);
+
+  // List navigation
+  const handleSelect = useCallback(() => {
+    setShowDetail(true);
+  }, []);
+
+  const handleCycleSort = useCallback(() => {
+    setSortMode((prev) => {
+      if (prev === 'cost') return 'name';
+      if (prev === 'name') return 'percent';
+      return 'cost';
+    });
+  }, []);
+
   const handleRefresh = useCallback(() => {
     void refresh();
   }, [refresh]);
 
-  useInput((input) => {
-    if (input === 'r') {
-      handleRefresh();
-    }
-  }, { isActive: !disableInput });
+  const { selectedIndex, isSelected } = useListNavigation({
+    items: agentEntries,
+    onSelect: handleSelect,
+    disabled: disableInput || showDetail,
+    customKeys: {
+      s: handleCycleSort,
+      r: handleRefresh,
+    },
+  });
 
-  // Keybinding hints for footer
-  const hints = [
+  // Focus/breadcrumb management
+  useEffect(() => {
+    if (showDetail && agentEntries[selectedIndex]) {
+      setFocus('view');
+      setBreadcrumbs([{ label: agentEntries[selectedIndex].name }]);
+    } else {
+      setFocus('main');
+      clearBreadcrumbs();
+    }
+  }, [showDetail, selectedIndex, agentEntries, setFocus, setBreadcrumbs, clearBreadcrumbs]);
+
+  // Detail view input handling
+  useInput((input, key) => {
+    if (showDetail) {
+      if (key.escape || input === 'q') {
+        setShowDetail(false);
+      }
+      if (input === 'r') {
+        handleRefresh();
+      }
+    }
+  }, { isActive: showDetail && !disableInput });
+
+  // Keybinding hints
+  const mainHints = [
+    { key: 'j/k', label: 'nav' },
+    { key: 'Enter', label: 'detail' },
+    { key: 's', label: 'sort' },
     { key: 'r', label: 'refresh' },
-    { key: 'ESC', label: 'back' },
+  ];
+
+  const detailHints = [
+    { key: 'Esc/q', label: 'back' },
+    { key: 'r', label: 'refresh' },
   ];
 
   if (loading) {
@@ -43,7 +129,7 @@ export function CostsView(_props: CostsViewProps = {}): React.ReactElement {
       <Box flexDirection="column">
         <Text bold>Costs</Text>
         <Text dimColor>Loading cost data...</Text>
-        <Footer hints={hints} />
+        <Footer hints={mainHints} />
       </Box>
     );
   }
@@ -57,155 +143,432 @@ export function CostsView(_props: CostsViewProps = {}): React.ReactElement {
       <Box flexDirection="column">
         <Text bold>Costs</Text>
         <Text dimColor>No cost data available</Text>
-        <Footer hints={hints} />
+        <Footer hints={mainHints} />
       </Box>
     );
   }
 
-  // #1346: Compact borderless layout for narrow terminals (<100 cols)
-  if (isNarrow) {
-    const agentEntries = Object.entries(costs.by_agent ?? {})
-      .sort(([, a], [, b]) => b - a)
-      .slice(0, 5);
-    const modelEntries = Object.entries(costs.by_model ?? {})
-      .sort(([, a], [, b]) => b - a)
-      .slice(0, 3);
-
+  // Detail sub-view
+  if (showDetail && agentEntries[selectedIndex]) {
+    const agent = agentEntries[selectedIndex];
     return (
-      <Box flexDirection="column" padding={1}>
-        <Text bold>Cost Dashboard</Text>
-
-        {/* Inline Summary */}
-        <Box marginTop={1}>
-          <Text dimColor>Total: </Text>
-          <Text color="yellow" bold>${costs.total_cost.toFixed(4)}</Text>
-          {costs.total_input_tokens > 0 && (
-            <>
-              <Text> · </Text>
-              <Text dimColor>{costs.total_input_tokens.toLocaleString()} in</Text>
-              <Text> / </Text>
-              <Text dimColor>{costs.total_output_tokens.toLocaleString()} out</Text>
-            </>
-          )}
-        </Box>
-
-        {/* Inline By Agent */}
-        {agentEntries.length > 0 && (
-          <Box flexDirection="column" marginTop={1}>
-            <Text bold dimColor>By Agent:</Text>
-            {agentEntries.map(([agent, cost]) => (
-              <Text key={agent}>
-                <Text color="green">{agent.length > 12 ? agent.slice(0, 11) + '…' : agent}</Text>
-                <Text dimColor>: </Text>
-                <Text>${cost.toFixed(4)}</Text>
-              </Text>
-            ))}
-            {Object.keys(costs.by_agent ?? {}).length > 5 && (
-              <Text dimColor>+{Object.keys(costs.by_agent ?? {}).length - 5} more</Text>
-            )}
-          </Box>
-        )}
-
-        {/* Inline By Model */}
-        {modelEntries.length > 0 && (
-          <Box flexDirection="column" marginTop={1}>
-            <Text bold dimColor>By Model:</Text>
-            {modelEntries.map(([model, cost]) => (
-              <Text key={model}>
-                <Text color="magenta">{model.length > 15 ? model.slice(0, 14) + '…' : model}</Text>
-                <Text dimColor>: </Text>
-                <Text>${cost.toFixed(4)}</Text>
-              </Text>
-            ))}
-          </Box>
-        )}
-
-        {/* #1816: Keybinding hints */}
-        <Footer hints={hints} />
-      </Box>
+      <AgentCostDetail
+        agent={agent}
+        costs={costs}
+        hints={detailHints}
+      />
     );
   }
 
-  // Standard bordered Panel layout for wider terminals
+  // Main view
+  if (isWide) {
+    return (
+      <CostsViewWide
+        costs={costs}
+        agentEntries={agentEntries}
+        selectedIndex={selectedIndex}
+        isSelected={isSelected}
+        sortMode={sortMode}
+        hints={mainHints}
+        terminalWidth={terminalWidth}
+      />
+    );
+  }
+
   return (
-    <Box flexDirection="column" padding={1} overflow="hidden">
-      <Text bold>Cost Dashboard</Text>
+    <CostsViewCompact
+      costs={costs}
+      agentEntries={agentEntries}
+      selectedIndex={selectedIndex}
+      isSelected={isSelected}
+      sortMode={sortMode}
+      hints={mainHints}
+      terminalWidth={terminalWidth}
+    />
+  );
+}
 
-      {/* Summary */}
-      <Panel title="Summary">
-        <Box>
-          <Text>Total Cost: </Text>
-          <Text color="yellow" bold>${costs.total_cost.toFixed(4)}</Text>
-        </Box>
-        <Box>
-          <Text>Input Tokens: </Text>
-          {costs.total_input_tokens === 0 && costs.total_cost > 0 ? (
-            <Text dimColor>N/A (manual entry)</Text>
-          ) : (
-            <Text>{costs.total_input_tokens.toLocaleString()}</Text>
-          )}
-        </Box>
-        <Box>
-          <Text>Output Tokens: </Text>
-          {costs.total_output_tokens === 0 && costs.total_cost > 0 ? (
-            <Text dimColor>N/A (manual entry)</Text>
-          ) : (
-            <Text>{costs.total_output_tokens.toLocaleString()}</Text>
-          )}
-        </Box>
-      </Panel>
+// ============================================================================
+// Compact layout (80x24)
+// ============================================================================
 
-      {/* By Agent */}
-      <Panel title="By Agent">
-        {Object.entries(costs.by_agent ?? {}).length === 0 ? (
-          <Text dimColor>No agent costs recorded</Text>
-        ) : (
-          Object.entries(costs.by_agent ?? {})
-            .sort(([, a], [, b]) => b - a)
-            .slice(0, 10)
-            .map(([agent, cost]) => (
-              <Box key={agent}>
-                <Text color="green" wrap="truncate">{agent.padEnd(20)}</Text>
-                <Text>${cost.toFixed(4)}</Text>
-              </Box>
-            ))
+interface CostsViewCompactProps {
+  costs: NonNullable<ReturnType<typeof useCosts>['data']>;
+  agentEntries: AgentEntry[];
+  selectedIndex: number;
+  isSelected: (index: number) => boolean;
+  sortMode: SortMode;
+  hints: { key: string; label: string }[];
+  terminalWidth: number;
+}
+
+const CostsViewCompact = memo(function CostsViewCompact({
+  costs,
+  agentEntries,
+  selectedIndex,
+  isSelected,
+  sortMode,
+  hints,
+  terminalWidth,
+}: CostsViewCompactProps) {
+  const agentCount = agentEntries.length;
+  const maxCost = agentEntries.length > 0 ? agentEntries[0].cost : 1;
+
+  // Scrolling: at 80x24, content budget is ~16 lines
+  // Header(1) + margin(1) + agents + margin(1) + model(1) + stats(1) = agents + 5
+  // So max visible agents = 11
+  const maxVisible = 11;
+  const needsScroll = agentCount > maxVisible;
+  let startIdx = 0;
+  if (needsScroll) {
+    startIdx = Math.max(0, Math.min(selectedIndex - Math.floor(maxVisible / 2), agentCount - maxVisible));
+  }
+  const visibleAgents = needsScroll ? agentEntries.slice(startIdx, startIdx + maxVisible) : agentEntries;
+  const hiddenBelow = needsScroll ? agentCount - (startIdx + maxVisible) : 0;
+
+  // Bar width: name(12) + cost(8) + space(1) + bar + space(1) + pct(4) = 26 + bar
+  const barWidth = Math.max(10, terminalWidth - 30);
+
+  const modelEntries = Object.entries(costs.by_model ?? {}).sort(([, a], [, b]) => b - a);
+
+  // Burn rate / projection
+  const burnRate = costs.burn_rate ?? 0;
+  const projected = costs.projected_total ?? 0;
+  const cacheHit = costs.cache_hit_rate ?? 0;
+  const billingSpent = costs.billing_window_spent ?? costs.total_cost;
+
+  // Cost status
+  const costStatus: CostStatus = burnRate > 50 ? 'critical' : burnRate > 20 ? 'warning' : 'normal';
+  const { symbol: costSymbol } = getCostIndicator(costStatus);
+
+  // Sort indicator
+  const sortLabel = sortMode === 'cost' ? 'by cost' : sortMode === 'name' ? 'by name' : 'by %';
+
+  return (
+    <Box flexDirection="column" paddingX={1} overflow="hidden">
+      {/* Header */}
+      <Box>
+        <Text bold>Costs</Text>
+        <Text dimColor> ({agentCount})</Text>
+        <Text>  </Text>
+        <Text color="yellow" bold>${costs.total_cost.toFixed(2)}</Text>
+        <Text dimColor> total</Text>
+        <Box flexGrow={1} />
+        {burnRate > 0 && (
+          <Text dimColor>
+            {costSymbol} ${burnRate.toFixed(2)}/hr → ${projected.toFixed(2)}
+          </Text>
         )}
-      </Panel>
+      </Box>
 
-      {/* By Model */}
-      <Panel title="By Model">
-        {Object.entries(costs.by_model ?? {}).length === 0 ? (
-          <Text dimColor>No model costs recorded</Text>
-        ) : (
-          Object.entries(costs.by_model ?? {})
-            .sort(([, a], [, b]) => b - a)
-            .map(([model, cost]) => (
-              <Box key={model}>
-                <Text color="magenta" wrap="truncate">{model.padEnd(20)}</Text>
-                <Text>${cost.toFixed(4)}</Text>
-              </Box>
-            ))
+      {/* Agent list */}
+      <Box flexDirection="column" marginTop={1}>
+        {visibleAgents.map((agent, visIdx) => {
+          const actualIdx = startIdx + visIdx;
+          const selected = isSelected(actualIdx);
+          const nameColor = getColorForName(agent.name);
+          const displayName = agent.name.length > 10 ? agent.name.slice(0, 9) + '…' : agent.name.padEnd(10);
+          const costStr = `$${agent.cost.toFixed(2)}`.padStart(7);
+          const pctStr = `${agent.percent}%`.padStart(4);
+
+          return (
+            <Box key={agent.name}>
+              <Text color={selected ? 'cyan' : undefined} bold={selected}>
+                {selected ? '▸ ' : '  '}
+              </Text>
+              <Text color={selected ? 'cyan' : nameColor} bold={selected} wrap="truncate">
+                {displayName}
+              </Text>
+              <Text> </Text>
+              <Text color={selected ? 'cyan' : 'yellow'}>{costStr}</Text>
+              <Text> </Text>
+              <InlineProgressBar
+                value={agent.cost}
+                max={maxCost}
+                width={barWidth}
+              />
+              <Text dimColor>{pctStr}</Text>
+            </Box>
+          );
+        })}
+        {hiddenBelow > 0 && (
+          <Text dimColor>  ↓ {hiddenBelow} more</Text>
         )}
-      </Panel>
+      </Box>
 
-      {/* By Team */}
-      {Object.keys(costs.by_team ?? {}).length > 0 && (
-        <Panel title="By Team">
-          {Object.entries(costs.by_team ?? {})
-            .sort(([, a], [, b]) => b - a)
-            .map(([team, cost]) => (
-              <Box key={team}>
-                <Text color="blue" wrap="truncate">{team.padEnd(20)}</Text>
-                <Text>${cost.toFixed(4)}</Text>
+      {/* Model summary */}
+      {modelEntries.length > 0 && (
+        <Box marginTop={1}>
+          {modelEntries.map(([model, cost]) => {
+            const pct = costs.total_cost > 0 ? Math.round((cost / costs.total_cost) * 100) : 0;
+            const shortName = model.length > 10 ? model.slice(0, 9) + '…' : model;
+            return (
+              <Box key={model} marginRight={2}>
+                <Text color="magenta">{shortName}</Text>
+                <Text> ${cost.toFixed(2)}</Text>
+                <Text dimColor> ({pct}%)</Text>
               </Box>
-            ))}
-        </Panel>
+            );
+          })}
+        </Box>
       )}
 
-      {/* #1816: Keybinding hints */}
+      {/* Stats line */}
+      <Box>
+        {cacheHit > 0 && (
+          <>
+            <Text dimColor>Cache {cacheHit.toFixed(1)}% hit</Text>
+            <Text dimColor> │ </Text>
+          </>
+        )}
+        <Text dimColor>Billing ${billingSpent.toFixed(2)} spent</Text>
+        <Box flexGrow={1} />
+        <Text dimColor>({sortLabel})</Text>
+      </Box>
+
       <Footer hints={hints} />
     </Box>
   );
+});
+
+// ============================================================================
+// Wide layout (120x30)
+// ============================================================================
+
+interface CostsViewWideProps {
+  costs: NonNullable<ReturnType<typeof useCosts>['data']>;
+  agentEntries: AgentEntry[];
+  selectedIndex: number;
+  isSelected: (index: number) => boolean;
+  sortMode: SortMode;
+  hints: { key: string; label: string }[];
+  terminalWidth: number;
 }
+
+const CostsViewWide = memo(function CostsViewWide({
+  costs,
+  agentEntries,
+  selectedIndex,
+  isSelected,
+  sortMode,
+  hints,
+  terminalWidth,
+}: CostsViewWideProps) {
+  const agentCount = agentEntries.length;
+  const maxCost = agentEntries.length > 0 ? agentEntries[0].cost : 1;
+
+  // More room at 120+ width
+  const maxVisible = 15;
+  const needsScroll = agentCount > maxVisible;
+  let startIdx = 0;
+  if (needsScroll) {
+    startIdx = Math.max(0, Math.min(selectedIndex - Math.floor(maxVisible / 2), agentCount - maxVisible));
+  }
+  const visibleAgents = needsScroll ? agentEntries.slice(startIdx, startIdx + maxVisible) : agentEntries;
+  const hiddenBelow = needsScroll ? agentCount - (startIdx + maxVisible) : 0;
+
+  const barWidth = Math.max(20, terminalWidth - 35);
+
+  const burnRate = costs.burn_rate ?? 0;
+  const projected = costs.projected_total ?? 0;
+  const cacheHit = costs.cache_hit_rate ?? 0;
+  const billingSpent = costs.billing_window_spent ?? costs.total_cost;
+
+  const costStatus: CostStatus = burnRate > 50 ? 'critical' : burnRate > 20 ? 'warning' : 'normal';
+  const { symbol: costSymbol } = getCostIndicator(costStatus);
+
+  const modelEntries = Object.entries(costs.by_model ?? {}).sort(([, a], [, b]) => b - a);
+
+  const sortLabel = sortMode === 'cost' ? 'by cost' : sortMode === 'name' ? 'by name' : 'by %';
+
+  return (
+    <Box flexDirection="column" paddingX={1} overflow="hidden">
+      {/* Header */}
+      <Box>
+        <Text bold>Costs</Text>
+        <Text dimColor> ({agentCount})</Text>
+        <Text>  </Text>
+        <Text color="yellow" bold>${costs.total_cost.toFixed(2)}</Text>
+        <Text dimColor> total</Text>
+        <Box flexGrow={1} />
+        {burnRate > 0 && (
+          <Text dimColor>
+            {costSymbol} ${burnRate.toFixed(2)}/hr → ${projected.toFixed(2)}
+          </Text>
+        )}
+      </Box>
+
+      {/* Agent list */}
+      <Box flexDirection="column" marginTop={1}>
+        {visibleAgents.map((agent, visIdx) => {
+          const actualIdx = startIdx + visIdx;
+          const selected = isSelected(actualIdx);
+          const nameColor = getColorForName(agent.name);
+          const displayName = agent.name.length > 12 ? agent.name.slice(0, 11) + '…' : agent.name.padEnd(12);
+          const costStr = `$${agent.cost.toFixed(2)}`.padStart(8);
+          const pctStr = `${agent.percent}%`.padStart(4);
+
+          return (
+            <Box key={agent.name}>
+              <Text color={selected ? 'cyan' : undefined} bold={selected}>
+                {selected ? '▸ ' : '  '}
+              </Text>
+              <Text color={selected ? 'cyan' : nameColor} bold={selected} wrap="truncate">
+                {displayName}
+              </Text>
+              <Text> </Text>
+              <Text color={selected ? 'cyan' : 'yellow'}>{costStr}</Text>
+              <Text> </Text>
+              <InlineProgressBar
+                value={agent.cost}
+                max={maxCost}
+                width={barWidth}
+              />
+              <Text dimColor>{pctStr}</Text>
+            </Box>
+          );
+        })}
+        {hiddenBelow > 0 && (
+          <Text dimColor>  ↓ {hiddenBelow} more</Text>
+        )}
+      </Box>
+
+      {/* Side-by-side Models + Billing panels */}
+      <Box marginTop={1}>
+        <Panel title="Models" width="50%">
+          {modelEntries.map(([model, cost]) => {
+            const pct = costs.total_cost > 0 ? Math.round((cost / costs.total_cost) * 100) : 0;
+            const maxModelCost = modelEntries.length > 0 ? modelEntries[0][1] : 1;
+            return (
+              <Box key={model}>
+                <Text color="magenta" wrap="truncate">{model.padEnd(10)}</Text>
+                <Text> ${cost.toFixed(2).padStart(7)}</Text>
+                <Text> </Text>
+                <InlineProgressBar value={cost} max={maxModelCost} width={13} />
+                <Text dimColor> {String(pct).padStart(3)}%</Text>
+              </Box>
+            );
+          })}
+          {modelEntries.length === 0 && <Text dimColor>No model data</Text>}
+        </Panel>
+        <Panel title="Billing" width="50%">
+          <Box>
+            <Text>Spent     </Text>
+            <Text color="yellow">${billingSpent.toFixed(2)}</Text>
+          </Box>
+          {burnRate > 0 && (
+            <Box>
+              <Text>Rate      </Text>
+              <Text>${burnRate.toFixed(2)}/hr</Text>
+            </Box>
+          )}
+          {projected > 0 && (
+            <Box>
+              <Text>Projected </Text>
+              <Text>${projected.toFixed(2)}</Text>
+            </Box>
+          )}
+          {cacheHit > 0 && (
+            <Box>
+              <Text>Cache     </Text>
+              <Text color="green">{cacheHit.toFixed(1)}% hit</Text>
+            </Box>
+          )}
+        </Panel>
+      </Box>
+
+      {/* Sort indicator + footer */}
+      <Box>
+        <Box flexGrow={1} />
+        <Text dimColor>({sortLabel})</Text>
+      </Box>
+
+      <Footer hints={[...hints, { key: 'm', label: 'models' }]} />
+    </Box>
+  );
+});
+
+// ============================================================================
+// Agent cost detail sub-view
+// ============================================================================
+
+interface AgentCostDetailProps {
+  agent: AgentEntry;
+  costs: NonNullable<ReturnType<typeof useCosts>['data']>;
+  hints: { key: string; label: string }[];
+}
+
+const AgentCostDetail = memo(function AgentCostDetail({
+  agent,
+  costs,
+  hints,
+}: AgentCostDetailProps) {
+  const totalTokensIn = costs.total_input_tokens;
+  const totalTokensOut = costs.total_output_tokens;
+
+  // Estimate per-agent tokens proportionally (until per-agent endpoint exists)
+  const ratio = costs.total_cost > 0 ? agent.cost / costs.total_cost : 0;
+  const estTokensIn = Math.round(totalTokensIn * ratio);
+  const estTokensOut = Math.round(totalTokensOut * ratio);
+
+  // Estimate per-agent model breakdown proportionally
+  const modelEntries = Object.entries(costs.by_model ?? {}).sort(([, a], [, b]) => b - a);
+  const agentModelCosts = modelEntries.map(([model, cost]) => ({
+    model,
+    cost: cost * ratio,
+    percent: costs.total_cost > 0 ? Math.round((cost / costs.total_cost) * 100) : 0,
+  }));
+  const maxModelCost = agentModelCosts.length > 0 ? agentModelCosts[0].cost : 1;
+
+  return (
+    <Box flexDirection="column" paddingX={1} overflow="hidden">
+      {/* Header */}
+      <Box>
+        <Text dimColor>◀ </Text>
+        <Text bold color={getColorForName(agent.name)}>{agent.name}</Text>
+        <Box flexGrow={1} />
+        <Text color="yellow" bold>${agent.cost.toFixed(2)}</Text>
+      </Box>
+
+      {/* Stats */}
+      <Box flexDirection="column" marginTop={1} marginLeft={2}>
+        <Box>
+          <Text dimColor>{'Tokens     '.padEnd(12)}</Text>
+          <Text>{estTokensIn.toLocaleString()} in / {estTokensOut.toLocaleString()} out</Text>
+        </Box>
+        <Box>
+          <Text dimColor>{'API calls  '.padEnd(12)}</Text>
+          <Text dimColor>—</Text>
+        </Box>
+        <Box>
+          <Text dimColor>{'% of total '.padEnd(12)}</Text>
+          <Text>{agent.percent}%</Text>
+        </Box>
+      </Box>
+
+      {/* Model Breakdown */}
+      {agentModelCosts.length > 0 && (
+        <Box flexDirection="column" marginTop={1} marginLeft={2}>
+          <Text bold dimColor>Model Breakdown</Text>
+          {agentModelCosts.map(({ model, cost, percent }) => {
+            const displayModel = model.length > 10 ? model.slice(0, 9) + '…' : model.padEnd(10);
+            return (
+              <Box key={model}>
+                <Text color="magenta">{displayModel}</Text>
+                <Text> ${cost.toFixed(2).padStart(7)}</Text>
+                <Text> </Text>
+                <InlineProgressBar value={cost} max={maxModelCost} width={34} />
+                <Text dimColor> {String(percent).padStart(3)}%</Text>
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+
+      <Box flexGrow={1} />
+      <Footer hints={hints} />
+    </Box>
+  );
+});
 
 export default CostsView;

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -320,21 +320,25 @@ interface CostPanelProps {
   inputTokens: number;
   outputTokens: number;
   budgetUSD?: number;
+  burnRate?: number;
+  topAgents?: { name: string; cost: number }[];
 }
 
 /**
- * Cost panel with budget progress bar (responsive width)
+ * Cost panel with budget progress bar, burn rate, and top agents
+ * #1882: Enhanced with ccusage integration fields
  * #1220: Added symbols and text labels for colorblind accessibility
  * #1352: Uses compact inline layout at <100 cols
  */
 const CostPanel = memo(function CostPanel({
   totalCostUSD,
-  inputTokens,
-  outputTokens,
+  inputTokens: _inputTokens,
+  outputTokens: _outputTokens,
   budgetUSD = 10.0,
+  burnRate = 0,
+  topAgents = [],
 }: CostPanelProps) {
   const isNarrow = false;
-  const totalTokens = inputTokens + outputTokens;
   const budgetPercent = Math.min(100, Math.round((totalCostUSD / budgetUSD) * 100));
   // Responsive bar width: smaller on narrow terminals
   const barWidth = isNarrow ? 10 : 15;
@@ -364,22 +368,44 @@ const CostPanel = memo(function CostPanel({
   return (
     <Panel title="Cost">
       <Box flexDirection="column">
+        {/* Line 1: Total + burn rate */}
         <Box>
           <Text bold color="yellow">${totalCostUSD.toFixed(2)}</Text>
-          <Text dimColor> / ${budgetUSD.toFixed(2)}</Text>
+          {burnRate > 0 && (
+            <Text dimColor>  {costSymbol} ${burnRate.toFixed(2)}/hr</Text>
+          )}
         </Box>
+        {/* Line 2: Budget bar */}
         <Box marginTop={1}>
           <Text color={barColor}>{'█'.repeat(filledWidth)}</Text>
           <Text dimColor>{'░'.repeat(emptyWidth)}</Text>
           <Text> {budgetPercent}%</Text>
-          {/* #1220: Symbol indicator for colorblind users */}
-          <Text color={barColor}> {costSymbol}</Text>
         </Box>
-        <Box marginTop={1}>
-          <Text dimColor>
-            {formatNumber(totalTokens)} tokens
-          </Text>
-        </Box>
+        {/* Lines 3-4: Top agents */}
+        {topAgents.length > 0 && (
+          <Box marginTop={1} flexDirection="column">
+            {/* Show top agents 2 per line */}
+            <Box>
+              {topAgents.slice(0, 2).map((a, i) => (
+                <Text key={a.name} dimColor>
+                  {i > 0 ? '  ' : ''}{a.name} ${Math.round(a.cost)}
+                </Text>
+              ))}
+            </Box>
+            {topAgents.length > 2 && (
+              <Box>
+                {topAgents.slice(2, 4).map((a, i) => (
+                  <Text key={a.name} dimColor>
+                    {i > 0 ? '  ' : ''}{a.name} ${Math.round(a.cost)}
+                  </Text>
+                ))}
+                {topAgents.length > 4 && (
+                  <Text dimColor>  +{topAgents.length - 4} more</Text>
+                )}
+              </Box>
+            )}
+          </Box>
+        )}
       </Box>
     </Panel>
   );
@@ -469,6 +495,8 @@ interface StatsPanelsProps {
     totalCostUSD: number;
     inputTokens: number;
     outputTokens: number;
+    burnRate?: number;
+    topAgents?: { name: string; cost: number }[];
   };
   agentStats: {
     byState: Record<string, number>;
@@ -503,24 +531,13 @@ const StatsPanels = memo(function StatsPanels({
         totalCostUSD={summary.totalCostUSD}
         inputTokens={summary.inputTokens}
         outputTokens={summary.outputTokens}
+        burnRate={summary.burnRate}
+        topAgents={summary.topAgents}
       />
       <AgentStatsPanel stats={agentStats} />
     </>
   );
 });
-
-/**
- * Format large numbers with K/M suffixes
- */
-function formatNumber(n: number): string {
-  if (n >= 1_000_000) {
-    return `${(n / 1_000_000).toFixed(1)}M`;
-  }
-  if (n >= 1_000) {
-    return `${(n / 1_000).toFixed(1)}K`;
-  }
-  return n.toString();
-}
 
 /**
  * Format date to relative time string


### PR DESCRIPTION
## Summary
- Rewrite CostsView with horizontal proportional bars, scrollable agent list, j/k navigation, sort cycling, and agent detail sub-view on Enter
- Responsive layouts: compact (80x24) with inline model summary + stats, wide (120x30) with side-by-side Models/Billing panels
- Dashboard CostPanel updated with burn rate display and top 4 agents
- CostSummary type extended with ccusage integration fields (cache_hit_rate, burn_rate, projected_total, billing_window_spent)

Closes #1882

## Test plan
- [x] `bun run build` passes clean
- [x] All 13 CostsView tests pass
- [x] All 31 Dashboard tests pass
- [ ] Manual test at 80x24: verify 11 agents fit, scrolling works for 12+
- [ ] Manual test at 120x30: verify side-by-side panels render
- [ ] Test j/k navigation, Enter for detail, Esc to return
- [ ] Test sort cycling with `s` key

Mockups: https://github.com/rpuneet/bc/issues/1882#issuecomment-3983650467

🤖 Generated with [Claude Code](https://claude.com/claude-code)