### PR TITLE
fix: remove custom stdlib duplicates

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -57,6 +57,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -194,12 +195,7 @@ func CheckPermission(permissions []string, required Permission) error {
 
 // HasPermissionStr checks if a permission string is in the list.
 func HasPermissionStr(permissions []string, required string) bool {
-	for _, p := range permissions {
-		if p == required {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(permissions, required)
 }
 
 // RoleCapabilities and RoleHierarchy are empty here.

--- a/pkg/channel/message_type_test.go
+++ b/pkg/channel/message_type_test.go
@@ -1,6 +1,7 @@
 package channel
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -37,23 +38,10 @@ func TestValidMessageTypes(t *testing.T) {
 	}
 	// Should contain all type names
 	for _, typ := range AllMessageTypes() {
-		if !contains(result, string(typ)) {
+		if !strings.Contains(result, string(typ)) {
 			t.Errorf("ValidMessageTypes missing %s", typ)
 		}
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
-}
-
-func containsHelper(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }
 
 func TestIsValidMessageType(t *testing.T) {
@@ -228,13 +216,13 @@ func TestTypedMessage_FormatForDisplay(t *testing.T) {
 	result := msg.FormatForDisplay()
 
 	// Should contain emoji and type
-	if !containsHelper(result, "👀") {
+	if !strings.Contains(result, "👀") {
 		t.Error("FormatForDisplay should contain review emoji")
 	}
-	if !containsHelper(result, "review") {
+	if !strings.Contains(result, "review") {
 		t.Error("FormatForDisplay should contain type name")
 	}
-	if !containsHelper(result, "Please review PR #123") {
+	if !strings.Contains(result, "Please review PR #123") {
 		t.Error("FormatForDisplay should contain message content")
 	}
 }

--- a/pkg/cost/importer.go
+++ b/pkg/cost/importer.go
@@ -235,4 +235,3 @@ func (imp *Importer) lastImportedTimestamp(ctx context.Context, path string) (ti
 	t, err := time.Parse(time.RFC3339Nano, watermark)
 	return t, err
 }
-

--- a/pkg/demon/demon.go
+++ b/pkg/demon/demon.go
@@ -490,13 +490,9 @@ func (c *CronSchedule) Next(after time.Time) time.Time {
 }
 
 func (c *CronSchedule) matches(t time.Time) bool {
-	return contains(c.Minute, t.Minute()) &&
-		contains(c.Hour, t.Hour()) &&
-		contains(c.DayOfMonth, t.Day()) &&
-		contains(c.Month, int(t.Month())) &&
-		contains(c.DayOfWeek, int(t.Weekday()))
-}
-
-func contains(slice []int, val int) bool {
-	return slices.Contains(slice, val)
+	return slices.Contains(c.Minute, t.Minute()) &&
+		slices.Contains(c.Hour, t.Hour()) &&
+		slices.Contains(c.DayOfMonth, t.Day()) &&
+		slices.Contains(c.Month, int(t.Month())) &&
+		slices.Contains(c.DayOfWeek, int(t.Weekday()))
 }

--- a/pkg/demon/demon_test.go
+++ b/pkg/demon/demon_test.go
@@ -3,6 +3,7 @@ package demon
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 )
@@ -963,22 +964,22 @@ func TestRangeSliceSingleValue(t *testing.T) {
 	}
 }
 
-// --- contains helper test ---
+// --- slices.Contains helper test ---
 
 func TestContainsHelper(t *testing.T) {
 	slice := []int{1, 2, 3, 4, 5}
 
-	if !contains(slice, 3) {
-		t.Error("contains should return true for existing value")
+	if !slices.Contains(slice, 3) {
+		t.Error("slices.Contains should return true for existing value")
 	}
 
-	if contains(slice, 10) {
-		t.Error("contains should return false for non-existing value")
+	if slices.Contains(slice, 10) {
+		t.Error("slices.Contains should return false for non-existing value")
 	}
 
 	// Empty slice
-	if contains([]int{}, 1) {
-		t.Error("contains should return false for empty slice")
+	if slices.Contains([]int{}, 1) {
+		t.Error("slices.Contains should return false for empty slice")
 	}
 }
 

--- a/pkg/tmux/session_test.go
+++ b/pkg/tmux/session_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -133,16 +134,6 @@ func newTestManager(prefix string, mock func(string, ...string) *exec.Cmd) *Mana
 		SessionPrefix: prefix,
 		execCommand:   mock,
 	}
-}
-
-// sliceContains checks if a string slice contains a target value.
-func sliceContains(strs []string, target string) bool {
-	for _, s := range strs {
-		if s == target {
-			return true
-		}
-	}
-	return false
 }
 
 // ---------------------------------------------------------------------------
@@ -475,13 +466,13 @@ func TestCreateSession_Success(t *testing.T) {
 	if rec.name != "tmux" {
 		t.Errorf("expected tmux command, got %s", rec.name)
 	}
-	if !sliceContains(rec.args, "new-session") {
+	if !slices.Contains(rec.args, "new-session") {
 		t.Error("expected new-session in args")
 	}
-	if !sliceContains(rec.args, "bc-agent1") {
+	if !slices.Contains(rec.args, "bc-agent1") {
 		t.Error("expected session name in args")
 	}
-	if !sliceContains(rec.args, "/workspace") {
+	if !slices.Contains(rec.args, "/workspace") {
 		t.Error("expected directory in args")
 	}
 }
@@ -494,7 +485,7 @@ func TestCreateSession_NoDir(t *testing.T) {
 		t.Fatalf("CreateSession failed: %v", err)
 	}
 
-	if sliceContains((*records)[0].args, "-c") {
+	if slices.Contains((*records)[0].args, "-c") {
 		t.Error("should not include -c flag when dir is empty")
 	}
 }
@@ -546,7 +537,7 @@ func TestCreateSessionWithEnv_Success(t *testing.T) {
 	if len(*records) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(*records))
 	}
-	if !sliceContains((*records)[0].args, "bash") {
+	if !slices.Contains((*records)[0].args, "bash") {
 		t.Error("expected bash in args")
 	}
 }
@@ -602,7 +593,7 @@ func TestKillSession_Success(t *testing.T) {
 	if len(*records) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(*records))
 	}
-	if !sliceContains((*records)[0].args, "kill-session") {
+	if !slices.Contains((*records)[0].args, "kill-session") {
 		t.Error("expected kill-session in args")
 	}
 }
@@ -653,11 +644,11 @@ func TestSendKeysWithSubmit_ShortMessage(t *testing.T) {
 		t.Fatalf("expected 2 calls, got %d", len(*records))
 	}
 
-	if !sliceContains((*records)[0].args, "-l") {
+	if !slices.Contains((*records)[0].args, "-l") {
 		t.Error("first call should include -l flag for literal mode")
 	}
 	// Enter is sent as -H 0D (raw hex CR byte) for tmux 3.5+ compatibility
-	if !sliceContains((*records)[1].args, "-H") || !sliceContains((*records)[1].args, "0D") {
+	if !slices.Contains((*records)[1].args, "-H") || !slices.Contains((*records)[1].args, "0D") {
 		t.Errorf("second call should use -H 0D for Enter, got args: %v", (*records)[1].args)
 	}
 }
@@ -708,13 +699,13 @@ func TestSendKeysWithSubmit_LongMessage(t *testing.T) {
 		t.Fatalf("expected 3 calls, got %d", len(*records))
 	}
 
-	if !sliceContains((*records)[0].args, "load-buffer") {
+	if !slices.Contains((*records)[0].args, "load-buffer") {
 		t.Error("first call should be load-buffer")
 	}
-	if !sliceContains((*records)[1].args, "paste-buffer") {
+	if !slices.Contains((*records)[1].args, "paste-buffer") {
 		t.Error("second call should be paste-buffer")
 	}
-	if !sliceContains((*records)[2].args, "-H") || !sliceContains((*records)[2].args, "0D") {
+	if !slices.Contains((*records)[2].args, "-H") || !slices.Contains((*records)[2].args, "0D") {
 		t.Errorf("third call should use -H 0D for Enter, got args: %v", (*records)[2].args)
 	}
 }
@@ -799,7 +790,7 @@ func TestSendKeysWithSubmit_CustomSubmitKey(t *testing.T) {
 	if len(*records) != 2 {
 		t.Fatalf("expected 2 calls, got %d", len(*records))
 	}
-	if !sliceContains((*records)[1].args, "C-m") {
+	if !slices.Contains((*records)[1].args, "C-m") {
 		t.Error("second call should use custom submit key C-m")
 	}
 }
@@ -827,10 +818,10 @@ func TestCapture_WithLines(t *testing.T) {
 		t.Fatalf("Capture failed: %v", err)
 	}
 
-	if !sliceContains((*records)[0].args, "-S") {
+	if !slices.Contains((*records)[0].args, "-S") {
 		t.Error("should include -S flag when lines > 0")
 	}
-	if !sliceContains((*records)[0].args, "-100") {
+	if !slices.Contains((*records)[0].args, "-100") {
 		t.Error("should include negative line count")
 	}
 }
@@ -843,7 +834,7 @@ func TestCapture_NoLines(t *testing.T) {
 		t.Fatalf("Capture failed: %v", err)
 	}
 
-	if sliceContains((*records)[0].args, "-S") {
+	if slices.Contains((*records)[0].args, "-S") {
 		t.Error("should not include -S flag when lines = 0")
 	}
 }
@@ -999,7 +990,7 @@ func TestAttachCmd_WorkspaceManager(t *testing.T) {
 	m.execCommand = exec.Command
 	cmd := m.AttachCmd(testCtx(), "agent1")
 	expectedName := m.SessionName("agent1")
-	if !sliceContains(cmd.Args, expectedName) {
+	if !slices.Contains(cmd.Args, expectedName) {
 		t.Errorf("args should contain full session name %q: %v", expectedName, cmd.Args)
 	}
 }
@@ -1062,13 +1053,13 @@ func TestSetEnvironment_Success(t *testing.T) {
 	if len(*records) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(*records))
 	}
-	if !sliceContains((*records)[0].args, "set-environment") {
+	if !slices.Contains((*records)[0].args, "set-environment") {
 		t.Error("expected set-environment in args")
 	}
-	if !sliceContains((*records)[0].args, "MY_VAR") {
+	if !slices.Contains((*records)[0].args, "MY_VAR") {
 		t.Error("expected env var name in args")
 	}
-	if !sliceContains((*records)[0].args, "my_value") {
+	if !slices.Contains((*records)[0].args, "my_value") {
 		t.Error("expected env var value in args")
 	}
 }

--- a/server/handlers/events.go
+++ b/server/handlers/events.go
@@ -65,4 +65,3 @@ func (h *EventHandler) byAgent(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, evts)
 }
-


### PR DESCRIPTION
## Summary

- Replaced custom `contains()`/`containsHelper()` in `pkg/channel/message_type_test.go` with `strings.Contains()`
- Replaced custom `contains([]int, int)` wrapper in `pkg/demon/demon.go` with direct `slices.Contains()` calls
- Replaced custom `sliceContains()` in `pkg/tmux/session_test.go` with `slices.Contains()`
- Simplified `HasPermissionStr()` in `pkg/agent/agent.go` to delegate to `slices.Contains()` (kept exported signature since it's part of the public API)
- Updated corresponding test files to use stdlib functions

Closes #2097

## Test plan

- [x] `go test -race ./pkg/channel/` passes
- [x] `go test -race ./pkg/demon/` passes
- [x] `go test -race ./pkg/tmux/` passes
- [x] `go test -race ./pkg/agent/` passes
- [x] `go vet` passes on all changed packages
- [x] `make fmt` produces no additional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)