### PR TITLE
fix: Playwright Dockerfile with browser pre-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 .PHONY: release-local-bc release-local-bcd install-local-bc
 # Docker
 .PHONY: build-docker-daemon build-docker-sql build-docker-stats
-.PHONY: build-docker-agent-base build-docker-agent build-docker-agents
+.PHONY: build-docker-agent-base build-docker-agent build-docker-agents build-docker-playwright
 # TS
 .PHONY: build-local-tui build-local-web build-local-landing
 .PHONY: test-ts test-tui test-web test-web-e2e test-landing
@@ -158,6 +158,9 @@ build-docker-agents: build-docker-agent-base ## Build all agent images
 		echo "Building $(REGISTRY)-agent-$$p..."; \
 		docker build -t $(REGISTRY)-agent-$$p:$(IMAGE_TAG) -f docker/Dockerfile.$$p . || exit 1; \
 	done
+
+build-docker-playwright: ## Build Playwright MCP Docker image (pre-installed browsers)
+	docker build -t $(REGISTRY)-playwright:$(IMAGE_TAG) -f docker/Dockerfile.playwright .
 
 # =============================================================================
 # Test

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -82,11 +82,13 @@ services:
       retries: 3
 
   playwright:
-    image: playwright-visible
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.playwright
+    image: bc-playwright:latest
     container_name: bc-playwright
     ports:
       - "3100:3100"
-    entrypoint: ["/bin/sh", "-c", "rm -f /tmp/.X*-lock /tmp/.X11-unix/X* 2>/dev/null; exec /entrypoint.sh"]
     volumes:
       - shared-tmp:/tmp/bc-shared
     networks:

--- a/docker/Dockerfile.playwright
+++ b/docker/Dockerfile.playwright
@@ -1,0 +1,13 @@
+# Playwright MCP server with pre-installed browsers
+# Extends playwright-visible to ensure browsers survive container restarts
+FROM playwright-visible
+
+# Pre-install Chromium browser (the default for Playwright)
+# This bakes the browser into the image layer so restarts don't need to re-download
+RUN npx playwright install chromium 2>/dev/null || true
+
+# Clean up stale X11 locks on startup
+COPY docker/playwright-entrypoint.sh /playwright-entrypoint.sh
+RUN chmod +x /playwright-entrypoint.sh
+
+ENTRYPOINT ["/playwright-entrypoint.sh"]

--- a/docker/playwright-entrypoint.sh
+++ b/docker/playwright-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Clear stale X11 display locks from previous crashes
+rm -f /tmp/.X*-lock /tmp/.X11-unix/X* 2>/dev/null
+
+# Execute the original entrypoint
+exec /entrypoint.sh "$@"


### PR DESCRIPTION
## Summary
- Adds `docker/Dockerfile.playwright` that extends `playwright-visible` and bakes Chromium into the image layer so container restarts don't hit "browser not installed" errors
- Adds `docker/playwright-entrypoint.sh` to clear stale X11 display locks from previous crashes before starting the original entrypoint
- Updates `docker-compose.yml.example` to build from the new Dockerfile instead of using the raw `playwright-visible` image directly, removing the inline entrypoint override
- Adds `build-docker-playwright` Makefile target following the existing `build-docker-*` pattern

## Test plan
- [ ] Run `make build-docker-playwright` to verify the image builds successfully
- [ ] Start the playwright service via `docker compose up playwright` and confirm Chromium is available without additional install steps
- [ ] Kill and restart the container; verify no "browser not installed" errors on restart
- [ ] Verify X11 lock cleanup works after a crash (force-kill container, then restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)