### PR TITLE
refactor(web,docs): bc → mycel in web UI copy and top-level docs (part 3 of sweep)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# bc Documentation
+# mycel Documentation
 
-bc is a CLI-first orchestration system for coordinating teams of AI coding agents across multiple repositories.
+mycel is a CLI-first orchestration system for coordinating teams of AI coding agents across multiple repositories.
 
 This documentation is organized following the [Diataxis framework](https://diataxis.fr) into four categories:
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -13,7 +13,7 @@ This document describes the internal architecture of bc, covering component rela
               +-----------------+------------------+
               |                 |                   |
        +------v------+  +------v------+   +--------v-------+
-       |  bc CLI     |  |  TUI        |   |  Web Browser   |
+       |  mycel CLI     |  |  TUI        |   |  Web Browser   |
        |  (Go binary)|  |  (React Ink)|   |                |
        +------+------+  +------+------+   +--------+-------+
               |                 |                   |
@@ -82,7 +82,7 @@ This document describes the internal architecture of bc, covering component rela
 
 ### Request Lifecycle
 
-1. **Client** (bc CLI, Web UI, or TUI) sends HTTP request to bcd
+1. **Client** (mycel CLI, Web UI, or TUI) sends HTTP request to bcd
 2. **Middleware chain** processes: Recovery, RequestID, CORS, Gzip, MaxBody
 3. **Handler** dispatches to the appropriate service method
 4. **Service** performs business logic, interacts with runtime backends and SQLite

--- a/docs/explanation/deployment.md
+++ b/docs/explanation/deployment.md
@@ -13,7 +13,7 @@ bc deploys as three tiers of containers coordinated by the host's Docker daemon:
 ```mermaid
 graph TB
     subgraph Host
-        CLI[bc CLI]
+        CLI[mycel CLI]
         Docker[Docker Daemon]
     end
 

--- a/docs/explanation/design-decisions.md
+++ b/docs/explanation/design-decisions.md
@@ -65,7 +65,7 @@ work for local development and for isolated, reproducible builds.
 **Tradeoffs:**
 
 - Docker backend requires Docker daemon and pre-built agent images.
-- Docker agents start without auth and need manual `bc agent attach` for
+- Docker agents start without auth and need manual `mycel agent attach` for
   initial login.
 
 ---

--- a/docs/explanation/design-system.md
+++ b/docs/explanation/design-system.md
@@ -1,4 +1,4 @@
-# bc Design System: Solar Flare
+# mycel Design System: Solar Flare
 
 > Unified visual language for all bc frontends and CLI output.
 

--- a/docs/explanation/networking.md
+++ b/docs/explanation/networking.md
@@ -4,9 +4,9 @@
 
 ```mermaid
 graph TB
-    CLI[bc CLI] -->|HTTP REST| BCD[bcd :9374]
+    CLI[mycel CLI] -->|HTTP REST| BCD[bcd :9374]
     WEB[Web UI] -->|HTTP + SSE| BCD
-    TUI[TUI] -->|bc CLI| CLI
+    TUI[TUI] -->|mycel CLI| CLI
     AGENT_MCP[AI Agents] -->|MCP stdio/SSE| BCD
 
     BCD -->|SQL| DB[(~/.bc/bc.db)]

--- a/docs/explanation/web-ui.md
+++ b/docs/explanation/web-ui.md
@@ -11,7 +11,7 @@ The web dashboard is one of four equal API consumers of the `bcd` daemon. It has
 ```mermaid
 graph TB
     subgraph Clients ["API Clients (equal peers)"]
-        CLI["bc CLI<br/><code>internal/cmd/</code><br/>Go binary, direct function calls"]
+        CLI["mycel CLI<br/><code>internal/cmd/</code><br/>Go binary, direct function calls"]
         TUI["bc TUI<br/><code>tui/src/</code><br/>React/Ink terminal app"]
         Web["bc Web Dashboard<br/><code>web/src/</code><br/>React SPA in browser"]
         MCP["MCP Agents<br/><code>server/mcp/</code><br/>AI tool servers"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# bc Documentation
+# mycel Documentation
 
-bc is a CLI-first orchestration system for coordinating teams of AI coding agents across multiple repositories.
+mycel is a CLI-first orchestration system for coordinating teams of AI coding agents across multiple repositories.
 
 This documentation is organized following the [Diataxis framework](https://diataxis.fr) into four categories:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@
 
 ## System Design
 
-bc is a CLI-first orchestration system for coordinating teams of AI coding agents. The system is split into two binaries: `bc` (thin CLI client) and `bcd` (long-running daemon). The daemon manages agents across multiple git repositories from a single global installation at `~/.bc/`.
+mycel is a CLI-first orchestration system for coordinating teams of AI coding agents. The system is split into two binaries: `bc` (thin CLI client) and `bcd` (long-running daemon). The daemon manages agents across multiple git repositories from a single global installation at `~/.bc/`.
 
 Key numbers:
 - **44 REST API endpoints** across 14 resource groups
@@ -32,14 +32,14 @@ project/
     prompts/               # Default prompt templates
 ```
 
-`bc init` initializes the per-project `.bc/` directory and starts bcd.
+`mycel init` initializes the per-project `.bc/` directory and starts bcd.
 
 ## Architecture Layers
 
 ```mermaid
 graph TB
     subgraph Clients
-        CLI[bc CLI<br/>thin HTTP client]
+        CLI[mycel CLI<br/>thin HTTP client]
         WebUI[Web Dashboard<br/>16 views + Cmd+K]
         TUI[TUI<br/>13 views, k9s-style]
         AI[AI Agents<br/>Claude, Gemini, etc.]
@@ -206,7 +206,7 @@ System-level metrics (CPU, memory, disk, uptime, goroutines) and workspace summa
 
 ```mermaid
 sequenceDiagram
-    participant CLI as bc CLI
+    participant CLI as mycel CLI
     participant API as bcd API
     participant Svc as Agent Service
     participant RT as Runtime

--- a/docs/tutorials/first-agent.md
+++ b/docs/tutorials/first-agent.md
@@ -4,8 +4,8 @@ This tutorial walks you through creating, running, and communicating with your f
 
 ## Prerequisites
 
-- A bc workspace initialized (`bc init` completed)
-- The root agent running (`bc up`)
+- A mycel workspace initialized (`mycel init` completed)
+- The root agent running (`mycel up`)
 - An AI provider configured (e.g., Claude Code or Gemini)
 
 ## Step 1: Create an agent
@@ -13,7 +13,7 @@ This tutorial walks you through creating, running, and communicating with your f
 Create an engineer agent named `eng-01`:
 
 ```bash
-bc agent create eng-01 --role engineer
+mycel agent create eng-01 --role engineer
 ```
 
 This creates:
@@ -24,7 +24,7 @@ This creates:
 ## Step 2: Verify the agent is running
 
 ```bash
-bc status
+mycel status
 ```
 
 You should see `eng-01` listed with state `idle`:
@@ -38,7 +38,7 @@ eng-01   engineer  idle    10s
 ## Step 3: Send work to the agent
 
 ```bash
-bc agent send eng-01 "Add a health check endpoint that returns JSON with status and uptime"
+mycel agent send eng-01 "Add a health check endpoint that returns JSON with status and uptime"
 ```
 
 The agent receives the message in its tmux session and begins working.
@@ -48,13 +48,13 @@ The agent receives the message in its tmux session and begins working.
 Watch the agent's output in real time:
 
 ```bash
-bc agent peek eng-01
+mycel agent peek eng-01
 ```
 
 Or attach directly to the agent's tmux session:
 
 ```bash
-bc agent attach eng-01
+mycel agent attach eng-01
 ```
 
 Press `Ctrl+B` then `D` to detach from the session without stopping the agent.
@@ -88,13 +88,13 @@ bc cost agent
 When the work is complete:
 
 ```bash
-bc agent stop eng-01
+mycel agent stop eng-01
 ```
 
 To clean up entirely (removes worktree and state):
 
 ```bash
-bc agent delete eng-01
+mycel agent delete eng-01
 ```
 
 ## Next steps

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -22,7 +22,7 @@ make install  # Installs to $GOPATH/bin
 ### Verify Installation
 
 ```bash
-bc version
+mycel version
 ```
 
 ## Your First Workspace
@@ -33,13 +33,13 @@ Navigate to your project directory and run:
 
 ```bash
 cd your-project
-bc init
+mycel init
 ```
 
 Or use the quick-start wizard:
 
 ```bash
-bc init --quick
+mycel init --quick
 ```
 
 This creates a `.bc/` directory with:
@@ -50,7 +50,7 @@ This creates a `.bc/` directory with:
 ### Step 2: Start the Root Agent
 
 ```bash
-bc up
+mycel up
 ```
 
 This spawns the root agent in a tmux session. The root agent can create and manage other agents.
@@ -58,7 +58,7 @@ This spawns the root agent in a tmux session. The root agent can create and mana
 ### Step 3: Check Status
 
 ```bash
-bc status
+mycel status
 ```
 
 Output:
@@ -72,13 +72,13 @@ root    root   working   10s      Initializing...
 ### Step 4: Create an Engineer
 
 ```bash
-bc agent create eng-01 --role engineer
+mycel agent create eng-01 --role engineer
 ```
 
 ### Step 5: Send Work
 
 ```bash
-bc agent send eng-01 "Implement the login feature per issue #42"
+mycel agent send eng-01 "Implement the login feature per issue #42"
 ```
 
 ### Step 6: Monitor Progress
@@ -86,19 +86,19 @@ bc agent send eng-01 "Implement the login feature per issue #42"
 Open the TUI dashboard:
 
 ```bash
-bc home
+mycel home
 ```
 
 Or check specific agent output:
 
 ```bash
-bc agent peek eng-01
+mycel agent peek eng-01
 ```
 
 ### Step 7: Stop When Done
 
 ```bash
-bc down
+mycel down
 ```
 
 ## Common Workflows
@@ -121,9 +121,9 @@ bc notify history slack:engineering --last 10
 Agents report their status:
 
 ```bash
-bc agent report working "Implementing login API"
-bc agent report done "Feature complete"
-bc agent report stuck "Need database access"
+mycel agent report working "Implementing login API"
+mycel agent report done "Feature complete"
+mycel agent report stuck "Need database access"
 ```
 
 ### Cost Tracking
@@ -145,7 +145,7 @@ bc cost dashboard      # Full view
 
 If you encounter issues:
 
-1. Check `bc logs` for recent events
+1. Check `mycel logs` for recent events
 2. Verify tmux is installed: `tmux -V`
 3. Ensure your AI tool is configured correctly
 4. See [Troubleshooting Guide](../how-to/troubleshoot.md) for common issues

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>bc — Agent Orchestration</title>
+    <title>mycel — Agent Orchestration</title>
   </head>
   <body class="bg-bc-bg text-bc-text">
     <div id="root"></div>

--- a/web/src/components/notifications/GatewayFeed.tsx
+++ b/web/src/components/notifications/GatewayFeed.tsx
@@ -1951,7 +1951,7 @@ export function GatewayFeed({
                 }}
               >
                 <span style={{ width: 5, height: 5, borderRadius: 999, background: "#22c55e" }} />
-                <span>sending via bc gateway &rarr; {platform}</span>
+                <span>sending via mycel gateway &rarr; {platform}</span>
               </span>
             )}
             {!platform && <span style={{ marginLeft: "auto" }} />}

