### PR TITLE
fix: document tool immutability in bc agent start help

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -161,9 +161,14 @@ This resurrects the agent's tmux session and memory.
 The agent must have been previously created and stopped.
 By default, resumes the previous session if available.
 
+The agent's tool (claude, gemini, cursor, etc.) is fixed at creation time
+and cannot be changed on restart. Use --runtime to switch infrastructure
+backends (tmux vs docker) without changing the agent's identity.
+
 Examples:
-  bc agent start eng-01          # Start stopped agent (resumes session)
-  bc agent start eng-01 --fresh  # Force new session`,
+  bc agent start eng-01                    # Start stopped agent (resumes session)
+  bc agent start eng-01 --fresh            # Force new session
+  bc agent start eng-01 --runtime docker   # Override runtime backend`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentStart,
 }


### PR DESCRIPTION
## Summary

Clarifies in `bc agent start` help text that the agent tool is fixed at creation time and cannot be changed on restart. The `--runtime` flag (tmux vs docker backend) remains available.

No functional change — the behavior was already correct:
- `agentStartCmd` has no `--tool` flag
- `SpawnAgentWithOptions` uses `a.Tool` (stored value) on restart  
- `bc agent show` already displays the tool field

## Test plan

- [ ] `bc agent start --help` shows the tool immutability note
- [ ] `bc agent start eng-01 --tool claude` errors with "unknown flag"

Closes #1960