### PR TITLE
fix: issue numbers no longer link to channel routes

### DIFF
--- a/web/src/components/MessageContent.tsx
+++ b/web/src/components/MessageContent.tsx
@@ -17,7 +17,7 @@ function parseContent(text: string): ReactNode[] {
   // Split on patterns we want to handle, preserving delimiters
   // Order matters: URLs first (greedy), then bold, then code, then #channel, then @mention
   const pattern =
-    /(https?:\/\/[^\s<>)"']+)|(\*\*(?:[^*]|\*(?!\*))+\*\*)|(`[^`]+`)|(\B#[a-zA-Z0-9_-]+\b)|(@[a-zA-Z0-9_-]+)/g;
+    /(https?:\/\/[^\s<>)"']+)|(\*\*(?:[^*]|\*(?!\*))+\*\*)|(`[^`]+`)|(\B#(?=[a-zA-Z0-9_-]*[a-zA-Z])[a-zA-Z0-9_-]+\b)|(@[a-zA-Z0-9_-]+)/g;
 
   const nodes: ReactNode[] = [];
   let lastIndex = 0;


### PR DESCRIPTION
## Summary

Fix issue number references like `#2609` incorrectly linking to `/channels/2609` in message content. One-line regex fix in MessageContent.tsx.

Closes #2681

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message parsing to more accurately identify valid channel references by requiring at least one alphabetic character in channel names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->