### PR TITLE
fix: persist EnvFile to SQLite database

### DIFF
--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -72,7 +72,7 @@ func createAgentsTable(d *db.DB) error {
 	// Migrations: add columns for existing databases
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN runtime_backend TEXT`)           //nolint:errcheck // ignore if already exists
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN session_id TEXT`)                //nolint:errcheck // ignore if already exists
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN env_file TEXT`)                //nolint:errcheck // ignore if already exists
+	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN env_file TEXT`)                  //nolint:errcheck // ignore if already exists
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN ttl INTEGER NOT NULL DEFAULT 0`) //nolint:errcheck // ignore if already exists
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN created_at TEXT`)                //nolint:errcheck // ignore if already exists
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN stopped_at TEXT`)                //nolint:errcheck // ignore if already exists

--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -49,6 +49,7 @@ func createAgentsTable(d *db.DB) error {
 			workspace     TEXT NOT NULL,
 			worktree_dir  TEXT,
 			log_file      TEXT,
+			env_file      TEXT,
 			hooked_work   TEXT,
 			children      TEXT,
 			is_root       INTEGER NOT NULL DEFAULT 0,
@@ -71,6 +72,7 @@ func createAgentsTable(d *db.DB) error {
 	// Migrations: add columns for existing databases
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN runtime_backend TEXT`)           //nolint:errcheck // ignore if already exists
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN session_id TEXT`)                //nolint:errcheck // ignore if already exists
+	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN env_file TEXT`)                  //nolint:errcheck // ignore if already exists
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN ttl INTEGER NOT NULL DEFAULT 0`) //nolint:errcheck // ignore if already exists
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN created_at TEXT`)                //nolint:errcheck // ignore if already exists
 	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN stopped_at TEXT`)                //nolint:errcheck // ignore if already exists
@@ -116,15 +118,15 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 	_, err = s.db.ExecContext(ctx, `
 		INSERT OR REPLACE INTO agents
 		(name, role, state, tool, parent_id, team, task, session, workspace,
-		 worktree_dir, log_file, hooked_work, children,
+		 worktree_dir, log_file, env_file, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
 		 started_at, updated_at, repo_root)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.Name, string(a.Role), string(a.State),
 		nullStr(a.Tool), nullStr(a.ParentID), nullStr(a.Team), nullStr(a.Task),
 		nullStr(a.Session), a.Workspace,
-		nullStr(a.WorktreeDir), nullStr(a.LogFile),
+		nullStr(a.WorktreeDir), nullStr(a.LogFile), nullStr(a.EnvFile),
 		nullStr(a.HookedWork), string(children),
 		boolToInt(a.IsRoot), a.CrashCount,
 		nullTime(a.LastCrashTime), nullStr(a.RecoveredFrom),
