### PR TITLE
feat: add GitHub CLI (gh) to agent Docker image

### DIFF
--- a/docker/Dockerfile.claude
+++ b/docker/Dockerfile.claude
@@ -16,6 +16,13 @@ RUN curl -fsSL https://claude.ai/install.sh | bash && \
     chmod +x /usr/local/bin/claude && \
     rm -rf /root/.local/share/claude /root/.claude
 
+# Install GitHub CLI
+RUN (type gh > /dev/null 2>&1) || \
+    (curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+     apt-get update && apt-get install -y --no-install-recommends gh && \
+     rm -rf /var/lib/apt/lists/*)
+
 # Pre-install official plugin marketplace so agents can install plugins at runtime.
 # The marketplace is a git repo — cloned at build time so docker exec claude plugin
 # install works without network access to claude.ai.


### PR DESCRIPTION
Installs gh CLI in Dockerfile.claude so all Claude-based agents have GitHub access for PR creation, issue management, and CI status checks.

Added to the install block as root before USER agent switch. Uses official GitHub APT repo with signed keyring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration to ensure the GitHub CLI is available in the deployment environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->