### PR TITLE
fix: MCP toggle for config-only servers

### DIFF
--- a/pkg/mcp/store.go
+++ b/pkg/mcp/store.go
@@ -34,11 +34,27 @@ type ServerConfig struct {
 	Enabled   bool              `json:"enabled"`
 }
 
+// ConfigLookupFunc resolves a server config by name from an external source
+// (e.g., the unified tool store). Returns nil if not found.
+type ConfigLookupFunc func(name string) *ServerConfig
+
 // Store provides MCP server config storage backed by SQLite or Postgres.
 type Store struct {
-	db     *db.DB
-	pg     *PostgresStore // non-nil when using Postgres via OpenStore
-	shared bool           // true when using shared bc.db (don't close on Close())
+	configLookup ConfigLookupFunc // optional fallback for config-only servers
+	db           *db.DB
+	pg           *PostgresStore // non-nil when using Postgres via OpenStore
+	shared       bool           // true when using shared bc.db (don't close on Close())
+}
+
+// SetConfigLookup registers a fallback function that resolves server configs
+// not yet present in the database (e.g., servers defined only in settings or
+// the unified tool store). Used by SetEnabled to auto-insert config-only
+// servers on first toggle.
+func (s *Store) SetConfigLookup(fn ConfigLookupFunc) {
+	s.configLookup = fn
+	if s.pg != nil {
+		s.pg.configLookup = fn
+	}
 }
 
 // NewStore creates a new MCP store for the given workspace path.
@@ -189,8 +205,8 @@ func (s *Store) Remove(name string) error {
 }
 
 // SetEnabled enables or disables an MCP server config.
