### PR TITLE
fix: restore playwright to build-docker target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ version: ## Show version info
 
 build: build-local build-docker ## Build everything (local + docker)
 build-local: build-local-go build-local-ts ## Build local binaries (go + ts)
-build-docker: build-docker-db build-docker-daemon ## Build Docker images (db, bcd)
+build-docker: build-docker-db build-docker-daemon build-docker-playwright ## Build Docker images (db, bcd, playwright)
 
 test: test-go test-ts ## Run all tests
 lint: lint-go lint-ts ## Run all linters


### PR DESCRIPTION
Playwright was dropped from `build-docker` during the unified DB merge. This restores it so `make build` builds all images including playwright.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build process to include building a Playwright Docker image in addition to existing database and daemon images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->