### PR TITLE
fix(web): use workspace nickname as channel message sender

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -176,6 +176,14 @@ export interface SystemStats {
   goroutines: number;
 }
 
+export interface WorkspaceInfo {
+  name: string;
+  nickname: string;
+  agent_count: number;
+  running_count: number;
+  is_healthy: boolean;
+}
+
 export interface StatsSummary {
   agents_total: number;
   agents_running: number;
@@ -231,6 +239,7 @@ export const api = {
 
   listCron: () => request<CronJob[]>('/cron'),
   listSecrets: () => request<Secret[]>('/secrets'),
+  getWorkspace: () => request<WorkspaceInfo>('/workspace'),
   getWorkspaceStatus: () => request<Record<string, unknown>>('/workspace/status'),
 
   getStatsSystem: () => request<SystemStats>('/stats/system'),

--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -162,9 +162,22 @@ function ChatRoom({ channelName, onPeekAgent }: { channelName: string; onPeekAge
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
   const [isNearBottom, setIsNearBottom] = useState(true);
+  const [senderName, setSenderName] = useState('web');
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { subscribe } = useWebSocket();
+
+  // Fetch workspace nickname once to use as sender identity
+  useEffect(() => {
+    void (async () => {
+      try {
+        const ws = await api.getWorkspace();
+        setSenderName(ws.nickname || ws.name || 'web');
+      } catch {
+        // keep default 'web'
+      }
+    })();
+  }, []);
   // Track whether the initial fetch for the current channel has completed
   // so we can force-scroll to bottom on channel switch.
   const channelLoadedRef = useRef<string | null>(null);
@@ -236,12 +249,12 @@ function ChatRoom({ channelName, onPeekAgent }: { channelName: string; onPeekAge
     setSending(true);
     setInput('');
     try {
-      await api.sendToChannel(channelName, content);
+      await api.sendToChannel(channelName, content, senderName);
       // Optimistically add the message to local state so it appears immediately
       // without waiting for SSE delivery
       setMessages((prev) => [
         ...prev,
-        { id: Date.now(), sender: 'you', content, created_at: new Date().toISOString(), channel: channelName, type: 'text' } as ChannelMessage,
+        { id: Date.now(), sender: senderName, content, created_at: new Date().toISOString(), channel: channelName, type: 'text' } as ChannelMessage,
       ]);
     } catch {
       // Restore input on failure


### PR DESCRIPTION
## Summary
- Replace hardcoded `'web'` sender in `sendToChannel` with the workspace nickname from `/api/workspace`
- Fetch workspace info once on `ChatRoom` mount; fall back to `name` then `'web'` if nickname is empty
- Update optimistic message sender from `'you'` to the actual nickname so messages display consistently

## Test plan
- [ ] Open the web dashboard channels view and send a message — verify the sender shows the workspace nickname (e.g. `@puneet`) instead of `web` or `you`
- [ ] Verify fallback: if `/api/workspace` fails, messages still send with `web` as sender
- [ ] Confirm SSE deduplication still works (optimistic message matches the real one by ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)