### PR TITLE
feat: wire container metrics into agent stats API

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -108,7 +108,7 @@ func run(addr, wsRoot, corsOrigin string) error {
 	go hub.Run()
 	defer hub.Stop()
 
-	agentMgr, agentErr := newAgentManager(ws)
+	agentMgr, containerBackend, agentErr := newAgentManager(ws)
 	if agentErr != nil {
 		return fmt.Errorf("agent manager: %w", agentErr)
 	}
@@ -120,6 +120,14 @@ func run(addr, wsRoot, corsOrigin string) error {
 		agentMgr.SetRoleManager(ws.RoleManager)
 	}
 	agentSvc := bcagent.NewAgentService(agentMgr, hub, nil)
+
+	// Background container metrics collector: periodically samples Docker
+	// resource usage via the container.Backend API and persists records into
+	// the SQLite agent_stats table. This feeds the /api/agents/{name}/stats
+	// endpoint so the dashboard shows real CPU/memory/disk/IO per agent.
+	if containerBackend != nil {
+		go runContainerStatsCollector(ctx, containerBackend, agentMgr)
+	}
 
 	var channelSvc *bcchannel.ChannelService
 	if chStore, err := bcchannel.OpenStore(ws.RootDir); err != nil {
@@ -325,7 +333,7 @@ func run(addr, wsRoot, corsOrigin string) error {
 	return srv.Start(ctx)
 }
 
-func newAgentManager(ws *bcworkspace.Workspace) (*bcagent.Manager, error) {
+func newAgentManager(ws *bcworkspace.Workspace) (*bcagent.Manager, *bccontainer.Backend, error) {
 	var wsCfg bcworkspace.DockerRuntimeConfig
 	if ws.Config != nil {
 		wsCfg = ws.Config.Runtime.Docker
@@ -334,9 +342,10 @@ func newAgentManager(ws *bcworkspace.Workspace) (*bcagent.Manager, error) {
 	be, err := bccontainer.NewBackend(dockerCfg, "bc-", ws.RootDir, provider.DefaultRegistry)
 	if err != nil {
 		log.Warn("Docker not available — agents will use tmux runtime only", "error", err)
-		return bcagent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir), nil
+		return bcagent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir), nil, nil
 	}
-	return bcagent.NewWorkspaceManagerWithRuntime(ws.AgentsDir(), ws.RootDir, be, "docker"), nil
+	mgr := bcagent.NewWorkspaceManagerWithRuntime(ws.AgentsDir(), ws.RootDir, be, "docker")
+	return mgr, be, nil
 }
 
 func writePID(path string) error {
@@ -556,6 +565,49 @@ func extractAgentName(containerName string) string {
 		return containerName[10:]
 	}
 	return containerName
+}
+
+// runContainerStatsCollector periodically samples Docker container resource
+// metrics via the container.Backend API (Docker socket) and persists them
+// into the SQLite agent_stats table. This feeds GET /api/agents/{name}/stats
+// so the dashboard shows real CPU/memory/disk/IO per agent without requiring
+// the optional TimescaleDB stats store.
+func runContainerStatsCollector(ctx context.Context, be *bccontainer.Backend, mgr *bcagent.Manager) {
+	const interval = 30 * time.Second
+	const bytesToMB = 1024 * 1024
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			allStats, err := be.AllStats(ctx)
+			if err != nil {
+				log.Debug("container stats collection failed", "error", err)
+				continue
+			}
+			for _, cs := range allStats {
+				agentName := extractAgentName(cs.Name)
+				rec := &bcagent.AgentStatsRecord{
+					AgentName:    agentName,
+					CollectedAt:  time.Now().UTC(),
+					CPUPct:       cs.CPUPercent,
+					MemUsedMB:    float64(cs.MemoryUsed) / bytesToMB,
+					MemLimitMB:   float64(cs.MemoryLimit) / bytesToMB,
+					NetRxMB:      float64(cs.NetRx) / bytesToMB,
+					NetTxMB:      float64(cs.NetTx) / bytesToMB,
+					BlockReadMB:  float64(cs.DiskRead) / bytesToMB,
+					BlockWriteMB: float64(cs.DiskWrite) / bytesToMB,
+				}
+				if err := mgr.RecordAgentStats(rec); err != nil {
+					log.Debug("failed to record container stats", "agent", agentName, "error", err)
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 // parsePercent parses a percentage string like "5.00%" into a float64.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2221,6 +2221,16 @@ func (m *Manager) QueryAgentStats(agentName string, limit int) ([]*AgentStatsRec
 	return m.store.QueryStats(agentName, limit)
 }
 
+// RecordAgentStats persists a single AgentStatsRecord to the SQLite store.
+// This is used by the background container metrics collector to save Docker
+// resource samples so the /api/agents/{name}/stats endpoint returns real data.
+func (m *Manager) RecordAgentStats(rec *AgentStatsRecord) error {
+	if m.store == nil {
+		return fmt.Errorf("no store available")
+	}
+	return m.store.SaveStats(rec)
+}
+
 // Close closes the SQLite store. Call when done with the manager.
 func (m *Manager) Close() error {
 	if m.store != nil {


### PR DESCRIPTION
## Summary
- Connects `pkg/container/stats.go` Docker metrics (via Docker socket API) to the agent stats endpoint so the dashboard shows real CPU/memory/disk/IO data per agent
- Adds `RecordAgentStats` method to `agent.Manager` for persisting container metrics to the SQLite `agent_stats` table
- Adds `runContainerStatsCollector` background goroutine in `bcd` that samples Docker container resources every 30s and saves them as `AgentStatsRecord` rows
- Returns `container.Backend` from `newAgentManager` so the collector can use the structured Docker API directly

Part of #2724.

## How it works
1. On startup, if Docker is available, `bcd` launches `runContainerStatsCollector` as a background goroutine
2. Every 30 seconds, the collector calls `container.Backend.AllStats()` which queries the Docker socket for one-shot container stats
3. Each `ContainerStats` result is converted to an `AgentStatsRecord` (CPU%, memory MB, disk IO MB, network MB) and saved to SQLite via `Manager.RecordAgentStats()`
4. The existing `GET /api/agents/{name}/stats` handler reads from the same SQLite table via `Manager.QueryAgentStats()`, so the dashboard now shows real metrics

## Test plan
- [x] `go build ./cmd/bcd/` compiles cleanly
- [x] `go vet ./cmd/bcd/ ./pkg/agent/` passes
- [x] Existing `TestSaveAndQueryStats`, `TestQueryStats_Empty`, `TestQueryStats_LimitRespected` all pass
- [ ] Deploy with Docker runtime and verify `/api/agents/{name}/stats` returns non-zero metrics
- [ ] Verify dashboard shows CPU/memory/disk/IO charts for running agents

Generated with [Claude Code](https://claude.com/claude-code)