### PR TITLE
fix: Playwright Makefile port 3100:3000

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ stop-docker-playwright: ## Stop and remove Playwright container
 run-docker-playwright: stop-docker-playwright ## Run Playwright MCP container (VNC :6080, MCP :3000)
 	docker run -d --name bc-playwright \
 		--init --ipc=host \
-		-p 3000:3000 -p 6080:6080 \
+		-p 3100:3000 -p 6080:6080 \
 		-v bc-shared-tmp:/tmp/bc-shared \
 		-e DISPLAY=:99 \
 		--restart unless-stopped \


### PR DESCRIPTION
## Summary
- Fixes port mapping in `run-docker-playwright` target from `3000:3000` to `3100:3000` to match `bc up` and agent MCP config.

## Test plan
- [ ] Run `make run-docker-playwright` and verify MCP is reachable on host port 3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker port mapping for the MCP endpoint from host port 3000 to 3100, while keeping the container port at 3000. VNC port mapping remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->