### PR TITLE
fix: consolidated infra migration fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# bc workspace secrets — DO NOT COMMIT
+# Copy to .env and fill in your values.
+
+# GitHub PAT (required for agent operations)
+# GITHUB_PERSONAL_ACCESS_TOKEN=github_pat_xxxxx
+
+# Docker runtime (set automatically by bc up)
+# BC_HOST_WORKSPACE=/path/to/workspace
+
+# TimescaleDB stats backend (optional)
+# STATS_DATABASE_URL=postgres://bc:bc@localhost:5433/bcstats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           cache: true
 
       - name: Build release binary
-        run: make release-bc-local
+        run: make release-local-bc
 
       - name: Verify binary runs
         run: ./bin/bc version

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@
 .PHONY: build-local-bc build-local-bcd test-go test-go-fast lint-go fmt-go vet-go coverage-go bench-go deps-go check-go scan-go
 .PHONY: release-local-bc release-local-bcd install-local-bc
 # Docker
-.PHONY: build-docker-daemon build-docker-db
+.PHONY: build-docker-daemon build-docker-db build-docker-bcdb
 .PHONY: build-docker-agent-base build-docker-agent build-docker-agents build-docker-agent-infra build-docker-playwright stop-docker-playwright run-docker-playwright
 # TS
 .PHONY: build-local-tui build-local-web build-local-landing
@@ -140,6 +140,8 @@ build-docker-daemon: ## Build bcd Docker image
 
 build-docker-db: ## Build bc-db (unified TimescaleDB) Docker image
 	docker build -t $(REGISTRY)-bcdb:$(IMAGE_TAG) -f docker/Dockerfile.bcdb .
+
+build-docker-bcdb: build-docker-db ## Alias: Build bcdb (Postgres) Docker image
 
 build-docker-agent-base: ## Build agent base image
 	docker build -t $(REGISTRY)-agent-base:$(IMAGE_TAG) -f docker/Dockerfile.base .


### PR DESCRIPTION
## Summary

- **CI workflow**: Fix reversed release target name (`release-bc-local` -> `release-local-bc`) in `.github/workflows/ci.yml` build step
- **Makefile**: Add `build-docker-bcdb` alias target pointing to existing `build-docker-db`
- **.env.example**: New file documenting `BC_HOST_WORKSPACE` and `STATS_DATABASE_URL` env vars

## Test plan

- [ ] Verify `make release-local-bc` succeeds in CI build job
- [ ] Verify `make build-docker-bcdb` resolves to `build-docker-db` target
- [ ] Verify `.env.example` documents all required and optional env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `.env.example` template file with environment variable setup guidance for local development.

* **Chores**
  * Updated build workflow configuration and added development build target alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->