### PR TITLE
chore(landing): remove unused RevealSection import and stale vitals TODO

### DIFF
--- a/landing/src/app/method/page.tsx
+++ b/landing/src/app/method/page.tsx
@@ -6,7 +6,6 @@ import {
   StaggerChildren,
   StaggerItem,
   FadeUp,
-  RevealSection,
 } from "../_components/Motion";
 
 const PRINCIPLES = [

--- a/landing/src/lib/vitals.ts
+++ b/landing/src/lib/vitals.ts
@@ -3,9 +3,6 @@ import { onCLS, onFCP, onINP, onLCP, onTTFB } from "web-vitals";
 
 /**
  * Logs a Web Vitals metric to the console.
- *
- * TODO: Wire up an analytics endpoint here to send metrics to a backend
- * service (e.g., POST to /api/vitals) for production monitoring.
  */
 function sendMetric(metric: Metric) {
   console.log(`[Web Vitals] ${metric.name}: ${metric.value.toFixed(2)}`, {


### PR DESCRIPTION
## Summary
- Remove unused `RevealSection` import in `landing/src/app/method/page.tsx` (component is still used elsewhere, so component file kept).
- Drop stale TODO in `landing/src/lib/vitals.ts` referencing an analytics endpoint that was never wired.

Part of #154

## Test plan
- [x] `bun run lint` (landing)
- [x] `bun run build` (landing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)