### PR TITLE
feat(web+server): About version accuracy + dev-build chip + theme icon + chart opacity (v0.3.2)

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -191,7 +191,7 @@ func RunServer(addr, wsRoot, corsOrigin, apiKey string) error {
 		SecretsVault: globalVault,
 		MCPGlobal:    mcpGlobal,
 		CostsGlobal:  costsGlobal,
-		Build:        server.BuildInfo{Commit: commit, BuiltAt: date},
+		Build:        server.BuildInfo{Version: version, Commit: commit, BuiltAt: date},
 	}
 
 	// Build the launch workspace's services via the factory.
@@ -231,6 +231,7 @@ func RunServer(addr, wsRoot, corsOrigin, apiKey string) error {
 		log.Info("API key authentication enabled")
 	}
 	cfg.Build = server.BuildInfo{
+		Version: version,
 		Commit:  commit,
 		BuiltAt: date,
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -49,6 +49,7 @@ const defaultAddr = "127.0.0.1:9374"
 
 // BuildInfo holds build-time metadata injected via ldflags.
 type BuildInfo struct {
+	Version string // semantic version tag (e.g. "0.3.1"), or "dev" for source builds
 	Commit  string // short git commit hash
 	BuiltAt string // UTC build timestamp (RFC 3339)
 }
@@ -202,7 +203,13 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 				}
 			}
 		}
