### PR TITLE
feat: add PATCH /api/settings/:section endpoint

### DIFF
--- a/server/handlers/settings.go
+++ b/server/handlers/settings.go
@@ -2,7 +2,9 @@ package handlers
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/rpuneet/bc/pkg/workspace"
 )
@@ -20,6 +22,7 @@ func NewSettingsHandler(ws *workspace.Workspace) *SettingsHandler {
 // Register mounts settings routes on mux.
 func (h *SettingsHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/settings", h.handle)
+	mux.HandleFunc("/api/settings/", h.handleSection)
 }
 
 func (h *SettingsHandler) handle(w http.ResponseWriter, r *http.Request) {
@@ -28,6 +31,20 @@ func (h *SettingsHandler) handle(w http.ResponseWriter, r *http.Request) {
 		h.get(w, r)
 	case http.MethodPut:
 		h.put(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *SettingsHandler) handleSection(w http.ResponseWriter, r *http.Request) {
+	section := strings.TrimPrefix(r.URL.Path, "/api/settings/")
+	if section == "" {
+		httpError(w, "missing section name", http.StatusBadRequest)
+		return
+	}
+	switch r.Method {
+	case http.MethodPatch:
+		h.patch(w, r, section)
 	default:
 		methodNotAllowed(w)
 	}
@@ -117,6 +134,88 @@ func (h *SettingsHandler) put(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "invalid services config: "+err.Error(), http.StatusBadRequest)
 			return
 		}
+	}
+
+	// Validate the merged config.
+	if err := merged.Validate(); err != nil {
+		httpError(w, "validation failed: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Update in-memory config and persist to disk.
+	*h.ws.Config = merged
+	if err := h.ws.Save(); err != nil {
+		httpError(w, "failed to save config: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, h.ws.Config)
+}
+
+func (h *SettingsHandler) patch(w http.ResponseWriter, r *http.Request, section string) {
+	if h.ws.Config == nil {
+		httpError(w, "no config loaded", http.StatusInternalServerError)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		httpError(w, "failed to read body: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Copy current config to avoid partial mutation on error.
+	merged := *h.ws.Config
+
+	switch section {
+	case "user":
+		if err := json.Unmarshal(body, &merged.User); err != nil {
+			httpError(w, "invalid user config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	case "tui":
+		if err := json.Unmarshal(body, &merged.TUI); err != nil {
+			httpError(w, "invalid tui config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	case "runtime":
+		if err := json.Unmarshal(body, &merged.Runtime); err != nil {
+			httpError(w, "invalid runtime config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	case "providers":
+		if err := json.Unmarshal(body, &merged.Providers); err != nil {
+			httpError(w, "invalid providers config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	case "services":
+		if err := json.Unmarshal(body, &merged.Services); err != nil {
+			httpError(w, "invalid services config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	case "logs":
+		if err := json.Unmarshal(body, &merged.Logs); err != nil {
+			httpError(w, "invalid logs config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	case "performance":
+		if err := json.Unmarshal(body, &merged.Performance); err != nil {
+			httpError(w, "invalid performance config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	case "env":
+		if err := json.Unmarshal(body, &merged.Env); err != nil {
+			httpError(w, "invalid env config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	case "roster":
+		if err := json.Unmarshal(body, &merged.Roster); err != nil {
+			httpError(w, "invalid roster config: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+	default:
+		httpError(w, "unknown section: "+section, http.StatusBadRequest)
+		return
 	}
 
 	// Validate the merged config.

--- a/server/handlers/settings_test.go
+++ b/server/handlers/settings_test.go
@@ -1,0 +1,215 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/workspace"
+)
+
+// newTestWorkspace creates a minimal workspace in a temp directory with a valid config.
+func newTestWorkspace(t *testing.T) *workspace.Workspace {
+	t.Helper()
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, ".bc")
+	if err := os.MkdirAll(stateDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &workspace.Config{
+		Workspace: workspace.WorkspaceConfig{
+			Name:    "test-ws",
+			Version: workspace.ConfigVersion,
+		},
+		Providers: workspace.ProvidersConfig{
+			Default: "claude",
+			Claude:  &workspace.ProviderConfig{Enabled: true},
+		},
+		Runtime: workspace.RuntimeConfig{
+			Backend: "tmux",
+		},
+	}
+	return &workspace.Workspace{
+		Config:  cfg,
+		RootDir: dir,
+	}
+}
+
+func TestSettingsPatchSection(t *testing.T) {
+	ws := newTestWorkspace(t)
+	h := NewSettingsHandler(ws)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	tests := []struct {
+		body       string
+		wantErr    string
+		name       string
+		section    string
+		wantStatus int
+	}{
+		{
+			name:       "patch user section",
+			section:    "user",
+			body:       `{"nickname":"@alice"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "patch runtime section",
+			section:    "runtime",
+			body:       `{"backend":"docker"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "patch env section",
+			section:    "env",
+			body:       `{"FOO":"bar"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "patch logs section",
+			section:    "logs",
+			body:       `{"path":"custom/logs"}`,
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "unknown section returns 400",
+			section:    "bogus",
+			body:       `{}`,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "unknown section: bogus",
+		},
+		{
+			name:       "invalid JSON returns 400",
+			section:    "user",
+			body:       `{not json}`,
+			wantStatus: http.StatusBadRequest,
+			wantErr:    "invalid user config:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPatch, "/api/settings/"+tt.section, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d; body = %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if tt.wantErr != "" {
+				if !strings.Contains(rec.Body.String(), tt.wantErr) {
+					t.Errorf("body = %q, want to contain %q", rec.Body.String(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestSettingsPatchUpdatesConfig(t *testing.T) {
+	ws := newTestWorkspace(t)
+	h := NewSettingsHandler(ws)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	// PATCH user section
+	body := `{"nickname":"@bob"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/settings/user", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	// Verify the response contains the full config with updated user.
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	// Verify the in-memory config was updated.
+	if ws.Config.User.Nickname != "@bob" {
+		t.Errorf("config.User.Nickname = %q, want %q", ws.Config.User.Nickname, "@bob")
+	}
+}
+
+func TestSettingsPatchMethodNotAllowed(t *testing.T) {
+	ws := newTestWorkspace(t)
+	h := NewSettingsHandler(ws)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	// GET on /api/settings/user should be 405
+	req := httptest.NewRequest(http.MethodGet, "/api/settings/user", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
+func TestSettingsPatchAllSections(t *testing.T) {
+	ws := newTestWorkspace(t)
+	h := NewSettingsHandler(ws)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	sections := []struct {
+		name string
+		body string
+	}{
+		{"user", `{"nickname":"@test"}`},
+		{"tui", `{}`},
+		{"runtime", `{"backend":"tmux"}`},
+		{"providers", `{"default":"claude"}`},
+		{"services", `{}`},
+		{"logs", `{}`},
+		{"performance", `{}`},
+		{"env", `{}`},
+		{"roster", `{}`},
+	}
+
+	for _, s := range sections {
+		t.Run(s.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPatch, "/api/settings/"+s.name, strings.NewReader(s.body))
+			req.Header.Set("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("section %q: status = %d, want %d; body = %s", s.name, rec.Code, http.StatusOK, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestSettingsPatchNilConfig(t *testing.T) {
+	ws := newTestWorkspace(t)
+	ws.Config = nil
+	h := NewSettingsHandler(ws)
+
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/settings/user", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusInternalServerError)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `PATCH /api/settings/{section}` endpoint for per-section config updates
- Valid sections: user, tui, runtime, providers, services, logs, performance, env, roster
- Returns 400 for unknown sections, validates merged config before persisting
- Add comprehensive test suite covering all sections, error cases, and edge cases

Closes #2493

## Test plan
- [x] All 9 valid sections return 200 with valid payloads
- [x] Unknown section returns 400 with descriptive error
- [x] Invalid JSON body returns 400
- [x] Nil config returns 500
- [x] Non-PATCH methods on section route return 405
- [x] In-memory config updated after successful PATCH
- [x] Full config returned in response
- [x] `golangci-lint` passes with zero issues
- [x] `go test -race` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)