### PR TITLE
feat(container): rename bc-agent-* Docker images to mycel-agent-* (#3187 pt 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_DIR ?= bin
 GO ?= go
 
-REGISTRY ?= bc
+REGISTRY ?= mycel
+LEGACY_REGISTRY ?= bc
 IMAGE_TAG ?= latest
 AGENT_PROVIDERS := claude gemini codex cursor
 
@@ -154,21 +155,26 @@ build-docker-bcdb: build-docker-db ## Alias: Build bcdb (Postgres) Docker image
 
 build-docker-agent-base: ## Build agent base image
 	docker build -t $(REGISTRY)-agent-base:$(IMAGE_TAG) -f docker/Dockerfile.base .
+	docker tag $(REGISTRY)-agent-base:$(IMAGE_TAG) $(LEGACY_REGISTRY)-agent-base:$(IMAGE_TAG)
 
 build-docker-agent: build-docker-agent-base ## Build default agent image (claude)
 	docker build -t $(REGISTRY)-agent-claude:$(IMAGE_TAG) -f docker/Dockerfile.claude .
+	docker tag $(REGISTRY)-agent-claude:$(IMAGE_TAG) $(LEGACY_REGISTRY)-agent-claude:$(IMAGE_TAG)
 
 build-docker-agent-%: build-docker-agent-base ## Build agent image for provider
 	docker build -t $(REGISTRY)-agent-$*:$(IMAGE_TAG) -f docker/Dockerfile.$* .
+	docker tag $(REGISTRY)-agent-$*:$(IMAGE_TAG) $(LEGACY_REGISTRY)-agent-$*:$(IMAGE_TAG)
 
 build-docker-agents: build-docker-agent-base ## Build all agent images
 	@for p in $(AGENT_PROVIDERS); do \
 		echo "Building $(REGISTRY)-agent-$$p..."; \
 		docker build -t $(REGISTRY)-agent-$$p:$(IMAGE_TAG) -f docker/Dockerfile.$$p . || exit 1; \
+		docker tag $(REGISTRY)-agent-$$p:$(IMAGE_TAG) $(LEGACY_REGISTRY)-agent-$$p:$(IMAGE_TAG); \
 	done
 
 build-docker-agent-infra: build-docker-agent ## Build infra agent image (extends claude)
 	docker build -t $(REGISTRY)-agent-infra:$(IMAGE_TAG) -f docker/Dockerfile.infra .
+	docker tag $(REGISTRY)-agent-infra:$(IMAGE_TAG) $(LEGACY_REGISTRY)-agent-infra:$(IMAGE_TAG)
 
 build-docker-playwright: ## Build Playwright MCP Docker image (separate from main build)
 	docker build -t bc-playwright:latest -f docker/Dockerfile.playwright .

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-# bc agent base image — developer tools shared by all provider images
+# mycel agent base image — developer tools shared by all provider images
 # Usage: docker build -t mycel-agent-base:latest -f docker/Dockerfile.base .
 
 FROM ubuntu:24.04

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,5 +1,5 @@
 # bc agent base image — developer tools shared by all provider images
-# Usage: docker build -t bc-agent-base:latest -f docker/Dockerfile.base .
+# Usage: docker build -t mycel-agent-base:latest -f docker/Dockerfile.base .
 
 FROM ubuntu:24.04
 

--- a/docker/Dockerfile.claude
+++ b/docker/Dockerfile.claude
@@ -1,11 +1,11 @@
 # Claude Code agent image
-# Usage: docker build -t bc-agent-claude:latest -f docker/Dockerfile.claude .
-# Requires: bc-agent-base:latest (docker build -f docker/Dockerfile.base .)
+# Usage: docker build -t mycel-agent-claude:latest -f docker/Dockerfile.claude .
+# Requires: mycel-agent-base:latest (docker build -f docker/Dockerfile.base .)
 
 FROM alpine/git AS plugins
 RUN git clone --depth 1 https://github.com/anthropics/claude-plugins-official.git /plugins
 
-FROM bc-agent-base:latest AS base
+FROM mycel-agent-base:latest AS base
 
 USER root
 

--- a/docker/Dockerfile.codex
+++ b/docker/Dockerfile.codex
@@ -1,11 +1,11 @@
 # OpenAI Codex agent image
-# Requires: bc-agent-base:latest
+# Requires: mycel-agent-base:latest
 # Base images pinned — update versions in Dependabot PRs or manually.
 
 FROM oven/bun:1.2 AS builder
 RUN bun install -g @openai/codex
 
-FROM bc-agent-base:latest
+FROM mycel-agent-base:latest
 USER root
 COPY --from=builder /root/.bun/install/global/node_modules /usr/local/lib/node_modules
 RUN for f in /usr/local/lib/node_modules/.bin/*; do ln -sf "$f" /usr/local/bin/ 2>/dev/null || true; done

--- a/docker/Dockerfile.cursor
+++ b/docker/Dockerfile.cursor
@@ -1,11 +1,11 @@
 # Cursor Agent image
-# Requires: bc-agent-base:latest
+# Requires: mycel-agent-base:latest
 # Base images pinned — update versions in Dependabot PRs or manually.
 
 FROM oven/bun:1.2 AS builder
 RUN bun install -g cursor-agent
 
-FROM bc-agent-base:latest
+FROM mycel-agent-base:latest
 USER root
 COPY --from=builder /root/.bun/install/global/node_modules /usr/local/lib/node_modules
 RUN for f in /usr/local/lib/node_modules/.bin/*; do ln -sf "$f" /usr/local/bin/ 2>/dev/null || true; done

--- a/docker/Dockerfile.gemini
+++ b/docker/Dockerfile.gemini
@@ -1,11 +1,11 @@
 # Gemini CLI agent image
-# Requires: bc-agent-base:latest
+# Requires: mycel-agent-base:latest
 # Base images pinned — update versions in Dependabot PRs or manually.
 
 FROM oven/bun:1.2 AS builder
 RUN bun install -g @google/gemini-cli
 
-FROM bc-agent-base:latest
+FROM mycel-agent-base:latest
 USER root
 COPY --from=builder /root/.bun/install/global/node_modules /usr/local/lib/node_modules
 RUN ln -sf /usr/local/lib/node_modules/@google/gemini-cli/build/cli.js /usr/local/bin/gemini

--- a/docker/Dockerfile.infra
+++ b/docker/Dockerfile.infra
@@ -1,9 +1,9 @@
 # Infrastructure agent image with AWS CLI and Cloudflare CLI
 # Extends the Claude agent image with cloud ops tooling.
-# Usage: docker build -t bc-agent-infra:latest -f docker/Dockerfile.infra .
-# Requires: bc-agent-claude:latest
+# Usage: docker build -t mycel-agent-infra:latest -f docker/Dockerfile.infra .
+# Requires: mycel-agent-claude:latest
 
-FROM bc-agent-claude:latest
+FROM mycel-agent-claude:latest
 
 USER root
 

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/rpuneet/mycel/pkg/log"
 	"github.com/rpuneet/mycel/pkg/provider"
@@ -81,7 +82,7 @@ func ConfigFromWorkspace(dcfg workspace.DockerRuntimeConfig) Config {
 		MemoryMB:    dcfg.MemoryMB,
 	}
 	if cfg.Image == "" {
-		cfg.Image = "bc-agent-claude:latest"
+		cfg.Image = "mycel-agent-claude:latest"
 	}
 	if cfg.CPUs == 0 {
 		cfg.CPUs = 2.0
@@ -186,6 +187,11 @@ func (b *Backend) hostAgentDir(agentName, hostRoot string) string {
 }
 
 // imageForTool returns the Docker image for a given agent tool name.
+//
+// Prefers the current mycel-agent-<tool>:latest tag. If only the legacy
+// bc-agent-<tool>:latest image is present locally, returns that instead so
+// pre-rename installs keep booting. The fallback is skipped when the caller
+// has no docker daemon available (probeImageExists returns false quickly).
 func (b *Backend) imageForTool(toolName string) string {
 	if toolName == "" {
 		return b.cfg.Image
@@ -199,7 +205,34 @@ func (b *Backend) imageForTool(toolName string) string {
 			}
 		}
 	}
-	return "bc-agent-" + toolName + ":latest"
+	return resolveImageWithLegacyFallback("mycel-agent-"+toolName+":latest", "bc-agent-"+toolName+":latest")
+}
+
+// resolveImageWithLegacyFallback returns preferred if it exists locally
+// (or if the local image inventory can't be probed), else fallback.
+// This exists solely to bridge the bc-agent-* → mycel-agent-* rename for
+// installs that were bootstrapped before v0.3.1. Remove after one cycle.
+func resolveImageWithLegacyFallback(preferred, fallback string) string {
+	if imageExistsLocally(preferred) {
+		return preferred
+	}
+	if imageExistsLocally(fallback) {
+		return fallback
+	}
+	return preferred
+}
+
+// imageExistsLocally returns true if `docker image inspect <ref>` succeeds.
+// Returns false on any error (including no docker daemon) so callers treat
+// "unknown" as "not present" and stick with the preferred name.
+func imageExistsLocally(ref string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	//nolint:gosec // trusted binary, ref built from constant prefixes
+	cmd := exec.CommandContext(ctx, "docker", "image", "inspect", ref)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
 }
 
 // SessionName returns the full session name with prefix.
@@ -290,10 +323,17 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 		cmdBin := strings.Fields(command)
 		if len(cmdBin) > 0 {
 			bin := cmdBin[0]
-			// If image is tool-specific (bc-agent-<X>) but command binary doesn't match,
-			// the binary likely doesn't exist in the image.
-			if strings.HasPrefix(image, "bc-agent-") {
-				imageTool := strings.TrimSuffix(strings.TrimPrefix(image, "bc-agent-"), ":latest")
+			// If image is tool-specific (mycel-agent-<X> or legacy bc-agent-<X>)
+			// but command binary doesn't match, the binary likely doesn't exist
+			// in the image.
+			var imageTool string
+			switch {
+			case strings.HasPrefix(image, "mycel-agent-"):
+				imageTool = strings.TrimSuffix(strings.TrimPrefix(image, "mycel-agent-"), ":latest")
+			case strings.HasPrefix(image, "bc-agent-"):
+				imageTool = strings.TrimSuffix(strings.TrimPrefix(image, "bc-agent-"), ":latest")
+			}
+			if imageTool != "" {
 				if bin != imageTool && bin != "bash" && bin != "sh" {
 					// Only warn if the binary name looks like a different tool
 					for _, knownTool := range []string{"claude", "gemini", "cursor", "codex"} {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -316,10 +316,16 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 		return fmt.Errorf("workspace %q is not a git repository (no .git found): %w", dir, err)
 	}
 
+	// Resolve image once per session — avoids double docker probe
+	// (validation below + docker run selection at the end).
+	image := b.cfg.Image
+	if toolName, ok := env["BC_AGENT_TOOL"]; ok && toolName != "" {
+		image = b.imageForTool(toolName)
+	}
+
 	// Validate tool/image consistency — catch mismatches like running "gemini"
 	// command inside a "bc-agent-claude" image (Exit 127).
 	if toolName, ok := env["BC_AGENT_TOOL"]; ok && toolName != "" {
-		image := b.imageForTool(toolName)
 		cmdBin := strings.Fields(command)
 		if len(cmdBin) > 0 {
 			bin := cmdBin[0]
@@ -448,13 +454,8 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 		args = append(args, "-e", k+"="+v)
 	}
 
-	// Select image based on agent tool
-	image := b.cfg.Image
-	if toolName, ok := env["BC_AGENT_TOOL"]; ok && toolName != "" {
-		image = b.imageForTool(toolName)
-	}
-
 	// Run the agent command. claude --tmux handles its own tmux session.
+	// image was resolved once at the top of this function.
 	args = append(args, "--entrypoint", "bash", image, "-c", command)
 
 	log.Debug("creating docker container", "name", cn, "image", image)

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -16,8 +16,8 @@ import (
 func TestConfigFromWorkspace_Defaults(t *testing.T) {
 	cfg := ConfigFromWorkspace(workspace.DockerRuntimeConfig{})
 
-	if cfg.Image != "bc-agent-claude:latest" {
-		t.Errorf("Image = %q, want bc-agent-claude:latest", cfg.Image)
+	if cfg.Image != "mycel-agent-claude:latest" {
+		t.Errorf("Image = %q, want mycel-agent-claude:latest", cfg.Image)
 	}
 	if cfg.CPUs != 2.0 {
 		t.Errorf("CPUs = %f, want 2.0", cfg.CPUs)
@@ -124,24 +124,24 @@ func TestSessionName(t *testing.T) {
 
 func TestImageForTool_Default(t *testing.T) {
 	b := &Backend{
-		cfg: Config{Image: "bc-agent-claude:latest"},
+		cfg: Config{Image: "mycel-agent-claude:latest"},
 	}
 
 	// Empty tool name returns default image
 	got := b.imageForTool("")
-	if got != "bc-agent-claude:latest" {
-		t.Errorf("imageForTool(\"\") = %q, want bc-agent-claude:latest", got)
+	if got != "mycel-agent-claude:latest" {
+		t.Errorf("imageForTool(\"\") = %q, want mycel-agent-claude:latest", got)
 	}
 }
 
 func TestImageForTool_Convention(t *testing.T) {
 	b := &Backend{
-		cfg: Config{Image: "bc-agent-claude:latest"},
+		cfg: Config{Image: "mycel-agent-claude:latest"},
 	}
 
 	// Unknown tool without registry falls back to convention
 	got := b.imageForTool("gemini")
-	want := "bc-agent-gemini:latest"
+	want := "mycel-agent-gemini:latest"
 	if got != want {
 		t.Errorf("imageForTool(\"gemini\") = %q, want %q", got, want)
 	}
@@ -155,7 +155,7 @@ func TestImageForTool_FallbackToConfig(t *testing.T) {
 	// Tool that doesn't match convention pattern
 	got := b.imageForTool("unknown-tool")
 	// Should return convention-based name
-	want := "bc-agent-unknown-tool:latest"
+	want := "mycel-agent-unknown-tool:latest"
 	if got != want {
 		t.Errorf("imageForTool(\"unknown-tool\") = %q, want %q", got, want)
 	}
@@ -185,7 +185,7 @@ func TestImageForTool_WithContainerCustomizer(t *testing.T) {
 	registry.Register(mp)
 
 	b := &Backend{
-		cfg:              Config{Image: "bc-agent-claude:latest"},
+		cfg:              Config{Image: "mycel-agent-claude:latest"},
 		providerRegistry: registry,
 	}
 
@@ -202,12 +202,12 @@ func TestImageForTool_CustomizerReturnsEmpty(t *testing.T) {
 	registry.Register(mp)
 
 	b := &Backend{
-		cfg:              Config{Image: "bc-agent-claude:latest"},
+		cfg:              Config{Image: "mycel-agent-claude:latest"},
 		providerRegistry: registry,
 	}
 
 	got := b.imageForTool("empty-img")
-	want := "bc-agent-empty-img:latest"
+	want := "mycel-agent-empty-img:latest"
 	if got != want {
 		t.Errorf("imageForTool(\"empty-img\") = %q, want %q (should fall through to convention)", got, want)
 	}
@@ -220,12 +220,12 @@ func TestImageForTool_RegistryMiss(t *testing.T) {
 	registry.Register(mp)
 
 	b := &Backend{
-		cfg:              Config{Image: "bc-agent-claude:latest"},
+		cfg:              Config{Image: "mycel-agent-claude:latest"},
 		providerRegistry: registry,
 	}
 
 	got := b.imageForTool("missing-tool")
-	want := "bc-agent-missing-tool:latest"
+	want := "mycel-agent-missing-tool:latest"
 	if got != want {
 		t.Errorf("imageForTool(\"missing-tool\") = %q, want %q", got, want)
 	}
@@ -236,7 +236,7 @@ func TestCreateSessionWithEnv_EmptyDir(t *testing.T) {
 		prefix:        "bc-",
 		workspaceHash: "aabbcc",
 		workspacePath: t.TempDir(),
-		cfg:           Config{Image: "bc-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
+		cfg:           Config{Image: "mycel-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
 		logCancels:    make(map[string]context.CancelFunc),
 	}
 
@@ -255,7 +255,7 @@ func TestCreateSessionWithEnv_NoGitDir(t *testing.T) {
 		prefix:        "bc-",
 		workspaceHash: "aabbcc",
 		workspacePath: dir,
-		cfg:           Config{Image: "bc-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
+		cfg:           Config{Image: "mycel-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
 		logCancels:    make(map[string]context.CancelFunc),
 	}
 
@@ -279,7 +279,7 @@ func TestCreateSessionWithEnv_ToolImageMismatch(t *testing.T) {
 		prefix:        "bc-",
 		workspaceHash: "aabbcc",
 		workspacePath: dir,
-		cfg:           Config{Image: "bc-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
+		cfg:           Config{Image: "mycel-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
 		logCancels:    make(map[string]context.CancelFunc),
 	}
 
@@ -305,7 +305,7 @@ func TestCreateSessionWithEnv_ToolImageMatch(t *testing.T) {
 		prefix:        "bc-",
 		workspaceHash: "aabbcc",
 		workspacePath: dir,
-		cfg:           Config{Image: "bc-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
+		cfg:           Config{Image: "mycel-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
 		logCancels:    make(map[string]context.CancelFunc),
 	}
 

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -162,7 +162,7 @@ func DefaultConfig() Config {
 		Runtime: RuntimeConfig{
 			Default: "docker",
 			Docker: DockerRuntimeConfig{
-				Image:            "bc-agent:latest",
+				Image:            "mycel-agent-claude:latest",
 				Network:          "bc-net",
 				DockerSocketPath: "/var/run/docker.sock",
 				CPUs:             2,


### PR DESCRIPTION
## Summary
Part of #3187 — rename the six agent image tags (base/claude/gemini/codex/cursor/infra) to the `mycel-*` namespace. Discovered while trying to dispatch lucid-meerkat post-v0.3.0: `bc-agent-cursor:latest` was missing and there was no fallback.

- Dockerfiles build/depend on `mycel-agent-base:latest` and `mycel-agent-claude:latest`.
- Makefile `REGISTRY` default → `mycel`; every agent build target dual-tags the produced image as `bc-agent-*:latest` for one transition cycle so pre-v0.3.1 configs keep working.
- `pkg/container`: `ConfigFromWorkspace` defaults to `mycel-agent-claude:latest`; `imageForTool` prefers `mycel-agent-<x>` but falls back to `bc-agent-<x>` if only the legacy image is present locally (via bounded `docker image inspect` probe). Image is now resolved once per session.
- `pkg/workspace`: `DefaultConfig()` seeds new workspaces with `mycel-agent-claude:latest` instead of the stale `bc-agent:latest`.
- Tool/image mismatch validator recognises both prefixes.
- Tests updated to mycel-* names.

Part 2 (tmux session prefix `bc-<hash>` → `mycel-<hash>` with reader-side fallback) will land in a separate PR.

## Test plan
- [x] go build/test/lint clean
- [ ] Re-verify locally with `make build-docker-agents` — expect both `mycel-agent-*:latest` and `bc-agent-*:latest` tags to appear
- [ ] Dispatch a docker agent (lucid-meerkat) after merge — expect no image-not-found errors

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>