### PR TITLE
fix(web): rework toast styling — surface card + level rail + icon

### DIFF
--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
 
 export type ToastLevel = "error" | "success" | "info";
 
@@ -10,11 +11,32 @@ export interface ToastMessage {
 
 let nextId = 1;
 
-const LEVEL_STYLES: Record<ToastLevel, string> = {
-  error:   "bg-mycel-error/90 text-white",
-  success: "bg-mycel-success/90 text-white",
-  info:    "bg-mycel-accent/90 text-white",
+// Pill-shaped surface with a tinted left accent rail so the level reads
+// at a glance without painting the whole toast a single brand color.
+const LEVEL_STYLES: Record<ToastLevel, { surface: string; rail: string; icon: string }> = {
+  error: {
+    surface: "bg-mycel-surface text-mycel-text border border-mycel-border ring-1 ring-rose-500/30",
+    rail: "bg-rose-500",
+    icon: "text-rose-400",
+  },
+  success: {
+    surface: "bg-mycel-surface text-mycel-text border border-mycel-border ring-1 ring-emerald-500/30",
+    rail: "bg-emerald-500",
+    icon: "text-emerald-400",
+  },
+  info: {
+    surface: "bg-mycel-surface text-mycel-text border border-mycel-border ring-1 ring-mycel-accent/30",
+    rail: "bg-mycel-accent",
+    icon: "text-mycel-accent",
+  },
 };
+
+function LevelIcon({ level, className }: { level: ToastLevel; className: string }) {
+  const common = { width: 14, height: 14, viewBox: "0 0 14 14", fill: "none", stroke: "currentColor", strokeWidth: 1.6, strokeLinecap: "round" as const, strokeLinejoin: "round" as const, className };
+  if (level === "success") return <svg {...common}><path d="M2.5 7.5l3 3 6-7" /></svg>;
+  if (level === "error") return <svg {...common}><circle cx="7" cy="7" r="5.5" /><path d="M7 4.5v3M7 10v.01" /></svg>;
+  return <svg {...common}><circle cx="7" cy="7" r="5.5" /><path d="M7 9.5V6.5M7 4.5v.01" /></svg>;
+}
 
 function ToastItem({ toast, onDismiss }: { toast: ToastMessage; onDismiss: (id: number) => void }) {
   useEffect(() => {
@@ -22,31 +44,43 @@ function ToastItem({ toast, onDismiss }: { toast: ToastMessage; onDismiss: (id: 
     return () => clearTimeout(timer);
   }, [toast.id, onDismiss]);
 
+  const style = LEVEL_STYLES[toast.level];
+
   return (
-    <div
+    <motion.div
       role="alert"
-      className={`flex items-center gap-2 px-3 py-2 rounded shadow-lg text-sm max-w-sm animate-slide-in ${LEVEL_STYLES[toast.level]}`}
+      initial={{ opacity: 0, y: 12, scale: 0.96 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: -8, scale: 0.96, transition: { duration: 0.15 } }}
+      transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+      layout
+      className={`relative flex items-center gap-2.5 pl-3.5 pr-2 py-2 rounded-lg shadow-lg text-[13px] max-w-sm overflow-hidden ${style.surface}`}
     >
-      <span className="flex-1 break-words">{toast.text}</span>
+      <span className={`absolute left-0 top-0 bottom-0 w-1 ${style.rail}`} aria-hidden />
+      <LevelIcon level={toast.level} className={`shrink-0 ${style.icon}`} />
+      <span className="flex-1 break-words leading-snug">{toast.text}</span>
       <button
         type="button"
         onClick={() => onDismiss(toast.id)}
-        className="shrink-0 opacity-70 hover:opacity-100 text-xs font-bold focus-visible:ring-2 focus-visible:ring-white/50 rounded px-1"
+        className="shrink-0 opacity-60 hover:opacity-100 text-mycel-muted hover:text-mycel-text rounded p-0.5 focus-visible:ring-2 focus-visible:ring-mycel-accent/40 transition-opacity"
         aria-label="Dismiss notification"
       >
-        &times;
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M3 3l6 6M9 3l-6 6" /></svg>
       </button>
-    </div>
+    </motion.div>
   );
 }
 
 export function ToastContainer({ toasts, onDismiss }: { toasts: ToastMessage[]; onDismiss: (id: number) => void }) {
-  if (toasts.length === 0) return null;
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2" aria-live="polite">
-      {toasts.map((t) => (
-        <ToastItem key={t.id} toast={t} onDismiss={onDismiss} />
-      ))}
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2 pointer-events-none" aria-live="polite">
+      <AnimatePresence initial={false}>
+        {toasts.map((t) => (
+          <div key={t.id} className="pointer-events-auto">
+            <ToastItem toast={t} onDismiss={onDismiss} />
+          </div>
+        ))}
+      </AnimatePresence>
     </div>
   );
 }


### PR DESCRIPTION
Part of #3047

## Summary
The previous toasts painted the entire surface a saturated brand color (success / error / info), which read as urgent regardless of severity and clashed with the dark dashboard chrome. Reworks the component into a quieter, more legible pattern.

### Changes
- **Surface** uses `mycel-surface` (matches everything else) with a level-tinted ring and a 1px-wide colored rail down the left edge for at-a-glance severity. No more "neon overlay" feel for routine info toasts.
- **Level icon** — each level gets a tiny outlined icon: check for success, exclamation-in-circle for error, info dot for info. Reinforces severity without relying on color alone (accessibility win).
- **Dismiss** is now a small × icon button instead of the literal × character; matches the rest of the dashboard's icon affordance.
- **AnimatePresence** wraps the stack so individual toasts now mount with a 200ms scale+lift and unmount with a 150ms fade. `layout` keeps the column compact when one in the middle dismisses.
- **pointer-events** trick on the wrapper so clicks pass through the empty bottom-right area when no toast is showing.

API surface (`useToast`, `ToastContainer`, `addToast(level, text)`) is unchanged — pure visual rework.

## Test plan
- [x] `cd web && bun run build` passes
- [ ] After merge + redeploy, trigger a toast from Tools (toggle/remove flow) — verify the new surface, rail, icon, dismiss button, and animation feel cohesive with the rest of the dark dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)