### PR TITLE
fix: soft-delete agents to prevent reappearance after bcd restart

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -342,6 +342,7 @@ type Agent struct {
 	StartedAt      time.Time    `json:"started_at"`
 	CreatedAt      time.Time    `json:"created_at"`
 	StoppedAt      *time.Time   `json:"stopped_at,omitempty"`
+	DeletedAt      *time.Time   `json:"deleted_at,omitempty"`
 	RolePrompt     *AgentMemory `json:"memory,omitempty"`
 	Workspace      string       `json:"workspace"`
 	ID             string       `json:"id"`
@@ -1519,12 +1520,28 @@ func (m *Manager) DeleteAgentWithOptions(ctx context.Context, name string, opts 
 	// 8. Remove from parent's children list
 	m.removeFromParent(name)
 
-	// 9. Delete from state map and clean up per-agent lock
+	// 9. Soft-delete in SQLite first (set deleted_at) so the agent won't be
+	// resurrected by LoadAll even if bcd crashes before the hard delete.
+	if m.store != nil {
+		if err := m.store.SoftDelete(name); err != nil {
+			log.Warn("delete: failed to soft-delete agent in store", "agent", name, "error", err)
+		}
+	}
+
+	// 10. Delete from state map and clean up per-agent lock
 	delete(m.agents, name)
 	delete(m.agentLocks, name)
 
 	if err := m.saveState(); err != nil {
 		log.Warn("delete: failed to save state", "agent", name, "error", err)
+	}
+
+	// 11. Hard-delete the row from SQLite. The soft-delete above already
+	// prevents resurrection; this removes the row entirely for cleanliness.
+	if m.store != nil {
+		if err := m.store.Delete(name); err != nil {
+			log.Warn("delete: failed to remove agent from store", "agent", name, "error", err)
+		}
 	}
 	m.mu.Unlock()
 

--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -70,6 +70,7 @@ func createAgentsTable(d *db.DB) error {
 	_, _ = d.Exec(`ALTER TABLE agents ADD COLUMN ttl INTEGER NOT NULL DEFAULT 0`) //nolint:errcheck // ignore if already exists
 	_, _ = d.Exec(`ALTER TABLE agents ADD COLUMN created_at TEXT`)                //nolint:errcheck // ignore if already exists
 	_, _ = d.Exec(`ALTER TABLE agents ADD COLUMN stopped_at TEXT`)                //nolint:errcheck // ignore if already exists
+	_, _ = d.Exec(`ALTER TABLE agents ADD COLUMN deleted_at TEXT`)                //nolint:errcheck // ignore if already exists
 
 	// agent_stats: time-series Docker resource samples.
 	statsSchema := `
@@ -112,9 +113,9 @@ func (s *SQLiteStore) Save(a *Agent) error {
 		(name, role, state, tool, parent_id, team, task, session, workspace,
 		 worktree_dir, log_file, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
-		 runtime_backend, session_id, created_at, stopped_at,
+		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
 		 started_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.Name, string(a.Role), string(a.State),
 		nullStr(a.Tool), nullStr(a.ParentID), nullStr(a.Team), nullStr(a.Task),
 		nullStr(a.Session), a.Workspace,
@@ -123,7 +124,7 @@ func (s *SQLiteStore) Save(a *Agent) error {
 		boolToInt(a.IsRoot), a.CrashCount,
 		nullTime(a.LastCrashTime), nullStr(a.RecoveredFrom),
 		nullStr(a.RuntimeBackend), nullStr(a.SessionID),
-		formatTime(createdAt), nullTime(a.StoppedAt),
+		formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
 		formatTime(a.StartedAt), formatTime(now),
 	)
 	return err
@@ -157,15 +158,26 @@ func (s *SQLiteStore) LoadRoot() (*Agent, error) {
 	return a, nil
 }
 
+// SoftDelete marks an agent as deleted by setting deleted_at.
+// The agent row remains in the database but is excluded from LoadAll.
+func (s *SQLiteStore) SoftDelete(name string) error {
+	_, err := s.db.Exec(
+		"UPDATE agents SET deleted_at = ?, updated_at = ? WHERE name = ?",
+		formatTime(time.Now()), formatTime(time.Now()), name,
+	)
+	return err
+}
+
 // Delete removes a single agent by name.
 func (s *SQLiteStore) Delete(name string) error {
 	_, err := s.db.Exec("DELETE FROM agents WHERE name = ?", name)
 	return err
 }
 
-// LoadAll reads every agent into a map keyed by name.
+// LoadAll reads every non-deleted agent into a map keyed by name.
+// Agents with a non-null deleted_at are skipped to prevent resurrection after restart.
 func (s *SQLiteStore) LoadAll() (map[string]*Agent, error) {
-	rows, err := s.db.Query(agentSelectCols + ` FROM agents`)
+	rows, err := s.db.Query(agentSelectCols + ` FROM agents WHERE deleted_at IS NULL`)
 	if err != nil {
 		return nil, err
 	}
@@ -195,9 +207,9 @@ func (s *SQLiteStore) SaveAll(agents map[string]*Agent) error {
 		(name, role, state, tool, parent_id, team, task, session, workspace,
 		 worktree_dir, log_file, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
-		 runtime_backend, session_id, created_at, stopped_at,
+		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
 		 started_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -222,7 +234,7 @@ func (s *SQLiteStore) SaveAll(agents map[string]*Agent) error {
 			boolToInt(a.IsRoot), a.CrashCount,
 			nullTime(a.LastCrashTime), nullStr(a.RecoveredFrom),
 			nullStr(a.RuntimeBackend), nullStr(a.SessionID),
-			formatTime(createdAt), nullTime(a.StoppedAt),
+			formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
 			formatTime(a.StartedAt), formatTime(now),
 		)
 		if err != nil {
@@ -284,7 +296,7 @@ func (s *SQLiteStore) Close() error {
 const agentSelectCols = `SELECT name, role, state, tool, parent_id, team, task, session, workspace,
 	       worktree_dir, log_file, hooked_work, children,
 	       is_root, crash_count, last_crash_time, recovered_from,
-	       runtime_backend, session_id, created_at, stopped_at,
+	       runtime_backend, session_id, created_at, stopped_at, deleted_at,
 	       started_at, updated_at`
 
 func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
@@ -292,7 +304,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	var role, state string
 	var tool, parentID, team, task, session, worktreeDir, logFile, hookedWork, childrenJSON *string
 	var lastCrashTime, recoveredFrom, runtimeBackend, sessionID *string
-	var createdAt, stoppedAt *string
+	var createdAt, stoppedAt, deletedAt *string
 	var startedAt, updatedAt string
 	var isRoot, crashCount int
 
@@ -301,7 +313,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 		&tool, &parentID, &team, &task, &session, &a.Workspace,
 		&worktreeDir, &logFile, &hookedWork, &childrenJSON,
 		&isRoot, &crashCount, &lastCrashTime, &recoveredFrom,
-		&runtimeBackend, &sessionID, &createdAt, &stoppedAt,
+		&runtimeBackend, &sessionID, &createdAt, &stoppedAt, &deletedAt,
 		&startedAt, &updatedAt,
 	)
 	if err != nil {
@@ -341,6 +353,11 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	if stoppedAt != nil && *stoppedAt != "" {
 		if t, err := time.Parse(time.RFC3339, *stoppedAt); err == nil {
 			a.StoppedAt = &t
+		}
+	}
+	if deletedAt != nil && *deletedAt != "" {
+		if t, err := time.Parse(time.RFC3339, *deletedAt); err == nil {
+			a.DeletedAt = &t
 		}
 	}
 	a.StartedAt, _ = time.Parse(time.RFC3339, startedAt)

--- a/pkg/agent/store_sqlite_test.go
+++ b/pkg/agent/store_sqlite_test.go
@@ -253,3 +253,101 @@ func TestSQLiteStore_ConcurrentAccess(t *testing.T) {
 		t.Errorf("s2 sees %d agents, want 2", len(all2))
 	}
 }
+
+func TestSQLiteStore_SoftDelete(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSQLiteStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	// Save two agents
+	for _, name := range []string{"keep", "remove"} {
+		_ = store.Save(&Agent{
+			Name:      name,
+			Role:      Role("worker"),
+			State:     StateIdle,
+			Workspace: "/tmp/ws",
+			StartedAt: time.Now(),
+		})
+	}
+
+	// Soft-delete one agent
+	if softErr := store.SoftDelete("remove"); softErr != nil {
+		t.Fatalf("SoftDelete: %v", softErr)
+	}
+
+	// LoadAll should exclude the soft-deleted agent
+	all, err := store.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("LoadAll returned %d agents, want 1", len(all))
+	}
+	if _, ok := all["keep"]; !ok {
+		t.Error("expected 'keep' agent to be present")
+	}
+	if _, ok := all["remove"]; ok {
+		t.Error("soft-deleted 'remove' agent should not appear in LoadAll")
+	}
+
+	// Direct Load should still find the soft-deleted agent (row exists)
+	removed, err := store.Load("remove")
+	if err != nil {
+		t.Fatalf("Load soft-deleted: %v", err)
+	}
+	if removed == nil {
+		t.Fatal("Load should still return the soft-deleted agent row")
+	}
+	if removed.DeletedAt == nil {
+		t.Error("DeletedAt should be set on soft-deleted agent")
+	}
+
+	// Hard-delete should remove the row entirely
+	if err := store.Delete("remove"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	after, _ := store.Load("remove")
+	if after != nil {
+		t.Error("expected nil after hard delete")
+	}
+}
+
+func TestSQLiteStore_DeletedAtPersistence(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "state.db")
+
+	// First session: create and soft-delete an agent
+	store1, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	_ = store1.Save(&Agent{
+		Name:      "zombie",
+		Role:      Role("worker"),
+		State:     StateIdle,
+		Workspace: "/tmp/ws",
+		StartedAt: time.Now(),
+	})
+	if softErr := store1.SoftDelete("zombie"); softErr != nil {
+		t.Fatalf("SoftDelete: %v", softErr)
+	}
+	_ = store1.Close()
+
+	// Second session: simulate bcd restart
+	store2, err := NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore after restart: %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+
+	all, err := store2.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll after restart: %v", err)
+	}
+	if len(all) != 0 {
+		t.Fatalf("expected 0 agents after restart, got %d (soft-deleted agent resurrected)", len(all))
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #2372 — deleted agents reappear after bcd restart.

Root cause: `SaveAll()` only writes in-memory agents. When an agent is deleted from the map, its SQLite row persists. `LoadState()` reads all rows on restart, resurrecting deleted agents.

Fix: Add `deleted_at` column to SQLite agent store with soft-delete semantics:
- `SoftDelete(name)` sets timestamp before removing from memory
- `LoadAll()` filters `WHERE deleted_at IS NULL`
- Hard `Delete(name)` removes the row entirely after state is saved

## Changes
- `pkg/agent/agent.go` — `DeletedAt` field on Agent struct, soft-delete in delete flow
- `pkg/agent/store_sqlite.go` — column migration, `SoftDelete()`, filtered `LoadAll()`
- `pkg/agent/store_sqlite_test.go` — 2 tests: soft-delete filtering + restart persistence

## Test plan
- [x] `TestSQLiteStore_SoftDelete` — verifies soft-deleted agent excluded from LoadAll
- [x] `TestSQLiteStore_DeletedAtPersistence` — simulates restart, verifies no resurrection
- [x] All agent package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)