### PR TITLE
feat: rewrite MCP tools — 6 focused agent tools

### DIFF
--- a/server/mcp/e2e_sse_test.go
+++ b/server/mcp/e2e_sse_test.go
@@ -429,7 +429,7 @@ func TestSSE_E2E_ToolsList(t *testing.T) {
 	}
 	decodeResult(t, resp, &result)
 
-	wantNames := []string{"create_agent", "send_message", "send_file", "read_channel", "report_status", "query_costs"}
+	wantNames := []string{"send_message", "send_file", "whoami", "list_channels", "read_channel", "list_agents"}
 	got := make(map[string]bool)
 	for _, tool := range result.Tools {
 		got[tool.Name] = true
@@ -444,7 +444,7 @@ func TestSSE_E2E_ToolsList(t *testing.T) {
 	}
 }
 
-func TestSSE_E2E_ToolsCall_QueryCosts(t *testing.T) {
+func TestSSE_E2E_ToolsCall_ListChannels(t *testing.T) {
 	srv := newTestServer(t)
 	broker := mcp.NewSSEBroker()
 
@@ -462,7 +462,7 @@ func TestSSE_E2E_ToolsCall_QueryCosts(t *testing.T) {
 	messageURL := ts.URL + ev.Data
 
 	postRPC(t, messageURL, 1, "tools/call", map[string]any{
-		"name":      "query_costs",
+		"name":      "list_channels",
 		"arguments": map[string]any{},
 	})
 
@@ -476,10 +476,10 @@ func TestSSE_E2E_ToolsCall_QueryCosts(t *testing.T) {
 	decodeResult(t, resp, &result)
 
 	if result.IsError {
-		t.Error("query_costs returned isError=true")
+		t.Error("list_channels returned isError=true")
 	}
 	if len(result.Content) == 0 {
-		t.Error("query_costs returned no content")
+		t.Error("list_channels returned no content")
 	}
 }
 

--- a/server/mcp/server.go
+++ b/server/mcp/server.go
@@ -309,18 +309,18 @@ func (s *Server) handleToolsCall(ctx context.Context, req Request) Response {
 	)
 
 	switch p.Name {
-	case "create_agent":
-		result, err = s.toolCreateAgent(ctx, p.Arguments)
 	case "send_message":
 		result, err = s.toolSendMessage(ctx, p.Arguments)
 	case "send_file":
 		result, err = s.toolSendFile(ctx, p.Arguments)
+	case "whoami":
+		result, err = s.toolWhoami(ctx)
+	case "list_channels":
+		result, err = s.toolListChannels(p.Arguments)
 	case "read_channel":
 		result, err = s.toolReadChannel(p.Arguments)
-	case "report_status":
-		result, err = s.toolReportStatus(p.Arguments)
-	case "query_costs":
-		result, err = s.toolQueryCosts(p.Arguments)
+	case "list_agents":
+		result, err = s.toolListAgents(p.Arguments)
 	default:
 		return errResponse(req.ID, ErrInvalidParams, fmt.Sprintf("unknown tool: %s", p.Name))
 	}

--- a/server/mcp/server_test.go
+++ b/server/mcp/server_test.go
@@ -331,7 +331,7 @@ func TestToolsList(t *testing.T) {
 	}
 	rpc(t, srv, "tools/list", nil, &result)
 
-	wantNames := []string{"create_agent", "send_message", "report_status", "query_costs"}
+	wantNames := []string{"send_message", "send_file", "whoami", "list_channels", "read_channel", "list_agents"}
 	got := make(map[string]bool)
 	for _, tool := range result.Tools {
 		got[tool.Name] = true
@@ -360,7 +360,7 @@ func TestToolCall_InvalidParams(t *testing.T) {
 	rpcErr(t, srv, "tools/call", "not an object", mcp.ErrInvalidParams)
 }
 
-func TestToolCall_CreateAgent_MissingName(t *testing.T) {
+func TestToolCall_Whoami(t *testing.T) {
 	srv := newTestServer(t)
 
 	var result struct {
@@ -368,16 +368,19 @@ func TestToolCall_CreateAgent_MissingName(t *testing.T) {
 		IsError bool              `json:"isError"`
 	}
 	rpc(t, srv, "tools/call", map[string]any{
-		"name":      "create_agent",
-		"arguments": map[string]any{"role": "engineer"},
+		"name":      "whoami",
+		"arguments": map[string]any{},
 	}, &result)
 
-	if !result.IsError {
-		t.Fatal("expected isError=true when name is missing")
+	if result.IsError {
+		t.Fatal("whoami returned isError=true")
+	}
+	if len(result.Content) == 0 {
+		t.Error("whoami returned no content")
 	}
 }
 
-func TestToolCall_CreateAgent_InvalidName(t *testing.T) {
+func TestToolCall_ListAgents(t *testing.T) {
 	srv := newTestServer(t)
 
 	var result struct {
@@ -385,15 +388,15 @@ func TestToolCall_CreateAgent_InvalidName(t *testing.T) {
 		IsError bool              `json:"isError"`
 	}
 	rpc(t, srv, "tools/call", map[string]any{
-		"name": "create_agent",
-		"arguments": map[string]any{
-			"name": "bad name with spaces",
-			"role": "engineer",
-		},
+		"name":      "list_agents",
+		"arguments": map[string]any{},
 	}, &result)
 
-	if !result.IsError {
-		t.Fatal("expected isError=true for invalid agent name")
+	if result.IsError {
+		t.Fatal("list_agents returned isError=true")
+	}
+	if len(result.Content) == 0 {
+		t.Error("list_agents returned no content")
 	}
 }
 
@@ -414,7 +417,7 @@ func TestToolCall_SendMessage_MissingChannel(t *testing.T) {
 	}
 }
 
-func TestToolCall_ReportStatus_UnknownAgent(t *testing.T) {
+func TestToolCall_ListChannels(t *testing.T) {
 	srv := newTestServer(t)
 
 	var result struct {
@@ -422,36 +425,32 @@ func TestToolCall_ReportStatus_UnknownAgent(t *testing.T) {
 		IsError bool              `json:"isError"`
 	}
 	rpc(t, srv, "tools/call", map[string]any{
-		"name": "report_status",
-		"arguments": map[string]any{
-			"agent": "no-such-agent",
-			"task":  "doing stuff",
-		},
-	}, &result)
-
-	if !result.IsError {
-		t.Fatal("expected isError=true for unknown agent")
-	}
-	if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, "no-such-agent") {
-		t.Error("expected error message to mention agent name")
-	}
-}
-
-func TestToolCall_QueryCosts_Empty(t *testing.T) {
-	srv := newTestServer(t)
-
-	var result struct {
-		Content []mcp.ToolContent `json:"content"`
-		IsError bool              `json:"isError"`
-	}
-	rpc(t, srv, "tools/call", map[string]any{
-		"name":      "query_costs",
+		"name":      "list_channels",
 		"arguments": map[string]any{},
 	}, &result)
 
-	// Empty workspace — call must not panic and must return content.
+	if result.IsError {
+		t.Fatal("list_channels returned isError=true")
+	}
 	if len(result.Content) == 0 {
-		t.Error("query_costs returned no content")
+		t.Error("list_channels returned no content")
+	}
+}
+
+func TestToolCall_ReadChannel_MissingChannel(t *testing.T) {
+	srv := newTestServer(t)
+
+	var result struct {
+		Content []mcp.ToolContent `json:"content"`
+		IsError bool              `json:"isError"`
+	}
+	rpc(t, srv, "tools/call", map[string]any{
+		"name":      "read_channel",
+		"arguments": map[string]any{},
+	}, &result)
+
+	if !result.IsError {
+		t.Fatal("expected isError=true when channel is missing")
 	}
 }
 

--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -10,53 +10,11 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/gh-curious-otter/bc/pkg/agent"
 )
 
 // definedTools returns the static list of tools this server exposes.
 func definedTools() []Tool {
 	return []Tool{
-		{
-			Name:        "create_agent",
-			Description: "Create a new agent in the bc workspace",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"name": map[string]any{
-						"type":        "string",
-						"description": "Unique agent name (alphanumeric, hyphens, underscores)",
-					},
-					"role": map[string]any{
-						"type":        "string",
-						"description": "Role for the agent (e.g. engineer, manager, root)",
-					},
-					"tool": map[string]any{
-						"type":        "string",
-						"description": "AI tool to use (claude, gemini, cursor, aider, codex)",
-					},
-				},
-				"required": []string{"name", "role"},
-			},
-		},
-		{
-			Name:        "read_channel",
-			Description: "Read recent messages from a bc channel",
-			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"channel": map[string]any{
-						"type":        "string",
-						"description": "Channel name to read from",
-					},
-					"limit": map[string]any{
-						"type":        "number",
-						"description": "Number of messages to return (default 20, max 100)",
-					},
-				},
-				"required": []string{"channel"},
-			},
-		},
 		{
 			Name:        "send_message",
 			Description: "Send a message to a bc channel",
@@ -98,32 +56,53 @@ func definedTools() []Tool {
 			},
 		},
 		{
-			Name:        "report_status",
-			Description: "Update the current task description for a bc agent",
+			Name:        "whoami",
+			Description: "Returns the current agent's identity, role, workspace, and capabilities",
 			InputSchema: map[string]any{
-				"type": "object",
-				"properties": map[string]any{
-					"agent": map[string]any{
-						"type":        "string",
-						"description": "Agent name to update",
-					},
-					"task": map[string]any{
-						"type":        "string",
-						"description": "Current task description",
-					},
-				},
-				"required": []string{"agent", "task"},
+				"type":       "object",
+				"properties": map[string]any{},
 			},
 		},
 		{
-			Name:        "query_costs",
-			Description: "Query cost usage for the workspace or a specific agent",
+			Name:        "list_channels",
+			Description: "List all available bc channels with member counts",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"agent": map[string]any{
+					"limit": map[string]any{
+						"type":        "number",
+						"description": "Maximum number of channels to return (default 50)",
+					},
+				},
+			},
+		},
+		{
+			Name:        "read_channel",
+			Description: "Read recent messages from a bc channel",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"channel": map[string]any{
 						"type":        "string",
-						"description": "Agent name to query (omit for workspace total)",
+						"description": "Channel name to read from",
+					},
+					"limit": map[string]any{
+						"type":        "number",
+						"description": "Number of messages to return (default 20, max 100)",
+					},
+				},
+				"required": []string{"channel"},
+			},
+		},
+		{
+			Name:        "list_agents",
+			Description: "List all agents in the workspace with their status and role",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"role": map[string]any{
+						"type":        "string",
+						"description": "Filter by role (optional)",
 					},
 				},
 			},
@@ -131,50 +110,124 @@ func definedTools() []Tool {
 	}
 }
 
-// ─── create_agent ─────────────────────────────────────────────────────────────
+// ─── whoami ──────────────────────────────────────────────────────────────────
 
-type createAgentArgs struct {
-	Name string `json:"name"`
-	Role string `json:"role"`
-	Tool string `json:"tool,omitempty"`
+func (s *Server) toolWhoami(ctx context.Context) (*toolsCallResult, error) {
+	agentID := AgentFromContext(ctx)
+	if agentID == "" {
+		if s.ws != nil {
+			nick := s.ws.Config.User.Name
+			nick = strings.TrimPrefix(nick, "@")
+			if nick != "" {
+				agentID = nick
+			}
+		}
+	}
+	if agentID == "" {
+		agentID = "unknown"
+	}
+
+	info := map[string]any{
+		"agent":     agentID,
+		"workspace": "",
+	}
+	if s.ws != nil {
+		info["workspace"] = s.ws.Name()
+	}
+
+	// Look up agent details if available
+	if s.agents != nil {
+		if ag := s.agents.GetAgent(agentID); ag != nil {
+			info["role"] = ag.Role
+			info["state"] = string(ag.State)
+			if ag.Task != "" {
+				info["task"] = ag.Task
+			}
+		}
+	}
+
+	b, _ := json.MarshalIndent(info, "", "  ")
+	return &toolsCallResult{
+		Content: []ToolContent{textContent(string(b))},
+	}, nil
 }
 
-func (s *Server) toolCreateAgent(ctx context.Context, raw json.RawMessage) (*toolsCallResult, error) {
-	var args createAgentArgs
-	if err := json.Unmarshal(raw, &args); err != nil {
-		return nil, fmt.Errorf("invalid arguments: %w", err)
+// ─── list_channels ───────────────────────────────────────────────────────────
+
+func (s *Server) toolListChannels(raw json.RawMessage) (*toolsCallResult, error) {
+	var args struct {
+		Limit int `json:"limit"`
+	}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &args) //nolint:errcheck // optional args
+	}
+	if args.Limit <= 0 {
+		args.Limit = 50
 	}
 
-	if args.Name == "" {
-		return nil, fmt.Errorf("name is required")
-	}
-	if args.Role == "" {
-		return nil, fmt.Errorf("role is required")
-	}
-	if !agent.IsValidAgentName(args.Name) {
-		return nil, fmt.Errorf("invalid agent name %q: use alphanumeric, hyphens, underscores", args.Name)
-	}
-
-	// Build bc agent create command
-	cmdArgs := []string{"agent", "create", args.Name, "--role", args.Role}
-	if args.Tool != "" {
-		cmdArgs = append(cmdArgs, "--tool", args.Tool)
-	}
-
-	//nolint:gosec // G204: arguments are validated above
-	out, err := exec.CommandContext(ctx, "bc", cmdArgs...).CombinedOutput()
-	if err != nil {
+	if s.chans == nil {
 		return &toolsCallResult{
-			Content: []ToolContent{textContent(fmt.Sprintf("failed to create agent: %s\n%s", err, out))},
+			Content: []ToolContent{textContent("channel store not available")},
 			IsError: true,
 		}, nil
 	}
 
+	channels := s.chans.List()
+	if len(channels) > args.Limit {
+		channels = channels[:args.Limit]
+	}
+
+	var sb strings.Builder
+	for _, ch := range channels {
+		members := len(ch.Members)
+		msgs := len(ch.History)
+		sb.WriteString(fmt.Sprintf("%-30s  members=%d  messages=%d\n", ch.Name, members, msgs))
+	}
+	if sb.Len() == 0 {
+		sb.WriteString("(no channels)")
+	}
+
 	return &toolsCallResult{
-		Content: []ToolContent{
-			textContent(fmt.Sprintf("Created agent %q with role %q\n%s",
-				args.Name, args.Role, strings.TrimSpace(string(out)))),
-		},
+		Content: []ToolContent{textContent(sb.String())},
+	}, nil
+}
+
+// ─── list_agents ─────────────────────────────────────────────────────────────
+
+func (s *Server) toolListAgents(raw json.RawMessage) (*toolsCallResult, error) {
+	var args struct {
+		Role string `json:"role"`
+	}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &args) //nolint:errcheck // optional args
+	}
+
+	if s.agents == nil {
+		return &toolsCallResult{
+			Content: []ToolContent{textContent("agent manager not available")},
+			IsError: true,
+		}, nil
+	}
+
+	agents := s.agents.ListAgents()
+	var sb strings.Builder
+	for _, ag := range agents {
+		if args.Role != "" && string(ag.Role) != args.Role {
+			continue
+		}
+		task := ag.Task
+		if task == "" {
+			task = "-"
+		}
+		sb.WriteString(fmt.Sprintf("%-20s  role=%-12s  state=%-8s  task=%s\n",
+			ag.Name, ag.Role, ag.State, task))
+	}
+	if sb.Len() == 0 {
+		sb.WriteString("(no agents)")
+	}
+
+	return &toolsCallResult{
+		Content: []ToolContent{textContent(sb.String())},
 	}, nil
 }
 
@@ -249,13 +302,6 @@ func (s *Server) toolSendMessage(ctx context.Context, raw json.RawMessage) (*too
 			textContent(fmt.Sprintf("Sent message to #%s from %s", args.Channel, sender)),
 		},
 	}, nil
-}
-
-// ─── report_status ────────────────────────────────────────────────────────────
-
-type reportStatusArgs struct {
-	Agent string `json:"agent"`
-	Task  string `json:"task"`
 }
 
 // ─── read_channel ───────────────────────────────────────────────────────────
