### PR TITLE
fix(agent): prevent crashes when 10 agents start concurrently

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -815,18 +815,6 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 		}
 	}
 
-	// Send bootstrap prompt if we have content
-	if len(promptParts) > 0 {
-		// Wait for agent to initialize (Gemini/Claude needs time to start REPL)
-		time.Sleep(m.getBootstrapDelay())
-
-		prompt := strings.Join(promptParts, "\n\n---\n\n")
-		prompt += fmt.Sprintf("\n\n---\n\nWorkspace: %s\nAgent ID: %s\n", workspace, name)
-		if err := m.tmux.SendKeys(context.TODO(), name, prompt); err != nil {
-			log.Warn("failed to send bootstrap prompt", "agent", name, "error", err)
-		}
-	}
-
 	// Update parent's children list
 	if parentID != "" {
 		if parent, exists := m.agents[parentID]; exists {
@@ -838,6 +826,25 @@ func (m *Manager) SpawnAgentWithOptions(name string, role Role, workspace string
 	// Save state
 	if err := m.saveState(); err != nil {
 		log.Warn("failed to save agent state", "error", err)
+	}
+
+	// Send bootstrap prompt asynchronously (like respawn path at line 656)
+	// to avoid holding m.mu during the blocking sleep.
+	if len(promptParts) > 0 {
+		bootstrapName := name
+		bootstrapWorkspace := workspace
+		bootstrapParts := make([]string, len(promptParts))
+		copy(bootstrapParts, promptParts)
+		bootstrapDelay := m.getBootstrapDelay()
+
+		go func() {
+			time.Sleep(bootstrapDelay)
+			prompt := strings.Join(bootstrapParts, "\n\n---\n\n")
+			prompt += fmt.Sprintf("\n\n---\n\nWorkspace: %s\nAgent ID: %s\n", bootstrapWorkspace, bootstrapName)
+			if err := m.tmux.SendKeys(context.TODO(), bootstrapName, prompt); err != nil {
+				log.Warn("failed to send bootstrap prompt", "agent", bootstrapName, "error", err)
+			}
+		}()
 	}
 
 	return agent, nil
@@ -945,13 +952,27 @@ func truncateLogFile(path string, maxBytes int64) {
 }
 
 // createWorktree creates a per-agent git worktree so agents don't clobber each other.
+// Uses a cross-process file lock to prevent concurrent git worktree operations.
 // Returns the worktree directory path.
 func createWorktree(workspace, agentName string) (string, error) {
 	worktreeDir := filepath.Join(workspace, ".bc", "worktrees", agentName)
 
-	// If worktree already exists, reuse it
+	// If worktree already exists, reuse it (fast path, no lock needed)
 	if _, err := os.Stat(worktreeDir); err == nil {
 		log.Debug("reusing existing worktree", "agent", agentName, "dir", worktreeDir)
+		return worktreeDir, nil
+	}
+
+	// Acquire cross-process lock for git worktree operations
+	fl := newFileLock(worktreeLockPath(workspace))
+	if err := fl.Lock(30 * time.Second); err != nil {
+		return "", fmt.Errorf("failed to acquire worktree lock: %w", err)
+	}
+	defer fl.Unlock()
+
+	// Re-check after acquiring lock (another process may have created it)
+	if _, err := os.Stat(worktreeDir); err == nil {
+		log.Debug("reusing existing worktree (after lock)", "agent", agentName, "dir", worktreeDir)
 		return worktreeDir, nil
 	}
 
@@ -960,27 +981,40 @@ func createWorktree(workspace, agentName string) (string, error) {
 		return "", fmt.Errorf("failed to create worktrees dir: %w", err)
 	}
 
-	// Create detached worktree at HEAD (current main)
-	cmd := exec.CommandContext(context.Background(), "git", "-C", workspace, "worktree", "add", "--detach", worktreeDir, "HEAD") //nolint:gosec // args are trusted internal paths
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		// If failed because it's already registered but missing, prune and retry
-		if strings.Contains(string(output), "already registered") {
-			log.Info("pruning stale worktrees to recover", "agent", agentName)
-			_ = exec.CommandContext(context.Background(), "git", "-C", workspace, "worktree", "prune").Run()
+	// Retry with backoff for transient git errors under concurrency
+	var lastErr error
+	backoffs := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 400 * time.Millisecond}
 
-			// Retry
-			cmd = exec.CommandContext(context.Background(), "git", "-C", workspace, "worktree", "add", "--detach", worktreeDir, "HEAD") //nolint:gosec // args are trusted internal paths
-			output, err = cmd.CombinedOutput()
+	for attempt := 0; attempt <= len(backoffs); attempt++ {
+		if attempt > 0 {
+			time.Sleep(backoffs[attempt-1])
 		}
 
+		// Create detached worktree at HEAD (current main)
+		cmd := exec.CommandContext(context.Background(), "git", "-C", workspace, "worktree", "add", "--detach", worktreeDir, "HEAD") //nolint:gosec // args are trusted internal paths
+		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return "", fmt.Errorf("failed to create worktree for %s: %w (%s)", agentName, err, string(output))
+			// If failed because it's already registered but missing, prune and retry
+			if strings.Contains(string(output), "already registered") {
+				log.Info("pruning stale worktrees to recover", "agent", agentName)
+				_ = exec.CommandContext(context.Background(), "git", "-C", workspace, "worktree", "prune").Run()
+
+				// Retry after prune
+				cmd = exec.CommandContext(context.Background(), "git", "-C", workspace, "worktree", "add", "--detach", worktreeDir, "HEAD") //nolint:gosec // args are trusted internal paths
+				output, err = cmd.CombinedOutput()
+			}
+
+			if err != nil {
+				lastErr = fmt.Errorf("failed to create worktree for %s: %w (%s)", agentName, err, string(output))
+				continue
+			}
 		}
+
+		log.Debug("created worktree", "agent", agentName, "dir", worktreeDir)
+		return worktreeDir, nil
 	}
 
-	log.Debug("created worktree", "agent", agentName, "dir", worktreeDir)
-	return worktreeDir, nil
+	return "", lastErr
 }
 
 // gitWrapperScript is the shell script that shadows git to warn on write
@@ -1070,10 +1104,20 @@ func createMemoryDir(workspace, agentName string) (string, error) {
 }
 
 // removeWorktree removes a per-agent git worktree.
+// Uses a cross-process file lock to prevent concurrent git worktree operations.
 func removeWorktree(workspace, worktreeDir string) {
 	if worktreeDir == "" {
 		return
 	}
+
+	// Acquire cross-process lock for git worktree operations
+	fl := newFileLock(worktreeLockPath(workspace))
+	if err := fl.Lock(30 * time.Second); err != nil {
+		log.Warn("failed to acquire worktree lock for removal", "dir", worktreeDir, "error", err)
+		return
+	}
+	defer fl.Unlock()
+
 	cmd := exec.CommandContext(context.Background(), "git", "-C", workspace, "worktree", "remove", "--force", worktreeDir)
 	if output, err := cmd.CombinedOutput(); err != nil {
 		log.Warn("failed to remove worktree", "dir", worktreeDir, "error", err, "output", string(output))
@@ -1782,7 +1826,9 @@ func (m *Manager) AttachToAgent(name string) error {
 	return cmd.Run()
 }
 
-// saveState persists agent state to disk.
+// saveState persists agent state to disk using atomic write (temp + rename)
+// and a cross-process file lock to prevent corruption from concurrent writers.
+// Must be called while holding m.mu.
 func (m *Manager) saveState() error {
 	if m.stateDir == "" {
 		return nil
@@ -1797,16 +1843,38 @@ func (m *Manager) saveState() error {
 		return err
 	}
 
-	return os.WriteFile(filepath.Join(m.stateDir, "agents.json"), data, 0600)
+	// Acquire cross-process lock
+	fl := newFileLock(stateLockPath(m.stateDir))
+	if err := fl.Lock(30 * time.Second); err != nil {
+		return fmt.Errorf("failed to acquire state lock: %w", err)
+	}
+	defer fl.Unlock()
+
+	// Atomic write: temp file then rename
+	target := filepath.Join(m.stateDir, "agents.json")
+	tmp := target + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, target)
 }
 
 // LoadState loads agent state from disk.
+// Uses a cross-process file lock to prevent reading a partially written file.
 func (m *Manager) LoadState() error {
 	if m.stateDir == "" {
 		return nil
 	}
 
+	// Acquire cross-process lock before reading
+	fl := newFileLock(stateLockPath(m.stateDir))
+	if err := fl.Lock(30 * time.Second); err != nil {
+		return fmt.Errorf("failed to acquire state lock for read: %w", err)
+	}
+
 	data, err := os.ReadFile(filepath.Join(m.stateDir, "agents.json"))
+	fl.Unlock()
+
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/pkg/agent/filelock.go
+++ b/pkg/agent/filelock.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/log"
+)
+
+// fileLock provides cross-process file locking using flock(2).
+// This is used to coordinate git worktree and state file operations
+// across multiple concurrent bc processes.
+type fileLock struct {
+	f    *os.File
+	path string
+}
+
+// newFileLock creates a new file lock at the given path.
+// The lock file is created if it doesn't exist.
+func newFileLock(path string) *fileLock {
+	return &fileLock{path: path}
+}
+
+// Lock acquires an exclusive flock with a timeout.
+// Returns an error if the lock cannot be acquired within the timeout.
+func (fl *fileLock) Lock(timeout time.Duration) error {
+	if err := os.MkdirAll(filepath.Dir(fl.path), 0750); err != nil {
+		return fmt.Errorf("create lock dir: %w", err)
+	}
+
+	f, err := os.OpenFile(fl.path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return fmt.Errorf("open lock file: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	interval := 100 * time.Millisecond
+
+	for {
+		err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			fl.f = f
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			_ = f.Close()
+			return fmt.Errorf("timeout acquiring lock %s after %v", fl.path, timeout)
+		}
+
+		time.Sleep(interval)
+	}
+}
+
+// Unlock releases the flock and closes the file.
+func (fl *fileLock) Unlock() {
+	if fl.f == nil {
+		return
+	}
+	if err := syscall.Flock(int(fl.f.Fd()), syscall.LOCK_UN); err != nil {
+		log.Warn("failed to unlock", "path", fl.path, "error", err)
+	}
+	_ = fl.f.Close()
+	fl.f = nil
+}
+
+// worktreeLockPath returns the path for the worktree file lock.
+func worktreeLockPath(workspace string) string {
+	return filepath.Join(workspace, ".bc", "worktree.lock")
+}
+
+// stateLockPath returns the path for the agent state file lock.
+func stateLockPath(stateDir string) string {
+	return filepath.Join(stateDir, "agents.lock")
+}

--- a/pkg/agent/filelock_test.go
+++ b/pkg/agent/filelock_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFileLock_BasicLockUnlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	fl := newFileLock(path)
+	if err := fl.Lock(time.Second); err != nil {
+		t.Fatalf("Lock() failed: %v", err)
+	}
+	fl.Unlock()
+
+	// Lock file should exist after locking
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("lock file should exist: %v", err)
+	}
+}
+
+func TestFileLock_DoubleUnlockSafe(t *testing.T) {
+	dir := t.TempDir()
+	fl := newFileLock(filepath.Join(dir, "test.lock"))
+	if err := fl.Lock(time.Second); err != nil {
+		t.Fatalf("Lock() failed: %v", err)
+	}
+	fl.Unlock()
+	fl.Unlock() // should not panic
+}
+
+func TestFileLock_MutualExclusion(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	fl1 := newFileLock(path)
+	if err := fl1.Lock(time.Second); err != nil {
+		t.Fatalf("fl1 Lock() failed: %v", err)
+	}
+
+	// Second lock should timeout quickly
+	fl2 := newFileLock(path)
+	err := fl2.Lock(300 * time.Millisecond)
+	if err == nil {
+		fl2.Unlock()
+		fl1.Unlock()
+		t.Fatal("expected fl2 Lock() to fail while fl1 holds the lock")
+	}
+
+	fl1.Unlock()
+
+	// Now fl2 should succeed
+	if err := fl2.Lock(time.Second); err != nil {
+		t.Fatalf("fl2 Lock() after fl1 unlock failed: %v", err)
+	}
+	fl2.Unlock()
+}
+
+func TestFileLock_ConcurrentGoroutines(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.lock")
+
+	var counter int64
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			fl := newFileLock(path)
+			if err := fl.Lock(10 * time.Second); err != nil {
+				t.Errorf("Lock() failed: %v", err)
+				return
+			}
+			// Increment non-atomically inside the lock to detect races
+			v := atomic.LoadInt64(&counter)
+			atomic.StoreInt64(&counter, v+1)
+			fl.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if atomic.LoadInt64(&counter) != 10 {
+		t.Fatalf("expected counter=10, got %d", atomic.LoadInt64(&counter))
+	}
+}
+
+func TestFileLock_CreatesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "dir", "test.lock")
+
+	fl := newFileLock(path)
+	if err := fl.Lock(time.Second); err != nil {
+		t.Fatalf("Lock() failed with nested dir: %v", err)
+	}
+	fl.Unlock()
+}
+
+func TestWorktreeLockPath(t *testing.T) {
+	got := worktreeLockPath("/workspace")
+	want := filepath.Join("/workspace", ".bc", "worktree.lock")
+	if got != want {
+		t.Fatalf("worktreeLockPath = %q, want %q", got, want)
+	}
+}
+
+func TestStateLockPath(t *testing.T) {
+	got := stateLockPath("/workspace/.bc/agents")
+	want := filepath.Join("/workspace/.bc/agents", "agents.lock")
+	if got != want {
+		t.Fatalf("stateLockPath = %q, want %q", got, want)
+	}
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -21,7 +21,7 @@
 // All connections use these settings:
 //   - WAL journal mode for better concurrency
 //   - Foreign keys enabled
-//   - 5 second busy timeout
+//   - 30 second busy timeout
 //   - Single connection pool (SQLite limitation)
 //   - Optimized cache and synchronous settings
 package db
@@ -39,7 +39,9 @@ import (
 )
 
 // DefaultBusyTimeout is the default timeout for SQLite busy handling.
-const DefaultBusyTimeout = 5000 // milliseconds
+// Set to 30s to handle concurrent agent access; SQLite returns as soon as
+// the lock is available — this is just the worst-case upper bound.
+const DefaultBusyTimeout = 30000 // milliseconds
 
 // DefaultCacheSize is the default SQLite page cache size in KB.
 const DefaultCacheSize = 2000
@@ -47,7 +49,7 @@ const DefaultCacheSize = 2000
 // Config holds database configuration options.
 type Config struct {
 	// BusyTimeout is the SQLite busy timeout in milliseconds.
-	// Default: 5000 (5 seconds)
+	// Default: 30000 (30 seconds)
 	BusyTimeout int
 
 	// CacheSize is the SQLite page cache size in KB.


### PR DESCRIPTION
## Summary

- **Async bootstrap**: Move blocking 3s sleep+send out of global mutex into goroutine (matches existing respawn path), reducing serial spawn time from 30s+ to ~instant
- **Cross-process file lock**: New `flock(2)`-based lock (`pkg/agent/filelock.go`) to coordinate git worktree and state file operations across concurrent `bc` processes
- **Atomic state writes**: `agents.json` now written via temp-file-then-rename under flock, preventing corruption from concurrent writers
- **Worktree retry with backoff**: `createWorktree` and `removeWorktree` wrapped with file lock + retry (3 attempts with 100/200/400ms backoff) for transient git errors
- **SQLite busy timeout**: Increased `DefaultBusyTimeout` from 5s to 30s — SQLite returns immediately when the lock is free, this just prevents premature SQLITE_BUSY under concurrent agent load

## Root causes addressed

| Problem | Fix |
|---------|-----|
| 3s `time.Sleep` inside global `m.mu.Lock()` serializes spawns to 30s+ | Move sleep+send into goroutine |
| Concurrent `git worktree add` from multiple processes races | Cross-process flock on `.bc/worktree.lock` |
| Concurrent `agents.json` writes corrupt state | Atomic write + flock on `.bc/agents.lock` |
| 5s SQLite busy timeout too aggressive for 10 agents | Increase to 30s |

## Test plan

- [x] `make test` — all existing tests pass (race detector on)
- [x] `make lint` — 0 issues
- [x] `make build` — compiles cleanly
- [ ] Manual: `bc up` then rapidly `bc agent create eng-{01..10} --role engineer` — all 10 stay alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)