### PR TITLE
docs: auto-generate CLI reference from Cobra commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@
 # .PHONY declarations
 # =============================================================================
 
-.PHONY: help version
+.PHONY: help version gen-docs
 # Aggregates
 .PHONY: build test lint fmt vet coverage bench deps check scan gen clean release run deploy
 # Go language aggregates
@@ -437,6 +437,9 @@ scan-ts: ## Run TS dependency audit (bun audit, non-blocking)
 
 gen-go: ## Generate Go code (currently no-op)
 	@true
+
+gen-docs: ## Generate CLI reference docs from Cobra commands
+	$(GO) run ./cmd/gendocs docs/reference/cli
 
 gen-ts: ## Generate TS code (currently no-op)
 	@true

--- a/cmd/gendocs/main.go
+++ b/cmd/gendocs/main.go
@@ -1,0 +1,29 @@
+// Package main generates CLI reference documentation from Cobra commands.
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/spf13/cobra/doc"
+
+	cmd "github.com/rpuneet/bc/internal/cmd"
+)
+
+func main() {
+	outDir := "docs/reference/cli"
+	if len(os.Args) > 1 {
+		outDir = os.Args[1]
+	}
+
+	if err := os.MkdirAll(outDir, 0o750); err != nil {
+		log.Fatalf("failed to create output directory: %v", err)
+	}
+
+	rootCmd := cmd.Root()
+	rootCmd.DisableAutoGenTag = true
+
+	if err := doc.GenMarkdownTree(rootCmd, outDir); err != nil {
+		log.Fatalf("failed to generate docs: %v", err)
+	}
+}

--- a/docs/reference/cli/bc.md
+++ b/docs/reference/cli/bc.md
@@ -1,0 +1,89 @@
+## bc
+
+A simpler, more controllable agent orchestrator
+
+### Synopsis
+
+bc is a multi-agent orchestration system for AI coding assistants.
+
+Coordinate multiple AI agents with predictable behavior and cost awareness.
+Supports Claude Code, Cursor, Codex, and other AI coding tools.
+
+Getting Started:
+  bc init                                 # Initialize workspace
+  bc up                                   # Start root agent
+  bc agent create eng-01 --role engineer  # Create engineer agent
+  bc status                               # View agent status
+  bc home                                 # Open TUI dashboard
+
+Common Workflows:
+  Start working:    bc up && bc status
+  Monitor agents:   bc status --activity
+  Send message:     bc channel send eng "message"
+  Debug agent:      bc logs --agent eng-01 --tail 50
+  Cost check:       bc cost show
+
+Command Groups (with short aliases):
+  agent                        Manage agents
+  channel (ch)                 Communication channels
+  cost (co)                    Cost tracking and budgets
+  workspace (ws)               Workspace management
+  doctor (dr)                  Health checks
+  demon (cr/cron)              Scheduled tasks
+
+Key Features:
+  • Coordinate multiple AI coding agents in parallel
+  • Isolated git worktrees per agent
+  • Channel-based agent communication
+  • Cost tracking and limits
+  • Hierarchical agent roles (product-manager, manager, engineer)
+
+Environment Variables:
+  BC_AGENT_ID       Current agent name (set automatically in agent sessions)
+  BC_AGENT_ROLE     Current agent role
+  BC_WORKSPACE      Path to workspace root
+  BC_AGENT_WORKTREE Path to agent's worktree
+  BC_BIN            Path to bc binary (default: bc in PATH)
+  BC_ROOT           Workspace root directory
+  NO_COLOR          Disable colored output
+
+Documentation: https://github.com/rpuneet/bc
+Full CLI reference: https://github.com/rpuneet/bc/docs/cli.md
+
+```
+bc [flags]
+```
+
+### Options
+
+```
+  -h, --help      help for bc
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+  -V, --version   Print version information
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+* [bc channel](bc_channel.md)	 - Manage communication channels
+* [bc completion](bc_completion.md)	 - Generate shell completion scripts
+* [bc config](bc_config.md)	 - Manage workspace configuration
+* [bc cost](bc_cost.md)	 - Show cost information
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+* [bc doctor](bc_doctor.md)	 - Health checks and diagnostics
+* [bc down](bc_down.md)	 - Stop bc agents
+* [bc env](bc_env.md)	 - Manage workspace environment variables
+* [bc home](bc_home.md)	 - Open the bc TUI dashboard
+* [bc init](bc_init.md)	 - Initialize a new bc v2 workspace
+* [bc logs](bc_logs.md)	 - Show the event log
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+* [bc role](bc_role.md)	 - Manage agent roles in the workspace
+* [bc secret](bc_secret.md)	 - Manage encrypted secrets
+* [bc status](bc_status.md)	 - Show agent status
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+* [bc up](bc_up.md)	 - Start bc agents
+* [bc version](bc_version.md)	 - Print version information
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_agent.md
+++ b/docs/reference/cli/bc_agent.md
@@ -1,0 +1,61 @@
+## bc agent
+
+Manage bc agents
+
+### Synopsis
+
+Manage bc agent lifecycle: create, list, attach, peek, stop, send.
+
+Examples:
+  bc agent list                          # List all agents
+  bc agent create eng-01 --role engineer # Create new agent
+  bc agent attach eng-01                 # Attach to agent session
+  bc agent peek eng-01                   # View recent output
+  bc agent send eng-01 "run tests"       # Send message to agent
+  bc agent stop eng-01                   # Stop agent
+  bc agent broadcast "check status"      # Send to all agents
+  bc agent send-to-role engineer "test"  # Send to all engineers
+  bc agent                               # List all agents (same as bc agent list)
+  bc agent send-pattern "eng-*" "hello"  # Send to matching agents
+
+```
+bc agent [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for agent
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc agent attach](bc_agent_attach.md)	 - Attach to an agent's session
+* [bc agent auth](bc_agent_auth.md)	 - Authenticate an agent for Docker containers
+* [bc agent broadcast](bc_agent_broadcast.md)	 - Send a message to all running agents
+* [bc agent cost](bc_agent_cost.md)	 - Show per-agent cost breakdown
+* [bc agent create](bc_agent_create.md)	 - Create a new agent
+* [bc agent delete](bc_agent_delete.md)	 - Permanently delete an agent
+* [bc agent health](bc_agent_health.md)	 - Check agent health status
+* [bc agent list](bc_agent_list.md)	 - List all agents
+* [bc agent logs](bc_agent_logs.md)	 - Show agent event history
+* [bc agent peek](bc_agent_peek.md)	 - Show recent output from an agent
+* [bc agent rename](bc_agent_rename.md)	 - Rename an agent
+* [bc agent report](bc_agent_report.md)	 - Report agent state (called by agents)
+* [bc agent send](bc_agent_send.md)	 - Send a message to an agent
+* [bc agent send-pattern](bc_agent_send-pattern.md)	 - Send a message to agents matching a pattern
+* [bc agent send-to-role](bc_agent_send-to-role.md)	 - Send a message to all agents of a specific role
+* [bc agent sessions](bc_agent_sessions.md)	 - List session history for an agent
+* [bc agent show](bc_agent_show.md)	 - Show agent details
+* [bc agent start](bc_agent_start.md)	 - Start a stopped agent
+* [bc agent stats](bc_agent_stats.md)	 - Show Docker resource stats for an agent
+* [bc agent stop](bc_agent_stop.md)	 - Stop an agent
+

