### PR TITLE
feat: add agent peek panel to web Channels view

### DIFF
--- a/web/src/components/AgentPeekPanel.tsx
+++ b/web/src/components/AgentPeekPanel.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from 'react';
+import { StatusBadge } from './StatusBadge';
+import type { Agent } from '../api/client';
+import { api } from '../api/client';
+import { usePolling } from '../hooks/usePolling';
+import { useCallback } from 'react';
+
+/** Strip ANSI escape codes from terminal output. */
+function stripAnsi(text: string): string {
+  // Covers CSI sequences, OSC sequences, and simple escape codes
+  return text.replace(
+    // eslint-disable-next-line no-control-regex
+    /\x1b\[[0-9;]*[A-Za-z]|\x1b\][^\x07]*\x07|\x1b[()][AB012]|\x1b[=>]|\x1b\[[?]?[0-9;]*[hlm]/g,
+    '',
+  );
+}
+
+interface AgentPeekPanelProps {
+  agentName: string;
+  onClose: () => void;
+}
+
+export function AgentPeekPanel({ agentName, onClose }: AgentPeekPanelProps) {
+  const [output, setOutput] = useState('');
+  const outputRef = useRef<HTMLPreElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  // Fetch agent details for header metadata
+  const agentFetcher = useCallback(async () => {
+    return api.getAgent(agentName);
+  }, [agentName]);
+  const { data: agent } = usePolling<Agent>(agentFetcher, 5000);
+
+  // Connect to SSE stream for live terminal output
+  useEffect(() => {
+    setOutput('');
+
+    const es = new EventSource(`/api/agents/${encodeURIComponent(agentName)}/output`);
+
+    // Initial snapshot comes as a plain "message" event (no event: field)
+    es.onmessage = (e: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(e.data as string) as { output?: string };
+        if (parsed.output) {
+          setOutput((prev) => prev + stripAnsi(parsed.output!));
+        }
+      } catch {
+        // ignore malformed data
+      }
+    };
+
+    // Incremental updates arrive as named "agent.output" events
+    es.addEventListener('agent.output', ((e: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(e.data as string) as { output?: string };
+        if (parsed.output) {
+          setOutput((prev) => prev + stripAnsi(parsed.output!));
+        }
+      } catch {
+        // ignore
+      }
+    }) as EventListener);
+
+    es.onerror = () => {
+      // EventSource auto-reconnects; nothing to do
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [agentName]);
+
+  // Auto-scroll when output grows, only if near bottom
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const isNearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 120;
+    if (isNearBottom) {
+      container.scrollTop = container.scrollHeight;
+    }
+  }, [output]);
+
+  return (
+    <div className="w-[420px] shrink-0 border-l border-bc-border flex flex-col bg-bc-bg">
+      {/* Header */}
+      <div className="px-4 py-2 border-b border-bc-border bg-bc-surface flex items-center justify-between">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-medium truncate">{agentName}</span>
+          {agent && <StatusBadge status={agent.state} />}
+        </div>
+        <button
+          onClick={onClose}
+          className="text-bc-muted hover:text-bc-text text-sm ml-2 shrink-0"
+          aria-label="Close peek panel"
+        >
+          close
+        </button>
+      </div>
+
+      {/* Agent metadata */}
+      {agent && (
+        <div className="px-4 py-1.5 border-b border-bc-border/50 text-xs text-bc-muted flex gap-3">
+          <span>Role: {agent.role}</span>
+          <span>Tool: {agent.tool || '\u2014'}</span>
+          {agent.cost_usd != null && <span>Cost: ${agent.cost_usd.toFixed(4)}</span>}
+        </div>
+      )}
+
+      {/* Live output */}
+      <div ref={scrollContainerRef} className="flex-1 overflow-auto">
+        <pre
+          ref={outputRef}
+          className="p-3 text-xs font-mono whitespace-pre-wrap break-words leading-relaxed text-bc-text/80"
+        >
+          {output || 'Connecting...'}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -3,6 +3,7 @@ import { api } from '../api/client';
 import type { ChannelMessage } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { useWebSocket } from '../hooks/useWebSocket';
+import { AgentPeekPanel } from '../components/AgentPeekPanel';
 
 export function Channels() {
   const fetcher = useCallback(async () => {
@@ -11,6 +12,7 @@ export function Channels() {
   }, []);
   const { data: channels, loading, error } = usePolling(fetcher, 10000);
   const [selected, setSelected] = useState<string | null>(null);
+  const [peekAgent, setPeekAgent] = useState<string | null>(null);
 
   if (loading && !channels) {
     return <div className="p-6 text-bc-muted">Loading channels...</div>;
@@ -40,20 +42,23 @@ export function Channels() {
           </button>
         ))}
       </div>
-      <div className="flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col min-w-0">
         {selected ? (
-          <ChatRoom channelName={selected} />
+          <ChatRoom channelName={selected} onPeekAgent={setPeekAgent} />
         ) : (
           <div className="flex-1 flex items-center justify-center text-bc-muted text-sm">
             Select a channel
           </div>
         )}
       </div>
+      {peekAgent && (
+        <AgentPeekPanel agentName={peekAgent} onClose={() => setPeekAgent(null)} />
+      )}
     </div>
   );
 }
 
