### PR TITLE
fix: post-migration alignment — system container classification

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -611,9 +611,9 @@ func collectDockerStats(ctx context.Context) []dockerStatsEntry {
 	return entries
 }
 
-// isSystemContainer returns true for bc-db or *-daemon containers.
+// isSystemContainer returns true for bc-db, bc-playwright, or *-daemon containers.
 func isSystemContainer(name string) bool {
-	if name == "bc-db" {
+	if name == "bc-db" || name == "bc-playwright" {
 		return true
 	}
 	return strings.Contains(name, "-daemon")


### PR DESCRIPTION
Consolidated alignment check after the unified DB migration:

- Add `bc-playwright` to `isSystemContainer()` — prevents stats collector from classifying it as an agent
- Verified all old bc-sql/bc-stats references already removed
- Verified init_bootstrap uses bc-db/bc-bcdb
- Verified MCP agent identity URLs correct for all agents
- Verified storage config supports both SQLite and Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)