### PR TITLE
fix(cli): rename remaining "bc <verb>" refs in Cobra Long/Example (v0.3.0 cleanup)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -71,7 +71,7 @@ Examples:
   mycel agent stop eng-01                   # Stop agent
   mycel agent broadcast "check status"      # Send to all agents
   mycel agent send-pattern "eng-*" "test"   # Send to matching agents
-  mycel agent                               # List all agents (same as bc agent list)
+  mycel agent                               # List all agents (same as mycel agent list)
   mycel agent send-pattern "eng-*" "hello"  # Send to matching agents`,
 	// #925: Default to list for consistency with bc channel
 	RunE: runAgentList,
@@ -109,7 +109,7 @@ Examples:
   mycel agent list --role engineer  # Filter by role`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
-			return fmt.Errorf("unexpected argument %q. To filter by role, use: bc agent list --role %s", args[0], args[0])
+			return fmt.Errorf("unexpected argument %q. To filter by role, use: mycel agent list --role %s", args[0], args[0])
 		}
 		return nil
 	},
@@ -495,9 +495,9 @@ func runAgentCreate(cmd *cobra.Command, args []string) error {
 	fmt.Println("Agent created successfully!")
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Printf("  bc agent attach %s    # Attach to session\n", agentName)
-	fmt.Printf("  bc agent send %s <msg> # Send message\n", agentName)
-	fmt.Printf("  bc agent peek %s       # View output\n", agentName)
+	fmt.Printf("  mycel agent attach %s    # Attach to session\n", agentName)
+	fmt.Printf("  mycel agent send %s <msg> # Send message\n", agentName)
+	fmt.Printf("  mycel agent peek %s       # View output\n", agentName)
 
 	return nil
 }
@@ -1128,10 +1128,10 @@ Usage:
 		agentName := args[0]
 		fmt.Printf("Agent auth is handled inside the container.\n\n")
 		fmt.Printf("To authenticate agent %q:\n", agentName)
-		fmt.Printf("  1. Attach: bc agent attach %s\n", agentName)
+		fmt.Printf("  1. Attach: mycel agent attach %s\n", agentName)
 		fmt.Printf("  2. Run /login inside Claude Code\n")
 		fmt.Printf("\nOr set ANTHROPIC_API_KEY in workspace env:\n")
-		fmt.Printf("  bc env set ANTHROPIC_API_KEY sk-ant-...\n")
+		fmt.Printf("  mycel env set ANTHROPIC_API_KEY sk-ant-...\n")
 		return nil
 	},
 }
@@ -1173,7 +1173,7 @@ func runAgentSessions(cmd *cobra.Command, args []string) error {
 		}
 		fmt.Printf("  %s%s%s\n", s.ID, current, ts)
 	}
-	fmt.Printf("\nResume a session: bc agent start %s --resume <id>\n", agentName)
+	fmt.Printf("\nResume a session: mycel agent start %s --resume <id>\n", agentName)
 
 	return nil
 }

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -63,16 +63,16 @@ var agentCmd = &cobra.Command{
 	Long: `Manage mycel agent lifecycle: create, list, attach, peek, stop, send.
 
 Examples:
-  bc agent list                          # List all agents
-  bc agent create eng-01 --template engineer # Create new agent
-  bc agent attach eng-01                 # Attach to agent session
-  bc agent peek eng-01                   # View recent output
-  bc agent send eng-01 "run tests"       # Send message to agent
-  bc agent stop eng-01                   # Stop agent
-  bc agent broadcast "check status"      # Send to all agents
-  bc agent send-pattern "eng-*" "test"   # Send to matching agents
-  bc agent                               # List all agents (same as bc agent list)
-  bc agent send-pattern "eng-*" "hello"  # Send to matching agents`,
+  mycel agent list                          # List all agents
+  mycel agent create eng-01 --template engineer # Create new agent
+  mycel agent attach eng-01                 # Attach to agent session
+  mycel agent peek eng-01                   # View recent output
+  mycel agent send eng-01 "run tests"       # Send message to agent
+  mycel agent stop eng-01                   # Stop agent
+  mycel agent broadcast "check status"      # Send to all agents
+  mycel agent send-pattern "eng-*" "test"   # Send to matching agents
+  mycel agent                               # List all agents (same as bc agent list)
+  mycel agent send-pattern "eng-*" "hello"  # Send to matching agents`,
 	// #925: Default to list for consistency with bc channel
 	RunE: runAgentList,
 }
@@ -88,11 +88,11 @@ Agents are configured via templates (markdown files at ~/.bc/templates/).
 Use --copy to clone settings from an existing agent.
 
 Examples:
-  bc agent create                              # Random name, base template
-  bc agent create worker-01                    # Explicit name, base template
-  bc agent create eng-01 --template engineer   # Use engineer template
-  bc agent create qa-01 --tool cursor          # Base template with Cursor
-  bc agent create clone-01 --copy swift-hawk   # Copy config from swift-hawk`,
+  mycel agent create                              # Random name, base template
+  mycel agent create worker-01                    # Explicit name, base template
+  mycel agent create eng-01 --template engineer   # Use engineer template
+  mycel agent create qa-01 --tool cursor          # Base template with Cursor
+  mycel agent create clone-01 --copy swift-hawk   # Copy config from swift-hawk`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentCreate,
 }
@@ -104,9 +104,9 @@ var agentListCmd = &cobra.Command{
 	Long: `List all agents with their status, role, and current task.
 
 Examples:
-  bc agent list          # List all agents
-  bc agent list --json   # Output as JSON
-  bc agent list --role engineer  # Filter by role`,
+  mycel agent list          # List all agents
+  mycel agent list --json   # Output as JSON
+  mycel agent list --role engineer  # Filter by role`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if len(args) > 0 {
 			return fmt.Errorf("unexpected argument %q. To filter by role, use: bc agent list --role %s", args[0], args[0])
@@ -125,7 +125,7 @@ var agentAttachCmd = &cobra.Command{
 Use Ctrl+b d to detach and return to your shell.
 
 Examples:
-  bc agent attach eng-01   # Attach to eng-01`,
+  mycel agent attach eng-01   # Attach to eng-01`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentAttach,
 }
@@ -137,9 +137,9 @@ var agentPeekCmd = &cobra.Command{
 	Long: `Capture and display recent output from an agent's session.
 
 Examples:
-  bc agent peek eng-01              # Show last 500 lines
-  bc agent peek eng-01 --lines 100  # Show last 100 lines
-  bc agent peek eng-01 --follow     # Stream live output (Ctrl+C to stop)`,
+  mycel agent peek eng-01              # Show last 500 lines
+  mycel agent peek eng-01 --lines 100  # Show last 100 lines
+  mycel agent peek eng-01 --follow     # Stream live output (Ctrl+C to stop)`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentPeek,
 }
@@ -151,8 +151,8 @@ var agentShowCmd = &cobra.Command{
 	Long: `Show detailed information about an agent.
 
 Examples:
-  bc agent show eng-01       # Show eng-01 details
-  bc agent show eng-01 --json  # Output as JSON`,
+  mycel agent show eng-01       # Show eng-01 details
+  mycel agent show eng-01 --json  # Output as JSON`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentShow,
 }
@@ -172,8 +172,8 @@ and cannot be changed on restart. Use --runtime to switch infrastructure
 backends (tmux vs docker) without changing the agent's identity.
 
 Examples:
-  bc agent start eng-01                    # Start stopped agent (resumes session)
-  bc agent start eng-01 --runtime docker   # Override runtime backend`,
+  mycel agent start eng-01                    # Start stopped agent (resumes session)
+  mycel agent start eng-01 --runtime docker   # Override runtime backend`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentStart,
 }
