### PR TITLE
fix(tui): loading timeout + skeleton for CostsView and ToolsView (#1898)

### DIFF
--- a/tui/src/hooks/index.ts
+++ b/tui/src/hooks/index.ts
@@ -141,3 +141,5 @@ export {
   type KeyCategory,
   type FocusStateMachineResult,
 } from './useFocusStateMachine';
+
+export { useLoadingTimeout } from './useLoadingTimeout';

--- a/tui/src/hooks/useLoadingTimeout.ts
+++ b/tui/src/hooks/useLoadingTimeout.ts
@@ -1,0 +1,27 @@
+/**
+ * useLoadingTimeout - Track elapsed time during loading states
+ * Issue #1898: CostsView and ToolsView stuck loading
+ *
+ * Returns elapsed seconds while loading is true. Resets to 0 when loading becomes false.
+ * Use to show progressive timeout messages (e.g. 5s slow warning, 10s timeout).
+ */
+
+import { useState, useEffect } from 'react';
+
+export function useLoadingTimeout(loading: boolean): number {
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (!loading) {
+      setElapsed(0);
+      return;
+    }
+    const start = Date.now();
+    const timer = setInterval(() => {
+      setElapsed(Math.floor((Date.now() - start) / 1000));
+    }, 1000);
+    return () => { clearInterval(timer); };
+  }, [loading]);
+
+  return elapsed;
+}

--- a/tui/src/views/CostsView.tsx
+++ b/tui/src/views/CostsView.tsx
@@ -11,7 +11,8 @@ import { InlineProgressBar } from '../components/ProgressBar';
 import { Panel } from '../components/Panel';
 import { ErrorDisplay } from '../components/ErrorDisplay';
 import { Footer } from '../components/Footer';
-import { useCosts, useDisableInput, useListNavigation } from '../hooks';
+import { Spinner } from '../components/LoadingIndicator';
+import { useCosts, useDisableInput, useListNavigation, useLoadingTimeout } from '../hooks';
 import { useFocus } from '../navigation/FocusContext';
 import { useNavigation } from '../navigation/NavigationContext';
 import { getCostIndicator, type CostStatus } from '../theme/StatusColors';
@@ -124,23 +125,61 @@ export function CostsView(_props: CostsViewProps = {}): React.ReactElement {
     { key: 'r', label: 'refresh' },
   ];
 
