### PR TITLE
fix(landing): text audit — Hemingway concision, no fluff

### DIFF
--- a/landing/src/app/_components/BentoGrid.tsx
+++ b/landing/src/app/_components/BentoGrid.tsx
@@ -82,7 +82,7 @@ export function BentoGrid() {
       {/* Large cards - span 3 cols each */}
       <BentoCard
         title="Agents"
-        description="Create, start, and monitor AI agents in isolated tmux sessions. Each agent gets its own git worktree, role, and tool provider."
+        description="Spawn agents in isolated worktrees with roles, tools, and real-time status."
         icon={Users}
         screenshot="/screenshots/dashboard-02-agents.png"
         screenshotAlt="Agent management table showing names, roles, tools, and statuses"
@@ -91,7 +91,7 @@ export function BentoGrid() {
       />
       <BentoCard
         title="Channels"
-        description="Slack-like communication between agents. Persistent, searchable, with @mentions and structured handoffs."
+        description="Persistent, searchable channels with @mentions and structured handoffs."
         icon={MessageSquare}
         screenshot="/screenshots/dashboard-03-channels.png"
         screenshotAlt="Channel view showing real-time agent-to-agent messages"
@@ -102,7 +102,7 @@ export function BentoGrid() {
       {/* Medium cards - span 2 cols each */}
       <BentoCard
         title="Costs"
-        description="Per-agent token tracking with budgets, alerts, and automatic hard stops."
+        description="Per-agent token tracking with budgets and automatic hard stops."
         icon={DollarSign}
         screenshot="/screenshots/dashboard-04-costs.png"
         screenshotAlt="Cost tracking with daily trend chart and per-agent breakdown"
@@ -111,7 +111,7 @@ export function BentoGrid() {
       />
       <BentoCard
         title="Roles"
-        description="Role-based hierarchy with scoped permissions. Manager, engineer, QA, and custom roles."
+        description="Scoped permissions per role. Manager, engineer, QA, or custom."
         icon={Shield}
         screenshot="/screenshots/dashboard-05-roles.png"
         screenshotAlt="Role configuration cards with capability settings"
@@ -120,7 +120,7 @@ export function BentoGrid() {
       />
       <BentoCard
         title="Worktrees"
-        description="Every agent gets its own git branch. Zero conflicts, clean merges."
+        description="Each agent works on its own git branch. No conflicts."
         icon={GitBranch}
         className="col-span-2"
         delay={0.3}
@@ -129,35 +129,35 @@ export function BentoGrid() {
       {/* Small cards */}
       <BentoCard
         title="Cron"
-        description="Schedule recurring tasks with cron expressions."
+        description="Schedule recurring agent tasks with cron syntax."
         icon={Clock}
         className="col-span-1"
         delay={0.35}
       />
       <BentoCard
         title="Secrets"
-        description="Encrypted secret storage for agent API keys."
+        description="Encrypted storage for API keys and tokens."
         icon={Lock}
         className="col-span-1"
         delay={0.4}
       />
       <BentoCard
         title="MCP"
-        description="Model Context Protocol server integration."
+        description="Connect MCP servers to extend agent capabilities."
         icon={Plug}
         className="col-span-1"
         delay={0.45}
       />
       <BentoCard
         title="Stats"
-        description="System overview with real-time metrics."
+        description="CPU, memory, disk, and agent metrics at a glance."
         icon={Activity}
         className="col-span-1"
         delay={0.5}
       />
       <BentoCard
         title="Doctor"
-        description="Health checks for your workspace."
+        description="Diagnose and auto-repair workspace issues."
         icon={Stethoscope}
         className="col-span-2 sm:col-span-1"
         delay={0.55}

--- a/landing/src/app/_components/HeroSection.tsx
+++ b/landing/src/app/_components/HeroSection.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { motion } from "framer-motion";
-import { ArrowRight, CheckCircle2, Layers, Monitor } from "lucide-react";
+import { ArrowRight, CheckCircle2, Layers } from "lucide-react";
 
 const fadeUp = {
   hidden: { opacity: 0, y: 30 },
@@ -98,10 +98,6 @@ export function HeroSection() {
             </span>
             <span className="flex items-center gap-1.5">
               <Layers className="h-3.5 w-3.5" aria-hidden="true" />7 AI tools
-            </span>
-            <span className="flex items-center gap-1.5">
-              <Monitor className="h-3.5 w-3.5" aria-hidden="true" />
-              CLI + TUI + Web
             </span>
           </motion.div>
         </div>

--- a/landing/src/app/_components/StatsBar.tsx
+++ b/landing/src/app/_components/StatsBar.tsx
@@ -37,15 +37,15 @@ export function StatsBar() {
           <StatItem icon={Layers} value="7" label="AI Tools" delay={0} />
           <StatItem icon={Github} value="OSS" label="Open Source" delay={0.1} />
           <StatItem
-            icon={Monitor}
-            value="15"
-            label="Dashboard Views"
+            icon={Code2}
+            value="Local"
+            label="Runs on your machine"
             delay={0.2}
           />
           <StatItem
-            icon={Code2}
-            value="3"
-            label="Interfaces"
+            icon={Monitor}
+            value="Free"
+            label="No login required"
             delay={0.3}
           />
         </div>

--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -44,10 +44,10 @@ export default function Home() {
                 The problem
               </span>
               <h2 className="mt-3 text-3xl font-bold tracking-tight sm:text-5xl">
-                AI agents are powerful alone &mdash;
+                One agent is useful.
                 <br />
                 <span className="text-muted-foreground/50">
-                  but chaotic when they work together.
+                  Five agents without structure is chaos.
                 </span>
               </h2>
             </div>
@@ -86,7 +86,7 @@ export default function Home() {
                     "5-10 agents working in parallel",
                     "Persistent memory injected on spawn",
                     "Git worktrees — zero merge conflicts",
-                    "Real-time dashboard, channels, and monitoring",
+                    "Real-time visibility into every agent",
                     "Per-agent budgets with automatic hard stops",
                   ].map((t) => (
                     <li key={t} className="flex gap-3 text-muted-foreground">
@@ -116,7 +116,7 @@ export default function Home() {
                   step: "01",
                   cmd: "bc init",
                   title: "Initialize workspace",
-                  desc: "Creates .bc/ with config, roles, channels, and agent definitions.",
+                  desc: "Creates .bc/ with config, roles, and channels.",
                   lines: [
                     { text: "Initializing bc workspace...", color: "text-terminal-muted" },
                     { text: "Created .bc/settings.toml", color: "text-terminal-muted" },
@@ -128,7 +128,7 @@ export default function Home() {
                   step: "02",
                   cmd: "bc daemon start",
                   title: "Start the daemon",
-                  desc: "Launches the bcd server with Web UI, WebSocket events, and MCP.",
+                  desc: "Launches the bcd server with dashboard and MCP.",
                   lines: [
                     { text: "Starting bcd on :9374...", color: "text-terminal-muted" },
                     { text: "\u2713 Web UI ready", color: "text-terminal-success" },
@@ -187,13 +187,13 @@ export default function Home() {
           <RevealSection className="py-12 sm:py-16 lg:py-24" id="demo">
             <div className="mb-12 text-center">
               <span className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-                Web UI Dashboard
+                Dashboard
               </span>
               <h2 className="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">
                 See the real dashboard.
               </h2>
               <p className="mt-4 text-muted-foreground text-lg max-w-xl mx-auto">
-                Monitor agents, channels, costs, and more from localhost:9374.
+                Monitor agents, channels, and costs from localhost:9374.
               </p>
             </div>
             <div className="mx-auto max-w-5xl">

--- a/landing/src/app/pricing/page.tsx
+++ b/landing/src/app/pricing/page.tsx
@@ -12,7 +12,6 @@ export const metadata = {
 const FREE_FEATURES = [
   "Unlimited agents",
   "All 7 AI tool providers",
-  "CLI, TUI, and Web UI",
   "Git worktree isolation",
   "Channel communication",
   "Cost tracking and budgets",
@@ -191,10 +190,8 @@ export default function PricingPage() {
                 Is bc really free?
               </h3>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                Yes. bc is open source and runs entirely on your local machine.
-                All features are included with no restrictions. You only pay for
-                the AI API tokens from your chosen providers (Claude, Gemini,
-                etc.).
+                Yes. bc is open source. All features included, no restrictions.
+                You only pay for AI API tokens from your providers.
               </p>
             </div>
             <div>
@@ -214,9 +211,8 @@ export default function PricingPage() {
                 What about Cloud and Enterprise?
               </h3>
               <p className="text-sm text-muted-foreground leading-relaxed">
-                We are working on hosted versions for teams who want managed
-                infrastructure. Join the waitlist to be notified when they
-                launch, or email us at{" "}
+                Hosted versions for teams are in development. Join the
+                waitlist or email{" "}
                 <a href="mailto:skitzo@bc-infra.com" className="text-primary hover:underline">
                   skitzo@bc-infra.com
                 </a>.

--- a/landing/src/app/product/page.tsx
+++ b/landing/src/app/product/page.tsx
@@ -163,9 +163,8 @@ export default function Product() {
             </span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground">
-            Agents, channels, roles, cost tracking, secrets, cron jobs, and a
-            real-time Web UI dashboard — everything you need to run parallel AI
-            agents from your terminal.
+            Agents, channels, roles, cost tracking, secrets, and cron jobs.
+            Everything you need to run parallel AI agents.
           </p>
         </motion.div>
 
@@ -188,7 +187,7 @@ export default function Product() {
           id="agents"
           label="Agent Lifecycle"
           title="Create, command, observe, stop."
-          description="Create agents with roles and tools, send them work, peek at their output in real-time, and manage the full lifecycle from spawn to cleanup. Each agent runs in its own tmux session with an isolated git worktree."
+          description="Spawn agents with roles and tools. Send work, peek at output, manage the full lifecycle. Each agent runs in its own tmux session with an isolated git worktree."
           commands={[
             'bc agent create eng-01 --role engineer --tool claude',
             'bc agent send eng-01 "Build the auth module"',
@@ -205,7 +204,7 @@ export default function Product() {
           id="channels"
           label="Communication"
           title="Structured coordination via channels."
-          description="Channels like #engineering, #merge, and #ops keep your agents organized. Agents @mention each other, hand off work, and coordinate autonomously. Every message is logged and searchable."
+          description="Structured channels keep agents coordinated. Agents @mention each other, hand off work, and converge. Every message is logged and searchable."
           commands={[
             'bc channel create deploys',
             'bc channel send engineering "@eng-01 review PR #42"',
@@ -222,7 +221,7 @@ export default function Product() {
           id="costs"
           label="Cost Tracking"
           title="Track spending across every agent."
-          description="See total cost, token usage, and per-agent breakdowns in real-time. Set budgets with alerts at configurable thresholds, and enable hard stops to automatically pause agents that exceed their budget."
+          description="Total cost, token usage, and per-agent breakdowns in real time. Set budgets with thresholds. Hard stops pause agents that exceed their limit."
           commands={[
             'bc cost show',
             'bc cost budget set 50.00 --agent eng-01 --alert-at 0.8',
@@ -238,7 +237,7 @@ export default function Product() {
           id="roles"
           label="Roles & Permissions"
           title="RBAC for your agent team."
-          description="Define roles with custom prompts and scoped capabilities. Engineers can implement tasks but can't create agents. Managers can assign work but can't modify config. Roles are defined as markdown files in .bc/roles/."
+          description="Define roles with scoped capabilities. Engineers implement tasks. Managers assign work. Roles live as markdown files in .bc/roles/."
           commands={[
             'bc role list',
             'bc role show engineer',
@@ -253,7 +252,7 @@ export default function Product() {
           id="tools"
           label="Tool Management"
           title="Add any AI tool. Mix and match."
-          description="Register AI coding tools and assign different tools to different agents — Claude Code for complex features, Cursor for UI work, Aider for quick fixes. bc manages the tool lifecycle including install, upgrade, and status checks."
+          description="Register AI tools and assign them to agents. Claude Code for complex features, Cursor for UI, Aider for quick fixes. bc manages install, upgrade, and status."
           commands={[
             'bc tool list',
             'bc tool add mytool --command "mytool --yes"',
@@ -269,7 +268,7 @@ export default function Product() {
           id="mcp"
           label="MCP Integration"
           title="Connect tools natively via MCP."
-          description="Configure Model Context Protocol servers that your agents connect to automatically. Supports stdio and SSE transport. Attach MCP servers to roles so every agent of that type gets the same capabilities."
+          description="Configure MCP servers that agents connect to on spawn. Supports stdio and SSE transport. Attach servers to roles for consistent capabilities."
           commands={[
             'bc mcp add github-server',
             'bc mcp list',
@@ -285,7 +284,7 @@ export default function Product() {
           id="cron"
           label="Scheduled Tasks"
           title="Cron-powered automation."
-          description="Schedule recurring tasks with familiar cron syntax. Send prompts to agents on a schedule, run shell commands, and view execution history with full log retention."
+          description="Schedule recurring tasks with cron syntax. Send prompts to agents on a schedule and view execution history."
           commands={[
             'bc cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint"',
             'bc cron list',
@@ -300,7 +299,7 @@ export default function Product() {
           id="secrets"
           label="Secrets Management"
           title="Encrypted credentials, zero plaintext."
-          description="Store API keys, tokens, and credentials encrypted at rest using macOS Keychain, Linux libsecret, or AES-256-GCM fallback. Reference secrets in configs — no plaintext in your repo, ever."
+          description="API keys and credentials encrypted at rest via macOS Keychain, Linux libsecret, or AES-256-GCM. No plaintext in your repo."
           commands={[
             'bc secret set OPENAI_KEY',
             'bc secret list',
@@ -316,7 +315,7 @@ export default function Product() {
           id="stats"
           label="System Stats"
           title="Full visibility into your workspace."
-          description="See agent counts, total cost, CPU/memory/disk usage, uptime, goroutines, and channel activity at a glance. The stats dashboard gives you a real-time system overview of your entire workspace."
+          description="Agent counts, total cost, CPU/memory/disk usage, uptime, and channel activity at a glance."
           commands={[
             'bc stats',
             'bc status',
@@ -330,7 +329,7 @@ export default function Product() {
           id="logs"
           label="Centralized Logs"
           title="Every event, searchable and filterable."
-          description="All agent activity, channel messages, cost events, and system events stream into a unified log. Filter by agent, level, or time range. Debug issues across your entire agent team from one place."
+          description="All agent activity, channel messages, and system events in one log. Filter by agent, level, or time range."
           commands={[
             'bc logs',
             'bc agent logs eng-01',
@@ -345,7 +344,7 @@ export default function Product() {
           id="daemons"
           label="Daemon Processes"
           title="Long-running services, managed."
-          description="Run background processes alongside your agents — databases, dev servers, watchers. bc manages their lifecycle, restarts them on failure, and shows their status in the dashboard."
+          description="Run background processes alongside your agents. bc manages their lifecycle and restarts them on failure."
           commands={[
             'bc status',
             'bc doctor',
@@ -359,7 +358,7 @@ export default function Product() {
           id="doctor"
           label="System Health"
           title="One command to check everything."
-          description="bc doctor checks 8 categories — workspace, database, agents, tools, MCP, secrets, git, and daemon. Found an issue? bc doctor fix auto-repairs what it can."
+          description="Checks workspace, database, agents, tools, MCP, secrets, git, and daemon. bc doctor fix auto-repairs what it can."
           commands={[
             'bc doctor',
             'bc doctor check tools',
@@ -383,24 +382,24 @@ export default function Product() {
               Not a new IDE. Not a framework. An orchestration layer.
             </h2>
             <p className="mt-4 max-w-2xl text-muted-foreground leading-relaxed">
-              bc doesn&apos;t replace your tools — it coordinates them. Keep
-              using Claude Code, Cursor, Codex, or any CLI-based agent. bc
-              handles the multi-agent complexity so you don&apos;t have to.
+              bc coordinates your existing tools. Keep using Claude Code,
+              Cursor, Codex, or any CLI agent. bc handles the multi-agent
+              complexity.
             </p>
           </div>
           <div className="grid gap-6 sm:grid-cols-3">
             {[
               {
                 title: "vs. Single-agent tools",
-                desc: "Claude Code, Cursor, and Codex are powerful — but limited to one agent at a time. bc runs many in parallel on isolated branches.",
+                desc: "Claude Code, Cursor, and Codex run one agent at a time. bc runs many in parallel on isolated branches.",
               },
               {
                 title: "vs. Agent frameworks",
-                desc: "CrewAI and LangGraph require you to build agents from scratch. bc orchestrates the agents you already use, with zero code changes.",
+                desc: "CrewAI and LangGraph require building agents from scratch. bc orchestrates agents you already use. No code changes.",
               },
               {
                 title: "vs. Custom scripts",
-                desc: "Shell scripts break at scale. bc gives you structured communication, persistent memory, cost tracking, and a Web UI dashboard out of the box.",
+                desc: "Shell scripts break at scale. bc gives you structured channels, persistent memory, and cost tracking out of the box.",
               },
             ].map((item) => (
               <div

--- a/landing/src/app/waitlist/page.tsx
+++ b/landing/src/app/waitlist/page.tsx
@@ -20,39 +20,39 @@ import { RevealSection } from "../_components/TerminalComponents";
 const BENEFITS = [
   {
     icon: Terminal,
-    title: "Full CLI + Web Dashboard",
+    title: "Full CLI Access",
     description:
-      "Complete CLI access to every feature — agents, channels, cost controls, roles, cron jobs, secrets, and MCP integrations. Plus a real-time Web UI dashboard for visual monitoring.",
+      "Agents, channels, cost controls, roles, cron, secrets, and MCP. Every feature from the command line.",
   },
   {
     icon: Users,
     title: "Multi-Agent Orchestration",
     description:
-      "Run 5+ AI coding agents simultaneously with zero conflicts. Git worktree isolation keeps every agent in its own lane while channels enable coordination.",
+      "Run 5+ agents in parallel. Git worktree isolation prevents conflicts. Channels enable coordination.",
   },
   {
     icon: Shield,
-    title: "Cost Control Built In",
+    title: "Cost Control",
     description:
-      "Real-time token tracking, per-agent budgets, and automatic kill switches. See exactly what each agent costs with daily trend charts and per-agent breakdowns.",
+      "Per-agent budgets, real-time token tracking, and automatic hard stops.",
   },
   {
     icon: GitBranch,
     title: "Agent-Agnostic",
     description:
-      "Works with Claude Code, Cursor, Codex, Gemini, Aider, OpenCode, OpenClaw, and any CLI-based coding assistant. No vendor lock-in.",
+      "Works with Claude Code, Cursor, Codex, Gemini, Aider, and any CLI agent. No vendor lock-in.",
   },
   {
     icon: Eye,
     title: "Real-Time Visibility",
     description:
-      "Watch agents communicate in shared channels, monitor live status, and track progress across your entire team from a single dashboard.",
+      "Watch agents coordinate in structured channels. Monitor status and cost across your team.",
   },
   {
     icon: Zap,
     title: "Cron, Secrets & MCP",
     description:
-      "Schedule recurring agent tasks with cron, manage encrypted secrets, and extend capabilities with MCP server integrations — all from the CLI.",
+      "Schedule tasks, manage encrypted credentials, and extend agents with MCP servers.",
   },
 ];
 
@@ -425,8 +425,8 @@ export default function Waitlist() {
               See what you&apos;ll get
             </h2>
             <p className="text-muted-foreground max-w-lg mx-auto">
-              A real-time Web UI dashboard ships with bc. Monitor agents,
-              channels, and costs from your browser.
+              A real-time dashboard ships with bc. Monitor agents, channels,
+              and costs from your browser.
             </p>
           </RevealSection>
           <RevealSection delay={0.2}>
@@ -527,25 +527,25 @@ export default function Waitlist() {
                 step: "01",
                 title: "Sign up for early access",
                 description:
-                  "Drop your email above. We'll notify you as soon as bc is ready for you to install.",
+                  "Drop your email above. We'll notify you when bc is ready.",
               },
               {
                 step: "02",
                 title: "Install locally",
                 description:
-                  "bc runs on your machine. One command to install, one command to start: `bc up`. No cloud accounts, no containers required.",
+                  "bc runs on your machine. One command to install, one to start. No cloud accounts required.",
               },
               {
                 step: "03",
                 title: "Orchestrate your agents",
                 description:
-                  "Point bc at your project, assign roles to agents, and let them work in parallel. Each agent gets its own git worktree — zero merge conflicts.",
+                  "Assign roles to agents and let them work in parallel. Each agent gets its own git worktree.",
               },
               {
                 step: "04",
                 title: "Shape the product",
                 description:
-                  "Early access users get direct input on the roadmap. Your feedback drives what we build next.",
+                  "Early access users shape the roadmap. Your feedback drives what we build.",
               },
             ].map((item, i) => (
               <RevealSection key={item.step} delay={i * 0.1}>
@@ -578,31 +578,31 @@ export default function Waitlist() {
             {[
               {
                 q: "What is bc?",
-                a: "bc is a CLI-first multi-agent orchestration tool. It coordinates multiple AI coding agents — like Claude Code, Cursor, Codex, and others — so they can work in parallel on isolated git worktrees without merge conflicts or context loss.",
+                a: "bc coordinates multiple AI coding agents working in parallel on isolated git worktrees. No merge conflicts, no context loss.",
               },
               {
                 q: "How is this different from using a single AI agent?",
-                a: "A single agent works serially on one task at a time. bc lets you run 5-10 agents simultaneously, each on its own branch, communicating through structured channels. Think of it as going from one developer to a full engineering team — with cost controls and real-time visibility.",
+                a: "A single agent works on one task at a time. bc runs 5-10 agents in parallel, each on its own branch, communicating through structured channels. Cost controls and real-time visibility included.",
               },
               {
                 q: "Which AI tools does bc support?",
-                a: "bc is agent-agnostic. It works with Claude Code, Cursor, Codex, Gemini, Aider, OpenCode, OpenClaw, and any CLI-based coding assistant. You configure providers in a simple TOML file and bc handles the coordination.",
+                a: "Claude Code, Cursor, Codex, Gemini, Aider, OpenCode, OpenClaw, and any CLI agent. Configure providers in a TOML file.",
               },
               {
                 q: "Do I need to change how my agents work?",
-                a: "No. bc orchestrates agents you already use with zero code changes. Your agents keep running the same commands — bc adds the coordination layer on top: worktree isolation, channels for communication, persistent memory, and cost tracking.",
+                a: "No. Your agents keep running the same commands. bc adds the coordination layer: worktree isolation, channels, persistent memory, and cost tracking.",
               },
               {
                 q: "Is bc open source?",
-                a: "Yes. bc is open source and runs entirely on your local machine. You can inspect the code, contribute, and self-host. Early access gives you the full platform — CLI, Web UI dashboard, and all features.",
+                a: "Yes. Open source, runs on your machine. Inspect the code, contribute, self-host. Early access includes all features.",
               },
               {
                 q: "Does bc require a cloud account?",
-                a: "No. bc is local-first. It runs on your machine using tmux sessions and local git worktrees. No data leaves your machine unless you configure external AI providers (which you control).",
+                a: "No. bc runs on your machine using tmux sessions and local git worktrees. No data leaves your machine unless you configure external AI providers.",
               },
               {
                 q: "How does early access work?",
-                a: "Sign up with your email and we'll notify you when bc is ready. You'll get installation instructions, full access to all features, and a direct line to the team for feedback and support.",
+                a: "Sign up with your email. You'll get install instructions, full access, and a direct line to the team.",
               },
             ].map((faq) => (
               <RevealSection key={faq.q}>


### PR DESCRIPTION
## Summary
- Thorough text audit across all landing pages matching the /method page tone
- Remove "Slack-like" references, "CLI + TUI + Web" interface listings, and marketing fluff
- Tighten all descriptions: BentoGrid cards under 15 words, product features to 1-2 sentences, FAQ answers cut by ~40%
- Replace filler words and passive voice with direct, concrete language

## Pages audited
- Homepage (`page.tsx`) — tightened problem/solution, how-it-works descriptions
- HeroSection — removed "CLI + TUI + Web" badge
- BentoGrid — all 10 card descriptions under 15 words, removed "Slack-like"
- StatsBar — replaced "3 Interfaces" and "15 Dashboard Views" with "Local" and "Free"
- Product page — cut all 12 feature descriptions to 1-2 sentences, tightened comparisons
- Pricing page — removed "CLI, TUI, and Web UI" feature line, tightened FAQ
- Waitlist page — tightened 6 benefits, 7 FAQ answers, 4 how-it-works steps

## Test plan
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [ ] Visual verification at localhost:3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refined product descriptions and feature messaging across landing pages for improved clarity and conciseness
  * Updated feature highlights to better reflect core capabilities including agents, channels, roles, and cost management
  * Streamlined pricing tier descriptions and benefits messaging
  * Enhanced hero section copy and product value propositions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->