### PR TITLE
docs: audit and fix CLI command documentation against --help output

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -4,7 +4,7 @@ Get bc running in 5 minutes.
 
 ## Prerequisites
 
-- **Go 1.25.1+** for building from source
+- **Go 1.25.4+** for building from source
 - **tmux** for agent session management
 - **An AI agent tool** (Claude Code, Cursor, or similar)
 
@@ -121,9 +121,9 @@ bc channel history eng
 Agents report their status:
 
 ```bash
-bc agent reportworking "Implementing login API"
-bc agent reportdone "Feature complete"
-bc agent reportstuck "Need database access"
+bc agent report working "Implementing login API"
+bc agent report done "Feature complete"
+bc agent report stuck "Need database access"
 ```
 
 ### Cost Tracking

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -42,7 +42,7 @@ sudo dnf install tmux
 
 **Solution**:
 ```bash
-# Check Go version (need 1.22+)
+# Check Go version (need 1.25.4+)
 go version
 
 # Update dependencies
@@ -151,11 +151,11 @@ bc agent start agent-name
 **Solution**:
 ```bash
 # These commands only work inside agent sessions:
-bc agent reportworking "..."
+bc agent report working "..."
 bc channel join eng
 
 # Use agent send instead:
-bc agent send eng-01 "bc agent reportworking '...'"
+bc agent send eng-01 "bc agent report working '...'"
 ```
 
 ## Channel Issues
@@ -305,49 +305,14 @@ git merge --abort  # or resolve manually
 
 **Solution**:
 ```bash
-# Check if enabled in config
-bc config show | grep cost
+# Check cost data
+bc cost show
 
-# Manually add entry
-bc cost add --agent eng-01 --amount 0.05
+# View per-agent breakdown
+bc cost agent
 
 # Check database
 sqlite3 .bc/bc.db "SELECT * FROM costs LIMIT 5;"
-```
-
-## Memory Issues
-
-### Memory Not Persisting
-
-**Cause**: Memory backend misconfigured.
-
-**Solution**:
-```bash
-# Check memory config
-bc config show | grep memory
-
-# Verify memory directory
-ls -la .bc/memory/
-
-# Test recording
-bc memory record "Test entry"
-# memory system not yet implemented
-```
-
-### Search Not Finding Results
-
-**Cause**: FTS index not built or search syntax.
-
-**Solution**:
-```bash
-# Rebuild index
-# memory system not yet implemented
-
-# Use simple search terms
-bc memory search testing
-
-# Check memory contents
-# memory system not yet implemented
 ```
 
 ## Performance Issues
@@ -363,10 +328,6 @@ du -sh .bc/*.db
 
 # Vacuum database
 sqlite3 .bc/bc.db "VACUUM;"
-
-# Prune old data
-bc logs prune --older-than 7d
-bc memory prune --older-than 30d
 ```
 
 ### High CPU Usage
@@ -439,7 +400,7 @@ bc logs
 bc logs --agent eng-01
 
 # Filter by type
-bc logs --type error
+bc logs --type agent.report
 ```
 
 ### Debug Mode

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -57,7 +57,7 @@ Command Groups (with short aliases):
   cost (co)                    Cost tracking and budgets
   workspace (ws)               Workspace management
   doctor (dr)                  Health checks
-  demon (cr/cron)              Scheduled tasks
+  cron (cr)                    Scheduled tasks
 
 Key Features:
   • Coordinate multiple AI coding agents in parallel

--- a/landing/docs/cli-reference.md
+++ b/landing/docs/cli-reference.md
@@ -6,748 +6,530 @@ Complete command reference for the bc multi-agent orchestration system.
 
 1. [Workspace Commands](#workspace-commands)
 2. [Agent Management](#agent-management)
-3. [Work Queue](#work-queue)
-4. [Git & Merging](#git--merging)
-5. [Channels & Communication](#channels--communication)
-6. [Configuration](#configuration)
-7. [Monitoring & Logs](#monitoring--logs)
-8. [Admin Commands](#admin-commands)
+3. [Channels & Communication](#channels--communication)
+4. [Cost Tracking](#cost-tracking)
+5. [Configuration](#configuration)
+6. [Scheduled Tasks](#scheduled-tasks)
+7. [Daemon & Processes](#daemon--processes)
+8. [Secrets & Environment](#secrets--environment)
+9. [Tools & Roles](#tools--roles)
+10. [Monitoring & Diagnostics](#monitoring--diagnostics)
 
 ---
 
 ## Workspace Commands
 
-Commands for managing the bc workspace.
-
 ### bc init
-Initialize a new bc workspace in the current directory.
+Initialize a new bc v2 workspace.
 
 ```bash
