### PR TITLE
fix(web): fix eslint errors and update Cron test

### DIFF
--- a/web/src/utils/text.ts
+++ b/web/src/utils/text.ts
@@ -1,9 +1,13 @@
 /** Strip ANSI escape codes (CSI, OSC, charset) from terminal output. */
+// eslint-disable-next-line no-control-regex
+const CSI = /\x1b\[[0-9;]*[a-zA-Z]/g;
+// eslint-disable-next-line no-control-regex
+const OSC = /\x1b\][^\x07]*\x07/g;
+// eslint-disable-next-line no-control-regex
+const CHARSET = /\x1b\(B/g;
+
 export function stripAnsi(str: string): string {
-  return str
-    .replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '')
-    .replace(/\x1b\][^\x07]*\x07/g, '')
-    .replace(/\x1b\(B/g, '');
+  return str.replace(CSI, '').replace(OSC, '').replace(CHARSET, '');
 }
 
 /** Truncate string to maxLen characters with ellipsis. */

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -191,7 +191,8 @@ describe('Cron', () => {
     const { container } = wrap(<Cron />);
     expectSkeletonLoading(container);
     await waitFor(() => {
-      expect(screen.getByText('nightly')).toBeInTheDocument();
+      expect(screen.getByText('Cron Jobs')).toBeInTheDocument();
+      expect(screen.getByText(/nightly/)).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Fixes 3 no-control-regex lint errors in utils/text.ts and updates Cron test for new CRUD view layout.