### PR TITLE
refactor(server): drop /api/workspaces/{id}/<rest> path-scope (#3079)

### DIFF
--- a/server/concurrent_workspace_test.go
+++ b/server/concurrent_workspace_test.go
@@ -154,7 +154,7 @@ func TestConcurrent_ScopedDispatch(t *testing.T) {
 			"system_prompt": "probe",
 		}
 		b, _ := json.Marshal(body)
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, h.ts.URL+"/api/workspaces/"+w.id+"/templates", bytes.NewReader(b))
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, h.ts.URL+"/api/templates?workspace="+w.id, bytes.NewReader(b))
 		if err != nil {
 			t.Fatalf("build seed req: %v", err)
 		}
@@ -177,7 +177,7 @@ func TestConcurrent_ScopedDispatch(t *testing.T) {
 		wantName := fmt.Sprintf("tpl-ws%d", idx)
 		go func() {
 			defer wg.Done()
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, h.ts.URL+"/api/workspaces/"+target.id+"/templates", nil)
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, h.ts.URL+"/api/templates?workspace="+target.id, nil)
 			if err != nil {
 				errCount.Add(1)
 				return

--- a/server/cors_scope_test.go
+++ b/server/cors_scope_test.go
@@ -1,24 +1,17 @@
-// cors_scope_test.go — regression test for commit 0e2bed15, where the
-// CORS middleware wrapper previously bypassed WorkspaceScope by wrapping
-// the mux directly instead of the already-wrapped handler.
-//
-// Symptom: with --cors-origin set (the default dev flow), any request
-// to /api/workspaces/{id}/<rest> hit the raw mux and 404'd because the
-// scope middleware never rewrote the URL.
+// cors_scope_test.go — regression test for the CORS + WorkspaceScope
+// middleware interaction (originally commit 0e2bed15). The CORS wrapper
+// must sit OUTSIDE the WorkspaceScope wrapper so that per-request
+// workspace resolution still fires while CORS headers land on the
+// response.
 //
 // This test boots the real middleware chain with CORS enabled, fires a
-// scoped request, and asserts BOTH concerns at once:
+// workspace-scoped request via the flat /api/<rest>?workspace=<id>
+// surface (#3079), and asserts BOTH concerns at once:
 //
 //  1. The CORS headers (Access-Control-Allow-Origin, Allow-Methods) land
 //     on the response — i.e. the CORS wrapper IS in the chain.
-//  2. The scoped URL is actually dispatched — i.e. the scope middleware
-//     is NOT bypassed. We prove this by reaching a registered handler
-//     (GET /api/workspaces/{id}/health returns 200 or a routed handler;
-//     here we assert we don't get the 404 that the bug produced).
-//
-// The original bug would manifest as 404 on the scoped path even when
-// the CORS headers were present. Keeping both checks in one test makes
-// the regression obvious.
+//  2. The request is actually dispatched (no 404) — i.e. the scope
+//     middleware is NOT bypassed.
 package server_test
 
 import (
@@ -109,7 +102,7 @@ func TestCORS_WorkspaceScope_Coexist(t *testing.T) {
 	// Fire a scoped GET. Under the buggy wiring this returned 404 from
 	// the mux because CORS wrapped the raw mux and the scope middleware
 	// never saw the request.
-	scopedURL := fmt.Sprintf("%s/api/workspaces/%s/agents", ts.URL, wsID)
+	scopedURL := fmt.Sprintf("%s/api/agents?workspace=%s", ts.URL, wsID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, scopedURL, nil)
 	if err != nil {
 		t.Fatalf("new req: %v", err)
@@ -205,7 +198,7 @@ func TestCORS_Preflight_Scoped(t *testing.T) {
 	defer ts.Close()
 
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodOptions,
-		fmt.Sprintf("%s/api/workspaces/%s/agents", ts.URL, wsID), nil)
+		fmt.Sprintf("%s/api/agents?workspace=%s", ts.URL, wsID), nil)
 	if err != nil {
 		t.Fatalf("new req: %v", err)
 	}

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -196,10 +196,8 @@ type agentDTO struct { //nolint:govet // field order matches JSON/API contract
 	ParentID   string         `json:"parent_id,omitempty"`
 	ID         string         `json:"id,omitempty"`
 	RepoRoot   string         `json:"repo_root,omitempty"`
-	// Workspace is the absolute path the agent is bound to. Surfaces
-	// the workspace-as-property model (#3079) so clients can filter
-	// /api/agents?workspace=<path> without going through the legacy
-	// /api/workspaces/<id>/agents route.
+	// Workspace is the absolute path the agent is bound to (#3079).
+	// Clients filter via /api/agents?workspace=<path>.
 	Workspace    string   `json:"workspace,omitempty"`
 	MCPServers   []string `json:"mcp_servers,omitempty"`
 	Children     []string `json:"children,omitempty"`
@@ -272,29 +270,10 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 			httpInternalError(w, "list agents", err)
 			return
 		}
-		// `?workspace=<absolute_path>` filter — first half of the
-		// workspace-as-property surface (#3079). When set, only agents
-		// bound to that workspace are returned. When unset, every
-		// workspace's agents are listed (the legacy default; the
-		// /api/workspaces/<id>/agents scoped route still works via the
-		// workspace_scope middleware for callers that haven't migrated
-		// yet).
-		if wsFilter := q.Get("workspace"); wsFilter != "" {
-			filtered := agents[:0]
-			for _, a := range agents {
-				if a.Workspace == wsFilter {
-					filtered = append(filtered, a)
-				}
-			}
-			agents = filtered
-		}
-		// `?workspace=<absolute_path>` filter — first half of the
-		// workspace-as-property surface (#3079). When set, only agents
-		// bound to that workspace are returned. When unset, every
-		// workspace's agents are listed (the legacy default; the
-		// /api/workspaces/<id>/agents scoped route still works via the
-		// workspace_scope middleware for callers that haven't migrated
-		// yet).
+		// `?workspace=<absolute_path>` filter narrows results to agents
+		// bound to a single workspace (#3079). The matching path is the
+		// agent's bound workspace path — typically the absolute fs path
+		// the registry uses as ID.
 		if wsFilter := q.Get("workspace"); wsFilter != "" {
 			filtered := agents[:0]
 			for _, a := range agents {

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -271,9 +271,10 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		// `?workspace=<absolute_path>` filter narrows results to agents
-		// bound to a single workspace (#3079). The matching path is the
-		// agent's bound workspace path — typically the absolute fs path
-		// the registry uses as ID.
+		// bound to a single workspace (#3079). The value must be the
+		// workspace's absolute filesystem path — NOT its registry ID
+		// hash — because we compare directly against a.Workspace which
+		// stores the absolute path the agent was spawned in.
 		if wsFilter := q.Get("workspace"); wsFilter != "" {
 			filtered := agents[:0]
 			for _, a := range agents {

--- a/server/handlers/code.go
+++ b/server/handlers/code.go
@@ -5,11 +5,10 @@
 //	GET /api/code/diff?worktree=[&path=]
 //
 // The routes are registered at /api/code/ and dispatched by ServeHTTP
-// based on the first path segment. They work under the WorkspaceScope
-// middleware (/api/workspaces/{id}/code/*) which rewrites the URL and
-// stashes the resolved workspace in the request context, and also
-// transparently for the legacy /api/code/* form using the active
-// workspace.
+// based on the first path segment. The WorkspaceScope middleware resolves
+// the target workspace from the X-BC-Workspace header or ?workspace=<id>
+// query param (falling back to the active workspace) and stashes the
+// resolved *WorkspaceServices in the request context.
 //
 // Every filesystem read is sandboxed via pkg/files.SafeJoin; .git/
 // and .bc/ subdirs are hidden by default; file reads cap at 2 MiB.

--- a/server/handlers/workspaces.go
+++ b/server/handlers/workspaces.go
@@ -113,9 +113,6 @@ func (h *WorkspacesHandler) item(w http.ResponseWriter, r *http.Request) {
 		}
 		h.activate(w, r, id)
 	default:
-		// Scoped resource routes (/api/workspaces/{id}/agents, etc.) are
-		// handled by the WorkspaceScope middleware upstream. If we reach
-		// here, the middleware did not match — surface a clear 404.
 		http.NotFound(w, r)
 	}
 }

--- a/server/multi_tenant_dispatch_test.go
+++ b/server/multi_tenant_dispatch_test.go
@@ -54,14 +54,17 @@ func (h *dispatchHarness) close() {
 	_ = h.mgr.Close() //nolint:errcheck
 }
 
-// api fires an HTTP call against the harness server. pathBuilder may be a
-// literal scoped URL like "/api/workspaces/<id>/templates".
+// api fires an HTTP call against the harness server. A scoped path like
+// "/api/workspaces/<id>/<rest>" is auto-rewritten to the flat
+// "/api/<rest>?workspace=<id>" form so legacy tests continue to exercise
+// per-workspace dispatch via the current API surface.
 func (h *dispatchHarness) api(t *testing.T, method, path string, body []byte) (int, []byte) {
 	t.Helper()
 	var r io.Reader
 	if body != nil {
 		r = bytes.NewReader(body)
 	}
+	path = rewriteWorkspaceScopedPath(path)
 	req, err := http.NewRequestWithContext(context.Background(), method, h.ts.URL+path, r)
 	if err != nil {
 		t.Fatalf("build request: %v", err)

--- a/server/multi_tenant_test.go
+++ b/server/multi_tenant_test.go
@@ -143,8 +143,11 @@ func newMultiTenantHarness(t *testing.T) *multiTenantHarness {
 }
 
 // apiGET performs GET against the harness and returns body + status.
+// Scoped paths of the form "/api/workspaces/<id>/<rest>" are auto-rewritten
+// to "/api/<rest>?workspace=<id>" (the current API surface, #3079).
 func (h *multiTenantHarness) apiGET(t *testing.T, path string) (int, []byte) {
 	t.Helper()
+	path = rewriteWorkspaceScopedPath(path)
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, h.ts.URL+path, nil)
 	if err != nil {
 		t.Fatalf("build request: %v", err)

--- a/server/test_helpers_scope_rewrite_test.go
+++ b/server/test_helpers_scope_rewrite_test.go
@@ -1,0 +1,40 @@
+package server_test
+
+import "strings"
+
+// rewriteWorkspaceScopedPath translates a legacy path of the form
+// "/api/workspaces/<id>/<rest>[?query]" into the flat
+// "/api/<rest>?workspace=<id>[&query]" form used by the current API
+// surface (#3079). Other paths (including the registry self-routes
+// "/api/workspaces", "/api/workspaces/<id>", "/api/workspaces/<id>/activate",
+// and the discovery sub-tree) are returned unchanged.
+//
+// It exists so multi-tenant test harnesses can keep their tabular
+// "/api/workspaces/<id>/<rest>" expressions while still exercising the
+// query-param surface.
+func rewriteWorkspaceScopedPath(path string) string {
+	const prefix = "/api/workspaces/"
+	if !strings.HasPrefix(path, prefix) {
+		return path
+	}
+	rest := strings.TrimPrefix(path, prefix)
+	// Split path from query first so the scope id and resource isolate
+	// cleanly.
+	pathPart, queryPart, hasQuery := strings.Cut(rest, "?")
+	id, tail, hasTail := strings.Cut(pathPart, "/")
+	if id == "" || !hasTail || tail == "" {
+		return path
+	}
+	// Self-routes / reserved discovery prefixes — leave alone.
+	if id == "discover" || id == "clone" {
+		return path
+	}
+	if tail == "activate" {
+		return path
+	}
+	q := "workspace=" + id
+	if hasQuery && queryPart != "" {
+		q += "&" + queryPart
+	}
+	return "/api/" + tail + "?" + q
+}

--- a/server/workspace_scope.go
+++ b/server/workspace_scope.go
@@ -1,35 +1,26 @@
-// workspace_scope.go implements URL-level workspace scoping middleware.
+// workspace_scope.go implements per-request workspace scoping for flat
+// /api/* routes (#3079).
 //
 // Overview
 // ========
 //
-// The bcd server historically exposes every resource at /api/<resource>/...
-// bound to a single workspace. With multi-workspace support the proposal
-// introduces two URL schemes:
+// Every workspace-scoped resource is served at /api/<resource>/... and the
+// scope is selected per request via one of:
 //
-//	/api/workspaces/{id}/<rest>     — scoped (canonical, post-migration)
-//	/api/<rest>                     — legacy (active workspace shim)
+//   - X-BC-Workspace: <id>     header (preferred — SPA sets it automatically)
+//   - ?workspace=<id>          query param (curl-friendly fallback)
+//   - none → the registry's active workspace
 //
-// The middleware in this file performs two jobs:
+// The middleware resolves the requested workspace via the WorkspaceManager
+// (lazy-loading if necessary), then annotates the request context with the
+// resolved WorkspaceServices so handlers can pull the right per-workspace
+// view via WorkspaceServicesFromContext.
 //
-//  1. Scoped rewrite: if the path matches /api/workspaces/{id}/<rest> AND
-//     {rest} is NOT empty AND NOT a registry-management route (detail,
-//     activate, etc.), rewrite the request's URL.Path to /api/<rest> and
-//     annotate the request context with the resolved WorkspaceServices.
-//     Existing handlers continue to use their closure-captured services
-//     (the active workspace's). If the {id} is the active workspace, this
-//     is a no-op rewrite and everything works. If {id} is a different
-//     registered workspace, we return 501 Not Implemented — full per-
-//     workspace handler dispatch is a future phase; switch via POST
-//     /api/workspaces/{id}/activate.
-//
-//  2. Legacy headers: if the path starts with /api/ but NOT /api/workspaces,
-//     the response is annotated with Deprecation: true and a Sunset date so
-//     clients can warn when they are still using the old shape. The handler
-//     chain is unchanged (handlers serve the active workspace as before).
-//
-// This split keeps the heavy refactor — per-workspace handler trees — for a
-// later phase while delivering the URL surface specified in proposal §4.5.
+// The historical /api/workspaces/{id}/<rest> path-scoped rewrite was
+// deleted alongside this rewrite — clients must use the header or query
+// param. Registry self-routes (/api/workspaces, /api/workspaces/{id},
+// /api/workspaces/{id}/activate, /api/workspaces/discover/*, /api/workspaces/clone)
+// still work and are served directly by their own handlers.
 package server
 
 import (
@@ -50,46 +41,24 @@ const (
 	ctxKeyWorkspaceServices               // *WorkspaceServices, loaded
 )
 
-// deprecationSunset is the date at which legacy /api/<rest> routes will stop
-// working. Matches proposal §9.3.
+// deprecationSunset is the date at which legacy compatibility surfaces
+// (legacy_scope, mcp_compat) will stop responding. Kept here as the
+// shared definition; matches proposal §9.3.
 const deprecationSunset = "Sun, 01 Nov 2026 00:00:00 GMT"
 
-// These sub-paths are registry management, not per-workspace dispatch — the
-// scoped rewrite must NOT strip the /api/workspaces/{id} prefix.
-var workspaceSelfRoutes = map[string]struct{}{
-	"":         {},
-	"activate": {},
-}
-
-// These top-level sub-paths are NOT workspace IDs — they live at
-// /api/workspaces/<name>/* and are served directly by discovery/registry
-// handlers. The scope middleware must pass them through unchanged.
-var workspacesReservedPrefixes = map[string]struct{}{
-	"discover": {},
-	"clone":    {},
-}
-
-// WorkspaceScope returns a middleware that:
-//   - rewrites /api/workspaces/{id}/<rest> → /api/<rest> when <rest> is a
-//     scoped resource (not a self-route), after resolving {id} to a
-//     loaded *WorkspaceServices.
-//   - annotates legacy /api/<rest> responses with Deprecation / Sunset.
+// WorkspaceScope returns a middleware that resolves a per-request
+// workspace scope for flat /api/* routes, prefers an explicit
+// X-BC-Workspace header, falls back to the ?workspace=<id> query
+// param, and finally to the registry's active workspace.
 //
-// The middleware is a no-op for any path that is not /api/... .
+// The middleware is a no-op for any path that is not /api/... or for
+// the /api/workspaces self-routes (collection, detail, activate,
+// discover/*, clone), which are owned by the WorkspacesHandler and
+// don't need a per-request scope.
 //
-// mgr may be nil — in which case scoped rewrites are disabled (registry
-// CRUD still works since it's served by handlers registered directly on the
-// mux). If mgr is non-nil but the {id} does not resolve, the request gets a
-// 404.
-//
-// Matching rules for scoped routes (see §4.5):
-//
-//	GET    /api/workspaces/{id}          -> registry detail (self route)
-//	POST   /api/workspaces/{id}/activate -> registry action (self route)
-//	* /api/workspaces/{id}/agents        -> scoped (rewrite)
-//	* /api/workspaces/{id}/channels      -> scoped (rewrite)
-//	* /api/workspaces/{id}/events        -> scoped (rewrite)
-//	etc.
+// mgr may be nil — in which case the middleware is a pure pass-through.
+// If mgr is non-nil but the requested id does not resolve, the request
+// gets a 404.
 func WorkspaceScope(next http.Handler, mgr *WorkspaceManager) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -100,46 +69,36 @@ func WorkspaceScope(next http.Handler, mgr *WorkspaceManager) http.Handler {
 			return
 		}
 
-		// Scoped: /api/workspaces/{id}/...
-		if strings.HasPrefix(path, "/api/workspaces/") {
-			rest := strings.TrimPrefix(path, "/api/workspaces/")
-			id, tail, _ := strings.Cut(rest, "/")
-			if id == "" {
-				next.ServeHTTP(w, r)
-				return
-			}
-			// Reserved top-level names (discover, clone, etc.) are NOT
-			// workspace IDs — forward without touching the URL.
-			if _, ok := workspacesReservedPrefixes[id]; ok {
-				next.ServeHTTP(w, r)
-				return
-			}
-			// Registry self-routes pass straight through to the
-			// WorkspacesHandler registered on the mux.
-			if _, ok := workspaceSelfRoutes[tail]; ok {
-				next.ServeHTTP(w, r)
-				return
-			}
+		// Registry self-routes — owned by WorkspacesHandler, no
+		// per-request workspace scope to inject.
+		if strings.HasPrefix(path, "/api/workspaces") {
+			next.ServeHTTP(w, r)
+			return
+		}
 
-			// Scoped dispatch — resolve the workspace.
-			if mgr == nil {
-				http.Error(w, `{"error":"workspace manager not configured"}`, http.StatusNotImplemented)
-				return
-			}
+		if mgr == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
 
-			// Must be a registered workspace.
-			entry := mgr.Registry().FindByID(id)
+		// Explicit scope hint — header preferred, query param fallback.
+		// The SPA sends X-BC-Workspace automatically once it detects
+		// /w/<id> in the URL; the query form is the curl-friendly
+		// equivalent and the surface we're standardizing on for
+		// external callers (#3079).
+		hdrID := r.Header.Get("X-BC-Workspace")
+		if hdrID == "" {
+			hdrID = r.URL.Query().Get("workspace")
+		}
+		if hdrID != "" {
+			entry := mgr.Registry().FindByID(hdrID)
 			if entry == nil {
-				entry = mgr.Registry().Resolve(id)
+				entry = mgr.Registry().Resolve(hdrID)
 			}
 			if entry == nil {
 				http.Error(w, `{"error":"workspace not found"}`, http.StatusNotFound)
 				return
 			}
-
-			// Phase M5: any registered workspace dispatches via the
-			// manager. First access lazy-loads the services; subsequent
-			// requests hit the cache.
 			svc := mgr.Get(entry.ID)
 			if svc == nil {
 				var err error
@@ -152,78 +111,25 @@ func WorkspaceScope(next http.Handler, mgr *WorkspaceManager) http.Handler {
 			}
 			ctx := context.WithValue(r.Context(), ctxKeyWorkspaceID, entry.ID)
 			ctx = context.WithValue(ctx, ctxKeyWorkspaceServices, svc)
-
-			r2 := r.Clone(ctx)
-			r2.URL.Path = "/api/" + tail
-			if r.URL.RawPath != "" {
-				// Preserve escaping if the original had one.
-				rawRest := strings.TrimPrefix(r.URL.RawPath, "/api/workspaces/")
-				_, rawTail, _ := strings.Cut(rawRest, "/")
-				r2.URL.RawPath = "/api/" + rawTail
-			}
-			next.ServeHTTP(w, r2)
+			next.ServeHTTP(w, r.WithContext(ctx))
 			return
 		}
 
-		// Legacy: /api/<rest> (not /api/workspaces/...)
-		// Mark as deprecated and stash the active workspace's services in
-		// context so handlers can transition to context-based resolution
-		// without needing scoped URLs. Phase M3.
-		w.Header().Set("Deprecation", "true")
-		w.Header().Set("Sunset", deprecationSunset)
-
-		if mgr != nil {
-			// X-BC-Workspace header OR ?workspace= query param overrides
-			// the active workspace, allowing clients to scope flat /api/
-			// routes to a specific workspace without using the
-			// /api/workspaces/{id}/... URL form. The header is preferred
-			// (browsers send it automatically once the SPA detects a
-			// /w/<id> path), but the query param is convenient for
-			// curl-style ad-hoc calls and is the form we're standardising
-			// on as we delete the /api/workspaces/{id} surface (#3079).
-			hdrID := r.Header.Get("X-BC-Workspace")
-			if hdrID == "" {
-				hdrID = r.URL.Query().Get("workspace")
+		// Fall back to the registry's active workspace.
+		if active := mgr.Active(); active != nil {
+			activeID := ""
+			if e := mgr.Registry().GetActive(); e != nil {
+				activeID = e.ID
+				if activeID == "" {
+					activeID = workspace.ComputeWorkspaceID(e.Path)
+				}
 			}
-			if hdrID != "" {
-				entry := mgr.Registry().FindByID(hdrID)
-				if entry == nil {
-					entry = mgr.Registry().Resolve(hdrID)
-				}
-				if entry == nil {
-					http.Error(w, `{"error":"workspace not found"}`, http.StatusNotFound)
-					return
-				}
-				svc := mgr.Get(entry.ID)
-				if svc == nil {
-					var err error
-					svc, err = mgr.Load(r.Context(), entry.ID)
-					if err != nil {
-						log.Warn("workspace scope: lazy load failed", "id", entry.ID, "error", err)
-						http.Error(w, `{"error":"failed to load workspace"}`, http.StatusInternalServerError)
-						return
-					}
-				}
-				ctx := context.WithValue(r.Context(), ctxKeyWorkspaceID, entry.ID)
-				ctx = context.WithValue(ctx, ctxKeyWorkspaceServices, svc)
-				next.ServeHTTP(w, r.WithContext(ctx))
-				return
-			}
-
-			if active := mgr.Active(); active != nil {
-				activeID := ""
-				if e := mgr.Registry().GetActive(); e != nil {
-					activeID = e.ID
-					if activeID == "" {
-						activeID = workspace.ComputeWorkspaceID(e.Path)
-					}
-				}
-				ctx := context.WithValue(r.Context(), ctxKeyWorkspaceID, activeID)
-				ctx = context.WithValue(ctx, ctxKeyWorkspaceServices, active)
-				next.ServeHTTP(w, r.WithContext(ctx))
-				return
-			}
+			ctx := context.WithValue(r.Context(), ctxKeyWorkspaceID, activeID)
+			ctx = context.WithValue(ctx, ctxKeyWorkspaceServices, active)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
 		}
+
 		next.ServeHTTP(w, r)
 	})
 }

--- a/server/workspace_scope.go
+++ b/server/workspace_scope.go
@@ -99,17 +99,24 @@ func WorkspaceScope(next http.Handler, mgr *WorkspaceManager) http.Handler {
 				http.Error(w, `{"error":"workspace not found"}`, http.StatusNotFound)
 				return
 			}
-			svc := mgr.Get(entry.ID)
+			// Legacy registry entries can lack a persisted ID; mirror the
+			// active-fallback path and derive one from the workspace path
+			// so mgr.Get/Load receive a stable key.
+			resolvedID := entry.ID
+			if resolvedID == "" {
+				resolvedID = workspace.ComputeWorkspaceID(entry.Path)
+			}
+			svc := mgr.Get(resolvedID)
 			if svc == nil {
 				var err error
-				svc, err = mgr.Load(r.Context(), entry.ID)
+				svc, err = mgr.Load(r.Context(), resolvedID)
 				if err != nil {
-					log.Warn("workspace scope: lazy load failed", "id", entry.ID, "error", err)
+					log.Warn("workspace scope: lazy load failed", "id", resolvedID, "error", err)
 					http.Error(w, `{"error":"failed to load workspace"}`, http.StatusInternalServerError)
 					return
 				}
 			}
-			ctx := context.WithValue(r.Context(), ctxKeyWorkspaceID, entry.ID)
+			ctx := context.WithValue(r.Context(), ctxKeyWorkspaceID, resolvedID)
 			ctx = context.WithValue(ctx, ctxKeyWorkspaceServices, svc)
 			next.ServeHTTP(w, r.WithContext(ctx))
 			return

--- a/server/workspace_scope_test.go
+++ b/server/workspace_scope_test.go
@@ -48,33 +48,13 @@ func newScopeTestManager(t *testing.T) (*WorkspaceManager, string, string) {
 	return mgr, id, wsDir
 }
 
-// TestWorkspaceScopeRewriteActive verifies that a scoped URL for the active
-// workspace is rewritten to the legacy /api/<rest> form.
-func TestWorkspaceScopeRewriteActive(t *testing.T) {
-	mgr, id, _ := newScopeTestManager(t)
-
-	inner := &dummyHandler{}
-	h := WorkspaceScope(inner, mgr)
-
-	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+id+"/agents", nil)
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-
-	if inner.seen != "/api/agents" {
-		t.Errorf("URL not rewritten: got %q want %q", inner.seen, "/api/agents")
-	}
-	if dep := rec.Header().Get("Deprecation"); dep != "" {
-		t.Errorf("scoped route should not carry Deprecation header, got %q", dep)
-	}
-}
-
-// TestWorkspaceScopeNonActiveDispatches verifies that phase M5 lifts the
-// 501-for-non-active restriction: a scoped request for any registered
-// workspace lazy-loads its services and rewrites to /api/<rest>.
-func TestWorkspaceScopeNonActiveDispatches(t *testing.T) {
+// TestWorkspaceScopeQueryParam verifies the ?workspace=<id> query param
+// resolves a registered (non-active) workspace and stashes its services
+// in the request context.
+func TestWorkspaceScopeQueryParam(t *testing.T) {
 	mgr, _, _ := newScopeTestManager(t)
 
-	// Register a second workspace (not active).
+	// Register a second (non-active) workspace.
 	tmpDir := t.TempDir()
 	wsDir2 := filepath.Join(tmpDir, "ws2")
 	if err := os.MkdirAll(wsDir2, 0750); err != nil {
@@ -87,29 +67,65 @@ func TestWorkspaceScopeNonActiveDispatches(t *testing.T) {
 	_ = mgr.Registry().RegisterWithAlias(wsDir2, "ws2", "")
 	id2 := workspace.ComputeWorkspaceID(wsDir2)
 
-	inner := &dummyHandler{}
+	var gotID string
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotID = WorkspaceIDFromContext(r.Context())
+	})
 	h := WorkspaceScope(inner, mgr)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/"+id2+"/agents", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/agents?workspace="+id2, nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200 (dispatch to non-active should succeed)", rec.Code)
+		t.Errorf("status = %d, want 200", rec.Code)
 	}
-	if inner.seen != "/api/agents" {
-		t.Errorf("rewritten path = %q, want /api/agents", inner.seen)
+	if gotID != id2 {
+		t.Errorf("ctx workspace id = %q, want %q", gotID, id2)
 	}
 }
 
-// TestWorkspaceScopeUnknownWorkspace returns 404.
+// TestWorkspaceScopeHeader verifies X-BC-Workspace overrides the active
+// workspace scope.
+func TestWorkspaceScopeHeader(t *testing.T) {
+	mgr, _, _ := newScopeTestManager(t)
+
+	tmpDir := t.TempDir()
+	wsDir2 := filepath.Join(tmpDir, "ws2")
+	if err := os.MkdirAll(wsDir2, 0750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	gitInitDir(t, wsDir2)
+	if _, err := workspace.Init(wsDir2); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	_ = mgr.Registry().RegisterWithAlias(wsDir2, "ws2", "")
+	id2 := workspace.ComputeWorkspaceID(wsDir2)
+
+	var gotID string
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotID = WorkspaceIDFromContext(r.Context())
+	})
+	h := WorkspaceScope(inner, mgr)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
+	req.Header.Set("X-BC-Workspace", id2)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if gotID != id2 {
+		t.Errorf("ctx workspace id = %q, want %q", gotID, id2)
+	}
+}
+
+// TestWorkspaceScopeUnknownWorkspace returns 404 for an unregistered id.
 func TestWorkspaceScopeUnknownWorkspace(t *testing.T) {
 	mgr, _, _ := newScopeTestManager(t)
 
 	inner := &dummyHandler{}
 	h := WorkspaceScope(inner, mgr)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/workspaces/deadbeef1234/agents", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/agents?workspace=deadbeef1234", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
@@ -118,15 +134,17 @@ func TestWorkspaceScopeUnknownWorkspace(t *testing.T) {
 	}
 }
 
-// TestWorkspaceScopeSelfRoutePassThrough ensures /api/workspaces/{id} and
-// /api/workspaces/{id}/activate go straight through to the mux (registry
-// self-routes) without URL rewrite.
+// TestWorkspaceScopeSelfRoutePassThrough ensures /api/workspaces/... self
+// routes go straight through to the mux (registry self-routes) without
+// any per-request scope injection.
 func TestWorkspaceScopeSelfRoutePassThrough(t *testing.T) {
 	mgr, id, _ := newScopeTestManager(t)
 
 	for _, path := range []string{
+		"/api/workspaces",
 		"/api/workspaces/" + id,
 		"/api/workspaces/" + id + "/activate",
+		"/api/workspaces/discover/local",
 	} {
 		inner := &dummyHandler{}
 		h := WorkspaceScope(inner, mgr)
@@ -139,26 +157,23 @@ func TestWorkspaceScopeSelfRoutePassThrough(t *testing.T) {
 	}
 }
 
-// TestWorkspaceScopeLegacyDeprecation ensures legacy /api/ routes get
-// Deprecation + Sunset headers.
-func TestWorkspaceScopeLegacyDeprecation(t *testing.T) {
-	mgr, _, _ := newScopeTestManager(t)
+// TestWorkspaceScopeDefaultsToActive ensures flat /api/ paths with no
+// explicit hint resolve to the active workspace.
+func TestWorkspaceScopeDefaultsToActive(t *testing.T) {
+	mgr, activeID, _ := newScopeTestManager(t)
 
-	inner := &dummyHandler{}
+	var gotID string
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		gotID = WorkspaceIDFromContext(r.Context())
+	})
 	h := WorkspaceScope(inner, mgr)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/agents", nil)
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
 
-	if rec.Header().Get("Deprecation") != "true" {
-		t.Errorf("Deprecation header missing")
-	}
-	if rec.Header().Get("Sunset") == "" {
-		t.Errorf("Sunset header missing")
-	}
-	if inner.seen != "/api/agents" {
-		t.Errorf("legacy path rewritten: %q", inner.seen)
+	if gotID != activeID {
+		t.Errorf("ctx workspace id = %q, want active %q", gotID, activeID)
 	}
 }
 
@@ -175,8 +190,5 @@ func TestWorkspaceScopeNonAPIPassThrough(t *testing.T) {
 
 	if inner.seen != "/" {
 		t.Errorf("non-API path affected: %q", inner.seen)
-	}
-	if rec.Header().Get("Deprecation") != "" {
-		t.Errorf("non-API should not get Deprecation")
 	}
 }

--- a/server/workspace_scope_test.go
+++ b/server/workspace_scope_test.go
@@ -145,6 +145,7 @@ func TestWorkspaceScopeSelfRoutePassThrough(t *testing.T) {
 		"/api/workspaces/" + id,
 		"/api/workspaces/" + id + "/activate",
 		"/api/workspaces/discover/local",
+		"/api/workspaces/clone",
 	} {
 		inner := &dummyHandler{}
 		h := WorkspaceScope(inner, mgr)

--- a/web/e2e/tests/agent-detail-tabs.spec.ts
+++ b/web/e2e/tests/agent-detail-tabs.spec.ts
@@ -22,7 +22,7 @@ async function firstWorkspaceAndAgent(
   if (!list.length) return null;
   const ws = list[0];
 
-  const aResp = await request.get(`/api/workspaces/${ws.id}/agents`);
+  const aResp = await request.get(`/api/agents?workspace=${encodeURIComponent(ws.id)}`);
   if (!aResp.ok()) return null;
   const agents = (await aResp.json()) as Agent[];
   if (!Array.isArray(agents) || !agents.length) return null;

--- a/web/e2e/tests/agent-detail-tabs.spec.ts
+++ b/web/e2e/tests/agent-detail-tabs.spec.ts
@@ -9,7 +9,7 @@
 
 import { test, expect } from "@playwright/test";
 
-type Ws = { id: string; name: string };
+type Ws = { id: string; name: string; path: string };
 type Agent = { name: string };
 
 async function firstWorkspaceAndAgent(
@@ -22,7 +22,9 @@ async function firstWorkspaceAndAgent(
   if (!list.length) return null;
   const ws = list[0];
 
-  const aResp = await request.get(`/api/agents?workspace=${encodeURIComponent(ws.id)}`);
+  // /api/agents filter compares against the agent's bound Workspace
+  // (absolute filesystem path), so pass ws.path — not the registry id hash.
+  const aResp = await request.get(`/api/agents?workspace=${encodeURIComponent(ws.path)}`);
   if (!aResp.ok()) return null;
   const agents = (await aResp.json()) as Agent[];
   if (!Array.isArray(agents) || !agents.length) return null;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -562,9 +562,8 @@ function splitChannel(channel: string): { gw: string; ch: string } {
 }
 
 export const api = {
-  /** List agents. Pass `workspace` to filter to a single workspace path —
-   *  this hits the flat /api/agents?workspace= surface (#3079) instead of
-   *  the legacy /api/workspaces/<id>/agents scoped route. Omit to list
+  /** List agents. Pass `workspace` to filter to a single workspace path
+   *  via the flat /api/agents?workspace= surface (#3079). Omit to list
    *  every workspace's agents (cross-workspace view). */
   listAgents: (workspace?: string) =>
     request<Agent[]>(

--- a/web/src/views/Code.tsx
+++ b/web/src/views/Code.tsx
@@ -11,9 +11,9 @@
  *           (default when a worktree other than main is selected)
  *
  * Backend endpoints used:
- *   GET /api/workspaces/{ws}/code/tree?path=&worktree=&show_hidden=
- *   GET /api/workspaces/{ws}/code/file?path=&worktree=
- *   GET /api/workspaces/{ws}/code/diff?worktree=&path=
+ *   GET /api/code/tree?path=&worktree=&show_hidden=&workspace=
+ *   GET /api/code/file?path=&worktree=&workspace=
+ *   GET /api/code/diff?worktree=&path=&workspace=
  */
 
 import Editor, { DiffEditor } from "@monaco-editor/react";
@@ -88,7 +88,7 @@ async function fetchTree(
   if (showHidden) qs.set("show_hidden", "1");
   try {
     const r = await fetch(
-      `/api/workspaces/${encodeURIComponent(wsId)}/code/tree?${qs.toString()}`,
+      `/api/code/tree?${qs.toString()}&workspace=${encodeURIComponent(wsId)}`,
     );
     if (!r.ok) return [];
     const data = (await r.json()) as unknown;
@@ -115,7 +115,7 @@ async function fetchFile(
   const qs = new URLSearchParams({ path, worktree });
   try {
     const r = await fetch(
-      `/api/workspaces/${encodeURIComponent(wsId)}/code/file?${qs.toString()}`,
+      `/api/code/file?${qs.toString()}&workspace=${encodeURIComponent(wsId)}`,
     );
     if (r.status === 404) {
       return { content: "", binary: false, ok: true, notFound: true };
@@ -134,12 +134,12 @@ async function fetchFile(
 
 function fileDownloadUrl(wsId: string, path: string, worktree: string): string {
   const qs = new URLSearchParams({ path, worktree });
-  return `/api/workspaces/${encodeURIComponent(wsId)}/code/file?${qs.toString()}`;
+  return `/api/code/file?${qs.toString()}&workspace=${encodeURIComponent(wsId)}`;
 }
 
 function patchDownloadUrl(wsId: string, path: string, worktree: string): string {
   const qs = new URLSearchParams({ worktree, path });
-  return `/api/workspaces/${encodeURIComponent(wsId)}/code/diff?${qs.toString()}`;
+  return `/api/code/diff?${qs.toString()}&workspace=${encodeURIComponent(wsId)}`;
 }
 
 async function fetchCodeServerStatus(): Promise<{ running: boolean; endpoint: string }> {


### PR DESCRIPTION
## Summary

Final wave of the workspace-as-property refactor (#3079, follows #3148, #3149).

- `WorkspaceScope` now does **only** per-request scope injection — header / query param / active fallback. The whole `/api/workspaces/{id}/<rest>` path-rewrite branch is deleted (and so are its dead tests).
- Web client moved its last scoped caller: `Code.tsx` now uses `/api/code/*?workspace=<id>`.
- Server multi-tenant test suites keep their scoped expressions via a tiny `rewriteWorkspaceScopedPath` helper so we don't fight thirty call sites; the helper resolves to the current flat surface.

Registry self-routes (`/api/workspaces`, `/api/workspaces/{id}`, `/api/workspaces/{id}/activate`, `/api/workspaces/discover/*`, `/api/workspaces/clone`) are unchanged.

Closes #3142 (wave 3). Lands the server piece of #3079.

## Test plan
- [x] `go test ./server/...` — green
- [x] `bun run test` (web) — 110/110
- [x] `bun run build` (web) — clean
- [x] `golangci-lint run ./server/...` — 0 issues
- [ ] CI green
- [ ] Smoke flat /api/code/* via curl after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Workspace-scoped API access now consistently uses flat endpoints with `workspace` query parameters (e.g., `/api/agents?workspace=<id>`), with workspace selection supported via the `X-BC-Workspace` header.
  * Code browsing and downloads were updated to use the new `/api/code/*` routes with `workspace` query parameters.
* **Tests**
  * Updated scope-routing, CORS, and multi-tenant dispatch tests to target the new endpoint shapes.
  * Revised workspace scope tests to validate header/query behavior and default-to-active workspace handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->