### PR TITLE
fix(server): skip gzip compression for SSE endpoints (#2356)

### DIFF
--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -370,6 +370,54 @@ func TestGzipMiddleware(t *testing.T) {
 	assertStatus(t, resp, http.StatusOK)
 }
 
+func TestGzipMiddlewareSkipsSSE(t *testing.T) {
+	ts := buildTestServer(t)
+	defer ts.Close()
+
+	tests := []struct {
+		name   string
+		path   string
+		accept string // Accept header (empty = omit)
+		wantGz bool
+	}{
+		{"health is gzipped", "/health", "", true},
+		{"events endpoint skipped", "/api/events", "", false},
+		{"mcp sse skipped", "/mcp/sse", "", false},
+		{"agent output skipped", "/api/agents/alice/output", "", false},
+		{"accept event-stream skipped", "/health", "text/event-stream", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+tt.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Accept-Encoding", "gzip")
+			if tt.accept != "" {
+				req.Header.Set("Accept", tt.accept)
+			}
+
+			client := &http.Client{
+				// Don't follow redirects, don't auto-decompress
+				Transport: &http.Transport{
+					DisableCompression: true,
+				},
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			gotGz := resp.Header.Get("Content-Encoding") == "gzip"
+			if gotGz != tt.wantGz {
+				t.Errorf("Content-Encoding gzip: got %v, want %v", gotGz, tt.wantGz)
+			}
+		})
+	}
+}
+
 func TestMultipleHealthCallsConsistent(t *testing.T) {
 	ts := buildTestServer(t)
 	defer ts.Close()

--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -125,15 +125,35 @@ func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
 	}
 }
 
+// isSSERequest returns true if the request targets a Server-Sent Events or
+// other streaming endpoint that must not be buffered/compressed. Checked by
+// path (known SSE routes) and by Accept header (generic text/event-stream).
+func isSSERequest(r *http.Request) bool {
+	// Known SSE/streaming paths
+	if r.URL.Path == "/api/events" || strings.HasPrefix(r.URL.Path, "/mcp/") {
+		return true
+	}
+	// /api/agents/{name}/output is an SSE stream
+	if strings.HasPrefix(r.URL.Path, "/api/agents/") && strings.HasSuffix(r.URL.Path, "/output") {
+		return true
+	}
+	// Generic: any request explicitly asking for event-stream
+	if strings.Contains(r.Header.Get("Accept"), "text/event-stream") {
+		return true
+	}
+	return false
+}
+
 // Gzip returns a middleware that compresses responses with gzip when the
-// client sends Accept-Encoding: gzip. Skips SSE and MCP streaming endpoints.
+// client sends Accept-Encoding: gzip. Skips SSE and MCP streaming endpoints
+// because gzip buffering breaks chunked encoding required by EventSource.
 func Gzip(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") {
 			next.ServeHTTP(w, r)
 			return
 		}
-		if r.URL.Path == "/api/events" || strings.HasPrefix(r.URL.Path, "/mcp/") {
+		if isSSERequest(r) {
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
Closes #2356

## Summary

- Gzip middleware was buffering SSE responses, breaking chunked encoding (`ERR_INCOMPLETE_CHUNKED_ENCODING` in the browser)
- Extract `isSSERequest()` helper that skips gzip for:
  - Known SSE paths: `/api/events`, `/mcp/*`, `/api/agents/*/output`
  - Requests with `Accept: text/event-stream` header (generic catch-all)
- Add table-driven test covering all SSE skip conditions

## Test plan

- [x] `TestGzipMiddlewareSkipsSSE` verifies no `Content-Encoding: gzip` on SSE endpoints
- [x] `TestGzipMiddleware` confirms regular endpoints still get gzip
- [x] All server tests pass with race detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)