-function ChatRoom({ channelName }: { channelName: string }) {
+function ChatRoom({ channelName, onPeekAgent }: { channelName: string; onPeekAgent: (name: string) => void }) {
   const [messages, setMessages] = useState<ChannelMessage[]>([]);
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
@@ -116,7 +121,13 @@ function ChatRoom({ channelName }: { channelName: string }) {
       <div ref={scrollContainerRef} className="flex-1 overflow-auto p-4 space-y-2">
         {messages.map((msg) => (
           <div key={msg.id} className="text-sm">
-            <span className="font-medium text-bc-accent">{msg.sender}</span>
+            <button
+              onClick={() => onPeekAgent(msg.sender)}
+              className="font-medium text-bc-accent hover:underline cursor-pointer"
+              title={`Peek at ${msg.sender}'s terminal`}
+            >
+              {msg.sender}
+            </button>
             <span className="ml-2 text-xs text-bc-muted">
               {new Date(msg.created_at).toLocaleTimeString()}
             </span>


### PR DESCRIPTION
## Summary
- Adds a toggleable side panel to the web Channels view that streams an agent's live terminal output via SSE (`/api/agents/{name}/output`)
- Clicking any agent name in channel messages opens the peek panel alongside the chat
- Panel displays agent metadata (name, role, tool, cost, state badge) and auto-scrolling terminal output with ANSI codes stripped

## Details
- **New file**: `web/src/components/AgentPeekPanel.tsx` — self-contained component using `EventSource` for SSE streaming, polls agent metadata via `usePolling`, strips ANSI escape codes with regex
- **Modified**: `web/src/views/Channels.tsx` — adds `peekAgent` state, passes `onPeekAgent` callback to `ChatRoom`, renders `AgentPeekPanel` as a right-side split panel (420px fixed width)
- Layout: channel sidebar | chat messages | peek panel (when open)
- Close button dismisses the panel and returns to full-width chat

## Test plan
- [ ] Open Channels view, select a channel with messages from agents
- [ ] Click an agent name in a message — peek panel should appear on the right
- [ ] Verify live terminal output streams in the panel (no ANSI artifacts)
- [ ] Verify agent metadata (role, tool, cost, state) displays in panel header
- [ ] Click "close" — panel dismisses, chat returns to full width
- [ ] Click a different agent name — panel switches to new agent's output
- [ ] Verify auto-scroll works when near bottom, pauses when scrolled up

Closes #2237

Generated with [Claude Code](https://claude.com/claude-code)