### PR TITLE
feat(web): P0 batch — $0 cost mute + CSS namespace sweep + hex-fallback strip

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -135,7 +135,7 @@ function ChannelList({
               padding: "0 8px",
               borderRadius: 5,
               fontSize: 12.5,
-              color: isActive ? "var(--mycel-text, #e5e5e5)" : count > 0 ? "var(--mycel-text, #e5e5e5)" : "var(--mycel-muted, #a0a0a0)",
+              color: isActive ? "var(--mycel-text)" : count > 0 ? "var(--mycel-text)" : "var(--mycel-muted)",
               background: isActive ? "color-mix(in srgb, var(--mycel-accent) 14%, transparent)" : "transparent",
               fontWeight: isActive ? 600 : count > 0 ? 500 : 400,
               cursor: "pointer",
@@ -146,7 +146,7 @@ function ChannelList({
             <span
               style={{
                 width: 12,
-                color: "var(--mycel-muted, #4a4a4a)",
+                color: "var(--mycel-muted)",
                 fontFamily: "'JetBrains Mono', monospace",
                 fontSize: 12,
                 display: "flex",
@@ -165,11 +165,11 @@ function ChannelList({
                 style={{
                   fontSize: 10.5,
                   fontWeight: 600,
-                  color: "var(--mycel-muted, #a0a0a0)",
+                  color: "var(--mycel-muted)",
                   fontFamily: "'JetBrains Mono', monospace",
                   padding: "1px 5px",
                   borderRadius: 999,
-                  background: "var(--mycel-surface, #212121)",
+                  background: "var(--mycel-surface)",
                 }}
               >
                 {count}
@@ -187,7 +187,7 @@ function ChannelList({
             width: "100%",
             padding: "3px 8px",
             fontSize: 11,
-            color: "var(--mycel-muted, #6b6b6b)",
+            color: "var(--mycel-muted)",
             background: "none",
             border: "none",
             cursor: "pointer",
@@ -337,7 +337,7 @@ function NotificationNavTree() {
                 gap: 6,
                 padding: "5px 8px 2px",
                 fontSize: 11.5,
-                color: "var(--mycel-text-2, #a0a0a0)",
+                color: "var(--mycel-text-2)",
                 fontWeight: 500,
                 background: "none",
                 border: "none",
@@ -353,7 +353,7 @@ function NotificationNavTree() {
                   return (
                     <span className="truncate flex items-baseline" style={{ gap: 5, minWidth: 0 }}>
                       <span style={{ flexShrink: 0 }}>{meta.label}</span>
-                      <span style={{ color: "var(--mycel-muted, #6b6b6b)", fontSize: 10.5 }}>·</span>
+                      <span style={{ color: "var(--mycel-muted)", fontSize: 10.5 }}>·</span>
                       <span className="truncate" style={{ minWidth: 0 }}>{subLabel}</span>
                     </span>
                   );
@@ -368,7 +368,7 @@ function NotificationNavTree() {
                     width: 5,
                     height: 5,
                     borderRadius: 999,
-                    background: "var(--mycel-success, #22c55e)",
+                    background: "var(--mycel-success)",
                     boxShadow: "0 0 5px color-mix(in srgb, var(--mycel-success) 50%, transparent)",
                   }}
                 />
@@ -396,9 +396,9 @@ function NotificationNavTree() {
           marginTop: 4,
           borderRadius: 5,
           fontSize: 12,
-          color: "var(--mycel-muted, #6b6b6b)",
+          color: "var(--mycel-muted)",
           cursor: "pointer",
-          border: "1px dashed var(--mycel-border, #2a2a2a)",
+          border: "1px dashed var(--mycel-border)",
           background: "none",
           whiteSpace: "nowrap",
         }}
@@ -654,7 +654,7 @@ export function Layout() {
                 className="w-6 h-6 shrink-0 flex items-center justify-center font-bold"
                 style={{
                   borderRadius: 7,
-                  background: "var(--mycel-accent, #f97316)",
+                  background: "var(--mycel-accent)",
                   color: "#0d0d0d",
                   fontSize: 14,
                   fontFamily: "'JetBrains Mono', monospace",
@@ -675,8 +675,8 @@ export function Layout() {
               className="w-6 h-6 shrink-0 flex items-center justify-center font-bold"
               style={{
                 borderRadius: 7,
-                background: "var(--mycel-accent, #f97316)",
-                color: "var(--mycel-accent-fg, #0d0d0d)",
+                background: "var(--mycel-accent)",
+                color: "var(--mycel-accent-fg)",
                 fontSize: 14,
                 fontFamily: "'JetBrains Mono', monospace",
                 letterSpacing: -0.5,

--- a/web/src/components/StatsTab.tsx
+++ b/web/src/components/StatsTab.tsx
@@ -22,11 +22,11 @@ const RANGES = [
 ] as const;
 
 const TT: React.CSSProperties = {
-  backgroundColor: "var(--color-mycel-surface)", border: "1px solid var(--color-mycel-border)",
-  borderRadius: "6px", color: "var(--color-mycel-text)", fontSize: "12px",
+  backgroundColor: "var(--mycel-surface)", border: "1px solid var(--mycel-border)",
+  borderRadius: "6px", color: "var(--mycel-text)", fontSize: "12px",
 };
 const AX = { axisLine: false as const, tickLine: false as const };
-const TICK = { fill: "var(--color-mycel-muted)", fontSize: 10 };
+const TICK = { fill: "var(--mycel-muted)", fontSize: 10 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────────
 
@@ -368,7 +368,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
             <Panel title="CPU (%)">
               <ResponsiveContainer width="100%" height={200}>
                 <AreaChart data={cpuChart} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                   <XAxis dataKey="time" tick={TICK} {...AX} />
                   <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => `${v}%`} />
                   <Tooltip contentStyle={TT} />
@@ -381,7 +381,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
             <Panel title="Memory (MB)">
               <ResponsiveContainer width="100%" height={200}>
                 <AreaChart data={memChart} margin={{ top: 4, right: 8, left: -10, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                   <XAxis dataKey="time" tick={TICK} {...AX} />
                   <YAxis tick={TICK} {...AX} />
                   <Tooltip contentStyle={TT} formatter={(v) => [`${Number(v ?? 0).toFixed(1)} MB`]} />
@@ -400,7 +400,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
             <Panel title="Network I/O">
               <ResponsiveContainer width="100%" height={200}>
                 <AreaChart data={netChart} margin={{ top: 4, right: 8, left: -10, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                   <XAxis dataKey="time" tick={TICK} {...AX} />
                   <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
                   <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
@@ -414,7 +414,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
             <Panel title="Token Usage">
               <ResponsiveContainer width="100%" height={200}>
                 <AreaChart data={tokenChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                   <XAxis dataKey="time" tick={TICK} {...AX} />
                   <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                   <Tooltip contentStyle={TT} formatter={(v, n) => [Number(v ?? 0).toLocaleString(), n === "input" ? "Input" : "Output"]} />
@@ -444,9 +444,9 @@ export function StatsTab({ agent }: { agent: Agent }) {
               <Panel title="Cost by Model">
                 <ResponsiveContainer width="100%" height={200}>
                   <BarChart layout="vertical" data={costBarData} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" horizontal={false} />
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
                     <XAxis type="number" tick={TICK} {...AX} tickFormatter={(v: number) => `$${v}`} />
-                    <YAxis type="category" dataKey="name" tick={{ ...TICK, fill: "var(--color-mycel-text)", fontSize: 9 }} {...AX} width={120} />
+                    <YAxis type="category" dataKey="name" tick={{ ...TICK, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
                     <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
                     <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
                       {costBarData.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}

--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -288,7 +288,7 @@ export function Live() {
 
   const hasFilters = agentFilter || typeFilter !== "all" || searchFilter;
 
-  const sseDotColor = connected ? "bg-emerald-500" : reconnecting ? "bg-yellow-500" : "bg-red-500";
+  const sseDotColor = connected ? "bg-mycel-success" : reconnecting ? "bg-mycel-warning" : "bg-mycel-error";
   const sseTooltip = connected ? "SSE connected" : reconnecting ? "Reconnecting..." : "Disconnected";
 
   // Drill-down view

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -47,15 +47,21 @@ const RANGES = [
   { label: "30d", seconds: 2592000 },
 ] as const;
 
-const INFRA = ["bc-db", "bc-daemon", "bc-playwright"];
+// Infrastructure container names to exclude from agent charts. Both the
+// canonical mycel-* namespace (v0.3.1+) and the legacy bc-* namespace are
+// filtered for one release cycle so pre-rename containers don't leak in.
+const INFRA = [
+  "mycel-db", "mycel-daemon", "mycel-playwright",
+  "bc-db", "bc-daemon", "bc-playwright",
+];
 const isInfra = (n: string) => INFRA.some(p => n === p || n.startsWith(p + "-")) || n.length <= 3;
 
 const TT: React.CSSProperties = {
-  backgroundColor: "var(--color-mycel-surface)", border: "1px solid var(--color-mycel-border)",
-  borderRadius: "6px", color: "var(--color-mycel-text)", fontSize: "12px",
+  backgroundColor: "var(--mycel-surface)", border: "1px solid var(--mycel-border)",
+  borderRadius: "6px", color: "var(--mycel-text)", fontSize: "12px",
 };
 const AX = { axisLine: false as const, tickLine: false as const };
-const TICK_STYLE = { fill: "var(--color-mycel-muted)", fontSize: 10 };
+const TICK_STYLE = { fill: "var(--mycel-muted)", fontSize: 10 };
 
 // ── Helpers ─────────────────────────────────────────────────────────────────────
 
@@ -279,7 +285,7 @@ export function Stats() {
                     <td className="py-1.5 px-2 font-mono">{a.cpu.toFixed(1)}</td>
                     <td className="py-1.5 px-2 font-mono">{a.mem.toFixed(0)}</td>
                     <td className="py-1.5 px-2 font-mono">{fmtTokens(a.tokens)}</td>
-                    <td className="py-1.5 px-2 font-mono text-mycel-accent">${a.cost.toFixed(2)}</td>
+                    <td className={`py-1.5 px-2 font-mono ${a.cost > 0 ? "text-mycel-accent" : "text-mycel-muted"}`}>${a.cost.toFixed(2)}</td>
                   </tr>
                 ))}
               </tbody>
@@ -306,7 +312,7 @@ export function Stats() {
           {cpuChart.data.length === 0 ? <Empty msg="No CPU data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart data={cpuChart.data} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `${v}%`} />
                 <Tooltip contentStyle={TT} />
@@ -321,7 +327,7 @@ export function Stats() {
           {memChart.data.length === 0 ? <Empty msg="No memory data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart data={memChart.data} margin={{ top: 4, right: 8, left: -10, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} />
                 <Tooltip contentStyle={TT} formatter={(v) => [`${Number(v ?? 0).toFixed(1)} MB`]} />
@@ -340,7 +346,7 @@ export function Stats() {
           {tokenChart.length === 0 ? <Empty msg="No token data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart data={tokenChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                 <Tooltip contentStyle={TT} formatter={(v, n) => [Number(v ?? 0).toLocaleString(), n === "input" ? "Input" : "Output"]} />
@@ -354,7 +360,7 @@ export function Stats() {
           {costOverTime.length === 0 ? <Empty msg="No cost data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart data={costOverTime} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v.toFixed(2)}`} />
                 <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
@@ -371,7 +377,7 @@ export function Stats() {
           {netChart.length === 0 ? <Empty msg="No network data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart data={netChart} margin={{ top: 4, right: 8, left: -10, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
                 <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
@@ -385,7 +391,7 @@ export function Stats() {
           {diskChart.length === 0 ? <Empty msg="No disk data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart data={diskChart} margin={{ top: 4, right: 8, left: -10, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
                 <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
@@ -403,9 +409,9 @@ export function Stats() {
           {tokensByModel.length === 0 ? <Empty msg="No model data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <BarChart layout="vertical" data={tokensByModel.slice(0, 8).map(m => ({ name: trunc(m.name, 24), tokens: m.tokens }))} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" horizontal={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
                 <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
-                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--color-mycel-text)", fontSize: 9 }} {...AX} width={120} />
+                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
                 <Tooltip contentStyle={TT} formatter={(v) => [fmtTokens(Number(v ?? 0))]} />
                 <Bar dataKey="tokens" radius={[0, 3, 3, 0]}>
                   {tokensByModel.slice(0, 8).map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
@@ -418,7 +424,7 @@ export function Stats() {
           {!hasCacheData ? <Empty msg="Cache data — coming soon" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <AreaChart data={cacheChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                 <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "cache_read" ? "Cache Read" : "Cache Create"]} />
@@ -436,9 +442,9 @@ export function Stats() {
           {notificationBarData.length === 0 ? <Empty msg="No notification data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <BarChart layout="vertical" data={notificationBarData} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" horizontal={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
                 <XAxis type="number" tick={TICK_STYLE} {...AX} />
-                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--color-mycel-text)", fontSize: 9 }} {...AX} width={100} />
+                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={100} />
                 <Tooltip contentStyle={TT} formatter={(v) => [Number(v ?? 0).toLocaleString(), "Messages"]} />
                 <Bar dataKey="messages" radius={[0, 3, 3, 0]}>
                   {notificationBarData.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
@@ -451,9 +457,9 @@ export function Stats() {
           {tokensByAgent.length === 0 ? <Empty msg="No cost data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <BarChart layout="vertical" data={tokensByAgent.slice(0, 8).map(a => ({ name: trunc(a.name, 20), cost: parseFloat(a.cost.toFixed(4)) }))} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" horizontal={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
                 <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v}`} />
-                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--color-mycel-text)", fontSize: 9 }} {...AX} width={100} />
+                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={100} />
                 <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
                 <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
                   {tokensByAgent.slice(0, 8).map((a, i) => <Cell key={i} fill={agentColors[a.name] ?? COLORS[i % COLORS.length]} />)}
@@ -470,7 +476,7 @@ export function Stats() {
           {tokensByAgent.length === 0 ? <Empty msg="No token data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <BarChart data={tokensByAgent.slice(0, 8).map(a => ({ name: trunc(a.name, 12), input: a.input, output: a.output }))} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="name" tick={{ ...TICK_STYLE, fontSize: 9 }} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                 <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "input" ? "Input" : "Output"]} />
@@ -484,9 +490,9 @@ export function Stats() {
           {costByModelBar.length === 0 ? <Empty msg="No cost data" /> : (
             <ResponsiveContainer width="100%" height={200}>
               <BarChart layout="vertical" data={costByModelBar} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-mycel-border)" horizontal={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
                 <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v}`} />
-                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--color-mycel-text)", fontSize: 9 }} {...AX} width={120} />
+                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
                 <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
                 <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
                   {costByModelBar.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}


### PR DESCRIPTION
Fixes 3 of the 5 P0 items on #3205 from the 5-lead design audit (Design / A11y / DataViz / UX / FE-Eng).

- **P0.1 `$0.00` cost mute** — every lead flagged the accent-colored `$0.00` reading as an alert. Now `text-mycel-accent` only when `cost > 0`, else `text-mycel-muted`.
- **P0.3 CSS namespace sweep** — `Stats.tsx` and `StatsTab.tsx` used `var(--color-mycel-*)`; the actual tokens are `--mycel-*`. 30 refs normalized. Root cause of chart tick labels rendering near-white on white in Light.
- **P0.4 hex fallbacks stripped** — 15 inline styles in `Layout.tsx` carried `var(--mycel-*, #rrggbb)`. If the token wasn't defined the app silently painted Solar Flare hex — exact reason the `@bc` brand tile still read orange under Dark for the first paint.

Also folds in two staged tweaks that fit the P0.5 semantic-color-roles item: INFRA list extended to include `mycel-*` prefixes, `sseDotColor` in Live tokenized to `bg-mycel-success/warning/error`.

## Test plan
- [x] Full web test suite (126 tests) green
- [x] `bun run lint` clean
- [x] `bunx tsc -b --noEmit` clean
- [x] Playwright verified on live host (`mycel down && mycel up`) in all 3 themes → screenshots `p0-stats-{solarflare,dark,light}.png` uploaded to Slack. Cost column shows muted `$0.00` in every theme; charts render (namespace fix confirmed).

Part of #3205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/Theme**
  * Updated sidebar, connection status, and chart visuals to use the latest app theme colors consistently.
  * Improved dashboard styling for charts, tooltips, and axis labels to better match the current design system.

* **Bug Fixes**
  * Expanded infrastructure filtering so more system containers are excluded from metrics views.
  * Refined cost display behavior in the agents table and standardized cost formatting across the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->