### PR TITLE
feat(landing): redesign docs page with sidebar navigation

### DIFF
--- a/landing/src/app/docs/DocsContent.tsx
+++ b/landing/src/app/docs/DocsContent.tsx
@@ -2,43 +2,57 @@
 
 import { Nav } from "../_components/Nav";
 import { Footer } from "../_components/Footer";
-import {
-  TerminalWindow,
-  CommandOutput,
-  RevealSection,
-} from "../_components/TerminalComponents";
-import { useState, useMemo } from "react";
-import Link from "next/link";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
 import type { CommandGroup, CliCommand } from "@/lib/cli-docs";
 import type { DocsSection } from "@/lib/docs-loader";
 import {
-  GitBranch,
-  MessageSquare,
-  Brain,
-  DollarSign,
-  Users,
-  Layers,
   ChevronDown,
+  ChevronRight,
   Copy,
   Check,
   Search,
-  Shield,
-  Clock,
-  Terminal,
-  Server,
-  Wrench,
-  Key,
-  Stethoscope,
-  Hash,
-  Settings,
-  FolderTree,
   BookOpen,
-  Lightbulb,
-  FileText,
   Compass,
+  FileText,
+  Lightbulb,
+  Terminal,
+  Menu,
+  X,
+  Construction,
 } from "lucide-react";
 
