### PR TITLE
fix: only auto-scroll channels when user is near bottom

### DIFF
--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -58,6 +58,7 @@ function ChatRoom({ channelName }: { channelName: string }) {
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { subscribe } = useWebSocket();
 
   // Fetch history on channel change
@@ -85,9 +86,14 @@ function ChatRoom({ channelName }: { channelName: string }) {
     });
   }, [subscribe, channelName]);
 
-  // Auto-scroll
+  // Auto-scroll only when user is near the bottom
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 100;
+    if (isNearBottom) {
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
   }, [messages]);
 
   const handleSend = async () => {
@@ -107,7 +113,7 @@ function ChatRoom({ channelName }: { channelName: string }) {
       <div className="px-4 py-2 border-b border-bc-border bg-bc-surface">
         <span className="font-medium">#{channelName}</span>
       </div>
-      <div className="flex-1 overflow-auto p-4 space-y-2">
+      <div ref={scrollContainerRef} className="flex-1 overflow-auto p-4 space-y-2">
         {messages.map((msg) => (
           <div key={msg.id} className="text-sm">
             <span className="font-medium text-bc-accent">{msg.sender}</span>


### PR DESCRIPTION
## Summary

Fix auto-scroll in web Channels view interrupting users reading message history. New messages only trigger scroll-to-bottom when the user is already within 100px of the bottom.

### Changes (`web/src/views/Channels.tsx`)

1. **Add `scrollContainerRef`** on the message list `div` to access scroll position
2. **Check proximity before scrolling** — `scrollHeight - scrollTop - clientHeight < 100`
3. **Skip scroll when user is reading history** — if scrolled up beyond 100px threshold

### Before
Every new message (from SSE) called `scrollIntoView` unconditionally, yanking the viewport to the bottom even if the user was reading older messages.

### After
- At bottom: auto-scrolls smoothly (same as before)
- Scrolled up: new messages append silently, user stays where they are

### Verification
- `npx tsc --noEmit` — zero errors
- `npx vite build` — builds successfully (197KB)

Closes #2172

Generated with [Claude Code](https://claude.com/claude-code)