### PR TITLE
fix: mount shared screenshot volume in agent containers

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -221,6 +221,7 @@ func (b *Backend) CreateSessionWithCommand(ctx context.Context, name, dir, comma
 // Mounts:
 //   - workspace dir → /workspace (project code)
 //   - .bc/volumes/<agent>/.claude → /home/agent/.claude (persistent Claude state)
+//   - bc-shared-tmp → /tmp/bc-shared (shared volume for cross-container file exchange)
 //
 // Env vars:
 //   - From the env map (BC_AGENT_ID, BC_AGENT_ROLE, role secrets via bc env)
@@ -326,6 +327,10 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 		_ = os.WriteFile(localClaudeJSON, []byte("{}"), 0600) //nolint:errcheck // best-effort
 	}
 	args = append(args, "-v", filepath.Join(hostAgentDir, "claude.json")+":/home/agent/.claude.json")
+
+	// Mount 4: Shared tmp volume for cross-container file exchange (e.g., Playwright screenshots).
+	// Uses a named Docker volume so all agent containers and the Playwright container share the same data.
+	args = append(args, "-v", "bc-shared-tmp:/tmp/bc-shared")
 
 	// Extra mounts from workspace config (e.g., shared caches, tool binaries).
 	// Validate each mount source to prevent arbitrary host filesystem access.


### PR DESCRIPTION
## Summary
- Adds `bc-shared-tmp:/tmp/bc-shared` named Docker volume mount to agent containers created by the container runtime backend
- Enables agents to read screenshots and other files written by the Playwright container via the shared volume
- Follows existing mount pattern in `CreateSessionWithEnv`

Closes #2724

## Test plan
- [ ] Verify agent containers are created with the `bc-shared-tmp` volume mounted at `/tmp/bc-shared`
- [ ] Verify Playwright screenshots written to `/tmp/bc-shared` are readable from inside agent containers
- [ ] Verify existing volume mounts (workspace, .claude, claude.json) are unaffected
- [ ] Run `go test ./pkg/container/` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced container infrastructure to support shared temporary file exchange between containers, enabling better handling of artifacts like Playwright screenshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->