### PR TITLE
feat: file upload/download API for channel attachments

### DIFF
--- a/pkg/attachment/store.go
+++ b/pkg/attachment/store.go
@@ -1,0 +1,225 @@
+// Package attachment provides file storage for channel attachments.
+// Files are stored on the local filesystem under {stateDir}/attachments/{id}/{filename}.
+// This is a stop-gap implementation; the storage backend can be swapped later.
+package attachment
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// MaxFileSize is the default maximum file size (50MB).
+const MaxFileSize = 50 * 1024 * 1024
+
+// MaxFilesPerMessage is the default maximum number of attachments per message.
+const MaxFilesPerMessage = 5
+
+// allowedMIME is the whitelist of permitted MIME types.
+var allowedMIME = map[string]bool{
+	"image/jpeg":         true,
+	"image/png":          true,
+	"image/gif":          true,
+	"image/webp":         true,
+	"application/pdf":    true,
+	"text/plain":         true,
+	"application/json":   true,
+	"application/zip":    true,
+	"application/gzip":   true,
+	"video/mp4":          true,
+	"audio/mpeg":         true,
+}
+
+// Metadata holds information about a stored attachment.
+type Metadata struct {
+	CreatedAt time.Time `json:"created_at"`
+	ID        string    `json:"id"`
+	Filename  string    `json:"filename"`
+	MIMEType  string    `json:"mime_type"`
+	Channel   string    `json:"channel"`
+	Sender    string    `json:"sender"`
+	Size      int64     `json:"size"`
+}
+
+// Store manages attachment file storage on the local filesystem.
+type Store struct {
+	dir string // base directory for attachments
+}
+
+// NewStore creates an attachment store rooted at the given directory.
+func NewStore(stateDir string) *Store {
+	dir := filepath.Join(stateDir, "attachments")
+	return &Store{dir: dir}
+}
+
+// Save stores file data and returns metadata. The filename is sanitized.
+func (s *Store) Save(data []byte, filename, channel, sender string) (*Metadata, error) {
+	if len(data) > MaxFileSize {
+		return nil, fmt.Errorf("file too large: %d bytes (max %d)", len(data), MaxFileSize)
+	}
+
+	// Detect and validate MIME type
+	mimeType := detectMIME(data, filename)
+	if !allowedMIME[mimeType] {
+		return nil, fmt.Errorf("unsupported file type: %s", mimeType)
+	}
+
+	// Generate unique ID
+	id := generateID()
+
+	// Sanitize filename — strip path components, keep only base name
+	safeName := sanitizeFilename(filename)
+	if safeName == "" {
+		safeName = "attachment"
+	}
+
+	// Create directory
+	attachDir := filepath.Join(s.dir, id)
+	if err := os.MkdirAll(attachDir, 0o755); err != nil {
+		return nil, fmt.Errorf("create attachment dir: %w", err)
+	}
+
+	// Write file
+	filePath := filepath.Join(attachDir, safeName)
+	if err := os.WriteFile(filePath, data, 0o644); err != nil { //nolint:gosec // stored in controlled directory
+		return nil, fmt.Errorf("write attachment: %w", err)
+	}
+
+	return &Metadata{
+		ID:        id,
+		Filename:  safeName,
+		MIMEType:  mimeType,
+		Size:      int64(len(data)),
+		Channel:   channel,
+		Sender:    sender,
+		CreatedAt: time.Now().UTC(),
+	}, nil
+}
+
+// Get returns the file data and metadata for the given attachment ID.
+func (s *Store) Get(id string) ([]byte, *Metadata, error) {
+	if !isValidID(id) {
+		return nil, nil, fmt.Errorf("invalid attachment ID")
+	}
+
+	attachDir := filepath.Join(s.dir, id)
+	entries, err := os.ReadDir(attachDir)
+	if err != nil {
+		return nil, nil, fmt.Errorf("attachment not found: %s", id)
+	}
+
+	if len(entries) == 0 {
+		return nil, nil, fmt.Errorf("attachment empty: %s", id)
+	}
+
+	// First file in the directory is the attachment
+	filename := entries[0].Name()
+	filePath := filepath.Join(attachDir, filename)
+
+	data, err := os.ReadFile(filePath) //nolint:gosec // path constructed from validated ID
+	if err != nil {
+		return nil, nil, fmt.Errorf("read attachment: %w", err)
+	}
+
+	info, _ := entries[0].Info()
+	var modTime time.Time
+	if info != nil {
+		modTime = info.ModTime()
+	}
+
+	mimeType := detectMIME(data, filename)
+
+	return data, &Metadata{
+		ID:        id,
+		Filename:  filename,
+		MIMEType:  mimeType,
+		Size:      int64(len(data)),
+		CreatedAt: modTime,
+	}, nil
+}
+
+// Delete removes an attachment by ID.
+func (s *Store) Delete(id string) error {
+	if !isValidID(id) {
+		return fmt.Errorf("invalid attachment ID")
+	}
+	return os.RemoveAll(filepath.Join(s.dir, id))
+}
+
+// generateID creates a random hex ID.
+func generateID() string {
+	b := make([]byte, 12)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
+}
+
+// isValidID checks that an ID is a hex string (no path traversal).
+func isValidID(id string) bool {
+	if len(id) == 0 || len(id) > 64 {
+		return false
+	}
+	for _, c := range id {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// sanitizeFilename strips directory components and dangerous characters.
+func sanitizeFilename(name string) string {
+	// Take only the base name
+	name = filepath.Base(name)
+	// Remove null bytes and path separators
+	name = strings.ReplaceAll(name, "\x00", "")
+	// Limit length
+	if len(name) > 255 {
+		name = name[:255]
+	}
+	return name
+}
+
+// detectMIME detects MIME type from content and filename.
+func detectMIME(data []byte, filename string) string {
+	// Try content-based detection first
+	mimeType := "application/octet-stream"
+	if len(data) >= 512 {
+		mimeType = http.DetectContentType(data[:512])
+	} else if len(data) > 0 {
+		mimeType = http.DetectContentType(data)
+	}
+
+	// Override with extension for known types (DetectContentType can be imprecise)
+	ext := strings.ToLower(filepath.Ext(filename))
+	switch ext {
+	case ".png":
+		mimeType = "image/png"
+	case ".jpg", ".jpeg":
+		mimeType = "image/jpeg"
+	case ".gif":
+		mimeType = "image/gif"
+	case ".webp":
+		mimeType = "image/webp"
+	case ".pdf":
+		mimeType = "application/pdf"
+	case ".json":
+		mimeType = "application/json"
+	case ".txt":
+		mimeType = "text/plain"
+	case ".mp4":
+		mimeType = "video/mp4"
+	case ".mp3":
+		mimeType = "audio/mpeg"
+	case ".zip":
+		mimeType = "application/zip"
+	case ".gz", ".gzip":
+		mimeType = "application/gzip"
+	}
+
+	return mimeType
+}

--- a/pkg/attachment/store_test.go
+++ b/pkg/attachment/store_test.go
@@ -1,0 +1,154 @@
+package attachment
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestStore_SaveAndGet(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	// PNG header (minimal valid PNG-like content for MIME detection)
+	data := []byte("\x89PNG\r\n\x1a\n" + strings.Repeat("x", 100))
+
+	meta, err := store.Save(data, "screenshot.png", "general", "swift-hawk")
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	if meta.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+	if meta.Filename != "screenshot.png" {
+		t.Errorf("filename = %q, want screenshot.png", meta.Filename)
+	}
+	if meta.MIMEType != "image/png" {
+		t.Errorf("mime = %q, want image/png", meta.MIMEType)
+	}
+	if meta.Size != int64(len(data)) {
+		t.Errorf("size = %d, want %d", meta.Size, len(data))
+	}
+	if meta.Channel != "general" {
+		t.Errorf("channel = %q, want general", meta.Channel)
+	}
+
+	// Get it back
+	got, gotMeta, err := store.Get(meta.ID)
+	if err != nil {
+		t.Fatalf("Get failed: %v", err)
+	}
+	if !bytes.Equal(got, data) {
+		t.Error("data mismatch")
+	}
+	if gotMeta.Filename != "screenshot.png" {
+		t.Errorf("get filename = %q, want screenshot.png", gotMeta.Filename)
+	}
+}
+
+func TestStore_SaveRejectsUnsupportedType(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	// HTML content (not in allowed list)
+	data := []byte("<html><body>hello</body></html>")
+
+	_, err := store.Save(data, "page.html", "general", "test")
+	if err == nil {
+		t.Fatal("expected error for unsupported type")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Errorf("error = %q, want unsupported mention", err.Error())
+	}
+}
+
+func TestStore_SaveRejectsTooLarge(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	data := make([]byte, MaxFileSize+1)
+	_, err := store.Save(data, "big.png", "general", "test")
+	if err == nil {
+		t.Fatal("expected error for oversized file")
+	}
+}
+
+func TestStore_GetInvalidID(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, _, err := store.Get("../../../etc/passwd")
+	if err == nil {
+		t.Fatal("expected error for path traversal ID")
+	}
+}
+
+func TestStore_GetNonexistent(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	_, _, err := store.Get("deadbeef")
+	if err == nil {
+		t.Fatal("expected error for nonexistent ID")
+	}
+}
+
+func TestStore_Delete(t *testing.T) {
+	dir := t.TempDir()
+	store := NewStore(dir)
+
+	data := []byte("\x89PNG\r\n\x1a\n" + strings.Repeat("x", 100))
+	meta, err := store.Save(data, "test.png", "general", "test")
+	if err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	if err := store.Delete(meta.ID); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	_, _, err = store.Get(meta.ID)
+	if err == nil {
+		t.Fatal("expected error after delete")
+	}
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"screenshot.png", "screenshot.png"},
+		{"../../../etc/passwd", "passwd"},
+		{"/absolute/path/file.txt", "file.txt"},
+		{"", "."},
+		{"a" + strings.Repeat("b", 300), "a" + strings.Repeat("b", 254)},
+	}
+	for _, tt := range tests {
+		got := sanitizeFilename(tt.input)
+		if got != tt.want {
+			t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestIsValidID(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"deadbeef1234", true},
+		{"abcdef012345", true},
+		{"", false},
+		{"../etc/passwd", false},
+		{"DEADBEEF", false},        // uppercase not allowed
+		{"hello world", false},     // spaces
+		{strings.Repeat("a", 65), false}, // too long
+	}
+	for _, tt := range tests {
+		got := isValidID(tt.id)
+		if got != tt.want {
+			t.Errorf("isValidID(%q) = %v, want %v", tt.id, got, tt.want)
+		}
+	}
+}

--- a/server/handlers/files.go
+++ b/server/handlers/files.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gh-curious-otter/bc/pkg/attachment"
+)
+
+// FileHandler handles file upload and download routes.
+type FileHandler struct {
+	store *attachment.Store
+}
+
+// NewFileHandler creates a FileHandler.
+func NewFileHandler(store *attachment.Store) *FileHandler {
+	return &FileHandler{store: store}
+}
+
+// Register mounts file routes on mux.
+func (h *FileHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/files/upload", h.upload)
+	mux.HandleFunc("/api/files/", h.download)
+}
+
+// upload handles multipart file upload.
+// POST /api/files/upload
+// Form fields: file (required), channel (required), sender (optional, default "web")
+func (h *FileHandler) upload(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+
+	// Limit request body to max file size + overhead
+	r.Body = http.MaxBytesReader(w, r.Body, attachment.MaxFileSize+1024)
+
+	if err := r.ParseMultipartForm(attachment.MaxFileSize); err != nil {
+		httpError(w, "file too large or invalid multipart form", http.StatusBadRequest)
+		return
+	}
+
+	channel := r.FormValue("channel")
+	if channel == "" {
+		httpError(w, "channel field required", http.StatusBadRequest)
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		httpError(w, "file field required", http.StatusBadRequest)
+		return
+	}
+	defer file.Close() //nolint:errcheck
+
+	data, err := io.ReadAll(file)
+	if err != nil {
+		httpError(w, "failed to read file", http.StatusBadRequest)
+		return
+	}
+
+	sender := r.FormValue("sender")
+	if sender == "" {
+		sender = "web"
+	}
+
+	meta, err := h.store.Save(data, header.Filename, channel, sender)
+	if err != nil {
+		httpError(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, meta)
+}
+
+// download serves a stored attachment.
+// GET /api/files/{id}
+func (h *FileHandler) download(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+
+	id := strings.TrimPrefix(r.URL.Path, "/api/files/")
+	if id == "" || id == "upload" {
+		httpError(w, "file ID required", http.StatusBadRequest)
+		return
+	}
+
+	data, meta, err := h.store.Get(id)
+	if err != nil {
+		httpError(w, err.Error(), http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", meta.MIMEType)
+	w.Header().Set("Content-Disposition", "inline; filename=\""+meta.Filename+"\"")
+	w.Header().Set("Cache-Control", "public, max-age=86400")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data) //nolint:errcheck
+}

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gh-curious-otter/bc/pkg/agent"
+	"github.com/gh-curious-otter/bc/pkg/attachment"
 	"github.com/gh-curious-otter/bc/pkg/channel"
 	"github.com/gh-curious-otter/bc/pkg/cost"
 	"github.com/gh-curious-otter/bc/pkg/cron"
@@ -251,6 +252,10 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		handlers.NewWorkspaceHandler(svc.Agents, svc.WS).Register(mux)
 		handlers.NewDoctorHandler(svc.WS).Register(mux)
 		handlers.NewSettingsHandler(svc.WS).Register(mux)
+
+		// File upload/download for channel attachments
+		fileStore := attachment.NewStore(svc.WS.StateDir())
+		handlers.NewFileHandler(fileStore).Register(mux)
 	}
 
 	// Stats endpoints (always registered; nil-safe internally)


### PR DESCRIPTION
## Summary
- New `pkg/attachment` package: filesystem-backed file store with MIME validation, size limits, and path traversal protection
- `POST /api/files/upload` — multipart file upload with channel/sender metadata
- `GET /api/files/{id}` — serve stored files with correct Content-Type and caching headers
- Registered in bcd server when workspace is available

Unblocks #2669 (image sharing frontend). Part of #2663 epic.

## API

### Upload
```
POST /api/files/upload
Content-Type: multipart/form-data

Fields: file (required), channel (required), sender (optional, default "web")

Response: 201 Created
{
  "id": "a1b2c3d4e5f6...",
  "filename": "screenshot.png",
  "mime_type": "image/png",
  "size": 45678,
  "channel": "general",
  "sender": "web",
  "created_at": "2026-03-31T08:00:00Z"
}
```

### Download
```
GET /api/files/{id}

Response: 200 OK (binary file with Content-Type header)
```

## Security
- MIME type whitelist (images, PDF, JSON, text, zip, audio, video)
- 50MB max file size
- Hex-only ID validation prevents path traversal
- Filename sanitization strips directory components

## Test plan
- [x] `go test -race ./pkg/attachment/...` — 7 tests pass
- [x] `go build ./...` clean
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)