### PR TITLE
fix(web): deep-testing pass — bugs, UX, design fixes (Part of #3074)

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -532,16 +532,15 @@ export function Layout() {
 
   useEffect(() => { if (isMobile) setCollapsed(true); }, [isMobile]);
   useEffect(() => {
-    // Match against the trailing segment of the URL so /w/<id>/live and
-    // the legacy /live both produce the "Live" title.
+    // Compare ONLY the first URL segment after an optional /w/<id> prefix
+    // so sub-routes such as /agents/<name>/live keep their parent ("Agents")
+    // title rather than incorrectly resolving to a same-named top-level
+    // tab ("Live").
+    const stripped = location.pathname.replace(/^\/w\/[^/]+/, "");
+    const firstSeg = stripped.replace(/^\//, "").split("/")[0] ?? "";
     const match = NAV_ITEMS.find((item) => {
       const seg = item.to.replace(/^\//, "");
-      return (
-        location.pathname === item.to ||
-        location.pathname.startsWith(`${item.to}/`) ||
-        location.pathname.endsWith(`/${seg}`) ||
-        location.pathname.includes(`/${seg}/`)
-      );
+      return seg === firstSeg;
     });
     document.title = match ? `${match.label} \u2014 mycel` : "mycel";
   }, [location.pathname]);

--- a/web/src/components/ProvidersTable.tsx
+++ b/web/src/components/ProvidersTable.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { ProviderInfo } from "../api/client";
 import { formatCost, formatTokens } from "../utils/format";
+import { useWorkspace } from "../context/WorkspaceContext";
 import { EmptyState } from "./EmptyState";
 import { ProviderCard } from "./ProviderCard";
 
@@ -92,6 +93,10 @@ export function ProvidersTable({ providers, search }: Props) {
   const [sortDir, setSortDir] = useState<SortDir>("asc");
   const [viewMode, setViewMode] = useState<ViewMode>("cards");
   const navigate = useNavigate();
+  const { workspace } = useWorkspace();
+  // Build workspace-scoped tools URL so clicks land on the scoped route
+  // directly rather than relying on a redirect.
+  const toolsBase = workspace ? `/w/${workspace.id}/tools` : "/tools";
 
   const filtered = useMemo(() => {
     const q = search.toLowerCase().trim();
@@ -184,7 +189,7 @@ export function ProvidersTable({ providers, search }: Props) {
             <ProviderCard
               key={p.name}
               provider={p}
-              onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+              onClick={() => navigate(`${toolsBase}/${encodeURIComponent(p.name)}`)}
             />
           ))}
         </div>
@@ -210,7 +215,7 @@ export function ProvidersTable({ providers, search }: Props) {
               {sorted.map((p) => (
                 <tr
                   key={p.name}
-                  onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+                  onClick={() => navigate(`${toolsBase}/${encodeURIComponent(p.name)}`)}
                   className="border-b border-mycel-border/50 cursor-pointer hover:bg-mycel-surface transition-colors"
                 >
                   <td className="px-4 py-2.5 font-medium">{p.name}</td>
@@ -224,7 +229,7 @@ export function ProvidersTable({ providers, search }: Props) {
                       {!p.installed && p.install_hint && (
                         <button
                           type="button"
-                          onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+                          onClick={() => navigate(`${toolsBase}/${encodeURIComponent(p.name)}`)}
                           className="text-xs px-2 py-0.5 rounded bg-mycel-warning/10 text-mycel-warning hover:bg-mycel-warning/20 transition-colors"
                         >
                           Install
@@ -237,7 +242,7 @@ export function ProvidersTable({ providers, search }: Props) {
                       )}
                       <button
                         type="button"
-                        onClick={() => navigate(`/tools/${encodeURIComponent(p.name)}`)}
+                        onClick={() => navigate(`${toolsBase}/${encodeURIComponent(p.name)}`)}
                         className="text-xs px-1.5 py-0.5 rounded border border-mycel-border text-mycel-muted hover:text-mycel-text hover:border-mycel-accent/50 transition-colors"
                         aria-label={`Configure ${p.name}`}
                       >

--- a/web/src/components/notifications/GatewayFeed.tsx
+++ b/web/src/components/notifications/GatewayFeed.tsx
@@ -1888,6 +1888,7 @@ export function GatewayFeed({
               }
             }}
             placeholder={`Message #${channelLabel} as ${subscribedAgents[0]?.name ?? "agent"}`}
+            aria-label={`Message #${channelLabel}`}
             rows={1}
             style={{
               background: "transparent",

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useLocation, useNavigate } from "react-router-dom";
+import { useWorkspace } from "../context/WorkspaceContext";
 import { api } from "../api/client";
 import type { Agent, AgentConfig } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
@@ -309,7 +310,7 @@ function AttachOverlay({
    System prompt, MCP servers, metadata, danger zone
    ═══════════════════════════════════════════════════════════════════ */
 
-function ConfigTab({ agent }: { agent: Agent }) {
+function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
   const navigate = useNavigate();
   const [config, setConfig] = useState<AgentConfig | null>(null);
   const [configLoading, setConfigLoading] = useState(true);
@@ -798,7 +799,7 @@ function ConfigTab({ agent }: { agent: Agent }) {
                     setArchiveError(null);
                     api
                       .unarchiveAgent(agent.name)
-                      .then(() => navigate("/agents"))
+                      .then(() => navigate(agentsUrl))
                       .catch((err: unknown) => {
                         setArchiving(false);
                         setArchiveError(
@@ -824,7 +825,7 @@ function ConfigTab({ agent }: { agent: Agent }) {
                       setArchiveError(null);
                       api
                         .archiveAgent(agent.name)
-                        .then(() => navigate("/agents"))
+                        .then(() => navigate(agentsUrl))
                         .catch((err: unknown) => {
                           setArchiving(false);
                           setConfirmArchive(false);
@@ -898,7 +899,7 @@ function ConfigTab({ agent }: { agent: Agent }) {
                       api
                         .deleteAgent(agent.name)
                         .then(() => {
-                          navigate("/agents");
+                          navigate(agentsUrl);
                         })
                         .catch((err: unknown) => {
                           setDeleting(false);
@@ -1010,6 +1011,9 @@ export function AgentDetail() {
   const { name } = useParams<{ name: string }>();
   const navigate = useNavigate();
   const location = useLocation();
+  const { workspace } = useWorkspace();
+  // Workspace-scoped /agents URL so back-links don't bounce through a redirect.
+  const agentsUrl = workspace ? `/w/${workspace.id}/agents` : "/agents";
 
   // Derive active tab from URL sub-path: /agents/<name>/<tab>
   // Defaults to "attach" when no sub-path is present.
@@ -1083,7 +1087,7 @@ export function AgentDetail() {
           selectTab("code");
           break;
         case "Escape":
-          navigate("/agents");
+          navigate(agentsUrl);
           break;
       }
     };
@@ -1091,7 +1095,7 @@ export function AgentDetail() {
     return () => {
       window.removeEventListener("keydown", handler);
     };
-  }, [navigate, selectTab]);
+  }, [navigate, selectTab, agentsUrl]);
 
   /* ─── Loading / Error ─── */
 
@@ -1111,7 +1115,7 @@ export function AgentDetail() {
           error: {error}
         </div>
         <Link
-          to="/agents"
+          to={agentsUrl}
           className="text-xs text-mycel-accent hover:underline"
           style={{ fontFamily: MONO }}
         >
@@ -1134,7 +1138,7 @@ export function AgentDetail() {
         <div className="flex items-center gap-2.5 min-w-0 px-6 h-[42px]">
           {/* Back link */}
           <Link
-            to="/agents"
+            to={agentsUrl}
             className="text-[10px] text-mycel-muted/40 hover:text-mycel-text transition-colors shrink-0"
             style={{ fontFamily: MONO }}
           >
@@ -1255,7 +1259,7 @@ export function AgentDetail() {
           />
         )}
         {activeTab === "attach" && <AttachTab agent={agent} />}
-        {activeTab === "config" && <ConfigTab agent={agent} />}
+        {activeTab === "config" && <ConfigTab agent={agent} agentsUrl={agentsUrl} />}
         {activeTab === "metrics" && <MetricsTab agent={agent} />}
         {activeTab === "code" && <CodeTabPlaceholder agent={agent} />}
       </div>

--- a/web/src/views/Cron.tsx
+++ b/web/src/views/Cron.tsx
@@ -118,8 +118,7 @@ function relativeTime(dateStr: string | null): string {
 // Create Job Form
 // ---------------------------------------------------------------------------
 
-function CreateJobForm({ onCreated }: { onCreated: () => void }) {
-  const [open, setOpen] = useState(false);
+function CreateJobForm({ onCreated, onCancel }: { onCreated: () => void; onCancel: () => void }) {
   const [name, setName] = useState("");
   const [schedule, setSchedule] = useState("");
   const [command, setCommand] = useState("");
@@ -143,7 +142,6 @@ function CreateJobForm({ onCreated }: { onCreated: () => void }) {
       });
       setStatus({ type: "success" });
       reset();
-      setOpen(false);
       onCreated();
     } catch (err) {
       setStatus({
@@ -153,8 +151,6 @@ function CreateJobForm({ onCreated }: { onCreated: () => void }) {
       setTimeout(() => setStatus({ type: "idle" }), 4000);
     }
   };
-
-  if (!open) return null;
 
   const inputCls =
     "w-full px-3 py-2 rounded border border-mycel-border bg-mycel-bg text-mycel-text text-sm focus:outline-none focus:ring-2 focus:ring-mycel-accent";
@@ -226,7 +222,7 @@ function CreateJobForm({ onCreated }: { onCreated: () => void }) {
           type="button"
           onClick={() => {
             reset();
-            setOpen(false);
+            onCancel();
           }}
           className="px-4 py-2 rounded border border-mycel-border text-mycel-muted text-sm hover:text-mycel-text transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
         >
@@ -703,6 +699,7 @@ export function Cron() {
             refresh();
             setShowCreateForm(false);
           }}
+          onCancel={() => setShowCreateForm(false)}
         />
       )}
 
@@ -711,7 +708,7 @@ export function Cron() {
         <EmptyState
           icon="~"
           title="No cron jobs"
-          description="Create a cron job above or use 'bc cron add <name>' to schedule recurring tasks."
+          description="Click '+ New Job' above or use 'bc cron add <name>' to schedule recurring tasks."
         />
       ) : (
         <div className="grid grid-cols-1 gap-3">

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -426,7 +426,7 @@ export function Secrets() {
         <EmptyState
           icon="*"
           title="No secrets stored"
-          description="Add a secret using the form above or run 'bc secret set <name> --value <value>'."
+          description="Click '+ Add Secret' above or run 'bc secret set <name> --value <value>'."
         />
       ) : (
         <div className="grid gap-3">


### PR DESCRIPTION
## Summary

A focused deep-testing pass over the web UI surfaced four real defects
and a handful of small polish items. All fixes are small, composable,
and avoid touching backend code.

### Pages exercised
Live, Agents (list + Create modal + detail tabs Attach/Live/Config/Metrics/Code),
Notifications (gateways + composer), Code, Templates (list + detail + create form),
Tools (providers table + provider detail), Cron, Secrets, Stats / Metrics,
Settings, global Costs, Workspace picker.

### Bugs fixed

- **Cron \"+ New Job\" button did nothing.** `CreateJobForm` carried its own
  internal `open` state defaulting to `false` and returned `null` until
  *something* clicked a button that no longer existed in its render path.
  The actual \"+ New Job\" trigger lives in the page header and only toggled
  the parent's `showCreateForm`, so the form was permanently invisible.
  Convert `CreateJobForm` into a controlled component (parent supplies
  `onCancel`; no internal `open`).
  `web/src/views/Cron.tsx`

- **Agent Detail's Live tab set the document title to \"Live — mycel\".**
  Layout's title resolver matched any URL containing `/live` against the
  top-level Live tab, so `/agents/<name>/live` resolved wrong. Match only
  the first URL segment after the optional `/w/<id>` prefix.
  `web/src/components/Layout.tsx`

- **Internal navigations bounced through `RedirectToActiveWorkspace`.**
  ProvidersTable's row/card/Install/Open clicks all called
  `navigate(\"/tools/...\")`; Agent Detail's back-arrow, post-action
  redirects (delete/archive/unarchive) and Esc shortcut all targeted
  `/agents`. The redirect masks the bug in the URL bar but every click
  flashes through an extra render. Build workspace-scoped URLs from
  context so the navigation lands directly on the scoped route.
  `web/src/components/ProvidersTable.tsx`, `web/src/views/AgentDetail.tsx`

### UX / copy

- **Empty-state copy on Secrets and Cron referenced a \"form above\" that
  doesn't exist** — the \"+ Add Secret\" / \"+ New Job\" triggers live in
  the page header, not above the empty state. Wording now points at the
  actual button labels.
  `web/src/views/Secrets.tsx`, `web/src/views/Cron.tsx`

- **Notifications composer textarea had no aria-label.** Screen-reader
  users got no announce when focused (placeholder is not reliably read).
  Add an aria-label mirroring the channel target.
  `web/src/components/notifications/GatewayFeed.tsx`

### Deferred (out of scope for this PR)

- **Settings inputs lack proper `<label htmlFor>` associations.** All
  ~20 settings inputs render with empty `name=\"\"` and no `htmlFor`
  binding. Fixing this is a multi-file accessibility refactor that
  deserves its own PR.
- **`navigate('/agents')` calls inside ConfigTab nested forms** — fixed
  via prop-drilled `agentsUrl`. Could be cleaner with a context hook,
  but the prop is fine and matches existing patterns.
- **Tools page reads CLI dependency status** — appears empty during
  testing; needs backend verification (separate from web).

### Verified manually with Playwright

- Help (\"?\") overlay on Live opens and closes
- ESC closes Create Agent modal
- Templates create form opens and the submit is correctly disabled
  until name is filled
- Provider detail loads from `/w/<id>/tools/claude` (verified shows
  agents list, model breakdown, cost summary)
- Agent Detail tab routes (Attach/Live/Config/Metrics/Code) all render
  and the title now says \"Agents — mycel\" everywhere
- `bun run lint` passes; `bun run build` succeeds with no new warnings

## Test plan
- [ ] On `/cron`, click \"+ New Job\" and verify the form appears and
      Cancel hides it
- [ ] Open `/w/<id>/agents/<name>/live` — confirm document.title is
      \"Agents — mycel\" not \"Live — mycel\"
- [ ] Click a provider card on `/tools` — verify URL goes directly to
      `/w/<id>/tools/<name>` without flashing through `/tools/<name>`
- [ ] Click the back arrow on Agent Detail — verify URL is
      `/w/<id>/agents` directly
- [ ] Verify Secrets and Cron empty-state copy reads \"Click '+ ...
      above\" not \"form above\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)