### PR TITLE
feat: CLI thin client (#1982)

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/log"
 )
 
@@ -31,43 +32,28 @@ func init() {
 func runDown(cmd *cobra.Command, args []string) error {
 	log.Debug("down command started", "force", downForce)
 
-	// Find workspace
 	ws, err := getWorkspace()
 	if err != nil {
 		return errNotInWorkspace(err)
 	}
 
-	fmt.Printf("Stopping bc agents in %s\n\n", ws.RootDir)
-
-	// Create agent manager and load state
-	mgr := newAgentManager(ws)
-	if err := mgr.LoadState(); err != nil {
-		log.Warn("failed to load agent state", "error", err)
+	c := client.New("")
+	if pingErr := c.Ping(cmd.Context()); pingErr != nil {
+		return fmt.Errorf("bcd is not running — start it with 'bc up' first\n(%w)", pingErr)
 	}
 
-	agents := mgr.ListAgents()
-	log.Debug("agents to stop", "count", len(agents))
-	if len(agents) == 0 {
+	fmt.Printf("Stopping bc agents in %s\n\n", ws.RootDir)
+
+	stopped, stopErr := c.Workspaces.Down(cmd.Context())
+	if stopErr != nil {
+		return fmt.Errorf("failed to stop agents: %w", stopErr)
+	}
+
+	if stopped == 0 {
 		fmt.Println("No agents running")
 		return nil
 	}
 
-	// Stop all agents
-	for _, a := range agents {
-		log.Debug("stopping agent", "name", a.Name, "state", a.State)
-		fmt.Printf("Stopping %s... ", a.Name)
-		if err := mgr.StopAgent(a.Name); err != nil {
-			log.Debug("agent stop failed", "name", a.Name, "error", err)
-			fmt.Println("✗")
-			fmt.Printf("  Warning: %v\n", err)
-		} else {
-			log.Debug("agent stopped", "name", a.Name)
-			fmt.Println("✓")
-		}
-	}
-
-	fmt.Println()
-	fmt.Println("All agents stopped")
-
+	fmt.Printf("Stopped %d agent(s)\n", stopped)
 	return nil
 }

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/channel"
+	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/ui"
@@ -233,6 +235,16 @@ func logEvent(ws *workspace.Workspace, event events.Event) {
 // errorAgentNotRunning returns an error message for commands that require BC_AGENT_ID.
 func errorAgentNotRunning(commandUsage string) error {
 	return fmt.Errorf("this command can only be run by agents in the bc system (use: bc agent send <agent-name> %q)", commandUsage)
+}
+
+// newDaemonClient creates a client connected to the bcd daemon.
+// Returns an error if the daemon is not running.
+func newDaemonClient(ctx context.Context) (*client.Client, error) {
+	c := client.New("")
+	if err := c.Ping(ctx); err != nil {
+		return nil, fmt.Errorf("bcd is not running — start it with 'bcd' or 'bc up' first\n(%w)", err)
+	}
+	return c, nil
 }
 
 // errNotInWorkspace returns an actionable error for commands that require a bc workspace.

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -3,8 +3,14 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
 
 	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/names"
 )
 
 // EventPublisher is the interface for publishing agent lifecycle events.
@@ -47,6 +53,21 @@ type CreateOptions struct {
 type StartOptions struct {
 	Runtime string // Runtime backend override
 	Fresh   bool   // Force new session (ignore session_id)
+}
+
+// SessionEntry represents a single session history record.
+type SessionEntry struct {
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	ID        string    `json:"id"`
+	Current   bool      `json:"current,omitempty"`
+}
+
+// SendResult holds the result of a broadcast/role/pattern send operation.
+type SendResult struct {
+	Matched []string `json:"matched"`
+	Sent    int      `json:"sent"`
+	Skipped int      `json:"skipped"`
+	Failed  int      `json:"failed"`
 }
 
 // AgentService provides the application-level API for agent management.
@@ -269,4 +290,136 @@ func (s *AgentService) publishEvent(eventType string, data map[string]any) {
 	if s.events != nil {
 		s.events.Publish(eventType, data)
 	}
+}
+
+// StopAll stops all running agents. Returns count of agents stopped.
+func (s *AgentService) StopAll(ctx context.Context) (int, error) {
+	agents := s.manager.ListAgents()
+	count := 0
+	for _, a := range agents {
+		if a.State != StateStopped && a.State != StateError {
+			count++
+		}
+	}
+	if err := s.manager.StopAll(); err != nil {
+		return 0, err
+	}
+	s.publishEvent("agents.stopped_all", map[string]any{"count": count})
+	return count, nil
+}
+
+// Rename renames an agent.
+func (s *AgentService) Rename(ctx context.Context, oldName, newName string) error {
+	if err := s.manager.RenameAgent(oldName, newName); err != nil {
+		return err
+	}
+	s.publishEvent("agent.renamed", map[string]any{
+		"old_name": oldName,
+		"new_name": newName,
+	})
+	return nil
+}
+
+// Sessions returns session history for an agent.
+func (s *AgentService) Sessions(ctx context.Context, name string) ([]SessionEntry, error) {
+	a := s.manager.GetAgent(name)
+	if a == nil {
+		return nil, fmt.Errorf("agent %q not found", name)
+	}
+
+	var entries []SessionEntry
+
+	if a.SessionID != "" {
+		entries = append(entries, SessionEntry{ID: a.SessionID, Current: true})
+	}
+
+	histDir := filepath.Join(s.manager.stateDir, "agents", name, "session_history")
+	files, err := os.ReadDir(histDir)
+	if err == nil {
+		sort.Slice(files, func(i, j int) bool {
+			return files[i].Name() > files[j].Name()
+		})
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			data, readErr := os.ReadFile(filepath.Join(histDir, f.Name())) //nolint:gosec // trusted path
+			if readErr != nil {
+				continue
+			}
+			id := strings.TrimSpace(string(data))
+			if id == "" || id == a.SessionID {
+				continue
+			}
+			fname := strings.TrimSuffix(f.Name(), ".txt")
+			ts, parseErr := time.Parse("2006-01-02T15:04:05", fname)
+			entry := SessionEntry{ID: id}
+			if parseErr == nil {
+				entry.Timestamp = ts
+			}
+			entries = append(entries, entry)
+		}
+	}
+
+	return entries, nil
+}
+
+// SendToRole sends a message to all running agents with the given role.
+func (s *AgentService) SendToRole(ctx context.Context, role, message string) (SendResult, error) {
+	agents := s.manager.ListAgents()
+	result := SendResult{}
+	for _, a := range agents {
+		if string(a.Role) != role {
+			continue
+		}
+		result.Matched = append(result.Matched, a.Name)
+		if a.State == StateStopped || a.State == StateError {
+			result.Skipped++
+			continue
+		}
+		if err := s.manager.SendToAgent(a.Name, message); err != nil {
+			log.Warn("send-role: failed to send", "agent", a.Name, "error", err)
+			result.Failed++
+			continue
+		}
+		result.Sent++
+	}
+	return result, nil
+}
+
+// SendToPattern sends a message to all agents whose names match the given glob pattern.
+func (s *AgentService) SendToPattern(ctx context.Context, pattern, message string) (SendResult, error) {
+	agents := s.manager.ListAgents()
+	result := SendResult{}
+	for _, a := range agents {
+		match, matchErr := filepath.Match(pattern, a.Name)
+		if matchErr != nil {
+			return result, fmt.Errorf("invalid pattern %q: %w", pattern, matchErr)
+		}
+		if !match {
+			continue
+		}
+		result.Matched = append(result.Matched, a.Name)
+		if a.State == StateStopped || a.State == StateError {
+			result.Skipped++
+			continue
+		}
+		if err := s.manager.SendToAgent(a.Name, message); err != nil {
+			log.Warn("send-pattern: failed to send", "agent", a.Name, "error", err)
+			result.Failed++
+			continue
+		}
+		result.Sent++
+	}
+	return result, nil
+}
+
+// GenerateName generates a unique agent name not already in use.
+func (s *AgentService) GenerateName(ctx context.Context) (string, error) {
+	agents := s.manager.ListAgents()
+	existing := make([]string, 0, len(agents))
+	for _, a := range agents {
+		existing = append(existing, a.Name)
+	}
+	return names.GenerateUniqueFromList(existing, 20)
 }

--- a/pkg/client/agents.go
+++ b/pkg/client/agents.go
@@ -1,6 +1,10 @@
 package client
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"time"
+)
 
 // AgentsClient provides agent operations via the daemon.
 type AgentsClient struct {
@@ -9,13 +13,46 @@ type AgentsClient struct {
 
 // AgentInfo represents agent data returned by the daemon.
 type AgentInfo struct {
+	CreatedAt time.Time  `json:"created_at"`
+	StartedAt time.Time  `json:"started_at,omitempty"`
+	UpdatedAt time.Time  `json:"updated_at,omitempty"`
+	StoppedAt *time.Time `json:"stopped_at,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	Name      string     `json:"name"`
+	Role      string     `json:"role"`
+	State     string     `json:"state"`
+	Task      string     `json:"task,omitempty"`
+	Team      string     `json:"team,omitempty"`
+	Tool      string     `json:"tool,omitempty"`
+	Session   string     `json:"session,omitempty"`
+	SessionID string     `json:"session_id,omitempty"`
+	ParentID  string     `json:"parent_id,omitempty"`
+	Children  []string   `json:"children,omitempty"`
+}
+
+// CreateAgentReq is the request to create an agent.
+type CreateAgentReq struct {
 	Name    string `json:"name"`
 	Role    string `json:"role"`
-	State   string `json:"state"`
-	Task    string `json:"task,omitempty"`
-	Team    string `json:"team,omitempty"`
 	Tool    string `json:"tool,omitempty"`
-	Session string `json:"session,omitempty"`
+	Runtime string `json:"runtime,omitempty"`
+	Parent  string `json:"parent,omitempty"`
+	EnvFile string `json:"env_file,omitempty"`
+}
+
+// SendResultInfo holds the result of a broadcast/role/pattern send.
+type SendResultInfo struct {
+	Matched []string `json:"matched"`
+	Sent    int      `json:"sent"`
+	Skipped int      `json:"skipped"`
+	Failed  int      `json:"failed"`
+}
+
+// SessionInfo represents a single session history entry.
+type SessionInfo struct {
+	Timestamp time.Time `json:"timestamp,omitempty"`
+	ID        string    `json:"id"`
+	Current   bool      `json:"current,omitempty"`
 }
 
 // List returns all agents from the daemon.
@@ -25,4 +62,136 @@ func (a *AgentsClient) List(ctx context.Context) ([]AgentInfo, error) {
 		return nil, err
 	}
 	return agents, nil
+}
+
+// ListByRole returns agents filtered by role.
+func (a *AgentsClient) ListByRole(ctx context.Context, role string) ([]AgentInfo, error) {
+	agents, err := a.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]AgentInfo, 0)
+	for _, ag := range agents {
+		if ag.Role == role {
+			filtered = append(filtered, ag)
+		}
+	}
+	return filtered, nil
+}
+
+// Get returns a single agent by name.
+func (a *AgentsClient) Get(ctx context.Context, name string) (*AgentInfo, error) {
+	var info AgentInfo
+	if err := a.client.get(ctx, "/api/agents/"+name, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Create creates a new agent.
+func (a *AgentsClient) Create(ctx context.Context, req CreateAgentReq) (*AgentInfo, error) {
+	var info AgentInfo
+	if err := a.client.post(ctx, "/api/agents", req, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Start starts a stopped agent.
+func (a *AgentsClient) Start(ctx context.Context, name string, runtime string, fresh bool) (*AgentInfo, error) {
+	body := map[string]any{"runtime": runtime, "fresh": fresh}
+	var info AgentInfo
+	if err := a.client.post(ctx, "/api/agents/"+name+"/start", body, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Stop stops a running agent.
+func (a *AgentsClient) Stop(ctx context.Context, name string) error {
+	return a.client.post(ctx, "/api/agents/"+name+"/stop", nil, nil)
+}
+
+// Delete permanently removes an agent.
+func (a *AgentsClient) Delete(ctx context.Context, name string) error {
+	return a.client.delete(ctx, "/api/agents/"+name)
+}
+
+// Send sends a message to a running agent.
+func (a *AgentsClient) Send(ctx context.Context, name, message string) error {
+	body := map[string]string{"message": message}
+	return a.client.post(ctx, "/api/agents/"+name+"/send", body, nil)
+}
+
+// Rename renames an agent.
+func (a *AgentsClient) Rename(ctx context.Context, oldName, newName string) error {
+	body := map[string]string{"new_name": newName}
+	return a.client.post(ctx, "/api/agents/"+oldName+"/rename", body, nil)
+}
+
+// Peek returns recent output from an agent.
+func (a *AgentsClient) Peek(ctx context.Context, name string, lines int) (string, error) {
+	path := fmt.Sprintf("/api/agents/%s/peek?lines=%d", name, lines)
+	var result map[string]string
+	if err := a.client.get(ctx, path, &result); err != nil {
+		return "", err
+	}
+	return result["output"], nil
+}
+
+// Sessions returns session history for an agent.
+func (a *AgentsClient) Sessions(ctx context.Context, name string) ([]SessionInfo, error) {
+	var sessions []SessionInfo
+	if err := a.client.get(ctx, "/api/agents/"+name+"/sessions", &sessions); err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
+// Broadcast sends a message to all running agents.
+func (a *AgentsClient) Broadcast(ctx context.Context, message string) (int, error) {
+	body := map[string]string{"message": message}
+	var result map[string]int
+	if err := a.client.post(ctx, "/api/agents/broadcast", body, &result); err != nil {
+		return 0, err
+	}
+	return result["sent"], nil
+}
+
+// SendToRole sends a message to all agents with the given role.
+func (a *AgentsClient) SendToRole(ctx context.Context, role, message string) (*SendResultInfo, error) {
+	body := map[string]string{"role": role, "message": message}
+	var result SendResultInfo
+	if err := a.client.post(ctx, "/api/agents/send-role", body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// SendToPattern sends a message to agents matching the given glob pattern.
+func (a *AgentsClient) SendToPattern(ctx context.Context, pattern, message string) (*SendResultInfo, error) {
+	body := map[string]string{"pattern": pattern, "message": message}
+	var result SendResultInfo
+	if err := a.client.post(ctx, "/api/agents/send-pattern", body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GenerateName generates a unique agent name.
+func (a *AgentsClient) GenerateName(ctx context.Context) (string, error) {
+	var result map[string]string
+	if err := a.client.get(ctx, "/api/agents/generate-name", &result); err != nil {
+		return "", err
+	}
+	return result["name"], nil
+}
+
+// StopAll stops all running agents. Returns the number of agents stopped.
+func (a *AgentsClient) StopAll(ctx context.Context) (int, error) {
+	var result map[string]int
+	if err := a.client.post(ctx, "/api/workspace/down", nil, &result); err != nil {
+		return 0, err
+	}
+	return result["stopped"], nil
 }

--- a/pkg/client/channels.go
+++ b/pkg/client/channels.go
@@ -1,6 +1,10 @@
 package client
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"time"
+)
 
 // ChannelsClient provides channel operations via the daemon.
 type ChannelsClient struct {
@@ -9,8 +13,31 @@ type ChannelsClient struct {
 
 // ChannelInfo represents channel data returned by the daemon.
 type ChannelInfo struct {
-	Name    string   `json:"name"`
-	Members []string `json:"members"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	Name         string    `json:"name"`
+	Description  string    `json:"description,omitempty"`
+	Type         string    `json:"type,omitempty"`
+	Members      []string  `json:"members"`
+	MemberCount  int       `json:"member_count"`
+	MessageCount int       `json:"message_count"`
+}
+
+// MessageInfo represents a channel message returned by the daemon.
+type MessageInfo struct {
+	Reactions map[string][]string `json:"reactions,omitempty"`
+	CreatedAt time.Time           `json:"created_at"`
+	Channel   string              `json:"channel"`
+	Sender    string              `json:"sender"`
+	Content   string              `json:"content"`
+	Type      string              `json:"type,omitempty"`
+	ID        int64               `json:"id,omitempty"`
+}
+
+// ChannelStatusInfo holds channel status summary.
+type ChannelStatusInfo struct {
+	ChannelCount int `json:"channel_count"`
+	TotalMembers int `json:"total_members"`
 }
 
 // List returns all channels from the daemon.
@@ -20,4 +47,91 @@ func (ch *ChannelsClient) List(ctx context.Context) ([]ChannelInfo, error) {
 		return nil, err
 	}
 	return channels, nil
+}
+
+// Get returns a single channel.
+func (ch *ChannelsClient) Get(ctx context.Context, name string) (*ChannelInfo, error) {
+	var info ChannelInfo
+	if err := ch.client.get(ctx, "/api/channels/"+name, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Create creates a new channel.
+func (ch *ChannelsClient) Create(ctx context.Context, name, description string) (*ChannelInfo, error) {
+	body := map[string]string{"name": name, "description": description}
+	var info ChannelInfo
+	if err := ch.client.post(ctx, "/api/channels", body, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Update updates a channel's settings.
+func (ch *ChannelsClient) Update(ctx context.Context, name, description string) (*ChannelInfo, error) {
+	body := map[string]string{"description": description}
+	var info ChannelInfo
+	if err := ch.client.put(ctx, "/api/channels/"+name, body, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Delete removes a channel.
+func (ch *ChannelsClient) Delete(ctx context.Context, name string) error {
+	return ch.client.delete(ctx, "/api/channels/"+name)
+}
+
+// AddMember adds an agent to a channel.
+func (ch *ChannelsClient) AddMember(ctx context.Context, chanName, agentName string) error {
+	body := map[string]string{"agent": agentName}
+	return ch.client.post(ctx, "/api/channels/"+chanName+"/members", body, nil)
+}
+
+// RemoveMember removes an agent from a channel.
+func (ch *ChannelsClient) RemoveMember(ctx context.Context, chanName, agentName string) error {
+	return ch.client.delete(ctx, "/api/channels/"+chanName+"/members/"+agentName)
+}
+
+// Send sends a message to a channel.
+func (ch *ChannelsClient) Send(ctx context.Context, chanName, sender, message string) (*MessageInfo, error) {
+	body := map[string]string{"sender": sender, "message": message}
+	var msg MessageInfo
+	if err := ch.client.post(ctx, "/api/channels/"+chanName+"/send", body, &msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}
+
+// History returns message history for a channel.
+func (ch *ChannelsClient) History(ctx context.Context, chanName string, limit, offset int, agentFilter string) ([]MessageInfo, error) {
+	path := fmt.Sprintf("/api/channels/%s/history?limit=%d&offset=%d", chanName, limit, offset)
+	if agentFilter != "" {
+		path += "&agent=" + agentFilter
+	}
+	var msgs []MessageInfo
+	if err := ch.client.get(ctx, path, &msgs); err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+// React adds or removes a reaction to a message.
+func (ch *ChannelsClient) React(ctx context.Context, chanName string, msgID int, emoji, user string) (bool, error) {
+	body := map[string]any{"msg_id": msgID, "emoji": emoji, "user": user}
+	var result map[string]bool
+	if err := ch.client.post(ctx, "/api/channels/"+chanName+"/react", body, &result); err != nil {
+		return false, err
+	}
+	return result["added"], nil
+}
+
+// Status returns the channel status summary.
+func (ch *ChannelsClient) Status(ctx context.Context) (*ChannelStatusInfo, error) {
+	var status ChannelStatusInfo
+	if err := ch.client.get(ctx, "/api/channels/status", &status); err != nil {
+		return nil, err
+	}
+	return &status, nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -34,6 +36,7 @@ type Client struct {
 	Agents     *AgentsClient
 	Channels   *ChannelsClient
 	Workspaces *WorkspacesClient
+	Events     *EventsClient
 	BaseURL    string
 }
 
@@ -54,6 +57,7 @@ func New(addr string) *Client {
 	c.Agents = &AgentsClient{client: c}
 	c.Channels = &ChannelsClient{client: c}
 	c.Workspaces = &WorkspacesClient{client: c}
+	c.Events = &EventsClient{client: c}
 
 	return c
 }
@@ -106,4 +110,73 @@ func discoverDaemon() string {
 		return addr
 	}
 	return DefaultHTTPAddr
+}
+
+// IsDaemonNotRunning returns true if the error indicates the daemon is not running.
+func IsDaemonNotRunning(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "daemon not running") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "no such file")
+}
+
+// post performs a POST request with JSON body and decodes the JSON response.
+func (c *Client) post(ctx context.Context, path string, body, result any) error {
+	return c.do(ctx, http.MethodPost, path, body, result)
+}
+
+// put performs a PUT request with JSON body and decodes the JSON response.
+func (c *Client) put(ctx context.Context, path string, body, result any) error {
+	return c.do(ctx, http.MethodPut, path, body, result)
+}
+
+// delete performs a DELETE request (no body, no response body expected).
+func (c *Client) delete(ctx context.Context, path string) error {
+	return c.do(ctx, http.MethodDelete, path, nil, nil)
+}
+
+// do performs an HTTP request with optional JSON body and response.
+func (c *Client) do(ctx context.Context, method, path string, body, result any) error {
+	var bodyReader io.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		bodyReader = bytes.NewReader(data)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, bodyReader)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon not running: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("request failed (status %d)", resp.StatusCode)
+		}
+		return fmt.Errorf("request failed (status %d): %s", resp.StatusCode, string(respBody))
+	}
+
+	if result != nil {
+		return json.NewDecoder(resp.Body).Decode(result)
+	}
+	return nil
 }

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// EventsClient provides event log operations via the daemon.
+type EventsClient struct {
+	client *Client
+}
+
+// EventInfo represents an event log entry returned by the daemon.
+type EventInfo struct {
+	Data      map[string]any `json:"data,omitempty"`
+	Timestamp time.Time      `json:"ts"`
+	Type      string         `json:"type"`
+	Agent     string         `json:"agent,omitempty"`
+	Message   string         `json:"message,omitempty"`
+}
+
+// List returns all events from the daemon.
+func (e *EventsClient) List(ctx context.Context) ([]EventInfo, error) {
+	var evts []EventInfo
+	if err := e.client.get(ctx, "/api/events", &evts); err != nil {
+		return nil, err
+	}
+	return evts, nil
+}
+
+// ListByAgent returns events for a specific agent.
+func (e *EventsClient) ListByAgent(ctx context.Context, agentName string) ([]EventInfo, error) {
+	var evts []EventInfo
+	if err := e.client.get(ctx, "/api/events?agent="+agentName, &evts); err != nil {
+		return nil, err
+	}
+	return evts, nil
+}
+
+// Tail returns the last N events.
+func (e *EventsClient) Tail(ctx context.Context, n int) ([]EventInfo, error) {
+	var evts []EventInfo
+	if err := e.client.get(ctx, fmt.Sprintf("/api/events?tail=%d", n), &evts); err != nil {
+		return nil, err
+	}
+	return evts, nil
+}

--- a/pkg/client/workspaces.go
+++ b/pkg/client/workspaces.go
@@ -9,10 +9,11 @@ type WorkspacesClient struct {
 
 // WorkspaceStatus represents workspace status from the daemon.
 type WorkspaceStatus struct {
-	Name       string `json:"name"`
-	RootDir    string `json:"root_dir"`
-	AgentCount int    `json:"agent_count"`
-	IsHealthy  bool   `json:"is_healthy"`
+	Name         string `json:"name"`
+	RootDir      string `json:"root_dir"`
+	AgentCount   int    `json:"agent_count"`
+	RunningCount int    `json:"running_count"`
+	IsHealthy    bool   `json:"is_healthy"`
 }
 
 // Status returns the current workspace status.
@@ -22,4 +23,23 @@ func (w *WorkspacesClient) Status(ctx context.Context) (*WorkspaceStatus, error)
 		return nil, err
 	}
 	return &status, nil
+}
+
+// Up starts the workspace (creates/starts root agent).
+func (w *WorkspacesClient) Up(ctx context.Context, tool, runtime string) (map[string]any, error) {
+	body := map[string]string{"tool": tool, "runtime": runtime}
+	var result map[string]any
+	if err := w.client.post(ctx, "/api/workspace/up", body, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Down stops all running agents. Returns the number stopped.
+func (w *WorkspacesClient) Down(ctx context.Context) (int, error) {
+	var result map[string]int
+	if err := w.client.post(ctx, "/api/workspace/down", nil, &result); err != nil {
+		return 0, err
+	}
+	return result["stopped"], nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5,13 +5,37 @@
 //
 // # Endpoints
 //
-//	GET  /health                    — liveness probe
-//	GET  /api/agents                — list agents
-//	GET  /api/agents/:name          — get agent
-//	POST /api/agents/:name/stop     — stop agent
-//	GET  /api/channels              — list channels
-//	GET  /api/workspace/status      — workspace info
-//	GET  /api/daemons               — list workspace daemons
+//	GET  /health                           — liveness probe
+//	GET  /api/agents                       — list agents
+//	POST /api/agents                       — create agent
+//	GET  /api/agents/generate-name         — generate a unique agent name
+//	POST /api/agents/broadcast             — broadcast message to all agents
+//	POST /api/agents/send-role             — send message to agents by role
+//	POST /api/agents/send-pattern          — send message to agents by pattern
+//	GET  /api/agents/:name                 — get agent
+//	DELETE /api/agents/:name               — delete agent
+//	POST /api/agents/:name/start           — start agent
+//	POST /api/agents/:name/stop            — stop agent
+//	POST /api/agents/:name/send            — send message to agent
+//	POST /api/agents/:name/rename          — rename agent
+//	GET  /api/agents/:name/peek            — peek at agent output
+//	GET  /api/agents/:name/sessions        — list agent sessions
+//	GET  /api/channels                     — list channels
+//	POST /api/channels                     — create channel
+//	GET  /api/channels/status              — channel status summary
+//	GET  /api/channels/:name               — get channel
+//	PUT  /api/channels/:name               — update channel
+//	DELETE /api/channels/:name             — delete channel
+//	POST /api/channels/:name/members       — add member
+//	DELETE /api/channels/:name/members/:agent — remove member
+//	POST /api/channels/:name/send          — send message to channel
+//	GET  /api/channels/:name/history       — get channel history
+//	POST /api/channels/:name/react         — react to message
+//	GET  /api/workspace/status             — workspace info
+//	POST /api/workspace/up                 — start workspace (root agent)
+//	POST /api/workspace/down               — stop all agents
+//	GET  /api/daemons                      — list workspace daemons
+//	GET  /api/events                       — list events (supports ?agent=, ?tail=)
 //
 // All responses are JSON. Errors are returned as {"error": "..."}.
 package server
@@ -22,12 +46,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/daemon"
+	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
@@ -37,6 +63,7 @@ type Server struct {
 	agents     *agent.AgentService
 	channels   *channel.ChannelService
 	daemons    *daemon.Manager
+	eventStore events.EventStore
 	ws         *workspace.Workspace
 	httpServer *http.Server
 	addr       string
@@ -75,11 +102,28 @@ func New(
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", s.handleHealth)
+
+	// Exact-path agent routes must be registered BEFORE the prefix route "/api/agents/"
+	mux.HandleFunc("/api/agents/generate-name", s.handleAgentGenerateName)
+	mux.HandleFunc("/api/agents/broadcast", s.handleAgentBroadcast)
+	mux.HandleFunc("/api/agents/send-role", s.handleAgentSendRole)
+	mux.HandleFunc("/api/agents/send-pattern", s.handleAgentSendPattern)
 	mux.HandleFunc("/api/agents", s.handleAgents)
 	mux.HandleFunc("/api/agents/", s.handleAgentByName)
+
+	// Channel routes
+	mux.HandleFunc("/api/channels/status", s.handleChannelStatus)
 	mux.HandleFunc("/api/channels", s.handleChannels)
+	mux.HandleFunc("/api/channels/", s.handleChannelByName)
+
+	// Workspace routes
 	mux.HandleFunc("/api/workspace/status", s.handleWorkspaceStatus)
+	mux.HandleFunc("/api/workspace/up", s.handleWorkspaceUp)
+	mux.HandleFunc("/api/workspace/down", s.handleWorkspaceDown)
+
+	// Other routes
 	mux.HandleFunc("/api/daemons", s.handleDaemons)
+	mux.HandleFunc("/api/events", s.handleEvents)
 
 	s.httpServer = &http.Server{
 		Addr:         cfg.Addr,
@@ -90,6 +134,11 @@ func New(
 	}
 
 	return s
+}
+
+// WithEventStore configures the server with an event store.
+func (s *Server) WithEventStore(store events.EventStore) {
+	s.eventStore = store
 }
 
 // Addr returns the resolved listen address after Start is called.
@@ -129,6 +178,46 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.httpServer.Shutdown(ctx)
 }
 
+// --- Agent DTO ---
+
+type agentDTO struct {
+	CreatedAt time.Time  `json:"created_at"`
+	StartedAt time.Time  `json:"started_at,omitempty"`
+	UpdatedAt time.Time  `json:"updated_at,omitempty"`
+	StoppedAt *time.Time `json:"stopped_at,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	Name      string     `json:"name"`
+	Role      string     `json:"role"`
+	State     string     `json:"state"`
+	Task      string     `json:"task,omitempty"`
+	Team      string     `json:"team,omitempty"`
+	Tool      string     `json:"tool,omitempty"`
+	Session   string     `json:"session,omitempty"`
+	SessionID string     `json:"session_id,omitempty"`
+	ParentID  string     `json:"parent_id,omitempty"`
+	Children  []string   `json:"children,omitempty"`
+}
+
+func toAgentDTO(a *agent.Agent) agentDTO {
+	return agentDTO{
+		ID:        a.ID,
+		Name:      a.Name,
+		Role:      string(a.Role),
+		State:     string(a.State),
+		Task:      a.Task,
+		Team:      a.Team,
+		Tool:      a.Tool,
+		Session:   a.Session,
+		SessionID: a.SessionID,
+		ParentID:  a.ParentID,
+		Children:  a.Children,
+		CreatedAt: a.CreatedAt,
+		StartedAt: a.StartedAt,
+		UpdatedAt: a.UpdatedAt,
+		StoppedAt: a.StoppedAt,
+	}
+}
+
 // --- Handlers ---
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -151,39 +240,121 @@ func (s *Server) handleAgents(w http.ResponseWriter, r *http.Request) {
 			httpError(w, fmt.Sprintf("list agents: %v", err), http.StatusInternalServerError)
 			return
 		}
-		type agentDTO struct {
-			CreatedAt time.Time `json:"created_at"`
-			Name      string    `json:"name"`
-			Role      string    `json:"role"`
-			State     string    `json:"state"`
-			Task      string    `json:"task,omitempty"`
-			Team      string    `json:"team,omitempty"`
-			Tool      string    `json:"tool,omitempty"`
-			Session   string    `json:"session,omitempty"`
-		}
 		dtos := make([]agentDTO, 0, len(agents))
 		for _, a := range agents {
-			dtos = append(dtos, agentDTO{
-				Name:      a.Name,
-				Role:      string(a.Role),
-				State:     string(a.State),
-				Task:      a.Task,
-				Team:      a.Team,
-				Tool:      a.Tool,
-				Session:   a.Session,
-				CreatedAt: a.CreatedAt,
-			})
+			dtos = append(dtos, toAgentDTO(a))
 		}
 		writeJSON(w, http.StatusOK, dtos)
+
+	case http.MethodPost:
+		var req struct {
+			Name    string `json:"name"`
+			Role    string `json:"role"`
+			Tool    string `json:"tool,omitempty"`
+			Runtime string `json:"runtime,omitempty"`
+			Parent  string `json:"parent,omitempty"`
+			EnvFile string `json:"env_file,omitempty"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+		a, err := s.agents.Create(r.Context(), agent.CreateOptions{
+			Name:    req.Name,
+			Role:    agent.Role(req.Role),
+			Tool:    req.Tool,
+			Runtime: req.Runtime,
+			Parent:  req.Parent,
+			EnvFile: req.EnvFile,
+		})
+		if err != nil {
+			httpError(w, fmt.Sprintf("create agent: %v", err), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusCreated, toAgentDTO(a))
 
 	default:
 		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 
+func (s *Server) handleAgentGenerateName(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	name, err := s.agents.GenerateName(r.Context())
+	if err != nil {
+		httpError(w, fmt.Sprintf("generate name: %v", err), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"name": name})
+}
+
+func (s *Server) handleAgentBroadcast(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+		return
+	}
+	sent, err := s.agents.Broadcast(r.Context(), req.Message)
+	if err != nil {
+		httpError(w, fmt.Sprintf("broadcast: %v", err), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]int{"sent": sent})
+}
+
+func (s *Server) handleAgentSendRole(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Role    string `json:"role"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+		return
+	}
+	result, err := s.agents.SendToRole(r.Context(), req.Role, req.Message)
+	if err != nil {
+		httpError(w, fmt.Sprintf("send-role: %v", err), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleAgentSendPattern(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Pattern string `json:"pattern"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+		return
+	}
+	result, err := s.agents.SendToPattern(r.Context(), req.Pattern, req.Message)
+	if err != nil {
+		httpError(w, fmt.Sprintf("send-pattern: %v", err), http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
 // handleAgentByName handles /api/agents/:name and /api/agents/:name/action
 func (s *Server) handleAgentByName(w http.ResponseWriter, r *http.Request) {
-	// Extract name from path: /api/agents/<name> or /api/agents/<name>/stop
 	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/agents/"), "/")
 	if len(parts) == 0 || parts[0] == "" {
 		httpError(w, "agent name required", http.StatusBadRequest)
@@ -202,22 +373,7 @@ func (s *Server) handleAgentByName(w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusNotFound)
 			return
 		}
-		writeJSON(w, http.StatusOK, a)
-
-	case r.Method == http.MethodPost && action == "stop":
-		if err := s.agents.Stop(r.Context(), name); err != nil {
-			httpError(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
-
-	case r.Method == http.MethodPost && action == "start":
-		a, err := s.agents.Start(r.Context(), name, agent.StartOptions{})
-		if err != nil {
-			httpError(w, err.Error(), http.StatusBadRequest)
-			return
-		}
-		writeJSON(w, http.StatusOK, a)
+		writeJSON(w, http.StatusOK, toAgentDTO(a))
 
 	case r.Method == http.MethodDelete && action == "":
 		if err := s.agents.Delete(r.Context(), name); err != nil {
@@ -226,12 +382,116 @@ func (s *Server) handleAgentByName(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(http.StatusNoContent)
 
+	case r.Method == http.MethodPost && action == "start":
+		var req struct {
+			Runtime string `json:"runtime,omitempty"`
+			Fresh   bool   `json:"fresh,omitempty"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck // optional body
+		a, err := s.agents.Start(r.Context(), name, agent.StartOptions{
+			Runtime: req.Runtime,
+			Fresh:   req.Fresh,
+		})
+		if err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, toAgentDTO(a))
+
+	case r.Method == http.MethodPost && action == "stop":
+		if err := s.agents.Stop(r.Context(), name); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "stopped"})
+
+	case r.Method == http.MethodPost && action == "send":
+		var req struct {
+			Message string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+		if err := s.agents.Send(r.Context(), name, req.Message); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "sent"})
+
+	case r.Method == http.MethodPost && action == "rename":
+		var req struct {
+			NewName string `json:"new_name"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+		if err := s.agents.Rename(r.Context(), name, req.NewName); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "renamed"})
+
+	case r.Method == http.MethodGet && action == "peek":
+		lines := 50
+		if q := r.URL.Query().Get("lines"); q != "" {
+			if n, err := strconv.Atoi(q); err == nil && n > 0 {
+				lines = n
+			}
+		}
+		output, err := s.agents.Peek(r.Context(), name, lines)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"output": output})
+
+	case r.Method == http.MethodGet && action == "sessions":
+		entries, err := s.agents.Sessions(r.Context(), name)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if entries == nil {
+			entries = []agent.SessionEntry{}
+		}
+		writeJSON(w, http.StatusOK, entries)
+
 	default:
 		httpError(w, "not found", http.StatusNotFound)
 	}
 }
 
 func (s *Server) handleChannels(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		channels, err := s.channels.List(r.Context())
+		if err != nil {
+			httpError(w, fmt.Sprintf("list channels: %v", err), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, channels)
+
+	case http.MethodPost:
+		var req channel.CreateChannelReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+		ch, err := s.channels.Create(r.Context(), req)
+		if err != nil {
+			httpError(w, fmt.Sprintf("create channel: %v", err), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusCreated, ch)
+
+	default:
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleChannelStatus(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -241,7 +501,159 @@ func (s *Server) handleChannels(w http.ResponseWriter, r *http.Request) {
 		httpError(w, fmt.Sprintf("list channels: %v", err), http.StatusInternalServerError)
 		return
 	}
-	writeJSON(w, http.StatusOK, channels)
+	totalMembers := 0
+	for _, ch := range channels {
+		totalMembers += ch.MemberCount
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"channel_count": len(channels),
+		"total_members": totalMembers,
+	})
+}
+
+// handleChannelByName handles /api/channels/:name and sub-actions
+func (s *Server) handleChannelByName(w http.ResponseWriter, r *http.Request) {
+	path := strings.TrimPrefix(r.URL.Path, "/api/channels/")
+	parts := strings.SplitN(path, "/", 3)
+	if len(parts) == 0 || parts[0] == "" {
+		httpError(w, "channel name required", http.StatusBadRequest)
+		return
+	}
+	name := parts[0]
+	action := ""
+	if len(parts) > 1 {
+		action = parts[1]
+	}
+
+	switch {
+	case r.Method == http.MethodGet && action == "":
+		ch, err := s.channels.Get(r.Context(), name)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		writeJSON(w, http.StatusOK, ch)
+
+	case r.Method == http.MethodPut && action == "":
+		var req channel.UpdateChannelReq
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+		ch, err := s.channels.Update(r.Context(), name, req)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, ch)
+
+	case r.Method == http.MethodDelete && action == "":
+		if err := s.channels.Delete(r.Context(), name); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+
+	case r.Method == http.MethodPost && action == "members":
+		var req struct {
+			Agent string `json:"agent"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+		if err := s.channels.AddMember(r.Context(), name, req.Agent); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "added"})
+
+	case r.Method == http.MethodDelete && action == "members":
+		agentID := ""
+		if len(parts) > 2 {
+			agentID = parts[2]
+		}
+		if agentID == "" {
+			httpError(w, "agent name required", http.StatusBadRequest)
+			return
+		}
+		if err := s.channels.RemoveMember(r.Context(), name, agentID); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+
+	case r.Method == http.MethodPost && action == "send":
+		var req struct {
+			Sender  string `json:"sender"`
+			Message string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+		msg, err := s.channels.Send(r.Context(), name, req.Sender, req.Message)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		// Also deliver to agent tmux sessions
+		ch, getErr := s.channels.Get(r.Context(), name)
+		if getErr == nil {
+			for _, member := range ch.Members {
+				if member == req.Sender {
+					continue
+				}
+				if sendErr := s.agents.Send(r.Context(), member, req.Message); sendErr != nil {
+					log.Debug("channel send: failed to deliver to agent", "agent", member, "error", sendErr)
+				}
+			}
+		}
+		writeJSON(w, http.StatusOK, msg)
+
+	case r.Method == http.MethodGet && action == "history":
+		q := r.URL.Query()
+		opts := channel.HistoryOpts{}
+		if n := q.Get("limit"); n != "" {
+			if v, err := strconv.Atoi(n); err == nil {
+				opts.Limit = v
+			}
+		}
+		if n := q.Get("offset"); n != "" {
+			if v, err := strconv.Atoi(n); err == nil {
+				opts.Offset = v
+			}
+		}
+		if a := q.Get("agent"); a != "" {
+			opts.Agent = a
+		}
+		msgs, err := s.channels.History(r.Context(), name, opts)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, msgs)
+
+	case r.Method == http.MethodPost && action == "react":
+		var req struct {
+			Emoji string `json:"emoji"`
+			User  string `json:"user"`
+			MsgID int    `json:"msg_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
+			return
+		}
+		added, err := s.channels.React(r.Context(), name, req.MsgID, req.Emoji, req.User)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]bool{"added": added})
+
+	default:
+		httpError(w, "not found", http.StatusNotFound)
+	}
 }
 
 func (s *Server) handleWorkspaceStatus(w http.ResponseWriter, r *http.Request) {
@@ -271,6 +683,65 @@ func (s *Server) handleWorkspaceStatus(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) handleWorkspaceUp(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Tool    string `json:"tool,omitempty"`
+		Runtime string `json:"runtime,omitempty"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck // optional body
+
+	// Create root agent if not already running
+	existing := s.agents.Manager().GetAgent("root")
+	if existing != nil && existing.State != agent.StateStopped && existing.State != agent.StateError {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":  "already_running",
+			"message": "root agent is already running",
+		})
+		return
+	}
+
+	var a *agent.Agent
+	var err error
+	if existing != nil {
+		a, err = s.agents.Start(r.Context(), "root", agent.StartOptions{
+			Runtime: req.Runtime,
+		})
+	} else {
+		a, err = s.agents.Create(r.Context(), agent.CreateOptions{
+			Name:    "root",
+			Role:    agent.RoleRoot,
+			Tool:    req.Tool,
+			Runtime: req.Runtime,
+		})
+	}
+	if err != nil {
+		httpError(w, fmt.Sprintf("start workspace: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"status": "started",
+		"agent":  toAgentDTO(a),
+	})
+}
+
+func (s *Server) handleWorkspaceDown(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	stopped, err := s.agents.StopAll(r.Context())
+	if err != nil {
+		httpError(w, fmt.Sprintf("stop all: %v", err), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]int{"stopped": stopped})
+}
+
 func (s *Server) handleDaemons(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -285,6 +756,47 @@ func (s *Server) handleDaemons(w http.ResponseWriter, r *http.Request) {
 		daemons = []*daemon.Daemon{}
 	}
 	writeJSON(w, http.StatusOK, daemons)
+}
+
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		httpError(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if s.eventStore == nil {
+		writeJSON(w, http.StatusOK, []any{})
+		return
+	}
+
+	q := r.URL.Query()
+	agentFilter := q.Get("agent")
+	tailStr := q.Get("tail")
+
+	var evts []events.Event
+	var err error
+
+	switch {
+	case agentFilter != "":
+		evts, err = s.eventStore.ReadByAgent(agentFilter)
+	case tailStr != "":
+		n, parseErr := strconv.Atoi(tailStr)
+		if parseErr != nil || n <= 0 {
+			httpError(w, "invalid tail value", http.StatusBadRequest)
+			return
+		}
+		evts, err = s.eventStore.ReadLast(n)
+	default:
+		evts, err = s.eventStore.Read()
+	}
+
+	if err != nil {
+		httpError(w, fmt.Sprintf("read events: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if evts == nil {
+		evts = []events.Event{}
+	}
+	writeJSON(w, http.StatusOK, evts)
 }
 
 // --- Helpers ---


### PR DESCRIPTION
## Summary

- Expanded `pkg/agent/service.go` with 6 new methods: `StopAll`, `Rename`, `Sessions`, `SendToRole`, `SendToPattern`, `GenerateName` + `SessionEntry`/`SendResult` types
- Complete rewrite of `pkg/server/server.go` — full REST API covering agents (CRUD + broadcast/send-role/send-pattern/peek/sessions/rename), channels (CRUD + members/send/history/react), workspace up/down, events
- Expanded `pkg/client/` — all resource clients with full method coverage (`post`/`put`/`delete`/`do` helpers, `Events` client, `IsDaemonNotRunning` helper)
- Refactored `internal/cmd/down.go` to delegate to daemon via HTTP
- Added `newDaemonClient` helper to `internal/cmd/init.go`

When `bcd` is not running, commands print an actionable error. `go build ./...` passes.

## Test plan

- [ ] `go build ./...` passes (verified)
- [ ] `bc down` with bcd running calls `POST /api/workspace/down`
- [ ] `bc down` without bcd prints "bcd is not running" error
- [ ] `GET /api/agents` returns agent list
- [ ] `POST /api/agents/broadcast` delivers to all running agents
- [ ] `GET /api/channels/:name/history` returns messages

Closes #1982

🤖 Generated with [Claude Code](https://claude.com/claude-code)