### PR TITLE
docs: update Cost Tracking commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,13 @@ bc down
 
 | Command | Description |
 |---------|-------------|
+| `bc cost [agent]` | Show cost records (default) |
 | `bc cost show [agent]` | Show cost records |
-| `bc cost summary` | Show cost summary |
-| `bc cost by-agent` | Show costs grouped by agent |
-| `bc cost budget` | Manage cost budgets |
-| `bc cost dashboard` | Show comprehensive cost dashboard |
-| `bc cost project` | Project future costs |
-| `bc cost trends` | Show spending trends |
+| `bc cost usage` | Claude Code token usage via ccusage |
+| `bc cost usage --monthly` | Monthly usage summary |
+| `bc cost budget show` | Show budget status |
+| `bc cost budget set <amount>` | Set a cost budget |
+| `bc cost budget delete` | Delete a budget |
 
 ### Worktrees
 


### PR DESCRIPTION
## Summary
- Remove 5 dead cost subcommands from README (`summary`, `by-agent`, `dashboard`, `project`, `trends`) that were removed in #1894
- Add current cost commands: `bc cost [agent]` default, `bc cost usage`, `bc cost budget show/set/delete`
- Reflects changes from #1893 (ccusage enrichment) and #1875 (cost usage command)

## Test plan
- [ ] Verify listed commands match `bc cost --help` output
- [ ] Verify `bc cost usage --help` matches documented flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)