### PR TITLE
fix: migrate cron + tool stores to pkg/db.Open()

### DIFF
--- a/pkg/cron/store.go
+++ b/pkg/cron/store.go
@@ -4,40 +4,31 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3" // SQLite driver
-
+	"github.com/rpuneet/bc/pkg/db"
 	"github.com/rpuneet/bc/pkg/log"
 )
 
 // Store is a SQLite-backed cron job store.
 type Store struct {
-	db   *sql.DB
+	db   *db.DB
 	path string
 }
 
 // Open opens (or creates) the cron database for the given workspace.
 func Open(workspacePath string) (*Store, error) {
 	path := filepath.Join(workspacePath, ".bc", "cron.db")
-	if err := os.MkdirAll(filepath.Dir(path), 0750); err != nil {
-		return nil, fmt.Errorf("create cron db directory: %w", err)
-	}
 
-	db, err := sql.Open("sqlite3", path+"?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=5000")
+	database, err := db.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open cron database: %w", err)
 	}
 
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
-	db.SetConnMaxLifetime(time.Hour)
-
-	s := &Store{db: db, path: path}
+	s := &Store{db: database, path: path}
 	if err := s.initSchema(); err != nil {
-		_ = db.Close()
+		_ = database.Close()
 		return nil, fmt.Errorf("init cron schema: %w", err)
 	}
 	return s, nil

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -6,11 +6,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 	"time"
 
-	_ "github.com/mattn/go-sqlite3"
+	"github.com/rpuneet/bc/pkg/db"
 )
 
 // Tool represents a configured AI tool provider stored in the workspace.
@@ -91,7 +90,7 @@ var builtinTools = []Tool{
 
 // Store provides SQLite-backed tool management.
 type Store struct {
-	db   *sql.DB
+	db   *db.DB
 	path string
 }
 
@@ -104,29 +103,20 @@ func NewStore(stateDir string) *Store {
 
 // Open initializes the SQLite database and seeds built-in tools.
 func (s *Store) Open() error {
-	if err := os.MkdirAll(filepath.Dir(s.path), 0750); err != nil {
-		return fmt.Errorf("failed to create database directory: %w", err)
-	}
-
-	db, err := sql.Open("sqlite3", s.path+"?_foreign_keys=on&_journal_mode=WAL&_busy_timeout=5000")
+	database, err := db.Open(s.path)
 	if err != nil {
 		return fmt.Errorf("failed to open database: %w", err)
 	}
 
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(1)
-	db.SetConnMaxLifetime(time.Hour)
-	db.SetConnMaxIdleTime(10 * time.Minute)
-
-	if err := initSchema(db); err != nil {
-		_ = db.Close()
+	if err := initSchema(database.DB); err != nil {
+		_ = database.Close()
 		return fmt.Errorf("failed to initialize schema: %w", err)
 	}
 
-	s.db = db
+	s.db = database
 
 	if err := s.seedBuiltins(context.Background()); err != nil {
-		_ = db.Close()
+		_ = database.Close()
 		return fmt.Errorf("failed to seed built-in tools: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
Migrates cron and tool SQLite stores from direct `sql.Open()` to `pkg/db.Open()` for consistent pragmas (30s busy timeout vs 5s, NORMAL sync, mmap, temp_store).

Part of #2089 — phase 1 of 4.

### Verified locally:
- `go build` — pass
- `go vet` — pass  
- `go test -race` — pass

Partially addresses #2089

Generated with [Claude Code](https://claude.com/claude-code)