-bc init
-```
-
-**Output:**
-```
-✓ Workspace initialized
-✓ Config created: .bc/config.toml
-✓ Queue initialized: .bc/queue.json
-✓ Events log created: .bc/events.jsonl
-```
-
-**Options:**
-```bash
-bc init --name "my-project"           # Set workspace name
-bc init --root /path/to/project       # Initialize in different directory
+bc init                        # Interactive wizard
+bc init --quick                # Quick init with defaults
+bc init --preset solo          # Use solo developer preset
+bc init --preset small-team    # Use small team preset
+bc init --preset full-team     # Use full team preset
+bc init ~/Projects/myapp       # Initialize specific directory
 ```
 
 **Creates:**
-- `.bc/` - State directory
-- `.bc/config.toml` - Configuration file
-- `.bc/queue.json` - Work queue
-- `.bc/events.jsonl` - Event log
+- `.bc/settings.toml` - Workspace configuration
+- `.bc/roles/` - Agent role definitions
+- `.bc/agents/` - Per-agent state files
 
 ---
 
 ### bc up
-Start the root coordinator agent and prepare workspace.
+Start the root agent via the bcd daemon.
 
 ```bash
-bc up
+bc up                      # Start root agent
+bc up --agent cursor       # Use Cursor AI for agents
+bc up --runtime docker     # Use Docker runtime
 ```
-
-**Output:**
-```
-✓ Root agent started
-✓ Workspace ready
-✓ Use 'bc home' to view dashboard
-✓ Use 'bc spawn' to create agents
-```
-
-**What it does:**
-- Starts root coordinator
-- Initializes tmux session
-- Validates workspace
-- Prepares for agent spawning
 
 ---
 
 ### bc down
-Stop all agents and shut down the workspace.
+Stop all running agents.
 
 ```bash
-bc down
-```
-
-**Output:**
-```
-✓ Stopping all agents...
-✓ Killed 5 agents
-✓ Saving workspace state
-✓ All sessions closed
-```
-
-**Options:**
-```bash
-bc down --force      # Force kill all sessions
-bc down --clean      # Remove temporary files
+bc down          # Stop all agents
+bc down --force  # Force kill without cleanup
 ```
 
 ---
 
 ### bc status
-Show current status of workspace and all agents.
+Show agent status overview.
 
 ```bash
-bc status
+bc status                   # Show all agents
+bc status --json            # Output as JSON
+bc status --activity        # Show recent channel activity
 ```
 
 **Output:**
 ```
-Workspace: my-project
-Status: running
-
-AGENTS (5)
-├── pm-01    ProductManager  idle       (1h 23m)
-├── mgr-01   Manager         working    (45m on work-0001)
-├── eng-01   Engineer        working    (2h 15m on work-0002)
-├── eng-02   Engineer        idle       (awaiting assignment)
-└── qa-01    QA              idle       (ready)
-
-WORK QUEUE
-├── work-0001  assigned  2h in      eng-01
-├── work-0002  working   1h in      (from work-0001)
-└── work-0003  pending   (unassigned)
-
-Recent: eng-01 "Implementing user auth"
+AGENT     ROLE      STATE    UPTIME    TASK
+eng-01    engineer  working  2h 15m    Implementing feature X
+eng-02    engineer  idle     1h 30m    -
 ```
 
-**Options:**
+---
+
+### bc home
+Open the TUI dashboard.
+
 ```bash
-bc status --json          # Output as JSON
-bc status --agent eng-01  # Status of single agent
-bc status --queue         # Show only work queue
+bc home
+```
+
+**Navigation:**
+- `[1-4]` Switch tabs (Dashboard, Agents, Channels, Costs)
+- `[j/k]` Navigate lists (down/up)
+- `[?]` Show help
+- `[q]` Quit
+
+---
+
+### bc workspace
+Manage workspaces.
+
+```bash
+bc workspace info                   # Show workspace details
+bc workspace status                 # Show agents and health
+bc workspace list                   # List discovered workspaces
+bc workspace list --scan ~/Projects # Scan additional paths
+bc workspace discover               # Discover and register new workspaces
+bc workspace migrate                # Migrate v1 workspace to v2
+bc ws up                            # Start all roster agents
 ```
 
 ---
 
 ## Agent Management
 
-Commands for spawning, managing, and controlling agents.
-
-### bc spawn
+### bc agent create
 Create and start a new agent.
 
 ```bash
