### PR TITLE
fix: publish raw hook JSON via SSE instead of summary format

### DIFF
--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -314,22 +314,13 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		// Publish the full hook event via SSE for web UI
+		// Publish raw hook JSON via SSE for web UI — same format as event log.
 		if h.hub != nil {
-			h.hub.Publish("agent.hook", map[string]any{
-				"agent":         name,
-				"event":         string(payload.Event),
-				"state":         string(targetState),
-				"task":          task,
-				"tool_name":     payload.ToolName,
-				"command":       payload.Command,
-				"error":         payload.Error,
-				"subagent_id":   payload.SubagentID,
-				"subagent_type": payload.SubagentType,
-				"channel":       payload.Channel,
-				"sender":        payload.Sender,
-				"message":       payload.Message,
-			})
+			var raw map[string]any
+			if err := json.Unmarshal(rawBody, &raw); err == nil {
+				raw["agent"] = name
+				h.hub.Publish("agent.hook", raw)
+			}
 		}
 
 		writeJSON(w, http.StatusOK, map[string]any{"ok": true})


### PR DESCRIPTION
## Summary

- Replace the hand-picked summary fields in the `agent.hook` SSE event with the full raw Claude Code hook JSON payload
- Web UI now receives the same data format as the event log — one consistent format instead of two
- Agent name is injected into the raw JSON (comes from URL path, not hook payload)

## Changes

Single file: `server/handlers/agents.go` — 6 additions, 15 deletions

## Test plan

- [x] Go build passes
- [ ] Deploy and verify event log UI shows consistent format

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent hook events now publish complete raw payload data instead of filtered fields, ensuring all relevant information is included in SSE messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->