### PR TITLE
feat(notifications): finalize sidebar, API proxy, and per-platform renderers

### DIFF
--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -70,10 +70,37 @@ func (h *GatewayHandler) gatewayRouter(w http.ResponseWriter, r *http.Request) {
 		h.gatewayPair(w, r, platform, rest)
 	case rest == "channels" || strings.HasPrefix(rest, "channels/"):
 		h.gatewayChannels(w, r, platform, strings.TrimPrefix(rest, "channels"))
+	case rest == "api" || strings.HasPrefix(rest, "api/"):
+		h.gatewayAPIProxy(w, r, platform, strings.TrimPrefix(rest, "api"))
 	default:
 		// Existing: PATCH /api/gateways/{platform}
 		h.byPlatform(w, r)
 	}
+}
+
+// gatewayAPIProxy forwards requests to /api/gateways/{platform}/api/* to the adapter's HTTP handler.
+// This allows agents to interact with platform-specific APIs through bc.
+func (h *GatewayHandler) gatewayAPIProxy(w http.ResponseWriter, r *http.Request, platform, subpath string) {
+	if h.gw == nil {
+		httpError(w, "gateway manager not available", http.StatusServiceUnavailable)
+		return
+	}
+
+	adapter := h.gw.GetAdapter(platform)
+	if adapter == nil {
+		httpError(w, "adapter not found: "+platform, http.StatusNotFound)
+		return
+	}
+
+	handler := adapter.HTTPHandler()
+	if handler == nil {
+		httpError(w, "adapter does not support API proxy: "+platform, http.StatusNotImplemented)
+		return
+	}
+
+	// Strip the prefix so the adapter sees only the sub-path
+	r.URL.Path = subpath
+	handler.ServeHTTP(w, r)
 }
 
 // gatewayHealth returns live health status for a gateway adapter.
@@ -372,12 +399,20 @@ func (h *GatewayHandler) list(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Enrich with bot name from adapter status (channels come from notify sources, not discovery)
+	// Enrich with bot name and discovered channels from adapter status
 	if h.gw != nil {
+		discovered := h.gw.DiscoveredSources()
 		for i := range platforms {
 			status := h.gw.AdapterStatus(platforms[i].Platform)
 			if status.BotName != "" {
 				platforms[i].BotName = status.BotName
+			}
+			// Populate channels from adapter discovery
+			prefix := platforms[i].Platform + ":"
+			for _, ch := range discovered {
+				if strings.HasPrefix(ch, prefix) {
+					platforms[i].Channels = append(platforms[i].Channels, ch)
+				}
 			}
 		}
 	}

--- a/web/src/components/notifications/GatewayFeed.tsx
+++ b/web/src/components/notifications/GatewayFeed.tsx
@@ -20,8 +20,10 @@ import {
   dateKey,
   formatDayLabel,
   parseGitHubCard,
+  parseRSSCard,
+  parseWebhookCard,
 } from "./messageUtils";
-import type { GitHubCard } from "./messageUtils";
+import type { GitHubCard, RSSCard, WebhookCard } from "./messageUtils";
 
 /* ── Helpers ──────────────────────────────────────────────────── */
 
@@ -169,10 +171,43 @@ function DiscordGlyph({ size = 11 }: { size?: number }) {
   );
 }
 
