### PR TITLE
fix: clear AgentsView action feedback timeout on unmount

### DIFF
--- a/tui/src/views/AgentsView.tsx
+++ b/tui/src/views/AgentsView.tsx
@@ -119,6 +119,7 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
 
   // Action feedback state - kept separate as it's timer-managed
   const [actionState, setActionState] = useState<ActionState | null>(null);
+  const feedbackTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   // #1743: Custom key handlers for agent actions
   const customKeys = useMemo(() => ({
@@ -191,8 +192,14 @@ export const AgentsView: React.FC<AgentsViewProps> = () => {
 
   // Clear action feedback after delay
   const showActionFeedback = useCallback((action: AgentAction, target: string, status: 'success' | 'error', message: string) => {
+    if (feedbackTimeoutRef.current) clearTimeout(feedbackTimeoutRef.current);
     setActionState({ action, target, status, message });
-    setTimeout(() => { setActionState(null); }, ACTION_FEEDBACK_DURATION);
+    feedbackTimeoutRef.current = setTimeout(() => { setActionState(null); }, ACTION_FEEDBACK_DURATION);
+  }, []);
+
+  // Cleanup action feedback timeout on unmount
+  useEffect(() => {
+    return () => { if (feedbackTimeoutRef.current) clearTimeout(feedbackTimeoutRef.current); };
   }, []);
 
   // Execute agent action


### PR DESCRIPTION
## Summary

Fix setTimeout leak in AgentsView. The action feedback timeout (2.5s) was not tracked or cleared, causing a React setState warning when navigating away during feedback display.

### Changes (3 lines added to `tui/src/views/AgentsView.tsx`)

1. **Add `feedbackTimeoutRef`** — `useRef<ReturnType<typeof setTimeout>>()` to store the timeout ID
2. **Clear previous timeout in `showActionFeedback`** — `clearTimeout(feedbackTimeoutRef.current)` before setting new one (handles rapid successive actions)
3. **Add cleanup `useEffect`** — clears timeout on unmount

### What this fixes
- No more "setState on unmounted component" React warning when navigating away within 2.5s of an agent action (start/stop/kill)
- Rapid successive actions no longer stack timeouts (previous is cancelled)

### Verification
- `npx tsc --noEmit` — zero errors
- `bun test src/__tests__/AgentsView.test.tsx src/views/__tests__/AgentsView.test.tsx` — 69 tests pass

Closes #2173

Generated with [Claude Code](https://claude.com/claude-code)