### PR TITLE
feat(whatsapp): add include_self_messages config flag

### DIFF
--- a/pkg/gateway/whatsapp/whatsapp.go
+++ b/pkg/gateway/whatsapp/whatsapp.go
@@ -32,16 +32,17 @@ import (
 
 // Adapter implements gateway.NotificationAdapter for WhatsApp via whatsmeow.
 type Adapter struct { //nolint:govet
-	client        *whatsmeow.Client
-	container     *sqlstore.Container
-	handler       func(gateway.Notification)
-	lastMessageAt time.Time
-	name          string
-	stateDir      string
-	lastError     string
-	mu            sync.Mutex
-	connected     bool
-	messageCount  atomic.Int64
+	client              *whatsmeow.Client
+	container           *sqlstore.Container
+	handler             func(gateway.Notification)
+	lastMessageAt       time.Time
+	name                string
+	stateDir            string
+	lastError           string
+	mu                  sync.Mutex
+	connected           bool
+	includeSelfMessages bool
+	messageCount        atomic.Int64
 	// qrChan receives QR codes during pairing.
 	qrChan     chan string
 	groupCache map[string]string
@@ -68,6 +69,15 @@ func New(stateDir string) *Adapter {
 // NewNamed creates a named WhatsApp adapter for multi-account setups.
 func NewNamed(name, stateDir string) *Adapter {
 	return &Adapter{name: name, stateDir: stateDir}
+}
+
+// SetIncludeSelfMessages controls whether messages sent by the paired account
+// itself are ingested. Off by default; enable to discover groups the user
+// created where no other party has yet sent a message.
+func (a *Adapter) SetIncludeSelfMessages(v bool) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.includeSelfMessages = v
 }
 
 func (a *Adapter) Name() string              { return a.name }
@@ -342,9 +352,14 @@ func (a *Adapter) handleEvent(evt interface{}) {
 
 // handleMessage processes an incoming WhatsApp message.
 func (a *Adapter) handleMessage(msg *events.Message) {
-	// Skip own messages.
+	// Skip own messages unless explicitly opted in.
 	if msg.Info.IsFromMe {
-		return
+		a.mu.Lock()
+		include := a.includeSelfMessages
+		a.mu.Unlock()
+		if !include {
+			return
+		}
 	}
 
 	// Skip status broadcasts.

--- a/pkg/workspace/config_gateways.go
+++ b/pkg/workspace/config_gateways.go
@@ -838,8 +838,9 @@ type NotionGatewayConfig struct {
 
 // WhatsAppGatewayConfig configures the WhatsApp (Meta Cloud API) webhook adapter.
 type WhatsAppGatewayConfig struct {
-	VerifyToken string `json:"verify_token"`
-	Enabled     bool   `json:"enabled"`
+	VerifyToken         string `json:"verify_token"`
+	Enabled             bool   `json:"enabled"`
+	IncludeSelfMessages bool   `json:"include_self_messages"`
 }
 
 // SignalGatewayConfig configures the Signal (signal-cli REST) poll adapter.

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -586,8 +586,10 @@ func buildGatewayManager(ctx context.Context, ws *bcworkspace.Workspace, notifyS
 			adapterName = "whatsapp:" + label
 		}
 		waStateDir := filepath.Join(ws.StateDir(), "gateways", adapterName)
-		m.Register(bcwhatsapp.NewNamed(adapterName, waStateDir))
-		log.Info("gateway: whatsapp adapter registered", "name", adapterName)
+		wa := bcwhatsapp.NewNamed(adapterName, waStateDir)
+		wa.SetIncludeSelfMessages(c.IncludeSelfMessages)
+		m.Register(wa)
+		log.Info("gateway: whatsapp adapter registered", "name", adapterName, "include_self", c.IncludeSelfMessages)
 	}
 
 	// Register Matrix poll adapters.


### PR DESCRIPTION
## Summary
- New `include_self_messages` flag on `WhatsAppGatewayConfig` (off by default).
- Adapter gates the `msg.Info.IsFromMe` early-return on the flag, so when enabled, the user's own WhatsApp messages flow into the notification system.
- `build_services.go` wires the flag from config when registering the adapter.

Fixes #3106

## Why
Newly-created WhatsApp groups where only the user has posted are invisible today because whatsmeow's `IsFromMe` messages are dropped. Opting in lets the user create a group, send the first message themselves, and have agents discover it via `/api/channels`.

## Test plan
- [ ] `go vet ./pkg/gateway/whatsapp/ ./pkg/workspace/` (passes locally)
- [ ] Enable `include_self_messages: true` in workspace preferences, restart bcd, send a message from paired phone, confirm a `whatsapp:*` channel appears with the message.
- [ ] Default config (flag absent / false): behavior unchanged, self-messages still skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)