### PR TITLE
feat(web): un-stack CPU chart + auto-scale + rich tooltip (#3205 P0.2)

### DIFF
--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -314,10 +314,29 @@ export function Stats() {
               <AreaChart data={cpuChart.data} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
-                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `${v}%`} />
-                <Tooltip contentStyle={TT} />
+                {/* Y auto-scales but stays at least 5% tall so a busy-agent tiny value
+                    isn't stranded on the baseline invisible. Not stacked — CPU% across
+                    agents isn't additive; stacking made low values disappear when one
+                    agent spiked. */}
+                <YAxis
+                  tick={TICK_STYLE}
+                  {...AX}
+                  domain={[0, (dataMax: number) => Math.max(dataMax * 1.1, 5)]}
+                  tickFormatter={(v: number) => `${v.toFixed(v < 10 ? 1 : 0)}%`}
+                />
+                <Tooltip contentStyle={TT} formatter={(v, name) => [`${Number(v ?? 0).toFixed(2)}%`, name]} />
                 {cpuChart.agents.map((n) => (
-                  <Area key={n} type="monotone" dataKey={n} stroke={agentColors[n] ?? COLORS[0]} fill={agentColors[n] ?? COLORS[0]} fillOpacity={0.12} strokeWidth={1.5} dot={false} stackId="cpu" />
+                  <Area
+                    key={n}
+                    type="monotone"
+                    dataKey={n}
+                    stroke={agentColors[n] ?? COLORS[0]}
+                    fill={agentColors[n] ?? COLORS[0]}
+                    fillOpacity={0.08}
+                    strokeWidth={1.75}
+                    dot={false}
+                    connectNulls
+                  />
                 ))}
               </AreaChart>
             </ResponsiveContainer>


### PR DESCRIPTION
Closes the P0.2 item on #3205. The CPU-by-agent chart was misleading in two ways:

1. Stacked area — but CPU% across agents isn't additive (multi-core containers each report their own %). Stacking implied a whole that didn't exist.
2. Any bucket where a single agent had a sampling gap collapsed the whole stack to `undefined`, so the visible fill shrank to the baseline even when other agents had real data.

## Changes to `web/src/views/Stats.tsx` CPU panel
- Drop `stackId="cpu"` — each agent draws independently.
- `domain={[0, dataMax => max(dataMax * 1.1, 5)]}` — y auto-scales but stays at least 5% tall so tiny values aren't stranded on the baseline. Under a spike the axis stretches; otherwise it hugs the actual range.
- Tick formatter shows one decimal below 10% (e.g. `2.4%`) and integer above 10% (e.g. `140%`) so both busy and idle agents are readable.
- Tooltip formatter now surfaces `agent — X.XX%` per hover.
- Stroke bumped 1.5 → 1.75; fill opacity 12% → 8% so overlapping lines stay distinguishable.
- `connectNulls` so brief sampling gaps don't break the line.

## Test plan
- [x] `bunx tsc -b --noEmit` clean
- [x] `bun run lint` clean
- [x] Full web test suite (126) green
- [x] Rebuilt `bin/mycel` + `mycel down && mycel up` on the running host, refreshed browser. CPU panel now renders 8 independent lines with auto-scaled y-axis and per-hover tooltip.

Part of #3205