### PR TITLE
feat(web): add CRUD and run/logs to cron page

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -154,6 +154,17 @@ export interface CronJob {
   created_at: string;
 }
 
+export interface CronLogEntry {
+  id: number;
+  job_name: string;
+  status: string;
+  output: string;
+  error: string;
+  started_at: string;
+  finished_at: string;
+  duration_ms: number;
+}
+
 export interface Secret {
   name: string;
   description: string;
@@ -297,6 +308,18 @@ export const api = {
   getDoctor: () => request<DoctorReport>('/doctor'),
 
   listCron: () => request<CronJob[]>('/cron'),
+  createCron: (job: { name: string; schedule: string; command: string }) =>
+    request<CronJob>('/cron', { method: 'POST', body: JSON.stringify(job) }),
+  runCron: (name: string) =>
+    request<void>(`/cron/${encodeURIComponent(name)}/run`, { method: 'POST' }),
+  enableCron: (name: string) =>
+    request<void>(`/cron/${encodeURIComponent(name)}/enable`, { method: 'POST' }),
+  disableCron: (name: string) =>
+    request<void>(`/cron/${encodeURIComponent(name)}/disable`, { method: 'POST' }),
+  deleteCron: (name: string) =>
+    request<void>(`/cron/${encodeURIComponent(name)}`, { method: 'DELETE' }),
+  getCronLogs: (name: string) =>
+    request<CronLogEntry[]>(`/cron/${encodeURIComponent(name)}/logs`),
   listSecrets: () => request<Secret[]>('/secrets'),
   getWorkspace: () => request<WorkspaceInfo>('/workspace'),
   getWorkspaceStatus: () => request<Record<string, unknown>>('/workspace/status'),

--- a/web/src/components/Table.tsx
+++ b/web/src/components/Table.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { EmptyState } from './EmptyState';
 
 interface Column<T> {
@@ -15,9 +16,10 @@ interface TableProps<T> {
   emptyMessage?: string;
   emptyIcon?: string;
   emptyDescription?: string;
+  renderRowExpansion?: (row: T) => React.ReactNode | null;
 }
 
-export function Table<T>({ columns, data, keyFn, onRowClick, emptyMessage = 'No data', emptyIcon, emptyDescription }: TableProps<T>) {
+export function Table<T>({ columns, data, keyFn, onRowClick, emptyMessage = 'No data', emptyIcon, emptyDescription, renderRowExpansion }: TableProps<T>) {
   if (!data || data.length === 0) {
     return <EmptyState icon={emptyIcon} title={emptyMessage} description={emptyDescription} />;
   }
@@ -34,21 +36,32 @@ export function Table<T>({ columns, data, keyFn, onRowClick, emptyMessage = 'No 
         </tr>
       </thead>
       <tbody>
-        {data.map((row) => (
-          <tr
-            key={keyFn(row)}
-            onClick={onRowClick ? () => onRowClick(row) : undefined}
-            className={`border-b border-bc-border/50 ${
-              onRowClick ? 'cursor-pointer hover:bg-bc-surface' : ''
-            }`}
-          >
-            {columns.map((col) => (
-              <td key={col.key} className={`px-4 py-2 ${col.className ?? ''}`}>
-                {col.render(row)}
-              </td>
-            ))}
-          </tr>
-        ))}
+        {data.map((row) => {
+          const expansion = renderRowExpansion ? renderRowExpansion(row) : null;
+          return (
+            <React.Fragment key={keyFn(row)}>
+              <tr
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                className={`border-b border-bc-border/50 ${
+                  onRowClick ? 'cursor-pointer hover:bg-bc-surface' : ''
+                }`}
+              >
+                {columns.map((col) => (
+                  <td key={col.key} className={`px-4 py-2 ${col.className ?? ''}`}>
+                    {col.render(row)}
+                  </td>
+                ))}
+              </tr>
+              {expansion && (
+                <tr>
+                  <td colSpan={columns.length} className="p-0">
+                    {expansion}
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/web/src/views/Cron.tsx
+++ b/web/src/views/Cron.tsx
@@ -1,14 +1,145 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { api } from '../api/client';
-import type { CronJob } from '../api/client';
+import type { CronJob, CronLogEntry } from '../api/client';
 import { usePolling } from '../hooks/usePolling';
 import { Table } from '../components/Table';
 import { LoadingSkeleton } from '../components/LoadingSkeleton';
 import { EmptyState } from '../components/EmptyState';
 
+function CreateCronForm({ onSave, onCancel }: { onSave: () => void; onCancel: () => void }) {
+  const [name, setName] = useState('');
+  const [schedule, setSchedule] = useState('');
+  const [command, setCommand] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !schedule.trim() || !command.trim()) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.createCron({ name: name.trim(), schedule: schedule.trim(), command: command.trim() });
+      onSave();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create cron job');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded border border-bc-border bg-bc-bg-secondary p-4 space-y-3">
+      <div className="flex items-center gap-3">
+        <input
+          type="text"
+          placeholder="Job name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="flex-1 rounded border border-bc-border bg-bc-bg px-3 py-1.5 text-sm text-bc-text placeholder:text-bc-muted focus:outline-none focus:border-bc-accent"
+          autoFocus
+        />
+        <input
+          type="text"
+          placeholder="Schedule (e.g. */5 * * * *)"
+          value={schedule}
+          onChange={(e) => setSchedule(e.target.value)}
+          className="flex-1 rounded border border-bc-border bg-bc-bg px-3 py-1.5 text-sm text-bc-text placeholder:text-bc-muted focus:outline-none focus:border-bc-accent"
+        />
+        <input
+          type="text"
+          placeholder="Command"
+          value={command}
+          onChange={(e) => setCommand(e.target.value)}
+          className="flex-[2] rounded border border-bc-border bg-bc-bg px-3 py-1.5 text-sm text-bc-text placeholder:text-bc-muted focus:outline-none focus:border-bc-accent"
+        />
+      </div>
+      {error && <p className="text-sm text-red-400">{error}</p>}
+      <div className="flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={saving || !name.trim() || !schedule.trim() || !command.trim()}
+          className="rounded bg-bc-accent px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+        >
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded border border-bc-border px-3 py-1.5 text-sm text-bc-muted hover:text-bc-text"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function CronLogs({ jobName }: { jobName: string }) {
+  const fetcher = useCallback(() => api.getCronLogs(jobName), [jobName]);
+  const { data: logs, loading, error } = usePolling(fetcher, 15000);
+
+  if (loading && !logs) {
+    return <div className="px-4 py-2 text-sm text-bc-muted">Loading logs...</div>;
+  }
+  if (error) {
+    return <div className="px-4 py-2 text-sm text-red-400">Failed to load logs: {error}</div>;
+  }
+  if (!logs || logs.length === 0) {
+    return <div className="px-4 py-2 text-sm text-bc-muted">No execution logs yet.</div>;
+  }
+
+  return (
+    <div className="border-t border-bc-border bg-bc-bg-secondary">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-bc-border text-left text-xs text-bc-muted">
+            <th className="px-4 py-1.5">Status</th>
+            <th className="px-4 py-1.5">Started</th>
+            <th className="px-4 py-1.5">Duration</th>
+            <th className="px-4 py-1.5">Output</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log: CronLogEntry) => (
+            <tr key={log.id} className="border-b border-bc-border/50 last:border-0">
+              <td className="px-4 py-1.5">
+                <span className={log.status === 'success' ? 'text-green-400' : log.status === 'running' ? 'text-yellow-400' : 'text-red-400'}>
+                  {log.status}
+                </span>
+              </td>
+              <td className="px-4 py-1.5 text-bc-muted">{new Date(log.started_at).toLocaleString()}</td>
+              <td className="px-4 py-1.5 text-bc-muted">{log.duration_ms}ms</td>
+              <td className="px-4 py-1.5 text-bc-muted truncate max-w-xs">
+                {log.error || log.output || '\u2014'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export function Cron() {
   const fetcher = useCallback(() => api.listCron(), []);
   const { data: jobs, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
+  const [showCreate, setShowCreate] = useState(false);
+  const [expandedJob, setExpandedJob] = useState<string | null>(null);
+  const [deleteConfirm, setDeleteConfirm] = useState<string | null>(null);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+
+  const handleAction = async (action: () => Promise<unknown>, key: string) => {
+    setActionLoading(key);
+    try {
+      await action();
+      refresh();
+    } catch {
+      // Error is transient; refresh will show current state
+    } finally {
+      setActionLoading(null);
+    }
+  };
 
   if (loading && !jobs) {
     return (
@@ -46,7 +177,17 @@ export function Cron() {
   }
 
   const columns = [
-    { key: 'name', label: 'Name', render: (j: CronJob) => <span className="font-medium">{j.name}</span> },
+    {
+      key: 'name', label: 'Name', render: (j: CronJob) => (
+        <button
+          type="button"
+          onClick={() => setExpandedJob(expandedJob === j.name ? null : j.name)}
+          className="font-medium text-bc-accent hover:underline cursor-pointer bg-transparent border-none p-0"
+        >
+          {expandedJob === j.name ? '\u25BC' : '\u25B6'} {j.name}
+        </button>
+      ),
+    },
     { key: 'schedule', label: 'Schedule', render: (j: CronJob) => <code className="text-xs text-bc-muted">{j.schedule}</code> },
     { key: 'agent', label: 'Agent', render: (j: CronJob) => <span>{j.agent_name || '\u2014'}</span> },
     {
@@ -64,14 +205,84 @@ export function Cron() {
         </span>
       ),
     },
+    {
+      key: 'actions', label: 'Actions', render: (j: CronJob) => (
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            title="Run now"
+            disabled={actionLoading === `run-${j.name}`}
+            onClick={() => handleAction(() => api.runCron(j.name), `run-${j.name}`)}
+            className="rounded border border-bc-border px-2 py-0.5 text-xs text-bc-muted hover:text-bc-text hover:border-bc-accent disabled:opacity-50"
+          >
+            {actionLoading === `run-${j.name}` ? '...' : 'Run'}
+          </button>
+          <button
+            type="button"
+            title={j.enabled ? 'Disable' : 'Enable'}
+            disabled={actionLoading === `toggle-${j.name}`}
+            onClick={() => handleAction(
+              () => j.enabled ? api.disableCron(j.name) : api.enableCron(j.name),
+              `toggle-${j.name}`,
+            )}
+            className="rounded border border-bc-border px-2 py-0.5 text-xs text-bc-muted hover:text-bc-text hover:border-bc-accent disabled:opacity-50"
+          >
+            {actionLoading === `toggle-${j.name}` ? '...' : j.enabled ? 'Disable' : 'Enable'}
+          </button>
+          {deleteConfirm === j.name ? (
+            <>
+              <button
+                type="button"
+                onClick={() => { handleAction(() => api.deleteCron(j.name), `del-${j.name}`); setDeleteConfirm(null); }}
+                className="rounded border border-red-500 px-2 py-0.5 text-xs text-red-400 hover:bg-red-500/10"
+              >
+                Confirm
+              </button>
+              <button
+                type="button"
+                onClick={() => setDeleteConfirm(null)}
+                className="rounded border border-bc-border px-2 py-0.5 text-xs text-bc-muted hover:text-bc-text"
+              >
+                No
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              title="Delete"
+              onClick={() => setDeleteConfirm(j.name)}
+              className="rounded border border-bc-border px-2 py-0.5 text-xs text-red-400 hover:border-red-500 hover:bg-red-500/10 disabled:opacity-50"
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      ),
+    },
   ];
 
   return (
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">Cron Jobs</h1>
-        <span className="text-sm text-bc-muted">{jobs?.length ?? 0} jobs</span>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-bc-muted">{jobs?.length ?? 0} jobs</span>
+          <button
+            type="button"
+            onClick={() => setShowCreate(!showCreate)}
+            className="rounded bg-bc-accent px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+          >
+            {showCreate ? 'Cancel' : '+ Create'}
+          </button>
+        </div>
       </div>
+
+      {showCreate && (
+        <CreateCronForm
+          onSave={() => { setShowCreate(false); refresh(); }}
+          onCancel={() => setShowCreate(false)}
+        />
+      )}
 
       <div className="rounded border border-bc-border overflow-hidden">
         <Table
@@ -81,6 +292,9 @@ export function Cron() {
           emptyMessage="No cron jobs"
           emptyIcon="~"
           emptyDescription="Use 'bc cron add <name>' to schedule recurring tasks."
+          renderRowExpansion={(j: CronJob) =>
+            expandedJob === j.name ? <CronLogs jobName={j.name} /> : null
+          }
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Adds inline create form (name, schedule, command) with Save/Cancel to the `/cron` page
- Adds per-row action buttons: Run (manual trigger), Enable/Disable toggle, Delete (with confirmation dialog)
- Clicking a job name expands the row to show execution logs fetched from `GET /api/cron/{name}/logs`
- Adds `CronLogEntry` type and 6 new API methods to `web/src/api/client.ts`
- Extends the `Table` component with a `renderRowExpansion` prop for expandable rows

## Test plan
- [ ] Verify create form appears/disappears when clicking +Create/Cancel
- [ ] Create a cron job and confirm it appears in the table
- [ ] Click Run and verify the job triggers (check run count increments)
- [ ] Toggle Enable/Disable and confirm status updates
- [ ] Click Delete, verify confirmation prompt, confirm deletion removes the row
- [ ] Click a job name to expand logs, verify log entries render correctly
- [ ] Verify build passes with `cd web && bun run build`

Closes #2445

Generated with [Claude Code](https://claude.com/claude-code)