### PR TITLE
fix(agent): fix data races, stale states, and lock contention

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -92,6 +92,8 @@ func run(addr, wsRoot, corsOrigin string) error {
 	if err := agentMgr.LoadState(); err != nil {
 		log.Warn("failed to load agent state", "error", err)
 	}
+	defer agentMgr.Close() //nolint:errcheck // best-effort
+	go agentMgr.RunReconciler(ctx, 10*time.Second)
 	agentSvc := bcagent.NewAgentService(agentMgr, hub, nil)
 
 	statsCollector := bcagent.NewStatsCollector(agentMgr)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -784,24 +784,31 @@ func (m *Manager) SpawnAgentWithOptions(ctx context.Context, opts SpawnOptions) 
 	}
 
 	// Check if already exists in our state
-	if existing, exists := m.agents[name]; exists {
-		// If its tmux session is still alive, reuse it
-		if m.runtimeForAgent(name).HasSession(ctx, name) {
-			// Correct stale stopped/error state when session is actually alive
-			if existing.State == StateStopped || existing.State == StateError {
-				existing.State = StateIdle
-				existing.StartedAt = time.Now()
-			}
-			existing.UpdatedAt = time.Now()
-			if err := m.saveState(); err != nil {
-				log.Warn("failed to save agent state", "error", err)
+	if _, exists := m.agents[name]; exists {
+		// Snapshot the runtime backend before releasing the lock so we can
+		// call HasSession (a potentially blocking subprocess) outside the lock (#2544).
+		rt := m.runtimeForAgent(name)
+		m.mu.Unlock()
+
+		// HasSession may shell out to tmux/docker — run without any lock.
+		if rt.HasSession(ctx, name) {
+			m.mu.Lock()
+			if existing, ok := m.agents[name]; ok {
+				// Correct stale stopped/error state when session is actually alive
+				if existing.State == StateStopped || existing.State == StateError {
+					existing.State = StateIdle
+					existing.StartedAt = time.Now()
+				}
+				existing.UpdatedAt = time.Now()
+				if err := m.saveState(); err != nil {
+					log.Warn("failed to save agent state", "error", err)
+				}
 			}
 			m.mu.Unlock()
-			return existing, nil
+			return m.GetAgent(name), nil
 		}
 		// Agent exists but session is dead — restart it.
-		// Release global lock; startAgent handles its own locking.
-		m.mu.Unlock()
+		// startAgent handles its own locking.
 		return m.startAgent(ctx, name, opts)
 	}
 
@@ -813,13 +820,16 @@ func (m *Manager) SpawnAgentWithOptions(ctx context.Context, opts SpawnOptions) 
 // startAgent restarts an existing agent whose session has died.
 // Acquires per-agent lock internally for slow I/O; does NOT require caller to hold mu.
 func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions) (*Agent, error) {
-	// Phase 1: global lock — read agent state and build command config
+	// Phase 1: global lock — snapshot agent state for building the command config.
+	// We read fields into local variables so we don't mutate the shared Agent
+	// struct while readers may be copying it under RLock (#2541).
 	m.mu.Lock()
 	existing := m.agents[name]
 	wsPath := opts.Workspace
 
+	runtimeBackend := existing.RuntimeBackend
 	if opts.Runtime != "" {
-		existing.RuntimeBackend = opts.Runtime
+		runtimeBackend = opts.Runtime
 	}
 
 	// Only resume if we have a real Claude session ID (UUID format) — avoids
@@ -830,12 +840,10 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	isRealSessionID := len(sessionID) == 36 && sessionID[8] == '-'
 	resume := !opts.Fresh && isRealSessionID
 	if opts.Fresh {
-		existing.SessionID = ""
 		sessionID = ""
 	}
 	if opts.SessionID != "" {
 		sessionID = opts.SessionID
-		existing.SessionID = sessionID
 	}
 	toolName := existing.Tool
 	if toolName == "" {
@@ -849,7 +857,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	}
 
 	// Apply provider session customization for container backends only.
-	if existing.RuntimeBackend != "tmux" {
+	if runtimeBackend != "tmux" {
 		if toolName != "" && m.providerRegistry != nil {
 			if p, ok := m.providerRegistry.Get(toolName); ok {
 				if sc, ok := p.(provider.SessionCustomizer); ok {
@@ -859,18 +867,24 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 		}
 	}
 
+	agentRole := existing.Role
+	parentID := existing.ParentID
+	envFile := existing.EnvFile
+	logFile := existing.LogFile
+	prevState := existing.State
+
 	env := map[string]string{
 		"BC_AGENT_ID":   name,
-		"BC_AGENT_ROLE": string(existing.Role),
+		"BC_AGENT_ROLE": string(agentRole),
 		"BC_WORKSPACE":  wsPath,
 	}
 	if toolName != "" {
 		env["BC_AGENT_TOOL"] = toolName
 	}
-	if existing.ParentID != "" {
-		env["BC_PARENT_ID"] = existing.ParentID
+	if parentID != "" {
+		env["BC_PARENT_ID"] = parentID
 	}
-	injectEnv(env, wsPath, toolName, existing.EnvFile)
+	injectEnv(env, wsPath, toolName, envFile)
 
 	// MCP servers and plugins are configured via file-based config
 	// (.mcp.json and .claude.json) written by SetupAgentFromRole.
@@ -889,34 +903,49 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 
 	if err := rt.CreateSessionWithEnv(ctx, name, wsPath, agentCmd, env); err != nil {
 		agentLock.Unlock()
+		// Reset state so the agent isn't permanently stuck in StateStarting (#2543).
+		m.mu.Lock()
+		if a, ok := m.agents[name]; ok && a.State == StateStarting {
+			a.State = StateStopped
+			a.UpdatedAt = time.Now()
+			if saveErr := m.saveState(); saveErr != nil {
+				log.Warn("failed to save agent state after start failure", "error", saveErr)
+			}
+		}
+		m.mu.Unlock()
 		return nil, fmt.Errorf("failed to recreate session: %w", err)
 	}
 
 	// Resume log streaming
-	if existing.LogFile != "" {
-		truncateLogFile(existing.LogFile, m.maxLogBytes)
-		if pipeErr := rt.PipePane(ctx, name, existing.LogFile); pipeErr != nil {
+	newLogFile := logFile
+	if logFile != "" {
+		truncateLogFile(logFile, m.maxLogBytes)
+		if pipeErr := rt.PipePane(ctx, name, logFile); pipeErr != nil {
 			log.Warn("failed to resume pipe-pane", "agent", name, "error", pipeErr)
 		}
 	} else {
-		existing.LogFile = m.setupLogPipe(ctx, name, wsPath)
+		newLogFile = m.setupLogPipe(ctx, name, wsPath)
 	}
-
-	if existing.State == StateStopped || existing.State == StateError {
-		existing.State = StateStarting
-	}
-	existing.UpdatedAt = time.Now()
 
 	agentLock.Unlock()
 
-	// Phase 3: global lock — persist state
+	// Phase 3: global lock — apply all mutations atomically to the shared struct (#2541).
 	m.mu.Lock()
-	if err := m.saveState(); err != nil {
-		log.Warn("failed to save agent state", "error", err)
+	if a, ok := m.agents[name]; ok {
+		a.RuntimeBackend = runtimeBackend
+		a.SessionID = sessionID
+		a.LogFile = newLogFile
+		if prevState == StateStopped || prevState == StateError {
+			a.State = StateStarting
+		}
+		a.UpdatedAt = time.Now()
+		if err := m.saveState(); err != nil {
+			log.Warn("failed to save agent state", "error", err)
+		}
 	}
 	m.mu.Unlock()
 
-	return existing, nil
+	return m.GetAgent(name), nil
 }
 
 // createAgent creates a brand-new agent and its runtime session.
@@ -928,11 +957,17 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	parentID := opts.ParentID
 	tool := opts.Tool
 
-	// Phase 1: global lock — build command config, register agent in map
-	m.mu.Lock()
+	// Snapshot backends under lock, then release before blocking subprocess calls (#2544).
+	m.mu.RLock()
+	backends := make(map[string]runtime.Backend, len(m.backends))
+	for k, v := range m.backends {
+		backends[k] = v
+	}
+	m.mu.RUnlock()
 
-	// If a session exists from a previous crash, kill it in all backends
-	for beName, be := range m.backends {
+	// If a session exists from a previous crash, kill it in all backends.
+	// HasSession / KillSession may shell out — run without holding any lock.
+	for beName, be := range backends {
 		if be.HasSession(ctx, name) {
 			log.Debug("killing stale session", "session", name, "backend", beName)
 			if err := be.KillSession(ctx, name); err != nil {
@@ -940,6 +975,9 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 			}
 		}
 	}
+
+	// Phase 1: global lock — build command config, register agent in map
+	m.mu.Lock()
 
 	// Resolve effective tool: use explicit tool or fall back to default.
 	// Persist the resolved value so restarts use the same tool.
@@ -1660,12 +1698,30 @@ func (m *Manager) RenameAgent(ctx context.Context, oldName, newName string) erro
 
 // StopAll stops all agents.
 func (m *Manager) StopAll(ctx context.Context) error {
+	// Snapshot agent names and their runtimes under lock, then release
+	// before calling KillSession which may block on subprocess I/O (#2544).
+	m.mu.RLock()
+	type agentRT struct {
+		rt   runtime.Backend
+		name string
+	}
+	targets := make([]agentRT, 0, len(m.agents))
+	for name := range m.agents {
+		targets = append(targets, agentRT{rt: m.runtimeForAgent(name), name: name})
+	}
+	m.mu.RUnlock()
+
+	// Kill sessions without holding any lock.
+	for _, t := range targets {
+		_ = t.rt.KillSession(ctx, t.name) //nolint:errcheck // best-effort cleanup
+	}
+
+	// Re-acquire lock to update state.
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	now := time.Now()
-	for name, agent := range m.agents {
-		_ = m.runtimeForAgent(name).KillSession(ctx, name) //nolint:errcheck // best-effort cleanup
+	for _, agent := range m.agents {
 		agent.State = StateStopped
 		agent.StoppedAt = &now
 		agent.UpdatedAt = now


### PR DESCRIPTION
## Summary

- **#2540**: Start `RunReconciler` goroutine on bcd startup so agent states are periodically refreshed instead of going stale after crashes/restarts
- **#2541**: Eliminate data race in `startAgent` by reading Agent fields into local variables under global lock, then writing mutations back atomically in Phase 3 (instead of mutating the shared struct under only the per-agent lock)
- **#2543**: Reset agent state to `StateStopped` when `CreateSessionWithEnv` fails, preventing agents from getting permanently stuck in `StateStarting`
- **#2544**: Move blocking `HasSession`/`KillSession` subprocess calls outside the global mutex in `SpawnAgentWithOptions`, `createAgent`, and `StopAll` to avoid starving concurrent readers

Closes #2540, Closes #2541, Closes #2543, Closes #2544

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race ./pkg/agent/` — passes with race detector
- [ ] Manual: restart bcd and verify agents transition to correct states
- [ ] Manual: kill an agent's tmux session and verify reconciler detects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent manager now properly shuts down when the application stops.
  * Reconciliation loop is now running periodically to maintain consistency.
  * Agent startup failures are now properly handled, preventing agents from remaining stuck in intermediate states.
  * Improved reliability of agent state management during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->