### PR TITLE
refactor: post-audit bc → mycel cleanup pass (pre-cut polish)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,15 +42,15 @@ Naming convention: `make <verb>[-<runtime>]-<component>` where `runtime` = `loca
 |---------|-------------|
 | `make build` | Build everything (local + docker) |
 | `make build-local` | Build all local binaries (go + ts) |
-| `make build-local-go` | Build all Go binaries (bc + bcd) |
-| `make build-local-bc` | Build bc CLI binary to `bin/bc` |
+| `make build-local-go` | Build all Go binaries (mycel + bcd) |
+| `make build-local-bc` | Build mycel CLI binary to `bin/mycel` |
 | `make build-local-bcd` | Build bcd server binary (embeds web UI) |
 | `make build-local-ts` | Build all TS packages (tui + web + landing) |
 | `make build-local-tui` | Build TUI package |
 | `make build-local-web` | Build React web UI → `server/web/dist/` |
 | `make build-local-landing` | Build Next.js landing page |
 | `make release` | Build optimized release binaries (stripped symbols) |
-| `make install-local-bc` | Install bc to `$GOPATH/bin` |
+| `make install-local-bc` | Install mycel to `$GOPATH/bin` |
 
 ### Build (Docker)
 
@@ -96,7 +96,7 @@ Naming convention: `make <verb>[-<runtime>]-<component>` where `runtime` = `loca
 
 | Command | Description |
 |---------|-------------|
-| `make run-bc` | Run bc CLI from source (`go run`) |
+| `make run-bc` | Run mycel CLI from source (`go run`) |
 | `make run-web` | Run web UI dev server (hot reload) |
 | `make run-landing` | Run landing dev server (hot reload) |
 | `make run-tui` | Run TUI in dev mode |
@@ -110,7 +110,7 @@ Naming convention: `make <verb>[-<runtime>]-<component>` where `runtime` = `loca
 | `make deps-ts` | Install all TS dependencies (bun install) |
 | `make scan-go` | Run govulncheck for Go vulnerabilities |
 | `make scan-ts` | Run TS dependency audit |
-| `make install-local-bc` | Install bc to `$GOPATH/bin` |
+| `make install-local-bc` | Install mycel to `$GOPATH/bin` |
 | `make clean` | Remove all build artifacts |
 | `make clean-deps` | Remove build artifacts + node_modules |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,7 +64,7 @@ This policy applies to:
 
 ### Secret Management
 
-bc stores secrets in an encrypted, per-workspace store under `.bc/secrets/`. Secrets are injected into agent sessions at startup via environment variables and are never written to disk in plaintext. Use `bc secret set` to manage secrets instead of placing them in `.env`.
+mycel stores secrets in an encrypted, per-workspace store under the mycel state directory. Secrets are injected into agent sessions at startup via environment variables and are never written to disk in plaintext. Use `mycel secret set` to manage secrets instead of placing them in `.env`.
 
 Sensitive patterns (API keys, tokens, DSNs) are redacted from WebSocket streams by the bcd server before reaching the web dashboard.
 
@@ -95,8 +95,8 @@ Each agent runs in its own tmux session (local) or Docker container (production)
 
 When using bc:
 
-- Keep bc updated to the latest version
-- Store API keys and tokens via `bc secret set`, not in `.env` or shell history
+- Keep mycel updated to the latest version
+- Store API keys and tokens via `mycel secret set`, not in `.env` or shell history
 - Review agent prompts and role definitions before execution
 - Use environment variables for sensitive data (never hardcode)
 - Restrict agent capabilities to the minimum required via role definitions

--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -103,7 +103,7 @@ func fetchCCUsageDailyReport(ctx context.Context) *ccusageDailyReport {
 	return &report
 }
 
-// costShowResponse is the enriched JSON response for 'bc cost show --json'.
+// costShowResponse is the enriched JSON response for 'mycel cost show --json'.
 type costShowResponse struct {
 	ByAgent            map[string]float64 `json:"by_agent"`
 	ByTeam             map[string]float64 `json:"by_team"`

--- a/internal/cmd/cost_budget.go
+++ b/internal/cmd/cost_budget.go
@@ -178,7 +178,7 @@ func runCostBudgetShow(cmd *cobra.Command, args []string) error {
 
 	if len(budgets) == 0 {
 		fmt.Println("No budgets configured")
-		fmt.Println("\nUse 'bc cost budget set <amount>' to set a budget")
+		fmt.Println("\nUse 'mycel cost budget set <amount>' to set a budget")
 		return nil
 	}
 

--- a/internal/cmd/cost_usage.go
+++ b/internal/cmd/cost_usage.go
@@ -138,7 +138,7 @@ func runCostUsage(cmd *cobra.Command, args []string) error {
 func fetchCCUsage(cmd *cobra.Command) ([]byte, error) {
 	npxPath, err := exec.LookPath("npx")
 	if err != nil {
-		return nil, fmt.Errorf("npx not found — install Node.js to use 'bc cost usage' (ccusage requires npx)")
+		return nil, fmt.Errorf("npx not found — install Node.js to use 'mycel cost usage' (ccusage requires npx)")
 	}
 
 	ccArgs := []string{npxPath, "ccusage@latest", "--json"}

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -27,7 +27,7 @@ var initCmd = &cobra.Command{
 	Short: "Initialize a new mycel v2 workspace",
 	Long: `Initialize a new mycel v2 workspace in the specified directory (or current directory).
 
