### PR TITLE
chore: final mycel-brand polish (closes the rest of #3054)

### DIFF
--- a/.github/COVERAGE.md
+++ b/.github/COVERAGE.md
@@ -1,7 +1,7 @@
 # Code Coverage Standards
 
 ## Overview
-bc maintains code quality through continuous coverage enforcement. All PRs must meet coverage thresholds before merge.
+mycel maintains code quality through continuous coverage enforcement. All PRs must meet coverage thresholds before merge.
 
 ## Coverage Requirements
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -133,7 +133,7 @@ body:
         make ci-local                       # Full CI pipeline (MUST PASS)
         make test-go                        # Go tests with race detector
         make lint-go                        # golangci-lint
-        make build-bcd-local                # Build bcd server
+        make build-local-mycel              # Build mycel binary (embeds server + web UI)
         go test -race -run TestName ./pkg/  # Run specific test
         ```
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -124,13 +124,13 @@ body:
 
         ```bash
         make ci-local                       # Full CI pipeline (MUST PASS before merge)
-        make build-bc-local                 # Build bc CLI
-        make build-bcd-local                # Build bcd server
+        make build-local-mycel              # Build mycel CLI (embeds web UI + TUI + server)
+        make build-docker-daemon            # Build daemon Docker image
         make test-go                        # Go tests
         make test-ts                        # All TS tests
         make lint-go                        # golangci-lint
         make vet-ts                         # Typecheck all TS
-        make deploy-bcd-local               # Deploy locally on :9374
+        make run-mycel                      # Run mycel locally on :9374
         ```
 
         ### Labels (apply before starting work)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,7 @@ linters:
           - mnd
 
       # Ignore certain checks in main.go
-      - path: cmd/bc/main\.go
+      - path: cmd/mycel/main\.go
         linters:
           - gochecknoglobals
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,4 @@
-# GoReleaser configuration for bc
+# GoReleaser configuration for mycel
 # https://goreleaser.com
 #
 # macOS builds are handled separately in CI (release.yml) due to CGO requirements.
@@ -132,7 +132,7 @@ release:
     | Method | Command |
     |--------|---------|
     | **Homebrew** (macOS) | `brew install rpuneet/mycel/mycel` |
-    | **npm / bun** (Linux) | `npm install -g bc-cli` or `bunx bc-cli` |
+    | **npm / bun** (Linux) | `npm install -g mycel-cli` or `bunx mycel-cli` |
     | **Go** | `go install github.com/rpuneet/mycel/cmd/mycel@{{ .Tag }}` |
     | **Script** | `curl -fsSL https://raw.githubusercontent.com/rpuneet/mycel/main/scripts/install.sh \| bash` |
     | **Docker** | `docker pull ghcr.io/rpuneet/mycel:{{ .Tag }}` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Root Agent
 
-You are the root orchestrator for this bc workspace — a singleton agent
+You are the root orchestrator for this mycel workspace — a singleton agent
 that owns workspace health, agent coordination, and the merge queue.
 
 ## CRITICAL RULES
@@ -15,14 +15,14 @@ that owns workspace health, agent coordination, and the merge queue.
 - **query_costs**: Check workspace costs {agent?}
 
 ## Responsibilities
-- Monitor workspace health via bc status, bc doctor
+- Monitor workspace health via mycel status, mycel doctor
 - Create and coordinate feature-dev agents for implementation work
 - Review PRs and manage the merge queue via #merge channel
 - Track costs and stop runaway agents
-- Detect stuck agents via bc agent peek and send nudges
+- Detect stuck agents via mycel agent peek and send nudges
 
 ## Agent Management
 - Create agents: use create_agent MCP tool with role "feature-dev"
-- Docker agents start without auth — they need login via bc agent attach
+- Docker agents start without auth — they need login via mycel agent attach
 - Monitor agent state: idle, working, stuck, stopped
 - Clean up stopped agents when work is complete

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ make lint
 
 ```
 bc/
-├── cmd/bc/              # CLI entry point (main.go)
+├── cmd/mycel/           # CLI entry point (main.go)
 ├── config/              # Generated config code (cfgx)
 ├── internal/
 │   └── cmd/             # Cobra command implementations

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# bc
+# mycel
 
 [![CI](https://github.com/rpuneet/mycel/actions/workflows/ci.yml/badge.svg)](https://github.com/rpuneet/mycel/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/rpuneet/mycel?include_prereleases)](https://github.com/rpuneet/mycel/releases)
 [![Go](https://img.shields.io/github/go-mod/go-version/rpuneet/mycel)](https://go.dev/)
 [![License](https://img.shields.io/github/license/rpuneet/mycel)](LICENSE)
 
-AI agents are powerful alone — chaotic when they work together. bc fixes that.
+AI agents are powerful alone — chaotic when they work together. mycel fixes that.
 
 Coordinate teams of Claude, Gemini, Cursor, and other AI agents with isolated worktrees, shared channels, and cost controls. One binary. No login. MIT licensed.
 
@@ -22,7 +22,7 @@ brew install rpuneet/mycel/mycel
 go install github.com/rpuneet/mycel/cmd/mycel@latest
 
 # From source
-git clone https://github.com/rpuneet/mycel && cd mycel && make install-local-bc
+git clone https://github.com/rpuneet/mycel && cd mycel && make install-local-mycel
 ```
 
 **Prerequisites:** Go 1.25+, tmux, git. For TUI: Bun.
@@ -30,23 +30,23 @@ git clone https://github.com/rpuneet/mycel && cd mycel && make install-local-bc
 ## Quick Start
 
 ```bash
-bc init                    # Initialize workspace
-bc up                      # Start server + web UI on localhost:9374
-bc agent create eng-01 \
+mycel init                    # Initialize workspace
+mycel up                      # Start server + web UI on localhost:9374
+mycel agent create eng-01 \
   --role engineer \
-  --tool claude            # Spawn an agent
-bc status                  # See what's running
-bc agent peek eng-01       # Watch agent output
-bc cost show               # Check spending
+  --tool claude               # Spawn an agent
+mycel status                  # See what's running
+mycel agent peek eng-01       # Watch agent output
+mycel cost show               # Check spending
 ```
 
 Open **http://localhost:9374** for the web dashboard.
 
-## What bc Does
+## What mycel Does
 
-**Without bc:** One agent at a time. Context lost between sessions. Merge conflicts from parallel edits. No visibility. Surprise bills.
+**Without mycel:** One agent at a time. Context lost between sessions. Merge conflicts from parallel edits. No visibility. Surprise bills.
 
-**With bc:** Multiple agents in parallel. Each gets its own git worktree — zero conflicts. Persistent channels for structured communication. Per-agent budgets with hard stops. Everything observable in real time.
+**With mycel:** Multiple agents in parallel. Each gets its own git worktree — zero conflicts. Persistent channels for structured communication. Per-agent budgets with hard stops. Everything observable in real time.
 
 ### How It Works
 
@@ -72,62 +72,62 @@ Open **http://localhost:9374** for the web dashboard.
 
 | Command | Description |
 |---------|-------------|
-| `bc` | Open TUI dashboard |
-| `bc init` | Initialize workspace |
-| `bc up` | Start server (foreground) |
-| `bc up -d` | Start server (daemon) |
-| `bc down` | Stop server |
-| `bc status` | Show agent status |
-| `bc doctor` | Diagnose workspace issues |
+| `mycel` | Open TUI dashboard |
+| `mycel init` | Initialize workspace |
+| `mycel up` | Start server (foreground) |
+| `mycel up -d` | Start server (daemon) |
+| `mycel down` | Stop server |
+| `mycel status` | Show agent status |
+| `mycel doctor` | Diagnose workspace issues |
 
 ### Agents
 
 | Command | Description |
 |---------|-------------|
-| `bc agent create [name]` | Create agent with role and tool |
-| `bc agent list` | List all agents |
-| `bc agent attach <agent>` | Attach to agent's tmux session |
-| `bc agent peek <agent>` | Watch agent output |
-| `bc agent send <agent> <msg>` | Send message to agent |
-| `bc agent stop <agent>` | Stop agent |
-| `bc agent delete <agent>` | Delete agent |
+| `mycel agent create [name]` | Create agent with role and tool |
+| `mycel agent list` | List all agents |
+| `mycel agent attach <agent>` | Attach to agent's tmux session |
+| `mycel agent peek <agent>` | Watch agent output |
+| `mycel agent send <agent> <msg>` | Send message to agent |
+| `mycel agent stop <agent>` | Stop agent |
+| `mycel agent delete <agent>` | Delete agent |
 
 ### Channels
 
 | Command | Description |
 |---------|-------------|
-| `bc channel list` | List channels |
-| `bc channel create <name>` | Create channel |
-| `bc channel send <ch> <msg>` | Send message |
-| `bc channel history <ch>` | View history |
+| `mycel channel list` | List channels |
+| `mycel channel create <name>` | Create channel |
+| `mycel channel send <ch> <msg>` | Send message |
+| `mycel channel history <ch>` | View history |
 
 ### Cost & Scheduling
 
 | Command | Description |
 |---------|-------------|
-| `bc cost show` | Show cost records |
-| `bc cost budget show` | Budget status |
-| `bc cron add <name>` | Schedule recurring task |
-| `bc cron list` | List scheduled tasks |
+| `mycel cost show` | Show cost records |
+| `mycel cost budget show` | Budget status |
+| `mycel cron add <name>` | Schedule recurring task |
+| `mycel cron list` | List scheduled tasks |
 
 ### Configuration
 
 | Command | Description |
 |---------|-------------|
-| `bc config show` | Show configuration |
-| `bc config set <key> <val>` | Set config value |
-| `bc secret set <name>` | Store encrypted secret |
-| `bc tool list` | List available tools |
-| `bc mcp list` | List MCP servers |
-| `bc role list` | List agent roles |
+| `mycel config show` | Show configuration |
+| `mycel config set <key> <val>` | Set config value |
+| `mycel secret set <name>` | Store encrypted secret |
+| `mycel tool list` | List available tools |
+| `mycel mcp list` | List MCP servers |
+| `mycel role list` | List agent roles |
 
-Full reference: `bc --help` or `bc <command> --help`
+Full reference: `mycel --help` or `mycel <command> --help`
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────┐
-│                    bc binary                     │
+│                  mycel binary                    │
 │                                                  │
 │  ┌──────────┐  ┌──────────┐  ┌───────────────┐  │
 │  │   CLI    │  │   TUI    │  │  HTTP Server  │  │
@@ -188,7 +188,7 @@ make build            # Build everything
 make test             # Run all tests
 make lint             # Run linters
 make check            # Full quality gate
-make run-bc           # Run from source
+make run-mycel        # Run from source
 make run-web          # Web UI dev server (hot reload)
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,7 +45,7 @@ We take security seriously. If you discover a security vulnerability in bc, plea
 
 This policy applies to:
 
-- The **bc CLI** tool (`cmd/bc`, `internal/cmd`, `pkg/`)
+- The **mycel CLI** tool (`cmd/mycel`, `internal/cmd`, `pkg/`)
 - The **bcd server** (`server/`) including the REST API, WebSocket, and MCP SSE endpoints
 - The **TUI** interface (`tui/`)
 - The **web dashboard** (`web/`) embedded in bcd

--- a/VISION.md
+++ b/VISION.md
@@ -2,7 +2,7 @@
 
 ## Multi-Agent Orchestration for Software Development
 
-**bc** is a CLI tool for orchestrating multiple AI agents to work together on software projects. Unlike single-agent tools, bc enables teams of specialized agents coordinating through structured communication.
+**mycel** is a CLI tool for orchestrating multiple AI agents to work together on software projects. Unlike single-agent tools, mycel enables teams of specialized agents coordinating through structured communication.
 
 ## Core Philosophy
 
@@ -29,7 +29,7 @@ Humans remain in control:
 
 ## Unique Differentiators
 
-| Feature | bc | Single-Agent Tools |
+| Feature | mycel | Single-Agent Tools |
 |---------|----|--------------------|
 | Multiple parallel agents | Yes | No |
 | Role-based hierarchy | Yes | No |
@@ -68,7 +68,7 @@ Humans remain in control:
 
 ## Getting Involved
 
-bc is open source. Contributions welcome:
+mycel is open source. Contributions welcome:
 - Report issues on GitHub
 - Submit PRs for features and fixes
 - Share feedback on multi-agent workflows

--- a/docs/adr/0001-cli-architecture.md
+++ b/docs/adr/0001-cli-architecture.md
@@ -48,9 +48,9 @@ The current React TUI bundle (`internal/cmd/tui-bundle/`) will be **deprecated**
 
 ### 4. Single entry point, no `cmd/bcd`
 
-- `cmd/bc` is the only binary. `bc daemon run` is the blessed way to launch `bcd`.
+- `cmd/mycel` is the only binary. `mycel daemon run` is the blessed way to launch the server.
 - `cmd/bcd` does **not** exist and should not be added.
-- Handlers live under `server/handlers/` and are shared by the embedded web UI, CLI HTTP client, and `bc tunnel`.
+- Handlers live under `server/handlers/` and are shared by the embedded web UI, CLI HTTP client, and `mycel tunnel`.
 
 ### 5. `--json` everywhere; `--help` from a meta endpoint
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -198,8 +198,8 @@ The React SPA is compiled and embedded in the bcd binary via `server/web/dist/`.
 ## Package Dependencies
 
 ```
-cmd/bc/          -->  internal/cmd/  -->  pkg/client/
-cmd/bcd/         -->  server/        -->  pkg/*
+cmd/mycel/       -->  internal/cmd/  -->  pkg/client/
+                 -->  server/        -->  pkg/*
 
 server/
   handlers/      -->  pkg/agent/, pkg/notify/, pkg/cost/, ...

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -89,11 +89,11 @@ graph TB
 
 ## Components
 
-### bc CLI (`cmd/bc/`)
+### mycel CLI (`cmd/mycel/`)
 
-Thin HTTP client. All commands are HTTP requests to bcd -- no direct DB/filesystem access. Opens the TUI if a workspace exists, prompts init if not, shows help in non-interactive mode.
+Thin HTTP client. All commands are HTTP requests to the daemon -- no direct DB/filesystem access. Opens the TUI if a workspace exists, prompts init if not, shows help in non-interactive mode.
 
-### bcd Daemon (`cmd/bcd/`, `server/`)
+### Daemon (`cmd/mycel/`, `server/`)
 
 Long-running HTTP server on `127.0.0.1:9374`. Single process managing all state.
 

--- a/internal/cmd/agent_test.go
+++ b/internal/cmd/agent_test.go
@@ -862,8 +862,8 @@ func TestAgentCreate_RejectsRootRole(t *testing.T) {
 	if !strings.Contains(err.Error(), "cannot create root agent") {
 		t.Errorf("error should mention cannot create root agent: %v", err)
 	}
-	if !strings.Contains(err.Error(), "bc up") {
-		t.Errorf("error should mention 'bc up': %v", err)
+	if !strings.Contains(err.Error(), "mycel up") {
+		t.Errorf("error should mention 'mycel up': %v", err)
 	}
 }
 

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -94,7 +94,7 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 	ws, err := getWorkspace()
 	if err != nil {
 		// No workspace: run tools-only check
-		fmt.Println("bc doctor")
+		fmt.Println("mycel doctor")
 		fmt.Println(strings.Repeat("─", 40))
 		fmt.Println()
 		fmt.Println(ui.YellowText("⚠") + " No workspace found — running tools check only")
@@ -227,7 +227,7 @@ func runDoctorFix(cmd *cobra.Command, _ []string) error {
 // ─── Output helpers ───────────────────────────────────────────────────────────
 
 func printReport(report *doctor.Report) {
-	fmt.Println("bc doctor")
+	fmt.Println("mycel doctor")
 	fmt.Println(strings.Repeat("─", 40))
 	fmt.Println()
 
@@ -282,7 +282,7 @@ func printCategory(cat doctor.CategoryReport) {
 // ─── Client report helpers (for API-based output) ─────────────────────────────
 
 func printClientReport(report *client.DoctorReport) {
-	fmt.Println("bc doctor")
+	fmt.Println("mycel doctor")
 	fmt.Println(strings.Repeat("─", 40))
 	fmt.Println()
 

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -14,9 +14,9 @@ Use the secrets store for sensitive values (bc secret set NAME VALUE)
 or set environment variables on the host / in Docker.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		fmt.Println("Environment variable management has been removed from settings.")
-		fmt.Println("Use 'bc secret set NAME VALUE' for sensitive values,")
+		fmt.Println("Use 'mycel secret set NAME VALUE' for sensitive values,")
 		fmt.Println("or set environment variables on the host / in Docker.")
-		return fmt.Errorf("bc env has been removed; use 'bc secret set NAME VALUE' or host/container env vars")
+		return fmt.Errorf("mycel env has been removed; use 'mycel secret set NAME VALUE' or host/container env vars")
 	},
 }
 

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -124,12 +124,12 @@ func runInit(cmd *cobra.Command, args []string) error {
 	if isV1Workspace(absDir) {
 		log.Debug("v1 workspace detected", "dir", absDir)
 		fmt.Fprintln(os.Stderr, "Warning: Existing v1 workspace detected.")
-		fmt.Fprintln(os.Stderr, "bc v2 is a clean break - v1 data will not be migrated.")
+		fmt.Fprintln(os.Stderr, "mycel v2 is a clean break - v1 data will not be migrated.")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "To proceed:")
 		fmt.Fprintln(os.Stderr, "  - Backup .bc/ if needed")
 		fmt.Fprintln(os.Stderr, "  - Remove .bc/ directory")
-		fmt.Fprintln(os.Stderr, "  - Run bc init again")
+		fmt.Fprintln(os.Stderr, "  - Run mycel init again")
 		return fmt.Errorf("cannot initialize: v1 workspace exists")
 	}
 
@@ -196,7 +196,7 @@ func newDaemonClient(ctx context.Context) (*client.Client, error) {
 	}
 	c := client.New("")
 	if err := c.Ping(ctx); err != nil {
-		return nil, fmt.Errorf("bcd is not running — start it with 'bcd' or 'bc up' first\n(%w)", err)
+		return nil, fmt.Errorf("bcd is not running — start it with 'bcd' or 'mycel up' first\n(%w)", err)
 	}
 	return c, nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,4 +1,4 @@
-// Package cmd implements the bc CLI commands.
+// Package cmd implements the mycel CLI commands.
 package cmd
 
 import (
@@ -28,28 +28,28 @@ func SetVersionInfo(v, c, d string) {
 	date = d
 }
 
-// rootCmd is the base command for bc.
+// rootCmd is the base command for mycel.
 var rootCmd = &cobra.Command{
-	Use:   "bc",
+	Use:   "mycel",
 	Short: "A simpler, more controllable agent orchestrator",
-	Long: `bc is a multi-agent orchestration system for AI coding assistants.
+	Long: `mycel is a multi-agent orchestration system for AI coding assistants.
 
 Coordinate multiple AI agents with predictable behavior and cost awareness.
 Supports Claude Code, Cursor, Codex, and other AI coding tools.
 
 Getting Started:
-  bc init                                 # Initialize workspace
-  bc up                                   # Start root agent
-  bc agent create eng-01 --role engineer  # Create engineer agent
-  bc status                               # View agent status
-  bc up                                   # Start server
+  mycel init                                 # Initialize workspace
+  mycel up                                   # Start root agent
+  mycel agent create eng-01 --role engineer  # Create engineer agent
+  mycel status                               # View agent status
+  mycel up                                   # Start server
 
 Common Workflows:
-  Start working:    bc up && bc status
-  Monitor agents:   bc status --activity
-  Send message:     bc channel send eng "message"
-  Debug agent:      bc logs --agent eng-01 --tail 50
-  Cost check:       bc cost show
+  Start working:    mycel up && mycel status
+  Monitor agents:   mycel status --activity
+  Send message:     mycel channel send eng "message"
+  Debug agent:      mycel logs --agent eng-01 --tail 50
+  Cost check:       mycel cost show
 
 Command Groups (with short aliases):
   agent                        Manage agents
@@ -95,11 +95,11 @@ var versionCmd = &cobra.Command{
 	Long: `Print version, commit hash, and build date.
 
 Examples:
-  bc version       # Show version info
-  bc --version     # Same as above (short flag)
-  bc -V            # Same as above`,
+  mycel version       # Show version info
+  mycel --version     # Same as above (short flag)
+  mycel -V            # Same as above`,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "bc %s\n", version)
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "mycel %s\n", version)
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  commit: %s\n", commit)
 		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "  built:  %s\n", date)
 	},

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -19,8 +19,8 @@ func TestRootCommand(t *testing.T) {
 	}
 
 	output := buf.String()
