### PR TITLE
fix: channel message delivery — formatting, retry, watermark, standalone

### DIFF
--- a/server/mcp/server.go
+++ b/server/mcp/server.go
@@ -142,14 +142,16 @@ type channelMessagePayload struct {
 func (s *Server) pollChannelMessages(ctx context.Context) {
 	defer s.pollWg.Done()
 
-	// Track the latest message count per channel to detect new messages.
-	lastCounts := make(map[string]int)
+	// Track the latest message timestamp per channel to detect new messages.
+	// Using timestamps instead of array length avoids breaking when history
+	// is capped (e.g., GetHistory returns last 100 messages).
+	lastSeen := make(map[string]time.Time)
 
-	// Seed initial counts so we don't replay old history on startup.
+	// Seed with current latest timestamp so we don't replay old history.
 	for _, ch := range s.chans.List() {
 		history, err := s.chans.GetHistory(ch.Name)
-		if err == nil {
-			lastCounts[ch.Name] = len(history)
+		if err == nil && len(history) > 0 {
+			lastSeen[ch.Name] = history[len(history)-1].Time
 		}
 	}
 
@@ -161,29 +163,31 @@ func (s *Server) pollChannelMessages(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.checkNewMessages(lastCounts)
+			s.checkNewMessages(lastSeen)
 		}
 	}
 }
 
-// checkNewMessages checks each channel for messages beyond lastCounts and pushes them.
-func (s *Server) checkNewMessages(lastCounts map[string]int) {
+// checkNewMessages checks each channel for messages newer than lastSeen and pushes them.
+func (s *Server) checkNewMessages(lastSeen map[string]time.Time) {
 	for _, ch := range s.chans.List() {
 		history, err := s.chans.GetHistory(ch.Name)
-		if err != nil {
+		if err != nil || len(history) == 0 {
 			continue
 		}
 
-		prev := lastCounts[ch.Name]
-		if len(history) <= prev {
-			continue
-		}
+		cutoff := lastSeen[ch.Name]
 
-		// Push each new message as a notification
-		for _, entry := range history[prev:] {
+		// Find new messages (those with timestamp after cutoff)
+		for _, entry := range history {
+			if !entry.Time.After(cutoff) {
+				continue
+			}
 			s.pushMessageNotification(ch.Name, entry.Sender, entry.Message, entry.Time)
 		}
-		lastCounts[ch.Name] = len(history)
+
+		// Update watermark to latest message
+		lastSeen[ch.Name] = history[len(history)-1].Time
 	}
 }
 

--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -174,12 +174,23 @@ func (s *Server) toolSendMessage(raw json.RawMessage) (*toolsCallResult, error) 
 			}, nil
 		}
 	} else {
-		// Standalone mode — store only (no delivery hooks available).
+		// Standalone mode — store message and attempt direct delivery.
 		if err := s.chans.AddHistory(args.Channel, sender, args.Message); err != nil {
 			return &toolsCallResult{
 				Content: []ToolContent{textContent(fmt.Sprintf("failed to send message: %s", err))},
 				IsError: true,
 			}, nil
+		}
+		// Best-effort delivery to channel members via agent manager
+		if s.agents != nil {
+			members, _ := s.chans.GetMembers(args.Channel)
+			formatted := fmt.Sprintf("[#%s @%s] %s", args.Channel, sender, args.Message)
+			for _, member := range members {
+				if member == sender {
+					continue
+				}
+				_ = s.agents.SendToAgent(member, formatted) //nolint:errcheck // best-effort
+			}
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -99,8 +99,9 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 	if svc.Channels != nil {
 		svc.Channels.OnMessage = func(ch, sender, content string) {
-			// Deliver to agent tmux/docker sessions
+			// Deliver to agent tmux/docker sessions with formatted context
 			if svc.Agents != nil {
+				formatted := fmt.Sprintf("[#%s @%s] %s", ch, sender, content)
 				chDTO, err := svc.Channels.Get(context.Background(), ch)
 				if err != nil {
 					log.Debug("channel send: failed to get channel", "channel", ch, "error", err)
@@ -109,8 +110,17 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 						if member == sender {
 							continue
 						}
-						if err := svc.Agents.Send(context.Background(), member, content); err != nil {
-							log.Debug("channel send: failed to deliver to agent", "agent", member, "error", err)
+						// Retry delivery up to 3 times
+						var sendErr error
+						for attempt := 0; attempt < 3; attempt++ {
+							sendErr = svc.Agents.Send(context.Background(), member, formatted)
+							if sendErr == nil {
+								break
+							}
+							time.Sleep(time.Duration(attempt+1) * 200 * time.Millisecond)
+						}
+						if sendErr != nil {
+							log.Warn("channel send: delivery failed after retries", "channel", ch, "agent", member, "error", sendErr)
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

Fixes 4 channel delivery edge cases remaining after #2041.

### Changes (3 files, +45/-20)

| Fix | File | What |
|-----|------|------|
| Message formatting | server/server.go | `[#channel @sender] content` prefix on delivered messages |
| Delivery retry | server/server.go | 3 attempts with 200/400/600ms backoff |
| Poll watermark | server/mcp/server.go | Timestamp-based instead of `len(history)` — works past 100 messages |
| Standalone delivery | server/mcp/tools.go | Direct agent delivery when chanSvc is nil |

### Before/After

**Before:** Messages arrive as bare text with no context. MCP poll stops detecting new messages after 100 per channel. Standalone MCP stores but never delivers. Failed deliveries are silently dropped.

**After:** Messages arrive as `[#engineering @eng-01] PR ready for review`. Poll works indefinitely. Standalone mode delivers. Failed deliveries retry 3x.

Closes #2164

Generated with [Claude Code](https://claude.com/claude-code)