### PR TITLE
docs: add security guide, ADRs, and testing guide

### DIFF
--- a/docs/architecture/design-decisions.md
+++ b/docs/architecture/design-decisions.md
@@ -1,0 +1,204 @@
+# Architecture Decision Records
+
+This document records the key architectural decisions in bc, their context,
+and the reasoning behind each choice.
+
+---
+
+## ADR-1: SQLite as the Default Database
+
+**Status:** Accepted
+
+**Context:** bc needs persistent storage for channels, costs, events, secrets,
+cron jobs, MCP servers, and tools. The storage must work out of the box for
+every developer without any setup steps.
+
+**Decision:** Use SQLite for all persistent storage, with separate `.db` files
+per concern (e.g., `channels.db`, `costs.db`, `secrets.db`) stored in the
+`.bc/` workspace directory.
+
+**Rationale:**
+
+- **Zero configuration**: no database server to install, configure, or manage.
+- **Embedded**: the database is a single file linked into the Go binary.
+- **Portable with workspace**: `.bc/` travels with the project (or is
+  `.gitignore`-d for sensitive data). Copying a workspace copies all state.
+- **Concurrent-safe**: SQLite WAL mode handles the concurrency level bc needs
+  (one daemon, a few CLI readers).
+- **Tables use `IF NOT EXISTS`**: schema is applied idempotently at startup,
+  so there is no migration tooling to maintain.
+
+**Tradeoffs:**
+
+- Not suitable for multi-node deployments (not a current requirement).
+- Write concurrency is limited to one writer at a time (acceptable for a
+  local tool).
+
+---
+
+## ADR-2: Tmux + Docker Dual Runtime
+
+**Status:** Accepted
+
+**Context:** Agents need an interactive session environment for running AI
+tools (Claude Code, Gemini, etc.) that expect a terminal. The system must
+work for local development and for isolated, reproducible builds.
+
+**Decision:** Support two runtime backends — tmux (local) and Docker
+(isolated) — selectable via `[runtime] backend` in `config.toml`.
+
+**Rationale:**
+
+- **Tmux for local development**: zero overhead, instant startup, direct
+  filesystem access. Developers already have tmux installed. Each agent gets
+  its own tmux session with a per-agent git worktree.
+- **Docker for isolation**: each agent runs in its own container with
+  resource limits (CPU, memory), controlled volume mounts, and optional
+  network restrictions. Provides reproducible environments across machines.
+- **Unified interface**: both backends implement the `runtime.Backend`
+  interface (`HasSession`, `CreateSession`, `SendKeys`, `Capture`,
+  `KillSession`, etc.), so the agent manager code is backend-agnostic.
+- **Docker uses tmux internally**: even Docker containers run tmux inside for
+  session management. Communication uses `docker exec ... tmux send-keys`,
+  requiring no persistent connections or FIFOs.
+
+**Tradeoffs:**
+
+- Docker backend requires Docker daemon and pre-built agent images.
+- Docker agents start without auth and need manual `bc agent attach` for
+  initial login.
+
+---
+
+## ADR-3: SSE (Server-Sent Events) for Real-Time Updates
+
+**Status:** Accepted
+
+**Context:** The web dashboard and TUI need real-time updates when agent
+state changes, channel messages arrive, or costs are recorded.
+
+**Decision:** Use Server-Sent Events (SSE) at `/api/events` instead of
+WebSockets.
+
+**Rationale:**
+
+- **Simpler protocol**: SSE is plain HTTP — one long-lived GET request with
+  `text/event-stream` content type. No upgrade handshake, no frame parsing.
+- **Auto-reconnect**: browsers and SSE client libraries handle reconnection
+  automatically with `EventSource`. No custom reconnection logic needed.
+- **Works through proxies**: SSE uses standard HTTP, so it works through
+  reverse proxies, load balancers, and firewalls without special
+  configuration (unlike WebSocket upgrade requests).
+- **Unidirectional is sufficient**: the server pushes state updates to
+  clients. Client-to-server communication uses REST API calls, which is the
+  natural fit for command/query separation.
+- **Implementation**: the `ws.Hub` struct manages SSE subscribers and
+  broadcasts JSON events. The `WriteTimeout` on the HTTP server is set to 0
+  to allow long-lived SSE connections, with per-handler timeouts used
+  elsewhere.
+
+**Tradeoffs:**
+
+- Unidirectional only (server→client). Not suitable if bidirectional
+  streaming were needed.
+- Maximum ~6 concurrent SSE connections per browser per domain (browser
+  limit, not relevant for localhost single-user use).
+
+---
+
+## ADR-4: Embedded Web UI in the Server Binary
+
+**Status:** Accepted
+
+**Context:** bc ships a web dashboard for workspace management. It needs to
+be easy to deploy and use without a separate frontend server.
+
+**Decision:** Embed the compiled web UI (from `web/dist/`) into the bcd
+binary using Go's `embed.FS`, served as static files with SPA fallback.
+
+**Rationale:**
+
+- **Single binary deployment**: `bcd` is one binary that contains the API
+  server, SSE hub, MCP server, and the complete web UI. No separate `npm
+  start` or nginx configuration.
+- **SPA routing**: the server tries to serve the exact file path first; if
+  the file does not exist, it falls back to `index.html` for client-side
+  routing.
+- **Development mode**: during development, `make run-web-local` runs a Vite
+  dev server with hot reload, proxying API calls to bcd.
+- **Build pipeline**: `make build-bcd-local` runs `make build-web-local`
+  first to produce `web/dist/`, then embeds it into the Go binary.
+
+**Tradeoffs:**
+
+- Web UI changes require rebuilding the Go binary (mitigated by the dev
+  server workflow).
+- Binary size increases by the size of the compiled frontend assets.
+
+---
+
+## ADR-5: File-Based Hooks for Agent State Detection
+
+**Status:** Accepted
+
+**Context:** bcd needs to know when agents transition between states
+(working, idle, stopped). Agents run inside tmux sessions or Docker
+containers, potentially without network access to bcd.
+
+**Decision:** Use file-based hooks where Claude Code lifecycle events
+(`PreToolUse`, `PostToolUse`, `Stop`) write the event name to a well-known
+file path: `.bc/agents/<NAME>/hook_event`.
+
+**Rationale:**
+
+- **Works in Docker**: containers mount the workspace directory, so
+  file writes are visible to the host without network configuration.
+- **Survives restarts**: files on disk persist across bcd restarts. If bcd
+  is down when an event fires, the file is still there when bcd comes back.
+- **Stateless consumption**: bcd's `StatsCollector` reads and deletes the
+  hook event file on each poll cycle via `ConsumeHookEvent()`. No connection
+  state to manage.
+- **Claude Code integration**: hooks are configured in
+  `.claude/settings.json` using Claude Code's native hook system. The
+  `WriteWorkspaceHookSettings()` function generates the settings
+  idempotently, merging with any existing user hooks.
+- **Simple command**: each hook runs a single `printf` command to write the
+  event name to the file. No dependencies, no network calls.
+
+**Tradeoffs:**
+
+- Polling-based (not instant) — there is a short delay between the event
+  and detection. Acceptable for status display purposes.
+- Only works with Claude Code's hook system. Other AI tools need different
+  state detection mechanisms.
+
+---
+
+## ADR-6: BFS Role Inheritance
+
+**Status:** Accepted
+
+**Context:** Roles can inherit from parent roles to share capabilities,
+prompts, MCP servers, and secrets. The inheritance model must be simple and
+predictable.
+
+**Decision:** Use breadth-first search (BFS) for role inheritance resolution
+via the `parent_roles` field in role YAML frontmatter.
+
+**Rationale:**
+
+- **Simple**: BFS is easy to understand and implement. Walk the parent chain
+  level by level.
+- **Predictable**: the resolution order is deterministic — closer parents
+  take priority over distant ancestors.
+- **No diamond problem**: BFS with visited-set tracking naturally handles
+  cases where two parents share a common ancestor. Each role is visited only
+  once, and the first encounter wins.
+- **Flat hierarchy in practice**: most workspaces use 2-3 levels at most
+  (e.g., `engineer` inherits from `base`, `lead` inherits from `engineer`).
+
+**Tradeoffs:**
+
+- No support for method-resolution-order (MRO) style linearization like
+  Python's C3. Not needed given the simple role hierarchies in practice.
+- No override/conflict detection — last-writer-wins for merged fields.

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -1,0 +1,262 @@
+# Testing Guide
+
+This guide covers how to run tests, write new tests, and maintain coverage
+in the bc codebase.
+
+## Running Tests
+
+### Quick Reference
+
+| Command                | What it runs                                     |
+|------------------------|--------------------------------------------------|
+| `make test`            | All tests (Go + TypeScript)                      |
+| `make test-go`         | Go tests with race detector                      |
+| `make test-go-fast`    | Go tests excluding slow/E2E packages             |
+| `make test-ts`         | All TypeScript tests (TUI + web + landing)       |
+| `make test-tui`        | TUI tests (bun test)                             |
+| `make test-web`        | Web dashboard tests (vitest)                     |
+| `make test-web-e2e`    | Web E2E tests (Playwright, requires running bcd) |
+| `make test-landing`    | Landing page tests (Playwright)                  |
+| `make coverage-go`     | Go coverage report with threshold check          |
+| `make bench-go`        | Go benchmarks                                    |
+| `make ci-local`        | Full CI pipeline locally                         |
+
+### Running a Specific Go Test
+
+```bash
+go test -race -run TestAgentStart ./pkg/agent/
+```
+
+The `-race` flag enables the race detector and should always be used during
+development.
+
+### Running a Specific TUI Test
+
+```bash
+cd tui && bun test src/hooks/__tests__/useStatus.test.tsx
+```
+
+### Running a Specific Web Test
+
+```bash
+cd web && bun run test -- --reporter=verbose src/components/CronTable.test.tsx
+```
+
+### Full CI Pipeline Locally
+
+```bash
+make ci-local
+```
+
+This runs the complete quality gate: formatting, vetting, linting, and
+testing across both Go and TypeScript. It matches what CI runs on pull
+requests.
+
+## Coverage
+
+### Go Coverage
+
+```bash
+make coverage-go
+```
+
+This generates a `coverage.out` file and checks that total coverage meets
+the **75% threshold** (configured via `COVERAGE_THRESHOLD` in the Makefile).
+The build fails if coverage drops below this threshold.
+
+To view a detailed HTML coverage report:
+
+```bash
+go test -race -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out -o coverage.html
+open coverage.html
+```
+
+### TypeScript Coverage
+
+```bash
+make coverage-ts
+```
+
+TUI coverage is provided by bun's built-in coverage. Web coverage requires
+`@vitest/coverage-v8`.
+
+## Where Tests Live
+
+### Go Tests
+
+Go tests live alongside the code they test, following Go convention:
+
+| Location                         | What it tests                          |
+|----------------------------------|----------------------------------------|
+| `pkg/agent/*_test.go`            | Agent lifecycle, hooks, state machine  |
+| `pkg/workspace/*_test.go`        | Workspace loading, config parsing      |
+| `pkg/channel/*_test.go`          | Channel CRUD, message delivery         |
+| `pkg/secret/*_test.go`           | Encryption, secret store operations    |
+| `pkg/cost/*_test.go`             | Cost tracking, import                  |
+| `pkg/container/*_test.go`        | Docker backend, mount validation       |
+| `pkg/tmux/*_test.go`             | Tmux backend                           |
+| `internal/cmd/*_test.go`         | CLI command integration tests          |
+| `server/handlers/*_test.go`      | HTTP handler unit tests                |
+| `server/mcp/*_test.go`           | MCP protocol tests                     |
+| `server/e2e_test.go`             | Server end-to-end tests                |
+| `server/e2e_web_test.go`         | Web UI SSE/API e2e tests               |
+
+### TypeScript Tests
+
+| Location                         | What it tests                          |
+|----------------------------------|----------------------------------------|
+| `tui/src/**/__tests__/*.test.tsx`| TUI component helpers and types        |
+| `web/src/**/*.test.ts(x)`        | Web dashboard components (vitest)      |
+| `web/e2e/`                       | Web E2E tests (Playwright)             |
+| `landing/e2e/`                   | Landing page E2E tests (Playwright)    |
+
+## Writing Go Tests
+
+### Table-Driven Tests
+
+Use table-driven tests as the default pattern:
+
+```go
+func TestValidateMount(t *testing.T) {
+    tests := []struct {
+        name      string
+        mount     string
+        root      string
+        wantErr   bool
+    }{
+        {
+            name:  "valid mount within workspace",
+            mount: "/workspace/data:/data",
+            root:  "/workspace",
+        },
+        {
+            name:    "path traversal rejected",
+            mount:   "/workspace/../etc/passwd:/etc/passwd",
+            root:    "/workspace",
+            wantErr: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            err := validateMount(tt.mount, tt.root)
+            if (err != nil) != tt.wantErr {
+                t.Errorf("validateMount() error = %v, wantErr %v", err, tt.wantErr)
+            }
+        })
+    }
+}
+```
+
+### TestMain Setup
+
+Some packages require global state initialization. `internal/cmd/` and
+`pkg/agent/` use `TestMain()` to set up `RoleCapabilities` and
+`RoleHierarchy` maps:
+
+```go
+func TestMain(m *testing.M) {
+    setupRoles()
+    os.Exit(m.Run())
+}
+```
+
+### HTTP Handler Tests
+
+Use `httptest.NewServer` for end-to-end handler testing:
+
+```go
+func TestAgentHandler(t *testing.T) {
+    svc := setupTestServices(t)
+    handler := handlers.NewAgentHandler(svc.Agents, svc.Costs, svc.WS)
+
+    mux := http.NewServeMux()
+    handler.Register(mux)
+    srv := httptest.NewServer(mux)
+    defer srv.Close()
+
+    resp, err := http.Get(srv.URL + "/api/agents")
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode != http.StatusOK {
+        t.Errorf("got status %d, want 200", resp.StatusCode)
+    }
+}
+```
+
+### Integration Tests
+
+Integration tests that need a real workspace use helper functions:
+
+- `setupIntegrationWorkspace()` — creates a temp directory with `.bc/`
+  structure.
+- `seedAgents()` — populates the workspace with test agent state.
+
+### E2E Tests
+
+E2E tests that require live tmux sessions are in `pkg/agent/agent_e2e_test.go`
+and `pkg/channel/channel_e2e_test.go`. These are included in `make test-go`
+but excluded from `make test-go-fast` (which skips `internal/cmd`).
+
+## Writing Web Dashboard Tests
+
+### Vitest Unit Tests
+
+Web component tests use vitest with React Testing Library:
+
+```typescript
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { CronTable } from "./CronTable";
+
+describe("CronTable", () => {
+  it("renders empty state", () => {
+    render(<CronTable jobs={[]} />);
+    expect(screen.getByText("No cron jobs")).toBeInTheDocument();
+  });
+});
+```
+
+### Playwright E2E Tests
+
+Web E2E tests live in `web/e2e/` and require a running bcd server:
+
+```bash
+# Start bcd first
+make deploy-bcd-local
+
+# Run e2e tests
+make test-web-e2e
+```
+
+## Writing TUI Tests
+
+The TUI uses React/Ink, which cannot be tested with DOM-based tools. Test
+exported helper functions and type interfaces rather than hooks directly:
+
+```typescript
+import { describe, it, expect } from "bun:test";
+import { formatDuration } from "../utils";
+
+describe("formatDuration", () => {
+  it("formats seconds", () => {
+    expect(formatDuration(45)).toBe("45s");
+  });
+});
+```
+
+## Best Practices
+
+1. **Always use `-race`** when running Go tests locally.
+2. **Table-driven tests** for any function with more than two test cases.
+3. **No magic numbers in tests** — use named constants or descriptive
+   variables (the `mnd` linter is disabled for test files).
+4. **Clean up temp files** — use `t.TempDir()` which auto-cleans.
+5. **Context propagation** — pass `context.Background()` or
+   `context.TODO()` in tests, never `nil`.
+6. **Run `make check` before committing** — this catches lint errors,
+   formatting issues, and test failures in one command.

