### PR TITLE
feat: add Cmd+K command palette to web dashboard

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import { useCommandPalette } from "../hooks/useCommandPalette";
+
+export function CommandPalette() {
+  const { open, query, setQuery, close, filtered } = useCommandPalette();
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Reset active index when filtered results change
+  useEffect(() => {
+    setActiveIndex(0);
+  }, [filtered]);
+
+  // Focus input when opened
+  useEffect(() => {
+    if (open) {
+      setActiveIndex(0);
+      // Slight delay to ensure the DOM is rendered
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (!listRef.current) return;
+    const active = listRef.current.querySelector("[data-active='true']");
+    active?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex]);
+
+  const handleSelect = useCallback(
+    (index: number) => {
+      const item = filtered[index];
+      if (item) {
+        item.action();
+        close();
+      }
+    },
+    [filtered, close],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setActiveIndex((prev) => (prev < filtered.length - 1 ? prev + 1 : 0));
+          break;
+        case "ArrowUp":
+          e.preventDefault();
+          setActiveIndex((prev) => (prev > 0 ? prev - 1 : filtered.length - 1));
+          break;
+        case "Enter":
+          e.preventDefault();
+          handleSelect(activeIndex);
+          break;
+        case "Escape":
+          e.preventDefault();
+          close();
+          break;
+      }
+    },
+    [activeIndex, filtered.length, handleSelect, close],
+  );
+
+  if (!open) return null;
+
+  // Group items by section
+  const sections = new Map<string, typeof filtered>();
+  for (const item of filtered) {
+    const group = sections.get(item.section) ?? [];
+    group.push(item);
+    sections.set(item.section, group);
+  }
+
+  // Build flat index mapping for sections
+  let flatIndex = 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex items-start justify-center pt-[15vh]"
+      onClick={close}
+      role="presentation"
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" />
+
+      {/* Palette */}
+      <div
+        className="relative w-full max-w-lg rounded-lg border border-bc-border bg-bc-surface shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-2 border-b border-bc-border px-4 py-3">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="shrink-0 text-bc-muted"
+          >
+            <circle cx="6.5" cy="6.5" r="4.5" />
+            <path d="M10 10l4 4" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type a command..."
+            className="flex-1 bg-transparent text-sm text-bc-text placeholder:text-bc-muted outline-none"
+            aria-label="Search commands"
+          />
+          <kbd className="hidden sm:inline-block rounded border border-bc-border px-1.5 py-0.5 text-[10px] text-bc-muted">
+            ESC
+          </kbd>
+        </div>
+
+        {/* Results */}
+        <div ref={listRef} className="max-h-72 overflow-y-auto py-2">
+          {filtered.length === 0 ? (
+            <div className="px-4 py-6 text-center text-sm text-bc-muted">
+              No results found
+            </div>
+          ) : (
+            Array.from(sections.entries()).map(([section, items]) => {
+              const sectionStart = flatIndex;
+              const sectionItems = items.map((item, i) => {
+                const itemIndex = sectionStart + i;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    data-active={itemIndex === activeIndex}
+                    onClick={() => handleSelect(itemIndex)}
+                    onMouseEnter={() => setActiveIndex(itemIndex)}
+                    className={`flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors ${
+                      itemIndex === activeIndex
+                        ? "bg-bc-accent/10 text-bc-accent"
+                        : "text-bc-text hover:bg-bc-bg"
+                    }`}
+                  >
+                    <span className="w-5 text-center font-mono text-xs text-bc-muted">
+                      {item.icon}
+                    </span>
+                    <span className="flex-1">{item.label}</span>
+                    {item.section === "Navigate" && (
+                      <span className="text-xs text-bc-muted">Go to</span>
+                    )}
+                    {item.section === "Action" && (
+                      <span className="text-xs text-bc-muted">Run</span>
+                    )}
+                  </button>
+                );
+              });
+              flatIndex += items.length;
+              return (
+                <div key={section}>
+                  <div className="px-4 py-1.5 text-xs font-medium text-bc-muted">
+                    {section}
+                  </div>
+                  {sectionItems}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <div className="flex items-center gap-3 border-t border-bc-border px-4 py-2 text-[10px] text-bc-muted">
+          <span>
+            <kbd className="rounded border border-bc-border px-1 py-0.5">
+              &uarr;&darr;
+            </kbd>{" "}
+            navigate
+          </span>
+          <span>
+            <kbd className="rounded border border-bc-border px-1 py-0.5">
+              &crarr;
+            </kbd>{" "}
+            select
+          </span>
+          <span>
+            <kbd className="rounded border border-bc-border px-1 py-0.5">
+              esc
+            </kbd>{" "}
+            close
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/KeyboardHelp.tsx
+++ b/web/src/components/KeyboardHelp.tsx
@@ -12,6 +12,7 @@ const SHORTCUTS = [
   { key: "/", description: "Focus search input" },
   { key: "1-9", description: "Switch sidebar navigation tabs" },
   { key: "Esc", description: "Close overlay / unfocus" },
+  { key: "⌘K", description: "Open command palette" },
 ] as const;
 
 export function KeyboardHelp({ open, onClose }: KeyboardHelpProps) {

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { useTheme } from "../context/ThemeContext";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import { CommandPalette } from "./CommandPalette";
 
 const SIDEBAR_KEY = "bc-sidebar-collapsed";
 
@@ -228,6 +229,7 @@ export function Layout() {
       <main className="flex-1 overflow-auto bg-bc-bg">
         <Outlet />
       </main>
+      <CommandPalette />
     </div>
   );
 }

--- a/web/src/hooks/useCommandPalette.ts
+++ b/web/src/hooks/useCommandPalette.ts
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+export interface CommandItem {
+  id: string;
+  label: string;
+  section: "Navigate" | "Action";
+  icon: string;
+  action: () => void;
+}
+
+export function useCommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const navigate = useNavigate();
+
+  const toggle = useCallback(() => {
+    setOpen((prev) => {
+      if (prev) setQuery("");
+      return !prev;
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+  }, []);
+
+  // Cmd+K / Ctrl+K listener
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        toggle();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [toggle]);
+
+  const items: CommandItem[] = useMemo(
+    () => [
+      // Navigation
+      {
+        id: "nav-dashboard",
+        label: "Dashboard",
+        section: "Navigate",
+        icon: "~",
+        action: () => navigate("/"),
+      },
+      {
+        id: "nav-agents",
+        label: "Agents",
+        section: "Navigate",
+        icon: "A",
+        action: () => navigate("/agents"),
+      },
+      {
+        id: "nav-channels",
+        label: "Channels",
+        section: "Navigate",
+        icon: "C",
+        action: () => navigate("/channels"),
+      },
+      {
+        id: "nav-costs",
+        label: "Costs",
+        section: "Navigate",
+        icon: "$",
+        action: () => navigate("/costs"),
+      },
+      {
+        id: "nav-roles",
+        label: "Roles",
+        section: "Navigate",
+        icon: "R",
+        action: () => navigate("/roles"),
+      },
+      {
+        id: "nav-tools",
+        label: "Tools",
+        section: "Navigate",
+        icon: "T",
+        action: () => navigate("/tools"),
+      },
+      {
+        id: "nav-mcp",
+        label: "MCP",
+        section: "Navigate",
+        icon: "M",
+        action: () => navigate("/mcp"),
+      },
+      {
+        id: "nav-cron",
+        label: "Cron",
+        section: "Navigate",
+        icon: "@",
+        action: () => navigate("/cron"),
+      },
+      {
+        id: "nav-secrets",
+        label: "Secrets",
+        section: "Navigate",
+        icon: "#",
+        action: () => navigate("/secrets"),
+      },
+      {
+        id: "nav-stats",
+        label: "Stats",
+        section: "Navigate",
+        icon: "S",
+        action: () => navigate("/stats"),
+      },
+      {
+        id: "nav-logs",
+        label: "Logs",
+        section: "Navigate",
+        icon: "L",
+        action: () => navigate("/logs"),
+      },
+      {
+        id: "nav-workspace",
+        label: "Workspace",
+        section: "Navigate",
+        icon: "W",
+        action: () => navigate("/workspace"),
+      },
+      {
+        id: "nav-daemons",
+        label: "Daemons",
+        section: "Navigate",
+        icon: "D",
+        action: () => navigate("/daemons"),
+      },
+      {
+        id: "nav-doctor",
+        label: "Doctor",
+        section: "Navigate",
+        icon: "+",
+        action: () => navigate("/doctor"),
+      },
+      {
+        id: "nav-settings",
+        label: "Settings",
+        section: "Navigate",
+        icon: "\u2699",
+        action: () => navigate("/settings"),
+      },
+      // Actions
+      {
+        id: "act-create-agent",
+        label: "Create Agent",
+        section: "Action",
+        icon: "+",
+        action: () => navigate("/agents?action=create"),
+      },
+      {
+        id: "act-create-channel",
+        label: "Create Channel",
+        section: "Action",
+        icon: "+",
+        action: () => navigate("/channels?action=create"),
+      },
+    ],
+    [navigate],
+  );
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return items;
+    const q = query.toLowerCase();
+    return items.filter((item) => item.label.toLowerCase().includes(q));
+  }, [items, query]);
+
+  return { open, query, setQuery, toggle, close, filtered };
+}


### PR DESCRIPTION
## Summary
- Add `CommandPalette` component with search overlay, keyboard navigation (arrow keys, Enter, Escape), and section-grouped results (Navigate / Action)
- Add `useCommandPalette` hook that listens for Cmd+K / Ctrl+K, manages open/close state, and provides fuzzy-filtered command items for all 15 pages plus create agent/channel actions
- Wire `CommandPalette` into `Layout.tsx` at the top level

Closes #2525

## Test plan
- [ ] Press Cmd+K (Mac) / Ctrl+K (Windows) to open the palette
- [ ] Type to filter results, verify matching works
- [ ] Arrow up/down to navigate items, Enter to select, Escape to close
- [ ] Click backdrop to close
- [ ] Verify navigation actions route to correct pages
- [ ] Verify Create Agent / Create Channel actions navigate with query params
- [ ] Check both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New command palette modal, toggled with Cmd+K / Ctrl+K, added to the app root
  * Real-time search with filtered results and grouped sections (Navigate / Action)
  * Keyboard support: ArrowUp/ArrowDown to navigate, Enter to execute, Escape to close
  * Focus and scroll behavior ensures the input and active result are visible
  * "No results found" state and keyboard hint added to help overlay
<!-- end of auto-generated comment: release notes by coderabbit.ai -->