### PR TITLE
fix: move theme toggle after install button

### DIFF
--- a/landing/src/app/_components/Nav.tsx
+++ b/landing/src/app/_components/Nav.tsx
@@ -188,10 +188,10 @@ export function Nav() {
           </nav>
         </div>
 
-        {/* Right: Theme toggle + Install */}
+        {/* Right: Install + Theme toggle */}
         <div className="hidden md:flex items-center gap-2 ml-auto">
-          <ThemeToggle />
           <InstallDropdown />
+          <ThemeToggle />
         </div>
 
         {/* Mobile: hamburger */}


### PR DESCRIPTION
## Summary
- Swaps the order of ThemeToggle and InstallDropdown in the desktop nav bar
- Theme toggle now appears after the install button instead of before

## Test plan
- [ ] Verify desktop nav shows: Logo | Nav links | ... | Install | Theme Toggle
- [ ] Verify mobile menu is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)