### PR TITLE
feat: add missing pkg/client packages for secrets, teams, daemons, doctor, settings, stats

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -42,6 +42,12 @@ type Client struct {
 	MCP        *MCPClient
 	Tools      *ToolsClient
 	Roles      *RolesClient
+	Secrets    *SecretsClient
+	Teams      *TeamsClient
+	Daemons    *DaemonsClient
+	Doctor     *DoctorClient
+	Settings   *SettingsClient
+	Stats      *StatsClient
 	BaseURL    string
 }
 
@@ -68,6 +74,12 @@ func New(addr string) *Client {
 	c.MCP = &MCPClient{client: c}
 	c.Tools = &ToolsClient{client: c}
 	c.Roles = &RolesClient{client: c}
+	c.Secrets = &SecretsClient{client: c}
+	c.Teams = &TeamsClient{client: c}
+	c.Daemons = &DaemonsClient{client: c}
+	c.Doctor = &DoctorClient{client: c}
+	c.Settings = &SettingsClient{client: c}
+	c.Stats = &StatsClient{client: c}
 
 	return c
 }

--- a/pkg/client/daemons.go
+++ b/pkg/client/daemons.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"context"
+	"time"
+)
+
+// DaemonsClient provides daemon process operations via the daemon.
+type DaemonsClient struct {
+	client *Client
+}
+
+// DaemonInfo represents a managed daemon process returned by the daemon.
+type DaemonInfo struct {
+	CreatedAt   time.Time  `json:"created_at"`
+	StartedAt   time.Time  `json:"started_at,omitempty"`
+	StoppedAt   *time.Time `json:"stopped_at,omitempty"`
+	Name        string     `json:"name"`
+	Runtime     string     `json:"runtime"`
+	Cmd         string     `json:"cmd,omitempty"`
+	Image       string     `json:"image,omitempty"`
+	ContainerID string     `json:"container_id,omitempty"`
+	Restart     string     `json:"restart"`
+	Status      string     `json:"status"`
+	Ports       []string   `json:"ports,omitempty"`
+	Volumes     []string   `json:"volumes,omitempty"`
+	EnvVars     []string   `json:"env,omitempty"`
+	PID         int64      `json:"pid,omitempty"`
+}
+
+// List returns all managed daemons from the daemon.
+func (d *DaemonsClient) List(ctx context.Context) ([]DaemonInfo, error) {
+	var daemons []DaemonInfo
+	if err := d.client.get(ctx, "/api/daemons", &daemons); err != nil {
+		return nil, err
+	}
+	return daemons, nil
+}
+
+// Get returns a single daemon by name.
+func (d *DaemonsClient) Get(ctx context.Context, name string) (*DaemonInfo, error) {
+	var info DaemonInfo
+	if err := d.client.get(ctx, "/api/daemons/"+name, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Stop stops a running daemon.
+func (d *DaemonsClient) Stop(ctx context.Context, name string) error {
+	return d.client.post(ctx, "/api/daemons/"+name+"/stop", nil, nil)
+}
+
+// Restart restarts a daemon.
+func (d *DaemonsClient) Restart(ctx context.Context, name string) (*DaemonInfo, error) {
+	var info DaemonInfo
+	if err := d.client.post(ctx, "/api/daemons/"+name+"/restart", nil, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Delete removes a daemon.
+func (d *DaemonsClient) Delete(ctx context.Context, name string) error {
+	return d.client.delete(ctx, "/api/daemons/"+name)
+}

--- a/pkg/client/doctor.go
+++ b/pkg/client/doctor.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// DoctorClient provides doctor/diagnostic operations via the daemon.
+type DoctorClient struct {
+	client *Client
+}
+
+// DoctorReport represents the full doctor report returned by the daemon.
+type DoctorReport struct {
+	Categories []DoctorCategory `json:"categories"`
+}
+
+// DoctorCategory represents a single category within a doctor report.
+type DoctorCategory struct {
+	Name  string       `json:"name"`
+	Items []DoctorItem `json:"items"`
+}
+
+// DoctorItem represents a single check item within a doctor category.
+type DoctorItem struct {
+	Name     string `json:"name"`
+	Severity string `json:"severity"`
+	Message  string `json:"message"`
+}
+
+// RunAll runs all doctor checks and returns the full report.
+func (d *DoctorClient) RunAll(ctx context.Context) (*DoctorReport, error) {
+	var report DoctorReport
+	if err := d.client.get(ctx, "/api/doctor", &report); err != nil {
+		return nil, err
+	}
+	return &report, nil
+}
+
+// ByCategory runs doctor checks for a specific category.
+func (d *DoctorClient) ByCategory(ctx context.Context, cat string) (*DoctorCategory, error) {
+	var category DoctorCategory
+	if err := d.client.get(ctx, "/api/doctor/"+cat, &category); err != nil {
+		return nil, err
+	}
+	return &category, nil
+}
+
+// RunAllRaw runs all doctor checks and returns the raw JSON.
+func (d *DoctorClient) RunAllRaw(ctx context.Context) (json.RawMessage, error) {
+	var raw json.RawMessage
+	if err := d.client.get(ctx, "/api/doctor", &raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}

--- a/pkg/client/secrets.go
+++ b/pkg/client/secrets.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"context"
+	"time"
+)
+
+// SecretsClient provides secret operations via the daemon.
+type SecretsClient struct {
+	client *Client
+}
+
+// SecretInfo represents secret metadata returned by the daemon.
+// Values are never exposed — only metadata.
+type SecretInfo struct {
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+}
+
+// List returns all secret metadata from the daemon.
+func (s *SecretsClient) List(ctx context.Context) ([]SecretInfo, error) {
+	var secrets []SecretInfo
+	if err := s.client.get(ctx, "/api/secrets", &secrets); err != nil {
+		return nil, err
+	}
+	return secrets, nil
+}
+
+// Create creates a new secret.
+func (s *SecretsClient) Create(ctx context.Context, name, value string) (*SecretInfo, error) {
+	body := map[string]string{"name": name, "value": value}
+	var info SecretInfo
+	if err := s.client.post(ctx, "/api/secrets", body, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Get returns metadata for a single secret by name.
+func (s *SecretsClient) Get(ctx context.Context, name string) (*SecretInfo, error) {
+	var info SecretInfo
+	if err := s.client.get(ctx, "/api/secrets/"+name, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Update updates an existing secret's value.
+func (s *SecretsClient) Update(ctx context.Context, name, value string) (*SecretInfo, error) {
+	body := map[string]string{"value": value}
+	var info SecretInfo
+	if err := s.client.put(ctx, "/api/secrets/"+name, body, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+// Delete removes a secret by name.
+func (s *SecretsClient) Delete(ctx context.Context, name string) error {
+	return s.client.delete(ctx, "/api/secrets/"+name)
+}

--- a/pkg/client/settings.go
+++ b/pkg/client/settings.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// SettingsClient provides workspace settings operations via the daemon.
+type SettingsClient struct {
+	client *Client
+}
+
+// Get returns the current workspace settings.
+func (s *SettingsClient) Get(ctx context.Context) (json.RawMessage, error) {
+	var settings json.RawMessage
+	if err := s.client.get(ctx, "/api/settings", &settings); err != nil {
+		return nil, err
+	}
+	return settings, nil
+}
+
+// Update replaces workspace settings with the given patch map.
+func (s *SettingsClient) Update(ctx context.Context, patch map[string]any) (json.RawMessage, error) {
+	var settings json.RawMessage
+	if err := s.client.put(ctx, "/api/settings", patch, &settings); err != nil {
+		return nil, err
+	}
+	return settings, nil
+}
+
+// Patch updates a specific section of workspace settings.
+func (s *SettingsClient) Patch(ctx context.Context, section string, data map[string]any) (json.RawMessage, error) {
+	var settings json.RawMessage
+	if err := s.client.do(ctx, http.MethodPatch, "/api/settings/"+section, data, &settings); err != nil {
+		return nil, err
+	}
+	return settings, nil
+}

--- a/pkg/client/stats.go
+++ b/pkg/client/stats.go
@@ -1,0 +1,57 @@
+package client
+
+import "context"
+
+// StatsClient provides system and workspace stats via the daemon.
+type StatsClient struct {
+	client *Client
+}
+
+// SystemStats represents system-level metrics returned by the daemon.
+type SystemStats struct {
+	Hostname         string  `json:"hostname"`
+	OS               string  `json:"os"`
+	Arch             string  `json:"arch"`
+	GoVersion        string  `json:"go_version"`
+	CPUUsagePercent  float64 `json:"cpu_usage_percent"`
+	MemoryPercent    float64 `json:"memory_usage_percent"`
+	DiskPercent      float64 `json:"disk_usage_percent"`
+	MemoryTotalBytes uint64  `json:"memory_total_bytes"`
+	MemoryUsedBytes  uint64  `json:"memory_used_bytes"`
+	DiskTotalBytes   uint64  `json:"disk_total_bytes"`
+	DiskUsedBytes    uint64  `json:"disk_used_bytes"`
+	UptimeSeconds    int64   `json:"uptime_seconds"`
+	CPUs             int     `json:"cpus"`
+	Goroutines       int     `json:"goroutines"`
+}
+
+// SummaryStats represents workspace-level summary metrics.
+type SummaryStats struct {
+	AgentsTotal   int     `json:"agents_total"`
+	AgentsRunning int     `json:"agents_running"`
+	AgentsStopped int     `json:"agents_stopped"`
+	ChannelsTotal int     `json:"channels_total"`
+	MessagesTotal int     `json:"messages_total"`
+	TotalCostUSD  float64 `json:"total_cost_usd"`
+	RolesTotal    int     `json:"roles_total"`
+	ToolsTotal    int     `json:"tools_total"`
+	UptimeSeconds int64   `json:"uptime_seconds"`
+}
+
+// System returns system-level metrics.
+func (s *StatsClient) System(ctx context.Context) (*SystemStats, error) {
+	var stats SystemStats
+	if err := s.client.get(ctx, "/api/stats/system", &stats); err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}
+
+// Summary returns workspace-level summary metrics.
+func (s *StatsClient) Summary(ctx context.Context) (*SummaryStats, error) {
+	var stats SummaryStats
+	if err := s.client.get(ctx, "/api/stats/summary", &stats); err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}

--- a/pkg/client/teams.go
+++ b/pkg/client/teams.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"context"
+	"time"
+)
+
+// TeamsClient provides team operations via the daemon.
+type TeamsClient struct {
+	client *Client
+}
+
+// TeamInfo represents team data returned by the daemon.
+type TeamInfo struct {
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	Lead        string    `json:"lead,omitempty"`
+	Members     []string  `json:"members,omitempty"`
+}
+
+// List returns all teams from the daemon.
+func (t *TeamsClient) List(ctx context.Context) ([]TeamInfo, error) {
+	var teams []TeamInfo
+	if err := t.client.get(ctx, "/api/teams", &teams); err != nil {
+		return nil, err
+	}
+	return teams, nil
+}
+
+// Get returns a single team by name.
+func (t *TeamsClient) Get(ctx context.Context, name string) (*TeamInfo, error) {
+	var info TeamInfo
+	if err := t.client.get(ctx, "/api/teams/"+name, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}


### PR DESCRIPTION
## Summary
- Add 6 new client packages (`SecretsClient`, `TeamsClient`, `DaemonsClient`, `DoctorClient`, `SettingsClient`, `StatsClient`) following the established pattern in `agents.go`
- Each client uses the parent `Client` HTTP helpers (`get`, `post`, `put`, `delete`, `do`) and is registered in the `Client` struct
- All struct fields pass `fieldalignment` checks and `golangci-lint`

Closes #2518

## Test plan
- [x] `go build ./pkg/client/` passes
- [x] `go test -race ./pkg/client/` passes
- [x] `golangci-lint run ./pkg/client/` reports 0 issues
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Secrets management: create, read, update, delete, and list operations
  * Team management: list and retrieve team details
  * Daemon control: list, retrieve, stop, restart, and delete operations
  * System diagnostics and health checks
  * Workspace settings management: get, update, and patch operations
  * System and workspace statistics retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->