### PR TITLE
fix(mcp): patch sender spoof (#2967) and SSE CORS wildcard (#2960)

### DIFF
--- a/server/mcp/cors_test.go
+++ b/server/mcp/cors_test.go
@@ -12,7 +12,7 @@ import (
 // ─── #2960: MCP SSE CORS wildcard ────────────────────────────────────────────
 
 // TestSSE_CORSOrigin_DefaultsToWildcard preserves the historic loopback
-// behaviour: callers that don't set an explicit origin get "*".
+// behavior: callers that don't set an explicit origin get "*".
 func TestSSE_CORSOrigin_DefaultsToWildcard(t *testing.T) {
 	b := mcp.NewSSEBroker()
 

--- a/server/mcp/cors_test.go
+++ b/server/mcp/cors_test.go
@@ -1,0 +1,64 @@
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rpuneet/bc/server/mcp"
+)
+
+// ─── #2960: MCP SSE CORS wildcard ────────────────────────────────────────────
+
+// TestSSE_CORSOrigin_DefaultsToWildcard preserves the historic loopback
+// behaviour: callers that don't set an explicit origin get "*".
+func TestSSE_CORSOrigin_DefaultsToWildcard(t *testing.T) {
+	b := mcp.NewSSEBroker()
+
+	srv := httptest.NewServer(b.SSEHandler())
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "*")
+	}
+}
+
+// TestSSE_CORSOrigin_RespectsConfiguredOrigin is the regression test for
+// #2960: when the broker has a configured origin, the SSE response must
+// echo that origin instead of the wildcard.
+func TestSSE_CORSOrigin_RespectsConfiguredOrigin(t *testing.T) {
+	b := mcp.NewSSEBroker()
+	b.SetCORSOrigin("https://app.example.com")
+
+	srv := httptest.NewServer(b.SSEHandler())
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	got := resp.Header.Get("Access-Control-Allow-Origin")
+	if got == "*" {
+		t.Fatalf("Access-Control-Allow-Origin = %q — wildcard must NOT leak when an origin is configured (#2960)", got)
+	}
+	if got != "https://app.example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want https://app.example.com", got)
+	}
+}

