### PR TITLE
fix: align Makefile coverage threshold with CI (60%)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ LDFLAGS_RELEASE = -s -w $(LDFLAGS_VERSION)
 # Go binary — use system default
 GO ?= go
 
-# Coverage threshold (matches CI)
-COVERAGE_THRESHOLD ?= 66.6
+# Coverage threshold (matches CI ci.yml "Check coverage threshold" step)
+COVERAGE_THRESHOLD ?= 60
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
## Summary
- Makefile had `COVERAGE_THRESHOLD=66.6` while CI (`ci.yml`) enforces 60%
- Comment said "matches CI" but didn't — this could cause local `make coverage` to fail while CI passes
- Aligned to 60% so local and CI gates match
- Target remains 90%+ per #2313

## Test plan
- [x] One-line Makefile change, no code affected
- [x] Verified CI threshold at ci.yml line 55-64

🤖 Generated with [Claude Code](https://claude.com/claude-code)