### PR TITLE
test: add backend E2E test suite (19 tests, httptest)

### DIFF
--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -74,7 +74,7 @@ enabled = true
 	hub := ws_hub(t)
 
 	// Agent service (no runtime backend — just state management)
-	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
+	mgr := agent.NewWorkspaceManager(ws.StateDir(), ws.RootDir)
 	_ = mgr.LoadState()
 	agentSvc := agent.NewAgentService(mgr, hub, nil)
 


### PR DESCRIPTION
## Summary
Adds a comprehensive backend E2E test suite that spins up a full bcd server in-process using `httptest`, backed by real SQLite databases in a temp directory. No external services, running daemon, or API keys needed.

### 19 tests covering all major API endpoints:
- **Health**: liveness, CORS preflight, method not allowed
- **Agents**: list empty, get 404, delete 404, generate-name, stop-all
- **Channels**: list 3 defaults, create + get, send message + history, delete
- **Costs**: summary on empty workspace
- **Cron**: list empty
- **Tools**: list
- **MCP**: list servers
- **Events**: list with tail
- **Workspace**: status (name verification), roles
- **Doctor**: full health diagnostics

### How it works
`newE2EServer(t)` creates:
1. Temp workspace with valid `config.toml`
2. All real stores (channel, cost, cron, mcp, tool, events) on temp SQLite
3. Agent manager (no runtime — state management only)
4. SSE hub
5. Full `server.New()` wired to `httptest.NewServer`

Tests run in ~5s with race detector. Already included in CI fast test path.

Closes #2167

## Test plan
- [x] `go test -race -v -run TestE2E ./server/` — 19/19 pass
- [x] `make lint` — 0 issues
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)