### PR TITLE
fix(cron): isolate cron command process group to prevent bcd self-shutdown

### DIFF
--- a/pkg/cron/scheduler.go
+++ b/pkg/cron/scheduler.go
@@ -226,8 +226,19 @@ func (s *Scheduler) executeJob(ctx context.Context, job *Job) {
 }
 
 // defaultExec runs a shell command and streams output to the writer.
+//
+// The child shell is placed in its own process group (see isolateProcessGroup)
+// so that signals delivered to the bcd process group — for example a cron job
+// that runs `kill 0`, `kill -- -$$`, or any tool that broadcasts SIGTERM to its
+// own process group — do not propagate to the bcd parent and trigger a
+// graceful shutdown of the cron scheduler itself.
+//
+// This does not protect against commands that target bcd by PID directly
+// (e.g. `lsof -ti :9374 | xargs kill`); such commands must exclude the bcd
+// PID themselves or use an external supervisor for restarts.
 func (s *Scheduler) defaultExec(ctx context.Context, command string, logWriter io.Writer) error {
 	cmd := exec.CommandContext(ctx, "sh", "-c", command) //#nosec G204 -- commands are user-configured cron jobs
+	isolateProcessGroup(cmd)
 	var buf bytes.Buffer
 	w := io.MultiWriter(&buf, logWriter)
 	cmd.Stdout = w

--- a/pkg/cron/scheduler_pgid_test.go
+++ b/pkg/cron/scheduler_pgid_test.go
@@ -1,0 +1,87 @@
+//go:build !windows
+
+package cron
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestDefaultExec_ChildHasOwnProcessGroup verifies that a cron command runs in
+// its own process group, so it cannot signal bcd by signaling its own group.
+//
+// Regression test for #2964 (cron build-and-deploy self-kills bcd).
+func TestDefaultExec_ChildHasOwnProcessGroup(t *testing.T) {
+	s := NewScheduler(nil, t.TempDir())
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// The child prints its own pgid. ps -o pgid= -p $$ trims the value via tr.
+	if err := s.defaultExec(ctx, "ps -o pgid= -p $$ | tr -d ' '", &out); err != nil {
+		t.Fatalf("defaultExec: %v", err)
+	}
+
+	childPgid, err := strconv.Atoi(strings.TrimSpace(out.String()))
+	if err != nil {
+		t.Fatalf("parse child pgid from %q: %v", out.String(), err)
+	}
+
+	parentPgid, err := syscall.Getpgid(os.Getpid())
+	if err != nil {
+		t.Fatalf("Getpgid(parent): %v", err)
+	}
+
+	if childPgid == parentPgid {
+		t.Fatalf("child cron command shares bcd's process group (pgid=%d); "+
+			"a `kill 0` in the cron command would terminate bcd. See #2964.",
+			childPgid)
+	}
+}
+
+// TestDefaultExec_SignalToChildGroupDoesNotReachParent simulates a cron job
+// that broadcasts SIGTERM to its own process group, and asserts the bcd
+// (test) process is not signaled.
+//
+// We register a SIGTERM handler before running, run a command that signals
+// its own group, then verify no SIGTERM was delivered to us.
+func TestDefaultExec_SignalToChildGroupDoesNotReachParent(t *testing.T) {
+	gotSig := make(chan os.Signal, 1)
+	// Install a handler that absorbs SIGTERM so the test process isn't killed
+	// even if the isolation regresses — we want to fail the test, not crash.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	go func() {
+		select {
+		case s := <-sigCh:
+			gotSig <- s
+		case <-time.After(2 * time.Second):
+		}
+	}()
+
+	s := NewScheduler(nil, t.TempDir())
+	var out bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// `kill -TERM 0` sends SIGTERM to every process in the caller's group.
+	// If isolation works, only the child shell receives it; the test process
+	// (the simulated bcd parent) does not.
+	_ = s.defaultExec(ctx, "kill -TERM 0", &out)
+
+	select {
+	case <-gotSig:
+		t.Fatalf("parent received SIGTERM from child cron command — process group isolation is broken (see #2964)")
+	case <-time.After(500 * time.Millisecond):
+		// Good: parent was not signaled.
+	}
+}

--- a/pkg/cron/scheduler_unix.go
+++ b/pkg/cron/scheduler_unix.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package cron
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// isolateProcessGroup configures cmd to run in a new process group.
+//
+// On Unix, signals sent to a process group (e.g. via `kill 0`, `kill -- -$pgid`,
+// or terminal-driven SIGTERM/SIGINT) are delivered to every process that shares
+// the group. By default a child started with exec.Command inherits its parent's
+// process group, so a cron command that signals its own group will also signal
+// bcd. Setting Setpgid=true with Pgid=0 makes the child the leader of a fresh
+// process group, isolating it from bcd.
+func isolateProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.SysProcAttr.Pgid = 0
+}

--- a/pkg/cron/scheduler_windows.go
+++ b/pkg/cron/scheduler_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package cron
+
+import "os/exec"
+
+// isolateProcessGroup is a no-op on Windows: signal semantics differ and bcd
+// is not supported on Windows in production. The function exists so the
+// platform-neutral scheduler code can call it unconditionally.
+func isolateProcessGroup(_ *exec.Cmd) {}


### PR DESCRIPTION
## Summary

Fixes #2964 — cron build-and-deploy (and any cron command that signals its own process group) was killing the bcd process running the scheduler.

## Root cause

`pkg/cron.Scheduler.defaultExec` invoked `exec.CommandContext("sh", "-c", command)` without setting `SysProcAttr.Setpgid`. The child shell therefore inherited bcd's process group. Any cron command that broadcast a signal to its own group — e.g. `kill 0`, `kill -- -$$`, or anything that ends up calling `killpg(0, SIGTERM)` — also signaled bcd. bcd's signal handler in `internal/cmd/serve.go` (`signal.NotifyContext(..., SIGINT, SIGTERM)`) then ran the graceful shutdown sequence (`tool health loop stopped` → `cron scheduler stopped`), which matches the symptom in the issue and the local daemon.log.

The 404 on `/api/agents/worker-01/send` that preceded each shutdown is incidental — it's just the resource handler returning `not found` for an unknown agent. No code path on that 404 triggers shutdown.

Note: this fix does NOT protect against commands that kill bcd by PID directly (e.g. `lsof -ti :9374 | xargs kill`); those need to exclude the bcd PID themselves or use an external supervisor for restarts. The store layer already logs a warning when such commands are added (see `pkg/cron/store.go`).

## Fix

Add `isolateProcessGroup(cmd)` (Unix: `Setpgid=true, Pgid=0`; Windows: no-op) so each cron command runs as its own process-group leader. Signals targeted at the child's group can no longer reach bcd.

## Test plan

- [x] `TestDefaultExec_ChildHasOwnProcessGroup` — runs `ps -o pgid= -p $$` in a cron command and asserts the child's pgid != bcd's pgid.
- [x] `TestDefaultExec_SignalToChildGroupDoesNotReachParent` — runs `kill -TERM 0` in a cron command and asserts the parent test process does not receive SIGTERM. Without the fix this test fails (exit code 144 = SIGTERM-killed).
- [x] `make lint-go` clean.
- [x] `go test ./pkg/cron/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cron job execution safety and stability. Jobs now run in isolated execution contexts, ensuring that signals sent by a job to itself do not propagate to the scheduler process. This prevents accidental scheduler shutdowns caused by job self-signaling, enhancing reliability across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->