### PR TITLE
feat(server): add channel stats endpoint (#2350)

### DIFF
--- a/pkg/channel/service.go
+++ b/pkg/channel/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -282,6 +283,63 @@ func (s *ChannelService) React(_ context.Context, ch string, msgID int, emoji, u
 	}
 
 	return added, nil
+}
+
+// SenderCount represents a sender and their message count.
+type SenderCount struct {
+	Sender string `json:"sender"`
+	Count  int    `json:"count"`
+}
+
+// ChannelStatsDTO is the API representation of per-channel activity statistics.
+type ChannelStatsDTO struct {
+	LastActivity *time.Time    `json:"last_activity"`
+	Name         string        `json:"name"`
+	TopSenders   []SenderCount `json:"top_senders"`
+	MessageCount int           `json:"message_count"`
+	MemberCount  int           `json:"member_count"`
+}
+
+// Stats returns per-channel activity statistics for all channels.
+func (s *ChannelService) Stats(_ context.Context) ([]ChannelStatsDTO, error) {
+	channels := s.store.List()
+	stats := make([]ChannelStatsDTO, 0, len(channels))
+	for _, ch := range channels {
+		dto := ChannelStatsDTO{
+			Name:         ch.Name,
+			MessageCount: len(ch.History),
+			MemberCount:  len(ch.Members),
+			TopSenders:   computeTopSenders(ch.History, 5),
+		}
+		if len(ch.History) > 0 {
+			last := ch.History[len(ch.History)-1].Time
+			dto.LastActivity = &last
+		}
+		stats = append(stats, dto)
+	}
+	return stats, nil
+}
+
+// computeTopSenders returns the top N senders by message count from history.
+func computeTopSenders(history []HistoryEntry, n int) []SenderCount {
+	counts := make(map[string]int)
+	for _, entry := range history {
+		counts[entry.Sender]++
+	}
+	senders := make([]SenderCount, 0, len(counts))
+	for sender, count := range counts {
+		senders = append(senders, SenderCount{Sender: sender, Count: count})
+	}
+	sort.Slice(senders, func(i, j int) bool {
+		if senders[i].Count != senders[j].Count {
+			return senders[i].Count > senders[j].Count
+		}
+		return senders[i].Sender < senders[j].Sender
+	})
+	if len(senders) > n {
+		senders = senders[:n]
+	}
+	return senders
 }
 
 // channelToDTO converts a Channel to a ChannelDTO.

--- a/server/handlers/channel_stats.go
+++ b/server/handlers/channel_stats.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/rpuneet/bc/pkg/channel"
+)
+
+// ChannelStatsHandler handles /api/stats/channels routes.
+type ChannelStatsHandler struct {
+	svc *channel.ChannelService
+}
+
+// NewChannelStatsHandler creates a ChannelStatsHandler.
+func NewChannelStatsHandler(svc *channel.ChannelService) *ChannelStatsHandler {
+	return &ChannelStatsHandler{svc: svc}
+}
+
+// Register mounts channel stats routes on mux.
+func (h *ChannelStatsHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/stats/channels", h.stats)
+}
+
+func (h *ChannelStatsHandler) stats(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	stats, err := h.svc.Stats(r.Context())
+	if err != nil {
+		httpError(w, "channel stats: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, stats)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -176,6 +176,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 			}
 		}
 		handlers.NewChannelHandler(svc.Channels).Register(mux)
+		handlers.NewChannelStatsHandler(svc.Channels).Register(mux)
 	}
 	if svc.Daemons != nil {
 		handlers.NewDaemonHandler(svc.Daemons).Register(mux)


### PR DESCRIPTION
## Summary
- Add `GET /api/stats/channels` endpoint returning per-channel activity statistics
- Response includes `name`, `message_count`, `member_count`, `last_activity`, and `top_senders` (top 5 by message count)
- Adds `Stats()` method to `ChannelService` and `ChannelStatsHandler` to `server/handlers`

Phase 3 of #2350

## Test plan
- [x] `make build` succeeds
- [x] `golangci-lint` passes on changed packages
- [x] All existing tests pass (`go test -race ./pkg/channel/ ./server/handlers/ ./server/`)
- [ ] Manual: start `bcd`, send messages to channels, verify `GET /api/stats/channels` returns correct stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)