### PR TITLE
fix(test): git init test workspaces (fixes #3040, unblocks main CI)

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -50,6 +50,7 @@ func setupIntegrationWorkspace(t *testing.T) (string, func()) {
 	}
 
 	tmpDir := t.TempDir()
+	gitInitDir(t, tmpDir)
 
 	// Initialize a workspace using the workspace package
 	ws, err := workspace.Init(tmpDir)

--- a/internal/cmd/init_test.go
+++ b/internal/cmd/init_test.go
@@ -62,6 +62,7 @@ func TestInitV2Workspace(t *testing.T) {
 	if err := os.MkdirAll(projectDir, 0750); err != nil {
 		t.Fatal(err)
 	}
+	gitInitDir(t, projectDir)
 
 	// Initialize v2 workspace. M11: state lives under ~/.bc/workspaces/<id>/.
 	if err := initV2Workspace(projectDir); err != nil {
@@ -114,6 +115,7 @@ func TestInitV2WorkspaceIdempotent(t *testing.T) {
 	if err := os.MkdirAll(projectDir, 0750); err != nil {
 		t.Fatal(err)
 	}
+	gitInitDir(t, projectDir)
 
 	// First init
 	if err := initV2Workspace(projectDir); err != nil {
@@ -157,6 +159,7 @@ func TestRunInitV2AlreadyInitialized(t *testing.T) {
 	if err := os.MkdirAll(projectDir, 0750); err != nil {
 		t.Fatal(err)
 	}
+	gitInitDir(t, projectDir)
 
 	// First init should succeed
 	if err := initV2Workspace(projectDir); err != nil {
@@ -182,6 +185,7 @@ func TestRunInitFreshDirectory(t *testing.T) {
 	if err := os.MkdirAll(projectDir, 0750); err != nil {
 		t.Fatal(err)
 	}
+	gitInitDir(t, projectDir)
 
 	// Use quick mode to skip interactive wizard (no stdin in tests)
 	initQuick = true

--- a/internal/cmd/logs_test.go
+++ b/internal/cmd/logs_test.go
@@ -30,6 +30,7 @@ func setupLogsWorkspace(t *testing.T) (string, func()) {
 	}
 
 	tmpDir := t.TempDir()
+	gitInitDir(t, tmpDir)
 	ws, err := workspace.Init(tmpDir)
 	if err != nil {
 		t.Fatalf("failed to init workspace: %v", err)

--- a/internal/cmd/testhelpers_test.go
+++ b/internal/cmd/testhelpers_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// gitInitDir runs `git init -q` inside dir. workspace.Init / workspace.Load
+// require the rootDir to be a git checkout (validated via the .git directory).
+func gitInitDir(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "init", "-q")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s failed: %v\n%s", dir, err, out)
+	}
+}

--- a/pkg/workspace/testhelpers_test.go
+++ b/pkg/workspace/testhelpers_test.go
@@ -1,0 +1,30 @@
+package workspace
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// gitInitTempDir returns a temporary directory that has been initialized
+// as a git repository. workspace.Init and workspace.Load require their
+// rootDir to be a git checkout (validated via the .git directory), so
+// tests that exercise those code paths must run git init first.
+//
+// The temp dir is cleaned up automatically by t.TempDir().
+func gitInitTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitInit(t, dir)
+	return dir
+}
+
+// gitInit runs `git init -q` inside dir. It uses t.Context() so the
+// command is canceled if the test is interrupted.
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "init", "-q")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s failed: %v\n%s", dir, err, out)
+	}
+}

--- a/pkg/workspace/workspace_test.go
+++ b/pkg/workspace/workspace_test.go
@@ -13,7 +13,7 @@ import (
 // --- Init ---
 
 func TestInit(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	ws, err := Init(dir)
 	if err != nil {
@@ -44,7 +44,7 @@ func TestInit(t *testing.T) {
 }
 
 func TestInitIdempotent(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	ws1, err := Init(dir)
 	if err != nil {
@@ -63,7 +63,7 @@ func TestInitIdempotent(t *testing.T) {
 // --- Load ---
 
 func TestLoad(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	if _, err := Init(dir); err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestLoad(t *testing.T) {
 }
 
 func TestLoadNotAWorkspace(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	_, err := Load(dir)
 	if err == nil {
@@ -87,7 +87,7 @@ func TestLoadNotAWorkspace(t *testing.T) {
 }
 
 func TestLoadInvalidTOML(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	bcDir := filepath.Join(dir, ".bc")
 	if err := os.MkdirAll(bcDir, 0750); err != nil {
 		t.Fatal(err)
@@ -104,13 +104,13 @@ func TestLoadInvalidTOML(t *testing.T) {
 
 func TestLoadUpdatesPathsIfMoved(t *testing.T) {
 	// Init in one location, then copy state to a new location with .bc/ and Load
-	orig := t.TempDir()
+	orig := gitInitTempDir(t)
 	origWS, err := Init(orig)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	moved := t.TempDir()
+	moved := gitInitTempDir(t)
 	// Copy settings from the global state dir to a legacy .bc/ in the moved location
 	srcCfg := filepath.Join(origWS.StateDir(), PreferencesFileName)
 	dstDir := filepath.Join(moved, ".bc")
@@ -152,7 +152,7 @@ func TestLoadUpdatesPathsIfMoved(t *testing.T) {
 // --- Find (upward search) ---
 
 func TestFindInCurrentDir(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	if _, err := Init(dir); err != nil {
 		t.Fatal(err)
 	}
@@ -172,7 +172,7 @@ func TestFindInCurrentDir(t *testing.T) {
 }
 
 func TestFindInParentDir(t *testing.T) {
-	parent := t.TempDir()
+	parent := gitInitTempDir(t)
 	if _, err := Init(parent); err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestFindInParentDir(t *testing.T) {
 
 func TestFindNestedWorkspaces(t *testing.T) {
 	// Outer workspace
-	outer := t.TempDir()
+	outer := gitInitTempDir(t)
 	if _, err := Init(outer); err != nil {
 		t.Fatal(err)
 	}
@@ -209,6 +209,7 @@ func TestFindNestedWorkspaces(t *testing.T) {
 	if err := os.MkdirAll(inner, 0750); err != nil {
 		t.Fatal(err)
 	}
+	gitInit(t, inner)
 	if _, err := Init(inner); err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +253,7 @@ func TestFindNoWorkspace(t *testing.T) {
 // --- Save ---
 
 func TestSave(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	ws, err := Init(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -279,7 +280,7 @@ func TestSave(t *testing.T) {
 // --- Path helpers ---
 
 func TestPathHelpers(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	ws, err := Init(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -309,7 +310,7 @@ func TestPathHelpers(t *testing.T) {
 // --- LogsDir ---
 
 func TestLogsDirV2CustomPath(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	ws, err := Init(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -333,7 +334,7 @@ func TestLogsDirV2CustomPath(t *testing.T) {
 }
 
 func TestLogsDirV2EmptyPath(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	ws, err := Init(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -358,7 +359,7 @@ func TestLogsDirV2EmptyPath(t *testing.T) {
 }
 
 func TestLogsDirNilConfig(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	ws, err := Init(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -377,7 +378,7 @@ func TestLogsDirNilConfig(t *testing.T) {
 // --- EnsureDirs ---
 
 func TestEnsureDirs(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	ws, err := Init(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -400,7 +401,7 @@ func TestEnsureDirs(t *testing.T) {
 }
 
 func TestEnsureDirsV2(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	// Init creates a v2 workspace
 	ws, err := Init(dir)
@@ -430,7 +431,7 @@ func TestEnsureDirsV2(t *testing.T) {
 }
 
 func TestEnsureDirsIdempotent(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 	ws, err := Init(dir)
 	if err != nil {
 		t.Fatal(err)
@@ -455,7 +456,7 @@ func TestIsWorkspace(t *testing.T) {
 	}{
 		{
 			func(t *testing.T) string {
-				dir := t.TempDir()
+				dir := gitInitTempDir(t)
 				if _, err := Init(dir); err != nil {
 					t.Fatal(err)
 				}
@@ -653,7 +654,7 @@ func TestRegistryPrune(t *testing.T) {
 	r := newTestRegistry(t)
 
 	// Create a real workspace
-	realDir := t.TempDir()
+	realDir := gitInitTempDir(t)
 	if _, err := Init(realDir); err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +697,7 @@ func TestRegistryPruneAllGone(t *testing.T) {
 func TestRegistryPruneNothingToPrune(t *testing.T) {
 	r := newTestRegistry(t)
 
-	realDir := t.TempDir()
+	realDir := gitInitTempDir(t)
 	if _, err := Init(realDir); err != nil {
 		t.Fatal(err)
 	}
@@ -771,7 +772,7 @@ func TestRegistrySaveCreatesDirectory(t *testing.T) {
 // =====================
 
 func TestInitV2Format(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	ws, err := Init(dir)
 	if err != nil {
@@ -810,7 +811,7 @@ func TestInitV2Format(t *testing.T) {
 }
 
 func TestLoadV2Workspace(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	// Initialize v2 workspace
 	_, err := Init(dir)
@@ -845,7 +846,7 @@ func TestLoadV2Workspace(t *testing.T) {
 }
 
 func TestWorkspaceV2Directories(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	ws, err := Init(dir)
 	if err != nil {
@@ -866,7 +867,7 @@ func TestWorkspaceV2Directories(t *testing.T) {
 }
 
 func TestWorkspaceGetRole(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	ws, err := Init(dir)
 	if err != nil {
@@ -890,7 +891,7 @@ func TestWorkspaceGetRole(t *testing.T) {
 }
 
 func TestWorkspaceGetRolePrompt(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	ws, err := Init(dir)
 	if err != nil {
@@ -910,7 +911,7 @@ func TestWorkspaceGetRolePrompt(t *testing.T) {
 }
 
 func TestWorkspaceDefaultProvider(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	// v2 workspace - default provider is gemini (minimal root-only startup)
 	ws, err := Init(dir)
@@ -929,7 +930,7 @@ func TestWorkspaceDefaultProvider(t *testing.T) {
 }
 
 func TestWorkspaceSaveV2(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	ws, err := Init(dir)
 	if err != nil {
@@ -956,7 +957,7 @@ func TestWorkspaceSaveV2(t *testing.T) {
 }
 
 func TestWorkspaceDefaultProviderCustom(t *testing.T) {
-	dir := t.TempDir()
+	dir := gitInitTempDir(t)
 
 	ws, err := Init(dir)
 	if err != nil {

--- a/server/concurrent_workspace_test.go
+++ b/server/concurrent_workspace_test.go
@@ -67,6 +67,7 @@ func newConcurrentHarness(t *testing.T, n int) *concurrentHarness {
 		if err := os.MkdirAll(p, 0o750); err != nil {
 			t.Fatalf("mkdir: %v", err)
 		}
+		gitInitDir(t, p)
 		if _, err := workspace.Init(p); err != nil {
 			t.Fatalf("init: %v", err)
 		}

--- a/server/cors_scope_test.go
+++ b/server/cors_scope_test.go
@@ -52,6 +52,7 @@ func TestCORS_WorkspaceScope_Coexist(t *testing.T) {
 	if err := os.MkdirAll(wsDir, 0o750); err != nil {
 		t.Fatalf("mkdir ws: %v", err)
 	}
+	gitInitDir(t, wsDir)
 	if _, err := workspace.Init(wsDir); err != nil {
 		t.Fatalf("workspace.Init: %v", err)
 	}
@@ -161,6 +162,7 @@ func TestCORS_Preflight_Scoped(t *testing.T) {
 	if err := os.MkdirAll(wsDir, 0o750); err != nil {
 		t.Fatalf("mkdir ws: %v", err)
 	}
+	gitInitDir(t, wsDir)
 	if _, err := workspace.Init(wsDir); err != nil {
 		t.Fatalf("Init: %v", err)
 	}

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -43,6 +44,12 @@ func newE2EServer(t *testing.T) *e2eServer {
 	t.Helper()
 
 	dir := t.TempDir()
+	// workspace.Load requires the dir to be a git checkout.
+	gitCmd := exec.CommandContext(t.Context(), "git", "init", "-q")
+	gitCmd.Dir = dir
+	if out, err := gitCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s failed: %v\n%s", dir, err, out)
+	}
 	bcDir := filepath.Join(dir, ".bc")
 	if err := os.MkdirAll(filepath.Join(bcDir, "roles"), 0750); err != nil {
 		t.Fatal(err)

--- a/server/e2e_web_test.go
+++ b/server/e2e_web_test.go
@@ -34,7 +34,7 @@ import (
 func newE2EServerWithWebUI(t *testing.T) *e2eServer {
 	t.Helper()
 
-	dir := t.TempDir()
+	dir := gitInitWorkspaceDir(t)
 	bcDir := filepath.Join(dir, ".bc")
 	if err := os.MkdirAll(filepath.Join(bcDir, "roles"), 0750); err != nil {
 		t.Fatal(err)

--- a/server/handlers/resource_handlers_test.go
+++ b/server/handlers/resource_handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -40,6 +41,12 @@ func setupWorkspace(t *testing.T) string {
 	t.Helper()
 	sandboxBCHome(t)
 	dir := t.TempDir()
+	// workspace.Init requires the dir to be a git checkout.
+	gitCmd := exec.CommandContext(t.Context(), "git", "init", "-q")
+	gitCmd.Dir = dir
+	if out, err := gitCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s failed: %v\n%s", dir, err, out)
+	}
 	wks, err := workspace.Init(dir)
 	if err != nil {
 		t.Fatalf("init workspace: %v", err)

--- a/server/idle_eviction_test.go
+++ b/server/idle_eviction_test.go
@@ -40,6 +40,7 @@ func TestWorkspaceManager_IdleEviction(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o750); err != nil {
 			t.Fatalf("mkdir %s: %v", name, err)
 		}
+		gitInitDir(t, dir)
 		if _, err := workspace.Init(dir); err != nil {
 			t.Fatalf("Init %s: %v", name, err)
 		}
@@ -138,6 +139,7 @@ func TestWorkspaceManager_SweepIdempotent(t *testing.T) {
 	if err := os.MkdirAll(wsDir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	gitInitDir(t, wsDir)
 	if _, err := workspace.Init(wsDir); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -197,6 +199,7 @@ func TestWorkspaceManager_NotIdleYet(t *testing.T) {
 	if err := os.MkdirAll(wsDir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	gitInitDir(t, wsDir)
 	if _, err := workspace.Init(wsDir); err != nil {
 		t.Fatalf("Init: %v", err)
 	}

--- a/server/legacy_scope_test.go
+++ b/server/legacy_scope_test.go
@@ -28,6 +28,7 @@ func bootLegacyScope(t *testing.T, withActive bool) (http.Handler, http.Handler)
 	}
 	if withActive {
 		wsDir := t.TempDir()
+		gitInitDir(t, wsDir)
 		if _, initErr := workspace.Init(wsDir); initErr != nil {
 			t.Fatalf("workspace.Init: %v", initErr)
 		}

--- a/server/m8_wiring_test.go
+++ b/server/m8_wiring_test.go
@@ -37,6 +37,7 @@ func TestM8WiringTemplatesGlobalOverride(t *testing.T) {
 	}
 
 	wsDir := t.TempDir()
+	gitInitDir(t, wsDir)
 	svc, err := BuildWorkspaceServices(context.Background(), globals, wsDir)
 	if err != nil {
 		t.Fatalf("build: %v", err)
@@ -99,7 +100,9 @@ func TestM8WiringSecretsPreferGlobalVault(t *testing.T) {
 	}
 
 	globals := &Globals{SecretsVault: vault}
-	svc, err := BuildWorkspaceServices(context.Background(), globals, t.TempDir())
+	wsDir := t.TempDir()
+	gitInitDir(t, wsDir)
+	svc, err := BuildWorkspaceServices(context.Background(), globals, wsDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +134,9 @@ func TestM8WiringMCPGlobalView(t *testing.T) {
 	}
 
 	globals := &Globals{MCPGlobal: gs}
-	svc, err := BuildWorkspaceServices(context.Background(), globals, t.TempDir())
+	wsDir := t.TempDir()
+	gitInitDir(t, wsDir)
+	svc, err := BuildWorkspaceServices(context.Background(), globals, wsDir)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -171,6 +176,7 @@ func TestM8WiringCostsGlobalLedger(t *testing.T) {
 
 	globals := &Globals{CostsGlobal: costs}
 	wsDir := t.TempDir()
+	gitInitDir(t, wsDir)
 	svc, err := BuildWorkspaceServices(context.Background(), globals, wsDir)
 	if err != nil {
 		t.Fatal(err)

--- a/server/mcp/server_test.go
+++ b/server/mcp/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -23,6 +24,12 @@ import (
 func makeWorkspace(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	// workspace.Load requires the dir to be a git checkout.
+	gitCmd := exec.CommandContext(t.Context(), "git", "init", "-q")
+	gitCmd.Dir = dir
+	if out, err := gitCmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s failed: %v\n%s", dir, err, out)
+	}
 	bcDir := filepath.Join(dir, ".bc")
 	if err := os.MkdirAll(filepath.Join(bcDir, "roles"), 0750); err != nil {
 		t.Fatal(err)

--- a/server/mcp_compat_test.go
+++ b/server/mcp_compat_test.go
@@ -40,6 +40,7 @@ func bootMCPCompat(t *testing.T, withActive bool) (http.Handler, *captureHandler
 	var activeID string
 	if withActive {
 		wsDir := t.TempDir()
+		gitInitDir(t, wsDir)
 		if _, initErr := workspace.Init(wsDir); initErr != nil {
 			t.Fatalf("workspace.Init: %v", initErr)
 		}

--- a/server/multi_tenant_dispatch_test.go
+++ b/server/multi_tenant_dispatch_test.go
@@ -96,6 +96,7 @@ func newDispatchHarness(t *testing.T) *dispatchHarness {
 		if err := os.MkdirAll(dir, 0o750); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
+		gitInitDir(t, dir)
 		if _, err := workspace.Init(dir); err != nil {
 			t.Fatalf("workspace.Init %s: %v", dir, err)
 		}

--- a/server/multi_tenant_test.go
+++ b/server/multi_tenant_test.go
@@ -63,6 +63,7 @@ func newMultiTenantHarness(t *testing.T) *multiTenantHarness {
 		if err := os.MkdirAll(dir, 0o750); err != nil {
 			t.Fatalf("mkdir %s: %v", dir, err)
 		}
+		gitInitDir(t, dir)
 		if _, err := workspace.Init(dir); err != nil {
 			t.Fatalf("workspace.Init %s: %v", dir, err)
 		}

--- a/server/testhelpers_internal_test.go
+++ b/server/testhelpers_internal_test.go
@@ -1,0 +1,17 @@
+package server
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// gitInitDir runs `git init -q` inside dir. workspace.Init / workspace.Load
+// require the rootDir to be a git checkout (validated via the .git directory).
+func gitInitDir(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "init", "-q")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s failed: %v\n%s", dir, err, out)
+	}
+}

--- a/server/testhelpers_test.go
+++ b/server/testhelpers_test.go
@@ -1,0 +1,26 @@
+package server_test
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// gitInitWorkspaceDir returns a t.TempDir() that has been initialized as
+// a git repository. workspace.Init / workspace.Load require the rootDir
+// to be a git checkout (validated via the .git directory).
+func gitInitWorkspaceDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	gitInitDir(t, dir)
+	return dir
+}
+
+// gitInitDir runs `git init -q` inside dir.
+func gitInitDir(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.CommandContext(t.Context(), "git", "init", "-q")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s failed: %v\n%s", dir, err, out)
+	}
+}

--- a/server/workspace_scope_test.go
+++ b/server/workspace_scope_test.go
@@ -28,6 +28,7 @@ func newScopeTestManager(t *testing.T) (*WorkspaceManager, string, string) {
 	if err := os.MkdirAll(wsDir, 0750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	gitInitDir(t, wsDir)
 	if _, err := workspace.Init(wsDir); err != nil {
 		t.Fatalf("Init: %v", err)
 	}
@@ -79,6 +80,7 @@ func TestWorkspaceScopeNonActiveDispatches(t *testing.T) {
 	if err := os.MkdirAll(wsDir2, 0750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
+	gitInitDir(t, wsDir2)
 	if _, err := workspace.Init(wsDir2); err != nil {
 		t.Fatalf("Init: %v", err)
 	}

--- a/server/workspace_services_test.go
+++ b/server/workspace_services_test.go
@@ -20,6 +20,7 @@ func initTestWorkspace(t *testing.T, tmpDir, name string) (string, string) {
 	if err := os.MkdirAll(wsDir, 0750); err != nil {
 		t.Fatalf("mkdir ws: %v", err)
 	}
+	gitInitDir(t, wsDir)
 	if _, err := workspace.Init(wsDir); err != nil {
 		t.Fatalf("workspace.Init: %v", err)
 	}


### PR DESCRIPTION
## Summary

Main CI has been red since Apr 24 because commit 8e97a48a (`fix: validate git repository in workspace Init and Load`) added a runtime check that rejects any `rootDir` without a `.git` directory. Many tests across `pkg/workspace`, `server`, `server/mcp`, `server/handlers`, and `internal/cmd` create their workspace via `t.TempDir()`, which is a plain temp dir — not a git checkout — so `workspace.Init` / `workspace.Load` now return `not a git repository` and the entire suite fails.

This PR runs `git init -q` on the temp dir before invoking the workspace functions, honoring the production validation rather than bypassing it. No production code changes.

- Adds small per-package test helpers (`gitInitDir` / `gitInitTempDir`) that wrap `exec.CommandContext(t.Context(), "git", "init", "-q")` so the spawned process is canceled if the test is interrupted.
- Updates every test that was failing with `not a git repository` to call the helper.
- Tests still hit the real `workspace.Init` / `workspace.Load` code path — no `t.Skip`, no build tags, no test-only constructors.

## Test plan
- [x] `go test ./pkg/workspace/...` — passes
- [x] `go test ./server/... ./server/mcp/... ./server/handlers/...` — passes (race detector too)
- [x] `go test ./internal/cmd/...` for the previously-failing init/logs/integration tests — passes
- [x] `make fmt-go vet-go lint-go` — clean (0 issues)
- [ ] CI green on this PR — unblocks main

Fixes #3040