### PR TITLE
fix(server): keep web/dist placeholder so go install works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,11 @@ tmp/
 # Build artifacts
 bc
 bcd
-server/web/dist/
+server/web/dist/*
+# Keep a placeholder so //go:embed in server/embed.go has at least one
+# file to embed (otherwise `go install github.com/rpuneet/mycel/cmd/bc`
+# fails when the consumer hasn't run `bun run build`).
+!server/web/dist/placeholder.txt
 web/dist/
 tui/dist/
 landing/.next/

--- a/server/web/dist/placeholder.txt
+++ b/server/web/dist/placeholder.txt
@@ -1,0 +1,8 @@
+This file is a placeholder kept in source control so the //go:embed
+directive in server/embed.go has at least one file to embed.
+
+When you build the web UI (`make build-local-web` or
+`cd web && bun run build`), the real dist artifacts land alongside this
+file and the server serves them. WebDist() in server/embed.go ignores
+this placeholder (and the historical .gitkeep) when deciding whether a
+real bundle is present.


### PR DESCRIPTION
## Summary

Closes #36. \`//go:embed web/dist\` in \`server/embed.go\` needs at least one file under that directory or the build fails. We previously relied on a \`.gitkeep\` that was sweep-deleted in ee058bda, so \`go install github.com/rpuneet/mycel/cmd/bc\` is currently broken for any consumer who hasn't run \`bun run build\` themselves.

Switch the \`.gitignore\` rule from \`server/web/dist/\` to \`server/web/dist/*\` plus an explicit force-include for \`placeholder.txt\`. \`WebDist()\` already ignores both \`placeholder.txt\` and the historical \`.gitkeep\` when deciding whether a real bundle is present.

Pure shipping fix; no runtime behavior change.

## Test plan
- [x] \`rm -rf server/web/dist/{assets,index.html} && go build ./...\` succeeds with only the placeholder present
- [x] \`bun run build\` still produces the real bundle alongside the placeholder
- [ ] CI green