### PR TITLE
feat: create shared @bc/design-tokens package with Solar Flare palette

### DIFF
--- a/packages/design-tokens/css/tokens.css
+++ b/packages/design-tokens/css/tokens.css
@@ -1,0 +1,60 @@
+/**
+ * CSS custom properties generated from the Solar Flare design tokens.
+ *
+ * Import this file in any web project to get all token values as
+ * CSS variables:
+ *
+ *   @import "@bc/design-tokens/css";
+ */
+
+:root {
+  /* ── Palette ─────────────────────────────────────────── */
+  --color-obsidian: #0C0A08;
+  --color-umber: #1E1A16;
+  --color-bark: #2A2420;
+  --color-sandstone: #8C7E72;
+  --color-warm-white: #F5F0EB;
+  --color-tangerine: #EA580C;
+  --color-amber-glow: #FB923C;
+  --color-peach: #FDBA74;
+
+  /* ── Semantic (dark theme) ───────────────────────────── */
+  --bg-base: var(--color-obsidian);
+  --bg-surface: var(--color-umber);
+  --bg-elevated: var(--color-bark);
+  --fg-default: var(--color-warm-white);
+  --fg-muted: var(--color-sandstone);
+  --accent-primary: var(--color-tangerine);
+  --accent-hover: var(--color-amber-glow);
+  --accent-subtle: var(--color-peach);
+  --border: var(--color-sandstone);
+
+  /* ── Typography ──────────────────────────────────────── */
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-heading: 'Space Grotesk', system-ui, -apple-system, sans-serif;
+  --font-code: 'Space Mono', ui-monospace, 'Cascadia Code', 'Fira Code', monospace;
+
+  --font-size-xs: 0.75rem;
+  --font-size-sm: 0.875rem;
+  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.875rem;
+  --font-size-4xl: 2.25rem;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* ── Spacing ─────────────────────────────────────────── */
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-6: 24px;
+  --spacing-8: 32px;
+  --spacing-12: 48px;
+  --spacing-16: 64px;
+}

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@bc/design-tokens",
+  "version": "0.1.0",
+  "description": "Shared design tokens for the bc UI — Solar Flare palette, typography, and spacing",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./colors": "./src/colors.ts",
+    "./semantic": "./src/semantic.ts",
+    "./terminal": "./src/terminal.ts",
+    "./typography": "./src/typography.ts",
+    "./spacing": "./src/spacing.ts",
+    "./css": "./css/tokens.css"
+  },
+  "files": [
+    "src",
+    "css"
+  ],
+  "license": "MIT"
+}

--- a/packages/design-tokens/src/colors.ts
+++ b/packages/design-tokens/src/colors.ts
@@ -1,0 +1,30 @@
+/**
+ * Solar Flare color palette.
+ *
+ * This is the single source of truth for all raw color values used
+ * across the bc UI (web, TUI, docs). Consumers should prefer the
+ * semantic mappings in `./semantic.ts` over reaching for these
+ * primitives directly.
+ */
+
+export const palette = {
+  /** Near-black base — deepest background tone */
+  obsidian: "#0C0A08",
+  /** Dark brown — elevated surface backgrounds */
+  umber: "#1E1A16",
+  /** Warm dark brown — card / panel backgrounds */
+  bark: "#2A2420",
+  /** Muted warm grey — secondary text, borders */
+  sandstone: "#8C7E72",
+  /** Off-white with warm undertone — primary text on dark */
+  warmWhite: "#F5F0EB",
+
+  /** Vivid orange — primary accent, CTAs */
+  tangerine: "#EA580C",
+  /** Lighter orange — hover states, highlights */
+  amberGlow: "#FB923C",
+  /** Soft peach — subtle accent, tags */
+  peach: "#FDBA74",
+} as const;
+
+export type PaletteColor = keyof typeof palette;

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * @bc/design-tokens — single source of truth for the Solar Flare
+ * design system (colors, typography, spacing).
+ */
+
+export { palette } from "./colors.js";
+export type { PaletteColor } from "./colors.js";
+
+export { darkTheme, lightTheme } from "./semantic.js";
+export type { SemanticTheme } from "./semantic.js";
+
+export { terminalColors } from "./terminal.js";
+export type { TerminalColor } from "./terminal.js";
+
+export { fontFamily, fontSize, fontWeight } from "./typography.js";
+
+export { spacing, spacingValues } from "./spacing.js";
+export type { SpacingValue } from "./spacing.js";

