### PR TITLE
feat: unified storage — consolidate SQLite into shared bc.db (#2642)

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -28,6 +28,7 @@ import (
 
 	bcagent "github.com/gh-curious-otter/bc/pkg/agent"
 	bcchannel "github.com/gh-curious-otter/bc/pkg/channel"
+	bcdb "github.com/gh-curious-otter/bc/pkg/db"
 	bccontainer "github.com/gh-curious-otter/bc/pkg/container"
 	bccost "github.com/gh-curious-otter/bc/pkg/cost"
 	bccron "github.com/gh-curious-otter/bc/pkg/cron"
@@ -84,7 +85,17 @@ func run(addr, wsRoot, corsOrigin string) error {
 		}
 	}
 
-	pidPath := filepath.Join(ws.RootDir, ".bc", "bcd.pid")
+	// Set up shared database connection for all stores.
+	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDB(ws.RootDir)
+	if dbErr != nil {
+		log.Warn("failed to open shared workspace db", "error", dbErr)
+	} else {
+		bcdb.SetShared(sharedDB, sharedDriver)
+		defer bcdb.CloseShared() //nolint:errcheck
+		log.Info("shared database ready", "driver", sharedDriver)
+	}
+
+	pidPath := filepath.Join(ws.StateDir(), "bcd.pid")
 	if err := writePID(pidPath); err != nil {
 		log.Warn("failed to write PID file", "path", pidPath, "error", err)
 	}

--- a/pkg/cron/store.go
+++ b/pkg/cron/store.go
@@ -19,10 +19,20 @@ type Store struct {
 	path string
 }
 
-// Open opens (or creates) the cron database for the given workspace.
+// Open opens (or creates) the cron store for the given workspace.
+// Uses the shared bc.db connection if available, falls back to cron.db.
 func Open(workspacePath string) (*Store, error) {
-	path := filepath.Join(workspacePath, ".bc", "cron.db")
+	// Try shared database first
+	if shared := db.SharedWrapped(); shared != nil {
+		s := &Store{db: shared}
+		if err := s.initSchema(); err != nil {
+			return nil, fmt.Errorf("init cron schema on shared db: %w", err)
+		}
+		return s, nil
+	}
 
+	// Fallback: open own database
+	path := filepath.Join(workspacePath, ".bc", "cron.db")
 	database, err := db.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("open cron database: %w", err)

--- a/pkg/db/unified.go
+++ b/pkg/db/unified.go
@@ -37,6 +37,17 @@ func Shared() *sql.DB {
 	return sharedDB
 }
 
+// SharedWrapped returns the shared database as a *DB wrapper.
+// Returns nil if no shared connection is set.
+func SharedWrapped() *DB {
+	sharedMu.RLock()
+	defer sharedMu.RUnlock()
+	if sharedDB == nil {
+		return nil
+	}
+	return &DB{DB: sharedDB}
+}
+
 // SharedDriver returns "sqlite" or "postgres".
 func SharedDriver() string {
 	sharedMu.RLock()

--- a/pkg/events/store_sqlite.go
+++ b/pkg/events/store_sqlite.go
@@ -15,11 +15,18 @@ type SQLiteLog struct {
 	db *db.DB
 }
 
-// NewSQLiteLog opens (or creates) the events table at dbPath.
+// NewSQLiteLog opens (or creates) the events table.
+// Uses shared bc.db if available, falls back to dbPath.
 func NewSQLiteLog(dbPath string) (*SQLiteLog, error) {
-	d, err := db.Open(dbPath)
-	if err != nil {
-		return nil, fmt.Errorf("open events db: %w", err)
+	var d *db.DB
+	var err error
+	if shared := db.SharedWrapped(); shared != nil {
+		d = shared
+	} else {
+		d, err = db.Open(dbPath)
+		if err != nil {
+			return nil, fmt.Errorf("open events db: %w", err)
+		}
 	}
 
 	schema := `

--- a/pkg/mcp/store.go
+++ b/pkg/mcp/store.go
@@ -42,7 +42,17 @@ type Store struct {
 }
 
 // NewStore creates a new MCP store for the given workspace path.
+// Uses shared bc.db if available, falls back to mcp.db.
 func NewStore(workspacePath string) (*Store, error) {
+	// Try shared database first
+	if shared := db.SharedWrapped(); shared != nil {
+		s := &Store{db: shared}
+		if err := s.initSchema(); err != nil {
+			return nil, fmt.Errorf("init mcp schema on shared db: %w", err)
+		}
+		return s, nil
+	}
+
 	dbPath := filepath.Join(workspacePath, ".bc", "mcp.db")
 	d, err := db.Open(dbPath)
 	if err != nil {

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -102,15 +102,24 @@ func NewStore(stateDir string) *Store {
 	}
 }
 
-// Open initializes the SQLite database and seeds built-in tools.
+// Open initializes the database and seeds built-in tools.
+// Uses shared bc.db if available, falls back to tools.db.
 func (s *Store) Open() error {
-	database, err := db.Open(s.path)
-	if err != nil {
-		return fmt.Errorf("failed to open database: %w", err)
+	var database *db.DB
+	var err error
+	if shared := db.SharedWrapped(); shared != nil {
+		database = shared
+	} else {
+		database, err = db.Open(s.path)
+		if err != nil {
+			return fmt.Errorf("failed to open database: %w", err)
+		}
 	}
 
 	if err := initSchema(database.DB); err != nil {
-		_ = database.Close()
+		if db.SharedWrapped() == nil {
+			_ = database.Close()
+		}
 		return fmt.Errorf("failed to initialize schema: %w", err)
 	}
 


### PR DESCRIPTION
Phase 1 of #2642. All stores use shared bc.db via db.SharedWrapped(). bcd sets up shared connection at startup. Falls back to individual .db files for CLI. One database instead of six.