### PR TITLE
feat(web): labeled filters + state color coding + kill duplicate legend (v0.3.2 batch 3)

### DIFF
--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -426,27 +426,35 @@ export function Live() {
 
       {/* Filter Bar */}
       <div className="flex flex-wrap items-center gap-2 mb-4 sticky top-0 z-10 bg-mycel-bg py-2">
-        <select
-          value={agentFilter}
-          onChange={(e) => setAgentFilter(e.target.value)}
-          className="text-sm rounded-md border border-mycel-border bg-mycel-surface px-2.5 py-1.5 text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent appearance-none pr-7"
-          style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238c7e72' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`, backgroundRepeat: "no-repeat", backgroundPosition: "right 8px center" }}
-        >
-          <option value="">All agents</option>
-          {agents.map((a) => (
-            <option key={a.name} value={a.name}>{a.name}</option>
-          ))}
-        </select>
-        <select
-          value={typeFilter}
-          onChange={(e) => setTypeFilter(e.target.value as FilterType)}
-          className="text-sm rounded-md border border-mycel-border bg-mycel-surface px-2.5 py-1.5 text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent appearance-none pr-7"
-          style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238c7e72' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`, backgroundRepeat: "no-repeat", backgroundPosition: "right 8px center" }}
-        >
-          <option value="all">All</option>
-          <option value="tools">Tool Calls</option>
-          <option value="state">State Changes</option>
-        </select>
+        <label className="inline-flex items-center gap-1.5">
+          <span className="text-[10px] uppercase tracking-[0.1em] text-mycel-muted">Agent</span>
+          <select
+            value={agentFilter}
+            onChange={(e) => setAgentFilter(e.target.value)}
+            aria-label="Filter by agent"
+            className="text-sm rounded-md border border-mycel-border bg-mycel-surface px-2.5 py-1.5 text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent appearance-none pr-7"
+            style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238c7e72' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`, backgroundRepeat: "no-repeat", backgroundPosition: "right 8px center" }}
+          >
+            <option value="">All</option>
+            {agents.map((a) => (
+              <option key={a.name} value={a.name}>{a.name}</option>
+            ))}
+          </select>
+        </label>
+        <label className="inline-flex items-center gap-1.5">
+          <span className="text-[10px] uppercase tracking-[0.1em] text-mycel-muted">Event</span>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value as FilterType)}
+            aria-label="Filter by event type"
+            className="text-sm rounded-md border border-mycel-border bg-mycel-surface px-2.5 py-1.5 text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent appearance-none pr-7"
+            style={{ backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='6' viewBox='0 0 10 6' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 1l4 4 4-4' stroke='%238c7e72' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")`, backgroundRepeat: "no-repeat", backgroundPosition: "right 8px center" }}
+          >
+            <option value="all">All types</option>
+            <option value="tools">Tool calls</option>
+            <option value="state">State changes</option>
+          </select>
+        </label>
         {/* Search with magnifying glass icon */}
         <div className="relative">
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className="absolute left-2.5 top-1/2 -translate-y-1/2 text-mycel-muted pointer-events-none">

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -288,11 +288,22 @@ export function Stats() {
                     <td className="py-1.5 px-2 text-mycel-muted">{a.provider}</td>
                     <td className="py-1.5 px-2">
                       <span className="flex items-center gap-1.5">
+                        {/* Distinct semantic tokens per state so idle vs
+                            working vs running don't all collapse to the
+                            same green. Unknown → muted grey (rendered
+                            without a text label since it's usually
+                            infra like `server`). */}
                         <span className={`w-1.5 h-1.5 rounded-full ${
-                          a.state === "working" || a.state === "idle" || a.state === "running" ? "bg-green-500"
-                          : a.state === "stuck" ? "bg-orange-500" : "bg-mycel-muted"
+                          a.state === "working" ? "bg-mycel-success"
+                          : a.state === "idle" ? "bg-mycel-warning"
+                          : a.state === "running" ? "bg-mycel-info"
+                          : a.state === "stuck" ? "bg-mycel-warning"
+                          : a.state === "error" ? "bg-mycel-error"
+                          : "bg-mycel-muted"
                         }`} />
-                        {a.state}
+                        <span className={a.state === "unknown" ? "text-mycel-muted italic" : ""}>
+                          {a.state === "unknown" ? "system" : a.state}
+                        </span>
                       </span>
                     </td>
                     <td className="py-1.5 px-2 font-mono">{a.cpu.toFixed(1)}</td>
@@ -307,17 +318,9 @@ export function Stats() {
         </Panel>
       )}
 
-      {/* Sticky agent legend bar */}
-      {Object.keys(agentColors).length > 0 && (
-        <div className="sticky top-0 z-10 flex flex-wrap items-center gap-3 px-3 py-2 bg-mycel-bg/95 backdrop-blur-sm border-b border-mycel-border">
-          {Object.entries(agentColors).map(([name, color]) => (
-            <span key={name} className="flex items-center gap-1.5 text-xs text-mycel-muted">
-              <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: color }} />
-              {name}
-            </span>
-          ))}
-        </div>
-      )}
+      {/* Legend removed — agent names + swatches are already in the
+          Agents table's Name column immediately above. Interactive legend
+          (hover-to-highlight, click-to-toggle) tracked as P2 on #3205. */}
 
       {/* Row 1: CPU + Memory */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">


### PR DESCRIPTION
Closes 4 more items on #3205.

## Live filter row
- `[Agent select]` and `[Event select]` were unlabeled — `All` alone told you nothing about the second dropdown. Both selects now sit inside a `<label>` with a caps caption (`AGENT` / `EVENT`), the `All` option in the event picker is disambiguated to `All types`, and `aria-label` is set on each `<select>` for screen readers.

## Metrics table state color coding
Same green dot was used for `working`, `idle`, and `running` — three meaningfully different states collapsed to one color. Now:
- `working` → `bg-mycel-success` (green)
- `idle` → `bg-mycel-warning` (amber)
- `running` → `bg-mycel-info` (cyan)
- `stuck` → `bg-mycel-warning`
- `error` → `bg-mycel-error`
- anything else → `bg-mycel-muted`

## `server` row state cell
- `unknown` state now renders as an italic `system` label instead of the literal string `unknown` — infra rows read as intentional instead of broken.

## Metrics agent legend
- Removed the sticky legend strip that duplicated the swatch + name already sitting in the Agents table's first column one row above. Interactive legend (hover-to-highlight, click-to-toggle) tracked as P2 on #3205 and will come with the chart-palette rework.

## Test plan
- [x] Full web suite (126) green
- [x] `bun run lint` clean
- [x] `bunx tsc -b --noEmit` clean
- [x] Rebuilt bin + `mycel down/up`; verified live. Screenshots `v032-batch3-live.png` (labeled filters + collapsed KPI row) + `v032-batch3-metrics.png` (color-coded state column + `system` label + no duplicate legend).

Part of #3205