### PR TITLE
fix(gateway/slack): let agent impersonation posts reach other agents

### DIFF
--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -284,9 +284,17 @@ func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload js
 	// bot token. We let those through so other agents — and the
 	// channel feed — see them. The notify layer's self-skip
 	// (pkg/notify/service.go) prevents the sender from receiving
-	// their own message back. Drop only unattributed bot posts.
+	// their own message back.
+	//
+	// CRITICAL: only honour `Username` when the event also came from
+	// our own bot user. Other apps in the same workspace can post
+	// with any `username` override they like, and treating that as
+	// agent identity would let any installed app impersonate
+	// `zen-zebra` / `lucid-meerkat`. Pinning on `ev.User == botUserID`
+	// makes the impersonation token-bound: only callers holding our
+	// own bot token can route as an agent.
 	if ev.SubType == "bot_message" {
-		if ev.Username == "" {
+		if ev.User != a.botUserID || ev.Username == "" {
 			return
 		}
 	} else {
@@ -340,9 +348,10 @@ func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload js
 	}
 
 	// Resolve user name. For bot_message posts the impersonation
-	// username IS the sender — that's the agent name we route on.
+	// Username is the sender — the gate above already verified the
+	// event came from our own bot user, so Username is trusted.
 	sender := ev.User
-	if ev.SubType == "bot_message" && ev.Username != "" {
+	if ev.SubType == "bot_message" && ev.User == a.botUserID && ev.Username != "" {
 		sender = ev.Username
 	} else if a.api != nil {
 		a.chatMu.RLock()

--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -286,7 +286,7 @@ func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload js
 	// (pkg/notify/service.go) prevents the sender from receiving
 	// their own message back.
 	//
-	// CRITICAL: only honour `Username` when the event also came from
+	// CRITICAL: only honor `Username` when the event also came from
 	// our own bot user. Other apps in the same workspace can post
 	// with any `username` override they like, and treating that as
 	// agent identity would let any installed app impersonate

--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -279,13 +279,27 @@ func (a *Adapter) handleEventsAPI(event slackevents.EventsAPIEvent, rawPayload j
 
 // handleMessageEvent processes a single message event.
 func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload json.RawMessage) {
-	// Skip bot messages and message edits/deletes.
-	// Allow file_share subtype for image sharing.
-	if ev.User == a.botUserID || ev.User == "" {
-		return
-	}
-	if ev.SubType != "" && ev.SubType != "file_share" {
-		return
+	// Bot-impersonation posts (subtype="bot_message" with a Username
+	// override) are how mycel agents publish to Slack via the shared
+	// bot token. We let those through so other agents — and the
+	// channel feed — see them. The notify layer's self-skip
+	// (pkg/notify/service.go) prevents the sender from receiving
+	// their own message back. Drop only unattributed bot posts.
+	if ev.SubType == "bot_message" {
+		if ev.Username == "" {
+			return
+		}
+	} else {
+		// Skip messages the bot itself emitted with no impersonation
+		// (legacy outbound echo) and messages with no user attribution.
+		if ev.User == a.botUserID || ev.User == "" {
+			return
+		}
+		// Allow file_share subtype for image sharing; drop other
+		// edit/delete/system subtypes.
+		if ev.SubType != "" && ev.SubType != "file_share" {
+			return
+		}
 	}
 
 	content := ev.Text
@@ -325,9 +339,12 @@ func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload js
 		}
 	}
 
-	// Resolve user name
+	// Resolve user name. For bot_message posts the impersonation
+	// username IS the sender — that's the agent name we route on.
 	sender := ev.User
-	if a.api != nil {
+	if ev.SubType == "bot_message" && ev.Username != "" {
+		sender = ev.Username
+	} else if a.api != nil {
 		a.chatMu.RLock()
 		cachedName, cached := a.userCache[ev.User]
 		a.chatMu.RUnlock()


### PR DESCRIPTION
Part of #3047

## Summary
Agents in this workspace publish to Slack via `chat.postMessage` with a username override (`username: "zen-zebra"` / `"lucid-meerkat"`). Slack delivers those back over the Events API as a regular message event with `subtype=bot_message`, `user=botUserID`, and `Username` set to the override.

The previous filter at `pkg/gateway/slack/slack.go:284` dropped any event where `user==botUserID`, so the two agents could never see each other's slack posts and the channel feed only logged Puneet's messages.

### Changes
- `subtype="bot_message"` with a non-empty `Username` is treated as a post by that named sender (use `Username` as the resolved sender).
- `subtype="bot_message"` with no `Username` — a truly unattributed bot post (workflow runs, third-party app webhooks) — is still dropped.
- Everything else keeps prior behaviour (user posts allowed; edit/delete/system subtypes skipped).

### Loop prevention
Already handled by the existing self-skip in `pkg/notify/service.go:137`, which strips the platform prefix and compares against subscriber agent names — so the sender never receives their own message back even now that bcd ingests it.

## Test plan
- [x] `go build ./pkg/gateway/slack/` passes
- [ ] After merge, zen-zebra posts to Slack and lucid-meerkat receives it as an inbound channel notification (and vice-versa); neither receives their own post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)