### PR TITLE
fix: post-merge bug fixes — workspace init, modal, device info, notify logging

### DIFF
--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -107,6 +107,12 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, content, message
 			return
 		}
 
+		log.Info("notify: dispatch", "channel", channel, "sender", sender, "subscribers", len(subs))
+
+		if len(subs) == 0 {
+			return
+		}
+
 		mentionSet := make(map[string]bool, len(mentions))
 		for _, m := range mentions {
 			mentionSet[m] = true
@@ -137,6 +143,8 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, content, message
 				status = StatusFailed
 				errStr = sendErr.Error()
 				log.Warn("notify: delivery failed", "agent", sub.Agent, "channel", channel, "error", sendErr)
+			} else {
+				log.Info("notify: delivered", "agent", sub.Agent, "channel", channel)
 			}
 
 			// Log delivery

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -109,10 +109,6 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, content, message
 
 		log.Info("notify: dispatch", "channel", channel, "sender", sender, "subscribers", len(subs))
 
-		if len(subs) == 0 {
-			return
-		}
-
 		mentionSet := make(map[string]bool, len(mentions))
 		for _, m := range mentions {
 			mentionSet[m] = true

--- a/server/handlers/stats.go
+++ b/server/handlers/stats.go
@@ -70,6 +70,9 @@ func (h *StatsHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/stats/system", h.system)
 	mux.HandleFunc("/api/stats/summary", h.summary)
 
+	// System info endpoint
+	mux.HandleFunc("/api/system/info", h.systemInfo)
+
 	// New per-resource timeseries endpoints
 	h.RegisterSystemStats(mux)
 	h.RegisterAgentStats(mux)
@@ -105,6 +108,20 @@ func (h *StatsHandler) system(w http.ResponseWriter, r *http.Request) {
 		"go_version":           runtime.Version(),
 		"uptime_seconds":       int64(time.Since(serverStartTime).Seconds()),
 		"goroutines":           runtime.NumGoroutine(),
+	})
+}
+
+func (h *StatsHandler) systemInfo(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+
+	hostname, _ := os.Hostname() //nolint:errcheck // best-effort
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"hostname": hostname,
+		"os":       runtime.GOOS,
+		"arch":     runtime.GOARCH,
 	})
 }
 

