### PR TITLE
feat(provider): add Pi provider support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,42 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+## Project Overview
+
+This project is **mycel** - an AI agent orchestration platform. Previously called `bc`, it helps coordinate multiple AI agents (Claude, Gemini, Cursor, etc.) in isolated environments.
+
+## Quick Start
+
+Initialize and run mycel:
+
+```bash
+mycel init                    # Initialize workspace
+mycel up                      # Start server + web UI on localhost:9374
+mycel agent create <name> \
+  --role engineer \
+  --tool claude              # Spawn an agent
+mycel status                  # See what's running
+```
 
 ## Quick Reference
 
+### Managing Agents
+
 ```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --status in_progress  # Claim work
-bd close <id>         # Complete work
-bd sync               # Sync with git
+mycel agent list              # List all agents
+mycel agent create <name>     # Create new agent
+mycel agent attach <agent>    # Attach to agent session
+mycel agent peek <agent>      # Watch agent output
+mycel agent stop <agent>      # Stop agent
+mycel down                    # Stop all agents
+```
+
+### Development
+
+```bash
+make build                    # Build everything
+make test                     # Run all tests
+make lint                     # Run linters
+make check                    # Full quality gate
 ```
 
 ## Landing the Plane (Session Completion)
@@ -18,17 +45,24 @@ bd sync               # Sync with git
 
 **MANDATORY WORKFLOW:**
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
+1. **File issues for remaining work** - Create GitHub issues for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
+   ```bash
+   make test                     # Run tests
+   make lint                     # Run linters
+   ```
+3. **Update issue status** - Close finished GitHub issues, update in-progress items
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd sync
    git push
    git status  # MUST show "up to date with origin"
    ```
 5. **Clean up** - Clear stashes, prune remote branches
+   ```bash
+   git stash clear
+   git remote prune origin
+   ```
 6. **Verify** - All changes committed AND pushed
 7. **Hand off** - Provide context for next session
 
@@ -38,3 +72,13 @@ bd sync               # Sync with git
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 
+## Architecture
+
+mycel uses a provider-based architecture where different AI agent CLIs (Claude, Gemini, Cursor, etc.) are registered as providers. Each provider implements a common interface for:
+
+- Starting agents with provider-specific commands
+- Session resumption (for providers that support it)
+- State detection (idle, working, done, error)
+- Version detection
+
+See `pkg/provider/` for provider implementations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,22 +47,28 @@ make check                    # Full quality gate
 
 1. **File issues for remaining work** - Create GitHub issues for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
+
    ```bash
    make test                     # Run tests
    make lint                     # Run linters
    ```
+
 3. **Update issue status** - Close finished GitHub issues, update in-progress items
 4. **PUSH TO REMOTE** - This is MANDATORY:
+
    ```bash
    git pull --rebase
    git push
    git status  # MUST show "up to date with origin"
    ```
+
 5. **Clean up** - Clear stashes, prune remote branches
+
    ```bash
    git stash clear
    git remote prune origin
    ```
+
 6. **Verify** - All changes committed AND pushed
 7. **Hand off** - Provide context for next session
 

--- a/pkg/provider/integration_test.go
+++ b/pkg/provider/integration_test.go
@@ -55,11 +55,11 @@ func TestProviderConfigRoundtrip(t *testing.T) {
 	cfg := workspace.Config{
 		Providers: workspace.ProvidersConfig{
 			Providers: map[string]workspace.ProviderConfig{
-				"claude": {Command: "claude --skip"},
+				"claude": {Command: "claude --dangerously-skip-permissions"},
 				"gemini": {Command: "gemini --yolo"},
 				"cursor": {Command: "cursor --force"},
 				"codex":  {Command: "codex --auto"},
-				"pi":     {Command: "pi --print"},
+				"pi":     {Command: "pi"},
 			},
 		},
 	}

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -65,10 +66,12 @@ func (p *PiProvider) InstallHint() string {
 
 // BuildCommand returns the full command for a given runtime context.
 // For pi, we use --print for non-interactive mode and --session to track state.
+// SessionID is quoted to prevent potential shell injection issues.
 func (p *PiProvider) BuildCommand(opts CommandOpts) string {
 	cmd := "pi --print"
 	if opts.SessionID != "" {
-		cmd += " --session " + opts.SessionID
+		// Quote SessionID to handle potential spaces/special chars
+		cmd += fmt.Sprintf(" --session \"%s\"", opts.SessionID)
 	}
 	if opts.Resume {
 		cmd += " --continue"

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -34,7 +34,7 @@ func NewPiProvider() *PiProvider {
 		GenericAdapter: NewGenericAdapter("pi"),
 		name:           "pi",
 		description:    "Pi coding assistant CLI",
-		command:        "pi --print",
+		command:        "pi",
 		binary:         "pi",
 	}
 }
@@ -65,10 +65,10 @@ func (p *PiProvider) InstallHint() string {
 }
 
 // BuildCommand returns the full command for a given runtime context.
-// For pi, we use --print for non-interactive mode and --session to track state.
+// For pi, we start with base command and add session flags as needed.
 // SessionID is quoted to prevent potential shell injection issues.
 func (p *PiProvider) BuildCommand(opts CommandOpts) string {
-	cmd := "pi --print"
+	cmd := p.Command()
 	if opts.SessionID != "" {
 		// Quote SessionID to handle potential spaces/special chars
 		cmd += fmt.Sprintf(" --session \"%s\"", opts.SessionID)


### PR DESCRIPTION
## Summary
Add support for Pi coding assistant CLI as a mycel provider.

## Changes
- Added  - Pi provider implementation with session resumption support
- Registered Pi provider in DefaultRegistry
- Updated integration tests to include Pi
- Updated agent help text to list Pi as available tool
- Updated AGENTS.md documentation

## Testing
- All provider tests pass
- All package tests pass
- Linting passes

## Notes
Pi supports session resumption via  and  flags, similar to Claude.

Resolves: TODO (add issue link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `pi` agent tool with session attachment and resumption options.
  * Expanded supported agent tools to include `openclaw`.

* **Documentation**
  * Updated project documentation with overview, quick-start guidance, and architecture information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->