### PR TITLE
feat(web): add reusable TerminalOutput, MessageInputBar, and useAgentOutput

### DIFF
--- a/web/src/components/MessageInputBar.tsx
+++ b/web/src/components/MessageInputBar.tsx
@@ -1,0 +1,67 @@
+import { useState, useCallback } from 'react';
+
+interface MessageInputBarProps {
+  onSend: (message: string) => Promise<void>;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+/**
+ * Text input with send button for messaging agents or channels.
+ *
+ * Supports Enter to send, Esc to clear, and shows a loading state while sending.
+ */
+export function MessageInputBar({
+  onSend,
+  placeholder = 'Send a message...',
+  disabled = false,
+}: MessageInputBarProps) {
+  const [message, setMessage] = useState('');
+  const [sending, setSending] = useState(false);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = message.trim();
+    if (!trimmed || sending || disabled) return;
+    setSending(true);
+    try {
+      await onSend(trimmed);
+      setMessage('');
+    } finally {
+      setSending(false);
+    }
+  }, [message, sending, disabled, onSend]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        void handleSend();
+      } else if (e.key === 'Escape') {
+        setMessage('');
+      }
+    },
+    [handleSend],
+  );
+
+  const isDisabled = disabled || sending;
+
+  return (
+    <div className="flex gap-2">
+      <input
+        type="text"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={placeholder}
+        disabled={isDisabled}
+        className="flex-1 bg-bc-bg border border-bc-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-bc-accent disabled:opacity-50"
+      />
+      <button
+        onClick={() => void handleSend()}
+        disabled={isDisabled || !message.trim()}
+        className="px-3 py-1.5 bg-bc-accent text-bc-bg rounded text-sm font-medium disabled:opacity-50"
+      >
+        {sending ? 'Sending...' : 'Send'}
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/TerminalOutput.tsx
+++ b/web/src/components/TerminalOutput.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+interface TerminalOutputProps {
+  lines: string[];
+  maxHeight?: string;
+  autoScroll?: boolean;
+  onScrollChange?: (nearBottom: boolean) => void;
+}
+
+/**
+ * Renders terminal output lines in a monospace dark panel with auto-scroll.
+ *
+ * Reusable across AgentDetail, peek panel, and inline terminal views.
+ */
+export function TerminalOutput({
+  lines,
+  maxHeight = '32rem',
+  autoScroll = true,
+  onScrollChange,
+}: TerminalOutputProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isNearBottomRef = useRef(true);
+
+  const checkNearBottom = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return true;
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 120;
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    const nearBottom = checkNearBottom();
+    isNearBottomRef.current = nearBottom;
+    onScrollChange?.(nearBottom);
+  }, [checkNearBottom, onScrollChange]);
+
+  // Auto-scroll when lines change, only if near bottom
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !autoScroll) return;
+    if (isNearBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [lines, autoScroll]);
+
+  return (
+    <div
+      ref={containerRef}
+      onScroll={handleScroll}
+      className="rounded-lg border border-bc-border/50 bg-[#0a0a0f] overflow-y-auto shadow-inner"
+      style={{ maxHeight }}
+    >
+      <pre
+        className="p-4 text-xs leading-relaxed whitespace-pre-wrap break-words text-bc-text/90"
+        style={{
+          fontFamily:
+            "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+        }}
+      >
+        {lines.length > 0 ? (
+          lines.join('\n')
+        ) : (
+          <span className="text-bc-muted italic">No output yet.</span>
+        )}
+      </pre>
+    </div>
+  );
+}

--- a/web/src/hooks/useAgentOutput.ts
+++ b/web/src/hooks/useAgentOutput.ts
@@ -1,0 +1,112 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { api } from '../api/client';
+import { stripAnsi } from '../utils/text';
+
+const MAX_LINES = 500;
+
+interface UseAgentOutputResult {
+  lines: string[];
+  isConnected: boolean;
+  isPaused: boolean;
+  togglePause: () => void;
+}
+
+/**
+ * Streams an agent's terminal output via peek + SSE.
+ *
+ * Buffers up to 500 lines. Supports pause/resume to freeze the display
+ * while still buffering incoming data.
+ */
+export function useAgentOutput(agentName: string): UseAgentOutputResult {
+  const [lines, setLines] = useState<string[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
+
+  // Buffer holds lines while paused so we don't lose data
+  const bufferRef = useRef<string[]>([]);
+  const isPausedRef = useRef(false);
+
+  const togglePause = useCallback(() => {
+    setIsPaused((prev) => {
+      const next = !prev;
+      isPausedRef.current = next;
+      if (!next) {
+        // Resuming — flush buffer to display
+        setLines(bufferRef.current.slice(-MAX_LINES));
+      }
+      return next;
+    });
+  }, []);
+
+  const appendLines = useCallback((newLines: string[]) => {
+    bufferRef.current = [...bufferRef.current, ...newLines].slice(-MAX_LINES);
+    if (!isPausedRef.current) {
+      setLines(bufferRef.current);
+    }
+  }, []);
+
+  // Fetch initial peek output
+  useEffect(() => {
+    bufferRef.current = [];
+    setLines([]);
+    setIsConnected(false);
+    setIsPaused(false);
+    isPausedRef.current = false;
+
+    api
+      .getAgentPeek(agentName, 100)
+      .then(({ output }) => {
+        if (output) {
+          const initial = stripAnsi(output).split('\n');
+          bufferRef.current = initial.slice(-MAX_LINES);
+          setLines(bufferRef.current);
+        }
+      })
+      .catch(() => {
+        // Peek may fail for stopped agents
+      });
+  }, [agentName]);
+
+  // Connect SSE stream
+  useEffect(() => {
+    const es = new EventSource(
+      `/api/agents/${encodeURIComponent(agentName)}/output`,
+    );
+    let errorCount = 0;
+
+    const handleOutput = (e: MessageEvent) => {
+      try {
+        const parsed = JSON.parse(e.data as string) as { output?: string };
+        if (parsed.output) {
+          const incoming = stripAnsi(parsed.output).split('\n');
+          appendLines(incoming);
+        }
+      } catch {
+        // ignore malformed data
+      }
+    };
+
+    es.onopen = () => {
+      setIsConnected(true);
+      errorCount = 0;
+    };
+
+    es.onmessage = handleOutput;
+    es.addEventListener('agent.output', handleOutput as EventListener);
+
+    es.onerror = () => {
+      errorCount++;
+      if (errorCount > 3) {
+        setIsConnected(false);
+        es.close();
+      }
+    };
+
+    return () => {
+      es.close();
+      setIsConnected(false);
+    };
+  }, [agentName, appendLines]);
+
+  return { lines, isConnected, isPaused, togglePause };
+}


### PR DESCRIPTION
## Summary

- **`TerminalOutput`** component: monospace dark terminal panel (`bg-[#0a0a0f]`) with configurable `maxHeight`, auto-scroll that respects user scroll position, and `onScrollChange` callback for pause/resume UIs
- **`MessageInputBar`** component: text input + Send button with Enter-to-send, Esc-to-clear, loading state while sending, and disabled state support
- **`useAgentOutput`** hook: streams agent terminal output via initial peek fetch + SSE, buffers up to 500 lines, with `isPaused`/`togglePause` for freezing the display without losing data

These are standalone reusable building blocks — not yet integrated into AgentDetail (that's #2398's job).

Closes #2401

## Test plan

- [x] `bun run build` passes with no TypeScript errors
- [x] `eslint` passes on all three new files
- [ ] Verify `TerminalOutput` renders lines and auto-scrolls when mounted
- [ ] Verify `MessageInputBar` sends on Enter, clears on Esc, shows loading state
- [ ] Verify `useAgentOutput` connects SSE and buffers lines, pause/resume works

Generated with [Claude Code](https://claude.com/claude-code)