### PR TITLE
refactor(web): consolidate 6 time-format helpers into shared time util (#3181)

### DIFF
--- a/web/src/components/live/liveHelpers.ts
+++ b/web/src/components/live/liveHelpers.ts
@@ -1,3 +1,5 @@
+import { formatDuration, formatRelative } from "../../utils/time";
+
 import type {
   AgentActivity,
   AggregatedNode,
@@ -215,12 +217,9 @@ export function stateBadgeClass(state: string): string {
 }
 
 export function relativeTime(ts: number): string {
-  const diff = Date.now() - ts;
-  if (diff < 1000) return "just now";
-  if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
-  return `${Math.floor(diff / 86_400_000)}d ago`;
+  // Unbounded ladder (no max-day fallback) — matches the pre-consolidation
+  // liveHelpers behavior used by the always-relative live view timeline.
+  return formatRelative(ts, { maxDays: Number.POSITIVE_INFINITY });
 }
 
 const INPUT_COST_PER_TOKEN = 3 / 1_000_000;
@@ -235,11 +234,7 @@ export function estimateCost(activity: AgentActivity): number {
 }
 
 export function idleDuration(lastEventTime: number): string {
-  const diff = Date.now() - lastEventTime;
-  if (diff < 60_000) return `Idle ${Math.floor(diff / 1000)}s`;
-  if (diff < 3_600_000) return `Idle ${Math.floor(diff / 60_000)}m`;
-  if (diff < 86_400_000) return `Idle ${Math.floor(diff / 3_600_000)}h`;
-  return `Idle ${Math.floor(diff / 86_400_000)}d`;
+  return formatDuration(Date.now() - lastEventTime, { prefix: "Idle " });
 }
 
 /* ── Node search / sort ────────────────────────────────────────────── */

--- a/web/src/components/notifications/messageUtils.ts
+++ b/web/src/components/notifications/messageUtils.ts
@@ -1,4 +1,5 @@
 import type { ChannelMessage } from "../../api/client";
+import { formatRelative } from "../../utils/time";
 
 /** Gateway notification sources are bridges to external platforms — read-only activity feeds. */
 export const GATEWAY_PREFIXES = [
@@ -82,22 +83,9 @@ export function formatTimestamp(iso: string): string {
   });
 }
 
-/** Format a timestamp as a relative time string ("2m ago", "1h ago", "Yesterday"). */
+/** Format a timestamp as a relative time string ("2m ago", "1h ago", "3d ago"). */
 export function formatRelativeTime(iso: string): string {
-  const d = new Date(iso);
-  const now = new Date();
-  const diffMs = now.getTime() - d.getTime();
-  const diffSec = Math.floor(diffMs / 1000);
-  const diffMin = Math.floor(diffSec / 60);
-  const diffHr = Math.floor(diffMin / 60);
-  const diffDay = Math.floor(diffHr / 24);
-
-  if (diffSec < 60) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  if (diffHr < 24) return `${diffHr}h ago`;
-  if (diffDay === 1) return "Yesterday";
-  if (diffDay < 7) return `${diffDay}d ago`;
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  return formatRelative(iso);
 }
 
 /** Format a date for day separators. */

--- a/web/src/components/shared/AgentActivityStream.tsx
+++ b/web/src/components/shared/AgentActivityStream.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api/client";
 import type { AgentActivityItem } from "../../api/client";
+import { formatAbsolute, formatRelative } from "../../utils/time";
 import { MONO } from "../../utils/typography";
+
+const formatTime = (t?: string): string => formatAbsolute(t);
 
 /* ═══════════════════════════════════════════════════════════════════
    Types & helpers
@@ -23,37 +26,6 @@ interface AgentActivityStreamProps {
   updatedAt?: string;
   startedAt?: string;
   createdAt?: string;
-}
-
-function formatTime(t?: string): string {
-  if (!t) return "\u2014";
-  try {
-    const d = new Date(t);
-    if (isNaN(d.getTime())) return "\u2014";
-    return d.toLocaleString();
-  } catch {
-    return "\u2014";
-  }
-}
-
-function formatRelative(t?: string): string {
-  if (!t) return "";
-  try {
-    const d = new Date(t);
-    if (isNaN(d.getTime())) return "";
-    const diffMs = Date.now() - d.getTime();
-    const diffSec = Math.floor(Math.abs(diffMs) / 1000);
-    if (diffSec < 60) return `${String(diffSec)}s ago`;
-    const diffMin = Math.floor(diffSec / 60);
-    if (diffMin < 60) return `${String(diffMin)}m ago`;
-    const diffHr = Math.floor(diffMin / 60);
-    if (diffHr < 24) return `${String(diffHr)}h ago`;
-    const diffDay = Math.floor(diffHr / 24);
-    if (diffDay < 30) return `${String(diffDay)}d ago`;
-    return d.toLocaleDateString();
-  } catch {
-    return "";
-  }
 }
 
 function buildTimeline(
@@ -302,7 +274,7 @@ export function AgentActivityStream({
                   title={formatTime(lastActivity)}
                   style={{ fontFamily: MONO }}
                 >
-                  {formatRelative(lastActivity)}
+                  {formatRelative(lastActivity, { emptyLabel: "" })}
                 </span>
               )}
             </div>
@@ -393,7 +365,7 @@ export function AgentActivityStream({
                         title={formatTime(evt.timestamp)}
                         style={{ fontFamily: MONO }}
                       >
-                        {formatRelative(evt.timestamp)}
+                        {formatRelative(evt.timestamp, { emptyLabel: "" })}
                       </span>
                     )}
                   </div>

--- a/web/src/utils/time.test.ts
+++ b/web/src/utils/time.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { formatAbsolute, formatDuration, formatRelative } from "./time";
+
+const NOW = new Date("2026-07-02T12:00:00Z");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("formatRelative", () => {
+  it("returns em-dash for null / undefined / empty", () => {
+    expect(formatRelative(null)).toBe("—");
+    expect(formatRelative(undefined)).toBe("—");
+    expect(formatRelative("")).toBe("—");
+  });
+
+  it("honors a custom empty label", () => {
+    expect(formatRelative(null, { emptyLabel: "never" })).toBe("never");
+  });
+
+  it("returns em-dash for invalid input", () => {
+    expect(formatRelative("not-a-date")).toBe("—");
+  });
+
+  it("returns 'just now' for sub-second deltas", () => {
+    expect(formatRelative(NOW)).toBe("just now");
+    expect(formatRelative(new Date(NOW.getTime() - 500))).toBe("just now");
+  });
+
+  it("formats seconds / minutes / hours / days with floor", () => {
+    expect(formatRelative(new Date(NOW.getTime() - 5 * 1000))).toBe("5s ago");
+    expect(formatRelative(new Date(NOW.getTime() - 59 * 1000))).toBe("59s ago");
+    expect(formatRelative(new Date(NOW.getTime() - 60 * 1000))).toBe("1m ago");
+    expect(formatRelative(new Date(NOW.getTime() - 90 * 1000))).toBe("1m ago");
+    expect(formatRelative(new Date(NOW.getTime() - 2 * 3_600_000))).toBe("2h ago");
+    expect(formatRelative(new Date(NOW.getTime() - 3 * 86_400_000))).toBe("3d ago");
+  });
+
+  it("falls back to a date string beyond maxDays (default 30)", () => {
+    const long = new Date(NOW.getTime() - 45 * 86_400_000);
+    const result = formatRelative(long);
+    expect(result).not.toContain("ago");
+    expect(result).toBe(long.toLocaleDateString());
+  });
+
+  it("respects a custom maxDays", () => {
+    const week = new Date(NOW.getTime() - 8 * 86_400_000);
+    expect(formatRelative(week, { maxDays: 7 })).toBe(week.toLocaleDateString());
+  });
+
+  it("collapses future dates to 'just now' by default", () => {
+    const future = new Date(NOW.getTime() + 5 * 60_000);
+    expect(formatRelative(future)).toBe("just now");
+  });
+
+  it("renders future dates with 'in X' when allowFuture is set", () => {
+    const future = new Date(NOW.getTime() + 5 * 60_000);
+    expect(formatRelative(future, { allowFuture: true })).toBe("in 5m");
+  });
+
+  it("accepts numeric milliseconds and ISO strings", () => {
+    const ts = NOW.getTime() - 3 * 60_000;
+    expect(formatRelative(ts)).toBe("3m ago");
+    expect(formatRelative(new Date(ts).toISOString())).toBe("3m ago");
+  });
+});
+
+describe("formatAbsolute", () => {
+  it("returns em-dash for null / invalid", () => {
+    expect(formatAbsolute(null)).toBe("—");
+    expect(formatAbsolute("nope")).toBe("—");
+  });
+
+  it("returns toLocaleString for a valid date", () => {
+    expect(formatAbsolute(NOW)).toBe(NOW.toLocaleString());
+  });
+
+  it("returns toLocaleDateString when dateOnly is set", () => {
+    expect(formatAbsolute(NOW, { dateOnly: true })).toBe(NOW.toLocaleDateString());
+  });
+});
+
+describe("formatDuration", () => {
+  it("returns '0s' for sub-second / negative / non-finite values", () => {
+    expect(formatDuration(500)).toBe("0s");
+    expect(formatDuration(-1000)).toBe("0s");
+    expect(formatDuration(Number.NaN)).toBe("0s");
+  });
+
+  it("formats seconds / minutes / hours / days", () => {
+    expect(formatDuration(5_000)).toBe("5s");
+    expect(formatDuration(90_000)).toBe("1m");
+    expect(formatDuration(2 * 3_600_000)).toBe("2h");
+    expect(formatDuration(3 * 86_400_000)).toBe("3d");
+  });
+
+  it("applies an optional prefix", () => {
+    expect(formatDuration(5 * 60_000, { prefix: "Idle " })).toBe("Idle 5m");
+  });
+});

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -1,0 +1,90 @@
+// Shared time-formatting helpers for the web UI.
+//
+// Consolidates six divergent helpers that existed across AgentActivityStream,
+// AgentDetail, liveHelpers, messageUtils, Cron, and Secrets (#3181). Every
+// caller shares the same relative-time ladder, empty-value handling, and
+// fallback beyond the max-days horizon.
+
+type TimeInput = string | number | Date | null | undefined;
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+const MINUTE_MS = 60_000;
+const SECOND_MS = 1_000;
+
+function toDate(input: TimeInput): Date | null {
+  if (input === null || input === undefined || input === "") return null;
+  const d = input instanceof Date ? input : new Date(input);
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+export interface FormatRelativeOptions {
+  /** String returned when input is null / empty / invalid. Default `—`. */
+  emptyLabel?: string;
+  /**
+   * When true, future timestamps render as `in Xs` / `in Xm` etc.
+   * When false (default), future timestamps collapse to `just now`.
+   */
+  allowFuture?: boolean;
+  /** How many days before falling back to an absolute date. Default 30. */
+  maxDays?: number;
+}
+
+/**
+ * Human-readable relative time: `just now` / `Xs ago` / `Xm ago` / `Xh ago`
+ * / `Xd ago`, falling back to a locale date string beyond `maxDays`.
+ */
+export function formatRelative(input: TimeInput, opts: FormatRelativeOptions = {}): string {
+  const emptyLabel = opts.emptyLabel ?? "—";
+  const d = toDate(input);
+  if (!d) return emptyLabel;
+
+  const now = Date.now();
+  const diff = now - d.getTime();
+  const future = diff < 0;
+  const absDiff = Math.abs(diff);
+
+  if (future && opts.allowFuture) {
+    return "in " + renderMagnitude(absDiff);
+  }
+  if (future) return "just now";
+
+  if (absDiff < SECOND_MS) return "just now";
+  const maxDays = opts.maxDays ?? 30;
+  if (absDiff >= maxDays * DAY_MS) return formatAbsolute(d, { dateOnly: true });
+  return renderMagnitude(absDiff) + " ago";
+}
+
+function renderMagnitude(ms: number): string {
+  if (ms < MINUTE_MS) return Math.floor(ms / SECOND_MS) + "s";
+  if (ms < HOUR_MS) return Math.floor(ms / MINUTE_MS) + "m";
+  if (ms < DAY_MS) return Math.floor(ms / HOUR_MS) + "h";
+  return Math.floor(ms / DAY_MS) + "d";
+}
+
+export interface FormatAbsoluteOptions {
+  /** String returned when input is null / empty / invalid. Default `—`. */
+  emptyLabel?: string;
+  /** When true, only render the date (no time). Default false. */
+  dateOnly?: boolean;
+}
+
+/** Locale-aware absolute timestamp, with an em-dash fallback for empty input. */
+export function formatAbsolute(input: TimeInput, opts: FormatAbsoluteOptions = {}): string {
+  const emptyLabel = opts.emptyLabel ?? "—";
+  const d = toDate(input);
+  if (!d) return emptyLabel;
+  return opts.dateOnly ? d.toLocaleDateString() : d.toLocaleString();
+}
+
+export interface FormatDurationOptions {
+  /** Optional prefix, e.g. "Idle " → "Idle 5m". */
+  prefix?: string;
+}
+
+/** Compact duration formatter: `Xs` / `Xm` / `Xh` / `Xd`. Negative → `0s`. */
+export function formatDuration(ms: number, opts: FormatDurationOptions = {}): string {
+  const prefix = opts.prefix ?? "";
+  if (!Number.isFinite(ms) || ms < SECOND_MS) return prefix + "0s";
+  return prefix + renderMagnitude(ms);
+}

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -16,42 +16,11 @@ import { SystemPromptEditor } from "../components/shared/SystemPromptEditor";
 import { SectionRule } from "../components/shared";
 import { AgentToolStream } from "../components/live/AgentToolStream";
 import { CreateAgentModal } from "../components/CreateAgentModal";
