### PR TITLE
feat: SSE event persistence with JSONL history API

### DIFF
--- a/cmd/bcd/main.go
+++ b/cmd/bcd/main.go
@@ -120,6 +120,10 @@ func run(addr, wsRoot, corsOrigin, apiKey string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
+	// SSE event persistence writer
+	eventsJSONL := filepath.Join(ws.StateDir(), "events.jsonl")
+	eventWriter := bcevents.NewJSONLWriter(eventsJSONL, 0)
+
 	hub := bcws.NewHub()
 	go hub.Run()
 	defer hub.Stop()
@@ -355,6 +359,7 @@ func run(addr, wsRoot, corsOrigin, apiKey string) error {
 		Tools:        toolStore,
 		Stats:        statsStore,
 		EventLog:     eventLog,
+		EventWriter:  eventWriter,
 		WS:           ws,
 		Gateway:      gwManager,
 	}

--- a/pkg/events/writer.go
+++ b/pkg/events/writer.go
@@ -1,0 +1,237 @@
+package events
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+const (
+	// DefaultMaxLines is the max number of lines kept in the JSONL file.
+	DefaultMaxLines = 10000
+	// rotationTrimLines is how many lines we keep after rotation (trim oldest).
+	rotationTrimLines = 5000
+)
+
+// SSEEvent is a single persisted SSE event with its broadcast timestamp.
+type SSEEvent struct {
+	Data      any       `json:"data"`
+	Timestamp time.Time `json:"ts"`
+	Type      string    `json:"type"`
+}
+
+// JSONLWriter appends SSE events to a JSONL file with line-count rotation.
+// It is safe for concurrent use.
+type JSONLWriter struct {
+	path     string
+	maxLines int
+	mu       sync.Mutex
+}
+
+// NewJSONLWriter creates a writer that appends to the given path.
+// maxLines controls when rotation triggers (0 = DefaultMaxLines).
+func NewJSONLWriter(path string, maxLines int) *JSONLWriter {
+	if maxLines <= 0 {
+		maxLines = DefaultMaxLines
+	}
+	return &JSONLWriter{
+		path:     path,
+		maxLines: maxLines,
+	}
+}
+
+// Write appends a single SSE event to the JSONL file.
+func (w *JSONLWriter) Write(eventType string, data any) error {
+	evt := SSEEvent{
+		Type:      eventType,
+		Data:      data,
+		Timestamp: time.Now().UTC(),
+	}
+	line, err := json.Marshal(evt)
+	if err != nil {
+		return fmt.Errorf("marshal SSE event: %w", err)
+	}
+	line = append(line, '\n')
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("open JSONL file: %w", err)
+	}
+	if _, err := f.Write(line); err != nil {
+		_ = f.Close() //nolint:errcheck // best-effort close on write error
+		return fmt.Errorf("write JSONL line: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close JSONL file: %w", err)
+	}
+
+	// Check if rotation is needed (count lines)
+	count, countErr := w.lineCount()
+	if countErr == nil && count > w.maxLines {
+		_ = w.rotate() //nolint:errcheck // best-effort rotation
+	}
+
+	return nil
+}
+
+// ReadLast returns the last n events from the JSONL file, oldest first.
+func (w *JSONLWriter) ReadLast(n int) ([]SSEEvent, int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	lines, err := w.readAllLines()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+
+	total := len(lines)
+	if n <= 0 || n > total {
+		n = total
+	}
+
+	// Take the last n lines
+	start := total - n
+	result := make([]SSEEvent, 0, n)
+	for _, line := range lines[start:] {
+		var evt SSEEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue // skip malformed lines
+		}
+		result = append(result, evt)
+	}
+	return result, total, nil
+}
+
+// ReadPage returns a page of events with offset/limit, oldest first.
+// Returns events, total count, and any error.
+func (w *JSONLWriter) ReadPage(limit, offset int) ([]SSEEvent, int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	lines, err := w.readAllLines()
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+
+	total := len(lines)
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= total {
+		return nil, total, nil
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+
+	result := make([]SSEEvent, 0, end-offset)
+	for _, line := range lines[offset:end] {
+		var evt SSEEvent
+		if err := json.Unmarshal(line, &evt); err != nil {
+			continue
+		}
+		result = append(result, evt)
+	}
+	return result, total, nil
+}
+
+// lineCount returns the number of lines in the file.
+// Caller must hold w.mu.
+func (w *JSONLWriter) lineCount() (int, error) {
+	f, err := os.Open(w.path)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }() //nolint:errcheck
+
+	count := 0
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		count++
+	}
+	return count, scanner.Err()
+}
+
+// readAllLines reads all non-empty lines from the file.
+// Caller must hold w.mu.
+func (w *JSONLWriter) readAllLines() ([][]byte, error) {
+	f, err := os.Open(w.path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }() //nolint:errcheck
+
+	var lines [][]byte
+	scanner := bufio.NewScanner(f)
+	// Allow large lines (1MB)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		b := scanner.Bytes()
+		if len(b) == 0 {
+			continue
+		}
+		cp := make([]byte, len(b))
+		copy(cp, b)
+		lines = append(lines, cp)
+	}
+	return lines, scanner.Err()
+}
+
+// rotate keeps only the newest rotationTrimLines lines.
+// Caller must hold w.mu.
+func (w *JSONLWriter) rotate() error {
+	lines, err := w.readAllLines()
+	if err != nil {
+		return err
+	}
+	if len(lines) <= rotationTrimLines {
+		return nil
+	}
+
+	// Keep only the last rotationTrimLines lines
+	keep := lines[len(lines)-rotationTrimLines:]
+
+	tmp := w.path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return fmt.Errorf("create tmp for rotation: %w", err)
+	}
+
+	bw := bufio.NewWriter(f)
+	for _, line := range keep {
+		if _, err := bw.Write(line); err != nil {
+			_ = f.Close() //nolint:errcheck
+			_ = os.Remove(tmp)
+			return fmt.Errorf("write rotated line: %w", err)
+		}
+		if err := bw.WriteByte('\n'); err != nil {
+			_ = f.Close() //nolint:errcheck
+			_ = os.Remove(tmp)
+			return fmt.Errorf("write newline: %w", err)
+		}
+	}
+	if err := bw.Flush(); err != nil {
+		_ = f.Close() //nolint:errcheck
+		_ = os.Remove(tmp)
+		return fmt.Errorf("flush rotated file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close rotated file: %w", err)
+	}
+
+	return os.Rename(tmp, w.path)
+}

