### PR TITLE
fix: Playwright screenshots to shared volume

### DIFF
--- a/docker/playwright-entrypoint.sh
+++ b/docker/playwright-entrypoint.sh
@@ -12,6 +12,10 @@ export DISPLAY=:99
 x11vnc -display :99 -forever -nopw -shared -rfbport 5900 2>/dev/null &
 websockify --web=/usr/share/novnc 6080 localhost:5900 2>/dev/null &
 
+# Shared volume for screenshots
+mkdir -p /tmp/bc-shared
+export PLAYWRIGHT_OUTPUT_DIR=/tmp/bc-shared
+
 # Playwright MCP server (headed — visible in VNC)
 # --host 0.0.0.0     : accept external connections
 # --allowed-hosts '*' : accept any Host header (Docker networking)


### PR DESCRIPTION
## Summary
- Sets `PLAYWRIGHT_OUTPUT_DIR=/tmp/bc-shared` in `docker/playwright-entrypoint.sh` so screenshots are saved to the shared volume accessible by all containers.
- Adds `mkdir -p /tmp/bc-shared` to ensure the directory exists before the MCP server starts.

## Test plan
- [ ] Verify `docker/playwright-entrypoint.sh` creates `/tmp/bc-shared` on container start
- [ ] Verify Playwright screenshots land in `/tmp/bc-shared`
- [ ] Confirm other containers can read screenshots from the shared volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test output management by establishing a dedicated directory for Playwright outputs, enhancing the organization of test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->