### PR TITLE
fix: agents table overflow clipping MCP and Actions columns

### DIFF
--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -483,7 +483,7 @@ export function Agents() {
 
       <CreateAgentForm onCreated={refresh} />
 
-      <div className="rounded border border-bc-border overflow-hidden">
+      <div className="rounded border border-bc-border overflow-x-auto">
         {agentList.length === 0 ? (
           <EmptyState
             icon=">"


### PR DESCRIPTION
## Summary

Fix rightmost columns (MCP, Actions) getting clipped on the Agents table. Changed `overflow-hidden` to `overflow-x-auto`.

🤖 Generated with [Claude Code](https://claude.ai/code)