--- a/docs/reference/cli/bc_agent_attach.md
+++ b/docs/reference/cli/bc_agent_attach.md
@@ -1,0 +1,34 @@
+## bc agent attach
+
+Attach to an agent's session
+
+### Synopsis
+
+Attach to an agent's tmux session for direct interaction.
+
+Use Ctrl+b d to detach and return to your shell.
+
+Examples:
+  bc agent attach eng-01   # Attach to eng-01
+
+```
+bc agent attach <agent> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for attach
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_auth.md
+++ b/docs/reference/cli/bc_agent_auth.md
@@ -1,0 +1,34 @@
+## bc agent auth
+
+Authenticate an agent for Docker containers
+
+### Synopsis
+
+Run OAuth login for a specific agent. Each agent has its own isolated
+credentials directory. Opens a browser for authentication.
+
+Usage:
+  bc agent auth my-agent        # Login for a specific agent
+  bc agent auth my-agent status # Check auth status
+
+```
+bc agent auth <agent-name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for auth
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_broadcast.md
+++ b/docs/reference/cli/bc_agent_broadcast.md
@@ -1,0 +1,33 @@
+## bc agent broadcast
+
+Send a message to all running agents
+
+### Synopsis
+
+Broadcast a message to all running agents in the workspace.
+
+Examples:
+  bc agent broadcast "run tests"
+  bc agent broadcast "check status"
+
+```
+bc agent broadcast <message> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for broadcast
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_cost.md
+++ b/docs/reference/cli/bc_agent_cost.md
@@ -1,0 +1,33 @@
+## bc agent cost
+
+Show per-agent cost breakdown
+
+### Synopsis
+
+Show the cost breakdown for a specific agent including tokens and USD cost.
+
+Examples:
+  bc agent cost eng-01       # Show eng-01 cost
+  bc agent cost eng-01 --json  # Output as JSON
+
+```
+bc agent cost <agent> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for cost
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_create.md
+++ b/docs/reference/cli/bc_agent_create.md
@@ -1,0 +1,43 @@
+## bc agent create
+
+Create a new agent
+
+### Synopsis
+
+Create and start a new agent.
+
+If no name is provided, a random memorable name is generated (e.g., swift-falcon).
+
+Examples:
+  bc agent create --role engineer              # Create with random name
+  bc agent create worker-01                    # Create with explicit name
+  bc agent create eng-01 --role engineer       # Create engineer
+  bc agent create qa-01 --role qa --tool cursor # Create QA with Cursor
+
+```
+bc agent create [name] [flags]
+```
+
+### Options
+
+```
+      --env string       Path to env file (KEY=VALUE per line)
+  -h, --help             help for create
+      --parent string    Parent agent ID (must have permission to create this role)
+      --role string      Agent role (required). Use 'bc role list' to see available roles
+      --runtime string   Runtime backend override: tmux or docker
+      --team string      Team name (alphanumeric)
+      --tool string      Agent tool (claude, gemini, cursor, codex, opencode, openclaw, aider)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_delete.md
+++ b/docs/reference/cli/bc_agent_delete.md
@@ -1,0 +1,43 @@
+## bc agent delete
+
+Permanently delete an agent
+
+### Synopsis
+
+Permanently delete an agent from the workspace.
+
+This removes the agent's tmux session, channel memberships,
+and agent state. Memory is preserved by default for recovery.
+
+Use --force to delete an agent without stopping it first.
+Use --purge to also delete the agent's memory directory.
+
+Examples:
+  bc agent delete eng-01              # Delete stopped agent (preserves memory)
+  bc agent delete eng-01 --force      # Force delete (any state)
+  bc agent delete eng-01 --purge      # Delete including memory
+  bc agent delete eng-01 --force --purge  # Force delete with full cleanup
+
+```
+bc agent delete <agent> [flags]
+```
+
+### Options
+
+```
+      --force   Force delete running agent without stopping first
+  -h, --help    help for delete
+      --purge   Also delete agent's memory directory
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_health.md
+++ b/docs/reference/cli/bc_agent_health.md
@@ -1,0 +1,40 @@
+## bc agent health
+
+Check agent health status
+
+### Synopsis
+
+Check health status of agents including tmux session and state freshness.
+
+Examples:
+  bc agent health              # Check all agents
+  bc agent health eng-01       # Check specific agent
+  bc agent health --json       # Output as JSON
+  bc agent health --detect-stuck --alert eng  # Detect stuck and alert
+
+```
+bc agent health [agent] [flags]
+```
+
+### Options
+
+```
+      --alert string          Send alert to channel when stuck agents detected (requires --detect-stuck)
+      --detect-stuck          Enable stuck detection analysis
+  -h, --help                  help for health
+      --json                  Output as JSON
+      --max-failures int      Max consecutive failures before considered stuck (default 3)
+      --timeout string        Stale state threshold (e.g., 30s, 2m) (default "60s")
+      --work-timeout string   Work timeout for stuck detection (e.g., 30m, 1h) (default "30m")
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_list.md
+++ b/docs/reference/cli/bc_agent_list.md
@@ -1,0 +1,37 @@
+## bc agent list
+
+List all agents
+
+### Synopsis
+
+List all agents with their status, role, and current task.
+
+Examples:
+  bc agent list          # List all agents
+  bc agent list --json   # Output as JSON
+  bc agent list --role engineer  # Filter by role
+
+```
+bc agent list [flags]
+```
+
+### Options
+
+```
+      --full            Include full agent data including prompts (with --json)
+  -h, --help            help for list
+      --json            Output as JSON (compact by default)
+      --role string     Filter by role
+      --status string   Filter by status (running, stopped, error)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_logs.md
+++ b/docs/reference/cli/bc_agent_logs.md
@@ -1,0 +1,34 @@
+## bc agent logs
+
+Show agent event history
+
+### Synopsis
+
+Show the event log history for a specific agent.
+
+Examples:
+  bc agent logs eng-01               # Show all events
+  bc agent logs eng-01 --since 1h    # Show events from last hour
+
+```
+bc agent logs <agent> [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for logs
+      --since string   Show events since duration (e.g., 1h, 30m)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_peek.md
+++ b/docs/reference/cli/bc_agent_peek.md
@@ -1,0 +1,36 @@
+## bc agent peek
+
+Show recent output from an agent
+
+### Synopsis
+
+Capture and display recent output from an agent's session.
+
+Examples:
+  bc agent peek eng-01              # Show last 500 lines
+  bc agent peek eng-01 --lines 100  # Show last 100 lines
+  bc agent peek eng-01 --follow     # Stream live output (Ctrl+C to stop)
+
+```
+bc agent peek <agent> [flags]
+```
+
+### Options
+
+```
+  -f, --follow      Stream live output (like tail -f)
+  -h, --help        help for peek
+      --lines int   Number of lines to show (default 500)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_rename.md
+++ b/docs/reference/cli/bc_agent_rename.md
@@ -1,0 +1,37 @@
+## bc agent rename
+
+Rename an agent
+
+### Synopsis
+
+Rename an agent to a new name.
+
+This updates the agent's name and channel memberships.
+By default, running agents cannot be renamed (use --force to override).
+
+Examples:
+  bc agent rename eng-01 engineer-01
+  bc agent rename eng-01 eng-02 --force  # Rename running agent
+
+```
+bc agent rename <old-name> <new-name> [flags]
+```
+
+### Options
+
+```
+      --force   Rename even if agent is running
+  -h, --help    help for rename
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_report.md
+++ b/docs/reference/cli/bc_agent_report.md
@@ -1,0 +1,44 @@
+## bc agent report
+
+Report agent state (called by agents)
+
+### Synopsis
+
+Report the calling agent's current state. This command must be run from within an agent session.
+
+Valid states: idle, working, done, stuck, error
+
+For stuck state, use --reason to provide detailed context:
+  bc agent report stuck --reason "database connection timeout"
+  bc agent report stuck --reason "auth fails" --reproduction "login with test user" --severity critical
+
+Examples:
+  bc agent report working "fixing auth bug"
+  bc agent report done "auth bug fixed"
+  bc agent report stuck "need database credentials"
+  bc agent report stuck --reason "TUI freezes on channel select" --severity high
+
+```
+bc agent report <state> [message] [flags]
+```
+
+### Options
+
+```
+  -h, --help                  help for report
+      --reason string         Detailed reason for stuck state
+      --reproduction string   Steps to reproduce the issue
+      --severity string       Issue severity (critical, high, medium, low) (default "medium")
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_send-pattern.md
+++ b/docs/reference/cli/bc_agent_send-pattern.md
@@ -1,0 +1,36 @@
+## bc agent send-pattern
+
+Send a message to agents matching a pattern
+
+### Synopsis
+
+Send a message to all running agents whose names match the given pattern.
+
+Pattern uses glob-style matching (* matches any characters).
+
+Examples:
+  bc agent send-pattern "engineer-*" "run tests"
+  bc agent send-pattern "eng-0*" "check status"
+  bc agent send-pattern "*-lead" "review PRs"
+
+```
+bc agent send-pattern <pattern> <message> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for send-pattern
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_send-to-role.md
+++ b/docs/reference/cli/bc_agent_send-to-role.md
@@ -1,0 +1,34 @@
+## bc agent send-to-role
+
+Send a message to all agents of a specific role
+
+### Synopsis
+
+Send a message to all running agents that have the specified role.
+
+Examples:
+  bc agent send-to-role engineer "run the tests"
+  bc agent send-to-role manager "check status"
+  bc agent send-to-role tech-lead "review PRs"
+
+```
+bc agent send-to-role <role> <message> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for send-to-role
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_send.md
+++ b/docs/reference/cli/bc_agent_send.md
@@ -1,0 +1,38 @@
+## bc agent send
+
+Send a message to an agent
+
+### Synopsis
+
+Send a message or command to an agent's session.
+
+Use --preview to see what action will be taken before sending (Intent Preview).
+This shows agent details and asks for confirmation.
+
+Examples:
+  bc agent send eng-01 "run the tests"
+  bc agent send coordinator "check status"
+  bc agent send eng-01 "implement login" --preview  # Preview before sending
+
+```
+bc agent send <agent> <message> [flags]
+```
+
+### Options
+
+```
+  -h, --help      help for send
+      --preview   Show preview of action before sending (Intent Preview)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_sessions.md
+++ b/docs/reference/cli/bc_agent_sessions.md
@@ -1,0 +1,36 @@
+## bc agent sessions
+
+List session history for an agent
+
+### Synopsis
+
+Show stored session IDs for an agent.
+
+The current session ID (if captured) is listed first, followed by archived
+session IDs from previous runs.
+
+Examples:
+  bc agent sessions eng-01       # List session IDs
+  bc agent sessions eng-01 --json
+
+```
+bc agent sessions <agent> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for sessions
+      --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_show.md
+++ b/docs/reference/cli/bc_agent_show.md
@@ -1,0 +1,34 @@
+## bc agent show
+
+Show agent details
+
+### Synopsis
+
+Show detailed information about an agent.
+
+Examples:
+  bc agent show eng-01       # Show eng-01 details
+  bc agent show eng-01 --json  # Output as JSON
+
+```
+bc agent show <agent> [flags]
+```
+
+### Options
+
+```
+      --full   Include full agent data including prompts (with --json)
+  -h, --help   help for show
+      --json   Output as JSON (compact by default)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_start.md
+++ b/docs/reference/cli/bc_agent_start.md
@@ -1,0 +1,45 @@
+## bc agent start
+
+Start a stopped agent
+
+### Synopsis
+
+Start a previously stopped agent from its saved state.
+
+This resurrects the agent's tmux session and memory.
+The agent must have been previously created and stopped.
+By default, resumes the previous session if available.
+
+The agent's tool (claude, gemini, cursor, etc.) is fixed at creation time
+and cannot be changed on restart. Use --runtime to switch infrastructure
+backends (tmux vs docker) without changing the agent's identity.
+
+Examples:
+  bc agent start eng-01                    # Start stopped agent (resumes session)
+  bc agent start eng-01 --fresh            # Force new session
+  bc agent start eng-01 --runtime docker   # Override runtime backend
+
+```
+bc agent start <agent> [flags]
+```
+
+### Options
+
+```
+      --fresh            Force new session (ignore saved session)
+  -h, --help             help for start
+      --resume string    Resume a specific session by ID (e.g. --resume cc78cadf-89ce-4820-ab6e-950afd2b6838)
+      --runtime string   Runtime backend override: tmux or docker
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_stats.md
+++ b/docs/reference/cli/bc_agent_stats.md
@@ -1,0 +1,38 @@
+## bc agent stats
+
+Show Docker resource stats for an agent
+
+### Synopsis
+
+Display recorded Docker CPU and memory stats for an agent.
+
+Stats are collected every 30 s by bcd while the agent is running with a
+Docker runtime backend. They are stored in .bc/bc.db.
+
+Examples:
+  bc agent stats eng-01              # Human-readable table
+  bc agent stats eng-01 --json       # JSON output
+  bc agent stats eng-01 --limit 50   # Show more records
+
+```
+bc agent stats <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help        help for stats
+      --json        Output as JSON
+      --limit int   Number of records to show (default 20)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_agent_stop.md
+++ b/docs/reference/cli/bc_agent_stop.md
@@ -1,0 +1,34 @@
+## bc agent stop
+
+Stop an agent
+
+### Synopsis
+
+Stop a specific agent and its tmux session.
+
+Examples:
+  bc agent stop eng-01       # Stop eng-01
+  bc agent stop eng-01 --force  # Force stop
+
+```
+bc agent stop <agent> [flags]
+```
+
+### Options
+
+```
+      --force   Force stop without cleanup
+  -h, --help    help for stop
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc agent](bc_agent.md)	 - Manage bc agents
+

