### PR TITLE
fix: suppress gosec G204 in health check CLI version detection

### DIFF
--- a/server/handlers/tools_unified.go
+++ b/server/handlers/tools_unified.go
@@ -231,7 +231,7 @@ func (h *UnifiedToolsHandler) checkAll(w http.ResponseWriter, r *http.Request) {
 					ut.Status = "installed"
 					ut.Command = path
 					// Try to get version
-					if out, verr := exec.Command(t, "--version").Output(); verr == nil {
+					if out, verr := exec.Command(t, "--version").Output(); verr == nil { //nolint:gosec // tool names from role configs
 						ver := strings.TrimSpace(string(out))
 						if len(ver) > 80 {
 							ver = ver[:80]


### PR DESCRIPTION
## Summary
- Adds `//nolint:gosec` annotation to the `exec.Command(t, "--version")` call in the `checkAll` health check handler
- Same trusted pattern as the existing `list` handler -- tool names come from role configs, not user input
- Fixes CI lint failure on main introduced by #2900

## Test plan
- [ ] CI lint passes (gosec G204 suppressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality checks and tooling configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->