### PR TITLE
fix: agent lifecycle reconciliation — detect dead containers

### DIFF
--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -168,7 +168,15 @@ func (s *AgentService) Start(ctx context.Context, name string, opts StartOptions
 	}
 
 	if existing.State != StateStopped && existing.State != StateError {
-		return nil, fmt.Errorf("agent %q is already running (state: %s)", name, existing.State)
+		// Reconcile: container may have died without bcd noticing
+		if !s.manager.runtimeForAgent(name).HasSession(ctx, name) {
+			log.Info("reconciling dead agent for restart", "agent", name, "state", existing.State)
+			existing.State = StateStopped
+			existing.UpdatedAt = time.Now()
+			_ = s.manager.saveState()
+		} else {
+			return nil, fmt.Errorf("agent %q is already running (state: %s)", name, existing.State)
+		}
 	}
 
 	a, err := s.manager.SpawnAgentWithOptions(ctx, SpawnOptions{
@@ -215,7 +223,14 @@ func (s *AgentService) Delete(ctx context.Context, name string, force bool) erro
 		return fmt.Errorf("agent %q not found", name)
 	}
 	if !force && a.State != StateStopped {
-		return fmt.Errorf("agent %q must be stopped before deletion (state: %s). Use --force to delete anyway", name, a.State)
+		// Reconcile: container may have died without bcd noticing
+		if !s.manager.runtimeForAgent(name).HasSession(ctx, name) {
+			a.State = StateStopped
+			a.UpdatedAt = time.Now()
+			_ = s.manager.saveState()
+		} else {
+			return fmt.Errorf("agent %q must be stopped before deletion (state: %s). Use ?force=true to delete anyway", name, a.State)
+		}
 	}
 
 	// Force: stop first if still running

--- a/pkg/agent/service_test.go
+++ b/pkg/agent/service_test.go
@@ -103,15 +103,19 @@ func TestAgentService_StopNonexistent(t *testing.T) {
 	}
 }
 
-func TestAgentService_DeleteRequiresStopped(t *testing.T) {
+func TestAgentService_DeleteReconcilesDead(t *testing.T) {
+	// An agent with StateIdle but no actual session should be reconciled
+	// to StateStopped and deleted successfully (not stuck in catch-22).
 	mgr := newTestManager(t)
 	mgr.agents["eng-1"] = &Agent{Name: "eng-1", Role: Role("engineer"), State: StateIdle, Children: []string{}}
 
-	svc := NewAgentService(mgr, nil, nil)
+	pub := &mockEventPublisher{}
+	svc := NewAgentService(mgr, pub, nil)
 
+	// Delete should succeed because no session exists (container dead)
 	err := svc.Delete(context.Background(), "eng-1", false)
-	if err == nil {
-		t.Error("expected error when deleting running agent")
+	if err != nil {
+		t.Fatalf("Delete of dead agent should succeed after reconciliation: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes #2344 — agents stuck in idle when container dies, creating a catch-22 (can't start, can't delete).

**Changes:**
- `Service.Start`: checks if container is actually alive before rejecting. If dead, reconciles to stopped and allows restart.
- `Service.Delete`: same reconciliation. Dead containers no longer block deletion.
- Updated test to verify reconciliation behavior.

Note: `RunReconciler` goroutine needs separate PR to wire into bcd startup (cmd/bcd gitignored).

Verified: build, lint 0, tests pass.

Closes #2344

Generated with [Claude Code](https://claude.com/claude-code)