### PR TITLE
fix: harden CI — permissions, blocking checks, concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   GO_VERSION: '1.25.8'
   BUN_VERSION: '1.2'
@@ -67,7 +71,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.out
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   # ── Go: Full Tests (main only) ─────────────────────────────────────
   test-full:
@@ -93,7 +97,6 @@ jobs:
     name: Security
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
         with:
@@ -105,7 +108,6 @@ jobs:
 
       - name: Run govulncheck
         run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
-        continue-on-error: true
 
       - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
@@ -129,7 +131,6 @@ jobs:
         run: cd tui && bun run lint
       - name: Test
         run: cd tui && bun test
-        continue-on-error: true
 
   # ── Build gate (fast tests + lint + tui) ─────────────────────────────
   build:

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     types: [opened, edited, synchronize]
 
+permissions:
+  pull-requests: read
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-quality:
     name: Check PR Quality


### PR DESCRIPTION
## Summary

- **Permissions**: Added explicit `permissions` block to `pr-quality.yml` (pull-requests: read, contents: read) for least-privilege compliance
- **Blocking checks**: Removed `continue-on-error: true` from TUI tests, govulncheck, and security job; set Codecov `fail_ci_if_error: true` so failures are no longer silently ignored
- **Concurrency groups**: Added `concurrency` with `cancel-in-progress: true` to both `ci.yml` and `pr-quality.yml` to avoid redundant runs on rapid pushes

Closes #2617, Closes #2619, Closes #2623
Part of #2614

## Test plan

- [x] `git diff` verified all changes match the spec
- [ ] CI runs on this PR validate the workflow syntax
- [ ] Verify redundant workflow runs are cancelled on force-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline reliability: security checks, test failures, and coverage upload issues now properly fail builds, preventing problematic changes from merging.
  * Improved CI efficiency by canceling redundant workflow runs for the same branch.
  * Added explicit permission controls to quality check workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->