### PR TITLE
feat(runtime): rename bc-<hash> session/container prefix to mycel- (#3187 pt 2)

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -39,10 +39,11 @@ func newAgentManager(ws *workspace.Workspace) *agent.Manager {
 			wsCfg = ws.Config.Runtime.Docker
 		}
 		dockerCfg := container.ConfigFromWorkspace(wsCfg)
-		be, err := container.NewBackend(dockerCfg, "bc-", ws.RootDir, provider.DefaultRegistry)
+		be, err := container.NewBackend(dockerCfg, agent.DefaultSessionPrefix, ws.RootDir, provider.DefaultRegistry)
 		if err != nil {
 			log.Warn("Docker unavailable, falling back to tmux", "error", err)
 		} else {
+			be = be.WithLegacyPrefix(agent.LegacySessionPrefix)
 			mgr = agent.NewWorkspaceManagerWithRuntime(ws.AgentsDir(), ws.RootDir, be, "docker")
 		}
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -83,13 +83,14 @@ const MaxAgentNameLength = 64
 // Default configuration constants.
 const (
 	// DefaultSessionPrefix is the tmux session / container name prefix for
-	// mycel agents (was "bc-" prior to v0.3.1).
-	DefaultSessionPrefix = "mycel-"
+	// mycel agents (was "bc-" prior to v0.3.1). Sourced from pkg/tmux so
+	// there is a single source of truth for the rename.
+	DefaultSessionPrefix = tmux.DefaultPrefix
 
 	// LegacySessionPrefix is the pre-v0.3.1 prefix. Reader-side fallbacks
 	// use this so agents/sessions created before the rename keep working
 	// for one release cycle. Remove after v0.3.2.
-	LegacySessionPrefix = "bc-"
+	LegacySessionPrefix = tmux.LegacyPrefix
 
 	// DefaultProvider is the default AI provider for new agents.
 	DefaultProvider = "claude"

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -82,8 +82,14 @@ const MaxAgentNameLength = 64
 
 // Default configuration constants.
 const (
-	// DefaultSessionPrefix is the tmux session name prefix for bc agents.
-	DefaultSessionPrefix = "bc-"
+	// DefaultSessionPrefix is the tmux session / container name prefix for
+	// mycel agents (was "bc-" prior to v0.3.1).
+	DefaultSessionPrefix = "mycel-"
+
+	// LegacySessionPrefix is the pre-v0.3.1 prefix. Reader-side fallbacks
+	// use this so agents/sessions created before the rename keep working
+	// for one release cycle. Remove after v0.3.2.
+	LegacySessionPrefix = "bc-"
 
 	// DefaultProvider is the default AI provider for new agents.
 	DefaultProvider = "claude"
@@ -579,7 +585,7 @@ func normalizeRuntime(rt string) string {
 // NewManager creates a new agent manager with workspace-scoped tmux sessions.
 func NewManager(stateDir string) *Manager {
 	cmd, tool := defaultAgentCmd()
-	tmuxBe := runtime.NewTmuxBackend(tmux.NewManager(DefaultSessionPrefix))
+	tmuxBe := runtime.NewTmuxBackend(tmux.NewManager(DefaultSessionPrefix).WithLegacyPrefix(LegacySessionPrefix))
 	return &Manager{
 		agents:           make(map[string]*Agent),
 		agentLocks:       make(map[string]*sync.Mutex),
@@ -601,7 +607,7 @@ func NewManager(stateDir string) *Manager {
 // and their worktrees at <stateDir>/agents/<name>/bc-<ws>-<name>/.
 func NewWorkspaceManager(stateDir, workspacePath string) *Manager {
 	cmd, tool := defaultAgentCmd()
-	tmuxBe := runtime.NewTmuxBackend(tmux.NewWorkspaceManager(DefaultSessionPrefix, workspacePath))
+	tmuxBe := runtime.NewTmuxBackend(tmux.NewWorkspaceManager(DefaultSessionPrefix, workspacePath).WithLegacyPrefix(LegacySessionPrefix))
 	return &Manager{
 		agents:           make(map[string]*Agent),
 		agentLocks:       make(map[string]*sync.Mutex),
@@ -624,7 +630,7 @@ func NewWorkspaceManagerWithRuntime(stateDir, workspacePath string, rt runtime.B
 	bes := map[string]runtime.Backend{rtName: rt}
 	// Always register a tmux backend so agents with RuntimeBackend="tmux" work
 	if rtName != "tmux" {
-		bes["tmux"] = runtime.NewTmuxBackend(tmux.NewWorkspaceManager(DefaultSessionPrefix, workspacePath))
+		bes["tmux"] = runtime.NewTmuxBackend(tmux.NewWorkspaceManager(DefaultSessionPrefix, workspacePath).WithLegacyPrefix(LegacySessionPrefix))
 	}
 	return &Manager{
 		agents:           make(map[string]*Agent),

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -102,11 +102,20 @@ type Backend struct {
 	logCancels        map[string]context.CancelFunc
 	providerRegistry  *provider.Registry
 	prefix            string
+	legacyPrefix      string // Optional prior container-name prefix ("bc-") — reader-side fallback for pre-rename containers.
 	workspaceHash     string
 	workspacePath     string
 	hostWorkspacePath string // host path for Docker-in-Docker mounts (from BC_HOST_WORKSPACE)
 	cfg               Config
 	mu                sync.RWMutex
+}
+
+// WithLegacyPrefix configures a prior container-name prefix that ListSessions
+// should also recognize. Used during renames (v0.3.1: "bc-" → "mycel-") so
+// pre-upgrade containers remain discoverable for one cycle.
+func (b *Backend) WithLegacyPrefix(prefix string) *Backend {
+	b.legacyPrefix = prefix
+	return b
 }
 
 // NewBackend creates a Docker runtime backend.
@@ -619,6 +628,10 @@ func (b *Backend) ListSessions(ctx context.Context) ([]runtime.Session, error) {
 
 	var sessions []runtime.Session
 	fullPrefix := b.prefix + b.workspaceHash + "-"
+	var legacyFullPrefix string
+	if b.legacyPrefix != "" && b.legacyPrefix != b.prefix {
+		legacyFullPrefix = b.legacyPrefix + b.workspaceHash + "-"
+	}
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		if line == "" {
 			continue
@@ -628,11 +641,17 @@ func (b *Backend) ListSessions(ctx context.Context) ([]runtime.Session, error) {
 			continue
 		}
 		n := parts[0]
-		if !strings.HasPrefix(n, fullPrefix) {
+		matched := ""
+		switch {
+		case strings.HasPrefix(n, fullPrefix):
+			matched = fullPrefix
+		case legacyFullPrefix != "" && strings.HasPrefix(n, legacyFullPrefix):
+			matched = legacyFullPrefix
+		default:
 			continue
 		}
 		sessions = append(sessions, runtime.Session{
-			Name:    strings.TrimPrefix(n, fullPrefix),
+			Name:    strings.TrimPrefix(n, matched),
 			Created: parts[1],
 		})
 	}

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -75,6 +75,15 @@ type Session struct {
 // DefaultCacheTTL is the default time-to-live for cached session data.
 const DefaultCacheTTL = 2 * time.Second
 
+// DefaultPrefix is the canonical tmux session-name prefix used since v0.3.1.
+// LegacyPrefix is the pre-v0.3.1 prefix retained for reader-side fallback
+// so upgraded workspaces can still see sessions that were created before
+// the rename. Remove LegacyPrefix + associated fallback after v0.3.2.
+const (
+	DefaultPrefix = "mycel-"
+	LegacyPrefix  = "bc-"
+)
+
 // Manager handles tmux session operations.
 type Manager struct {
 	// Session cache for reducing tmux subprocess calls (#980).
@@ -150,12 +159,13 @@ func NewWorkspaceManager(prefix, workspacePath string) *Manager {
 	}
 }
 
-// NewDefaultManager creates a new tmux manager with default prefix "mycel-"
-// and "bc-" as the reader-side legacy fallback.
+// NewDefaultManager creates a new tmux manager with the canonical prefix
+// (DefaultPrefix, "mycel-") and the legacy prefix (LegacyPrefix, "bc-")
+// wired for reader-side fallback.
 func NewDefaultManager() *Manager {
 	return &Manager{
-		SessionPrefix:   "mycel-",
-		LegacyPrefix:    "bc-",
+		SessionPrefix:   DefaultPrefix,
+		LegacyPrefix:    LegacyPrefix,
 		execCommand:     exec.Command,
 		hasSessionCache: make(map[string]bool),
 		cacheTTL:        DefaultCacheTTL,
@@ -512,6 +522,21 @@ func (m *Manager) ListSessions(ctx context.Context) ([]Session, error) {
 		return nil, err
 	}
 
+	// Build full prefixes once — they don't depend on the current line.
+	// The legacy prefix is also matched so pre-rename sessions remain
+	// listable during the transition cycle.
+	fullPrefix := m.SessionPrefix
+	if m.workspaceHash != "" {
+		fullPrefix = m.SessionPrefix + m.workspaceHash + "-"
+	}
+	var legacyFullPrefix string
+	if m.LegacyPrefix != "" && m.LegacyPrefix != m.SessionPrefix {
+		legacyFullPrefix = m.LegacyPrefix
+		if m.workspaceHash != "" {
+			legacyFullPrefix = m.LegacyPrefix + m.workspaceHash + "-"
+		}
+	}
+
 	var sessions []Session
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
 		if line == "" {
@@ -524,20 +549,6 @@ func (m *Manager) ListSessions(ctx context.Context) ([]Session, error) {
 		}
 
 		name := parts[0]
-		// Build full prefixes including workspace hash. The legacy prefix
-		// is also matched so pre-rename sessions remain listable during
-		// the transition cycle.
-		fullPrefix := m.SessionPrefix
-		if m.workspaceHash != "" {
-			fullPrefix = m.SessionPrefix + m.workspaceHash + "-"
-		}
-		var legacyFullPrefix string
-		if m.LegacyPrefix != "" && m.LegacyPrefix != m.SessionPrefix {
-			legacyFullPrefix = m.LegacyPrefix
-			if m.workspaceHash != "" {
-				legacyFullPrefix = m.LegacyPrefix + m.workspaceHash + "-"
-			}
-		}
 		matchedPrefix := ""
 		switch {
 		case strings.HasPrefix(name, fullPrefix):

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -84,7 +84,8 @@ type Manager struct {
 	execCommand     func(name string, arg ...string) *exec.Cmd
 	sessionLocks    map[string]*sync.Mutex
 	hasSessionCache map[string]bool // Cached session existence checks
-	SessionPrefix   string          // Prepended to all session names (e.g., "bc-")
+	SessionPrefix   string          // Prepended to all session names (e.g., "mycel-")
+	LegacyPrefix    string          // Optional prior prefix (e.g., "bc-") — reader-side fallback for pre-rename sessions.
 	workspaceHash   string          // Included in session names for workspace isolation
 	sessionsCache   []Session       // Cached list of sessions
 	cacheTTL        time.Duration   // Cache TTL (default: 2 seconds)
@@ -149,14 +150,24 @@ func NewWorkspaceManager(prefix, workspacePath string) *Manager {
 	}
 }
 
-// NewDefaultManager creates a new tmux manager with default prefix "bc-".
+// NewDefaultManager creates a new tmux manager with default prefix "mycel-"
+// and "bc-" as the reader-side legacy fallback.
 func NewDefaultManager() *Manager {
 	return &Manager{
-		SessionPrefix:   "bc-",
+		SessionPrefix:   "mycel-",
+		LegacyPrefix:    "bc-",
 		execCommand:     exec.Command,
 		hasSessionCache: make(map[string]bool),
 		cacheTTL:        DefaultCacheTTL,
 	}
+}
+
+// WithLegacyPrefix configures a prior session-name prefix that the manager
+// should also recognize when reading existing sessions. Used during renames
+// (v0.3.1: "bc-" → "mycel-") so pre-upgrade sessions remain discoverable.
+func (m *Manager) WithLegacyPrefix(prefix string) *Manager {
+	m.LegacyPrefix = prefix
+	return m
 }
 
 // WithExecCommand returns a copy of the Manager with a custom command executor.
@@ -197,6 +208,15 @@ func (m *Manager) HasSession(ctx context.Context, name string) bool {
 	cmd := m.command(ctx, "tmux", "has-session", "-t", fullName)
 	exists := cmd.Run() == nil
 
+	// Fallback: check the legacy prefix so pre-rename sessions still resolve.
+	if !exists && m.LegacyPrefix != "" && m.LegacyPrefix != m.SessionPrefix {
+		legacyName := m.legacySessionName(name)
+		if legacyName != fullName {
+			legacyCmd := m.command(ctx, "tmux", "has-session", "-t", legacyName)
+			exists = legacyCmd.Run() == nil
+		}
+	}
+
 	// Update cache
 	m.cacheMu.Lock()
 	if m.hasSessionCache == nil {
@@ -207,6 +227,18 @@ func (m *Manager) HasSession(ctx context.Context, name string) bool {
 	m.cacheMu.Unlock()
 
 	return exists
+}
+
+// legacySessionName returns the session name using LegacyPrefix instead of
+// SessionPrefix, or an empty string when no legacy prefix is configured.
+func (m *Manager) legacySessionName(name string) string {
+	if m.LegacyPrefix == "" {
+		return ""
+	}
+	if m.workspaceHash != "" {
+		return m.LegacyPrefix + m.workspaceHash + "-" + name
+	}
+	return m.LegacyPrefix + name
 }
 
 // invalidateCache clears all cached session data.
@@ -492,19 +524,33 @@ func (m *Manager) ListSessions(ctx context.Context) ([]Session, error) {
 		}
 
 		name := parts[0]
-		// Build full prefix including workspace hash
+		// Build full prefixes including workspace hash. The legacy prefix
+		// is also matched so pre-rename sessions remain listable during
+		// the transition cycle.
 		fullPrefix := m.SessionPrefix
 		if m.workspaceHash != "" {
 			fullPrefix = m.SessionPrefix + m.workspaceHash + "-"
 		}
-		// Only include sessions with our prefix
-		if !strings.HasPrefix(name, fullPrefix) {
+		var legacyFullPrefix string
+		if m.LegacyPrefix != "" && m.LegacyPrefix != m.SessionPrefix {
+			legacyFullPrefix = m.LegacyPrefix
+			if m.workspaceHash != "" {
+				legacyFullPrefix = m.LegacyPrefix + m.workspaceHash + "-"
+			}
+		}
+		matchedPrefix := ""
+		switch {
+		case strings.HasPrefix(name, fullPrefix):
+			matchedPrefix = fullPrefix
+		case legacyFullPrefix != "" && strings.HasPrefix(name, legacyFullPrefix):
+			matchedPrefix = legacyFullPrefix
+		default:
 			continue
 		}
 
 		windows, _ := strconv.Atoi(parts[3])
 		sessions = append(sessions, Session{
-			Name:      strings.TrimPrefix(name, fullPrefix),
+			Name:      strings.TrimPrefix(name, matchedPrefix),
 			Created:   parts[1],
 			Directory: parts[4],
 			Windows:   windows,

--- a/pkg/tmux/session_test.go
+++ b/pkg/tmux/session_test.go
@@ -183,8 +183,11 @@ func TestNewManager(t *testing.T) {
 
 func TestNewDefaultManager(t *testing.T) {
 	m := NewDefaultManager()
-	if m.SessionPrefix != "bc-" {
-		t.Errorf("SessionPrefix = %q, want %q", m.SessionPrefix, "bc-")
+	if m.SessionPrefix != "mycel-" {
+		t.Errorf("SessionPrefix = %q, want %q", m.SessionPrefix, "mycel-")
+	}
+	if m.LegacyPrefix != "bc-" {
+		t.Errorf("LegacyPrefix = %q, want %q", m.LegacyPrefix, "bc-")
 	}
 	if m.execCommand == nil {
 		t.Error("execCommand should not be nil")

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -169,7 +169,7 @@ func DefaultConfig() Config {
 				MemoryMB:         4096,
 			},
 			Tmux: TmuxRuntimeConfig{
-				SessionPrefix: "bc",
+				SessionPrefix: "mycel",
 				HistoryLimit:  10000,
 				DefaultShell:  "/bin/bash",
 			},

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -370,11 +370,12 @@ func newAgentManager(ws *bcworkspace.Workspace) (*bcagent.Manager, *bccontainer.
 		wsCfg = ws.Config.Runtime.Docker
 	}
 	dockerCfg := bccontainer.ConfigFromWorkspace(wsCfg)
-	be, err := bccontainer.NewBackend(dockerCfg, "bc-", ws.RootDir, provider.DefaultRegistry)
+	be, err := bccontainer.NewBackend(dockerCfg, bcagent.DefaultSessionPrefix, ws.RootDir, provider.DefaultRegistry)
 	if err != nil {
 		log.Warn("Docker not available — agents will use tmux runtime only", "error", err, "workspace", ws.RootDir)
 		return bcagent.NewWorkspaceManager(ws.AgentsDir(), ws.RootDir), nil, nil
 	}
+	be = be.WithLegacyPrefix(bcagent.LegacySessionPrefix)
 	mgr := bcagent.NewWorkspaceManagerWithRuntime(ws.AgentsDir(), ws.RootDir, be, "docker")
 	return mgr, be, nil
 }


### PR DESCRIPTION
## Summary
Part of #3187 — rename the tmux session and Docker container name prefix from `bc-<hash>-*` to `mycel-<hash>-*`. Reader-side fallback keeps pre-v0.3.1 sessions/containers discoverable for one release cycle.

- `pkg/agent`: `DefaultSessionPrefix` → `mycel-`; new `LegacySessionPrefix = "bc-"`.
- `pkg/tmux`: `NewDefaultManager` defaults to `mycel-` with `bc-` as legacy. `Manager` gains `WithLegacyPrefix(prefix)`. `HasSession` and `ListSessions` also match the legacy prefix.
- `pkg/container`: `Backend` gains `WithLegacyPrefix(prefix)`. `ListSessions` also matches `bc-<hash>-` alongside `mycel-<hash>-`.
- `pkg/workspace`: `DefaultConfig().Runtime.Tmux.SessionPrefix` → `mycel`.
- `internal/cmd`, `server/build_services`: `container.NewBackend` uses `agent.DefaultSessionPrefix` and chains `WithLegacyPrefix(agent.LegacySessionPrefix)`.

Wraps up the v0.3.1 rename work started by #3197 (Part 1: Docker image tag rename). After one release cycle, `LegacySessionPrefix` and the fallback branches can be removed.

## Test plan
- [x] go build ./... clean
- [x] go test ./... clean (tmux/agent/container/workspace/internal/cmd all pass)
- [x] golangci-lint run clean on touched packages
- [ ] After merge: restart bcd, verify running agents show up under new mycel-<hash>-* names and any pre-existing bc-<hash>-* session/container is still listed via fallback

Part of #3187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default session/container naming to a new prefix for newly created workspaces and sessions.
  * Added support for recognizing older sessions and containers using the previous naming scheme.

* **Bug Fixes**
  * Preserved access to existing sessions after the prefix change, including workspace-specific names.
  * Improved session discovery so both current and legacy names can be listed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->