### PR TITLE
fix: tools/cron pages broken — SQLite schema on Postgres (#2756, #2758)

### DIFF
--- a/pkg/cron/store.go
+++ b/pkg/cron/store.go
@@ -25,8 +25,12 @@ func Open(workspacePath string) (*Store, error) {
 	// Try shared database first
 	if shared := db.SharedWrapped(); shared != nil {
 		s := &Store{db: shared}
-		if err := s.initSchema(); err != nil {
-			return nil, fmt.Errorf("init cron schema on shared db: %w", err)
+		// Skip initSchema on Postgres — init.sql handles table creation.
+		// The SQLite-specific schema (AUTOINCREMENT, DATETIME) breaks on Postgres.
+		if db.SharedDriver() != "postgres" {
+			if err := s.initSchema(); err != nil {
+				return nil, fmt.Errorf("init cron schema on shared db: %w", err)
+			}
 		}
 		return s, nil
 	}

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -116,11 +116,14 @@ func (s *Store) Open() error {
 		}
 	}
 
-	if err := initSchema(database.DB); err != nil {
-		if db.SharedWrapped() == nil {
-			_ = database.Close()
+	// Skip schema init on Postgres — init.sql handles table creation.
+	if db.SharedDriver() != "postgres" {
+		if err := initSchema(database.DB); err != nil {
+			if db.SharedWrapped() == nil {
+				_ = database.Close()
+			}
+			return fmt.Errorf("failed to initialize schema: %w", err)
 		}
-		return fmt.Errorf("failed to initialize schema: %w", err)
 	}
 
 	s.db = database


### PR DESCRIPTION
## Root Cause
Tool and cron stores run SQLite-specific CREATE TABLE (AUTOINCREMENT, BOOLEAN, DATETIME) on the shared Postgres database. Schema init fails silently → stores stay nil → API handlers never register → routes return HTML (SPA fallback).

## Fix
Skip `initSchema()` when shared driver is Postgres. The tables already exist from `docker/bcdb/init.sql`.

Fixes #2756, #2758

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database initialization handling for shared Postgres configurations. Schema setup now intelligently skips redundant initialization steps when using shared Postgres databases, enhancing startup performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->