--- a/server/mcp/security_test.go
+++ b/server/mcp/security_test.go
@@ -1,0 +1,208 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/bc/pkg/gateway"
+	"github.com/rpuneet/bc/pkg/workspace"
+	"github.com/rpuneet/bc/server/mcp"
+)
+
+// ─── #2967: MCP sender spoof regression ──────────────────────────────────────
+
+// fakeAdapter implements gateway.NotificationAdapter + the unexported
+// messageSender contract by exposing a Send method that captures the sender
+// passed by the caller. We register one channel ("fake:room") so the gateway
+// Manager has a route to dispatch to.
+type fakeAdapter struct {
+	lastSender  string
+	lastContent string
+	lastChannel string
+}
+
+func (a *fakeAdapter) Name() string                     { return "fake" }
+func (a *fakeAdapter) Type() gateway.AdapterType        { return gateway.AdapterPoll }
+func (a *fakeAdapter) Stop() error                      { return nil }
+func (a *fakeAdapter) HTTPHandler() http.Handler        { return nil }
+func (a *fakeAdapter) Status() gateway.AdapterStatus    { return gateway.AdapterStatus{Connected: true} }
+func (a *fakeAdapter) Channels() []gateway.ChannelInfo {
+	return []gateway.ChannelInfo{{ID: "room", Name: "room", Platform: "fake"}}
+}
+func (a *fakeAdapter) Start(ctx context.Context, _ func(gateway.Notification)) error {
+	<-ctx.Done()
+	return nil
+}
+
+// Send satisfies the unexported messageSender interface checked at runtime
+// inside gateway.Manager.Send.
+func (a *fakeAdapter) Send(_ context.Context, channelID, sender, content string) error {
+	a.lastChannel = channelID
+	a.lastSender = sender
+	a.lastContent = content
+	return nil
+}
+
+// newServerWithFakeGateway returns an mcp.Server backed by a real
+// gateway.Manager whose only adapter is a fakeAdapter with a discovered
+// channel "fake:room". Because Manager.Start() is what triggers
+// discoverChannels but blocks until ctx is canceled, we instead drive
+// discovery by calling Start in a cancellable goroutine and waiting one
+// scheduler turn — but the simpler path is to call HandleNotification on
+// nothing and rely on the existing discovery happening synchronously
+// inside Start before it begins to wait. The cleanest is to start the
+// manager with an immediately-cancelled context: Start runs discovery
+// before <-ctx.Done().
+func newServerWithFakeGateway(t *testing.T) (*mcp.Server, *fakeAdapter) {
+	t.Helper()
+
+	wsDir := makeWorkspace(t)
+	ws, err := workspace.Load(wsDir)
+	if err != nil {
+		t.Fatalf("workspace.Load: %v", err)
+	}
+
+	mgr := gateway.NewManager()
+	fa := &fakeAdapter{}
+	mgr.Register(fa)
+
+	// Drive channel discovery: Manager.Start runs restorePersistedChannels
+	// + discoverChannels synchronously, then enters a select on ctx.Done().
+	// With an already-cancelled ctx, Start returns immediately AFTER
+	// discovery runs.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_ = mgr.Start(ctx) //nolint:errcheck // discovery side-effect only
+
+	srv, err := mcp.New(mcp.Config{Workspace: ws, Gateway: mgr, Version: "test"})
+	if err != nil {
+		t.Fatalf("mcp.New: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Close() })
+	return srv, fa
+}
+
+// rpcWithCtx mirrors the rpc() helper but lets the caller supply a context
+// so we can attach an authenticated agent identity.
+func rpcWithCtx(t *testing.T, ctx context.Context, srv *mcp.Server, method string, params any, dst any) {
+	t.Helper()
+	id := json.RawMessage(`1`)
+	var rawParams json.RawMessage
+	if params != nil {
+		b, err := json.Marshal(params)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		rawParams = b
+	}
+	req := mcp.Request{JSONRPC: "2.0", ID: &id, Method: method, Params: rawParams}
+	resp := srv.Handle(ctx, req)
+	if resp.Error != nil {
+		t.Fatalf("rpc error: %s (code %d)", resp.Error.Message, resp.Error.Code)
+	}
+	if dst == nil {
+		return
+	}
+	b, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	if err := json.Unmarshal(b, dst); err != nil {
+		t.Fatalf("unmarshal into %T: %v", dst, err)
+	}
+}
+
+// TestSendMessage_SenderSpoofIsOverridden ensures a client passing an
+// arbitrary "sender" cannot impersonate another agent: the authenticated
+// context agent always wins. Regression for issue #2967.
+func TestSendMessage_SenderSpoofIsOverridden(t *testing.T) {
+	srv, fa := newServerWithFakeGateway(t)
+
+	ctx := mcp.ContextWithAgent(context.Background(), "alice")
+
+	var result struct {
+		Content []mcp.ToolContent `json:"content"`
+		IsError bool              `json:"isError"`
+	}
+	rpcWithCtx(t, ctx, srv, "tools/call", map[string]any{
+		"name": "send_message",
+		"arguments": map[string]any{
+			"channel": "fake:room",
+			"message": "hello",
+			"sender":  "bob", // spoof attempt — must be ignored
+		},
+	}, &result)
+
+	if result.IsError {
+		t.Fatalf("unexpected isError=true: %+v", result.Content)
+	}
+	if fa.lastSender != "alice" {
+		t.Fatalf("sender = %q, want alice (client-supplied %q must be ignored)",
+			fa.lastSender, "bob")
+	}
+	if fa.lastContent != "hello" {
+		t.Errorf("content = %q, want hello", fa.lastContent)
+	}
+	if len(result.Content) == 0 || !strings.Contains(result.Content[0].Text, "as alice") {
+		t.Errorf("response should attribute send to alice, got %+v", result.Content)
+	}
+}
+
+// TestSendMessage_NoCtxAgent_FallsBackToClient verifies the legacy fallback
+// path: when no agent is bound to the context (e.g., stdio transport), the
+// client value is honoured for backward compatibility.
+func TestSendMessage_NoCtxAgent_FallsBackToClient(t *testing.T) {
+	srv, fa := newServerWithFakeGateway(t)
+
+	var result struct {
+		Content []mcp.ToolContent `json:"content"`
+		IsError bool              `json:"isError"`
+	}
+	rpcWithCtx(t, context.Background(), srv, "tools/call", map[string]any{
+		"name": "send_message",
+		"arguments": map[string]any{
+			"channel": "fake:room",
+			"message": "hi",
+			"sender":  "carol",
+		},
+	}, &result)
+
+	if result.IsError {
+		t.Fatalf("unexpected isError=true: %+v", result.Content)
+	}
+	if fa.lastSender != "carol" {
+		t.Fatalf("sender = %q, want carol (no ctx agent → trust client value)",
+			fa.lastSender)
+	}
+}
+
+// TestSendMessage_CtxAgent_BlankClientUsesCtx covers the ordinary case: no
+// client sender supplied, ctx agent is used.
+func TestSendMessage_CtxAgent_BlankClientUsesCtx(t *testing.T) {
+	srv, fa := newServerWithFakeGateway(t)
+
+	ctx := mcp.ContextWithAgent(context.Background(), "alice")
+
+	var result struct {
+		Content []mcp.ToolContent `json:"content"`
+		IsError bool              `json:"isError"`
+	}
+	rpcWithCtx(t, ctx, srv, "tools/call", map[string]any{
+		"name": "send_message",
+		"arguments": map[string]any{
+			"channel": "fake:room",
+			"message": "hi",
+		},
+	}, &result)
+
+	if result.IsError {
+		t.Fatalf("unexpected isError=true: %+v", result.Content)
+	}
+	if fa.lastSender != "alice" {
+		t.Fatalf("sender = %q, want alice", fa.lastSender)
+	}
+}
+

--- a/server/mcp/security_test.go
+++ b/server/mcp/security_test.go
@@ -24,11 +24,11 @@ type fakeAdapter struct {
 	lastChannel string
 }
 
-func (a *fakeAdapter) Name() string                     { return "fake" }
-func (a *fakeAdapter) Type() gateway.AdapterType        { return gateway.AdapterPoll }
-func (a *fakeAdapter) Stop() error                      { return nil }
-func (a *fakeAdapter) HTTPHandler() http.Handler        { return nil }
-func (a *fakeAdapter) Status() gateway.AdapterStatus    { return gateway.AdapterStatus{Connected: true} }
+func (a *fakeAdapter) Name() string                  { return "fake" }
+func (a *fakeAdapter) Type() gateway.AdapterType     { return gateway.AdapterPoll }
+func (a *fakeAdapter) Stop() error                   { return nil }
+func (a *fakeAdapter) HTTPHandler() http.Handler     { return nil }
+func (a *fakeAdapter) Status() gateway.AdapterStatus { return gateway.AdapterStatus{Connected: true} }
 func (a *fakeAdapter) Channels() []gateway.ChannelInfo {
 	return []gateway.ChannelInfo{{ID: "room", Name: "room", Platform: "fake"}}
 }
@@ -54,7 +54,7 @@ func (a *fakeAdapter) Send(_ context.Context, channelID, sender, content string)
 // scheduler turn — but the simpler path is to call HandleNotification on
 // nothing and rely on the existing discovery happening synchronously
 // inside Start before it begins to wait. The cleanest is to start the
-// manager with an immediately-cancelled context: Start runs discovery
+// manager with an immediately-canceled context: Start runs discovery
 // before <-ctx.Done().
 func newServerWithFakeGateway(t *testing.T) (*mcp.Server, *fakeAdapter) {
 	t.Helper()
@@ -71,7 +71,7 @@ func newServerWithFakeGateway(t *testing.T) (*mcp.Server, *fakeAdapter) {
 
 	// Drive channel discovery: Manager.Start runs restorePersistedChannels
 	// + discoverChannels synchronously, then enters a select on ctx.Done().
-	// With an already-cancelled ctx, Start returns immediately AFTER
+	// With an already-canceled ctx, Start returns immediately AFTER
 	// discovery runs.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -153,7 +153,7 @@ func TestSendMessage_SenderSpoofIsOverridden(t *testing.T) {
 
 // TestSendMessage_NoCtxAgent_FallsBackToClient verifies the legacy fallback
 // path: when no agent is bound to the context (e.g., stdio transport), the
-// client value is honoured for backward compatibility.
+// client value is honored for backward compatibility.
 func TestSendMessage_NoCtxAgent_FallsBackToClient(t *testing.T) {
 	srv, fa := newServerWithFakeGateway(t)
 
@@ -205,4 +205,3 @@ func TestSendMessage_CtxAgent_BlankClientUsesCtx(t *testing.T) {
 		t.Fatalf("sender = %q, want alice", fa.lastSender)
 	}
 }
-

--- a/server/mcp/server.go
+++ b/server/mcp/server.go
@@ -27,6 +27,14 @@ func AgentFromContext(ctx context.Context) string {
 	return ""
 }
 
+// ContextWithAgent returns ctx with the given authenticated agent ID
+// attached. The agent identity is treated as the only trusted source of
+// "sender" for outbound MCP tool calls (#2967). Used by the SSE message
+// handler and by tests that need to simulate an authenticated request.
+func ContextWithAgent(ctx context.Context, agentID string) context.Context {
+	return context.WithValue(ctx, ctxKeyAgent, agentID)
+}
+
 // Server is a bc MCP server. It owns handles to workspace state and dispatches
 // JSON-RPC 2.0 requests from either stdio or SSE transports.
 type Server struct {

--- a/server/mcp/sse.go
+++ b/server/mcp/sse.go
@@ -80,7 +80,7 @@ func (s *Server) HandleSSEMessage(ctx context.Context, broker *SSEBroker) http.H
 
 		// Pass agent identity from query param into context for tool handlers.
 		if agentID := r.URL.Query().Get("agent"); agentID != "" {
-			ctx = context.WithValue(ctx, ctxKeyAgent, agentID) //nolint:staticcheck // string key is fine for internal use
+			ctx = ContextWithAgent(ctx, agentID)
 		}
 
 		resp := s.Handle(ctx, req)
@@ -108,12 +108,34 @@ type sseClient struct {
 type SSEBroker struct {
 	clients         map[chan []byte]*sseClient
 	messageEndpoint string
+	corsOrigin      string
 	mu              sync.Mutex
 }
 
 // NewSSEBroker creates an SSEBroker ready to use.
+//
+// The default CORS origin is "*" — safe because bcd binds to loopback by
+// default. Callers that expose bcd beyond loopback should call
+// SetCORSOrigin to lock the SSE endpoint to a specific origin (issue #2960).
 func NewSSEBroker() *SSEBroker {
-	return &SSEBroker{clients: make(map[chan []byte]*sseClient), messageEndpoint: "/message"}
+	return &SSEBroker{
+		clients:         make(map[chan []byte]*sseClient),
+		messageEndpoint: "/message",
+		corsOrigin:      "*",
+	}
+}
+
+// SetCORSOrigin overrides the Access-Control-Allow-Origin value emitted on
+// SSE responses. Pass an empty string to keep the wildcard default. Used by
+// bcd to mirror the API CORSOrigin setting onto the MCP SSE transport so
+// MCP cannot bypass the configured origin policy (issue #2960).
+func (b *SSEBroker) SetCORSOrigin(origin string) {
+	if origin == "" {
+		return
+	}
+	b.mu.Lock()
+	b.corsOrigin = origin
+	b.mu.Unlock()
 }
 
 // SetMessageEndpoint overrides the endpoint URL returned to new SSE clients
@@ -200,7 +222,13 @@ func (b *SSEBroker) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	b.mu.Lock()
+	origin := b.corsOrigin
+	b.mu.Unlock()
+	if origin == "" {
+		origin = "*"
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
 
 	agentID := r.URL.Query().Get("agent")
 	ch := b.subscribe(agentID)

--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -9,7 +9,36 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/rpuneet/bc/pkg/log"
 )
+
+// resolveSender returns the authoritative sender identity for outbound MCP
+// tool calls (send_message, send_file).
+//
+// Security (issue #2967): the agent identity attached to the request context
+// (set from the authenticated SSE connection — either the agent-scoped path
+// /_mcp/<agent>/{sse,message} or the ?agent= query param) is the ONLY
+// trusted source of identity. Any client-supplied "sender" value is
+// advisory: if it disagrees with the context agent we log a warning and
+// override it to prevent MCP sender spoofing.
+//
+// If no agent is bound to the context (legacy / unauthenticated flows) we
+// fall back to the client value, and finally to "agent".
+func resolveSender(ctx context.Context, clientSender string) string {
+	ctxAgent := AgentFromContext(ctx)
+	if ctxAgent != "" {
+		if clientSender != "" && clientSender != ctxAgent {
+			log.Warn("mcp: ignoring client-supplied sender — using authenticated agent",
+				"client_sender", clientSender, "ctx_agent", ctxAgent)
+		}
+		return ctxAgent
+	}
+	if clientSender != "" {
+		return clientSender
+	}
+	return "agent"
+}
 
 // definedTools returns the static list of tools this server exposes.
 func definedTools() []Tool {
@@ -125,13 +154,9 @@ func (s *Server) toolSendMessage(ctx context.Context, raw json.RawMessage) (*too
 			IsError: true,
 		}, nil
 	}
-	if args.Sender == "" {
-		if agentID, ok := ctx.Value(ctxKeyAgent).(string); ok && agentID != "" {
-			args.Sender = agentID
-		} else {
-			args.Sender = "agent"
-		}
-	}
+	// Always derive the sender from the authenticated context — never trust
+	// the client-supplied value. See resolveSender / issue #2967.
+	args.Sender = resolveSender(ctx, args.Sender)
 
 	if s.gateway == nil {
 		return &toolsCallResult{
@@ -406,11 +431,10 @@ func (s *Server) toolSendFile(ctx context.Context, raw json.RawMessage) (*toolsC
 		mimeType = "application/pdf"
 	}
 
-	// Get sender from context
-	sender := "agent"
-	if agentID, ok := ctx.Value(ctxKeyAgent).(string); ok && agentID != "" {
-		sender = agentID
-	}
+	// Get sender from context — always trust ctx over client input (#2967).
+	// send_file currently has no client-supplied sender field, but route
+	// through resolveSender for consistency and future-proofing.
+	sender := resolveSender(ctx, "")
 
 	// Route through gateway manager
 	if s.gateway == nil {

--- a/server/mcp_dispatch.go
+++ b/server/mcp_dispatch.go
@@ -38,7 +38,7 @@ var mcpRegistry = &perWorkspaceMCP{
 // /_mcp/ws/<wsID>/<agent>/<action> and dispatches them to the workspace's
 // MCP server. The first request for a given wsID lazily constructs that
 // workspace's MCP server using its loaded WorkspaceServices.
-func scopedMCPDispatch(mgr *WorkspaceManager) http.HandlerFunc {
+func scopedMCPDispatch(mgr *WorkspaceManager, corsOrigin string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		remainder := strings.TrimPrefix(r.URL.Path, "/_mcp/ws/")
 		parts := strings.SplitN(remainder, "/", 3)
@@ -64,7 +64,7 @@ func scopedMCPDispatch(mgr *WorkspaceManager) http.HandlerFunc {
 			}
 		}
 
-		srv, broker, err := ensureMCPServer(wsID, svc)
+		srv, broker, err := ensureMCPServer(wsID, svc, corsOrigin)
 		if err != nil {
 			log.Warn("scoped MCP: server build failed", "id", wsID, "error", err)
 			http.Error(w, `{"error":"mcp unavailable"}`, http.StatusInternalServerError)
@@ -90,7 +90,7 @@ func scopedMCPDispatch(mgr *WorkspaceManager) http.HandlerFunc {
 
 // ensureMCPServer returns a cached MCP server for wsID or builds one on
 // first access. Caller must hold the workspace services (non-nil).
-func ensureMCPServer(wsID string, svc *WorkspaceServices) (*servermcp.Server, *servermcp.SSEBroker, error) {
+func ensureMCPServer(wsID string, svc *WorkspaceServices, corsOrigin string) (*servermcp.Server, *servermcp.SSEBroker, error) {
 	mcpRegistry.mu.Lock()
 	defer mcpRegistry.mu.Unlock()
 
@@ -114,6 +114,9 @@ func ensureMCPServer(wsID string, svc *WorkspaceServices) (*servermcp.Server, *s
 	}
 	broker := servermcp.NewSSEBroker()
 	broker.SetMessageEndpoint("/_mcp/ws/" + wsID + "/{agent}/message")
+	if corsOrigin != "" {
+		broker.SetCORSOrigin(corsOrigin)
+	}
 	srv.SetBroker(broker)
 
 	mcpRegistry.servers[wsID] = srv

--- a/server/server.go
+++ b/server/server.go
@@ -456,12 +456,17 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		if mcpErr != nil {
 			log.Warn("MCP server unavailable", "error", mcpErr)
 		} else {
-			servermcp.MountOn(mux, mcpSrv, "/_mcp")
+			broker := servermcp.MountOn(mux, mcpSrv, "/_mcp")
+			// Mirror the API CORS policy onto the MCP SSE transport so MCP
+			// cannot bypass the configured origin policy (#2960).
+			if cfg.CORSOrigin != "" {
+				broker.SetCORSOrigin(cfg.CORSOrigin)
+			}
 		}
 	}
 	// Scoped MCP dispatcher — per-workspace path.
 	if svc.WorkspaceManager != nil {
-		mux.HandleFunc("/_mcp/ws/", scopedMCPDispatch(svc.WorkspaceManager))
+		mux.HandleFunc("/_mcp/ws/", scopedMCPDispatch(svc.WorkspaceManager, cfg.CORSOrigin))
 	}
 
 	// Static web UI with SPA fallback — serves files if they exist,


### PR DESCRIPTION
## Summary

Two P0 MCP security fixes shipped together.

- **#2967 — MCP sender spoof**: `toolSendMessage` previously only overwrote a client-supplied `sender` when the field was blank, so any caller could impersonate another agent. Fixed by introducing `resolveSender` which always derives the sender from the authenticated request context (set from the SSE connection / `?agent=` param). When ctx has an agent, the client value is ignored and a warning is logged. `toolSendFile` is routed through the same helper for consistency. Falls back to the client value only when no ctx agent exists (legacy stdio transport).
- **#2960 — MCP SSE CORS wildcard**: `handleSSE` hardcoded `Access-Control-Allow-Origin: *`. Replaced with a configurable origin that mirrors the existing `cfg.CORSOrigin` used by the API (`server/handlers/helpers.go` `CORSWithOrigin`). `SSEBroker` now stores its own origin (default `*` so loopback deployments are unaffected) with a `SetCORSOrigin` setter; both `MountOn` and `scopedMCPDispatch` propagate `cfg.CORSOrigin` through. No new globals.

A small follow-up commit fixes misspell + gofmt findings in the new tests (no behavioral change).

Closes #2967
Closes #2960

## Test plan

- [x] New regression tests:
  - `TestSendMessage_SenderSpoofIsOverridden` — ctx="alice" + client `sender:"bob"` → stored sender is "alice"; response message attributes "as alice"
  - `TestSendMessage_NoCtxAgent_FallsBackToClient` — preserves legacy stdio behavior
  - `TestSendMessage_CtxAgent_BlankClientUsesCtx` — ordinary path
  - `TestSSE_CORSOrigin_DefaultsToWildcard` — preserves loopback default
  - `TestSSE_CORSOrigin_RespectsConfiguredOrigin` — locked origin no longer leaks `*`
- [x] `make lint-go` clean
- [x] `make build-local-go` succeeds
- [x] No regressions in `./server/mcp/...` test package