### PR TITLE
fix: add HEALTHCHECK to bcd and bcdb Dockerfiles

### DIFF
--- a/docker/Dockerfile.bcd
+++ b/docker/Dockerfile.bcd
@@ -21,11 +21,13 @@ RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o /bcd ./cmd/bcd
 FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates tmux git docker.io && \
+        ca-certificates tmux git docker.io curl && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=go-builder /bcd /usr/local/bin/bcd
 # Mount host Docker socket at runtime: -v /var/run/docker.sock:/var/run/docker.sock
 EXPOSE 9374
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:9374/health || exit 1
 WORKDIR /workspace
 ENTRYPOINT ["bcd"]
 CMD ["--addr", "0.0.0.0:9374", "--workspace", "/workspace"]

--- a/docker/Dockerfile.bcdb
+++ b/docker/Dockerfile.bcdb
@@ -12,3 +12,5 @@ ENV POSTGRES_DB=bc
 COPY docker/bcdb/init.sql /docker-entrypoint-initdb.d/01-init.sql
 
 EXPOSE 5432
+HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=5 \
+    CMD pg_isready -U bc -d bc || exit 1


### PR DESCRIPTION
## Summary
Adds Docker HEALTHCHECK instructions so orchestrators can detect unhealthy containers.

| Image | Check | Interval | Start Period |
|-------|-------|----------|-------------|
| bcd | `curl -f http://localhost:9374/health` | 30s | 10s |
| bcdb | `pg_isready -U bc -d bc` | 10s | 30s |

Also adds `curl` to bcd runtime image (needed for health check).

Closes #2078

## Test plan
- [x] HEALTHCHECK syntax valid
- [x] bcd health endpoint exists (`GET /health`)
- [x] `pg_isready` is built into postgres base image

Generated with [Claude Code](https://claude.com/claude-code)