### PR TITLE
fix: Docker config for ~/.bc workspace architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@
 # POSTGRES_PASSWORD=change-me-in-production
 # POSTGRES_DB=bc
 
+# ─── Workspace Paths ─────────────────────────────────────────────────────────
+# BC home directory (default: ~/.bc/)
+# BC_HOME=
+# Workspace state directory (default: ~/.bc/workspaces/<id>/)
+# BC_STATE_DIR=
+
 # ─── Misc ─────────────────────────────────────────────────────────────────────
 # Disable color output
 # NO_COLOR=1

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,6 +1,10 @@
 # Local development stack: bc-sql + bc-stats + bcd server + Playwright MCP
 # Usage: docker compose up -d
 #
+# Architecture: project source is mounted at /workspace, while workspace state
+# lives under ~/.bc/workspaces/<id>/. The BC_HOME env var overrides the default
+# ~/.bc/ base directory, and BC_STATE_DIR overrides the per-workspace state path.
+#
 # Prerequisites: build images first
 #   make build-docker
 
@@ -52,11 +56,14 @@ services:
       DATABASE_URL: postgres://bc:bc@bc-sql:5432/bc?sslmode=disable
       STATS_DATABASE_URL: postgres://bc:bc@bc-stats:5432/bcstats?sslmode=disable
       BC_HOST_WORKSPACE: ${BC_HOST_WORKSPACE:-/workspace}
+      BC_HOME: /home/agent/.bc
+      # BC_STATE_DIR: override at runtime to set per-workspace state path
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - .:/workspace
+      - ${HOME}/.bc:/home/agent/.bc
       - shared-tmp:/tmp/bc-shared
     networks:
       - bc-net

--- a/docker/Dockerfile.bcd
+++ b/docker/Dockerfile.bcd
@@ -58,13 +58,19 @@ RUN curl -fsSL https://claude.ai/install.sh | bash && \
 
 COPY --from=go /bcd /usr/local/bin/bcd
 
+# Workspace architecture: project source is mounted at /workspace, while
+# workspace state lives under BC_HOME (default ~/.bc/). The BC_STATE_DIR
+# env var can override the per-workspace state path at runtime.
+ENV BC_HOME=/home/agent/.bc
+
 # Runs as root because bcd needs access to the Docker socket
 # (/var/run/docker.sock) to manage agent containers.
 EXPOSE 9374
 HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
     CMD curl -sf http://localhost:9374/health
 
-RUN git config --global --add safe.directory /workspace
+RUN git config --global --add safe.directory /workspace && \
+    git config --global --add safe.directory /home/agent/.bc
 
 WORKDIR /workspace
 ENTRYPOINT ["bash", "-c", "tmux new-session -d -s _bc_init 'sleep infinity' && exec bcd \"$@\"", "--"]


### PR DESCRIPTION
## Summary

Part of #2708. Updates Docker configuration for the workspace architecture refactor that moves state from `<project>/.bc/` to `~/.bc/workspaces/<id>/`.

- **docker-compose.yml.example**: Add `BC_HOME` env var and `~/.bc` volume mount to bcd service; update header comment with new architecture description
- **docker/Dockerfile.bcd**: Add `ENV BC_HOME=/home/agent/.bc` default; mark `/home/agent/.bc` as a git safe directory alongside `/workspace`
- **.env.example**: Document `BC_HOME` and `BC_STATE_DIR` env vars

Backward compatible — existing setups without `BC_HOME` set will continue to work with defaults.

## Test plan

- [ ] `docker build -f docker/Dockerfile.bcd .` succeeds
- [ ] `docker compose -f docker-compose.yml.example config` validates
- [ ] bcd container starts with both `/workspace` and `/home/agent/.bc` accessible
- [ ] Existing setups without `BC_HOME` still work (default fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added configuration options for workspace storage paths, enabling customizable workspace state directory management in both local and containerized environments.
  * Docker setup updated to properly manage and mount workspace state directories with configurable storage locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->