### PR TITLE
fix: P0 — auto-recover broken/stale agent worktrees on start (#2857)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -933,17 +933,42 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	agentLock := m.getAgentLock(name)
 	agentLock.Lock()
 
-	// Ensure worktree exists (may have been cleaned up)
+	// Ensure worktree exists and is valid (may have been cleaned up, moved,
+	// or corrupted by runtime changes like Docker→localhost migration).
 	wtDir := existing.WorktreeDir
-	if wtDir == "" || !m.worktreeMgr.Exists(name) {
+	needsRecreate := wtDir == "" || !m.worktreeMgr.Exists(name)
+
+	// Also check that the worktree has a valid .git reference
+	if !needsRecreate && wtDir != "" {
+		gitPath := filepath.Join(wtDir, ".git")
+		if _, statErr := os.Stat(gitPath); statErr != nil {
+			log.Warn("worktree .git missing, will recreate", "agent", name, "path", wtDir)
+			needsRecreate = true
+		}
+	}
+
+	// Check for stale Docker paths (e.g., /workspace/... when running locally)
+	if !needsRecreate && wtDir != "" && !filepath.IsAbs(wtDir) {
+		needsRecreate = true
+	}
+	if !needsRecreate && wtDir != "" {
+		if _, statErr := os.Stat(wtDir); statErr != nil {
+			log.Warn("worktree path inaccessible, will recreate", "agent", name, "path", wtDir, "error", statErr)
+			needsRecreate = true
+		}
+	}
+
+	if needsRecreate {
+		// Remove stale worktree if it exists
+		_ = m.worktreeMgr.Remove(ctx, name) //nolint:errcheck
 		var wtErr error
 		wtDir, wtErr = m.worktreeMgr.Create(ctx, name)
 		if wtErr != nil {
 			agentLock.Unlock()
 			return nil, fmt.Errorf("failed to create worktree for agent %s: %w", name, wtErr)
-		} else {
-			existing.WorktreeDir = wtDir
 		}
+		existing.WorktreeDir = wtDir
+		log.Info("worktree recreated", "agent", name, "path", wtDir)
 	}
 
 	// Write hook settings and role files to worktree (regenerate on every start


### PR DESCRIPTION
Agent restart validates worktree: checks dir, .git, accessibility. Auto-recreates if broken. Fixes Docker→localhost migration and worktree corruption. Fixes #2857.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced agent initialization to validate worktree integrity before reuse and automatically detect and recreate invalid or corrupted worktrees, improving system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->