-bc spawn eng-01 --role engineer
-```
-
-**Output:**
-```
-✓ Agent eng-01 spawned
-✓ Worktree created: .bc/worktrees/eng-01/
-✓ tmux session: bc-xxxx-eng-01
-✓ Ready to accept work
-```
-
-**Roles:**
-- `product-manager` - Create epics, spawn managers, assign work
-- `manager` - Spawn engineers/QA, assign work, review
-- `engineer` - Implement code
-- `qa` - Test and validate
-
-**Options:**
-```bash
-bc spawn eng-01 --role engineer        # Basic spawn
-bc spawn eng-01 --role engineer --parent mgr-01  # With parent
-bc spawn eng-01 --role engineer --tool claude-code # Specify AI tool
-```
-
-**Example - Spawn hierarchical team:**
-```bash
-bc spawn pm-01 --role product-manager
-
-bc spawn mgr-01 --role manager --parent pm-01
-bc spawn mgr-02 --role manager --parent pm-01
-
-bc spawn eng-01 --role engineer --parent mgr-01
-bc spawn eng-02 --role engineer --parent mgr-01
-bc spawn qa-01 --role qa --parent mgr-01
-
-bc spawn eng-03 --role engineer --parent mgr-02
-bc spawn qa-02 --role qa --parent mgr-02
-```
-
----
-
-### bc attach
-Connect to an agent's tmux session and monitor work.
-
-```bash
-bc attach eng-01
-```
-
-**Inside session:**
-- Type normally to send commands to agent
-- Press `Ctrl+B` then `D` to detach without stopping agent
-- Type `exit` to stop agent
-- Agent continues work in background if you detach
-
-**Options:**
-```bash
-bc attach eng-01 --read-only     # View-only mode
-bc attach eng-01 --follow        # Stream mode (watch output)
-```
-
----
-
-### bc stop
-Gracefully stop an agent.
-
-```bash
-bc stop eng-01
-```
-
-**Output:**
-```
-✓ Sent stop signal to eng-01
-✓ Agent gracefully shutting down
-✓ Work saved to .bc/
-```
-
----
-
-### bc kill
-Forcefully kill an agent session.
-
-```bash
-bc kill eng-01
-```
-
-**Output:**
-```
-✓ Killed tmux session for eng-01
-⚠ Work may be incomplete
-✓ State saved
-```
-
-**Difference:**
-- `bc stop` - Graceful shutdown
-- `bc kill` - Immediate termination (use if agent stuck)
-
----
-
-### bc list
-List all agents in workspace.
-
-```bash
-bc list
-```
-
-**Output:**
-```
-AGENTS
-┌─────────────────────────────────────────────────────────────┐
-│ ID      │ Role              │ Status     │ Uptime    │ Task  │
-├─────────────────────────────────────────────────────────────┤
-│ pm-01   │ ProductManager    │ idle       │ 2h 45m    │ -     │
-│ mgr-01  │ Manager           │ idle       │ 2h 40m    │ -     │
-│ eng-01  │ Engineer          │ working    │ 2h 30m    │ 0001  │
-│ eng-02  │ Engineer          │ idle       │ 1h 15m    │ -     │
-│ qa-01   │ QA                │ idle       │ 45m       │ -     │
-└─────────────────────────────────────────────────────────────┘
+bc agent create --role engineer              # Create with random name
+bc agent create worker-01                    # Create with explicit name
+bc agent create eng-01 --role engineer       # Create engineer
+bc agent create qa-01 --role qa --tool cursor # Create QA with Cursor
 ```
 
 **Options:**
+- `--role` - Agent role (required). Use `bc role list` to see available roles
+- `--tool` - AI tool (claude, gemini, cursor, codex, opencode, openclaw, aider)
+- `--runtime` - Runtime backend: tmux or docker
+- `--parent` - Parent agent ID
+- `--team` - Team name
+- `--env` - Path to env file
+
+---
+
+### bc agent list
+List all agents.
+
 ```bash
-bc list --json              # JSON output
-bc list --role engineer     # Filter by role
-bc list --status working    # Filter by status
+bc agent list                  # List all agents
+bc agent list --json           # Output as JSON
+bc agent list --role engineer  # Filter by role
+bc agent list --status running # Filter by status
 ```
 
 ---
 
-## Work Queue
-
-Commands for managing the work queue and task assignments.
-
-### bc queue add
-Add a new task to the work queue.
+### bc agent attach
+Attach to an agent's tmux session.
 
 ```bash
