### PR TITLE
feat: validate tools on agent start — fail fast (#2828)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1136,6 +1136,15 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 		agent.Task = fmt.Sprintf("role setup failed: %v", setupErr)
 	}
 
+	// Validate required tools before starting — fail fast with clear errors.
+	if toolErrs := validateAgentTools(wsPath, string(role)); len(toolErrs) > 0 {
+		for _, te := range toolErrs {
+			log.Warn("tool validation failed", "agent", name, "error", te)
+		}
+		agent.Task = fmt.Sprintf("tool validation: %d issue(s)", len(toolErrs))
+		// Non-fatal: agent starts but issues are logged for visibility
+	}
+
 	// Create session IN the worktree directory
 	if err := rt.CreateSessionWithEnv(ctx, name, wtDir, agentCmd, env); err != nil {
 		agentLock.Unlock()

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -397,4 +398,53 @@ func writeMDFiles(dir string, files map[string]string) error {
 		}
 	}
 	return nil
+}
+
+// validateAgentTools checks that CLI tools listed in the role config are available.
+// Returns a list of issues found (empty = all good).
+func validateAgentTools(workspacePath, roleName string) []string {
+	if roleName == "" {
+		return nil
+	}
+
+	stateDir := filepath.Join(workspacePath, ".bc")
+	rm := workspace.NewRoleManager(stateDir)
+
+	resolved, err := rm.ResolveRole(roleName)
+	if err != nil {
+		return []string{fmt.Sprintf("cannot resolve role %q: %v", roleName, err)}
+	}
+
+	var issues []string
+
+	// Check CLI tools from role config
+	for _, toolName := range resolved.CLITools {
+		if _, err := execLookPath(toolName); err != nil {
+			issues = append(issues, fmt.Sprintf("CLI tool %q not found in PATH", toolName))
+		}
+	}
+
+	// Check MCP servers from role config (verify store has definitions)
+	mcpStore, mcpErr := pkgmcp.NewStore(workspacePath)
+	if mcpErr != nil {
+		issues = append(issues, fmt.Sprintf("MCP store unavailable: %v", mcpErr))
+		return issues
+	}
+	defer mcpStore.Close() //nolint:errcheck
+
+	for _, name := range resolved.MCPServers {
+		def, getErr := mcpStore.Get(name)
+		if getErr != nil || def == nil {
+			issues = append(issues, fmt.Sprintf("MCP server %q not defined in store", name))
+		}
+	}
+
+	return issues
+}
+
+// execLookPath is a testable wrapper around exec.LookPath.
+var execLookPath = defaultLookPath
+
+func defaultLookPath(name string) (string, error) {
+	return exec.LookPath(name)
 }


### PR DESCRIPTION
Validates CLI tools (PATH check) and MCP servers (store lookup) from role config before starting agent session. Issues logged as warnings for dashboard visibility. Part of #2808, closes #2828.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now validate their tools before startup, with warnings logged for any missing CLI tools or server configurations. Validation issues are tracked in the agent task status and do not prevent agent startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->