### PR TITLE
test(cost): increase test coverage (#2313)

### DIFF
--- a/pkg/cost/importer_test.go
+++ b/pkg/cost/importer_test.go
@@ -144,6 +144,201 @@ func TestImporter_ResolveAgent_HostPath(t *testing.T) {
 	}
 }
 
+func TestNewImporter(t *testing.T) {
+	s := openTestStore(t)
+	wsDir := t.TempDir()
+	imp := NewImporter(s, wsDir)
+	if imp == nil {
+		t.Fatal("NewImporter returned nil")
+	}
+	if imp.store != s {
+		t.Error("store not set correctly")
+	}
+	if imp.workspaceDir != wsDir {
+		t.Errorf("workspaceDir = %q, want %q", imp.workspaceDir, wsDir)
+	}
+}
+
+func TestImporter_ImportAll_NoError(t *testing.T) {
+	s := openTestStore(t)
+	wsDir := t.TempDir()
+	imp := NewImporter(s, wsDir)
+
+	// ImportAll scans the host ~/.claude/projects/ dir plus any Docker agent
+	// dirs. It should complete without error regardless of what is on disk.
+	_, err := imp.ImportAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestImporter_ImportAll_WithDockerAgentSessions(t *testing.T) {
+	s := openTestStore(t)
+	wsDir := t.TempDir()
+
+	// Create a Docker agent projects directory with a JSONL file.
+	agentDir := filepath.Join(wsDir, ".bc", "agents", "docker-agent", "auth", ".claude", "projects", "-proj")
+	if err := os.MkdirAll(agentDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"assistant","sessionId":"ds1","timestamp":"2026-03-10T12:00:00Z","cwd":"/proj","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":50,"output_tokens":20}}}
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "ds1.jsonl"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	imp := NewImporter(s, wsDir)
+	n, err := imp.ImportAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// At least 1 record from the Docker agent session (may be more from host
+	// ~/.claude/projects/ if it exists on the machine).
+	if n < 1 {
+		t.Errorf("want at least 1 imported, got %d", n)
+	}
+}
+
+func TestImporter_ImportAll_ContextCancelled(t *testing.T) {
+	s := openTestStore(t)
+	wsDir := t.TempDir()
+
+	// Create a Docker agent projects directory with JSONL files.
+	agentDir := filepath.Join(wsDir, ".bc", "agents", "agent1", "auth", ".claude", "projects", "-proj")
+	if err := os.MkdirAll(agentDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"assistant","sessionId":"cs1","timestamp":"2026-03-10T12:00:00Z","cwd":"/proj","message":{"model":"claude-sonnet-4-6","usage":{"input_tokens":10,"output_tokens":5}}}
+`
+	if err := os.WriteFile(filepath.Join(agentDir, "cs1.jsonl"), []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately.
+
+	imp := NewImporter(s, wsDir)
+	_, err := imp.ImportAll(ctx)
+	if err != nil {
+		// Context cancellation is returned as an error.
+		if err != context.Canceled {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestImporter_ClaudeProjectsDirs(t *testing.T) {
+	wsDir := t.TempDir()
+	imp := &Importer{store: nil, workspaceDir: wsDir}
+
+	dirs := imp.claudeProjectsDirs()
+	// Should include at least the home/.claude/projects dir.
+	if len(dirs) == 0 {
+		t.Fatal("expected at least one directory")
+	}
+
+	// Now create a Docker agent auth dir and check it shows up.
+	agentAuth := filepath.Join(wsDir, ".bc", "agents", "test-agent", "auth", ".claude", "projects")
+	if err := os.MkdirAll(agentAuth, 0750); err != nil {
+		t.Fatal(err)
+	}
+	dirs = imp.claudeProjectsDirs()
+	found := false
+	for _, d := range dirs {
+		if d == agentAuth {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected Docker agent projects dir %q in dirs: %v", agentAuth, dirs)
+	}
+}
+
+func TestImporter_ClaudeProjectsDirs_SkipsFiles(t *testing.T) {
+	wsDir := t.TempDir()
+	agentsDir := filepath.Join(wsDir, ".bc", "agents")
+	if err := os.MkdirAll(agentsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Create a file (not dir) in agents dir — should be skipped.
+	if err := os.WriteFile(filepath.Join(agentsDir, "not-a-dir"), []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	imp := &Importer{store: nil, workspaceDir: wsDir}
+	dirs := imp.claudeProjectsDirs()
+	for _, d := range dirs {
+		if filepath.Base(d) == "not-a-dir" {
+			t.Error("file entry should be skipped, not listed as dir")
+		}
+	}
+}
+
+func TestImporter_ResolveAgent_EmptyCWD(t *testing.T) {
+	wsDir := t.TempDir()
+	imp := &Importer{store: nil, workspaceDir: wsDir}
+
+	agent := imp.resolveAgent("", "/some/random/path/sess.jsonl")
+	if agent != "unknown" {
+		t.Errorf("want 'unknown' for empty CWD, got %q", agent)
+	}
+}
+
+func TestImporter_ImportFile_MalformedJSONL(t *testing.T) {
+	s := openTestStore(t)
+	jsonlPath := filepath.Join(t.TempDir(), "bad.jsonl")
+	// Write a completely malformed file — all lines are bad JSON.
+	if err := os.WriteFile(jsonlPath, []byte("not json at all\nalso bad\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	imp := &Importer{store: s, workspaceDir: t.TempDir()}
+	n, err := imp.importFile(context.Background(), jsonlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("want 0 records from malformed JSONL, got %d", n)
+	}
+}
+
+func TestImporter_ImportFile_NonExistentFile(t *testing.T) {
+	s := openTestStore(t)
+	imp := &Importer{store: s, workspaceDir: t.TempDir()}
+	_, err := imp.importFile(context.Background(), "/nonexistent/file.jsonl")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestImporter_ImportFile_CacheTokens(t *testing.T) {
+	s := openTestStore(t)
+	content := `{"type":"assistant","sessionId":"cache1","timestamp":"2026-03-10T12:00:00Z","cwd":"/proj","message":{"model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":300,"cache_read_input_tokens":200}}}
+`
+	jsonlPath := filepath.Join(t.TempDir(), "cache.jsonl")
+	if err := os.WriteFile(jsonlPath, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	imp := &Importer{store: s, workspaceDir: t.TempDir()}
+	n, err := imp.importFile(context.Background(), jsonlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("want 1 record imported, got %d", n)
+	}
+
+	// Verify total tokens include cache tokens.
+	summary, err := s.WorkspaceSummary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Total = input(100) + output(50) + cache_creation(300) + cache_read(200) = 650
+	if summary.TotalTokens != 650 {
+		t.Errorf("want 650 total tokens, got %d", summary.TotalTokens)
+	}
+}
+
 func TestImporterSchema_MigratesColumns(t *testing.T) {
 	s := openTestStore(t)
 	// Verify the new columns exist by inserting a record that uses them.

--- a/pkg/cost/session_test.go
+++ b/pkg/cost/session_test.go
@@ -1,6 +1,8 @@
 package cost
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -92,6 +94,158 @@ func TestCalcCost_UnknownModelFallsBack(t *testing.T) {
 	cost := CalcCost("claude-unknown-99", 1_000_000, 0, 0, 0)
 	if cost <= 0 {
 		t.Errorf("expected positive cost for unknown model, got %f", cost)
+	}
+}
+
+func TestFindSessionFiles_ReturnsJSONLFiles(t *testing.T) {
+	root := t.TempDir()
+
+	// Create nested dirs with .jsonl files and non-.jsonl files.
+	sub := filepath.Join(root, "project-a")
+	if err := os.MkdirAll(sub, 0750); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"sess1.jsonl", "sess2.jsonl", "readme.txt"} {
+		if err := os.WriteFile(filepath.Join(sub, name), []byte("{}"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Deeper nesting.
+	deep := filepath.Join(root, "project-b", "nested")
+	if err := os.MkdirAll(deep, 0750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(deep, "sess3.jsonl"), []byte("{}"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := FindSessionFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 3 {
+		t.Fatalf("want 3 .jsonl files, got %d: %v", len(files), files)
+	}
+	for _, f := range files {
+		if filepath.Ext(f) != ".jsonl" {
+			t.Errorf("unexpected non-.jsonl file: %s", f)
+		}
+	}
+}
+
+func TestFindSessionFiles_EmptyDir(t *testing.T) {
+	root := t.TempDir()
+	files, err := FindSessionFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("want 0 files in empty dir, got %d", len(files))
+	}
+}
+
+func TestFindSessionFiles_NonExistentDir(t *testing.T) {
+	files, err := FindSessionFiles("/nonexistent/path/abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Errorf("want 0 files for nonexistent dir, got %d", len(files))
+	}
+}
+
+func TestParseSessionFile_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	content := `{"type":"assistant","sessionId":"s1","timestamp":"2026-03-01T10:00:00Z","cwd":"/ws","message":{"model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":50}}}
+`
+	path := filepath.Join(dir, "test.jsonl")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := ParseSessionFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	if entries[0].InputTokens != 100 {
+		t.Errorf("want 100 input tokens, got %d", entries[0].InputTokens)
+	}
+}
+
+func TestParseSessionFile_NonExistentFile(t *testing.T) {
+	_, err := ParseSessionFile("/nonexistent/test.jsonl")
+	if err == nil {
+		t.Error("expected error for nonexistent file")
+	}
+}
+
+func TestParseSessionReader_EmptyInput(t *testing.T) {
+	entries, err := parseSessionReader(strings.NewReader(""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("want 0 entries for empty input, got %d", len(entries))
+	}
+}
+
+func TestParseSessionReader_SkipsNonAssistantTypes(t *testing.T) {
+	jsonl := strings.NewReader(`{"type":"user","sessionId":"s1","timestamp":"2026-03-01T10:00:00Z","cwd":"/ws","message":{"role":"user"}}
+{"type":"system","sessionId":"s1","timestamp":"2026-03-01T10:00:00Z","cwd":"/ws","message":{"role":"system"}}
+`)
+	entries, err := parseSessionReader(jsonl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("want 0 entries for non-assistant types, got %d", len(entries))
+	}
+}
+
+func TestParseSessionReader_SkipsEmptyMessage(t *testing.T) {
+	jsonl := strings.NewReader(`{"type":"assistant","sessionId":"s1","timestamp":"2026-03-01T10:00:00Z","cwd":"/ws"}
+`)
+	entries, err := parseSessionReader(jsonl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("want 0 entries when message is empty, got %d", len(entries))
+	}
+}
+
+func TestParseSessionReader_InvalidTimestampFallback(t *testing.T) {
+	jsonl := strings.NewReader(`{"type":"assistant","sessionId":"s1","timestamp":"not-a-timestamp","cwd":"/ws","message":{"model":"claude-opus-4-6","usage":{"input_tokens":10,"output_tokens":5}}}
+`)
+	entries, err := parseSessionReader(jsonl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("want 1 entry, got %d", len(entries))
+	}
+	// When timestamp parsing fails, it falls back to time.Now().
+	if entries[0].Timestamp.IsZero() {
+		t.Error("expected non-zero timestamp fallback")
+	}
+	// Should be close to now (within a few seconds).
+	if time.Since(entries[0].Timestamp) > 10*time.Second {
+		t.Errorf("timestamp too far from now: %v", entries[0].Timestamp)
+	}
+}
+
+func TestParseSessionReader_BadMessageJSON(t *testing.T) {
+	jsonl := strings.NewReader(`{"type":"assistant","sessionId":"s1","timestamp":"2026-03-01T10:00:00Z","cwd":"/ws","message":"not an object"}
+`)
+	entries, err := parseSessionReader(jsonl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("want 0 entries when message is not valid JSON object, got %d", len(entries))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add 20+ new tests covering previously untested functions in `pkg/cost/`
- Coverage increased from 78.3% to 86.9% (all previously 0% functions now at 72-100%)
- Key areas covered: `FindSessionFiles`, `ParseSessionFile`, `NewImporter`, `ImportAll`, `claudeProjectsDirs`, `resolveAgent` edge cases, `importFile` error paths

## Test plan
- [x] `go test -race -count=1 ./pkg/cost/...` passes
- [x] `golangci-lint run ./pkg/cost/...` reports 0 issues
- [x] Coverage verified at 86.9% via `go tool cover -func`

🤖 Generated with [Claude Code](https://claude.com/claude-code)