### PR TITLE
fix: WebSocket terminal Hijacker error

### DIFF
--- a/server/handlers/logging.go
+++ b/server/handlers/logging.go
@@ -23,9 +23,12 @@ func (r *statusRecorder) WriteHeader(code int) {
 // SSE and MCP long-lived connections are excluded to avoid log spam.
 func RequestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip long-lived SSE/MCP connections
+		// Skip long-lived SSE/MCP connections and WebSocket upgrades.
+		// WebSocket requires http.Hijacker on the ResponseWriter — wrapping
+		// it in statusRecorder breaks the Hijack() call.
 		if strings.HasSuffix(r.URL.Path, "/events") ||
-			strings.HasSuffix(r.URL.Path, "/sse") {
+			strings.HasSuffix(r.URL.Path, "/sse") ||
+			isWebSocketRequest(r) {
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
## Summary

- Fixes `websocket: response does not implement http.Hijacker` error when attaching to agent terminal
- Root cause: `RequestLogger` middleware wraps `ResponseWriter` in `statusRecorder` which doesn't implement `http.Hijacker`
- Fix: Skip WebSocket upgrade requests in `RequestLogger`, same pattern as SSE/MCP connections

## Context

The terminal WebSocket endpoint (`GET /api/agents/:name/terminal`) was failing because the middleware chain wraps the `ResponseWriter` before it reaches the handler. `gorilla/websocket`'s `Upgrade()` calls `Hijack()` internally, which requires the original `http.ResponseWriter`.

The Gzip middleware already had a WebSocket bypass (added in PR #2613), but `RequestLogger` runs *before* Gzip in the chain and was the actual culprit.

## Test plan

- [x] `go test -race ./server/handlers/` passes
- [ ] Deploy and verify `GET /api/agents/steady-badger/terminal` upgrades successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection handling by preventing unnecessary logging overhead for WebSocket upgrade requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->