### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,37 @@
+# EditorConfig — consistent formatting across editors
+# https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.go]
+indent_style = tab
+
+[*.{ts,tsx,js,jsx,json,css,html}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml,toml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.sql]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[Dockerfile*]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
## Summary
Adds `.editorconfig` so all editors respect the project's formatting conventions without manual setup.

| Pattern | Style | Matches |
|---------|-------|---------|
| `*.go` | Tab indent | gofmt default |
| `*.{ts,tsx,js,json,css}` | 2-space | prettier/eslint config |
| `*.{yml,yaml,toml}` | 2-space | CI/config files |
| `*.md` | 2-space, keep trailing whitespace | Markdown line breaks |
| `*.sql` | 4-space | SQL convention |
| `Makefile` | Tab | Make requirement |
| `Dockerfile*` | 4-space | Docker convention |
| `*` | LF endings, final newline, trim trailing whitespace | Universal |

Closes #2069

## Test plan
- [x] Settings match existing gofmt, prettier, eslint configs
- [x] No code changes — editor config only

Generated with [Claude Code](https://claude.com/claude-code)