### PR TITLE
feat: add Playwright to docker-compose with shared volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ server/web/dist/assets/
 
 .mcp.json
 *.tsbuildinfo
+.bc/tmp/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# Local development stack: bcd server + bcdb Postgres
+# Local development stack: bcd server + bcdb Postgres + Playwright MCP
 # Usage: docker-compose up
 #
 # Prerequisites: build images first
@@ -31,6 +31,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/workspace
+      - shared-tmp:/tmp/bc-shared
     depends_on:
       bcdb:
         condition: service_healthy
@@ -41,5 +42,14 @@ services:
       start_period: 10s
       retries: 3
 
+  playwright:
+    image: playwright-visible
+    ports:
+      - "3100:3100"
+    volumes:
+      - shared-tmp:/tmp/bc-shared
+    restart: unless-stopped
+
 volumes:
   bcdb-data:
+  shared-tmp:


### PR DESCRIPTION
## Summary

Adds Playwright MCP server to docker-compose.yml with a shared volume so agents can save screenshots and upload them to Slack.

Closes #2667.

## Changes

- Added `playwright` service (image: `playwright-visible`, port 3100)
- Added `shared-tmp` named volume mounted at `/tmp/bc-shared` in both bcd and playwright
- Added `.bc/tmp/` to `.gitignore`

## Usage

After pull:
```bash
git pull origin main
bin/bc down
docker compose up -d
```

Agents save screenshots to `/tmp/bc-shared/`, `send_file` reads from the same path.

## Test plan
- [ ] `docker compose up -d` starts all 3 services
- [ ] Agent saves file to `/tmp/bc-shared/test.png`
- [ ] `send_file` reads from `/tmp/bc-shared/test.png` successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated local development environment configuration to support Playwright testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->