### PR TITLE
fix(landing): update install/CLI commands for v0.2.3 mycel binary

### DIFF
--- a/landing/docs/cli-reference.md
+++ b/landing/docs/cli-reference.md
@@ -19,16 +19,16 @@ Complete command reference for the mycel multi-agent orchestration system.
 
 ## Workspace Commands
 
-### bc init
-Initialize a new bc workspace.
+### mycel init
+Initialize a new mycel workspace.
 
 ```bash
-bc init                        # Interactive wizard
-bc init --quick                # Quick init with defaults
-bc init --preset solo          # Use solo developer preset
-bc init --preset small-team    # Use small team preset
-bc init --preset full-team     # Use full team preset
-bc init ~/Projects/myapp       # Initialize specific directory
+mycel init                        # Interactive wizard
+mycel init --quick                # Quick init with defaults
+mycel init --preset solo          # Use solo developer preset
+mycel init --preset small-team    # Use small team preset
+mycel init --preset full-team     # Use full team preset
+mycel init ~/Projects/myapp       # Initialize specific directory
 ```
 
 **Creates:**
@@ -38,34 +38,34 @@ bc init ~/Projects/myapp       # Initialize specific directory
 
 ---
 
-### bc up
+### mycel up
 Start the root agent via the bcd daemon.
 
 ```bash
-bc up                      # Start root agent
-bc up --agent cursor       # Use Cursor AI for agents
-bc up --runtime docker     # Use Docker runtime
+mycel up                      # Start root agent
+mycel up --agent cursor       # Use Cursor AI for agents
+mycel up --runtime docker     # Use Docker runtime
 ```
 
 ---
 
-### bc down
+### mycel down
 Stop all running agents.
 
 ```bash
-bc down          # Stop all agents
-bc down --force  # Force kill without cleanup
+mycel down          # Stop all agents
+mycel down --force  # Force kill without cleanup
 ```
 
 ---
 
-### bc status
+### mycel status
 Show agent status overview.
 
 ```bash
-bc status                   # Show all agents
-bc status --json            # Output as JSON
-bc status --activity        # Show recent channel activity
+mycel status                   # Show all agents
+mycel status --json            # Output as JSON
+mycel status --activity        # Show recent channel activity
 ```
 
 **Output:**
@@ -77,11 +77,11 @@ eng-02    engineer  idle     1h 30m    -
 
 ---
 
-### bc home
+### mycel home
 Open the TUI dashboard.
 
 ```bash
-bc home
+mycel home
 ```
 
 **Navigation:**
@@ -92,34 +92,34 @@ bc home
 
 ---
 
-### bc workspace
+### mycel workspace
 Manage workspaces.
 
 ```bash
-bc workspace info                   # Show workspace details
-bc workspace status                 # Show agents and health
-bc workspace list                   # List discovered workspaces
-bc workspace list --scan ~/Projects # Scan additional paths
-bc workspace discover               # Discover and register new workspaces
-bc ws up                            # Start all roster agents
+mycel workspace info                   # Show workspace details
+mycel workspace status                 # Show agents and health
+mycel workspace list                   # List discovered workspaces
+mycel workspace list --scan ~/Projects # Scan additional paths
+mycel workspace discover               # Discover and register new workspaces
+mycel ws up                            # Start all roster agents
 ```
 
 ---
 
 ## Agent Management
 
-### bc agent create
+### mycel agent create
 Create and start a new agent.
 
 ```bash
-bc agent create --role engineer              # Create with random name
-bc agent create worker-01                    # Create with explicit name
-bc agent create eng-01 --role engineer       # Create engineer
-bc agent create qa-01 --role qa --tool cursor # Create QA with Cursor
+mycel agent create --role engineer              # Create with random name
+mycel agent create worker-01                    # Create with explicit name
+mycel agent create eng-01 --role engineer       # Create engineer
+mycel agent create qa-01 --role qa --tool cursor # Create QA with Cursor
 ```
 
 **Options:**
-- `--role` - Agent role (required). Use `bc role list` to see available roles
+- `--role` - Agent role (required). Use `mycel role list` to see available roles
 - `--tool` - AI tool (claude, gemini, cursor, codex, opencode, openclaw, aider)
 - `--runtime` - Runtime backend: tmux or docker
 - `--parent` - Parent agent ID
@@ -128,112 +128,112 @@ bc agent create qa-01 --role qa --tool cursor # Create QA with Cursor
 
 ---
 
-### bc agent list
+### mycel agent list
 List all agents.
 
 ```bash
-bc agent list                  # List all agents
-bc agent list --json           # Output as JSON
-bc agent list --role engineer  # Filter by role
-bc agent list --status running # Filter by status
+mycel agent list                  # List all agents
+mycel agent list --json           # Output as JSON
+mycel agent list --role engineer  # Filter by role
+mycel agent list --status running # Filter by status
 ```
 
 ---
 
-### bc agent attach
+### mycel agent attach
 Attach to an agent's tmux session.
 
 ```bash
-bc agent attach eng-01   # Attach to eng-01
+mycel agent attach eng-01   # Attach to eng-01
 ```
 
 Use `Ctrl+b d` to detach and return to your shell.
 
 ---
 
-### bc agent peek
+### mycel agent peek
 View recent output from an agent's session.
 
 ```bash
-bc agent peek eng-01              # Show last 500 lines
-bc agent peek eng-01 --lines 100  # Show last 100 lines
-bc agent peek eng-01 --follow     # Stream live output (Ctrl+C to stop)
+mycel agent peek eng-01              # Show last 500 lines
+mycel agent peek eng-01 --lines 100  # Show last 100 lines
+mycel agent peek eng-01 --follow     # Stream live output (Ctrl+C to stop)
 ```
 
 ---
 
-### bc agent send
+### mycel agent send
 Send a message to an agent.
 
 ```bash
-bc agent send eng-01 "run the tests"
-bc agent send eng-01 "implement login" --preview  # Preview before sending
+mycel agent send eng-01 "run the tests"
+mycel agent send eng-01 "implement login" --preview  # Preview before sending
 ```
 
 ---
 
-### bc agent broadcast
+### mycel agent broadcast
 Send a message to all running agents.
 
 ```bash
-bc agent broadcast "run tests"
-bc agent broadcast "check status"
+mycel agent broadcast "run tests"
+mycel agent broadcast "check status"
 ```
 
 ---
 
-### bc agent send-to-role
+### mycel agent send-to-role
 Send a message to all agents of a role.
 
 ```bash
-bc agent send-to-role engineer "run the tests"
-bc agent send-to-role manager "check status"
+mycel agent send-to-role engineer "run the tests"
+mycel agent send-to-role manager "check status"
 ```
 
 ---
 
-### bc agent send-pattern
+### mycel agent send-pattern
 Send a message to agents matching a name pattern.
 
 ```bash
-bc agent send-pattern "eng-*" "run tests"
-bc agent send-pattern "*-lead" "review PRs"
+mycel agent send-pattern "eng-*" "run tests"
+mycel agent send-pattern "*-lead" "review PRs"
 ```
 
 ---
 
-### bc agent stop / start / delete
+### mycel agent stop / start / delete
 
 ```bash
-bc agent stop eng-01               # Stop agent
-bc agent stop eng-01 --force       # Force stop
-bc agent start eng-01              # Restart stopped agent
-bc agent start eng-01 --fresh      # Force new session
-bc agent delete eng-01             # Delete agent (preserves memory)
-bc agent delete eng-01 --purge     # Delete including memory
+mycel agent stop eng-01               # Stop agent
+mycel agent stop eng-01 --force       # Force stop
+mycel agent start eng-01              # Restart stopped agent
+mycel agent start eng-01 --fresh      # Force new session
+mycel agent delete eng-01             # Delete agent (preserves memory)
+mycel agent delete eng-01 --purge     # Delete including memory
 ```
 
 ---
 
-### bc agent report
+### mycel agent report
 Report agent state (used inside agent sessions).
 
 ```bash
-bc agent report working "fixing auth bug"
-bc agent report done "auth bug fixed"
-bc agent report stuck "need database credentials"
-bc agent report stuck --reason "TUI freezes" --severity high
+mycel agent report working "fixing auth bug"
+mycel agent report done "auth bug fixed"
+mycel agent report stuck "need database credentials"
+mycel agent report stuck --reason "TUI freezes" --severity high
 ```
 
 ---
 
-### bc agent health
+### mycel agent health
 Check agent health status.
 
 ```bash
-bc agent health              # Check all agents
-bc agent health eng-01       # Check specific agent
-bc agent health --detect-stuck --alert eng  # Alert on stuck
+mycel agent health              # Check all agents
+mycel agent health eng-01       # Check specific agent
+mycel agent health --detect-stuck --alert eng  # Alert on stuck
 ```
 
 ---
@@ -241,74 +241,74 @@ bc agent health --detect-stuck --alert eng  # Alert on stuck
 ### Other agent commands
 
 ```bash
-bc agent show eng-01         # Show agent details
-bc agent rename old new      # Rename an agent
-bc agent cost eng-01         # Show agent cost
-bc agent logs eng-01         # Show agent event history
-bc agent sessions eng-01     # Show session IDs
-bc agent stats eng-01        # Docker resource stats
-bc agent auth my-agent       # Authenticate for Docker
+mycel agent show eng-01         # Show agent details
+mycel agent rename old new      # Rename an agent
+mycel agent cost eng-01         # Show agent cost
+mycel agent logs eng-01         # Show agent event history
+mycel agent sessions eng-01     # Show session IDs
+mycel agent stats eng-01        # Docker resource stats
+mycel agent auth my-agent       # Authenticate for Docker
 ```
 
 ---
 
 ## Channels & Communication
 
-### bc channel create / delete
+### mycel channel create / delete
 
 ```bash
-bc channel create workers            # Create a channel
-bc channel create workers --desc "Worker discussion"
-bc channel delete workers            # Delete a channel
+mycel channel create workers            # Create a channel
+mycel channel create workers --desc "Worker discussion"
+mycel channel delete workers            # Delete a channel
 ```
 
 ---
 