-This creates a .bc directory with v2 configuration for managing agents.
+This creates a .mycel-scoped workspace directory with v2 configuration for managing agents.
 
 v2 workspace structure:
   .bc/

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -434,13 +434,13 @@ func runMCPServe(cmd *cobra.Command, _ []string) error {
 	defer srv.Close() //nolint:errcheck
 
 	if mcpServeSSE {
-		fmt.Fprintf(os.Stderr, "bc MCP server listening on %s (SSE transport)\n", mcpServeAddr)
+		fmt.Fprintf(os.Stderr, "mycel MCP server listening on %s (SSE transport)\n", mcpServeAddr)
 		fmt.Fprintf(os.Stderr, "  Connect via: http://%s/sse\n", mcpServeAddr)
 		return srv.ServeSSE(ctx, mcpServeAddr)
 	}
 
 	// stdio transport — don't write to stdout (it's the protocol stream)
-	fmt.Fprintf(os.Stderr, "bc MCP server ready (stdio transport)\n")
+	fmt.Fprintf(os.Stderr, "mycel MCP server ready (stdio transport)\n")
 	return srv.ServeStdio(ctx)
 }
 

--- a/internal/cmd/notify.go
+++ b/internal/cmd/notify.go
@@ -51,7 +51,7 @@ Examples:
 
 			if len(subs) == 0 {
 				fmt.Println("No subscriptions configured.")
-				fmt.Println("Use 'bc notify subscribe <channel> <agent>' to add one.")
+				fmt.Println("Use 'mycel notify subscribe <channel> <agent>' to add one.")
 				return nil
 			}
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -72,7 +72,7 @@ Environment Variables:
   BC_AGENT_ROLE     Current agent role
   BC_WORKSPACE      Path to workspace root
   BC_AGENT_WORKTREE Path to agent's worktree
-  BC_BIN            Path to mycel binary (default: bc in PATH)
+  BC_BIN            Path to mycel binary (default: mycel in PATH)
   BC_ROOT           Workspace root directory
   NO_COLOR          Disable colored output
 

--- a/pkg/mcp/global.go
+++ b/pkg/mcp/global.go
@@ -135,7 +135,7 @@ func (g *GlobalStore) Add(cfg *ServerConfig) error {
 	}
 	for _, s := range reg.Servers {
 		if s.Name == cfg.Name {
-			return fmt.Errorf("mcp server %q already exists (use 'bc mcp remove %s' first)", cfg.Name, cfg.Name)
+			return fmt.Errorf("mcp server %q already exists (use 'mycel mcp remove %s' first)", cfg.Name, cfg.Name)
 		}
 	}
 	copy := *cfg

--- a/pkg/mcp/store.go
+++ b/pkg/mcp/store.go
@@ -141,7 +141,7 @@ func (s *Store) Add(cfg *ServerConfig) error {
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "UNIQUE constraint") {
-			return fmt.Errorf("mcp server %q already exists (use 'bc mcp remove %s' first)", cfg.Name, cfg.Name)
+			return fmt.Errorf("mcp server %q already exists (use 'mycel mcp remove %s' first)", cfg.Name, cfg.Name)
 		}
 		return fmt.Errorf("add mcp server %q: %w", cfg.Name, err)
 	}

