### PR TITLE
fix: server hardening — panic recovery, stdlib cleanup, event LIMIT, query caps

### DIFF
--- a/pkg/events/store_sqlite.go
+++ b/pkg/events/store_sqlite.go
@@ -71,7 +71,7 @@ func (l *SQLiteLog) Append(event Event) error {
 // Read returns all events ordered by timestamp.
 func (l *SQLiteLog) Read() ([]Event, error) {
 	rows, err := l.db.Query(
-		"SELECT type, agent, message, data, timestamp FROM events ORDER BY id ASC",
+		"SELECT type, agent, message, data, timestamp FROM events ORDER BY id ASC LIMIT 1000",
 	)
 	if err != nil {
 		return nil, err
@@ -106,7 +106,7 @@ func (l *SQLiteLog) ReadLast(n int) ([]Event, error) {
 // ReadByAgent returns events for a specific agent.
 func (l *SQLiteLog) ReadByAgent(name string) ([]Event, error) {
 	rows, err := l.db.Query(
-		"SELECT type, agent, message, data, timestamp FROM events WHERE agent = ? ORDER BY id ASC", name,
+		"SELECT type, agent, message, data, timestamp FROM events WHERE agent = ? ORDER BY id ASC LIMIT 1000", name,
 	)
 	if err != nil {
 		return nil, err

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -203,6 +203,7 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 				limit = n
 			}
 		}
+		limit = clampInt(limit, 1, 1000)
 		records, err := h.svc.Manager().QueryAgentStats(name, limit)
 		if err != nil {
 			httpError(w, "stats unavailable: "+err.Error(), http.StatusInternalServerError)
@@ -234,6 +235,7 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 				lines = n
 			}
 		}
+		lines = clampInt(lines, 1, 10000)
 		output, err := h.svc.Peek(r.Context(), name, lines)
 		if err != nil {
 			httpError(w, err.Error(), http.StatusBadRequest)

--- a/server/handlers/channels.go
+++ b/server/handlers/channels.go
@@ -126,6 +126,7 @@ func (h *ChannelHandler) history(w http.ResponseWriter, r *http.Request, name st
 			opts.Limit = n
 		}
 	}
+	opts.Limit = clampInt(opts.Limit, 1, 1000)
 	if s := q.Get("offset"); s != "" {
 		if n, err := strconv.Atoi(s); err == nil && n >= 0 {
 			opts.Offset = n

--- a/server/handlers/costs.go
+++ b/server/handlers/costs.go
@@ -89,6 +89,7 @@ func (h *CostHandler) daily(w http.ResponseWriter, r *http.Request) {
 			days = n
 		}
 	}
+	days = clampInt(days, 1, 365)
 	since := time.Now().AddDate(0, 0, -days)
 	costs, err := h.store.GetDailyCosts(r.Context(), since)
 	if err != nil {

--- a/server/handlers/cron.go
+++ b/server/handlers/cron.go
@@ -150,6 +150,7 @@ func (h *CronHandler) logs(w http.ResponseWriter, r *http.Request, name string) 
 			last = n
 		}
 	}
+	last = clampInt(last, 1, 1000)
 	logs, err := h.store.GetLogs(r.Context(), name, last)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)

--- a/server/handlers/events.go
+++ b/server/handlers/events.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/rpuneet/bc/pkg/events"
 )
@@ -27,21 +28,14 @@ func (h *EventHandler) list(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodGet) {
 		return
 	}
-	tail := 0
+	tail := 100
 	if s := r.URL.Query().Get("tail"); s != "" {
 		if n, err := strconv.Atoi(s); err == nil && n > 0 {
 			tail = n
 		}
 	}
-	var (
-		evts []events.Event
-		err  error
-	)
-	if tail > 0 {
-		evts, err = h.store.ReadLast(tail)
-	} else {
-		evts, err = h.store.Read()
-	}
+	tail = clampInt(tail, 1, 10000)
+	evts, err := h.store.ReadLast(tail)
 	if err != nil {
 		httpError(w, "read events: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -56,7 +50,7 @@ func (h *EventHandler) byAgent(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodGet) {
 		return
 	}
-	name := trimPrefix(r.URL.Path, "/api/logs/")
+	name := strings.TrimPrefix(r.URL.Path, "/api/logs/")
 	if name == "" {
 		httpError(w, "agent name required", http.StatusBadRequest)
 		return
@@ -72,9 +66,3 @@ func (h *EventHandler) byAgent(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, evts)
 }
 
-func trimPrefix(s, prefix string) string {
-	if len(s) >= len(prefix) && s[:len(prefix)] == prefix {
-		return s[len(prefix):]
-	}
-	return s
-}

--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -41,6 +41,33 @@ func requireMethod(w http.ResponseWriter, r *http.Request, methods ...string) bo
 	return false
 }
 
+// Recovery returns a middleware that recovers from panics, logs the error,
+// and returns a 500 JSON response instead of crashing the server.
+func Recovery(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				log.Error("panic recovered", "error", err, "method", r.Method, "path", r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				json.NewEncoder(w).Encode(map[string]string{"error": "internal server error"}) //nolint:errcheck
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}
+
+// clampInt clamps n to the range [min, max].
+func clampInt(n, min, max int) int {
+	if n < min {
+		return min
+	}
+	if n > max {
+		return max
+	}
+	return n
+}
+
 // CORS returns a middleware that adds permissive CORS headers.
 // This is safe because bcd only binds to loopback by default.
 func CORS(next http.Handler) http.Handler {

--- a/server/handlers/workspace.go
+++ b/server/handlers/workspace.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/workspace"
@@ -117,18 +118,5 @@ func isAlreadyRunning(err error) bool {
 		return false
 	}
 	msg := err.Error()
-	return len(msg) > 0 && (contains(msg, "already running") || contains(msg, "session is alive"))
-}
-
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && indexBytes(s, sub) >= 0)
-}
-
-func indexBytes(s, sub string) int {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
+	return len(msg) > 0 && (strings.Contains(msg, "already running") || strings.Contains(msg, "session is alive"))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -207,6 +207,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	if cfg.CORS {
 		handler = handlers.CORS(mux)
 	}
+	handler = handlers.Recovery(handler)
 
 	return &Server{
 		addr:    cfg.Addr,


### PR DESCRIPTION
## Summary

4 server hardening fixes batched. 9 files, +42/-33.

| Fix | Issue | What |
|-----|-------|------|
| Panic recovery | #2083 | Middleware catches panics, logs, returns 500 JSON |
| Stdlib cleanup | #2097 | Replace custom contains/trimPrefix with strings pkg |
| Event log LIMIT | #2080 | Read() capped at 1000, handler defaults tail=100 |
| Cap query params | #2092 | clampInt on all numeric params (limit, days, lines, tail) |

Closes #2083, #2097, #2080, #2092

Generated with [Claude Code](https://claude.com/claude-code)