### PR TITLE
feat(channel): add ChannelService, edit command, CLI enhancements

### DIFF
--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -17,8 +17,9 @@ import (
 )
 
 var channelCmd = &cobra.Command{
-	Use:   "channel",
-	Short: "Manage communication channels",
+	Use:     "channel",
+	Aliases: []string{"ch"},
+	Short:   "Manage communication channels",
 	Long: `Manage channels for broadcasting messages to groups of agents.
 
 Channels are named groups of agent members. Messages sent to a channel are
@@ -27,13 +28,20 @@ delivered to all member tmux sessions.
 Examples:
   bc channel list                      # List all channels
   bc channel create workers            # Create a channel named "workers"
+  bc channel show workers              # Show channel details
   bc channel add workers worker-01     # Add member to channel
+  bc channel add workers --agent w-01  # Add member via --agent flag
   bc channel send workers "run tests"  # Send to all members
+  bc channel history workers --last 20 # Show last 20 messages
+  bc channel react workers 5 👍        # React to message
+  bc channel edit workers --desc "..."  # Edit channel description
   bc channel remove workers worker-01  # Remove a member
   bc channel delete workers            # Delete the channel
+  bc channel status                    # Overview of all channels
+
+Agent Commands (require BC_AGENT_ID):
   bc channel join workers              # Join a channel (current agent)
   bc channel leave workers             # Leave a channel (current agent)
-  bc channel history workers           # Show channel message history
 
 Default Channels:
   #eng       Engineering team (all engineer agents)
@@ -59,16 +67,16 @@ var channelCreateCmd = &cobra.Command{
 }
 
 var channelAddCmd = &cobra.Command{
-	Use:   "add <channel> <member> [member...]",
+	Use:   "add <channel> [member...]",
 	Short: "Add members to a channel",
-	Args:  cobra.MinimumNArgs(2),
+	Args:  cobra.MinimumNArgs(1),
 	RunE:  runChannelAdd,
 }
 
 var channelRemoveCmd = &cobra.Command{
-	Use:   "remove <channel> <member>",
+	Use:   "remove <channel> [member]",
 	Short: "Remove a member from a channel",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.RangeArgs(1, 2),
 	RunE:  runChannelRemove,
 }
 
@@ -174,11 +182,30 @@ Examples:
 	RunE: runChannelStatus,
 }
 
+var channelEditCmd = &cobra.Command{
+	Use:   "edit <channel>",
+	Short: "Edit channel description/settings",
+	Long: `Edit a channel's description or settings.
+
+Examples:
+  bc channel edit eng --desc "Engineering discussion"`,
+	Args: cobra.ExactArgs(1),
+	RunE: runChannelEdit,
+}
+
 var channelCreateDesc string
+var channelEditDesc string
+
+// Channel add/remove --agent flags
+var (
+	channelAddAgent    string
+	channelRemoveAgent string
+)
 
 // Channel history flags
 var (
 	channelHistoryLimit  int
+	channelHistoryLast   int
 	channelHistoryOffset int
 	channelHistorySince  string
 	channelHistoryAgent  string
@@ -188,7 +215,14 @@ var (
 
 func init() {
 	channelCreateCmd.Flags().StringVar(&channelCreateDesc, "desc", "", "Channel description")
+	channelEditCmd.Flags().StringVar(&channelEditDesc, "desc", "", "New channel description")
+
+	// --agent flag for add/remove (alternative to positional args)
+	channelAddCmd.Flags().StringVar(&channelAddAgent, "agent", "", "Agent to add to channel")
+	channelRemoveCmd.Flags().StringVar(&channelRemoveAgent, "agent", "", "Agent to remove from channel")
+
 	channelHistoryCmd.Flags().IntVar(&channelHistoryLimit, "limit", 50, "Maximum number of messages to show")
+	channelHistoryCmd.Flags().IntVar(&channelHistoryLast, "last", 0, "Show last N messages (alias for --limit)")
 	channelHistoryCmd.Flags().IntVar(&channelHistoryOffset, "offset", 0, "Number of messages to skip")
 	channelHistoryCmd.Flags().StringVar(&channelHistorySince, "since", "", "Show messages since duration (e.g., 1h, 30m)")
 	channelHistoryCmd.Flags().StringVar(&channelHistoryAgent, "agent", "", "Filter messages by sender agent")
@@ -206,6 +240,7 @@ func init() {
 	channelReactCmd.ValidArgsFunction = CompleteChannelNames
 	channelShowCmd.ValidArgsFunction = CompleteChannelNames
 	channelDescCmd.ValidArgsFunction = CompleteChannelNames
+	channelEditCmd.ValidArgsFunction = CompleteChannelNames
 
 	channelCmd.AddCommand(channelCreateCmd)
 	channelCmd.AddCommand(channelAddCmd)
@@ -220,6 +255,7 @@ func init() {
 	channelCmd.AddCommand(channelShowCmd)
 	channelCmd.AddCommand(channelDescCmd)
 	channelCmd.AddCommand(channelStatusCmd)
+	channelCmd.AddCommand(channelEditCmd)
 	rootCmd.AddCommand(channelCmd)
 }
 
@@ -362,7 +398,15 @@ func runChannelAdd(cmd *cobra.Command, args []string) error {
 	if !validIdentifier(channelName) {
 		return fmt.Errorf("channel name %q contains invalid characters (use letters, numbers, dash, underscore)", channelName)
 	}
+
+	// Collect members from positional args and --agent flag
 	members := args[1:]
+	if channelAddAgent != "" {
+		members = append(members, channelAddAgent)
+	}
+	if len(members) == 0 {
+		return fmt.Errorf("at least one member is required (use positional args or --agent)")
+	}
 
 	added := 0
 	for _, member := range members {
@@ -398,7 +442,16 @@ func runChannelRemove(cmd *cobra.Command, args []string) error {
 	if !validIdentifier(channelName) {
 		return fmt.Errorf("channel name %q contains invalid characters (use letters, numbers, dash, underscore)", channelName)
 	}
-	member := args[1]
+
+	// Get member from positional arg or --agent flag
+	var member string
+	if len(args) > 1 {
+		member = args[1]
+	} else if channelRemoveAgent != "" {
+		member = channelRemoveAgent
+	} else {
+		return fmt.Errorf("member is required (use positional arg or --agent)")
+	}
 
 	if err := store.RemoveMember(channelName, member); err != nil {
 		return err
@@ -676,6 +729,11 @@ func runChannelHistory(cmd *cobra.Command, args []string) error {
 		history = filtered
 	}
 
+	// --last overrides --limit when explicitly set
+	if channelHistoryLast > 0 {
+		channelHistoryLimit = channelHistoryLast
+	}
+
 	// Apply --offset and --limit
 	if channelHistoryOffset > 0 {
 		if channelHistoryOffset >= len(history) {
@@ -909,6 +967,44 @@ func runChannelDesc(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Updated description for channel %q: %s\n", channelName, description)
+	return nil
+}
+
+func runChannelEdit(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return errNotInWorkspace(err)
+	}
+
+	store, err := loadChannelStore(ws.RootDir)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = store.Close() }()
+
+	channelName := args[0]
+	if !validIdentifier(channelName) {
+		return fmt.Errorf("channel name %q contains invalid characters (use letters, numbers, dash, underscore)", channelName)
+	}
+
+	// Verify channel exists
+	if _, exists := store.Get(channelName); !exists {
+		return fmt.Errorf("channel %q not found (use 'bc channel list' to see available channels)", channelName)
+	}
+
+	if channelEditDesc == "" {
+		return fmt.Errorf("at least one setting is required (e.g. --desc)")
+	}
+
+	if err := store.SetDescription(channelName, channelEditDesc); err != nil {
+		return fmt.Errorf("failed to set description: %w", err)
+	}
+
+	if err := store.Save(); err != nil {
+		return fmt.Errorf("failed to save channels: %w", err)
+	}
+
+	fmt.Printf("Updated channel %q\n", channelName)
 	return nil
 }
 

--- a/internal/cmd/channel_test.go
+++ b/internal/cmd/channel_test.go
@@ -285,7 +285,7 @@ func TestChannelAdd_RequiresArgs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing args, got nil")
 	}
-	if !strings.Contains(err.Error(), "requires at least 2 arg") {
+	if !strings.Contains(err.Error(), "requires at least 1 arg") {
 		t.Errorf("expected arg count error, got: %v", err)
 	}
 }
@@ -313,7 +313,7 @@ func TestChannelRemove_RequiresArgs(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing args, got nil")
 	}
-	if !strings.Contains(err.Error(), "accepts 2 arg") {
+	if !strings.Contains(err.Error(), "between 1 and 2 arg") {
 		t.Errorf("expected arg count error, got: %v", err)
 	}
 }
@@ -799,6 +799,168 @@ func TestChannelHistory_JSON(t *testing.T) {
 	}
 	if !strings.Contains(stdout, "test message") {
 		t.Errorf("expected message content in JSON, got: %s", stdout)
+	}
+}
+
+// --- Channel Edit Tests ---
+
+func TestChannelEdit_RequiresArgs(t *testing.T) {
+	_, _, err := executeIntegrationCmd("channel", "edit")
+	if err == nil {
+		t.Fatal("expected error for missing args, got nil")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Errorf("expected arg count error, got: %v", err)
+	}
+}
+
+func TestChannelEdit_NonexistentChannel(t *testing.T) {
+	_, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	_, _, err := executeIntegrationCmd("channel", "edit", "nonexistent", "--desc", "new desc")
+	if err == nil {
+		t.Fatal("expected error for nonexistent channel, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestChannelEdit_NoFlags(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	store := channel.NewStore(wsDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("failed to load store: %v", err)
+	}
+	if _, err := store.Create("edit-test"); err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	_, _, err := executeIntegrationCmd("channel", "edit", "edit-test")
+	if err == nil {
+		t.Fatal("expected error for edit with no flags, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one setting") {
+		t.Errorf("expected 'at least one setting' error, got: %v", err)
+	}
+}
+
+func TestChannelEdit_SetDescription(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	store := channel.NewStore(wsDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("failed to load store: %v", err)
+	}
+	if _, err := store.Create("edit-desc"); err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	stdout, _, err := executeIntegrationCmd("channel", "edit", "edit-desc", "--desc", "New description")
+	if err != nil {
+		t.Fatalf("channel edit error: %v", err)
+	}
+	if !strings.Contains(stdout, "Updated channel") {
+		t.Errorf("expected success message, got: %s", stdout)
+	}
+}
+
+// --- Channel Add with --agent flag ---
+
+func TestChannelAdd_WithAgentFlag(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	store := channel.NewStore(wsDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("failed to load store: %v", err)
+	}
+	if _, err := store.Create("flag-test"); err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	stdout, _, err := executeIntegrationCmd("channel", "add", "flag-test", "--agent", "agent-flag")
+	if err != nil {
+		t.Fatalf("channel add --agent error: %v", err)
+	}
+	if !strings.Contains(stdout, "Added 1") {
+		t.Errorf("expected 'Added 1' in output, got: %s", stdout)
+	}
+}
+
+func TestChannelAdd_NoMember(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	store := channel.NewStore(wsDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("failed to load store: %v", err)
+	}
+	if _, err := store.Create("no-member-test"); err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	_, _, err := executeIntegrationCmd("channel", "add", "no-member-test")
+	if err == nil {
+		t.Fatal("expected error for add with no member, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one member") {
+		t.Errorf("expected 'at least one member' error, got: %v", err)
+	}
+}
+
+// --- Channel History with --last flag ---
+
+func TestChannelHistory_WithLastFlag(t *testing.T) {
+	wsDir, cleanup := setupIntegrationWorkspace(t)
+	defer cleanup()
+
+	store := channel.NewStore(wsDir)
+	if err := store.Load(); err != nil {
+		t.Fatalf("failed to load store: %v", err)
+	}
+	if _, err := store.Create("last-test"); err != nil {
+		t.Fatalf("failed to create channel: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if err := store.AddHistory("last-test", "agent", fmt.Sprintf("message %d", i)); err != nil {
+			t.Fatalf("failed to add history: %v", err)
+		}
+	}
+	if err := store.Save(); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	stdout, _, err := executeIntegrationCmd("channel", "history", "last-test", "--last", "3")
+	if err != nil {
+		t.Fatalf("channel history --last error: %v", err)
+	}
+	// Should show only 3 messages (the last 3)
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	messageLines := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "[") && strings.Contains(line, "agent:") {
+			messageLines++
+		}
+	}
+	if messageLines > 3 {
+		t.Errorf("expected at most 3 message lines with --last 3, got %d", messageLines)
 	}
 }
 

--- a/pkg/channel/service.go
+++ b/pkg/channel/service.go
@@ -1,0 +1,255 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// ChannelDTO is the API representation of a channel.
+type ChannelDTO struct {
+	Name         string    `json:"name"`
+	Description  string    `json:"description,omitempty"`
+	Members      []string  `json:"members"`
+	Type         string    `json:"type"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	MemberCount  int       `json:"member_count"`
+	MessageCount int       `json:"message_count"`
+}
+
+// MessageDTO is the API representation of a channel message.
+type MessageDTO struct {
+	Reactions map[string][]string `json:"reactions,omitempty"`
+	CreatedAt time.Time           `json:"created_at"`
+	Channel   string              `json:"channel"`
+	Sender    string              `json:"sender"`
+	Content   string              `json:"content"`
+	Type      string              `json:"type"`
+	Metadata  string              `json:"metadata,omitempty"`
+	ID        int64               `json:"id"`
+}
+
+// CreateChannelReq is the request to create a channel.
+type CreateChannelReq struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// UpdateChannelReq is the request to update a channel.
+type UpdateChannelReq struct {
+	Description string `json:"description,omitempty"`
+}
+
+// HistoryOpts configures message history retrieval.
+type HistoryOpts struct {
+	Since  *time.Time `json:"since,omitempty"`
+	Agent  string     `json:"agent,omitempty"`
+	Limit  int        `json:"limit,omitempty"`
+	Offset int        `json:"offset,omitempty"`
+}
+
+// ChannelService encapsulates channel business logic, wrapping the Store.
+// It provides the service layer between CLI/API handlers and storage,
+// enforcing validation and returning DTOs.
+type ChannelService struct {
+	store *Store
+}
+
+// NewChannelService creates a ChannelService backed by the given Store.
+func NewChannelService(store *Store) *ChannelService {
+	return &ChannelService{store: store}
+}
+
+// List returns all channels as DTOs.
+func (s *ChannelService) List(_ context.Context) ([]ChannelDTO, error) {
+	channels := s.store.List()
+	dtos := make([]ChannelDTO, 0, len(channels))
+	for _, ch := range channels {
+		dto := channelToDTO(ch)
+		dtos = append(dtos, dto)
+	}
+	return dtos, nil
+}
+
+// Create creates a new channel and returns its DTO.
+func (s *ChannelService) Create(_ context.Context, req CreateChannelReq) (*ChannelDTO, error) {
+	if req.Name == "" {
+		return nil, fmt.Errorf("channel name is required")
+	}
+
+	ch, err := s.store.Create(req.Name)
+	if err != nil {
+		return nil, fmt.Errorf("create channel: %w", err)
+	}
+
+	if req.Description != "" {
+		if err := s.store.SetDescription(req.Name, req.Description); err != nil {
+			return nil, fmt.Errorf("set description: %w", err)
+		}
+		ch.Description = req.Description
+	}
+
+	if err := s.store.Save(); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+
+	dto := channelToDTO(ch)
+	return &dto, nil
+}
+
+// Get returns a single channel detail with members.
+func (s *ChannelService) Get(_ context.Context, name string) (*ChannelDTO, error) {
+	ch, exists := s.store.Get(name)
+	if !exists {
+		return nil, fmt.Errorf("channel %q not found", name)
+	}
+	dto := channelToDTO(ch)
+	return &dto, nil
+}
+
+// Update modifies a channel's settings (description).
+func (s *ChannelService) Update(_ context.Context, name string, req UpdateChannelReq) (*ChannelDTO, error) {
+	ch, exists := s.store.Get(name)
+	if !exists {
+		return nil, fmt.Errorf("channel %q not found", name)
+	}
+
+	if req.Description != "" {
+		if err := s.store.SetDescription(name, req.Description); err != nil {
+			return nil, fmt.Errorf("set description: %w", err)
+		}
+		ch.Description = req.Description
+	}
+
+	if err := s.store.Save(); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+
+	dto := channelToDTO(ch)
+	return &dto, nil
+}
+
+// Delete removes a channel.
+func (s *ChannelService) Delete(_ context.Context, name string) error {
+	if err := s.store.Delete(name); err != nil {
+		return fmt.Errorf("delete channel: %w", err)
+	}
+	return s.store.Save()
+}
+
+// AddMember adds an agent to a channel.
+func (s *ChannelService) AddMember(_ context.Context, ch, agentID string) error {
+	if err := s.store.AddMember(ch, agentID); err != nil {
+		return fmt.Errorf("add member: %w", err)
+	}
+	return s.store.Save()
+}
+
+// RemoveMember removes an agent from a channel.
+func (s *ChannelService) RemoveMember(_ context.Context, ch, agentID string) error {
+	if err := s.store.RemoveMember(ch, agentID); err != nil {
+		return fmt.Errorf("remove member: %w", err)
+	}
+	return s.store.Save()
+}
+
+// Send adds a message to a channel and returns the message DTO.
+func (s *ChannelService) Send(_ context.Context, ch, sender, content string) (*MessageDTO, error) {
+	if err := s.store.AddHistory(ch, sender, content); err != nil {
+		return nil, fmt.Errorf("send message: %w", err)
+	}
+
+	if err := s.store.Save(); err != nil {
+		return nil, fmt.Errorf("save: %w", err)
+	}
+
+	dto := &MessageDTO{
+		Channel:   ch,
+		Sender:    sender,
+		Content:   content,
+		Type:      string(TypeText),
+		CreatedAt: time.Now(),
+	}
+	return dto, nil
+}
+
+// History retrieves filtered message history for a channel.
+func (s *ChannelService) History(_ context.Context, ch string, opts HistoryOpts) ([]MessageDTO, error) {
+	history, err := s.store.GetHistory(ch)
+	if err != nil {
+		return nil, fmt.Errorf("get history: %w", err)
+	}
+
+	// Apply filters
+	filtered := make([]HistoryEntry, 0, len(history))
+	for _, entry := range history {
+		if opts.Since != nil && entry.Time.Before(*opts.Since) {
+			continue
+		}
+		if opts.Agent != "" && entry.Sender != opts.Agent {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+
+	// Apply offset
+	if opts.Offset > 0 {
+		if opts.Offset >= len(filtered) {
+			filtered = nil
+		} else {
+			filtered = filtered[opts.Offset:]
+		}
+	}
+
+	// Apply limit (take last N messages)
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = 50
+	}
+	if len(filtered) > limit {
+		filtered = filtered[len(filtered)-limit:]
+	}
+
+	dtos := make([]MessageDTO, 0, len(filtered))
+	for _, entry := range filtered {
+		dtos = append(dtos, MessageDTO{
+			Channel:   ch,
+			Sender:    entry.Sender,
+			Content:   entry.Message,
+			Type:      string(TypeText),
+			CreatedAt: entry.Time,
+			Reactions: entry.Reactions,
+		})
+	}
+	return dtos, nil
+}
+
+// React toggles an emoji reaction on a message. Returns true if added.
+func (s *ChannelService) React(_ context.Context, ch string, msgID int, emoji, user string) (bool, error) {
+	added, err := s.store.ToggleReaction(ch, msgID, emoji, user)
+	if err != nil {
+		return false, fmt.Errorf("toggle reaction: %w", err)
+	}
+
+	if err := s.store.Save(); err != nil {
+		return false, fmt.Errorf("save: %w", err)
+	}
+
+	return added, nil
+}
+
+// channelToDTO converts a Channel to a ChannelDTO.
+func channelToDTO(ch *Channel) ChannelDTO {
+	members := ch.Members
+	if members == nil {
+		members = []string{}
+	}
+	return ChannelDTO{
+		Name:         ch.Name,
+		Description:  ch.Description,
+		Members:      members,
+		MemberCount:  len(members),
+		MessageCount: len(ch.History),
+	}
+}

--- a/pkg/channel/service_test.go
+++ b/pkg/channel/service_test.go
@@ -1,0 +1,449 @@
+package channel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newTestService(t *testing.T) *ChannelService {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".bc"), 0750); err != nil {
+		t.Fatal(err)
+	}
+	store := NewStore(dir)
+	return NewChannelService(store)
+}
+
+func TestServiceCreate(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		req     CreateChannelReq
+		wantErr bool
+	}{
+		{
+			name:    "valid channel",
+			req:     CreateChannelReq{Name: "eng", Description: "Engineering"},
+			wantErr: false,
+		},
+		{
+			name:    "without description",
+			req:     CreateChannelReq{Name: "ops"},
+			wantErr: false,
+		},
+		{
+			name:    "empty name",
+			req:     CreateChannelReq{Name: ""},
+			wantErr: true,
+		},
+		{
+			name:    "duplicate name",
+			req:     CreateChannelReq{Name: "eng"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dto, err := svc.Create(ctx, tt.req)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if dto.Name != tt.req.Name {
+				t.Errorf("got name %q, want %q", dto.Name, tt.req.Name)
+			}
+			if dto.Description != tt.req.Description {
+				t.Errorf("got desc %q, want %q", dto.Description, tt.req.Description)
+			}
+			if dto.MemberCount != 0 {
+				t.Errorf("got member count %d, want 0", dto.MemberCount)
+			}
+		})
+	}
+}
+
+func TestServiceList(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	// Empty list
+	dtos, err := svc.List(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dtos) != 0 {
+		t.Errorf("got %d channels, want 0", len(dtos))
+	}
+
+	// Create some channels
+	_, err = svc.Create(ctx, CreateChannelReq{Name: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = svc.Create(ctx, CreateChannelReq{Name: "beta"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dtos, err = svc.List(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(dtos) != 2 {
+		t.Fatalf("got %d channels, want 2", len(dtos))
+	}
+	if dtos[0].Name != "alpha" {
+		t.Errorf("got name %q, want %q", dtos[0].Name, "alpha")
+	}
+	if dtos[1].Name != "beta" {
+		t.Errorf("got name %q, want %q", dtos[1].Name, "beta")
+	}
+}
+
+func TestServiceGet(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng", Description: "Engineering"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dto, err := svc.Get(ctx, "eng")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dto.Name != "eng" {
+		t.Errorf("got name %q, want %q", dto.Name, "eng")
+	}
+	if dto.Description != "Engineering" {
+		t.Errorf("got desc %q, want %q", dto.Description, "Engineering")
+	}
+
+	// Not found
+	_, err = svc.Get(ctx, "nonexistent")
+	if err == nil {
+		t.Error("expected error for nonexistent channel")
+	}
+}
+
+func TestServiceUpdate(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dto, err := svc.Update(ctx, "eng", UpdateChannelReq{Description: "Updated desc"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dto.Description != "Updated desc" {
+		t.Errorf("got desc %q, want %q", dto.Description, "Updated desc")
+	}
+
+	// Verify persistence
+	dto, err = svc.Get(ctx, "eng")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dto.Description != "Updated desc" {
+		t.Errorf("got desc %q, want %q", dto.Description, "Updated desc")
+	}
+
+	// Update nonexistent
+	_, err = svc.Update(ctx, "nope", UpdateChannelReq{Description: "x"})
+	if err == nil {
+		t.Error("expected error for nonexistent channel")
+	}
+}
+
+func TestServiceDelete(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.Delete(ctx, "eng"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify deleted
+	_, err = svc.Get(ctx, "eng")
+	if err == nil {
+		t.Error("expected error after deletion")
+	}
+
+	// Delete nonexistent
+	if err := svc.Delete(ctx, "nope"); err == nil {
+		t.Error("expected error for nonexistent channel")
+	}
+}
+
+func TestServiceMembers(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add members
+	if err := svc.AddMember(ctx, "eng", "agent-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := svc.AddMember(ctx, "eng", "agent-2"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify
+	dto, err := svc.Get(ctx, "eng")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dto.MemberCount != 2 {
+		t.Errorf("got member count %d, want 2", dto.MemberCount)
+	}
+
+	// Remove member
+	if err := svc.RemoveMember(ctx, "eng", "agent-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dto, err = svc.Get(ctx, "eng")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dto.MemberCount != 1 {
+		t.Errorf("got member count %d, want 1", dto.MemberCount)
+	}
+
+	// Add to nonexistent channel
+	if err := svc.AddMember(ctx, "nope", "agent-1"); err == nil {
+		t.Error("expected error for nonexistent channel")
+	}
+
+	// Remove nonexistent member
+	if err := svc.RemoveMember(ctx, "eng", "ghost"); err == nil {
+		t.Error("expected error for nonexistent member")
+	}
+}
+
+func TestServiceSend(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dto, err := svc.Send(ctx, "eng", "agent-1", "hello world")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dto.Channel != "eng" {
+		t.Errorf("got channel %q, want %q", dto.Channel, "eng")
+	}
+	if dto.Sender != "agent-1" {
+		t.Errorf("got sender %q, want %q", dto.Sender, "agent-1")
+	}
+	if dto.Content != "hello world" {
+		t.Errorf("got content %q, want %q", dto.Content, "hello world")
+	}
+
+	// Send to nonexistent
+	_, err = svc.Send(ctx, "nope", "agent-1", "msg")
+	if err == nil {
+		t.Error("expected error for nonexistent channel")
+	}
+}
+
+func TestServiceHistory(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Send messages
+	for i := 0; i < 10; i++ {
+		sender := "agent-1"
+		if i%2 == 0 {
+			sender = "agent-2"
+		}
+		_, err := svc.Send(ctx, "eng", sender, fmt.Sprintf("msg-%d", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name      string
+		opts      HistoryOpts
+		wantCount int
+	}{
+		{
+			name:      "default limit",
+			opts:      HistoryOpts{},
+			wantCount: 10,
+		},
+		{
+			name:      "with limit",
+			opts:      HistoryOpts{Limit: 3},
+			wantCount: 3,
+		},
+		{
+			name:      "filter by agent",
+			opts:      HistoryOpts{Agent: "agent-1"},
+			wantCount: 5,
+		},
+		{
+			name:      "filter by agent-2",
+			opts:      HistoryOpts{Agent: "agent-2"},
+			wantCount: 5,
+		},
+		{
+			name:      "with offset",
+			opts:      HistoryOpts{Offset: 8, Limit: 50},
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dtos, err := svc.History(ctx, "eng", tt.opts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(dtos) != tt.wantCount {
+				t.Errorf("got %d messages, want %d", len(dtos), tt.wantCount)
+			}
+		})
+	}
+
+	// History with since filter
+	since := time.Now().Add(-1 * time.Second)
+	dtos, err := svc.History(ctx, "eng", HistoryOpts{Since: &since})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All messages were just sent, so all should match
+	if len(dtos) != 10 {
+		t.Errorf("got %d messages with since filter, want 10", len(dtos))
+	}
+
+	// Future since should return nothing
+	future := time.Now().Add(1 * time.Hour)
+	dtos, err = svc.History(ctx, "eng", HistoryOpts{Since: &future})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dtos) != 0 {
+		t.Errorf("got %d messages with future since, want 0", len(dtos))
+	}
+
+	// Nonexistent channel
+	_, err = svc.History(ctx, "nope", HistoryOpts{})
+	if err == nil {
+		t.Error("expected error for nonexistent channel")
+	}
+}
+
+func TestServiceReact(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = svc.Send(ctx, "eng", "agent-1", "test message")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add reaction
+	added, err := svc.React(ctx, "eng", 0, "thumbsup", "agent-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !added {
+		t.Error("expected reaction to be added")
+	}
+
+	// Toggle off
+	added, err = svc.React(ctx, "eng", 0, "thumbsup", "agent-2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if added {
+		t.Error("expected reaction to be removed on toggle")
+	}
+
+	// Invalid message index
+	_, err = svc.React(ctx, "eng", 999, "thumbsup", "agent-2")
+	if err == nil {
+		t.Error("expected error for invalid message index")
+	}
+}
+
+func TestServiceChannelToDTO(t *testing.T) {
+	ch := &Channel{
+		Name:        "test",
+		Description: "Test channel",
+		Members:     []string{"a", "b", "c"},
+		History: []HistoryEntry{
+			{Time: time.Now(), Sender: "a", Message: "hello"},
+			{Time: time.Now(), Sender: "b", Message: "world"},
+		},
+	}
+
+	dto := channelToDTO(ch)
+	if dto.Name != "test" {
+		t.Errorf("got name %q, want %q", dto.Name, "test")
+	}
+	if dto.MemberCount != 3 {
+		t.Errorf("got member count %d, want 3", dto.MemberCount)
+	}
+	if dto.MessageCount != 2 {
+		t.Errorf("got message count %d, want 2", dto.MessageCount)
+	}
+}
+
+func TestServiceChannelToDTONilMembers(t *testing.T) {
+	ch := &Channel{
+		Name:    "test",
+		Members: nil,
+	}
+
+	dto := channelToDTO(ch)
+	if dto.Members == nil {
+		t.Error("expected non-nil members slice")
+	}
+	if len(dto.Members) != 0 {
+		t.Errorf("got %d members, want 0", len(dto.Members))
+	}
+}


### PR DESCRIPTION
## Summary

Implements the service layer and CLI enhancements from #1919 (bc channel Command).

- **ChannelService** (`pkg/channel/service.go`): Service layer wrapping `Store` with DTO types (`ChannelDTO`, `MessageDTO`, `CreateChannelReq`, `UpdateChannelReq`, `HistoryOpts`). Methods: `List`, `Create`, `Get`, `Update`, `Delete`, `AddMember`, `RemoveMember`, `Send`, `History`, `React`.
- **`bc channel edit`**: New command to edit channel description/settings (`--desc` flag)
- **`ch` alias**: `bc ch` is now a shorthand for `bc channel`
- **`--agent` flag**: `bc channel add NAME --agent A` / `bc channel remove NAME --agent A`
- **`--last` flag**: `bc channel history NAME --last N` as alias for `--limit`
- **Comprehensive tests**: 11 new service tests + 7 new CLI tests

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Service tests pass: `go test -run TestService ./pkg/channel/...`
- [x] CLI tests pass: `go test -run "TestChannelEdit|TestChannelAdd_WithAgentFlag|TestChannelAdd_NoMember|TestChannelHistory_WithLastFlag" ./internal/cmd/...`
- [x] Pre-existing channel tests still pass (except SQLite-dependent tests that require CGO)
- [ ] Full `make check` in CI (requires CGO for SQLite tests)

Closes #1919

🤖 Generated with [Claude Code](https://claude.com/claude-code)