### PR TITLE
fix(web,gateway): P1/P2 bundle from Playwright audit

### DIFF
--- a/pkg/gateway/discord/discord.go
+++ b/pkg/gateway/discord/discord.go
@@ -141,17 +141,24 @@ func (a *Adapter) handleReady(_ *discordgo.Session, r *discordgo.Ready) {
 	log.Info("discord: ready", "guilds", len(r.Guilds))
 
 	for _, guild := range r.Guilds {
+		guildName := guild.ID
+		if g, err := a.session.Guild(guild.ID); err == nil && g.Name != "" {
+			guildName = g.Name
+		}
+
 		channels, err := a.session.GuildChannels(guild.ID)
 		if err != nil {
-			log.Warn("discord: failed to list channels", "guild", guild.ID, "error", err)
+			log.Warn("discord: failed to list channels", "guild", guildName, "error", err)
 			continue
 		}
 
 		a.chatMu.Lock()
 		for _, ch := range channels {
 			if ch.Type == discordgo.ChannelTypeGuildText {
-				a.guildChannels[ch.ID] = ch.Name
-				log.Info("discord: discovered channel", "channel", ch.Name, "id", ch.ID, "guild", guild.ID)
+				// Format: "guildName:channelName" — gateway manager keeps the
+				// separator so the sidebar shows server + channel separately.
+				a.guildChannels[ch.ID] = guildName + ":" + ch.Name
+				log.Info("discord: discovered channel", "channel", guildName+":"+ch.Name, "id", ch.ID)
 			}
 		}
 		a.chatMu.Unlock()

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -407,13 +407,15 @@ func (m *Manager) WebhookHandlers() map[string]http.Handler {
 }
 
 // sanitizeChannelName converts a group name to a valid bc channel name.
+// Preserves ':' so adapters can pass compound names like
+// "guildName:channelName" (Discord) without the segments concatenating.
 func sanitizeChannelName(name string) string {
 	name = strings.ToLower(name)
 	name = strings.ReplaceAll(name, " ", "-")
-	// Remove any characters that aren't alphanumeric, dash, or underscore
+	// Remove any characters that aren't alphanumeric, dash, underscore, or colon
 	var b strings.Builder
 	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == ':' {
 			b.WriteRune(r)
 		}
 	}

--- a/pkg/gateway/manager_test.go
+++ b/pkg/gateway/manager_test.go
@@ -18,6 +18,7 @@ func TestSanitizeChannelName(t *testing.T) {
 		{"café ☕", "caf-"},
 		{"UPPER CASE", "upper-case"},
 		{"a/b\\c", "abc"},
+		{"My Server:general", "my-server:general"},
 		{"", ""},
 	}
 	for _, tt := range tests {

--- a/server/handlers/terminal.go
+++ b/server/handlers/terminal.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"os"
@@ -13,7 +14,33 @@ import (
 
 	"github.com/rpuneet/mycel/pkg/agent"
 	"github.com/rpuneet/mycel/pkg/log"
+	"github.com/rpuneet/mycel/pkg/runtime"
 )
+
+// waitForSession polls rt.HasSession with short backoff until the session
+// is up or the deadline expires. Returns true if the session became
+// available within the deadline.
+func waitForSession(ctx context.Context, rt runtime.Backend, name string, max time.Duration) bool {
+	if rt.HasSession(ctx, name) {
+		return true
+	}
+	deadline := time.Now().Add(max)
+	delay := 50 * time.Millisecond
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(delay):
+		}
+		if rt.HasSession(ctx, name) {
+			return true
+		}
+		if delay < 400*time.Millisecond {
+			delay *= 2
+		}
+	}
+	return false
+}
 
 // TerminalHandler handles /api/agents/:name/terminal WebSocket connections.
 // It bridges the browser to a tmux session via a PTY.
@@ -61,7 +88,11 @@ func (h *TerminalHandler) HandleTerminal(w http.ResponseWriter, r *http.Request,
 		httpError(w, "no runtime backend for agent", http.StatusInternalServerError)
 		return
 	}
-	if !rt.HasSession(r.Context(), agentName) {
+	// Freshly-spawned agents race with the runtime: the agent record is
+	// already in StateRunning before tmux/docker has finished bringing the
+	// session up. Retry briefly (up to ~2s) before giving up so the UI's
+	// Attach tab does not 409 on the first connect after Create.
+	if !waitForSession(r.Context(), rt, agentName, 2*time.Second) {
 		httpError(w, "no active session for agent", http.StatusConflict)
 		return
 	}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -12,7 +12,7 @@
         "framer-motion": "^12.38.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "react-router-dom": "^7.14.2",
+        "react-router-dom": "^6.30.3",
         "react-virtuoso": "^4.18.3",
         "recharts": "^3.8.0",
       },
@@ -210,6 +210,8 @@
     "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
+    "@remix-run/router": ["@remix-run/router@1.23.2", "", {}, "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -412,8 +414,6 @@
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
-
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -703,9 +703,9 @@
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
 
-    "react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
+    "react-router": ["react-router@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2" }, "peerDependencies": { "react": ">=16.8" } }, "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw=="],
 
