### PR TITLE
feat(infra): embed TUI bundle + security fixes + dev tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Build web UI for embed
         run: cd web && bun install && bun run build && rm -rf ../server/web/dist && mkdir -p ../server/web && cp -r dist ../server/web/dist
 
+      - name: Build TUI bundle for embed
+        run: make build-local-tui-bundle
+
       - name: Determine goreleaser skip flags
         id: release_flags
         env:
@@ -119,6 +122,9 @@ jobs:
 
       - name: Build web UI for embed
         run: cd web && bun install && bun run build && rm -rf ../server/web/dist && mkdir -p ../server/web && cp -r dist ../server/web/dist
+
+      - name: Build TUI bundle for embed
+        run: make build-local-tui-bundle
 
       - name: Build macOS binaries
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ node_modules/
 *.tsbuildinfo
 .bc/tmp/
 .playwright-mcp/
+packages/bc-cli/bin/bc

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@
 # Top-level
 .PHONY: build build-local build-docker test lint fmt vet check clean deps release install
 # Go
-.PHONY: build-local-bc test-go test-go-fast lint-go fmt-go vet-go coverage-go bench-go deps-go check-go scan-go
+.PHONY: build-local-bc build-local-tui-bundle test-go test-go-fast lint-go fmt-go vet-go coverage-go bench-go deps-go check-go scan-go
 .PHONY: release-local-bc install-local-bc
 # Docker
 .PHONY: build-docker-daemon build-docker-db build-docker-bcdb
@@ -105,10 +105,21 @@ clean: clean-local ## Remove all build artifacts
 
 build-local-go: build-local-bc ## Build all Go binaries
 
-build-local-bc: ## Build bc (embeds web UI + server)
+build-local-bc: build-local-tui-bundle ## Build bc (embeds web UI, TUI bundle, server)
 	@mkdir -p $(BUILD_DIR)
 	@if [ ! -d server/web/dist ]; then mkdir -p server/web/dist && echo '<!-- stub -->' > server/web/dist/index.html; fi
 	$(GO) build -ldflags="$(LDFLAGS_VERSION)" -o $(BUILD_DIR)/bc ./cmd/bc
+
+build-local-tui-bundle: ## Build single-file TUI bundle for embedding into bc binary
+	@mkdir -p internal/cmd/tui-bundle
+	@if [ ! -f tui/node_modules/.package-lock.json ] && [ ! -d tui/node_modules/react-devtools-core ]; then \
+		echo "Installing TUI dependencies..."; \
+		cd tui && bun install; \
+	fi
+	cd tui && bun build --target=bun --minify \
+		--external react-devtools-core --external yoga-wasm-web \
+		--outfile=../internal/cmd/tui-bundle/index.js \
+		src/index.tsx
 
 # =============================================================================
 # Build — Local TypeScript
@@ -277,7 +288,7 @@ ci-docker: ## Build all Docker images
 # Release
 # =============================================================================
 
-release-local-bc: ## Build optimized bc binary
+release-local-bc: build-local-tui-bundle ## Build optimized bc binary (embeds web + TUI)
 	@mkdir -p $(BUILD_DIR)
 	@if [ ! -d server/web/dist ]; then mkdir -p server/web/dist && echo '<!-- stub -->' > server/web/dist/index.html; fi
 	$(GO) build -ldflags="$(LDFLAGS_RELEASE)" -o $(BUILD_DIR)/bc ./cmd/bc
@@ -338,7 +349,8 @@ scan-ts: ## TS dependency audit
 
 clean-local: ## Remove build artifacts
 	rm -rf $(BUILD_DIR)/ dist/ coverage.out coverage.html
-	rm -rf tui/dist web/dist server/web/dist landing/.next landing/out
+	rm -rf tui/dist tui/dist-bundle web/dist server/web/dist landing/.next landing/out
+	rm -rf internal/cmd/tui-bundle/index.js
 
 clean-deps: clean-local ## Remove artifacts + node_modules
 	rm -rf tui/node_modules web/node_modules landing/node_modules

--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -26,36 +26,9 @@ func runHome(cmd *cobra.Command, args []string) error {
 		return errNotInWorkspace(err)
 	}
 
