### PR TITLE
docs: rewrite CLAUDE.md to fix inaccuracies and add missing details

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,227 +4,125 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Quick Start
 
+**Prerequisites**: Go 1.25.1+, tmux, golangci-lint, make. For TUI: Bun.
+
 **Build**
 ```bash
-make build              # Build binary to bin/bc with version info
-make build-release      # Optimized release build
+make build              # Build binary to bin/bc (runs go generate first)
+make build-release      # Optimized release build (stripped symbols)
 ```
 
 **Test**
 ```bash
-make test               # Run all tests with race detector
-make coverage           # Generate coverage report
-make test -k TestName   # Run specific test (use pattern matching)
+make test                                    # Run all tests with race detector
+go test -race -run TestAgentStart ./pkg/agent/  # Run a specific test
+make coverage                                # Generate coverage report
+make bench                                   # Run benchmarks
 ```
 
-**Development**
+**Lint & Check**
 ```bash
-make dev                # Run CLI in development mode (go run)
-make gen                # Generate config from config.toml
 make fmt                # Format code with gofmt
 make lint               # Run golangci-lint (strict)
-make check              # Run full check suite (gen + fmt + lint + test)
+make check              # Full check suite: gen + fmt + vet + lint + test
 ```
 
-**TUI (TypeScript/React with Ink)**
+**TUI**
 ```bash
-cd tui && bun install && bun run build   # Build TUI package
-cd tui && bun test                       # Run TUI tests
-cd tui && bun run lint                   # Lint TUI code
+make build-tui          # Build TUI (cd tui && bun install && bun run build)
+make test-tui           # Run TUI tests
+make lint-tui           # Lint TUI code
+bun test src/hooks/__tests__/useStatus.test.tsx  # Run specific TUI test (from tui/)
 ```
 
-## Project Structure
+## Architecture
 
-### Core Architecture
+**bc** is a CLI-first AI agent orchestration system built in Go with a TypeScript/React TUI. It coordinates teams of AI agents (Claude Code, Gemini, Cursor, etc.) working in isolated tmux sessions with per-agent git worktrees.
 
-**bc** is an AI agent orchestration CLI built in Go with a TypeScript/React TUI. Key components:
+### Package Layout
 
