### PR TITLE
feat: add remove, enable/disable actions to MCP page

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -293,6 +293,9 @@ export const api = {
   listRoles: () => request<Record<string, Role>>('/workspace/roles'),
   listTools: () => request<Tool[]>('/tools'),
   listMCP: () => request<MCPServer[]>('/mcp'),
+  removeMCP: (name: string) => request<void>(`/mcp/${encodeURIComponent(name)}`, { method: 'DELETE' }),
+  enableMCP: (name: string) => request<void>(`/mcp/${encodeURIComponent(name)}/enable`, { method: 'POST' }),
+  disableMCP: (name: string) => request<void>(`/mcp/${encodeURIComponent(name)}/disable`, { method: 'POST' }),
   getLogs: (tail = 50) => request<EventLogEntry[]>(`/logs?${new URLSearchParams({ tail: String(tail) })}`),
   getDoctor: () => request<DoctorReport>('/doctor'),
 

--- a/web/src/views/MCP.tsx
+++ b/web/src/views/MCP.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { api } from '../api/client';
 import type { MCPServer } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
@@ -9,6 +9,37 @@ import { EmptyState } from '../components/EmptyState';
 export function MCP() {
   const fetcher = useCallback(() => api.listMCP(), []);
   const { data: servers, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<string | null>(null);
+
+  const handleToggle = useCallback(async (name: string, currentlyEnabled: boolean) => {
+    setActionLoading(`toggle:${name}`);
+    try {
+      if (currentlyEnabled) {
+        await api.disableMCP(name);
+      } else {
+        await api.enableMCP(name);
+      }
+      refresh();
+    } catch {
+      // Error will show on next poll
+    } finally {
+      setActionLoading(null);
+    }
+  }, [refresh]);
+
+  const handleRemove = useCallback(async (name: string) => {
+    setActionLoading(`remove:${name}`);
+    try {
+      await api.removeMCP(name);
+      refresh();
+    } catch {
+      // Error will show on next poll
+    } finally {
+      setActionLoading(null);
+      setConfirmRemove(null);
+    }
+  }, [refresh]);
 
   if (loading && !servers) {
     return (
@@ -59,9 +90,31 @@ export function MCP() {
     },
     {
       key: 'enabled', label: 'Status', render: (s: MCPServer) => (
-        <span className={s.enabled ? 'text-green-400' : 'text-bc-muted'}>
-          {s.enabled ? 'enabled' : 'disabled'}
-        </span>
+        <button
+          type="button"
+          disabled={actionLoading !== null}
+          onClick={(e) => { e.stopPropagation(); handleToggle(s.name, s.enabled); }}
+          className={`inline-flex items-center gap-1.5 text-xs px-2 py-1 rounded border transition-colors disabled:opacity-50 ${
+            s.enabled
+              ? 'text-green-400 border-green-400/30 hover:bg-green-400/10'
+              : 'text-bc-muted border-bc-border hover:text-bc-text hover:border-bc-text/30'
+          }`}
+        >
+          <span className={`inline-block w-1.5 h-1.5 rounded-full ${s.enabled ? 'bg-green-400' : 'bg-bc-muted'}`} />
+          {actionLoading === `toggle:${s.name}` ? 'Updating...' : s.enabled ? 'Enabled' : 'Disabled'}
+        </button>
+      ),
+    },
+    {
+      key: 'actions', label: '', render: (s: MCPServer) => (
+        <button
+          type="button"
+          disabled={actionLoading !== null}
+          onClick={(e) => { e.stopPropagation(); setConfirmRemove(s.name); }}
+          className="px-2 py-1 text-xs rounded border border-bc-border text-bc-muted hover:text-red-400 hover:border-red-400/50 transition-colors disabled:opacity-50"
+        >
+          Remove
+        </button>
       ),
     },
   ];
@@ -83,6 +136,37 @@ export function MCP() {
           emptyDescription="Use 'bc mcp add <name>' to connect an MCP server."
         />
       </div>
+
+      {/* Confirmation dialog for removal */}
+      {confirmRemove && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-bc-surface border border-bc-border rounded-lg p-6 max-w-sm w-full mx-4 space-y-4">
+            <h2 className="text-lg font-bold">Remove MCP server</h2>
+            <p className="text-sm text-bc-muted">
+              Are you sure you want to remove{' '}
+              <span className="font-medium text-bc-text">{confirmRemove}</span>?
+              {' '}This cannot be undone.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmRemove(null)}
+                className="px-3 py-1.5 text-sm rounded border border-bc-border text-bc-muted hover:text-bc-text transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={actionLoading !== null}
+                onClick={() => handleRemove(confirmRemove)}
+                className="px-3 py-1.5 text-sm rounded border border-red-400/50 text-red-400 hover:bg-red-400/10 font-medium transition-colors disabled:opacity-50"
+              >
+                {actionLoading ? 'Removing...' : 'Remove'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `removeMCP`, `enableMCP`, `disableMCP` API methods to `web/src/api/client.ts`
- Convert the MCP status column into a clickable enable/disable toggle button with visual indicator
- Add a "Remove" button per server row
- Show a confirmation dialog before removing a server
- Refresh the server list after any action completes

## Test plan
- [ ] Navigate to `/mcp` page and verify servers display correctly
- [ ] Click the enable/disable toggle on a server and verify state changes
- [ ] Click "Remove" on a server, verify confirmation dialog appears
- [ ] Cancel the confirmation dialog and verify no action is taken
- [ ] Confirm removal and verify the server is removed and list refreshes
- [ ] Verify buttons are disabled while an action is in progress

Closes #2444

Generated with [Claude Code](https://claude.com/claude-code)