### PR TITLE
feat: migrate agent/completion/report/status/workspace CLI to thin client

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -437,13 +437,13 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Parse role
-	role, roleErr := parseRole(agentCreateRole)
+	role, roleErr := parseRoleStr(agentCreateRole)
 	if roleErr != nil {
 		return roleErr
 	}
 
 	// Prevent root agent creation via this command
-	if role == agent.RoleRoot {
+	if role == "root" {
 		return fmt.Errorf("cannot create root agent via 'bc agent create'. Use 'bc up' to initialize the root agent")
 	}
 
@@ -466,10 +466,10 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 	toolName := agentCreateTool
 
 	// Create via client
-	fmt.Printf("Creating %s (%s)... ", agentName, role)
+	fmt.Printf("Creating %s (%s)... ", agentName, agentCreateRole)
 	info, createErr := c.Agents.Create(cmd.Context(), client.CreateAgentReq{
 		Name:    agentName,
-		Role:    string(role),
+		Role:    role,
 		Tool:    toolName,
 		Runtime: agentCreateRuntime,
 		Parent:  agentCreateParent,
@@ -508,13 +508,13 @@ func runAgentList(cmd *cobra.Command, args []string) error {
 
 	// Filter by role if specified
 	if agentListRole != "" {
-		filterRole, roleErr := parseRole(agentListRole)
+		filterRole, roleErr := parseRoleStr(agentListRole)
 		if roleErr != nil {
 			return roleErr
 		}
 		filtered := make([]client.AgentInfo, 0, len(agentList))
 		for _, a := range agentList {
-			if a.Role == string(filterRole) {
+			if a.Role == filterRole {
 				filtered = append(filtered, a)
 			}
 		}
@@ -525,7 +525,7 @@ func runAgentList(cmd *cobra.Command, args []string) error {
 	if agentListStatus != "" {
 		filtered := make([]client.AgentInfo, 0, len(agentList))
 		for _, a := range agentList {
-			if matchesAgentStatus(agent.State(a.State), agentListStatus) {
+			if matchesAgentStatusStr(a.State, agentListStatus) {
 				filtered = append(filtered, a)
 			}
 		}
@@ -563,7 +563,7 @@ func runAgentList(cmd *cobra.Command, args []string) error {
 
 	for _, a := range agentList {
 		uptime := "-"
-		if agent.State(a.State) != agent.StateStopped {
+		if a.State != "stopped" {
 			uptime = formatDuration(time.Since(a.StartedAt))
 		}
 
@@ -575,7 +575,7 @@ func runAgentList(cmd *cobra.Command, args []string) error {
 			task = task[:taskWidth-3] + "..."
 		}
 
-		stateStr := colorState(agent.State(a.State))
+		stateStr := colorStateStr(a.State)
 
 		table.AddRow(a.Name, a.Role, stateStr, uptime, task)
 	}
@@ -625,7 +625,7 @@ func runAgentPeek(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentName)
 		}
 
-		if a.State == agent.StateStopped {
+		if a.State == "stopped" {
 			return fmt.Errorf("agent %q is stopped (use 'bc agent start %s' to start it)", agentName, agentName)
 		}
 
@@ -987,22 +987,22 @@ func runAgentSendPattern(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// parseRole parses and validates a role string.
-func parseRole(roleStr string) (agent.Role, error) {
+// parseRoleStr parses and validates a role string, returning a plain string.
+func parseRoleStr(roleStr string) (string, error) {
 	roleStr = strings.ToLower(strings.TrimSpace(roleStr))
 	if roleStr == "" {
-		return agent.RoleRoot, nil // Default to root if not specified
+		return "root", nil // Default to root if not specified
 	}
 	// "null" role is a special case - represents an agent with no system prompt
 	if roleStr == "null" {
-		return agent.Role("null"), nil
+		return "null", nil
 	}
 	// All roles are now custom - loaded from .bc/roles/<role>.md files
 	// Just validate that the role name is sensible
 	if !isValidRoleName(roleStr) {
 		return "", fmt.Errorf("invalid role name %q (must be alphanumeric with hyphens)", roleStr)
 	}
-	return agent.Role(roleStr), nil
+	return roleStr, nil
 }
 
 // isValidTeamName validates that a team name is alphanumeric with optional hyphens/underscores.
@@ -1027,21 +1027,21 @@ func isValidAgentName(name string) bool {
 	return isValidTeamName(name)
 }
 
-// matchesAgentStatus checks if an agent state matches a status filter.
+// matchesAgentStatusStr checks if an agent state string matches a status filter.
 // Maps detailed internal states to the simplified 4-state model from #1918.
-func matchesAgentStatus(state agent.State, status string) bool {
+func matchesAgentStatusStr(state, status string) bool {
 	switch status {
 	case "running":
-		return state == agent.StateIdle || state == agent.StateWorking || state == agent.StateStarting
+		return state == "idle" || state == "working" || state == "starting"
 	case "stopped":
-		return state == agent.StateStopped
+		return state == "stopped"
 	case "error":
-		return state == agent.StateError
+		return state == "error"
 	case "starting":
-		return state == agent.StateStarting
+		return state == "starting"
 	default:
 		// Allow matching by exact internal state name
-		return string(state) == status
+		return state == status
 	}
 }
 

--- a/internal/cmd/agent_health.go
+++ b/internal/cmd/agent_health.go
@@ -10,8 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rpuneet/bc/pkg/agent"
-	"github.com/rpuneet/bc/pkg/channel"
+	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/ui"
@@ -70,12 +69,7 @@ type AgentHealth struct {
 }
 
 func runAgentHealth(cmd *cobra.Command, args []string) error {
-	ws, err := getWorkspace()
-	if err != nil {
-		return errNotInWorkspace(err)
-	}
-
-	// Parse timeout duration
+	// Parse timeout duration (for validation and stuck detection)
 	timeout, parseErr := time.ParseDuration(agentHealthTimeout)
 	if parseErr != nil {
 		return fmt.Errorf("invalid timeout format: %w", parseErr)
@@ -93,80 +87,88 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := cmd.Context()
-	mgr := newAgentManager(ws)
-	if loadErr := mgr.LoadState(); loadErr != nil {
-		log.Warn("failed to load agent state", "error", loadErr)
+	c, err := newDaemonClient(ctx)
+	if err != nil {
+		return err
 	}
 
-	if refreshErr := mgr.RefreshState(ctx); refreshErr != nil {
-		log.Warn("failed to refresh agent state", "error", refreshErr)
-	}
-
-	// Get agents to check
-	var agents []*agent.Agent
+	// Get health data from daemon
+	agentFilter := ""
 	if len(args) > 0 {
-		// Check specific agent
-		a := mgr.GetAgent(args[0])
-		if a == nil {
-			return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", args[0])
-		}
-		agents = []*agent.Agent{a}
-	} else {
-		// Check all agents
-		agents = mgr.ListAgents()
+		agentFilter = args[0]
+	}
+	healthData, healthErr := c.Agents.Health(ctx, agentHealthTimeout, agentFilter)
+	if healthErr != nil {
+		return fmt.Errorf("health check failed: %w", healthErr)
 	}
 
-	if len(agents) == 0 {
+	if agentFilter != "" && len(healthData) == 0 {
+		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentFilter)
+	}
+
+	if len(healthData) == 0 {
 		fmt.Println("No agents found")
 		return nil
 	}
 
-	// Prepare stuck detection if enabled
-	var eventLog events.EventStore
-	var stuckConfig events.StuckConfig
+	// Convert to AgentHealth structs
+	healthResults := make([]AgentHealth, 0, len(healthData))
+	for _, h := range healthData {
+		healthResults = append(healthResults, AgentHealth{
+			Name:          h.Name,
+			Role:          h.Role,
+			Status:        h.Status,
+			LastUpdated:   h.LastUpdated,
+			StaleDuration: h.StaleDuration,
+			ErrorMessage:  h.ErrorMessage,
+			TmuxAlive:     h.TmuxAlive,
+			StateFresh:    h.StateFresh,
+		})
+	}
+
+	// Stuck detection via daemon event log
 	if agentHealthDetect {
-		eventLog = openEventLog(ws)
-		if eventLog != nil {
-			defer func() { _ = eventLog.Close() }()
-		}
-		stuckConfig = events.StuckConfig{
+		stuckConfig := events.StuckConfig{
 			ActivityTimeout: timeout,
 			WorkTimeout:     workTimeout,
 			MaxFailures:     agentHealthMaxFail,
 		}
-	}
 
-	// Compute health for each agent
-	healthResults := make([]AgentHealth, 0, len(agents))
-	for _, a := range agents {
-		health := computeAgentHealth(ctx, a, mgr, timeout)
-
-		// Add stuck detection if enabled
-		if agentHealthDetect && eventLog != nil {
-			agentEvents, readErr := eventLog.ReadByAgent(a.Name)
+		for i := range healthResults {
+			agentEvents, readErr := c.Events.ListByAgent(ctx, healthResults[i].Name)
 			if readErr != nil {
-				log.Warn("failed to read agent events", "agent", a.Name, "error", readErr)
-			} else {
-				stuck := events.DetectStuck(agentEvents, stuckConfig)
-				if stuck.IsStuck {
-					health.IsStuck = true
-					health.StuckReason = string(stuck.Reason)
-					health.StuckDetails = stuck.Details
-					// Override status if stuck
-					if health.Status == "healthy" || health.Status == "degraded" {
-						health.Status = "stuck"
-						health.ErrorMessage = stuck.Details
-					}
+				log.Warn("failed to read agent events", "agent", healthResults[i].Name, "error", readErr)
+				continue
+			}
+
+			// Convert client EventInfo to events.Event for stuck detection
+			evts := make([]events.Event, 0, len(agentEvents))
+			for _, e := range agentEvents {
+				evts = append(evts, events.Event{
+					Timestamp: e.Timestamp,
+					Type:      events.EventType(e.Type),
+					Agent:     e.Agent,
+					Message:   e.Message,
+					Data:      e.Data,
+				})
+			}
+
+			stuck := events.DetectStuck(evts, stuckConfig)
+			if stuck.IsStuck {
+				healthResults[i].IsStuck = true
+				healthResults[i].StuckReason = string(stuck.Reason)
+				healthResults[i].StuckDetails = stuck.Details
+				if healthResults[i].Status == "healthy" || healthResults[i].Status == "degraded" {
+					healthResults[i].Status = "stuck"
+					healthResults[i].ErrorMessage = stuck.Details
 				}
 			}
 		}
-
-		healthResults = append(healthResults, health)
 	}
 
 	// Send alert to channel if --alert is set and there are stuck agents
 	if agentHealthAlert != "" {
-		if alertErr := sendStuckAlert(ctx, ws.RootDir, agentHealthAlert, healthResults, mgr); alertErr != nil {
+		if alertErr := sendStuckAlertViaClient(ctx, c, agentHealthAlert, healthResults); alertErr != nil {
 			log.Warn("failed to send stuck alert", "error", alertErr)
 		}
 	}
@@ -243,46 +245,8 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func computeAgentHealth(ctx context.Context, a *agent.Agent, mgr *agent.Manager, timeout time.Duration) AgentHealth {
-	health := AgentHealth{
-		Name:        a.Name,
-		Role:        string(a.Role),
-		LastUpdated: a.UpdatedAt.Format(time.RFC3339),
-	}
-
-	// Check tmux session
-	health.TmuxAlive = mgr.RuntimeForAgent(a.Name).HasSession(ctx, a.Name)
-
-	// Check state freshness
-	staleDuration := time.Since(a.UpdatedAt)
-	health.StateFresh = staleDuration < timeout
-	if !health.StateFresh {
-		health.StaleDuration = staleDuration.Round(time.Second).String()
-	}
-
-	// Determine overall status
-	switch {
-	case a.State == agent.StateStopped:
-		health.Status = "unhealthy"
-		health.ErrorMessage = "agent stopped"
-	case a.State == agent.StateError:
-		health.Status = "unhealthy"
-		health.ErrorMessage = "agent in error state"
-	case !health.TmuxAlive:
-		health.Status = "unhealthy"
-		health.ErrorMessage = "tmux session not found"
-	case !health.StateFresh:
-		health.Status = "degraded"
-		health.ErrorMessage = fmt.Sprintf("state stale (%s since last update)", health.StaleDuration)
-	default:
-		health.Status = "healthy"
-	}
-
-	return health
-}
-
-// sendStuckAlert sends an alert to the specified channel when stuck agents are detected.
-func sendStuckAlert(ctx context.Context, rootDir, channelName string, healthResults []AgentHealth, mgr *agent.Manager) error {
+// sendStuckAlertViaClient sends an alert to the specified channel via daemon client.
+func sendStuckAlertViaClient(ctx context.Context, c *client.Client, channelName string, healthResults []AgentHealth) error {
 	// Collect stuck agents
 	var stuckAgents []AgentHealth
 	for _, h := range healthResults {
@@ -292,7 +256,6 @@ func sendStuckAlert(ctx context.Context, rootDir, channelName string, healthResu
 	}
 
 	if len(stuckAgents) == 0 {
-		// No stuck agents, no alert needed
 		return nil
 	}
 
@@ -313,51 +276,12 @@ func sendStuckAlert(ctx context.Context, rootDir, channelName string, healthResu
 
 	message := sb.String()
 
-	// Load channel store
-	store, err := channel.OpenStore(rootDir)
-	if err != nil {
-		return fmt.Errorf("failed to open channel store: %w", err)
-	}
-	defer func() { _ = store.Close() }()
-
-	if loadErr := store.Load(); loadErr != nil {
-		return fmt.Errorf("failed to load channel store: %w", loadErr)
+	// Send via daemon channel API
+	_, sendErr := c.Channels.Send(ctx, channelName, "bc-health", message)
+	if sendErr != nil {
+		return fmt.Errorf("failed to send alert to channel %q: %w", channelName, sendErr)
 	}
 
-	// Get channel members
-	members, membersErr := store.GetMembers(channelName)
-	if membersErr != nil {
-		return fmt.Errorf("channel %q not found: %w", channelName, membersErr)
-	}
-
-	if len(members) == 0 {
-		fmt.Printf("Alert: channel %q has no members, alert not sent\n", channelName)
-		return nil
-	}
-
-	// Record in channel history
-	if err := store.AddHistory(channelName, "bc-health", message); err != nil {
-		log.Warn("failed to record alert history", "error", err)
-	}
-	if err := store.Save(); err != nil {
-		log.Warn("failed to save alert history", "error", err)
-	}
-
-	// Send to all members
-	sent := 0
-	for _, member := range members {
-		a := mgr.GetAgent(member)
-		if a == nil || a.State == agent.StateStopped {
-			continue
-		}
-		formattedMsg := fmt.Sprintf("[#%s] bc-health: %s", channelName, message)
-		if sendErr := mgr.SendToAgent(ctx, member, formattedMsg); sendErr != nil {
-			log.Warn("failed to send alert to agent", "agent", member, "error", sendErr)
-			continue
-		}
-		sent++
-	}
-
-	fmt.Printf("Alert sent to %d member(s) in channel %q\n", sent, channelName)
+	fmt.Printf("Alert sent to channel %q\n", channelName)
 	return nil
 }

--- a/internal/cmd/agent_test.go
+++ b/internal/cmd/agent_test.go
@@ -79,26 +79,26 @@ func TestAgentCreate_ValidRole(t *testing.T) {
 	tests := []struct {
 		name     string
 		role     string
-		wantRole agent.Role
+		wantRole string
 	}{
-		{"null role (default)", "null", agent.Role("null")},
-		{"worker role", "worker", agent.Role("worker")},
-		{"engineer role", "engineer", agent.Role("engineer")},
-		{"manager role", "manager", agent.Role("manager")},
-		{"qa role", "qa", agent.Role("qa")},
-		{"tech-lead role", "tech-lead", agent.Role("tech-lead")},
-		{"product-manager role", "product-manager", agent.Role("product-manager")},
+		{"null role (default)", "null", "null"},
+		{"worker role", "worker", "worker"},
+		{"engineer role", "engineer", "engineer"},
+		{"manager role", "manager", "manager"},
+		{"qa role", "qa", "qa"},
+		{"tech-lead role", "tech-lead", "tech-lead"},
+		{"product-manager role", "product-manager", "product-manager"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			role, err := parseRole(tt.role)
+			role, err := parseRoleStr(tt.role)
 			if err != nil {
-				t.Errorf("parseRole(%q) error = %v", tt.role, err)
+				t.Errorf("parseRoleStr(%q) error = %v", tt.role, err)
 				return
 			}
 			if role != tt.wantRole {
-				t.Errorf("parseRole(%q) = %v, want %v", tt.role, role, tt.wantRole)
+				t.Errorf("parseRoleStr(%q) = %v, want %v", tt.role, role, tt.wantRole)
 			}
 		})
 	}
@@ -117,9 +117,9 @@ func TestAgentCreate_InvalidRole(t *testing.T) {
 
 	for _, tt := range invalidRoles {
 		t.Run(tt.desc, func(t *testing.T) {
-			_, err := parseRole(tt.role)
+			_, err := parseRoleStr(tt.role)
 			if err == nil {
-				t.Errorf("parseRole(%q) expected error, got nil", tt.role)
+				t.Errorf("parseRoleStr(%q) expected error, got nil", tt.role)
 			}
 		})
 	}
@@ -130,24 +130,24 @@ func TestAgentCreate_CustomRoles(t *testing.T) {
 	// Legacy aliases ('pm', 'coord', 'tl') are returned as-is
 	tests := []struct {
 		input    string
-		wantRole agent.Role
+		wantRole string
 	}{
-		{"pm", agent.Role("pm")},       // No expansion
-		{"coord", agent.Role("coord")}, // No expansion
-		{"tl", agent.Role("tl")},       // No expansion
-		{"custom-role", agent.Role("custom-role")},
-		{"admin", agent.Role("admin")},
+		{"pm", "pm"},             // No expansion
+		{"coord", "coord"},       // No expansion
+		{"tl", "tl"},             // No expansion
+		{"custom-role", "custom-role"},
+		{"admin", "admin"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			role, err := parseRole(tt.input)
+			role, err := parseRoleStr(tt.input)
 			if err != nil {
-				t.Errorf("parseRole(%q) error = %v", tt.input, err)
+				t.Errorf("parseRoleStr(%q) error = %v", tt.input, err)
 				return
 			}
 			if role != tt.wantRole {
-				t.Errorf("parseRole(%q) = %v, want %v", tt.input, role, tt.wantRole)
+				t.Errorf("parseRoleStr(%q) = %v, want %v", tt.input, role, tt.wantRole)
 			}
 		})
 	}
@@ -231,9 +231,9 @@ func TestAgentList_FilterByRole(t *testing.T) {
 
 	for _, role := range validRoles {
 		t.Run(role, func(t *testing.T) {
-			_, err := parseRole(role)
+			_, err := parseRoleStr(role)
 			if err != nil {
-				t.Errorf("parseRole(%q) should be valid for filtering", role)
+				t.Errorf("parseRoleStr(%q) should be valid for filtering", role)
 			}
 		})
 	}

--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -359,22 +359,22 @@ func TestColorStateIntegration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.state, func(t *testing.T) {
-			result := colorState(agent.State(tt.state))
+			result := colorStateStr(tt.state)
 			if !strings.Contains(result, tt.contains) {
-				t.Errorf("colorState(%s) = %q, should contain %q", tt.state, result, tt.contains)
+				t.Errorf("colorStateStr(%s) = %q, should contain %q", tt.state, result, tt.contains)
 			}
 		})
 	}
 }
 
-func TestColorState_Default(t *testing.T) {
-	result := colorState(agent.State("unknown"))
+func TestColorStateStr_Default(t *testing.T) {
+	result := colorStateStr("unknown")
 	if !strings.Contains(result, "unknown") {
-		t.Errorf("colorState(unknown) = %q, should contain 'unknown'", result)
+		t.Errorf("colorStateStr(unknown) = %q, should contain 'unknown'", result)
 	}
 	// Default should NOT contain ANSI escape codes
 	if strings.Contains(result, "\033[") {
-		t.Errorf("colorState(unknown) should not have color codes, got: %q", result)
+		t.Errorf("colorStateStr(unknown) should not have color codes, got: %q", result)
 	}
 }
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
-
-	"github.com/rpuneet/bc/pkg/agent"
 )
 
 // --- Test helpers ---
@@ -128,25 +126,25 @@ func TestFormatDuration(t *testing.T) {
 	}
 }
 
-// --- colorState tests ---
+// --- colorStateStr tests ---
 
-func TestColorState(t *testing.T) {
+func TestColorStateStr(t *testing.T) {
 	tests := []struct {
-		state agent.State
+		state string
 		want  string
 	}{
-		{agent.StateIdle, "idle"},
-		{agent.StateWorking, "working"},
-		{agent.StateDone, "done"},
-		{agent.StateStuck, "stuck"},
-		{agent.StateError, "error"},
-		{agent.StateStopped, "stopped"},
+		{"idle", "idle"},
+		{"working", "working"},
+		{"done", "done"},
+		{"stuck", "stuck"},
+		{"error", "error"},
+		{"stopped", "stopped"},
 	}
 	for _, tt := range tests {
-		t.Run(string(tt.state), func(t *testing.T) {
-			result := colorState(tt.state)
+		t.Run(tt.state, func(t *testing.T) {
+			result := colorStateStr(tt.state)
 			if !strings.Contains(result, tt.want) {
-				t.Errorf("colorState(%q) = %q, should contain %q", tt.state, result, tt.want)
+				t.Errorf("colorStateStr(%q) = %q, should contain %q", tt.state, result, tt.want)
 			}
 		})
 	}
@@ -156,39 +154,39 @@ func TestColorState(t *testing.T) {
 
 // --- parseRole tests ---
 
-func TestParseRole(t *testing.T) {
-	// All roles are custom now - parseRole accepts any valid alphanumeric name
+func TestParseRoleStr(t *testing.T) {
+	// All roles are custom now - parseRoleStr accepts any valid alphanumeric name
 	// No alias expansion (pm, coord, tl are returned as-is)
 	// Empty defaults to root
 	tests := []struct {
 		input   string
-		want    agent.Role
+		want    string
 		wantErr bool
 	}{
-		{"worker", agent.Role("worker"), false},
-		{"engineer", agent.Role("engineer"), false},
-		{"manager", agent.Role("manager"), false},
-		{"product-manager", agent.Role("product-manager"), false},
-		{"pm", agent.Role("pm"), false}, // No expansion, returned as-is
-		{"coordinator", agent.Role("coordinator"), false},
-		{"coord", agent.Role("coord"), false}, // No expansion, returned as-is
-		{"qa", agent.Role("qa"), false},
-		{"WORKER", agent.Role("worker"), false},           // case insensitive (lowercased)
-		{"Engineer", agent.Role("engineer"), false},       // case insensitive (lowercased)
-		{"custom-role", agent.Role("custom-role"), false}, // Custom roles accepted
-		{"", agent.RoleRoot, false},                       // Empty defaults to root
-		{"role@invalid", "", true},                        // Format error (contains @)
-		{"role with space", "", true},                     // Format error (contains space)
+		{"worker", "worker", false},
+		{"engineer", "engineer", false},
+		{"manager", "manager", false},
+		{"product-manager", "product-manager", false},
+		{"pm", "pm", false}, // No expansion, returned as-is
+		{"coordinator", "coordinator", false},
+		{"coord", "coord", false}, // No expansion, returned as-is
+		{"qa", "qa", false},
+		{"WORKER", "worker", false},           // case insensitive (lowercased)
+		{"Engineer", "engineer", false},       // case insensitive (lowercased)
+		{"custom-role", "custom-role", false}, // Custom roles accepted
+		{"", "root", false},                   // Empty defaults to root
+		{"role@invalid", "", true},            // Format error (contains @)
+		{"role with space", "", true},         // Format error (contains space)
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got, err := parseRole(tt.input)
+			got, err := parseRoleStr(tt.input)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("parseRole(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				t.Errorf("parseRoleStr(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("parseRole(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("parseRoleStr(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -5,23 +5,22 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rpuneet/bc/pkg/channel"
 	"github.com/rpuneet/bc/pkg/log"
 )
 
 // CompleteAgentNames returns a completion function for agent names
 func CompleteAgentNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	ws, err := getWorkspace()
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	mgr := newAgentManager(ws)
-	if loadErr := mgr.LoadState(); loadErr != nil {
-		log.Debug("completion: failed to load agent state", "error", loadErr)
+	agents, listErr := c.Agents.List(cmd.Context())
+	if listErr != nil {
+		log.Debug("completion: failed to list agents", "error", listErr)
+		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	agents := mgr.ListAgents()
 	names := make([]string, 0, len(agents))
 	for _, a := range agents {
 		names = append(names, a.Name)
@@ -31,19 +30,17 @@ func CompleteAgentNames(cmd *cobra.Command, args []string, toComplete string) ([
 
 // CompleteChannelNames returns a completion function for channel names
 func CompleteChannelNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	ws, err := getWorkspace()
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
-	store := channel.NewStore(ws.RootDir)
-	defer func() {
-		if closeErr := store.Close(); closeErr != nil {
-			log.Debug("completion: failed to close channel store", "error", closeErr)
-		}
-	}()
+	channels, listErr := c.Channels.List(cmd.Context())
+	if listErr != nil {
+		log.Debug("completion: failed to list channels", "error", listErr)
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 
-	channels := store.List()
 	names := make([]string, 0, len(channels))
 	for _, ch := range channels {
 		names = append(names, ch.Name)

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rpuneet/bc/pkg/agent"
-	"github.com/rpuneet/bc/pkg/events"
-	bclog "github.com/rpuneet/bc/pkg/log"
+	"github.com/rpuneet/bc/pkg/client"
 )
 
 // Flags for report command (enhanced for stuck reports - #675)
@@ -61,38 +59,32 @@ func runReport(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate state
-	state := agent.State(stateStr)
-	switch state {
-	case agent.StateIdle, agent.StateWorking, agent.StateDone, agent.StateStuck, agent.StateError:
+	switch stateStr {
+	case "idle", "working", "done", "stuck", "error":
 		// valid
 	default:
 		return fmt.Errorf("invalid state: %s (valid: idle, working, done, stuck, error)", stateStr)
 	}
 
-	// Find workspace
-	ws, err := getWorkspace()
+	// Update agent state via daemon
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
-		return errNotInWorkspace(err)
+		return err
 	}
 
-	// Update agent state
-	mgr := newAgentManager(ws)
-	if err := mgr.LoadState(); err != nil {
-		bclog.Warn("failed to load agent state", "error", err)
-	}
-	if err := mgr.UpdateAgentState(agentID, state, message); err != nil {
-		return fmt.Errorf("failed to update agent state: %w", err)
+	if reportErr := c.Agents.Report(cmd.Context(), agentID, stateStr, message); reportErr != nil {
+		return fmt.Errorf("failed to update agent state: %w", reportErr)
 	}
 
 	// Build event data
 	eventData := make(map[string]any)
-	eventMsg := fmt.Sprintf("%s: %s", state, message)
+	eventMsg := fmt.Sprintf("%s: %s", stateStr, message)
 
 	// Enhanced stuck reporting (#675)
-	if state == agent.StateStuck {
+	if stateStr == "stuck" {
 		if reportReason != "" {
 			eventData["reason"] = reportReason
-			eventMsg = fmt.Sprintf("%s: %s", state, reportReason)
+			eventMsg = fmt.Sprintf("%s: %s", stateStr, reportReason)
 		}
 		if reportReproduction != "" {
 			eventData["reproduction"] = reportReproduction
@@ -103,26 +95,29 @@ func runReport(cmd *cobra.Command, args []string) error {
 		eventData["stuck"] = true
 	}
 
-	// Log the report event
-	event := events.Event{
-		Type:    events.AgentReport,
+	// Log the report event via daemon
+	ev := client.EventInfo{
+		Type:    "agent_report",
 		Agent:   agentID,
 		Message: eventMsg,
 	}
 	if len(eventData) > 0 {
-		event.Data = eventData
+		ev.Data = eventData
 	}
-	logEvent(ws, event)
+	if appendErr := c.Events.Append(cmd.Context(), ev); appendErr != nil {
+		// Non-fatal: state was already updated
+		fmt.Fprintf(os.Stderr, "warning: failed to log event: %v\n", appendErr)
+	}
 
 	// Output message
-	if state == agent.StateStuck && reportReason != "" {
-		fmt.Printf("Reported: %s [%s]\n", state, reportSeverity)
+	if stateStr == "stuck" && reportReason != "" {
+		fmt.Printf("Reported: %s [%s]\n", stateStr, reportSeverity)
 		fmt.Printf("  Reason: %s\n", reportReason)
 		if reportReproduction != "" {
 			fmt.Printf("  Reproduction: %s\n", reportReproduction)
 		}
 	} else {
-		fmt.Printf("Reported: %s %s\n", state, message)
+		fmt.Printf("Reported: %s %s\n", stateStr, message)
 	}
 	return nil
 }

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -11,7 +11,6 @@ import (
 	"github.com/charmbracelet/x/term"
 	"github.com/spf13/cobra"
 
-	"github.com/rpuneet/bc/pkg/agent"
 	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/ui"
@@ -76,11 +75,10 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	activeCount := 0
 	workingCount := 0
 	for _, a := range agentList {
-		st := agent.State(a.State)
-		if st != agent.StateStopped && st != agent.StateError {
+		if a.State != "stopped" && a.State != "error" {
 			activeCount++
 		}
-		if st == agent.StateWorking {
+		if a.State == "working" {
 			workingCount++
 		}
 	}
@@ -138,7 +136,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	for _, a := range agentList {
 		uptime := "-"
-		if agent.State(a.State) != agent.StateStopped && !a.StartedAt.IsZero() {
+		if a.State != "stopped" && !a.StartedAt.IsZero() {
 			uptime = formatDuration(time.Since(a.StartedAt))
 		}
 
@@ -150,7 +148,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			task = task[:taskWidth-3] + "..."
 		}
 
-		stateStr := colorState(agent.State(a.State))
+		stateStr := colorStateStr(a.State)
 		fmt.Printf("%-15s %-12s %s %-20s %s\n", a.Name, a.Role, stateStr, uptime, task)
 	}
 
@@ -251,21 +249,22 @@ func normalizeTask(task string) string {
 	return task
 }
 
-func colorState(s agent.State) string {
+// colorStateStr colors a state string for terminal output.
+func colorStateStr(s string) string {
 	padded := fmt.Sprintf("%-10s", s)
 
 	switch s {
-	case agent.StateIdle:
+	case "idle":
 		return ui.CyanText(padded)
-	case agent.StateWorking:
+	case "working":
 		return ui.GreenText(padded)
-	case agent.StateDone:
+	case "done":
 		return ui.GreenText(padded)
-	case agent.StateStuck:
+	case "stuck":
 		return ui.RedText(padded)
-	case agent.StateError:
+	case "error":
 		return ui.RedText(padded)
-	case agent.StateStopped:
+	case "stopped":
 		return ui.YellowText(padded)
 	default:
 		return padded

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/rpuneet/bc/pkg/agent"
+	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/ui"
 	"github.com/rpuneet/bc/pkg/workspace"
@@ -292,15 +292,24 @@ func runWorkspaceUp(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("failed to ensure default roles: %w", err)
 	}
 
-	mgr := newAgentManager(ws)
-	if loadErr := mgr.LoadState(); loadErr != nil {
-		log.Warn("failed to load agent state", "error", loadErr)
+	c, clientErr := newDaemonClient(cmd.Context())
+	if clientErr != nil {
+		return clientErr
+	}
+
+	// Get existing agents to check which are already running
+	existingAgents, listErr := c.Agents.List(cmd.Context())
+	if listErr != nil {
+		return fmt.Errorf("list agents: %w", listErr)
+	}
+	existingMap := make(map[string]client.AgentInfo, len(existingAgents))
+	for _, a := range existingAgents {
+		existingMap[a.Name] = a
 	}
 
 	var started, skipped, failed int
 	for _, entry := range roster {
-		existing := mgr.GetAgent(entry.Name)
-		if existing != nil && existing.State != agent.StateStopped && existing.State != agent.StateError {
+		if existing, ok := existingMap[entry.Name]; ok && existing.State != "stopped" && existing.State != "error" {
 			fmt.Printf("  %-20s %s\n", entry.Name, ui.DimText("already running"))
 			skipped++
 			continue
@@ -319,21 +328,31 @@ func runWorkspaceUp(cmd *cobra.Command, _ []string) error {
 			tool = ws.DefaultProvider()
 		}
 
-		role := agent.Role(strings.ToLower(entry.Role))
+		role := strings.ToLower(entry.Role)
 		fmt.Printf("  %-20s starting...", entry.Name)
 
-		_, spawnErr := mgr.SpawnAgentWithOptions(cmd.Context(), agent.SpawnOptions{
-			Name:      entry.Name,
-			Role:      role,
-			Workspace: ws.RootDir,
-			Tool:      tool,
-			Runtime:   entry.Runtime,
-		})
-		if spawnErr != nil {
-			fmt.Printf(" %s\n", ui.RedText("✗"))
-			log.Warn("failed to start agent", "name", entry.Name, "error", spawnErr)
-			failed++
-			continue
+		// Check if agent exists but is stopped — start it. Otherwise create.
+		if _, exists := existingMap[entry.Name]; exists {
+			_, startErr := c.Agents.Start(cmd.Context(), entry.Name, entry.Runtime, "", false)
+			if startErr != nil {
+				fmt.Printf(" %s\n", ui.RedText("✗"))
+				log.Warn("failed to start agent", "name", entry.Name, "error", startErr)
+				failed++
+				continue
+			}
+		} else {
+			_, createErr := c.Agents.Create(cmd.Context(), client.CreateAgentReq{
+				Name:    entry.Name,
+				Role:    role,
+				Tool:    tool,
+				Runtime: entry.Runtime,
+			})
+			if createErr != nil {
+				fmt.Printf(" %s\n", ui.RedText("✗"))
+				log.Warn("failed to create agent", "name", entry.Name, "error", createErr)
+				failed++
+				continue
+			}
 		}
 
 		fmt.Printf(" %s\n", ui.GreenText("✓"))
@@ -610,9 +629,13 @@ func runWorkspaceInfo(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	mgr := agent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir)
-	_ = mgr.LoadState() // Non-fatal: continue without agent counts
-	agents := mgr.ListAgents()
+	// Get agent count via daemon client
+	agentCount := 0
+	if c, clientErr := newDaemonClient(cmd.Context()); clientErr == nil {
+		if agents, listErr := c.Agents.List(cmd.Context()); listErr == nil {
+			agentCount = len(agents)
+		}
+	}
 
 	// Count roles
 	roleCount := 0
@@ -646,7 +669,7 @@ func runWorkspaceInfo(cmd *cobra.Command, _ []string) error {
 			Version:    workspace.ConfigVersion,
 			Backend:    backend,
 			RoleCount:  roleCount,
-			AgentCount: len(agents),
+			AgentCount: agentCount,
 		}
 		if ws.Config != nil {
 			info.ConfigValid = ws.Config.Validate() == nil
@@ -664,7 +687,7 @@ func runWorkspaceInfo(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("  %-18s v%d\n", "Version:", workspace.ConfigVersion)
 	fmt.Printf("  %-18s %s\n", "Runtime:", backend)
 	fmt.Printf("  %-18s %d\n", "Roles:", roleCount)
-	fmt.Printf("  %-18s %d\n", "Agents:", len(agents))
+	fmt.Printf("  %-18s %d\n", "Agents:", agentCount)
 
 	if ws.Config != nil {
 		if err := ws.Config.Validate(); err != nil {
@@ -690,20 +713,26 @@ func runWorkspaceStatus(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	mgr := newAgentManager(ws)
-	_ = mgr.LoadState() // Non-fatal warning
-	agents := mgr.ListAgents()
+	c, clientErr := newDaemonClient(cmd.Context())
+	if clientErr != nil {
+		return clientErr
+	}
+
+	agents, listErr := c.Agents.List(cmd.Context())
+	if listErr != nil {
+		return fmt.Errorf("list agents: %w", listErr)
+	}
 
 	var running, idle, working, stopped int
 	for _, a := range agents {
 		switch a.State {
-		case agent.StateWorking:
+		case "working":
 			working++
 			running++
-		case agent.StateIdle, agent.StateStarting:
+		case "idle", "starting":
 			idle++
 			running++
-		case agent.StateStopped, agent.StateError, agent.StateDone:
+		case "stopped", "error", "done":
 			stopped++
 		default:
 			stopped++
@@ -757,11 +786,11 @@ func runWorkspaceStatus(cmd *cobra.Command, _ []string) error {
 		fmt.Printf("  %-16s %-12s %-10s %s\n", "AGENT", "ROLE", "STATE", "UPTIME")
 		for _, a := range agents {
 			uptime := "-"
-			if a.State != agent.StateStopped && a.State != agent.StateError {
+			if a.State != "stopped" && a.State != "error" {
 				uptime = formatDuration(time.Since(a.StartedAt))
 			}
 			fmt.Printf("  %-16s %-12s %-10s %s\n",
-				a.Name, string(a.Role), string(a.State), uptime)
+				a.Name, a.Role, a.State, uptime)
 		}
 	}
 

--- a/pkg/client/agents.go
+++ b/pkg/client/agents.go
@@ -234,6 +234,37 @@ func (a *AgentsClient) Cost(ctx context.Context, name string) (*AgentCostSummary
 	return &summary, nil
 }
 
+// Report updates an agent's state via the daemon.
+func (a *AgentsClient) Report(ctx context.Context, name, state, message string) error {
+	body := map[string]string{"state": state, "message": message}
+	return a.client.post(ctx, "/api/agents/"+name+"/report", body, nil)
+}
+
+// AgentHealthInfo represents health status of an agent.
+type AgentHealthInfo struct {
+	Name          string `json:"name"`
+	Role          string `json:"role"`
+	Status        string `json:"status"`
+	LastUpdated   string `json:"last_updated"`
+	StaleDuration string `json:"stale_duration,omitempty"`
+	ErrorMessage  string `json:"error_message,omitempty"`
+	TmuxAlive     bool   `json:"tmux_alive"`
+	StateFresh    bool   `json:"state_fresh"`
+}
+
+// Health returns health status for agents. If agentName is non-empty, filters to that agent.
+func (a *AgentsClient) Health(ctx context.Context, timeout string, agentName string) ([]AgentHealthInfo, error) {
+	path := "/api/agents/health?timeout=" + timeout
+	if agentName != "" {
+		path += "&agent=" + agentName
+	}
+	var results []AgentHealthInfo
+	if err := a.client.get(ctx, path, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 // StopAll stops all running agents. Returns the number of agents stopped.
 func (a *AgentsClient) StopAll(ctx context.Context) (int, error) {
 	var result map[string]int

--- a/pkg/client/events.go
+++ b/pkg/client/events.go
@@ -38,6 +38,11 @@ func (e *EventsClient) ListByAgent(ctx context.Context, agentName string) ([]Eve
 	return evts, nil
 }
 
+// Append logs a new event via the daemon.
+func (e *EventsClient) Append(ctx context.Context, ev EventInfo) error {
+	return e.client.post(ctx, "/api/logs", ev, nil)
+}
+
 // Tail returns the last N events.
 func (e *EventsClient) Tail(ctx context.Context, n int) ([]EventInfo, error) {
 	var evts []EventInfo

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -29,6 +29,7 @@ func (h *AgentHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/agents/send-role", h.sendRole)
 	mux.HandleFunc("/api/agents/send-pattern", h.sendPattern)
 	mux.HandleFunc("/api/agents/stop-all", h.stopAll)
+	mux.HandleFunc("/api/agents/health", h.health)
 	mux.HandleFunc("/api/agents", h.list)
 	mux.HandleFunc("/api/agents/", h.byName)
 }
@@ -264,6 +265,22 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, sessions)
 
+	case r.Method == http.MethodPost && action == "report":
+		var req struct {
+			State   string `json:"state"`
+			Message string `json:"message"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpError(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+		state := agent.State(req.State)
+		if err := h.svc.Manager().UpdateAgentState(name, state, req.Message); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "reported"})
+
 	case r.Method == http.MethodGet && action == "output":
 		h.streamOutput(w, r, name)
 
@@ -353,6 +370,81 @@ func (h *AgentHandler) stopAll(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]int{"stopped": stopped})
+}
+
+// AgentHealthInfo represents health status of an agent.
+type AgentHealthInfo struct {
+	Name          string `json:"name"`
+	Role          string `json:"role"`
+	Status        string `json:"status"`
+	LastUpdated   string `json:"last_updated"`
+	StaleDuration string `json:"stale_duration,omitempty"`
+	ErrorMessage  string `json:"error_message,omitempty"`
+	TmuxAlive     bool   `json:"tmux_alive"`
+	StateFresh    bool   `json:"state_fresh"`
+}
+
+func (h *AgentHandler) health(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	timeoutStr := r.URL.Query().Get("timeout")
+	timeout := 60 * time.Second
+	if timeoutStr != "" {
+		if d, err := time.ParseDuration(timeoutStr); err == nil {
+			timeout = d
+		}
+	}
+
+	agents, err := h.svc.List(r.Context(), agent.ListOptions{})
+	if err != nil {
+		httpError(w, "list agents: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Optionally filter to a single agent.
+	nameFilter := r.URL.Query().Get("agent")
+
+	mgr := h.svc.Manager()
+	results := make([]AgentHealthInfo, 0, len(agents))
+	for _, a := range agents {
+		if nameFilter != "" && a.Name != nameFilter {
+			continue
+		}
+		health := AgentHealthInfo{
+			Name:        a.Name,
+			Role:        string(a.Role),
+			LastUpdated: a.UpdatedAt.Format(time.RFC3339),
+		}
+		health.TmuxAlive = mgr.RuntimeForAgent(a.Name).HasSession(r.Context(), a.Name)
+
+		staleDuration := time.Since(a.UpdatedAt)
+		health.StateFresh = staleDuration < timeout
+		if !health.StateFresh {
+			health.StaleDuration = staleDuration.Round(time.Second).String()
+		}
+
+		switch {
+		case a.State == agent.StateStopped:
+			health.Status = "unhealthy"
+			health.ErrorMessage = "agent stopped"
+		case a.State == agent.StateError:
+			health.Status = "unhealthy"
+			health.ErrorMessage = "agent in error state"
+		case !health.TmuxAlive:
+			health.Status = "unhealthy"
+			health.ErrorMessage = "tmux session not found"
+		case !health.StateFresh:
+			health.Status = "degraded"
+			health.ErrorMessage = fmt.Sprintf("state stale (%s since last update)", health.StaleDuration)
+		default:
+			health.Status = "healthy"
+		}
+
+		results = append(results, health)
+	}
+
+	writeJSON(w, http.StatusOK, results)
 }
 
 // streamOutput streams agent terminal output as SSE events.

--- a/server/handlers/events.go
+++ b/server/handlers/events.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -20,14 +21,22 @@ func NewEventHandler(store events.EventStore) *EventHandler {
 
 // Register mounts event log routes on mux.
 func (h *EventHandler) Register(mux *http.ServeMux) {
-	mux.HandleFunc("/api/logs", h.list)
+	mux.HandleFunc("/api/logs", h.logs)
 	mux.HandleFunc("/api/logs/", h.byAgent)
 }
 
-func (h *EventHandler) list(w http.ResponseWriter, r *http.Request) {
-	if !requireMethod(w, r, http.MethodGet) {
-		return
+func (h *EventHandler) logs(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.list(w, r)
+	case http.MethodPost:
+		h.appendEvent(w, r)
+	default:
+		methodNotAllowed(w)
 	}
+}
+
+func (h *EventHandler) list(w http.ResponseWriter, r *http.Request) {
 	tail := 100
 	if s := r.URL.Query().Get("tail"); s != "" {
 		if n, err := strconv.Atoi(s); err == nil && n > 0 {
@@ -64,4 +73,24 @@ func (h *EventHandler) byAgent(w http.ResponseWriter, r *http.Request) {
 		evts = []events.Event{}
 	}
 	writeJSON(w, http.StatusOK, evts)
+}
+
+func (h *EventHandler) appendEvent(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var ev events.Event
+	if err := json.NewDecoder(r.Body).Decode(&ev); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if h.store == nil {
+		httpError(w, "event store not configured", http.StatusInternalServerError)
+		return
+	}
+	if err := h.store.Append(ev); err != nil {
+		httpError(w, "append event: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }


### PR DESCRIPTION
## Summary

Phase 3 of #2023. 6 command files migrated from direct pkg/ imports to HTTP client. 3 new API endpoints added. 13 files, +418/-319.

Build+vet+tests all pass locally.

Generated with [Claude Code](https://claude.com/claude-code)