### PR TITLE
fix(server): use workspace nickname as MCP default sender + path-based member delete

### DIFF
--- a/server/handlers/channels.go
+++ b/server/handlers/channels.go
@@ -80,15 +80,18 @@ func (h *ChannelHandler) byName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	switch sub {
-	case "":
+	switch {
+	case sub == "":
 		h.channel(w, r, name)
-	case "history":
+	case sub == "history":
 		h.history(w, r, name)
-	case "messages":
+	case sub == "messages":
 		h.postMessage(w, r, name)
-	case "members":
+	case sub == "members":
 		h.members(w, r, name)
+	case strings.HasPrefix(sub, "members/"):
+		agent := strings.TrimPrefix(sub, "members/")
+		h.memberByPath(w, r, name, agent)
 	default:
 		httpError(w, "not found", http.StatusNotFound)
 	}
@@ -206,4 +209,19 @@ func (h *ChannelHandler) members(w http.ResponseWriter, r *http.Request, name st
 	default:
 		methodNotAllowed(w)
 	}
+}
+
+func (h *ChannelHandler) memberByPath(w http.ResponseWriter, r *http.Request, name, agentName string) {
+	if !requireMethod(w, r, http.MethodDelete) {
+		return
+	}
+	if agentName == "" {
+		httpError(w, "agent name required", http.StatusBadRequest)
+		return
+	}
+	if err := h.svc.RemoveMember(r.Context(), name, agentName); err != nil {
+		httpError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -163,6 +163,13 @@ func (s *Server) toolSendMessage(raw json.RawMessage) (*toolsCallResult, error) 
 	sender := args.Sender
 	if sender == "" {
 		sender = "mcp"
+		if s.ws != nil {
+			nick := s.ws.Config.User.Nickname
+			nick = strings.TrimPrefix(nick, "@")
+			if nick != "" {
+				sender = nick
+			}
+		}
 	}
 
 	// Use ChannelService when available — its OnMessage hook handles agent


### PR DESCRIPTION
## Summary
- **MCP send_message default sender**: When the `sender` field is empty, the tool now reads `ws.Config.User.Nickname` (stripping the leading `@`) instead of hardcoding `"mcp"`. Falls back to `"mcp"` if workspace is nil.
- **Path-based member removal**: Added `DELETE /api/channels/{name}/members/{agent}` endpoint. The existing query-param route (`?agent_id=xxx`) is preserved for backward compatibility.

## Test plan
- [x] `make build` succeeds
- [x] `go test -race ./server/mcp/ ./server/handlers/` passes
- [x] Lint issues are all pre-existing (none introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)