### PR TITLE
feat: per-agent container metrics via Docker stats API

### DIFF
--- a/pkg/container/stats.go
+++ b/pkg/container/stats.go
@@ -1,0 +1,192 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/gh-curious-otter/bc/pkg/log"
+)
+
+// ContainerStats holds resource usage metrics for a single Docker container.
+type ContainerStats struct {
+	Name          string  `json:"name"`
+	CPUPercent    float64 `json:"cpu_percent"`
+	MemoryUsed    int64   `json:"memory_used_bytes"`
+	MemoryLimit   int64   `json:"memory_limit_bytes"`
+	MemoryPercent float64 `json:"memory_percent"`
+	DiskRead      int64   `json:"disk_read_bytes"`
+	DiskWrite     int64   `json:"disk_write_bytes"`
+	NetRx         int64   `json:"net_rx_bytes"`
+	NetTx         int64   `json:"net_tx_bytes"`
+	PIDs          int     `json:"pids"`
+}
+
+// dockerStatsOneShot maps the JSON response from the Docker container stats API
+// (stream=false). We query the Docker socket directly for structured data rather
+// than parsing human-readable output from `docker stats`.
+type dockerStatsOneShot struct {
+	CPUStats struct {
+		CPUUsage struct {
+			TotalUsage  int64   `json:"total_usage"`
+			PercpuUsage []int64 `json:"percpu_usage"`
+		} `json:"cpu_usage"`
+		SystemCPUUsage int64 `json:"system_cpu_usage"`
+		OnlineCPUs     int   `json:"online_cpus"`
+	} `json:"cpu_stats"`
+	PrecpuStats struct {
+		CPUUsage struct {
+			TotalUsage int64 `json:"total_usage"`
+		} `json:"cpu_usage"`
+		SystemCPUUsage int64 `json:"system_cpu_usage"`
+	} `json:"precpu_stats"`
+	MemoryStats struct {
+		Usage int64 `json:"usage"`
+		Limit int64 `json:"limit"`
+		Stats struct {
+			InactiveFile int64 `json:"inactive_file"`
+			Cache        int64 `json:"cache"`
+		} `json:"stats"`
+	} `json:"memory_stats"`
+	BlkioStats struct {
+		IOServiceBytesRecursive []struct {
+			Op    string `json:"op"`
+			Value int64  `json:"value"`
+		} `json:"io_service_bytes_recursive"`
+	} `json:"blkio_stats"`
+	Networks map[string]struct {
+		RxBytes int64 `json:"rx_bytes"`
+		TxBytes int64 `json:"tx_bytes"`
+	} `json:"networks"`
+	PidsStats struct {
+		Current int `json:"current"`
+	} `json:"pids_stats"`
+	Name string `json:"name"`
+}
+
+// Stats collects resource usage metrics for a single Docker container.
+// Uses one-shot stats (stream=false) via the Docker API on the unix socket
+// to avoid blocking. Returns zero-value stats if the container is not running.
+func Stats(ctx context.Context, containerName string) (ContainerStats, error) {
+	// Use curl against the Docker socket for one-shot stats.
+	// This avoids adding the docker SDK as a dependency and matches the
+	// existing CLI-based pattern, but uses the API directly for structured JSON.
+	//nolint:gosec // containerName is from trusted internal sources (containerName method)
+	cmd := exec.CommandContext(ctx, "curl", "--silent", "--unix-socket",
+		"/var/run/docker.sock",
+		fmt.Sprintf("http://localhost/containers/%s/stats?stream=false", containerName))
+
+	output, err := cmd.Output()
+	if err != nil {
+		// Container may not be running — return zero stats rather than error
+		log.Debug("failed to get container stats", "container", containerName, "error", err)
+		return ContainerStats{Name: containerName}, nil
+	}
+
+	var raw dockerStatsOneShot
+	if err := json.Unmarshal(output, &raw); err != nil {
+		return ContainerStats{Name: containerName}, fmt.Errorf("failed to parse stats for %s: %w", containerName, err)
+	}
+
+	return parseStats(containerName, &raw), nil
+}
+
+// parseStats converts raw Docker stats JSON into our ContainerStats struct.
+func parseStats(name string, raw *dockerStatsOneShot) ContainerStats {
+	cs := ContainerStats{Name: name}
+
+	// CPU percent: (cpuDelta / systemDelta) * numCPUs * 100
+	cpuDelta := float64(raw.CPUStats.CPUUsage.TotalUsage - raw.PrecpuStats.CPUUsage.TotalUsage)
+	systemDelta := float64(raw.CPUStats.SystemCPUUsage - raw.PrecpuStats.SystemCPUUsage)
+
+	numCPUs := raw.CPUStats.OnlineCPUs
+	if numCPUs == 0 {
+		numCPUs = len(raw.CPUStats.CPUUsage.PercpuUsage)
+	}
+
+	if systemDelta > 0 && numCPUs > 0 {
+		cs.CPUPercent = (cpuDelta / systemDelta) * float64(numCPUs) * 100.0
+	}
+
+	// Memory: subtract inactive file (cache) from usage for actual memory consumption.
+	// This matches how `docker stats` reports memory.
+	usedMemory := raw.MemoryStats.Usage - raw.MemoryStats.Stats.InactiveFile
+	if usedMemory < 0 {
+		usedMemory = raw.MemoryStats.Usage
+	}
+	cs.MemoryUsed = usedMemory
+	cs.MemoryLimit = raw.MemoryStats.Limit
+
+	if cs.MemoryLimit > 0 {
+		cs.MemoryPercent = float64(cs.MemoryUsed) / float64(cs.MemoryLimit) * 100.0
+	}
+
+	// Disk IO
+	for _, entry := range raw.BlkioStats.IOServiceBytesRecursive {
+		switch strings.ToLower(entry.Op) {
+		case "read":
+			cs.DiskRead += entry.Value
+		case "write":
+			cs.DiskWrite += entry.Value
+		}
+	}
+
+	// Network IO (sum across all interfaces)
+	for _, iface := range raw.Networks {
+		cs.NetRx += iface.RxBytes
+		cs.NetTx += iface.TxBytes
+	}
+
+	// PIDs
+	cs.PIDs = raw.PidsStats.Current
+
+	return cs
+}
+
+// AllAgentStats collects resource metrics for all running containers matching the prefix.
+// The prefix should be the bc container prefix (e.g., "bc-<hash>-") to scope results
+// to a single workspace.
+func AllAgentStats(ctx context.Context, containerPrefix string) ([]ContainerStats, error) {
+	// List running containers matching the prefix using docker ps.
+	//nolint:gosec // containerPrefix is from trusted internal sources
+	cmd := exec.CommandContext(ctx, "docker", "ps",
+		"--filter", "label=bc.managed=true",
+		"--filter", "status=running",
+		"--format", "{{.Names}}")
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list containers: %w", err)
+	}
+
+	var stats []ContainerStats
+	for _, name := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if name == "" {
+			continue
+		}
+		if !strings.HasPrefix(name, containerPrefix) {
+			continue
+		}
+
+		s, sErr := Stats(ctx, name)
+		if sErr != nil {
+			log.Warn("failed to collect stats for container", "container", name, "error", sErr)
+			continue
+		}
+		stats = append(stats, s)
+	}
+
+	return stats, nil
+}
+
+// AgentStats is a convenience method on Backend that collects stats for a single agent.
+func (b *Backend) AgentStats(ctx context.Context, name string) (ContainerStats, error) {
+	return Stats(ctx, b.containerName(name))
+}
+
+// AllStats collects stats for all running agents in this workspace.
+func (b *Backend) AllStats(ctx context.Context) ([]ContainerStats, error) {
+	return AllAgentStats(ctx, b.prefix+b.workspaceHash+"-")
+}