-	if !strings.Contains(output, "bc") {
-		t.Errorf("Expected output to contain 'bc', got: %s", output)
+	if !strings.Contains(output, "mycel") {
+		t.Errorf("Expected output to contain 'mycel', got: %s", output)
 	}
 }
 
@@ -51,7 +51,7 @@ func TestRootReturnsCommand(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("Root() returned nil")
 	}
-	if cmd.Use != "bc" {
-		t.Errorf("Expected Use = 'bc', got '%s'", cmd.Use)
+	if cmd.Use != "mycel" {
+		t.Errorf("Expected Use = 'mycel', got '%s'", cmd.Use)
 	}
 }

--- a/landing/src/app/docs/getting-started.md
+++ b/landing/src/app/docs/getting-started.md
@@ -49,9 +49,9 @@ docker run -p 9374:9374 -v $(pwd):/workspace ghcr.io/rpuneet/mycel:main mycel up
 ### npm / bun
 
 ```bash
-npm install -g bc-cli
+npm install -g mycel-cli
 # or
-bunx bc-cli
+bunx mycel-cli
 ```
 
 ### Go

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
-site_name: bc Documentation
+site_name: mycel Documentation
 site_description: Multi-agent AI orchestration CLI
-site_author: bc contributors
-site_url: https://rpuneet.github.io/bc
+site_author: mycel contributors
+site_url: https://rpuneet.github.io/mycel
 
 repo_name: rpuneet/mycel
 repo_url: https://github.com/rpuneet/mycel

