### PR TITLE
feat: providers table UI on Tools page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,9 @@ const Roles = lazy(() =>
 const Tools = lazy(() =>
   import("./views/UnifiedTools").then((m) => ({ default: m.UnifiedTools })),
 );
+const ProviderDetail = lazy(() =>
+  import("./views/ProviderDetail").then((m) => ({ default: m.ProviderDetail })),
+);
 const Logs = lazy(() =>
   import("./views/Logs").then((m) => ({ default: m.Logs })),
 );
@@ -121,6 +124,16 @@ export function App() {
                   <Suspense fallback={<Loading />}>
                     <ErrorBoundary>
                       <Tools />
+                    </ErrorBoundary>
+                  </Suspense>
+                }
+              />
+              <Route
+                path="tools/:provider"
+                element={
+                  <Suspense fallback={<Loading />}>
+                    <ErrorBoundary>
+                      <ProviderDetail />
                     </ErrorBoundary>
                   </Suspense>
                 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -179,6 +179,21 @@ export interface UnifiedTool {
   upgrade_cmd?: string;
 }
 
+export interface ProviderInfo {
+  name: string;
+  description: string;
+  binary: string;
+  command: string;
+  install_hint: string;
+  version: string;
+  status: string;
+  total_cost_usd: number;
+  total_tokens: number;
+  agent_count: number;
+  installed: boolean;
+  enabled: boolean;
+}
+
 export interface EventLogEntry {
   id: number;
   type: string;
@@ -493,6 +508,7 @@ export const api = {
     }),
   deleteRole: (name: string) =>
     request<void>(`/roles/${encodeURIComponent(name)}`, { method: "DELETE" }),
+  listProviders: () => request<ProviderInfo[]>("/providers"),
   listTools: () => request<Tool[]>("/tools"),
   enableTool: (name: string) =>
     request<{ enabled: boolean }>(`/tools/${encodeURIComponent(name)}/enable`, {

--- a/web/src/components/ProvidersTable.tsx
+++ b/web/src/components/ProvidersTable.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import type { ProviderInfo } from "../api/client";
+import { EmptyState } from "./EmptyState";
+
+type SortKey = "name" | "status" | "version" | "agent_count" | "total_tokens" | "total_cost_usd";
+type SortDir = "asc" | "desc";
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+  return String(n);
+}
+
+function formatCost(n: number): string {
+  if (n === 0) return "$0.00";
+  return `$${n.toFixed(2)}`;
+}
+
+function statusOrder(p: ProviderInfo): number {
+  if (p.installed && p.agent_count > 0) return 0; // active
+  if (p.installed) return 1; // idle
+  return 2; // not installed
+}
+
+function StatusDot({ provider }: { provider: ProviderInfo }) {
+  if (!provider.installed) {
+    return <span className="inline-flex items-center gap-1.5 text-bc-error"><span className="text-xs">&#10005;</span> N/A</span>;
+  }
+  if (provider.agent_count > 0) {
+    return <span className="inline-flex items-center gap-1.5 text-bc-success"><span className="w-2 h-2 rounded-full bg-bc-success inline-block" /> Active</span>;
+  }
+  return <span className="inline-flex items-center gap-1.5 text-bc-muted"><span className="w-2 h-2 rounded-full bg-bc-muted inline-block" /> Idle</span>;
+}
+
+interface Props {
+  providers: ProviderInfo[];
+  search: string;
+}
+
+export function ProvidersTable({ providers, search }: Props) {
+  const [sortKey, setSortKey] = useState<SortKey>("name");
+  const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const navigate = useNavigate();
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase().trim();
+    if (!q) return providers;
+    return providers.filter((p) => p.name.toLowerCase().includes(q));
+  }, [providers, search]);
+
+  const sorted = useMemo(() => {
+    const arr = [...filtered];
+    arr.sort((a, b) => {
+      let cmp = 0;
+      switch (sortKey) {
+        case "name":
+          cmp = a.name.localeCompare(b.name);
+          break;
+        case "status":
+          cmp = statusOrder(a) - statusOrder(b);
+          break;
+        case "version":
+          cmp = (a.version || "").localeCompare(b.version || "");
+          break;
+        case "agent_count":
+          cmp = a.agent_count - b.agent_count;
+          break;
+        case "total_tokens":
+          cmp = a.total_tokens - b.total_tokens;
+          break;
+        case "total_cost_usd":
+          cmp = a.total_cost_usd - b.total_cost_usd;
+          break;
+      }
+      return sortDir === "asc" ? cmp : -cmp;
+    });
+    return arr;
+  }, [filtered, sortKey, sortDir]);
+
+  const toggleSort = (key: SortKey) => {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  };
+
+  const sortIndicator = (key: SortKey) => {
+    if (sortKey !== key) return null;
+    return <span className="ml-1 text-bc-accent">{sortDir === "asc" ? "\u25B2" : "\u25BC"}</span>;
+  };
+
+  if (sorted.length === 0) {
+    return (
+      <EmptyState
+        icon="*"
+        title={search ? "No matching providers" : "No providers"}
+        description={search ? "Try a different search term." : "No AI providers configured."}
+      />
+    );
+  }
+
+  const columns: { key: SortKey; label: string; className?: string }[] = [
+    { key: "name", label: "Provider" },
+    { key: "status", label: "Status" },
+    { key: "version", label: "Version" },
+    { key: "agent_count", label: "Agents", className: "text-right" },
+    { key: "total_tokens", label: "Tokens", className: "text-right" },
+    { key: "total_cost_usd", label: "Cost", className: "text-right" },
+  ];
+
+  return (
+    <div className="rounded border border-bc-border overflow-hidden">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-bc-border bg-bc-surface">
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                onClick={() => toggleSort(col.key)}
+                className={`px-4 py-2 font-medium text-bc-muted cursor-pointer select-none hover:text-bc-text transition-colors text-left ${col.className ?? ""}`}
+              >
+                {col.label}{sortIndicator(col.key)}
+              </th>
+            ))}
+            <th className="px-4 py-2 font-medium text-bc-muted text-right">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((p) => (
+            <tr
+              key={p.name}
+              onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+              className="border-b border-bc-border/50 cursor-pointer hover:bg-bc-surface transition-colors"
+            >
+              <td className="px-4 py-2.5 font-medium">{p.name}</td>
+              <td className="px-4 py-2.5 text-xs"><StatusDot provider={p} /></td>
+              <td className="px-4 py-2.5 text-xs text-bc-muted font-mono">{p.version || "\u2014"}</td>
+              <td className="px-4 py-2.5 text-right tabular-nums">{p.agent_count}</td>
+              <td className="px-4 py-2.5 text-right tabular-nums text-bc-muted">{formatTokens(p.total_tokens)}</td>
+              <td className="px-4 py-2.5 text-right tabular-nums">{formatCost(p.total_cost_usd)}</td>
+              <td className="px-4 py-2.5 text-right">
+                <div className="flex items-center justify-end gap-1.5" onClick={(e) => e.stopPropagation()}>
+                  {!p.installed && p.install_hint && (
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+                      className="text-xs px-2 py-0.5 rounded bg-bc-warning/10 text-bc-warning hover:bg-bc-warning/20 transition-colors"
+                    >
+                      Install
+                    </button>
+                  )}
+                  {p.installed && p.install_hint && (
+                    <span className="text-xs px-2 py-0.5 rounded bg-bc-info/10 text-bc-info">
+                      Update
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+                    className="text-xs px-1.5 py-0.5 rounded border border-bc-border text-bc-muted hover:text-bc-text hover:border-bc-accent/50 transition-colors"
+                    aria-label={`Configure ${p.name}`}
+                  >
+                    &#9881;
+                  </button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -1,0 +1,18 @@
+import { useParams, Link } from "react-router-dom";
+
+export function ProviderDetail() {
+  const { provider } = useParams<{ provider: string }>();
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex items-center gap-3">
+        <Link to="/tools" className="text-sm text-bc-accent hover:underline">&larr; Tools</Link>
+        <h1 className="text-xl font-bold">{provider}</h1>
+      </div>
+      <div className="rounded border border-bc-border bg-bc-surface p-6 text-center">
+        <p className="text-bc-muted">Provider detail page coming soon.</p>
+        <p className="text-xs text-bc-muted mt-2">This page will show configuration, MCP servers, agent list, and cost breakdown for <span className="font-medium text-bc-text">{provider}</span>.</p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/views/UnifiedTools.tsx
+++ b/web/src/views/UnifiedTools.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useMemo, useState } from "react";
 import { api } from "../api/client";
-import type { UnifiedTool } from "../api/client";
+import type { ProviderInfo, UnifiedTool } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
+import { ProvidersTable } from "../components/ProvidersTable";
 import { ToastContainer, useToast } from "../components/Toast";
 import type { ToastLevel } from "../components/Toast";
 
@@ -22,24 +23,6 @@ const STATUS_CONFIG: Record<string, { dot: string; label: string; textColor: str
 const inputCls = "w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent";
 
 function getStatusConfig(s: string) { return STATUS_CONFIG[s] ?? STATUS_CONFIG.unknown!; }
-
-function ProviderCard({ tool }: { tool: UnifiedTool }) {
-  const cfg = getStatusConfig(tool.status);
-  return (
-    <div className="rounded border border-bc-border bg-bc-surface p-3 flex items-center gap-3">
-      <span className={`w-2 h-2 rounded-full shrink-0 ${cfg.dot}`} aria-label={`Status: ${cfg.label}`} />
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium">{tool.name}</span>
-          <span className={`text-[10px] ${cfg.textColor}`}>{cfg.label}</span>
-        </div>
-        <p className="text-[10px] text-bc-muted font-mono truncate" title={tool.command || ""}>{tool.command || "\u2014"}</p>
-        {tool.version && <span className="text-[10px] text-bc-muted">v{tool.version}</span>}
-        {tool.error && <p className="text-[10px] text-bc-error">{tool.error}</p>}
-      </div>
-    </div>
-  );
-}
 
 function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, onExpand }: {
   tool: UnifiedTool; onToggle: () => void; onRemove: () => void;
@@ -198,6 +181,11 @@ function AddCLIToolForm({ onClose, onAdded, onToast }: { onClose: () => void; on
 }
 
 export function UnifiedTools() {
+  // Fetch providers from dedicated endpoint
+  const providerFetcher = useCallback(() => api.listProviders(), []);
+  const { data: providers, loading: providersLoading } = usePolling(providerFetcher, 10000);
+
+  // Fetch CLI tools from unified endpoint
   const fetcher = useCallback(() => api.listUnifiedTools(), []);
   const { data: tools, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
   const [addForm, setAddForm] = useState<AddFormType>(null);
@@ -242,18 +230,18 @@ export function UnifiedTools() {
 
   const searchLower = search.toLowerCase().trim();
 
-  const { providers, cliTools, filteredProviders, filteredCli } = useMemo(() => {
+  const { cliTools, filteredCli } = useMemo(() => {
     const matchesSearch = (t: UnifiedTool) => !searchLower || t.name.toLowerCase().includes(searchLower);
-    const prov = allTools.filter((t) => t.type === "provider");
     const cli = allTools.filter((t) => t.type !== "provider" && t.type !== "mcp");
     return {
-      providers: prov, cliTools: cli,
-      filteredProviders: prov.filter(matchesSearch),
+      cliTools: cli,
       filteredCli: cli.filter(matchesSearch),
     };
   }, [allTools, searchLower]);
 
-  if (loading && !tools) {
+  const providerList: ProviderInfo[] = providers ?? [];
+
+  if (loading && !tools && providersLoading && !providers) {
     return (
       <div className="p-6 space-y-6">
         <div className="h-6 w-32 animate-pulse rounded bg-bc-border/50" />
@@ -268,8 +256,8 @@ export function UnifiedTools() {
     return <div className="p-6"><EmptyState icon="!" title="Failed to load tools" description={error} actionLabel="Retry" onAction={refresh} /></div>;
   }
 
-  const totalCount = allTools.length;
-  const matchCount = filteredProviders.length + filteredCli.length;
+  const totalCount = providerList.length + allTools.length;
+  const matchCount = providerList.filter((p) => !searchLower || p.name.toLowerCase().includes(searchLower)).length + filteredCli.length;
 
   const handleToggle = async (tool: UnifiedTool) => {
     const wasDisabled = tool.status === "disabled" || tool.status === "not_installed";
@@ -323,7 +311,7 @@ export function UnifiedTools() {
           <p className="text-xs text-bc-muted mt-0.5 hidden sm:block">
             {searchLower
               ? `${matchCount} of ${totalCount} tools`
-              : <>{providers.length} Providers &middot; {cliTools.length} CLI{checkedTools && " \u00b7 checked"}</>
+              : <>{providerList.length} Providers &middot; {cliTools.length} CLI{checkedTools && " \u00b7 checked"}</>
             }
           </p>
         </div>
@@ -360,18 +348,12 @@ export function UnifiedTools() {
 
       {addForm && <AddCLIToolForm onClose={() => setAddForm(null)} onAdded={() => { setCheckedTools(null); refresh(); }} onToast={addToast} />}
 
-      {/* Providers */}
+      {/* Providers Table */}
       <section>
         <h2 className="text-xs font-medium text-bc-muted uppercase tracking-widest mb-3">
-          Providers ({filteredProviders.length}{searchLower ? `/${providers.length}` : ""}) &mdash; AI model providers
+          Providers ({providerList.length}) &mdash; AI model providers
         </h2>
-        {filteredProviders.length === 0 ? (
-          <EmptyState icon="*" title={searchLower ? "No matching providers" : "No providers"} description={searchLower ? "Try a different search term." : "No AI providers configured."} />
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-            {filteredProviders.map((t) => <ProviderCard key={t.name} tool={t} />)}
-          </div>
-        )}
+        <ProvidersTable providers={providerList} search={search} />
       </section>
 
       {/* CLI Dependencies */}


### PR DESCRIPTION
## Summary
- Replace providers grid cards with a rich sortable data table (Provider, Status, Version, Agents, Tokens, Cost, Actions columns)
- Fetch provider data from `/api/providers` endpoint with agent counts, token usage, and cost stats
- Add `/tools/:provider` route with placeholder ProviderDetail view for future drill-down
- Keep CLI Dependencies section below the providers table

## Test plan
- [ ] Verify providers table renders with correct columns and data
- [ ] Click column headers to sort ascending/descending
- [ ] Search filters both providers table and CLI tools
- [ ] Click row navigates to `/tools/:provider`
- [ ] Install/Update badges show in Actions column
- [ ] `bun run build` in web/ passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a searchable and sortable providers table displaying provider status, version, token usage, and cost information.
  * Added a dedicated provider detail page accessible by clicking individual providers.
  * Providers now display status indicators (Active/Idle/N/A) and aggregate usage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->