-		fmt.Fprintf(w, `{"status":"ok","db":"ok","version":%q}`, cfg.Build.Commit) //nolint:errcheck
+		// version = semver tag when available (release builds), else commit
+		// hash so source builds still round-trip a meaningful identifier.
+		v := cfg.Build.Version
+		if v == "" || v == "dev" {
+			v = cfg.Build.Commit
+		}
+		fmt.Fprintf(w, `{"status":"ok","db":"ok","version":%q,"commit":%q}`, v, cfg.Build.Commit) //nolint:errcheck
 	}
 	mux.HandleFunc("/api/health", apiHealth)
 	mux.HandleFunc("/healthz", apiHealth)

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -740,9 +740,9 @@ export function Layout() {
               title={`Theme: ${THEME_LABELS[mode]}`}
               aria-label={`Switch theme — currently ${THEME_LABELS[mode]}`}
             >
-              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <circle cx="7" cy="7" r="3" />
-                <path d="M7 1v2M7 11v2M1 7h2M11 7h2M2.5 2.5l1.5 1.5M10 10l1.5 1.5M2.5 11.5L4 10M10 4l1.5-1.5" strokeLinecap="round" />
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.4" />
+                <path d="M7 2a5 5 0 010 10z" fill="currentColor" />
               </svg>
             </button>
           </div>
@@ -776,15 +776,16 @@ export function Layout() {
               <span className="truncate">About</span>
             </NavLink>
             <button type="button" onClick={toggle}
-              className="shrink-0 flex items-center gap-1.5 px-3 py-[9px] text-[10px] text-mycel-muted hover:text-mycel-text hover:bg-mycel-surface-hover border-l border-mycel-border/40 transition-colors"
+              className="shrink-0 flex items-center justify-center w-9 py-[9px] text-mycel-muted hover:text-mycel-text hover:bg-mycel-surface-hover border-l border-mycel-border/40 transition-colors"
               title={`Theme: ${THEME_LABELS[mode]} — click to switch`}
               aria-label={`Switch theme — currently ${THEME_LABELS[mode]}`}
             >
-              <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className="opacity-80">
-                <circle cx="7" cy="7" r="3" />
-                <path d="M7 1v2M7 11v2M1 7h2M11 7h2M2.5 2.5l1.5 1.5M10 10l1.5 1.5M2.5 11.5L4 10M10 4l1.5-1.5" strokeLinecap="round" />
+              {/* Half-shaded circle — semantically "theme mode" (dark/light
+                  split), visually distinct from the gear (Settings) icon. */}
+              <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.4" />
+                <path d="M7 2a5 5 0 010 10z" fill="currentColor" />
               </svg>
-              <span className="hidden md:inline truncate">{THEME_LABELS[mode]}</span>
             </button>
           </div>
         )}

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -150,7 +150,11 @@ export function About() {
       label: "GitHub release",
       href: latest?.html_url,
       version: latestTag ?? undefined,
-      detail: latest?.published_at ? new Date(latest.published_at).toLocaleString() : undefined,
+      detail: latest?.published_at
+        ? new Date(latest.published_at).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }) +
+          " · " +
+          new Date(latest.published_at).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })
+        : undefined,
       state: latest ? "ok" : "unknown",
     },
     {
@@ -200,11 +204,31 @@ export function About() {
           <span className="text-2xl font-semibold text-mycel-text font-mono tabular-nums">
             {health?.version ?? "—"}
           </span>
-          {latestTag && health && health.version !== latestTag && (
-            <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-amber-500/15 text-amber-300 ring-1 ring-amber-500/30">
-              update available
-            </span>
-          )}
+          {/* Compare like-with-like. `latestTag` is a semver ("0.3.1"). The
+              daemon's version is either the same shape (release binaries) or
+              a `YYYY.MM.DD.<sha>` dev-build string. Only surface "update
+              available" when both look like semver — for dev builds render a
+              "dev build" chip instead. Fixes #3212. */}
+          {(() => {
+            if (!latestTag || !health?.version) return null;
+            // Semver = up to 3-digit major.minor.patch, optionally followed
+            // by a pre-release or metadata suffix. Rejects the date-hash
+            // dev-build format `YYYY.MM.DD.<sha>` since it starts with a
+            // 4-digit year.
+            const looksLikeSemver = /^\d{1,3}\.\d{1,3}\.\d{1,3}(?:[-+][A-Za-z0-9.]+)?$/.test(health.version);
+            if (!looksLikeSemver) {
+              return (
+                <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-info/15 text-mycel-info ring-1 ring-mycel-info/30">
+                  dev build
+                </span>
+              );
+            }
+            return health.version !== latestTag ? (
+              <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-warning/15 text-mycel-warning ring-1 ring-mycel-warning/30">
+                update available
+              </span>
+            ) : null;
+          })()}
         </div>
         <button
           type="button"

--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -108,17 +108,12 @@ function writeShowStopped(value: boolean): void {
 
 export function Live() {
   useHeaderSlot({
-    title: (
-      <TabHeaderTitle>
-        <span className="inline-flex items-center gap-2">
-          Live
-          <span className="relative flex h-2 w-2">
-            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-mycel-error opacity-75" />
-            <span className="relative inline-flex rounded-full h-2 w-2 bg-mycel-error" />
-          </span>
-        </span>
-      </TabHeaderTitle>
-    ),
+    // Title-only. Sidebar `Live` already carries a pulse dot for the
+    // not-in-focus signal, and the `Connected/Reconnecting/Disconnected`
+    // chip in the header actions bar is the source of truth for SSE
+    // health. A third pulse next to the page title was pure noise
+    // (#3205 v0.3.2).
+    title: <TabHeaderTitle>Live</TabHeaderTitle>,
   });
 
   const { activities, tasks, rawEventsRef, connected, reconnecting, eventCount } = useAgentActivity();

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -351,7 +351,7 @@ export function Stats() {
                 <YAxis tick={TICK_STYLE} {...AX} />
                 <Tooltip contentStyle={TT} formatter={(v) => [`${Number(v ?? 0).toFixed(1)} MB`]} />
                 {memChart.agents.map((n) => (
-                  <Area key={n} type="monotone" dataKey={n} stroke={agentColors[n] ?? COLORS[0]} fill={agentColors[n] ?? COLORS[0]} fillOpacity={0.12} strokeWidth={1.5} dot={false} stackId="mem" />
+                  <Area key={n} type="monotone" dataKey={n} stroke={agentColors[n] ?? COLORS[0]} fill={agentColors[n] ?? COLORS[0]} fillOpacity={0.20} strokeWidth={1.75} dot={false} stackId="mem" />
                 ))}
               </AreaChart>
             </ResponsiveContainer>
@@ -369,8 +369,8 @@ export function Stats() {
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                 <Tooltip contentStyle={TT} formatter={(v, n) => [Number(v ?? 0).toLocaleString(), n === "input" ? "Input" : "Output"]} />
-                <Area type="monotone" dataKey="input" name="Input" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
-                <Area type="monotone" dataKey="output" name="Output" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
+                <Area type="monotone" dataKey="input" name="Input" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.20} strokeWidth={1.75} stackId="1" dot={false} />
+                <Area type="monotone" dataKey="output" name="Output" stroke={ACCENT} fill={ACCENT} fillOpacity={0.20} strokeWidth={1.75} stackId="1" dot={false} />
               </AreaChart>
             </ResponsiveContainer>
           )}
@@ -400,8 +400,8 @@ export function Stats() {
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
                 <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
-                <Area type="monotone" dataKey="rx" name="RX" stroke="#10B981" fill="#10B981" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
-                <Area type="monotone" dataKey="tx" name="TX" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} dot={false} />
+                <Area type="monotone" dataKey="rx" name="RX" stroke="#10B981" fill="#10B981" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
+                <Area type="monotone" dataKey="tx" name="TX" stroke={ACCENT} fill={ACCENT} fillOpacity={0.20} strokeWidth={1.75} dot={false} />
               </AreaChart>
             </ResponsiveContainer>
           )}
@@ -414,8 +414,8 @@ export function Stats() {
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
                 <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
-                <Area type="monotone" dataKey="read" name="Read" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
-                <Area type="monotone" dataKey="write" name="Write" stroke="#A855F7" fill="#A855F7" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
+                <Area type="monotone" dataKey="read" name="Read" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
+                <Area type="monotone" dataKey="write" name="Write" stroke="#A855F7" fill="#A855F7" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
               </AreaChart>
             </ResponsiveContainer>
           )}
