### PR TITLE
fix(web): optimistically show sent messages without waiting for SSE

### DIFF
--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -232,10 +232,20 @@ function ChatRoom({ channelName, onPeekAgent }: { channelName: string; onPeekAge
 
   const handleSend = async () => {
     if (!input.trim()) return;
+    const content = input;
     setSending(true);
+    setInput('');
     try {
-      await api.sendToChannel(channelName, input);
-      setInput('');
+      await api.sendToChannel(channelName, content);
+      // Optimistically add the message to local state so it appears immediately
+      // without waiting for SSE delivery
+      setMessages((prev) => [
+        ...prev,
+        { id: Date.now(), sender: 'you', content, created_at: new Date().toISOString(), channel: channelName, type: 'text' } as ChannelMessage,
+      ]);
+    } catch {
+      // Restore input on failure
+      setInput(content);
     } finally {
       setSending(false);
     }


### PR DESCRIPTION
## Summary
- When user sends a channel message, it now appears immediately in the chat
- Previously relied on SSE to deliver the message back, which could fail or be slow
- Input is cleared on send, restored on API failure
- Uses optimistic local state update with `Date.now()` as temporary ID

Fixes the "chat gets stuck, message doesn't show" bug reported by @web.

## Test plan
- [x] Send message → appears immediately without waiting for SSE
- [x] If API fails, input is restored
- [x] SSE still delivers the message (may create brief duplicate, deduplicated by existing logic)

Generated with [Claude Code](https://claude.com/claude-code)