### PR TITLE
fix(web): channel selection updates URL to /channels/:name

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,7 +43,7 @@ export function App() {
             <Route index element={<Suspense fallback={<Loading />}><ErrorBoundary><Dashboard /></ErrorBoundary></Suspense>} />
             <Route path="agents" element={<Suspense fallback={<Loading />}><ErrorBoundary><Agents /></ErrorBoundary></Suspense>} />
             <Route path="agents/:name" element={<Suspense fallback={<Loading />}><ErrorBoundary><AgentDetail /></ErrorBoundary></Suspense>} />
-            <Route path="channels" element={<Suspense fallback={<Loading />}><ErrorBoundary><Channels /></ErrorBoundary></Suspense>} />
+            <Route path="channels/:channelName?" element={<Suspense fallback={<Loading />}><ErrorBoundary><Channels /></ErrorBoundary></Suspense>} />
             <Route path="costs" element={<Suspense fallback={<Loading />}><ErrorBoundary><Costs /></ErrorBoundary></Suspense>} />
             <Route path="roles" element={<Suspense fallback={<Loading />}><ErrorBoundary><Roles /></ErrorBoundary></Suspense>} />
             <Route path="tools" element={<Suspense fallback={<Loading />}><ErrorBoundary><Tools /></ErrorBoundary></Suspense>} />

--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, useEffect, useRef } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { api } from '../api/client';
 import type { ChannelMessage } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
@@ -9,13 +10,24 @@ import { EmptyState } from '../components/EmptyState';
 import { MessageContent } from '../components/MessageContent';
 
 export function Channels() {
+  const { channelName: paramChannel } = useParams<{ channelName: string }>();
+  const navigate = useNavigate();
   const fetcher = useCallback(async () => {
     const res = await api.listChannels();
     return res;
   }, []);
   const { data: channels, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(paramChannel ?? null);
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
+
+  // Sync selected state when URL param changes
+  useEffect(() => {
+    setSelected(paramChannel ?? null);
+  }, [paramChannel]);
+
+  const selectChannel = (name: string) => {
+    navigate('/channels/' + name);
+  };
 
   if (loading && !channels) {
     return (
@@ -70,7 +82,7 @@ export function Channels() {
           (channels ?? []).map((ch) => (
             <button
               key={ch.name}
-              onClick={() => setSelected(ch.name)}
+              onClick={() => selectChannel(ch.name)}
               className={`w-full text-left px-3 py-2 text-sm border-b border-bc-border/30 ${
                 selected === ch.name
                   ? 'bg-bc-accent/10 text-bc-accent'


### PR DESCRIPTION
## Summary
- Add optional `:channelName` route param to the channels route in `App.tsx`
- Use `useParams` and `useNavigate` in `Channels.tsx` so selecting a channel updates the URL to `/channels/:name`
- URL param is read on mount to restore selected channel on direct navigation or page refresh

Closes #2357

## Test plan
- [ ] Navigate to `/channels` — no channel selected, sidebar visible
- [ ] Click a channel — URL updates to `/channels/<name>`, messages load
- [ ] Navigate directly to `/channels/all` — channel is auto-selected
- [ ] Browser back/forward buttons work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)