### PR TITLE
feat(server): add settings API (#2388)

### DIFF
--- a/server/handlers/settings.go
+++ b/server/handlers/settings.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rpuneet/bc/pkg/workspace"
+)
+
+// SettingsHandler handles /api/settings routes.
+type SettingsHandler struct {
+	ws *workspace.Workspace
+}
+
+// NewSettingsHandler creates a SettingsHandler.
+func NewSettingsHandler(ws *workspace.Workspace) *SettingsHandler {
+	return &SettingsHandler{ws: ws}
+}
+
+// Register mounts settings routes on mux.
+func (h *SettingsHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/settings", h.handle)
+}
+
+func (h *SettingsHandler) handle(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		h.get(w, r)
+	case http.MethodPut:
+		h.put(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *SettingsHandler) get(w http.ResponseWriter, _ *http.Request) {
+	if h.ws.Config == nil {
+		httpError(w, "no config loaded", http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, h.ws.Config)
+}
+
+func (h *SettingsHandler) put(w http.ResponseWriter, r *http.Request) {
+	if h.ws.Config == nil {
+		httpError(w, "no config loaded", http.StatusInternalServerError)
+		return
+	}
+
+	// Decode partial update into a map to detect which fields are present.
+	var patch map[string]json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		httpError(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Start from current config (copy by value to avoid partial mutation on error).
+	merged := *h.ws.Config
+
+	// Apply each section if present in the patch.
+	if raw, ok := patch["user"]; ok {
+		if err := json.Unmarshal(raw, &merged.User); err != nil {
+			httpError(w, "invalid user config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["providers"]; ok {
+		if err := json.Unmarshal(raw, &merged.Providers); err != nil {
+			httpError(w, "invalid providers config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["env"]; ok {
+		if err := json.Unmarshal(raw, &merged.Env); err != nil {
+			httpError(w, "invalid env config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["logs"]; ok {
+		if err := json.Unmarshal(raw, &merged.Logs); err != nil {
+			httpError(w, "invalid logs config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["runtime"]; ok {
+		if err := json.Unmarshal(raw, &merged.Runtime); err != nil {
+			httpError(w, "invalid runtime config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["performance"]; ok {
+		if err := json.Unmarshal(raw, &merged.Performance); err != nil {
+			httpError(w, "invalid performance config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["tui"]; ok {
+		if err := json.Unmarshal(raw, &merged.TUI); err != nil {
+			httpError(w, "invalid tui config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["workspace"]; ok {
+		if err := json.Unmarshal(raw, &merged.Workspace); err != nil {
+			httpError(w, "invalid workspace config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["roster"]; ok {
+		if err := json.Unmarshal(raw, &merged.Roster); err != nil {
+			httpError(w, "invalid roster config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+	if raw, ok := patch["services"]; ok {
+		if err := json.Unmarshal(raw, &merged.Services); err != nil {
+			httpError(w, "invalid services config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Validate the merged config.
+	if err := merged.Validate(); err != nil {
+		httpError(w, "validation failed: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Update in-memory config and persist to disk.
+	*h.ws.Config = merged
+	if err := h.ws.Save(); err != nil {
+		httpError(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, h.ws.Config)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -217,6 +217,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		handlers.NewRolesHandler(svc.WS).Register(mux)
 		handlers.NewWorkspaceHandler(svc.Agents, svc.WS).Register(mux)
 		handlers.NewDoctorHandler(svc.WS).Register(mux)
+		handlers.NewSettingsHandler(svc.WS).Register(mux)
 	}
 
 	// Stats endpoints (always registered; nil-safe internally)


### PR DESCRIPTION
## Summary
- Add `GET /api/settings` endpoint that returns the full workspace config as JSON
- Add `PUT /api/settings` endpoint that accepts partial config updates, merges with existing config, validates, and persists to `.bc/config.toml`
- Register `SettingsHandler` in the server alongside other workspace handlers

Sub-issue 5 of #2388

## Test plan
- [ ] `GET /api/settings` returns full config JSON
- [ ] `PUT /api/settings` with partial body merges correctly (e.g. updating only `user.nickname` preserves all other sections)
- [ ] `PUT /api/settings` with invalid JSON returns 400
- [ ] `PUT /api/settings` with config that fails validation returns 400
- [ ] Unsupported methods return 405
- [ ] Saved config persists correctly as TOML in `.bc/config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)