### PR TITLE
fix: remove hardcoded POSTGRES_PASSWORD from Dockerfile.bcdb

### DIFF
--- a/docker/Dockerfile.bcdb
+++ b/docker/Dockerfile.bcdb
@@ -1,12 +1,17 @@
 # bcdb image — Postgres database for bc workspaces
 # Usage: docker build -t bc-bcdb:latest -f docker/Dockerfile.bcdb .
 # Base images pinned — update versions in Dependabot PRs or manually.
+#
+# POSTGRES_PASSWORD must be set at runtime:
+#   docker run -e POSTGRES_PASSWORD=secret bc-bcdb:latest
+#   Or via docker-compose.yml / .env file
 
 FROM postgres:17.4
 
 ENV POSTGRES_USER=bc
-ENV POSTGRES_PASSWORD=bc
 ENV POSTGRES_DB=bc
+# POSTGRES_PASSWORD intentionally not set — must be provided at runtime.
+# See .env.example for documentation.
 
 # Init scripts run on first start (alphabetical order)
 COPY docker/bcdb/init.sql /docker-entrypoint-initdb.d/01-init.sql


### PR DESCRIPTION
## Summary
Removes `ENV POSTGRES_PASSWORD=bc` from the Docker image. Password must be provided at runtime via `-e` flag, docker-compose, or `.env` file.

`POSTGRES_USER=bc` and `POSTGRES_DB=bc` kept as defaults (non-sensitive).

`docker-compose.yml` already uses `${POSTGRES_PASSWORD:-bc}` which provides the dev default at runtime, not baked into the image.

Closes #2051

## Test plan
- [x] Dockerfile syntax valid
- [x] Comment documents runtime requirement
- [x] docker-compose.yml still works (env var default)
- [x] .env.example already documents POSTGRES_PASSWORD

Generated with [Claude Code](https://claude.com/claude-code)