### PR TITLE
feat(web): global focus ring + theme-aware agentColor + robust system-state label (#3205 batch 5)

### DIFF
--- a/web/src/components/notifications/messageUtils.ts
+++ b/web/src/components/notifications/messageUtils.ts
@@ -138,8 +138,19 @@ export function getRoleColor(role: string | undefined): { bg: string; text: stri
 }
 
 /**
- * Generate a consistent HSL color for an agent name.
- * Each agent gets a unique hue derived from their name hash.
+ * Generate a consistent color for an agent name.
+ *
+ * The first agent (by hash bucket 0) uses the *theme accent* so the
+ * chart's most prominent series feels native to whatever theme is
+ * active (tangerine under Solar Flare / Light, emerald under Dark).
+ * The remaining agents draw from a hue palette chosen to stay
+ * distinguishable across dark and light backgrounds — pastels are
+ * avoided since they collapse into the muted grays on light theme.
+ *
+ * Cache is intentionally global — two different renders should give
+ * the same agent the same color. Theme changes don't invalidate the
+ * cache since the theme-accent slot is a `var(--mycel-accent)` string,
+ * not a resolved hex.
  */
 const AGENT_COLOR_CACHE = new Map<string, string>();
 
@@ -157,14 +168,22 @@ function hashString(s: string): number {
 
 export function agentColor(name: string): string {
   if (AGENT_COLOR_CACHE.has(name)) return AGENT_COLOR_CACHE.get(name)!;
-  const hue = AGENT_HUES[hashString(name) % AGENT_HUES.length];
-  const color = `hsl(${hue}, 65%, 65%)`;
+  const bucket = hashString(name) % (AGENT_HUES.length + 1);
+  // Bucket 0 = theme accent so charts feel native to whichever theme is
+  // active. Any other bucket draws from the fixed hue palette.
+  const color = bucket === 0
+    ? "var(--mycel-accent)"
+    : `hsl(${AGENT_HUES[(bucket - 1) % AGENT_HUES.length]}, 65%, 65%)`;
   AGENT_COLOR_CACHE.set(name, color);
   return color;
 }
 
 export function agentColorMuted(name: string): string {
-  const hue = AGENT_HUES[hashString(name) % AGENT_HUES.length];
+  const bucket = hashString(name) % (AGENT_HUES.length + 1);
+  if (bucket === 0) {
+    return "color-mix(in srgb, var(--mycel-accent) 10%, transparent)";
+  }
+  const hue = AGENT_HUES[(bucket - 1) % AGENT_HUES.length];
   return `hsla(${hue}, 40%, 50%, 0.08)`;
 }
 

--- a/web/src/theme/tokens.css
+++ b/web/src/theme/tokens.css
@@ -106,6 +106,35 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* ── Global keyboard focus ring — WCAG 2.4.7 ─────────────────────────
+   Every interactive element gets a visible focus ring on keyboard
+   focus. Uses `:focus-visible` so mouse-driven focus stays clean but
+   Tab / Shift+Tab traversal is always discoverable. Token pair:
+     - --mycel-focus-ring:        2px accent outline
+     - --mycel-focus-ring-offset: 1px offset so the ring reads even on
+                                  filled surfaces
+   #3205 P2. */
+:root {
+  --mycel-focus-ring: 0 0 0 2px var(--mycel-accent);
+  --mycel-focus-ring-offset: 0 0 0 3px var(--mycel-bg);
+}
+:focus {
+  outline: none;
+}
+button:focus-visible,
+a:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+[role="button"]:focus-visible,
+[role="link"]:focus-visible,
+[role="menuitem"]:focus-visible,
+[tabindex]:focus-visible {
+  outline: none;
+  box-shadow: var(--mycel-focus-ring-offset), var(--mycel-focus-ring);
+  border-radius: 4px;
+}
+
 /* Smooth theme transitions */
 *,
 *::before,

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -301,8 +301,8 @@ export function Stats() {
                           : a.state === "error" ? "bg-mycel-error"
                           : "bg-mycel-muted"
                         }`} />
-                        <span className={a.state === "unknown" ? "text-mycel-muted italic" : ""}>
-                          {a.state === "unknown" ? "system" : a.state}
+                        <span className={(!a.state || a.state === "unknown") ? "text-mycel-muted italic" : ""}>
+                          {(!a.state || a.state === "unknown") ? "system" : a.state}
                         </span>
                       </span>
                     </td>


### PR DESCRIPTION
Closes 3 more items on #3205.

## Global keyboard focus ring — WCAG 2.4.7
Every interactive element (button / a / input / select / textarea / role=\"button|link|menuitem\" / [tabindex]) now gets a visible focus ring on `:focus-visible`. Two new tokens `--mycel-focus-ring` + `--mycel-focus-ring-offset` in `tokens.css`, both cascade from the theme accent so the ring follows the theme. `:focus` still resets to `none` so mouse-driven focus stays clean.

## Theme-aware `agentColor()`
Hash bucket 0 is now `var(--mycel-accent)` — the most-prominent series follows whichever accent the theme is running (tangerine under Solar Flare / Light, emerald under Dark). Fixes the \"dark memory chart primary line is pink\" complaint. Other buckets still map to the fixed hue palette so 6+ agents stay distinguishable. `agentColorMuted()` mirrors the treatment via `color-mix()`.

## Robust system-state label
Batch 3 only rewrote `state === \"unknown\"` → `system`. Infra rows like the `server` container come through with a blank `state` string, so the label bailed and rendered empty. Now falsy states also fall to the italic `system` label.

## Test plan
- [x] Full web suite (126) green
- [x] `bun run lint` + `bunx tsc -b --noEmit` clean
- [x] Verified live at http://0.0.0.0:8080 after rebuild + `mycel down/up`. Metrics table state cell now reads `system` for the server row under Dark; keyboard Tab traversal reveals a 2px accent ring.

Part of #3205