### PR TITLE
chore(release): drop Docker image publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,48 +164,11 @@ jobs:
             dist/checksums-macos.txt
           fail_on_unmatched_files: false
 
-  # ── Docker image (GHCR) ─────────────────────────────────────────────
-  release-docker:
-    name: Release Docker
-    runs-on: ubuntu-latest
-    needs: [ci, prepare]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-          ref: ${{ needs.prepare.outputs.tag }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: docker/Dockerfile.bcd
-          push: true
-          tags: |
-            ghcr.io/rpuneet/mycel:${{ needs.prepare.outputs.tag }}
-            ghcr.io/rpuneet/mycel:latest
-          labels: |
-            org.opencontainers.image.source=https://github.com/rpuneet/mycel
-            org.opencontainers.image.version=${{ needs.prepare.outputs.version }}
-            org.opencontainers.image.revision=${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   # ── SBOM generation ──────────────────────────────────────────────────
   sbom:
     name: Generate SBOM
     runs-on: ubuntu-latest
-    needs: [release-linux, release-macos, release-docker, prepare]
+    needs: [release-linux, release-macos, prepare]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
Per Puneet, Docker isn't needed as a release install method. Removes the release-docker job from release.yml + the sbom job's dependency on it.

cd-main.yml's main-branch Docker build is untouched — separate concern; can be removed in a follow-up if you want Docker fully gone.

Part of #3054