### PR TITLE
feat: expose runtime field in agent API response (#2844)

### DIFF
--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -78,6 +78,7 @@ type agentDTO struct {
 	Task         string           `json:"task,omitempty"`
 	Team         string           `json:"team,omitempty"`
 	Tool         string           `json:"tool,omitempty"`
+	Runtime      string           `json:"runtime,omitempty"`
 	Session      string           `json:"session,omitempty"`
 	SessionID    string           `json:"session_id,omitempty"`
 	ParentID     string           `json:"parent_id,omitempty"`
@@ -109,6 +110,7 @@ func toDTO(a *agent.Agent) agentDTO {
 		Task:      a.Task,
 		Team:      a.Team,
 		Tool:      a.Tool,
+		Runtime:   a.RuntimeBackend,
 		Session:   a.Session,
 		SessionID: a.SessionID,
 		ParentID:  a.ParentID,


### PR DESCRIPTION
agentDTO now includes runtime field. API create already supported it, GET response was missing it. Closes #2844.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent API responses now include runtime backend information. The `/api/agents` and `/api/agents/{name}` endpoints will display runtime details when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->