### PR TITLE
docs(mkdocs): exclude_docs for parked _* files

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,13 @@ markdown_extensions:
   - toc:
       permalink: true
 
+# Skip the parked notifications page (pygments NoneType filename bug
+# in one of its code fences) and any other underscore-prefixed archive
+# files until they can be rehabilitated.
+exclude_docs: |
+  _*
+  _archive-notifications.md
+
 nav:
   - Home: index.md
   - Overview: overview.md


### PR DESCRIPTION
Part of #3047

Follow-up to #3131. The underscore-rename alone didn't work — mkdocs scans every .md under docs/ regardless of the leading underscore, so `_architecture-notifications.md` still tripped the pygments NoneType bug.

Added an explicit `exclude_docs:` block matching `_*` so the parked archive file (and any future underscore-prefixed parked docs) are skipped from the build, finally unblocking the docs site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)