@@ -185,8 +185,8 @@ var agentStopCmd = &cobra.Command{
 	Long: `Stop a specific agent and its tmux session.
 
 Examples:
-  bc agent stop eng-01       # Stop eng-01
-  bc agent stop eng-01 --force  # Force stop`,
+  mycel agent stop eng-01       # Stop eng-01
+  mycel agent stop eng-01 --force  # Force stop`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentStop,
 }
@@ -201,9 +201,9 @@ Use --preview to see what action will be taken before sending (Intent Preview).
 This shows agent details and asks for confirmation.
 
 Examples:
-  bc agent send eng-01 "run the tests"
-  bc agent send coordinator "check status"
-  bc agent send eng-01 "implement login" --preview  # Preview before sending`,
+  mycel agent send eng-01 "run the tests"
+  mycel agent send coordinator "check status"
+  mycel agent send eng-01 "implement login" --preview  # Preview before sending`,
 	Args: cobra.MinimumNArgs(2),
 	RunE: runAgentSend,
 }
@@ -221,10 +221,10 @@ Use --force to delete an agent without stopping it first.
 Use --purge to also delete the agent's memory directory.
 
 Examples:
-  bc agent delete eng-01              # Delete stopped agent (preserves memory)
-  bc agent delete eng-01 --force      # Force delete (any state)
-  bc agent delete eng-01 --purge      # Delete including memory
-  bc agent delete eng-01 --force --purge  # Force delete with full cleanup`,
+  mycel agent delete eng-01              # Delete stopped agent (preserves memory)
+  mycel agent delete eng-01 --force      # Force delete (any state)
+  mycel agent delete eng-01 --purge      # Delete including memory
+  mycel agent delete eng-01 --force --purge  # Force delete with full cleanup`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentDelete,
 }
@@ -239,8 +239,8 @@ This updates the agent's name and channel memberships.
 By default, running agents cannot be renamed (use --force to override).
 
 Examples:
-  bc agent rename eng-01 engineer-01
-  bc agent rename eng-01 eng-02 --force  # Rename running agent`,
+  mycel agent rename eng-01 engineer-01
+  mycel agent rename eng-01 eng-02 --force  # Rename running agent`,
 	Args: cobra.ExactArgs(2),
 	RunE: runAgentRename,
 }
@@ -257,8 +257,8 @@ The current session ID (if captured) is listed first, followed by archived
 session IDs from previous runs.
 
 Examples:
-  bc agent sessions eng-01       # List session IDs
-  bc agent sessions eng-01 --json`,
+  mycel agent sessions eng-01       # List session IDs
+  mycel agent sessions eng-01 --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentSessions,
 }
@@ -272,8 +272,8 @@ var agentBroadcastCmd = &cobra.Command{
 	Long: `Broadcast a message to all running agents in the workspace.
 
 Examples:
-  bc agent broadcast "run tests"
-  bc agent broadcast "check status"`,
+  mycel agent broadcast "run tests"
+  mycel agent broadcast "check status"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runAgentBroadcast,
 }
@@ -287,9 +287,9 @@ var agentSendPatternCmd = &cobra.Command{
 Pattern uses glob-style matching (* matches any characters).
 
 Examples:
-  bc agent send-pattern "engineer-*" "run tests"
-  bc agent send-pattern "eng-0*" "check status"
-  bc agent send-pattern "*-lead" "review PRs"`,
+  mycel agent send-pattern "engineer-*" "run tests"
+  mycel agent send-pattern "eng-0*" "check status"
+  mycel agent send-pattern "*-lead" "review PRs"`,
 	Args: cobra.MinimumNArgs(2),
 	RunE: runAgentSendPattern,
 }
@@ -1027,8 +1027,8 @@ var agentCostCmd = &cobra.Command{
 	Long: `Show the cost breakdown for a specific agent including tokens and USD cost.
 
 Examples:
-  bc agent cost eng-01       # Show eng-01 cost
-  bc agent cost eng-01 --json  # Output as JSON`,
+  mycel agent cost eng-01       # Show eng-01 cost
+  mycel agent cost eng-01 --json  # Output as JSON`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentCost,
 }
@@ -1040,8 +1040,8 @@ var agentLogsCmd = &cobra.Command{
 	Long: `Show the event log history for a specific agent.
 
 Examples:
-  bc agent logs eng-01               # Show all events
-  bc agent logs eng-01 --since 1h    # Show events from last hour`,
+  mycel agent logs eng-01               # Show all events
+  mycel agent logs eng-01 --since 1h    # Show events from last hour`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentLogs,
 }
@@ -1121,8 +1121,8 @@ var agentAuthCmd = &cobra.Command{
 credentials directory. Opens a browser for authentication.
 
 Usage:
-  bc agent auth my-agent        # Login for a specific agent
-  bc agent auth my-agent status # Check auth status`,
+  mycel agent auth my-agent        # Login for a specific agent
+  mycel agent auth my-agent status # Check auth status`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		agentName := args[0]
@@ -1188,9 +1188,9 @@ Stats are collected every 30 s by bcd while the agent is running with a
 Docker runtime backend. They are stored in .bc/bc.db.
 
 Examples:
-  bc agent stats eng-01              # Human-readable table
-  bc agent stats eng-01 --json       # JSON output
-  bc agent stats eng-01 --limit 50   # Show more records`,
+  mycel agent stats eng-01              # Human-readable table
+  mycel agent stats eng-01 --json       # JSON output
+  mycel agent stats eng-01 --limit 50   # Show more records`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentStats,
 }

--- a/internal/cmd/agent_health.go
+++ b/internal/cmd/agent_health.go
@@ -25,10 +25,10 @@ var agentHealthCmd = &cobra.Command{
 	Long: `Check health status of agents including tmux session and state freshness.
 
 Examples:
-  bc agent health              # Check all agents
-  bc agent health eng-01       # Check specific agent
-  bc agent health --json       # Output as JSON
-  bc agent health --detect-stuck --alert eng  # Detect stuck and alert`,
+  mycel agent health              # Check all agents
+  mycel agent health eng-01       # Check specific agent
+  mycel agent health --json       # Output as JSON
+  mycel agent health --detect-stuck --alert eng  # Detect stuck and alert`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runAgentHealth,
 }

--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -25,22 +25,22 @@ Channels are named groups of agent members. Messages sent to a channel are
 delivered to all member tmux sessions.
 
 Examples:
