### PR TITLE
chore: add Dependabot config for Go, npm, and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,79 @@
+# Dependabot configuration — keeps dependencies current automatically.
+# Creates PRs grouped by ecosystem on a weekly schedule.
+# Security updates are created immediately regardless of schedule.
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+
+updates:
+  # Go modules
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - infrastructure
+    commit-message:
+      prefix: "deps(go):"
+    groups:
+      go-minor:
+        update-types: [minor, patch]
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - ci/cd
+    commit-message:
+      prefix: "deps(actions):"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # npm — TUI
+  - package-ecosystem: npm
+    directory: /tui
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "deps(tui):"
+    groups:
+      tui-deps:
+        update-types: [minor, patch]
+
+  # npm — Web UI
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "deps(web):"
+    groups:
+      web-deps:
+        update-types: [minor, patch]
+
+  # npm — Landing page
+  - package-ecosystem: npm
+    directory: /landing
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "deps(landing):"
+    groups:
+      landing-deps:
+        update-types: [minor, patch]


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` for automated dependency update PRs.

### Ecosystems configured:
| Ecosystem | Directory | Schedule | Grouping |
|-----------|-----------|----------|----------|
| Go modules | `/` | Weekly Monday | Minor+patch grouped |
| GitHub Actions | `/` | Weekly Monday | All grouped |
| npm (TUI) | `/tui` | Weekly Monday | Minor+patch grouped |
| npm (Web) | `/web` | Weekly Monday | Minor+patch grouped |
| npm (Landing) | `/landing` | Weekly Monday | Minor+patch grouped |

### Features:
- Security updates created immediately (Dependabot default)
- PRs labeled by ecosystem (`dependencies` + domain label)
- Conventional commit prefixes: `deps(go):`, `deps(actions):`, `deps(tui):`, etc.
- Minor/patch updates grouped to reduce PR noise

Closes #2109

## Test plan
- [x] YAML validates (Dependabot schema)
- [ ] First batch of Dependabot PRs appears within 24 hours of merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)