-### bc channel send
+### mycel channel send
 
 ```bash
-bc channel send workers "run tests"  # Send to all members
+mycel channel send workers "run tests"  # Send to all members
 ```
 
 ---
 
-### bc channel list / show / status
+### mycel channel list / show / status
 
 ```bash
-bc channel list                      # List all channels
-bc channel show workers              # Show channel details
-bc channel status                    # Overview with activity
+mycel channel list                      # List all channels
+mycel channel show workers              # Show channel details
+mycel channel status                    # Overview with activity
 ```
 
 ---
 
-### bc channel history
+### mycel channel history
 
 ```bash
-bc channel history eng                       # Last 50 messages
-bc channel history eng --last 20             # Last 20 messages
-bc channel history eng --since 1h            # Messages from last hour
-bc channel history eng --agent agent-core    # Filter by sender
+mycel channel history eng                       # Last 50 messages
+mycel channel history eng --last 20             # Last 20 messages
+mycel channel history eng --since 1h            # Messages from last hour
+mycel channel history eng --agent agent-core    # Filter by sender
 ```
 
 ---
 
-### bc channel add / remove / join / leave
+### mycel channel add / remove / join / leave
 
 ```bash
-bc channel add workers worker-01     # Add member
-bc channel remove workers worker-01  # Remove member
-bc channel join workers              # Join (agent session)
-bc channel leave workers             # Leave (agent session)
+mycel channel add workers worker-01     # Add member
+mycel channel remove workers worker-01  # Remove member
+mycel channel join workers              # Join (agent session)
+mycel channel leave workers             # Leave (agent session)
 ```
 
 ---
 
-### bc channel react / edit
+### mycel channel react / edit
 
 ```bash
-bc channel react engineering 5 thumbsup  # React to message
-bc channel edit eng --desc "Engineering" # Edit description
+mycel channel react engineering 5 thumbsup  # React to message
+mycel channel edit eng --desc "Engineering" # Edit description
 ```
 
 ---
@@ -316,51 +316,51 @@ bc channel edit eng --desc "Engineering" # Edit description
 ## Cost Tracking
 
 ```bash
-bc cost                              # Show cost records
-bc cost show eng-01                  # Show costs for agent
-bc cost summary                      # Workspace cost overview
-bc cost daily                        # Daily cost totals
-bc cost agent                        # Per-agent breakdown
-bc cost model                        # Per-model breakdown
-bc cost dashboard                    # Rich cost dashboard
-bc cost usage                        # Claude Code usage via ccusage
-bc cost usage --monthly              # Monthly summary
-bc cost budget show                  # Show budget status
+mycel cost                              # Show cost records
+mycel cost show eng-01                  # Show costs for agent
+mycel cost summary                      # Workspace cost overview
+mycel cost daily                        # Daily cost totals
+mycel cost agent                        # Per-agent breakdown
+mycel cost model                        # Per-model breakdown
+mycel cost dashboard                    # Rich cost dashboard
+mycel cost usage                        # Claude Code usage via ccusage
+mycel cost usage --monthly              # Monthly summary
+mycel cost budget show                  # Show budget status
 ```
 
 ---
 
 ## Configuration
 
-### bc config
+### mycel config
 
 ```bash
-bc config show                        # Show all config
-bc config get providers.default       # Get a specific value
-bc config set providers.default claude # Set a value
-bc config list                        # List all config keys
-bc config edit                        # Open in editor
-bc config validate                    # Validate config file
-bc config reset                       # Reset to defaults
-bc config user init                   # User config wizard
-bc config user show                   # Show user config
+mycel config show                        # Show all config
+mycel config get providers.default       # Get a specific value
+mycel config set providers.default claude # Set a value
+mycel config list                        # List all config keys
+mycel config edit                        # Open in editor
+mycel config validate                    # Validate config file
+mycel config reset                       # Reset to defaults
+mycel config user init                   # User config wizard
+mycel config user show                   # Show user config
 ```
 
 ---
 
 ## Scheduled Tasks
 
-### bc cron
+### mycel cron
 
 ```bash
-bc cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint"
-bc cron list                          # List all cron jobs
-bc cron show daily-lint               # Show job details
-bc cron enable daily-lint             # Enable a disabled job
-bc cron disable daily-lint            # Disable without deleting
-bc cron run daily-lint                # Trigger manually
-bc cron logs daily-lint --last 10     # Show last 10 executions
-bc cron remove daily-lint             # Delete a job
+mycel cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint"
+mycel cron list                          # List all cron jobs
+mycel cron show daily-lint               # Show job details
+mycel cron enable daily-lint             # Enable a disabled job
+mycel cron disable daily-lint            # Disable without deleting
+mycel cron run daily-lint                # Trigger manually
+mycel cron logs daily-lint --last 10     # Show last 10 executions
+mycel cron remove daily-lint             # Delete a job
 ```
 
 ---
@@ -386,115 +386,115 @@ mycel daemon rm myproc      # Remove a stopped process
 
 ## Secrets & Environment
 
-### bc secret
+### mycel secret
 
 ```bash
-bc secret set ANTHROPIC_API_KEY                    # Prompt for value
-bc secret set ANTHROPIC_API_KEY --value "sk-..."   # Set directly
-bc secret set GITHUB_TOKEN --from-env GITHUB_TOKEN # Import from env
-bc secret list                                     # List names (no values)
-bc secret show ANTHROPIC_API_KEY                   # Show metadata
-bc secret show ANTHROPIC_API_KEY --reveal          # Show actual value
-bc secret get ANTHROPIC_API_KEY                    # Print value to stdout
-bc secret delete ANTHROPIC_API_KEY                 # Delete a secret
+mycel secret set ANTHROPIC_API_KEY                    # Prompt for value
+mycel secret set ANTHROPIC_API_KEY --value "sk-..."   # Set directly
+mycel secret set GITHUB_TOKEN --from-env GITHUB_TOKEN # Import from env
+mycel secret list                                     # List names (no values)
+mycel secret show ANTHROPIC_API_KEY                   # Show metadata
+mycel secret show ANTHROPIC_API_KEY --reveal          # Show actual value
+mycel secret get ANTHROPIC_API_KEY                    # Print value to stdout
+mycel secret delete ANTHROPIC_API_KEY                 # Delete a secret
 ```
 
 Reference secrets in config with `${secret:NAME}` syntax.
 
 ---
 
-### bc env
+### mycel env
 
 ```bash
-bc env set SHARED_VAR global                           # Workspace env
-bc env set --provider claude CLAUDE_CODE_USE_BEDROCK 1 # Provider env
-bc env list                                            # All env vars
-bc env list --provider claude                          # Provider-specific
-bc env get SHARED_VAR                                  # Get value
-bc env unset SHARED_VAR                                # Remove
+mycel env set SHARED_VAR global                           # Workspace env
+mycel env set --provider claude CLAUDE_CODE_USE_BEDROCK 1 # Provider env
+mycel env list                                            # All env vars
+mycel env list --provider claude                          # Provider-specific
+mycel env get SHARED_VAR                                  # Get value
+mycel env unset SHARED_VAR                                # Remove
 ```
 
 ---
 
 ## Tools & Roles
 
-### bc tool
+### mycel tool
 
 ```bash
-bc tool list              # Show all tools with status
-bc tool add myagent       # Add a custom tool
-bc tool show claude       # Show tool details
-bc tool setup claude      # Install and configure
-bc tool status claude     # Check installation status
-bc tool upgrade claude    # Upgrade an installed tool
-bc tool delete mytool     # Remove a custom tool
-bc tool run claude        # Run a tool directly
-bc tool edit mytool       # Edit tool configuration
+mycel tool list              # Show all tools with status
+mycel tool add myagent       # Add a custom tool
+mycel tool show claude       # Show tool details
+mycel tool setup claude      # Install and configure
+mycel tool status claude     # Check installation status
+mycel tool upgrade claude    # Upgrade an installed tool
+mycel tool delete mytool     # Remove a custom tool
+mycel tool run claude        # Run a tool directly
+mycel tool edit mytool       # Edit tool configuration
 ```
 
 ---
 
-### bc role
+### mycel role
 
 ```bash
-bc role list              # List all roles
-bc role show engineer     # Show role details
+mycel role list              # List all roles
+mycel role show engineer     # Show role details
 ```
 
 ---
 
 ## Monitoring & Diagnostics
 
-### bc logs
+### mycel logs
 View the event log.
 
 ```bash
-bc logs                     # Show all events
-bc logs --agent eng-01      # Filter by agent
-bc logs --type agent.report # Filter by event type
-bc logs --since 1h          # Events from last hour
-bc logs --tail 20           # Last N events
-bc logs --full              # Show full messages
+mycel logs                     # Show all events
+mycel logs --agent eng-01      # Filter by agent
+mycel logs --type agent.report # Filter by event type
+mycel logs --since 1h          # Events from last hour
+mycel logs --tail 20           # Last N events
+mycel logs --full              # Show full messages
 ```
 
 ---
 
-### bc doctor
+### mycel doctor
 Run health checks.
 
 ```bash
-bc doctor                          # Full health check
-bc doctor check workspace          # Check specific category
-bc doctor fix                      # Auto-fix fixable issues
-bc doctor fix --dry-run            # Preview fixes
-bc doctor fix --category git       # Fix specific category
+mycel doctor                          # Full health check
+mycel doctor check workspace          # Check specific category
+mycel doctor fix                      # Auto-fix fixable issues
+mycel doctor fix --dry-run            # Preview fixes
+mycel doctor fix --category git       # Fix specific category
 ```
 
 ---
 
-### bc version
+### mycel version
 
 ```bash
-bc version       # Show version info
-bc --version     # Same as above
+mycel version       # Show version info
+mycel --version     # Same as above
 mycel -V            # Same as above
 ```
 
 ---
 
