### PR TITLE
fix(web): add loading skeletons and empty states across all views

### DIFF
--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -1,0 +1,27 @@
+interface EmptyStateProps {
+  icon?: string;
+  title: string;
+  description?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export function EmptyState({ icon, title, description, actionLabel, onAction }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+      {icon && <span className="text-3xl mb-3 opacity-60">{icon}</span>}
+      <h3 className="text-sm font-medium text-bc-text">{title}</h3>
+      {description && (
+        <p className="mt-1 text-sm text-bc-muted max-w-sm">{description}</p>
+      )}
+      {actionLabel && onAction && (
+        <button
+          onClick={onAction}
+          className="mt-4 px-4 py-1.5 bg-bc-accent text-bc-bg rounded text-sm font-medium hover:opacity-90"
+        >
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/LoadingSkeleton.tsx
+++ b/web/src/components/LoadingSkeleton.tsx
@@ -1,0 +1,68 @@
+interface LoadingSkeletonProps {
+  rows?: number;
+  variant?: 'table' | 'cards' | 'text';
+}
+
+function SkeletonBar({ className = '', style }: { className?: string; style?: React.CSSProperties }) {
+  return (
+    <div
+      className={`animate-pulse rounded bg-bc-border/50 ${className}`}
+      style={style}
+    />
+  );
+}
+
+function TableSkeleton({ rows }: { rows: number }) {
+  return (
+    <div className="rounded border border-bc-border overflow-hidden">
+      <div className="border-b border-bc-border bg-bc-surface px-4 py-2 flex gap-4">
+        <SkeletonBar className="h-4 w-24" />
+        <SkeletonBar className="h-4 w-20" />
+        <SkeletonBar className="h-4 w-16" />
+        <SkeletonBar className="h-4 w-20" />
+      </div>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="border-b border-bc-border/50 px-4 py-3 flex gap-4">
+          <SkeletonBar className="h-3 w-28" />
+          <SkeletonBar className="h-3 w-20" />
+          <SkeletonBar className="h-3 w-16" />
+          <SkeletonBar className="h-3 w-14" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CardsSkeleton({ rows }: { rows: number }) {
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="rounded border border-bc-border bg-bc-surface p-4 space-y-2">
+          <SkeletonBar className="h-3 w-16" />
+          <SkeletonBar className="h-6 w-24" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TextSkeleton({ rows }: { rows: number }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: rows }).map((_, i) => (
+        <SkeletonBar key={i} className="h-4" style={{ width: `${70 + (i % 3) * 10}%` }} />
+      ))}
+    </div>
+  );
+}
+
+export function LoadingSkeleton({ rows = 4, variant = 'table' }: LoadingSkeletonProps) {
+  switch (variant) {
+    case 'cards':
+      return <CardsSkeleton rows={rows} />;
+    case 'text':
+      return <TextSkeleton rows={rows} />;
+    default:
+      return <TableSkeleton rows={rows} />;
+  }
+}

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -1,3 +1,5 @@
+import { EmptyState } from './EmptyState';
+
 interface Column<T> {
   key: string;
   label: string;
@@ -11,11 +13,13 @@ interface TableProps<T> {
   keyFn: (row: T) => string;
   onRowClick?: (row: T) => void;
   emptyMessage?: string;
+  emptyIcon?: string;
+  emptyDescription?: string;
 }
 
-export function Table<T>({ columns, data, keyFn, onRowClick, emptyMessage = 'No data' }: TableProps<T>) {
+export function Table<T>({ columns, data, keyFn, onRowClick, emptyMessage = 'No data', emptyIcon, emptyDescription }: TableProps<T>) {
   if (!data || data.length === 0) {
-    return <p className="p-4 text-bc-muted text-sm">{emptyMessage}</p>;
+    return <EmptyState icon={emptyIcon} title={emptyMessage} description={emptyDescription} />;
   }
 
   return (

--- a/web/src/hooks/__tests__/usePolling.test.ts
+++ b/web/src/hooks/__tests__/usePolling.test.ts
@@ -22,6 +22,7 @@ describe('usePolling', () => {
     expect(result.current.data).toEqual(['a', 'b']);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
+    expect(result.current.timedOut).toBe(false);
   });
 
   it('sets error on fetch failure', async () => {
@@ -70,5 +71,38 @@ describe('usePolling', () => {
     });
 
     expect(fetcher.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('sets timedOut after 10 seconds without data', async () => {
+    const fetcher = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => usePolling(fetcher, 5000));
+
+    expect(result.current.timedOut).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+
+    expect(result.current.timedOut).toBe(true);
+  });
+
+  it('clears timedOut when data arrives', async () => {
+    let resolve: (v: string) => void;
+    const fetcher = vi.fn().mockImplementation(() => new Promise<string>((r) => { resolve = r; }));
+    const { result } = renderHook(() => usePolling(fetcher, 5000));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10000);
+    });
+
+    expect(result.current.timedOut).toBe(true);
+
+    await act(async () => {
+      resolve!('data');
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.timedOut).toBe(false);
+    expect(result.current.data).toBe('data');
   });
 });

--- a/web/src/hooks/usePolling.ts
+++ b/web/src/hooks/usePolling.ts
@@ -1,13 +1,17 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 
+const TIMEOUT_MS = 10000;
+
 export function usePolling<T>(
   fetcher: () => Promise<T>,
   intervalMs: number = 5000,
-): { data: T | null; loading: boolean; error: string | null; refresh: () => void } {
+): { data: T | null; loading: boolean; error: string | null; refresh: () => void; timedOut: boolean } {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
   const timer = useRef<ReturnType<typeof setInterval>>();
+  const timeoutTimer = useRef<ReturnType<typeof setTimeout>>();
   const abortRef = useRef<AbortController>();
 
   const doFetch = useCallback(async () => {
@@ -21,6 +25,8 @@ export function usePolling<T>(
       if (!controller.signal.aborted) {
         setData(result);
         setError(null);
+        setTimedOut(false);
+        clearTimeout(timeoutTimer.current);
       }
     } catch (err) {
       if (controller.signal.aborted) return; // Silently ignore aborted requests
@@ -33,13 +39,29 @@ export function usePolling<T>(
   }, [fetcher]);
 
   useEffect(() => {
+    setTimedOut(false);
+    timeoutTimer.current = setTimeout(() => {
+      setTimedOut(true);
+    }, TIMEOUT_MS);
+
     void doFetch();
     timer.current = setInterval(() => void doFetch(), intervalMs);
     return () => {
       clearInterval(timer.current);
+      clearTimeout(timeoutTimer.current);
       abortRef.current?.abort(); // Abort in-flight request on unmount
     };
   }, [doFetch, intervalMs]);
 
-  return { data, loading, error, refresh: doFetch };
+  const refresh = useCallback(() => {
+    setTimedOut(false);
+    setLoading(true);
+    clearTimeout(timeoutTimer.current);
+    timeoutTimer.current = setTimeout(() => {
+      setTimedOut(true);
+    }, TIMEOUT_MS);
+    void doFetch();
+  }, [doFetch]);
+
+  return { data, loading, error, refresh, timedOut };
 }

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -6,13 +6,15 @@ import { usePolling } from '../hooks/usePolling';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { StatusBadge } from '../components/StatusBadge';
 import { Table } from '../components/Table';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function Agents() {
   const fetcher = useCallback(async () => {
     const res = await api.listAgents();
     return res;
   }, []);
-  const { data: agents, loading, error, refresh } = usePolling(fetcher, 5000);
+  const { data: agents, loading, error, refresh, timedOut } = usePolling(fetcher, 5000);
   const { subscribe } = useWebSocket();
   const navigate = useNavigate();
 
@@ -24,20 +26,48 @@ export function Agents() {
   const columns = [
     { key: 'name', label: 'Name', render: (a: Agent) => <span className="font-medium">{a.name}</span> },
     { key: 'role', label: 'Role', render: (a: Agent) => <span className="text-bc-muted">{a.role}</span> },
-    { key: 'tool', label: 'Tool', render: (a: Agent) => <span className="text-bc-muted">{a.tool || '—'}</span> },
+    { key: 'tool', label: 'Tool', render: (a: Agent) => <span className="text-bc-muted">{a.tool || '\u2014'}</span> },
     { key: 'state', label: 'Status', render: (a: Agent) => <StatusBadge status={a.state} /> },
     {
       key: 'cost', label: 'Cost', render: (a: Agent) => (
-        <span className="text-bc-muted">{a.cost_usd != null ? `$${a.cost_usd.toFixed(4)}` : '—'}</span>
+        <span className="text-bc-muted">{a.cost_usd != null ? `$${a.cost_usd.toFixed(4)}` : '\u2014'}</span>
       ),
     },
   ];
 
   if (loading && !agents) {
-    return <div className="p-6 text-bc-muted">Loading agents...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-24 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="table" rows={4} />
+      </div>
+    );
+  }
+  if (timedOut && !agents) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Agents took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !agents) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load agents"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
 
   return (
@@ -53,7 +83,9 @@ export function Agents() {
           data={agents ?? []}
           keyFn={(a) => a.name}
           onRowClick={(a) => navigate(`/agents/${encodeURIComponent(a.name)}`)}
-          emptyMessage="No agents. Use 'bc agent create' to create one."
+          emptyMessage="No agents yet"
+          emptyIcon=">"
+          emptyDescription="Create your first agent with 'bc agent create <name> --role <role>'."
         />
       </div>
 

--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -4,21 +4,51 @@ import type { ChannelMessage } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { AgentPeekPanel } from '../components/AgentPeekPanel';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function Channels() {
   const fetcher = useCallback(async () => {
     const res = await api.listChannels();
     return res;
   }, []);
-  const { data: channels, loading, error } = usePolling(fetcher, 10000);
+  const { data: channels, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
   const [selected, setSelected] = useState<string | null>(null);
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
 
   if (loading && !channels) {
-    return <div className="p-6 text-bc-muted">Loading channels...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-28 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="text" rows={5} />
+      </div>
+    );
+  }
+  if (timedOut && !channels) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Channels took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !channels) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load channels"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
 
   return (
@@ -27,27 +57,41 @@ export function Channels() {
         <div className="p-3 border-b border-bc-border">
           <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">Channels</h2>
         </div>
-        {(channels ?? []).map((ch) => (
-          <button
-            key={ch.name}
-            onClick={() => setSelected(ch.name)}
-            className={`w-full text-left px-3 py-2 text-sm border-b border-bc-border/30 ${
-              selected === ch.name
-                ? 'bg-bc-accent/10 text-bc-accent'
-                : 'text-bc-text hover:bg-bc-surface'
-            }`}
-          >
-            <span className="font-medium">#{ch.name}</span>
-            <span className="ml-2 text-xs text-bc-muted">({ch.member_count})</span>
-          </button>
-        ))}
+        {(channels ?? []).length === 0 ? (
+          <div className="p-4">
+            <EmptyState
+              icon="#"
+              title="No channels"
+              description="Channels are created automatically when agents communicate."
+            />
+          </div>
+        ) : (
+          (channels ?? []).map((ch) => (
+            <button
+              key={ch.name}
+              onClick={() => setSelected(ch.name)}
+              className={`w-full text-left px-3 py-2 text-sm border-b border-bc-border/30 ${
+                selected === ch.name
+                  ? 'bg-bc-accent/10 text-bc-accent'
+                  : 'text-bc-text hover:bg-bc-surface'
+              }`}
+            >
+              <span className="font-medium">#{ch.name}</span>
+              <span className="ml-2 text-xs text-bc-muted">({ch.member_count})</span>
+            </button>
+          ))
+        )}
       </div>
       <div className="flex-1 flex flex-col min-w-0">
         {selected ? (
           <ChatRoom channelName={selected} onPeekAgent={setPeekAgent} />
         ) : (
-          <div className="flex-1 flex items-center justify-center text-bc-muted text-sm">
-            Select a channel
+          <div className="flex-1 flex items-center justify-center">
+            <EmptyState
+              icon="#"
+              title="Select a channel"
+              description="Choose a channel from the sidebar to view messages."
+            />
           </div>
         )}
       </div>
@@ -196,8 +240,12 @@ function ChatRoom({ channelName, onPeekAgent }: { channelName: string; onPeekAge
       <div className="relative flex-1">
         <div ref={scrollContainerRef} className="absolute inset-0 overflow-auto p-4 space-y-3">
           {messages.length === 0 && (
-            <div className="text-sm text-bc-muted text-center py-8">
-              No messages yet. Start the conversation!
+            <div className="flex-1 flex items-center justify-center py-8">
+              <EmptyState
+                icon="..."
+                title="No messages yet"
+                description={`Be the first to send a message in #${channelName}.`}
+              />
             </div>
           )}
           {groups.map((group) => {

--- a/web/src/views/Costs.tsx
+++ b/web/src/views/Costs.tsx
@@ -3,6 +3,8 @@ import { api } from '../api/client';
 import type { CostSummary, AgentCostSummary } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { Table } from '../components/Table';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 interface CostData {
   summary: CostSummary;
@@ -35,13 +37,42 @@ export function Costs() {
     return { summary, byAgent };
   }, []);
 
-  const { data, loading, error } = usePolling(fetcher, 10000);
+  const { data, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
 
   if (loading && !data) {
-    return <div className="p-6 text-bc-muted">Loading costs...</div>;
+    return (
+      <div className="p-6 space-y-6">
+        <div className="h-6 w-20 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="cards" rows={3} />
+        <LoadingSkeleton variant="table" rows={3} />
+      </div>
+    );
+  }
+  if (timedOut && !data) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Costs took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !data) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load costs"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (!data) return null;
 
@@ -85,7 +116,9 @@ export function Costs() {
             columns={columns}
             data={data.byAgent}
             keyFn={(r) => r.agent_id}
-            emptyMessage="No cost records yet."
+            emptyMessage="No cost records yet"
+            emptyIcon="$"
+            emptyDescription="Cost data will appear here once agents start running and using tokens."
           />
         </div>
       </section>

--- a/web/src/views/Cron.tsx
+++ b/web/src/views/Cron.tsx
@@ -3,22 +3,52 @@ import { api } from '../api/client';
 import type { CronJob } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { Table } from '../components/Table';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function Cron() {
   const fetcher = useCallback(() => api.listCron(), []);
-  const { data: jobs, loading, error } = usePolling(fetcher, 10000);
+  const { data: jobs, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
 
   if (loading && !jobs) {
-    return <div className="p-6 text-bc-muted">Loading cron jobs...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-28 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="table" rows={3} />
+      </div>
+    );
+  }
+  if (timedOut && !jobs) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Cron jobs took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !jobs) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load cron jobs"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
 
   const columns = [
     { key: 'name', label: 'Name', render: (j: CronJob) => <span className="font-medium">{j.name}</span> },
     { key: 'schedule', label: 'Schedule', render: (j: CronJob) => <code className="text-xs text-bc-muted">{j.schedule}</code> },
-    { key: 'agent', label: 'Agent', render: (j: CronJob) => <span>{j.agent_name || '—'}</span> },
+    { key: 'agent', label: 'Agent', render: (j: CronJob) => <span>{j.agent_name || '\u2014'}</span> },
     {
       key: 'enabled', label: 'Status', render: (j: CronJob) => (
         <span className={j.enabled ? 'text-green-400' : 'text-bc-muted'}>
@@ -48,7 +78,9 @@ export function Cron() {
           columns={columns}
           data={jobs ?? []}
           keyFn={(j) => j.name}
-          emptyMessage="No cron jobs. Use 'bc cron add' to create one."
+          emptyMessage="No cron jobs"
+          emptyIcon="~"
+          emptyDescription="Use 'bc cron add <name>' to schedule recurring tasks."
         />
       </div>
     </div>

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -4,6 +4,8 @@ import { api } from '../api/client';
 import type { Agent, CostSummary, Channel } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { StatusBadge } from '../components/StatusBadge';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 interface DashData {
   agents: Agent[];
@@ -31,13 +33,42 @@ export function Dashboard() {
     return { agents: agentsRes, channels: channelsRes, costs };
   }, []);
 
-  const { data, loading, error } = usePolling(fetcher, 5000);
+  const { data, loading, error, refresh, timedOut } = usePolling(fetcher, 5000);
 
   if (loading && !data) {
-    return <div className="p-6 text-bc-muted">Loading dashboard...</div>;
+    return (
+      <div className="p-6 space-y-6">
+        <div className="h-6 w-32 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="cards" rows={4} />
+        <LoadingSkeleton variant="table" rows={3} />
+      </div>
+    );
+  }
+  if (timedOut && !data) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Dashboard took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !data) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load dashboard"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (!data) return null;
 
@@ -60,7 +91,11 @@ export function Dashboard() {
           <Link to="/agents" className="text-xs text-bc-accent hover:underline">View all</Link>
         </div>
         {data.agents.length === 0 ? (
-          <p className="text-sm text-bc-muted">No agents yet.</p>
+          <EmptyState
+            icon=">"
+            title="No agents running"
+            description="Create your first agent with 'bc agent create <name> --role <role>' to get started."
+          />
         ) : (
           <div className="rounded border border-bc-border overflow-hidden">
             <table className="w-full text-sm">

--- a/web/src/views/Doctor.tsx
+++ b/web/src/views/Doctor.tsx
@@ -2,6 +2,8 @@ import { useCallback } from 'react';
 import { api } from '../api/client';
 import type { DoctorCategory } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 const severityIcon = (s: number) => {
   switch (s) {
@@ -14,19 +16,48 @@ const severityIcon = (s: number) => {
 
 export function Doctor() {
   const fetcher = useCallback(() => api.getDoctor(), []);
-  const { data: report, loading, error } = usePolling(fetcher, 30000);
+  const { data: report, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
 
   if (loading && !report) {
-    return <div className="p-6 text-bc-muted">Running diagnostics...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-24 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="text" rows={4} />
+        <LoadingSkeleton variant="text" rows={3} />
+      </div>
+    );
+  }
+  if (timedOut && !report) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Diagnostics took too long to run"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !report) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to run diagnostics"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (!report) return null;
 
-  const totalPassed = report.Categories.reduce((n, c) => n + c.Items.filter(i => i.Severity === 0).length, 0);
-  const totalFailed = report.Categories.reduce((n, c) => n + c.Items.filter(i => i.Severity === 2).length, 0);
-  const totalWarnings = report.Categories.reduce((n, c) => n + c.Items.filter(i => i.Severity === 1).length, 0);
+  const totalPassed = report.Categories.reduce((n: number, c: DoctorCategory) => n + c.Items.filter(i => i.Severity === 0).length, 0);
+  const totalFailed = report.Categories.reduce((n: number, c: DoctorCategory) => n + c.Items.filter(i => i.Severity === 2).length, 0);
+  const totalWarnings = report.Categories.reduce((n: number, c: DoctorCategory) => n + c.Items.filter(i => i.Severity === 1).length, 0);
 
   return (
     <div className="p-6 space-y-6">
@@ -39,7 +70,7 @@ export function Doctor() {
         </div>
       </div>
 
-      {report.Categories.map((cat) => (
+      {report.Categories.map((cat: DoctorCategory) => (
         <CategorySection key={cat.Name} category={cat} />
       ))}
     </div>

--- a/web/src/views/Logs.tsx
+++ b/web/src/views/Logs.tsx
@@ -1,16 +1,46 @@
 import { useCallback } from 'react';
 import { api } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function Logs() {
   const fetcher = useCallback(() => api.getLogs(100), []);
-  const { data: logs, loading, error } = usePolling(fetcher, 5000);
+  const { data: logs, loading, error, refresh, timedOut } = usePolling(fetcher, 5000);
 
   if (loading && !logs) {
-    return <div className="p-6 text-bc-muted">Loading logs...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-28 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="table" rows={6} />
+      </div>
+    );
+  }
+  if (timedOut && !logs) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Logs took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !logs) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load logs"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
 
   return (
@@ -21,7 +51,11 @@ export function Logs() {
       </div>
 
       {(!logs || logs.length === 0) ? (
-        <p className="text-bc-muted text-sm">No events recorded yet.</p>
+        <EmptyState
+          icon="[]"
+          title="No events recorded yet"
+          description="Events will appear here as agents start, stop, and communicate."
+        />
       ) : (
         <div className="rounded border border-bc-border overflow-hidden">
           <div className="overflow-auto max-h-[70vh]">
@@ -38,13 +72,13 @@ export function Logs() {
                 {logs.map((entry, i) => (
                   <tr key={entry.id || i} className="border-b border-bc-border/50">
                     <td className="px-4 py-2 text-bc-muted whitespace-nowrap">
-                      {entry.created_at ? new Date(entry.created_at).toLocaleString() : '—'}
+                      {entry.created_at ? new Date(entry.created_at).toLocaleString() : '\u2014'}
                     </td>
                     <td className="px-4 py-2">
                       <span className="text-xs px-2 py-0.5 rounded bg-bc-border text-bc-muted">{entry.type}</span>
                     </td>
-                    <td className="px-4 py-2 font-medium">{entry.agent || '—'}</td>
-                    <td className="px-4 py-2 text-bc-muted">{entry.message || '—'}</td>
+                    <td className="px-4 py-2 font-medium">{entry.agent || '\u2014'}</td>
+                    <td className="px-4 py-2 text-bc-muted">{entry.message || '\u2014'}</td>
                   </tr>
                 ))}
               </tbody>

--- a/web/src/views/MCP.tsx
+++ b/web/src/views/MCP.tsx
@@ -3,16 +3,46 @@ import { api } from '../api/client';
 import type { MCPServer } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { Table } from '../components/Table';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function MCP() {
   const fetcher = useCallback(() => api.listMCP(), []);
-  const { data: servers, loading, error } = usePolling(fetcher, 30000);
+  const { data: servers, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
 
   if (loading && !servers) {
-    return <div className="p-6 text-bc-muted">Loading MCP servers...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-32 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="table" rows={3} />
+      </div>
+    );
+  }
+  if (timedOut && !servers) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="MCP servers took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !servers) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load MCP servers"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
 
   const columns = [
@@ -24,7 +54,7 @@ export function MCP() {
     },
     {
       key: 'endpoint', label: 'Endpoint', render: (s: MCPServer) => (
-        <code className="text-xs text-bc-muted">{s.url || s.command || '—'}</code>
+        <code className="text-xs text-bc-muted">{s.url || s.command || '\u2014'}</code>
       ),
     },
     {
@@ -48,7 +78,9 @@ export function MCP() {
           columns={columns}
           data={servers ?? []}
           keyFn={(s) => s.name}
-          emptyMessage="No MCP servers configured. Use 'bc mcp add' to add one."
+          emptyMessage="No MCP servers configured"
+          emptyIcon="~"
+          emptyDescription="Use 'bc mcp add <name>' to connect an MCP server."
         />
       </div>
     </div>

--- a/web/src/views/Roles.tsx
+++ b/web/src/views/Roles.tsx
@@ -2,19 +2,49 @@ import { useCallback, useState } from 'react';
 import { api } from '../api/client';
 import type { Role } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function Roles() {
   const fetcher = useCallback(async () => {
     const res = await api.listRoles();
     return Object.entries(res).map(([key, role]) => ({ key, ...role }));
   }, []);
-  const { data: roles, loading, error } = usePolling(fetcher, 30000);
+  const { data: roles, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
 
   if (loading && !roles) {
-    return <div className="p-6 text-bc-muted">Loading roles...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-20 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="text" rows={6} />
+      </div>
+    );
+  }
+  if (timedOut && !roles) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Roles took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !roles) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load roles"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
 
   return (
@@ -23,11 +53,19 @@ export function Roles() {
         <h1 className="text-xl font-bold">Roles</h1>
         <span className="text-sm text-bc-muted">{roles?.length ?? 0} roles</span>
       </div>
-      <div className="grid gap-4">
-        {(roles ?? []).map((r) => (
-          <RoleCard key={r.key} role={r} />
-        ))}
-      </div>
+      {(roles ?? []).length === 0 ? (
+        <EmptyState
+          icon="@"
+          title="No roles defined"
+          description="Define roles in .bc/roles/ to assign capabilities and prompts to agents."
+        />
+      ) : (
+        <div className="grid gap-4">
+          {(roles ?? []).map((r) => (
+            <RoleCard key={r.key} role={r} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -86,7 +124,7 @@ function RoleCard({ role }: { role: Role & { key: string } }) {
           {hasPrompts && <span className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-400">lifecycle</span>}
           {hasCommands && <span className="text-xs px-2 py-0.5 rounded bg-cyan-500/20 text-cyan-400">commands</span>}
           {hasRules && <span className="text-xs px-2 py-0.5 rounded bg-orange-500/20 text-orange-400">rules</span>}
-          <span className="text-xs text-bc-muted">{expanded ? '▼' : '▶'}</span>
+          <span className="text-xs text-bc-muted">{expanded ? '\u25BC' : '\u25B6'}</span>
         </div>
       </div>
 

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -3,26 +3,56 @@ import { api } from '../api/client';
 import type { Secret } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { Table } from '../components/Table';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function Secrets() {
   const fetcher = useCallback(() => api.listSecrets(), []);
-  const { data: secrets, loading, error } = usePolling(fetcher, 30000);
+  const { data: secrets, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
 
   if (loading && !secrets) {
-    return <div className="p-6 text-bc-muted">Loading secrets...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-24 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="table" rows={3} />
+      </div>
+    );
+  }
+  if (timedOut && !secrets) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Secrets took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !secrets) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load secrets"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
 
   const columns = [
     { key: 'name', label: 'Name', render: (s: Secret) => <span className="font-medium">{s.name}</span> },
-    { key: 'desc', label: 'Description', render: (s: Secret) => <span className="text-bc-muted">{s.description || '—'}</span> },
+    { key: 'desc', label: 'Description', render: (s: Secret) => <span className="text-bc-muted">{s.description || '\u2014'}</span> },
     { key: 'backend', label: 'Backend', render: (s: Secret) => <code className="text-xs text-bc-muted">{s.backend}</code> },
     {
       key: 'created', label: 'Created', render: (s: Secret) => (
         <span className="text-xs text-bc-muted">
-          {s.created_at ? new Date(s.created_at).toLocaleDateString() : '—'}
+          {s.created_at ? new Date(s.created_at).toLocaleDateString() : '\u2014'}
         </span>
       ),
     },
@@ -42,7 +72,9 @@ export function Secrets() {
           columns={columns}
           data={secrets ?? []}
           keyFn={(s) => s.name}
-          emptyMessage="No secrets. Use 'bc secret set <name> --value <value>' to add one."
+          emptyMessage="No secrets stored"
+          emptyIcon="*"
+          emptyDescription="Use 'bc secret set <name> --value <value>' to store a secret."
         />
       </div>
     </div>

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -3,16 +3,46 @@ import { api } from '../api/client';
 import type { Tool } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { Table } from '../components/Table';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function Tools() {
   const fetcher = useCallback(() => api.listTools(), []);
-  const { data: tools, loading, error } = usePolling(fetcher, 30000);
+  const { data: tools, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
 
   if (loading && !tools) {
-    return <div className="p-6 text-bc-muted">Loading tools...</div>;
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-20 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="table" rows={4} />
+      </div>
+    );
+  }
+  if (timedOut && !tools) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Tools took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !tools) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load tools"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
 
   const columns = [
@@ -32,7 +62,7 @@ export function Tools() {
     },
     {
       key: 'install', label: 'Install', render: (t: Tool) => (
-        <code className="text-xs text-bc-muted">{t.install_cmd || '—'}</code>
+        <code className="text-xs text-bc-muted">{t.install_cmd || '\u2014'}</code>
       ),
     },
   ];
@@ -49,7 +79,9 @@ export function Tools() {
           columns={columns}
           data={tools ?? []}
           keyFn={(t) => t.name}
-          emptyMessage="No tools configured."
+          emptyMessage="No tools configured"
+          emptyIcon="*"
+          emptyDescription="Add tools in your config.toml [tools] section."
         />
       </div>
     </div>

--- a/web/src/views/Workspace.tsx
+++ b/web/src/views/Workspace.tsx
@@ -1,16 +1,46 @@
 import { useCallback } from 'react';
 import { api } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
+import { LoadingSkeleton } from '../components/LoadingSkeleton';
+import { EmptyState } from '../components/EmptyState';
 
 export function Workspace() {
   const fetcher = useCallback(() => api.getWorkspaceStatus(), []);
-  const { data: status, loading, error } = usePolling(fetcher, 10000);
+  const { data: status, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
 
   if (loading && !status) {
-    return <div className="p-6 text-bc-muted">Loading workspace...</div>;
+    return (
+      <div className="p-6 space-y-6">
+        <div className="h-6 w-32 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="cards" rows={4} />
+      </div>
+    );
+  }
+  if (timedOut && !status) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Workspace took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (error && !status) {
-    return <div className="p-6 text-bc-error">Error: {error}</div>;
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load workspace"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
   }
   if (!status) return null;
 

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -33,29 +33,47 @@ beforeEach(() => {
   fetchMock.mockReset();
 });
 
+function expectSkeletonLoading(container: HTMLElement) {
+  const pulseElements = container.querySelectorAll('.animate-pulse');
+  expect(pulseElements.length).toBeGreaterThan(0);
+}
+
 describe('Dashboard', () => {
-  it('renders loading then data', async () => {
+  it('renders skeleton loading then data', async () => {
     fetchMock.mockImplementation((url: string) => {
       if (url.includes('/agents')) return jsonResponse([]);
       if (url.includes('/channels')) return jsonResponse([]);
       if (url.includes('/costs')) return jsonResponse({ input_tokens: 0, output_tokens: 0, total_tokens: 100, total_cost_usd: 1.5, record_count: 2 });
       return jsonResponse({});
     });
-    wrap(<Dashboard />);
-    expect(screen.getByText('Loading dashboard...')).toBeInTheDocument();
+    const { container } = wrap(<Dashboard />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    });
+  });
+
+  it('renders empty state for no agents', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('/agents')) return jsonResponse([]);
+      if (url.includes('/channels')) return jsonResponse([]);
+      if (url.includes('/costs')) return jsonResponse({ input_tokens: 0, output_tokens: 0, total_tokens: 0, total_cost_usd: 0, record_count: 0 });
+      return jsonResponse({});
+    });
+    wrap(<Dashboard />);
+    await waitFor(() => {
+      expect(screen.getByText('No agents running')).toBeInTheDocument();
     });
   });
 });
 
 describe('Agents', () => {
-  it('renders loading then agent list', async () => {
+  it('renders skeleton loading then agent list', async () => {
     fetchMock.mockReturnValue(jsonResponse([
       { name: 'bot-1', role: 'engineer', tool: 'claude', state: 'running', cost_usd: 0.01, started_at: '' },
     ]));
-    wrap(<Agents />);
-    expect(screen.getByText('Loading agents...')).toBeInTheDocument();
+    const { container } = wrap(<Agents />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('bot-1')).toBeInTheDocument();
     });
@@ -63,12 +81,12 @@ describe('Agents', () => {
 });
 
 describe('Channels', () => {
-  it('renders loading then channel list', async () => {
+  it('renders skeleton loading then channel list', async () => {
     fetchMock.mockReturnValue(jsonResponse([
       { name: 'general', description: '', members: [], member_count: 3 },
     ]));
-    wrap(<Channels />);
-    expect(screen.getByText('Loading channels...')).toBeInTheDocument();
+    const { container } = wrap(<Channels />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('#general')).toBeInTheDocument();
     });
@@ -76,14 +94,14 @@ describe('Channels', () => {
 });
 
 describe('Costs', () => {
-  it('renders loading then cost data', async () => {
+  it('renders skeleton loading then cost data', async () => {
     fetchMock.mockImplementation((url: string) => {
       if (url.includes('/costs/agents')) return jsonResponse([]);
       if (url.includes('/costs')) return jsonResponse({ input_tokens: 0, output_tokens: 0, total_tokens: 0, total_cost_usd: 0, record_count: 0 });
       return jsonResponse({});
     });
-    wrap(<Costs />);
-    expect(screen.getByText('Loading costs...')).toBeInTheDocument();
+    const { container } = wrap(<Costs />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('Costs')).toBeInTheDocument();
     });
@@ -91,12 +109,12 @@ describe('Costs', () => {
 });
 
 describe('Roles', () => {
-  it('renders loading then role cards', async () => {
+  it('renders skeleton loading then role cards', async () => {
     fetchMock.mockReturnValue(jsonResponse({
       eng: { Name: 'engineer', Prompt: '', MCPServers: [], Secrets: [], Plugins: [], PromptCreate: '', PromptStart: '', PromptStop: '', PromptDelete: '', Commands: {}, Skills: {}, Agents: {}, Rules: {}, Settings: {}, Review: '' },
     }));
-    wrap(<Roles />);
-    expect(screen.getByText('Loading roles...')).toBeInTheDocument();
+    const { container } = wrap(<Roles />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('engineer')).toBeInTheDocument();
     });
@@ -104,12 +122,12 @@ describe('Roles', () => {
 });
 
 describe('Tools', () => {
-  it('renders loading then tool table', async () => {
+  it('renders skeleton loading then tool table', async () => {
     fetchMock.mockReturnValue(jsonResponse([
       { name: 'my-tool', command: '/usr/bin/tool', install_cmd: '', builtin: true, enabled: true },
     ]));
-    wrap(<Tools />);
-    expect(screen.getByText('Loading tools...')).toBeInTheDocument();
+    const { container } = wrap(<Tools />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('my-tool')).toBeInTheDocument();
     });
@@ -117,12 +135,12 @@ describe('Tools', () => {
 });
 
 describe('MCP', () => {
-  it('renders loading then server list', async () => {
+  it('renders skeleton loading then server list', async () => {
     fetchMock.mockReturnValue(jsonResponse([
       { name: 'test-server', transport: 'stdio', command: 'node', url: '', enabled: true },
     ]));
-    wrap(<MCP />);
-    expect(screen.getByText('Loading MCP servers...')).toBeInTheDocument();
+    const { container } = wrap(<MCP />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('test-server')).toBeInTheDocument();
     });
@@ -130,25 +148,33 @@ describe('MCP', () => {
 });
 
 describe('Logs', () => {
-  it('renders loading then event log', async () => {
+  it('renders skeleton loading then event log', async () => {
     fetchMock.mockReturnValue(jsonResponse([
       { id: 1, type: 'agent.start', agent: 'bot', message: 'started', created_at: '2025-01-01T00:00:00Z' },
     ]));
-    wrap(<Logs />);
-    expect(screen.getByText('Loading logs...')).toBeInTheDocument();
+    const { container } = wrap(<Logs />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('Event Log')).toBeInTheDocument();
+    });
+  });
+
+  it('renders empty state when no logs', async () => {
+    fetchMock.mockReturnValue(jsonResponse([]));
+    wrap(<Logs />);
+    await waitFor(() => {
+      expect(screen.getByText('No events recorded yet')).toBeInTheDocument();
     });
   });
 });
 
 describe('Doctor', () => {
-  it('renders loading then report', async () => {
+  it('renders skeleton loading then report', async () => {
     fetchMock.mockReturnValue(jsonResponse({
       Categories: [{ Name: 'System', Items: [{ Name: 'go', Message: 'installed', Fix: '', Severity: 0 }] }],
     }));
-    wrap(<Doctor />);
-    expect(screen.getByText('Running diagnostics...')).toBeInTheDocument();
+    const { container } = wrap(<Doctor />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('Doctor')).toBeInTheDocument();
     });
@@ -156,12 +182,12 @@ describe('Doctor', () => {
 });
 
 describe('Cron', () => {
-  it('renders loading then cron table', async () => {
+  it('renders skeleton loading then cron table', async () => {
     fetchMock.mockReturnValue(jsonResponse([
       { name: 'nightly', schedule: '0 0 * * *', agent_name: 'bot', prompt: '', command: '', enabled: true, run_count: 5, last_run: null, next_run: null, created_at: '' },
     ]));
-    wrap(<Cron />);
-    expect(screen.getByText('Loading cron jobs...')).toBeInTheDocument();
+    const { container } = wrap(<Cron />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('nightly')).toBeInTheDocument();
     });
@@ -169,12 +195,12 @@ describe('Cron', () => {
 });
 
 describe('Secrets', () => {
-  it('renders loading then secrets table', async () => {
+  it('renders skeleton loading then secrets table', async () => {
     fetchMock.mockReturnValue(jsonResponse([
       { name: 'API_KEY', description: 'key', backend: 'env', created_at: '2025-01-01' },
     ]));
-    wrap(<Secrets />);
-    expect(screen.getByText('Loading secrets...')).toBeInTheDocument();
+    const { container } = wrap(<Secrets />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('API_KEY')).toBeInTheDocument();
     });
@@ -182,10 +208,10 @@ describe('Secrets', () => {
 });
 
 describe('Workspace', () => {
-  it('renders loading then workspace status', async () => {
+  it('renders skeleton loading then workspace status', async () => {
     fetchMock.mockReturnValue(jsonResponse({ root_dir: '/home/project', version: '2' }));
-    wrap(<Workspace />);
-    expect(screen.getByText('Loading workspace...')).toBeInTheDocument();
+    const { container } = wrap(<Workspace />);
+    expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText('Workspace')).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- Adds reusable `LoadingSkeleton` and `EmptyState` components
- Updates all 12 web dashboard views with proper loading/empty states
- Adds 10s timeout with retry button via `usePolling` enhancement
- Updates Table component with EmptyState integration
- 27 web tests passing

Rebased on latest main with conflict resolved (Channels.tsx merged with message history + peek panel features).

Closes #2292

## Test plan
- [x] All 27 web tests pass
- [x] Web build succeeds
- [x] Loading skeletons render with pulse animation
- [x] Empty states show contextual messages
- [x] Timeout retry works after 10s

Generated with [Claude Code](https://claude.com/claude-code)