### PR TITLE
fix: deduplicate channel messages — SSE delivers, no post-send refetch

### DIFF
--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -72,12 +72,15 @@ function ChatRoom({ channelName }: { channelName: string }) {
     })();
   }, [channelName]);
 
-  // Live messages — cleanup prevents listener leak
+  // Live messages via SSE — deduplicate by ID to prevent doubles
   useEffect(() => {
     return subscribe('channel.message', (event) => {
       const data = event.data as { channel?: string; message?: ChannelMessage };
       if (data.channel === channelName && data.message) {
-        setMessages((prev) => [...prev, data.message!]);
+        setMessages((prev) => {
+          if (prev.some((m) => m.id === data.message!.id)) return prev;
+          return [...prev, data.message!];
+        });
       }
     });
   }, [subscribe, channelName]);
@@ -87,21 +90,13 @@ function ChatRoom({ channelName }: { channelName: string }) {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const fetchMessages = async () => {
-    try {
-      const msgs = await api.getChannelHistory(channelName, 100);
-      setMessages(msgs ?? []);
-    } catch { /* ignore */ }
-  };
-
   const handleSend = async () => {
     if (!input.trim()) return;
     setSending(true);
     try {
       await api.sendToChannel(channelName, input);
       setInput('');
-      // Refetch to show the new message immediately
-      await fetchMessages();
+      // SSE listener will deliver the message — no refetch needed
     } finally {
       setSending(false);
     }


### PR DESCRIPTION
## Summary

Fix message duplication in the web Channels view. When sending a message, both the SSE `channel.message` listener AND the post-send `fetchMessages()` call were adding the same message to state.

### Changes
- **Remove `fetchMessages()` call after send** — the SSE listener already delivers the message
- **Add ID-based deduplication in SSE listener** — `prev.some(m => m.id === data.message.id)` prevents doubles if SSE delivers before the initial history fetch completes
- **Remove unused `fetchMessages` function** — no longer called anywhere

### Root cause
`handleSend` called `api.sendToChannel()` then immediately `fetchMessages()` (full re-fetch). Meanwhile the SSE `channel.message` event also fired, appending the same message. Result: message appears twice.

Fixes #2171

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npx vite build` — builds successfully (197KB)
- [ ] Manual: send message in Channels view, verify it appears exactly once
- [ ] Manual: verify messages from other senders still appear in real-time via SSE

Generated with [Claude Code](https://claude.com/claude-code)