### PR TITLE
fix(web): make StatusBadge readable across all agent states

### DIFF
--- a/web/src/components/StatusBadge.tsx
+++ b/web/src/components/StatusBadge.tsx
@@ -1,18 +1,24 @@
+// Status pills surface agent lifecycle state across Agents, Live, and the
+// agent detail header. The map is keyed on the canonical agent state names
+// emitted by pkg/agent (idle, working, starting, stuck, done, error,
+// stopped). Each variant pairs a soft background with a higher-contrast
+// foreground so the badge stays readable on the dark surface and the
+// inactive states are still visibly chips — not just muted text.
 const COLORS: Record<string, string> = {
-  idle: "bg-amber-500/15 text-amber-400",
-  working: "bg-green-500/20 text-green-400",
-  starting: "bg-green-500/20 text-green-400",
-  done: "bg-mycel-success/20 text-mycel-success",
-  stuck: "bg-amber-500/20 text-amber-400",
-  error: "bg-mycel-error/20 text-red-400",
-  stopped: "bg-mycel-muted/10 text-mycel-muted",
+  idle: "bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/20",
+  working: "bg-emerald-500/20 text-emerald-300 ring-1 ring-emerald-500/30",
+  starting: "bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/25",
+  done: "bg-sky-500/15 text-sky-300 ring-1 ring-sky-500/25",
+  stuck: "bg-amber-500/20 text-amber-300 ring-1 ring-amber-500/30",
+  error: "bg-rose-500/15 text-rose-300 ring-1 ring-rose-500/30",
+  stopped: "bg-zinc-500/15 text-zinc-300 ring-1 ring-zinc-500/25",
 };
 
 export function StatusBadge({ status }: { status: string }) {
   const cls = COLORS[status] ?? COLORS["idle"]!;
   return (
     <span
-      className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${cls}`}
+      className={`inline-block px-2 py-0.5 rounded text-xs font-medium tabular-nums ${cls}`}
     >
       {status}
     </span>


### PR DESCRIPTION
Part of #3047

## Summary
Screenshot review of v0.2.6 (see Agents page upload in #general) caught a real visual bug: the Agents table rendered `starting` as a green filled pill but `stopped`/`error`/`idle` as nearly-invisible muted text on the dark surface. The badge was supposed to unify these but its color map fell back to near-bg tones for inactive states.

### Changes
- Every state gets a faint background + ring + brighter foreground so inactive rows look like real pills instead of plain text.
- Switched to Tailwind's named palettes (emerald/amber/sky/rose/zinc) for consistent contrast; `tabular-nums` lines up badge widths when rows stack.

## Test plan
- [ ] After merge + redeploy, lucid-meerkat reverifies the Agents page screenshot — all states should be visible pills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated status badge visual appearance with improved styling and color scheme for different agent statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->