-// Uses a simple UPDATE to avoid creating duplicate/broken rows with default
-// values. The server must already exist in the database (via Add).
+// If the server is not yet in the database but a ConfigLookupFunc is set,
+// the full config is resolved and inserted before applying the toggle.
 func (s *Store) SetEnabled(name string, enabled bool) error {
 	if s.pg != nil {
 		return s.pg.SetEnabled(name, enabled)
@@ -209,6 +225,16 @@ func (s *Store) SetEnabled(name string, enabled bool) error {
 	}
 	affected, _ := result.RowsAffected()
 	if affected == 0 {
+		// Server not in DB — try config lookup (e.g., unified tool store).
+		if s.configLookup != nil {
+			if cfg := s.configLookup(name); cfg != nil {
+				cfg.Enabled = enabled
+				if addErr := s.Add(cfg); addErr != nil {
+					return fmt.Errorf("insert config-only mcp server %q: %w", name, addErr)
+				}
+				return nil
+			}
+		}
 		return fmt.Errorf("mcp server %q not found", name)
 	}
 	return nil

--- a/pkg/mcp/store_postgres.go
+++ b/pkg/mcp/store_postgres.go
@@ -14,7 +14,8 @@ import (
 
 // PostgresStore provides Postgres-backed MCP server config storage.
 type PostgresStore struct {
-	db *sql.DB
+	configLookup ConfigLookupFunc // optional fallback for config-only servers
+	db           *sql.DB
 }
 
 // NewPostgresStore creates a PostgresStore from an existing *sql.DB connection.
@@ -138,8 +139,8 @@ func (p *PostgresStore) Remove(name string) error {
 }
 
 // SetEnabled enables or disables an MCP server config.
-// Uses a simple UPDATE to avoid creating duplicate/broken rows with default
-// values. The server must already exist in the database (via Add).
+// If the server is not yet in the database but a ConfigLookupFunc is set,
+// the full config is resolved and inserted before applying the toggle.
 func (p *PostgresStore) SetEnabled(name string, enabled bool) error {
 	enabledInt := 0
 	if enabled {
@@ -155,6 +156,16 @@ func (p *PostgresStore) SetEnabled(name string, enabled bool) error {
 	}
 	affected, _ := result.RowsAffected()
 	if affected == 0 {
+		// Server not in DB — try config lookup (e.g., unified tool store).
+		if p.configLookup != nil {
+			if cfg := p.configLookup(name); cfg != nil {
+				cfg.Enabled = enabled
+				if addErr := p.Add(cfg); addErr != nil {
+					return fmt.Errorf("insert config-only mcp server %q: %w", name, addErr)
+				}
+				return nil
+			}
+		}
 		return fmt.Errorf("mcp server %q not found", name)
 	}
 	return nil

--- a/pkg/mcp/store_test.go
+++ b/pkg/mcp/store_test.go
@@ -179,8 +179,8 @@ func TestSetEnabled(t *testing.T) {
 func TestSetEnabledNotFound(t *testing.T) {
 	s := setupTestStore(t)
 
-	// SetEnabled on a server not in the database should return an error
-	// (not silently create a broken row with default values).
+	// SetEnabled on a server not in the database and no config lookup
+	// should return an error.
 	err := s.SetEnabled("config-only", false)
 	if err == nil {
 		t.Fatal("expected error for SetEnabled on nonexistent server")
@@ -196,6 +196,70 @@ func TestSetEnabledNotFound(t *testing.T) {
 	}
 	if got != nil {
 		t.Error("expected nil, got a row — SetEnabled should not create rows")
+	}
+}
+
+func TestSetEnabledConfigOnly(t *testing.T) {
+	s := setupTestStore(t)
+
+	// Register a config lookup that returns a server config for "github".
+	s.SetConfigLookup(func(name string) *ServerConfig {
+		if name == "github" {
+			return &ServerConfig{
+				Name:      "github",
+				Transport: TransportStdio,
+				Command:   "github-mcp-server",
+				Env:       map[string]string{"GITHUB_TOKEN": "tok"},
+				Enabled:   true,
+			}
+		}
+		return nil
+	})
+
+	// Disabling a config-only server should auto-insert it with enabled=false.
+	if err := s.SetEnabled("github", false); err != nil {
+		t.Fatalf("SetEnabled config-only server: %v", err)
+	}
+
+	got, err := s.Get("github")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected row after SetEnabled on config-only server")
+	}
+	if got.Enabled {
+		t.Error("expected enabled=false after disabling config-only server")
+	}
+	if got.Command != "github-mcp-server" {
+		t.Errorf("command = %q, want %q", got.Command, "github-mcp-server")
+	}
+	if got.Transport != TransportStdio {
+		t.Errorf("transport = %q, want %q", got.Transport, TransportStdio)
+	}
+
+	// Toggling back to enabled should work via normal UPDATE path.
+	if err := s.SetEnabled("github", true); err != nil {
+		t.Fatalf("re-enable: %v", err)
+	}
+	got, _ = s.Get("github")
+	if !got.Enabled {
+		t.Error("expected enabled=true after re-enabling")
+	}
+}
+
+func TestSetEnabledConfigLookupMiss(t *testing.T) {
+	s := setupTestStore(t)
+
+	// Config lookup that never matches.
+	s.SetConfigLookup(func(name string) *ServerConfig { return nil })
+
+	err := s.SetEnabled("nonexistent", false)
+	if err == nil {
+		t.Fatal("expected error when config lookup returns nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -240,6 +240,30 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		handlers.NewSecretHandler(svc.Secrets).Register(mux)
 	}
 	if svc.MCP != nil {
+		// Wire config lookup so SetEnabled can auto-insert config-only servers
+		// (e.g., github, playwright) that exist in the tool store but not in
+		// the mcp_servers table.
+		if svc.Tools != nil {
+			svc.MCP.SetConfigLookup(func(name string) *mcp.ServerConfig {
+				t, err := svc.Tools.Get(context.Background(), name)
+				if err != nil || t == nil || t.Type != tool.ToolTypeMCP {
+					return nil
+				}
+				transport := mcp.TransportStdio
+				if t.Transport == "sse" {
+					transport = mcp.TransportSSE
+				}
+				return &mcp.ServerConfig{
+					Name:      t.Name,
+					Transport: transport,
+					Command:   t.Command,
+					URL:       t.URL,
+					Args:      t.Args,
+					Env:       t.Env,
+					Enabled:   t.Enabled,
+				}
+			})
+		}
 		handlers.NewMCPHandler(svc.MCP).Register(mux)
 	}
 	if svc.Tools != nil {


### PR DESCRIPTION
## Summary
- MCP toggle returned 400 "not found" for servers like `github` and `playwright` that exist in the unified tool store but not in the `mcp_servers` DB table
- Added `ConfigLookupFunc` to `mcp.Store` — when `SetEnabled` UPDATE affects 0 rows, falls back to resolving full config from the tool store and INSERTs it
- Wired lookup in `server.go` so the MCP store can resolve config-only servers from `pkg/tool.Store`

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./pkg/mcp/...` passes (3 new tests for config-only toggle)
- [x] `go vet` clean on affected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP servers can now be resolved from tool definitions when missing from the database, enabling automatic setup on first use without pre-registration.

* **Bug Fixes**
  * Enabled/disabled toggling for servers now works seamlessly even when the server hasn't been explicitly added yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->