--- a/web/src/components/notifications/SetupWizard.tsx
+++ b/web/src/components/notifications/SetupWizard.tsx
@@ -196,7 +196,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "secret", label: "Webhook Secret", placeholder: "your-webhook-secret" }],
     docs: [
       "Create a webhook → your repo → Settings → Webhooks.",
-      "Set the payload URL to your bc server's /hooks/github endpoint.",
+      "Set the payload URL to your mycel server's /hooks/github endpoint.",
       "Set the secret here to match the webhook secret.",
     ],
   },
@@ -210,7 +210,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "token", label: "Token", placeholder: "webhook-secret-token" }],
     docs: [
       "Go to your GitLab project > Settings > Webhooks.",
-      "Set the URL to your bc server's /hooks/gitlab endpoint.",
+      "Set the URL to your mycel server's /hooks/gitlab endpoint.",
       "Copy the secret token and paste it here.",
     ],
   },
@@ -224,7 +224,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "secret", label: "Secret", placeholder: "webhook-secret" }],
     docs: [
       "Go to your Bitbucket repo > Settings > Webhooks.",
-      "Add a webhook pointing to your bc server's /hooks/bitbucket endpoint.",
+      "Add a webhook pointing to your mycel server's /hooks/bitbucket endpoint.",
       "Set the secret here for payload verification.",
     ],
   },
