### PR TITLE
fix: codex version/update-prompt and role name normalization

### DIFF
--- a/pkg/provider/codex.go
+++ b/pkg/provider/codex.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"regexp"
 	"strings"
 )
 
@@ -54,8 +55,10 @@ func (p *CodexProvider) InstallHint() string {
 }
 
 // BuildCommand returns the full command for a given runtime context.
+// Pipes /dev/null to stdin and sets NO_UPDATE_NOTIFIER to suppress
+// interactive update prompts that would block a headless agent.
 func (p *CodexProvider) BuildCommand(_ CommandOpts) string {
-	return p.command
+	return "NO_UPDATE_NOTIFIER=1 " + p.command + " </dev/null"
 }
 
 // IsInstalled checks if the provider binary is available.
@@ -63,9 +66,17 @@ func (p *CodexProvider) IsInstalled(ctx context.Context) bool {
 	return checkBinaryExists(ctx, p.binary)
 }
 
-// Version returns the installed version.
+// codexVersionRe extracts a semver-like version from codex --version output
+// which may look like "codex-cli 0.111.0" or "v0.111.0".
+var codexVersionRe = regexp.MustCompile(`(\d+\.\d+\.\d+)`)
+
+// Version returns the installed version, stripped of any prefix like "codex-cli".
 func (p *CodexProvider) Version(ctx context.Context) string {
-	return getBinaryVersion(ctx, p.binary, "--version")
+	raw := getBinaryVersion(ctx, p.binary, "--version")
+	if m := codexVersionRe.FindString(raw); m != "" {
+		return m
+	}
+	return raw
 }
 
 // DetectState analyzes output to determine agent state.
@@ -82,12 +93,12 @@ func (p *CodexProvider) DetectState(output string) State {
 		lineLower := strings.ToLower(line)
 
 		// Working indicators - Codex spinner patterns
-		if strings.HasPrefix(line, "⠋") ||
-			strings.HasPrefix(line, "⠙") ||
-			strings.HasPrefix(line, "⠹") ||
-			strings.HasPrefix(line, "⠸") ||
-			strings.HasPrefix(line, "⠼") ||
-			strings.HasPrefix(line, "⠴") ||
+		if strings.HasPrefix(line, "\u280b") ||
+			strings.HasPrefix(line, "\u2819") ||
+			strings.HasPrefix(line, "\u2839") ||
+			strings.HasPrefix(line, "\u2838") ||
+			strings.HasPrefix(line, "\u283c") ||
+			strings.HasPrefix(line, "\u2834") ||
 			strings.Contains(lineLower, "generating") ||
 			strings.Contains(lineLower, "thinking") ||
 			strings.Contains(lineLower, "processing") ||
@@ -96,8 +107,8 @@ func (p *CodexProvider) DetectState(output string) State {
 		}
 
 		// Done indicators
-		if strings.Contains(line, "✓") ||
-			strings.Contains(line, "✔") ||
+		if strings.Contains(line, "\u2713") ||
+			strings.Contains(line, "\u2714") ||
 			strings.Contains(lineLower, "complete") ||
 			strings.Contains(lineLower, "finished") ||
 			strings.Contains(lineLower, "done") ||
@@ -109,8 +120,8 @@ func (p *CodexProvider) DetectState(output string) State {
 		if strings.Contains(lineLower, "error") ||
 			strings.Contains(lineLower, "failed") ||
 			strings.Contains(lineLower, "exception") ||
-			strings.Contains(line, "✗") ||
-			strings.Contains(line, "✖") {
+			strings.Contains(line, "\u2717") ||
+			strings.Contains(line, "\u2716") {
 			return StateError
 		}
 

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -812,7 +812,7 @@ func TestProviderBuildCommand(t *testing.T) {
 		{"claude with agent", "claude --dangerously-skip-permissions", NewClaudeProvider(), CommandOpts{AgentName: "eng-01"}},
 		{"gemini no opts", "gemini --yolo", NewGeminiProvider(), CommandOpts{}},
 		{"gemini with agent", "gemini --yolo", NewGeminiProvider(), CommandOpts{AgentName: "eng-01"}},
-		{"codex no opts", "codex --full-auto", NewCodexProvider(), CommandOpts{}},
+		{"codex no opts", "NO_UPDATE_NOTIFIER=1 codex --full-auto </dev/null", NewCodexProvider(), CommandOpts{}},
 		{"aider no opts", "aider --yes", NewAiderProvider(), CommandOpts{}},
 	}
 

--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -371,8 +371,17 @@ func (rm *RoleManager) EnsureDefaultRoot() (bool, error) {
 	return true, nil
 }
 
+// NormalizeRoleName canonicalises a role name by replacing underscores
+// with hyphens and lower-casing, preventing duplicates like
+// "product_manager" vs "product-manager".
+func NormalizeRoleName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(name, "_", "-"))
+}
+
 // LoadRole loads and parses a single role from the SQL store.
 func (rm *RoleManager) LoadRole(name string) (*Role, error) {
+	name = NormalizeRoleName(name)
+
 	// Check cache first
 	if role, ok := rm.roles[name]; ok {
 		return role, nil
@@ -415,6 +424,8 @@ func (rm *RoleManager) GetRole(name string) (*Role, bool) {
 
 // HasRole checks if a role exists (cached or in store).
 func (rm *RoleManager) HasRole(name string) bool {
+	name = NormalizeRoleName(name)
+
 	// Check cache
 	if _, ok := rm.roles[name]; ok {
 		return true
@@ -480,10 +491,11 @@ func ParseRoleFile(data []byte) (*Role, error) {
 
 // WriteRole writes a role to the SQL store.
 func (rm *RoleManager) WriteRole(role *Role) error {
-	name := role.Metadata.Name
+	name := NormalizeRoleName(role.Metadata.Name)
 	if name == "" {
 		return fmt.Errorf("role name is required")
 	}
+	role.Metadata.Name = name
 
 	if rm.store == nil {
 		return fmt.Errorf("role store is required")
@@ -575,6 +587,7 @@ func (rm *RoleManager) ResolveRole(name string) (*ResolvedRole, error) {
 
 // DeleteRole removes a role by name from the SQL store.
 func (rm *RoleManager) DeleteRole(name string) error {
+	name = NormalizeRoleName(name)
 	if name == "" {
 		return fmt.Errorf("role name is required")
 	}


### PR DESCRIPTION
## Summary
- **Codex version string (#196)**: Extract semver from `codex --version` output that includes "codex-cli" prefix (e.g. "codex-cli 0.111.0" → "0.111.0") using a regex
- **Codex update prompt (#197)**: Set `NO_UPDATE_NOTIFIER=1` env var and redirect stdin from `/dev/null` in `BuildCommand()` to prevent interactive update prompts from blocking headless agents
- **Role name normalization (#199)**: Add `NormalizeRoleName()` that lowercases and converts underscores to hyphens, applied in `LoadRole`, `HasRole`, `WriteRole`, and `DeleteRole` to prevent duplicates like "product_manager" vs "product-manager"

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `TestCodexProvider` and `TestProviderBuildCommand` pass with updated expectations
- [x] `TestRoleStore*` and `TestRoleManager*` pass with normalization in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role names are now automatically normalized to lowercase with underscores converted to hyphens.

* **Improvements**
  * Version detection for Codex provider now properly extracts semantic version information.
  * State detection enhanced with expanded Unicode character support.
  * Command execution environment updated with new settings and stdin redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->