### PR TITLE
fix: make theme toggle button circular

### DIFF
--- a/landing/src/app/_components/ThemeToggle.tsx
+++ b/landing/src/app/_components/ThemeToggle.tsx
@@ -10,7 +10,7 @@ export function ThemeToggle() {
     <button
       onClick={toggleTheme}
       aria-label={`Switch to ${resolvedTheme === "light" ? "dark" : "light"} mode`}
-      className="inline-flex h-10 w-10 items-center justify-center rounded-lg hover:bg-accent transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary"
+      className="inline-flex h-10 w-10 items-center justify-center rounded-full hover:bg-accent transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-primary"
       title={`Current theme: ${resolvedTheme}`}
     >
       {resolvedTheme === "light" ? (


### PR DESCRIPTION
## Summary
- Changes `rounded-lg` to `rounded-full` on the theme toggle button
- Hover background is now a perfect circle instead of rounded rectangle
- Also changed `transition-colors` to `transition-all` for smoother effect

## Test plan
- [ ] Hover over the dark/light toggle icon in the nav bar
- [ ] Verify the hover background is circular

🤖 Generated with [Claude Code](https://claude.com/claude-code)