### PR TITLE
fix: symlink Playwright output to shared volume

### DIFF
--- a/docker/playwright-entrypoint.sh
+++ b/docker/playwright-entrypoint.sh
@@ -17,6 +17,12 @@ mkdir -p /tmp/bc-shared
 chmod 777 /tmp/bc-shared
 export PLAYWRIGHT_OUTPUT_DIR=/tmp/bc-shared
 
+# Symlink Playwright MCP default output dir to shared volume
+# Playwright MCP restricts file access to /.playwright-mcp/, so symlink it
+# to the shared volume so all containers can access screenshots
+rm -rf /.playwright-mcp 2>/dev/null
+ln -s /tmp/bc-shared /.playwright-mcp
+
 # Playwright MCP server (headed — visible in VNC)
 # --host 0.0.0.0     : accept external connections
 # --allowed-hosts '*' : accept any Host header (Docker networking)


### PR DESCRIPTION
## Summary
- Symlinks `/.playwright-mcp` → `/tmp/bc-shared` in the Playwright entrypoint so screenshots saved by Playwright MCP are accessible by all containers via the shared volume mount.
- Playwright MCP restricts file access to `/.playwright-mcp/` by default; without the symlink, other containers cannot read its output.

## Test plan
- [ ] Build the Playwright Docker image and verify `/.playwright-mcp` is a symlink to `/tmp/bc-shared`
- [ ] Take a screenshot via Playwright MCP and confirm it appears in `/tmp/bc-shared/` on another container

🤖 Generated with [Claude Code](https://claude.com/claude-code)