### PR TITLE
fix: validate roles against DB, not filesystem

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -105,6 +105,9 @@ func run(addr, wsRoot, corsOrigin string) error {
 		log.Warn("failed to load agent state", "error", err)
 	}
 	defer agentMgr.Close() //nolint:errcheck // best-effort
+	if ws.RoleManager != nil {
+		agentMgr.SetRoleManager(ws.RoleManager)
+	}
 	agentSvc := bcagent.NewAgentService(agentMgr, hub, nil)
 
 	var channelSvc *bcchannel.ChannelService

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -457,6 +457,9 @@ type Manager struct {
 	// Workspace path for env vars
 	workspacePath string
 
+	// roleManager validates role existence (shared with workspace)
+	roleManager *workspace.RoleManager
+
 	// maxLogBytes is the maximum log file size before truncation.
 	// Defaults to DefaultMaxLogBytes; overridden by ApplyWorkspaceConfig.
 	maxLogBytes int64
@@ -474,6 +477,11 @@ func (m *Manager) SetOnStateChange(fn func(name string, state State, task string
 	m.mu.Lock()
 	m.onStateChange = fn
 	m.mu.Unlock()
+}
+
+// SetRoleManager sets the role manager used for role validation.
+func (m *Manager) SetRoleManager(rm *workspace.RoleManager) {
+	m.roleManager = rm
 }
 
 // ApplyWorkspaceConfig applies workspace-level configuration overrides to the manager.
@@ -772,12 +780,13 @@ func (m *Manager) SpawnAgentWithOptions(ctx context.Context, opts SpawnOptions) 
 		return nil, fmt.Errorf("role is required and cannot be empty or null")
 	}
 
-	// Validate role exists on disk (built-in roles like "root" are always valid)
-	if role != RoleRoot {
-		rm := workspace.NewRoleManager(m.stateDir)
-		if !rm.HasRole(string(role)) {
+	// Validate role exists. Skip validation if no role manager is available
+	// (e.g., standalone agent manager without workspace). Built-in roles
+	// like "root" are always valid.
+	if role != RoleRoot && m.roleManager != nil {
+		if !m.roleManager.HasRole(string(role)) {
 			m.mu.Unlock()
-			return nil, fmt.Errorf("role %q does not exist; create it in .bc/roles/%s.md first", role, role)
+			return nil, fmt.Errorf("role %q does not exist; create it via the API or in .bc/roles/%s.md", role, role)
 		}
 	}
 


### PR DESCRIPTION
Fixes agent creation failing when role exists in DB but no .md file on disk. Uses workspace RoleManager with SQLite store instead of filesystem check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role validation is now conditionally enforced based on agent configuration.

* **Bug Fixes**
  * Improved error messaging for missing role configurations to provide clearer guidance on setup methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->