### PR TITLE
feat: auto-migrate .bc/ to ~/.bc/workspaces/<id>/ (#2708)

### DIFF
--- a/pkg/workspace/migrate_v3.go
+++ b/pkg/workspace/migrate_v3.go
@@ -1,0 +1,151 @@
+package workspace
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/gh-curious-otter/bc/pkg/log"
+)
+
+// MigrateToGlobalState moves workspace state from <project>/.bc/ to
+// ~/.bc/workspaces/<id>/. Leaves a .bc-migrated marker in the old location.
+// Returns the new state directory path.
+func MigrateToGlobalState(rootDir string) (string, error) {
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return "", err
+	}
+
+	legacyDir := filepath.Join(absRoot, ".bc")
+	if _, statErr := os.Stat(legacyDir); statErr != nil {
+		return "", fmt.Errorf("no legacy .bc/ directory found in %s", absRoot)
+	}
+
+	newDir, err := GlobalStateDir(absRoot)
+	if err != nil {
+		return "", err
+	}
+
+	if err := EnsureBCHome(); err != nil {
+		return "", err
+	}
+
+	// Create new state directory
+	if err := os.MkdirAll(newDir, 0750); err != nil {
+		return "", fmt.Errorf("failed to create %s: %w", newDir, err)
+	}
+
+	// Copy files from legacy to new location
+	entries, err := os.ReadDir(legacyDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read legacy dir: %w", err)
+	}
+
+	for _, entry := range entries {
+		src := filepath.Join(legacyDir, entry.Name())
+		dst := filepath.Join(newDir, entry.Name())
+
+		if entry.IsDir() {
+			// Copy directory recursively
+			if cpErr := copyDir(src, dst); cpErr != nil {
+				log.Warn("migration: failed to copy directory", "src", src, "error", cpErr)
+				continue
+			}
+		} else {
+			// Copy file
+			if cpErr := migrateFile(src, dst); cpErr != nil {
+				log.Warn("migration: failed to copy file", "src", src, "error", cpErr)
+				continue
+			}
+		}
+	}
+
+	// Write .bc-migrated marker in the old location
+	marker := filepath.Join(legacyDir, ".bc-migrated")
+	markerContent := fmt.Sprintf("Workspace state migrated to: %s\n", newDir)
+	_ = os.WriteFile(marker, []byte(markerContent), 0644) //nolint:gosec
+
+	log.Info("migrated workspace state", "from", legacyDir, "to", newDir)
+	return newDir, nil
+}
+
+// NeedsMigration returns true if the workspace has legacy .bc/ state
+// that hasn't been migrated to ~/.bc/workspaces/<id>/ yet.
+func NeedsMigration(rootDir string) bool {
+	absRoot, err := filepath.Abs(rootDir)
+	if err != nil {
+		return false
+	}
+
+	legacyDir := filepath.Join(absRoot, ".bc")
+	legacySettings := filepath.Join(legacyDir, "settings.json")
+
+	// Legacy exists?
+	if _, err := os.Stat(legacySettings); err != nil {
+		return false
+	}
+
+	// Already migrated?
+	if _, err := os.Stat(filepath.Join(legacyDir, ".bc-migrated")); err == nil {
+		return false
+	}
+
+	// Global dir already has settings?
+	globalDir, gErr := GlobalStateDir(absRoot)
+	if gErr != nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(globalDir, "settings.json")); err == nil {
+		return false // already migrated
+	}
+
+	return true
+}
+
+func migrateFile(src, dst string) error {
+	in, err := os.Open(src) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer in.Close() //nolint:errcheck
+
+	out, err := os.Create(dst) //nolint:gosec
+	if err != nil {
+		return err
+	}
+	defer out.Close() //nolint:errcheck
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Sync()
+}
+
+func copyDir(src, dst string) error {
+	if err := os.MkdirAll(dst, 0750); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if entry.IsDir() {
+			if err := copyDir(srcPath, dstPath); err != nil {
+				return err
+			}
+		} else {
+			if err := migrateFile(srcPath, dstPath); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -118,12 +118,26 @@ func Load(rootDir string) (*Workspace, error) {
 	// Load settings.json — check global dir first, then legacy .bc/
 	jsonPath := filepath.Join(stateDir, "settings.json")
 	if _, statErr := os.Stat(jsonPath); statErr != nil {
-		// Try legacy path
+		// Try legacy path — auto-migrate if found
 		legacyDir := filepath.Join(absRoot, ".bc")
 		legacyPath := filepath.Join(legacyDir, "settings.json")
 		if _, legacyErr := os.Stat(legacyPath); legacyErr == nil {
-			stateDir = legacyDir
-			jsonPath = legacyPath
+			// Auto-migrate legacy .bc/ to ~/.bc/workspaces/<id>/
+			if NeedsMigration(absRoot) {
+				log.Info("migrating workspace state to ~/.bc/", "from", legacyDir)
+				newDir, migrateErr := MigrateToGlobalState(absRoot)
+				if migrateErr == nil {
+					stateDir = newDir
+					jsonPath = filepath.Join(newDir, "settings.json")
+				} else {
+					log.Warn("migration failed, using legacy path", "error", migrateErr)
+					stateDir = legacyDir
+					jsonPath = legacyPath
+				}
+			} else {
+				stateDir = legacyDir
+				jsonPath = legacyPath
+			}
 		} else {
 			// Check for v1 workspace
 			if _, v1Err := os.Stat(filepath.Join(legacyDir, "config.json")); v1Err == nil {


### PR DESCRIPTION
Auto-migration for existing workspaces. Copies state from legacy .bc/ to global ~/.bc/workspaces/<id>/, writes .bc-migrated marker. Transparent, no data loss. Part of #2708.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace state is now automatically migrated from project-local directories to a centralized global configuration directory when first loaded.

* **Chores**
  * Enhanced workspace configuration management with built-in support for legacy layouts and graceful fallback handling during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->