### PR TITLE
feat(landing): redesign pricing page and replace stats bar

### DIFF
--- a/landing/src/app/_components/HeroSection.tsx
+++ b/landing/src/app/_components/HeroSection.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import Image from "next/image";
 import { motion } from "framer-motion";
-import { ArrowRight, CheckCircle2, Layers } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 
 const fadeUp = {
   hidden: { opacity: 0, y: 30 },
@@ -87,17 +87,19 @@ export function HeroSection() {
           <motion.div
             variants={fadeUp}
             custom={4}
-            className="mt-8 flex flex-wrap items-center gap-6 font-mono text-xs text-muted-foreground"
+            className="mt-8 flex flex-wrap items-center gap-5 font-mono text-xs text-muted-foreground"
           >
             <span className="flex items-center gap-1.5">
-              <CheckCircle2
-                className="h-3.5 w-3.5 text-success"
-                aria-hidden="true"
-              />
+              <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" aria-hidden="true" />
               Open source
             </span>
             <span className="flex items-center gap-1.5">
-              <Layers className="h-3.5 w-3.5" aria-hidden="true" />7 AI tools
+              <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" aria-hidden="true" />
+              CLI-first
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/50" aria-hidden="true" />
+              Local
             </span>
           </motion.div>
         </div>

--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -4,7 +4,6 @@ import { DashboardScreenshots } from "./_components/DashboardScreenshots";
 import { Footer } from "./_components/Footer";
 import { HeroSection } from "./_components/HeroSection";
 import { BentoGrid } from "./_components/BentoGrid";
-import { StatsBar } from "./_components/StatsBar";
 import {
   TerminalWindow,
   CommandOutput,
@@ -25,11 +24,6 @@ export default function Home() {
 
         {/* Hero */}
         <HeroSection />
-
-        {/* Stats Bar */}
-        <div className="mt-12 sm:mt-16">
-          <StatsBar />
-        </div>
 
         {/* Tool Carousel */}
         <div className="mt-8 sm:mt-12 lg:mt-16 mx-auto max-w-6xl px-4 sm:px-6">

--- a/landing/src/app/pricing/layout.tsx
+++ b/landing/src/app/pricing/layout.tsx
@@ -1,3 +1,9 @@
+export const metadata = {
+  title: "Pricing - bc",
+  description:
+    "bc is free and open source. Run it locally with all features. No login required.",
+};
+
 export default function PricingLayout({
   children,
 }: {

--- a/landing/src/app/pricing/page.tsx
+++ b/landing/src/app/pricing/page.tsx
@@ -1,237 +1,426 @@
+"use client";
+
 import Link from "next/link";
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Nav } from "../_components/Nav";
 import { Footer } from "../_components/Footer";
-import { Check } from "lucide-react";
+import {
+  Server,
+  Cloud,
+  Terminal,
+  Key,
+  Lock,
+  Shield,
+  Database,
+  Container,
+  Copy,
+  Check,
+  ChevronDown,
+  Apple,
+  GitBranch,
+  Cpu,
+  ExternalLink,
+} from "lucide-react";
 
-export const metadata = {
-  title: "Pricing - bc",
-  description:
-    "bc is free and open source. Run it locally with all features. No login required.",
+const fadeUp = {
+  hidden: { opacity: 0, y: 30 },
+  visible: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: { delay: i * 0.12, duration: 0.6, ease: "easeOut" as const },
+  }),
 };
 
-const FREE_FEATURES = [
-  "Unlimited agents",
-  "All 7 AI tool providers",
-  "Git worktree isolation",
-  "Channel communication",
-  "Cost tracking and budgets",
-  "Persistent memory",
-  "Role-based hierarchy",
-  "Cron scheduling",
-  "MCP integration",
-  "Secrets management",
-  "Event logs and stats",
-];
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
 
-const CLOUD_FEATURES = [
-  "Everything in Free",
-  "Hosted dashboard",
-  "Team management",
-  "Usage analytics",
-  "Cloud-synced memory",
-  "Webhooks and integrations",
-];
+  const handleCopy = () => {
+    void navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
-const ENTERPRISE_FEATURES = [
-  "Everything in Cloud",
-  "SSO / SAML",
-  "Audit logs",
-  "Dedicated support",
-  "Custom SLA",
-  "On-premise deployment",
-];
+  return (
+    <button
+      onClick={handleCopy}
+      className="shrink-0 p-1 rounded hover:bg-accent/30 transition-colors"
+      aria-label="Copy to clipboard"
+    >
+      {copied ? (
+        <Check className="h-3.5 w-3.5 text-success" />
+      ) : (
+        <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+      )}
+    </button>
+  );
+}
+
+interface InstallCardProps {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  command: string;
+}
+
+function InstallCard({ icon: Icon, title, command }: InstallCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div
+      className="group rounded-lg border border-border/60 bg-accent/5 hover:bg-accent/15 transition-all cursor-pointer"
+      onClick={() => setExpanded(!expanded)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") setExpanded(!expanded);
+      }}
+      role="button"
+      tabIndex={0}
+      aria-expanded={expanded}
+    >
+      <div className="flex items-center gap-3 px-4 py-3">
+        <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
+        <span className="text-sm font-medium">{title}</span>
+        <ChevronDown
+          className={`h-3.5 w-3.5 text-muted-foreground/50 ml-auto transition-transform ${expanded ? "rotate-180" : ""}`}
+        />
+      </div>
+      <AnimatePresence>
+        {expanded && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <div className="px-4 pb-3">
+              <div className="flex items-center gap-2 rounded-md bg-background/80 border border-border/40 px-3 py-2 font-mono text-xs">
+                <code className="text-muted-foreground flex-1 overflow-x-auto whitespace-nowrap">
+                  {command}
+                </code>
+                <CopyButton text={command} />
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+interface FAQItemProps {
+  question: string;
+  answer: string;
+}
+
+function FAQItem({ question, answer }: FAQItemProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="border-b border-border/40">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between py-5 text-left"
+        aria-expanded={open}
+      >
+        <span className="font-semibold text-sm">{question}</span>
+        <ChevronDown
+          className={`h-4 w-4 text-muted-foreground shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="overflow-hidden"
+          >
+            <p className="pb-5 text-sm text-muted-foreground leading-relaxed">
+              {answer}
+            </p>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
 
 export default function PricingPage() {
   return (
     <main className="min-h-screen selection:bg-primary/20 selection:text-foreground">
-      <Nav />
+      <div className="pointer-events-none fixed inset-0 z-[1] bg-[radial-gradient(ellipse_80%_60%_at_50%_-20%,rgba(234,88,12,0.04),transparent)] dark:bg-[radial-gradient(ellipse_80%_60%_at_50%_-20%,rgba(234,88,12,0.08),transparent)]" />
 
-      <div className="mx-auto max-w-5xl px-4 sm:px-6 py-16 sm:py-24">
-        <div className="text-center mb-16">
-          <span className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
-            Pricing
-          </span>
-          <h1 className="mt-3 text-4xl font-bold tracking-tight sm:text-6xl">
-            Open source. Free forever.
-          </h1>
-          <p className="mt-4 text-lg text-muted-foreground max-w-xl mx-auto">
-            bc runs on your machine. No login, no signup, no cloud dependency.
-            Every feature included.
-          </p>
-        </div>
+      <div className="relative z-[2]">
+        <Nav />
 
-        <div className="grid gap-8 lg:grid-cols-3">
-          {/* Free Tier */}
-          <div className="rounded-xl border-2 border-primary bg-card p-8 relative">
-            <div className="absolute -top-3 left-6 px-3 py-0.5 rounded-full bg-primary text-primary-foreground text-xs font-semibold">
-              Recommended
-            </div>
-            <div className="mb-6">
-              <h2 className="text-xl font-bold">Open Source</h2>
-              <div className="mt-4 flex items-baseline gap-1">
-                <span className="text-5xl font-bold tracking-tight">₹0</span>
-                <span className="text-muted-foreground text-sm">/forever</span>
-              </div>
-              <p className="mt-3 text-sm text-muted-foreground">
-                Runs locally on your machine. No account required.
-              </p>
-            </div>
-            <Link
-              href="https://github.com/bcinfra1/bc"
-              className="block w-full rounded-lg bg-primary py-2.5 text-center text-sm font-semibold text-primary-foreground transition-all hover:opacity-90 active:scale-[0.98]"
+        <div className="mx-auto max-w-5xl px-4 sm:px-6 py-16 sm:py-24">
+          <motion.div
+            initial="hidden"
+            animate="visible"
+            className="text-center mb-16"
+          >
+            <motion.span
+              variants={fadeUp}
+              custom={0}
+              className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground"
             >
-              Get Started
-            </Link>
-            <ul className="mt-8 space-y-3">
-              {FREE_FEATURES.map((f) => (
-                <li
-                  key={f}
-                  className="flex items-start gap-2.5 text-sm text-muted-foreground"
-                >
-                  <Check
-                    className="h-4 w-4 text-success shrink-0 mt-0.5"
-                    aria-hidden="true"
-                  />
-                  {f}
-                </li>
-              ))}
-            </ul>
-          </div>
+              Pricing
+            </motion.span>
+            <motion.h1
+              variants={fadeUp}
+              custom={1}
+              className="mt-3 text-4xl font-bold tracking-tight sm:text-6xl"
+            >
+              Open source. Free forever.
+            </motion.h1>
+            <motion.p
+              variants={fadeUp}
+              custom={2}
+              className="mt-4 text-lg text-muted-foreground max-w-xl mx-auto"
+            >
+              bc runs on your machine. No login, no signup, no cloud dependency.
+              You only pay for your AI API tokens.
+            </motion.p>
+          </motion.div>
 
-          {/* Cloud Tier - Coming Soon */}
-          <div className="rounded-xl border border-border bg-card p-8 relative overflow-hidden">
-            <div className="absolute inset-0 bg-background/60 backdrop-blur-[2px] z-10 flex items-center justify-center">
-              <span className="px-4 py-2 rounded-full border border-border bg-card text-sm font-semibold text-muted-foreground">
-                Coming Soon
-              </span>
-            </div>
-            <div className="mb-6 opacity-40">
-              <h2 className="text-xl font-bold">Cloud</h2>
-              <div className="mt-4 flex items-baseline gap-1">
-                <span className="text-5xl font-bold tracking-tight">—</span>
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: "-50px" }}
+            className="grid gap-8 lg:grid-cols-3"
+          >
+            {/* Free Tier */}
+            <motion.div
+              variants={fadeUp}
+              custom={0}
+              className="rounded-xl border-2 border-primary bg-card p-8 relative shadow-lg shadow-primary/5"
+            >
+              <div className="absolute -top-3 left-6 px-3 py-0.5 rounded-full bg-primary text-primary-foreground text-xs font-semibold">
+                Recommended
               </div>
-              <p className="mt-3 text-sm text-muted-foreground">
-                For teams that want hosted infrastructure.
-              </p>
-            </div>
-            <div className="opacity-40">
-              <button
-                disabled
-                className="block w-full rounded-lg border border-border py-2.5 text-center text-sm font-semibold text-muted-foreground cursor-not-allowed"
+
+              <div className="mb-6">
+                <h2 className="text-xl font-bold">Free</h2>
+                <div className="mt-4 flex items-baseline gap-1">
+                  <span className="text-5xl font-bold tracking-tight">
+                    &#8377;0
+                  </span>
+                  <span className="text-muted-foreground text-sm">
+                    / forever
+                  </span>
+                </div>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  Runs locally on your machine
+                </p>
+              </div>
+
+              {/* Tech icons */}
+              <div className="flex items-center gap-3 mb-6 text-muted-foreground">
+                <span title="Docker" className="flex items-center gap-1 text-xs">
+                  <Container className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span title="tmux" className="flex items-center gap-1 text-xs">
+                  <Terminal className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span title="PostgreSQL" className="flex items-center gap-1 text-xs">
+                  <Database className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span title="SQLite" className="flex items-center gap-1 text-xs">
+                  <Server className="h-4 w-4" aria-hidden="true" />
+                </span>
+              </div>
+
+              {/* Install cards */}
+              <div className="space-y-2 mb-6">
+                <InstallCard
+                  icon={Apple}
+                  title="macOS / Linux"
+                  command="go install github.com/rpuneet/bc/cmd/bc@latest"
+                />
+                <InstallCard
+                  icon={Container}
+                  title="Docker"
+                  command="docker pull bcinfra/bc:latest"
+                />
+                <InstallCard
+                  icon={GitBranch}
+                  title="Build from source"
+                  command="git clone https://github.com/rpuneet/bc.git && cd bc && make build"
+                />
+              </div>
+
+              <Link
+                href="https://github.com/gh-curious-otter/bc"
+                className="flex items-center justify-center gap-2 w-full rounded-lg bg-primary py-2.5 text-center text-sm font-semibold text-primary-foreground transition-all hover:opacity-90 active:scale-[0.98]"
+              >
+                Get Started
+                <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+              </Link>
+            </motion.div>
+
+            {/* Cloud Tier */}
+            <motion.div
+              variants={fadeUp}
+              custom={1}
+              className="rounded-xl border border-border bg-card p-8 relative"
+            >
+              <div className="mb-6">
+                <h2 className="text-xl font-bold">Cloud</h2>
+                <div className="mt-4 flex items-baseline gap-1">
+                  <span className="text-5xl font-bold tracking-tight">
+                    &#8377;1,000
+                  </span>
+                  <span className="text-muted-foreground text-sm">
+                    / month
+                  </span>
+                </div>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  Access your workspace from anywhere
+                </p>
+              </div>
+
+              <ul className="space-y-3 mb-6">
+                {[
+                  "SSH into your workspace",
+                  "Chat with agents remotely",
+                  "Everything in Free, plus:",
+                ].map((f) => (
+                  <li
+                    key={f}
+                    className="flex items-start gap-2.5 text-sm text-muted-foreground"
+                  >
+                    <Check
+                      className="h-4 w-4 text-success shrink-0 mt-0.5"
+                      aria-hidden="true"
+                    />
+                    {f}
+                  </li>
+                ))}
+              </ul>
+
+              {/* Tech icons */}
+              <div className="flex items-center gap-3 mb-6 text-muted-foreground">
+                <span title="Kubernetes" className="flex items-center">
+                  <Cpu className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span title="Cloud" className="flex items-center">
+                  <Cloud className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span title="Terminal" className="flex items-center">
+                  <Terminal className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <span title="API Keys" className="flex items-center">
+                  <Key className="h-4 w-4" aria-hidden="true" />
+                </span>
+              </div>
+
+              <Link
+                href="/waitlist"
+                className="block w-full rounded-lg border border-border py-2.5 text-center text-sm font-semibold transition-colors hover:bg-accent/20 active:scale-[0.98]"
               >
                 Join Waitlist
-              </button>
-              <ul className="mt-8 space-y-3">
-                {CLOUD_FEATURES.map((f) => (
-                  <li
-                    key={f}
-                    className="flex items-start gap-2.5 text-sm text-muted-foreground"
-                  >
-                    <Check
-                      className="h-4 w-4 text-muted-foreground/40 shrink-0 mt-0.5"
-                      aria-hidden="true"
-                    />
-                    {f}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
+              </Link>
+            </motion.div>
 
-          {/* Enterprise Tier - Coming Soon */}
-          <div className="rounded-xl border border-border bg-card p-8 relative overflow-hidden">
-            <div className="absolute inset-0 bg-background/60 backdrop-blur-[2px] z-10 flex items-center justify-center">
-              <span className="px-4 py-2 rounded-full border border-border bg-card text-sm font-semibold text-muted-foreground">
-                Coming Soon
-              </span>
-            </div>
-            <div className="mb-6 opacity-40">
-              <h2 className="text-xl font-bold">Enterprise</h2>
-              <div className="mt-4 flex items-baseline gap-1">
-                <span className="text-5xl font-bold tracking-tight">—</span>
+            {/* Enterprise Tier - Blurred */}
+            <motion.div
+              variants={fadeUp}
+              custom={2}
+              className="rounded-xl border border-border/30 bg-card p-8 relative overflow-hidden"
+            >
+              {/* Content behind blur */}
+              <div className="blur-[6px] select-none pointer-events-none">
+                <div className="mb-6">
+                  <h2 className="text-xl font-bold">Enterprise</h2>
+                  <div className="mt-4 flex items-baseline gap-1">
+                    <span className="text-5xl font-bold tracking-tight">
+                      Custom
+                    </span>
+                  </div>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    For teams at scale
+                  </p>
+                </div>
+
+                <div className="flex items-center gap-3 mb-6 text-muted-foreground">
+                  <Lock className="h-4 w-4" />
+                  <Shield className="h-4 w-4" />
+                  <Server className="h-4 w-4" />
+                  <Key className="h-4 w-4" />
+                </div>
+
+                <ul className="space-y-3 mb-6">
+                  {["SSO / SAML", "Audit logs", "Dedicated support", "Custom SLA"].map(
+                    (f) => (
+                      <li
+                        key={f}
+                        className="flex items-start gap-2.5 text-sm text-muted-foreground"
+                      >
+                        <Check className="h-4 w-4 shrink-0 mt-0.5" />
+                        {f}
+                      </li>
+                    )
+                  )}
+                </ul>
+
+                <div className="w-full rounded-lg border border-border py-2.5 text-center text-sm font-semibold">
+                  Contact Sales
+                </div>
               </div>
-              <p className="mt-3 text-sm text-muted-foreground">
-                For organizations with compliance requirements.
-              </p>
-            </div>
-            <div className="opacity-40">
-              <button
-                disabled
-                className="block w-full rounded-lg border border-border py-2.5 text-center text-sm font-semibold text-muted-foreground cursor-not-allowed"
-              >
-                Contact Sales
-              </button>
-              <ul className="mt-8 space-y-3">
-                {ENTERPRISE_FEATURES.map((f) => (
-                  <li
-                    key={f}
-                    className="flex items-start gap-2.5 text-sm text-muted-foreground"
-                  >
-                    <Check
-                      className="h-4 w-4 text-muted-foreground/40 shrink-0 mt-0.5"
-                      aria-hidden="true"
-                    />
-                    {f}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
+
+              {/* Frosted overlay */}
+              <div className="absolute inset-0 bg-background/40 backdrop-blur-sm z-10 flex flex-col items-center justify-center gap-4">
+                <span className="px-5 py-2 rounded-full border border-border/60 bg-card/80 text-sm font-semibold text-muted-foreground backdrop-blur-sm">
+                  Coming soon
+                </span>
+                <a
+                  href="mailto:skitzo@bc-infra.com"
+                  className="text-xs text-muted-foreground/60 hover:text-primary transition-colors"
+                >
+                  Talk to us &rarr; skitzo@bc-infra.com
+                </a>
+              </div>
+            </motion.div>
+          </motion.div>
+
+          {/* FAQ Section */}
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, margin: "-50px" }}
+            className="mt-24 max-w-2xl mx-auto"
+          >
+            <motion.h2
+              variants={fadeUp}
+              custom={0}
+              className="text-2xl font-bold tracking-tight text-center mb-8"
+            >
+              Frequently asked questions
+            </motion.h2>
+            <motion.div variants={fadeUp} custom={1}>
+              <FAQItem
+                question="Is bc really free?"
+                answer="Yes. bc is open source and runs locally on your machine. All features are included with no restrictions. You only pay for AI API tokens from your chosen providers (Claude, Gemini, etc.)."
+              />
+              <FAQItem
+                question="Do I need an account?"
+                answer="No for the Free tier. Install bc, run bc init, and start orchestrating. No signup, no login, no telemetry. The Cloud tier requires a signup for remote access features."
+              />
+              <FAQItem
+                question="What's included in Cloud?"
+                answer="SSH access to your workspace, remote agent chat, hosted dashboard, team management features, and cloud-synced memory. Everything in the Free tier is included plus remote access capabilities."
+              />
+              <FAQItem
+                question="What AI providers work with bc?"
+                answer="bc supports Claude Code, Cursor, Gemini, Codex, Aider, OpenCode, and OpenClaw. You bring your own API keys and bc orchestrates agents across any combination of providers."
+              />
+            </motion.div>
+          </motion.div>
         </div>
 
-        {/* FAQ-like section */}
-        <div className="mt-24 text-center">
-          <h2 className="text-2xl font-bold tracking-tight">
-            Frequently asked questions
-          </h2>
-          <div className="mt-12 grid gap-8 sm:grid-cols-2 text-left max-w-3xl mx-auto">
-            <div>
-              <h3 className="font-semibold mb-2">
-                Is bc really free?
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Yes. bc is open source. All features included, no restrictions.
-                You only pay for AI API tokens from your providers.
-              </p>
-            </div>
-            <div>
-              <h3 className="font-semibold mb-2">
-                Do I need to create an account?
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                No. bc is a local CLI tool. Install it, run{" "}
-                <code className="text-xs bg-muted px-1.5 py-0.5 rounded">
-                  bc init
-                </code>
-                , and start orchestrating. No signup, no login, no telemetry.
-              </p>
-            </div>
-            <div>
-              <h3 className="font-semibold mb-2">
-                What about Cloud and Enterprise?
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                Hosted versions for teams are in development. Join the
-                waitlist or email{" "}
-                <a href="mailto:skitzo@bc-infra.com" className="text-primary hover:underline">
-                  skitzo@bc-infra.com
-                </a>.
-              </p>
-            </div>
-            <div>
-              <h3 className="font-semibold mb-2">
-                What AI providers are supported?
-              </h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">
-                bc supports Claude Code, Cursor, Gemini, Codex, Aider,
-                OpenCode, and OpenClaw. You bring your own API keys.
-              </p>
-            </div>
-          </div>
-        </div>
+        <Footer />
       </div>
-
-      <Footer />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced StatsBar component with 3 minimal inline text badges in HeroSection: "Open source", "CLI-first", "Local"
- Redesigned pricing page with 3 tiers: Free (with interactive install cards), Cloud (with waitlist CTA), Enterprise (frosted glass blur overlay)
- Added expandable FAQ section with updated questions and answers
- All cards use framer-motion scroll animations

## Changes
- `landing/src/app/_components/HeroSection.tsx` — replaced CheckCircle2/Layers badges with circle-dot text badges
- `landing/src/app/page.tsx` — removed StatsBar import and section
- `landing/src/app/pricing/page.tsx` — complete rewrite with 3-tier pricing, install cards, FAQ
- `landing/src/app/pricing/layout.tsx` — added metadata export (since page.tsx is now client component)

## Test plan
- [x] `bun run lint` passes
- [x] `bun run build` passes
- [ ] Visual verification of pricing page at localhost:3000/pricing
- [ ] Verify install card expand/collapse and copy buttons work
- [ ] Verify FAQ accordion expand/collapse
- [ ] Check dark theme rendering
- [ ] Check responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned pricing page with animated reveal effects and interactive elements.
  * Copy-to-clipboard functionality for installation commands.
  * Expandable installation instruction cards and accordion-style FAQ section.

* **UI/UX Improvements**
  * Updated hero section indicators and labels.
  * Cloud tier now fully displayed with pricing and call-to-action.
  * Removed stats bar from home page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->