### PR TITLE
fix: P1 deduplicate MCP tools to prevent search-clear DOM growth

### DIFF
--- a/server/handlers/tools_unified.go
+++ b/server/handlers/tools_unified.go
@@ -52,12 +52,14 @@ func (h *UnifiedToolsHandler) list(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var tools []UnifiedTool
+	seen := make(map[string]bool) // deduplicate across all three sources
 
-	// MCP servers from store
+	// MCP servers from store (highest priority — added first)
 	if h.mcpStore != nil {
 		servers, err := h.mcpStore.List()
 		if err == nil {
 			for _, s := range servers {
+				seen[s.Name] = true
 				status := "unknown"
 				if s.Enabled {
 					status = "configured"
@@ -79,7 +81,6 @@ func (h *UnifiedToolsHandler) list(w http.ResponseWriter, r *http.Request) {
 
 	// CLI tools from role configs
 	if h.ws != nil && h.ws.RoleManager != nil {
-		seen := make(map[string]bool)
 		roles, _ := h.ws.RoleManager.LoadAllRoles()
 		for _, role := range roles {
 			for _, t := range role.Metadata.CLITools {
@@ -112,60 +113,61 @@ func (h *UnifiedToolsHandler) list(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Built-in tools from tool store
+	// Built-in tools from tool store — skip names already added from mcpStore or roles
 	if h.toolStore != nil {
 		builtins, err := h.toolStore.List(r.Context())
 		if err == nil {
 			for _, t := range builtins {
-				if true { // Include all tools from store (builtin and user-added)
-					toolType := "cli"
-					if t.Type != "" {
-						toolType = t.Type
-					}
-					// Determine status: disabled overrides all other states
-					var status string
-					if !t.Enabled {
-						status = "disabled"
-					} else if toolType == "mcp" {
-						status = "configured"
-					} else {
-						// Extract binary name (first word) from command — e.g. "claude --dangerously-skip-permissions" → "claude"
-						bin := t.Command
-						if i := strings.IndexByte(bin, ' '); i > 0 {
-							bin = bin[:i]
-						}
-						if bin == "" {
-							bin = t.Name // fallback to tool name
-						}
-						if _, lookErr := exec.LookPath(bin); lookErr != nil {
-							status = "not_installed"
-						} else {
-							status = "installed"
-						}
-					}
-					ut := UnifiedTool{
-						Name:       t.Name,
-						Type:       toolType,
-						Command:    t.Command,
-						Transport:  t.Transport,
-						URL:        t.URL,
-						Status:     status,
-						InstallCmd: t.InstallCmd,
-						UpgradeCmd: t.UpgradeCmd,
-					}
-					// Try to get version for CLI tools
-					if toolType == "cli" && status == "installed" && t.VersionCmd != "" {
-						parts := strings.Fields(t.VersionCmd)
-						if out, verr := exec.Command(parts[0], parts[1:]...).Output(); verr == nil {
-							ver := strings.TrimSpace(string(out))
-							if len(ver) > 80 {
-								ver = ver[:80]
-							}
-							ut.Version = ver
-						}
-					}
-					tools = append(tools, ut)
+				if seen[t.Name] {
+					continue
 				}
+				seen[t.Name] = true
+				toolType := "cli"
+				if t.Type != "" {
+					toolType = t.Type
+				}
+				// Determine status: disabled overrides all other states
+				var status string
+				if !t.Enabled {
+					status = "disabled"
+				} else if toolType == "mcp" {
+					status = "configured"
+				} else {
+					// Extract binary name (first word) from command
+					bin := t.Command
+					if i := strings.IndexByte(bin, ' '); i > 0 {
+						bin = bin[:i]
+					}
+					if bin == "" {
+						bin = t.Name
+					}
+					if _, lookErr := exec.LookPath(bin); lookErr != nil {
+						status = "not_installed"
+					} else {
+						status = "installed"
+					}
+				}
+				ut := UnifiedTool{
+					Name:       t.Name,
+					Type:       toolType,
+					Command:    t.Command,
+					Transport:  t.Transport,
+					URL:        t.URL,
+					Status:     status,
+					InstallCmd: t.InstallCmd,
+					UpgradeCmd: t.UpgradeCmd,
+				}
+				if toolType == "cli" && status == "installed" && t.VersionCmd != "" {
+					parts := strings.Fields(t.VersionCmd)
+					if out, verr := exec.Command(parts[0], parts[1:]...).Output(); verr == nil {
+						ver := strings.TrimSpace(string(out))
+						if len(ver) > 80 {
+							ver = ver[:80]
+						}
+						ut.Version = ver
+					}
+				}
+				tools = append(tools, ut)
 			}
 		}
 	}

--- a/web/src/views/UnifiedTools.tsx
+++ b/web/src/views/UnifiedTools.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { api } from "../api/client";
 import type { UnifiedTool } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
@@ -277,21 +277,37 @@ export function UnifiedTools() {
     return <div className="p-6"><EmptyState icon="!" title="Failed to load tools" description={error} actionLabel="Retry" onAction={refresh} /></div>;
   }
 
-  const allTools = (checkedTools ?? tools ?? []).map((t) => {
-    const optimistic = optimisticToggles.get(t.name);
-    return optimistic ? { ...t, status: optimistic } : t;
-  });
+  // Deduplicate tools by name (first occurrence wins) and apply optimistic toggles.
+  // This prevents duplicate DOM entries when the same tool appears in multiple backend stores.
+  const allTools = useMemo(() => {
+    const source = checkedTools ?? tools ?? [];
+    const seen = new Set<string>();
+    const deduped: UnifiedTool[] = [];
+    for (const t of source) {
+      if (seen.has(t.name)) continue;
+      seen.add(t.name);
+      const optimistic = optimisticToggles.get(t.name);
+      deduped.push(optimistic ? { ...t, status: optimistic } : t);
+    }
+    return deduped;
+  }, [checkedTools, tools, optimisticToggles]);
 
   const searchLower = search.toLowerCase().trim();
-  const matchesSearch = (t: UnifiedTool) => !searchLower || t.name.toLowerCase().includes(searchLower);
 
-  const providers = allTools.filter((t) => t.type === "provider");
-  const mcpTools = allTools.filter((t) => t.type === "mcp");
-  const cliTools = allTools.filter((t) => !["provider", "mcp"].includes(t.type));
+  // Derive filtered views from allTools — never mutate the source array.
+  const { providers, mcpTools, cliTools, filteredProviders, filteredMcp, filteredCli } = useMemo(() => {
+    const matchesSearch = (t: UnifiedTool) => !searchLower || t.name.toLowerCase().includes(searchLower);
+    const prov = allTools.filter((t) => t.type === "provider");
+    const mcp = allTools.filter((t) => t.type === "mcp");
+    const cli = allTools.filter((t) => !["provider", "mcp"].includes(t.type));
+    return {
+      providers: prov, mcpTools: mcp, cliTools: cli,
+      filteredProviders: prov.filter(matchesSearch),
+      filteredMcp: mcp.filter(matchesSearch),
+      filteredCli: cli.filter(matchesSearch),
+    };
+  }, [allTools, searchLower]);
 
-  const filteredProviders = providers.filter(matchesSearch);
-  const filteredMcp = mcpTools.filter(matchesSearch);
-  const filteredCli = cliTools.filter(matchesSearch);
   const totalCount = allTools.length;
   const matchCount = filteredProviders.length + filteredMcp.length + filteredCli.length;
 


### PR DESCRIPTION
## Summary
- **Backend**: Unified tools endpoint gathered tools from three sources (mcpStore, role configs, toolStore) without cross-source deduplication. MCP servers in both mcpStore and toolStore appeared twice.
- **Frontend**: Duplicate tool names caused duplicate React keys. On search-then-clear cycles, React reconciliation with ambiguous keys left stale DOM nodes — rendered list grew unboundedly while header counts stayed correct.
- **Fix**: Lift `seen` map to top-level in Go handler so all three sources share it (mcpStore wins). On frontend, deduplicate `allTools` by name in `useMemo` and wrap filtering in a second `useMemo` for stable derived arrays.

## Test plan
- [ ] Load Tools page — MCP count in header matches rendered card count
- [ ] Search for a term, clear search — card count matches header count
- [ ] Repeat search/clear 5x — counts stay stable
- [ ] Health check still merges status correctly
- [ ] Toggle enable/disable still works with optimistic updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate tool entries appearing in the unified tools view when the same tools are registered across multiple sources.

* **Improvements**
  * Enhanced performance of tool filtering and search functionality through optimized deduplication logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->