### PR TITLE
fix: daemon detection — wrong port, localhost IPv6, no addr file (#2015)

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -200,6 +200,7 @@ func run(addr, wsRoot string) error {
 	if addr != "" {
 		cfg.Addr = addr
 	}
+	cfg.AddrFile = filepath.Join(ws.RootDir, ".bc", "bcd.addr")
 
 	srv := server.New(cfg, svc, hub, server.WebDist())
 	return srv.Start(ctx)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,17 +18,13 @@ import (
 	"time"
 )
 
-// DefaultSocketPath returns the default Unix socket path for bcd.
-func DefaultSocketPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "/tmp/bcd.sock"
-	}
-	return filepath.Join(home, ".bc", "bcd.sock")
-}
-
 // DefaultHTTPAddr is the fallback HTTP address for bcd.
-const DefaultHTTPAddr = "http://localhost:4880"
+// Uses 127.0.0.1 (IPv4 loopback) to match the server's bind address and avoid
+// localhost→::1 (IPv6) resolution failures on dual-stack systems.
+const DefaultHTTPAddr = "http://127.0.0.1:9374"
+
+// AddrFileName is the name of the file written by bcd containing its listen address.
+const AddrFileName = "bcd.addr"
 
 // Client is the HTTP client for the bcd daemon.
 type Client struct {
@@ -104,12 +100,39 @@ func (c *Client) get(ctx context.Context, path string, result any) error {
 }
 
 // discoverDaemon tries to find the daemon address.
-// Priority: BC_DAEMON_ADDR env > default HTTP address.
+// Priority: BC_DAEMON_ADDR env > bcd.addr file in workspace .bc/ > default HTTP address.
 func discoverDaemon() string {
 	if addr := os.Getenv("BC_DAEMON_ADDR"); addr != "" {
 		return addr
 	}
+	if addr := readAddrFile(); addr != "" {
+		return addr
+	}
 	return DefaultHTTPAddr
+}
+
+// readAddrFile walks up from the current directory looking for a .bc/bcd.addr file
+// written by bcd on startup, and returns the address it contains.
+func readAddrFile() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		addrPath := filepath.Join(dir, ".bc", AddrFileName)
+		if data, err := os.ReadFile(addrPath); err == nil {
+			addr := strings.TrimSpace(string(data))
+			if addr != "" {
+				return addr
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return ""
 }
 
 // IsDaemonNotRunning returns true if the error indicates the daemon is not running.

--- a/server/server.go
+++ b/server/server.go
@@ -17,6 +17,8 @@ import (
 	"io/fs"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/rpuneet/bc/pkg/agent"
@@ -38,8 +40,9 @@ const defaultAddr = "127.0.0.1:9374"
 
 // Config holds server configuration.
 type Config struct {
-	Addr string // default "127.0.0.1:9374"
-	CORS bool   // enable permissive CORS headers (safe for loopback)
+	Addr     string // default "127.0.0.1:9374"
+	AddrFile string // path to write the resolved listen address on startup (e.g. .bc/bcd.addr)
+	CORS     bool   // enable permissive CORS headers (safe for loopback)
 }
 
 // DefaultConfig returns the default server configuration.
@@ -65,6 +68,7 @@ type Services struct {
 type Server struct {
 	httpServer *http.Server
 	handler    http.Handler
+	addrFile   string
 	addr       string
 }
 
@@ -142,8 +146,9 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 
 	return &Server{
-		addr:    cfg.Addr,
-		handler: handler,
+		addr:     cfg.Addr,
+		addrFile: cfg.AddrFile,
+		handler:  handler,
 		httpServer: &http.Server{
 			Addr:        cfg.Addr,
 			Handler:     handler,
@@ -176,6 +181,16 @@ func (s *Server) Start(ctx context.Context) error {
 
 	log.Info("bcd listening", "addr", s.addr)
 
+	// Write the resolved address to bcd.addr so the CLI can discover it.
+	if s.addrFile != "" {
+		httpAddr := "http://" + s.addr
+		if err := writeAddrFile(s.addrFile, httpAddr); err != nil {
+			log.Warn("failed to write addr file", "path", s.addrFile, "error", err)
+		} else {
+			defer os.Remove(s.addrFile) //nolint:errcheck // best-effort cleanup
+		}
+	}
+
 	go func() {
 		<-ctx.Done()
 		shutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -189,4 +204,11 @@ func (s *Server) Start(ctx context.Context) error {
 		return fmt.Errorf("serve: %w", err)
 	}
 	return nil
+}
+
+func writeAddrFile(path, addr string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(addr+"\n"), 0600)
 }


### PR DESCRIPTION
## Summary

Three root causes why CLI said "bcd not running" even when bcd was healthy:

1. **Wrong port**: `DefaultHTTPAddr` used `localhost:4880` but `bcd` listens on `127.0.0.1:9374`
2. **IPv6 resolution**: `localhost` resolves to `::1` on dual-stack systems but bcd binds IPv4-only (`127.0.0.1`), causing "connection refused"
3. **No addr file**: CLI had no way to discover the actual address bcd bound to

## Fix

- `pkg/client/client.go`: Change `DefaultHTTPAddr` to `http://127.0.0.1:9374`
- `server/server.go`: Add `AddrFile` to `Config`; write `http://<addr>` to `bcd.addr` after binding, remove on shutdown
- `pkg/client/client.go`: `discoverDaemon()` walks up from CWD looking for `.bc/bcd.addr` before falling back to default
- `cmd/bcd/main.go`: Set `cfg.AddrFile = <workspace>/.bc/bcd.addr`

## Test plan

- [ ] `go build ./...` passes
- [ ] Start bcd; verify `.bc/bcd.addr` contains `http://127.0.0.1:9374`
- [ ] `bc status` works without `BC_DAEMON_ADDR` set
- [ ] Stop bcd; verify `.bc/bcd.addr` is removed
- [ ] `bc status` with bcd stopped prints "bcd is not running"
- [ ] `BC_DAEMON_ADDR=http://...` env override still works

Closes #2015

🤖 Generated with [Claude Code](https://claude.com/claude-code)