### PR TITLE
feat: bc init bootstraps bcd + bcdb as Docker daemons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build build-release build-all clean gen test coverage bench fmt vet lint check deps help version build-tui test-tui lint-tui build-web build-bcd build-agent-base build-agent-image build-agent-images build-landing dev-landing
+.PHONY: dev build build-release build-all clean gen test coverage bench fmt vet lint check deps help version build-tui test-tui lint-tui build-web build-bcd build-bcd-image build-bcdb-image build-agent-base build-agent-image build-agent-images build-landing dev-landing
 
 # Version information
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -137,6 +137,15 @@ build-landing:
 dev-landing:
 	@echo "Starting landing page dev server at http://localhost:8080"
 	@cd landing && python3 -m http.server 8080
+
+# Docker server images (bcd + bcdb)
+build-bcd-image:
+	@echo "Building bc-bcd image (includes web UI)..."
+	docker build -t bc-bcd:latest -f docker/Dockerfile.bcd .
+
+build-bcdb-image:
+	@echo "Building bc-bcdb image (postgres:17 + init SQL)..."
+	docker build -t bc-bcdb:latest -f docker/Dockerfile.bcdb .
 
 # Docker agent images (per-provider)
 AGENT_PROVIDERS := claude gemini codex aider opencode openclaw cursor

--- a/docker/Dockerfile.bcd
+++ b/docker/Dockerfile.bcd
@@ -1,0 +1,58 @@
+# bc coordination daemon (bcd) — multi-stage build
+# Builds the React web UI, then the bcd binary with it embedded.
+#
+# Usage:
+#   docker build -t bc-bcd:latest -f docker/Dockerfile.bcd .
+#   docker run -p 9374:9374 -v /path/to/.bc:/workspace/.bc bc-bcd:latest
+
+# ---------------------------------------------------------------------------
+# Stage 1: Build React web UI
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS web-builder
+
+WORKDIR /app
+
+# Install bun
+RUN npm install -g bun
+
+COPY web/package.json web/bun.lock ./web/
+RUN cd web && bun install --frozen-lockfile
+
+COPY web ./web
+RUN cd web && bun run build
+
+# ---------------------------------------------------------------------------
+# Stage 2: Build bcd Go binary (with embedded web UI)
+# ---------------------------------------------------------------------------
+FROM golang:1.25 AS builder
+
+WORKDIR /app
+
+# Cache dependencies
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source
+COPY . .
+
+# Inject pre-built web UI so go:embed picks it up
+COPY --from=web-builder /app/web/dist ./web/dist
+RUN cp -r web/dist server/web/dist
+
+# Build bcd (CGO required for go-sqlite3)
+RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o /bin/bcd ./cmd/bcd
+
+# ---------------------------------------------------------------------------
+# Stage 3: Minimal runtime image
+# ---------------------------------------------------------------------------
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /bin/bcd /usr/local/bin/bcd
+
+EXPOSE 9374
+
+ENTRYPOINT ["bcd"]

--- a/docker/Dockerfile.bcdb
+++ b/docker/Dockerfile.bcdb
@@ -1,0 +1,23 @@
+# bc database (bcdb) — Postgres 17 with bc-specific init scripts
+#
+# Usage:
+#   docker build -t bc-bcdb:latest -f docker/Dockerfile.bcdb .
+#   docker run -d \
+#     -e POSTGRES_DB=bc \
+#     -e POSTGRES_USER=bc \
+#     -e POSTGRES_PASSWORD=bc \
+#     -p 5432:5432 \
+#     -v /path/to/.bc/pgdata:/var/lib/postgresql/data \
+#     bc-bcdb:latest
+
+FROM postgres:17
+
+# Copy bc-specific init SQL scripts. Postgres runs *.sql files in /docker-entrypoint-initdb.d/
+# in alphabetical order on first startup.
+COPY docker/bcdb/ /docker-entrypoint-initdb.d/
+
+ENV POSTGRES_DB=bc
+ENV POSTGRES_USER=bc
+ENV POSTGRES_PASSWORD=bc
+
+EXPOSE 5432

