### PR TITLE
feat(web): drop workspace pill + explicit Include-stopped toggle (#3205 P1b)

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -800,6 +800,12 @@ export function Layout() {
           </div>
         </main>
       </HeaderSlotProvider>
+      {/* WorkspaceDropdown owns the Cmd/Ctrl+Shift+W hotkey; keep it mounted
+          in a visually-hidden slot so the shortcut still opens the switcher
+          even though the header no longer renders the pill (#3205 P1b). */}
+      <div className="sr-only" aria-hidden>
+        <WorkspaceDropdown />
+      </div>
       <CommandPalette />
     </div>
   );
@@ -825,12 +831,7 @@ function LayoutHeader({
   if (slot.hidden) return null;
   return (
     <Header
-      left={
-        <>
-          <SidebarToggle collapsed={collapsed} onToggle={onToggleCollapsed} />
-          <WorkspaceDropdown />
-        </>
-      }
+      left={<SidebarToggle collapsed={collapsed} onToggle={onToggleCollapsed} />}
       center={slot.title}
       actions={slot.actions}
     />

--- a/web/src/views/Live.test.tsx
+++ b/web/src/views/Live.test.tsx
@@ -130,12 +130,15 @@ describe("Live — show-stopped toggle", () => {
     expect(agentCardVisible("carol")).toBe(false);
     expect(agentCardVisible("dave")).toBe(false);
 
-    // Badge reports the split.
+    // Badge reports active count; toggle exposes stopped count with the
+    // explicit "Include stopped" CTA (#3205 P1b).
     const badge = screen.getByTestId("live-state-badge");
     expect(badge.textContent).toContain("2");
     expect(badge.textContent).toContain("active");
-    expect(badge.textContent).toContain("stopped");
-    expect(badge.textContent).toContain("(show)");
+    const toggle = screen.getByTestId("toggle-show-stopped");
+    expect(toggle.textContent).toContain("Include stopped");
+    expect(toggle.textContent).toContain("2");
+    expect(toggle.getAttribute("aria-pressed")).toBe("false");
   });
 
   it("toggle reveals stopped agents when clicked", async () => {
@@ -157,8 +160,8 @@ describe("Live — show-stopped toggle", () => {
     await waitForAgentCard("carol");
     expect(agentCardVisible("dave")).toBe(true);
 
-    // Label flips to "(hide)".
-    expect(screen.getByTestId("toggle-show-stopped").textContent).toContain("hide");
+    // Toggle now announces the pressed state via aria-pressed.
+    expect(screen.getByTestId("toggle-show-stopped").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("persists the toggle state in localStorage", async () => {
@@ -186,7 +189,7 @@ describe("Live — show-stopped toggle", () => {
     await waitForAgentCard("alice");
     // Stopped agent visible immediately on second mount — no toggle click needed.
     expect(agentCardVisible("carol")).toBe(true);
-    expect(screen.getByTestId("toggle-show-stopped").textContent).toContain("hide");
+    expect(screen.getByTestId("toggle-show-stopped").getAttribute("aria-pressed")).toBe("true");
   });
 
   it("reads existing localStorage value on first mount", async () => {

--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -459,32 +459,45 @@ export function Live() {
             className="text-sm rounded-md border border-mycel-border bg-mycel-surface pl-8 pr-2.5 py-1.5 text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent w-56"
           />
         </div>
-        {/* Active/stopped count badge with toggle */}
+        {/* Active count badge (read-only) */}
         <span
           className="inline-flex items-center gap-1.5 whitespace-nowrap text-[11px] font-mono px-2 py-1 rounded-md border border-mycel-border bg-mycel-surface text-mycel-muted"
           data-testid="live-state-badge"
-          title={showStopped ? "Showing all agents" : "Stopped/errored agents hidden"}
         >
           <span className="text-mycel-success tabular-nums">{activeCount}</span>
           <span>active</span>
-          {stoppedCount > 0 && (
-            <>
-              <span className="text-mycel-border">&middot;</span>
-              <span className="tabular-nums">{stoppedCount}</span>
-              <span>stopped</span>
-              <button
-                type="button"
-                onClick={() => setShowStopped((prev) => !prev)}
-                className="text-mycel-accent hover:text-mycel-text underline decoration-dotted underline-offset-2 transition-colors"
-                aria-pressed={showStopped}
-                aria-label={showStopped ? "Hide stopped agents" : "Show stopped agents"}
-                data-testid="toggle-show-stopped"
-              >
-                ({showStopped ? "hide" : "show"})
-              </button>
-            </>
-          )}
         </span>
+        {/* Include-stopped toggle — surfaced as an explicit checkbox-style pill
+            rather than a hidden (show) link in caption text. #3205 P1b. */}
+        {stoppedCount > 0 && (
+          <button
+            type="button"
+            onClick={() => setShowStopped((prev) => !prev)}
+            aria-pressed={showStopped}
+            aria-label={showStopped ? "Hide stopped agents" : "Show stopped agents"}
+            data-testid="toggle-show-stopped"
+            className={`inline-flex items-center gap-1.5 whitespace-nowrap text-[11px] font-mono px-2 py-1 rounded-md border transition-colors ${
+              showStopped
+                ? "border-mycel-accent bg-mycel-accent/10 text-mycel-accent"
+                : "border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-text hover:border-mycel-muted"
+            }`}
+          >
+            <span
+              aria-hidden
+              className={`inline-flex items-center justify-center w-3 h-3 rounded-sm border ${
+                showStopped ? "bg-mycel-accent border-mycel-accent text-mycel-accent-fg" : "border-mycel-border"
+              }`}
+            >
+              {showStopped && (
+                <svg width="9" height="9" viewBox="0 0 10 10" fill="none">
+                  <path d="M2 5l2 2 4-4" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              )}
+            </span>
+            <span>Include stopped</span>
+            <span className="tabular-nums opacity-70">({stoppedCount})</span>
+          </button>
+        )}
         {/* Active filter pills */}
         {hasFilters && (
           <div className="flex items-center gap-1.5">


### PR DESCRIPTION
Closes P1b on #3205.

### Header
- `LayoutHeader` no longer renders `WorkspaceDropdown` in the left slot. The sidebar workspace tile already anchors identity; the header pill was triple-stating context. Interior pages now sit page title next to the back arrow.
- `WorkspaceDropdown` stays mounted in a visually-hidden slot at the layout root so its global `Cmd/Ctrl+Shift+W` hotkey still opens the switcher — no regression on power-user navigation.

### Live filter row
- The stopped-agents affordance was a `(show)` underline link inside caption-styled badge text; UX audit called it buried. It's now a proper toggle pill with a checkbox icon: `☐ Include stopped (N)` / `☑ Include stopped (N)`, sized to match the other filter controls.
- `aria-pressed` reflects the toggle state so screen readers + tests can query without parsing the visible text.

### Live.test.tsx
- Three assertions retargeted from the old `(show)` / `(hide)` text to the new `Include stopped` label + `aria-pressed` state.

## Test plan
- [x] Full web test suite (126) green
- [x] `bun run lint` clean
- [x] `bunx tsc -b --noEmit` clean
- [x] Rebuilt `bin/mycel` + `mycel down && mycel up` on live host. Playwright screenshot `p1b-final-solarflare.png`: header shows only `← Live 🔴`, filter row shows `7 active` + `☐ Include stopped (4)` toggle. Cmd+Shift+W still opens the workspace switcher.

Part of #3205