### PR TITLE
feat(gateway): deprecate outbound send endpoint (#3178 phase 1)

### DIFF
--- a/docs/_architecture-notifications.md
+++ b/docs/_architecture-notifications.md
@@ -56,6 +56,28 @@ path (e.g. when a local channel relays to an external platform via the
 the other 30+ adapters deliberately have no `Send` method — that is
 correct per this design, **not** a missing feature or a bug.
 
+### `POST /api/gateways/{platform}/channels/{channel}/send` is deprecated
+
+**Status: Deprecated since v0.3.1. Sunset: v0.4.0 (target 2026-07-01).**
+
+This endpoint violates the "notifications strictly inbound" principle
+above. It is retained as a legacy shim so pre-v0.3.1 integrations keep
+working during the transition. Every response now carries RFC 8594
+Deprecation + Sunset headers so callers can detect the deprecation
+programmatically:
+
+```
+Deprecation: true
+Sunset: Wed, 01 Jul 2026 00:00:00 GMT
+Link: <https://github.com/rpuneet/mycel/issues/3178>; rel="deprecation"; type="text/html"
+Warning: 299 - "Deprecated API: prefer per-agent platform SDKs. See issue #3178."
+```
+
+The replacement pattern is already documented above: each agent calls the
+platform's official SDK directly with credentials from its own env, so
+posts, file uploads, and reactions attribute correctly to the agent's own
+bot identity. Tracking issue: [#3178](https://github.com/rpuneet/mycel/issues/3178).
+
 If you find a code-review tool flagging "adapter X is missing Send",
 that finding is incorrect: outbound is the agent's responsibility, and
 the inbound adapter is complete without it.

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -194,7 +194,24 @@ func (h *GatewayHandler) gatewayChannels(w http.ResponseWriter, r *http.Request,
 }
 
 // gatewayChannelSend handles POST /api/gateways/{platform}/channels/{channel}/send
+//
+// DEPRECATED (v0.3.1 → v0.4.0): outbound-to-platform is an agent responsibility.
+// Agents should call the platform's official SDK/API (chat.postMessage etc.)
+// directly with per-agent credentials so file uploads and posts attribute
+// correctly. See issue #3178. This endpoint will return 410 Gone in v0.4.0.
+//
+// Every response includes RFC 8594 Deprecation + Sunset headers so callers
+// can detect the deprecation programmatically without having to parse the body.
 func (h *GatewayHandler) gatewayChannelSend(w http.ResponseWriter, r *http.Request, channel string) {
+	// Always signal deprecation on this endpoint — even on error responses —
+	// so clients discover the deprecation on their next call regardless of
+	// input shape. RFC 8594 §3 (Deprecation) + §3 (Sunset). Sunset date is
+	// the projected v0.4.0 cut; adjust if the release slips.
+	w.Header().Set("Deprecation", "true")
+	w.Header().Set("Sunset", "Wed, 01 Jul 2026 00:00:00 GMT")
+	w.Header().Add("Link", `<https://github.com/rpuneet/mycel/issues/3178>; rel="deprecation"; type="text/html"`)
+	w.Header().Add("Warning", `299 - "Deprecated API: prefer per-agent platform SDKs. See issue #3178."`)
+
 	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}

--- a/server/handlers/gateways_test.go
+++ b/server/handlers/gateways_test.go
@@ -298,6 +298,32 @@ func TestGatewayChannelSendMethodNotAllowed(t *testing.T) {
 	}
 }
 
+// TestGatewayChannelSendEmitsDeprecationHeaders — RFC 8594 Deprecation +
+// Sunset headers must be present on every response from the send endpoint,
+// including error responses. See issue #3178.
+func TestGatewayChannelSendEmitsDeprecationHeaders(t *testing.T) {
+	gw := gateway.NewManager()
+	h := &GatewayHandler{gw: gw}
+
+	// Even a wrong method must still carry the deprecation signal.
+	req := httptest.NewRequest(http.MethodGet, "/api/gateways/slack/channels/eng/send", nil)
+	rr := httptest.NewRecorder()
+	h.gatewayChannelSend(rr, req, "slack:eng")
+
+	if rr.Header().Get("Deprecation") != "true" {
+		t.Errorf("Deprecation header = %q, want %q", rr.Header().Get("Deprecation"), "true")
+	}
+	if rr.Header().Get("Sunset") == "" {
+		t.Errorf("Sunset header missing")
+	}
+	if !strings.Contains(rr.Header().Get("Link"), `rel="deprecation"`) {
+		t.Errorf("Link header missing rel=deprecation, got %q", rr.Header().Get("Link"))
+	}
+	if !strings.Contains(rr.Header().Get("Warning"), "Deprecated") {
+		t.Errorf("Warning header missing deprecation text, got %q", rr.Header().Get("Warning"))
+	}
+}
+
 func TestGatewayListNoNullChannels(t *testing.T) {
 	// Verify channels is never null in JSON output (always []).
 	gw := gateway.NewManager()


### PR DESCRIPTION
## Summary
Part of #3178. First actionable step toward "gateways strictly inbound, move outbound to per-agent platform tools": signal the deprecation of the legacy `POST /api/gateways/{platform}/channels/{channel}/send` endpoint on the wire so clients can migrate away from it before the sunset.

- `server/handlers/gateways.go` `gatewayChannelSend`: sets RFC 8594 `Deprecation`, `Sunset`, `Link` (rel="deprecation"), and `Warning` headers on **every** response, including error responses. Sunset date: **2026-07-01** (target v0.4.0).
- `docs/_architecture-notifications.md`: adds a subsection under the existing "Gateway adapters are inbound-only" heading documenting the deprecation contract, the exact header set, and pointing to #3178 for the tracking issue.

## Not in this PR
- Removing the endpoint (target v0.4.0 — this PR only *marks* it deprecated).
- Building the new per-agent outbound tools (`slack_post`, `telegram_send`, etc.). Those need their own design discussion and will land as separate PRs; the tracking issue stays open.

## Test plan
- [x] New test `TestGatewayChannelSendEmitsDeprecationHeaders` verifies all four headers appear on the method-not-allowed error path (worst-case branch, guarantees they're set unconditionally).
- [x] `go test ./server/handlers/...` passes.
- [x] `golangci-lint run ./server/handlers/...` clean.
- [x] `go build ./...` clean.

Part of #3178