### PR TITLE
fix(web): migrate tokens.css to Solar Flare palette

### DIFF
--- a/web/src/theme/tokens.css
+++ b/web/src/theme/tokens.css
@@ -3,17 +3,17 @@
 @tailwind utilities;
 
 :root {
-  --bc-bg: #0f1117;
-  --bc-surface: #1a1d27;
-  --bc-border: #2a2d3a;
-  --bc-text: #e2e4e9;
-  --bc-muted: #6b7280;
-  --bc-accent: #60a5fa;
-  --bc-success: #34d399;
-  --bc-warning: #fbbf24;
-  --bc-error: #f87171;
+  --bc-bg: #0C0A08;
+  --bc-surface: #1E1A16;
+  --bc-border: #2A2420;
+  --bc-text: #F5F0EB;
+  --bc-muted: #8C7E72;
+  --bc-accent: #EA580C;
+  --bc-success: #22C55E;
+  --bc-warning: #FB923C;
+  --bc-error: #EF4444;
 
-  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace;
+  font-family: Inter, 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
   color-scheme: dark;
 }
 


### PR DESCRIPTION
## Summary
- Replace cool blue/gray CSS custom properties with Solar Flare warm orange/earth-tone palette in `web/src/theme/tokens.css`
- Update font-family from monospace stack to sans-serif stack (Inter, Space Grotesk)
- All `--bc-*` variable names preserved; no component changes needed

Closes #2158

## Test plan
- [x] `bun run build` in `web/` succeeds with no errors
- [x] `make check` passes (pre-existing lint issues only, no new issues introduced)
- [ ] Visual review: verify dashboard renders with warm orange palette

Generated with [Claude Code](https://claude.com/claude-code)