### PR TITLE
feat: add workspace up/down, agent rename/stop-all, secret edit to web UI

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -343,6 +343,12 @@ export const api = {
       `/agents/${encodeURIComponent(name)}${force ? "?force=true" : ""}`,
       { method: "DELETE" },
     ),
+  renameAgent: (name: string, newName: string) =>
+    request<Agent>(`/agents/${encodeURIComponent(name)}/rename`, {
+      method: "POST",
+      body: JSON.stringify({ name: newName }),
+    }),
+  stopAllAgents: () => request<void>("/agents/stop-all", { method: "POST" }),
   sendToAgent: (name: string, message: string) =>
     request<void>(`/agents/${encodeURIComponent(name)}/send`, {
       method: "POST",
@@ -492,11 +498,18 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ name, value, description: description ?? "" }),
     }),
+  updateSecret: (name: string, value: string) =>
+    request<Secret>(`/secrets/${encodeURIComponent(name)}`, {
+      method: "PUT",
+      body: JSON.stringify({ value }),
+    }),
   deleteSecret: (name: string) =>
     request<void>(`/secrets/${encodeURIComponent(name)}`, { method: "DELETE" }),
   getWorkspace: () => request<WorkspaceInfo>("/workspace"),
   getWorkspaceStatus: () =>
     request<Record<string, unknown>>("/workspace/status"),
+  workspaceUp: () => request<void>("/workspace/up", { method: "POST" }),
+  workspaceDown: () => request<void>("/workspace/down", { method: "POST" }),
 
   getStatsSystem: () => request<SystemStats>("/stats/system"),
   getStatsSummary: () => request<StatsSummary>("/stats/summary"),

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -173,6 +173,76 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
   );
 }
 
