### PR TITLE
fix(agent): publish SSE events on agent state changes

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -207,7 +207,10 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 	if loadErr := agentMgr.LoadState(); loadErr != nil {
 		log.Warn("failed to load agent state", "error", loadErr)
 	}
-	agentSvc := agent.NewAgentService(agentMgr, nil, nil)
+	hub := bcws.NewHub()
+	go hub.Run()
+
+	agentSvc := agent.NewAgentService(agentMgr, hub, nil)
 
 	chStore, chErr := channel.OpenStore(ws.RootDir)
 	if chErr != nil {
@@ -220,9 +223,6 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 	if daemonErr != nil {
 		log.Warn("failed to open daemon manager", "error", daemonErr)
 	}
-
-	hub := bcws.NewHub()
-	go hub.Run()
 
 	teamStore := team.NewStore(ws.RootDir)
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -407,8 +407,13 @@ type Manager struct {
 	backends         map[string]runtime.Backend // keyed by "tmux", "docker"
 	agentLocks       map[string]*sync.Mutex     // per-agent locks for slow I/O operations
 	providerRegistry *provider.Registry
-	defaultBackend   string // "tmux" or "docker"
-	stateDir         string
+
+	// onStateChange is called when an agent's state changes.
+	// Set by AgentService to publish SSE events.
+	onStateChange func(name string, state State, task string)
+
+	defaultBackend string // "tmux" or "docker"
+	stateDir       string
 
 	// Agent command (e.g., "claude" or "claude --dangerously-skip-permissions")
 	agentCmd string
@@ -424,6 +429,19 @@ type Manager struct {
 	BootstrapDelay time.Duration
 
 	mu sync.RWMutex // protects maps (agents, agentLocks) only
+}
+
+// SetOnStateChange registers a callback invoked whenever an agent's state
+// changes through the reconciler or hook-event processing.
+func (m *Manager) SetOnStateChange(fn func(name string, state State, task string)) {
+	m.onStateChange = fn
+}
+
+// notifyStateChange calls the onStateChange callback if set.
+func (m *Manager) notifyStateChange(name string, state State, task string) {
+	if m.onStateChange != nil {
+		m.onStateChange(name, state, task)
+	}
 }
 
 // getAgentLock returns the per-agent mutex, creating it if needed.
@@ -1765,13 +1783,22 @@ func (m *Manager) RefreshState(ctx context.Context) error {
 	}
 
 	// Phase 3: global lock — apply state updates
+	type stateChange struct {
+		name  string
+		state State
+		task  string
+	}
+	var changes []stateChange
+
 	m.mu.Lock()
-	defer m.mu.Unlock()
 
 	for name, a := range m.agents {
+		prevState := a.State
+
 		if !active[name] && a.State != StateStopped {
 			a.State = StateStopped
 			a.UpdatedAt = time.Now()
+			changes = append(changes, stateChange{name, a.State, a.Task})
 			continue
 		}
 		if !active[name] {
@@ -1808,6 +1835,17 @@ func (m *Manager) RefreshState(ctx context.Context) error {
 				}
 			}
 		}
+
+		if a.State != prevState {
+			changes = append(changes, stateChange{name, a.State, a.Task})
+		}
+	}
+
+	m.mu.Unlock()
+
+	// Notify outside the lock to avoid potential deadlocks.
+	for _, c := range changes {
+		m.notifyStateChange(c.name, c.state, c.task)
 	}
 
 	return nil
@@ -1932,12 +1970,17 @@ func (m *Manager) UpdateAgentState(name string, state State, task string) error 
 		return fmt.Errorf("agent %s: %w", name, err)
 	}
 
+	prevState := agent.State
 	agent.State = state
 	agent.Task = task
 	agent.UpdatedAt = time.Now()
 
 	if err := m.saveState(); err != nil {
 		log.Warn("failed to save agent state", "error", err)
+	}
+
+	if prevState != state {
+		m.notifyStateChange(name, state, task)
 	}
 	return nil
 }

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -82,12 +82,25 @@ type AgentService struct {
 }
 
 // NewAgentService creates a new agent service wrapping the given manager.
+// It registers a state-change callback on the manager so that ongoing
+// state transitions (reconciler, hook events) are published as SSE events.
 func NewAgentService(mgr *Manager, events EventPublisher, costs CostQuerier) *AgentService {
-	return &AgentService{
+	svc := &AgentService{
 		manager: mgr,
 		events:  events,
 		costs:   costs,
 	}
+
+	// Wire the manager's state-change callback to publish SSE events.
+	mgr.SetOnStateChange(func(name string, state State, task string) {
+		svc.publishEvent("agent.state_changed", map[string]any{
+			"name":  name,
+			"state": string(state),
+			"task":  task,
+		})
+	})
+
+	return svc
 }
 
 // Manager returns the underlying agent manager.


### PR DESCRIPTION
## Summary
- Agent state change SSE events (`agent.state_changed`) were never published despite the frontend subscribing to them
- Added an `onStateChange` callback to `Manager` that fires on state transitions in both `UpdateAgentState` (hook events via StatsCollector) and `RefreshState` (reconciler)
- Wired the callback in `NewAgentService` to publish `agent.state_changed` events with `{name, state, task}` payload
- Fixed `daemon.go` to pass the SSE hub to `AgentService` (was previously `nil`)

## Test plan
- [x] All `pkg/agent` tests pass with race detector
- [x] All `server/...` tests pass
- [x] No new lint issues in changed files
- [x] Existing create/start/stop/delete events unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)