### PR TITLE
fix(landing): add Nav + Footer to /pricing and /waitlist

### DIFF
--- a/landing/src/app/pricing/page.tsx
+++ b/landing/src/app/pricing/page.tsx
@@ -9,6 +9,8 @@ import {
   StaggerChildren,
   StaggerItem,
 } from "../_components/Motion";
+import { Nav } from "../_components/Nav";
+import { Footer } from "../_components/Footer";
 
 const CHECK = (
   <svg
@@ -107,6 +109,7 @@ function FAQAccordion() {
 export default function PricingPage() {
   return (
     <main className="min-h-screen bg-background">
+      <Nav />
       {/* Hero */}
       <section className="hero-glow py-16">
         <div className="mx-auto max-w-5xl px-4 text-center">
@@ -272,6 +275,7 @@ export default function PricingPage() {
           </RevealSection>
         </div>
       </section>
+      <Footer />
     </main>
   );
 }

--- a/landing/src/app/waitlist/page.tsx
+++ b/landing/src/app/waitlist/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { FadeUp } from "../_components/Motion";
+import { Nav } from "../_components/Nav";
+import { Footer } from "../_components/Footer";
 
 const GOOGLE_FORM_ACTION =
   "https://docs.google.com/forms/d/e/1FAIpQLSc_aJ3S3nV5EizpkzTZnN7H5UykoANpC8jet2M7J0Qo3rhG8Q/formResponse";
@@ -94,8 +96,10 @@ export default function WaitlistPage() {
   };
 
   return (
-    <main className="hero-glow flex min-h-screen items-center justify-center bg-background">
-      <div className="mx-auto max-w-2xl px-4 text-center">
+    <div className="flex min-h-screen flex-col bg-background">
+      <Nav />
+      <main className="hero-glow flex flex-1 items-center justify-center">
+        <div className="mx-auto max-w-2xl px-4 text-center">
         <FadeUp delay={0.1}>
           <h1 className="font-headline text-4xl font-bold tracking-tight text-on-background lg:text-6xl">
             Orchestrate{" "}
@@ -188,7 +192,9 @@ export default function WaitlistPage() {
             4+ PROVIDERS &bull; OPEN SOURCE &bull; LOCAL-FIRST
           </p>
         </FadeUp>
-      </div>
-    </main>
+        </div>
+      </main>
+      <Footer />
+    </div>
   );
 }


### PR DESCRIPTION
Closes #3078. Both pages previously rendered without Nav/Footer, stranding visitors. /pricing is a one-line insert each; /waitlist swaps its hero `main` for a flex-column wrapper so the hero stays centered while Nav/Footer sit above and below. `bun run build` clean.