### PR TITLE
fix(ci): bump Go 1.25.9 for crypto/tls CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rpuneet/bc
 
 go 1.25.4
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0


### PR DESCRIPTION
## Summary

Main CI has been failing for 5 consecutive commits on the **Security / govulncheck** job.

Root cause: `crypto/tls` CVE **GO-2026-4870** (Unauthenticated TLS 1.3 KeyUpdate DoS), fixed in Go 1.25.9. We were pinned to 1.25.8.

## Changes

- \`go.mod\`: \`toolchain go1.25.8\` → \`toolchain go1.25.9\`

## Also noticed (separate fix needed)

**Container Scan** is also failing — \`aquasecurity/trivy-action@18f2510ee396bbf400402947e7b4b18e97b232c4\` is an invalid SHA. The correct v0.29.0 SHA is \`18f2510ee396bbf400402947b394f2dd8c87dbb0\`. I could not include this fix because this OAuth token lacks \`workflow\` scope. Needs a manual follow-up in \`.github/workflows/ci.yml\` and \`security-nightly.yml\`.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`golangci-lint run ./...\` 0 issues
- [ ] CI govulncheck passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)