### PR TITLE
fix(tui): wrap test renders with ThemeProvider after color migration

### DIFF
--- a/tui/src/__tests__/80x24-terminal.test.tsx
+++ b/tui/src/__tests__/80x24-terminal.test.tsx
@@ -16,6 +16,7 @@
 import { describe, it, expect } from 'bun:test';
 import { render } from 'ink-testing-library';
 import React from 'react';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { TabBar } from '../navigation/TabBar';
 import { NavigationProvider } from '../navigation/NavigationContext';
 /** Layout mode type (previously from useResponsiveLayout) */
@@ -74,9 +75,11 @@ describe('80x24 Terminal - Breakpoints', () => {
 describe('80x24 Terminal - TabBar', () => {
   function renderTabBar(terminalWidth: number) {
     return render(
-      <NavigationProvider>
-        <TabBar terminalWidth={terminalWidth} />
-      </NavigationProvider>
+      <ThemeProvider>
+        <NavigationProvider>
+          <TabBar terminalWidth={terminalWidth} />
+        </NavigationProvider>
+      </ThemeProvider>
     );
   }
 

--- a/tui/src/__tests__/AgentsView.test.tsx
+++ b/tui/src/__tests__/AgentsView.test.tsx
@@ -3,8 +3,11 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'bun:test';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { StatusBadge } from '../components/StatusBadge';
 import { Table } from '../components/Table';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 // Test StatusBadge component (no useInput dependency)
 describe('StatusBadge', () => {
@@ -47,7 +50,7 @@ describe('Table', () => {
   ];
 
   it('renders column headers', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <Table data={mockData} columns={columns} />
     );
     expect(lastFrame()).toContain('Name');
@@ -56,7 +59,7 @@ describe('Table', () => {
   });
 
   it('renders data rows', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <Table data={mockData} columns={columns} />
     );
     expect(lastFrame()).toContain('eng-01');
@@ -65,7 +68,7 @@ describe('Table', () => {
   });
 
   it('renders empty state when no data', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <Table data={[]} columns={columns} />
     );
     expect(lastFrame()).toContain('No data');

--- a/tui/src/__tests__/ChatMessage.test.tsx
+++ b/tui/src/__tests__/ChatMessage.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'bun:test';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { ChatMessage } from '../components/ChatMessage';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 describe('ChatMessage', () => {
   const baseProps = {
@@ -12,17 +15,17 @@ describe('ChatMessage', () => {
 
   describe('basic rendering', () => {
     it('renders sender name', () => {
-      const { lastFrame } = render(<ChatMessage {...baseProps} />);
+      const { lastFrame } = renderWithTheme(<ChatMessage {...baseProps} />);
       expect(lastFrame()).toContain('eng-01');
     });
 
     it('renders message text', () => {
-      const { lastFrame } = render(<ChatMessage {...baseProps} />);
+      const { lastFrame } = renderWithTheme(<ChatMessage {...baseProps} />);
       expect(lastFrame()).toContain('Hello world');
     });
 
     it('renders timestamp in relative format', () => {
-      const { lastFrame } = render(<ChatMessage {...baseProps} />);
+      const { lastFrame } = renderWithTheme(<ChatMessage {...baseProps} />);
       const frame = lastFrame();
       // Should contain time indicator like "now", "1m ago", etc or gray colored text
       expect(frame).toContain('now');
@@ -31,21 +34,21 @@ describe('ChatMessage', () => {
 
   describe('role-based colors', () => {
     it('renders root sender with special color', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="root" />
       );
       expect(lastFrame()).toContain('root');
     });
 
     it('renders tech-lead sender', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="tech-lead-01" />
       );
       expect(lastFrame()).toContain('tech-lead-01');
     });
 
     it('renders engineer sender', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="eng-02" />
       );
       expect(lastFrame()).toContain('eng-02');
@@ -54,7 +57,7 @@ describe('ChatMessage', () => {
 
   describe('read status', () => {
     it('does not show read indicator when isRead is true', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} isRead={true} />
       );
       // Should not have unread indicator
@@ -62,7 +65,7 @@ describe('ChatMessage', () => {
     });
 
     it('shows read indicator when isRead is false', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} isRead={false} />
       );
       expect(lastFrame()).toContain('●');
@@ -71,7 +74,7 @@ describe('ChatMessage', () => {
 
   describe('selection state', () => {
     it('renders without border when not selected', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} isSelected={false} />
       );
       const frame = lastFrame();
@@ -80,7 +83,7 @@ describe('ChatMessage', () => {
     });
 
     it('renders with border when selected', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} isSelected={true} />
       );
       const frame = lastFrame();
@@ -90,7 +93,7 @@ describe('ChatMessage', () => {
 
   describe('reactions', () => {
     it('does not render reaction bar when no reactions', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} reactions={[]} />
       );
       // Should only have message content, no reaction area
@@ -101,7 +104,7 @@ describe('ChatMessage', () => {
       const reactions = [
         { type: 'thumbsup' as const, count: 2, isOwn: false },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} reactions={reactions} />
       );
       const frame = lastFrame();
@@ -114,7 +117,7 @@ describe('ChatMessage', () => {
         { type: 'thumbsup' as const, count: 2 },
         { type: 'heart' as const, count: 1 },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} reactions={reactions} />
       );
       expect(lastFrame()).toContain('Hello world');
@@ -124,7 +127,7 @@ describe('ChatMessage', () => {
   describe('timestamp formatting', () => {
     it('shows "now" for very recent messages', () => {
       const recent = new Date().toISOString();
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} timestamp={recent} />
       );
       expect(lastFrame()).toContain('now');
@@ -132,14 +135,14 @@ describe('ChatMessage', () => {
 
     it('handles old timestamps gracefully', () => {
       const oldDate = new Date('2025-01-01').toISOString();
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} timestamp={oldDate} />
       );
       expect(lastFrame()).toContain('Jan');
     });
 
     it('handles invalid timestamp gracefully', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} timestamp="invalid" />
       );
       // When given an invalid timestamp, component catches error and displays fallback
@@ -151,21 +154,21 @@ describe('ChatMessage', () => {
 
   describe('special characters', () => {
     it('renders messages with @mentions', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} message="@eng-02 please review this" />
       );
       expect(lastFrame()).toContain('eng-02');
     });
 
     it('renders messages with special characters', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} message="Message with !@#$% chars" />
       );
       expect(lastFrame()).toContain('!@#$%');
     });
 
     it('renders multiline messages', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} message="Line 1\nLine 2\nLine 3" />
       );
       expect(lastFrame()).toContain('Line 1');
@@ -174,28 +177,28 @@ describe('ChatMessage', () => {
 
   describe('bubble styling and alignment', () => {
     it('shows "(you)" indicator for own messages', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="eng-01" currentUser="eng-01" />
       );
       expect(lastFrame()).toContain('(you)');
     });
 
     it('does not show "(you)" for other users messages', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="eng-02" currentUser="eng-01" />
       );
       expect(lastFrame()).not.toContain('(you)');
     });
 
     it('renders message without "(you)" when no currentUser provided', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="eng-01" />
       );
       expect(lastFrame()).not.toContain('(you)');
     });
 
     it('renders own message with bubble border', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="eng-01" currentUser="eng-01" />
       );
       // Should render with round border (indicated by border characters)
@@ -204,7 +207,7 @@ describe('ChatMessage', () => {
     });
 
     it('renders other user message with bubble border', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="eng-02" currentUser="eng-01" />
       );
       // Should render with round border (gray for others)
@@ -213,7 +216,7 @@ describe('ChatMessage', () => {
     });
 
     it('applies custom maxBubbleWidth', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} maxBubbleWidth={40} />
       );
       // Should render without errors with custom width
@@ -223,28 +226,28 @@ describe('ChatMessage', () => {
 
   describe('role colors for additional roles', () => {
     it('renders tl- prefix sender (tech lead)', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="tl-01" />
       );
       expect(lastFrame()).toContain('tl-01');
     });
 
     it('renders mgr- prefix sender (manager)', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="mgr-01" />
       );
       expect(lastFrame()).toContain('mgr-01');
     });
 
     it('renders pm- prefix sender (product manager)', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="pm-01" />
       );
       expect(lastFrame()).toContain('pm-01');
     });
 
     it('renders ux- prefix sender', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ChatMessage {...baseProps} sender="ux-01" />
       );
       expect(lastFrame()).toContain('ux-01');

--- a/tui/src/__tests__/ErrorDisplay.test.tsx
+++ b/tui/src/__tests__/ErrorDisplay.test.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'bun:test';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { ErrorDisplay } from '../components/ErrorDisplay';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 describe('ErrorDisplay', () => {
   describe('error message rendering', () => {
     it('renders string error message', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ErrorDisplay error="Something went wrong" />
       );
       expect(lastFrame()).toContain('Error');
@@ -15,13 +18,13 @@ describe('ErrorDisplay', () => {
 
     it('renders Error object message', () => {
       const error = new Error('Failed to load data');
-      const { lastFrame } = render(<ErrorDisplay error={error} />);
+      const { lastFrame } = renderWithTheme(<ErrorDisplay error={error} />);
       expect(lastFrame()).toContain('Error');
       expect(lastFrame()).toContain('Failed to load data');
     });
 
     it('renders error with special characters', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ErrorDisplay error="Error: Failed @ operation #123 with status 500" />
       );
       expect(lastFrame()).toContain('Error');
@@ -31,7 +34,7 @@ describe('ErrorDisplay', () => {
 
   describe('retry option', () => {
     it('does not show retry message when onRetry is not provided', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ErrorDisplay error="Network error" />
       );
       const frame = lastFrame();
@@ -40,7 +43,7 @@ describe('ErrorDisplay', () => {
     });
 
     it('shows retry message when onRetry is provided', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ErrorDisplay error="Network error" onRetry={() => {}} />
       );
       expect(lastFrame()).toContain('retry');
@@ -49,7 +52,7 @@ describe('ErrorDisplay', () => {
 
   describe('edge cases', () => {
     it('handles empty error message', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ErrorDisplay error="" />
       );
       expect(lastFrame()).toContain('Error');
@@ -57,14 +60,14 @@ describe('ErrorDisplay', () => {
 
     it('handles long error messages', () => {
       const longError = 'A'.repeat(200);
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ErrorDisplay error={longError} />
       );
       expect(lastFrame()).toContain('A');
     });
 
     it('handles multiline error messages', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ErrorDisplay error="Line 1\nLine 2\nLine 3" />
       );
       const frame = lastFrame();
@@ -74,7 +77,7 @@ describe('ErrorDisplay', () => {
     it('handles errors with custom properties', () => {
       const error = new Error('Custom error');
       (error as any).code = 'ERR_CUSTOM';
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <ErrorDisplay error={error} />
       );
       expect(lastFrame()).toContain('Custom error');

--- a/tui/src/__tests__/Footer.test.tsx
+++ b/tui/src/__tests__/Footer.test.tsx
@@ -1,11 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 import { render } from 'ink-testing-library';
 import React from 'react';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { Footer, KeyHint } from '../components/Footer';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 describe('KeyHint', () => {
   test('renders key and label', () => {
-    const { lastFrame } = render(<KeyHint keyChar="q" label="quit" />);
+    const { lastFrame } = renderWithTheme(<KeyHint keyChar="q" label="quit" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('[');
     expect(output).toContain('q');
@@ -14,7 +17,7 @@ describe('KeyHint', () => {
   });
 
   test('renders with special keys', () => {
-    const { lastFrame } = render(<KeyHint keyChar="?" label="help" />);
+    const { lastFrame } = renderWithTheme(<KeyHint keyChar="?" label="help" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('?');
     expect(output).toContain('help');
@@ -28,7 +31,7 @@ describe('Footer', () => {
       { key: 'k', label: 'up' },
       { key: 'q', label: 'quit' },
     ];
-    const { lastFrame } = render(<Footer hints={hints} />);
+    const { lastFrame } = renderWithTheme(<Footer hints={hints} />);
     const output = lastFrame() ?? '';
     expect(output).toContain('j');
     expect(output).toContain('down');
@@ -39,13 +42,13 @@ describe('Footer', () => {
   });
 
   test('renders empty hints array', () => {
-    const { lastFrame } = render(<Footer hints={[]} />);
+    const { lastFrame } = renderWithTheme(<Footer hints={[]} />);
     expect(lastFrame()).toBeDefined();
   });
 
   test('renders single hint', () => {
     const hints = [{ key: 'r', label: 'refresh' }];
-    const { lastFrame } = render(<Footer hints={hints} />);
+    const { lastFrame } = renderWithTheme(<Footer hints={hints} />);
     const output = lastFrame() ?? '';
     expect(output).toContain('r');
     expect(output).toContain('refresh');

--- a/tui/src/__tests__/MentionAutocomplete.test.tsx
+++ b/tui/src/__tests__/MentionAutocomplete.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'bun:test';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { MentionAutocomplete, type MentionSuggestion } from '../components/MentionAutocomplete';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 describe('MentionAutocomplete', () => {
   const baseSuggestions: MentionSuggestion[] = [
@@ -12,7 +15,7 @@ describe('MentionAutocomplete', () => {
 
   describe('visibility', () => {
     it('does not render when not visible', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={0}
@@ -25,7 +28,7 @@ describe('MentionAutocomplete', () => {
     });
 
     it('renders when visible', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={0}
@@ -42,7 +45,7 @@ describe('MentionAutocomplete', () => {
       const suggestions: MentionSuggestion[] = [
         { name: 'eng-01', state: 'working' },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={suggestions}
           selectedIndex={0}
@@ -53,7 +56,7 @@ describe('MentionAutocomplete', () => {
     });
 
     it('renders multiple suggestions', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={0}
@@ -67,7 +70,7 @@ describe('MentionAutocomplete', () => {
     });
 
     it('renders no suggestions', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={[]}
           selectedIndex={-1}
@@ -80,7 +83,7 @@ describe('MentionAutocomplete', () => {
 
   describe('selection state', () => {
     it('highlights first suggestion when selectedIndex is 0', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={0}
@@ -91,7 +94,7 @@ describe('MentionAutocomplete', () => {
     });
 
     it('handles middle selection', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={1}
@@ -102,7 +105,7 @@ describe('MentionAutocomplete', () => {
     });
 
     it('handles last selection', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={2}
@@ -113,7 +116,7 @@ describe('MentionAutocomplete', () => {
     });
 
     it('handles invalid selection index', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={-1}
@@ -129,7 +132,7 @@ describe('MentionAutocomplete', () => {
       const suggestions: MentionSuggestion[] = [
         { name: 'eng-01', state: 'working' },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={suggestions}
           selectedIndex={0}
@@ -143,7 +146,7 @@ describe('MentionAutocomplete', () => {
       const suggestions: MentionSuggestion[] = [
         { name: 'eng-02', state: 'idle' },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={suggestions}
           selectedIndex={0}
@@ -157,7 +160,7 @@ describe('MentionAutocomplete', () => {
       const suggestions: MentionSuggestion[] = [
         { name: 'eng-03', state: 'stuck' },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={suggestions}
           selectedIndex={0}
@@ -173,7 +176,7 @@ describe('MentionAutocomplete', () => {
         { name: 'eng-02', state: 'idle' },
         { name: 'eng-03', state: 'stuck' },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={suggestions}
           selectedIndex={0}
@@ -189,7 +192,7 @@ describe('MentionAutocomplete', () => {
 
   describe('query highlighting', () => {
     it('renders with query parameter', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={0}
@@ -201,7 +204,7 @@ describe('MentionAutocomplete', () => {
     });
 
     it('renders with partial match query', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={baseSuggestions}
           selectedIndex={0}
@@ -219,7 +222,7 @@ describe('MentionAutocomplete', () => {
       const suggestions: MentionSuggestion[] = [
         { name: longName, state: 'working' },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={suggestions}
           selectedIndex={0}
@@ -233,7 +236,7 @@ describe('MentionAutocomplete', () => {
       const suggestions: MentionSuggestion[] = [
         { name: 'eng_01-special', state: 'working' },
       ];
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={suggestions}
           selectedIndex={0}
@@ -251,7 +254,7 @@ describe('MentionAutocomplete', () => {
           state: i % 2 === 0 ? 'working' : 'idle',
         })
       );
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionAutocomplete
           suggestions={suggestions}
           selectedIndex={50}

--- a/tui/src/__tests__/MentionText.test.tsx
+++ b/tui/src/__tests__/MentionText.test.tsx
@@ -1,23 +1,27 @@
 import { describe, expect, test } from 'bun:test';
 import { render } from 'ink-testing-library';
 import React from 'react';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { MentionText } from '../components/MentionText';
+
+// Wrap render with ThemeProvider for color system
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 describe('MentionText', () => {
   test('renders plain text without mentions', () => {
-    const { lastFrame } = render(<MentionText text="Hello world" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="Hello world" />);
     expect(lastFrame()).toContain('Hello world');
   });
 
   test('highlights @mentions', () => {
-    const { lastFrame } = render(<MentionText text="Hello @eng-01" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="Hello @eng-01" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('Hello');
     expect(output).toContain('@eng-01');
   });
 
   test('highlights multiple mentions', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <MentionText text="@eng-01 and @eng-02 are working" />
     );
     const output = lastFrame() ?? '';
@@ -27,7 +31,7 @@ describe('MentionText', () => {
   });
 
   test('highlights self-mentions differently', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <MentionText text="Hello @eng-04" currentUser="eng-04" />
     );
     const output = lastFrame() ?? '';
@@ -35,54 +39,54 @@ describe('MentionText', () => {
   });
 
   test('highlights broadcast mentions (@all)', () => {
-    const { lastFrame } = render(<MentionText text="@all please review" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="@all please review" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('@all');
     expect(output).toContain('please review');
   });
 
   test('highlights broadcast mentions (@everyone)', () => {
-    const { lastFrame } = render(<MentionText text="@everyone meeting now" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="@everyone meeting now" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('@everyone');
   });
 
   test('handles text with no mentions', () => {
-    const { lastFrame } = render(<MentionText text="No mentions here" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="No mentions here" />);
     expect(lastFrame()).toContain('No mentions here');
   });
 
   test('handles empty text with placeholder', () => {
-    const { lastFrame } = render(<MentionText text="" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="" />);
     expect(lastFrame()).toContain('(empty)');
   });
 
   test('handles whitespace-only text with placeholder', () => {
-    const { lastFrame } = render(<MentionText text="   " />);
+    const { lastFrame } = renderWithTheme(<MentionText text="   " />);
     expect(lastFrame()).toContain('(empty)');
   });
 
   test('handles newline-only text with placeholder', () => {
     const newlineText = "\n\n";
-    const { lastFrame } = render(<MentionText text={newlineText} />);
+    const { lastFrame } = renderWithTheme(<MentionText text={newlineText} />);
     expect(lastFrame()).toContain('(empty)');
   });
 
   test('handles tab-only text with placeholder', () => {
     const tabText = "\t\t";
-    const { lastFrame } = render(<MentionText text={tabText} />);
+    const { lastFrame } = renderWithTheme(<MentionText text={tabText} />);
     expect(lastFrame()).toContain('(empty)');
   });
 
   test('handles mention at start of text', () => {
-    const { lastFrame } = render(<MentionText text="@wise-owl says hello" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="@wise-owl says hello" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('@wise-owl');
     expect(output).toContain('says hello');
   });
 
   test('handles mention at end of text', () => {
-    const { lastFrame } = render(<MentionText text="Message for @clever-fox" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="Message for @clever-fox" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('Message for');
     expect(output).toContain('@clever-fox');
@@ -91,46 +95,46 @@ describe('MentionText', () => {
   // Edge cases for #915 - ensure all empty/invalid cases show placeholder
   test('handles undefined text gracefully', () => {
     // TypeScript wouldn't allow this, but runtime JSON parsing might produce it
-    const { lastFrame } = render(<MentionText text={undefined as unknown as string} />);
+    const { lastFrame } = renderWithTheme(<MentionText text={undefined as unknown as string} />);
     expect(lastFrame()).toContain('(empty)');
   });
 
   test('handles null text gracefully', () => {
     // TypeScript wouldn't allow this, but runtime JSON parsing might produce it
-    const { lastFrame } = render(<MentionText text={null as unknown as string} />);
+    const { lastFrame } = renderWithTheme(<MentionText text={null as unknown as string} />);
     expect(lastFrame()).toContain('(empty)');
   });
 
   test('handles mixed whitespace text with placeholder', () => {
     const mixedWhitespace = "  \n\t  \n  ";
-    const { lastFrame } = render(<MentionText text={mixedWhitespace} />);
+    const { lastFrame } = renderWithTheme(<MentionText text={mixedWhitespace} />);
     expect(lastFrame()).toContain('(empty)');
   });
 
   test('handles very long text without truncation', () => {
     const longText = 'A'.repeat(500);
-    const { lastFrame } = render(<MentionText text={longText} />);
+    const { lastFrame } = renderWithTheme(<MentionText text={longText} />);
     // Should not show (empty), should render the text
     expect(lastFrame()).not.toContain('(empty)');
     expect(lastFrame()).toContain('AAA');
   });
 
   test('handles text with special characters', () => {
-    const { lastFrame } = render(<MentionText text="Hello <script>alert('xss')</script> world" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="Hello <script>alert('xss')</script> world" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('Hello');
     expect(output).toContain('world');
   });
 
   test('handles text with unicode/emoji', () => {
-    const { lastFrame } = render(<MentionText text="Hello 👋 world 🌍" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="Hello 👋 world 🌍" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('Hello');
     expect(output).toContain('world');
   });
 
   test('handles multiline text', () => {
-    const { lastFrame } = render(<MentionText text="Line 1\nLine 2\nLine 3" />);
+    const { lastFrame } = renderWithTheme(<MentionText text="Line 1\nLine 2\nLine 3" />);
     const output = lastFrame() ?? '';
     expect(output).toContain('Line 1');
     expect(output).toContain('Line 2');
@@ -139,7 +143,7 @@ describe('MentionText', () => {
   // #972: Markdown rendering tests
   describe('markdown rendering', () => {
     test('renders **bold** text', () => {
-      const { lastFrame } = render(<MentionText text="This is **bold** text" />);
+      const { lastFrame } = renderWithTheme(<MentionText text="This is **bold** text" />);
       const output = lastFrame() ?? '';
       expect(output).toContain('This is');
       expect(output).toContain('bold');
@@ -149,14 +153,14 @@ describe('MentionText', () => {
     });
 
     test('renders __bold__ text (underscore style)', () => {
-      const { lastFrame } = render(<MentionText text="This is __bold__ text" />);
+      const { lastFrame } = renderWithTheme(<MentionText text="This is __bold__ text" />);
       const output = lastFrame() ?? '';
       expect(output).toContain('bold');
       expect(output).not.toContain('__');
     });
 
     test('renders *italic* text', () => {
-      const { lastFrame } = render(<MentionText text="This is *italic* text" />);
+      const { lastFrame } = renderWithTheme(<MentionText text="This is *italic* text" />);
       const output = lastFrame() ?? '';
       expect(output).toContain('italic');
       // Single asterisks should be removed
@@ -164,21 +168,21 @@ describe('MentionText', () => {
     });
 
     test('renders _italic_ text (underscore style)', () => {
-      const { lastFrame } = render(<MentionText text="This is _italic_ text" />);
+      const { lastFrame } = renderWithTheme(<MentionText text="This is _italic_ text" />);
       const output = lastFrame() ?? '';
       expect(output).toContain('italic');
       expect(output).not.toContain('_italic_');
     });
 
     test('renders `code` text', () => {
-      const { lastFrame } = render(<MentionText text="Run `npm install` first" />);
+      const { lastFrame } = renderWithTheme(<MentionText text="Run `npm install` first" />);
       const output = lastFrame() ?? '';
       expect(output).toContain('npm install');
       expect(output).not.toContain('`');
     });
 
     test('renders mixed markdown and mentions', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionText text="@eng-01 please **review** the `code`" />
       );
       const output = lastFrame() ?? '';
@@ -190,7 +194,7 @@ describe('MentionText', () => {
     });
 
     test('renders multiple markdown elements', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionText text="**Bold** and *italic* and `code`" />
       );
       const output = lastFrame() ?? '';
@@ -200,7 +204,7 @@ describe('MentionText', () => {
     });
 
     test('handles markdown with self-mention', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MentionText text="**Important:** @eng-03 needs to fix this" currentUser="eng-03" />
       );
       const output = lastFrame() ?? '';
@@ -210,7 +214,7 @@ describe('MentionText', () => {
 
     test('handles unmatched markdown gracefully', () => {
       // Single asterisk without closing should be treated as plain text
-      const { lastFrame } = render(<MentionText text="5 * 3 = 15" />);
+      const { lastFrame } = renderWithTheme(<MentionText text="5 * 3 = 15" />);
       const output = lastFrame() ?? '';
       expect(output).toContain('5');
       expect(output).toContain('15');

--- a/tui/src/__tests__/Panel.test.tsx
+++ b/tui/src/__tests__/Panel.test.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'bun:test';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { Panel } from '../components/Panel';
 import { Text } from 'ink';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 describe('Panel', () => {
   describe('basic rendering', () => {
     it('renders children content', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel>
           <Text>Panel content</Text>
         </Panel>
@@ -16,7 +19,7 @@ describe('Panel', () => {
     });
 
     it('renders title when provided', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="My Panel">
           <Text>Content</Text>
         </Panel>
@@ -27,7 +30,7 @@ describe('Panel', () => {
     });
 
     it('renders without title when not provided', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel>
           <Text>Content</Text>
         </Panel>
@@ -38,7 +41,7 @@ describe('Panel', () => {
 
   describe('focus state', () => {
     it('renders with default border color when not focused', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel>
           <Text>Content</Text>
         </Panel>
@@ -47,7 +50,7 @@ describe('Panel', () => {
     });
 
     it('renders with focused styling', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel focused={true}>
           <Text>Content</Text>
         </Panel>
@@ -56,7 +59,7 @@ describe('Panel', () => {
     });
 
     it('renders with custom border color', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel borderColor="red">
           <Text>Content</Text>
         </Panel>
@@ -67,7 +70,7 @@ describe('Panel', () => {
 
   describe('dimensions', () => {
     it('renders with width constraint', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel width={40}>
           <Text>Content</Text>
         </Panel>
@@ -76,7 +79,7 @@ describe('Panel', () => {
     });
 
     it('renders with height constraint', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel height={10}>
           <Text>Content</Text>
         </Panel>
@@ -85,7 +88,7 @@ describe('Panel', () => {
     });
 
     it('renders with both width and height', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel width={50} height={15}>
           <Text>Content</Text>
         </Panel>
@@ -96,7 +99,7 @@ describe('Panel', () => {
 
   describe('title styling', () => {
     it('renders title in bold', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Bold Title">
           <Text>Content</Text>
         </Panel>
@@ -106,7 +109,7 @@ describe('Panel', () => {
 
     it('renders title with long text', () => {
       const longTitle = 'A'.repeat(50);
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title={longTitle}>
           <Text>Content</Text>
         </Panel>
@@ -115,7 +118,7 @@ describe('Panel', () => {
     });
 
     it('renders title with special characters', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Title [#123] - Status">
           <Text>Content</Text>
         </Panel>
@@ -126,7 +129,7 @@ describe('Panel', () => {
 
   describe('multiple children', () => {
     it('renders multiple child components', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel>
           <Text>Child 1</Text>
           <Text>Child 2</Text>
@@ -140,7 +143,7 @@ describe('Panel', () => {
     });
 
     it('renders empty panel when no children', () => {
-      const { lastFrame } = render(<Panel></Panel>);
+      const { lastFrame } = renderWithTheme(<Panel></Panel>);
       // Should still render the border
       expect(lastFrame()).toBeDefined();
     });

--- a/tui/src/__tests__/TabBar.test.tsx
+++ b/tui/src/__tests__/TabBar.test.tsx
@@ -12,6 +12,7 @@
 import { describe, expect, test } from 'bun:test';
 import { render } from 'ink-testing-library';
 import React from 'react';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { TabBar } from '../navigation/TabBar';
 import { NavigationProvider } from '../navigation/NavigationContext';
 
@@ -21,9 +22,11 @@ const ALL_TAB_KEYS = ['[dash]', '[ag]', '[ch]', '[co]', '[log]', '[ro]', '[wt]',
 /** Wrapper to provide navigation context */
 function renderTabBar(terminalWidth: number) {
   return render(
-    <NavigationProvider>
-      <TabBar terminalWidth={terminalWidth} />
-    </NavigationProvider>
+    <ThemeProvider>
+      <NavigationProvider>
+        <TabBar terminalWidth={terminalWidth} />
+      </NavigationProvider>
+    </ThemeProvider>
   );
 }
 

--- a/tui/src/__tests__/ViewWrapper.test.tsx
+++ b/tui/src/__tests__/ViewWrapper.test.tsx
@@ -8,8 +8,11 @@ import { describe, expect, test } from 'bun:test';
 import { render } from 'ink-testing-library';
 import React from 'react';
 import { Text, Box } from 'ink';
+import { ThemeProvider } from '../theme/ThemeContext';
 import { ViewWrapper } from '../components/ViewWrapper';
 import { HintsProvider, useHintsContext } from '../hooks/useHintsContext';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 // Helper to render with HintsProvider and display hints
 function HintsDisplay(): React.ReactElement {
@@ -25,7 +28,7 @@ function HintsDisplay(): React.ReactElement {
 
 describe('ViewWrapper', () => {
   test('renders children', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper>
         <Text>Test Content</Text>
       </ViewWrapper>
@@ -34,7 +37,7 @@ describe('ViewWrapper', () => {
   });
 
   test('renders title when provided', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper title="Test Title">
         <Text>Content</Text>
       </ViewWrapper>
@@ -43,7 +46,7 @@ describe('ViewWrapper', () => {
   });
 
   test('shows loading indicator when loading with no children', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper loading loadingMessage="Loading data...">
         {null}
       </ViewWrapper>
@@ -52,7 +55,7 @@ describe('ViewWrapper', () => {
   });
 
   test('shows error display when error is set', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper error="Something went wrong">
         <Text>Content</Text>
       </ViewWrapper>
@@ -62,7 +65,7 @@ describe('ViewWrapper', () => {
 
   test('renders footer with hints', async () => {
     // Issue #1497: Hints now go to global footer via HintsContext
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <HintsProvider>
         <ViewWrapper
           hints={[
@@ -84,7 +87,7 @@ describe('ViewWrapper', () => {
   });
 
   test('hides footer when hideFooter is true', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper
         hideFooter
         hints={[{ key: 'q', label: 'quit' }]}
@@ -96,7 +99,7 @@ describe('ViewWrapper', () => {
   });
 
   test('shows refreshing indicator when loading with content', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper title="Test" loading>
         <Text>Existing Content</Text>
       </ViewWrapper>
@@ -107,7 +110,7 @@ describe('ViewWrapper', () => {
   });
 
   test('error state takes precedence over loading', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper loading error="Error occurred">
         <Text>Content</Text>
       </ViewWrapper>
@@ -118,7 +121,7 @@ describe('ViewWrapper', () => {
   });
 
   test('renders custom footer when provided', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper footer={<Text>Custom Footer</Text>}>
         <Text>Content</Text>
       </ViewWrapper>
@@ -127,7 +130,7 @@ describe('ViewWrapper', () => {
   });
 
   test('renders with renderWithLayout prop', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper
         renderWithLayout={(layout) => (
           <Text>Width: {layout.width}</Text>
@@ -141,7 +144,7 @@ describe('ViewWrapper', () => {
 
 describe('ViewWrapper with Panel', () => {
   test('wraps content in Panel when usePanel is true', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper usePanel title="Panel Title">
         <Text>Panel Content</Text>
       </ViewWrapper>
@@ -155,7 +158,7 @@ describe('ViewWrapper with Panel', () => {
   });
 
   test('Panel respects borderColor prop', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <ViewWrapper usePanel borderColor="cyan" title="Colored">
         <Text>Content</Text>
       </ViewWrapper>

--- a/tui/src/__tests__/components/ActivityFeed.test.tsx
+++ b/tui/src/__tests__/components/ActivityFeed.test.tsx
@@ -6,7 +6,10 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect, vi, beforeEach } from 'bun:test';
+import { ThemeProvider } from '../../theme/ThemeContext';
 import { ActivityFeed } from '../../components/ActivityFeed';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 // Mock useLogs hook with correct getSeverityColor implementation
 // IMPORTANT: Must match the real implementation's case-insensitivity
@@ -53,7 +56,7 @@ describe('ActivityFeed', () => {
   });
 
   it('renders activity entries', () => {
-    const { lastFrame } = render(<ActivityFeed />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed />);
     const output = lastFrame();
 
     expect(output).toContain('Activity');
@@ -62,7 +65,7 @@ describe('ActivityFeed', () => {
   });
 
   it('renders in compact mode without timestamps', () => {
-    const { lastFrame } = render(<ActivityFeed compact />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed compact />);
     const output = lastFrame();
 
     expect(output).toContain('eng-01');
@@ -70,7 +73,7 @@ describe('ActivityFeed', () => {
   });
 
   it('shows error entries with error styling', () => {
-    const { lastFrame } = render(<ActivityFeed />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed />);
     const output = lastFrame();
 
     expect(output).toContain('eng-02');
@@ -78,7 +81,7 @@ describe('ActivityFeed', () => {
   });
 
   it('shows warning entries', () => {
-    const { lastFrame } = render(<ActivityFeed />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed />);
     const output = lastFrame();
 
     expect(output).toContain('eng-03');
@@ -86,7 +89,7 @@ describe('ActivityFeed', () => {
   });
 
   it('respects maxEntries limit', () => {
-    const { lastFrame } = render(<ActivityFeed maxEntries={2} />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed maxEntries={2} />);
     const output = lastFrame();
 
     // Should show limited entries
@@ -94,14 +97,14 @@ describe('ActivityFeed', () => {
   });
 
   it('hides filter hints when showFilterHints is false', () => {
-    const { lastFrame } = render(<ActivityFeed showFilterHints={false} />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed showFilterHints={false} />);
     const output = lastFrame();
 
     expect(output).not.toContain('(i/w/e/*)');
   });
 
   it('shows filter hints by default', () => {
-    const { lastFrame } = render(<ActivityFeed showFilterHints />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed showFilterHints />);
     const output = lastFrame();
 
     expect(output).toContain('(i/w/e/*)');
@@ -125,7 +128,7 @@ describe('ActivityFeed', () => {
       refresh: vi.fn(),
     });
 
-    const { lastFrame } = render(<ActivityFeed />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed />);
     const output = lastFrame();
 
     expect(output).toContain('eng-04');
@@ -149,7 +152,7 @@ describe('ActivityFeed', () => {
       refresh: vi.fn(),
     });
 
-    const { lastFrame } = render(<ActivityFeed />);
+    const { lastFrame } = renderWithTheme(<ActivityFeed />);
     const output = lastFrame();
 
     expect(output).toContain('Activity');

--- a/tui/src/__tests__/components/InlineEditor.test.tsx
+++ b/tui/src/__tests__/components/InlineEditor.test.tsx
@@ -6,17 +6,20 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect, vi } from 'bun:test';
+import { ThemeProvider } from '../../theme/ThemeContext';
 import { InlineEditor, EditorModal } from '../../components/InlineEditor';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 describe('InlineEditor', () => {
   describe('basic rendering', () => {
     it('renders without crashing', () => {
-      const { lastFrame } = render(<InlineEditor disableInput />);
+      const { lastFrame } = renderWithTheme(<InlineEditor disableInput />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('renders with initial value', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor initialValue="Hello" disableInput />
       );
       const output = lastFrame();
@@ -24,7 +27,7 @@ describe('InlineEditor', () => {
     });
 
     it('renders placeholder when empty', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor placeholder="Type here" disableInput />
       );
       const output = lastFrame();
@@ -32,7 +35,7 @@ describe('InlineEditor', () => {
     });
 
     it('renders with custom placeholder', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor placeholder="Enter name" disableInput />
       );
       const output = lastFrame();
@@ -40,7 +43,7 @@ describe('InlineEditor', () => {
     });
 
     it('renders with label', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor label="Name" disableInput />
       );
       const output = lastFrame();
@@ -50,40 +53,40 @@ describe('InlineEditor', () => {
 
   describe('single-line mode', () => {
     it('shows single-line hints', () => {
-      const { lastFrame } = render(<InlineEditor disableInput />);
+      const { lastFrame } = renderWithTheme(<InlineEditor disableInput />);
       const output = lastFrame();
       expect(output).toContain('Enter');
       expect(output).toContain('save');
     });
 
     it('shows cancel hint', () => {
-      const { lastFrame } = render(<InlineEditor disableInput />);
+      const { lastFrame } = renderWithTheme(<InlineEditor disableInput />);
       const output = lastFrame();
       expect(output).toContain('Esc');
       expect(output).toContain('cancel');
     });
 
     it('renders border', () => {
-      const { lastFrame } = render(<InlineEditor disableInput />);
+      const { lastFrame } = renderWithTheme(<InlineEditor disableInput />);
       expect(lastFrame()).toBeDefined();
     });
   });
 
   describe('multi-line mode', () => {
     it('renders in multi-line mode', () => {
-      const { lastFrame } = render(<InlineEditor multiline disableInput />);
+      const { lastFrame } = renderWithTheme(<InlineEditor multiline disableInput />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('shows multi-line hints', () => {
-      const { lastFrame } = render(<InlineEditor multiline disableInput />);
+      const { lastFrame } = renderWithTheme(<InlineEditor multiline disableInput />);
       const output = lastFrame();
       expect(output).toContain('Ctrl+S');
       expect(output).toContain('newline');
     });
 
     it('renders multi-line content', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor
           initialValue={'Line 1\nLine 2\nLine 3'}
           multiline
@@ -97,7 +100,7 @@ describe('InlineEditor', () => {
 
     it('respects maxHeight', () => {
       const longContent = Array(20).fill('Line').join('\n');
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor
           initialValue={longContent}
           multiline
@@ -112,12 +115,12 @@ describe('InlineEditor', () => {
 
   describe('focus state', () => {
     it('renders focused state', () => {
-      const { lastFrame } = render(<InlineEditor focused disableInput />);
+      const { lastFrame } = renderWithTheme(<InlineEditor focused disableInput />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('renders unfocused state', () => {
-      const { lastFrame } = render(<InlineEditor focused={false} disableInput />);
+      const { lastFrame } = renderWithTheme(<InlineEditor focused={false} disableInput />);
       expect(lastFrame()).toBeDefined();
     });
   });
@@ -125,7 +128,7 @@ describe('InlineEditor', () => {
   describe('callbacks', () => {
     it('accepts onChange callback', () => {
       const onChange = vi.fn();
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor onChange={onChange} disableInput />
       );
       expect(lastFrame()).toBeDefined();
@@ -133,7 +136,7 @@ describe('InlineEditor', () => {
 
     it('accepts onSave callback', () => {
       const onSave = vi.fn();
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor onSave={onSave} disableInput />
       );
       expect(lastFrame()).toBeDefined();
@@ -141,7 +144,7 @@ describe('InlineEditor', () => {
 
     it('accepts onCancel callback', () => {
       const onCancel = vi.fn();
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <InlineEditor onCancel={onCancel} disableInput />
       );
       expect(lastFrame()).toBeDefined();
@@ -152,27 +155,27 @@ describe('InlineEditor', () => {
 describe('EditorModal', () => {
   describe('visibility', () => {
     it('renders nothing when not visible', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <EditorModal visible={false} disableInput />
       );
       expect(lastFrame()).toBe('');
     });
 
     it('renders when visible', () => {
-      const { lastFrame } = render(<EditorModal visible disableInput />);
+      const { lastFrame } = renderWithTheme(<EditorModal visible disableInput />);
       expect(lastFrame()).toBeDefined();
     });
   });
 
   describe('title', () => {
     it('renders with default title', () => {
-      const { lastFrame } = render(<EditorModal visible disableInput />);
+      const { lastFrame } = renderWithTheme(<EditorModal visible disableInput />);
       const output = lastFrame();
       expect(output).toContain('Edit');
     });
 
     it('renders with custom title', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <EditorModal visible title="Edit Role" disableInput />
       );
       const output = lastFrame();
@@ -182,7 +185,7 @@ describe('EditorModal', () => {
 
   describe('editor content', () => {
     it('passes initial value to editor', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <EditorModal visible initialValue="Test value" disableInput />
       );
       const output = lastFrame();
@@ -190,7 +193,7 @@ describe('EditorModal', () => {
     });
 
     it('passes label to editor', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <EditorModal visible label="Field" disableInput />
       );
       const output = lastFrame();
@@ -198,7 +201,7 @@ describe('EditorModal', () => {
     });
 
     it('supports multiline in modal', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <EditorModal visible multiline disableInput />
       );
       const output = lastFrame();

--- a/tui/src/__tests__/components/MembersPanel.test.tsx
+++ b/tui/src/__tests__/components/MembersPanel.test.tsx
@@ -6,7 +6,10 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'bun:test';
+import { ThemeProvider } from '../../theme/ThemeContext';
 import { MembersPanel, MemberCountBadge } from '../../components/MembersPanel';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 import type { MemberInfo } from '../../components/MembersPanel';
 
 const mockMembers: string[] = ['eng-01', 'eng-02', 'tl-01', 'mgr-01'];
@@ -20,20 +23,20 @@ const mockMembersWithInfo: MemberInfo[] = [
 describe('MembersPanel', () => {
   describe('basic rendering', () => {
     it('renders member list', () => {
-      const { lastFrame } = render(<MembersPanel members={mockMembers} />);
+      const { lastFrame } = renderWithTheme(<MembersPanel members={mockMembers} />);
       const output = lastFrame();
       expect(output).toContain('eng-01');
       expect(output).toContain('eng-02');
     });
 
     it('shows member count in title', () => {
-      const { lastFrame } = render(<MembersPanel members={mockMembers} />);
+      const { lastFrame } = renderWithTheme(<MembersPanel members={mockMembers} />);
       const output = lastFrame();
       expect(output).toContain('(4)');
     });
 
     it('renders with custom title', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={mockMembers} title="Channel Members" />
       );
       const output = lastFrame();
@@ -41,7 +44,7 @@ describe('MembersPanel', () => {
     });
 
     it('renders empty list', () => {
-      const { lastFrame } = render(<MembersPanel members={[]} />);
+      const { lastFrame } = renderWithTheme(<MembersPanel members={[]} />);
       const output = lastFrame();
       expect(output).toContain('(0)');
     });
@@ -49,21 +52,21 @@ describe('MembersPanel', () => {
 
   describe('member info display', () => {
     it('renders string members', () => {
-      const { lastFrame } = render(<MembersPanel members={mockMembers} />);
+      const { lastFrame } = renderWithTheme(<MembersPanel members={mockMembers} />);
       const output = lastFrame();
       expect(output).toContain('eng-01');
       expect(output).toContain('tl-01');
     });
 
     it('renders members with role info', () => {
-      const { lastFrame } = render(<MembersPanel members={mockMembersWithInfo} />);
+      const { lastFrame } = renderWithTheme(<MembersPanel members={mockMembersWithInfo} />);
       const output = lastFrame();
       expect(output).toContain('eng-01');
       expect(output).toContain('engineer');
     });
 
     it('renders members with state info', () => {
-      const { lastFrame } = render(<MembersPanel members={mockMembersWithInfo} />);
+      const { lastFrame } = renderWithTheme(<MembersPanel members={mockMembersWithInfo} />);
       const output = lastFrame();
       expect(output).toContain('working');
     });
@@ -71,13 +74,13 @@ describe('MembersPanel', () => {
 
   describe('collapsible behavior', () => {
     it('renders expanded by default', () => {
-      const { lastFrame } = render(<MembersPanel members={mockMembers} />);
+      const { lastFrame } = renderWithTheme(<MembersPanel members={mockMembers} />);
       const output = lastFrame();
       expect(output).toContain('eng-01');
     });
 
     it('renders collapsed when defaultCollapsed is true', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={mockMembers} defaultCollapsed />
       );
       const output = lastFrame();
@@ -85,7 +88,7 @@ describe('MembersPanel', () => {
     });
 
     it('shows collapse hint when collapsible', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={mockMembers} collapsible />
       );
       const output = lastFrame();
@@ -93,7 +96,7 @@ describe('MembersPanel', () => {
     });
 
     it('hides collapse hint when not collapsible', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={mockMembers} collapsible={false} />
       );
       const output = lastFrame();
@@ -105,7 +108,7 @@ describe('MembersPanel', () => {
     const manyMembers = Array.from({ length: 20 }, (_, i) => `member-${String(i + 1)}`);
 
     it('limits visible members', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={manyMembers} maxVisible={5} />
       );
       const output = lastFrame();
@@ -115,7 +118,7 @@ describe('MembersPanel', () => {
     });
 
     it('shows all members when under limit', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={mockMembers} maxVisible={10} />
       );
       const output = lastFrame();
@@ -123,7 +126,7 @@ describe('MembersPanel', () => {
     });
 
     it('handles exact limit', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={mockMembers} maxVisible={4} />
       );
       const output = lastFrame();
@@ -133,14 +136,14 @@ describe('MembersPanel', () => {
 
   describe('focus state', () => {
     it('renders without focus', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={mockMembers} focused={false} />
       );
       expect(lastFrame()).toBeDefined();
     });
 
     it('renders with focus', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <MembersPanel members={mockMembers} focused />
       );
       expect(lastFrame()).toBeDefined();
@@ -150,30 +153,30 @@ describe('MembersPanel', () => {
 
 describe('MemberCountBadge', () => {
   it('renders count', () => {
-    const { lastFrame } = render(<MemberCountBadge count={5} />);
+    const { lastFrame } = renderWithTheme(<MemberCountBadge count={5} />);
     const output = lastFrame();
     expect(output).toContain('[5]');
   });
 
   it('renders zero count', () => {
-    const { lastFrame } = render(<MemberCountBadge count={0} />);
+    const { lastFrame } = renderWithTheme(<MemberCountBadge count={0} />);
     const output = lastFrame();
     expect(output).toContain('[0]');
   });
 
   it('renders large count', () => {
-    const { lastFrame } = render(<MemberCountBadge count={100} />);
+    const { lastFrame } = renderWithTheme(<MemberCountBadge count={100} />);
     const output = lastFrame();
     expect(output).toContain('[100]');
   });
 
   it('renders with custom color', () => {
-    const { lastFrame } = render(<MemberCountBadge count={3} color="green" />);
+    const { lastFrame } = renderWithTheme(<MemberCountBadge count={3} color="green" />);
     expect(lastFrame()).toBeDefined();
   });
 
   it('renders with default color', () => {
-    const { lastFrame } = render(<MemberCountBadge count={3} />);
+    const { lastFrame } = renderWithTheme(<MemberCountBadge count={3} />);
     expect(lastFrame()).toBeDefined();
   });
 });

--- a/tui/src/__tests__/components/Panel.extended.test.tsx
+++ b/tui/src/__tests__/components/Panel.extended.test.tsx
@@ -7,12 +7,15 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import { Text } from 'ink';
 import { describe, it, expect } from 'bun:test';
+import { ThemeProvider } from '../../theme/ThemeContext';
 import { Panel } from '../../components/Panel';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 describe('Panel - Extended Tests', () => {
   describe('title variations', () => {
     it('renders without title', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel>
           <Text>Content</Text>
         </Panel>
@@ -21,7 +24,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with short title', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Hi">
           <Text>Content</Text>
         </Panel>
@@ -31,7 +34,7 @@ describe('Panel - Extended Tests', () => {
 
     it('renders with long title', () => {
       const longTitle = 'A'.repeat(50);
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title={longTitle}>
           <Text>Content</Text>
         </Panel>
@@ -40,7 +43,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with special characters in title', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test: Special!@#$%">
           <Text>Content</Text>
         </Panel>
@@ -49,7 +52,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with unicode title', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="测试 🎉">
           <Text>Content</Text>
         </Panel>
@@ -58,7 +61,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with empty string title', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="">
           <Text>Content</Text>
         </Panel>
@@ -69,7 +72,7 @@ describe('Panel - Extended Tests', () => {
 
   describe('border styles', () => {
     it('renders with default border color', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test">
           <Text>Content</Text>
         </Panel>
@@ -78,7 +81,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with custom border color', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test" borderColor="red">
           <Text>Content</Text>
         </Panel>
@@ -87,7 +90,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders when focused', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test" focused>
           <Text>Content</Text>
         </Panel>
@@ -96,7 +99,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders when not focused', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test" focused={false}>
           <Text>Content</Text>
         </Panel>
@@ -107,7 +110,7 @@ describe('Panel - Extended Tests', () => {
 
   describe('dimensions', () => {
     it('renders with fixed width', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test" width={50}>
           <Text>Content</Text>
         </Panel>
@@ -116,7 +119,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with fixed height', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test" height={10}>
           <Text>Content</Text>
         </Panel>
@@ -125,7 +128,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with both fixed dimensions', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test" width={50} height={10}>
           <Text>Content</Text>
         </Panel>
@@ -134,7 +137,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with percentage width', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test" width="50%">
           <Text>Content</Text>
         </Panel>
@@ -143,7 +146,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with small width', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test" width={10}>
           <Text>Content</Text>
         </Panel>
@@ -154,7 +157,7 @@ describe('Panel - Extended Tests', () => {
 
   describe('children content', () => {
     it('renders single child', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test">
           <Text>Single child</Text>
         </Panel>
@@ -163,7 +166,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders multiple children', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Test">
           <Text>Child 1</Text>
           <Text>Child 2</Text>
@@ -176,7 +179,7 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders nested panels', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Outer">
           <Panel title="Inner">
             <Text>Nested content</Text>
@@ -188,12 +191,12 @@ describe('Panel - Extended Tests', () => {
     });
 
     it('renders with no children', () => {
-      const { lastFrame } = render(<Panel title="Empty">{null}</Panel>);
+      const { lastFrame } = renderWithTheme(<Panel title="Empty">{null}</Panel>);
       expect(lastFrame()).toContain('Empty');
     });
 
     it('renders with complex children', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Panel title="Complex">
           <Text bold>Bold text</Text>
           <Text color="red">Red text</Text>
@@ -206,12 +209,12 @@ describe('Panel - Extended Tests', () => {
 
   describe('consistency', () => {
     it('produces consistent output', () => {
-      const { lastFrame: frame1 } = render(
+      const { lastFrame: frame1 } = renderWithTheme(
         <Panel title="Test">
           <Text>Content</Text>
         </Panel>
       );
-      const { lastFrame: frame2 } = render(
+      const { lastFrame: frame2 } = renderWithTheme(
         <Panel title="Test">
           <Text>Content</Text>
         </Panel>

--- a/tui/src/__tests__/components/Table.test.tsx
+++ b/tui/src/__tests__/components/Table.test.tsx
@@ -6,7 +6,10 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect } from 'bun:test';
+import { ThemeProvider } from '../../theme/ThemeContext';
 import { Table } from '../../components/Table';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 import type { Column } from '../../components/Table';
 
 interface TestData {
@@ -37,7 +40,7 @@ describe('Table', () => {
     });
 
     it('renders column headers', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={testData} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('ID');
       expect(output).toContain('Name');
@@ -45,14 +48,14 @@ describe('Table', () => {
     });
 
     it('renders row data', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={testData} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('Alice');
       expect(output).toContain('Engineer');
     });
 
     it('renders all rows', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={testData} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('Alice');
       expect(output).toContain('Bob');
@@ -62,13 +65,13 @@ describe('Table', () => {
 
   describe('empty state', () => {
     it('renders empty message when no data', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={[]} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={[]} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('No data');
     });
 
     it('shows headers even with no data', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={[]} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={[]} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('ID');
       expect(output).toContain('Name');
@@ -77,7 +80,7 @@ describe('Table', () => {
 
   describe('column configuration', () => {
     it('respects column width', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={testData} />);
       expect(lastFrame()).toBeDefined();
     });
 
@@ -86,13 +89,13 @@ describe('Table', () => {
         { key: 'name', header: 'Name' },
         { key: 'role', header: 'Role' },
       ];
-      const { lastFrame } = render(<Table columns={columnsNoWidth} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={columnsNoWidth} data={testData} />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('handles single column', () => {
       const singleColumn: Column<TestData>[] = [{ key: 'name', header: 'Name' }];
-      const { lastFrame } = render(<Table columns={singleColumn} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={singleColumn} data={testData} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('Name');
       expect(output).toContain('Alice');
@@ -105,33 +108,33 @@ describe('Table', () => {
         { key: 'role', header: 'Role' },
         { key: 'active', header: 'Active' },
       ];
-      const { lastFrame } = render(<Table columns={manyColumns} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={manyColumns} data={testData} />);
       expect(lastFrame()).toBeDefined();
     });
   });
 
   describe('row selection', () => {
     it('highlights selected row', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Table columns={testColumns} data={testData} selectedRow={1} />
       );
       expect(lastFrame()).toBeDefined();
     });
 
     it('handles no selection', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={testData} />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('handles out-of-bounds selection', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Table columns={testColumns} data={testData} selectedRow={999} />
       );
       expect(lastFrame()).toBeDefined();
     });
 
     it('handles negative selection', () => {
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <Table columns={testColumns} data={testData} selectedRow={-1} />
       );
       expect(lastFrame()).toBeDefined();
@@ -140,7 +143,7 @@ describe('Table', () => {
 
   describe('data types', () => {
     it('handles numeric values', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={testData} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('1');
     });
@@ -150,39 +153,39 @@ describe('Table', () => {
         { key: 'name', header: 'Name' },
         { key: 'active', header: 'Active' },
       ];
-      const { lastFrame } = render(<Table columns={columnsWithBool} data={testData} />);
+      const { lastFrame } = renderWithTheme(<Table columns={columnsWithBool} data={testData} />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('handles empty strings', () => {
       const dataWithEmpty = [{ id: 1, name: '', role: '', active: true }];
-      const { lastFrame } = render(<Table columns={testColumns} data={dataWithEmpty} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={dataWithEmpty} />);
       expect(lastFrame()).toBeDefined();
     });
   });
 
   describe('edge cases', () => {
     it('handles single row', () => {
-      const { lastFrame } = render(<Table columns={testColumns} data={[testData[0]]} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={[testData[0]]} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('Alice');
     });
 
     it('handles very long strings', () => {
       const dataWithLong = [{ id: 1, name: 'A'.repeat(100), role: 'B'.repeat(50), active: true }];
-      const { lastFrame } = render(<Table columns={testColumns} data={dataWithLong} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={dataWithLong} />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('handles special characters', () => {
       const dataWithSpecial = [{ id: 1, name: '<script>alert(1)</script>', role: 'Test', active: true }];
-      const { lastFrame } = render(<Table columns={testColumns} data={dataWithSpecial} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={dataWithSpecial} />);
       expect(lastFrame()).toBeDefined();
     });
 
     it('handles unicode characters', () => {
       const dataWithUnicode = [{ id: 1, name: '你好世界 🌍', role: 'Engineer', active: true }];
-      const { lastFrame } = render(<Table columns={testColumns} data={dataWithUnicode} />);
+      const { lastFrame } = renderWithTheme(<Table columns={testColumns} data={dataWithUnicode} />);
       const output = lastFrame() ?? '';
       expect(output).toContain('你好世界');
     });
@@ -190,8 +193,8 @@ describe('Table', () => {
 
   describe('consistency', () => {
     it('produces consistent output on re-render', () => {
-      const { lastFrame: frame1 } = render(<Table columns={testColumns} data={testData} />);
-      const { lastFrame: frame2 } = render(<Table columns={testColumns} data={testData} />);
+      const { lastFrame: frame1 } = renderWithTheme(<Table columns={testColumns} data={testData} />);
+      const { lastFrame: frame2 } = renderWithTheme(<Table columns={testColumns} data={testData} />);
       expect(frame1()).toBe(frame2());
     });
   });

--- a/tui/src/__tests__/dataLayer.advanced.test.ts
+++ b/tui/src/__tests__/dataLayer.advanced.test.ts
@@ -38,6 +38,7 @@ describe('Advanced: BC Service - Timeout and Retry Edge Cases', () => {
 
     mockBcService.execBc.mockReturnValue(timeoutPromise);
 
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     await expect(
       Promise.race([
         bcService.execBc(['status']),
@@ -55,6 +56,7 @@ describe('Advanced: BC Service - Timeout and Retry Edge Cases', () => {
         )
     );
 
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     await expect(bcService.execBc(['status'])).rejects.toThrow();
   });
 
@@ -64,6 +66,7 @@ describe('Advanced: BC Service - Timeout and Retry Edge Cases', () => {
       .mockResolvedValueOnce('{"agents":[]}');
 
     // First call fails
+    // eslint-disable-next-line @typescript-eslint/await-thenable
     await expect(bcService.execBc(['status'])).rejects.toThrow('Failed to spawn');
 
     // Retry succeeds

--- a/tui/src/__tests__/theme.test.tsx
+++ b/tui/src/__tests__/theme.test.tsx
@@ -135,7 +135,7 @@ describe('applyOverrides', () => {
 
   it('preserves original theme', () => {
     applyOverrides(darkTheme, { primary: 'magenta' });
-    expect(darkTheme.colors.primary).toBe('cyan');
+    expect(darkTheme.colors.primary).toBe('#EA580C');
   });
 });
 

--- a/tui/src/__tests__/useListNavigation.test.tsx
+++ b/tui/src/__tests__/useListNavigation.test.tsx
@@ -2,7 +2,13 @@ import { describe, expect, test } from 'bun:test';
 import { render } from 'ink-testing-library';
 import React from 'react';
 import { Text, Box } from 'ink';
+import { ThemeProvider } from '../theme/ThemeContext';
+import { FocusProvider } from '../navigation/FocusContext';
 import { useListNavigation } from '../hooks/useListNavigation';
+
+const renderWithProviders = (ui: React.ReactElement) => render(
+  <ThemeProvider><FocusProvider>{ui}</FocusProvider></ThemeProvider>
+);
 
 // Test component that uses the hook
 function TestList({
@@ -32,7 +38,7 @@ function TestList({
 
 describe('useListNavigation', () => {
   test('renders list with first item selected by default', () => {
-    const { lastFrame } = render(<TestList items={['Item 1', 'Item 2', 'Item 3']} />);
+    const { lastFrame } = renderWithProviders(<TestList items={['Item 1', 'Item 2', 'Item 3']} />);
     const output = lastFrame() ?? '';
 
     expect(output).toContain('> Item 1');
@@ -40,14 +46,14 @@ describe('useListNavigation', () => {
   });
 
   test('handles empty list gracefully', () => {
-    const { lastFrame } = render(<TestList items={[]} />);
+    const { lastFrame } = renderWithProviders(<TestList items={[]} />);
     const output = lastFrame() ?? '';
 
     expect(output).toContain('Selected: 0');
   });
 
   test('shows selection indicator', () => {
-    const { lastFrame } = render(<TestList items={['A', 'B', 'C']} />);
+    const { lastFrame } = renderWithProviders(<TestList items={['A', 'B', 'C']} />);
     const output = lastFrame() ?? '';
 
     // First item should have selection indicator

--- a/tui/src/__tests__/views/RolesView.test.tsx
+++ b/tui/src/__tests__/views/RolesView.test.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, it, expect, vi, beforeEach, mock } from 'bun:test';
+import { ThemeProvider } from '../../theme/ThemeContext';
 import { RolesView } from '../../views/RolesView';
 import { FocusProvider } from '../../navigation/FocusContext';
 import { NavigationProvider } from '../../navigation/NavigationContext';
@@ -17,13 +18,15 @@ import { DisableInputProvider } from '../../hooks';
 // #1604: Add NavigationProvider for breadcrumb context
 const renderWithProviders = (ui: React.ReactElement) => {
   return render(
-    <ConfigProvider>
-      <NavigationProvider>
-        <FocusProvider>
-          <DisableInputProvider disabled>{ui}</DisableInputProvider>
-        </FocusProvider>
-      </NavigationProvider>
-    </ConfigProvider>
+    <ThemeProvider>
+      <ConfigProvider>
+        <NavigationProvider>
+          <FocusProvider>
+            <DisableInputProvider disabled>{ui}</DisableInputProvider>
+          </FocusProvider>
+        </NavigationProvider>
+      </ConfigProvider>
+    </ThemeProvider>
   );
 };
 

--- a/tui/src/views/__tests__/AgentDetailView.test.tsx
+++ b/tui/src/views/__tests__/AgentDetailView.test.tsx
@@ -4,10 +4,13 @@ import { describe, test, expect } from 'bun:test';
 const noTTY = !process.stdin.isTTY;
 import React from 'react';
 import { render } from 'ink-testing-library';
+import { ThemeProvider } from '../../theme/ThemeContext';
 import { AgentDetailView } from '../AgentDetailView';
 import { FocusProvider } from '../../navigation/FocusContext';
 import { ConfigProvider } from '../../config';
 import type { Agent } from '../../types';
+
+const renderWithTheme = (ui: React.ReactElement) => render(<ThemeProvider>{ui}</ThemeProvider>);
 
 // NOTE: useInput tests require TTY stdin, so they're skipped in non-TTY test environments
 // These should be tested manually with: bc home -> select an agent -> verify detail view
@@ -54,7 +57,7 @@ describe('AgentDetailView Component', () => {
   // Unit tests for component prop handling (no useInput)
   // Full rendering tests are skipped due to useInput requiring TTY stdin
   test.skipIf(noTTY)('renders agent name in header', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -62,7 +65,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test.skipIf(noTTY)('renders agent role in header', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -83,7 +86,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test.skipIf(noTTY)('renders agent task', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -91,7 +94,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test.skipIf(noTTY)('shows input prompt when not in input mode', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -99,7 +102,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test.skipIf(noTTY)('shows navigation hints in footer', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -108,7 +111,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test.skipIf(noTTY)('displays agent state (running)', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -139,7 +142,7 @@ describe('AgentDetailView Component', () => {
     const states: Agent['state'][] = ['running', 'idle', 'working', 'stopped'];
     states.forEach(state => {
       const agent = { ...mockAgent, state };
-      const { lastFrame } = render(
+      const { lastFrame } = renderWithTheme(
         <AgentDetailView agent={agent} onBack={() => {}} />
       );
       const output = lastFrame() ?? '';
@@ -148,7 +151,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test('renders output area with border', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -157,7 +160,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test('renders message input area with border', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -167,7 +170,7 @@ describe('AgentDetailView Component', () => {
 
   test('accepts onBack callback', () => {
     let callbackCalled = false;
-    render(
+    renderWithTheme(
       <FocusProvider>
         <AgentDetailView
           agent={mockAgent}
@@ -180,7 +183,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test('displays loading state when fetching output', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -190,7 +193,7 @@ describe('AgentDetailView Component', () => {
 
   test('handles agent with long name', () => {
     const agentLongName = { ...mockAgent, name: 'very-long-agent-name-that-might-cause-layout-issues' };
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={agentLongName} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -202,7 +205,7 @@ describe('AgentDetailView Component', () => {
       ...mockAgent,
       task: 'This is a very long task description that spans many words and might cause layout wrapping issues in the TUI component'
     };
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={agentLongTask} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -210,7 +213,7 @@ describe('AgentDetailView Component', () => {
   });
 
   test('renders all required UI sections', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={mockAgent} onBack={() => {}} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -231,7 +234,7 @@ describe('AgentDetailView Integration Patterns', () => {
   };
 
   test.skipIf(noTTY)('component receives agent prop correctly', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <AgentDetailView agent={agent} onBack={() => {}} />
     );
     const output = lastFrame() ?? '';
@@ -240,7 +243,7 @@ describe('AgentDetailView Integration Patterns', () => {
 
   test('component receives onBack callback correctly', () => {
     const mockCallback = () => {};
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={agent} onBack={mockCallback} /></FocusProvider>
     );
     const output = lastFrame() ?? '';
@@ -248,7 +251,7 @@ describe('AgentDetailView Integration Patterns', () => {
   });
 
   test('component handles missing onBack callback gracefully', () => {
-    const { lastFrame } = render(
+    const { lastFrame } = renderWithTheme(
       <FocusProvider><AgentDetailView agent={agent} /></FocusProvider>
     );
     const output = lastFrame() ?? '';

--- a/tui/src/views/__tests__/HelpView.test.tsx
+++ b/tui/src/views/__tests__/HelpView.test.tsx
@@ -15,6 +15,7 @@ import React from 'react';
 import { render } from 'ink-testing-library';
 import { describe, test, expect } from 'bun:test';
 import { ThemeProvider } from '../../theme';
+import { FocusProvider } from '../../navigation/FocusContext';
 import { DisableInputProvider } from '../../hooks';
 import { HelpView } from '../HelpView';
 
@@ -23,9 +24,11 @@ import { HelpView } from '../HelpView';
 function renderWithProviders(component: React.ReactElement) {
   return render(
     <ThemeProvider>
-      <DisableInputProvider disabled>
-        {component}
-      </DisableInputProvider>
+      <FocusProvider>
+        <DisableInputProvider disabled>
+          {component}
+        </DisableInputProvider>
+      </FocusProvider>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary

- **Fix 197 test failures** caused by color migration PRs: components now call `useTheme()` which requires `ThemeProvider` in the render tree. Added `ThemeProvider` wrapper to 19 test files that render themed components directly.
- **Fix 3 ESLint errors** (`@typescript-eslint/await-thenable`) in `dataLayer.advanced.test.ts` by adding eslint-disable comments — the `await` is correct at runtime (bun:test `rejects.toThrow()` returns a Promise) but the linter cannot resolve the type.
- **Fix 1 color assertion** in `theme.test.tsx`: `darkTheme.colors.primary` changed from `'cyan'` to `'#EA580C'`.
- **Add `FocusProvider`** to `HelpView.test.tsx` (now uses `useIsOverlayActive` which calls `useFocus`) and `useListNavigation.test.tsx` (uses `useFocus`).

**Test results after fix:** 2809 pass, 33 fail (all pre-existing), 0 ESLint errors.

**Remaining 33 failures are pre-existing and unrelated to color migration:**
- bc.test.ts service tests: test isolation issue (pass when run alone)
- tmux integration: dimension mismatch (80x23 vs 80x24)
- 80x24 breakpoint: test logic bug (SM/MD boundary)
- FocusContext cycleFocus: wrap-around logic
- RolesView footer: missing "back" hint
- 5 module-not-found errors: tests reference deleted modules

## Test plan

- [x] `bun run lint` — 0 errors (5 pre-existing warnings)
- [x] `bun test` — 197 failures fixed, remaining 33 are pre-existing
- [x] No test logic changed — only added provider wrappers and updated color assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)