### PR TITLE
fix: enforce 64-char max length on channel names

### DIFF
--- a/pkg/channel/service.go
+++ b/pkg/channel/service.go
@@ -17,12 +17,15 @@ var channelNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
 // ErrChannelExists is returned when attempting to create a channel that already exists.
 var ErrChannelExists = errors.New("channel already exists")
 
-// ErrInvalidChannelName is returned when a channel name contains invalid characters.
-var ErrInvalidChannelName = errors.New("invalid channel name: must start with alphanumeric and contain only alphanumeric, hyphens, or underscores")
+// MaxChannelNameLength is the maximum allowed length for a channel name.
+const MaxChannelNameLength = 64
 
-// IsValidChannelName validates that a channel name contains only allowed characters.
+// ErrInvalidChannelName is returned when a channel name is invalid.
+var ErrInvalidChannelName = errors.New("invalid channel name: must be 1-64 chars, start with alphanumeric, contain only alphanumeric, hyphens, or underscores")
+
+// IsValidChannelName validates channel name format and length.
 func IsValidChannelName(name string) bool {
-	return channelNameRegex.MatchString(name)
+	return len(name) > 0 && len(name) <= MaxChannelNameLength && channelNameRegex.MatchString(name)
 }
 
 // ChannelDTO is the API representation of a channel.

--- a/pkg/channel/service_test.go
+++ b/pkg/channel/service_test.go
@@ -483,6 +483,8 @@ func TestIsValidChannelName(t *testing.T) {
 		{"spaces", "has space", false},
 		{"dots", "has.dot", false},
 		{"slash", "a/b", false},
+		{"exactly 64 chars", "a234567890b234567890c234567890d234567890e234567890f234567890g234", true},
+		{"65 chars too long", "a234567890b234567890c234567890d234567890e234567890f234567890g2345", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `MaxChannelNameLength = 64` constant
- Enforce in `IsValidChannelName()` — rejects names > 64 chars
- Add test cases for boundary (64 ok, 65 rejected)

Closes #2481

## Test plan
- [x] `make ci-local` passes
- [x] `TestIsValidChannelName` covers 64/65 char boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)