### PR TITLE
feat: implement bc mcp server configuration (#1925)

### DIFF
--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -241,9 +241,17 @@ func runMCPShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if jsonOutput {
+		// Mask env values in JSON output to avoid leaking secrets
+		masked := *cfg
+		if len(masked.Env) > 0 {
+			masked.Env = make(map[string]string, len(cfg.Env))
+			for k := range cfg.Env {
+				masked.Env[k] = "***"
+			}
+		}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
-		return enc.Encode(cfg)
+		return enc.Encode(&masked)
 	}
 
 	enabled := "yes"

--- a/pkg/mcp/store.go
+++ b/pkg/mcp/store.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/rpuneet/bc/pkg/db"
@@ -106,6 +107,9 @@ func (s *Store) Add(cfg *ServerConfig) error {
 		cfg.Name, cfg.Transport, cfg.Command, string(argsJSON), cfg.URL, string(envJSON), cfg.Enabled,
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "UNIQUE constraint") {
+			return fmt.Errorf("mcp server %q already exists (use 'bc mcp remove %s' first)", cfg.Name, cfg.Name)
+		}
 		return fmt.Errorf("add mcp server %q: %w", cfg.Name, err)
 	}
 	return nil

--- a/pkg/mcp/store_test.go
+++ b/pkg/mcp/store_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -186,6 +187,9 @@ func TestAddDuplicate(t *testing.T) {
 	err := s.Add(cfg)
 	if err == nil {
 		t.Fatal("expected error for duplicate add")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **`pkg/mcp/store.go`** — SQLite-backed store for MCP server configurations using `pkg/db` patterns. Schema: `mcp_servers` table with name (PK), transport (stdio/sse), command, args (JSON), url, env (JSON), enabled, created_at. Full CRUD + enable/disable operations with input validation.
- **`internal/cmd/mcp.go`** — Cobra CLI commands following existing `channel.go` patterns: `bc mcp add`, `bc mcp list`, `bc mcp show`, `bc mcp remove`, `bc mcp enable`, `bc mcp disable`. Supports `--json` output, `--env KEY=VALUE` (repeatable), `--args` (comma-separated), `--transport stdio|sse`.

## Files Changed

| File | Description |
|------|-------------|
| `pkg/mcp/store.go` | New SQLite store for MCP server configs (248 lines) |
| `internal/cmd/mcp.go` | New CLI commands for MCP management (262 lines) |

## Test Plan

- [ ] `make build` passes
- [ ] `go vet ./...` passes clean
- [ ] `bc mcp add github --command npx --args "@modelcontextprotocol/server-github" --env "GITHUB_TOKEN=tok_123"` creates config
- [ ] `bc mcp list` shows the server with transport, command, enabled status
- [ ] `bc mcp show github` displays full details (env vars masked)
- [ ] `bc mcp disable github` / `bc mcp enable github` toggles enabled state
- [ ] `bc mcp remove github` deletes the config
- [ ] `bc mcp add remote --transport sse --url "https://api.example.com/mcp"` works for SSE transport
- [ ] `bc mcp list --json` outputs structured JSON
- [ ] Validation: stdio requires --command, sse requires --url, invalid names rejected

Closes #1925

🤖 Generated with [Claude Code](https://claude.com/claude-code)