### PR TITLE
perf: add gzip response compression middleware

### DIFF
--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -3,10 +3,13 @@
 package handlers
 
 import (
+	"compress/gzip"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/rpuneet/bc/pkg/log"
 )
@@ -103,6 +106,40 @@ func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// Gzip returns a middleware that compresses responses with gzip when the
+// client sends Accept-Encoding: gzip. Skips SSE and MCP streaming endpoints.
+func Gzip(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if r.URL.Path == "/api/events" || strings.HasPrefix(r.URL.Path, "/mcp/") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		gz, err := gzip.NewWriterLevel(w, gzip.DefaultCompression)
+		if err != nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		defer gz.Close()
+		w.Header().Set("Content-Encoding", "gzip")
+		w.Header().Set("Vary", "Accept-Encoding")
+		w.Header().Del("Content-Length")
+		next.ServeHTTP(&gzipResponseWriter{ResponseWriter: w, Writer: gz}, r)
+	})
+}
+
+type gzipResponseWriter struct {
+	http.ResponseWriter
+	io.Writer
+}
+
+func (w *gzipResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
 }
 
 // CORSWithOrigin returns a middleware that adds CORS headers with the specified

--- a/server/server.go
+++ b/server/server.go
@@ -234,7 +234,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 
 	// Middleware chain (outermost runs first):
-	// RateLimit → RequestID → RequestLogger → Recovery → MaxBodySize → CORS → mux
+	// RateLimit → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → mux
 	var handler http.Handler = mux
 	if cfg.CORS {
 		origin := cfg.CORSOrigin
@@ -244,6 +244,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		handler = handlers.CORSWithOrigin(origin, mux)
 	}
 	handler = handlers.MaxBodySize(1 << 20)(handler)
+	handler = handlers.Gzip(handler)
 	handler = handlers.Recovery(handler)
 	handler = handlers.RequestLogger(handler)
 	handler = handlers.RequestID(handler)


### PR DESCRIPTION
## Summary

Gzip middleware compresses JSON responses when client sends Accept-Encoding: gzip. Skips SSE/MCP streaming endpoints.

2 files, +40/-1.

Closes #2096

Generated with [Claude Code](https://claude.com/claude-code)