### PR TITLE
fix: sync test package exclusions between CI and Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Run fast tests with race detector and coverage
         run: |
+          # NOTE: Keep SLOW list in sync with Makefile test-go-fast target
           SLOW="github.com/rpuneet/bc/pkg/tmux github.com/rpuneet/bc/pkg/secret github.com/rpuneet/bc/pkg/doctor github.com/rpuneet/bc/internal/cmd"
           PACKAGES=$(go list ./... | grep -v -F "$(echo $SLOW | tr ' ' '\n')")
           go test -race -coverprofile=coverage.out $PACKAGES

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,8 @@ test-go: ## Run Go tests with race detector
 	$(GO) test -race ./...
 
 test-go-fast: ## Run Go tests excluding slow packages
-	$(GO) test -race $$($(GO) list ./... | grep -v -F "github.com/rpuneet/bc/internal/cmd")
+	# NOTE: Keep SLOW list in sync with .github/workflows/ci.yml "Run fast tests" step
+	$(GO) test -race $$($(GO) list ./... | grep -v -F "$$(printf 'github.com/rpuneet/bc/pkg/tmux\ngithub.com/rpuneet/bc/pkg/secret\ngithub.com/rpuneet/bc/pkg/doctor\ngithub.com/rpuneet/bc/internal/cmd')")
 
 test-ts: test-tui test-web test-landing ## Run all TS tests
 


### PR DESCRIPTION
## Summary
- Aligns the "slow packages" exclusion list between CI fast tests (`.github/workflows/ci.yml`) and the Makefile `test-go-fast` target
- Makefile was only excluding `internal/cmd`; now excludes all 4 slow packages: `pkg/tmux`, `pkg/secret`, `pkg/doctor`, `internal/cmd`
- Added cross-reference comments in both files to keep them in sync

Closes #2620
Part of #2614

## Test plan
- [ ] `make test-go-fast` runs and excludes the same packages as CI
- [ ] CI fast test job still passes with unchanged exclusion list

🤖 Generated with [Claude Code](https://claude.com/claude-code)