### PR TITLE
feat: gateway activity feed endpoint

### DIFF
--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -4,16 +4,21 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"sort"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/gh-curious-otter/bc/pkg/channel"
 	"github.com/gh-curious-otter/bc/pkg/gateway"
 	"github.com/gh-curious-otter/bc/pkg/workspace"
 )
 
 // GatewayHandler handles /api/gateways routes.
 type GatewayHandler struct {
-	gw *gateway.Manager
-	ws *workspace.Workspace
+	gw      *gateway.Manager
+	ws      *workspace.Workspace
+	chanSvc *channel.ChannelService
 }
 
 // NewGatewayHandler creates a GatewayHandler.
@@ -21,8 +26,14 @@ func NewGatewayHandler(gw *gateway.Manager, ws *workspace.Workspace) *GatewayHan
 	return &GatewayHandler{gw: gw, ws: ws}
 }
 
+// SetChannelService sets the channel service for activity queries.
+func (h *GatewayHandler) SetChannelService(svc *channel.ChannelService) {
+	h.chanSvc = svc
+}
+
 // Register mounts gateway routes.
 func (h *GatewayHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/gateways/activity", h.activity)
 	mux.HandleFunc("/api/gateways", h.list)
 	mux.HandleFunc("/api/gateways/", h.byPlatform)
 }
@@ -158,4 +169,78 @@ func (h *GatewayHandler) updatePlatform(w http.ResponseWriter, r *http.Request, 
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated", "platform": platform})
+}
+
+// activityEntry is a message from a gateway channel in the unified activity feed.
+type activityEntry struct {
+	Time     time.Time `json:"time"`
+	Channel  string    `json:"channel"`
+	Platform string    `json:"platform"`
+	Sender   string    `json:"sender"`
+	Content  string    `json:"content"`
+}
+
+// activity returns recent messages across all gateway channels as a unified feed.
+// GET /api/gateways/activity?limit=50
+func (h *GatewayHandler) activity(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+
+	limit := 50
+	if s := r.URL.Query().Get("limit"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	limit = clampInt(limit, 1, 200)
+
+	if h.chanSvc == nil {
+		writeJSON(w, http.StatusOK, []activityEntry{})
+		return
+	}
+
+	// Get all gateway channels
+	var gwChannelNames []string
+	if h.gw != nil {
+		gwChannelNames = h.gw.ExternalChannels()
+	}
+	if len(gwChannelNames) == 0 {
+		writeJSON(w, http.StatusOK, []activityEntry{})
+		return
+	}
+
+	// Collect recent messages from all gateway channels
+	var entries []activityEntry
+	for _, chName := range gwChannelNames {
+		msgs, err := h.chanSvc.History(r.Context(), chName, channel.HistoryOpts{Limit: limit})
+		if err != nil {
+			continue
+		}
+		platform := "unknown"
+		if idx := strings.Index(chName, ":"); idx > 0 {
+			platform = chName[:idx]
+		}
+		for _, msg := range msgs {
+			entries = append(entries, activityEntry{
+				Time:     msg.CreatedAt,
+				Channel:  chName,
+				Platform: platform,
+				Sender:   msg.Sender,
+				Content:  msg.Content,
+			})
+		}
+	}
+
+	// Sort by time descending (newest first)
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Time.After(entries[j].Time)
+	})
+
+	// Apply limit
+	if len(entries) > limit {
+		entries = entries[:limit]
+	}
+
+	writeJSON(w, http.StatusOK, entries)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -248,7 +248,11 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		handlers.NewEventHandler(svc.EventLog).Register(mux)
 	}
 	if svc.Gateway != nil {
-		handlers.NewGatewayHandler(svc.Gateway, svc.WS).Register(mux)
+		gh := handlers.NewGatewayHandler(svc.Gateway, svc.WS)
+		if svc.Channels != nil {
+			gh.SetChannelService(svc.Channels)
+		}
+		gh.Register(mux)
 	}
 	if svc.WS != nil {
 		handlers.NewRolesHandler(svc.WS).Register(mux)


### PR DESCRIPTION
## Summary
- New endpoint: `GET /api/gateways/activity?limit=50`
- Returns unified feed of recent messages across all gateway channels (slack:*, telegram:*, discord:*)
- Sorted by time descending (newest first)
- Completes the final deliverable from #2720 spec

## Response Shape
```json
[
  {
    "time": "2026-03-31T08:00:00Z",
    "channel": "slack:eng",
    "platform": "slack",
    "sender": "[slack] Puneet Rai",
    "content": "continue"
  }
]
```

## Implementation
- Collects messages from all gateway channels via `ChannelService.History()`
- Merges and sorts across channels
- Configurable limit (default 50, max 200)
- Returns empty array when no gateway is configured

## Test plan
- [x] `go build ./...` clean
- [x] `go vet` clean
- [ ] Manual: `curl /api/gateways/activity?limit=10`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new API endpoint to retrieve recent gateway activity across all connected channels, with configurable pagination via an optional limit parameter (range: 1-200, default: 50).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->