### PR TITLE
chore: address unresolved CodeRabbit feedback across today's PRs

### DIFF
--- a/landing/src/app/_components/InstallSection.tsx
+++ b/landing/src/app/_components/InstallSection.tsx
@@ -84,8 +84,8 @@ function getMethods(version: string): Method[] {
       platforms: "Requires Go 1.25+, Bun, tmux",
       commands: [
         "git clone https://github.com/rpuneet/mycel",
-        "cd bc",
-        "make install-local-bc",
+        "cd mycel",
+        "make install-local-mycel",
       ],
     },
   ];

--- a/packages/mycel-agent-runner/src/agent.ts
+++ b/packages/mycel-agent-runner/src/agent.ts
@@ -9,6 +9,16 @@ import type {
 } from "./types.js";
 import type { SseHub } from "./sse.js";
 
+// AgentBusyError is thrown when startQuery is called while a query is already
+// in flight. Callers (e.g. the HTTP server) can use `instanceof` to map this
+// to a 409 instead of relying on string matching against the error message.
+export class AgentBusyError extends Error {
+  constructor() {
+    super("agent is busy; call /stop before starting a new query");
+    this.name = "AgentBusyError";
+  }
+}
+
 // AgentRunner wraps a single Claude agent. Only one query can be in flight at
 // a time — if a new /query arrives while one is already running, the caller
 // gets a 409. /stop interrupts the active query so a new one can start.
@@ -78,7 +88,7 @@ export class AgentRunner {
   // until completion.
   async startQuery(req: QueryRequest): Promise<{ session_id: string | null }> {
     if (this.isBusy()) {
-      throw new Error("agent is busy; call /stop before starting a new query");
+      throw new AgentBusyError();
     }
 
     const options = this.buildOptions(req);

--- a/packages/mycel-agent-runner/src/index.ts
+++ b/packages/mycel-agent-runner/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // mycel-agent-runner entry point.
 //
 // One process per agent. Reads its identity, working directory, and policy

--- a/packages/mycel-agent-runner/src/server.ts
+++ b/packages/mycel-agent-runner/src/server.ts
@@ -1,6 +1,6 @@
 import express, { type Express, type Request, type Response } from "express";
 
-import { AgentRunner } from "./agent.js";
+import { AgentBusyError, AgentRunner } from "./agent.js";
 import { SseHub } from "./sse.js";
 import type {
   HealthResponse,
@@ -52,10 +52,12 @@ export function buildServer(
       };
       res.status(202).json(response);
     } catch (err) {
+      if (err instanceof AgentBusyError) {
+        res.status(409).json({ error: err.message });
+        return;
+      }
       const message = err instanceof Error ? err.message : String(err);
-      // Busy is the only expected error path here.
-      const status = message.includes("busy") ? 409 : 500;
-      res.status(status).json({ error: message });
+      res.status(500).json({ error: message });
     }
   });
 


### PR DESCRIPTION
## Summary

Audit pass over the 33 non-dependabot PRs merged on 2026-04-29 to pick up the small, still-applicable CodeRabbit comments that didn't get folded into their original PR. Most CR threads were already resolved during the day; this PR cleans up the residue.

Part of #2990, #3004, #3038, #3052, #3065 — completes the CR-feedback loop for those PRs.

## Actioned (3)

- **agent-runner (#2990)** — `packages/mycel-agent-runner/src/index.ts`: add `#!/usr/bin/env node` shebang so the published `mycel-agent-runner` bin actually runs when installed globally / linked. Verified `tsc` preserves it on the first emitted line.
- **agent-runner (#2990)** — `packages/mycel-agent-runner/src/{agent,server}.ts`: replace fragile `message.includes("busy")` string matching with a typed `AgentBusyError` class. Server now does `instanceof AgentBusyError -> 409`, everything else -> 500. No behavior change for HTTP callers.
- **landing (#3004)** — `landing/src/app/_components/InstallSection.tsx`: fix the "From source" snippet — `cd bc` -> `cd mycel`, `make install-local-bc` -> `make install-local-mycel`. The previous strings would fail copy/paste because `git clone .../mycel` produces a `mycel/` dir and the canonical Makefile target is `install-local-mycel` (with `install-local-bc` retained only as a deprecated alias).

## Skipped

**Already resolved on main** (verified by reading current code):
- #3004 Footer hardcoded year — already uses `new Date().getFullYear()`
- #3004 ThemeContext storage migration — migration logic already present
- #3004 most rebrand nits (faq.md, page.tsx, Nav.tsx, method/page.tsx, etc.) — CR itself marked "Addressed in commit a8b1ce8…2d62811"
- #3038 `pkg/agent/agent.go` SetArchived ctx — addressed in 71309c6
- #3038 `pkg/workspace/config_validate.go:138` — error message already mentions `'sql' (legacy)`
- #3038 `pkg/workspace/config_validate.go:177` — addressed
- #3038 `pkg/gateway/manager.go` persist-only-on-change — already gated by `!exists`
- #3038 `server/mcp/server_test.go` git-init in helpers — addressed
- #3052 `pkg/cron/scheduler_pgid_test.go` assert ExitError — already done
- #3065 `pkg/gateway/README.md` anchor — already verified

**Outdated** (file/code refactored away):
- #2990 `packages/bc-agent-runner/*` paths — package was renamed to `packages/mycel-agent-runner`; the shebang + typed-error fixes were re-applied at the new path

**Deferred** (too large for a sweep PR):
- #3038 `pkg/workspace/config_gateways.go` — table-driven refactor of the ~25-platform switch. Would need a dedicated PR with proper tests.

**Nits** (CR self-flagged low value, not worth churn):
- #2990 `agent.ts:134` `shutdown()` await race — CR's own marker: 🔵 Trivial, 💤 Low value
- #3004 Footer `mycel_` vs `mycel` underscore — intentional terminal aesthetic
- #3004 docs MD022/MD031 markdownlint warnings on faq.md
- #3004 tab buttons `type="button"` defensive add
- #3004 `docs/DocsContent.tsx` copy-button focus reveal (a11y nit on docs page)
- #3004 `globals.css` font-family quoting

PRs with **zero** unresolved CR comments after audit: #3043, #3044, #3045, #3046, #3048, #3050, #3051, #3053, #3055, #3056, #3059, #3060, #3061, #3062, #3063, #3064, #3066, #3069, #3070, #3071, #3072, #3073, #3074, #3080, #3081, #3082, #3083, #3084.

## Test plan

- [x] `make check-go` — all green (60s server tests pass)
- [x] `make lint-ts` — no new errors (only pre-existing eslint-disable warnings)
- [x] `cd packages/mycel-agent-runner && bun run typecheck && bun run build` — clean, `dist/index.js` shebang preserved on line 1
- [x] Confirmed the 2 failing TUI 80x24 TabBar tests are pre-existing on `main` (commit 81ff1488 already documented this flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)