-### bc mcp
+### mycel mcp
 Manage MCP server configurations.
 
 ```bash
-bc mcp list                                     # List all MCP servers
-bc mcp add github --command npx --args "@modelcontextprotocol/server-github"
-bc mcp add remote --transport sse --url "https://api.example.com/mcp"
-bc mcp show github                              # Show server details
-bc mcp remove github                            # Remove a server
-bc mcp disable github                           # Disable a server
-bc mcp enable github                            # Re-enable a server
-bc mcp register                                 # Register mycel as MCP server
-bc mcp serve                                    # Start mycel as MCP server
+mycel mcp list                                     # List all MCP servers
+mycel mcp add github --command npx --args "@modelcontextprotocol/server-github"
+mycel mcp add remote --transport sse --url "https://api.example.com/mcp"
+mycel mcp show github                              # Show server details
+mycel mcp remove github                            # Remove a server
+mycel mcp disable github                           # Disable a server
+mycel mcp enable github                            # Re-enable a server
+mycel mcp register                                 # Register mycel as MCP server
+mycel mcp serve                                    # Start mycel as MCP server
 ```
 
 ---
@@ -503,22 +503,22 @@ bc mcp serve                                    # Start mycel as MCP server
 
 ```bash
 # Daily workflow
-bc up                                    # Start root agent
-bc status                                # Check status
-bc agent create eng-01 --role engineer   # Create agent
-bc agent send eng-01 "implement X"       # Send work
-bc agent peek eng-01                     # Watch output
-bc home                                  # Open dashboard
-bc down                                  # Stop all
+mycel up                                    # Start root agent
+mycel status                                # Check status
+mycel agent create eng-01 --role engineer   # Create agent
+mycel agent send eng-01 "implement X"       # Send work
+mycel agent peek eng-01                     # Watch output
+mycel home                                  # Open dashboard
+mycel down                                  # Stop all
 
 # Communication
-bc channel send eng "starting tests"     # Channel message
-bc agent broadcast "check status"        # Broadcast to all
+mycel channel send eng "starting tests"     # Channel message
+mycel agent broadcast "check status"        # Broadcast to all
 
 # Monitoring
-bc logs --tail 20                        # Recent events
-bc doctor                                # Health check
-bc cost summary                          # Cost overview
+mycel logs --tail 20                        # Recent events
+mycel doctor                                # Health check
+mycel cost summary                          # Cost overview
 ```
 
 ---
@@ -540,11 +540,11 @@ BC_AGENT_ID       # Current agent name (set in agent sessions)
 BC_AGENT_ROLE     # Current agent role
 BC_WORKSPACE      # Path to workspace root
 BC_AGENT_WORKTREE # Path to agent's worktree
-BC_BIN            # Path to bc binary
+BC_BIN            # Path to mycel binary
 BC_ROOT           # Workspace root directory
 NO_COLOR          # Disable colored output
 ```
 
 ---
 
-**For more help:** `bc --help` or `mycel <command> --help`
+**For more help:** `mycel --help` or `mycel <command> --help`

--- a/landing/docs/examples.md
+++ b/landing/docs/examples.md
@@ -21,31 +21,31 @@ Practical examples of mycel in action for common development scenarios.
 ### Team Structure
 ```bash
 # Product Manager coordinates
-bc agent create pm-01 --role product-manager
+mycel agent create pm-01 --role product-manager
 
 # Manager executes strategy
-bc agent create mgr-01 --role manager --parent pm-01
+mycel agent create mgr-01 --role manager --parent pm-01
 
 # 2 Engineers + 1 QA
-bc agent create eng-01 --role engineer --parent mgr-01  # Backend
-bc agent create eng-02 --role engineer --parent mgr-01  # Frontend
-bc agent create qa-01 --role qa --parent mgr-01         # Testing
+mycel agent create eng-01 --role engineer --parent mgr-01  # Backend
+mycel agent create eng-02 --role engineer --parent mgr-01  # Frontend
+mycel agent create qa-01 --role qa --parent mgr-01         # Testing
 ```
 
 ### Week 1: User Authentication
 ```bash
 # PM creates epic
-bc queue add "Week 1: User Authentication System"
+mycel queue add "Week 1: User Authentication System"
 
 # Break into tasks
-bc queue add "Backend: JWT auth endpoints" --priority high
-bc queue add "Frontend: Login/Signup UI" --priority high
-bc queue add "Test: Auth flow end-to-end" --priority high
+mycel queue add "Backend: JWT auth endpoints" --priority high
+mycel queue add "Frontend: Login/Signup UI" --priority high
+mycel queue add "Test: Auth flow end-to-end" --priority high
 
 # Assign parallel work
-bc queue assign work-0001 eng-01  # Backend engineer
-bc queue assign work-0002 eng-02  # Frontend engineer
-bc queue assign work-0003 qa-01   # QA engineer
+mycel queue assign work-0001 eng-01  # Backend engineer
+mycel queue assign work-0002 eng-02  # Frontend engineer
+mycel queue assign work-0003 qa-01   # QA engineer
 
 # Monitor progress
 bc home
@@ -90,7 +90,7 @@ git checkout -b feature/auth-ui
 git commit -m "feat: authentication UI"
 
 # Both merge to main without conflicts
-bc merge process
+mycel merge process
 ```
 
 ---
@@ -117,20 +117,20 @@ Each PM spawns 3 engineers + 1 QA
 ### Initialization
 ```bash
 # Root coordinates
-bc agent create root-01 --role product-manager
+mycel agent create root-01 --role product-manager
 
 # 5 service managers
-bc agent create pm-user --role manager --parent root-01
-bc agent create pm-order --role manager --parent root-01
-bc agent create pm-payment --role manager --parent root-01
-bc agent create pm-inventory --role manager --parent root-01
-bc agent create pm-analytics --role manager --parent root-01
+mycel agent create pm-user --role manager --parent root-01
+mycel agent create pm-order --role manager --parent root-01
+mycel agent create pm-payment --role manager --parent root-01
+mycel agent create pm-inventory --role manager --parent root-01
+mycel agent create pm-analytics --role manager --parent root-01
 
 # Each manager spawns engineers
 for service in user order payment inventory analytics; do
-  bc agent create eng-${service}-01 --role engineer --parent pm-${service}
-  bc agent create eng-${service}-02 --role engineer --parent pm-${service}
-  bc agent create qa-${service}-01 --role qa --parent pm-${service}
+  mycel agent create eng-${service}-01 --role engineer --parent pm-${service}
+  mycel agent create eng-${service}-02 --role engineer --parent pm-${service}
+  mycel agent create qa-${service}-01 --role qa --parent pm-${service}
 done
 
 # Result: 15 agents in organized hierarchy
@@ -139,25 +139,25 @@ done
 ### Sprint Planning
 ```bash
 # All 5 services developing in parallel
-bc queue add "Sprint 23: User service - add profile updates"
-bc queue add "Sprint 23: Order service - implement cancellation"
-bc queue add "Sprint 23: Payment service - add refund logic"
-bc queue add "Sprint 23: Inventory service - sync across regions"
-bc queue add "Sprint 23: Analytics service - track user journey"
+mycel queue add "Sprint 23: User service - add profile updates"
+mycel queue add "Sprint 23: Order service - implement cancellation"
+mycel queue add "Sprint 23: Payment service - add refund logic"
+mycel queue add "Sprint 23: Inventory service - sync across regions"
+mycel queue add "Sprint 23: Analytics service - track user journey"
 
 # Each service team executes independently
-bc queue assign work-0001 eng-user-01
-bc queue assign work-0002 eng-order-01
-bc queue assign work-0003 eng-payment-01
-bc queue assign work-0004 eng-inventory-01
-bc queue assign work-0005 eng-analytics-01
+mycel queue assign work-0001 eng-user-01
+mycel queue assign work-0002 eng-order-01
+mycel queue assign work-0003 eng-payment-01
+mycel queue assign work-0004 eng-inventory-01
+mycel queue assign work-0005 eng-analytics-01
 
 # Managers review cross-service dependencies
 bc send pm-order "Need updated user IDs from user-service"
 bc send pm-user "User updates ready for order service"
 
 # All merge simultaneously when ready
-bc merge process
+mycel merge process
 # Result: 5 microservices evolved, deployed together
 ```
 
@@ -188,35 +188,35 @@ mycel Approach:
 ### Team Roles
 ```bash
 # Core maintainers (permanent)
-bc agent create maintainer-01 --role product-manager  # Lead
-bc agent create maintainer-02 --role manager
-bc agent create maintainer-03 --role manager
+mycel agent create maintainer-01 --role product-manager  # Lead
+mycel agent create maintainer-02 --role manager
+mycel agent create maintainer-03 --role manager
 
 # Triage: QA role
-bc agent create qa-triage-01 --role qa
+mycel agent create qa-triage-01 --role qa
 
 # Contributor engineers (rotating)
-bc agent create contributor-01 --role engineer
-bc agent create contributor-02 --role engineer
+mycel agent create contributor-01 --role engineer
+mycel agent create contributor-02 --role engineer
 # ... etc
 ```
 
 ### Issue Processing
 ```bash
 # Issues come in from GitHub
-bc queue add "Fix: Memory leak in parser (Issue #542)"
-bc queue add "Feature: Add TypeScript support (Issue #438)"
-bc queue add "Docs: Update API reference"
-bc queue add "Perf: Optimize critical path"
-bc queue add "Test: Add Windows CI support"
+mycel queue add "Fix: Memory leak in parser (Issue #542)"
+mycel queue add "Feature: Add TypeScript support (Issue #438)"
+mycel queue add "Docs: Update API reference"
+mycel queue add "Perf: Optimize critical path"
+mycel queue add "Test: Add Windows CI support"
 
 # Triage: High priority issues
 bc send qa-triage-01 "Review high-priority issues"
 
 # Assign to available contributors
-bc queue assign work-0001 contributor-01  # Memory leak
-bc queue assign work-0002 contributor-02  # TypeScript
-bc queue assign work-0003 contributor-03  # Docs
+mycel queue assign work-0001 contributor-01  # Memory leak
+mycel queue assign work-0002 contributor-02  # TypeScript
+mycel queue assign work-0003 contributor-03  # Docs
 
 # Monitor contributions
 bc home
@@ -231,14 +231,14 @@ bc attach contributor-01
 git commit -m "fix: memory leak in parser"
 
 # Maintainer reviews
-bc merge list
+mycel merge list
 # Shows: contributor-01 work ready for review
 
 # Code review via GitHub
 # + automated CI/CD testing
 
 # Maintainer approves
-bc merge process
+mycel merge process
 # Merges to main
 
 # Auto-publish to npm
@@ -264,17 +264,17 @@ bc merge process
 ### Sprint Board as Work Queue
 ```bash
 # Sprint 15 created