-  bc channel list                      # List all channels
-  bc channel create workers            # Create a channel named "workers"
-  bc channel show workers              # Show channel details
-  bc channel add workers worker-01     # Add member to channel
-  bc channel add workers --agent w-01  # Add member via --agent flag
-  bc channel send workers "run tests"  # Send to all members
-  bc channel history workers --last 20 # Show last 20 messages
-  bc channel react workers 5 👍        # React to message
-  bc channel edit workers --desc "..."  # Edit channel description
-  bc channel remove workers worker-01  # Remove a member
-  bc channel delete workers            # Delete the channel
-  bc channel status                    # Overview of all channels
+  mycel channel list                      # List all channels
+  mycel channel create workers            # Create a channel named "workers"
+  mycel channel show workers              # Show channel details
+  mycel channel add workers worker-01     # Add member to channel
+  mycel channel add workers --agent w-01  # Add member via --agent flag
+  mycel channel send workers "run tests"  # Send to all members
+  mycel channel history workers --last 20 # Show last 20 messages
+  mycel channel react workers 5 👍        # React to message
+  mycel channel edit workers --desc "..."  # Edit channel description
+  mycel channel remove workers worker-01  # Remove a member
+  mycel channel delete workers            # Delete the channel
+  mycel channel status                    # Overview of all channels
 
 Agent Commands (require BC_AGENT_ID):
-  bc channel join workers              # Join a channel (current agent)
-  bc channel leave workers             # Leave a channel (current agent)
+  mycel channel join workers              # Join a channel (current agent)
+  mycel channel leave workers             # Leave a channel (current agent)
 
 Default Channels:
   #eng       Engineering team (all engineer agents)
@@ -53,9 +53,9 @@ Message Format:
   Use @agent-name to mention specific agents in messages.
 
 See Also:
-  bc agent send       Send message to single agent
-  bc agent broadcast  Send to all agents
-  bc status           View agents and their channels`,
+  mycel agent send       Send message to single agent
+  mycel agent broadcast  Send to all agents
+  mycel status           View agents and their channels`,
 }
 
 var channelCreateCmd = &cobra.Command{
@@ -121,13 +121,13 @@ var channelHistoryCmd = &cobra.Command{
 	Long: `Display the history of messages sent to a channel.
 
 Examples:
-  bc channel history eng                       # Last 50 messages (default)
-  bc channel history eng --limit 10            # Last 10 messages
-  bc channel history eng --since 1h            # Messages from last hour
-  bc channel history eng --agent agent-core    # Messages from agent-core only
-  bc channel history eng --from 2026-03-01     # Messages from date
-  bc channel history eng --from 2026-03-01 --to 2026-03-05  # Date range
-  bc channel history eng --limit 20 --offset 20  # Page 2 of 20`,
+  mycel channel history eng                       # Last 50 messages (default)
+  mycel channel history eng --limit 10            # Last 10 messages
+  mycel channel history eng --since 1h            # Messages from last hour
+  mycel channel history eng --agent agent-core    # Messages from agent-core only
+  mycel channel history eng --from 2026-03-01     # Messages from date
+  mycel channel history eng --from 2026-03-01 --to 2026-03-05  # Date range
+  mycel channel history eng --limit 20 --offset 20  # Page 2 of 20`,
 	Args: cobra.ExactArgs(1),
 	RunE: runChannelHistory,
 }
@@ -141,8 +141,8 @@ The message-index is shown in 'mycel channel history' output.
 Use common emoji like 👍, 👎, ❤️, 🎉, 👀, 🚀 or any emoji.
 
 Examples:
-  bc channel react engineering 5 👍
-  bc channel react general 0 🎉`,
+  mycel channel react engineering 5 👍
+  mycel channel react general 0 🎉`,
 	Args: cobra.ExactArgs(3),
 	RunE: runChannelReact,
 }
@@ -154,8 +154,8 @@ var channelShowCmd = &cobra.Command{
 description, and message history statistics.
 
 Examples:
-  bc channel show engineering    # Show engineering channel details
-  bc channel show standup --json # Output as JSON`,
+  mycel channel show engineering    # Show engineering channel details
+  mycel channel show standup --json # Output as JSON`,
 	Args: cobra.ExactArgs(1),
 	RunE: runChannelShow,
 }
@@ -176,8 +176,8 @@ var channelStatusCmd = &cobra.Command{
 Columns: Name, Members, Messages, Last Message (preview), Last Activity.
 
 Examples:
-  bc channel status           # Show all channels with details
-  bc channel status --json    # JSON output`,
+  mycel channel status           # Show all channels with details
+  mycel channel status --json    # JSON output`,
 	RunE: runChannelStatus,
 }
 
@@ -187,7 +187,7 @@ var channelEditCmd = &cobra.Command{
 	Long: `Edit a channel's description or settings.
 
 Examples:
-  bc channel edit eng --desc "Engineering discussion"`,
+  mycel channel edit eng --desc "Engineering discussion"`,
 	Args: cobra.ExactArgs(1),
 	RunE: runChannelEdit,
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -27,13 +27,13 @@ Configuration uses a hierarchical key structure with dot notation:
   providers.default
 
 Examples:
-  bc config show                        # Show all config
-  bc config get providers.default           # Get a specific value
-  bc config set providers.default 6      # Set a value
-  bc config list                        # List all config keys
-  bc config edit                        # Open config in editor
-  bc config validate                    # Validate config file
-  bc config reset                       # Reset to defaults`,
+  mycel config show                        # Show all config
+  mycel config get providers.default           # Get a specific value
+  mycel config set providers.default 6      # Set a value
+  mycel config list                        # List all config keys
+  mycel config edit                        # Open config in editor
+  mycel config validate                    # Validate config file
+  mycel config reset                       # Reset to defaults`,
 	RunE: runConfigShow,
 }
 
@@ -45,10 +45,10 @@ var configShowCmd = &cobra.Command{
 If a key is specified, shows only that section. Otherwise shows entire config.
 
 Examples:
-  bc config show                  # Show all config
-  bc config show tools            # Show tools section
-  bc config show tools.claude     # Show specific tool config
-  bc config show --json           # Output as JSON`,
+  mycel config show                  # Show all config
+  mycel config show tools            # Show tools section
+  mycel config show tools.claude     # Show specific tool config
+  mycel config show --json           # Output as JSON`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runConfigShow,
 }
@@ -59,10 +59,10 @@ var configGetCmd = &cobra.Command{
 	Long: `Get a specific configuration value using dot notation.
 
 Examples:
-  bc config get workspace.name
-  bc config get providers.default
-  bc config get providers.default
-  bc config get tools.claude.command`,
+  mycel config get workspace.name
+  mycel config get providers.default
+  mycel config get providers.default
+  mycel config get tools.claude.command`,
 	Args: cobra.ExactArgs(1),
 	RunE: runConfigGet,
 }
@@ -75,10 +75,10 @@ var configSetCmd = &cobra.Command{
 The value type is automatically inferred (string, number, boolean).
 
 Examples:
-  bc config set providers.default 6
-  bc config set providers.default claude
-  bc config set runtime.backend docker
-  bc config set tools.claude.command "claude --force"`,
+  mycel config set providers.default 6
+  mycel config set providers.default claude
+  mycel config set runtime.backend docker
+  mycel config set tools.claude.command "claude --force"`,
 	Args: cobra.ExactArgs(2),
 	RunE: runConfigSet,
 }
@@ -89,8 +89,8 @@ var configListCmd = &cobra.Command{
 	Long: `List all available configuration keys in the workspace config.
 
 Examples:
-  bc config list
-  bc config list --json           # Output as JSON array`,
+  mycel config list
+  mycel config list --json           # Output as JSON array`,
 	RunE: runConfigList,
 }
 
