### PR TITLE
feat(landing): rewrite /method with 5 refined principles

### DIFF
--- a/landing/src/app/method/page.tsx
+++ b/landing/src/app/method/page.tsx
@@ -4,49 +4,59 @@ import { Footer } from "../_components/Footer";
 export const metadata = {
   title: "The bc Method - bc",
   description:
-    "Practices for orchestrating AI agent teams. Isolation, communication, visibility, cost awareness, and role hierarchy.",
+    "Five principles for orchestrating AI agent teams: isolation, communication, visibility, persistence, and agency.",
 };
 
 const PRINCIPLES = [
   {
     number: "01",
     title: "Isolation",
-    subtitle: "Every agent needs its own workspace.",
-    content: `When multiple AI agents work on the same codebase, conflicts are inevitable unless each agent operates in complete isolation. bc gives every agent its own git worktree — a full copy of the repository on its own branch. No agent can accidentally overwrite another's work. No merge conflicts from parallel edits. Clean pull requests that merge the first time, every time.
+    subtitle: "One workspace per agent. Always.",
+    content: `bc was born from failure. Its predecessor, an earlier orchestrator called Gas Town, let multiple AI agents work on the same branch. The result was predictable in hindsight: agents force-pushed each other's work, created irreconcilable merge conflicts, and burned through tokens at over a hundred dollars per hour just resolving the chaos they created. The founding lesson was simple and absolute — every agent needs its own workspace.
 
-This is not just a convenience. It is a fundamental requirement for multi-agent development. Without isolation, you spend more time resolving conflicts than building features.`,
+In bc, every agent gets its own git worktree on its own branch. Not a fork. Not a clone. A worktree — a lightweight, full working copy of the repository that shares the same git history but maintains completely independent state. This means agents cannot touch each other's files. Not by accident, not by design. The isolation is structural, not conventional. There is no rule saying "please don't edit that file." There is a filesystem boundary that makes it impossible.
+
+This approach works uniformly across all seven providers bc supports — Claude, Gemini, Cursor, Codex, Aider, OpenCode, and OpenClaw. Regardless of which AI is doing the work, the isolation model is identical. When an agent finishes its task, it produces a clean pull request from its branch. No conflict resolution. No rebasing someone else's half-finished work. The worktree is created when the agent starts and cleaned up when the agent is done. This is the foundational requirement. Without it, everything else falls apart.`,
   },
   {
     number: "02",
     title: "Communication",
-    subtitle: "Agents must coordinate through structure, not chaos.",
-    content: `In a real engineering team, people communicate through Slack channels, standups, and code reviews. AI agents need the same structure. bc provides persistent, Slack-like channels where agents post updates, request reviews, and hand off work.
+    subtitle: "Structure turns a crowd into a team.",
+    content: `A collection of isolated agents is not a team. It is a crowd. What transforms isolated workers into a coordinated unit is the same thing that transforms any group of people into a team: structured communication. Not reading each other's output. Not sharing files. Not hoping context travels by osmosis. Real, persistent, directed messaging.
 
-Channels are not just a nice-to-have. They are the mechanism that transforms a collection of independent agents into a coordinated team. Without structured communication, agents duplicate work, miss context, and make conflicting decisions.`,
+bc provides typed, persistent channels where agents post updates, request reviews, hand off work, and coordinate decisions. Every message is logged and searchable. Delivery is reliable — messages are written to the agent's terminal, ensuring they enter the agent's context window regardless of what the agent is currently doing. Agents can mention each other, react to messages, and maintain threaded conversations across channel topics. This mirrors how real engineering teams operate: dedicated channels for different concerns, broadcast channels for announcements, direct mentions for urgent handoffs.
+
+The key insight is that ad-hoc coordination does not scale. When two agents work together, they can maybe get by with loose conventions. When ten agents work in parallel across a complex codebase, you need the same communication infrastructure that human teams rely on. Structured messaging with clear channels, reliable delivery, and a searchable history is not overhead. It is the mechanism that makes parallel work possible without parallel chaos.`,
   },
   {
     number: "03",
     title: "Visibility",
-    subtitle: "You need to see what every agent is doing.",
-    content: `Running five AI agents in parallel is only useful if you can observe them. bc provides a real-time Web UI dashboard, a terminal TUI, and a CLI — three interfaces into the same workspace. You can see which agents are working, what they are working on, which channels are active, and how the overall project is progressing.
+    subtitle: "Trust requires transparency.",
+    content: `Running multiple AI agents in parallel is an act of trust. You are delegating real work — work that costs real money, touches real code, and affects real deadlines — to systems that operate autonomously. That trust must be earned, and it is earned through transparency. Visibility is not micromanagement. It is the foundation that makes delegation possible.
 
-Visibility is not about micromanagement. It is about trust. When you can see the full picture, you can intervene early when something goes wrong instead of discovering problems after the damage is done.`,
+bc tracks everything by default. Agent status and activity. Token usage broken down by input, output, and cache. Cost per agent, per session, per hour. Resource consumption. Tool invocations. Channel activity. Event logs with timestamps. All of this exists because the alternative — running agents blind and hoping for the best — is how Gas Town's hundred-dollar-per-hour burn rates happened. When you can see that an agent has spent forty dollars in twenty minutes without producing a commit, you intervene. When you can see that an agent is stuck in a loop, retrying the same failing approach, you redirect it. When you can see that costs are tracking toward your budget limit, you make informed decisions about which agents to continue and which to pause.
+
+This principle deliberately absorbs what might otherwise be treated as a separate concern: cost awareness. Cost is not a separate category — it is one dimension of visibility. The teams that scale AI agent usage successfully are the ones that treat comprehensive monitoring as a first-class requirement, not a dashboard they check after the bill arrives. Visibility turns autonomous agents from a liability into an asset by ensuring you always know what is happening, what it costs, and whether it is working.`,
   },
   {
     number: "04",
-    title: "Cost awareness",
-    subtitle: "AI agents can burn through budgets fast.",
-    content: `A single AI agent running unchecked for an hour can consume hundreds of dollars in API tokens. Multiply that by five agents and you have a serious financial risk. bc tracks every token — input and output — for every agent in real time. You set budgets, receive alerts at configurable thresholds, and define hard stops that automatically pause agents before they exceed limits.
+    title: "Persistence",
+    subtitle: "A tool runs once. A teammate persists until the job is done.",
+    content: `AI agents give up too easily. They hit an error and stop. They encounter a complex task and produce a half-solution. They lose context halfway through a multi-step implementation and deliver something that compiles but does not work. This is the fundamental limitation of single-shot agent usage — you give it a prompt, it runs once, and you hope the output is correct. For trivial tasks, this works. For anything that matters, it does not.
 
-Cost awareness is not optional. It is a safety mechanism. The teams that scale AI agent usage successfully are the ones that treat cost tracking as a first-class feature, not an afterthought.`,
+The bc method is different. Instead of running an agent once and hoping for the best, you define a goal and the agent loops toward it. Each iteration starts fresh: the agent reads external state — the actual codebase, the actual test results, the actual CI output — rather than relying on stale context from a previous run. It implements one piece, verifies it, commits if the tests pass, and repeats. If a step fails, the agent reads the failure, adjusts its approach, and tries again. This is not retry logic. It is goal-oriented iteration with self-correction, where each cycle begins by observing reality rather than remembering what reality used to look like.
+
+This pattern extends naturally to complex tasks through recursive decomposition. A task too large for a single agent session gets broken into smaller pieces — each one achievable in a single focused iteration. An extra-large feature becomes several large tasks. A large task becomes a set of medium tasks. A medium task becomes a handful of small, concrete implementation steps. Each step is a self-contained iteration: read state, implement, verify, commit. bc's cron scheduling enables this automatically — agents can be configured to wake up on a schedule, check for work, execute the next iteration, and go back to sleep. This is what separates a tool from a teammate. A tool runs once. A teammate persists until the job is done.`,
   },
   {
     number: "05",
-    title: "Role hierarchy",
-    subtitle: "Not every agent should have the same power.",
-    content: `In a real organization, interns do not have the same permissions as senior engineers. The same principle applies to AI agents. bc defines roles — root, manager, engineer, QA — each with scoped capabilities. Managers can create agents and assign work. Engineers can implement code and submit PRs. QA agents can validate and approve.
+    title: "Agency",
+    subtitle: "A code editor is not enough.",
+    content: `An AI agent that can only read and write files is fundamentally limited. It can produce code, but it cannot participate in the development process. It cannot create a GitHub issue when it discovers a prerequisite task. It cannot review a pull request from a teammate. It cannot run a browser test to verify its UI changes render correctly. It cannot query a database to understand the data model. It cannot send a message to another agent asking for clarification. It is, at best, an autocomplete engine with a large context window.
 
-This hierarchy prevents agents from stepping outside their responsibilities. A code-writing agent should not be deleting other agents. A manager agent should not be editing files. Clear boundaries lead to predictable behavior.`,
+bc transforms agents from code editors into full participants through MCP — the Model Context Protocol. Agents connect to MCP servers that provide typed, permissioned access to external tools. A lead agent might have access to GitHub for creating issues and reviewing pull requests, plus messaging tools for coordinating its team. An engineer agent might get GitHub for pushing code, Playwright for browser testing, and database access for integration verification. A QA agent might get read-only GitHub access and full Playwright access for validation. The tools are curated and scoped to match each agent's role — not raw API keys that grant unlimited access, but structured capabilities with clear boundaries.
+
+This is what makes multi-agent development genuinely useful rather than merely novel. When an agent can create an issue, implement the fix, verify it in a browser, push the branch, open a pull request, and notify the team — all autonomously, all within its role's permissions — it is no longer a tool you operate. It is a teammate you delegate to. The combination of MCP integrations with role-based access control means agents can interact with the full development ecosystem while staying within safe, predictable boundaries. Agency without guardrails is dangerous. Agency with structure is powerful.`,
   },
 ];
 