-bc queue add "Feature: Dark mode support" --priority high
-bc queue add "Feature: Bulk export CSV" --priority high
-bc queue add "Feature: Custom dashboard layouts" --priority medium
-bc queue add "Fix: Email notification delay" --priority high
-bc queue add "Perf: Optimize database queries" --priority medium
-bc queue add "Docs: Update API v2 docs" --priority low
-bc queue add "Test: Load testing for 1M users" --priority medium
-bc queue add "Infra: CDN optimization" --priority medium
+mycel queue add "Feature: Dark mode support" --priority high
+mycel queue add "Feature: Bulk export CSV" --priority high
+mycel queue add "Feature: Custom dashboard layouts" --priority medium
+mycel queue add "Fix: Email notification delay" --priority high
+mycel queue add "Perf: Optimize database queries" --priority medium
+mycel queue add "Docs: Update API v2 docs" --priority low
+mycel queue add "Test: Load testing for 1M users" --priority medium
+mycel queue add "Infra: CDN optimization" --priority medium
 
 # Daily standup shows progress
-bc queue list
+mycel queue list
 # Shows: 3 done, 2 working, 3 pending
 
 # Sprint metrics
@@ -285,24 +285,24 @@ bc metrics
 ### Continuous Integration
 ```bash
 # Multiple engineers working on different features
-bc agent create eng-01 --role engineer  # Dark mode
-bc agent create eng-02 --role engineer  # Bulk export
-bc agent create eng-03 --role engineer  # Dashboards
-bc agent create eng-04 --role engineer  # Email fix
-bc agent create eng-05 --role engineer  # Performance
-bc agent create eng-06 --role engineer  # Documentation
-bc agent create qa-01 --role qa         # Testing
-bc agent create tech-lead-01 --role tech-lead
+mycel agent create eng-01 --role engineer  # Dark mode
+mycel agent create eng-02 --role engineer  # Bulk export
+mycel agent create eng-03 --role engineer  # Dashboards
+mycel agent create eng-04 --role engineer  # Email fix
+mycel agent create eng-05 --role engineer  # Performance
+mycel agent create eng-06 --role engineer  # Documentation
+mycel agent create qa-01 --role qa         # Testing
+mycel agent create tech-lead-01 --role tech-lead
 
 # Wednesday: Merge features to staging
-bc merge process --to staging
+mycel merge process --to staging
 # Result: All features integrated on staging branch
 
 # Thursday: Final testing on staging
 bc send qa-01 "Run full test suite on staging"
 
 # Friday: Release to production
-bc merge process --to main
+mycel merge process --to main
 # Automatic CI/CD deploys
 ```
 
@@ -315,20 +315,20 @@ bc merge process --to main
 ### Team Specialization
 ```bash
 # 3 iOS engineers
-bc agent create ios-lead --role manager
-bc agent create ios-eng-01 --role engineer --parent ios-lead
-bc agent create ios-eng-02 --role engineer --parent ios-lead
-bc agent create ios-qa --role qa --parent ios-lead
+mycel agent create ios-lead --role manager
+mycel agent create ios-eng-01 --role engineer --parent ios-lead
+mycel agent create ios-eng-02 --role engineer --parent ios-lead
+mycel agent create ios-qa --role qa --parent ios-lead
 
 # 3 Android engineers
-bc agent create android-lead --role manager
-bc agent create android-eng-01 --role engineer --parent android-lead
-bc agent create android-eng-02 --role engineer --parent android-lead
-bc agent create android-qa --role qa --parent android-lead
+mycel agent create android-lead --role manager
+mycel agent create android-eng-01 --role engineer --parent android-lead
+mycel agent create android-eng-02 --role engineer --parent android-lead
+mycel agent create android-qa --role qa --parent android-lead
 
 # Shared features (backend)
-bc agent create backend-lead --role manager
-bc agent create backend-eng --role engineer --parent backend-lead
+mycel agent create backend-lead --role manager
+mycel agent create backend-eng --role engineer --parent backend-lead
 ```
 
 ### Parallel Platform Development
@@ -349,7 +349,7 @@ cd .bc/worktrees/backend-eng/
 # Used by both platforms
 
 # All merge to main simultaneously
-bc merge process
+mycel merge process
 # Result: Complete auth system integrated across platforms
 ```
 
@@ -387,23 +387,23 @@ Data Ingestion → Transformation → Storage → Analytics
 ### Parallel Pipeline Development
 ```bash
 # Each stage has owner
-bc agent create eng-01 --role engineer  # Ingestion (APIs, webhooks)
-bc agent create eng-02 --role engineer  # Transformation (cleaning, enrichment)
-bc agent create eng-03 --role engineer  # Storage (DB, data warehouse)
-bc agent create eng-04 --role engineer  # Analytics (dashboards, reports)
-bc agent create qa-01 --role qa         # Data quality testing
+mycel agent create eng-01 --role engineer  # Ingestion (APIs, webhooks)
+mycel agent create eng-02 --role engineer  # Transformation (cleaning, enrichment)
+mycel agent create eng-03 --role engineer  # Storage (DB, data warehouse)
+mycel agent create eng-04 --role engineer  # Analytics (dashboards, reports)
+mycel agent create qa-01 --role qa         # Data quality testing
 
 # Sprint: Add email interaction tracking
-bc queue add "Ingest email events from SendGrid"
-bc queue add "Transform email events for analytics"
-bc queue add "Store email events in warehouse"
-bc queue add "Build email interaction dashboard"
+mycel queue add "Ingest email events from SendGrid"
+mycel queue add "Transform email events for analytics"
+mycel queue add "Store email events in warehouse"
+mycel queue add "Build email interaction dashboard"
 
 # Parallel development
-bc queue assign work-0001 eng-01  # Ingestion: Accept SendGrid webhooks
-bc queue assign work-0002 eng-02  # Transform: Extract fields
-bc queue assign work-0003 eng-03  # Store: Create table, indexes
-bc queue assign work-0004 eng-04  # Analytics: Create visualizations
+mycel queue assign work-0001 eng-01  # Ingestion: Accept SendGrid webhooks
+mycel queue assign work-0002 eng-02  # Transform: Extract fields
+mycel queue assign work-0003 eng-03  # Store: Create table, indexes
+mycel queue assign work-0004 eng-04  # Analytics: Create visualizations
 ```
 
 ### Data Quality Validation
@@ -434,46 +434,46 @@ bc home
 ### Microservice Coordination
 ```bash
 # API Gateway
-bc agent create gateway-eng --role engineer
+mycel agent create gateway-eng --role engineer
 
 # 4 Backend Services
-bc agent create auth-service-eng --role engineer
-bc agent create users-service-eng --role engineer
-bc agent create products-service-eng --role engineer
-bc agent create orders-service-eng --role engineer
+mycel agent create auth-service-eng --role engineer
+mycel agent create users-service-eng --role engineer
+mycel agent create products-service-eng --role engineer
+mycel agent create orders-service-eng --role engineer
 
 # Shared utilities
-bc agent create utils-eng --role engineer
+mycel agent create utils-eng --role engineer
 
 # Infrastructure
-bc agent create ops-eng --role engineer
+mycel agent create ops-eng --role engineer
 ```
 
 ### Contract-First API Development
 ```bash
 # Week 1: Define API contracts
-bc queue add "Define Auth service API contract"
-bc queue add "Define Users service API contract"
-bc queue add "Define Products service API contract"
-bc queue add "Define Orders service API contract"
+mycel queue add "Define Auth service API contract"
+mycel queue add "Define Users service API contract"
+mycel queue add "Define Products service API contract"
+mycel queue add "Define Orders service API contract"
 
 # Week 2: Implement services in parallel
-bc queue add "Auth: Implement JWT endpoints"
-bc queue add "Users: Implement user CRUD"
-bc queue add "Products: Implement product catalog"
-bc queue add "Orders: Implement order pipeline"
+mycel queue add "Auth: Implement JWT endpoints"
+mycel queue add "Users: Implement user CRUD"
+mycel queue add "Products: Implement product catalog"
+mycel queue add "Orders: Implement order pipeline"
 
 # Week 3: Implement gateway routing
-bc queue add "Gateway: Route to auth service"
-bc queue add "Gateway: Route to users service"
-bc queue add "Gateway: Route to products service"
-bc queue add "Gateway: Route to orders service"
+mycel queue add "Gateway: Route to auth service"
+mycel queue add "Gateway: Route to users service"
+mycel queue add "Gateway: Route to products service"
+mycel queue add "Gateway: Route to orders service"
 
 # Parallel implementation
-bc queue assign work-0008 auth-service-eng
-bc queue assign work-0009 users-service-eng
-bc queue assign work-0010 products-service-eng
-bc queue assign work-0011 orders-service-eng
+mycel queue assign work-0008 auth-service-eng
+mycel queue assign work-0009 users-service-eng
+mycel queue assign work-0010 products-service-eng
+mycel queue assign work-0011 orders-service-eng
 ```
 
 ### Contract Verification
@@ -517,7 +517,7 @@ bc send qa-01 "- Order service returns order confirmation"
 ```
 Daily:
 - bc home (dashboard check)