--- a/server/handlers/events.go
+++ b/server/handlers/events.go
@@ -11,7 +11,8 @@ import (
 
 // EventHandler handles /api/logs (historical event log).
 type EventHandler struct {
-	store events.EventStore
+	store  events.EventStore
+	writer *events.JSONLWriter
 }
 
 // NewEventHandler creates an EventHandler.
@@ -19,10 +20,16 @@ func NewEventHandler(store events.EventStore) *EventHandler {
 	return &EventHandler{store: store}
 }
 
+// SetWriter attaches a JSONLWriter for the /api/events/history endpoint.
+func (h *EventHandler) SetWriter(w *events.JSONLWriter) {
+	h.writer = w
+}
+
 // Register mounts event log routes on mux.
 func (h *EventHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/logs", h.logs)
 	mux.HandleFunc("/api/logs/", h.byAgent)
+	mux.HandleFunc("/api/events/history", h.history)
 }
 
 func (h *EventHandler) logs(w http.ResponseWriter, r *http.Request) {
@@ -93,4 +100,45 @@ func (h *EventHandler) appendEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// history serves GET /api/events/history?limit=100&offset=0
+// Returns paginated SSE events from the JSONL persistence file.
+func (h *EventHandler) history(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.writer == nil {
+		httpError(w, "event history not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	limit := 100
+	if s := r.URL.Query().Get("limit"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	limit = clampInt(limit, 1, 10000)
+
+	offset := 0
+	if s := r.URL.Query().Get("offset"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+
+	evts, total, err := h.writer.ReadPage(limit, offset)
+	if err != nil {
+		httpInternalError(w, "read event history", err)
+		return
+	}
+	if evts == nil {
+		evts = []events.SSEEvent{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"events": evts,
+		"total":  total,
+	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -74,6 +74,7 @@ type Services struct {
 	Tools        *tool.Store
 	Stats        *stats.Store
 	EventLog     events.EventStore
+	EventWriter  *events.JSONLWriter
 	WS           *workspace.Workspace
 	Gateway      *gateway.Manager
 }
@@ -136,6 +137,11 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		}
 		writeJSON(map[string]any{"status": status, "checks": checks})
 	})
+
+	// Wire event persistence into the SSE hub
+	if hub != nil && svc.EventWriter != nil {
+		hub.SetWriter(svc.EventWriter)
+	}
 
 	// SSE event stream
 	if hub != nil {
@@ -271,8 +277,12 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 	// Unified tools endpoint (MCP + CLI) — always registered
 	handlers.NewUnifiedToolsHandler(svc.MCP, svc.Tools, svc.Agents, svc.WS).Register(mux)
-	if svc.EventLog != nil {
-		handlers.NewEventHandler(svc.EventLog).Register(mux)
+	if svc.EventLog != nil || svc.EventWriter != nil {
+		eh := handlers.NewEventHandler(svc.EventLog)
+		if svc.EventWriter != nil {
+			eh.SetWriter(svc.EventWriter)
+		}
+		eh.Register(mux)
 	}
 	if svc.Gateway != nil {
 		gh := handlers.NewGatewayHandler(svc.Gateway, svc.WS)

--- a/server/ws/hub.go
+++ b/server/ws/hub.go
@@ -17,6 +17,11 @@ type Event struct {
 	Type string `json:"type"`
 }
 
+// EventWriter persists SSE events for later retrieval.
+type EventWriter interface {
+	Write(eventType string, data any) error
+}
+
 type subscriber struct {
 	ch   chan []byte
 	done <-chan struct{}
@@ -28,6 +33,7 @@ type Hub struct {
 	subscribers map[*subscriber]struct{}
 	broadcast   chan []byte
 	done        chan struct{}
+	writer      EventWriter
 	mu          sync.RWMutex
 	stopOnce    sync.Once
 }
@@ -39,6 +45,11 @@ func NewHub() *Hub {
 		broadcast:   make(chan []byte, 256),
 		done:        make(chan struct{}),
 	}
+}
+
+// SetWriter attaches an EventWriter for persisting broadcast events.
+func (h *Hub) SetWriter(w EventWriter) {
+	h.writer = w
 }
 
 // Run processes the broadcast channel until Stop is called.
@@ -60,8 +71,10 @@ func (h *Hub) Stop() {
 
 // Publish implements agent.EventPublisher.
 // Data is redacted before broadcast to prevent secrets from leaking to the UI.
+// If an EventWriter is attached, the event is also persisted to disk.
 func (h *Hub) Publish(eventType string, data map[string]any) {
-	evt := Event{Type: eventType, Data: RedactMap(data)}
+	redacted := RedactMap(data)
+	evt := Event{Type: eventType, Data: redacted}
 	msg, err := json.Marshal(evt)
 	if err != nil {
 		return
@@ -70,6 +83,13 @@ func (h *Hub) Publish(eventType string, data map[string]any) {
 	case h.broadcast <- msg:
 	default:
 		log.Debug("event dropped: broadcast buffer full", "type", eventType)
+	}
+
+	// Persist to JSONL (best-effort)
+	if h.writer != nil {
+		if wErr := h.writer.Write(eventType, redacted); wErr != nil {
+			log.Debug("event persist failed", "type", eventType, "error", wErr)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `pkg/events/writer.go` — thread-safe JSONLWriter that appends SSE events to `.bc/events.jsonl` with automatic rotation (keeps newest 5000 lines when exceeding 10000)
- Wire persistence into `server/ws/hub.go` — every `Publish()` call now also writes to disk via an `EventWriter` interface (best-effort, non-blocking)
- Add `GET /api/events/history?limit=100&offset=0` endpoint for paginated retrieval of persisted SSE events

## Test plan
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Start bcd, trigger SSE events, verify `.bc/events.jsonl` is written
- [ ] `curl localhost:9374/api/events/history?limit=10` returns paginated results
- [ ] Verify rotation by writing >10000 events and checking file is trimmed to 5000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/api/events/history` API endpoint to retrieve past events with pagination (limit/offset parameters).
  * Enabled automatic persistence of server-sent events to disk for historical access and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->