### PR TITLE
feat: prefix channel messages with [bc-mcp][timestamp] sender: metadata

### DIFF
--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/rpuneet/bc/pkg/agent"
 )
@@ -184,7 +185,7 @@ func (s *Server) toolSendMessage(raw json.RawMessage) (*toolsCallResult, error) 
 		// Best-effort delivery to channel members via agent manager
 		if s.agents != nil {
 			members, _ := s.chans.GetMembers(args.Channel)
-			formatted := fmt.Sprintf("[#%s @%s] %s", args.Channel, sender, args.Message)
+			formatted := fmt.Sprintf("[bc-mcp][%s] %s: %s", time.Now().UTC().Format(time.RFC3339), sender, args.Message)
 			for _, member := range members {
 				if member == sender {
 					continue

--- a/server/server.go
+++ b/server/server.go
@@ -101,7 +101,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		svc.Channels.OnMessage = func(ch, sender, content string) {
 			// Deliver to agent tmux/docker sessions with formatted context
 			if svc.Agents != nil {
-				formatted := fmt.Sprintf("[#%s @%s] %s", ch, sender, content)
+				formatted := fmt.Sprintf("[bc-mcp][%s] %s: %s", time.Now().UTC().Format(time.RFC3339), sender, content)
 				chDTO, err := svc.Channels.Get(context.Background(), ch)
 				if err != nil {
 					log.Debug("channel send: failed to get channel", "channel", ch, "error", err)


### PR DESCRIPTION
## Summary

Agents now receive channel messages with parseable metadata prefix.

**Before:** `[#channel @sender] content`
**After:** `[bc-mcp][2026-03-21T13:08:34Z] root: content`

### Changes (2 files, +3/-2)
- `server/server.go` — OnMessage callback format
- `server/mcp/tools.go` — standalone delivery format + added `time` import

Storage and API responses unchanged.

Closes #2228

Generated with [Claude Code](https://claude.com/claude-code)