### PR TITLE
docs(channels): channel architecture documentation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,7 +92,7 @@ make clean-deps            # Remove artifacts + node_modules
 - **pkg/** → reusable packages:
   - **agent/** → agent lifecycle, Manager, SpawnOptions, role setup
   - **attachment/** → file attachment handling
-  - **channel/** → SQLite-backed inter-agent communication with reactions
+  - **channel/** → (legacy, being removed) SQLite-backed inter-agent communication
   - **client/** → HTTP client for bcd API
   - **container/** → Docker runtime backend
   - **cost/** → cost tracking, budgets, import from Claude
@@ -100,7 +100,7 @@ make clean-deps            # Remove artifacts + node_modules
   - **db/** → database utilities and connection management
   - **doctor/** → workspace health diagnostics
   - **events/** → event log (SQLite)
-  - **gateway/** → API gateway routing
+  - **gateway/** → inbound notification adapters for external platforms (Slack, Telegram, Discord, etc.)
   - **log/** → structured logging
   - **mcp/** → Model Context Protocol client/server
   - **names/** → agent name generation
@@ -126,7 +126,7 @@ make clean-deps            # Remove artifacts + node_modules
 
 - **Agents**: Isolated AI assistants in tmux sessions, each with own git worktree. Have roles (root, engineer, manager) with capabilities. State in `.bc/agents/<name>/`.
 - **Workspace**: Project dir with `.bc/` subdirectory for config, state, logs. Uses settings.json (v2) config format.
-- **Channels**: SQLite-backed persistent inter-agent communication with reactions.
+- **Channels**: Inbound notification-only gateways connecting external platforms (Slack, Telegram, etc.) to agents. See [docs/architecture/channels.md](docs/architecture/channels.md).
 - **Memory**: Per-agent persistent knowledge (experiences, learnings).
 - **Runtime backends**: Agents run in either tmux sessions or Docker containers, configured via `[runtime]` in settings.json.
 - **Roles**: Defined in `.bc/roles/*.md` with capabilities (create_agents, assign_work, implement_tasks, etc.) and hierarchy.
@@ -197,5 +197,5 @@ make build-docker-agent-base       # Build agent base image
 - cmd imports pkg, never vice versa; pkg packages are self-contained
 - Workspace access: `workspace.Load(rootDir)` / `workspace.Init(rootDir)`
 - Agent operations: `ws.Agents(ctx)`, `agent.Start(ctx, ws, name, role)`
-- Channel communication: `ws.Channel(name)`, `ch.Send(agentName, message)`
+- Channel communication: notification-only inbound via `pkg/gateway` + `pkg/notify`
 - Use interfaces for loose coupling between packages

--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,0 +1,441 @@
+# Channel Architecture
+
+> **Status:** Active | **Issue:** [#3006](https://github.com/gh-curious-otter/bc/issues/3006) | **Supersedes:** [channels-revamp proposal](../proposals/channels-revamp.md)
+
+## Overview
+
+Channels are **inbound notification-only gateways** that connect external platforms to bc agents. bc receives platform events and forwards the raw JSON payload to subscribed agents. Agents handle all outbound communication themselves using injected credentials.
+
+**Key principles:**
+1. bc handles **inbound only** -- no Send/outbound implementation
+2. **Raw JSON passthrough** -- platform payloads forwarded as-is, agents parse them
+3. **Agent handles outbound** using platform credentials injected as environment variables
+4. **Identity via instructions** -- agent system prompt tells it how to identify itself per platform
+
+```
+                        INBOUND ONLY
+                        ============
+
+  +----------+    +----------+    +----------+    +----------+
+  |  Slack   |    | Telegram |    |  GitHub  |    | Discord  |
+  |  events  |    |  events  |    |  events  |    |  events  |
+  +----+-----+    +----+-----+    +----+-----+    +----+-----+
+       |               |               |               |
+       v               v               v               v
+  +----+-----+    +----+-----+    +----+-----+    +----+-----+
+  |  Slack   |    | Telegram |    |  GitHub  |    | Discord  |
+  | Adapter  |    | Adapter  |    | Adapter  |    | Adapter  |
+  +----+-----+    +----+-----+    +----+-----+    +----+-----+
+       |               |               |               |
+       +-------+-------+-------+-------+
+               |
+               v
+       +-------+--------+
+       | notify.Dispatch |-----> SSE Hub (Web UI)
+       +-------+--------+
+               |
+       +-------+--------+
+       | Subscription   |
+       | Filter         |
+       | (self-skip,    |
+       |  mention_only) |
+       +-------+--------+
+               |
+       +---+---+---+
+       |   |       |
+       v   v       v
+     eng-01 eng-02 lead-01
+     (tmux send-keys)
+
+  Agent outbound: agent uses env var credentials
+  (SLACK_BOT_TOKEN, GITHUB_TOKEN, etc.) to call
+  platform APIs directly.
+```
+
+## NotificationAdapter Interface
+
+Each platform adapter implements a minimal interface with no outbound methods:
+
+```go
+type NotificationAdapter interface {
+    // Name returns the platform identifier ("slack", "telegram", "github").
+    Name() string
+
+    // Platform returns the platform identifier (may differ from Name for
+    // multi-instance adapters, e.g., "telegram" for "telegram:my-bot").
+    Platform() string
+
+    // Start connects to the platform and begins receiving events.
+    // Calls handler for each inbound notification. Blocks until ctx is canceled.
+    Start(ctx context.Context, handler func(Notification)) error
+
+    // Stop gracefully disconnects from the platform.
+    Stop() error
+
+    // Channels returns all channels/groups the bot has access to.
+    Channels() []ChannelInfo
+}
+```
+
+There is no `Send()`, `SendFile()`, or `React()` method. Outbound is the agent's responsibility.
+
+Each adapter is ~50-100 lines: connect to platform, extract sender field, forward raw JSON.
+
+## Notification Data Model
+
+A minimal envelope wrapping the raw platform payload:
+
+```go
+type Notification struct {
+    Channel   string          // "slack:eng", "github:bc", "telegram:chat"
+    Platform  string          // "slack", "github", "telegram"
+    Sender    string          // extracted for self-skip only
+    Mentions  []string        // extracted via regex for mention_only filter
+    Timestamp time.Time
+    Raw       json.RawMessage // entire platform payload, no parsing
+}
+```
+
+No `Content`, `Event`, `ThreadID`, `MessageID`, or `Metadata` fields. The agent reads the raw JSON directly and decides how to act.
+
+## Message Flow (Inbound Only)
+
+```
+1. Platform event arrives (WebSocket, webhook, long-poll)
+2. Adapter extracts: sender (for self-skip), mentions (regex @name)
+3. Adapter wraps entire payload in Notification{Raw: <original JSON>}
+4. Adapter calls handler(notification)
+5. notify.Dispatch() receives the notification
+6. Load subscribers for this channel from DB
+7. For each subscriber:
+   a. Self-skip: if sub.Agent == sender, skip
+   b. Mention filter: if mention_only=ON and agent not @mentioned, skip
+   c. Deliver: tmux send-keys with JSON notification
+   d. Log delivery result to DB
+8. Publish to SSE Hub for Web UI live updates
+```
+
+## Credential Injection
+
+When an agent starts, bc injects platform credentials from workspace secrets as environment variables:
+
+```
+BC_AGENT_ID=zen-zebra
+SLACK_BOT_TOKEN=xoxb-...
+TELEGRAM_BOT_TOKEN=123456:ABC...
+GITHUB_TOKEN=ghp_...
+DISCORD_BOT_TOKEN=...
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+```
+
+Credentials are stored encrypted via `pkg/secret` (AES-256-GCM). No plaintext tokens in settings.json.
+
+## Agent Identity Per Platform
+
+bc injects identity instructions into the agent's system prompt / CLAUDE.md:
+
+```markdown
+## Platform Credentials
+You have access to these platform credentials via environment variables:
+- SLACK_BOT_TOKEN: Use Slack API. Set `username` param to your agent name (BC_AGENT_ID).
+- TELEGRAM_BOT_TOKEN: Use Telegram Bot API. Prefix messages with [your-agent-name].
+- DISCORD_WEBHOOK_URL: Use Discord webhook API. Set `username` param to your agent name.
+- GITHUB_TOKEN: Use GitHub API. Comments appear as the token owner.
+```
+
+Per-platform identity support:
+
+| Platform | Per-message identity? | Approach |
+|----------|----------------------|----------|
+| Slack | Yes | `username` param in chat.postMessage |
+| Discord | Yes | `username` param in webhook execute |
+| Mattermost | Yes | Bot API username param |
+| Telegram | No (fixed bot name) | Prefix `[agent-name]: message` |
+| GitHub | App-level | One bot identity (natural for PR comments) |
+| Gmail | No (account holder) | Sends as authenticated user |
+
+## Self-Skip and Mention Filtering
+
+**Self-skip:** Each adapter extracts `Sender` (one field lookup per platform). `notify.Dispatch()` skips delivery when `sub.Agent == sender`.
+
+**Mention filter:** Regex `@[a-zA-Z][a-zA-Z0-9_-]*` applied across raw JSON bytes. Used for the `mention_only` subscription toggle.
+
+**Bot filtering:** Adapter skips messages from its own bot ID before forwarding:
+- Slack: check `BotID` field
+- Telegram: check `is_bot` field
+- Discord: check `author.bot` field
+
+## Subscription Model
+
+Agents subscribe to channels. Each subscription has a `mention_only` toggle:
+
+| Setting | Behavior | Use Case |
+|---------|----------|----------|
+| OFF (default) | Agent receives all messages in the channel | Small/focused channels |
+| ON | Agent only receives when `@<agent-name>` appears | Noisy channels |
+
+Per-agent, per-channel. Example: `eng-01` has mention_only=ON for `slack:all-bc` but OFF for `slack:engineering`.
+
+### Database Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS notify_subscriptions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    channel      TEXT NOT NULL,          -- "slack:engineering"
+    agent        TEXT NOT NULL,
+    mention_only INTEGER NOT NULL DEFAULT 0,
+    created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    UNIQUE(channel, agent)
+);
+
+CREATE TABLE IF NOT EXISTS notify_delivery_log (
+    id        INTEGER PRIMARY KEY AUTOINCREMENT,
+    logged_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    channel   TEXT NOT NULL,
+    agent     TEXT NOT NULL,
+    status    TEXT NOT NULL CHECK(status IN ('delivered', 'failed', 'pending')),
+    error     TEXT,
+    preview   TEXT  -- first 120 chars for debugging
+);
+
+CREATE TABLE IF NOT EXISTS notify_gateways (
+    name         TEXT PRIMARY KEY,
+    enabled      INTEGER NOT NULL DEFAULT 0,
+    connected    INTEGER NOT NULL DEFAULT 0,
+    last_seen_at TEXT,
+    updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+```
+
+Delivery log pruned to last 1000 entries per channel.
+
+## Web UI Design
+
+### Channels Page Layout
+
+```
++------------------+------------------------------------------+----------------------+
+| GATEWAYS         |  slack:engineering                        | AGENTS               |
+|                  |                                          |                      |
+| > Slack     (3)  |  10:32  alice                            | * eng-01  (engineer) |
+|   #engineering <-|  Can someone review PR #428?             |   [@] mention only   |
+|   #all-bc        |                                          |                      |
+|   #infra         |  10:32  bob                              | * eng-02  (engineer) |
+|                  |  @eng-01 take a look                     |   [ ] all messages   |
+| > Telegram  (1)  |  -> delivered to eng-01                  |                      |
+|   bc-dev         |                                          | o lead-01 (lead)     |
+|                  |  10:35  eng-01                            |   [Add]              |
+| > Discord   (1)  |  Looking now, will review                |                      |
+|   #general       |  -> relayed to eng-02                    | * = online  o = off  |
+|                  |                                          |                      |
+| > GitHub    (0)  |                                          |                      |
+|   [Setup ->]     |                                          |                      |
+|                  |                                          |                      |
+| + Connect app    |                                          |                      |
++------------------+------------------------------------------+----------------------+
+```
+
+| Panel | Content |
+|-------|---------|
+| Left sidebar | Gateway dropdowns with channel lists. Unconnected gateways show Setup link. |
+| Main area | Activity feed -- notifications with delivery status badges. |
+| Right panel | Agent subscriptions -- add/remove agents, mention_only toggle. |
+
+### SSE Events
+
+| Event | Trigger |
+|-------|---------|
+| `gateway.message` | New notification received |
+| `gateway.delivery` | Delivery status update |
+| `gateway.connected` | Gateway connected |
+| `gateway.disconnected` | Gateway lost connection |
+
+## Integration List
+
+47 platforms across 4 tiers. Full details in [issue #3006](https://github.com/gh-curious-otter/bc/issues/3006).
+
+### Tier 1 -- Chat Channels (19 platforms)
+
+Bidirectional messaging. Agents receive chat messages and respond via platform API.
+
+| # | Platform | Transport | In bc? |
+|---|----------|-----------|--------|
+| 1 | Slack | Socket Mode (WebSocket) | Yes |
+| 2 | Telegram | Bot API long-polling | Yes |
+| 3 | Discord | Gateway WebSocket | Stub |
+| 4 | WhatsApp | Cloud API webhooks | No |
+| 5 | Signal | signal-cli bridge | No |
+| 6 | iMessage | BlueBubbles server | No |
+| 7 | Matrix | Client-Server API | No |
+| 8 | Microsoft Teams | Bot Framework + Graph API | No |
+| 9 | Google Chat | Chat API + Pub/Sub | No |
+| 10 | LINE | Messaging API | No |
+| 11 | Feishu/Lark | Event Subscription API | No |
+| 12 | Mattermost | WebSocket + REST API | No |
+| 13 | IRC | IRC protocol | No |
+| 14 | Nostr | NIP-04 encrypted DMs | No |
+| 15 | QQ | QQ Bot API | No |
+| 16 | Zalo | Zalo OA API | No |
+| 17 | Twitch | IRC + EventSub | No |
+| 18 | Synology Chat | Incoming/Outgoing webhooks | No |
+| 19 | Nextcloud Talk | Nextcloud OCS API | No |
+
+### Tier 2 -- Event/Webhook Channels (20 platforms)
+
+Inbound notifications from platform events (not chat). Agents respond via platform API.
+
+| # | Platform | Event Types | Transport |
+|---|----------|-------------|-----------|
+| 20 | GitHub | PR, issue, push, CI, release, deployment | Webhooks |
+| 21 | GitLab | MR, pipeline, issue, push | Webhooks |
+| 22 | Bitbucket | PR, push, pipeline | Webhooks |
+| 23 | Gmail | Email received, label change | Google Pub/Sub |
+| 24 | Outlook | Email received | Microsoft Graph webhooks |
+| 25 | Jira | Issue created/updated/transitioned | Webhooks |
+| 26 | Linear | Issue created/updated, cycle changes | Webhooks |
+| 27 | Sentry | Error/exception alerts | Webhooks |
+| 28 | PagerDuty | Incident triggered/resolved | Webhooks |
+| 29 | Datadog | Alert triggered | Webhooks |
+| 30 | Grafana | Alert firing/resolved | Webhooks |
+| 31 | Vercel | Deployment created/ready/error | Webhooks |
+| 32 | Netlify | Deploy succeeded/failed | Webhooks |
+| 33 | AWS SNS | Any SNS topic notification | HTTP subscription |
+| 34 | Stripe | Payment succeeded/failed, subscription events | Webhooks |
+| 35 | Shopify | Order created, product updated | Webhooks |
+| 36 | Notion | Page updated, database changed | Polling |
+| 37 | Obsidian | Vault file changed | Filesystem watcher |
+| 38 | Generic Webhook | Any HTTP POST with JSON payload | HTTP endpoint |
+| 39 | Cron | Scheduled time triggers | Internal timer |
+
+### Tier 3 -- IoT & Smart Home (3 platforms)
+
+| # | Platform | Events | Transport |
+|---|----------|--------|-----------|
+| 40 | Home Assistant | Device state changes, automations | WebSocket + REST |
+| 41 | Philips Hue | Light state, motion sensors | Hue Bridge API |
+| 42 | MQTT | Any IoT topic message | MQTT protocol |
+
+### Tier 4 -- Social & Media (5 platforms)
+
+| # | Platform | Events | Transport |
+|---|----------|--------|-----------|
+| 43 | Twitter/X | Mentions, DMs, timeline | Twitter API v2 |
+| 44 | Reddit | Post/comment in subreddit | Reddit API |
+| 45 | YouTube | New video, comment, live chat | YouTube Data API |
+| 46 | Spotify | Playback state changes | Spotify Web API |
+| 47 | RSS/Atom | New feed entries | HTTP polling |
+
+## How to Add a New Channel
+
+Step-by-step guide for implementing a new platform adapter.
+
+### 1. Create the adapter package
+
+```
+pkg/gateway/<platform>/
+    adapter.go      -- NotificationAdapter implementation
+    adapter_test.go -- unit tests
+```
+
+### 2. Implement NotificationAdapter
+
+```go
+package myplatform
+
+import (
+    "context"
+    "encoding/json"
+
+    "github.com/rpuneet/bc/pkg/gateway"
+    "github.com/rpuneet/bc/pkg/notify"
+)
+
+type Adapter struct {
+    token    string
+    channels []notify.ChannelInfo
+}
+
+func New(token string) *Adapter {
+    return &Adapter{token: token}
+}
+
+func (a *Adapter) Name() string     { return "myplatform" }
+func (a *Adapter) Platform() string { return "myplatform" }
+
+func (a *Adapter) Start(ctx context.Context, handler func(notify.Notification)) error {
+    // 1. Connect to platform (WebSocket, long-poll, webhook listener)
+    // 2. For each incoming event:
+    //    - Extract sender name (for self-skip)
+    //    - Extract @mentions via regex (for mention_only filter)
+    //    - Skip messages from own bot ID
+    //    - Marshal entire platform payload to json.RawMessage
+    //    - Call handler(Notification{...})
+    // 3. Block until ctx.Done()
+    return nil
+}
+
+func (a *Adapter) Stop() error {
+    // Disconnect from platform
+    return nil
+}
+
+func (a *Adapter) Channels() []notify.ChannelInfo {
+    return a.channels
+}
+```
+
+### 3. Register the adapter
+
+In `server/` startup code, register the adapter with the gateway manager:
+
+```go
+if token := secrets.Get("GATEWAY_MYPLATFORM_TOKEN"); token != "" {
+    adapter := myplatform.New(token)
+    manager.Register(adapter)
+}
+```
+
+### 4. Store credentials
+
+Add the platform token to workspace secrets:
+
+```bash
+bc secret set GATEWAY_MYPLATFORM_TOKEN <token>
+```
+
+### 5. Test
+
+- Verify the adapter connects and discovers channels
+- Send a test message on the platform and confirm notification delivery
+- Subscribe an agent and verify tmux send-keys delivery
+- Test self-skip (agent's own messages not echoed back)
+- Test mention_only filtering
+
+## REST API
+
+```
+GET    /api/gateways                                              -- list + status
+POST   /api/gateways                                              -- connect
+PATCH  /api/gateways/{gateway}                                    -- update settings
+DELETE /api/gateways/{gateway}                                    -- disconnect
+GET    /api/gateways/{gateway}/health                             -- live probe
+GET    /api/gateways/{gateway}/channels                           -- discovered channels
+GET    /api/gateways/{gateway}/channels/{channel}                 -- detail + agents
+POST   /api/gateways/{gateway}/channels/{channel}/agents          -- subscribe agent
+DELETE /api/gateways/{gateway}/channels/{channel}/agents/{agent}  -- unsubscribe
+PATCH  /api/gateways/{gateway}/channels/{channel}/agents/{agent}  -- toggle mention_only
+GET    /api/gateways/{gateway}/channels/{channel}/activity        -- delivery log
+```
+
+## What Changed from the Previous Design
+
+The [channels-revamp proposal](../proposals/channels-revamp.md) described a **bidirectional** gateway with `Adapter.Send()` and `FileSender` interfaces. The new architecture removes all outbound responsibility from bc:
+
+| Previous Design | New Architecture |
+|----------------|------------------|
+| `Adapter.Send()` routes outbound messages | No outbound -- agent calls platform API directly |
+| `FileSender.SendFile()` for file uploads | No file upload -- agent uses platform file API |
+| `InboundMessage` with parsed fields | `Notification` with `Raw json.RawMessage` |
+| bc parses message content, extracts types | Raw passthrough -- agent parses the payload |
+| Gateway Manager routes both directions | Manager handles inbound dispatch only |
+| Complex channel mapping and persistence | Simple subscription-based routing |

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -35,7 +35,7 @@ This document describes the internal architecture of bc, covering component rela
        |  +-----v----------------v----------------v-------+  |
        |  |              Service Layer                     |  |
        |  |                                                |  |
-       |  |  AgentService    ChannelService   TeamService  |  |
+       |  |  AgentService    NotifyService   TeamService  |  |
        |  |  CostStore       SecretStore      CronService  |  |
        |  |  DaemonManager   EventLog         RoleManager  |  |
        |  |  ToolStore       MCPStore         StatsHandler |  |
@@ -200,12 +200,13 @@ cmd/bc/          -->  internal/cmd/  -->  pkg/client/
 cmd/bcd/         -->  server/        -->  pkg/*
 
 server/
-  handlers/      -->  pkg/agent/, pkg/channel/, pkg/cost/, ...
-  mcp/           -->  pkg/agent/, pkg/channel/, pkg/cost/
+  handlers/      -->  pkg/agent/, pkg/gateway/, pkg/notify/, pkg/cost/, ...
+  mcp/           -->  pkg/agent/, pkg/notify/, pkg/cost/
 
 pkg/ (self-contained, no cross-imports between packages)
   agent/         -->  pkg/tmux/, pkg/git/
-  channel/       -->  (SQLite only)
+  gateway/       -->  pkg/notify/ (inbound notification adapters)
+  notify/        -->  (SQLite, tmux send-keys delivery)
   cost/          -->  (SQLite only)
   workspace/     -->  config/
   tmux/          -->  (external: tmux binary)

--- a/docs/explanation/networking.md
+++ b/docs/explanation/networking.md
@@ -31,7 +31,7 @@ All communication flows through **bcd** as the central hub. No component talks d
 
 ## Message Delivery Flow
 
-When a message is sent to a channel, it's delivered to all members:
+When an external platform notification arrives, it is delivered to subscribed agents:
 
 ```mermaid
 sequenceDiagram
@@ -120,7 +120,7 @@ bcd maintains an in-memory SSE hub. All connected clients (web UI, TUI) receive 
 graph LR
     subgraph Sources
         AGENT_SVC[Agent Service]
-        CHAN_SVC[Channel Service]
+        NOTIFY_SVC[Notify Service]
         COST_SVC[Cost Importer]
     end
 
@@ -133,7 +133,7 @@ graph LR
     end
 
     AGENT_SVC -->|agent.created<br/>agent.stopped<br/>agent.state| HUB
-    CHAN_SVC -->|channel.message| HUB
+    NOTIFY_SVC -->|gateway.message| HUB
     HUB --> WEB1
     HUB --> WEB2
     HUB --> TUI1
@@ -150,7 +150,7 @@ graph LR
 | `agent.deleted` | Agent deleted | `{"name"}` |
 | `agent.renamed` | Agent renamed | `{"old_name","new_name"}` |
 | `agents.stopped_all` | All agents stopped | `{"count"}` |
-| `channel.message` | New message posted | `{"channel","message"}` |
+| `gateway.message` | Notification received from external platform | `{"channel","platform","sender"}` |
 
 ## Request/Response Format
 

--- a/docs/how-to/set-up-channels.md
+++ b/docs/how-to/set-up-channels.md
@@ -1,133 +1,68 @@
-# Channel Message Conventions
+# Set Up Channels
 
-This document defines the standard message formats for bc's channel-based PR workflow.
+Channels connect external platforms (Slack, Telegram, Discord, etc.) to your bc agents as **inbound notification gateways**. Agents receive raw platform events and respond using injected credentials.
 
-## Channel Types
+For the full architecture, see [Channel Architecture](../architecture/channels.md).
 
-### #all
-Broadcast channel for system-wide announcements and nudges.
+## Connect a Platform
 
-### #reviews
-PR workflow channel for review requests, approvals, and merge notifications.
+### Slack
 
-## Message Formats
-
-### Review Request
-
-```
-@<target> PR #<number> ready for review
-```
-
-**Examples:**
-- `@tech-lead PR #123 ready for review`
-- `@tech-lead-01 PR #456 ready for review: Add user authentication`
-
-**With URL:**
-- `@tech-lead PR #789 ready for review: https://github.com/org/repo/pull/789`
-
-### Approval
-
-```
-PR #<number> approved [checkmark]
-LGTM PR #<number>
-PR #<number> looks good
-```
-
-**Examples:**
-- `PR #123 approved`
-- `LGTM PR #456`
-- `PR #789 looks good to me`
-
-### Changes Requested
-
-```
-PR #<number> needs changes: <reason>
-PR #<number> please fix <issue>
-```
-
-**Examples:**
-- `PR #123 needs changes: fix the failing tests`
-- `PR #456 please fix the formatting issues`
-
-### Merge Notification
-
-```
-PR #<number> merged to <branch>
-Merged PR #<number>
-```
-
-**Examples:**
-- `PR #123 merged to main`
-- `Merged PR #456`
-- `PR #789 pushed to develop`
-
-## Parsing Rules
-
-### PR Number Extraction
-PR numbers are extracted using pattern: `(?i)(?:pr\s*#?|#)(\d+)`
-- Matches: `PR #123`, `PR 123`, `#123`, `pr#456`
-- Does NOT match standalone numbers like agent IDs: `tech-lead-01`
-
-### @Mentions
-Mentions are extracted using pattern: `@([a-zA-Z0-9_-]+)`
-- Matches: `@tech-lead`, `@tech-lead-01`, `@user_name`
-
-### Approval Detection
-Approvals are detected by these patterns (case-insensitive):
-- `approved`
-- `lgtm`
-- `looks good`
-- `ship it`
-
-### Changes Requested Detection
-Change requests are detected by these patterns (case-insensitive):
-- `needs changes`
-- `changes requested`
-- `please fix`
-- `needs work`
-
-### Merge Detection
-Merges are detected by these patterns (case-insensitive):
-- `merged`
-- `merge to`
-- `pushed to`
-
-## Workflow
-
-1. **Engineer** opens PR, posts to #reviews:
+1. Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps)
+2. Enable Socket Mode
+3. Add scopes: `channels:read`, `connections:write`
+4. Copy the bot token and app-level token
+5. Store credentials:
+   ```bash
+   bc secret set GATEWAY_SLACK_BOT_TOKEN xoxb-...
+   bc secret set GATEWAY_SLACK_APP_TOKEN xapp-...
    ```
-   @tech-lead-01 PR #123 ready for review
+6. Invite the bot to the channels you want to monitor
+
+### Telegram
+
+1. Message [@BotFather](https://t.me/BotFather) with `/newbot`
+2. Copy the bot token
+3. Store credential:
+   ```bash
+   bc secret set GATEWAY_TELEGRAM_BOT_TOKEN 123456:ABC...
    ```
+4. Add the bot to your groups
+5. Optionally disable privacy mode for full message access
 
-2. **Tech Lead** reviews and responds:
-   - Approved: `PR #123 approved`
-   - Needs work: `PR #123 needs changes: please add tests`
+### Discord
 
-3. **Automation** detects approval, notifies manager:
+1. Create an app at the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Enable the `MESSAGE_CONTENT` intent
+3. Copy the bot token
+4. Store credential:
+   ```bash
+   bc secret set GATEWAY_DISCORD_BOT_TOKEN ...
    ```
-   @manager PR #123 approved by tech-lead-01 - ready to merge to main
-   ```
+5. Generate an invite URL and add the bot to your server
 
-4. **Manager** merges and posts:
-   ```
-   PR #123 merged to main
-   ```
+## Subscribe Agents
 
-## Message Types
+```bash
+bc channel subscribe --channel slack:engineering --agent eng-01
+bc channel subscribe --channel telegram:bc-dev --agent eng-02 --mention-only
+```
 
-| Type | Code | Description |
-|------|------|-------------|
-| text | `TypeText` | Regular conversation |
-| task | `TypeTask` | Work assignment with @mention |
-| review | `TypeReview` | PR review request |
-| approval | `TypeApproval` | Tech lead approval |
-| merge | `TypeMerge` | Merge request/notification |
-| status | `TypeStatus` | Agent status update |
+## Unsubscribe Agents
 
-## Code Reference
+```bash
+bc channel unsubscribe --channel slack:engineering --agent eng-01
+```
 
-The parsing and formatting functions are in `pkg/channel/`:
-- `review_request.go` - Review request parsing/formatting
-- `approval_message.go` - Approval and merge message handling
-- `automation.go` - Approval-to-merge workflow automation
-- `message_type.go` - Message type definitions
+## Check Status
+
+```bash
+bc channel list       # all channels across gateways with subscriber counts
+bc channel status     # gateway connection status + health
+```
+
+## How Agents Respond
+
+bc does **not** send outbound messages. Agents use injected platform credentials (environment variables) to call platform APIs directly. Identity instructions in the agent's system prompt tell it how to identify itself on each platform.
+
+See [Channel Architecture -- Credential Injection](../architecture/channels.md#credential-injection) for details.

--- a/docs/proposals/channels-revamp.md
+++ b/docs/proposals/channels-revamp.md
@@ -1,6 +1,8 @@
 # Proposal: Channels Revamp — Notification Gateway
 
-> **Status:** Proposal (v3) &nbsp;|&nbsp; **Author:** zen-zebra &nbsp;|&nbsp; **Date:** 2026-04-09 &nbsp;|&nbsp; **Issue:** [#2947](https://github.com/gh-curious-otter/bc/issues/2947)
+> **Status:** Superseded by [Channel Architecture](../architecture/channels.md) &nbsp;|&nbsp; **Author:** zen-zebra &nbsp;|&nbsp; **Date:** 2026-04-09 &nbsp;|&nbsp; **Issue:** [#2947](https://github.com/gh-curious-otter/bc/issues/2947)
+>
+> **Note:** This proposal described a bidirectional gateway with `Adapter.Send()`. The final architecture is **inbound notification-only** with raw JSON passthrough. Agents handle outbound using injected credentials. See [docs/architecture/channels.md](../architecture/channels.md) for the current design.
 
 ---
 

--- a/pkg/gateway/README.md
+++ b/pkg/gateway/README.md
@@ -1,0 +1,38 @@
+# pkg/gateway
+
+Inbound notification adapters for external platforms (Slack, Telegram, Discord, etc.).
+
+## Architecture
+
+Channels are **inbound notification-only gateways**. Each platform adapter implements `NotificationAdapter`:
+
+```go
+type NotificationAdapter interface {
+    Name() string
+    Platform() string
+    Start(ctx context.Context, handler func(Notification)) error
+    Stop() error
+    Channels() []ChannelInfo
+}
+```
+
+There is no `Send()` method. Agents handle outbound communication using injected credentials.
+
+See [docs/architecture/channels.md](../../docs/architecture/channels.md) for the full architecture.
+
+## Packages
+
+- `gateway.go` -- core interfaces and types
+- `manager.go` -- orchestrates adapters, routes inbound notifications to `pkg/notify`
+- `slack/` -- Slack Socket Mode adapter
+- `telegram/` -- Telegram Bot API long-polling adapter
+- `discord/` -- Discord Gateway WebSocket adapter
+
+## Adding a New Adapter
+
+1. Create `pkg/gateway/<platform>/adapter.go`
+2. Implement `NotificationAdapter`
+3. Register in server startup
+4. Store credentials via `bc secret set GATEWAY_<PLATFORM>_TOKEN`
+
+See [How to Add a New Channel](../../docs/architecture/channels.md#how-to-add-a-new-channel) for step-by-step instructions.


### PR DESCRIPTION
## Summary
- Created `docs/architecture/channels.md` — comprehensive architecture doc for the new notification-only channel system covering the NotificationAdapter interface, Notification data model, inbound-only message flow, credential injection, agent identity, self-skip/mention filtering, subscription model, Web UI design, 47-platform integration list, and step-by-step guide for adding new channels
- Updated `.claude/CLAUDE.md` to reflect new channel/gateway package descriptions and remove references to bidirectional channel communication
- Updated `docs/explanation/architecture.md` and `docs/explanation/networking.md` to replace ChannelService references with NotifyService and gateway event types
- Rewrote `docs/how-to/set-up-channels.md` to align with notification-only design
- Marked `docs/proposals/channels-revamp.md` as superseded by the new architecture doc
- Added `pkg/gateway/README.md` with package overview and adapter guide

## Test plan
- [ ] Verify all internal doc links resolve correctly
- [ ] Review architecture doc against issue #3006 requirements
- [ ] Confirm no Go/TypeScript code was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Architecture Redesign**: Channel architecture reclassified from bidirectional inter-agent communication to inbound-only notification gateways connecting external platforms (Slack, Telegram, Discord) to agents.
* **Updated Setup & Management**: New guides document gateway credential configuration, agent subscription control, and notification delivery flow with SSE events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->