-  if (loading) {
+  // #1898: Track loading duration for timeout messages
+  const loadingElapsed = useLoadingTimeout(loading && !costs);
+
+  // #1898: Skeleton state during initial load (no data yet)
+  if (loading && !costs) {
+    // After 10s: timeout message with retry
+    if (loadingElapsed >= 10) {
+      return (
+        <Box flexDirection="column" paddingX={1}>
+          <Box>
+            <Text bold>Costs</Text>
+            <Text>  </Text>
+            <Text color="yellow">⚠ Data unavailable</Text>
+          </Box>
+          <Box flexDirection="column" marginTop={1}>
+            <Text dimColor>Cost data could not be loaded.</Text>
+            <Text dimColor>This usually means ccusage is slow or not installed.</Text>
+            <Text dimColor>Press [r] to retry.</Text>
+          </Box>
+          <Footer hints={[{ key: 'r', label: 'refresh' }]} />
+        </Box>
+      );
+    }
+
+    // Skeleton with spinner and placeholder rows
+    const loadingMsg = loadingElapsed >= 5
+      ? 'Taking longer than expected...'
+      : 'Fetching cost analytics...';
+
     return (
-      <Box flexDirection="column">
-        <Text bold>Costs</Text>
-        <Text dimColor>Loading cost data...</Text>
+      <Box flexDirection="column" paddingX={1}>
+        <Box>
+          <Text bold>Costs</Text>
+          <Text dimColor> (—)</Text>
+          <Box flexGrow={1} />
+          <Spinner />
+          <Text> {loadingMsg}</Text>
+        </Box>
+        <Box flexDirection="column" marginTop={1}>
+          <Text dimColor>  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─</Text>
+          <Text dimColor>  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─</Text>
+          <Text dimColor>  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─</Text>
+        </Box>
         <Footer hints={mainHints} />
       </Box>
     );
   }
 
-  if (error) {
+  if (error && !costs) {
     return <ErrorDisplay error={error} onRetry={handleRefresh} />;
   }
 
   if (!costs) {
     return (
-      <Box flexDirection="column">
+      <Box flexDirection="column" paddingX={1}>
         <Text bold>Costs</Text>
         <Text dimColor>No cost data available</Text>
         <Footer hints={mainHints} />

--- a/tui/src/views/ToolsView.tsx
+++ b/tui/src/views/ToolsView.tsx
@@ -8,7 +8,7 @@ import { Box, Text } from 'ink';
 import { LoadingIndicator } from '../components/LoadingIndicator';
 import { HeaderBar } from '../components/HeaderBar';
 import { Footer } from '../components/Footer';
-import { useDisableInput, useListNavigation } from '../hooks';
+import { useDisableInput, useListNavigation, useLoadingTimeout } from '../hooks';
 import { truncate } from '../utils';
 import type { ToolInfo } from '../types';
 import { getToolList } from '../services/bc';
@@ -59,15 +59,48 @@ export function ToolsView(_props: ToolsViewProps = {}): React.ReactElement {
     return Math.min(25, Math.max(15, maxLen + 3));
   }, [tools]);
 
+  // #1898: Track loading duration for timeout messages
+  const loadingElapsed = useLoadingTimeout(loading && tools.length === 0);
+
   if (loading && tools.length === 0) {
-    return <LoadingIndicator message="Loading tools..." />;
+    // After 10s: timeout with retry
+    if (loadingElapsed >= 10) {
+      return (
+        <Box flexDirection="column" width="100%" overflow="hidden">
+          <HeaderBar title="Tools" count={0} loading={false} color="cyan" />
+          <Box paddingX={1} marginTop={1} flexDirection="column">
+            <Text color="yellow">Some tools could not be checked — press [r] to retry</Text>
+          </Box>
+          <Footer hints={[{ key: 'r', label: 'refresh' }]} />
+        </Box>
+      );
+    }
+
+    // Loading with progressive message
+    const loadingMsg = loadingElapsed >= 5
+      ? 'Tools check taking longer than expected...'
+      : 'Loading tools...';
+
+    return (
+      <Box flexDirection="column" width="100%" overflow="hidden">
+        <HeaderBar title="Tools" count={0} loading={true} color="cyan" />
+        <Box paddingX={1} marginTop={1}>
+          <LoadingIndicator message={loadingMsg} />
+        </Box>
+        <Footer hints={[{ key: 'r', label: 'refresh' }]} />
+      </Box>
+    );
   }
 
   if (error && tools.length === 0) {
     return (
-      <Box flexDirection="column" padding={1}>
-        <Text color="red">Error: {error}</Text>
-        <Text dimColor>Press r to retry, q to go back</Text>
+      <Box flexDirection="column" width="100%" overflow="hidden">
+        <HeaderBar title="Tools" count={0} loading={false} color="cyan" />
+        <Box paddingX={1} marginTop={1}>
+          <Text color="red">Error: {error}</Text>
+          <Text dimColor> — Press r to retry</Text>
+        </Box>
+        <Footer hints={[{ key: 'r', label: 'refresh' }]} />
       </Box>
     );
   }


### PR DESCRIPTION
## Summary
- Add `useLoadingTimeout` hook to track elapsed loading seconds
- **CostsView**: Replace plain "Loading cost data..." with skeleton layout (header + spinner + placeholder rows). Progressive messages at 5s, timeout at 10s with retry
- **ToolsView**: Add timeout to existing spinner. Slow message at 5s, timeout with retry at 10s. Consistent view layout (HeaderBar + Footer) for loading/error states

## Test plan
- [ ] Navigate to Costs view — see skeleton with spinner during initial load
- [ ] Wait 5s on slow connection — message changes to "Taking longer than expected..."
- [ ] Wait 10s — see timeout message with retry prompt, press [r] to retry
- [ ] Navigate to Tools view — spinner with HeaderBar during load
- [ ] Verify 80x24 compliance for all loading states
- [ ] Typecheck clean (`tsc --noEmit`), no new lint errors, no new test failures

Closes #1898

🤖 Generated with [Claude Code](https://claude.com/claude-code)