### PR TITLE
fix(bcd): wire teams store in standalone daemon binary (#2322)

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -32,6 +32,7 @@ import (
 	bcmcp "github.com/rpuneet/bc/pkg/mcp"
 	"github.com/rpuneet/bc/pkg/provider"
 	bcsecret "github.com/rpuneet/bc/pkg/secret"
+	bcteam "github.com/rpuneet/bc/pkg/team"
 	bctool "github.com/rpuneet/bc/pkg/tool"
 	bcworkspace "github.com/rpuneet/bc/pkg/workspace"
 	"github.com/rpuneet/bc/server"
@@ -186,6 +187,8 @@ func run(addr, wsRoot, corsOrigin string) error {
 		defer el.Close() //nolint:errcheck // best-effort
 	}
 
+	teamStore := bcteam.NewStore(ws.RootDir)
+
 	svc := server.Services{
 		Agents:       agentSvc,
 		Channels:     channelSvc,
@@ -197,6 +200,7 @@ func run(addr, wsRoot, corsOrigin string) error {
 		MCP:          mcpStore,
 		Tools:        toolStore,
 		EventLog:     eventLog,
+		Teams:        teamStore,
 		WS:           ws,
 	}
 


### PR DESCRIPTION
## Summary
- Follow-up to #2326 — the teams handler was only wired in `internal/cmd/daemon.go` but not in `cmd/bcd/main.go`. This caused `/api/teams` to return HTML on `bcd` deployments.
- Added `bcteam` import, created `teamStore`, and added `Teams: teamStore` to the `server.Services` struct in `cmd/bcd/main.go`.

## Test plan
- [x] `go build ./cmd/bcd/` compiles successfully
- [x] Server and handler tests pass
- [ ] Verify `/api/teams` returns JSON on `bcd` deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)