### PR TITLE
fix: add PageUp/PageDown keyboard navigation to TUI lists

### DIFF
--- a/tui/src/hooks/useListNavigation.ts
+++ b/tui/src/hooks/useListNavigation.ts
@@ -39,6 +39,8 @@ export interface UseListNavigationOptions<T> {
   disabled?: boolean;
   /** Wrap around when reaching start/end of list */
   wrap?: boolean;
+  /** Number of items to jump on PageUp/PageDown (defaults to 10) */
+  pageSize?: number;
   /** Enable search mode with / key */
   enableSearch?: boolean;
   /** Callback when search query changes */
@@ -89,6 +91,7 @@ export function useListNavigation<T>(
     initialIndex = 0,
     disabled = false,
     wrap = false,
+    pageSize = 10,
     enableSearch = false,
     onSearchChange,
     customKeys = {},
@@ -222,6 +225,18 @@ export function useListNavigation<T>(
       // G (shift+g): jump to last
       if (input === 'G') {
         jumpToLast();
+        return;
+      }
+
+      // PageDown: move down by pageSize
+      if (key.pageDown) {
+        moveDown(pageSize);
+        return;
+      }
+
+      // PageUp: move up by pageSize
+      if (key.pageUp) {
+        moveUp(pageSize);
         return;
       }
 


### PR DESCRIPTION
## Summary

Add PageUp/PageDown support to the shared `useListNavigation` hook. All list views (agents, channels, logs, costs, roles) inherit this automatically.

### Changes (`tui/src/hooks/useListNavigation.ts`)

- Add `pageSize` option (default 10) to `UseListNavigationOptions`
- Add `key.pageDown` handler → `moveDown(pageSize)`
- Add `key.pageUp` handler → `moveUp(pageSize)`
- Cursor clamps at boundaries via existing `clampIndex` (never out of bounds)

### How it works
- PageDown moves cursor down by `pageSize` items (clamped to end)
- PageUp moves cursor up by `pageSize` items (clamped to 0)
- Views can pass a custom `pageSize` matching their visible viewport height
- Default of 10 is reasonable for most terminal sizes

### Verification
- `tsc --noEmit` — zero errors
- `eslint` — zero errors
- 54 pass in useListNavigation tests (3 pre-existing failures from missing FocusProvider in test wrapper — same on main)

Closes #2130

Generated with [Claude Code](https://claude.com/claude-code)