### PR TITLE
feat: expand config schema with server, scheduler, storage sections

### DIFF
--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -24,9 +24,12 @@ type Config struct {
 	TUI         TUIConfig         `toml:"tui"`
 	User        UserConfig        `toml:"user"`
 	Workspace   WorkspaceConfig   `toml:"workspace"`
+	Server      ServerConfig      `toml:"server"`
 	Roster      RosterConfig      `toml:"roster"`
 	Logs        LogsConfig        `toml:"logs"`
+	Storage     StorageConfig     `toml:"storage"`
 	Runtime     RuntimeConfig     `toml:"runtime"`
+	Scheduler   SchedulerConfig   `toml:"scheduler"`
 	Performance PerformanceConfig `toml:"performance"`
 }
 
@@ -62,6 +65,23 @@ type DockerRuntimeConfig struct {
 type LogsConfig struct {
 	Path     string `toml:"path"`
 	MaxBytes int64  `toml:"max_bytes"`
+}
+
+// ServerConfig configures the bcd HTTP server.
+type ServerConfig struct {
+	Addr       string `toml:"addr"`
+	CORSOrigin string `toml:"cors_origin"`
+}
+
+// SchedulerConfig configures the cron/job scheduler.
+type SchedulerConfig struct {
+	TickInterval int `toml:"tick_interval"` // seconds between scheduler ticks
+	JobTimeout   int `toml:"job_timeout"`   // seconds before a job is considered timed out
+}
+
+// StorageConfig configures persistent storage paths.
+type StorageConfig struct {
+	SQLitePath string `toml:"sqlite_path"`
 }
 
 // UserConfig holds user identity settings.
@@ -193,6 +213,17 @@ func DefaultConfig(name string) Config {
 			},
 		},
 		Env: map[string]string{},
+		Server: ServerConfig{
+			Addr:       "127.0.0.1:9374",
+			CORSOrigin: "*",
+		},
+		Scheduler: SchedulerConfig{
+			TickInterval: 60,
+			JobTimeout:   300,
+		},
+		Storage: StorageConfig{
+			SQLitePath: ".bc/bc.db",
+		},
 		Logs: LogsConfig{
 			Path:     ".bc/logs",
 			MaxBytes: 1048576, // 1MB

--- a/pkg/workspace/config_test.go
+++ b/pkg/workspace/config_test.go
@@ -1728,3 +1728,110 @@ func TestRosterConfig_SaveAndLoad(t *testing.T) {
 		t.Errorf("Agents[0].Name = %q, want dev1", loaded.Roster.Agents[0].Name)
 	}
 }
