### PR TITLE
feat: agent online/offline status indicators in channel member panel

### DIFF
--- a/web/src/components/channels/ChatRoom.tsx
+++ b/web/src/components/channels/ChatRoom.tsx
@@ -14,12 +14,14 @@ export function ChatRoom({
   channelName,
   channel,
   agentRoles,
+  agentStates,
   onPeekAgent,
   onChannelUpdated,
 }: {
   channelName: string;
   channel?: Channel;
   agentRoles: Record<string, string>;
+  agentStates?: Record<string, string>;
   onPeekAgent: (name: string) => void;
   onChannelUpdated: () => void;
 }) {
@@ -197,6 +199,7 @@ export function ChatRoom({
         <MemberPanel
           channel={channel}
           agentRoles={agentRoles}
+          agentStates={agentStates}
           onChannelUpdated={onChannelUpdated}
         />
       )}

--- a/web/src/components/channels/GatewayFeed.tsx
+++ b/web/src/components/channels/GatewayFeed.tsx
@@ -31,12 +31,14 @@ export function GatewayFeed({
   channelName,
   channel,
   agentRoles,
+  agentStates,
   onPeekAgent,
   onChannelUpdated,
 }: {
   channelName: string;
   channel?: Channel;
   agentRoles: Record<string, string>;
+  agentStates?: Record<string, string>;
   onPeekAgent: (name: string) => void;
   onChannelUpdated: () => void;
 }) {
@@ -192,6 +194,7 @@ export function GatewayFeed({
         <MemberPanel
           channel={channel}
           agentRoles={agentRoles}
+          agentStates={agentStates}
           onChannelUpdated={onChannelUpdated}
         />
       )}

--- a/web/src/components/channels/MemberPanel.tsx
+++ b/web/src/components/channels/MemberPanel.tsx
@@ -3,13 +3,43 @@ import { api } from "../../api/client";
 import type { Channel } from "../../api/client";
 import { AgentAvatar, RoleBadge } from "./AgentAvatar";
 
+function AgentStatusDot({ state }: { state?: string }) {
+  const s = state ?? "unknown";
+  const colors: Record<string, string> = {
+    working: "bg-bc-success",
+    running: "bg-bc-success",
+    idle: "bg-bc-warning",
+    waiting: "bg-bc-warning",
+    stopped: "bg-bc-muted",
+    error: "bg-bc-error",
+    stuck: "bg-bc-error",
+  };
+  const labels: Record<string, string> = {
+    working: "Online",
+    running: "Online",
+    idle: "Idle",
+    waiting: "Waiting",
+    stopped: "Offline",
+    error: "Error",
+    stuck: "Stuck",
+  };
+  return (
+    <span
+      className={`w-2 h-2 rounded-full shrink-0 ${colors[s] ?? "bg-bc-muted"}`}
+      title={labels[s] ?? s}
+    />
+  );
+}
+
 export function MemberPanel({
   channel,
   agentRoles,
+  agentStates,
   onChannelUpdated,
 }: {
   channel: Channel;
   agentRoles: Record<string, string>;
+  agentStates?: Record<string, string>;
   onChannelUpdated: () => void;
 }) {
   const [addingMember, setAddingMember] = useState(false);
@@ -56,6 +86,14 @@ export function MemberPanel({
         <h3 className="text-xs font-semibold text-bc-muted uppercase tracking-wider">
           Members ({channel.member_count})
         </h3>
+        {agentStates && (
+          <p className="text-[10px] text-bc-muted mt-0.5">
+            {(channel.members ?? []).filter((m) => {
+              const s = agentStates[m];
+              return s === "working" || s === "running";
+            }).length}/{channel.member_count} online
+          </p>
+        )}
       </div>
       <div className="p-2 space-y-1">
         {(channel.members ?? []).map((m) => (
@@ -64,8 +102,9 @@ export function MemberPanel({
             className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-bc-surface/50 transition-colors group"
           >
             <AgentAvatar name={m} role={agentRoles[m]} size="sm" />
-            <div className="flex-1 min-w-0">
-              <span className="text-sm text-bc-text truncate block">{m}</span>
+            <div className="flex-1 min-w-0 flex items-center gap-1.5">
+              <AgentStatusDot state={agentStates?.[m]} />
+              <span className="text-sm text-bc-text truncate">{m}</span>
             </div>
             <RoleBadge role={agentRoles[m]} />
             <button

--- a/web/src/hooks/useAgentRoles.ts
+++ b/web/src/hooks/useAgentRoles.ts
@@ -3,17 +3,22 @@ import { api } from "../api/client";
 
 /** Module-level cache to avoid re-fetching across component remounts. */
 let cachedRoleMap: Record<string, string> | null = null;
+let cachedStateMap: Record<string, string> | null = null;
 
 /**
- * Fetches agent list once and returns a name→role map.
+ * Fetches agent list once and returns name→role and name→state maps.
  * Cached at module level so it persists across component remounts.
  */
 export function useAgentRoles(): {
   roleMap: Record<string, string>;
+  stateMap: Record<string, string>;
   loading: boolean;
 } {
   const [roleMap, setRoleMap] = useState<Record<string, string>>(
     cachedRoleMap ?? {},
+  );
+  const [stateMap, setStateMap] = useState<Record<string, string>>(
+    cachedStateMap ?? {},
   );
   const [loading, setLoading] = useState(cachedRoleMap === null);
   const fetched = useRef(cachedRoleMap !== null);
@@ -24,19 +29,23 @@ export function useAgentRoles(): {
     void (async () => {
       try {
         const agents = await api.listAgents();
-        const map: Record<string, string> = {};
+        const roles: Record<string, string> = {};
+        const states: Record<string, string> = {};
         for (const agent of agents) {
-          map[agent.name] = agent.role;
+          roles[agent.name] = agent.role;
+          states[agent.name] = agent.state;
         }
-        cachedRoleMap = map;
-        setRoleMap(map);
+        cachedRoleMap = roles;
+        cachedStateMap = states;
+        setRoleMap(roles);
+        setStateMap(states);
       } catch {
-        // keep empty map
+        // keep empty maps
       } finally {
         setLoading(false);
       }
     })();
   }, []);
 
-  return { roleMap, loading };
+  return { roleMap, stateMap, loading };
 }

--- a/web/src/views/Channels.tsx
+++ b/web/src/views/Channels.tsx
@@ -25,7 +25,7 @@ export function Channels() {
     refresh,
     timedOut,
   } = usePolling(fetcher, 10000);
-  const { roleMap } = useAgentRoles();
+  const { roleMap, stateMap } = useAgentRoles();
   const [selected, setSelected] = useState<string | null>(paramChannel ?? null);
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
 
@@ -89,6 +89,7 @@ export function Channels() {
               channelName={selected}
               channel={selectedChannel}
               agentRoles={roleMap}
+              agentStates={stateMap}
               onPeekAgent={setPeekAgent}
               onChannelUpdated={refresh}
             />
@@ -97,6 +98,7 @@ export function Channels() {
               channelName={selected}
               channel={selectedChannel}
               agentRoles={roleMap}
+              agentStates={stateMap}
               onPeekAgent={setPeekAgent}
               onChannelUpdated={refresh}
             />


### PR DESCRIPTION
## Summary
- Agent status dots in channel member list (green=working, yellow=idle, grey=offline, red=stuck)
- Online count in member header ("3/5 online")
- Uses existing /api/agents endpoint for status data

Follow-up to #2798.

## Test plan
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent status indicators now display next to member names with visual color-coded indicators showing current availability
  * Online counter added to the member panel header to display the number of active agents
  * Real-time agent state tracking integrated across chat channels
<!-- end of auto-generated comment: release notes by coderabbit.ai -->