### PR TITLE
fix(web): drop duplicate header band on AgentDetail

### DIFF
--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useLocation, useNavigate } from "react-router-dom";
 import { useWorkspace } from "../context/WorkspaceContext";
+import { useHeaderSlot } from "../context/HeaderSlotContext";
 import { api } from "../api/client";
 import type { Agent, AgentConfig } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
@@ -1014,6 +1015,14 @@ export function AgentDetail() {
   const { workspace } = useWorkspace();
   // Workspace-scoped /agents URL so back-links don't bounce through a redirect.
   const agentsUrl = workspace ? `/w/${workspace.id}/agents` : "/agents";
+
+  // AgentDetail renders its own comprehensive HUD bar (back link + agent
+  // icon + name + state + task + tabs). Clearing the global LayoutHeader's
+  // center slot here prevents the two-band stack the v0.2.6 review flagged
+  // (stale parent-page title sitting on top of our richer local header).
+  // The left slot (workspace dropdown + sidebar toggle) stays untouched
+  // for navigation context.
+  useHeaderSlot({ title: null });
 
   // Derive active tab from URL sub-path: /agents/<name>/<tab>
   // Defaults to "attach" when no sub-path is present.


### PR DESCRIPTION
Part of #3047

## Summary
Spotted via screenshot in #general: visiting an agent stacks two header bands on top of each other. The top band (global LayoutHeader) shows the workspace chip + whatever title the previous tab set (e.g. `Agents ●`). The bottom band is AgentDetail's own HUD bar — back link, agent icon, name, runtime icon, status dot, Loop button, task, last-seen, tabs.

The bottom band is the comprehensive one; the top one is visual debt that duplicates the workspace info and shows a stale parent-page title.

### Fix
`AgentDetail` calls `useHeaderSlot({ title: null })` so the global header's center is intentionally blank. The left slot (workspace dropdown + sidebar toggle) stays untouched for navigation context. The local HUD bar is unchanged.

## Test plan
- [x] `cd web && bun run build` passes
- [ ] After merge + redeploy: navigate Agents → click an agent. Only the local HUD bar should render; the global header above shows only the workspace chip and sidebar toggle (no duplicate title).

🤖 Generated with [Claude Code](https://claude.com/claude-code)