--- a/packages/design-tokens/src/semantic.ts
+++ b/packages/design-tokens/src/semantic.ts
@@ -1,0 +1,57 @@
+/**
+ * Semantic color mappings built on top of the Solar Flare palette.
+ *
+ * Use these tokens instead of raw palette values so that themes can be
+ * swapped without touching component code.
+ */
+
+import { palette } from "./colors.js";
+
+export interface SemanticTheme {
+  /* Backgrounds */
+  bgBase: string;
+  bgSurface: string;
+  bgElevated: string;
+
+  /* Foregrounds / text */
+  fgDefault: string;
+  fgMuted: string;
+
+  /* Accent */
+  accentPrimary: string;
+  accentHover: string;
+  accentSubtle: string;
+
+  /* Borders */
+  border: string;
+}
+
+export const darkTheme: SemanticTheme = {
+  bgBase: palette.obsidian,
+  bgSurface: palette.umber,
+  bgElevated: palette.bark,
+
+  fgDefault: palette.warmWhite,
+  fgMuted: palette.sandstone,
+
+  accentPrimary: palette.tangerine,
+  accentHover: palette.amberGlow,
+  accentSubtle: palette.peach,
+
+  border: palette.sandstone,
+};
+
+export const lightTheme: SemanticTheme = {
+  bgBase: palette.warmWhite,
+  bgSurface: "#EDE8E3",
+  bgElevated: "#FFFFFF",
+
+  fgDefault: palette.obsidian,
+  fgMuted: palette.sandstone,
+
+  accentPrimary: palette.tangerine,
+  accentHover: palette.amberGlow,
+  accentSubtle: palette.peach,
+
+  border: palette.sandstone,
+};

--- a/packages/design-tokens/src/spacing.ts
+++ b/packages/design-tokens/src/spacing.ts
@@ -1,0 +1,24 @@
+/**
+ * Spacing scale in pixels (base-4 progression).
+ *
+ * Usage:  `spacing[4]` -> "16px"
+ */
+
+const values = [4, 8, 12, 16, 24, 32, 48, 64] as const;
+
+export type SpacingValue = (typeof values)[number];
+
+/** Map from numeric step to pixel string, e.g. `spacing[16] === "16px"`. */
+export const spacing: Record<SpacingValue, string> = {
+  4: "4px",
+  8: "8px",
+  12: "12px",
+  16: "16px",
+  24: "24px",
+  32: "32px",
+  48: "48px",
+  64: "64px",
+} as const;
+
+/** Raw numeric values for programmatic use. */
+export const spacingValues = values;

--- a/packages/design-tokens/src/terminal.ts
+++ b/packages/design-tokens/src/terminal.ts
@@ -1,0 +1,27 @@
+/**
+ * Terminal / ANSI color mappings for the TUI.
+ *
+ * Maps each palette color to the closest standard ANSI color name for
+ * terminals that don't support 24-bit color, alongside the true hex
+ * value for truecolor-capable terminals.
+ */
+
+import { palette } from "./colors.js";
+
+export interface TerminalColor {
+  /** Hex value for truecolor terminals */
+  hex: string;
+  /** Closest ANSI 16-color name as fallback */
+  ansi: string;
+}
+
+export const terminalColors: Record<string, TerminalColor> = {
+  obsidian: { hex: palette.obsidian, ansi: "black" },
+  umber: { hex: palette.umber, ansi: "black" },
+  bark: { hex: palette.bark, ansi: "black" },
+  sandstone: { hex: palette.sandstone, ansi: "white" },
+  warmWhite: { hex: palette.warmWhite, ansi: "brightWhite" },
+  tangerine: { hex: palette.tangerine, ansi: "red" },
+  amberGlow: { hex: palette.amberGlow, ansi: "yellow" },
+  peach: { hex: palette.peach, ansi: "brightYellow" },
+} as const;

--- a/packages/design-tokens/src/typography.ts
+++ b/packages/design-tokens/src/typography.ts
@@ -1,0 +1,31 @@
+/**
+ * Typography tokens — font families, sizes, and weights.
+ */
+
+export const fontFamily = {
+  /** Body text */
+  body: "'Inter', system-ui, -apple-system, sans-serif",
+  /** Headings */
+  heading: "'Space Grotesk', system-ui, -apple-system, sans-serif",
+  /** Code / monospace */
+  code: "'Space Mono', ui-monospace, 'Cascadia Code', 'Fira Code', monospace",
+} as const;
+
+/** Font sizes in rem, keyed by t-shirt size. */
+export const fontSize = {
+  xs: "0.75rem",
+  sm: "0.875rem",
+  base: "1rem",
+  lg: "1.125rem",
+  xl: "1.25rem",
+  "2xl": "1.5rem",
+  "3xl": "1.875rem",
+  "4xl": "2.25rem",
+} as const;
+
+export const fontWeight = {
+  regular: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+} as const;

--- a/packages/design-tokens/tsconfig.json
+++ b/packages/design-tokens/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- Creates a new `packages/design-tokens/` package (`@bc/design-tokens`) as the single source of truth for the Solar Flare design system
- Exports color palette, dark/light semantic themes, terminal ANSI fallbacks, typography (Inter, Space Grotesk, Space Mono), and spacing scale (4-64px)
- Includes a CSS custom properties file (`css/tokens.css`) for web consumers
- Pure static values only — zero runtime dependencies

Closes #2157

## Test plan
- [x] Verify all `.ts` files export correct Solar Flare hex values
- [x] Verify `css/tokens.css` contains matching CSS custom properties
- [x] Confirm `make check` passes (pre-existing `web/dist` embed failure is unrelated)
- [ ] Downstream: wire up consumers (web, TUI) in follow-up PRs

Generated with [Claude Code](https://claude.com/claude-code)