### PR TITLE
feat(tui): redesign ChannelsView with HeaderBar, table layout, polish (#1890)

### DIFF
--- a/tui/src/components/channels/ChannelHistoryView.tsx
+++ b/tui/src/components/channels/ChannelHistoryView.tsx
@@ -8,6 +8,7 @@ import { Box, Text, useInput, useStdout } from 'ink';
 import { useChannelHistory, useUnread } from '../../hooks';
 import { useFocus } from '../../navigation/FocusContext';
 import { ChatMessage } from '../ChatMessage';
+import { HeaderBar } from '../HeaderBar';
 import { Footer } from '../Footer';
 import type { Channel } from '../../types';
 
@@ -189,13 +190,18 @@ export function ChannelHistoryView({
   return (
     // #1425 fix: Use flexGrow instead of height="100%" to prevent layout overflow
     <Box flexDirection="column" width="100%" flexGrow={1} overflow="hidden">
-      {/* Header section - #1461 fix: Removed duplicate hints (shown in footer) */}
-      <Box flexDirection="column" height={2} marginBottom={1}>
-        <Box>
-          <Text bold color="cyan">#{channel.name}</Text>
-          <Text dimColor> - {channel.members.length} members</Text>
+      {/* #1890: HeaderBar with member count */}
+      <HeaderBar
+        title={`#${channel.name}`}
+        subtitle={`${String(channel.members.length)} members`}
+        loading={loading}
+        color="cyan"
+      />
+      {channel.description && (
+        <Box paddingX={1} marginBottom={1}>
+          <Text dimColor wrap="truncate">{channel.description}</Text>
         </Box>
-      </Box>
+      )}
 
       {/* Message area - dynamic height adjusts as input expands */}
       <Box

--- a/tui/src/components/channels/ChannelRow.tsx
+++ b/tui/src/components/channels/ChannelRow.tsx
@@ -14,56 +14,40 @@ export interface ChannelRowProps {
 }
 
 /**
- * ChannelRow - Renders a single channel in the list
+ * ChannelRow - Renders a single channel as a table row
+ * #1890: Redesigned with column layout matching ChannelsView headers
  *
  * Features:
- * - Selection indicator (▸)
- * - Unread message badge (● or "N new")
- * - Member count suffix
- * - Color highlighting for selected/unread
+ * - Selection indicator (▸) with cyan highlight
+ * - Unread badge with yellow highlight
+ * - Column layout: CHANNEL (24) | UNREAD (12) | MEMBERS (10) | DESCRIPTION (flex)
  */
 export function ChannelRow({ channel, selected, unreadCount }: ChannelRowProps): React.ReactElement {
-  // #981 fix: Build name row as single truncated text to ensure visibility at 80 cols
-  // #1129: Highlight channels with unread messages
-  // #1364 Issue 2: Clarify channel numbers (unread vs members)
-  // Priority: name > unread indicator > member count > description
-  const namePrefix = selected ? '▸ ' : '  ';
-  const channelName = `#${channel.name}`;
-
-  // Format member count with 'm' suffix to distinguish from unread (#1364)
-  const memberInfo = ` ${String(channel.members.length)}m`;
-
-  // Format unread badge with 'new' label to clarify meaning (#1364)
-  // #1779: Always include text label alongside symbol for accessibility
-  const unreadBadge = unreadCount > 0
-    ? unreadCount === 1
-      ? ' ● 1 new'
-      : ` ● ${unreadCount > 99 ? '99+' : String(unreadCount)} new`
-    : '';
-
-  // Build single text line to avoid nested Text truncation issues on narrow terminals
-  // Issue #981: Nested Text elements break rendering at 80x24 width
-  const nameLineText = `${namePrefix}${channelName}${unreadBadge}${memberInfo}`;
-
-  // Determine text color: cyan if selected, yellow if has unread, default otherwise
   const textColor = selected ? 'cyan' : unreadCount > 0 ? 'yellow' : undefined;
 
-  // #1171 fix: Remove explicit width="100%" to avoid nested width calculation issues at 80x24
-  // #1528 fix: Add flexGrow={1} to ensure Box takes available width for wrap="truncate" to work
-  // The parent Box already has width="100%", inner Box needs flexGrow to claim its share
+  // Unread display: "● N new" or "-"
+  const unreadDisplay = unreadCount > 0
+    ? `● ${unreadCount > 99 ? '99+' : String(unreadCount)} new`
+    : '-';
+
   return (
-    <Box flexDirection="column" flexGrow={1}>
-      {/* Name row: single Text for proper truncation at narrow widths */}
-      <Text
-        wrap="truncate"
-        color={textColor}
-        bold={selected || unreadCount > 0}
-      >
-        {nameLineText}
-      </Text>
-      {channel.description && (
-        <Text dimColor wrap="truncate">{channel.description}</Text>
-      )}
+    <Box paddingX={1}>
+      <Box width={24}>
+        <Text color={textColor} bold={selected || unreadCount > 0} wrap="truncate">
+          {selected ? '▸ ' : '  '}#{channel.name}
+        </Text>
+      </Box>
+      <Box width={12}>
+        <Text color={unreadCount > 0 ? 'yellow' : undefined} bold={unreadCount > 0}>
+          {unreadDisplay}
+        </Text>
+      </Box>
+      <Box width={10}>
+        <Text dimColor>{String(channel.members.length)}</Text>
+      </Box>
+      <Box flexGrow={1}>
+        <Text dimColor wrap="truncate">{channel.description ?? '-'}</Text>
+      </Box>
     </Box>
   );
 }

--- a/tui/src/views/ChannelsView.tsx
+++ b/tui/src/views/ChannelsView.tsx
@@ -13,7 +13,9 @@ import { useChannelsWithUnread, useDisableInput, useListNavigation } from '../ho
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { ErrorDisplay } from '../components/ErrorDisplay';
+import { HeaderBar } from '../components/HeaderBar';
 import { Footer } from '../components/Footer';
+import { LoadingIndicator } from '../components/LoadingIndicator';
 import { ChannelRow, ChannelHistoryView } from '../components/channels';
 import type { Channel } from '../types';
 
@@ -64,7 +66,8 @@ export function ChannelsView(_props: ChannelsViewProps = {}): React.ReactElement
         setViewMode('history');
       }
     },
-  }), [channelList.length, setFocus]);
+    r: () => { void refresh(); },
+  }), [channelList.length, setFocus, refresh]);
 
   // #1737: Use useListNavigation for keyboard handling
   const {
@@ -89,13 +92,8 @@ export function ChannelsView(_props: ChannelsViewProps = {}): React.ReactElement
     }
   }, [viewMode, selectedChannel, setBreadcrumbs, clearBreadcrumbs, setFocus]);
 
