### PR TITLE
fix: homepage UI polish v2

### DIFF
--- a/landing/src/app/_components/BentoGrid.tsx
+++ b/landing/src/app/_components/BentoGrid.tsx
@@ -50,10 +50,10 @@ function BentoCard({
       animate={inView ? "visible" : "hidden"}
       variants={fadeUp}
       transition={{ delay }}
-      className={`group rounded-xl border border-border bg-card/80 backdrop-blur-sm overflow-hidden transition-all hover:border-primary/30 hover:shadow-lg hover:shadow-primary/5 ${className}`}
+      className={`bento-card group rounded-xl border border-border bg-card/80 backdrop-blur-sm overflow-hidden ${className}`}
     >
       {screenshot && (
-        <div className="overflow-hidden">
+        <div className="overflow-hidden shadow-inner">
           <Image
             src={screenshot}
             alt={screenshotAlt || title}

--- a/landing/src/app/_components/DashboardScreenshots.tsx
+++ b/landing/src/app/_components/DashboardScreenshots.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
+import { motion, AnimatePresence } from "framer-motion";
 
 const TABS = [
   {
@@ -59,16 +60,41 @@ export function DashboardScreenshots() {
         ))}
       </div>
 
-      {/* Screenshot */}
+      {/* Browser chrome + Screenshot */}
       <div className="overflow-hidden rounded-xl border border-border shadow-2xl bg-card">
-        <Image
-          src={TABS[active].src}
-          alt={TABS[active].alt}
-          width={1200}
-          height={750}
-          className="w-full h-auto"
-          priority={active === 0}
-        />
+        {/* Browser chrome header */}
+        <div className="flex items-center gap-3 border-b border-border bg-muted/50 px-4 py-2.5">
+          <div className="flex gap-1.5" aria-hidden="true">
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--traffic-red)]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--traffic-yellow)]" />
+            <span className="h-2.5 w-2.5 rounded-full bg-[var(--traffic-green)]" />
+          </div>
+          <div className="flex-1 rounded-md bg-background/60 border border-border px-3 py-1 text-xs text-muted-foreground font-mono">
+            localhost:9374
+          </div>
+        </div>
+
+        {/* Screenshot with crossfade */}
+        <div className="relative">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={TABS[active].id}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+            >
+              <Image
+                src={TABS[active].src}
+                alt={TABS[active].alt}
+                width={1200}
+                height={750}
+                className="w-full h-auto"
+                priority={active === 0}
+              />
+            </motion.div>
+          </AnimatePresence>
+        </div>
       </div>
     </div>
   );

