### PR TITLE
feat: add keyboard shortcuts to web dashboard

### DIFF
--- a/web/src/components/KeyboardHelp.tsx
+++ b/web/src/components/KeyboardHelp.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from "react";
+
+interface KeyboardHelpProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SHORTCUTS = [
+  { key: "?", description: "Toggle this help overlay" },
+  { key: "j", description: "Next item in list" },
+  { key: "k", description: "Previous item in list" },
+  { key: "/", description: "Focus search input" },
+  { key: "1-9", description: "Switch sidebar navigation tabs" },
+  { key: "Esc", description: "Close overlay / unfocus" },
+] as const;
+
+export function KeyboardHelp({ open, onClose }: KeyboardHelpProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Close on click outside the modal content
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClick(e: MouseEvent) {
+      if (
+        overlayRef.current &&
+        e.target instanceof Node &&
+        !overlayRef.current.contains(e.target)
+      ) {
+        onClose();
+      }
+    }
+
+    // Defer to avoid catching the same click that opened it
+    const id = requestAnimationFrame(() => {
+      document.addEventListener("mousedown", handleClick);
+    });
+
+    return () => {
+      cancelAnimationFrame(id);
+      document.removeEventListener("mousedown", handleClick);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts"
+    >
+      <div
+        ref={overlayRef}
+        className="w-full max-w-md mx-4 rounded-lg border border-bc-border bg-bc-surface shadow-xl"
+      >
+        <div className="flex items-center justify-between px-5 py-4 border-b border-bc-border">
+          <h2 className="text-base font-semibold text-bc-text">
+            Keyboard Shortcuts
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1 rounded text-bc-muted hover:text-bc-text transition-colors"
+            aria-label="Close shortcuts help"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M4 4l8 8M12 4l-8 8" />
+            </svg>
+          </button>
+        </div>
+        <div className="px-5 py-4 space-y-3">
+          {SHORTCUTS.map(({ key, description }) => (
+            <div key={key} className="flex items-center justify-between">
+              <span className="text-sm text-bc-muted">{description}</span>
+              <kbd className="inline-flex items-center px-2 py-0.5 rounded border border-bc-border bg-bc-bg text-xs font-mono text-bc-text">
+                {key}
+              </kbd>
+            </div>
+          ))}
+        </div>
+        <div className="px-5 py-3 border-t border-bc-border">
+          <p className="text-xs text-bc-muted">
+            Shortcuts are disabled when typing in input fields.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { useTheme } from "../context/ThemeContext";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import { KeyboardHelp } from "./KeyboardHelp";
 
 const NAV_ITEMS = [
   { to: "/", label: "Dashboard", icon: "~" },
@@ -30,6 +32,7 @@ export function Layout() {
   const location = useLocation();
   const { mode, toggle } = useTheme();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const { helpOpen, closeHelp } = useKeyboardShortcuts();
 
   // Dynamic page title (#2150)
   useEffect(() => {
@@ -143,6 +146,7 @@ export function Layout() {
       <main className="flex-1 overflow-auto bg-bc-bg">
         <Outlet />
       </main>
+      <KeyboardHelp open={helpOpen} onClose={closeHelp} />
     </div>
   );
 }

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,150 @@
+import { useEffect, useCallback, useState } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+
+const NAV_PATHS = [
+  "/",
+  "/agents",
+  "/channels",
+  "/costs",
+  "/roles",
+  "/tools",
+  "/mcp",
+  "/cron",
+  "/secrets",
+] as const;
+
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  if (tag === "input" || tag === "textarea" || tag === "select") return true;
+  if ((el as HTMLElement).isContentEditable) return true;
+  return false;
+}
+
+export function useKeyboardShortcuts() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  const toggleHelp = useCallback(() => {
+    setHelpOpen((prev) => !prev);
+  }, []);
+
+  const closeHelp = useCallback(() => {
+    setHelpOpen(false);
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Always allow Escape to close help
+      if (e.key === "Escape" && helpOpen) {
+        e.preventDefault();
+        closeHelp();
+        return;
+      }
+
+      // Ignore when typing in inputs
+      if (isInputFocused()) return;
+
+      // Ignore when modifier keys are held (except Shift for ?)
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      switch (e.key) {
+        case "?": {
+          e.preventDefault();
+          toggleHelp();
+          break;
+        }
+
+        case "/": {
+          const searchInput = document.querySelector<HTMLInputElement>(
+            'input[type="search"], input[placeholder*="earch"], input[data-search]',
+          );
+          if (searchInput) {
+            e.preventDefault();
+            searchInput.focus();
+          }
+          break;
+        }
+
+        case "j": {
+          e.preventDefault();
+          scrollListItem(1);
+          break;
+        }
+
+        case "k": {
+          e.preventDefault();
+          scrollListItem(-1);
+          break;
+        }
+
+        default: {
+          // 1-9 for sidebar navigation
+          const num = parseInt(e.key, 10);
+          if (num >= 1 && num <= 9 && num <= NAV_PATHS.length) {
+            const target = NAV_PATHS[num - 1];
+            if (target && location.pathname !== target) {
+              e.preventDefault();
+              navigate(target);
+            }
+          }
+          break;
+        }
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [navigate, location.pathname, helpOpen, toggleHelp, closeHelp]);
+
+  return { helpOpen, closeHelp };
+}
+
+function scrollListItem(direction: 1 | -1) {
+  // Find table rows or list items in the main content area
+  const main = document.querySelector("main");
+  if (!main) return;
+
+  const rows = main.querySelectorAll<HTMLElement>(
+    "tbody tr, [role='listitem'], [data-list-item]",
+  );
+  if (rows.length === 0) return;
+
+  // Find currently highlighted row
+  const highlighted = main.querySelector<HTMLElement>(
+    "tr[data-kb-active], [data-kb-active]",
+  );
+  let currentIndex = -1;
+
+  if (highlighted) {
+    rows.forEach((row, i) => {
+      if (row === highlighted) currentIndex = i;
+    });
+  }
+
+  // Calculate next index
+  let nextIndex: number;
+  if (currentIndex === -1) {
+    nextIndex = direction === 1 ? 0 : rows.length - 1;
+  } else {
+    nextIndex = currentIndex + direction;
+    if (nextIndex < 0) nextIndex = 0;
+    if (nextIndex >= rows.length) nextIndex = rows.length - 1;
+  }
+
+  // Remove previous highlight
+  if (highlighted) {
+    highlighted.removeAttribute("data-kb-active");
+    highlighted.classList.remove("bg-bc-surface");
+  }
+
+  // Apply new highlight and scroll into view
+  const nextRow = rows[nextIndex];
+  if (nextRow) {
+    nextRow.setAttribute("data-kb-active", "true");
+    nextRow.classList.add("bg-bc-surface");
+    nextRow.scrollIntoView({ block: "nearest", behavior: "smooth" });
+  }
+}


### PR DESCRIPTION
## Summary
- Add `useKeyboardShortcuts` hook with j/k list navigation, `/` search focus, `1-9` sidebar tab switching, and `?` help overlay toggle
- Add `KeyboardHelp` modal component showing all available shortcuts with Escape/click-outside dismissal
- Wire shortcuts into `Layout.tsx` so they are active across all pages
- Shortcuts are automatically disabled when focus is in input/textarea fields

Closes #2523

## Test plan
- [ ] Press `?` to open/close the keyboard shortcuts help overlay
- [ ] Press `j`/`k` on pages with tables to navigate rows
- [ ] Press `/` on pages with search inputs to focus the search field
- [ ] Press `1`-`9` to switch between sidebar navigation tabs
- [ ] Press `Escape` to close the help overlay
- [ ] Verify shortcuts do not fire when typing in input fields
- [ ] Verify both dark and light themes render the overlay correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an accessible keyboard shortcut help overlay that displays all available shortcuts, toggled via the `?` key
  * Implemented comprehensive keyboard navigation: `/` focuses the search input, `j`/`k` navigate through lists and tables, `1`-`9` enable quick sidebar navigation, `Escape` closes the help overlay
  * Shortcuts intelligently disable when input fields are focused or modifier keys are held to prevent conflicts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->