### PR TITLE
feat: add agent detail view to web dashboard

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from './components/ErrorBoundary';
 // Lazy-loaded views — each gets its own chunk
 const Dashboard = lazy(() => import('./views/Dashboard').then(m => ({ default: m.Dashboard })));
 const Agents = lazy(() => import('./views/Agents').then(m => ({ default: m.Agents })));
+const AgentDetail = lazy(() => import('./views/AgentDetail').then(m => ({ default: m.AgentDetail })));
 const Channels = lazy(() => import('./views/Channels').then(m => ({ default: m.Channels })));
 const Costs = lazy(() => import('./views/Costs').then(m => ({ default: m.Costs })));
 const Roles = lazy(() => import('./views/Roles').then(m => ({ default: m.Roles })));
@@ -39,6 +40,7 @@ export function App() {
           <Route element={<Layout />}>
             <Route index element={<Suspense fallback={<Loading />}><ErrorBoundary><Dashboard /></ErrorBoundary></Suspense>} />
             <Route path="agents" element={<Suspense fallback={<Loading />}><ErrorBoundary><Agents /></ErrorBoundary></Suspense>} />
+            <Route path="agents/:name" element={<Suspense fallback={<Loading />}><ErrorBoundary><AgentDetail /></ErrorBoundary></Suspense>} />
             <Route path="channels" element={<Suspense fallback={<Loading />}><ErrorBoundary><Channels /></ErrorBoundary></Suspense>} />
             <Route path="costs" element={<Suspense fallback={<Loading />}><ErrorBoundary><Costs /></ErrorBoundary></Suspense>} />
             <Route path="roles" element={<Suspense fallback={<Loading />}><ErrorBoundary><Roles /></ErrorBoundary></Suspense>} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -18,6 +18,15 @@ export interface Agent {
   state: string;
   cost_usd: number;
   started_at: string;
+  created_at: string;
+  updated_at: string;
+  stopped_at?: string;
+  task?: string;
+  team?: string;
+  session?: string;
+  session_id?: string;
+  parent_id?: string;
+  children?: string[];
 }
 
 export interface Channel {
@@ -125,6 +134,8 @@ export interface Secret {
 export const api = {
   listAgents: () => request<Agent[]>('/agents'),
   getAgent: (name: string) => request<Agent>(`/agents/${encodeURIComponent(name)}`),
+  getAgentPeek: (name: string, lines = 50) =>
+    request<{ output: string }>(`/agents/${encodeURIComponent(name)}/peek?${new URLSearchParams({ lines: String(lines) })}`),
   startAgent: (name: string) => request<Agent>(`/agents/${encodeURIComponent(name)}/start`, { method: 'POST' }),
   stopAgent: (name: string) => request<void>(`/agents/${encodeURIComponent(name)}/stop`, { method: 'POST' }),
   sendToAgent: (name: string, message: string) =>

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1,0 +1,219 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { api } from '../api/client';
+import type { Agent } from '../api/client';
+import { usePolling } from '../hooks/usePolling';
+import { useWebSocket } from '../hooks/useWebSocket';
+import { StatusBadge } from '../components/StatusBadge';
+
+/** Strip ANSI escape sequences from a string. */
+function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+}
+
+function RoleBadge({ role }: { role: string }) {
+  return (
+    <span className="inline-block px-2 py-0.5 rounded text-xs font-medium bg-bc-accent/20 text-bc-accent">
+      {role}
+    </span>
+  );
+}
+
+function MetadataRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-start gap-2 py-1.5 border-b border-bc-border/30 last:border-0">
+      <span className="text-bc-muted text-sm w-32 shrink-0">{label}</span>
+      <span className="text-sm break-all">{value ?? '—'}</span>
+    </div>
+  );
+}
+
+function formatTime(t?: string): string {
+  if (!t) return '—';
+  try {
+    const d = new Date(t);
+    if (isNaN(d.getTime())) return '—';
+    return d.toLocaleString();
+  } catch {
+    return '—';
+  }
+}
+
+export function AgentDetail() {
+  const { name } = useParams<{ name: string }>();
+  const [outputLines, setOutputLines] = useState<string[]>([]);
+  const [message, setMessage] = useState('');
+  const [sending, setSending] = useState(false);
+  const outputRef = useRef<HTMLPreElement>(null);
+  const { subscribe } = useWebSocket();
+
+  const agentFetcher = useCallback(async () => {
+    if (!name) throw new Error('No agent name');
+    return api.getAgent(name);
+  }, [name]);
+
+  const { data: agent, loading, error, refresh } = usePolling<Agent>(agentFetcher, 3000);
+
+  // Fetch initial output via peek, then stream via SSE
+  useEffect(() => {
+    if (!name) return;
+    api.getAgentPeek(name, 100).then(({ output }) => {
+      if (output) {
+        setOutputLines(stripAnsi(output).split('\n'));
+      }
+    }).catch(() => {
+      // Peek may fail for stopped agents — ignore
+    });
+  }, [name]);
+
+  // Stream live output via SSE
+  useEffect(() => {
+    if (!name) return;
+
+    const es = new EventSource(`/api/agents/${encodeURIComponent(name)}/output`);
+
+    es.onmessage = (e: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(e.data as string) as { output: string };
+        if (parsed.output) {
+          const newLines = stripAnsi(parsed.output).split('\n');
+          setOutputLines((prev) => [...prev, ...newLines].slice(-500));
+        }
+      } catch {
+        // ignore malformed events
+      }
+    };
+
+    es.addEventListener('agent.output', ((e: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(e.data as string) as { output: string };
+        if (parsed.output) {
+          const newLines = stripAnsi(parsed.output).split('\n');
+          setOutputLines((prev) => [...prev, ...newLines].slice(-500));
+        }
+      } catch {
+        // ignore
+      }
+    }) as EventListener);
+
+    es.onerror = () => {
+      // SSE reconnects automatically; no action needed
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [name]);
+
+  // Auto-scroll output to bottom
+  useEffect(() => {
+    if (outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight;
+    }
+  }, [outputLines]);
+
+  // Refresh on agent state changes
+  useEffect(() => {
+    return subscribe('agent.state_changed', () => void refresh());
+  }, [subscribe, refresh]);
+
+  const handleSend = async () => {
+    if (!name || !message.trim()) return;
+    setSending(true);
+    try {
+      await api.sendToAgent(name, message);
+      setMessage('');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (loading && !agent) {
+    return <div className="p-6 text-bc-muted">Loading agent...</div>;
+  }
+  if (error && !agent) {
+    return (
+      <div className="p-6 space-y-2">
+        <div className="text-bc-error">Error: {error}</div>
+        <Link to="/agents" className="text-sm text-bc-accent hover:underline">Back to agents</Link>
+      </div>
+    );
+  }
+  if (!agent) return null;
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Link to="/agents" className="text-bc-muted hover:text-bc-text text-sm">
+          &larr; Agents
+        </Link>
+        <h1 className="text-xl font-bold">{agent.name}</h1>
+        <RoleBadge role={agent.role} />
+        <StatusBadge status={agent.state} />
+      </div>
+
+      {/* Task */}
+      {agent.task && (
+        <div className="rounded border border-bc-border bg-bc-surface p-3">
+          <span className="text-xs text-bc-muted uppercase tracking-wide">Current Task</span>
+          <p className="mt-1 text-sm">{agent.task}</p>
+        </div>
+      )}
+
+      {/* Live Output */}
+      <div className="space-y-2">
+        <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">Live Output</h2>
+        <pre
+          ref={outputRef}
+          className="rounded border border-bc-border bg-bc-bg p-4 text-xs font-mono overflow-auto max-h-96 whitespace-pre-wrap"
+        >
+          {outputLines.length > 0
+            ? outputLines.join('\n')
+            : <span className="text-bc-muted">No output yet. Agent may be idle or stopped.</span>}
+        </pre>
+      </div>
+
+      {/* Send Message */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') void handleSend(); }}
+          placeholder="Send message to agent..."
+          className="flex-1 bg-bc-bg border border-bc-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-bc-accent"
+        />
+        <button
+          onClick={() => void handleSend()}
+          disabled={sending || !message.trim()}
+          className="px-3 py-1.5 bg-bc-accent text-bc-bg rounded text-sm font-medium disabled:opacity-50"
+        >
+          Send
+        </button>
+      </div>
+
+      {/* Metadata */}
+      <div className="space-y-2">
+        <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">Agent Details</h2>
+        <div className="rounded border border-bc-border bg-bc-surface p-4">
+          <MetadataRow label="Role" value={agent.role} />
+          <MetadataRow label="Tool" value={agent.tool || '—'} />
+          <MetadataRow label="State" value={<StatusBadge status={agent.state} />} />
+          <MetadataRow label="Team" value={agent.team || '—'} />
+          <MetadataRow label="Session" value={agent.session || '—'} />
+          <MetadataRow label="Parent" value={agent.parent_id || '—'} />
+          <MetadataRow
+            label="Children"
+            value={agent.children && agent.children.length > 0 ? agent.children.join(', ') : '—'}
+          />
+          <MetadataRow label="Created" value={formatTime(agent.created_at)} />
+          <MetadataRow label="Started" value={formatTime(agent.started_at)} />
+          <MetadataRow label="Updated" value={formatTime(agent.updated_at)} />
+          <MetadataRow label="Stopped" value={formatTime(agent.stopped_at)} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { api } from '../api/client';
 import type { Agent } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
@@ -13,7 +14,7 @@ export function Agents() {
   }, []);
   const { data: agents, loading, error, refresh } = usePolling(fetcher, 5000);
   const { subscribe } = useWebSocket();
-  const [selected, setSelected] = useState<string | null>(null);
+  const navigate = useNavigate();
 
   // Refresh on agent state changes — cleanup prevents listener leak
   useEffect(() => {
@@ -51,66 +52,11 @@ export function Agents() {
           columns={columns}
           data={agents ?? []}
           keyFn={(a) => a.name}
-          onRowClick={(a) => setSelected(a.name === selected ? null : a.name)}
+          onRowClick={(a) => navigate(`/agents/${encodeURIComponent(a.name)}`)}
           emptyMessage="No agents. Use 'bc agent create' to create one."
         />
       </div>
 
-      {selected && agents && (
-        <AgentDetail
-          agent={agents.find((a) => a.name === selected)}
-          onClose={() => setSelected(null)}
-        />
-      )}
-    </div>
-  );
-}
-
-function AgentDetail({ agent, onClose }: { agent?: Agent; onClose: () => void }) {
-  const [message, setMessage] = useState('');
-  const [sending, setSending] = useState(false);
-
-  if (!agent) return null;
-
-  const handleSend = async () => {
-    if (!message.trim()) return;
-    setSending(true);
-    try {
-      await api.sendToAgent(agent.name, message);
-      setMessage('');
-    } finally {
-      setSending(false);
-    }
-  };
-
-  return (
-    <div className="rounded border border-bc-border bg-bc-surface p-4 space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="font-medium">{agent.name}</h3>
-        <button onClick={onClose} className="text-bc-muted hover:text-bc-text text-sm">close</button>
-      </div>
-      <div className="grid grid-cols-3 gap-4 text-sm">
-        <div><span className="text-bc-muted">Role:</span> {agent.role}</div>
-        <div><span className="text-bc-muted">Tool:</span> {agent.tool}</div>
-        <div><span className="text-bc-muted">Cost:</span> {agent.cost_usd != null ? `$${agent.cost_usd.toFixed(4)}` : '—'}</div>
-      </div>
-      <div className="flex gap-2">
-        <input
-          type="text"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          onKeyDown={(e) => { if (e.key === 'Enter') void handleSend(); }}
-          placeholder="Send message to agent..."
-          className="flex-1 bg-bc-bg border border-bc-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-bc-accent"
-        />
-        <button
-          onClick={() => void handleSend()}
-          disabled={sending || !message.trim()}
-          className="px-3 py-1.5 bg-bc-accent text-bc-bg rounded text-sm font-medium disabled:opacity-50"
-        >
-          Send
-        </button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add new `/agents/:name` route with a full agent detail view showing name, role badge, state badge, current task, live terminal output (via SSE), send message input, and agent metadata
- Update `Agent` interface in `client.ts` to include all DTO fields (task, team, session, children, timestamps) and add `getAgentPeek` API method
- Replace inline expand panel in the agents list with row-click navigation to the detail view

## Test plan
- [ ] Click an agent row in the Agents table — should navigate to `/agents/:name`
- [ ] Verify header shows agent name, role badge, and state badge for all states (idle, working, stopped, starting)
- [ ] Verify current task is displayed when present
- [ ] Verify live output streams via SSE and ANSI codes are stripped
- [ ] Verify send message input works
- [ ] Verify metadata section shows all agent details (tool, team, session, timestamps, children)
- [ ] Verify back arrow link returns to the agents list
- [ ] Verify error state (nonexistent agent) shows error with back link
- [ ] Run `cd web && bun run build` — passes TypeScript and Vite build

Closes #2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)