### PR TITLE
feat(notifications): finalize sidebar, adapters, and per-platform renderers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,6 @@ build-local-tui: ## Build TUI
 build-local-web: ## Build web UI → server/web/dist/
 	cd web && bun install && bun run build
 	@rm -rf server/web/dist
-	@mkdir -p server/web
 	@cp -r web/dist server/web/dist
 
 build-local-landing: ## Build landing page

--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -1,38 +1,24 @@
 # Notifications
 
-Notifications bridge external platforms (Slack, Telegram, Discord, WhatsApp, GitHub, and 30+ others) to bc agents. Each adapter follows a three-part pattern: **Connect** (authenticate with the platform), **Listen** (receive real-time events), and **API Proxy** (expose the platform's native API to agents).
+Notifications are inbound-only gateways that bridge external platforms (Slack, GitHub, Telegram, and 30+ others) to bc agents. bc routes platform events to subscribed agents, who respond directly using injected credentials and platform APIs.
 
 ## Architecture
 
-Each adapter follows a simple 3-part pattern:
-
-### 1. Connect
-
-Authenticate with the platform (token, QR code, OAuth). The adapter stores only credentials and session state. Everything else comes from the platform API at runtime.
-
-### 2. Listen
-
-Receive real-time events via one of three transport patterns. Forward each event as `Notification{Raw JSON}` -- no parsing, no platform-specific data models. The agent gets the full platform payload.
-
-### 3. API Proxy
-
-Expose the platform's native API via `/api/gateways/{platform}/api/*`. Agents call platform APIs through this proxy (send messages, upload files, list channels, etc.). There are no `Send`/`SendFile`/`React` methods on the adapter interface. The proxy passes through auth headers from stored credentials.
+bc acts as a notification router, not a messaging proxy. External platforms push events into bc through adapter connections. bc dispatches those events to subscribed agents based on filtering rules. Agents call platform APIs themselves using environment variable credentials.
 
 ```mermaid
 flowchart LR
     subgraph Platforms["External Platforms"]
         S[Slack]
         T[Telegram]
-        D[Discord]
-        W[WhatsApp]
         G[GitHub]
-        More["...30+ more"]
+        W[Webhooks]
+        More["...40+ more"]
     end
 
-    subgraph bc["bc daemon"]
-        GW["Gateway Adapters<br/>(Connect + Listen)"]
+    subgraph bc["bc (notification router)"]
+        GW["Gateway Adapters"]
         NS["Notify Service"]
-        PROXY["API Proxy<br/>/api/gateways/{platform}/api/*"]
     end
 
     subgraph Agents["Agents (tmux/Docker)"]
@@ -41,46 +27,68 @@ flowchart LR
         A3[agent-3]
     end
 
-    S & T & D & W & G & More -- "events" --> GW
+    S & T & G & W & More -- "events" --> GW
     GW -- "Notification{Raw JSON}" --> NS
     NS -- "dispatch to subscribers" --> A1 & A2 & A3
-    A1 & A2 & A3 -. "platform API calls\nvia proxy" .-> PROXY
-    PROXY -. "forwarded with\nstored credentials" .-> Platforms
+    A1 & A2 & A3 -. "respond via platform API\n(credentials in env vars)" .-> Platforms
 ```
 
-All adapters follow one of three transport patterns:
+All 37+ platform adapters follow one of three connection patterns:
 
 | Pattern | Examples | Mechanism |
 |---------|----------|-----------|
-| **Socket** | Slack, Discord, Telegram, WhatsApp, IRC, Mattermost, MQTT | Long-lived connection. `Start()` blocks, events stream in. |
-| **Webhook** | GitHub, Generic Webhook | bc exposes an HTTP endpoint. The platform POSTs events. |
-| **Poll** | RSS, Matrix, Reddit, Twitter | Timer-based fetch. `Start()` polls on interval, forwards new items. |
+| **Socket** | Slack, Discord, Telegram, Matrix, IRC, Mattermost, Twitch, MQTT | Long-lived connection. `Start()` blocks, events stream in. |
+| **Webhook** | GitHub, GitLab, Stripe, Sentry, PagerDuty, Datadog, Generic | bc exposes an HTTP endpoint. The platform POSTs events. |
+| **Poll** | RSS, Notion, Reddit, Gmail | Timer-based fetch. `Start()` polls on interval, forwards new items. |
 
 ## NotificationAdapter Interface
 
-Every platform adapter implements this interface. The interface is intentionally minimal -- adapters connect, listen, and expose an HTTP handler for webhooks and API proxy. There are no platform-specific send/reply methods.
+Every platform adapter implements this interface. Adapters are thin wrappers (~50-100 lines) that connect to a platform and forward raw events.
 
 ```go
 // Located in: pkg/gateway/gateway.go
 
+// AdapterType identifies the connection pattern.
 type AdapterType string
 
 const (
     AdapterSocket  AdapterType = "socket"   // long-lived connection (WebSocket, polling loop)
-    AdapterWebhook AdapterType = "webhook"  // HTTP endpoint -- platform POSTs events to bc
-    AdapterPoll    AdapterType = "poll"      // timer-based polling -- bc fetches new events
+    AdapterWebhook AdapterType = "webhook"  // HTTP endpoint — platform POSTs events to bc
+    AdapterPoll    AdapterType = "poll"     // timer-based polling — bc fetches new events
 )
 
+// NotificationAdapter handles the platform connection lifecycle.
 type NotificationAdapter interface {
-    Name() string                                            // adapter identifier ("slack", "github", "telegram")
-    Type() AdapterType                                       // socket, webhook, or poll
-    Start(ctx context.Context, handler func(Notification)) error  // connect + listen; blocks until ctx canceled
-    Stop() error                                             // graceful disconnect
-    Channels() []ChannelInfo                                 // from platform API, not stored history
-    Status() AdapterStatus                                   // connection state for web UI
-    HTTPHandler() http.Handler                               // for webhooks + API proxy
+    // Name returns the adapter identifier ("slack", "github", "telegram").
+    Name() string
+
+    // Type returns the connection pattern. Determines how bc wires the adapter:
+    //   socket  → goroutine running Start()
+    //   webhook → HTTPHandler() mounted on bcd HTTP mux at /hooks/{name}
+    //   poll    → goroutine running Start() with internal ticker
+    Type() AdapterType
+
+    // Start connects to the platform and begins receiving notifications.
+    // Calls handler for each inbound event with raw JSON payload.
+    // Blocks until ctx is canceled. For webhook adapters, this is a no-op.
+    Start(ctx context.Context, handler func(Notification)) error
+
+    // Stop gracefully disconnects from the platform.
+    Stop() error
+
+    // HTTPHandler returns an http.Handler for webhook-based adapters.
+    // Socket and poll adapters return nil.
+    // The handler is mounted at /hooks/{name} on the bcd HTTP server.
+    HTTPHandler() http.Handler
+
+    // Channels returns discovered channels/groups the bot has access to.
+    Channels() []ChannelInfo
+
+    // Status returns the adapter's connection state for the web UI.
+    Status() AdapterStatus
 }
 
+// AdapterStatus is reported to the web UI for observability.
 type AdapterStatus struct {
     Connected     bool      `json:"connected"`
     Error         string    `json:"error,omitempty"`
@@ -89,18 +97,13 @@ type AdapterStatus struct {
     MessageCount  int64     `json:"message_count"`
 }
 
+// ChannelInfo represents a discovered channel on a platform.
 type ChannelInfo struct {
     ID       string `json:"id"`       // platform channel ID
     Name     string `json:"name"`     // human-readable name
     Platform string `json:"platform"` // adapter name
 }
 ```
-
-Key design decisions:
-
-- **No Send/SendFile/React methods.** Agents interact with platforms through the API proxy at `/api/gateways/{platform}/api/*`, which forwards requests using stored credentials.
-- **Channels() queries the platform API live**, not a stored message history. The web UI sidebar shows channels/groups from this method.
-- **HTTPHandler() serves double duty** for webhook adapters (receiving inbound events) and all adapters (API proxy pass-through).
 
 ## Notification Data Model
 
@@ -167,74 +170,86 @@ The gateway manager registers each as a separate adapter. Subscriptions referenc
 
 ## Platform Integrations
 
-### Working Adapters
+### Tier 1: Chat Platforms
 
-These adapters use real platform SDKs and are fully functional.
+Bidirectional messaging platforms where agents receive and respond.
 
-| # | Platform | Transport | SDK / Library | Status |
-|---|----------|-----------|---------------|--------|
-| 1 | **Slack** | Socket Mode (WebSocket) | `slack-go/slack` | Working |
-| 2 | **Telegram** | Bot API long-polling | `go-telegram-bot-api` | Working |
-| 3 | **Discord** | Gateway WebSocket | `bwmarrin/discordgo` | Working |
-| 4 | **WhatsApp** | Multi-device protocol | `whatsmeow` (QR pairing) | Working |
-| 5 | **IRC** | IRC protocol | `ergochat/irc-go` | Working |
-| 6 | **MQTT** | MQTT 3.1.1/5.0 | `eclipse/paho.mqtt.golang` | Working |
-| 7 | **Mattermost** | WebSocket + REST | `gorilla/websocket` | Working |
-| 8 | **GitHub** | Webhooks | Webhook handler | Working |
-| 9 | **Generic Webhook** | HTTP POST | Webhook receiver | Working |
-| 10 | **RSS/Atom** | HTTP polling | HTTP client | Working |
-| 11 | **Matrix** | Client-Server API polling | HTTP client | Working |
-| 12 | **Reddit** | Reddit API polling | HTTP client | Working |
-| 13 | **Twitter/X** | Twitter API v2 polling | HTTP client | Working |
+| # | Platform | Transport | Credential Env Vars | Identity Method | Status |
+|---|----------|-----------|---------------------|-----------------|--------|
+| 1 | **Slack** | Socket Mode (WebSocket) | `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN` | `username` param in `chat.postMessage` | Implemented |
+| 2 | **Telegram** | Bot API long-polling | `TELEGRAM_BOT_TOKEN` | Prefix `[agent-name]: message` | Implemented |
+| 3 | **Discord** | Gateway WebSocket | `DISCORD_BOT_TOKEN` or `DISCORD_WEBHOOK_URL` | `username` param in webhook execute | Implemented |
+| 4 | WhatsApp | Cloud API webhooks | `WHATSAPP_TOKEN` | Prefix text (fixed number) | Planned |
+| 5 | Signal | signal-cli bridge | `SIGNAL_CLI_URL` | Prefix text (fixed number) | Planned |
+| 6 | iMessage | BlueBubbles server | `BLUEBUBBLES_URL`, `BLUEBUBBLES_PASSWORD` | Prefix text (fixed Apple ID) | Planned |
+| 7 | Matrix | Client-Server API | `MATRIX_HOMESERVER`, `MATRIX_TOKEN` | Bot display name | Planned |
+| 8 | Microsoft Teams | Bot Framework | `TEAMS_APP_ID`, `TEAMS_APP_SECRET` | Bot identity | Planned |
+| 9 | Google Chat | Chat API + Pub/Sub | `GOOGLE_CHAT_SA_KEY` | Bot identity | Planned |
+| 10 | LINE | Messaging API | `LINE_CHANNEL_TOKEN` | Bot identity | Planned |
+| 11 | Feishu/Lark | Event Subscription | `FEISHU_APP_ID`, `FEISHU_APP_SECRET` | Bot identity | Planned |
+| 12 | Mattermost | WebSocket + REST | `MATTERMOST_URL`, `MATTERMOST_TOKEN` | `username` param | Planned |
+| 13 | IRC | IRC protocol | `IRC_SERVER`, `IRC_NICK`, `IRC_PASSWORD` | Nick per agent | Planned |
+| 14 | Nostr | NIP-04 DMs | `NOSTR_PRIVATE_KEY` | Public key identity | Planned |
+| 15 | Twitch | IRC + EventSub | `TWITCH_OAUTH_TOKEN` | Bot username | Planned |
 
-### Coming Soon
+### Tier 2: Event and Webhook Platforms
 
-These adapters have scaffolding but are not yet connected to real platform SDKs.
+Inbound-only platforms that push structured events (CI results, issue updates, deployments).
 
-| Platform | Transport | Notes |
-|----------|-----------|-------|
-| Signal | signal-cli bridge | Stub |
-| Line | Messaging API | Stub |
-| Feishu/Lark | Event Subscription | Stub |
-| Google Chat | Chat API + Pub/Sub | Stub |
-| Microsoft Teams | Bot Framework | Stub |
-| GitLab | Webhooks | Stub |
-| Bitbucket | Webhooks | Stub |
-| Jira | Webhooks | Stub |
-| Linear | Webhooks | Stub |
-| Sentry | Webhooks | Stub |
-| PagerDuty | Webhooks | Stub |
-| Datadog | Webhooks | Stub |
-| Grafana | Webhooks | Stub |
-| Stripe | Webhooks | Stub |
-| Vercel | Webhooks | Stub |
-| Netlify | Webhooks | Stub |
-| Notion | Polling | Stub |
-| Twitch | IRC + EventSub | Stub |
-| Home Assistant | WebSocket + REST | Stub |
-| Nostr | NIP-04 DMs | Stub |
-| iMessage | BlueBubbles | Stub |
+| # | Platform | Event Types | Transport | Credential Env Vars | Status |
+|---|----------|-------------|-----------|---------------------|--------|
+| 16 | **GitHub** | PR, issue, push, CI, review, release, deployment | Webhooks | `GITHUB_TOKEN`, `GITHUB_WEBHOOK_SECRET` | Planned |
+| 17 | GitLab | MR, pipeline, issue, push | Webhooks | `GITLAB_TOKEN`, `GITLAB_WEBHOOK_SECRET` | Planned |
+| 18 | Bitbucket | PR, push, pipeline | Webhooks | `BITBUCKET_TOKEN` | Planned |
+| 19 | Gmail | Email received | Google Pub/Sub | `GMAIL_SA_KEY` | Planned |
+| 20 | Outlook | Email received | Graph API webhooks | `OUTLOOK_CLIENT_ID`, `OUTLOOK_CLIENT_SECRET` | Planned |
+| 21 | Jira | Issue CRUD, transitions | Webhooks | `JIRA_TOKEN`, `JIRA_WEBHOOK_SECRET` | Planned |
+| 22 | Linear | Issue CRUD, cycle changes | Webhooks | `LINEAR_API_KEY`, `LINEAR_WEBHOOK_SECRET` | Planned |
+| 23 | Sentry | Error/exception alerts | Webhooks | `SENTRY_DSN` | Planned |
+| 24 | PagerDuty | Incident triggered/resolved | Webhooks | `PAGERDUTY_TOKEN` | Planned |
+| 25 | Datadog | Alert triggered | Webhooks | `DATADOG_API_KEY` | Planned |
+| 26 | Grafana | Alert firing/resolved | Webhooks | `GRAFANA_API_KEY` | Planned |
+| 27 | Vercel | Deployment events | Webhooks | `VERCEL_TOKEN` | Planned |
+| 28 | Netlify | Deploy events | Webhooks | `NETLIFY_TOKEN` | Planned |
+| 29 | AWS SNS | Any SNS topic | HTTP subscription | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | Planned |
+| 30 | Stripe | Payment, subscription events | Webhooks | `STRIPE_WEBHOOK_SECRET` | Planned |
+| 31 | Notion | Page/database changes | Polling | `NOTION_TOKEN` | Planned |
+| 32 | Generic Webhook | Any HTTP POST with JSON | HTTP endpoint | None (public endpoint) | Planned |
+
+### Tier 3: IoT and Smart Home
+
+| # | Platform | Events | Transport | Credential Env Vars | Status |
+|---|----------|--------|-----------|---------------------|--------|
+| 33 | Home Assistant | Device state changes | WebSocket + REST | `HASS_URL`, `HASS_TOKEN` | Planned |
+| 34 | MQTT | IoT topic messages | MQTT protocol | `MQTT_BROKER`, `MQTT_USERNAME`, `MQTT_PASSWORD` | Planned |
+
+### Tier 4: Social and Media
+
+| # | Platform | Events | Transport | Credential Env Vars | Status |
+|---|----------|--------|-----------|---------------------|--------|
+| 35 | Twitter/X | Mentions, DMs | Twitter API v2 | `TWITTER_BEARER_TOKEN` | Planned |
+| 36 | Reddit | Posts/comments | Reddit API | `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET` | Planned |
+| 37 | RSS/Atom | New feed entries | HTTP polling | None | Planned |
 
 ## Credential Management
 
-Credentials flow from the web UI through encrypted storage into the adapter. Agents access platform APIs through the API proxy -- they do not need credentials in their environment.
+Credentials flow from the web UI through encrypted storage into agent environment variables.
 
 ```mermaid
 flowchart LR
     UI["Web UI<br/>Setup Wizard"] -->|"POST /api/secrets"| SEC["pkg/secret<br/>AES-256-GCM"]
-    SEC -->|"adapter start"| ADAPTER["Gateway Adapter"]
-    ADAPTER -->|"authenticates"| PLATFORM["Platform API"]
-    AGENT["Agent"] -->|"/api/gateways/{platform}/api/*"| PROXY["API Proxy"]
-    PROXY -->|"stored credentials"| PLATFORM
+    SEC -->|"agent start"| ENV["Agent env vars"]
+    ENV --> AGENT["Agent process<br/>(tmux/Docker)"]
+    AGENT -->|"uses credentials"| PLATFORM["Platform API"]
 
     style SEC fill:#2d5016,stroke:#4ade80
 ```
 
 1. The user enters platform credentials in the web UI setup wizard.
 2. `POST /api/secrets` encrypts them with AES-256-GCM via `pkg/secret`.
-3. When the adapter starts, it authenticates with the platform using stored credentials.
-4. Agents call platform APIs through the API proxy at `/api/gateways/{platform}/api/*`.
-5. The proxy injects stored credentials into outbound requests.
+3. When an agent starts, bc reads workspace secrets and injects them as environment variables.
+4. The agent's system prompt includes instructions on which env vars are available.
+5. The agent calls platform APIs directly using those credentials.
 
 Secrets are never stored in `settings.json`, never transmitted via SSE events, and never exposed in API responses.
 
@@ -243,12 +258,11 @@ Secrets are never stored in `settings.json`, never transmitted via SSE events, a
 | **Slack** | Create app at api.slack.com > Enable Socket Mode > Add scopes (`channels:read`, `chat:write`, `connections:write`) > Copy bot token + app token > Invite bot to channels |
 | **Telegram** | Message @BotFather `/newbot` > Copy bot token > Add bot to groups > Disable privacy mode (optional, for reading all group messages) |
 | **Discord** | Create app at discord.com/developers > Enable `MESSAGE_CONTENT` intent > Copy bot token > Generate invite URL with required permissions > Add bot to server |
-| **WhatsApp** | Scan QR code in the web UI to pair via whatsmeow multi-device protocol |
 | **GitHub** | Create GitHub App or configure repository webhook > Select events (PR comments, reviews, issues, pushes) > Copy token and webhook secret |
 
 ## Agent Identity
 
-Agents interact with platforms through the API proxy. Per-message identity depends on what the platform API supports:
+Each platform has different support for per-message identity. Some allow setting a username per API call; others require the agent to prefix its name in the message body.
 
 | Platform | Per-Message Identity? | Mechanism |
 |----------|----------------------|-----------|
@@ -257,9 +271,19 @@ Agents interact with platforms through the API proxy. Per-message identity depen
 | Mattermost | Yes | Bot API username parameter |
 | Telegram | No (fixed bot name) | Agent prefixes message with `[agent-name]: ` |
 | WhatsApp | No (fixed number) | Agent prefixes message text |
+| Signal | No (fixed number) | Agent prefixes message text |
 | GitHub | App-level | Comments appear as the GitHub App / token owner |
+| Gmail | No (account holder) | Sends as authenticated user |
 
-Identity instructions are injected into the agent's system prompt at startup. Agents know their own name via the `BC_AGENT_ID` environment variable and use it when calling the API proxy.
+Identity instructions are injected into the agent's system prompt at startup:
+
+```markdown
+## Platform Credentials
+You have access to these platform credentials via environment variables:
+- SLACK_BOT_TOKEN: Use Slack API. Set `username` param to your agent name
+  (available as BC_AGENT_ID env var) for identity.
+- TELEGRAM_BOT_TOKEN: Use Telegram Bot API. Prefix messages with your agent name.
+```
 
 ## Subscriptions
 
@@ -445,7 +469,7 @@ Settings are per-agent, per-channel.
 
 | Panel | Content |
 |-------|---------|
-| **Left sidebar** | Connected apps listed by platform icon + bot/server name (from `adapter.Channels()`). Channels/groups come from the platform API, not stored message history. Per-platform UI renderers for activity (WhatsApp shows contacts/groups, Slack shows threads, Discord shows servers). Unconnected gateways show a "Setup" link. |
+| **Left sidebar** | Gateway dropdowns with channel lists. Unconnected gateways show a "Setup" link. |
 | **Main area** | Activity feed with delivery status badges. Polls every 5s and receives live SSE updates via `/api/events`. |
 | **Right panel** | Agent list with online indicators, role badges, and `@mention` toggle. |
 
@@ -482,34 +506,27 @@ graph TD
 
 1. Create the adapter file at `pkg/gateway/<platform>/<platform>.go`.
 
-2. Implement the three-part pattern:
+2. Implement `NotificationAdapter`:
 
 ```go
 package myplatform
 
 import (
     "context"
-    "net/http"
     "github.com/rpuneet/bc/pkg/gateway"
 )
 
 type Adapter struct {
-    token     string
-    connected bool
-    count     int64
+    token string
 }
 
 func New(token string) *Adapter {
     return &Adapter{token: token}
 }
 
-func (a *Adapter) Name() string          { return "myplatform" }
-func (a *Adapter) Type() gateway.AdapterType { return gateway.AdapterSocket }
+func (a *Adapter) Name() string { return "myplatform" }
 
-// Connect + Listen: authenticate, then forward raw events
 func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification)) error {
-    // Connect to the platform using a.token
-    // ...
     for {
         select {
         case <-ctx.Done():
@@ -521,26 +538,17 @@ func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification))
                 Platform:  "myplatform",
                 Sender:    extractSender(event),
                 Timestamp: time.Now(),
-                Raw:       raw,  // full platform payload, no parsing
+                Raw:       raw,
             })
         }
     }
 }
 
-func (a *Adapter) Stop() error { return a.conn.Close() }
-
-// Channels from the platform API (live query, not stored history)
-func (a *Adapter) Channels() []gateway.ChannelInfo { return a.queryPlatformChannels() }
-
+func (a *Adapter) Stop() error              { return a.conn.Close() }
+func (a *Adapter) HTTPHandler() http.Handler { return nil }
+func (a *Adapter) Channels() []gateway.ChannelInfo { return a.discovered }
 func (a *Adapter) Status() gateway.AdapterStatus {
     return gateway.AdapterStatus{Connected: a.connected, MessageCount: a.count}
-}
-
-// API Proxy: forward /api/gateways/myplatform/api/* to the platform
-func (a *Adapter) HTTPHandler() http.Handler {
-    mux := http.NewServeMux()
-    mux.HandleFunc("/api/", a.proxyToPlatform)
-    return mux
 }
 ```
 
@@ -551,7 +559,9 @@ adapter := myplatform.New(token)
 gatewayMgr.Register(adapter)
 ```
 
-4. Add the platform to the [Platform Integrations](#platform-integrations) table and the setup wizard.
+4. Add credential env vars to the [Platform Integrations](#platform-integrations) table and the setup wizard.
+
+5. Update the agent system prompt template with identity instructions for the new platform.
 
 ## API Reference
 
@@ -563,9 +573,9 @@ All endpoints are served by bcd at `http://127.0.0.1:9374`. No authentication (l
 GET    /api/gateways                                              -- list all gateways + status
 PATCH  /api/gateways/{platform}                                   -- update tokens/settings
 GET    /api/gateways/{platform}/health                            -- live connection probe
-GET    /api/gateways/{platform}/channels                          -- discovered channels (from platform API)
+GET    /api/gateways/{platform}/channels                          -- discovered channels
 GET    /api/gateways/{platform}/channels/{channel}                -- channel detail + subscribers
-*      /api/gateways/{platform}/api/*                             -- API proxy (pass-through to platform)
+POST   /api/gateways/{platform}/channels/{channel}/send           -- send outbound message
 ```
 
 ### Agent Subscription Management
@@ -594,7 +604,7 @@ GET    /api/channels/{name}/history                               -- legacy mess
 
 | Package | Purpose |
 |---------|---------|
-| [`pkg/gateway/`](../../pkg/gateway/README.md) | Adapter interface, Manager, 34 platform adapters (13 working, 21 coming soon) |
+| [`pkg/gateway/`](../../pkg/gateway/README.md) | Adapter interface, Manager, platform adapters (Slack, Telegram, Discord) |
 | [`pkg/notify/`](../../pkg/notify/README.md) | Notification types, Store (SQLite/Postgres), Service (dispatch + subscription management) |
 | `pkg/secret/` | AES-256-GCM encrypted credential storage |
 | `server/handlers/` | REST API handlers for gateway and subscription management |

--- a/docs/explanation/agents.md
+++ b/docs/explanation/agents.md
@@ -166,6 +166,4 @@ Agents receive notifications from external platforms via `tmux send-keys` -- the
 
 Agents subscribe to notification sources (`platform:channel`) and can filter with `mention_only` to receive only events where they are @mentioned.
 
-To respond, agents call the platform's native API through the API proxy at `/api/gateways/{platform}/api/*`. The proxy injects stored credentials, so agents do not need platform tokens in their environment.
-
 On delivery failure: logged to `notify_delivery_log` with status `failed` and the error message. There is no automatic retry -- failed deliveries are recorded for observability and the next inbound message will attempt delivery independently.

--- a/docs/explanation/networking.md
+++ b/docs/explanation/networking.md
@@ -31,7 +31,7 @@ All communication flows through **bcd** as the central hub. No component talks d
 
 ## Notification Delivery Flow
 
-External platform events are delivered to subscribed agents via the notification gateway. Each adapter follows a 3-part pattern: Connect (authenticate), Listen (receive events), and API Proxy (expose platform API to agents).
+External platform events are delivered to subscribed agents via the notification gateway:
 
 ```mermaid
 sequenceDiagram
@@ -44,7 +44,7 @@ sequenceDiagram
     participant Web as Web UI
 
     Platform->>Adapter: Inbound event (message/webhook)
-    Adapter->>Notify: Dispatch(Notification{Raw JSON})
+    Adapter->>Notify: Dispatch(channel, sender, content)
     Notify->>DB: Save message + query subscribers
     Notify->>Hub: Publish gateway.message event
     Hub->>Web: SSE: gateway.message
@@ -53,10 +53,6 @@ sequenceDiagram
         Notify->>Agent: tmux send-keys (JSON payload)
         Notify->>DB: Log delivery (delivered/failed)
     end
-
-    Note over Agent,Platform: Agents respond via API proxy
-    Agent->>Adapter: /api/gateways/{platform}/api/*
-    Adapter->>Platform: Forward with stored credentials
 ```
 
 See [Notification Architecture](../architecture/notifications.md) for the full notification system design.

--- a/docs/explanation/web-ui.md
+++ b/docs/explanation/web-ui.md
@@ -281,7 +281,6 @@ Navigation is a static `NAV_ITEMS` array in `Layout.tsx`. Each entry has a `to` 
 | `api.getChannelHistory(name, limit, before)` | `GET /api/channels/:name/history` | Notifications |
 | `api.getChannelSubscriptions(channel)` | `GET /api/gateways/:gw/channels/:ch/agents` or `/api/notify/subscriptions/:channel` | Notifications |
 | `api.getChannelActivity(channel, limit)` | `GET /api/gateways/:gw/channels/:ch/activity` or `/api/notify/activity/:channel` | Notifications |
-| `api.proxyPlatformAPI(gateway, path)` | `* /api/gateways/:gw/api/*` | Notifications (agent API calls) |
 | `api.getCostSummary()` | `GET /api/costs` | Dashboard, Costs |
 | `api.getCostByAgent()` | `GET /api/costs/agents` | Costs |
 | `api.listRoles()` | `GET /api/roles` | Roles |
@@ -420,7 +419,7 @@ graph TD
 |---|---|---|---|
 | Dashboard | 5s | -- | `listAgents`, `listGateways`, `getCostSummary` |
 | Agents | 5s | `agent.state_changed` | `listAgents`, `startAgent`, `stopAgent`, `sendToAgent` |
-| Notifications | 10s (list) | `gateway.message` | `listGateways`, `listNotificationSources`, `getChannelHistory`, `getChannelActivity`. Sidebar shows channels from platform API (`adapter.Channels()`), per-platform UI renderers for activity. |
+| Notifications | 10s (list) | `gateway.message` | `listGateways`, `listNotificationSources`, `getChannelHistory`, `getChannelActivity` |
 | Costs | 10s | -- | `getCostSummary`, `getCostByAgent` |
 | Roles | 30s | -- | `listRoles` + full CRUD |
 | Tools | 30s | -- | `listTools` |

--- a/docs/how-to/set-up-notifications.md
+++ b/docs/how-to/set-up-notifications.md
@@ -4,7 +4,7 @@ This guide walks through connecting external platforms to bc and routing notific
 
 ## Overview
 
-bc routes inbound events from external platforms (Slack, Telegram, Discord, WhatsApp, GitHub, and others) to subscribed agents. Each adapter connects to a platform, listens for events, and exposes the platform's native API via a proxy. Agents receive notifications as JSON payloads in their tmux or Docker sessions and interact with platforms through the API proxy at `/api/gateways/{platform}/api/*`.
+bc routes inbound events from external platforms (Slack, Telegram, GitHub, and others) to subscribed agents. Agents receive notifications as JSON payloads in their tmux or Docker sessions and respond using platform APIs directly.
 
 ## 1. Add a Notification Source
 

--- a/docs/reference/api-rest.md
+++ b/docs/reference/api-rest.md
@@ -219,7 +219,7 @@ Delete role. Agents keep their current config.
 
 ## Gateways & Channels
 
-Notification gateways bridge external platforms to bc agents. Each adapter follows a 3-part pattern: Connect, Listen, and API Proxy. See [Notification Architecture](../architecture/notifications.md) for full design.
+Notification gateways bridge external platforms to bc agents. See [Channel Architecture](../architecture/notifications.md) for full design.
 
 ### `GET /api/gateways`
 
@@ -245,7 +245,7 @@ Live connection probe.
 
 ### `GET /api/gateways/{gateway}/channels`
 
-List discovered channels for a gateway. Channels come from the platform API (via `adapter.Channels()`), not stored history.
+List discovered channels for a gateway.
 
 ### `POST /api/gateways/{gateway}/channels/{channel}/agents`
 
@@ -266,10 +266,6 @@ Update subscription settings (e.g., toggle mention_only).
 ### `GET /api/gateways/{gateway}/channels/{channel}/activity`
 
 Recent delivery log entries for a channel.
-
-### `* /api/gateways/{gateway}/api/*`
-
-API proxy -- pass-through to the platform's native API. Agents use this to send messages, upload files, list channels, etc. The proxy injects stored credentials from `pkg/secret`.
 
 ---
 

--- a/pkg/gateway/README.md
+++ b/pkg/gateway/README.md
@@ -4,45 +4,36 @@ External platform adapters for the bc notification system.
 
 ## Overview
 
-This package defines the `NotificationAdapter` interface and `Manager` that orchestrate connections to 34 external platforms. Each adapter follows a 3-part pattern:
-
-1. **Connect** -- Authenticate with the platform (token, QR code, OAuth). Store only credentials + session state.
-2. **Listen** -- Receive real-time events and forward them as `Notification{Raw JSON}` to `pkg/notify` for dispatch.
-3. **API Proxy** -- Expose the platform's native API via `/api/gateways/{platform}/api/*` so agents can send messages, upload files, etc.
-
-There are no `Send`/`SendFile`/`React` methods on the adapter interface. Agents interact with platforms through the API proxy.
+This package defines the `NotificationAdapter` interface and `Manager` that orchestrate connections to 34 external platforms. Each adapter connects to a platform, receives inbound events, and forwards them to `pkg/notify` for dispatch to subscribed agents.
 
 ## Key Types
 
-- **`NotificationAdapter`** -- interface each platform implements (Name, Type, Start, Stop, HTTPHandler, Channels, Status)
-- **`Notification`** -- inbound event with raw JSON payload (Channel, Platform, Sender, Content, Mentions, Timestamp, Raw)
-- **`Manager`** -- registers adapters, discovers channels, routes inbound events
-- **`ChannelInfo`** -- a channel/group from the platform API (ID, Name, Platform)
-- **`AdapterStatus`** -- connection state (Connected, Error, BotName, LastMessageAt, MessageCount)
-- **`AdapterType`** -- socket, webhook, or poll
+- **`NotificationAdapter`** — interface each platform implements (Name, Type, Start, Stop, HTTPHandler, Channels, Status)
+- **`Notification`** — normalized inbound event (Channel, Platform, Sender, Content, Mentions, Timestamp, Raw json.RawMessage)
+- **`Manager`** — registers adapters, discovers channels, routes inbound events
+- **`ChannelInfo`** — a channel/group discovered on a platform (ID, Name, Platform)
+- **`AdapterStatus`** — connection state (Connected, Error, BotName, LastMessageAt, MessageCount)
+- **`AdapterType`** — socket, webhook, or poll
 
-## Working Adapters
+## Adapters
 
-| Platform | Directory | Transport | SDK / Library |
-|----------|-----------|-----------|---------------|
-| Slack | `slack/` | Socket Mode (WebSocket) | `slack-go/slack` |
-| Telegram | `telegram/` | Bot API long-polling | `go-telegram-bot-api` |
-| Discord | `discord/` | Gateway WebSocket | `bwmarrin/discordgo` |
-| WhatsApp | `whatsapp/` | Multi-device protocol | `whatsmeow` (QR pairing) |
-| IRC | `irc/` | IRC protocol | `ergochat/irc-go` |
-| MQTT | `mqtt/` | MQTT protocol | `eclipse/paho.mqtt.golang` |
-| Mattermost | `mattermost/` | WebSocket | `gorilla/websocket` |
-| GitHub | `github/` | Webhook | Webhook handler |
-| Generic Webhook | `webhook/` | HTTP POST | Webhook receiver |
-| RSS | `rss/` | HTTP polling | HTTP client |
-| Matrix | `matrix/` | HTTP polling | HTTP client |
-| Reddit | `reddit/` | HTTP polling | HTTP client |
-| Twitter | `twitter/` | HTTP polling | HTTP client |
-
-## Stub Adapters (Coming Soon)
-
-Signal, Line, Feishu, Google Chat, MS Teams, GitLab, Bitbucket, Jira, Linear, Sentry, PagerDuty, Datadog, Grafana, Stripe, Vercel, Netlify, Notion, Twitch, Home Assistant, Nostr, iMessage.
+| Platform | Directory | Transport |
+|----------|-----------|-----------|
+| Slack | `slack/` | Socket Mode (WebSocket) |
+| Telegram | `telegram/` | Bot API long-polling |
+| Discord | `discord/` | Gateway WebSocket |
+| GitHub | `github/` | Webhook |
+| GitLab | `gitlab/` | Webhook |
+| Sentry | `sentry/` | Webhook |
+| PagerDuty | `pagerduty/` | Webhook |
+| Datadog | `datadog/` | Webhook |
+| Grafana | `grafana/` | Webhook |
+| RSS | `rss/` | Poll |
+| Notion | `notion/` | Poll |
+| WhatsApp | `whatsapp/` | Socket |
+| Matrix | `matrix/` | Poll |
+| + 21 more | see subdirectories | various |
 
 ## Architecture
 
-See [docs/architecture/notifications.md](../../docs/architecture/notifications.md) for the full notification architecture, including the 3-part adapter pattern, message flow diagrams, and how to add new adapters.
+See [docs/architecture/notifications.md](../../docs/architecture/notifications.md) for the full notification architecture, including message flow diagrams, credential injection, and how to add new adapters.

--- a/pkg/gateway/discord/discord.go
+++ b/pkg/gateway/discord/discord.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"regexp"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -108,15 +107,10 @@ func (a *Adapter) Channels() []gateway.ChannelInfo {
 func (a *Adapter) Status() gateway.AdapterStatus {
 	a.chatMu.RLock()
 	defer a.chatMu.RUnlock()
-	botName := ""
-	if a.session != nil && a.session.State != nil && a.session.State.User != nil {
-		botName = a.session.State.User.Username
-	}
 	return gateway.AdapterStatus{
 		Connected:     a.connected,
 		LastMessageAt: a.lastMessageAt,
 		Error:         a.lastError,
-		BotName:       botName,
 		MessageCount:  a.messageCount.Load(),
 	}
 }
@@ -159,26 +153,6 @@ func (a *Adapter) Health(_ context.Context) error {
 	return nil
 }
 
-// sanitizeGuildName replaces spaces, colons, and runs of non-alphanumeric
-// characters with dashes so that the guild:channel key is URL-safe and
-// doesn't conflict with the platform:channel separator.
-var reUnsafe = regexp.MustCompile(`[^a-zA-Z0-9-]+`)
-
-func sanitizeGuildName(name string) string {
-	s := reUnsafe.ReplaceAllString(name, "-")
-	// Trim leading/trailing dashes.
-	for len(s) > 0 && s[0] == '-' {
-		s = s[1:]
-	}
-	for len(s) > 0 && s[len(s)-1] == '-' {
-		s = s[:len(s)-1]
-	}
-	if s == "" {
-		return "unknown"
-	}
-	return s
-}
-
 // --- Internal handlers ---
 
 // handleReady processes the Ready event to discover guilds and channels.
@@ -186,22 +160,17 @@ func (a *Adapter) handleReady(_ *discordgo.Session, r *discordgo.Ready) {
 	log.Info("discord: ready", "guilds", len(r.Guilds))
 
 	for _, guild := range r.Guilds {
-		guildName := guild.ID
-		if g, err := a.session.Guild(guild.ID); err == nil && g.Name != "" {
-			guildName = sanitizeGuildName(g.Name)
-		}
-
 		channels, err := a.session.GuildChannels(guild.ID)
 		if err != nil {
-			log.Warn("discord: failed to list channels", "guild", guildName, "error", err)
+			log.Warn("discord: failed to list channels", "guild", guild.ID, "error", err)
 			continue
 		}
 
 		a.chatMu.Lock()
 		for _, ch := range channels {
 			if ch.Type == discordgo.ChannelTypeGuildText {
-				a.guildChannels[ch.ID] = guildName + ":" + ch.Name
-				log.Info("discord: discovered channel", "channel", guildName+":"+ch.Name, "id", ch.ID)
+				a.guildChannels[ch.ID] = ch.Name
+				log.Info("discord: discovered channel", "channel", ch.Name, "id", ch.ID, "guild", guild.ID)
 			}
 		}
 		a.chatMu.Unlock()
@@ -225,23 +194,12 @@ func (a *Adapter) handleMessage(s *discordgo.Session, m *discordgo.MessageCreate
 		return
 	}
 
-	// Get channel name as "guild:channel" (resolve via API if not cached)
+	// Get channel name
 	a.chatMu.RLock()
 	channelName, ok := a.guildChannels[m.ChannelID]
 	a.chatMu.RUnlock()
 	if !ok {
-		chName := m.ChannelID
-		if ch, err := s.Channel(m.ChannelID); err == nil && ch.Name != "" {
-			chName = ch.Name
-		}
-		guildName := m.GuildID
-		if guild, err := s.Guild(m.GuildID); err == nil && guild.Name != "" {
-			guildName = sanitizeGuildName(guild.Name)
-		}
-		channelName = guildName + ":" + chName
-		a.chatMu.Lock()
-		a.guildChannels[m.ChannelID] = channelName
-		a.chatMu.Unlock()
+		channelName = m.ChannelID
 	}
 
 	sender := m.Author.Username

--- a/pkg/gateway/homeassistant/homeassistant.go
+++ b/pkg/gateway/homeassistant/homeassistant.go
@@ -1,0 +1,78 @@
+// Package homeassistant implements a placeholder gateway.NotificationAdapter
+// for the Home Assistant WebSocket API. Real implementation requires a
+// WebSocket client library.
+package homeassistant
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/gateway"
+	"github.com/rpuneet/bc/pkg/log"
+)
+
+// Adapter implements gateway.NotificationAdapter for Home Assistant (placeholder).
+type Adapter struct {
+	lastMessageAt time.Time
+	handler       func(gateway.Notification)
+	name          string
+	url           string
+	token         string
+	lastError     string
+	mu            sync.Mutex
+	connected     bool
+	messageCount  atomic.Int64
+}
+
+var _ gateway.NotificationAdapter = (*Adapter)(nil)
+
+// New creates a Home Assistant adapter with the default name.
+func New(url, token string) *Adapter {
+	return &Adapter{name: "homeassistant", url: url, token: token}
+}
+
+// NewNamed creates a named Home Assistant adapter.
+func NewNamed(name, url, token string) *Adapter {
+	return &Adapter{name: name, url: url, token: token}
+}
+
+func (a *Adapter) Name() string              { return a.name }
+func (a *Adapter) Type() gateway.AdapterType { return gateway.AdapterSocket }
+func (a *Adapter) HTTPHandler() http.Handler { return nil }
+func (a *Adapter) Stop() error               { return nil }
+
+// Start is a placeholder that blocks until ctx is canceled.
+// Real implementation requires a WebSocket client library for
+// the Home Assistant WebSocket API.
+func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification)) error {
+	a.handler = handler
+	log.Info("homeassistant: adapter registered (placeholder — real implementation requires WebSocket client)",
+		"adapter", a.name, "url", a.url)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Channels returns common Home Assistant event channels.
+func (a *Adapter) Channels() []gateway.ChannelInfo {
+	types := []string{"state_changed", "automation_triggered", "script_started"}
+	channels := make([]gateway.ChannelInfo, len(types))
+	for i, t := range types {
+		channels[i] = gateway.ChannelInfo{ID: t, Name: t, Platform: "homeassistant"}
+	}
+	return channels
+}
+
+// Status returns the adapter's connection state.
+func (a *Adapter) Status() gateway.AdapterStatus {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return gateway.AdapterStatus{
+		Connected:     a.connected,
+		LastMessageAt: a.lastMessageAt,
+		Error:         a.lastError,
+		MessageCount:  a.messageCount.Load(),
+	}
+}

--- a/pkg/gateway/imessage/imessage.go
+++ b/pkg/gateway/imessage/imessage.go
@@ -1,0 +1,180 @@
+// Package imessage implements a gateway.NotificationAdapter that polls
+// the BlueBubbles API for new iMessage messages.
+package imessage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/gateway"
+	"github.com/rpuneet/bc/pkg/log"
+)
+
+const defaultInterval = 10 // seconds
+
+// Adapter implements gateway.NotificationAdapter for iMessage via BlueBubbles.
+type Adapter struct {
+	httpClient   *http.Client
+	handler      func(gateway.Notification)
+	lastFetchAt  time.Time
+	name         string
+	apiURL       string
+	password     string
+	lastError    string
+	lastTS       int64
+	messageCount atomic.Int64
+	mu           sync.Mutex
+	interval     int
+	connected    bool
+}
+
+var _ gateway.NotificationAdapter = (*Adapter)(nil)
+
+// New creates an iMessage adapter with the default name.
+func New(apiURL, password string, intervalSeconds int) *Adapter {
+	return NewNamed("imessage", apiURL, password, intervalSeconds)
+}
+
+// NewNamed creates a named iMessage adapter.
+func NewNamed(name, apiURL, password string, intervalSeconds int) *Adapter {
+	if intervalSeconds <= 0 {
+		intervalSeconds = defaultInterval
+	}
+	return &Adapter{
+		name:       name,
+		apiURL:     apiURL,
+		password:   password,
+		interval:   intervalSeconds,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (a *Adapter) Name() string              { return a.name }
+func (a *Adapter) Type() gateway.AdapterType { return gateway.AdapterPoll }
+func (a *Adapter) HTTPHandler() http.Handler { return nil }
+func (a *Adapter) Stop() error               { return nil }
+
+// Start polls the BlueBubbles API until ctx is canceled.
+func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification)) error {
+	a.handler = handler
+
+	a.poll(ctx)
+
+	ticker := time.NewTicker(time.Duration(a.interval) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			a.poll(ctx)
+		}
+	}
+}
+
+// Channels returns a single channel.
+func (a *Adapter) Channels() []gateway.ChannelInfo {
+	return []gateway.ChannelInfo{{ID: "messages", Name: "messages", Platform: "imessage"}}
+}
+
+// Status returns the adapter's connection state.
+func (a *Adapter) Status() gateway.AdapterStatus {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return gateway.AdapterStatus{
+		Connected:     a.connected,
+		LastMessageAt: a.lastFetchAt,
+		Error:         a.lastError,
+		MessageCount:  a.messageCount.Load(),
+	}
+}
+
+// poll fetches recent messages from the BlueBubbles API.
+func (a *Adapter) poll(ctx context.Context) {
+	url := fmt.Sprintf("%s/api/v1/message?password=%s&limit=10&sort=desc", a.apiURL, a.password)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		a.setError(fmt.Sprintf("build request: %v", err))
+		return
+	}
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		a.setError(fmt.Sprintf("fetch: %v", err))
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		a.setError(fmt.Sprintf("read body: %v", err))
+		return
+	}
+
+	a.mu.Lock()
+	a.connected = true
+	a.lastFetchAt = time.Now()
+	a.lastError = ""
+	a.mu.Unlock()
+
+	var result struct {
+		Data []struct {
+			Handle struct {
+				Address string `json:"address"`
+			} `json:"handle"`
+			DateCreated int64 `json:"dateCreated"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return
+	}
+
+	var count int
+	for _, msg := range result.Data {
+		if msg.DateCreated <= a.lastTS {
+			continue
+		}
+
+		sender := msg.Handle.Address
+		if sender == "" {
+			sender = "imessage"
+		}
+
+		raw, _ := json.Marshal(msg) //nolint:errcheck
+		a.messageCount.Add(1)
+		count++
+
+		if a.handler != nil {
+			a.handler(gateway.Notification{
+				Channel:   "messages",
+				Platform:  "imessage",
+				Sender:    sender,
+				Timestamp: time.Now(),
+				Raw:       raw,
+			})
+		}
+	}
+
+	// Update last timestamp.
+	if len(result.Data) > 0 && result.Data[0].DateCreated > a.lastTS {
+		a.mu.Lock()
+		a.lastTS = result.Data[0].DateCreated
+		a.mu.Unlock()
+	}
+
+	log.Debug("imessage: poll complete", "adapter", a.name, "messages", count)
+}
+
+func (a *Adapter) setError(msg string) {
+	a.mu.Lock()
+	a.lastError = msg
+	a.mu.Unlock()
+	log.Warn("imessage: "+msg, "adapter", a.name)
+}

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -105,7 +105,7 @@ func (m *Manager) Start(ctx context.Context) error {
 			defer wg.Done()
 			platformName := adapter.Name()
 			handler := func(n Notification) {
-				m.HandleNotification(platformName, n)
+				m.handleNotification(platformName, n)
 			}
 			if err := adapter.Start(ctx, handler); err != nil && ctx.Err() == nil {
 				log.Error("gateway: adapter stopped with error", "adapter", adapter.Name(), "error", err)
@@ -209,6 +209,13 @@ func (m *Manager) lateDiscovery(ctx context.Context) {
 	}
 }
 
+// GetAdapter returns a registered adapter by name, or nil if not found.
+func (m *Manager) GetAdapter(name string) NotificationAdapter {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.adapters[name]
+}
+
 // AdapterNames returns the names of all registered adapters.
 func (m *Manager) AdapterNames() []string {
 	m.mu.RLock()
@@ -220,11 +227,9 @@ func (m *Manager) AdapterNames() []string {
 	return names
 }
 
-// GetAdapter returns a registered adapter by name, or nil if not found.
-func (m *Manager) GetAdapter(name string) NotificationAdapter {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-	return m.adapters[name]
+// HandleNotification processes an inbound notification from a specific platform.
+func (m *Manager) HandleNotification(platform string, n Notification) {
+	m.handleNotification(platform, n)
 }
 
 // AdapterStatus returns the connection status for a specific adapter.
@@ -334,10 +339,8 @@ func (m *Manager) DiscoveredSources() []string {
 	return names
 }
 
-// HandleNotification processes an event from a NotificationAdapter into bc.
-// Exported so that dynamically paired adapters (e.g., WhatsApp QR) can route
-// messages through the manager without going through Start().
-func (m *Manager) HandleNotification(platform string, n Notification) {
+// handleNotification processes an event from a NotificationAdapter into bc.
+func (m *Manager) handleNotification(platform string, n Notification) {
 	channelName := n.Channel
 	if channelName == "" {
 		channelName = "default"

--- a/pkg/gateway/nostr/nostr.go
+++ b/pkg/gateway/nostr/nostr.go
@@ -1,0 +1,71 @@
+// Package nostr implements a placeholder gateway.NotificationAdapter
+// for Nostr relay WebSocket connections. Real implementation requires
+// a WebSocket client library.
+package nostr
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/gateway"
+	"github.com/rpuneet/bc/pkg/log"
+)
+
+// Adapter implements gateway.NotificationAdapter for Nostr (placeholder).
+type Adapter struct {
+	lastMessageAt time.Time
+	handler       func(gateway.Notification)
+	name          string
+	relayURL      string
+	lastError     string
+	mu            sync.Mutex
+	connected     bool
+	messageCount  atomic.Int64
+}
+
+var _ gateway.NotificationAdapter = (*Adapter)(nil)
+
+// New creates a Nostr adapter with the default name.
+func New(relayURL string) *Adapter {
+	return &Adapter{name: "nostr", relayURL: relayURL}
+}
+
+// NewNamed creates a named Nostr adapter.
+func NewNamed(name, relayURL string) *Adapter {
+	return &Adapter{name: name, relayURL: relayURL}
+}
+
+func (a *Adapter) Name() string              { return a.name }
+func (a *Adapter) Type() gateway.AdapterType { return gateway.AdapterSocket }
+func (a *Adapter) HTTPHandler() http.Handler { return nil }
+func (a *Adapter) Stop() error               { return nil }
+
+// Start is a placeholder that blocks until ctx is canceled.
+// Real implementation requires a WebSocket/Nostr client library.
+func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification)) error {
+	a.handler = handler
+	log.Info("nostr: adapter registered (placeholder — real implementation requires Nostr client library)",
+		"adapter", a.name, "relay", a.relayURL)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// Channels returns a single placeholder channel.
+func (a *Adapter) Channels() []gateway.ChannelInfo {
+	return []gateway.ChannelInfo{{ID: a.name, Name: a.name, Platform: "nostr"}}
+}
+
+// Status returns the adapter's connection state.
+func (a *Adapter) Status() gateway.AdapterStatus {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return gateway.AdapterStatus{
+		Connected:     a.connected,
+		LastMessageAt: a.lastMessageAt,
+		Error:         a.lastError,
+		MessageCount:  a.messageCount.Load(),
+	}
+}

--- a/pkg/gateway/signal/signal.go
+++ b/pkg/gateway/signal/signal.go
@@ -1,0 +1,164 @@
+// Package signal implements a gateway.NotificationAdapter that polls
+// a signal-cli REST API for new messages.
+package signal
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rpuneet/bc/pkg/gateway"
+	"github.com/rpuneet/bc/pkg/log"
+)
+
+const defaultInterval = 10 // seconds
+
+// Adapter implements gateway.NotificationAdapter for Signal via signal-cli REST.
+type Adapter struct {
+	httpClient   *http.Client
+	handler      func(gateway.Notification)
+	lastFetchAt  time.Time
+	name         string
+	apiURL       string
+	lastError    string
+	messageCount atomic.Int64
+	mu           sync.Mutex
+	interval     int
+	connected    bool
+}
+
+var _ gateway.NotificationAdapter = (*Adapter)(nil)
+
+// New creates a Signal adapter with the default name.
+func New(apiURL string, intervalSeconds int) *Adapter {
+	return NewNamed("signal", apiURL, intervalSeconds)
+}
+
+// NewNamed creates a named Signal adapter.
+func NewNamed(name, apiURL string, intervalSeconds int) *Adapter {
+	if intervalSeconds <= 0 {
+		intervalSeconds = defaultInterval
+	}
+	return &Adapter{
+		name:       name,
+		apiURL:     apiURL,
+		interval:   intervalSeconds,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (a *Adapter) Name() string              { return a.name }
+func (a *Adapter) Type() gateway.AdapterType { return gateway.AdapterPoll }
+func (a *Adapter) HTTPHandler() http.Handler { return nil }
+func (a *Adapter) Stop() error               { return nil }
+
+// Start polls the signal-cli REST API until ctx is canceled.
+func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification)) error {
+	a.handler = handler
+
+	a.poll(ctx)
+
+	ticker := time.NewTicker(time.Duration(a.interval) * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			a.poll(ctx)
+		}
+	}
+}
+
+// Channels returns a single channel.
+func (a *Adapter) Channels() []gateway.ChannelInfo {
+	return []gateway.ChannelInfo{{ID: "messages", Name: "messages", Platform: "signal"}}
+}
+
+// Status returns the adapter's connection state.
+func (a *Adapter) Status() gateway.AdapterStatus {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return gateway.AdapterStatus{
+		Connected:     a.connected,
+		LastMessageAt: a.lastFetchAt,
+		Error:         a.lastError,
+		MessageCount:  a.messageCount.Load(),
+	}
+}
+
+// poll fetches new messages from the signal-cli REST API.
+func (a *Adapter) poll(ctx context.Context) {
+	url := fmt.Sprintf("%s/v1/receive", a.apiURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		a.setError(fmt.Sprintf("build request: %v", err))
+		return
+	}
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		a.setError(fmt.Sprintf("fetch: %v", err))
+		return
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		a.setError(fmt.Sprintf("read body: %v", err))
+		return
+	}
+
+	a.mu.Lock()
+	a.connected = true
+	a.lastFetchAt = time.Now()
+	a.lastError = ""
+	a.mu.Unlock()
+
+	var messages []struct {
+		Envelope struct {
+			Source      string `json:"source"`
+			DataMessage struct {
+				Message string `json:"message"`
+			} `json:"dataMessage"`
+		} `json:"envelope"`
+	}
+	if err := json.Unmarshal(body, &messages); err != nil {
+		return // no messages or unexpected format
+	}
+
+	for _, msg := range messages {
+		sender := msg.Envelope.Source
+		if sender == "" {
+			sender = "signal"
+		}
+
+		raw, _ := json.Marshal(msg) //nolint:errcheck
+		a.messageCount.Add(1)
+
+		if a.handler != nil {
+			a.handler(gateway.Notification{
+				Channel:   "messages",
+				Platform:  "signal",
+				Sender:    sender,
+				Timestamp: time.Now(),
+				Raw:       raw,
+			})
+		}
+	}
+
+	log.Debug("signal: poll complete", "adapter", a.name, "messages", len(messages))
+}
+
+func (a *Adapter) setError(msg string) {
+	a.mu.Lock()
+	a.lastError = msg
+	a.mu.Unlock()
+	log.Warn("signal: "+msg, "adapter", a.name)
+}

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -27,13 +27,17 @@ import (
 	bcgateway "github.com/rpuneet/bc/pkg/gateway"
 	bcdiscord "github.com/rpuneet/bc/pkg/gateway/discord"
 	bcgithub "github.com/rpuneet/bc/pkg/gateway/github"
+	bchomeassistant "github.com/rpuneet/bc/pkg/gateway/homeassistant"
+	bcimessage "github.com/rpuneet/bc/pkg/gateway/imessage"
 	bcirc "github.com/rpuneet/bc/pkg/gateway/irc"
 	bcmatrix "github.com/rpuneet/bc/pkg/gateway/matrix"
 	bcmattermost "github.com/rpuneet/bc/pkg/gateway/mattermost"
 	bcmqtt "github.com/rpuneet/bc/pkg/gateway/mqtt"
+	bcnostr "github.com/rpuneet/bc/pkg/gateway/nostr"
 	bcnotion "github.com/rpuneet/bc/pkg/gateway/notion"
 	bcreddit "github.com/rpuneet/bc/pkg/gateway/reddit"
 	bcrss "github.com/rpuneet/bc/pkg/gateway/rss"
+	bcsignal "github.com/rpuneet/bc/pkg/gateway/signal"
 	bcslack "github.com/rpuneet/bc/pkg/gateway/slack"
 	bctelegram "github.com/rpuneet/bc/pkg/gateway/telegram"
 	bctwitter "github.com/rpuneet/bc/pkg/gateway/twitter"
@@ -679,6 +683,58 @@ func buildGatewayManager(ctx context.Context, ws *bcworkspace.Workspace, notifyS
 		}
 		m.Register(bctwitter.NewNamed(adapterName, c.BearerToken, c.UserID, c.Interval))
 		log.Info("gateway: twitter adapter registered", "name", adapterName)
+	}
+
+	// Register Signal poll adapters.
+	for label, c := range gw.Signals {
+		if !c.Enabled || c.APIURL == "" {
+			continue
+		}
+		adapterName := "signal"
+		if label != "" {
+			adapterName = "signal:" + label
+		}
+		m.Register(bcsignal.NewNamed(adapterName, c.APIURL, c.Interval))
+		log.Info("gateway: signal adapter registered", "name", adapterName)
+	}
+
+	// Register Nostr socket adapters.
+	for label, c := range gw.Nostrs {
+		if !c.Enabled {
+			continue
+		}
+		adapterName := "nostr"
+		if label != "" {
+			adapterName = "nostr:" + label
+		}
+		m.Register(bcnostr.NewNamed(adapterName, c.RelayURL))
+		log.Info("gateway: nostr adapter registered", "name", adapterName)
+	}
+
+	// Register iMessage poll adapters.
+	for label, c := range gw.IMessages {
+		if !c.Enabled || c.APIURL == "" {
+			continue
+		}
+		adapterName := "imessage"
+		if label != "" {
+			adapterName = "imessage:" + label
+		}
+		m.Register(bcimessage.NewNamed(adapterName, c.APIURL, c.Password, c.Interval))
+		log.Info("gateway: imessage adapter registered", "name", adapterName)
+	}
+
+	// Register Home Assistant socket adapters.
+	for label, c := range gw.HomeAssistants {
+		if !c.Enabled {
+			continue
+		}
+		adapterName := "homeassistant"
+		if label != "" {
+			adapterName = "homeassistant:" + label
+		}
+		m.Register(bchomeassistant.NewNamed(adapterName, c.URL, c.Token))
+		log.Info("gateway: homeassistant adapter registered", "name", adapterName)
 	}
 
 	// Register Reddit poll adapters.

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -70,10 +70,32 @@ func (h *GatewayHandler) gatewayRouter(w http.ResponseWriter, r *http.Request) {
 		h.gatewayPair(w, r, platform, rest)
 	case rest == "channels" || strings.HasPrefix(rest, "channels/"):
 		h.gatewayChannels(w, r, platform, strings.TrimPrefix(rest, "channels"))
+	case rest == "api" || strings.HasPrefix(rest, "api/"):
+		h.gatewayAPIProxy(w, r, platform, strings.TrimPrefix(rest, "api"))
 	default:
 		// Existing: PATCH /api/gateways/{platform}
 		h.byPlatform(w, r)
 	}
+}
+
+// gatewayAPIProxy forwards requests to /api/gateways/{platform}/api/* to the adapter's HTTP handler.
+func (h *GatewayHandler) gatewayAPIProxy(w http.ResponseWriter, r *http.Request, platform, subpath string) {
+	if h.gw == nil {
+		httpError(w, "gateway manager not available", http.StatusServiceUnavailable)
+		return
+	}
+	adapter := h.gw.GetAdapter(platform)
+	if adapter == nil {
+		httpError(w, "adapter not found: "+platform, http.StatusNotFound)
+		return
+	}
+	handler := adapter.HTTPHandler()
+	if handler == nil {
+		httpError(w, "adapter does not support API proxy: "+platform, http.StatusNotImplemented)
+		return
+	}
+	r.URL.Path = subpath
+	handler.ServeHTTP(w, r)
 }
 
 // gatewayHealth returns live health status for a gateway adapter.
@@ -372,12 +394,20 @@ func (h *GatewayHandler) list(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Enrich with bot name from adapter status (channels come from notify sources, not discovery)
+	// Enrich with bot name and discovered channels from adapter status
 	if h.gw != nil {
+		discovered := h.gw.DiscoveredSources()
 		for i := range platforms {
 			status := h.gw.AdapterStatus(platforms[i].Platform)
 			if status.BotName != "" {
 				platforms[i].BotName = status.BotName
+			}
+			// Populate channels from adapter discovery
+			prefix := platforms[i].Platform + ":"
+			for _, ch := range discovered {
+				if strings.HasPrefix(ch, prefix) {
+					platforms[i].Channels = append(platforms[i].Channels, ch)
+				}
 			}
 		}
 	}

--- a/web/src/components/notifications/GatewayFeed.tsx
+++ b/web/src/components/notifications/GatewayFeed.tsx
@@ -20,8 +20,10 @@ import {
   dateKey,
   formatDayLabel,
   parseGitHubCard,
+  parseRSSCard,
+  parseWebhookCard,
 } from "./messageUtils";
-import type { GitHubCard } from "./messageUtils";
+import type { GitHubCard, RSSCard, WebhookCard } from "./messageUtils";
 
 /* ── Helpers ──────────────────────────────────────────────────── */
 
@@ -169,10 +171,33 @@ function DiscordGlyph({ size = 11 }: { size?: number }) {
   );
 }
 