@@ -102,7 +102,7 @@ var configEditCmd = &cobra.Command{
 Uses $EDITOR environment variable, falls back to 'nano' if not set.
 
 Examples:
-  bc config edit`,
+  mycel config edit`,
 	RunE: runConfigEdit,
 }
 
@@ -118,7 +118,7 @@ Checks for:
   - Tool references exist
 
 Examples:
-  bc config validate`,
+  mycel config validate`,
 	RunE: runConfigValidate,
 }
 
@@ -130,8 +130,8 @@ var configResetCmd = &cobra.Command{
 WARNING: This will overwrite your current config. Back up first if needed.
 
 Examples:
-  bc config reset
-  bc config reset --force         # Skip confirmation`,
+  mycel config reset
+  mycel config reset --force         # Skip confirmation`,
 	RunE: runConfigReset,
 }
 
@@ -150,9 +150,9 @@ User configuration provides defaults that apply across all mycel workspaces:
 Workspace config (.bc/settings.json) takes precedence over user config.
 
 Examples:
-  bc config user init   # Create ~/.bcrc with guided prompts
-  bc config user show   # Show user config
-  bc config user path   # Show user config path`,
+  mycel config user init   # Create ~/.bcrc with guided prompts
+  mycel config user show   # Show user config
+  mycel config user path   # Show user config path`,
 	RunE: runConfigUserShow,
 }
 
@@ -162,8 +162,8 @@ var configUserInitCmd = &cobra.Command{
 	Long: `Create a new ~/.bcrc file with guided prompts.
 
 Examples:
-  bc config user init          # Interactive setup
-  bc config user init --quick  # Use defaults without prompts`,
+  mycel config user init          # Interactive setup
+  mycel config user init --quick  # Use defaults without prompts`,
 	RunE: runConfigUserInit,
 }
 
@@ -173,7 +173,7 @@ var configUserShowCmd = &cobra.Command{
 	Long: `Display the current user configuration from ~/.bcrc.
 
 Examples:
-  bc config user show`,
+  mycel config user show`,
 	RunE: runConfigUserShow,
 }
 
@@ -183,7 +183,7 @@ var configUserPathCmd = &cobra.Command{
 	Long: `Display the path to the user configuration file.
 
 Examples:
-  bc config user path`,
+  mycel config user path`,
 	RunE: runConfigUserPath,
 }
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -61,7 +61,7 @@ var configGetCmd = &cobra.Command{
 Examples:
   mycel config get workspace.name
   mycel config get providers.default
-  mycel config get providers.default
+  mycel config get providers.claude.command
   mycel config get tools.claude.command`,
 	Args: cobra.ExactArgs(1),
 	RunE: runConfigGet,

--- a/internal/cmd/cost.go
+++ b/internal/cmd/cost.go
@@ -23,15 +23,15 @@ var costCmd = &cobra.Command{
 Shows Claude Code token usage, costs, and budget management.
 
 Examples:
-  bc cost                              # Show cost records (default)
-  bc cost show eng-01                  # Show costs for specific agent
-  bc cost usage                        # Claude Code usage via ccusage
-  bc cost usage --monthly              # Monthly summary
-  bc cost budget show                  # Show budget status
+  mycel cost                              # Show cost records (default)
+  mycel cost show eng-01                  # Show costs for specific agent
+  mycel cost usage                        # Claude Code usage via ccusage
+  mycel cost usage --monthly              # Monthly summary
+  mycel cost budget show                  # Show budget status
 
 See Also:
-  bc home           TUI dashboard with cost overview
-  bc status         Agent status (includes cost info)`,
+  mycel home           TUI dashboard with cost overview
+  mycel status         Agent status (includes cost info)`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runCostShow,
 }
@@ -44,9 +44,9 @@ var costShowCmd = &cobra.Command{
 You can specify the agent either as a positional argument or using --agent flag.
 
 Examples:
-  bc cost show
-  bc cost show engineer-01
-  bc cost show --agent engineer-01`,
+  mycel cost show
+  mycel cost show engineer-01
+  mycel cost show --agent engineer-01`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runCostShow,
 }

--- a/internal/cmd/cost_analytics.go
+++ b/internal/cmd/cost_analytics.go
@@ -42,8 +42,8 @@ var costSummaryCmd = &cobra.Command{
 	Long: `Show cost summary with today, this week, this month, and all-time totals.
 
 Examples:
-  bc cost summary
-  bc cost summary --json`,
+  mycel cost summary
+  mycel cost summary --json`,
 	RunE: runCostSummary,
 }
 
@@ -53,8 +53,8 @@ var costAgentCmd = &cobra.Command{
 	Long: `Show cost breakdown by agent. If a name is given, shows detail for that agent.
 
 Examples:
-  bc cost agent                    # All agents
-  bc cost agent swift-falcon       # Specific agent`,
+  mycel cost agent                    # All agents
+  mycel cost agent swift-falcon       # Specific agent`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runCostAgent,
 }
@@ -65,8 +65,8 @@ var costModelCmd = &cobra.Command{
 	Long: `Show cost breakdown by model.
 
 Examples:
-  bc cost model
-  bc cost model claude-sonnet-4-6`,
+  mycel cost model
+  mycel cost model claude-sonnet-4-6`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runCostModel,
 }
@@ -77,9 +77,9 @@ var costDailyCmd = &cobra.Command{
 	Long: `Show daily cost totals for the last N days.
 
 Examples:
-  bc cost daily              # Last 30 days (default)
-  bc cost daily --days 7     # Last 7 days
-  bc cost daily --json`,
+  mycel cost daily              # Last 30 days (default)
+  mycel cost daily --days 7     # Last 7 days
+  mycel cost daily --json`,
 	RunE: runCostDaily,
 }
 
@@ -90,8 +90,8 @@ var costDashboardCmd = &cobra.Command{
 per-model breakdown, and budget status.
 
 Examples:
-  bc cost dashboard
-  bc cost dashboard --json`,
+  mycel cost dashboard
+  mycel cost dashboard --json`,
 	RunE: runCostDashboard,
 }
 

--- a/internal/cmd/cost_budget.go
+++ b/internal/cmd/cost_budget.go
@@ -17,10 +17,10 @@ var costBudgetCmd = &cobra.Command{
 	Long: `Commands for managing cost budgets and limits.
 
 Examples:
-  bc cost budget show
-  bc cost budget set 100.00
-  bc cost budget set 50.00 --agent engineer-01
-  bc cost budget set 500.00 --period monthly --alert-at 0.9`,
+  mycel cost budget show
+  mycel cost budget set 100.00
+  mycel cost budget set 50.00 --agent engineer-01
+  mycel cost budget set 500.00 --period monthly --alert-at 0.9`,
 }
 
 var costBudgetSetCmd = &cobra.Command{
@@ -29,12 +29,12 @@ var costBudgetSetCmd = &cobra.Command{
 	Long: `Set a cost budget for the workspace, agent, or team.
 
 Examples:
-  bc cost budget set 100.00                          # Set workspace budget to $100
-  bc cost budget set 50.00 --agent engineer-01       # Set agent budget
-  bc cost budget set 500.00 --team engineering       # Set team budget
-  bc cost budget set 100.00 --period weekly          # Weekly budget
-  bc cost budget set 100.00 --alert-at 0.9           # Alert at 90%
-  bc cost budget set 100.00 --hard-stop              # Stop when limit reached`,
+  mycel cost budget set 100.00                          # Set workspace budget to $100
+  mycel cost budget set 50.00 --agent engineer-01       # Set agent budget
+  mycel cost budget set 500.00 --team engineering       # Set team budget
+  mycel cost budget set 100.00 --period weekly          # Weekly budget
+  mycel cost budget set 100.00 --alert-at 0.9           # Alert at 90%
+  mycel cost budget set 100.00 --hard-stop              # Stop when limit reached`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCostBudgetSet,
 }
