### PR TITLE
fix: Tools page chevron, column sort, health check versions

### DIFF
--- a/web/src/components/ProvidersTable.tsx
+++ b/web/src/components/ProvidersTable.tsx
@@ -119,7 +119,7 @@ export function ProvidersTable({ providers, search }: Props) {
             {columns.map((col) => (
               <th
                 key={col.key}
-                onClick={() => toggleSort(col.key)}
+                onClick={(e) => { e.stopPropagation(); toggleSort(col.key); }}
                 className={`px-4 py-2 font-medium text-bc-muted cursor-pointer select-none hover:text-bc-text transition-colors text-left ${col.className ?? ""}`}
               >
                 {col.label}{sortIndicator(col.key)}

--- a/web/src/views/UnifiedTools.tsx
+++ b/web/src/views/UnifiedTools.tsx
@@ -41,7 +41,11 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
         {/* Chevron + Name */}
         <td className="px-3 py-2 text-sm">
           <div className="flex items-center gap-2">
-            <span className={`text-[10px] text-bc-muted transition-transform ${expanded ? "rotate-90" : ""}`}>&#9654;</span>
+            <span
+              className={`text-[10px] text-bc-muted inline-block transition-transform ${expanded ? "rotate-90" : ""}`}
+            >
+              &#9654;
+            </span>
             <span className="font-medium">{tool.name}</span>
           </div>
         </td>
@@ -202,12 +206,13 @@ export function UnifiedTools() {
     setChecking(true);
     try {
       const checked = await api.checkUnifiedTools();
-      const statusMap = new Map(checked.map((t) => [t.name, t.status]));
-      setCheckedTools((tools ?? []).map((t) => ({
-        ...t,
-        status: statusMap.get(t.name) ?? t.status,
-        health_status: statusMap.has(t.name) ? "checked" : undefined,
-      })));
+      const checkMap = new Map(checked.map((t) => [t.name, t]));
+      setCheckedTools((tools ?? []).map((t) => {
+        const c = checkMap.get(t.name);
+        return c
+          ? { ...t, status: c.status, version: c.version || t.version, health_status: "checked" as const }
+          : t;
+      }));
       addToast("success", "Health check complete");
     } catch {
       addToast("error", "Health check failed");


### PR DESCRIPTION
## Summary
- Add `inline-block` to chevron span so `rotate-90` CSS transform applies when CLI row is expanded (#108)
- Add `e.stopPropagation()` to ProvidersTable column header click handlers to prevent row navigation (#109)
- Map `version` field from health check results into CLI tools so Version column shows actual versions (#110)

## Test plan
- [ ] Expand a CLI tool row — chevron rotates 90 degrees
- [ ] Click column headers in Providers table — sorts without navigating
- [ ] Run Health Check — CLI tool versions populate in the Version column

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed table column header click handling to eliminate unintended event propagation affecting sort functionality
  * Improved health-check state updates to properly synchronize tool status and version information

* **Style**
  * Refined visual styling for the CLI dependencies section chevron

<!-- end of auto-generated comment: release notes by coderabbit.ai -->