### PR TITLE
fix: remove CLAUDE.md from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,4 @@ bcd
 server/web/dist/*.html
 server/web/dist/assets/
 
-CLAUDE.md
 .mcp.json


### PR DESCRIPTION
## Summary
- Removes `CLAUDE.md` from `.gitignore` so it can be tracked in the repo
- All agents and contributors should share the same project instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)