### PR TITLE
fix: use exec.CommandContext for CLI version check in health endpoint

### DIFF
--- a/server/handlers/tools_unified.go
+++ b/server/handlers/tools_unified.go
@@ -231,7 +231,7 @@ func (h *UnifiedToolsHandler) checkAll(w http.ResponseWriter, r *http.Request) {
 					ut.Status = "installed"
 					ut.Command = path
 					// Try to get version
-					if out, verr := exec.Command(t, "--version").Output(); verr == nil { //nolint:gosec // tool names from role configs
+					if out, verr := exec.CommandContext(r.Context(), t, "--version").Output(); verr == nil { //nolint:gosec // tool names from role configs
 						ver := strings.TrimSpace(string(out))
 						if len(ver) > 80 {
 							ver = ver[:80]


### PR DESCRIPTION
## Summary
- Fixes noctx lint error on main by using `exec.CommandContext(r.Context(), ...)` instead of `exec.Command(...)` in the health check CLI version detection
- Ensures proper request context propagation for cancellation

## Test plan
- [ ] CI lint passes (noctx satisfied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of tool version detection to ensure more reliable subprocess management and proper cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->