### PR TITLE
feat(web): switch primary type to Geist Sans + Geist Mono

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "@bc/web",
       "dependencies": {
+        "@fontsource/geist-mono": "^5.2.8",
+        "@fontsource/geist-sans": "^5.2.5",
         "@monaco-editor/react": "^4.7.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
@@ -176,6 +178,10 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@fontsource/geist-mono": ["@fontsource/geist-mono@5.2.8", "", {}, "sha512-YqZUb3X42GjRaHkibUNyE8K4Rk9A6I9Ez81YpJYiuJN4ggmTW2ixoQpa9EWCPfXZtIsCQJTyrDoV9OJOZO/UcA=="],
+
+    "@fontsource/geist-sans": ["@fontsource/geist-sans@5.2.5", "", {}, "sha512-anllOHyJbElRs9fV15TeDRqAeb1IKm4bSknPl6ZMoyPTx1BBy7logudcUwpNjmQLkzn4Q0JGQLRCUKJYoyST6A=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,8 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@fontsource/geist-mono": "^5.2.8",
+    "@fontsource/geist-sans": "^5.2.5",
     "@monaco-editor/react": "^4.7.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+
+// Geist Sans + Geist Mono via @fontsource. We import only the weights the
+// dashboard actually uses (400 normal, 500 medium, 600 semibold for sans;
+// 400 + 600 for mono) to keep the initial bundle slim and avoid a FOIT.
+import "@fontsource/geist-sans/400.css";
+import "@fontsource/geist-sans/500.css";
+import "@fontsource/geist-sans/600.css";
+import "@fontsource/geist-mono/400.css";
+import "@fontsource/geist-mono/600.css";
+
 import "./theme/tokens.css";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(

--- a/web/src/theme/tokens.css
+++ b/web/src/theme/tokens.css
@@ -26,8 +26,22 @@
   --mycel-shadow: 0 1px 3px rgba(0,0,0,0.4), 0 1px 2px rgba(0,0,0,0.3);
   --mycel-shadow-lg: 0 4px 12px rgba(0,0,0,0.5), 0 2px 4px rgba(0,0,0,0.3);
 
-  font-family: Inter, "Space Grotesk", ui-sans-serif, system-ui, sans-serif;
+  /* Geist Sans for body copy; falls back to ui-sans-serif so the
+     dashboard stays readable if @fontsource fails to load. JetBrains
+     Mono stays around as a mono fallback for the existing
+     font-mono-styled tabular numbers. */
+  font-family: "Geist Sans", ui-sans-serif, system-ui, -apple-system, sans-serif;
   color-scheme: dark;
+}
+
+/* Tailwind's `font-mono` utility resolves to this stack via the global
+   theme; Geist Mono is the preferred monospaced face. */
+.font-mono,
+code,
+kbd,
+pre,
+samp {
+  font-family: "Geist Mono", "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
 }
 
 /* ── Dark ────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Part of #3047

## Summary
v0.2.9 design-system pass: replace the generic Inter / Space Grotesk stack with Vercel's *Geist Sans* for body copy and *Geist Mono* for the tabular numbers and code-style chips that already use `font-mono`. Geist has a more distinctive characterful glyph design and better tabular alignment than Inter, while staying functional and readable.

### Implementation
- `@fontsource/geist-sans` + `@fontsource/geist-mono` — Vite-friendly font loading, woff2 + woff per subset, `font-display: swap` so first paint is not blocked.
- Import only the weights we use: **400 / 500 / 600** sans, **400 / 600** mono.
- `tokens.css` points the body `font-family` at Geist Sans with `ui-sans-serif` fallback, and a global rule swaps the mono family on `.font-mono` / `code` / `kbd` / `pre` / `samp` so Tailwind's `font-mono` utility picks up Geist Mono.

JetBrains Mono stays in the mono fallback chain so the dashboard keeps its current shape if @fontsource ever fails to load.

### Bundle impact
~50 small woff2 files added under `/assets/` (latin / latin-ext / cyrillic / greek / vietnamese × 400/500/600 sans + 400/600 mono). Each subset is < 20 KB woff2 and only the subset the browser needs is fetched. Initial paint stays snappy via `font-display: swap`.

## Test plan
- [x] `cd web && bun run build` passes; fonts emitted as expected
- [ ] After merge + redeploy, lucid-meerkat verifies Geist Sans is in effect on body text and Geist Mono on tabular pills (StatusBadge, Live summary strip, agent name tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refreshed application typography by introducing new font families for primary text display and dedicated monospace elements, enhancing visual clarity and design consistency across the entire dashboard interface. The updated typefaces provide improved readability and a more refined, professional visual aesthetic. These typography changes apply throughout all dashboard components and interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->