### PR TITLE
fix: restore docker.io in bcd Dockerfile

### DIFF
--- a/docker/Dockerfile.bcd
+++ b/docker/Dockerfile.bcd
@@ -32,7 +32,7 @@ RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o /bcd ./cmd/bcd
 FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        ca-certificates tmux git curl sqlite3 jq \
+        ca-certificates tmux git curl sqlite3 jq docker.io \
         make gcc libc6-dev python3 python3-pip unzip && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Reverts the docker.io removal from PR #2813
- bcd uses `exec.Command("docker", ...)` to spawn and stop agent containers via the Docker socket, so the CLI binary must be present in the runtime image

## Test plan
- [ ] Verify `docker` binary exists in built bcd image: `docker run --rm bc-bcd:latest which docker`
- [ ] Confirm bcd can spawn agent containers when Docker socket is mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker support to the runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->