### PR TITLE
fix: remove root_dir from workspace status + validate up request body

### DIFF
--- a/server/handlers/workspace.go
+++ b/server/handlers/workspace.go
@@ -46,7 +46,6 @@ func (h *WorkspaceHandler) status(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"name":          h.ws.Name(),
-		"root_dir":      h.ws.RootDir,
 		"agent_count":   len(agents),
 		"running_count": runningCount,
 		"is_healthy":    true,
@@ -82,7 +81,12 @@ func (h *WorkspaceHandler) up(w http.ResponseWriter, r *http.Request) {
 		Tool    string `json:"tool"`
 		Runtime string `json:"runtime"`
 	}
-	_ = json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck // optional body
+	if r.ContentLength > 0 {
+		if decodeErr := json.NewDecoder(r.Body).Decode(&req); decodeErr != nil {
+			httpError(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+	}
 	a, err := h.svc.Create(r.Context(), agent.CreateOptions{
 		Name:    "root",
 		Role:    agent.RoleRoot,


### PR DESCRIPTION
## Summary

Two small workspace handler fixes. 1 file, +6/-2.

- Remove `root_dir` from GET /api/workspace response (closes #2098)
- Validate POST /api/workspace/up body when present (closes #2100)

Closes #2098, #2100

Generated with [Claude Code](https://claude.com/claude-code)