### PR TITLE
chore: add docker-compose.yml for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+# Local development stack: bcd server + bcdb Postgres
+# Usage: docker-compose up
+#
+# Prerequisites: build images first
+#   make build-server-images
+
+services:
+  bcdb:
+    image: bc-bcdb:latest
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-bc}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-bc}
+      POSTGRES_DB: ${POSTGRES_DB:-bc}
+    ports:
+      - "5432:5432"
+    volumes:
+      - bcdb-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bc -d bc"]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 5
+
+  bcd:
+    image: bc-bcd:latest
+    ports:
+      - "9374:9374"
+    environment:
+      DATABASE_URL: postgres://${POSTGRES_USER:-bc}:${POSTGRES_PASSWORD:-bc}@bcdb:5432/${POSTGRES_DB:-bc}?sslmode=disable
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - .:/workspace
+    depends_on:
+      bcdb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9374/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+
+volumes:
+  bcdb-data:


### PR DESCRIPTION
## Summary
`docker-compose up` starts the full bcd + bcdb stack for local development.

### Services:
| Service | Image | Port | Health Check |
|---------|-------|------|-------------|
| bcdb | bc-bcdb:latest | 5432 | `pg_isready` every 10s |
| bcd | bc-bcd:latest | 9374 | `curl /health` every 30s |

### Features:
- bcd waits for bcdb health before starting
- Postgres credentials configurable via env vars (defaults: bc/bc/bc)
- `DATABASE_URL` auto-wired to bcdb service
- Docker socket mounted for agent container management
- Workspace mounted at `/workspace`
- Named volume `bcdb-data` for persistence

### Usage:
```bash
make build-server-images   # Build images first
docker-compose up          # Start stack
docker-compose down        # Stop (data preserved)
docker-compose down -v     # Stop + wipe data
```

Closes #2081

## Test plan
- [x] YAML syntax valid
- [x] Health checks match Dockerfile HEALTHCHECK directives
- [x] Env var defaults match Dockerfile.bcdb

Generated with [Claude Code](https://claude.com/claude-code)