### PR TITLE
chore: rename rpuneet/bc to rpuneet/mycel (non-Go references)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://github.com/rpuneet/bc/tree/main/docs
+    url: https://github.com/rpuneet/mycel/tree/main/docs
     about: Check the docs before filing an issue
   - name: Security Vulnerability
-    url: https://github.com/rpuneet/bc/security/advisories/new
+    url: https://github.com/rpuneet/mycel/security/advisories/new
     about: Report security issues privately via GitHub Security Advisories

--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -1,10 +1,10 @@
 # Continuous Deployment for main branch
 # On every push to main, builds and publishes:
-#   - Docker image: ghcr.io/rpuneet/bc:main (and :main-<sha>)
+#   - Docker image: ghcr.io/rpuneet/mycel:main (and :main-<sha>)
 #   - Does NOT create GitHub releases (use release.yml for tagged releases)
 #
 # This gives users a way to pull the latest bleeding-edge main:
-#   docker pull ghcr.io/rpuneet/bc:main
+#   docker pull ghcr.io/rpuneet/mycel:main
 
 name: CD (main)
 
@@ -51,10 +51,10 @@ jobs:
           file: docker/Dockerfile.bcd
           push: true
           tags: |
-            ghcr.io/rpuneet/bc:main
-            ghcr.io/rpuneet/bc:main-${{ github.sha }}
+            ghcr.io/rpuneet/mycel:main
+            ghcr.io/rpuneet/mycel:main-${{ github.sha }}
           labels: |
-            org.opencontainers.image.source=https://github.com/rpuneet/bc
+            org.opencontainers.image.source=https://github.com/rpuneet/mycel
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.description=bc AI agent orchestration (main branch)
           cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v5
-        if: github.event_name == 'push' || github.repository == 'rpuneet/bc'
+        if: github.event_name == 'push' || github.repository == 'rpuneet/mycel'
         with:
           files: coverage.out
           fail_ci_if_error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,10 +195,10 @@ jobs:
           file: docker/Dockerfile.bcd
           push: true
           tags: |
-            ghcr.io/rpuneet/bc:${{ needs.prepare.outputs.tag }}
-            ghcr.io/rpuneet/bc:latest
+            ghcr.io/rpuneet/mycel:${{ needs.prepare.outputs.tag }}
+            ghcr.io/rpuneet/mycel:latest
           labels: |
-            org.opencontainers.image.source=https://github.com/rpuneet/bc
+            org.opencontainers.image.source=https://github.com/rpuneet/mycel
             org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=gha

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -131,16 +131,16 @@ release:
 
     | Method | Command |
     |--------|---------|
-    | **Homebrew** (macOS) | `brew install rpuneet/bc/bc` |
+    | **Homebrew** (macOS) | `brew install rpuneet/mycel/bc` |
     | **npm / bun** (Linux) | `npm install -g bc-cli` or `bunx bc-cli` |
-    | **Go** | `go install github.com/rpuneet/bc/cmd/bc@{{ .Tag }}` |
-    | **Script** | `curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh \| bash` |
-    | **Docker** | `docker pull ghcr.io/rpuneet/bc:{{ .Tag }}` |
+    | **Go** | `go install github.com/rpuneet/mycel/cmd/bc@{{ .Tag }}` |
+    | **Script** | `curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh \| bash` |
+    | **Docker** | `docker pull ghcr.io/rpuneet/mycel:{{ .Tag }}` |
     | **Scoop** (Windows) | `scoop bucket add bc https://github.com/rpuneet/scoop-bc && scoop install bc` |
   footer: |
     ---
 
