### PR TITLE
fix: prevent docker agents crashing with --continue on fresh start

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -704,7 +704,7 @@ func (m *Manager) SpawnAgentWithOptions(opts SpawnOptions) (*Agent, error) {
 		// The SessionID field may contain the tmux session name (e.g. "frontend")
 		// which is not a valid Claude conversation ID.
 		sessionID := existing.SessionID
-		isRealSessionID := len(sessionID) > 8 && strings.Contains(sessionID, "-")
+		isRealSessionID := len(sessionID) == 36 && sessionID[8] == '-'
 		resume := !opts.Fresh && isRealSessionID
 		if opts.Fresh {
 			existing.SessionID = ""


### PR DESCRIPTION
## Summary
- Docker agents crash with "No conversation found to continue" on first start
- `SessionID` field stores tmux session name (e.g. `"frontend"`) not a Claude UUID
- Code always set `resume = true` because `sessionID != ""` was always true
- Now only passes `--continue` when session ID looks like a real UUID

## Fix
```go
// Before:
resume := !opts.Fresh && sessionID != ""

// After:
isRealSessionID := len(sessionID) > 8 && strings.Contains(sessionID, "-")
resume := !opts.Fresh && isRealSessionID
```

## Test plan
- [ ] Create a new docker agent and start it — should NOT crash
- [ ] Stop and restart — should work without --fresh flag
- [ ] Agent with a real Claude session UUID still resumes correctly

Related: #2165

🤖 Generated with [Claude Code](https://claude.com/claude-code)