### PR TITLE
fix: skip stdio MCP servers for Docker agents (unreachable)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1005,7 +1005,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	if agent.WorktreeDir != "" {
 		roleTarget = agent.WorktreeDir
 	}
-	if setupErr := SetupAgentFromRole(wsPath, name, string(role), roleTarget); setupErr != nil {
+	if setupErr := SetupAgentFromRoleWithRuntime(wsPath, name, string(role), roleTarget, agentRuntime); setupErr != nil {
 		log.Warn("role setup failed", "agent", name, "error", setupErr)
 	}
 

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -25,7 +25,19 @@ import (
 //   - .claude/agents/*.md    ← subagent definitions
 //   - .claude/rules/*.md     ← topic-specific rules
 //   - REVIEW.md              ← code review checklist
+// SetupAgentFromRoleWithRuntime sets up agent workspace files for the given role
+// and runtime backend. Docker agents skip stdio-transport MCP servers (unreachable).
+func SetupAgentFromRoleWithRuntime(workspacePath, agentName, roleName, targetDir, runtimeBackend string) error {
+	return setupAgentFromRole(workspacePath, agentName, roleName, targetDir, runtimeBackend)
+}
+
+// SetupAgentFromRole sets up agent workspace files for the given role.
+// Defaults to tmux runtime (all MCP transports available).
 func SetupAgentFromRole(workspacePath, agentName, roleName, targetDir string) error {
+	return setupAgentFromRole(workspacePath, agentName, roleName, targetDir, "tmux")
+}
+
+func setupAgentFromRole(workspacePath, agentName, roleName, targetDir, runtimeBackend string) error {
 	stateDir := filepath.Join(workspacePath, ".bc")
 	rm := workspace.NewRoleManager(stateDir)
 
@@ -46,7 +58,7 @@ func SetupAgentFromRole(workspacePath, agentName, roleName, targetDir string) er
 	}
 
 	// .mcp.json (project-level MCP config)
-	if e := writeMCPJSON(workspacePath, agentName, resolved, secrets, targetDir); e != nil {
+	if e := writeMCPJSON(workspacePath, agentName, resolved, secrets, targetDir, runtimeBackend); e != nil {
 		errs = append(errs, e.Error())
 	}
 
@@ -172,7 +184,8 @@ type mcpServerEntry struct {
 
 var secretRefPattern = regexp.MustCompile(`\$\{secret:([^}]+)\}`)
 
-func writeMCPJSON(workspacePath, agentName string, resolved *workspace.ResolvedRole, secrets map[string]string, targetDir string) error {
+func writeMCPJSON(workspacePath, agentName string, resolved *workspace.ResolvedRole, secrets map[string]string, targetDir, runtimeBackend string) error {
+	isDocker := runtimeBackend == "docker"
 	cfg := mcpConfig{MCPServers: make(map[string]mcpServerEntry)}
 
 	mcpStore, mcpErr := pkgmcp.NewStore(workspacePath)
@@ -185,6 +198,14 @@ func writeMCPJSON(workspacePath, agentName string, resolved *workspace.ResolvedR
 	for _, name := range resolved.MCPServers {
 		def, getErr := mcpStore.Get(name)
 		if getErr != nil || def == nil || !def.Enabled {
+			continue
+		}
+		// Docker agents can't use stdio-transport MCP servers (no access to
+		// host processes). Skip with warning — use tmux runtime for full MCP.
+		if isDocker && def.Transport != "sse" {
+			log.Warn("skipping stdio MCP server for Docker agent (unreachable)",
+				"agent", agentName, "mcp", name,
+				"hint", "use tmux runtime for stdio MCP servers")
 			continue
 		}
 		entry := mcpServerEntry{Command: def.Command, Args: def.Args, URL: def.URL}


### PR DESCRIPTION
## Summary
Docker agents can't use stdio-transport MCP servers (Playwright, etc.) because they can't exec into host processes. Instead of writing broken `.mcp.json` entries that cause connection failures, skip them with a warning.

SSE-transport MCP servers still work in Docker (HTTP reachable via host.docker.internal).

### Changes:
- `pkg/agent/role_setup.go` — `writeMCPJSON` now checks runtime; skips stdio MCP for Docker with log warning
- `pkg/agent/role_setup.go` — New `SetupAgentFromRoleWithRuntime()` accepts runtime param
- `pkg/agent/agent.go` — Fresh create path passes `agentRuntime` to setup

### Verified locally:
- `go build ./...` — pass
- `go test -race ./pkg/agent/` — pass

Closes #2034

Generated with [Claude Code](https://claude.com/claude-code)