### PR TITLE
feat: debloat workspace config (#2388)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -80,9 +80,6 @@ path = ".bc/logs"
 # Maximum log file size in bytes before lazy truncation (keeps last half)
 max_bytes = 1048576  # 1MB
 
-# Preserve ANSI escape codes in log files (for colored output in peek/TUI)
-preserve_ansi = true
-
 # =============================================================================
 # Tmux Settings
 # =============================================================================

--- a/config/config.go
+++ b/config/config.go
@@ -10,9 +10,8 @@ type DatabaseConfig struct {
 }
 
 type LogsConfig struct {
-	MaxBytes     int64
-	Path         string
-	PreserveAnsi bool
+	MaxBytes int64
+	Path     string
 }
 
 type PerformanceConfig struct {
@@ -145,9 +144,8 @@ var (
 		Url:          "",
 	}
 	Logs = LogsConfig{
-		MaxBytes:     1048576,
-		Path:         ".bc/logs",
-		PreserveAnsi: true,
+		MaxBytes: 1048576,
+		Path:     ".bc/logs",
 	}
 	Performance = PerformanceConfig{
 		AdaptiveFastInterval:   1000,

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -216,17 +216,17 @@ type mockProvider struct {
 	dockerImage string
 }
 
-func (m *mockProvider) Name() string                            { return m.name }
-func (m *mockProvider) Description() string                     { return "mock provider" }
-func (m *mockProvider) Command() string                         { return "mock" }
-func (m *mockProvider) Binary() string                          { return "mock" }
-func (m *mockProvider) InstallHint() string                     { return "install mock" }
+func (m *mockProvider) Name() string                               { return m.name }
+func (m *mockProvider) Description() string                        { return "mock provider" }
+func (m *mockProvider) Command() string                            { return "mock" }
+func (m *mockProvider) Binary() string                             { return "mock" }
+func (m *mockProvider) InstallHint() string                        { return "install mock" }
 func (m *mockProvider) BuildCommand(_ provider.CommandOpts) string { return "mock" }
-func (m *mockProvider) IsInstalled(_ context.Context) bool      { return true }
-func (m *mockProvider) Version(_ context.Context) string        { return "1.0.0" }
-func (m *mockProvider) DetectState(_ string) provider.State     { return provider.StateUnknown }
-func (m *mockProvider) DockerImage() string                     { return m.dockerImage }
-func (m *mockProvider) AdjustContainerCommand(cmd string) string { return cmd }
+func (m *mockProvider) IsInstalled(_ context.Context) bool         { return true }
+func (m *mockProvider) Version(_ context.Context) string           { return "1.0.0" }
+func (m *mockProvider) DetectState(_ string) provider.State        { return provider.StateUnknown }
+func (m *mockProvider) DockerImage() string                        { return m.dockerImage }
+func (m *mockProvider) AdjustContainerCommand(cmd string) string   { return cmd }
 
 func TestImageForTool_WithContainerCustomizer(t *testing.T) {
 	registry := provider.NewRegistry()

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -60,9 +60,8 @@ type DockerRuntimeConfig struct {
 
 // LogsConfig configures persistent session log streaming.
 type LogsConfig struct {
-	Path         string `toml:"path"`
-	MaxBytes     int64  `toml:"max_bytes"`
-	PreserveAnsi bool   `toml:"preserve_ansi"`
+	Path     string `toml:"path"`
+	MaxBytes int64  `toml:"max_bytes"`
 }
 
 // UserConfig holds user identity settings.
@@ -92,10 +91,9 @@ type ProvidersConfig struct {
 
 // ProviderConfig defines an AI provider's configuration.
 type ProviderConfig struct {
-	Env     map[string]string `toml:"env"`             // Per-provider env vars
-	Command string            `toml:"command"`         // Command to launch the provider
-	Model   string            `toml:"model,omitempty"` // Default model (for API providers)
-	Enabled bool              `toml:"enabled"`         // Whether the provider is enabled
+	Env     map[string]string `toml:"env"`     // Per-provider env vars
+	Command string            `toml:"command"` // Command to launch the provider
+	Enabled bool              `toml:"enabled"` // Whether the provider is enabled
 }
 
 // ServicesConfig configures external service integrations (GitHub, GitLab, etc.).
@@ -107,10 +105,8 @@ type ServicesConfig struct {
 
 // ServiceConfig defines an external service integration.
 type ServiceConfig struct {
-	Command   string `toml:"command"`              // Command to execute (e.g., "gh")
-	TokenEnv  string `toml:"token_env,omitempty"`  // Environment variable for auth token
-	RateLimit int    `toml:"rate_limit,omitempty"` // Requests per hour (0 = unlimited)
-	Enabled   bool   `toml:"enabled"`              // Whether the service is enabled
+	Command string `toml:"command"` // Command to execute (e.g., "gh")
+	Enabled bool   `toml:"enabled"` // Whether the service is enabled
 }
 
 // PerformanceConfig configures TUI polling intervals and cache TTLs.
@@ -196,10 +192,10 @@ func DefaultConfig(name string) Config {
 				Enabled: true,
 			},
 		},
+		Env: map[string]string{},
 		Logs: LogsConfig{
-			Path:         ".bc/logs",
-			MaxBytes:     1048576, // 1MB
-			PreserveAnsi: true,
+			Path:     ".bc/logs",
+			MaxBytes: 1048576, // 1MB
 		},
 		User: UserConfig{
 			Nickname: DefaultNickname,

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -32,9 +32,6 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.Logs.MaxBytes != 1048576 {
 		t.Errorf("expected logs.max_bytes 1048576, got %d", cfg.Logs.MaxBytes)
 	}
-	if !cfg.Logs.PreserveAnsi {
-		t.Error("expected logs.preserve_ansi true")
-	}
 }
 
 func TestParseConfigWithLogs(t *testing.T) {
@@ -53,7 +50,6 @@ enabled = true
 [logs]
 path = ".bc/custom-logs"
 max_bytes = 2097152
-preserve_ansi = false
 `)
 	cfg, err := ParseConfig(tomlData)
 	if err != nil {
@@ -65,9 +61,6 @@ preserve_ansi = false
 	if cfg.Logs.MaxBytes != 2097152 {
 		t.Errorf("expected logs.max_bytes 2097152, got %d", cfg.Logs.MaxBytes)
 	}
-	if cfg.Logs.PreserveAnsi {
-		t.Error("expected logs.preserve_ansi false")
-	}
 }
 
 func TestLogsConfigSaveAndLoad(t *testing.T) {
@@ -77,7 +70,6 @@ func TestLogsConfigSaveAndLoad(t *testing.T) {
 	cfg := DefaultConfig("test")
 	cfg.Logs.Path = ".bc/my-logs"
 	cfg.Logs.MaxBytes = 512000
-	cfg.Logs.PreserveAnsi = false
 
 	if err := cfg.Save(path); err != nil {
 		t.Fatalf("failed to save: %v", err)
@@ -93,9 +85,6 @@ func TestLogsConfigSaveAndLoad(t *testing.T) {
 	}
 	if loaded.Logs.MaxBytes != 512000 {
 		t.Errorf("expected max_bytes 512000, got %d", loaded.Logs.MaxBytes)
-	}
-	if loaded.Logs.PreserveAnsi {
-		t.Error("expected preserve_ansi false")
 	}
 }
 

--- a/server/handlers/helpers_test.go
+++ b/server/handlers/helpers_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestClampInt(t *testing.T) {
 	tests := []struct {
-		name       string
+		name        string
 		n, min, max int
-		want       int
+		want        int
 	}{
 		{"within range", 5, 1, 10, 5},
 		{"below min", -1, 0, 10, 0},


### PR DESCRIPTION
## Summary
- Remove dead fields from workspace config: `ServiceConfig.TokenEnv`, `ServiceConfig.RateLimit`, `ProviderConfig.Model`, `LogsConfig.PreserveAnsi` (all confirmed unused via codebase-wide grep)
- Add `[env]` section to `DefaultConfig()` so `bc init` creates configs with the env map ready for use
- Update tests referencing removed fields
- Regenerate `config/config.go` from updated `config.toml`

Sub-issues 3-4 of #2388

## Test plan
- [x] All workspace package tests pass (`go test -race ./pkg/workspace/...`)
- [x] All package tests pass (`go test -race ./pkg/... ./config/...`)
- [x] `go vet` clean on changed packages
- [x] Confirmed each removed field is unused outside of config definition and config-specific tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)