### PR TITLE
feat(server): add build info to health endpoint

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -39,6 +39,12 @@ import (
 	bcws "github.com/rpuneet/bc/server/ws"
 )
 
+// Build information set by ldflags during build.
+var (
+	commit = "unknown"
+	date   = "unknown"
+)
+
 func main() {
 	addr := flag.String("addr", server.DefaultConfig().Addr, "listen address")
 	wsRoot := flag.String("workspace", ".", "workspace root directory")
@@ -209,6 +215,10 @@ func run(addr, wsRoot, corsOrigin string) error {
 		cfg.Addr = addr
 	}
 	cfg.CORSOrigin = corsOrigin
+	cfg.Build = server.BuildInfo{
+		Commit:  commit,
+		BuiltAt: date,
+	}
 
 	srv := server.New(cfg, svc, hub, server.WebDist())
 	return srv.Start(ctx)

--- a/server/server.go
+++ b/server/server.go
@@ -39,11 +39,18 @@ import (
 
 const defaultAddr = "127.0.0.1:9374"
 
+// BuildInfo holds build-time metadata injected via ldflags.
+type BuildInfo struct {
+	Commit  string // short git commit hash
+	BuiltAt string // UTC build timestamp (RFC 3339)
+}
+
 // Config holds server configuration.
 type Config struct {
-	Addr       string // default "127.0.0.1:9374"
-	CORSOrigin string // allowed origin (default "*")
-	CORS       bool   // enable permissive CORS headers (safe for loopback)
+	Build      BuildInfo // build-time metadata
+	Addr       string    // default "127.0.0.1:9374"
+	CORSOrigin string    // allowed origin (default "*")
+	CORS       bool      // enable permissive CORS headers (safe for loopback)
 }
 
 // DefaultConfig returns the default server configuration.
@@ -89,7 +96,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"status":"ok","addr":%q}`, cfg.Addr) //nolint:errcheck // writing to response
+		fmt.Fprintf(w, `{"status":"ok","addr":%q,"commit":%q,"built_at":%q}`, cfg.Addr, cfg.Build.Commit, cfg.Build.BuiltAt) //nolint:errcheck // writing to response
 	})
 
 	// Readiness probe — verifies downstream dependencies


### PR DESCRIPTION
## Summary
- Add `commit` and `built_at` fields to the `GET /health` endpoint response
- Introduce `BuildInfo` struct in server config, populated via ldflags in `cmd/bcd/main.go`
- Enables the web UI to display when bcd was last deployed

## Test plan
- [x] Existing `TestHandleHealth` passes (response now includes commit/built_at fields)
- [x] `golangci-lint` passes with no new issues
- [ ] Verify `make build-bcd` injects commit and date via ldflags
- [ ] Confirm `GET /health` returns `commit` and `built_at` in response JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)