--- a/landing/src/app/_components/HeroSection.tsx
+++ b/landing/src/app/_components/HeroSection.tsx
@@ -66,7 +66,7 @@ export function HeroSection() {
           >
             <Link
               href="https://github.com/gh-curious-otter/bc"
-              className="group inline-flex h-10 sm:h-11 items-center gap-2 rounded-lg bg-primary px-6 sm:px-8 text-sm font-semibold text-primary-foreground shadow-[var(--btn-shadow)] transition-all hover:shadow-xl hover:shadow-primary/20 active:scale-[0.97]"
+              className="cta-glow group inline-flex h-10 sm:h-11 items-center gap-2 rounded-lg bg-primary px-6 sm:px-8 text-sm font-semibold text-primary-foreground shadow-[var(--btn-shadow)] transition-all hover:shadow-xl hover:shadow-primary/20 active:scale-[0.97]"
               aria-label="Get started with bc on GitHub"
             >
               Get Started

--- a/landing/src/app/_components/TerminalComponents.tsx
+++ b/landing/src/app/_components/TerminalComponents.tsx
@@ -34,7 +34,7 @@ export function TerminalWindow({
           {title}
         </span>
       </div>
-      <div className="p-5 font-mono text-[13px] leading-relaxed text-terminal-text">
+      <div className="p-5 font-mono text-[13px] leading-[1.7] text-terminal-text">
         {children}
       </div>
     </div>

--- a/landing/src/app/globals.css
+++ b/landing/src/app/globals.css
@@ -404,3 +404,14 @@ input:focus-visible,
 .method-page .method-principle-label {
   letter-spacing: 0.3em;
 }
+
+/* Blinking terminal cursor */
+@keyframes terminal-blink { 0%,100% { opacity:1 } 50% { opacity:0 } }
+.terminal-cursor::after { content: '▋'; animation: terminal-blink 1s step-end infinite; color: var(--primary); }
+
+/* Bento card hover glow */
+.bento-card { transition: all 0.2s ease; }
+.bento-card:hover { border-color: rgba(234,88,12,0.3); transform: translateY(-2px); box-shadow: 0 8px 30px rgba(234,88,12,0.08); }
+
+/* CTA button glow on hover */
+.cta-glow:hover { box-shadow: 0 0 20px rgba(234,88,12,0.3); }

--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
 
         <div className="mx-auto max-w-7xl px-4 sm:px-6">
           {/* Problem / Solution */}
-          <RevealSection className="py-12 sm:py-16 lg:py-24" id="problem">
+          <RevealSection className="py-12 sm:py-16 lg:py-28" id="problem">
             <div className="mb-16">
               <span className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                 The problem
@@ -98,7 +98,7 @@ export default function Home() {
           </RevealSection>
 
           {/* How It Works */}
-          <RevealSection className="py-12 sm:py-16 lg:py-24" id="how-it-works">
+          <RevealSection className="py-12 sm:py-16 lg:py-28" id="how-it-works">
             <div className="mb-16 text-center">
               <span className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                 How it works
@@ -169,7 +169,7 @@ export default function Home() {
           </RevealSection>
 
           {/* Feature Bento Grid */}
-          <RevealSection className="py-12 sm:py-16 lg:py-24" id="features">
+          <RevealSection className="py-12 sm:py-16 lg:py-28" id="features">
             <div className="mb-16 text-center">
               <span className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                 Features
@@ -182,7 +182,7 @@ export default function Home() {
           </RevealSection>
 
           {/* Dashboard Preview */}
-          <RevealSection className="py-12 sm:py-16 lg:py-24" id="demo">
+          <RevealSection className="py-12 sm:py-16 lg:py-28" id="demo">
             <div className="mb-12 text-center">
               <span className="font-mono text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                 Dashboard
@@ -214,7 +214,7 @@ export default function Home() {
                   <div className="mt-8 flex flex-wrap items-center gap-4">
                     <Link
                       href="https://github.com/gh-curious-otter/bc"
-                      className="group inline-flex h-12 items-center gap-2 rounded-lg bg-primary px-8 text-sm font-semibold text-primary-foreground shadow-[var(--btn-shadow)] transition-all hover:shadow-xl active:scale-[0.97]"
+                      className="cta-glow group inline-flex h-12 items-center gap-2 rounded-lg bg-primary px-8 text-sm font-semibold text-primary-foreground shadow-[var(--btn-shadow)] transition-all hover:shadow-xl active:scale-[0.97]"
                       aria-label="Get started with bc on GitHub"
                     >
                       Get Started
@@ -249,7 +249,7 @@ export default function Home() {
                       <span className="text-terminal-prompt">$ </span>bc agent
                       create eng-01 --role engineer --tool claude
                     </div>
-                    <div className="text-terminal-comment mt-3 text-[12px]">
+                    <div className="terminal-cursor text-terminal-comment mt-3 text-[12px]">
                       # That&apos;s it. Your agent team is running.
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- Add bento-card hover glow effect (orange border, translateY, box-shadow)
- Add blinking terminal cursor on quickstart last line
- Add CTA glow on hover for primary buttons (hero + final CTA)
- Add browser chrome (traffic light dots + address bar) around dashboard screenshots
- Add AnimatePresence crossfade for smoother screenshot tab transitions
- Increase section spacing (py-24 -> py-28) on major content sections
- Change terminal body line-height to leading-[1.7] for authentic feel

Homepage UI polish — card hovers, terminal cursor, CTA glow, spacing

## Test plan
- [ ] Verify bento cards show orange glow on hover
- [ ] Verify terminal cursor blinks on quickstart section
- [ ] Verify CTA buttons glow on hover (hero + final CTA)
- [ ] Verify dashboard screenshots have browser chrome header
- [ ] Verify screenshot tab switching has smooth crossfade
- [ ] Verify no text content was changed
- [ ] Verify dark theme is preserved
- [ ] Verify animated particle background still works
- [ ] Run `cd landing && bun run lint && bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Animated transitions between screenshots with enhanced browser chrome header display
  * Terminal cursor animation effect added to code examples

* **Style**
  * Enhanced CTA buttons with glow effects on hover
  * Improved card hover animations and interactions
  * Refined spacing and visual polish across landing sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->