### PR TITLE
fix: handle Slack file_share events

### DIFF
--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -257,6 +257,10 @@ func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent) {
 	if content == "" && ev.SubType != "file_share" {
 		return
 	}
+	// For file_share events with no text, add a descriptive message
+	if content == "" && ev.SubType == "file_share" {
+		content = "[shared a file]"
+	}
 
 	// Resolve channel name — try cache first, then API lookup
 	a.chatMu.RLock()


### PR DESCRIPTION
When users share files on Slack, agents now see '[shared a file]' instead of the message being silently dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where file share messages could display with empty content. These messages now include a default indicator that a file was shared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->