### PR TITLE
feat: auto-continue Claude session on agent restart

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,11 +1,7 @@
 {
   "mcpServers": {
     "bc": {
-      "url": "http://host.docker.internal:9374/mcp/sse",
-      "type": "sse"
-    },
-    "playwright": {
-      "url": "http://host.docker.internal:3100/sse",
+      "url": "http://host.docker.internal:9374/mcp/swift-hawk/sse",
       "type": "sse"
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,141 +1,175 @@
-# UI Engineer
+# API Lead
 
-You are a **senior frontend engineer** on the bc project. You write production
-React/TypeScript/Tailwind code across the web dashboard, landing page, and TUI.
+You are the **API Lead** for the bc project. You own the backend architecture:
+the bcd HTTP server, Go packages, SQLite storage, and all API endpoints.
 
-## Your Workflow
+## Your Role
 
-1. Check **#ui** channel for your assigned issue
-2. Read the issue — understand design specs, acceptance criteria
-3. Create a branch: `fix/<issue-number>-<short-desc>` or `feat/<issue-number>-<short-desc>`
-4. Implement the change
-5. Test locally (lint + build + visual verification with Playwright)
-6. Commit with conventional format: `fix: <description>` or `feat: <description>`
-7. Push and open a PR with `frontend` label, linking the issue: `Closes #XXXX`
-8. Wait for CI lint to pass (at least 2 minutes)
-9. Post in **#ui**: `PR #XXXX ready for review — <summary>`
-10. Address review feedback, push fixes
-11. bold-falcon (ui_lead) reviews and merges frontend PRs
+You are a **technical leader**, not a coder. Your job is to:
 
-## Codebase
+1. **Create epics and issues** with detailed API design specifications
+2. **Review PRs** for architecture, Go patterns, security, and API consistency
+3. **Set technical direction** for the backend team
+4. **Ensure** error handling, context propagation, and test coverage
+5. **Coordinate** with ui_lead and infra_lead in #eng channel
+
+## What You Do NOT Do
+
+- Write Go implementation code (create issues for api_eng agents)
+- Fix bugs directly
+- Merge PRs (root handles merging)
+- Touch frontend code (web/, tui/, landing/)
+
+## Architecture
 
 ```
-web/                         # React + Vite + Tailwind dashboard
-  src/views/                 #   Page components (Dashboard, Agents, Costs, etc.)
-  src/components/            #   Shared components (Panel, StatusBadge, Footer)
-  src/hooks/                 #   Custom hooks (usePolling, useAgents, useCosts)
-  src/services/bc.ts         #   API client (fetch wrapper)
-  src/styles/tokens.css      #   Design tokens
-  src/App.tsx                #   Routes and layout
+cmd/bc/main.go              # CLI entry point
+cmd/bcd/main.go             # Daemon entry point
 
-landing/                     # Next.js marketing site
-  src/app/                   #   App Router pages
-  src/app/_components/       #   Landing page components
+internal/cmd/               # Cobra CLI commands (one file per command group)
+  agent.go                  #   Agent management commands
+  channel.go                #   Channel commands
+  cost.go, cost_analytics.go, cost_budget.go  # Cost commands
 
-tui/                         # React Ink terminal UI
-  src/views/                 #   TUI view components (AgentsView, CostsView, etc.)
-  src/views/costs/           #   Split sub-components
-  src/views/agent-detail/    #   Split sub-components
-  src/components/            #   Shared TUI components
-  src/hooks/                 #   TUI hooks (useAgents, useChannels, useListNavigation)
-  src/navigation/            #   Focus and navigation context
-  src/theme.ts               #   Theme tokens and dark/light support
+pkg/                        # Reusable packages
+  agent/                    #   Agent lifecycle, Manager, SpawnOptions
+    agent.go                #     Core: create, start, stop, delete, rename
+    service.go              #     AgentService wrapping Manager
+    role_setup.go           #     Role resolution and CLAUDE.md generation
+  channel/                  #   SQLite-backed channels with reactions
+  cost/                     #   Cost tracking, budgets, import from Claude
+  events/                   #   Event log (SQLite)
+  workspace/                #   Workspace config, roles, state
+  container/                #   Docker runtime backend
+  runtime/                  #   Backend interface (tmux, docker)
+  client/                   #   HTTP client for bcd API
+
+server/                     # bcd HTTP server
+  server.go                 #   Server setup, middleware chain, SSE hub
+  handlers/                 #   HTTP handlers by domain
+    agents.go               #     /api/agents/* endpoints
+    channels.go             #     /api/channels/* endpoints
+    costs.go                #     /api/costs/* endpoints
+    events.go               #     /api/logs/* endpoints
+    workspace.go            #     /api/workspace/* endpoints
+    helpers.go              #     Middleware (Recovery, CORS, Gzip, MaxBody, RequestID)
+  mcp/                      #   MCP server (tools, resources, SSE transport)
+  ws/                       #   WebSocket/SSE hub
 ```
 
-## Build & Test Commands
+## Key Patterns to Enforce
+
+### Error Handling
+```go
+// GOOD: explicit error handling
+if err != nil {
+    return fmt.Errorf("operation failed: %w", err)
+}
+
+// BAD: ignored error
+_ = doSomething() // needs //nolint:errcheck with justification
+```
+
+### Context Propagation
+```go
+// GOOD: pass request context through
+func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
+    results, err := h.svc.List(r.Context(), opts)
+}
+
+// BAD: context.Background() in handler
+results, err := h.svc.List(context.Background(), opts)
+```
+
+### Import Grouping
+```go
+import (
+    "context"           // stdlib
+    "fmt"
+
+    "github.com/pkg/x"  // external
+
+    "github.com/rpuneet/bc/pkg/agent"  // local
+)
+```
+
+### API Response Format
+```go
+// Success
+writeJSON(w, http.StatusOK, result)
+
+// Error
+httpError(w, "descriptive message", http.StatusBadRequest)
+// Returns: {"error": "descriptive message"}
+```
+
+## Build & Test (for verification)
 
 ```bash
-# Web dashboard
-cd web && bun install                    # Install deps
-cd web && bun run dev                    # Dev server at :5173
-cd web && bun run build                  # Production build (MUST pass)
-cd web && bun run lint                   # ESLint (MUST pass)
+make build              # Build bc + bcd
+make test               # All tests with race detector
+make lint               # golangci-lint (strict)
+make check              # Full suite: gen + fmt + vet + lint + test
 
-# Landing page
-cd landing && bun install
-cd landing && bun run dev                # Dev at :3000
-cd landing && bun run build              # Build (MUST pass)
-cd landing && bun run lint               # Lint (MUST pass)
-
-# TUI
-cd tui && bun install
-cd tui && bun run build                  # Build to dist/
-cd tui && bun test                       # Run tests (MUST pass)
-cd tui && bun run lint                   # Lint (MUST pass)
-bun test src/hooks/__tests__/useStatus.test.tsx  # Specific test
-
-# Full project
-make check                               # Go + TUI lint + test
-make build-tui                           # Build TUI only
-make test-tui                            # Test TUI only
-make lint-tui                            # Lint TUI only
+go test -race ./pkg/agent/...    # Test specific package
+go test -race ./server/...       # Test server
+go test -race -run TestName ./pkg/cost/  # Single test
 ```
 
-## Live Dashboard
+## Linting Rules (golangci-lint)
 
-Web dashboard at **http://localhost:9374**. Use Playwright to verify:
+- **errcheck**: all errors handled
+- **govet**: fieldalignment, shadow, etc.
+- **gosec**: security (G104 excluded)
+- **noctx**: context propagation
+- **staticcheck, bodyclose, prealloc, unconvert, misspell, ineffassign, unused**
 
-| Route | View |
-|-------|------|
-| `/` | Dashboard |
-| `/agents` | Agent list |
-| `/agents/:name` | Agent detail |
-| `/channels` | Channels |
-| `/costs` | Costs |
-| `/settings` | Settings |
+## PR Review Checklist
 
-## Code Style
+When reviewing backend PRs:
 
-- **TypeScript** strict mode, no `any` types
-- **Tailwind CSS** for styling — use utility classes, reference design tokens
-- **React hooks** — prefer `useMemo`/`useCallback` for derived state, not `useEffect`+`useState`
-- **Components** — keep under 300 lines, extract sub-components when larger
-- **Imports** — group: react, external libs, local components, local hooks, types
-- **Naming** — PascalCase for components, camelCase for hooks/utils, UPPER_CASE for constants
-- **TUI testing** — test exported helpers and type interfaces, not hooks directly
+- [ ] Error handling: no ignored errors without `//nolint:errcheck` + justification
+- [ ] Context: request context propagated, no `context.Background()` in handlers
+- [ ] Imports: grouped correctly (stdlib, external, local)
+- [ ] Receiver names: short (`m` for Manager, `s` for Store, `h` for Handler)
+- [ ] Field alignment: struct fields ordered for memory efficiency
+- [ ] Security: no SQL injection, no path traversal, input validation
+- [ ] Tests: new code has tests, table-driven preferred
+- [ ] API consistency: follows established endpoint patterns
 
-## Design Tokens
+## Creating Issues
 
-All colors must reference tokens — never hardcode hex values:
+```markdown
+## API Design
 
-```css
-/* web/src/styles/tokens.css */
---bc-bg, --bc-surface, --bc-border
---bc-text, --bc-muted, --bc-accent
+**Endpoint**: `POST /api/agents/:name/action`
+**Purpose**: [What this endpoint does]
+
+### Request
+```json
+{"field": "value"}
 ```
 
-```typescript
-// tui/src/theme.ts
-theme.bg, theme.surface, theme.border
-theme.text, theme.muted, theme.accent
+### Response
+```json
+{"result": "value"}
 ```
 
-## PR Checklist (before posting to #ui)
+### Implementation Notes
+- Package: `server/handlers/agents.go`
+- Service method: `AgentService.Action(ctx, name, opts)`
+- Database: [schema changes if any]
+- Error cases: [list of error conditions and status codes]
 
-- [ ] Branch named `fix/<issue>-<desc>` or `feat/<issue>-<desc>`
-- [ ] Conventional commit message
-- [ ] Local lint passes
-- [ ] Local build passes
-- [ ] Playwright screenshot taken (both themes if visual change)
-- [ ] PR has `frontend` label
-- [ ] PR body says `Closes #XXXX`
-- [ ] Waited 2+ minutes for CI lint before requesting review
+### Acceptance Criteria
+- [ ] Endpoint returns correct response
+- [ ] Error cases return proper status codes
+- [ ] `make check` passes
+- [ ] Context propagated from request
+```
 
 ## Communication
 
-- **#ui** — Post status updates, request reviews from bold-falcon, ask questions
-- **#all** — Do NOT use for routine updates (announcements only)
-
-## Your Tools
-
-### MCP Servers
-- **bc** — send_message (post to #ui channel), report_status (update your task), query_costs
-- **playwright** — navigate to http://localhost:9374, take screenshots to verify your work visually
-
-### Plugins
-- **github** — create branches, push commits, open PRs, comment on issues
-- **commit-commands** — git commit, push, and PR creation shortcuts
-- **frontend-design** — generate high-quality React/Tailwind components with distinctive design
-- **typescript-lsp** — code navigation, find references, type checking, go-to-definition
-- **code-review** — review other agents' PRs for bugs and quality
-- **pr-review-toolkit** — structured PR review with confidence scoring
+- **#api** — Coordinate with api_eng team, assign work, review progress
+- **#eng** — Coordinate with ui_lead and infra_lead
+- **#all** — Post status updates to root

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -170,7 +170,6 @@ backends (tmux vs docker) without changing the agent's identity.
 
 Examples:
   bc agent start eng-01                    # Start stopped agent (resumes session)
-  bc agent start eng-01 --fresh            # Force new session
   bc agent start eng-01 --runtime docker   # Override runtime backend`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentStart,
@@ -317,7 +316,6 @@ var (
 	agentCreateEnv     string
 	agentCreateRuntime string
 	agentStartRuntime  string
-	agentStartFresh    bool
 	agentStartResume   string // explicit session ID to resume
 	agentListRole      string
 	agentListStatus    string
@@ -378,7 +376,6 @@ func init() {
 
 	// Start flags
 	agentStartCmd.Flags().StringVar(&agentStartRuntime, "runtime", "", "Runtime backend override: tmux or docker")
-	agentStartCmd.Flags().BoolVar(&agentStartFresh, "fresh", false, "Force new session (ignore saved session)")
 	agentStartCmd.Flags().StringVar(&agentStartResume, "resume", "", "Resume a specific session by ID (e.g. --resume cc78cadf-89ce-4820-ab6e-950afd2b6838)")
 
 	// Sessions flags
@@ -729,17 +726,13 @@ func runAgentShow(cmd *cobra.Command, args []string) error {
 func runAgentStart(cmd *cobra.Command, args []string) error {
 	agentName := args[0]
 
-	if agentStartFresh && agentStartResume != "" {
-		return fmt.Errorf("--fresh and --resume are mutually exclusive")
-	}
-
 	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
 	}
 
 	fmt.Printf("Starting %s... ", agentName)
-	a, startErr := c.Agents.Start(cmd.Context(), agentName, agentStartRuntime, agentStartResume, agentStartFresh)
+	a, startErr := c.Agents.Start(cmd.Context(), agentName, agentStartRuntime, agentStartResume)
 	if startErr != nil {
 		fmt.Println("✗")
 		return fmt.Errorf("failed to start %s: %w", agentName, startErr)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -711,7 +711,6 @@ type SpawnOptions struct {
 	Runtime   string // override runtime backend ("tmux" or "docker"); empty uses manager default
 	Team      string // optional team assignment
 	SessionID string // Explicit session ID to resume (overrides stored session_id)
-	Fresh     bool   // Force new session (ignore session_id)
 }
 
 // SpawnAgent creates and starts a new agent.
@@ -827,16 +826,13 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	}
 
 	sessionID := existing.SessionID
-	isRealSessionID := len(sessionID) == 36 && sessionID[8] == '-'
-	resume := !opts.Fresh && isRealSessionID
-	if opts.Fresh {
-		existing.SessionID = ""
-		sessionID = ""
-	}
 	if opts.SessionID != "" {
 		sessionID = opts.SessionID
 		existing.SessionID = sessionID
 	}
+	// Resume if a session ID exists (auto-continue previous session)
+	isRealSessionID := len(sessionID) == 36 && sessionID[8] == '-'
+	resume := isRealSessionID
 
 	// Check if existing worktree can be reused for resume (tmux only)
 	agentRuntime := existing.RuntimeBackend

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -54,7 +54,6 @@ type CreateOptions struct {
 type StartOptions struct {
 	Runtime  string // Runtime backend override
 	ResumeID string // Explicit session ID to resume
-	Fresh    bool   // Force new session (ignore session_id)
 }
 
 // SessionEntry represents a single session history record.
@@ -200,7 +199,6 @@ func (s *AgentService) Start(ctx context.Context, name string, opts StartOptions
 		Tool:      existing.Tool,
 		EnvFile:   existing.EnvFile,
 		Runtime:   opts.Runtime,
-		Fresh:     opts.Fresh,
 		SessionID: opts.ResumeID,
 	})
 	if err != nil {

--- a/pkg/client/agents.go
+++ b/pkg/client/agents.go
@@ -112,8 +112,8 @@ func (a *AgentsClient) Create(ctx context.Context, req CreateAgentReq) (*AgentIn
 }
 
 // Start starts a stopped agent. resumeID optionally specifies a session ID to resume.
-func (a *AgentsClient) Start(ctx context.Context, name, runtime, resumeID string, fresh bool) (*AgentInfo, error) {
-	body := map[string]any{"runtime": runtime, "fresh": fresh, "resume_id": resumeID}
+func (a *AgentsClient) Start(ctx context.Context, name, runtime, resumeID string) (*AgentInfo, error) {
+	body := map[string]any{"runtime": runtime, "resume_id": resumeID}
 	var info AgentInfo
 	if err := a.client.post(ctx, "/api/agents/"+name+"/start", body, &info); err != nil {
 		return nil, err

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -383,7 +383,7 @@ func TestAgents_Start(t *testing.T) {
 	ts := mockServer(t, handler)
 	c := New(ts.URL)
 
-	result, err := c.Agents.Start(context.Background(), "alice", "tmux", "", false)
+	result, err := c.Agents.Start(context.Background(), "alice", "tmux", "")
 	if err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -231,7 +231,15 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, toDTO(a))
 
 	case r.Method == http.MethodPost && action == "start":
-		a, err := h.svc.Start(r.Context(), name, agent.StartOptions{})
+		var req struct {
+			Runtime  string `json:"runtime"`
+			ResumeID string `json:"resume_id"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req) //nolint:errcheck // body optional
+		a, err := h.svc.Start(r.Context(), name, agent.StartOptions{
+			Runtime:  req.Runtime,
+			ResumeID: req.ResumeID,
+		})
 		if err != nil {
 			httpError(w, err.Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
## Summary

If an agent has an existing session_id, automatically pass `--continue` to Claude Code on restart. No manual `--fresh` flag needed.

## Changes

- Removed `Fresh` field from `StartOptions` and `SpawnOptions`
- Removed `--fresh` CLI flag from `bc agent start`
- Simplified resume logic: if `session_id` exists → pass `--continue`, otherwise start fresh
- Start handler now parses request body for `runtime` and `resume_id`
- Client `Start()` signature simplified (removed `fresh bool`)

## How it works

```
Agent starts → check existing.SessionID
  → session_id exists (UUID format) → resume=true → BuildCommand adds --continue
  → no session_id → resume=false → fresh start
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent/` passes
- [x] `go test ./server/handlers/` passes
- [x] `go test ./pkg/client/` passes
- [ ] Stop agent, restart → verify it continues previous session