### PR TITLE
fix: Docker image optimization — ~200MB smaller bcd image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,11 @@ landing/node_modules/
 landing/.next/
 landing/out/
 coverage.out
+docs/
+*.test.go
+*_test.go
+.golangci.yml
+.editorconfig
+CODE_OF_CONDUCT.md
 *.md
 !README.md

--- a/docker/Dockerfile.bcd
+++ b/docker/Dockerfile.bcd
@@ -32,7 +32,7 @@ RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o /bcd ./cmd/bcd
 FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates tmux git docker.io curl sqlite3 jq \
+        ca-certificates tmux git curl sqlite3 jq \
         make gcc libc6-dev python3 python3-pip unzip && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.claude
+++ b/docker/Dockerfile.claude
@@ -2,6 +2,9 @@
 # Usage: docker build -t bc-agent-claude:latest -f docker/Dockerfile.claude .
 # Requires: bc-agent-base:latest (docker build -f docker/Dockerfile.base .)
 
+FROM alpine/git AS plugins
+RUN git clone --depth 1 https://github.com/anthropics/claude-plugins-official.git /plugins
+
 FROM bc-agent-base:latest AS base
 
 USER root
@@ -20,10 +23,10 @@ RUN curl -fsSL https://claude.ai/install.sh | bash && \
 # The marketplace is a git repo — cloned at build time so docker exec claude plugin
 # install works without network access to claude.ai.
 USER agent
-RUN mkdir -p /home/agent/.claude/plugins/marketplaces && \
-    git clone --depth 1 https://github.com/anthropics/claude-plugins-official.git \
-        /home/agent/.claude/plugins/marketplaces/claude-plugins-official && \
-    echo '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"/home/agent/.claude/plugins/marketplaces/claude-plugins-official","lastUpdated":"2026-01-01T00:00:00.000Z"}}' \
+RUN mkdir -p /home/agent/.claude/plugins/marketplaces
+COPY --from=plugins --chown=agent:agent /plugins \
+    /home/agent/.claude/plugins/marketplaces/claude-plugins-official
+RUN echo '{"claude-plugins-official":{"source":{"source":"github","repo":"anthropics/claude-plugins-official"},"installLocation":"/home/agent/.claude/plugins/marketplaces/claude-plugins-official","lastUpdated":"2026-01-01T00:00:00.000Z"}}' \
         > /home/agent/.claude/plugins/known_marketplaces.json
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

- **Remove `docker.io` package from `Dockerfile.bcd`** (~150MB savings). bcd accesses the Docker socket via volume mount and uses the Go Docker client library — the Docker CLI is never invoked inside the container.
- **Expand `.dockerignore`** with `docs/`, `*_test.go`, `*.test.go`, `.golangci.yml`, `.editorconfig`, and `CODE_OF_CONDUCT.md` to reduce build context sent to the Docker daemon.
- **Move plugin clone in `Dockerfile.claude`** to a separate `alpine/git` build stage so it's cached independently and doesn't re-clone on unrelated layer invalidations.

## Test plan

- [ ] `docker build -f docker/Dockerfile.bcd .` succeeds and image is ~150MB smaller
- [ ] `docker build -f docker/Dockerfile.claude .` succeeds with plugins present at `/home/agent/.claude/plugins/marketplaces/claude-plugins-official`
- [ ] bcd container can still manage agent containers via Docker socket mount
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build configuration by excluding additional files from the build context
  * Streamlined container runtime dependencies
  * Improved Docker build efficiency through enhanced build staging processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->