-  if (channelsLoading) {
-    return (
-      <Box flexDirection="column">
-        <Text bold>Channels</Text>
-        <Text dimColor>Loading channels...</Text>
-      </Box>
-    );
+  if (channelsLoading && channelList.length === 0) {
+    return <LoadingIndicator message="Loading channels..." />;
   }
 
   if (channelsError) {
@@ -116,27 +114,49 @@ export function ChannelsView(_props: ChannelsViewProps = {}): React.ReactElement
     );
   }
 
-  // #1483 fix: Remove width="100%" to avoid layout overflow at 80 columns
-  // Ink's layout calculates width incorrectly when width="100%" + padding + border
-  // Let flexbox handle width naturally through flexGrow
-  // #1461 fix: Removed inline hints - global footer shows view-specific hints
+  // #1890: Redesigned with HeaderBar, table layout, Footer
   return (
-    <Box flexDirection="column" flexGrow={1} overflow="hidden">
-      <Text bold>Channels</Text>
-      <Box marginTop={1} flexDirection="column" flexGrow={1} borderStyle="single" borderColor="gray" paddingX={1}>
-        {channels?.map((channel, index) => (
-          <ChannelRow
-            key={channel.name}
-            channel={channel}
-            selected={index === selectedIndex}
-            unreadCount={channel.unread}
-          />
-        ))}
-        {(!channels || channels.length === 0) && (
-          <Box flexDirection="column">
+    <Box flexDirection="column" width="100%" overflow="hidden">
+      <HeaderBar
+        title="Channels"
+        count={channelList.length}
+        loading={channelsLoading}
+        color="cyan"
+      />
+
+      {/* Channel table */}
+      <Box flexDirection="column" marginBottom={1}>
+        {/* Column headers */}
+        <Box paddingX={1}>
+          <Box width={24}>
+            <Text bold dimColor>CHANNEL</Text>
+          </Box>
+          <Box width={12}>
+            <Text bold dimColor>UNREAD</Text>
+          </Box>
+          <Box width={10}>
+            <Text bold dimColor>MEMBERS</Text>
+          </Box>
+          <Box flexGrow={1}>
+            <Text bold dimColor>DESCRIPTION</Text>
+          </Box>
+        </Box>
+
+        {/* Channel rows */}
+        {channelList.length === 0 ? (
+          <Box paddingX={1} marginTop={1} flexDirection="column">
             <Text dimColor>No channels yet.</Text>
             <Text dimColor>Create one with: bc channel create &lt;name&gt;</Text>
           </Box>
+        ) : (
+          channelList.map((channel, index) => (
+            <ChannelRow
+              key={channel.name}
+              channel={channel}
+              selected={index === selectedIndex}
+              unreadCount={channel.unread}
+            />
+          ))
         )}
       </Box>
 
@@ -146,6 +166,7 @@ export function ChannelsView(_props: ChannelsViewProps = {}): React.ReactElement
         { key: 'g/G', label: 'top/bottom' },
         { key: 'Enter', label: 'open' },
         { key: 'm', label: 'compose' },
+        { key: 'r', label: 'refresh' },
       ]} />
     </Box>
   );


