### PR TITLE
chore: add GitHub issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+labels: bug
+---
+
+## Description
+<!-- What happened? Be specific. -->
+
+
+## Steps to Reproduce
+1. 
+2. 
+3. 
+
+## Expected Behavior
+<!-- What should have happened? -->
+
+
+## Actual Behavior
+<!-- What happened instead? Include error messages, logs, screenshots. -->
+
+
+## Environment
+- **OS**: macOS / Linux / Windows
+- **Go version**: `go version`
+- **bc version**: `bc version`
+- **Runtime**: tmux / Docker
+- **Provider**: claude / gemini / codex / aider / other
+
+## Additional Context
+<!-- Logs, config snippets, related issues. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/rpuneet/bc/tree/main/docs
+    about: Check the docs before filing an issue
+  - name: Security Vulnerability
+    url: https://github.com/rpuneet/bc/security/advisories/new
+    about: Report security issues privately via GitHub Security Advisories

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Problem
+<!-- What problem does this solve? Why is it needed? -->
+
+
+## Proposed Solution
+<!-- How should it work? Be specific about the user experience. -->
+
+
+## Alternatives Considered
+<!-- What other approaches did you consider? Why were they rejected? -->
+
+
+## Additional Context
+<!-- Mockups, examples from other tools, related issues. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+<!-- What does this PR do? Link the issue it addresses. -->
+
+
+## Changes
+<!-- Key files changed and why. -->
+- 
+
+## Test Plan
+<!-- How was this tested? Check all that apply. -->
+- [ ] `make check` passes
+- [ ] New/updated tests cover the change
+- [ ] Manual testing done (describe below)
+
+## Checklist
+- [ ] PR title follows conventional commits (`feat:`, `fix:`, `chore:`, etc.)
+- [ ] No secrets or credentials in the diff
+- [ ] Documentation updated (if applicable)


### PR DESCRIPTION
## Summary
Adds structured templates for issues and pull requests.

### New files:
| File | Purpose |
|------|---------|
| `.github/ISSUE_TEMPLATE/bug_report.md` | Bug reports with repro steps, environment info |
| `.github/ISSUE_TEMPLATE/feature_request.md` | Feature requests with problem/solution structure |
| `.github/ISSUE_TEMPLATE/config.yml` | External links (docs, security advisories), allows blank issues |
| `.github/pull_request_template.md` | PR template with summary, test plan, checklist |

Existing `agent-task.md` template unchanged.

Closes #2067

## Test plan
- [x] Templates render correctly in GitHub new issue/PR UI
- [x] Labels auto-applied (bug, enhancement)
- [x] Blank issues still allowed (config.yml)

Generated with [Claude Code](https://claude.com/claude-code)