### PR TITLE
ci(pages): pin Pygments to 2.17 to unblock docs build

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,7 +32,14 @@ jobs:
           python-version: '3.12.9'
       - name: Build docs
         run: |
-          pip install mkdocs-material==9.6.12 pymdown-extensions==10.14.3
+          # Pygments 2.18+ raises 'NoneType has no attribute replace' when
+          # pymdown-extensions 10.14 calls HtmlFormatter with filename=None
+          # for untitled code fences. Pin to 2.17 until the pymdownx fix
+          # lands so we can drop this pin.
+          pip install \
+            'mkdocs-material==9.6.12' \
+            'pymdown-extensions==10.14.3' \
+            'Pygments==2.17.2'
           mkdocs build
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:


### PR DESCRIPTION
Part of #3047

## Summary
The mkdocs-material + pymdown-extensions + Pygments combination broke pages builds in two files in a row (formerly `architecture/notifications.md`, now `contributing/testing.md`, with more likely lurking): `HtmlFormatter` receives `filename=None` from pymdownx 10.14 and Pygments 2.18+ stopped tolerating that.

Pin Pygments to **2.17.2** — the last release where `html.escape` on a None filename was a no-op. Drop the pin once pymdownx ships its fix or we move to a newer mkdocs-material that pulls in both together.

## Test plan
- [ ] After merge: pages.yml builds and deploys; rpuneet.github.io/mycel renders the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)