### PR TITLE
fix: mount bin/ read-only in Docker, redirect build output (#2003)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
+# Build output directory (override with BUILD_DIR=/tmp/bc-build for Docker agents)
+BUILD_DIR ?= bin
+
 # ldflags for version injection
 LDFLAGS_VERSION = -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 
@@ -58,7 +61,8 @@ dev:
 	go run ./cmd/bc
 
 build: gen
-	go build -ldflags="$(LDFLAGS_VERSION)" -o bin/bc ./cmd/bc
+	@mkdir -p $(BUILD_DIR)
+	go build -ldflags="$(LDFLAGS_VERSION)" -o $(BUILD_DIR)/bc ./cmd/bc
 
 build-web:
 	@echo "Building React web UI..."
@@ -69,10 +73,12 @@ build-web:
 
 build-bcd: gen build-web
 	@echo "Building bcd server (with embedded web UI)..."
-	go build -ldflags="$(LDFLAGS_VERSION)" -o bin/bcd ./cmd/bcd
+	@mkdir -p $(BUILD_DIR)
+	go build -ldflags="$(LDFLAGS_VERSION)" -o $(BUILD_DIR)/bcd ./cmd/bcd
 
 build-release: gen
-	go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o bin/bc ./cmd/bc
+	@mkdir -p $(BUILD_DIR)
+	go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o $(BUILD_DIR)/bc ./cmd/bc
 
 build-all: gen
 	@mkdir -p dist
@@ -83,7 +89,7 @@ build-all: gen
 	GOOS=windows GOARCH=amd64 go build -ldflags="-s -w $(LDFLAGS_VERSION)" -o dist/bc-windows-amd64.exe ./cmd/bc
 
 clean:
-	rm -rf bin/ dist/
+	rm -rf $(BUILD_DIR)/ dist/
 
 gen:
 	go generate ./...

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -217,12 +218,24 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 	// Volume mounts
 	if dir != "" {
 		args = append(args, "-v", dir+":/workspace")
-		// Prevent container builds from overwriting host binaries (e.g. bin/bc).
-		// An anonymous volume shadows /workspace/bin so writes stay container-local.
-		args = append(args, "-v", "/workspace/bin")
-		// Same for dist/ directories that may differ per platform.
-		args = append(args, "-v", "/workspace/dist")
+
+		// Prevent container builds from overwriting host binaries (#2003).
+		// Mount bin/ and dist/ as read-only so `make build` inside the container
+		// cannot clobber the host's native binaries. The Makefile respects
+		// BUILD_DIR to redirect output to a container-local path.
+		binDir := filepath.Join(dir, "bin")
+		if _, err := os.Stat(binDir); err == nil {
+			args = append(args, "-v", binDir+":/workspace/bin:ro")
+		}
+		distDir := filepath.Join(dir, "dist")
+		if _, err := os.Stat(distDir); err == nil {
+			args = append(args, "-v", distDir+":/workspace/dist:ro")
+		}
 	}
+
+	// Tell the Makefile to write build output to a container-local directory
+	// so `make build` works even though bin/ is read-only.
+	env["BUILD_DIR"] = "/tmp/bc-build"
 
 	// Per-agent auth — seeded from host credentials on first use so agents start
 	// pre-authenticated without a separate login. Two mounts:


### PR DESCRIPTION
## Summary

Replaces the unreliable anonymous volume approach from #2007 with read-only mounts + redirected build output.

**Layer 1 — Read-only mounts:** Host `bin/` and `dist/` mounted `:ro` into containers. Write attempts fail with clear `read-only file system` error.

**Layer 2 — BUILD_DIR:** Containers set `BUILD_DIR=/tmp/bc-build`. Makefile uses `BUILD_DIR ?= bin` so `make build` inside Docker writes to `/tmp/bc-build/bc`. Host workflow unchanged (defaults to `bin/`).

## Files Changed

| File | Change |
|------|--------|
| `pkg/container/container.go` | `:ro` mounts for bin/ and dist/, set `BUILD_DIR` env |
| `Makefile` | `BUILD_DIR ?= bin`, use `$(BUILD_DIR)` in build targets and clean |

## Test Plan

- [x] `make build` passes on host
- [x] `go vet ./pkg/container/` clean
- [ ] Docker agent `make build` succeeds, writes to /tmp/bc-build/
- [ ] Host bin/bc unchanged after container build

Closes #2003

🤖 Generated with [Claude Code](https://claude.com/claude-code)