+function WhatsAppGlyph({ size = 11 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={{ flexShrink: 0 }}>
+      <circle cx="12" cy="12" r="11" fill="#25D366" />
+      <text x="12" y="16" textAnchor="middle" fill="#fff" fontSize="10" fontWeight="bold">W</text>
+    </svg>
+  );
+}
+
+function RSSGlyph({ size = 11 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={{ flexShrink: 0 }}>
+      <circle cx="12" cy="12" r="11" fill="#F78422" />
+      <circle cx="8" cy="16" r="2" fill="#fff" />
+      <path d="M6 12a8 8 0 0 1 8 8" stroke="#fff" strokeWidth="2" fill="none" strokeLinecap="round" />
+      <path d="M6 8a12 12 0 0 1 12 12" stroke="#fff" strokeWidth="2" fill="none" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function WebhookGlyph({ size = 11 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={{ flexShrink: 0 }}>
+      <circle cx="12" cy="12" r="11" fill="#6B7280" />
+      <text x="12" y="16" textAnchor="middle" fill="#fff" fontSize="9" fontWeight="bold">⚡</text>
+    </svg>
+  );
+}
+
 const PLATFORM_GLYPHS: Record<string, React.FC<{ size?: number }>> = {
   slack: SlackGlyph,
   telegram: TelegramGlyph,
   discord: DiscordGlyph,
+  whatsapp: WhatsAppGlyph,
+  github: ({ size = 11 }) => <GitHubGlyph size={size} />,
+  rss: RSSGlyph,
+  webhook: WebhookGlyph,
 };
 
 /* ── GitHub card renderer ────────────────────────────────────── */
@@ -353,6 +388,117 @@ function GitHubCardView({ card }: { card: GitHubCard }) {
               <span style={{ color: "#ef4444" }}>-{card.deletions}</span>
             )}
           </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── RSS card renderer ──────────────────────────────────────── */
+
+function RSSCardView({ card }: { card: RSSCard }) {
+  return (
+    <div
+      className="mt-1.5 max-w-lg overflow-hidden"
+      style={{
+        background: "var(--bc-surface, #151515)",
+        borderRadius: 6,
+        borderLeft: "2px solid #F78422",
+      }}
+    >
+      <div
+        className="flex items-center"
+        style={{
+          padding: "8px 12px 4px",
+          gap: 7,
+          fontSize: 10.5,
+          color: "var(--bc-muted, #6b6b6b)",
+          fontFamily: "'JetBrains Mono', monospace",
+        }}
+      >
+        <RSSGlyph size={11} />
+        <span style={{ fontSize: 9.5, padding: "1px 5px", borderRadius: 3, background: "var(--bc-surface-hover, #1a1a1a)", color: "var(--bc-muted, #a0a0a0)", textTransform: "uppercase", letterSpacing: 0.5, fontWeight: 600 }}>
+          feed
+        </span>
+        {card.source && <span>{card.source}</span>}
+        {card.pubDate && <span style={{ marginLeft: "auto" }}>{formatRelativeTime(card.pubDate)}</span>}
+      </div>
+      <div style={{ padding: "4px 12px 10px" }}>
+        <div style={{ fontSize: 13, fontWeight: 500, color: "var(--bc-text, #e5e5e5)", lineHeight: 1.4 }}>
+          {card.link ? (
+            <a href={card.link} target="_blank" rel="noopener noreferrer" className="hover:underline" style={{ color: "var(--bc-text, #e5e5e5)", textDecoration: "none" }}>
+              {card.title}
+            </a>
+          ) : card.title}
+        </div>
+        {card.description && (
+          <div style={{ fontSize: 12, color: "var(--bc-muted, #a0a0a0)", marginTop: 4, lineHeight: 1.4, maxHeight: 60, overflow: "hidden", textOverflow: "ellipsis" }}>
+            {card.description.slice(0, 200)}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Webhook JSON card renderer ────────────────────────────── */
+
+function WebhookCardView({ card }: { card: WebhookCard }) {
+  const [expanded, setExpanded] = useState(false);
+  const preview = JSON.stringify(card.payload, null, 2);
+  const short = preview.slice(0, 200);
+
+  return (
+    <div
+      className="mt-1.5 max-w-lg overflow-hidden"
+      style={{
+        background: "var(--bc-surface, #151515)",
+        borderRadius: 6,
+        borderLeft: "2px solid #6B7280",
+      }}
+    >
+      <div
+        className="flex items-center"
+        style={{
+          padding: "8px 12px 4px",
+          gap: 7,
+          fontSize: 10.5,
+          color: "var(--bc-muted, #6b6b6b)",
+          fontFamily: "'JetBrains Mono', monospace",
+        }}
+      >
+        <WebhookGlyph size={11} />
+        {card.event && (
+          <span style={{ fontSize: 9.5, padding: "1px 5px", borderRadius: 3, background: "var(--bc-surface-hover, #1a1a1a)", color: "var(--bc-muted, #a0a0a0)", textTransform: "uppercase", letterSpacing: 0.5, fontWeight: 600 }}>
+            {card.event}
+          </span>
+        )}
+        {card.action && <span style={{ color: "var(--bc-muted, #a0a0a0)", fontWeight: 500 }}>{card.action}</span>}
+      </div>
+      <div style={{ padding: "4px 12px 10px" }}>
+        <pre
+          style={{
+            fontSize: 11,
+            color: "var(--bc-muted, #a0a0a0)",
+            fontFamily: "'JetBrains Mono', monospace",
+            lineHeight: 1.4,
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-all",
+            maxHeight: expanded ? "none" : 80,
+            overflow: "hidden",
+            margin: 0,
+          }}
+        >
+          {expanded ? preview : short}
+        </pre>
+        {preview.length > 200 && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            style={{ fontSize: 10, color: "var(--bc-accent, #f97316)", background: "none", border: "none", cursor: "pointer", padding: "4px 0 0", fontFamily: "'JetBrains Mono', monospace" }}
+          >
+            {expanded ? "collapse" : "expand JSON..."}
+          </button>
         )}
       </div>
     </div>
@@ -1700,6 +1846,8 @@ export function GatewayFeed({
                           const looksLikeWebhook = msg.content.trimStart().startsWith("{") &&
                             /pull_request|"issue"|"ref".*"commits"|"action"/i.test(msg.content);
                           const ghCard = (platform === "github" || looksLikeWebhook) ? parseGitHubCard(msg.content) : null;
+                          const rssCard = platform === "rss" ? parseRSSCard(msg.content) : null;
+                          const webhookCard = !ghCard && !rssCard && platform === "webhook" ? parseWebhookCard(msg.content) : null;
                           const fileAttachments = parseFileAttachments(msg.content);
 
                           return (
@@ -1715,6 +1863,10 @@ export function GatewayFeed({
                               >
                                 {ghCard ? (
                                   <GitHubCardView card={ghCard} />
+                                ) : rssCard ? (
+                                  <RSSCardView card={rssCard} />
+                                ) : webhookCard ? (
+                                  <WebhookCardView card={webhookCard} />
                                 ) : (
                                   <div
                                     className="whitespace-pre-wrap break-words"

--- a/web/src/components/notifications/messageUtils.ts
+++ b/web/src/components/notifications/messageUtils.ts
@@ -1,7 +1,14 @@
 import type { ChannelMessage } from "../../api/client";
 
 /** Gateway notification sources are bridges to external platforms — read-only activity feeds. */
-export const GATEWAY_PREFIXES = ["slack:", "telegram:", "discord:"];
+export const GATEWAY_PREFIXES = [
+  "slack:", "telegram:", "discord:", "whatsapp:", "github:", "gitlab:",
+  "webhook:", "rss:", "mqtt:", "irc:", "matrix:", "mattermost:", "reddit:",
+  "twitter:", "notion:", "jira:", "linear:", "sentry:", "pagerduty:",
+  "datadog:", "grafana:", "stripe:", "bitbucket:", "signal:", "msteams:",
+  "feishu:", "googlechat:", "line:", "netlify:", "vercel:", "twitch:",
+  "nostr:", "homeassistant:", "imessage:",
+];
 
 export function isGatewaySource(name: string): boolean {
   return GATEWAY_PREFIXES.some((p) => name.startsWith(p));
@@ -278,5 +285,57 @@ export function parseGitHubCard(content: string): GitHubCard | null {
     };
   }
 
+  return null;
+}
+
+/* ── RSS / webhook card parsing ───────────────────────────────── */
+
+export interface RSSCard {
+  title: string;
+  link?: string;
+  description?: string;
+  pubDate?: string;
+  source?: string;
+}
+
+/** Try to extract an RSS entry card from a message. */
+export function parseRSSCard(content: string): RSSCard | null {
+  try {
+    const obj = JSON.parse(content);
+    if (obj && typeof obj === "object" && obj.title && (obj.link || obj.url)) {
+      return {
+        title: obj.title,
+        link: obj.link ?? obj.url,
+        description: obj.description ?? obj.summary,
+        pubDate: obj.pubDate ?? obj.published ?? obj.date,
+        source: obj.feed ?? obj.source,
+      };
+    }
+  } catch {
+    // not JSON
+  }
+  return null;
+}
+
+export interface WebhookCard {
+  event?: string;
+  action?: string;
+  payload: Record<string, unknown>;
+}
+
+/** Try to parse a generic webhook JSON payload. */
+export function parseWebhookCard(content: string): WebhookCard | null {
+  try {
+    const obj = JSON.parse(content);
+    if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+      return {
+        event: obj.event_type ?? obj.event ?? obj.type,
+        action: obj.action,
+        payload: obj,
+      };
+    }
+  } catch {
+    // not JSON
+  }
   return null;
 }


### PR DESCRIPTION
## Summary
- **#87**: Sidebar now shows channels from adapter API discovery instead of empty arrays
- **#90**: Add `/api/gateways/{platform}/api/*` proxy endpoint for agent access to platform APIs
- **#89**: Per-platform UI renderers — RSS card, webhook JSON card, extended platform glyphs (WhatsApp, GitHub, RSS, webhook), all 34 platforms in GATEWAY_PREFIXES

Closes #87, #89, #90. Completes the notifications page finalization from #3031.

## Test plan
- [ ] `go build ./...` compiles
- [ ] `npx tsc --noEmit` in web/ passes
- [ ] Sidebar shows discovered channels for connected gateways
- [ ] RSS feed messages render as article cards
- [ ] Webhook JSON payloads render with collapsible view
- [ ] Platform glyphs appear in feed header for all supported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for RSS feeds, Webhooks, and additional gateway platforms including WhatsApp, GitHub, GitLab, MQTT, IRC, Matrix, Mattermost, and more
  * Gateway channels are now discovered and displayed per platform
  * RSS and Webhook message types now render with formatted cards displaying metadata such as titles, links, descriptions, and publish dates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->