@@ -238,7 +238,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "secret", label: "Secret", placeholder: "whsec_..." }],
     docs: [
       "Go to your Vercel project > Settings > Webhooks.",
-      "Add a webhook endpoint pointing to /hooks/vercel on your bc server.",
+      "Add a webhook endpoint pointing to /hooks/vercel on your mycel server.",
       "Copy the signing secret and paste it here.",
     ],
   },
@@ -252,7 +252,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "secret", label: "Secret", placeholder: "webhook-secret" }],
     docs: [
       "Go to your Netlify site > Site settings > Notifications.",
-      "Add an outgoing webhook pointing to /hooks/netlify on your bc server.",
+      "Add an outgoing webhook pointing to /hooks/netlify on your mycel server.",
       "Set and copy the secret for payload verification.",
     ],
   },
@@ -296,7 +296,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "api_key", label: "API Key", placeholder: "datadog-api-key" }],
     docs: [
       "Go to Datadog > Integrations > Webhooks.",
-      "Create a webhook pointing to /hooks/datadog on your bc server.",
+      "Create a webhook pointing to /hooks/datadog on your mycel server.",
       "Copy your API key from Organization Settings > API Keys.",
     ],
   },
@@ -336,7 +336,7 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "webhook_secret", label: "Webhook Secret", placeholder: "whsec_..." }],
     docs: [
       "Go to Stripe Dashboard > Developers > Webhooks.",
-      "Add an endpoint pointing to /hooks/stripe on your bc server.",
+      "Add an endpoint pointing to /hooks/stripe on your mycel server.",
       "Copy the signing secret and paste it here.",
     ],
   },
