### PR TITLE
fix(cli,server): init self-heal + agent DM/state hygiene (#3173, #3174, #3175)

### DIFF
--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -322,7 +322,11 @@ func (s *AgentService) Send(ctx context.Context, name, message string) error {
 	// if not we return the honest "not running" error.
 	if a.State == StateStopped || a.State == StateStarting {
 		if s.manager.RuntimeForAgent(name).HasSession(ctx, name) {
-			a.State = StateIdle
+			// GetAgent returned a copy — reset via UpdateAgentState so
+			// the manager's authoritative state actually moves.
+			if uErr := s.manager.UpdateAgentState(ctx, name, StateIdle, a.Task); uErr != nil {
+				log.Warn("reconcile to idle failed", "agent", name, "from", a.State, "error", uErr)
+			}
 		} else if a.State == StateStopped {
 			return fmt.Errorf("agent %q is stopped: %w", name, ErrNotRunning)
 		} else {

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -311,12 +311,22 @@ func (s *AgentService) Send(ctx context.Context, name, message string) error {
 	if a == nil {
 		return fmt.Errorf("agent %q: %w", name, ErrNotFound)
 	}
-	// Reconcile stale state: if marked stopped but session is alive, correct it
-	if a.State == StateStopped {
+	// Reconcile stale state (#3175). Two wedges are common:
+	//
+	//   - marked stopped but the tmux session is actually alive → idle
+	//   - stuck at "starting" because the transition hook was missed
+	//     (crash before writing state, hook dropped, etc.) → idle
+	//
+	// In both cases we probe the runtime for a live session. If one
+	// exists we correct the visible state so the dashboard stops lying;
+	// if not we return the honest "not running" error.
+	if a.State == StateStopped || a.State == StateStarting {
 		if s.manager.RuntimeForAgent(name).HasSession(ctx, name) {
 			a.State = StateIdle
-		} else {
+		} else if a.State == StateStopped {
 			return fmt.Errorf("agent %q is stopped: %w", name, ErrNotRunning)
+		} else {
+			return fmt.Errorf("agent %q is still starting: %w", name, ErrNotRunning)
 		}
 	}
 	return s.manager.SendToAgent(ctx, name, message)

--- a/pkg/workspace/init_regression_test.go
+++ b/pkg/workspace/init_regression_test.go
@@ -1,0 +1,79 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestInit_FailsWhenRegistrySaveFails locks the fix for #3173.
+// Historically Init swallowed the registry Save error and returned a
+// "success" workspace that every subsequent command rejected as "not
+// in a bc workspace" because the registry file was never written.
+// Now Init must surface the failure loudly.
+func TestInit_FailsWhenRegistrySaveFails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BC_HOME", filepath.Join(home, ".bc"))
+
+	// Pre-create the registry file's parent directory as a read-only
+	// path so the rename step in Registry.Save fails.
+	if err := os.MkdirAll(filepath.Join(home, ".bc"), 0o500); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Undo the restriction on cleanup so t.TempDir can clean.
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(home, ".bc"), 0o700) }) //nolint:gosec // cleanup only
+
+	proj := t.TempDir()
+	gitInitDir(t, proj)
+
+	_, err := Init(proj)
+	if err == nil {
+		t.Fatal("Init: expected error when registry cannot persist, got nil")
+	}
+}
+
+// TestFind_SelfHealsAfterRegistryLoss reproduces the #3173 scenario:
+// a workspace exists on disk (state dir + preferences.json) but the
+// registry file was deleted / never wrote. Find must probe the
+// deterministic workspace ID for the walked directory, discover the
+// state dir, register on the fly, and return the workspace.
+func TestFind_SelfHealsAfterRegistryLoss(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("BC_HOME", filepath.Join(home, ".bc"))
+
+	proj := t.TempDir()
+	gitInitDir(t, proj)
+
+	if _, err := Init(proj); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Simulate a lost registry — user wiped ~/.bc/workspaces.json,
+	// permission race on install, whatever.
+	if err := os.Remove(RegistryPath()); err != nil {
+		t.Fatalf("remove registry: %v", err)
+	}
+
+	ws, err := Find(proj)
+	if err != nil {
+		t.Fatalf("Find after registry loss: %v", err)
+	}
+	if ws.RootDir != proj {
+		t.Errorf("Find returned wrong workspace: got %q want %q", ws.RootDir, proj)
+	}
+
+	// The self-heal should have re-written the registry so the next
+	// call doesn't need to re-probe.
+	if _, stErr := os.Stat(RegistryPath()); stErr != nil {
+		t.Errorf("self-heal did not persist registry: %v", stErr)
+	}
+	reg, regErr := LoadRegistry()
+	if regErr != nil {
+		t.Fatalf("LoadRegistry after self-heal: %v", regErr)
+	}
+	if reg.Find(proj) == nil {
+		t.Errorf("registry entry not re-created for %s", proj)
+	}
+}

--- a/pkg/workspace/init_regression_test.go
+++ b/pkg/workspace/init_regression_test.go
@@ -14,18 +14,23 @@ import (
 func TestInit_FailsWhenRegistrySaveFails(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("BC_HOME", filepath.Join(home, ".bc"))
+	bcHome := filepath.Join(home, ".bc")
+	t.Setenv("BC_HOME", bcHome)
 
-	// Pre-create the registry file's parent directory as a read-only
-	// path so the rename step in Registry.Save fails.
-	if err := os.MkdirAll(filepath.Join(home, ".bc"), 0o500); err != nil {
-		t.Fatalf("mkdir: %v", err)
+	// Pre-create the state dir so Init's own mkdir/EnsureBCHome/config
+	// save steps succeed. Only then clamp ~/.bc/ read-only so the
+	// atomic rename in Registry.Save is the specific step that fails —
+	// otherwise this test would pass for the wrong reason.
+	if err := os.MkdirAll(filepath.Join(bcHome, "workspaces"), 0o750); err != nil {
+		t.Fatalf("mkdir bc home: %v", err)
 	}
-	// Undo the restriction on cleanup so t.TempDir can clean.
-	t.Cleanup(func() { _ = os.Chmod(filepath.Join(home, ".bc"), 0o700) }) //nolint:gosec // cleanup only
-
 	proj := t.TempDir()
 	gitInitDir(t, proj)
+
+	if err := os.Chmod(bcHome, 0o500); err != nil { //nolint:gosec // read-only clamp is the point of the test
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(bcHome, 0o700) }) //nolint:gosec // cleanup only
 
 	_, err := Init(proj)
 	if err == nil {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -112,10 +112,20 @@ func Init(rootDir string) (*Workspace, error) {
 	}
 	_ = closeStore // store stays open for workspace lifetime
 
-	// Register in global registry so Find()/IsWorkspace() work without .bc/ marker.
-	if reg, regErr := LoadRegistry(); regErr == nil {
-		reg.Register(absRoot, cfg.User.Name)
-		_ = reg.Save() //nolint:errcheck // best-effort
+	// Register in global registry so Find()/IsWorkspace() work — M11+
+	// workspaces live at ~/.bc/workspaces/<id>/ with NO .bc/ marker in
+	// the project directory, so the registry is the ONLY thing that
+	// makes `bc <cmd>` resolve after init. If we can't persist it, init
+	// must fail loudly (#3173) — silently succeeding here leaves the
+	// user with a phantom workspace that every subsequent command
+	// rejects as "not in a bc workspace".
+	reg, regErr := LoadRegistry()
+	if regErr != nil {
+		return nil, fmt.Errorf("failed to load workspace registry (%s): %w", RegistryPath(), regErr)
+	}
+	reg.Register(absRoot, cfg.User.Name)
+	if saveErr := reg.Save(); saveErr != nil {
+		return nil, fmt.Errorf("failed to persist workspace registry (%s): %w", RegistryPath(), saveErr)
 	}
 
 	return &Workspace{
@@ -231,8 +241,39 @@ func Find(dir string) (*Workspace, error) {
 		}
 	}
 
-	// Legacy fallback: walk up looking for .bc/ directory marker.
+	// Self-heal (#3173): if the registry says nothing matches but a
+	// state directory exists at ~/.bc/workspaces/<id>/ where
+	// <id> == ComputeWorkspaceID(walked-path), the workspace was
+	// initialized but the registry file got out of sync — most often
+	// because Init's Save() failed on a fresh HOME, or the user hand-
+	// deleted workspaces.json. Register the entry on the fly so the
+	// next `bc` call sees a healed registry.
 	current := absDir
+	for {
+		id := ComputeWorkspaceID(current)
+		stateDir, sdErr := DataDir(id)
+		if sdErr == nil {
+			if prefs := firstExisting(stateDir, PreferencesFileName, LegacySettingsFileName); prefs != "" {
+				if reg, regErr := LoadRegistry(); regErr == nil {
+					reg.Register(current, "")
+					if saveErr := reg.Save(); saveErr != nil {
+						log.Warn("workspace registry: self-heal save failed", "path", current, "error", saveErr)
+					} else {
+						log.Info("workspace registry: self-healed on find", "id", id, "path", current)
+					}
+				}
+				return Load(current)
+			}
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+
+	// Legacy fallback: walk up looking for .bc/ directory marker.
+	current = absDir
 	for {
 		stateDir := filepath.Join(current, ".bc")
 		if _, err := os.Stat(stateDir); err == nil {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -121,10 +121,16 @@ func Init(rootDir string) (*Workspace, error) {
 	// rejects as "not in a bc workspace".
 	reg, regErr := LoadRegistry()
 	if regErr != nil {
+		if closeStore != nil {
+			_ = closeStore() //nolint:errcheck // best-effort cleanup on error path
+		}
 		return nil, fmt.Errorf("failed to load workspace registry (%s): %w", RegistryPath(), regErr)
 	}
 	reg.Register(absRoot, cfg.User.Name)
 	if saveErr := reg.Save(); saveErr != nil {
+		if closeStore != nil {
+			_ = closeStore() //nolint:errcheck // best-effort cleanup on error path
+		}
 		return nil, fmt.Errorf("failed to persist workspace registry (%s): %w", RegistryPath(), saveErr)
 	}
 
@@ -254,8 +260,14 @@ func Find(dir string) (*Workspace, error) {
 		stateDir, sdErr := DataDir(id)
 		if sdErr == nil {
 			if prefs := firstExisting(stateDir, PreferencesFileName, LegacySettingsFileName); prefs != "" {
+				// Preserve the configured user name when re-registering so
+				// the self-heal doesn't clobber it with an empty string.
+				name := ""
+				if cfg, cfgErr := LoadConfig(prefs); cfgErr == nil && cfg != nil {
+					name = cfg.User.Name
+				}
 				if reg, regErr := LoadRegistry(); regErr == nil {
-					reg.Register(current, "")
+					reg.Register(current, name)
 					if saveErr := reg.Save(); saveErr != nil {
 						log.Warn("workspace registry: self-heal save failed", "path", current, "error", saveErr)
 					} else {

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -496,8 +496,19 @@ func (h *AgentHandler) byName(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			Message string `json:"message"`
 		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			httpError(w, "invalid request body", http.StatusBadRequest)
+		// Strict decode: agents were silently no-op'ing DMs to each other
+		// because the /send endpoint accepted the gateway body shape
+		// ({sender, content}) and typed an empty string into the target's
+		// session (#3174). Reject unknown fields and empty messages so the
+		// caller gets a clear 400 instead of a false success.
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			httpError(w, "invalid request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if strings.TrimSpace(req.Message) == "" {
+			httpError(w, "message must not be empty", http.StatusBadRequest)
 			return
 		}
 		if err := svc.Send(r.Context(), name, req.Message); err != nil {


### PR DESCRIPTION
Fixes #3173.
Fixes #3174.
Fixes #3175.
Part of #3172.

## Summary

Three related fixes for the v0.3.0 blocker list (#3172). All touch the agent lifecycle path; bundled because they share tests and reviewer context.

### #3173 — init regression on fresh install
Reported: after `brew install` / `npm i -g mycel-cli` + `bc init`, subsequent commands fail with `not in a bc workspace`.
- `workspace.Init` now surfaces registry `Save` errors. Silent failures previously left users with a phantom workspace.
- `workspace.Find` gains a **self-heal probe**: if the registry has no entry for the walked cwd but `~/.bc/workspaces/<ComputeWorkspaceID(cwd)>/preferences.json` exists, register on the fly and `Load`. Broken installs recover on the next call.
- Regression tests use isolated `BC_HOME` and cover both the loud-fail-on-save path and the self-heal path.

### #3174 — inter-agent DMs silently no-op'd
- `POST /api/agents/{name}/send` now uses `DisallowUnknownFields` and rejects empty messages with 400. Callers using the gateway body shape (`{sender, content}`) previously returned `sent` and typed an empty string into the target tmux session. This is how the fleet's inter-agent coordination has been quietly failing.

### #3175 — agent state stuck at "starting"
- `AgentService.Send` now reconciles both `stopped` and `starting` when a live tmux session is detected. The error message clarifies stopped vs still-starting when no session exists.

## Test plan
- [x] `go test ./pkg/workspace ./pkg/agent ./server/handlers` — green
- [x] `golangci-lint run ./pkg/workspace/... ./pkg/agent/... ./server/handlers/...` — 0 issues
- [ ] CI green
- [ ] lucid-meerkat smoke: fresh HOME → `bc init` → `bc status` — must succeed