### PR TITLE
fix: add member management to gateway channels + remove member button

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -607,6 +607,12 @@ export const api = {
       body: JSON.stringify({ agent_id: agentName }),
     }),
 
+  removeChannelMember: (channelName: string, agentName: string) =>
+    request<void>(
+      `/channels/${encodeURIComponent(channelName)}/members/${encodeURIComponent(agentName)}`,
+      { method: "DELETE" },
+    ),
+
   updateChannel: (name: string, patch: { description?: string }) =>
     request<Channel>(`/channels/${encodeURIComponent(name)}`, {
       method: "PATCH",

--- a/web/src/components/channels/GatewayFeed.tsx
+++ b/web/src/components/channels/GatewayFeed.tsx
@@ -4,6 +4,7 @@ import type { Channel, ChannelMessage } from "../../api/client";
 import { useWebSocket } from "../../hooks/useWebSocket";
 import { MessageContent } from "../MessageContent";
 import { EmptyState } from "../EmptyState";
+import { MemberPanel } from "./MemberPanel";
 import { gatewayPlatform, formatTimestamp } from "./messageUtils";
 
 /** Classify activity type from message content. */
@@ -29,13 +30,18 @@ function activityType(content: string): {
 export function GatewayFeed({
   channelName,
   channel,
+  agentRoles,
   onPeekAgent,
+  onChannelUpdated,
 }: {
   channelName: string;
   channel?: Channel;
+  agentRoles: Record<string, string>;
   onPeekAgent: (name: string) => void;
+  onChannelUpdated: () => void;
 }) {
   const [messages, setMessages] = useState<ChannelMessage[]>([]);
+  const [showMembers, setShowMembers] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const { subscribe } = useWebSocket();
@@ -82,87 +88,113 @@ export function GatewayFeed({
   }, [messages]);
 
   return (
-    <>
-      {/* Header */}
-      <div className="px-4 py-3 border-b border-bc-border bg-bc-surface">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="font-medium">#{channelLabel}</span>
-            <span className="text-[10px] px-2 py-0.5 rounded-full bg-bc-border/60 text-bc-muted font-medium uppercase tracking-wider">
-              {platform} gateway
-            </span>
-          </div>
-          <span className="text-xs text-bc-muted">
-            {messages.length} event{messages.length !== 1 ? "s" : ""}
-          </span>
-        </div>
-        {channel?.description && (
-          <p className="text-xs text-bc-muted mt-1">{channel.description}</p>
-        )}
-      </div>
-
-      {/* Activity feed */}
-      <div className="relative flex-1">
-        <div
-          ref={scrollContainerRef}
-          className="absolute inset-0 overflow-auto p-4"
-        >
-          {messages.length === 0 && (
-            <div className="flex items-center justify-center py-8">
-              <EmptyState
-                icon="⇄"
-                title="No gateway activity"
-                description={`Messages from ${platform ?? "the external platform"} will appear here.`}
-              />
+    <div className="flex flex-1 min-w-0">
+      <div className="flex flex-col flex-1 min-w-0">
+        {/* Header */}
+        <div className="px-4 py-3 border-b border-bc-border bg-bc-surface">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <span className="font-medium">#{channelLabel}</span>
+              <span className="text-[10px] px-2 py-0.5 rounded-full bg-bc-border/60 text-bc-muted font-medium uppercase tracking-wider">
+                {platform} gateway
+              </span>
             </div>
-          )}
-          <div className="space-y-1">
-            {messages.map((msg) => {
-              const activity = activityType(msg.content);
-              return (
-                <div
-                  key={msg.id}
-                  className="flex items-start gap-3 py-1.5 px-2 rounded hover:bg-bc-surface/50 transition-colors group"
-                >
-                  <span
-                    className={`text-xs mt-0.5 w-4 text-center shrink-0 ${activity.color}`}
-                  >
-                    {activity.icon}
-                  </span>
-                  <div className="flex-1 min-w-0 text-sm">
-                    <span className="inline-flex items-baseline gap-2">
-                      <button
-                        type="button"
-                        onClick={() => onPeekAgent(msg.sender)}
-                        className="font-medium text-bc-accent hover:underline cursor-pointer text-xs"
-                        title={`Peek at ${msg.sender}`}
-                      >
-                        {msg.sender}
-                      </button>
-                      <span className="text-[11px] text-bc-muted">
-                        {formatTimestamp(msg.created_at)}
-                      </span>
-                    </span>
-                    <p className="text-xs text-bc-text/80 mt-0.5 whitespace-pre-wrap break-words line-clamp-3 group-hover:line-clamp-none">
-                      <MessageContent content={msg.content} />
-                    </p>
-                  </div>
-                </div>
-              );
-            })}
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setShowMembers((p) => !p)}
+                className={`px-2 py-1 rounded border text-xs transition-colors focus-visible:ring-1 focus-visible:ring-bc-accent ${
+                  showMembers
+                    ? "border-bc-accent text-bc-accent bg-bc-accent/10"
+                    : "border-bc-border text-bc-muted hover:text-bc-text"
+                }`}
+                aria-label="Toggle members panel"
+                aria-pressed={showMembers}
+              >
+                Members ({channel?.member_count ?? 0})
+              </button>
+              <span className="text-xs text-bc-muted">
+                {messages.length} event{messages.length !== 1 ? "s" : ""}
+              </span>
+            </div>
           </div>
-          <div ref={bottomRef} />
+          {channel?.description && (
+            <p className="text-xs text-bc-muted mt-1">{channel.description}</p>
+          )}
+        </div>
+
+        {/* Activity feed */}
+        <div className="relative flex-1">
+          <div
+            ref={scrollContainerRef}
+            className="absolute inset-0 overflow-auto p-4"
+          >
+            {messages.length === 0 && (
+              <div className="flex items-center justify-center py-8">
+                <EmptyState
+                  icon="⇄"
+                  title="No gateway activity"
+                  description={`Messages from ${platform ?? "the external platform"} will appear here.`}
+                />
+              </div>
+            )}
+            <div className="space-y-1">
+              {messages.map((msg) => {
+                const activity = activityType(msg.content);
+                return (
+                  <div
+                    key={msg.id}
+                    className="flex items-start gap-3 py-1.5 px-2 rounded hover:bg-bc-surface/50 transition-colors group"
+                  >
+                    <span
+                      className={`text-xs mt-0.5 w-4 text-center shrink-0 ${activity.color}`}
+                    >
+                      {activity.icon}
+                    </span>
+                    <div className="flex-1 min-w-0 text-sm">
+                      <span className="inline-flex items-baseline gap-2">
+                        <button
+                          type="button"
+                          onClick={() => onPeekAgent(msg.sender)}
+                          className="font-medium text-bc-accent hover:underline cursor-pointer text-xs"
+                          title={`Peek at ${msg.sender}`}
+                        >
+                          {msg.sender}
+                        </button>
+                        <span className="text-[11px] text-bc-muted">
+                          {formatTimestamp(msg.created_at)}
+                        </span>
+                      </span>
+                      <p className="text-xs text-bc-text/80 mt-0.5 whitespace-pre-wrap break-words line-clamp-3 group-hover:line-clamp-none">
+                        <MessageContent content={msg.content} />
+                      </p>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+            <div ref={bottomRef} />
+          </div>
+        </div>
+
+        {/* Read-only footer */}
+        <div className="px-4 py-2.5 border-t border-bc-border bg-bc-surface/50">
+          <p className="text-xs text-bc-muted text-center">
+            Gateway channel — activity from{" "}
+            {platform ?? "external platform"}. Messages are sent via{" "}
+            {platform ?? "the platform"} directly.
+          </p>
         </div>
       </div>
 
-      {/* Read-only footer */}
-      <div className="px-4 py-2.5 border-t border-bc-border bg-bc-surface/50">
-        <p className="text-xs text-bc-muted text-center">
-          Gateway channel — activity from{" "}
-          {platform ?? "external platform"}. Messages are sent via{" "}
-          {platform ?? "the platform"} directly.
-        </p>
-      </div>
-    </>
+      {/* Member panel */}
+      {showMembers && channel && (
+        <MemberPanel
+          channel={channel}
+          agentRoles={agentRoles}
+          onChannelUpdated={onChannelUpdated}
+        />
+      )}
+    </div>
   );
 }

--- a/web/src/components/channels/MemberPanel.tsx
+++ b/web/src/components/channels/MemberPanel.tsx
@@ -14,6 +14,7 @@ export function MemberPanel({
 }) {
   const [addingMember, setAddingMember] = useState(false);
   const [agents, setAgents] = useState<string[]>([]);
+  const [removingMember, setRemovingMember] = useState<string | null>(null);
 
   useEffect(() => {
     if (!addingMember) return;
@@ -37,6 +38,18 @@ export function MemberPanel({
     setAddingMember(false);
   };
 
+  const handleRemoveMember = async (agentName: string) => {
+    setRemovingMember(agentName);
+    try {
+      await api.removeChannelMember(channel.name, agentName);
+      onChannelUpdated();
+    } catch {
+      // silently fail
+    } finally {
+      setRemovingMember(null);
+    }
+  };
+
   return (
     <div className="w-56 shrink-0 border-l border-bc-border overflow-auto bg-bc-surface/30">
       <div className="p-3 border-b border-bc-border">
@@ -48,13 +61,23 @@ export function MemberPanel({
         {(channel.members ?? []).map((m) => (
           <div
             key={m}
-            className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-bc-surface/50 transition-colors"
+            className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-bc-surface/50 transition-colors group"
           >
             <AgentAvatar name={m} role={agentRoles[m]} size="sm" />
             <div className="flex-1 min-w-0">
               <span className="text-sm text-bc-text truncate block">{m}</span>
             </div>
             <RoleBadge role={agentRoles[m]} />
+            <button
+              type="button"
+              onClick={() => void handleRemoveMember(m)}
+              disabled={removingMember === m}
+              className="text-xs text-bc-muted hover:text-bc-error opacity-0 group-hover:opacity-100 transition-opacity disabled:opacity-50 focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-bc-error rounded px-1"
+              aria-label={`Remove ${m} from channel`}
+              title={`Remove ${m}`}
+            >
+              ✕
+            </button>
           </div>
         ))}
       </div>

--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -88,7 +88,9 @@ export function Channels() {
             <GatewayFeed
               channelName={selected}
               channel={selectedChannel}
+              agentRoles={roleMap}
               onPeekAgent={setPeekAgent}
+              onChannelUpdated={refresh}
             />
           ) : (
             <ChatRoom


### PR DESCRIPTION
## Summary
- Gateway channels now have Members button + panel (same as internal channels)
- Remove member button (X) on hover in member list
- API: added removeChannelMember (DELETE endpoint)
- GatewayFeed gets agentRoles + onChannelUpdated props

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] Gateway channels show Members panel
- [x] Remove member button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)