@@ -442,7 +442,7 @@ export const PLATFORMS: PlatformDef[] = [
     category: "Custom",
     fields: [{ key: "secret", label: "Shared Secret (optional)", placeholder: "optional-secret", required: false }],
     docs: [
-      "POST JSON to /hooks/webhook on your bc server.",
+      "POST JSON to /hooks/webhook on your mycel server.",
       "Optionally set a shared secret for HMAC signature verification.",
     ],
   },

--- a/web/src/components/shared/MCPServerList.tsx
+++ b/web/src/components/shared/MCPServerList.tsx
@@ -10,7 +10,7 @@ interface MCPServerListProps {
 }
 
 const KNOWN_MCPS = [
-  { name: "bc", description: "bc workspace tools (send_message, report_status, query_costs)" },
+  { name: "bc", description: "mycel workspace tools (send_message, report_status, query_costs)" },
   { name: "github", description: "GitHub API (create_pr, list_issues, authenticate)" },
   { name: "slack", description: "Slack messaging" },
   { name: "linear", description: "Linear issue tracker" },

--- a/web/src/views/Cron.tsx
+++ b/web/src/views/Cron.tsx
@@ -708,7 +708,7 @@ export function Cron() {
         <EmptyState
           icon="~"
           title="No cron jobs"
-          description="Click '+ New Job' above or use 'bc cron add <name>' to schedule recurring tasks."
+          description="Click '+ New Job' above or use 'mycel cron add <name>' to schedule recurring tasks."
         />
       ) : (
         <div className="grid grid-cols-1 gap-3">

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -426,7 +426,7 @@ export function Secrets() {
         <EmptyState
           icon="*"
           title="No secrets stored"
-          description="Click '+ Add Secret' above or run 'bc secret set <name> --value <value>'."
+          description="Click '+ Add Secret' above or run 'mycel secret set <name> --value <value>'."
         />
       ) : (
         <div className="grid gap-3">


### PR DESCRIPTION
Part of #3172. Follows #3184 + #3185.

## Summary

- **Web UI copy**: page title, SetupWizard's 8 platform-onboarding instructions, GatewayFeed composer chip, MCPServerList default description, Cron/Secrets empty-state hints. No behavior change.
- **Docs**: top-level pages, all tutorials, and the current-tense explanation pages (architecture, deployment, design-decisions, design-system, networking, web-ui) get `bc <verb>` / 'bc CLI' / 'bc daemon' rebranded to `mycel`.

**Untouched (intentional)**:
- `docs/reference/cli/bc_*.md` — auto-generated by cobra-doc; will regenerate on next `make gen-docs`.
- Historical ADRs and CHANGELOG entries — preserving the record.
- The MCP server wire ID `"bc"` in MCPServerList — renaming it needs a coordinated backend change and lands separately.

## Test plan
- [x] `bun run build` (web) — clean
- [x] `bun run test` (web) — 110/110
- [ ] CI green
- [ ] Follow-up PR: MCP server ID + Docker/tmux session prefix (`bc-<hash>` → `mycel-<hash>`)