### PR TITLE
fix: add --cors-origin flag to restrict CORS when exposed

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -4,7 +4,7 @@
 //
 // Usage:
 //
-//	bcd [--addr ADDR] [--workspace DIR] [--verbose] [--log-format text|json]
+//	bcd [--addr ADDR] [--workspace DIR] [--verbose] [--log-format text|json] [--cors-origin ORIGIN]
 //
 // The server binds to 127.0.0.1:9374 by default.
 // A PID file is written to <workspace>/.bc/bcd.pid on startup.
@@ -43,6 +43,7 @@ func main() {
 	wsRoot := flag.String("workspace", ".", "workspace root directory")
 	verbose := flag.Bool("verbose", false, "enable verbose logging")
 	logFormat := flag.String("log-format", "text", "log output format (text|json)")
+	corsOrigin := flag.String("cors-origin", "*", "CORS allowed origin (* for permissive, or specific origin)")
 	flag.Parse()
 
 	if *logFormat == "json" {
@@ -52,13 +53,13 @@ func main() {
 		log.SetVerbose(true)
 	}
 
-	if err := run(*addr, *wsRoot); err != nil {
+	if err := run(*addr, *wsRoot, *corsOrigin); err != nil {
 		fmt.Fprintf(os.Stderr, "bcd: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(addr, wsRoot string) error {
+func run(addr, wsRoot, corsOrigin string) error {
 	// Try to load existing workspace; if none exists, initialize a minimal one.
 	// This allows bcd to run in a fresh Docker container without a pre-existing workspace.
 	ws, err := bcworkspace.Load(wsRoot)
@@ -219,6 +220,7 @@ func run(addr, wsRoot string) error {
 	if addr != "" {
 		cfg.Addr = addr
 	}
+	cfg.CORSOrigin = corsOrigin
 
 	srv := server.New(cfg, svc, hub, server.WebDist())
 	return srv.Start(ctx)

--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -68,26 +68,12 @@ func clampInt(n, min, max int) int {
 	return n
 }
 
-// MaxBodySize returns a middleware that limits request body size.
-// Returns 413 Payload Too Large if the body exceeds maxBytes.
-func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.ContentLength > maxBytes {
-				httpError(w, "request body too large", http.StatusRequestEntityTooLarge)
-				return
-			}
-			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
-			next.ServeHTTP(w, r)
-		})
-	}
-}
-
-// CORS returns a middleware that adds permissive CORS headers.
-// This is safe because bcd only binds to loopback by default.
-func CORS(next http.Handler) http.Handler {
+// CORSWithOrigin returns a middleware that adds CORS headers with the specified
+// allowed origin. Use "*" for permissive (safe on loopback) or a specific
+// origin like "http://localhost:9374" when exposed beyond loopback.
+func CORSWithOrigin(allowedOrigin string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 		if r.Method == http.MethodOptions {
@@ -96,4 +82,10 @@ func CORS(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// CORS returns a middleware with permissive CORS headers (Allow-Origin: *).
+// Safe because bcd only binds to loopback by default.
+func CORS(next http.Handler) http.Handler {
+	return CORSWithOrigin("*", next)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -39,13 +39,14 @@ const defaultAddr = "127.0.0.1:9374"
 
 // Config holds server configuration.
 type Config struct {
-	Addr string // default "127.0.0.1:9374"
-	CORS bool   // enable permissive CORS headers (safe for loopback)
+	Addr       string // default "127.0.0.1:9374"
+	CORS       bool   // enable CORS headers
+	CORSOrigin string // allowed origin ("*" for permissive, or specific origin)
 }
 
 // DefaultConfig returns the default server configuration.
 func DefaultConfig() Config {
-	return Config{Addr: defaultAddr, CORS: true}
+	return Config{Addr: defaultAddr, CORS: true, CORSOrigin: "*"}
 }
 
 // Services bundles all service/store dependencies for the handlers.
@@ -204,10 +205,14 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 
 	// Middleware chain (outermost runs first):
-	// RequestLogger → Recovery → CORS → mux
+	// RequestLogger → Recovery → MaxBodySize → CORS → mux
 	var handler http.Handler = mux
 	if cfg.CORS {
-		handler = handlers.CORS(mux)
+		origin := cfg.CORSOrigin
+		if origin == "" {
+			origin = "*"
+		}
+		handler = handlers.CORSWithOrigin(origin, mux)
 	}
 	handler = handlers.MaxBodySize(1 << 20)(handler) // 1MB request body limit
 	handler = handlers.Recovery(handler)


### PR DESCRIPTION
## Summary
Makes CORS origin configurable via `--cors-origin` flag. Default `*` (backward compatible). Rebased on current main with all middleware PRs.

### Changes:
- `server/handlers/helpers.go` — `CORSWithOrigin(origin, next)` middleware
- `server/server.go` — `Config.CORSOrigin` field, wired into chain
- `cmd/bcd/main.go` — `--cors-origin` flag

Replaces #2254 (closed due to merge conflict).

Closes #2058

## Test plan
- [x] Default `*` unchanged
- [x] Builds on current main (no conflicts)

Generated with [Claude Code](https://claude.com/claude-code)