### PR TITLE
fix: Makefile references deleted Dockerfile.bcdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ version: ## Show version info
 
 build: build-local build-docker ## Build everything (local + docker)
 build-local: build-local-go build-local-ts ## Build local binaries (go + ts)
-build-docker: build-docker-db build-docker-daemon build-docker-playwright ## Build Docker images (db, bcd, playwright)
+build-docker: build-docker-sql build-docker-daemon build-docker-playwright ## Build Docker images (sql, bcd, playwright)
 
 test: test-go test-ts ## Run all tests
 lint: lint-go lint-ts ## Run all linters
@@ -139,7 +139,7 @@ build-docker-daemon: ## Build bcd Docker image
 	docker build -t $(REGISTRY)-daemon:$(IMAGE_TAG) -f docker/Dockerfile.bcd .
 
 build-docker-db: ## Build bc-db (unified TimescaleDB) Docker image
-	docker build -t $(REGISTRY)-bcdb:$(IMAGE_TAG) -f docker/Dockerfile.bcdb .
+	docker build -t $(REGISTRY)-bcsql:$(IMAGE_TAG) -f docker/Dockerfile.bcsql .
 
 build-docker-sql: ## Build bc-sql (legacy, use build-docker-db instead)
 	docker build -t $(REGISTRY)-bcsql:$(IMAGE_TAG) -f docker/Dockerfile.bcsql .


### PR DESCRIPTION
## Summary
- PR #2777 deleted `Dockerfile.bcdb` but the Makefile still referenced it, breaking `make build-docker` and `make build-docker-db`
- Updated `build-docker-db` target to use `docker/Dockerfile.bcsql` instead of the deleted `docker/Dockerfile.bcdb`
- Updated `build-docker` aggregate target to depend on `build-docker-sql` instead of `build-docker-db`

## Test plan
- [ ] `make build-docker-db` resolves to the correct Dockerfile
- [ ] `make build-docker` completes without missing file errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)