### PR TITLE
fix(server): return 404 instead of null for missing resources (#2339)

### DIFF
--- a/server/handlers/cron.go
+++ b/server/handlers/cron.go
@@ -53,6 +53,10 @@ func (h *CronHandler) list(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
+		if job.Command == "" && job.Prompt == "" {
+			httpError(w, "command or prompt is required", http.StatusBadRequest)
+			return
+		}
 		if err := h.store.AddJob(r.Context(), &job); err != nil {
 			httpError(w, err.Error(), http.StatusBadRequest)
 			return
@@ -98,6 +102,10 @@ func (h *CronHandler) job(w http.ResponseWriter, r *http.Request, name string) {
 		job, err := h.store.GetJob(r.Context(), name)
 		if err != nil {
 			httpError(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if job == nil {
+			httpError(w, "cron job not found", http.StatusNotFound)
 			return
 		}
 		writeJSON(w, http.StatusOK, job)

--- a/server/handlers/daemons.go
+++ b/server/handlers/daemons.go
@@ -99,6 +99,10 @@ func (h *DaemonHandler) byName(w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusNotFound)
 			return
 		}
+		if d == nil {
+			httpError(w, "daemon not found", http.StatusNotFound)
+			return
+		}
 		writeJSON(w, http.StatusOK, d)
 
 	case r.Method == http.MethodPost && action == "stop":

--- a/server/handlers/secrets.go
+++ b/server/handlers/secrets.go
@@ -84,6 +84,10 @@ func (h *SecretHandler) byName(w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusNotFound)
 			return
 		}
+		if meta == nil {
+			httpError(w, "secret not found", http.StatusNotFound)
+			return
+		}
 		writeJSON(w, http.StatusOK, meta)
 
 	case http.MethodPut:

--- a/server/handlers/tools.go
+++ b/server/handlers/tools.go
@@ -80,6 +80,10 @@ func (h *ToolHandler) tool(w http.ResponseWriter, r *http.Request, name string) 
 			httpError(w, err.Error(), http.StatusNotFound)
 			return
 		}
+		if t == nil {
+			httpError(w, "tool not found", http.StatusNotFound)
+			return
+		}
 		writeJSON(w, http.StatusOK, t)
 
 	case http.MethodPut:


### PR DESCRIPTION
## Summary

- **GET endpoints return 404 for nonexistent resources**: `GET /api/cron/{name}`, `/api/tools/{name}`, `/api/daemons/{name}`, and `/api/secrets/{name}` now return `{"error": "<resource> not found"}` with HTTP 404 instead of `null` with HTTP 200 when the resource does not exist.
- **Cron job creation requires command or prompt**: `POST /api/cron` now validates that at least one of `command` or `prompt` is provided, returning 400 if neither is set.

Partial fix for #2339.

## Test plan

- [ ] `GET /api/cron/nonexistent` returns 404 with error message
- [ ] `GET /api/tools/nonexistent` returns 404 with error message
- [ ] `GET /api/daemons/nonexistent` returns 404 with error message
- [ ] `GET /api/secrets/nonexistent` returns 404 with error message
- [ ] `POST /api/cron` with `{"name":"x","schedule":"* * * * *"}` (no command/prompt) returns 400
- [ ] `POST /api/cron` with command or prompt still creates successfully (201)
- [ ] Existing handler tests pass (`go test ./server/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)