### PR TITLE
feat: add Teams page, channel member management, channel edit

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,6 +51,9 @@ const Settings = lazy(() =>
 const Daemons = lazy(() =>
   import("./views/Daemons").then((m) => ({ default: m.Daemons })),
 );
+const Teams = lazy(() =>
+  import("./views/Teams").then((m) => ({ default: m.Teams })),
+);
 
 function Loading() {
   return <div className="p-6 text-bc-muted">Loading...</div>;
@@ -231,6 +234,16 @@ export function App() {
                   <Suspense fallback={<Loading />}>
                     <ErrorBoundary>
                       <Daemons />
+                    </ErrorBoundary>
+                  </Suspense>
+                }
+              />
+              <Route
+                path="teams"
+                element={
+                  <Suspense fallback={<Loading />}>
+                    <ErrorBoundary>
+                      <Teams />
                     </ErrorBoundary>
                   </Suspense>
                 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -294,6 +294,13 @@ export interface SettingsConfig {
   Storage: { SQLitePath: string };
 }
 
+export interface Team {
+  name: string;
+  description: string;
+  lead: string;
+  members: string[];
+}
+
 export interface Daemon {
   name: string;
   runtime: string;
@@ -520,4 +527,20 @@ export const api = {
     }),
   removeDaemon: (name: string) =>
     request<void>(`/daemons/${encodeURIComponent(name)}`, { method: "DELETE" }),
+
+  listTeams: () => request<Team[]>("/teams"),
+  getTeam: (name: string) =>
+    request<Team>(`/teams/${encodeURIComponent(name)}`),
+
+  addChannelMember: (channelName: string, agentName: string) =>
+    request<void>(`/channels/${encodeURIComponent(channelName)}/members`, {
+      method: "POST",
+      body: JSON.stringify({ agent: agentName }),
+    }),
+
+  updateChannel: (name: string, patch: { description?: string }) =>
+    request<Channel>(`/channels/${encodeURIComponent(name)}`, {
+      method: "PATCH",
+      body: JSON.stringify(patch),
+    }),
 };

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -10,6 +10,7 @@ const NAV_ITEMS = [
   { to: "/", label: "Dashboard", icon: "~" },
   { to: "/agents", label: "Agents", icon: "A" },
   { to: "/channels", label: "Channels", icon: "C" },
+  { to: "/teams", label: "Teams", icon: "G" },
   { to: "/costs", label: "Costs", icon: "$" },
   { to: "/roles", label: "Roles", icon: "R" },
   { to: "/tools", label: "Tools", icon: "T" },

--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState, useEffect, useRef } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { api } from "../api/client";
-import type { ChannelMessage } from "../api/client";
+import type { Channel, ChannelMessage } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { AgentPeekPanel } from "../components/AgentPeekPanel";
@@ -107,7 +107,12 @@ export function Channels() {
       </div>
       <div className="flex-1 flex flex-col min-w-0">
         {selected ? (
-          <ChatRoom channelName={selected} onPeekAgent={setPeekAgent} />
+          <ChatRoom
+            channelName={selected}
+            channel={(channels ?? []).find((c) => c.name === selected)}
+            onPeekAgent={setPeekAgent}
+            onChannelUpdated={refresh}
+          />
         ) : (
           <div className="flex-1 flex items-center justify-center">
             <EmptyState
@@ -175,20 +180,66 @@ function formatTimestamp(iso: string): string {
 
 function ChatRoom({
   channelName,
+  channel,
   onPeekAgent,
+  onChannelUpdated,
 }: {
   channelName: string;
+  channel?: Channel;
   onPeekAgent: (name: string) => void;
+  onChannelUpdated: () => void;
 }) {
   const [messages, setMessages] = useState<ChannelMessage[]>([]);
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [isNearBottom, setIsNearBottom] = useState(true);
   const [senderName, setSenderName] = useState("web");
+  const [showMembers, setShowMembers] = useState(false);
+  const [addingMember, setAddingMember] = useState(false);
+  const [agents, setAgents] = useState<string[]>([]);
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [descDraft, setDescDraft] = useState("");
+  const [savingDesc, setSavingDesc] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { subscribe } = useWebSocket();
+
+  // Fetch agents list for the add-member dropdown
+  useEffect(() => {
+    if (!addingMember) return;
+    void (async () => {
+      try {
+        const list = await api.listAgents();
+        setAgents(list.map((a) => a.name));
+      } catch {
+        setAgents([]);
+      }
+    })();
+  }, [addingMember]);
+
+  const handleAddMember = async (agentName: string) => {
+    try {
+      await api.addChannelMember(channelName, agentName);
+      onChannelUpdated();
+    } catch {
+      // silently fail
+    }
+    setAddingMember(false);
+  };
+
+  const handleSaveDescription = async () => {
+    setSavingDesc(true);
+    try {
+      await api.updateChannel(channelName, { description: descDraft });
+      onChannelUpdated();
+      setEditingDesc(false);
+    } catch {
+      // keep editing open
+    } finally {
+      setSavingDesc(false);
+    }
+  };
 
   // Fetch workspace nickname once to use as sender identity
   useEffect(() => {
@@ -316,11 +367,112 @@ function ChatRoom({
 
   return (
     <>
-      <div className="px-4 py-2 border-b border-bc-border bg-bc-surface">
-        <span className="font-medium">#{channelName}</span>
-        <span className="ml-2 text-xs text-bc-muted">
-          {messages.length} message{messages.length !== 1 ? "s" : ""}
-        </span>
+      <div className="px-4 py-2 border-b border-bc-border bg-bc-surface space-y-1">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="font-medium">#{channelName}</span>
+            <span className="text-xs text-bc-muted">
+              {messages.length} message{messages.length !== 1 ? "s" : ""}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setShowMembers((p) => !p)}
+              className="px-2 py-1 rounded border border-bc-border text-xs text-bc-muted hover:text-bc-text transition-colors"
+              aria-label="Toggle members panel"
+            >
+              Members ({channel?.member_count ?? 0})
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setDescDraft(channel?.description ?? "");
+                setEditingDesc(true);
+              }}
+              className="px-2 py-1 rounded border border-bc-border text-xs text-bc-muted hover:text-bc-text transition-colors"
+              aria-label="Edit channel description"
+            >
+              Edit
+            </button>
+          </div>
+        </div>
+        {editingDesc && (
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={descDraft}
+              onChange={(e) => setDescDraft(e.target.value)}
+              placeholder="Channel description"
+              className="flex-1 px-2 py-1 rounded border border-bc-border bg-bc-bg text-sm text-bc-text focus:outline-none focus:border-bc-accent"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void handleSaveDescription();
+                if (e.key === "Escape") setEditingDesc(false);
+              }}
+              aria-label="Channel description"
+            />
+            <button
+              type="button"
+              onClick={() => void handleSaveDescription()}
+              disabled={savingDesc}
+              className="px-2 py-1 rounded bg-bc-accent text-bc-bg text-xs font-medium disabled:opacity-50"
+            >
+              {savingDesc ? "Saving..." : "Save"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setEditingDesc(false)}
+              className="px-2 py-1 rounded border border-bc-border text-xs text-bc-muted hover:text-bc-text"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+        {!editingDesc && channel?.description && (
+          <p className="text-xs text-bc-muted">{channel.description}</p>
+        )}
+        {showMembers && (
+          <div className="flex flex-wrap items-center gap-2 pt-1">
+            {(channel?.members ?? []).map((m) => (
+              <span
+                key={m}
+                className="text-xs px-2 py-0.5 rounded bg-bc-accent/10 text-bc-accent"
+              >
+                {m}
+              </span>
+            ))}
+            {addingMember ? (
+              <select
+                className="text-xs px-2 py-1 rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none"
+                onChange={(e) => {
+                  if (e.target.value) void handleAddMember(e.target.value);
+                }}
+                defaultValue=""
+                aria-label="Select agent to add"
+              >
+                <option value="" disabled>
+                  Select agent...
+                </option>
+                {agents
+                  .filter((a) => !(channel?.members ?? []).includes(a))
+                  .map((a) => (
+                    <option key={a} value={a}>
+                      {a}
+                    </option>
+                  ))}
+              </select>
+            ) : (
+              <button
+                type="button"
+                onClick={() => setAddingMember(true)}
+                className="text-xs px-2 py-0.5 rounded border border-dashed border-bc-border text-bc-muted hover:text-bc-accent hover:border-bc-accent transition-colors"
+                aria-label="Add member to channel"
+              >
+                + Add Member
+              </button>
+            )}
+          </div>
+        )}
       </div>
       <div className="relative flex-1">
         <div

--- a/web/src/views/Teams.tsx
+++ b/web/src/views/Teams.tsx
@@ -1,0 +1,113 @@
+import { useCallback } from "react";
+import { api } from "../api/client";
+import { usePolling } from "../hooks/usePolling";
+import { Table } from "../components/Table";
+import { LoadingSkeleton } from "../components/LoadingSkeleton";
+import { EmptyState } from "../components/EmptyState";
+import type { Team } from "../api/client";
+
+export function Teams() {
+  const fetcher = useCallback(() => api.listTeams(), []);
+  const {
+    data: teams,
+    loading,
+    error,
+    refresh,
+    timedOut,
+  } = usePolling(fetcher, 15000);
+
+  if (loading && !teams) {
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-6 w-20 animate-pulse rounded bg-bc-border/50" />
+        <LoadingSkeleton variant="text" rows={5} />
+      </div>
+    );
+  }
+  if (timedOut && !teams) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Teams took too long to load"
+          description="The server may be unavailable. Check your connection and try again."
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
+  }
+  if (error && !teams) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon="!"
+          title="Failed to load teams"
+          description={error}
+          actionLabel="Retry"
+          onAction={refresh}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Teams</h1>
+        <span className="text-sm text-bc-muted">
+          {teams?.length ?? 0} teams
+        </span>
+      </div>
+
+      <Table<Team>
+        columns={[
+          {
+            key: "name",
+            label: "Name",
+            render: (t) => <span className="font-medium">{t.name}</span>,
+          },
+          {
+            key: "description",
+            label: "Description",
+            render: (t) => (
+              <span className="text-bc-muted">{t.description || "-"}</span>
+            ),
+          },
+          {
+            key: "lead",
+            label: "Lead",
+            render: (t) => (
+              <span className="text-bc-accent">{t.lead || "-"}</span>
+            ),
+          },
+          {
+            key: "members",
+            label: "Members",
+            render: (t) => (
+              <div className="flex flex-wrap gap-1">
+                {(t.members ?? []).length === 0 ? (
+                  <span className="text-bc-muted">-</span>
+                ) : (
+                  (t.members ?? []).map((m) => (
+                    <span
+                      key={m}
+                      className="text-xs px-2 py-0.5 rounded bg-bc-accent/10 text-bc-accent"
+                    >
+                      {m}
+                    </span>
+                  ))
+                )}
+              </div>
+            ),
+          },
+        ]}
+        data={teams ?? []}
+        keyFn={(t) => t.name}
+        emptyMessage="No teams"
+        emptyIcon="G"
+        emptyDescription="Teams are created via bc team create or the config file."
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Teams page**: New `/teams` route with table view showing team name, description, lead, and members. Added `api.listTeams()` and `api.getTeam()` to the API client. Added "G" icon nav item in sidebar.
- **Channel member management**: Added "Members" toggle button in channel header that shows current members as tags, plus an "Add Member" button with a dropdown of available agents (calls `api.addChannelMember()`).
- **Channel description editing**: Added "Edit" button in channel header for inline description editing with Save/Cancel controls (calls `api.updateChannel()` via PATCH).

## Test plan
- [ ] Navigate to `/teams` and verify the page loads (empty state or populated table)
- [ ] Verify "Teams" appears in sidebar nav with "G" icon
- [ ] Open a channel, click "Members" to toggle member list visibility
- [ ] Click "+ Add Member", verify agent dropdown appears and excludes existing members
- [ ] Click "Edit" on a channel, modify description, press Save
- [ ] Press Escape while editing description to cancel
- [ ] Verify `bun run lint` and `bun run build` pass in `web/`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Teams view displaying all teams with names, descriptions, leads, and member lists in a sortable table
  * Enhanced channel management with the ability to view and edit channel descriptions
  * Added functionality to add new members to channels via agent selection
  * Added Teams link to the sidebar navigation menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->