### PR TITLE
refactor(web): final pages polish — Tools headers, Costs total, Templates icon, Notifications gateway chip

### DIFF
--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -64,6 +64,15 @@ function GlyphIcon({ kind }: { kind: string }) {
           <path d="M12 7v5l3 2" />
         </svg>
       );
+    case "T":
+      // Stack of two cards — templates
+      return (
+        <svg {...common} aria-hidden>
+          <rect x="6" y="4" width="14" height="12" rx="1.5" />
+          <rect x="4" y="8" width="14" height="12" rx="1.5" />
+          <path d="M8 12h6M8 15h4" opacity="0.5" />
+        </svg>
+      );
     default:
       return null;
   }

--- a/web/src/components/notifications/GatewayFeed.tsx
+++ b/web/src/components/notifications/GatewayFeed.tsx
@@ -1935,23 +1935,34 @@ export function GatewayFeed({
               </svg>
             </button>
 
-            {/* Gateway indicator */}
+            {/* Gateway indicator — clearer bordered chip so it reads
+                as a routing badge, not disposable meta text. */}
             {platform && (
               <span
-                className="inline-flex items-center"
+                className="inline-flex items-center gap-1.5"
                 style={{
-                  gap: 5,
                   fontSize: 10.5,
                   color: "var(--mycel-muted, #6b6b6b)",
                   fontFamily: "'JetBrains Mono', monospace",
-                  padding: "2px 7px",
+                  padding: "3px 8px",
                   background: "var(--mycel-surface-hover, #1a1a1a)",
-                  borderRadius: 4,
+                  border: "1px solid var(--mycel-border, rgba(255,255,255,0.06))",
+                  borderRadius: 5,
                   marginLeft: "auto",
                 }}
+                title="Outgoing messages route through the mycel gateway to the destination platform."
               >
-                <span style={{ width: 5, height: 5, borderRadius: 999, background: "#22c55e" }} />
-                <span>sending via mycel gateway &rarr; {platform}</span>
+                <span
+                  style={{
+                    width: 6,
+                    height: 6,
+                    borderRadius: 999,
+                    background: "#22c55e",
+                    boxShadow: "0 0 6px rgba(34,197,94,0.5)",
+                  }}
+                />
+                <span>routing via</span>
+                <span style={{ color: "var(--mycel-text, #cccccc)", fontWeight: 500 }}>{platform}</span>
               </span>
             )}
             {!platform && <span style={{ marginLeft: "auto" }} />}

--- a/web/src/views/CostsGlobal.tsx
+++ b/web/src/views/CostsGlobal.tsx
@@ -76,10 +76,19 @@ export function CostsGlobal() {
         </div>
       )}
 
-      <div className="flex items-baseline gap-3">
-        <span className="text-[11px] uppercase tracking-wider text-mycel-muted/60">Total</span>
-        <span className="text-2xl font-semibold text-mycel-text">{formatCost(total)}</span>
-        <span className="text-[11px] text-mycel-muted/60">
+      {/* TOTAL block — label + big number reads as a headline row.
+          Counter drops below the number as a caption so it doesn't
+          crowd the value. Keeps the "grow into a chart" affordance
+          open — the row can accept a donut / spark to its right
+          later without another restructure. */}
+      <div className="flex flex-col gap-1">
+        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-mycel-muted/60">
+          Total
+        </span>
+        <span className="text-[28px] font-semibold text-mycel-text leading-none tabular-nums">
+          {formatCost(total)}
+        </span>
+        <span className="text-[11px] text-mycel-muted/60 tabular-nums">
           {/* Date repeats the value in the picker top-right; show the
               counter only to avoid the DD/MM ↔ ISO format mismatch. */}
           {rows?.length ?? 0} {(rows?.length ?? 0) === 1 ? (groupBy === "workspace" ? "workspace" : "project") : (groupBy === "workspace" ? "workspaces" : "projects")}

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -422,16 +422,31 @@ export function Tools() {
       </AnimatePresence>
 
       <section>
-        <h2 className="text-xs font-medium text-mycel-muted uppercase tracking-widest mb-3">
-          Providers ({providerList.length}) &mdash; AI model providers
-        </h2>
+        {/* Section header: single sentence, no redundant count in a
+            "5 providers" chip elsewhere on the page. Keep it a quiet
+            editorial rule + label. */}
+        <div className="flex items-baseline gap-2 mb-3">
+          <h2 className="text-[11px] font-medium text-mycel-muted uppercase tracking-[0.14em]">
+            AI Model Providers
+          </h2>
+          <span className="text-[11px] text-mycel-muted/50 tabular-nums">
+            {providerList.length}
+          </span>
+          <span className="flex-1 h-px bg-mycel-border/40 self-center" aria-hidden />
+        </div>
         <ProvidersTable providers={providerList} search={search} />
       </section>
 
       <section>
-        <h2 className="text-xs font-medium text-mycel-muted uppercase tracking-widest mb-3">
-          CLI Dependencies ({filteredCli.length}{searchLower ? `/${cliTools.length}` : ""})
-        </h2>
+        <div className="flex items-baseline gap-2 mb-3">
+          <h2 className="text-[11px] font-medium text-mycel-muted uppercase tracking-[0.14em]">
+            CLI Dependencies
+          </h2>
+          <span className="text-[11px] text-mycel-muted/50 tabular-nums">
+            {filteredCli.length}{searchLower ? `/${cliTools.length}` : ""}
+          </span>
+          <span className="flex-1 h-px bg-mycel-border/40 self-center" aria-hidden />
+        </div>
         {filteredCli.length === 0 ? (
           <EmptyState icon=">" title={searchLower ? "No matching CLI tools" : "No CLI dependencies"} description={searchLower ? "Try a different search term." : "Add CLI tools like gh, aws, or wrangler."} />
         ) : (


### PR DESCRIPTION
Part of #3172. Related task #112. Batch closer for the page-by-page redesign.

## Changes

- **Tools**: section headers ("AI Model Providers", "CLI Dependencies") reflow to caps + count caption + hairline rule. Drops the redundant "5 providers" chip.
- **Costs (global)**: TOTAL row reflows from one-baseline label·value·count to stacked caps label + 28px display number + tiny caption. Same billboard vocabulary as Live's summary strip; room to grow a donut/spark next to it.
- **Templates**: EmptyState "T" icon token was unmapped so empty states rendered without a glyph. Add a stack-of-cards glyph.
- **Notifications composer chip**: 'sending via mycel gateway → whatsapp' upgraded to a bordered chip with soft-glow dot, muted "routing via" + higher-contrast platform name + tooltip. Reads as intentional status.

## Test plan
- [x] `bun run build` clean
- [x] `bun run test` 110/110
- [x] Playwright vs fresh bcd (63302731)
- [ ] CI green

Closes the page-by-page redesign work — after this the four earlier PRs (#3190, #3191, #3192, #3193) plus this cover the visible pages. Remaining leftover polish (donut chart on Costs, richer WorkspacePicker onboarding, per-tab AgentDetail bodies) is v0.3.1 territory.