### PR TITLE
fix: replace hardcoded colors with design tokens across all views

### DIFF
--- a/web/src/views/Activity.tsx
+++ b/web/src/views/Activity.tsx
@@ -92,7 +92,7 @@ function StateDot({ state }: { state: string }) {
   if (state === "stuck")
     return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-amber-500" />;
   if (state === "error" || state === "stopped")
-    return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-red-500/60" />;
+    return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-bc-error/60" />;
   return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-zinc-500/40" />;
 }
 
@@ -105,8 +105,8 @@ function ToolDot({ status }: { status: ToolNode["status"] }) {
       </span>
     );
   if (status === "failed")
-    return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-red-500" />;
-  return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-emerald-500" />;
+    return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-bc-error" />;
+  return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-bc-success" />;
 }
 
 /* ── Tool Node Component ───────────────────────────────────────────── */
@@ -150,7 +150,7 @@ function ToolNodeRow({ node, depth = 0 }: { node: ToolNode; depth?: number }) {
 
       {node.error && (
         <div
-          className="text-[11px] text-red-400/80 font-mono px-3 py-0.5"
+          className="text-[11px] text-bc-error/80 font-mono px-3 py-0.5"
           style={{ paddingLeft: `${indent + 40}px` }}
         >
           {node.error.length > 120 ? node.error.slice(0, 117) + "..." : node.error}
@@ -170,7 +170,7 @@ function ToolNodeRow({ node, depth = 0 }: { node: ToolNode; depth?: number }) {
 
       {expanded && node.fullOutput && (
         <div
-          className="text-[11px] text-emerald-600 font-mono px-3 py-1 bg-zinc-900/50 mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto"
+          className="text-[11px] text-bc-success font-mono px-3 py-1 bg-zinc-900/50 mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto"
           style={{ marginLeft: `${indent + 12}px` }}
         >
           <pre className="whitespace-pre-wrap break-all">

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -158,7 +158,7 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
         </div>
       </div>
 
-      {error && <p className="text-xs text-red-400">{error}</p>}
+      {error && <p className="text-xs text-bc-error">{error}</p>}
 
       <div className="flex justify-end">
         <button
@@ -271,14 +271,14 @@ function AgentActions({ agent, onDone }: { agent: Agent; onDone: () => void }) {
         className="inline-flex items-center gap-1"
         onClick={(e) => e.stopPropagation()}
       >
-        <span className="text-xs text-red-400 mr-1">Delete?</span>
+        <span className="text-xs text-bc-error mr-1">Delete?</span>
         <button
           onClick={(e) => {
             e.stopPropagation();
             act(() => api.deleteAgent(agent.name));
           }}
           disabled={busy}
-          className="px-1.5 py-0.5 text-xs rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 disabled:opacity-50"
+          className="px-1.5 py-0.5 text-xs rounded bg-bc-error/20 text-bc-error hover:bg-bc-error/30 disabled:opacity-50"
         >
           {busy ? "..." : "Yes"}
         </button>
@@ -332,7 +332,7 @@ function AgentActions({ agent, onDone }: { agent: Agent; onDone: () => void }) {
           setConfirming("delete");
         }}
         title="Delete agent"
-        className="px-1.5 py-0.5 text-xs rounded bg-red-500/10 text-red-400/70 hover:bg-red-500/20 hover:text-red-400"
+        className="px-1.5 py-0.5 text-xs rounded bg-bc-error/10 text-bc-error/70 hover:bg-bc-error/20 hover:text-bc-error"
       >
         Del
       </button>
@@ -472,7 +472,7 @@ export function Agents() {
             <button
               onClick={handleStopAll}
               disabled={stoppingAll}
-              className="px-3 py-1.5 text-sm rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400"
+              className="px-3 py-1.5 text-sm rounded bg-bc-error/20 text-bc-error hover:bg-bc-error/30 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-bc-error"
               aria-label="Stop all agents"
             >
               {stoppingAll ? "Stopping..." : "Stop All"}

--- a/web/src/views/Costs.tsx
+++ b/web/src/views/Costs.tsx
@@ -39,9 +39,9 @@ function CostCard({
 }
 
 function progressColor(pct: number): string {
-  if (pct >= 80) return "bg-red-500";
-  if (pct >= 50) return "bg-yellow-500";
-  return "bg-emerald-500";
+  if (pct >= 80) return "bg-bc-error";
+  if (pct >= 50) return "bg-bc-warning";
+  return "bg-bc-success";
 }
 
 function AgentBreakdown({
@@ -328,10 +328,10 @@ function AddBudgetForm({ onCreated }: { onCreated: () => void }) {
           {status.type === "saving" ? "Adding..." : "Add Budget"}
         </button>
         {status.type === "success" && (
-          <span className="text-xs text-green-400">Budget added</span>
+          <span className="text-xs text-bc-success">Budget added</span>
         )}
         {status.type === "error" && (
-          <span className="text-xs text-red-400">{status.message}</span>
+          <span className="text-xs text-bc-error">{status.message}</span>
         )}
       </div>
     </form>
@@ -366,7 +366,7 @@ function BudgetDeleteButton({
           type="button"
           onClick={handleDelete}
           disabled={deleting}
-          className="px-2 py-1 rounded bg-red-600 text-white text-xs font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
+          className="px-2 py-1 rounded bg-bc-error text-bc-bg text-xs font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
         >
           {deleting ? "Deleting..." : "Confirm"}
         </button>
@@ -386,7 +386,7 @@ function BudgetDeleteButton({
     <button
       type="button"
       onClick={() => setConfirming(true)}
-      className="px-2 py-1 rounded border border-bc-border text-bc-muted text-xs hover:text-red-400 hover:border-red-400/50 transition-colors"
+      className="px-2 py-1 rounded border border-bc-border text-bc-muted text-xs hover:text-bc-error hover:border-bc-error/50 transition-colors"
     >
       Delete
     </button>
@@ -425,7 +425,7 @@ function BudgetList({
                   {b.period}
                 </span>
                 {b.hard_stop && (
-                  <span className="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-400">
+                  <span className="text-xs px-2 py-0.5 rounded bg-bc-error/20 text-bc-error">
                     Hard Stop
                   </span>
                 )}

--- a/web/src/views/Cron.tsx
+++ b/web/src/views/Cron.tsx
@@ -124,7 +124,7 @@ function CreateJobForm({ onCreated }: { onCreated: () => void }) {
           Cancel
         </button>
         {status.type === "error" && (
-          <span className="text-xs text-red-400">{status.message}</span>
+          <span className="text-xs text-bc-error">{status.message}</span>
         )}
       </div>
     </div>
@@ -137,7 +137,7 @@ function RunDetail({ log }: { log: CronLogEntry }) {
       <div className="flex items-center gap-4 text-xs text-bc-muted mb-2">
         <span>Duration: {log.duration_ms}ms</span>
         <span
-          className={`font-medium ${log.status === "success" ? "text-green-400" : log.status === "failed" ? "text-red-400" : "text-yellow-400"}`}
+          className={`font-medium ${log.status === "success" ? "text-bc-success" : log.status === "failed" ? "text-bc-error" : "text-bc-warning"}`}
         >
           {log.status}
         </span>
@@ -171,7 +171,7 @@ function LiveLogs({ name }: { name: string }) {
   return (
     <div className="mt-2 rounded border border-bc-border bg-[#0a0a0f] p-3">
       <div className="flex items-center gap-2 text-xs text-bc-muted mb-2">
-        <span className="inline-block w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+        <span className="inline-block w-2 h-2 rounded-full bg-bc-success animate-pulse" />
         <span>Running — live output</span>
       </div>
       <pre className="text-xs text-bc-text/80 whitespace-pre-wrap max-h-64 overflow-y-auto font-mono">
@@ -228,7 +228,7 @@ function JobRuns({ name, running }: { name: string; running: boolean }) {
                     : "\u2014"}
                 </span>
                 <span
-                  className={`font-medium w-16 ${log.status === "success" ? "text-green-400" : log.status === "failed" ? "text-red-400" : "text-yellow-400"}`}
+                  className={`font-medium w-16 ${log.status === "success" ? "text-bc-success" : log.status === "failed" ? "text-bc-error" : "text-bc-warning"}`}
                 >
                   {log.status}
                 </span>
@@ -285,7 +285,7 @@ function JobActions({
           );
         }}
         disabled={busy !== null}
-        className={`${btnCls} ${job.enabled ? "bg-yellow-400/10 text-yellow-400 hover:bg-yellow-400/20" : "bg-green-400/10 text-green-400 hover:bg-green-400/20"}`}
+        className={`${btnCls} ${job.enabled ? "bg-bc-warning/10 text-bc-warning hover:bg-bc-warning/20" : "bg-bc-success/10 text-bc-success hover:bg-bc-success/20"}`}
       >
         {busy === "toggle" ? "..." : job.enabled ? "Disable" : "Enable"}
       </button>
@@ -310,7 +310,7 @@ function JobActions({
             act("delete", () => api.deleteCron(job.name));
         }}
         disabled={busy !== null}
-        className={`${btnCls} bg-red-400/10 text-red-400 hover:bg-red-400/20`}
+        className={`${btnCls} bg-bc-error/10 text-bc-error hover:bg-bc-error/20`}
       >
         {busy === "delete" ? "..." : "Delete"}
       </button>
@@ -415,7 +415,7 @@ export function Cron() {
                     <td className="px-4 py-2">
                       <span
                         className={
-                          j.running ? "text-blue-400" : j.enabled ? "text-green-400" : "text-bc-muted"
+                          j.running ? "text-blue-400" : j.enabled ? "text-bc-success" : "text-bc-muted"
                         }
                       >
                         {j.running ? "running" : j.enabled ? "enabled" : "disabled"}

--- a/web/src/views/Dashboard.tsx
+++ b/web/src/views/Dashboard.tsx
@@ -130,7 +130,7 @@ function StateDot({ state }: { state: string }) {
   if (state === "stuck")
     return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-amber-500" />;
   if (state === "error" || state === "stopped")
-    return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-red-500/60" />;
+    return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-bc-error/60" />;
   return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-zinc-500/40" />;
 }
 
@@ -143,8 +143,8 @@ function ToolDot({ status }: { status: ToolNode["status"] }) {
       </span>
     );
   if (status === "failed")
-    return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-red-500" />;
-  return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-emerald-500" />;
+    return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-bc-error" />;
+  return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-bc-success" />;
 }
 
 /* ── Elapsed Timer ─────────────────────────────────────────────────── */
@@ -194,7 +194,7 @@ function ToolNodeRow({ node, depth = 0 }: { node: ToolNode; depth?: number }) {
 
       {node.error && (
         <div
-          className="text-[11px] text-red-400/80 font-mono px-3 py-0.5"
+          className="text-[11px] text-bc-error/80 font-mono px-3 py-0.5"
           style={{ paddingLeft: `${indent + 40}px` }}
         >
           {node.error.length > 120 ? node.error.slice(0, 117) + "..." : node.error}
@@ -214,7 +214,7 @@ function ToolNodeRow({ node, depth = 0 }: { node: ToolNode; depth?: number }) {
 
       {expanded && node.fullOutput && (
         <div
-          className="text-[11px] text-emerald-600 font-mono px-3 py-1 bg-zinc-900/50 mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto"
+          className="text-[11px] text-bc-success font-mono px-3 py-1 bg-zinc-900/50 mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto"
           style={{ marginLeft: `${indent + 12}px` }}
         >
           <pre className="whitespace-pre-wrap break-all">
@@ -590,7 +590,7 @@ export function Dashboard() {
             label="Online"
             value={String(activeAgents.length)}
             sub={`${data.agents.length} total`}
-            accent="text-emerald-400"
+            accent="text-bc-success"
           />
           <SummaryCard
             label="Working"

--- a/web/src/views/Doctor.tsx
+++ b/web/src/views/Doctor.tsx
@@ -8,11 +8,11 @@ import { EmptyState } from "../components/EmptyState";
 const severityIcon = (s: string) => {
   switch (s) {
     case "ok":
-      return <span className="text-green-400">&#10003;</span>;
+      return <span className="text-bc-success">&#10003;</span>;
     case "warn":
-      return <span className="text-yellow-400">&#9888;</span>;
+      return <span className="text-bc-warning">&#9888;</span>;
     case "error":
-      return <span className="text-red-400">&#10007;</span>;
+      return <span className="text-bc-error">&#10007;</span>;
     default:
       return <span className="text-bc-muted">?</span>;
   }
@@ -77,12 +77,12 @@ export function Doctor() {
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">Doctor</h1>
         <div className="flex gap-4 text-sm">
-          <span className="text-green-400">{totalPassed} passed</span>
+          <span className="text-bc-success">{totalPassed} passed</span>
           {totalFailed > 0 && (
-            <span className="text-red-400">{totalFailed} failed</span>
+            <span className="text-bc-error">{totalFailed} failed</span>
           )}
           {totalWarnings > 0 && (
-            <span className="text-yellow-400">{totalWarnings} warnings</span>
+            <span className="text-bc-warning">{totalWarnings} warnings</span>
           )}
         </div>
       </div>
@@ -109,7 +109,7 @@ function FixButton({ fix }: { fix: string }) {
       <code className="text-xs text-bc-accent">{fix}</code>
       <button
         onClick={handleCopy}
-        className="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-300 hover:bg-red-500/30 transition-colors shrink-0"
+        className="text-xs px-2 py-0.5 rounded bg-bc-error/20 text-bc-error hover:bg-bc-error/30 transition-colors shrink-0"
         title="Copy fix command to clipboard"
       >
         {copied ? "Copied!" : "Fix"}

--- a/web/src/views/Logs.tsx
+++ b/web/src/views/Logs.tsx
@@ -172,7 +172,7 @@ export function Logs() {
         <span className="text-sm text-bc-muted">
           {allLogs.length} events
           {streamedLogs.length > 0 && (
-            <span className="ml-2 text-green-500">
+            <span className="ml-2 text-bc-success">
               +{streamedLogs.length} live
             </span>
           )}

--- a/web/src/views/MCP.tsx
+++ b/web/src/views/MCP.tsx
@@ -168,7 +168,7 @@ function RegisterForm({ onRegistered }: { onRegistered: () => void }) {
           Cancel
         </button>
         {status.type === "error" && (
-          <span className="text-xs text-red-400">{status.message}</span>
+          <span className="text-xs text-bc-error">{status.message}</span>
         )}
       </div>
     </div>
@@ -192,7 +192,7 @@ function ToggleSwitch({
       onClick={onToggle}
       disabled={disabled}
       className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-bc-accent disabled:opacity-50 ${
-        enabled ? "bg-green-500" : "bg-bc-border"
+        enabled ? "bg-bc-success" : "bg-bc-border"
       }`}
     >
       <span
@@ -324,7 +324,7 @@ export function MCP() {
           type="button"
           onClick={() => handleRemove(s)}
           disabled={!!actionLoading[s.name]}
-          className="text-xs text-red-400 hover:text-red-300 disabled:opacity-50 transition-colors"
+          className="text-xs text-bc-error hover:text-bc-error/80 disabled:opacity-50 transition-colors"
         >
           Remove
         </button>

--- a/web/src/views/Roles.tsx
+++ b/web/src/views/Roles.tsx
@@ -70,7 +70,7 @@ function CreateRoleForm({ onCreated }: { onCreated: () => void }) {
           + New Role
         </button>
         {status.type === "success" && (
-          <span className="text-xs text-green-400">Role created</span>
+          <span className="text-xs text-bc-success">Role created</span>
         )}
       </div>
     );
@@ -170,10 +170,10 @@ function CreateRoleForm({ onCreated }: { onCreated: () => void }) {
           {status.type === "saving" ? "Creating..." : "Create Role"}
         </button>
         {status.type === "success" && (
-          <span className="text-xs text-green-400">Role created</span>
+          <span className="text-xs text-bc-success">Role created</span>
         )}
         {status.type === "error" && (
-          <span className="text-xs text-red-400">{status.message}</span>
+          <span className="text-xs text-bc-error">{status.message}</span>
         )}
       </div>
     </form>
@@ -208,7 +208,7 @@ function DeleteButton({
           type="button"
           onClick={handleDelete}
           disabled={deleting}
-          className="px-2 py-1 rounded bg-red-600 text-white text-xs font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
+          className="px-2 py-1 rounded bg-bc-error text-bc-bg text-xs font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
           aria-label={`Confirm delete role ${name}`}
         >
           {deleting ? "Deleting..." : "Confirm"}
@@ -230,7 +230,7 @@ function DeleteButton({
     <button
       type="button"
       onClick={() => setConfirming(true)}
-      className="px-2 py-1 rounded border border-bc-border text-bc-muted text-xs hover:text-red-400 hover:border-red-400/50 transition-colors"
+      className="px-2 py-1 rounded border border-bc-border text-bc-muted text-xs hover:text-bc-error hover:border-bc-error/50 transition-colors"
       aria-label={`Delete role ${name}`}
     >
       Delete

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -79,10 +79,10 @@ function AddSecretForm({ onCreated }: { onCreated: () => void }) {
           {status.type === "saving" ? "Adding..." : "Add Secret"}
         </button>
         {status.type === "success" && (
-          <span className="text-xs text-green-400">Secret added</span>
+          <span className="text-xs text-bc-success">Secret added</span>
         )}
         {status.type === "error" && (
-          <span className="text-xs text-red-400">{status.message}</span>
+          <span className="text-xs text-bc-error">{status.message}</span>
         )}
       </div>
     </form>
@@ -157,7 +157,7 @@ function EditSecretButton({
         >
           Cancel
         </button>
-        {error && <span className="text-xs text-red-400">{error}</span>}
+        {error && <span className="text-xs text-bc-error">{error}</span>}
       </div>
     );
   }
@@ -201,7 +201,7 @@ function DeleteButton({
           type="button"
           onClick={handleDelete}
           disabled={deleting}
-          className="px-2 py-1 rounded bg-red-600 text-white text-xs font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
+          className="px-2 py-1 rounded bg-bc-error text-bc-bg text-xs font-medium hover:bg-red-700 disabled:opacity-50 transition-colors"
         >
           {deleting ? "Deleting..." : "Confirm"}
         </button>
@@ -221,7 +221,7 @@ function DeleteButton({
     <button
       type="button"
       onClick={() => setConfirming(true)}
-      className="px-2 py-1 rounded border border-bc-border text-bc-muted text-xs hover:text-red-400 hover:border-red-400/50 transition-colors"
+      className="px-2 py-1 rounded border border-bc-border text-bc-muted text-xs hover:text-bc-error hover:border-red-400/50 transition-colors"
     >
       Delete
     </button>

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -180,17 +180,17 @@ function GatewaysSection({ config }: { config: SettingsConfig }) {
   return (
     <Section title="Gateways">
       <Field label="Telegram">
-        <span className={`text-sm ${gw.telegram?.enabled ? "text-green-400" : "text-bc-muted"}`}>
+        <span className={`text-sm ${gw.telegram?.enabled ? "text-bc-success" : "text-bc-muted"}`}>
           {gw.telegram?.enabled ? "enabled" : "disabled"}
         </span>
       </Field>
       <Field label="Discord">
-        <span className={`text-sm ${gw.discord?.enabled ? "text-green-400" : "text-bc-muted"}`}>
+        <span className={`text-sm ${gw.discord?.enabled ? "text-bc-success" : "text-bc-muted"}`}>
           {gw.discord?.enabled ? "enabled" : "disabled"}
         </span>
       </Field>
       <Field label="Slack">
-        <span className={`text-sm ${gw.slack?.enabled ? "text-green-400" : "text-bc-muted"}`}>
+        <span className={`text-sm ${gw.slack?.enabled ? "text-bc-success" : "text-bc-muted"}`}>
           {gw.slack?.enabled ? "enabled" : "disabled"}
         </span>
       </Field>

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -27,7 +27,7 @@ function ToggleSwitch({
       }}
       className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-bc-accent/50 ${
         loading ? "opacity-50 cursor-not-allowed" : "cursor-pointer"
-      } ${enabled ? "bg-green-500" : "bg-bc-border"}`}
+      } ${enabled ? "bg-bc-success" : "bg-bc-border"}`}
     >
       <span
         className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${
@@ -51,7 +51,7 @@ function DeleteConfirmButton({
   if (confirming) {
     return (
       <span className="inline-flex gap-1.5 items-center">
-        <span className="text-xs text-red-400">Delete {name}?</span>
+        <span className="text-xs text-bc-error">Delete {name}?</span>
         <button
           type="button"
           disabled={deleting}
@@ -60,7 +60,7 @@ function DeleteConfirmButton({
             setDeleting(true);
             onDelete();
           }}
-          className="text-xs px-1.5 py-0.5 rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 disabled:opacity-50"
+          className="text-xs px-1.5 py-0.5 rounded bg-bc-error/20 text-bc-error hover:bg-bc-error/30 disabled:opacity-50"
         >
           {deleting ? "..." : "Yes"}
         </button>
@@ -85,7 +85,7 @@ function DeleteConfirmButton({
         e.stopPropagation();
         setConfirming(true);
       }}
-      className="text-xs px-2 py-0.5 rounded bg-bc-border/30 text-bc-muted hover:bg-red-500/20 hover:text-red-400 transition-colors"
+      className="text-xs px-2 py-0.5 rounded bg-bc-border/30 text-bc-muted hover:bg-bc-error/20 hover:text-bc-error transition-colors"
     >
       Delete
     </button>

--- a/web/src/views/Workspace.tsx
+++ b/web/src/views/Workspace.tsx
@@ -99,7 +99,7 @@ export function Workspace() {
           <button
             onClick={handleDown}
             disabled={actionBusy !== null}
-            className="px-3 py-1.5 text-sm rounded bg-red-500/20 text-red-400 hover:bg-red-500/30 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-red-400"
+            className="px-3 py-1.5 text-sm rounded bg-bc-error/20 text-bc-error hover:bg-bc-error/30 disabled:opacity-50 transition-colors focus:outline-none focus:ring-2 focus:ring-bc-error"
             aria-label="Stop all agents"
           >
             {actionBusy === "down" ? "Stopping..." : "Stop All Agents"}
@@ -107,7 +107,7 @@ export function Workspace() {
         </div>
       </div>
 
-      {actionError && <p className="text-xs text-red-400">{actionError}</p>}
+      {actionError && <p className="text-xs text-bc-error">{actionError}</p>}
 
       <div className="grid grid-cols-2 gap-4">
         {Object.entries(status).map(([key, value]) => (


### PR DESCRIPTION
## Summary

Replaces 60+ hardcoded Tailwind colors with bc-success/bc-error/bc-warning tokens across 13 view files. Proper dark/light theme support.

Build passes. Part of #2721.

🤖 Generated with [Claude Code](https://claude.ai/code)