### PR TITLE
feat(agents): phase 4 — activity timeline API + stopped terminal capture

### DIFF
--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -279,6 +279,9 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, toDTO(a))
 
+	case action == "activity":
+		h.agentActivity(w, r, name)
+
 	case r.Method == http.MethodPost && action == "start":
 		var req struct {
 			Runtime  string `json:"runtime"`

--- a/server/handlers/agents_activity.go
+++ b/server/handlers/agents_activity.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+)
+
+// activityItem is one row in the agent activity timeline response.
+type activityItem struct { //nolint:govet // field order matches JSON contract
+	Data      map[string]any `json:"data,omitempty"`
+	Timestamp string         `json:"timestamp"`
+	Event     string         `json:"event"`
+	Message   string         `json:"message,omitempty"`
+}
+
+// agentActivity returns the most recent activity events for an agent, built
+// from the append-only event store. Used by the InfoTab Activity timeline.
+// GET /api/agents/{name}/activity
+func (h *AgentHandler) agentActivity(w http.ResponseWriter, r *http.Request, name string) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.events == nil {
+		// Fall back to empty list rather than erroring — the InfoTab degrades
+		// to timestamp-derived timeline if the store is unavailable.
+		writeJSON(w, http.StatusOK, []activityItem{})
+		return
+	}
+
+	evts, err := h.events.ReadByAgent(name)
+	if err != nil {
+		httpInternalError(w, "read activity", err)
+		return
+	}
+
+	// Reverse chronological (newest first), cap at 50 entries to keep the
+	// timeline readable. The UI handles ordering client-side.
+	const maxItems = 50
+	out := make([]activityItem, 0, len(evts))
+	for i := len(evts) - 1; i >= 0 && len(out) < maxItems; i-- {
+		e := evts[i]
+		out = append(out, activityItem{
+			Timestamp: e.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z"),
+			Event:     strings.TrimPrefix(string(e.Type), "agent."),
+			Message:   e.Message,
+			Data:      e.Data,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -27,6 +27,13 @@ export interface BulkResult {
   error?: string;
 }
 
+export interface AgentActivityItem {
+  timestamp: string;
+  event: string;
+  message?: string;
+  data?: Record<string, unknown>;
+}
+
 export interface Agent {
   name: string;
   role: string;
@@ -545,6 +552,10 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ agents, message }),
     }),
+
+  // Agent activity timeline — newest first, capped at 50 entries.
+  getAgentActivity: (name: string) =>
+    request<AgentActivityItem[]>(`/agents/${encodeURIComponent(name)}/activity`),
 
   sendToAgent: (name: string, message: string) =>
     request<void>(`/agents/${encodeURIComponent(name)}/send`, {

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { api } from "../api/client";
-import type { Agent } from "../api/client";
+import type { Agent, AgentActivityItem } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { StatusBadge } from "../components/StatusBadge";
@@ -188,12 +188,46 @@ function buildTimeline(agent: Agent): TimelineEvent[] {
   return events;
 }
 
+function humanizeEvent(type: string): string {
+  // "agent.spawned" -> "Spawned", "work.assigned" -> "Work assigned"
+  const cleaned = type.replace(/^agent\./, "").replace(/[._-]/g, " ");
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
 function InfoTab({ agent }: { agent: Agent }) {
   const navigate = useNavigate();
   const [metaOpen, setMetaOpen] = useState(true);
+  const [activity, setActivity] = useState<AgentActivityItem[]>([]);
+
+  // Fetch agent activity from the event store.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getAgentActivity(agent.name)
+      .then((items) => {
+        if (!cancelled) setActivity(items);
+      })
+      .catch(() => {
+        // Activity is best-effort; if the endpoint fails the UI falls back
+        // to the derived timeline from timestamps.
+      });
+    return () => { cancelled = true; };
+  }, [agent.name]);
 
   const isStopped = agent.state === "stopped" || agent.state === "error";
-  const timeline = buildTimeline(agent);
+  const derivedTimeline = buildTimeline(agent);
+  // If we have live activity from the event store, prefer it; otherwise fall
+  // back to the derived timeline built from agent timestamps.
+  const timeline: TimelineEvent[] =
+    activity.length > 0
+      ? activity.slice(0, 8).map((it, idx) => ({
+          key: `${it.event}-${String(idx)}`,
+          label: humanizeEvent(it.event),
+          timestamp: it.timestamp,
+          detail: it.message,
+          active: idx === 0,
+        }))
+      : derivedTimeline;
   const lastActivity =
     agent.stopped_at ??
     agent.updated_at ??
@@ -649,8 +683,23 @@ export function AgentDetail() {
               Interactive Terminal
             </h2>
             {agent.state === "stopped" || agent.state === "error" ? (
-              <div className="rounded border border-bc-border bg-bc-surface p-4 text-bc-muted text-sm">
-                Agent is not active. Start the agent to attach to its terminal.
+              <div className="space-y-2">
+                <div className="rounded border border-bc-border/60 bg-bc-surface/50 px-3 py-2 text-[11px] text-bc-muted italic">
+                  Agent is not running — showing last captured output. Start the agent to attach a live terminal.
+                </div>
+                <pre
+                  className="rounded-lg border border-bc-border/50 bg-bc-bg p-4 text-xs leading-relaxed overflow-y-auto overflow-x-hidden max-h-[60vh] whitespace-pre-wrap break-words text-bc-text/80 shadow-inner w-full min-w-0"
+                  style={{
+                    fontFamily:
+                      "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+                  }}
+                >
+                  {outputLines.length > 0 ? (
+                    outputLines.join("\n")
+                  ) : (
+                    <span className="text-bc-muted italic">No captured output from the last run.</span>
+                  )}
+                </pre>
               </div>
             ) : (
               <div className="h-[60vh]">


### PR DESCRIPTION
Part of #2979

## Summary

Phase 4 of the agents revamp — adds a live activity feed to the Info tab and replaces the dead Terminal screen for stopped agents with the last captured output.

Stacked on PR #2983 (Phase 3).

## Changes

### Backend

- \`GET /api/agents/{name}/activity\` — returns the last 50 events for an agent from the existing \`pkg/events\` EventStore, reverse chronological.
- Reuses the existing event log (agent.spawned, agent.stopped, work.assigned, health.*, etc.) rather than introducing a new \`agent_activity\` table — the data is already there.
- Falls back to empty list (not error) if the events store is unavailable so the InfoTab degrades gracefully.
- Response shape: \`{timestamp, event, message?, data?}\`.

### Frontend

- InfoTab fetches \`/agents/{name}/activity\` on mount.
- If the store returns events, render them as the timeline (up to 8 items, newest marked active).
- If the store is empty or unavailable, fall back to the derived timeline from agent timestamps (Phase 2 behavior).
- \`humanizeEvent()\` cleans event type strings (\"agent.spawned\" → \"Spawned\").

### Terminal tab for stopped agents

- Replaces the dead \"Agent is not active\" screen with the last captured output (already polled via \`getAgentPeek\`).
- Banner: \"Agent is not running — showing last captured output. Start the agent to attach a live terminal.\"
- Uses Space Mono monospace, same styling as Logs tab.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`golangci-lint run ./...\` 0 issues
- [x] \`bun run lint\` 0 errors
- [x] \`bun run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)