### PR TITLE
fix: pre-seed Claude settings to skip theme prompt in Docker agents

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -264,6 +264,13 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 		args = append(args, "-v", mount)
 	}
 
+	// Pre-seed Claude settings to skip interactive theme selection prompt.
+	// Claude Code shows an interactive theme picker on first run when no
+	// settings exist, which blocks headless Docker agents indefinitely.
+	if err := SeedClaudeSettings(volumeDir); err != nil {
+		log.Warn("failed to seed claude settings", "agent", name, "error", err)
+	}
+
 	// Environment variables — only from the env map.
 	// The env map contains BC_* identity vars and role secrets resolved
 	// from bc env by the agent manager's injectEnv().

--- a/pkg/container/settings.go
+++ b/pkg/container/settings.go
@@ -1,0 +1,33 @@
+package container
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// defaultClaudeSettings is the minimal settings file that prevents the
+// interactive theme selection prompt on first run of Claude Code.
+var defaultClaudeSettings = map[string]string{
+	"theme": "dark",
+}
+
+// SeedClaudeSettings writes a default settings.json into the given Claude
+// volume directory if one does not already exist. This prevents Docker agents
+// from getting stuck on the interactive theme picker that Claude Code shows
+// on first run.
+func SeedClaudeSettings(volumeDir string) error {
+	settingsPath := filepath.Join(volumeDir, "settings.json")
+
+	// Don't overwrite existing settings — the agent may have customized them.
+	if _, err := os.Stat(settingsPath); err == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(defaultClaudeSettings)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(settingsPath, data, 0600)
+}

--- a/pkg/container/settings_test.go
+++ b/pkg/container/settings_test.go
@@ -1,0 +1,53 @@
+package container
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSeedClaudeSettings_CreatesFile(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := SeedClaudeSettings(dir); err != nil {
+		t.Fatalf("SeedClaudeSettings() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "settings.json")) //nolint:gosec // test uses temp dir
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+
+	var settings map[string]string
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("failed to parse settings.json: %v", err)
+	}
+
+	if settings["theme"] != "dark" {
+		t.Errorf("theme = %q, want %q", settings["theme"], "dark")
+	}
+}
+
+func TestSeedClaudeSettings_PreservesExisting(t *testing.T) {
+	dir := t.TempDir()
+
+	existing := []byte(`{"theme":"light","custom":"value"}`)
+	settingsPath := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(settingsPath, existing, 0600); err != nil { //nolint:gosec // test uses temp dir
+		t.Fatalf("failed to write existing settings: %v", err)
+	}
+
+	if err := SeedClaudeSettings(dir); err != nil {
+		t.Fatalf("SeedClaudeSettings() error = %v", err)
+	}
+
+	data, err := os.ReadFile(settingsPath) //nolint:gosec // test uses temp dir
+	if err != nil {
+		t.Fatalf("failed to read settings.json: %v", err)
+	}
+
+	if string(data) != string(existing) {
+		t.Errorf("settings.json was modified: got %q, want %q", string(data), string(existing))
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #2459 — Docker agents get stuck on Claude Code's first-run theme selection prompt.

Pre-seeds `settings.json` with `{"theme":"dark"}` in the agent's Claude volume directory before the container starts. Only writes if the file doesn't exist (preserves existing settings).

## Changes
- `pkg/container/container.go` — call `SeedClaudeSettings` after volume dir creation
- `pkg/container/settings.go` — new `SeedClaudeSettings` function
- `pkg/container/settings_test.go` — tests for creation and no-overwrite

## Test plan
- [x] Settings file created with correct theme
- [x] Existing settings not overwritten
- [x] Container package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)