--- a/server/workspace_services.go
+++ b/server/workspace_services.go
@@ -252,7 +252,13 @@ func (m *WorkspaceManager) Load(ctx context.Context, wsID string) (*WorkspaceSer
 
 	ws, err := workspace.Load(entry.Path)
 	if err != nil {
-		return nil, fmt.Errorf("load workspace %s: %w", entry.Path, err)
+		// Registered but never initialized (no settings.json / preferences.json).
+		// Auto-initialize so the UI gets a valid (empty) workspace instead of 500.
+		ws, err = workspace.Init(entry.Path)
+		if err != nil {
+			return nil, fmt.Errorf("load/init workspace %s: %w", entry.Path, err)
+		}
+		log.Info("workspace auto-initialized on first access", "path", entry.Path)
 	}
 
 	if m.factory == nil {

--- a/server/workspace_services.go
+++ b/server/workspace_services.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -252,11 +253,15 @@ func (m *WorkspaceManager) Load(ctx context.Context, wsID string) (*WorkspaceSer
 
 	ws, err := workspace.Load(entry.Path)
 	if err != nil {
-		// Registered but never initialized (no settings.json / preferences.json).
-		// Auto-initialize so the UI gets a valid (empty) workspace instead of 500.
+		// Only auto-init if the workspace is uninitialized (no config file).
+		// Permission errors, corrupt config, etc. should propagate as real errors.
+		errMsg := err.Error()
+		if !strings.Contains(errMsg, "not a bc workspace") && !strings.Contains(errMsg, "no preferences.json") && !strings.Contains(errMsg, "no settings.json") {
+			return nil, fmt.Errorf("load workspace %s: %w", entry.Path, err)
+		}
 		ws, err = workspace.Init(entry.Path)
 		if err != nil {
-			return nil, fmt.Errorf("load/init workspace %s: %w", entry.Path, err)
+			return nil, fmt.Errorf("init workspace %s: %w", entry.Path, err)
 		}
 		log.Info("workspace auto-initialized on first access", "path", entry.Path)
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -970,6 +970,7 @@ export const api = {
   /** Get file download URL. */
   getFileUrl: (id: string) => `${BASE}/files/${encodeURIComponent(id)}`,
 
+  getSystemInfo: () => request<{ hostname: string; os: string; arch: string }>("/system/info"),
   getSettings: () => request<SettingsConfig>("/settings"),
   updateSettings: (patch: Record<string, unknown>) =>
     request<SettingsConfig>("/settings", {

--- a/web/src/components/CreateAgentModal.tsx
+++ b/web/src/components/CreateAgentModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, memo } from "react";
 import { AgentIcon } from "./agent-ui";
 import type { AgentShape } from "./agent-ui";
 import { MONO } from "../utils/typography";
@@ -66,6 +66,9 @@ const VALID_RUNTIMES = new Set<string>(["docker", "tmux"]);
 
 const SHAPES: AgentShape[] = ["hexagon", "circle", "square"];
 
+// Memoized avatar so CSS animation ticks don't cause parent re-renders
+const MemoAgentIcon = memo(AgentIcon);
+
 const INPUT_CLS =
   "w-full bg-bc-bg border border-bc-border rounded px-3 py-2 text-sm text-bc-text " +
   "placeholder:text-bc-muted outline-none focus:border-bc-accent transition-colors";
@@ -109,9 +112,13 @@ export function CreateAgentModal({
       });
   }, []);
 
-  // Reset on open
+  // Reset form only when the modal is first opened (open transitions to true).
+  // We use a ref to track the previous open state so that changes to
+  // existingNames or defaultCloneFrom while the modal is already open
+  // do not wipe form fields the user is actively typing in.
+  const prevOpenRef = useRef(false);
   useEffect(() => {
-    if (open) {
+    if (open && !prevOpenRef.current) {
       const newName = generateName(existingNames);
       setName(newName);
       setShape(SHAPES[Math.floor(Math.random() * SHAPES.length)] ?? "hexagon");
@@ -124,8 +131,9 @@ export function CreateAgentModal({
       setCloneFrom(defaultCloneFrom);
       requestAnimationFrame(() => firstInputRef.current?.focus());
     }
+    prevOpenRef.current = open;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, existingNames, defaultCloneFrom]);
+  }, [open]);
 
   // Close on Escape
   useEffect(() => {
@@ -216,7 +224,7 @@ export function CreateAgentModal({
         <div className="px-5 py-4 flex flex-col gap-4">
           {/* Shape preview */}
           <div className="flex justify-center">
-            <AgentIcon shape={shape} state="idle" size={64} tool={provider} />
+            <MemoAgentIcon shape={shape} state="idle" size={64} tool={provider} />
           </div>
 
           {/* Name + regen */}

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -342,6 +342,7 @@ function ConfigTab({ agent }: { agent: Agent }) {
   const [syncing, setSyncing] = useState(false);
   const [syncDone, setSyncDone] = useState(false);
   const syncDoneTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [hostname, setHostname] = useState("localhost");
 
   const fetchMcps = useCallback(() => {
     setMcpLoading(true);
@@ -400,6 +401,16 @@ function ConfigTab({ agent }: { agent: Agent }) {
       })
       .catch(() => {/* best-effort */});
     return () => { cancelled = true; };
+  }, []);
+
+  // Fetch hostname from system info endpoint.
+  useEffect(() => {
+    fetch("/api/system/info")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (data?.hostname) setHostname(data.hostname);
+      })
+      .catch(() => {/* best-effort */});
   }, []);
 
   // Load persisted env vars from API on mount.
@@ -510,7 +521,7 @@ function ConfigTab({ agent }: { agent: Agent }) {
             </svg>
           )}
           <span className="font-semibold">
-            {isDocker ? "Docker container" : "tmux (localhost)"}
+            {isDocker ? "Docker container" : `tmux (${hostname})`}
           </span>
           <span className="text-current/50">·</span>
           {isDocker ? (

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -403,13 +403,10 @@ function ConfigTab({ agent }: { agent: Agent }) {
     return () => { cancelled = true; };
   }, []);
 
-  // Fetch hostname from system info endpoint.
+  // Fetch hostname from system info endpoint (uses shared API client for workspace header).
   useEffect(() => {
-    fetch("/api/system/info")
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        if (data?.hostname) setHostname(data.hostname);
-      })
+    api.getSystemInfo()
+      .then((data) => { if (data?.hostname) setHostname(data.hostname); })
       .catch(() => {/* best-effort */});
   }, []);
 


### PR DESCRIPTION
## Summary
- **Auto-init workspaces**: Registered but uninitialized workspaces (gymhq, imx) no longer 500 — auto-initialized on first access
- **Create agent modal**: Fixed re-render on avatar animation that cleared form inputs — `useEffect` guard prevents reset after open
- **Device hostname**: Added `/api/system/info` endpoint; agent detail shows actual hostname instead of "localhost"
- **Notify dispatch logging**: Added INFO-level logs for dispatch entry, subscriber count, and per-agent delivery — makes the delivery pipeline observable
- **Build pipeline**: `make build-local-bc` now depends on `build-local-web` — binary always embeds fresh frontend
- **Workspace scoping**: All API calls send `X-BC-Workspace` header — workspace switching actually works

## Test plan
- [ ] Switch to gymhq workspace — should show empty agents, not 500
- [ ] Open create agent modal, type a name — text should not be cleared
- [ ] Check agent detail config banner — should show hostname not "localhost"
- [ ] Send Slack message — check daemon log for `notify: dispatch` and `notify: delivered` lines
- [ ] `make build-local-bc` rebuilds web before Go binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System information endpoint exposing hostname, OS, and architecture
  * Agent detail view shows dynamically fetched hostname for tmux runtime agents

* **Improvements**
  * Workspaces auto-initialize on first access for smoother onboarding
  * Agent creation modal no longer overwrites user edits when open
<!-- end of auto-generated comment: release notes by coderabbit.ai -->