### PR TITLE
fix(web): align Templates expand-trigger to shared ghost pattern

### DIFF
--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -451,9 +451,9 @@ function CreateTemplateForm({ onCreated }: { onCreated: (name: string) => void }
         <button
           type="button"
           onClick={() => setExpanded(true)}
-          className="px-4 py-2 rounded bg-mycel-accent text-white text-sm font-medium hover:opacity-90 transition-opacity focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
+          className="flex items-center gap-2 px-4 py-2 rounded-lg border border-dashed border-mycel-border text-sm text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent/50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
         >
-          + Create Template
+          <span className="text-lg leading-none">+</span> Create Template
         </button>
         {status.type === "success" && (
           <span className="text-xs text-mycel-success">Template created</span>


### PR DESCRIPTION
Part of #3172.

## Summary

The audit flagged inconsistent primary-button treatment between Templates and Secrets — same UI pattern (collapsed → expand a form), different visual weight.

- Templates `+ Create Template` was a **filled accent** button
- Secrets `+ Add Secret` is a **dashed-border ghost** button

Aligning Templates to the ghost pattern so inline expand-triggers look the same across the app. Filled accent stays for actual submit buttons inside the expanded forms.

## Test plan
- [x] `bun run build` clean
- [x] `bun run test` 110/110
- [ ] CI green