### PR TITLE
feat: wire all settings.json fields as source of truth

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -86,13 +86,28 @@ func run(addr, wsRoot, corsOrigin string) error {
 	}
 
 	// Set up shared database connection for all stores.
-	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDB(ws.RootDir)
+	// Settings.json storage config is the source of truth; DATABASE_URL env var overrides for Docker.
+	var storageCfg *bcdb.StorageSettings
+	if ws.Config != nil {
+		storageCfg = &bcdb.StorageSettings{
+			Default: ws.Config.Storage.Default,
+			SQLite:  bcdb.SQLiteSettings{Path: ws.Config.Storage.SQLite.Path},
+			Postgres: bcdb.PostgresSettings{
+				Host:     ws.Config.Storage.SQL.Host,
+				Port:     ws.Config.Storage.SQL.Port,
+				User:     ws.Config.Storage.SQL.User,
+				Password: ws.Config.Storage.SQL.Password,
+				Database: ws.Config.Storage.SQL.Database,
+			},
+		}
+	}
+	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDBWithConfig(ws.RootDir, storageCfg)
 	if dbErr != nil {
 		log.Warn("failed to open shared workspace db", "error", dbErr)
 	} else {
 		bcdb.SetShared(sharedDB, sharedDriver)
 		defer bcdb.CloseShared() //nolint:errcheck
-		log.Info("shared database ready", "driver", sharedDriver)
+		log.Info("shared database ready", "driver", sharedDriver, "config_driver", ws.Config.Storage.Default)
 	}
 
 	pidPath := filepath.Join(ws.StateDir(), "bcd.pid")
@@ -178,7 +193,8 @@ func run(addr, wsRoot, corsOrigin string) error {
 		defer cr.Close() //nolint:errcheck // best-effort
 
 		cronLogDir := filepath.Join(ws.RootDir, ".bc", "logs", "cron")
-		cronScheduler = bccron.NewScheduler(cr, cronLogDir)
+		cronScheduler = bccron.NewSchedulerWithConfig(cr, cronLogDir,
+			ws.Config.Cron.PollIntervalSeconds, ws.Config.Cron.JobTimeoutSeconds)
 		go cronScheduler.Run(ctx)
 	}
 

