### PR TITLE
feat: unified database — merge bc-sql + bc-stats into bc-db

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ version: ## Show version info
 
 build: build-local build-docker ## Build everything (local + docker)
 build-local: build-local-go build-local-ts ## Build local binaries (go + ts)
-build-docker: build-docker-sql build-docker-stats build-docker-daemon build-docker-playwright ## Build Docker images (sql, stats, bcd, playwright)
+build-docker: build-docker-db build-docker-daemon build-docker-playwright ## Build Docker images (db, bcd, playwright)
 
 test: test-go test-ts ## Run all tests
 lint: lint-go lint-ts ## Run all linters
@@ -138,10 +138,13 @@ build-local-landing: ## Build landing page
 build-docker-daemon: ## Build bcd Docker image
 	docker build -t $(REGISTRY)-daemon:$(IMAGE_TAG) -f docker/Dockerfile.bcd .
 
-build-docker-sql: ## Build bc-sql (Postgres) Docker image
+build-docker-db: ## Build bc-db (unified TimescaleDB) Docker image
+	docker build -t $(REGISTRY)-bcdb:$(IMAGE_TAG) -f docker/Dockerfile.bcdb .
+
+build-docker-sql: ## Build bc-sql (legacy, use build-docker-db instead)
 	docker build -t $(REGISTRY)-bcsql:$(IMAGE_TAG) -f docker/Dockerfile.bcsql .
 
-build-docker-stats: ## Build bc-stats (TimescaleDB) Docker image
+build-docker-stats: ## Build bc-stats (legacy, use build-docker-db instead)
 	docker build -t $(REGISTRY)-bcstats:$(IMAGE_TAG) -f docker/Dockerfile.bcstats .
 
 build-docker-agent-base: ## Build agent base image

--- a/docker/Dockerfile.bcdb
+++ b/docker/Dockerfile.bcdb
@@ -1,19 +1,21 @@
-# bcdb image — Postgres database for bc workspaces
+# bcdb — Unified database for bc workspaces (relational + time-series)
+# Uses TimescaleDB (which IS Postgres) for both relational data and hypertables.
+# Replaces the separate bc-bcsql and bc-bcstats images.
+#
 # Usage: docker build -t bc-bcdb:latest -f docker/Dockerfile.bcdb .
-# Base images pinned — update versions in Dependabot PRs or manually.
 #
 # POSTGRES_PASSWORD must be set at runtime:
 #   docker run -e POSTGRES_PASSWORD=secret bc-bcdb:latest
-#   Or via .env file (see .env.example)
+#   Or via bc up (which sets POSTGRES_PASSWORD automatically)
 
-FROM postgres:17.4
+FROM timescale/timescaledb:2.19.1-pg17
 
 ENV POSTGRES_USER=bc
 ENV POSTGRES_DB=bc
 # POSTGRES_PASSWORD intentionally not set — must be provided at runtime.
-# See .env.example for documentation.
 
 # Init scripts run on first start (alphabetical order)
+# Contains both relational tables AND TimescaleDB hypertables
 COPY docker/bcdb/init.sql /docker-entrypoint-initdb.d/01-init.sql
 
 EXPOSE 5432

--- a/docker/bcdb/init.sql
+++ b/docker/bcdb/init.sql
@@ -1,5 +1,15 @@
--- bc workspace schema — shared by SQLite and Postgres
--- All tables use standard SQL compatible with both backends
+-- bc unified database schema — relational + time-series in one database
+-- Uses TimescaleDB extension for hypertables (time-series metrics)
+-- All tables use standard SQL compatible with both SQLite and Postgres
+
+-- ============================================================================
+-- TimescaleDB extension (no-op if already enabled)
+-- ============================================================================
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+-- ============================================================================
+-- Relational tables (agents, channels, costs, events, cron, etc.)
+-- ============================================================================
 
 CREATE TABLE IF NOT EXISTS agents (
     name          TEXT PRIMARY KEY,
@@ -139,7 +149,7 @@ CREATE TABLE IF NOT EXISTS daemons (
     stopped_at    TEXT
 );
 
--- Indexes
+-- Relational indexes
 CREATE INDEX IF NOT EXISTS idx_agents_state ON agents(state);
 CREATE INDEX IF NOT EXISTS idx_agents_role ON agents(role);
 CREATE INDEX IF NOT EXISTS idx_messages_channel ON messages(channel_id);
@@ -149,3 +159,71 @@ CREATE INDEX IF NOT EXISTS idx_cost_records_model ON cost_records(model);
 CREATE INDEX IF NOT EXISTS idx_cost_records_timestamp ON cost_records(timestamp);
 CREATE INDEX IF NOT EXISTS idx_events_agent ON events(agent);
 CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp);
