### PR TITLE
feat(live): hydrate cross-agent activity on Live mount (#3138)

### DIFF
--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -163,6 +163,7 @@ func (h *AgentHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/agents/stop-all", h.stopAll)
 	mux.HandleFunc("/api/agents/sync", h.syncSessions)
 	mux.HandleFunc("/api/agents/health", h.health)
+	mux.HandleFunc("/api/agents/activity", h.activity)
 	// Bulk operations — must be registered before the catch-all below.
 	h.registerBulkRoutes(mux)
 	mux.HandleFunc("/api/agents", h.list)

--- a/server/handlers/agents_activity.go
+++ b/server/handlers/agents_activity.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/rpuneet/mycel/pkg/events"
 )
 
 // activityItem is one row in the agent activity timeline response.
@@ -12,6 +14,37 @@ type activityItem struct { //nolint:govet // field order matches JSON contract
 	Timestamp string         `json:"timestamp"`
 	Event     string         `json:"event"`
 	Message   string         `json:"message,omitempty"`
+	Agent     string         `json:"agent,omitempty"`
+}
+
+// toActivityItem normalizes an events.Event into the timeline DTO consumed by
+// both the per-agent activity timeline and the cross-agent Live hydration
+// endpoint. The mapping rules (tool_name + tool_input.command > message, plus
+// hook./agent. prefix stripping) live here so both surfaces stay in sync.
+func toActivityItem(e events.Event, includeAgent bool) activityItem {
+	msg := ""
+	if e.Data != nil {
+		if toolName, ok := e.Data["tool_name"].(string); ok && toolName != "" {
+			msg = toolName
+			if toolInput, ok2 := e.Data["tool_input"].(map[string]any); ok2 {
+				if cmd, ok3 := toolInput["command"].(string); ok3 && cmd != "" {
+					msg += ": " + cmd
+				}
+			}
+		} else if m, ok := e.Data["message"].(string); ok && m != "" {
+			msg = m
+		}
+	}
+	out := activityItem{
+		Timestamp: e.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z"),
+		Event:     strings.TrimPrefix(strings.TrimPrefix(string(e.Type), "hook."), "agent."),
+		Message:   msg,
+		Data:      e.Data,
+	}
+	if includeAgent {
+		out.Agent = e.Agent
+	}
+	return out
 }
 
 // agentActivity returns the most recent activity events for an agent, built
@@ -44,28 +77,45 @@ func (h *AgentHandler) agentActivity(w http.ResponseWriter, r *http.Request, nam
 	}
 	out := make([]activityItem, 0, len(evts))
 	for i := len(evts) - 1; i >= 0 && len(out) < maxItems; i-- {
-		e := evts[i]
-		// Derive a human-readable message from structured data fields.
-		// Prefer: tool_name + tool_input.command > message field > omit.
-		msg := ""
-		if e.Data != nil {
-			if toolName, ok := e.Data["tool_name"].(string); ok && toolName != "" {
-				msg = toolName
-				if toolInput, ok2 := e.Data["tool_input"].(map[string]any); ok2 {
-					if cmd, ok3 := toolInput["command"].(string); ok3 && cmd != "" {
-						msg += ": " + cmd
-					}
-				}
-			} else if m, ok := e.Data["message"].(string); ok && m != "" {
-				msg = m
-			}
+		out = append(out, toActivityItem(evts[i], false))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// activity returns the most recent activity events across ALL agents,
+// used by the Live page to hydrate its multi-agent stream on mount so
+// the page is never empty on reload (#3138).
+// GET /api/agents/activity?limit=N (default 200, max 2000)
+func (h *AgentHandler) activity(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.events == nil {
+		writeJSON(w, http.StatusOK, []activityItem{})
+		return
+	}
+
+	maxItems := 200
+	if limitStr := r.URL.Query().Get("limit"); limitStr != "" {
+		if n, err := strconv.Atoi(limitStr); err == nil && n > 0 && n <= 2000 {
+			maxItems = n
 		}
-		out = append(out, activityItem{
-			Timestamp: e.Timestamp.UTC().Format("2006-01-02T15:04:05.000Z"),
-			Event:     strings.TrimPrefix(strings.TrimPrefix(string(e.Type), "hook."), "agent."),
-			Message:   msg,
-			Data:      e.Data,
-		})
+	}
+
+	evts, err := h.events.ReadLast(maxItems)
+	if err != nil {
+		httpInternalError(w, "read activity", err)
+		return
+	}
+
+	// Newest-first to match per-agent activity ordering.
+	out := make([]activityItem, 0, len(evts))
+	for i := len(evts) - 1; i >= 0; i-- {
+		e := evts[i]
+		if e.Agent == "" {
+			continue // skip non-agent events
+		}
+		out = append(out, toActivityItem(e, true))
 	}
 	writeJSON(w, http.StatusOK, out)
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -43,6 +43,10 @@ export interface AgentActivityItem {
   event: string;
   message?: string;
   data?: Record<string, unknown>;
+  // Present on the cross-agent /api/agents/activity response (#3138).
+  // Omitted on the per-agent /api/agents/{name}/activity response since
+  // the agent is implied by the URL.
+  agent?: string;
 }
 
 export interface Agent {
@@ -648,6 +652,11 @@ export const api = {
   // Agent activity timeline — newest first, capped at `limit` entries (default 50, max 1000).
   getAgentActivity: (name: string, limit = 50) =>
     request<AgentActivityItem[]>(`/agents/${encodeURIComponent(name)}/activity?limit=${limit}`),
+  // Cross-agent recent activity for Live page hydration (#3138). Newest
+  // first; each item carries an `agent` field so callers can route to
+  // the right card.
+  getActivity: (limit = 200) =>
+    request<AgentActivityItem[]>(`/agents/activity?limit=${limit}`),
 
   getAgentConfig: (name: string) =>
     request<AgentConfig>(`/agents/${encodeURIComponent(name)}/config`),

--- a/web/src/hooks/useAgentActivity.ts
+++ b/web/src/hooks/useAgentActivity.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../api/client";
 import { useWebSocket } from "./useWebSocket";
+import type { AgentActivityItem } from "../api/client";
 import type {
   AgentActivity,
   HookEvent,
@@ -8,6 +9,33 @@ import type {
   TaskItem,
   ToolNode,
 } from "../components/live/liveTypes";
+
+// Turn a persisted activity row into a ToolNode for the Live card.
+// Historical rows lack Pre/Post pairing so we mark them completed with
+// unknown duration — same approach as the per-agent hydration path.
+function activityItemToNode(item: AgentActivityItem): ToolNode {
+  const toolName = (() => {
+    if (item.message) {
+      const colonIdx = item.message.indexOf(":");
+      if (colonIdx > 0) return item.message.slice(0, colonIdx).trim();
+      const spaceIdx = item.message.indexOf(" ");
+      if (spaceIdx > 0) return item.message.slice(0, spaceIdx).trim();
+      return item.message;
+    }
+    return item.event || "unknown";
+  })();
+  return {
+    id: nextId(),
+    toolName,
+    args: item.message || "",
+    fullInput: null,
+    fullOutput: null,
+    startTime: item.timestamp ? new Date(item.timestamp).getTime() : Date.now(),
+    endTime: undefined,
+    status: "completed" as const,
+    children: [],
+  };
+}
 import {
   AUTO_COLLAPSE_MS,
   FLUSH_INTERVAL,
@@ -84,30 +112,36 @@ export function useAgentActivity(agentName?: string): {
             const next = new Map(prev);
             const existing = next.get(agentName);
             if (existing && existing.nodes.length === 0 && items.length > 0) {
-              const nodes: ToolNode[] = items.map((item) => ({
-                id: nextId(),
-                toolName: (() => {
-                  // Prefer the actual tool name embedded in the message (e.g. "Bash: sleep 120")
-                  // over the generic hook event type ("PreToolUse", "PostToolUse").
-                  if (item.message) {
-                    const colonIdx = item.message.indexOf(":");
-                    if (colonIdx > 0) return item.message.slice(0, colonIdx).trim();
-                    const spaceIdx = item.message.indexOf(" ");
-                    if (spaceIdx > 0) return item.message.slice(0, spaceIdx).trim();
-                    return item.message;
-                  }
-                  return item.event || "unknown";
-                })(),
-                args: item.message || "",
-                fullInput: null,
-                fullOutput: null,
-                startTime: item.timestamp ? new Date(item.timestamp).getTime() : Date.now(),
-                // Historical events don't have Pre/Post pairing so duration is unknown
-                endTime: undefined,
-                status: "completed" as const,
-                children: [],
-              }));
+              const nodes: ToolNode[] = items.map(activityItemToNode);
               next.set(agentName, { ...existing, nodes });
+            }
+            return next;
+          });
+        }).catch(() => { /* best effort */ });
+      } else {
+        // Multi-agent view (Live page): hydrate from the cross-agent
+        // /api/agents/activity feed so cards aren't empty on reload (#3138).
+        api.getActivity(400).then((items) => {
+          if (items.length === 0) return;
+          const byAgent = new Map<string, AgentActivityItem[]>();
+          for (const it of items) {
+            const who = it.agent || "";
+            if (!who) continue;
+            const list = byAgent.get(who);
+            if (list) list.push(it);
+            else byAgent.set(who, [it]);
+          }
+          setActivities((prev) => {
+            const next = new Map(prev);
+            for (const [who, rows] of byAgent) {
+              const existing = next.get(who);
+              if (!existing || existing.nodes.length > 0) continue;
+              // Oldest-first inside each card; the REST feed is newest-first.
+              const nodes: ToolNode[] = rows
+                .slice()
+                .reverse()
+                .map(activityItemToNode);
+              next.set(who, { ...existing, nodes });
             }
             return next;
           });


### PR DESCRIPTION
## Summary

Closes #3138. The Live page no longer renders empty cards after a reload — each agent card is pre-filled from the persisted event store on first paint, then SSE keeps appending live events as today.

- **Server**: new \`GET /api/agents/activity?limit=N\` (default 200, max 2000) returning recent events across all agents, with the \`agent\` field set per row so the client can route. Per-agent and cross-agent feeds share a \`toActivityItem\` helper.
- **Web**: \`api.getActivity()\` wraps the endpoint; \`useAgentActivity()\` (multi-agent mode) groups by agent and seeds nodes via the shared \`activityItemToNode\` helper. No \"history mode\" toggle — same card UI, just no longer empty on cold load.

No new tables or migrations — pure read-side use of the existing \`pkg/events\` store. Trimming is already handled by \`SQLiteLog.Prune\`.

## Test plan
- [x] \`go test ./server/handlers/...\` — green
- [x] \`bun run test\` (web) — 110/110
- [x] \`bun run build\` (web) — clean
- [x] \`golangci-lint run ./server/...\` — 0 issues
- [ ] CI green
- [ ] Smoke: reload Live page on a workspace with prior agent activity → cards pre-populated