### PR TITLE
feat: add limit/offset pagination to all list API endpoints

### DIFF
--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -84,6 +84,15 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 		for _, a := range agents {
 			dtos = append(dtos, toDTO(a))
 		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(dtos) {
+			dtos = []agentDTO{}
+		} else {
+			dtos = dtos[offset:]
+			if len(dtos) > limit {
+				dtos = dtos[:limit]
+			}
+		}
 		writeJSON(w, http.StatusOK, dtos)
 
 	case http.MethodPost:

--- a/server/handlers/channels.go
+++ b/server/handlers/channels.go
@@ -33,6 +33,15 @@ func (h *ChannelHandler) list(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "list channels: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(channels) {
+			channels = channels[:0]
+		} else {
+			channels = channels[offset:]
+			if len(channels) > limit {
+				channels = channels[:limit]
+			}
+		}
 		writeJSON(w, http.StatusOK, channels)
 
 	case http.MethodPost:

--- a/server/handlers/costs.go
+++ b/server/handlers/costs.go
@@ -52,6 +52,15 @@ func (h *CostHandler) byResource(w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(summaries) {
+			summaries = []*cost.Summary{}
+		} else {
+			summaries = summaries[offset:]
+			if len(summaries) > limit {
+				summaries = summaries[:limit]
+			}
+		}
 		writeJSON(w, http.StatusOK, summaries)
 
 	case "teams":
@@ -60,6 +69,15 @@ func (h *CostHandler) byResource(w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(summaries) {
+			summaries = []*cost.Summary{}
+		} else {
+			summaries = summaries[offset:]
+			if len(summaries) > limit {
+				summaries = summaries[:limit]
+			}
+		}
 		writeJSON(w, http.StatusOK, summaries)
 
 	case "models":
@@ -67,6 +85,15 @@ func (h *CostHandler) byResource(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			httpError(w, err.Error(), http.StatusInternalServerError)
 			return
+		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(summaries) {
+			summaries = []*cost.Summary{}
+		} else {
+			summaries = summaries[offset:]
+			if len(summaries) > limit {
+				summaries = summaries[:limit]
+			}
 		}
 		writeJSON(w, http.StatusOK, summaries)
 

--- a/server/handlers/cron.go
+++ b/server/handlers/cron.go
@@ -36,6 +36,15 @@ func (h *CronHandler) list(w http.ResponseWriter, r *http.Request) {
 		if jobs == nil {
 			jobs = []*cron.Job{}
 		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(jobs) {
+			jobs = []*cron.Job{}
+		} else {
+			jobs = jobs[offset:]
+			if len(jobs) > limit {
+				jobs = jobs[:limit]
+			}
+		}
 		writeJSON(w, http.StatusOK, jobs)
 
 	case http.MethodPost:

--- a/server/handlers/daemons.go
+++ b/server/handlers/daemons.go
@@ -35,6 +35,15 @@ func (h *DaemonHandler) list(w http.ResponseWriter, r *http.Request) {
 		if daemons == nil {
 			daemons = []*daemon.Daemon{}
 		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(daemons) {
+			daemons = []*daemon.Daemon{}
+		} else {
+			daemons = daemons[offset:]
+			if len(daemons) > limit {
+				daemons = daemons[:limit]
+			}
+		}
 		writeJSON(w, http.StatusOK, daemons)
 
 	case http.MethodPost:

--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/rpuneet/bc/pkg/log"
@@ -80,6 +81,22 @@ func generateRequestID() string {
 	b := make([]byte, 8)
 	_, _ = rand.Read(b) //nolint:errcheck // crypto/rand never fails on supported platforms
 	return hex.EncodeToString(b)
+}
+
+// parsePagination extracts limit and offset from query params with defaults and clamping.
+func parsePagination(r *http.Request, defaultLimit int) (limit, offset int) {
+	limit = defaultLimit
+	if s := r.URL.Query().Get("limit"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			limit = clampInt(n, 1, 1000)
+		}
+	}
+	if s := r.URL.Query().Get("offset"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	return
 }
 
 // clampInt clamps n to the range [min, max].

--- a/server/handlers/mcp.go
+++ b/server/handlers/mcp.go
@@ -35,6 +35,15 @@ func (h *MCPHandler) list(w http.ResponseWriter, r *http.Request) {
 		if servers == nil {
 			servers = []*mcp.ServerConfig{}
 		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(servers) {
+			servers = []*mcp.ServerConfig{}
+		} else {
+			servers = servers[offset:]
+			if len(servers) > limit {
+				servers = servers[:limit]
+			}
+		}
 		writeJSON(w, http.StatusOK, servers)
 
 	case http.MethodPost:

--- a/server/handlers/secrets.go
+++ b/server/handlers/secrets.go
@@ -33,6 +33,15 @@ func (h *SecretHandler) list(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "list secrets: "+err.Error(), http.StatusInternalServerError)
 			return
 		}
+		limit, offset := parsePagination(r, 50)
+		if offset >= len(secrets) {
+			secrets = []*secret.SecretMeta{}
+		} else {
+			secrets = secrets[offset:]
+			if len(secrets) > limit {
+				secrets = secrets[:limit]
+			}
+		}
 		writeJSON(w, http.StatusOK, secrets)
 
 	case http.MethodPost:

--- a/server/handlers/tools.go
+++ b/server/handlers/tools.go
@@ -36,6 +36,15 @@ func (h *ToolHandler) list(w http.ResponseWriter, r *http.Request) {
 	if tools == nil {
 		tools = []*tool.Tool{}
 	}
+	limit, offset := parsePagination(r, 50)
+	if offset >= len(tools) {
+		tools = []*tool.Tool{}
+	} else {
+		tools = tools[offset:]
+		if len(tools) > limit {
+			tools = tools[:limit]
+		}
+	}
 	writeJSON(w, http.StatusOK, tools)
 }
 


### PR DESCRIPTION
## Summary

All 10 list endpoints now support `?limit=N&offset=M`. Default limit=50, max=1000.

9 files, +107 lines. Build+vet+tests pass locally.

Closes #2084

Generated with [Claude Code](https://claude.com/claude-code)