--- a/docs/reference/cli/bc_channel.md
+++ b/docs/reference/cli/bc_channel.md
@@ -1,0 +1,75 @@
+## bc channel
+
+Manage communication channels
+
+### Synopsis
+
+Manage channels for broadcasting messages to groups of agents.
+
+Channels are named groups of agent members. Messages sent to a channel are
+delivered to all member tmux sessions.
+
+Examples:
+  bc channel list                      # List all channels
+  bc channel create workers            # Create a channel named "workers"
+  bc channel show workers              # Show channel details
+  bc channel add workers worker-01     # Add member to channel
+  bc channel add workers --agent w-01  # Add member via --agent flag
+  bc channel send workers "run tests"  # Send to all members
+  bc channel history workers --last 20 # Show last 20 messages
+  bc channel react workers 5 👍        # React to message
+  bc channel edit workers --desc "..."  # Edit channel description
+  bc channel remove workers worker-01  # Remove a member
+  bc channel delete workers            # Delete the channel
+  bc channel status                    # Overview of all channels
+
+Agent Commands (require BC_AGENT_ID):
+  bc channel join workers              # Join a channel (current agent)
+  bc channel leave workers             # Leave a channel (current agent)
+
+Default Channels:
+  #eng       Engineering team (all engineer agents)
+  #pr        Pull request reviews and notifications
+  #standup   Daily standup updates
+  #leads     Tech leads and managers
+
+Message Format:
+  Messages are delivered as system reminders to agent sessions.
+  Use @agent-name to mention specific agents in messages.
+
+See Also:
+  bc agent send       Send message to single agent
+  bc agent broadcast  Send to all agents
+  bc status           View agents and their channels
+
+### Options
+
+```
+  -h, --help   help for channel
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc channel add](bc_channel_add.md)	 - Add members to a channel
+* [bc channel create](bc_channel_create.md)	 - Create a new channel
+* [bc channel delete](bc_channel_delete.md)	 - Delete a channel
+* [bc channel desc](bc_channel_desc.md)	 - Set channel description
+* [bc channel edit](bc_channel_edit.md)	 - Edit channel description/settings
+* [bc channel history](bc_channel_history.md)	 - Show channel message history
+* [bc channel join](bc_channel_join.md)	 - Join a channel (for agents)
+* [bc channel leave](bc_channel_leave.md)	 - Leave a channel (for agents)
+* [bc channel list](bc_channel_list.md)	 - List all channels
+* [bc channel react](bc_channel_react.md)	 - React to a channel message
+* [bc channel remove](bc_channel_remove.md)	 - Remove a member from a channel
+* [bc channel send](bc_channel_send.md)	 - Send a message to all channel members
+* [bc channel show](bc_channel_show.md)	 - Show channel details
+* [bc channel status](bc_channel_status.md)	 - Show channel overview with activity details
+

--- a/docs/reference/cli/bc_channel_add.md
+++ b/docs/reference/cli/bc_channel_add.md
@@ -1,0 +1,26 @@
+## bc channel add
+
+Add members to a channel
+
+```
+bc channel add <channel> [member...] [flags]
+```
+
+### Options
+
+```
+      --agent string   Agent to add to channel
+  -h, --help           help for add
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_create.md
+++ b/docs/reference/cli/bc_channel_create.md
@@ -1,0 +1,26 @@
+## bc channel create
+
+Create a new channel
+
+```
+bc channel create <name> [flags]
+```
+
+### Options
+
+```
+      --desc string   Channel description
+  -h, --help          help for create
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_delete.md
+++ b/docs/reference/cli/bc_channel_delete.md
@@ -1,0 +1,25 @@
+## bc channel delete
+
+Delete a channel
+
+```
+bc channel delete <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_desc.md
+++ b/docs/reference/cli/bc_channel_desc.md
@@ -1,0 +1,29 @@
+## bc channel desc
+
+Set channel description
+
+### Synopsis
+
+Set or update the description for a channel.
+
+```
+bc channel desc <channel> <description> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for desc
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_edit.md
+++ b/docs/reference/cli/bc_channel_edit.md
@@ -1,0 +1,33 @@
+## bc channel edit
+
+Edit channel description/settings
+
+### Synopsis
+
+Edit a channel's description or settings.
+
+Examples:
+  bc channel edit eng --desc "Engineering discussion"
+
+```
+bc channel edit <channel> [flags]
+```
+
+### Options
+
+```
+      --desc string   New channel description
+  -h, --help          help for edit
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_history.md
+++ b/docs/reference/cli/bc_channel_history.md
@@ -1,0 +1,45 @@
+## bc channel history
+
+Show channel message history
+
+### Synopsis
+
+Display the history of messages sent to a channel.
+
+Examples:
+  bc channel history eng                       # Last 50 messages (default)
+  bc channel history eng --limit 10            # Last 10 messages
+  bc channel history eng --since 1h            # Messages from last hour
+  bc channel history eng --agent agent-core    # Messages from agent-core only
+  bc channel history eng --from 2026-03-01     # Messages from date
+  bc channel history eng --from 2026-03-01 --to 2026-03-05  # Date range
+  bc channel history eng --limit 20 --offset 20  # Page 2 of 20
+
+```
+bc channel history <channel> [flags]
+```
+
+### Options
+
+```
+      --agent string   Filter messages by sender agent
+      --from string    Show messages from timestamp (RFC3339 or 2006-01-02)
+  -h, --help           help for history
+      --last int       Show last N messages (alias for --limit)
+      --limit int      Maximum number of messages to show (default 50)
+      --offset int     Number of messages to skip
+      --since string   Show messages since duration (e.g., 1h, 30m)
+      --to string      Show messages until timestamp (RFC3339 or 2006-01-02)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_join.md
+++ b/docs/reference/cli/bc_channel_join.md
@@ -1,0 +1,29 @@
+## bc channel join
+
+Join a channel (for agents)
+
+### Synopsis
+
+Add yourself to a channel. This command must be run from within an agent session.
+
+```
+bc channel join <channel> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for join
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_leave.md
+++ b/docs/reference/cli/bc_channel_leave.md
@@ -1,0 +1,29 @@
+## bc channel leave
+
+Leave a channel (for agents)
+
+### Synopsis
+
+Remove yourself from a channel. This command must be run from within an agent session.
+
+```
+bc channel leave <channel> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for leave
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_list.md
+++ b/docs/reference/cli/bc_channel_list.md
@@ -1,0 +1,25 @@
+## bc channel list
+
+List all channels
+
+```
+bc channel list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_react.md
+++ b/docs/reference/cli/bc_channel_react.md
@@ -1,0 +1,36 @@
+## bc channel react
+
+React to a channel message
+
+### Synopsis
+
+Add an emoji reaction to a message in a channel.
+
+The message-index is shown in 'bc channel history' output.
+Use common emoji like 👍, 👎, ❤️, 🎉, 👀, 🚀 or any emoji.
+
+Examples:
+  bc channel react engineering 5 👍
+  bc channel react general 0 🎉
+
+```
+bc channel react <channel> <message-index> <emoji> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for react
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_remove.md
+++ b/docs/reference/cli/bc_channel_remove.md
@@ -1,0 +1,26 @@
+## bc channel remove
+
+Remove a member from a channel
+
+```
+bc channel remove <channel> [member] [flags]
+```
+
+### Options
+
+```
+      --agent string   Agent to remove from channel
+  -h, --help           help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_send.md
+++ b/docs/reference/cli/bc_channel_send.md
@@ -1,0 +1,25 @@
+## bc channel send
+
+Send a message to all channel members
+
+```
+bc channel send <channel> <message> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for send
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_show.md
+++ b/docs/reference/cli/bc_channel_show.md
@@ -1,0 +1,34 @@
+## bc channel show
+
+Show channel details
+
+### Synopsis
+
+Display detailed information about a channel including members,
+description, and message history statistics.
+
+Examples:
+  bc channel show engineering    # Show engineering channel details
+  bc channel show standup --json # Output as JSON
+
+```
+bc channel show <channel> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_channel_status.md
+++ b/docs/reference/cli/bc_channel_status.md
@@ -1,0 +1,35 @@
+## bc channel status
+
+Show channel overview with activity details
+
+### Synopsis
+
+List all channels with detailed status columns.
+
+Columns: Name, Members, Messages, Last Message (preview), Last Activity.
+
+Examples:
+  bc channel status           # Show all channels with details
+  bc channel status --json    # JSON output
+
+```
+bc channel status [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc channel](bc_channel.md)	 - Manage communication channels
+

--- a/docs/reference/cli/bc_completion.md
+++ b/docs/reference/cli/bc_completion.md
@@ -1,0 +1,64 @@
+## bc completion
+
+Generate shell completion scripts
+
+### Synopsis
+
+Generate shell completion scripts for bc.
+
+To load completions:
+
+Bash:
+  $ source <(bc completion bash)
+
+  # To load completions for each session, execute once:
+  # Linux:
+  $ bc completion bash > /etc/bash_completion.d/bc
+  # macOS:
+  $ bc completion bash > $(brew --prefix)/etc/bash_completion.d/bc
+
+Zsh:
+  # If shell completion is not already enabled in your environment,
+  # you will need to enable it. You can execute the following once:
+  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+  # To load completions for each session, execute once:
+  $ bc completion zsh > "${fpath[1]}/_bc"
+
+  # You will need to start a new shell for this setup to take effect.
+
+Fish:
+  $ bc completion fish | source
+
+  # To load completions for each session, execute once:
+  $ bc completion fish > ~/.config/fish/completions/bc.fish
+
+PowerShell:
+  PS> bc completion powershell | Out-String | Invoke-Expression
+
+  # To load completions for every new session, run:
+  PS> bc completion powershell > bc.ps1
+  # and source this file from your PowerShell profile.
+
+
+```
+bc completion [bash|zsh|fish|powershell]
+```
+
+### Options
+
+```
+  -h, --help   help for completion
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+

--- a/docs/reference/cli/bc_config.md
+++ b/docs/reference/cli/bc_config.md
@@ -1,0 +1,51 @@
+## bc config
+
+Manage workspace configuration
+
+### Synopsis
+
+Commands for managing workspace configuration (.bc/settings.toml).
+
+Configuration uses a hierarchical key structure with dot notation:
+  workspace.name
+  providers.claude.command
+  providers.default
+
+Examples:
+  bc config show                        # Show all config
+  bc config get providers.default           # Get a specific value
+  bc config set providers.default 6      # Set a value
+  bc config list                        # List all config keys
+  bc config edit                        # Open config in editor
+  bc config validate                    # Validate config file
+  bc config reset                       # Reset to defaults
+
+```
+bc config [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc config edit](bc_config_edit.md)	 - Edit configuration file
+* [bc config get](bc_config_get.md)	 - Get a configuration value
+* [bc config list](bc_config_list.md)	 - List all configuration keys
+* [bc config reset](bc_config_reset.md)	 - Reset configuration to defaults
+* [bc config set](bc_config_set.md)	 - Set a configuration value
+* [bc config show](bc_config_show.md)	 - Show configuration
+* [bc config user](bc_config_user.md)	 - Manage user-level configuration (~/.bcrc)
+* [bc config validate](bc_config_validate.md)	 - Validate configuration file
+

--- a/docs/reference/cli/bc_config_edit.md
+++ b/docs/reference/cli/bc_config_edit.md
@@ -1,0 +1,34 @@
+## bc config edit
+
+Edit configuration file
+
+### Synopsis
+
+Open the workspace configuration file in your default editor.
+
+Uses $EDITOR environment variable, falls back to 'nano' if not set.
+
+Examples:
+  bc config edit
+
+```
+bc config edit [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for edit
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config](bc_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_config_get.md
+++ b/docs/reference/cli/bc_config_get.md
@@ -1,0 +1,35 @@
+## bc config get
+
+Get a configuration value
+
+### Synopsis
+
+Get a specific configuration value using dot notation.
+
+Examples:
+  bc config get workspace.name
+  bc config get providers.default
+  bc config get providers.default
+  bc config get tools.claude.command
+
+```
+bc config get <key> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config](bc_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_config_list.md
+++ b/docs/reference/cli/bc_config_list.md
@@ -1,0 +1,33 @@
+## bc config list
+
+List all configuration keys
+
+### Synopsis
+
+List all available configuration keys in the workspace config.
+
+Examples:
+  bc config list
+  bc config list --json           # Output as JSON array
+
+```
+bc config list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config](bc_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_config_reset.md
+++ b/docs/reference/cli/bc_config_reset.md
@@ -1,0 +1,36 @@
+## bc config reset
+
+Reset configuration to defaults
+
+### Synopsis
+
+Reset the workspace configuration to default values.
+
+WARNING: This will overwrite your current config. Back up first if needed.
+
+Examples:
+  bc config reset
+  bc config reset --force         # Skip confirmation
+
+```
+bc config reset [flags]
+```
+
+### Options
+
+```
+      --force   Skip confirmation prompt
+  -h, --help    help for reset
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config](bc_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_config_set.md
+++ b/docs/reference/cli/bc_config_set.md
@@ -1,0 +1,37 @@
+## bc config set
+
+Set a configuration value
+
+### Synopsis
+
+Set a specific configuration value using dot notation.
+
+The value type is automatically inferred (string, number, boolean).
+
+Examples:
+  bc config set providers.default 6
+  bc config set providers.default claude
+  bc config set runtime.backend docker
+  bc config set tools.claude.command "claude --force"
+
+```
+bc config set <key> <value> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config](bc_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_config_show.md
+++ b/docs/reference/cli/bc_config_show.md
@@ -1,0 +1,37 @@
+## bc config show
+
+Show configuration
+
+### Synopsis
+
+Display the current workspace configuration.
+
+If a key is specified, shows only that section. Otherwise shows entire config.
+
+Examples:
+  bc config show                  # Show all config
+  bc config show tools            # Show tools section
+  bc config show tools.claude     # Show specific tool config
+  bc config show --json           # Output as JSON
+
+```
+bc config show [key] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config](bc_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_config_user.md
+++ b/docs/reference/cli/bc_config_user.md
@@ -1,0 +1,44 @@
+## bc config user
+
+Manage user-level configuration (~/.bcrc)
+
+### Synopsis
+
+Manage user-level configuration stored in ~/.bcrc.
+
+User configuration provides defaults that apply across all bc workspaces:
+  - Your nickname for channel messages
+  - Default role for new agents
+  - Preferred AI tools
+
+Workspace config (.bc/settings.toml) takes precedence over user config.
+
+Examples:
+  bc config user init   # Create ~/.bcrc with guided prompts
+  bc config user show   # Show user config
+  bc config user path   # Show user config path
+
+```
+bc config user [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for user
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config](bc_config.md)	 - Manage workspace configuration
+* [bc config user init](bc_config_user_init.md)	 - Create user configuration file (~/.bcrc)
+* [bc config user path](bc_config_user_path.md)	 - Show user configuration file path
+* [bc config user show](bc_config_user_show.md)	 - Show user configuration
+

--- a/docs/reference/cli/bc_config_user_init.md
+++ b/docs/reference/cli/bc_config_user_init.md
@@ -1,0 +1,34 @@
+## bc config user init
+
+Create user configuration file (~/.bcrc)
+
+### Synopsis
+
+Create a new ~/.bcrc file with guided prompts.
+
+Examples:
+  bc config user init          # Interactive setup
+  bc config user init --quick  # Use defaults without prompts
+
+```
+bc config user init [flags]
+```
+
+### Options
+
+```
+  -h, --help    help for init
+      --quick   Use defaults without prompts
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config user](bc_config_user.md)	 - Manage user-level configuration (~/.bcrc)
+

--- a/docs/reference/cli/bc_config_user_path.md
+++ b/docs/reference/cli/bc_config_user_path.md
@@ -1,0 +1,32 @@
+## bc config user path
+
+Show user configuration file path
+
+### Synopsis
+
+Display the path to the user configuration file.
+
+Examples:
+  bc config user path
+
+```
+bc config user path [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for path
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config user](bc_config_user.md)	 - Manage user-level configuration (~/.bcrc)
+

--- a/docs/reference/cli/bc_config_user_show.md
+++ b/docs/reference/cli/bc_config_user_show.md
@@ -1,0 +1,32 @@
+## bc config user show
+
+Show user configuration
+
+### Synopsis
+
+Display the current user configuration from ~/.bcrc.
+
+Examples:
+  bc config user show
+
+```
+bc config user show [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config user](bc_config_user.md)	 - Manage user-level configuration (~/.bcrc)
+

--- a/docs/reference/cli/bc_config_validate.md
+++ b/docs/reference/cli/bc_config_validate.md
@@ -1,0 +1,38 @@
+## bc config validate
+
+Validate configuration file
+
+### Synopsis
+
+Validate the workspace configuration file for errors.
+
+Checks for:
+  - Valid TOML syntax
+  - Required fields present
+  - Valid values and types
+  - Tool references exist
+
+Examples:
+  bc config validate
+
+```
+bc config validate [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for validate
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc config](bc_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_cost.md
+++ b/docs/reference/cli/bc_cost.md
@@ -1,0 +1,50 @@
+## bc cost
+
+Show cost information
+
+### Synopsis
+
+Commands for viewing API cost information.
+
+Shows Claude Code token usage, costs, and budget management.
+
+Examples:
+  bc cost                              # Show cost records (default)
+  bc cost show eng-01                  # Show costs for specific agent
+  bc cost usage                        # Claude Code usage via ccusage
+  bc cost usage --monthly              # Monthly summary
+  bc cost budget show                  # Show budget status
+
+See Also:
+  bc home           TUI dashboard with cost overview
+  bc status         Agent status (includes cost info)
+
+```
+bc cost [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for cost
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc cost agent](bc_cost_agent.md)	 - Show per-agent cost breakdown
+* [bc cost budget](bc_cost_budget.md)	 - Manage cost budgets
+* [bc cost daily](bc_cost_daily.md)	 - Show daily cost totals
+* [bc cost dashboard](bc_cost_dashboard.md)	 - Show rich cost dashboard
+* [bc cost model](bc_cost_model.md)	 - Show per-model cost breakdown
+* [bc cost show](bc_cost_show.md)	 - Show cost records
+* [bc cost summary](bc_cost_summary.md)	 - Show workspace cost overview
+* [bc cost usage](bc_cost_usage.md)	 - Show Claude Code token usage via ccusage
+

--- a/docs/reference/cli/bc_cost_agent.md
+++ b/docs/reference/cli/bc_cost_agent.md
@@ -1,0 +1,33 @@
+## bc cost agent
+
+Show per-agent cost breakdown
+
+### Synopsis
+
+Show cost breakdown by agent. If a name is given, shows detail for that agent.
+
+Examples:
+  bc cost agent                    # All agents
+  bc cost agent swift-falcon       # Specific agent
+
+```
+bc cost agent [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for agent
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost](bc_cost.md)	 - Show cost information
+

--- a/docs/reference/cli/bc_cost_budget.md
+++ b/docs/reference/cli/bc_cost_budget.md
@@ -1,0 +1,34 @@
+## bc cost budget
+
+Manage cost budgets
+
+### Synopsis
+
+Commands for managing cost budgets and limits.
+
+Examples:
+  bc cost budget show
+  bc cost budget set 100.00
+  bc cost budget set 50.00 --agent engineer-01
+  bc cost budget set 500.00 --period monthly --alert-at 0.9
+
+### Options
+
+```
+  -h, --help   help for budget
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost](bc_cost.md)	 - Show cost information
+* [bc cost budget delete](bc_cost_budget_delete.md)	 - Delete a budget
+* [bc cost budget set](bc_cost_budget_set.md)	 - Set a cost budget
+* [bc cost budget show](bc_cost_budget_show.md)	 - Show budget status
+

--- a/docs/reference/cli/bc_cost_budget_delete.md
+++ b/docs/reference/cli/bc_cost_budget_delete.md
@@ -1,0 +1,35 @@
+## bc cost budget delete
+
+Delete a budget
+
+### Synopsis
+
+Delete a budget configuration.
+
+Examples:
+  bc cost budget delete                  # Delete workspace budget
+  bc cost budget delete --agent eng-01   # Delete agent budget
+
+```
+bc cost budget delete [flags]
+```
+
+### Options
+
+```
+      --agent string   Delete budget for specific agent
+  -h, --help           help for delete
+      --team string    Delete budget for specific team
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost budget](bc_cost_budget.md)	 - Manage cost budgets
+

--- a/docs/reference/cli/bc_cost_budget_set.md
+++ b/docs/reference/cli/bc_cost_budget_set.md
@@ -1,0 +1,42 @@
+## bc cost budget set
+
+Set a cost budget
+
+### Synopsis
+
+Set a cost budget for the workspace, agent, or team.
+
+Examples:
+  bc cost budget set 100.00                          # Set workspace budget to $100
+  bc cost budget set 50.00 --agent engineer-01       # Set agent budget
+  bc cost budget set 500.00 --team engineering       # Set team budget
+  bc cost budget set 100.00 --period weekly          # Weekly budget
+  bc cost budget set 100.00 --alert-at 0.9           # Alert at 90%
+  bc cost budget set 100.00 --hard-stop              # Stop when limit reached
+
+```
+bc cost budget set <amount> [flags]
+```
+
+### Options
+
+```
+      --agent string     Set budget for specific agent
+      --alert-at float   Alert when usage reaches this percentage (0.0-1.0) (default 0.8)
+      --hard-stop        Stop operations when budget is exceeded
+  -h, --help             help for set
+      --period string    Budget period (daily, weekly, monthly) (default "monthly")
+      --team string      Set budget for specific team
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost budget](bc_cost_budget.md)	 - Manage cost budgets
+

--- a/docs/reference/cli/bc_cost_budget_show.md
+++ b/docs/reference/cli/bc_cost_budget_show.md
@@ -1,0 +1,35 @@
+## bc cost budget show
+
+Show budget status
+
+### Synopsis
+
+Show current budget configuration and status.
+
+Examples:
+  bc cost budget show                   # Show all budgets
+  bc cost budget show --agent eng-01    # Show agent budget
+
+```
+bc cost budget show [flags]
+```
+
+### Options
+
+```
+      --agent string   Show budget for specific agent
+  -h, --help           help for show
+      --team string    Show budget for specific team
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost budget](bc_cost_budget.md)	 - Manage cost budgets
+

