### PR TITLE
feat: SBOM generation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,3 +91,24 @@ jobs:
             dist/bc_*.tar.gz
             dist/checksums-macos.txt
           fail_on_unmatched_files: false
+
+  # ── SBOM generation ──────────────────────────────────────────────────
+  sbom:
+    name: Generate SBOM
+    runs-on: ubuntu-latest
+    needs: [release-linux, release-macos]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM to release
+        uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
+        with:
+          files: sbom.spdx.json


### PR DESCRIPTION
Closes #2628. Adds SPDX SBOM generation via anchore/sbom-action (syft) to the release workflow. SBOM attached to GitHub releases as sbom.spdx.json. Runs after Linux + macOS release jobs. Existing release process untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Software Bill of Materials (SBOM) files are now included with each release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->