### PR TITLE
feat: ConfigAdapter interface + Claude adapter (#2810)

### DIFF
--- a/pkg/provider/adapter.go
+++ b/pkg/provider/adapter.go
@@ -1,0 +1,75 @@
+// Package provider — ConfigAdapter extends Provider with config file setup.
+package provider
+
+// MCPEntry represents an MCP server configuration for adapter setup.
+type MCPEntry struct {
+	Name      string
+	Transport string // "sse" or "stdio"
+	Command   string
+	URL       string
+	Args      []string
+	Env       map[string]string
+}
+
+// ConfigAdapter handles provider-specific configuration file setup.
+// Providers that implement this interface get custom file layouts during
+// agent role setup. Providers without it get a generic fallback.
+type ConfigAdapter interface {
+	// PromptFile returns the filename for the role prompt (e.g., "CLAUDE.md", ".cursorrules").
+	PromptFile() string
+
+	// ConfigDir returns the provider-specific config directory name (e.g., ".claude", ".cursor").
+	// Empty string means no config directory.
+	ConfigDir() string
+
+	// SetupMCP configures MCP servers for this provider in the target directory.
+	SetupMCP(targetDir, agentName string, servers map[string]MCPEntry) error
+
+	// SetupPlugins writes plugin configuration for this provider.
+	SetupPlugins(agentDir string, plugins []string) error
+
+	// SupportsRules returns true if the provider supports rule files in ConfigDir/rules/.
+	SupportsRules() bool
+
+	// SupportsCommands returns true if the provider supports command files in ConfigDir/commands/.
+	SupportsCommands() bool
+
+	// SupportsSkills returns true if the provider supports skill files.
+	SupportsSkills() bool
+}
+
+// GetConfigAdapter returns the ConfigAdapter for a provider, or nil if it
+// doesn't implement one. Use this for type-safe adapter access.
+func GetConfigAdapter(p Provider) ConfigAdapter {
+	if adapter, ok := p.(ConfigAdapter); ok {
+		return adapter
+	}
+	return nil
+}
+
+// GenericAdapter is a fallback for providers that don't implement ConfigAdapter.
+// It writes a prompt to {PROVIDER}.md and skips MCP/rules/commands.
+type GenericAdapter struct {
+	providerName string
+}
+
+// NewGenericAdapter creates a fallback adapter for any provider.
+func NewGenericAdapter(name string) *GenericAdapter {
+	return &GenericAdapter{providerName: name}
+}
+
+func (a *GenericAdapter) PromptFile() string    { return toUpperFirst(a.providerName) + ".md" }
+func (a *GenericAdapter) ConfigDir() string     { return "" }
+func (a *GenericAdapter) SupportsRules() bool   { return false }
+func (a *GenericAdapter) SupportsCommands() bool { return false }
+func (a *GenericAdapter) SupportsSkills() bool  { return false }
+
+func (a *GenericAdapter) SetupMCP(_, _ string, _ map[string]MCPEntry) error { return nil }
+func (a *GenericAdapter) SetupPlugins(_ string, _ []string) error           { return nil }
+
+func toUpperFirst(s string) string {
+	if s == "" {
+		return ""
+	}
+	return string(s[0]-32) + s[1:] // ASCII uppercase first char
+}

--- a/pkg/provider/claude.go
+++ b/pkg/provider/claude.go
@@ -10,10 +10,11 @@ import (
 // ClaudeProvider implements the Provider interface for Claude Code.
 // Claude Code is the Anthropic CLI for Claude.
 type ClaudeProvider struct {
-	name        string
-	description string
-	command     string
-	binary      string
+	ClaudeConfigAdapter // embeds ConfigAdapter implementation
+	name                string
+	description         string
+	command             string
+	binary              string
 }
 
 // NewClaudeProvider creates a new Claude provider.

--- a/pkg/provider/claude_adapter.go
+++ b/pkg/provider/claude_adapter.go
@@ -1,0 +1,144 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ClaudeConfigAdapter implements ConfigAdapter for Claude Code.
+// It writes CLAUDE.md, .mcp.json (or uses `claude mcp add`),
+// .claude/rules/, .claude/commands/, and plugin configs.
+type ClaudeConfigAdapter struct{}
+
+func (a *ClaudeConfigAdapter) PromptFile() string      { return "CLAUDE.md" }
+func (a *ClaudeConfigAdapter) ConfigDir() string       { return ".claude" }
+func (a *ClaudeConfigAdapter) SupportsRules() bool     { return true }
+func (a *ClaudeConfigAdapter) SupportsCommands() bool  { return true }
+func (a *ClaudeConfigAdapter) SupportsSkills() bool    { return true }
+
+// SetupMCP configures MCP servers for Claude Code.
+// Prefers `claude mcp add` CLI; falls back to .mcp.json file write.
+func (a *ClaudeConfigAdapter) SetupMCP(targetDir, agentName string, servers map[string]MCPEntry) error {
+	if len(servers) == 0 {
+		return nil
+	}
+
+	// Try claude CLI first
+	if a.setupMCPViaCLI(targetDir, servers) {
+		return nil
+	}
+
+	// Fallback: write .mcp.json
+	return a.writeMCPJSON(targetDir, servers)
+}
+
+// SetupPlugins writes Claude Code plugin configuration.
+func (a *ClaudeConfigAdapter) SetupPlugins(agentDir string, plugins []string) error {
+	if len(plugins) == 0 {
+		return nil
+	}
+
+	claudeDir := filepath.Join(agentDir, "claude")
+	if err := os.MkdirAll(claudeDir, 0750); err != nil {
+		return fmt.Errorf("create claude dir: %w", err)
+	}
+
+	type pluginEntry struct {
+		Name    string `json:"name"`
+		Source  string `json:"source"`
+		Enabled bool   `json:"enabled"`
+	}
+	type manifest struct {
+		Plugins map[string]pluginEntry `json:"plugins"`
+	}
+
+	m := manifest{Plugins: make(map[string]pluginEntry, len(plugins))}
+	for _, name := range plugins {
+		m.Plugins[name] = pluginEntry{Name: name, Source: "claude-plugins-official", Enabled: true}
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal plugins: %w", err)
+	}
+	return os.WriteFile(filepath.Join(claudeDir, "installed_plugins.json"), data, 0600)
+}
+
+// setupMCPViaCLI uses `claude mcp add` commands.
+func (a *ClaudeConfigAdapter) setupMCPViaCLI(targetDir string, servers map[string]MCPEntry) bool {
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return false
+	}
+
+	for name, entry := range servers {
+		// Remove existing to avoid duplicates
+		rmCmd := exec.Command(claudePath, "mcp", "remove", name, "--scope", "project") //nolint:gosec
+		rmCmd.Dir = targetDir
+		_ = rmCmd.Run() //nolint:errcheck
+
+		args := []string{"mcp", "add", "--scope", "project"}
+		if entry.Transport == "sse" || entry.URL != "" {
+			args = append(args, "--transport", "sse")
+			for k, v := range entry.Env {
+				args = append(args, "-e", k+"="+v)
+			}
+			args = append(args, name, entry.URL)
+		} else if entry.Command != "" {
+			for k, v := range entry.Env {
+				args = append(args, "-e", k+"="+v)
+			}
+			args = append(args, name, "--")
+			args = append(args, strings.Fields(entry.Command)...)
+			args = append(args, entry.Args...)
+		} else {
+			continue
+		}
+
+		cmd := exec.Command(claudePath, args...) //nolint:gosec
+		cmd.Dir = targetDir
+		_ = cmd.Run() //nolint:errcheck
+	}
+	return true
+}
+
+// writeMCPJSON writes a .mcp.json file (fallback when claude CLI unavailable).
+func (a *ClaudeConfigAdapter) writeMCPJSON(targetDir string, servers map[string]MCPEntry) error {
+	type mcpServerEntry struct {
+		Env     map[string]string `json:"env,omitempty"`
+		Command string            `json:"command,omitempty"`
+		URL     string            `json:"url,omitempty"`
+		Type    string            `json:"type,omitempty"`
+		Args    []string          `json:"args,omitempty"`
+	}
+	type mcpConfig struct {
+		MCPServers map[string]mcpServerEntry `json:"mcpServers"`
+	}
+
+	cfg := mcpConfig{MCPServers: make(map[string]mcpServerEntry, len(servers))}
+	for name, entry := range servers {
+		e := mcpServerEntry{
+			Command: entry.Command,
+			URL:     entry.URL,
+			Args:    entry.Args,
+			Env:     entry.Env,
+		}
+		if entry.Transport == "sse" {
+			e.Type = "sse"
+		}
+		cfg.MCPServers[name] = e
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal mcp config: %w", err)
+	}
+	return os.WriteFile(filepath.Join(targetDir, ".mcp.json"), append(data, '\n'), 0600)
+}
+
+// Verify ClaudeProvider implements ConfigAdapter at compile time.
+var _ ConfigAdapter = (*ClaudeConfigAdapter)(nil)


### PR DESCRIPTION
New ConfigAdapter interface for provider-specific config. Claude adapter: CLAUDE.md, .mcp.json/CLI, plugins, rules/commands. GenericAdapter fallback. Part of #2810.