### PR TITLE
feat: Cursor, Gemini, Codex config adapters (#2810)

### DIFF
--- a/pkg/provider/codex.go
+++ b/pkg/provider/codex.go
@@ -10,6 +10,7 @@ import (
 //
 // Issue #1479: Codex CLI Provider Integration
 type CodexProvider struct {
+	*GenericAdapter
 	name        string
 	description string
 	command     string
@@ -19,10 +20,11 @@ type CodexProvider struct {
 // NewCodexProvider creates a new Codex provider.
 func NewCodexProvider() *CodexProvider {
 	return &CodexProvider{
-		name:        "codex",
-		description: "OpenAI Codex CLI",
-		command:     "codex --full-auto",
-		binary:      "codex",
+		GenericAdapter: NewGenericAdapter("codex"),
+		name:           "codex",
+		description:    "OpenAI Codex CLI",
+		command:        "codex --full-auto",
+		binary:         "codex",
 	}
 }
 

--- a/pkg/provider/cursor.go
+++ b/pkg/provider/cursor.go
@@ -7,6 +7,7 @@ import (
 
 // CursorProvider implements the Provider interface for Cursor Agent.
 type CursorProvider struct {
+	CursorConfigAdapter
 	name        string
 	description string
 	command     string

--- a/pkg/provider/cursor_adapter.go
+++ b/pkg/provider/cursor_adapter.go
@@ -1,0 +1,61 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// CursorConfigAdapter implements ConfigAdapter for Cursor.
+// Cursor uses .cursorrules for prompts and .cursor/mcp.json for MCP config.
+type CursorConfigAdapter struct{}
+
+func (a *CursorConfigAdapter) PromptFile() string      { return ".cursorrules" }
+func (a *CursorConfigAdapter) ConfigDir() string       { return ".cursor" }
+func (a *CursorConfigAdapter) SupportsRules() bool     { return true }
+func (a *CursorConfigAdapter) SupportsCommands() bool  { return false }
+func (a *CursorConfigAdapter) SupportsSkills() bool    { return false }
+
+// SetupMCP writes .cursor/mcp.json for Cursor's MCP support.
+func (a *CursorConfigAdapter) SetupMCP(targetDir, _ string, servers map[string]MCPEntry) error {
+	if len(servers) == 0 {
+		return nil
+	}
+
+	type cursorMCPServer struct {
+		Command string            `json:"command,omitempty"`
+		URL     string            `json:"url,omitempty"`
+		Args    []string          `json:"args,omitempty"`
+		Env     map[string]string `json:"env,omitempty"`
+	}
+	type cursorMCPConfig struct {
+		MCPServers map[string]cursorMCPServer `json:"mcpServers"`
+	}
+
+	cfg := cursorMCPConfig{MCPServers: make(map[string]cursorMCPServer, len(servers))}
+	for name, entry := range servers {
+		cfg.MCPServers[name] = cursorMCPServer{
+			Command: entry.Command,
+			URL:     entry.URL,
+			Args:    entry.Args,
+			Env:     entry.Env,
+		}
+	}
+
+	cursorDir := filepath.Join(targetDir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0750); err != nil {
+		return fmt.Errorf("create .cursor dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal cursor mcp config: %w", err)
+	}
+	return os.WriteFile(filepath.Join(cursorDir, "mcp.json"), append(data, '\n'), 0600)
+}
+
+// SetupPlugins is a no-op for Cursor (no plugin system).
+func (a *CursorConfigAdapter) SetupPlugins(_ string, _ []string) error { return nil }
+
+var _ ConfigAdapter = (*CursorConfigAdapter)(nil)

--- a/pkg/provider/gemini.go
+++ b/pkg/provider/gemini.go
@@ -7,19 +7,21 @@ import (
 
 // GeminiProvider implements the Provider interface for Google Gemini CLI.
 type GeminiProvider struct {
-	name        string
-	description string
-	command     string
-	binary      string
+	*GenericAdapter // GEMINI.md prompt, no special config
+	name           string
+	description    string
+	command        string
+	binary         string
 }
 
 // NewGeminiProvider creates a new Gemini provider.
 func NewGeminiProvider() *GeminiProvider {
 	return &GeminiProvider{
-		name:        "gemini",
-		description: "Google Gemini CLI",
-		command:     "gemini --yolo",
-		binary:      "gemini",
+		GenericAdapter: NewGenericAdapter("gemini"),
+		name:           "gemini",
+		description:    "Google Gemini CLI",
+		command:        "gemini --yolo",
+		binary:         "gemini",
 	}
 }
 


### PR DESCRIPTION
All 4 main providers now have ConfigAdapter. Cursor: .cursorrules + .cursor/mcp.json. Gemini/Codex: generic adapters. Part of #2810.