### PR TITLE
fix: replace useEffect+useState with useMemo for unread channel derivation

### DIFF
--- a/tui/src/hooks/useChannels.ts
+++ b/tui/src/hooks/useChannels.ts
@@ -6,7 +6,7 @@
  * Poll interval is configurable via workspace config [performance] section.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { Channel, ChannelMessage, BcResult } from '../types';
 import { getChannels, getChannelHistory, sendChannelMessage } from '../services/bc';
 import { usePerformanceConfig } from '../config';
@@ -176,9 +176,6 @@ export function useChannelsWithUnread(options?: UseChannelsOptions): {
 } {
   const { data: channels, loading: channelsLoading, error, refresh: refreshChannels } = useChannels(options);
   const { getUnread } = useUnread();
-  const [channelsWithUnread, setChannelsWithUnread] = useState<
-    (Channel & { unread: number; messageCount: number })[] | null
-  >(null);
   const [messageCounts, setMessageCounts] = useState<Record<string, number>>({});
   const [countsLoading, setCountsLoading] = useState(true);
 
@@ -236,13 +233,12 @@ export function useChannelsWithUnread(options?: UseChannelsOptions): {
     };
   }, [channels]);
 
-  // Calculate unread for each channel using UnreadContext
-  useEffect(() => {
-    if (!channels) return;
+  // Derive unread counts — pure computation, no state needed
+  const channelsWithUnread = useMemo(() => {
+    if (!channels) return null;
 
-    const withUnread = channels.map((ch) => {
+    return channels.map((ch) => {
       const currentCount = messageCounts[ch.name] ?? 0;
-      // Use UnreadContext to calculate unread based on stored lastMessageCount
       const unread = getUnread(ch.name, currentCount);
 
       return {
@@ -251,7 +247,6 @@ export function useChannelsWithUnread(options?: UseChannelsOptions): {
         unread,
       };
     });
-    setChannelsWithUnread(withUnread);
   }, [channels, messageCounts, getUnread]);
 
   const refresh = useCallback(async () => {


### PR DESCRIPTION
## Summary

Fix stale closure and unnecessary re-renders in `useChannelsWithUnread`. The hook stored derived state (channels + unread counts) in `useState` via a `useEffect`, causing an extra render cycle on every change and risking stale closures.

### Changes (`tui/src/hooks/useChannels.ts`)

- **Remove** `channelsWithUnread` `useState` — derived state doesn't need its own state variable
- **Replace** `useEffect` that computed `withUnread` and called `setChannelsWithUnread` with `useMemo` — pure derivation, no state update, no extra render
- **Add** `useMemo` to imports

### Before
```
channels change → useEffect fires → setChannelsWithUnread(derived) → extra render
```

### After
```
channels change → useMemo recomputes → same render
```

### Why this works
`getUnread` is already stable (`useCallback(fn, [])` reading from `dataRef`). The context `useMemo` was fixed in PR #2153. So `getUnread` in the dependency array doesn't cause spurious recomputation — only actual `channels` or `messageCounts` changes trigger it.

### Verification
- `eslint src/hooks/useChannels.ts` — clean
- `tsc --noEmit` — clean
- 102 tests pass across 4 test files (useChannels, ChannelsView x2, app)

Closes #2135

Generated with [Claude Code](https://claude.com/claude-code)