### PR TITLE
feat: image sharing frontend — file upload, drag-drop, paste, inline render (#2669)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -69,6 +69,16 @@ export interface ModelCostSummary {
   record_count: number;
 }
 
+export interface FileAttachment {
+  id: string;
+  filename: string;
+  mime_type: string;
+  size: number;
+  channel: string;
+  sender: string;
+  created_at: string;
+}
+
 export interface DailyCost {
   date: string;
   cost_usd: number;
@@ -577,4 +587,18 @@ export const api = {
       method: "PATCH",
       body: JSON.stringify(patch),
     }),
+
+  /** Upload a file attachment to a channel. */
+  uploadFile: async (file: File, channel: string, sender: string) => {
+    const form = new FormData();
+    form.append("file", file);
+    form.append("channel", channel);
+    form.append("sender", sender);
+    const res = await fetch(`${BASE}/files/upload`, { method: "POST", body: form });
+    if (!res.ok) throw new Error(`Upload failed: ${res.status}`);
+    return res.json() as Promise<FileAttachment>;
+  },
+
+  /** Get file download URL. */
+  getFileUrl: (id: string) => `${BASE}/files/${encodeURIComponent(id)}`,
 };

--- a/web/src/components/MessageContent.tsx
+++ b/web/src/components/MessageContent.tsx
@@ -2,22 +2,25 @@ import type { ReactNode } from "react";
 
 /**
  * Renders message content with basic markdown-like formatting:
- * - URLs become clickable links
+ * - URLs become clickable links (images rendered inline)
  * - **bold** text
  * - `code` backticks
  * - #channel references link to /channels/<name>
  * - @mentions link to agent detail page
+ * - [file:ID] attachment references rendered inline
  */
 export function MessageContent({ content }: { content: string }) {
   return <>{parseContent(content)}</>;
 }
 