-- bc queue list (progress)
+- mycel queue list (progress)
 
 Weekly:
 - Sprint planning (new tasks)

--- a/landing/docs/faq.md
+++ b/landing/docs/faq.md
@@ -16,7 +16,7 @@ Optional: Node.js 18+ if using mycel with JavaScript/TypeScript projects.
 1. Install WSL2: `wsl --install -d Ubuntu-22.04`
 2. Inside WSL2, install Go and tmux
 3. Install mycel using Linux instructions
-4. Run bc commands from WSL2 terminal
+4. Run mycel commands from WSL2 terminal
 
 Native Windows support is not available yet, but WSL2 works well.
 
@@ -47,7 +47,7 @@ Run `make clean` then `make build` again.
 ## Core Concepts
 
 ### Q: What is a worktree?
-**A:** A worktree is an isolated copy of your git repository where an agent works. bc creates one worktree per agent at `.bc/worktrees/<agent-id>/`. This allows multiple agents to work simultaneously without merge conflicts.
+**A:** A worktree is an isolated copy of your git repository where an agent works. mycel creates one worktree per agent at `.bc/worktrees/<agent-id>/`. This allows multiple agents to work simultaneously without merge conflicts.
 
 Benefits:
 - Each agent has independent git state
@@ -79,8 +79,8 @@ This means:
 
 Example:
 ```bash
-bc spawn pm-01 --role product-manager  # Can spawn managers
-bc spawn eng-01 --role engineer        # Can only execute work
+mycel spawn pm-01 --role product-manager  # Can spawn managers
+mycel spawn eng-01 --role engineer        # Can only execute work
 ```
 
 ### Q: What is the work queue?
@@ -97,7 +97,7 @@ Each task has:
 - Assigned agent
 - Merge state
 
-View with: `bc queue list`
+View with: `mycel queue list`
 
 ---
 
@@ -114,7 +114,7 @@ This is mycel's core innovation - true parallel development.
 ### Q: How do I handle merge conflicts?
 **A:**
 1. **Prevention**: Most conflicts prevented by worktree isolation
-2. **Detection**: `bc merge list` shows conflicts
+2. **Detection**: `mycel merge list` shows conflicts
 3. **Resolution**:
    ```bash
    # Manual resolution
@@ -122,27 +122,27 @@ This is mycel's core innovation - true parallel development.
    git add conflicted-file
    git commit -m "resolve conflict"
    ```
-4. **Retry**: `bc merge process` to continue
+4. **Retry**: `mycel merge process` to continue
 
 ### Q: What happens if an agent crashes?
 **A:** No data loss due to git-backed persistence:
 1. Agent state saved in `.bc/agents/agents.json`
 2. Work queue saved in `.bc/queue.json`
 3. Kill tmux session: `tmux kill-session -t bc-<agent>`
-4. Restart agent: `bc spawn eng-01 --role engineer`
+4. Restart agent: `mycel spawn eng-01 --role engineer`
 5. Agent continues from where it left off
 
 ### Q: Can agents communicate?
 **A:** Yes, via channels:
 ```bash
 # Send message
-bc send eng-01 "Check your email for requirements"
+mycel send eng-01 "Check your email for requirements"
 
 # Send to channel
-bc send #engineering "API ready for testing"
+mycel send #engineering "API ready for testing"
 
 # View messages
-bc logs eng-01
+mycel logs eng-01
 ```
 
 ### Q: How do I review work before merging?
@@ -159,7 +159,7 @@ cd .bc/worktrees/eng-01/
 git log --oneline
 
 # Merge when ready
-bc merge process
+mycel merge process
 ```
 
 ---
@@ -170,16 +170,16 @@ bc merge process
 **A:** Scaling strategies:
 1. **Hierarchical teams**: PM → Managers → Engineers
    ```bash
-   bc spawn pm-01 --role product-manager
-   bc spawn mgr-01 --role manager --parent pm-01
-   bc spawn eng-01 --role engineer --parent mgr-01
+   mycel spawn pm-01 --role product-manager
+   mycel spawn mgr-01 --role manager --parent pm-01
+   mycel spawn eng-01 --role engineer --parent mgr-01
    ```
 
 2. **Parallel work queues**: Assign multiple tasks
    ```bash
-   bc queue assign work-0001 eng-01
-   bc queue assign work-0002 eng-02
-   bc queue assign work-0003 eng-03
+   mycel queue assign work-0001 eng-01
+   mycel queue assign work-0002 eng-02
+   mycel queue assign work-0003 eng-03
    ```
 
 3. **Dedicated roles**: QA, TechLead, etc.
@@ -211,7 +211,7 @@ Test with your workload to find optimal team size.
 Example:
 ```bash
 # Agent completes work
-bc report done "Feature ready"
+mycel report done "Feature ready"
 
 # GitHub Actions triggered by push to main
 # CI/CD runs tests automatically
@@ -224,29 +224,29 @@ bc report done "Feature ready"
 ### Q: Agents are stuck (not running)
 **A:** Check status:
 ```bash
-bc status
+mycel status
 # If shows "stuck", investigate:
-bc logs eng-01  # View agent logs
+mycel logs eng-01  # View agent logs
 ps aux | grep tmux  # Check tmux sessions
 ```
 
 Solutions:
 ```bash
 # Force restart
-bc kill eng-01
-bc spawn eng-01 --role engineer
+mycel kill eng-01
+mycel spawn eng-01 --role engineer
 
 # Or full reset
-bc down
-bc init
-bc up
+mycel down
+mycel init
+mycel up
 ```
 
 ### Q: "Merge conflict" when trying to merge
 **A:** Handle conflicting changes:
 ```bash
 # View conflicts
-bc merge list
+mycel merge list
 
 # Resolve using git
 cd .bc/worktrees/eng-01/
@@ -255,7 +255,7 @@ git add .
 git commit -m "resolve conflicts"
 
 # Retry merge
-bc merge process
+mycel merge process
 ```
 
 ### Q: "Permission denied" errors
@@ -269,7 +269,7 @@ chmod -R 755 .bc/
 chmod -R 755 .bc/worktrees/
 
 # Retry command
-bc status
+mycel status
 ```
 
 ### Q: tmux session won't start
@@ -282,9 +282,9 @@ tmux list-sessions
 tmux kill-server
 
 # Restart mycel
-bc down
-bc init
-bc up
+mycel down
+mycel init
+mycel up
 ```
 
 ### Q: Agent can't access files
@@ -320,11 +320,11 @@ git clone https://github.com/yourorg/project.git
 cd project
 
 # Initialize mycel
-bc init
-bc up
+mycel init
+mycel up
 
 # Work normally
-# bc creates branches, agents work, merge to main
+# mycel creates branches, agents work, merge to main
 # Push to GitHub when ready
 git push origin main
 ```
@@ -343,7 +343,7 @@ Recommended production setup:
 3. Monitoring: Watch merge queue for errors
 4. Rollback: Easy via git history
 
-### Q: How do I backup my bc workspace?
+### Q: How do I backup my mycel workspace?
 **A:**
 ```bash
 # Git clone handles it automatically
