### PR TITLE
docs: fix accuracy issues in documentation

### DIFF
--- a/docs/backend/agent-lifecycle-redesign.md
+++ b/docs/backend/agent-lifecycle-redesign.md
@@ -1,3 +1,5 @@
+> **Status: Draft Proposal** — This document describes a proposed refactoring (#2165). It has not been fully implemented. See docs/backend/agents.md for current architecture.
+
 # Design: Agent Lifecycle Consolidation
 
 **Issue:** #2165

--- a/docs/database/database.md
+++ b/docs/database/database.md
@@ -244,4 +244,4 @@ OLD (per-project):                NEW (global):
   project/.bc/logs/        ->     ~/.bc/logs/
 ```
 
-`bc migrate` copies data from per-project `.bc/` to `~/.bc/`, converts role files to DB records.
+`bc workspace migrate` migrates workspace config format from v1 (`.bc/config.json`) to v2 (`.bc/settings.toml`). It does not migrate database schema or copy data between directories. Agent JSON state files auto-migrate on next load.

--- a/docs/frontend/web-ui.md
+++ b/docs/frontend/web-ui.md
@@ -120,6 +120,8 @@ graph TD
 
 ## 3. Shared Component Library Design
 
+> **Note:** The @bc/ui shared component library is a Phase 1 roadmap item. The current implementation uses local components in each package.
+
 ### 3.1 Problem Statement
 
 The web dashboard and TUI duplicate every UI primitive. Both have a `StatusBadge`, both have a `Table`, both have a `Panel` -- but with incompatible interfaces and no code sharing. When the Solar Flare design system rolls out, every component must be updated in two places. When a new component is needed, it is built twice.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -5,7 +5,7 @@
 bc is a CLI-first orchestration system for coordinating teams of AI coding agents. The system is split into two binaries: `bc` (thin CLI client) and `bcd` (long-running daemon). The daemon manages agents across multiple git repositories from a single global installation at `~/.bc/`.
 
 Key numbers:
-- **41 REST API endpoints** across 14 resource groups
+- **44 REST API endpoints** across 14 resource groups
 - **SQLite WAL** database with goose migrations
 - **16 web dashboard views** with Cmd+K command palette
 - **13 TUI views** with k9s-style keyboard navigation
@@ -14,23 +14,25 @@ Key numbers:
 
 ### Global Installation
 
-All bc state lives in `~/.bc/`:
+bc creates a per-project `.bc/` directory inside the workspace root:
 
 ```
-~/.bc/
-  bc.db                  # Primary SQLite database (WAL mode)
-  settings.toml          # Global config (providers, runtime, defaults)
-  secret-key             # Auto-generated AES-256 encryption key (0600)
-  agents/
-    <name>/
-      .claude/            # Claude config (mounted into containers)
-        CLAUDE.md         # Role prompt
-        settings.json     # Claude Code settings + hooks
-        .mcp.json         # MCP server configs
-      worktree/           # Git worktree checkout
+project/
+  .bc/
+    settings.toml          # Workspace config (providers, runtime, defaults)
+    agents/
+      <name>/
+        .claude/            # Claude config (mounted into containers)
+          CLAUDE.md         # Role prompt
+          settings.json     # Claude Code settings + hooks
+          .mcp.json         # MCP server configs
+        worktree/           # Git worktree checkout
+    roles/                 # Role definitions
+    channels/              # Channel data
+    prompts/               # Default prompt templates
 ```
 
-There is no per-project config. `bc init` initializes `~/.bc/` and starts bcd.
+`bc init` initializes the per-project `.bc/` directory and starts bcd.
 
 ## Architecture Layers
 
@@ -44,7 +46,7 @@ graph TB
     end
 
     subgraph "bcd Daemon :9374"
-        REST[REST API<br/>41 endpoints]
+        REST[REST API<br/>44 endpoints]
         SSE[SSE Hub<br/>real-time events]
         MCP[MCP Server<br/>JSON-RPC 2.0]
     end
@@ -97,7 +99,7 @@ Long-running HTTP server on `127.0.0.1:9374`. Single process managing all state.
 
 | Component | Path | Purpose |
 |-----------|------|---------|
-| REST API | `/api/*` | CRUD for all resources (41 endpoints) |
+| REST API | `/api/*` | CRUD for all resources (44 endpoints) |
 | SSE Hub | `/api/events` | Real-time event stream |
 | MCP Server | `/mcp/*` | AI agent integration (JSON-RPC 2.0 over SSE + stdio) |
 | Web UI | `/` | Embedded React dashboard (16 views) |
@@ -265,7 +267,7 @@ sequenceDiagram
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Global `~/.bc/` | Not per-project | One daemon manages agents across all repos |
+| Per-project `.bc/` | Per-project directory | Each workspace has its own `.bc/` directory for config, agents, and state |
 | bc/bcd split | Thin CLI + daemon | CLI stays fast; daemon holds state and connections |
 | SQLite WAL | Single database file | Zero-config, local-first, WAL for concurrent reads |
 | Embedded web UI | Single binary | No separate web server; version-locked to API |

--- a/docs/reviews/backend.md
+++ b/docs/reviews/backend.md
@@ -1,3 +1,7 @@
+*Last Updated: March 2026*
+
+> **Staleness Notice:** All issues referenced in this review (#2023, #2026, #2029, #2031, #2038, #2105, #2106, #2107, #2164, #2165, #2169) have been closed as of March 2026. The action plan items may no longer reflect current project state. Treat this document as a historical snapshot.
+
 # Backend Engineering Review
 
 **Date:** 2026-03-21 (updated)

--- a/docs/reviews/frontend.md
+++ b/docs/reviews/frontend.md
@@ -1,3 +1,7 @@
+*Last Updated: March 2026*
+
+> **Staleness Notice:** All issues referenced in this review (#2122, #2124, #2125, #2126, #2127, #2128, #2129, #2130, #2131, #2132, #2133, #2134, #2135, #2136, #2137, #2138, #2139, #2140, #2142, #2148, #2150, #2151, #2153, #2154, #2155, #2156, #2160, #2171, #2172, #2173, #2174) have been closed as of March 2026. The action plan items may no longer reflect current project state. Treat this document as a historical snapshot.
+
 # Frontend Engineering Review
 
 **Date:** 2026-03-20 (updated 2026-03-21)

--- a/docs/reviews/infrastructure.md
+++ b/docs/reviews/infrastructure.md
@@ -1,3 +1,7 @@
+*Last Updated: March 2026*
+
+> **Staleness Notice:** All issues referenced in this review (#2044, #2045, #2046, #2047, #2048, #2049, #2050, #2051, #2052, #2053, #2054, #2055, #2056, #2057, #2058, #2059, #2060, #2061, #2074, #2089, #2099, #2102, #2103, #2104) have been closed as of March 2026. The action plan items may no longer reflect current project state. Treat this document as a historical snapshot.
+
 # Infrastructure & Open-Source Readiness Review
 
 **Date:** 2026-03-21 (revised)


### PR DESCRIPTION
## Summary
- **overview.md**: Updated REST API endpoint count from 41 to 44 (verified via grep). Fixed incorrect claim of global `~/.bc/` — the codebase creates a per-project `.bc/` directory (see `pkg/workspace/workspace.go` Init()).
- **database.md**: Corrected `bc migrate` reference to `bc workspace migrate` — it migrates workspace config format (v1 JSON to v2 TOML), not database schema.
- **agent-lifecycle-redesign.md**: Added draft proposal banner noting this is an unimplemented proposal (#2165), pointing to `docs/backend/agents.md` for current architecture.
- **reviews/*.md**: Added "Last Updated: March 2026" header and staleness notice to all three review docs (backend, frontend, infrastructure). All referenced issues are now closed.
- **web-ui.md**: Added note to section 3 clarifying the @bc/ui shared component library is a Phase 1 roadmap item, not yet implemented.

Closes #2554

## Test plan
- [ ] Verify endpoint count: `grep -rn "HandleFunc\|mux.Handle" server/handlers/*.go server/server.go | wc -l` returns 44
- [ ] Verify `bc workspace migrate` exists: `grep -r "workspaceMigrateCmd" internal/cmd/workspace.go`
- [ ] Verify per-project `.bc/`: `grep "stateDir.*\.bc" pkg/workspace/workspace.go`
- [ ] Review each changed doc for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)