### PR TITLE
fix: remove runtime claude mcp add, use file-based config only

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -872,14 +872,9 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	}
 	injectEnv(env, wsPath, toolName, existing.EnvFile)
 
-	// On restart (not fresh create), prepend role setup commands
-	// (mcp add, plugin install) so the agent has everything configured
-	// before Claude starts. First create is bare — user logs in first.
-	if existing.RuntimeBackend != "tmux" {
-		if setupCmd := BuildSetupCommand(wsPath, string(existing.Role)); setupCmd != "" {
-			agentCmd = setupCmd + " && " + agentCmd
-		}
-	}
+	// MCP servers and plugins are configured via file-based config
+	// (.mcp.json and .claude.json) written by SetupAgentFromRole.
+	// No need for runtime `claude mcp add` commands.
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -1061,13 +1056,9 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	// Clean stale worktree from previous container run (crash recovery).
 	cleanStaleWorktree(ctx, wsPath, name)
 
-	// For Docker agents on first create, prepend role setup commands
-	// (mcp add, plugin install) so the agent is fully configured.
-	if agentRuntime != "tmux" {
-		if setupCmd := BuildSetupCommand(wsPath, string(role)); setupCmd != "" {
-			agentCmd = setupCmd + " && " + agentCmd
-		}
-	}
+	// MCP servers and plugins are configured via file-based config
+	// (.mcp.json and .claude.json) written by SetupAgentFromRole above.
+	// No runtime `claude mcp add` commands — they kill running Claude instances.
 
 	// Create session in the workspace directory using the agent's runtime backend
 	if err := rt.CreateSessionWithEnv(ctx, name, wsPath, agentCmd, env); err != nil {

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -111,62 +111,14 @@ func setupAgentFromRole(workspacePath, agentName, roleName, targetDir, runtimeBa
 	return nil
 }
 
-// BuildSetupCommand generates bash commands to configure Claude Code before
-// starting it. These run as part of the container entrypoint so plugins and
-// MCP servers are ready when Claude launches.
+// BuildSetupCommand is deprecated — MCP servers and plugins are now configured
+// via file-based config (.mcp.json and .claude.json) written by SetupAgentFromRole.
+// Running `claude mcp add` at startup kills running Claude instances and causes
+// restart loops in Docker containers.
 //
-// Returns empty string if no setup is needed.
-func BuildSetupCommand(workspacePath, roleName string) string {
-	stateDir := filepath.Join(workspacePath, ".bc")
-	rm := workspace.NewRoleManager(stateDir)
-
-	resolved, err := rm.ResolveRole(roleName)
-	if err != nil {
-		log.Debug("failed to resolve role for setup command", "role", roleName, "error", err)
-		return ""
-	}
-
-	var cmds []string
-
-	// Add MCP servers using claude mcp add
-	if len(resolved.MCPServers) > 0 {
-		mcpStore, mcpErr := pkgmcp.NewStore(workspacePath)
-		if mcpErr == nil {
-			defer mcpStore.Close() //nolint:errcheck
-			for _, name := range resolved.MCPServers {
-				def, getErr := mcpStore.Get(name)
-				if getErr != nil || def == nil || !def.Enabled {
-					continue
-				}
-				switch def.Transport {
-				case "sse":
-					cmds = append(cmds, fmt.Sprintf("claude mcp add --transport sse %s %s 2>/dev/null || true", name, def.URL))
-				default: // stdio
-					if def.Command != "" {
-						args := strings.Join(def.Args, " ")
-						if args != "" {
-							cmds = append(cmds, fmt.Sprintf("claude mcp add %s %s %s 2>/dev/null || true", name, def.Command, args))
-						} else {
-							cmds = append(cmds, fmt.Sprintf("claude mcp add %s %s 2>/dev/null || true", name, def.Command))
-						}
-					}
-				}
-			}
-		}
-	}
-
-	// Install plugins using claude plugin install
-	if len(resolved.Plugins) > 0 {
-		for _, plugin := range resolved.Plugins {
-			cmds = append(cmds, fmt.Sprintf("claude plugin install %s 2>/dev/null || true", plugin))
-		}
-	}
-
-	if len(cmds) == 0 {
-		return ""
-	}
-
-	return strings.Join(cmds, " && ")
+// Kept as a no-op for backward compatibility. Will be removed in a future release.
+func BuildSetupCommand(_, _ string) string {
+	return ""
 }
 
 // ── MCP config ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Remove `BuildSetupCommand()` which generated `claude mcp add` and `claude plugin install` shell commands that ran at Docker container startup. These commands:
- Kill running Claude instances (restart loop)
- Are redundant with file-based config already written by `SetupAgentFromRole`

MCP servers are already configured via:
- `.mcp.json` written by `writeMCPJSON()` → Claude reads at startup
- `.claude/settings.json` seeded by `SeedClaudeSettings()` → prevents theme prompt

The function is kept as a no-op for backward compatibility.

**Root cause of the Docker agent loop:** `claude mcp add` modifies `.claude.json`, triggering a Claude restart, which re-runs the entrypoint, which runs `claude mcp add` again → infinite loop.

Closes #2508

## Changes
- `pkg/agent/agent.go` — Remove 2 call sites of `BuildSetupCommand`
- `pkg/agent/role_setup.go` — Replace `BuildSetupCommand` body with no-op return

## Test plan
- [x] `make ci-local` passes
- [x] `make lint-go` — 0 issues
- [ ] Docker agent starts without looping (manual test)
- [ ] MCP servers work via `.mcp.json` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)