-bc queue add "Implement user authentication"
+bc agent attach eng-01   # Attach to eng-01
 ```
 
-**Output:**
-```
-✓ Task created: work-0001
-✓ Status: pending
-✓ Ready for assignment
-```
+Use `Ctrl+b d` to detach and return to your shell.
 
-**Options:**
+---
+
+### bc agent peek
+View recent output from an agent's session.
+
 ```bash
-bc queue add "Title" --priority high          # Set priority
-bc queue add "Title" --desc "Description"     # With description
-bc queue add "Title" --estimate 4h            # Time estimate
+bc agent peek eng-01              # Show last 500 lines
+bc agent peek eng-01 --lines 100  # Show last 100 lines
+bc agent peek eng-01 --follow     # Stream live output (Ctrl+C to stop)
 ```
 
 ---
 
-### bc queue list
-List all tasks in work queue.
+### bc agent send
+Send a message to an agent.
 
 ```bash
-bc queue list
-```
-
-**Output:**
-```
-WORK QUEUE
-┌────────────────────────────────────────────────────────────────┐
-│ ID    │ Status    │ Title                  │ Assigned │ Duration│
-├────────────────────────────────────────────────────────────────┤
-│ 0001  │ done      │ User authentication    │ eng-01   │ 2h 15m │
-│ 0002  │ working   │ Payment integration    │ eng-02   │ 1h 45m │
-│ 0003  │ assigned  │ Email notifications    │ eng-03   │ -      │
-│ 0004  │ pending   │ Documentation          │ -        │ -      │
-└────────────────────────────────────────────────────────────────┘
-```
-
-**Options:**
-```bash
-bc queue list --status working               # Filter by status
-bc queue list --assigned-to eng-01           # Agent's tasks
-bc queue list --json                         # JSON output
+bc agent send eng-01 "run the tests"
+bc agent send eng-01 "implement login" --preview  # Preview before sending
 ```
 
 ---
 
-### bc queue show
-Show detailed information about a specific task.
+### bc agent broadcast
+Send a message to all running agents.
 
 ```bash
-bc queue show work-0001
-```
-
-**Output:**
-```
-Task: work-0001
-Title: User authentication implementation
-Description: Implement JWT-based user auth with refresh tokens
-Status: done
-Assigned To: eng-01
-Created: 2026-02-09 10:00:00 UTC
-Started: 2026-02-09 10:15:00 UTC
-Completed: 2026-02-09 14:30:00 UTC
-Duration: 4h 15m
-Priority: high
-Branch: feature/user-auth
-Commits: 5
-Merge Status: merged
-Merge Conflicts: 0
+bc agent broadcast "run tests"
+bc agent broadcast "check status"
 ```
 
 ---
 
-### bc queue assign
-Assign a task to an agent.
+### bc agent send-to-role
+Send a message to all agents of a role.
 
 ```bash
-bc queue assign work-0001 eng-01
-```
-
-**Output:**
-```
-✓ Assigned work-0001 to eng-01
-✓ Status: assigned
-✓ Ready for eng-01 to start
-```
-
-**Validation:**
-- Task must exist
-- Agent must exist and have role capability
-- Agent must not already be assigned max tasks
-
----
-
-### bc queue unassign
-Remove assignment of a task.
-
-```bash
-bc queue unassign work-0001
-```
-
-**Output:**
-```
-✓ Unassigned work-0001 from eng-01
-✓ Status: pending
-✓ Ready for new assignment
+bc agent send-to-role engineer "run the tests"
+bc agent send-to-role manager "check status"
 ```
 
 ---
 
-### bc report
-Report task status update.
+### bc agent send-pattern
+Send a message to agents matching a name pattern.
 
 ```bash
-bc report working "Implementing JWT validation"
-```
-
-**Statuses:**
-- `working` - Task is in progress
-- `done` - Task is completed
-- `stuck` - Task is blocked
-- `failed` - Task failed
-
-**Examples:**
-```bash
-bc report working "Building API endpoints"
-bc report done "Authentication complete - ready for testing"
-bc report stuck "Waiting on database schema from team"
-bc report failed "Dependency not compatible"
+bc agent send-pattern "eng-*" "run tests"
+bc agent send-pattern "*-lead" "review PRs"
 ```
 
 ---
 
-## Git & Merging
-
-Commands for managing git integration and merging work.
-
-### bc merge list
-Show tasks ready to merge.
+### bc agent stop / start / delete
 
 ```bash
