### PR TITLE
fix: close channel store on daemon shutdown

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -262,6 +262,11 @@ func runDaemonStart(cmd *cobra.Command, _ []string) error {
 			return cronStore.Close()
 		})
 	}
+	if chStore != nil {
+		shutdown.OnShutdownNamed(shutdown.PriorityLow, "bcd-channel-db", func(_ context.Context) error {
+			return chStore.Close()
+		})
+	}
 
 	fmt.Printf("bcd listening on %s (workspace: %s)\n", cfg.Addr, ws.RootDir)
 	fmt.Println("Press Ctrl+C to stop")


### PR DESCRIPTION
## Summary
- Register `chStore.Close()` as a shutdown handler in `bc daemon start`
- Ensures SQLite WAL files are properly checkpointed on SIGTERM
- Matches the pattern already used for `daemonMgr` and `cronStore`

Closes #2479

## Test plan
- [x] `make ci-local` passes
- [ ] Start bcd, send SIGTERM, verify no WAL file remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)