-    **Full Changelog**: https://github.com/rpuneet/bc/compare/{{ .PreviousTag }}...{{ .Tag }}
+    **Full Changelog**: https://github.com/rpuneet/mycel/compare/{{ .PreviousTag }}...{{ .Tag }}
 
 brews:
   - name: bc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for your interest in contributing to bc! This document provides guidel
 
 ```bash
 # Clone the repository
-git clone https://github.com/rpuneet/bc.git
+git clone https://github.com/rpuneet/mycel.git
 cd bc
 
 # Install dependencies
@@ -305,7 +305,7 @@ Releases are cut manually via GitHub Actions. CI/CD is fully automated from tag 
 
 ### Steps
 
-1. Ensure `main` is green. Check https://github.com/rpuneet/bc/actions/workflows/ci.yml
+1. Ensure `main` is green. Check https://github.com/rpuneet/mycel/actions/workflows/ci.yml
 2. Go to **Actions → Release → Run workflow**
 3. Enter version in semver format: `vMAJOR.MINOR.PATCH` (e.g. `v0.1.0`)
    - Alpha/RC allowed: `v0.2.0-alpha`, `v1.0.0-rc.1`
@@ -319,7 +319,7 @@ The release workflow:
 2. **CI** — full test suite (lint, test, TUI, web, landing, build gate, security, container scan)
 3. **Release Linux** — GoReleaser builds `linux/amd64`, creates archive + checksums, publishes GitHub release
 4. **Release macOS** — Native CGO builds for `darwin/amd64` and `darwin/arm64`, uploads to release
-5. **Release Docker** — Pushes `ghcr.io/rpuneet/bc:<version>` and `:latest` to GHCR
+5. **Release Docker** — Pushes `ghcr.io/rpuneet/mycel:<version>` and `:latest` to GHCR
 6. **SBOM** — Generates and uploads `sbom.spdx.json` to release
 
 ### Homebrew tap publish
@@ -328,7 +328,7 @@ Requires `HOMEBREW_TAP_TOKEN` repo secret (GitHub PAT with repo scope for `rpune
 
 ### Continuous deployment
 
-Every merge to `main` also publishes `ghcr.io/rpuneet/bc:main` via `.github/workflows/cd-main.yml`. No tagging required — users can pull the bleeding edge.
+Every merge to `main` also publishes `ghcr.io/rpuneet/mycel:main` via `.github/workflows/cd-main.yml`. No tagging required — users can pull the bleeding edge.
 
 ### Version strategy
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # bc
 