-bc merge list
-```
-
-**Output:**
-```
-READY TO MERGE (3)
-┌────────────────────────────────────────────────────────────────┐
-│ ID    │ Agent  │ Branch             │ Changes │ Conflicts │ Time │
-├────────────────────────────────────────────────────────────────┤
-│ 0001  │ eng-01 │ feature/user-auth  │ 12f     │ 0         │ 4h   │
-│ 0002  │ eng-02 │ feature/payments   │ 8f      │ 0         │ 6h   │
-│ 0003  │ eng-03 │ feature/emails     │ 5f      │ 0         │ 3h   │
-└────────────────────────────────────────────────────────────────┘
-```
-
-**Options:**
-```bash
-bc merge list --conflicts    # Show only conflicting
-bc merge list --agent eng-01 # Agent's work
+bc agent stop eng-01               # Stop agent
+bc agent stop eng-01 --force       # Force stop
+bc agent start eng-01              # Restart stopped agent
+bc agent start eng-01 --fresh      # Force new session
+bc agent delete eng-01             # Delete agent (preserves memory)
+bc agent delete eng-01 --purge     # Delete including memory
 ```
 
 ---
 
-### bc merge process
-Merge all ready tasks to main branch.
+### bc agent report
+Report agent state (used inside agent sessions).
 
 ```bash
-bc merge process
-```
-
-**Output:**
-```
-Merging work-0001 from eng-01...
-✓ feature/user-auth merged to main
-✓ Branch deleted
-
-Merging work-0002 from eng-02...
-✓ feature/payments merged to main
-✓ Branch deleted
-
-Merging work-0003 from eng-03...
-✓ feature/emails merged to main
-✓ Branch deleted
-
-✓ All 3 tasks merged
-✓ Worktrees cleaned up
-```
-
-**Options:**
-```bash
-bc merge process --dry-run       # Preview without merging
-bc merge process --no-delete     # Keep branches after merge
+bc agent report working "fixing auth bug"
+bc agent report done "auth bug fixed"
+bc agent report stuck "need database credentials"
+bc agent report stuck --reason "TUI freezes" --severity high
 ```
 
 ---
 
-### bc merge abort
-Cancel in-progress merge.
+### bc agent health
+Check agent health status.
 
 ```bash
-bc merge abort
+bc agent health              # Check all agents
+bc agent health eng-01       # Check specific agent
+bc agent health --detect-stuck --alert eng  # Alert on stuck
 ```
 
-**Output:**
-```
-✓ Merge aborted
-✓ Branches restored
-✓ Worktrees cleaned
+---
+
+### Other agent commands
+
+```bash
+bc agent show eng-01         # Show agent details
+bc agent rename old new      # Rename an agent
+bc agent cost eng-01         # Show agent cost
+bc agent logs eng-01         # Show agent event history
+bc agent sessions eng-01     # Show session IDs
+bc agent stats eng-01        # Docker resource stats
+bc agent auth my-agent       # Authenticate for Docker
 ```
 
 ---
 
 ## Channels & Communication
 
-Commands for agent communication.
-
-### bc send
-Send message to agent or channel.
+### bc channel create / delete
 
 ```bash
-# Send to agent
-bc send eng-01 "Check requirements in /docs/spec.md"
-
-# Send to channel
-bc send #engineering "API ready for integration"
-```
-
-**Output:**
-```
-✓ Message sent to eng-01
-✓ Timestamp: 2026-02-09 15:35:20
+bc channel create workers            # Create a channel
+bc channel create workers --desc "Worker discussion"
+bc channel delete workers            # Delete a channel
 ```
 
 ---
 
-### bc logs
-View communication and activity logs.
+### bc channel send
 
 ```bash
-# Agent logs
-bc logs eng-01
-
-# Channel logs
-bc logs #engineering
-
-# Full system logs
-bc logs
-```
-
-**Options:**
-```bash
-bc logs eng-01 --lines 50        # Last 50 lines
-bc logs eng-01 --since "2h ago"  # Logs from past 2 hours
-bc logs eng-01 --json            # JSON format
+bc channel send workers "run tests"  # Send to all members
 ```
 
 ---
 
-### bc channels list
-List all active channels.
+### bc channel list / show / status
 
 ```bash
-bc channels list
+bc channel list                      # List all channels
+bc channel show workers              # Show channel details
+bc channel status                    # Overview with activity
 ```
 
