### PR TITLE
refactor(workspace): rename ~/.bc → ~/.mycel with silent migration (part 1 of bc→mycel sweep)

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/rpuneet/mycel/pkg/log"
 	"github.com/rpuneet/mycel/pkg/ui"
+	"github.com/rpuneet/mycel/pkg/workspace"
 )
 
 var (
@@ -77,11 +78,19 @@ Environment Variables:
 
 Documentation: https://github.com/rpuneet/mycel
 Full CLI reference: https://github.com/rpuneet/mycel/docs/cli.md`,
-	// PersistentPreRun initializes logging based on flags
+	// PersistentPreRun initializes logging based on flags and runs the
+	// one-time ~/.bc → ~/.mycel migration on real user invocations.
+	// Tests set MYCEL_HOME/BC_HOME so MigrateLegacyHome is a no-op for
+	// them.
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		verbose, err := cmd.Flags().GetBool("verbose")
 		if err == nil {
 			log.SetVerbose(verbose)
+		}
+		if migrated, migErr := workspace.MigrateLegacyHome(); migErr != nil {
+			log.Warn("legacy ~/.bc migration failed; continuing with legacy path", "error", migErr)
+		} else if migrated {
+			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "mycel: migrated legacy ~/.bc → ~/.mycel")
 		}
 	},
 	// Run with no args: open home if initialized, else prompt for init

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -169,7 +169,7 @@ func (b *Backend) containerAgentDir(agentName string) string {
 func (b *Backend) hostAgentDir(agentName, hostRoot string) string {
 	containerDir := b.containerAgentDir(agentName)
 	// Only translate when the path is under BC_HOME (the M11 global dir).
-	bcHome, err := workspace.BCHome()
+	bcHome, err := workspace.MycelHome()
 	if err == nil && strings.HasPrefix(containerDir, bcHome+string(filepath.Separator)) {
 		if hostBCHome := os.Getenv("BC_HOST_BC_HOME"); hostBCHome != "" {
 			rel := strings.TrimPrefix(containerDir, bcHome)

--- a/pkg/workspace/home.go
+++ b/pkg/workspace/home.go
@@ -4,28 +4,113 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/rpuneet/mycel/pkg/log"
 )
 
-// BCHome returns the global bc home directory (~/.bc).
-// Respects BC_HOME env var override.
-func BCHome() (string, error) {
+// The state directory used to live under ~/.bc for historical reasons
+// (the project was called bc before the mycel rename). Every new install
+// now uses ~/.mycel. Callers can invoke MigrateLegacyHome() once at
+// startup to rename an old ~/.bc/ tree into ~/.mycel/.
+const (
+	legacyHomeDirName = ".bc"
+	homeDirName       = ".mycel"
+)
+
+// MycelHome returns the global mycel home directory.
+//
+// Resolution order:
+//  1. MYCEL_HOME env var (canonical, post-rename).
+//  2. BC_HOME env var (deprecated but honored so bc-era scripts and
+//     tests keep working; a one-line WARN is logged).
+//  3. ~/.mycel/ when it exists on disk.
+//  4. ~/.bc/ when it exists but ~/.mycel/ doesn't — a bc-era install
+//     that hasn't run the migration yet.
+//  5. ~/.mycel/ as the default when nothing exists yet.
+//
+// This function never mutates the filesystem. Use MigrateLegacyHome()
+// at CLI startup to rename an existing ~/.bc/ to ~/.mycel/.
+func MycelHome() (string, error) {
+	if env := os.Getenv("MYCEL_HOME"); env != "" {
+		return env, nil
+	}
 	if env := os.Getenv("BC_HOME"); env != "" {
+		log.Warn("BC_HOME is deprecated; use MYCEL_HOME", "value", env)
 		return env, nil
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-	return filepath.Join(home, ".bc"), nil
+
+	target := filepath.Join(home, homeDirName)
+	if _, statErr := os.Stat(target); statErr == nil {
+		return target, nil
+	}
+
+	legacy := filepath.Join(home, legacyHomeDirName)
+	if _, statErr := os.Stat(legacy); statErr == nil {
+		return legacy, nil
+	}
+
+	return target, nil
+}
+
+// BCHome is the pre-rename spelling of MycelHome. Retained so existing
+// call sites keep compiling; new code should use MycelHome directly.
+//
+// Deprecated: use MycelHome.
+func BCHome() (string, error) {
+	return MycelHome()
+}
+
+// MigrateLegacyHome renames ~/.bc/ to ~/.mycel/ when the legacy tree
+// exists and the canonical one doesn't. Idempotent, safe to call
+// multiple times, safe to call when nothing needs migrating. Returns
+// (migrated, err) — migrated is true only when a rename actually
+// happened, so callers can print a one-time notice.
+//
+// Callers must have resolved the "real" user HOME (i.e. not overridden
+// via MYCEL_HOME/BC_HOME) before calling this — the migration is a
+// no-op when the resolved home already looks like something other
+// than "$HOME/.bc" or "$HOME/.mycel".
+func MigrateLegacyHome() (bool, error) {
+	if os.Getenv("MYCEL_HOME") != "" || os.Getenv("BC_HOME") != "" {
+		return false, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false, err
+	}
+	target := filepath.Join(home, homeDirName)
+	legacy := filepath.Join(home, legacyHomeDirName)
+
+	if _, statErr := os.Stat(target); statErr == nil {
+		return false, nil // canonical already exists
+	}
+	if _, statErr := os.Stat(legacy); statErr != nil {
+		return false, nil // nothing to migrate
+	}
+	if renameErr := os.Rename(legacy, target); renameErr != nil {
+		return false, fmt.Errorf("rename %s → %s: %w", legacy, target, renameErr)
+	}
+	log.Info("migrated legacy ~/.bc to ~/.mycel", "from", legacy, "to", target)
+	return true, nil
 }
 
 // GlobalStateDir returns the state directory for a workspace at
-// ~/.bc/workspaces/<workspace-id>/, where the ID is the 12-char sha256
-// prefix produced by ComputeWorkspaceID. Matches RegistryEntry.DataDir so
-// the migration and the registry agree on a single path.
-// Respects BC_STATE_DIR env var override.
+// <MycelHome>/workspaces/<workspace-id>/, where the ID is the 12-char
+// sha256 prefix produced by ComputeWorkspaceID. Matches
+// RegistryEntry.DataDir so migration and registry agree on a single
+// path.
+//
+// Respects MYCEL_STATE_DIR (canonical) and BC_STATE_DIR (deprecated).
 func GlobalStateDir(rootDir string) (string, error) {
+	if env := os.Getenv("MYCEL_STATE_DIR"); env != "" {
+		return env, nil
+	}
 	if env := os.Getenv("BC_STATE_DIR"); env != "" {
+		log.Warn("BC_STATE_DIR is deprecated; use MYCEL_STATE_DIR", "value", env)
 		return env, nil
 	}
 
@@ -34,24 +119,25 @@ func GlobalStateDir(rootDir string) (string, error) {
 		return "", err
 	}
 
-	bcHome, err := BCHome()
+	home, err := MycelHome()
 	if err != nil {
 		return "", err
 	}
 
 	id := ComputeWorkspaceID(absRoot)
-	return filepath.Join(bcHome, globalWorkspacesDirName, id), nil
+	return filepath.Join(home, globalWorkspacesDirName, id), nil
 }
 
-// EnsureBCHome creates the global ~/.bc directory structure if it doesn't exist.
-func EnsureBCHome() error {
-	bcHome, err := BCHome()
+// EnsureMycelHome creates the global mycel home directory structure if
+// it doesn't already exist. Idempotent.
+func EnsureMycelHome() error {
+	home, err := MycelHome()
 	if err != nil {
 		return err
 	}
 	dirs := []string{
-		bcHome,
-		filepath.Join(bcHome, "workspaces"),
+		home,
+		filepath.Join(home, "workspaces"),
 	}
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0750); err != nil {
@@ -59,4 +145,11 @@ func EnsureBCHome() error {
 		}
 	}
 	return nil
+}
+
+// EnsureBCHome is the pre-rename spelling of EnsureMycelHome.
+//
+// Deprecated: use EnsureMycelHome.
+func EnsureBCHome() error {
+	return EnsureMycelHome()
 }

--- a/pkg/workspace/home_test.go
+++ b/pkg/workspace/home_test.go
@@ -1,0 +1,118 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMycelHome_LegacyFallback locks the read-only fallback path:
+// when only ~/.bc/ exists on disk, MycelHome returns that so a fresh
+// binary still finds pre-rename state.
+func TestMycelHome_LegacyFallback(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MYCEL_HOME", "")
+	t.Setenv("BC_HOME", "")
+
+	legacy := filepath.Join(home, ".bc")
+	if err := os.MkdirAll(legacy, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	got, err := MycelHome()
+	if err != nil {
+		t.Fatalf("MycelHome: %v", err)
+	}
+	if got != legacy {
+		t.Errorf("got %s, want legacy %s", got, legacy)
+	}
+}
+
+// TestMycelHome_CanonicalDefault when nothing exists yet, MycelHome
+// returns ~/.mycel/ so a fresh install writes to the new tree.
+func TestMycelHome_CanonicalDefault(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MYCEL_HOME", "")
+	t.Setenv("BC_HOME", "")
+
+	got, err := MycelHome()
+	if err != nil {
+		t.Fatalf("MycelHome: %v", err)
+	}
+	want := filepath.Join(home, ".mycel")
+	if got != want {
+		t.Errorf("got %s, want %s", got, want)
+	}
+}
+
+// TestMigrateLegacyHome renames ~/.bc → ~/.mycel exactly once and
+// only when appropriate.
+func TestMigrateLegacyHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MYCEL_HOME", "")
+	t.Setenv("BC_HOME", "")
+
+	legacy := filepath.Join(home, ".bc")
+	target := filepath.Join(home, ".mycel")
+	if err := os.MkdirAll(legacy, 0o750); err != nil {
+		t.Fatalf("mkdir legacy: %v", err)
+	}
+	sentinel := filepath.Join(legacy, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("preserved"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	migrated, err := MigrateLegacyHome()
+	if err != nil {
+		t.Fatalf("MigrateLegacyHome: %v", err)
+	}
+	if !migrated {
+		t.Fatal("expected migrated=true, got false")
+	}
+	if _, statErr := os.Stat(legacy); statErr == nil {
+		t.Errorf("legacy %s should be gone after migration", legacy)
+	}
+	if _, statErr := os.Stat(target); statErr != nil {
+		t.Errorf("target %s not created: %v", target, statErr)
+	}
+	body, err := os.ReadFile(filepath.Join(target, "sentinel.txt")) //nolint:gosec // test-controlled path
+	if err != nil || string(body) != "preserved" {
+		t.Errorf("sentinel not preserved: body=%q err=%v", string(body), err)
+	}
+
+	// Second call is a no-op.
+	migrated2, err := MigrateLegacyHome()
+	if err != nil {
+		t.Fatalf("second MigrateLegacyHome: %v", err)
+	}
+	if migrated2 {
+		t.Error("second call should return migrated=false")
+	}
+}
+
+// TestMigrateLegacyHome_NoOpWhenEnvOverride ensures we don't touch
+// ~/.bc when the user has explicitly pointed us elsewhere via env.
+func TestMigrateLegacyHome_NoOpWhenEnvOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MYCEL_HOME", filepath.Join(home, "custom"))
+
+	legacy := filepath.Join(home, ".bc")
+	if err := os.MkdirAll(legacy, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	migrated, err := MigrateLegacyHome()
+	if err != nil {
+		t.Fatalf("MigrateLegacyHome: %v", err)
+	}
+	if migrated {
+		t.Error("should not migrate when MYCEL_HOME is set")
+	}
+	if _, statErr := os.Stat(legacy); statErr != nil {
+		t.Error("legacy should be untouched when env override is set")
+	}
+}

--- a/pkg/workspace/registry_test.go
+++ b/pkg/workspace/registry_test.go
@@ -198,9 +198,11 @@ func TestGlobalDir(t *testing.T) {
 		t.Skip("no home directory available")
 	}
 
-	// Should end with .bc
-	if filepath.Base(dir) != ".bc" {
-		t.Errorf("GlobalDir should end with .bc, got %s", dir)
+	// Should end with .mycel (canonical) or .bc (legacy install still
+	// on the old tree — MigrateLegacyHome hasn't run yet).
+	base := filepath.Base(dir)
+	if base != ".mycel" && base != ".bc" {
+		t.Errorf("GlobalDir should end with .mycel or .bc, got %s", dir)
 	}
 }
 


### PR DESCRIPTION
Part of #3172. First PR in the bc → mycel sweep.

## Summary

Rename the state root from `~/.bc/` to `~/.mycel/` and add silent migration so existing installs don't need any user action.

- **Canonical**: `~/.mycel/`, `MYCEL_HOME`, `MYCEL_STATE_DIR`.
- **Deprecated but honored**: `~/.bc/`, `BC_HOME`, `BC_STATE_DIR` — logs a WARN, keeps working.
- `MycelHome()` is read-only fallback: prefers `~/.mycel/`, falls back to `~/.bc/` if that's what's on disk. Never mutates the FS.
- `MigrateLegacyHome()` is the explicit renamer. Wired into cobra root's `PersistentPreRun` — real CLI invocations rename `~/.bc → ~/.mycel` once and print a one-line notice. Env override → no-op, so tests never touch a real user's home (learned that the hard way while writing this).
- `BCHome` / `EnsureBCHome` kept as deprecated aliases so ~20 existing call sites keep compiling. Follow-up PRs will migrate them batch-style.

Silent migration is safe: only runs when `~/.mycel/` doesn't exist AND `~/.bc/` does. If both exist (unlikely), prefers `~/.mycel/` and leaves the old tree alone.

## Test plan
- [x] `go test ./pkg/workspace/...` — green (4 new tests for legacy fallback, canonical default, migrate-once with sentinel preservation, env-override no-op)
- [x] `golangci-lint` — 0 issues
- [ ] CI green
- [ ] Follow-up PRs: docs sweep, CLI help/error text, web UI copy, env-var call-site migration