@@ -417,93 +463,6 @@ func (s *Server) toolSendFile(ctx context.Context, raw json.RawMessage) (*toolsC
 
 	return &toolsCallResult{
 		Content: []ToolContent{textContent(fmt.Sprintf("Uploaded %s (%d bytes) to %s", filename, len(data), args.Channel))},
-	}, nil
-}
-
-// ─── report_status ──────────────────────────────────────────────────────────
-
-func (s *Server) toolReportStatus(raw json.RawMessage) (*toolsCallResult, error) {
-	var args reportStatusArgs
-	if err := json.Unmarshal(raw, &args); err != nil {
-		return nil, fmt.Errorf("invalid arguments: %w", err)
-	}
-
-	if args.Agent == "" {
-		return nil, fmt.Errorf("agent is required")
-	}
-	if args.Task == "" {
-		return nil, fmt.Errorf("task is required")
-	}
-
-	ag := s.agents.GetAgent(args.Agent)
-	if ag == nil {
-		return &toolsCallResult{
-			Content: []ToolContent{textContent(fmt.Sprintf("agent %q not found", args.Agent))},
-			IsError: true,
-		}, nil
-	}
-
-	// Keep current state; only update the task description.
-	if err := s.agents.UpdateAgentState(args.Agent, ag.State, args.Task); err != nil {
-		return &toolsCallResult{
-			Content: []ToolContent{textContent(fmt.Sprintf("failed to update status: %s", err))},
-			IsError: true,
-		}, nil
-	}
-
-	return &toolsCallResult{
-		Content: []ToolContent{
-			textContent(fmt.Sprintf("Updated task for agent %q: %s", args.Agent, args.Task)),
-		},
-	}, nil
-}
-
-// ─── query_costs ──────────────────────────────────────────────────────────────
-
-type queryCostsArgs struct {
-	Agent string `json:"agent,omitempty"`
-}
-
-func (s *Server) toolQueryCosts(raw json.RawMessage) (*toolsCallResult, error) {
-	var args queryCostsArgs
-	if len(raw) > 0 {
-		if err := json.Unmarshal(raw, &args); err != nil {
-			return nil, fmt.Errorf("invalid arguments: %w", err)
-		}
-	}
-
-	if args.Agent != "" {
-		summaries, err := s.costs.SummaryByAgent(context.Background())
-		if err != nil {
-			return &toolsCallResult{
-				Content: []ToolContent{textContent(fmt.Sprintf("failed to query costs: %s", err))},
-				IsError: true,
-			}, nil
-		}
-		for _, a := range summaries {
-			if a.AgentID == args.Agent {
-				b, _ := json.MarshalIndent(a, "", "  ")
-				return &toolsCallResult{
-					Content: []ToolContent{textContent(string(b))},
-				}, nil
-			}
-		}
-		return &toolsCallResult{
-			Content: []ToolContent{textContent(fmt.Sprintf("no cost data for agent %q", args.Agent))},
-		}, nil
-	}
-
-	ws, err := s.costs.WorkspaceSummary(context.Background())
-	if err != nil {
-		return &toolsCallResult{
-			Content: []ToolContent{textContent(fmt.Sprintf("failed to query costs: %s", err))},
-			IsError: true,
-		}, nil
-	}
-
-	b, _ := json.MarshalIndent(ws, "", "  ")
-	return &toolsCallResult{
-		Content: []ToolContent{textContent(string(b))},
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Strips MCP tools to what agents actually need per Puneet's directive
- **Removed:** `query_costs`, `create_agent`, `report_status` (status handled by hooks)
- **Added:** `whoami` (agent identity/role/workspace), `list_channels` (channels with member counts), `list_agents` (team members with status/role)
- **Kept:** `send_message`, `send_file`, `read_channel`
- Net reduction: 215 lines removed, 173 added (cleaner codebase)

Closes #2727

## Final MCP Tool List (6 tools)
1. `send_message` — send to a channel
2. `send_file` — upload file to gateway channel
3. `whoami` — agent identity, role, workspace
4. `list_channels` — available channels with member counts
5. `read_channel` — read message history (paginated)
6. `list_agents` — team members with status and role

## Test plan
- [x] `go build ./...` clean
- [x] `go test -race ./server/mcp/...` passes
- [x] `go vet ./server/mcp/...` clean
- [x] All existing tests updated for new tool names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `whoami`, `list_channels`, and `list_agents` tools to provide agent identity information, channel listings, and agent status

* **Changes**
  * Removed `create_agent`, `report_status`, and `query_costs` tools
  * Updated `read_channel` tool schema

<!-- end of auto-generated comment: release notes by coderabbit.ai -->