-- **cmd/bc/main.go**: Entry point that delegates to internal/cmd
-- **internal/cmd/**: All Cobra CLI command implementations (single package, many files)
-  - Commands are organized as `*Cmd` variables (agent.go, channel.go, etc.)
-  - Each command file contains subcommand handlers
-- **pkg/**: Reusable packages imported by commands
-  - **agent/**: Agent lifecycle, roles, capabilities, tmux session management
-  - **workspace/**: Workspace/project initialization, config (v1 JSON and v2 TOML), roles
-  - **channel/**: Agent-to-agent communication channels, SQLite storage
-  - **memory/**: Agent memory system, learnings, experiences
-  - **cost/**: Cost tracking, budgets, spending analytics
-  - **events/**: Event logging and stuck-agent detection
-  - **process/**: Background process management
-  - **demon/**: Scheduled task management
-  - **tmux/**: tmux session control for agent isolation
-  - **git/**: Git worktree operations for per-agent isolation
-  - **team/**: Team and grouping management
-  - **routing/**: Agent routing and pattern matching
-  - **stats/**: Workspace statistics
-  - **log/**: Logging utilities
-  - **names/**: Random agent name generation
-  - **ui/**: CLI output formatting (colors, lists, tables, messages)
-- **tui/src/**: React/TypeScript TUI built with Ink
-  - Components, hooks, views for terminal UI
-  - Compiled to CommonJS in tui/dist/
-- **config.toml**: Default configuration
-- **prompts/**: Default role prompt templates
+- **cmd/bc/main.go** → entry point, injects version via ldflags, delegates to internal/cmd
+- **internal/cmd/** → all Cobra CLI commands in a single package. Commands are `*Cmd` variables registered via `init()`. Access workspace via `getWorkspace(cmd)` helper.
+- **pkg/** → reusable packages (agent, workspace, channel, cost, events, memory, tmux, git, etc.)
+- **config/** → generated from config.toml via `make gen` (uses cfgx tool)
+- **tui/src/** → React/Ink terminal UI with 14 views, compiled to CommonJS in tui/dist/
+- **prompts/** → default role prompt templates
+- **docker/** → per-provider Dockerfiles (claude, gemini, codex, aider, opencode, openclaw, cursor)
 
 ### Key Concepts
 
-**Agents**: Isolated AI assistants running in tmux sessions, each with own git worktree. Agents have roles (engineer, manager, etc.) loaded from workspace role files.
+- **Agents**: Isolated AI assistants in tmux sessions, each with own git worktree. Have roles (root, engineer, manager) with capabilities. State in `.bc/agents/<name>/`.
+- **Workspace**: Project dir with `.bc/` subdirectory for config, state, logs. Supports v2 (TOML) and legacy v1 (JSON) config formats.
+- **Channels**: SQLite-backed persistent inter-agent communication with reactions.
+- **Memory**: Per-agent persistent knowledge (experiences, learnings).
+- **Runtime backends**: Agents run in either tmux sessions or Docker containers, configured via `[runtime]` in config.toml.
+- **Roles**: Defined in `.bc/roles/*.md` with capabilities (create_agents, assign_work, implement_tasks, etc.) and hierarchy.
 
-**Workspace**: Project directory with `.bc/` subdirectory containing configuration, state, logs, and per-agent workspaces. Supports both v1 (JSON) and v2 (TOML) config formats.
+### Config Generation
 
-**Channels**: Persistent SQLite-backed inter-agent communication. Messages can have reactions.
+Config code is generated from `config.toml` using the `cfgx` tool (`go generate ./...`). The `make build` target runs `make gen` as a prerequisite. After modifying config.toml, always run `make gen`.
 
-**Memory**: Per-agent persistent knowledge (experiences, learnings). Stored in `.bc/` directory.
-
-**Cost Tracking**: All agent commands have tracked costs, with budgets and spending analytics.
-
-**Roles & Capabilities**: Agents have roles (root, engineer, manager, etc.) with capabilities (create_agents, assign_work, implement_tasks, etc.). Defined in workspace role files (.bc/roles/*.md).
-
-## Important Implementation Details
+## Implementation Details
 
 ### Command Structure
-- All commands are in `internal/cmd` as a single package
-- Use Cobra for CLI framework
-- Each command file (agent.go, channel.go, etc.) contains command tree for that feature
-- Commands use `*Cmd` variables and `init()` to register subcommands
-- Access workspace via `getWorkspace(cmd)` and related helpers
+- Single `internal/cmd` package with one file per command group (agent.go, channel.go, etc.)
+- Cobra framework with `*Cmd` variables and `init()` registration
+- Root command: opens TUI if workspace exists, prompts init if not, shows help in non-interactive mode
+- Global flags: `-v/--verbose`, `--json`
 
 ### Database
-- SQLite used for persistent storage (channels, cost, events)
-- Stored in `.bc/` directory (typically `.bc/state.db` or separate files)
-- Create tables with `IF NOT EXISTS` for idempotency
-- Use JSON encoding for complex data types
+- SQLite for persistent storage (channels, cost, events) in `.bc/` directory
+- Tables created with `IF NOT EXISTS` for idempotency
+- JSON encoding for complex data types
 
-### Testing
+### Testing Patterns
 - Table-driven tests preferred
-- Integration tests use actual workspace creation (see agent_integration_test.go)
-- E2E tests use tmux sessions (agent_e2e_test.go)
-- Strict linting enforced: errcheck, gosec, govet, noctx, etc.
+- `TestMain()` in `internal/cmd/` and `pkg/agent/` sets up global `RoleCapabilities` and `RoleHierarchy` maps
+- Integration tests use `setupIntegrationWorkspace()` and `seedAgents()` helpers
+- E2E tests use live tmux sessions (agent_e2e_test.go, channel_e2e_test.go)
+- TUI: test exported helper functions and type interfaces, not hooks directly (hooks can't be tested without DOM in Ink)
 
 ### Error Handling
-- Never ignore errors - use explicit handling or `//nolint:errcheck` with justification
-- Context must be propagated through call chains (noctx linter enforces this)
-- Exported functions should have clear error documentation
+- Never ignore errors — use explicit handling or `//nolint:errcheck` with justification
+- `noctx` linter enforces context.Context propagation through all call chains
 
-### Version Injection
-- Version, commit, commit date are injected via ldflags during build
-- Set via `main.version`, `main.commit`, `main.date` in cmd/bc/main.go
-- Passed to internal/cmd via `SetVersionInfo()` before command execution
+## Code Style
 
-### Configuration
-- **v2 config** (config.toml): TOML format with tools, workspace, roster, etc.
-- **v1 config** (.bc/config.json): Legacy JSON format
-- Generated config code in `config/` package via `make gen` (cfgx tool)
-- Role files: `.bc/roles/*.md` contain role definitions, capabilities, hierarchy
-
-### Agent Isolation
-- Each agent runs in isolated tmux session
-- Each agent has isolated git worktree via `git worktree add`
-- Memory/state stored per-agent in `.bc/agents/<name>/`
-
-## Development Practices
-
-**Code Style**
 - gofmt with -s (simplify)
+- goimports with local prefix `github.com/rpuneet/bc` (import grouping: stdlib, external, local)
+- Short receiver names: `w` for workspace, `a` for agent, `c` for channel
 - Avoid package-level variables except for cobra commands
-- Struct field alignment matters (fieldalignment linter)
-- Short identifiers preferred (receiver name 'w' for workspace, 'a' for agent)
+- Struct field alignment matters for memory efficiency (govet fieldalignment)
 
-**Logging**
-- Use pkg/log for all logging
-- Verbose flag controlled via `-v` or `--verbose`
-- JSON output via `--json` flag
+## Linting
 
-**Testing**
-- Write tests for new functionality
-- Use `make test` with race detector enabled
-- Test edge cases and error paths
-- Integration tests are acceptable but should clean up after themselves
+Strict golangci-lint config in `.golangci.yml`. Key linters:
+- **errcheck**: all errors handled (type assertions too)
+- **govet**: enable-all (includes fieldalignment, shadow, etc.)
+- **gosec**: security issues (G104 excluded)
+- **noctx**: context propagation
+- **staticcheck, bodyclose, prealloc, unconvert, misspell, ineffassign, unused**
 
-**Dependencies**
-- Keep minimal: BurntSushi/toml, charmbracelet/x, mattn/go-sqlite3, spf13/cobra
-- Run `make deps` to download and tidy
+Exclusions: deprecated queue/beads migration, test file magic numbers, main.go globals.
 
-## Linting & Quality
+## Git Conventions
 
-Critical lint rules enforced:
-- **errcheck**: All errors must be handled
-- **gosec**: Security issues must be addressed
-- **govet**: No shadowed variables
-- **noctx**: Context must be propagated properly
-- **fieldalignment**: Struct fields optimally aligned
+- Branch naming: `feat/`, `fix/`, `docs/` prefixes
+- Conventional commits format
+- Run `make check` before committing
 
-Run `make lint` to check. Configuration is in `.golangci.yml` with exceptions for deprecated queue/beads migration.
+## Docker Agent Images
+
+```bash
+make build-agent-image          # Build default (claude) agent image
+make build-agent-image-gemini   # Build specific provider image
+make build-agent-images         # Build all provider images
+```
 
 ## Architecture Patterns
 
-**Package Dependencies**
-- cmd imports pkg packages, not vice versa
-- pkg packages are self-contained
-- Use interfaces for loose coupling
-
-**Workspace Access**
-```go
-ws, err := workspace.Load(rootDir)  // Load existing
-ws, err := workspace.Init(rootDir)  // Initialize new
-```
-
-**Agent Operations**
-```go
-agents, err := ws.Agents(ctx)       // List agents
-ag, err := agent.Start(ctx, ws, name, role)  // Start new
-```
-
-**Channel Communication**
-```go
-ch, err := ws.Channel(name)         // Get channel
-err := ch.Send(agentName, message)  // Send message
-```
-
-## TUI (tui/)
-
-- Built with Bun (package manager) and TypeScript/React with Ink
-- Compiled to CommonJS in tui/dist/
-- Main app in src/app.tsx
-- 14 views: Dashboard, Agents, Channels, Costs, Commands, Roles, Logs, Worktrees, Workspaces, Demons, Processes, Memory, Routing, Help
-- Views, components, hooks organized by feature
-- Uses theme system for consistent styling
-- 3-tier keybinding system (global, view-local, context) in hooks/useKeybindings
-- Tests in src/__tests__/ using Jest/Bun test runner
-
-Run `make build-tui` to build, `make test-tui` to test, `make lint-tui` to lint.
-
-## Common Tasks
-
-**Add a new command**
-1. Create function in internal/cmd/newcmd.go following agent.go pattern
-2. Register with rootCmd in internal/cmd/root.go
-3. Add tests following cmd_test.go pattern
-4. Run `make check` before committing
-
-**Add a new package**
-1. Create directory in pkg/newpkg/
-2. Implement interfaces and functions
-3. Add tests alongside implementation
-4. Import in commands as needed
-
-**Debug agent session**
-```bash
-bc agent attach <name>      # Attach to tmux session
-bc agent peek <name>        # Show recent output
-bc logs --agent <name>      # Show event logs
-```
-
-**Profile performance**
-```bash
-make bench                   # Run benchmarks
-make coverage                # Generate coverage report
-```
-
-## References
-
-- README.md: Full feature list and command reference
-- CONTRIBUTING.md: Contribution guidelines with detailed examples
-- config.toml: Configuration file format and defaults
-- internal/cmd/AUDIT.md: Security audit notes
-- internal/cmd/MEMORY.md: Memory system documentation
+- cmd imports pkg, never vice versa; pkg packages are self-contained
+- Workspace access: `workspace.Load(rootDir)` / `workspace.Init(rootDir)`
+- Agent operations: `ws.Agents(ctx)`, `agent.Start(ctx, ws, name, role)`
+- Channel communication: `ws.Channel(name)`, `ch.Send(agentName, message)`
+- Use interfaces for loose coupling between packages


### PR DESCRIPTION
## Summary
- **Fix incorrect test command**: `make test -k TestName` → `go test -race -run TestName ./path/` (#1942)
- **Fix linter list to match .golangci.yml**: remove `fieldalignment` as standalone linter, add all actually-enabled linters (`bodyclose`, `prealloc`, `staticcheck`, etc.), correct `govet` description to reflect `enable-all` mode (#1943)
- **Add missing documentation**: Docker agent image build targets, Go 1.25.1+ prerequisite, `goimports` local prefix, config generation (`cfgx`), runtime backends, TestMain patterns, TUI testing guidance, git conventions (#1944)
- **Condense**: remove redundant package listing, generic advice, and verbose sections — cut from 230 to 125 lines while increasing information density

Closes #1942
Closes #1943
Closes #1944

## Test plan
- [ ] Verify all documented commands (`make build`, `make test`, `make lint`, etc.) work correctly
- [ ] Verify `go test -race -run TestName ./path/` syntax is correct
- [ ] Confirm linter list matches `.golangci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)