### PR TITLE
feat: @mention-only message delivery (#2694)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -200,8 +200,19 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 						log.Debug("channel send: failed to get channel", "channel", ch, "error", err)
 						return
 					}
+					// Build mention set for O(1) lookup
+					hasMentions := len(mentionedAgents) > 0
+					mentionSet := make(map[string]bool, len(mentionedAgents))
+					for _, m := range mentionedAgents {
+						mentionSet[m] = true
+					}
+
 					for _, member := range chDTO.Members {
 						if member == "" || member == sender {
+							continue
+						}
+						// If @mentions exist, only deliver to mentioned agents
+						if hasMentions && !mentionSet[member] {
 							continue
 						}
 						if sendErr := svc.Agents.Send(context.Background(), member, msg); sendErr != nil {


### PR DESCRIPTION
Messages with @mentions only deliver to mentioned agents. No mentions = deliver to all members (backward compat). Reduces noise and token waste. Closes #2694.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced channel message delivery to properly respect @mentions. Previously, messages were broadcast to all channel members regardless of mentions included. Now, messages containing @mentions are delivered exclusively to the mentioned members, enabling more focused and efficient communication within channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->