### PR TITLE
ci: unblock dependabot + add cd-npm dispatch

### DIFF
--- a/.github/workflows/cd-npm.yml
+++ b/.github/workflows/cd-npm.yml
@@ -8,6 +8,12 @@ on:
   workflow_run:
     workflows: [Release]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g., v0.2.6)'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,11 +22,20 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     steps:
+      - name: Validate dispatch tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          TAG_INPUT: ${{ github.event.inputs.tag }}
+        run: |
+          if [[ ! "$TAG_INPUT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid tag format: $TAG_INPUT (expected vX.Y.Z)"
+            exit 1
+          fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.inputs.tag || github.event.workflow_run.head_sha }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/cd-npm.yml
+++ b/.github/workflows/cd-npm.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: cd-npm-${{ github.event.inputs.tag || github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish to npm
@@ -31,6 +35,10 @@ jobs:
         run: |
           if [[ ! "$TAG_INPUT" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
             echo "::error::Invalid tag format: $TAG_INPUT (expected vX.Y.Z)"
+            exit 1
+          fi
+          if ! git ls-remote --tags --exit-code "https://github.com/${{ github.repository }}.git" "refs/tags/$TAG_INPUT" >/dev/null; then
+            echo "::error::Tag $TAG_INPUT does not exist in ${{ github.repository }}"
             exit 1
           fi
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -16,6 +16,7 @@ jobs:
   pr-quality:
     name: Check PR Quality
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Check PR standards
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
Part of #3047

## Summary

- **pr-quality.yml**: exempt `dependabot[bot]` from the issue-reference rule. All 13 open dependabot PRs are currently CI-blocked by this — dependabot never references issues.
- **cd-npm.yml**: add `workflow_dispatch` trigger with a validated tag input. Lets us re-publish a tag after fixing the missing `NPM_TOKEN` secret without cutting a new GitHub release. Tag input is validated against the same semver regex used in release.yml before being passed to actions/checkout.

## Test plan
- [ ] Pr-quality CI on this PR passes (after this body edit re-triggers it)
- [ ] After merge: re-run pr-quality on a dependabot PR and confirm the job is skipped
- [ ] After NPM_TOKEN is set: gh workflow run cd-npm.yml -f tag=v0.2.5 should publish mycel-cli@0.2.5 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)