### PR TITLE
fix(server): filter message delivery to @mentioned agents only (#2421)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -166,8 +166,18 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 						log.Debug("channel send: failed to get channel", "channel", ch, "error", err)
 						return
 					}
+					// Parse @mentions to filter delivery targets.
+					// If mentions exist, only deliver to mentioned agents.
+					// If no mentions, deliver to all members (backward compat).
+					mentionedAgents, hasAll := channel.ExtractMentionedAgents(content)
+					hasMentions := hasAll || len(mentionedAgents) > 0
+
 					for _, member := range chDTO.Members {
 						if member == sender {
+							continue
+						}
+						// If mentions are present, only deliver to mentioned agents
+						if hasMentions && !channel.ContainsMention(content, member) {
 							continue
 						}
 						// Retry delivery up to 3 times


### PR DESCRIPTION
Closes #2421

## Summary
- When a channel message contains `@mentions`, only deliver to the mentioned agents' tmux/Docker sessions instead of broadcasting to all channel members
- Messages without mentions still deliver to all members (backward compatibility)
- SSE events are unaffected — the web UI continues to see all messages
- Reuses existing `channel.ExtractMentionedAgents` and `channel.ContainsMention` helpers which handle `@all`, case-insensitive matching, and deduplication

## Test plan
- [x] `go build ./server/...` compiles cleanly
- [x] `go vet ./server/...` passes
- [x] `go test -race ./server/...` passes
- [x] `go test -race ./pkg/channel/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)