### PR TITLE
fix: direct MCP SSE delivery, remove broken channel poller

### DIFF
--- a/server/mcp/server.go
+++ b/server/mcp/server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gh-curious-otter/bc/pkg/agent"
@@ -35,10 +34,8 @@ type Server struct {
 	chans      *channel.Store
 	chanSvc    *channel.ChannelService
 	costs      *cost.Store
-	broker     *SSEBroker
-	cancelPoll context.CancelFunc
-	version    string
-	pollWg     sync.WaitGroup
+	broker  *SSEBroker
+	version string
 	ownChans   bool
 	ownCosts   bool
 }
@@ -116,10 +113,6 @@ func New(cfg Config) (*Server, error) {
 // Close releases resources held by the server.
 // Only closes stores that the server created itself (not injected ones).
 func (s *Server) Close() error {
-	if s.cancelPoll != nil {
-		s.cancelPoll()
-		s.pollWg.Wait()
-	}
 	if s.ownChans && s.chans != nil {
 		if err := s.chans.Close(); err != nil {
 			return err
@@ -131,111 +124,35 @@ func (s *Server) Close() error {
 	return nil
 }
 
-// SetBroker attaches an SSE broker and starts polling channels for new messages.
-// New messages are pushed as notifications/message to all connected clients.
+// SetBroker attaches an SSE broker for MCP notifications.
+// Message delivery is now handled directly by the OnMessage callback in
+// server.go — no poller needed.
 func (s *Server) SetBroker(broker *SSEBroker) {
 	s.broker = broker
-	ctx, cancel := context.WithCancel(context.Background())
-	s.cancelPoll = cancel
-	s.pollWg.Add(1)
-	go s.pollChannelMessages(ctx)
 }
 
-// channelMessagePayload is the notification payload for new channel messages.
-type channelMessagePayload struct {
+// ChannelMessagePayload is the notification payload for new channel messages.
+type ChannelMessagePayload struct {
 	Time    time.Time `json:"time"`
 	Channel string    `json:"channel"`
 	Sender  string    `json:"sender"`
 	Message string    `json:"message"`
 }
 
-// pollChannelMessages watches all channels for new messages and pushes them
-// as MCP notifications to connected SSE clients.
-func (s *Server) pollChannelMessages(ctx context.Context) {
-	defer s.pollWg.Done()
-
-	// Track the latest message timestamp per channel to detect new messages.
-	// Using timestamps instead of array length avoids breaking when history
-	// is capped (e.g., GetHistory returns last 100 messages).
-	lastSeen := make(map[string]time.Time)
-
-	// Seed with current latest timestamp so we don't replay old history.
-	for _, ch := range s.chans.List() {
-		history, err := s.chans.GetHistory(ch.Name)
-		if err == nil && len(history) > 0 {
-			lastSeen[ch.Name] = history[len(history)-1].Time
-		}
-	}
-
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			s.checkNewMessages(lastSeen)
-		}
-	}
-}
-
-// checkNewMessages checks each channel for messages newer than lastSeen and pushes them.
-func (s *Server) checkNewMessages(lastSeen map[string]time.Time) {
-	for _, ch := range s.chans.List() {
-		history, err := s.chans.GetHistory(ch.Name)
-		if err != nil || len(history) == 0 {
-			continue
-		}
-
-		cutoff := lastSeen[ch.Name]
-
-		// Find new messages (those with timestamp after cutoff)
-		for _, entry := range history {
-			if !entry.Time.After(cutoff) {
-				continue
-			}
-			s.pushMessageNotification(ch.Name, entry.Sender, entry.Message, entry.Time)
-		}
-
-		// Update watermark to latest message
-		lastSeen[ch.Name] = history[len(history)-1].Time
-	}
-}
-
-// pushMessageNotification sends a notifications/message event to SSE clients
-// that are members of the channel. Non-agent clients (web UI) are skipped.
-func (s *Server) pushMessageNotification(ch, sender, message string, t time.Time) {
-	if s.broker == nil {
-		return
-	}
-
-	notification := Notification{
+// NewChannelNotification creates a notifications/message JSON-RPC notification.
+func NewChannelNotification(ch, sender, message string, t time.Time) Notification {
+	return Notification{
 		JSONRPC: "2.0",
 		Method:  "notifications/message",
-		Params: channelMessagePayload{
+		Params: ChannelMessagePayload{
 			Channel: ch,
 			Sender:  sender,
 			Message: message,
 			Time:    t,
 		},
 	}
-
-	// Look up channel members to filter delivery.
-	members, err := s.chans.GetMembers(ch)
-	if err != nil || len(members) == 0 {
-		// No members or error — skip delivery
-		return
-	}
-
-	// Build member set for O(1) lookup
-	memberSet := make(map[string]bool, len(members))
-	for _, m := range members {
-		memberSet[m] = true
-	}
-
-	s.broker.sendToAgents(notification, memberSet)
 }
+
 
 // Handle processes a single JSON-RPC request and returns the response.
 // For notifications (no ID), the returned Response has a nil ID and no result/error set.

--- a/server/mcp/sse.go
+++ b/server/mcp/sse.go
@@ -148,9 +148,9 @@ func (b *SSEBroker) send(v any) {
 	}
 }
 
-// sendToAgents sends a notification only to clients whose agent name is in the set.
+// SendToAgents sends a notification only to clients whose agent name is in the set.
 // Used for channel-membership-filtered message delivery.
-func (b *SSEBroker) sendToAgents(v any, agents map[string]bool) {
+func (b *SSEBroker) SendToAgents(v any, agents map[string]bool) {
 	if len(agents) == 0 {
 		return
 	}
@@ -230,12 +230,14 @@ func (b *SSEBroker) handleSSE(w http.ResponseWriter, r *http.Request) {
 
 // MountOn registers MCP SSE endpoints on an existing ServeMux under the given prefix.
 // This allows embedding the MCP server into bcd's HTTP server.
-func MountOn(mux *http.ServeMux, srv *Server, prefix string) {
+// Returns the broker so callers can push notifications directly.
+func MountOn(mux *http.ServeMux, srv *Server, prefix string) *SSEBroker {
 	broker := NewSSEBroker()
 	broker.messageEndpoint = prefix + "/message"
 	srv.SetBroker(broker)
 	mux.HandleFunc(prefix+"/sse", broker.handleSSE)
 	mux.HandleFunc(prefix+"/message", srv.HandleSSEMessage(context.Background(), broker))
+	return broker
 }
 
 // LocalhostAddr rewrites a bare ":port" address to "127.0.0.1:port".

--- a/server/server.go
+++ b/server/server.go
@@ -172,15 +172,8 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 					},
 				})
 			}
-			// Agent delivery is handled by the MCP SSE notification path:
-			// pollChannelMessages() in server/mcp/server.go polls channels
-			// every 2s for new messages and pushes notifications/message to
-			// all connected MCP clients (agents). This replaces the previous
-			// tmux send-keys approach which required channel membership and
-			// was fragile (terminal interference, buffering issues).
-			//
-			// Messages are persisted to SQLite before OnMessage fires, so
-			// the MCP poller will pick them up on the next tick (~2s delay).
+			// Agent delivery via MCP SSE is wired below after MCP server
+			// initialization — see the mcpBroker.SendToAgents call.
 		}
 		handlers.NewChannelHandler(svc.Channels).Register(mux)
 		handlers.NewChannelStatsHandler(svc.Channels).Register(mux)
@@ -230,7 +223,31 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		if mcpErr != nil {
 			log.Warn("MCP server unavailable", "error", mcpErr)
 		} else {
-			servermcp.MountOn(mux, mcpSrv, "/mcp")
+			mcpBroker := servermcp.MountOn(mux, mcpSrv, "/mcp")
+
+			// Wire MCP SSE delivery into the OnMessage callback.
+			// When a channel message is stored, push a notification directly
+			// to member agents via the MCP SSE broker — no poller needed.
+			if svc.Channels != nil && mcpBroker != nil {
+				prevOnMessage := svc.Channels.OnMessage
+				svc.Channels.OnMessage = func(ch, sender, content string) {
+					// Call previous OnMessage (gateway routing + web UI hub)
+					if prevOnMessage != nil {
+						prevOnMessage(ch, sender, content)
+					}
+					// Push MCP SSE notification to channel members
+					members, err := svc.Channels.Store().GetMembers(ch)
+					if err != nil || len(members) == 0 {
+						return
+					}
+					memberSet := make(map[string]bool, len(members))
+					for _, m := range members {
+						memberSet[m] = true
+					}
+					notification := servermcp.NewChannelNotification(ch, sender, content, time.Now())
+					mcpBroker.SendToAgents(notification, memberSet)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Fixes channel message delivery to agents — messages are now pushed immediately via MCP SSE, not polled
- Removes the broken `pollChannelMessages` goroutine that failed on channels with 100+ messages
- Net: -108 lines, +44 lines

## Root cause

The poller called `GetHistory(100)` every 2 seconds for every channel. For `slack:all-bc` with 100+ messages, the poller's watermark was seeded from the 100th-newest message at startup. New messages were stored but `GetHistory(100)` returned the same 100 newest — the watermark never advanced past the initial seed because the "new" messages were already in the returned set.

## Fix

Push notifications directly from the `OnMessage` callback instead of polling:

```
OnMessage fires (message already in SQLite)
  → Gateway routing (unchanged)
  → Web UI SSE hub (unchanged)
  → NEW: mcpBroker.SendToAgents(notification, memberSet)
    → Immediate delivery to member agents via MCP SSE
```

Zero delay, no polling, no history limit bugs.

## Changes

- `server/server.go`: OnMessage callback wraps previous handler, adds direct `mcpBroker.SendToAgents()` with channel membership lookup
- `server/mcp/sse.go`: `MountOn()` returns `*SSEBroker`, exported `SendToAgents()`
- `server/mcp/server.go`: Removed `pollChannelMessages`, `checkNewMessages`, `pushMessageNotification`. Exported `NewChannelNotification()`. `SetBroker()` no longer starts goroutine.

## Test plan
- [x] `go test ./server/handlers/` passes
- [x] `go test ./server/mcp/` passes
- [ ] Deploy, send Slack message, verify agents receive immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized message delivery architecture by transitioning from polling-based infrastructure to direct event-based notifications for improved responsiveness and efficiency.
  * Streamlined internal notification handling to enhance message propagation performance across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->