### PR TITLE
feat: agent session resume — capture ID, --resume flag, session history

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -242,6 +243,24 @@ Examples:
 
 // agentHealthCmd is defined in agent_health.go (issue #1648)
 
+// agentSessionsCmd lists session history for an agent
+var agentSessionsCmd = &cobra.Command{
+	Use:   "sessions <agent>",
+	Short: "List session history for an agent",
+	Long: `Show stored session IDs for an agent.
+
+The current session ID (if captured) is listed first, followed by archived
+session IDs from previous runs.
+
+Examples:
+  bc agent sessions eng-01       # List session IDs
+  bc agent sessions eng-01 --json`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAgentSessions,
+}
+
+var agentSessionsJSON bool
+
 // agentBroadcastCmd sends a message to all running agents
 var agentBroadcastCmd = &cobra.Command{
 	Use:   "broadcast <message>",
@@ -295,6 +314,7 @@ var (
 	agentCreateRuntime string
 	agentStartRuntime  string
 	agentStartFresh    bool
+	agentStartResume   string // explicit session ID to resume
 	agentListRole      string
 	agentListStatus    string
 	agentListJSON      bool
@@ -355,6 +375,10 @@ func init() {
 	// Start flags
 	agentStartCmd.Flags().StringVar(&agentStartRuntime, "runtime", "", "Runtime backend override: tmux or docker")
 	agentStartCmd.Flags().BoolVar(&agentStartFresh, "fresh", false, "Force new session (ignore saved session)")
+	agentStartCmd.Flags().StringVar(&agentStartResume, "resume", "", "Resume a specific session by ID (e.g. --resume cc78cadf-89ce-4820-ab6e-950afd2b6838)")
+
+	// Sessions flags
+	agentSessionsCmd.Flags().BoolVar(&agentSessionsJSON, "json", false, "Output as JSON")
 
 	// Add shell completion for agent name arguments
 	agentAttachCmd.ValidArgsFunction = CompleteAgentNames
@@ -365,6 +389,7 @@ func init() {
 	agentSendCmd.ValidArgsFunction = CompleteAgentNames
 	agentDeleteCmd.ValidArgsFunction = CompleteAgentNames
 	agentRenameCmd.ValidArgsFunction = CompleteAgentNames
+	agentSessionsCmd.ValidArgsFunction = CompleteAgentNames
 
 	// Add subcommands
 	agentCmd.AddCommand(agentCreateCmd)
@@ -378,6 +403,7 @@ func init() {
 	agentCmd.AddCommand(agentDeleteCmd)
 	agentCmd.AddCommand(agentRenameCmd)
 	agentCmd.AddCommand(agentHealthCmd)
+	agentCmd.AddCommand(agentSessionsCmd)
 	agentCmd.AddCommand(agentBroadcastCmd)
 	agentCmd.AddCommand(agentSendRoleCmd)
 	agentCmd.AddCommand(agentSendPatternCmd)
@@ -796,9 +822,16 @@ func runAgentStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("agent %q is already running (state: %s). Stop it first with: bc agent stop %s", agentName, a.State, agentName)
 	}
 
-	if agentStartFresh {
+	if agentStartFresh && agentStartResume != "" {
+		return fmt.Errorf("--fresh and --resume are mutually exclusive")
+	}
+
+	switch {
+	case agentStartFresh:
 		fmt.Printf("Starting %s (%s) with fresh session... ", agentName, a.Role)
-	} else {
+	case agentStartResume != "":
+		fmt.Printf("Starting %s (%s) resuming session %s... ", agentName, a.Role, agentStartResume)
+	default:
 		fmt.Printf("Starting %s (%s)... ", agentName, a.Role)
 	}
 	// SpawnAgentWithOptions will detect the stopped state and resurrect it
@@ -811,6 +844,7 @@ func runAgentStart(cmd *cobra.Command, args []string) error {
 		EnvFile:   a.EnvFile,
 		Runtime:   agentStartRuntime,
 		Fresh:     agentStartFresh,
+		SessionID: agentStartResume,
 	})
 	if spawnErr != nil {
 		fmt.Println("✗")
@@ -1695,4 +1729,95 @@ Usage:
 		// Run login
 		return container.LoginIfNeeded(cmd.Context(), ws.RootDir, agentName)
 	},
+}
+
+func runAgentSessions(cmd *cobra.Command, args []string) error {
+	agentName := args[0]
+
+	ws, err := getWorkspace()
+	if err != nil {
+		return errNotInWorkspace(err)
+	}
+
+	mgr := newAgentManager(ws)
+	if loadErr := mgr.LoadState(); loadErr != nil {
+		log.Warn("failed to load agent state", "error", loadErr)
+	}
+
+	a := mgr.GetAgent(agentName)
+	if a == nil {
+		return fmt.Errorf("agent %q not found", agentName)
+	}
+
+	type sessionEntry struct {
+		ID        string    `json:"id"`
+		Timestamp time.Time `json:"timestamp,omitempty"`
+		Current   bool      `json:"current,omitempty"`
+	}
+
+	var entries []sessionEntry
+
+	// Current stored session ID from state DB
+	if a.SessionID != "" {
+		entries = append(entries, sessionEntry{ID: a.SessionID, Current: true})
+	}
+
+	// Session history files from .bc/agents/<name>/session_history/
+	histDir := filepath.Join(ws.StateDir(), "agents", agentName, "session_history")
+	files, readErr := os.ReadDir(histDir)
+	if readErr == nil {
+		// Sort descending (newest first)
+		sort.Slice(files, func(i, j int) bool {
+			return files[i].Name() > files[j].Name()
+		})
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			data, readFileErr := os.ReadFile(filepath.Join(histDir, f.Name())) //nolint:gosec // trusted path
+			if readFileErr != nil {
+				continue
+			}
+			id := strings.TrimSpace(string(data))
+			if id == "" || id == a.SessionID {
+				continue // skip duplicates
+			}
+			// Parse timestamp from filename (2006-01-02T15:04:05.txt)
+			name := strings.TrimSuffix(f.Name(), ".txt")
+			ts, parseErr := time.Parse("2006-01-02T15:04:05", name)
+			entry := sessionEntry{ID: id}
+			if parseErr == nil {
+				entry.Timestamp = ts
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	if agentSessionsJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(entries)
+	}
+
+	if len(entries) == 0 {
+		fmt.Printf("No session IDs stored for agent %s.\n", agentName)
+		fmt.Printf("Session IDs are captured automatically when the agent stops.\n")
+		return nil
+	}
+
+	fmt.Printf("Sessions for %s:\n\n", agentName)
+	for _, e := range entries {
+		current := ""
+		if e.Current {
+			current = " " + ui.GreenText("(current)")
+		}
+		ts := ""
+		if !e.Timestamp.IsZero() {
+			ts = "  " + ui.DimText(e.Timestamp.Format("2006-01-02 15:04:05"))
+		}
+		fmt.Printf("  %s%s%s\n", e.ID, current, ts)
+	}
+	fmt.Printf("\nResume a session: bc agent start %s --resume <id>\n", agentName)
+
+	return nil
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -504,7 +504,8 @@ func defaultAgentCmd() (string, string) {
 }
 
 // getAgentCommand looks up the command for a tool from the manager's provider registry.
-func (m *Manager) getAgentCommand(toolName, agentName string, resume bool) (string, bool) {
+// SessionID takes priority over the resume flag when non-empty.
+func (m *Manager) getAgentCommand(toolName, agentName string, resume bool, sessionID string) (string, bool) {
 	if m.providerRegistry != nil {
 		if p, ok := m.providerRegistry.Get(toolName); ok {
 			wsName := filepath.Base(m.workspacePath)
@@ -512,6 +513,7 @@ func (m *Manager) getAgentCommand(toolName, agentName string, resume bool) (stri
 				AgentName:     agentName,
 				WorkspaceName: wsName,
 				Resume:        resume,
+				SessionID:     sessionID,
 			}), true
 		}
 	}
@@ -610,6 +612,7 @@ type SpawnOptions struct {
 	EnvFile   string
 	Runtime   string // override runtime backend ("tmux" or "docker"); empty uses manager default
 	Fresh     bool   // Force new session (ignore session_id)
+	SessionID string // Explicit session ID to resume (overrides stored session_id)
 }
 
 // SpawnAgent creates and starts a new agent.
@@ -692,9 +695,16 @@ func (m *Manager) SpawnAgentWithOptions(opts SpawnOptions) (*Agent, error) {
 		// Existing agent = `bc agent start` = resume previous session.
 		// The auth dir persists across restarts so --continue finds the prior conversation.
 		// --fresh overrides this and forces a new session.
+		// Session ID priority: explicit --resume flag > stored session_id > --continue.
 		resume := !opts.Fresh
+		sessionID := existing.SessionID
 		if opts.Fresh {
 			existing.SessionID = ""
+			sessionID = ""
+		}
+		if opts.SessionID != "" {
+			sessionID = opts.SessionID
+			existing.SessionID = sessionID
 		}
 		toolName := existing.Tool
 		if toolName == "" {
@@ -702,7 +712,7 @@ func (m *Manager) SpawnAgentWithOptions(opts SpawnOptions) (*Agent, error) {
 		}
 		agentCmd := m.agentCmd
 		if toolName != "" {
-			if cmd, ok := m.getAgentCommand(toolName, name, resume); ok {
+			if cmd, ok := m.getAgentCommand(toolName, name, resume, sessionID); ok {
 				agentCmd = cmd
 			}
 		}
@@ -778,16 +788,16 @@ func (m *Manager) SpawnAgentWithOptions(opts SpawnOptions) (*Agent, error) {
 		}
 	}
 
-	// Determine the command to use (fresh create — no resume)
+	// Determine the command to use (fresh create — no resume, no session ID)
 	agentCmd := m.agentCmd
 	if tool != "" {
-		if cmd, ok := m.getAgentCommand(tool, name, false); ok {
+		if cmd, ok := m.getAgentCommand(tool, name, false, ""); ok {
 			agentCmd = cmd
 		} else {
 			return nil, fmt.Errorf("unknown tool %q, available tools: %v", tool, m.listAvailableTools())
 		}
 	} else if m.defaultTool != "" {
-		if cmd, ok := m.getAgentCommand(m.defaultTool, name, false); ok {
+		if cmd, ok := m.getAgentCommand(m.defaultTool, name, false, ""); ok {
 			agentCmd = cmd
 		}
 	}
@@ -1130,6 +1140,89 @@ func (m *Manager) removeFromParent(name string) {
 	parent.UpdatedAt = time.Now()
 }
 
+// captureSessionIDLocked reads the agent's pane output and extracts the provider
+// session ID (e.g. Claude's "claude --resume <uuid>" line).
+// Must be called while holding m.mu (any variant).
+// Returns "" if the tool does not support resume or no session ID is found.
+func (m *Manager) captureSessionIDLocked(name string) string {
+	ag, exists := m.agents[name]
+	if !exists {
+		return ""
+	}
+
+	toolName := ag.Tool
+	if toolName == "" {
+		toolName = m.defaultTool
+	}
+	if m.providerRegistry == nil {
+		return ""
+	}
+	p, ok := m.providerRegistry.Get(toolName)
+	if !ok {
+		return ""
+	}
+	sr, ok := p.(provider.SessionResumer)
+	if !ok || !sr.SupportsResume() {
+		return ""
+	}
+
+	// Capture pane output without acquiring the lock (already held).
+	// Read from log file first; fall back to runtime capture.
+	var output string
+	if ag.LogFile != "" {
+		data, err := os.ReadFile(ag.LogFile) //nolint:gosec // trusted path
+		if err == nil {
+			output = string(data)
+		}
+	}
+	if output == "" {
+		var captureErr error
+		output, captureErr = m.runtimeForAgent(name).Capture(context.TODO(), name, 100)
+		if captureErr != nil {
+			log.Debug("failed to capture pane for session ID", "agent", name, "error", captureErr)
+			return ""
+		}
+	}
+
+	return sr.ParseSessionID(output)
+}
+
+// writeSessionIDFile persists the session ID to a plain-text file and archives
+// it in the session history directory alongside a timestamp.
+// Permissions are 0600 (session IDs may grant conversation access).
+func writeSessionIDFile(stateDir, agentName, sessionID string) {
+	agentDir := filepath.Join(stateDir, "agents", agentName)
+	if err := os.MkdirAll(agentDir, 0750); err != nil {
+		log.Warn("failed to create agent dir for session_id", "error", err)
+		return
+	}
+
+	sessionFile := filepath.Join(agentDir, "session_id")
+	if err := os.WriteFile(sessionFile, []byte(sessionID+"\n"), 0600); err != nil {
+		log.Warn("failed to write session_id file", "agent", agentName, "error", err)
+		return
+	}
+
+	// Archive to session_history/ with a timestamp name.
+	histDir := filepath.Join(agentDir, "session_history")
+	if err := os.MkdirAll(histDir, 0750); err != nil {
+		return
+	}
+	stamp := time.Now().UTC().Format("2006-01-02T15:04:05")
+	histFile := filepath.Join(histDir, stamp+".txt")
+	_ = os.WriteFile(histFile, []byte(sessionID+"\n"), 0600) //nolint:errcheck // best-effort history
+}
+
+// readSessionIDFile reads the persisted session ID for an agent, returning "" if absent.
+func readSessionIDFile(stateDir, agentName string) string {
+	path := filepath.Join(stateDir, "agents", agentName, "session_id")
+	data, err := os.ReadFile(path) //nolint:gosec // trusted path
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 // StopAgent stops an agent.
 func (m *Manager) StopAgent(name string) error {
 	m.mu.Lock()
@@ -1141,6 +1234,13 @@ func (m *Manager) StopAgent(name string) error {
 	if !exists {
 		log.Warn("agent not found", "name", name)
 		return fmt.Errorf("agent %s not found", name)
+	}
+
+	// Capture session ID from output before killing the session.
+	if sessionID := m.captureSessionIDLocked(name); sessionID != "" {
+		agent.SessionID = sessionID
+		writeSessionIDFile(m.stateDir, name, sessionID)
+		log.Debug("captured session ID on stop", "agent", name, "session_id", sessionID)
 	}
 
 	// Kill tmux session (ignore error - session might already be dead)

--- a/pkg/provider/claude.go
+++ b/pkg/provider/claude.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"regexp"
 	"strings"
 )
 
@@ -52,6 +53,7 @@ func (p *ClaudeProvider) InstallHint() string {
 // BuildCommand returns the full command for a given runtime context.
 // Uses -w bc-<workspace>-<agent> for unique worktree names across workspaces
 // to avoid branch collisions with other Claude Code sessions.
+// Resume priority: SessionID (--resume <id>) > Resume flag (--continue).
 func (p *ClaudeProvider) BuildCommand(opts CommandOpts) string {
 	cmd := p.command
 	if opts.AgentName != "" {
@@ -61,7 +63,12 @@ func (p *ClaudeProvider) BuildCommand(opts CommandOpts) string {
 		}
 		cmd = "claude -w " + worktreeName + " " + strings.TrimPrefix(cmd, "claude")
 	}
-	if opts.Resume {
+	switch {
+	case opts.SessionID != "":
+		// Explicit session ID — resume that exact conversation.
+		cmd += " --resume " + opts.SessionID
+	case opts.Resume:
+		// Generic resume — pick up the most recent conversation.
 		cmd += " --continue"
 	}
 	return cmd
@@ -128,7 +135,26 @@ func (p *ClaudeProvider) DetectState(output string) State {
 	return StateUnknown
 }
 
-// Ensure ClaudeProvider implements Provider, ContainerCustomizer, and SessionCustomizer interfaces.
+// claudeResumePattern matches Claude's "Resume this session with: claude --resume <uuid>" output.
+// The UUID format is standard 8-4-4-4-12 hex.
+var claudeResumePattern = regexp.MustCompile(`claude --resume ([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})`)
+
+// SupportsResume reports that Claude Code supports resuming sessions by ID.
+func (p *ClaudeProvider) SupportsResume() bool { return true }
+
+// ParseSessionID scans tool output for Claude's resume hint and returns the session UUID.
+// Returns "" if no session ID is found.
+// Claude prints "Resume this session with:\nclaude --resume <uuid>" on graceful exit.
+func (p *ClaudeProvider) ParseSessionID(output string) string {
+	m := claudeResumePattern.FindStringSubmatch(output)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// Ensure ClaudeProvider implements all declared interfaces.
 var _ Provider = (*ClaudeProvider)(nil)
 var _ ContainerCustomizer = (*ClaudeProvider)(nil)
 var _ SessionCustomizer = (*ClaudeProvider)(nil)
+var _ SessionResumer = (*ClaudeProvider)(nil)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -47,6 +47,7 @@ type CommandOpts struct {
 	WorkspaceName string // workspace name for unique worktree naming
 	Docker        bool   // running inside Docker container
 	Resume        bool   // resume previous session (claude uses --continue)
+	SessionID     string // explicit session ID for resume (overrides Resume flag if set)
 }
 
 // ContainerCustomizer is optionally implemented by providers needing
@@ -64,6 +65,16 @@ type ContainerCustomizer interface {
 type SessionCustomizer interface {
 	// AdjustSessionCommand modifies the command for headless session execution.
 	AdjustSessionCommand(command string) string
+}
+
+// SessionResumer is optionally implemented by providers that support resuming
+// a specific named session by ID (e.g. claude --resume <id>).
+type SessionResumer interface {
+	// SupportsResume reports whether this provider can resume a specific session by ID.
+	SupportsResume() bool
+	// ParseSessionID extracts a session ID from tool output, returning "" if none found.
+	// Claude prints "claude --resume <uuid>" on graceful exit.
+	ParseSessionID(output string) string
 }
 
 // State represents the detected state of a provider's agent.

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -895,3 +895,115 @@ func TestCursorDetectState(t *testing.T) {
 		})
 	}
 }
+
+func TestClaudeSessionResumer(t *testing.T) {
+	p := NewClaudeProvider()
+
+	// Verify interface implementation
+	sr, ok := interface{}(p).(SessionResumer)
+	if !ok {
+		t.Fatal("ClaudeProvider must implement SessionResumer")
+	}
+	if !sr.SupportsResume() {
+		t.Error("ClaudeProvider.SupportsResume() must return true")
+	}
+}
+
+func TestClaudeParseSessionID(t *testing.T) {
+	p := NewClaudeProvider()
+
+	tests := []struct {
+		name   string
+		output string
+		wantID string
+	}{
+		{
+			name: "standard resume line",
+			output: `Some output here...
+Resume this session with:
+claude --resume cc78cadf-89ce-4820-ab6e-950afd2b6838`,
+			wantID: "cc78cadf-89ce-4820-ab6e-950afd2b6838",
+		},
+		{
+			name: "resume line in middle of output",
+			output: `❯ 
+claude --resume aa11bb22-cc33-dd44-ee55-ff6677889900
+Some more output`,
+			wantID: "aa11bb22-cc33-dd44-ee55-ff6677889900",
+		},
+		{
+			name:   "no session ID present",
+			output: "Normal claude output without resume line",
+			wantID: "",
+		},
+		{
+			name:   "empty output",
+			output: "",
+			wantID: "",
+		},
+		{
+			name:   "malformed UUID",
+			output: "claude --resume not-a-valid-uuid-here",
+			wantID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.ParseSessionID(tt.output)
+			if got != tt.wantID {
+				t.Errorf("ParseSessionID() = %q, want %q", got, tt.wantID)
+			}
+		})
+	}
+}
+
+func TestClaudeBuildCommandSessionID(t *testing.T) {
+	p := NewClaudeProvider()
+
+	tests := []struct {
+		name string
+		opts CommandOpts
+		want string
+	}{
+		{
+			name: "session ID takes priority over resume flag",
+			opts: CommandOpts{
+				AgentName: "eng-01",
+				SessionID: "cc78cadf-89ce-4820-ab6e-950afd2b6838",
+				Resume:    true,
+			},
+			want: "claude -w bc-eng-01  --dangerously-skip-permissions --resume cc78cadf-89ce-4820-ab6e-950afd2b6838",
+		},
+		{
+			name: "session ID alone",
+			opts: CommandOpts{
+				AgentName: "eng-01",
+				SessionID: "cc78cadf-89ce-4820-ab6e-950afd2b6838",
+			},
+			want: "claude -w bc-eng-01  --dangerously-skip-permissions --resume cc78cadf-89ce-4820-ab6e-950afd2b6838",
+		},
+		{
+			name: "resume flag without session ID uses --continue",
+			opts: CommandOpts{
+				AgentName: "eng-01",
+				Resume:    true,
+			},
+			want: "claude -w bc-eng-01  --dangerously-skip-permissions --continue",
+		},
+		{
+			name: "no resume flags — fresh session",
+			opts: CommandOpts{AgentName: "eng-01"},
+			want: "claude -w bc-eng-01  --dangerously-skip-permissions",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.BuildCommand(tt.opts)
+			if got != tt.want {
+				t.Errorf("BuildCommand() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implements #1939 (Phase 1 & 2). Builds on #1965 which added `--continue` on restart.

### What's new

**Session ID capture on stop**
- `StopAgent` calls `captureSessionIDLocked()` before killing the tmux session
- Reads from the agent's log file (or falls back to `runtime.Capture`)
- Parses Claude's `"claude --resume <uuid>"` exit line via provider interface
- Stores UUID in `Agent.SessionID` (state DB) and `.bc/agents/<name>/session_id` file
- Archives to `.bc/agents/<name>/session_history/<timestamp>.txt` for history

**Provider interface — `SessionResumer`**
- New optional interface: `SupportsResume() bool`, `ParseSessionID(output string) string`
- `ClaudeProvider` implements it: regex `claude --resume <uuid>` (standard 8-4-4-4-12 UUID)
- `CommandOpts.SessionID string` — when set, `BuildCommand` uses `--resume <id>` instead of `--continue`
- Priority: `SessionID` (explicit) > `Resume` flag (`--continue`) > fresh

**CLI**
- `bc agent start --resume <session-id>` — explicit session ID override; mutually exclusive with `--fresh`
- `bc agent sessions <name>` — list current + archived session IDs with timestamps; `--json` flag

**`bc agent show`** already displayed `session_id` — now populated automatically on stop.

### Flow

```
bc agent stop eng-01
  → captures tmux output
  → finds "claude --resume cc78cadf-..."
  → stores in state DB + session_id file + session_history/

bc agent start eng-01
  → reads stored SessionID
  → passes --resume cc78cadf-... to claude (instead of --continue)

bc agent start eng-01 --fresh
  → clears stored SessionID, starts new conversation

bc agent start eng-01 --resume <other-id>
  → overrides stored ID, resumes that specific session

bc agent sessions eng-01
  cc78cadf-89ce-4820-ab6e-950afd2b6838  (current)
  aa11bb22-cc33-dd44-ee55-ff6677889900  2026-03-17 10:23:00
```

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `TestClaudeSessionResumer` — interface assertion
- [x] `TestClaudeParseSessionID` — UUID extraction from Claude output (5 cases)
- [x] `TestClaudeBuildCommandSessionID` — SessionID priority over Resume flag (4 cases)
- [x] `go test -race ./pkg/agent/...` passes

Closes #1939 (Phase 1 & 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)