### PR TITLE
feat: agent team structure, role definitions, and bc ws up

### DIFF
--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/agent"
+	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/ui"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
@@ -204,6 +206,21 @@ Examples:
 	RunE: runWorkspaceSwitch,
 }
 
+// workspaceUpCmd starts all agents defined in the roster config.
+var workspaceUpCmd = &cobra.Command{
+	Use:   "up",
+	Short: "Start all roster agents",
+	Long: `Start all agents defined in [roster] of .bc/config.toml.
+
+Agents that are already running are skipped. Missing role files are
+created from built-in defaults automatically.
+
+Examples:
+  bc workspace up          # Start roster agents
+  bc ws up                 # Short alias`,
+	RunE: runWorkspaceUp,
+}
+
 func init() {
 	// List command flags
 	workspaceListCmd.Flags().StringSlice("scan", nil, "Additional paths to scan")
@@ -230,6 +247,7 @@ func init() {
 	// Add subcommands
 	workspaceCmd.AddCommand(workspaceInfoCmd)
 	workspaceCmd.AddCommand(workspaceStatusCmd)
+	workspaceCmd.AddCommand(workspaceUpCmd)
 	workspaceCmd.AddCommand(workspaceConfigCmd)
 	workspaceCmd.AddCommand(workspaceMigrateCmd)
 	workspaceCmd.AddCommand(workspaceListCmd)
@@ -240,6 +258,86 @@ func init() {
 
 	// Register with root
 	rootCmd.AddCommand(workspaceCmd)
+}
+
+func runWorkspaceUp(cmd *cobra.Command, _ []string) error {
+	ws, err := requireWorkspace()
+	if err != nil {
+		return err
+	}
+
+	roster := ws.Config.Roster.Agents
+	if len(roster) == 0 {
+		fmt.Println("No agents in roster. Add agents under [roster] in .bc/config.toml.")
+		fmt.Println()
+		fmt.Println("Example:")
+		fmt.Println("  [[roster.agents]]")
+		fmt.Println("  name = \"go-reviewer\"")
+		fmt.Println("  role = \"go-reviewer\"")
+		fmt.Println("  tool = \"claude\"")
+		return nil
+	}
+
+	// Ensure built-in role files exist before spawning agents.
+	if _, err := ws.RoleManager.EnsureDefaultRoles(); err != nil {
+		return fmt.Errorf("failed to ensure default roles: %w", err)
+	}
+
+	mgr := newAgentManager(ws)
+	if loadErr := mgr.LoadState(); loadErr != nil {
+		log.Warn("failed to load agent state", "error", loadErr)
+	}
+
+	var started, skipped, failed int
+	for _, entry := range roster {
+		existing := mgr.GetAgent(entry.Name)
+		if existing != nil && existing.State != agent.StateStopped && existing.State != agent.StateError {
+			fmt.Printf("  %-20s %s\n", entry.Name, ui.DimText("already running"))
+			skipped++
+			continue
+		}
+
+		// Validate role file exists
+		roleFile := filepath.Join(ws.RolesDir(), entry.Role+".md")
+		if _, statErr := os.Stat(roleFile); statErr != nil {
+			fmt.Printf("  %-20s %s\n", entry.Name, ui.RedText("✗ role not found: "+entry.Role))
+			failed++
+			continue
+		}
+
+		tool := entry.Tool
+		if tool == "" {
+			tool = ws.DefaultProvider()
+		}
+
+		role := agent.Role(strings.ToLower(entry.Role))
+		fmt.Printf("  %-20s starting...", entry.Name)
+
+		_, spawnErr := mgr.SpawnAgentWithOptions(agent.SpawnOptions{
+			Name:      entry.Name,
+			Role:      role,
+			Workspace: ws.RootDir,
+			Tool:      tool,
+			Runtime:   entry.Runtime,
+		})
+		if spawnErr != nil {
+			fmt.Printf(" %s\n", ui.RedText("✗"))
+			log.Warn("failed to start agent", "name", entry.Name, "error", spawnErr)
+			failed++
+			continue
+		}
+
+		fmt.Printf(" %s\n", ui.GreenText("✓"))
+		started++
+	}
+
+	fmt.Println()
+	fmt.Printf("Started %d, skipped %d", started, skipped)
+	if failed > 0 {
+		fmt.Printf(", failed %d", failed)
+	}
+	fmt.Println()
+	return nil
 }
 
 func runWorkspaceList(cmd *cobra.Command, args []string) error {

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -28,6 +28,20 @@ type Config struct {
 	Logs        LogsConfig        `toml:"logs"`
 	Runtime     RuntimeConfig     `toml:"runtime"`
 	Performance PerformanceConfig `toml:"performance"`
+	Roster      RosterConfig      `toml:"roster"`
+}
+
+// RosterConfig defines the team roster: agents that bc ws up will start.
+type RosterConfig struct {
+	Agents []RosterEntry `toml:"agents"`
+}
+
+// RosterEntry describes a single agent in the workspace roster.
+type RosterEntry struct {
+	Name    string `toml:"name"`    // Agent name
+	Role    string `toml:"role"`    // Role file name (e.g. "feature-dev")
+	Tool    string `toml:"tool"`    // Provider tool (e.g. "claude")
+	Runtime string `toml:"runtime"` // Runtime backend override (optional)
 }
 
 // RuntimeConfig configures the agent session backend.

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -1660,3 +1660,82 @@ func TestListServicesNewConfig(t *testing.T) {
 		t.Errorf("expected 2 services, got %d", len(services))
 	}
 }
+
+func TestRosterConfig_ParsesTOML(t *testing.T) {
+	tomlData := `
+[workspace]
+name = "bc"
+version = 2
+
+[providers]
+default = "claude"
+
+[[roster.agents]]
+name = "go-reviewer"
+role = "go-reviewer"
+tool = "claude"
+
+[[roster.agents]]
+name = "agent-core"
+role = "feature-dev"
+tool = "claude"
+
+[[roster.agents]]
+name = "pm"
+role = "product-manager"
+tool = "claude"
+`
+	cfg, err := ParseConfig([]byte(tomlData))
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+
+	if len(cfg.Roster.Agents) != 3 {
+		t.Fatalf("expected 3 roster agents, got %d", len(cfg.Roster.Agents))
+	}
+
+	agent := cfg.Roster.Agents[0]
+	if agent.Name != "go-reviewer" {
+		t.Errorf("Agents[0].Name = %q, want go-reviewer", agent.Name)
+	}
+	if agent.Role != "go-reviewer" {
+		t.Errorf("Agents[0].Role = %q, want go-reviewer", agent.Role)
+	}
+	if agent.Tool != "claude" {
+		t.Errorf("Agents[0].Tool = %q, want claude", agent.Tool)
+	}
+}
+
+func TestRosterConfig_EmptyByDefault(t *testing.T) {
+	cfg := DefaultConfig("test")
+	if len(cfg.Roster.Agents) != 0 {
+		t.Errorf("expected empty roster by default, got %d agents", len(cfg.Roster.Agents))
+	}
+}
+
+func TestRosterConfig_SaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := DefaultConfig("myws")
+	cfg.Roster.Agents = []RosterEntry{
+		{Name: "dev1", Role: "feature-dev", Tool: "claude"},
+		{Name: "reviewer", Role: "go-reviewer", Tool: "claude"},
+	}
+
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if len(loaded.Roster.Agents) != 2 {
+		t.Fatalf("loaded %d roster agents, want 2", len(loaded.Roster.Agents))
+	}
+	if loaded.Roster.Agents[0].Name != "dev1" {
+		t.Errorf("Agents[0].Name = %q, want dev1", loaded.Roster.Agents[0].Name)
+	}
+}

--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -96,6 +96,179 @@ You are the root agent for this bc workspace.
 4. Monitor workspace health
 `
 
+// DefaultRoles contains the built-in role definitions for the bc agent team.
+// These are written to .bc/roles/ if the files don't already exist.
+var DefaultRoles = map[string]string{
+	"go-reviewer": `---
+name: go-reviewer
+description: Go code quality reviewer
+level: 0
+capabilities:
+  - review_work
+mcp_servers:
+  - github
+---
+
+# Go Reviewer
+
+You are a Go code quality reviewer for this bc workspace.
+
+## Responsibilities
+- Review Go CLI pull requests for correctness, security, and test coverage
+- Enforce Go idioms, linting standards, and project conventions
+- Check for security issues (OWASP, injection, credentials exposure)
+- Ensure error handling is explicit and complete
+- Validate that tests cover edge cases and use table-driven patterns
+
+## Guidelines
+1. Use the github MCP to fetch PR diffs and leave inline review comments
+2. Block merges on security issues or broken tests; suggest rather than block on style
+3. Reference .golangci.yml rules when flagging lint violations
+4. Be concise — one clear comment beats three vague ones
+`,
+	"web-reviewer": `---
+name: web-reviewer
+description: Web/TypeScript UI reviewer
+level: 0
+capabilities:
+  - review_work
+mcp_servers:
+  - github
+---
+
+# Web Reviewer
+
+You are a React/TypeScript code quality reviewer for this bc workspace.
+
+## Responsibilities
+- Review TUI (Ink/React) pull requests for correctness and component patterns
+- Enforce TypeScript type safety and accessibility best practices
+- Check for performance issues in React hooks and re-render paths
+- Validate test coverage for exported helpers and type interfaces
+
+## Guidelines
+1. Use the github MCP to fetch PR diffs and leave inline review comments
+2. Note: hooks cannot be tested without a DOM in Ink — test exported helpers instead
+3. Block on broken builds or type errors; suggest on style
+4. Keep feedback actionable — link to specific lines
+`,
+	"feature-dev": `---
+name: feature-dev
+description: Feature developer — implements tasks in isolated worktrees
+level: 1
+capabilities:
+  - implement_tasks
+  - run_tests
+  - fix_bugs
+mcp_servers:
+  - github
+  - filesystem
+---
+
+# Feature Developer
+
+You are a feature developer for the bc project. You work in an isolated git worktree
+and commit your changes to a feature branch for review.
+
+## Responsibilities
+- Implement assigned issues and feature tasks
+- Write tests for all new code (table-driven where applicable)
+- Fix bugs and regressions in your area of ownership
+- Create pull requests targeting main for review
+
+## Workflow
+1. Read the assigned issue thoroughly before writing any code
+2. Create a feature branch: feat/<issue>-<slug> from main
+3. Implement the feature with tests; run make check before pushing
+4. Open a PR and request review from the appropriate reviewer agent
+
+## Guidelines
+- Follow CLAUDE.md conventions: gofmt -s, goimports, short receivers
+- Never ignore errors — use explicit handling or //nolint:errcheck with justification
+- Prefer editing existing files over creating new ones
+- Commit messages: conventional commits format (feat:, fix:, docs:, etc.)
+`,
+	"designer": `---
+name: designer
+description: Design system and Web UI specialist
+level: 1
+capabilities:
+  - implement_tasks
+mcp_servers:
+  - github
+---
+
+# Designer
+
+You are the design system and Web UI specialist for the bc project.
+
+## Responsibilities
+- Maintain the design token system (colors, spacing, typography)
+- Build and refine React/Ink TUI components
+- Create component specs and accessibility guidelines
+- Implement CSS/Tailwind changes for the web dashboard
+
+## Guidelines
+1. Consistency over novelty — extend the existing design system
+2. Every new component needs a usage example and props documentation
+3. Accessibility is non-negotiable: keyboard navigation, color contrast, screen readers
+4. Test components in both dark and light themes
+`,
+	"product-manager": `---
+name: product-manager
+description: Product coordination and epic management
+level: 0
+capabilities:
+  - create_epics
+  - assign_work
+  - review_work
+---
+
+# Product Manager
+
+You are the product manager for the bc project, responsible for coordinating
+the agent team and ensuring the product vision is reflected in delivered work.
+
+## Responsibilities
+- Break down high-level goals into actionable epics and issues
+- Assign work to the appropriate agent based on role and current load
+- Review completed work against acceptance criteria before merge
+- Maintain the product roadmap and prioritization
+
+## Guidelines
+1. Use GitHub issues to track all work — no verbal assignments
+2. Each epic must have clear acceptance criteria before agents start work
+3. Communicate blockers to the root agent immediately
+4. Keep the team focused: one epic per engineer at a time
+`,
+	"docs": `---
+name: docs
+description: Documentation writer
+level: 1
+capabilities:
+  - implement_tasks
+mcp_servers:
+  - github
+---
+
+# Documentation Writer
+
+You are the documentation specialist for the bc project.
+
+## Responsibilities
+- Write and maintain README, CONTRIBUTING, and API reference docs
+- Keep CLAUDE.md up-to-date with architecture and convention changes
+- Build and maintain the mkdocs documentation site
+- Document CLI commands, flags, and usage examples
+
+## Guidelines
+1. Docs live alongside the code — update docs in the same PR as the feature
+2. Use concrete examples — show, don't just tell
+3. Keep the CLI help text in sync with the markdown docs
+4. Plain language over jargon; assume the reader is new to bc
+`,
+}
+
 // NewRoleManager creates a new role manager for the given workspace state directory.
 func NewRoleManager(stateDir string) *RoleManager {
 	return &RoleManager{
@@ -112,6 +285,29 @@ func (rm *RoleManager) RolesDir() string {
 // EnsureRolesDir creates the roles directory if it doesn't exist.
 func (rm *RoleManager) EnsureRolesDir() error {
 	return os.MkdirAll(rm.rolesDir, 0750)
+}
+
+// EnsureDefaultRoles creates built-in role files that don't already exist.
+// Returns the names of any roles that were created.
+func (rm *RoleManager) EnsureDefaultRoles() ([]string, error) {
+	if err := rm.EnsureRolesDir(); err != nil {
+		return nil, err
+	}
+
+	var created []string
+	for name, content := range DefaultRoles {
+		rolePath := filepath.Join(rm.rolesDir, name+".md")
+		if _, err := os.Stat(rolePath); err == nil {
+			continue // already exists
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to check %s.md: %w", name, err)
+		}
+		if err := os.WriteFile(rolePath, []byte(content), 0600); err != nil {
+			return nil, fmt.Errorf("failed to create %s.md: %w", name, err)
+		}
+		created = append(created, name)
+	}
+	return created, nil
 }
 
 // EnsureDefaultRoot creates the default root.md if it doesn't exist.

--- a/pkg/workspace/roles_test.go
+++ b/pkg/workspace/roles_test.go
@@ -1030,3 +1030,95 @@ You are a feature developer agent.
 		}
 	}
 }
+
+func TestEnsureDefaultRoles_CreatesFiles(t *testing.T) {
+	dir := t.TempDir()
+	rm := NewRoleManager(dir)
+
+	created, err := rm.EnsureDefaultRoles()
+	if err != nil {
+		t.Fatalf("EnsureDefaultRoles: %v", err)
+	}
+
+	if len(created) != len(DefaultRoles) {
+		t.Errorf("created %d roles, want %d", len(created), len(DefaultRoles))
+	}
+
+	for name := range DefaultRoles {
+		rolePath := filepath.Join(rm.RolesDir(), name+".md")
+		if _, statErr := os.Stat(rolePath); statErr != nil {
+			t.Errorf("expected role file %s.md to exist", name)
+		}
+	}
+}
+
+func TestEnsureDefaultRoles_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	rm := NewRoleManager(dir)
+
+	_, err := rm.EnsureDefaultRoles()
+	if err != nil {
+		t.Fatalf("first EnsureDefaultRoles: %v", err)
+	}
+
+	created, err := rm.EnsureDefaultRoles()
+	if err != nil {
+		t.Fatalf("second EnsureDefaultRoles: %v", err)
+	}
+	if len(created) != 0 {
+		t.Errorf("second call created %v, want none", created)
+	}
+}
+
+func TestEnsureDefaultRoles_ParsesCleanly(t *testing.T) {
+	dir := t.TempDir()
+	rm := NewRoleManager(dir)
+
+	if _, err := rm.EnsureDefaultRoles(); err != nil {
+		t.Fatalf("EnsureDefaultRoles: %v", err)
+	}
+
+	for name := range DefaultRoles {
+		role, err := rm.LoadRole(name)
+		if err != nil {
+			t.Errorf("LoadRole(%q): %v", name, err)
+			continue
+		}
+		if role.Metadata.Name != name {
+			t.Errorf("role %q: Name = %q, want %q", name, role.Metadata.Name, name)
+		}
+		if len(role.Metadata.Capabilities) == 0 {
+			t.Errorf("role %q: no capabilities defined", name)
+		}
+	}
+}
+
+func TestDefaultRoles_HaveValidLevels(t *testing.T) {
+	managerRoles := map[string]bool{
+		"go-reviewer":     true,
+		"web-reviewer":    true,
+		"product-manager": true,
+	}
+	engineerRoles := map[string]bool{
+		"feature-dev": true,
+		"designer":    true,
+		"docs":        true,
+	}
+
+	for name, content := range DefaultRoles {
+		role, err := ParseRoleFile([]byte(content))
+		if err != nil {
+			t.Fatalf("ParseRoleFile(%q): %v", name, err)
+		}
+		switch {
+		case managerRoles[name]:
+			if role.Metadata.Level != 0 {
+				t.Errorf("role %q: Level = %d, want 0 (manager)", name, role.Metadata.Level)
+			}
+		case engineerRoles[name]:
+			if role.Metadata.Level != 1 {
+				t.Errorf("role %q: Level = %d, want 1 (engineer)", name, role.Metadata.Level)
+			}
+		}
+	}
+}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -81,6 +81,9 @@ func Init(rootDir string) (*Workspace, error) {
 	if _, err := rm.EnsureDefaultRoot(); err != nil {
 		return nil, fmt.Errorf("failed to create default role: %w", err)
 	}
+	if _, err := rm.EnsureDefaultRoles(); err != nil {
+		log.Warn("failed to create default roles", "error", err)
+	}
 
 	return &Workspace{
 		RootDir:     absRoot,


### PR DESCRIPTION
## Summary

- Adds 6 built-in role definitions (`go-reviewer`, `web-reviewer`, `feature-dev`, `designer`, `product-manager`, `docs`) as Go constants in `pkg/workspace/roles.go` with correct hierarchy levels, capabilities, and MCP server associations
- Adds `RoleManager.EnsureDefaultRoles()` — writes missing role files to `.bc/roles/` on workspace init; idempotent
- Extends `Config` with `RosterConfig` + `RosterEntry` for `[[roster.agents]]` in `.bc/config.toml` (name, role, tool, runtime)
- Implements `bc workspace up` (alias: `bc ws up`) — iterates the roster, ensures default roles exist, and spawns any agents not already running

Closes #1930

## Role Hierarchy

| Role | Level | Capabilities |
|------|-------|-------------|
| go-reviewer | 0 (manager) | review_work |
| web-reviewer | 0 (manager) | review_work |
| product-manager | 0 (manager) | create_epics, assign_work, review_work |
| feature-dev | 1 (engineer) | implement_tasks, run_tests, fix_bugs |
| designer | 1 (engineer) | implement_tasks |
| docs | 1 (engineer) | implement_tasks |

## Roster Config Example

```toml
[[roster.agents]]
name = "go-reviewer"
role = "go-reviewer"
tool = "claude"

[[roster.agents]]
name = "agent-ops"
role = "feature-dev"
tool = "claude"
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./pkg/workspace/...` — all pass including new tests for `EnsureDefaultRoles`, roster TOML parsing, save/load roundtrip, default role levels
- [x] `go test -race ./pkg/daemon/... ./pkg/server/...` — pass (no regression)
- [x] `bc ws up` with empty roster prints guidance message
- [x] `bc ws up` with roster creates/skips agents correctly
- [x] Role files written by `EnsureDefaultRoles` parse cleanly with correct metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)