+
+-- ============================================================================
+-- Time-series tables (TimescaleDB hypertables)
+-- ============================================================================
+
+-- System Metrics — bc-daemon, bc-db containers
+CREATE TABLE IF NOT EXISTS system_metrics (
+    time             TIMESTAMPTZ NOT NULL,
+    system_name      TEXT NOT NULL,
+    cpu_percent      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    mem_used_bytes   BIGINT NOT NULL DEFAULT 0,
+    mem_limit_bytes  BIGINT NOT NULL DEFAULT 0,
+    mem_percent      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    net_rx_bytes     BIGINT NOT NULL DEFAULT 0,
+    net_tx_bytes     BIGINT NOT NULL DEFAULT 0,
+    disk_read_bytes  BIGINT NOT NULL DEFAULT 0,
+    disk_write_bytes BIGINT NOT NULL DEFAULT 0
+);
+SELECT create_hypertable('system_metrics', 'time', if_not_exists => TRUE);
+
+-- Agent Metrics — per-agent container stats
+CREATE TABLE IF NOT EXISTS agent_metrics (
+    time             TIMESTAMPTZ NOT NULL,
+    agent_name       TEXT NOT NULL,
+    role             TEXT NOT NULL DEFAULT '',
+    tool             TEXT NOT NULL DEFAULT '',
+    runtime          TEXT NOT NULL DEFAULT 'docker',
+    state            TEXT NOT NULL DEFAULT '',
+    cpu_percent      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    mem_used_bytes   BIGINT NOT NULL DEFAULT 0,
+    mem_limit_bytes  BIGINT NOT NULL DEFAULT 0,
+    mem_percent      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    net_rx_bytes     BIGINT NOT NULL DEFAULT 0,
+    net_tx_bytes     BIGINT NOT NULL DEFAULT 0,
+    disk_read_bytes  BIGINT NOT NULL DEFAULT 0,
+    disk_write_bytes BIGINT NOT NULL DEFAULT 0
+);
+SELECT create_hypertable('agent_metrics', 'time', if_not_exists => TRUE);
+
+-- Token Metrics — per-agent token consumption from JSONL
+CREATE TABLE IF NOT EXISTS token_metrics (
+    time          TIMESTAMPTZ NOT NULL,
+    agent_name    TEXT NOT NULL DEFAULT '',
+    model         TEXT NOT NULL DEFAULT '',
+    input_tokens  BIGINT NOT NULL DEFAULT 0,
+    output_tokens BIGINT NOT NULL DEFAULT 0,
+    cache_read    BIGINT NOT NULL DEFAULT 0,
+    cache_create  BIGINT NOT NULL DEFAULT 0,
+    cost_usd      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    UNIQUE (time, agent_name, model)
+);
+SELECT create_hypertable('token_metrics', 'time', if_not_exists => TRUE);
+
+-- Channel Metrics — message/member/reaction counts
+CREATE TABLE IF NOT EXISTS channel_metrics (
+    time           TIMESTAMPTZ NOT NULL,
+    channel_name   TEXT NOT NULL,
+    message_count  BIGINT NOT NULL DEFAULT 0,
+    member_count   INT NOT NULL DEFAULT 0,
+    reaction_count BIGINT NOT NULL DEFAULT 0
+);
+SELECT create_hypertable('channel_metrics', 'time', if_not_exists => TRUE);
+
+-- Retention policies
+SELECT add_retention_policy('system_metrics',  INTERVAL '7 days',  if_not_exists => TRUE);
+SELECT add_retention_policy('agent_metrics',   INTERVAL '7 days',  if_not_exists => TRUE);
+SELECT add_retention_policy('token_metrics',   INTERVAL '30 days', if_not_exists => TRUE);
+SELECT add_retention_policy('channel_metrics', INTERVAL '30 days', if_not_exists => TRUE);

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -15,7 +15,7 @@ import (
 var downCmd = &cobra.Command{
 	Use:   "down",
 	Short: "Stop bc services",
-	Long: `Stop bc-<id>-daemon, bc-playwright, bc-stats, and bc-sql Docker containers.
+	Long: `Stop bc-<id>-daemon, bc-playwright, and bc-db Docker containers.
 
 Examples:
   bc down
@@ -53,7 +53,7 @@ func runDown(cmd *cobra.Command, _ []string) error {
 	daemonName := fmt.Sprintf("bc-%s-daemon", id)
 
 	var stopped int
-	for _, name := range []string{daemonName, "bc-playwright", "bc-stats", "bc-sql"} {
+	for _, name := range []string{daemonName, "bc-playwright", "bc-db", "bc-stats", "bc-sql"} {
 		//nolint:gosec // trusted
 		out, _ := exec.CommandContext(ctx, "docker", "inspect", "-f", "{{.State.Running}}", name).Output()
 		if strings.TrimSpace(string(out)) != "true" {

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -20,7 +20,7 @@ import (
 var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Start bc services",
-	Long: `Start bc-sql, bc-stats, bc-<id>-daemon, and bc-playwright in Docker.
+	Long: `Start bc-db, bc-<id>-daemon, and bc-playwright in Docker.
 
 Examples:
   bc up
@@ -61,42 +61,28 @@ func runUp(cmd *cobra.Command, _ []string) error {
 
 	id := wsID(ws.RootDir)
 
-	// 1. bc-sql — persistent volume for Postgres data
-	if err := dockerRun(ctx, "bc-sql", []string{
-		"-p", "5432:5432",
-		"-e", "POSTGRES_PASSWORD=bc",
-		"-v", "bc-sql-data:/var/lib/postgresql/data",
-		"--restart", "always",
-		"bc-bcsql:latest",
-	}); err != nil {
-		return fmt.Errorf("bc-sql failed to start: %w", err)
-	}
-
-	// 2. bc-stats — persistent volume for TimescaleDB data
-	if err := dockerRun(ctx, "bc-stats", []string{
-		"-p", "5433:5432",
-		"-e", "POSTGRES_PASSWORD=bc",
-		"-v", "bc-stats-data:/var/lib/postgresql/data",
-		"--restart", "always",
-		"bc-bcstats:latest",
-	}); err != nil {
-		return fmt.Errorf("bc-stats failed to start: %w", err)
-	}
-
-	// 3. Wait for databases
-	fmt.Print("  Waiting for databases... ")
-	if err := waitPG(ctx, "bc-sql", 30*time.Second); err != nil {
-		return fmt.Errorf("bc-sql not ready: %w", err)
-	}
-	if err := waitPG(ctx, "bc-stats", 30*time.Second); err != nil {
-		return fmt.Errorf("bc-stats not ready: %w", err)
-	}
-	fmt.Println(ui.GreenText("ready"))
-
 	// Shared volume for screenshots and temp files between containers
 	const sharedVolume = "bc-shared-tmp"
 
-	// 4. bc-<id>-daemon with docker.sock + workspace mount
+	// 1. bc-db — unified database (TimescaleDB = Postgres + hypertables)
+	if err := dockerRun(ctx, "bc-db", []string{
+		"-p", "5432:5432",
+		"-e", "POSTGRES_PASSWORD=bc",
+		"-v", "bc-db-data:/var/lib/postgresql/data",
+		"--restart", "always",
+		"bc-bcdb:latest",
+	}); err != nil {
+		return fmt.Errorf("bc-db failed to start: %w", err)
+	}
+
+	// 2. Wait for database
+	fmt.Print("  Waiting for database... ")
+	if err := waitPG(ctx, "bc-db", 30*time.Second); err != nil {
+		return fmt.Errorf("bc-db not ready: %w", err)
+	}
+	fmt.Println(ui.GreenText("ready"))
+
+	// 3. bc-<id>-daemon with docker.sock + workspace mount
 	daemonName := fmt.Sprintf("bc-%s-daemon", id)
 	daemonArgs := []string{
 		"-p", upPort + ":9374",
@@ -104,7 +90,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		"-v", "/var/run/docker.sock:/var/run/docker.sock",
 		"-v", sharedVolume + ":/tmp/bc-shared",
 		"-e", "DATABASE_URL=postgres://bc:bc@host.docker.internal:5432/bc",
-		"-e", "STATS_DATABASE_URL=postgres://bc:bc@host.docker.internal:5433/bcstats",
+		"-e", "STATS_DATABASE_URL=postgres://bc:bc@host.docker.internal:5432/bc",
 		"-e", "BC_HOST_WORKSPACE=" + ws.RootDir,
 		"--restart", "always",
 	}
@@ -121,7 +107,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		fmt.Printf("  %s daemon failed to start: %v\n", ui.YellowText("warning"), err)
 	}
 
-	// 5. Wait for bcd
+	// 4. Wait for bcd
 	addr := fmt.Sprintf("127.0.0.1:%s", upPort)
 	fmt.Print("  Waiting for bcd... ")
 	if waitHTTP(ctx, addr, 30*time.Second) != nil {
@@ -130,7 +116,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		fmt.Println(ui.GreenText("ready"))
 	}
 
-	// 6. bc-playwright — Playwright MCP server with Chromium + noVNC
+	// 5. bc-playwright — Playwright MCP server with Chromium + noVNC
 	// --init prevents zombie processes, --ipc=host prevents Chromium OOM crashes
 	// See: https://playwright.dev/docs/docker
 	if err := dockerRun(ctx, "bc-playwright", []string{
@@ -150,8 +136,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	fmt.Println()
 	fmt.Printf("  %s bc workspace ready\n", ui.GreenText("ok"))
 	fmt.Printf("  bcd:        http://%s\n", addr)
-	fmt.Println("  bc-sql:     localhost:5432")
-	fmt.Println("  bc-stats:   localhost:5433")
+	fmt.Println("  bc-db:      localhost:5432")
 	fmt.Println("  playwright: http://localhost:6080 (noVNC), MCP localhost:3100")
 	fmt.Println()
 
@@ -229,4 +214,3 @@ func wsID(path string) string {
 	h := sha256.Sum256([]byte(path))
 	return fmt.Sprintf("%x", h[:3])
 }
-


### PR DESCRIPTION
## Summary
Merge separate `bc-sql` (Postgres) and `bc-stats` (TimescaleDB) into a single `bc-db` container. TimescaleDB IS Postgres — one instance handles both relational data and time-series hypertables.

Part of #2642

## Changes
- **`docker/Dockerfile.bcdb`** — Now uses `timescale/timescaledb:2.19.1-pg17` base image
- **`docker/bcdb/init.sql`** — Merged: relational tables + TimescaleDB hypertables + retention policies
- **`internal/cmd/up.go`** — Single `bc-db` on port 5432 (was 2 containers on 5432+5433)
- **`internal/cmd/down.go`** — Stops `bc-db` (+ legacy `bc-sql`/`bc-stats` for migration)
- **`Makefile`** — `build-docker` now uses `build-docker-db`

## Migration
- `bc down` stops old `bc-sql` and `bc-stats` containers
- `make build` builds new `bc-bcdb` image
- `bc up` starts single `bc-db` with fresh volume
- Both `DATABASE_URL` and `STATS_DATABASE_URL` point to `bc-db:5432`
- Old `bc-sql-data` and `bc-stats-data` volumes can be removed manually

## Test plan
- [x] `go build ./...` clean
- [x] `go vet` clean
- [ ] `make build-docker-db` builds image
- [ ] `bc down && bc up` starts single database

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unified database service consolidating relational and time-series workloads into a single, more efficient instance
  * Integrated metric tables for system, agent, token, and channel performance tracking with automatic data retention policies (7-30 days depending on metric type)

* **Chores**
  * Streamlined database initialization and simplified deployment configuration
  * Improved container management with consolidated service startup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->