### PR TITLE
feat(api): /api/agents?workspace= filter — workspace-as-property wave 1 (#3079)

### DIFF
--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -176,35 +176,35 @@ type avatarDTO struct {
 }
 
 type agentDTO struct { //nolint:govet // field order matches JSON/API contract
-	CreatedAt    time.Time      `json:"created_at"`
-	StartedAt    time.Time      `json:"started_at,omitempty"`
-	UpdatedAt    time.Time      `json:"updated_at"`
-	StoppedAt    *time.Time     `json:"stopped_at,omitempty"`
-	ArchivedAt   *time.Time     `json:"archived_at,omitempty"`
-	Stats        *agentStatsDTO `json:"stats,omitempty"`
-	Avatar       *avatarDTO     `json:"avatar,omitempty"`
-	Tool         string         `json:"tool,omitempty"`
-	Session      string         `json:"session,omitempty"`
-	State        string         `json:"state"`
-	Task         string         `json:"task,omitempty"`
-	Team         string         `json:"team,omitempty"`
-	Name         string         `json:"name"`
-	Runtime      string         `json:"runtime_backend,omitempty"`
-	Role         string         `json:"role"`
-	Template     string         `json:"template,omitempty"`
-	SessionID    string         `json:"session_id,omitempty"`
-	ParentID     string         `json:"parent_id,omitempty"`
-	ID           string         `json:"id,omitempty"`
-	RepoRoot     string         `json:"repo_root,omitempty"`
+	CreatedAt  time.Time      `json:"created_at"`
+	StartedAt  time.Time      `json:"started_at,omitempty"`
+	UpdatedAt  time.Time      `json:"updated_at"`
+	StoppedAt  *time.Time     `json:"stopped_at,omitempty"`
+	ArchivedAt *time.Time     `json:"archived_at,omitempty"`
+	Stats      *agentStatsDTO `json:"stats,omitempty"`
+	Avatar     *avatarDTO     `json:"avatar,omitempty"`
+	Tool       string         `json:"tool,omitempty"`
+	Session    string         `json:"session,omitempty"`
+	State      string         `json:"state"`
+	Task       string         `json:"task,omitempty"`
+	Team       string         `json:"team,omitempty"`
+	Name       string         `json:"name"`
+	Runtime    string         `json:"runtime_backend,omitempty"`
+	Role       string         `json:"role"`
+	Template   string         `json:"template,omitempty"`
+	SessionID  string         `json:"session_id,omitempty"`
+	ParentID   string         `json:"parent_id,omitempty"`
+	ID         string         `json:"id,omitempty"`
+	RepoRoot   string         `json:"repo_root,omitempty"`
 	// Workspace is the absolute path the agent is bound to. Surfaces
 	// the workspace-as-property model (#3079) so clients can filter
 	// /api/agents?workspace=<path> without going through the legacy
 	// /api/workspaces/<id>/agents route.
-	Workspace    string         `json:"workspace,omitempty"`
-	MCPServers   []string       `json:"mcp_servers,omitempty"`
-	Children     []string       `json:"children,omitempty"`
-	TotalCostUSD float64        `json:"total_cost_usd"`
-	TotalTokens  int64          `json:"total_tokens"`
+	Workspace    string   `json:"workspace,omitempty"`
+	MCPServers   []string `json:"mcp_servers,omitempty"`
+	Children     []string `json:"children,omitempty"`
+	TotalCostUSD float64  `json:"total_cost_usd"`
+	TotalTokens  int64    `json:"total_tokens"`
 }
 
 // agentStatsDTO holds resource metrics included when ?include=stats is set.

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -196,6 +196,11 @@ type agentDTO struct { //nolint:govet // field order matches JSON/API contract
 	ParentID     string         `json:"parent_id,omitempty"`
 	ID           string         `json:"id,omitempty"`
 	RepoRoot     string         `json:"repo_root,omitempty"`
+	// Workspace is the absolute path the agent is bound to. Surfaces
+	// the workspace-as-property model (#3079) so clients can filter
+	// /api/agents?workspace=<path> without going through the legacy
+	// /api/workspaces/<id>/agents route.
+	Workspace    string         `json:"workspace,omitempty"`
 	MCPServers   []string       `json:"mcp_servers,omitempty"`
 	Children     []string       `json:"children,omitempty"`
 	TotalCostUSD float64        `json:"total_cost_usd"`
@@ -234,6 +239,7 @@ func toDTO(a *agent.Agent) agentDTO {
 		StoppedAt:  a.StoppedAt,
 		ArchivedAt: a.ArchivedAt,
 		RepoRoot:   a.RepoRoot,
+		Workspace:  a.Workspace,
 	}
 }
 
@@ -265,6 +271,38 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 		if err != nil {
 			httpInternalError(w, "list agents", err)
 			return
+		}
+		// `?workspace=<absolute_path>` filter — first half of the
+		// workspace-as-property surface (#3079). When set, only agents
+		// bound to that workspace are returned. When unset, every
+		// workspace's agents are listed (the legacy default; the
+		// /api/workspaces/<id>/agents scoped route still works via the
+		// workspace_scope middleware for callers that haven't migrated
+		// yet).
+		if wsFilter := q.Get("workspace"); wsFilter != "" {
+			filtered := agents[:0]
+			for _, a := range agents {
+				if a.Workspace == wsFilter {
+					filtered = append(filtered, a)
+				}
+			}
+			agents = filtered
+		}
+		// `?workspace=<absolute_path>` filter — first half of the
+		// workspace-as-property surface (#3079). When set, only agents
+		// bound to that workspace are returned. When unset, every
+		// workspace's agents are listed (the legacy default; the
+		// /api/workspaces/<id>/agents scoped route still works via the
+		// workspace_scope middleware for callers that haven't migrated
+		// yet).
+		if wsFilter := q.Get("workspace"); wsFilter != "" {
+			filtered := agents[:0]
+			for _, a := range agents {
+				if a.Workspace == wsFilter {
+					filtered = append(filtered, a)
+				}
+			}
+			agents = filtered
 		}
 		dtos := make([]agentDTO, 0, len(agents))
 		for _, a := range agents {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -562,7 +562,14 @@ function splitChannel(channel: string): { gw: string; ch: string } {
 }
 
 export const api = {
-  listAgents: () => request<Agent[]>("/agents"),
+  /** List agents. Pass `workspace` to filter to a single workspace path —
+   *  this hits the flat /api/agents?workspace= surface (#3079) instead of
+   *  the legacy /api/workspaces/<id>/agents scoped route. Omit to list
+   *  every workspace's agents (cross-workspace view). */
+  listAgents: (workspace?: string) =>
+    request<Agent[]>(
+      workspace ? `/agents?workspace=${encodeURIComponent(workspace)}` : "/agents",
+    ),
   getAgent: (name: string) =>
     request<Agent>(`/agents/${encodeURIComponent(name)}`),
   getAgentPeek: (name: string, lines = 50) =>


### PR DESCRIPTION
Closes #3142
Part of #3079 / #3047 workspace-as-property refactor (wave 1).

## Summary
The `Agent` struct already carries the absolute workspace path it's bound to (`pkg/agent/agent.go:356`), but the server never surfaced it on the JSON DTO or accepted it as a filter. Clients had to route through the scoped `/api/workspaces/<id>/agents` middleware just to list agents for a single repo.

### Changes
- `agentDTO` gains a `workspace` field, populated from `a.Workspace` in `toDTO`. Backwards compatible — older clients ignore the new key.
- `GET /api/agents` accepts an optional `workspace=<absolute_path>` query param. When set, returns only agents bound to that exact path. When unset, behaviour is unchanged (every workspace's agents).
- `web/src/api/client.ts::listAgents()` gains an optional `workspace` argument so the typed client picks up the same filter. Default call signature unchanged.

The legacy `/api/workspaces/<id>/agents` scoped route still works via the workspace_scope middleware — this PR only adds the flat alternative so clients can migrate. Removing the scoped route is a later wave.

## Test plan
- [x] `go build ./...` passes
- [x] web `bun run build` passes
- [ ] After merge + redeploy: `curl :8080/api/agents?workspace=/Users/puneetrai/Projects/bc` returns only this workspace's agents; `workspace` field present on each DTO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents can now be filtered by workspace. View agents scoped to a specific workspace for better organization and management across multiple workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->