### PR TITLE
fix(web): use Date.now() fallback for SSE message timestamps

### DIFF
--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -189,9 +189,10 @@ function ChatRoom({ channelName, onPeekAgent }: { channelName: string; onPeekAge
     return subscribe('channel.message', (event) => {
       const data = event.data as { channel?: string; message?: ChannelMessage };
       if (data.channel === channelName && data.message) {
+        const msg = { ...data.message, created_at: data.message.created_at || new Date().toISOString() };
         setMessages((prev) => {
-          if (prev.some((m) => m.id === data.message!.id)) return prev;
-          return [...prev, data.message!];
+          if (prev.some((m) => m.id === msg.id)) return prev;
+          return [...prev, msg];
         });
       }
     });


### PR DESCRIPTION
SSE channel.message events don't include created_at. Uses current time as fallback since SSE messages are real-time. Fixes 'Invalid Date' shown on live messages.