### PR TITLE
fix: remove --dangerously-skip-permissions from default config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,7 +24,8 @@ path = ""
 default = "claude"
 
 [providers.claude]
-command = "claude --dangerously-skip-permissions"
+# Add --dangerously-skip-permissions if you want agents to run without approval prompts
+command = "claude"
 enabled = true
 
 [providers.gemini]


### PR DESCRIPTION
## Summary
Default claude provider command changes from `claude --dangerously-skip-permissions` to `claude`. Users opt in to dangerous flags explicitly.

Added comment in config.toml explaining how to add the flag back.

Closes #2088

## Test plan
- [x] Config change only — no code affected
- [x] Comment documents the opt-in flag

Generated with [Claude Code](https://claude.com/claude-code)