### PR TITLE
fix(cmd): platform-split detachSession to unblock v0.2.4 Windows build

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -214,8 +213,8 @@ func runUpDaemon(wsRoot string) error {
 	cmd.Stderr = logFile
 	cmd.Dir = wsRoot
 	cmd.Env = os.Environ()
-	// Start in a new session so SIGHUP from terminal close doesn't propagate.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	// Start in a new session so SIGHUP from terminal close doesn't propagate (no-op on Windows).
+	detachSession(cmd)
 
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()

--- a/internal/cmd/up_unix.go
+++ b/internal/cmd/up_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// detachSession starts the command in a new session so SIGHUP from terminal
+// close doesn't propagate. Unix-only.
+func detachSession(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+}

--- a/internal/cmd/up_windows.go
+++ b/internal/cmd/up_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package cmd
+
+import "os/exec"
+
+// detachSession is a no-op on Windows (no Setsid equivalent).
+func detachSession(cmd *exec.Cmd) {}


### PR DESCRIPTION
v0.2.4 Linux+Windows release failed because `internal/cmd/up.go` used `syscall.SysProcAttr{Setsid: true}` which is Unix-only — `unknown field Setsid in struct literal of type syscall.SysProcAttr` on windows_amd64.

Split the platform-specific call into:
- `up_unix.go` (build !windows): `detachSession(cmd) → cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}`
- `up_windows.go` (build windows): `detachSession(cmd)` is a no-op

Verified locally with `GOOS=windows GOARCH=amd64 go build` and `GOOS=linux GOARCH=amd64 go build` — both clean.

Part of #3054