-	// Find TUI directory - prefer cwd for worktree support
-	// In worktrees, ws.RootDir resolves through symlinked .bc to parent repo,
-	// but we want to use the worktree's local tui/ directory if it exists.
-	tuiRoot, err := findTUIRoot(ws.RootDir)
+	tuiEntry, tuiRoot, err := resolveTUIEntry(ws.RootDir)
 	if err != nil {
 		return err
-	}
-	tuiDir := filepath.Join(tuiRoot, "tui")
-	tuiEntry := filepath.Join(tuiDir, "dist", "index.js")
-
-	// Check if TUI is built
-	if _, statErr := os.Stat(tuiEntry); os.IsNotExist(statErr) {
-		log.Debug("TUI not built, checking for source")
-
-		// Check if TUI source exists
-		tuiSrc := filepath.Join(tuiDir, "src", "index.tsx")
-		if _, srcErr := os.Stat(tuiSrc); os.IsNotExist(srcErr) {
-			return fmt.Errorf("TUI not found. Run from the bc repository root")
-		}
-
-		// Prompt to build
-		fmt.Println("TUI not built. Building now...")
-		buildCtx := context.Background()
-		buildCmd := exec.CommandContext(buildCtx, "make", "build-tui")
-		buildCmd.Dir = tuiRoot
-		buildCmd.Stdout = os.Stdout
-		buildCmd.Stderr = os.Stderr
-		if buildErr := buildCmd.Run(); buildErr != nil {
-			return fmt.Errorf("failed to build TUI: %w\nRun 'make build-tui-local' manually", buildErr)
-		}
 	}
 
 	// Find bun or node
@@ -128,4 +101,89 @@ func findTUIRoot(wsRoot string) (string, error) {
 	}
 
 	return "", fmt.Errorf("TUI directory not found in cwd (%s) or workspace root (%s)", cwd, wsRoot)
+}
+
+// resolveTUIEntry returns the path to the TUI entry point script and the
+// directory to run it from. It prefers the embedded bundle (released binary),
+// falling back to the dev checkout's tui/dist/index.js (or builds it if
+// source is present).
+//
+// Returns (entryPath, runDir, error).
+func resolveTUIEntry(wsRoot string) (string, string, error) {
+	// Released binary: use the embedded bundle.
+	if hasEmbeddedTUI() {
+		return extractEmbeddedTUI()
+	}
+
+	// Dev checkout: find tui/ directory and use tsc-built dist/index.js.
+	tuiRoot, err := findTUIRoot(wsRoot)
+	if err != nil {
+		return "", "", err
+	}
+	tuiDir := filepath.Join(tuiRoot, "tui")
+	tuiEntry := filepath.Join(tuiDir, "dist", "index.js")
+
+	if _, statErr := os.Stat(tuiEntry); os.IsNotExist(statErr) {
+		log.Debug("TUI not built, checking for source")
+		tuiSrc := filepath.Join(tuiDir, "src", "index.tsx")
+		if _, srcErr := os.Stat(tuiSrc); os.IsNotExist(srcErr) {
+			return "", "", fmt.Errorf("TUI not found. Run from the bc repository root or install a released bc binary")
+		}
+
+		fmt.Println("TUI not built. Building now...")
+		buildCtx := context.Background()
+		buildCmd := exec.CommandContext(buildCtx, "make", "build-local-tui")
+		buildCmd.Dir = tuiRoot
+		buildCmd.Stdout = os.Stdout
+		buildCmd.Stderr = os.Stderr
+		if buildErr := buildCmd.Run(); buildErr != nil {
+			return "", "", fmt.Errorf("failed to build TUI: %w\nRun 'make build-local-tui' manually", buildErr)
+		}
+	}
+
+	return tuiEntry, tuiRoot, nil
+}
+
+// extractEmbeddedTUI writes the embedded tuiBundleJS to a stable cache dir
+// under $XDG_CACHE_HOME/bc/tui/ (or ~/.cache/bc/tui/) and returns its path.
+// The cache dir is reused across invocations to avoid disk churn; a hash of
+// the embedded content gates re-extraction so binary upgrades get fresh files.
+func extractEmbeddedTUI() (string, string, error) {
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil {
+		cacheRoot = os.TempDir()
+	}
+	bundleDir := filepath.Join(cacheRoot, "bc", "tui", fmt.Sprintf("%x", tuiBundleHash()))
+	entry := filepath.Join(bundleDir, "index.js")
+
+	// Skip re-extraction if the file already exists and is the right size.
+	if info, statErr := os.Stat(entry); statErr == nil && info.Size() == int64(len(tuiBundleJS)) {
+		log.Debug("using cached embedded TUI bundle", "path", entry)
+		return entry, bundleDir, nil
+	}
+
+	if mkErr := os.MkdirAll(bundleDir, 0o750); mkErr != nil {
+		return "", "", fmt.Errorf("create TUI cache dir: %w", mkErr)
+	}
+	if writeErr := os.WriteFile(entry, tuiBundleJS, 0o600); writeErr != nil {
+		return "", "", fmt.Errorf("write TUI bundle: %w", writeErr)
+	}
+	log.Debug("extracted embedded TUI bundle", "path", entry, "bytes", len(tuiBundleJS))
+	return entry, bundleDir, nil
+}
+
+// tuiBundleHash returns a short content hash of the embedded bundle.
+// Used to pick a cache directory that changes when the binary is upgraded.
+func tuiBundleHash() [8]byte {
+	var h [8]byte
+	// FNV-1a 64-bit, kept inline to avoid another import.
+	hash := uint64(14695981039346656037)
+	for _, b := range tuiBundleJS {
+		hash ^= uint64(b)
+		hash *= 1099511628211
+	}
+	for i := 0; i < 8; i++ {
+		h[i] = byte(hash >> (i * 8))
+	}
+	return h
 }

