### PR TITLE
feat: tool health check — mark agent stuck on tool failure

### DIFF
--- a/pkg/agent/tool_health.go
+++ b/pkg/agent/tool_health.go
@@ -1,0 +1,103 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gh-curious-otter/bc/pkg/log"
+)
+
+// CheckToolHealth verifies that the tool binary for the named agent is still
+// installed. If the binary is missing, the agent is marked as StateStuck and
+// diagnostic information is logged. This is intended to be called from a
+// health-check loop or on-demand.
+func (m *Manager) CheckToolHealth(ctx context.Context, agentName string) error {
+	m.mu.RLock()
+	ag, exists := m.agents[agentName]
+	if !exists {
+		m.mu.RUnlock()
+		return fmt.Errorf("agent %q not found", agentName)
+	}
+
+	// Only check agents that are in an active state.
+	if ag.State == StateStopped || ag.State == StateError {
+		m.mu.RUnlock()
+		return nil
+	}
+
+	toolName := ag.Tool
+	m.mu.RUnlock()
+
+	// Resolve the provider for this agent's tool.
+	if toolName == "" {
+		toolName = m.defaultTool
+	}
+	if toolName == "" {
+		toolName = DefaultProvider
+	}
+
+	if m.providerRegistry == nil {
+		return fmt.Errorf("no provider registry configured")
+	}
+
+	prov, ok := m.providerRegistry.Get(toolName)
+	if !ok {
+		return fmt.Errorf("unknown provider %q for agent %q", toolName, agentName)
+	}
+
+	if prov.IsInstalled(ctx) {
+		return nil
+	}
+
+	// Tool binary is unavailable — mark agent as stuck.
+	binaryName := prov.Binary()
+	log.Warn("tool binary unavailable, marking agent stuck",
+		"agent", agentName,
+		"tool", toolName,
+		"binary", binaryName,
+	)
+
+	task := fmt.Sprintf("tool unavailable: %s binary not found", toolName)
+	if err := m.updateStateForToolHealth(agentName, task); err != nil {
+		return fmt.Errorf("failed to mark agent %q as stuck: %w", agentName, err)
+	}
+
+	return nil
+}
+
+// updateStateForToolHealth sets an agent to StateStuck when its tool is
+// unavailable. It validates the transition and notifies state-change
+// listeners.
+func (m *Manager) updateStateForToolHealth(name, task string) error {
+	var changed bool
+
+	m.mu.Lock()
+	ag, exists := m.agents[name]
+	if !exists {
+		m.mu.Unlock()
+		return fmt.Errorf("agent %q not found", name)
+	}
+
+	if err := ValidateTransition(ag.State, StateStuck); err != nil {
+		m.mu.Unlock()
+		return err
+	}
+
+	prevState := ag.State
+	ag.State = StateStuck
+	ag.Task = task
+	ag.UpdatedAt = time.Now()
+	changed = prevState != StateStuck
+
+	if err := m.saveState(); err != nil {
+		log.Warn("failed to save agent state after tool health check", "error", err)
+	}
+	m.mu.Unlock()
+
+	if changed {
+		m.notifyStateChange(name, StateStuck, task)
+	}
+
+	return nil
+}

