### PR TITLE
refactor: rename Logs→Live, UnifiedTools→Tools, consolidate routes

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,12 +1,12 @@
 import { lazy, Suspense } from "react";
-import { BrowserRouter, Routes, Route, Link } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, Link } from "react-router-dom";
 import { Layout } from "./components/Layout";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ThemeProvider } from "./context/ThemeContext";
 
 // Lazy-loaded views — each gets its own chunk
-const Dashboard = lazy(() =>
-  import("./views/Dashboard").then((m) => ({ default: m.Dashboard })),
+const Live = lazy(() =>
+  import("./views/Live").then((m) => ({ default: m.Live })),
 );
 const Agents = lazy(() =>
   import("./views/Agents").then((m) => ({ default: m.Agents })),
@@ -21,13 +21,10 @@ const Roles = lazy(() =>
   import("./views/Roles").then((m) => ({ default: m.Roles })),
 );
 const Tools = lazy(() =>
-  import("./views/UnifiedTools").then((m) => ({ default: m.UnifiedTools })),
+  import("./views/Tools").then((m) => ({ default: m.Tools })),
 );
 const ProviderDetail = lazy(() =>
   import("./views/ProviderDetail").then((m) => ({ default: m.ProviderDetail })),
-);
-const Logs = lazy(() =>
-  import("./views/Logs").then((m) => ({ default: m.Logs })),
 );
 const Cron = lazy(() =>
   import("./views/Cron").then((m) => ({ default: m.Cron })),
@@ -54,8 +51,8 @@ function NotFound() {
     <div className="flex-1 flex flex-col items-center justify-center p-6">
       <p className="text-6xl font-bold font-mono text-bc-muted">404</p>
       <p className="mt-2 text-bc-muted">Page not found</p>
-      <Link to="/" className="mt-4 text-sm text-bc-accent hover:underline">
-        Back to Dashboard
+      <Link to="/live" className="mt-4 text-sm text-bc-accent hover:underline">
+        Back to Live
       </Link>
     </div>
   );
@@ -68,16 +65,19 @@ export function App() {
         <BrowserRouter>
           <Routes>
             <Route element={<Layout />}>
+              <Route index element={<Navigate to="/live" replace />} />
               <Route
-                index
+                path="live"
                 element={
                   <Suspense fallback={<Loading />}>
                     <ErrorBoundary>
-                      <Dashboard />
+                      <Live />
                     </ErrorBoundary>
                   </Suspense>
                 }
               />
+              {/* Backward compat: /logs redirects to /live */}
+              <Route path="logs" element={<Navigate to="/live" replace />} />
               <Route
                 path="agents"
                 element={
@@ -134,16 +134,6 @@ export function App() {
                   <Suspense fallback={<Loading />}>
                     <ErrorBoundary>
                       <ProviderDetail />
-                    </ErrorBoundary>
-                  </Suspense>
-                }
-              />
-              <Route
-                path="logs"
-                element={
-                  <Suspense fallback={<Loading />}>
-                    <ErrorBoundary>
-                      <Logs />
                     </ErrorBoundary>
                   </Suspense>
                 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -147,7 +147,7 @@ export interface Role {
   CLITools?: string[];
 }
 
-export interface Tool {
+export interface CLITool {
   name: string;
   command: string;
   install_cmd: string;
@@ -165,7 +165,7 @@ export interface MCPServer {
   enabled: boolean;
 }
 
-export interface UnifiedTool {
+export interface Tool {
   name: string;
   type: "provider" | "mcp" | "cli";
   status: string;
@@ -591,7 +591,7 @@ export const api = {
       method: "PATCH",
       body: JSON.stringify(config),
     }),
-  listTools: () => request<Tool[]>("/tools"),
+  listCLITools: () => request<CLITool[]>("/tools"),
   enableTool: (name: string) =>
     request<{ enabled: boolean }>(`/tools/${encodeURIComponent(name)}/enable`, {
       method: "POST",
@@ -620,16 +620,16 @@ export const api = {
       method: "POST",
     }),
 
-  /** Unified tool list — merges MCP + CLI tools with status. */
-  listUnifiedTools: () => request<UnifiedTool[]>("/tools/unified"),
+  /** Tool list — merges MCP + CLI tools with status. */
+  listTools: () => request<Tool[]>("/tools/unified"),
 
   /** Run live health checks on all tools. */
-  checkUnifiedTools: () =>
-    request<UnifiedTool[]>("/tools/unified/check", { method: "POST" }),
+  checkTools: () =>
+    request<Tool[]>("/tools/unified/check", { method: "POST" }),
 
   /** Create or update a CLI tool. */
-  upsertTool: (tool: Partial<Tool> & { name: string }) =>
-    request<Tool>(`/tools/${encodeURIComponent(tool.name)}`, {
+  upsertTool: (tool: Partial<CLITool> & { name: string }) =>
+    request<CLITool>(`/tools/${encodeURIComponent(tool.name)}`, {
       method: "PUT",
       body: JSON.stringify(tool),
     }),

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -32,7 +32,7 @@ function NavIcon({ name }: { name: string }) {
 }
 
 const MAIN_NAV_ITEMS = [
-  { to: "/", label: "Dashboard", icon: "dashboard" },
+  { to: "/live", label: "Live", icon: "live" },
   { to: "/agents", label: "Agents", icon: "agents" },
   { to: "/channels", label: "Channels", icon: "channels" },
   { to: "/roles", label: "Roles", icon: "roles" },
@@ -43,7 +43,6 @@ const MAIN_NAV_ITEMS = [
 ] as const;
 
 const UTIL_NAV_ITEMS = [
-  { to: "/logs", label: "Live", icon: "live" },
   { to: "/workspace", label: "Workspace", icon: "workspace" },
   { to: "/settings", label: "Settings", icon: "settings" },
 ] as const;
@@ -82,7 +81,7 @@ function NavList({
         <li key={to}>
           <NavLink
             to={to}
-            end={to === "/"}
+            end
             title={isIconOnly ? label : undefined}
             className={({ isActive }) =>
               `relative flex items-center gap-3 ${isIconOnly ? "justify-center px-2" : "px-4"} py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-inset transition-colors ${
@@ -143,9 +142,7 @@ export function Layout() {
   // Dynamic page title (#2150)
   useEffect(() => {
     const match = NAV_ITEMS.find((item) =>
-      item.to === "/"
-        ? location.pathname === "/"
-        : location.pathname.startsWith(item.to),
+      location.pathname.startsWith(item.to),
     );
     document.title = match ? `${match.label} \u2014 bc` : "bc";
   }, [location.pathname]);

--- a/web/src/hooks/useCommandPalette.ts
+++ b/web/src/hooks/useCommandPalette.ts
@@ -42,11 +42,11 @@ export function useCommandPalette() {
     () => [
       // Navigation
       {
-        id: "nav-dashboard",
-        label: "Dashboard",
+        id: "nav-live",
+        label: "Live",
         section: "Navigate",
         icon: "~",
-        action: () => navigate("/"),
+        action: () => navigate("/live"),
       },
       {
         id: "nav-agents",
@@ -102,7 +102,7 @@ export function useCommandPalette() {
         label: "Logs",
         section: "Navigate",
         icon: "L",
-        action: () => navigate("/logs"),
+        action: () => navigate("/live"),
       },
       {
         id: "nav-workspace",

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -40,7 +40,7 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
       .then((r) => setRoles(Object.keys(r)))
       .catch(() => { /* ignore */ });
     api
-      .listTools()
+      .listCLITools()
       .then((t) => setTools(t.filter((tool) => tool.enabled).map((tool) => tool.name)))
       .catch(() => { /* ignore */ });
   }, [open]);

--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -1645,9 +1645,9 @@ function updateTopLevelNode(
   return true;
 }
 
-/* ── Logs (Live Operations Center) ─────────────────────────────────── */
+/* ── Live (Live Operations Center) ─────────────────────────────────── */
 
-export function Logs() {
+export function Live() {
   const [activities, setActivities] = useState<Map<string, AgentActivity>>(new Map());
   const [agents, setAgents] = useState<Agent[]>([]);
   const [agentFilter, setAgentFilter] = useState("");

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -280,7 +280,7 @@ function MCPSection({
   const handleCheckAll = async () => {
     setChecking(true);
     try {
-      const tools = await api.checkUnifiedTools();
+      const tools = await api.checkTools();
       const mcpTools = tools.filter((t) => t.type === "mcp");
       const newMap: Record<string, { status: string; error?: string }> = {};
       for (const t of mcpTools) {

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
 import { api } from "../api/client";
-import type { UnifiedTool } from "../api/client";
+import type { Tool } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
@@ -23,7 +23,7 @@ const inputCls = "w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-
 function getStatusConfig(s: string) { return STATUS_CONFIG[s] ?? STATUS_CONFIG.unknown!; }
 
 function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, onExpand }: {
-  tool: UnifiedTool; onToggle: () => void; onRemove: () => void;
+  tool: Tool; onToggle: () => void; onRemove: () => void;
   toggling: boolean; removing: boolean; expanded: boolean; onExpand: () => void;
 }) {
   const [confirmRemove, setConfirmRemove] = useState(false);
@@ -177,15 +177,15 @@ function AddCLIToolForm({ onClose, onAdded, onToast }: { onClose: () => void; on
   );
 }
 
-export function UnifiedTools() {
+export function Tools() {
   const providerFetcher = useCallback(() => api.listProviders(), []);
   const { data: providers, loading: providersLoading } = usePolling(providerFetcher, 10000);
 
-  const fetcher = useCallback(() => api.listUnifiedTools(), []);
+  const fetcher = useCallback(() => api.listTools(), []);
   const { data: tools, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
   const [showAddForm, setShowAddForm] = useState(false);
   const [checking, setChecking] = useState(false);
-  const [checkedTools, setCheckedTools] = useState<UnifiedTool[] | null>(null);
+  const [checkedTools, setCheckedTools] = useState<Tool[] | null>(null);
   const [optimisticToggles, setOptimisticToggles] = useState<Map<string, string>>(new Map());
   const [togglingSet, setTogglingSet] = useState<Set<string>>(new Set());
   const [removingSet, setRemovingSet] = useState<Set<string>>(new Set());
@@ -196,7 +196,7 @@ export function UnifiedTools() {
   const handleCheck = async () => {
     setChecking(true);
     try {
-      const checked = await api.checkUnifiedTools();
+      const checked = await api.checkTools();
       const checkMap = new Map(checked.map((t) => [t.name, t]));
       setCheckedTools((tools ?? []).map((t) => {
         const c = checkMap.get(t.name);
@@ -222,7 +222,7 @@ export function UnifiedTools() {
   const allTools = useMemo(() => {
     const source = checkedTools ?? tools ?? [];
     const seen = new Set<string>();
-    const deduped: UnifiedTool[] = [];
+    const deduped: Tool[] = [];
     for (const t of source) {
       if (seen.has(t.name)) continue;
       seen.add(t.name);
@@ -235,7 +235,7 @@ export function UnifiedTools() {
   const searchLower = useMemo(() => search.toLowerCase().trim(), [search]);
 
   const { cliTools, filteredCli } = useMemo(() => {
-    const matchesSearch = (t: UnifiedTool) => !searchLower || t.name.toLowerCase().includes(searchLower);
+    const matchesSearch = (t: Tool) => !searchLower || t.name.toLowerCase().includes(searchLower);
     const cli = allTools.filter((t) => t.type !== "provider" && t.type !== "mcp");
     return {
       cliTools: cli,
@@ -263,7 +263,7 @@ export function UnifiedTools() {
   const totalCount = providerList.length + allTools.length;
   const matchCount = providerList.filter((p) => !searchLower || p.name.toLowerCase().includes(searchLower)).length + filteredCli.length;
 
-  const handleToggle = async (tool: UnifiedTool) => {
+  const handleToggle = async (tool: Tool) => {
     const wasDisabled = tool.status === "disabled" || tool.status === "not_installed";
     const newStatus = wasDisabled ? "installed" : "disabled";
     const oldStatus = tool.status;
@@ -292,7 +292,7 @@ export function UnifiedTools() {
     }
   };
 
-  const handleRemove = async (tool: UnifiedTool) => {
+  const handleRemove = async (tool: Tool) => {
     setRemovingSet((prev) => new Set(prev).add(tool.name));
     try {
       await api.deleteTool(tool.name);

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -5,8 +5,8 @@ import { Dashboard } from "../Dashboard";
 import { Agents } from "../Agents";
 import { Channels } from "../Channels";
 import { Roles } from "../Roles";
-import { UnifiedTools } from "../UnifiedTools";
-import { Logs } from "../Logs";
+import { Tools } from "../Tools";
+import { Live } from "../Live";
 import { Cron } from "../Cron";
 import { Secrets } from "../Secrets";
 import { Workspace } from "../Workspace";
@@ -146,7 +146,7 @@ describe("Roles", () => {
   });
 });
 
-describe("UnifiedTools", () => {
+describe("Tools", () => {
   it("renders skeleton loading then tool list", async () => {
     fetchMock.mockReturnValue(
       jsonResponse([
@@ -165,7 +165,7 @@ describe("UnifiedTools", () => {
         },
       ]),
     );
-    const { container } = wrap(<UnifiedTools />);
+    const { container } = wrap(<Tools />);
     expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText("my-tool")).toBeInTheDocument();
@@ -173,7 +173,7 @@ describe("UnifiedTools", () => {
   });
 });
 
-describe("Logs", () => {
+describe("Live", () => {
   it("renders skeleton loading then event log", async () => {
     fetchMock.mockReturnValue(
       jsonResponse([
@@ -186,7 +186,7 @@ describe("Logs", () => {
         },
       ]),
     );
-    const { container } = wrap(<Logs />);
+    const { container } = wrap(<Live />);
     expectSkeletonLoading(container);
     await waitFor(() => {
       expect(screen.getByText("Event Log")).toBeInTheDocument();
@@ -195,7 +195,7 @@ describe("Logs", () => {
 
   it("renders empty state when no logs", async () => {
     fetchMock.mockReturnValue(jsonResponse([]));
-    wrap(<Logs />);
+    wrap(<Live />);
     await waitFor(() => {
       expect(screen.getByText("No events recorded yet")).toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary
- Rename `Logs.tsx` → `Live.tsx` and `UnifiedTools.tsx` → `Tools.tsx` with updated exports
- Default route `/` now redirects to `/live`; `/logs` redirects to `/live` for backward compat
- Sidebar updated: Live is first nav item, Dashboard removed as separate entry
- API client types cleaned up: `UnifiedTool` → `Tool`, `Tool` → `CLITool`
- All imports, callers, command palette, and test files updated

## Changes
| File | Change |
|------|--------|
| `web/src/views/Logs.tsx` → `Live.tsx` | Renamed file and export |
| `web/src/views/UnifiedTools.tsx` → `Tools.tsx` | Renamed file and export |
| `web/src/App.tsx` | Updated imports, routes, redirects |
| `web/src/api/client.ts` | Type and method renames |
| `web/src/components/Layout.tsx` | Sidebar nav restructured |
| `web/src/hooks/useCommandPalette.ts` | Updated nav targets |
| `web/src/views/Agents.tsx` | Updated API call |
| `web/src/views/ProviderDetail.tsx` | Updated API call |
| `web/src/views/__tests__/views.test.tsx` | Updated imports and test names |

## Test plan
- [x] `bun run build` passes with no TypeScript errors
- [x] `go build ./...` passes
- [ ] Manual: verify `/` redirects to `/live`
- [ ] Manual: verify `/logs` redirects to `/live`
- [ ] Manual: verify sidebar shows Live as first item
- [ ] Manual: verify Tools page loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)