### PR TITLE
fix(web): first UI/UX cleanup pass for v0.3.0

### DIFF
--- a/web/src/components/live/LiveRenderers.tsx
+++ b/web/src/components/live/LiveRenderers.tsx
@@ -1011,9 +1011,13 @@ export const AgentCard = memo(function AgentCard({
       </AnimatePresence>
 
       {!activity.collapsed && showToolNodes && visibleNodes.length === 0 && !searchTerm && (
-        <div className="border-t border-mycel-border/60 py-3 px-4 text-[12px] text-mycel-muted italic">
+        <div className="border-t border-mycel-border/60 py-3 px-4 text-[12px] text-mycel-muted italic flex items-center gap-2">
           {activity.lastEventTime > 0 ? (
-            <IdleTimer lastEventTime={activity.lastEventTime} />
+            <>
+              <span>No recent events</span>
+              <span className="text-mycel-border">·</span>
+              <IdleTimer lastEventTime={activity.lastEventTime} />
+            </>
           ) : (
             "Waiting for activity..."
           )}

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1243,7 +1243,12 @@ export function AgentDetail() {
                 style={{ fontFamily: MONO }}
               >
                 {tab.label}
-                <span className="ml-1 text-[9px] opacity-40">{tab.shortcut}</span>
+                <span
+                  className="ml-1.5 inline-flex items-center justify-center rounded border border-mycel-border/40 px-1 text-[9px] leading-none py-[3px] opacity-50"
+                  aria-hidden
+                >
+                  {tab.shortcut}
+                </span>
                 {/* Active indicator — bottom glow bar */}
                 {isActive && (
                   <span className="absolute bottom-0 left-1 right-1 h-[2px] rounded-full bg-mycel-accent shadow-[0_0_8px_rgba(var(--mycel-accent-rgb,255,165,0),0.5)]" />

--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -445,7 +445,7 @@ export function Live() {
         </div>
         {/* Active/stopped count badge with toggle */}
         <span
-          className="inline-flex items-center gap-1.5 text-[11px] font-mono px-2 py-1 rounded-md border border-mycel-border bg-mycel-surface text-mycel-muted"
+          className="inline-flex items-center gap-1.5 whitespace-nowrap text-[11px] font-mono px-2 py-1 rounded-md border border-mycel-border bg-mycel-surface text-mycel-muted"
           data-testid="live-state-badge"
           title={showStopped ? "Showing all agents" : "Stopped/errored agents hidden"}
         >


### PR DESCRIPTION
Part of #3172.

## Summary

First batch of fixes from the v0.3.0 UI/UX audit (Playwright screenshot pass across all top-level surfaces).

- **AgentDetail tab shortcuts** — the `1/2/3/4/5` hints were rendered as bare numbers jammed against the tab label (`Attach1 Live2 …`), reading as typos. Now they render as a bordered keyboard-style chip.
- **Live count badge** — `5 active · 2 stopped` locks to `whitespace-nowrap` so it stops wrapping awkwardly next to the search field.
- **Live idle rows** — agents with no visible tool nodes now show `No recent events · Idle 14d` instead of just `Idle 14d`, so blank-looking rows have context.

Pure visual polish. No behavior changes.

## Test plan
- [x] `bun run build` clean
- [x] `bun run test` — 110/110
- [ ] CI green
- [ ] Visual re-verify on localhost:8080

More UI/UX PRs coming (button system standardization, empty-state consistency, time formatting).