### PR TITLE
fix(ci): allow same-version npm publish so v0.3.0 can ship

### DIFF
--- a/.github/workflows/cd-npm.yml
+++ b/.github/workflows/cd-npm.yml
@@ -67,7 +67,7 @@ jobs:
         working-directory: packages/mycel-cli
         env:
           PKG_VERSION: ${{ steps.version.outputs.version }}
-        run: npm version "$PKG_VERSION" --no-git-tag-version
+        run: npm version "$PKG_VERSION" --no-git-tag-version --allow-same-version
 
       - name: Check if version already published
         id: published


### PR DESCRIPTION
## Summary
- CD (npm) failed on v0.3.0 with `npm error Version not changed` because `packages/mycel-cli/package.json` was pre-bumped to 0.3.0 in an earlier commit. `npm version` refuses to rewrite the same value.
- Add `--allow-same-version` so the step is idempotent.

## Test plan
- [ ] Merge, then re-dispatch `cd-npm.yml` with `tag=v0.3.0` — expect a successful publish of `mycel-cli@0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)