### PR TITLE
fix(cmd): set cobra root command name to mycel

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -30,7 +30,7 @@ func SetVersionInfo(v, c, d string) {
 
 // rootCmd is the base command for bc.
 var rootCmd = &cobra.Command{
-	Use:   "bc",
+	Use:   "mycel",
 	Short: "A simpler, more controllable agent orchestrator",
 	Long: `bc is a multi-agent orchestration system for AI coding assistants.
 


### PR DESCRIPTION
Cobra root.go had `Use: "bc"` which caused `mycel version` and `mycel --help` output to say 'bc' even after the binary was renamed to mycel in #3062.

1-line change to make output consistent with binary name.

Part of #3054