### PR TITLE
fix: filter infrastructure containers from agent stats cards

### DIFF
--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -202,9 +202,17 @@ function AgentOverview({
   selectedAgent: string | null;
   onSelectAgent: (name: string | null) => void;
 }) {
+  // Filter out infrastructure containers — only show actual agents
+  const INFRA_PREFIXES = ["bc-db", "bc-daemon", "bc-sql", "bc-stats", "bc-playwright", "bc-bcsql", "bc-bcstats"];
+  const isInfra = (name: string) =>
+    INFRA_PREFIXES.some((p) => name === p || name.startsWith(p + "-")) ||
+    name.length <= 3; // filter truncated/garbage entries like "ght"
+
   // Build per-agent latest metrics
   const latest = new Map<string, AgentMetricTS>();
-  for (const m of metrics) latest.set(m.agent_name, m);
+  for (const m of metrics) {
+    if (!isInfra(m.agent_name)) latest.set(m.agent_name, m);
+  }
 
   // Build cost lookup
   const costMap = new Map<string, AgentCostSummary>();


### PR DESCRIPTION
## Summary

Filters out bc-db, bc-daemon, bc-sql, bc-stats, bc-playwright and truncated entries from per-agent stats. Only real agents show.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Infrastructure agents are now automatically filtered from the Agents section in the Statistics view.
  * Agent entries with very short or truncated identifiers (3 characters or fewer) are excluded to improve data quality.
  * The Agents section now displays a cleaner list focused on relevant, properly-identified agents, enhancing interface clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->