### PR TITLE
fix(stats): CPU chart renders empty despite data present (#3182)

### DIFF
--- a/server/stats_collector.go
+++ b/server/stats_collector.go
@@ -284,23 +284,48 @@ func runContainerStatsCollector(ctx context.Context, be *bccontainer.Backend, mg
 	}
 }
 
+// agentContainerPrefixes are all container-name prefixes that identify an
+// agent container. "mycel-" is the canonical v0.3.1+ prefix; "bc-" is kept
+// for one release cycle so pre-rename containers keep reporting stats.
+var agentContainerPrefixes = []string{"mycel-", "bc-"}
+
+// systemContainerNames identifies infrastructure containers that should be
+// recorded via RecordSystem rather than RecordAgent.
 func isSystemContainer(name string) bool {
-	if name == "bc-db" || name == "bc-playwright" {
+	switch name {
+	case "mycel-db", "mycel-playwright", "bc-db", "bc-playwright":
 		return true
 	}
 	return strings.Contains(name, "-daemon")
 }
 
 func isAgentContainer(name string) bool {
-	if !strings.HasPrefix(name, "bc-") {
+	for _, p := range agentContainerPrefixes {
+		if !strings.HasPrefix(name, p) {
+			continue
+		}
+		rest := name[len(p):]
+		// Require a `<hash>-<agent>` suffix — bare "mycel-" / "bc-" aren't agents.
+		if i := strings.Index(rest, "-"); i > 0 && i < len(rest)-1 {
+			return !isSystemContainer(name)
+		}
 		return false
 	}
-	return !isSystemContainer(name)
+	return false
 }
 
+// extractAgentName strips the "<prefix><hash>-" segment from a full container
+// name (e.g. "mycel-13c6e9-zen-zebra" → "zen-zebra"). Falls back to the raw
+// container name when the shape is unexpected.
 func extractAgentName(containerName string) string {
-	if len(containerName) > 10 && strings.HasPrefix(containerName, "bc-") {
-		return containerName[10:]
+	for _, p := range agentContainerPrefixes {
+		if !strings.HasPrefix(containerName, p) {
+			continue
+		}
+		rest := containerName[len(p):]
+		if i := strings.Index(rest, "-"); i > 0 && i < len(rest)-1 {
+			return rest[i+1:]
+		}
 	}
 	return containerName
 }

--- a/server/stats_collector_test.go
+++ b/server/stats_collector_test.go
@@ -1,0 +1,65 @@
+package server
+
+import "testing"
+
+func TestIsSystemContainer(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"mycel-db", true},
+		{"mycel-playwright", true},
+		{"bc-db", true},
+		{"bc-playwright", true},
+		{"mycel-daemon", true},
+		{"bc-daemon", true},
+		{"mycel-13c6e9-zen-zebra", false},
+		{"bc-13c6e9-zen-zebra", false},
+		{"unrelated", false},
+	}
+	for _, c := range cases {
+		if got := isSystemContainer(c.name); got != c.want {
+			t.Errorf("isSystemContainer(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestIsAgentContainer(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"mycel-13c6e9-zen-zebra", true},
+		{"mycel-abc123-bold-falcon", true},
+		{"bc-13c6e9-zen-zebra", true}, // legacy prefix
+		{"mycel-db", false},
+		{"bc-db", false},
+		{"mycel-daemon", false},
+		{"random-container", false},
+		{"mycel-", false}, // no agent name after prefix — treated as not an agent
+	}
+	for _, c := range cases {
+		if got := isAgentContainer(c.name); got != c.want {
+			t.Errorf("isAgentContainer(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestExtractAgentName(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"mycel-13c6e9-zen-zebra", "zen-zebra"},
+		{"mycel-abc123-bold-falcon", "bold-falcon"},
+		{"bc-13c6e9-zen-zebra", "zen-zebra"},           // legacy
+		{"bc-abc123-noble-hyena", "noble-hyena"},       // legacy
+		{"mycel-13c6e9-a", "a"},                        // single-char agent name
+		{"unrelated-container", "unrelated-container"}, // no known prefix
+	}
+	for _, c := range cases {
+		if got := extractAgentName(c.name); got != c.want {
+			t.Errorf("extractAgentName(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -511,6 +511,13 @@ function pivotAgentMetric(metrics: AgentMetricTS[], mode: "cpu_percent" | "mem_m
       : parseFloat((m.mem_used_bytes / 1024 / 1024).toFixed(1));
     buckets.set(t, b);
   }
+  // Backfill missing agents in each bucket with 0 — otherwise stacked areas
+  // collapse at any bucket where an agent has no sample (#3182).
+  for (const b of buckets.values()) {
+    for (const a of agents) {
+      if (b[a] === undefined) b[a] = 0;
+    }
+  }
   return { agents, data: Array.from(buckets.values()) };
 }
 


### PR DESCRIPTION
## Summary
Closes #3182. The Metrics page "CPU BY AGENT (%)" chart rendered empty even when the table below it clearly had rows with real CPU values. Two independent bugs stacked on top of each other; both are fixed here.

### Bug 1 — stats collector still keyed on the pre-v0.3.1 container prefix

`server/stats_collector.go` classifies containers via `isAgentContainer` / `isSystemContainer` and strips the workspace prefix via `extractAgentName`. All three helpers still checked `strings.HasPrefix(name, "bc-")`. After the v0.3.1 rename to `mycel-<hash>-<name>` (#3187), the docker sampler stopped classifying agent containers as agents, so `RecordAgent` was never called for docker-runtime agents. Only tmux-runtime agents kept feeding `agent_metrics` — which is why the table below the chart still showed partial data.

Fix: both `mycel-` (canonical) and `bc-` (legacy, one release cycle) are accepted. Extraction is prefix-length-aware instead of the hardcoded `[10:]` slice.

### Bug 2 — pivotAgentMetric produced sparse rows that collapsed the stacked area

`web/src/views/Stats.tsx` `pivotAgentMetric` builds one row per time bucket, setting `row[agentName] = value`. When an agent had no sample in a bucket (very common — sampling is best-effort), that agent's dataKey was left `undefined`. Recharts' stacked `<Area>` treats `undefined` as a break in the stack, which collapses the entire fill to zero height at that bucket and produces the visually-empty CPU chart shown below.

Fix: backfill every agent key with `0` in every bucket so the stacked areas stay continuous. Memory chart benefits from the same fix.

## Before / after

### Before (production `bc-` prefix + sparse pivot)
Table shows `zen-zebra 17.4` under CPU% + `1546` MB, but the CPU chart is empty axis labels.

![before](https://github.com/user-attachments/assets/before-fix-3182-stats-empty-cpu-chart.png)

_Screenshot: `.playwright-mcp/before-fix-3182-stats-empty-cpu-chart.png` captured against the running `c87893d4` build._

### After (fresh build, fresh stats window)
The rebuilt daemon at commit `7883bfb7` immediately writes agent rows into `agent_metrics` for both docker and tmux runtimes; the CPU chart now renders continuous stacked areas.

_Screenshot: `.playwright-mcp/after-fix-3182-stats-cpu-chart-populated.png` (attached to close-comment on #3182 with a fully-populated hour of data)._

## Test plan
- [x] `go test ./server/...` — including 3 new tests for `isSystemContainer` / `isAgentContainer` / `extractAgentName` covering both prefixes + edge cases (bare prefix, non-agent names).
- [x] `bun run test` in `web/` — full 110-test suite passes.
- [x] `golangci-lint run ./server/...` clean.
- [x] Manual verification: rebuilt `bin/mycel`, restarted bcd via `mycel down && mycel up`, browsed to `/stats`, captured the after-fix screenshot showing agent CPU rendering with 6 series stacked.

Closes #3182