--- a/docs/infrastructure/security.md
+++ b/docs/infrastructure/security.md
@@ -1,0 +1,168 @@
+# Security
+
+This document describes the security model, threat boundaries, and hardening
+measures in bc and its daemon server (bcd).
+
+## Threat Model
+
+bc is a **local development tool**. The bcd server binds to `127.0.0.1:9374`
+by default and is only reachable from the local machine. There is no
+authentication layer — security relies on the localhost trust boundary.
+
+**In scope:**
+
+- Protecting secrets at rest (API keys, tokens stored via `bc secret set`).
+- Isolating Docker-based agents from each other and from the host filesystem.
+- Preventing information leakage through HTTP error responses.
+- Rate-limiting the API to mitigate local denial-of-service.
+
+**Out of scope (by design):**
+
+- Network authentication or TLS — bcd is not designed to be exposed to a
+  network. If you need remote access, put it behind an authenticating reverse
+  proxy.
+- Multi-tenant isolation — a single workspace is used by one developer (or
+  one CI job) at a time.
+
+## Secret Management
+
+Secrets are stored in an SQLite database at `.bc/secrets.db` and encrypted
+with **AES-256-GCM**. The encryption key is derived from a master passphrase
+using **PBKDF2-SHA256** with 600,000 iterations (per OWASP 2023 guidance) and
+a random 16-byte salt.
+
+### Passphrase Resolution
+
+The passphrase is resolved in priority order:
+
+1. **`BC_SECRET_PASSPHRASE` environment variable** — set this in CI or when
+   you want explicit control.
+2. **Auto-generated key file at `~/.bc/secret-key`** — created on first use
+   with 32 random bytes (hex-encoded), file permissions `0600`, directory
+   permissions `0700`.
+
+### Encryption Details
+
+| Parameter       | Value                        |
+|-----------------|------------------------------|
+| Algorithm       | AES-256-GCM                  |
+| Key derivation  | PBKDF2-SHA256, 600k rounds   |
+| Salt            | 16 bytes, random, per-store  |
+| Nonce           | 12 bytes, random, per-value  |
+| Storage format  | Base64(nonce ‖ ciphertext)   |
+
+Secrets are resolved at runtime via `${secret:NAME}` references in agent
+environment variables. The `ResolveEnv` method substitutes these references
+with decrypted values just before the agent process starts.
+
+## Docker Agent Isolation
+
+When the runtime is set to `docker`, each agent runs in its own container
+with the following isolation measures.
+
+### Volume Mounts
+
+Containers receive exactly two mounts by default:
+
+1. **Workspace directory** → `/workspace` (project source code).
+2. **Persistent Claude state** → `/home/agent/.claude` (auth, plugins,
+   sessions). Stored at `.bc/volumes/<agent>/.claude` on the host.
+
+### Mount Validation
+
+Extra mounts (configured via `[runtime.docker] extra_mounts`) are validated
+by `validateMount()` before being passed to `docker run`:
+
+- **Format check**: must be `src:dst` or `src:dst:opts`.
+- **Path traversal rejection**: source paths containing `..` are rejected.
+- **Absolute path requirement**: source must be an absolute path.
+- **Symlink resolution**: source is resolved via `filepath.EvalSymlinks` to
+  prevent symlink-based escapes (e.g., a symlink inside the workspace
+  pointing to `/etc`).
+- **Workspace containment**: the resolved source path must be within or equal
+  to the workspace root directory.
+
+### Network
+
+The default Docker network is `bridge`. Network configuration is set via
+`[runtime.docker] network` in `config.toml`. To fully isolate agents from
+the network, set `network = "none"`.
+
+### Resource Limits
+
+Containers are created with configurable CPU and memory limits (defaults:
+2 CPUs, 2048 MB). These prevent runaway agents from starving the host.
+
+### Environment Variable Validation
+
+Environment variable names passed to `docker run -e` are validated against
+the POSIX pattern `^[A-Za-z_][A-Za-z0-9_]*$` to prevent injection through
+crafted key names.
+
+## HTTP Security
+
+### Middleware Chain
+
+The bcd server applies middleware in this order (outermost runs first):
+
+```
+RateLimit → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → Router
+```
+
+### Rate Limiting
+
+A token-bucket rate limiter is applied globally:
+
+- **Rate**: 100 requests per second
+- **Burst**: 200 tokens
+
+Requests that exceed the limit receive `429 Too Many Requests`.
+
+### Request Body Limit
+
+All requests are limited to **1 MB** (`1 << 20` bytes) via the `MaxBodySize`
+middleware. Requests exceeding this limit are rejected before the handler
+runs.
+
+### Error Wrapping
+
+Internal errors are never leaked to clients. The `httpInternalError` helper
+logs the full error server-side and returns a generic JSON response:
+
+```json
+{"error": "internal server error"}
+```
+
+The `Recovery` middleware catches panics and returns the same generic error
+instead of crashing the server or exposing stack traces.
+
+### CORS
+
+CORS is enabled by default with origin `*` (safe because bcd only listens
+on localhost). The origin can be restricted via `Config.CORSOrigin`.
+
+### Request IDs
+
+Every request is assigned a unique ID (via `X-Request-ID` header). If the
+client provides one, it is reused; otherwise a random hex ID is generated.
+
+## MCP Security
+
+The MCP (Model Context Protocol) server is mounted at `/mcp/sse` and
+`/mcp/message` on the same bcd HTTP server. It inherits the same localhost
+trust model — no additional authentication is applied.
+
+MCP endpoints are protected by the same middleware chain (rate limiting,
+body size limit, recovery) as the REST API.
+
+## Recommendations for Production-Like Deployments
+
+If you need to expose bcd beyond localhost (e.g., for remote agent
+coordination):
+
+1. Place bcd behind an authenticating reverse proxy (nginx, Caddy, etc.).
+2. Use TLS termination at the proxy layer.
+3. Restrict CORS origin to your specific domain.
+4. Set `BC_SECRET_PASSPHRASE` explicitly rather than relying on the
+   auto-generated key file.
+5. Use `network = "none"` for Docker agents that do not need outbound access.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ nav:
   - Architecture:
     - Overview: overview.md
     - System Design: architecture/README.md
