### PR TITLE
fix: P0 security — redact secrets from SSE activity broadcast

### DIFF
--- a/server/ws/hub.go
+++ b/server/ws/hub.go
@@ -59,8 +59,9 @@ func (h *Hub) Stop() {
 }
 
 // Publish implements agent.EventPublisher.
+// Data is redacted before broadcast to prevent secrets from leaking to the UI.
 func (h *Hub) Publish(eventType string, data map[string]any) {
-	evt := Event{Type: eventType, Data: data}
+	evt := Event{Type: eventType, Data: RedactMap(data)}
 	msg, err := json.Marshal(evt)
 	if err != nil {
 		return

--- a/server/ws/redact.go
+++ b/server/ws/redact.go
@@ -1,0 +1,78 @@
+package ws
+
+import (
+	"regexp"
+	"strings"
+)
+
+// secretPatterns matches known secret/token formats that should be redacted.
+var secretPatterns = []*regexp.Regexp{
+	// GitHub PATs (classic and fine-grained)
+	regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,}`),
+	regexp.MustCompile(`ghp_[A-Za-z0-9]{36,}`),
+	regexp.MustCompile(`gho_[A-Za-z0-9]{36,}`),
+	regexp.MustCompile(`ghs_[A-Za-z0-9]{36,}`),
+	regexp.MustCompile(`ghr_[A-Za-z0-9]{36,}`),
+
+	// AWS
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+	regexp.MustCompile(`(?i)aws[_-]?secret[_-]?access[_-]?key["'=:\s]+[A-Za-z0-9/+=]{20,}`),
+
+	// Generic secret patterns in env var assignments
+	regexp.MustCompile(`(?i)(GH_TOKEN|GITHUB_TOKEN|GITHUB_PERSONAL_ACCESS_TOKEN|AWS_SECRET_ACCESS_KEY|AWS_ACCESS_KEY_ID|CLOUDFLARE_API_TOKEN|TELEGRAM_BOT_TOKEN|SLACK_BOT_TOKEN|SLACK_APP_TOKEN|DISCORD_BOT_TOKEN|DATABASE_URL|STATS_DATABASE_URL)["'=:\s]+[^\s"']{8,}`),
+
+	// Bearer tokens
+	regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._\-]{20,}`),
+
+	// Generic long hex/base64 tokens (likely secrets)
+	regexp.MustCompile(`(?i)(token|secret|password|api[_-]?key)["'=:\s]+[A-Za-z0-9._\-/+=]{20,}`),
+}
+
+const redacted = "***"
+
+// RedactSecrets replaces known secret patterns in a string with "***".
+func RedactSecrets(s string) string {
+	for _, pat := range secretPatterns {
+		s = pat.ReplaceAllString(s, redacted)
+	}
+	return s
+}
+
+// RedactMap recursively redacts secrets from string values in a map.
+func RedactMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]any, len(m))
+	for k, v := range m {
+		result[k] = redactValue(k, v)
+	}
+	return result
+}
+
+func redactValue(key string, v any) any {
+	// Redact entire value if key looks like a secret
+	lk := strings.ToLower(key)
+	if strings.Contains(lk, "token") || strings.Contains(lk, "secret") ||
+		strings.Contains(lk, "password") || strings.Contains(lk, "api_key") ||
+		strings.Contains(lk, "apikey") {
+		if s, ok := v.(string); ok && len(s) > 0 {
+			return redacted
+		}
+	}
+
+	switch val := v.(type) {
+	case string:
+		return RedactSecrets(val)
+	case map[string]any:
+		return RedactMap(val)
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			out[i] = redactValue("", item)
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/server/ws/redact_test.go
+++ b/server/ws/redact_test.go
@@ -1,0 +1,80 @@
+package ws
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactSecrets_GitHubPAT(t *testing.T) {
+	input := `GH_TOKEN="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" gh pr create`
+	result := RedactSecrets(input)
+	if strings.Contains(result, "github_pat_") {
+		t.Errorf("GitHub PAT not redacted: %s", result)
+	}
+	if !strings.Contains(result, "***") {
+		t.Error("expected *** in redacted output")
+	}
+}
+
+func TestRedactSecrets_GHP(t *testing.T) {
+	input := "Authorization: token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl"
+	result := RedactSecrets(input)
+	if strings.Contains(result, "ghp_") {
+		t.Errorf("ghp token not redacted: %s", result)
+	}
+}
+
+func TestRedactSecrets_AWSKey(t *testing.T) {
+	input := "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE"
+	result := RedactSecrets(input)
+	if strings.Contains(result, "AKIAIOSFODNN7EXAMPLE") {
+		t.Errorf("AWS key not redacted: %s", result)
+	}
+}
+
+func TestRedactSecrets_NoSecrets(t *testing.T) {
+	input := "go build ./..."
+	result := RedactSecrets(input)
+	if result != input {
+		t.Errorf("clean string was modified: %q -> %q", input, result)
+	}
+}
+
+func TestRedactMap_NestedSecrets(t *testing.T) {
+	data := map[string]any{
+		"command": `GH_TOKEN="github_pat_11CAICWNY09vzYZ4KAovm5_test" gh pr list`,
+		"agent":   "swift-hawk",
+		"nested": map[string]any{
+			"token": "should-be-redacted-by-key",
+		},
+	}
+	result := RedactMap(data)
+
+	cmd, ok := result["command"].(string)
+	if !ok {
+		t.Fatal("command not a string")
+	}
+	if strings.Contains(cmd, "github_pat_") {
+		t.Errorf("command not redacted: %s", cmd)
+	}
+
+	nested, ok := result["nested"].(map[string]any)
+	if !ok {
+		t.Fatal("nested not a map")
+	}
+	if nested["token"] != "***" {
+		t.Errorf("nested token not redacted: %v", nested["token"])
+	}
+
+	// Non-secret field should be preserved
+	if result["agent"] != "swift-hawk" {
+		t.Errorf("agent field modified: %v", result["agent"])
+	}
+}
+
+func TestRedactMap_Nil(t *testing.T) {
+	result := RedactMap(nil)
+	if result != nil {
+		t.Error("nil map should return nil")
+	}
+}


### PR DESCRIPTION
## P0 Security Fix

GitHub PATs and other secrets were visible in the Dashboard activity tree. SSE event data containing command output was broadcast to all connected web clients without redaction.

## Fix
All event data is now redacted in `Hub.Publish()` before SSE broadcast. Covers:
- GitHub PATs (`github_pat_*`, `ghp_*`, `gho_*`, `ghs_*`, `ghr_*`)
- AWS keys (`AKIA*`, `AWS_SECRET_ACCESS_KEY`)
- Known secret env vars (`GH_TOKEN`, `CLOUDFLARE_API_TOKEN`, `TELEGRAM_BOT_TOKEN`, etc.)
- Bearer tokens
- Generic token/secret/password/api_key patterns
- Recursive map redaction for nested data
- Key-based redaction for any key containing "token", "secret", "password"

Fixes #2775

## Test plan
- [x] `go test -race ./server/ws/...` — 6 redaction tests pass
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)