### PR TITLE
fix(landing): replace non-existent CLI commands with real ones

### DIFF
--- a/landing/src/app/_components/InteractiveCarouselDemos.tsx
+++ b/landing/src/app/_components/InteractiveCarouselDemos.tsx
@@ -419,7 +419,7 @@ const CHANNELS_STEPS: CarouselStep[] = [
     render: () => (
       <div className="space-y-4 font-mono text-sm">
         <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-          bc channel history #general --search &quot;PR #347&quot;
+          bc channel history general --since 1h
         </div>
         <div className="space-y-2 p-4 rounded-lg bg-background/50 border border-border/50">
           <div className="text-xs text-muted-foreground">5 results found</div>

--- a/landing/src/app/_components/ProductCarouselDemos.tsx
+++ b/landing/src/app/_components/ProductCarouselDemos.tsx
@@ -521,7 +521,7 @@ function CronScheduleFrame() {
         <div className="text-foreground">Add a cron job</div>
         <div className="mt-3 rounded-xl border border-border bg-card p-4">
           <div className="text-muted-foreground">
-            $ bc cron add cron-health --schedule &quot;0 * * * *&quot; --cmd
+            $ bc cron add cron-health --schedule &quot;0 * * * *&quot; --command
             &quot;npm test&quot;
           </div>
         </div>

--- a/landing/src/app/docs/getting-started.md
+++ b/landing/src/app/docs/getting-started.md
@@ -132,25 +132,7 @@ AGENTS (3):
 
 ### Scenario: Build a Feature with bc
 
-**Step 1: Create a Work Queue Task**
-
-```bash
-# Add task to work queue
-bc queue add "Implement user authentication feature" \
-  --priority high \
-  --epic "auth-v2"
-
-# View queue
-bc queue work
-```
-
-**Output:**
-```
-WORK QUEUE:
-  1. Implement user authentication (priority: high, epic: auth-v2)
-```
-
-**Step 2: Assign Work via Channels**
+**Step 1: Assign Work via Channels**
 
 ```bash
 # Send task assignment to #engineering channel
@@ -160,7 +142,7 @@ bc channel send engineering "@engineer-pixel: Take task #1 - user auth implement
 bc channel history engineering --limit 5
 ```
 
-**Step 3: Engineer Works on Task**
+**Step 2: Engineer Works on Task**
 
 ```bash
 # Simulate engineer picking up work
@@ -176,20 +158,7 @@ AGENT: engineer-pixel (state: tool)
   ✻ running tests
 ```
 
-**Step 4: Manager Reviews & Merges**
-
-```bash
-# Check manager's queue
-bc queue merge
-
-# Merge PR #42
-bc merge feature/user-auth --branch main
-
-# Verify merge
-bc queue merge
-```
-
-**Step 5: Celebrate!**
+**Step 3: Review & Announce**
 
 ```bash
 # Post status to channel
@@ -216,20 +185,17 @@ bc agent send engineer-pixel "Status update please?"
 bc agent attach engineer-pixel
 ```
 
-### Work Queue
+### Cost Tracking
 
 ```bash
-# View incoming work
-bc queue work
+# View cost summary
+bc cost show
 
-# View merge queue
-bc queue merge
+# View token usage
+bc cost usage
 
-# Add task to queue
-bc queue add "Task description" --priority high
-
-# Complete task
-bc queue complete 42
+# Set budget for an agent
+bc cost budget set 50.00 --agent engineer-pixel
 ```
 
 ### Channels (Team Communication)
@@ -245,36 +211,23 @@ bc channel send #general "Update: Feature X shipped 🚀"
 bc channel history #engineering --limit 10
 
 # Create new channel
-bc channel create #product-team
+bc channel create product-team
 ```
 
-### Memory & Learning
-
-```bash
-# View agent memory
-bc memory show --agent engineer-pixel
-
-# Record learning
-bc memory record "Pattern: Always validate user input before processing"
-
-# Search past experiences
-bc memory search "authentication patterns"
-```
-
-### Automation (Demons)
+### Scheduled Tasks (Cron)
 
 ```bash
 # List scheduled tasks
-bc demon list
+bc cron list
 
-# Run a demon manually
-bc demon run nightly-tests
+# Run a cron job manually
+bc cron run nightly-tests
 
-# Create new demon
-bc demon create test-suite --schedule "0 2 * * *" --role qa --task "Nightly test run"
+# Create new cron job
+bc cron add test-suite --schedule "0 2 * * *" --command "make test"
 
-# View demon logs
-bc demon logs test-suite
+# View cron logs
+bc cron logs test-suite
 ```
 
 ---
@@ -302,25 +255,26 @@ bc status
 # Check agent status
 bc agent list
 
-# Restart agent
-bc agent restart engineer-pixel
+# Restart agent (stop then start)
+bc agent stop engineer-pixel
+bc agent start engineer-pixel
 
 # View agent logs
-bc agent logs engineer-pixel --tail 20
+bc agent logs engineer-pixel --since 1h
 ```
 
 ### Issue: Merge conflict preventing PR merge
 
 **Solution:**
 ```bash
-# Check merge queue for conflicts
-bc queue merge
+# Check agent status to see if it's stuck
+bc status
 
-# Agent should resolve automatically, if not:
-# Contact tech lead for manual resolution
+# Send the agent instructions to resolve conflicts
+bc agent send engineer-pixel "Resolve merge conflicts on your branch and push"
 
-# Once resolved, retry merge
-bc merge feature/branch-name --branch main
+# Monitor progress
+bc agent peek engineer-pixel
 ```
 
 ### Issue: Channel messages not appearing
@@ -342,12 +296,12 @@ bc channel send #general "Test message"
 **Solution:**
 ```bash
 # Check system resources
-bc status --verbose
+bc doctor
 
-# Clear cache
-bc cache clear
+# Run auto-fix for common issues
+bc doctor fix
 
-# Restart root agent
+# Restart agents
 bc down && bc up
 ```
 
@@ -391,29 +345,22 @@ Here's a realistic end-to-end workflow:
 bc init && bc up
 
 # 2. Create team
-bc agent create pm-alex --role product-manager --tool notion
-bc agent create eng-sam --role engineer --tool cursor
-bc agent create qa-jamie --role qa --tool chrome
+bc agent create pm-alex --role manager --tool cursor
+bc agent create eng-sam --role engineer --tool claude
+bc agent create qa-jamie --role engineer --tool gemini
 
-# 3. Define work
-bc queue add "Build user profile page" --priority high --epic "user-feature"
+# 3. Assign work via channel
+bc channel send engineering "@eng-sam: Build user profile page. UI design in #product. Ship within 2 hours?"
 
-# 4. Assign via channel
-bc channel send #engineering "@eng-sam: Pick up user profile task. UI design in #product. Ship within 2 hours?"
-
-# 5. Monitor progress
+# 4. Monitor progress
 bc agent peek eng-sam
-bc channel history #engineering
+bc channel history engineering
 
-# 6. Approve & merge
-bc queue merge
-bc merge feature/user-profile --branch main
+# 5. Check costs
+bc cost show
 
-# 7. Announce
-bc channel send #general "🎉 User profile feature live! Thanks team!"
-
-# 8. Record learning
-bc memory record "User profile workflow successful. Took 1.5 hours end-to-end"
+# 6. Announce
+bc channel send general "User profile feature live! Thanks team!"
 ```
 
 ---
@@ -424,13 +371,12 @@ bc memory record "User profile workflow successful. Took 1.5 hours end-to-end"
 |------|---------|
 | Check status | `bc status` |
 | List agents | `bc agent list` |
-| View work queue | `bc queue work` |
-| Send message | `bc channel send #channel "message"` |
+| Send message | `bc channel send engineering "message"` |
 | View agent work | `bc agent peek engineer-name` |
-| Merge PR | `bc merge branch-name --branch main` |
-| Schedule task | `bc demon create name --schedule "0 2 * * *"` |
-| Search memory | `bc memory search "pattern"` |
-| View logs | `bc agent logs agent-name --tail 20` |
+| Schedule task | `bc cron add name --schedule "0 2 * * *" --command "make test"` |
+| View costs | `bc cost show` |
+| View logs | `bc agent logs agent-name --since 1h` |
+| Health check | `bc doctor` |
 | Get help | `bc --help` |
 
 ---

--- a/landing/src/app/docs/page.tsx
+++ b/landing/src/app/docs/page.tsx
@@ -587,9 +587,9 @@ bc tl run <tool>`}
                 defaultOpen={!!search}
               >
                 <CodeBlock
-                  code={`bc sec create <name> [--from-env] [--from-file]
+                  code={`bc sec set <name> [--from-env VAR] [--from-file PATH]
 bc sec list
-bc sec show|edit|delete <name>`}
+bc sec show|get|delete <name>`}
                 />
                 <p className="mt-3 text-sm text-muted-foreground">
                   Encrypted at rest (macOS Keychain / Linux libsecret /
@@ -627,11 +627,11 @@ bc co budget show|set|delete [--agent X] [--period daily|weekly|monthly] [--aler
                 defaultOpen={!!search}
               >
                 <CodeBlock
-                  code={`bc cr add <name> --schedule '<cron>' --cmd '<command>' [--prompt "..."]
+                  code={`bc cr add <name> --schedule '<cron>' --command '<command>' [--prompt "..."]
 bc cr list
 bc cr show <name>
 bc cr run <name>                   # Manual trigger
-bc cr edit|delete|enable|disable <name>
+bc cr enable|disable|remove <name>
 bc cr logs <name>`}
                 />
               </CommandSection>
@@ -681,7 +681,7 @@ bc rl permissions show|list|set|add|remove <role> [<perm>...]`}
                 <CodeBlock
                   code={`bc mcp add <name>
 bc mcp list
-bc mcp show|edit|delete|status <name>`}
+bc mcp show|enable|disable|remove <name>`}
                 />
                 <p className="mt-3 text-sm text-muted-foreground">
                   MCP server configs referenced by roles. Supports stdio and SSE
@@ -799,7 +799,7 @@ bc version`}
                   {
                     cmd: "bc secret",
                     alias: "bc sec",
-                    example: "bc sec create API_KEY",
+                    example: "bc sec set API_KEY",
                   },
                   {
                     cmd: "bc cost",

--- a/landing/src/app/product/page.tsx
+++ b/landing/src/app/product/page.tsx
@@ -271,9 +271,9 @@ export default function Product() {
           title="Connect tools natively via MCP."
           description="Configure Model Context Protocol servers that your agents connect to automatically. Supports stdio and SSE transport. Attach MCP servers to roles so every agent of that type gets the same capabilities."
           commands={[
-            'bc mcp add github-server',
+            'bc mcp add github --command npx --args "@modelcontextprotocol/server-github"',
             'bc mcp list',
-            'bc mcp enable github-server',
+            'bc mcp enable github',
           ]}
           screenshot="/screenshots/dashboard-07-mcp.png"
           screenshotAlt="bc MCP view showing configured MCP servers with transport type and connection status"


### PR DESCRIPTION
## Summary
- Audited all landing page files against actual `bc --help` output
- Fixed 15+ fake/non-existent CLI commands across 5 files
- Replaced `bc queue`, `bc merge`, `bc memory`, `bc demon`, `bc cache` with real commands
- Fixed incorrect flags: `--cmd` -> `--command`, `--search` (removed), `--tail` on agent logs -> `--since`
- Fixed non-existent subcommands: `mcp edit|delete|status`, `sec create`, `cr edit|delete`, `agent restart`
- Fixed invalid tool names: `--tool notion/chrome` -> valid tools
- Added missing required flags: `mcp add` now includes `--command`

Part of #2569

## Test plan
- [x] `bun run lint` passes
- [x] `bun run build` passes (all 11 static pages generate successfully)
- [ ] Visual review of landing pages at localhost:3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)