### PR TITLE
fix: tool toggle disabled state not persisting

### DIFF
--- a/server/handlers/tools_unified.go
+++ b/server/handlers/tools_unified.go
@@ -122,12 +122,12 @@ func (h *UnifiedToolsHandler) list(w http.ResponseWriter, r *http.Request) {
 					if t.Type != "" {
 						toolType = t.Type
 					}
-					status := "installed"
-					if toolType == "mcp" {
+					// Determine status: disabled overrides all other states
+					var status string
+					if !t.Enabled {
+						status = "disabled"
+					} else if toolType == "mcp" {
 						status = "configured"
-						if !t.Enabled {
-							status = "disabled"
-						}
 					} else {
 						// Extract binary name (first word) from command — e.g. "claude --dangerously-skip-permissions" → "claude"
 						bin := t.Command
@@ -139,6 +139,8 @@ func (h *UnifiedToolsHandler) list(w http.ResponseWriter, r *http.Request) {
 						}
 						if _, lookErr := exec.LookPath(bin); lookErr != nil {
 							status = "not_installed"
+						} else {
+							status = "installed"
 						}
 					}
 					ut := UnifiedTool{


### PR DESCRIPTION
## Summary
- The `/api/tools/unified` endpoint only checked `t.Enabled` for MCP tools, always showing CLI and provider tools as "installed" or "not_installed" regardless of their DB state
- After toggling a tool to disabled via `/api/tools/:name/disable`, refreshing the page called the unified endpoint which ignored the `Enabled=false` and showed the tool as enabled
- Now checks `t.Enabled` first for **all** tool types — if disabled, status is `"disabled"` regardless of install state

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./pkg/tool/...` passes
- [x] Server handler test failures are pre-existing (shared DB setup issue), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool status reporting accuracy in the unified tool listing. Enabled MCP tools now display as "configured," non-MCP tools verify binary existence before showing "installed," and disabled tools consistently display as "disabled."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->