### PR TITLE
feat(server): enrich agents list with cost and MCP data

### DIFF
--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,16 +10,21 @@ import (
 	"time"
 
 	"github.com/rpuneet/bc/pkg/agent"
+	"github.com/rpuneet/bc/pkg/cost"
+	"github.com/rpuneet/bc/pkg/workspace"
 )
 
 // AgentHandler handles /api/agents routes.
 type AgentHandler struct {
-	svc *agent.AgentService
+	svc   *agent.AgentService
+	costs *cost.Store
+	ws    *workspace.Workspace
 }
 
 // NewAgentHandler creates an AgentHandler.
-func NewAgentHandler(svc *agent.AgentService) *AgentHandler {
-	return &AgentHandler{svc: svc}
+// costs and ws may be nil; enrichment fields will be omitted when unavailable.
+func NewAgentHandler(svc *agent.AgentService, costs *cost.Store, ws *workspace.Workspace) *AgentHandler {
+	return &AgentHandler{svc: svc, costs: costs, ws: ws}
 }
 
 // Register mounts agent routes on mux.
@@ -35,21 +41,24 @@ func (h *AgentHandler) Register(mux *http.ServeMux) {
 }
 
 type agentDTO struct {
-	CreatedAt time.Time  `json:"created_at"`
-	StartedAt time.Time  `json:"started_at,omitempty"`
-	UpdatedAt time.Time  `json:"updated_at"`
-	StoppedAt *time.Time `json:"stopped_at,omitempty"`
-	ID        string     `json:"id,omitempty"`
-	Name      string     `json:"name"`
-	Role      string     `json:"role"`
-	State     string     `json:"state"`
-	Task      string     `json:"task,omitempty"`
-	Team      string     `json:"team,omitempty"`
-	Tool      string     `json:"tool,omitempty"`
-	Session   string     `json:"session,omitempty"`
-	SessionID string     `json:"session_id,omitempty"`
-	ParentID  string     `json:"parent_id,omitempty"`
-	Children  []string   `json:"children,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	StartedAt    time.Time  `json:"started_at,omitempty"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+	StoppedAt    *time.Time `json:"stopped_at,omitempty"`
+	ID           string     `json:"id,omitempty"`
+	Name         string     `json:"name"`
+	Role         string     `json:"role"`
+	State        string     `json:"state"`
+	Task         string     `json:"task,omitempty"`
+	Team         string     `json:"team,omitempty"`
+	Tool         string     `json:"tool,omitempty"`
+	Session      string     `json:"session,omitempty"`
+	SessionID    string     `json:"session_id,omitempty"`
+	ParentID     string     `json:"parent_id,omitempty"`
+	Children     []string   `json:"children,omitempty"`
+	MCPServers   []string   `json:"mcp_servers,omitempty"`
+	TotalCostUSD float64    `json:"total_cost_usd"`
+	TotalTokens  int64      `json:"total_tokens"`
 }
 
 func toDTO(a *agent.Agent) agentDTO {
@@ -72,6 +81,19 @@ func toDTO(a *agent.Agent) agentDTO {
 	}
 }
 
+// buildCostMap queries per-agent cost summaries and returns them keyed by agent ID.
+func buildCostMap(ctx context.Context, store *cost.Store) map[string]*cost.Summary {
+	summaries, err := store.SummaryByAgent(ctx)
+	if err != nil {
+		return nil
+	}
+	m := make(map[string]*cost.Summary, len(summaries))
+	for _, s := range summaries {
+		m[s.AgentID] = s
+	}
+	return m
+}
+
 func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
@@ -85,6 +107,30 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 		for _, a := range agents {
 			dtos = append(dtos, toDTO(a))
 		}
+
+		// Enrich with per-agent cost summaries.
+		if h.costs != nil {
+			costMap := buildCostMap(r.Context(), h.costs)
+			for i := range dtos {
+				if summary, ok := costMap[dtos[i].Name]; ok {
+					dtos[i].TotalCostUSD = summary.TotalCostUSD
+					dtos[i].TotalTokens = summary.TotalTokens
+				}
+			}
+		}
+
+		// Enrich with resolved MCP servers from the agent's role.
+		if h.ws != nil && h.ws.RoleManager != nil {
+			for i := range dtos {
+				if dtos[i].Role != "" {
+					resolved, resolveErr := h.ws.RoleManager.ResolveRole(dtos[i].Role)
+					if resolveErr == nil && len(resolved.MCPServers) > 0 {
+						dtos[i].MCPServers = resolved.MCPServers
+					}
+				}
+			}
+		}
+
 		limit, offset := parsePagination(r, 50)
 		if offset >= len(dtos) {
 			dtos = []agentDTO{}

--- a/server/server.go
+++ b/server/server.go
@@ -133,7 +133,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 
 	// Resource handlers (only registered when service is available)
 	if svc.Agents != nil {
-		handlers.NewAgentHandler(svc.Agents).Register(mux)
+		handlers.NewAgentHandler(svc.Agents, svc.Costs, svc.WS).Register(mux)
 	}
 	if svc.Channels != nil {
 		svc.Channels.OnMessage = func(ch, sender, content string) {


### PR DESCRIPTION
## Summary
- Adds `total_cost_usd`, `total_tokens`, and `mcp_servers` fields to each agent in the `GET /api/agents` response
- Queries `cost.Store.SummaryByAgent()` once per request and merges into agent DTOs by name
- Resolves MCP servers via `workspace.RoleManager.ResolveRole()` (includes inherited servers from parent roles)
- Both cost store and workspace are nil-safe — enrichment is skipped when dependencies are unavailable

## Test plan
- [x] `go build ./server/...` compiles cleanly
- [x] `go test -race ./server/...` passes (all 4 sub-packages)
- [x] `golangci-lint` passes with no new issues (fieldalignment verified)
- [ ] Manual: confirm agents list response includes new fields with active cost data
- [ ] Manual: confirm response is unchanged when cost store is nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)