### PR TITLE
feat(mcp): add SSE end-to-end integration tests (#2318)

### DIFF
--- a/server/mcp/e2e_sse_test.go
+++ b/server/mcp/e2e_sse_test.go
@@ -1,0 +1,483 @@
+package mcp_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rpuneet/bc/server/mcp"
+)
+
+// sseEvent represents a parsed SSE event from the stream.
+type sseEvent struct {
+	Event string // "endpoint", "message", or "" (default)
+	Data  string
+}
+
+// sseClient manages a long-lived SSE connection and parses events.
+type sseClient struct {
+	events chan sseEvent
+	resp   *http.Response
+	cancel context.CancelFunc
+}
+
+// newSSEClient connects to the SSE endpoint and starts reading events in a goroutine.
+func newSSEClient(t *testing.T, url string) *sseClient {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		cancel()
+		t.Fatalf("new SSE request: %v", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req) //nolint:bodyclose // body kept open for SSE streaming; closed in sseClient.close()
+	if err != nil {
+		cancel()
+		t.Fatalf("GET /sse: %v", err)
+	}
+
+	c := &sseClient{
+		events: make(chan sseEvent, 16),
+		resp:   resp,
+		cancel: cancel,
+	}
+
+	go c.readLoop()
+	return c
+}
+
+// readLoop reads SSE events from the response body and sends them on the events channel.
+func (c *sseClient) readLoop() {
+	defer close(c.events)
+	scanner := bufio.NewScanner(c.resp.Body)
+	var event, data string
+	for scanner.Scan() {
+		line := scanner.Text()
+		switch {
+		case strings.HasPrefix(line, "event: "):
+			event = strings.TrimPrefix(line, "event: ")
+		case strings.HasPrefix(line, "data: "):
+			data = strings.TrimPrefix(line, "data: ")
+		case line == "":
+			if data != "" || event != "" {
+				c.events <- sseEvent{Event: event, Data: data}
+				event = ""
+				data = ""
+			}
+		}
+	}
+}
+
+// close shuts down the SSE connection.
+func (c *sseClient) close() {
+	c.cancel()
+	c.resp.Body.Close() //nolint:errcheck
+}
+
+// readEvent reads the next SSE event with a timeout.
+func (c *sseClient) readEvent(t *testing.T) sseEvent {
+	t.Helper()
+	select {
+	case ev, ok := <-c.events:
+		if !ok {
+			t.Fatal("SSE stream closed unexpectedly")
+		}
+		return ev
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for SSE event")
+		return sseEvent{}
+	}
+}
+
+// postRPC sends a JSON-RPC request to the message endpoint and asserts 202 Accepted.
+func postRPC(t *testing.T, url string, id int, method string, params any) {
+	t.Helper()
+
+	rawID := json.RawMessage(jsonNum(id))
+	var rawParams json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("marshal params: %v", err)
+		}
+		rawParams = b
+	}
+
+	req := mcp.Request{JSONRPC: "2.0", ID: &rawID, Method: method, Params: rawParams}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, url,
+		strings.NewReader(string(body)),
+	)
+	if err != nil {
+		t.Fatalf("new POST request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(httpReq)
+	if err != nil {
+		t.Fatalf("POST %s: %v", method, err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("POST %s: status = %d, want 202", method, resp.StatusCode)
+	}
+}
+
+// jsonNum returns a JSON number string for an int.
+func jsonNum(n int) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+// decodeSSEResponse unmarshals the SSE event data as a JSON-RPC response.
+func decodeSSEResponse(t *testing.T, ev sseEvent) mcp.Response {
+	t.Helper()
+	var resp mcp.Response
+	if err := json.Unmarshal([]byte(ev.Data), &resp); err != nil {
+		t.Fatalf("decode SSE response: %v\nraw: %s", err, ev.Data)
+	}
+	return resp
+}
+
+// decodeResult re-marshals the response result and unmarshals into dst.
+func decodeResult(t *testing.T, resp mcp.Response, dst any) {
+	t.Helper()
+	if resp.Error != nil {
+		t.Fatalf("unexpected RPC error: %s (code %d)", resp.Error.Message, resp.Error.Code)
+	}
+	b, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("re-marshal result: %v", err)
+	}
+	if err := json.Unmarshal(b, dst); err != nil {
+		t.Fatalf("decode result into %T: %v", dst, err)
+	}
+}
+
+// ─── E2E SSE tests ───────────────────────────────────────────────────────────
+
+func TestSSE_E2E_InitializeRoundTrip(t *testing.T) {
+	srv := newTestServer(t)
+	broker := mcp.NewSSEBroker()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", broker.SSEHandler())
+	mux.HandleFunc("/message", srv.HandleSSEMessage(context.Background(), broker))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newSSEClient(t, ts.URL+"/sse")
+	defer client.close()
+
+	// First event must be the endpoint event.
+	ev := client.readEvent(t)
+	if ev.Event != "endpoint" {
+		t.Fatalf("first event type = %q, want endpoint", ev.Event)
+	}
+
+	// The endpoint data tells us where to POST.
+	messageURL := ts.URL + ev.Data
+
+	// POST initialize request.
+	postRPC(t, messageURL, 1, "initialize", map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "e2e-test"},
+	})
+
+	// Read initialize response from SSE stream.
+	respEv := client.readEvent(t)
+	resp := decodeSSEResponse(t, respEv)
+
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		ServerInfo      struct {
+			Name    string `json:"name"`
+			Version string `json:"version"`
+		} `json:"serverInfo"`
+		Capabilities struct {
+			Resources json.RawMessage `json:"resources"`
+			Tools     json.RawMessage `json:"tools"`
+		} `json:"capabilities"`
+	}
+	decodeResult(t, resp, &result)
+
+	if result.ProtocolVersion != "2024-11-05" {
+		t.Errorf("protocolVersion = %q, want 2024-11-05", result.ProtocolVersion)
+	}
+	if result.ServerInfo.Name != "bc" {
+		t.Errorf("serverInfo.name = %q, want bc", result.ServerInfo.Name)
+	}
+	if result.ServerInfo.Version != "test" {
+		t.Errorf("serverInfo.version = %q, want test", result.ServerInfo.Version)
+	}
+	if result.Capabilities.Resources == nil {
+		t.Error("capabilities.resources should be present")
+	}
+	if result.Capabilities.Tools == nil {
+		t.Error("capabilities.tools should be present")
+	}
+}
+
+func TestSSE_E2E_ResourcesList(t *testing.T) {
+	srv := newTestServer(t)
+	broker := mcp.NewSSEBroker()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", broker.SSEHandler())
+	mux.HandleFunc("/message", srv.HandleSSEMessage(context.Background(), broker))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newSSEClient(t, ts.URL+"/sse")
+	defer client.close()
+
+	ev := client.readEvent(t)
+	messageURL := ts.URL + ev.Data
+
+	postRPC(t, messageURL, 1, "resources/list", nil)
+
+	respEv := client.readEvent(t)
+	resp := decodeSSEResponse(t, respEv)
+
+	var result struct {
+		Resources []mcp.Resource `json:"resources"`
+	}
+	decodeResult(t, resp, &result)
+
+	wantURIs := []string{
+		"bc://workspace/status",
+		"bc://agents",
+		"bc://channels",
+		"bc://costs",
+		"bc://roles",
+		"bc://tools",
+	}
+	got := make(map[string]bool, len(result.Resources))
+	for _, r := range result.Resources {
+		got[r.URI] = true
+	}
+	for _, uri := range wantURIs {
+		if !got[uri] {
+			t.Errorf("resources/list missing URI %q", uri)
+		}
+	}
+	if len(result.Resources) != len(wantURIs) {
+		t.Errorf("got %d resources, want %d", len(result.Resources), len(wantURIs))
+	}
+}
+
+func TestSSE_E2E_ResourcesRead(t *testing.T) {
+	srv := newTestServer(t)
+	broker := mcp.NewSSEBroker()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", broker.SSEHandler())
+	mux.HandleFunc("/message", srv.HandleSSEMessage(context.Background(), broker))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newSSEClient(t, ts.URL+"/sse")
+	defer client.close()
+
+	ev := client.readEvent(t)
+	messageURL := ts.URL + ev.Data
+
+	postRPC(t, messageURL, 1, "resources/read", map[string]string{"uri": "bc://agents"})
+
+	respEv := client.readEvent(t)
+	resp := decodeSSEResponse(t, respEv)
+
+	var result struct {
+		Contents []struct {
+			URI      string `json:"uri"`
+			MIMEType string `json:"mimeType"`
+			Text     string `json:"text"`
+		} `json:"contents"`
+	}
+	decodeResult(t, resp, &result)
+
+	if len(result.Contents) != 1 {
+		t.Fatalf("expected 1 content item, got %d", len(result.Contents))
+	}
+	c := result.Contents[0]
+	if c.URI != "bc://agents" {
+		t.Errorf("content URI = %q, want bc://agents", c.URI)
+	}
+	if c.MIMEType != "application/json" {
+		t.Errorf("mimeType = %q, want application/json", c.MIMEType)
+	}
+	// Verify the text is valid JSON.
+	if !json.Valid([]byte(c.Text)) {
+		t.Errorf("content text is not valid JSON: %s", c.Text)
+	}
+}
+
+func TestSSE_E2E_ToolsList(t *testing.T) {
+	srv := newTestServer(t)
+	broker := mcp.NewSSEBroker()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", broker.SSEHandler())
+	mux.HandleFunc("/message", srv.HandleSSEMessage(context.Background(), broker))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newSSEClient(t, ts.URL+"/sse")
+	defer client.close()
+
+	ev := client.readEvent(t)
+	messageURL := ts.URL + ev.Data
+
+	postRPC(t, messageURL, 1, "tools/list", nil)
+
+	respEv := client.readEvent(t)
+	resp := decodeSSEResponse(t, respEv)
+
+	var result struct {
+		Tools []mcp.Tool `json:"tools"`
+	}
+	decodeResult(t, resp, &result)
+
+	wantNames := []string{"create_agent", "send_message", "report_status", "query_costs"}
+	got := make(map[string]bool)
+	for _, tool := range result.Tools {
+		got[tool.Name] = true
+	}
+	for _, name := range wantNames {
+		if !got[name] {
+			t.Errorf("tools/list missing tool %q", name)
+		}
+	}
+	if len(result.Tools) != len(wantNames) {
+		t.Errorf("got %d tools, want %d", len(result.Tools), len(wantNames))
+	}
+}
+
+func TestSSE_E2E_ToolsCall_QueryCosts(t *testing.T) {
+	srv := newTestServer(t)
+	broker := mcp.NewSSEBroker()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", broker.SSEHandler())
+	mux.HandleFunc("/message", srv.HandleSSEMessage(context.Background(), broker))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newSSEClient(t, ts.URL+"/sse")
+	defer client.close()
+
+	ev := client.readEvent(t)
+	messageURL := ts.URL + ev.Data
+
+	postRPC(t, messageURL, 1, "tools/call", map[string]any{
+		"name":      "query_costs",
+		"arguments": map[string]any{},
+	})
+
+	respEv := client.readEvent(t)
+	resp := decodeSSEResponse(t, respEv)
+
+	var result struct {
+		Content []mcp.ToolContent `json:"content"`
+		IsError bool              `json:"isError"`
+	}
+	decodeResult(t, resp, &result)
+
+	if result.IsError {
+		t.Error("query_costs returned isError=true")
+	}
+	if len(result.Content) == 0 {
+		t.Error("query_costs returned no content")
+	}
+}
+
+func TestSSE_E2E_ErrorHandling(t *testing.T) {
+	srv := newTestServer(t)
+	broker := mcp.NewSSEBroker()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", broker.SSEHandler())
+	mux.HandleFunc("/message", srv.HandleSSEMessage(context.Background(), broker))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newSSEClient(t, ts.URL+"/sse")
+	defer client.close()
+
+	ev := client.readEvent(t)
+	messageURL := ts.URL + ev.Data
+
+	// Send a request with an unknown method.
+	postRPC(t, messageURL, 1, "nonexistent/method", nil)
+
+	respEv := client.readEvent(t)
+	resp := decodeSSEResponse(t, respEv)
+
+	if resp.Error == nil {
+		t.Fatal("expected error response for unknown method")
+	}
+	if resp.Error.Code != mcp.ErrMethodNotFound {
+		t.Errorf("error code = %d, want %d (ErrMethodNotFound)", resp.Error.Code, mcp.ErrMethodNotFound)
+	}
+}
+
+func TestSSE_E2E_MultipleRequests(t *testing.T) {
+	srv := newTestServer(t)
+	broker := mcp.NewSSEBroker()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/sse", broker.SSEHandler())
+	mux.HandleFunc("/message", srv.HandleSSEMessage(context.Background(), broker))
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	client := newSSEClient(t, ts.URL+"/sse")
+	defer client.close()
+
+	ev := client.readEvent(t)
+	messageURL := ts.URL + ev.Data
+
+	// Send multiple requests in sequence and verify each response arrives on the SSE stream.
+	postRPC(t, messageURL, 1, "initialize", map[string]any{
+		"protocolVersion": "2024-11-05",
+		"capabilities":    map[string]any{},
+	})
+	resp1 := decodeSSEResponse(t, client.readEvent(t))
+	if resp1.Error != nil {
+		t.Errorf("initialize: unexpected error: %s", resp1.Error.Message)
+	}
+
+	postRPC(t, messageURL, 2, "tools/list", nil)
+	resp2 := decodeSSEResponse(t, client.readEvent(t))
+	if resp2.Error != nil {
+		t.Errorf("tools/list: unexpected error: %s", resp2.Error.Message)
+	}
+
+	postRPC(t, messageURL, 3, "resources/list", nil)
+	resp3 := decodeSSEResponse(t, client.readEvent(t))
+	if resp3.Error != nil {
+		t.Errorf("resources/list: unexpected error: %s", resp3.Error.Message)
+	}
+}

--- a/server/mcp/sse.go
+++ b/server/mcp/sse.go
@@ -136,6 +136,12 @@ func (b *SSEBroker) send(v any) {
 	}
 }
 
+// SSEHandler returns an http.HandlerFunc for the SSE endpoint.
+// Exported so tests in mcp_test can mount it on their own ServeMux.
+func (b *SSEBroker) SSEHandler() http.HandlerFunc {
+	return b.handleSSE
+}
+
 // handleSSE streams server→client events over SSE.
 func (b *SSEBroker) handleSSE(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)


### PR DESCRIPTION
## Summary
- Add `server/mcp/e2e_sse_test.go` with 7 integration tests exercising the full MCP SSE transport round-trip: connect to SSE stream, read endpoint event, POST JSON-RPC requests, verify responses arrive on the SSE stream
- Export `SSEBroker.SSEHandler()` so external test packages can mount the SSE endpoint on their own `ServeMux`
- Tests cover: initialize handshake, resources/list, resources/read, tools/list, tools/call, error handling, and multiple sequential requests

Closes #2318

## Test plan
- [x] `go test -race -count=1 ./server/mcp/...` passes (all 7 new E2E tests + existing tests)
- [x] `golangci-lint run ./server/mcp/...` clean (no new lint issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)