### PR TITLE
fix(tui): prevent CommandBar/FilterBar key leaks (#1870)

### DIFF
--- a/tui/src/app.tsx
+++ b/tui/src/app.tsx
@@ -14,6 +14,7 @@ import {
   type View,
 } from './navigation';
 import { useTheme } from './theme';
+import { useFocus } from './navigation/FocusContext';
 import { UnreadProvider, HintsProvider, DisableInputProvider, useDisableInput } from './hooks';
 import { useThemeConfig } from './config';
 import { RootProvider } from './providers';
@@ -85,6 +86,7 @@ function AppContent({ themeConfig }: AppContentProps): React.ReactElement {
   const { stdout } = useStdout();
   const { setThemeName } = useTheme();
   const { isDisabled: disableInput } = useDisableInput();
+  const { setFocus, returnFocus } = useFocus();
   const [showCommandBar, setShowCommandBar] = useState(false);
   const [showFilterBar, setShowFilterBar] = useState(false);
 
@@ -94,28 +96,34 @@ function AppContent({ themeConfig }: AppContentProps): React.ReactElement {
     }
   }, [themeConfig.theme, setThemeName]);
 
+  // #1870: Set focus to 'command'/'filter' when overlays open to prevent key leaks
   const openCommandBar = useCallback(() => {
     setShowCommandBar(true);
     setShowFilterBar(false);
-  }, []);
+    setFocus('command');
+  }, [setFocus]);
 
   const closeCommandBar = useCallback(() => {
     setShowCommandBar(false);
-  }, []);
+    returnFocus();
+  }, [returnFocus]);
 
   const handleCommandSelect = useCallback((view: View) => {
     navigate(view);
     setShowCommandBar(false);
-  }, [navigate]);
+    returnFocus();
+  }, [navigate, returnFocus]);
 
   const openFilterBar = useCallback(() => {
     setShowFilterBar(true);
     setShowCommandBar(false);
-  }, []);
+    setFocus('filter');
+  }, [setFocus]);
 
   const closeFilterBar = useCallback(() => {
     setShowFilterBar(false);
-  }, []);
+    returnFocus();
+  }, [returnFocus]);
 
   useKeyboardNavigation({
     disabled: disableInput || showCommandBar || showFilterBar,

--- a/tui/src/hooks/useListNavigation.ts
+++ b/tui/src/hooks/useListNavigation.ts
@@ -15,6 +15,7 @@
 
 import { useState, useCallback, useMemo } from 'react';
 import { useInput } from 'ink';
+import { useFocus } from '../navigation/FocusContext';
 
 export interface SearchState {
   /** Whether search mode is active */
@@ -93,6 +94,10 @@ export function useListNavigation<T>(
     customKeys = {},
     isActive = true,
   } = options;
+
+  // #1870: Check focus state to disable input when CommandBar/FilterBar is open
+  const { focusedArea } = useFocus();
+  const isOverlayActive = focusedArea === 'command' || focusedArea === 'filter' || focusedArea === 'modal';
 
   // Use itemCount override when provided (e.g., visibleItems.length in grouped view)
   const navLength = itemCount !== undefined ? itemCount : items.length;
@@ -252,7 +257,7 @@ export function useListNavigation<T>(
         return;
       }
     },
-    { isActive: !disabled && isActive && navLength > 0 }
+    { isActive: !disabled && isActive && !isOverlayActive && navLength > 0 }
   );
 
   return {

--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -171,7 +171,7 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
     return undefined;
   }, [visibleItems, validIndex]);
 
-  const { setFocus } = useFocus();
+  const { setFocus, focusedArea } = useFocus();
   const { setBreadcrumbs, clearBreadcrumbs } = useNavigation();
 
   // Manage focus state and breadcrumbs for nested view navigation (#1604)
@@ -256,6 +256,8 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
   // #1743: Keyboard handling for special keys not covered by useListNavigation
   // The hook handles j/k/g/G navigation, / for search, c to clear search
   useInput((input, key) => {
+    // #1870: Don't handle input when CommandBar/FilterBar is open
+    if (focusedArea === 'command' || focusedArea === 'filter') return;
     // Let hook handle search mode
     if (search.isActive) return;
     if (showDetail) return;


### PR DESCRIPTION
## Summary
- Fix keys typed in CommandBar/FilterBar leaking to views behind the overlay
- Uses existing FocusContext plumbing to gate input handlers when overlays are active
- 3 files changed, ~22 lines — minimal, surgical fix

## Changes
1. **app.tsx**: Call `setFocus('command')` / `setFocus('filter')` when overlays open, `returnFocus()` when they close
2. **useListNavigation.ts**: Check `focusedArea` from FocusContext, disable `useInput` when overlay is active (`command`, `filter`, or `modal`)
3. **AgentsView.tsx**: Add early-return guard in raw `useInput` handler for overlay focus state

## How it works
The FocusContext already had `'command'` and `'filter'` focus areas defined but nothing was setting them. This fix wires up the open/close handlers in `app.tsx` to set focus properly, then `useListNavigation` (used by all list views) checks `focusedArea` and disables its `useInput` handler when an overlay is active. AgentsView has an additional raw `useInput` for special keys (attach, peek, etc.) that also needs the guard.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run build` — clean  
- [x] `npx eslint` on changed files — clean (2 pre-existing errors only)
- [x] `bun test` — 2816 pass, 41 fail + 7 errors (all pre-existing)
- [ ] Manual: open CommandBar with `:`, type `agents` — verify no j/k navigation in background view
- [ ] Manual: open FilterBar with `/`, type filter text — verify no view actions triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)