### PR TITLE
fix: playwright MCP port mapping + include in make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ version: ## Show version info
 
 build: build-local build-docker ## Build everything (local + docker)
 build-local: build-local-go build-local-ts ## Build local binaries (go + ts)
-build-docker: build-docker-sql build-docker-stats build-docker-daemon ## Build Docker images (sql, stats, bcd)
+build-docker: build-docker-sql build-docker-stats build-docker-daemon build-docker-playwright ## Build Docker images (sql, stats, bcd, playwright)
 
 test: test-go test-ts ## Run all tests
 lint: lint-go lint-ts ## Run all linters

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -132,7 +132,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 
 	// 6. playwright-visible — Playwright MCP server with Chromium + noVNC
 	if err := dockerRun(ctx, "playwright-visible", []string{
-		"-p", "3100:3100",
+		"-p", "3100:3000",
 		"-p", "6080:6080",
 		"-v", sharedVolume + ":/tmp/bc-shared",
 		"-e", "DISPLAY=:99",
@@ -148,7 +148,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	fmt.Printf("  bcd:        http://%s\n", addr)
 	fmt.Println("  bc-sql:     localhost:5432")
 	fmt.Println("  bc-stats:   localhost:5433")
-	fmt.Println("  playwright: http://localhost:6080 (noVNC)")
+	fmt.Println("  playwright: http://localhost:6080 (noVNC), MCP localhost:3100")
 	fmt.Println()
 
 	return nil


### PR DESCRIPTION
## Fixes
1. **Port mapping**: `3100:3000` (MCP server listens on 3000 inside container, not 3100)
2. **make build**: Now includes `build-docker-playwright` so `make build` builds the playwright image automatically

After this: `make build && bc down && bc up` will start everything correctly with MCP on port 3100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)