### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-03
+
+### Renamed
+- **Docker image tags**: `bc-agent-*` → `mycel-agent-*` (base/claude/gemini/codex/cursor/infra). Every agent build target dual-tags the produced image so pre-v0.3.1 configs that still reference `bc-agent-*` keep working for one release cycle (#3187 pt 1, #3197).
+- **tmux session + Docker container prefix**: `bc-<hash>-<name>` → `mycel-<hash>-<name>`. Reader-side legacy fallback (`Manager.HasSession` / `Manager.ListSessions` / `Backend.ListSessions`) still finds `bc-<hash>-*` sessions and containers, so upgraded workspaces don't lose pre-existing agents (#3187 pt 2, #3198).
+
+### Added
+- **RFC 8594 Deprecation headers** on `POST /api/gateways/{platform}/channels/{channel}/send` — signals the endpoint's sunset (target v0.4.0) so callers can migrate to per-agent platform SDKs. See #3178 for the tracking epic (#3201).
+- **Theme tokens** — `--mycel-accent-fg`, `--mycel-text-2`, `--mycel-live` per theme, wired through `tailwind.config.ts` so the brand tile stays readable across Solar Flare, Dark, and Light and the pulsing "live" indicator follows the theme (#3202).
+
+### Changed
+- **Web: consolidated 6 divergent time-format helpers** into `web/src/utils/time.ts` (`formatRelative` / `formatAbsolute` / `formatDuration`); 16 new colocated tests (#3181, #3199).
+- **Web: header + drawer alignment** — both use 48px min-height. Active nav item now uses `bg-mycel-surface-hover`; section labels + workspace caption bumped from 9px @ 40% opacity to 10px muted (#3203, #3202).
+- **Web: sidebar flattened** — `GLOBAL`/`SYSTEM` section headers removed. Costs merged into main nav; Settings moved to footer next to About + theme toggle (#3205 P1a, #3208).
+- **Web: workspace pill removed from header** on interior pages. `WorkspaceDropdown` stays mounted in a visually-hidden slot so `Cmd/Ctrl+Shift+W` still opens the switcher (#3205 P1b, #3209).
+- **Web: `(show) stopped` promoted** to an explicit `☐ Include stopped (N)` toggle pill with `aria-pressed` (#3205 P1b, #3209).
+- **Web: KPI row hierarchy** — Working at 26px, other cells 20px; Errored column hidden when 0; zero-value cells dimmed. Semantic tokens replace hard-coded Tailwind hues (#3205 P1d, #3210).
+- **Web: chart palette follows the theme accent** — replaced hard-coded solar-flare tangerine `#FF6B35` with `var(--mycel-accent)` in every chart (#3204).
+- **Web: `$0.00` cost cells muted** — accent only when `cost > 0` (#3205 P0.1, #3206).
+- **Web: CSS namespace sweep** — `Stats.tsx` + `StatsTab.tsx` corrected from incorrect `var(--color-mycel-*)` to canonical `--mycel-*` (#3205 P0.3, #3206).
+
+### Fixed
+- **Metrics CPU chart rendered empty despite data.** Two independent bugs: (a) `server/stats_collector.go` still keyed `isAgentContainer` / `isSystemContainer` / `extractAgentName` on the `bc-` prefix so docker-runtime agents stopped being classified post-rename; (b) `pivotAgentMetric` left `undefined` for agents with sample gaps, collapsing the stacked area to the baseline. Both fixed + unit tests (#3182, #3200).
+- **CPU chart y-axis + tooltip** — un-stacked, auto-scale with `min 5%`, per-agent tooltip (#3205 P0.2, #3207).
+- **npm CD pipeline** — `--allow-same-version` on `npm version` so the tag drives the publish, not the working tree (#3196).
+- **`Layout.tsx` hex fallbacks** — 15 inline styles dropped their `#rrggbb` fallbacks; the tokens are always defined so the fallback was silently painting Solar Flare hex under Dark for the first paint (#3205 P0.4, #3206).
+- **Stats INFRA filter** — includes `mycel-*` prefixes alongside legacy `bc-*` (#3205, #3206).
+- **`Live` SSE indicator** — dot color tokenized (`bg-mycel-success/warning/error`) instead of raw Tailwind hues (#3206).
+- **`GatewayFeed` hover states** — five `hover:bg-white/[…]` sites invisible under Light theme; now `hover:bg-mycel-surface-hover` (#3202).
+
+### Deferred to v0.3.2
+- **#3178 phase 2** — per-agent outbound tools (`slack_post`, `telegram_send`, `discord_send`, `whatsapp_send`).
+- **#3205 P1c** — Live event row visual simplification (collapse dual status dots, defer avg/ok-ratio behind expand).
+- **#3205 P2 + P3** — chart palette rework, interactive legend, global focus-ring token, remaining opacity sprinkle cleanup.
+
 ## [0.3.0] - 2026-07-02
 
 ### Renamed

--- a/packages/mycel-agent-runner/package.json
+++ b/packages/mycel-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycel/agent-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Thin HTTP wrapper around the Claude Agent SDK. Hosts a single Claude agent and exposes it over REST + SSE so bcd can drive it.",
   "license": "MIT",
   "type": "module",

--- a/packages/mycel-cli/package.json
+++ b/packages/mycel-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mycel-cli",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "mycel — AI agent orchestration. Coordinate teams of Claude, Gemini, Cursor, and other AI agents.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Cut v0.3.1. Bumps `packages/mycel-cli` + `packages/mycel-agent-runner` to `0.3.1` and extends CHANGELOG with the full v0.3.1 changeset.

## What's in v0.3.1

**Renamed (bc → mycel completion)**
- Docker image tags `bc-agent-*` → `mycel-agent-*` with legacy alias for one cycle (#3187 pt 1, #3197)
- tmux session + Docker container prefix `bc-<hash>-*` → `mycel-<hash>-*` with reader-side legacy fallback (#3187 pt 2, #3198)

**Added**
- RFC 8594 Deprecation + Sunset headers on the outbound gateway send endpoint — see #3178 tracking (#3201)
- Theme tokens: `--mycel-accent-fg`, `--mycel-text-2`, `--mycel-live` per theme, wired through tailwind (#3202)

**Changed / UI polish batch (from #3205 5-lead design review)**
- Web time-format helper consolidation (6 → 1) + 16 new tests (#3181, #3199)
- Header + drawer aligned; sidebar flattened (GLOBAL/SYSTEM section headers removed); workspace pill dropped from interior page headers; `(show) stopped` promoted to explicit toggle pill; KPI row hierarchy with Errored-conditional + emphasis type ramp (#3202, #3208, #3209, #3210)
- Chart palette follows theme accent (#3204)
- `$0.00` cost cells muted; CSS namespace corrected (#3206)

**Fixed**
- CPU chart empty-despite-data — server-side prefix bug + client-side sparse pivot (#3182, #3200, #3207)
- npm CD pipeline (`--allow-same-version`) (#3196)
- Layout.tsx hex fallbacks stripped; Stats INFRA filter includes mycel-*; Live SSE dot tokenized; GatewayFeed hover-white sites tokenized (#3202, #3206)

**Deferred to v0.3.2**
- #3178 phase 2 (per-agent platform outbound tools)
- #3205 P1c (Live event row simplification), P2 + P3 (chart palette rework, interactive legend, focus-ring token, opacity cleanup)

## Post-merge

1. Tag `v0.3.1`, push tag → release workflow runs.
2. Homebrew tap picks up the release.
3. Verify: `brew upgrade rpuneet/mycel/mycel && mycel --version` → `0.3.1`.

Part of #3205