### PR TITLE
feat: render markdown and clickable links in channel messages

### DIFF
--- a/web/src/components/MessageContent.tsx
+++ b/web/src/components/MessageContent.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Renders message content with basic markdown-like formatting:
+ * - URLs become clickable links
+ * - **bold** text
+ * - `code` backticks
+ * - GitHub issue/PR references (#1234) become links
+ */
+export function MessageContent({ content }: { content: string }) {
+  return <>{parseContent(content)}</>;
+}
+
+const REPO_URL = 'https://github.com/gh-curious-otter/bc';
+
+/** Tokenize and render inline formatting. */
+function parseContent(text: string): ReactNode[] {
+  // Split on patterns we want to handle, preserving delimiters
+  // Order matters: URLs first (greedy), then bold, then code, then issue refs
+  const pattern =
+    /(https?:\/\/[^\s<>)"']+)|(\*\*(?:[^*]|\*(?!\*))+\*\*)|(`[^`]+`)|(\B#\d+\b)/g;
+
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    // Push preceding plain text
+    if (match.index > lastIndex) {
+      nodes.push(text.slice(lastIndex, match.index));
+    }
+
+    const [full] = match;
+    const key = `${match.index}`;
+
+    if (match[1]) {
+      // URL
+      nodes.push(
+        <a
+          key={key}
+          href={full}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-bc-accent underline-offset-2 hover:underline"
+        >
+          {full}
+        </a>,
+      );
+    } else if (match[2]) {
+      // Bold **text**
+      const inner = full.slice(2, -2);
+      nodes.push(<strong key={key}>{inner}</strong>);
+    } else if (match[3]) {
+      // Inline code `text`
+      const inner = full.slice(1, -1);
+      nodes.push(
+        <code
+          key={key}
+          className="rounded bg-bc-surface px-1 py-0.5 font-mono text-[0.85em]"
+        >
+          {inner}
+        </code>,
+      );
+    } else if (match[4]) {
+      // GitHub issue/PR reference #1234
+      const num = full.slice(1);
+      nodes.push(
+        <a
+          key={key}
+          href={`${REPO_URL}/issues/${num}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-bc-accent underline-offset-2 hover:underline"
+        >
+          {full}
+        </a>,
+      );
+    }
+
+    lastIndex = match.index + full.length;
+  }
+
+  // Push trailing plain text
+  if (lastIndex < text.length) {
+    nodes.push(text.slice(lastIndex));
+  }
+
+  return nodes;
+}

--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -6,6 +6,7 @@ import { useWebSocket } from '../hooks/useWebSocket';
 import { AgentPeekPanel } from '../components/AgentPeekPanel';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { EmptyState } from '../components/EmptyState';
+import { MessageContent } from '../components/MessageContent';
 
 export function Channels() {
   const fetcher = useCallback(async () => {
@@ -264,7 +265,7 @@ function ChatRoom({ channelName, onPeekAgent }: { channelName: string; onPeekAge
               </div>
               {group.messages.map((msg) => (
                 <p key={msg.id} className="mt-0.5 pl-0 whitespace-pre-wrap break-words">
-                  {msg.content}
+                  <MessageContent content={msg.content} />
                 </p>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- Add `MessageContent` component that parses channel message text with simple regex and renders inline formatting
- URLs (http/https) become clickable `<a>` tags with `target="_blank"` and `rel="noopener"`
- `**bold**` renders as `<strong>`, backtick `` `code` `` renders as `<code>` with monospace styling
- GitHub issue/PR references like `#1234` become clickable links to the repo
- No external markdown library used — pure regex-based parsing only

## Test plan
- [ ] Verify URLs in channel messages render as clickable links that open in new tabs
- [ ] Verify `**bold**` text renders with bold styling
- [ ] Verify backtick code renders with monospace font and background
- [ ] Verify `#1234` references link to the correct GitHub issues page
- [ ] Verify plain text without formatting renders unchanged
- [ ] Verify web build succeeds (`cd web && bun run build`)

Closes #2329

🤖 Generated with [Claude Code](https://claude.com/claude-code)