### PR TITLE
fix: agent UX — terminal rendering, auto-confirm prompts, attach fix

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -5,11 +5,18 @@ FROM ubuntu:24.04
 
 ENV GOVERSION=1.24.1
 ENV PATH=/usr/local/go/bin:/root/go/bin:/home/agent/go/bin:$PATH
+ENV TERM=xterm-256color
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+ENV COLORTERM=truecolor
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         git curl ca-certificates openssh-client gh tmux \
-        gcc libc6-dev make sqlite3 jq unzip && \
+        gcc libc6-dev make sqlite3 jq unzip \
+        locales ncurses-term && \
+    sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Go (arch-aware)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -910,19 +910,37 @@ func (m *Manager) SpawnAgentWithOptions(opts SpawnOptions) (*Agent, error) {
 
 	// Send bootstrap prompt asynchronously (like respawn path at line 656)
 	// to avoid holding m.mu during the blocking sleep.
-	if len(promptParts) > 0 {
+	{
 		bootstrapName := name
 		bootstrapWorkspace := wsPath
 		bootstrapParts := make([]string, len(promptParts))
 		copy(bootstrapParts, promptParts)
-		bootstrapDelay := m.getBootstrapDelay()
-
 		go func() {
-			time.Sleep(bootstrapDelay)
-			prompt := strings.Join(bootstrapParts, "\n\n---\n\n")
-			prompt += fmt.Sprintf("\n\n---\n\nWorkspace: %s\nAgent ID: %s\n", bootstrapWorkspace, bootstrapName)
-			if err := m.runtimeForAgent(name).SendKeys(context.TODO(), bootstrapName, prompt); err != nil {
-				log.Warn("failed to send bootstrap prompt", "agent", bootstrapName, "error", err)
+			// Wait for the agent's TUI to fully initialize (worktree creation,
+			// trust dialog render). Docker + tmux + claude startup takes ~10s.
+			time.Sleep(10 * time.Second)
+
+			// Auto-confirm interactive prompts (workspace trust dialog, theme picker)
+			// by sending Enter. Claude pre-selects "Yes, I trust" and "Dark mode"
+			// so Enter confirms the defaults. Send a few times with delays to catch
+			// any multi-step onboarding prompts.
+			rt := m.runtimeForAgent(bootstrapName)
+			for range 3 {
+				if err := rt.SendKeys(context.TODO(), bootstrapName, ""); err != nil {
+					log.Debug("pre-bootstrap Enter failed", "agent", bootstrapName, "error", err)
+					break // tmux not ready yet, stop trying
+				}
+				time.Sleep(3 * time.Second)
+			}
+
+			// Then send the actual bootstrap prompt if we have role instructions
+			if len(bootstrapParts) > 0 {
+				time.Sleep(3 * time.Second)
+				prompt := strings.Join(bootstrapParts, "\n\n---\n\n")
+				prompt += fmt.Sprintf("\n\n---\n\nWorkspace: %s\nAgent ID: %s\n", bootstrapWorkspace, bootstrapName)
+				if err := rt.SendKeys(context.TODO(), bootstrapName, prompt); err != nil {
+					log.Warn("failed to send bootstrap prompt", "agent", bootstrapName, "error", err)
+				}
 			}
 		}()
 	}

--- a/pkg/container/auth.go
+++ b/pkg/container/auth.go
@@ -32,7 +32,10 @@ func AgentAuthTokenFile(workspaceDir, agentName string) string {
 
 // EnsureAuthDir creates the per-agent auth directories and seeds credentials
 // from the host on first use so agents start pre-authenticated.
+// The workspaceName is filepath.Base(workspaceDir) — used to pre-create
+// Claude's project trust directory for the agent's worktree path.
 func EnsureAuthDir(workspaceDir, agentName string) (string, error) {
+	workspaceName := filepath.Base(workspaceDir)
 	dir := AgentAuthDir(workspaceDir, agentName)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", fmt.Errorf("failed to create agent auth dir: %w", err)
@@ -43,6 +46,9 @@ func EnsureAuthDir(workspaceDir, agentName string) (string, error) {
 	if _, err := os.Stat(tokenFile); os.IsNotExist(err) {
 		seedAuthFromHost(filepath.Dir(dir)) // pass auth/ parent so seeding writes to correct locations
 	}
+
+	// Pre-create project trust directories so the workspace trust prompt is skipped.
+	ensureProjectTrust(dir, workspaceName, agentName)
 
 	return dir, nil
 }
@@ -81,6 +87,13 @@ func seedAuthFromHost(parentDir string) {
 		if writeErr := os.WriteFile(dst, data, 0600); writeErr != nil {
 			log.Debug("failed to seed auth file", "file", name, "error", writeErr)
 		}
+	}
+
+	// Write default settings.json if not seeded from host — skips theme picker
+	// and permission prompts so agents start directly without interaction.
+	settingsPath := filepath.Join(agentClaudeDir, "settings.json")
+	if _, err := os.Stat(settingsPath); os.IsNotExist(err) {
+		writeDefaultSettings(settingsPath)
 	}
 
 	log.Debug("seeded agent auth from host credentials", "auth_dir", parentDir)
@@ -142,6 +155,50 @@ func LoginIfNeeded(ctx context.Context, workspaceDir, agentName string) error {
 
 	fmt.Printf("Agent %q needs authentication. Opening browser for login...\n", agentName)
 	return Login(ctx, workspaceDir, agentName)
+}
+
+// writeDefaultSettings creates a settings.json that pre-configures Claude Code
+// so agents skip interactive prompts and start working immediately.
+func writeDefaultSettings(path string) {
+	settings := map[string]any{
+		// UI — skip theme picker, use dark mode
+		"theme": "dark",
+		// Permissions — agents run with --dangerously-skip-permissions,
+		// this suppresses the confirmation prompt for that mode
+		"skipDangerousModePermissionPrompt": true,
+		// Auto-update — disabled inside containers (image controls version)
+		"autoUpdaterStatus": "disabled",
+		// Verbose tool output — helps with debugging agent actions
+		"verbose": false,
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return
+	}
+	if writeErr := os.WriteFile(path, data, 0600); writeErr != nil {
+		log.Debug("failed to write default settings", "error", writeErr)
+	}
+}
+
+// ensureProjectTrust pre-creates Claude's per-project directory so the workspace
+// trust prompt is skipped on agent start. Claude encodes directory paths by
+// replacing / with - (e.g., /workspace/.claude/worktrees/bc-myproj-eng-01
+// becomes -workspace--claude-worktrees-bc-myproj-eng-01).
+func ensureProjectTrust(claudeDir, workspaceName, agentName string) {
+	projectsDir := filepath.Join(claudeDir, "projects")
+
+	// The agent's worktree inside Docker is at:
+	//   /workspace/.claude/worktrees/bc-<workspaceName>-<agentName>
+	// Claude encodes this as:
+	//   -workspace--claude-worktrees-bc-<workspaceName>-<agentName>
+	worktreeName := "bc-" + workspaceName + "-" + agentName
+	encodedPath := "-workspace--claude-worktrees-" + worktreeName
+
+	// Also trust /workspace itself (root of the mounted workspace)
+	for _, p := range []string{"-workspace", encodedPath} {
+		dir := filepath.Join(projectsDir, p)
+		_ = os.MkdirAll(dir, 0700) //nolint:errcheck // best-effort
+	}
 }
 
 // authEnv returns environment variables with HOME set to the auth parent dir,

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -161,11 +161,11 @@ func (b *Backend) HasSession(ctx context.Context, name string) bool {
 		return false
 	}
 
-	// Also verify the tmux session inside the container is alive.
-	// `claude --tmux` creates a session named "workspace0".
-	// If it's dead (zombie), treat the whole session as gone.
+	// Also verify at least one tmux session is alive inside the container.
+	// Claude --tmux creates sessions with varying names (workspace0, workspace_worktree-*).
+	// If all tmux sessions are dead (zombie), treat the container as gone.
 	//nolint:gosec // trusted
-	tmuxCheck := exec.CommandContext(ctx, "docker", "exec", cn, "tmux", "has-session", "-t", "workspace0")
+	tmuxCheck := exec.CommandContext(ctx, "docker", "exec", cn, "tmux", "list-sessions")
 	return tmuxCheck.Run() == nil
 }
 


### PR DESCRIPTION
## Summary

Fixes three UX issues with Docker-based agents that made them effectively unusable without manual intervention on every start.

### 1. Broken terminal rendering
Claude Code's TUI rendered garbled text because the container had `TERM=dumb` and no UTF-8 locale.

**Fix:** Added `TERM=xterm-256color`, `LANG=en_US.UTF-8`, `COLORTERM=truecolor`, plus `locales` and `ncurses-term` packages to the base image.

### 2. Interactive prompts blocking agents
Every agent start required manually confirming the workspace trust dialog and theme picker. Agents would sit at these prompts indefinitely.

**Fix:** Two-part approach:
- Pre-populate `settings.json` with `theme: dark`, `skipDangerousModePermissionPrompt: true`, `autoUpdaterStatus: disabled` — eliminates theme picker
- Bootstrap sends 3x Enter with delays after 10s to auto-confirm the workspace trust dialog (Claude pre-selects "Yes, I trust this folder")
- Pre-create Claude's project trust directories for the agent's worktree path

### 3. `bc agent attach` always said "not running"
`HasSession` was hardcoded to check for a tmux session named `workspace0`, but Claude creates sessions named `workspace_worktree-bc-<workspace>-<agentname>`. So it always returned false.

**Fix:** Changed `HasSession` to use `tmux list-sessions` (checks if ANY tmux session exists, not a specific name).

## Test Plan
- [x] `make build` passes
- [x] Agent starts without theme picker prompt
- [x] Workspace trust dialog auto-confirmed by bootstrap
- [x] `bc agent attach <name>` works (verified — gets past "not running" check)
- [x] `bc agent peek <name>` shows agent at `❯` prompt after bootstrap

Relates to #1960

🤖 Generated with [Claude Code](https://claude.com/claude-code)