### PR TITLE
docs(changelog): document bc → mycel sweep in v0.3.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2026-07-02
 
+### Renamed
+- **State root**: `~/.bc/` → `~/.mycel/`. Existing installs are migrated silently on the first invocation of any `mycel` command — no user action required. `~/.bc/` still resolves as a read-only fallback if the migration cannot run (permissions, etc.), so no state is silently lost (#3184).
+- **Environment variables**: `MYCEL_HOME` / `MYCEL_STATE_DIR` are canonical. `BC_HOME` / `BC_STATE_DIR` are still honored, with a deprecation warn.
+- **User-facing CLI copy**: every help / error / example string that referenced `bc <verb>` is now `mycel <verb>`; `bc CLI` / `bc server` / `bc daemon` prose rebranded (#3185).
+- **Web UI + docs**: page title, SetupWizard onboarding steps, GatewayFeed composer chip, MCPServerList description, top-level docs, tutorials, and current-tense explanation pages all say "mycel" (#3186).
+- Deferred to v0.3.1: `bc-agent-*` Docker image names and `bc-<hash>-<name>` tmux session prefix — both need coordinated backward-compat migration (#3187).
+
 ### Added
 - **Pi provider** — new agent tool option, wired end-to-end (backend + web modal) (#3135).
 - **About page** (`/about`) — installed version, dist-channel availability, live daemon health checks (#3137).
@@ -22,20 +29,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Landing `/pricing` and `/waitlist` now render `Nav` + `Footer` (#3078, #3167).
 
 ### Fixed
-- Fresh install + `bc init` followed by any command errored with "not in a bc workspace". `workspace.Init` now surfaces registry-save errors instead of swallowing them, and `workspace.Find` self-heals by probing `~/.bc/workspaces/<id>/preferences.json` for the walked directory (#3173).
+- Fresh install + `mycel init` followed by any command errored with "not in a mycel workspace". `workspace.Init` now surfaces registry-save errors instead of swallowing them, and `workspace.Find` self-heals by probing `~/.mycel/workspaces/<id>/preferences.json` for the walked directory (#3173).
 - Inter-agent DMs silently no-op'd — `POST /api/agents/{name}/send` now uses `DisallowUnknownFields` and rejects empty message bodies with 400 instead of typing an empty string into the target session (#3174).
 - Agent state wedged at `starting` — `AgentService.Send` now reconciles both `stopped` and `starting` when a live session is detected (#3175).
 - Agent env vars silently dropped — `EnvFile` column was never persisted to SQLite, so `${secret:NAME}` refs (including AWS Bedrock keys) failed to load. Re-save env from the UI/API after upgrading to recover (#3136).
 - Provider command override was dead code — `agent.Start` now actually reads `wsCfg.GetProvider(toolName).Command` (#3141, #3147).
-- `go install github.com/rpuneet/mycel/cmd/bc` was broken because `//go:embed web/dist` had nothing to embed on a fresh checkout. Track `server/web/dist/placeholder.txt` in git (#3036, #3165).
+- `go install github.com/rpuneet/mycel/cmd/mycel` was broken because `//go:embed web/dist` had nothing to embed on a fresh checkout. Track `server/web/dist/placeholder.txt` in git (#3036, #3165).
 
 ### Removed
-- Dead `bc env` command and hidden `tool check` alias (#3143, #3146).
+- Dead `mycel env` command and hidden `tool check` alias (#3143, #3146).
 - Historical `/api/workspaces/{id}/<rest>` path-scoped route family (see workspace-as-property above).
 
 ### Deferred to v0.3.1+
 - npm Trusted Publishing (OIDC) migration for `cd-npm.yml` — pending Trusted Publisher registration on npmjs.com (#3166).
-- Gateway → per-agent platform-tool rearchitecture: outbound Slack / Telegram / Discord / WhatsApp will move from `POST /api/gateways/{platform}/…/send` into per-agent tools using the official platform APIs. Also fixes the recurring "bc gateway" attribution issue on Slack file uploads.
+- Gateway → per-agent platform-tool rearchitecture: outbound Slack / Telegram / Discord / WhatsApp will move from `POST /api/gateways/{platform}/…/send` into per-agent tools using the official platform APIs. Also fixes the recurring "mycel gateway" attribution issue on Slack file uploads (#3178).
+- Docker image names `bc-agent-*` → `mycel-agent-*` and tmux session prefix `bc-<hash>-<name>` → `mycel-<hash>-<name>` — deferred so v0.3.0 doesn't break existing agent sessions on upgrade (#3187).
 - Major dependency bumps: React 19 (#3163), Vite 8 (#3155), Tailwind 4 (#3161), react-router 7 (#3159), ink 7 (#3152), slack-go 0.27 (#3168), landing eslint 10 (#3169), landing lucide 1.22 (#3170).
 
 ## [0.2.3] - 2026-05-02


### PR DESCRIPTION
Adds a Renamed section at the top of the v0.3.0 changelog entry (path root, env vars, CLI copy, web/docs) and updates the historical bullets that read as current-tense with the correct `mycel` spelling. Links deferred bullets to #3178 / #3187. Docs-only, no code impact.