### PR TITLE
fix: add 1MB request body size limit to all API endpoints

### DIFF
--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -68,6 +68,21 @@ func clampInt(n, min, max int) int {
 	return n
 }
 
+// MaxBodySize returns a middleware that limits request body size.
+// Returns 413 Payload Too Large if the body exceeds maxBytes.
+func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.ContentLength > maxBytes {
+				httpError(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // CORS returns a middleware that adds permissive CORS headers.
 // This is safe because bcd only binds to loopback by default.
 func CORS(next http.Handler) http.Handler {

--- a/server/server.go
+++ b/server/server.go
@@ -207,6 +207,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	if cfg.CORS {
 		handler = handlers.CORS(mux)
 	}
+	handler = handlers.MaxBodySize(1 << 20)(handler) // 1MB request body limit
 	handler = handlers.Recovery(handler)
 
 	return &Server{


### PR DESCRIPTION
## Summary

MaxBodySize middleware limits all request bodies to 1MB. Returns 413 if exceeded. Prevents DoS via memory exhaustion.

2 files, +16 lines. SSE unaffected (GET-only). MCP has own 4MB limit.

Closes #2077

Generated with [Claude Code](https://claude.com/claude-code)