--- a/internal/cmd/tui-bundle/index.js
+++ b/internal/cmd/tui-bundle/index.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+// Stub — real TUI bundle is built by `make build-local-tui-bundle` and
+// embedded into the bc binary. In dev checkouts before the first build,
+// this stub is present so //go:embed doesn't fail.
+// hasEmbeddedTUI() returns false for files smaller than 10KB, so the
+// runtime falls back to tui/dist/index.js in dev mode.
+console.error("TUI bundle not built. Run: make build-local-tui-bundle");
+process.exit(1);

--- a/internal/cmd/tui_embed.go
+++ b/internal/cmd/tui_embed.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	_ "embed"
+)
+
+// tuiBundleJS is the precompiled TUI bundle (single JS file produced by
+// `bun build --minify`). At runtime the TUI is extracted to a temp directory
+// and executed via `bun run`.
+//
+// The bundle is built by `make build-local-tui-bundle` which writes to
+// internal/cmd/tui-bundle/index.js. In dev checkouts without the bundle,
+// this will be a tiny stub file and the code falls back to tui/dist/index.js.
+//
+//go:embed tui-bundle/index.js
+var tuiBundleJS []byte
+
+// hasEmbeddedTUI reports whether a real TUI bundle is embedded (vs the stub).
+func hasEmbeddedTUI() bool {
+	return len(tuiBundleJS) > 10_000 // stub is ~100 bytes, real bundle is MB
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -928,6 +928,11 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	if existing.ParentID != "" {
 		env["BC_PARENT_ID"] = existing.ParentID
 	}
+	// Pass through BC_API_KEY from the host environment so agents inside
+	// containers can authenticate back to bcd when --api-key is enabled.
+	if apiKey := os.Getenv("BC_API_KEY"); apiKey != "" {
+		env["BC_API_KEY"] = apiKey
+	}
 	injectEnv(env, wsPath, toolName, existing.EnvFile)
 
 	rt := m.runtimeForAgent(name)
@@ -1140,6 +1145,11 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	}
 	if parentID != "" {
 		env["BC_PARENT_ID"] = parentID
+	}
+	// Pass through BC_API_KEY from the host environment so agents inside
+	// containers can authenticate back to bcd when --api-key is enabled.
+	if apiKey := os.Getenv("BC_API_KEY"); apiKey != "" {
+		env["BC_API_KEY"] = apiKey
 	}
 	injectEnv(env, wsPath, effectiveTool, opts.EnvFile)
 

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# test-install.sh — end-to-end smoke test for every bc install method.
+#
+# Tests:
+#   1. Build from source via `make install-local-bc` and run `bc version`.
+#   2. Dry-run verify scripts/install.sh URL patterns without touching the host.
+#   3. `go install github.com/rpuneet/bc/cmd/bc@latest` into a throwaway GOPATH.
+#   4. Pull + run ghcr.io/rpuneet/bc:v0.1.0 Docker image.
+#
+# Exit 0 if every test passes, exit 1 if any fail. Individual test failures
+# are reported but do not abort the run — we want the full picture.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_SLUG="rpuneet/bc"
+DOCKER_IMAGE="ghcr.io/${REPO_SLUG}:v0.1.0"
+GO_PKG="github.com/${REPO_SLUG}/cmd/bc@latest"
+INSTALL_SH="${REPO_ROOT}/scripts/install.sh"
+
+# ANSI colors (skip if not a TTY or NO_COLOR set).
+if [[ -t 1 && -z "${NO_COLOR:-}" ]]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[1;33m'
+    CYAN=$'\033[0;36m'
+    BOLD=$'\033[1m'
+    NC=$'\033[0m'
+else
+    RED=""; GREEN=""; YELLOW=""; CYAN=""; BOLD=""; NC=""
+fi
+
+pass_count=0
+fail_count=0
+skip_count=0
+fail_names=()
+
+header() {
+    echo
+    echo "${BOLD}${CYAN}==> $1${NC}"
+}
+
+pass() {
+    echo "${GREEN}PASS${NC} $1"
+    pass_count=$((pass_count + 1))
+}
+
+fail() {
+    echo "${RED}FAIL${NC} $1"
+    fail_count=$((fail_count + 1))
+    fail_names+=("$1")
+}
+
+skip() {
+    echo "${YELLOW}SKIP${NC} $1 ($2)"
+    skip_count=$((skip_count + 1))
+}
+
+# -----------------------------------------------------------------------------
+# Test 1: Build from source.
+# -----------------------------------------------------------------------------
+test_build_from_source() {
+    header "Test 1: build from source (make install-local-bc)"
+    if ! command -v make >/dev/null 2>&1; then
+        skip "build-from-source" "make not installed"
+        return
+    fi
+    if ! command -v go >/dev/null 2>&1; then
+        skip "build-from-source" "go not installed"
+        return
+    fi
+
+    local gobin
+    gobin="$(go env GOBIN)"
+    if [[ -z "$gobin" ]]; then
+        gobin="$(go env GOPATH)/bin"
+    fi
+
+    ( cd "$REPO_ROOT" && make install-local-bc ) >/tmp/bc-test-install-build.log 2>&1
+    if [[ $? -ne 0 ]]; then
+        echo "  see /tmp/bc-test-install-build.log for details"
+        fail "build-from-source"
+        return
+    fi
+
+    if [[ ! -x "${gobin}/bc" ]]; then
+        echo "  expected binary at ${gobin}/bc"
+        fail "build-from-source"
+        return
+    fi
+
+    if ! "${gobin}/bc" version >/tmp/bc-test-install-version.log 2>&1; then
+        echo "  bc version failed, see /tmp/bc-test-install-version.log"
+        fail "build-from-source"
+        return
+    fi
+
+    pass "build-from-source"
+}
+
+# -----------------------------------------------------------------------------
+# Test 2: install.sh dry-run URL pattern check.
+# -----------------------------------------------------------------------------
+test_install_sh_dry_run() {
+    header "Test 2: scripts/install.sh URL pattern (dry run)"
+    if [[ ! -f "$INSTALL_SH" ]]; then
+        fail "install-sh-exists"
+        return
+    fi
+
+    if ! bash -n "$INSTALL_SH" 2>/tmp/bc-test-install-shcheck.log; then
+        echo "  shell syntax error in $INSTALL_SH"
+        fail "install-sh-syntax"
+        return
+    fi
+
+    if ! grep -q 'rpuneet/bc' "$INSTALL_SH"; then
+        echo "  install.sh does not reference rpuneet/bc"
+        fail "install-sh-repo-url"
+        return
+    fi
+
+    if ! grep -qE 'github\.com/rpuneet/bc/releases' "$INSTALL_SH"; then
+        echo "  install.sh missing GitHub releases URL pattern"
+        fail "install-sh-release-url"
+        return
+    fi
+
+    pass "install-sh-dry-run"
+}
+
+# -----------------------------------------------------------------------------
+# Test 3: go install into throwaway GOPATH.
+# -----------------------------------------------------------------------------
+test_go_install() {
+    header "Test 3: go install ${GO_PKG}"
+    if ! command -v go >/dev/null 2>&1; then
+        skip "go-install" "go not installed"
+        return
+    fi
+
+    local tmp_gopath
+    tmp_gopath="$(mktemp -d -t bc-test-gopath.XXXXXX)"
+    trap 'rm -rf "$tmp_gopath"' RETURN
+
+    GOPATH="$tmp_gopath" GOBIN="$tmp_gopath/bin" \
+        go install "$GO_PKG" >/tmp/bc-test-install-goinstall.log 2>&1
+    if [[ $? -ne 0 ]]; then
+        echo "  go install failed, see /tmp/bc-test-install-goinstall.log"
+        fail "go-install"
+        return
+    fi
+
+    if [[ ! -x "${tmp_gopath}/bin/bc" ]]; then
+        echo "  expected binary at ${tmp_gopath}/bin/bc"
+        fail "go-install"
+        return
+    fi
+
+    if ! "${tmp_gopath}/bin/bc" version >/tmp/bc-test-install-govers.log 2>&1; then
+        echo "  installed bc version failed, see /tmp/bc-test-install-govers.log"
+        fail "go-install"
+        return
+    fi
+
+    pass "go-install"
+}
+
+# -----------------------------------------------------------------------------
+# Test 4: Docker pull + run.
+# -----------------------------------------------------------------------------
+test_docker() {
+    header "Test 4: docker pull ${DOCKER_IMAGE}"
+    if ! command -v docker >/dev/null 2>&1; then
+        skip "docker" "docker not installed"
+        return
+    fi
+    if ! docker info >/dev/null 2>&1; then
+        skip "docker" "docker daemon unreachable"
+        return
+    fi
+
+    if ! docker pull "$DOCKER_IMAGE" >/tmp/bc-test-install-dockerpull.log 2>&1; then
+        echo "  docker pull failed, see /tmp/bc-test-install-dockerpull.log"
+        fail "docker-pull"
+        return
+    fi
+
+    if ! docker run --rm "$DOCKER_IMAGE" bc version >/tmp/bc-test-install-dockerrun.log 2>&1; then
+        echo "  docker run failed, see /tmp/bc-test-install-dockerrun.log"
+        fail "docker-run"
+        return
+    fi
+
+    pass "docker"
+}
+
+# -----------------------------------------------------------------------------
+# Runner.
+# -----------------------------------------------------------------------------
+test_build_from_source
+test_install_sh_dry_run
+test_go_install
+test_docker
+
+echo
+echo "${BOLD}Summary:${NC} ${GREEN}${pass_count} passed${NC}, ${RED}${fail_count} failed${NC}, ${YELLOW}${skip_count} skipped${NC}"
+
+if (( fail_count > 0 )); then
+    echo "${RED}Failures:${NC}"
+    for name in "${fail_names[@]}"; do
+        echo "  - $name"
+    done
+    exit 1
+fi
+
+exit 0

--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -120,9 +120,17 @@ func clampInt(n, min, max int) int {
 
 // MaxBodySize returns a middleware that limits request body size.
 // Returns 413 Payload Too Large if the body exceeds maxBytes.
+//
+// MCP endpoints (/_mcp/*) are excluded because MCP tools like send_file
+// legitimately handle large payloads (up to 50MB) and enforce their own
+// per-tool size limits in server/mcp/tools.go.
 func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/_mcp/") {
+				next.ServeHTTP(w, r)
+				return
+			}
 			if r.ContentLength > maxBytes {
 				httpError(w, "request body too large", http.StatusRequestEntityTooLarge)
 				return

--- a/tui/bun.lock
+++ b/tui/bun.lock
@@ -8,6 +8,7 @@
         "ink": "^4.4.1",
         "ink-text-input": "^5.0.1",
         "react": "^18.2.0",
+        "react-devtools-core": "^7.0.1",
       },
       "devDependencies": {
         "@eslint/js": "^8.54.0",
@@ -539,6 +540,8 @@
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
+    "react-devtools-core": ["react-devtools-core@7.0.1", "", { "dependencies": { "shell-quote": "^1.6.1", "ws": "^7" } }, "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw=="],
+
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
@@ -580,6 +583,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
@@ -704,6 +709,8 @@
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
+    "react-devtools-core/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 

--- a/tui/package.json
+++ b/tui/package.json
@@ -19,7 +19,8 @@
   "dependencies": {
     "ink": "^4.4.1",
     "ink-text-input": "^5.0.1",
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "react-devtools-core": "^7.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^8.54.0",


### PR DESCRIPTION
## Summary

Major: **TUI now embedded in the bc binary.** Released binaries no longer require a source checkout to run `bc home` — just `bun` as a runtime.

Also batches three deferred infra fixes and adds an install smoke test script.

## Changes

### 1. Embed TUI bundle (the big one)

**Problem:** The released `bc` binary only embedded the web UI. `bc home` read `tui/dist/index.js` from disk and failed on users who installed from `curl`/Homebrew/`go install` — they had no source checkout.

**Fix:**
- New Makefile target `build-local-tui-bundle` runs `bun build --target=bun --minify --external react-devtools-core --external yoga-wasm-web` to produce a single 490KB JS file at `internal/cmd/tui-bundle/index.js`
- `internal/cmd/tui_embed.go` uses `//go:embed` to pack that file into the Go binary
- `internal/cmd/home.go` rewritten: `resolveTUIEntry` picks the embedded bundle (released) or falls back to `tui/dist/index.js` (dev checkouts)
- Embedded bundle extracted to `$XDG_CACHE_HOME/bc/tui/<content-hash>/index.js` on first run, cached across invocations, re-extracted on binary upgrade (hash changes)
- Tiny 435B stub committed at `tui-bundle/index.js` so `//go:embed` succeeds on fresh clones; real bundle overwrites it during build
- `release-local-bc` and CI release workflow now both build the bundle before the Go build
- Final release binary: **~18MB** (was ~15MB) with full TUI embedded

### 2. Task #60 — BC_API_KEY passthrough to Docker agents

**Problem:** When `bcd` runs with `--api-key`, Docker-based agents couldn't authenticate back because the API key wasn't forwarded into container env.

**Fix:** `pkg/agent/agent.go` now adds `BC_API_KEY` to the env map in both create and restart paths, gated on the host having it set. The container backend already forwards every env key as a `-v` flag — no changes needed there.

### 3. Task #61 — MCP body size mismatch

**Problem:** `server/mcp/tools.go` allows 50MB files for `send_file`, but `server/server.go` globally capped HTTP bodies at 1MB via `MaxBodySize(1<<20)`. Large MCP payloads were pre-rejected with 413.

**Fix:** `MaxBodySize` middleware in `server/handlers/helpers.go` short-circuits for paths starting with `/_mcp/`, letting the MCP handler enforce its own limits.

### 4. Task #48 — Install smoke test script

**New file:** `scripts/test-install.sh` — tests the full install matrix locally:
- `make install-local-bc` + `bc version`
- `install.sh` syntax check and URL pattern verification
- `go install github.com/rpuneet/bc/cmd/bc@latest` in throwaway GOPATH
- `docker pull ghcr.io/rpuneet/bc:v0.1.0 && docker run --rm ... bc version`

Skips gracefully when tooling is missing; exits 1 on any real failure.

## Verification

```bash
make build-local-tui-bundle  # produces internal/cmd/tui-bundle/index.js (490KB)
make release-local-bc        # embeds it, produces bin/bc (~18MB)
cd /tmp && /path/to/bin/bc version  # works outside source tree
```

- `go build ./...` clean
- `golangci-lint run ./pkg/agent/... ./server/handlers/...` zero issues
- `go test ./server/handlers/ -run MaxBodySize` passes

## Test plan

- [ ] CI green (lint, test, TUI, web, landing, build gate, security)
- [ ] `make release-local-bc` builds successfully with embedded bundle
- [ ] `bin/bc version` runs
- [ ] `bin/bc home` from a tmp dir extracts TUI and runs (manual)
- [ ] Next v0.1.1 release ships binaries where `bc home` works without a source checkout

Closes #60, #61, #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)