### PR TITLE
feat(web): responsive design and polish for agents page

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { NavLink, Outlet, useLocation } from 'react-router-dom';
 import { useTheme } from '../context/ThemeContext';
 
@@ -23,6 +23,7 @@ const THEME_LABELS = { dark: 'Dark', light: 'Light', system: 'System' } as const
 export function Layout() {
   const location = useLocation();
   const { mode, toggle } = useTheme();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   // Dynamic page title (#2150)
   useEffect(() => {
@@ -32,21 +33,45 @@ export function Layout() {
     document.title = match ? `${match.label} \u2014 bc` : 'bc';
   }, [location.pathname]);
 
+  // Close sidebar on navigation (mobile)
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [location.pathname]);
+
   return (
     <div className="flex h-screen">
-      <nav className="w-48 shrink-0 border-r border-bc-border bg-bc-surface flex flex-col">
+      {/* Mobile hamburger button */}
+      <button
+        type="button"
+        onClick={() => setSidebarOpen(!sidebarOpen)}
+        className="fixed top-3 left-3 z-50 md:hidden inline-flex items-center justify-center w-9 h-9 rounded border border-bc-border bg-bc-surface text-bc-muted hover:text-bc-text transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-bc-accent"
+        aria-label={sidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+      >
+        {sidebarOpen ? '\u2715' : '\u2630'}
+      </button>
+
+      {/* Backdrop overlay for mobile */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-black/50 md:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <nav className={`fixed inset-y-0 left-0 z-40 w-48 shrink-0 border-r border-bc-border bg-bc-surface flex flex-col transition-transform duration-200 md:static md:translate-x-0 ${sidebarOpen ? 'translate-x-0' : '-translate-x-full'}`}>
         <div className="p-4 border-b border-bc-border">
           <span className="text-lg font-bold text-bc-accent">bc</span>
           <span className="ml-2 text-xs text-bc-muted">v2</span>
         </div>
-        <ul className="flex-1 py-2">
+        <ul className="flex-1 py-2 overflow-y-auto">
           {NAV_ITEMS.map(({ to, label, icon }) => (
             <li key={to}>
               <NavLink
                 to={to}
                 end={to === '/'}
                 className={({ isActive }) =>
-                  `flex items-center gap-2 px-4 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-inset ${
+                  `flex items-center gap-2 px-4 py-2 text-sm outline-none transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-inset ${
                     isActive
                       ? 'text-bc-accent bg-bc-bg font-medium'
                       : 'text-bc-muted hover:text-bc-text hover:bg-bc-bg/50'
@@ -64,7 +89,7 @@ export function Layout() {
           <button
             type="button"
             onClick={toggle}
-            className="px-2 py-1 rounded border border-bc-border text-bc-muted hover:text-bc-text hover:border-bc-accent transition-colors"
+            className="px-2 py-1 rounded border border-bc-border text-bc-muted hover:text-bc-text hover:border-bc-accent transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-bc-accent"
             title={`Theme: ${THEME_LABELS[mode]}`}
           >
             {THEME_LABELS[mode]}

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -145,7 +145,7 @@ export function AgentDetail() {
   return (
     <div className="p-6 space-y-6">
       {/* Header */}
-      <div className="flex items-center gap-4">
+      <div className="flex flex-wrap items-center gap-4">
         <Link to="/agents" className="text-bc-muted hover:text-bc-text text-sm">
           &larr; Agents
         </Link>
@@ -167,7 +167,7 @@ export function AgentDetail() {
         <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">Live Output</h2>
         <pre
           ref={outputRef}
-          className="rounded-lg border border-bc-border/50 bg-[#0a0a0f] p-4 text-xs leading-relaxed overflow-y-auto max-h-[32rem] whitespace-pre-wrap text-bc-text/90 shadow-inner"
+          className="rounded-lg border border-bc-border/50 bg-[#0a0a0f] p-4 text-xs leading-relaxed overflow-y-auto max-h-[50vh] md:max-h-[70vh] whitespace-pre-wrap text-bc-text/90 shadow-inner"
           style={{ fontFamily: "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" }}
         >
           {outputLines.length > 0
@@ -184,12 +184,12 @@ export function AgentDetail() {
           onChange={(e) => setMessage(e.target.value)}
           onKeyDown={(e) => { if (e.key === 'Enter') void handleSend(); }}
           placeholder="Send message to agent..."
-          className="flex-1 bg-bc-bg border border-bc-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-bc-accent"
+          className="flex-1 min-w-0 bg-bc-bg border border-bc-border rounded px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-bc-accent transition-colors duration-150"
         />
         <button
           onClick={() => void handleSend()}
           disabled={sending || !message.trim()}
-          className="px-3 py-1.5 bg-bc-accent text-bc-bg rounded text-sm font-medium disabled:opacity-50"
+          className="px-3 py-1.5 bg-bc-accent text-bc-bg rounded text-sm font-medium disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-bc-accent transition-colors duration-150"
         >
           Send
         </button>

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -111,10 +111,10 @@ export function Agents() {
               <tr className="border-b border-bc-border text-left">
                 <th className="px-4 py-2 font-medium text-bc-muted">Name</th>
                 <th className="px-4 py-2 font-medium text-bc-muted">Role</th>
-                <th className="px-4 py-2 font-medium text-bc-muted">Tool</th>
+                <th className="px-4 py-2 font-medium text-bc-muted hidden sm:table-cell">Tool</th>
                 <th className="px-4 py-2 font-medium text-bc-muted">Status</th>
                 <th className="px-4 py-2 font-medium text-bc-muted">Task</th>
-                <th className="px-4 py-2 font-medium text-bc-muted">Cost</th>
+                <th className="px-4 py-2 font-medium text-bc-muted hidden md:table-cell">Cost</th>
                 <th className="px-4 py-2 font-medium text-bc-muted w-10"></th>
               </tr>
             </thead>
@@ -123,7 +123,7 @@ export function Agents() {
                 <Fragment key={a.name}>
                   <tr
                     onClick={() => navigate(`/agents/${encodeURIComponent(a.name)}`)}
-                    className="border-b border-bc-border/50 cursor-pointer hover:bg-bc-surface"
+                    className="border-b border-bc-border/50 cursor-pointer hover:bg-bc-surface transition-colors duration-150"
                   >
                     <td className="px-4 py-2">
                       <span className="font-medium">{a.name}</span>
@@ -131,7 +131,7 @@ export function Agents() {
                     <td className="px-4 py-2">
                       <span className="text-bc-muted">{a.role}</span>
                     </td>
-                    <td className="px-4 py-2">
+                    <td className="px-4 py-2 hidden sm:table-cell">
                       <span className="text-bc-muted">{a.tool || '\u2014'}</span>
                     </td>
                     <td className="px-4 py-2">
@@ -142,7 +142,7 @@ export function Agents() {
                         {a.task ? truncate(a.task, 50) : '\u2014'}
                       </span>
                     </td>
-                    <td className="px-4 py-2">
+                    <td className="px-4 py-2 hidden md:table-cell">
                       <span className="text-bc-muted">
                         {a.cost_usd != null ? `$${a.cost_usd.toFixed(4)}` : '\u2014'}
                       </span>
@@ -150,7 +150,7 @@ export function Agents() {
                     <td className="px-4 py-2 text-center">
                       <button
                         onClick={(e) => handlePeekToggle(a.name, e)}
-                        className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors ${
+                        className={`inline-flex items-center justify-center w-7 h-7 rounded transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-bc-accent ${
                           peekAgent === a.name
                             ? 'bg-bc-accent/20 text-bc-accent'
                             : 'text-bc-muted hover:text-bc-fg hover:bg-bc-surface'


### PR DESCRIPTION
## Summary
- **Agents table**: hide Tool column on small screens (`hidden sm:table-cell`), hide Cost column on medium and below (`hidden md:table-cell`); Name, Role, Status, Task, Actions remain visible at all sizes
- **Agent detail**: flex-wrap on header for mobile, responsive terminal output height (`max-h-[50vh] md:max-h-[70vh]`), full-width message input with `min-w-0`
- **Layout sidebar**: collapses off-screen on mobile with a hamburger toggle button (fixed top-left), backdrop overlay, auto-closes on navigation
- **Polish**: `transition-colors duration-150` on all hover states, `focus:ring-2 focus:ring-bc-accent` on interactive elements (peek button, message input, send button, theme toggle, hamburger)

## Test plan
- [ ] Resize browser below 768px (md breakpoint): sidebar should be hidden, hamburger button visible
- [ ] Click hamburger: sidebar slides in with backdrop overlay
- [ ] Navigate via sidebar link on mobile: sidebar auto-closes
- [ ] Agents table at small viewport: Cost column hidden; at extra-small: Tool column also hidden
- [ ] Agent detail page: terminal output respects `50vh`/`70vh` max heights at small/large viewports
- [ ] Tab through interactive elements: focus rings visible on all buttons and inputs
- [ ] Hover over table rows: smooth color transition

Closes #2402

🤖 Generated with [Claude Code](https://claude.com/claude-code)