### PR TITLE
fix: migration skips agent worktrees (P0 — was copying 2.9GB)

### DIFF
--- a/pkg/workspace/migrate_v3.go
+++ b/pkg/workspace/migrate_v3.go
@@ -43,18 +43,40 @@ func MigrateToGlobalState(rootDir string) (string, error) {
 		return "", fmt.Errorf("failed to read legacy dir: %w", err)
 	}
 
+	// Only migrate essential state files — skip agent worktrees and
+	// Claude session data (can be multi-GB). Agents will be recreated.
+	essentialFiles := map[string]bool{
+		"settings.json": true,
+		"bc.db":         true,
+		"state.db":      true,
+		"cron.db":       true,
+		"channels.db":   true,
+		"cost.db":       true,
+	}
+	essentialDirs := map[string]bool{
+		"roles": true,
+		"logs":  true,
+	}
+
 	for _, entry := range entries {
-		src := filepath.Join(legacyDir, entry.Name())
-		dst := filepath.Join(newDir, entry.Name())
+		name := entry.Name()
+		src := filepath.Join(legacyDir, name)
+		dst := filepath.Join(newDir, name)
 
 		if entry.IsDir() {
-			// Copy directory recursively
+			if !essentialDirs[name] {
+				log.Debug("migration: skipping directory", "name", name)
+				continue
+			}
 			if cpErr := copyDir(src, dst); cpErr != nil {
 				log.Warn("migration: failed to copy directory", "src", src, "error", cpErr)
 				continue
 			}
 		} else {
-			// Copy file
+			if !essentialFiles[name] {
+				log.Debug("migration: skipping file", "name", name)
+				continue
+			}
 			if cpErr := migrateFile(src, dst); cpErr != nil {
 				log.Warn("migration: failed to copy file", "src", src, "error", cpErr)
 				continue


### PR DESCRIPTION
P0 hotfix. Migration now only copies essential state files (settings.json, .db files, roles/). Skips agent worktrees and Claude session data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace migration to selectively copy only essential state files and directories, preventing unnecessary entries from being migrated during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->