### PR TITLE
fix: update CI Go version from 1.22 to 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: '1.22'
-  BUN_VERSION: '1.1.0'
+  GO_VERSION: '1.25'
+  BUN_VERSION: '1.2'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Update `GO_VERSION` from 1.22 to 1.25 to match `go.mod` requirement (Go 1.25.1) and support the `tool` directive introduced in Go 1.24
- Update `BUN_VERSION` from 1.1.0 to 1.2

Fixes #1949

## Test plan
- [ ] Verify CI workflow runs successfully with Go 1.25
- [ ] Verify TUI build/test steps work with Bun 1.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)