### PR TITLE
feat: add Trivy container image scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -150,3 +151,26 @@ jobs:
 
       - name: Verify binary runs
         run: ./bin/bc version
+
+  # ── Container Scan (main only) ──────────────────────────────────────
+  scan:
+    name: Container Scan
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [build]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6
+      - name: Build bcd image
+        run: docker build -t bc-daemon:latest -f docker/Dockerfile.bcd .
+      - name: Scan with Trivy
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947e7b4b18e97b232c4 # v0.29.0
+        with:
+          image-ref: bc-daemon:latest
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary

- Adds a new `scan` job to `.github/workflows/ci.yml` that builds the `bcd` Docker image and scans it with [Trivy](https://github.com/aquasecurity/trivy) for CRITICAL and HIGH vulnerabilities
- Uploads scan results as SARIF to the GitHub Security tab
- Runs on main branch only (after the build gate), following the same pattern as `security` and `test-full` jobs
- Adds `security-events: write` permission required for SARIF upload

Closes #2624
Part of #2614

## Test plan

- [ ] Verify CI passes on this PR (scan job is skipped on PRs, as intended)
- [ ] After merge to main, confirm the `Container Scan` job runs and uploads SARIF
- [ ] Check GitHub Security tab shows Trivy results

🤖 Generated with [Claude Code](https://claude.com/claude-code)