### PR TITLE
fix(channel): validate name, duplicates, and empty messages (#2339)

### DIFF
--- a/pkg/channel/service.go
+++ b/pkg/channel/service.go
@@ -2,9 +2,27 @@ package channel
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 )
+
+// channelNameRegex matches valid channel names: alphanumeric, hyphens, underscores,
+// must start with an alphanumeric character.
+var channelNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+
+// ErrChannelExists is returned when attempting to create a channel that already exists.
+var ErrChannelExists = errors.New("channel already exists")
+
+// ErrInvalidChannelName is returned when a channel name contains invalid characters.
+var ErrInvalidChannelName = errors.New("invalid channel name: must start with alphanumeric and contain only alphanumeric, hyphens, or underscores")
+
+// IsValidChannelName validates that a channel name contains only allowed characters.
+func IsValidChannelName(name string) bool {
+	return channelNameRegex.MatchString(name)
+}
 
 // ChannelDTO is the API representation of a channel.
 type ChannelDTO struct {
@@ -82,6 +100,15 @@ func (s *ChannelService) List(_ context.Context) ([]ChannelDTO, error) {
 func (s *ChannelService) Create(_ context.Context, req CreateChannelReq) (*ChannelDTO, error) {
 	if req.Name == "" {
 		return nil, fmt.Errorf("channel name is required")
+	}
+
+	if !IsValidChannelName(req.Name) {
+		return nil, ErrInvalidChannelName
+	}
+
+	// Check for duplicate channel name
+	if _, exists := s.store.Get(req.Name); exists {
+		return nil, fmt.Errorf("%w: %q", ErrChannelExists, req.Name)
 	}
 
 	ch, err := s.store.Create(req.Name)
@@ -162,6 +189,13 @@ func (s *ChannelService) RemoveMember(_ context.Context, ch, agentID string) err
 
 // Send adds a message to a channel and returns the message DTO.
 func (s *ChannelService) Send(_ context.Context, ch, sender, content string) (*MessageDTO, error) {
+	if strings.TrimSpace(content) == "" {
+		return nil, fmt.Errorf("message content is required")
+	}
+	if strings.TrimSpace(sender) == "" {
+		sender = "anonymous"
+	}
+
 	if err := s.store.AddHistory(ch, sender, content); err != nil {
 		return nil, fmt.Errorf("send message: %w", err)
 	}

--- a/pkg/channel/service_test.go
+++ b/pkg/channel/service_test.go
@@ -2,6 +2,7 @@ package channel
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -41,6 +42,26 @@ func TestServiceCreate(t *testing.T) {
 			name:    "duplicate name",
 			req:     CreateChannelReq{Name: "eng"},
 			wantErr: true,
+		},
+		{
+			name:    "special chars in name",
+			req:     CreateChannelReq{Name: "test/channel@#$"},
+			wantErr: true,
+		},
+		{
+			name:    "name starting with hyphen",
+			req:     CreateChannelReq{Name: "-invalid"},
+			wantErr: true,
+		},
+		{
+			name:    "name with spaces",
+			req:     CreateChannelReq{Name: "has space"},
+			wantErr: true,
+		},
+		{
+			name:    "valid name with hyphens and underscores",
+			req:     CreateChannelReq{Name: "my-channel_2"},
+			wantErr: false,
 		},
 	}
 
@@ -439,5 +460,103 @@ func TestServiceChannelToDTONilMembers(t *testing.T) {
 	}
 	if len(dto.Members) != 0 {
 		t.Errorf("got %d members, want 0", len(dto.Members))
+	}
+}
+
+func TestIsValidChannelName(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"simple", "general", true},
+		{"with hyphens", "my-channel", true},
+		{"with underscores", "my_channel", true},
+		{"with digits", "channel123", true},
+		{"starts with digit", "1channel", true},
+		{"uppercase", "Engineering", true},
+		{"mixed", "Dev-Team_01", true},
+		{"empty", "", false},
+		{"starts with hyphen", "-invalid", false},
+		{"starts with underscore", "_invalid", false},
+		{"special chars", "test/channel@#$", false},
+		{"spaces", "has space", false},
+		{"dots", "has.dot", false},
+		{"slash", "a/b", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsValidChannelName(tt.input)
+			if got != tt.want {
+				t.Errorf("IsValidChannelName(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServiceCreateDuplicateReturnsErrChannelExists(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "all"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = svc.Create(ctx, CreateChannelReq{Name: "all"})
+	if err == nil {
+		t.Fatal("expected error for duplicate channel name")
+	}
+	if !errors.Is(err, ErrChannelExists) {
+		t.Errorf("expected ErrChannelExists, got: %v", err)
+	}
+}
+
+func TestServiceSendEmptyContent(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty content should fail
+	_, err = svc.Send(ctx, "eng", "agent-1", "")
+	if err == nil {
+		t.Error("expected error for empty content")
+	}
+
+	// Whitespace-only content should fail
+	_, err = svc.Send(ctx, "eng", "agent-1", "   ")
+	if err == nil {
+		t.Error("expected error for whitespace-only content")
+	}
+}
+
+func TestServiceSendEmptySenderDefaultsToAnonymous(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.Create(ctx, CreateChannelReq{Name: "eng"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dto, err := svc.Send(ctx, "eng", "", "hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dto.Sender != "anonymous" {
+		t.Errorf("got sender %q, want %q", dto.Sender, "anonymous")
+	}
+
+	// Whitespace-only sender should also default
+	dto, err = svc.Send(ctx, "eng", "  ", "hello again")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if dto.Sender != "anonymous" {
+		t.Errorf("got sender %q, want %q", dto.Sender, "anonymous")
 	}
 }

--- a/server/handlers/channels.go
+++ b/server/handlers/channels.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -52,6 +53,10 @@ func (h *ChannelHandler) list(w http.ResponseWriter, r *http.Request) {
 		}
 		ch, err := h.svc.Create(r.Context(), req)
 		if err != nil {
+			if errors.Is(err, channel.ErrChannelExists) {
+				httpError(w, err.Error(), http.StatusConflict)
+				return
+			}
 			httpError(w, err.Error(), http.StatusBadRequest)
 			return
 		}


### PR DESCRIPTION
## Summary
- Add channel name format validation (`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`) to reject special characters that break URL routing
- Return 409 Conflict when creating a channel with a duplicate name (was silently returning 201)
- Reject empty/whitespace-only message content with 400 Bad Request; default empty sender to "anonymous"
- Add `IsValidChannelName`, `ErrChannelExists`, and `ErrInvalidChannelName` sentinel errors

Partial fix for #2339

## Test plan
- [x] `TestIsValidChannelName` covers valid/invalid name patterns
- [x] `TestServiceCreate` extended with special char, hyphen-start, and space cases
- [x] `TestServiceCreateDuplicateReturnsErrChannelExists` verifies error type
- [x] `TestServiceSendEmptyContent` verifies empty/whitespace rejection
- [x] `TestServiceSendEmptySenderDefaultsToAnonymous` verifies fallback
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)