-**Output:**
+---
+
+### bc channel history
+
+```bash
+bc channel history eng                       # Last 50 messages
+bc channel history eng --last 20             # Last 20 messages
+bc channel history eng --since 1h            # Messages from last hour
+bc channel history eng --agent agent-core    # Filter by sender
 ```
-CHANNELS (6)
-├── #engineering   (5 members)
-├── #design        (3 members)
-├── #qa            (2 members)
-├── #deployments   (4 members)
-├── #general       (5 members)
-└── #random        (5 members)
+
+---
+
+### bc channel add / remove / join / leave
+
+```bash
+bc channel add workers worker-01     # Add member
+bc channel remove workers worker-01  # Remove member
+bc channel join workers              # Join (agent session)
+bc channel leave workers             # Leave (agent session)
+```
+
+---
+
+### bc channel react / edit
+
+```bash
+bc channel react engineering 5 thumbsup  # React to message
+bc channel edit eng --desc "Engineering" # Edit description
+```
+
+---
+
+## Cost Tracking
+
+```bash
+bc cost                              # Show cost records
+bc cost show eng-01                  # Show costs for agent
+bc cost summary                      # Workspace cost overview
+bc cost daily                        # Daily cost totals
+bc cost agent                        # Per-agent breakdown
+bc cost model                        # Per-model breakdown
+bc cost dashboard                    # Rich cost dashboard
+bc cost usage                        # Claude Code usage via ccusage
+bc cost usage --monthly              # Monthly summary
+bc cost budget show                  # Show budget status
 ```
 
 ---
 
 ## Configuration
 
-Commands for workspace configuration.
-
-### bc config show
-Display current configuration.
+### bc config
 
 ```bash
-bc config show
-```
-
-**Output:**
-```
-WORKSPACE CONFIG (.bc/config.toml)
-
-[workspace]
-name = "my-project"
-root = "/Users/user/my-project"
-
-[agents]
-max_concurrent = 10
-timeout = "30m"
-auto_restart = true
-
-[git]
-auto_merge = true
-merge_strategy = "squash"
+bc config show                        # Show all config
+bc config get providers.default       # Get a specific value
+bc config set providers.default claude # Set a value
+bc config list                        # List all config keys
+bc config edit                        # Open in editor
+bc config validate                    # Validate config file
+bc config reset                       # Reset to defaults
+bc config user init                   # User config wizard
+bc config user show                   # Show user config
 ```
 
 ---
 
-### bc config set
-Update configuration value.
+## Scheduled Tasks
+
+### bc cron
 
 ```bash
-bc config set workspace.name "new-name"
-bc config set agents.max_concurrent 20
-bc config set git.auto_merge false
+bc cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint"
+bc cron list                          # List all cron jobs
+bc cron show daily-lint               # Show job details
+bc cron enable daily-lint             # Enable a disabled job
+bc cron disable daily-lint            # Disable without deleting
+bc cron run daily-lint                # Trigger manually
+bc cron logs daily-lint --last 10     # Show last 10 executions
+bc cron remove daily-lint             # Delete a job
 ```
 
 ---
 
-## Monitoring & Logs
+## Daemon & Processes
 
-Commands for monitoring and debugging.
-
-### bc home
-Open interactive TUI dashboard.
+### bc daemon
 
 ```bash
-bc home
-```
-
-**Features:**
-- Real-time agent status
-- Work queue progress
-- Communication history
-- System metrics
-- Merge queue status
-
-**Navigation:**
-- ↑/↓ - Navigate
-- Enter - View details
-- q - Quit
-- : - Command mode
-
----
-
-### bc metrics
-Show performance metrics.
-
-```bash
-bc metrics
-```
-
-**Output:**
-```
-METRICS
-├── Tasks Completed: 42
-├── Avg Duration: 2h 15m
-├── Success Rate: 98.8%
-├── Merge Conflicts: 2
-├── Team Size: 5
-└── Uptime: 23h 45m
+bc daemon start          # Start the bcd HTTP server
+bc daemon status         # Check bcd server health
+bc daemon stop           # Stop bcd server
+bc daemon stop myproc    # Stop a named process
+bc daemon run --name db  # Run a workspace process
+bc daemon list           # List running workspace processes
+bc daemon logs           # View bcd logs
+bc daemon logs myproc    # View process logs
+bc daemon restart myproc # Restart a process
+bc daemon rm myproc      # Remove a stopped process
 ```
 
 ---
 
