### PR TITLE
feat(cost): enrich bc cost show --json with ccusage data

### DIFF
--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"text/tabwriter"
 	"time"
 
@@ -253,6 +255,101 @@ func getCostStore() (*cost.Store, error) {
 	return store, nil
 }
 
+// ccusageRunner runs ccusage and returns raw JSON output. Overridable for testing.
+var ccusageRunner = defaultCCUsageRunner
+
+func defaultCCUsageRunner(ctx context.Context) ([]byte, error) {
+	npxPath, err := exec.LookPath("npx")
+	if err != nil {
+		return nil, err
+	}
+	ccCmd := exec.CommandContext(ctx, npxPath, "ccusage@latest", "--json") //nolint:gosec // args are static
+	ccCmd.Stderr = os.Stderr
+	return ccCmd.Output()
+}
+
+// fetchCCUsageDailyReport calls ccusage and returns the daily report, or nil if unavailable.
+func fetchCCUsageDailyReport(ctx context.Context) *ccusageDailyReport {
+	output, err := ccusageRunner(ctx)
+	if err != nil {
+		return nil
+	}
+	var report ccusageDailyReport
+	if unmarshalErr := json.Unmarshal(output, &report); unmarshalErr != nil {
+		return nil
+	}
+	return &report
+}
+
+// costShowResponse is the enriched JSON response for 'bc cost show --json'.
+type costShowResponse struct {
+	ByAgent            map[string]float64 `json:"by_agent"`
+	ByTeam             map[string]float64 `json:"by_team"`
+	ByModel            map[string]float64 `json:"by_model"`
+	CacheHitRate       *float64           `json:"cache_hit_rate,omitempty"`
+	BurnRate           *float64           `json:"burn_rate,omitempty"`
+	ProjectedTotal     *float64           `json:"projected_total,omitempty"`
+	BillingWindowSpent *float64           `json:"billing_window_spent,omitempty"`
+	TotalInputTokens   int64              `json:"total_input_tokens"`
+	TotalOutputTokens  int64              `json:"total_output_tokens"`
+	TotalCost          float64            `json:"total_cost"`
+}
+
+// enrichWithCCUsage merges ccusage daily report data into the cost show response.
+func enrichWithCCUsage(resp *costShowResponse, report *ccusageDailyReport) {
+	if report == nil {
+		return
+	}
+
+	totals := report.Totals
+
+	// Override totals from ccusage if internal DB had no data
+	if resp.TotalCost == 0 && totals.TotalCost > 0 {
+		resp.TotalCost = totals.TotalCost
+		resp.TotalInputTokens = totals.InputTokens
+		resp.TotalOutputTokens = totals.OutputTokens
+	}
+
+	// cache_hit_rate: cacheRead / (cacheRead + cacheCreation)
+	cacheTotal := totals.CacheReadTokens + totals.CacheCreationTokens
+	if cacheTotal > 0 {
+		rate := float64(totals.CacheReadTokens) / float64(cacheTotal)
+		resp.CacheHitRate = &rate
+	}
+
+	// burn_rate: average daily cost from ccusage daily entries
+	if len(report.Daily) > 0 {
+		burnRate := totals.TotalCost / float64(len(report.Daily))
+		resp.BurnRate = &burnRate
+
+		// projected_total: burn_rate * days_in_current_month
+		now := time.Now()
+		daysInMonth := float64(time.Date(now.Year(), now.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day())
+		projected := burnRate * daysInMonth
+		resp.ProjectedTotal = &projected
+	}
+
+	// billing_window_spent: total cost from ccusage
+	if totals.TotalCost > 0 {
+		spent := totals.TotalCost
+		resp.BillingWindowSpent = &spent
+	}
+
+	// Enrich by_model from ccusage daily modelsUsed (frequency count, no cost attribution)
+	if len(resp.ByModel) == 0 {
+		modelSeen := make(map[string]bool)
+		for _, d := range report.Daily {
+			for _, m := range d.ModelsUsed {
+				modelSeen[m] = true
+			}
+		}
+		// Add models with zero cost — signals to TUI which models are in use
+		for m := range modelSeen {
+			resp.ByModel[m] = 0
+		}
+	}
+}
+
 func runCostShow(cmd *cobra.Command, args []string) error {
 	// Validate limit parameter
 	if cmd.Flags().Changed("limit") && costLimitFlag <= 0 {
@@ -317,14 +414,7 @@ func runCostShow(cmd *cobra.Command, args []string) error {
 			byModel[r.Model] += r.CostUSD
 		}
 
-		response := struct {
-			ByAgent           map[string]float64 `json:"by_agent"`
-			ByTeam            map[string]float64 `json:"by_team"`
-			ByModel           map[string]float64 `json:"by_model"`
-			TotalInputTokens  int64              `json:"total_input_tokens"`
-			TotalOutputTokens int64              `json:"total_output_tokens"`
-			TotalCost         float64            `json:"total_cost"`
-		}{
+		response := &costShowResponse{
 			ByAgent:           byAgent,
 			ByTeam:            byTeam,
 			ByModel:           byModel,
@@ -332,6 +422,10 @@ func runCostShow(cmd *cobra.Command, args []string) error {
 			TotalOutputTokens: int64(totalOutput),
 			TotalCost:         totalCost,
 		}
+
+		// Enrich with ccusage data (graceful — nil if unavailable)
+		ccReport := fetchCCUsageDailyReport(cmd.Context())
+		enrichWithCCUsage(response, ccReport)
 
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")

--- a/internal/cmd/cost_test.go
+++ b/internal/cmd/cost_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -1767,5 +1770,479 @@ func TestCostSummaryModelEmpty(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "No cost records found") {
 		t.Errorf("expected no records message, got: %s", stdout)
+	}
+}
+
+// --- ccusage enrichment tests ---
+
+func TestEnrichWithCCUsage(t *testing.T) {
+	resp := &costShowResponse{
+		ByAgent:           make(map[string]float64),
+		ByTeam:            make(map[string]float64),
+		ByModel:           make(map[string]float64),
+		TotalInputTokens:  0,
+		TotalOutputTokens: 0,
+		TotalCost:         0,
+	}
+
+	report := &ccusageDailyReport{
+		Daily: []ccusageDailyEntry{
+			{
+				Date:                "2026-03-01",
+				ModelsUsed:          []string{"claude-opus-4-20250514", "claude-sonnet-4-20250514"},
+				InputTokens:         1000,
+				OutputTokens:        5000,
+				CacheCreationTokens: 200,
+				CacheReadTokens:     800,
+				TotalTokens:         7000,
+				TotalCost:           3.50,
+			},
+			{
+				Date:                "2026-03-02",
+				ModelsUsed:          []string{"claude-opus-4-20250514"},
+				InputTokens:         500,
+				OutputTokens:        2500,
+				CacheCreationTokens: 100,
+				CacheReadTokens:     400,
+				TotalTokens:         3500,
+				TotalCost:           1.75,
+			},
+		},
+		Totals: ccusageTotals{
+			InputTokens:         1500,
+			OutputTokens:        7500,
+			CacheCreationTokens: 300,
+			CacheReadTokens:     1200,
+			TotalTokens:         10500,
+			TotalCost:           5.25,
+		},
+	}
+
+	enrichWithCCUsage(resp, report)
+
+	// Totals should be overridden from ccusage (internal DB was empty)
+	if resp.TotalCost != 5.25 {
+		t.Errorf("TotalCost = %f, want 5.25", resp.TotalCost)
+	}
+	if resp.TotalInputTokens != 1500 {
+		t.Errorf("TotalInputTokens = %d, want 1500", resp.TotalInputTokens)
+	}
+	if resp.TotalOutputTokens != 7500 {
+		t.Errorf("TotalOutputTokens = %d, want 7500", resp.TotalOutputTokens)
+	}
+
+	// cache_hit_rate = 1200 / (1200 + 300) = 0.8
+	if resp.CacheHitRate == nil {
+		t.Fatal("CacheHitRate is nil")
+	}
+	if *resp.CacheHitRate != 0.8 {
+		t.Errorf("CacheHitRate = %f, want 0.8", *resp.CacheHitRate)
+	}
+
+	// burn_rate = 5.25 / 2 = 2.625
+	if resp.BurnRate == nil {
+		t.Fatal("BurnRate is nil")
+	}
+	if *resp.BurnRate != 2.625 {
+		t.Errorf("BurnRate = %f, want 2.625", *resp.BurnRate)
+	}
+
+	// projected_total = burn_rate * days_in_current_month
+	if resp.ProjectedTotal == nil {
+		t.Fatal("ProjectedTotal is nil")
+	}
+	now := time.Now()
+	daysInMonth := float64(time.Date(now.Year(), now.Month()+1, 0, 0, 0, 0, 0, time.UTC).Day())
+	expectedProjected := 2.625 * daysInMonth
+	if *resp.ProjectedTotal != expectedProjected {
+		t.Errorf("ProjectedTotal = %f, want %f", *resp.ProjectedTotal, expectedProjected)
+	}
+
+	// billing_window_spent
+	if resp.BillingWindowSpent == nil {
+		t.Fatal("BillingWindowSpent is nil")
+	}
+	if *resp.BillingWindowSpent != 5.25 {
+		t.Errorf("BillingWindowSpent = %f, want 5.25", *resp.BillingWindowSpent)
+	}
+
+	// by_model should have models from ccusage (since internal DB was empty)
+	if len(resp.ByModel) != 2 {
+		t.Errorf("ByModel has %d entries, want 2", len(resp.ByModel))
+	}
+	if _, ok := resp.ByModel["claude-opus-4-20250514"]; !ok {
+		t.Error("ByModel missing claude-opus-4-20250514")
+	}
+	if _, ok := resp.ByModel["claude-sonnet-4-20250514"]; !ok {
+		t.Error("ByModel missing claude-sonnet-4-20250514")
+	}
+}
+
+func TestEnrichWithCCUsage_NilReport(t *testing.T) {
+	resp := &costShowResponse{
+		ByAgent:           make(map[string]float64),
+		ByTeam:            make(map[string]float64),
+		ByModel:           make(map[string]float64),
+		TotalInputTokens:  100,
+		TotalOutputTokens: 200,
+		TotalCost:         0.05,
+	}
+
+	enrichWithCCUsage(resp, nil)
+
+	// Nothing should change
+	if resp.TotalCost != 0.05 {
+		t.Errorf("TotalCost = %f, want 0.05", resp.TotalCost)
+	}
+	if resp.CacheHitRate != nil {
+		t.Error("CacheHitRate should be nil when report is nil")
+	}
+	if resp.BurnRate != nil {
+		t.Error("BurnRate should be nil when report is nil")
+	}
+	if resp.ProjectedTotal != nil {
+		t.Error("ProjectedTotal should be nil when report is nil")
+	}
+	if resp.BillingWindowSpent != nil {
+		t.Error("BillingWindowSpent should be nil when report is nil")
+	}
+}
+
+func TestEnrichWithCCUsage_NoCache(t *testing.T) {
+	resp := &costShowResponse{
+		ByAgent:           make(map[string]float64),
+		ByTeam:            make(map[string]float64),
+		ByModel:           make(map[string]float64),
+		TotalInputTokens:  0,
+		TotalOutputTokens: 0,
+		TotalCost:         0,
+	}
+
+	report := &ccusageDailyReport{
+		Daily: []ccusageDailyEntry{
+			{Date: "2026-03-01", TotalTokens: 1000, TotalCost: 2.00},
+		},
+		Totals: ccusageTotals{
+			InputTokens:         500,
+			OutputTokens:        500,
+			CacheCreationTokens: 0,
+			CacheReadTokens:     0,
+			TotalTokens:         1000,
+			TotalCost:           2.00,
+		},
+	}
+
+	enrichWithCCUsage(resp, report)
+
+	// cache_hit_rate should be nil when no cache tokens
+	if resp.CacheHitRate != nil {
+		t.Errorf("CacheHitRate should be nil with no cache, got %f", *resp.CacheHitRate)
+	}
+
+	// burn_rate and projected_total should still be set
+	if resp.BurnRate == nil {
+		t.Fatal("BurnRate should not be nil")
+	}
+	if *resp.BurnRate != 2.00 {
+		t.Errorf("BurnRate = %f, want 2.00", *resp.BurnRate)
+	}
+}
+
+func TestEnrichWithCCUsage_InternalDBHasData(t *testing.T) {
+	// When internal DB has data, totals should NOT be overridden
+	resp := &costShowResponse{
+		ByAgent:           map[string]float64{"eng-01": 0.05},
+		ByTeam:            make(map[string]float64),
+		ByModel:           map[string]float64{"claude-opus": 0.05},
+		TotalInputTokens:  1000,
+		TotalOutputTokens: 500,
+		TotalCost:         0.05,
+	}
+
+	report := &ccusageDailyReport{
+		Daily: []ccusageDailyEntry{
+			{Date: "2026-03-01", ModelsUsed: []string{"opus"}, TotalCost: 10.00},
+		},
+		Totals: ccusageTotals{
+			InputTokens:  5000,
+			OutputTokens: 25000,
+			TotalCost:    10.00,
+		},
+	}
+
+	enrichWithCCUsage(resp, report)
+
+	// TotalCost should NOT be overridden since internal DB had data
+	if resp.TotalCost != 0.05 {
+		t.Errorf("TotalCost = %f, want 0.05 (should not be overridden)", resp.TotalCost)
+	}
+
+	// ByModel should NOT be overridden since internal DB had data
+	if len(resp.ByModel) != 1 {
+		t.Errorf("ByModel should keep internal DB data, got %d entries", len(resp.ByModel))
+	}
+
+	// ccusage-derived fields should still be set
+	if resp.BurnRate == nil {
+		t.Fatal("BurnRate should be set even with internal DB data")
+	}
+	if resp.BillingWindowSpent == nil {
+		t.Fatal("BillingWindowSpent should be set")
+	}
+	if *resp.BillingWindowSpent != 10.00 {
+		t.Errorf("BillingWindowSpent = %f, want 10.00", *resp.BillingWindowSpent)
+	}
+}
+
+func TestEnrichWithCCUsage_EmptyDaily(t *testing.T) {
+	resp := &costShowResponse{
+		ByAgent:           make(map[string]float64),
+		ByTeam:            make(map[string]float64),
+		ByModel:           make(map[string]float64),
+		TotalInputTokens:  0,
+		TotalOutputTokens: 0,
+		TotalCost:         0,
+	}
+
+	report := &ccusageDailyReport{
+		Daily:  []ccusageDailyEntry{},
+		Totals: ccusageTotals{TotalCost: 0},
+	}
+
+	enrichWithCCUsage(resp, report)
+
+	// No burn_rate or projected_total with empty daily entries
+	if resp.BurnRate != nil {
+		t.Error("BurnRate should be nil with empty daily entries")
+	}
+	if resp.ProjectedTotal != nil {
+		t.Error("ProjectedTotal should be nil with empty daily entries")
+	}
+	if resp.BillingWindowSpent != nil {
+		t.Error("BillingWindowSpent should be nil with zero cost")
+	}
+}
+
+func TestFetchCCUsageDailyReport_MockRunner(t *testing.T) {
+	// Save and restore original runner
+	origRunner := ccusageRunner
+	defer func() { ccusageRunner = origRunner }()
+
+	t.Run("valid_response", func(t *testing.T) {
+		ccusageRunner = func(_ context.Context) ([]byte, error) {
+			return []byte(`{
+				"daily": [{"date":"2026-03-01","inputTokens":100,"outputTokens":200,"cacheCreationTokens":10,"cacheReadTokens":50,"totalTokens":360,"totalCost":1.50,"modelsUsed":["opus"]}],
+				"totals": {"inputTokens":100,"outputTokens":200,"cacheCreationTokens":10,"cacheReadTokens":50,"totalTokens":360,"totalCost":1.50}
+			}`), nil
+		}
+
+		report := fetchCCUsageDailyReport(context.Background())
+		if report == nil {
+			t.Fatal("expected non-nil report")
+		}
+		if len(report.Daily) != 1 {
+			t.Errorf("Daily entries = %d, want 1", len(report.Daily))
+		}
+		if report.Totals.TotalCost != 1.50 {
+			t.Errorf("TotalCost = %f, want 1.50", report.Totals.TotalCost)
+		}
+	})
+
+	t.Run("runner_error", func(t *testing.T) {
+		ccusageRunner = func(_ context.Context) ([]byte, error) {
+			return nil, fmt.Errorf("npx not found")
+		}
+
+		report := fetchCCUsageDailyReport(context.Background())
+		if report != nil {
+			t.Error("expected nil report when runner fails")
+		}
+	})
+
+	t.Run("invalid_json", func(t *testing.T) {
+		ccusageRunner = func(_ context.Context) ([]byte, error) {
+			return []byte("not json"), nil
+		}
+
+		report := fetchCCUsageDailyReport(context.Background())
+		if report != nil {
+			t.Error("expected nil report for invalid JSON")
+		}
+	})
+}
+
+func TestCostShowJSON_WithCCUsageEnrichment(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Mock ccusage runner
+	origRunner := ccusageRunner
+	defer func() { ccusageRunner = origRunner }()
+
+	ccusageRunner = func(_ context.Context) ([]byte, error) {
+		return []byte(`{
+			"daily": [
+				{"date":"2026-03-01","inputTokens":1000,"outputTokens":5000,"cacheCreationTokens":200,"cacheReadTokens":800,"totalTokens":7000,"totalCost":3.50,"modelsUsed":["claude-opus-4-20250514"]},
+				{"date":"2026-03-02","inputTokens":500,"outputTokens":2500,"cacheCreationTokens":100,"cacheReadTokens":400,"totalTokens":3500,"totalCost":1.75,"modelsUsed":["claude-opus-4-20250514","claude-sonnet-4-20250514"]}
+			],
+			"totals": {"inputTokens":1500,"outputTokens":7500,"cacheCreationTokens":300,"cacheReadTokens":1200,"totalTokens":10500,"totalCost":5.25}
+		}`), nil
+	}
+
+	stdout, _, err := executeIntegrationCmd("cost", "show", "--json")
+	if err != nil {
+		t.Fatalf("cost show --json failed: %v\nOutput: %s", err, stdout)
+	}
+
+	var resp costShowResponse
+	if unmarshalErr := json.Unmarshal([]byte(stdout), &resp); unmarshalErr != nil {
+		t.Fatalf("failed to unmarshal JSON: %v\nOutput: %s", unmarshalErr, stdout)
+	}
+
+	// Verify ccusage enrichment fields are present
+	if resp.CacheHitRate == nil {
+		t.Error("CacheHitRate missing from JSON output")
+	} else if *resp.CacheHitRate != 0.8 {
+		t.Errorf("CacheHitRate = %f, want 0.8", *resp.CacheHitRate)
+	}
+
+	if resp.BurnRate == nil {
+		t.Error("BurnRate missing from JSON output")
+	} else if *resp.BurnRate != 2.625 {
+		t.Errorf("BurnRate = %f, want 2.625", *resp.BurnRate)
+	}
+
+	if resp.ProjectedTotal == nil {
+		t.Error("ProjectedTotal missing from JSON output")
+	}
+
+	if resp.BillingWindowSpent == nil {
+		t.Error("BillingWindowSpent missing from JSON output")
+	} else if *resp.BillingWindowSpent != 5.25 {
+		t.Errorf("BillingWindowSpent = %f, want 5.25", *resp.BillingWindowSpent)
+	}
+
+	// Verify totals from ccusage (internal DB empty)
+	if resp.TotalCost != 5.25 {
+		t.Errorf("TotalCost = %f, want 5.25", resp.TotalCost)
+	}
+	if resp.TotalInputTokens != 1500 {
+		t.Errorf("TotalInputTokens = %d, want 1500", resp.TotalInputTokens)
+	}
+
+	// Verify by_model populated from ccusage
+	if len(resp.ByModel) != 2 {
+		t.Errorf("ByModel has %d entries, want 2", len(resp.ByModel))
+	}
+}
+
+func TestCostShowJSON_CCUsageUnavailable(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Mock ccusage runner to fail (simulates npx not installed)
+	origRunner := ccusageRunner
+	defer func() { ccusageRunner = origRunner }()
+
+	ccusageRunner = func(_ context.Context) ([]byte, error) {
+		return nil, fmt.Errorf("npx not found")
+	}
+
+	// Seed some internal DB records
+	store := cost.NewStore(wsDir)
+	if openErr := store.Open(); openErr != nil {
+		t.Fatalf("failed to open cost store: %v", openErr)
+	}
+	_, _ = store.Record("eng-01", "", "claude-opus", 1000, 500, 0.05)
+	_ = store.Close()
+
+	stdout, _, err := executeIntegrationCmd("cost", "show", "--json")
+	if err != nil {
+		t.Fatalf("cost show --json failed: %v\nOutput: %s", err, stdout)
+	}
+
+	var resp costShowResponse
+	if unmarshalErr := json.Unmarshal([]byte(stdout), &resp); unmarshalErr != nil {
+		t.Fatalf("failed to unmarshal JSON: %v\nOutput: %s", unmarshalErr, stdout)
+	}
+
+	// Should gracefully degrade — no ccusage fields
+	if resp.CacheHitRate != nil {
+		t.Error("CacheHitRate should be nil when ccusage unavailable")
+	}
+	if resp.BurnRate != nil {
+		t.Error("BurnRate should be nil when ccusage unavailable")
+	}
+	if resp.ProjectedTotal != nil {
+		t.Error("ProjectedTotal should be nil when ccusage unavailable")
+	}
+	if resp.BillingWindowSpent != nil {
+		t.Error("BillingWindowSpent should be nil when ccusage unavailable")
+	}
+
+	// Internal DB data should still be present
+	if resp.TotalCost != 0.05 {
+		t.Errorf("TotalCost = %f, want 0.05", resp.TotalCost)
+	}
+	if resp.ByAgent["eng-01"] != 0.05 {
+		t.Errorf("ByAgent[eng-01] = %f, want 0.05", resp.ByAgent["eng-01"])
+	}
+}
+
+func TestCostShowJSON_MixedDBAndCCUsage(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	// Mock ccusage runner
+	origRunner := ccusageRunner
+	defer func() { ccusageRunner = origRunner }()
+
+	ccusageRunner = func(_ context.Context) ([]byte, error) {
+		return []byte(`{
+			"daily": [{"date":"2026-03-01","inputTokens":5000,"outputTokens":25000,"cacheCreationTokens":500,"cacheReadTokens":4500,"totalTokens":35000,"totalCost":15.00,"modelsUsed":["opus"]}],
+			"totals": {"inputTokens":5000,"outputTokens":25000,"cacheCreationTokens":500,"cacheReadTokens":4500,"totalTokens":35000,"totalCost":15.00}
+		}`), nil
+	}
+
+	// Seed internal DB with records
+	store := cost.NewStore(wsDir)
+	if openErr := store.Open(); openErr != nil {
+		t.Fatalf("failed to open cost store: %v", openErr)
+	}
+	_, _ = store.Record("eng-01", "", "claude-opus", 1000, 500, 0.05)
+	_, _ = store.Record("eng-02", "", "claude-sonnet", 2000, 1000, 0.03)
+	_ = store.Close()
+
+	stdout, _, err := executeIntegrationCmd("cost", "show", "--json")
+	if err != nil {
+		t.Fatalf("cost show --json failed: %v\nOutput: %s", err, stdout)
+	}
+
+	var resp costShowResponse
+	if unmarshalErr := json.Unmarshal([]byte(stdout), &resp); unmarshalErr != nil {
+		t.Fatalf("failed to unmarshal JSON: %v\nOutput: %s", unmarshalErr, stdout)
+	}
+
+	// Internal DB has data — totals should NOT be overridden
+	if resp.TotalCost != 0.08 {
+		t.Errorf("TotalCost = %f, want 0.08 (from internal DB)", resp.TotalCost)
+	}
+
+	// But ccusage enrichment fields should still be present
+	if resp.CacheHitRate == nil {
+		t.Error("CacheHitRate should be present")
+	} else if *resp.CacheHitRate != 0.9 {
+		t.Errorf("CacheHitRate = %f, want 0.9", *resp.CacheHitRate)
+	}
+
+	if resp.BillingWindowSpent == nil {
+		t.Error("BillingWindowSpent should be present")
+	} else if *resp.BillingWindowSpent != 15.00 {
+		t.Errorf("BillingWindowSpent = %f, want 15.00", *resp.BillingWindowSpent)
+	}
+
+	// by_model from internal DB should be preserved (not overridden)
+	if len(resp.ByModel) != 2 {
+		t.Errorf("ByModel has %d entries, want 2 (from internal DB)", len(resp.ByModel))
 	}
 }


### PR DESCRIPTION
## Summary

Enriches `bc cost show --json` with ccusage analytics data for the TUI CostsView (#1891). Part of #1892 cost CLI cleanup.

**New JSON fields added to CostSummary response:**
- `cache_hit_rate` — cache read / (read + creation) from ccusage
- `burn_rate` — average daily cost (USD/day) from ccusage daily entries
- `projected_total` — burn_rate * days in current month
- `billing_window_spent` — total ccusage billing window cost

**Behavior:**
- Calls ccusage internally via `npx ccusage@latest --json` during `--json` mode
- Gracefully degrades if npx/ccusage unavailable (fields omitted, no error)
- When internal DB has data, its totals are preserved; ccusage only fills enrichment fields
- When internal DB is empty, totals are populated from ccusage
- `by_model` populated from ccusage `modelsUsed` when internal DB has no model data

**Files changed:**
- `internal/cmd/cost.go` — `costShowResponse` struct, `enrichWithCCUsage()`, `fetchCCUsageDailyReport()`, injectable `ccusageRunner` for testing
- `internal/cmd/cost_test.go` — 10 new tests: 5 unit tests for enrichment logic, 3 mock runner tests, 3 integration tests

## Test plan

- [x] `TestEnrichWithCCUsage` — full enrichment with cache, burn rate, projection
- [x] `TestEnrichWithCCUsage_NilReport` — graceful nil handling
- [x] `TestEnrichWithCCUsage_NoCache` — no cache tokens scenario
- [x] `TestEnrichWithCCUsage_InternalDBHasData` — totals not overridden
- [x] `TestEnrichWithCCUsage_EmptyDaily` — empty daily entries
- [x] `TestFetchCCUsageDailyReport_MockRunner` — valid, error, invalid JSON
- [x] `TestCostShowJSON_WithCCUsageEnrichment` — full integration
- [x] `TestCostShowJSON_CCUsageUnavailable` — graceful degradation
- [x] `TestCostShowJSON_MixedDBAndCCUsage` — DB + ccusage coexistence
- [x] Verified e2e: `./bin/bc cost show --json` returns enriched data with real ccusage

Closes go-3's part of #1892.

🤖 Generated with [Claude Code](https://claude.com/claude-code)