### PR TITLE
feat(web): KPI row hierarchy — hide Errored=0, dim zeros, promote Working (#3205 P1d)

### DIFF
--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -27,6 +27,8 @@ function SummaryStat({
   accent,
   mono,
   first,
+  emphasis,
+  dim,
 }: {
   label: string;
   value: React.ReactNode;
@@ -34,18 +36,24 @@ function SummaryStat({
   mono?: boolean;
   /** When true, suppress the left divider (first cell in row). */
   first?: boolean;
+  /** Primary metric — largest type size. Only one per row should carry this. */
+  emphasis?: boolean;
+  /** When true, render the whole cell at reduced opacity — used for zero-value
+   *  metrics so they read as "nothing to see" rather than shouting alongside
+   *  active counts (#3205 P1d). */
+  dim?: boolean;
 }) {
   return (
     <div
       className={`relative flex flex-col justify-between gap-1.5 px-5 py-3 ${
         first ? "" : "sm:before:absolute sm:before:inset-y-3 sm:before:left-0 sm:before:w-px sm:before:bg-mycel-border/50 sm:before:content-['']"
-      }`}
+      } ${dim ? "opacity-60" : ""}`}
     >
-      <span className="text-[9px] uppercase tracking-[0.12em] text-mycel-muted/60 font-medium">
+      <span className="text-[10px] uppercase tracking-[0.10em] text-mycel-muted font-medium">
         {label}
       </span>
       <span
-        className={`text-[22px] leading-none tabular-nums ${
+        className={`${emphasis ? "text-[26px]" : "text-[20px]"} leading-none tabular-nums ${
           mono ? "font-mono" : "font-semibold"
         } ${accent ?? "text-mycel-text"}`}
       >
@@ -521,12 +529,26 @@ export function Live() {
           Rendered only when there is at least one agent so the page doesn't
           show a "0 / 0 / 0" header on the cold-start empty state. */}
       {activities.size > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-5 rounded-lg border border-mycel-border bg-mycel-surface mb-4">
-          <SummaryStat label="Working" value={summary.working} accent="text-emerald-300" first />
-          <SummaryStat label="Idle" value={summary.idle} accent="text-amber-300" />
-          <SummaryStat label="Errored" value={summary.errored} accent={summary.errored > 0 ? "text-rose-300" : "text-mycel-muted/60"} />
-          <SummaryStat label="Tokens" value={formatTokens(summary.tokens)} mono />
-          <SummaryStat label="Last event" value={summary.lastEvent > 0 ? <RelTime ms={summary.lastEvent} /> : "—"} mono />
+        <div className={`grid grid-cols-2 ${summary.errored > 0 ? "sm:grid-cols-5" : "sm:grid-cols-4"} rounded-lg border border-mycel-border bg-mycel-surface mb-4`}>
+          <SummaryStat
+            label="Working"
+            value={summary.working}
+            accent="text-mycel-success"
+            first
+            emphasis
+            dim={summary.working === 0}
+          />
+          <SummaryStat
+            label="Idle"
+            value={summary.idle}
+            accent="text-mycel-warning"
+            dim={summary.idle === 0}
+          />
+          {summary.errored > 0 && (
+            <SummaryStat label="Errored" value={summary.errored} accent="text-mycel-error" />
+          )}
+          <SummaryStat label="Tokens" value={formatTokens(summary.tokens)} mono dim={summary.tokens === 0} />
+          <SummaryStat label="Last event" value={summary.lastEvent > 0 ? <RelTime ms={summary.lastEvent} /> : "—"} mono dim={summary.lastEvent === 0} />
         </div>
       )}
 


### PR DESCRIPTION
Closes P1d on #3205. Design + UX audit: `WORKING/IDLE/ERRORED/TOKENS/LAST EVENT` rendered at identical weight + size, so `Errored 0` shouted as loudly as `Working 3` and `Tokens 0` read as broken rather than empty.

## Changes to `web/src/views/Live.tsx`
- `SummaryStat` gains `emphasis` (26px value vs 20px) and `dim` (60% opacity) props. Working is the only cell rendered at emphasis size; every other cell uses the calmer 20px so the eye lands on the primary metric first.
- `Errored` column conditionally rendered — only appears when `summary.errored > 0`. Grid switches between 4 and 5 columns to match. No more zero-count red herring.
- All zero-value cells get `dim` so they mute back into the row.
- Label styling: 9px @ 60% opacity → 10px muted (readability pass follows #3202).
- Accent colors moved from hard-coded `text-emerald-300`/`text-amber-300`/`text-rose-300` to semantic tokens (`text-mycel-success/warning/error`) — KPI row now follows the theme.

## Test plan
- [x] Full web test suite (126) green
- [x] `bun run lint` clean
- [x] `bunx tsc -b --noEmit` clean
- [x] Rebuilt bin/mycel + `mycel down && mycel up`; verified live at http://0.0.0.0:8080. Screenshot `p1d-kpi-solarflare.png` — Errored column hidden (was 0), Working promoted to 26px emerald, Tokens=0 dimmed.

Part of #3205