--- a/pkg/agent/tool_health_test.go
+++ b/pkg/agent/tool_health_test.go
@@ -1,0 +1,143 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gh-curious-otter/bc/pkg/provider"
+)
+
+// stubProvider is a minimal provider for testing tool health checks.
+type stubProvider struct {
+	name      string
+	binary    string
+	installed bool
+}
+
+func (s *stubProvider) Name() string                                  { return s.name }
+func (s *stubProvider) Description() string                           { return "stub" }
+func (s *stubProvider) Command() string                               { return s.binary }
+func (s *stubProvider) Binary() string                                { return s.binary }
+func (s *stubProvider) InstallHint() string                           { return "install " + s.name }
+func (s *stubProvider) BuildCommand(_ provider.CommandOpts) string    { return s.binary }
+func (s *stubProvider) IsInstalled(_ context.Context) bool            { return s.installed }
+func (s *stubProvider) Version(_ context.Context) string              { return "1.0" }
+func (s *stubProvider) DetectState(_ string) provider.State           { return "" }
+
+func TestCheckToolHealth_Installed(t *testing.T) {
+	reg := provider.NewRegistry()
+	reg.Register(&stubProvider{name: "test-tool", binary: "test-bin", installed: true})
+
+	m := &Manager{
+		agents:           map[string]*Agent{"a1": {Name: "a1", Tool: "test-tool", State: StateWorking}},
+		providerRegistry: reg,
+		defaultTool:      "test-tool",
+	}
+
+	if err := m.CheckToolHealth(context.Background(), "a1"); err != nil {
+		t.Fatalf("expected no error for installed tool, got: %v", err)
+	}
+
+	if m.agents["a1"].State != StateWorking {
+		t.Fatalf("expected state to remain working, got: %s", m.agents["a1"].State)
+	}
+}
+
+func TestCheckToolHealth_Unavailable(t *testing.T) {
+	reg := provider.NewRegistry()
+	reg.Register(&stubProvider{name: "test-tool", binary: "missing-bin", installed: false})
+
+	m := &Manager{
+		agents:           map[string]*Agent{"a1": {Name: "a1", Tool: "test-tool", State: StateWorking}},
+		providerRegistry: reg,
+		defaultTool:      "test-tool",
+	}
+
+	if err := m.CheckToolHealth(context.Background(), "a1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if m.agents["a1"].State != StateStuck {
+		t.Fatalf("expected state stuck, got: %s", m.agents["a1"].State)
+	}
+
+	if m.agents["a1"].Task == "" {
+		t.Fatal("expected task to be set with diagnostic info")
+	}
+}
+
+func TestCheckToolHealth_StoppedAgent(t *testing.T) {
+	reg := provider.NewRegistry()
+	reg.Register(&stubProvider{name: "test-tool", binary: "missing-bin", installed: false})
+
+	m := &Manager{
+		agents:           map[string]*Agent{"a1": {Name: "a1", Tool: "test-tool", State: StateStopped}},
+		providerRegistry: reg,
+	}
+
+	if err := m.CheckToolHealth(context.Background(), "a1"); err != nil {
+		t.Fatalf("expected no error for stopped agent, got: %v", err)
+	}
+
+	if m.agents["a1"].State != StateStopped {
+		t.Fatal("stopped agent state should not change")
+	}
+}
+
+func TestCheckToolHealth_NotFound(t *testing.T) {
+	m := &Manager{
+		agents: make(map[string]*Agent),
+	}
+
+	err := m.CheckToolHealth(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent agent")
+	}
+}
+
+func TestCheckToolHealth_DefaultTool(t *testing.T) {
+	reg := provider.NewRegistry()
+	reg.Register(&stubProvider{name: "claude", binary: "claude", installed: true})
+
+	m := &Manager{
+		agents:           map[string]*Agent{"a1": {Name: "a1", Tool: "", State: StateIdle}},
+		providerRegistry: reg,
+		defaultTool:      "claude",
+	}
+
+	if err := m.CheckToolHealth(context.Background(), "a1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if m.agents["a1"].State != StateIdle {
+		t.Fatalf("expected state to remain idle, got: %s", m.agents["a1"].State)
+	}
+}
+
+func TestCheckToolHealth_NotifiesStateChange(t *testing.T) {
+	reg := provider.NewRegistry()
+	reg.Register(&stubProvider{name: "test-tool", binary: "missing-bin", installed: false})
+
+	var notified bool
+	m := &Manager{
+		agents:           map[string]*Agent{"a1": {Name: "a1", Tool: "test-tool", State: StateWorking}},
+		providerRegistry: reg,
+		onStateChange: func(name string, state State, task string) {
+			notified = true
+			if name != "a1" {
+				t.Errorf("expected agent name a1, got %s", name)
+			}
+			if state != StateStuck {
+				t.Errorf("expected state stuck, got %s", state)
+			}
+		},
+	}
+
+	if err := m.CheckToolHealth(context.Background(), "a1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !notified {
+		t.Fatal("expected state change notification")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CheckToolHealth(ctx, agentName)` method to `Manager` that verifies an agent's tool binary is still installed via `provider.IsInstalled`
- When the binary becomes unavailable, transitions the agent to `StateStuck` with diagnostic info (tool name, binary path) logged
- Skips agents already in `stopped` or `error` states; validates state transitions before updating

Closes #2830, Part of #2808

## Test plan

- [x] Unit tests for all cases: installed tool (no-op), unavailable tool (marks stuck), stopped agent (skipped), unknown agent (error), default tool fallback, state change notification
- [x] `go vet` passes
- [x] `go test -race ./pkg/agent/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)