### PR TITLE
fix(server): add teams and roles API handlers (#2322)

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rpuneet/bc/pkg/daemon"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/shutdown"
+	"github.com/rpuneet/bc/pkg/team"
 	bcdserver "github.com/rpuneet/bc/server"
 	bcws "github.com/rpuneet/bc/server/ws"
 )
@@ -223,11 +224,14 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 	hub := bcws.NewHub()
 	go hub.Run()
 
+	teamStore := team.NewStore(ws.RootDir)
+
 	cfg := bcdserver.DefaultConfig()
 	svc := bcdserver.Services{
 		Agents:   agentSvc,
 		Channels: channelSvc,
 		Daemons:  daemonMgr,
+		Teams:    teamStore,
 		WS:       ws,
 	}
 	srv := bcdserver.New(cfg, svc, hub, bcdserver.WebDist())

--- a/server/handlers/roles.go
+++ b/server/handlers/roles.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/rpuneet/bc/pkg/workspace"
+)
+
+// RolesHandler handles /api/roles routes.
+type RolesHandler struct {
+	ws *workspace.Workspace
+}
+
+// NewRolesHandler creates a RolesHandler.
+func NewRolesHandler(ws *workspace.Workspace) *RolesHandler {
+	return &RolesHandler{ws: ws}
+}
+
+// Register mounts roles routes on mux.
+func (h *RolesHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/roles", h.list)
+	mux.HandleFunc("/api/roles/", h.byName)
+}
+
+// list handles GET /api/roles — returns all resolved roles.
+func (h *RolesHandler) list(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	roles, err := h.ws.RoleManager.LoadAllRoles()
+	if err != nil {
+		httpError(w, "list roles: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resolved := make(map[string]*workspace.ResolvedRole, len(roles))
+	for name := range roles {
+		if res, resolveErr := h.ws.RoleManager.ResolveRole(name); resolveErr == nil {
+			resolved[name] = res
+		}
+	}
+	writeJSON(w, http.StatusOK, resolved)
+}
+
+// byName handles GET /api/roles/{name} — returns a single resolved role.
+func (h *RolesHandler) byName(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, "/api/roles/")
+	if name == "" {
+		httpError(w, "role name required", http.StatusBadRequest)
+		return
+	}
+
+	resolved, err := h.ws.RoleManager.ResolveRole(name)
+	if err != nil {
+		httpError(w, "role not found: "+err.Error(), http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, resolved)
+}

--- a/server/handlers/teams.go
+++ b/server/handlers/teams.go
@@ -1,0 +1,63 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/rpuneet/bc/pkg/team"
+)
+
+// TeamHandler handles /api/teams routes.
+type TeamHandler struct {
+	store *team.Store
+}
+
+// NewTeamHandler creates a TeamHandler.
+func NewTeamHandler(store *team.Store) *TeamHandler {
+	return &TeamHandler{store: store}
+}
+
+// Register mounts team routes on mux.
+func (h *TeamHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/teams", h.list)
+	mux.HandleFunc("/api/teams/", h.byName)
+}
+
+// list handles GET /api/teams — returns all teams.
+func (h *TeamHandler) list(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	teams, err := h.store.List()
+	if err != nil {
+		httpError(w, "list teams: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if teams == nil {
+		teams = []*team.Team{}
+	}
+	writeJSON(w, http.StatusOK, teams)
+}
+
+// byName handles GET /api/teams/{name} — returns a single team.
+func (h *TeamHandler) byName(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, "/api/teams/")
+	if name == "" {
+		httpError(w, "team name required", http.StatusBadRequest)
+		return
+	}
+
+	t, err := h.store.Get(name)
+	if err != nil {
+		httpError(w, "get team: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if t == nil {
+		httpError(w, "team not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, t)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/mcp"
 	"github.com/rpuneet/bc/pkg/secret"
+	"github.com/rpuneet/bc/pkg/team"
 	"github.com/rpuneet/bc/pkg/tool"
 	"github.com/rpuneet/bc/pkg/workspace"
 	"github.com/rpuneet/bc/server/handlers"
@@ -60,6 +61,7 @@ type Services struct {
 	Cron         *cron.Store
 	Secrets      *secret.Store
 	MCP          *mcp.Store
+	Teams        *team.Store
 	Tools        *tool.Store
 	EventLog     events.EventStore
 	WS           *workspace.Workspace
@@ -196,7 +198,11 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	if svc.EventLog != nil {
 		handlers.NewEventHandler(svc.EventLog).Register(mux)
 	}
+	if svc.Teams != nil {
+		handlers.NewTeamHandler(svc.Teams).Register(mux)
+	}
 	if svc.WS != nil {
+		handlers.NewRolesHandler(svc.WS).Register(mux)
 		handlers.NewWorkspaceHandler(svc.Agents, svc.WS).Register(mux)
 		handlers.NewDoctorHandler(svc.WS).Register(mux)
 	}


### PR DESCRIPTION
Closes #2322

## Summary
- Add `GET /api/roles` and `GET /api/roles/{name}` handlers backed by the existing workspace `RoleManager`, returning resolved roles with BFS inheritance
- Add `GET /api/teams` and `GET /api/teams/{name}` handlers backed by `pkg/team.Store`, returning team data from `.bc/teams/`
- Register both handlers in `server.go` before the SPA fallback catch-all so they return proper JSON instead of HTML
- Wire up `team.Store` in the daemon start command

## Test plan
- [x] `go build ./server/... ./internal/cmd/...` compiles cleanly
- [x] `go test -race ./server/...` passes
- [x] No new lint issues in changed files
- [ ] Manual: `GET /api/teams` returns `[]` (empty JSON array) instead of HTML
- [ ] Manual: `GET /api/roles` returns role map with resolved inheritance

🤖 Generated with [Claude Code](https://claude.com/claude-code)