--- a/docker/bcdb/01-init.sql
+++ b/docker/bcdb/01-init.sql
@@ -1,0 +1,31 @@
+-- bc database initialisation
+-- Runs once on first Postgres startup.
+-- Tables are also created by bcd on connect (migrations), so this
+-- file just ensures the database and search_path are correct.
+
+\connect bc
+
+-- Channels
+CREATE TABLE IF NOT EXISTS channels (
+    id         SERIAL PRIMARY KEY,
+    name       TEXT NOT NULL UNIQUE,
+    topic      TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS channel_members (
+    channel_name TEXT NOT NULL,
+    agent        TEXT NOT NULL,
+    joined_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (channel_name, agent)
+);
+
+CREATE TABLE IF NOT EXISTS channel_messages (
+    id           SERIAL PRIMARY KEY,
+    channel_name TEXT        NOT NULL,
+    sender       TEXT        NOT NULL,
+    body         TEXT        NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_channel_messages_channel ON channel_messages (channel_name, created_at DESC);

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -421,6 +421,10 @@ func initV2WorkspaceWithNickname(rootDir string, nickname string) error {
 	}
 	fmt.Println("    .bc/channels.db     # Channel database")
 	fmt.Println()
+
+	// Bootstrap server daemons (non-fatal; warns if Docker unavailable)
+	bootstrapServerDaemons(rootDir)
+
 	fmt.Println("  Next steps:")
 	fmt.Println("    bc          # Open the dashboard")
 	fmt.Println("    bc up       # Start agents")

--- a/internal/cmd/init_bootstrap.go
+++ b/internal/cmd/init_bootstrap.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/daemon"
+	"github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/ui"
+)
+
+// bootstrapServerDaemons starts bcdb (postgres:17) and bcd (bc-bcd:latest) as
+// Docker-managed workspace daemons. It is called automatically by bc init.
+// Failures are non-fatal — a warning is printed if Docker is unavailable or the
+// bc-bcd:latest image has not been built yet.
+func bootstrapServerDaemons(rootDir string) {
+	mgr, err := daemon.NewManager(rootDir)
+	if err != nil {
+		log.Debug("daemon manager unavailable; skipping server bootstrap", "error", err)
+		return
+	}
+	defer func() { _ = mgr.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Start bcdb (Postgres)
+	fmt.Print("  Starting bcdb (postgres:17)... ")
+	_, dbErr := mgr.Run(ctx, daemon.RunOptions{
+		Name:    "bcdb",
+		Runtime: daemon.RuntimeDocker,
+		Image:   "postgres:17",
+		Ports:   []string{"5432:5432"},
+		Env: []string{
+			"POSTGRES_DB=bc",
+			"POSTGRES_USER=bc",
+			"POSTGRES_PASSWORD=bc",
+		},
+		Restart: "always",
+		Detach:  true,
+	})
+	if dbErr != nil {
+		fmt.Println(ui.YellowText("✗ (Docker unavailable — run manually: bc daemon run --name bcdb --runtime docker --image postgres:17)"))
+		log.Debug("bcdb start failed", "error", dbErr)
+		return
+	}
+	fmt.Println(ui.GreenText("✓"))
+
+	// Start bcd
+	fmt.Print("  Starting bcd server...       ")
+	_, bcdErr := mgr.Run(ctx, daemon.RunOptions{
+		Name:    "bcd",
+		Runtime: daemon.RuntimeDocker,
+		Image:   "bc-bcd:latest",
+		Ports:   []string{"9374:9374"},
+		Env:     []string{"DATABASE_URL=postgres://bc:bc@localhost:5432/bc"},
+		Restart: "always",
+		Detach:  true,
+	})
+	if bcdErr != nil {
+		fmt.Println(ui.YellowText("✗ (image not found — run: make build-bcd-image)"))
+		log.Debug("bcd start failed", "error", bcdErr)
+		return
+	}
+	fmt.Println(ui.GreenText("✓"))
+
+	fmt.Println()
+	fmt.Printf("  %s bc workspace ready at http://localhost:9374\n", ui.GreenText("✓"))
+	fmt.Println()
+}

--- a/internal/cmd/init_wizard.go
+++ b/internal/cmd/init_wizard.go
@@ -242,6 +242,9 @@ func createWorkspaceFromWizard(state *WizardState) error {
 		_ = reg.Save()
 	}
 
+	// Bootstrap server daemons (non-fatal; warns if Docker unavailable)
+	bootstrapServerDaemons(state.Dir)
+
 	// Print success
 	printWizardSuccess(state)
 	return nil


### PR DESCRIPTION
## Summary

- Add `docker/Dockerfile.bcd` — multi-stage build (Node 20 for web UI + Go 1.25 for binary with embedded `server/web/dist`)
- Add `docker/Dockerfile.bcdb` — `postgres:17` image with bc-specific init SQL (`docker/bcdb/01-init.sql`)
- Add Makefile targets: `build-bcd-image`, `build-bcdb-image`
- `bc init` now auto-starts `bcdb` (postgres:17) and `bcd` (bc-bcd:latest) via the daemon manager after workspace creation
- Bootstrap is **non-fatal**: if Docker is unavailable or `bc-bcd:latest` hasn't been built yet, a yellow warning is printed and init succeeds normally
- Prints `bc workspace ready at http://localhost:9374` on success

## Architecture

```
bc init myproject
  → creates .bc/ directory structure
  → starts bcdb (postgres:17) via Docker daemon manager
  → starts bcd (bc-bcd:latest) via Docker daemon manager
  → prints: "bc workspace ready at http://localhost:9374"
```

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go test -race ./internal/cmd/ -run TestInit` passes
- [ ] `make build-bcd-image` builds `bc-bcd:latest` Docker image
- [ ] `make build-bcdb-image` builds `bc-bcdb:latest` Docker image
- [ ] `bc init <dir>` in environment with Docker starts both containers and prints the ready URL
- [ ] `bc init <dir>` in environment without Docker prints a yellow warning and completes successfully

Closes #2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)