### PR TITLE
feat: add Runtime field to agent detail Overview tab

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -37,6 +37,7 @@ export interface Agent {
   parent_id?: string;
   children?: string[];
   total_tokens?: number;
+  runtime_backend?: string;
   mcp_servers?: string[];
 }
 

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -123,6 +123,7 @@ function OverviewTab({ agent }: { agent: Agent }) {
             value={<StatusBadge status={agent.state} />}
           />
           <MetadataRow label="Tool" value={agent.tool || "\u2014"} />
+          <MetadataRow label="Runtime" value={agent.runtime_backend || "\u2014"} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Add `runtime_backend` optional field to the `Agent` TypeScript interface in `web/src/api/client.ts`
- Display a "Runtime" row (tmux/docker) in the Identity section of the Overview tab in `AgentDetail.tsx`

## Test plan
- [ ] Open agent detail page, switch to Overview tab, verify Runtime field shows tmux or docker
- [ ] Verify build passes: `cd web && bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime backend information display in agent details view, showing the configured runtime backend for each agent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->