-    "react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
+    "react-router-dom": ["react-router-dom@6.30.3", "", { "dependencies": { "@remix-run/router": "1.23.2", "react-router": "6.30.3" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag=="],
 
     "react-virtuoso": ["react-virtuoso@4.18.6", "", { "peerDependencies": { "react": ">=16 || >=17 || >= 18 || >= 19", "react-dom": ">=16 || >=17 || >= 18 || >=19" } }, "sha512-CrT3P6HyjJMHZVWSste2bG2q5aWGlHfW2QuySZjiFwB2Qok/xsvgy+k8Z2jeDP8PP5KsBip7zNrl/F0QoxeyKw=="],
 
@@ -738,8 +738,6 @@
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
-
-    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "framer-motion": "^12.38.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.14.2",
+    "react-router-dom": "^6.30.3",
     "react-virtuoso": "^4.18.3",
     "recharts": "^3.8.0"
   },

--- a/web/src/components/CreateAgentModal.tsx
+++ b/web/src/components/CreateAgentModal.tsx
@@ -164,11 +164,16 @@ export function CreateAgentModal({
   }, [existingNames]);
 
   const handleCreate = useCallback(async () => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      alert("Agent name is required.");
+      return;
+    }
     try {
       const res = await fetch("/api/agents", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, template, tool: provider, runtime_backend: runtime, task: task || undefined }),
+        body: JSON.stringify({ name: trimmed, template, tool: provider, runtime_backend: runtime, task: task || undefined }),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({})) as { error?: string };
@@ -177,7 +182,7 @@ export function CreateAgentModal({
       }
       onClose();
       // Navigate to new agent
-      window.location.href = `/agents/${encodeURIComponent(name)}`;
+      window.location.href = `/agents/${encodeURIComponent(trimmed)}`;
     } catch {
       alert("Failed to create agent");
     }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -33,8 +33,8 @@ export function Header({ left, center, actions, compact = true }: HeaderProps) {
       style={{ fontFamily: MONO }}
     >
       <div
-        className={`flex items-center gap-2.5 min-w-0 px-6 ${
-          compact ? "h-[42px]" : "h-[52px]"
+        className={`flex items-center gap-2.5 min-w-0 px-3 sm:px-6 flex-wrap sm:flex-nowrap py-1.5 sm:py-0 ${
+          compact ? "sm:min-h-[42px]" : "sm:min-h-[52px]"
         }`}
       >
         {/* Left slot */}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -572,16 +572,16 @@ export function Layout() {
                   borderRadius: 7,
                   background: "var(--mycel-accent, #f97316)",
                   color: "#0d0d0d",
-                  fontSize: 12,
+                  fontSize: 14,
                   fontFamily: "'JetBrains Mono', monospace",
                   letterSpacing: -0.5,
                 }}
               >
-                mycel
+                m
               </span>
               <div className="min-w-0">
                 <p className="text-[13px] font-semibold text-mycel-text truncate" style={{ letterSpacing: -0.1 }}>
-                  {userName ? `@${userName}` : "@mycel"}
+                  {userName ? (userName.startsWith("@") ? userName : `@${userName}`) : "@mycel"}
                 </p>
                 <p className="text-[9px] text-mycel-muted/40 -mt-0.5" style={{ fontFamily: "'JetBrains Mono', monospace" }}>workspace</p>
               </div>
@@ -593,12 +593,12 @@ export function Layout() {
                 borderRadius: 7,
                 background: "var(--mycel-accent, #f97316)",
                 color: "#0d0d0d",
-                fontSize: 12,
+                fontSize: 14,
                 fontFamily: "'JetBrains Mono', monospace",
                 letterSpacing: -0.5,
               }}
             >
-              mycel
+              m
             </span>
           )}
           {isMobile ? (

--- a/web/src/components/notifications/SetupWizard.tsx
+++ b/web/src/components/notifications/SetupWizard.tsx
@@ -196,7 +196,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "secret", label: "Webhook Secret", placeholder: "your-webhook-secret" }],
     docs: [
       "Create a webhook → your repo → Settings → Webhooks.",
-      "Set the payload URL to your bc server\u2019s /hooks/github endpoint.",
+      "Set the payload URL to your bc server's /hooks/github endpoint.",
       "Set the secret here to match the webhook secret.",
     ],
   },
@@ -210,7 +210,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "token", label: "Token", placeholder: "webhook-secret-token" }],
     docs: [
       "Go to your GitLab project > Settings > Webhooks.",
-      "Set the URL to your bc server\u2019s /hooks/gitlab endpoint.",
+      "Set the URL to your bc server's /hooks/gitlab endpoint.",
       "Copy the secret token and paste it here.",
     ],
   },
@@ -224,7 +224,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "secret", label: "Secret", placeholder: "webhook-secret" }],
     docs: [
       "Go to your Bitbucket repo > Settings > Webhooks.",
-      "Add a webhook pointing to your bc server\u2019s /hooks/bitbucket endpoint.",
+      "Add a webhook pointing to your bc server's /hooks/bitbucket endpoint.",
       "Set the secret here for payload verification.",
     ],
   },

--- a/web/src/components/shared/McpEnvEditor.tsx
+++ b/web/src/components/shared/McpEnvEditor.tsx
@@ -51,7 +51,7 @@ export function McpEnvEditor({ serverNames }: McpEnvEditorProps) {
       <p className="text-[11px] text-mycel-muted/60" style={{ fontFamily: MONO }}>
         {serverNames.length === 0
           ? "No MCP servers attached."
-          : "Attached servers aren\u2019t in the MCP registry yet."}
+          : "Attached servers aren't in the MCP registry yet."}
       </p>
     );
   }
@@ -116,7 +116,7 @@ export function McpEnvEditor({ serverNames }: McpEnvEditorProps) {
       })}
       <p className="text-[10px] text-mycel-muted/40 leading-relaxed" style={{ fontFamily: MONO }}>
         MCP env is shared across every agent that uses the server. To override a
-        value per-agent, set it in the agent\u2019s Environment section above.
+        value per-agent, set it in the agent's Environment section above.
       </p>
     </div>
   );

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -966,7 +966,7 @@ function CodeTabPlaceholder({ agent }: { agent: Agent }) {
           Agent code — diff view
         </p>
         <p className="text-sm text-mycel-muted leading-relaxed">
-          Open the Code view with <span className="text-mycel-text/90">{agent.name}</span>&rsquo;s
+          Open the Code view with <span className="text-mycel-text/90">{agent.name}</span>'s
           worktree selected to see its uncommitted changes against the main repo.
         </p>
         <Link

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -71,18 +71,19 @@ function InlineAgentName({
   }
 
   return (
-    <button
-      type="button"
-      className="font-medium cursor-pointer hover:text-mycel-accent transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg rounded"
-      onClick={(e) => {
+    <span
+      className="font-medium"
+      // Double-click enters rename mode; single click should fall through
+      // to the row click (which opens the agent detail page).
+      onDoubleClick={(e) => {
         e.stopPropagation();
         setEditing(true);
       }}
-      title="Click to rename"
-      aria-label={`Rename agent ${agent.name}`}
+      title="Double-click to rename"
+      aria-label={`Agent ${agent.name} (double-click to rename)`}
     >
       {agent.name}
-    </button>
+    </span>
   );
 }
 
@@ -306,6 +307,9 @@ export function Agents() {
   // see the useEffect labelled "Global keyboard shortcuts".
 
   const handleStopAll = async () => {
+    if (typeof window !== "undefined" && !window.confirm("Stop all running agents? This cannot be undone.")) {
+      return;
+    }
     setStoppingAll(true);
     try {
       await api.stopAllAgents();
@@ -579,9 +583,10 @@ export function Agents() {
             (a) => a.state !== "stopped" && a.state !== "error",
           ) && (
             <button
+              type="button"
               onClick={handleStopAll}
               disabled={stoppingAll}
-              className="px-3 py-1.5 text-sm rounded bg-mycel-error/20 text-mycel-error hover:bg-mycel-error/30 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-mycel-error focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
+              className="px-3 py-1.5 text-xs font-medium rounded border border-mycel-error/40 bg-mycel-error/10 text-mycel-error hover:bg-mycel-error/20 hover:border-mycel-error/60 disabled:opacity-50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-mycel-error focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
               aria-label="Stop all agents"
             >
               {stoppingAll ? "Stopping..." : "Stop All"}

--- a/web/src/views/Code.tsx
+++ b/web/src/views/Code.tsx
@@ -163,14 +163,20 @@ export function Code() {
   useEffect(() => {
     let cancelled = false;
     const tick = async () => {
+      if (typeof document !== "undefined" && document.hidden) return;
       const s = await fetchCodeServerStatus();
       if (!cancelled) setCodeServer(s);
     };
     void tick();
-    const id = setInterval(() => void tick(), 5000);
+    const id = setInterval(() => void tick(), 10000);
+    const onVis = () => {
+      if (!document.hidden) void tick();
+    };
+    document.addEventListener("visibilitychange", onVis);
     return () => {
       cancelled = true;
       clearInterval(id);
+      document.removeEventListener("visibilitychange", onVis);
     };
   }, []);
 

--- a/web/src/views/CostsGlobal.tsx
+++ b/web/src/views/CostsGlobal.tsx
@@ -21,7 +21,7 @@ function defaultStart(): string {
 
 export function CostsGlobal() {
   const [start, setStart] = useState<string>(defaultStart);
-  const [groupBy, setGroupBy] = useState<GroupBy>("workspace");
+  const groupBy: GroupBy = "workspace";
   const [rows, setRows] = useState<CostRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -61,22 +61,9 @@ export function CostsGlobal() {
           onChange={(e) => setStart(e.target.value)}
           className="bg-mycel-bg border border-mycel-border rounded px-2 py-1 text-mycel-text outline-none focus:border-mycel-accent"
         />
-        <div className="flex rounded border border-mycel-border overflow-hidden">
-          {(["workspace", "project"] as const).map((g) => (
-            <button
-              key={g}
-              type="button"
-              onClick={() => setGroupBy(g)}
-              className={`px-2.5 py-1 text-[11px] ${
-                groupBy === g
-                  ? "bg-mycel-accent/15 text-mycel-accent"
-                  : "bg-mycel-surface text-mycel-muted hover:text-mycel-text"
-              }`}
-            >
-              {g === "workspace" ? "By workspace" : "By project"}
-            </button>
-          ))}
-        </div>
+        {/* "By project" toggle removed: project labels currently resolve to
+            the same workspace name, producing identical rows. Re-add when a
+            distinct project axis exists in the data model. */}
       </div>
     ),
   });

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -57,7 +57,10 @@ function AddSecretForm({ onCreated }: { onCreated: () => void }) {
     e.preventDefault();
     const trimmedName = name.trim().toUpperCase().replace(/[^A-Z0-9_]/g, "_");
     const trimmedValue = value.trim();
-    if (!trimmedName || !trimmedValue) return;
+    if (!trimmedName || !trimmedValue) {
+      setError(!trimmedName ? "Name is required." : "Value is required.");
+      return;
+    }
 
     setSaving(true);
     setError(null);

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -351,6 +351,14 @@ export function Settings() {
         preferences.json{typeof version !== "undefined" ? ` v${version}` : ""}
       </p>
 
+      {/* Saved confirmation toast — visible briefly after a successful save
+          when no other sections are dirty. */}
+      {saveStatus === "saved" && dirtySections.length === 0 && (
+        <div className="fixed bottom-4 right-4 z-30 rounded border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-400">
+          Saved
+        </div>
+      )}
+
       {/* Floating save bar */}
       {dirtySections.length > 0 && (
         <div className="sticky top-0 z-20 rounded border border-mycel-accent/50 bg-mycel-accent/10 backdrop-blur px-3 py-2 flex items-center justify-between">


### PR DESCRIPTION
Part of #14 — Playwright audit follow-ups.

## Summary

Fixes the P1 bugs and high-impact P2/P3 items surfaced by the audit. ~150 LOC across 15 files.

## P1 fixes
- **#1 SPA routing** — pin react-router-dom to ^6.30.3 (v7 + React 18 + legacy BrowserRouter doesn't propagate useLocation updates).
- **#2 Logo clipped behind chevron** — single "m" glyph in 24px pill instead of full "mycel".
- **#3 Workspace label "@@bc"** — strip leading "@" before re-prefixing.
- **#4 Discord channel collapse** — `guildName:channelName` in handleReady + sanitizeChannelName preserves ":".
- **#5 Smart-quote apostrophes** — replace with plain ASCII in MCP/SetupWizard/AgentDetail.
- **#6 Terminal WS 409** — waitForSession poll (~2s backoff) before returning 409.
- **#7 Empty agent name** — alert on submit.
- **#8 Secrets silent submit** — surface "required" errors.
- **#9 Costs duplicate toggle** — hide By project until data model has distinct axis.
- **#10 Mobile header overflow** — flex-wrap on small screens.
- **#11 Code polling** — 5s → 10s + pause when hidden.
- **#12 Code file-tree** — handler wiring already correct.

## P2/P3
- Rename now requires double-click on agent row.
- Stop All wrapped in confirm + proper destructive button.
- Settings: "Saved" toast after successful write.

## Test plan
- [x] bun lint + build clean
- [x] go build + go test (gateway + handlers) pass
- [x] Manual Playwright sweep: SPA routing, sidebar, mobile