### PR TITLE
fix(ui): improve agent detail log output styling

### DIFF
--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -9,7 +9,7 @@ import { StatusBadge } from '../components/StatusBadge';
 /** Strip ANSI escape sequences from a string. */
 function stripAnsi(s: string): string {
   // eslint-disable-next-line no-control-regex
-  return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+  return s.replace(/\x1b(?:\[[0-9;]*[A-Za-z]|\].*?(?:\x07|\x1b\\)|\([A-B0-2])/g, '');
 }
 
 function RoleBadge({ role }: { role: string }) {
@@ -167,11 +167,12 @@ export function AgentDetail() {
         <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">Live Output</h2>
         <pre
           ref={outputRef}
-          className="rounded border border-bc-border bg-bc-bg p-4 text-xs font-mono overflow-auto max-h-96 whitespace-pre-wrap"
+          className="rounded-lg border border-bc-border/50 bg-[#0a0a0f] p-4 text-xs leading-relaxed overflow-y-auto max-h-[32rem] whitespace-pre-wrap text-bc-text/90 shadow-inner"
+          style={{ fontFamily: "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" }}
         >
           {outputLines.length > 0
             ? outputLines.join('\n')
-            : <span className="text-bc-muted">No output yet. Agent may be idle or stopped.</span>}
+            : <span className="text-bc-muted italic">No output yet. Agent may be idle or stopped.</span>}
         </pre>
       </div>
 


### PR DESCRIPTION
## Summary
- Restyle the agent detail page log output to look like a proper terminal: dark background, monospace font (Space Mono), rounded corners, inner shadow, relaxed line height, and overflow scroll
- Improve ANSI escape sequence stripping to handle OSC and charset sequences in addition to CSI sequences
- No new dependencies — pure CSS/Tailwind changes

Closes #2362

## Test plan
- [ ] Open an agent detail page and verify the output area has a dark terminal-style appearance
- [ ] Confirm no raw ANSI escape codes are visible in the output
- [ ] Verify output scrolls properly when content exceeds the container height
- [ ] Check the build succeeds with `cd web && bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)