### PR TITLE
feat: add enable/disable/delete actions to /tools page

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -292,6 +292,12 @@ export const api = {
 
   listRoles: () => request<Record<string, Role>>('/workspace/roles'),
   listTools: () => request<Tool[]>('/tools'),
+  enableTool: (name: string) =>
+    request<{ enabled: boolean }>(`/tools/${encodeURIComponent(name)}/enable`, { method: 'POST' }),
+  disableTool: (name: string) =>
+    request<{ enabled: boolean }>(`/tools/${encodeURIComponent(name)}/disable`, { method: 'POST' }),
+  deleteTool: (name: string) =>
+    request<void>(`/tools/${encodeURIComponent(name)}`, { method: 'DELETE' }),
   listMCP: () => request<MCPServer[]>('/mcp'),
   getLogs: (tail = 50) => request<EventLogEntry[]>(`/logs?${new URLSearchParams({ tail: String(tail) })}`),
   getDoctor: () => request<DoctorReport>('/doctor'),

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { api } from '../api/client';
 import type { Tool } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
@@ -9,6 +9,37 @@ import { EmptyState } from '../components/EmptyState';
 export function Tools() {
   const fetcher = useCallback(() => api.listTools(), []);
   const { data: tools, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+
+  const toggleEnabled = useCallback(async (name: string, currentlyEnabled: boolean) => {
+    setActionLoading(`toggle:${name}`);
+    try {
+      if (currentlyEnabled) {
+        await api.disableTool(name);
+      } else {
+        await api.enableTool(name);
+      }
+      refresh();
+    } catch {
+      // Error will show on next poll
+    } finally {
+      setActionLoading(null);
+    }
+  }, [refresh]);
+
+  const deleteTool = useCallback(async (name: string) => {
+    setActionLoading(`delete:${name}`);
+    try {
+      await api.deleteTool(name);
+      refresh();
+    } catch {
+      // Error will show on next poll
+    } finally {
+      setActionLoading(null);
+      setConfirmDelete(null);
+    }
+  }, [refresh]);
 
   if (loading && !tools) {
     return (
@@ -65,6 +96,34 @@ export function Tools() {
         <code className="text-xs text-bc-muted">{t.install_cmd || '\u2014'}</code>
       ),
     },
+    {
+      key: 'actions', label: 'Actions', render: (t: Tool) => (
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            disabled={actionLoading !== null}
+            onClick={(e) => { e.stopPropagation(); toggleEnabled(t.name, t.enabled); }}
+            className={`px-2 py-1 text-xs rounded border border-bc-border transition-colors disabled:opacity-50 ${
+              t.enabled
+                ? 'text-bc-muted hover:text-yellow-400 hover:border-yellow-400/50'
+                : 'text-bc-muted hover:text-green-400 hover:border-green-400/50'
+            }`}
+          >
+            {actionLoading === `toggle:${t.name}` ? '...' : t.enabled ? 'Disable' : 'Enable'}
+          </button>
+          {!t.builtin && (
+            <button
+              type="button"
+              disabled={actionLoading !== null}
+              onClick={(e) => { e.stopPropagation(); setConfirmDelete(t.name); }}
+              className="px-2 py-1 text-xs rounded border border-bc-border text-bc-muted hover:text-red-400 hover:border-red-400/50 transition-colors disabled:opacity-50"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      ),
+    },
   ];
 
   return (
@@ -84,6 +143,37 @@ export function Tools() {
           emptyDescription="Add tools in your config.toml [tools] section."
         />
       </div>
+
+      {/* Delete confirmation dialog */}
+      {confirmDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-bc-surface border border-bc-border rounded-lg p-6 max-w-sm w-full mx-4 space-y-4">
+            <h2 className="text-lg font-bold">Delete tool</h2>
+            <p className="text-sm text-bc-muted">
+              Are you sure you want to delete{' '}
+              <span className="font-medium text-bc-text">{confirmDelete}</span>?
+              {' '}This cannot be undone.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(null)}
+                className="px-3 py-1.5 text-sm rounded border border-bc-border text-bc-muted hover:text-bc-text transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                disabled={actionLoading !== null}
+                onClick={() => deleteTool(confirmDelete)}
+                className="px-3 py-1.5 text-sm rounded border border-red-400/50 text-red-400 hover:bg-red-400/10 font-medium transition-colors disabled:opacity-50"
+              >
+                {actionLoading ? 'Deleting...' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add **Enable/Disable toggle** button per tool row, calling `POST /api/tools/{name}/enable` or `/disable`
- Add **Delete button** (custom tools only) with a confirmation modal, calling `DELETE /api/tools/{name}`
- Tool list auto-refreshes after any action
- Add `enableTool`, `disableTool`, `deleteTool` methods to the API client

## Test plan
- [ ] Navigate to /tools page and verify action buttons appear in each row
- [ ] Click Enable/Disable on a tool and verify the toggle updates after refresh
- [ ] Click Delete on a custom tool, verify confirmation modal appears
- [ ] Confirm deletion and verify the tool is removed from the list
- [ ] Verify built-in tools do not show a Delete button
- [ ] Verify buttons are disabled while an action is in progress

Closes #2443

Generated with [Claude Code](https://claude.com/claude-code)