--- a/docs/reference/cli/bc_cost_daily.md
+++ b/docs/reference/cli/bc_cost_daily.md
@@ -1,0 +1,35 @@
+## bc cost daily
+
+Show daily cost totals
+
+### Synopsis
+
+Show daily cost totals for the last N days.
+
+Examples:
+  bc cost daily              # Last 30 days (default)
+  bc cost daily --days 7     # Last 7 days
+  bc cost daily --json
+
+```
+bc cost daily [flags]
+```
+
+### Options
+
+```
+      --days int   Number of days to show (default 30)
+  -h, --help       help for daily
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost](bc_cost.md)	 - Show cost information
+

--- a/docs/reference/cli/bc_cost_dashboard.md
+++ b/docs/reference/cli/bc_cost_dashboard.md
@@ -1,0 +1,34 @@
+## bc cost dashboard
+
+Show rich cost dashboard
+
+### Synopsis
+
+Show a rich formatted cost dashboard with summary, per-agent breakdown,
+per-model breakdown, and budget status.
+
+Examples:
+  bc cost dashboard
+  bc cost dashboard --json
+
+```
+bc cost dashboard [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for dashboard
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost](bc_cost.md)	 - Show cost information
+

--- a/docs/reference/cli/bc_cost_model.md
+++ b/docs/reference/cli/bc_cost_model.md
@@ -1,0 +1,33 @@
+## bc cost model
+
+Show per-model cost breakdown
+
+### Synopsis
+
+Show cost breakdown by model.
+
+Examples:
+  bc cost model
+  bc cost model claude-sonnet-4-6
+
+```
+bc cost model [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for model
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost](bc_cost.md)	 - Show cost information
+

--- a/docs/reference/cli/bc_cost_show.md
+++ b/docs/reference/cli/bc_cost_show.md
@@ -1,0 +1,39 @@
+## bc cost show
+
+Show cost records
+
+### Synopsis
+
+Show cost records, optionally filtered by agent.
+
+You can specify the agent either as a positional argument or using --agent flag.
+
+Examples:
+  bc cost show
+  bc cost show engineer-01
+  bc cost show --agent engineer-01
+
+```
+bc cost show [agent] [flags]
+```
+
+### Options
+
+```
+      --agent string   Filter by agent (alternative to positional argument)
+  -h, --help           help for show
+  -n, --limit int      Number of records to show (default 20)
+      --offset int     Number of records to skip (for pagination)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost](bc_cost.md)	 - Show cost information
+

--- a/docs/reference/cli/bc_cost_summary.md
+++ b/docs/reference/cli/bc_cost_summary.md
@@ -1,0 +1,33 @@
+## bc cost summary
+
+Show workspace cost overview
+
+### Synopsis
+
+Show cost summary with today, this week, this month, and all-time totals.
+
+Examples:
+  bc cost summary
+  bc cost summary --json
+
+```
+bc cost summary [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for summary
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost](bc_cost.md)	 - Show cost information
+

--- a/docs/reference/cli/bc_cost_usage.md
+++ b/docs/reference/cli/bc_cost_usage.md
@@ -1,0 +1,48 @@
+## bc cost usage
+
+Show Claude Code token usage via ccusage
+
+### Synopsis
+
+Show Claude Code token usage and cost analytics via ccusage.
+
+Wraps the ccusage tool (https://github.com/ryoppippi/ccusage) to display
+detailed token usage, per-model cost breakdown, and cache analytics from
+Claude Code's local JSONL session files.
+
+Requires npx (Node.js) to be available on the system.
+
+Examples:
+  bc cost usage                        # Daily usage report
+  bc cost usage --monthly              # Monthly summary
+  bc cost usage --session              # Per-session breakdown
+  bc cost usage --since 20260301       # Usage since date (YYYYMMDD)
+  bc cost usage --until 20260301       # Usage until date (YYYYMMDD)
+  bc cost usage --json                 # Raw JSON output
+
+```
+bc cost usage [flags]
+```
+
+### Options
+
+```
+  -h, --help           help for usage
+      --monthly        Show monthly summary
+      --refresh        Force refresh cached data
+      --session        Show per-session breakdown
+      --since string   Filter from date (YYYYMMDD)
+      --until string   Filter until date (YYYYMMDD)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cost](bc_cost.md)	 - Show cost information
+