@@ -381,14 +381,14 @@ git tag snapshot-$(date +%Y%m%d)
 **A:**
 - [GitHub Issues](https://github.com/bcinfra1/bc/issues)
 - Include: version, OS, steps to reproduce
-- Attach logs: `bc logs`
+- Attach logs: `mycel logs`
 
 ### Q: How do I get help?
 **A:**
 - **Documentation**: [mycel GitHub Wiki](https://github.com/bcinfra1/bc/wiki)
 - **Issues**: [Feature requests & bugs](https://github.com/bcinfra1/bc/issues)
 - **Discussions**: [GitHub Discussions](https://github.com/bcinfra1/bc/discussions)
-- **Community**: Ask in channels within bc workspace
+- **Community**: Ask in channels within mycel workspace
 
 ---
 

--- a/landing/docs/features.md
+++ b/landing/docs/features.md
@@ -33,7 +33,7 @@ project/
 ### How It Works
 ```bash
 # Initialize workspace
-bc init
+mycel init
 
 # Two engineers spawned
 bc spawn eng-01 --role engineer
@@ -49,7 +49,7 @@ cd .bc/worktrees/eng-02/
 git commit -m "add logging"
 
 # Merge both to main - NO CONFLICTS!
-bc merge process
+mycel merge process
 # Result: app.js has both changes merged cleanly
 ```
 
@@ -115,15 +115,15 @@ All mycel state stored in git-tracked files:
 ```bash
 # Session 1: Agent starts work
 bc spawn eng-01 --role engineer
-bc queue add "Implement authentication"
-bc queue assign work-0001 eng-01
+mycel queue add "Implement authentication"
+mycel queue assign work-0001 eng-01
 bc attach eng-01
 # eng-01 works on authentication...
 bc report working "Implementing JWT validation"
 # ... agent crashes or is stopped
 
 # Session 2: Complete recovery
-bc status  # Shows: eng-01 was working on work-0001
+mycel status  # Shows: eng-01 was working on work-0001
 cd .bc/worktrees/eng-01/
 git log --oneline  # Shows all previous work
 cat .bc/queue.json  # Shows eng-01 still assigned to work-0001
@@ -225,7 +225,7 @@ bc spawn eng-02 --role engineer --parent pm-01  # ✗ Fails
 bc spawn eng-01 --role engineer --parent mgr-01  # ✓ Works
 
 # Invalid: Engineer cannot assign work
-bc queue assign work-0001 eng-01  # ✗ Fails (engineers execute, don't assign)
+mycel queue assign work-0001 eng-01  # ✗ Fails (engineers execute, don't assign)
 ```
 
 ### Benefits
@@ -306,8 +306,8 @@ bc spawn eng-02 --role engineer
 bc spawn qa-01 --role qa
 
 # Assign task
-bc queue add "Build user authentication"
-bc queue assign work-0001 eng-01
+mycel queue add "Build user authentication"
+mycel queue assign work-0001 eng-01
 
 # Send context
 bc send eng-01 "User auth task assigned. See requirements at /docs/auth.md"
@@ -355,7 +355,7 @@ Feature: "Add password reset"
    bc send #engineering "All password reset tests passing"
 
 6. Ready to merge
-   bc merge process
+   mycel merge process
 
 All communication in context, none lost
 ```
@@ -382,11 +382,11 @@ Lifecycle: pending → assigned → working → done
 ### How It Works
 ```bash
 # Create work item
-bc queue add "Implement user registration"
+mycel queue add "Implement user registration"
 # Creates: work-0001 (status: pending)
 
 # Assign to agent
-bc queue assign work-0001 eng-01
+mycel queue assign work-0001 eng-01
 # Updates: work-0001 (status: assigned, assigned_to: eng-01)
 
 # Agent reports progress
@@ -399,27 +399,27 @@ bc report done "Registration form complete - ready for testing"
 # Updates: work-0001 (status: done, merge_status: unmerged)
 
 # Review and merge
-bc merge list  # Shows: work-0001 ready to merge
-bc merge process
+mycel merge list  # Shows: work-0001 ready to merge
+mycel merge process
 # Updates: work-0001 (merge_status: merged, merged_at: timestamp)
 ```
 
 ### Queue Operations
 ```bash
 # List all work
-bc queue list
+mycel queue list
 
 # Show details
-bc queue show work-0001
+mycel queue show work-0001
 
 # View progress
-bc queue status
+mycel queue status
 
 # Clear completed
-bc queue clear completed
+mycel queue clear completed
 
 # Track metrics
-bc queue metrics  # Shows: completed, avg time, etc.
+mycel queue metrics  # Shows: completed, avg time, etc.
 ```
 
 ### Queue Fields
@@ -456,7 +456,7 @@ Sprint Planning:
 - Teams execute independently
 
 Progress Tracking:
-- bc queue list shows: 2 done, 3 working, 5 pending
+- mycel queue list shows: 2 done, 3 working, 5 pending
 - Can drill down: eng-01 blocked on API response
 - Can prioritize: move API work to top
 

--- a/landing/docs/getting-started.md
+++ b/landing/docs/getting-started.md
@@ -57,7 +57,7 @@ make build
 make install
 
 # Verify installation
-bc --version
+mycel --version
 ```
 
 ### Linux
@@ -77,7 +77,7 @@ make build
 make install
 
 # Verify installation
-bc --version
+mycel --version
 ```
 
 ### Windows (WSL2 Recommended)
@@ -97,7 +97,7 @@ make build
 make install
 
 # Verify installation
-bc --version
+mycel --version
 ```
 
 ---
@@ -111,8 +111,8 @@ bc --version
 mkdir my-project
 cd my-project
 
-# Initialize bc workspace
-bc init
+# Initialize mycel workspace
+mycel init
 
 # Expected output:
 # ✓ Workspace initialized at /Users/you/my-project/.bc/
@@ -124,15 +124,15 @@ bc init
 
 ```bash
 # Start the root coordinator agent
-bc up
+mycel up
 
 # Expected output:
 # ✓ Root agent started
 # ✓ Workspace ready
-# ✓ Use 'bc home' to view dashboard
+# ✓ Use 'mycel home' to view dashboard
 
 # Check status
-bc status
+mycel status
 # Shows: root (running)
 ```
 
@@ -140,7 +140,7 @@ bc status
 
 ```bash
 # View the interactive dashboard
-bc home
+mycel home
 
 # Navigation:
 # - Arrow keys: Navigate agents/tasks
@@ -152,7 +152,7 @@ bc home
 
 ```bash
 # In a new terminal, spawn an engineer agent
-bc spawn eng-01 --role engineer
+mycel spawn eng-01 --role engineer
 
 # Expected output:
 # ✓ Agent eng-01 spawned
@@ -164,10 +164,10 @@ bc spawn eng-01 --role engineer
 
 ```bash
 # Add a task to the queue
-bc queue add "Implement login feature"
+mycel queue add "Implement login feature"
 
 # List tasks
-bc queue list
+mycel queue list
 
 # Output:
 # ID          Status     Title
@@ -178,10 +178,10 @@ bc queue list
 
 ```bash
 # Assign task to agent
-bc queue assign work-0001 eng-01
+mycel queue assign work-0001 eng-01
 
 # Check assignment
-bc queue list
+mycel queue list
 
 # Output:
 # work-0001   assigned   Implement login feature   (assigned to: eng-01)
@@ -191,23 +191,23 @@ bc queue list
 
 ```bash
 # Attach to agent session to see execution
-bc attach eng-01
+mycel attach eng-01
 
 # Inside agent session:
 # - View current working directory: pwd
 # - Agent has access to full project
 # - Agent can make commits, create branches
-# - Agent reports progress via: bc report working "message"
+# - Agent reports progress via: mycel report working "message"
 ```
 
 ### 8. Report Completion
 
 ```bash
 # Agent signals completion (from within session or external)
-bc report done "Login feature implemented and tested"
+mycel report done "Login feature implemented and tested"
 
 # Check queue
-bc queue list
+mycel queue list
 
 # Output:
 # work-0001   done   Implement login feature   (completed by: eng-01)
@@ -217,10 +217,10 @@ bc queue list
 
 ```bash
 # List mergeable work
-bc merge list
+mycel merge list
 
 # Merge all completed work to main
-bc merge process
+mycel merge process
 
 # Verify main branch has changes
 git log --oneline -5
@@ -243,50 +243,50 @@ mkdir notification-service
 cd notification-service
 git init
 git branch main
-bc init
-bc up
+mycel init
+mycel up
 ```
 
 **Step 2: Create Work Items**
 
 ```bash
 # Add feature task
-bc queue add "Add email notification service"
+mycel queue add "Add email notification service"
 
 # Add parallel work
-bc queue add "Create email templates"
-bc queue add "Write tests for notifications"
+mycel queue add "Create email templates"
+mycel queue add "Write tests for notifications"
 ```
 
 **Step 3: Spawn Team**
 
 ```bash
 # Spawn engineers for parallel work
-bc spawn eng-01 --role engineer  # Backend API
-bc spawn eng-02 --role engineer  # Templates
-bc spawn qa-01 --role qa         # Testing
+mycel spawn eng-01 --role engineer  # Backend API
+mycel spawn eng-02 --role engineer  # Templates
+mycel spawn qa-01 --role qa         # Testing
 
 # Spawn tech lead for reviews
-bc spawn tech-lead-01 --role tech-lead
+mycel spawn tech-lead-01 --role tech-lead
 ```
 
 **Step 4: Assign Work**
 
 ```bash
 # Assign tasks
-bc queue assign work-0001 eng-01  # API task
-bc queue assign work-0002 eng-02  # Templates task
-bc queue assign work-0003 qa-01   # Tests task
+mycel queue assign work-0001 eng-01  # API task
+mycel queue assign work-0002 eng-02  # Templates task
+mycel queue assign work-0003 qa-01   # Tests task
 
 # Check progress
-bc status
+mycel status
 ```
 
 **Step 5: Monitor Execution**
 
 ```bash
 # View real-time status
-bc home
+mycel home
 
 # See all agents working in parallel:
 # - eng-01: working (in .bc/worktrees/eng-01/)
@@ -305,17 +305,17 @@ git checkout -b feature/email-api
 # ... implement email service ...
 git add .
 git commit -m "feat: email notification API"
-bc report done "Email API complete - ready for review"
+mycel report done "Email API complete - ready for review"
 ```
 
 **Step 7: Review and Merge**
 
 ```bash
 # List completed work
-bc merge list
+mycel merge list
 
 # Merge to main
-bc merge process
+mycel merge process
 
 # Verify on main
 git log --oneline
@@ -330,9 +330,9 @@ git log --oneline
 
 ```bash
 # Spawn next team for additional features
-bc spawn eng-03 --role engineer
-bc queue add "Add SMS notification provider"
-bc queue assign work-0004 eng-03
+mycel spawn eng-03 --role engineer
+mycel queue add "Add SMS notification provider"
+mycel queue assign work-0004 eng-03
 ```
 
 ---
@@ -343,89 +343,89 @@ bc queue assign work-0004 eng-03
 
 ```bash
 # Initialize new workspace
-bc init
+mycel init
 
 # Start root agent
-bc up
+mycel up
 
 # Check workspace status
-bc status
+mycel status
 
 # Stop all agents
-bc down
+mycel down
 
 # View logs
-bc logs
+mycel logs
 
 # View dashboard
-bc home
+mycel home
 ```
 
 ### Agent Management
 
 ```bash
 # Spawn new agent
-bc spawn eng-01 --role engineer
-bc spawn tech-lead-01 --role tech-lead
+mycel spawn eng-01 --role engineer
+mycel spawn tech-lead-01 --role tech-lead
 
 # List agents
-bc status
+mycel status
 
 # Attach to agent session
-bc attach eng-01
+mycel attach eng-01
 
 # View agent logs
-bc logs eng-01
+mycel logs eng-01
 
 # Stop agent
-bc stop eng-01
+mycel stop eng-01
 
 # Kill agent session
-bc kill eng-01
+mycel kill eng-01
 ```
 
 ### Work Queue
 
 ```bash
 # Add task
-bc queue add "Implement feature X"
+mycel queue add "Implement feature X"
 
 # List all tasks
-bc queue list
+mycel queue list
 
 # Show task details
-bc queue show work-0001
+mycel queue show work-0001
 
 # Assign task
-bc queue assign work-0001 eng-01
+mycel queue assign work-0001 eng-01
 
 # Mark task status
-bc report working "In progress..."
-bc report done "Completed!"
-bc report stuck "Blocked by dependency"
-bc report failed "Error occurred"
+mycel report working "In progress..."
+mycel report done "Completed!"
+mycel report stuck "Blocked by dependency"
+mycel report failed "Error occurred"
 
 # Clear completed
-bc queue clear completed
+mycel queue clear completed
 ```
 
 ### Git & Merge
 
 ```bash
 # View branches to merge
-bc merge list
+mycel merge list
 
 # Merge all ready branches
-bc merge process
+mycel merge process
 
 # Merge specific task
-bc merge work-0001
+mycel merge work-0001
 
 # View merge conflicts
-bc merge conflicts
+mycel merge conflicts
 
 # Abort merge
-bc merge abort
+mycel merge abort
 
 # View main branch
 git log main --oneline
@@ -435,16 +435,16 @@ git log main --oneline
 
 ```bash
 # Send message to agent
-bc send eng-01 "Check our conversation for details"
+mycel send eng-01 "Check our conversation for details"
 
 # Send to channel
-bc send #eng-team "Update ready for review"
+mycel send #eng-team "Update ready for review"
 
 # List channels
-bc channels list
+mycel channels list
 
 # View channel history
-bc channels read #eng-team
+mycel channels read #eng-team
 ```
 
 ---
@@ -489,10 +489,10 @@ tmux list-sessions
 tmux kill-server
 
 # Re-init workspace
-bc down
+mycel down
 rm -rf .bc/
-bc init
-bc up
+mycel init
+mycel up
 ```
 
 ### Issue: "Merge conflicts"
@@ -505,7 +505,7 @@ error: merge conflict in src/app/page.tsx
 **Solution:**
 ```bash
 # View conflicts
-bc merge conflicts
+mycel merge conflicts
 
 # Resolve manually or use agent
 cd .bc/worktrees/eng-01/
@@ -514,7 +514,7 @@ git add .
 git commit -m "resolve merge conflicts"
 
 # Continue merge
-bc merge process
+mycel merge process
 ```
 
 ### Issue: "Permission denied" on worktree
@@ -533,7 +533,7 @@ ls -la .bc/worktrees/
 chmod -R 755 .bc/
 
 # Retry operation
-bc status
+mycel status
 ```
 
 ### Issue: "Agent not in workspace"
@@ -550,7 +550,7 @@ pwd
 ls .bc/
 
 # If missing, re-initialize
-bc init
+mycel init
 
 # Or navigate to correct project
 cd /path/to/project
@@ -569,10 +569,10 @@ error: no AI agent configured
 # Visit: https://claude.com/claude-code
 
 # Configure mycel to use Claude Code
-bc config set agent-tool claude-code
+mycel config set agent-tool claude-code
 
 # Verify configuration
-bc config show
+mycel config show
 ```
 
 ---
@@ -649,7 +649,7 @@ Real-time messaging between agents for coordination without losing context.
 
 ### Build Your First Project
 1. Create a small project (e.g., API service, web app)
-2. Initialize bc workspace
+2. Initialize mycel workspace
 3. Spawn 2-3 agents for different features
 4. Assign work and monitor progress
 5. Merge completed work to main
@@ -665,12 +665,12 @@ Real-time messaging between agents for coordination without losing context.
 ## Support
 
 ### Documentation
-- Full docs: [bc GitHub Repository](https://github.com/bcinfra1/bc)
+- Full docs: [mycel GitHub Repository](https://github.com/bcinfra1/bc)
 - Issues: [GitHub Issues](https://github.com/bcinfra1/bc/issues)
 - Discussions: [GitHub Discussions](https://github.com/bcinfra1/bc/discussions)
 
 ### Community
-- Join bc workspace for real-time support
+- Join mycel workspace for real-time support
 - Ask questions in #help channel
 - Share workflows in #showcase
 
@@ -680,30 +680,30 @@ Real-time messaging between agents for coordination without losing context.
 
 ```bash
 # Initialization
-bc init                                # Initialize workspace
-bc up                                  # Start root agent
+mycel init                                # Initialize workspace
+mycel up                                  # Start root agent
 
 # Agents
-bc spawn eng-01 --role engineer       # Spawn agent
-bc status                              # List agents
-bc attach eng-01                       # Connect to agent
-bc down                                # Stop all agents
+mycel spawn eng-01 --role engineer       # Spawn agent
+mycel status                              # List agents
+mycel attach eng-01                       # Connect to agent
+mycel down                                # Stop all agents
 
 # Work
-bc queue add "Title"                   # Create task
-bc queue assign work-0001 eng-01       # Assign task
-bc report done "Message"               # Complete task
-bc merge process                       # Merge to main
+mycel queue add "Title"                   # Create task
+mycel queue assign work-0001 eng-01       # Assign task
+mycel report done "Message"               # Complete task
+mycel merge process                       # Merge to main
 
 # Monitoring
-bc home                                # View dashboard
-bc status                              # Check status
-bc logs                                # View logs
-bc queue list                          # List tasks
+mycel home                                # View dashboard
+mycel status                              # Check status
+mycel logs                                # View logs
+mycel queue list                          # List tasks
 ```
 
 ---
 
 **Happy building with bc! 🚀**
 
-For more information, visit [bc on GitHub](https://github.com/bcinfra1/bc)
+For more information, visit [mycel on GitHub](https://github.com/bcinfra1/bc)

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -36,9 +36,9 @@ mycel works with any CLI-based AI coding assistant:
 ## Quick Start
 
 ```bash
-bc init --preset small-team
-bc up
-bc home
+mycel init --preset small-team
+mycel up
+mycel home
 ```
 
 ## Contact

--- a/landing/src/app/_components/InstallSection.tsx
+++ b/landing/src/app/_components/InstallSection.tsx
@@ -72,7 +72,7 @@ function getMethods(version: string): Method[] {
       platforms: "Stable + main branch",
       commands: [
         `docker pull ghcr.io/rpuneet/mycel:${version}`,
-        `docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:${version} bc up --addr 0.0.0.0:9374`,
+        `docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:${version} mycel up --addr 0.0.0.0:9374`,
         `# Bleeding edge from main:`,
         `docker pull ghcr.io/rpuneet/mycel:main`,
       ],
@@ -235,9 +235,9 @@ export function InstallSection() {
             <CodeBlock
               id="after"
               lines={[
-                "bc init          # Initialize workspace",
-                "bc up            # Start server + web UI on localhost:9374",
-                "bc agent create  # Spawn an AI agent",
+                "mycel init          # Initialize workspace",
+                "mycel up            # Start server + web UI on localhost:9374",
+                "mycel agent create  # Spawn an AI agent",
               ]}
             />
           </div>

--- a/landing/src/app/_components/InstallSection.tsx
+++ b/landing/src/app/_components/InstallSection.tsx
@@ -63,6 +63,8 @@ function getMethods(version: string): Method[] {
       platforms: "All platforms · requires Go 1.25+",
       commands: [
         `go install github.com/rpuneet/bc/cmd/bc@latest`,
+        `# Note: go install produces a binary named 'bc'.`,
+        `# For the 'mycel' binary, use brew install or docker run.`,
       ],
     },
     {

--- a/landing/src/app/_components/Nav.tsx
+++ b/landing/src/app/_components/Nav.tsx
@@ -105,7 +105,7 @@ function GetStartedDropdown() {
     {
       icon: Container,
       label: "Docker",
-      cmd: "docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel bc up --addr 0.0.0.0:9374",
+      cmd: "docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel mycel up --addr 0.0.0.0:9374",
     },
   ];
 

--- a/landing/src/app/docs/getting-started.md
+++ b/landing/src/app/docs/getting-started.md
@@ -60,6 +60,8 @@ bunx bc-cli
 go install github.com/rpuneet/bc/cmd/bc@latest
 ```
 
+> Note: `go install` produces a binary named `bc`. For the `mycel` binary, use `brew install` or `docker run` above.
+
 ### After Install
 
 ```bash

--- a/landing/src/app/docs/getting-started.md
+++ b/landing/src/app/docs/getting-started.md
@@ -40,10 +40,10 @@ curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.
 
 ```bash
 # Stable release
-docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:latest bc up --addr 0.0.0.0:9374
+docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:latest mycel up --addr 0.0.0.0:9374
 
 # Bleeding-edge (main branch)
-docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:main bc up --addr 0.0.0.0:9374
+docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:main mycel up --addr 0.0.0.0:9374
 ```
 
 ### npm / bun
@@ -63,9 +63,9 @@ go install github.com/rpuneet/bc/cmd/bc@latest
 ### After Install
 
 ```bash
-bc init          # Initialize workspace
-bc up            # Start server
-bc up -d         # Start as daemon
+mycel init          # Initialize workspace
+mycel up            # Start server
+mycel up -d         # Start as daemon
 ```
 
 ---
@@ -78,11 +78,11 @@ bc up -d         # Start as daemon
 # Create a new project directory
 mkdir my-project && cd my-project
 
-# Initialize bc workspace
-bc init
+# Initialize mycel workspace
+mycel init
 
 # Verify setup
-bc status
+mycel status
 ```
 
 **Output:**
@@ -96,10 +96,10 @@ bc status
 
 ```bash
 # Start root coordinator
-bc up
+mycel up
 
 # Check status
-bc status
+mycel status
 ```
 
 **Expected Output:**
@@ -113,13 +113,13 @@ ROOT AGENT: running
 
 ```bash
 # Create a manager agent
-bc agent create manager-atlas --role manager --tool cursor
+mycel agent create manager-atlas --role manager --tool cursor
 
 # Create an engineer agent
-bc agent create engineer-pixel --role engineer --tool claude
+mycel agent create engineer-pixel --role engineer --tool claude
 
 # List agents
-bc agent list
+mycel agent list
 ```
 
 **Output:**
@@ -140,12 +140,12 @@ AGENTS (3):
 
 ```bash
 # Add task to work queue
-bc queue add "Implement user authentication feature" \
+mycel queue add "Implement user authentication feature" \
   --priority high \
   --epic "auth-v2"
 
 # View queue
-bc queue work
+mycel queue work
 ```
 
 **Output:**
@@ -158,17 +158,17 @@ WORK QUEUE:
 
 ```bash
 # Send task assignment to #engineering channel
-bc channel send engineering "@engineer-pixel: Take task #1 - user auth implementation. Use jwt tokens, verify against db. DM when ready."
+mycel channel send engineering "@engineer-pixel: Take task #1 - user auth implementation. Use jwt tokens, verify against db. DM when ready."
 
 # Check messages
-bc channel history engineering --limit 5
+mycel channel history engineering --limit 5
 ```
 
 **Step 3: Engineer Works on Task**
 
 ```bash
 # Simulate engineer picking up work
-bc agent peek engineer-pixel
+mycel agent peek engineer-pixel
 ```
 
 **Output:**
@@ -184,20 +184,20 @@ AGENT: engineer-pixel (state: tool)
 
 ```bash
 # Check manager's queue
-bc queue merge
+mycel queue merge
 
 # Merge PR #42
-bc merge feature/user-auth --branch main
+mycel merge feature/user-auth --branch main
 
 # Verify merge
-bc queue merge
+mycel queue merge
 ```
 
 **Step 5: Celebrate!**
 
 ```bash
 # Post status to channel
-bc channel send general "🎉 Task complete! User auth feature merged and live. Great work team!"
+mycel channel send general "🎉 Task complete! User auth feature merged and live. Great work team!"
 ```
 
 ---
@@ -208,77 +208,77 @@ bc channel send general "🎉 Task complete! User auth feature merged and live. 
 
 ```bash
 # View all agents
-bc agent list
+mycel agent list
 
 # Peek at agent's current work
-bc agent peek engineer-pixel
+mycel agent peek engineer-pixel
 
 # Send direct message to agent
-bc agent send engineer-pixel "Status update please?"
+mycel agent send engineer-pixel "Status update please?"
 
 # Attach to agent's live session
-bc agent attach engineer-pixel
+mycel agent attach engineer-pixel
 ```
 
 ### Work Queue
 
 ```bash
 # View incoming work
-bc queue work
+mycel queue work
 
 # View merge queue
-bc queue merge
+mycel queue merge
 
 # Add task to queue
-bc queue add "Task description" --priority high
+mycel queue add "Task description" --priority high
 
 # Complete task
-bc queue complete 42
+mycel queue complete 42
 ```
 
 ### Channels (Team Communication)
 
 ```bash
 # List channels
-bc channel list
+mycel channel list
 
 # Send message to channel
-bc channel send #general "Update: Feature X shipped 🚀"
+mycel channel send #general "Update: Feature X shipped 🚀"
 
 # Check channel history
-bc channel history #engineering --limit 10
+mycel channel history #engineering --limit 10
 
 # Create new channel
-bc channel create #product-team
+mycel channel create #product-team
 ```
 
 ### Memory & Learning
 
 ```bash
 # View agent memory
-bc memory show --agent engineer-pixel
+mycel memory show --agent engineer-pixel
 
 # Record learning
-bc memory record "Pattern: Always validate user input before processing"
+mycel memory record "Pattern: Always validate user input before processing"
 
 # Search past experiences
-bc memory search "authentication patterns"
+mycel memory search "authentication patterns"
 ```
 
 ### Automation (Demons)
 
 ```bash
 # List scheduled tasks
-bc cron list
+mycel cron list
 
 # Run a demon manually
-bc cron run nightly-tests
+mycel cron run nightly-tests
 
 # Create new demon
-bc cron create test-suite --schedule "0 2 * * *" --role qa --task "Nightly test run"
+mycel cron create test-suite --schedule "0 2 * * *" --role qa --task "Nightly test run"
 
 # View demon logs
-bc cron logs test-suite
+mycel cron logs test-suite
 ```
 
 ---
@@ -293,10 +293,10 @@ bc cron logs test-suite
 pwd
 
 # If needed, reinitialize
-bc init
+mycel init
 
 # Verify
-bc status
+mycel status
 ```
 
 ### Issue: Agent stuck or unresponsive
@@ -304,13 +304,13 @@ bc status
 **Solution:**
 ```bash
 # Check agent status
-bc agent list
+mycel agent list
 
 # Restart agent
-bc agent restart engineer-pixel
+mycel agent restart engineer-pixel
 
 # View agent logs
-bc agent logs engineer-pixel --tail 20
+mycel agent logs engineer-pixel --tail 20
 ```
 
 ### Issue: Merge conflict preventing PR merge
@@ -318,13 +318,13 @@ bc agent logs engineer-pixel --tail 20
 **Solution:**
 ```bash
 # Check merge queue for conflicts
-bc queue merge
+mycel queue merge
 
 # Agent should resolve automatically, if not:
 # Contact tech lead for manual resolution
 
 # Once resolved, retry merge
-bc merge feature/branch-name --branch main
+mycel merge feature/branch-name --branch main
 ```
 
 ### Issue: Channel messages not appearing
@@ -332,13 +332,13 @@ bc merge feature/branch-name --branch main
 **Solution:**
 ```bash
 # Verify channel exists
-bc channel list
+mycel channel list
 
 # Verify you're sending to correct channel
-bc channel history #general
+mycel channel history #general
 
 # Resend message
-bc channel send #general "Test message"
+mycel channel send #general "Test message"
 ```
 
 ### Issue: Performance slow or timeouts
@@ -346,13 +346,13 @@ bc channel send #general "Test message"
 **Solution:**
 ```bash
 # Check system resources
-bc status --verbose
+mycel status --verbose
 
 # Clear cache
-bc cache clear
+mycel cache clear
 
 # Restart root agent
-bc down && bc up
+mycel down && mycel up
 ```
 
 ---
@@ -392,32 +392,32 @@ Here's a realistic end-to-end workflow:
 
 ```bash
 # 1. Initialize
-bc init && bc up
+mycel init && mycel up
 
 # 2. Create team
-bc agent create pm-alex --role product-manager --tool notion
-bc agent create eng-sam --role engineer --tool cursor
-bc agent create qa-jamie --role qa --tool chrome
+mycel agent create pm-alex --role product-manager --tool notion
+mycel agent create eng-sam --role engineer --tool cursor
+mycel agent create qa-jamie --role qa --tool chrome
 
 # 3. Define work
-bc queue add "Build user profile page" --priority high --epic "user-feature"
+mycel queue add "Build user profile page" --priority high --epic "user-feature"
 
 # 4. Assign via channel
-bc channel send #engineering "@eng-sam: Pick up user profile task. UI design in #product. Ship within 2 hours?"
+mycel channel send #engineering "@eng-sam: Pick up user profile task. UI design in #product. Ship within 2 hours?"
 
 # 5. Monitor progress
-bc agent peek eng-sam
-bc channel history #engineering
+mycel agent peek eng-sam
+mycel channel history #engineering
 
 # 6. Approve & merge
-bc queue merge
-bc merge feature/user-profile --branch main
+mycel queue merge
+mycel merge feature/user-profile --branch main
 
 # 7. Announce
-bc channel send #general "🎉 User profile feature live! Thanks team!"
+mycel channel send #general "🎉 User profile feature live! Thanks team!"
 
 # 8. Record learning
-bc memory record "User profile workflow successful. Took 1.5 hours end-to-end"
+mycel memory record "User profile workflow successful. Took 1.5 hours end-to-end"
 ```
 
 ---
@@ -426,16 +426,16 @@ bc memory record "User profile workflow successful. Took 1.5 hours end-to-end"
 
 | Task | Command |
 |------|---------|
-| Check status | `bc status` |
-| List agents | `bc agent list` |
-| View work queue | `bc queue work` |
-| Send message | `bc channel send #channel "message"` |
-| View agent work | `bc agent peek engineer-name` |
-| Merge PR | `bc merge branch-name --branch main` |
-| Schedule task | `bc cron create name --schedule "0 2 * * *"` |
-| Search memory | `bc memory search "pattern"` |
-| View logs | `bc agent logs agent-name --tail 20` |
-| Get help | `bc --help` |
+| Check status | `mycel status` |
+| List agents | `mycel agent list` |
+| View work queue | `mycel queue work` |
+| Send message | `mycel channel send #channel "message"` |
+| View agent work | `mycel agent peek engineer-name` |
+| Merge PR | `mycel merge branch-name --branch main` |
+| Schedule task | `mycel cron create name --schedule "0 2 * * *"` |
+| Search memory | `mycel memory search "pattern"` |
+| View logs | `mycel agent logs agent-name --tail 20` |
+| Get help | `mycel --help` |
 
 ---
 
@@ -443,7 +443,7 @@ bc memory record "User profile workflow successful. Took 1.5 hours end-to-end"
 
 **Command line help:**
 ```bash
-bc --help
+mycel --help
 bc <command> --help
 ```
 


### PR DESCRIPTION
## Summary

- Update docker run commands and post-install CLI examples in `landing/` to use `mycel` (the binary shipped by `ghcr.io/rpuneet/mycel:*` and `brew install rpuneet/mycel/mycel` since v0.2.3).
- Leave `go install github.com/rpuneet/bc/cmd/bc@latest` untouched — the Go module path rename is deferred to #3054 — and add an inline note explaining that `go install` produces a binary named `bc`.

Part of #3054

## Files touched

- `landing/src/app/_components/InstallSection.tsx`, `Nav.tsx`
- `landing/src/app/docs/getting-started.md`
- `landing/docs/{cli-reference,faq,getting-started,examples,features}.md`
- `landing/public/llms.txt`

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run lint`
- [x] `bun run build` (Next.js static export green)
- [ ] CI green on PR