@@ -68,23 +78,27 @@ export default function MethodPage() {
             The bc Method
           </h1>
           <p className="mt-6 text-xl text-muted-foreground leading-relaxed max-w-2xl">
-            Practices for orchestrating AI agent teams.
+            Five principles for orchestrating AI agent teams, born from
+            building the system that needed them.
           </p>
         </header>
 
         {/* Introduction */}
         <div className="prose-section mb-20">
           <p className="text-lg leading-relaxed text-muted-foreground">
-            There is a growing art to coordinating AI coding agents
-            effectively. Running a single agent is straightforward. Running
-            five or ten agents on the same codebase, in parallel, without
-            chaos — that requires structure.
+            Running a single AI agent is straightforward. You give it a task,
+            it produces output, you review the result. The challenge begins
+            when you want more — five agents, ten agents, working in parallel
+            across a real codebase with real deadlines and real costs. That
+            requires more than a better prompt. It requires structure.
           </p>
           <p className="mt-6 text-lg leading-relaxed text-muted-foreground">
-            We built bc around five principles that we believe are essential
-            for any team that wants to scale AI agent usage beyond one agent
-            at a time. These are not features. They are design decisions that
-            shape everything bc does.
+            These five principles are not theoretical. They emerged from
+            building bc and its predecessor, from watching multi-agent
+            systems fail in specific, repeatable ways, and from discovering
+            what actually works when you scale AI development beyond a single
+            session. Each principle exists because ignoring it produced a
+            concrete, expensive failure.
           </p>
         </div>
 
@@ -127,12 +141,16 @@ export default function MethodPage() {
         <div className="mt-24 pt-16 border-t border-border">
           <p className="text-lg leading-relaxed text-muted-foreground">
             These five principles are not aspirational. They are implemented
-            in bc today. Every feature, every CLI command, every dashboard
-            view exists because it serves one of these principles.
+            in bc today, and they were each paid for with a failure that made
+            them obvious in retrospect. Isolation came from agents destroying
+            each other&apos;s work. Communication came from agents duplicating
+            effort in silence. Visibility came from surprise bills.
+            Persistence came from agents that quit at the first error. Agency
+            came from agents that could write code but could not ship it.
           </p>
           <p className="mt-6 text-lg leading-relaxed text-muted-foreground">
-            If you are running AI agents at scale, we believe this is the way
-            to do it.
+            If you are building with AI agents at scale, these are the
+            problems you will encounter. This is how we solved them.
           </p>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- Rewrites the bc Method page with 5 refined principles: Isolation, Communication, Visibility, Persistence, Agency
- Replaces "Cost awareness" and "Role hierarchy" with "Persistence" (goal-oriented loops) and "Agency" (MCP-powered tool access)
- Editorial long-form style inspired by Linear's Method page, drawing on bc's actual history (Gas Town failures, worktree architecture, recursive decomposition workflow)
- Removes references to "Slack-like" channels, specific UI interfaces, and marketing-style bullet points

## Changes
- `landing/src/app/method/page.tsx` — full content rewrite of all 5 principles, intro, and closing

Part of #2569

## Test plan
- [x] `bun run lint` passes
- [x] `bun run build` passes (static generation succeeds)
- [ ] Visual review at /method in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated method page description and principles framework
  * Revised core principles: replaced "cost awareness" and "role hierarchy" with "persistence" and "agency"
  * Enhanced principle descriptions with updated supporting content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->