### PR TITLE
fix: remove playwright from bc up help text

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -20,7 +20,7 @@ import (
 var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Start bc services",
-	Long: `Start bc-db, bc-<id>-daemon, and bc-playwright in Docker.
+	Long: `Start bc-db and bc-<id>-daemon in Docker.
 
 Examples:
   bc up


### PR DESCRIPTION
Playwright is managed separately via make commands, not bc up/down.