### PR TITLE
feat(web): tokenize stats chart palette so charts follow the theme accent

### DIFF
--- a/web/src/components/StatsTab.tsx
+++ b/web/src/components/StatsTab.tsx
@@ -11,7 +11,9 @@ import { Panel, fmtTime, fmtBytes, fmtTokens } from "./shared/stats-primitives";
 
 // ── Constants ────────────────────────────────────────────────────────────────────
 
-const COLORS = ["#FF6B35", "#3B82F6", "#10B981", "#A855F7", "#F59E0B", "#EC4899", "#06B6D4", "#84CC16"];
+// Chart palette — first entry follows the theme accent (see Stats.tsx).
+const ACCENT = "var(--mycel-accent)";
+const COLORS = [ACCENT, "#3B82F6", "#10B981", "#A855F7", "#F59E0B", "#EC4899", "#06B6D4", "#84CC16"];
 const RANGES = [
   { label: "1h", seconds: 3600 },
   { label: "6h", seconds: 21600 },
@@ -370,7 +372,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
                   <XAxis dataKey="time" tick={TICK} {...AX} />
                   <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => `${v}%`} />
                   <Tooltip contentStyle={TT} />
-                  <Area type="monotone" dataKey="cpu" name="CPU %" stroke="#FF6B35" fill="#FF6B35" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
+                  <Area type="monotone" dataKey="cpu" name="CPU %" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} dot={false} />
                 </AreaChart>
               </ResponsiveContainer>
             </Panel>
@@ -403,7 +405,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
                   <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
                   <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
                   <Area type="monotone" dataKey="rx" name="RX" stroke="#10B981" fill="#10B981" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
-                  <Area type="monotone" dataKey="tx" name="TX" stroke="#FF6B35" fill="#FF6B35" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
+                  <Area type="monotone" dataKey="tx" name="TX" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} dot={false} />
                 </AreaChart>
               </ResponsiveContainer>
             </Panel>
@@ -417,7 +419,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
                   <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                   <Tooltip contentStyle={TT} formatter={(v, n) => [Number(v ?? 0).toLocaleString(), n === "input" ? "Input" : "Output"]} />
                   <Area type="monotone" dataKey="input" name="Input" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
-                  <Area type="monotone" dataKey="output" name="Output" stroke="#FF6B35" fill="#FF6B35" fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
+                  <Area type="monotone" dataKey="output" name="Output" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
                 </AreaChart>
               </ResponsiveContainer>
             </Panel>

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -33,7 +33,11 @@ export function calculateCost(model: string, inputTokens: number, outputTokens: 
 
 // ── Constants ───────────────────────────────────────────────────────────────────
 
-const COLORS = ["#FF6B35", "#3B82F6", "#10B981", "#A855F7", "#F59E0B", "#EC4899", "#06B6D4", "#84CC16"];
+// Chart palette. First entry uses the theme accent so charts feel like they
+// belong to the current theme (tangerine in Solar Flare / Light, emerald in
+// Dark). The rest are theme-agnostic hues that stay readable in all three.
+const ACCENT = "var(--mycel-accent)";
+const COLORS = [ACCENT, "#3B82F6", "#10B981", "#A855F7", "#F59E0B", "#EC4899", "#06B6D4", "#84CC16"];
 const RANGES = [
   { label: "1h", seconds: 3600 },
   { label: "6h", seconds: 21600 },
@@ -341,7 +345,7 @@ export function Stats() {
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                 <Tooltip contentStyle={TT} formatter={(v, n) => [Number(v ?? 0).toLocaleString(), n === "input" ? "Input" : "Output"]} />
                 <Area type="monotone" dataKey="input" name="Input" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
-                <Area type="monotone" dataKey="output" name="Output" stroke="#FF6B35" fill="#FF6B35" fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
+                <Area type="monotone" dataKey="output" name="Output" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
               </AreaChart>
             </ResponsiveContainer>
           )}
@@ -354,7 +358,7 @@ export function Stats() {
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v.toFixed(2)}`} />
                 <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
-                <Area type="monotone" dataKey="cost" name="Cost" stroke="#FF6B35" fill="#FF6B35" fillOpacity={0.15} strokeWidth={1.5} dot={false} />
+                <Area type="monotone" dataKey="cost" name="Cost" stroke={ACCENT} fill={ACCENT} fillOpacity={0.15} strokeWidth={1.5} dot={false} />
               </AreaChart>
             </ResponsiveContainer>
           )}
@@ -372,7 +376,7 @@ export function Stats() {
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
                 <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
                 <Area type="monotone" dataKey="rx" name="RX" stroke="#10B981" fill="#10B981" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
-                <Area type="monotone" dataKey="tx" name="TX" stroke="#FF6B35" fill="#FF6B35" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
+                <Area type="monotone" dataKey="tx" name="TX" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} dot={false} />
               </AreaChart>
             </ResponsiveContainer>
           )}
@@ -471,7 +475,7 @@ export function Stats() {
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                 <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "input" ? "Input" : "Output"]} />
                 <Bar dataKey="input" name="Input" fill="#3B82F6" radius={[3, 3, 0, 0]} />
-                <Bar dataKey="output" name="Output" fill="#FF6B35" radius={[3, 3, 0, 0]} />
+                <Bar dataKey="output" name="Output" fill={ACCENT} radius={[3, 3, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           )}


### PR DESCRIPTION
## Summary
Follow-up to #3202. Every chart on `Stats.tsx` and `StatsTab.tsx` hard-coded the solar-flare tangerine `#FF6B35` as the "primary" series color. Under dark theme (emerald accent) the tangerine bar-chart / cost-over-time / output-tokens series clashed with the surrounding emerald UI; under light theme it doubled up with the theme accent.

- `web/src/views/Stats.tsx` + `web/src/components/StatsTab.tsx`: replace every literal `#FF6B35` with `ACCENT = "var(--mycel-accent)"`. Both files expose the same `COLORS = [ACCENT, blue, emerald, purple, …]` palette so downstream cell/series maps keep working; only the first slot follows the theme.

The remaining palette entries (`#3B82F6` / `#10B981` / `#A855F7` / `#F59E0B` / `#EC4899` / `#06B6D4` / `#84CC16`) are theme-agnostic hues chosen so multiple concurrent series stay distinguishable in all three themes.

## Test plan
- [x] Playwright captured on the running host in all three themes (`.playwright-mcp/stats-palette-{solarflare,dark,light}.png`). Under dark: Memory chart series render as emerald+orange+purple etc. (was all-orange). Under light: primary series is tangerine matching the theme.
- [x] Full web test suite (126 tests) green
- [x] `bun run lint` clean
- [x] `bunx tsc -b --noEmit` clean

Part of #3203