### PR TITLE
feat: migrate config, env, secret commands to bcd API

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
@@ -226,8 +227,33 @@ func loadWorkspaceConfig() (*workspace.Config, string, error) {
 	return ws.Config, configPath, nil
 }
 
+// loadConfigViaAPI tries to load workspace config through the daemon API,
+// falling back to direct file read when the daemon is not running.
+func loadConfigViaAPI(ctx context.Context) (*workspace.Config, error) {
+	c, err := newDaemonClient(ctx)
+	if err != nil && client.IsDaemonNotRunning(err) {
+		// Offline fallback
+		cfg, _, loadErr := loadWorkspaceConfig()
+		return cfg, loadErr
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := c.Settings.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg workspace.Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("decode settings: %w", err)
+	}
+	return &cfg, nil
+}
+
 func runConfigShow(cmd *cobra.Command, args []string) error {
-	cfg, _, err := loadWorkspaceConfig()
+	cfg, err := loadConfigViaAPI(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -240,9 +266,9 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 	// If a key is specified, show only that section
 	if len(args) > 0 {
 		key := args[0]
-		value, err := getConfigValue(cfg, key)
-		if err != nil {
-			return err
+		value, valErr := getConfigValue(cfg, key)
+		if valErr != nil {
+			return valErr
 		}
 
 		if jsonOutput {
@@ -266,7 +292,7 @@ func runConfigShow(cmd *cobra.Command, args []string) error {
 }
 
 func runConfigGet(cmd *cobra.Command, args []string) error {
-	cfg, _, err := loadWorkspaceConfig()
+	cfg, err := loadConfigViaAPI(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -283,19 +309,54 @@ func runConfigGet(cmd *cobra.Command, args []string) error {
 }
 
 func runConfigSet(cmd *cobra.Command, args []string) error {
+	key := args[0]
+	valueStr := args[1]
+
+	// Try API first for live config updates
+	c, clientErr := newDaemonClient(cmd.Context())
+	if clientErr == nil {
+		// Load current config via API, apply change, push update
+		raw, getErr := c.Settings.Get(cmd.Context())
+		if getErr != nil {
+			return getErr
+		}
+		var cfg workspace.Config
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return fmt.Errorf("decode settings: %w", err)
+		}
+		if err := setConfigValue(&cfg, key, valueStr); err != nil {
+			return err
+		}
+		// Build patch from the modified config
+		data, err := json.Marshal(&cfg)
+		if err != nil {
+			return fmt.Errorf("marshal config: %w", err)
+		}
+		var patch map[string]any
+		if err := json.Unmarshal(data, &patch); err != nil {
+			return fmt.Errorf("build patch: %w", err)
+		}
+		if _, err := c.Settings.Update(cmd.Context(), patch); err != nil {
+			return err
+		}
+		fmt.Printf("Set %s = %s\n", key, valueStr)
+		return nil
+	}
+
+	if !client.IsDaemonNotRunning(clientErr) {
+		return clientErr
+	}
+
+	// Offline fallback: direct file modification
 	cfg, configPath, err := loadWorkspaceConfig()
 	if err != nil {
 		return err
 	}
 
-	key := args[0]
-	valueStr := args[1]
-
 	if err := setConfigValue(cfg, key, valueStr); err != nil {
 		return err
 	}
 
-	// Save the config
 	if err := cfg.Save(configPath); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}
@@ -304,8 +365,8 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runConfigList(cmd *cobra.Command, args []string) error {
-	cfg, _, err := loadWorkspaceConfig()
+func runConfigList(cmd *cobra.Command, _ []string) error {
+	cfg, err := loadConfigViaAPI(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -349,19 +410,19 @@ func runConfigEdit(cmd *cobra.Command, args []string) error {
 	return editorCmd.Run()
 }
 
-func runConfigValidate(cmd *cobra.Command, args []string) error {
+func runConfigValidate(cmd *cobra.Command, _ []string) error {
 	cfg, configPath, err := loadWorkspaceConfig()
 	if err != nil {
 		return err
 	}
 
 	if err := cfg.Validate(); err != nil {
-		fmt.Printf("❌ Config validation failed: %v\n", err)
+		fmt.Printf("Config validation failed: %v\n", err)
 		fmt.Printf("   File: %s\n", configPath)
 		return err
 	}
 
-	fmt.Printf("✓ Config is valid\n")
+	fmt.Printf("Config is valid\n")
 	fmt.Printf("  File: %s\n", configPath)
 	return nil
 }

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/workspace"
 )
 
@@ -84,13 +86,83 @@ func getProviderEnv(cfg *workspace.Config, name string) (*workspace.ProviderConf
 	return p, nil
 }
 
-func runEnvSet(_ *cobra.Command, args []string) error {
-	cfg, configPath, err := loadWorkspaceConfig()
+// envSetViaAPI sets an env var through the daemon API. Returns true if successful.
+func envSetViaAPI(cmd *cobra.Command, key, value string) (bool, error) {
+	c, err := newDaemonClient(cmd.Context())
+	if err != nil {
+		if client.IsDaemonNotRunning(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Load current config to merge with
+	raw, err := c.Settings.Get(cmd.Context())
+	if err != nil {
+		return false, err
+	}
+
+	var cfg workspace.Config
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return false, fmt.Errorf("decode settings: %w", err)
+	}
+
+	if envProvider != "" {
+		p, pErr := getProviderEnv(&cfg, envProvider)
+		if pErr != nil {
+			return false, pErr
+		}
+		p.Env[key] = value
+		// Patch providers section
+		data, mErr := json.Marshal(cfg.Providers)
+		if mErr != nil {
+			return false, mErr
+		}
+		var provPatch map[string]any
+		if err := json.Unmarshal(data, &provPatch); err != nil {
+			return false, err
+		}
+		if _, err := c.Settings.Patch(cmd.Context(), "providers", provPatch); err != nil {
+			return false, err
+		}
+	} else {
+		if cfg.Env == nil {
+			cfg.Env = make(map[string]string)
+		}
+		cfg.Env[key] = value
+		envAny := make(map[string]any, len(cfg.Env))
+		for k, v := range cfg.Env {
+			envAny[k] = v
+		}
+		if _, err := c.Settings.Patch(cmd.Context(), "env", envAny); err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func runEnvSet(cmd *cobra.Command, args []string) error {
+	key, value := args[0], args[1]
+
+	ok, err := envSetViaAPI(cmd, key, value)
 	if err != nil {
 		return err
 	}
+	if ok {
+		if envProvider != "" {
+			fmt.Printf("Set %s=%s (provider: %s)\n", key, value, envProvider)
+		} else {
+			fmt.Printf("Set %s=%s\n", key, value)
+		}
+		return nil
+	}
 
-	key, value := args[0], args[1]
+	// Offline fallback: direct file modification
+	cfg, configPath, loadErr := loadWorkspaceConfig()
+	if loadErr != nil {
+		return loadErr
+	}
 
 	if envProvider != "" {
 		p, pErr := getProviderEnv(cfg, envProvider)
@@ -117,13 +189,13 @@ func runEnvSet(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runEnvGet(_ *cobra.Command, args []string) error {
-	cfg, _, err := loadWorkspaceConfig()
+func runEnvGet(cmd *cobra.Command, args []string) error {
+	key := args[0]
+
+	cfg, err := loadConfigViaAPI(cmd.Context())
 	if err != nil {
 		return err
 	}
-
-	key := args[0]
 
 	if envProvider != "" {
 		p := cfg.GetProvider(envProvider)
@@ -147,8 +219,8 @@ func runEnvGet(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runEnvList(_ *cobra.Command, _ []string) error {
-	cfg, _, err := loadWorkspaceConfig()
+func runEnvList(cmd *cobra.Command, _ []string) error {
+	cfg, err := loadConfigViaAPI(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -214,13 +286,80 @@ func printEnvMap(env map[string]string, provider string) {
 	}
 }
 
-func runEnvUnset(_ *cobra.Command, args []string) error {
+func runEnvUnset(cmd *cobra.Command, args []string) error {
+	key := args[0]
+
+	// Try API first
+	c, clientErr := newDaemonClient(cmd.Context())
+	if clientErr == nil {
+		raw, getErr := c.Settings.Get(cmd.Context())
+		if getErr != nil {
+			return getErr
+		}
+		var cfg workspace.Config
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return fmt.Errorf("decode settings: %w", err)
+		}
+
+		if envProvider != "" {
+			p, pErr := getProviderEnv(&cfg, envProvider)
+			if pErr != nil {
+				return pErr
+			}
+			if _, ok := p.Env[key]; !ok {
+				return fmt.Errorf("environment variable %s is not set for provider %s", key, envProvider)
+			}
+			delete(p.Env, key)
+			if len(p.Env) == 0 {
+				p.Env = nil
+			}
+			data, mErr := json.Marshal(cfg.Providers)
+			if mErr != nil {
+				return mErr
+			}
+			var provPatch map[string]any
+			if err := json.Unmarshal(data, &provPatch); err != nil {
+				return err
+			}
+			if _, err := c.Settings.Patch(cmd.Context(), "providers", provPatch); err != nil {
+				return err
+			}
+		} else {
+			if _, ok := cfg.Env[key]; !ok {
+				return fmt.Errorf("environment variable %s is not set", key)
+			}
+			delete(cfg.Env, key)
+			if len(cfg.Env) == 0 {
+				cfg.Env = nil
+			}
+			envAny := make(map[string]any)
+			if cfg.Env != nil {
+				for k, v := range cfg.Env {
+					envAny[k] = v
+				}
+			}
+			if _, err := c.Settings.Patch(cmd.Context(), "env", envAny); err != nil {
+				return err
+			}
+		}
+
+		if envProvider != "" {
+			fmt.Printf("Unset %s (provider: %s)\n", key, envProvider)
+		} else {
+			fmt.Printf("Unset %s\n", key)
+		}
+		return nil
+	}
+
+	if !client.IsDaemonNotRunning(clientErr) {
+		return clientErr
+	}
+
+	// Offline fallback: direct file modification
 	cfg, configPath, err := loadWorkspaceConfig()
 	if err != nil {
 		return err
 	}
-
-	key := args[0]
 
 	if envProvider != "" {
 		p, pErr := getProviderEnv(cfg, envProvider)

--- a/internal/cmd/secret.go
+++ b/internal/cmd/secret.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/secret"
 	"github.com/rpuneet/bc/pkg/ui"
 )
@@ -122,48 +123,54 @@ func openSecretStore() (*secret.Store, error) {
 	return secret.NewStore(ws.RootDir, passphrase)
 }
 
+// resolveSecretValue extracts the secret value from flags or stdin.
+func resolveSecretValue() (string, error) {
+	switch {
+	case secretSetValue != "":
+		return secretSetValue, nil
+	case secretSetFromEnv != "":
+		value := os.Getenv(secretSetFromEnv)
+		if value == "" {
+			return "", fmt.Errorf("environment variable %q is empty or not set", secretSetFromEnv)
+		}
+		return value, nil
+	case secretSetFromFile != "":
+		data, err := os.ReadFile(secretSetFromFile) //nolint:gosec // user-provided path
+		if err != nil {
+			return "", fmt.Errorf("read secret file: %w", err)
+		}
+		return strings.TrimRight(string(data), "\n\r"), nil
+	default:
+		// Read from stdin
+		stat, _ := os.Stdin.Stat()
+		if (stat.Mode() & os.ModeCharDevice) != 0 {
+			return "", fmt.Errorf("no value provided (use --value, --from-env, --from-file, or pipe to stdin)")
+		}
+		data, err := io.ReadAll(io.LimitReader(os.Stdin, 1024*1024)) // 1MB max
+		if err != nil {
+			return "", fmt.Errorf("read stdin: %w", err)
+		}
+		return strings.TrimRight(string(data), "\n\r"), nil
+	}
+}
+
 func runSecretSet(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	if !validIdentifier(name) {
 		return fmt.Errorf("secret name %q contains invalid characters (use letters, numbers, dash, underscore)", name)
 	}
 
-	// Resolve value from flags
-	var value string
-	switch {
-	case secretSetValue != "":
-		value = secretSetValue
-	case secretSetFromEnv != "":
-		value = os.Getenv(secretSetFromEnv)
-		if value == "" {
-			return fmt.Errorf("environment variable %q is empty or not set", secretSetFromEnv)
-		}
-	case secretSetFromFile != "":
-		data, err := os.ReadFile(secretSetFromFile) //nolint:gosec // user-provided path
-		if err != nil {
-			return fmt.Errorf("read secret file: %w", err)
-		}
-		value = strings.TrimRight(string(data), "\n\r")
-	default:
-		// Read from stdin
-		stat, _ := os.Stdin.Stat()
-		if (stat.Mode() & os.ModeCharDevice) != 0 {
-			return fmt.Errorf("no value provided (use --value, --from-env, --from-file, or pipe to stdin)")
-		}
-		data, err := io.ReadAll(io.LimitReader(os.Stdin, 1024*1024)) // 1MB max
-		if err != nil {
-			return fmt.Errorf("read stdin: %w", err)
-		}
-		value = strings.TrimRight(string(data), "\n\r")
-	}
-
-	store, err := openSecretStore()
+	value, err := resolveSecretValue()
 	if err != nil {
 		return err
 	}
-	defer func() { _ = store.Close() }()
 
-	if err := store.Set(name, value, secretSetDesc); err != nil {
+	c, err := newDaemonClient(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.Secrets.Create(cmd.Context(), name, value, secretSetDesc); err != nil {
 		return err
 	}
 
@@ -177,6 +184,7 @@ func runSecretGet(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("secret name %q contains invalid characters", name)
 	}
 
+	// secret get requires direct store access — the API never returns values
 	store, err := openSecretStore()
 	if err != nil {
 		return err
@@ -192,14 +200,13 @@ func runSecretGet(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func runSecretList(cmd *cobra.Command, args []string) error {
-	store, err := openSecretStore()
+func runSecretList(cmd *cobra.Command, _ []string) error {
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
 	}
-	defer func() { _ = store.Close() }()
 
-	secrets, err := store.List()
+	secrets, err := c.Secrets.List(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -210,7 +217,7 @@ func runSecretList(cmd *cobra.Command, args []string) error {
 	}
 	if jsonOutput {
 		response := struct {
-			Secrets []*secret.SecretMeta `json:"secrets"`
+			Secrets []client.SecretInfo `json:"secrets"`
 		}{Secrets: secrets}
 		enc := json.NewEncoder(cmd.OutOrStdout())
 		enc.SetIndent("", "  ")
@@ -243,18 +250,14 @@ func runSecretShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("secret name %q contains invalid characters", name)
 	}
 
-	store, err := openSecretStore()
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
 	}
-	defer func() { _ = store.Close() }()
 
-	meta, err := store.GetMeta(name)
+	meta, err := c.Secrets.Get(cmd.Context(), name)
 	if err != nil {
 		return err
-	}
-	if meta == nil {
-		return fmt.Errorf("secret %q not found (use 'bc secret list' to see available secrets)", name)
 	}
 
 	jsonOutput, err := cmd.Flags().GetBool("json")
@@ -276,9 +279,16 @@ func runSecretShow(cmd *cobra.Command, args []string) error {
 	)
 
 	if secretShowReveal {
-		value, err := store.GetValue(name)
-		if err != nil {
-			return fmt.Errorf("reveal secret: %w", err)
+		// --reveal requires direct store access — API never returns values
+		store, storeErr := openSecretStore()
+		if storeErr != nil {
+			return fmt.Errorf("reveal secret: %w", storeErr)
+		}
+		defer func() { _ = store.Close() }()
+
+		value, valErr := store.GetValue(name)
+		if valErr != nil {
+			return fmt.Errorf("reveal secret: %w", valErr)
 		}
 		fmt.Printf("\nValue: %s\n", value)
 	}
@@ -292,13 +302,12 @@ func runSecretDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("secret name %q contains invalid characters", name)
 	}
 
-	store, err := openSecretStore()
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
 	}
-	defer func() { _ = store.Close() }()
 
-	if err := store.Delete(name); err != nil {
+	if err := c.Secrets.Delete(cmd.Context(), name); err != nil {
 		return err
 	}
 

--- a/pkg/client/secrets.go
+++ b/pkg/client/secrets.go
@@ -28,9 +28,9 @@ func (s *SecretsClient) List(ctx context.Context) ([]SecretInfo, error) {
 	return secrets, nil
 }
 
-// Create creates a new secret.
-func (s *SecretsClient) Create(ctx context.Context, name, value string) (*SecretInfo, error) {
-	body := map[string]string{"name": name, "value": value}
+// Create creates or updates a secret with an optional description.
+func (s *SecretsClient) Create(ctx context.Context, name, value, description string) (*SecretInfo, error) {
+	body := map[string]string{"name": name, "value": value, "description": description}
 	var info SecretInfo
 	if err := s.client.post(ctx, "/api/secrets", body, &info); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- **secret.go**: Replace direct `pkg/secret` store access with `client.Secrets.*` API calls for set, list, show, and delete operations. Direct store access is preserved for `get` (value retrieval) and `show --reveal` since the API never exposes secret values.
- **config.go**: Add `loadConfigViaAPI()` helper that tries `SettingsClient.Get()` first, falls back to direct config file read when bcd is not running. Applied to `show`, `get`, `list`, `set`. Keep `edit`, `reset`, `user` as direct file operations.
- **env.go**: `env set/get/list/unset` use `SettingsClient` when bcd is running, fall back to direct config file modification when offline.
- **pkg/client/secrets.go**: Add `description` parameter to `Create()`.

Closes #2519

## Test plan
- [x] All existing config tests pass (`TestConfigShow`, `TestConfigGet`, `TestConfigSet`, etc.)
- [x] All client tests pass
- [x] `go vet` clean
- [x] `golangci-lint` clean (0 issues)
- [ ] Manual: verify `bc secret set/list/show/delete` work with bcd running
- [ ] Manual: verify `bc config show/get/set` work with and without bcd
- [ ] Manual: verify `bc env set/get/list/unset` work with and without bcd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configuration, environment variable, and secret management commands now operate through the daemon API with automatic fallback to file-based mode when the daemon is unavailable.
  * Added description support when creating secrets.

* **Improvements**
  * Enhanced configuration validation command output and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->