### PR TITLE
chore: add .env.example with placeholder values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,40 @@
+# bc environment variables
+# Copy to .env and fill in values. Never commit .env to git.
+
+# ─── AI Provider API Keys ────────────────────────────────────────────────────
+# Set the key for whichever provider(s) you use.
+# ANTHROPIC_API_KEY=sk-ant-...
+# GOOGLE_API_KEY=...
+# OPENAI_API_KEY=sk-...
+
+# ─── Database ─────────────────────────────────────────────────────────────────
+# Default: SQLite at ~/.bc/bc.db (no config needed)
+# Set DATABASE_URL to use PostgreSQL instead:
+# DATABASE_URL=postgres://bc:bc@localhost:5432/bc
+
+# Or configure driver and URL separately:
+# BC_DATABASE_DRIVER=postgres
+# BC_DATABASE_URL=postgres://bc:bc@localhost:5432/bc
+
+# ─── Daemon ───────────────────────────────────────────────────────────────────
+# bcd listen address (default: 127.0.0.1:9374)
+# BC_DAEMON_ADDR=127.0.0.1:9374
+
+# ─── Secrets ──────────────────────────────────────────────────────────────────
+# Master passphrase for encrypting secrets stored in bc.
+# If unset, an auto-generated key is stored at ~/.bc/secret-key
+# BC_SECRET_PASSPHRASE=
+
+# ─── Docker (bcdb) ────────────────────────────────────────────────────────────
+# Used by docker/Dockerfile.bcdb — override at runtime:
+#   docker run -e POSTGRES_PASSWORD=secure-password bc-bcdb:latest
+# POSTGRES_USER=bc
+# POSTGRES_PASSWORD=change-me-in-production
+# POSTGRES_DB=bc
+
+# ─── Misc ─────────────────────────────────────────────────────────────────────
+# Disable color output
+# NO_COLOR=1
+
+# Preferred editor for bc commands that open files
+# EDITOR=vim


### PR DESCRIPTION
## Summary
Documents all environment variables bc reads, grouped by category: AI provider keys, database, daemon, secrets, Docker, misc.

Closes #2059

## Test plan
- [x] All env vars verified against source code (grep os.Getenv)
- [x] .gitignore already covers .env

Generated with [Claude Code](https://claude.com/claude-code)