@@ -45,8 +45,8 @@ var costBudgetShowCmd = &cobra.Command{
 	Long: `Show current budget configuration and status.
 
 Examples:
-  bc cost budget show                   # Show all budgets
-  bc cost budget show --agent eng-01    # Show agent budget`,
+  mycel cost budget show                   # Show all budgets
+  mycel cost budget show --agent eng-01    # Show agent budget`,
 	RunE: runCostBudgetShow,
 }
 
@@ -56,8 +56,8 @@ var costBudgetDeleteCmd = &cobra.Command{
 	Long: `Delete a budget configuration.
 
 Examples:
-  bc cost budget delete                  # Delete workspace budget
-  bc cost budget delete --agent eng-01   # Delete agent budget`,
+  mycel cost budget delete                  # Delete workspace budget
+  mycel cost budget delete --agent eng-01   # Delete agent budget`,
 	RunE: runCostBudgetDelete,
 }
 

--- a/internal/cmd/cost_report.go
+++ b/internal/cmd/cost_report.go
@@ -24,10 +24,10 @@ var costReportCmd = &cobra.Command{
 
 By default prints per-workspace breakdown. Use --by to change grouping:
 
-  bc cost report                  # per-workspace totals
-  bc cost report --by workspace   # per-workspace totals
-  bc cost report --by project     # per-project totals (workspace name grouping)
-  bc cost report --since 30d      # only include records from last 30 days`,
+  mycel cost report                  # per-workspace totals
+  mycel cost report --by workspace   # per-workspace totals
+  mycel cost report --by project     # per-project totals (workspace name grouping)
+  mycel cost report --since 30d      # only include records from last 30 days`,
 	RunE: runCostReport,
 }
 

--- a/internal/cmd/cost_usage.go
+++ b/internal/cmd/cost_usage.go
@@ -24,12 +24,12 @@ Claude Code's local JSONL session files.
 Requires npx (Node.js) to be available on the system.
 
 Examples:
-  bc cost usage                        # Daily usage report
-  bc cost usage --monthly              # Monthly summary
-  bc cost usage --session              # Per-session breakdown
-  bc cost usage --since 20260301       # Usage since date (YYYYMMDD)
-  bc cost usage --until 20260301       # Usage until date (YYYYMMDD)
-  bc cost usage --json                 # Raw JSON output`,
+  mycel cost usage                        # Daily usage report
+  mycel cost usage --monthly              # Monthly summary
+  mycel cost usage --session              # Per-session breakdown
+  mycel cost usage --since 20260301       # Usage since date (YYYYMMDD)
+  mycel cost usage --until 20260301       # Usage until date (YYYYMMDD)
+  mycel cost usage --json                 # Raw JSON output`,
 	RunE: runCostUsage,
 }
 

--- a/internal/cmd/cron.go
+++ b/internal/cmd/cron.go
@@ -27,14 +27,14 @@ Cron expressions use standard 5-field format:
   * * * * *
 
 Examples:
-  bc cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint"
-  bc cron list                          # List all cron jobs
-  bc cron show daily-lint               # Show job details
-  bc cron enable daily-lint             # Enable a disabled job
-  bc cron disable daily-lint            # Disable without deleting
-  bc cron run daily-lint                # Trigger manually
-  bc cron logs daily-lint --last 10     # Show last 10 executions
-  bc cron remove daily-lint             # Delete a job`,
+  mycel cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint"
+  mycel cron list                          # List all cron jobs
+  mycel cron show daily-lint               # Show job details
+  mycel cron enable daily-lint             # Enable a disabled job
+  mycel cron disable daily-lint            # Disable without deleting
+  mycel cron run daily-lint                # Trigger manually
+  mycel cron logs daily-lint --last 10     # Show last 10 executions
+  mycel cron remove daily-lint             # Delete a job`,
 }
 
 var cronAddCmd = &cobra.Command{
@@ -45,9 +45,9 @@ var cronAddCmd = &cobra.Command{
 One of --agent+--prompt or --command is required.
 
 Examples:
-  bc cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint and report"
-  bc cron add hourly-check --schedule "0 * * * *" --command "make check"
-  bc cron add weekday-standup --schedule "0 9 * * 1-5" --agent root --prompt "Send standup"`,
+  mycel cron add daily-lint --schedule "0 9 * * *" --agent qa-01 --prompt "Run make lint and report"
+  mycel cron add hourly-check --schedule "0 * * * *" --command "make check"
+  mycel cron add weekday-standup --schedule "0 9 * * 1-5" --agent root --prompt "Send standup"`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCronAdd,
 }
@@ -58,8 +58,8 @@ var cronListCmd = &cobra.Command{
 	Long: `Display all scheduled cron jobs with their status.
 
 Examples:
-  bc cron list
-  bc cron list --json`,
+  mycel cron list
+  mycel cron list --json`,
 	RunE: runCronList,
 }
 
@@ -69,8 +69,8 @@ var cronShowCmd = &cobra.Command{
 	Long: `Display full details of a cron job including schedule and run history stats.
 
 Examples:
-  bc cron show daily-lint
-  bc cron show daily-lint --json`,
+  mycel cron show daily-lint
+  mycel cron show daily-lint --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCronShow,
 }
@@ -82,7 +82,7 @@ var cronRemoveCmd = &cobra.Command{
 	Long: `Delete a cron job and its execution logs.
 
 Examples:
-  bc cron remove daily-lint`,
+  mycel cron remove daily-lint`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCronRemove,
 }
@@ -93,7 +93,7 @@ var cronEnableCmd = &cobra.Command{
 	Long: `Enable a disabled cron job. The next run time is recalculated from now.
 
 Examples:
-  bc cron enable daily-lint`,
+  mycel cron enable daily-lint`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCronEnable,
 }
@@ -104,7 +104,7 @@ var cronDisableCmd = &cobra.Command{
 	Long: `Disable a cron job without deleting it.
 
 Examples:
-  bc cron disable daily-lint`,
+  mycel cron disable daily-lint`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCronDisable,
 }
@@ -117,7 +117,7 @@ The job must be enabled. The daemon (bcd) executes the actual agent interaction;
 this command records the trigger and updates run stats.
 
 Examples:
-  bc cron run daily-lint`,
+  mycel cron run daily-lint`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCronRun,
 }
