### PR TITLE
fix(landing): restore original particle background animation

### DIFF
--- a/landing/src/app/_components/AnimatedBackground.tsx
+++ b/landing/src/app/_components/AnimatedBackground.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useRef } from "react";
 
 /**
- * Glowing spore network background.
- * 50-60 spores with Brownian motion, proximity connections,
- * mouse attraction, and bloom glow rendering.
+ * Lightweight canvas particle background.
+ * Particles drift very slowly on their own, react to scroll position,
+ * and gently gravitate toward the mouse cursor.
  */
 export function AnimatedBackground() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -17,37 +17,38 @@ export function AnimatedBackground() {
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
 
-    // Check for reduced motion preference
-    const prefersReducedMotion = window.matchMedia(
-      "(prefers-reduced-motion: reduce)",
-    ).matches;
-    if (prefersReducedMotion) return;
-
     let animationId: number;
-    let mouseX = -1;
-    let mouseY = -1;
     let scrollY = 0;
     let prevScrollY = 0;
+    let scrollVelocity = 0;
+    let mouseX = -1;
+    let mouseY = -1;
 
     const dpr = Math.min(window.devicePixelRatio || 1, 2);
 
-    const SPORE_COUNT = 55;
-    const CONNECTION_DISTANCE = 150;
-    const MOUSE_RADIUS = 200;
-    const MOUSE_ATTRACTION = 0.012;
+    // Particle configuration
+    const PARTICLE_COUNT = 40;
+    const CONNECTION_DISTANCE = 120;
     const GRID_CELL_SIZE = CONNECTION_DISTANCE;
+    const MOUSE_RADIUS = 200;
+    const MOUSE_STRENGTH = 0.015;
     let idleFrames = 0;
-    const IDLE_THRESHOLD = 120;
+    const IDLE_THRESHOLD = 120; // ~2s at 60fps before throttling
 
-    interface Spore {
+    interface Particle {
       x: number;
       y: number;
+      z: number;
+      baseX: number;
+      baseY: number;
       vx: number;
       vy: number;
-      radius: number;
+      vz: number;
+      size: number;
+      phase: number;
     }
 
-    let spores: Spore[] = [];
+    let particles: Particle[] = [];
     let width = 0;
     let height = 0;
 
@@ -58,88 +59,103 @@ export function AnimatedBackground() {
       canvas!.height = height * dpr;
       canvas!.style.width = `${width}px`;
       canvas!.style.height = `${height}px`;
-      ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx!.scale(dpr, dpr);
     }
 
-    function initSpores() {
-      spores = [];
-      for (let i = 0; i < SPORE_COUNT; i++) {
-        spores.push({
-          x: Math.random() * width,
-          y: Math.random() * height,
-          vx: (Math.random() - 0.5) * 0.4,
+    function initParticles() {
+      particles = [];
+      for (let i = 0; i < PARTICLE_COUNT; i++) {
+        const x = Math.random() * width;
+        const y = Math.random() * height;
+        particles.push({
+          x,
+          y,
+          z: Math.random() * 400 + 100,
+          baseX: x,
+          baseY: y,
+          vx: (Math.random() - 0.5) * 0.5,
           vy: (Math.random() - 0.5) * 0.4,
-          radius: (2 + Math.random() * 6) * 0.8, // 20% smaller
+          vz: (Math.random() - 0.5) * 0.3,
+          size: Math.random() * 1.5 + 0.5,
+          phase: Math.random() * Math.PI * 2,
         });
       }
     }
 
-    function draw() {
+    function project(x: number, y: number, z: number) {
+      const fov = 600;
+      const scale = fov / (fov + z);
+      return {
+        x: x * scale + width * 0.5 * (1 - scale),
+        y: y * scale + height * 0.5 * (1 - scale),
+        scale,
+      };
+    }
+
+    function draw(time: number) {
       ctx!.clearRect(0, 0, width, height);
 
-      // Scroll delta for parallax
-      const scrollDelta = scrollY - prevScrollY;
+      const isDark = document.documentElement.classList.contains("dark");
+      const particleColor = isDark ? "rgba(234, 88, 12," : "rgba(234, 88, 12,";
+      const lineColor = isDark ? "rgba(251, 146, 60," : "rgba(234, 88, 12,";
+
+      // Smooth scroll velocity (decays each frame)
+      scrollVelocity = scrollVelocity * 0.92 + (scrollY - prevScrollY) * 0.08;
       prevScrollY = scrollY;
 
-      // Update spore positions (Brownian motion)
-      for (const s of spores) {
-        // Parallax: larger spores (closer) move more with scroll
-        // radius ranges ~1.6-6.4, normalize to 0-1 depth factor
-        const depthFactor = (s.radius - 1.6) / 4.8; // 0 = small/far, 1 = large/close
-        s.y -= scrollDelta * (0.02 + depthFactor * 0.06);
-        // Random velocity nudge each frame
-        s.vx += (Math.random() - 0.5) * 0.06;
-        s.vy += (Math.random() - 0.5) * 0.06;
+      // Sort by z for depth ordering
+      particles.sort((a, b) => b.z - a.z);
 
-        // Damping to keep slow
-        s.vx *= 0.98;
-        s.vy *= 0.98;
+      // Update and project particles
+      const projected = particles.map((p) => {
+        // Medium drift
+        p.x += p.vx;
+        p.y += p.vy;
+        p.z += p.vz + Math.sin(time * 0.0004 + p.phase) * 0.08;
 
-        // Clamp velocity
-        const maxV = 0.8;
-        const speed = Math.sqrt(s.vx * s.vx + s.vy * s.vy);
-        if (speed > maxV) {
-          s.vx = (s.vx / speed) * maxV;
-          s.vy = (s.vy / speed) * maxV;
-        }
+        // Scroll influence — particles shift with scroll velocity
+        p.y += scrollVelocity * 0.02;
 
-        // Mouse attraction
+        // Mouse influence — gentle pull toward cursor
         if (mouseX >= 0 && mouseY >= 0) {
-          const dx = mouseX - s.x;
-          const dy = mouseY - s.y;
+          const dx = mouseX - p.x;
+          const dy = mouseY - p.y;
           const dist = Math.sqrt(dx * dx + dy * dy);
           if (dist < MOUSE_RADIUS && dist > 1) {
-            const force = (1 - dist / MOUSE_RADIUS) * MOUSE_ATTRACTION;
-            s.vx += dx * force;
-            s.vy += dy * force;
+            const force = (1 - dist / MOUSE_RADIUS) * MOUSE_STRENGTH;
+            p.x += dx * force;
+            p.y += dy * force;
           }
         }
 
-        s.x += s.vx;
-        s.y += s.vy;
+        // Wrap around
+        if (p.x < -50) p.x = width + 50;
+        if (p.x > width + 50) p.x = -50;
+        if (p.y < -50) p.y = height + 50;
+        if (p.y > height + 50) p.y = -50;
+        if (p.z < 50) p.z = 500;
+        if (p.z > 500) p.z = 50;
 
-        // Wrap around edges
-        if (s.x < -20) s.x = width + 20;
-        if (s.x > width + 20) s.x = -20;
-        if (s.y < -20) s.y = height + 20;
-        if (s.y > height + 20) s.y = -20;
-      }
+        return { ...project(p.x, p.y, p.z), particle: p };
+      });
 
-      // Build spatial grid
+      // Draw connections using spatial grid (O(n) average instead of O(n^2))
       const grid = new Map<string, number[]>();
-      for (let i = 0; i < spores.length; i++) {
-        const cx = Math.floor(spores[i].x / GRID_CELL_SIZE);
-        const cy = Math.floor(spores[i].y / GRID_CELL_SIZE);
-        const key = `${cx},${cy}`;
+      for (let i = 0; i < projected.length; i++) {
+        const cellX = Math.floor(projected[i].x / GRID_CELL_SIZE);
+        const cellY = Math.floor(projected[i].y / GRID_CELL_SIZE);
+        const key = `${cellX},${cellY}`;
         const cell = grid.get(key);
-        if (cell) cell.push(i);
-        else grid.set(key, [i]);
+        if (cell) {
+          cell.push(i);
+        } else {
+          grid.set(key, [i]);
+        }
       }
 
-      // Draw connections between nearby spores
-      ctx!.save();
       for (const [key, indices] of grid) {
         const [cx, cy] = key.split(",").map(Number);
+        // Check this cell and 4 neighbors (right, below, below-left, below-right) to avoid double-checking
         const neighborKeys = [
           key,
           `${cx + 1},${cy}`,
@@ -153,105 +169,59 @@ export function AnimatedBackground() {
           for (const i of indices) {
             for (const j of neighbors) {
               if (j <= i) continue;
-              const a = spores[i];
-              const b = spores[j];
+              const a = projected[i];
+              const b = projected[j];
               const dx = a.x - b.x;
               const dy = a.y - b.y;
               const dist = Math.sqrt(dx * dx + dy * dy);
               if (dist < CONNECTION_DISTANCE) {
-                const opacity = (1 - dist / CONNECTION_DISTANCE) * 0.25;
-
-                // Bloom pass (thick, faint) — 10% thinner
+                const opacity =
+                  (1 - dist / CONNECTION_DISTANCE) *
+                  0.12 *
+                  Math.min(a.scale, b.scale);
+                ctx!.strokeStyle = `${lineColor}${opacity})`;
+                ctx!.lineWidth = 0.5;
                 ctx!.beginPath();
                 ctx!.moveTo(a.x, a.y);
                 ctx!.lineTo(b.x, b.y);
-                ctx!.strokeStyle = `rgba(234, 88, 12, ${opacity * 0.3})`;
-                ctx!.lineWidth = 2.7;
-                ctx!.shadowColor = "#EA580C";
-                ctx!.shadowBlur = 10;
-                ctx!.stroke();
-
-                // Sharp pass (thin, bright) — 10% thinner
-                ctx!.beginPath();
-                ctx!.moveTo(a.x, a.y);
-                ctx!.lineTo(b.x, b.y);
-                ctx!.strokeStyle = `rgba(234, 88, 12, ${opacity * 0.8})`;
-                ctx!.lineWidth = 0.72;
-                ctx!.shadowBlur = 0;
                 ctx!.stroke();
               }
             }
           }
         }
       }
-      ctx!.restore();
 
-      // Draw mouse connections
-      if (mouseX >= 0 && mouseY >= 0) {
-        for (const s of spores) {
-          const dx = mouseX - s.x;
-          const dy = mouseY - s.y;
-          const dist = Math.sqrt(dx * dx + dy * dy);
-          if (dist < MOUSE_RADIUS) {
-            const opacity = (1 - dist / MOUSE_RADIUS) * 0.2;
-            ctx!.beginPath();
-            ctx!.moveTo(s.x, s.y);
-            ctx!.lineTo(mouseX, mouseY);
-            ctx!.strokeStyle = `rgba(253, 186, 116, ${opacity})`;
-            ctx!.lineWidth = 0.54;
-            ctx!.stroke();
-          }
+      // Draw particles
+      for (const p of projected) {
+        const opacity = 0.35 * p.scale;
+        const r = p.particle.size * p.scale * 2;
+        ctx!.fillStyle = `${particleColor}${opacity})`;
+        ctx!.beginPath();
+        ctx!.arc(p.x, p.y, r, 0, Math.PI * 2);
+        ctx!.fill();
+
+        // Glow effect for closer particles
+        if (p.scale > 0.7) {
+          const glow = ctx!.createRadialGradient(p.x, p.y, 0, p.x, p.y, r * 4);
+          glow.addColorStop(0, `${particleColor}${opacity * 0.25})`);
+          glow.addColorStop(1, `${particleColor}0)`);
+          ctx!.fillStyle = glow;
+          ctx!.beginPath();
+          ctx!.arc(p.x, p.y, r * 4, 0, Math.PI * 2);
+          ctx!.fill();
         }
       }
 
-      // Draw spore nodes
-      for (const s of spores) {
-        // Mouse proximity brightness boost
-        let brightnessBoost = 0;
-        if (mouseX >= 0 && mouseY >= 0) {
-          const dx = mouseX - s.x;
-          const dy = mouseY - s.y;
-          const dist = Math.sqrt(dx * dx + dy * dy);
-          if (dist < MOUSE_RADIUS) {
-            brightnessBoost = (1 - dist / MOUSE_RADIUS) * 0.5;
-          }
-        }
-
-        const baseOpacity = 0.5 + brightnessBoost;
-
-        // Glow (radial gradient)
-        const glowRadius = s.radius * 4;
-        const glow = ctx!.createRadialGradient(
-          s.x, s.y, 0,
-          s.x, s.y, glowRadius,
-        );
-        glow.addColorStop(0, `rgba(253, 186, 116, ${(0.15 + brightnessBoost * 0.2)})`);
-        glow.addColorStop(1, "rgba(253, 186, 116, 0)");
-        ctx!.fillStyle = glow;
-        ctx!.beginPath();
-        ctx!.arc(s.x, s.y, glowRadius, 0, Math.PI * 2);
-        ctx!.fill();
-
-        // Bright core
-        ctx!.beginPath();
-        ctx!.arc(s.x, s.y, s.radius, 0, Math.PI * 2);
-        ctx!.fillStyle = `rgba(251, 146, 60, ${baseOpacity})`;
-        ctx!.shadowColor = "#EA580C";
-        ctx!.shadowBlur = 8 + brightnessBoost * 16;
-        ctx!.fill();
-        ctx!.shadowBlur = 0;
-      }
-
-      // Adaptive frame rate
-      const hasMotion = mouseX >= 0;
+      // Adaptive frame rate: 60fps when active, ~15fps when idle (2s no interaction)
+      const hasMotion = Math.abs(scrollVelocity) > 0.1 || mouseX >= 0;
       if (hasMotion) {
         idleFrames = 0;
         animationId = requestAnimationFrame(draw);
       } else {
         idleFrames++;
-        const delay = idleFrames > IDLE_THRESHOLD ? 66 : 0;
+        const delay = idleFrames > IDLE_THRESHOLD ? 66 : 0; // ~15fps idle, 60fps active
         if (delay > 0) {
-          animationId = window.setTimeout(
+          animationId = setTimeout(
             () => requestAnimationFrame(draw),
             delay,
           ) as unknown as number;
@@ -275,8 +245,14 @@ export function AnimatedBackground() {
       mouseY = -1;
     }
 
+    // Check for reduced motion preference
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    if (prefersReducedMotion) return;
+
     resize();
-    initSpores();
+    initParticles();
     animationId = requestAnimationFrame(draw);
 
     window.addEventListener("resize", resize);


### PR DESCRIPTION
Reverts the AnimatedBackground.tsx change from #3004 (mycel rebrand) — keeps the rest of the rebrand (logo, copy, theme) but restores the original particle animation that ran on bc-infra.com pre-rebrand.

The rebrand swapped a 'Lightweight canvas particle background' (drifting particles, scroll/cursor reactions) for a 'Glowing spore network' (Brownian motion, bloom glow). Per Puneet's preference, restoring the original.

Single file change. `bun run build` passes locally, generates 10 static pages.