### PR TITLE
refactor(web): misc polish — Cron empty state + Settings header badge

### DIFF
--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -56,6 +56,14 @@ function GlyphIcon({ kind }: { kind: string }) {
           <path d="M12 8v4M12 16h.01" />
         </svg>
       );
+    case "clock":
+      // Clock face + hour/minute hands — schedule / cron / recurring
+      return (
+        <svg {...common} aria-hidden>
+          <circle cx="12" cy="12" r="9" />
+          <path d="M12 7v5l3 2" />
+        </svg>
+      );
     default:
       return null;
   }

--- a/web/src/views/Cron.tsx
+++ b/web/src/views/Cron.tsx
@@ -706,7 +706,7 @@ export function Cron() {
       {/* Job cards */}
       {jobList.length === 0 ? (
         <EmptyState
-          icon="~"
+          icon="clock"
           title="No cron jobs"
           description="Click '+ New Job' above or use 'mycel cron add <name>' to schedule recurring tasks."
         />

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -361,10 +361,19 @@ export function Settings() {
 
   return (
     <div className="p-4 md:p-6 space-y-3">
-      {/* File metadata (title lives in the top-bar chip) */}
-      <p className="text-[10px] text-mycel-muted">
-        preferences.json{typeof version !== "undefined" ? ` v${version}` : ""}
-      </p>
+      {/* File metadata badge — the source of truth for what these
+          settings map to on disk. Small chip with a bordered file
+          glyph so it reads as chrome, not as a subtitle competing
+          with the page header above. */}
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 text-[10px] font-mono px-2 py-1 rounded border border-mycel-border/50 bg-mycel-surface/40 text-mycel-muted">
+          <svg width="10" height="10" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 1.5h5l3 3v8H3z" />
+            <path d="M8 1.5v3h3" />
+          </svg>
+          preferences.json{typeof version !== "undefined" ? ` · v${version}` : ""}
+        </span>
+      </div>
 
       {/* Saved confirmation toast — visible briefly after a successful save
           when no other sections are dirty. */}


### PR DESCRIPTION
Part of #3172. Related task #112.

Two targeted follow-ups to the Live / Agents / AgentDetail passes.

- `EmptyState`: new `clock` glyph (circle + hour/minute hands) so schedule/recurring pages get a domain-appropriate icon.
- `Cron`: swap empty-state icon from `~` (pulse) to `clock` — first-time visitors see something that matches the concept.
- `Settings`: promote the orphan `preferences.json v2` subtitle into a proper bordered chip with a file glyph. Reads as chrome now, not a title-competing subtitle.

## Test plan
- [x] `bun run build` clean
- [x] `bun run test` 110/110 green
- [x] Playwright vs fresh bcd (948e0d18)
- [ ] CI green

More pages queued (Notifications composer chip, Templates/Secrets consistency, Costs donut/chart treatment) but shipping this small batch now to keep the review surface small and predictable.