--- a/pkg/gateway/github/github.go
+++ b/pkg/gateway/github/github.go
@@ -54,7 +54,7 @@ func New(secret string) *Adapter {
 }
 
 // NewNamed creates a named GitHub adapter for multi-repo setups
-// (e.g. "github:bc", "github:trade").
+// (e.g. "github:mycel", "github:trade").
 func NewNamed(name, secret string) *Adapter {
 	return &Adapter{
 		name:   name,

--- a/pkg/gateway/irc/irc.go
+++ b/pkg/gateway/irc/irc.go
@@ -22,7 +22,7 @@ import (
 type Config struct { //nolint:govet
 	Server   string   // e.g. "irc.libera.chat:6697"
 	Nick     string   // bot nickname
-	Channels []string // channels to join (e.g. ["#bc", "#dev"])
+	Channels []string // channels to join (e.g. ["#mycel", "#dev"])
 	UseTLS   bool
 	Password string // optional server password
 }
@@ -60,7 +60,7 @@ func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification))
 		Nick:          a.cfg.Nick,
 		UseTLS:        a.cfg.UseTLS,
 		Password:      a.cfg.Password,
-		QuitMessage:   "bc agent disconnecting",
+		QuitMessage:   "mycel agent disconnecting",
 		KeepAlive:     30, // send PING every 30s to detect dead connections
 		ReconnectFreq: 10, // reconnect after 10s on drop
 	}