+import { formatAbsolute, formatRelative as sharedFormatRelative } from "../utils/time";
 import { MONO } from "../utils/typography";
 
-/* ═══════════════════════════════════════════════════════════════════
-   Utility
-   ═══════════════════════════════════════════════════════════════════ */
-
-function formatTime(t?: string): string {
-  if (!t) return "\u2014";
-  try {
-    const d = new Date(t);
-    if (isNaN(d.getTime())) return "\u2014";
-    return d.toLocaleString();
-  } catch {
-    return "\u2014";
-  }
-}
-
-function formatRelative(t?: string): string {
-  if (!t) return "";
-  try {
-    const d = new Date(t);
-    if (isNaN(d.getTime())) return "";
-    const diffMs = Date.now() - d.getTime();
-    const diffSec = Math.floor(Math.abs(diffMs) / 1000);
-    if (diffSec < 60) return `${String(diffSec)}s ago`;
-    const diffMin = Math.floor(diffSec / 60);
-    if (diffMin < 60) return `${String(diffMin)}m ago`;
-    const diffHr = Math.floor(diffMin / 60);
-    if (diffHr < 24) return `${String(diffHr)}h ago`;
-    const diffDay = Math.floor(diffHr / 24);
-    if (diffDay < 30) return `${String(diffDay)}d ago`;
-    return d.toLocaleDateString();
-  } catch {
-    return "";
-  }
-}
+const formatTime = (t?: string): string => formatAbsolute(t);
+const formatRelative = (t?: string): string => sharedFormatRelative(t, { emptyLabel: "" });
 
 /* ═══════════════════════════════════════════════════════════════════
    Tab types — v3: Live / Attach / Config / Metrics

--- a/web/src/views/Cron.tsx
+++ b/web/src/views/Cron.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "../components/EmptyState";
 
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 import { TabHeaderTitle } from "../components/Header";
+import { formatRelative } from "../utils/time";
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -94,24 +95,11 @@ function describeCron(expr: string): string {
 }
 
 function relativeTime(dateStr: string | null): string {
-  if (!dateStr) return "never";
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diff = now - then;
-
-  if (diff < 0) {
-    // Future
-    const abs = Math.abs(diff);
-    if (abs < 60_000) return `in ${Math.round(abs / 1000)}s`;
-    if (abs < 3_600_000) return `in ${Math.round(abs / 60_000)}m`;
-    if (abs < 86_400_000) return `in ${Math.round(abs / 3_600_000)}h`;
-    return `in ${Math.round(abs / 86_400_000)}d`;
-  }
-
-  if (diff < 60_000) return `${Math.round(diff / 1000)}s ago`;
-  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
-  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`;
-  return `${Math.round(diff / 86_400_000)}d ago`;
+  return formatRelative(dateStr, {
+    emptyLabel: "never",
+    allowFuture: true,
+    maxDays: Number.POSITIVE_INFINITY,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -7,20 +7,9 @@ import { EmptyState } from "../components/EmptyState";
 
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 import { TabHeaderTitle } from "../components/Header";
-function timeAgo(dateStr: string): string {
-  if (!dateStr) return "—";
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const seconds = Math.floor((now - then) / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  return new Date(dateStr).toLocaleDateString();
-}
+import { formatRelative } from "../utils/time";
+
+const timeAgo = (dateStr: string): string => formatRelative(dateStr);
 
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);


### PR DESCRIPTION
## Summary
Closes #3181. Six divergent time-format helpers across the web UI had drifted on the "just now" threshold, seconds granularity, floor vs round, 30-day fallback vs unbounded, "Yesterday" bucket, future-time handling, and null guards. Consolidated into `web/src/utils/time.ts`:

- `formatRelative(input, { emptyLabel?, allowFuture?, maxDays? })` — one ladder (just now / Xs / Xm / Xh / Xd ago), consistent floor, em-dash empty label, optional future rendering (`in Xm`), and `maxDays: Number.POSITIVE_INFINITY` for callers that want unbounded ladders.
- `formatAbsolute(input, { emptyLabel?, dateOnly? })` — locale-aware absolute timestamp with em-dash fallback.
- `formatDuration(ms, { prefix? })` — compact duration formatter (feeds `idleDuration` etc.).

## Callers migrated
| Old | New |
|-----|-----|
| `AgentActivityStream.formatTime` / `formatRelative` | shared `formatAbsolute` / `formatRelative` |
| `AgentDetail.formatTime` / `formatRelative` | shared `formatAbsolute` / `formatRelative` |
| `liveHelpers.relativeTime` (ms input, unbounded) | `formatRelative(ms, { maxDays: Infinity })` |
| `liveHelpers.idleDuration` | `formatDuration(ms, { prefix: "Idle " })` |
| `messageUtils.formatRelativeTime` | `formatRelative(iso)` — drops divergent "Yesterday" bucket |
| `Cron.relativeTime` | `formatRelative(iso, { emptyLabel: "never", allowFuture: true, maxDays: Infinity })` |
| `Secrets.timeAgo` | `formatRelative(iso)` |

## Test plan
- [x] 16 new colocated tests in `web/src/utils/time.test.ts` covering empty inputs, seconds/minutes/hours/days ladder, maxDays fallback, custom maxDays, future handling (both modes), numeric ms + ISO inputs, absolute + duration edge cases
- [x] Full web test suite: `bun run test` → 126 tests pass across 11 files
- [x] `bun run lint` clean
- [x] `bunx tsc -b --noEmit` clean

Closes #3181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared time formatting for relative dates, absolute dates, and compact durations.
  * Updated multiple screens and widgets to use consistent time labels across the app.

* **Bug Fixes**
  * Improved handling of empty, invalid, and future timestamps.
  * Standardized fallback text and date formatting for overdue, recent, and idle states.

* **Tests**
  * Added coverage for relative time, absolute time, and duration formatting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->