### PR TITLE
fix: task ID mismatch causing tasks to stay pending forever

### DIFF
--- a/pkg/events/writer.go
+++ b/pkg/events/writer.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -237,13 +238,17 @@ func (w *JSONLWriter) rotate() error {
 	return os.Rename(tmp, w.path)
 }
 
+// taskIDRegexp matches "Task #123" in tool response strings.
+var taskIDRegexp = regexp.MustCompile(`Task\s+#(\d+)`)
+
 // TaskItem represents a task extracted from SSE event history.
 type TaskItem struct {
-	ID          string `json:"id"`
-	Subject     string `json:"subject"`
-	Status      string `json:"status"`
-	Owner       string `json:"owner,omitempty"`
-	Description string `json:"description,omitempty"`
+	ID          string   `json:"id"`
+	Subject     string   `json:"subject"`
+	Status      string   `json:"status"`
+	Owner       string   `json:"owner,omitempty"`
+	Description string   `json:"description,omitempty"`
+	BlockedBy   []string `json:"blockedBy,omitempty"`
 }
 
 // CurrentTasks scans the JSONL event history for TaskCreate/TaskUpdate
@@ -296,10 +301,13 @@ func (w *JSONLWriter) CurrentTasks() ([]TaskItem, error) {
 
 		// TaskUpdate: extract from Pre/PostToolUse events
 		if (eventName == "PreToolUse" || eventName == "PostToolUse") && containsTaskUpdate(toolName) {
-			id, status := extractTaskUpdate(data)
+			id, status, blockedBy := extractTaskUpdate(data)
 			if id != "" && status != "" {
 				if t, exists := tasks[id]; exists {
 					t.Status = status
+					if len(blockedBy) > 0 {
+						t.BlockedBy = append(t.BlockedBy, blockedBy...)
+					}
 				}
 			}
 		}
@@ -331,22 +339,28 @@ func extractTaskCreate(data map[string]any) *TaskItem {
 	}
 
 	id := "task-" + fmt.Sprintf("%d", time.Now().UnixMilli())
-	if resp != nil {
-		if s, ok := resp["id"].(string); ok && s != "" {
-			id = s
-		} else if s, ok := resp["task_id"].(string); ok && s != "" {
-			id = s
-		}
-	}
-	// Also try parsing string response as JSON
-	if resp == nil {
-		if respStr, ok := data["tool_response"].(string); ok && respStr != "" {
+
+	// First, try to parse numeric ID from string response like "Task #125 created successfully: ..."
+	if respStr, ok := data["tool_response"].(string); ok && respStr != "" {
+		if m := taskIDRegexp.FindStringSubmatch(respStr); len(m) > 1 {
+			id = m[1]
+		} else {
+			// Try parsing string response as JSON
 			var parsed map[string]any
 			if json.Unmarshal([]byte(respStr), &parsed) == nil {
 				if s, ok := parsed["id"].(string); ok && s != "" {
 					id = s
 				}
 			}
+		}
+	}
+
+	// If still a fallback ID, try structured response fields
+	if strings.HasPrefix(id, "task-") && resp != nil {
+		if s, ok := resp["id"].(string); ok && s != "" {
+			id = s
+		} else if s, ok := resp["task_id"].(string); ok && s != "" {
+			id = s
 		}
 	}
 
@@ -371,10 +385,10 @@ func extractTaskCreate(data map[string]any) *TaskItem {
 	}
 }
 
-func extractTaskUpdate(data map[string]any) (string, string) {
+func extractTaskUpdate(data map[string]any) (string, string, []string) {
 	inp, _ := data["tool_input"].(map[string]any)
 	if inp == nil {
-		return "", ""
+		return "", "", nil
 	}
 
 	var id string
@@ -386,12 +400,12 @@ func extractTaskUpdate(data map[string]any) (string, string) {
 		id = s
 	}
 	if id == "" {
-		return "", ""
+		return "", "", nil
 	}
 
 	rawStatus, _ := inp["status"].(string)
 	if rawStatus == "" {
-		return "", ""
+		return "", "", nil
 	}
 
 	statusMap := map[string]string{
@@ -410,5 +424,15 @@ func extractTaskUpdate(data map[string]any) (string, string) {
 	if !ok {
 		status = "pending"
 	}
-	return id, status
+
+	var blockedBy []string
+	if arr, ok := inp["addBlockedBy"].([]any); ok {
+		for _, v := range arr {
+			if s, ok := v.(string); ok {
+				blockedBy = append(blockedBy, s)
+			}
+		}
+	}
+
+	return id, status, blockedBy
 }

--- a/web/src/views/Logs.tsx
+++ b/web/src/views/Logs.tsx
@@ -78,6 +78,7 @@ interface TaskItem {
   status: "pending" | "in_progress" | "completed" | "deleted";
   owner?: string;
   description?: string;
+  blockedBy?: string[];
 }
 
 type FilterType = "all" | "tools" | "state";
@@ -596,7 +597,15 @@ function parseTaskCreate(
   if (!inp) return null;
 
   let id = "task-" + Date.now();
-  if (resp) {
+
+  // First, try to parse numeric ID from string response like "Task #125 created successfully: ..."
+  if (typeof toolResponse === "string") {
+    const numMatch = (toolResponse as string).match(/Task\s+#(\d+)/);
+    if (numMatch) id = numMatch[1]!;
+  }
+
+  // If still a fallback ID, try structured response fields
+  if (id.startsWith("task-") && resp) {
     if (typeof resp.id === "string") id = resp.id;
     else if (typeof resp.task_id === "string") id = resp.task_id;
     else if (typeof resp === "string") {
@@ -620,7 +629,7 @@ function parseTaskCreate(
   return { id, subject, status: "pending", owner: agentName, description };
 }
 
-function parseTaskUpdate(toolInput: unknown): { taskId: string; status: TaskItem["status"] } | null {
+function parseTaskUpdate(toolInput: unknown): { taskId: string; status: TaskItem["status"]; blockedBy?: string[] } | null {
   const inp = toolInput as Record<string, unknown> | null;
   if (!inp) return null;
 
@@ -650,7 +659,8 @@ function parseTaskUpdate(toolInput: unknown): { taskId: string; status: TaskItem
   };
 
   const status = statusMap[rawStatus] ?? "pending";
-  return { taskId, status };
+  const blockedBy = Array.isArray(inp.addBlockedBy) ? inp.addBlockedBy as string[] : undefined;
+  return { taskId, status, blockedBy };
 }
 
 function parseTaskListResponse(text: string): TaskItem[] {
@@ -1103,10 +1113,14 @@ function TasksPanel({ tasks }: { tasks: Map<string, TaskItem> }) {
 
       {!collapsed && total > 0 && (
         <div className="border-t border-bc-border/60 px-4 py-2 space-y-1">
-          {visible.map((task) => (
-            <div key={task.id} className="flex items-center gap-2 py-0.5">
+          {visible.map((task) => {
+            const isBlocked = task.blockedBy && task.blockedBy.length > 0 && task.status !== "completed";
+            return (
+            <div key={task.id} className={`flex items-center gap-2 py-0.5 ${isBlocked ? "opacity-50" : ""}`}>
               {task.status === "completed" ? (
                 <span className="text-bc-success text-xs shrink-0">{"\u2713"}</span>
+              ) : isBlocked ? (
+                <span className="inline-flex h-2 w-2 rounded-full bg-yellow-500/60 shrink-0" />
               ) : task.status === "in_progress" ? (
                 <span className="inline-flex h-2 w-2 rounded-full bg-blue-500 shrink-0" />
               ) : (
@@ -1116,13 +1130,20 @@ function TasksPanel({ tasks }: { tasks: Map<string, TaskItem> }) {
                 className={`text-sm font-mono ${
                   task.status === "completed"
                     ? "line-through text-bc-muted/60"
-                    : task.status === "in_progress"
-                      ? "text-blue-400 font-semibold"
-                      : "text-bc-text"
+                    : isBlocked
+                      ? "text-bc-muted"
+                      : task.status === "in_progress"
+                        ? "text-blue-400 font-semibold"
+                        : "text-bc-text"
                 }`}
               >
                 {task.subject}
               </span>
+              {isBlocked && (
+                <span className="text-[10px] text-yellow-500/80 font-mono shrink-0">
+                  Blocked by {task.blockedBy!.map(b => `#${b}`).join(", ")}
+                </span>
+              )}
               {task.owner && (
                 <span className="text-[10px] text-bc-muted font-mono shrink-0">
                   {task.owner}
@@ -1132,7 +1153,8 @@ function TasksPanel({ tasks }: { tasks: Map<string, TaskItem> }) {
                 {task.status.replace("_", " ")}
               </span>
             </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>
@@ -1426,7 +1448,9 @@ export function Logs() {
             if (update) {
               const existing = historicalTasks.get(update.taskId);
               if (existing) {
-                historicalTasks.set(update.taskId, { ...existing, status: update.status });
+                const merged = { ...existing, status: update.status };
+                if (update.blockedBy) merged.blockedBy = [...(existing.blockedBy ?? []), ...update.blockedBy];
+                historicalTasks.set(update.taskId, merged);
               }
             }
           }
@@ -1602,7 +1626,9 @@ export function Logs() {
             if (!changed) { nextTasks = new Map(prevTasks); changed = true; }
             const existing = nextTasks.get(update.taskId);
             if (existing) {
-              nextTasks.set(update.taskId, { ...existing, status: update.status });
+              const merged = { ...existing, status: update.status };
+              if (update.blockedBy) merged.blockedBy = [...(existing.blockedBy ?? []), ...update.blockedBy];
+              nextTasks.set(update.taskId, merged);
             }
           }
         }


### PR DESCRIPTION
## Summary
- TaskCreate responses contain `Task #125 created successfully: ...` but `parseTaskCreate` generated IDs as `task-{Date.now()}`. TaskUpdate sends `taskId: "125"` which never matched the map key, so tasks stayed "pending" forever.
- Now parses the numeric ID from the response string using regex `/Task\s+#(\d+)/` as the primary ID source in both frontend (`Logs.tsx`) and backend (`writer.go`).
- Adds `blockedBy` support: `addBlockedBy` field from TaskUpdate tool_input is stored on tasks and displayed in the TasksPanel with grayed-out styling and "Blocked by #X, #Y" labels.

## Test plan
- [ ] Verify tasks transition from pending to in_progress/completed when agents call TaskUpdate
- [ ] Verify blocked tasks show yellow dot, reduced opacity, and "Blocked by #X" text
- [ ] Verify `go build ./...` passes
- [ ] Verify `cd web && bun run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)