### PR TITLE
fix(web): pluralize workspace count, truncate CLI versions, add Costs to ⌘K

### DIFF
--- a/web/src/hooks/useCommandPalette.ts
+++ b/web/src/hooks/useCommandPalette.ts
@@ -50,6 +50,7 @@ export function useCommandPalette() {
       { id: "nav-cron", label: "Cron", section: "Navigate", icon: "@", action: () => navigate("/cron") },
       { id: "nav-secrets", label: "Secrets", section: "Navigate", icon: "#", action: () => navigate("/secrets") },
       { id: "nav-metrics", label: "Metrics", section: "Navigate", icon: "M", action: () => navigate("/metrics") },
+      { id: "nav-costs", label: "Costs", section: "Navigate", icon: "$", action: () => navigate("/costs") },
       { id: "nav-settings", label: "Settings", section: "Navigate", icon: "\u2699", action: () => navigate("/settings") },
       // Actions
       { id: "act-create-agent", label: "Create Agent", section: "Action", icon: "+", action: () => navigate("/agents?action=create") },

--- a/web/src/views/CostsGlobal.tsx
+++ b/web/src/views/CostsGlobal.tsx
@@ -80,7 +80,7 @@ export function CostsGlobal() {
         <span className="text-[11px] uppercase tracking-wider text-mycel-muted/60">Total</span>
         <span className="text-2xl font-semibold text-mycel-text">{formatCost(total)}</span>
         <span className="text-[11px] text-mycel-muted/60">
-          since {start} · {rows?.length ?? 0} {groupBy === "workspace" ? "workspaces" : "projects"}
+          since {start} · {rows?.length ?? 0} {(rows?.length ?? 0) === 1 ? (groupBy === "workspace" ? "workspace" : "project") : (groupBy === "workspace" ? "workspaces" : "projects")}
         </span>
       </div>
 

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -69,7 +69,7 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
             <span className={`text-xs ${cfg.textColor}`}>{tool.version || cfg.label}</span>
           </span>
         </td>
-        <td className="px-3 py-2 text-xs text-mycel-muted font-mono">{tool.version || "\u2014"}</td>
+        <td className="px-3 py-2 text-xs text-mycel-muted font-mono max-w-[180px] truncate" title={tool.version || ""}>{tool.version || "\u2014"}</td>
         <td className="px-3 py-2 text-xs">
           {tool.required ? (
             <span className="px-1.5 py-0.5 rounded bg-mycel-accent/10 text-mycel-accent text-[10px] font-medium">Yes</span>


### PR DESCRIPTION
Part of #3047

## Summary
Three small polish items from lucid-meerkat's v0.2.6 UI review:

- **CostsGlobal**: render "1 workspace" / "1 project" instead of "1 workspaces" when the count is one.
- **Tools**: cap the CLI version cell at 180px with `truncate` + `title` tooltip so providers with long ISO-ish versions (e.g. cursor's `2026.06.12-19-59-36-f6aba9a`) stop overflowing the card.
- **Command palette**: add a Costs entry — the page is real and global, but the palette only listed workspace-scoped tabs.

Deferred to a follow-up PR: restore the Settings Nickname section and surface the actual bound port (both need server-side work to expose runtime values vs. configured defaults).

## Test plan
- [ ] After merge, lucid-meerkat reverifies on v0.2.7 build

🤖 Generated with [Claude Code](https://claude.com/claude-code)