+// --- Inline Rename ---
+
+function InlineAgentName({
+  agent,
+  onRenamed,
+}: {
+  agent: Agent;
+  onRenamed: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [newName, setNewName] = useState(agent.name);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed || trimmed === agent.name) {
+      setEditing(false);
+      setNewName(agent.name);
+      return;
+    }
+    setSaving(true);
+    try {
+      await api.renameAgent(agent.name, trimmed);
+      setEditing(false);
+      onRenamed();
+    } catch {
+      setNewName(agent.name);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <input
+        type="text"
+        value={newName}
+        onChange={(e) => setNewName(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSave();
+          if (e.key === "Escape") {
+            setEditing(false);
+            setNewName(agent.name);
+          }
+        }}
+        onBlur={handleSave}
+        disabled={saving}
+        autoFocus
+        onClick={(e) => e.stopPropagation()}
+        className="px-1 py-0.5 text-sm font-medium rounded border border-bc-accent bg-bc-bg text-bc-fg focus:outline-none focus:ring-1 focus:ring-bc-accent w-32"
+        aria-label="Rename agent"
+      />
+    );
+  }
+
+  return (
+    <span
+      className="font-medium cursor-pointer hover:text-bc-accent transition-colors"
+      onClick={(e) => {
+        e.stopPropagation();
+        setEditing(true);
+      }}
+      title="Click to rename"
+    >
+      {agent.name}
+    </span>
+  );
+}
+
 // --- Agent Action Buttons ---
 
 function AgentActions({ agent, onDone }: { agent: Agent; onDone: () => void }) {
@@ -288,6 +358,19 @@ export function Agents() {
   const navigate = useNavigate();
 
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
+  const [stoppingAll, setStoppingAll] = useState(false);
+
+  const handleStopAll = async () => {
+    setStoppingAll(true);
+    try {
+      await api.stopAllAgents();
+      refresh();
+    } catch {
+      // transient error; list will refresh
+    } finally {
+      setStoppingAll(false);
+    }
+  };
 
   // Refresh on agent lifecycle events via SSE
   useEffect(() => {
@@ -361,7 +444,23 @@ export function Agents() {
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">Agents</h1>
-        <span className="text-sm text-bc-muted">{agentList.length} agents</span>
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-bc-muted">
+            {agentList.length} agents
+          </span>
+          {agentList.some(
+            (a) => a.state !== "stopped" && a.state !== "error",
+          ) && (
+            <button
+              onClick={handleStopAll}
+              disabled={stoppingAll}
+              className="px-3 py-1.5 text-sm rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400"
+              aria-label="Stop all agents"
+            >
+              {stoppingAll ? "Stopping..." : "Stop All"}
+            </button>
+          )}
+        </div>
       </div>
 
       <CreateAgentForm onCreated={refresh} />
@@ -411,7 +510,7 @@ export function Agents() {
                     className="border-b border-bc-border/50 cursor-pointer hover:bg-bc-surface transition-colors duration-150"
                   >
                     <td className="px-4 py-2">
-                      <span className="font-medium">{a.name}</span>
+                      <InlineAgentName agent={a} onRenamed={refresh} />
                     </td>
                     <td className="px-4 py-2">
                       <span className="text-bc-muted">{a.role}</span>

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -89,6 +89,90 @@ function AddSecretForm({ onCreated }: { onCreated: () => void }) {
   );
 }
 
+function EditSecretButton({
+  name,
+  onUpdated,
+}: {
+  name: string;
+  onUpdated: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async () => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await api.updateSecret(name, trimmed);
+      setValue("");
+      setEditing(false);
+      onUpdated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update secret");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSave();
+            if (e.key === "Escape") {
+              setEditing(false);
+              setValue("");
+              setError(null);
+            }
+          }}
+          placeholder="new value"
+          autoFocus
+          className="px-2 py-1 text-xs rounded border border-bc-border bg-bc-bg text-bc-fg focus:outline-none focus:ring-1 focus:ring-bc-accent w-36"
+          aria-label={`New value for ${name}`}
+        />
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving || !value.trim()}
+          className="px-2 py-1 rounded bg-bc-accent text-white text-xs font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          {saving ? "..." : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setEditing(false);
+            setValue("");
+            setError(null);
+          }}
+          className="px-2 py-1 rounded border border-bc-border text-bc-muted text-xs hover:text-bc-text transition-colors"
+        >
+          Cancel
+        </button>
+        {error && <span className="text-xs text-red-400">{error}</span>}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      className="px-2 py-1 rounded border border-bc-border text-bc-muted text-xs hover:text-bc-accent hover:border-bc-accent/50 transition-colors"
+    >
+      Edit
+    </button>
+  );
+}
+
 function DeleteButton({
   name,
   onDeleted,
@@ -218,6 +302,13 @@ export function Secrets() {
             ? new Date(s.created_at).toLocaleDateString()
             : "\u2014"}
         </span>
+      ),
+    },
+    {
+      key: "edit",
+      label: "",
+      render: (s: Secret) => (
+        <EditSecretButton name={s.name} onUpdated={refresh} />
       ),
     },
     {

--- a/web/src/views/Workspace.tsx
+++ b/web/src/views/Workspace.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { api } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
@@ -13,6 +13,39 @@ export function Workspace() {
     refresh,
     timedOut,
   } = usePolling(fetcher, 10000);
+
+  const [actionBusy, setActionBusy] = useState<"up" | "down" | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const handleUp = async () => {
+    setActionBusy("up");
+    setActionError(null);
+    try {
+      await api.workspaceUp();
+      refresh();
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : "Failed to start workspace",
+      );
+    } finally {
+      setActionBusy(null);
+    }
+  };
+
+  const handleDown = async () => {
+    setActionBusy("down");
+    setActionError(null);
+    try {
+      await api.workspaceDown();
+      refresh();
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : "Failed to stop workspace",
+      );
+    } finally {
+      setActionBusy(null);
+    }
+  };
 
   if (loading && !status) {
     return (
@@ -52,7 +85,29 @@ export function Workspace() {
 
   return (
     <div className="p-6 space-y-6">
-      <h1 className="text-xl font-bold">Workspace</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Workspace</h1>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleUp}
+            disabled={actionBusy !== null}
+            className="px-3 py-1.5 text-sm rounded bg-bc-success/20 text-bc-success hover:bg-bc-success/30 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-bc-success"
+            aria-label="Start workspace"
+          >
+            {actionBusy === "up" ? "Starting..." : "Start Workspace"}
+          </button>
+          <button
+            onClick={handleDown}
+            disabled={actionBusy !== null}
+            className="px-3 py-1.5 text-sm rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400"
+            aria-label="Stop all agents"
+          >
+            {actionBusy === "down" ? "Stopping..." : "Stop All Agents"}
+          </button>
+        </div>
+      </div>
+
+      {actionError && <p className="text-xs text-red-400">{actionError}</p>}
 
       <div className="grid grid-cols-2 gap-4">
         {Object.entries(status).map(([key, value]) => (


### PR DESCRIPTION
## Summary
- **Workspace page**: Added "Start Workspace" and "Stop All Agents" buttons calling `POST /api/workspace/up` and `POST /api/workspace/down`
- **Agents page**: Added inline rename (click agent name to edit, Enter to save) calling `POST /api/agents/{name}/rename`, and "Stop All" button in header calling `POST /api/agents/stop-all`
- **Secrets page**: Added Edit button per secret with inline password form calling `PUT /api/secrets/{name}`
- **API client**: Added `workspaceUp`, `workspaceDown`, `renameAgent`, `stopAllAgents`, `updateSecret` methods

Closes #2297 (partial)

## Test plan
- [ ] Verify workspace Start/Stop buttons appear and handle loading/error states
- [ ] Verify clicking agent name enters edit mode, Enter saves, Escape cancels
- [ ] Verify Stop All button only appears when running agents exist
- [ ] Verify secret Edit button shows inline form, Save/Cancel work correctly
- [ ] Check both dark and light themes
- [ ] Verify lint and build pass (`cd web && bun run lint && bun run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rename agents inline by clicking on their names in the agents view
  * New "Stop All" button for stopping multiple agents at once
  * Edit secret values directly with inline Save/Cancel options
  * Workspace can now be started and stopped from the UI

<!-- end of auto-generated comment: release notes by coderabbit.ai -->