### PR TITLE
feat(web): inline peek expansion with SSE streaming

### DIFF
--- a/web/src/components/InlineTerminal.tsx
+++ b/web/src/components/InlineTerminal.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api } from '../api/client';
+import { stripAnsi } from '../utils/text';
+
+interface InlineTerminalProps {
+  agentName: string;
+  lines?: number;
+}
+
+export function InlineTerminal({ agentName, lines = 10 }: InlineTerminalProps) {
+  const [outputLines, setOutputLines] = useState<string[]>([]);
+  const [sseError, setSseError] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Fetch initial snapshot via peek endpoint
+  useEffect(() => {
+    setOutputLines([]);
+    setSseError(false);
+    setLoading(true);
+
+    api
+      .getAgentPeek(agentName, lines)
+      .then(({ output }) => {
+        if (output) {
+          setOutputLines(stripAnsi(output).split('\n'));
+        }
+      })
+      .catch(() => {
+        // Peek may fail for stopped agents
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [agentName, lines]);
+
+  // Connect to SSE stream for live output
+  useEffect(() => {
+    const es = new EventSource(
+      `/api/agents/${encodeURIComponent(agentName)}/output`,
+    );
+    let errorCount = 0;
+
+    const handleOutputEvent = (e: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(e.data as string) as { output?: string };
+        if (parsed.output) {
+          const newLines = stripAnsi(parsed.output).split('\n');
+          setOutputLines((prev) => [...prev, ...newLines].slice(-500));
+        }
+      } catch {
+        // ignore malformed data
+      }
+    };
+
+    es.onmessage = handleOutputEvent;
+    es.addEventListener('agent.output', handleOutputEvent as EventListener);
+
+    es.onerror = () => {
+      errorCount++;
+      if (errorCount > 3) {
+        setSseError(true);
+        es.close();
+      }
+    };
+
+    return () => {
+      es.close();
+    };
+  }, [agentName]);
+
+  // Auto-scroll when near bottom
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+    const isNearBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight <
+      80;
+    if (isNearBottom) {
+      container.scrollTop = container.scrollHeight;
+    }
+  }, [outputLines]);
+
+  return (
+    <div className="bg-bc-bg border-t border-bc-border/30 px-4 py-3">
+      <div
+        ref={scrollRef}
+        className="rounded bg-[#0a0a0f] border border-bc-border/40 p-3 font-mono text-xs leading-relaxed text-[#c9d1d9] max-h-48 overflow-auto whitespace-pre-wrap"
+      >
+        {loading ? (
+          <span className="text-bc-muted animate-pulse">
+            Loading output...
+          </span>
+        ) : outputLines.length > 0 ? (
+          outputLines.join('\n')
+        ) : sseError ? (
+          <span className="text-bc-muted">Agent not running.</span>
+        ) : (
+          <span className="text-bc-muted">No output available.</span>
+        )}
+      </div>
+      <div className="mt-2 text-right">
+        <Link
+          to={`/agents/${encodeURIComponent(agentName)}`}
+          onClick={(e) => e.stopPropagation()}
+          className="text-xs text-bc-accent hover:underline"
+        >
+          View Detail &rarr;
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -6,7 +6,8 @@ import { useWebSocket } from '../hooks/useWebSocket';
 import { StatusBadge } from '../components/StatusBadge';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { EmptyState } from '../components/EmptyState';
-import { stripAnsi, truncate } from '../utils/text';
+import { InlineTerminal } from '../components/InlineTerminal';
+import { truncate } from '../utils/text';
 
 export function Agents() {
   const fetcher = useCallback(async () => {
@@ -18,8 +19,6 @@ export function Agents() {
   const navigate = useNavigate();
 
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
-  const [peekOutput, setPeekOutput] = useState<string>('');
-  const [peekLoading, setPeekLoading] = useState(false);
 
   // Refresh on agent lifecycle events via SSE
   useEffect(() => {
@@ -32,24 +31,9 @@ export function Agents() {
     return () => unsubs.forEach((fn) => fn());
   }, [subscribe, refresh]);
 
-  const handlePeekToggle = async (agentName: string, e: React.MouseEvent) => {
+  const handlePeekToggle = (agentName: string, e: React.MouseEvent) => {
     e.stopPropagation();
-    if (peekAgent === agentName) {
-      setPeekAgent(null);
-      setPeekOutput('');
-      return;
-    }
-    setPeekAgent(agentName);
-    setPeekLoading(true);
-    setPeekOutput('');
-    try {
-      const data = await api.getAgentPeek(agentName, 10);
-      setPeekOutput(stripAnsi(data.output));
-    } catch {
-      setPeekOutput('Failed to load output.');
-    } finally {
-      setPeekLoading(false);
-    }
+    setPeekAgent((prev) => (prev === agentName ? null : agentName));
   };
 
   const columns = ['Name', 'Role', 'Tool', 'Status', 'Task', 'Cost', ''] as const;
@@ -165,26 +149,7 @@ export function Agents() {
                   {peekAgent === a.name && (
                     <tr key={`${a.name}-peek`} className="border-b border-bc-border/50">
                       <td colSpan={columns.length} className="p-0">
-                        <div className="bg-bc-bg border-t border-bc-border/30 px-4 py-3">
-                          <div className="rounded bg-[#0d1117] border border-bc-border/40 p-3 font-mono text-xs leading-relaxed text-[#c9d1d9] max-h-48 overflow-auto whitespace-pre-wrap">
-                            {peekLoading ? (
-                              <span className="text-bc-muted animate-pulse">Loading output...</span>
-                            ) : (
-                              peekOutput || <span className="text-bc-muted">No output available.</span>
-                            )}
-                          </div>
-                          <div className="mt-2 text-right">
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                navigate(`/agents/${encodeURIComponent(a.name)}`);
-                              }}
-                              className="text-xs text-bc-accent hover:underline"
-                            >
-                              View Detail &rarr;
-                            </button>
-                          </div>
-                        </div>
+                        <InlineTerminal agentName={a.name} lines={10} />
                       </td>
                     </tr>
                   )}


### PR DESCRIPTION
## Summary
- Create `InlineTerminal` component (`web/src/components/InlineTerminal.tsx`) with SSE streaming via `/api/agents/{name}/output` and initial snapshot fallback via peek endpoint
- Replace static peek div in `Agents.tsx` with the new `InlineTerminal` component, removing stale `peekOutput`/`peekLoading` state
- Dark terminal styling (`bg-[#0a0a0f]`, monospace, `text-xs`), max-height scroll, auto-scroll near bottom, and "View Detail" link

## Test plan
- [ ] Open agents list, click peek toggle on a running agent -- verify live SSE output streams in
- [ ] Click peek on a stopped agent -- verify initial snapshot loads and "Agent not running" appears after SSE errors
- [ ] Click peek toggle again -- verify inline terminal collapses
- [ ] Click "View Detail" link -- verify navigation to agent detail page
- [ ] Verify `bun run build` passes cleanly

Closes #2397

Generated with [Claude Code](https://claude.com/claude-code)