### PR TITLE
test(cmd): isolate integration tests with httptest.Server

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,9 +74,31 @@ func setupIntegrationWorkspace(t *testing.T) (string, func()) {
 	}
 }
 
+// executeIntegrationCmdT runs rootCmd with an isolated fake bcd server.
+// If handler is non-nil, it overrides the package-level fake bcd handler
+// for the duration of the test. The default handler (set in TestMain)
+// returns 200 on /health and 404 elsewhere — enough to exercise CLI
+// error paths without ever reaching the real bcd at :9374.
+//
+// Prefer this over executeIntegrationCmd when a test wants to assert
+// against bcd responses (e.g. a successful agent send). Otherwise the
+// plain executeIntegrationCmd is fine — TestMain pins BC_DAEMON_ADDR
+// at the fake server for the whole test process.
+func executeIntegrationCmdT(t *testing.T, handler http.HandlerFunc, args ...string) (string, string, error) {
+	t.Helper()
+	if handler != nil {
+		setTestBcdHandler(t, handler)
+	}
+	return executeIntegrationCmd(args...)
+}
+
 // executeIntegrationCmd runs rootCmd with the given args, capturing real stdout output.
 // Commands use fmt.Printf/Println (writing to os.Stdout), so we redirect
 // os.Stdout to a pipe to capture output. Returns captured stdout and any error.
+//
+// All callers are automatically isolated from the production bcd: TestMain
+// starts a fake httptest.Server and pins BC_DAEMON_ADDR to it for the
+// entire test process.
 func executeIntegrationCmd(args ...string) (string, string, error) {
 	// Save and redirect os.Stdout
 	origStdout := os.Stdout
@@ -146,12 +169,25 @@ func TestAgentSendNoWorkspace(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(origDir) }()
 
-	_, _, err = executeIntegrationCmd("agent", "send", "worker-01", "hello")
+	// Use the per-test handler variant so this test additionally asserts
+	// no bcd traffic is generated when there's no workspace: any request
+	// the CLI makes would be a bug (workspace check must run first).
+	bcdHit := false
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			bcdHit = true
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+	_, _, err = executeIntegrationCmdT(t, handler, "agent", "send", "worker-01", "hello")
 	if err == nil {
 		t.Fatal("expected error when not in workspace, got nil")
 	}
 	if !strings.Contains(err.Error(), "not in a bc workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
+	}
+	if bcdHit {
+		t.Error("CLI should not contact bcd when there is no workspace")
 	}
 }
 

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -1,13 +1,80 @@
 package cmd
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
 
 	"github.com/rpuneet/bc/pkg/agent"
 )
 
+// testBcdHandler is the handler used by the package-level fake bcd server.
+// Tests can swap it via setTestBcdHandler / resetTestBcdHandler to assert
+// against bcd interactions; the default returns 404 for every path so that
+// "no agent found" / "not in workspace" code paths are exercised without
+// reaching a real bcd.
+//
+// IMPORTANT: this server protects production bcd from `go test` runs.
+// Without it, executeIntegrationCmd would resolve BC_DAEMON_ADDR to the
+// real daemon at 127.0.0.1:9374 and hammer it during CI / dev test runs.
+var testBcdHandler atomic.Value // stores http.HandlerFunc
+
+func defaultTestBcdHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// /health must succeed so newDaemonClient.Ping() doesn't fail
+		// before workspace checks complete.
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+// setTestBcdHandler swaps the active fake-bcd handler for the duration
+// of the test, restoring the default on cleanup.
+func setTestBcdHandler(t *testing.T, h http.HandlerFunc) {
+	t.Helper()
+	prev := testBcdHandler.Load()
+	testBcdHandler.Store(h)
+	t.Cleanup(func() {
+		if prev != nil {
+			testBcdHandler.Store(prev)
+		} else {
+			testBcdHandler.Store(defaultTestBcdHandler())
+		}
+	})
+}
+
 func TestMain(m *testing.M) {
+	// Start a fake bcd server for the entire test process so no test
+	// accidentally reaches the real bcd. Individual tests can override
+	// the handler via setTestBcdHandler.
+	testBcdHandler.Store(defaultTestBcdHandler())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h, _ := testBcdHandler.Load().(http.HandlerFunc)
+		if h == nil {
+			http.NotFound(w, r)
+			return
+		}
+		h.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+
+	// Force the bc client to talk to our fake server, not the real bcd.
+	_ = os.Setenv("BC_DAEMON_ADDR", srv.URL)
+
+	// Clear workspace env vars inherited from the dev's shell so tests
+	// that intentionally chdir to a tmpDir (and expect "not in a bc
+	// workspace") don't accidentally pick up the developer's BC_WORKSPACE
+	// pointing at the bc repo. Tests that need a workspace set this
+	// explicitly via t.Setenv in setupIntegrationWorkspace.
+	_ = os.Unsetenv("BC_WORKSPACE")
+	_ = os.Unsetenv("BC_AGENT_WORKTREE")
+
 	// Setup roles for tests - mirrors pkg/agent/agent_test.go TestMain
 	agent.RoleCapabilities[agent.Role("engineer")] = []agent.Capability{agent.CapImplementTasks}
 	agent.RoleCapabilities[agent.Role("manager")] = []agent.Capability{agent.CapAssignWork, agent.CapCreateAgents}


### PR DESCRIPTION
Fixes #3057

## Summary

`go test ./internal/cmd/...` runs reached the **production bcd** at `127.0.0.1:9374`, hammering it with 404s. This was the root cause of the bcd-dying-all-day pattern: subagents running these tests caused real bcd shutdown cascades.

The CLI's `client.discoverDaemon()` falls back to `DefaultHTTPAddr` when `BC_DAEMON_ADDR` is not set, so any test that runs `executeIntegrationCmd` and proceeds past the workspace check sent traffic to the real daemon.

## Fix

- **TestMain** in `internal/cmd/setup_test.go` now starts a package-level `httptest.Server` and pins `BC_DAEMON_ADDR` to its URL for the entire test process. Every `executeIntegrationCmd` call is automatically isolated.
- The default fake handler returns 200 on `/health` (so `newDaemonClient.Ping` succeeds for tests that legitimately need to proceed) and 404 on all other paths.
- `TestMain` also clears inherited `BC_WORKSPACE` / `BC_AGENT_WORKTREE` env vars from the dev's shell so "not in a bc workspace" tests behave deterministically regardless of where `go test` is invoked from.
- New `executeIntegrationCmdT(t, handler, args...)` and `setTestBcdHandler(t, h)` helpers let individual tests inject custom handlers (e.g. to assert specific bcd interactions).
- `TestAgentSendNoWorkspace` now additionally asserts the CLI makes **zero** bcd requests when no workspace is found — guarding against future regressions to the workspace-check ordering in `newDaemonClient`.

The `BC_TEST_DAEMON` skip in `setupIntegrationWorkspace` is preserved unchanged — that gates a separate workspace-required test path and is independent of this isolation fix.

## CLI ordering verification

Confirmed `internal/cmd/init.go:newDaemonClient` already calls `getWorkspace()` **before** `client.Ping()`. The "not in a bc workspace" error path is correct; the test failures were purely from inherited env causing the workspace check to succeed against the dev's repo, then `Ping` hitting real bcd. No CLI code changes needed.

## Test plan

- [x] `go test ./internal/cmd/... -count=1 -race` passes with **no bcd running**
- [x] `make check-go` clean (lint + vet + tests)
- [x] `TestAgentSendNoWorkspace` verifies zero bcd traffic on workspace-missing path

🤖 Generated with [Claude Code](https://claude.com/claude-code)