### PR TITLE
fix: frontend review quick wins — memoize contexts, fix deps, fix styling

### DIFF
--- a/tui/package.json
+++ b/tui/package.json
@@ -17,7 +17,6 @@
     "test:viewport": "bun test src/__tests__/viewport-ci.test.tsx src/__tests__/80x24-terminal.test.tsx"
   },
   "dependencies": {
-    "@bc/tui": ".",
     "ink": "^4.4.1",
     "ink-text-input": "^5.0.1",
     "react": "^18.2.0"

--- a/tui/src/config/ConfigContext.tsx
+++ b/tui/src/config/ConfigContext.tsx
@@ -7,7 +7,7 @@
  * it available to all hooks via React context.
  */
 
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
 import type { PerformanceConfig, TUIConfig } from '../types';
 import { execBcJson } from '../services/bc';
 
@@ -63,7 +63,7 @@ export function ConfigProvider({ children }: ConfigProviderProps): React.ReactEl
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchConfig = async () => {
+  const fetchConfig = useCallback(async () => {
     try {
       // Fetch performance section from workspace config
       const performanceResponse = await execBcJson<PerformanceConfig>(['config', 'show', 'performance']);
@@ -92,20 +92,20 @@ export function ConfigProvider({ children }: ConfigProviderProps): React.ReactEl
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   // Fetch config on mount
   useEffect(() => {
     void fetchConfig();
   }, []);
 
-  const value: ConfigContextValue = {
+  const value = useMemo<ConfigContextValue>(() => ({
     performance,
     tui,
     loading,
     error,
     refresh: fetchConfig,
-  };
+  }), [performance, tui, loading, error, fetchConfig]);
 
   return (
     <ConfigContext.Provider value={value}>

--- a/tui/src/hooks/UnreadContext.tsx
+++ b/tui/src/hooks/UnreadContext.tsx
@@ -5,7 +5,7 @@
  * Persists data to ~/.bc/tui-unread.json for cross-session tracking.
  */
 
-import React, { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
@@ -112,11 +112,11 @@ export function UnreadProvider({ children }: UnreadProviderProps): React.ReactEl
     return timestamp ? new Date(timestamp) : null;
   }, []);
 
-  const value: UnreadContextValue = {
+  const value = useMemo<UnreadContextValue>(() => ({
     getUnread,
     markViewed,
     getLastViewed,
-  };
+  }), [getUnread, markViewed, getLastViewed]);
 
   return (
     <UnreadContext.Provider value={value}>{children}</UnreadContext.Provider>

--- a/tui/src/providers/RootProvider.tsx
+++ b/tui/src/providers/RootProvider.tsx
@@ -10,7 +10,7 @@
  * This reduces provider nesting depth and groups related contexts.
  */
 
-import React, { type ReactNode } from 'react';
+import React, { useMemo, type ReactNode } from 'react';
 import { ConfigProvider, useThemeConfig } from '../config';
 import { ThemeProvider, type ThemeMode } from '../theme';
 
@@ -31,8 +31,10 @@ function RootProviderInner({ children }: RootProviderProps): React.ReactElement 
       ? 'dark' // Default to dark in auto mode (terminal UIs typically dark)
       : themeConfig.mode;
 
+  const themeProviderConfig = useMemo(() => ({ mode: effectiveMode }), [effectiveMode]);
+
   return (
-    <ThemeProvider config={{ mode: effectiveMode }}>
+    <ThemeProvider config={themeProviderConfig}>
       {children}
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary

Quick wins from the frontend engineering review (#2151). These are safe, mechanical fixes that address performance cascade re-renders, a security edge case, and a styling bug.

### Changes
- **Memoize ConfigContext value** — wraps provider value in `useMemo`, wraps `fetchConfig` in `useCallback`. Fixes cascade re-renders for all `useConfig()` consumers. (#2123)
- **Memoize UnreadContext value** — wraps provider value in `useMemo`. Fixes cascade re-renders for all `useUnread()` consumers. (#2123)
- **Memoize RootProvider config** — replaces inline `{{ mode: effectiveMode }}` with `useMemo`. Prevents ThemeProvider re-init on every render. (#2143)
- **Remove `@bc/tui` self-reference** — removes circular `"@bc/tui": "."` from dependencies. (#2141)
- **Escape HOME regex** — escapes special chars in `process.env.HOME` before using in `new RegExp()`. (#2145)
- **Fix undefined Tailwind class** — changes `text-bc-fg/80` to `text-bc-text/80` in web Roles view. (#2149)
- **Add FRONTEND_REVIEW.md** — comprehensive review report covering all 3 frontends.

### Verification
- TypeScript compiles with zero errors (`tsc --noEmit`)
- All config context tests pass (15/15)
- All app-level tests pass (13/13, 4 pre-existing skips)

### Related
- Master tracker: #2151
- Full report: `FRONTEND_REVIEW.md`

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `bun test src/config/__tests__/config.test.tsx` — 15 pass
- [x] `bun test src/__tests__/app.test.tsx src/__tests__/ViewWrapper.test.tsx` — 13 pass
- [ ] Verify TUI renders correctly in terminal
- [ ] Verify web dashboard Roles page text color renders

Generated with [Claude Code](https://claude.com/claude-code)