### PR TITLE
fix: standardize landing TypeScript target to ES2020

### DIFF
--- a/landing/tsconfig.json
+++ b/landing/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Updates `landing/tsconfig.json` target from `ES2017` to `ES2020` to match the web package and ensure Next.js 16 compatibility
- Closes #2625
- Part of #2614

## Details
The three TypeScript packages had inconsistent `target` settings:
| Package | Before | After |
|---------|--------|-------|
| landing | ES2017 | **ES2020** |
| web     | ES2020 | ES2020 (unchanged) |
| tui     | ES2022 | ES2022 (unchanged) |

ES2017 is too old for Next.js 16 and lacks features like optional chaining and nullish coalescing at the type-check level. Updating to ES2020 aligns landing with the web package.

## Test plan
- [ ] `make lint-ts` passes
- [ ] `make build-ts-local` succeeds
- [ ] Landing page renders correctly in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compiler configuration to improve JavaScript output compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->