--- a/docs/reference/cli/bc_cron.md
+++ b/docs/reference/cli/bc_cron.md
@@ -1,0 +1,51 @@
+## bc cron
+
+Manage scheduled agent tasks
+
+### Synopsis
+
+Manage cron jobs that trigger agent prompts or shell commands on a schedule.
+
+Cron expressions use standard 5-field format:
+  ┌────── minute (0-59)
+  │ ┌──── hour (0-23)
+  │ │ ┌── day of month (1-31)
+  │ │ │ ┌ month (1-12)
+  │ │ │ │ ┌ day of week (0-6, 0=Sun)
+  * * * * *
+
+Examples:
+  bc cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint"
+  bc cron list                          # List all cron jobs
+  bc cron show daily-lint               # Show job details
+  bc cron enable daily-lint             # Enable a disabled job
+  bc cron disable daily-lint            # Disable without deleting
+  bc cron run daily-lint                # Trigger manually
+  bc cron logs daily-lint --last 10     # Show last 10 executions
+  bc cron remove daily-lint             # Delete a job
+
+### Options
+
+```
+  -h, --help   help for cron
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc cron add](bc_cron_add.md)	 - Add a new cron job
+* [bc cron disable](bc_cron_disable.md)	 - Disable a cron job
+* [bc cron enable](bc_cron_enable.md)	 - Enable a cron job
+* [bc cron list](bc_cron_list.md)	 - List all cron jobs
+* [bc cron logs](bc_cron_logs.md)	 - Show execution history for a cron job
+* [bc cron remove](bc_cron_remove.md)	 - Remove a cron job
+* [bc cron run](bc_cron_run.md)	 - Manually trigger a cron job
+* [bc cron show](bc_cron_show.md)	 - Show cron job details
+

--- a/docs/reference/cli/bc_cron_add.md
+++ b/docs/reference/cli/bc_cron_add.md
@@ -1,0 +1,41 @@
+## bc cron add
+
+Add a new cron job
+
+### Synopsis
+
+Create a new scheduled cron job.
+
+One of --agent+--prompt or --command is required.
+
+Examples:
+  bc cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint and report"
+  bc cron add hourly-check --schedule "0 * * * *" --command "make check"
+  bc cron add weekday-standup --schedule "0 9 * * 1-5" --agent root --prompt "Send standup"
+
+```
+bc cron add <name> [flags]
+```
+
+### Options
+
+```
+      --agent string      Target agent name
+      --command string    Shell command to run (alternative to --agent+--prompt)
+      --disabled          Create job in disabled state
+  -h, --help              help for add
+      --prompt string     Prompt to send to the agent
+      --schedule string   5-field cron expression (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+

--- a/docs/reference/cli/bc_cron_disable.md
+++ b/docs/reference/cli/bc_cron_disable.md
@@ -1,0 +1,32 @@
+## bc cron disable
+
+Disable a cron job
+
+### Synopsis
+
+Disable a cron job without deleting it.
+
+Examples:
+  bc cron disable daily-lint
+
+```
+bc cron disable <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for disable
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+

--- a/docs/reference/cli/bc_cron_enable.md
+++ b/docs/reference/cli/bc_cron_enable.md
@@ -1,0 +1,32 @@
+## bc cron enable
+
+Enable a cron job
+
+### Synopsis
+
+Enable a disabled cron job. The next run time is recalculated from now.
+
+Examples:
+  bc cron enable daily-lint
+
+```
+bc cron enable <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for enable
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+

--- a/docs/reference/cli/bc_cron_list.md
+++ b/docs/reference/cli/bc_cron_list.md
@@ -1,0 +1,33 @@
+## bc cron list
+
+List all cron jobs
+
+### Synopsis
+
+Display all scheduled cron jobs with their status.
+
+Examples:
+  bc cron list
+  bc cron list --json
+
+```
+bc cron list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+

--- a/docs/reference/cli/bc_cron_logs.md
+++ b/docs/reference/cli/bc_cron_logs.md
@@ -1,0 +1,35 @@
+## bc cron logs
+
+Show execution history for a cron job
+
+### Synopsis
+
+Display the execution log for a cron job.
+
+Examples:
+  bc cron logs daily-lint
+  bc cron logs daily-lint --last 5
+  bc cron logs daily-lint --json
+
+```
+bc cron logs <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help       help for logs
+      --json       Output as JSON
+      --last int   Number of entries to show (default 20)
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+

--- a/docs/reference/cli/bc_cron_remove.md
+++ b/docs/reference/cli/bc_cron_remove.md
@@ -1,0 +1,32 @@
+## bc cron remove
+
+Remove a cron job
+
+### Synopsis
+
+Delete a cron job and its execution logs.
+
+Examples:
+  bc cron remove daily-lint
+
+```
+bc cron remove <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+

--- a/docs/reference/cli/bc_cron_run.md
+++ b/docs/reference/cli/bc_cron_run.md
@@ -1,0 +1,34 @@
+## bc cron run
+
+Manually trigger a cron job
+
+### Synopsis
+
+Trigger a cron job immediately outside its normal schedule.
+The job must be enabled. The daemon (bcd) executes the actual agent interaction;
+this command records the trigger and updates run stats.
+
+Examples:
+  bc cron run daily-lint
+
+```
+bc cron run <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for run
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+

--- a/docs/reference/cli/bc_cron_show.md
+++ b/docs/reference/cli/bc_cron_show.md
@@ -1,0 +1,33 @@
+## bc cron show
+
+Show cron job details
+
+### Synopsis
+
+Display full details of a cron job including schedule and run history stats.
+
+Examples:
+  bc cron show daily-lint
+  bc cron show daily-lint --json
+
+```
+bc cron show <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+      --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc cron](bc_cron.md)	 - Manage scheduled agent tasks
+

--- a/docs/reference/cli/bc_daemon.md
+++ b/docs/reference/cli/bc_daemon.md
@@ -1,0 +1,41 @@
+## bc daemon
+
+Manage workspace processes and the bcd server
+
+### Synopsis
+
+Manage long-lived workspace processes (databases, servers, etc.)
+and the bcd coordination server.
+
+  bc daemon start          — start the bcd HTTP server
+  bc daemon run --name db  — run a workspace process
+  bc daemon list           — list running workspace processes
+  bc daemon stop [name]    — stop bcd server or a named process
+  bc daemon status         — check bcd server health
+  bc daemon logs [name]    — view bcd or process logs
+
+### Options
+
+```
+  -h, --help   help for daemon
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc daemon list](bc_daemon_list.md)	 - List workspace processes
+* [bc daemon logs](bc_daemon_logs.md)	 - Show bcd server or process logs
+* [bc daemon restart](bc_daemon_restart.md)	 - Restart a workspace process
+* [bc daemon rm](bc_daemon_rm.md)	 - Remove a stopped workspace process
+* [bc daemon run](bc_daemon_run.md)	 - Run a named workspace process
+* [bc daemon start](bc_daemon_start.md)	 - Start the bcd daemon
+* [bc daemon status](bc_daemon_status.md)	 - Show bcd server status
+* [bc daemon stop](bc_daemon_stop.md)	 - Stop the bcd server or a named workspace process
+

--- a/docs/reference/cli/bc_daemon_list.md
+++ b/docs/reference/cli/bc_daemon_list.md
@@ -1,0 +1,32 @@
+## bc daemon list
+
+List workspace processes
+
+### Synopsis
+
+List all workspace processes managed by bc daemon.
+
+Examples:
+  bc daemon list
+
+```
+bc daemon list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+

--- a/docs/reference/cli/bc_daemon_logs.md
+++ b/docs/reference/cli/bc_daemon_logs.md
@@ -1,0 +1,37 @@
+## bc daemon logs
+
+Show bcd server or process logs
+
+### Synopsis
+
+Show logs for the bcd server or a named workspace process.
+
+Without an argument, shows bcd server logs.
+With a name, shows the named workspace process logs.
+
+Examples:
+  bc daemon logs           # bcd server logs
+  bc daemon logs postgres  # workspace process logs
+
+```
+bc daemon logs [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help       help for logs
+      --tail int   Number of lines to show (default 50)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+

--- a/docs/reference/cli/bc_daemon_restart.md
+++ b/docs/reference/cli/bc_daemon_restart.md
@@ -1,0 +1,32 @@
+## bc daemon restart
+
+Restart a workspace process
+
+### Synopsis
+
+Restart a named workspace process using its saved configuration.
+
+Examples:
+  bc daemon restart postgres
+
+```
+bc daemon restart <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for restart
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+

--- a/docs/reference/cli/bc_daemon_rm.md
+++ b/docs/reference/cli/bc_daemon_rm.md
@@ -1,0 +1,32 @@
+## bc daemon rm
+
+Remove a stopped workspace process
+
+### Synopsis
+
+Remove a stopped workspace process record. The process must be stopped first.
+
+Examples:
+  bc daemon rm postgres
+
+```
+bc daemon rm <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rm
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+

--- a/docs/reference/cli/bc_daemon_run.md
+++ b/docs/reference/cli/bc_daemon_run.md
@@ -1,0 +1,43 @@
+## bc daemon run
+
+Run a named workspace process
+
+### Synopsis
+
+Run a long-lived workspace process in a tmux session or Docker container.
+
+Examples:
+  bc daemon run --name api --runtime tmux --cmd "go run ./cmd/api"
+  bc daemon run --name db --runtime docker --image postgres:17 --port 5432:5432
+
+```
+bc daemon run --name <name> --runtime <tmux|docker> [options] [flags]
+```
+
+### Options
+
+```
+      --cmd string           Command to run (tmux runtime)
+  -d, --detach               Run in background (default true) (default true)
+      --env stringArray      Env var KEY=VALUE (repeatable)
+      --env-file string      File of KEY=VALUE env vars
+  -h, --help                 help for run
+      --image string         Docker image (docker runtime)
+      --name string          Process name (required)
+      --port stringArray     Port mapping, e.g. 5432:5432 (repeatable)
+      --restart string       Restart policy: no|always|on-failure (default "no")
+      --runtime string       Runtime: tmux or docker (required)
+      --volume stringArray   Volume mount, e.g. /var/run/docker.sock:/var/run/docker.sock (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+

--- a/docs/reference/cli/bc_daemon_start.md
+++ b/docs/reference/cli/bc_daemon_start.md
@@ -1,0 +1,37 @@
+## bc daemon start
+
+Start the bcd daemon
+
+### Synopsis
+
+Start the bc coordination daemon (bcd).
+
+bcd is an HTTP server that manages agent, channel, and workspace state.
+By default it listens on :4880. Use -d to run in the background.
+
+Examples:
+  bc daemon start          # Foreground (blocks)
+  bc daemon start -d       # Background (daemonized)
+
+```
+bc daemon start [flags]
+```
+
+### Options
+
+```
+  -d, --daemonize   Run in background (daemonized)
+  -h, --help        help for start
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+

--- a/docs/reference/cli/bc_daemon_status.md
+++ b/docs/reference/cli/bc_daemon_status.md
@@ -1,0 +1,32 @@
+## bc daemon status
+
+Show bcd server status
+
+### Synopsis
+
+Check bcd server health, address, and uptime.
+
+Examples:
+  bc daemon status
+
+```
+bc daemon status [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+

--- a/docs/reference/cli/bc_daemon_stop.md
+++ b/docs/reference/cli/bc_daemon_stop.md
@@ -1,0 +1,36 @@
+## bc daemon stop
+
+Stop the bcd server or a named workspace process
+
+### Synopsis
+
+Stop the bcd server or a named workspace process.
+
+Without an argument, sends a shutdown signal to the bcd HTTP server.
+With a name, stops the named workspace process.
+
+Examples:
+  bc daemon stop           # Stop bcd server
+  bc daemon stop postgres  # Stop workspace process
+
+```
+bc daemon stop [name] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for stop
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc daemon](bc_daemon.md)	 - Manage workspace processes and the bcd server
+

--- a/docs/reference/cli/bc_doctor.md
+++ b/docs/reference/cli/bc_doctor.md
@@ -1,0 +1,51 @@
+## bc doctor
+
+Health checks and diagnostics
+
+### Synopsis
+
+Run health checks on your bc workspace and dependencies.
+
+Checks workspace config, agent state, databases, tools, and git worktrees.
+
+Categories:
+  workspace   .bc/ directory, settings.toml, role files
+  database    SQLite integrity and table existence
+  agents      Running agents, stale sessions, missing worktrees
+  tools       tmux, git, and AI provider installations
+  git         Worktree validity and orphaned worktrees
+
+Examples:
+  bc doctor                          # Full health check
+  bc doctor check workspace          # Check specific category
+  bc doctor fix                      # Auto-fix fixable issues
+  bc doctor fix --dry-run            # Preview fixes
+  bc doctor fix --category git       # Fix specific category
+
+Exit codes:
+  0  All checks passed or only warnings
+  1  One or more checks failed
+
+```
+bc doctor [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for doctor
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc doctor check](bc_doctor_check.md)	 - Check a specific health category
+* [bc doctor fix](bc_doctor_fix.md)	 - Auto-fix fixable issues
+

--- a/docs/reference/cli/bc_doctor_check.md
+++ b/docs/reference/cli/bc_doctor_check.md
@@ -1,0 +1,25 @@
+## bc doctor check
+
+Check a specific health category
+
+```
+bc doctor check [category] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for check
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc doctor](bc_doctor.md)	 - Health checks and diagnostics
+

--- a/docs/reference/cli/bc_doctor_fix.md
+++ b/docs/reference/cli/bc_doctor_fix.md
@@ -1,0 +1,42 @@
+## bc doctor fix
+
+Auto-fix fixable issues
+
+### Synopsis
+
+Attempt to automatically repair fixable issues found by 'bc doctor'.
+
+Fixable issues include:
+  - Orphaned git worktrees
+  - Missing workspace directories
+
+Use --dry-run to preview actions without making changes.
+
+Examples:
+  bc doctor fix                      # Fix all fixable issues
+  bc doctor fix --dry-run            # Preview fixes
+  bc doctor fix --category git       # Fix specific category
+
+```
+bc doctor fix [flags]
+```
+
+### Options
+
+```
+      --category string   Fix only the specified category
+      --dry-run           Preview fixes without making changes
+  -h, --help              help for fix
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc doctor](bc_doctor.md)	 - Health checks and diagnostics
+

--- a/docs/reference/cli/bc_down.md
+++ b/docs/reference/cli/bc_down.md
@@ -1,0 +1,36 @@
+## bc down
+
+Stop bc agents
+
+### Synopsis
+
+Stop all running bc agents.
+
+This will gracefully stop all agent tmux sessions.
+
+Examples:
+  bc down          # Stop all agents
+  bc down --force  # Force kill without cleanup
+
+```
+bc down [flags]
+```
+
+### Options
+
+```
+      --force   Force kill without cleanup
+  -h, --help    help for down
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+

--- a/docs/reference/cli/bc_env.md
+++ b/docs/reference/cli/bc_env.md
@@ -1,0 +1,44 @@
+## bc env
+
+Manage workspace environment variables
+
+### Synopsis
+
+Configure environment variables for agent sessions.
+
+Environment variables are stored in settings.toml and injected into agent
+sessions at startup. Use --provider to set per-provider env vars.
+
+Priority (highest wins): agent --env file > provider env > workspace env.
+
+Examples:
+  bc env set SHARED_VAR global                           # workspace [env]
+  bc env set --provider claude CLAUDE_CODE_USE_BEDROCK 1 # [providers.claude.env]
+  bc env list                                            # all env vars
+  bc env list --provider claude                          # claude-only env vars
+  bc env get SHARED_VAR
+  bc env unset SHARED_VAR
+  bc env unset --provider claude CLAUDE_CODE_USE_BEDROCK
+
+### Options
+
+```
+  -h, --help              help for env
+      --provider string   Target a specific provider (e.g., claude, gemini)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc env get](bc_env_get.md)	 - Get an environment variable value
+* [bc env list](bc_env_list.md)	 - List environment variables
+* [bc env set](bc_env_set.md)	 - Set an environment variable
+* [bc env unset](bc_env_unset.md)	 - Remove an environment variable
+

--- a/docs/reference/cli/bc_env_get.md
+++ b/docs/reference/cli/bc_env_get.md
@@ -1,0 +1,26 @@
+## bc env get
+
+Get an environment variable value
+
+```
+bc env get <KEY> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --json              Output in JSON format
+      --provider string   Target a specific provider (e.g., claude, gemini)
+  -v, --verbose           Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc env](bc_env.md)	 - Manage workspace environment variables
+

