### PR TITLE
fix: change Docker default network mode from host to bridge

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -109,7 +109,7 @@ cpus = 2.0
 # Memory limit per container in MB
 memory_mb = 2048
 # Docker network mode
-network = "host"
+network = "bridge"
 # Extra volume mounts (host:container:mode)
 # extra_mounts = ["/data:/data:ro"]
 

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -57,7 +57,7 @@ func ConfigFromWorkspace(dcfg workspace.DockerRuntimeConfig) Config {
 		cfg.MemoryMB = 2048
 	}
 	if cfg.Network == "" {
-		cfg.Network = "host"
+		cfg.Network = "bridge"
 	}
 	return cfg
 }


### PR DESCRIPTION
## Summary

Default Docker network changed from `host` to `bridge` for better container isolation. 2 files, 2 lines.

Closes #2093

Generated with [Claude Code](https://claude.com/claude-code)