@@ -210,11 +212,11 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 	stmt, err := tx.PrepareContext(ctx, `
 		INSERT OR REPLACE INTO agents
 		(name, role, state, tool, parent_id, team, task, session, workspace,
-		 worktree_dir, log_file, hooked_work, children,
+		 worktree_dir, log_file, env_file, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
 		 started_at, updated_at, repo_root)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -234,7 +236,7 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 			a.Name, string(a.Role), string(a.State),
 			nullStr(a.Tool), nullStr(a.ParentID), nullStr(a.Team), nullStr(a.Task),
 			nullStr(a.Session), a.Workspace,
-			nullStr(a.WorktreeDir), nullStr(a.LogFile),
+			nullStr(a.WorktreeDir), nullStr(a.LogFile), nullStr(a.EnvFile),
 			nullStr(a.HookedWork), string(children),
 			boolToInt(a.IsRoot), a.CrashCount,
 			nullTime(a.LastCrashTime), nullStr(a.RecoveredFrom),
@@ -299,7 +301,7 @@ func (s *SQLiteStore) Close() error {
 
 // agentSelectCols is the SELECT column list used by all Load* methods.
 const agentSelectCols = `SELECT name, role, state, tool, parent_id, team, task, session, workspace,
-	       worktree_dir, log_file, hooked_work, children,
+	       worktree_dir, log_file, env_file, hooked_work, children,
 	       is_root, crash_count, last_crash_time, recovered_from,
 	       runtime_backend, session_id, created_at, stopped_at, deleted_at,
 	       started_at, updated_at, repo_root`
@@ -307,7 +309,7 @@ const agentSelectCols = `SELECT name, role, state, tool, parent_id, team, task, 
 func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	var a Agent
 	var role, state string
-	var tool, parentID, team, task, session, worktreeDir, logFile, hookedWork, childrenJSON *string
+	var tool, parentID, team, task, session, worktreeDir, logFile, envFile, hookedWork, childrenJSON *string
 	var lastCrashTime, recoveredFrom, runtimeBackend, sessionID, repoRoot *string
 	var createdAt, stoppedAt, deletedAt *string
 	var startedAt, updatedAt string
@@ -316,7 +318,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	err := s.Scan(
 		&a.Name, &role, &state,
 		&tool, &parentID, &team, &task, &session, &a.Workspace,
-		&worktreeDir, &logFile, &hookedWork, &childrenJSON,
+		&worktreeDir, &logFile, &envFile, &hookedWork, &childrenJSON,
 		&isRoot, &crashCount, &lastCrashTime, &recoveredFrom,
 		&runtimeBackend, &sessionID, &createdAt, &stoppedAt, &deletedAt,
 		&startedAt, &updatedAt, &repoRoot,
@@ -336,6 +338,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	a.SessionID = deref(sessionID)
 	a.WorktreeDir = deref(worktreeDir)
 	a.LogFile = deref(logFile)
+	a.EnvFile = deref(envFile)
 	a.HookedWork = deref(hookedWork)
 	a.IsRoot = isRoot != 0
 	a.CrashCount = crashCount

--- a/pkg/agent/store_sqlite_test.go
+++ b/pkg/agent/store_sqlite_test.go
@@ -352,3 +352,88 @@ func TestSQLiteStore_DeletedAtPersistence(t *testing.T) {
 		t.Fatalf("expected 0 agents after restart, got %d (soft-deleted agent resurrected)", len(all))
 	}
 }
+
+func TestSQLiteStore_EnvFilePersistence(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSQLiteStore(filepath.Join(dir, "state.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+
+	now := time.Now().Truncate(time.Second)
+	testEnvPath := "/tmp/test-agent-env.json"
+
+	a := &Agent{
+		Name:      "agent-with-env",
+		ID:        "agent-with-env",
+		Role:      Role("engineer"),
+		State:     StateIdle,
+		Tool:      "claude",
+		Workspace: "/tmp/ws",
+		CreatedAt: now,
+		StartedAt: now,
+		EnvFile:   testEnvPath,
+		Children:  []string{},
+	}
+
+	// Save agent with EnvFile
+	if saveErr := store.Save(context.Background(), a); saveErr != nil {
+		t.Fatalf("Save: %v", saveErr)
+	}
+
+	// Load and verify EnvFile persisted
+	loaded, err := store.Load(context.Background(), "agent-with-env")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("Load returned nil")
+	}
+	if loaded.EnvFile != testEnvPath {
+		t.Errorf("EnvFile = %q, want %q", loaded.EnvFile, testEnvPath)
+	}
+
+	// Test SaveAll also persists EnvFile
+	agents := map[string]*Agent{
+		"agent-1": {
+			Name:      "agent-1",
+			ID:        "agent-1",
+			Role:      Role("engineer"),
+			State:     StateIdle,
+			Tool:      "claude",
+			Workspace: "/tmp/ws",
+			CreatedAt: now,
+			StartedAt: now,
+			EnvFile:   "/tmp/agent-1-env.json",
+			Children:  []string{},
+		},
+		"agent-2": {
+			Name:      "agent-2",
+			ID:        "agent-2",
+			Role:      Role("manager"),
+			State:     StateWorking,
+			Tool:      "pi",
+			Workspace: "/tmp/ws2",
+			CreatedAt: now,
+			StartedAt: now,
+			EnvFile:   "/tmp/agent-2-env.json",
+			Children:  []string{},
+		},
+	}
+
+	if saveAllErr := store.SaveAll(context.Background(), agents); saveAllErr != nil {
+		t.Fatalf("SaveAll: %v", saveAllErr)
+	}
+
+	// Verify both agents loaded with correct EnvFile
+	for name, expectedAgent := range agents {
+		loaded, err := store.Load(context.Background(), name)
+		if err != nil {
+			t.Fatalf("Load %s: %v", name, err)
+		}
+		if loaded.EnvFile != expectedAgent.EnvFile {
+			t.Errorf("%s EnvFile = %q, want %q", name, loaded.EnvFile, expectedAgent.EnvFile)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a critical bug where environment variables set via the web UI were not being persisted to the SQLite database, causing them to be lost when agents were reloaded.

## Root Cause

The `EnvFile` field in the `Agent` struct was defined but never stored in the SQLite database schema. This caused the following failure chain:

1. Web UI saves env vars to `.bc/agents/<name>/env.json` ✓
2. But `Agent.EnvFile` field (pointer to that file) was never persisted ✗
3. When agent loaded from DB, `EnvFile` was empty ✗
4. `injectEnv()` couldn't load the env file ✗
5. Environment variables never reached tmux sessions ✗

**Impact:** AWS Bedrock API keys and all other environment variables silently failed to load

## Solution

Added `env_file` column to the agents table and wired it through all database operations:

### Changes Made:

1. **Schema** (`createAgentsTable`):
   - Added `env_file TEXT` to CREATE TABLE
   - Added `ALTER TABLE agents ADD COLUMN env_file TEXT` migration

2. **INSERT operations**:
   - Updated `Save()` INSERT columns and VALUES (added `env_file,` and `nullStr(a.EnvFile)`)
   - Updated `SaveAll()` INSERT columns, VALUES placeholders (26 ?), and ExecContext values
   - Verified: 26 columns ↔ 26 values match

3. **SELECT operations**:
   - Updated `agentSelectCols` to include `env_file`

4. **Scan operations**:
   - Added `envFile *string` variable to `scanAgentRow`
   - Added `&envFile` to `Scan()` call
   - Added `a.EnvFile = deref(envFile)` assignment

### Testing

✅ **All existing tests pass:**
- `TestSQLiteStore_RuntimeBackend_*` (4 tests)
- `TestSQLiteStore_SaveLoadDelete`
- `TestSQLiteStore_LoadAll`
- `TestSQLiteStore_SaveAll`
- `TestSQLiteStore_UpdateState`
- `TestSQLiteStore_UpdateField`
- `TestSQLiteStore_RootFields`
- `TestSQLiteStore_ConcurrentAccess`
- `TestSQLiteStore_SoftDelete`
- `TestSQLiteStore_DeletedAtPersistence`

✅ **New test added:**
- `TestSQLiteStore_EnvFilePersistence`: Verifies env_file roundtrip through Save/Load and SaveAll/Load

### Test Plan

- [x] Run `go test ./pkg/agent -v` - All tests pass
- [x] Verify `TestSQLiteStore_EnvFilePersistence` passes
- [x] Verify no regression in existing SQLite tests
- [x] Check database schema in new store has env_file column
- [x] Verify migration SQL for existing databases is safe

### Files Changed

- `pkg/agent/store_sqlite.go` - Core persistence logic (added env_file handling)
- `pkg/agent/store_sqlite_test.go` - Added comprehensive test coverage

### How to Test Manually

1. Create an agent and set environment variables via web UI Config tab
2. Verify env vars are saved to `.bc/agents/<agent-name>/env.json`
3. Restart agent (stop and start)
4. Verify environment variables persist and are accessible in agent session
5. Test with AWS Bedrock API key: should work after restart

### CI Status

✅ All Go tests pass locally
⚠️ TUI tests may show failures (pre-existing, unrelated to this change)

</details>