--- a/docs/reference/cli/bc_env_list.md
+++ b/docs/reference/cli/bc_env_list.md
@@ -1,0 +1,26 @@
+## bc env list
+
+List environment variables
+
+```
+bc env list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --json              Output in JSON format
+      --provider string   Target a specific provider (e.g., claude, gemini)
+  -v, --verbose           Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc env](bc_env.md)	 - Manage workspace environment variables
+

--- a/docs/reference/cli/bc_env_set.md
+++ b/docs/reference/cli/bc_env_set.md
@@ -1,0 +1,26 @@
+## bc env set
+
+Set an environment variable
+
+```
+bc env set <KEY> <VALUE> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --json              Output in JSON format
+      --provider string   Target a specific provider (e.g., claude, gemini)
+  -v, --verbose           Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc env](bc_env.md)	 - Manage workspace environment variables
+

--- a/docs/reference/cli/bc_env_unset.md
+++ b/docs/reference/cli/bc_env_unset.md
@@ -1,0 +1,26 @@
+## bc env unset
+
+Remove an environment variable
+
+```
+bc env unset <KEY> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for unset
+```
+
+### Options inherited from parent commands
+
+```
+      --json              Output in JSON format
+      --provider string   Target a specific provider (e.g., claude, gemini)
+  -v, --verbose           Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc env](bc_env.md)	 - Manage workspace environment variables
+

--- a/docs/reference/cli/bc_home.md
+++ b/docs/reference/cli/bc_home.md
@@ -1,0 +1,45 @@
+## bc home
+
+Open the bc TUI dashboard
+
+### Synopsis
+
+Open the bc terminal user interface (TUI) dashboard.
+
+The TUI provides a visual interface for managing agents, channels,
+costs, and other bc features using keyboard navigation.
+
+Requirements:
+  - bun (or node) must be installed
+  - TUI must be built (run 'make build-tui-local' if needed)
+
+Navigation:
+  [1-4]  Switch tabs (Dashboard, Agents, Channels, Costs)
+  [j/k]  Navigate lists (down/up)
+  [?]    Show help
+  [q]    Quit
+
+Examples:
+  bc home          # Open TUI dashboard
+
+```
+bc home [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for home
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+

--- a/docs/reference/cli/bc_init.md
+++ b/docs/reference/cli/bc_init.md
@@ -1,0 +1,48 @@
+## bc init
+
+Initialize a new bc v2 workspace
+
+### Synopsis
+
+Initialize a new bc v2 workspace in the specified directory (or current directory).
+
+This creates a .bc directory with v2 configuration for managing agents.
+
+v2 workspace structure:
+  .bc/
+    settings.toml  # Workspace configuration
+    roles/         # Agent role definitions
+      root.md      # Root agent role
+    agents/        # Per-agent state files
+
+Examples:
+  bc init                        # Interactive wizard
+  bc init --quick                # Quick init with defaults
+  bc init --preset solo          # Use solo developer preset
+  bc init --preset small-team    # Use small team preset
+  bc init --preset full-team     # Use full team preset
+  bc init ~/Projects/myapp       # Initialize specific directory
+
+```
+bc init [directory] [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for init
+      --preset string   Use preset configuration (solo, small-team, full-team)
+      --quick           Quick init with defaults (skip wizard)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+

--- a/docs/reference/cli/bc_logs.md
+++ b/docs/reference/cli/bc_logs.md
@@ -1,0 +1,60 @@
+## bc logs
+
+Show the event log
+
+### Synopsis
+
+View the bc event log showing agent spawns, stops, work assignments, and reports.
+
+Examples:
+  bc logs                     # Show all events
+  bc logs --agent eng-01      # Filter by agent
+  bc logs --type agent.report # Filter by event type
+  bc logs --since 1h          # Events from last hour
+  bc logs --tail 20           # Last N events
+  bc logs --full              # Show full messages (no truncation)
+  bc logs --json              # JSON output
+
+Event Types:
+  agent.started    Agent was created and started
+  agent.stopped    Agent was stopped
+  agent.report     Agent submitted a progress report
+  state.working    Agent started working on task
+  state.idle       Agent became idle
+  state.stuck      Agent is stuck (may need intervention)
+
+Output:
+  TIME      AGENT     TYPE           MESSAGE
+  10:15:32  eng-01    state.working  Starting implementation
+  10:16:45  eng-01    agent.report   Completed feature X
+
+See Also:
+  bc status    Quick agent status overview
+  bc home      TUI with activity timeline
+
+```
+bc logs [flags]
+```
+
+### Options
+
+```
+      --agent string   Filter by agent name
+      --full           Show full messages without truncation
+  -h, --help           help for logs
+      --since string   Show events since duration ago (e.g. 1h, 30m)
+      --tail int       Show last N events
+      --type string    Filter by event type (e.g. agent.report)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+

--- a/docs/reference/cli/bc_mcp.md
+++ b/docs/reference/cli/bc_mcp.md
@@ -1,0 +1,47 @@
+## bc mcp
+
+Manage MCP server configurations
+
+### Synopsis
+
+Manage Model Context Protocol (MCP) server configurations.
+
+MCP servers provide tools and resources to AI agents. Configurations are
+stored per-workspace and can be referenced by roles.
+
+Examples:
+  bc mcp list                                     # List all MCP servers
+  bc mcp add github --command npx --args "@modelcontextprotocol/server-github"
+  bc mcp add sqlite --command npx --args "@modelcontextprotocol/server-sqlite,/path/to/db"
+  bc mcp add remote --transport sse --url "https://api.example.com/mcp"
+  bc mcp add github --command npx --env "GITHUB_TOKEN=tok_123"
+  bc mcp show github                              # Show server details
+  bc mcp remove github                            # Remove a server
+  bc mcp disable github                           # Disable a server
+  bc mcp enable github                            # Re-enable a server
+
+### Options
+
+```
+  -h, --help   help for mcp
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc mcp add](bc_mcp_add.md)	 - Add an MCP server configuration
+* [bc mcp disable](bc_mcp_disable.md)	 - Disable an MCP server configuration
+* [bc mcp enable](bc_mcp_enable.md)	 - Enable an MCP server configuration
+* [bc mcp list](bc_mcp_list.md)	 - List MCP server configurations
+* [bc mcp register](bc_mcp_register.md)	 - Register bc as an MCP server in agent settings.json
+* [bc mcp remove](bc_mcp_remove.md)	 - Remove an MCP server configuration
+* [bc mcp serve](bc_mcp_serve.md)	 - Start bc as an MCP server
+* [bc mcp show](bc_mcp_show.md)	 - Show MCP server configuration details
+

--- a/docs/reference/cli/bc_mcp_add.md
+++ b/docs/reference/cli/bc_mcp_add.md
@@ -1,0 +1,47 @@
+## bc mcp add
+
+Add an MCP server configuration
+
+### Synopsis
+
+Add a new MCP server configuration to the workspace.
+
+For stdio transport (default), specify --command and optionally --args.
+For SSE transport, specify --transport sse and --url.
+
+Environment variables can be passed with --env as KEY=VALUE pairs.
+
+Examples:
+  bc mcp add github --command npx --args "@modelcontextprotocol/server-github"
+  bc mcp add db --command npx --args "@modelcontextprotocol/server-sqlite,/tmp/test.db"
+  bc mcp add remote --transport sse --url "https://api.example.com/mcp"
+  bc mcp add github --command npx --env 'GITHUB_TOKEN=${secret:GITHUB_TOKEN}' --env "OWNER=me"
+
+Use ${secret:NAME} references for sensitive values (see 'bc secret set').
+
+```
+bc mcp add <name> [flags]
+```
+
+### Options
+
+```
+      --args string        Comma-separated arguments
+      --command string     Command to run (for stdio transport)
+      --env stringArray    Environment variables (KEY=VALUE, repeatable)
+  -h, --help               help for add
+      --transport string   Transport type (stdio or sse) (default "stdio")
+      --url string         Server URL (for sse transport)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+

--- a/docs/reference/cli/bc_mcp_disable.md
+++ b/docs/reference/cli/bc_mcp_disable.md
@@ -1,0 +1,25 @@
+## bc mcp disable
+
+Disable an MCP server configuration
+
+```
+bc mcp disable <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for disable
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+

--- a/docs/reference/cli/bc_mcp_enable.md
+++ b/docs/reference/cli/bc_mcp_enable.md
@@ -1,0 +1,25 @@
+## bc mcp enable
+
+Enable an MCP server configuration
+
+```
+bc mcp enable <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for enable
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+

--- a/docs/reference/cli/bc_mcp_list.md
+++ b/docs/reference/cli/bc_mcp_list.md
@@ -1,0 +1,25 @@
+## bc mcp list
+
+List MCP server configurations
+
+```
+bc mcp list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+

--- a/docs/reference/cli/bc_mcp_register.md
+++ b/docs/reference/cli/bc_mcp_register.md
@@ -1,0 +1,38 @@
+## bc mcp register
+
+Register bc as an MCP server in agent settings.json
+
+### Synopsis
+
+Automatically add bc to the Claude Code MCP server configuration.
+
+This writes (or updates) the mcp.servers entry in the workspace
+settings.json so that agents automatically have access to bc MCP tools.
+
+Examples:
+  bc mcp register               # Register with stdio transport
+  bc mcp register --sse         # Register with SSE transport
+
+```
+bc mcp register [flags]
+```
+
+### Options
+
+```
+      --addr string   SSE server address to register (default ":8811")
+  -h, --help          help for register
+      --sse           Register SSE transport endpoint
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+

--- a/docs/reference/cli/bc_mcp_remove.md
+++ b/docs/reference/cli/bc_mcp_remove.md
@@ -1,0 +1,25 @@
+## bc mcp remove
+
+Remove an MCP server configuration
+
+```
+bc mcp remove <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+

--- a/docs/reference/cli/bc_mcp_serve.md
+++ b/docs/reference/cli/bc_mcp_serve.md
@@ -1,0 +1,56 @@
+## bc mcp serve
+
+Start bc as an MCP server
+
+### Synopsis
+
+Start bc as an MCP (Model Context Protocol) server.
+
+AI tools like Claude Code and Cursor can connect to bc via MCP to query
+workspace state and control agents natively.
+
+Default transport is stdio (newline-delimited JSON on stdin/stdout).
+Use --sse to start an HTTP server instead.
+
+Resources exposed:
+  bc://workspace/status   Workspace name, path, and config
+  bc://agents             All agents with state, role, and worktree info
+  bc://channels           All channels with members and message counts
+  bc://costs              Workspace and per-agent cost summaries
+  bc://roles              Role definitions with capabilities
+  bc://tools              Available AI agent tools
+
+Tools available:
+  create_agent     Create a new agent in the workspace
+  send_message     Send a message to a channel
+  report_status    Update an agent's current task
+  query_costs      Query cost usage
+
+Examples:
+  bc mcp serve                    # stdio — use in Claude Code settings.json
+  bc mcp serve --sse              # SSE on :8811
+  bc mcp serve --sse --addr :9000 # SSE on custom port
+
+```
+bc mcp serve [flags]
+```
+
+### Options
+
+```
+      --addr string   Address to listen on (SSE mode only) (default ":8811")
+  -h, --help          help for serve
+      --sse           Use SSE transport instead of stdio
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+

--- a/docs/reference/cli/bc_mcp_show.md
+++ b/docs/reference/cli/bc_mcp_show.md
@@ -1,0 +1,25 @@
+## bc mcp show
+
+Show MCP server configuration details
+
+```
+bc mcp show <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc mcp](bc_mcp.md)	 - Manage MCP server configurations
+

--- a/docs/reference/cli/bc_role.md
+++ b/docs/reference/cli/bc_role.md
@@ -1,0 +1,32 @@
+## bc role
+
+Manage agent roles in the workspace
+
+### Synopsis
+
+Manage agent roles via the bcd daemon.
+
+Examples:
+  bc role list                                      # List all roles
+  bc role show engineer                             # Show engineer role details
+  bc role list --json                               # JSON output
+
+### Options
+
+```
+  -h, --help   help for role
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc role list](bc_role_list.md)	 - List all roles in the workspace
+* [bc role show](bc_role_show.md)	 - Show role definition and metadata
+

