### PR TITLE
fix: run bcd Docker container as non-root user

### DIFF
--- a/docker/Dockerfile.bcd
+++ b/docker/Dockerfile.bcd
@@ -24,10 +24,17 @@ RUN apt-get update && \
         ca-certificates tmux git docker.io curl && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=go-builder /bcd /usr/local/bin/bcd
+
+# Run as non-root. Docker socket access via docker group membership.
+# The host Docker socket GID must match — use --group-add on docker run if needed.
+RUN useradd -m -s /bin/bash bcd && usermod -aG docker bcd
+
 # Mount host Docker socket at runtime: -v /var/run/docker.sock:/var/run/docker.sock
 EXPOSE 9374
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:9374/health || exit 1
+
+USER bcd
 WORKDIR /workspace
 ENTRYPOINT ["bcd"]
 CMD ["--addr", "0.0.0.0:9374", "--workspace", "/workspace"]


### PR DESCRIPTION
## Summary
Adds `bcd` user to the bcd Docker image and runs the server as non-root. Docker socket access via `docker` group membership.

### Changes:
- `RUN useradd -m -s /bin/bash bcd && usermod -aG docker bcd`
- `USER bcd` before ENTRYPOINT
- Comment documenting `--group-add` for GID mismatch

Closes #2075

## Test plan
- [x] Dockerfile syntax valid
- [x] `docker` group gives socket access
- [x] HEALTHCHECK still works as non-root (curl)
- [x] tmux/git work as non-root

Generated with [Claude Code](https://claude.com/claude-code)