-### bc health
-Check workspace health.
+## Secrets & Environment
+
+### bc secret
 
 ```bash
-bc health
+bc secret set ANTHROPIC_API_KEY                    # Prompt for value
+bc secret set ANTHROPIC_API_KEY --value "sk-..."   # Set directly
+bc secret set GITHUB_TOKEN --from-env GITHUB_TOKEN # Import from env
+bc secret list                                     # List names (no values)
+bc secret show ANTHROPIC_API_KEY                   # Show metadata
+bc secret show ANTHROPIC_API_KEY --reveal          # Show actual value
+bc secret get ANTHROPIC_API_KEY                    # Print value to stdout
+bc secret delete ANTHROPIC_API_KEY                 # Delete a secret
 ```
 
-**Output:**
-```
-HEALTH CHECK
-├── Workspace: OK
-├── Git Repository: OK
-├── Agents (5): 5 running, 0 stuck
-├── Queue: 1 working, 2 pending
-├── Disk Space: 2.3 GB / 5 GB
-└── Overall: HEALTHY
+Reference secrets in config with `${secret:NAME}` syntax.
+
+---
+
+### bc env
+
+```bash
+bc env set SHARED_VAR global                           # Workspace env
+bc env set --provider claude CLAUDE_CODE_USE_BEDROCK 1 # Provider env
+bc env list                                            # All env vars
+bc env list --provider claude                          # Provider-specific
+bc env get SHARED_VAR                                  # Get value
+bc env unset SHARED_VAR                                # Remove
 ```
 
 ---
 
-## Admin Commands
+## Tools & Roles
 
-Advanced administrative commands.
-
-### bc backup
-Create workspace backup.
+### bc tool
 
 ```bash
-bc backup
-```
-
-**Output:**
-```
-✓ Backup created: .bc/backup-2026-02-09-T15-35-20.tar.gz
-✓ Size: 2.3 MB
-✓ Location: .bc/backups/
+bc tool list              # Show all tools with status
+bc tool add myagent       # Add a custom tool
+bc tool show claude       # Show tool details
+bc tool setup claude      # Install and configure
+bc tool status claude     # Check installation status
+bc tool upgrade claude    # Upgrade an installed tool
+bc tool delete mytool     # Remove a custom tool
+bc tool run claude        # Run a tool directly
+bc tool edit mytool       # Edit tool configuration
 ```
 
 ---
 
-### bc restore
-Restore from backup.
+### bc role
 
 ```bash
-bc restore .bc/backup-2026-02-09-T15-35-20.tar.gz
-```
-
-**Output:**
-```
-✓ Restoring from backup...
-✓ Workspace restored
-✓ All agents: running
-✓ Queue: 42 items
+bc role list              # List all roles
+bc role show engineer     # Show role details
 ```
 
 ---
 
-### bc clean
-Clean up temporary files and optimize workspace.
+## Monitoring & Diagnostics
+
+### bc logs
+View the event log.
 
 ```bash
-bc clean
+bc logs                     # Show all events
+bc logs --agent eng-01      # Filter by agent
+bc logs --type agent.report # Filter by event type
+bc logs --since 1h          # Events from last hour
+bc logs --tail 20           # Last N events
+bc logs --full              # Show full messages
 ```
 
-**Output:**
+---
+
+### bc doctor
+Run health checks.
+
+```bash
+bc doctor                          # Full health check
+bc doctor check workspace          # Check specific category
+bc doctor fix                      # Auto-fix fixable issues
+bc doctor fix --dry-run            # Preview fixes
+bc doctor fix --category git       # Fix specific category
 ```
-✓ Removed temporary files
-✓ Cleaned up old logs
-✓ Optimized git repository
-✓ Freed 156 MB
+
+---
+
+### bc version
+
+```bash
+bc version       # Show version info
+bc --version     # Same as above
+bc -V            # Same as above
+```
+
+---
+
+### bc mcp
+Manage MCP server configurations.
+
+```bash
+bc mcp list                                     # List all MCP servers
+bc mcp add github --command npx --args "@modelcontextprotocol/server-github"
+bc mcp add remote --transport sse --url "https://api.example.com/mcp"
+bc mcp show github                              # Show server details
+bc mcp remove github                            # Remove a server
+bc mcp disable github                           # Disable a server
+bc mcp enable github                            # Re-enable a server
+bc mcp register                                 # Register bc as MCP server
+bc mcp serve                                    # Start bc as MCP server
 ```
 
 ---
 
 ## Quick Reference
 
-### Most Common Commands
-
 ```bash
 # Daily workflow
