### PR TITLE
fix: regenerate .mcp.json on agent rename — MCP identity bug

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1673,6 +1673,19 @@ func (m *Manager) RenameAgent(ctx context.Context, oldName, newName string) erro
 		newWorktreeDir = newPath
 	}
 
+	// Regenerate .mcp.json with the new agent name so MCP SSE URLs
+	// point to /_mcp/{newName}/sse instead of /_mcp/{oldName}/sse.
+	if newWorktreeDir != "" && agent.Role != "" {
+		wsPath := m.workspacePath
+		agentRuntime := agent.RuntimeBackend
+		if agentRuntime == "" {
+			agentRuntime = "tmux"
+		}
+		if setupErr := SetupAgentFromRoleWithRuntime(wsPath, newName, string(agent.Role), newWorktreeDir, agentRuntime); setupErr != nil {
+			log.Warn("rename: failed to regenerate role files", "agent", newName, "error", setupErr)
+		}
+	}
+
 	// Rename log file
 	oldLogDir := filepath.Join(m.workspacePath, ".bc", "logs")
 	oldLogFile := filepath.Join(oldLogDir, oldName+".log")


### PR DESCRIPTION
## Problem
When agents are renamed via `bc agent rename`, the `.mcp.json` file kept the old agent name in `/_mcp/{oldName}/sse` URLs. This caused the renamed agent to use the wrong MCP identity.

## Root Cause
`RenameAgent()` moved the worktree and updated the agent struct, but never regenerated the role files (.mcp.json, CLAUDE.md, rules, etc.) with the new name.

## Fix
Call `SetupAgentFromRoleWithRuntime()` after the worktree move to regenerate all role files with the new agent name.

## Size: Small
One 13-line addition to `pkg/agent/agent.go` RenameAgent().

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent renaming to regenerate workspace files based on agent configuration, ensuring proper setup after rename operations. Non-critical failures during this process are now logged as warnings without interrupting the rename.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->