### PR TITLE
fix: add checksum verification to Dockerfile downloads

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -3,7 +3,11 @@
 
 FROM ubuntu:24.04
 
-ENV GOVERSION=1.25.8
+ARG GOVERSION=1.25.8
+# SHA256 checksums from https://go.dev/dl/ for Go ${GOVERSION}
+ARG GO_SHA256_AMD64=ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6
+ARG GO_SHA256_ARM64=7d137f59f66bb93f40a6b2b11e713adc2a9d0c8d9ae581718e3fad19e5295dc7
+ENV GOVERSION=${GOVERSION}
 ENV PATH=/usr/local/go/bin:/root/go/bin:/home/agent/go/bin:$PATH
 ENV TERM=xterm-256color
 ENV LANG=en_US.UTF-8
@@ -19,11 +23,19 @@ RUN apt-get update && \
     locale-gen en_US.UTF-8 && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Go (arch-aware)
-RUN ARCH=$(dpkg --print-architecture | sed 's/amd64/amd64/;s/arm64/arm64/') && \
-    curl -fsSL "https://go.dev/dl/go${GOVERSION}.linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
+# Install Go (arch-aware, download-then-verify pattern)
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ]; then GO_SHA256="$GO_SHA256_AMD64"; else GO_SHA256="$GO_SHA256_ARM64"; fi && \
+    curl -fsSL "https://go.dev/dl/go${GOVERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz && \
+    echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c - && \
+    tar -C /usr/local -xzf /tmp/go.tar.gz && \
+    rm /tmp/go.tar.gz
 
 # Install Bun (for TUI / JS tooling)
+# SECURITY: curl-pipe-bash without checksum verification is a supply chain risk.
+# Bun does not currently publish SHA256 checksums for its install script.
+# Mitigations: pinned BUN_INSTALL path, non-root user created after install.
+# TODO(#2616): pin Bun version and verify checksum when available.
 RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash && \
     ln -sf /usr/local/bin/bun /usr/local/bin/bunx && \
     ln -sf /usr/local/bin/bun /usr/local/bin/node && \

--- a/docker/Dockerfile.bcd
+++ b/docker/Dockerfile.bcd
@@ -41,10 +41,15 @@ COPY --from=go /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install Bun (for TypeScript builds)
+# SECURITY(#2616): curl-pipe-bash without checksum is a supply chain risk.
+# TODO: pin Bun version and verify checksum when available.
 RUN curl -fsSL https://bun.sh/install | bash && \
     ln -s /root/.bun/bin/bun /usr/local/bin/bun
 
 # Install Claude Code so bcd can run tmux agents inside this container
+# SECURITY(#2616): curl-pipe-bash without checksum is a supply chain risk.
+# Anthropic does not currently publish checksums for the install script.
+# TODO: add checksum verification when Anthropic provides signed releases.
 SHELL ["/bin/bash", "-c"]
 RUN curl -fsSL https://claude.ai/install.sh | bash && \
     cp /root/.local/share/claude/versions/* /usr/local/bin/claude && \

--- a/docker/Dockerfile.claude
+++ b/docker/Dockerfile.claude
@@ -7,6 +7,9 @@ FROM bc-agent-base:latest AS base
 USER root
 
 # Install Claude Code native binary (includes syntax highlighting + tree-sitter)
+# SECURITY(#2616): curl-pipe-bash without checksum is a supply chain risk.
+# Anthropic does not currently publish checksums for the install script.
+# TODO: add checksum verification when Anthropic provides signed releases.
 SHELL ["/bin/bash", "-c"]
 RUN curl -fsSL https://claude.ai/install.sh | bash && \
     cp /root/.local/share/claude/versions/* /usr/local/bin/claude && \


### PR DESCRIPTION
## Summary
- Replaces `curl | tar` with download-then-verify pattern for Go tarball in `docker/Dockerfile.base`, using SHA256 checksums from go.dev/dl
- Documents supply chain risks for `curl | bash` patterns (Bun install, Claude Code install) in `Dockerfile.base`, `Dockerfile.bcd`, and `Dockerfile.claude` with tracking TODOs referencing #2616
- Go checksums are parameterized via `ARG` for easy updates when the Go version changes

Part of #2616, Part of #2614

## Test plan
- [ ] Build `docker/Dockerfile.base` on amd64 — verify Go checksum passes and Go is installed correctly
- [ ] Build `docker/Dockerfile.base` on arm64 — verify arm64 checksum is selected and passes
- [ ] Tamper with checksum value and confirm the build fails (proves verification works)
- [ ] Verify Bun and Claude Code installs still succeed (comments only, no functional change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Go download integrity verification with architecture-specific checksums in Docker build configurations
  * Added security documentation for remote installation scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->