--- a/pkg/mcp/store_postgres.go
+++ b/pkg/mcp/store_postgres.go
@@ -84,7 +84,7 @@ func (p *PostgresStore) Add(cfg *ServerConfig) error {
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") || strings.Contains(err.Error(), "unique constraint") {
-			return fmt.Errorf("mcp server %q already exists (use 'bc mcp remove %s' first)", cfg.Name, cfg.Name)
+			return fmt.Errorf("mcp server %q already exists (use 'mycel mcp remove %s' first)", cfg.Name, cfg.Name)
 		}
 		return fmt.Errorf("add mcp server %q: %w", cfg.Name, err)
 	}

--- a/pkg/secret/layered.go
+++ b/pkg/secret/layered.go
@@ -214,7 +214,7 @@ func (l *LayeredStore) Delete(name string) error {
 	return fmt.Errorf("secret %q not found", name)
 }
 
-// DeleteScoped removes from a specific scope. Useful for "bc secret
+// DeleteScoped removes from a specific scope. Useful for "mycel secret
 // delete NAME --global" / "--workspace".
 func (l *LayeredStore) DeleteScoped(scope Scope, name string) error {
 	switch scope {

--- a/pkg/workspace/global.go
+++ b/pkg/workspace/global.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 )
 
-// Subdirectories and files relative to BCHome().
+// Subdirectories and files relative to MycelHome().
 const (
 	globalTemplatesDirName  = "templates"
 	globalSecretsFileName   = "secrets.vault"
@@ -39,7 +39,7 @@ func DataDir(id string) (string, error) {
 	if id == "" {
 		return "", fmt.Errorf("workspace id is empty")
 	}
-	home, err := BCHome()
+	home, err := MycelHome()
 	if err != nil {
 		return "", err
 	}
@@ -108,9 +108,9 @@ func DaemonAddrPath() (string, error) {
 
 // EnsureGlobalDir makes sure ~/.bc/ exists with 0750 permissions. It is
 // idempotent and safe to call from any process path that needs to write
-// a global asset. Returns the resolved BCHome path for convenience.
+// a global asset. Returns the resolved MycelHome path for convenience.
 func EnsureGlobalDir() (string, error) {
-	home, err := BCHome()
+	home, err := MycelHome()
 	if err != nil {
 		return "", err
 	}
@@ -120,11 +120,11 @@ func EnsureGlobalDir() (string, error) {
 	return home, nil
 }
 
-// globalPath joins BCHome() with name. It does NOT create the parent; use
-// EnsureGlobalDir when writing. Returns an error only if BCHome cannot
+// globalPath joins MycelHome() with name. It does NOT create the parent; use
+// EnsureGlobalDir when writing. Returns an error only if MycelHome cannot
 // be resolved (HOME unset and BC_HOME unset).
 func globalPath(name string) (string, error) {
-	home, err := BCHome()
+	home, err := MycelHome()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/workspace/home.go
+++ b/pkg/workspace/home.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/rpuneet/mycel/pkg/log"
 )
@@ -15,6 +16,16 @@ import (
 const (
 	legacyHomeDirName = ".bc"
 	homeDirName       = ".mycel"
+)
+
+// warnBCHomeOnce / warnBCStateDirOnce keep the "deprecated env var"
+// WARN to at most one line per process. Both MycelHome() and
+// GlobalStateDir() are called from bcd request handlers, so without the
+// guard the log would be flooded on every request when a deployment
+// still exports the legacy env var.
+var (
+	warnBCHomeOnce     sync.Once
+	warnBCStateDirOnce sync.Once
 )
 
 // MycelHome returns the global mycel home directory.
@@ -35,7 +46,9 @@ func MycelHome() (string, error) {
 		return env, nil
 	}
 	if env := os.Getenv("BC_HOME"); env != "" {
-		log.Warn("BC_HOME is deprecated; use MYCEL_HOME", "value", env)
+		warnBCHomeOnce.Do(func() {
+			log.Warn("BC_HOME is deprecated; use MYCEL_HOME", "value", env)
+		})
 		return env, nil
 	}
 	home, err := os.UserHomeDir()
@@ -110,7 +123,9 @@ func GlobalStateDir(rootDir string) (string, error) {
 		return env, nil
 	}
 	if env := os.Getenv("BC_STATE_DIR"); env != "" {
-		log.Warn("BC_STATE_DIR is deprecated; use MYCEL_STATE_DIR", "value", env)
+		warnBCStateDirOnce.Do(func() {
+			log.Warn("BC_STATE_DIR is deprecated; use MYCEL_STATE_DIR", "value", env)
+		})
 		return env, nil
 	}
 

--- a/pkg/workspace/registry.go
+++ b/pkg/workspace/registry.go
@@ -88,7 +88,7 @@ func ComputeWorkspaceID(path string) string {
 // same sandbox — previously this ignored BC_HOME and always read the
 // host's real registry, which let tests corrupt production state.
 func GlobalDir() string {
-	home, err := BCHome()
+	home, err := MycelHome()
 	if err != nil {
 		return ""
 	}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -73,7 +73,7 @@ func Init(rootDir string) (*Workspace, error) {
 		return nil, fmt.Errorf("not a git repository: %s\nRun 'git init' first, then 'mycel init'", absRoot)
 	}
 
-	if homeErr := EnsureBCHome(); homeErr != nil {
+	if homeErr := EnsureMycelHome(); homeErr != nil {
 		return nil, homeErr
 	}
 

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bc/tui",
   "version": "0.1.0",
-  "description": "Terminal UI for bc agent orchestration",
+  "description": "Terminal UI for mycel agent orchestration",
   "type": "module",
   "main": "dist/index.js",
   "scripts": {

--- a/tui/src/index.tsx
+++ b/tui/src/index.tsx
@@ -18,7 +18,7 @@ if (!process.stdin.isTTY) {
   console.error('');
   console.error('Alternatives:');
   console.error('  bc status       # View agent status (non-interactive)');
-  console.error('  bc agent list   # List agents');
+  console.error('  mycel agent list   # List agents');
   console.error('  bc notify list  # List notification sources');
   process.exit(1);
 }

--- a/tui/src/views/agents/AgentList.tsx
+++ b/tui/src/views/agents/AgentList.tsx
@@ -83,7 +83,7 @@ export function AgentList({
       return (
         <Box flexDirection="column" padding={1}>
           <Text dimColor>No agents yet.</Text>
-          <Text dimColor>Create one with: bc agent create --role &lt;role&gt;</Text>
+          <Text dimColor>Create one with: mycel agent create --role &lt;role&gt;</Text>
         </Box>
       );
     }
@@ -95,7 +95,7 @@ export function AgentList({
     return (
       <Box flexDirection="column" padding={1}>
         <Text dimColor>No agents yet.</Text>
-        <Text dimColor>Create one with: bc agent create --role &lt;role&gt;</Text>
+        <Text dimColor>Create one with: mycel agent create --role &lt;role&gt;</Text>
       </Box>
     );
   }


### PR DESCRIPTION
Part of #3172. Address the code-review + Playwright audit findings before cutting v0.3.0.

## Summary

**Code**:
- Migrate `pkg/workspace/{global,registry,workspace}.go` from the deprecated `BCHome`/`EnsureBCHome` aliases to `MycelHome`/`EnsureMycelHome` (SA1019 hygiene).
- `sync.Once` guard around `BC_HOME` / `BC_STATE_DIR` deprecation warns so a single env var doesn't flood bcd logs.
- `root.go` help text: 'BC_BIN default: bc in PATH' → 'mycel in PATH'.
- `init.go` prose '.bc directory' → 'mycel-scoped workspace directory'.
- Rename remaining internal `bc <verb>` strings across `pkg/mcp/*`, `pkg/secret/layered.go`, `internal/cmd/cost_*.go`, `internal/cmd/notify.go`, `internal/cmd/mcp.go`.

**TUI**:
- `tui/package.json` description → mycel.
- `AgentList.tsx` empty state + `index.tsx` startup error hint say `mycel agent …`.

**Docs**:
- `SECURITY.md`: 'bc stores secrets' → 'mycel stores secrets' and usage examples.
- `CONTRIBUTING.md`: `cd bc` → `cd mycel`; make target descriptions.

## Verified
- go test ./pkg/workspace ./internal/cmd — green
- golangci-lint — 0 issues
- Playwright verification against bcd 8842982c: **no release blockers**. Every user-visible 'bc' the Playwright pass saw was legitimate workspace-name data (this dev workspace happens to be *named* 'bc').