+
+func TestDefaultConfigServerSchedulerStorage(t *testing.T) {
+	cfg := DefaultConfig("test-project")
+
+	// Server defaults
+	if cfg.Server.Addr != "127.0.0.1:9374" {
+		t.Errorf("expected server.addr '127.0.0.1:9374', got %q", cfg.Server.Addr)
+	}
+	if cfg.Server.CORSOrigin != "*" {
+		t.Errorf("expected server.cors_origin '*', got %q", cfg.Server.CORSOrigin)
+	}
+
+	// Scheduler defaults
+	if cfg.Scheduler.TickInterval != 60 {
+		t.Errorf("expected scheduler.tick_interval 60, got %d", cfg.Scheduler.TickInterval)
+	}
+	if cfg.Scheduler.JobTimeout != 300 {
+		t.Errorf("expected scheduler.job_timeout 300, got %d", cfg.Scheduler.JobTimeout)
+	}
+
+	// Storage defaults
+	if cfg.Storage.SQLitePath != ".bc/bc.db" {
+		t.Errorf("expected storage.sqlite_path '.bc/bc.db', got %q", cfg.Storage.SQLitePath)
+	}
+}
+
+func TestParseConfigServerSchedulerStorage(t *testing.T) {
+	tomlData := []byte(`
+[workspace]
+name = "test"
+version = 2
+
+[providers]
+default = "claude"
+
+[providers.claude]
+command = "claude"
+enabled = true
+
+[server]
+addr = "0.0.0.0:8080"
+cors_origin = "https://example.com"
+
+[scheduler]
+tick_interval = 30
+job_timeout = 600
+
+[storage]
+sqlite_path = "/var/data/bc.db"
+`)
+	cfg, err := ParseConfig(tomlData)
+	if err != nil {
+		t.Fatalf("failed to parse: %v", err)
+	}
+	if cfg.Server.Addr != "0.0.0.0:8080" {
+		t.Errorf("expected server.addr '0.0.0.0:8080', got %q", cfg.Server.Addr)
+	}
+	if cfg.Server.CORSOrigin != "https://example.com" {
+		t.Errorf("expected server.cors_origin 'https://example.com', got %q", cfg.Server.CORSOrigin)
+	}
+	if cfg.Scheduler.TickInterval != 30 {
+		t.Errorf("expected scheduler.tick_interval 30, got %d", cfg.Scheduler.TickInterval)
+	}
+	if cfg.Scheduler.JobTimeout != 600 {
+		t.Errorf("expected scheduler.job_timeout 600, got %d", cfg.Scheduler.JobTimeout)
+	}
+	if cfg.Storage.SQLitePath != "/var/data/bc.db" {
+		t.Errorf("expected storage.sqlite_path '/var/data/bc.db', got %q", cfg.Storage.SQLitePath)
+	}
+}
+
+func TestServerSchedulerStorageSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	cfg := DefaultConfig("test")
+	cfg.Server.Addr = "0.0.0.0:9000"
+	cfg.Server.CORSOrigin = "https://myapp.com"
+	cfg.Scheduler.TickInterval = 120
+	cfg.Scheduler.JobTimeout = 900
+	cfg.Storage.SQLitePath = ".bc/custom.db"
+
+	if err := cfg.Save(path); err != nil {
+		t.Fatalf("failed to save: %v", err)
+	}
+
+	loaded, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("failed to load: %v", err)
+	}
+
+	if loaded.Server.Addr != "0.0.0.0:9000" {
+		t.Errorf("expected server.addr '0.0.0.0:9000', got %q", loaded.Server.Addr)
+	}
+	if loaded.Server.CORSOrigin != "https://myapp.com" {
+		t.Errorf("expected server.cors_origin 'https://myapp.com', got %q", loaded.Server.CORSOrigin)
+	}
+	if loaded.Scheduler.TickInterval != 120 {
+		t.Errorf("expected scheduler.tick_interval 120, got %d", loaded.Scheduler.TickInterval)
+	}
+	if loaded.Scheduler.JobTimeout != 900 {
+		t.Errorf("expected scheduler.job_timeout 900, got %d", loaded.Scheduler.JobTimeout)
+	}
+	if loaded.Storage.SQLitePath != ".bc/custom.db" {
+		t.Errorf("expected storage.sqlite_path '.bc/custom.db', got %q", loaded.Storage.SQLitePath)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -289,6 +289,9 @@ export interface SettingsConfig {
   Roster: {
     Agents: { Name: string; Role: string; Tool: string; Runtime: string }[];
   };
+  Server: { Addr: string; CORSOrigin: string };
+  Scheduler: { TickInterval: number; JobTimeout: number };
+  Storage: { SQLitePath: string };
 }
 
 export interface Daemon {


### PR DESCRIPTION
## Summary
- Add `ServerConfig` struct with `Addr` and `CORSOrigin` fields (defaults: `127.0.0.1:9374`, `*`)
- Add `SchedulerConfig` struct with `TickInterval` and `JobTimeout` fields (defaults: 60s, 300s)
- Add `StorageConfig` struct with `SQLitePath` field (default: `.bc/bc.db`)
- Update `SettingsConfig` TypeScript type in `web/src/api/client.ts` to include the new sections
- Add tests for default values, TOML parsing, and save/load round-trip

## Test plan
- [x] `go test -race ./pkg/workspace/` passes
- [x] `golangci-lint run ./pkg/workspace/` — 0 issues
- [x] `bun run lint` and `bun run build` pass in web/

Closes #2494

🤖 Generated with [Claude Code](https://claude.com/claude-code)