### PR TITLE
fix: resolve 4 frontend bugs from Codex agent audit

### DIFF
--- a/web/src/components/StatsTab.tsx
+++ b/web/src/components/StatsTab.tsx
@@ -37,7 +37,10 @@ const fmtBytes = (b: number) => {
   const i = Math.floor(Math.log(b) / Math.log(1024));
   return `${(b / Math.pow(1024, i)).toFixed(1)} ${u[i]}`;
 };
-const fmtMB = (b: number) => (b / 1024 / 1024).toFixed(1);
+const fmtMB = (b: number) => {
+  if (!b || !isFinite(b)) return "0.0";
+  return (b / 1024 / 1024).toFixed(1);
+};
 const fmtTokens = (n: number) => {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
@@ -153,13 +156,13 @@ export function StatsTab({ agent }: { agent: Agent }) {
 
   // ── Summary values ─────────────────────────────────────────────────────────
 
-  const cpuAvg = s?.cpu_avg ?? 0;
-  const cpuMax = s?.cpu_max ?? 0;
-  const memAvgMB = s ? parseFloat(fmtMB(s.mem_avg_bytes)) : 0;
-  const memMaxMB = s ? parseFloat(fmtMB(s.mem_max_bytes)) : 0;
+  const cpuAvg = isFinite(s?.cpu_avg ?? 0) ? (s?.cpu_avg ?? 0) : 0;
+  const cpuMax = isFinite(s?.cpu_max ?? 0) ? (s?.cpu_max ?? 0) : 0;
+  const memAvgMB = s ? parseFloat(fmtMB(s.mem_avg_bytes)) || 0 : 0;
+  const memMaxMB = s ? parseFloat(fmtMB(s.mem_max_bytes)) || 0 : 0;
   const totalIn = s?.input_tokens ?? 0;
   const totalOut = s?.output_tokens ?? 0;
-  const totalCost = s?.total_cost_usd ?? 0;
+  const totalCost = isFinite(s?.total_cost_usd ?? 0) ? (s?.total_cost_usd ?? 0) : 0;
 
   // ── Render ─────────────────────────────────────────────────────────────────
 

--- a/web/src/utils/text.ts
+++ b/web/src/utils/text.ts
@@ -1,13 +1,9 @@
-/** Strip ANSI escape codes (CSI, OSC, charset) from terminal output. */
+/** Strip ANSI escape codes (CSI, OSC, charset, DEC private mode) from terminal output. */
 // eslint-disable-next-line no-control-regex
-const CSI = /\x1b\[[0-9;]*[a-zA-Z]/g;
-// eslint-disable-next-line no-control-regex
-const OSC = /\x1b\][^\x07]*\x07/g;
-// eslint-disable-next-line no-control-regex
-const CHARSET = /\x1b\(B/g;
+const ANSI_RE = /\x1b\[[0-9;]*[a-zA-Z]|\x1b\].*?(?:\x07|\x1b\\)|\x1b[()][0-9A-Z]|\x1b\[\??[0-9;]*[hlm]/g;
 
 export function stripAnsi(str: string): string {
-  return str.replace(CSI, "").replace(OSC, "").replace(CHARSET, "");
+  return str.replace(ANSI_RE, "");
 }
 
 /** Truncate string to maxLen characters with ellipsis. */

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -7,15 +7,7 @@ import { useWebSocket } from "../hooks/useWebSocket";
 import { StatusBadge } from "../components/StatusBadge";
 import { StatsTab as StatsTabComponent } from "../components/StatsTab";
 import { WebTerminal } from "../components/WebTerminal";
-
-/** Strip ANSI escape sequences from a string. */
-function stripAnsi(s: string): string {
-  return s.replace(
-    // eslint-disable-next-line no-control-regex
-    /\x1b(?:\[[0-9;]*[A-Za-z]|\].*?(?:\x07|\x1b\\)|\([A-B0-2])/g,
-    "",
-  );
-}
+import { stripAnsi } from "../utils/text";
 
 function RoleBadge({ role }: { role: string }) {
   return (

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -134,9 +134,29 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
             className="w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
           >
             <option value="">Default</option>
-            {tools.map((t) => (
-              <option key={t} value={t}>{t}</option>
-            ))}
+            {(() => {
+              const AI_PROVIDERS = new Set(["claude", "codex", "cursor", "gemini", "aider", "openclaw", "opencode"]);
+              const providers = tools.filter((t) => AI_PROVIDERS.has(t));
+              const cliTools = tools.filter((t) => !AI_PROVIDERS.has(t));
+              return (
+                <>
+                  {providers.length > 0 && (
+                    <optgroup label="AI Providers">
+                      {providers.map((t) => (
+                        <option key={t} value={t}>{t}</option>
+                      ))}
+                    </optgroup>
+                  )}
+                  {cliTools.length > 0 && (
+                    <optgroup label="CLI Tools">
+                      {cliTools.map((t) => (
+                        <option key={t} value={t}>{t}</option>
+                      ))}
+                    </optgroup>
+                  )}
+                </>
+              );
+            })()}
           </select>
         </div>
 
@@ -580,7 +600,7 @@ export function Agents() {
                     <td className="px-4 py-2 hidden md:table-cell">
                       <div className="flex flex-wrap gap-1">
                         {(a.mcp_servers ?? []).length === 0 ? (
-                          <span className="text-bc-muted">u2014</span>
+                          <span className="text-bc-muted">{"\u2014"}</span>
                         ) : (a.mcp_servers ?? []).length <= 3 ? (
                           (a.mcp_servers ?? []).map((s) => (
                             <span key={s} className="text-[10px] px-1.5 py-0.5 rounded bg-bc-accent/10 text-bc-accent font-medium">


### PR DESCRIPTION
## Summary
- **NaN MB on Stats tab (#194)**: Add `isFinite` guards to `fmtMB`, `cpuAvg`, `cpuMax`, and `totalCost` in `StatsTab.tsx` so undefined/NaN values display as `0` instead of `NaN MB`
- **MCP column shows "u2014" (#195)**: Fix literal string `"u2014"` to proper Unicode escape `"\u2014"` (em dash) in `Agents.tsx` MCP column
- **ANSI escape codes in agent logs (#198)**: Consolidate and improve the `stripAnsi` regex in `utils/text.ts` to handle DEC private mode sequences and all charset escapes; remove duplicate local function from `AgentDetail.tsx`
- **Categorize Tool dropdown (#201)**: Separate AI providers (claude, codex, cursor, gemini, aider, openclaw, opencode) from CLI tools using `<optgroup>` elements in the create agent form

## Test plan
- [ ] Open Stats tab for an agent with no metrics -- verify "0.0 MB" instead of "NaN MB"
- [ ] Check Agents table MCP column for agents with no MCP servers -- verify em dash renders correctly
- [ ] View agent logs with ANSI-colored output -- verify no escape sequences visible
- [ ] Open Create Agent form -- verify Tool dropdown shows "AI Providers" and "CLI Tools" groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of numeric value handling in statistics display to prevent invalid data from showing incorrectly.

* **New Features**
  * Tools selection dropdown now organized into categorized groups: "AI Providers" and "CLI Tools" for easier navigation.

* **Improvements**
  * Enhanced output text sanitization for cleaner display of special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->