### PR TITLE
feat(channel): highlight @mentions and link to agent detail page

### DIFF
--- a/web/src/components/MessageContent.tsx
+++ b/web/src/components/MessageContent.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
  * - **bold** text
  * - `code` backticks
  * - GitHub issue/PR references (#1234) become links
+ * - @mentions link to agent detail page
  */
 export function MessageContent({ content }: { content: string }) {
   return <>{parseContent(content)}</>;
@@ -18,7 +19,7 @@ function parseContent(text: string): ReactNode[] {
   // Split on patterns we want to handle, preserving delimiters
   // Order matters: URLs first (greedy), then bold, then code, then issue refs
   const pattern =
-    /(https?:\/\/[^\s<>)"']+)|(\*\*(?:[^*]|\*(?!\*))+\*\*)|(`[^`]+`)|(\B#\d+\b)/g;
+    /(https?:\/\/[^\s<>)"']+)|(\*\*(?:[^*]|\*(?!\*))+\*\*)|(`[^`]+`)|(\B#\d+\b)|(@[a-zA-Z0-9_-]+)/g;
 
   const nodes: ReactNode[] = [];
   let lastIndex = 0;
@@ -71,6 +72,18 @@ function parseContent(text: string): ReactNode[] {
           target="_blank"
           rel="noopener noreferrer"
           className="text-bc-accent underline-offset-2 hover:underline"
+        >
+          {full}
+        </a>,
+      );
+    } else if (match[5]) {
+      // @mention → link to agent detail page
+      const name = full.slice(1);
+      nodes.push(
+        <a
+          key={key}
+          href={`/agents/${name}`}
+          className="text-bc-accent font-medium hover:underline"
         >
           {full}
         </a>,


### PR DESCRIPTION
## Summary
- Add `@mention` detection (`@[a-zA-Z0-9_-]+`) to the existing regex pipeline in `MessageContent.tsx`
- Render @mentions as accent-colored links pointing to `/agents/{name}`
- URLs are matched first in the regex so `@`-text inside URLs is never incorrectly captured

Closes #2420

## Test plan
- [ ] Verify `@agent-name` in a channel message renders as a clickable link
- [ ] Verify clicking the link navigates to `/agents/agent-name`
- [ ] Verify @-text inside URLs (e.g. `https://example.com/@foo`) is not split out as a mention
- [ ] Verify existing formatting (bold, code, issue refs, plain URLs) still works

Generated with [Claude Code](https://claude.com/claude-code)