### PR TITLE
fix(agent): validate name length and role existence (#2339)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -74,10 +74,17 @@ import (
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
-// IsValidAgentName validates that agent names contain only alphanumeric characters, hyphens, and underscores.
+// MaxAgentNameLength is the maximum allowed length for an agent name.
+const MaxAgentNameLength = 64
+
+// IsValidAgentName validates that agent names contain only alphanumeric characters, hyphens, and underscores,
+// and are at most MaxAgentNameLength characters long.
 // This ensures agent names are safe for use in file paths, shell environments, and tmux sessions.
 func IsValidAgentName(name string) bool {
 	if name == "" {
+		return false
+	}
+	if len(name) > MaxAgentNameLength {
 		return false
 	}
 	for _, c := range name {
@@ -667,13 +674,22 @@ func (m *Manager) SpawnAgentWithOptions(ctx context.Context, opts SpawnOptions) 
 	// Validate agent name format
 	if !IsValidAgentName(name) {
 		m.mu.Unlock()
-		return nil, fmt.Errorf("agent name %q contains invalid characters (use letters, numbers, dash, underscore)", name)
+		return nil, fmt.Errorf("agent name %q is invalid: use letters, numbers, dash, underscore (max %d chars)", name, MaxAgentNameLength)
 	}
 
 	// Validate role is not empty or null-like
 	if role == "" || role == "null" || role == "<nil>" {
 		m.mu.Unlock()
 		return nil, fmt.Errorf("role is required and cannot be empty or null")
+	}
+
+	// Validate role exists on disk (built-in roles like "root" are always valid)
+	if role != RoleRoot {
+		rm := workspace.NewRoleManager(m.stateDir)
+		if !rm.HasRole(string(role)) {
+			m.mu.Unlock()
+			return nil, fmt.Errorf("role %q does not exist; create it in .bc/roles/%s.md first", role, role)
+		}
 	}
 
 	// Enforce root singleton constraint
@@ -1416,7 +1432,7 @@ func (m *Manager) DeleteAgentWithOptions(ctx context.Context, name string, opts 
 // RenameAgent renames an agent from oldName to newName.
 func (m *Manager) RenameAgent(ctx context.Context, oldName, newName string) error {
 	if !IsValidAgentName(newName) {
-		return fmt.Errorf("agent name %q contains invalid characters", newName)
+		return fmt.Errorf("agent name %q is invalid: use letters, numbers, dash, underscore (max %d chars)", newName, MaxAgentNameLength)
 	}
 
 	// Phase 1: validate under global lock, snapshot agent

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -43,6 +43,22 @@ func newTestManager(t *testing.T) *Manager {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 	be := runtime.NewTmuxBackend(tmux.NewManager(fmt.Sprintf("bctest-%d-", time.Now().UnixNano())))
+
+	// Create role files for test roles so role existence validation passes.
+	rm := workspace.NewRoleManager(dir)
+	if mkErr := rm.EnsureRolesDir(); mkErr != nil {
+		t.Fatalf("EnsureRolesDir: %v", mkErr)
+	}
+	for _, roleName := range []string{"engineer", "manager", "qa", "worker", "product-manager"} {
+		if writeErr := os.WriteFile(
+			filepath.Join(rm.RolesDir(), roleName+".md"),
+			[]byte("---\nname: "+roleName+"\n---\n"),
+			0600,
+		); writeErr != nil {
+			t.Fatalf("write role %s: %v", roleName, writeErr)
+		}
+	}
+
 	return &Manager{
 		agents:         make(map[string]*Agent),
 		backends:       map[string]runtime.Backend{"tmux": be},
@@ -1186,6 +1202,29 @@ func TestSpawnAgentWithOptions_NullRole(t *testing.T) {
 				t.Errorf("expected 'role is required' error, got: %v", err)
 			}
 		})
+	}
+}
+
+func TestSpawnAgentWithOptions_NameTooLong(t *testing.T) {
+	m := newTestManager(t)
+	longName := strings.Repeat("a", MaxAgentNameLength+1)
+	_, err := m.SpawnAgentWithOptions(context.Background(), SpawnOptions{Name: longName, Role: Role("engineer"), Workspace: "/tmp"})
+	if err == nil {
+		t.Error("expected error for name exceeding max length")
+	}
+	if !strings.Contains(err.Error(), "invalid") {
+		t.Errorf("expected 'invalid' in error, got: %v", err)
+	}
+}
+
+func TestSpawnAgentWithOptions_NonexistentRole(t *testing.T) {
+	m := newTestManager(t)
+	_, err := m.SpawnAgentWithOptions(context.Background(), SpawnOptions{Name: "test-agent", Role: Role("nonexistent-role"), Workspace: "/tmp"})
+	if err == nil {
+		t.Error("expected error for nonexistent role")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Errorf("expected 'does not exist' in error, got: %v", err)
 	}
 }
 
@@ -2558,6 +2597,9 @@ func TestIsValidAgentName(t *testing.T) {
 		{"contains slash", "agent/path", false},
 		{"contains dot", "agent.test", false},
 		{"contains newline", "agent\ntest", false},
+		{"exactly 64 chars", strings.Repeat("a", MaxAgentNameLength), true},
+		{"65 chars exceeds max", strings.Repeat("a", MaxAgentNameLength+1), false},
+		{"500 chars exceeds max", strings.Repeat("a", 500), false},
 	}
 
 	for _, tc := range tests {
@@ -3307,13 +3349,30 @@ func newTestManagerWithProvider(t *testing.T, p provider.Provider) *Manager {
 	t.Helper()
 	reg := provider.NewRegistry()
 	reg.Register(p)
+	dir := t.TempDir()
 	be := runtime.NewTmuxBackend(tmux.NewManager(fmt.Sprintf("bctest-%d-", time.Now().UnixNano())))
+
+	// Create role files for test roles so role existence validation passes.
+	rm := workspace.NewRoleManager(dir)
+	if mkErr := rm.EnsureRolesDir(); mkErr != nil {
+		t.Fatalf("EnsureRolesDir: %v", mkErr)
+	}
+	for _, roleName := range []string{"engineer", "manager", "qa", "worker"} {
+		if writeErr := os.WriteFile(
+			filepath.Join(rm.RolesDir(), roleName+".md"),
+			[]byte("---\nname: "+roleName+"\n---\n"),
+			0600,
+		); writeErr != nil {
+			t.Fatalf("write role %s: %v", roleName, writeErr)
+		}
+	}
+
 	return &Manager{
 		agents:           make(map[string]*Agent),
 		backends:         map[string]runtime.Backend{"tmux": be},
 		defaultBackend:   "tmux",
 		providerRegistry: reg,
-		stateDir:         t.TempDir(),
+		stateDir:         dir,
 		agentCmd:         "/bin/true",
 	}
 }


### PR DESCRIPTION
## Summary

- Add `MaxAgentNameLength = 64` constant and enforce it in `IsValidAgentName`, rejecting names longer than 64 characters
- Add role existence validation in `SpawnAgentWithOptions` using `workspace.RoleManager.HasRole()` — nonexistent roles now return a 400 error instead of being silently accepted
- Update error messages to include the max length constraint
- Add tests for both validations (`TestSpawnAgentWithOptions_NameTooLong`, `TestSpawnAgentWithOptions_NonexistentRole`)

Partial fix for #2339

## Test plan

- [x] `TestIsValidAgentName` — new cases for 64-char boundary and 500-char names
- [x] `TestSpawnAgentWithOptions_NameTooLong` — verifies 65+ char names are rejected
- [x] `TestSpawnAgentWithOptions_NonexistentRole` — verifies unknown roles are rejected with "does not exist" error
- [x] All existing agent tests pass (test helpers updated to create role files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)