### PR TITLE
fix(live): pin scroll anchor so card updates don't jump the viewport

### DIFF
--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -514,8 +514,18 @@ export function Live() {
         </div>
       )}
 
-      {/* Agent Activity Cards */}
-      <div ref={scrollContainerRef} className="flex-1 overflow-y-auto min-h-0 space-y-3 relative">
+      {/* Agent Activity Cards.
+          overflow-anchor: none stops the browser auto-scrolling when a
+          card above the viewport changes height (the source of the
+          "jumps to bottom / latest at top swap" the team flagged).
+          Newest is anchored at the top via the sort comparator above,
+          and the explicit Jump-to-latest button handles intentional
+          recentering when the user has scrolled away. */}
+      <div
+        ref={scrollContainerRef}
+        className="flex-1 overflow-y-auto min-h-0 space-y-3 relative max-h-full"
+        style={{ overflowAnchor: "none", scrollbarGutter: "stable" }}
+      >
         {sorted.length === 0 ? (
           !showStopped && activeCount === 0 && stoppedCount > 0 ? (
             <EmptyState


### PR DESCRIPTION
Closes #3139

## Summary
The Live page felt wonky on every event: when a card above the viewport updated (token tick, state change, new tool node), the browser's automatic scroll-anchoring would yank the visible area — sometimes throwing the newest card to the bottom, sometimes swapping top/latest order. The card sort itself is already deterministic (working > stuck > idle > stopped > error, then name) and newest is intended to be at the top.

Three minimal CSS-level fixes on the existing scroll container:
- **`overflow-anchor: none`** disables the browser's auto-anchor heuristic entirely, so layout changes above the viewport stop relocating the user's scroll position.
- **`scrollbar-gutter: stable`** reserves the scrollbar width even when the list is short, so adding/removing cards no longer shifts the horizontal layout under the cards.
- **`max-h-full`** hardens the existing `flex-1 min-h-0` so the cards always scroll inside their own pane instead of pushing the page body.

The Jump-to-latest button still owns intentional recentering when the user has scrolled away. No new state, no new effects.

## Test plan
- [x] `cd web && bun run build` passes
- [ ] After merge + redeploy: open Live with 2+ active agents, scroll mid-page, watch a token tick or state change — viewport stays put. Click Jump to latest → smoothly scrolls to top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll behavior for agent activity cards to prevent unintended scroll jumps and maintain stable scrollbar positioning during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->