### PR TITLE
fix(web): channel labels + last-message tooltip (Playwright pass 2)

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -254,13 +254,21 @@ function NotificationNavTree() {
     if (h.connected) {
       let tip = "Connected";
       if (h.last_message_at) {
-        const ago = Date.now() - new Date(h.last_message_at).getTime();
-        const mins = Math.floor(ago / 60000);
-        if (mins < 1) tip += " · last message: just now";
-        else if (mins < 60) tip += ` · last message: ${mins}m ago`;
-        else {
-          const hrs = Math.floor(mins / 60);
-          tip += ` · last message: ${hrs}h ago`;
+        const ts = new Date(h.last_message_at).getTime();
+        // Guard against zero / unset / pre-2001 timestamps that produce
+        // nonsensical "17753690h ago" tooltips.
+        if (Number.isFinite(ts) && ts > 978307200000) {
+          const ago = Date.now() - ts;
+          const mins = Math.floor(ago / 60000);
+          if (mins < 1) tip += " · last message: just now";
+          else if (mins < 60) tip += ` · last message: ${mins}m ago`;
+          else if (mins < 1440) {
+            const hrs = Math.floor(mins / 60);
+            tip += ` · last message: ${hrs}h ago`;
+          } else {
+            const days = Math.floor(mins / 1440);
+            tip += ` · last message: ${days}d ago`;
+          }
         }
       }
       return tip;

--- a/web/src/components/notifications/GatewayFeed.tsx
+++ b/web/src/components/notifications/GatewayFeed.tsx
@@ -777,8 +777,11 @@ export function GatewayFeed({
 
   const navigate = useNavigate();
   const platform = gatewayPlatform(channelName);
+  // Show the leaf channel segment as the visible label. Internal keys carry
+  // the full path (e.g. "discord:server:general"); only the final segment is
+  // meaningful to humans.
   const channelLabel = channelName.includes(":")
-    ? channelName.split(":").slice(1).join(":")
+    ? (channelName.split(":").pop() || channelName)
     : channelName;
 
   /* ── Data fetching ─────────────────────────────────────────── */

--- a/web/src/components/notifications/NotificationSidebar.tsx
+++ b/web/src/components/notifications/NotificationSidebar.tsx
@@ -11,8 +11,11 @@ function getMeta(p: string) {
 }
 
 function displayName(name: string): string {
-  const idx = name.indexOf(":");
-  return idx > 0 ? name.slice(idx + 1) : name;
+  // Show only the leaf channel segment, e.g.:
+  //   "discord:server-name:general" → "general"
+  //   "slack:engineering"           → "engineering"
+  const parts = name.split(":");
+  return parts[parts.length - 1] || name;
 }
 
 /* ── Platform glyphs ─────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Second Playwright crawl of the mycel web UI (after #3074 / #3080). Spot-checked every page in Phase 1; verified the previous P1/P2 fixes are still working. Phase 2 surfaced three small UX bugs in the notifications surface, all addressed here.

Part of #3074

## Phase 1 verification (previous fixes still working)

- SPA routing (Live/Agents/Costs/Stats/Tools/Channels/Secrets/MCP/Templates/Code/Cron/Settings) — view + URL update on click. OK.
- Logo "m" not clipped behind chevron — OK.
- Workspace label shows "@bc" (not "@@bc") — OK.
- Discord channel keys carry `:` separator for newly-discovered channels — partially OK (see deferred section).
- Apostrophe rendering — OK on visited pages.
- Costs duplicate toggle — gone, OK.
- Tools provider grid auto-fills (4 providers, no orphan) — OK.
- Theme button + sidebar nav alignment — OK.

## Phase 2 — what this PR ships

- **NotificationSidebar.displayName** — was returning everything after the first `:`, so a 3-segment Discord key like `discord:server-name:general` rendered as `server-name:general` in the sidebar instead of `general`. Now uses the leaf segment, matching `Layout.displaySourceName`.
- **GatewayFeed.channelLabel** — same root cause: the channel header / placeholder / "Coordination feed for #..." all showed the full server-prefixed key. Now uses the leaf segment.
- **Layout.healthTooltip** — for gateways whose `last_message_at` is zero / unset / pre-2001 (e.g. `bc_gateway_bot` with no traffic yet) the tooltip rendered `last message: 17753690h ago`. Now guards bogus timestamps and adds a `d ago` bucket for legitimately old ones.

## Deferred (separate PR)

- **Discord channel-key concatenation at the storage layer**: `/api/gateways` returns a mix of `discord:server:channel` (correct) and `discord:serverchannel` (concatenated, no separator) for the same Discord server. This is in the gateway adapter, not the web layer. Tracking separately so this PR stays scoped to web.

## Test plan

- [x] `cd web && bun run lint` — clean
- [x] `cd web && bun run build` — clean (2s)
- [ ] Manual: open Notifications, pick a multi-segment Discord channel, confirm sidebar + header + composer placeholder show only the leaf name
- [ ] Manual: hover a freshly-connected gateway with no `last_message_at`, confirm tooltip says "Connected" with no nonsense duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)