+    - Design Decisions: architecture/design-decisions.md
     - Agent Lifecycle: backend/agents.md
     - Database Schema: database/database.md
   - API Reference:
@@ -82,6 +83,9 @@ nav:
   - Infrastructure:
     - CI/CD: infrastructure/ci-cd.md
     - Deployment: infrastructure/deployment.md
+    - Security: infrastructure/security.md
+  - Contributing:
+    - Testing Guide: contributing/testing.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary
- **docs/infrastructure/security.md**: Covers threat model (localhost trust boundary), AES-256-GCM secret encryption with PBKDF2-SHA256 key derivation, Docker agent isolation (mount validation with symlink checks, env var sanitization, resource limits), HTTP middleware chain (rate limiting at 100 rps, 1MB body limit, error wrapping), and MCP security model.
- **docs/architecture/design-decisions.md**: Six ADRs — SQLite over Postgres (embedded, zero-config), tmux + Docker dual runtime (local dev vs isolation), SSE over WebSocket (simpler, auto-reconnect, proxy-friendly), embedded web UI (single binary), file-based hooks (works in Docker, survives restarts), BFS role inheritance (simple, no diamond problem).
- **docs/contributing/testing.md**: Complete testing reference — all make targets, how to run specific Go/TUI/web tests, coverage thresholds (75%), test file locations, patterns for table-driven tests, httptest handlers, integration helpers, and Playwright E2E.
- All three files added to mkdocs.yml nav.

Closes #2557

## Test plan
- [ ] Verify `mkdocs serve` renders all three new pages correctly
- [ ] Check all code references match actual codebase (encryption params, middleware order, make targets)
- [ ] Confirm nav links work in both Architecture and Infrastructure sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)