### PR TITLE
feat(agents): fleet command center (phases 1-6)

### DIFF
--- a/docs/proposals/agents-revamp.md
+++ b/docs/proposals/agents-revamp.md
@@ -1,0 +1,438 @@
+# Proposal: Agents Revamp — Fleet Command Center
+
+> **Status:** Proposal (v1) &nbsp;|&nbsp; **Author:** zen-zebra &nbsp;|&nbsp; **Date:** 2026-04-10 &nbsp;|&nbsp; **Issue:** [#2979](https://github.com/rpuneet/bc/issues/2979)
+
+---
+
+## 1. What Are Agents?
+
+Agents are the unit of work in bc. Each agent is an isolated AI assistant (Claude, Codex, Cursor, Gemini, …) running in a tmux session or Docker container, with its own git worktree and its own role. A workspace is a **fleet** of agents — some working, some idle, some stopped, some blocked on each other.
+
+Today the Agents page lets you see them. Tomorrow it should let you **operate** them.
+
+```mermaid
+flowchart LR
+    subgraph Human
+        H[You]
+    end
+
+    subgraph bc Agents Page
+        L[Fleet View]
+        D[Agent Drill-down]
+        B[Bulk Actions]
+    end
+
+    subgraph Fleet
+        A1[curious-otter root]
+        A2[swift-hawk api_lead]
+        A3[sharp-impala product_mgr]
+        A4[smart-osprey ui_lead]
+        A5[jolly-vulture base]
+        A6[...]
+    end
+
+    H -->|search/filter| L
+    L -->|click| D
+    L -->|select multiple| B
+    B -->|start/stop/delete/message| A1 & A2 & A3 & A4 & A5 & A6
+    D -->|logs/terminal/info| A1
+```
+
+---
+
+## 2. Current State (What's Broken)
+
+The current Agents page is a flat table with a 5-tab drill-down. It works for 3 agents. It falls apart at 12 agents.
+
+### Issues found in 2026-04-10 review (20 screenshots)
+
+| # | Issue | Severity |
+|---|-------|----------|
+| 1 | Stopped agents show `0.0%` cards and empty charts instead of last-known state | **High** |
+| 2 | Terminal tab is a dead screen for stopped agents | **High** |
+| 3 | Stats cards + charts feel visually disconnected | Medium |
+| 4 | Role tab duplicates Overview content | Medium |
+| 5 | No bulk actions (start/stop/delete multiple agents) | **High** |
+| 6 | Create Agent form has no task/description field | **High** |
+| 7 | No search or filter on the list page | **High** |
+| 8 | MCP column truncates with no popover | Low |
+| 9 | Task text truncates at 50 chars with no tooltip | Low |
+| 10 | No visual indicator for rows with peek expanded | Low |
+
+### Architecture problems
+
+- **No hierarchy view**: parent_id and children exist in the data model but the UI is flat
+- **No cost context per agent**: tokens and cost are shown in Stats but there's no per-agent budget or warning
+- **No activity timeline**: state changes (created → started → stopped → error) are logged but never surfaced
+- **Tab sprawl**: 5 tabs for what is essentially 3 concerns (logs / terminal / everything else)
+- **Reactive only**: no notifications when an agent errors, stops, or exceeds its cost threshold
+
+---
+
+## 3. The Vision
+
+Turn the Agents page into a **fleet command center**. Three shifts:
+
+1. **List → Workspace.** Search, filter, bulk select, saved views. Operate a fleet, not one agent at a time.
+2. **5 tabs → 3 tabs.** Logs, Terminal, **Info** (merged Overview + Role + Stats + Activity).
+3. **Static → smart.** Stopped agents show last-run context; live agents show real metrics; idle agents show hierarchy.
+
+### Target layout
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Agents (12) · 1 working · $1,469 total              [+ Create] [⚙] [⋮]  │
+│ [/] Search...          [Role ▼] [State ▼] [Tool ▼]    [Flat | Tree]     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ ☐  Name            Role          Task                 $     State      │
+│ ☐  curious-otter   root          Turn complete       $1469  idle   [+] │
+│ ☐  ▼ zen-zebra     root          Session ended        $0    stopped[+] │
+│ ☐    ↳ jolly-vulture base        Processing prompt    —     ● working  │
+│ ☐  fresh-panda     base          tool validation: 1   —     stopped[+] │
+│ ☐  sharp-impala    product_mgr   Turn complete        $892  stopped[+] │
+│ ...                                                                     │
+├─────────────────────────────────────────────────────────────────────────┤
+│ Selected: 3   [Start] [Stop] [Delete] [Message]  [Clear]                │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Bulk action bar
+
+When one or more rows are selected, a bottom bar slides up with:
+- **Start** (if any stopped)
+- **Stop** (if any running)
+- **Delete** (with confirm)
+- **Message** (broadcast a message to all selected)
+- **Clear** selection
+
+### Search + filters
+
+- `/` focuses search from anywhere on the list page
+- Filters: Role, State (running/stopped/error/working/idle), Tool (claude/codex/cursor/gemini)
+- URL state: filters persist in the query string (`?role=base&state=stopped`)
+- Empty state when no matches: "No agents match your filters. [Clear]"
+
+### Tree view
+
+Toggle between **Flat** (current table) and **Tree** (parent → children indent). Default depends on the workspace:
+- Flat for flat workspaces (no parents)
+- Tree for hierarchical workspaces (any agent with children)
+
+---
+
+## 4. Drill-down — From 5 Tabs to 3
+
+### Current: `Logs · Terminal · Overview · Stats · Role`
+
+### New: `Logs · Terminal · Info`
+
+**Info** is a single page that flows top to bottom:
+
+```
+┌─ zen-zebra · root · stopped · tmux ────────────────────────────────────┐
+│                                                                         │
+│ CURRENT TASK                                                            │
+│ Session ended · 4h ago                                                  │
+│                                                                         │
+│ ─── STATS ──────────────────────────────────────────────────────────── │
+│ CPU 0%    Memory 0 MB    Tokens 925,480    Cost $1,469.01               │
+│ [1h] [6h] [12h] [24h]                                                   │
+│ ┌─ CPU ──────┐  ┌─ Memory ───┐  ┌─ Tokens ────┐  ┌─ Cost ─────┐         │
+│ │ (sparkline)│  │ (sparkline)│  │ (sparkline) │  │ (sparkline)│         │
+│ └────────────┘  └────────────┘  └─────────────┘  └────────────┘         │
+│                                                                         │
+│ ─── HIERARCHY ─────────────────────────────────────────────────────── │
+│ Parent: —                                                               │
+│ Children: jolly-vulture, warm-raccoon (2)                               │
+│                                                                         │
+│ ─── ACTIVITY TIMELINE ─────────────────────────────────────────────── │
+│ ● Created    2026-04-04 14:33:10                                        │
+│ ● Started    2026-04-04 14:34:22                                        │
+│ ● Working    2026-04-04 14:35:01  "Processing prompt..."                │
+│ ● Stopped    2026-04-10 03:45:12  reason: session_ended                 │
+│                                                                         │
+│ ─── PATHS & METADATA ──────────────────────────────────────────────── │
+│ Role file     .bc/roles/root.md                                         │
+│ Session       zen-zebra                                                 │
+│ Worktree      .bc/agents/zen-zebra/bc-bc-zen-zebra                      │
+│ MCP servers   bc, github                                                │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Why merge?** Because when you are debugging an agent you are asking one question: "what is going on with this agent?" The answer involves the current task, recent metrics, hierarchy, and activity — all at once. Flipping between 3 tabs to piece this together is friction.
+
+### Stopped-agent placeholders
+
+When an agent is stopped, the Info tab shows **last known state**, not zeros:
+
+```
+CPU —     Memory —     Last tokens 925,480    Last cost $1,469.01
+         (last run: 4h ago)
+```
+
+And the Terminal tab shows the **last captured pane** with a banner:
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│ ⚠ Agent is stopped. Last capture from 2026-04-10 03:45:12      │
+├────────────────────────────────────────────────────────────────┤
+│ > Turn complete                                                │
+│ > Waiting for next prompt...                                   │
+│ $                                                              │
+└────────────────────────────────────────────────────────────────┘
+      [Start agent to attach live terminal]
+```
+
+---
+
+## 5. Architecture
+
+### Data model changes
+
+#### New table: `agent_activity`
+
+```sql
+CREATE TABLE IF NOT EXISTS agent_activity (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent      TEXT NOT NULL,
+    event      TEXT NOT NULL CHECK(event IN ('created', 'started', 'working', 'idle', 'stopped', 'error')),
+    detail     TEXT,
+    logged_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_activity_agent ON agent_activity(agent, id DESC);
+```
+
+The activity log is written by the agent manager on every state transition. Pruned to last 1000 entries per agent (same pattern as `notify_delivery_log`).
+
+#### Extend `agent_stats` or use existing
+
+Current `pkg/stats` already captures CPU/memory/token metrics. We reuse it for the Info tab's time-series charts.
+
+### REST API additions
+
+All existing endpoints keep working. New:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/agents/{name}/activity` | Return last N activity events |
+| GET | `/api/agents/{name}/last-terminal` | Return last captured tmux pane |
+| POST | `/api/agents/bulk/start` | `{agents: []}` — start many |
+| POST | `/api/agents/bulk/stop` | `{agents: []}` — stop many |
+| POST | `/api/agents/bulk/delete` | `{agents: []}` — delete many |
+| POST | `/api/agents/bulk/message` | `{agents: [], message: ""}` — broadcast |
+
+### Bulk operations implementation
+
+Bulk ops are just loops over individual handlers, executed in parallel with a `sync.WaitGroup` and a result aggregator. No new state. Failures for individual agents are reported per-agent in the response:
+
+```json
+{
+  "results": [
+    {"agent": "zen-zebra", "status": "ok"},
+    {"agent": "jolly-vulture", "status": "error", "error": "already running"}
+  ]
+}
+```
+
+### Frontend component split
+
+```
+web/src/views/Agents.tsx          (root, routing, shared state)
+├── AgentsList/
+│   ├── AgentsHeader.tsx          title, count, cost, [+ Create]
+│   ├── AgentsSearch.tsx          / search, filters, Flat/Tree toggle
+│   ├── AgentsTable.tsx           flat table (existing, enhanced)
+│   ├── AgentsTree.tsx            hierarchical view (new)
+│   ├── AgentsBulkBar.tsx         bottom action bar (new)
+│   └── AgentRow.tsx              single row (+ selection checkbox)
+└── AgentDetail/
+    ├── AgentHeader.tsx           name, role, state, breadcrumb
+    ├── AgentTabs.tsx              Logs / Terminal / Info
+    ├── AgentLogs.tsx              SSE stream
+    ├── AgentTerminal.tsx          xterm WS (live) or last-capture (stopped)
+    ├── AgentInfo.tsx              merged Overview + Role + Stats + Activity
+    └── AgentMessageBar.tsx        sticky bottom input
+```
+
+---
+
+## 6. UX Details
+
+### Keyboard shortcuts
+
+| Key | Action |
+|-----|--------|
+| `/` | Focus search |
+| `x` | Toggle bulk select mode |
+| `a` | Select all visible |
+| `Esc` | Clear selection / close detail |
+| `j` / `k` | Move selection down / up |
+| `Enter` | Open selected agent detail |
+| `Space` | Toggle peek for selected |
+| `1` / `2` / `3` | Switch tab (Logs / Terminal / Info) on detail page |
+| `.` | Focus message input (detail page) |
+
+### Peek row expansion
+
+Current: `[+]` button on the right expands an inline terminal under the row.
+
+New:
+- **Row-level click** on the name cell also expands
+- Expanded row gets a **subtle left accent bar** (same color as the agent's role)
+- The `[+]` becomes `[−]` and stays as an explicit close handle
+- Only one peek row open at a time by default (click another to switch)
+
+### Task text tooltip
+
+Hovering on the truncated Task cell shows a tooltip with the full text. Uses native `title=` attribute for minimal implementation.
+
+### MCP column popover
+
+Hovering on the MCP cell shows a small popover listing all MCP servers attached. Click outside to dismiss. For 1–2 servers, just show inline (no popover).
+
+### Activity badge
+
+Each row has a tiny badge showing the most recent activity event:
+
+- `● working` (accent color)
+- `○ idle`
+- `◌ stopped`
+- `✗ error` (red, with a dot pulse animation)
+
+---
+
+## 7. Create Agent Form — Upgrades
+
+Current form: Name (optional), Role, Tool, Runtime. Create button.
+
+New form adds:
+
+- **Task** (text area, optional): the initial task to assign. If set, the agent is started immediately and the task is attached via the existing `/api/agents/{name}/send` endpoint.
+- **Template** (dropdown, optional): pre-filled configs for common setups:
+  - `feature-dev + claude + docker` — a standard feature branch agent
+  - `reviewer + claude + tmux` — a code review agent
+  - `manager + gemini + tmux` — a coordination agent
+  - `blank` — current default
+
+Templates store: `role`, `tool`, `runtime`, `prompt_template`.
+
+- **Recent configs** (suggestion chips): "Use the same config as *smart-osprey*" — clicking pre-fills from an existing agent.
+
+---
+
+## 8. Build Sequence
+
+Each phase is a separate PR to keep scope reviewable.
+
+| Phase | Issue | Scope | Size |
+|-------|-------|-------|------|
+| 1 | #TBD | Bulk select + action bar + search/filter | Medium |
+| 2 | #TBD | Merge Overview/Role/Stats → Info tab | Medium |
+| 3 | #TBD | Tree view + hierarchy | Small |
+| 4 | #TBD | Activity timeline + smart stopped-agent cards | Medium |
+| 5 | #TBD | Create form upgrade (task, templates, recent configs) | Small |
+| 6 | #TBD | Keyboard shortcuts + MCP/task tooltips + polish | Small |
+
+**Total**: ~6 PRs, each reviewable in under 30 min.
+
+### Dependencies
+
+- Phase 1 and Phase 2 are independent, can parallelize
+- Phase 3 depends on Phase 1 (tree view reuses selection state)
+- Phase 4 depends on Phase 2 (Info tab hosts the timeline)
+- Phase 5 and 6 are independent and can land any time after Phase 1
+
+---
+
+## 9. Code Impact
+
+| | Files | Lines |
+|---|-------|-------|
+| **Deleted** | ~2 (RoleTab, separate StatsPanel) | ~200 |
+| **Created** | ~8 (bulk, search, tree, activity, timeline components) | ~1500 |
+| **Modified** | ~6 (Agents.tsx, AgentDetail, routes, API client) | ~400 net |
+| **Net add** | ~12 files | ~1700 lines |
+
+This is a **building** revamp, not a **deleting** revamp. The current code isn't broken — it's under-featured. We keep most of it and add on top.
+
+---
+
+## 10. Design Decisions
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | Keep Role tab? | **No.** Merge into Info. | Duplicates Overview; no unique content. |
+| 2 | Tree view default? | **Auto-detect.** Tree if any parent/child, else flat. | Respects flat workspaces; rewards hierarchical ones. |
+| 3 | Bulk delete confirm? | **Yes.** Single modal for N agents. | Delete is destructive; always confirm. |
+| 4 | Single peek or multiple? | **Single (default).** Users can override with a setting. | Keeps the list readable at 20+ rows. |
+| 5 | Activity log retention? | **1000 entries per agent**, pruned hourly. | Same pattern as notify_delivery_log. |
+| 6 | Cost budgets in v1? | **No.** Shown but not enforced. | Enforcement needs its own proposal. |
+| 7 | URL state for filters? | **Yes.** `?role=base&state=stopped`. | Shareable, back-button friendly. |
+| 8 | Templates in v1? | **Yes, but hardcoded.** Dynamic templates later. | Unblocks the core create-form improvement. |
+| 9 | Breaking API changes? | **No.** Only additions. | Existing clients keep working. |
+| 10 | New DB table? | **Yes. `agent_activity`.** | Timeline needs a durable log; derive from events infeasible. |
+
+---
+
+## 11. Open Questions
+
+1. **Should `agent_activity` live in `pkg/events`** (generic event log) rather than its own table? Would let us reuse the events UI but couples agents to the event schema.
+2. **Do we need an "Activity" tab separate from Info?** I argue no — the timeline fits in a single section of Info. But if the log gets long, a dedicated tab might be cleaner.
+3. **Should bulk delete require typing "delete"?** Like GitHub repo delete. Overkill for agents IMO — a simple confirm is enough.
+4. **How do we handle agent rename with bulk select?** Out of scope for v1. Rename stays single-agent.
+
+---
+
+## 12. Non-Goals
+
+Explicitly **not** in this proposal:
+
+- **Cost enforcement / budgets.** Separate proposal. v1 only surfaces cost, doesn't stop agents on overage.
+- **Multi-workspace view.** The current page is workspace-scoped; cross-workspace is a separate feature.
+- **Agent marketplace / shared templates across workspaces.** Templates are local-only in v1.
+- **Dependency graph between agents.** Hierarchy is parent/child only; full DAG is out of scope.
+- **Time-travel debugging.** Activity timeline is append-only, no replay.
+
+---
+
+## Appendix A — Screenshot Review (2026-04-10)
+
+Findings from a 20-screenshot walkthrough of the current Agents page:
+
+1. List page — 12 agents, looks clean, sortable columns
+2. Create form — expanded, 4 fields, no task field
+3. Create form detail — role/tool/runtime dropdowns work
+4. Row hover on working agent — highlight works
+5. Peek inline terminal — **killer feature**, live SSE
+6. zen-zebra detail Logs tab — streaming output
+7. zen-zebra Terminal — **dead screen** (stopped)
+8. zen-zebra Overview — metadata, timestamps
+9. zen-zebra Stats — **empty cards + "No data yet"** charts
+10. zen-zebra Role — duplicates Overview
+11. jolly-vulture (working) Logs — live stream works
+12. jolly-vulture Terminal — **attached xterm**, interactive
+13. jolly-vulture Overview — running state
+14. jolly-vulture Stats — live CPU/Memory
+15. sharp-impala product_manager Overview
+16. sharp-impala Stats bottom — cost + I/O summary
+17. curious-otter (925K tokens) Logs
+18. curious-otter Stats — historical breakdown
+19. Message input focused
+20. Inline rename — double-click to edit
+
+---
+
+## Appendix B — Comparison to Channels Revamp
+
+| | Channels Revamp | Agents Revamp |
+|---|---|---|
+| **Motivation** | Delete bad architecture | Level up good architecture |
+| **Scope** | 45 files deleted, 15 created | 2 deleted, 8 created |
+| **Breaking changes** | Yes (pkg/channel removed) | No (API additive only) |
+| **DB schema** | 5 new tables, old dropped | 1 new table (`agent_activity`) |
+| **Phases** | 7 | 6 |
+| **Net LOC** | **-2,329** (deletion heavy) | **+1,700** (addition heavy) |
+
+The Agents revamp is smaller and safer. It doesn't tear anything down — it adds the missing pieces.

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -279,6 +279,9 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 		}
 		writeJSON(w, http.StatusOK, toDTO(a))
 
+	case action == "activity":
+		h.agentActivity(w, r, name)
+
 	case r.Method == http.MethodPost && action == "start":
 		var req struct {
 			Runtime  string `json:"runtime"`

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -62,6 +62,8 @@ func (h *AgentHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/agents/send-pattern", h.sendPattern)
 	mux.HandleFunc("/api/agents/stop-all", h.stopAll)
 	mux.HandleFunc("/api/agents/health", h.health)
+	// Bulk operations — must be registered before the catch-all below.
+	h.registerBulkRoutes(mux)
 	mux.HandleFunc("/api/agents", h.list)
 	mux.HandleFunc("/api/agents/", h.byName)
 }

--- a/server/handlers/agents_activity.go
+++ b/server/handlers/agents_activity.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"net/http"
+	"strings"
+)
+
+// activityItem is one row in the agent activity timeline response.
+type activityItem struct { //nolint:govet // field order matches JSON contract
+	Data      map[string]any `json:"data,omitempty"`
+	Timestamp string         `json:"timestamp"`
+	Event     string         `json:"event"`
+	Message   string         `json:"message,omitempty"`
+}
+
+// agentActivity returns the most recent activity events for an agent, built
+// from the append-only event store. Used by the InfoTab Activity timeline.
+// GET /api/agents/{name}/activity
+func (h *AgentHandler) agentActivity(w http.ResponseWriter, r *http.Request, name string) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.events == nil {
+		// Fall back to empty list rather than erroring — the InfoTab degrades
+		// to timestamp-derived timeline if the store is unavailable.
+		writeJSON(w, http.StatusOK, []activityItem{})
+		return
+	}
+
+	evts, err := h.events.ReadByAgent(name)
+	if err != nil {
+		httpInternalError(w, "read activity", err)
+		return
+	}
+
+	// Reverse chronological (newest first), cap at 50 entries to keep the
+	// timeline readable. The UI handles ordering client-side.
+	const maxItems = 50
+	out := make([]activityItem, 0, len(evts))
+	for i := len(evts) - 1; i >= 0 && len(out) < maxItems; i-- {
+		e := evts[i]
+		out = append(out, activityItem{
+			Timestamp: e.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z"),
+			Event:     strings.TrimPrefix(string(e.Type), "agent."),
+			Message:   e.Message,
+			Data:      e.Data,
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}

--- a/server/handlers/agents_bulk.go
+++ b/server/handlers/agents_bulk.go
@@ -1,0 +1,155 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/rpuneet/bc/pkg/agent"
+)
+
+// bulkResult is the per-agent result of a bulk operation.
+type bulkResult struct {
+	Agent  string `json:"agent"`
+	Status string `json:"status"` // "ok" | "error"
+	Error  string `json:"error,omitempty"`
+}
+
+// bulkRequest is the common request shape for bulk start/stop/delete.
+type bulkRequest struct {
+	Agents []string `json:"agents"`
+}
+
+// bulkMessageRequest extends bulkRequest with a broadcast message.
+type bulkMessageRequest struct {
+	Message string   `json:"message"`
+	Agents  []string `json:"agents"`
+}
+
+// registerBulkRoutes mounts /api/agents/bulk/* routes.
+// Called from Register() in agents.go.
+func (h *AgentHandler) registerBulkRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/api/agents/bulk/start", h.bulkStart)
+	mux.HandleFunc("/api/agents/bulk/stop", h.bulkStop)
+	mux.HandleFunc("/api/agents/bulk/delete", h.bulkDelete)
+	mux.HandleFunc("/api/agents/bulk/message", h.bulkMessage)
+}
+
+// runBulk executes fn against each agent in parallel and collects results.
+// Uses a bounded goroutine pool to avoid spawning hundreds at once.
+func runBulk(ctx context.Context, agents []string, fn func(ctx context.Context, name string) error) []bulkResult {
+	const maxConcurrent = 10
+	results := make([]bulkResult, len(agents))
+	sem := make(chan struct{}, maxConcurrent)
+	var wg sync.WaitGroup
+
+	for i, name := range agents {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(idx int, n string) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			err := fn(ctx, n)
+			if err != nil {
+				results[idx] = bulkResult{Agent: n, Status: "error", Error: err.Error()}
+			} else {
+				results[idx] = bulkResult{Agent: n, Status: "ok"}
+			}
+		}(i, name)
+	}
+	wg.Wait()
+	return results
+}
+
+// bulkStart starts many agents in parallel.
+// POST /api/agents/bulk/start
+func (h *AgentHandler) bulkStart(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req bulkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Agents) == 0 {
+		httpError(w, "agents array is required", http.StatusBadRequest)
+		return
+	}
+
+	results := runBulk(r.Context(), req.Agents, func(ctx context.Context, name string) error {
+		_, err := h.svc.Start(ctx, name, agent.StartOptions{})
+		return err
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+// bulkStop stops many agents in parallel.
+// POST /api/agents/bulk/stop
+func (h *AgentHandler) bulkStop(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req bulkRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Agents) == 0 {
+		httpError(w, "agents array is required", http.StatusBadRequest)
+		return
+	}
+
+	results := runBulk(r.Context(), req.Agents, h.svc.Stop)
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+// bulkDelete deletes many agents in parallel.
+// POST /api/agents/bulk/delete  {agents: [], force: bool}
+func (h *AgentHandler) bulkDelete(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req struct {
+		Agents []string `json:"agents"`
+		Force  bool     `json:"force"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Agents) == 0 {
+		httpError(w, "agents array is required", http.StatusBadRequest)
+		return
+	}
+
+	force := req.Force
+	results := runBulk(r.Context(), req.Agents, func(ctx context.Context, name string) error {
+		return h.svc.Delete(ctx, name, force)
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}
+
+// bulkMessage sends a message to many agents in parallel.
+// POST /api/agents/bulk/message  {agents: [], message: ""}
+func (h *AgentHandler) bulkMessage(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	var req bulkMessageRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.Agents) == 0 || req.Message == "" {
+		httpError(w, "agents and message are required", http.StatusBadRequest)
+		return
+	}
+
+	msg := req.Message
+	results := runBulk(r.Context(), req.Agents, func(ctx context.Context, name string) error {
+		return h.svc.Send(ctx, name, msg)
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"results": results})
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -21,6 +21,12 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+export interface BulkResult {
+  agent: string;
+  status: "ok" | "error";
+  error?: string;
+}
+
 export interface Agent {
   name: string;
   role: string;
@@ -517,6 +523,29 @@ export const api = {
       body: JSON.stringify({ new_name: newName }),
     }),
   stopAllAgents: () => request<void>("/agents/stop-all", { method: "POST" }),
+
+  // Bulk agent operations — parallel ops with per-agent results
+  bulkStartAgents: (agents: string[]) =>
+    request<{ results: BulkResult[] }>("/agents/bulk/start", {
+      method: "POST",
+      body: JSON.stringify({ agents }),
+    }),
+  bulkStopAgents: (agents: string[]) =>
+    request<{ results: BulkResult[] }>("/agents/bulk/stop", {
+      method: "POST",
+      body: JSON.stringify({ agents }),
+    }),
+  bulkDeleteAgents: (agents: string[], force = false) =>
+    request<{ results: BulkResult[] }>("/agents/bulk/delete", {
+      method: "POST",
+      body: JSON.stringify({ agents, force }),
+    }),
+  bulkMessageAgents: (agents: string[], message: string) =>
+    request<{ results: BulkResult[] }>("/agents/bulk/message", {
+      method: "POST",
+      body: JSON.stringify({ agents, message }),
+    }),
+
   sendToAgent: (name: string, message: string) =>
     request<void>(`/agents/${encodeURIComponent(name)}/send`, {
       method: "POST",

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -27,6 +27,13 @@ export interface BulkResult {
   error?: string;
 }
 
+export interface AgentActivityItem {
+  timestamp: string;
+  event: string;
+  message?: string;
+  data?: Record<string, unknown>;
+}
+
 export interface Agent {
   name: string;
   role: string;
@@ -545,6 +552,10 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ agents, message }),
     }),
