### PR TITLE
perf: move RefreshState to background 5s ticker

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -92,6 +92,10 @@ func run(addr, wsRoot string) error {
 	statsCollector := bcagent.NewStatsCollector(agentMgr)
 	go statsCollector.Run(ctx)
 
+	// Background state reconciler: refreshes agent states every 5s.
+	// Replaces the synchronous RefreshState call on GET /api/agents.
+	go agentMgr.RunReconciler(ctx, 5*time.Second)
+
 	// Channel service
 	var channelSvc *bcchannel.ChannelService
 	if chStore, err := bcchannel.OpenStore(ws.RootDir); err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1532,6 +1532,28 @@ func (m *Manager) ListByRole(role Role) []*Agent {
 	return agents
 }
 
+// RunReconciler runs RefreshState on a background ticker until ctx is canceled.
+// This replaces the synchronous RefreshState call on every GET /api/agents.
+func (m *Manager) RunReconciler(ctx context.Context, interval time.Duration) {
+	// Run once immediately on startup
+	if err := m.RefreshState(); err != nil {
+		log.Warn("initial state refresh failed", "error", err)
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := m.RefreshState(); err != nil {
+				log.Warn("state refresh failed", "error", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 // RefreshState updates agent states from tmux.
 // Also captures a live task summary from each agent's tmux pane.
 func (m *Manager) RefreshState() error {

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -73,8 +73,7 @@ func toDTO(a *agent.Agent) agentDTO {
 func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		// Reconcile in-memory state with live sessions before listing
-		_ = h.svc.Refresh() //nolint:errcheck // best-effort reconciliation
+		// State is refreshed by background reconciler (RunReconciler) — no sync call here.
 		agents, err := h.svc.List(r.Context(), agent.ListOptions{})
 		if err != nil {
 			httpError(w, "list agents: "+err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

Phase 3 of agent lifecycle redesign (#2165). GET /api/agents no longer blocks on subprocess calls.

### Changes (3 files, +27/-2)

- `pkg/agent/agent.go` — new `RunReconciler(ctx, interval)` method
- `cmd/bcd/main.go` — start reconciler goroutine with 5s interval
- `server/handlers/agents.go` — remove synchronous `Refresh()` call from list handler

### Before/After

| | Before | After |
|---|--------|-------|
| GET /api/agents | Shells out to `docker ps` + `tmux list-sessions` + `capture-pane` per agent | Returns cached in-memory state |
| Latency | 100ms-2s (depends on agent count) | <1ms |
| Staleness | 0 | Max 5 seconds |

Hooks still update state instantly via POST /api/agents/{name}/hook.

Closes #2192

Generated with [Claude Code](https://claude.com/claude-code)