### PR TITLE
feat: polish Tools and Provider pages UI/UX redesign

### DIFF
--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -1,0 +1,55 @@
+import { useState, useCallback } from "react";
+
+interface CopyButtonProps {
+  text: string;
+  className?: string;
+}
+
+export function CopyButton({ text, className = "" }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Fallback: noop
+    }
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        void handleCopy();
+      }}
+      className={`inline-flex items-center justify-center w-6 h-6 rounded transition-colors hover:bg-bc-surface-hover focus-visible:ring-2 focus-visible:ring-bc-accent ${className}`}
+      aria-label={copied ? "Copied" : "Copy to clipboard"}
+    >
+      {copied ? (
+        <svg
+          className="w-3.5 h-3.5 text-bc-success"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2.5}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      ) : (
+        <svg
+          className="w-3.5 h-3.5 text-bc-muted hover:text-bc-text"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <rect x="9" y="9" width="13" height="13" rx="2" />
+          <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/web/src/components/ProviderCard.tsx
+++ b/web/src/components/ProviderCard.tsx
@@ -1,0 +1,87 @@
+import { motion } from "framer-motion";
+import type { ProviderInfo } from "../api/client";
+import { formatCost, formatTokens } from "../utils/format";
+
+interface ProviderCardProps {
+  provider: ProviderInfo;
+  onClick: () => void;
+}
+
+export function ProviderCard({ provider, onClick }: ProviderCardProps) {
+  const letter = provider.name.charAt(0).toUpperCase();
+  const isActive = provider.installed && provider.agent_count > 0;
+  const isInstalled = provider.installed;
+
+  return (
+    <motion.div
+      whileHover={{ y: -1 }}
+      transition={{ type: "spring", stiffness: 400, damping: 25 }}
+      onClick={onClick}
+      className="group rounded-lg border border-bc-border bg-bc-surface p-4 cursor-pointer hover:border-bc-accent/40 hover:bg-bc-surface-hover transition-colors"
+    >
+      <div className="flex items-start gap-3">
+        {/* Monogram */}
+        <div className="flex-shrink-0 w-10 h-10 rounded-full bg-bc-accent/20 flex items-center justify-center">
+          <span className="text-sm font-bold text-bc-accent">{letter}</span>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          {/* Name + status */}
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-sm text-bc-text truncate">
+              {provider.name}
+            </span>
+            <span className="relative flex h-2 w-2 shrink-0">
+              {isActive && (
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-bc-success opacity-75" />
+              )}
+              <span
+                className={`relative inline-flex rounded-full h-2 w-2 ${
+                  isActive
+                    ? "bg-bc-success"
+                    : isInstalled
+                      ? "bg-bc-muted"
+                      : "bg-bc-error"
+                }`}
+              />
+            </span>
+          </div>
+
+          {/* Version badge */}
+          {provider.version && (
+            <span className="inline-block mt-1 px-1.5 py-0.5 rounded text-xs font-mono bg-bc-surface border border-bc-border text-bc-muted">
+              v{provider.version}
+            </span>
+          )}
+        </div>
+
+        {/* Arrow */}
+        <svg
+          className="w-4 h-4 text-bc-muted opacity-0 group-hover:opacity-100 transition-opacity shrink-0 mt-1"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </div>
+
+      {/* Chips row */}
+      <div className="flex items-center gap-2 mt-3 flex-wrap">
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-bc-accent/10 text-bc-accent">
+          <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+          {provider.agent_count}
+        </span>
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-bc-info/10 text-bc-info tabular-nums">
+          {formatTokens(provider.total_tokens)} tok
+        </span>
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-bc-success/10 text-bc-success tabular-nums">
+          {formatCost(provider.total_cost_usd)}
+        </span>
+      </div>
+    </motion.div>
+  );
+}

--- a/web/src/components/ProvidersTable.tsx
+++ b/web/src/components/ProvidersTable.tsx
@@ -3,9 +3,11 @@ import { useNavigate } from "react-router-dom";
 import type { ProviderInfo } from "../api/client";
 import { formatCost, formatTokens } from "../utils/format";
 import { EmptyState } from "./EmptyState";
+import { ProviderCard } from "./ProviderCard";
 
 type SortKey = "name" | "status" | "version" | "agent_count" | "total_tokens" | "total_cost_usd";
 type SortDir = "asc" | "desc";
+type ViewMode = "cards" | "table";
 
 function statusOrder(p: ProviderInfo): number {
   if (p.installed && p.agent_count > 0) return 0; // active
@@ -23,6 +25,63 @@ function StatusDot({ provider }: { provider: ProviderInfo }) {
   return <span className="inline-flex items-center gap-1.5 text-bc-muted"><span className="w-2 h-2 rounded-full bg-bc-muted inline-block" /> Idle</span>;
 }
 
+/* ── Sort dropdown for card mode ── */
+function SortDropdown({ sortKey, sortDir, onSort }: { sortKey: SortKey; sortDir: SortDir; onSort: (key: SortKey) => void }) {
+  const options: { key: SortKey; label: string }[] = [
+    { key: "name", label: "Name" },
+    { key: "status", label: "Status" },
+    { key: "agent_count", label: "Agents" },
+    { key: "total_cost_usd", label: "Cost" },
+    { key: "total_tokens", label: "Tokens" },
+  ];
+
+  return (
+    <select
+      value={sortKey}
+      onChange={(e) => onSort(e.target.value as SortKey)}
+      className="text-xs px-2 py-1 rounded border border-bc-border bg-bc-bg text-bc-muted focus:outline-none focus:ring-1 focus:ring-bc-accent"
+      aria-label="Sort providers"
+    >
+      {options.map((o) => (
+        <option key={o.key} value={o.key}>
+          {o.label} {sortKey === o.key ? (sortDir === "asc" ? "\u2191" : "\u2193") : ""}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/* ── View mode toggle icons ── */
+function ViewToggle({ mode, onChange }: { mode: ViewMode; onChange: (m: ViewMode) => void }) {
+  return (
+    <div className="flex items-center border border-bc-border rounded overflow-hidden">
+      <button
+        type="button"
+        onClick={() => onChange("cards")}
+        className={`p-1.5 transition-colors ${mode === "cards" ? "bg-bc-accent/10 text-bc-accent" : "text-bc-muted hover:text-bc-text"}`}
+        aria-label="Card view"
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <rect x="3" y="3" width="7" height="7" rx="1" />
+          <rect x="14" y="3" width="7" height="7" rx="1" />
+          <rect x="3" y="14" width="7" height="7" rx="1" />
+          <rect x="14" y="14" width="7" height="7" rx="1" />
+        </svg>
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("table")}
+        className={`p-1.5 transition-colors ${mode === "table" ? "bg-bc-accent/10 text-bc-accent" : "text-bc-muted hover:text-bc-text"}`}
+        aria-label="Table view"
+      >
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" d="M3 6h18M3 12h18M3 18h18" />
+        </svg>
+      </button>
+    </div>
+  );
+}
+
 interface Props {
   providers: ProviderInfo[];
   search: string;
@@ -31,6 +90,7 @@ interface Props {
 export function ProvidersTable({ providers, search }: Props) {
   const [sortKey, setSortKey] = useState<SortKey>("name");
   const [sortDir, setSortDir] = useState<SortDir>("asc");
+  const [viewMode, setViewMode] = useState<ViewMode>("cards");
   const navigate = useNavigate();
 
   const filtered = useMemo(() => {
@@ -102,65 +162,92 @@ export function ProvidersTable({ providers, search }: Props) {
   ];
 
   return (
-    <div className="rounded border border-bc-border overflow-hidden">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-bc-border bg-bc-surface">
-            {columns.map((col) => (
-              <th
-                key={col.key}
-                onClick={(e) => { e.stopPropagation(); e.preventDefault(); toggleSort(col.key); }}
-                className={`px-4 py-2 font-medium text-bc-muted cursor-pointer select-none hover:text-bc-text transition-colors text-left ${col.className ?? ""}`}
-              >
-                {col.label}{sortIndicator(col.key)}
-              </th>
-            ))}
-            <th className="px-4 py-2 font-medium text-bc-muted text-right">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
+    <div>
+      {/* Controls row */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <ViewToggle mode={viewMode} onChange={setViewMode} />
+          {viewMode === "cards" && (
+            <SortDropdown sortKey={sortKey} sortDir={sortDir} onSort={toggleSort} />
+          )}
+        </div>
+        <span className="text-xs text-bc-muted">{sorted.length} provider{sorted.length !== 1 ? "s" : ""}</span>
+      </div>
+
+      {/* Card grid view */}
+      {viewMode === "cards" ? (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           {sorted.map((p) => (
-            <tr
+            <ProviderCard
               key={p.name}
+              provider={p}
               onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
-              className="border-b border-bc-border/50 cursor-pointer hover:bg-bc-surface transition-colors"
-            >
-              <td className="px-4 py-2.5 font-medium">{p.name}</td>
-              <td className="px-4 py-2.5 text-xs"><StatusDot provider={p} /></td>
-              <td className="px-4 py-2.5 text-xs text-bc-muted font-mono">{p.version || "\u2014"}</td>
-              <td className="px-4 py-2.5 text-right tabular-nums">{p.agent_count}</td>
-              <td className="px-4 py-2.5 text-right tabular-nums text-bc-muted">{formatTokens(p.total_tokens)}</td>
-              <td className="px-4 py-2.5 text-right tabular-nums">{formatCost(p.total_cost_usd)}</td>
-              <td className="px-4 py-2.5 text-right">
-                <div className="flex items-center justify-end gap-1.5" onClick={(e) => e.stopPropagation()}>
-                  {!p.installed && p.install_hint && (
-                    <button
-                      type="button"
-                      onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
-                      className="text-xs px-2 py-0.5 rounded bg-bc-warning/10 text-bc-warning hover:bg-bc-warning/20 transition-colors"
-                    >
-                      Install
-                    </button>
-                  )}
-                  {p.installed && p.install_hint && (
-                    <span className="text-xs px-2 py-0.5 rounded bg-bc-info/10 text-bc-info">
-                      Update
-                    </span>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
-                    className="text-xs px-1.5 py-0.5 rounded border border-bc-border text-bc-muted hover:text-bc-text hover:border-bc-accent/50 transition-colors"
-                    aria-label={`Configure ${p.name}`}
-                  >
-                    &#9881;
-                  </button>
-                </div>
-              </td>
-            </tr>
+            />
           ))}
-        </tbody>
-      </table>
+        </div>
+      ) : (
+        /* Table view */
+        <div className="rounded border border-bc-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-bc-border bg-bc-surface">
+                {columns.map((col) => (
+                  <th
+                    key={col.key}
+                    onClick={(e) => { e.stopPropagation(); e.preventDefault(); toggleSort(col.key); }}
+                    className={`px-4 py-2 font-medium text-bc-muted cursor-pointer select-none hover:text-bc-text transition-colors text-left ${col.className ?? ""}`}
+                  >
+                    {col.label}{sortIndicator(col.key)}
+                  </th>
+                ))}
+                <th className="px-4 py-2 font-medium text-bc-muted text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((p) => (
+                <tr
+                  key={p.name}
+                  onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+                  className="border-b border-bc-border/50 cursor-pointer hover:bg-bc-surface transition-colors"
+                >
+                  <td className="px-4 py-2.5 font-medium">{p.name}</td>
+                  <td className="px-4 py-2.5 text-xs"><StatusDot provider={p} /></td>
+                  <td className="px-4 py-2.5 text-xs text-bc-muted font-mono">{p.version || "\u2014"}</td>
+                  <td className="px-4 py-2.5 text-right tabular-nums">{p.agent_count}</td>
+                  <td className="px-4 py-2.5 text-right tabular-nums text-bc-muted">{formatTokens(p.total_tokens)}</td>
+                  <td className="px-4 py-2.5 text-right tabular-nums">{formatCost(p.total_cost_usd)}</td>
+                  <td className="px-4 py-2.5 text-right">
+                    <div className="flex items-center justify-end gap-1.5" onClick={(e) => e.stopPropagation()}>
+                      {!p.installed && p.install_hint && (
+                        <button
+                          type="button"
+                          onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+                          className="text-xs px-2 py-0.5 rounded bg-bc-warning/10 text-bc-warning hover:bg-bc-warning/20 transition-colors"
+                        >
+                          Install
+                        </button>
+                      )}
+                      {p.installed && p.install_hint && (
+                        <span className="text-xs px-2 py-0.5 rounded bg-bc-info/10 text-bc-info">
+                          Update
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+                        className="text-xs px-1.5 py-0.5 rounded border border-bc-border text-bc-muted hover:text-bc-text hover:border-bc-accent/50 transition-colors"
+                        aria-label={`Configure ${p.name}`}
+                      >
+                        &#9881;
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/theme/tokens.css
+++ b/web/src/theme/tokens.css
@@ -21,6 +21,7 @@
   --bc-success: #22c55e;
   --bc-warning: #fb923c;
   --bc-error: #ef4444;
+  --bc-info: #06b6d4;
 
   font-family: Inter, "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
   color-scheme: dark;
@@ -40,6 +41,7 @@ html.dark {
   --bc-success: #22c55e;
   --bc-warning: #f59e0b;
   --bc-error: #ef4444;
+  --bc-info: #38bdf8;
 
   color-scheme: dark;
 }
@@ -58,6 +60,7 @@ html.light {
   --bc-success: #16a34a;
   --bc-warning: #d97706;
   --bc-error: #dc2626;
+  --bc-info: #0891b2;
 
   color-scheme: light;
 }

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { motion } from "framer-motion";
 import { api } from "../api/client";
 import type {
   ProviderDetailResponse,
@@ -10,6 +11,7 @@ import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { StatusBadge } from "../components/StatusBadge";
+import { CopyButton } from "../components/CopyButton";
 import { ToastContainer, useToast } from "../components/Toast";
 import { formatCost, formatTokens } from "../utils/format";
 
@@ -53,13 +55,23 @@ function ProviderHeader({
         >
           &larr; Tools
         </Link>
-        <h1 className="text-xl font-bold">{provider.name}</h1>
-        {provider.version && (
-          <span className="px-2 py-0.5 rounded text-xs font-mono bg-bc-surface border border-bc-border text-bc-muted">
-            v{provider.version}
+        {/* Monogram */}
+        <div className="w-9 h-9 rounded-full bg-bc-accent/20 flex items-center justify-center shrink-0">
+          <span className="text-sm font-bold text-bc-accent">
+            {provider.name.charAt(0).toUpperCase()}
           </span>
-        )}
-        <StatusBadge status={providerStatus(provider)} />
+        </div>
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-xl font-bold">{provider.name}</h1>
+            <StatusBadge status={providerStatus(provider)} />
+          </div>
+          {provider.version && (
+            <span className="inline-block mt-0.5 px-2 py-0.5 rounded text-xs font-mono bg-bc-surface border border-bc-border text-bc-muted">
+              v{provider.version}
+            </span>
+          )}
+        </div>
       </div>
       <div className="flex items-center gap-2">
         {!provider.installed && provider.install_hint && (
@@ -165,8 +177,11 @@ function ConfigPanel({
           </div>
           <div>
             <label className="text-xs text-bc-muted block mb-1">Install Hint</label>
-            <div className="text-sm font-mono text-bc-text/80 px-2.5 py-1.5 rounded bg-bc-bg border border-bc-border/50 truncate">
-              {provider.install_hint || "\u2014"}
+            <div className="flex items-center gap-1">
+              <div className="flex-1 text-sm font-mono text-bc-text/80 px-2.5 py-1.5 rounded bg-bc-bg border border-bc-border/50 truncate">
+                {provider.install_hint || "\u2014"}
+              </div>
+              {provider.install_hint && <CopyButton text={provider.install_hint} />}
             </div>
           </div>
         </div>
@@ -226,15 +241,40 @@ function resolveMCPHealth(server: ProviderMCPServer, healthMap: Record<string, {
     if (isHealthy(checked.status)) return { status: "connected" };
     return { status: "error", error: checked.error || checked.status };
   }
-
-  // Without a confirmed health check, only trust explicit error states
   if (server.status) {
     const s = server.status.toLowerCase();
     if (s === "error" || s === "failed") return { status: "error", error: server.error };
     return { status: "unknown" };
   }
-
   return { status: "unknown" };
+}
+
+/* ── MCP Health Summary Bar ── */
+function MCPHealthSummary({ servers, healthMap }: { servers: ProviderMCPServer[]; healthMap: Record<string, { status: string; error?: string }> }) {
+  if (servers.length === 0) return null;
+
+  const healthy = servers.filter((s) => {
+    const h = resolveMCPHealth(s, healthMap);
+    return h.status === "connected";
+  }).length;
+  const pct = Math.round((healthy / servers.length) * 100);
+
+  return (
+    <div className="mb-3">
+      <div className="flex items-center justify-between text-xs text-bc-muted mb-1">
+        <span>MCP Health</span>
+        <span>{healthy}/{servers.length} healthy</span>
+      </div>
+      <div className="h-1.5 rounded-full bg-bc-border overflow-hidden">
+        <motion.div
+          className={`h-full rounded-full ${pct === 100 ? "bg-bc-success" : pct > 0 ? "bg-bc-warning" : "bg-bc-error"}`}
+          initial={{ width: 0 }}
+          animate={{ width: `${pct}%` }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+        />
+      </div>
+    </div>
+  );
 }
 
 function MCPSection({
@@ -327,6 +367,8 @@ function MCPSection({
         </div>
       </div>
 
+      <MCPHealthSummary servers={servers} healthMap={healthMap} />
+
       {showAdd && (
         <div className="rounded border border-bc-accent bg-bc-surface p-4 space-y-3 mb-4">
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
@@ -404,7 +446,10 @@ function MCPSection({
                       </span>
                     </td>
                     <td className="px-4 py-2.5 font-mono text-xs text-bc-muted truncate max-w-xs">
-                      {s.url || s.command || "\u2014"}
+                      <div className="flex items-center gap-1">
+                        <span className="truncate">{s.url || s.command || "\u2014"}</span>
+                        {(s.url || s.command) && <CopyButton text={s.url || s.command || ""} />}
+                      </div>
                     </td>
                     <td className="px-4 py-2.5">
                       <MCPHealthBadge status={health.status} error={health.error} />
@@ -420,57 +465,152 @@ function MCPSection({
   );
 }
 
-/* ── Section: Agents ── */
+/* ── Stat Tile ── */
+function StatTile({ label, value, icon, accent }: { label: string; value: string; icon: React.ReactNode; accent?: boolean }) {
+  return (
+    <div className="rounded border border-bc-border bg-bc-surface p-3">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="text-bc-muted">{icon}</span>
+        <span className="text-[11px] text-bc-muted uppercase tracking-wider">{label}</span>
+      </div>
+      <p className={`text-lg font-bold ${accent ? "text-bc-accent" : ""}`}>{value}</p>
+    </div>
+  );
+}
 
-function AgentsSection({
+/* ── StatBar (4 tiles) ── */
+function StatBar({ provider }: { provider: ProviderDetailResponse }) {
+  const models = provider.cost_by_model ?? [];
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <StatTile
+        label="Cost"
+        value={formatCost(provider.total_cost_usd)}
+        accent
+        icon={
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1" />
+          </svg>
+        }
+      />
+      <StatTile
+        label="Tokens"
+        value={formatTokens(provider.total_tokens)}
+        icon={
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />
+          </svg>
+        }
+      />
+      <StatTile
+        label="Agents"
+        value={String(provider.agent_count)}
+        icon={
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+        }
+      />
+      <StatTile
+        label="Models"
+        value={String(models.length)}
+        icon={
+          <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />
+          </svg>
+        }
+      />
+    </div>
+  );
+}
+
+/* ── Cost Bars ── */
+function CostBars({ provider }: { provider: ProviderDetailResponse }) {
+  const models = provider.cost_by_model ?? [];
+  if (models.length === 0) return null;
+
+  const maxCost = Math.max(...models.map((m) => m.total_cost_usd), 0.01);
+
+  return (
+    <section>
+      <h3 className="text-xs font-medium text-bc-muted uppercase tracking-widest mb-3">
+        Cost by Model
+      </h3>
+      <div className="space-y-2">
+        {models.map((m) => {
+          const pct = Math.max((m.total_cost_usd / maxCost) * 100, 2);
+          return (
+            <div key={m.model}>
+              <div className="flex items-center justify-between text-xs mb-0.5">
+                <span className="font-mono text-bc-text truncate mr-2">{m.model}</span>
+                <span className="text-bc-muted tabular-nums shrink-0">{formatCost(m.total_cost_usd)}</span>
+              </div>
+              <div className="h-1.5 rounded-full bg-bc-border overflow-hidden">
+                <div
+                  className="h-full rounded-full bg-bc-accent transition-all duration-500 ease-out"
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+/* ── Section: Agents (sidebar style) ── */
+
+function AgentsSidebar({
   agents,
 }: {
   agents: ProviderDetailResponse["agents"];
 }) {
   return (
     <section>
-      <h2 className="text-xs font-medium text-bc-muted uppercase tracking-widest mb-3">
-        Agents Using This Provider ({agents.length})
-      </h2>
+      <h3 className="text-xs font-medium text-bc-muted uppercase tracking-widest mb-3">
+        Agents ({agents.length})
+      </h3>
       {agents.length === 0 ? (
-        <EmptyState
-          icon="*"
-          title="No agents"
-          description="No agents are currently using this provider."
-        />
+        <p className="text-xs text-bc-muted">No agents using this provider.</p>
       ) : (
-        <div className="rounded border border-bc-border overflow-hidden">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-bc-border bg-bc-surface text-[11px] text-bc-muted uppercase tracking-wider">
-                <th className="px-4 py-2 font-medium text-left">Agent</th>
-                <th className="px-4 py-2 font-medium text-left">Role</th>
-                <th className="px-4 py-2 font-medium text-left">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {agents.map((a) => (
-                <tr key={a.name} className="border-b border-bc-border/50 hover:bg-bc-surface/50 transition-colors">
-                  <td className="px-4 py-2.5">
-                    <Link
-                      to={`/agents/${encodeURIComponent(a.name)}`}
-                      className="font-medium text-bc-accent hover:underline"
-                    >
-                      {a.name}
-                    </Link>
-                  </td>
-                  <td className="px-4 py-2.5">
-                    <span className="px-2 py-0.5 rounded text-xs font-medium bg-bc-accent/20 text-bc-accent">
-                      {a.role}
-                    </span>
-                  </td>
-                  <td className="px-4 py-2.5">
-                    <StatusBadge status={a.state} />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className="space-y-1">
+          {agents.map((a) => {
+            const isRunning = a.state === "running" || a.state === "working";
+            return (
+              <Link
+                key={a.name}
+                to={`/agents/${encodeURIComponent(a.name)}`}
+                className="group flex items-center gap-2 px-3 py-2 rounded border border-bc-border hover:border-bc-accent/40 hover:bg-bc-surface-hover transition-colors"
+              >
+                {/* Pulse dot */}
+                <span className="relative flex h-2 w-2 shrink-0">
+                  {isRunning && (
+                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-bc-success opacity-75" />
+                  )}
+                  <span
+                    className={`relative inline-flex rounded-full h-2 w-2 ${
+                      isRunning ? "bg-bc-success" : "bg-bc-muted"
+                    }`}
+                  />
+                </span>
+                <div className="flex-1 min-w-0">
+                  <span className="text-sm font-medium text-bc-text truncate block">{a.name}</span>
+                  <span className="text-[10px] text-bc-muted">{a.role}</span>
+                </div>
+                {/* Hover arrow */}
+                <svg
+                  className="w-3.5 h-3.5 text-bc-muted opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+              </Link>
+            );
+          })}
         </div>
       )}
     </section>
@@ -502,80 +642,28 @@ function CommandsSection({ commands }: { commands: ProviderCommand[] }) {
               </tr>
             </thead>
             <tbody>
-              {commands.map((c) => (
-                <tr key={c.name} className="border-b border-bc-border/50 hover:bg-bc-surface/50 transition-colors">
-                  <td className="px-4 py-2.5 font-medium">{c.name}</td>
-                  <td className="px-4 py-2.5 text-bc-muted">{c.description}</td>
-                  <td className="px-4 py-2.5 font-mono text-xs text-bc-text/80">
-                    {c.command}
-                    {c.args && <span className="text-bc-muted ml-1">{c.args}</span>}
-                  </td>
-                </tr>
-              ))}
+              {commands.map((c) => {
+                const fullCmd = c.args ? `${c.command} ${c.args}` : c.command;
+                return (
+                  <tr key={c.name} className="border-b border-bc-border/50 hover:bg-bc-surface/50 transition-colors">
+                    <td className="px-4 py-2.5 font-medium">{c.name}</td>
+                    <td className="px-4 py-2.5 text-bc-muted">{c.description}</td>
+                    <td className="px-4 py-2.5">
+                      <div className="flex items-center gap-1">
+                        <code className="font-mono text-xs text-bc-text/80">
+                          {c.command}
+                          {c.args && <span className="text-bc-muted ml-1">{c.args}</span>}
+                        </code>
+                        <CopyButton text={fullCmd} />
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>
       )}
-    </section>
-  );
-}
-
-/* ── Section: Cost Breakdown ── */
-
-function CostSection({
-  provider,
-}: {
-  provider: ProviderDetailResponse;
-}) {
-  const models = provider.cost_by_model ?? [];
-  return (
-    <section>
-      <h2 className="text-xs font-medium text-bc-muted uppercase tracking-widest mb-3">
-        Cost Breakdown
-      </h2>
-      <div className="rounded border border-bc-border bg-bc-surface p-4 space-y-4">
-        <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-          <div>
-            <span className="text-xs text-bc-muted block">Total Cost</span>
-            <span className="text-lg font-bold">{formatCost(provider.total_cost_usd)}</span>
-          </div>
-          <div>
-            <span className="text-xs text-bc-muted block">Total Tokens</span>
-            <span className="text-lg font-bold">{formatTokens(provider.total_tokens)}</span>
-          </div>
-          <div>
-            <span className="text-xs text-bc-muted block">Models Used</span>
-            <span className="text-lg font-bold">{models.length}</span>
-          </div>
-        </div>
-
-        {models.length > 0 && (
-          <div className="rounded border border-bc-border overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-bc-border bg-bc-bg text-[11px] text-bc-muted uppercase tracking-wider">
-                  <th className="px-4 py-2 font-medium text-left">Model</th>
-                  <th className="px-4 py-2 font-medium text-right">Tokens</th>
-                  <th className="px-4 py-2 font-medium text-right">Cost</th>
-                </tr>
-              </thead>
-              <tbody>
-                {models.map((m) => (
-                  <tr key={m.model} className="border-b border-bc-border/50">
-                    <td className="px-4 py-2 font-mono text-xs">{m.model}</td>
-                    <td className="px-4 py-2 text-right tabular-nums text-bc-muted">
-                      {formatTokens(m.total_tokens)}
-                    </td>
-                    <td className="px-4 py-2 text-right tabular-nums">
-                      {formatCost(m.total_cost_usd)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
     </section>
   );
 }
@@ -689,20 +777,29 @@ export function ProviderDetail() {
         updating={updating}
       />
 
-      <ConfigPanel provider={provider} onSave={handleSaveConfig} />
+      {/* 2-column layout on desktop */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left column: Config + MCP + Commands */}
+        <div className="lg:col-span-2 space-y-8">
+          <ConfigPanel provider={provider} onSave={handleSaveConfig} />
 
-      <MCPSection
-        providerName={provider.name}
-        servers={mcpServers ?? []}
-        onRefresh={refreshMCPs}
-        onToast={addToast}
-      />
+          <MCPSection
+            providerName={provider.name}
+            servers={mcpServers ?? []}
+            onRefresh={refreshMCPs}
+            onToast={addToast}
+          />
 
-      <AgentsSection agents={provider.agents ?? []} />
+          <CommandsSection commands={commands ?? []} />
+        </div>
 
-      <CommandsSection commands={commands ?? []} />
-
-      <CostSection provider={provider} />
+        {/* Right column: Stats + Cost bars + Agents */}
+        <div className="space-y-6">
+          <StatBar provider={provider} />
+          <CostBars provider={provider} />
+          <AgentsSidebar agents={provider.agents ?? []} />
+        </div>
+      </div>
 
       <ToastContainer toasts={toasts} onDismiss={dismiss} />
     </div>

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useMemo, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 import { api } from "../api/client";
 import type { Tool } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { ProvidersTable } from "../components/ProvidersTable";
+import { CopyButton } from "../components/CopyButton";
 import { ToastContainer, useToast } from "../components/Toast";
 import type { ToastLevel } from "../components/Toast";
 
@@ -22,6 +24,23 @@ const inputCls = "w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-
 
 function getStatusConfig(s: string) { return STATUS_CONFIG[s] ?? STATUS_CONFIG.unknown!; }
 
+/* ── Animated chevron icon ── */
+function ChevronIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <motion.svg
+      animate={{ rotate: expanded ? 90 : 0 }}
+      transition={{ type: "spring", stiffness: 300, damping: 20 }}
+      className="w-3 h-3 text-bc-muted"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2.5}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+    </motion.svg>
+  );
+}
+
 function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, onExpand }: {
   tool: Tool; onToggle: () => void; onRemove: () => void;
   toggling: boolean; removing: boolean; expanded: boolean; onExpand: () => void;
@@ -38,11 +57,7 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
       >
         <td className="px-3 py-2 text-sm">
           <div className="flex items-center gap-2">
-            <span
-              className={`text-[10px] text-bc-muted inline-block transition-transform ${expanded ? "rotate-90" : ""}`}
-            >
-              &#9654;
-            </span>
+            <ChevronIcon expanded={expanded} />
             <span className="font-medium">{tool.name}</span>
           </div>
         </td>
@@ -87,37 +102,56 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
           </div>
         </td>
       </tr>
-      {expanded && (
-        <tr className="border-b border-bc-border bg-bc-surface/30">
-          <td colSpan={5} className="px-8 py-3">
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs">
-              {tool.install_cmd && (
-                <div>
-                  <span className="text-bc-muted">Install:</span>{" "}
-                  <span className="font-mono text-bc-text">{tool.install_cmd}</span>
+      <AnimatePresence>
+        {expanded && (
+          <tr className="border-b border-bc-border">
+            <td colSpan={5} className="p-0">
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.2, ease: "easeOut" }}
+                className="overflow-hidden bg-bc-surface/30"
+              >
+                <div className="px-8 py-3 space-y-2">
+                  {tool.install_cmd && (
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-bc-muted shrink-0">Install:</span>
+                      <code className="flex-1 text-xs font-mono text-bc-text bg-bc-bg rounded px-2 py-1 border border-bc-border/50">
+                        {tool.install_cmd}
+                      </code>
+                      <CopyButton text={tool.install_cmd} />
+                    </div>
+                  )}
+                  {tool.command && (
+                    <>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-bc-muted shrink-0">Version cmd:</span>
+                        <code className="flex-1 text-xs font-mono text-bc-text bg-bc-bg rounded px-2 py-1 border border-bc-border/50">
+                          {tool.command} --version
+                        </code>
+                        <CopyButton text={`${tool.command} --version`} />
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-bc-muted shrink-0">Path:</span>
+                        <code className="flex-1 text-xs font-mono text-bc-text bg-bc-bg rounded px-2 py-1 border border-bc-border/50">
+                          {tool.command}
+                        </code>
+                        <CopyButton text={tool.command} />
+                      </div>
+                    </>
+                  )}
+                  {tool.error && (
+                    <div className="text-xs text-bc-error bg-bc-error/5 rounded px-2 py-1 border border-bc-error/20">
+                      Error: {tool.error}
+                    </div>
+                  )}
                 </div>
-              )}
-              {tool.command && (
-                <>
-                  <div>
-                    <span className="text-bc-muted">Version cmd:</span>{" "}
-                    <span className="font-mono text-bc-text">{tool.command} --version</span>
-                  </div>
-                  <div>
-                    <span className="text-bc-muted">Path:</span>{" "}
-                    <span className="font-mono text-bc-text">{tool.command}</span>
-                  </div>
-                </>
-              )}
-              {tool.error && (
-                <div className="sm:col-span-3">
-                  <span className="text-bc-error">Error: {tool.error}</span>
-                </div>
-              )}
-            </div>
-          </td>
-        </tr>
-      )}
+              </motion.div>
+            </td>
+          </tr>
+        )}
+      </AnimatePresence>
     </>
   );
 }
@@ -148,7 +182,13 @@ function AddCLIToolForm({ onClose, onAdded, onToast }: { onClose: () => void; on
   };
 
   return (
-    <div className="rounded border border-bc-accent bg-bc-surface p-4 space-y-3">
+    <motion.div
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={{ duration: 0.2 }}
+      className="rounded border border-bc-accent bg-bc-surface p-4 space-y-3"
+    >
       <div className="flex items-center justify-between">
         <h3 className="text-sm font-medium">Add CLI Tool</h3>
         <button type="button" onClick={onClose} className="text-xs text-bc-muted hover:text-bc-text">Cancel</button>
@@ -173,7 +213,17 @@ function AddCLIToolForm({ onClose, onAdded, onToast }: { onClose: () => void; on
         className="px-3 py-1.5 text-sm rounded bg-bc-accent text-bc-bg font-medium disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-bc-accent">
         {submitting ? "Adding..." : "Add CLI Tool"}
       </button>
-    </div>
+    </motion.div>
+  );
+}
+
+/* ── Spinner icon ── */
+function Spinner() {
+  return (
+    <svg className="animate-spin w-4 h-4 text-bc-muted" fill="none" viewBox="0 0 24 24">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
   );
 }
 
@@ -320,13 +370,24 @@ export function Tools() {
           </p>
         </div>
         <div className="flex items-center gap-2">
+          {/* Search with magnifying glass icon */}
           <div className="relative">
+            <svg
+              className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-bc-muted pointer-events-none"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <circle cx="11" cy="11" r="8" />
+              <path strokeLinecap="round" d="M21 21l-4.35-4.35" />
+            </svg>
             <input
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search tools..."
-              className="w-40 sm:w-52 px-2 py-1.5 pr-7 text-sm rounded border border-bc-border bg-bc-bg text-bc-text placeholder:text-bc-muted focus:outline-none focus:ring-1 focus:ring-bc-accent"
+              className="w-40 sm:w-52 pl-7 pr-7 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text placeholder:text-bc-muted focus:outline-none focus:ring-1 focus:ring-bc-accent"
             />
             {search && (
               <button
@@ -340,7 +401,8 @@ export function Tools() {
             )}
           </div>
           <button type="button" onClick={() => void handleCheck()} disabled={checking}
-            className="px-3 py-1.5 text-sm rounded border border-bc-border text-bc-muted hover:text-bc-text transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-bc-accent">
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded border border-bc-border text-bc-muted hover:text-bc-text transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-bc-accent">
+            {checking ? <Spinner /> : null}
             {checking ? "Checking..." : "Health Check"}
           </button>
           <button type="button" onClick={() => setShowAddForm(!showAddForm)}
@@ -350,7 +412,9 @@ export function Tools() {
         </div>
       </div>
 
-      {showAddForm && <AddCLIToolForm onClose={() => setShowAddForm(false)} onAdded={() => { setCheckedTools(null); refresh(); }} onToast={addToast} />}
+      <AnimatePresence>
+        {showAddForm && <AddCLIToolForm onClose={() => setShowAddForm(false)} onAdded={() => { setCheckedTools(null); refresh(); }} onToast={addToast} />}
+      </AnimatePresence>
 
       <section>
         <h2 className="text-xs font-medium text-bc-muted uppercase tracking-widest mb-3">

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -9,9 +9,19 @@ export default {
           '0%': { opacity: '0', transform: 'translateX(1rem)' },
           '100%': { opacity: '1', transform: 'translateX(0)' },
         },
+        'fade-in': {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        'expand-height': {
+          '0%': { opacity: '0', maxHeight: '0' },
+          '100%': { opacity: '1', maxHeight: '500px' },
+        },
       },
       animation: {
         'slide-in': 'slide-in 0.2s ease-out',
+        'fade-in': 'fade-in 0.25s ease-out',
+        'expand-height': 'expand-height 0.3s ease-out',
       },
       colors: {
         bc: {
@@ -26,6 +36,7 @@ export default {
           success: 'var(--bc-success)',
           warning: 'var(--bc-warning)',
           error: 'var(--bc-error)',
+          info: 'var(--bc-info)',
         },
       },
     },


### PR DESCRIPTION
## Summary
- **New components**: `CopyButton` (clipboard with checkmark feedback, 1500ms reset) and `ProviderCard` (monogram circle, animated pulse dot, version badge, agent/token/cost chips, framer-motion spring hover)
- **ProvidersTable**: Card grid view (default) with table alternative, grid/list toggle icons, sort dropdown for card mode, responsive grid-cols-1/2/3
- **Tools CLI section**: Animated SVG chevron via framer-motion rotate, AnimatePresence expand panels with monospace code blocks + CopyButton, search input with magnifying glass icon, health check spinner
- **ProviderDetail**: 2-column desktop layout (lg:grid-cols-3), StatBar (4 tiles: Cost/Tokens/Agents/Models with icons), CSS width% cost bars with transitions, MCP health summary progress bar, CopyButton on commands/install hints, agent sidebar with pulse dots + hover arrows
- **Design tokens**: `--bc-info` added to all 3 themes (Solar Flare, Dark, Light), `fade-in`/`expand-height` keyframes, `info` color in Tailwind config

## Test plan
- [ ] Verify Tools page renders with card grid view by default
- [ ] Toggle between card and table views on ProvidersTable
- [ ] Expand CLI tool rows and verify animated chevron + CopyButton
- [ ] Navigate to ProviderDetail and verify 2-column layout on desktop
- [ ] Verify StatBar tiles, cost bars, and agent sidebar render correctly
- [ ] Test all 3 themes (Solar Flare, Dark, Light) for --bc-info token
- [ ] Verify `cd web && bun run build` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard buttons for provider hints, commands, and URLs throughout the interface
  * Introduced card and table view toggle for browsing providers
  * Redesigned provider detail page with improved layout, stat tiles, and agent sidebar
  * Enhanced CLI dependency display with animations and copy functionality for commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->