### PR TITLE
fix(web): correct useEffect dep for selectTab in AgentDetail

### DIFF
--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1091,7 +1091,7 @@ export function AgentDetail() {
     return () => {
       window.removeEventListener("keydown", handler);
     };
-  }, [navigate]);
+  }, [navigate, selectTab]);
 
   /* ─── Loading / Error ─── */
 


### PR DESCRIPTION
## Summary
- The keyboard-shortcut effect in `AgentDetail.tsx` (keys 1-5 switch tabs, Esc goes back) called `selectTab` from its handler closure but did not list it as a dependency.
- `selectTab` is a `useCallback` memoized on `[name, location.pathname, navigate]`. When the user navigated and `location.pathname` changed, the effect kept the original closure, so a tab keypress would compute the destination URL from a stale pathname and could route to the wrong place.
- Fix: add `selectTab` to the dep array so the listener is rebound whenever the memoized callback updates. No `eslint-disable` suppression.

Part of #17

## Root cause
Stale closure on `selectTab` inside a `keydown` listener whose effect deps were `[navigate]` only.

## Test plan
- [x] `bun run lint` in `web/` — 0 errors, 0 warnings
- [ ] Manual: load an agent page, press 1/2/3/4/5 to flip tabs, confirm the URL segment updates correctly each time and the listener doesn't fire spuriously

🤖 Generated with [Claude Code](https://claude.com/claude-code)