### PR TITLE
fix(agent): clear stale task on restart

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1061,6 +1061,10 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 
 	if existing.State == StateStopped || existing.State == StateError {
 		existing.State = StateStarting
+		// Reset the task so the UI doesn't render the previous session's
+		// terminal task (e.g. "Session ended") next to a fresh "Starting"
+		// badge. The next hook fires within seconds and replaces this.
+		existing.Task = "Starting…"
 	}
 	existing.UpdatedAt = time.Now()
 


### PR DESCRIPTION
Part of #3047

## Summary
lucid-meerkat's v0.2.6 UI review flagged the Agents / Live page rendering rows with state="starting" alongside task="Session ended" — the SessionEnd hook left the task string behind and the restart path only updated state, not task.

This patches the only restart point (pkg/agent/agent.go:1062) so the agent's task resets to "Starting…" the moment we transition stopped/error → starting. Within seconds the next hook (SessionStart / UserPromptSubmit / Stop) overwrites with the real task, so the placeholder is invisible to anyone except a refresh in the first second.

## Test plan
- [x] go build ./pkg/agent passes
- [ ] After merge + redeploy, lucid-meerkat reverifies no agent row shows starting+SessionEnded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent restart now resets the status display to "Starting…" for stopped or errored agents, ensuring the UI reflects a fresh starting phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->