### PR TITLE
feat(cron): add background scheduler daemon (#2389)

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -152,6 +152,9 @@ func run(addr, wsRoot, corsOrigin string) error {
 	} else {
 		cronStore = cr
 		defer cr.Close() //nolint:errcheck // best-effort
+
+		cronSched := bccron.NewScheduler(cr)
+		go cronSched.Run(ctx)
 	}
 
 	var secretStore *bcsecret.Store

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -1,0 +1,141 @@
+package cron
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/log"
+)
+
+const (
+	// DefaultPollInterval is how often the scheduler checks for due jobs.
+	DefaultPollInterval = 30 * time.Second
+
+	// DefaultJobTimeout is the maximum time a single job execution may take.
+	DefaultJobTimeout = 5 * time.Minute
+)
+
+// Scheduler polls the cron store and executes due jobs in the background.
+type Scheduler struct {
+	// execFn is the function used to run a command. Replaceable for testing.
+	execFn     func(ctx context.Context, command string) (output string, err error)
+	store      *Store
+	interval   time.Duration
+	jobTimeout time.Duration
+}
+
+// NewScheduler creates a Scheduler that polls at DefaultPollInterval.
+func NewScheduler(store *Store) *Scheduler {
+	s := &Scheduler{
+		store:      store,
+		interval:   DefaultPollInterval,
+		jobTimeout: DefaultJobTimeout,
+	}
+	s.execFn = s.defaultExec
+	return s
+}
+
+// Run blocks until ctx is canceled, polling for due jobs on each tick.
+func (s *Scheduler) Run(ctx context.Context) {
+	log.Info("cron scheduler started", "interval", s.interval.String())
+
+	// Perform an initial tick immediately so jobs due at startup are caught.
+	s.tick(ctx)
+
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("cron scheduler stopped")
+			return
+		case <-ticker.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+// tick checks all enabled jobs and executes any that are due.
+func (s *Scheduler) tick(ctx context.Context) {
+	jobs, err := s.store.ListJobs(ctx)
+	if err != nil {
+		log.Error("cron scheduler: failed to list jobs", "error", err)
+		return
+	}
+
+	now := time.Now()
+	for _, job := range jobs {
+		if !job.Enabled {
+			continue
+		}
+		if job.Command == "" {
+			continue
+		}
+		if !isDue(job, now) {
+			continue
+		}
+		s.executeJob(ctx, job)
+	}
+}
+
+// isDue reports whether a job should run: it has a next_run time that is at or before now.
+func isDue(job *Job, now time.Time) bool {
+	if job.NextRun == nil {
+		return false
+	}
+	return !job.NextRun.After(now)
+}
+
+// executeJob runs a single job's command and records the result.
+func (s *Scheduler) executeJob(ctx context.Context, job *Job) {
+	log.Info("cron scheduler: executing job", "job", job.Name, "command", job.Command)
+
+	jobCtx, cancel := context.WithTimeout(ctx, s.jobTimeout)
+	defer cancel()
+
+	start := time.Now()
+	output, execErr := s.execFn(jobCtx, job.Command)
+	elapsed := time.Since(start)
+
+	status := "success"
+	if execErr != nil {
+		status = "failed"
+		if jobCtx.Err() == context.DeadlineExceeded {
+			status = "timeout"
+		}
+		log.Warn("cron scheduler: job failed", "job", job.Name, "error", execErr)
+	}
+
+	entry := &LogEntry{
+		JobName:    job.Name,
+		Status:     status,
+		DurationMS: elapsed.Milliseconds(),
+		Output:     output,
+		RunAt:      start,
+	}
+
+	if err := s.store.RecordRun(ctx, entry); err != nil {
+		log.Error("cron scheduler: failed to record run", "job", job.Name, "error", err)
+	}
+}
+
+// defaultExec runs a shell command and captures combined stdout/stderr.
+func (s *Scheduler) defaultExec(ctx context.Context, command string) (string, error) {
+	cmd := exec.CommandContext(ctx, "sh", "-c", command) //#nosec G204 -- commands are user-configured cron jobs
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+
+	err := cmd.Run()
+	output := buf.String()
+	// Truncate very large output to avoid bloating the database.
+	const maxOutput = 64 * 1024
+	if len(output) > maxOutput {
+		output = output[:maxOutput] + fmt.Sprintf("\n... (truncated, total %d bytes)", len(output))
+	}
+	return output, err
+}

--- a/pkg/cron/scheduler_test.go
+++ b/pkg/cron/scheduler_test.go
@@ -1,0 +1,227 @@
+package cron
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// openTestStore creates a temporary cron store for testing.
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	dir := t.TempDir()
+	wsDir := filepath.Join(dir, "ws")
+	if err := os.MkdirAll(wsDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	store, err := Open(wsDir)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { store.Close() }) //nolint:errcheck // test
+	return store
+}
+
+func TestScheduler_EnabledJobGetExecuted(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	// Add an enabled job with a command.
+	job := &Job{
+		Name:     "echo-job",
+		Schedule: "* * * * *", // every minute
+		Command:  "echo hello",
+		Enabled:  true,
+	}
+	if err := store.AddJob(ctx, job); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// Force next_run to be in the past so the scheduler picks it up.
+	past := time.Now().Add(-2 * time.Minute)
+	_, err := store.db.ExecContext(ctx, `UPDATE cron_jobs SET next_run = ? WHERE name = ?`, past, "echo-job")
+	if err != nil {
+		t.Fatalf("update next_run: %v", err)
+	}
+
+	var mu sync.Mutex
+	var execCalls []string
+
+	sched := NewScheduler(store)
+	sched.execFn = func(_ context.Context, command string) (string, error) {
+		mu.Lock()
+		execCalls = append(execCalls, command)
+		mu.Unlock()
+		return "ok", nil
+	}
+
+	// Run a single tick.
+	sched.tick(ctx)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(execCalls) != 1 {
+		t.Fatalf("expected 1 exec call, got %d", len(execCalls))
+	}
+	if execCalls[0] != "echo hello" {
+		t.Errorf("expected command %q, got %q", "echo hello", execCalls[0])
+	}
+
+	// Verify a log entry was recorded.
+	logs, err := store.GetLogs(ctx, "echo-job", 10)
+	if err != nil {
+		t.Fatalf("GetLogs: %v", err)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(logs))
+	}
+	if logs[0].Status != "success" {
+		t.Errorf("expected status %q, got %q", "success", logs[0].Status)
+	}
+}
+
+func TestScheduler_DisabledJobsSkipped(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	job := &Job{
+		Name:     "disabled-job",
+		Schedule: "* * * * *",
+		Command:  "echo should-not-run",
+		Enabled:  false,
+	}
+	if err := store.AddJob(ctx, job); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// Force next_run to the past.
+	past := time.Now().Add(-2 * time.Minute)
+	_, err := store.db.ExecContext(ctx, `UPDATE cron_jobs SET next_run = ? WHERE name = ?`, past, "disabled-job")
+	if err != nil {
+		t.Fatalf("update next_run: %v", err)
+	}
+
+	var mu sync.Mutex
+	var execCalls []string
+
+	sched := NewScheduler(store)
+	sched.execFn = func(_ context.Context, command string) (string, error) {
+		mu.Lock()
+		execCalls = append(execCalls, command)
+		mu.Unlock()
+		return "", nil
+	}
+
+	sched.tick(ctx)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(execCalls) != 0 {
+		t.Fatalf("expected 0 exec calls for disabled job, got %d", len(execCalls))
+	}
+}
+
+func TestScheduler_FutureNextRunSkipped(t *testing.T) {
+	store := openTestStore(t)
+	ctx := context.Background()
+
+	job := &Job{
+		Name:     "future-job",
+		Schedule: "* * * * *",
+		Command:  "echo not-yet",
+		Enabled:  true,
+	}
+	if err := store.AddJob(ctx, job); err != nil {
+		t.Fatalf("AddJob: %v", err)
+	}
+
+	// next_run is already in the future from AddJob, so no override needed.
+
+	var mu sync.Mutex
+	var execCalls []string
+
+	sched := NewScheduler(store)
+	sched.execFn = func(_ context.Context, command string) (string, error) {
+		mu.Lock()
+		execCalls = append(execCalls, command)
+		mu.Unlock()
+		return "", nil
+	}
+
+	sched.tick(ctx)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(execCalls) != 0 {
+		t.Fatalf("expected 0 exec calls for future job, got %d", len(execCalls))
+	}
+}
+
+func TestScheduler_ContextCancellation(t *testing.T) {
+	store := openTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	sched := NewScheduler(store)
+	sched.interval = 10 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		sched.Run(ctx)
+		close(done)
+	}()
+
+	// Cancel immediately and verify Run returns.
+	cancel()
+
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("scheduler did not stop after context cancellation")
+	}
+}
+
+func TestIsDue(t *testing.T) {
+	now := time.Now()
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+
+	tests := []struct {
+		job  *Job
+		name string
+		want bool
+	}{
+		{
+			name: "nil next_run",
+			job:  &Job{NextRun: nil},
+			want: false,
+		},
+		{
+			name: "past next_run",
+			job:  &Job{NextRun: &past},
+			want: true,
+		},
+		{
+			name: "future next_run",
+			job:  &Job{NextRun: &future},
+			want: false,
+		},
+		{
+			name: "exactly now",
+			job:  &Job{NextRun: &now},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDue(tt.job, now)
+			if got != tt.want {
+				t.Errorf("isDue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `pkg/cron/scheduler.go` — poll-based cron scheduler that checks for due jobs every 30s and executes them via `sh -c` with a 5-minute timeout
- Record execution results (status, duration, output) via `Store.RecordRun`, which updates `run_count`, `last_run`, and `next_run`
- Wire scheduler into `cmd/bcd/main.go` so it starts automatically when the cron store is available

Closes #2389

## Test plan
- [x] Enabled jobs with past `next_run` get executed
- [x] Disabled jobs are skipped
- [x] Jobs with future `next_run` are skipped
- [x] Context cancellation stops the scheduler
- [x] `isDue` unit tests cover nil, past, future, and exact-now cases
- [x] All tests pass with race detector (`go test -race`)
- [x] Linter passes (`golangci-lint run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)