### PR TITLE
feat(web): add /about page showing installed version + dist channels

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -23,6 +23,7 @@ const Settings = lazy(() => import("./views/Settings").then((m) => ({ default: m
 const WorkspacePicker = lazy(() => import("./views/WorkspacePicker").then((m) => ({ default: m.WorkspacePicker })));
 const Code = lazy(() => import("./views/Code").then((m) => ({ default: m.Code })));
 const CostsGlobal = lazy(() => import("./views/CostsGlobal").then((m) => ({ default: m.CostsGlobal })));
+const About = lazy(() => import("./views/About").then((m) => ({ default: m.About })));
 
 function Loading() {
   return <div className="p-6 text-mycel-muted">Loading...</div>;
@@ -62,6 +63,7 @@ export function App() {
 
                 {/* Global (cross-workspace) routes — outside /w/:wsId */}
                 <Route path="costs" element={wrap(<CostsGlobal />)} />
+                <Route path="about" element={wrap(<About />)} />
 
                 {/* Workspace-scoped routes (guard renders <Outlet /> for children) */}
                 <Route path="w/:wsId" element={<ActiveWorkspaceGuard />}>

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -449,6 +449,14 @@ const GLOBAL_NAV_ITEMS = [
 
 const NAV_ITEMS = [...MAIN_NAV_ITEMS, ...UTIL_NAV_ITEMS, ...GLOBAL_NAV_ITEMS];
 
+/**
+ * TITLE_ITEMS — extends NAV_ITEMS with surfaces that resolve to a
+ * document title but live outside the sidebar nav lists (e.g. /about
+ * sits in the sidebar footer next to the theme toggle, not in any
+ * NavList). Keep this list in sync with non-nav top-level routes.
+ */
+const TITLE_ITEMS = [...NAV_ITEMS, { to: "/about", label: "About" }];
+
 function readCollapsed(): boolean {
   try { return localStorage.getItem(SIDEBAR_KEY) === "true"; } catch { return false; }
 }
@@ -581,7 +589,7 @@ export function Layout() {
     // tab ("Live").
     const stripped = location.pathname.replace(/^\/w\/[^/]+/, "");
     const firstSeg = stripped.replace(/^\//, "").split("/")[0] ?? "";
-    const match = NAV_ITEMS.find((item) => {
+    const match = TITLE_ITEMS.find((item) => {
       const seg = item.to.replace(/^\//, "");
       return seg === firstSeg;
     });

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -690,6 +690,32 @@ export function Layout() {
           <NavList items={UTIL_NAV_ITEMS} collapsed={collapsed} isMobile={isMobile} />
         </ul>
 
+        {/* About chip — surfaces installed version + distribution channel
+            status. Sits in the sidebar footer next to the theme toggle so
+            users always have a one-click answer to "what version am I on?". */}
+        <div className="py-1 border-t border-mycel-border/30">
+          <NavLink
+            to="/about"
+            className={({ isActive }) =>
+              `relative flex items-center gap-2.5 ${collapsed && !isMobile ? "justify-center px-2" : "pl-4 pr-3"} py-[7px] w-full text-[11px] ${isActive ? "text-mycel-text bg-mycel-bg/30 border-l-2 border-mycel-accent" : "text-mycel-muted/75 hover:text-mycel-text hover:bg-mycel-bg/30 border-l-2 border-transparent"} transition-colors`
+            }
+            title="About / version info"
+          >
+            <span className="shrink-0 flex items-center justify-center w-4 opacity-80">
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
+                <circle cx="7" cy="7" r="5.5" />
+                <path d="M7 4.5v.01M6 6.5h1v3h1" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </span>
+            {(!collapsed || isMobile) && (
+              <>
+                <span className="truncate font-medium tracking-tight">About</span>
+                <span className="ml-auto text-[9px] text-mycel-muted/50 uppercase tracking-wider">version</span>
+              </>
+            )}
+          </NavLink>
+        </div>
+
         {/* Theme toggle — matches nav-item width and padding for visual alignment.
             Foreground bumped from muted/50 to muted/75 so the label is legible
             without competing with the active-nav highlight above it. */}

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -33,6 +33,17 @@ interface ChannelStatus {
 
 const GITHUB_REPO = "rpuneet/mycel";
 
+/** withTimeout — caps any one channel-check fetch at `ms` so a hung
+ *  request (DNS timeout, GitHub API rate-limit holding the socket open,
+ *  slow mirror) can't pin the page in the loading state. Resolves the
+ *  supplied fallback instead of rejecting. */
+function withTimeout<T>(p: Promise<T>, fallback: T, ms = 8000): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((resolve) => setTimeout(() => resolve(fallback), ms)),
+  ]);
+}
+
 async function fetchHealth(): Promise<Health | null> {
   try {
     const r = await fetch("/api/health");
@@ -104,19 +115,22 @@ export function About() {
 
   const refresh = useCallback(async () => {
     setLoading(true);
-    const [h, l, n, b, p] = await Promise.all([
-      fetchHealth(),
-      fetchLatestGhRelease(),
-      fetchNpmLatest(),
-      fetchBrewVersion(),
-      pingPages(),
-    ]);
-    setHealth(h);
-    setLatest(l);
-    setNpm(n);
-    setBrew(b);
-    setPagesOk(p);
-    setLoading(false);
+    try {
+      const [h, l, n, b, p] = await Promise.all([
+        withTimeout(fetchHealth(), null),
+        withTimeout(fetchLatestGhRelease(), null),
+        withTimeout(fetchNpmLatest(), null),
+        withTimeout(fetchBrewVersion(), null),
+        withTimeout(pingPages(), false),
+      ]);
+      setHealth(h);
+      setLatest(l);
+      setNpm(n);
+      setBrew(b);
+      setPagesOk(p);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {
@@ -144,14 +158,31 @@ export function About() {
       href: "https://www.npmjs.com/package/mycel-cli",
       version: npm?.latest,
       detail: npm ? `${npm.versions.length} versions` : undefined,
-      state: npm ? (latestTag && npm.latest !== latestTag ? "stale" : "ok") : "unknown",
+      // Without a latest GitHub tag we have no baseline to call this
+      // "ok" or "stale" against — degrade to "unknown" instead of
+      // showing a false green dot when the GitHub API is rate-limited.
+      state: npm
+        ? latestTag
+          ? npm.latest !== latestTag
+            ? "stale"
+            : "ok"
+          : "unknown"
+        : "unknown",
     },
     {
       label: "Homebrew tap",
       href: `https://github.com/${GITHUB_REPO.split("/")[0]}/homebrew-mycel`,
       version: brew ?? undefined,
       detail: "brew tap rpuneet/mycel",
-      state: brew ? (latestTag && brew !== latestTag ? "stale" : "ok") : "unknown",
+      // Same reasoning as the npm tile — without latestTag we can't
+      // declare healthy or stale, so fall back to "unknown".
+      state: brew
+        ? latestTag
+          ? brew !== latestTag
+            ? "stale"
+            : "ok"
+          : "unknown"
+        : "unknown",
     },
     {
       label: "Docs site",

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useState } from "react";
+import { useHeaderSlot } from "../context/HeaderSlotContext";
+import { TabHeaderTitle } from "../components/Header";
+
+/* ── Types ──────────────────────────────────────────────────────────── */
+
+interface Health {
+  status: string;
+  db: string;
+  version: string;
+}
+
+interface GhRelease {
+  tag_name: string;
+  html_url: string;
+  published_at: string;
+}
+
+interface NpmInfo {
+  versions: string[];
+  latest: string;
+}
+
+interface ChannelStatus {
+  label: string;
+  href?: string;
+  version?: string;
+  detail?: string;
+  state: "ok" | "stale" | "loading" | "unknown" | "error";
+}
+
+/* ── Helpers ────────────────────────────────────────────────────────── */
+
+const GITHUB_REPO = "rpuneet/mycel";
+
+async function fetchHealth(): Promise<Health | null> {
+  try {
+    const r = await fetch("/api/health");
+    if (!r.ok) return null;
+    return (await r.json()) as Health;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchLatestGhRelease(): Promise<GhRelease | null> {
+  try {
+    const r = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases/latest`);
+    if (!r.ok) return null;
+    const j = (await r.json()) as GhRelease;
+    return j;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchNpmLatest(): Promise<NpmInfo | null> {
+  try {
+    const r = await fetch(`https://registry.npmjs.org/mycel-cli`);
+    if (!r.ok) return null;
+    const j = (await r.json()) as { "dist-tags"?: { latest?: string }; versions?: Record<string, unknown> };
+    const versions = Object.keys(j.versions ?? {});
+    const latest = j["dist-tags"]?.latest ?? versions[versions.length - 1] ?? "?";
+    return { versions, latest };
+  } catch {
+    return null;
+  }
+}
+
+async function fetchBrewVersion(): Promise<string | null> {
+  try {
+    // The Formula file lives on the homebrew-mycel tap repo at a stable path.
+    const r = await fetch(`https://raw.githubusercontent.com/${GITHUB_REPO.split("/")[0]}/homebrew-mycel/main/Formula/mycel.rb`);
+    if (!r.ok) return null;
+    const text = await r.text();
+    const m = text.match(/version\s+"([^"]+)"/);
+    return m?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function pingPages(): Promise<boolean> {
+  try {
+    const r = await fetch(`https://${GITHUB_REPO.split("/")[0]}.github.io/${GITHUB_REPO.split("/")[1]}/`, { method: "HEAD", mode: "no-cors" });
+    // no-cors fetches return opaque responses; presence of a non-throwing fetch is the strongest signal we can get.
+    return r.type === "opaque" || r.ok;
+  } catch {
+    return false;
+  }
+}
+
+/* ── View ──────────────────────────────────────────────────────────── */
+
+export function About() {
+  useHeaderSlot({ title: <TabHeaderTitle>About</TabHeaderTitle> });
+
+  const [health, setHealth] = useState<Health | null>(null);
+  const [latest, setLatest] = useState<GhRelease | null>(null);
+  const [npm, setNpm] = useState<NpmInfo | null>(null);
+  const [brew, setBrew] = useState<string | null>(null);
+  const [pagesOk, setPagesOk] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const [h, l, n, b, p] = await Promise.all([
+      fetchHealth(),
+      fetchLatestGhRelease(),
+      fetchNpmLatest(),
+      fetchBrewVersion(),
+      pingPages(),
+    ]);
+    setHealth(h);
+    setLatest(l);
+    setNpm(n);
+    setBrew(b);
+    setPagesOk(p);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const latestTag = latest?.tag_name?.replace(/^v/, "") ?? null;
+
+  const channels: ChannelStatus[] = [
+    {
+      label: "Daemon (bcd)",
+      version: health?.version ?? undefined,
+      detail: health ? `db: ${health.db}` : "unavailable",
+      state: health ? "ok" : "error",
+    },
+    {
+      label: "GitHub release",
+      href: latest?.html_url,
+      version: latestTag ?? undefined,
+      detail: latest?.published_at ? new Date(latest.published_at).toLocaleString() : undefined,
+      state: latest ? "ok" : "unknown",
+    },
+    {
+      label: "npm (mycel-cli)",
+      href: "https://www.npmjs.com/package/mycel-cli",
+      version: npm?.latest,
+      detail: npm ? `${npm.versions.length} versions` : undefined,
+      state: npm ? (latestTag && npm.latest !== latestTag ? "stale" : "ok") : "unknown",
+    },
+    {
+      label: "Homebrew tap",
+      href: `https://github.com/${GITHUB_REPO.split("/")[0]}/homebrew-mycel`,
+      version: brew ?? undefined,
+      detail: "brew tap rpuneet/mycel",
+      state: brew ? (latestTag && brew !== latestTag ? "stale" : "ok") : "unknown",
+    },
+    {
+      label: "Docs site",
+      href: `https://${GITHUB_REPO.split("/")[0]}.github.io/${GITHUB_REPO.split("/")[1]}/`,
+      detail: "GitHub Pages",
+      state: pagesOk == null ? "loading" : pagesOk ? "ok" : "error",
+    },
+  ];
+
+  return (
+    <div className="p-6 flex flex-col gap-6 max-w-3xl mx-auto">
+      <header className="flex items-baseline justify-between gap-3">
+        <div className="flex items-baseline gap-3">
+          <span className="text-[11px] uppercase tracking-wider text-mycel-muted/60">Installed</span>
+          <span className="text-2xl font-semibold text-mycel-text font-mono tabular-nums">
+            {health?.version ?? "—"}
+          </span>
+          {latestTag && health && health.version !== latestTag && (
+            <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/30">
+              update available
+            </span>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          disabled={loading}
+          className="text-[11px] px-2.5 py-1 rounded border border-mycel-border hover:border-mycel-accent bg-mycel-surface text-mycel-muted hover:text-mycel-text transition-colors disabled:opacity-50"
+        >
+          {loading ? "Refreshing…" : "Refresh"}
+        </button>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-px rounded-md border border-mycel-border bg-mycel-border/40 overflow-hidden">
+        {channels.map((c) => (
+          <ChannelTile key={c.label} channel={c} />
+        ))}
+      </div>
+
+      <section className="rounded-md border border-mycel-border/60 bg-mycel-surface px-4 py-3 text-[12px] leading-relaxed text-mycel-muted">
+        <p className="text-mycel-text mb-1.5 font-medium">Install or upgrade</p>
+        <pre className="font-mono text-[11px] text-mycel-text whitespace-pre-wrap">
+{`brew tap rpuneet/mycel && brew install mycel    # macOS / Linux
+npm i -g mycel-cli                              # any platform with node
+go install github.com/rpuneet/mycel/cmd/mycel@latest    # from source`}
+        </pre>
+      </section>
+
+      <footer className="text-[10px] text-mycel-muted/60 font-mono">
+        Built from commit <span className="text-mycel-text">{health?.version ?? "?"}</span>.
+        Live distribution checks hit github.com / registry.npmjs.org / raw.githubusercontent.com directly.
+      </footer>
+    </div>
+  );
+}
+
+/* ── Channel tile ──────────────────────────────────────────────────── */
+
+const STATE_DOT: Record<ChannelStatus["state"], string> = {
+  ok: "bg-emerald-400",
+  stale: "bg-amber-400",
+  loading: "bg-mycel-muted animate-pulse",
+  unknown: "bg-mycel-muted/40",
+  error: "bg-rose-400",
+};
+
+function ChannelTile({ channel }: { channel: ChannelStatus }) {
+  const body = (
+    <div className="bg-mycel-surface px-4 py-3 flex items-start gap-3 h-full hover:bg-mycel-surface-hover transition-colors">
+      <span className={`mt-1.5 shrink-0 inline-flex w-2 h-2 rounded-full ${STATE_DOT[channel.state]}`} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2 flex-wrap">
+          <span className="text-[12px] text-mycel-text font-medium">{channel.label}</span>
+          {channel.version && (
+            <span className="text-[11px] font-mono tabular-nums text-mycel-muted">v{channel.version}</span>
+          )}
+        </div>
+        {channel.detail && (
+          <p className="mt-0.5 text-[10px] text-mycel-muted/70 truncate" title={channel.detail}>
+            {channel.detail}
+          </p>
+        )}
+      </div>
+      {channel.href && (
+        <span className="text-[10px] text-mycel-muted/50 shrink-0" aria-hidden>↗</span>
+      )}
+    </div>
+  );
+  if (channel.href) {
+    return (
+      <a href={channel.href} target="_blank" rel="noreferrer" className="block focus:outline-none focus:ring-1 focus:ring-mycel-accent">
+        {body}
+      </a>
+    );
+  }
+  return body;
+}


### PR DESCRIPTION
Part of #3047

## Summary
Puneet's ask: "how do we know it's live? there should be a version page or something." Adds a small About surface so the user always has a one-click answer to *what version am I on, and where is it shipping from*.

### Page (`web/src/views/About.tsx`)
- Big **Installed** header with the commit the running daemon was built from (read live from `/api/health`). Shows an **"update available"** amber chip when it differs from the latest GitHub release tag.
- **5-tile status grid** for distribution channels, each with a semantic dot (emerald / amber / rose) + version + last-known detail:

| Tile | Source |
|---|---|
| Daemon (bcd) | `/api/health` |
| GitHub release | `api.github.com/.../releases/latest` |
| npm (mycel-cli) | `registry.npmjs.org/mycel-cli` |
| Homebrew tap | `Formula/mycel.rb` on `homebrew-mycel` |
| Docs site | HEAD ping to `rpuneet.github.io/mycel/` |

Tiles with an `href` deep-link to the canonical channel page. Stale states (channel version ≠ latest release) get the amber dot so drift surfaces immediately.

- "Install or upgrade" code block with the brew / npm / go install one-liners so first-time installers don't bounce around.
- All checks hit public endpoints from the client — no server changes required.

### Wiring
- `App.tsx`: lazy-loaded `/about` route under the global routes (cross-workspace, like `/costs`).
- `Layout.tsx`: sidebar footer gains an "About / version" NavLink right above the theme chip, matching the sidebar's footer rhythm. Collapses to just an icon when the sidebar is collapsed.

## Test plan
- [x] `cd web && bun run build` passes
- [ ] After merge + redeploy: `/about` renders, all five tiles populate within ~1s, deep-links open the right pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new About page accessible via sidebar navigation
  * Displays installed version and checks for available updates across distribution channels
  * Shows status of various availability channels
  * Includes refresh button to manually check for latest version information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->