### PR TITLE
fix: remove docker-compose files

### DIFF
--- a/docker/Dockerfile.bcdb
+++ b/docker/Dockerfile.bcdb
@@ -4,7 +4,7 @@
 #
 # POSTGRES_PASSWORD must be set at runtime:
 #   docker run -e POSTGRES_PASSWORD=secret bc-bcdb:latest
-#   Or via docker-compose.yml / .env file
+#   Or via .env file (see .env.example)
 
 FROM postgres:17.4
 


### PR DESCRIPTION
## Summary
- Per Puneet's directive — bc up/down manages all containers. docker-compose.yml.example removed.
- No docker-compose YAML files existed in the repo; removed the last reference to docker-compose.yml from `docker/Dockerfile.bcdb` comment.

## Test plan
- [ ] Verify `docker/Dockerfile.bcdb` builds correctly
- [ ] Confirm no remaining docker-compose references in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)