--- a/docs/reference/cli/bc_role_list.md
+++ b/docs/reference/cli/bc_role_list.md
@@ -1,0 +1,26 @@
+## bc role list
+
+List all roles in the workspace
+
+```
+bc role list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output in JSON format
+      --mcp    Show MCP server associations column
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc role](bc_role.md)	 - Manage agent roles in the workspace
+

--- a/docs/reference/cli/bc_role_show.md
+++ b/docs/reference/cli/bc_role_show.md
@@ -1,0 +1,25 @@
+## bc role show
+
+Show role definition and metadata
+
+```
+bc role show <role> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc role](bc_role.md)	 - Manage agent roles in the workspace
+

--- a/docs/reference/cli/bc_secret.md
+++ b/docs/reference/cli/bc_secret.md
@@ -1,0 +1,47 @@
+## bc secret
+
+Manage encrypted secrets
+
+### Synopsis
+
+Manage encrypted secrets for the workspace.
+
+Secrets store API keys and tokens used by tools, MCP servers, and agents.
+Values are encrypted at rest with AES-256-GCM. The API never exposes
+secret values in list/show operations.
+
+Other configs reference secrets with ${secret:NAME} syntax:
+  [tools.claude-code]
+  env = { ANTHROPIC_API_KEY = "${secret:ANTHROPIC_API_KEY}" }
+
+Examples:
+  bc secret set ANTHROPIC_API_KEY                    # Prompt for value
+  bc secret set ANTHROPIC_API_KEY --value "sk-..."   # Set directly
+  bc secret set GITHUB_TOKEN --from-env GITHUB_TOKEN # Import from env var
+  bc secret list                                     # List names (no values)
+  bc secret show ANTHROPIC_API_KEY                   # Show metadata
+  bc secret show ANTHROPIC_API_KEY --reveal          # Show actual value
+  bc secret delete ANTHROPIC_API_KEY                 # Delete a secret
+
+### Options
+
+```
+  -h, --help   help for secret
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc secret delete](bc_secret_delete.md)	 - Delete a secret
+* [bc secret get](bc_secret_get.md)	 - Get a secret value (prints to stdout)
+* [bc secret list](bc_secret_list.md)	 - List secrets (names and metadata only)
+* [bc secret set](bc_secret_set.md)	 - Create or update a secret
+* [bc secret show](bc_secret_show.md)	 - Show secret metadata
+

--- a/docs/reference/cli/bc_secret_delete.md
+++ b/docs/reference/cli/bc_secret_delete.md
@@ -1,0 +1,25 @@
+## bc secret delete
+
+Delete a secret
+
+```
+bc secret delete <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc secret](bc_secret.md)	 - Manage encrypted secrets
+

--- a/docs/reference/cli/bc_secret_get.md
+++ b/docs/reference/cli/bc_secret_get.md
@@ -1,0 +1,25 @@
+## bc secret get
+
+Get a secret value (prints to stdout)
+
+```
+bc secret get <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc secret](bc_secret.md)	 - Manage encrypted secrets
+

--- a/docs/reference/cli/bc_secret_list.md
+++ b/docs/reference/cli/bc_secret_list.md
@@ -1,0 +1,25 @@
+## bc secret list
+
+List secrets (names and metadata only)
+
+```
+bc secret list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc secret](bc_secret.md)	 - Manage encrypted secrets
+

--- a/docs/reference/cli/bc_secret_set.md
+++ b/docs/reference/cli/bc_secret_set.md
@@ -1,0 +1,46 @@
+## bc secret set
+
+Create or update a secret
+
+### Synopsis
+
+Create or update an encrypted secret.
+
+The value can be provided via --value, --from-env, or --from-file.
+If none are specified, reads from stdin.
+
+Note: --value appears in shell history. For sensitive values, prefer:
+  bc secret set API_KEY --from-env API_KEY
+  echo "sk-abc123" | bc secret set API_KEY
+
+Examples:
+  bc secret set API_KEY --value "sk-abc123"
+  bc secret set API_KEY --from-env API_KEY
+  bc secret set API_KEY --from-file /path/to/key
+  echo "sk-abc123" | bc secret set API_KEY
+
+```
+bc secret set <name> [flags]
+```
+
+### Options
+
+```
+      --desc string        Secret description
+      --from-env string    Import value from environment variable
+      --from-file string   Import value from file
+  -h, --help               help for set
+      --value string       Secret value (visible in shell history — prefer --from-env or stdin)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc secret](bc_secret.md)	 - Manage encrypted secrets
+

--- a/docs/reference/cli/bc_secret_show.md
+++ b/docs/reference/cli/bc_secret_show.md
@@ -1,0 +1,26 @@
+## bc secret show
+
+Show secret metadata
+
+```
+bc secret show <name> [flags]
+```
+
+### Options
+
+```
+  -h, --help     help for show
+      --reveal   Show the actual secret value
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc secret](bc_secret.md)	 - Manage encrypted secrets
+

--- a/docs/reference/cli/bc_status.md
+++ b/docs/reference/cli/bc_status.md
@@ -1,0 +1,52 @@
+## bc status
+
+Show agent status
+
+### Synopsis
+
+Show the status of all bc agents.
+
+Examples:
+  bc status                   # Show all agents
+  bc status --json            # Output as JSON
+  bc status --activity        # Show recent channel activity
+
+Output:
+  AGENT     ROLE      STATE    UPTIME    TASK
+  eng-01    engineer  working  2h 15m    Implementing feature X
+  eng-02    engineer  idle     1h 30m    -
+
+Agent States:
+  working   Agent is actively processing
+  idle      Agent is waiting for input
+  done      Agent has completed task
+  error     Agent encountered an error
+  stopped   Agent is not running
+
+See Also:
+  bc agent list   List agents with more detail
+  bc logs         View agent event logs
+  bc home         Open TUI dashboard
+
+```
+bc status [flags]
+```
+
+### Options
+
+```
+      --activity   Show recent channel activity
+  -h, --help       help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+

--- a/docs/reference/cli/bc_tool.md
+++ b/docs/reference/cli/bc_tool.md
@@ -1,0 +1,44 @@
+## bc tool
+
+Manage AI tool providers
+
+### Synopsis
+
+Add, remove, and inspect AI tool providers for agent spawning.
+
+Examples:
+  bc tool list              # Show all tools with status
+  bc tool add myagent       # Add a custom tool
+  bc tool show claude       # Show tool details
+  bc tool setup claude      # Install and configure a tool
+  bc tool status claude     # Check installation status
+  bc tool upgrade claude    # Upgrade an installed tool
+  bc tool delete mytool     # Remove a custom tool
+  bc tool run claude --help # Run a tool directly
+
+### Options
+
+```
+  -h, --help   help for tool
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc tool add](bc_tool_add.md)	 - Add a tool to the workspace
+* [bc tool delete](bc_tool_delete.md)	 - Remove a tool from the workspace
+* [bc tool edit](bc_tool_edit.md)	 - Edit a tool's configuration
+* [bc tool list](bc_tool_list.md)	 - List all configured tools and their status
+* [bc tool run](bc_tool_run.md)	 - Run a tool directly
+* [bc tool setup](bc_tool_setup.md)	 - Install and configure a tool
+* [bc tool show](bc_tool_show.md)	 - Show detailed information about a tool
+* [bc tool status](bc_tool_status.md)	 - Check installation status of a tool
+* [bc tool upgrade](bc_tool_upgrade.md)	 - Upgrade an installed tool
+

--- a/docs/reference/cli/bc_tool_add.md
+++ b/docs/reference/cli/bc_tool_add.md
@@ -1,0 +1,37 @@
+## bc tool add
+
+Add a tool to the workspace
+
+### Synopsis
+
+Add a custom tool provider to the workspace.
+
+Examples:
+  bc tool add mytool --command "mytool --yes" --install "pip install mytool"
+  bc tool add mytool --command "mytool" --slash-cmds "/help,/quit"
+
+```
+bc tool add <name> [flags]
+```
+
+### Options
+
+```
+      --command string      Command to run the tool (required)
+  -h, --help                help for add
+      --install string      Command to install the tool
+      --json                Output as JSON
+      --slash-cmds string   Comma-separated list of slash commands (e.g. /help,/quit)
+      --upgrade string      Command to upgrade the tool
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_tool_delete.md
+++ b/docs/reference/cli/bc_tool_delete.md
@@ -1,0 +1,25 @@
+## bc tool delete
+
+Remove a tool from the workspace
+
+```
+bc tool delete <tool> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for delete
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_tool_edit.md
+++ b/docs/reference/cli/bc_tool_edit.md
@@ -1,0 +1,30 @@
+## bc tool edit
+
+Edit a tool's configuration
+
+```
+bc tool edit <tool> [flags]
+```
+
+### Options
+
+```
+      --command string      New run command
+      --enabled string      Enable or disable (true/false)
+  -h, --help                help for edit
+      --install string      New install command
+      --slash-cmds string   New slash commands (comma-separated)
+      --upgrade string      New upgrade command
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_tool_list.md
+++ b/docs/reference/cli/bc_tool_list.md
@@ -1,0 +1,33 @@
+## bc tool list
+
+List all configured tools and their status
+
+### Synopsis
+
+Show all registered AI tool providers with installation status, version, and command.
+
+Examples:
+  bc tool list        # Table output
+  bc tool list --json # JSON output for scripting
+
+```
+bc tool list [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+      --json   Output as JSON
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_tool_run.md
+++ b/docs/reference/cli/bc_tool_run.md
@@ -1,0 +1,25 @@
+## bc tool run
+
+Run a tool directly
+
+```
+bc tool run <tool> [args...] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for run
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_tool_setup.md
+++ b/docs/reference/cli/bc_tool_setup.md
@@ -1,0 +1,34 @@
+## bc tool setup
+
+Install and configure a tool
+
+### Synopsis
+
+Run the tool's install command to set it up.
+
+Steps:
+  1. Check if the tool binary is already installed
+  2. Run the install command if missing
+  3. Verify installation succeeded
+
+```
+bc tool setup <tool> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for setup
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_tool_show.md
+++ b/docs/reference/cli/bc_tool_show.md
@@ -1,0 +1,25 @@
+## bc tool show
+
+Show detailed information about a tool
+
+```
+bc tool show <tool> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_tool_status.md
+++ b/docs/reference/cli/bc_tool_status.md
@@ -1,0 +1,25 @@
+## bc tool status
+
+Check installation status of a tool
+
+```
+bc tool status <tool> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_tool_upgrade.md
+++ b/docs/reference/cli/bc_tool_upgrade.md
@@ -1,0 +1,25 @@
+## bc tool upgrade
+
+Upgrade an installed tool
+
+```
+bc tool upgrade <tool> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for upgrade
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc tool](bc_tool.md)	 - Manage AI tool providers
+

--- a/docs/reference/cli/bc_up.md
+++ b/docs/reference/cli/bc_up.md
@@ -1,0 +1,38 @@
+## bc up
+
+Start bc agents
+
+### Synopsis
+
+Start the bc agent system via the bcd daemon.
+
+Starts the root agent through the running bcd daemon.
+
+Examples:
+  bc up                      # Start root agent
+  bc up --agent cursor       # Use Cursor AI for agents
+  bc up --runtime docker     # Use Docker runtime
+
+```
+bc up [flags]
+```
+
+### Options
+
+```
+      --agent string     Agent type from config (e.g. claude, cursor, cursor-agent, codex)
+  -h, --help             help for up
+      --runtime string   Runtime backend override: tmux or docker
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+

--- a/docs/reference/cli/bc_version.md
+++ b/docs/reference/cli/bc_version.md
@@ -1,0 +1,34 @@
+## bc version
+
+Print version information
+
+### Synopsis
+
+Print version, commit hash, and build date.
+
+Examples:
+  bc version       # Show version info
+  bc --version     # Same as above (short flag)
+  bc -V            # Same as above
+
+```
+bc version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+

--- a/docs/reference/cli/bc_workspace.md
+++ b/docs/reference/cli/bc_workspace.md
@@ -1,0 +1,46 @@
+## bc workspace
+
+Manage bc workspaces
+
+### Synopsis
+
+Manage bc workspaces: info, config, logs, list, migrate.
+
+Examples:
+  bc workspace info                   # Show workspace details
+  bc workspace status                 # Show agents and health
+  bc workspace config show            # Show workspace config
+  bc workspace config set KEY VAL     # Set config value
+  bc workspace migrate                # Migrate v1 workspace to v2
+  bc workspace list                   # List discovered workspaces
+  bc workspace list --scan ~/Projects # Scan additional paths
+  bc workspace discover               # Discover and register new workspaces
+
+### Options
+
+```
+  -h, --help   help for workspace
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc](bc.md)	 - A simpler, more controllable agent orchestrator
+* [bc workspace add](bc_workspace_add.md)	 - Add a workspace to the registry
+* [bc workspace config](bc_workspace_config.md)	 - Manage workspace configuration
+* [bc workspace discover](bc_workspace_discover.md)	 - Discover and register workspaces
+* [bc workspace info](bc_workspace_info.md)	 - Show workspace information
+* [bc workspace list](bc_workspace_list.md)	 - List discovered workspaces
+* [bc workspace migrate](bc_workspace_migrate.md)	 - Migrate a v1 workspace to v2
+* [bc workspace remove](bc_workspace_remove.md)	 - Remove a workspace from the registry
+* [bc workspace stats](bc_workspace_stats.md)	 - Show workspace statistics
+* [bc workspace status](bc_workspace_status.md)	 - Show workspace status and agent health
+* [bc workspace switch](bc_workspace_switch.md)	 - Switch active workspace
+* [bc workspace up](bc_workspace_up.md)	 - Start all roster agents
+