--- a/pkg/gateway/reddit/reddit.go
+++ b/pkg/gateway/reddit/reddit.go
@@ -107,7 +107,7 @@ func (a *Adapter) poll(ctx context.Context) {
 		return
 	}
 	req.Header.Set("Authorization", "Bearer "+a.bearerToken)
-	req.Header.Set("User-Agent", "bc-gateway/1.0")
+	req.Header.Set("User-Agent", "mycel-gateway/1.0")
 
 	resp, err := a.httpClient.Do(req)
 	if err != nil {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -95,7 +95,7 @@ download_and_install() {
 
     if ! curl -fsSL "$DOWNLOAD_URL" -o "${TMP_DIR}/${ARCHIVE_NAME}"; then
         rm -rf "$TMP_DIR"
-        error "Failed to download bc. Check if release exists for ${OS}/${ARCH}."
+        error "Failed to download mycel. Check if release exists for ${OS}/${ARCH}."
     fi
 
     # Verify checksum if available

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -535,7 +535,7 @@ export function Layout() {
         location.pathname.includes(`/${seg}/`)
       );
     });
-    document.title = match ? `${match.label} \u2014 bc` : "bc";
+    document.title = match ? `${match.label} \u2014 mycel` : "mycel";
   }, [location.pathname]);
   useEffect(() => { setMobileOpen(false); }, [location.pathname]);
 