+
+  // Agent activity timeline — newest first, capped at 50 entries.
+  getAgentActivity: (name: string) =>
+    request<AgentActivityItem[]>(`/agents/${encodeURIComponent(name)}/activity`),
 
   sendToAgent: (name: string, message: string) =>
     request<void>(`/agents/${encodeURIComponent(name)}/send`, {

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { api } from "../api/client";
-import type { Agent } from "../api/client";
+import type { Agent, AgentActivityItem } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { StatusBadge } from "../components/StatusBadge";
@@ -188,12 +188,46 @@ function buildTimeline(agent: Agent): TimelineEvent[] {
   return events;
 }
 
+function humanizeEvent(type: string): string {
+  // "agent.spawned" -> "Spawned", "work.assigned" -> "Work assigned"
+  const cleaned = type.replace(/^agent\./, "").replace(/[._-]/g, " ");
+  return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
 function InfoTab({ agent }: { agent: Agent }) {
   const navigate = useNavigate();
   const [metaOpen, setMetaOpen] = useState(true);
+  const [activity, setActivity] = useState<AgentActivityItem[]>([]);
+
+  // Fetch agent activity from the event store.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getAgentActivity(agent.name)
+      .then((items) => {
+        if (!cancelled) setActivity(items);
+      })
+      .catch(() => {
+        // Activity is best-effort; if the endpoint fails the UI falls back
+        // to the derived timeline from timestamps.
+      });
+    return () => { cancelled = true; };
+  }, [agent.name]);
 
   const isStopped = agent.state === "stopped" || agent.state === "error";
-  const timeline = buildTimeline(agent);
+  const derivedTimeline = buildTimeline(agent);
+  // If we have live activity from the event store, prefer it; otherwise fall
+  // back to the derived timeline built from agent timestamps.
+  const timeline: TimelineEvent[] =
+    activity.length > 0
+      ? activity.slice(0, 8).map((it, idx) => ({
+          key: `${it.event}-${String(idx)}`,
+          label: humanizeEvent(it.event),
+          timestamp: it.timestamp,
+          detail: it.message,
+          active: idx === 0,
+        }))
+      : derivedTimeline;
   const lastActivity =
     agent.stopped_at ??
     agent.updated_at ??
@@ -649,8 +683,23 @@ export function AgentDetail() {
               Interactive Terminal
             </h2>
             {agent.state === "stopped" || agent.state === "error" ? (
-              <div className="rounded border border-bc-border bg-bc-surface p-4 text-bc-muted text-sm">
-                Agent is not active. Start the agent to attach to its terminal.
+              <div className="space-y-2">
+                <div className="rounded border border-bc-border/60 bg-bc-surface/50 px-3 py-2 text-[11px] text-bc-muted italic">
+                  Agent is not running — showing last captured output. Start the agent to attach a live terminal.
+                </div>
+                <pre
+                  className="rounded-lg border border-bc-border/50 bg-bc-bg p-4 text-xs leading-relaxed overflow-y-auto overflow-x-hidden max-h-[60vh] whitespace-pre-wrap break-words text-bc-text/80 shadow-inner w-full min-w-0"
+                  style={{
+                    fontFamily:
+                      "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+                  }}
+                >
+                  {outputLines.length > 0 ? (
+                    outputLines.join("\n")
+                  ) : (
+                    <span className="text-bc-muted italic">No captured output from the last run.</span>
+                  )}
+                </pre>
               </div>
             ) : (
               <div className="h-[60vh]">

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { api } from "../api/client";
 import type { Agent } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
@@ -17,21 +17,6 @@ function RoleBadge({ role }: { role: string }) {
   );
 }
 
-function MetadataRow({
-  label,
-  value,
-}: {
-  label: string;
-  value: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-start gap-2 py-1.5 border-b border-bc-border/30 last:border-0">
-      <span className="text-bc-muted text-sm w-32 shrink-0">{label}</span>
-      <span className="text-sm break-all">{value ?? "\u2014"}</span>
-    </div>
-  );
-}
-
 function formatTime(t?: string): string {
   if (!t) return "\u2014";
   try {
@@ -43,16 +28,34 @@ function formatTime(t?: string): string {
   }
 }
 
+function formatRelative(t?: string): string {
+  if (!t) return "";
+  try {
+    const d = new Date(t);
+    if (isNaN(d.getTime())) return "";
+    const diffMs = Date.now() - d.getTime();
+    const diffSec = Math.floor(Math.abs(diffMs) / 1000);
+    if (diffSec < 60) return `${String(diffSec)}s ago`;
+    const diffMin = Math.floor(diffSec / 60);
+    if (diffMin < 60) return `${String(diffMin)}m ago`;
+    const diffHr = Math.floor(diffMin / 60);
+    if (diffHr < 24) return `${String(diffHr)}h ago`;
+    const diffDay = Math.floor(diffHr / 24);
+    if (diffDay < 30) return `${String(diffDay)}d ago`;
+    return d.toLocaleDateString();
+  } catch {
+    return "";
+  }
+}
+
 /* ───────────────────────── Tab types ───────────────────────── */
 
-type Tab = "logs" | "terminal" | "overview" | "stats" | "role";
+type Tab = "logs" | "terminal" | "info";
 
 const TABS: { key: Tab; label: string; shortcut: string }[] = [
   { key: "logs", label: "Logs", shortcut: "1" },
   { key: "terminal", label: "Terminal", shortcut: "2" },
-  { key: "overview", label: "Overview", shortcut: "3" },
-  { key: "stats", label: "Stats", shortcut: "4" },
-  { key: "role", label: "Role", shortcut: "5" },
+  { key: "info", label: "Info", shortcut: "3" },
 ];
 
 /* ───────────────────────── Tab content ───────────────────────── */
@@ -89,103 +92,361 @@ function LogsTab({
   );
 }
 
-function OverviewTab({ agent }: { agent: Agent }) {
+/* ───────────────────────── Info tab building blocks ───────────────────────── */
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
   return (
-    <div className="space-y-6">
-      {/* Task */}
-      {agent.task && (
-        <div className="rounded border border-bc-border bg-bc-surface p-3">
-          <span className="text-xs text-bc-muted uppercase tracking-wide">
-            Current Task
-          </span>
-          <p className="mt-1 text-sm">{agent.task}</p>
-        </div>
-      )}
-
-      {/* Identity */}
-      <div className="space-y-2">
-        <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">
-          Identity
-        </h2>
-        <div className="rounded border border-bc-border bg-bc-surface p-4">
-          <MetadataRow label="Name" value={agent.name} />
-          <MetadataRow label="Role" value={agent.role} />
-          <MetadataRow
-            label="State"
-            value={<StatusBadge status={agent.state} />}
-          />
-          <MetadataRow label="Tool" value={agent.tool || "\u2014"} />
-          <MetadataRow label="Runtime" value={agent.runtime_backend || "\u2014"} />
-        </div>
-      </div>
-
-      {/* Hierarchy */}
-      <div className="space-y-2">
-        <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">
-          Hierarchy
-        </h2>
-        <div className="rounded border border-bc-border bg-bc-surface p-4">
-          <MetadataRow label="Parent" value={agent.parent_id || "\u2014"} />
-          <MetadataRow
-            label="Children"
-            value={
-              agent.children && agent.children.length > 0
-                ? agent.children.join(", ")
-                : "\u2014"
-            }
-          />
-        </div>
-      </div>
-
-      {/* Paths */}
-      <div className="space-y-2">
-        <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">
-          Paths
-        </h2>
-        <div className="rounded border border-bc-border bg-bc-surface p-4">
-          <MetadataRow label="Session" value={agent.session || "\u2014"} />
-        </div>
-      </div>
-
-      {/* Timestamps */}
-      <div className="space-y-2">
-        <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">
-          Timestamps
-        </h2>
-        <div className="rounded border border-bc-border bg-bc-surface p-4">
-          <MetadataRow label="Created" value={formatTime(agent.created_at)} />
-          <MetadataRow label="Started" value={formatTime(agent.started_at)} />
-          <MetadataRow label="Updated" value={formatTime(agent.updated_at)} />
-          <MetadataRow label="Stopped" value={formatTime(agent.stopped_at)} />
-        </div>
-      </div>
+    <div className="mb-3 flex items-baseline gap-3">
+      <h2 className="text-[10px] font-semibold text-bc-muted uppercase tracking-[0.18em]">
+        {children}
+      </h2>
+      <div className="flex-1 h-px bg-bc-border/40" />
     </div>
   );
 }
 
-function StatsTab({ agent }: { agent: Agent }) {
-  return <StatsTabComponent agent={agent} />;
+function AgentPill({
+  name,
+  onClick,
+}: {
+  name: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md border border-bc-border bg-bc-surface hover:border-bc-accent/50 hover:bg-bc-accent/5 transition-colors text-xs font-medium text-bc-text focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+    >
+      <span className="w-1 h-1 rounded-full bg-bc-accent/70" />
+      <span
+        style={{
+          fontFamily:
+            "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+        }}
+      >
+        {name}
+      </span>
+    </button>
+  );
 }
 
-function RoleTab({ agent }: { agent: Agent }) {
+interface TimelineEvent {
+  key: string;
+  label: string;
+  timestamp?: string;
+  detail?: string;
+  active: boolean;
+}
+
+function buildTimeline(agent: Agent): TimelineEvent[] {
+  const events: TimelineEvent[] = [];
+  const isRunning = agent.state !== "stopped" && agent.state !== "error";
+
+  if (agent.created_at) {
+    events.push({
+      key: "created",
+      label: "Created",
+      timestamp: agent.created_at,
+      active: false,
+    });
+  }
+  if (agent.started_at) {
+    events.push({
+      key: "started",
+      label: "Started",
+      timestamp: agent.started_at,
+      active: false,
+    });
+  }
+  if (isRunning) {
+    // Current running state — skip stale stopped_at from a previous run.
+    events.push({
+      key: "current",
+      label:
+        agent.state === "working"
+          ? "Working"
+          : agent.state === "starting"
+          ? "Starting"
+          : agent.state === "idle"
+          ? "Idle"
+          : "Active",
+      timestamp: agent.updated_at,
+      detail: agent.task,
+      active: true,
+    });
+  } else if (agent.stopped_at) {
+    // Stopped state is current — show it as the active event.
+    events.push({
+      key: "stopped",
+      label: agent.state === "error" ? "Errored" : "Stopped",
+      timestamp: agent.stopped_at,
+      detail: agent.task,
+      active: true,
+    });
+  }
+  return events;
+}
+
+function InfoTab({ agent }: { agent: Agent }) {
+  const navigate = useNavigate();
+  const [metaOpen, setMetaOpen] = useState(true);
+
+  const isStopped = agent.state === "stopped" || agent.state === "error";
+  const timeline = buildTimeline(agent);
+  const lastActivity =
+    agent.stopped_at ??
+    agent.updated_at ??
+    agent.started_at ??
+    agent.created_at;
+
   return (
-    <div className="space-y-2">
-      <h2 className="text-sm font-medium text-bc-muted uppercase tracking-wide">
-        Role
-      </h2>
-      <div className="rounded border border-bc-border bg-bc-surface p-4">
-        <MetadataRow label="Role" value={<RoleBadge role={agent.role} />} />
-        <MetadataRow label="Tool" value={agent.tool || "\u2014"} />
-        <MetadataRow label="Parent" value={agent.parent_id || "\u2014"} />
-        <MetadataRow
-          label="Children"
-          value={
-            agent.children && agent.children.length > 0
-              ? agent.children.join(", ")
-              : "\u2014"
-          }
-        />
-      </div>
+    <div className="max-w-4xl mx-auto space-y-10">
+      {/* ── CURRENT TASK BANNER ── */}
+      <section>
+        <div
+          className={`rounded-lg border p-4 transition-colors ${
+            isStopped
+              ? "border-bc-border/60 bg-bc-surface/50"
+              : "border-bc-accent/30 bg-bc-accent/5"
+          }`}
+        >
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="text-[10px] font-semibold text-bc-muted uppercase tracking-[0.18em] mb-1.5">
+                {isStopped ? "Last Task" : "Current Task"}
+              </div>
+              <p className="text-sm text-bc-text break-words leading-relaxed">
+                {agent.task ? (
+                  agent.task
+                ) : (
+                  <span className="text-bc-muted italic">no task recorded</span>
+                )}
+              </p>
+            </div>
+            {lastActivity && (
+              <div className="shrink-0 text-right">
+                <div className="text-[10px] font-semibold text-bc-muted uppercase tracking-[0.18em] mb-1.5">
+                  {isStopped ? "Last ran" : "Updated"}
+                </div>
+                <span
+                  className="text-sm text-bc-text tabular-nums"
+                  title={formatTime(lastActivity)}
+                >
+                  {formatRelative(lastActivity)}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+        {isStopped && (
+          <p className="mt-2 ml-1 text-[11px] text-bc-muted/70 italic">
+            Agent is not running. Stats below show last known values.
+          </p>
+        )}
+      </section>
+
+      {/* ── STATS ── */}
+      <section>
+        <SectionHeader>Stats</SectionHeader>
+        <StatsTabComponent agent={agent} />
+      </section>
+
+      {/* ── HIERARCHY ── */}
+      <section>
+        <SectionHeader>Hierarchy</SectionHeader>
+        <div className="space-y-3">
+          <div className="flex items-center gap-3">
+            <span className="text-[11px] text-bc-muted w-16 shrink-0 uppercase tracking-wider">
+              Parent
+            </span>
+            {agent.parent_id ? (
+              <AgentPill
+                name={agent.parent_id}
+                onClick={() => {
+                  navigate(`/agents/${encodeURIComponent(agent.parent_id ?? "")}`);
+                }}
+              />
+            ) : (
+              <span className="text-xs text-bc-muted/40">—</span>
+            )}
+          </div>
+          <div className="flex items-start gap-3">
+            <span className="text-[11px] text-bc-muted w-16 shrink-0 pt-1 uppercase tracking-wider">
+              Children
+            </span>
+            <div className="flex flex-wrap gap-1.5">
+              {agent.children && agent.children.length > 0 ? (
+                agent.children.map((c) => (
+                  <AgentPill
+                    key={c}
+                    name={c}
+                    onClick={() => {
+                      navigate(`/agents/${encodeURIComponent(c)}`);
+                    }}
+                  />
+                ))
+              ) : (
+                <span className="text-xs text-bc-muted/40 pt-1">—</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* ── ACTIVITY TIMELINE ── */}
+      <section>
+        <SectionHeader>Activity</SectionHeader>
+        {timeline.length === 0 ? (
+          <p className="text-xs text-bc-muted/40">No activity recorded</p>
+        ) : (
+          <ol className="relative ml-1">
+            {/* Vertical rail */}
+            <span
+              aria-hidden
+              className="absolute left-[3px] top-2 bottom-2 w-px bg-bc-border/60"
+            />
+            {timeline.map((evt) => (
+              <li key={evt.key} className="relative pl-6 pb-4 last:pb-0">
+                {/* Dot */}
+                <span
+                  aria-hidden
+                  className={`absolute left-0 top-[7px] w-[9px] h-[9px] rounded-full border-2 ${
+                    evt.active
+                      ? "bg-bc-accent border-bc-accent animate-pulse"
+                      : "bg-bc-bg border-bc-muted/60"
+                  }`}
+                />
+                <div className="flex items-baseline justify-between gap-3">
+                  <span
+                    className={`text-sm font-medium ${
+                      evt.active ? "text-bc-accent" : "text-bc-text/85"
+                    }`}
+                  >
+                    {evt.label}
+                  </span>
+                  {evt.timestamp && (
+                    <span
+                      className="text-[11px] text-bc-muted tabular-nums shrink-0"
+                      title={formatTime(evt.timestamp)}
+                    >
+                      {formatRelative(evt.timestamp)}
+                    </span>
+                  )}
+                </div>
+                {evt.detail && (
+                  <p className="mt-0.5 text-xs text-bc-muted break-words leading-relaxed">
+                    {evt.detail}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      {/* ── METADATA (collapsible) ── */}
+      <section>
+        <button
+          type="button"
+          onClick={() => {
+            setMetaOpen((v) => !v);
+          }}
+          className="w-full flex items-center gap-3 text-left group"
+          aria-expanded={metaOpen}
+        >
+          <span className="text-[10px] font-semibold text-bc-muted uppercase tracking-[0.18em] group-hover:text-bc-text transition-colors">
+            Metadata
+          </span>
+          <div className="flex-1 h-px bg-bc-border/40" />
+          <span className="text-[10px] text-bc-muted tabular-nums">
+            {metaOpen ? "−" : "+"}
+          </span>
+        </button>
+        {metaOpen && (
+          <dl className="mt-4 grid grid-cols-[6rem_1fr] gap-y-2.5 gap-x-4 text-sm">
+            <dt className="text-[11px] text-bc-muted uppercase tracking-wider pt-0.5">
+              Role
+            </dt>
+            <dd>
+              <RoleBadge role={agent.role} />
+            </dd>
+
+            <dt className="text-[11px] text-bc-muted uppercase tracking-wider pt-0.5">
+              Tool
+            </dt>
+            <dd
+              className="text-xs text-bc-text/80"
+              style={{
+                fontFamily:
+                  "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+              }}
+            >
+              {agent.tool || "—"}
+            </dd>
+
+            <dt className="text-[11px] text-bc-muted uppercase tracking-wider pt-0.5">
+              Runtime
+            </dt>
+            <dd
+              className="text-xs text-bc-text/80"
+              style={{
+                fontFamily:
+                  "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+              }}
+            >
+              {agent.runtime_backend || "—"}
+            </dd>
+
+            <dt className="text-[11px] text-bc-muted uppercase tracking-wider pt-0.5">
+              Session
+            </dt>
+            <dd
+              className="text-xs text-bc-text/80 break-all"
+              style={{
+                fontFamily:
+                  "'Space Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace",
+              }}
+            >
+              {agent.session || "—"}
+            </dd>
+
+            {agent.mcp_servers && agent.mcp_servers.length > 0 && (
+              <>
+                <dt className="text-[11px] text-bc-muted uppercase tracking-wider pt-1">
+                  MCP
+                </dt>
+                <dd>
+                  <div className="flex flex-wrap gap-1">
+                    {agent.mcp_servers.map((s) => (
+                      <span
+                        key={s}
+                        className="inline-block px-1.5 py-0.5 rounded text-[10px] font-medium bg-bc-accent/10 text-bc-accent"
+                      >
+                        {s.replace(/^mcp__/, "")}
+                      </span>
+                    ))}
+                  </div>
+                </dd>
+              </>
+            )}
+
+            <dt className="text-[11px] text-bc-muted uppercase tracking-wider pt-0.5">
+              Created
+            </dt>
+            <dd className="text-xs text-bc-text/80 tabular-nums">
+              {formatTime(agent.created_at)}
+            </dd>
+
+            <dt className="text-[11px] text-bc-muted uppercase tracking-wider pt-0.5">
+              Started
+            </dt>
+            <dd className="text-xs text-bc-text/80 tabular-nums">
+              {formatTime(agent.started_at)}
+            </dd>
+          </dl>
+        )}
+      </section>
     </div>
   );
 }
@@ -288,21 +549,29 @@ export function AgentDetail() {
     return subscribe("agent.state_changed", () => void refresh());
   }, [subscribe, refresh]);
 
-  // Keyboard shortcuts: 1-4 to switch tabs
+  // Keyboard shortcuts: 1=Logs, 2=Terminal, 3=Info.
+  // 4 and 5 also map to Info (muscle memory from the old 5-tab layout).
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      // Don't intercept when typing in an input
-      const tag = (e.target as HTMLElement)?.tagName;
+      const tag = (e.target as HTMLElement | null)?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA") return;
 
-      const idx = parseInt(e.key, 10);
-      const tab = TABS[idx - 1];
-      if (idx >= 1 && idx <= TABS.length && tab) {
-        setActiveTab(tab.key);
+      switch (e.key) {
+        case "1":
+          setActiveTab("logs");
+          break;
+        case "2":
+          setActiveTab("terminal");
+          break;
+        case "3":
+        case "4":
+        case "5":
+          setActiveTab("info");
+          break;
       }
     };
     window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
+    return () => { window.removeEventListener("keydown", handler); };
   }, []);
 
   const handleSend = async () => {
@@ -390,9 +659,7 @@ export function AgentDetail() {
             )}
           </div>
         )}
-        {activeTab === "overview" && <OverviewTab agent={agent} />}
-        {activeTab === "stats" && <StatsTab agent={agent} />}
-        {activeTab === "role" && <RoleTab agent={agent} />}
+        {activeTab === "info" && <InfoTab agent={agent} />}
       </div>
 
       {/* Message input bar -- always visible at bottom */}

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -527,6 +527,66 @@ export function Agents() {
     });
   }, [allAgents, search, roleFilter, stateFilter, toolFilter]);
 
+  // View mode: flat | tree. Auto-detect default based on whether any agent has a parent.
+  const hasHierarchy = useMemo(
+    () => allAgents.some((a) => a.parent_id != null && a.parent_id !== ""),
+    [allAgents],
+  );
+  const viewParam = searchParams.get("view");
+  const viewMode: "flat" | "tree" =
+    viewParam === "flat" || viewParam === "tree"
+      ? viewParam
+      : hasHierarchy
+      ? "tree"
+      : "flat";
+  const setViewMode = (mode: "flat" | "tree") => {
+    const next = new URLSearchParams(searchParams);
+    next.set("view", mode);
+    setSearchParams(next, { replace: true });
+  };
+
+  // Build display order: either flat list or hierarchical traversal with depth.
+  const displayRows = useMemo<{ agent: Agent; depth: number }[]>(() => {
+    if (viewMode === "flat") {
+      return filteredAgents.map((a) => ({ agent: a, depth: 0 }));
+    }
+    // Build parent → children adjacency from the filtered list.
+    const byName = new Map<string, Agent>();
+    for (const a of filteredAgents) byName.set(a.name, a);
+    const childrenOf = new Map<string, Agent[]>();
+    const roots: Agent[] = [];
+    for (const a of filteredAgents) {
+      const parent = a.parent_id ?? "";
+      if (parent && byName.has(parent)) {
+        const list = childrenOf.get(parent) ?? [];
+        list.push(a);
+        childrenOf.set(parent, list);
+      } else {
+        roots.push(a);
+      }
+    }
+    // Sort roots and children alphabetically for stable order.
+    const sortFn = (x: Agent, y: Agent) => x.name.localeCompare(y.name);
+    roots.sort(sortFn);
+    for (const list of childrenOf.values()) list.sort(sortFn);
+
+    const out: { agent: Agent; depth: number }[] = [];
+    const visited = new Set<string>();
+    const walk = (a: Agent, depth: number): void => {
+      if (visited.has(a.name)) return;
+      visited.add(a.name);
+      out.push({ agent: a, depth });
+      const kids = childrenOf.get(a.name) ?? [];
+      for (const k of kids) walk(k, depth + 1);
+    };
+    for (const r of roots) walk(r, 0);
+    // Catch any agents we missed (shouldn't happen, defensive).
+    for (const a of filteredAgents) {
+      if (!visited.has(a.name)) walk(a, 0);
+    }
+    return out;
+  }, [filteredAgents, viewMode]);
+
   // Bulk action helpers
   const visibleNames = filteredAgents.map((a) => a.name);
   const allVisibleSelected = visibleNames.length > 0 && visibleNames.every((n) => selected.has(n));
@@ -706,6 +766,40 @@ export function Agents() {
               Clear
             </button>
           )}
+          {hasHierarchy && (
+            <div
+              role="group"
+              aria-label="View mode"
+              className="inline-flex rounded border border-bc-border overflow-hidden text-xs"
+            >
+              <button
+                type="button"
+                onClick={() => { setViewMode("flat"); }}
+                className={`px-2.5 py-1.5 transition-colors ${
+                  viewMode === "flat"
+                    ? "bg-bc-accent/20 text-bc-accent"
+                    : "text-bc-muted hover:text-bc-text hover:bg-bc-surface"
+                }`}
+                aria-pressed={viewMode === "flat"}
+                title="Flat view"
+              >
+                Flat
+              </button>
+              <button
+                type="button"
+                onClick={() => { setViewMode("tree"); }}
+                className={`px-2.5 py-1.5 border-l border-bc-border transition-colors ${
+                  viewMode === "tree"
+                    ? "bg-bc-accent/20 text-bc-accent"
+                    : "text-bc-muted hover:text-bc-text hover:bg-bc-surface"
+                }`}
+                aria-pressed={viewMode === "tree"}
+                title="Tree view (parent → children)"
+              >
+                Tree
+              </button>
+            </div>
+          )}
         </div>
       )}
 
@@ -761,7 +855,7 @@ export function Agents() {
               </tr>
             </thead>
             <tbody>
-              {filteredAgents.map((a) => (
+              {displayRows.map(({ agent: a, depth }) => (
                 <Fragment key={a.name}>
                   <tr
                     onClick={() =>
@@ -789,7 +883,17 @@ export function Agents() {
                       />
                     </td>
                     <td className="px-4 py-2">
-                      <InlineAgentName agent={a} onRenamed={refresh} />
+                      <div className="flex items-center" style={{ paddingLeft: `${String(depth * 16)}px` }}>
+                        {depth > 0 && (
+                          <span
+                            aria-hidden
+                            className="text-bc-muted/40 mr-1.5 font-mono text-xs select-none"
+                          >
+                            └
+                          </span>
+                        )}
+                        <InlineAgentName agent={a} onRenamed={refresh} />
+                      </div>
                     </td>
                     <td className="px-4 py-2">
                       <span className="text-bc-muted">{a.role}</span>

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -10,6 +10,17 @@ import { EmptyState } from "../components/EmptyState";
 import { InlineTerminal } from "../components/InlineTerminal";
 import { truncate } from "../utils/text";
 
+function KeyHint({ k, label }: { k: string; label: string }) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <kbd className="px-1 py-px rounded border border-bc-border/60 bg-bc-bg text-[9px] font-mono text-bc-muted">
+        {k}
+      </kbd>
+      <span>{label}</span>
+    </span>
+  );
+}
+
 // --- Create Agent Form ---
 
 interface CreateFormState {
@@ -542,6 +553,7 @@ export function Agents() {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
   const [bulkError, setBulkError] = useState<string | null>(null);
+  const [focusIndex, setFocusIndex] = useState(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const updateFilter = (key: "role" | "state" | "tool", value: string) => {
@@ -563,22 +575,8 @@ export function Agents() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
 
-  // Global keyboard shortcut: "/" focuses search
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
-      const isInput = target != null && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
-      if (e.key === "/" && !isInput) {
-        e.preventDefault();
-        searchInputRef.current?.focus();
-      }
-      if (e.key === "Escape" && selected.size > 0) {
-        setSelected(new Set());
-      }
-    };
-    window.addEventListener("keydown", onKeyDown);
-    return () => { window.removeEventListener("keydown", onKeyDown); };
-  }, [selected.size]);
+  // Keyboard shortcuts now live after displayRows is declared below —
+  // see the useEffect labelled "Global keyboard shortcuts".
 
   // Fetch latest CPU/Mem stats for all agents
   useEffect(() => {
@@ -732,6 +730,99 @@ export function Agents() {
     }
     return out;
   }, [filteredAgents, viewMode]);
+
+  // Clamp focusIndex when displayRows shrinks (e.g. after filtering).
+  useEffect(() => {
+    if (focusIndex >= displayRows.length && displayRows.length > 0) {
+      setFocusIndex(displayRows.length - 1);
+    }
+  }, [displayRows.length, focusIndex]);
+
+  // Global keyboard shortcuts. These work when focus is anywhere on the page,
+  // except inside inputs/textareas/contenteditable elements.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isInput =
+        target != null &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable);
+
+      // "/" always focuses search even from inputs? no — only outside.
+      if (e.key === "/" && !isInput) {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+        return;
+      }
+      if (e.key === "Escape" && selected.size > 0) {
+        setSelected(new Set());
+        return;
+      }
+      if (isInput) return;
+
+      // Row navigation
+      if (e.key === "j" || e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusIndex((i) => Math.min(i + 1, Math.max(0, displayRows.length - 1)));
+        return;
+      }
+      if (e.key === "k" || e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusIndex((i) => Math.max(i - 1, 0));
+        return;
+      }
+      // Enter opens the focused agent
+      if (e.key === "Enter") {
+        const row = displayRows[focusIndex];
+        if (row) {
+          e.preventDefault();
+          navigate(`/agents/${encodeURIComponent(row.agent.name)}`);
+        }
+        return;
+      }
+      // Space toggles peek for the focused row
+      if (e.key === " ") {
+        const row = displayRows[focusIndex];
+        if (row) {
+          e.preventDefault();
+          setPeekAgent((prev) => (prev === row.agent.name ? null : row.agent.name));
+        }
+        return;
+      }
+      // x toggles selection on the focused row
+      if (e.key === "x") {
+        const row = displayRows[focusIndex];
+        if (row) {
+          e.preventDefault();
+          setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(row.agent.name)) next.delete(row.agent.name);
+            else next.add(row.agent.name);
+            return next;
+          });
+        }
+        return;
+      }
+      // a selects all visible
+      if (e.key === "a") {
+        e.preventDefault();
+        setSelected((prev) => {
+          const next = new Set(prev);
+          const names = displayRows.map((r) => r.agent.name);
+          const allSel = names.every((n) => next.has(n));
+          if (allSel) {
+            for (const n of names) next.delete(n);
+          } else {
+            for (const n of names) next.add(n);
+          }
+          return next;
+        });
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => { window.removeEventListener("keydown", onKeyDown); };
+  }, [selected.size, displayRows, focusIndex, navigate]);
 
   // Bulk action helpers
   const visibleNames = filteredAgents.map((a) => a.name);
@@ -949,6 +1040,19 @@ export function Agents() {
         </div>
       )}
 
+      {/* Keyboard hints — only shown when the list is visible */}
+      {allAgents.length > 0 && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[10px] text-bc-muted/60">
+          <KeyHint k="/" label="search" />
+          <KeyHint k="j / k" label="nav" />
+          <KeyHint k="↵" label="open" />
+          <KeyHint k="space" label="peek" />
+          <KeyHint k="x" label="select" />
+          <KeyHint k="a" label="select all" />
+          <KeyHint k="esc" label="clear" />
+        </div>
+      )}
+
       <div className="rounded border border-bc-border overflow-x-auto">
         {allAgents.length === 0 ? (
           <EmptyState
@@ -1001,7 +1105,7 @@ export function Agents() {
               </tr>
             </thead>
             <tbody>
-              {displayRows.map(({ agent: a, depth }) => (
+              {displayRows.map(({ agent: a, depth }, rowIdx) => (
                 <Fragment key={a.name}>
                   <tr
                     onClick={() =>
@@ -1013,6 +1117,10 @@ export function Agents() {
                     role="link"
                     tabIndex={0}
                     className={`border-b border-bc-border/50 cursor-pointer transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg ${
+                      rowIdx === focusIndex ? "ring-1 ring-inset ring-bc-accent/40 " : ""
+                    }${
+                      peekAgent === a.name ? "bg-bc-accent/5 " : ""
+                    }${
                       selected.has(a.name) ? "bg-bc-accent/10 hover:bg-bc-accent/15" : "hover:bg-bc-surface"
                     }`}
                   >
@@ -1079,26 +1187,40 @@ export function Agents() {
                       </span>
                     </td>
                     <td className="px-4 py-2 hidden md:table-cell">
-                      <div className="flex flex-wrap gap-1">
-                        {(a.mcp_servers ?? []).length === 0 ? (
-                          <span className="text-bc-muted">{"\u2014"}</span>
-                        ) : (a.mcp_servers ?? []).length <= 3 ? (
-                          (a.mcp_servers ?? []).map((s) => (
-                            <span key={s} className="text-[10px] px-1.5 py-0.5 rounded bg-bc-accent/10 text-bc-accent font-medium">
-                              {s.replace(/^mcp__/, "")}
-                            </span>
-                          ))
-                        ) : (
-                          <>
-                            {(a.mcp_servers ?? []).slice(0, 2).map((s) => (
+                      {(() => {
+                        const servers = a.mcp_servers ?? [];
+                        if (servers.length === 0) {
+                          return <span className="text-bc-muted">{"\u2014"}</span>;
+                        }
+                        const fullList = servers.map((s) => s.replace(/^mcp__/, "")).join(", ");
+                        if (servers.length <= 3) {
+                          return (
+                            <div className="flex flex-wrap gap-1" title={fullList}>
+                              {servers.map((s) => (
+                                <span key={s} className="text-[10px] px-1.5 py-0.5 rounded bg-bc-accent/10 text-bc-accent font-medium">
+                                  {s.replace(/^mcp__/, "")}
+                                </span>
+                              ))}
+                            </div>
+                          );
+                        }
+                        const rest = servers.slice(2).map((s) => s.replace(/^mcp__/, "")).join(", ");
+                        return (
+                          <div className="flex flex-wrap gap-1" title={fullList}>
+                            {servers.slice(0, 2).map((s) => (
                               <span key={s} className="text-[10px] px-1.5 py-0.5 rounded bg-bc-accent/10 text-bc-accent font-medium">
                                 {s.replace(/^mcp__/, "")}
                               </span>
                             ))}
-                            <span className="text-[10px] text-bc-muted">+{(a.mcp_servers ?? []).length - 2}</span>
-                          </>
-                        )}
-                      </div>
+                            <span
+                              className="text-[10px] px-1.5 py-0.5 rounded border border-bc-border text-bc-muted cursor-help"
+                              title={rest}
+                            >
+                              +{String(servers.length - 2)}
+                            </span>
+                          </div>
+                        );
+                      })()}
                     </td>
                     <td className="px-4 py-2">
                       <AgentActions agent={a} onDone={refresh} />

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -1,7 +1,7 @@
-import { Fragment, useCallback, useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { api } from "../api/client";
-import type { Agent, AgentMetricTS } from "../api/client";
+import type { Agent, AgentMetricTS, BulkResult } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { StatusBadge } from "../components/StatusBadge";
@@ -382,10 +382,57 @@ export function Agents() {
   } = usePolling(fetcher, 5000);
   const { subscribe } = useWebSocket();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
 
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
   const [stoppingAll, setStoppingAll] = useState(false);
   const [latestStats, setLatestStats] = useState<Record<string, AgentMetricTS>>({});
+
+  // Search + filter + bulk state (URL-synced where useful)
+  const [search, setSearch] = useState(searchParams.get("q") ?? "");
+  const roleFilter = searchParams.get("role") ?? "";
+  const stateFilter = searchParams.get("state") ?? "";
+  const toolFilter = searchParams.get("tool") ?? "";
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [bulkBusy, setBulkBusy] = useState(false);
+  const [bulkError, setBulkError] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const updateFilter = (key: "role" | "state" | "tool", value: string) => {
+    const next = new URLSearchParams(searchParams);
+    if (value) next.set(key, value);
+    else next.delete(key);
+    setSearchParams(next, { replace: true });
+  };
+
+  // Debounced search → URL sync
+  useEffect(() => {
+    const t = setTimeout(() => {
+      const next = new URLSearchParams(searchParams);
+      if (search) next.set("q", search);
+      else next.delete("q");
+      setSearchParams(next, { replace: true });
+    }, 250);
+    return () => { clearTimeout(t); };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
+
+  // Global keyboard shortcut: "/" focuses search
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isInput = target != null && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
+      if (e.key === "/" && !isInput) {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+      }
+      if (e.key === "Escape" && selected.size > 0) {
+        setSelected(new Set());
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => { window.removeEventListener("keydown", onKeyDown); };
+  }, [selected.size]);
 
   // Fetch latest CPU/Mem stats for all agents
   useEffect(() => {
@@ -434,6 +481,7 @@ export function Agents() {
   };
 
   const columns = [
+    "Select",
     "Name",
     "Role",
     "Tool",
@@ -446,6 +494,99 @@ export function Agents() {
     "",
     "",
   ] as const;
+
+  // Compute filter options from agent list
+  const allAgents = useMemo(() => agents ?? [], [agents]);
+  const { availableRoles, availableStates, availableTools } = useMemo(() => {
+    const r = new Set<string>();
+    const s = new Set<string>();
+    const t = new Set<string>();
+    for (const a of allAgents) {
+      if (a.role) r.add(a.role);
+      if (a.state) s.add(a.state);
+      if (a.tool) t.add(a.tool);
+    }
+    return {
+      availableRoles: Array.from(r).sort((x, y) => x.localeCompare(y)),
+      availableStates: Array.from(s).sort((x, y) => x.localeCompare(y)),
+      availableTools: Array.from(t).sort((x, y) => x.localeCompare(y)),
+    };
+  }, [allAgents]);
+
+  // Apply filters + search
+  const filteredAgents = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return allAgents.filter((a) => {
+      if (q && !a.name.toLowerCase().includes(q) && !(a.task ?? "").toLowerCase().includes(q)) {
+        return false;
+      }
+      if (roleFilter && a.role !== roleFilter) return false;
+      if (stateFilter && a.state !== stateFilter) return false;
+      if (toolFilter && a.tool !== toolFilter) return false;
+      return true;
+    });
+  }, [allAgents, search, roleFilter, stateFilter, toolFilter]);
+
+  // Bulk action helpers
+  const visibleNames = filteredAgents.map((a) => a.name);
+  const allVisibleSelected = visibleNames.length > 0 && visibleNames.every((n) => selected.has(n));
+  const toggleAllVisible = () => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allVisibleSelected) {
+        for (const n of visibleNames) next.delete(n);
+      } else {
+        for (const n of visibleNames) next.add(n);
+      }
+      return next;
+    });
+  };
+  const toggleOne = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  };
+  const summarizeResults = (results: BulkResult[]): string | null => {
+    const failed = results.filter((r) => r.status === "error");
+    if (failed.length === 0) return null;
+    return `${String(failed.length)}/${String(results.length)} failed: ${failed.slice(0, 3).map((f) => `${f.agent} (${f.error ?? "error"})`).join(", ")}`;
+  };
+  const runBulk = async (fn: () => Promise<{ results: BulkResult[] }>) => {
+    setBulkBusy(true);
+    setBulkError(null);
+    try {
+      const { results } = await fn();
+      const err = summarizeResults(results);
+      if (err) setBulkError(err);
+      refresh();
+    } catch (e) {
+      setBulkError(e instanceof Error ? e.message : "Bulk operation failed");
+    } finally {
+      setBulkBusy(false);
+    }
+  };
+  const handleBulkStart = () => runBulk(() => api.bulkStartAgents(Array.from(selected)));
+  const handleBulkStop = () => runBulk(() => api.bulkStopAgents(Array.from(selected)));
+  const handleBulkDelete = () => {
+    if (!window.confirm(`Delete ${String(selected.size)} agent(s)? This cannot be undone.`)) return;
+    void runBulk(() => api.bulkDeleteAgents(Array.from(selected), false)).then(() => {
+      setSelected(new Set());
+    });
+  };
+  const handleBulkMessage = () => {
+    const msg = window.prompt(`Send message to ${String(selected.size)} agent(s):`);
+    if (msg == null || msg.trim() === "") return;
+    void runBulk(() => api.bulkMessageAgents(Array.from(selected), msg.trim()));
+  };
+  const clearSelection = () => { setSelected(new Set()); };
+  const clearFilters = () => {
+    setSearch("");
+    setSearchParams(new URLSearchParams(), { replace: true });
+  };
+  const hasFilters = search !== "" || roleFilter !== "" || stateFilter !== "" || toolFilter !== "";
 
   if (loading && !agents) {
     return (
@@ -482,17 +623,17 @@ export function Agents() {
     );
   }
 
-  const agentList = agents ?? [];
-
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-4 pb-24">
       <div className="flex items-center justify-between">
         <h1 className="text-xl font-bold">Agents</h1>
         <div className="flex items-center gap-3">
           <span className="text-sm text-bc-muted">
-            {agentList.length} agents
+            {hasFilters
+              ? `${String(filteredAgents.length)} of ${String(allAgents.length)} agents`
+              : `${String(allAgents.length)} agents`}
           </span>
-          {agentList.some(
+          {allAgents.some(
             (a) => a.state !== "stopped" && a.state !== "error",
           ) && (
             <button
@@ -509,17 +650,93 @@ export function Agents() {
 
       <CreateAgentForm onCreated={refresh} />
 
+      {/* Search + filter toolbar */}
+      {allAgents.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative flex-1 min-w-[200px]">
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={search}
+              onChange={(e) => { setSearch(e.target.value); }}
+              placeholder="Search by name or task...  (press / to focus)"
+              className="w-full px-3 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text placeholder:text-bc-muted/60 focus:outline-none focus:ring-1 focus:ring-bc-accent"
+              aria-label="Search agents"
+            />
+          </div>
+          <select
+            value={roleFilter}
+            onChange={(e) => { updateFilter("role", e.target.value); }}
+            className="px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
+            aria-label="Filter by role"
+          >
+            <option value="">All roles</option>
+            {availableRoles.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+          <select
+            value={stateFilter}
+            onChange={(e) => { updateFilter("state", e.target.value); }}
+            className="px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
+            aria-label="Filter by state"
+          >
+            <option value="">All states</option>
+            {availableStates.map((s) => (
+              <option key={s} value={s}>{s}</option>
+            ))}
+          </select>
+          <select
+            value={toolFilter}
+            onChange={(e) => { updateFilter("tool", e.target.value); }}
+            className="px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
+            aria-label="Filter by tool"
+          >
+            <option value="">All tools</option>
+            {availableTools.map((t) => (
+              <option key={t} value={t}>{t}</option>
+            ))}
+          </select>
+          {hasFilters && (
+            <button
+              onClick={clearFilters}
+              className="px-2 py-1.5 text-xs text-bc-muted hover:text-bc-text border border-bc-border rounded focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg"
+              aria-label="Clear filters"
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      )}
+
       <div className="rounded border border-bc-border overflow-x-auto">
-        {agentList.length === 0 ? (
+        {allAgents.length === 0 ? (
           <EmptyState
             icon=">"
             title="No agents yet"
             description="Create your first agent using the form above."
           />
+        ) : filteredAgents.length === 0 ? (
+          <EmptyState
+            icon=">"
+            title="No agents match your filters"
+            description="Try adjusting your search or clearing the filters."
+            actionLabel="Clear filters"
+            onAction={clearFilters}
+          />
         ) : (
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-bc-border text-left">
+                <th className="px-2 py-2 font-medium text-bc-muted w-8">
+                  <input
+                    type="checkbox"
+                    checked={allVisibleSelected}
+                    onChange={toggleAllVisible}
+                    className="cursor-pointer accent-bc-accent"
+                    aria-label="Select all visible agents"
+                  />
+                </th>
                 <th className="px-4 py-2 font-medium text-bc-muted">Name</th>
                 <th className="px-4 py-2 font-medium text-bc-muted">Role</th>
                 <th className="px-4 py-2 font-medium text-bc-muted hidden sm:table-cell">
@@ -544,7 +761,7 @@ export function Agents() {
               </tr>
             </thead>
             <tbody>
-              {agentList.map((a) => (
+              {filteredAgents.map((a) => (
                 <Fragment key={a.name}>
                   <tr
                     onClick={() =>
@@ -555,8 +772,22 @@ export function Agents() {
                     }}
                     role="link"
                     tabIndex={0}
-                    className="border-b border-bc-border/50 cursor-pointer hover:bg-bc-surface transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg"
+                    className={`border-b border-bc-border/50 cursor-pointer transition-colors duration-150 focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg ${
+                      selected.has(a.name) ? "bg-bc-accent/10 hover:bg-bc-accent/15" : "hover:bg-bc-surface"
+                    }`}
                   >
+                    <td
+                      className="px-2 py-2"
+                      onClick={(e) => { e.stopPropagation(); }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selected.has(a.name)}
+                        onChange={() => { toggleOne(a.name); }}
+                        className="cursor-pointer accent-bc-accent"
+                        aria-label={`Select agent ${a.name}`}
+                      />
+                    </td>
                     <td className="px-4 py-2">
                       <InlineAgentName agent={a} onRenamed={refresh} />
                     </td>
@@ -657,6 +888,64 @@ export function Agents() {
           </table>
         )}
       </div>
+
+      {/* Bulk action bar */}
+      {selected.size > 0 && (
+        <div className="fixed left-0 right-0 bottom-0 z-40 border-t border-bc-border bg-bc-surface/95 backdrop-blur shadow-bc-lg">
+          <div className="max-w-6xl mx-auto px-6 py-3 flex items-center gap-3 flex-wrap">
+            <span className="text-sm font-medium text-bc-text">
+              {selected.size} selected
+            </span>
+            {bulkError && (
+              <span className="text-xs text-bc-error truncate max-w-md" title={bulkError}>
+                {bulkError}
+              </span>
+            )}
+            <div className="flex items-center gap-2 ml-auto">
+              <button
+                onClick={handleBulkStart}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded bg-bc-success/20 text-bc-success hover:bg-bc-success/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Start selected agents"
+              >
+                {bulkBusy ? "..." : "Start"}
+              </button>
+              <button
+                onClick={handleBulkStop}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded bg-bc-warning/20 text-bc-warning hover:bg-bc-warning/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Stop selected agents"
+              >
+                {bulkBusy ? "..." : "Stop"}
+              </button>
+              <button
+                onClick={handleBulkMessage}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded bg-bc-accent/20 text-bc-accent hover:bg-bc-accent/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Send message to selected agents"
+              >
+                {bulkBusy ? "..." : "Message"}
+              </button>
+              <button
+                onClick={handleBulkDelete}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded bg-bc-error/20 text-bc-error hover:bg-bc-error/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Delete selected agents"
+              >
+                {bulkBusy ? "..." : "Delete"}
+              </button>
+              <button
+                onClick={clearSelection}
+                disabled={bulkBusy}
+                className="px-3 py-1.5 text-sm rounded border border-bc-border text-bc-muted hover:text-bc-text disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+                aria-label="Clear selection"
+              >
+                Clear
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -17,9 +17,63 @@ interface CreateFormState {
   role: string;
   tool: string;
   runtime: string;
+  task: string;
 }
 
-function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
+// Hardcoded templates for common agent setups. Templates pre-fill the
+// create form with a role/tool/runtime + optional task prompt.
+interface AgentTemplate {
+  id: string;
+  label: string;
+  description: string;
+  role: string;
+  tool: string;
+  runtime: string;
+  taskPrompt?: string;
+}
+
+const TEMPLATES: AgentTemplate[] = [
+  {
+    id: "feature-dev",
+    label: "Feature developer",
+    description: "Claude in Docker, feature-dev role",
+    role: "feature-dev",
+    tool: "claude",
+    runtime: "docker",
+  },
+  {
+    id: "reviewer",
+    label: "Code reviewer",
+    description: "Claude in tmux, reviewer role",
+    role: "reviewer",
+    tool: "claude",
+    runtime: "tmux",
+  },
+  {
+    id: "manager",
+    label: "Manager",
+    description: "Gemini in tmux, manager role",
+    role: "manager",
+    tool: "gemini",
+    runtime: "tmux",
+  },
+  {
+    id: "blank",
+    label: "Blank",
+    description: "Empty form — pick everything manually",
+    role: "",
+    tool: "",
+    runtime: "",
+  },
+];
+
+function CreateAgentForm({
+  onCreated,
+  existingAgents,
+}: {
+  onCreated: () => void;
+  existingAgents: Agent[];
+}) {
   const [open, setOpen] = useState(false);
   const [roles, setRoles] = useState<string[]>([]);
   const [tools, setTools] = useState<string[]>([]);
@@ -28,6 +82,7 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
     role: "",
     tool: "",
     runtime: "",
+    task: "",
   });
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -37,13 +92,40 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
     if (!open) return;
     api
       .listRoles()
-      .then((r) => setRoles(Object.keys(r)))
+      .then((r) => { setRoles(Object.keys(r)); })
       .catch(() => { /* ignore */ });
     api
       .listCLITools()
-      .then((t) => setTools(t.filter((tool) => tool.enabled).map((tool) => tool.name)))
+      .then((t) => { setTools(t.filter((tool) => tool.enabled).map((tool) => tool.name)); })
       .catch(() => { /* ignore */ });
   }, [open]);
+
+  const applyTemplate = (t: AgentTemplate) => {
+    setForm((f) => ({
+      ...f,
+      role: t.role,
+      tool: t.tool,
+      runtime: t.runtime,
+      task: t.taskPrompt ?? f.task,
+    }));
+  };
+
+  const copyFromAgent = (a: Agent) => {
+    setForm((f) => ({
+      ...f,
+      role: a.role,
+      tool: a.tool,
+      runtime: a.runtime_backend ?? "",
+    }));
+  };
+
+  // Top 3 most recent agents as "copy config" suggestions
+  const recentAgents = useMemo(() => {
+    return [...existingAgents]
+      .filter((a) => a.created_at)
+      .sort((a, b) => (b.created_at > a.created_at ? 1 : -1))
+      .slice(0, 3);
+  }, [existingAgents]);
 
   const handleCreate = async () => {
     if (!form.role) {
@@ -53,13 +135,23 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
     setCreating(true);
     setError(null);
     try {
-      await api.createAgent({
+      const created = await api.createAgent({
         name: form.name || undefined,
         role: form.role,
         tool: form.tool || undefined,
         runtime: form.runtime || undefined,
       });
-      setForm({ name: "", role: "", tool: "", runtime: "" });
+      // If a task was entered, send it immediately after creation so the
+      // user doesn't have to open the agent and attach work manually.
+      const task = form.task.trim();
+      if (task) {
+        try {
+          await api.sendToAgent(created.name, task);
+        } catch {
+          // Best-effort — the agent is already created, surface only create errors.
+        }
+      }
+      setForm({ name: "", role: "", tool: "", runtime: "", task: "" });
       setOpen(false);
       onCreated();
     } catch (err) {
@@ -72,7 +164,7 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
   if (!open) {
     return (
       <button
-        onClick={() => setOpen(true)}
+        onClick={() => { setOpen(true); }}
         className="px-3 py-1.5 text-sm rounded bg-bc-accent text-white hover:bg-bc-accent/80 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg"
         aria-label="Create agent"
       >
@@ -86,15 +178,56 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-medium">Create Agent</h2>
         <button
-          onClick={() => {
-            setOpen(false);
-            setError(null);
-          }}
+          type="button"
+          onClick={() => { setOpen(false); setError(null); }}
           className="text-bc-muted hover:text-bc-text text-sm"
         >
           Cancel
         </button>
       </div>
+
+      {/* Templates — quick presets */}
+      <div>
+        <div className="text-[10px] font-semibold text-bc-muted uppercase tracking-wider mb-1.5">
+          Start from template
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {TEMPLATES.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => { applyTemplate(t); }}
+              title={t.description}
+              className="px-2.5 py-1 text-xs rounded-md border border-bc-border bg-bc-bg text-bc-text hover:border-bc-accent/50 hover:bg-bc-accent/5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Recent config chips — copy from existing agents */}
+      {recentAgents.length > 0 && (
+        <div>
+          <div className="text-[10px] font-semibold text-bc-muted uppercase tracking-wider mb-1.5">
+            Or copy config from
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {recentAgents.map((a) => (
+              <button
+                key={a.name}
+                type="button"
+                onClick={() => { copyFromAgent(a); }}
+                title={`${a.role} · ${a.tool} · ${a.runtime_backend ?? "default"}`}
+                className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md border border-bc-border bg-bc-bg hover:border-bc-accent/40 hover:bg-bc-accent/5 transition-colors text-[11px] text-bc-muted hover:text-bc-text focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent"
+              >
+                <span className="w-1 h-1 rounded-full bg-bc-accent/60" />
+                {a.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         <div>
@@ -104,7 +237,7 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
           <input
             type="text"
             value={form.name}
-            onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
+            onChange={(e) => { setForm((f) => ({ ...f, name: e.target.value })); }}
             placeholder="auto-generated"
             className="w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text placeholder:text-bc-muted/50 focus:outline-none focus:ring-1 focus:ring-bc-accent"
           />
@@ -114,7 +247,7 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
           <label className="block text-xs text-bc-muted mb-1">Role *</label>
           <select
             value={form.role}
-            onChange={(e) => setForm((f) => ({ ...f, role: e.target.value }))}
+            onChange={(e) => { setForm((f) => ({ ...f, role: e.target.value })); }}
             className="w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
           >
             <option value="">Select role...</option>
@@ -130,7 +263,7 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
           <label className="block text-xs text-bc-muted mb-1">Tool</label>
           <select
             value={form.tool}
-            onChange={(e) => setForm((f) => ({ ...f, tool: e.target.value }))}
+            onChange={(e) => { setForm((f) => ({ ...f, tool: e.target.value })); }}
             className="w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
           >
             <option value="">Default</option>
@@ -164,9 +297,7 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
           <label className="block text-xs text-bc-muted mb-1">Runtime</label>
           <select
             value={form.runtime}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, runtime: e.target.value }))
-            }
+            onChange={(e) => { setForm((f) => ({ ...f, runtime: e.target.value })); }}
             className="w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text focus:outline-none focus:ring-1 focus:ring-bc-accent"
           >
             <option value="">Default</option>
@@ -177,11 +308,26 @@ function CreateAgentForm({ onCreated }: { onCreated: () => void }) {
         </div>
       </div>
 
+      {/* Task (optional) — sent to the agent immediately after creation */}
+      <div>
+        <label className="block text-xs text-bc-muted mb-1">
+          Initial task <span className="text-bc-muted/50">(optional, sent to the agent on create)</span>
+        </label>
+        <textarea
+          value={form.task}
+          onChange={(e) => { setForm((f) => ({ ...f, task: e.target.value })); }}
+          placeholder="e.g. Review PR #428 and leave comments on the auth flow"
+          rows={3}
+          className="w-full px-2 py-1.5 text-sm rounded border border-bc-border bg-bc-bg text-bc-text placeholder:text-bc-muted/50 focus:outline-none focus:ring-1 focus:ring-bc-accent resize-none"
+        />
+      </div>
+
       {error && <p className="text-xs text-bc-error">{error}</p>}
 
       <div className="flex justify-end">
         <button
-          onClick={handleCreate}
+          type="button"
+          onClick={() => { void handleCreate(); }}
           disabled={creating}
           className="px-3 py-1.5 text-sm rounded bg-bc-accent text-white hover:bg-bc-accent/80 transition-colors disabled:opacity-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-bc-accent focus-visible:ring-offset-1 focus-visible:ring-offset-bc-bg"
         >
@@ -708,7 +854,7 @@ export function Agents() {
         </div>
       </div>
 
-      <CreateAgentForm onCreated={refresh} />
+      <CreateAgentForm onCreated={refresh} existingAgents={allAgents} />
 
       {/* Search + filter toolbar */}
       {allAgents.length > 0 && (


### PR DESCRIPTION
Part of #2979

## Summary

**Combined PR for the full agents revamp, targeting main.** This contains all 6 phases stacked as separate commits for reviewability, plus triggers CI on the full change (the individual stacked PRs target each other, not main, so CI doesn't run on them).

If you prefer to review phase-by-phase, see the stacked PRs:
- Phase 1: #2981 — bulk select + search/filter
- Phase 2: #2982 — Info tab merge (5 tabs → 3)
- Phase 3: #2983 — tree view + hierarchy toggle
- Phase 4: #2984 — activity timeline API + stopped terminal capture
- Phase 5: #2985 — create form upgrade
- Phase 6: #2986 — keyboard shortcuts + MCP popover + polish

## What changed

### Phase 1 — Bulk + search/filter
- 4 new parallel bulk endpoints (`/api/agents/bulk/{start,stop,delete,message}`)
- Search input with `/` keyboard shortcut, debounced to URL `?q=`
- Role / state / tool filters, URL-synced
- Checkbox column + select-all-visible
- Sticky bottom bulk action bar with partial-failure summary
- Esc clears selection, selected rows highlighted

### Phase 2 — Info tab merge
- 5 tabs (Logs/Terminal/Overview/Stats/Role) → 3 tabs (Logs/Terminal/Info)
- Deleted OverviewTab, StatsTab wrapper, RoleTab, MetadataRow
- New InfoTab: Current Task → Stats → Hierarchy → Activity timeline → Metadata (collapsible)
- Smart stopped-agent banner (Last Task / Last ran + italic hint)
- AgentPill component for clickable parent/child navigation
- Keyboard: 1=Logs, 2=Terminal, 3/4/5=Info (muscle memory)

### Phase 3 — Tree view + hierarchy
- Flat / Tree toggle in toolbar, only shown when any agent has parent_id
- Default: Tree if hierarchy exists, Flat otherwise
- URL-synced via `?view=flat|tree`
- Depth-indented rows with └ connector glyph
- Search / filters / bulk select still work in tree mode

### Phase 4 — Activity timeline API + stopped terminal
- `GET /api/agents/{name}/activity` returns last 50 events from `pkg/events`
- InfoTab timeline uses live activity if available, falls back to derived timeline from timestamps
- Terminal tab for stopped agents now shows last captured output (via existing peek polling) instead of a dead screen

### Phase 5 — Create form upgrade
- "Start from template" chips: feature-dev, reviewer, manager, blank
- "Or copy config from" chips: 3 most-recent existing agents
- Initial task textarea — task sent to agent immediately after creation

### Phase 6 — Keyboard shortcuts + polish
- `/` focus search, `j/k` nav, `Enter` open, `Space` peek, `x` toggle select, `a` select all, `Esc` clear
- Focused row gets `ring-1 ring-inset ring-bc-accent/40`
- Peek row gets `bg-bc-accent/5` for visual indicator
- MCP column: full server list in `title` tooltip, "+N" chip with its own tooltip
- KeyHint bar above the table for shortcut discoverability

## Code impact

| | Files | Lines |
|---|---|---|
| Created | 2 (agents_bulk.go, agents_activity.go) | ~240 |
| Modified | 4 (Agents.tsx, AgentDetail.tsx, agents.go, client.ts) | ~1400 |
| Deleted | 0 (InfoTab replaces 3 old tabs inline) | ~300 removed |

Net: ~+1300 lines, 1 new Go file, 1 new handler file. No breaking API changes.

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] `go test ./server/handlers/...` pass
- [x] `(cd web && bun run lint)` 0 errors
- [x] `(cd web && bun run build)` clean
- [x] Playwright verified: list (search, filter, bulk), detail (Info tab on running + stopped), Terminal tab fallback, Create form templates
- [ ] CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)