+const IMAGE_EXT = /\.(png|jpg|jpeg|gif|webp|svg)(\?|$)/i;
+
 /** Tokenize and render inline formatting. */
 function parseContent(text: string): ReactNode[] {
   // Split on patterns we want to handle, preserving delimiters
-  // Order matters: URLs first (greedy), then bold, then code, then #channel, then @mention
+  // Order: file refs, URLs (greedy), bold, code, #channel, @mention
   const pattern =
-    /(https?:\/\/[^\s<>)"']+)|(\*\*(?:[^*]|\*(?!\*))+\*\*)|(`[^`]+`)|(\B#(?=[a-zA-Z0-9_-]*[a-zA-Z])[a-zA-Z0-9_-]+\b)|(@[a-zA-Z0-9_-]+)/g;
+    /(\[file:[a-zA-Z0-9_-]+\])|(https?:\/\/[^\s<>)"']+)|(\*\*(?:[^*]|\*(?!\*))+\*\*)|(`[^`]+`)|(\B#(?=[a-zA-Z0-9_-]*[a-zA-Z])[a-zA-Z0-9_-]+\b)|(@[a-zA-Z0-9_-]+)/g;
 
   const nodes: ReactNode[] = [];
   let lastIndex = 0;
@@ -33,23 +36,59 @@ function parseContent(text: string): ReactNode[] {
     const key = `${match.index}`;
 
     if (match[1]) {
-      // URL
+      // [file:ID] attachment reference
+      const fileId = full.slice(6, -1);
+      const fileUrl = `/api/files/${encodeURIComponent(fileId)}`;
       nodes.push(
         <a
           key={key}
-          href={full}
+          href={fileUrl}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-bc-accent underline-offset-2 hover:underline"
+          className="inline-block my-1"
         >
-          {full}
+          <img
+            src={fileUrl}
+            alt="attachment"
+            className="max-w-sm max-h-64 rounded border border-bc-border"
+            loading="lazy"
+            onError={(e) => {
+              const el = e.currentTarget;
+              const parent = el.parentElement;
+              if (parent) {
+                parent.className = "text-bc-accent underline-offset-2 hover:underline text-xs";
+                parent.textContent = `📎 ${fileId}`;
+              }
+            }}
+          />
         </a>,
       );
     } else if (match[2]) {
+      // URL — render images inline
+      if (IMAGE_EXT.test(full)) {
+        nodes.push(
+          <a key={key} href={full} target="_blank" rel="noopener noreferrer" className="inline-block my-1">
+            <img src={full} alt="" className="max-w-sm max-h-64 rounded border border-bc-border" loading="lazy" />
+          </a>,
+        );
+      } else {
+        nodes.push(
+          <a
+            key={key}
+            href={full}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-bc-accent underline-offset-2 hover:underline"
+          >
+            {full}
+          </a>,
+        );
+      }
+    } else if (match[3]) {
       // Bold **text**
       const inner = full.slice(2, -2);
       nodes.push(<strong key={key}>{inner}</strong>);
-    } else if (match[3]) {
+    } else if (match[4]) {
       // Inline code `text`
       const inner = full.slice(1, -1);
       nodes.push(
@@ -60,7 +99,7 @@ function parseContent(text: string): ReactNode[] {
           {inner}
         </code>,
       );
-    } else if (match[4]) {
+    } else if (match[5]) {
       // #channel reference → link to /channels/<name>
       const channelName = full.slice(1);
       nodes.push(
@@ -72,7 +111,7 @@ function parseContent(text: string): ReactNode[] {
           {full}
         </a>,
       );
-    } else if (match[5]) {
+    } else if (match[6]) {
       // @mention → link to agent detail page
       const name = full.slice(1);
       nodes.push(

--- a/web/src/components/channels/ChatRoom.tsx
+++ b/web/src/components/channels/ChatRoom.tsx
@@ -128,6 +128,25 @@ export function ChatRoom({
     ]);
   };
 
+  const handleFileUpload = async (file: File) => {
+    const attachment = await api.uploadFile(file, channelName, senderName);
+    // Send a message referencing the uploaded file
+    const isImage = file.type.startsWith("image/");
+    const content = isImage
+      ? `[file:${attachment.id}]`
+      : `📎 [${file.name}](${api.getFileUrl(attachment.id)})`;
+    await api.sendToChannel(channelName, content, senderName);
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: Date.now(),
+        sender: senderName,
+        content,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+  };
+
   const handleDescriptionSave = async (description: string) => {
     await api.updateChannel(channelName, { description });
     onChannelUpdated();
@@ -172,6 +191,7 @@ export function ChatRoom({
         <MessageComposer
           channelName={channelName}
           onSend={handleSend}
+          onFileUpload={handleFileUpload}
         />
       </div>
       {showMembers && channel && (

--- a/web/src/components/channels/MessageComposer.tsx
+++ b/web/src/components/channels/MessageComposer.tsx
@@ -1,17 +1,27 @@
 import { useState, useCallback, useRef } from "react";
 
+interface PendingFile {
+  file: File;
+  preview: string | null;
+}
+
 export function MessageComposer({
   channelName,
   onSend,
+  onFileUpload,
   disabled = false,
 }: {
   channelName: string;
   onSend: (content: string) => Promise<void>;
+  onFileUpload?: (file: File) => Promise<void>;
   disabled?: boolean;
 }) {
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
+  const [pendingFile, setPendingFile] = useState<PendingFile | null>(null);
+  const [uploading, setUploading] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const autoGrow = useCallback(() => {
     const ta = textareaRef.current;
@@ -37,41 +47,161 @@ export function MessageComposer({
     }
   };
 
+  const handleFileSelect = (file: File) => {
+    const isImage = file.type.startsWith("image/");
+    const preview = isImage ? URL.createObjectURL(file) : null;
+    setPendingFile({ file, preview });
+  };
+
+  const handleFileUpload = async () => {
+    if (!pendingFile || !onFileUpload || uploading) return;
+    setUploading(true);
+    try {
+      await onFileUpload(pendingFile.file);
+      if (pendingFile.preview) URL.revokeObjectURL(pendingFile.preview);
+      setPendingFile(null);
+    } catch {
+      // keep pending
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const cancelFile = () => {
+    if (pendingFile?.preview) URL.revokeObjectURL(pendingFile.preview);
+    setPendingFile(null);
+  };
+
+  const handlePaste = (e: React.ClipboardEvent) => {
+    if (!onFileUpload) return;
+    const items = e.clipboardData.items;
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (item && item.type.startsWith("image/")) {
+        e.preventDefault();
+        const file = item.getAsFile();
+        if (file) handleFileSelect(file);
+        return;
+      }
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    if (!onFileUpload) return;
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault();
+  };
+
   return (
-    <div className="p-3 border-t border-bc-border flex gap-2 items-end">
-      <textarea
-        ref={textareaRef}
-        rows={1}
-        value={input}
-        onChange={(e) => {
-          setInput(e.target.value);
-          autoGrow();
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && !e.shiftKey) {
-            e.preventDefault();
-            void handleSend();
-          }
-          if (e.key === "Escape") {
-            setInput("");
-            if (textareaRef.current) {
-              textareaRef.current.style.height = "auto";
-              textareaRef.current.blur();
+    <div
+      className="border-t border-bc-border"
+      onDrop={handleDrop}
+      onDragOver={handleDragOver}
+    >
+      {/* File preview */}
+      {pendingFile && (
+        <div className="px-3 pt-2 flex items-center gap-2">
+          {pendingFile.preview ? (
+            <img
+              src={pendingFile.preview}
+              alt="preview"
+              className="w-16 h-16 rounded border border-bc-border object-cover"
+            />
+          ) : (
+            <div className="w-16 h-16 rounded border border-bc-border bg-bc-surface flex items-center justify-center text-xs text-bc-muted">
+              📎
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-bc-text truncate">{pendingFile.file.name}</p>
+            <p className="text-[10px] text-bc-muted">
+              {(pendingFile.file.size / 1024).toFixed(1)} KB
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleFileUpload()}
+            disabled={uploading}
+            className="text-xs px-2 py-1 rounded bg-bc-accent text-bc-bg font-medium disabled:opacity-50"
+          >
+            {uploading ? "..." : "Upload"}
+          </button>
+          <button
+            type="button"
+            onClick={cancelFile}
+            className="text-xs px-2 py-1 rounded border border-bc-border text-bc-muted hover:text-bc-text"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+
+      {/* Input area */}
+      <div className="p-3 flex gap-2 items-end">
+        {onFileUpload && (
+          <>
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={disabled}
+              className="px-2 py-1.5 rounded border border-bc-border text-bc-muted hover:text-bc-accent hover:border-bc-accent transition-colors disabled:opacity-50 focus-visible:ring-1 focus-visible:ring-bc-accent"
+              aria-label="Attach file"
+              title="Attach file"
+            >
+              📎
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) handleFileSelect(file);
+                e.target.value = "";
+              }}
+            />
+          </>
+        )}
+        <textarea
+          ref={textareaRef}
+          rows={1}
+          value={input}
+          onChange={(e) => {
+            setInput(e.target.value);
+            autoGrow();
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault();
+              void handleSend();
             }
-          }
-        }}
-        placeholder={`Message #${channelName}...`}
-        disabled={disabled}
-        className="flex-1 bg-bc-bg border border-bc-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-bc-accent focus-visible:ring-1 focus-visible:ring-bc-accent resize-none disabled:opacity-50"
-      />
-      <button
-        type="button"
-        onClick={() => void handleSend()}
-        disabled={sending || !input.trim() || disabled}
-        className="px-4 py-1.5 bg-bc-accent text-bc-bg rounded text-sm font-medium disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bc-bg"
-      >
-        {sending ? "..." : "Send"}
-      </button>
+            if (e.key === "Escape") {
+              setInput("");
+              if (textareaRef.current) {
+                textareaRef.current.style.height = "auto";
+                textareaRef.current.blur();
+              }
+            }
+          }}
+          onPaste={handlePaste}
+          placeholder={`Message #${channelName}...`}
+          disabled={disabled}
+          className="flex-1 bg-bc-bg border border-bc-border rounded px-3 py-1.5 text-sm focus:outline-none focus:border-bc-accent focus-visible:ring-1 focus-visible:ring-bc-accent resize-none disabled:opacity-50"
+        />
+        <button
+          type="button"
+          onClick={() => void handleSend()}
+          disabled={sending || !input.trim() || disabled}
+          className="px-4 py-1.5 bg-bc-accent text-bc-bg rounded text-sm font-medium disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bc-bg"
+        >
+          {sending ? "..." : "Send"}
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Image sharing frontend: file attach button, drag-and-drop, clipboard paste, preview before send, inline image rendering in messages. Closes #2669.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added file attachment support with multiple upload methods: drag-and-drop, paste from clipboard, or file picker
  * Images display inline in messages; other files appear as downloadable links
  * File preview shows before sending

<!-- end of auto-generated comment: release notes by coderabbit.ai -->