### PR TITLE
feat: migrate remaining agent/workspace direct accesses to API

### DIFF
--- a/internal/cmd/agent_health.go
+++ b/internal/cmd/agent_health.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/bc/pkg/client"
-	"github.com/rpuneet/bc/pkg/events"
 	"github.com/rpuneet/bc/pkg/log"
 	"github.com/rpuneet/bc/pkg/ui"
 )
@@ -128,7 +127,7 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 
 	// Stuck detection via daemon event log
 	if agentHealthDetect {
-		stuckConfig := events.StuckConfig{
+		stuckConfig := client.StuckConfig{
 			ActivityTimeout: timeout,
 			WorkTimeout:     workTimeout,
 			MaxFailures:     agentHealthMaxFail,
@@ -141,19 +140,7 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 				continue
 			}
 
-			// Convert client EventInfo to events.Event for stuck detection
-			evts := make([]events.Event, 0, len(agentEvents))
-			for _, e := range agentEvents {
-				evts = append(evts, events.Event{
-					Timestamp: e.Timestamp,
-					Type:      events.EventType(e.Type),
-					Agent:     e.Agent,
-					Message:   e.Message,
-					Data:      e.Data,
-				})
-			}
-
-			stuck := events.DetectStuck(evts, stuckConfig)
+			stuck := client.DetectStuck(agentEvents, stuckConfig)
 			if stuck.IsStuck {
 				healthResults[i].IsStuck = true
 				healthResults[i].StuckReason = string(stuck.Reason)

--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/rpuneet/bc/pkg/client"
 	"github.com/rpuneet/bc/pkg/ui"
-	"github.com/rpuneet/bc/pkg/workspace"
 )
 
 var channelCmd = &cobra.Command{
@@ -427,7 +427,7 @@ func runChannelSend(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	sender := getUserSender()
+	sender := getUserSenderCtx(cmd.Context())
 	if _, err := c.Channels.Send(cmd.Context(), channelName, sender, message); err != nil {
 		return err
 	}
@@ -643,7 +643,7 @@ func runChannelReact(cmd *cobra.Command, args []string) error {
 	}
 	msgID := int(msgs[msgIndex-1].ID)
 
-	added, err := c.Channels.React(cmd.Context(), channelName, msgID, emoji, getUserSender())
+	added, err := c.Channels.React(cmd.Context(), channelName, msgID, emoji, getUserSenderCtx(cmd.Context()))
 	if err != nil {
 		return err
 	}
@@ -879,23 +879,34 @@ func parseTimestamp(s string) (time.Time, error) {
 	return time.Time{}, fmt.Errorf("expected RFC3339 (2006-01-02T15:04:05Z) or date (2006-01-02), got %q", s)
 }
 
-// getUserSender returns the sender identity for channel messages.
+// defaultNickname is the fallback sender name when no user nickname is configured.
+const defaultNickname = "@bc"
+
+// getUserSenderCtx returns the sender identity for channel messages.
 // If running as an agent, returns BC_AGENT_ID.
-// Otherwise, returns the user's configured nickname from workspace config.
-func getUserSender() string {
+// Otherwise, queries the daemon settings API for user.nickname.
+func getUserSenderCtx(ctx context.Context) string {
 	// Check if running as an agent
 	if agentID := os.Getenv("BC_AGENT_ID"); agentID != "" {
 		return agentID
 	}
 
-	// Try to get nickname from workspace config (v2)
-	ws, err := getWorkspace()
-	if err == nil && ws != nil && ws.Config != nil {
-		if ws.Config.User.Nickname != "" {
-			return ws.Config.User.Nickname
+	// Try to get nickname from daemon settings API
+	c, err := newDaemonClient(ctx)
+	if err == nil {
+		raw, settingsErr := c.Settings.Get(ctx)
+		if settingsErr == nil {
+			var settings struct {
+				User struct {
+					Nickname string `json:"nickname"`
+				} `json:"user"`
+			}
+			if jsonErr := json.Unmarshal(raw, &settings); jsonErr == nil && settings.User.Nickname != "" {
+				return settings.User.Nickname
+			}
 		}
 	}
 
 	// Fallback to default nickname
-	return workspace.DefaultNickname
+	return defaultNickname
 }

--- a/pkg/client/stuck.go
+++ b/pkg/client/stuck.go
@@ -1,0 +1,155 @@
+package client
+
+import (
+	"time"
+)
+
+// StuckReason describes why an agent is considered stuck.
+type StuckReason string
+
+const (
+	// StuckNoActivity indicates no events in the timeout period.
+	StuckNoActivity StuckReason = "no_activity"
+	// StuckRepeatedFailures indicates the same task has failed multiple times.
+	StuckRepeatedFailures StuckReason = "repeated_failures"
+	// StuckWorkTimeout indicates work started but not completed within timeout.
+	StuckWorkTimeout StuckReason = "work_timeout"
+)
+
+// Event type constants matching pkg/events.
+const (
+	eventWorkStarted   = "work.started"
+	eventWorkCompleted = "work.completed"
+	eventWorkFailed    = "work.failed"
+)
+
+// StuckDetection contains the result of analyzing an agent for stuck conditions.
+//
+//nolint:govet // JSON field order is more important than memory layout
+type StuckDetection struct {
+	LastEventTime time.Time     `json:"last_event_time,omitempty"`
+	IdleDuration  time.Duration `json:"idle_duration,omitempty"`
+	AgentName     string        `json:"agent_name"`
+	Reason        StuckReason   `json:"reason,omitempty"`
+	Details       string        `json:"details,omitempty"`
+	FailureCount  int           `json:"failure_count,omitempty"`
+	IsStuck       bool          `json:"is_stuck"`
+}
+
+// StuckConfig configures stuck detection thresholds.
+type StuckConfig struct {
+	// ActivityTimeout is how long without events before considering stuck.
+	ActivityTimeout time.Duration
+	// WorkTimeout is how long a task can run before considered stuck.
+	WorkTimeout time.Duration
+	// MaxFailures is the number of consecutive failures before considered stuck.
+	MaxFailures int
+}
+
+// DetectStuck analyzes events to determine if an agent is stuck.
+// This mirrors pkg/events.DetectStuck but operates on client EventInfo types,
+// avoiding the need for CLI commands to import pkg/events directly.
+func DetectStuck(events []EventInfo, config StuckConfig) StuckDetection {
+	if len(events) == 0 {
+		return StuckDetection{
+			IsStuck: false,
+		}
+	}
+
+	detection := StuckDetection{
+		AgentName: events[0].Agent,
+	}
+
+	// Find the most recent event
+	var lastEvent EventInfo
+	for _, ev := range events {
+		if ev.Timestamp.After(lastEvent.Timestamp) {
+			lastEvent = ev
+		}
+	}
+	detection.LastEventTime = lastEvent.Timestamp
+	detection.IdleDuration = time.Since(lastEvent.Timestamp)
+
+	// Check 1: No activity in timeout period
+	if detection.IdleDuration > config.ActivityTimeout {
+		detection.IsStuck = true
+		detection.Reason = StuckNoActivity
+		detection.Details = "no events in " + detection.IdleDuration.Round(time.Second).String()
+		return detection
+	}
+
+	// Check 2: Repeated failures on same task
+	failureCount := countRecentFailures(events, config.ActivityTimeout)
+	detection.FailureCount = failureCount
+	if failureCount >= config.MaxFailures {
+		detection.IsStuck = true
+		detection.Reason = StuckRepeatedFailures
+		detection.Details = "task failed " + string(rune('0'+failureCount)) + " times"
+		return detection
+	}
+
+	// Check 3: Work started but not completed within timeout
+	if workTimedOut := checkWorkTimeout(events, config.WorkTimeout); workTimedOut != "" {
+		detection.IsStuck = true
+		detection.Reason = StuckWorkTimeout
+		detection.Details = "work '" + workTimedOut + "' exceeds timeout"
+		return detection
+	}
+
+	return detection
+}
+
+// countRecentFailures counts consecutive WorkFailed events in the recent window.
+func countRecentFailures(events []EventInfo, window time.Duration) int {
+	cutoff := time.Now().Add(-window)
+	count := 0
+	for i := len(events) - 1; i >= 0; i-- {
+		ev := events[i]
+		if ev.Timestamp.Before(cutoff) {
+			break
+		}
+		if ev.Type == eventWorkFailed {
+			count++
+		} else if ev.Type == eventWorkCompleted {
+			break
+		}
+	}
+	return count
+}
+
+// checkWorkTimeout checks if any work has been running longer than the timeout.
+func checkWorkTimeout(events []EventInfo, timeout time.Duration) string {
+	startedWork := make(map[string]time.Time)
+
+	for _, ev := range events {
+		switch ev.Type {
+		case eventWorkStarted:
+			task := ""
+			if ev.Message != "" {
+				task = ev.Message
+			} else if t, ok := ev.Data["task"].(string); ok {
+				task = t
+			}
+			if task != "" {
+				startedWork[task] = ev.Timestamp
+			}
+		case eventWorkCompleted, eventWorkFailed:
+			task := ""
+			if ev.Message != "" {
+				task = ev.Message
+			} else if t, ok := ev.Data["task"].(string); ok {
+				task = t
+			}
+			delete(startedWork, task)
+		}
+	}
+
+	now := time.Now()
+	for task, startTime := range startedWork {
+		if now.Sub(startTime) > timeout {
+			return task
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
## Summary
- **agent_health.go**: Removed `pkg/events` import; stuck detection now uses new `client.DetectStuck` helper that operates directly on `client.EventInfo`, eliminating the conversion step between event types
- **channel.go**: Removed `pkg/workspace` import; `getUserSenderCtx()` now queries the daemon Settings API for `user.nickname` instead of loading the workspace config directly, with `"@bc"` fallback
- **pkg/client/stuck.go**: New client-side stuck detection module mirroring `pkg/events.DetectStuck` logic but operating on `client.EventInfo` types

Inherently local operations (agent attach, peek --follow, delete --purge) are preserved unchanged.

Closes #2521

## Test plan
- [x] `go build` passes for affected packages
- [x] `go vet` passes for `./internal/cmd/...` and `./pkg/client/...`
- [x] `golangci-lint run` passes with 0 issues for affected packages
- [x] `go test -race ./pkg/client/...` passes
- [x] Pre-existing integration test failures confirmed unrelated (live daemon state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)