### PR TITLE
fix: P0 — prevent stores from closing shared DB connection (#2856)

### DIFF
--- a/pkg/cron/store.go
+++ b/pkg/cron/store.go
@@ -51,9 +51,14 @@ func Open(workspacePath string) (*Store, error) {
 }
 
 // Close closes the database connection.
+// If using the shared bc.db, this is a no-op — CloseShared() handles it.
 func (s *Store) Close() error {
 	if s.pg != nil {
 		return s.pg.Close()
+	}
+	// Don't close shared DB — it's owned by the shared connection manager.
+	if s.path == "" {
+		return nil // shared DB, no-op
 	}
 	return s.db.Close()
 }

--- a/pkg/mcp/store.go
+++ b/pkg/mcp/store.go
@@ -37,8 +37,9 @@ type ServerConfig struct {
 
 // Store provides MCP server config storage backed by SQLite or Postgres.
 type Store struct {
-	db *db.DB
-	pg *PostgresStore // non-nil when using Postgres via OpenStore
+	db     *db.DB
+	pg     *PostgresStore // non-nil when using Postgres via OpenStore
+	shared bool           // true when using shared bc.db (don't close on Close())
 }
 
 // NewStore creates a new MCP store for the given workspace path.
@@ -46,7 +47,7 @@ type Store struct {
 func NewStore(workspacePath string) (*Store, error) {
 	// Try shared database first
 	if shared := db.SharedWrapped(); shared != nil {
-		s := &Store{db: shared}
+		s := &Store{db: shared, shared: true}
 		if err := s.initSchema(); err != nil {
 			return nil, fmt.Errorf("init mcp schema on shared db: %w", err)
 		}
@@ -90,9 +91,13 @@ func (s *Store) initSchema() error {
 }
 
 // Close closes the database connection.
+// No-op when using shared bc.db — CloseShared() handles that.
 func (s *Store) Close() error {
 	if s.pg != nil {
 		return s.pg.Close()
+	}
+	if s.shared {
+		return nil // shared DB, don't close
 	}
 	if s.db != nil {
 		return s.db.Close()

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -234,6 +234,10 @@ func (s *Store) Close() error {
 	if s.pg != nil {
 		return s.pg.Close()
 	}
+	// Don't close shared DB — CloseShared() handles it.
+	if db.SharedWrapped() != nil && s.db == db.SharedWrapped() {
+		return nil
+	}
 	if s.db != nil {
 		return s.db.Close()
 	}


### PR DESCRIPTION
Stores using shared bc.db must not close the connection in their Close() method. Fixed cron, MCP, and tool stores. Fixes #2856 (cron sql: database is closed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of shared database connections across internal components to prevent them from being incorrectly closed during cleanup operations, enhancing system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->