### PR TITLE
fix: shared volume permissions for screenshots

### DIFF
--- a/docker/playwright-entrypoint.sh
+++ b/docker/playwright-entrypoint.sh
@@ -14,6 +14,7 @@ websockify --web=/usr/share/novnc 6080 localhost:5900 2>/dev/null &
 
 # Shared volume for screenshots
 mkdir -p /tmp/bc-shared
+chmod 777 /tmp/bc-shared
 export PLAYWRIGHT_OUTPUT_DIR=/tmp/bc-shared
 
 # Playwright MCP server (headed — visible in VNC)


### PR DESCRIPTION
Sets /tmp/bc-shared to 777 in Playwright entrypoint so all containers can read/write screenshots. One line change.

PLAYWRIGHT_OUTPUT_DIR=/tmp/bc-shared already set from PR #2749.