@@ -128,9 +128,9 @@ var cronLogsCmd = &cobra.Command{
 	Long: `Display the execution log for a cron job.
 
 Examples:
-  bc cron logs daily-lint
-  bc cron logs daily-lint --last 5
-  bc cron logs daily-lint --json`,
+  mycel cron logs daily-lint
+  mycel cron logs daily-lint --last 5
+  mycel cron logs daily-lint --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runCronLogs,
 }

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -27,11 +27,11 @@ Categories:
   git         Worktree validity and orphaned worktrees
 
 Examples:
-  bc doctor                          # Full health check
-  bc doctor check workspace          # Check specific category
-  bc doctor fix                      # Auto-fix fixable issues
-  bc doctor fix --dry-run            # Preview fixes
-  bc doctor fix --category git       # Fix specific category
+  mycel doctor                          # Full health check
+  mycel doctor check workspace          # Check specific category
+  mycel doctor fix                      # Auto-fix fixable issues
+  mycel doctor fix --dry-run            # Preview fixes
+  mycel doctor fix --category git       # Fix specific category
 
 Exit codes:
   0  All checks passed or only warnings
@@ -60,9 +60,9 @@ Fixable issues include:
 Use --dry-run to preview actions without making changes.
 
 Examples:
-  bc doctor fix                      # Fix all fixable issues
-  bc doctor fix --dry-run            # Preview fixes
-  bc doctor fix --category git       # Fix specific category`,
+  mycel doctor fix                      # Fix all fixable issues
+  mycel doctor fix --dry-run            # Preview fixes
+  mycel doctor fix --category git       # Fix specific category`,
 	RunE: runDoctorFix,
 }
 

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -19,8 +19,8 @@ var downCmd = &cobra.Command{
 	Long: `Stop bc-<id>-daemon and bc-db Docker containers.
 
 Examples:
-  bc down
-  bc down --workspace /path/to/workspace`,
+  mycel down
+  mycel down --workspace /path/to/workspace`,
 	RunE: runDown,
 }
 

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -15,8 +15,8 @@ import (
 
 var downCmd = &cobra.Command{
 	Use:   "down",
-	Short: "Stop bc services",
-	Long: `Stop bc-<id>-daemon and bc-db Docker containers.
+	Short: "Stop mycel services",
+	Long: `Stop the mycel daemon and database Docker containers for this workspace.
 
 Examples:
   mycel down
@@ -48,7 +48,7 @@ func runDown(cmd *cobra.Command, _ []string) error {
 
 	ctx := cmd.Context()
 
-	fmt.Printf("Stopping bc in %s\n\n", ws.RootDir)
+	fmt.Printf("Stopping mycel in %s\n\n", ws.RootDir)
 
 	id := wsID(ws.RootDir)
 	daemonName := fmt.Sprintf("bc-%s-daemon", id)

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -29,20 +29,20 @@ var initCmd = &cobra.Command{
 
 This creates a .mycel-scoped workspace directory with v2 configuration for managing agents.
 
-v2 workspace structure:
-  .bc/
-    settings.json  # Workspace configuration
-    roles/         # Agent role definitions
-      root.md      # Root agent role
-    agents/        # Per-agent state files
+v2 workspace structure (runtime state lives outside the project dir):
+  ~/.mycel/workspaces/<id>/
+    preferences.json  # Workspace configuration
+    roles/            # Agent role definitions
+      root.md         # Root agent role
+    agents/           # Per-agent state files
 
 Examples:
-  bc init                        # Interactive wizard
-  bc init --quick                # Quick init with defaults
-  bc init --preset solo          # Use solo developer preset
-  bc init --preset small-team    # Use small team preset
-  bc init --preset full-team     # Use full team preset
-  bc init ~/Projects/myapp       # Initialize specific directory`,
+  mycel init                        # Interactive wizard
+  mycel init --quick                # Quick init with defaults
+  mycel init --preset solo          # Use solo developer preset
+  mycel init --preset small-team    # Use small team preset
+  mycel init --preset full-team     # Use full team preset
+  mycel init ~/Projects/myapp       # Initialize specific directory`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runInit,
 }
@@ -159,8 +159,8 @@ func initV2Workspace(rootDir string) error {
 	fmt.Printf("  Default provider: %s\n", ws.Config.Providers.Default)
 	fmt.Printf("\n")
 	fmt.Printf("Next steps:\n")
-	fmt.Printf("  bc up       # Start agents\n")
-	fmt.Printf("  bc status   # Check agent status\n")
+	fmt.Printf("  mycel up       # Start agents\n")
+	fmt.Printf("  mycel status   # Check agent status\n")
 
 	return nil
 }
@@ -312,9 +312,9 @@ func initV2WorkspaceWithNickname(rootDir string, nickname string) error {
 	bootstrapServerDaemons(rootDir)
 
 	fmt.Println("  Next steps:")
-	fmt.Println("    bc          # Open the dashboard")
-	fmt.Println("    bc up       # Start agents")
-	fmt.Println("    bc status   # Check agent status")
+	fmt.Println("    mycel       # Open the dashboard")
+	fmt.Println("    mycel up    # Start agents")
+	fmt.Println("    mycel status # Check agent status")
 
 	return nil
 }

