### PR TITLE
fix(tui): compact chat messages at 80x24 to fix border corruption (#1899)

### DIFF
--- a/tui/src/components/ChatMessage.tsx
+++ b/tui/src/components/ChatMessage.tsx
@@ -17,6 +17,8 @@ export interface ChatMessageProps {
   maxBubbleWidth?: number;
   /** Maximum lines to display before truncating (default: unlimited, set 0 for no limit) */
   maxLines?: number;
+  /** #1899: Compact mode — no bubble borders, flat layout for narrow terminals */
+  compact?: boolean;
 }
 
 const formatRelativeTime = (timestamp: string): string => {
@@ -68,6 +70,7 @@ export const ChatMessage = memo<ChatMessageProps>(function ChatMessage({
   isSelected = false,
   maxBubbleWidth = 60,
   maxLines = 0, // #1718: Default to no truncation for full message visibility
+  compact = false, // #1899: Flat layout for narrow terminals
 }) {
   const time = formatRelativeTime(timestamp);
   const senderColor = getColorForName(sender);
@@ -81,6 +84,32 @@ export const ChatMessage = memo<ChatMessageProps>(function ChatMessage({
   const displayMessage = isTruncated
     ? lines.slice(0, maxLines).join('\n')
     : message;
+
+  // #1899: Compact mode — no bubble borders, sender + time on one line, message below
+  // Used at narrow terminals (<100 cols) to avoid border corruption and wasted space
+  if (compact) {
+    return (
+      <Box flexDirection="column" width="100%" paddingX={1} marginBottom={1}>
+        <Box>
+          <Text color={senderColor} bold>{rolePrefix}{sender}</Text>
+          {isOwnMessage && <Text color="cyan" dimColor> (you)</Text>}
+          <Text dimColor>  {time}</Text>
+          {!isRead && <Text color="blue"> ●</Text>}
+        </Box>
+        <Box paddingLeft={2} flexDirection="column">
+          <MentionText text={displayMessage} currentUser={currentUser} />
+          {isTruncated && (
+            <Text dimColor>... ({lines.length - maxLines} more lines)</Text>
+          )}
+        </Box>
+        {reactions.length > 0 && (
+          <Box paddingLeft={2}>
+            <ReactionBar reactions={reactions} />
+          </Box>
+        )}
+      </Box>
+    );
+  }
 
   // Bubble styling based on ownership
   const bubbleBorderColor = isOwnMessage ? 'cyan' : 'gray';

--- a/tui/src/components/channels/ChannelHistoryView.tsx
+++ b/tui/src/components/channels/ChannelHistoryView.tsx
@@ -86,19 +86,26 @@ export function ChannelHistoryView({
     [messageBuffer.length, terminalWidth]
   );
 
+  // #1899: Compact mode for narrow terminals — no bubble borders, flat layout
+  const isNarrow = terminalWidth < 100;
+
   // Dynamic layout based on terminal size (#976)
   // CLI directive: Fix messages appearing behind input field
-  // Layout breakdown: header(3+1margin) + input(inputHeight+1margin) + footer(1) + borders(4) + safety(2)
-  const layoutOverhead = 4 + inputHeight + 1 + 1 + 4 + 2; // = 12 + inputHeight
+  // #1899: Updated overhead for HeaderBar (2 lines) vs old header (4 lines)
+  // Layout: HeaderBar(2) + description?(2) + msgBorder(2) + inputHeight + inputMargin(1) + footer(1) + safety(2)
+  const headerOverhead = channel.description ? 4 : 2;
+  const layoutOverhead = headerOverhead + 2 + inputHeight + 1 + 1 + 2;
   const messageAreaHeight = Math.max(8, terminalHeight - layoutOverhead);
 
-  // Dynamic bubble width: 80% of available width, min 40, max 140
-  // #1681 fix: Account for container overhead (8 cols: view border/padding + bubble border/padding)
-  const containerOverhead = 8;
-  const maxBubbleWidth = Math.min(140, Math.max(40, Math.floor((terminalWidth - containerOverhead) * 0.8)));
+  // #1899: At narrow widths, use full width for compact messages (no bubble borders)
+  // At wide widths, use 80% with bubble border overhead
+  const containerOverhead = isNarrow ? 4 : 8; // narrow: just message area border/padding; wide: + bubble border/padding
+  const bubblePercent = isNarrow ? 1.0 : 0.8;
+  const maxBubbleWidth = Math.min(140, Math.max(40, Math.floor((terminalWidth - containerOverhead) * bubblePercent)));
 
-  // Dynamic message count: ~4 lines per message bubble
-  const maxMessages = Math.max(3, Math.floor(messageAreaHeight / 4));
+  // Dynamic message count: compact messages are ~3 lines, bubbles ~4 lines
+  const linesPerMessage = isNarrow ? 3 : 4;
+  const maxMessages = Math.max(3, Math.floor(messageAreaHeight / linesPerMessage));
 
   /**
    * Synchronize focus state with input mode
@@ -226,6 +233,7 @@ export function ChannelHistoryView({
                 timestamp={msg.time}
                 currentUser={process.env.BC_AGENT_ID}
                 maxBubbleWidth={maxBubbleWidth}
+                compact={isNarrow}
               />
             ))}
             {hasMoreBelow && <Text dimColor>↓ more messages below</Text>}


### PR DESCRIPTION
## Summary
- At narrow terminals (<100 cols), ChatMessage renders in **compact mode** — no bubble borders, flat layout
- Fixes 4 of 6 issues from #1899: border corruption, invisible sender names, wasted space, message truncation
- Updated layoutOverhead calculation in ChannelHistoryView for new HeaderBar (merged in #1907)

## Changes
- **ChatMessage.tsx**: Added `compact` prop. When true, renders sender + time on one line, indented message below — no `borderStyle="round"` that causes corruption at narrow widths
- **ChannelHistoryView.tsx**: Detects narrow terminal (`<100 cols`), passes `compact={true}` to ChatMessage, uses full width for messages, fixes layoutOverhead formula (HeaderBar is 2 lines, not 4)

## What this fixes from #1899
- [x] Sender names visible on every message (compact format: `sender  time`)
- [x] No bubble border corruption (borders removed at narrow widths)
- [x] Full width messages (no 15-char wasted space on right)
- [x] Better message fit — more messages visible (3 lines per compact msg vs 4 per bubble)
- [x] Footer hints — already fixed by #1878

## What's not in scope
- Channel list layout — already fixed by #1907 (HeaderBar + table layout)
- Wide terminal (120+) enhancements — tracked in #1890 remaining items

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/__tests__/ChannelsView.test.tsx` — 16 pass
- [x] `bun test src/__tests__/ChannelsViewEnter.test.tsx` — 6 pass
- [x] `bunx eslint` on changed files — clean
- [ ] Manual: at 80x24, open a channel — messages show sender name, no border corruption
- [ ] Manual: at 120x30, open a channel — bubble borders still used (not compact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)