### PR TITLE
chore(ci): allow deps(...) prefix in PR Quality regex

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -29,7 +29,7 @@ jobs:
             let warnings = [];
 
             // Conventional commit title (blocking)
-            const conventionalRegex = /^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert)(\([^)]+\))?: .+/;
+            const conventionalRegex = /^(feat|fix|docs|style|refactor|test|chore|build|ci|perf|revert|deps)(\([^)]+\))?: .+/;
             if (!conventionalRegex.test(title)) {
               errors.push('Title must follow conventional commit format: type(scope): description');
             }


### PR DESCRIPTION
## Why

Dependabot opens PRs titled like `deps(go): bump X from A to B` and `deps(actions): bump the actions group ...`. The PR Quality workflow's conventional-commits regex doesn't include `deps`, so every dependabot PR fails the "Check PR Quality" job. Main isn't protected so this doesn't block merges, but it adds red-X noise on every bot PR.

Recent example: https://github.com/rpuneet/bc/pull/3049

## How

Added `deps` to the type alternation in the regex in `.github/workflows/pr-quality.yml`. No other changes.

## Test plan
- [x] Verified regex on sample dependabot title locally
- [ ] Confirm green PR Quality job after re-run

Fixes #32