### PR TITLE
fix(gateway): persist Telegram channel mapping correctly + extract numeric chat ID

### DIFF
--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -365,9 +365,10 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 		}
 	}
 
-	// Ensure channel is in the map
+	// Ensure channel is in the map — only persist when first created
 	m.mu.Lock()
-	if _, exists := m.channelMap[bcChannel]; !exists {
+	_, exists := m.channelMap[bcChannel]
+	if !exists {
 		adapter := m.adapters[platform]
 		m.channelMap[bcChannel] = channelRoute{
 			Platform:  platform,
@@ -377,7 +378,9 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 		log.Info("gateway: dynamically mapped notification channel", "bc_channel", bcChannel, "platform", platform, "channel_id", channelID)
 	}
 	m.mu.Unlock()
-	m.persistChannel(bcChannel, platform, channelID)
+	if !exists {
+		m.persistChannel(bcChannel, platform, channelID)
+	}
 
 	sender := fmt.Sprintf("[%s] %s", platform, n.Sender)
 

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -347,19 +348,36 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 	}
 	bcChannel := platform + ":" + sanitizeChannelName(channelName)
 
+	// Determine the channel ID for routing. For platforms that need a
+	// numeric ID (e.g., Telegram chat_id), extract it from the raw payload.
+	// Fall back to the channel name if extraction fails.
+	channelID := channelName
+	if len(n.Raw) > 0 {
+		var rawMsg struct {
+			Message struct {
+				Chat struct {
+					ID int64 `json:"id"`
+				} `json:"chat"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(n.Raw, &rawMsg); err == nil && rawMsg.Message.Chat.ID != 0 {
+			channelID = strconv.FormatInt(rawMsg.Message.Chat.ID, 10)
+		}
+	}
+
 	// Ensure channel is in the map
 	m.mu.Lock()
 	if _, exists := m.channelMap[bcChannel]; !exists {
 		adapter := m.adapters[platform]
 		m.channelMap[bcChannel] = channelRoute{
 			Platform:  platform,
-			ChannelID: channelName,
+			ChannelID: channelID,
 			Adapter:   adapter,
 		}
-		log.Info("gateway: dynamically mapped notification channel", "bc_channel", bcChannel, "platform", platform)
+		log.Info("gateway: dynamically mapped notification channel", "bc_channel", bcChannel, "platform", platform, "channel_id", channelID)
 	}
 	m.mu.Unlock()
-	m.persistChannel(bcChannel, platform, channelName)
+	m.persistChannel(bcChannel, platform, channelID)
 
 	sender := fmt.Sprintf("[%s] %s", platform, n.Sender)
 


### PR DESCRIPTION
## Summary

Two small standalone fixes for the Telegram outbound channel-ID flow, split out from the larger refactor PR #3038 so they can land independently.

- **fix(gateway): extract numeric chat ID from notification raw payload** — outbound Telegram messages now extract the numeric `chat_id` from the inbound notification's raw payload instead of using a stringified channel name, so the bot replies to the correct chat.
- **fix(gateway): persist channel mapping only on first discovery** — channel-ID mapping is now persisted only when first discovered, avoiding redundant writes and stale overwrites on every inbound message.

Part of #2977 (multi-gateway / per-platform channel routing).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/gateway/... ./pkg/notify/...`
- [x] `go test -race ./pkg/gateway/... ./pkg/notify/...`
- [ ] Manual repro: send a Telegram message to the bot, verify the outbound reply uses the correct numeric `chat_id` from the original chat (not the channel name) and that the mapping row is written exactly once on first discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved dynamic channel routing with enhanced channel identification logic and fallback mechanisms
  * Optimized channel persistence to reduce unnecessary write operations
  * Enhanced diagnostic logging for better channel routing visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->