### PR TITLE
fix: cap query params + add channel name to message format

### DIFF
--- a/server/handlers/channels.go
+++ b/server/handlers/channels.go
@@ -141,6 +141,7 @@ func (h *ChannelHandler) history(w http.ResponseWriter, r *http.Request, name st
 			opts.Offset = n
 		}
 	}
+	opts.Offset = clampInt(opts.Offset, 0, 100000)
 	msgs, err := h.svc.History(r.Context(), name, opts)
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError)

--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -185,7 +185,7 @@ func (s *Server) toolSendMessage(raw json.RawMessage) (*toolsCallResult, error) 
 		// Best-effort delivery to channel members via agent manager
 		if s.agents != nil {
 			members, _ := s.chans.GetMembers(args.Channel)
-			formatted := fmt.Sprintf("[bc-mcp][%s] %s: %s", time.Now().UTC().Format(time.RFC3339), sender, args.Message)
+			formatted := fmt.Sprintf("[bc-mcp][%s][#%s] %s: %s", time.Now().UTC().Format(time.RFC3339), args.Channel, sender, args.Message)
 			for _, member := range members {
 				if member == sender {
 					continue

--- a/server/server.go
+++ b/server/server.go
@@ -136,7 +136,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	if svc.Channels != nil {
 		svc.Channels.OnMessage = func(ch, sender, content string) {
 			if svc.Agents != nil {
-				formatted := fmt.Sprintf("[bc-mcp][%s] %s: %s", time.Now().UTC().Format(time.RFC3339), sender, content)
+				formatted := fmt.Sprintf("[bc-mcp][%s][#%s] %s: %s", time.Now().UTC().Format(time.RFC3339), ch, sender, content)
 				chDTO, err := svc.Channels.Get(context.Background(), ch)
 				if err != nil {
 					log.Debug("channel send: failed to get channel", "channel", ch, "error", err)


### PR DESCRIPTION
## Summary
- **Cap offset query param** in channel history endpoint (`clampInt(offset, 0, 100000)`) to prevent abuse. All other query params were already capped — this was the last uncapped one. Closes #2092.
- **Add channel name to agent message format**: `[bc-mcp][ts][#channel] sender: msg` — gives agents context about which channel a message came from. Both the ChannelService OnMessage hook and standalone MCP delivery are updated.

## Test plan
- [ ] Verify `GET /api/channels/{name}/history?offset=999999` is clamped to 100000
- [ ] Verify channel messages delivered to agents include `[#channelname]` prefix
- [ ] `go vet ./server/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)