--- a/internal/cmd/init_wizard.go
+++ b/internal/cmd/init_wizard.go
@@ -254,9 +254,9 @@ func printWizardSuccess(state *WizardState) {
 	fmt.Println("    .bc/bc.db            # Workspace database")
 	fmt.Println()
 	fmt.Println("  Next steps:")
-	fmt.Println("    bc          # Open the dashboard")
-	fmt.Println("    bc up       # Start agents")
-	fmt.Println("    bc status   # Check agent status")
+	fmt.Println("    mycel       # Open the dashboard")
+	fmt.Println("    mycel up    # Start agents")
+	fmt.Println("    mycel status # Check agent status")
 	fmt.Println()
 }
 

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -19,13 +19,13 @@ var logsCmd = &cobra.Command{
 	Long: `View the bc event log showing agent spawns, stops, work assignments, and reports.
 
 Examples:
-  bc logs                     # Show all events
-  bc logs --agent eng-01      # Filter by agent
-  bc logs --type agent.report # Filter by event type
-  bc logs --since 1h          # Events from last hour
-  bc logs --tail 20           # Last N events
-  bc logs --full              # Show full messages (no truncation)
-  bc logs --json              # JSON output
+  mycel logs                     # Show all events
+  mycel logs --agent eng-01      # Filter by agent
+  mycel logs --type agent.report # Filter by event type
+  mycel logs --since 1h          # Events from last hour
+  mycel logs --tail 20           # Last N events
+  mycel logs --full              # Show full messages (no truncation)
+  mycel logs --json              # JSON output
 
 Event Types:
   agent.started    Agent was created and started
@@ -41,8 +41,8 @@ Output:
   10:16:45  eng-01    agent.report   Completed feature X
 
 See Also:
-  bc status    Quick agent status overview
-  bc home      TUI with activity timeline`,
+  mycel status    Quick agent status overview
+  mycel home      TUI with activity timeline`,
 	RunE: runLogs,
 }
 

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -26,15 +26,15 @@ MCP servers provide tools and resources to AI agents. Configurations are
 stored per-workspace and can be referenced by roles.
 
 Examples:
-  bc mcp list                                     # List all MCP servers
-  bc mcp add github --command npx --args "@modelcontextprotocol/server-github"
-  bc mcp add sqlite --command npx --args "@modelcontextprotocol/server-sqlite,/path/to/db"
-  bc mcp add remote --transport sse --url "https://api.example.com/mcp"
-  bc mcp add github --command npx --env "GITHUB_TOKEN=tok_123"
-  bc mcp show github                              # Show server details
-  bc mcp remove github                            # Remove a server
-  bc mcp disable github                           # Disable a server
-  bc mcp enable github                            # Re-enable a server`,
+  mycel mcp list                                     # List all MCP servers
+  mycel mcp add github --command npx --args "@modelcontextprotocol/server-github"
+  mycel mcp add sqlite --command npx --args "@modelcontextprotocol/server-sqlite,/path/to/db"
+  mycel mcp add remote --transport sse --url "https://api.example.com/mcp"
+  mycel mcp add github --command npx --env "GITHUB_TOKEN=tok_123"
+  mycel mcp show github                              # Show server details
+  mycel mcp remove github                            # Remove a server
+  mycel mcp disable github                           # Disable a server
+  mycel mcp enable github                            # Re-enable a server`,
 }
 
 var mcpAddCmd = &cobra.Command{
@@ -48,10 +48,10 @@ For SSE transport, specify --transport sse and --url.
 Environment variables can be passed with --env as KEY=VALUE pairs.
 
 Examples:
-  bc mcp add github --command npx --args "@modelcontextprotocol/server-github"
-  bc mcp add db --command npx --args "@modelcontextprotocol/server-sqlite,/tmp/test.db"
-  bc mcp add remote --transport sse --url "https://api.example.com/mcp"
-  bc mcp add github --command npx --env 'GITHUB_TOKEN=${secret:GITHUB_TOKEN}' --env "OWNER=me"
+  mycel mcp add github --command npx --args "@modelcontextprotocol/server-github"
+  mycel mcp add db --command npx --args "@modelcontextprotocol/server-sqlite,/tmp/test.db"
+  mycel mcp add remote --transport sse --url "https://api.example.com/mcp"
+  mycel mcp add github --command npx --env 'GITHUB_TOKEN=${secret:GITHUB_TOKEN}' --env "OWNER=me"
 
 Use ${secret:NAME} references for sensitive values (see 'mycel secret set').`,
 	Args: cobra.ExactArgs(1),
@@ -120,9 +120,9 @@ Tools available:
   query_costs      Query cost usage
 
 Examples:
-  bc mcp serve                    # stdio — use in Claude Code settings.json
-  bc mcp serve --sse              # SSE on :8811
-  bc mcp serve --sse --addr :9000 # SSE on custom port`,
+  mycel mcp serve                    # stdio — use in Claude Code settings.json
+  mycel mcp serve --sse              # SSE on :8811
+  mycel mcp serve --sse --addr :9000 # SSE on custom port`,
 	RunE: runMCPServe,
 }
 
@@ -135,8 +135,8 @@ This writes (or updates) the mcp.servers entry in the workspace
 settings.json so that agents automatically have access to bc MCP tools.
 
 Examples:
-  bc mcp register               # Register with stdio transport
-  bc mcp register --sse         # Register with SSE transport`,
+  mycel mcp register               # Register with stdio transport
+  mycel mcp register --sse         # Register with SSE transport`,
 	RunE: runMCPRegister,
 }
 

--- a/internal/cmd/notify.go
+++ b/internal/cmd/notify.go
@@ -23,11 +23,11 @@ Channels deliver external app messages to subscribed agents via tmux send-keys.
 Agents respond using the platform's own MCP tools.
 
 Examples:
-  bc notify status                               # Show gateway connection status
-  bc notify list                                  # List all subscriptions
-  bc notify subscribe slack:eng eng-01            # Subscribe agent to channel
-  bc notify unsubscribe slack:eng eng-01          # Unsubscribe agent
-  bc notify activity slack:eng                    # Show delivery activity log`,
+  mycel notify status                               # Show gateway connection status
+  mycel notify list                                  # List all subscriptions
+  mycel notify subscribe slack:eng eng-01            # Subscribe agent to channel
+  mycel notify unsubscribe slack:eng eng-01          # Unsubscribe agent
+  mycel notify activity slack:eng                    # Show delivery activity log`,
 	}
 
 	statusCmd := &cobra.Command{

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -25,14 +25,14 @@ var agentReportCmd = &cobra.Command{
 Valid states: idle, working, done, stuck, error
 
 For stuck state, use --reason to provide detailed context:
-  bc agent report stuck --reason "database connection timeout"
-  bc agent report stuck --reason "auth fails" --reproduction "login with test user" --severity critical
+  mycel agent report stuck --reason "database connection timeout"
+  mycel agent report stuck --reason "auth fails" --reproduction "login with test user" --severity critical
 
 Examples:
-  bc agent report working "fixing auth bug"
-  bc agent report done "auth bug fixed"
-  bc agent report stuck "need database credentials"
-  bc agent report stuck --reason "TUI freezes on channel select" --severity high`,
+  mycel agent report working "fixing auth bug"
+  mycel agent report done "auth bug fixed"
+  mycel agent report stuck "need database credentials"
+  mycel agent report stuck --reason "TUI freezes on channel select" --severity high`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: runReport,
 }

--- a/internal/cmd/secret.go
+++ b/internal/cmd/secret.go
@@ -30,13 +30,13 @@ Other configs reference secrets with ${secret:NAME} syntax:
   env = { ANTHROPIC_API_KEY = "${secret:ANTHROPIC_API_KEY}" }
 
 Examples:
-  bc secret set ANTHROPIC_API_KEY                    # Prompt for value
-  bc secret set ANTHROPIC_API_KEY --value "sk-..."   # Set directly
-  bc secret set GITHUB_TOKEN --from-env GITHUB_TOKEN # Import from env var
-  bc secret list                                     # List names (no values)
-  bc secret show ANTHROPIC_API_KEY                   # Show metadata
-  bc secret show ANTHROPIC_API_KEY --reveal          # Show actual value
-  bc secret delete ANTHROPIC_API_KEY                 # Delete a secret`,
+  mycel secret set ANTHROPIC_API_KEY                    # Prompt for value
+  mycel secret set ANTHROPIC_API_KEY --value "sk-..."   # Set directly
+  mycel secret set GITHUB_TOKEN --from-env GITHUB_TOKEN # Import from env var
+  mycel secret list                                     # List names (no values)
+  mycel secret show ANTHROPIC_API_KEY                   # Show metadata
+  mycel secret show ANTHROPIC_API_KEY --reveal          # Show actual value
+  mycel secret delete ANTHROPIC_API_KEY                 # Delete a secret`,
 }
 
 var secretSetCmd = &cobra.Command{
@@ -48,13 +48,13 @@ The value can be provided via --value, --from-env, or --from-file.
 If none are specified, reads from stdin.
 
 Note: --value appears in shell history. For sensitive values, prefer:
-  bc secret set API_KEY --from-env API_KEY
+  mycel secret set API_KEY --from-env API_KEY
   echo "sk-abc123" | bc secret set API_KEY
 
 Examples:
-  bc secret set API_KEY --value "sk-abc123"
-  bc secret set API_KEY --from-env API_KEY
-  bc secret set API_KEY --from-file /path/to/key
+  mycel secret set API_KEY --value "sk-abc123"
+  mycel secret set API_KEY --from-env API_KEY
+  mycel secret set API_KEY --from-file /path/to/key
   echo "sk-abc123" | bc secret set API_KEY`,
 	Args: cobra.ExactArgs(1),
 	RunE: runSecretSet,

--- a/internal/cmd/secret.go
+++ b/internal/cmd/secret.go
@@ -49,13 +49,13 @@ If none are specified, reads from stdin.
 
 Note: --value appears in shell history. For sensitive values, prefer:
   mycel secret set API_KEY --from-env API_KEY
-  echo "sk-abc123" | bc secret set API_KEY
+  echo "sk-abc123" | mycel secret set API_KEY
 
 Examples:
   mycel secret set API_KEY --value "sk-abc123"
   mycel secret set API_KEY --from-env API_KEY
   mycel secret set API_KEY --from-file /path/to/key
-  echo "sk-abc123" | bc secret set API_KEY`,
+  echo "sk-abc123" | mycel secret set API_KEY`,
 	Args: cobra.ExactArgs(1),
 	RunE: runSecretSet,
 }
@@ -129,7 +129,7 @@ func openSecretStore() (*secret.Store, error) {
 		return nil, fmt.Errorf("resolve global vault path: %w", err)
 	}
 	if _, ensureErr := workspace.EnsureGlobalDir(); ensureErr != nil {
-		return nil, fmt.Errorf("ensure global bc dir: %w", ensureErr)
+		return nil, fmt.Errorf("ensure global mycel dir: %w", ensureErr)
 	}
 	return secret.OpenVaultFile(vaultPath, passphrase)
 }

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -24,9 +24,9 @@ var statusCmd = &cobra.Command{
 	Long: `Show the status of all bc agents.
 
 Examples:
-  bc status                   # Show all agents
-  bc status --json            # Output as JSON
-  bc status --activity        # Show recent channel activity
+  mycel status                   # Show all agents
+  mycel status --json            # Output as JSON
+  mycel status --activity        # Show recent channel activity
 
 Output:
   AGENT     ROLE      STATE    UPTIME    TASK
@@ -41,9 +41,9 @@ Agent States:
   stopped   Agent is not running
 
 See Also:
-  bc agent list   List agents with more detail
-  bc logs         View agent event logs
-  bc home         Open TUI dashboard`,
+  mycel agent list   List agents with more detail
+  mycel logs         View agent event logs
+  mycel home         Open TUI dashboard`,
 	RunE: runStatus,
 }
 

