### PR TITLE
feat(server): expose user nickname in workspace API response

### DIFF
--- a/server/handlers/workspace.go
+++ b/server/handlers/workspace.go
@@ -44,8 +44,13 @@ func (h *WorkspaceHandler) status(w http.ResponseWriter, r *http.Request) {
 			runningCount++
 		}
 	}
+	nickname := ""
+	if h.ws.Config != nil {
+		nickname = h.ws.Config.User.Nickname
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"name":          h.ws.Name(),
+		"nickname":      nickname,
 		"agent_count":   len(agents),
 		"running_count": runningCount,
 		"is_healthy":    true,


### PR DESCRIPTION
## Summary
- Add `nickname` field to `GET /api/workspace` response, sourced from `ws.Config.User.Nickname`
- Enables the web UI to use the workspace nickname as the default sender name
- Backward-compatible: only adds a new field, no existing fields changed

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./server/handlers/` passes
- [x] `go vet ./server/handlers/` passes
- [ ] Verify `GET /api/workspace` returns `"nickname": "@puneet"` (or configured value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)