### PR TITLE
fix: rename MCP mount /mcp → /_mcp (fixes #2677 route conflict)

### DIFF
--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -156,10 +156,10 @@ func writeMCPJSON(workspacePath, agentName string, resolved *workspace.ResolvedR
 			entry.URL = rewriteDockerURL(entry.URL)
 		}
 		// Rewrite MCP SSE URL to include agent identity in the path.
-		// /mcp/sse → /mcp/{agentName}/sse
+		// /_mcp/sse → /mcp/{agentName}/sse
 		// This is permanent — survives config regeneration unlike ?agent= query params.
-		if entry.URL != "" && strings.Contains(entry.URL, "/mcp/sse") {
-			entry.URL = strings.Replace(entry.URL, "/mcp/sse", "/mcp/"+agentName+"/sse", 1)
+		if entry.URL != "" && strings.Contains(entry.URL, "/_mcp/sse") {
+			entry.URL = strings.Replace(entry.URL, "/_mcp/sse", "/mcp/"+agentName+"/sse", 1)
 		}
 		if def.Transport == "sse" {
 			entry.Type = "sse"
@@ -190,8 +190,8 @@ func writeMCPJSON(workspacePath, agentName string, resolved *workspace.ResolvedR
 			if isDocker && bcURL != "" {
 				bcURL = rewriteDockerURL(bcURL)
 			}
-			if bcURL != "" && strings.Contains(bcURL, "/mcp/sse") {
-				bcURL = strings.Replace(bcURL, "/mcp/sse", "/mcp/"+agentName+"/sse", 1)
+			if bcURL != "" && strings.Contains(bcURL, "/_mcp/sse") {
+				bcURL = strings.Replace(bcURL, "/_mcp/sse", "/mcp/"+agentName+"/sse", 1)
 			}
 			cfg.MCPServers["bc"] = mcpServerEntry{URL: bcURL, Type: "sse"}
 		}

--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -138,7 +138,7 @@ func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
 // path (known SSE routes) and by Accept header (generic text/event-stream).
 func isSSERequest(r *http.Request) bool {
 	// Known SSE/streaming paths
-	if r.URL.Path == "/api/events" || strings.HasPrefix(r.URL.Path, "/mcp/") {
+	if r.URL.Path == "/api/events" || strings.HasPrefix(r.URL.Path, "/_mcp/") {
 		return true
 	}
 	// /api/agents/{name}/output is an SSE stream

--- a/server/server.go
+++ b/server/server.go
@@ -258,7 +258,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		if mcpErr != nil {
 			log.Warn("MCP server unavailable", "error", mcpErr)
 		} else {
-			servermcp.MountOn(mux, mcpSrv, "/mcp")
+			servermcp.MountOn(mux, mcpSrv, "/_mcp")
 		}
 	}
 


### PR DESCRIPTION
Fixes /mcp web page 404. Backend SSE mount moved to /_mcp/ to avoid conflicting with the frontend SPA route. All agent configs and MCP store URL updated.