+function WhatsAppGlyph({ size = 11 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={{ flexShrink: 0 }}>
+      <circle cx="12" cy="12" r="11" fill="#25D366" />
+      <text x="12" y="16" textAnchor="middle" fill="#fff" fontSize="10" fontWeight="bold">W</text>
+    </svg>
+  );
+}
+
+function RSSGlyph({ size = 11 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" style={{ flexShrink: 0 }}>
+      <circle cx="12" cy="12" r="11" fill="#F78422" />
+      <circle cx="8" cy="16" r="2" fill="#fff" />
+      <path d="M6 12a8 8 0 0 1 8 8" stroke="#fff" strokeWidth="2" fill="none" strokeLinecap="round" />
+      <path d="M6 8a12 12 0 0 1 12 12" stroke="#fff" strokeWidth="2" fill="none" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 const PLATFORM_GLYPHS: Record<string, React.FC<{ size?: number }>> = {
   slack: SlackGlyph,
   telegram: TelegramGlyph,
   discord: DiscordGlyph,
+  whatsapp: WhatsAppGlyph,
+  github: ({ size = 11 }) => <GitHubGlyph size={size} />,
+  rss: RSSGlyph,
 };
 
 /* ── GitHub card renderer ────────────────────────────────────── */
@@ -353,6 +378,55 @@ function GitHubCardView({ card }: { card: GitHubCard }) {
               <span style={{ color: "#ef4444" }}>-{card.deletions}</span>
             )}
           </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ── RSS card renderer ──────────────────────────────────────── */
+
+function RSSCardView({ card }: { card: RSSCard }) {
+  const pubDateLabel = card.pubDate && !isNaN(new Date(card.pubDate).getTime())
+    ? formatRelativeTime(card.pubDate) : null;
+  return (
+    <div className="mt-1.5 max-w-lg overflow-hidden" style={{ background: "var(--bc-surface, #151515)", borderRadius: 6, borderLeft: "2px solid #F78422" }}>
+      <div className="flex items-center" style={{ padding: "8px 12px 4px", gap: 7, fontSize: 10.5, color: "var(--bc-muted, #6b6b6b)", fontFamily: "'JetBrains Mono', monospace" }}>
+        <RSSGlyph size={11} />
+        <span style={{ fontSize: 9.5, padding: "1px 5px", borderRadius: 3, background: "var(--bc-surface-hover, #1a1a1a)", color: "var(--bc-muted, #a0a0a0)", textTransform: "uppercase", letterSpacing: 0.5, fontWeight: 600 }}>feed</span>
+        {card.source && <span>{card.source}</span>}
+        {pubDateLabel && <span style={{ marginLeft: "auto" }}>{pubDateLabel}</span>}
+      </div>
+      <div style={{ padding: "4px 12px 10px" }}>
+        <div style={{ fontSize: 13, fontWeight: 500, color: "var(--bc-text, #e5e5e5)", lineHeight: 1.4 }}>
+          {card.link ? (<a href={card.link} target="_blank" rel="noopener noreferrer" className="hover:underline" style={{ color: "var(--bc-text, #e5e5e5)", textDecoration: "none" }}>{card.title}</a>) : card.title}
+        </div>
+        {card.description && <div style={{ fontSize: 12, color: "var(--bc-muted, #a0a0a0)", marginTop: 4, lineHeight: 1.4, maxHeight: 60, overflow: "hidden" }}>{card.description.slice(0, 200)}</div>}
+      </div>
+    </div>
+  );
+}
+
+/* ── Webhook JSON card renderer ────────────────────────────── */
+
+function WebhookCardView({ card }: { card: WebhookCard }) {
+  const [expanded, setExpanded] = useState(false);
+  const preview = useMemo(() => JSON.stringify(card.payload, null, 2), [card.payload]);
+  const short = preview.slice(0, 200);
+  return (
+    <div className="mt-1.5 max-w-lg overflow-hidden" style={{ background: "var(--bc-surface, #151515)", borderRadius: 6, borderLeft: "2px solid #6B7280" }}>
+      <div className="flex items-center" style={{ padding: "8px 12px 4px", gap: 7, fontSize: 10.5, color: "var(--bc-muted, #6b6b6b)", fontFamily: "'JetBrains Mono', monospace" }}>
+        {card.event && <span style={{ fontSize: 9.5, padding: "1px 5px", borderRadius: 3, background: "var(--bc-surface-hover, #1a1a1a)", color: "var(--bc-muted, #a0a0a0)", textTransform: "uppercase", letterSpacing: 0.5, fontWeight: 600 }}>{card.event}</span>}
+        {card.action && <span style={{ color: "var(--bc-muted, #a0a0a0)", fontWeight: 500 }}>{card.action}</span>}
+      </div>
+      <div style={{ padding: "4px 12px 10px" }}>
+        <pre style={{ fontSize: 11, color: "var(--bc-muted, #a0a0a0)", fontFamily: "'JetBrains Mono', monospace", lineHeight: 1.4, whiteSpace: "pre-wrap", wordBreak: "break-all", maxHeight: expanded ? "none" : 80, overflow: "hidden", margin: 0 }}>
+          {expanded ? preview : short}
+        </pre>
+        {preview.length > 200 && (
+          <button type="button" onClick={() => setExpanded((v) => !v)} style={{ fontSize: 10, color: "var(--bc-accent, #f97316)", background: "none", border: "none", cursor: "pointer", padding: "4px 0 0", fontFamily: "'JetBrains Mono', monospace" }}>
+            {expanded ? "collapse" : "expand JSON..."}
+          </button>
         )}
       </div>
     </div>
@@ -1700,6 +1774,8 @@ export function GatewayFeed({
                           const looksLikeWebhook = msg.content.trimStart().startsWith("{") &&
                             /pull_request|"issue"|"ref".*"commits"|"action"/i.test(msg.content);
                           const ghCard = (platform === "github" || looksLikeWebhook) ? parseGitHubCard(msg.content) : null;
+                          const rssCard = platform === "rss" ? parseRSSCard(msg.content) : null;
+                          const webhookCard = !ghCard && !rssCard && platform === "webhook" ? parseWebhookCard(msg.content) : null;
                           const fileAttachments = parseFileAttachments(msg.content);
 
                           return (
@@ -1715,6 +1791,10 @@ export function GatewayFeed({
                               >
                                 {ghCard ? (
                                   <GitHubCardView card={ghCard} />
+                                ) : rssCard ? (
+                                  <RSSCardView card={rssCard} />
+                                ) : webhookCard ? (
+                                  <WebhookCardView card={webhookCard} />
                                 ) : (
                                   <div
                                     className="whitespace-pre-wrap break-words"

--- a/web/src/components/notifications/messageUtils.ts
+++ b/web/src/components/notifications/messageUtils.ts
@@ -1,7 +1,11 @@
 import type { ChannelMessage } from "../../api/client";
 
 /** Gateway notification sources are bridges to external platforms — read-only activity feeds. */
-export const GATEWAY_PREFIXES = ["slack:", "telegram:", "discord:"];
+export const GATEWAY_PREFIXES = [
+  "slack:", "telegram:", "discord:", "whatsapp:", "github:", "webhook:",
+  "rss:", "mqtt:", "irc:", "matrix:", "mattermost:", "reddit:", "twitter:",
+  "notion:", "signal:", "nostr:", "homeassistant:", "imessage:",
+];
 
 export function isGatewaySource(name: string): boolean {
   return GATEWAY_PREFIXES.some((p) => name.startsWith(p));
@@ -278,5 +282,55 @@ export function parseGitHubCard(content: string): GitHubCard | null {
     };
   }
 
+  return null;
+}
+
+/* ── RSS / webhook card parsing ───────────────────────────────── */
+
+export interface RSSCard {
+  title: string;
+  link?: string;
+  description?: string;
+  pubDate?: string;
+  source?: string;
+}
+
+export function parseRSSCard(content: string): RSSCard | null {
+  try {
+    const obj = JSON.parse(content);
+    if (obj && typeof obj === "object" && !Array.isArray(obj) && obj.title && (obj.link || obj.url)) {
+      return {
+        title: obj.title,
+        link: obj.link ?? obj.url,
+        description: obj.description ?? obj.summary,
+        pubDate: obj.pubDate ?? obj.published ?? obj.date,
+        source: obj.feed ?? obj.source,
+      };
+    }
+  } catch {
+    // not JSON
+  }
+  return null;
+}
+
+export interface WebhookCard {
+  event?: string;
+  action?: string;
+  payload: Record<string, unknown>;
+}
+
+export function parseWebhookCard(content: string): WebhookCard | null {
+  try {
+    const obj = JSON.parse(content);
+    if (obj && typeof obj === "object" && !Array.isArray(obj)) {
+      return {
+        event: obj.event_type ?? obj.event ?? obj.type,
+        action: obj.action,
+        payload: obj,
+      };
+    }
+  } catch {
+    // not JSON
+  }
   return null;
 }


### PR DESCRIPTION
## Summary
- **#87**: Sidebar channels populated from adapter discovery API
- **#90**: API proxy endpoint at `/api/gateways/{platform}/api/*`
- **#89**: Per-platform UI renderers (RSS cards, webhook JSON, extended platform glyphs)
- 4 new adapters (no public URL needed): Signal, Nostr, iMessage, Home Assistant
- Webhook adapters (GitLab, Jira, etc.) excluded — require `bc tunnel` (#3000)

Closes #3031

## Test plan
- [ ] `go build ./...` and `npx tsc --noEmit` pass
- [ ] Sidebar shows discovered channels for connected gateways
- [ ] RSS/webhook messages render with card UI
- [ ] New adapters register when configured in settings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Home Assistant, iMessage, Nostr, and Signal as notification sources.
  * Added RSS and Webhook message card rendering in the notifications interface.
  * Extended gateway platform detection for improved message categorization.

* **Documentation**
  * Updated architecture documentation to reflect simplified notification routing.
  * Updated platform integration guides and API reference.

* **Chores**
  * Optimized build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->