### PR TITLE
fix(tui): Dashboard 120x30 layout corruption (#1897)

### DIFF
--- a/tui/src/components/MetricCard.tsx
+++ b/tui/src/components/MetricCard.tsx
@@ -23,7 +23,7 @@ export const MetricCard = memo(function MetricCard({
   suffix = '',
 }: MetricCardProps) {
   return (
-    <Box flexDirection="column" paddingX={1} borderStyle="single" borderColor="gray" minHeight={4}>
+    <Box flexDirection="column" paddingX={1} marginRight={1} borderStyle="single" borderColor="gray" minHeight={4}>
       <Text dimColor>{label}</Text>
       <Text bold color={color}>
         {prefix}{value}{suffix}

--- a/tui/src/views/Dashboard.tsx
+++ b/tui/src/views/Dashboard.tsx
@@ -214,7 +214,7 @@ const SummaryCards = memo(function SummaryCards({
 
   // Standard bordered MetricCards for wider terminals
   return (
-    <Box flexWrap="wrap">
+    <Box flexWrap="wrap" marginBottom={1}>
       <MetricCard value={total} label="Total" />
       <MetricCard value={active} label="Active" color="green" />
       <MetricCard value={working} label="Working" color="cyan" />
@@ -281,7 +281,7 @@ const SystemHealthPanel = memo(function SystemHealthPanel({
 
   // Standard bordered Panel for wider terminals
   return (
-    <Panel title="System Health">
+    <Panel title="Health">
       <Box flexDirection="column">
         {/* Health percentage - Box layout to prevent truncation garbling */}
         <Box>
@@ -375,9 +375,9 @@ const CostPanel = memo(function CostPanel({
   return (
     <Panel title="Cost">
       <Box flexDirection="column">
-        {/* Line 1: Total + burn rate */}
+        {/* Line 1: Total + burn rate (show placeholder when no data yet) */}
         <Box>
-          <Text bold color="yellow">${totalCostUSD.toFixed(2)}</Text>
+          <Text bold color="yellow">{totalCostUSD > 0 ? `$${totalCostUSD.toFixed(2)}` : '$—'}</Text>
           {burnRate > 0 && (
             <Text dimColor>  {costSymbol} ${burnRate.toFixed(2)}/hr</Text>
           )}
@@ -469,24 +469,19 @@ const AgentStatsPanel = memo(function AgentStatsPanel({ stats, isNarrow }: Agent
 
   // Standard bordered Panel for wider terminals
   return (
-    <Panel title="Agent Distribution">
+    <Panel title="Roles">
       <Box flexDirection="column">
-        <Text dimColor>By Role:</Text>
-        <Box flexDirection="column" marginTop={1}>
-          {roleEntries.map(([role, count]) => {
-            // Truncate long role names to prevent overflow at narrow widths
-            const displayRole = role.length > MAX_ROLE_LEN
-              ? role.slice(0, MAX_ROLE_LEN - 1) + '…'
-              : role;
-            // #1338: Use single Text with wrap="truncate" to prevent text corruption
-            // Avoid nested Box which causes layout issues at 80x24
-            return (
-              <Text key={role} wrap="truncate">
-                {displayRole}: {count}
-              </Text>
-            );
-          })}
-        </Box>
+        {roleEntries.map(([role, count]) => {
+          // Truncate long role names to prevent overflow at narrow widths
+          const displayRole = role.length > MAX_ROLE_LEN
+            ? role.slice(0, MAX_ROLE_LEN - 1) + '…'
+            : role;
+          return (
+            <Text key={role} wrap="truncate">
+              {displayRole}: {count}
+            </Text>
+          );
+        })}
       </Box>
     </Panel>
   );


### PR DESCRIPTION
## Summary
- Fix MetricCards overlapping panels at 120x30 — add horizontal gaps between cards and vertical margin before panels
- Fix "91% healthyth" garble — shorten panel title from "System Health" to "Health"
- Fix "By Role:stribution" garble — shorten title from "Agent Distribution" to "Roles", remove redundant prefix
- Show `$—` placeholder in CostPanel when cost data is zero/loading instead of `$0.00`

## Changes
1. **MetricCard.tsx**: Add `marginRight={1}` for 1-char gap between cards
2. **Dashboard.tsx**: Add `marginBottom={1}` on SummaryCards wrapping Box for clear card/panel separation
3. **Dashboard.tsx**: Rename panel titles — "Health" and "Roles" — to prevent text corruption in narrow side column
4. **Dashboard.tsx**: CostPanel shows `$—` instead of `$0.00` when no cost data loaded

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `bun test` — 2821 pass, 36 fail + 7 errors (all pre-existing)
- [x] `bun run build` — clean
- [ ] Manual: `printf '\e[8;30;120t' && bc home` — verify card gaps, panel titles, no overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)