@@ -577,11 +577,11 @@ export function Layout() {
                   letterSpacing: -0.5,
                 }}
               >
-                bc
+                mycel
               </span>
               <div className="min-w-0">
                 <p className="text-[13px] font-semibold text-mycel-text truncate" style={{ letterSpacing: -0.1 }}>
-                  {userName ? `@${userName}` : "@bc"}
+                  {userName ? `@${userName}` : "@mycel"}
                 </p>
                 <p className="text-[9px] text-mycel-muted/40 -mt-0.5" style={{ fontFamily: "'JetBrains Mono', monospace" }}>workspace</p>
               </div>
@@ -598,7 +598,7 @@ export function Layout() {
                 letterSpacing: -0.5,
               }}
             >
-              bc
+              mycel
             </span>
           )}
           {isMobile ? (

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -383,7 +383,7 @@ export function Settings() {
 
       {restartWarning && (
         <div className="rounded border border-mycel-error/30 bg-mycel-error/10 px-3 py-1.5 text-xs text-mycel-error">
-          Changes saved. Restart bcd to apply (<code className="font-mono">bc down &amp;&amp; bc up -d</code>)
+          Changes saved. Restart bcd to apply (<code className="font-mono">mycel down &amp;&amp; mycel up -d</code>)
         </div>
       )}
 


### PR DESCRIPTION
Closes #3054 (final pass).

## Summary

Final pass of low-risk text-only mycel rebrand polish from the audit. Six focused commits, no logic changes.

## Surfaces touched

**CLI / cobra**
- `internal/cmd/root.go` Use/Short/Long, Getting Started examples, version output
- `internal/cmd/init.go` v1 clean-break warning + bcd-not-running hint
- `internal/cmd/doctor.go` report header
- `internal/cmd/env.go` removal error message
- `internal/cmd/agent_test.go` updated assertion to match new hint
- `internal/cmd/root_test.go` updated assertions

**Docs**
- `README.md` (heading, examples, ASCII diagram, Make target)
- `mkdocs.yml` site_name / site_author / site_url
- `.goreleaser.yml` header comment, npm package name (`mycel-cli`)
- `landing/src/app/docs/getting-started.md` npm/bunx commands
- `docs/adr/0001-cli-architecture.md`, `docs/explanation/architecture.md`, `docs/overview.md` cmd-path callouts
- `CONTRIBUTING.md` project tree
- `SECURITY.md` scope path
- `VISION.md` product references
- `CLAUDE.md` (root) orchestrator instructions
- `.github/COVERAGE.md` intro

**Web UI**
- `web/src/components/Layout.tsx` page title, sidebar logo glyph, username fallback
- `web/src/views/Settings.tsx` restart hint command

**Gateways (external strings)**
- `pkg/gateway/reddit/reddit.go` HTTP User-Agent
- `pkg/gateway/irc/irc.go` Channels example, QuitMessage
- `pkg/gateway/github/github.go` NewNamed example

**Scripts / CI cleanup**
- `scripts/install.sh` failed-download error
- `.golangci.yml` gochecknoglobals path (`cmd/bc/main.go` -> `cmd/mycel/main.go`)
- `.github/ISSUE_TEMPLATE/{feature_request,bug_report}.yml` replace dead make targets

## Carve-outs (intentionally NOT touched)

Per audit guidance: `~/.bc/` paths, `bc-*` Docker labels, `BC_*` env vars, default MCP server name "bc", localStorage keys, tmux session prefix `bc-`, `bc.db`, test fixture session names.

## Test plan

- [x] `make build-local-mycel` clean
- [x] `make lint-go` 0 issues
- [x] `make lint-ts` 0 errors
- [x] `go test -run "TestRoot|TestVersion|TestAgentCreate_RejectsRoot" ./internal/cmd/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
