### PR TITLE
chore(release): drop scoop publishing to unblock v0.2.3 Linux+Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,11 +92,9 @@ jobs:
       - name: Verify release secrets
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          SCOOP_TAP_TOKEN: ${{ secrets.SCOOP_TAP_TOKEN }}
         run: |
           MISSING=""
           if [ -z "$HOMEBREW_TAP_TOKEN" ]; then MISSING="$MISSING HOMEBREW_TAP_TOKEN"; fi
-          if [ -z "$SCOOP_TAP_TOKEN" ]; then MISSING="$MISSING SCOOP_TAP_TOKEN"; fi
           if [ -n "$MISSING" ]; then
             echo "::error::Missing required secrets:$MISSING"
             exit 1
@@ -111,7 +109,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          SCOOP_TAP_TOKEN: ${{ secrets.SCOOP_TAP_TOKEN }}
 
   # ── macOS release (native CGO builds on both architectures) ─────────
   release-macos:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -159,17 +159,6 @@ brews:
     test: |
       system "#{bin}/mycel", "version"
 
-scoops:
-  - name: mycel
-    repository:
-      owner: rpuneet
-      name: scoop-mycel
-      token: "{{ .Env.SCOOP_TAP_TOKEN }}"
-      branch: main
-    homepage: https://bc-infra.com
-    description: Orchestration for AI agents
-    license: MIT
-    skip_upload: auto
 
 nfpms:
   - id: mycel-linux


### PR DESCRIPTION
Removes the scoop bucket from .goreleaser.yml + SCOOP_TAP_TOKEN refs from release.yml. The rpuneet/scoop-mycel tap doesn't exist; until it does, the secret-verification gate fails the whole Linux+Windows release. Skipping scoop until/unless we set up a Scoop bucket later.

Once HOMEBREW_TAP_TOKEN is on rpuneet/mycel, the v0.2.3 Linux+Windows job can be re-run and will publish.

Part of #3054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Scoop package manager distribution from the release process.
  * Simplified release workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->