### PR TITLE
feat: optional API key authentication for bcd (#2629)

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -61,6 +61,7 @@ func main() {
 	verbose := flag.Bool("verbose", false, "enable verbose logging")
 	logFormat := flag.String("log-format", "text", "log output format (text|json)")
 	corsOrigin := flag.String("cors-origin", "*", "CORS allowed origin (* for permissive, or specific origin)")
+	apiKey := flag.String("api-key", os.Getenv("BC_API_KEY"), "API key for Bearer token auth (or set BC_API_KEY env var)")
 	flag.Parse()
 
 	if *logFormat == "json" {
@@ -70,13 +71,13 @@ func main() {
 		log.SetVerbose(true)
 	}
 
-	if err := run(*addr, *wsRoot, *corsOrigin); err != nil {
+	if err := run(*addr, *wsRoot, *corsOrigin, *apiKey); err != nil {
 		fmt.Fprintf(os.Stderr, "bcd: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(addr, wsRoot, corsOrigin string) error {
+func run(addr, wsRoot, corsOrigin, apiKey string) error {
 	ws, err := bcworkspace.Load(wsRoot)
 	if err != nil {
 		ws, err = bcworkspace.Init(wsRoot)
@@ -357,6 +358,10 @@ func run(addr, wsRoot, corsOrigin string) error {
 		cfg.Addr = addr
 	}
 	cfg.CORSOrigin = corsOrigin
+	cfg.APIKey = apiKey
+	if apiKey != "" {
+		log.Info("API key authentication enabled")
+	}
 	cfg.Build = server.BuildInfo{
 		Commit:  commit,
 		BuiltAt: date,

--- a/server/handlers/auth.go
+++ b/server/handlers/auth.go
@@ -1,0 +1,49 @@
+package handlers
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+)
+
+// APIKeyAuth returns middleware that validates Bearer token authentication.
+// If apiKey is empty, the middleware is a no-op (auth disabled).
+// Exempt paths (health, SSE) skip authentication.
+func APIKeyAuth(apiKey string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		// No API key configured — auth disabled (zero-config localhost)
+		if apiKey == "" {
+			return next
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Exempt paths: health check, SSE streams, MCP protocol
+			path := r.URL.Path
+			if path == "/health" || strings.HasPrefix(path, "/_mcp/") {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Check Authorization header
+			auth := r.Header.Get("Authorization")
+			if auth == "" {
+				// Also check X-API-Key header (alternative)
+				auth = "Bearer " + r.Header.Get("X-API-Key")
+			}
+
+			if !strings.HasPrefix(auth, "Bearer ") {
+				http.Error(w, `{"error":"unauthorized: missing Bearer token"}`, http.StatusUnauthorized)
+				return
+			}
+
+			token := strings.TrimPrefix(auth, "Bearer ")
+			// Constant-time comparison to prevent timing attacks
+			if subtle.ConstantTimeCompare([]byte(token), []byte(apiKey)) != 1 {
+				http.Error(w, `{"error":"unauthorized: invalid API key"}`, http.StatusUnauthorized)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -52,6 +52,7 @@ type Config struct {
 	Build      BuildInfo // build-time metadata
 	Addr       string    // default "127.0.0.1:9374"
 	CORSOrigin string    // allowed origin (default "*")
+	APIKey     string    // optional API key for Bearer token auth (empty = disabled)
 	CORS       bool      // enable permissive CORS headers (safe for loopback)
 }
 
@@ -313,7 +314,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 
 	// Middleware chain (outermost runs first):
-	// RateLimit → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → mux
+	// RateLimit → APIKeyAuth → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → mux
 	var handler http.Handler = mux
 	if cfg.CORS {
 		origin := cfg.CORSOrigin
@@ -327,6 +328,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	handler = handlers.Recovery(handler)
 	handler = handlers.RequestLogger(handler)
 	handler = handlers.RequestID(handler)
+	handler = handlers.APIKeyAuth(cfg.APIKey)(handler)
 	limiter := handlers.NewRateLimiter(100, 200)
 	handler = handlers.RateLimit(limiter)(handler)
 


### PR DESCRIPTION
Bearer token auth via --api-key flag or BC_API_KEY env var. Disabled by default. Constant-time comparison. Exempt: /health, /_mcp/*. Part of #2629.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional API key-based authentication to secure daemon access via Bearer tokens
  * API key can be configured using a CLI flag or environment variable
  * Health status and protocol-specific endpoints remain accessible without authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->