### PR TITLE
fix: prevent Docker agents from overwriting host bin/bc (#2002)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+bin/
+dist/
+.bc/
+node_modules/
+web/node_modules/
+web/dist/
+tui/node_modules/
+tui/dist/

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -217,6 +217,11 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 	// Volume mounts
 	if dir != "" {
 		args = append(args, "-v", dir+":/workspace")
+		// Prevent container builds from overwriting host binaries (e.g. bin/bc).
+		// An anonymous volume shadows /workspace/bin so writes stay container-local.
+		args = append(args, "-v", "/workspace/bin")
+		// Same for dist/ directories that may differ per platform.
+		args = append(args, "-v", "/workspace/dist")
 	}
 
 	// Per-agent auth — seeded from host credentials on first use so agents start


### PR DESCRIPTION
## Summary

Docker agents mount the workspace read-write (`-v dir:/workspace`). When an agent runs `make build` inside the container, it writes a **Linux** binary to `bin/bc`, overwriting the host's native binary (e.g., macOS arm64). The host `bc` command then fails with `exec format error`.

### Fix

**Anonymous volume shadows** for build output directories:

```go
// pkg/container/container.go — CreateSessionWithEnv()
args = append(args, "-v", "/workspace/bin")   // shadow bin/
args = append(args, "-v", "/workspace/dist")  // shadow dist/
```

Docker anonymous volumes overlay the bind mount at those specific paths. Container writes to `/workspace/bin/` go to an ephemeral Docker volume instead of the host filesystem, while the rest of the workspace remains shared read-write.

Also added `.dockerignore` to exclude `bin/`, `dist/`, `node_modules/`, and `.bc/` from Docker build contexts.

## Files Changed

| File | Change |
|------|--------|
| `pkg/container/container.go` | Add anonymous volume mounts for bin/ and dist/ (+5 lines) |
| `.dockerignore` | New — excludes build artifacts from Docker context |

## Test Plan

- [x] `make build` passes
- [x] `go vet ./pkg/container/` passes
- [ ] Start Docker agent → verify `ls /workspace/bin/` is empty inside container
- [ ] Agent runs `make build` → Linux binary in container's `/workspace/bin/`
- [ ] Host `bin/bc` unchanged (still native architecture)
- [ ] Agent can still read/write all other workspace files normally

Closes #2002

🤖 Generated with [Claude Code](https://claude.com/claude-code)