### PR TITLE
fix: correct test command in CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,9 +12,10 @@ make build-release      # Optimized release build
 
 **Test**
 ```bash
-make test               # Run all tests with race detector
-make coverage           # Generate coverage report
-make test -k TestName   # Run specific test (use pattern matching)
+make test                                      # Run all tests with race detector
+make coverage                                  # Generate coverage report
+go test -race ./pkg/agent/ -run TestName       # Run a specific test
+go test -race ./internal/cmd/ -run TestName    # Run a specific cmd test
 ```
 
 **Development**


### PR DESCRIPTION
## Summary
- Replace incorrect `make test -k TestName` with proper `go test -race ./pkg/agent/ -run TestName` examples
- The Makefile test target runs `go test -race ./...` and doesn't accept `-k`; Go uses `-run` for filtering tests

Fixes #1942

## Test plan
- [x] Verified `make test -k TestName` does not work with the Makefile
- [x] Verified `go test -race ./pkg/agent/ -run TestName` is the correct invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)