@@ -447,8 +447,8 @@ export function Stats() {
                 <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
                 <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                 <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "cache_read" ? "Cache Read" : "Cache Create"]} />
-                <Area type="monotone" dataKey="cache_read" name="Cache Read" stroke="#10B981" fill="#10B981" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
-                <Area type="monotone" dataKey="cache_create" name="Cache Create" stroke="#F59E0B" fill="#F59E0B" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
+                <Area type="monotone" dataKey="cache_read" name="Cache Read" stroke="#10B981" fill="#10B981" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
+                <Area type="monotone" dataKey="cache_create" name="Cache Create" stroke="#F59E0B" fill="#F59E0B" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
               </AreaChart>
             </ResponsiveContainer>
           )}

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -98,12 +98,32 @@ type SortKey = "name" | "role" | "provider" | "state" | "cpu" | "mem" | "tokens"
 // ── Main ────────────────────────────────────────────────────────────────────────
 
 export function Stats() {
-  useHeaderSlot({ title: <TabHeaderTitle>Metrics</TabHeaderTitle> });
+  // Slot the range picker directly into the page header actions area so
+  // it sits inline with the title instead of floating in a mostly-empty
+  // sub-row (#3205 v0.3.2). The picker component is defined below and
+  // reads/writes the local `range` state.
 
   const navigate = useNavigate();
   const [range, setRange] = useState(0);
   const [sortKey, setSortKey] = useState<SortKey>("cost");
   const [sortAsc, setSortAsc] = useState(false);
+
+  useHeaderSlot({
+    title: <TabHeaderTitle>Metrics</TabHeaderTitle>,
+    actions: (
+      <div className="flex gap-1">
+        {RANGES.map((r, i) => (
+          <button key={r.label} type="button" onClick={() => setRange(i)}
+            className={`px-2 py-0.5 text-[11px] rounded border transition-colors ${
+              i === range
+                ? "border-mycel-accent bg-mycel-accent/10 text-mycel-accent"
+                : "border-mycel-border text-mycel-muted hover:text-mycel-text hover:border-mycel-muted"
+            }`}
+          >{r.label}</button>
+        ))}
+      </div>
+    ),
+  });
 
   const from = useMemo(() => fromParam(RANGES[range]?.seconds ?? 3600), [range]);
 
@@ -226,21 +246,6 @@ export function Stats() {
 
   return (
     <div className="p-6 space-y-4">
-      {/* Time range selector (title lives in the top-bar chip) */}
-      <div className="flex items-center justify-end">
-        <div className="flex gap-1">
-          {RANGES.map((r, i) => (
-            <button key={r.label} type="button" onClick={() => setRange(i)}
-              className={`px-2.5 py-1 text-xs rounded border transition-colors ${
-                i === range
-                  ? "border-mycel-accent bg-mycel-accent/10 text-mycel-accent"
-                  : "border-mycel-border text-mycel-muted hover:text-mycel-text hover:border-mycel-muted"
-              }`}
-            >{r.label}</button>
-          ))}
-        </div>
-      </div>
-
       {/* Agent Table */}
       {agentTable.length > 0 && (
         <Panel title={`Agents (${agentTable.length})`}>
@@ -249,10 +254,18 @@ export function Stats() {
               <thead>
                 <tr className="text-mycel-muted text-left">
                   {colHeaders.map(h => (
-                    <th key={h.key} className="py-1.5 px-2 font-medium cursor-pointer hover:text-mycel-text select-none" onClick={(e) => { e.stopPropagation(); e.preventDefault(); handleSort(h.key); }}>
+                    <th key={h.key} className="py-1.5 px-2 font-medium cursor-pointer hover:text-mycel-text select-none group" onClick={(e) => { e.stopPropagation(); e.preventDefault(); handleSort(h.key); }}>
                       <div className="flex items-center">
                         {h.label}
-                        {sortKey === h.key && <span className="ml-1">{sortAsc ? "\u25B2" : "\u25BC"}</span>}
+                        {/* Neutral sort affordance surfaces on hover for every
+                            column so users see the option; active column shows
+                            the current direction in the accent color.
+                            (#3205 v0.3.2) */}
+                        <span className={`ml-1 text-[9px] leading-none tabular-nums ${
+                          sortKey === h.key ? "text-mycel-accent opacity-100" : "opacity-0 group-hover:opacity-60"
+                        }`}>
+                          {sortKey === h.key ? (sortAsc ? "\u25B2" : "\u25BC") : "\u25BE"}
+                        </span>
                       </div>
                       {h.agg && <div className="text-[10px] font-normal text-mycel-muted">{h.agg}</div>}
                     </th>


### PR DESCRIPTION
First batch of v0.3.2 polish. Addresses #3212 (About page \`UPDATE AVAILABLE\` false positive) plus the visual issues Puneet called out after the v0.3.1 verification pass — the sidebar footer theme toggle looked like a duplicate Settings gear, and the Network/Disk charts read as empty despite having data.

## Server
- `BuildInfo` gains a `Version` field; `internal/cmd/serve.go` wires the existing `version` ldflag var into it. `/api/health` returns both `version` (semver on release binaries, falls back to commit hash on dev builds) *and* `commit` so the About page can render each correctly.

## About page (#3212)
- INSTALLED now uses the semver `version` field — was showing the commit hash and always tripped `UPDATE AVAILABLE`.
- New `DEV BUILD` chip for dev builds whose version matches the Makefile `YYYY.MM.DD.<sha>` format. `UPDATE AVAILABLE` only fires when both installed + latest look like semver and differ.
- Release date reformatted from `03/07/2026, 13:15:41` (ambiguous DD/MM/YYYY + seconds noise) to `3 Jul 2026 · 13:15`.
- Amber-500 hard-code replaced with the `mycel-warning` / `mycel-info` theme tokens.

## Sidebar footer
- Theme toggle icon swapped from sun-with-rays (visually collided with the Settings gear at 14px) to a half-shaded circle — semantically "mode swap", distinct from Settings.
- Dropped the trailing `Solar Flare` / `Dark` / `Light` text label — icon + tooltip suffice, and the label was overflowing on narrow sidebars.

## Chart visibility
- Bumped non-CPU chart `fillOpacity` `0.12` → `0.20` (stroke 1.5 → 1.75) across 9 Area series so Network / Disk / Token panels render visibly when data is small-magnitude. CPU stays at 0.08 to preserve overlapping-line readability.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./server/...` clean
- [x] Full web suite (126 tests) clean
- [x] `bun run lint` + `bunx tsc -b --noEmit` clean
- [x] Rebuilt `bin/mycel` + `mycel down && mycel up`; verified live at http://0.0.0.0:8080. About shows `DEV BUILD` chip (not misleading `UPDATE AVAILABLE`); GitHub release date reads `3 Jul 2026 · 13:15`; sidebar footer theme icon is a distinct half-circle.

Fixes #3212
Part of #3205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer build/version reporting in health checks, including a separate commit value and better handling for development builds.
  * Improved the About page to distinguish release versions, dev builds, and available updates more accurately.

* **Style**
  * Refreshed the theme toggle icon and footer presentation for a cleaner look.
  * Updated chart styling to make dashboard graphs slightly bolder and easier to read.

* **Bug Fixes**
  * Adjusted release date formatting on the About page for clearer date and time display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->