### PR TITLE
fix: idempotent token_metrics inserts

### DIFF
--- a/docker/bcstats/init.sql
+++ b/docker/bcstats/init.sql
@@ -38,6 +38,7 @@ CREATE TABLE IF NOT EXISTS agent_metrics (
 SELECT create_hypertable('agent_metrics', 'time', if_not_exists => TRUE);
 
 -- Token Metrics — per-agent token consumption from JSONL
+-- UNIQUE constraint makes inserts idempotent across bcd restarts.
 CREATE TABLE IF NOT EXISTS token_metrics (
     time          TIMESTAMPTZ NOT NULL,
     agent_name    TEXT NOT NULL DEFAULT '',
@@ -46,7 +47,8 @@ CREATE TABLE IF NOT EXISTS token_metrics (
     output_tokens BIGINT NOT NULL DEFAULT 0,
     cache_read    BIGINT NOT NULL DEFAULT 0,
     cache_create  BIGINT NOT NULL DEFAULT 0,
-    cost_usd      DOUBLE PRECISION NOT NULL DEFAULT 0
+    cost_usd      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    UNIQUE (time, agent_name, model)
 );
 SELECT create_hypertable('token_metrics', 'time', if_not_exists => TRUE);
 

--- a/pkg/stats/record.go
+++ b/pkg/stats/record.go
@@ -31,11 +31,14 @@ func (s *Store) RecordAgent(ctx context.Context, m AgentMetric) error {
 	return nil
 }
 
-// RecordToken inserts a token usage sample.
+// RecordToken inserts a token usage sample. Duplicate entries (same time,
+// agent, model) are silently skipped via ON CONFLICT, making this idempotent
+// across bcd restarts.
 func (s *Store) RecordToken(ctx context.Context, m TokenMetric) error {
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO token_metrics (time, agent_name, model, input_tokens, output_tokens, cache_read, cache_create, cost_usd)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		 ON CONFLICT (time, agent_name, model) DO NOTHING`,
 		m.Time, m.AgentName, m.Model, m.InputTokens, m.OutputTokens, m.CacheRead, m.CacheCreate, m.CostUSD,
 	)
 	if err != nil {

--- a/pkg/stats/store.go
+++ b/pkg/stats/store.go
@@ -103,6 +103,8 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 			disk_write_bytes BIGINT NOT NULL DEFAULT 0
 		)`,
 		// Token metrics — per-agent token consumption from JSONL
+		// UNIQUE constraint on (time, agent_name, model) makes inserts
+		// idempotent so bcd restarts don't duplicate historical entries.
 		`CREATE TABLE IF NOT EXISTS token_metrics (
 			time          TIMESTAMPTZ NOT NULL,
 			agent_name    TEXT NOT NULL DEFAULT '',
@@ -111,7 +113,8 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 			output_tokens BIGINT NOT NULL DEFAULT 0,
 			cache_read    BIGINT NOT NULL DEFAULT 0,
 			cache_create  BIGINT NOT NULL DEFAULT 0,
-			cost_usd      DOUBLE PRECISION NOT NULL DEFAULT 0
+			cost_usd      DOUBLE PRECISION NOT NULL DEFAULT 0,
+			UNIQUE (time, agent_name, model)
 		)`,
 		// Channel metrics — message/member/reaction counts
 		`CREATE TABLE IF NOT EXISTS channel_metrics (


### PR DESCRIPTION
## Summary

Fixes CodeRabbit review on PR #2633: bcd restarts replay all historical token events, duplicating rows.

## Fix

- Added `UNIQUE(time, agent_name, model)` constraint on `token_metrics`
- Changed `INSERT` to `INSERT ... ON CONFLICT DO NOTHING`
- Updated both `store.go` (ensureSchema) and `docker/bcstats/init.sql`

Duplicate entries from restart replays are silently skipped.

## Test plan
- [x] `go build ./pkg/stats/` passes
- [ ] Restart bcd, verify no duplicate token rows