--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -37,13 +37,27 @@ type Scheduler struct {
 
 // NewScheduler creates a Scheduler that polls at DefaultPollInterval.
 func NewScheduler(store *Store, logDir string) *Scheduler {
+	return NewSchedulerWithConfig(store, logDir, 0, 0)
+}
+
+// NewSchedulerWithConfig creates a Scheduler with configurable poll interval and job timeout.
+// Zero values use defaults (30s poll, 5m timeout).
+func NewSchedulerWithConfig(store *Store, logDir string, pollIntervalSec, jobTimeoutSec int) *Scheduler {
 	if logDir != "" {
 		_ = os.MkdirAll(logDir, 0o755)
 	}
+	interval := DefaultPollInterval
+	if pollIntervalSec > 0 {
+		interval = time.Duration(pollIntervalSec) * time.Second
+	}
+	jobTimeout := DefaultJobTimeout
+	if jobTimeoutSec > 0 {
+		jobTimeout = time.Duration(jobTimeoutSec) * time.Second
+	}
 	s := &Scheduler{
 		store:      store,
-		interval:   DefaultPollInterval,
-		jobTimeout: DefaultJobTimeout,
+		interval:   interval,
+		jobTimeout: jobTimeout,
 		logDir:     logDir,
 		running:    make(map[string]bool),
 	}

--- a/pkg/db/unified.go
+++ b/pkg/db/unified.go
@@ -55,10 +55,64 @@ func SharedDriver() string {
 	return sharedDriver
 }
 
+// StorageSettings holds the storage configuration from settings.json.
+// Used by OpenWorkspaceDB to determine the database backend.
+type StorageSettings struct {
+	Default  string // "sqlite" or "sql"
+	SQLite   SQLiteSettings
+	Postgres PostgresSettings
+}
+
+// SQLiteSettings configures the SQLite database path.
+type SQLiteSettings struct {
+	Path string // base directory for bc.db (default: workspace .bc/ dir)
+}
+
+// PostgresSettings configures the Postgres connection.
+type PostgresSettings struct {
+	Host     string
+	Port     int
+	User     string
+	Password string
+	Database string
+}
+
+// DSN builds a Postgres connection string from config fields.
+func (p PostgresSettings) DSN() string {
+	host := p.Host
+	if host == "" {
+		host = "localhost"
+	}
+	port := p.Port
+	if port == 0 {
+		port = 5432
+	}
+	user := p.User
+	if user == "" {
+		user = "bc"
+	}
+	pw := p.Password
+	if pw == "" {
+		pw = "bc"
+	}
+	db := p.Database
+	if db == "" {
+		db = "bc"
+	}
+	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s", user, pw, host, port, db)
+}
+
 // OpenWorkspaceDB opens the workspace database based on configuration.
-// If DATABASE_URL is set, connects to Postgres.
-// Otherwise, opens SQLite at .bc/bc.db.
+// Priority: DATABASE_URL env var > settings.json storage config > SQLite default.
 func OpenWorkspaceDB(workspaceRoot string) (*sql.DB, string, error) {
+	return OpenWorkspaceDBWithConfig(workspaceRoot, nil)
+}
+
+// OpenWorkspaceDBWithConfig opens the workspace database using settings.json config.
+// If DATABASE_URL env var is set, it takes priority (for Docker/CI).
+// Otherwise, settings.json storage.default determines the backend.
+func OpenWorkspaceDBWithConfig(workspaceRoot string, cfg *StorageSettings) (*sql.DB, string, error) {
+	// Priority 1: DATABASE_URL env var (Docker/CI override)
 	if IsPostgresEnabled() {
 		db, err := OpenPostgres(PostgresDSN())
 		if err != nil {
@@ -67,7 +121,26 @@ func OpenWorkspaceDB(workspaceRoot string) (*sql.DB, string, error) {
 		return db, "postgres", nil
 	}
 
-	path := BCDBPath(workspaceRoot)
+	// Priority 2: settings.json storage config
+	if cfg != nil && cfg.Default == "sql" {
+		dsn := cfg.Postgres.DSN()
+		db, err := OpenPostgres(dsn)
+		if err != nil {
+			return nil, "", fmt.Errorf("open postgres from config: %w", err)
+		}
+		return db, "postgres", nil
+	}
+
+	// Priority 3: SQLite (default)
+	basePath := workspaceRoot
+	if cfg != nil && cfg.SQLite.Path != "" {
+		basePath = cfg.SQLite.Path
+	}
+	path := filepath.Join(basePath, ".bc", "bc.db")
+	if cfg != nil && cfg.SQLite.Path != "" && cfg.SQLite.Path != ".bc" {
+		// If a custom path is set, use it directly
+		path = filepath.Join(basePath, "bc.db")
+	}
 	d, err := Open(path)
 	if err != nil {
 		return nil, "", fmt.Errorf("open sqlite %s: %w", path, err)

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -331,6 +331,31 @@ func (c *Config) Validate() error {
 	if err := c.validateUser(); err != nil {
 		return err
 	}
+	if err := c.validateServer(); err != nil {
+		return err
+	}
+	if err := c.validateStorage(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateServer validates server configuration.
+func (c *Config) validateServer() error {
+	if c.Server.Port != 0 && (c.Server.Port < 1 || c.Server.Port > 65535) {
+		return fmt.Errorf("server.port must be between 1 and 65535, got %d", c.Server.Port)
+	}
+	return nil
+}
+
+// validateStorage validates storage configuration.
+func (c *Config) validateStorage() error {
+	if c.Storage.Default != "" && c.Storage.Default != "sqlite" && c.Storage.Default != "sql" {
+		return fmt.Errorf("storage.default must be 'sqlite' or 'sql', got %q", c.Storage.Default)
+	}
+	if c.Storage.SQL.Port != 0 && (c.Storage.SQL.Port < 1 || c.Storage.SQL.Port > 65535) {
+		return fmt.Errorf("storage.sql.port must be between 1 and 65535, got %d", c.Storage.SQL.Port)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Make settings.json the single source of truth. Storage config, cron config, and validation all wired. Fixes #2796.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace database storage is now fully configurable, supporting SQLite with custom file paths and Postgres with host, port, user, password, and database parameters.
  * Cron scheduler behavior is now tunable via polling interval and job timeout configuration options.

* **Chores**
  * Configuration validation has been enhanced to validate server port ranges and storage driver selection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->