### PR TITLE
feat: add auto-deploy script for dogfood

### DIFF
--- a/scripts/auto-deploy.sh
+++ b/scripts/auto-deploy.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Auto-deploy dogfood bcd when main branch has new commits.
+# Usage:
+#   scripts/auto-deploy.sh          # one-shot check and deploy
+#   scripts/auto-deploy.sh --loop   # poll every 60s
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+deploy_if_needed() {
+    git fetch origin main --quiet
+    LOCAL=$(git rev-parse HEAD)
+    REMOTE=$(git rev-parse origin/main)
+
+    if [ "$LOCAL" = "$REMOTE" ]; then
+        return 0
+    fi
+
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] New commits detected: $LOCAL -> $REMOTE"
+    git pull origin main --quiet
+    make deploy-dogfood
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Deployed commit $(git rev-parse --short HEAD)"
+}
+
+if [ "${1:-}" = "--loop" ]; then
+    echo "Auto-deploy loop started (polling every 60s)"
+    while true; do
+        deploy_if_needed || echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] Deploy failed, will retry"
+        sleep 60
+    done
+else
+    deploy_if_needed
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/auto-deploy.sh` that polls `origin/main` for new commits and runs `make deploy-dogfood` when changes are detected
- Supports one-shot mode (default) and `--loop` mode for continuous polling every 60s
- Logs deploys with timestamps and commit hashes; handles failures gracefully in loop mode

Closes #2375

## Test plan
- [ ] Run `scripts/auto-deploy.sh` on a dogfood host with no new commits — verify it exits cleanly
- [ ] Push a commit to main and run the script — verify it pulls and deploys
- [ ] Run with `--loop` and verify it polls every 60s and recovers from deploy failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)