### PR TITLE
fix: idle agent green dot + agent detail log wrapping (#2822, #2826)

### DIFF
--- a/web/src/components/channels/MemberPanel.tsx
+++ b/web/src/components/channels/MemberPanel.tsx
@@ -8,7 +8,7 @@ function AgentStatusDot({ state }: { state?: string }) {
   const colors: Record<string, string> = {
     working: "bg-bc-success",
     running: "bg-bc-success",
-    idle: "bg-bc-warning",
+    idle: "bg-bc-success",
     waiting: "bg-bc-warning",
     stopped: "bg-bc-muted",
     error: "bg-bc-error",
@@ -17,7 +17,7 @@ function AgentStatusDot({ state }: { state?: string }) {
   const labels: Record<string, string> = {
     working: "Online",
     running: "Online",
-    idle: "Idle",
+    idle: "Online (idle)",
     waiting: "Waiting",
     stopped: "Offline",
     error: "Error",
@@ -77,7 +77,7 @@ export function MemberPanel({
           <p className="text-[10px] text-bc-muted mt-0.5">
             {(channel.members ?? []).filter((m) => {
               const s = agentStates[m];
-              return s === "working" || s === "running";
+              return s === "working" || s === "running" || s === "idle";
             }).length}/{channel.member_count} online
           </p>
         )}

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -79,7 +79,7 @@ function LogsTab({
       </h2>
       <pre
         ref={outputRef}
-        className="rounded-lg border border-bc-border/50 bg-[#0a0a0f] p-4 text-xs leading-relaxed overflow-y-auto max-h-[50vh] md:max-h-[70vh] whitespace-pre-wrap text-bc-text/90 shadow-inner"
+        className="rounded-lg border border-bc-border/50 bg-[#0a0a0f] p-4 text-xs leading-relaxed overflow-y-auto overflow-x-hidden max-h-[50vh] md:max-h-[70vh] whitespace-pre-wrap break-words text-bc-text/90 shadow-inner w-full min-w-0"
         style={{
           fontFamily:
             "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",


### PR DESCRIPTION
## Summary
- #2826: Idle agents now green (online-idle), not yellow. Online count includes idle.
- #2822: Log output wraps long lines properly (break-words, overflow-x-hidden, min-w-0).

Closes #2822, #2826.

## Test plan
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent idle status now displays as "Online (idle)" with updated visual indicator
  * Idle team members now contribute to the online member count
  * Log viewer text wrapping improved to prevent horizontal scrolling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->