### PR TITLE
feat: Live page animated event stream and time-based auto-aggregation

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -8,6 +8,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "framer-motion": "^12.38.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.28.0",
@@ -518,6 +519,8 @@
 
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
 
+    "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
+
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -625,6 +628,10 @@
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
+
+    "motion-utils": ["motion-utils@12.36.0", "", {}, "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -811,6 +818,8 @@
     "ts-api-utils": ["ts-api-utils@1.4.3", "", { "peerDependencies": { "typescript": ">=4.2.0" } }, "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "framer-motion": "^12.38.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.28.0",

--- a/web/src/views/Logs.tsx
+++ b/web/src/views/Logs.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, memo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { api } from "../api/client";
 import type { Agent } from "../api/client";
 import { useWebSocket } from "../hooks/useWebSocket";
@@ -52,6 +53,8 @@ interface AgentActivity {
   lastEventTime: number;
   nodes: ToolNode[];
   collapsed: boolean;
+  /** Index of the currently-active subagent node in nodes[], for nesting */
+  activeSubagentIdx?: number;
 }
 
 interface HookEvent {
@@ -331,9 +334,87 @@ function shouldNeverAggregate(node: ToolNode): boolean {
 /**
  * Scan a list of ToolNodes and aggregate consecutive same-tool nodes
  * that fall within the AGGREGATION_WINDOW_MS time window.
+ * When collapseOlderThan is provided (ms), events older than that threshold
+ * are also aggregated by tool type (even non-consecutive).
  * Returns a mixed list of ToolNode and AggregatedNode.
  */
-function aggregateNodes(nodes: ToolNode[]): DisplayNode[] {
+function aggregateNodes(nodes: ToolNode[], collapseOlderThan?: number): DisplayNode[] {
+  if (nodes.length === 0) return [];
+
+  const now = Date.now();
+  const threshold = collapseOlderThan ?? 0;
+
+  // If collapseOlderThan is set, split into recent and old nodes
+  if (threshold > 0) {
+    const recentNodes: ToolNode[] = [];
+    const oldByTool = new Map<string, ToolNode[]>();
+
+    for (const n of nodes) {
+      const age = now - n.startTime;
+      if (age <= threshold || n.status === "running" || shouldNeverAggregate(n)) {
+        recentNodes.push(n);
+      } else {
+        const key = n.toolName;
+        if (!oldByTool.has(key)) oldByTool.set(key, []);
+        oldByTool.get(key)!.push(n);
+      }
+    }
+
+    // Build aggregated groups for old nodes
+    const oldAggregated: DisplayNode[] = [];
+    for (const [toolName, group] of oldByTool) {
+      if (group.length >= 2) {
+        let totalDuration = 0;
+        const totalTokens = 0;
+        let successCount = 0;
+        let failCount = 0;
+        let minStart = Infinity;
+        let maxEnd = 0;
+
+        for (const n of group) {
+          const dur = n.endTime ? n.endTime - n.startTime : 0;
+          totalDuration += dur;
+          if (n.status === "completed") successCount++;
+          if (n.status === "failed") failCount++;
+          if (n.startTime < minStart) minStart = n.startTime;
+          if (n.endTime && n.endTime > maxEnd) maxEnd = n.endTime;
+        }
+
+        oldAggregated.push({
+          type: "aggregate",
+          id: `agg-old-${group[0]!.id}`,
+          toolName,
+          count: group.length,
+          children: group,
+          totalDuration,
+          totalTokens,
+          successCount,
+          failCount,
+          startTime: minStart,
+          endTime: maxEnd || now,
+        });
+      } else {
+        oldAggregated.push(...group);
+      }
+    }
+
+    // Sort old aggregated by startTime descending
+    oldAggregated.sort((a, b) => {
+      const aTime = isAggregatedNode(a) ? a.startTime : (a as ToolNode).startTime;
+      const bTime = isAggregatedNode(b) ? b.startTime : (b as ToolNode).startTime;
+      return bTime - aTime;
+    });
+
+    // Apply standard consecutive aggregation to recent nodes
+    const recentAggregated = aggregateConsecutive(recentNodes);
+    return [...recentAggregated, ...oldAggregated];
+  }
+
+  return aggregateConsecutive(nodes);
+}
+
+/** Standard consecutive same-tool aggregation within AGGREGATION_WINDOW_MS */
+function aggregateConsecutive(nodes: ToolNode[]): DisplayNode[] {
   if (nodes.length === 0) return [];
 
   const result: DisplayNode[] = [];
@@ -749,6 +830,7 @@ const AgentCard = memo(function AgentCard({
   isFilterActive,
   searchTerm,
   typeFilter,
+  isPaused,
 }: {
   activity: AgentActivity;
   onToggle: () => void;
@@ -756,7 +838,10 @@ const AgentCard = memo(function AgentCard({
   isFilterActive: boolean;
   searchTerm: string;
   typeFilter: FilterType;
+  isPaused: boolean;
 }) {
+  const [collapseOld, setCollapseOld] = useState(true);
+
   // Filter nodes based on search term (individual node filtering)
   const visibleNodes = searchTerm
     ? activity.nodes.filter((n) => nodeMatchesSearch(n, searchTerm.toLowerCase()))
@@ -764,9 +849,12 @@ const AgentCard = memo(function AgentCard({
 
   const runningCount = visibleNodes.filter((n) => n.status === "running").length;
   const errorCount = activity.nodes.filter((n) => n.status === "failed").length;
-  const displayNodes = aggregateNodes(visibleNodes);
+  const displayNodes = aggregateNodes(visibleNodes, collapseOld ? AUTO_COLLAPSE_MS : undefined);
   const matchCount = searchTerm ? visibleNodes.length : 0;
   const showToolNodes = typeFilter !== "state";
+
+  // Skip animations when paused or when bulk-flushing (>5 events arrive at once)
+  const skipAnimation = isPaused || visibleNodes.length > 5;
 
   return (
     <div className={`rounded-lg border bg-bc-surface overflow-hidden transition-colors ${isFilterActive ? "border-bc-accent ring-1 ring-bc-accent/30" : "border-bc-border"}`}>
@@ -849,9 +937,42 @@ const AgentCard = memo(function AgentCard({
 
       {!activity.collapsed && showToolNodes && displayNodes.length > 0 && (
         <div className="border-t border-bc-border/60 py-1">
-          {displayNodes.map((node) => (
-            <DisplayNodeRow key={isAggregatedNode(node) ? node.id : node.id} node={node} />
-          ))}
+          {/* Show all / Collapse old toggle */}
+          {visibleNodes.length > 3 && (
+            <div className="flex justify-end px-3 py-1">
+              <button
+                type="button"
+                onClick={() => setCollapseOld((prev) => !prev)}
+                className="text-[10px] text-bc-muted hover:text-bc-accent font-mono transition-colors"
+              >
+                {collapseOld ? "Show all" : "Collapse old"}
+              </button>
+            </div>
+          )}
+          <AnimatePresence mode="popLayout" initial={false}>
+            {displayNodes.map((node) => {
+              const nodeKey = isAggregatedNode(node) ? node.id : node.id;
+              if (skipAnimation) {
+                return (
+                  <div key={nodeKey}>
+                    <DisplayNodeRow node={node} />
+                  </div>
+                );
+              }
+              return (
+                <motion.div
+                  key={nodeKey}
+                  initial={{ opacity: 0, y: -20, height: 0 }}
+                  animate={{ opacity: 1, y: 0, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.2, ease: "easeOut" }}
+                  layout
+                >
+                  <DisplayNodeRow node={node} />
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
         </div>
       )}
 
@@ -1368,6 +1489,7 @@ export function Logs() {
                 isFilterActive={agentFilter === activity.name}
                 searchTerm={searchFilter}
                 typeFilter={typeFilter}
+                isPaused={paused}
               />
             </div>
           ))


### PR DESCRIPTION
## Summary
- Add framer-motion animations for smooth event slide-in/out in Live activity feed
- Enhance aggregation: events older than 30s auto-collapse by tool type within each agent
- Add "Show all / Collapse old" toggle per agent card
- Skip animations when paused or during bulk event flushes (>5 events)

## Test plan
- [ ] Verify `bun run build` passes in web/
- [ ] Open Live page, confirm new events animate in smoothly
- [ ] Wait 30s, confirm older events auto-aggregate by tool type
- [ ] Click aggregated group to expand individual events
- [ ] Toggle "Show all" / "Collapse old" per agent card
- [ ] Pause stream, resume with buffered events — confirm no animation jank

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Show all / Collapse old" toggle control in activity logs for easier navigation of extended log lists
  * Implemented smooth animations for log entries entering and exiting the view for improved visual feedback
  * Enhanced log aggregation to group older entries by tool type for better readability when collapse is enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->