--- a/internal/cmd/template.go
+++ b/internal/cmd/template.go
@@ -24,12 +24,12 @@ may override a template by placing a file with the same name under
 writing the user-global copy.
 
 Examples:
-  bc template list                    # List all templates (global + workspace overrides)
-  bc template show feature-dev        # Show template details
-  bc template create my-template      # Scaffold a new user-global template
-  bc template create my-template --workspace   # Workspace-local override
-  bc template delete my-template      # Delete (prefers workspace scope)
-  bc template delete my-template --global      # Delete user-global`,
+  mycel template list                    # List all templates (global + workspace overrides)
+  mycel template show feature-dev        # Show template details
+  mycel template create my-template      # Scaffold a new user-global template
+  mycel template create my-template --workspace   # Workspace-local override
+  mycel template delete my-template      # Delete (prefers workspace scope)
+  mycel template delete my-template --global      # Delete user-global`,
 	RunE: runTemplateList,
 }
 

--- a/internal/cmd/tool.go
+++ b/internal/cmd/tool.go
@@ -25,14 +25,14 @@ var toolCmd = &cobra.Command{
 	Long: `Add, remove, and inspect AI tool providers for agent spawning.
 
 Examples:
-  bc tool list              # Show all tools with status
-  bc tool add myagent       # Add a custom tool
-  bc tool show claude       # Show tool details
-  bc tool setup claude      # Install and configure a tool
-  bc tool status claude     # Check installation status
-  bc tool upgrade claude    # Upgrade an installed tool
-  bc tool delete mytool     # Remove a custom tool
-  bc tool run claude --help # Run a tool directly`,
+  mycel tool list              # Show all tools with status
+  mycel tool add myagent       # Add a custom tool
+  mycel tool show claude       # Show tool details
+  mycel tool setup claude      # Install and configure a tool
+  mycel tool status claude     # Check installation status
+  mycel tool upgrade claude    # Upgrade an installed tool
+  mycel tool delete mytool     # Remove a custom tool
+  mycel tool run claude --help # Run a tool directly`,
 }
 
 // ── list ──────────────────────────────────────────────────────────────────────
@@ -43,8 +43,8 @@ var toolListCmd = &cobra.Command{
 	Long: `Show all registered AI tool providers with installation status, version, and command.
 
 Examples:
-  bc tool list        # Table output
-  bc tool list --json # JSON output for scripting`,
+  mycel tool list        # Table output
+  mycel tool list --json # JSON output for scripting`,
 	RunE: runToolList,
 }
 
@@ -76,8 +76,8 @@ var toolAddCmd = &cobra.Command{
 	Long: `Add a custom tool provider to the workspace.
 
 Examples:
-  bc tool add mytool --command "mytool --yes" --install "pip install mytool"
-  bc tool add mytool --command "mytool" --slash-cmds "/help,/quit"`,
+  mycel tool add mytool --command "mytool --yes" --install "pip install mytool"
+  mycel tool add mytool --command "mytool" --slash-cmds "/help,/quit"`,
 	Args: cobra.ExactArgs(1),
 	RunE: runToolAdd,
 }

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -38,10 +38,10 @@ By default the server runs in the foreground (for Docker/Railway).
 Use -d to run as a background daemon.
 
 Examples:
-  bc up                              # Foreground (Docker/Railway)
-  bc up -d                           # Background daemon
-  bc up --addr 0.0.0.0:9374         # Custom listen address
-  bc up --workspace /path/to/ws     # Explicit workspace`,
+  mycel up                              # Foreground (Docker/Railway)
+  mycel up -d                           # Background daemon
+  mycel up --addr 0.0.0.0:9374         # Custom listen address
+  mycel up --workspace /path/to/ws     # Explicit workspace`,
 	RunE: runUp,
 }
 


### PR DESCRIPTION
## Summary
- Rename leftover `bc <verb>` references in Cobra `Long`/`Example` strings across 23 files under `internal/cmd/` to `mycel <verb>`. PR #3185 caught the common patterns but missed the multi-space indented example blocks.
- Update the "v2 workspace structure" block in `mycel init --help` to point at the M11+ runtime path (`~/.mycel/workspaces/<id>/`) instead of the legacy in-project `.bc/` layout.

Part of #3172.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/cmd/ ./pkg/workspace/` green
- [x] `golangci-lint run ./...` 0 issues
- [x] Fresh-HOME `mycel init --quick` — help + Next-steps output shows `mycel` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI help, examples, and “next steps” text throughout the app to use the `mycel` command prefix instead of the legacy `bc` prefix.
  * Aligned onboarding text with the current workspace layout and where runtime state is stored.
* **Bug Fixes**
  * Fixed inconsistent command examples across status, logs, config, cost, agent, channel, cron, and other CLI commands so help output matches the current command names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->