### PR TITLE
fix: plumb ctx through doctor, provider, and agent role-setup chains

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1039,7 +1039,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	if err := WriteWorkspaceHookSettings(wtDir); err != nil {
 		log.Error("failed to write hook settings", "dir", wtDir, "error", err)
 	}
-	if setupErr := SetupAgentFromRoleWithRuntime(wsPath, name, string(existing.Role), wtDir, agentRuntime, existing.Tool); setupErr != nil {
+	if setupErr := SetupAgentFromRoleWithRuntime(ctx, wsPath, name, string(existing.Role), wtDir, agentRuntime, existing.Tool); setupErr != nil {
 		log.Warn("role setup failed on restart", "agent", name, "error", setupErr)
 	}
 	appendGatewayPrompt(wtDir, existing.Tool, m.gatewayConfig)
@@ -1239,7 +1239,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	}
 
 	// Write role files (prompt, MCP, rules, etc.) to the worktree using provider adapter
-	if setupErr := SetupAgentFromRoleWithRuntime(wsPath, name, string(role), wtDir, agentRuntime, effectiveTool); setupErr != nil {
+	if setupErr := SetupAgentFromRoleWithRuntime(ctx, wsPath, name, string(role), wtDir, agentRuntime, effectiveTool); setupErr != nil {
 		log.Warn("role setup failed", "agent", name, "error", setupErr)
 		agent.Task = fmt.Sprintf("role setup failed: %v", setupErr)
 	}
@@ -1805,7 +1805,7 @@ func (m *Manager) RenameAgent(ctx context.Context, oldName, newName string) erro
 		if agentRuntime == "" {
 			agentRuntime = "tmux"
 		}
-		if setupErr := SetupAgentFromRoleWithRuntime(wsPath, newName, string(agent.Role), newWorktreeDir, agentRuntime, agent.Tool); setupErr != nil {
+		if setupErr := SetupAgentFromRoleWithRuntime(ctx, wsPath, newName, string(agent.Role), newWorktreeDir, agentRuntime, agent.Tool); setupErr != nil {
 			log.Warn("rename: failed to regenerate role files", "agent", newName, "error", setupErr)
 		}
 	}

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -35,21 +35,21 @@ import (
 // SetupAgentFromRoleWithRuntime sets up agent workspace files for the given role,
 // runtime backend, and tool provider. Uses ConfigAdapter for provider-specific
 // file layout (prompt file, config dir, MCP setup, plugins).
-func SetupAgentFromRoleWithRuntime(workspacePath, agentName, roleName, targetDir, runtimeBackend string, toolName ...string) error {
+func SetupAgentFromRoleWithRuntime(ctx context.Context, workspacePath, agentName, roleName, targetDir, runtimeBackend string, toolName ...string) error {
 	tool := ""
 	if len(toolName) > 0 {
 		tool = toolName[0]
 	}
-	return setupAgentFromRole(workspacePath, agentName, roleName, targetDir, runtimeBackend, tool)
+	return setupAgentFromRole(ctx, workspacePath, agentName, roleName, targetDir, runtimeBackend, tool)
 }
 
 // SetupAgentFromRole sets up agent workspace files for the given role.
 // Defaults to tmux runtime (all MCP transports available).
-func SetupAgentFromRole(workspacePath, agentName, roleName, targetDir string) error {
-	return setupAgentFromRole(workspacePath, agentName, roleName, targetDir, "tmux", "")
+func SetupAgentFromRole(ctx context.Context, workspacePath, agentName, roleName, targetDir string) error {
+	return setupAgentFromRole(ctx, workspacePath, agentName, roleName, targetDir, "tmux", "")
 }
 
-func setupAgentFromRole(workspacePath, agentName, roleName, targetDir, runtimeBackend, toolName string) error {
+func setupAgentFromRole(ctx context.Context, workspacePath, agentName, roleName, targetDir, runtimeBackend, toolName string) error {
 	stateDir := workspaceStateDir(workspacePath)
 	rm := workspace.NewRoleManager(stateDir)
 
@@ -74,7 +74,7 @@ func setupAgentFromRole(workspacePath, agentName, roleName, targetDir, runtimeBa
 	}
 
 	// MCP config via adapter (claude mcp add, .mcp.json, .cursor/mcp.json, etc.)
-	if e := writeMCPJSON(workspacePath, agentName, resolved, secrets, targetDir, runtimeBackend); e != nil {
+	if e := writeMCPJSON(ctx, workspacePath, agentName, resolved, secrets, targetDir, runtimeBackend); e != nil {
 		errs = append(errs, e.Error())
 	}
 
@@ -153,7 +153,7 @@ type mcpServerEntry struct {
 
 var secretRefPattern = regexp.MustCompile(`\$\{secret:([^}]+)\}`)
 
-func writeMCPJSON(workspacePath, agentName string, resolved *workspace.ResolvedRole, secrets map[string]string, targetDir, runtimeBackend string) error {
+func writeMCPJSON(ctx context.Context, workspacePath, agentName string, resolved *workspace.ResolvedRole, secrets map[string]string, targetDir, runtimeBackend string) error {
 	isDocker := runtimeBackend == "docker"
 	cfg := mcpConfig{MCPServers: make(map[string]mcpServerEntry)}
 
@@ -261,7 +261,7 @@ func writeMCPJSON(workspacePath, agentName string, resolved *workspace.ResolvedR
 	}
 
 	// Prefer claude CLI for MCP setup; fall back to .mcp.json file write.
-	if len(cfg.MCPServers) > 0 && setupMCPViaCLI(targetDir, agentName, cfg.MCPServers) {
+	if len(cfg.MCPServers) > 0 && setupMCPViaCLI(ctx, targetDir, agentName, cfg.MCPServers) {
 		log.Debug("MCP servers configured via claude CLI", "agent", agentName, "count", len(cfg.MCPServers))
 		return nil
 	}
@@ -524,7 +524,7 @@ func checkSSEEndpoint(url string) error {
 //
 // Returns true if claude CLI was used successfully, false if caller should
 // fall back to file-based .mcp.json.
-func setupMCPViaCLI(targetDir, agentName string, servers map[string]mcpServerEntry) bool {
+func setupMCPViaCLI(ctx context.Context, targetDir, agentName string, servers map[string]mcpServerEntry) bool {
 	// Check if claude CLI is available
 	claudePath, err := exec.LookPath("claude")
 	if err != nil {
@@ -533,12 +533,12 @@ func setupMCPViaCLI(targetDir, agentName string, servers map[string]mcpServerEnt
 	}
 
 	// First remove any existing MCP servers to avoid duplicates
-	existingCmd := exec.CommandContext(context.TODO(), claudePath, "mcp", "list") //nolint:gosec // trusted claude CLI path
+	existingCmd := exec.CommandContext(ctx, claudePath, "mcp", "list") //nolint:gosec // trusted claude CLI path
 	existingCmd.Dir = targetDir
 	if out, err := existingCmd.Output(); err == nil && len(out) > 0 {
 		// Parse existing servers and remove them
 		for name := range servers {
-			rmCmd := exec.CommandContext(context.TODO(), claudePath, "mcp", "remove", name, "--scope", "project") //nolint:gosec // trusted claude CLI path
+			rmCmd := exec.CommandContext(ctx, claudePath, "mcp", "remove", name, "--scope", "project") //nolint:gosec // trusted claude CLI path
 			rmCmd.Dir = targetDir
 			_ = rmCmd.Run() //nolint:errcheck // ignore if not found
 		}
@@ -574,7 +574,7 @@ func setupMCPViaCLI(targetDir, agentName string, servers map[string]mcpServerEnt
 			continue
 		}
 
-		cmd := exec.CommandContext(context.TODO(), claudePath, args...) //nolint:gosec // args are from trusted config
+		cmd := exec.CommandContext(ctx, claudePath, args...) //nolint:gosec // args are from trusted config
 		cmd.Dir = targetDir
 		if out, err := cmd.CombinedOutput(); err != nil {
 			log.Warn("claude mcp add failed", "name", name, "error", err, "output", string(out))

--- a/pkg/cron/store.go
+++ b/pkg/cron/store.go
@@ -72,6 +72,10 @@ CREATE TABLE IF NOT EXISTS cron_logs (
 
 CREATE INDEX IF NOT EXISTS idx_cron_logs_job ON cron_logs(job_name, run_at DESC);
 `
+	// context.TODO() retained: initSchema runs synchronously during cron.Open at
+	// startup before any request context exists; threading ctx through would
+	// force a public API change on Open() and dozens of call sites across
+	// tests/services for no operational benefit (schema DDL is fire-and-forget).
 	_, err := s.db.ExecContext(context.TODO(), schema)
 	return err
 }

--- a/pkg/doctor/doctor.go
+++ b/pkg/doctor/doctor.go
@@ -13,7 +13,7 @@
 // Run a single category:
 //
 //	cat := doctor.CheckWorkspace(ws)
-//	cat := doctor.CheckDatabase(ws)
+//	cat := doctor.CheckDatabase(ctx, ws)
 //	cat := doctor.CheckAgents(ctx, ws)
 //	cat := doctor.CheckTools(ctx)
 //	cat := doctor.CheckGit(ctx, ws)
@@ -136,7 +136,7 @@ func (r *Report) Summary() (ok, warn, fail int) {
 func RunAll(ctx context.Context, ws *workspace.Workspace) *Report {
 	cats := []CategoryReport{
 		CheckWorkspace(ws),
-		CheckDatabase(ws),
+		CheckDatabase(ctx, ws),
 		CheckAgents(ctx, ws),
 		CheckTools(ctx),
 		CheckGit(ctx, ws),
@@ -152,7 +152,7 @@ func CategoryByName(ctx context.Context, ws *workspace.Workspace, name string) *
 		c := CheckWorkspace(ws)
 		return &c
 	case "database", "db":
-		c := CheckDatabase(ws)
+		c := CheckDatabase(ctx, ws)
 		return &c
 	case "agents", "agent":
 		c := CheckAgents(ctx, ws)
@@ -301,24 +301,24 @@ func CheckWorkspace(ws *workspace.Workspace) CategoryReport {
 // ─── Database ────────────────────────────────────────────────────────────────
 
 // CheckDatabase checks SQLite integrity and table existence.
-func CheckDatabase(ws *workspace.Workspace) CategoryReport {
+func CheckDatabase(ctx context.Context, ws *workspace.Workspace) CategoryReport {
 	cat := CategoryReport{Name: "Database"}
 
 	stateDir := ws.StateDir()
 
 	// bc.db — agents table
 	stateDB := filepath.Join(stateDir, "bc.db")
-	cat.Items = append(cat.Items, checkSQLiteFile(stateDB, "bc.db", []string{"agents"})...)
+	cat.Items = append(cat.Items, checkSQLiteFile(ctx, stateDB, "bc.db", []string{"agents"})...)
 
 	// bc.db — channels/messages tables
 	channelsDB := filepath.Join(stateDir, "bc.db")
-	cat.Items = append(cat.Items, checkSQLiteFile(channelsDB, "bc.db", []string{"channels", "messages"})...)
+	cat.Items = append(cat.Items, checkSQLiteFile(ctx, channelsDB, "bc.db", []string{"channels", "messages"})...)
 
 	return cat
 }
 
 // checkSQLiteFile checks a SQLite file: existence, integrity, and required tables.
-func checkSQLiteFile(path, label string, requiredTables []string) []Item {
+func checkSQLiteFile(ctx context.Context, path, label string, requiredTables []string) []Item {
 	// 1 for file check, 1 for integrity, len(requiredTables) for table checks
 	items := make([]Item, 0, 2+len(requiredTables))
 
@@ -345,7 +345,7 @@ func checkSQLiteFile(path, label string, requiredTables []string) []Item {
 
 	// PRAGMA integrity_check
 	var result string
-	if err := db.QueryRowContext(context.TODO(), "PRAGMA integrity_check").Scan(&result); err != nil {
+	if err := db.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&result); err != nil {
 		items = append(items, Item{
 			Name:     label + " integrity",
 			Message:  fmt.Sprintf("check failed: %v", err),
@@ -368,7 +368,7 @@ func checkSQLiteFile(path, label string, requiredTables []string) []Item {
 	// Check required tables
 	for _, table := range requiredTables {
 		var name string
-		err := db.QueryRowContext(context.TODO(),
+		err := db.QueryRowContext(ctx,
 			"SELECT name FROM sqlite_master WHERE type='table' AND name=?", table,
 		).Scan(&name)
 		if err == sql.ErrNoRows {

--- a/pkg/doctor/doctor_test.go
+++ b/pkg/doctor/doctor_test.go
@@ -311,7 +311,7 @@ func TestCheckDatabase_NoDB(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cat := CheckDatabase(ws)
+	cat := CheckDatabase(context.Background(), ws)
 
 	// With no databases, we expect warnings (not found = will be created on use)
 	_, warn, fail := cat.Counts()
@@ -336,7 +336,7 @@ func TestCheckDatabase_ValidDB(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cat := CheckDatabase(ws)
+	cat := CheckDatabase(context.Background(), ws)
 
 	for _, item := range cat.Items {
 		if item.Name == "state.db integrity" && item.Severity != SeverityOK {
@@ -361,7 +361,7 @@ func TestCheckDatabase_MissingTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cat := CheckDatabase(ws)
+	cat := CheckDatabase(context.Background(), ws)
 
 	var foundMissingTable bool
 	for _, item := range cat.Items {

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -59,6 +59,10 @@ func (s *Store) initSchema() error {
 	} else {
 		schema = schemaSQLite
 	}
+	// context.TODO() retained: initSchema runs synchronously during OpenStore at
+	// startup before any request context exists; threading ctx through would
+	// force a public API change on OpenStore and dozens of call sites across
+	// tests/services for no operational benefit (schema DDL is fire-and-forget).
 	_, err := s.db.ExecContext(context.TODO(), schema)
 	return err
 }

--- a/pkg/provider/adapter.go
+++ b/pkg/provider/adapter.go
@@ -1,6 +1,8 @@
 // Package provider — ConfigAdapter extends Provider with config file setup.
 package provider
 
+import "context"
+
 // MCPEntry represents an MCP server configuration for adapter setup.
 type MCPEntry struct { //nolint:govet // field order matches API contract
 	Env       map[string]string
@@ -23,7 +25,7 @@ type ConfigAdapter interface {
 	ConfigDir() string
 
 	// SetupMCP configures MCP servers for this provider in the target directory.
-	SetupMCP(targetDir, agentName string, servers map[string]MCPEntry) error
+	SetupMCP(ctx context.Context, targetDir, agentName string, servers map[string]MCPEntry) error
 
 	// SetupPlugins writes plugin configuration for this provider.
 	SetupPlugins(agentDir string, plugins []string) error
@@ -64,8 +66,10 @@ func (a *GenericAdapter) SupportsRules() bool    { return false }
 func (a *GenericAdapter) SupportsCommands() bool { return false }
 func (a *GenericAdapter) SupportsSkills() bool   { return false }
 
-func (a *GenericAdapter) SetupMCP(_, _ string, _ map[string]MCPEntry) error { return nil }
-func (a *GenericAdapter) SetupPlugins(_ string, _ []string) error           { return nil }
+func (a *GenericAdapter) SetupMCP(_ context.Context, _, _ string, _ map[string]MCPEntry) error {
+	return nil
+}
+func (a *GenericAdapter) SetupPlugins(_ string, _ []string) error { return nil }
 
 func toUpperFirst(s string) string {
 	if s == "" {

--- a/pkg/provider/claude_adapter.go
+++ b/pkg/provider/claude_adapter.go
@@ -23,13 +23,13 @@ func (a *ClaudeConfigAdapter) SupportsSkills() bool   { return true }
 
 // SetupMCP configures MCP servers for Claude Code.
 // Prefers `claude mcp add` CLI; falls back to .mcp.json file write.
-func (a *ClaudeConfigAdapter) SetupMCP(targetDir, agentName string, servers map[string]MCPEntry) error {
+func (a *ClaudeConfigAdapter) SetupMCP(ctx context.Context, targetDir, agentName string, servers map[string]MCPEntry) error {
 	if len(servers) == 0 {
 		return nil
 	}
 
 	// Try claude CLI first
-	if a.setupMCPViaCLI(targetDir, servers) {
+	if a.setupMCPViaCLI(ctx, targetDir, servers) {
 		return nil
 	}
 
@@ -70,7 +70,7 @@ func (a *ClaudeConfigAdapter) SetupPlugins(agentDir string, plugins []string) er
 }
 
 // setupMCPViaCLI uses `claude mcp add` commands.
-func (a *ClaudeConfigAdapter) setupMCPViaCLI(targetDir string, servers map[string]MCPEntry) bool {
+func (a *ClaudeConfigAdapter) setupMCPViaCLI(ctx context.Context, targetDir string, servers map[string]MCPEntry) bool {
 	claudePath, err := exec.LookPath("claude")
 	if err != nil {
 		return false
@@ -78,7 +78,7 @@ func (a *ClaudeConfigAdapter) setupMCPViaCLI(targetDir string, servers map[strin
 
 	for name, entry := range servers {
 		// Remove existing to avoid duplicates
-		rmCmd := exec.CommandContext(context.TODO(), claudePath, "mcp", "remove", name, "--scope", "project") //nolint:gosec
+		rmCmd := exec.CommandContext(ctx, claudePath, "mcp", "remove", name, "--scope", "project") //nolint:gosec
 		rmCmd.Dir = targetDir
 		_ = rmCmd.Run() //nolint:errcheck
 
@@ -100,7 +100,7 @@ func (a *ClaudeConfigAdapter) setupMCPViaCLI(targetDir string, servers map[strin
 			continue
 		}
 
-		cmd := exec.CommandContext(context.TODO(), claudePath, args...) //nolint:gosec
+		cmd := exec.CommandContext(ctx, claudePath, args...) //nolint:gosec
 		cmd.Dir = targetDir
 		_ = cmd.Run() //nolint:errcheck
 	}

--- a/pkg/provider/cursor_adapter.go
+++ b/pkg/provider/cursor_adapter.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -18,7 +19,7 @@ func (a *CursorConfigAdapter) SupportsCommands() bool { return false }
 func (a *CursorConfigAdapter) SupportsSkills() bool   { return false }
 
 // SetupMCP writes .cursor/mcp.json for Cursor's MCP support.
-func (a *CursorConfigAdapter) SetupMCP(targetDir, _ string, servers map[string]MCPEntry) error {
+func (a *CursorConfigAdapter) SetupMCP(_ context.Context, targetDir, _ string, servers map[string]MCPEntry) error {
 	if len(servers) == 0 {
 		return nil
 	}

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -227,6 +227,11 @@ func (s *Store) Close() error {
 }
 
 func initSchema(db *sql.DB) error {
+	// context.TODO() retained: initSchema runs synchronously during Store.Open
+	// at startup/test setup before any request context exists; threading ctx
+	// through would force a public API change on NewStore/Open and dozens of
+	// call sites across tests/services for no operational benefit (DDL completes
+	// in microseconds and cannot be canceled meaningfully).
 	_, err := db.ExecContext(context.TODO(), `
 		CREATE TABLE IF NOT EXISTS tools (
 			name          TEXT PRIMARY KEY,
@@ -264,6 +269,7 @@ func initSchema(db *sql.DB) error {
 		"ALTER TABLE tools ADD COLUMN health_status TEXT DEFAULT 'unknown'",
 		"ALTER TABLE tools ADD COLUMN last_checked TEXT",
 	} {
+		// context.TODO() retained: see initSchema header comment — startup-only DDL.
 		_, _ = db.ExecContext(context.TODO(), col) //nolint:errcheck // ignore if columns exist
 	}
 

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -275,7 +275,7 @@ func (h *ProviderHandler) addMCP(w http.ResponseWriter, r *http.Request, name st
 
 	// Use the provider's ConfigAdapter if available.
 	type mcpSetup interface {
-		SetupMCP(targetDir, agentName string, servers map[string]provider.MCPEntry) error
+		SetupMCP(ctx context.Context, targetDir, agentName string, servers map[string]provider.MCPEntry) error
 	}
 	adapter, hasAdapter := p.(mcpSetup)
 	if !hasAdapter {
@@ -296,7 +296,7 @@ func (h *ProviderHandler) addMCP(w http.ResponseWriter, r *http.Request, name st
 		URL:       req.URL,
 		Command:   req.Command,
 	}
-	if err := adapter.SetupMCP(h.ws.RootDir, "", map[string]provider.MCPEntry{req.Name: entry}); err != nil {
+	if err := adapter.SetupMCP(r.Context(), h.ws.RootDir, "", map[string]provider.MCPEntry{req.Name: entry}); err != nil {
 		httpInternalError(w, "add mcp server", err)
 		return
 	}


### PR DESCRIPTION
Part of #2961 (context propagation hygiene)

## Summary

Replaces `context.TODO()` with caller-supplied `ctx` across three packages where a real request/operation context is reachable. For four startup-only DDL sites in store init schemas, retains `context.TODO()` with a justification comment per the linter convention — those calls are fire-and-forget and threading ctx would force >30 unrelated call-site changes.

### Why ctx propagation matters
- **Cancellation**: long-running `claude mcp add/remove` shells now abort when the parent agent spawn/rename is cancelled.
- **Deadlines**: `doctor` SQLite integrity checks respect `RunAll(ctx, ws)` timeouts.
- **Tracing**: ctx values (request IDs, trace spans) propagate end-to-end through MCP setup.

### Packages touched

| Package | Change |
|---------|--------|
| `pkg/doctor` | `CheckDatabase` and `checkSQLiteFile` take `ctx`; `PRAGMA integrity_check` and `sqlite_master` queries use it |
| `pkg/provider` | `ConfigAdapter.SetupMCP` interface now takes `ctx`; Claude/Cursor/Generic adapters updated; Claude `setupMCPViaCLI` uses `ctx` for `exec.CommandContext` |
| `pkg/agent` | `SetupAgentFromRole`/`SetupAgentFromRoleWithRuntime` take `ctx`; threaded into `writeMCPJSON` and `setupMCPViaCLI`; all three in-tree callers (`Manager.startAgent`/`createAgent`/`RenameAgent`) already had ctx |
| `server/handlers/providers.go` | `addMCP` passes `r.Context()` into the adapter |

### Sites still on `context.TODO()` (with justification comments)
- `pkg/notify/store.go:initSchema` — startup-only DDL via shared DB; threading ctx requires API change to `OpenStore` (>20 call sites incl. tests)
- `pkg/cron/store.go:initSchema` — same shape, requires API change to `cron.Open`
- `pkg/tool/store.go:initSchema` (×2: CREATE TABLE + ALTER TABLE migrations) — startup-only DDL via `Store.Open()`; >15 call sites in tests/services

These four are documented in code with `// context.TODO() retained: <reason>` so the deliberate retention is auditable.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/doctor/... ./pkg/provider/... ./pkg/agent/... ./pkg/notify/... ./pkg/cron/... ./pkg/tool/...` → 0 issues
- [x] `go test -short ./pkg/doctor/... ./pkg/provider/... ./pkg/agent/... ./pkg/notify/... ./pkg/cron/... ./pkg/tool/... ./server/handlers/...` → all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)