### PR TITLE
feat: agent state via Claude Code hooks + Docker stats (#1995)

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -82,6 +82,11 @@ func run(addr, wsRoot string) error {
 	}
 	agentSvc := bcagent.NewAgentService(agentMgr, hub, nil)
 
+	// Stats collector: polls Docker stats + consumes hook event files every 30s.
+	statsCollector := bcagent.NewStatsCollector(agentMgr)
+	go statsCollector.Run(ctx)
+
+
 	// Channel service
 	var channelSvc *bcchannel.ChannelService
 	if chStore, err := bcchannel.OpenStore(ws.RootDir); err != nil {

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -307,6 +307,8 @@ Examples:
 // Flags
 var (
 	agentCreateTool    string
+	agentStatsJSON     bool
+	agentStatsLimit    int
 	agentCreateRole    string
 	agentCreateParent  string
 	agentCreateTeam    string
@@ -410,9 +412,15 @@ func init() {
 	agentCmd.AddCommand(agentAuthCmd)
 	agentCmd.AddCommand(agentCostCmd)
 	agentCmd.AddCommand(agentLogsCmd)
+	agentCmd.AddCommand(agentStatsCmd)
 
 	// Logs flags
 	agentLogsCmd.Flags().StringVar(&agentLogsSince, "since", "", "Show events since duration (e.g., 1h, 30m)")
+
+	// Stats flags
+	agentStatsCmd.Flags().BoolVar(&agentStatsJSON, "json", false, "Output as JSON")
+	agentStatsCmd.Flags().IntVar(&agentStatsLimit, "limit", 20, "Number of records to show")
+	agentStatsCmd.ValidArgsFunction = CompleteAgentNames
 
 	// Add parent command to root
 	rootCmd.AddCommand(agentCmd)
@@ -1819,5 +1827,66 @@ func runAgentSessions(cmd *cobra.Command, args []string) error {
 	}
 	fmt.Printf("\nResume a session: bc agent start %s --resume <id>\n", agentName)
 
+	return nil
+}
+
+// agentStatsCmd shows Docker resource stats for a given agent.
+var agentStatsCmd = &cobra.Command{
+	Use:   "stats <name>",
+	Short: "Show Docker resource stats for an agent",
+	Long: `Display recorded Docker CPU and memory stats for an agent.
+
+Stats are collected every 30 s by bcd while the agent is running with a
+Docker runtime backend. They are stored in .bc/state.db.
+
+Examples:
+  bc agent stats eng-01              # Human-readable table
+  bc agent stats eng-01 --json       # JSON output
+  bc agent stats eng-01 --limit 50   # Show more records`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAgentStats,
+}
+
+func runAgentStats(cmd *cobra.Command, args []string) error {
+	ws, err := getWorkspace()
+	if err != nil {
+		return errNotInWorkspace(err)
+	}
+
+	agentName := args[0]
+	mgr := newAgentManager(ws)
+	if loadErr := mgr.LoadState(); loadErr != nil {
+		log.Warn("failed to load agent state", "error", loadErr)
+	}
+
+	records, err := mgr.QueryAgentStats(agentName, agentStatsLimit)
+	if err != nil {
+		return fmt.Errorf("query stats: %w", err)
+	}
+
+	if agentStatsJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if records == nil {
+			records = []*agent.AgentStatsRecord{}
+		}
+		return enc.Encode(records)
+	}
+
+	if len(records) == 0 {
+		fmt.Printf("No stats recorded for agent %s.\n", agentName)
+		fmt.Println("Stats are collected when the agent is running with runtime=docker.")
+		return nil
+	}
+
+	fmt.Printf("Stats for %s (newest first):\n\n", agentName)
+	fmt.Printf("%-20s  %6s  %8s  %8s  %8s  %8s\n",
+		"Time", "CPU%", "Mem(MB)", "MemLim", "NetRx", "NetTx")
+	fmt.Println(strings.Repeat("-", 72))
+	for _, r := range records {
+		fmt.Printf("%-20s  %6.1f  %8.1f  %8.1f  %8.1f  %8.1f\n",
+			r.CollectedAt.Format("2006-01-02 15:04:05"),
+			r.CPUPct, r.MemUsedMB, r.MemLimitMB, r.NetRxMB, r.NetTxMB)
+	}
 	return nil
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -899,6 +899,13 @@ func (m *Manager) SpawnAgentWithOptions(opts SpawnOptions) (*Agent, error) {
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 
+	// Write workspace-level Claude Code hook settings so agents emit state events.
+	if wsPath != "" {
+		if err := WriteWorkspaceHookSettings(wsPath); err != nil {
+			log.Debug("failed to write hook settings", "workspace", wsPath, "error", err)
+		}
+	}
+
 	// Start log streaming via pipe-pane
 	agent.LogFile = m.setupLogPipe(name, wsPath)
 
@@ -1953,6 +1960,22 @@ func (m *Manager) Tmux() *tmux.Manager {
 		return tb.TmuxManager()
 	}
 	return nil
+}
+
+// saveAgentStats persists a Docker stats sample via the SQLite store.
+func (m *Manager) saveAgentStats(rec *AgentStatsRecord) error {
+	if m.store == nil {
+		return fmt.Errorf("no store available")
+	}
+	return m.store.SaveStats(rec)
+}
+
+// QueryAgentStats returns up to limit recent stats records for the named agent.
+func (m *Manager) QueryAgentStats(agentName string, limit int) ([]*AgentStatsRecord, error) {
+	if m.store == nil {
+		return nil, fmt.Errorf("no store available")
+	}
+	return m.store.QueryStats(agentName, limit)
 }
 
 // Close closes the SQLite store. Call when done with the manager.

--- a/pkg/agent/hooks.go
+++ b/pkg/agent/hooks.go
@@ -1,0 +1,154 @@
+package agent
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// HookEvent is a Claude Code lifecycle hook event type.
+type HookEvent string
+
+const (
+	// HookEventPreToolUse fires before each tool call — agent is actively working.
+	HookEventPreToolUse HookEvent = "pre_tool_use"
+	// HookEventPostToolUse fires after each tool call — agent may be idle.
+	HookEventPostToolUse HookEvent = "post_tool_use"
+	// HookEventStop fires when Claude Code exits — agent is stopped.
+	HookEventStop HookEvent = "stop"
+)
+
+// hookEventStateMap maps hook events to the target agent state.
+var hookEventStateMap = map[HookEvent]State{
+	HookEventPreToolUse:  StateWorking,
+	HookEventPostToolUse: StateIdle,
+	HookEventStop:        StateStopped,
+}
+
+// StateForHookEvent returns the target agent State for a hook event.
+// Returns false if the event is unknown.
+func StateForHookEvent(ev HookEvent) (State, bool) {
+	s, ok := hookEventStateMap[ev]
+	return s, ok
+}
+
+// hookEventFile is the filename written by hook scripts to signal a state event.
+const hookEventFile = "hook_event"
+
+// hookEventPath returns the path of the hook event file for an agent.
+func hookEventPath(stateDir, agentName string) string {
+	return filepath.Join(stateDir, agentName, hookEventFile)
+}
+
+// claudeSettings is the minimal shape of .claude/settings.json used by Claude Code.
+type claudeSettings struct {
+	Hooks map[string][]claudeHookMatcher `json:"hooks,omitempty"`
+}
+
+type claudeHookMatcher struct {
+	Matcher string       `json:"matcher,omitempty"`
+	Hooks   []claudeHook `json:"hooks"`
+}
+
+type claudeHook struct {
+	Type    string `json:"type"`
+	Command string `json:"command"`
+}
+
+// WriteWorkspaceHookSettings writes .claude/settings.json to the workspace root
+// so Claude Code agents automatically emit state events to bcd.
+//
+// The hook scripts write to .bc/agents/$BC_AGENT_ID/hook_event (file-based, works
+// in both tmux and Docker without network configuration). The StatsCollector in
+// bcd consumes those files on each poll cycle.
+//
+// This is idempotent: if settings.json already exists the hooks section is merged.
+func WriteWorkspaceHookSettings(workspaceRoot string) error {
+	claudeDir := filepath.Join(workspaceRoot, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		return fmt.Errorf("create .claude dir: %w", err)
+	}
+
+	// Each hook writes the event name into .bc/agents/$BC_AGENT_ID/hook_event.
+	// Using printf avoids a newline; the file is consumed and deleted by bcd.
+	hookCmd := func(event HookEvent) string {
+		return fmt.Sprintf(
+			`printf '%%s' %q > "${BC_WORKSPACE}/.bc/agents/${BC_AGENT_ID}/%s" 2>/dev/null || true`,
+			string(event), hookEventFile,
+		)
+	}
+
+	settings := claudeSettings{
+		Hooks: map[string][]claudeHookMatcher{
+			"PreToolUse": {{
+				Hooks: []claudeHook{{Type: "command", Command: hookCmd(HookEventPreToolUse)}},
+			}},
+			"PostToolUse": {{
+				Hooks: []claudeHook{{Type: "command", Command: hookCmd(HookEventPostToolUse)}},
+			}},
+			"Stop": {{
+				Hooks: []claudeHook{{Type: "command", Command: hookCmd(HookEventStop)}},
+			}},
+		},
+	}
+
+	settingsPath := filepath.Join(claudeDir, "settings.json")
+
+	// Merge if file already exists so we don't clobber user customisations.
+	if existing, err := loadClaudeSettings(settingsPath); err == nil {
+		mergeHooks(existing, settings.Hooks)
+		data, marshalErr := json.MarshalIndent(existing, "", "  ")
+		if marshalErr != nil {
+			return fmt.Errorf("marshal hook settings: %w", marshalErr)
+		}
+		return os.WriteFile(settingsPath, data, 0600)
+	}
+
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal hook settings: %w", err)
+	}
+	return os.WriteFile(settingsPath, data, 0600)
+}
+
+// loadClaudeSettings reads an existing .claude/settings.json.
+func loadClaudeSettings(path string) (*claudeSettings, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is workspace-relative, caller-controlled
+	if err != nil {
+		return nil, err
+	}
+	var s claudeSettings
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+// mergeHooks adds bc hook entries to an existing settings struct,
+// preserving any existing hooks the user has set.
+func mergeHooks(dst *claudeSettings, src map[string][]claudeHookMatcher) {
+	if dst.Hooks == nil {
+		dst.Hooks = make(map[string][]claudeHookMatcher)
+	}
+	for event, matchers := range src {
+		if _, exists := dst.Hooks[event]; !exists {
+			dst.Hooks[event] = matchers
+		}
+		// If the event already has matchers, skip to avoid duplicating bc hooks.
+	}
+}
+
+// ConsumeHookEvent reads and removes the hook event file for an agent,
+// returning the event if one was written. Returns "" if no event is pending.
+func ConsumeHookEvent(stateDir, agentName string) (HookEvent, bool) {
+	path := hookEventPath(stateDir, agentName)
+	data, err := os.ReadFile(path) //nolint:gosec // path is internal state dir
+	if err != nil {
+		return "", false
+	}
+	_ = os.Remove(path) //nolint:errcheck // best-effort
+	ev := HookEvent(data)
+	_, ok := hookEventStateMap[ev]
+	return ev, ok
+}

--- a/pkg/agent/hooks_test.go
+++ b/pkg/agent/hooks_test.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStateForHookEvent(t *testing.T) {
+	tests := []struct {
+		event HookEvent
+		want  State
+		ok    bool
+	}{
+		{HookEventPreToolUse, StateWorking, true},
+		{HookEventPostToolUse, StateIdle, true},
+		{HookEventStop, StateStopped, true},
+		{HookEvent("unknown"), "", false},
+		{HookEvent(""), "", false},
+	}
+	for _, tc := range tests {
+		got, ok := StateForHookEvent(tc.event)
+		if ok != tc.ok {
+			t.Errorf("StateForHookEvent(%q) ok=%v, want %v", tc.event, ok, tc.ok)
+		}
+		if ok && got != tc.want {
+			t.Errorf("StateForHookEvent(%q) = %q, want %q", tc.event, got, tc.want)
+		}
+	}
+}
+
+func TestWriteWorkspaceHookSettings_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteWorkspaceHookSettings(dir); err != nil {
+		t.Fatalf("WriteWorkspaceHookSettings: %v", err)
+	}
+	settingsPath := filepath.Join(dir, ".claude", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("settings.json not created: %v", err)
+	}
+	content := string(data)
+	for _, event := range []string{"PreToolUse", "PostToolUse", "Stop"} {
+		if !strings.Contains(content, event) {
+			t.Errorf("settings.json missing hook event %q", event)
+		}
+	}
+	if !strings.Contains(content, hookEventFile) {
+		t.Errorf("settings.json missing hook_event filename reference")
+	}
+}
+
+func TestWriteWorkspaceHookSettings_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 3 {
+		if err := WriteWorkspaceHookSettings(dir); err != nil {
+			t.Fatalf("call %d: WriteWorkspaceHookSettings: %v", i, err)
+		}
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+	if err != nil {
+		t.Fatalf("settings.json not found: %v", err)
+	}
+	// Should only contain each hook section once.
+	count := strings.Count(string(data), "PreToolUse")
+	if count != 1 {
+		t.Errorf("PreToolUse appears %d times, want 1", count)
+	}
+}
+
+func TestWriteWorkspaceHookSettings_MergesExisting(t *testing.T) {
+	dir := t.TempDir()
+	claudeDir := filepath.Join(dir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	existing := `{"hooks":{"Notification":[{"hooks":[{"type":"command","command":"echo hi"}]}]}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(existing), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteWorkspaceHookSettings(dir); err != nil {
+		t.Fatalf("WriteWorkspaceHookSettings: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(claudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("settings.json not found: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "Notification") {
+		t.Error("existing Notification hook was removed during merge")
+	}
+	if !strings.Contains(content, "PreToolUse") {
+		t.Error("PreToolUse hook not added during merge")
+	}
+}
+
+func TestConsumeHookEvent_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	ev, ok := ConsumeHookEvent(dir, "alice")
+	if ok {
+		t.Errorf("expected ok=false, got event=%q", ev)
+	}
+}
+
+func TestConsumeHookEvent_Valid(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "alice")
+	if err := os.MkdirAll(agentDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, hookEventFile), []byte("pre_tool_use"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ev, ok := ConsumeHookEvent(dir, "alice")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if ev != HookEventPreToolUse {
+		t.Errorf("event = %q, want %q", ev, HookEventPreToolUse)
+	}
+	// File should be deleted after consumption.
+	if _, err := os.Stat(filepath.Join(agentDir, hookEventFile)); err == nil {
+		t.Error("hook event file should be deleted after consumption")
+	}
+}
+
+func TestConsumeHookEvent_Unknown(t *testing.T) {
+	dir := t.TempDir()
+	agentDir := filepath.Join(dir, "bob")
+	if err := os.MkdirAll(agentDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(agentDir, hookEventFile), []byte("bogus_event"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	_, ok := ConsumeHookEvent(dir, "bob")
+	if ok {
+		t.Error("expected ok=false for unknown event")
+	}
+}

--- a/pkg/agent/stats.go
+++ b/pkg/agent/stats.go
@@ -1,0 +1,209 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/log"
+)
+
+// AgentStatsRecord holds a single Docker stats sample for an agent.
+type AgentStatsRecord struct {
+	CollectedAt  time.Time `json:"collected_at"`
+	AgentName    string    `json:"agent_name"`
+	CPUPct       float64   `json:"cpu_pct"`
+	MemUsedMB    float64   `json:"mem_used_mb"`
+	MemLimitMB   float64   `json:"mem_limit_mb"`
+	NetRxMB      float64   `json:"net_rx_mb"`
+	NetTxMB      float64   `json:"net_tx_mb"`
+	BlockReadMB  float64   `json:"block_read_mb"`
+	BlockWriteMB float64   `json:"block_write_mb"`
+}
+
+// dockerStatsJSON is the raw JSON emitted by `docker stats --format json --no-stream`.
+type dockerStatsJSON struct {
+	Name        string `json:"Name"`
+	CPUPerc     string `json:"CPUPerc"`     // "0.50%"
+	MemUsage    string `json:"MemUsage"`    // "150MiB / 7.77GiB"
+	NetIO       string `json:"NetIO"`       // "1.5kB / 500B"
+	BlockIO     string `json:"BlockIO"`     // "10MB / 5MB"
+}
+
+// statsCollectInterval is how often Docker stats are polled.
+const statsCollectInterval = 30 * time.Second
+
+// StatsCollector collects Docker container stats and processes hook events
+// for all running agents. It runs as a background goroutine in bcd.
+type StatsCollector struct {
+	mgr *Manager
+}
+
+// NewStatsCollector creates a StatsCollector backed by the given Manager.
+func NewStatsCollector(mgr *Manager) *StatsCollector {
+	return &StatsCollector{mgr: mgr}
+}
+
+// Run starts collecting stats until ctx is cancelled.
+// It polls every statsCollectInterval.
+func (c *StatsCollector) Run(ctx context.Context) {
+	ticker := time.NewTicker(statsCollectInterval)
+	defer ticker.Stop()
+
+	// Do an immediate pass on startup.
+	c.collect(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.collect(ctx)
+		}
+	}
+}
+
+// collect performs one poll: consume hook events then gather Docker stats.
+func (c *StatsCollector) collect(ctx context.Context) {
+	c.consumeAllHookEvents()
+	c.collectDockerStats(ctx)
+}
+
+// consumeAllHookEvents drains pending hook event files for every agent and
+// updates the manager's in-memory + persisted state.
+func (c *StatsCollector) consumeAllHookEvents() {
+	agents := c.mgr.ListAgents()
+	for _, a := range agents {
+		ev, ok := ConsumeHookEvent(c.mgr.stateDir, a.Name)
+		if !ok {
+			continue
+		}
+		targetState, known := StateForHookEvent(ev)
+		if !known {
+			continue
+		}
+		if err := c.mgr.UpdateAgentState(a.Name, targetState, ""); err != nil {
+			// Transition may be invalid (e.g., already stopped) — log at debug.
+			log.Debug("hook state update skipped", "agent", a.Name, "event", ev, "error", err)
+		} else {
+			log.Debug("hook state applied", "agent", a.Name, "event", ev, "state", targetState)
+		}
+	}
+}
+
+// collectDockerStats fetches stats for all docker-backend agents.
+func (c *StatsCollector) collectDockerStats(ctx context.Context) {
+	agents := c.mgr.ListAgents()
+	for _, a := range agents {
+		if a.RuntimeBackend != "docker" {
+			continue
+		}
+		if a.State == StateStopped || a.State == StateError {
+			continue
+		}
+		rec, err := fetchDockerStats(ctx, a.Name)
+		if err != nil {
+			log.Debug("docker stats unavailable", "agent", a.Name, "error", err)
+			continue
+		}
+		if err := c.mgr.saveAgentStats(rec); err != nil {
+			log.Warn("failed to save agent stats", "agent", a.Name, "error", err)
+		}
+	}
+}
+
+// fetchDockerStats runs `docker stats --no-stream --format json <name>` and
+// parses the result into an AgentStatsRecord.
+func fetchDockerStats(ctx context.Context, containerName string) (*AgentStatsRecord, error) {
+	cmd := exec.CommandContext(ctx, "docker", "stats", "--no-stream", "--format", "json", containerName)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker stats: %w", err)
+	}
+
+	// docker stats outputs one JSON object per line; we want the first non-empty line.
+	var raw dockerStatsJSON
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if err := json.Unmarshal([]byte(line), &raw); err != nil {
+			return nil, fmt.Errorf("parse docker stats json: %w", err)
+		}
+		break
+	}
+
+	rec := &AgentStatsRecord{
+		AgentName:   containerName,
+		CollectedAt: time.Now(),
+	}
+	rec.CPUPct = parseDockerPct(raw.CPUPerc)
+	rec.MemUsedMB, rec.MemLimitMB = parseDockerMemory(raw.MemUsage)
+	rec.NetRxMB, rec.NetTxMB = parseDockerIO(raw.NetIO)
+	rec.BlockReadMB, rec.BlockWriteMB = parseDockerIO(raw.BlockIO)
+	return rec, nil
+}
+
+// parseDockerPct converts "0.50%" → 0.50.
+func parseDockerPct(s string) float64 {
+	s = strings.TrimSuffix(strings.TrimSpace(s), "%")
+	v, _ := strconv.ParseFloat(s, 64)
+	return v
+}
+
+// parseDockerMemory converts "150MiB / 7.77GiB" → (used, limit) in MB.
+func parseDockerMemory(s string) (float64, float64) {
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	return parseDockerBytes(strings.TrimSpace(parts[0])), parseDockerBytes(strings.TrimSpace(parts[1]))
+}
+
+// parseDockerIO converts "1.5MB / 500kB" → (rx, tx) in MB.
+func parseDockerIO(s string) (float64, float64) {
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) != 2 {
+		return 0, 0
+	}
+	return parseDockerBytes(strings.TrimSpace(parts[0])), parseDockerBytes(strings.TrimSpace(parts[1]))
+}
+
+// parseDockerBytes converts human-readable Docker byte strings to megabytes.
+// Supports B, kB, MB, GB, MiB, GiB, KiB suffixes.
+func parseDockerBytes(s string) float64 {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "--" {
+		return 0
+	}
+	multipliers := []struct {
+		suffix string
+		factor float64
+	}{
+		{"GiB", 1024},
+		{"MiB", 1},
+		{"KiB", 1.0 / 1024},
+		{"GB", 1000},
+		{"MB", 1},
+		{"kB", 1.0 / 1000},
+		{"KB", 1.0 / 1000},
+		{"B", 1.0 / (1024 * 1024)},
+	}
+	for _, m := range multipliers {
+		if strings.HasSuffix(s, m.suffix) {
+			num, err := strconv.ParseFloat(strings.TrimSuffix(s, m.suffix), 64)
+			if err != nil {
+				return 0
+			}
+			return num * m.factor
+		}
+	}
+	// Fallback: assume bytes.
+	num, _ := strconv.ParseFloat(s, 64)
+	return num / (1024 * 1024)
+}

--- a/pkg/agent/stats_test.go
+++ b/pkg/agent/stats_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseDockerPct(t *testing.T) {
+	tests := []struct{ in string; want float64 }{
+		{"0.50%", 0.50},
+		{"100.00%", 100.0},
+		{"--", 0},
+		{"", 0},
+	}
+	for _, tc := range tests {
+		got := parseDockerPct(tc.in)
+		if got != tc.want {
+			t.Errorf("parseDockerPct(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseDockerBytes(t *testing.T) {
+	tests := []struct {
+		in   string
+		want float64 // MB
+	}{
+		{"1MB", 1},
+		{"1MiB", 1},
+		{"1024kB", 1.024},
+		{"1GiB", 1024},
+		{"512B", 512.0 / (1024 * 1024)},
+		{"--", 0},
+		{"", 0},
+	}
+	for _, tc := range tests {
+		got := parseDockerBytes(tc.in)
+		if got < tc.want*0.99 || got > tc.want*1.01 {
+			t.Errorf("parseDockerBytes(%q) = %v, want ~%v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseDockerMemory(t *testing.T) {
+	used, limit := parseDockerMemory("150MiB / 7.77GiB")
+	if used < 149 || used > 151 {
+		t.Errorf("used = %v, want ~150 MB", used)
+	}
+	if limit < 7000 || limit > 8000 {
+		t.Errorf("limit = %v, want ~7.77 GiB in MB", limit)
+	}
+}
+
+func TestParseDockerIO(t *testing.T) {
+	rx, tx := parseDockerIO("1.5MB / 500kB")
+	if rx < 1.4 || rx > 1.6 {
+		t.Errorf("rx = %v, want ~1.5 MB", rx)
+	}
+	if tx < 0.4 || tx > 0.6 {
+		t.Errorf("tx = %v, want ~0.5 MB", tx)
+	}
+}
+
+func TestSaveAndQueryStats(t *testing.T) {
+	store, err := NewSQLiteStore(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	rec := &AgentStatsRecord{
+		AgentName:   "eng-01",
+		CollectedAt: time.Now().UTC().Truncate(time.Second),
+		CPUPct:      12.5,
+		MemUsedMB:   256.0,
+		MemLimitMB:  1024.0,
+		NetRxMB:     0.1,
+		NetTxMB:     0.05,
+	}
+	if err := store.SaveStats(rec); err != nil {
+		t.Fatalf("SaveStats: %v", err)
+	}
+
+	records, err := store.QueryStats("eng-01", 10)
+	if err != nil {
+		t.Fatalf("QueryStats: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("len(records) = %d, want 1", len(records))
+	}
+	got := records[0]
+	if got.AgentName != rec.AgentName {
+		t.Errorf("AgentName = %q, want %q", got.AgentName, rec.AgentName)
+	}
+	if got.CPUPct != rec.CPUPct {
+		t.Errorf("CPUPct = %v, want %v", got.CPUPct, rec.CPUPct)
+	}
+	if got.MemUsedMB != rec.MemUsedMB {
+		t.Errorf("MemUsedMB = %v, want %v", got.MemUsedMB, rec.MemUsedMB)
+	}
+}
+
+func TestQueryStats_Empty(t *testing.T) {
+	store, err := NewSQLiteStore(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	records, err := store.QueryStats("nobody", 10)
+	if err != nil {
+		t.Fatalf("QueryStats: %v", err)
+	}
+	if len(records) != 0 {
+		t.Errorf("expected 0 records, got %d", len(records))
+	}
+}
+
+func TestQueryStats_LimitRespected(t *testing.T) {
+	store, err := NewSQLiteStore(t.TempDir() + "/state.db")
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	for i := range 5 {
+		rec := &AgentStatsRecord{
+			AgentName:   "worker",
+			CollectedAt: time.Now().Add(time.Duration(i) * time.Second),
+			CPUPct:      float64(i),
+		}
+		if err := store.SaveStats(rec); err != nil {
+			t.Fatalf("SaveStats #%d: %v", i, err)
+		}
+	}
+	records, err := store.QueryStats("worker", 3)
+	if err != nil {
+		t.Fatalf("QueryStats: %v", err)
+	}
+	if len(records) != 3 {
+		t.Errorf("len(records) = %d, want 3", len(records))
+	}
+}

--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -71,6 +71,27 @@ func createAgentsTable(d *db.DB) error {
 	_, _ = d.Exec(`ALTER TABLE agents ADD COLUMN created_at TEXT`)                //nolint:errcheck // ignore if already exists
 	_, _ = d.Exec(`ALTER TABLE agents ADD COLUMN stopped_at TEXT`)                //nolint:errcheck // ignore if already exists
 
+	// agent_stats: time-series Docker resource samples.
+	statsSchema := `
+		CREATE TABLE IF NOT EXISTS agent_stats (
+			id            INTEGER PRIMARY KEY AUTOINCREMENT,
+			agent_name    TEXT    NOT NULL,
+			collected_at  TEXT    NOT NULL,
+			cpu_pct       REAL    NOT NULL DEFAULT 0,
+			mem_used_mb   REAL    NOT NULL DEFAULT 0,
+			mem_limit_mb  REAL    NOT NULL DEFAULT 0,
+			net_rx_mb     REAL    NOT NULL DEFAULT 0,
+			net_tx_mb     REAL    NOT NULL DEFAULT 0,
+			block_read_mb  REAL   NOT NULL DEFAULT 0,
+			block_write_mb REAL   NOT NULL DEFAULT 0
+		);
+		CREATE INDEX IF NOT EXISTS idx_agent_stats_agent ON agent_stats(agent_name);
+		CREATE INDEX IF NOT EXISTS idx_agent_stats_time  ON agent_stats(collected_at);
+	`
+	if _, err := d.Exec(statsSchema); err != nil {
+		return fmt.Errorf("create agent_stats table: %w", err)
+	}
+
 	return nil
 }
 
@@ -369,4 +390,51 @@ func deref(s *string) string {
 		return ""
 	}
 	return *s
+}
+
+// SaveStats inserts a single AgentStatsRecord into the agent_stats table.
+func (s *SQLiteStore) SaveStats(rec *AgentStatsRecord) error {
+	_, err := s.db.Exec(`
+		INSERT INTO agent_stats
+		(agent_name, collected_at, cpu_pct, mem_used_mb, mem_limit_mb,
+		 net_rx_mb, net_tx_mb, block_read_mb, block_write_mb)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		rec.AgentName, rec.CollectedAt.Format(time.RFC3339),
+		rec.CPUPct, rec.MemUsedMB, rec.MemLimitMB,
+		rec.NetRxMB, rec.NetTxMB, rec.BlockReadMB, rec.BlockWriteMB,
+	)
+	return err
+}
+
+// QueryStats returns the most recent limit stats rows for an agent, newest first.
+func (s *SQLiteStore) QueryStats(agentName string, limit int) ([]*AgentStatsRecord, error) {
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.db.Query(`
+		SELECT agent_name, collected_at, cpu_pct, mem_used_mb, mem_limit_mb,
+		       net_rx_mb, net_tx_mb, block_read_mb, block_write_mb
+		FROM agent_stats
+		WHERE agent_name = ?
+		ORDER BY collected_at DESC
+		LIMIT ?`, agentName, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var records []*AgentStatsRecord
+	for rows.Next() {
+		var rec AgentStatsRecord
+		var collectedAt string
+		if err := rows.Scan(
+			&rec.AgentName, &collectedAt, &rec.CPUPct, &rec.MemUsedMB, &rec.MemLimitMB,
+			&rec.NetRxMB, &rec.NetTxMB, &rec.BlockReadMB, &rec.BlockWriteMB,
+		); err != nil {
+			return nil, err
+		}
+		rec.CollectedAt, _ = time.Parse(time.RFC3339, collectedAt)
+		records = append(records, &rec)
+	}
+	return records, rows.Err()
 }

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -163,6 +164,46 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
+
+	case r.Method == http.MethodPost && action == "hook":
+		// Receive a Claude Code hook event and update agent state.
+		var req struct {
+			Event string `json:"event"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		ev := agent.HookEvent(req.Event)
+		targetState, ok := agent.StateForHookEvent(ev)
+		if !ok {
+			httpError(w, "unknown event: "+req.Event, http.StatusBadRequest)
+			return
+		}
+		if err := h.svc.Manager().UpdateAgentState(name, targetState, ""); err != nil {
+			// Transition may be invalid (agent stopped, etc.) — treat as no-op.
+			writeJSON(w, http.StatusOK, map[string]any{"ok": true, "skipped": true})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+
+	case r.Method == http.MethodGet && action == "stats":
+		// Return recent Docker stats samples for this agent.
+		limit := 20
+		if lStr := r.URL.Query().Get("limit"); lStr != "" {
+			if n, err := strconv.Atoi(lStr); err == nil && n > 0 {
+				limit = n
+			}
+		}
+		records, err := h.svc.Manager().QueryAgentStats(name, limit)
+		if err != nil {
+			httpError(w, "stats unavailable: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if records == nil {
+			records = []*agent.AgentStatsRecord{}
+		}
+		writeJSON(w, http.StatusOK, records)
 
 	default:
 		httpError(w, "not found", http.StatusNotFound)


### PR DESCRIPTION
## Summary

- **Claude Code hook integration**: `WriteWorkspaceHookSettings` writes `.claude/settings.json` to the workspace root with `PreToolUse`, `PostToolUse`, and `Stop` hooks. Hooks write the event name to `.bc/agents/<name>/hook_event` (file-based — no network config needed, works in both tmux and Docker). Called automatically on first `SpawnAgentWithOptions`.
- **HTTP hook endpoint**: `POST /api/agents/{name}/hook {"event":"pre_tool_use|post_tool_use|stop"}` updates agent state directly — for tmux agents where bcd is reachable over localhost.
- **Docker stats collection**: `StatsCollector` polls `docker stats --no-stream --format json` every 30 s for all docker-backend agents. Also calls `ConsumeHookEvent` on every tick to drain pending hook files.
- **SQLite persistence**: New `agent_stats` table stores CPU%, mem used/limit, net I/O, block I/O. `SaveStats`/`QueryStats` on `SQLiteStore`; `Manager.QueryAgentStats` wrapper.
- **`bcd` wiring**: `StatsCollector` started as background goroutine in `cmd/bcd/main.go`.
- **CLI**: `bc agent stats <name>` shows a CPU/mem table (or `--json`). `GET /api/agents/{name}/stats?limit=N` returns JSON.

## State transitions from hooks

| Hook event | Agent state |
|------------|-------------|
| `pre_tool_use` | `working` |
| `post_tool_use` | `idle` |
| `stop` | `stopped` |

## Test plan

- [x] `go test -race ./pkg/agent/` — all pass (hooks_test.go, stats_test.go)
- [ ] Spawn a Docker agent; observe `.claude/settings.json` created in workspace
- [ ] Trigger a tool use; verify `hook_event` file written then consumed by bcd
- [ ] `bc agent stats <name>` shows rows after agent runs for 30s+
- [ ] `GET /api/agents/<name>/stats` returns JSON array

Closes #1995

🤖 Generated with [Claude Code](https://claude.com/claude-code)