### PR TITLE
fix: correct docker-compose.yml to use bc-bcsql, bc-bcstats, bc-daemon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,64 @@
-# Local development stack: bcd server + bcdb Postgres + Playwright MCP
-# Usage: docker-compose up
+# Local development stack: bc-sql + bc-stats + bcd server + Playwright MCP
+# Usage: docker compose up -d
 #
 # Prerequisites: build images first
-#   make build-bcd-docker build-bcdb-docker
+#   make build-docker
 
 services:
-  bcdb:
-    image: bc-bcdb:latest
+  bc-sql:
+    image: bc-bcsql:latest
+    container_name: bc-sql
     environment:
-      POSTGRES_USER: ${POSTGRES_USER:-bc}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-bc}
-      POSTGRES_DB: ${POSTGRES_DB:-bc}
+      POSTGRES_PASSWORD: bc
     ports:
       - "5432:5432"
     volumes:
-      - bcdb-data:/var/lib/postgresql/data
+      - bc-sql-data:/var/lib/postgresql/data
+    restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U bc -d bc"]
+      test: ["CMD-SHELL", "pg_isready -U bc"]
+      interval: 10s
+      timeout: 5s
+      start_period: 30s
+      retries: 5
+
+  bc-stats:
+    image: bc-bcstats:latest
+    container_name: bc-stats
+    environment:
+      POSTGRES_PASSWORD: bc
+    ports:
+      - "5433:5432"
+    volumes:
+      - bc-stats-data:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U bc"]
       interval: 10s
       timeout: 5s
       start_period: 30s
       retries: 5
 
   bcd:
-    image: bc-bcd:latest
+    image: bc-daemon:latest
+    container_name: bc-daemon
     ports:
-      - "9374:9374"
+      - "${BC_PORT:-9374}:9374"
     environment:
-      DATABASE_URL: postgres://${POSTGRES_USER:-bc}:${POSTGRES_PASSWORD:-bc}@bcdb:5432/${POSTGRES_DB:-bc}?sslmode=disable
+      DATABASE_URL: postgres://bc:bc@bc-sql:5432/bc?sslmode=disable
+      STATS_DATABASE_URL: postgres://bc:bc@bc-stats:5432/bcstats?sslmode=disable
+      BC_HOST_WORKSPACE: ${BC_HOST_WORKSPACE:-.}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/workspace
       - shared-tmp:/tmp/bc-shared
     depends_on:
-      bcdb:
+      bc-sql:
         condition: service_healthy
+      bc-stats:
+        condition: service_healthy
+    restart: always
+    command: ["--addr", "0.0.0.0:9374", "--workspace", "/workspace"]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9374/health"]
       interval: 30s
@@ -44,6 +68,7 @@ services:
 
   playwright:
     image: playwright-visible
+    container_name: bc-playwright
     ports:
       - "3100:3100"
     volumes:
@@ -51,5 +76,6 @@ services:
     restart: unless-stopped
 
 volumes:
-  bcdb-data:
+  bc-sql-data:
+  bc-stats-data:
   shared-tmp:


### PR DESCRIPTION
## Summary

Fix docker-compose.yml which was using non-existent `bc-bcdb` image and missing the `bc-stats` service. Now matches the actual infrastructure used by `bc up`:

- `bc-sql` (bc-bcsql:latest) on port 5432 — Postgres for channels, agents, cost, cron, events
- `bc-stats` (bc-bcstats:latest) on port 5433 — TimescaleDB for metrics
- `bcd` (bc-daemon:latest) on port 9374 — server with both DATABASE_URL and STATS_DATABASE_URL
- `playwright` on port 3100 — shared volume for screenshots

Part of #2675

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restructured database services into separate instances
  * Added health checks for database availability
  * Updated environment variables for new database configuration
  * Changed service container image and startup parameters
  * Modified service dependencies and restart policies
  * Updated data storage volumes

This represents a deployment infrastructure update requiring configuration adjustments for local and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->