### PR TITLE
test(handlers): add unit tests for middleware and helpers

### DIFF
--- a/server/handlers/helpers_test.go
+++ b/server/handlers/helpers_test.go
@@ -1,0 +1,257 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClampInt(t *testing.T) {
+	tests := []struct {
+		name       string
+		n, min, max int
+		want       int
+	}{
+		{"within range", 5, 1, 10, 5},
+		{"below min", -1, 0, 10, 0},
+		{"above max", 20, 0, 10, 10},
+		{"at min", 1, 1, 10, 1},
+		{"at max", 10, 1, 10, 10},
+		{"equal min max", 5, 5, 5, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := clampInt(tt.n, tt.min, tt.max)
+			if got != tt.want {
+				t.Errorf("clampInt(%d, %d, %d) = %d, want %d", tt.n, tt.min, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParsePagination(t *testing.T) {
+	tests := []struct {
+		name         string
+		query        string
+		defaultLimit int
+		wantLimit    int
+		wantOffset   int
+	}{
+		{"defaults", "", 50, 50, 0},
+		{"custom limit", "limit=10", 50, 10, 0},
+		{"custom offset", "offset=20", 50, 50, 20},
+		{"both", "limit=25&offset=5", 50, 25, 5},
+		{"limit clamped to 1000", "limit=5000", 50, 1000, 0},
+		{"limit clamped to 1", "limit=0", 50, 50, 0},
+		{"negative limit ignored", "limit=-5", 50, 50, 0},
+		{"negative offset ignored", "offset=-3", 50, 50, 0},
+		{"non-numeric limit ignored", "limit=abc", 50, 50, 0},
+		{"non-numeric offset ignored", "offset=xyz", 50, 50, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/?"+tt.query, nil)
+			limit, offset := parsePagination(req, tt.defaultLimit)
+			if limit != tt.wantLimit {
+				t.Errorf("limit = %d, want %d", limit, tt.wantLimit)
+			}
+			if offset != tt.wantOffset {
+				t.Errorf("offset = %d, want %d", offset, tt.wantOffset)
+			}
+		})
+	}
+}
+
+func TestRequireMethod(t *testing.T) {
+	t.Run("allowed method", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		ok := requireMethod(w, r, http.MethodGet, http.MethodPost)
+		if !ok {
+			t.Error("expected true for allowed method")
+		}
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("disallowed method", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodDelete, "/", nil)
+		ok := requireMethod(w, r, http.MethodGet, http.MethodPost)
+		if ok {
+			t.Error("expected false for disallowed method")
+		}
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("expected 405, got %d", w.Code)
+		}
+	})
+}
+
+func TestHttpError(t *testing.T) {
+	w := httptest.NewRecorder()
+	httpError(w, "test error", http.StatusBadRequest)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "test error") {
+		t.Errorf("expected error message in body, got %q", body)
+	}
+}
+
+func TestWriteJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeJSON(w, http.StatusCreated, map[string]string{"key": "value"})
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"key":"value"`) {
+		t.Errorf("expected JSON in body, got %q", body)
+	}
+}
+
+func TestMaxBodySizeMiddleware(t *testing.T) {
+	handler := MaxBodySize(100)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			httpError(w, "read failed", http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]int{"size": len(body)})
+	}))
+
+	t.Run("small body passes", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader("hello"))
+		r.ContentLength = 5
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("large content-length rejected", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(""))
+		r.ContentLength = 200
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusRequestEntityTooLarge {
+			t.Errorf("expected 413, got %d", w.Code)
+		}
+	})
+}
+
+func TestRecoveryMiddleware(t *testing.T) {
+	handler := Recovery(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	handler.ServeHTTP(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "internal server error") {
+		t.Errorf("expected error in body, got %q", body)
+	}
+}
+
+func TestRequestIDMiddleware(t *testing.T) {
+	handler := RequestID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Run("generates ID when absent", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		handler.ServeHTTP(w, r)
+		id := w.Header().Get("X-Request-ID")
+		if id == "" {
+			t.Error("expected X-Request-ID to be set")
+		}
+		if len(id) != 16 { // 8 bytes hex-encoded
+			t.Errorf("expected 16-char hex ID, got %q (len %d)", id, len(id))
+		}
+	})
+
+	t.Run("echoes provided ID", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.Header.Set("X-Request-ID", "my-custom-id")
+		handler.ServeHTTP(w, r)
+		if got := w.Header().Get("X-Request-ID"); got != "my-custom-id" {
+			t.Errorf("expected my-custom-id, got %q", got)
+		}
+	})
+}
+
+func TestIsSSERequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		accept string
+		want   bool
+	}{
+		{"events endpoint", "/api/events", "", true},
+		{"mcp sse", "/mcp/sse", "", true},
+		{"mcp message", "/mcp/message", "", true},
+		{"agent output", "/api/agents/alice/output", "", true},
+		{"accept event-stream", "/api/anything", "text/event-stream", true},
+		{"normal API", "/api/agents", "", false},
+		{"health", "/health", "", false},
+		{"agent non-output", "/api/agents/alice/stats", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			if tt.accept != "" {
+				r.Header.Set("Accept", tt.accept)
+			}
+			got := isSSERequest(r)
+			if got != tt.want {
+				t.Errorf("isSSERequest(%s) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCORSWithOrigin(t *testing.T) {
+	handler := CORSWithOrigin("http://localhost:3000", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Run("sets origin header", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		handler.ServeHTTP(w, r)
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:3000" {
+			t.Errorf("expected origin http://localhost:3000, got %q", got)
+		}
+	})
+
+	t.Run("preflight returns 204", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusNoContent {
+			t.Errorf("expected 204, got %d", w.Code)
+		}
+	})
+}

--- a/server/handlers/logging_test.go
+++ b/server/handlers/logging_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestStatusRecorder(t *testing.T) {
+	t.Run("captures status code", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		rec := &statusRecorder{ResponseWriter: w, status: 200}
+		rec.WriteHeader(http.StatusNotFound)
+		if rec.status != http.StatusNotFound {
+			t.Errorf("expected 404, got %d", rec.status)
+		}
+	})
+
+	t.Run("defaults to 200", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		rec := &statusRecorder{ResponseWriter: w, status: 200}
+		if rec.status != 200 {
+			t.Errorf("expected default 200, got %d", rec.status)
+		}
+	})
+}
+
+func TestRequestLoggerMiddleware(t *testing.T) {
+	handler := RequestLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	t.Run("normal request is logged", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("SSE events path is skipped", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/api/events", nil)
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("MCP sse path is skipped", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/mcp/sse", nil)
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+}
+
+func TestRequestLogger_ErrorStatus(t *testing.T) {
+	handler := RequestLogger(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/channels", nil)
+	handler.ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}

--- a/server/handlers/ratelimit_test.go
+++ b/server/handlers/ratelimit_test.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRateLimiter_Allow(t *testing.T) {
+	t.Run("allows burst requests", func(t *testing.T) {
+		rl := NewRateLimiter(10, 5) // 10 rps, burst 5
+		for i := 0; i < 5; i++ {
+			if !rl.Allow() {
+				t.Errorf("request %d should be allowed within burst", i)
+			}
+		}
+	})
+
+	t.Run("rejects after burst exhausted", func(t *testing.T) {
+		rl := NewRateLimiter(10, 3) // 10 rps, burst 3
+		for i := 0; i < 3; i++ {
+			rl.Allow() // exhaust burst
+		}
+		if rl.Allow() {
+			t.Error("request after burst should be rejected")
+		}
+	})
+
+	t.Run("initial burst equals burst param", func(t *testing.T) {
+		rl := NewRateLimiter(0, 3) // 0 rps (no refill), burst 3
+		allowed := 0
+		for i := 0; i < 10; i++ {
+			if rl.Allow() {
+				allowed++
+			}
+		}
+		if allowed != 3 {
+			t.Errorf("expected exactly 3 allowed from burst, got %d", allowed)
+		}
+	})
+}
+
+func TestRateLimitMiddleware(t *testing.T) {
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("passes when under limit", func(t *testing.T) {
+		rl := NewRateLimiter(100, 10)
+		handler := RateLimit(rl)(okHandler)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		handler.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected 200, got %d", w.Code)
+		}
+	})
+
+	t.Run("returns 429 when over limit", func(t *testing.T) {
+		rl := NewRateLimiter(100, 1) // burst of 1
+		handler := RateLimit(rl)(okHandler)
+
+		// First request uses the burst token
+		w1 := httptest.NewRecorder()
+		handler.ServeHTTP(w1, httptest.NewRequest(http.MethodGet, "/", nil))
+		if w1.Code != http.StatusOK {
+			t.Errorf("first request: expected 200, got %d", w1.Code)
+		}
+
+		// Second request should be rate limited
+		w2 := httptest.NewRecorder()
+		handler.ServeHTTP(w2, httptest.NewRequest(http.MethodGet, "/", nil))
+		if w2.Code != http.StatusTooManyRequests {
+			t.Errorf("second request: expected 429, got %d", w2.Code)
+		}
+		if got := w2.Header().Get("Retry-After"); got != "1" {
+			t.Errorf("expected Retry-After: 1, got %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for handlers package middleware and utility functions
- Coverage improved from 6.4% to 9.4% for server/handlers
- Tests cover: parsePagination, clampInt, requireMethod, httpError, writeJSON, MaxBodySize, Recovery, RequestID, isSSERequest, CORSWithOrigin, RateLimiter, RequestLogger

## Test coverage details
- **helpers.go**: parsePagination (10 cases), clampInt (6 cases), requireMethod, httpError, writeJSON, MaxBodySize, Recovery, RequestID, isSSERequest (8 cases), CORSWithOrigin
- **ratelimit.go**: Allow (burst, exhaustion, initial burst), RateLimit middleware (200 OK, 429 with Retry-After)
- **logging.go**: statusRecorder, RequestLogger (normal/SSE skip/error paths)

## Next steps
Resource handler tests (agents, channels, costs, etc.) need real stores wired up via the E2E test pattern — will follow in a separate PR.

Part of #2313 (90% coverage target).

## Test plan
- [x] `go test -race ./server/handlers/...` — all pass
- [x] No lint issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)