### PR TITLE
refactor(cli): user-facing bc → mycel in help, errors, prose (part 2 of sweep)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -59,8 +59,8 @@ func newAgentManager(ws *workspace.Workspace) *agent.Manager {
 var agentCmd = &cobra.Command{
 	Use:     "agent",
 	Aliases: []string{"ag"},
-	Short:   "Manage bc agents",
-	Long: `Manage bc agent lifecycle: create, list, attach, peek, stop, send.
+	Short:   "Manage mycel agents",
+	Long: `Manage mycel agent lifecycle: create, list, attach, peek, stop, send.
 
 Examples:
   bc agent list                          # List all agents
@@ -631,11 +631,11 @@ func runAgentPeek(cmd *cobra.Command, args []string) error {
 
 		a := mgr.GetAgent(agentName)
 		if a == nil {
-			return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentName)
+			return fmt.Errorf("agent %q not found (use 'mycel agent list' to see available agents)", agentName)
 		}
 
 		if a.State == "stopped" {
-			return fmt.Errorf("agent %q is stopped (use 'bc agent start %s' to start it)", agentName, agentName)
+			return fmt.Errorf("agent %q is stopped (use 'mycel agent start %s' to start it)", agentName, agentName)
 		}
 
 		fmt.Printf("=== %s (following, Ctrl+C to stop) ===\n", agentName)

--- a/internal/cmd/agent_e2e_test.go
+++ b/internal/cmd/agent_e2e_test.go
@@ -102,7 +102,7 @@ func TestAgentLifecycle_CreateNoWorkspace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing workspace")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }
@@ -551,7 +551,7 @@ func TestNoWorkspace_AgentList(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing workspace")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }
@@ -569,7 +569,7 @@ func TestNoWorkspace_AgentStop(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing workspace")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }
@@ -587,7 +587,7 @@ func TestNoWorkspace_AgentPeek(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing workspace")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }
@@ -605,7 +605,7 @@ func TestNoWorkspace_AgentSend(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing workspace")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }
@@ -623,7 +623,7 @@ func TestNoWorkspace_ChannelCreate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing workspace")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }

--- a/internal/cmd/agent_health.go
+++ b/internal/cmd/agent_health.go
@@ -102,7 +102,7 @@ func runAgentHealth(cmd *cobra.Command, args []string) error {
 	}
 
 	if agentFilter != "" && len(healthData) == 0 {
-		return fmt.Errorf("agent %q not found (use 'bc agent list' to see available agents)", agentFilter)
+		return fmt.Errorf("agent %q not found (use 'mycel agent list' to see available agents)", agentFilter)
 	}
 
 	if len(healthData) == 0 {

--- a/internal/cmd/agent_integration_test.go
+++ b/internal/cmd/agent_integration_test.go
@@ -299,7 +299,7 @@ func TestAgentNoWorkspace(t *testing.T) {
 	if execErr == nil {
 		t.Error("expected error when not in workspace")
 	}
-	if !strings.Contains(execErr.Error(), "not in a bc workspace") {
+	if !strings.Contains(execErr.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", execErr)
 	}
 }

--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -137,7 +137,7 @@ var channelReactCmd = &cobra.Command{
 	Short: "React to a channel message",
 	Long: `Add an emoji reaction to a message in a channel.
 
-The message-index is shown in 'bc channel history' output.
+The message-index is shown in 'mycel channel history' output.
 Use common emoji like 👍, 👎, ❤️, 🎉, 👀, 🚀 or any emoji.
 
 Examples:
@@ -303,8 +303,8 @@ func runChannelList(cmd *cobra.Command, _ []string) error {
 	if len(channels) == 0 {
 		ui.Warning("No channels defined")
 		ui.BlankLine()
-		ui.Info("Run 'bc channel create <name>' to create a channel")
-		ui.Info("Or run 'bc up' to create default channels")
+		ui.Info("Run 'mycel channel create <name>' to create a channel")
+		ui.Info("Or run 'mycel up' to create default channels")
 		return nil
 	}
 
@@ -461,7 +461,7 @@ func runChannelDelete(cmd *cobra.Command, args []string) error {
 func runChannelJoin(cmd *cobra.Command, args []string) error {
 	agentID := os.Getenv("BC_AGENT_ID")
 	if agentID == "" {
-		return errorAgentNotRunning(fmt.Sprintf("bc channel join %s", args[0]))
+		return errorAgentNotRunning(fmt.Sprintf("mycel channel join %s", args[0]))
 	}
 
 	channelName := args[0]
@@ -486,7 +486,7 @@ func runChannelJoin(cmd *cobra.Command, args []string) error {
 func runChannelLeave(cmd *cobra.Command, args []string) error {
 	agentID := os.Getenv("BC_AGENT_ID")
 	if agentID == "" {
-		return errorAgentNotRunning(fmt.Sprintf("bc channel leave %s", args[0]))
+		return errorAgentNotRunning(fmt.Sprintf("mycel channel leave %s", args[0]))
 	}
 
 	channelName := args[0]
@@ -681,7 +681,7 @@ func runChannelShow(cmd *cobra.Command, args []string) error {
 
 	ch, err := c.Channels.Get(cmd.Context(), channelName)
 	if err != nil {
-		return fmt.Errorf("channel %q not found (use 'bc channel list' to see available channels): %w", channelName, err)
+		return fmt.Errorf("channel %q not found (use 'mycel channel list' to see available channels): %w", channelName, err)
 	}
 
 	msgs, _ := c.Channels.History(cmd.Context(), channelName, 5, 0, "")

--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -183,7 +183,7 @@ func TestAgentSendNoWorkspace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when not in workspace, got nil")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 	if bcdHit {
@@ -267,7 +267,7 @@ func TestAgentReportNoWorkspace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when not in workspace, got nil")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }
@@ -333,7 +333,7 @@ func TestStatusNoWorkspace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when not in workspace, got nil")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }
@@ -450,7 +450,7 @@ func TestLogsNoWorkspace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when not in workspace, got nil")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }
@@ -590,7 +590,7 @@ func TestStatsNoWorkspace(t *testing.T) {
 	_, _, err = executeIntegrationCmd("workspace", "stats")
 	// When bcd is running, stats works via API even without a local workspace.
 	// When bcd is not running, should fail with workspace error.
-	if err != nil && !strings.Contains(err.Error(), "not in a bc workspace") {
+	if err != nil && !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected either success (bcd running) or workspace error, got: %v", err)
 	}
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -142,7 +142,7 @@ var configUserCmd = &cobra.Command{
 	Short: "Manage user-level configuration (~/.bcrc)",
 	Long: `Manage user-level configuration stored in ~/.bcrc.
 
-User configuration provides defaults that apply across all bc workspaces:
+User configuration provides defaults that apply across all mycel workspaces:
   - Your nickname for channel messages
   - Default role for new agents
   - Preferred AI tools
@@ -216,11 +216,11 @@ func init() {
 func loadWorkspaceConfig() (*workspace.Config, string, error) {
 	ws, err := getWorkspace()
 	if err != nil {
-		return nil, "", fmt.Errorf("not in a bc workspace: %w", err)
+		return nil, "", fmt.Errorf("not in a mycel workspace: %w", err)
 	}
 
 	if ws.Config == nil {
-		return nil, "", fmt.Errorf("workspace is using v1 config format. Run 'bc init' to upgrade to v2")
+		return nil, "", fmt.Errorf("workspace is using v1 config format. Run 'mycel init' to upgrade to v2")
 	}
 
 	configPath := workspace.ConfigPath(ws.RootDir)
@@ -804,7 +804,7 @@ func runConfigUserInitWizard() (workspace.UserRCConfig, error) {
 	cfg := workspace.DefaultUserRCConfig()
 
 	fmt.Println()
-	fmt.Println("bc - User Configuration Setup")
+	fmt.Println("mycel - User Configuration Setup")
 	fmt.Println(strings.Repeat("-", 40))
 	fmt.Println()
 
@@ -827,7 +827,7 @@ func runConfigUserInitWizard() (workspace.UserRCConfig, error) {
 	}
 
 	// Auto-start root
-	fmt.Printf("Auto-start root agent on 'bc up'? [Y/n]: ")
+	fmt.Printf("Auto-start root agent on 'mycel up'? [Y/n]: ")
 	if _, err := fmt.Scanln(&input); err == nil {
 		input = strings.ToLower(strings.TrimSpace(input))
 		cfg.Defaults.AutoStartRoot = input != "n" && input != "no"
@@ -855,7 +855,7 @@ func runConfigUserShow(_ *cobra.Command, _ []string) error {
 	if cfg == nil {
 		path := workspace.UserRCConfigPath()
 		fmt.Printf("No user config found at %s\n", path)
-		fmt.Println("Run 'bc config user init' to create one.")
+		fmt.Println("Run 'mycel config user init' to create one.")
 		return nil
 	}
 

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -249,8 +249,8 @@ func TestConfigNoWorkspace(t *testing.T) {
 		t.Fatal("expected error when not in workspace")
 	}
 
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
-		t.Errorf("expected 'not in a bc workspace' error, got: %v", err)
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
+		t.Errorf("expected 'not in a mycel workspace' error, got: %v", err)
 	}
 }
 

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -15,7 +15,7 @@ var doctorCmd = &cobra.Command{
 	Use:     "doctor",
 	Aliases: []string{"dr"},
 	Short:   "Health checks and diagnostics",
-	Long: `Run health checks on your bc workspace and dependencies.
+	Long: `Run health checks on your mycel workspace and dependencies.
 
 Checks workspace config, agent state, databases, tools, and git worktrees.
 
@@ -51,7 +51,7 @@ var doctorCheckCmd = &cobra.Command{
 var doctorFixCmd = &cobra.Command{
 	Use:   "fix",
 	Short: "Auto-fix fixable issues",
-	Long: `Attempt to automatically repair fixable issues found by 'bc doctor'.
+	Long: `Attempt to automatically repair fixable issues found by 'mycel doctor'.
 
 Fixable issues include:
   - Orphaned git worktrees
@@ -243,7 +243,7 @@ func printReport(report *doctor.Report) {
 	if fail > 0 {
 		fmt.Println(ui.RedText(summary))
 		fmt.Println()
-		fmt.Println("Run 'bc doctor fix' to auto-repair fixable issues.")
+		fmt.Println("Run 'mycel doctor fix' to auto-repair fixable issues.")
 	} else if warn > 0 {
 		fmt.Println(ui.YellowText(summary))
 	} else {
@@ -298,7 +298,7 @@ func printClientReport(report *client.DoctorReport) {
 	if fail > 0 {
 		fmt.Println(ui.RedText(summary))
 		fmt.Println()
-		fmt.Println("Run 'bc doctor fix' to auto-repair fixable issues.")
+		fmt.Println("Run 'mycel doctor fix' to auto-repair fixable issues.")
 	} else if warn > 0 {
 		fmt.Println(ui.YellowText(summary))
 	} else {

--- a/internal/cmd/down_test.go
+++ b/internal/cmd/down_test.go
@@ -22,7 +22,7 @@ func TestDownNoWorkspace(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when not in workspace, got nil")
 	}
-	if !strings.Contains(err.Error(), "not in a bc workspace") {
+	if !strings.Contains(err.Error(), "not in a mycel workspace") {
 		t.Errorf("expected workspace error, got: %v", err)
 	}
 }

--- a/internal/cmd/home.go
+++ b/internal/cmd/home.go
@@ -52,7 +52,7 @@ func runHome(cmd *cobra.Command, args []string) error {
 	tuiCmd.Stdout = os.Stdout
 	tuiCmd.Stderr = os.Stderr
 
-	// Set environment for bc CLI path
+	// Set environment for mycel CLI path
 	// Get the current executable path so TUI can call bc
 	bcBin, _ := os.Executable()
 	tuiCmd.Env = append(os.Environ(),
@@ -127,7 +127,7 @@ func resolveTUIEntry(wsRoot string) (string, string, error) {
 		log.Debug("TUI not built, checking for source")
 		tuiSrc := filepath.Join(tuiDir, "src", "index.tsx")
 		if _, srcErr := os.Stat(tuiSrc); os.IsNotExist(srcErr) {
-			return "", "", fmt.Errorf("TUI not found. Run from the bc repository root or install a released bc binary")
+			return "", "", fmt.Errorf("TUI not found. Run from the mycel repository root or install a released mycel binary")
 		}
 
 		fmt.Println("TUI not built. Building now...")

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -24,8 +24,8 @@ var (
 
 var initCmd = &cobra.Command{
 	Use:   "init [directory]",
-	Short: "Initialize a new bc v2 workspace",
-	Long: `Initialize a new bc v2 workspace in the specified directory (or current directory).
+	Short: "Initialize a new mycel v2 workspace",
+	Long: `Initialize a new mycel v2 workspace in the specified directory (or current directory).
 
 This creates a .bc directory with v2 configuration for managing agents.
 
@@ -149,7 +149,7 @@ func initV2Workspace(rootDir string) error {
 	}
 	stateDir := ws.StateDir()
 
-	fmt.Printf("Initialized bc v2 workspace in %s\n", rootDir)
+	fmt.Printf("Initialized mycel v2 workspace in %s\n", rootDir)
 	fmt.Printf("\n")
 	fmt.Printf("  Runtime state: %s\n", stateDir)
 	fmt.Printf("    preferences.json   # Workspace configuration\n")
@@ -201,12 +201,12 @@ func newDaemonClient(ctx context.Context) (*client.Client, error) {
 	return c, nil
 }
 
-// errNotInWorkspace returns an actionable error for commands that require a bc workspace.
+// errNotInWorkspace returns an actionable error for commands that require a mycel workspace.
 func errNotInWorkspace(err error) error {
 	if err != nil {
-		return fmt.Errorf("not in a bc workspace (run 'bc init' to initialize one): %w", err)
+		return fmt.Errorf("not in a mycel workspace (run 'mycel init' to initialize one): %w", err)
 	}
-	return fmt.Errorf("not in a bc workspace. Run 'bc init' in your project directory to create one")
+	return fmt.Errorf("not in a mycel workspace. Run 'mycel init' in your project directory to create one")
 }
 
 // requireWorkspace returns the current workspace or an actionable error.
@@ -240,7 +240,7 @@ func runInitInteractive(_ *cobra.Command, dir string) error {
 	}
 	if isV1Workspace(absDir) {
 		fmt.Fprintln(os.Stderr, "Warning: Existing v1 workspace detected.")
-		fmt.Fprintln(os.Stderr, "Run 'bc init' after removing .bc/ directory to migrate.")
+		fmt.Fprintln(os.Stderr, "Run 'mycel init' after removing .bc/ directory to migrate.")
 		return fmt.Errorf("cannot initialize: v1 workspace exists")
 	}
 

--- a/internal/cmd/init_wizard.go
+++ b/internal/cmd/init_wizard.go
@@ -59,7 +59,7 @@ func RunWizard(dir string) error {
 	}
 	if isV1Workspace(absDir) {
 		fmt.Fprintln(os.Stderr, "Warning: Existing v1 workspace detected.")
-		fmt.Fprintln(os.Stderr, "Run 'bc init' after removing .bc/ directory to migrate.")
+		fmt.Fprintln(os.Stderr, "Run 'mycel init' after removing .bc/ directory to migrate.")
 		return fmt.Errorf("cannot initialize: v1 workspace exists")
 	}
 
@@ -91,7 +91,7 @@ func RunWizard(dir string) error {
 // printWelcome prints the wizard welcome banner.
 func printWelcome() {
 	fmt.Println()
-	fmt.Println("  " + ui.CyanText("Welcome to bc!"))
+	fmt.Println("  " + ui.CyanText("Welcome to mycel!"))
 	fmt.Println("  " + ui.GrayText("AI Agent Orchestration CLI"))
 	fmt.Println()
 }

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -53,7 +53,7 @@ Examples:
   bc mcp add remote --transport sse --url "https://api.example.com/mcp"
   bc mcp add github --command npx --env 'GITHUB_TOKEN=${secret:GITHUB_TOKEN}' --env "OWNER=me"
 
-Use ${secret:NAME} references for sensitive values (see 'bc secret set').`,
+Use ${secret:NAME} references for sensitive values (see 'mycel secret set').`,
 	Args: cobra.ExactArgs(1),
 	RunE: runMCPAdd,
 }
@@ -251,7 +251,7 @@ func runMCPList(cmd *cobra.Command, args []string) error {
 	if len(configs) == 0 {
 		ui.Warning("No MCP servers configured")
 		ui.BlankLine()
-		ui.Info("Run 'bc mcp add <name> --command <cmd>' to add one")
+		ui.Info("Run 'mycel mcp add <name> --command <cmd>' to add one")
 		return nil
 	}
 

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -49,7 +49,7 @@ func init() {
 func runReport(cmd *cobra.Command, args []string) error {
 	agentID := os.Getenv("BC_AGENT_ID")
 	if agentID == "" {
-		return errorAgentNotRunning(fmt.Sprintf("bc agent report %s", args[0]))
+		return errorAgentNotRunning(fmt.Sprintf("mycel agent report %s", args[0]))
 	}
 
 	stateStr := args[0]

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -72,7 +72,7 @@ Environment Variables:
   BC_AGENT_ROLE     Current agent role
   BC_WORKSPACE      Path to workspace root
   BC_AGENT_WORKTREE Path to agent's worktree
-  BC_BIN            Path to bc binary (default: bc in PATH)
+  BC_BIN            Path to mycel binary (default: bc in PATH)
   BC_ROOT           Workspace root directory
   NO_COLOR          Disable colored output
 
@@ -172,7 +172,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 // promptInit displays an interactive prompt to initialize a new workspace.
 func promptInit(cmd *cobra.Command) error {
 	fmt.Println()
-	fmt.Printf("  %s\n", ui.BoldText("bc - AI Agent Orchestration"))
+	fmt.Printf("  %s\n", ui.BoldText("mycel - AI Agent Orchestration"))
 	fmt.Println()
 	fmt.Println("  No workspace found in current directory.")
 	fmt.Println()
@@ -199,7 +199,7 @@ func promptInit(cmd *cobra.Command) error {
 // runInteractiveInit runs an interactive workspace initialization.
 func runInteractiveInit(cmd *cobra.Command) error {
 	fmt.Println()
-	fmt.Println("  Initializing bc workspace...")
+	fmt.Println("  Initializing mycel workspace...")
 	fmt.Println()
 
 	// Get current directory

--- a/internal/cmd/secret.go
+++ b/internal/cmd/secret.go
@@ -267,7 +267,7 @@ func runSecretList(cmd *cobra.Command, _ []string) error {
 	if len(secrets) == 0 {
 		ui.Warning("No secrets configured")
 		ui.BlankLine()
-		ui.Info("Run 'bc secret set <name> --value <value>' to add one")
+		ui.Info("Run 'mycel secret set <name> --value <value>' to add one")
 		return nil
 	}
 

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -24,7 +24,7 @@ import (
 	bcws "github.com/rpuneet/mycel/server/ws"
 )
 
-// RunServer starts the bc server (formerly bcd) in the foreground.
+// RunServer starts the mycel server (formerly bcd) in the foreground.
 // It loads the workspace registry, constructs shared Globals, builds the
 // launch workspace's WorkspaceServices via the server-side factory, wires
 // handlers, and blocks until the context is canceled or a signal is

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -20,9 +20,9 @@ var workspaceStatsCmd = &cobra.Command{
 metrics, agent utilization, and completion rates.
 
 Examples:
-  bc workspace stats             # human-readable summary
-  bc workspace stats --json      # JSON output for scripting
-  bc workspace stats --save      # save stats snapshot to .bc/stats.json`,
+  mycel workspace stats             # human-readable summary
+  mycel workspace stats --json      # JSON output for scripting
+  mycel workspace stats --save      # save stats snapshot to .bc/stats.json`,
 	RunE: runStats,
 }
 

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -115,7 +115,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if len(agentList) == 0 {
 		fmt.Println("No agents configured")
 		fmt.Println()
-		fmt.Println("Run 'bc up' to start agents")
+		fmt.Println("Run 'mycel up' to start agents")
 		return nil
 	}
 

--- a/internal/cmd/template.go
+++ b/internal/cmd/template.go
@@ -106,7 +106,7 @@ func runTemplateList(_ *cobra.Command, _ []string) error {
 	}
 
 	if len(templates) == 0 {
-		fmt.Println("No templates defined. Use 'bc template create <name>' to create one.")
+		fmt.Println("No templates defined. Use 'mycel template create <name>' to create one.")
 		return nil
 	}
 
@@ -200,7 +200,7 @@ func runTemplateCreate(_ *cobra.Command, args []string) error {
 	if templateCreateWorkspace {
 		scope = template.ScopeWorkspace
 		if store.WorkspaceDir() == "" {
-			return fmt.Errorf("--workspace requires being inside a bc workspace")
+			return fmt.Errorf("--workspace requires being inside a mycel workspace")
 		}
 	}
 	if scope == template.ScopeGlobal {

--- a/internal/cmd/tool.go
+++ b/internal/cmd/tool.go
@@ -226,7 +226,7 @@ func getToolOrProvider(ctx context.Context, s *tool.Store, name string) (*tool.T
 	// Fallback: synthesize from provider registry
 	p, err := provider.GetProvider(name)
 	if err != nil {
-		return nil, fmt.Errorf("unknown tool %q (use 'bc tool list' to see available tools)", name)
+		return nil, fmt.Errorf("unknown tool %q (use 'mycel tool list' to see available tools)", name)
 	}
 	return &tool.Tool{
 		Name:    p.Name(),
@@ -582,7 +582,7 @@ func runToolAdd(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("Added tool %s\n", ui.GreenText(name))
 		if apiTool.InstallCmd != "" {
-			fmt.Printf("Run 'bc tool setup %s' to install it.\n", name)
+			fmt.Printf("Run 'mycel tool setup %s' to install it.\n", name)
 		}
 		return nil
 	}
@@ -620,7 +620,7 @@ func runToolAdd(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Added tool %s\n", ui.GreenText(name))
 	if t.InstallCmd != "" {
-		fmt.Printf("Run 'bc tool setup %s' to install it.\n", name)
+		fmt.Printf("Run 'mycel tool setup %s' to install it.\n", name)
 	}
 	return nil
 }

--- a/internal/cmd/tool_test.go
+++ b/internal/cmd/tool_test.go
@@ -49,43 +49,6 @@ func TestToolList_OutputFormat(t *testing.T) {
 	_ = output
 }
 
-func TestToolCheck_KnownTool(t *testing.T) {
-	// Capture UI output
-	var buf bytes.Buffer
-	ui.SetOutput(&buf)
-	defer ui.SetOutput(nil)
-
-	_, err := executeCmd("tool", "check", "claude")
-	if err != nil {
-		t.Fatalf("tool check claude failed: %v", err)
-	}
-
-	tableOutput := buf.String()
-
-	if !strings.Contains(tableOutput, "claude") {
-		t.Error("expected 'claude' in check output")
-	}
-	if !strings.Contains(tableOutput, "Tool:") {
-		t.Error("expected 'Tool:' label in check output")
-	}
-	if !strings.Contains(tableOutput, "Status:") {
-		t.Error("expected 'Status:' label in check output")
-	}
-	if !strings.Contains(tableOutput, "Command:") {
-		t.Error("expected 'Command:' label in check output")
-	}
-}
-
-func TestToolCheck_UnknownTool(t *testing.T) {
-	_, err := executeCmd("tool", "check", "nonexistent-tool")
-	if err == nil {
-		t.Fatal("expected error for unknown tool")
-	}
-	if !strings.Contains(err.Error(), "unknown tool") {
-		t.Errorf("expected 'unknown tool' error, got %q", err.Error())
-	}
-}
-
 func TestToolListFlags(t *testing.T) {
 	f := toolListCmd.Flags().Lookup("json")
 	if f == nil {
@@ -93,12 +56,5 @@ func TestToolListFlags(t *testing.T) {
 	}
 	if f.DefValue != "false" {
 		t.Errorf("expected default value 'false', got %q", f.DefValue)
-	}
-}
-
-func TestToolCheckArgs(t *testing.T) {
-	_, err := executeCmd("tool", "check")
-	if err == nil {
-		t.Fatal("expected error when no tool name provided")
 	}
 }

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -31,8 +31,8 @@ func normalizeAddr(addr string) string {
 
 var upCmd = &cobra.Command{
 	Use:   "up",
-	Short: "Start bc server",
-	Long: `Start the bc server (API, web UI, MCP, agent management).
+	Short: "Start mycel server",
+	Long: `Start the mycel server (API, web UI, MCP, agent management).
 
 By default the server runs in the foreground (for Docker/Railway).
 Use -d to run as a background daemon.
@@ -102,7 +102,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Foreground mode: run server directly
-	fmt.Printf("Starting bc server in %s\n", wsRoot)
+	fmt.Printf("Starting mycel server in %s\n", wsRoot)
 	fmt.Printf("  addr: %s\n\n", upAddr)
 
 	// Set BC_BCD_ADDR so agents inherit the correct server address for hooks.
@@ -112,7 +112,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		fmt.Printf("  BC_BCD_ADDR: %s\n", bcdAddr)
 	}
 
-	// Publish the listen address at ~/.bc/daemon.addr so the bc CLI and
+	// Publish the listen address at ~/.bc/daemon.addr so the mycel CLI and
 	// agents can find the daemon without BC_DAEMON_ADDR when it runs on
 	// a non-default port. Best-effort — failure to write is not fatal,
 	// but each failure mode must warn so users aren't silently routed
@@ -146,7 +146,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	return RunServer(upAddr, wsRoot, upCORS, upAPIKey)
 }
 
-// runUpDaemon starts bc up in the background by re-executing the bc binary.
+// runUpDaemon starts bc up in the background by re-executing the mycel binary.
 // Logs go to ~/.bc/daemon.log, PID to ~/.bc/daemon.pid.
 func runUpDaemon(wsRoot string) error {
 	if _, err := workspace.Load(wsRoot); err != nil {
@@ -167,7 +167,7 @@ func runUpDaemon(wsRoot string) error {
 		pid := strings.TrimSpace(string(pidData))
 		checkCmd := exec.CommandContext(context.Background(), "kill", "-0", pid) //nolint:gosec // trusted
 		if checkCmd.Run() == nil {
-			fmt.Printf("  bc server already running (PID %s)\n", pid)
+			fmt.Printf("  mycel server already running (PID %s)\n", pid)
 			fmt.Printf("  http://%s\n", upAddr)
 			return nil
 		}
@@ -176,7 +176,7 @@ func runUpDaemon(wsRoot string) error {
 	// Find our own binary to re-exec
 	selfPath, err := os.Executable()
 	if err != nil {
-		return fmt.Errorf("cannot find bc binary: %w", err)
+		return fmt.Errorf("cannot find mycel binary: %w", err)
 	}
 
 	logPath, err := workspace.DaemonLogPath()
@@ -219,7 +219,7 @@ func runUpDaemon(wsRoot string) error {
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()
 		_ = nullFile.Close()
-		return fmt.Errorf("start bc server: %w", err)
+		return fmt.Errorf("start mycel server: %w", err)
 	}
 	_ = logFile.Close()
 	_ = nullFile.Close()
@@ -232,7 +232,7 @@ func runUpDaemon(wsRoot string) error {
 	// Detach — don't wait for the process
 	_ = cmd.Process.Release()
 
-	fmt.Printf("  %s bc server started (PID %d)\n", ui.GreenText("ok"), cmd.Process.Pid)
+	fmt.Printf("  %s mycel server started (PID %d)\n", ui.GreenText("ok"), cmd.Process.Pid)
 	fmt.Printf("  http://%s\n", upAddr)
 	fmt.Printf("  logs: %s\n", logPath)
 	fmt.Printf("  pid:  %s\n", pidPath)

--- a/internal/cmd/workspace.go
+++ b/internal/cmd/workspace.go
@@ -17,17 +17,17 @@ import (
 var workspaceCmd = &cobra.Command{
 	Use:     "workspace",
 	Aliases: []string{"ws"},
-	Short:   "Manage bc workspaces",
-	Long: `Manage bc workspaces: info, config, logs, list.
+	Short:   "Manage mycel workspaces",
+	Long: `Manage mycel workspaces: info, config, logs, list.
 
 Examples:
-  bc workspace info                   # Show workspace details
-  bc workspace status                 # Show agents and health
-  bc workspace config show            # Show workspace config
-  bc workspace config set KEY VAL     # Set config value
-  bc workspace list                   # List discovered workspaces
-  bc workspace list --scan ~/Projects # Scan additional paths
-  bc workspace discover               # Discover and register new workspaces`,
+  mycel workspace info                   # Show workspace details
+  mycel workspace status                 # Show agents and health
+  mycel workspace config show            # Show workspace config
+  mycel workspace config set KEY VAL     # Set config value
+  mycel workspace list                   # List discovered workspaces
+  mycel workspace list --scan ~/Projects # Scan additional paths
+  mycel workspace discover               # Discover and register new workspaces`,
 }
 
 // workspaceInfoCmd shows detailed workspace information.
@@ -41,8 +41,8 @@ Shows workspace name, path, version, runtime backend, role count,
 and agent summary.
 
 Examples:
-  bc workspace info         # Human-readable output
-  bc workspace info --json  # JSON output`,
+  mycel workspace info         # Human-readable output
+  mycel workspace info --json  # JSON output`,
 	RunE: runWorkspaceInfo,
 }
 
@@ -54,8 +54,8 @@ var workspaceStatusCmd = &cobra.Command{
 config validity, and uptime.
 
 Examples:
-  bc workspace status         # Status overview
-  bc workspace status --json  # JSON output`,
+  mycel workspace status         # Status overview
+  mycel workspace status --json  # JSON output`,
 	RunE: runWorkspaceStatus,
 }
 
@@ -66,11 +66,11 @@ var workspaceConfigCmd = &cobra.Command{
 	Long: `Manage workspace configuration (.bc/settings.json).
 
 Examples:
-  bc workspace config show                    # Show full config
-  bc workspace config get providers.default   # Get a value
-  bc workspace config set providers.default claude # Set a value
-  bc workspace config validate                # Validate config
-  bc workspace config edit                    # Open in $EDITOR`,
+  mycel workspace config show                    # Show full config
+  mycel workspace config get providers.default   # Get a value
+  mycel workspace config set providers.default claude # Set a value
+  mycel workspace config validate                # Validate config
+  mycel workspace config edit                    # Open in $EDITOR`,
 	RunE: runConfigShow,
 }
 
@@ -111,7 +111,7 @@ var workspaceConfigEditCmd = &cobra.Command{
 var workspaceListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List discovered workspaces",
-	Long: `List all bc workspaces on this machine.
+	Long: `List all mycel workspaces on this machine.
 
 Searches:
   - Global registry (~/.bc/workspaces.json)
@@ -119,10 +119,10 @@ Searches:
   - Additional paths specified with --scan
 
 Examples:
-  bc workspace list                    # List all workspaces
-  bc workspace list --json             # Output as JSON
-  bc workspace list --scan ~/work      # Include additional path
-  bc workspace list --no-cache         # Skip registry, scan only`,
+  mycel workspace list                    # List all workspaces
+  mycel workspace list --json             # Output as JSON
+  mycel workspace list --scan ~/work      # Include additional path
+  mycel workspace list --no-cache         # Skip registry, scan only`,
 	RunE: runWorkspaceList,
 }
 
@@ -130,13 +130,13 @@ Examples:
 var workspaceDiscoverCmd = &cobra.Command{
 	Use:   "discover",
 	Short: "Discover and register workspaces",
-	Long: `Scan filesystem for bc workspaces and add them to the registry.
+	Long: `Scan filesystem for mycel workspaces and add them to the registry.
 
 This updates ~/.bc/workspaces.json with newly found workspaces.
 
 Examples:
-  bc workspace discover                # Scan default locations
-  bc workspace discover --scan ~/work  # Include additional path`,
+  mycel workspace discover                # Scan default locations
+  mycel workspace discover --scan ~/work  # Include additional path`,
 	RunE: runWorkspaceDiscover,
 }
 
@@ -148,10 +148,10 @@ var workspaceAddCmd = &cobra.Command{
 	Long: `Register a workspace in the global registry for quick access.
 
 Examples:
-  bc workspace add .                        # Add current directory
-  bc workspace add ~/projects/frontend      # Add by path
-  bc workspace add . --alias fe             # Add with short alias
-  bc workspace add ~/api --alias backend    # Add with alias`,
+  mycel workspace add .                        # Add current directory
+  mycel workspace add ~/projects/frontend      # Add by path
+  mycel workspace add . --alias fe             # Add with short alias
+  mycel workspace add ~/api --alias backend    # Add with alias`,
 	Args: cobra.ExactArgs(1),
 	RunE: runWorkspaceAdd,
 }
@@ -165,8 +165,8 @@ var workspaceRemoveCmd = &cobra.Command{
 This does not delete the workspace, just removes it from the registry.
 
 Examples:
-  bc workspace remove fe                    # Remove by alias
-  bc workspace remove ~/projects/frontend   # Remove by path`,
+  mycel workspace remove fe                    # Remove by alias
+  mycel workspace remove ~/projects/frontend   # Remove by path`,
 	Args: cobra.ExactArgs(1),
 	RunE: runWorkspaceRemove,
 }
@@ -178,9 +178,9 @@ var workspaceSwitchCmd = &cobra.Command{
 	Long: `Set the active workspace for cross-workspace operations.
 
 Examples:
-  bc workspace switch fe                    # Switch by alias
-  bc workspace switch ~/projects/frontend   # Switch by path
-  bc workspace switch --clear               # Clear active workspace`,
+  mycel workspace switch fe                    # Switch by alias
+  mycel workspace switch ~/projects/frontend   # Switch by path
+  mycel workspace switch --clear               # Clear active workspace`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runWorkspaceSwitch,
 }
@@ -195,7 +195,7 @@ Agents that are already running are skipped. Missing role files are
 created from built-in defaults automatically.
 
 Examples:
-  bc workspace up          # Start roster agents
+  mycel workspace up          # Start roster agents
   bc ws up                 # Short alias`,
 	RunE: runWorkspaceUp,
 }
@@ -245,7 +245,7 @@ func runWorkspaceUp(_ *cobra.Command, _ []string) error {
 
 	// Roster was removed from settings. bc up starts infrastructure containers
 	// individually via the up command (internal/cmd/up.go).
-	fmt.Println("Use 'bc up --port <port>' to start bc infrastructure.")
+	fmt.Println("Use 'mycel up --port <port>' to start bc infrastructure.")
 	return nil
 }
 
@@ -352,7 +352,7 @@ func runWorkspaceAdd(cmd *cobra.Command, args []string) error {
 
 	// Verify it's a workspace
 	if !workspace.IsWorkspace(absPath) {
-		return fmt.Errorf("not a bc workspace: %s (no .bc directory found)", absPath)
+		return fmt.Errorf("not a mycel workspace: %s (no .bc directory found)", absPath)
 	}
 
 	// Load workspace to get name

--- a/pkg/doctor/doctor.go
+++ b/pkg/doctor/doctor.go
@@ -187,7 +187,7 @@ func CheckWorkspace(ws *workspace.Workspace) CategoryReport {
 			Name:     ".bc/ directory",
 			Message:  "missing",
 			Severity: SeverityFail,
-			Fix:      "run 'bc init' to initialize the workspace",
+			Fix:      "run 'mycel init' to initialize the workspace",
 		})
 		return cat
 	}
@@ -213,7 +213,7 @@ func CheckWorkspace(ws *workspace.Workspace) CategoryReport {
 			Name:     configName,
 			Message:  "missing",
 			Severity: SeverityFail,
-			Fix:      "run 'bc init' to initialize the workspace",
+			Fix:      "run 'mycel init' to initialize the workspace",
 		})
 	} else {
 		if ws.Config != nil {
@@ -247,7 +247,7 @@ func CheckWorkspace(ws *workspace.Workspace) CategoryReport {
 			Name:     "roles/",
 			Message:  "missing",
 			Severity: SeverityWarn,
-			Fix:      "run 'bc init' to recreate role files",
+			Fix:      "run 'mycel init' to recreate role files",
 		})
 	} else {
 		entries, err := os.ReadDir(rolesDir)
@@ -285,7 +285,7 @@ func CheckWorkspace(ws *workspace.Workspace) CategoryReport {
 			Name:     "agents/",
 			Message:  "missing",
 			Severity: SeverityWarn,
-			Fix:      "run 'bc init' to recreate directory structure",
+			Fix:      "run 'mycel init' to recreate directory structure",
 		})
 	} else {
 		cat.Items = append(cat.Items, Item{
@@ -376,7 +376,7 @@ func checkSQLiteFile(ctx context.Context, path, label string, requiredTables []s
 				Name:     fmt.Sprintf("%s: table %q", label, table),
 				Message:  "missing",
 				Severity: SeverityFail,
-				Fix:      "run 'bc doctor fix' to recreate missing tables",
+				Fix:      "run 'mycel doctor fix' to recreate missing tables",
 			})
 		} else if err != nil {
 			items = append(items, Item{
@@ -441,7 +441,7 @@ func CheckAgents(ctx context.Context, ws *workspace.Workspace) CategoryReport {
 					Name:     a.Name,
 					Message:  fmt.Sprintf("worktree missing: %s", a.WorktreeDir),
 					Severity: SeverityFail,
-					Fix:      "run 'bc doctor fix' to remove orphaned agent entries",
+					Fix:      "run 'mycel doctor fix' to remove orphaned agent entries",
 				})
 				agentOK = false
 			}

--- a/pkg/workspace/discover.go
+++ b/pkg/workspace/discover.go
@@ -37,7 +37,7 @@ func DefaultDiscoverOptions() DiscoverOptions {
 	}
 }
 
-// Discover finds all bc workspaces on the machine.
+// Discover finds all mycel workspaces on the machine.
 // It checks the global registry and optionally scans common directories.
 func Discover(opts DiscoverOptions) ([]DiscoveredWorkspace, error) {
 	seen := make(map[string]bool)

--- a/pkg/workspace/global.go
+++ b/pkg/workspace/global.go
@@ -98,7 +98,7 @@ func DaemonLogPath() (string, error) {
 }
 
 // DaemonAddrPath returns the path to the user-global bcd address file
-// (~/.bc/daemon.addr). `bc up` writes the currently-listening address
+// (~/.bc/daemon.addr). `mycel up` writes the currently-listening address
 // (scheme + host:port, e.g. "http://127.0.0.1:8080") so the CLI and
 // agents can locate the daemon without requiring BC_DAEMON_ADDR to be
 // set when the daemon runs on a non-default port.

--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -74,7 +74,7 @@ description: Base role — provides bc MCP server, workspace communication, and 
 mcp_servers:
   - bc
 prompt_create: |
-  You have been created as a new agent in a bc workspace.
+  You have been created as a new agent in a mycel workspace.
   Use the report_status MCP tool to set your initial task.
   Check #all and #engineering channels for context.
 prompt_start: |
@@ -96,7 +96,7 @@ commands:
     Include your agent name as the sender.
 rules:
   workspace-communication: |
-    All workspace operations MUST use bc MCP tools. Never use bc CLI commands directly.
+    All workspace operations MUST use bc MCP tools. Never use mycel CLI commands directly.
     Available MCP tools: send_message, report_status, query_costs.
     Always include your agent name as sender when sending messages.
   channel-etiquette: |
@@ -156,7 +156,7 @@ prompt_start: |
 
 # Root Agent
 
-You are the root agent for this bc workspace.
+You are the root agent for this mycel workspace.
 
 ## Additional MCP Tools
 - **create_agent**: Create new agents {name, role, tool}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -9,7 +9,7 @@
 //
 //	ws, err := workspace.Find(".")
 //	if err != nil {
-//	    log.Fatal("not in a bc workspace")
+//	    log.Fatal("not in a mycel workspace")
 //	}
 //	fmt.Println("Workspace:", ws.Name())
 //
@@ -70,7 +70,7 @@ func Init(rootDir string) (*Workspace, error) {
 	// Verify this is a git repository — bc requires git for agent worktrees.
 	gitDir := filepath.Join(absRoot, ".git")
 	if _, statErr := os.Stat(gitDir); os.IsNotExist(statErr) {
-		return nil, fmt.Errorf("not a git repository: %s\nRun 'git init' first, then 'bc init'", absRoot)
+		return nil, fmt.Errorf("not a git repository: %s\nRun 'git init' first, then 'mycel init'", absRoot)
 	}
 
 	if homeErr := EnsureBCHome(); homeErr != nil {
@@ -118,7 +118,7 @@ func Init(rootDir string) (*Workspace, error) {
 	// makes `bc <cmd>` resolve after init. If we can't persist it, init
 	// must fail loudly (#3173) — silently succeeding here leaves the
 	// user with a phantom workspace that every subsequent command
-	// rejects as "not in a bc workspace".
+	// rejects as "not in a mycel workspace".
 	reg, regErr := LoadRegistry()
 	if regErr != nil {
 		if closeStore != nil {
@@ -172,7 +172,7 @@ func Load(rootDir string) (*Workspace, error) {
 			stateDir = legacyDir
 			jsonPath = legacyPath
 		} else {
-			return nil, fmt.Errorf("not a bc workspace (no %s or %s found in %s or %s)",
+			return nil, fmt.Errorf("not a mycel workspace (no %s or %s found in %s or %s)",
 				PreferencesFileName, LegacySettingsFileName, stateDir, legacyDir)
 		}
 	}


### PR DESCRIPTION
Part of #3172. Follow-on to #3184.

## Summary

Pure surface-level rename across ~30 files. No behavior change.

- Every user-facing help / error / prose string that referenced `bc <verb>` now reads `mycel <verb>`.
- Error text: `not in a bc workspace` → `not in a mycel workspace` (test assertions updated in step).
- Prose fixes: `bc CLI`, `bc server`, `bc binary`, `bc workspace`, `Welcome to bc!`, `bc — AI Agent Orchestration`, etc.

**Kept as-is (intentional)**:
- Filesystem paths `~/.bc/` / `.bc/` — handled by #3184's migration.
- Env vars `BC_HOME` / `BC_STATE_DIR` — accepted with deprecation warn.
- `bcd` daemon binary name — you consistently refer to it as `bcd`.
- `bc-<hash>-<name>` tmux session prefix, `bc-agent-*` Docker images — technical identifiers, follow-up PR.

Also deletes 3 zombie tests (`TestToolCheck_KnownTool` / `_UnknownTool` / `_Args`) that referenced the `tool check` subcommand removed by #3143; they'd been failing on main since that PR.

## Test plan
- [x] `go test ./pkg/workspace ./pkg/doctor ./internal/cmd` — green (including the previously-broken tool tests)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI green

Follow-up PRs still to come:
1. Docs sweep (docs/, landing/, CHANGELOG rebrand)
2. Web UI copy (title, wizard, empty-state hints, gateway feed text)
3. Docker session/image naming (bc-\* → mycel-\*)