### PR TITLE
fix: make pr-quality checks blocking for commit format and issue refs

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -25,33 +25,38 @@ jobs:
             const body = context.payload.pull_request.body || '';
             const cleanBody = body.replace(/<!--[\s\S]*?-->/g, '').trim();
 
+            let errors = [];
             let warnings = [];
 
-            // Conventional commit title
-            const conventionalRegex = /^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\(.+\))?: .+/;
+            // Conventional commit title (blocking)
+            const conventionalRegex = /^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\([^)]+\))?: .+/;
             if (!conventionalRegex.test(title)) {
-              warnings.push('Title should follow conventional commit format: type(scope): description');
+              errors.push('Title must follow conventional commit format: type(scope): description');
             }
 
-            // Issue reference
-            if (!/#\d+/.test(body)) {
-              warnings.push('Should reference an issue (e.g., "Fixes #123")');
+            // Issue reference (blocking)
+            if (!/(?:Closes|Fixes|Resolves|Part of) #\d+/i.test(body)) {
+              errors.push('Must reference an issue (e.g., "Fixes #123", "Closes #123", "Part of #123")');
             }
 
-            // Description length
+            // Description length (advisory)
             if (cleanBody.length < 50) {
               warnings.push(`Description is too short (${cleanBody.length} chars, minimum 50)`);
             }
 
-            // Test evidence
+            // Test evidence (advisory)
             if (!/(test plan|testing|tests pass|\[x\].*test)/i.test(body)) {
               warnings.push('Should include a test plan or test evidence');
             }
 
             // Report
-            if (warnings.length === 0) {
-              core.info('✅ PR meets quality guidelines');
-            } else {
+            if (warnings.length > 0) {
               core.warning('PR quality suggestions:');
               warnings.forEach(w => core.warning(`  - ${w}`));
+            }
+            if (errors.length > 0) {
+              errors.forEach(e => core.setFailed(`  - ${e}`));
+            }
+            if (errors.length === 0 && warnings.length === 0) {
+              core.info('✅ PR meets quality guidelines');
             }


### PR DESCRIPTION
## Summary

- Conventional commit format and issue reference checks now use `core.setFailed()` instead of `core.warning()`, blocking non-compliant PRs from merging
- Description length and test evidence checks remain advisory (`core.warning()`)
- Tightened conventional commit scope regex to `(\([^)]+\))?` for proper matching of scopes with dashes
- Tightened issue reference regex to require standard keywords (`Closes`, `Fixes`, `Resolves`, `Part of`)

Closes #2622, Part of #2614

## Test plan

- [x] Verified YAML syntax is valid
- [x] Confirmed `core.setFailed()` is used only for the two critical checks
- [x] Confirmed `core.warning()` is preserved for the two advisory checks
- [x] Verified regex patterns are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request validation workflow with stricter enforcement of commit message formatting and issue reference requirements. Validation failures now block PR merging, while advisory checks provide guidance for best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->