### PR TITLE
feat(web): add SSE real-time updates to Dashboard, Agents, and Costs

### DIFF
--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1,10 +1,16 @@
 /** WebSocket event types from bcd */
 export type WSEventType =
+  | 'agent.created'
+  | 'agent.started'
+  | 'agent.stopped'
+  | 'agent.deleted'
   | 'agent.state_changed'
   | 'agent.output'
   | 'channel.message'
   | 'cost.updated'
-  | 'cost.budget_alert';
+  | 'cost.budget_alert'
+  | 'team.updated'
+  | 'connected';
 
 export interface WSEvent {
   type: WSEventType;

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -18,9 +18,15 @@ export function Agents() {
   const { subscribe } = useWebSocket();
   const navigate = useNavigate();
 
-  // Refresh on agent state changes — cleanup prevents listener leak
+  // Refresh on agent lifecycle events via SSE
   useEffect(() => {
-    return subscribe('agent.state_changed', () => void refresh());
+    const unsubs = [
+      subscribe('agent.state_changed', () => void refresh()),
+      subscribe('agent.created', () => void refresh()),
+      subscribe('agent.stopped', () => void refresh()),
+      subscribe('agent.deleted', () => void refresh()),
+    ];
+    return () => unsubs.forEach((fn) => fn());
   }, [subscribe, refresh]);
 
   const columns = [

--- a/web/src/views/Costs.tsx
+++ b/web/src/views/Costs.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { api } from '../api/client';
 import type { CostSummary, AgentCostSummary, ModelCostSummary, DailyCost } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
+import { useWebSocket } from '../hooks/useWebSocket';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { EmptyState } from '../components/EmptyState';
 
@@ -178,6 +179,12 @@ export function Costs() {
   }, []);
 
   const { data, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
+  const { subscribe } = useWebSocket();
+
+  // Refresh cost data in real-time via SSE
+  useEffect(() => {
+    return subscribe('cost.updated', () => void refresh());
+  }, [subscribe, refresh]);
 
   if (loading && !data) {
     return (

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -1,8 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../api/client';
 import type { Agent, CostSummary, Channel } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
+import { useWebSocket } from '../hooks/useWebSocket';
 import { StatusBadge } from '../components/StatusBadge';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { EmptyState } from '../components/EmptyState';
@@ -34,6 +35,19 @@ export function Dashboard() {
   }, []);
 
   const { data, loading, error, refresh, timedOut } = usePolling(fetcher, 5000);
+  const { subscribe } = useWebSocket();
+
+  // Refresh dashboard on agent or cost changes via SSE
+  useEffect(() => {
+    const unsubs = [
+      subscribe('agent.state_changed', () => void refresh()),
+      subscribe('agent.created', () => void refresh()),
+      subscribe('agent.stopped', () => void refresh()),
+      subscribe('agent.deleted', () => void refresh()),
+      subscribe('cost.updated', () => void refresh()),
+    ];
+    return () => unsubs.forEach((fn) => fn());
+  }, [subscribe, refresh]);
 
   if (loading && !data) {
     return (


### PR DESCRIPTION
## Summary
- Wires SSE events to Dashboard, Agents, and Costs views for real-time updates
- Agent state changes, cost updates reflected immediately without polling delay
- Polling preserved as fallback for initial data load

Rebased on latest main (resolved Costs.tsx conflict from #2335).

Closes #2330

## Test plan
- [x] Web build succeeds
- [x] SSE subscriptions with proper cleanup
- [x] Polling still works as fallback

Generated with [Claude Code](https://claude.com/claude-code)