### PR TITLE
feat(api): accept ?workspace= query as scope hint

### DIFF
--- a/server/workspace_scope.go
+++ b/server/workspace_scope.go
@@ -173,10 +173,19 @@ func WorkspaceScope(next http.Handler, mgr *WorkspaceManager) http.Handler {
 		w.Header().Set("Sunset", deprecationSunset)
 
 		if mgr != nil {
-			// X-BC-Workspace header overrides the default active workspace,
-			// allowing clients to scope legacy /api/ routes to a specific
-			// workspace without using the /api/workspaces/{id}/... URL form.
-			if hdrID := r.Header.Get("X-BC-Workspace"); hdrID != "" {
+			// X-BC-Workspace header OR ?workspace= query param overrides
+			// the active workspace, allowing clients to scope flat /api/
+			// routes to a specific workspace without using the
+			// /api/workspaces/{id}/... URL form. The header is preferred
+			// (browsers send it automatically once the SPA detects a
+			// /w/<id> path), but the query param is convenient for
+			// curl-style ad-hoc calls and is the form we're standardising
+			// on as we delete the /api/workspaces/{id} surface (#3079).
+			hdrID := r.Header.Get("X-BC-Workspace")
+			if hdrID == "" {
+				hdrID = r.URL.Query().Get("workspace")
+			}
+			if hdrID != "" {
 				entry := mgr.Registry().FindByID(hdrID)
 				if entry == nil {
 					entry = mgr.Registry().Resolve(hdrID)


### PR DESCRIPTION
Part of #3079 / #3047. Closes the wave-2 portion of #3142.

## Summary
`WorkspaceScope` already honoured `X-BC-Workspace` as a per-request scope override on flat `/api/` routes. This extends it to also accept a `?workspace=` query param so curl-style ad-hoc calls (and clients that can't set headers easily) can pick a workspace without going through the deprecated `/api/workspaces/{id}/...` path family.

Header still wins when both are set — the browser SPA already sends the header automatically once it detects a `/w/<id>` path. Query param is the form we'll standardise on as we tear down the path-scoped surface in PR-C3.

Lookup goes through the same `Registry().FindByID → Resolve` fallback so id, hash, or repo path all work.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./server -run TestWorkspaceScope` passes
- [ ] After merge: `curl :8080/api/notifications?workspace=<id>` and `/api/agents?workspace=<id>` resolve the same scope; existing `X-BC-Workspace` header continues to work; bare requests still hit active workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying workspace using `?workspace=` query parameter as an alternative to the `X-BC-Workspace` header method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->