### PR TITLE
feat(landing): add changelog to navigation and footer

### DIFF
--- a/landing/src/app/_components/Footer.tsx
+++ b/landing/src/app/_components/Footer.tsx
@@ -51,6 +51,12 @@ export function Footer() {
               >
                 Method
               </Link>
+              <Link
+                href="/changelog"
+                className="hover:text-foreground transition-colors"
+              >
+                Changelog
+              </Link>
             </nav>
           </div>
           <div className="space-y-4">

--- a/landing/src/app/_components/Nav.tsx
+++ b/landing/src/app/_components/Nav.tsx
@@ -12,6 +12,7 @@ const links = [
   { href: "/method", label: "Method" },
   { href: "/docs", label: "Docs" },
   { href: "/pricing", label: "Pricing" },
+  { href: "/changelog", label: "Changelog" },
 ];
 
 function Logo() {

--- a/landing/src/app/changelog/layout.tsx
+++ b/landing/src/app/changelog/layout.tsx
@@ -1,0 +1,51 @@
+import { Metadata } from "next";
+import { BreadcrumbSchema } from "../_components/StructuredData";
+
+export const metadata: Metadata = {
+  title: "Changelog — bc | Release Notes & Updates",
+  description:
+    "What's new in bc. Release notes, features, and improvements for the CLI-first multi-agent orchestration platform.",
+  alternates: {
+    canonical: "/changelog",
+  },
+  openGraph: {
+    title: "Changelog — bc | Release Notes & Updates",
+    description:
+      "What's new in bc. Release notes, features, and improvements for the CLI-first multi-agent orchestration platform.",
+    url: "https://bc-infra.com/changelog",
+    siteName: "bc",
+    type: "website",
+    images: [
+      {
+        url: "https://bc-infra.com/og-image.png",
+        width: 1200,
+        height: 630,
+        alt: "bc - Multi-Agent Orchestration Platform",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Changelog — bc | Release Notes & Updates",
+    description:
+      "What's new in bc. Release notes, features, and improvements for the CLI-first multi-agent orchestration platform.",
+    images: ["https://bc-infra.com/og-image.png"],
+    creator: "@bcinfra",
+  },
+};
+
+export default function ChangelogLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      {BreadcrumbSchema([
+        { name: "Home", url: "https://bc-infra.com" },
+        { name: "Changelog", url: "https://bc-infra.com/changelog" },
+      ])}
+      {children}
+    </>
+  );
+}

--- a/landing/src/app/changelog/page.tsx
+++ b/landing/src/app/changelog/page.tsx
@@ -1,12 +1,6 @@
 import { Nav } from "../_components/Nav";
 import { Footer } from "../_components/Footer";
 
-export const metadata = {
-  title: "Changelog — bc",
-  description:
-    "What's new in bc. Release notes, features, and improvements.",
-};
-
 const ENTRIES = [
   {
     date: "March 2026",

--- a/landing/tests/smoke.spec.ts
+++ b/landing/tests/smoke.spec.ts
@@ -191,6 +191,7 @@ test.describe("Navigation", () => {
     const nav = page.locator("nav").first();
     await expect(nav.locator('a[href="/product"]')).toBeAttached();
     await expect(nav.locator('a[href="/docs"]')).toBeAttached();
+    await expect(nav.locator('a[href="/changelog"]')).toBeAttached();
     await expect(nav.locator('a[href="/waitlist"]')).toBeAttached();
   });
 
@@ -258,6 +259,7 @@ test.describe("Mobile Navigation", () => {
     await expect(menu.locator('a[href="/"]')).toBeAttached();
     await expect(menu.locator('a[href="/product"]')).toBeAttached();
     await expect(menu.locator('a[href="/docs"]')).toBeAttached();
+    await expect(menu.locator('a[href="/changelog"]')).toBeAttached();
     await expect(menu.locator('a[href="/waitlist"]')).toBeAttached();
   });
 


### PR DESCRIPTION
## Summary
- Add "Changelog" link after "Pricing" in desktop and mobile navigation
- Add "Changelog" link to the Product column in the footer
- Create `changelog/layout.tsx` with full metadata (OpenGraph, Twitter cards, breadcrumb schema)
- Move metadata from `page.tsx` to `layout.tsx` to follow existing patterns
- Update smoke tests to assert changelog link presence in both desktop and mobile nav

Part of #2569

## Test plan
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [ ] Verify changelog link appears in desktop nav after Pricing
- [ ] Verify changelog link appears in mobile hamburger menu
- [ ] Verify changelog link appears in footer Product column
- [ ] Verify /changelog page renders with correct metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Changelog page to view release notes and updates.
  * Changelog is now accessible from the main navigation menu on both desktop and mobile platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->