### PR TITLE
refactor: simplify store patterns across mcp, tool, and events

### DIFF
--- a/pkg/events/writer.go
+++ b/pkg/events/writer.go
@@ -289,7 +289,7 @@ func (w *JSONLWriter) CurrentTasks() ([]TaskItem, error) {
 		toolName, _ := data["tool_name"].(string)
 
 		// TaskCreate: extract from PostToolUse events
-		if eventName == "PostToolUse" && containsTaskCreate(toolName) {
+		if eventName == "PostToolUse" && strings.Contains(toolName, "TaskCreate") {
 			task := extractTaskCreate(data)
 			if task != nil {
 				if _, exists := tasks[task.ID]; !exists {
@@ -300,7 +300,7 @@ func (w *JSONLWriter) CurrentTasks() ([]TaskItem, error) {
 		}
 
 		// TaskUpdate: extract from Pre/PostToolUse events
-		if (eventName == "PreToolUse" || eventName == "PostToolUse") && containsTaskUpdate(toolName) {
+		if (eventName == "PreToolUse" || eventName == "PostToolUse") && strings.Contains(toolName, "TaskUpdate") {
 			id, status, blockedBy := extractTaskUpdate(data)
 			if id != "" && status != "" {
 				if t, exists := tasks[id]; exists {
@@ -321,14 +321,6 @@ func (w *JSONLWriter) CurrentTasks() ([]TaskItem, error) {
 		}
 	}
 	return result, nil
-}
-
-func containsTaskCreate(s string) bool {
-	return strings.Contains(s, "TaskCreate")
-}
-
-func containsTaskUpdate(s string) bool {
-	return strings.Contains(s, "TaskUpdate")
 }
 
 func extractTaskCreate(data map[string]any) *TaskItem {

--- a/pkg/mcp/store_postgres.go
+++ b/pkg/mcp/store_postgres.go
@@ -171,14 +171,9 @@ func (p *PostgresStore) SetEnabled(name string, enabled bool) error {
 	return nil
 }
 
-// --- helpers ---
-
-// pgMCPScanner is implemented by both *sql.Row and *sql.Rows.
-type pgMCPScanner interface {
-	Scan(dest ...any) error
-}
-
-func pgScanMCPInto(sc pgMCPScanner) (*ServerConfig, error) {
+// pgScanMCPInto scans a Postgres row into a ServerConfig.
+// Uses the scanner interface defined in store.go.
+func pgScanMCPInto(sc scanner) (*ServerConfig, error) {
 	var (
 		cfg               ServerConfig
 		command, url      sql.NullString

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -291,8 +291,7 @@ func (s *Store) seedBuiltins(ctx context.Context) error {
 		return s.pg.SeedBuiltins(ctx)
 	}
 
-	// Seed provider tools (claude, gemini, cursor, etc.)
-	for _, t := range builtinTools {
+	for _, t := range allBuiltins() {
 		t := t
 		existing, err := s.Get(ctx, t.Name)
 		if err != nil {
@@ -305,35 +304,16 @@ func (s *Store) seedBuiltins(ctx context.Context) error {
 			return fmt.Errorf("failed to seed %s: %w", t.Name, err)
 		}
 	}
-	// Seed MCP server tools (bc, playwright, github)
-	for _, t := range builtinMCPServers {
-		t := t
-		existing, err := s.Get(ctx, t.Name)
-		if err != nil {
-			return fmt.Errorf("failed to check MCP %s: %w", t.Name, err)
-		}
-		if existing != nil {
-			continue
-		}
-		if err := s.add(ctx, &t); err != nil {
-			return fmt.Errorf("failed to seed MCP %s: %w", t.Name, err)
-		}
-	}
-	// Seed CLI tools (gh, git, go, make, docker, etc.)
-	for _, t := range builtinCLITools {
-		t := t
-		existing, err := s.Get(ctx, t.Name)
-		if err != nil {
-			return fmt.Errorf("failed to check CLI %s: %w", t.Name, err)
-		}
-		if existing != nil {
-			continue
-		}
-		if err := s.add(ctx, &t); err != nil {
-			return fmt.Errorf("failed to seed CLI %s: %w", t.Name, err)
-		}
-	}
 	return nil
+}
+
+// allBuiltins returns all built-in tool definitions (providers, MCP servers, CLI tools).
+func allBuiltins() []Tool {
+	all := make([]Tool, 0, len(builtinTools)+len(builtinMCPServers)+len(builtinCLITools))
+	all = append(all, builtinTools...)
+	all = append(all, builtinMCPServers...)
+	all = append(all, builtinCLITools...)
+	return all
 }
 
 func marshalJSON(v any) (string, error) {
@@ -433,16 +413,22 @@ func (s *Store) Get(ctx context.Context, name string) (*Tool, error) {
 	}
 	row := s.db.QueryRowContext(ctx,
 		`SELECT `+allColumns+` FROM tools WHERE name = ?`, name)
-	return scanTool(row)
+	return scanToolFrom(row)
 }
 
-func scanTool(row *sql.Row) (*Tool, error) {
+// toolScanner is implemented by both *sql.Row and *sql.Rows.
+type toolScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanToolFrom scans a row into a Tool. Returns (nil, nil) for sql.ErrNoRows.
+func scanToolFrom(sc toolScanner) (*Tool, error) {
 	var t Tool
 	var toolType, installCmd, upgradeCmd, versionCmd sql.NullString
 	var transport, url, argsJSON, envJSON sql.NullString
 	var slashCmds, mcpServers, config sql.NullString
 	var healthStatus, lastChecked sql.NullString
-	if err := row.Scan(
+	if err := sc.Scan(
 		&t.Name, &toolType, &t.Command,
 		&installCmd, &upgradeCmd, &versionCmd,
 		&transport, &url, &argsJSON, &envJSON,
@@ -510,38 +496,11 @@ func (s *Store) ListWithOptions(ctx context.Context, opts ListOptions) ([]*Tool,
 
 	var tools []*Tool
 	for rows.Next() {
-		var t Tool
-		var toolType, installCmd, upgradeCmd, versionCmd sql.NullString
-		var transport, url, argsJSON, envJSON sql.NullString
-		var slashCmds, mcpServers, config sql.NullString
-		var healthStatus, lastChecked sql.NullString
-		if err := rows.Scan(
-			&t.Name, &toolType, &t.Command,
-			&installCmd, &upgradeCmd, &versionCmd,
-			&transport, &url, &argsJSON, &envJSON,
-			&slashCmds, &mcpServers, &config,
-			&healthStatus, &lastChecked,
-			&t.Builtin, &t.Enabled, &t.CreatedAt,
-		); err != nil {
-			return nil, err
+		t, scanErr := scanToolFrom(rows)
+		if scanErr != nil {
+			return nil, scanErr
 		}
-		t.Type = toolType.String
-		if t.Type == "" {
-			t.Type = ToolTypeProvider
-		}
-		t.InstallCmd = installCmd.String
-		t.UpgradeCmd = upgradeCmd.String
-		t.VersionCmd = versionCmd.String
-		t.Transport = transport.String
-		t.URL = url.String
-		t.Args = unmarshalStrings(argsJSON.String)
-		t.Env = unmarshalStringMap(envJSON.String)
-		t.SlashCmds = unmarshalStrings(slashCmds.String)
-		t.MCPServers = unmarshalStrings(mcpServers.String)
-		t.Config = unmarshalMap(config.String)
-		t.HealthStatus = healthStatus.String
-		t.LastChecked = lastChecked.String
-		tools = append(tools, &t)
+		tools = append(tools, t)
 	}
 	return tools, rows.Err()
 }

--- a/pkg/tool/store_postgres.go
+++ b/pkg/tool/store_postgres.go
@@ -68,7 +68,7 @@ func (p *PostgresStore) Close() error {
 
 // SeedBuiltins seeds built-in tools and MCP servers if they don't exist.
 func (p *PostgresStore) SeedBuiltins(ctx context.Context) error {
-	for _, t := range builtinTools {
+	for _, t := range allBuiltins() {
 		t := t
 		existing, err := p.Get(ctx, t.Name)
 		if err != nil {
@@ -79,32 +79,6 @@ func (p *PostgresStore) SeedBuiltins(ctx context.Context) error {
 		}
 		if err := p.add(ctx, &t); err != nil {
 			return fmt.Errorf("failed to seed %s: %w", t.Name, err)
-		}
-	}
-	for _, t := range builtinMCPServers {
-		t := t
-		existing, err := p.Get(ctx, t.Name)
-		if err != nil {
-			return fmt.Errorf("failed to check MCP %s: %w", t.Name, err)
-		}
-		if existing != nil {
-			continue
-		}
-		if err := p.add(ctx, &t); err != nil {
-			return fmt.Errorf("failed to seed MCP %s: %w", t.Name, err)
-		}
-	}
-	for _, t := range builtinCLITools {
-		t := t
-		existing, err := p.Get(ctx, t.Name)
-		if err != nil {
-			return fmt.Errorf("failed to check CLI %s: %w", t.Name, err)
-		}
-		if existing != nil {
-			continue
-		}
-		if err := p.add(ctx, &t); err != nil {
-			return fmt.Errorf("failed to seed CLI %s: %w", t.Name, err)
 		}
 	}
 	return nil
@@ -161,14 +135,20 @@ func (p *PostgresStore) Get(ctx context.Context, name string) (*Tool, error) {
 	row := p.db.QueryRowContext(ctx,
 		`SELECT name, type, command, install_cmd, upgrade_cmd, version_cmd, transport, url, slash_cmds, mcp_servers, config, builtin, enabled, created_at
 		 FROM tools WHERE name = $1`, name)
-	return pgScanTool(row)
+	return pgScanToolFrom(row)
 }
 
-func pgScanTool(row *sql.Row) (*Tool, error) {
+// pgToolScanner is implemented by both *sql.Row and *sql.Rows.
+type pgToolScanner interface {
+	Scan(dest ...any) error
+}
+
+// pgScanToolFrom scans a Postgres row into a Tool. Returns (nil, nil) for sql.ErrNoRows.
+func pgScanToolFrom(sc pgToolScanner) (*Tool, error) {
 	var t Tool
 	var toolType, installCmd, upgradeCmd, versionCmd, transport, url, slashCmds, mcpServers, config sql.NullString
 	var createdAt time.Time
-	if err := row.Scan(
+	if err := sc.Scan(
 		&t.Name, &toolType, &t.Command,
 		&installCmd, &upgradeCmd, &versionCmd,
 		&transport, &url,
@@ -205,29 +185,11 @@ func (p *PostgresStore) List(ctx context.Context) ([]*Tool, error) {
 
 	var tools []*Tool
 	for rows.Next() {
-		var t Tool
-		var toolType, installCmd, upgradeCmd, versionCmd, transport, url, slashCmds, mcpServers, config sql.NullString
-		var createdAt time.Time
-		if scanErr := rows.Scan(
-			&t.Name, &toolType, &t.Command,
-			&installCmd, &upgradeCmd, &versionCmd,
-			&transport, &url,
-			&slashCmds, &mcpServers, &config,
-			&t.Builtin, &t.Enabled, &createdAt,
-		); scanErr != nil {
+		t, scanErr := pgScanToolFrom(rows)
+		if scanErr != nil {
 			return nil, scanErr
 		}
-		t.CreatedAt = createdAt
-		t.Type = toolType.String
-		t.InstallCmd = installCmd.String
-		t.UpgradeCmd = upgradeCmd.String
-		t.VersionCmd = versionCmd.String
-		t.Transport = transport.String
-		t.URL = url.String
-		t.SlashCmds = unmarshalStrings(slashCmds.String)
-		t.MCPServers = unmarshalStrings(mcpServers.String)
-		t.Config = unmarshalMap(config.String)
-		tools = append(tools, &t)
+		tools = append(tools, t)
 	}
 	return tools, rows.Err()
 }


### PR DESCRIPTION
## Summary
- Consolidate three identical seeding loops (builtinTools, builtinMCPServers, builtinCLITools) into a single `allBuiltins()` helper in both SQLite and Postgres tool stores, removing ~60 lines of duplication
- Extract shared scanner interfaces (`toolScanner`, `pgToolScanner`) to eliminate duplicated scan-into-struct logic between `Get` and `List` methods in both store backends
- Remove duplicate `pgMCPScanner` interface in `mcp/store_postgres.go`, reusing the `scanner` interface already defined in `store.go`
- Inline trivial `containsTaskCreate`/`containsTaskUpdate` wrapper functions in `events/writer.go` (single `strings.Contains` calls that added no value)

Net reduction: **-92 lines** across 4 files with no behavior changes.

## Test plan
- [x] `go build ./pkg/mcp/... ./pkg/tool/... ./pkg/events/...` passes
- [x] `go vet ./pkg/mcp/... ./pkg/tool/... ./pkg/events/...` passes
- [x] `go test ./pkg/events/...` passes
- [ ] CI passes (lint, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal tool and event handling logic for improved code maintainability and consistency across storage operations. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->