### PR TITLE
fix: pin all Docker base images to specific versions

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -3,8 +3,9 @@
 #
 # Build with: make build-agent-images
 # Or individually: docker build -t bc-agent-claude:latest -f docker/Dockerfile.claude .
+# Base images pinned — update versions in Dependabot PRs or manually.
 
-FROM oven/bun:latest AS builder
+FROM oven/bun:1.2 AS builder
 RUN bun install -g @anthropic-ai/claude-code
 
 FROM ubuntu:24.04

--- a/docker/Dockerfile.bcd
+++ b/docker/Dockerfile.bcd
@@ -1,8 +1,9 @@
 # bcd server image — bc coordination daemon
 # Multi-stage build: Go binary + embedded React web UI
 # Usage: docker build -t bc-bcd:latest -f docker/Dockerfile.bcd .
+# Base images pinned — update versions in Dependabot PRs or manually.
 
-FROM oven/bun:latest AS web-builder
+FROM oven/bun:1.2 AS web-builder
 WORKDIR /app/web
 COPY web/package.json web/bun.lock ./
 RUN bun install --frozen-lockfile

--- a/docker/Dockerfile.bcdb
+++ b/docker/Dockerfile.bcdb
@@ -1,7 +1,8 @@
 # bcdb image — Postgres database for bc workspaces
 # Usage: docker build -t bc-bcdb:latest -f docker/Dockerfile.bcdb .
+# Base images pinned — update versions in Dependabot PRs or manually.
 
-FROM postgres:17
+FROM postgres:17.4
 
 ENV POSTGRES_USER=bc
 ENV POSTGRES_PASSWORD=bc

--- a/docker/Dockerfile.codex
+++ b/docker/Dockerfile.codex
@@ -1,7 +1,8 @@
 # OpenAI Codex agent image
 # Requires: bc-agent-base:latest
+# Base images pinned — update versions in Dependabot PRs or manually.
 
-FROM oven/bun:latest AS builder
+FROM oven/bun:1.2 AS builder
 RUN bun install -g @openai/codex
 
 FROM bc-agent-base:latest

--- a/docker/Dockerfile.cursor
+++ b/docker/Dockerfile.cursor
@@ -1,7 +1,8 @@
 # Cursor Agent image
 # Requires: bc-agent-base:latest
+# Base images pinned — update versions in Dependabot PRs or manually.
 
-FROM oven/bun:latest AS builder
+FROM oven/bun:1.2 AS builder
 RUN bun install -g cursor-agent
 
 FROM bc-agent-base:latest

--- a/docker/Dockerfile.gemini
+++ b/docker/Dockerfile.gemini
@@ -1,7 +1,8 @@
 # Gemini CLI agent image
 # Requires: bc-agent-base:latest
+# Base images pinned — update versions in Dependabot PRs or manually.
 
-FROM oven/bun:latest AS builder
+FROM oven/bun:1.2 AS builder
 RUN bun install -g @google/gemini-cli
 
 FROM bc-agent-base:latest

--- a/docker/Dockerfile.openclaw
+++ b/docker/Dockerfile.openclaw
@@ -1,7 +1,8 @@
 # OpenClaw agent image
 # Requires: bc-agent-base:latest
+# Base images pinned — update versions in Dependabot PRs or manually.
 
-FROM oven/bun:latest AS builder
+FROM oven/bun:1.2 AS builder
 RUN bun install -g openclaw
 
 FROM bc-agent-base:latest


### PR DESCRIPTION
## Summary\nPin all external Docker base images to specific versions. No `latest` tags remain.\n\n| Image | Before | After | Files |\n|-------|--------|-------|-------|\n| oven/bun | `latest` | `1.2` (matches CI) | Dockerfile.agent, bcd, codex, cursor, gemini, openclaw |\n| postgres | `17` | `17.4` | Dockerfile.bcdb |\n| golang | `1.25.8` | unchanged | Dockerfile.bcd |\n| ubuntu | `24.04` | unchanged | Dockerfile.agent, base, bcd |\n| python | `3.12-slim` | unchanged | Dockerfile.aider |\n| bc-agent-base | `latest` | unchanged (local) | All provider images |\n\n7 files changed. Added pinning comment to each.\n\nCloses #2074\n\n## Test plan\n- [x] All FROM directives verified — no external `latest` tags\n- [x] Versions match CI config (BUN_VERSION=1.2, GO_VERSION=1.25.8)\n- [ ] Docker builds verified (optional — CI doesn't build images yet)\n\nGenerated with [Claude Code](https://claude.com/claude-code)