### PR TITLE
fix(provider): apply workspace command override on agent start (#3141)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -480,6 +480,13 @@ type Manager struct { //nolint:govet // field order is intentional for readabili
 	// gatewayConfig holds gateway credentials for injection into agent env vars.
 	gatewayConfig *workspace.GatewaysConfig
 
+	// providersConfig holds the workspace's provider command overrides
+	// (preferences.json `providers.<tool>.command`). Used by
+	// getAgentCommand to layer a user-supplied command on top of the
+	// provider's hardcoded BuildCommand — e.g. so `pi` can be pointed
+	// at AWS Bedrock via workspace config.
+	providersConfig *workspace.ProvidersConfig
+
 	// maxLogBytes is the maximum log file size before truncation.
 	// Defaults to DefaultMaxLogBytes; overridden by ApplyWorkspaceConfig.
 	maxLogBytes int64
@@ -511,6 +518,7 @@ func (m *Manager) ApplyWorkspaceConfig(cfg *workspace.Config) {
 		m.maxLogBytes = cfg.Logs.MaxBytes
 	}
 	m.gatewayConfig = &cfg.Gateways
+	m.providersConfig = &cfg.Providers
 }
 
 // notifyStateChange calls the onStateChange callback if set.
@@ -681,19 +689,59 @@ func defaultAgentCmd() (string, string) {
 	return p.Command(), name
 }
 
-// getAgentCommand looks up the command for a tool from the manager's provider registry.
+// getAgentCommand looks up the command for a tool from the manager's
+// provider registry, layering a workspace-level override on top when
+// the workspace's preferences.json defines one. The override path is
+// what makes a user able to spawn pi against AWS Bedrock by writing:
+//
+//	providers:
+//	  pi:
+//	    command: pi --provider amazon-bedrock --model anthropic.claude-…
+//
+// Resolution order: workspace ProvidersConfig command (if non-empty)
+// → provider's own BuildCommand. Session flags from the provider
+// (--continue / --session) are appended even when the workspace
+// overrides the base command so resume still works.
 // SessionID takes priority over the resume flag when non-empty.
 func (m *Manager) getAgentCommand(toolName, agentName string, resume bool, sessionID string) (string, bool) {
-	if m.providerRegistry != nil {
-		if p, ok := m.providerRegistry.Get(toolName); ok {
-			return p.BuildCommand(provider.CommandOpts{
-				AgentName: agentName,
-				Resume:    resume,
-				SessionID: sessionID,
-			}), true
+	if m.providerRegistry == nil {
+		return "", false
+	}
+	p, ok := m.providerRegistry.Get(toolName)
+	if !ok {
+		return "", false
+	}
+	opts := provider.CommandOpts{
+		AgentName: agentName,
+		Resume:    resume,
+		SessionID: sessionID,
+	}
+	// Apply workspace-level command override when present. We rebuild
+	// the session flags via the provider so we don't lose --continue
+	// or --session "<id>" handling.
+	if m.providersConfig != nil {
+		if cfg, ok := m.providersConfig.Providers[toolName]; ok && cfg.Command != "" {
+			return appendSessionFlags(cfg.Command, opts), true
 		}
 	}
-	return "", false
+	return p.BuildCommand(opts), true
+}
+
+// appendSessionFlags adds the same --continue / --session flags the
+// provider's BuildCommand would, but to an arbitrary base command. We
+// keep the logic in one place so workspace overrides cooperate with
+// resume cleanly.
+func appendSessionFlags(base string, opts provider.CommandOpts) string {
+	cmd := base
+	if opts.SessionID != "" {
+		// Quote SessionID to handle potential spaces / special chars,
+		// matching PiProvider.BuildCommand's approach.
+		cmd += fmt.Sprintf(" --session %q", opts.SessionID)
+	}
+	if opts.Resume {
+		cmd += " --continue"
+	}
+	return cmd
 }
 
 // listAvailableTools returns tool names from the manager's provider registry.


### PR DESCRIPTION
Closes #3141
Closes #3144
Part of #3047 / #3079.

## Problem
`pkg/agent/agent.go:GetAgentCommandFromConfig` was defined but had no call site. Writing
```yaml
providers:
  pi:
    command: pi --provider amazon-bedrock --model …
```
into a workspace's preferences.json was silently dropped — the agent always got the provider's hardcoded `BuildCommand`. Surfaced while trying to point `fierce-capybara` at AWS Bedrock.

## Fix
- `Manager` gains a `providersConfig` field (`*workspace.ProvidersConfig`) populated by `ApplyWorkspaceConfig` next to the existing `gatewayConfig`.
- `Manager.getAgentCommand` (the resolver every spawn / restart calls through) checks the workspace override first; if present, it appends the provider's session flags (`--session "<id>"` and `--continue`) on top of the user-supplied base command so resume still works identically.
- Extracted `appendSessionFlags` helper so the flag-append logic stays in one place — providers and overrides agree on shape.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/agent` passes
- [ ] After merge + redeploy: set `providers.pi.command = "pi --provider amazon-bedrock --model anthropic.claude-3-5-sonnet-20241022-v2:0"` in preferences.json, restart fierce-capybara; the tmux pane status line should switch from `(anthropic) claude-opus-4-8` to `(amazon-bedrock) anthropic.claude-3-5-sonnet…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace-level provider command overrides are now captured and applied during command resolution.
  * Session and resume flags are now properly handled when executing agent commands with workspace-level customizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->