-/* ── Copy button ── */
+/* ═══════════════════════════════════════════════════════════════════
+   TYPES
+   ═══════════════════════════════════════════════════════════════════ */
+
+interface NavItem {
+  id: string;
+  label: string;
+  type: "article" | "cli-group" | "cli-command" | "placeholder";
+  sectionId: string;
+  content?: string;
+  description?: string;
+  cliGroup?: CommandGroup;
+  cliCommand?: CliCommand;
+}
+
+interface NavSection {
+  id: string;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  items: NavItem[];
+}
+
+interface TocHeading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   COPY BUTTON
+   ═══════════════════════════════════════════════════════════════════ */
+
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   return (
@@ -63,16 +77,30 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-/* ── Code block with copy ── */
-function CodeBlock({ code, title }: { code: string; title?: string }) {
+/* ═══════════════════════════════════════════════════════════════════
+   CODE BLOCK
+   ═══════════════════════════════════════════════════════════════════ */
+
+function CodeBlock({
+  code,
+  language,
+  title,
+}: {
+  code: string;
+  language?: string;
+  title?: string;
+}) {
   return (
-    <div className="relative overflow-hidden rounded-xl border border-border bg-terminal-bg">
+    <div className="group relative overflow-hidden rounded-lg border border-border bg-[#0C0A08] my-4">
       {title && (
-        <div className="border-b border-white/[0.06] bg-terminal-header px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-terminal-muted">
-          {title}
+        <div className="border-b border-white/[0.06] bg-[#151210] px-4 py-2 text-[10px] font-bold uppercase tracking-[0.2em] text-terminal-muted flex items-center justify-between">
+          <span>{title}</span>
+          {language && (
+            <span className="text-terminal-muted/50">{language}</span>
+          )}
         </div>
       )}
-      <div className="p-4 font-mono text-[13px] leading-relaxed text-terminal-text overflow-x-auto">
+      <div className="relative p-4 font-mono text-[13px] leading-relaxed text-terminal-text overflow-x-auto">
         <CopyButton text={code} />
         <pre>
           <code>{code}</code>
@@ -82,196 +110,162 @@ function CodeBlock({ code, title }: { code: string; title?: string }) {
   );
 }
 
-/* ── Icon map for command groups ── */
-const GROUP_ICONS: Record<
-  string,
-  React.ComponentType<{ className?: string }>
-> = {
-  agent: Users,
-  workspace: Layers,
-  channel: MessageSquare,
-  tool: Wrench,
-  secret: Key,
-  cost: DollarSign,
-  cron: Clock,
-  role: Shield,
-  mcp: Hash,
-  doctor: Stethoscope,
-  daemon: Server,
-  config: Settings,
-  env: FolderTree,
-};
+/* ═══════════════════════════════════════════════════════════════════
+   INLINE MARKDOWN
+   ═══════════════════════════════════════════════════════════════════ */
 
-/* ── Section icons ── */
-const SECTION_ICONS: Record<
-  string,
-  React.ComponentType<{ className?: string }>
-> = {
-  tutorials: BookOpen,
-  "how-to": Compass,
-  reference: FileText,
-  explanation: Lightbulb,
-};
+interface InlineMatch {
+  type: string;
+  pre: string;
+  content: string;
+  post: string;
+  href?: string;
+  idx: number;
+}
 
-/* ── Collapsible section ── */
-function CollapsibleSection({
-  id,
-  title,
-  alias,
-  count,
-  icon: Icon,
-  children,
-  defaultOpen = false,
-  visible = true,
+function InlineMarkdown({ text }: { text: string }) {
+  const parts: React.ReactNode[] = [];
+  let remaining = text;
+  let partKey = 0;
+
+  while (remaining.length > 0) {
+    const codeMatch = remaining.match(/^(.*?)`([^`]+)`(.*)$/);
+    const boldMatch = remaining.match(/^(.*?)\*\*([^*]+)\*\*(.*)$/);
+    const italicMatch = remaining.match(/^(.*?)(?<!\*)\*([^*]+)\*(?!\*)(.*)$/);
+    const linkMatch = remaining.match(/^(.*?)\[([^\]]+)\]\(([^)]+)\)(.*)$/);
+
+    const candidates: InlineMatch[] = [];
+
+    if (codeMatch) {
+      candidates.push({
+        type: "code",
+        pre: codeMatch[1],
+        content: codeMatch[2],
+        post: codeMatch[3],
+        idx: codeMatch[1].length,
+      });
+    }
+    if (boldMatch) {
+      candidates.push({
+        type: "bold",
+        pre: boldMatch[1],
+        content: boldMatch[2],
+        post: boldMatch[3],
+        idx: boldMatch[1].length,
+      });
+    }
+    if (italicMatch) {
+      candidates.push({
+        type: "italic",
+        pre: italicMatch[1],
+        content: italicMatch[2],
+        post: italicMatch[3],
+        idx: italicMatch[1].length,
+      });
+    }
+    if (linkMatch) {
+      candidates.push({
+        type: "link",
+        pre: linkMatch[1],
+        content: linkMatch[2],
+        post: linkMatch[4],
+        href: linkMatch[3],
+        idx: linkMatch[1].length,
+      });
+    }
+
+    // Pick the candidate with the earliest position
+    candidates.sort((a, b) => a.idx - b.idx);
+    const earliest = candidates.length > 0 ? candidates[0] : null;
+
+    if (!earliest) {
+      parts.push(<span key={partKey++}>{remaining}</span>);
+      break;
+    }
+
+    if (earliest.pre) {
+      parts.push(<span key={partKey++}>{earliest.pre}</span>);
+    }
+
+    if (earliest.type === "code") {
+      parts.push(
+        <code
+          key={partKey++}
+          className="rounded bg-muted px-1.5 py-0.5 text-[0.85em] font-mono text-primary"
+        >
+          {earliest.content}
+        </code>,
+      );
+    } else if (earliest.type === "bold") {
+      parts.push(
+        <strong key={partKey++} className="font-semibold text-foreground">
+          {earliest.content}
+        </strong>,
+      );
+    } else if (earliest.type === "italic") {
+      parts.push(
+        <em key={partKey++} className="italic">
+          {earliest.content}
+        </em>,
+      );
+    } else if (earliest.type === "link") {
+      parts.push(
+        <a
+          key={partKey++}
+          href={earliest.href}
+          className="text-primary hover:underline"
+          target={earliest.href?.startsWith("http") ? "_blank" : undefined}
+          rel={
+            earliest.href?.startsWith("http")
+              ? "noopener noreferrer"
+              : undefined
+          }
+        >
+          {earliest.content}
+        </a>,
+      );
+    }
+
+    remaining = earliest.post;
+  }
+
+  return <>{parts}</>;
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   MARKDOWN RENDERER
+   ═══════════════════════════════════════════════════════════════════ */
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+function MarkdownContent({
+  content,
+  onHeadings,
 }: {
-  id?: string;
-  title: string;
-  alias?: string;
-  count: number;
-  icon?: React.ComponentType<{ className?: string }>;
-  children: React.ReactNode;
-  defaultOpen?: boolean;
-  visible?: boolean;
+  content: string;
+  onHeadings?: (headings: TocHeading[]) => void;
 }) {
-  const [open, setOpen] = useState(defaultOpen);
-  if (!visible) return null;
-  return (
-    <div id={id} className="border border-border rounded-xl overflow-hidden">
-      <button
-        onClick={() => setOpen(!open)}
-        aria-expanded={open}
-        className="flex w-full items-center justify-between px-5 py-4 text-left hover:bg-accent/50 transition-colors"
-      >
-        <div className="flex items-center gap-3">
-          {Icon && (
-            <Icon className="h-4 w-4 text-primary/60" aria-hidden="true" />
-          )}
-          <span className="font-semibold text-sm">{title}</span>
-          {alias && (
-            <span className="rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-mono font-bold text-primary">
-              {alias}
-            </span>
-          )}
-          <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-bold text-muted-foreground">
-            {count}
-          </span>
-        </div>
-        <ChevronDown
-          className={`h-4 w-4 text-muted-foreground transition-transform ${open ? "rotate-180" : ""}`}
-          aria-hidden="true"
-        />
-      </button>
-      {open && (
-        <div className="border-t border-border px-5 py-4 bg-accent/20">
-          {children}
-        </div>
-      )}
-    </div>
-  );
-}
-
-/* ── Concept card ── */
-function ConceptCard({
-  icon: Icon,
-  title,
-  desc,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  title: string;
-  desc: string;
-}) {
-  return (
-    <div className="rounded-xl border border-border bg-card p-5 transition-colors hover:border-primary/20">
-      <Icon className="h-5 w-5 text-primary/60 mb-3" aria-hidden="true" />
-      <h3 className="font-semibold text-sm mb-1.5">{title}</h3>
-      <p className="text-sm text-muted-foreground leading-relaxed">{desc}</p>
-    </div>
-  );
-}
-
-/* ── Render a command group's subcommands ── */
-function CommandGroupContent({ group }: { group: CommandGroup }) {
-  const lines = group.commands.map((cmd) => {
-    const shortName = cmd.name;
-    const paddedName = shortName.padEnd(40);
-    return `${paddedName} # ${cmd.description}`;
-  });
-  const code = lines.join("\n");
-
-  return (
-    <div className="space-y-3">
-      <CodeBlock code={code} />
-      {group.commands.length > 0 && (
-        <details className="text-sm">
-          <summary className="cursor-pointer text-muted-foreground hover:text-foreground transition-colors font-medium py-1">
-            Show detailed flags and options
-          </summary>
-          <div className="mt-3 space-y-4 pl-2 border-l-2 border-border">
-            {group.commands.map((cmd) => (
-              <SubcommandDetail key={cmd.name} cmd={cmd} />
-            ))}
-          </div>
-        </details>
-      )}
-    </div>
-  );
-}
-
-function SubcommandDetail({ cmd }: { cmd: CliCommand }) {
-  const meaningfulOptions = cmd.options
-    .split("\n")
-    .filter((l) => !l.match(/^\s*-h,\s+--help/) && l.trim())
-    .join("\n")
-    .trim();
-
-  if (!meaningfulOptions) return null;
-
-  return (
-    <div>
-      <h4 className="font-mono text-xs font-bold text-foreground mb-1">
-        {cmd.name}
-      </h4>
-      {cmd.description && (
-        <p className="text-xs text-muted-foreground mb-2">{cmd.description}</p>
-      )}
-      {meaningfulOptions && (
-        <pre className="text-[11px] font-mono text-muted-foreground bg-muted/50 rounded-lg px-3 py-2 overflow-x-auto">
-          <code>{meaningfulOptions}</code>
-        </pre>
-      )}
-    </div>
-  );
-}
-
-/* ── Standalone commands section ── */
-function StandaloneCommandsContent({
-  commands,
-}: {
-  commands: CliCommand[];
-}) {
-  const lines = commands.map((cmd) => {
-    const paddedName = cmd.name.padEnd(40);
-    return `${paddedName} # ${cmd.description}`;
-  });
-  return <CodeBlock code={lines.join("\n")} />;
-}
-
-/* ── Markdown renderer ── */
-function MarkdownContent({ content }: { content: string }) {
   const lines = content.split("\n");
   const elements: React.ReactNode[] = [];
+  const headings: TocHeading[] = [];
   let i = 0;
   let key = 0;
+  let skipFirstH1 = true;
 
   while (i < lines.length) {
     const line = lines[i];
 
-    // Skip the first H1 (already shown as section title)
-    if (line.startsWith("# ") && key === 0) {
+    // Skip the first H1
+    if (line.startsWith("# ") && skipFirstH1) {
+      skipFirstH1 = false;
       i++;
-      // Skip blank line after title
       if (i < lines.length && lines[i].trim() === "") i++;
-      // Skip the description line (already shown)
+      // Skip description line
       if (
         i < lines.length &&
         lines[i].trim() &&
@@ -285,61 +279,169 @@ function MarkdownContent({ content }: { content: string }) {
 
     // Code blocks
     if (line.startsWith("```")) {
+      const langMatch = line.match(/^```(\w+)?/);
+      const language = langMatch?.[1] || "";
       const codeLines: string[] = [];
       i++;
       while (i < lines.length && !lines[i].startsWith("```")) {
         codeLines.push(lines[i]);
         i++;
       }
-      i++; // skip closing ```
+      i++;
       const code = codeLines.join("\n");
       if (code.trim()) {
         elements.push(
-          <div key={key++} className="my-3">
-            <CodeBlock code={code} />
+          <CodeBlock key={key++} code={code} language={language} />,
+        );
+      }
+      continue;
+    }
+
+    // Tables
+    if (line.includes("|") && line.trim().startsWith("|")) {
+      const tableRows: string[] = [];
+      while (
+        i < lines.length &&
+        lines[i].includes("|") &&
+        lines[i].trim().startsWith("|")
+      ) {
+        tableRows.push(lines[i]);
+        i++;
+      }
+      if (tableRows.length >= 2) {
+        const parseRow = (row: string) =>
+          row
+            .split("|")
+            .slice(1, -1)
+            .map((c) => c.trim());
+        const headerCells = parseRow(tableRows[0]);
+        // Skip separator row (row[1])
+        const bodyRows = tableRows.slice(2).map(parseRow);
+        elements.push(
+          <div key={key++} className="my-4 overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b border-border">
+                  {headerCells.map((cell, ci) => (
+                    <th
+                      key={ci}
+                      className="text-left px-3 py-2 font-semibold text-foreground text-xs uppercase tracking-wider"
+                    >
+                      {cell}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {bodyRows.map((row, ri) => (
+                  <tr key={ri} className="border-b border-border/50">
+                    {row.map((cell, ci) => (
+                      <td
+                        key={ci}
+                        className="px-3 py-2 text-muted-foreground"
+                      >
+                        <InlineMarkdown text={cell} />
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>,
         );
       }
       continue;
     }
 
-    // Headings
+    // H2 headings
     if (line.startsWith("## ")) {
+      const text = line.replace("## ", "");
+      const id = slugify(text);
+      headings.push({ id, text, level: 2 });
+      elements.push(
+        <h2
+          key={key++}
+          id={id}
+          className="text-xl font-bold tracking-tight mt-10 mb-4 text-foreground scroll-mt-20"
+        >
+          {text}
+        </h2>,
+      );
+      i++;
+      continue;
+    }
+
+    // H3 headings
+    if (line.startsWith("### ")) {
+      const text = line.replace("### ", "");
+      const id = slugify(text);
+      headings.push({ id, text, level: 3 });
       elements.push(
         <h3
           key={key++}
-          className="text-lg font-bold tracking-tight mt-8 mb-3 text-foreground"
+          id={id}
+          className="text-base font-bold tracking-tight mt-8 mb-3 text-foreground scroll-mt-20"
         >
-          {line.replace("## ", "")}
+          {text}
         </h3>,
       );
       i++;
       continue;
     }
-    if (line.startsWith("### ")) {
+
+    // H4 headings
+    if (line.startsWith("#### ")) {
+      const text = line.replace("#### ", "");
+      const id = slugify(text);
+      headings.push({ id, text, level: 4 });
       elements.push(
         <h4
           key={key++}
-          className="text-sm font-bold tracking-tight mt-6 mb-2 text-foreground"
+          id={id}
+          className="text-sm font-bold tracking-tight mt-6 mb-2 text-foreground scroll-mt-20"
         >
-          {line.replace("### ", "")}
+          {text}
         </h4>,
       );
       i++;
       continue;
     }
 
-    // Blockquotes
+    // Blockquotes (rendered as callout boxes)
     if (line.startsWith("> ")) {
+      const quoteLines: string[] = [];
+      while (i < lines.length && lines[i].startsWith("> ")) {
+        quoteLines.push(lines[i].replace(/^>\s*/, ""));
+        i++;
+      }
+      const quoteText = quoteLines.join(" ");
+      // Detect admonition type
+      const isWarning =
+        quoteText.toLowerCase().startsWith("warning") ||
+        quoteText.toLowerCase().startsWith("caution");
+      const isTip =
+        quoteText.toLowerCase().startsWith("tip") ||
+        quoteText.toLowerCase().startsWith("note");
+      const borderColor = isWarning
+        ? "border-warning"
+        : isTip
+          ? "border-info"
+          : "border-primary/30";
+      const bgColor = isWarning
+        ? "bg-warning/5"
+        : isTip
+          ? "bg-info/5"
+          : "bg-primary/5";
       elements.push(
-        <blockquote
+        <div
           key={key++}
-          className="border-l-2 border-primary/30 pl-4 my-3 text-sm text-muted-foreground italic"
+          className={`border-l-4 ${borderColor} ${bgColor} rounded-r-lg pl-4 pr-4 py-3 my-4`}
         >
-          {line.replace(/^>\s*/, "")}
-        </blockquote>,
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            <InlineMarkdown text={quoteText} />
+          </p>
+        </div>,
       );
-      i++;
       continue;
     }
 
@@ -351,7 +453,7 @@ function MarkdownContent({ content }: { content: string }) {
         i++;
       }
       elements.push(
-        <ul key={key++} className="list-disc pl-5 my-3 space-y-1">
+        <ul key={key++} className="list-disc pl-5 my-3 space-y-1.5">
           {listItems.map((item, idx) => (
             <li
               key={idx}
@@ -373,7 +475,7 @@ function MarkdownContent({ content }: { content: string }) {
         i++;
       }
       elements.push(
-        <ol key={key++} className="list-decimal pl-5 my-3 space-y-1">
+        <ol key={key++} className="list-decimal pl-5 my-3 space-y-1.5">
           {listItems.map((item, idx) => (
             <li
               key={idx}
@@ -387,34 +489,18 @@ function MarkdownContent({ content }: { content: string }) {
       continue;
     }
 
-    // Blank lines
-    if (!line.trim()) {
+    // Horizontal rule
+    if (line.match(/^---+$/)) {
+      elements.push(
+        <hr key={key++} className="border-border my-8" />,
+      );
       i++;
       continue;
     }
 
-    // ASCII art / diagrams (lines with lots of special chars like +, |, -)
-    if (line.match(/^[\s+\-|/\\><=*#`]+$/) && line.trim().length > 3) {
-      // Collect the whole diagram block
-      const diagramLines: string[] = [line];
+    // Blank lines
+    if (!line.trim()) {
       i++;
-      while (
-        i < lines.length &&
-        (lines[i].match(/^[\s+\-|/\\><=*#`]+$/) ||
-          lines[i].match(/^\s*[|+]/) ||
-          lines[i].match(/^\s{2,}\S/))
-      ) {
-        diagramLines.push(lines[i]);
-        i++;
-      }
-      elements.push(
-        <pre
-          key={key++}
-          className="my-3 text-[11px] font-mono text-muted-foreground bg-muted/50 rounded-lg px-4 py-3 overflow-x-auto"
-        >
-          <code>{diagramLines.join("\n")}</code>
-        </pre>,
-      );
       continue;
     }
 
@@ -430,130 +516,405 @@ function MarkdownContent({ content }: { content: string }) {
     i++;
   }
 
-  return <div>{elements}</div>;
+  // Report headings for TOC
+  useEffect(() => {
+    if (onHeadings) {
+      onHeadings(headings);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [content]);
+
+  return <div className="docs-content">{elements}</div>;
 }
 
-/* ── Inline markdown (bold, code, links) ── */
-function InlineMarkdown({ text }: { text: string }) {
-  // Split on inline code, bold, and links
-  const parts: React.ReactNode[] = [];
-  let remaining = text;
-  let partKey = 0;
+/* ═══════════════════════════════════════════════════════════════════
+   CLI COMMAND CONTENT
+   ═══════════════════════════════════════════════════════════════════ */
 
-  while (remaining.length > 0) {
-    // Inline code
-    const codeMatch = remaining.match(/^(.*?)`([^`]+)`(.*)$/);
-    // Bold
-    const boldMatch = remaining.match(/^(.*?)\*\*([^*]+)\*\*(.*)$/);
-    // Links
-    const linkMatch = remaining.match(/^(.*?)\[([^\]]+)\]\(([^)]+)\)(.*)$/);
-
-    // Find the earliest match
-    let earliest: {
-      type: string;
-      pre: string;
-      content: string;
-      post: string;
-      href?: string;
-    } | null = null;
-    let earliestIdx = Infinity;
-
-    if (codeMatch && codeMatch[1].length < earliestIdx) {
-      earliestIdx = codeMatch[1].length;
-      earliest = {
-        type: "code",
-        pre: codeMatch[1],
-        content: codeMatch[2],
-        post: codeMatch[3],
-      };
-    }
-    if (boldMatch && boldMatch[1].length < earliestIdx) {
-      earliestIdx = boldMatch[1].length;
-      earliest = {
-        type: "bold",
-        pre: boldMatch[1],
-        content: boldMatch[2],
-        post: boldMatch[3],
-      };
-    }
-    if (linkMatch && linkMatch[1].length < earliestIdx) {
-      earliestIdx = linkMatch[1].length;
-      earliest = {
-        type: "link",
-        pre: linkMatch[1],
-        content: linkMatch[2],
-        post: linkMatch[4],
-        href: linkMatch[3],
-      };
-    }
-
-    if (!earliest) {
-      parts.push(<span key={partKey++}>{remaining}</span>);
-      break;
-    }
-
-    if (earliest.pre) {
-      parts.push(<span key={partKey++}>{earliest.pre}</span>);
-    }
-
-    if (earliest.type === "code") {
-      parts.push(
-        <code
-          key={partKey++}
-          className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono text-primary"
-        >
-          {earliest.content}
-        </code>,
-      );
-    } else if (earliest.type === "bold") {
-      parts.push(
-        <strong key={partKey++} className="font-semibold text-foreground">
-          {earliest.content}
-        </strong>,
-      );
-    } else if (earliest.type === "link") {
-      parts.push(
-        <span
-          key={partKey++}
-          className="text-primary/80"
-        >
-          {earliest.content}
-        </span>,
-      );
-    }
-
-    remaining = earliest.post;
-  }
-
-  return <>{parts}</>;
-}
-
-/* ── Article card for doc sections ── */
-function ArticleCard({
-  title,
-  description,
-  onClick,
+function CliGroupContent({
+  group,
+  onHeadings,
 }: {
-  title: string;
-  description: string;
-  onClick: () => void;
+  group: CommandGroup;
+  onHeadings?: (headings: TocHeading[]) => void;
 }) {
+  const headings: TocHeading[] = [
+    { id: "commands", text: "Commands", level: 2 },
+  ];
+
+  useEffect(() => {
+    if (onHeadings) {
+      onHeadings(headings);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [group.id]);
+
   return (
-    <button
-      onClick={onClick}
-      className="w-full text-left rounded-xl border border-border bg-card p-4 transition-colors hover:border-primary/20 hover:bg-accent/30"
-    >
-      <h4 className="font-semibold text-sm mb-1">{title}</h4>
-      {description && (
-        <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
-          {description}
+    <div>
+      <p className="text-sm text-muted-foreground mb-6">{group.description}</p>
+      {group.alias && (
+        <p className="text-sm text-muted-foreground mb-4">
+          Alias:{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 text-[0.85em] font-mono text-primary">
+            {group.alias}
+          </code>
         </p>
       )}
-    </button>
+      <h2
+        id="commands"
+        className="text-xl font-bold tracking-tight mt-8 mb-4 text-foreground scroll-mt-20"
+      >
+        Commands
+      </h2>
+      <div className="space-y-4">
+        {group.commands.map((cmd) => (
+          <CliCommandCard key={cmd.name} cmd={cmd} />
+        ))}
+      </div>
+    </div>
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════ */
+function CliCommandContent({
+  cmd,
+  onHeadings,
+}: {
+  cmd: CliCommand;
+  onHeadings?: (headings: TocHeading[]) => void;
+}) {
+  const headings: TocHeading[] = [];
+  if (cmd.usage) headings.push({ id: "usage", text: "Usage", level: 2 });
+  if (cmd.options) headings.push({ id: "options", text: "Options", level: 2 });
+  if (cmd.subcommands.length > 0)
+    headings.push({ id: "see-also", text: "See Also", level: 2 });
+
+  useEffect(() => {
+    if (onHeadings) {
+      onHeadings(headings);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cmd.name]);
+
+  return (
+    <div>
+      <p className="text-sm text-muted-foreground mb-6">{cmd.description}</p>
+      {cmd.synopsis && (
+        <p className="text-sm text-muted-foreground mb-4">{cmd.synopsis}</p>
+      )}
+      {cmd.usage && (
+        <>
+          <h2
+            id="usage"
+            className="text-xl font-bold tracking-tight mt-8 mb-4 text-foreground scroll-mt-20"
+          >
+            Usage
+          </h2>
+          <CodeBlock code={cmd.usage} language="bash" />
+        </>
+      )}
+      {cmd.options && (
+        <>
+          <h2
+            id="options"
+            className="text-xl font-bold tracking-tight mt-8 mb-4 text-foreground scroll-mt-20"
+          >
+            Options
+          </h2>
+          <CodeBlock code={cmd.options} />
+        </>
+      )}
+      {cmd.inheritedOptions && (
+        <>
+          <h3 className="text-base font-bold tracking-tight mt-6 mb-3 text-foreground">
+            Inherited Options
+          </h3>
+          <CodeBlock code={cmd.inheritedOptions} />
+        </>
+      )}
+      {cmd.subcommands.length > 0 && (
+        <>
+          <h2
+            id="see-also"
+            className="text-xl font-bold tracking-tight mt-8 mb-4 text-foreground scroll-mt-20"
+          >
+            See Also
+          </h2>
+          <ul className="list-disc pl-5 space-y-1.5">
+            {cmd.subcommands.map((sub) => (
+              <li
+                key={sub.name}
+                className="text-sm text-muted-foreground leading-relaxed"
+              >
+                <code className="rounded bg-muted px-1.5 py-0.5 text-[0.85em] font-mono text-primary">
+                  {sub.name}
+                </code>{" "}
+                — {sub.description}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </div>
+  );
+}
+
+function CliCommandCard({ cmd }: { cmd: CliCommand }) {
+  const [expanded, setExpanded] = useState(false);
+  const meaningfulOptions = cmd.options
+    .split("\n")
+    .filter((l) => !l.match(/^\s*-h,\s+--help/) && l.trim())
+    .join("\n")
+    .trim();
+
+  return (
+    <div className="rounded-lg border border-border overflow-hidden">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-accent/30 transition-colors"
+        aria-expanded={expanded}
+      >
+        <div className="flex items-center gap-3">
+          <code className="text-sm font-mono font-semibold text-foreground">
+            {cmd.name}
+          </code>
+          <span className="text-xs text-muted-foreground">
+            {cmd.description}
+          </span>
+        </div>
+        <ChevronDown
+          className={`h-4 w-4 text-muted-foreground transition-transform ${expanded ? "rotate-180" : ""}`}
+          aria-hidden="true"
+        />
+      </button>
+      {expanded && (
+        <div className="border-t border-border px-4 py-3 bg-accent/10">
+          {cmd.usage && (
+            <CodeBlock code={cmd.usage} language="bash" title="Usage" />
+          )}
+          {meaningfulOptions && (
+            <div className="mt-2">
+              <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2">
+                Options
+              </div>
+              <pre className="text-[12px] font-mono text-muted-foreground bg-[#0C0A08] rounded-lg px-3 py-2 overflow-x-auto">
+                <code>{meaningfulOptions}</code>
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PLACEHOLDER CONTENT
+   ═══════════════════════════════════════════════════════════════════ */
+
+function PlaceholderContent({ label }: { label: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <Construction
+        className="h-12 w-12 text-muted-foreground/30 mb-4"
+        aria-hidden="true"
+      />
+      <h2 className="text-lg font-semibold text-foreground mb-2">{label}</h2>
+      <p className="text-sm text-muted-foreground max-w-md">
+        This page is under construction. Check back soon or contribute on{" "}
+        <a
+          href="https://github.com/rpuneet/bc"
+          className="text-primary hover:underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub
+        </a>
+        .
+      </p>
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   TABLE OF CONTENTS (right sidebar)
+   ═══════════════════════════════════════════════════════════════════ */
+
+function TableOfContents({ headings }: { headings: TocHeading[] }) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setActiveId(entry.target.id);
+          }
+        }
+      },
+      { rootMargin: "-80px 0px -70% 0px" },
+    );
+
+    for (const h of headings) {
+      const el = document.getElementById(h.id);
+      if (el) observer.observe(el);
+    }
+
+    return () => observer.disconnect();
+  }, [headings]);
+
+  if (headings.length === 0) return null;
+
+  return (
+    <nav aria-label="Table of contents" className="text-xs">
+      <div className="font-semibold text-foreground mb-3 text-xs uppercase tracking-wider">
+        On this page
+      </div>
+      <ul className="space-y-1.5">
+        {headings.map((h) => (
+          <li key={h.id} style={{ paddingLeft: `${(h.level - 2) * 12}px` }}>
+            <a
+              href={`#${h.id}`}
+              className={`block py-0.5 transition-colors ${
+                activeId === h.id
+                  ? "text-primary font-medium"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {h.text}
+            </a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   SIDEBAR NAV SECTION
+   ═══════════════════════════════════════════════════════════════════ */
+
+function SidebarSection({
+  section,
+  activeItemId,
+  onItemClick,
+  defaultOpen,
+}: {
+  section: NavSection;
+  activeItemId: string | null;
+  onItemClick: (item: NavItem) => void;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const Icon = section.icon;
+  const isActive = section.items.some((item) => item.id === activeItemId);
+
+  return (
+    <div className="mb-1">
+      <button
+        onClick={() => setOpen(!open)}
+        className={`flex w-full items-center gap-2 px-3 py-2 text-left text-sm rounded-md transition-colors ${
+          isActive
+            ? "text-foreground font-medium"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+        aria-expanded={open}
+      >
+        {open ? (
+          <ChevronDown className="h-3 w-3 shrink-0" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="h-3 w-3 shrink-0" aria-hidden="true" />
+        )}
+        <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span className="font-medium">{section.label}</span>
+      </button>
+      {open && (
+        <div className="ml-4 pl-3 border-l border-border/50 mt-0.5">
+          {section.items.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => onItemClick(item)}
+              className={`block w-full text-left px-3 py-1.5 text-[13px] rounded-md transition-colors ${
+                activeItemId === item.id
+                  ? "text-primary bg-primary/5 border-l-2 border-primary -ml-[1px] font-medium"
+                  : "text-muted-foreground hover:text-foreground hover:bg-accent/30"
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   PREVIOUS / NEXT NAVIGATION
+   ═══════════════════════════════════════════════════════════════════ */
+
+function PrevNextNav({
+  allItems,
+  activeItemId,
+  onNavigate,
+}: {
+  allItems: NavItem[];
+  activeItemId: string | null;
+  onNavigate: (item: NavItem) => void;
+}) {
+  const currentIdx = allItems.findIndex((item) => item.id === activeItemId);
+  const prev = currentIdx > 0 ? allItems[currentIdx - 1] : null;
+  const next =
+    currentIdx < allItems.length - 1 ? allItems[currentIdx + 1] : null;
+
+  if (!prev && !next) return null;
+
+  return (
+    <div className="flex items-center justify-between mt-12 pt-6 border-t border-border">
+      {prev ? (
+        <button
+          onClick={() => onNavigate(prev)}
+          className="group flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ChevronRight
+            className="h-4 w-4 rotate-180 group-hover:-translate-x-0.5 transition-transform"
+            aria-hidden="true"
+          />
+          <div className="text-left">
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+              Previous
+            </div>
+            <div className="font-medium">{prev.label}</div>
+          </div>
+        </button>
+      ) : (
+        <div />
+      )}
+      {next ? (
+        <button
+          onClick={() => onNavigate(next)}
+          className="group flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors text-right"
+        >
+          <div>
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+              Next
+            </div>
+            <div className="font-medium">{next.label}</div>
+          </div>
+          <ChevronRight
+            className="h-4 w-4 group-hover:translate-x-0.5 transition-transform"
+            aria-hidden="true"
+          />
+        </button>
+      ) : (
+        <div />
+      )}
+    </div>
+  );
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   MAIN DOCS CONTENT
+   ═══════════════════════════════════════════════════════════════════ */
 
 export default function DocsContent({
   groups,
@@ -564,604 +925,436 @@ export default function DocsContent({
   standalone: CliCommand[];
   sections: DocsSection[];
 }) {
+  const [tocHeadings, setTocHeadings] = useState<TocHeading[]>([]);
   const [search, setSearch] = useState("");
-  const [activeSection, setActiveSection] = useState<string | null>(null);
-  const [activeArticle, setActiveArticle] = useState<string | null>(null);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const initializedRef = useRef(false);
 
-  // Build searchable index for CLI commands
-  const searchableGroups = useMemo(() => {
-    return groups.map((g) => ({
-      ...g,
-      keywords: [
-        g.name,
-        g.alias,
-        g.description,
-        ...g.commands.map((c) => c.name),
-        ...g.commands.map((c) => c.description),
-      ]
-        .join(" ")
-        .toLowerCase(),
-    }));
-  }, [groups]);
+  // Build navigation structure
+  const navSections: NavSection[] = useMemo(() => {
+    const result: NavSection[] = [];
 
-  const filteredGroupIds = useMemo(() => {
-    if (!search.trim()) return searchableGroups.map((g) => g.id);
+    // Getting Started / Tutorials
+    const tutorials = sections.find((s) => s.id === "tutorials");
+    if (tutorials && tutorials.articles.length > 0) {
+      result.push({
+        id: "tutorials",
+        label: "Getting Started",
+        icon: BookOpen,
+        items: tutorials.articles.map((a) => ({
+          id: `tutorials/${a.slug}`,
+          label: a.title,
+          type: "article" as const,
+          sectionId: "tutorials",
+          content: a.content,
+          description: a.description,
+        })),
+      });
+    }
+
+    // How-To Guides
+    const howto = sections.find((s) => s.id === "how-to");
+    if (howto && howto.articles.length > 0) {
+      result.push({
+        id: "how-to",
+        label: "How-To Guides",
+        icon: Compass,
+        items: howto.articles.map((a) => ({
+          id: `how-to/${a.slug}`,
+          label: a.title,
+          type: "article" as const,
+          sectionId: "how-to",
+          content: a.content,
+          description: a.description,
+        })),
+      });
+    }
+
+    // CLI Reference
+    const cliItems: NavItem[] = [];
+    for (const group of groups) {
+      cliItems.push({
+        id: `cli/${group.name}`,
+        label: `bc ${group.name}`,
+        type: "cli-group",
+        sectionId: "cli",
+        cliGroup: group,
+      });
+    }
+    // Add standalone commands
+    for (const cmd of standalone) {
+      cliItems.push({
+        id: `cli/${cmd.name.replace(/\s+/g, "-")}`,
+        label: cmd.name,
+        type: "cli-command",
+        sectionId: "cli",
+        cliCommand: cmd,
+      });
+    }
+    if (cliItems.length > 0) {
+      result.push({
+        id: "cli",
+        label: "CLI Reference",
+        icon: Terminal,
+        items: cliItems,
+      });
+    }
+
+    // API Reference
+    const reference = sections.find((s) => s.id === "reference");
+    if (reference && reference.articles.length > 0) {
+      result.push({
+        id: "reference",
+        label: "API Reference",
+        icon: FileText,
+        items: reference.articles.map((a) => ({
+          id: `reference/${a.slug}`,
+          label: a.title,
+          type: "article" as const,
+          sectionId: "reference",
+          content: a.content,
+          description: a.description,
+        })),
+      });
+    }
+
+    // Architecture / Explanation
+    const explanation = sections.find((s) => s.id === "explanation");
+    if (explanation && explanation.articles.length > 0) {
+      result.push({
+        id: "explanation",
+        label: "Architecture",
+        icon: Lightbulb,
+        items: explanation.articles.map((a) => ({
+          id: `explanation/${a.slug}`,
+          label: a.title,
+          type: "article" as const,
+          sectionId: "explanation",
+          content: a.content,
+          description: a.description,
+        })),
+      });
+    }
+
+    // Placeholder sections
+    result.push({
+      id: "contributing",
+      label: "Contributing",
+      icon: FileText,
+      items: [
+        {
+          id: "contributing/guide",
+          label: "Contributing Guide",
+          type: "placeholder" as const,
+          sectionId: "contributing",
+        },
+      ],
+    });
+
+    result.push({
+      id: "release-notes",
+      label: "Release Notes",
+      icon: FileText,
+      items: [
+        {
+          id: "release-notes/latest",
+          label: "Latest Release",
+          type: "placeholder" as const,
+          sectionId: "release-notes",
+        },
+      ],
+    });
+
+    return result;
+  }, [sections, groups, standalone]);
+
+  // Flatten all items for prev/next nav
+  const allItems = useMemo(() => {
+    return navSections.flatMap((s) => s.items);
+  }, [navSections]);
+
+  // Compute initial active item from URL hash or default to first item
+  const defaultItemId = useMemo(() => {
+    if (typeof window === "undefined" || allItems.length === 0) {
+      return allItems[0]?.id ?? null;
+    }
+    const hash = window.location.hash.slice(1);
+    if (hash) {
+      const matchingItem = allItems.find(
+        (item) => item.id === hash || item.id === decodeURIComponent(hash),
+      );
+      if (matchingItem) return matchingItem.id;
+    }
+    return allItems[0]?.id ?? null;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const [activeItemId, setActiveItemId] = useState<string | null>(
+    defaultItemId,
+  );
+
+  // On first render in the browser, check hash if SSR couldn't
+  if (!initializedRef.current && activeItemId === null && allItems.length > 0) {
+    initializedRef.current = true;
+    const hash =
+      typeof window !== "undefined" ? window.location.hash.slice(1) : "";
+    if (hash) {
+      const matchingItem = allItems.find(
+        (item) => item.id === hash || item.id === decodeURIComponent(hash),
+      );
+      if (matchingItem) {
+        setActiveItemId(matchingItem.id);
+      } else {
+        setActiveItemId(allItems[0].id);
+      }
+    } else {
+      setActiveItemId(allItems[0].id);
+    }
+  }
+
+  // Update URL hash when active item changes
+  useEffect(() => {
+    if (activeItemId) {
+      window.history.replaceState(null, "", `#${activeItemId}`);
+    }
+  }, [activeItemId]);
+
+  // Find active item
+  const activeItem = useMemo(() => {
+    return allItems.find((item) => item.id === activeItemId) ?? null;
+  }, [allItems, activeItemId]);
+
+  // Search filtering
+  const filteredSections = useMemo(() => {
+    if (!search.trim()) return navSections;
     const q = search.toLowerCase();
-    return searchableGroups
-      .filter((g) => g.keywords.includes(q))
-      .map((g) => g.id);
-  }, [search, searchableGroups]);
+    return navSections
+      .map((section) => ({
+        ...section,
+        items: section.items.filter(
+          (item) =>
+            item.label.toLowerCase().includes(q) ||
+            item.description?.toLowerCase().includes(q) ||
+            item.sectionId.toLowerCase().includes(q),
+        ),
+      }))
+      .filter((section) => section.items.length > 0);
+  }, [navSections, search]);
 
-  const isVisible = (id: string) => filteredGroupIds.includes(id);
+  const handleItemClick = useCallback(
+    (item: NavItem) => {
+      setActiveItemId(item.id);
+      setMobileNavOpen(false);
+      // Scroll content to top
+      const contentEl = document.getElementById("docs-content-area");
+      if (contentEl) {
+        contentEl.scrollTo({ top: 0, behavior: "smooth" });
+      }
+    },
+    [],
+  );
 
-  // Find active article content
-  const activeArticleData = useMemo(() => {
-    if (!activeSection || !activeArticle) return null;
-    const section = sections.find((s) => s.id === activeSection);
-    if (!section) return null;
-    return section.articles.find((a) => a.slug === activeArticle) ?? null;
-  }, [sections, activeSection, activeArticle]);
+  const handleHeadings = useCallback((headings: TocHeading[]) => {
+    setTocHeadings(headings);
+  }, []);
 
-  // Section navigation items
-  const sectionNav = [
-    { id: "tutorials", label: "Tutorials" },
-    { id: "how-to", label: "How-To" },
-    { id: "reference", label: "Reference" },
-    { id: "explanation", label: "Explanation" },
-  ];
+  // Render active content
+  const renderContent = () => {
+    if (!activeItem) {
+      return (
+        <div className="text-center py-16 text-muted-foreground">
+          <p>Select a page from the sidebar.</p>
+        </div>
+      );
+    }
+
+    if (activeItem.type === "placeholder") {
+      return <PlaceholderContent label={activeItem.label} />;
+    }
+
+    if (activeItem.type === "cli-group" && activeItem.cliGroup) {
+      return (
+        <CliGroupContent
+          group={activeItem.cliGroup}
+          onHeadings={handleHeadings}
+        />
+      );
+    }
+
+    if (activeItem.type === "cli-command" && activeItem.cliCommand) {
+      return (
+        <CliCommandContent
+          cmd={activeItem.cliCommand}
+          onHeadings={handleHeadings}
+        />
+      );
+    }
+
+    if (activeItem.type === "article" && activeItem.content) {
+      return (
+        <MarkdownContent
+          content={activeItem.content}
+          onHeadings={handleHeadings}
+        />
+      );
+    }
+
+    return <PlaceholderContent label={activeItem.label} />;
+  };
+
+  // Get title for active item
+  const getTitle = () => {
+    if (!activeItem) return "Documentation";
+    if (activeItem.type === "cli-group" && activeItem.cliGroup) {
+      return `bc ${activeItem.cliGroup.name}`;
+    }
+    if (activeItem.type === "cli-command" && activeItem.cliCommand) {
+      return activeItem.cliCommand.name;
+    }
+    return activeItem.label;
+  };
+
+  const getDescription = () => {
+    if (!activeItem) return "";
+    if (activeItem.type === "cli-group" && activeItem.cliGroup) {
+      return activeItem.cliGroup.description;
+    }
+    if (activeItem.type === "cli-command" && activeItem.cliCommand) {
+      return activeItem.cliCommand.description;
+    }
+    return activeItem.description || "";
+  };
 
   return (
     <main className="min-h-screen selection:bg-primary/20 selection:text-foreground overflow-x-hidden">
-      <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_-20%,rgba(234,88,12,0.04),transparent)] dark:bg-[radial-gradient(ellipse_80%_60%_at_50%_-20%,rgba(234,88,12,0.08),transparent)]" />
-
       <Nav />
 
-      <div className="mx-auto max-w-5xl px-6 py-16 lg:py-24">
-        {/* ═══════════════════ HEADER ═══════════════════ */}
-        <div className="mb-12">
-          <span className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Documentation
-          </span>
-          <h1 className="mt-3 text-4xl font-bold tracking-tight sm:text-6xl">
-            Documentation
-          </h1>
-          <p className="mt-4 max-w-2xl text-lg text-muted-foreground leading-relaxed">
-            Everything you need to orchestrate AI agents from your terminal.
-            CLI-first with a Web UI companion at localhost:9374.
-          </p>
-        </div>
-
-        {/* ═══════════════════ SEARCH ═══════════════════ */}
-        <div className="sticky top-0 z-20 -mx-6 px-6 py-4 bg-background/80 backdrop-blur-xl border-b border-border/50 mb-12">
-          <div className="relative max-w-xl">
-            <Search
-              className="absolute left-4 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground"
-              aria-hidden="true"
-            />
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search commands, features, or aliases..."
-              className="h-12 w-full rounded-xl border border-border bg-card pl-11 pr-4 text-sm font-mono outline-none transition-all placeholder:text-muted-foreground/50 focus:border-primary/50 focus:ring-2 focus:ring-primary/10"
-            />
-            {search && (
-              <button
-                onClick={() => setSearch("")}
-                className="absolute right-4 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground"
-              >
-                Clear
-              </button>
-            )}
-          </div>
-          {search && (
-            <p className="mt-2 text-xs text-muted-foreground">
-              {filteredGroupIds.length}{" "}
-              {filteredGroupIds.length === 1 ? "group" : "groups"} matching
-              &quot;{search}&quot;
-            </p>
+      {/* Mobile nav toggle */}
+      <div className="lg:hidden sticky top-0 z-40 border-b border-border bg-background/95 backdrop-blur-sm px-4 py-3 flex items-center gap-3">
+        <button
+          onClick={() => setMobileNavOpen(!mobileNavOpen)}
+          className="p-2 rounded-md hover:bg-accent/30 transition-colors"
+          aria-label="Toggle navigation"
+        >
+          {mobileNavOpen ? (
+            <X className="h-5 w-5" />
+          ) : (
+            <Menu className="h-5 w-5" />
           )}
-        </div>
+        </button>
+        <span className="text-sm font-medium truncate">
+          {getTitle()}
+        </span>
+      </div>
 
-        {/* ═══════════════════ SECTION NAV ═══════════════════ */}
-        {!search && (
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-12">
-            {sectionNav.map((nav) => {
-              const Icon = SECTION_ICONS[nav.id] || FileText;
-              const section = sections.find((s) => s.id === nav.id);
-              const count = section?.articles.length ?? 0;
-              return (
-                <a
-                  key={nav.id}
-                  href={`#section-${nav.id}`}
-                  className="group rounded-xl border border-border bg-card p-4 transition-colors hover:border-primary/30 hover:bg-accent/30"
-                >
-                  <Icon
-                    className="h-5 w-5 text-primary/60 mb-2 group-hover:text-primary transition-colors"
+      <div className="flex min-h-[calc(100vh-64px)]">
+        {/* ═══ LEFT SIDEBAR ═══ */}
+        <aside
+          className={`${
+            mobileNavOpen
+              ? "fixed inset-0 top-[105px] z-30 bg-background"
+              : "hidden"
+          } lg:block lg:sticky lg:top-0 lg:h-screen w-full lg:w-[260px] xl:w-[280px] shrink-0 border-r border-border overflow-y-auto`}
+        >
+          <div className="p-4 pt-20 lg:pt-6">
+            {/* Search */}
+            <div className="relative mb-5">
+              <Search
+                className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search docs..."
+                className="h-9 w-full rounded-lg border border-border bg-card pl-9 pr-3 text-sm outline-none transition-all placeholder:text-muted-foreground/50 focus:border-primary/50 focus:ring-1 focus:ring-primary/10"
+              />
+            </div>
+
+            {/* Nav sections */}
+            <nav aria-label="Documentation navigation">
+              {filteredSections.map((section) => (
+                <SidebarSection
+                  key={section.id}
+                  section={section}
+                  activeItemId={activeItemId}
+                  onItemClick={handleItemClick}
+                  defaultOpen={
+                    section.id === "tutorials" ||
+                    section.items.some((item) => item.id === activeItemId)
+                  }
+                />
+              ))}
+              {search && filteredSections.length === 0 && (
+                <div className="text-center py-8 text-muted-foreground">
+                  <Search
+                    className="h-6 w-6 mx-auto mb-2 opacity-30"
                     aria-hidden="true"
                   />
-                  <div className="font-semibold text-sm">{nav.label}</div>
-                  <div className="text-xs text-muted-foreground mt-0.5">
-                    {count} {count === 1 ? "article" : "articles"}
-                  </div>
-                </a>
-              );
-            })}
-          </div>
-        )}
-
-        {/* ═══════════════════ NAV PILLS ═══════════════════ */}
-        {!search && (
-          <div className="flex flex-wrap gap-2 mb-12">
-            {[
-              { href: "#quickstart", label: "Quick Start" },
-              { href: "#section-tutorials", label: "Tutorials" },
-              { href: "#section-how-to", label: "How-To Guides" },
-              { href: "#section-reference", label: "Reference" },
-              { href: "#section-explanation", label: "Explanation" },
-              { href: "#commands", label: "CLI Commands" },
-              { href: "#aliases", label: "Aliases" },
-              { href: "#config", label: "Configuration" },
-              { href: "#env", label: "Env Vars" },
-            ].map((link) => (
-              <a
-                key={link.href}
-                href={link.href}
-                className="rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-mono font-semibold text-muted-foreground hover:text-foreground hover:border-primary/30 transition-colors"
-              >
-                {link.label}
-              </a>
-            ))}
-          </div>
-        )}
-
-        <div className="space-y-20">
-          {/* ═══════════════════ QUICK START ═══════════════════ */}
-          {!search && (
-            <RevealSection id="quickstart">
-              <h2 className="text-2xl font-bold tracking-tight mb-6">
-                Quick Start
-              </h2>
-              <TerminalWindow title="quickstart">
-                <CommandOutput
-                  command="bc init"
-                  lines={[
-                    {
-                      text: "Initializing bc workspace...",
-                      color: "text-terminal-muted",
-                    },
-                    {
-                      text: "Created .bc/settings.toml",
-                      color: "text-terminal-muted",
-                    },
-                    { text: "Ready.", color: "text-terminal-success" },
-                  ]}
-                />
-                <div className="mt-4">
-                  <CommandOutput
-                    command="bc daemon start"
-                    delay={0.3}
-                    lines={[
-                      {
-                        text: "Starting bcd server...",
-                        color: "text-terminal-muted",
-                      },
-                      {
-                        text: "  \u2713 Daemon running on localhost:9374",
-                        color: "text-terminal-success",
-                      },
-                    ]}
-                  />
-                </div>
-                <div className="mt-4">
-                  <CommandOutput
-                    command='bc agent create eng-01 --role engineer'
-                    delay={0.6}
-                    lines={[
-                      {
-                        text: "Creating agent eng-01...",
-                        color: "text-terminal-muted",
-                      },
-                      {
-                        text: "  \u2713 eng-01  engineer  created",
-                        color: "text-terminal-success",
-                      },
-                    ]}
-                  />
-                </div>
-                <div className="mt-4">
-                  <CommandOutput
-                    command="bc agent start eng-01"
-                    delay={0.9}
-                    lines={[
-                      {
-                        text: "Starting agent eng-01...",
-                        color: "text-terminal-muted",
-                      },
-                      {
-                        text: "  \u2713 eng-01  engineer  working",
-                        color: "text-terminal-success",
-                      },
-                      {
-                        text: "1 agent active.",
-                        color: "text-terminal-muted",
-                      },
-                    ]}
-                  />
-                </div>
-              </TerminalWindow>
-            </RevealSection>
-          )}
-
-          {/* ═══════════════════ INSTALLATION ═══════════════════ */}
-          {!search && (
-            <RevealSection id="installation">
-              <h2 className="text-2xl font-bold tracking-tight mb-6">
-                Installation
-              </h2>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <CodeBlock
-                  title="Go Install"
-                  code="go install github.com/rpuneet/bc/cmd/bc@latest"
-                />
-                <CodeBlock
-                  title="Build from Source"
-                  code={`git clone https://github.com/rpuneet/bc.git
-cd bc && make build`}
-                />
-              </div>
-              <p className="mt-4 text-sm text-muted-foreground">
-                Verify installation:{" "}
-                <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
-                  bc doctor
-                </code>
-              </p>
-            </RevealSection>
-          )}
-
-          {/* ═══════════════════ DIATAXIS SECTIONS ═══════════════════ */}
-          {!search &&
-            sections.map((section) => {
-              const Icon = SECTION_ICONS[section.id] || FileText;
-              return (
-                <RevealSection key={section.id} id={`section-${section.id}`}>
-                  <div className="flex items-center gap-3 mb-2">
-                    <Icon
-                      className="h-5 w-5 text-primary/60"
-                      aria-hidden="true"
-                    />
-                    <h2 className="text-2xl font-bold tracking-tight">
-                      {section.label}
-                    </h2>
-                  </div>
-                  <p className="text-sm text-muted-foreground mb-6">
-                    {section.description}
-                  </p>
-
-                  {/* Article list or expanded article */}
-                  {activeSection === section.id && activeArticleData ? (
-                    <div>
-                      <button
-                        onClick={() => {
-                          setActiveSection(null);
-                          setActiveArticle(null);
-                        }}
-                        className="mb-4 text-xs text-primary hover:underline font-medium"
-                      >
-                        Back to {section.label}
-                      </button>
-                      <div className="rounded-xl border border-border bg-card p-6">
-                        <h3 className="text-xl font-bold tracking-tight mb-1">
-                          {activeArticleData.title}
-                        </h3>
-                        {activeArticleData.description && (
-                          <p className="text-sm text-muted-foreground mb-4">
-                            {activeArticleData.description}
-                          </p>
-                        )}
-                        <div className="border-t border-border pt-4">
-                          <MarkdownContent
-                            content={activeArticleData.content}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  ) : (
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      {section.articles.map((article) => (
-                        <ArticleCard
-                          key={article.slug}
-                          title={article.title}
-                          description={article.description}
-                          onClick={() => {
-                            setActiveSection(section.id);
-                            setActiveArticle(article.slug);
-                            // Scroll to section
-                            document
-                              .getElementById(`section-${section.id}`)
-                              ?.scrollIntoView({ behavior: "smooth" });
-                          }}
-                        />
-                      ))}
-                    </div>
-                  )}
-                </RevealSection>
-              );
-            })}
-
-          {/* ═══════════════════ CORE CONCEPTS ═══════════════════ */}
-          {!search && (
-            <RevealSection id="concepts">
-              <h2 className="text-2xl font-bold tracking-tight mb-6">
-                Core Concepts
-              </h2>
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                <ConceptCard
-                  icon={Layers}
-                  title="Workspaces"
-                  desc="The .bc/ directory stores config, roles, agents, memory, and channel history. Managed via bc ws."
-                />
-                <ConceptCard
-                  icon={Users}
-                  title="Agents"
-                  desc="AI instances with roles, tools, and states. Lifecycle: create \u2192 start \u2192 work \u2192 stop \u2192 delete."
-                />
-                <ConceptCard
-                  icon={MessageSquare}
-                  title="Channels"
-                  desc="Structured coordination. Default: #eng, #pr, #standup, #leads. Supports @mentions and reactions."
-                />
-                <ConceptCard
-                  icon={GitBranch}
-                  title="Worktrees"
-                  desc="Each agent gets an isolated git worktree. Zero merge conflicts by design."
-                />
-                <ConceptCard
-                  icon={Brain}
-                  title="Memory"
-                  desc="Learnings (permanent) + Experiences (time-stamped). Injected on agent spawn across sessions."
-                />
-                <ConceptCard
-                  icon={Key}
-                  title="Secrets"
-                  desc="Encrypted credential management. macOS Keychain, Linux libsecret, or AES-256-GCM fallback."
-                />
-                <ConceptCard
-                  icon={DollarSign}
-                  title="Cost Tracking"
-                  desc="Per-agent token costs, budgets with alerts, and hard stops to prevent runaway spend."
-                />
-                <ConceptCard
-                  icon={Clock}
-                  title="Cron Jobs"
-                  desc="Schedule recurring tasks with familiar cron syntax. Automate tests, deploys, reports."
-                />
-                <ConceptCard
-                  icon={Server}
-                  title="Daemon"
-                  desc="Persistent bcd server. Eliminates write contention, enables the Web UI at localhost:9374."
-                />
-              </div>
-            </RevealSection>
-          )}
-
-          {/* ═══════════════════ COMMAND REFERENCE ═══════════════════ */}
-          <RevealSection id="commands">
-            {!search && (
-              <h2 className="text-2xl font-bold tracking-tight mb-6">
-                CLI Command Reference
-              </h2>
-            )}
-            <div className="space-y-3">
-              {groups.map((group) => {
-                const Icon = GROUP_ICONS[group.name.toLowerCase()] || Terminal;
-                return (
-                  <CollapsibleSection
-                    key={group.id}
-                    id={group.id}
-                    title={group.name.charAt(0).toUpperCase() + group.name.slice(1)}
-                    alias={group.alias}
-                    count={group.commands.length}
-                    icon={Icon}
-                    visible={isVisible(group.id)}
-                    defaultOpen={!!search}
-                  >
-                    <CommandGroupContent group={group} />
-                  </CollapsibleSection>
-                );
-              })}
-
-              {/* Standalone commands */}
-              {standalone.length > 0 && (
-                <CollapsibleSection
-                  id="cmd-misc"
-                  title="Other Commands"
-                  count={standalone.length}
-                  icon={Terminal}
-                  visible={!search || filteredGroupIds.length === 0}
-                  defaultOpen={!!search}
-                >
-                  <StandaloneCommandsContent commands={standalone} />
-                </CollapsibleSection>
-              )}
-
-              {search && filteredGroupIds.length === 0 && (
-                <div className="text-center py-12 text-muted-foreground">
-                  <Search className="h-8 w-8 mx-auto mb-3 opacity-30" />
-                  <p className="text-sm">
-                    No commands matching &quot;{search}&quot;
-                  </p>
+                  <p className="text-xs">No results for &quot;{search}&quot;</p>
                   <button
                     onClick={() => setSearch("")}
-                    className="mt-2 text-xs text-primary hover:underline"
+                    className="mt-1 text-xs text-primary hover:underline"
                   >
                     Clear search
                   </button>
                 </div>
               )}
+            </nav>
+          </div>
+        </aside>
+
+        {/* ═══ MAIN CONTENT ═══ */}
+        <div
+          id="docs-content-area"
+          className="flex-1 min-w-0 overflow-y-auto"
+        >
+          <div className="max-w-3xl mx-auto px-6 lg:px-10 py-8 lg:py-12">
+            {/* Breadcrumb */}
+            {activeItem && (
+              <div className="text-xs text-muted-foreground mb-4 flex items-center gap-1.5">
+                <span>Docs</span>
+                <ChevronRight className="h-3 w-3" aria-hidden="true" />
+                <span>
+                  {navSections.find((s) =>
+                    s.items.some((i) => i.id === activeItemId),
+                  )?.label || ""}
+                </span>
+                <ChevronRight className="h-3 w-3" aria-hidden="true" />
+                <span className="text-foreground">{getTitle()}</span>
+              </div>
+            )}
+
+            {/* Title */}
+            <h1 className="text-3xl lg:text-4xl font-bold tracking-tight mb-2 text-foreground">
+              {getTitle()}
+            </h1>
+            {getDescription() && (
+              <p className="text-base text-muted-foreground mb-8 leading-relaxed">
+                {getDescription()}
+              </p>
+            )}
+
+            <div className="border-t border-border pt-6">
+              {renderContent()}
             </div>
-          </RevealSection>
 
-          {/* ═══════════════════ ALIASES TABLE ═══════════════════ */}
-          {!search && (
-            <RevealSection id="aliases">
-              <h2 className="text-2xl font-bold tracking-tight mb-6">
-                Command Aliases
-              </h2>
-              <p className="text-muted-foreground mb-4">
-                Every command group has a short alias for faster typing.
-              </p>
-              <div className="overflow-hidden rounded-xl border border-border">
-                <div className="grid grid-cols-3 bg-muted px-5 py-3 text-xs font-bold uppercase tracking-widest text-muted-foreground">
-                  <div>Command</div>
-                  <div>Alias</div>
-                  <div>Example</div>
-                </div>
-                {groups
-                  .filter((g) => g.alias)
-                  .map((g) => {
-                    const fullCmd = `bc ${g.name}`;
-                    const example =
-                      g.commands.length > 0
-                        ? g.commands[0].name
-                        : g.alias;
-                    return (
-                      <div
-                        key={g.id}
-                        className="grid grid-cols-3 border-t border-border px-5 py-3 text-sm"
-                      >
-                        <div className="font-mono text-[12px] text-foreground">
-                          {fullCmd}
-                        </div>
-                        <div className="font-mono text-[12px] text-primary">
-                          {g.alias}
-                        </div>
-                        <div className="font-mono text-[12px] text-muted-foreground">
-                          {example}
-                        </div>
-                      </div>
-                    );
-                  })}
-              </div>
-            </RevealSection>
-          )}
-
-          {/* ═══════════════════ CONFIGURATION ═══════════════════ */}
-          {!search && (
-            <RevealSection id="config">
-              <h2 className="text-2xl font-bold tracking-tight mb-6">
-                Configuration
-              </h2>
-              <p className="text-muted-foreground mb-4">
-                Manage config via{" "}
-                <code className="rounded bg-muted px-1.5 py-0.5 text-sm font-mono">
-                  bc config
-                </code>{" "}
-                or edit{" "}
-                <code className="rounded bg-muted px-1.5 py-0.5 text-sm font-mono">
-                  .bc/settings.toml
-                </code>{" "}
-                directly.
-              </p>
-              <CodeBlock
-                title=".bc/settings.toml"
-                code={`[workspace]
-name = "my-project"
-version = 2
-
-[user]
-nickname = "@yourname"
-
-[providers]
-default = "claude"
-
-[providers.claude]
-command = "claude"
-enabled = true
-
-[providers.gemini]
-command = "gemini"
-enabled = true
-
-[runtime]
-backend = "tmux"     # or "docker"`}
-              />
-            </RevealSection>
-          )}
-
-          {/* ═══════════════════ ENV VARS ═══════════════════ */}
-          {!search && (
-            <RevealSection id="env">
-              <h2 className="text-2xl font-bold tracking-tight mb-6">
-                Environment Variables
-              </h2>
-              <p className="text-muted-foreground mb-4">
-                Automatically set in each agent&apos;s session:
-              </p>
-              <div className="overflow-hidden rounded-xl border border-border">
-                <div className="grid grid-cols-[180px_1fr] bg-muted px-5 py-3 text-xs font-bold uppercase tracking-widest text-muted-foreground">
-                  <div>Variable</div>
-                  <div>Description</div>
-                </div>
-                {[
-                  {
-                    var: "BC_AGENT_ID",
-                    desc: "Unique identifier for the agent",
-                  },
-                  {
-                    var: "BC_AGENT_ROLE",
-                    desc: "The agent's assigned role (engineer, manager, etc.)",
-                  },
-                  {
-                    var: "BC_WORKSPACE",
-                    desc: "Path to the .bc/ workspace directory",
-                  },
-                  {
-                    var: "BC_AGENT_WORKTREE",
-                    desc: "Path to the agent's isolated git worktree",
-                  },
-                  { var: "BC_BIN", desc: "Path to the bc binary" },
-                  {
-                    var: "BC_ROOT",
-                    desc: "Root directory of the bc workspace",
-                  },
-                  {
-                    var: "NO_COLOR",
-                    desc: "Disables color output in agent sessions",
-                  },
-                ].map((e) => (
-                  <div
-                    key={e.var}
-                    className="grid grid-cols-[180px_1fr] border-t border-border px-5 py-3 text-sm"
-                  >
-                    <div className="font-mono text-[12px] text-primary">
-                      {e.var}
-                    </div>
-                    <div className="text-muted-foreground">{e.desc}</div>
-                  </div>
-                ))}
-              </div>
-            </RevealSection>
-          )}
-
-          {/* ═══════════════════ CTA ═══════════════════ */}
-          {!search && (
-            <RevealSection>
-              <div className="text-center pt-8 border-t border-border">
-                <p className="text-muted-foreground mb-6">
-                  Explore the full documentation above, or get started on
-                  GitHub.
-                </p>
-                <Link
-                  href="https://github.com/rpuneet/bc"
-                  className="inline-flex h-12 items-center justify-center rounded-lg bg-primary px-8 text-sm font-semibold text-primary-foreground shadow-lg transition-all hover:shadow-xl active:scale-[0.97]"
-                >
-                  Get Started
-                </Link>
-              </div>
-            </RevealSection>
-          )}
+            {/* Previous / Next */}
+            <PrevNextNav
+              allItems={allItems}
+              activeItemId={activeItemId}
+              onNavigate={handleItemClick}
+            />
+          </div>
         </div>
+
+        {/* ═══ RIGHT SIDEBAR (Table of Contents) ═══ */}
+        <aside className="hidden xl:block sticky top-0 h-screen w-[200px] shrink-0 overflow-y-auto border-l border-border">
+          <div className="p-4 pt-20 lg:pt-12">
+            <TableOfContents headings={tocHeadings} />
+          </div>
+        </aside>
       </div>
 
       <Footer />


### PR DESCRIPTION
## Summary

- Replaces the single-page accordion docs layout with a proper 3-column documentation site layout inspired by Next.js, Tailwind, Stripe, and shadcn docs
- Left sidebar with collapsible navigation tree (Getting Started, How-To Guides, CLI Reference, API Reference, Architecture, Contributing, Release Notes)
- Right sidebar with scroll-spy "On this page" table of contents
- Client-side routing via URL hash, previous/next navigation, breadcrumbs, mobile-responsive hamburger menu

Part of #2569

## Test plan

- [ ] Verify sidebar navigation works - clicking items loads correct content
- [ ] Verify URL hash updates when navigating, and deep-links work on page load
- [ ] Verify "On this page" TOC highlights the correct heading on scroll
- [ ] Verify Previous/Next navigation at bottom of page
- [ ] Verify mobile view shows hamburger menu that opens sidebar overlay
- [ ] Verify search in sidebar filters navigation items
- [ ] Verify CLI reference pages render command details correctly
- [ ] Verify markdown rendering: code blocks, tables, blockquotes, lists, links
- [ ] Verify placeholder pages show "under construction" message
- [ ] Run `cd landing && bun run lint && bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)