-[![CI](https://github.com/rpuneet/bc/actions/workflows/ci.yml/badge.svg)](https://github.com/rpuneet/bc/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/rpuneet/bc?include_prereleases)](https://github.com/rpuneet/bc/releases)
-[![Go](https://img.shields.io/github/go-mod/go-version/rpuneet/bc)](https://go.dev/)
-[![License](https://img.shields.io/github/license/rpuneet/bc)](LICENSE)
+[![CI](https://github.com/rpuneet/mycel/actions/workflows/ci.yml/badge.svg)](https://github.com/rpuneet/mycel/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/rpuneet/mycel?include_prereleases)](https://github.com/rpuneet/mycel/releases)
+[![Go](https://img.shields.io/github/go-mod/go-version/rpuneet/mycel)](https://go.dev/)
+[![License](https://img.shields.io/github/license/rpuneet/mycel)](LICENSE)
 
 AI agents are powerful alone — chaotic when they work together. bc fixes that.
 
@@ -13,16 +13,16 @@ Coordinate teams of Claude, Gemini, Cursor, and other AI agents with isolated wo
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash
 
 # Homebrew
-brew install rpuneet/bc/bc
+brew install rpuneet/mycel/bc
 
 # Go
 go install github.com/rpuneet/bc/cmd/bc@latest
 
 # From source
-git clone https://github.com/rpuneet/bc && cd bc && make install-local-bc
+git clone https://github.com/rpuneet/mycel && cd bc && make install-local-bc
 ```
 
 **Prerequisites:** Go 1.25+, tmux, git. For TUI: Bun.

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -427,4 +427,4 @@ When reporting issues, include:
 5. Relevant logs: `bc logs --tail 100`
 6. Config (without secrets): `bc config show`
 
-File issues at: https://github.com/rpuneet/bc/issues
+File issues at: https://github.com/rpuneet/mycel/issues

--- a/docs/proposals/agents-revamp.md
+++ b/docs/proposals/agents-revamp.md
@@ -7,7 +7,7 @@
 
 # Proposal: Agents Revamp v2 — Templates, Avatars, and Live Operations
 
-> **Status:** Proposal (v2) &nbsp;|&nbsp; **Author:** zen-zebra &nbsp;|&nbsp; **Date:** 2026-04-13 &nbsp;|&nbsp; **Issue:** [#2979](https://github.com/rpuneet/bc/issues/2979)
+> **Status:** Proposal (v2) &nbsp;|&nbsp; **Author:** zen-zebra &nbsp;|&nbsp; **Date:** 2026-04-13 &nbsp;|&nbsp; **Issue:** [#2979](https://github.com/rpuneet/mycel/issues/2979)
 
 ---
 

--- a/docs/reference/cli/bc.md
+++ b/docs/reference/cli/bc.md
@@ -47,8 +47,8 @@ Environment Variables:
   BC_ROOT           Workspace root directory
   NO_COLOR          Disable colored output
 
-Documentation: https://github.com/rpuneet/bc
-Full CLI reference: https://github.com/rpuneet/bc/docs/cli.md
+Documentation: https://github.com/rpuneet/mycel
+Full CLI reference: https://github.com/rpuneet/mycel/docs/cli.md
 
 ```
 bc [flags]

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -13,7 +13,7 @@ Get bc running in 5 minutes.
 ### From Source
 
 ```bash
-git clone https://github.com/rpuneet/bc.git
+git clone https://github.com/rpuneet/mycel.git
 cd bc
 make build
 make install  # Installs to $GOPATH/bin

--- a/landing/README.md
+++ b/landing/README.md
@@ -14,7 +14,7 @@ A modern, interactive landing page showcasing mycel's capabilities for coordinat
 - **TUI Dashboard** - Visual monitoring of agent status and progress
 - **Multi-Tool Support** - Works with Claude Code, Cursor, and other AI development tools
 
-Learn more: [bc on GitHub](https://github.com/rpuneet/bc)
+Learn more: [bc on GitHub](https://github.com/rpuneet/mycel)
 
 ## 📋 Project Structure
 
@@ -276,7 +276,7 @@ Create a `.env.local` file for local development:
 
 ## 📚 Resources
 
-- [bc Documentation](https://github.com/rpuneet/bc)
+- [bc Documentation](https://github.com/rpuneet/mycel)
 - [Next.js Documentation](https://nextjs.org/docs)
 - [Tailwind CSS Documentation](https://tailwindcss.com/docs)
 - [Framer Motion Documentation](https://www.framer.com/motion)

--- a/landing/src/app/_components/Footer.tsx
+++ b/landing/src/app/_components/Footer.tsx
@@ -73,7 +73,7 @@ export function Footer() {
                 Getting Started
               </Link>
               <Link
-                href="https://github.com/rpuneet/bc"
+                href="https://github.com/rpuneet/mycel"
                 className="hover:text-on-surface transition-colors"
                 target="_blank"
                 rel="noopener noreferrer"

--- a/landing/src/app/_components/HeroSection.tsx
+++ b/landing/src/app/_components/HeroSection.tsx
@@ -91,7 +91,7 @@ export function HeroSection() {
               />
             </Link>
             <Link
-              href="https://github.com/rpuneet/bc"
+              href="https://github.com/rpuneet/mycel"
               className="inline-flex h-10 sm:h-11 items-center gap-2 rounded-lg border border-outline-variant/50 px-6 sm:px-8 text-sm font-medium transition-colors hover:bg-accent/20 active:scale-[0.97]"
               aria-label="View mycel on GitHub"
             >

--- a/landing/src/app/_components/InstallSection.tsx
+++ b/landing/src/app/_components/InstallSection.tsx
@@ -7,7 +7,7 @@ import { Copy, Check, Terminal, Beer, Code2, Container, Package, GitBranch } fro
 function useLatestVersion() {
   const [version, setVersion] = useState("latest");
   useEffect(() => {
-    fetch("https://api.github.com/repos/rpuneet/bc/releases/latest")
+    fetch("https://api.github.com/repos/rpuneet/mycel/releases/latest")
       .then((r) => r.json())
       .then((data) => {
         if (data.tag_name) setVersion(data.tag_name);
@@ -33,7 +33,7 @@ function getMethods(version: string): Method[] {
       icon: Terminal,
       platforms: "macOS · Linux",
       commands: [
-        "curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash",
+        "curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash",
       ],
     },
     {
@@ -42,7 +42,7 @@ function getMethods(version: string): Method[] {
       icon: Beer,
       platforms: "macOS",
       commands: [
-        "brew install rpuneet/bc/mycel",
+        "brew install rpuneet/mycel/mycel",
       ],
     },
     {
@@ -71,10 +71,10 @@ function getMethods(version: string): Method[] {
       icon: Container,
       platforms: "Stable + main branch",
       commands: [
-        `docker pull ghcr.io/rpuneet/bc:${version}`,
-        `docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/bc:${version} bc up --addr 0.0.0.0:9374`,
+        `docker pull ghcr.io/rpuneet/mycel:${version}`,
+        `docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:${version} bc up --addr 0.0.0.0:9374`,
         `# Bleeding edge from main:`,
-        `docker pull ghcr.io/rpuneet/bc:main`,
+        `docker pull ghcr.io/rpuneet/mycel:main`,
       ],
     },
     {
@@ -83,7 +83,7 @@ function getMethods(version: string): Method[] {
       icon: GitBranch,
       platforms: "Requires Go 1.25+, Bun, tmux",
       commands: [
-        "git clone https://github.com/rpuneet/bc",
+        "git clone https://github.com/rpuneet/mycel",
         "cd bc",
         "make install-local-bc",
       ],

--- a/landing/src/app/_components/Nav.tsx
+++ b/landing/src/app/_components/Nav.tsx
@@ -95,17 +95,17 @@ function GetStartedDropdown() {
     {
       icon: Apple,
       label: "macOS / Linux",
-      cmd: "curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash",
+      cmd: "curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash",
     },
     {
       icon: Monitor,
       label: "Homebrew",
-      cmd: "brew install rpuneet/bc/mycel",
+      cmd: "brew install rpuneet/mycel/mycel",
     },
     {
       icon: Container,
       label: "Docker",
-      cmd: "docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/bc bc up --addr 0.0.0.0:9374",
+      cmd: "docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel bc up --addr 0.0.0.0:9374",
     },
   ];
 
@@ -325,10 +325,10 @@ export function Nav() {
                   Install
                 </div>
                 <code className="block text-xs font-label text-on-background bg-surface-container-highest/50 rounded px-2.5 py-2 mb-1.5">
-                  curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash
+                  curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash
                 </code>
                 <code className="block text-xs font-label text-on-background bg-surface-container-highest/50 rounded px-2.5 py-2 mb-1.5">
-                  brew install rpuneet/bc/mycel
+                  brew install rpuneet/mycel/mycel
                 </code>
                 <Link
                   href="/docs#installation"

--- a/landing/src/app/docs/DocsContent.tsx
+++ b/landing/src/app/docs/DocsContent.tsx
@@ -915,7 +915,7 @@ function PlaceholderContent({ label }: { label: string }) {
       <p className="text-sm text-muted-foreground max-w-md">
         This page is under construction. Check back soon or contribute on{" "}
         <a
-          href="https://github.com/rpuneet/bc"
+          href="https://github.com/rpuneet/mycel"
           className="text-primary hover:underline"
           target="_blank"
           rel="noopener noreferrer"

--- a/landing/src/app/docs/getting-started.md
+++ b/landing/src/app/docs/getting-started.md
@@ -21,29 +21,29 @@ Welcome to **mycel** – the multi-agent orchestration system for coordinated so
 
 **Install script:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash
 ```
 
 **Using Homebrew:**
 ```bash
-brew install rpuneet/bc/mycel
+brew install rpuneet/mycel/mycel
 ```
 
 ### Linux
 
 **Install script:**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash
 ```
 
 ### Docker
 
 ```bash
 # Stable release
-docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/bc:latest bc up --addr 0.0.0.0:9374
+docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:latest bc up --addr 0.0.0.0:9374
 
 # Bleeding-edge (main branch)
-docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/bc:main bc up --addr 0.0.0.0:9374
+docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:main bc up --addr 0.0.0.0:9374
 ```
 
 ### npm / bun
@@ -380,7 +380,7 @@ bc down && bc up
 - Audit logging and compliance
 
 ### 5. Get Support
-- GitHub Issues: [Report bugs](https://github.com/rpuneet/bc/issues)
+- GitHub Issues: [Report bugs](https://github.com/rpuneet/mycel/issues)
 - Documentation: [Full docs](https://docs.mycel.dev)
 - Community: [Discord server](https://discord.gg/mycel-dev)
 
@@ -453,7 +453,7 @@ bc <command> --help
 - [CLI Reference](https://docs.mycel.dev/cli)
 
 **Support:**
-- [GitHub Issues](https://github.com/rpuneet/bc/issues)
+- [GitHub Issues](https://github.com/rpuneet/mycel/issues)
 - [Discord Community](https://discord.gg/mycel-dev)
 - Email: hello@mycel.dev
 

--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -19,10 +19,10 @@ import { AnimatedBackground } from "./_components/AnimatedBackground";
 
 /* ── Install commands by platform ── */
 const installCommands = {
-  macOS: "curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash",
-  Linux: "curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash",
-  Homebrew: "brew install rpuneet/bc/mycel",
-  Docker: "docker run -p 9374:9374 ghcr.io/rpuneet/bc mycel up",
+  macOS: "curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash",
+  Linux: "curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash",
+  Homebrew: "brew install rpuneet/mycel/mycel",
+  Docker: "docker run -p 9374:9374 ghcr.io/rpuneet/mycel mycel up",
 } as const;
 
 type Platform = keyof typeof installCommands;
@@ -183,7 +183,7 @@ export default function Home() {
                     <ExternalLink className="h-3.5 w-3.5" />
                   </Link>
                   <Link
-                    href="https://github.com/rpuneet/bc"
+                    href="https://github.com/rpuneet/mycel"
                     className="inline-flex h-11 items-center gap-2 rounded-lg border border-outline-variant/20 px-6 text-sm font-medium text-on-surface-variant transition-colors hover:bg-surface-container hover:border-primary/30 hover:text-primary active:scale-[0.97] font-body"
                   >
                     <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
@@ -195,13 +195,13 @@ export default function Home() {
                 {/* GitHub badges */}
                 <div className="flex items-center gap-2 flex-wrap justify-center">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src="https://img.shields.io/github/stars/rpuneet/bc?style=flat-square&color=ea580c&labelColor=1e1b18" alt="GitHub stars" className="h-5" />
+                  <img src="https://img.shields.io/github/stars/rpuneet/mycel?style=flat-square&color=ea580c&labelColor=1e1b18" alt="GitHub stars" className="h-5" />
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src="https://img.shields.io/github/license/rpuneet/bc?style=flat-square&color=ea580c&labelColor=1e1b18" alt="License" className="h-5" />
+                  <img src="https://img.shields.io/github/license/rpuneet/mycel?style=flat-square&color=ea580c&labelColor=1e1b18" alt="License" className="h-5" />
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src="https://img.shields.io/github/last-commit/rpuneet/bc?style=flat-square&color=ea580c&labelColor=1e1b18" alt="Last commit" className="h-5" />
+                  <img src="https://img.shields.io/github/last-commit/rpuneet/mycel?style=flat-square&color=ea580c&labelColor=1e1b18" alt="Last commit" className="h-5" />
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img src="https://img.shields.io/github/go-mod/go-version/rpuneet/bc?style=flat-square&color=ea580c&labelColor=1e1b18" alt="Go version" className="h-5" />
+                  <img src="https://img.shields.io/github/go-mod/go-version/rpuneet/mycel?style=flat-square&color=ea580c&labelColor=1e1b18" alt="Go version" className="h-5" />
                 </div>
               </div>
             </FadeUp>
@@ -348,7 +348,7 @@ export default function Home() {
             </p>
             <div className="mt-8">
               <Link
-                href="https://github.com/rpuneet/bc"
+                href="https://github.com/rpuneet/mycel"
                 className="inline-flex h-11 items-center gap-2 rounded-lg bg-primary px-8 text-sm font-semibold text-primary-foreground shadow-[var(--btn-shadow)] transition-all hover:shadow-[0_0_20px_rgba(234,88,12,0.3)] active:scale-[0.97]"
               >
                 <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">

--- a/landing/src/app/product/page.tsx
+++ b/landing/src/app/product/page.tsx
@@ -445,7 +445,7 @@ export default function Product() {
                 <div className="p-4 font-label text-[13px] leading-relaxed text-[var(--terminal-text)]">
                   <div>
                     <span className="text-[var(--terminal-prompt)]">$ </span>
-                    <span className="text-[var(--terminal-command)]">curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash</span>
+                    <span className="text-[var(--terminal-command)]">curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash</span>
                   </div>
                   <div>
                     <span className="text-[var(--terminal-prompt)]">$ </span>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,8 @@ site_description: Multi-agent AI orchestration CLI
 site_author: bc contributors
 site_url: https://rpuneet.github.io/bc
 
-repo_name: rpuneet/bc
-repo_url: https://github.com/rpuneet/bc
+repo_name: rpuneet/mycel
+repo_url: https://github.com/rpuneet/mycel
 edit_uri: edit/main/docs/
 
 theme:
@@ -105,4 +105,4 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/rpuneet/bc
+      link: https://github.com/rpuneet/mycel

--- a/packages/bc-cli/README.md
+++ b/packages/bc-cli/README.md
@@ -1,6 +1,6 @@
 # bc-cli
 
-npm installer for [bc](https://github.com/rpuneet/bc) — a CLI-first AI agent orchestration system. bc coordinates teams of Claude, Gemini, Cursor, Codex, and other AI agents working in isolated environments with per-agent git worktrees.
+npm installer for [bc](https://github.com/rpuneet/mycel) — a CLI-first AI agent orchestration system. bc coordinates teams of Claude, Gemini, Cursor, Codex, and other AI agents working in isolated environments with per-agent git worktrees.
 
 This package downloads the pre-built Go binary for your platform on `npm install`. No build tools or Go toolchain required.
 
@@ -47,7 +47,7 @@ The `postinstall` script (`install.mjs`) runs after `npm install` and:
 
 1. Detects your OS and CPU architecture
 2. Fetches the latest release version from the GitHub API
-3. Downloads the matching `bc_VERSION_OS_ARCH.tar.gz` from [GitHub Releases](https://github.com/rpuneet/bc/releases)
+3. Downloads the matching `bc_VERSION_OS_ARCH.tar.gz` from [GitHub Releases](https://github.com/rpuneet/mycel/releases)
 4. Extracts the `bc` binary into `bin/bc`
 5. Verifies the binary runs
 
@@ -59,13 +59,13 @@ If the npm postinstall doesn't work (corporate firewalls, CI restrictions, etc.)
 
 ```bash
 # Homebrew (macOS)
-brew install rpuneet/bc/bc-infra
+brew install rpuneet/mycel/bc-infra
 
 # From source
-git clone https://github.com/rpuneet/bc && cd bc && make install-local-bc
+git clone https://github.com/rpuneet/mycel && cd bc && make install-local-bc
 
 # Direct download
-# https://github.com/rpuneet/bc/releases/latest
+# https://github.com/rpuneet/mycel/releases/latest
 ```
 
 ## Troubleshooting

--- a/packages/bc-cli/install.mjs
+++ b/packages/bc-cli/install.mjs
@@ -15,7 +15,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const BIN_DIR = join(__dirname, "bin");
 const BIN_PATH = join(BIN_DIR, "bc");
-const REPO = "rpuneet/bc";
+const REPO = "rpuneet/mycel";
 
 function getPlatform() {
   const platform = process.platform;
@@ -211,15 +211,15 @@ install().catch((err) => {
   console.error("You can install bc manually:");
   console.error("");
   console.error("  # macOS (Homebrew)");
-  console.error("  brew install rpuneet/bc/bc-infra");
+  console.error("  brew install rpuneet/mycel/bc-infra");
   console.error("");
   console.error("  # From source");
   console.error(
-    "  git clone https://github.com/rpuneet/bc && cd bc && make install-local-bc"
+    "  git clone https://github.com/rpuneet/mycel && cd bc && make install-local-bc"
   );
   console.error("");
   console.error("  # Direct download");
-  console.error("  https://github.com/rpuneet/bc/releases/latest");
+  console.error("  https://github.com/rpuneet/mycel/releases/latest");
   console.error("");
 
   // Exit 0 so npm install doesn't fail — the placeholder script will tell

--- a/packages/bc-cli/package.json
+++ b/packages/bc-cli/package.json
@@ -5,9 +5,9 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/rpuneet/bc"
+    "url": "https://github.com/rpuneet/mycel"
   },
-  "homepage": "https://github.com/rpuneet/bc",
+  "homepage": "https://github.com/rpuneet/mycel",
   "keywords": ["ai", "agents", "orchestration", "claude", "gemini", "cursor", "codex", "cli"],
   "bin": {
     "bc": "bin/bc"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # bc installer script
-# Usage: curl -fsSL https://raw.githubusercontent.com/rpuneet/bc/main/scripts/install.sh | bash
+# Usage: curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash
 
 set -e
 
 # Configuration
-REPO="rpuneet/bc"
+REPO="rpuneet/mycel"
 INSTALL_DIR="${BC_INSTALL_DIR:-/usr/local/bin}"
 BINARY_NAME="bc"
 

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -5,7 +5,7 @@
 #   1. Build from source via `make install-local-bc` and run `bc version`.
 #   2. Dry-run verify scripts/install.sh URL patterns without touching the host.
 #   3. `go install github.com/rpuneet/bc/cmd/bc@latest` into a throwaway GOPATH.
-#   4. Pull + run ghcr.io/rpuneet/bc:v0.1.0 Docker image.
+#   4. Pull + run ghcr.io/rpuneet/mycel:v0.1.0 Docker image.
 #
 # Exit 0 if every test passes, exit 1 if any fail. Individual test failures
 # are reported but do not abort the run — we want the full picture.
@@ -13,9 +13,10 @@
 set -u
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-REPO_SLUG="rpuneet/bc"
+REPO_SLUG="rpuneet/mycel"
 DOCKER_IMAGE="ghcr.io/${REPO_SLUG}:v0.1.0"
-GO_PKG="github.com/${REPO_SLUG}/cmd/bc@latest"
+# Go module path still uses the legacy slug until a separate module rename PR.
+GO_PKG="github.com/rpuneet/bc/cmd/bc@latest"
 INSTALL_SH="${REPO_ROOT}/scripts/install.sh"
 
 # ANSI colors (skip if not a TTY or NO_COLOR set).
@@ -114,13 +115,13 @@ test_install_sh_dry_run() {
         return
     fi
 
-    if ! grep -q 'rpuneet/bc' "$INSTALL_SH"; then
-        echo "  install.sh does not reference rpuneet/bc"
+    if ! grep -q 'rpuneet/mycel' "$INSTALL_SH"; then
+        echo "  install.sh does not reference rpuneet/mycel"
         fail "install-sh-repo-url"
         return
     fi
 
-    if ! grep -qE 'github\.com/rpuneet/bc/releases' "$INSTALL_SH"; then
+    if ! grep -qE 'github\.com/rpuneet/mycel/releases' "$INSTALL_SH"; then
         echo "  install.sh missing GitHub releases URL pattern"
         fail "install-sh-release-url"
         return


### PR DESCRIPTION
Part of #3054

## Summary

The repo was renamed from `rpuneet/bc` to `rpuneet/mycel`. GitHub redirects keep old links alive, but workflows, docs, install scripts, and landing pages should reflect the canonical name. This PR sweeps all non-Go references.

The Go module path (`module github.com/rpuneet/bc` in `go.mod` and every `import` in `*.go`) is intentionally left alone — that's a much bigger blast radius and will land in a follow-up PR.

## What changed

- **Workflows / release**
  - `.github/workflows/release.yml`, `cd-main.yml` — GHCR image tags `ghcr.io/rpuneet/bc:*` → `ghcr.io/rpuneet/mycel:*`, `org.opencontainers.image.source` labels, header comments.
  - `.github/workflows/ci.yml` — `github.repository == 'rpuneet/bc'` guard for codecov upload.
  - `.goreleaser.yml` — release notes template (homebrew, install, docker, changelog URLs).
  - `.github/ISSUE_TEMPLATE/config.yml` — docs and security advisory URLs.
- **Docs**
  - `README.md`, `CONTRIBUTING.md`, `mkdocs.yml`, `docs/how-to/troubleshoot.md`, `docs/proposals/agents-revamp.md`, `docs/reference/cli/bc.md`, `docs/tutorials/getting-started.md` — badges, repo URL, brew tap, GHCR refs.
- **Landing / packages / scripts**
  - `landing/**` — install commands, GitHub stars/license badges, `git clone` URLs, GHCR tags.
  - `packages/bc-cli/{install.mjs,package.json,README.md}` — `REPO` slug, repository URL, brew tap.
  - `scripts/install.sh`, `scripts/test-install.sh` — `REPO` slug, dry-run regex assertions.

## What was NOT changed (deliberately)

- `go.mod` `module github.com/rpuneet/bc` — separate PR.
- All `*.go` imports of `github.com/rpuneet/bc/...`.
- `go install github.com/rpuneet/bc/cmd/bc@latest` lines in README, landing, and `scripts/install.sh` — those reference the Go module path, which has not been renamed yet. They'll be updated in the same PR that renames the module.
- `.github/workflows/ci.yml` line 62 (`SLOW="github.com/rpuneet/bc/pkg/..."`) — these are Go import paths used by `go test`, not GitHub URLs.
- `scripts/test-install.sh` `GO_PKG` is now hardcoded to `github.com/rpuneet/bc/cmd/bc@latest` (instead of derived from `REPO_SLUG`) so the install smoke test still works against the unrenamed module.

## Stranded refs flagged for follow-up

- Existing GHCR images at `ghcr.io/rpuneet/bc:*` (v*, main, main-<sha>) are stranded after the repo rename. The next CD/release run will publish to `ghcr.io/rpuneet/mycel:*`. Old tags should be deleted manually from the GHCR package settings once we're confident nothing pulls them.
- No runtime code paths (CLI / doctor / installer) were found that pull `ghcr.io/rpuneet/bc` at runtime — the only references are in docs/landing install snippets, which this PR updates.

## Test plan

- [x] `landing` builds clean (`bun run build` + `bun run lint`).
- [ ] CI green on this PR.
- [ ] Verify rendered docs / landing previews show new URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository references across the entire project to reflect a new location. Changes include GitHub Actions workflows, Docker image configurations, installation scripts and commands, documentation, package metadata, and CLI tooling. All distribution channels and installation methods now point to the updated repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->