### PR TITLE
feat(agents): phase 1 — bulk select + search/filter + action bar

### DIFF
--- a/docs/proposals/agents-revamp.md
+++ b/docs/proposals/agents-revamp.md
@@ -1,0 +1,438 @@
+# Proposal: Agents Revamp — Fleet Command Center
+
+> **Status:** Proposal (v1) &nbsp;|&nbsp; **Author:** zen-zebra &nbsp;|&nbsp; **Date:** 2026-04-10 &nbsp;|&nbsp; **Issue:** [#2979](https://github.com/rpuneet/bc/issues/2979)
+
+---
+
+## 1. What Are Agents?
+
+Agents are the unit of work in bc. Each agent is an isolated AI assistant (Claude, Codex, Cursor, Gemini, …) running in a tmux session or Docker container, with its own git worktree and its own role. A workspace is a **fleet** of agents — some working, some idle, some stopped, some blocked on each other.
+
+Today the Agents page lets you see them. Tomorrow it should let you **operate** them.
+
+```mermaid
+flowchart LR
+    subgraph Human
+        H[You]
+    end
+
+    subgraph bc Agents Page
+        L[Fleet View]
+        D[Agent Drill-down]
+        B[Bulk Actions]
+    end
+
+    subgraph Fleet
+        A1[curious-otter root]
+        A2[swift-hawk api_lead]
+        A3[sharp-impala product_mgr]
+        A4[smart-osprey ui_lead]
+        A5[jolly-vulture base]
+        A6[...]
+    end
+
+    H -->|search/filter| L
+    L -->|click| D
+    L -->|select multiple| B
+    B -->|start/stop/delete/message| A1 & A2 & A3 & A4 & A5 & A6
+    D -->|logs/terminal/info| A1
+```
+
+---
+
+## 2. Current State (What's Broken)
+
+The current Agents page is a flat table with a 5-tab drill-down. It works for 3 agents. It falls apart at 12 agents.
+
+### Issues found in 2026-04-10 review (20 screenshots)
+
+| # | Issue | Severity |
+|---|-------|----------|
+| 1 | Stopped agents show `0.0%` cards and empty charts instead of last-known state | **High** |
+| 2 | Terminal tab is a dead screen for stopped agents | **High** |
+| 3 | Stats cards + charts feel visually disconnected | Medium |
+| 4 | Role tab duplicates Overview content | Medium |
+| 5 | No bulk actions (start/stop/delete multiple agents) | **High** |
+| 6 | Create Agent form has no task/description field | **High** |
+| 7 | No search or filter on the list page | **High** |
+| 8 | MCP column truncates with no popover | Low |
+| 9 | Task text truncates at 50 chars with no tooltip | Low |
+| 10 | No visual indicator for rows with peek expanded | Low |
+
+### Architecture problems
+
+- **No hierarchy view**: parent_id and children exist in the data model but the UI is flat
+- **No cost context per agent**: tokens and cost are shown in Stats but there's no per-agent budget or warning
+- **No activity timeline**: state changes (created → started → stopped → error) are logged but never surfaced
+- **Tab sprawl**: 5 tabs for what is essentially 3 concerns (logs / terminal / everything else)
+- **Reactive only**: no notifications when an agent errors, stops, or exceeds its cost threshold
+
+---
+
+## 3. The Vision
+
+Turn the Agents page into a **fleet command center**. Three shifts:
+
+1. **List → Workspace.** Search, filter, bulk select, saved views. Operate a fleet, not one agent at a time.
+2. **5 tabs → 3 tabs.** Logs, Terminal, **Info** (merged Overview + Role + Stats + Activity).
+3. **Static → smart.** Stopped agents show last-run context; live agents show real metrics; idle agents show hierarchy.
+
+### Target layout
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Agents (12) · 1 working · $1,469 total              [+ Create] [⚙] [⋮]  │
+│ [/] Search...          [Role ▼] [State ▼] [Tool ▼]    [Flat | Tree]     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ ☐  Name            Role          Task                 $     State      │
+│ ☐  curious-otter   root          Turn complete       $1469  idle   [+] │
+│ ☐  ▼ zen-zebra     root          Session ended        $0    stopped[+] │
+│ ☐    ↳ jolly-vulture base        Processing prompt    —     ● working  │
+│ ☐  fresh-panda     base          tool validation: 1   —     stopped[+] │
+│ ☐  sharp-impala    product_mgr   Turn complete        $892  stopped[+] │
+│ ...                                                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Selected: 3   [Start] [Stop] [Delete] [Message]  [Clear]                │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Bulk action bar
+
+When one or more rows are selected, a bottom bar slides up with:
+- **Start** (if any stopped)
+- **Stop** (if any running)
+- **Delete** (with confirm)
+- **Message** (broadcast a message to all selected)
+- **Clear** selection
+
+### Search + filters
+
+- `/` focuses search from anywhere on the list page
+- Filters: Role, State (running/stopped/error/working/idle), Tool (claude/codex/cursor/gemini)
+- URL state: filters persist in the query string (`?role=base&state=stopped`)
+- Empty state when no matches: "No agents match your filters. [Clear]"
+
+### Tree view
+
+Toggle between **Flat** (current table) and **Tree** (parent → children indent). Default depends on the workspace:
+- Flat for flat workspaces (no parents)
+- Tree for hierarchical workspaces (any agent with children)
+
+---
+
+## 4. Drill-down — From 5 Tabs to 3
+
+### Current: `Logs · Terminal · Overview · Stats · Role`
+
+### New: `Logs · Terminal · Info`
+
+**Info** is a single page that flows top to bottom:
+
+```
+┌─ zen-zebra · root · stopped · tmux ────────────────────────────────────┐
+│                                                                         │
+│ CURRENT TASK                                                            │
+│ Session ended · 4h ago                                                  │
+│                                                                         │
+│ ─── STATS ──────────────────────────────────────────────────────────── │
+│ CPU 0%    Memory 0 MB    Tokens 925,480    Cost $1,469.01               │
+│ [1h] [6h] [12h] [24h]                                                   │
+│ ┌─ CPU ──────┐  ┌─ Memory ───┐  ┌─ Tokens ────┐  ┌─ Cost ─────┐         │
+│ │ (sparkline)│  │ (sparkline)│  │ (sparkline) │  │ (sparkline)│         │
+│ └────────────┘  └────────────┘  └─────────────┘  └────────────┘         │
+│                                                                         │
+│ ─── HIERARCHY ─────────────────────────────────────────────────────── │
+│ Parent: —                                                               │
+│ Children: jolly-vulture, warm-raccoon (2)                               │
+│                                                                         │
+│ ─── ACTIVITY TIMELINE ─────────────────────────────────────────────── │
+│ ● Created    2026-04-04 14:33:10                                        │
+│ ● Started    2026-04-04 14:34:22                                        │
+│ ● Working    2026-04-04 14:35:01  "Processing prompt..."                │
+│ ● Stopped    2026-04-10 03:45:12  reason: session_ended                 │
+│                                                                         │
+│ ─── PATHS & METADATA ──────────────────────────────────────────────── │
+│ Role file     .bc/roles/root.md                                         │
+│ Session       zen-zebra                                                 │
+│ Worktree      .bc/agents/zen-zebra/bc-bc-zen-zebra                      │
+│ MCP servers   bc, github                                                │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Why merge?** Because when you are debugging an agent you are asking one question: "what is going on with this agent?" The answer involves the current task, recent metrics, hierarchy, and activity — all at once. Flipping between 3 tabs to piece this together is friction.
+
+### Stopped-agent placeholders
+
+When an agent is stopped, the Info tab shows **last known state**, not zeros:
+
+```
+CPU —     Memory —     Last tokens 925,480    Last cost $1,469.01
+         (last run: 4h ago)
+```
+
+And the Terminal tab shows the **last captured pane** with a banner:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ ⚠ Agent is stopped. Last capture from 2026-04-10 03:45:12      │
+├────────────────────────────────────────────────────────────────┤
+│ > Turn complete                                                │
+│ > Waiting for next prompt...                                   │
+│ $                                                              │
+└────────────────────────────────────────────────────────────────┘
+      [Start agent to attach live terminal]
+```
+
+---
+
+## 5. Architecture
+
+### Data model changes
+
+#### New table: `agent_activity`
+
+```sql
+CREATE TABLE IF NOT EXISTS agent_activity (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent      TEXT NOT NULL,
+    event      TEXT NOT NULL CHECK(event IN ('created', 'started', 'working', 'idle', 'stopped', 'error')),
+    detail     TEXT,
+    logged_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_activity_agent ON agent_activity(agent, id DESC);
+```
+
+The activity log is written by the agent manager on every state transition. Pruned to last 1000 entries per agent (same pattern as `notify_delivery_log`).
+
+#### Extend `agent_stats` or use existing
+
+Current `pkg/stats` already captures CPU/memory/token metrics. We reuse it for the Info tab's time-series charts.
+
+### REST API additions
+
+All existing endpoints keep working. New:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/agents/{name}/activity` | Return last N activity events |
+| GET | `/api/agents/{name}/last-terminal` | Return last captured tmux pane |
+| POST | `/api/agents/bulk/start` | `{agents: []}` — start many |
+| POST | `/api/agents/bulk/stop` | `{agents: []}` — stop many |
+| POST | `/api/agents/bulk/delete` | `{agents: []}` — delete many |
+| POST | `/api/agents/bulk/message` | `{agents: [], message: ""}` — broadcast |
+
+### Bulk operations implementation
+
+Bulk ops are just loops over individual handlers, executed in parallel with a `sync.WaitGroup` and a result aggregator. No new state. Failures for individual agents are reported per-agent in the response:
+
+```json
+{
+  "results": [
+    {"agent": "zen-zebra", "status": "ok"},
+    {"agent": "jolly-vulture", "status": "error", "error": "already running"}
+  ]
+}
+```
+
+### Frontend component split
+
+```
+web/src/views/Agents.tsx          (root, routing, shared state)
+├── AgentsList/
+│   ├── AgentsHeader.tsx          title, count, cost, [+ Create]
+│   ├── AgentsSearch.tsx          / search, filters, Flat/Tree toggle
+│   ├── AgentsTable.tsx           flat table (existing, enhanced)
+│   ├── AgentsTree.tsx            hierarchical view (new)
+│   ├── AgentsBulkBar.tsx         bottom action bar (new)
+│   └── AgentRow.tsx              single row (+ selection checkbox)
+└── AgentDetail/
+    ├── AgentHeader.tsx           name, role, state, breadcrumb
+    ├── AgentTabs.tsx              Logs / Terminal / Info
+    ├── AgentLogs.tsx              SSE stream
+    ├── AgentTerminal.tsx          xterm WS (live) or last-capture (stopped)
+    ├── AgentInfo.tsx              merged Overview + Role + Stats + Activity
+    └── AgentMessageBar.tsx        sticky bottom input
+```
+
+---
+
+## 6. UX Details
+
+### Keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| `/` | Focus search |
+| `x` | Toggle bulk select mode |
+| `a` | Select all visible |
+| `Esc` | Clear selection / close detail |
+| `j` / `k` | Move selection down / up |
+| `Enter` | Open selected agent detail |
+| `Space` | Toggle peek for selected |
+| `1` / `2` / `3` | Switch tab (Logs / Terminal / Info) on detail page |
+| `.` | Focus message input (detail page) |
+
+### Peek row expansion
+
+Current: `[+]` button on the right expands an inline terminal under the row.
+
+New:
+- **Row-level click** on the name cell also expands
+- Expanded row gets a **subtle left accent bar** (same color as the agent's role)
+- The `[+]` becomes `[−]` and stays as an explicit close handle
+- Only one peek row open at a time by default (click another to switch)
+
+### Task text tooltip
+
+Hovering on the truncated Task cell shows a tooltip with the full text. Uses native `title=` attribute for minimal implementation.
+
+### MCP column popover
+
+Hovering on the MCP cell shows a small popover listing all MCP servers attached. Click outside to dismiss. For 1–2 servers, just show inline (no popover).
+
+### Activity badge
+
+Each row has a tiny badge showing the most recent activity event:
+
+- `● working` (accent color)
+- `○ idle`
+- `◌ stopped`
+- `✗ error` (red, with a dot pulse animation)
+
+---
+
+## 7. Create Agent Form — Upgrades
+
+Current form: Name (optional), Role, Tool, Runtime. Create button.
+
+New form adds:
+
+- **Task** (text area, optional): the initial task to assign. If set, the agent is started immediately and the task is attached via the existing `/api/agents/{name}/send` endpoint.
+- **Template** (dropdown, optional): pre-filled configs for common setups:
+  - `feature-dev + claude + docker` — a standard feature branch agent
+  - `reviewer + claude + tmux` — a code review agent
+  - `manager + gemini + tmux` — a coordination agent
+  - `blank` — current default
+
+Templates store: `role`, `tool`, `runtime`, `prompt_template`.
+
+- **Recent configs** (suggestion chips): "Use the same config as *smart-osprey*" — clicking pre-fills from an existing agent.
+
+---
+
+## 8. Build Sequence
+
+Each phase is a separate PR to keep scope reviewable.
+
+| Phase | Issue | Scope | Size |
+|-------|-------|-------|------|
+| 1 | #TBD | Bulk select + action bar + search/filter | Medium |
+| 2 | #TBD | Merge Overview/Role/Stats → Info tab | Medium |
+| 3 | #TBD | Tree view + hierarchy | Small |
+| 4 | #TBD | Activity timeline + smart stopped-agent cards | Medium |
+| 5 | #TBD | Create form upgrade (task, templates, recent configs) | Small |
+| 6 | #TBD | Keyboard shortcuts + MCP/task tooltips + polish | Small |
+
+**Total**: ~6 PRs, each reviewable in under 30 min.
+
+### Dependencies
+
+- Phase 1 and Phase 2 are independent, can parallelize
+- Phase 3 depends on Phase 1 (tree view reuses selection state)
+- Phase 4 depends on Phase 2 (Info tab hosts the timeline)
+- Phase 5 and 6 are independent and can land any time after Phase 1
+
+---
+
+## 9. Code Impact
+
+| | Files | Lines |
+|---|-------|-------|
+| **Deleted** | ~2 (RoleTab, separate StatsPanel) | ~200 |
+| **Created** | ~8 (bulk, search, tree, activity, timeline components) | ~1500 |
+| **Modified** | ~6 (Agents.tsx, AgentDetail, routes, API client) | ~400 net |
+| **Net add** | ~12 files | ~1700 lines |
+
+This is a **building** revamp, not a **deleting** revamp. The current code isn't broken — it's under-featured. We keep most of it and add on top.
+
+---
+
+## 10. Design Decisions
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | Keep Role tab? | **No.** Merge into Info. | Duplicates Overview; no unique content. |
+| 2 | Tree view default? | **Auto-detect.** Tree if any parent/child, else flat. | Respects flat workspaces; rewards hierarchical ones. |
+| 3 | Bulk delete confirm? | **Yes.** Single modal for N agents. | Delete is destructive; always confirm. |
+| 4 | Single peek or multiple? | **Single (default).** Users can override with a setting. | Keeps the list readable at 20+ rows. |
+| 5 | Activity log retention? | **1000 entries per agent**, pruned hourly. | Same pattern as notify_delivery_log. |
+| 6 | Cost budgets in v1? | **No.** Shown but not enforced. | Enforcement needs its own proposal. |
+| 7 | URL state for filters? | **Yes.** `?role=base&state=stopped`. | Shareable, back-button friendly. |
+| 8 | Templates in v1? | **Yes, but hardcoded.** Dynamic templates later. | Unblocks the core create-form improvement. |
+| 9 | Breaking API changes? | **No.** Only additions. | Existing clients keep working. |
+| 10 | New DB table? | **Yes. `agent_activity`.** | Timeline needs a durable log; derive from events infeasible. |
+
+---
+
+## 11. Open Questions
+
+1. **Should `agent_activity` live in `pkg/events`** (generic event log) rather than its own table? Would let us reuse the events UI but couples agents to the event schema.
+2. **Do we need an "Activity" tab separate from Info?** I argue no — the timeline fits in a single section of Info. But if the log gets long, a dedicated tab might be cleaner.
+3. **Should bulk delete require typing "delete"?** Like GitHub repo delete. Overkill for agents IMO — a simple confirm is enough.
+4. **How do we handle agent rename with bulk select?** Out of scope for v1. Rename stays single-agent.
+
+---
+
+## 12. Non-Goals
+
+Explicitly **not** in this proposal:
+
+- **Cost enforcement / budgets.** Separate proposal. v1 only surfaces cost, doesn't stop agents on overage.
+- **Multi-workspace view.** The current page is workspace-scoped; cross-workspace is a separate feature.
+- **Agent marketplace / shared templates across workspaces.** Templates are local-only in v1.
+- **Dependency graph between agents.** Hierarchy is parent/child only; full DAG is out of scope.
+- **Time-travel debugging.** Activity timeline is append-only, no replay.
+
+---
+
+## Appendix A — Screenshot Review (2026-04-10)
+
+Findings from a 20-screenshot walkthrough of the current Agents page:
+
+1. List page — 12 agents, looks clean, sortable columns
+2. Create form — expanded, 4 fields, no task field
+3. Create form detail — role/tool/runtime dropdowns work
+4. Row hover on working agent — highlight works
+5. Peek inline terminal — **killer feature**, live SSE
+6. zen-zebra detail Logs tab — streaming output
+7. zen-zebra Terminal — **dead screen** (stopped)
+8. zen-zebra Overview — metadata, timestamps
+9. zen-zebra Stats — **empty cards + "No data yet"** charts
+10. zen-zebra Role — duplicates Overview
+11. jolly-vulture (working) Logs — live stream works
+12. jolly-vulture Terminal — **attached xterm**, interactive
+13. jolly-vulture Overview — running state
+14. jolly-vulture Stats — live CPU/Memory
+15. sharp-impala product_manager Overview
+16. sharp-impala Stats bottom — cost + I/O summary
+17. curious-otter (925K tokens) Logs
+18. curious-otter Stats — historical breakdown
+19. Message input focused
+20. Inline rename — double-click to edit
+
+---
+
+## Appendix B — Comparison to Channels Revamp
+
+| | Channels Revamp | Agents Revamp |
+|---|---|---|
+| **Motivation** | Delete bad architecture | Level up good architecture |
+| **Scope** | 45 files deleted, 15 created | 2 deleted, 8 created |
+| **Breaking changes** | Yes (pkg/channel removed) | No (API additive only) |
+| **DB schema** | 5 new tables, old dropped | 1 new table (`agent_activity`) |
+| **Phases** | 7 | 6 |
+| **Net LOC** | **-2,329** (deletion heavy) | **+1,700** (addition heavy) |
+
+The Agents revamp is smaller and safer. It doesn't tear anything down — it adds the missing pieces.

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -62,6 +62,8 @@ func (h *AgentHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/agents/send-pattern", h.sendPattern)
 	mux.HandleFunc("/api/agents/stop-all", h.stopAll)
 	mux.HandleFunc("/api/agents/health", h.health)
+	// Bulk operations — must be registered before the catch-all below.
+	h.registerBulkRoutes(mux)
 	mux.HandleFunc("/api/agents", h.list)
 	mux.HandleFunc("/api/agents/", h.byName)
 }

--- a/server/handlers/agents_bulk.go
+++ b/server/handlers/agents_bulk.go
@@ -1,0 +1,155 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/rpuneet/bc/pkg/agent"
+)
+
+// bulkResult is the per-agent result of a bulk operation.
+type bulkResult struct {
+	Agent  string `json:"agent"`
+	Status string `json:"status"` // "ok" | "error"
+	Error  string `json:"error,omitempty"`
+}
+
+// bulkRequest is the common request shape for bulk start/stop/delete.
+type bulkRequest struct {
+	Agents []string `json:"agents"`
+}
+
+// bulkMessageRequest extends bulkRequest with a broadcast message.
+type bulkMessageRequest struct {
+	Message string   `json:"message"`
+	Agents  []string `json:"agents"`
+}
+
+// registerBulkRoutes mounts /api/agents/bulk/* routes.
+// Called from Register() in agents.go.
+func (h *AgentHandler) registerBulkRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/agents/bulk/start", h.bulkStart)
+	mux.HandleFunc("/api/agents/bulk/stop", h.bulkStop)
+	mux.HandleFunc("/api/agents/bulk/delete", h.bulkDelete)
+	mux.HandleFunc("/api/agents/bulk/message", h.bulkMessage)
+}
+
+// runBulk executes fn against each agent in parallel and collects results.
+// Uses a bounded goroutine pool to avoid spawning hundreds at once.
+func runBulk(ctx context.Context, agents []string, fn func(ctx context.Context, name string) error) []bulkResult {
+	const maxConcurrent = 10
+	results := make([]bulkResult, len(agents))
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+
+	for i, name := range agents {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, n string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			err := fn(ctx, n)
+			if err != nil {
+				results[idx] = bulkResult{Agent: n, Status: "error", Error: err.Error()}
+			} else {
+				results[idx] = bulkResult{Agent: n, Status: "ok"}
+			}
+		}(i, name)
+	}
+	wg.Wait()
+	return results
+}
+
+// bulkStart starts many agents in parallel.
+// POST /api/agents/bulk/start
+func (h *AgentHandler) bulkStart(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req bulkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Agents) == 0 {
+		httpError(w, "agents array is required", http.StatusBadRequest)
+		return
+	}
+
+	results := runBulk(r.Context(), req.Agents, func(ctx context.Context, name string) error {
+		_, err := h.svc.Start(ctx, name, agent.StartOptions{})
+		return err
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+// bulkStop stops many agents in parallel.
+// POST /api/agents/bulk/stop
+func (h *AgentHandler) bulkStop(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req bulkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Agents) == 0 {
+		httpError(w, "agents array is required", http.StatusBadRequest)
+		return
+	}
+
+	results := runBulk(r.Context(), req.Agents, h.svc.Stop)
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+// bulkDelete deletes many agents in parallel.
+// POST /api/agents/bulk/delete  {agents: [], force: bool}
+func (h *AgentHandler) bulkDelete(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		Agents []string `json:"agents"`
+		Force  bool     `json:"force"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Agents) == 0 {
+		httpError(w, "agents array is required", http.StatusBadRequest)
+		return
+	}
+
+	force := req.Force
+	results := runBulk(r.Context(), req.Agents, func(ctx context.Context, name string) error {
+		return h.svc.Delete(ctx, name, force)
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+// bulkMessage sends a message to many agents in parallel.
+// POST /api/agents/bulk/message  {agents: [], message: ""}
+func (h *AgentHandler) bulkMessage(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req bulkMessageRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Agents) == 0 || req.Message == "" {
+		httpError(w, "agents and message are required", http.StatusBadRequest)
+		return
+	}
+
+	msg := req.Message
+	results := runBulk(r.Context(), req.Agents, func(ctx context.Context, name string) error {
+		return h.svc.Send(ctx, name, msg)
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -21,6 +21,12 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+export interface BulkResult {
+  agent: string;
+  status: "ok" | "error";
+  error?: string;
+}
+
 export interface Agent {
   name: string;
   role: string;
@@ -517,6 +523,29 @@ export const api = {
       body: JSON.stringify({ new_name: newName }),
     }),
   stopAllAgents: () => request<void>("/agents/stop-all", { method: "POST" }),
+
+  // Bulk agent operations — parallel ops with per-agent results
+  bulkStartAgents: (agents: string[]) =>
+    request<{ results: BulkResult[] }>("/agents/bulk/start", {
+      method: "POST",
+      body: JSON.stringify({ agents }),
+    }),
+  bulkStopAgents: (agents: string[]) =>
+    request<{ results: BulkResult[] }>("/agents/bulk/stop", {
+      method: "POST",
+      body: JSON.stringify({ agents }),
+    }),
+  bulkDeleteAgents: (agents: string[], force = false) =>
+    request<{ results: BulkResult[] }>("/agents/bulk/delete", {
+      method: "POST",
+      body: JSON.stringify({ agents, force }),
+    }),
+  bulkMessageAgents: (agents: string[], message: string) =>
+    request<{ results: BulkResult[] }>("/agents/bulk/message", {
+      method: "POST",
+      body: JSON.stringify({ agents, message }),
+    }),
+
   sendToAgent: (name: string, message: string) =>
     request<void>(`/agents/${encodeURIComponent(name)}/send`, {
       method: "POST",

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -1,7 +1,7 @@
-import { Fragment, useCallback, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { api } from "../api/client";
-import type { Agent, AgentMetricTS } from "../api/client";
+import type { Agent, AgentMetricTS, BulkResult } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { StatusBadge } from "../components/StatusBadge";
@@ -382,10 +382,57 @@ export function Agents() {
   } = usePolling(fetcher, 5000);
   const { subscribe } = useWebSocket();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
   const [stoppingAll, setStoppingAll] = useState(false);
   const [latestStats, setLatestStats] = useState<Record<string, AgentMetricTS>>({});
+
+  // Search + filter + bulk state (URL-synced where useful)
+  const [search, setSearch] = useState(searchParams.get("q") ?? "");
+  const roleFilter = searchParams.get("role") ?? "";
+  const stateFilter = searchParams.get("state") ?? "";
+  const toolFilter = searchParams.get("tool") ?? "";
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [bulkError, setBulkError] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const updateFilter = (key: "role" | "state" | "tool", value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set(key, value);
+    else next.delete(key);
+    setSearchParams(next, { replace: true });
+  };
+
+  // Debounced search → URL sync
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const next = new URLSearchParams(searchParams);
+      if (search) next.set("q", search);
+      else next.delete("q");
+      setSearchParams(next, { replace: true });
+    }, 250);
+    return () => { clearTimeout(t); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  // Global keyboard shortcut: "/" focuses search
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isInput = target != null && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
+      if (e.key === "/" && !isInput) {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      }
+      if (e.key === "Escape" && selected.size > 0) {
+        setSelected(new Set());
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => { window.removeEventListener("keydown", onKeyDown); };
+  }, [selected.size]);
 
   // Fetch latest CPU/Mem stats for all agents
   useEffect(() => {
@@ -434,6 +481,7 @@ export function Agents() {
   };
 
   const columns = [
+    "Select",
     "Name",
     "Role",
     "Tool",
@@ -446,6 +494,99 @@ export function Agents() {
     "",
     "",
   ] as const;
+
+  // Compute filter options from agent list
+  const allAgents = useMemo(() => agents ?? [], [agents]);
+  const { availableRoles, availableStates, availableTools } = useMemo(() => {
+    const r = new Set<string>();
+    const s = new Set<string>();
+    const t = new Set<string>();
+    for (const a of allAgents) {
+      if (a.role) r.add(a.role);
+      if (a.state) s.add(a.state);
+      if (a.tool) t.add(a.tool);
+    }
+    return {
+      availableRoles: Array.from(r).sort((x, y) => x.localeCompare(y)),
+      availableStates: Array.from(s).sort((x, y) => x.localeCompare(y)),
+      availableTools: Array.from(t).sort((x, y) => x.localeCompare(y)),
+    };
+  }, [allAgents]);
+
+  // Apply filters + search
+  const filteredAgents = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return allAgents.filter((a) => {
+      if (q && !a.name.toLowerCase().includes(q) && !(a.task ?? "").toLowerCase().includes(q)) {
+        return false;
+      }
+      if (roleFilter && a.role !== roleFilter) return false;
+      if (stateFilter && a.state !== stateFilter) return false;
+      if (toolFilter && a.tool !== toolFilter) return false;
+      return true;
+    });
+  }, [allAgents, search, roleFilter, stateFilter, toolFilter]);
+
+  // Bulk action helpers
+  const visibleNames = filteredAgents.map((a) => a.name);
+  const allVisibleSelected = visibleNames.length > 0 && visibleNames.every((n) => selected.has(n));
+  const toggleAllVisible = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allVisibleSelected) {
+        for (const n of visibleNames) next.delete(n);
+      } else {
+        for (const n of visibleNames) next.add(n);
+      }
+      return next;
+    });
+  };
+  const toggleOne = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+  const summarizeResults = (results: BulkResult[]): string | null => {
+    const failed = results.filter((r) => r.status === "error");
+    if (failed.length === 0) return null;
+    return `${String(failed.length)}/${String(results.length)} failed: ${failed.slice(0, 3).map((f) => `${f.agent} (${f.error ?? "error"})`).join(", ")}`;
+  };
+  const runBulk = async (fn: () => Promise<{ results: BulkResult[] }>) => {
+    setBulkBusy(true);
+    setBulkError(null);
+    try {
+      const { results } = await fn();
+      const err = summarizeResults(results);
+      if (err) setBulkError(err);
+      refresh();
+    } catch (e) {
+      setBulkError(e instanceof Error ? e.message : "Bulk operation failed");
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+  const handleBulkStart = () => runBulk(() => api.bulkStartAgents(Array.from(selected)));
+  const handleBulkStop = () => runBulk(() => api.bulkStopAgents(Array.from(selected)));
+  const handleBulkDelete = () => {
+    if (!window.confirm(`Delete ${String(selected.size)} agent(s)? This cannot be undone.`)) return;
+    void runBulk(() => api.bulkDeleteAgents(Array.from(selected), false)).then(() => {
+      setSelected(new Set());
+    });
+  };
+  const handleBulkMessage = () => {
+    const msg = window.prompt(`Send message to ${String(selected.size)} agent(s):`);
+    if (msg == null || msg.trim() === "") return;
+    void runBulk(() => api.bulkMessageAgents(Array.from(selected), msg.trim()));
+  };
+  const clearSelection = () => { setSelected(new Set()); };
+  const clearFilters = () => {
+    setSearch("");
+    setSearchParams(new URLSearchParams(), { replace: true });
+  };
+  const hasFilters = search !== "" || roleFilter !== "" || stateFilter !== "" || toolFilter !== "";
 
   if (loading && !agents) {
     return (
@@ -482,17 +623,17 @@ export function Agents() {
     );
   }
 
-  const agentList = agents ?? [];
-
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-4 pb-24">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">Agents</h1>
         <div className="flex items-center gap-3">
           <span className="text-sm text-bc-muted">
-            {agentList.length} agents
+            {hasFilters
+              ? `${String(filteredAgents.length)} of ${String(allAgents.length)} agents`
+              : `${String(allAgents.length)} agents`}
           </span>
-          {agentList.some(
+          {allAgents.some(
             (a) => a.state !== "stopped" && a.state !== "error",
           ) && (
             <button
@@ -509,17 +650,93 @@ export function Agents() {
 
       <CreateAgentForm onCreated={refresh} />
 
+      {/* Search + filter toolbar */}
+      {allAgents.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative flex-1 min-w-[200px]">
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); }}
+              placeholder="Search by name or task...  (press / to focus)"
+              className="w-full px-3 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text placeholder:text-bc-muted/60 focus:outline-none focus:ring-1 focus:ring-bc-accent"
+              aria-label="Search agents"
+            />
+          </div>
+          <select
+            value={roleFilter}
+            onChange={(e) => { updateFilter("role", e.target.value); }}
+            className="px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
+            aria-label="Filter by role"
+          >
+            <option value="">All roles</option>
+            {availableRoles.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+          <select
+            value={stateFilter}
+            onChange={(e) => { updateFilter("state", e.target.value); }}
+            className="px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
+            aria-label="Filter by state"
+          >
+            <option value="">All states</option>
+            {availableStates.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <select
+            value={toolFilter}
+            onChange={(e) => { updateFilter("tool", e.target.value); }}
+            className="px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
+            aria-label="Filter by tool"
+          >
+            <option value="">All tools</option>
+            {availableTools.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="px-2 py-1.5 text-xs text-bc-muted hover:text-bc-text border border-bc-border rounded focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg"
+              aria-label="Clear filters"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+
       <div className="rounded border border-bc-border overflow-x-auto">
-        {agentList.length === 0 ? (
+        {allAgents.length === 0 ? (
           <EmptyState
             icon=">"
             title="No agents yet"
             description="Create your first agent using the form above."
           />
+        ) : filteredAgents.length === 0 ? (
+          <EmptyState
+            icon=">"
+            title="No agents match your filters"
+            description="Try adjusting your search or clearing the filters."
+            actionLabel="Clear filters"
+            onAction={clearFilters}
+          />
         ) : (
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-bc-border text-left">
+                <th className="px-2 py-2 font-medium text-bc-muted w-8">
+                  <input
+                    type="checkbox"
+                    checked={allVisibleSelected}
+                    onChange={toggleAllVisible}
+                    className="cursor-pointer accent-bc-accent"
+                    aria-label="Select all visible agents"
+                  />
+                </th>
                 <th className="px-4 py-2 font-medium text-bc-muted">Name</th>
                 <th className="px-4 py-2 font-medium text-bc-muted">Role</th>
                 <th className="px-4 py-2 font-medium text-bc-muted hidden sm:table-cell">
@@ -544,7 +761,7 @@ export function Agents() {
               </tr>
             </thead>
             <tbody>
-              {agentList.map((a) => (
+              {filteredAgents.map((a) => (
                 <Fragment key={a.name}>
                   <tr
                     onClick={() =>
@@ -555,8 +772,22 @@ export function Agents() {
                     }}
                     role="link"
                     tabIndex={0}
-                    className="border-b border-bc-border/50 cursor-pointer hover:bg-bc-surface transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg"
+                    className={`border-b border-bc-border/50 cursor-pointer transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg ${
+                      selected.has(a.name) ? "bg-bc-accent/10 hover:bg-bc-accent/15" : "hover:bg-bc-surface"
+                    }`}
                   >
+                    <td
+                      className="px-2 py-2"
+                      onClick={(e) => { e.stopPropagation(); }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected.has(a.name)}
+                        onChange={() => { toggleOne(a.name); }}
+                        className="cursor-pointer accent-bc-accent"
+                        aria-label={`Select agent ${a.name}`}
+                      />
+                    </td>
                     <td className="px-4 py-2">
                       <InlineAgentName agent={a} onRenamed={refresh} />
                     </td>
@@ -657,6 +888,64 @@ export function Agents() {
           </table>
         )}
       </div>
+
+      {/* Bulk action bar */}
+      {selected.size > 0 && (
+        <div className="fixed left-0 right-0 bottom-0 z-40 border-t border-bc-border bg-bc-surface/95 backdrop-blur shadow-bc-lg">
+          <div className="max-w-6xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+            <span className="text-sm font-medium text-bc-text">
+              {selected.size} selected
+            </span>
+            {bulkError && (
+              <span className="text-xs text-bc-error truncate max-w-md" title={bulkError}>
+                {bulkError}
+              </span>
+            )}
+            <div className="flex items-center gap-2 ml-auto">
+              <button
+                onClick={handleBulkStart}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded bg-bc-success/20 text-bc-success hover:bg-bc-success/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Start selected agents"
+              >
+                {bulkBusy ? "..." : "Start"}
+              </button>
+              <button
+                onClick={handleBulkStop}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded bg-bc-warning/20 text-bc-warning hover:bg-bc-warning/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Stop selected agents"
+              >
+                {bulkBusy ? "..." : "Stop"}
+              </button>
+              <button
+                onClick={handleBulkMessage}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded bg-bc-accent/20 text-bc-accent hover:bg-bc-accent/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Send message to selected agents"
+              >
+                {bulkBusy ? "..." : "Message"}
+              </button>
+              <button
+                onClick={handleBulkDelete}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded bg-bc-error/20 text-bc-error hover:bg-bc-error/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Delete selected agents"
+              >
+                {bulkBusy ? "..." : "Delete"}
+              </button>
+              <button
+                onClick={clearSelection}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded border border-bc-border text-bc-muted hover:text-bc-text disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Clear selection"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Part of #2979

## Summary

Phase 1 of the agents revamp (#2979). Adds bulk operations, search, and filters to the Agents page.

Proposal: `docs/proposals/agents-revamp.md` (PR #2980)
Issue: #2979

## Changes

### Backend

4 new endpoints in `server/handlers/agents_bulk.go`:

| Method | Path | Body |
|--------|------|------|
| POST | `/api/agents/bulk/start` | `{agents: []}` |
| POST | `/api/agents/bulk/stop` | `{agents: []}` |
| POST | `/api/agents/bulk/delete` | `{agents: [], force}` |
| POST | `/api/agents/bulk/message` | `{agents: [], message}` |

All use a bounded goroutine pool (max 10 concurrent) and return per-agent results:

```json
{
  "results": [
    {"agent": "zen-zebra", "status": "ok"},
    {"agent": "jolly-vulture", "status": "error", "error": "already running"}
  ]
}
```

Partial failures are reported, never swallowed.

### Frontend

**Search toolbar**
- Search input (name + task) with `/` keyboard shortcut to focus
- 250ms debounced → URL `?q=` param
- Role / State / Tool dropdowns — URL-synced (`?role=base&state=stopped`)
- Filter counts in header: "3 of 12 agents" when filtered
- Clear filters button + empty state

**Bulk select**
- Checkbox column + select-all-visible header checkbox
- Selected rows highlighted with `bg-bc-accent/10`
- `Esc` clears selection
- Sticky bottom action bar (Start / Stop / Message / Delete / Clear)
- Partial-failure summary in the bar when errors occur
- Delete uses `window.confirm` before executing

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] `go test ./server/handlers/...` pass
- [x] `(cd web && bun run lint)` clean (no warnings after useMemo fix)
- [x] `(cd web && bun run build)` clean
- [x] Playwright: search filters list (sharp → 1 of 12)
- [x] Playwright: state filter works (stopped → 10 of 12)
- [x] Playwright: bulk select highlights rows and shows action bar
- [x] Playwright: Esc clears selection

## Screenshots

(screenshots attached on Telegram)

## Not in this PR

- Merge Overview / Role / Stats → Info tab (Phase 2)
- Tree view + hierarchy (Phase 3)
- Activity timeline + smart stopped cards (Phase 4)
- Create form upgrade (Phase 5)
- Keyboard shortcuts + tooltips polish (Phase 6)

Each will be a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
