### PR TITLE
fix: CI test failures — SetOutput, MCP paths, event store (#2867, #2868)

### DIFF
--- a/pkg/ui/message.go
+++ b/pkg/ui/message.go
@@ -10,6 +10,15 @@ import (
 // Default output writer (can be overridden for testing).
 var output io.Writer = os.Stdout
 
+// SetOutput overrides the output writer (for testing). Pass nil to reset to stdout.
+func SetOutput(w io.Writer) {
+	if w == nil {
+		output = os.Stdout
+	} else {
+		output = w
+	}
+}
+
 // Message prefixes with colors.
 const (
 	successPrefix = "✓"

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -501,7 +501,7 @@ func TestE2E_MCP_SSE_ContentType(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	req, _ := http.NewRequestWithContext(ctx, "GET", s.URL+"/mcp/sse", nil)
+	req, _ := http.NewRequestWithContext(ctx, "GET", s.URL+"/_mcp/sse", nil)
 	req.Header.Set("Accept", "text/event-stream")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/server/handlers/handlers_test.go
+++ b/server/handlers/handlers_test.go
@@ -381,7 +381,7 @@ func TestGzipMiddlewareSkipsSSE(t *testing.T) {
 	}{
 		{"health is gzipped", "/health", "", true},
 		{"events endpoint skipped", "/api/events", "", false},
-		{"mcp sse skipped", "/mcp/sse", "", false},
+		{"mcp sse skipped", "/_mcp/sse", "", false},
 		{"agent output skipped", "/api/agents/alice/output", "", false},
 		{"accept event-stream skipped", "/health", "text/event-stream", false},
 	}

--- a/server/handlers/helpers_test.go
+++ b/server/handlers/helpers_test.go
@@ -210,8 +210,8 @@ func TestIsSSERequest(t *testing.T) {
 		want   bool
 	}{
 		{"events endpoint", "/api/events", "", true},
-		{"mcp sse", "/mcp/sse", "", true},
-		{"mcp message", "/mcp/message", "", true},
+		{"mcp sse", "/_mcp/sse", "", true},
+		{"mcp message", "/_mcp/message", "", true},
 		{"agent output", "/api/agents/alice/output", "", true},
 		{"accept event-stream", "/api/anything", "text/event-stream", true},
 		{"normal API", "/api/agents", "", false},

--- a/server/handlers/logging_test.go
+++ b/server/handlers/logging_test.go
@@ -49,7 +49,7 @@ func TestRequestLoggerMiddleware(t *testing.T) {
 
 	t.Run("MCP sse path is skipped", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodGet, "/mcp/sse", nil)
+		r := httptest.NewRequest(http.MethodGet, "/_mcp/sse", nil)
 		handler.ServeHTTP(w, r)
 		if w.Code != http.StatusOK {
 			t.Errorf("expected 200, got %d", w.Code)

--- a/server/handlers/resource_handlers_test.go
+++ b/server/handlers/resource_handlers_test.go
@@ -1513,7 +1513,9 @@ func TestToolHandler_MethodNotAllowed(t *testing.T) {
 	ts := buildTestServerWithServices(t, server.Services{Tools: store})
 	defer ts.Close()
 
-	resp := post(t, ts.URL+"/api/tools", "application/json", `{}`)
+	// POST is now valid (creates tools), test PATCH instead
+	req, _ := http.NewRequest(http.MethodPatch, ts.URL+"/api/tools", nil)
+	resp, _ := http.DefaultClient.Do(req)
 	assertStatus(t, resp, http.StatusMethodNotAllowed)
 	_ = resp.Body.Close()
 }
@@ -1609,8 +1611,8 @@ func TestToolHandler_ToolMethodNotAllowed(t *testing.T) {
 
 func TestEventHandler_ListEmpty(t *testing.T) {
 	dir := setupWorkspace(t)
-	logPath := filepath.Join(dir, ".bc", "events.log")
-	store := events.NewLog(logPath)
+	logPath := filepath.Join(dir, ".bc", "events.db")
+	store, _ := events.NewSQLiteLog(logPath)
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1627,8 +1629,8 @@ func TestEventHandler_ListEmpty(t *testing.T) {
 
 func TestEventHandler_AppendAndList(t *testing.T) {
 	dir := setupWorkspace(t)
-	logPath := filepath.Join(dir, ".bc", "events.log")
-	store := events.NewLog(logPath)
+	logPath := filepath.Join(dir, ".bc", "events.db")
+	store, _ := events.NewSQLiteLog(logPath)
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1656,8 +1658,8 @@ func TestEventHandler_AppendAndList(t *testing.T) {
 
 func TestEventHandler_ByAgent(t *testing.T) {
 	dir := setupWorkspace(t)
-	logPath := filepath.Join(dir, ".bc", "events.log")
-	store := events.NewLog(logPath)
+	logPath := filepath.Join(dir, ".bc", "events.db")
+	store, _ := events.NewSQLiteLog(logPath)
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1684,8 +1686,8 @@ func TestEventHandler_ByAgent(t *testing.T) {
 
 func TestEventHandler_MethodNotAllowed(t *testing.T) {
 	dir := setupWorkspace(t)
-	logPath := filepath.Join(dir, ".bc", "events.log")
-	store := events.NewLog(logPath)
+	logPath := filepath.Join(dir, ".bc", "events.db")
+	store, _ := events.NewSQLiteLog(logPath)
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1698,8 +1700,8 @@ func TestEventHandler_MethodNotAllowed(t *testing.T) {
 
 func TestEventHandler_AppendInvalidBody(t *testing.T) {
 	dir := setupWorkspace(t)
-	logPath := filepath.Join(dir, ".bc", "events.log")
-	store := events.NewLog(logPath)
+	logPath := filepath.Join(dir, ".bc", "events.db")
+	store, _ := events.NewSQLiteLog(logPath)
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1712,8 +1714,8 @@ func TestEventHandler_AppendInvalidBody(t *testing.T) {
 
 func TestEventHandler_EmptyAgentName(t *testing.T) {
 	dir := setupWorkspace(t)
-	logPath := filepath.Join(dir, ".bc", "events.log")
-	store := events.NewLog(logPath)
+	logPath := filepath.Join(dir, ".bc", "events.db")
+	store, _ := events.NewSQLiteLog(logPath)
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1726,8 +1728,8 @@ func TestEventHandler_EmptyAgentName(t *testing.T) {
 
 func TestEventHandler_ByAgentMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspace(t)
-	logPath := filepath.Join(dir, ".bc", "events.log")
-	store := events.NewLog(logPath)
+	logPath := filepath.Join(dir, ".bc", "events.db")
+	store, _ := events.NewSQLiteLog(logPath)
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})


### PR DESCRIPTION
Restores ui.SetOutput, fixes /mcp/→/_mcp/ in tests, updates event store refs, fixes tool handler test. Fixes #2867, #2868.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * API endpoint paths updated for MCP SSE and message functionality
  * HTTP method for tools API endpoint changed
  * Event logging backend switched to SQLite for improved data persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->