-bc status                    # Check status
-bc queue add "Task title"    # Create task
-bc queue assign work-0001 eng-01  # Assign
-bc attach eng-01             # Watch agent
-bc merge process             # Merge when done
+bc up                                    # Start root agent
+bc status                                # Check status
+bc agent create eng-01 --role engineer   # Create agent
+bc agent send eng-01 "implement X"       # Send work
+bc agent peek eng-01                     # Watch output
+bc home                                  # Open dashboard
+bc down                                  # Stop all
 
-# Team management
-bc spawn eng-01 --role engineer   # Add agent
-bc send eng-01 "Message"          # Communicate
-bc logs eng-01                    # View history
+# Communication
+bc channel send eng "starting tests"     # Channel message
+bc agent broadcast "check status"        # Broadcast to all
 
-# Dashboard
-bc home                      # Open dashboard
+# Monitoring
+bc logs --tail 20                        # Recent events
+bc doctor                                # Health check
+bc cost summary                          # Cost overview
 ```
 
-### Exit Codes
+---
 
-```
-0   - Success
-1   - General error
-2   - Invalid arguments
-3   - Agent not found
-4   - Task not found
-5   - Permission denied
-10  - Merge conflict
+## Global Flags
+
+```bash
+-v, --verbose   # Enable verbose output
+    --json      # Output in JSON format
+-V, --version   # Print version information
 ```
 
 ---
@@ -755,33 +537,13 @@ bc home                      # Open dashboard
 ## Environment Variables
 
 ```bash
-BC_WORKSPACE         # Workspace root (auto-detected)
-BC_AGENT_ID          # Current agent ID
-BC_AGENT_ROLE        # Current agent role
-BC_AGENT_WORKTREE    # Agent's worktree path
-BC_DEBUG             # Enable debug logging (true/false)
-BC_VERBOSE           # Verbose output (true/false)
-```
-
----
-
-## Tips & Tricks
-
-```bash
-# Watch agent in real-time
-bc attach eng-01 --follow
-
-# Export queue as JSON
-bc queue list --json > queue.json
-
-# Get agent metrics
-bc status --json | jq '.agents[] | {id, role, duration}'
-
-# Find stuck agents
-bc status | grep "stuck"
-
-# Merge specific task
-bc merge process --only work-0001
+BC_AGENT_ID       # Current agent name (set in agent sessions)
+BC_AGENT_ROLE     # Current agent role
+BC_WORKSPACE      # Path to workspace root
+BC_AGENT_WORKTREE # Path to agent's worktree
+BC_BIN            # Path to bc binary
+BC_ROOT           # Workspace root directory
+NO_COLOR          # Disable colored output
 ```
 
 ---

--- a/landing/docs/getting-started.md
+++ b/landing/docs/getting-started.md
@@ -19,7 +19,7 @@ Welcome to bc! This guide will walk you through installation, setup, and your fi
 Before installing bc, ensure you have:
 
 ### Required
-- **Go 1.25.1+** - [Download Go](https://go.dev/dl)
+- **Go 1.25.4+** - [Download Go](https://go.dev/dl)
 - **tmux** - Terminal multiplexer for session management
 - **Claude Code** (or compatible AI agent like Cursor)
 - **git** - Version control system


### PR DESCRIPTION
## Summary

- Fixed `demon (cr/cron)` typo to `cron (cr)` in root command help text (`internal/cmd/root.go`)
- Updated Go version requirement from `1.25.1+` / `1.22+` to `1.25.4+` across quickstart, troubleshooting, and landing docs
- Fixed missing spaces in `bc agent report` command examples (`reportworking` -> `report working`)
- Removed references to non-existent CLI commands (`bc cost add`, `bc logs prune`, `bc memory`) from troubleshooting guide
- Fixed `bc logs --type` example to use valid event type (`agent.report` instead of `error`)
- Complete rewrite of `landing/docs/cli-reference.md` which referenced many stale/removed commands (`bc spawn`, `bc kill`, `bc queue`, `bc merge`, `bc send`, `bc list`, `bc attach`, `bc metrics`, `bc health`, `bc backup`, `bc restore`, `bc clean`)

Closes #2558

## Test plan

- [x] `make build-bc-local` succeeds
- [x] `./bin/bc --help` shows `cron (cr)` instead of `demon (cr/cron)`
- [x] All 20 top-level commands audited via `--help`
- [x] All doc command examples verified against actual CLI flags and subcommands

Generated with [Claude Code](https://claude.com/claude-code)