### PR TITLE
fix: pin all loose versions for reproducible builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 env:
   GO_VERSION: '1.25.8'
-  BUN_VERSION: '1.2'
+  BUN_VERSION: '1.2.15'
 
 jobs:
   # ── Go: Lint ─────────────────────────────────────────────────────────

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,10 +29,10 @@ jobs:
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.12'
+          python-version: '3.12.9'
       - name: Build docs
         run: |
-          pip install mkdocs-material pymdown-extensions
+          pip install mkdocs-material==9.6.12 pymdown-extensions==10.14.3
           mkdocs build
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9ed2f89a662bf1735a48bc8557fd212fa902bebf # v7
         with:
           distribution: goreleaser
-          version: '~> v2'
+          version: 'v2.8.2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -36,7 +36,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Bun does not currently publish SHA256 checksums for its install script.
 # Mitigations: pinned BUN_INSTALL path, non-root user created after install.
 # TODO(#2616): pin Bun version and verify checksum when available.
-RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash && \
+RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local BUN_VERSION=1.2.15 bash && \
     ln -sf /usr/local/bin/bun /usr/local/bin/bunx && \
     ln -sf /usr/local/bin/bun /usr/local/bin/node && \
     ln -sf /usr/local/bin/bunx /usr/local/bin/npx


### PR DESCRIPTION
## Summary

- Pin `BUN_VERSION` from `1.2` to `1.2.15` in CI workflow
- Pin Python from `3.12` to `3.12.9` in pages workflow
- Pin pip dependencies: `mkdocs-material==9.6.12`, `pymdown-extensions==10.14.3`
- Pin GoReleaser from `~> v2` to `v2.8.2` in release workflow
- Pin Bun install to `1.2.15` in `docker/Dockerfile.base`

Closes #2621
Part of #2614

## Test plan

- [ ] CI workflow runs successfully with pinned BUN_VERSION
- [ ] Pages workflow builds docs with pinned Python and pip versions
- [ ] Release workflow uses exact GoReleaser version
- [ ] Docker agent base image builds with pinned Bun version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment infrastructure dependencies: Bun runtime to 1.2.15, Python to 3.12.9, and pinned specific versions of documentation build tools for consistency and stability.
  * Updated GoReleaser tool version to v2.8.2 for the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->