### PR TITLE
feat: agent-scoped MCP paths /mcp/{agent}/sse

### DIFF
--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -155,14 +155,11 @@ func writeMCPJSON(workspacePath, agentName string, resolved *workspace.ResolvedR
 		if isDocker && entry.URL != "" {
 			entry.URL = rewriteDockerURL(entry.URL)
 		}
-		// Append agent identity to SSE URLs so the MCP server knows the caller.
-		// This is used by send_message to set the correct sender automatically.
+		// Rewrite MCP SSE URL to include agent identity in the path.
+		// /mcp/sse → /mcp/{agentName}/sse
+		// This is permanent — survives config regeneration unlike ?agent= query params.
 		if entry.URL != "" && strings.Contains(entry.URL, "/mcp/sse") {
-			sep := "?"
-			if strings.Contains(entry.URL, "?") {
-				sep = "&"
-			}
-			entry.URL += sep + "agent=" + agentName
+			entry.URL = strings.Replace(entry.URL, "/mcp/sse", "/mcp/"+agentName+"/sse", 1)
 		}
 		if def.Transport == "sse" {
 			entry.Type = "sse"

--- a/server/mcp/sse.go
+++ b/server/mcp/sse.go
@@ -197,11 +197,18 @@ func (b *SSEBroker) handleSSE(w http.ResponseWriter, r *http.Request) {
 	ch := b.subscribe(agentID)
 	defer b.unsubscribe(ch)
 
-	// Include agent identity in the message endpoint URL so tool calls
-	// know which agent is the caller (used by send_message for sender).
+	// Build the message endpoint URL with agent identity.
+	// If the agent connected via /mcp/{agent}/sse, point to /mcp/{agent}/message.
+	// Otherwise fall back to legacy ?agent= query param.
 	endpoint := b.messageEndpoint
 	if agentID != "" {
-		endpoint += "?agent=" + url.QueryEscape(agentID)
+		// Derive agent-scoped message path from the SSE request path.
+		// e.g., /mcp/swift-hawk/sse → /mcp/swift-hawk/message
+		if strings.Contains(r.URL.Path, "/"+agentID+"/sse") {
+			endpoint = strings.Replace(r.URL.Path, "/sse", "/message", 1)
+		} else {
+			endpoint += "?agent=" + url.QueryEscape(agentID)
+		}
 	}
 	// Send endpoint event so client knows where to POST
 	fmt.Fprintf(w, "event: endpoint\ndata: %s\n\n", endpoint) //nolint:errcheck // writing to response
@@ -229,14 +236,48 @@ func (b *SSEBroker) handleSSE(w http.ResponseWriter, r *http.Request) {
 }
 
 // MountOn registers MCP SSE endpoints on an existing ServeMux under the given prefix.
-// This allows embedding the MCP server into bcd's HTTP server.
+// Supports both legacy paths (/mcp/sse) and agent-scoped paths (/mcp/{agent}/sse).
 // Returns the broker so callers can push notifications directly.
 func MountOn(mux *http.ServeMux, srv *Server, prefix string) *SSEBroker {
 	broker := NewSSEBroker()
 	broker.messageEndpoint = prefix + "/message"
 	srv.SetBroker(broker)
+
+	// Legacy endpoints (no agent identity — backward compatible)
 	mux.HandleFunc(prefix+"/sse", broker.handleSSE)
 	mux.HandleFunc(prefix+"/message", srv.HandleSSEMessage(context.Background(), broker))
+
+	// Agent-scoped endpoints: /mcp/{agent}/sse and /mcp/{agent}/message
+	// The agent name is extracted from the URL path, not a query param.
+	mux.HandleFunc(prefix+"/", func(w http.ResponseWriter, r *http.Request) {
+		// Parse: prefix + "/{agent}/{action}"
+		remainder := strings.TrimPrefix(r.URL.Path, prefix+"/")
+		parts := strings.SplitN(remainder, "/", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			http.NotFound(w, r)
+			return
+		}
+		agentName := parts[0]
+		action := parts[1]
+
+		switch action {
+		case "sse":
+			// Inject agent name — handleSSE reads from query param,
+			// so set it on the URL to reuse the same handler.
+			q := r.URL.Query()
+			q.Set("agent", agentName)
+			r.URL.RawQuery = q.Encode()
+			broker.handleSSE(w, r)
+		case "message":
+			q := r.URL.Query()
+			q.Set("agent", agentName)
+			r.URL.RawQuery = q.Encode()
+			srv.HandleSSEMessage(context.Background(), broker)(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
 	return broker
 }
 


### PR DESCRIPTION
## Summary

Fixes agent identity being dropped from MCP SSE connections when `.mcp.json` is regenerated.

## Problem

The `?agent=name` query param on `/mcp/sse?agent=name` gets lost when `/mcp` dialog or `/reload-plugins` regenerates `.mcp.json` — they read the raw URL from the MCP store (which has no `?agent=`) and overwrite the file.

## Fix

Agent identity is now part of the URL **path**, not a query param:
```
Old: /mcp/sse?agent=swift-hawk        (fragile — param gets dropped)
New: /mcp/swift-hawk/sse              (permanent — part of the URL)
```

## How it works

`MountOn` registers a wildcard handler at `prefix + "/"` that:
1. Extracts agent name from path: `/mcp/{agent}/sse` or `/mcp/{agent}/message`
2. Injects it as a query param on the request (reuses existing handler logic)
3. Routes to `handleSSE` or `HandleSSEMessage`

`writeMCPJSON` now rewrites `/mcp/sse` → `/mcp/{agentName}/sse` in the URL path.

Legacy `/mcp/sse` and `/mcp/message` endpoints still work (backward compatible).

## Test plan
- [x] `go build` passes
- [x] `go test ./server/mcp/` passes (31s, all green)
- [ ] Deploy, verify agents connect via `/mcp/{agent}/sse`
- [ ] Verify `send_message` sender is correct
- [ ] Verify `/mcp` dialog doesn't break agent identity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated MCP SSE endpoint URL configuration to support both new agent-scoped route formats and legacy query parameter formats, ensuring backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->