--- a/docs/reference/cli/bc_workspace_add.md
+++ b/docs/reference/cli/bc_workspace_add.md
@@ -1,0 +1,36 @@
+## bc workspace add
+
+Add a workspace to the registry
+
+### Synopsis
+
+Register a workspace in the global registry for quick access.
+
+Examples:
+  bc workspace add .                        # Add current directory
+  bc workspace add ~/projects/frontend      # Add by path
+  bc workspace add . --alias fe             # Add with short alias
+  bc workspace add ~/api --alias backend    # Add with alias
+
+```
+bc workspace add <path> [flags]
+```
+
+### Options
+
+```
+      --alias string   Short alias for quick access
+  -h, --help           help for add
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_config.md
+++ b/docs/reference/cli/bc_workspace_config.md
@@ -1,0 +1,41 @@
+## bc workspace config
+
+Manage workspace configuration
+
+### Synopsis
+
+Manage workspace configuration (.bc/settings.toml).
+
+Examples:
+  bc workspace config show                    # Show full config
+  bc workspace config get providers.default   # Get a value
+  bc workspace config set providers.default claude # Set a value
+  bc workspace config validate                # Validate config
+  bc workspace config edit                    # Open in $EDITOR
+
+```
+bc workspace config [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for config
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+* [bc workspace config edit](bc_workspace_config_edit.md)	 - Edit configuration file in $EDITOR
+* [bc workspace config get](bc_workspace_config_get.md)	 - Get a configuration value
+* [bc workspace config set](bc_workspace_config_set.md)	 - Set a configuration value
+* [bc workspace config show](bc_workspace_config_show.md)	 - Show configuration
+* [bc workspace config validate](bc_workspace_config_validate.md)	 - Validate configuration file
+

--- a/docs/reference/cli/bc_workspace_config_edit.md
+++ b/docs/reference/cli/bc_workspace_config_edit.md
@@ -1,0 +1,25 @@
+## bc workspace config edit
+
+Edit configuration file in $EDITOR
+
+```
+bc workspace config edit [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for edit
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace config](bc_workspace_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_workspace_config_get.md
+++ b/docs/reference/cli/bc_workspace_config_get.md
@@ -1,0 +1,25 @@
+## bc workspace config get
+
+Get a configuration value
+
+```
+bc workspace config get <key> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for get
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace config](bc_workspace_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_workspace_config_set.md
+++ b/docs/reference/cli/bc_workspace_config_set.md
@@ -1,0 +1,25 @@
+## bc workspace config set
+
+Set a configuration value
+
+```
+bc workspace config set <key> <value> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for set
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace config](bc_workspace_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_workspace_config_show.md
+++ b/docs/reference/cli/bc_workspace_config_show.md
@@ -1,0 +1,25 @@
+## bc workspace config show
+
+Show configuration
+
+```
+bc workspace config show [key] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace config](bc_workspace_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_workspace_config_validate.md
+++ b/docs/reference/cli/bc_workspace_config_validate.md
@@ -1,0 +1,25 @@
+## bc workspace config validate
+
+Validate configuration file
+
+```
+bc workspace config validate [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for validate
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace config](bc_workspace_config.md)	 - Manage workspace configuration
+

--- a/docs/reference/cli/bc_workspace_discover.md
+++ b/docs/reference/cli/bc_workspace_discover.md
@@ -1,0 +1,37 @@
+## bc workspace discover
+
+Discover and register workspaces
+
+### Synopsis
+
+Scan filesystem for bc workspaces and add them to the registry.
+
+This updates ~/.bc/workspaces.json with newly found workspaces.
+
+Examples:
+  bc workspace discover                # Scan default locations
+  bc workspace discover --scan ~/work  # Include additional path
+
+```
+bc workspace discover [flags]
+```
+
+### Options
+
+```
+      --depth int      Maximum scan depth (default 3)
+  -h, --help           help for discover
+      --scan strings   Additional paths to scan
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_info.md
+++ b/docs/reference/cli/bc_workspace_info.md
@@ -1,0 +1,36 @@
+## bc workspace info
+
+Show workspace information
+
+### Synopsis
+
+Display detailed information about the current workspace.
+
+Shows workspace name, path, version, runtime backend, role count,
+and agent summary.
+
+Examples:
+  bc workspace info         # Human-readable output
+  bc workspace info --json  # JSON output
+
+```
+bc workspace info [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for info
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_list.md
+++ b/docs/reference/cli/bc_workspace_list.md
@@ -1,0 +1,43 @@
+## bc workspace list
+
+List discovered workspaces
+
+### Synopsis
+
+List all bc workspaces on this machine.
+
+Searches:
+  - Global registry (~/.bc/workspaces.json)
+  - Common directories (~/Projects, ~/Developer, ~/dev, ~/code, ~/repos, ~/src)
+  - Additional paths specified with --scan
+
+Examples:
+  bc workspace list                    # List all workspaces
+  bc workspace list --json             # Output as JSON
+  bc workspace list --scan ~/work      # Include additional path
+  bc workspace list --no-cache         # Skip registry, scan only
+
+```
+bc workspace list [flags]
+```
+
+### Options
+
+```
+      --depth int      Maximum scan depth (default 3)
+  -h, --help           help for list
+      --no-cache       Skip registry, scan filesystem only
+      --scan strings   Additional paths to scan
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_migrate.md
+++ b/docs/reference/cli/bc_workspace_migrate.md
@@ -1,0 +1,44 @@
+## bc workspace migrate
+
+Migrate a v1 workspace to v2
+
+### Synopsis
+
+Migrate a bc v1 workspace (.bc/config.json) to v2 (.bc/settings.toml).
+
+bc v2 uses a TOML-based config format. The migration:
+  - Reads .bc/config.json (v1 format)
+  - Writes .bc/config.json.bak (backup of original)
+  - Writes .bc/settings.toml  (v2 format, best-effort field mapping)
+
+Agent state (JSON files) are migrated automatically the next time they
+are opened — no manual step needed.
+
+Examples:
+  bc workspace migrate          # Check and prompt for migration
+  bc workspace migrate ~/myapp  # Check a specific path
+  bc workspace migrate --yes    # Migrate without prompting
+
+```
+bc workspace migrate [directory] [flags]
+```
+
+### Options
+
+```
+      --dry-run   Show what would be migrated without making changes
+  -h, --help      help for migrate
+      --yes       Perform migration without prompting
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_remove.md
+++ b/docs/reference/cli/bc_workspace_remove.md
@@ -1,0 +1,35 @@
+## bc workspace remove
+
+Remove a workspace from the registry
+
+### Synopsis
+
+Unregister a workspace from the global registry.
+
+This does not delete the workspace, just removes it from the registry.
+
+Examples:
+  bc workspace remove fe                    # Remove by alias
+  bc workspace remove ~/projects/frontend   # Remove by path
+
+```
+bc workspace remove <alias|path> [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for remove
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_stats.md
+++ b/docs/reference/cli/bc_workspace_stats.md
@@ -1,0 +1,36 @@
+## bc workspace stats
+
+Show workspace statistics
+
+### Synopsis
+
+Display statistics about the current workspace including work item
+metrics, agent utilization, and completion rates.
+
+Examples:
+  bc workspace stats             # human-readable summary
+  bc workspace stats --json      # JSON output for scripting
+  bc workspace stats --save      # save stats snapshot to .bc/stats.json
+
+```
+bc workspace stats [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for stats
+      --json   Output as JSON
+      --save   Save stats snapshot to disk
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_status.md
+++ b/docs/reference/cli/bc_workspace_status.md
@@ -1,0 +1,34 @@
+## bc workspace status
+
+Show workspace status and agent health
+
+### Synopsis
+
+Show a health overview of the workspace: running agents, idle agents,
+config validity, and uptime.
+
+Examples:
+  bc workspace status         # Status overview
+  bc workspace status --json  # JSON output
+
+```
+bc workspace status [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_switch.md
+++ b/docs/reference/cli/bc_workspace_switch.md
@@ -1,0 +1,35 @@
+## bc workspace switch
+
+Switch active workspace
+
+### Synopsis
+
+Set the active workspace for cross-workspace operations.
+
+Examples:
+  bc workspace switch fe                    # Switch by alias
+  bc workspace switch ~/projects/frontend   # Switch by path
+  bc workspace switch --clear               # Clear active workspace
+
+```
+bc workspace switch <alias|path> [flags]
+```
+
+### Options
+
+```
+      --clear   Clear active workspace
+  -h, --help    help for switch
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/docs/reference/cli/bc_workspace_up.md
+++ b/docs/reference/cli/bc_workspace_up.md
@@ -1,0 +1,36 @@
+## bc workspace up
+
+Start all roster agents
+
+### Synopsis
+
+Start all agents defined in [roster] of .bc/settings.toml.
+
+Agents that are already running are skipped. Missing role files are
+created from built-in defaults automatically.
+
+Examples:
+  bc workspace up          # Start roster agents
+  bc ws up                 # Short alias
+
+```
+bc workspace up [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for up
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [bc workspace](bc_workspace.md)	 - Manage bc workspaces
+

--- a/go.mod
+++ b/go.mod
@@ -16,12 +16,15 @@ require (
 )
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,7 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/charmbracelet/x/term v0.2.2 h1:xVRT/S2ZcKdhhOuSP4t5cLi5o+JxklsoEObBSgfgZRk=
 github.com/charmbracelet/x/term v0.2.2/go.mod h1:kF8CY5RddLWrsgVwpw4kAa6TESp6EB5y3uxGLeCqzAI=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -27,6 +28,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
@@ -38,6 +40,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
 golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,21 @@ nav:
     - Networking: frontend/networking.md
   - Guides:
     - Channels: guides/channels.md
+  - CLI Reference:
+    - Overview: reference/cli/bc.md
+    - bc agent: reference/cli/bc_agent.md
+    - bc channel: reference/cli/bc_channel.md
+    - bc config: reference/cli/bc_config.md
+    - bc cost: reference/cli/bc_cost.md
+    - bc cron: reference/cli/bc_cron.md
+    - bc daemon: reference/cli/bc_daemon.md
+    - bc doctor: reference/cli/bc_doctor.md
+    - bc env: reference/cli/bc_env.md
+    - bc mcp: reference/cli/bc_mcp.md
+    - bc role: reference/cli/bc_role.md
+    - bc secret: reference/cli/bc_secret.md
+    - bc tool: reference/cli/bc_tool.md
+    - bc workspace: reference/cli/bc_workspace.md
   - Infrastructure:
     - CI/CD: infrastructure/ci-cd.md
     - Deployment: infrastructure/deployment.md


### PR DESCRIPTION
## Summary
- Add `cmd/gendocs` tool that uses `cobra/doc.GenMarkdownTree` to auto-generate markdown reference docs for all CLI commands
- Add `make gen-docs` Makefile target to regenerate docs
- Wire up CLI Reference section in `mkdocs.yml` navigation with all top-level command groups
- Generated 130+ reference pages covering every bc subcommand

Closes #2555

## Test plan
- [x] `go build ./cmd/gendocs/` compiles cleanly
- [x] `make gen-docs` generates docs to `docs/reference/cli/`
- [x] `go build ./cmd/bc/` still compiles (no regressions)
- [ ] `mkdocs serve` renders CLI Reference section correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Generated comprehensive CLI reference documentation for all `bc` commands and subcommands, including agent management, channels, configuration, costs, scheduling, daemons, tools, and workspace operations.

* **Chores**
  * Added documentation generation tooling and updated build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->