### PR TITLE
fix: agent store uses unified bc.db instead of state.db

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -17,7 +17,6 @@ import (
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/container"
-	"github.com/rpuneet/bc/pkg/cost"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/provider"
 	"github.com/rpuneet/bc/pkg/ui"
@@ -1075,24 +1074,15 @@ Examples:
 func runAgentCost(cmd *cobra.Command, args []string) error {
 	agentName := args[0]
 
-	ws, err := getWorkspace()
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
-		return errNotInWorkspace(err)
+		return err
 	}
 
-	// Try to get cost data
-	costStore := newCostStore(ws.RootDir)
-	if costStore == nil {
+	summary, costErr := c.Agents.Cost(cmd.Context(), agentName)
+	if costErr != nil {
 		fmt.Printf("Agent: %s\n", agentName)
 		fmt.Println("No cost data available (cost tracking not enabled)")
-		return nil
-	}
-	defer func() { _ = costStore.Close() }()
-
-	summary, costErr := costStore.AgentSummary(agentName)
-	if costErr != nil || summary == nil {
-		fmt.Printf("Agent: %s\n", agentName)
-		fmt.Println("No cost data recorded yet")
 		return nil
 	}
 
@@ -1101,7 +1091,7 @@ func runAgentCost(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Output tokens: %d\n", summary.OutputTokens)
 	fmt.Printf("  Total tokens:  %d\n", summary.TotalTokens)
 	fmt.Printf("  Total cost:    $%.4f\n", summary.TotalCostUSD)
-	fmt.Printf("  Requests:      %d\n", summary.RecordCount)
+	fmt.Printf("  Requests:      %d\n", summary.RequestCount)
 
 	return nil
 }
@@ -1146,21 +1136,6 @@ func runAgentLogs(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-// newCostStore opens the cost store, returning nil if unavailable.
-func newCostStore(workspacePath string) costStoreCloser {
-	cs := cost.NewStore(workspacePath)
-	if err := cs.Open(); err != nil {
-		return nil
-	}
-	return cs
-}
-
-// costStoreCloser wraps cost.Store for agent cost queries.
-type costStoreCloser interface {
-	AgentSummary(agentID string) (*cost.Summary, error)
-	Close() error
 }
 
 // agentAuthCmd manages per-agent authentication for Docker containers.
@@ -1235,7 +1210,7 @@ var agentStatsCmd = &cobra.Command{
 	Long: `Display recorded Docker CPU and memory stats for an agent.
 
 Stats are collected every 30 s by bcd while the agent is running with a
-Docker runtime backend. They are stored in .bc/state.db.
+Docker runtime backend. They are stored in .bc/bc.db.
 
 Examples:
   bc agent stats eng-01              # Human-readable table

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/client"
+	"github.com/rpuneet/bc/pkg/db"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/ui"
@@ -225,9 +226,9 @@ func getWorkspace() (*workspace.Workspace, error) {
 	return workspace.Find(cwd)
 }
 
-// stateDBPath returns the path to the workspace's state.db for events and agents.
+// stateDBPath returns the path to the workspace's unified bc.db for events and agents.
 func stateDBPath(ws *workspace.Workspace) string {
-	return filepath.Join(ws.StateDir(), "state.db")
+	return db.BCDBPath(ws.RootDir)
 }
 
 // openEventLog opens the SQLite event log for the given workspace.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -64,6 +64,7 @@ import (
 
 	"github.com/rpuneet/bc/config"
 	"github.com/rpuneet/bc/pkg/container"
+	"github.com/rpuneet/bc/pkg/db"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/provider"
 	"github.com/rpuneet/bc/pkg/runtime"
@@ -1834,8 +1835,14 @@ func (m *Manager) LoadState() error {
 		return nil
 	}
 
-	// Open SQLite store (state.db lives alongside agents dir)
-	dbPath := filepath.Join(m.stateDir, "state.db")
+	// Open SQLite store — use the unified bc.db when workspace path is known,
+	// otherwise fall back to state.db in the agents dir (tests / standalone).
+	var dbPath string
+	if m.workspacePath != "" {
+		dbPath = db.BCDBPath(m.workspacePath)
+	} else {
+		dbPath = filepath.Join(m.stateDir, "state.db")
+	}
 	store, err := NewSQLiteStore(dbPath)
 	if err != nil {
 		return fmt.Errorf("open agent store: %w", err)

--- a/pkg/agent/service_test.go
+++ b/pkg/agent/service_test.go
@@ -109,7 +109,7 @@ func TestAgentService_DeleteRequiresStopped(t *testing.T) {
 
 	svc := NewAgentService(mgr, nil, nil)
 
-	err := svc.Delete(context.Background(), "eng-1")
+	err := svc.Delete(context.Background(), "eng-1", false)
 	if err == nil {
 		t.Error("expected error when deleting running agent")
 	}
@@ -122,7 +122,7 @@ func TestAgentService_DeleteStopped(t *testing.T) {
 	pub := &mockEventPublisher{}
 	svc := NewAgentService(mgr, pub, nil)
 
-	err := svc.Delete(context.Background(), "eng-1")
+	err := svc.Delete(context.Background(), "eng-1", false)
 	if err != nil {
 		t.Fatalf("Delete: %v", err)
 	}

--- a/pkg/client/agents.go
+++ b/pkg/client/agents.go
@@ -215,6 +215,25 @@ func (a *AgentsClient) Stats(ctx context.Context, name string, limit int) ([]*Ag
 	return records, nil
 }
 
+// AgentCostSummary holds cost breakdown for an agent.
+type AgentCostSummary struct {
+	AgentID      string  `json:"agent_id"`
+	InputTokens  int64   `json:"input_tokens"`
+	OutputTokens int64   `json:"output_tokens"`
+	TotalTokens  int64   `json:"total_tokens"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	RequestCount int64   `json:"request_count"`
+}
+
+// Cost returns cost breakdown for an agent.
+func (a *AgentsClient) Cost(ctx context.Context, name string) (*AgentCostSummary, error) {
+	var summary AgentCostSummary
+	if err := a.client.get(ctx, "/api/agents/"+name+"/cost", &summary); err != nil {
+		return nil, err
+	}
+	return &summary, nil
+}
+
 // StopAll stops all running agents. Returns the number of agents stopped.
 func (a *AgentsClient) StopAll(ctx context.Context) (int, error) {
 	var result map[string]int

--- a/pkg/doctor/doctor.go
+++ b/pkg/doctor/doctor.go
@@ -271,11 +271,11 @@ func CheckDatabase(ws *workspace.Workspace) CategoryReport {
 
 	stateDir := ws.StateDir()
 
-	// state.db
+	// bc.db — agents table
 	stateDB := filepath.Join(stateDir, "bc.db")
 	cat.Items = append(cat.Items, checkSQLiteFile(stateDB, "bc.db", []string{"agents"})...)
 
-	// channels.db
+	// bc.db — channels/messages tables
 	channelsDB := filepath.Join(stateDir, "bc.db")
 	cat.Items = append(cat.Items, checkSQLiteFile(channelsDB, "bc.db", []string{"channels", "messages"})...)
 

--- a/pkg/doctor/doctor_test.go
+++ b/pkg/doctor/doctor_test.go
@@ -357,9 +357,9 @@ func TestCheckDatabase_MissingTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create state.db WITHOUT the agents table
-	stateDBPath := filepath.Join(stateDir, "state.db")
-	if err := createTestDB(t, stateDBPath /*, no tables*/); err != nil {
+	// Create bc.db WITHOUT the agents table
+	bcDBPath := filepath.Join(stateDir, "bc.db")
+	if err := createTestDB(t, bcDBPath /*, no tables*/); err != nil {
 		t.Fatal(err)
 	}
 
@@ -367,7 +367,7 @@ func TestCheckDatabase_MissingTable(t *testing.T) {
 
 	var foundMissingTable bool
 	for _, item := range cat.Items {
-		if item.Name == `state.db: table "agents"` && item.Severity == SeverityFail {
+		if item.Name == `bc.db: table "agents"` && item.Severity == SeverityFail {
 			foundMissingTable = true
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -463,6 +463,18 @@ func (s *Server) handleAgentByName(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, entries)
 
+	case r.Method == http.MethodGet && action == "cost":
+		summary, err := s.agents.Cost(r.Context(), name)
+		if err != nil {
+			httpError(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if summary == nil {
+			writeJSON(w, http.StatusOK, &agent.CostSummary{AgentID: name})
+			return
+		}
+		writeJSON(w, http.StatusOK, summary)
+
 	default:
 		httpError(w, "not found", http.StatusNotFound)
 	}

--- a/pkg/stats/stats_test.go
+++ b/pkg/stats/stats_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/rpuneet/bc/pkg/agent"
+	"github.com/rpuneet/bc/pkg/db"
 )
 
 func TestNew(t *testing.T) {
@@ -162,14 +163,15 @@ func TestSummaryNoAgentStatsSection(t *testing.T) {
 	}
 }
 
-func seedAgentsFile(t *testing.T, stateDir string, agents map[string]*agent.Agent) {
+// seedAgentsFile writes agent data to the unified bc.db for the given workspace root.
+// The workspaceRoot is the parent of the .bc directory.
+func seedAgentsFile(t *testing.T, workspaceRoot string, agents map[string]*agent.Agent) {
 	t.Helper()
-	agentsDir := filepath.Join(stateDir, "agents")
-	if err := os.MkdirAll(agentsDir, 0750); err != nil {
-		t.Fatalf("mkdir agents: %v", err)
+	bcDir := filepath.Join(workspaceRoot, ".bc")
+	if err := os.MkdirAll(filepath.Join(bcDir, "agents"), 0750); err != nil {
+		t.Fatalf("mkdir .bc/agents: %v", err)
 	}
-	// Write to agentsDir/state.db since NewWorkspaceManager uses agentsDir as stateDir
-	store, err := agent.NewSQLiteStore(filepath.Join(agentsDir, "state.db"))
+	store, err := agent.NewSQLiteStore(db.BCDBPath(workspaceRoot))
 	if err != nil {
 		t.Fatalf("NewSQLiteStore: %v", err)
 	}
@@ -180,14 +182,15 @@ func seedAgentsFile(t *testing.T, stateDir string, agents map[string]*agent.Agen
 }
 
 func TestCollectAgentMetricsEmpty(t *testing.T) {
-	stateDir := t.TempDir()
+	wsRoot := t.TempDir()
+	stateDir := filepath.Join(wsRoot, ".bc")
 	agentsDir := filepath.Join(stateDir, "agents")
 	if err := os.MkdirAll(agentsDir, 0750); err != nil {
 		t.Fatal(err)
 	}
 
 	s := New(stateDir)
-	mgr := agent.NewWorkspaceManager(agentsDir, filepath.Dir(stateDir))
+	mgr := agent.NewWorkspaceManager(agentsDir, wsRoot)
 
 	s.collectAgentMetrics(mgr)
 
@@ -203,7 +206,8 @@ func TestCollectAgentMetricsEmpty(t *testing.T) {
 }
 
 func TestCollectAgentMetricsRoleCounts(t *testing.T) {
-	stateDir := t.TempDir()
+	wsRoot := t.TempDir()
+	stateDir := filepath.Join(wsRoot, ".bc")
 	agentsDir := filepath.Join(stateDir, "agents")
 
 	agents := map[string]*agent.Agent{
@@ -213,9 +217,9 @@ func TestCollectAgentMetricsRoleCounts(t *testing.T) {
 		"eng-02":   {Name: "eng-02", Role: agent.Role("worker"), State: agent.StateWorking, StartedAt: time.Now()},
 		"eng-03":   {Name: "eng-03", Role: agent.Role("worker"), State: agent.StateDone, StartedAt: time.Now()},
 	}
-	seedAgentsFile(t, stateDir, agents)
+	seedAgentsFile(t, wsRoot, agents)
 
-	mgr := agent.NewWorkspaceManager(agentsDir, filepath.Dir(stateDir))
+	mgr := agent.NewWorkspaceManager(agentsDir, wsRoot)
 	if err := mgr.LoadState(); err != nil {
 		t.Fatalf("LoadState: %v", err)
 	}
@@ -235,7 +239,8 @@ func TestCollectAgentMetricsRoleCounts(t *testing.T) {
 }
 
 func TestCollectAgentMetricsStateCounts(t *testing.T) {
-	stateDir := t.TempDir()
+	wsRoot := t.TempDir()
+	stateDir := filepath.Join(wsRoot, ".bc")
 	agentsDir := filepath.Join(stateDir, "agents")
 
 	agents := map[string]*agent.Agent{
@@ -246,9 +251,9 @@ func TestCollectAgentMetricsStateCounts(t *testing.T) {
 		"a5": {Name: "a5", Role: agent.Role("worker"), State: agent.StateError},
 		"a6": {Name: "a6", Role: agent.Role("worker"), State: agent.StateStopped},
 	}
-	seedAgentsFile(t, stateDir, agents)
+	seedAgentsFile(t, wsRoot, agents)
 
-	mgr := agent.NewWorkspaceManager(agentsDir, filepath.Dir(stateDir))
+	mgr := agent.NewWorkspaceManager(agentsDir, wsRoot)
 	if err := mgr.LoadState(); err != nil {
 		t.Fatalf("LoadState: %v", err)
 	}
@@ -281,7 +286,8 @@ func TestCollectAgentMetricsStateCounts(t *testing.T) {
 }
 
 func TestCollectAgentMetricsUptime(t *testing.T) {
-	stateDir := t.TempDir()
+	wsRoot := t.TempDir()
+	stateDir := filepath.Join(wsRoot, ".bc")
 	agentsDir := filepath.Join(stateDir, "agents")
 
 	startTime := time.Now().Add(-2 * time.Hour)
@@ -290,9 +296,9 @@ func TestCollectAgentMetricsUptime(t *testing.T) {
 		"stopped": {Name: "stopped", Role: agent.Role("worker"), State: agent.StateStopped, StartedAt: startTime},
 		"no-time": {Name: "no-time", Role: agent.Role("worker"), State: agent.StateIdle},
 	}
-	seedAgentsFile(t, stateDir, agents)
+	seedAgentsFile(t, wsRoot, agents)
 
-	mgr := agent.NewWorkspaceManager(agentsDir, filepath.Dir(stateDir))
+	mgr := agent.NewWorkspaceManager(agentsDir, wsRoot)
 	if err := mgr.LoadState(); err != nil {
 		t.Fatalf("LoadState: %v", err)
 	}
@@ -319,7 +325,11 @@ func TestCollectAgentMetricsUptime(t *testing.T) {
 }
 
 func TestLoadEmptyStateDir(t *testing.T) {
-	stateDir := t.TempDir()
+	wsRoot := t.TempDir()
+	stateDir := filepath.Join(wsRoot, ".bc")
+	if err := os.MkdirAll(stateDir, 0750); err != nil {
+		t.Fatal(err)
+	}
 
 	s, err := Load(stateDir)
 	if err != nil {
@@ -332,13 +342,14 @@ func TestLoadEmptyStateDir(t *testing.T) {
 	if s.CollectedAt.IsZero() {
 		t.Error("CollectedAt should not be zero")
 	}
-	if s.WorkspacePath != filepath.Dir(stateDir) {
-		t.Errorf("WorkspacePath = %q, want %q", s.WorkspacePath, filepath.Dir(stateDir))
+	if s.WorkspacePath != wsRoot {
+		t.Errorf("WorkspacePath = %q, want %q", s.WorkspacePath, wsRoot)
 	}
 }
 
 func TestLoadWithAgentsData(t *testing.T) {
-	stateDir := t.TempDir()
+	wsRoot := t.TempDir()
+	stateDir := filepath.Join(wsRoot, ".bc")
 
 	// Seed agents as already stopped so RefreshState won't change their state
 	agents := map[string]*agent.Agent{
@@ -346,7 +357,7 @@ func TestLoadWithAgentsData(t *testing.T) {
 		"eng-1": {Name: "eng-1", Role: agent.Role("worker"), State: agent.StateStopped},
 		"eng-2": {Name: "eng-2", Role: agent.Role("worker"), State: agent.StateStopped},
 	}
-	seedAgentsFile(t, stateDir, agents)
+	seedAgentsFile(t, wsRoot, agents)
 
 	s, err := Load(stateDir)
 	if err != nil {


### PR DESCRIPTION
## Summary
- **Fixes #2027**: Agent store opened `.bc/agents/state.db` instead of unified `.bc/bc.db`, causing bcd to show 0 agents
- `LoadState()` now uses `db.BCDBPath()` when workspace path is known, with fallback for standalone/test usage
- `stateDBPath()` in CLI init updated to use `db.BCDBPath()` so event log also writes to `bc.db`
- `agent cost` command migrated from direct `pkg/cost` access to daemon HTTP client (`GET /api/agents/{name}/cost`)
- Added `Cost()` method to `pkg/client/agents.go` and cost endpoint to `pkg/server`
- Fixed stale `state.db` comments in doctor
- Updated stats and doctor tests to use proper workspace layout (`wsRoot/.bc/bc.db`)

## Test plan
- [x] `go build ./pkg/... ./internal/...` compiles cleanly
- [x] `go vet ./pkg/... ./internal/...` passes
- [x] `go test -race ./pkg/agent/` — all pass
- [x] `go test -race ./pkg/stats/` — all pass (previously failing)
- [x] `go test -race ./pkg/doctor/` — all pass (previously failing)
- [x] `go test -race ./pkg/server/` — all pass
- [x] `go test -race ./pkg/events/` — all pass
- [ ] Verify bcd shows agents after restart (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)