### PR TITLE
fix: restore tmux send-keys delivery with JSON format

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -177,13 +177,17 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 			if svc.Agents != nil {
 				go func() {
 					mentionedAgents, _ := channel.ExtractMentionedAgents(content)
-					payload, _ := json.Marshal(map[string]any{
+					payload, marshalErr := json.Marshal(map[string]any{
 						"timestamp": time.Now().UTC().Format(time.RFC3339),
 						"channel":   ch,
 						"sender":    sender,
 						"content":   content,
 						"mentions":  mentionedAgents,
 					})
+					if marshalErr != nil {
+						log.Warn("channel send: failed to marshal message", "channel", ch, "error", marshalErr)
+						return
+					}
 					msg := string(payload)
 
 					chDTO, err := svc.Channels.Get(context.Background(), ch)


### PR DESCRIPTION
## Summary

Restores tmux send-keys as channel message delivery to agents. MCP SSE notifications are not processed by Claude Code, so agents never received messages via that path.

## Message format

```json
{"timestamp":"2026-03-26T01:00:00Z","channel":"slack:all-bc","sender":"Puneet Rai","content":"message text","mentions":[]}
```

Agents receive structured JSON with full context: timestamp, channel, sender, content, and @mentions.

## Delivery path

```
OnMessage fires
  → Gateway routing (unchanged)
  → Web UI SSE hub (unchanged)
  → JSON payload built with mentions
  → For each channel member (skip sender, skip empty):
    → svc.Agents.Send(member, json) → tmux send-keys
```

## What changed

- Replaced MCP SSE broker wiring with tmux send-keys delivery in OnMessage
- JSON format instead of the old `[bc-mcp][timestamp][#channel] sender: message` text format
- Removed the prevOnMessage/mcpBroker wrapper (MountOn still called for MCP tool calls)

## Test plan
- [x] `go build ./server/...` passes
- [x] `go test ./server/handlers/` passes  
- [x] `go test ./server/mcp/` passes
- [ ] Deploy, send Slack message, verify agents receive JSON via tmux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved channel message delivery: agent notifications are now sent directly and in-process for lower latency and simpler routing. Messages include standardized UTC timestamps and extracted mention lists; the original sender is excluded from distribution. Delivery now has clearer logging for failures, improving reliability and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->