### PR TITLE
fix(web): drop redundant ISO date from Costs summary + cap page width

### DIFF
--- a/web/src/views/CostsGlobal.tsx
+++ b/web/src/views/CostsGlobal.tsx
@@ -69,7 +69,7 @@ export function CostsGlobal() {
   });
 
   return (
-    <div className="p-6 flex flex-col gap-4 max-w-4xl">
+    <div className="p-6 flex flex-col gap-4 max-w-4xl mx-auto">
       {error && (
         <div className="rounded border border-mycel-error/40 bg-mycel-error/5 px-3 py-2 text-[12px] text-mycel-error">
           {error}

--- a/web/src/views/CostsGlobal.tsx
+++ b/web/src/views/CostsGlobal.tsx
@@ -69,7 +69,7 @@ export function CostsGlobal() {
   });
 
   return (
-    <div className="p-6 flex flex-col gap-4">
+    <div className="p-6 flex flex-col gap-4 max-w-4xl">
       {error && (
         <div className="rounded border border-mycel-error/40 bg-mycel-error/5 px-3 py-2 text-[12px] text-mycel-error">
           {error}
@@ -80,7 +80,9 @@ export function CostsGlobal() {
         <span className="text-[11px] uppercase tracking-wider text-mycel-muted/60">Total</span>
         <span className="text-2xl font-semibold text-mycel-text">{formatCost(total)}</span>
         <span className="text-[11px] text-mycel-muted/60">
-          since {start} · {rows?.length ?? 0} {(rows?.length ?? 0) === 1 ? (groupBy === "workspace" ? "workspace" : "project") : (groupBy === "workspace" ? "workspaces" : "projects")}
+          {/* Date repeats the value in the picker top-right; show the
+              counter only to avoid the DD/MM ↔ ISO format mismatch. */}
+          {rows?.length ?? 0} {(rows?.length ?? 0) === 1 ? (groupBy === "workspace" ? "workspace" : "project") : (groupBy === "workspace" ? "workspaces" : "projects")}
         </span>
       </div>
 


### PR DESCRIPTION
Part of #3047

## Summary
Costs page polish on two visible quirks from the v0.2.6 screenshot review:

- The summary line read `Total $X.XX since 2026-05-17 · 1 workspace` while the date picker in the header showed `17/05/2026` — the same date in two formats inches apart. *Dropped the `since X` fragment* from the summary; the picker is the single source of truth for the window. (The picker's locale-driven format is browser-controlled and we can't override it.)
- The page used the full main width for a single table that often has one or two rows, leaving an enormous empty rectangle. *Capped at `max-w-4xl`* so the layout reads as a focused panel instead of a half-empty sheet.

Zero data-shape changes.

## Test plan
- [x] `cd web && bun run build` passes
- [ ] After merge + redeploy, Costs page summary shows only the count (no date dupe); table is centered to ~4xl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the main container's layout by adding maximum width constraints, improving visual consistency and readability across different screen sizes.
  * Updated the header display to show dynamic item counts instead of date ranges, providing clearer information while preventing date-format inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->