### PR TITLE
feat: Playwright Dockerfile with Chrome, VNC, and Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@
 .PHONY: release-local-bc release-local-bcd install-local-bc
 # Docker
 .PHONY: build-docker-daemon build-docker-sql build-docker-stats
-.PHONY: build-docker-agent-base build-docker-agent build-docker-agents build-docker-playwright
+.PHONY: build-docker-agent-base build-docker-agent build-docker-agents build-docker-playwright stop-docker-playwright run-docker-playwright
 # TS
 .PHONY: build-local-tui build-local-web build-local-landing
 .PHONY: test-ts test-tui test-web test-web-e2e test-landing
@@ -159,8 +159,19 @@ build-docker-agents: build-docker-agent-base ## Build all agent images
 		docker build -t $(REGISTRY)-agent-$$p:$(IMAGE_TAG) -f docker/Dockerfile.$$p . || exit 1; \
 	done
 
-build-docker-playwright: ## Build Playwright MCP Docker image (pre-installed browsers)
-	docker build -t $(REGISTRY)-playwright:$(IMAGE_TAG) -f docker/Dockerfile.playwright .
+build-docker-playwright: ## Build Playwright MCP Docker image
+	docker build -t bc-playwright:latest -f docker/Dockerfile.playwright .
+
+stop-docker-playwright: ## Stop and remove Playwright container
+	docker stop bc-playwright 2>/dev/null || true
+	docker rm bc-playwright 2>/dev/null || true
+
+run-docker-playwright: stop-docker-playwright ## Run Playwright MCP container
+	docker run -d --name bc-playwright \
+		-p 3100:3000 -p 6080:6080 \
+		-v bc-shared-tmp:/tmp/bc-shared \
+		--restart unless-stopped \
+		bc-playwright:latest
 
 # =============================================================================
 # Test

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -85,20 +85,20 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.playwright
-    image: bc-playwright:latest
     container_name: bc-playwright
     ports:
-      - "3100:3100"
+      - "3100:3000"
+      - "6080:6080"
     volumes:
       - shared-tmp:/tmp/bc-shared
     networks:
       - bc-net
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:3100/sse"]
+      test: ["CMD", "curl", "-sf", "http://localhost:3000/sse"]
       interval: 30s
       timeout: 5s
-      start_period: 15s
+      start_period: 30s
       retries: 3
 
 networks:

--- a/docker/Dockerfile.playwright
+++ b/docker/Dockerfile.playwright
@@ -1,12 +1,23 @@
-# Playwright MCP server with pre-installed browsers
-# Extends playwright-visible to ensure browsers survive container restarts
-FROM playwright-visible
+# Playwright MCP server with pre-installed Chrome and VNC viewing
+FROM mcr.microsoft.com/playwright:v1.52.0-noble
 
-# Pre-install Chromium browser (the default for Playwright)
-# This bakes the browser into the image layer so restarts don't need to re-download
+# Install VNC server and noVNC for browser viewing
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    x11vnc \
+    xvfb \
+    websockify \
+    novnc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Playwright MCP server and Chrome browser
+RUN npm install -g @anthropic-ai/claude-code@latest 2>/dev/null || true
+RUN npx -y @playwright/mcp@latest install-browser chrome-for-testing 2>/dev/null || true
+RUN npx playwright install-deps 2>/dev/null || true
 RUN npx playwright install chromium 2>/dev/null || true
 
-# Clean up stale X11 locks on startup
+# Expose ports: 3000 for MCP, 6080 for noVNC
+EXPOSE 3000 6080
+
 COPY docker/playwright-entrypoint.sh /playwright-entrypoint.sh
 RUN chmod +x /playwright-entrypoint.sh
 

--- a/docker/playwright-entrypoint.sh
+++ b/docker/playwright-entrypoint.sh
@@ -1,6 +1,18 @@
-#!/bin/sh
-# Clear stale X11 display locks from previous crashes
+#!/bin/bash
+set -e
+
+# Clear stale X11 locks
 rm -f /tmp/.X*-lock /tmp/.X11-unix/X* 2>/dev/null
 
-# Execute the original entrypoint
-exec /entrypoint.sh "$@"
+# Start Xvfb (virtual framebuffer)
+Xvfb :99 -screen 0 1280x720x24 &
+export DISPLAY=:99
+
+# Start x11vnc (VNC server on the virtual display)
+x11vnc -display :99 -forever -nopw -shared -rfbport 5900 &
+
+# Start noVNC (web-based VNC client on port 6080)
+websockify --web=/usr/share/novnc 6080 localhost:5900 &
+
+# Start Playwright MCP server
+exec npx -y @playwright/mcp@latest --port 3000


### PR DESCRIPTION
## Summary
- Rewrites `docker/Dockerfile.playwright` to use `mcr.microsoft.com/playwright:v1.52.0-noble` base with pre-installed Chrome, Xvfb, x11vnc, and noVNC for live browser viewing
- Updates `docker/playwright-entrypoint.sh` to start virtual framebuffer, VNC server on :5900, and noVNC web client on port 6080
- Updates `docker-compose.yml.example` playwright service with correct port mapping (3100->3000 for MCP, 6080 for noVNC)
- Adds Makefile targets: `build-docker-playwright`, `stop-docker-playwright`, `run-docker-playwright`

## Test plan
- [ ] `make build-docker-playwright` builds successfully
- [ ] `make run-docker-playwright` starts container with MCP on :3100 and noVNC on :6080
- [ ] Browse http://localhost:6080 to confirm noVNC viewer loads
- [ ] Verify MCP SSE endpoint responds at http://localhost:3100/sse
- [ ] `make stop-docker-playwright` cleanly stops and removes container

🤖 Generated with [Claude Code](https://claude.com/claude-code)