### PR TITLE
fix: role setup — clean stale files, merge settings, write plugin manifest

### DIFF
--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -64,8 +64,10 @@ func setupAgentFromRole(workspacePath, agentName, roleName, targetDir, runtimeBa
 	}
 
 	// .claude/settings.json (project-level settings)
+	// Merge role settings into existing settings.json to preserve hooks
+	// written by WriteWorkspaceHookSettings (called before role setup).
 	if len(resolved.Settings) > 0 {
-		if e := writeJSONFile(filepath.Join(targetDir, ".claude"), "settings.json", resolved.Settings); e != nil {
+		if e := mergeSettingsJSON(filepath.Join(targetDir, ".claude"), resolved.Settings); e != nil {
 			errs = append(errs, e.Error())
 		}
 	}
@@ -90,7 +92,11 @@ func setupAgentFromRole(workspacePath, agentName, roleName, targetDir, runtimeBa
 		{resolved.Agents, "agents"},
 		{resolved.Rules, "rules"},
 	} {
-		if e := writeMDFiles(filepath.Join(claudeDir, pair.dir), pair.files); e != nil {
+		subDir := filepath.Join(claudeDir, pair.dir)
+		if e := cleanStaleMDFiles(subDir, pair.files); e != nil {
+			errs = append(errs, e.Error())
+		}
+		if e := writeMDFiles(subDir, pair.files); e != nil {
 			errs = append(errs, e.Error())
 		}
 	}
@@ -247,13 +253,33 @@ func resolveSecretValue(value string, secrets map[string]string) string {
 
 // ── Plugin config ────────────────────────────────────────────────────────────
 
-// writePluginConfig is a no-op for now.
-// Plugins must be installed inside the Docker container at runtime
-// (via /plugin command) or pre-installed in the Docker image.
-// Copying host installed_plugins.json doesn't work because paths
-// reference the host filesystem which doesn't exist in containers.
-func writePluginConfig(_ string, _ []string) error {
-	return nil
+// pluginEntry represents a single plugin in installed_plugins.json.
+type pluginEntry struct {
+	Name    string `json:"name"`
+	Source  string `json:"source"`
+	Enabled bool   `json:"enabled"`
+}
+
+// pluginManifest is the top-level structure for installed_plugins.json.
+type pluginManifest struct {
+	Plugins map[string]pluginEntry `json:"plugins"`
+}
+
+// writePluginConfig writes an installed_plugins.json manifest so Claude Code
+// knows which plugins to load. The file is placed in the agent's auth .claude/
+// directory (authClaudeDir).
+func writePluginConfig(authClaudeDir string, plugins []string) error {
+	manifest := pluginManifest{
+		Plugins: make(map[string]pluginEntry, len(plugins)),
+	}
+	for _, name := range plugins {
+		manifest.Plugins[name] = pluginEntry{
+			Name:    name,
+			Source:  "claude-plugins-official",
+			Enabled: true,
+		}
+	}
+	return writeJSONFile(authClaudeDir, "installed_plugins.json", manifest)
 }
 
 // ── File writers ────────────────────────────────────────────────────────────
@@ -277,6 +303,78 @@ func writeJSONFile(dir, name string, data any) error {
 		return fmt.Errorf("marshal %s: %w", name, err)
 	}
 	return os.WriteFile(filepath.Join(dir, name), b, 0600)
+}
+
+// cleanStaleMDFiles removes .md files from dir that are not in the new file set.
+// Non-.md files and the directory itself are left untouched.
+func cleanStaleMDFiles(dir string, newFiles map[string]string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // directory doesn't exist yet, nothing to clean
+		}
+		return fmt.Errorf("read dir %s: %w", dir, err)
+	}
+
+	// Build a set of expected .md filenames from the new file map.
+	expected := make(map[string]struct{}, len(newFiles))
+	for name := range newFiles {
+		fname := name
+		if !strings.HasSuffix(fname, ".md") {
+			fname += ".md"
+		}
+		expected[fname] = struct{}{}
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".md") {
+			continue
+		}
+		if _, ok := expected[name]; ok {
+			continue
+		}
+		// Stale .md file — remove it.
+		if rmErr := os.Remove(filepath.Join(dir, name)); rmErr != nil {
+			return fmt.Errorf("remove stale file %s: %w", name, rmErr)
+		}
+	}
+	return nil
+}
+
+// mergeSettingsJSON reads existing settings.json from dir, merges role settings
+// into it (role settings override non-hook keys, but existing hooks are preserved),
+// and writes the merged result back.
+func mergeSettingsJSON(dir string, roleSettings map[string]any) error {
+	settingsPath := filepath.Join(dir, "settings.json")
+
+	// Read existing settings (may contain hooks from WriteWorkspaceHookSettings).
+	existing := make(map[string]any)
+	data, err := os.ReadFile(settingsPath)
+	if err == nil {
+		_ = json.Unmarshal(data, &existing) //nolint:errcheck // if malformed, start fresh
+	}
+
+	// Preserve existing hooks — save them before merging.
+	savedHooks, hasHooks := existing["hooks"]
+
+	// Merge role settings into existing (role overrides existing keys).
+	for k, v := range roleSettings {
+		existing[k] = v
+	}
+
+	// Restore hooks if they existed and role settings didn't explicitly set them,
+	// or merge them back so hooks from WriteWorkspaceHookSettings are not lost.
+	if hasHooks {
+		if _, roleHasHooks := roleSettings["hooks"]; !roleHasHooks {
+			existing["hooks"] = savedHooks
+		}
+	}
+
+	return writeJSONFile(dir, "settings.json", existing)
 }
 
 func writeMDFiles(dir string, files map[string]string) error {

--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -540,6 +540,8 @@ type ResolvedRole struct {
 	Plugins      []string          // Unioned plugins from all ancestors
 	Secrets      []string          // Unioned secret names from all ancestors
 	MCPServers   []string          // Unioned MCP servers from all ancestors
+	CLITools     []string          // Unioned CLI tools from all ancestors
+	Description  string            // Human-readable role description
 }
 
 // ResolveRole loads a role directly from the store. No inheritance — each role
@@ -556,6 +558,8 @@ func (rm *RoleManager) ResolveRole(name string) (*ResolvedRole, error) {
 		MCPServers:   append([]string{}, role.Metadata.MCPServers...),
 		Secrets:      append([]string{}, role.Metadata.Secrets...),
 		Plugins:      append([]string{}, role.Metadata.Plugins...),
+		CLITools:     append([]string{}, role.Metadata.CLITools...),
+		Description:  role.Metadata.Description,
 		PromptCreate: role.Metadata.PromptCreate,
 		PromptStart:  role.Metadata.PromptStart,
 		PromptStop:   role.Metadata.PromptStop,


### PR DESCRIPTION
## Summary

Fixes 5 bugs in the role → agent restart file generation flow:

1. **Stale files not cleaned up**: `writeMDFiles()` only added/overwrote files but never deleted removed ones. Old rules/commands/skills persisted after being removed from a role. Added `cleanStaleMDFiles()` that removes `.md` files not in the new set before writing.

2. **Role settings overwrite hooks**: If a role had `Settings`, it overwrote `.claude/settings.json` including hooks from `WriteWorkspaceHookSettings`. Replaced with `mergeSettingsJSON()` that preserves existing hooks while merging role settings.

3. **Plugin config was a no-op**: `writePluginConfig()` did nothing — plugins listed in role metadata were never installed. Now writes `installed_plugins.json` manifest to the agent's auth `.claude/` directory.

4. **CLITools missing from ResolvedRole**: The `ResolvedRole` struct lacked `CLITools` field — saved to DB but lost during resolution and never appeared in API responses.

5. **Description missing from ResolvedRole**: Role description was stored in DB but not included in resolved role output.

## Files Changed

- `pkg/agent/role_setup.go` — `cleanStaleMDFiles()`, `mergeSettingsJSON()`, `writePluginConfig()` implementation
- `pkg/workspace/roles.go` — `CLITools` and `Description` fields added to `ResolvedRole`

## Test plan

- [x] `go build ./pkg/agent/... ./pkg/workspace/... ./server/...` passes
- [x] `go vet ./pkg/agent/... ./pkg/workspace/...` passes
- [x] `go test -race ./pkg/workspace/...` passes
- [ ] Restart agent with role that has removed rules — verify old rule files are cleaned up
- [ ] Restart agent with role settings — verify hooks are preserved
- [ ] Check `/api/roles/api_lead` includes `CLITools` and `Description` in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings configuration now preserves existing customizations instead of overwriting them.
  * Stale role files are automatically cleaned up during role updates.

* **New Features**
  * Plugin installations are now tracked in a manifest file within the agent's configuration directory.
  * Roles now support descriptions and CLI tools metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->