### PR TITLE
fix: clean stale worktree before Docker agent restart

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -758,6 +758,10 @@ func (m *Manager) SpawnAgentWithOptions(opts SpawnOptions) (*Agent, error) {
 			}
 		}
 
+		// Clean stale worktree from previous container run to prevent
+		// "fatal: '<dir>' already exists" on restart.
+		cleanStaleWorktree(wsPath, name)
+
 		if err := m.runtimeForAgent(name).CreateSessionWithEnv(context.TODO(), name, wsPath, agentCmd, env); err != nil {
 			return nil, fmt.Errorf("failed to recreate session: %w", err)
 		}
@@ -897,6 +901,9 @@ func (m *Manager) SpawnAgentWithOptions(opts SpawnOptions) (*Agent, error) {
 		env["BC_PARENT_ID"] = parentID
 	}
 	injectEnv(env, wsPath, effectiveTool, opts.EnvFile)
+
+	// Clean stale worktree from previous container run (crash recovery).
+	cleanStaleWorktree(wsPath, name)
 
 	// Create session in the workspace directory using the agent's runtime backend
 	if err := m.runtimeForAgent(name).CreateSessionWithEnv(context.TODO(), name, wsPath, agentCmd, env); err != nil {
@@ -1176,6 +1183,39 @@ func (m *Manager) stopAgentTreeLocked(name string) error {
 	agent.Children = []string{} // Clear children since they're stopped
 
 	return nil
+}
+
+// cleanStaleWorktree removes a pre-existing git worktree directory that may
+// persist from a previous Docker container run. Without this, `claude -w`
+// fails with "fatal: '<dir>' already exists" on restart.
+func cleanStaleWorktree(workspacePath, agentName string) {
+	if workspacePath == "" {
+		return
+	}
+	worktreeName := "bc-" + filepath.Base(workspacePath) + "-" + agentName
+	worktreeDir := filepath.Join(workspacePath, ".claude", "worktrees", worktreeName)
+
+	// Check if directory exists before doing any work
+	if _, err := os.Stat(worktreeDir); os.IsNotExist(err) {
+		return
+	}
+
+	log.Debug("cleaning stale worktree", "agent", agentName, "dir", worktreeDir)
+
+	// Prune stale worktree refs (handles /workspace/... Docker paths that
+	// no longer exist on the host)
+	//nolint:gosec // trusted paths from workspace config
+	_ = exec.CommandContext(context.TODO(), "git", "-C", workspacePath, "worktree", "prune").Run()
+
+	// Try git worktree remove first (cleanest approach)
+	//nolint:gosec // trusted paths
+	if err := exec.CommandContext(context.TODO(), "git", "-C", workspacePath, "worktree", "remove", "--force", worktreeDir).Run(); err != nil {
+		// If git worktree remove fails, fall back to removing the directory
+		// This handles cases where the worktree is not tracked by git
+		// (e.g., created inside a Docker container with a different /workspace path)
+		log.Debug("git worktree remove failed, removing directory directly", "error", err)
+		_ = os.RemoveAll(worktreeDir)
+	}
 }
 
 // DeleteOptions configures agent deletion behavior.


### PR DESCRIPTION
## Summary
Docker agent containers crash on restart with:
```
fatal: '/workspace/.claude/worktrees/bc-bc-frontend' already exists
```

The git worktree directory from the previous container run persists in the mounted workspace volume. When `claude -w` tries to create it again, it fails.

### Fix
Added `cleanStaleWorktree()` function called in both code paths:
1. **Restart path** (line 763) — agent exists, session dead, recreating container
2. **Fresh create path** (line 906) — crash recovery, stale directory from previous crash

The cleanup:
1. Check if worktree dir exists (skip if not — fast path for normal operation)
2. `git worktree prune` — clean stale refs (handles Docker `/workspace/...` paths)
3. `git worktree remove --force` — remove the worktree cleanly
4. Fallback to `os.RemoveAll` — handles cases where git can't track the worktree (Docker path mismatch)

### What it doesn't touch
- Agent auth/session state (preserved in `~/.bc/agents/`)
- Container volumes
- Session ID for `--continue` resume

Closes #2195

## Test plan
- [x] `go build ./...` passes
- [x] `make lint` — 0 issues
- [x] `go test -race ./pkg/agent/` — all pass
- [x] Verified: stale worktree dir is cleaned before session creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)