### PR TITLE
fix(server): make stats handler cross-platform (#2350)

### DIFF
--- a/server/handlers/stats.go
+++ b/server/handlers/stats.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"syscall"
 	"time"
 
 	"github.com/rpuneet/bc/pkg/agent"
@@ -14,6 +13,17 @@ import (
 	"github.com/rpuneet/bc/pkg/tool"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
+
+// systemMetrics holds platform-dependent system resource metrics.
+type systemMetrics struct {
+	MemoryTotalBytes uint64
+	MemoryUsedBytes  uint64
+	MemoryPercent    float64
+	DiskTotalBytes   uint64
+	DiskUsedBytes    uint64
+	DiskPercent      float64
+	CPUUsagePercent  float64
+}
 
 // serverStartTime is used to compute uptime.
 var serverStartTime = time.Now() //nolint:gochecknoglobals // intentional: tracks server start
@@ -57,56 +67,25 @@ func (h *StatsHandler) system(w http.ResponseWriter, r *http.Request) {
 
 	hostname, _ := os.Hostname() //nolint:errcheck // best-effort
 
-	var memStats runtime.MemStats
-	runtime.ReadMemStats(&memStats)
-
-	// System memory via Sysinfo
-	var sysInfo syscall.Sysinfo_t
-	var memTotal, memUsed uint64
-	var memPercent float64
-	if err := syscall.Sysinfo(&sysInfo); err == nil {
-		memTotal = sysInfo.Totalram * uint64(sysInfo.Unit)
-		freeRAM := sysInfo.Freeram * uint64(sysInfo.Unit)
-		memUsed = memTotal - freeRAM
-		if memTotal > 0 {
-			memPercent = roundTo(float64(memUsed)/float64(memTotal)*100, 1)
-		}
-	}
-
-	// Disk usage via Statfs on workspace root
-	var diskTotal, diskUsed uint64
-	var diskPercent float64
 	rootDir := "/"
 	if h.ws != nil {
 		rootDir = h.ws.RootDir
 	}
-	var statfs syscall.Statfs_t
-	if err := syscall.Statfs(rootDir, &statfs); err == nil && statfs.Bsize > 0 {
-		bsize := uint64(statfs.Bsize) //nolint:gosec // Bsize is always positive from the kernel
-		diskTotal = statfs.Blocks * bsize
-		diskFree := statfs.Bavail * bsize
-		diskUsed = diskTotal - diskFree
-		if diskTotal > 0 {
-			diskPercent = roundTo(float64(diskUsed)/float64(diskTotal)*100, 1)
-		}
-	}
 
-	// CPU usage approximation: ratio of Go's Sys memory to total (not ideal,
-	// but avoids cgo/proc parsing). We report 0 when unavailable.
-	cpuPercent := 0.0
+	metrics := getSystemMetrics(rootDir)
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"hostname":             hostname,
 		"os":                   runtime.GOOS,
 		"arch":                 runtime.GOARCH,
 		"cpus":                 runtime.NumCPU(),
-		"cpu_usage_percent":    cpuPercent,
-		"memory_total_bytes":   memTotal,
-		"memory_used_bytes":    memUsed,
-		"memory_usage_percent": memPercent,
-		"disk_total_bytes":     diskTotal,
-		"disk_used_bytes":      diskUsed,
-		"disk_usage_percent":   diskPercent,
+		"cpu_usage_percent":    metrics.CPUUsagePercent,
+		"memory_total_bytes":   metrics.MemoryTotalBytes,
+		"memory_used_bytes":    metrics.MemoryUsedBytes,
+		"memory_usage_percent": metrics.MemoryPercent,
+		"disk_total_bytes":     metrics.DiskTotalBytes,
+		"disk_used_bytes":      metrics.DiskUsedBytes,
+		"disk_usage_percent":   metrics.DiskPercent,
 		"go_version":           runtime.Version(),
 		"uptime_seconds":       int64(time.Since(serverStartTime).Seconds()),
 		"goroutines":           runtime.NumGoroutine(),

--- a/server/handlers/stats_linux.go
+++ b/server/handlers/stats_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package handlers
+
+import "syscall"
+
+// getSystemMetrics returns system resource metrics using Linux-specific syscalls.
+func getSystemMetrics(rootDir string) systemMetrics {
+	var m systemMetrics
+
+	// System memory via Sysinfo
+	var sysInfo syscall.Sysinfo_t
+	if err := syscall.Sysinfo(&sysInfo); err == nil {
+		m.MemoryTotalBytes = sysInfo.Totalram * uint64(sysInfo.Unit)
+		freeRAM := sysInfo.Freeram * uint64(sysInfo.Unit)
+		m.MemoryUsedBytes = m.MemoryTotalBytes - freeRAM
+		if m.MemoryTotalBytes > 0 {
+			m.MemoryPercent = roundTo(float64(m.MemoryUsedBytes)/float64(m.MemoryTotalBytes)*100, 1)
+		}
+	}
+
+	// Disk usage via Statfs
+	var statfs syscall.Statfs_t
+	if err := syscall.Statfs(rootDir, &statfs); err == nil && statfs.Bsize > 0 {
+		bsize := uint64(statfs.Bsize) //nolint:gosec // Bsize is always positive from the kernel
+		m.DiskTotalBytes = statfs.Blocks * bsize
+		diskFree := statfs.Bavail * bsize
+		m.DiskUsedBytes = m.DiskTotalBytes - diskFree
+		if m.DiskTotalBytes > 0 {
+			m.DiskPercent = roundTo(float64(m.DiskUsedBytes)/float64(m.DiskTotalBytes)*100, 1)
+		}
+	}
+
+	return m
+}

--- a/server/handlers/stats_other.go
+++ b/server/handlers/stats_other.go
@@ -1,0 +1,25 @@
+//go:build !linux
+
+package handlers
+
+import "runtime"
+
+// getSystemMetrics returns system resource metrics using portable Go APIs.
+// On non-Linux platforms, disk and system memory stats are unavailable, so we
+// fall back to Go runtime memory stats and report 0 for disk.
+func getSystemMetrics(_ string) systemMetrics {
+	var m systemMetrics
+
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+
+	m.MemoryTotalBytes = memStats.Sys
+	m.MemoryUsedBytes = memStats.Alloc
+	if m.MemoryTotalBytes > 0 {
+		m.MemoryPercent = roundTo(float64(m.MemoryUsedBytes)/float64(m.MemoryTotalBytes)*100, 1)
+	}
+
+	// Disk stats are not available without platform-specific syscalls.
+
+	return m
+}


### PR DESCRIPTION
## Summary
- Split Linux-only `syscall.Sysinfo` and `syscall.Statfs` calls out of `stats.go` into build-tagged files (`stats_linux.go`, `stats_other.go`)
- Fixes macOS build failure — `syscall.Sysinfo_t` is Linux-only
- Non-Linux platforms fall back to `runtime.MemStats` for memory and return 0 for disk metrics

## Test plan
- [x] `make build` succeeds on Linux
- [x] `go test -race ./server/...` passes
- [x] No new lint issues in changed files
- [ ] Verify `make build` on macOS (cross-compile or native)

🤖 Generated with [Claude Code](https://claude.com/claude-code)