### PR DESCRIPTION
## Summary
- **ChannelsView**: Replace plain `<Text bold>Channels</Text>` with `<HeaderBar>` (cyan, channel count, loading indicator). Replace gray-bordered wrapper with table layout using column headers (CHANNEL, UNREAD, MEMBERS, DESCRIPTION). Add 'r' refresh key. Use `<LoadingIndicator>`.
- **ChannelRow**: Convert from single-line text to table row format matching column headers. Separate columns for name (cyan ▸ selection), unread badge (yellow ● N new), member count, and description.
- **ChannelHistoryView**: Replace plain text header with `<HeaderBar>` showing `#channel-name` with member count subtitle. Add channel description line below header when present.

## What this covers from #1890
- [x] ChannelsView uses HeaderBar, Footer, theme colors
- [x] Proper visual hierarchy with column headers
- [x] Unread channels have clear yellow ● indicator in dedicated column
- [x] Compose area has clear active/inactive states (already existed, verified)
- [x] Looks good at 80x24 (table fits: 24+12+10+flex = fits in 80 cols)

## Not in scope (per approach posted on issue)
- ChatMessage bubble restyling (functional, fits 80x24)
- Theme token replacement (depends on #1847)
- Side-by-side split view (not enough room at 80 cols)

## Files Changed
- `tui/src/views/ChannelsView.tsx` — HeaderBar + table layout + refresh + LoadingIndicator
- `tui/src/components/channels/ChannelRow.tsx` — Table row with fixed columns
- `tui/src/components/channels/ChannelHistoryView.tsx` — HeaderBar + description

## Test plan
- [x] TypeScript compiles cleanly
- [x] ChannelsView tests pass (22/22)
- [ ] Manual: verify channel list with column headers at 80x24
- [ ] Manual: verify unread badge in yellow, selected in cyan
- [ ] Manual: Enter channel → HeaderBar + subtitle + description
- [ ] Manual: 'r' refreshes channel list

🤖 Generated with [Claude Code](https://claude.com/claude-code)