### PR TITLE
fix: cost_imports strftime → CURRENT_TIMESTAMP for Postgres (#2825)

### DIFF
--- a/pkg/cost/importer.go
+++ b/pkg/cost/importer.go
@@ -245,12 +245,14 @@ func (imp *Importer) resolveAgent(cwd, path string) string {
 func initImporterSchema(db *sql.DB) error {
 	ctx := context.Background()
 
+	// Use CURRENT_TIMESTAMP — works on both SQLite and Postgres.
+	// (strftime is SQLite-only and breaks on Postgres)
 	schema := `
 		CREATE TABLE IF NOT EXISTS cost_imports (
 			source_path  TEXT NOT NULL,
 			watermark    TEXT NOT NULL,
 			record_count INTEGER NOT NULL DEFAULT 0,
-			imported_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+			imported_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (source_path)
 		);
 	`


### PR DESCRIPTION
Same strftime bug class as #2767. Safety net for cost_imports table creation on Postgres. Fixes #2825.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database schema initialization to use a database-agnostic timestamp default, ensuring compatibility across SQLite and PostgreSQL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->