### PR TITLE
fix(web): surface actual bound port in Settings

### DIFF
--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -144,10 +144,25 @@ function Section({
 
 function ServerSection({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
   const s = (data.server ?? {}) as Record<string, unknown>;
+  const configuredPort = Number(s.port ?? 0);
+  // The Settings page renders the *configured* port from settings.json,
+  // but the daemon may be running on an override (BC_BCD_ADDR, --addr flag,
+  // or the legacy 9374 default if neither is set). Surface the actual
+  // listen port from the browser's connection so users see the live
+  // value alongside the editable config value.
+  const actualPort = typeof window !== "undefined" && window.location.port
+    ? Number(window.location.port)
+    : 0;
+  const portDrift = actualPort > 0 && actualPort !== configuredPort;
   return (
     <>
       <Field label="Host"><input className={INPUT_CLS} value={String(s.host ?? "")} onChange={(e) => onChange(["server", "host"], e.target.value)} /></Field>
-      <Field label="Port"><input className={INPUT_CLS} type="number" value={Number(s.port ?? 0)} onChange={(e) => onChange(["server", "port"], Number(e.target.value))} /></Field>
+      <Field
+        label="Port"
+        suffix={portDrift ? `running on ${actualPort}` : actualPort > 0 ? "live" : undefined}
+      >
+        <input className={INPUT_CLS} type="number" value={configuredPort} onChange={(e) => onChange(["server", "port"], Number(e.target.value))} />
+      </Field>
       <Field label="CORS Origin"><input className={INPUT_CLS} value={String(s.cors_origin ?? "")} onChange={(e) => onChange(["server", "cors_origin"], e.target.value)} /></Field>
     </>
   );


### PR DESCRIPTION
Part of #3047

## Summary
v0.2.6 review caught the Settings page showing port `9374` while the daemon was actually running on `:8080` — the field renders the *configured* default from settings.json, not the live listen port. Users suspecting a stale config when in fact the daemon was overriding at runtime (BC_BCD_ADDR, `--addr` flag).

Read `window.location.port` — the browser already knows which port it reached the daemon on — and:
- Show `live` suffix when it matches the configured value (reassurance).
- Show `running on <N>` suffix when there is drift (overridden at runtime).

Zero server changes; works because the SPA is always served from the same origin as the API.

## Test plan
- [x] `cd web && bun run build` passes
- [ ] After merge + redeploy on :8080 with configured port 9374, suffix reads `running on 8080`.
- [ ] After merge + redeploy on configured port 8080, suffix reads `live`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)