### PR TITLE
fix: codex update prompt, duplicate roles, and runtime field mismatch

### DIFF
--- a/pkg/provider/codex.go
+++ b/pkg/provider/codex.go
@@ -55,10 +55,10 @@ func (p *CodexProvider) InstallHint() string {
 }
 
 // BuildCommand returns the full command for a given runtime context.
-// Pipes /dev/null to stdin and sets NO_UPDATE_NOTIFIER to suppress
-// interactive update prompts that would block a headless agent.
+// Pipes "n" to stdin via echo so any interactive update prompt is
+// automatically declined, and sets NO_UPDATE_NOTIFIER=1 as a belt-and-suspenders measure.
 func (p *CodexProvider) BuildCommand(_ CommandOpts) string {
-	return "NO_UPDATE_NOTIFIER=1 " + p.command + " </dev/null"
+	return "echo n | NO_UPDATE_NOTIFIER=1 " + p.command
 }
 
 // IsInstalled checks if the provider binary is available.

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -78,7 +78,7 @@ type agentDTO struct {
 	Task         string           `json:"task,omitempty"`
 	Team         string           `json:"team,omitempty"`
 	Tool         string           `json:"tool,omitempty"`
-	Runtime      string           `json:"runtime,omitempty"`
+	Runtime      string           `json:"runtime_backend,omitempty"`
 	Session      string           `json:"session,omitempty"`
 	SessionID    string           `json:"session_id,omitempty"`
 	ParentID     string           `json:"parent_id,omitempty"`

--- a/server/handlers/roles.go
+++ b/server/handlers/roles.go
@@ -79,10 +79,16 @@ func (h *RolesHandler) list(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Deduplicate roles by normalized name to prevent duplicates
+		// like "product_manager" vs "product-manager".
 		resolved := make(map[string]*workspace.ResolvedRole, len(roles))
 		for name := range roles {
+			normalized := workspace.NormalizeRoleName(name)
+			if _, exists := resolved[normalized]; exists {
+				continue // already have this role under normalized name
+			}
 			if res, resolveErr := h.ws.RoleManager.ResolveRole(name); resolveErr == nil {
-				resolved[name] = res
+				resolved[normalized] = res
 			}
 		}
 		writeJSON(w, http.StatusOK, resolved)


### PR DESCRIPTION
## Summary
- **Codex update prompt**: `NO_UPDATE_NOTIFIER=1` alone doesn't suppress the interactive update check. Now pipes `echo n` to auto-decline.
- **Duplicate roles in dropdown**: The roles list API now deduplicates by normalized name (e.g. `product_manager` and `product-manager` collapse to one entry).
- **Runtime field shows "--"**: The agent DTO JSON tag was `"runtime"` but the TypeScript `Agent` interface expects `"runtime_backend"`. Fixed the Go tag to match.
- **Tool optgroup headers**: Already present in `Agents.tsx` — confirmed no change needed (PR #2914 was not lost).

## Test plan
- [ ] Verify `codex --full-auto` no longer blocks on update prompt in headless mode
- [ ] Create a role with underscores, confirm no duplicate appears in create agent dropdown
- [ ] Check agent detail Overview tab shows correct runtime value instead of "--"
- [ ] Verify Go builds: `go build ./...`
- [ ] Verify web builds: `cd web && bun run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed role name handling by implementing deduplication and normalization in the roles API.

* **Refactor**
  * Updated agent response field names for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->