### PR TITLE
docs(gateway): clarify adapters are inbound-only; outbound is agent's responsibility

### DIFF
--- a/docs/architecture/notifications.md
+++ b/docs/architecture/notifications.md
@@ -33,6 +33,35 @@ flowchart LR
     A1 & A2 & A3 -. "respond via platform API\n(credentials in env vars)" .-> Platforms
 ```
 
+## Gateway adapters are inbound-only
+
+Gateway adapters in `pkg/gateway/<platform>/` exist to **receive** messages
+from external platforms (Slack, Telegram, Discord, WhatsApp, GitHub, etc.)
+and dispatch them into bcd's notification pipeline. They are **not** a
+generic outbound abstraction.
+
+When an agent needs to **send** a message to an external platform, the
+agent talks to the platform's API directly using credentials injected
+from `prefs.json` / the workspace secret store. Examples:
+
+- **Telegram**: `curl -H "Authorization: Bearer $TELEGRAM_BOT_TOKEN" https://api.telegram.org/bot.../sendMessage`
+- **Slack**: `chat.postMessage` via the Slack Web API using `$SLACK_BOT_TOKEN`
+- **WhatsApp**: `whatsmeow` library directly — the gateway only listens; agents send
+
+The existing `Send` methods on the Slack, Telegram, and Discord adapters
+are a **legacy convenience** used internally by bcd's notify dispatch
+path (e.g. when a local channel relays to an external platform via the
+`POST /api/gateways/{platform}/channels/{channel}/send` endpoint). Do
+**not** add `Send` to new adapters. WhatsApp, Matrix, IRC, Signal, and
+the other 30+ adapters deliberately have no `Send` method — that is
+correct per this design, **not** a missing feature or a bug.
+
+If you find a code-review tool flagging "adapter X is missing Send",
+that finding is incorrect: outbound is the agent's responsibility, and
+the inbound adapter is complete without it.
+
+## Connection patterns
+
 All 37+ platform adapters follow one of three connection patterns:
 
 | Pattern | Examples | Mechanism |

--- a/pkg/gateway/README.md
+++ b/pkg/gateway/README.md
@@ -40,15 +40,19 @@ Gateway adapters are **inbound-only**. They receive messages from
 external platforms and forward them to `pkg/notify` for dispatch. They
 are not a generic outbound abstraction.
 
-When an agent needs to **send** a message back to an external platform,
-the agent calls the platform's API directly using credentials injected
-from the workspace secret store (e.g. `$SLACK_BOT_TOKEN`,
-`$TELEGRAM_BOT_TOKEN`). New adapters should **not** implement `Send`.
+**Interface contract**: the `NotificationAdapter` interface itself is
+inbound-only — it does **not** require a `Send` method. The required
+surface is `Name`, `Type`, `Start`, `Stop`, `HTTPHandler`, `Channels`,
+and `Status`. Outbound message sending is performed directly by
+agents and handlers using credentials injected from the workspace
+secret store (e.g. `$SLACK_BOT_TOKEN`, `$TELEGRAM_BOT_TOKEN`). New
+adapters should **not** implement `Send`.
 
 The `Send` methods on the Slack, Telegram, and Discord adapters are a
-legacy convenience used by bcd's internal notify dispatch path. Most
-adapters (WhatsApp, Matrix, IRC, Signal, etc.) deliberately have no
-`Send` method — that is correct, not a missing feature.
+legacy exception, retained as a convenience for bcd's internal notify
+dispatch path. They are not part of the `NotificationAdapter` contract.
+Most adapters (WhatsApp, Matrix, IRC, Signal, etc.) deliberately have
+no `Send` method — that is correct, not a missing feature.
 
 See [docs/architecture/notifications.md](../../docs/architecture/notifications.md#gateway-adapters-are-inbound-only)
 for the full rationale, message flow diagrams, credential injection,

--- a/pkg/gateway/README.md
+++ b/pkg/gateway/README.md
@@ -34,6 +34,26 @@ This package defines the `NotificationAdapter` interface and `Manager` that orch
 | Matrix | `matrix/` | Poll |
 | + 21 more | see subdirectories | various |
 
+## Inbound-only by design
+
+Gateway adapters are **inbound-only**. They receive messages from
+external platforms and forward them to `pkg/notify` for dispatch. They
+are not a generic outbound abstraction.
+
+When an agent needs to **send** a message back to an external platform,
+the agent calls the platform's API directly using credentials injected
+from the workspace secret store (e.g. `$SLACK_BOT_TOKEN`,
+`$TELEGRAM_BOT_TOKEN`). New adapters should **not** implement `Send`.
+
+The `Send` methods on the Slack, Telegram, and Discord adapters are a
+legacy convenience used by bcd's internal notify dispatch path. Most
+adapters (WhatsApp, Matrix, IRC, Signal, etc.) deliberately have no
+`Send` method — that is correct, not a missing feature.
+
+See [docs/architecture/notifications.md](../../docs/architecture/notifications.md#gateway-adapters-are-inbound-only)
+for the full rationale, message flow diagrams, credential injection,
+and how to add new adapters.
+
 ## Architecture
 
 See [docs/architecture/notifications.md](../../docs/architecture/notifications.md) for the full notification architecture, including message flow diagrams, credential injection, and how to add new adapters.


### PR DESCRIPTION
Closes #3067.

## Summary

Documents that gateway adapters in `pkg/gateway/<platform>/` are **inbound-only** by design. Outbound messaging is the agent's job — agents call platform APIs directly using credentials injected from the workspace secret store.

The `Send` methods on Slack, Telegram, and Discord are legacy convenience used by bcd's internal notify dispatch path (the `POST /api/gateways/{platform}/channels/{channel}/send` endpoint). They are **not** a template for new adapters.

## Why

Code review tools have been flagging "adapter X is missing `Send`" as a bug — most recently on the WhatsApp adapter. This finding is incorrect: WhatsApp, Matrix, IRC, Signal, and 30+ other adapters deliberately have no `Send`, because outbound is the agent's responsibility. This PR makes the design intent explicit so the same finding doesn't keep getting re-raised.

## Changes

- `docs/architecture/notifications.md` — add **"Gateway adapters are inbound-only"** section before the connection patterns table
- `pkg/gateway/README.md` — add **"Inbound-only by design"** section pointing to the architecture doc

## Test plan

- [x] `make check-go` passes
- [ ] Docs render correctly on GitHub
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced notification system architecture documentation explaining how gateway adapters function as inbound-only receivers that forward events through the notification pipeline.
  * Clarified that outbound messaging is handled by agents directly via platform APIs using workspace credentials.
  * Documented implementation guidelines for new adapters and clarified legacy patterns in existing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->