### PR TITLE
fix: Playwright container X11 lock crash on restart

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -86,11 +86,18 @@ services:
     container_name: bc-playwright
     ports:
       - "3100:3100"
+    entrypoint: ["/bin/sh", "-c", "rm -f /tmp/.X*-lock /tmp/.X11-unix/X* 2>/dev/null; exec /entrypoint.sh"]
     volumes:
       - shared-tmp:/tmp/bc-shared
     networks:
       - bc-net
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:3100/sse"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
 
 networks:
   bc-net:


### PR DESCRIPTION
## Summary
- Fixes the "Server is already active for display 99" crash by clearing stale X server lock files (`/tmp/.X*-lock`, `/tmp/.X11-unix/X*`) before starting the entrypoint
- Adds a healthcheck (`curl` against `/sse`) so docker-compose can detect and auto-restart an unresponsive Playwright service

## Test plan
- [ ] `docker compose up -d playwright` starts cleanly on first run
- [ ] `docker compose restart playwright` does not crash with X11 lock error
- [ ] `docker compose ps` shows playwright as healthy after start_period
- [ ] Killing the X server process inside the container and restarting recovers cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)