### PR TITLE
fix(web): hide LayoutHeader entirely on AgentDetail

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -742,6 +742,12 @@ function LayoutHeader({
   onToggleCollapsed: () => void;
 }) {
   const { slot } = useHeaderSlotContext();
+  // Pages that render their own self-contained top band (AgentDetail's
+  // HUD bar) opt out of the LayoutHeader entirely so we don't render an
+  // empty 42px row + border above their own header. Sidebar toggle +
+  // workspace dropdown still live in the sidebar, so navigation is
+  // unaffected.
+  if (slot.hidden) return null;
   return (
     <Header
       left={

--- a/web/src/context/HeaderSlotContext.tsx
+++ b/web/src/context/HeaderSlotContext.tsx
@@ -22,6 +22,10 @@ import {
 interface HeaderSlot {
   title?: ReactNode;
   actions?: ReactNode;
+  /** When true, the LayoutHeader is removed entirely (no row, no border).
+   *  Pages that render their own self-contained header (AgentDetail's HUD
+   *  bar) use this to avoid a second top band stacking above their own. */
+  hidden?: boolean;
 }
 
 interface HeaderSlotContextValue {
@@ -63,5 +67,5 @@ export function useHeaderSlot(slot: HeaderSlot) {
     setSlot(slot);
     return () => clearSlot();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [slot.title, slot.actions]);
+  }, [slot.title, slot.actions, slot.hidden]);
 }

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1017,12 +1017,12 @@ export function AgentDetail() {
   const agentsUrl = workspace ? `/w/${workspace.id}/agents` : "/agents";
 
   // AgentDetail renders its own comprehensive HUD bar (back link + agent
-  // icon + name + state + task + tabs). Clearing the global LayoutHeader's
-  // center slot here prevents the two-band stack the v0.2.6 review flagged
-  // (stale parent-page title sitting on top of our richer local header).
-  // The left slot (workspace dropdown + sidebar toggle) stays untouched
-  // for navigation context.
-  useHeaderSlot({ title: null });
+  // icon + name + state + task + tabs), so the global LayoutHeader is
+  // hidden entirely on this view — no empty 42px row + border above our
+  // own header. The sidebar still owns its own collapse arrow and the
+  // workspace dropdown is reachable from the sidebar header, so nothing
+  // navigation-critical is lost.
+  useHeaderSlot({ hidden: true });
 
   // Derive active tab from URL sub-path: /agents/<name>/<tab>
   // Defaults to "attach" when no sub-path is present.


### PR DESCRIPTION
Part of #3047

## Summary
Follow-up to #3128: clearing the header slot's title left an empty 42px row + border above AgentDetail's own HUD bar — the two-band stack was still visible. Puneet asked for the top bar gone outright.

### Changes
- `HeaderSlot` gains a `hidden` flag; `LayoutHeader` returns null when set.
- `AgentDetail` switches its `useHeaderSlot` call from `{ title: null }` to `{ hidden: true }` so the global Header doesn't render on agent pages.
- Sidebar toggle and workspace dropdown stay reachable from the sidebar itself, so nothing navigation-critical is lost.

## Test plan
- [x] `cd web && bun run build` passes
- [ ] After merge + redeploy: AgentDetail shows only the HUD bar at the top. Other pages still show the LayoutHeader as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to completely hide the global layout header on specific pages, enabling cleaner custom page layouts without reserved header space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->