### PR TITLE
fix(web): redirect retired routes + sync smoke test list

### DIFF
--- a/web/e2e/tests/smoke.spec.ts
+++ b/web/e2e/tests/smoke.spec.ts
@@ -1,21 +1,25 @@
 import { test, expect } from "@playwright/test";
 
+// Unscoped paths that should either render directly or redirect into the
+// workspace-scoped equivalent (/w/<active>/<tab>). Retired surfaces
+// (/mcp, /doctor, /daemons) are intentionally absent — see App.tsx for
+// the redirect table that lands them on the nearest live page.
 const pages = [
-  { path: "/", name: "Dashboard" },
+  { path: "/", name: "Live (root)" },
   { path: "/agents", name: "Agents" },
-  { path: "/channels", name: "Channels" },
+  { path: "/notifications", name: "Notifications" },
+  { path: "/channels", name: "Channels (legacy → Notifications)" },
   { path: "/costs", name: "Costs" },
-  { path: "/roles", name: "Roles" },
   { path: "/tools", name: "Tools" },
-  { path: "/mcp", name: "MCP" },
+  { path: "/code", name: "Code" },
   { path: "/cron", name: "Cron" },
   { path: "/secrets", name: "Secrets" },
   { path: "/settings", name: "Settings" },
-  { path: "/doctor", name: "Doctor" },
-  { path: "/logs", name: "Logs" },
-  { path: "/stats", name: "Stats" },
-  { path: "/workspace", name: "Workspace" },
-  { path: "/daemons", name: "Daemons" },
+  { path: "/templates", name: "Templates" },
+  { path: "/logs", name: "Logs (legacy → Live)" },
+  { path: "/stats", name: "Metrics" },
+  { path: "/workspace", name: "Workspace (legacy → Settings)" },
+  { path: "/roles", name: "Roles (legacy → Templates)" },
 ];
 
 test.describe("Smoke tests — every sidebar page loads", () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -112,6 +112,12 @@ export function App() {
                 <Route path="settings" element={<RedirectToActiveWorkspace tab="settings" />} />
                 <Route path="workspace" element={<RedirectToActiveWorkspace tab="settings" />} />
                 <Route path="roles" element={<RedirectToActiveWorkspace tab="templates" />} />
+                <Route path="code" element={<RedirectToActiveWorkspace tab="code" />} />
+                <Route path="code/*" element={<RedirectToActiveWorkspace tab="code" />} />
+                {/* Retired surfaces — bookmarks land on the closest live page */}
+                <Route path="mcp" element={<RedirectToActiveWorkspace tab="tools" />} />
+                <Route path="doctor" element={<RedirectToActiveWorkspace tab="settings" />} />
+                <Route path="daemons" element={<RedirectToActiveWorkspace tab="settings" />} />
 
                 <Route path="*" element={<NotFound />} />
               </Route>


### PR DESCRIPTION
Part of #3047

## Summary

UI v0.2.6 surface review (lucid-meerkat) found four unscoped paths 404'ing: `/code`, `/mcp`, `/doctor`, `/daemons`.

- `/code` is the real Code page that only existed scoped under `/w/<id>`.
- `/mcp`, `/doctor`, `/daemons` are retired surfaces still reachable from old bookmarks and the e2e suite.

### Changes
- `App.tsx`: redirect `/code` to active workspace's `/code`; redirect `/mcp → tools`, `/doctor → settings`, `/daemons → settings` so legacy bookmarks land on the closest live page instead of NotFound.
- `smoke.spec.ts`: drop the three retired routes; add the legacy redirects that now have a target (channels, logs, workspace, roles, code) so the smoke pass actually exercises them.

## Test plan
- [x] Smoke spec covers all live legacy redirects (15 paths total)
- [ ] After merge, lucid-meerkat redeploys v0.2.7 and reverifies the four formerly-404 paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)