### PR TITLE
fix(release): cross-platform Homebrew formula generation (no more macOS-broken brew installs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,83 @@ jobs:
             dist/checksums-macos.txt
           fail_on_unmatched_files: false
 
+  # ── Update Homebrew formula (cross-platform: macOS + Linux) ─────────
+  release-formula:
+    name: Update Homebrew Formula
+    runs-on: ubuntu-latest
+    needs: [release-linux, release-macos, prepare]
+    steps:
+      - name: Build cross-platform formula
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          # Fetch checksums from both jobs' uploaded assets
+          curl -sfL "https://github.com/rpuneet/mycel/releases/download/${TAG}/checksums.txt" -o /tmp/cs-linux.txt
+          curl -sfL "https://github.com/rpuneet/mycel/releases/download/${TAG}/checksums-macos.txt" -o /tmp/cs-macos.txt
+
+          DARWIN_AMD64=$(grep "darwin_amd64" /tmp/cs-macos.txt | awk '{print $1}')
+          DARWIN_ARM64=$(grep "darwin_arm64" /tmp/cs-macos.txt | awk '{print $1}')
+          LINUX_AMD64=$(grep "linux_amd64.tar.gz" /tmp/cs-linux.txt | awk '{print $1}')
+          LINUX_ARM64=$(grep "linux_arm64.tar.gz" /tmp/cs-linux.txt | awk '{print $1}')
+
+          cat > /tmp/mycel.rb <<FORMULA
+          class Mycel < Formula
+            desc "CLI-first AI agent orchestration system"
+            homepage "https://github.com/rpuneet/mycel"
+            version "${VERSION}"
+            license "MIT"
+
+            on_macos do
+              if Hardware::CPU.arm?
+                url "https://github.com/rpuneet/mycel/releases/download/${TAG}/mycel_${VERSION}_darwin_arm64.tar.gz"
+                sha256 "${DARWIN_ARM64}"
+              else
+                url "https://github.com/rpuneet/mycel/releases/download/${TAG}/mycel_${VERSION}_darwin_amd64.tar.gz"
+                sha256 "${DARWIN_AMD64}"
+              end
+
+              def install
+                bin.install "mycel"
+              end
+            end
+
+            on_linux do
+              if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+                url "https://github.com/rpuneet/mycel/releases/download/${TAG}/mycel_${VERSION}_linux_arm64.tar.gz"
+                sha256 "${LINUX_ARM64}"
+              elsif Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
+                url "https://github.com/rpuneet/mycel/releases/download/${TAG}/mycel_${VERSION}_linux_amd64.tar.gz"
+                sha256 "${LINUX_AMD64}"
+              end
+
+              def install
+                bin.install "mycel"
+              end
+            end
+
+            test do
+              system "#{bin}/mycel", "version"
+            end
+          end
+          FORMULA
+
+          cat /tmp/mycel.rb
+
+      - name: Push formula to homebrew-mycel
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          OLD_SHA=$(curl -sfL -H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+            https://api.github.com/repos/rpuneet/homebrew-mycel/contents/Formula/mycel.rb | jq -r .sha)
+          CONTENT_B64=$(base64 -w0 /tmp/mycel.rb)
+          curl -sfL -X PUT \
+            -H "Authorization: Bearer ${HOMEBREW_TAP_TOKEN}" \
+            -H "Content-Type: application/json" \
+            https://api.github.com/repos/rpuneet/homebrew-mycel/contents/Formula/mycel.rb \
+            -d "{\"message\":\"chore(formula): bump to ${TAG} (cross-platform)\",\"content\":\"${CONTENT_B64}\",\"sha\":\"${OLD_SHA}\",\"branch\":\"main\"}"
+
   # ── SBOM generation ──────────────────────────────────────────────────
   sbom:
     name: Generate SBOM

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -142,23 +142,6 @@ release:
 
     **Full Changelog**: https://github.com/rpuneet/mycel/compare/{{ .PreviousTag }}...{{ .Tag }}
 
-brews:
-  - name: mycel
-    repository:
-      owner: rpuneet
-      name: homebrew-mycel
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-      branch: main
-    directory: Formula
-    homepage: https://bc-infra.com
-    description: Orchestration for AI agents
-    license: MIT
-    skip_upload: auto
-    install: |
-      bin.install "mycel"
-    test: |
-      system "#{bin}/mycel", "version"
-
 
 nfpms:
   - id: mycel-linux


### PR DESCRIPTION
## Why

Each release shipped a broken homebrew formula on macOS — `brew install rpuneet/mycel/mycel` errored with `Linux is required for this software`.

Root cause: goreleaser's `brews:` block only sees the Linux+Windows artifacts goreleaser itself builds. macOS builds are done in a separate `release-macos` job in release.yml (CGO + cross-compile constraints). So goreleaser auto-generated a Linux-only formula with `depends_on :linux`.

We had to manually patch the formula after each release. This automates it.

## Fix

- Drop `brews:` from .goreleaser.yml
- Add `release-formula` job to release.yml that runs after both `release-linux` and `release-macos` complete, fetches both checksums.txt files from the GitHub release, and PUTs a proper cross-platform formula via the Contents API.

## Verification

Will verify on the next release tag. The current v0.2.5 formula is already manually patched to be cross-platform.

Part of #3054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to automate Homebrew formula generation and distribution with per-architecture checksums.
  * Simplified release configuration by relocating Homebrew tap management to the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->