### PR TITLE
chore(release): rename binary and tarballs from bc_* to mycel_* (preps v0.2.3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,14 +147,14 @@ jobs:
           LDFLAGS="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}"
 
           # arm64 (native on macos-latest)
-          CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o dist/bc ./cmd/bc
-          tar -C dist -czvf "dist/bc_${VERSION}_darwin_arm64.tar.gz" bc
-          rm dist/bc
+          CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o dist/mycel ./cmd/bc
+          tar -C dist -czvf "dist/mycel_${VERSION}_darwin_arm64.tar.gz" mycel
+          rm dist/mycel
 
           # amd64 (cross-compile — macOS supports this natively via universal toolchain)
-          CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/bc ./cmd/bc
-          tar -C dist -czvf "dist/bc_${VERSION}_darwin_amd64.tar.gz" bc
-          rm dist/bc
+          CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -ldflags="${LDFLAGS}" -o dist/mycel ./cmd/bc
+          tar -C dist -czvf "dist/mycel_${VERSION}_darwin_amd64.tar.gz" mycel
+          rm dist/mycel
 
           cd dist && shasum -a 256 *.tar.gz > checksums-macos.txt
 
@@ -163,7 +163,7 @@ jobs:
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           files: |
-            dist/bc_*.tar.gz
+            dist/mycel_*.tar.gz
             dist/checksums-macos.txt
           fail_on_unmatched_files: false
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@
 
 version: 2
 
-project_name: bc
+project_name: mycel
 
 before:
   hooks:
@@ -15,9 +15,9 @@ before:
 
 builds:
   # Linux amd64 — native CGO
-  - id: bc-linux-amd64
+  - id: mycel-linux-amd64
     main: ./cmd/bc
-    binary: bc
+    binary: mycel
     env:
       - CGO_ENABLED=1
     ldflags:
@@ -31,9 +31,9 @@ builds:
       - amd64
 
   # Linux arm64 — CGO via Zig cross-compiler
-  - id: bc-linux-arm64
+  - id: mycel-linux-arm64
     main: ./cmd/bc
-    binary: bc
+    binary: mycel
     env:
       - CGO_ENABLED=1
       - CC=zig cc -target aarch64-linux-musl -lc
@@ -49,9 +49,9 @@ builds:
       - arm64
 
   # Windows — CGO disabled (pure Go)
-  - id: bc-windows
+  - id: mycel-windows
     main: ./cmd/bc
-    binary: bc
+    binary: mycel
     env:
       - CGO_ENABLED=0
     ldflags:
@@ -118,12 +118,12 @@ changelog:
 release:
   github:
     owner: rpuneet
-    name: bc
+    name: mycel
   draft: false
   prerelease: auto
   mode: append
   header: |
-    ## bc {{ .Tag }}
+    ## mycel {{ .Tag }}
 
     Orchestration for AI agents.
 
@@ -131,22 +131,22 @@ release:
 
     | Method | Command |
     |--------|---------|
-    | **Homebrew** (macOS) | `brew install rpuneet/mycel/bc` |
+    | **Homebrew** (macOS) | `brew install rpuneet/mycel/mycel` |
     | **npm / bun** (Linux) | `npm install -g bc-cli` or `bunx bc-cli` |
     | **Go** | `go install github.com/rpuneet/mycel/cmd/bc@{{ .Tag }}` |
     | **Script** | `curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh \| bash` |
     | **Docker** | `docker pull ghcr.io/rpuneet/mycel:{{ .Tag }}` |
-    | **Scoop** (Windows) | `scoop bucket add bc https://github.com/rpuneet/scoop-bc && scoop install bc` |
+    | **Scoop** (Windows) | `scoop bucket add mycel https://github.com/rpuneet/scoop-mycel && scoop install mycel` |
   footer: |
     ---
 
     **Full Changelog**: https://github.com/rpuneet/mycel/compare/{{ .PreviousTag }}...{{ .Tag }}
 
 brews:
-  - name: bc
+  - name: mycel
     repository:
       owner: rpuneet
-      name: homebrew-bc
+      name: homebrew-mycel
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
       branch: main
     directory: Formula
@@ -155,15 +155,15 @@ brews:
     license: MIT
     skip_upload: auto
     install: |
-      bin.install "bc"
+      bin.install "mycel"
     test: |
-      system "#{bin}/bc", "version"
+      system "#{bin}/mycel", "version"
 
 scoops:
-  - name: bc
+  - name: mycel
     repository:
       owner: rpuneet
-      name: scoop-bc
+      name: scoop-mycel
       token: "{{ .Env.SCOOP_TAP_TOKEN }}"
       branch: main
     homepage: https://bc-infra.com
@@ -172,8 +172,8 @@ scoops:
     skip_upload: auto
 
 nfpms:
-  - id: bc-linux
-    package_name: bc
+  - id: mycel-linux
+    package_name: mycel
     homepage: https://bc-infra.com
     description: Orchestration for AI agents
     license: MIT

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# bc installer script
+# mycel installer script
 # Usage: curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh | bash
 
 set -e
 
 # Configuration
 REPO="rpuneet/mycel"
-INSTALL_DIR="${BC_INSTALL_DIR:-/usr/local/bin}"
-BINARY_NAME="bc"
+INSTALL_DIR="${MYCEL_INSTALL_DIR:-${BC_INSTALL_DIR:-/usr/local/bin}}"
+BINARY_NAME="mycel"
 
 # Colors
 RED='\033[0;31m'
@@ -65,7 +65,7 @@ detect_platform() {
 
     # Linux arm64 builds are not yet available
     if [ "$OS" = "linux" ] && [ "$ARCH" = "arm64" ]; then
-        error "Linux arm64 builds are not yet available. Please build from source: go install github.com/rpuneet/bc/cmd/bc@latest"
+        error "Linux arm64 builds are not yet available. Please build from source: go install github.com/rpuneet/mycel/cmd/bc@latest"
     fi
 
     info "Detecting OS... ${OS} ${ARCH}"
@@ -85,13 +85,13 @@ get_latest_version() {
 
 # Download and install binary
 download_and_install() {
-    # Archive naming: bc_VERSION_OS_ARCH.tar.gz (version without leading v)
+    # Archive naming: mycel_VERSION_OS_ARCH.tar.gz (version without leading v)
     VERSION_NUM="${VERSION#v}"
-    ARCHIVE_NAME="bc_${VERSION_NUM}_${OS}_${ARCH}.tar.gz"
+    ARCHIVE_NAME="mycel_${VERSION_NUM}_${OS}_${ARCH}.tar.gz"
     DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE_NAME}"
     TMP_DIR=$(mktemp -d)
 
-    info "Downloading bc ${VERSION}..."
+    info "Downloading mycel ${VERSION}..."
 
     if ! curl -fsSL "$DOWNLOAD_URL" -o "${TMP_DIR}/${ARCHIVE_NAME}"; then
         rm -rf "$TMP_DIR"
@@ -110,7 +110,7 @@ download_and_install() {
     info "Extracting archive..."
     tar -xzf "${TMP_DIR}/${ARCHIVE_NAME}" -C "$TMP_DIR"
 
-    TMP_FILE="${TMP_DIR}/bc"
+    TMP_FILE="${TMP_DIR}/mycel"
     if [ ! -f "$TMP_FILE" ]; then
         rm -rf "$TMP_DIR"
         error "Binary not found in archive."
@@ -136,7 +136,7 @@ verify_installation() {
     info "Verifying installation..."
 
     if [ -x "${INSTALL_DIR}/${BINARY_NAME}" ]; then
-        success "bc installed successfully!"
+        success "mycel installed successfully!"
     else
         error "Installation failed. Binary not found."
     fi
@@ -145,7 +145,7 @@ verify_installation() {
 # Check dependencies
 check_dependencies() {
     if ! command -v tmux &> /dev/null; then
-        warn "tmux is not installed (required for bc agents)"
+        warn "tmux is not installed (required for mycel agents)"
         echo ""
         case "$OS" in
             darwin)
@@ -162,12 +162,12 @@ check_dependencies() {
 # Print next steps
 print_next_steps() {
     echo ""
-    success "Run 'bc' to get started."
+    success "Run 'mycel' to get started."
     echo ""
     echo "Quick start:"
-    echo "  bc init          # Initialize workspace"
-    echo "  bc up            # Start server"
-    echo "  bc up -d         # Start as daemon"
+    echo "  mycel init          # Initialize workspace"
+    echo "  mycel up            # Start server"
+    echo "  mycel up -d         # Start as daemon"
     echo ""
     echo "Documentation: https://github.com/${REPO}#readme"
 }
@@ -175,8 +175,8 @@ print_next_steps() {
 # Main
 main() {
     echo ""
-    echo "bc Installer"
-    echo "============"
+    echo "mycel Installer"
+    echo "==============="
     echo ""
 
     detect_platform


### PR DESCRIPTION
Part of #3054

## Summary

Aligns release artifacts with the **mycel** rebrand ahead of v0.2.3:

- CLI binary renamed `bc` → `mycel`
- Release tarballs become `mycel_<version>_<os>_<arch>.tar.gz`
- Goreleaser brews/scoops/nfpms updated
- install.sh fetches and installs `mycel`
- macOS workflow builds emit `mycel` binary

**Breaking change for end-users**: the installed CLI invocation changes from `bc` to `mycel`. Homebrew users will get the new binary on the next upgrade; `install.sh` consumers pick it up automatically.

## Untouched (intentional)

- Go module path (`go.mod` stays `github.com/rpuneet/bc` for now — separate effort)
- `cmd/bc/main.go` package path
- Existing v0.2.2 release assets

## Test plan

- [x] `make check-go` passes locally
- [x] `make check-ts` — TUI failures (TabBar 80x24) are pre-existing on main, unrelated
- [x] `bash -n scripts/install.sh` syntax OK
- [ ] CI green
- [ ] After merge, tag v0.2.3 → release workflow produces `mycel_*.tar.gz`
- [ ] `brew install rpuneet/mycel/mycel` end-to-end smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)