### PR TITLE
fix: RequestLogger breaks Flusher for cron live logs SSE

### DIFF
--- a/server/handlers/logging.go
+++ b/server/handlers/logging.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/gh-curious-otter/bc/pkg/log"
@@ -23,12 +22,11 @@ func (r *statusRecorder) WriteHeader(code int) {
 // SSE and MCP long-lived connections are excluded to avoid log spam.
 func RequestLogger(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Skip long-lived SSE/MCP connections and WebSocket upgrades.
-		// WebSocket requires http.Hijacker on the ResponseWriter — wrapping
-		// it in statusRecorder breaks the Hijack() call.
-		if strings.HasSuffix(r.URL.Path, "/events") ||
-			strings.HasSuffix(r.URL.Path, "/sse") ||
-			isWebSocketRequest(r) {
+		// Skip SSE, WebSocket, and other streaming endpoints.
+		// statusRecorder wraps ResponseWriter, breaking http.Flusher
+		// (needed by SSE) and http.Hijacker (needed by WebSocket).
+		// Reuse isSSERequest() to stay in sync with Gzip bypass.
+		if isSSERequest(r) || isWebSocketRequest(r) {
 			next.ServeHTTP(w, r)
 			return
 		}


### PR DESCRIPTION
## Summary

Fixes cron live logs showing "streaming not supported" — `RequestLogger` wraps ResponseWriter in `statusRecorder` which doesn't implement `http.Flusher`.

## Root fix

Instead of adding another path to the hardcoded skip list, switched `RequestLogger` to reuse `isSSERequest()` from helpers.go. Both `Gzip` and `RequestLogger` now use the same function, so new SSE endpoints are automatically bypassed in both middlewares.

## Test plan
- [x] Handler tests pass
- [ ] Deploy, expand running cron job, verify live logs stream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized request-logging middleware's handling of streaming connections to improve detection accuracy and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->