--- a/pkg/container/stats_test.go
+++ b/pkg/container/stats_test.go
@@ -1,0 +1,185 @@
+package container
+
+import (
+	"testing"
+)
+
+func TestParseStats_CPUPercent(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	raw.CPUStats.CPUUsage.TotalUsage = 500_000_000
+	raw.PrecpuStats.CPUUsage.TotalUsage = 400_000_000
+	raw.CPUStats.SystemCPUUsage = 2_000_000_000
+	raw.PrecpuStats.SystemCPUUsage = 1_000_000_000
+	raw.CPUStats.OnlineCPUs = 4
+
+	cs := parseStats("test-container", raw)
+
+	// cpuDelta=100M, systemDelta=1000M => (100/1000)*4*100 = 40%
+	want := 40.0
+	if cs.CPUPercent != want {
+		t.Errorf("CPUPercent = %f, want %f", cs.CPUPercent, want)
+	}
+}
+
+func TestParseStats_CPUPercent_ZeroDelta(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	raw.CPUStats.CPUUsage.TotalUsage = 100
+	raw.PrecpuStats.CPUUsage.TotalUsage = 100
+	raw.CPUStats.SystemCPUUsage = 1000
+	raw.PrecpuStats.SystemCPUUsage = 1000
+	raw.CPUStats.OnlineCPUs = 2
+
+	cs := parseStats("test-container", raw)
+
+	if cs.CPUPercent != 0 {
+		t.Errorf("CPUPercent = %f, want 0 (zero delta)", cs.CPUPercent)
+	}
+}
+
+func TestParseStats_CPUPercent_FallbackPercpuUsage(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	raw.CPUStats.CPUUsage.TotalUsage = 200_000_000
+	raw.PrecpuStats.CPUUsage.TotalUsage = 100_000_000
+	raw.CPUStats.SystemCPUUsage = 2_000_000_000
+	raw.PrecpuStats.SystemCPUUsage = 1_000_000_000
+	raw.CPUStats.OnlineCPUs = 0 // force fallback
+	raw.CPUStats.CPUUsage.PercpuUsage = []int64{100, 200} // 2 CPUs
+
+	cs := parseStats("test-container", raw)
+
+	// cpuDelta=100M, systemDelta=1000M => (100/1000)*2*100 = 20%
+	want := 20.0
+	if cs.CPUPercent != want {
+		t.Errorf("CPUPercent = %f, want %f (fallback to percpu_usage len)", cs.CPUPercent, want)
+	}
+}
+
+func TestParseStats_Memory(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	raw.MemoryStats.Usage = 1_073_741_824 // 1GiB
+	raw.MemoryStats.Limit = 4_294_967_296 // 4GiB
+	raw.MemoryStats.Stats.InactiveFile = 100_000_000
+
+	cs := parseStats("test-container", raw)
+
+	wantUsed := int64(1_073_741_824 - 100_000_000)
+	if cs.MemoryUsed != wantUsed {
+		t.Errorf("MemoryUsed = %d, want %d", cs.MemoryUsed, wantUsed)
+	}
+	if cs.MemoryLimit != 4_294_967_296 {
+		t.Errorf("MemoryLimit = %d, want 4294967296", cs.MemoryLimit)
+	}
+
+	wantPercent := float64(wantUsed) / float64(cs.MemoryLimit) * 100.0
+	if cs.MemoryPercent != wantPercent {
+		t.Errorf("MemoryPercent = %f, want %f", cs.MemoryPercent, wantPercent)
+	}
+}
+
+func TestParseStats_MemoryZeroLimit(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	raw.MemoryStats.Usage = 500_000
+	raw.MemoryStats.Limit = 0
+
+	cs := parseStats("test-container", raw)
+
+	if cs.MemoryPercent != 0 {
+		t.Errorf("MemoryPercent = %f, want 0 (zero limit)", cs.MemoryPercent)
+	}
+}
+
+func TestParseStats_DiskIO(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	raw.BlkioStats.IOServiceBytesRecursive = []struct {
+		Op    string `json:"op"`
+		Value int64  `json:"value"`
+	}{
+		{Op: "Read", Value: 1024},
+		{Op: "Write", Value: 2048},
+		{Op: "Read", Value: 512},
+		{Op: "Write", Value: 256},
+		{Op: "Sync", Value: 999}, // should be ignored
+	}
+
+	cs := parseStats("test-container", raw)
+
+	if cs.DiskRead != 1536 {
+		t.Errorf("DiskRead = %d, want 1536", cs.DiskRead)
+	}
+	if cs.DiskWrite != 2304 {
+		t.Errorf("DiskWrite = %d, want 2304", cs.DiskWrite)
+	}
+}
+
+func TestParseStats_NetworkIO(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	raw.Networks = map[string]struct {
+		RxBytes int64 `json:"rx_bytes"`
+		TxBytes int64 `json:"tx_bytes"`
+	}{
+		"eth0": {RxBytes: 1000, TxBytes: 2000},
+		"eth1": {RxBytes: 3000, TxBytes: 4000},
+	}
+
+	cs := parseStats("test-container", raw)
+
+	if cs.NetRx != 4000 {
+		t.Errorf("NetRx = %d, want 4000", cs.NetRx)
+	}
+	if cs.NetTx != 6000 {
+		t.Errorf("NetTx = %d, want 6000", cs.NetTx)
+	}
+}
+
+func TestParseStats_PIDs(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	raw.PidsStats.Current = 42
+
+	cs := parseStats("test-container", raw)
+
+	if cs.PIDs != 42 {
+		t.Errorf("PIDs = %d, want 42", cs.PIDs)
+	}
+}
+
+func TestParseStats_EmptyRaw(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+
+	cs := parseStats("empty-container", raw)
+
+	if cs.Name != "empty-container" {
+		t.Errorf("Name = %q, want %q", cs.Name, "empty-container")
+	}
+	if cs.CPUPercent != 0 {
+		t.Errorf("CPUPercent = %f, want 0", cs.CPUPercent)
+	}
+	if cs.MemoryUsed != 0 {
+		t.Errorf("MemoryUsed = %d, want 0", cs.MemoryUsed)
+	}
+	if cs.PIDs != 0 {
+		t.Errorf("PIDs = %d, want 0", cs.PIDs)
+	}
+}
+
+func TestParseStats_Name(t *testing.T) {
+	raw := &dockerStatsOneShot{}
+	cs := parseStats("bc-a1b2c3-alice", raw)
+
+	if cs.Name != "bc-a1b2c3-alice" {
+		t.Errorf("Name = %q, want %q", cs.Name, "bc-a1b2c3-alice")
+	}
+}
+
+func TestBackendAgentStats_ContainerName(t *testing.T) {
+	b := &Backend{
+		prefix:        "bc-",
+		workspaceHash: "aabbcc",
+	}
+
+	// Verify the container name used for stats lookup matches the convention
+	cn := b.containerName("alice")
+	want := "bc-aabbcc-alice"
+	if cn != want {
+		t.Errorf("containerName = %q, want %q", cn, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `pkg/container/stats.go` with `ContainerStats` struct for per-agent CPU, memory, disk IO, network, and PID metrics
- Queries Docker stats API via unix socket (one-shot, non-blocking) using `curl` against `/var/run/docker.sock`
- Provides both standalone functions (`Stats`, `AllAgentStats`) and `Backend` methods (`AgentStats`, `AllStats`)
- Includes comprehensive unit tests for the stats parsing logic (11 test cases covering CPU calculation, memory, disk IO, network aggregation, PIDs, and edge cases)

Part of #2724. swift-hawk can wire this into the unified stats endpoint.

## Test plan
- [x] `go test -race ./pkg/container/` passes (all 30 tests including 11 new stats tests)
- [x] `go vet ./pkg/container/` clean
- [x] `go build ./pkg/container/` clean
- [ ] Integration: verify with running Docker containers that stats are collected correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)