### PR TITLE
fix: cost importer Postgres timestamp encoding (#2872)

### DIFF
--- a/pkg/cost/importer.go
+++ b/pkg/cost/importer.go
@@ -161,7 +161,7 @@ func (imp *Importer) importFile(ctx context.Context, path string) (int, error) {
 				e.InputTokens, e.OutputTokens, total,
 				e.CacheCreationTokens, e.CacheReadTokens,
 				ie.costUSD,
-				e.Timestamp.UTC(),
+				e.Timestamp.UTC().Format(time.RFC3339Nano),
 			)
 		} else {
 			_, insertErr = tx.ExecContext(ctx,


### PR DESCRIPTION
Format time.Time as RFC3339 string for Postgres text column. One-line fix. Fixes #2872.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp precision and formatting in cost records for better consistency across database backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->