### PR TITLE
chore(web): P3/P4 design alignment + polish from Playwright audit

### DIFF
--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -1,9 +1,64 @@
+import type { ReactNode } from "react";
+
 interface EmptyStateProps {
-  icon?: string;
+  /**
+   * Optional iconography. Accepts:
+   *   - a ReactNode (preferred — render an SVG / lucide icon directly)
+   *   - a short string token: ">" / "*" / "~" / "#" / "!" — mapped to a built-in SVG glyph.
+   * String tokens are kept for back-compat; new code should pass an SVG.
+   */
+  icon?: ReactNode;
   title: string;
   description?: string;
   actionLabel?: string;
   onAction?: () => void;
+}
+
+/* Inline SVGs replace the previous ASCII placeholders (">" "*" "~"). */
+function GlyphIcon({ kind }: { kind: string }) {
+  const stroke = "currentColor";
+  const common = { width: 32, height: 32, viewBox: "0 0 24 24", fill: "none", stroke, strokeWidth: 1.5, strokeLinecap: "round" as const, strokeLinejoin: "round" as const };
+  switch (kind) {
+    case ">":
+      // Inbox / list — generic empty list
+      return (
+        <svg {...common} aria-hidden>
+          <path d="M22 12h-6l-2 3h-4l-2-3H2" />
+          <path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11Z" />
+        </svg>
+      );
+    case "*":
+      // Sparkle — generic absence-of-results
+      return (
+        <svg {...common} aria-hidden>
+          <path d="M12 3v3M12 18v3M3 12h3M18 12h3M5.6 5.6l2.1 2.1M16.3 16.3l2.1 2.1M5.6 18.4l2.1-2.1M16.3 7.7l2.1-2.1" />
+        </svg>
+      );
+    case "~":
+      // Pulse / activity
+      return (
+        <svg {...common} aria-hidden>
+          <path d="M3 12h4l2-7 4 14 2-7h6" />
+        </svg>
+      );
+    case "#":
+      // Hash / channel
+      return (
+        <svg {...common} aria-hidden>
+          <path d="M4 9h16M4 15h16M10 3 8 21M16 3l-2 18" />
+        </svg>
+      );
+    case "!":
+      // Alert
+      return (
+        <svg {...common} aria-hidden>
+          <circle cx="12" cy="12" r="9" />
+          <path d="M12 8v4M12 16h.01" />
+        </svg>
+      );
+    default:
+      return null;
+  }
 }
 
 export function EmptyState({
@@ -13,9 +68,19 @@ export function EmptyState({
   actionLabel,
   onAction,
 }: EmptyStateProps) {
+  let iconNode: ReactNode = null;
+  if (typeof icon === "string") {
+    iconNode = <GlyphIcon kind={icon} />;
+  } else if (icon) {
+    iconNode = icon;
+  }
   return (
     <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-      {icon && <span className="text-3xl mb-3 opacity-60">{icon}</span>}
+      {iconNode && (
+        <span className="mb-3 text-mycel-muted/50" aria-hidden>
+          {iconNode}
+        </span>
+      )}
       <h3 className="text-sm font-medium text-mycel-text">{title}</h3>
       {description && (
         <p className="mt-1 text-sm text-mycel-muted max-w-sm">{description}</p>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -396,7 +396,7 @@ const GLOBAL_NAV_ITEMS = [
   { to: "/costs", label: "Costs", icon: "metrics" },
 ] as const;
 
-const NAV_ITEMS = [...MAIN_NAV_ITEMS, ...UTIL_NAV_ITEMS];
+const NAV_ITEMS = [...MAIN_NAV_ITEMS, ...UTIL_NAV_ITEMS, ...GLOBAL_NAV_ITEMS];
 
 function readCollapsed(): boolean {
   try { return localStorage.getItem(SIDEBAR_KEY) === "true"; } catch { return false; }
@@ -640,13 +640,21 @@ export function Layout() {
           <NavList items={UTIL_NAV_ITEMS} collapsed={collapsed} isMobile={isMobile} />
         </ul>
 
-        {/* Theme toggle */}
-        <div className="px-3 py-2 border-t border-mycel-border/20">
+        {/* Theme toggle — matches nav-item width and padding for visual alignment */}
+        <div className="py-1.5 border-t border-mycel-border/20">
           <button type="button" onClick={toggle}
-            className="px-2 py-1 rounded text-[10px] text-mycel-muted/30 hover:text-mycel-muted/60 border border-mycel-border/15 hover:border-mycel-border/30 transition-colors w-full"
+            className={`relative flex items-center gap-2.5 ${collapsed && !isMobile ? "justify-center px-2" : "pl-4 pr-3"} py-[7px] w-full text-[11px] text-mycel-muted/50 hover:text-mycel-text hover:bg-mycel-bg/30 border-l-2 border-transparent transition-colors`}
             title={`Theme: ${THEME_LABELS[mode]}`}
           >
-            {collapsed && !isMobile ? THEME_LABELS[mode][0] : THEME_LABELS[mode]}
+            <span className="shrink-0 flex items-center justify-center w-4 opacity-60">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="7" cy="7" r="3" />
+                <path d="M7 1v2M7 11v2M1 7h2M11 7h2M2.5 2.5l1.5 1.5M10 10l1.5 1.5M2.5 11.5L4 10M10 4l1.5-1.5" strokeLinecap="round" />
+              </svg>
+            </span>
+            {(!collapsed || isMobile) && (
+              <span className="truncate">{THEME_LABELS[mode]}</span>
+            )}
           </button>
         </div>
       </nav>

--- a/web/src/components/ProvidersTable.tsx
+++ b/web/src/components/ProvidersTable.tsx
@@ -176,7 +176,10 @@ export function ProvidersTable({ providers, search }: Props) {
 
       {/* Card grid view */}
       {viewMode === "cards" ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div
+          className="grid gap-3"
+          style={{ gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}
+        >
           {sorted.map((p) => (
             <ProviderCard
               key={p.name}

--- a/web/src/components/WorkspaceDropdown.tsx
+++ b/web/src/components/WorkspaceDropdown.tsx
@@ -102,8 +102,7 @@ export function WorkspaceDropdown({
         style={{ fontFamily: MONO }}
         title="Switch workspace (Cmd+Shift+W)"
       >
-        <span className="text-mycel-muted/60 text-[9px] uppercase tracking-wider">ws</span>
-        <span className="font-semibold truncate max-w-[160px]">
+        <span className="font-semibold truncate max-w-[180px]">
           {active ? (active.name || active.path.split("/").pop() || "unnamed") : (loading ? "…" : "no workspace")}
         </span>
         {active?.id && (

--- a/web/src/components/notifications/GatewayFeed.tsx
+++ b/web/src/components/notifications/GatewayFeed.tsx
@@ -1157,6 +1157,8 @@ export function GatewayFeed({
             type="button"
             onClick={() => setShowAgents((v) => !v)}
             className="flex items-center"
+            title={`${liveCount} live / ${subscribedAgents.length + availableAgents.length} total agents — click to manage subscriptions`}
+            aria-label={`${liveCount} of ${subscribedAgents.length + availableAgents.length} agents live; manage subscriptions`}
             style={{
               gap: 5,
               padding: "3px 8px 3px 6px",
@@ -1967,20 +1969,20 @@ export function GatewayFeed({
                   display: "flex",
                   alignItems: "center",
                   gap: 5,
-                  background: composerText.trim() && !composerSending ? "var(--mycel-accent, #f97316)" : "var(--mycel-muted, #4a4a4a)",
-                  color: "var(--mycel-bg, #0d0d0d)",
+                  background: composerText.trim() && !composerSending ? "var(--mycel-accent, #f97316)" : "var(--mycel-surface-hover, #2a2a2a)",
+                  color: composerText.trim() && !composerSending ? "var(--mycel-bg, #0d0d0d)" : "var(--mycel-text, #e5e5e5)",
                   padding: "4px 10px",
                   borderRadius: 5,
                   fontSize: 12,
                   fontWeight: 600,
                   cursor: composerText.trim() && !composerSending ? "pointer" : "default",
-                  border: "none",
-                  opacity: composerText.trim() && !composerSending ? 1 : 0.5,
+                  border: composerText.trim() && !composerSending ? "none" : "1px solid var(--mycel-border, #333)",
+                  opacity: composerText.trim() && !composerSending ? 1 : 0.7,
                   transition: "background 100ms, opacity 100ms",
                 }}
               >
                 <span>{composerSending ? "Sending..." : "Send"}</span>
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="var(--mycel-bg, #0d0d0d)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                   <line x1="5" y1="12" x2="19" y2="12" /><polyline points="12 5 19 12 12 19" />
                 </svg>
               </button>

--- a/web/src/components/settings/Dependencies.tsx
+++ b/web/src/components/settings/Dependencies.tsx
@@ -270,11 +270,43 @@ export function DependenciesSection() {
     );
   }
 
+  const active = deps.filter((d) => !d.deprecated);
+  const deprecated = deps.filter((d) => d.deprecated);
+
   return (
     <div className="space-y-2">
-      {deps.map((d) => (
+      {active.map((d) => (
         <DepCard key={d.id} dep={d} onRefresh={refresh} />
       ))}
+      {deprecated.length > 0 && (
+        <DeprecatedSection deps={deprecated} onRefresh={refresh} />
+      )}
+    </div>
+  );
+}
+
+function DeprecatedSection({ deps, onRefresh }: { deps: DepView[]; onRefresh: () => void }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded border border-mycel-border/40 bg-mycel-bg/30">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-2 px-3 py-1.5 text-[11px] text-mycel-muted hover:text-mycel-text transition-colors"
+      >
+        <svg className={`w-3 h-3 transition-transform ${open ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+        <span className="uppercase tracking-wide">Deprecated</span>
+        <span className="text-mycel-muted/60">({deps.length})</span>
+      </button>
+      {open && (
+        <div className="px-2 pb-2 space-y-2">
+          {deps.map((d) => (
+            <DepCard key={d.id} dep={d} onRefresh={onRefresh} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/views/Code.tsx
+++ b/web/src/views/Code.tsx
@@ -54,8 +54,28 @@ const EMPTY_FILE: FileResult = {
   notFound: false,
 };
 
+// Common build / dependency directories that clutter the file tree.
+// When `Show hidden` is off, these are filtered out alongside dotfiles.
+// Users can still inspect them by toggling `Show hidden`.
+const HIDDEN_DIRS = new Set([
+  ".git",
+  ".bc",
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  ".turbo",
+  ".cache",
+  ".parcel-cache",
+  "__pycache__",
+  ".venv",
+  "venv",
+  "target",
+  "vendor",
+]);
+
 function isHiddenEntry(name: string): boolean {
-  return name === ".git" || name === ".bc";
+  return HIDDEN_DIRS.has(name);
 }
 
 async function fetchTree(

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -101,7 +101,7 @@ function AddSecretForm({ onCreated }: { onCreated: () => void }) {
         <button
           type="button"
           onClick={() => { setOpen(false); setError(null); }}
-          className="text-mycel-muted hover:text-mycel-text text-sm transition-colors"
+          className="px-3 py-1 rounded text-xs text-mycel-muted hover:text-mycel-text border border-mycel-border hover:border-mycel-muted bg-mycel-bg transition-colors"
         >
           Cancel
         </button>


### PR DESCRIPTION
Part of #3074 follow-on polish.

## Summary

Follow-on bundle to #3074. Picks up the remaining P3 (design alignment) and P4 (nice-to-have) items from the Playwright audit. Eight files touched, no data-model or routing changes.

## Items shipped

P3 — design alignment:
- **#2** document.title: include `/costs` in nav-match so global Costs page resolves to "Costs — mycel"
- **#6** Secrets new-form Cancel button switched to outlined pattern (matches CreateAgentModal)
- **#7** Theme cycler in sidebar now matches nav-item layout (border-l slot, same horizontal padding)

P4 — polish:
- **#8** EmptyState ASCII placeholders (`*`, `~`, `>`, `#`, `!`) replaced with inline SVG glyphs (back-compat: existing string tokens still work)
- **#9** Tools providers grid: auto-fill `minmax(220px, 1fr)` instead of fixed 1/2/3-col, so a 4-card layout fills evenly
- **#11** Settings: deprecated optional-services collapsed into an expandable "Deprecated (N)" section
- **#12** Code page tree: default-ignore list now includes `node_modules`, `dist`, `build`, `.next`, `.turbo`, `.cache`, `target`, `vendor`, `venv`, `__pycache__` (toggling "Show hidden" still surfaces them)
- **#13** WorkspaceDropdown: drop redundant "ws" prefix
- **#17** Notifications composer Send button: idle state now uses outlined surface + readable text instead of muted-on-muted
- **#18** Notifications agents-popover button: added title / aria-label tooltip explaining `N/M agents`
- **#15** Live "?" shortcuts button — already functional in current code, no change needed

## Items deferred (would require new components or major refactor)

- **#1** Shared `<PageHeader />` — pages already centralize via existing `Header` + `useHeaderSlot`; deferred a top-bar refactor since a new component would touch many files
- **#3** Costs date-format split — uses browser-native `<input type="date">`, behavior is locale-driven; low value to override
- **#4** CTA placement standardization — partial via #6, full sweep across Templates/Cron/Tools deferred
- **#5** Tab-bar restyle — would touch AgentDetail, Costs, and Notifications tabs; out of scope for a polish bundle
- **#10** Stats / agent-metrics empty whitespace — needs scope investigation
- **#14** Costs sparkline — net-new chart component, scope creep
- **#16** Agents mobile card-stack — non-trivial refactor of the table

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run build` — clean
- [x] `bun run test` — 109 passing; the 1 failure (`whatsapp` platform expectation) is pre-existing on `main` and unrelated to this PR