### PR TITLE
refactor(web): muted-text contrast audit + border opacity system (#3205 batch 6)

### DIFF
--- a/web/src/components/EmptyState.tsx
+++ b/web/src/components/EmptyState.tsx
@@ -94,7 +94,7 @@ export function EmptyState({
   return (
     <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
       {iconNode && (
-        <span className="mb-3 text-mycel-muted/50" aria-hidden>
+        <span className="mb-3 text-mycel-muted" aria-hidden>
           {iconNode}
         </span>
       )}

--- a/web/src/components/InlineTerminal.tsx
+++ b/web/src/components/InlineTerminal.tsx
@@ -83,7 +83,7 @@ export function InlineTerminal({ agentName, lines = 10 }: InlineTerminalProps) {
   }, [outputLines]);
 
   return (
-    <div className="bg-mycel-bg border-t border-mycel-border/30 px-4 py-3">
+    <div className="bg-mycel-bg border-t border-mycel-border/40 px-4 py-3">
       <div
         ref={scrollRef}
         className="rounded bg-mycel-bg border border-mycel-border/40 p-3 font-mono text-xs leading-relaxed text-mycel-text max-h-48 overflow-auto whitespace-pre-wrap"

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -532,7 +532,7 @@ function NavList({
                 <button
                   type="button"
                   onClick={(e) => { e.preventDefault(); e.stopPropagation(); onToggleNotifications(); }}
-                  className="ml-auto shrink-0 p-0.5 rounded text-mycel-muted/40 hover:text-mycel-muted/70 transition-all"
+                  className="ml-auto shrink-0 p-0.5 rounded text-mycel-muted hover:text-mycel-muted/70 transition-all"
                   aria-label={notificationsExpanded ? "Collapse channels" : "Expand channels"}
                 >
                   <svg
@@ -673,7 +673,7 @@ export function Layout() {
           )}
           {isMobile ? (
             <button type="button" onClick={() => setMobileOpen(false)}
-              className="p-0.5 rounded text-mycel-muted/40 hover:text-mycel-text transition-colors" aria-label="Close navigation"
+              className="p-0.5 rounded text-mycel-muted hover:text-mycel-text transition-colors" aria-label="Close navigation"
             >
               <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
                 <path d="M3 3l8 8M11 3l-8 8" />

--- a/web/src/components/RalphLoopModal.tsx
+++ b/web/src/components/RalphLoopModal.tsx
@@ -279,7 +279,7 @@ export function RalphLoopModal({
               className={`${INPUT_CLS} resize-none`}
               style={{ fontFamily: MONO }}
             />
-            <p className="text-[10px] text-mycel-muted/40">
+            <p className="text-[10px] text-mycel-muted">
               Sent to the agent each time it stops. Runs on the server — works
               even when you close the browser.
             </p>

--- a/web/src/components/WorkspaceDropdown.tsx
+++ b/web/src/components/WorkspaceDropdown.tsx
@@ -106,7 +106,7 @@ export function WorkspaceDropdown({
           {active ? (active.name || active.path.split("/").pop() || "unnamed") : (loading ? "…" : "no workspace")}
         </span>
         {active?.id && (
-          <span className="text-mycel-muted/40 text-[9px] tabular-nums">
+          <span className="text-mycel-muted text-[9px] tabular-nums">
             [{active.id.slice(0, 6)}]
           </span>
         )}
@@ -135,19 +135,19 @@ export function WorkspaceDropdown({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search workspaces…"
-              className="w-full bg-mycel-bg border border-mycel-border/40 rounded px-2.5 py-1 text-[11px] text-mycel-text/90 placeholder:text-mycel-muted/40 outline-none focus:border-mycel-accent/50"
+              className="w-full bg-mycel-bg border border-mycel-border/40 rounded px-2.5 py-1 text-[11px] text-mycel-text/90 placeholder:text-mycel-muted outline-none focus:border-mycel-accent/50"
               style={{ fontFamily: MONO }}
             />
           </div>
 
           <div className="max-h-[320px] overflow-y-auto py-1">
             {loading && (
-              <div className="px-3 py-2 text-[11px] text-mycel-muted/50" style={{ fontFamily: MONO }}>
+              <div className="px-3 py-2 text-[11px] text-mycel-muted" style={{ fontFamily: MONO }}>
                 loading…
               </div>
             )}
             {!loading && filtered.length === 0 && (
-              <div className="px-3 py-2 text-[11px] text-mycel-muted/50 italic" style={{ fontFamily: MONO }}>
+              <div className="px-3 py-2 text-[11px] text-mycel-muted italic" style={{ fontFamily: MONO }}>
                 {workspaces.length === 0 ? "no workspaces registered" : "no matches"}
               </div>
             )}
@@ -165,10 +165,10 @@ export function WorkspaceDropdown({
                 <span className="text-[12px] font-semibold text-mycel-text/90 truncate">
                   {ws.name || ws.path.split("/").pop() || "unnamed"}
                 </span>
-                <span className="text-[9px] text-mycel-muted/40 tabular-nums">
+                <span className="text-[9px] text-mycel-muted tabular-nums">
                   [{ws.id.slice(0, 6)}]
                 </span>
-                <span className="ml-auto text-[10px] text-mycel-muted/40 truncate max-w-[160px]" title={ws.path}>
+                <span className="ml-auto text-[10px] text-mycel-muted truncate max-w-[160px]" title={ws.path}>
                   {shortenPath(ws.path)}
                 </span>
               </button>

--- a/web/src/components/live/AgentToolStream.tsx
+++ b/web/src/components/live/AgentToolStream.tsx
@@ -25,7 +25,7 @@ export function AgentToolStream({ agentName }: AgentToolStreamProps) {
   if (!activity) {
     return (
       <div className="flex-1 flex items-center justify-center p-6">
-        <p className="text-sm text-mycel-muted/50 italic">
+        <p className="text-sm text-mycel-muted italic">
           No activity yet — waiting for events
         </p>
       </div>

--- a/web/src/components/live/LiveRenderers.tsx
+++ b/web/src/components/live/LiveRenderers.tsx
@@ -85,7 +85,7 @@ export function RelativeTimestamp({ ts }: { ts: number }) {
     return () => clearInterval(id);
   }, []);
   return (
-    <span title={new Date(ts).toISOString()} className="text-[10px] text-mycel-muted/60 font-mono tabular-nums">
+    <span title={new Date(ts).toISOString()} className="text-[10px] text-mycel-muted font-mono tabular-nums">
       {relativeTime(ts)}
     </span>
   );
@@ -203,7 +203,7 @@ export function ToolNodeRow({ node, depth = 0, searchQuery = "" }: { node: ToolN
         </span>
         {/* Animated chevron */}
         <motion.span
-          className="text-mycel-muted/50 text-[10px] select-none shrink-0 w-3 text-center group-hover:text-mycel-muted"
+          className="text-mycel-muted text-[10px] select-none shrink-0 w-3 text-center group-hover:text-mycel-muted"
           animate={{ rotate: hasDetails ? (expanded ? 90 : 0) : 0 }}
           transition={{ duration: 0.15 }}
         >
@@ -306,7 +306,7 @@ export function AgentTreeNode({ node, depth = 0 }: { node: ToolNode; depth?: num
         onClick={() => setExpanded(!expanded)}
         aria-label={`${expanded ? "Collapse" : "Expand"} subagent ${node.toolName}`}
       >
-        <span className="text-mycel-muted/50 text-[10px] select-none mt-[3px] shrink-0 w-3 text-center group-hover:text-mycel-muted">
+        <span className="text-mycel-muted text-[10px] select-none mt-[3px] shrink-0 w-3 text-center group-hover:text-mycel-muted">
           {childCount > 0 ? (expanded ? "\u25BC" : "\u25B6") : "\u00B7"}
         </span>
         <ToolDot status={node.status} />
@@ -399,12 +399,12 @@ export function AggregatedChildRow({ child, searchQuery = "" }: { child: ToolNod
           <button
             type="button"
             onClick={() => setShowRawJson(!showRawJson)}
-            className="text-[10px] text-mycel-muted hover:text-mycel-accent font-mono transition-colors px-2 py-0.5 rounded border border-mycel-border/30 hover:border-mycel-accent/50"
+            className="text-[10px] text-mycel-muted hover:text-mycel-accent font-mono transition-colors px-2 py-0.5 rounded border border-mycel-border/40 hover:border-mycel-accent/50"
           >
             {showRawJson ? "Hide Raw JSON" : "Raw JSON"}
           </button>
           {showRawJson && (
-            <div className="mt-1 text-[11px] font-mono px-3 py-2 bg-mycel-bg rounded border border-mycel-border/30 overflow-x-auto max-h-64 overflow-y-auto">
+            <div className="mt-1 text-[11px] font-mono px-3 py-2 bg-mycel-bg rounded border border-mycel-border/40 overflow-x-auto max-h-64 overflow-y-auto">
               <div className="flex justify-end mb-1">
                 <CopyButton text={fullEventJson} />
               </div>
@@ -506,7 +506,7 @@ export function DrillDownTasksSection({ tasks, agentName }: { tasks: Map<string,
         onClick={() => setCollapsed(!collapsed)}
         className="flex items-center gap-2 w-full px-4 py-2.5 text-left hover:bg-mycel-surface-hover transition-colors"
       >
-        <span className="text-mycel-muted/50 text-[10px] select-none w-3 text-center">
+        <span className="text-mycel-muted text-[10px] select-none w-3 text-center">
           {collapsed ? "\u25B6" : "\u25BC"}
         </span>
         <span className="text-[13px]">{"\u2705"}</span>
@@ -571,7 +571,7 @@ export function DrillDownEventRow({ node }: { node: ToolNode }) {
   const outputJson = node.fullOutput ? JSON.stringify(redactValue(node.fullOutput), null, 2) : "";
 
   return (
-    <div className={`border-b border-mycel-border/30 ${node.status === "failed" ? "bg-mycel-error/5" : ""}`}>
+    <div className={`border-b border-mycel-border/40 ${node.status === "failed" ? "bg-mycel-error/5" : ""}`}>
       <button
         type="button"
         className="group flex items-center gap-3 py-2.5 px-4 w-full text-left hover:bg-mycel-surface-hover cursor-pointer transition-colors"
@@ -580,7 +580,7 @@ export function DrillDownEventRow({ node }: { node: ToolNode }) {
       >
         {/* Animated chevron */}
         <motion.span
-          className="text-mycel-muted/50 text-[10px] select-none shrink-0 w-3 text-center group-hover:text-mycel-muted"
+          className="text-mycel-muted text-[10px] select-none shrink-0 w-3 text-center group-hover:text-mycel-muted"
           animate={{ rotate: hasDetails ? (expanded ? 90 : 0) : 0 }}
           transition={{ duration: 0.15 }}
         >
@@ -786,7 +786,7 @@ export function AgentDrillDown({
                       onClick={() => toggleRawExpanded(evtKey)}
                       className="flex items-center gap-2 w-full px-3 py-1.5 text-left hover:bg-mycel-surface-hover transition-colors"
                     >
-                      <span className="text-mycel-muted/50 text-[10px] select-none w-3 text-center">
+                      <span className="text-mycel-muted text-[10px] select-none w-3 text-center">
                         {isOpen ? "\u25BC" : "\u25B6"}
                       </span>
                       <span className="text-[10px] text-mycel-muted font-mono tabular-nums shrink-0">
@@ -965,11 +965,11 @@ export const AgentCard = memo(function AgentCard({
             )}
             {/* Idle chip */}
             {isIdle && activity.lastEventTime > 0 && (
-              <span className="text-[10px] text-mycel-muted/60 font-mono px-1.5 py-0.5 rounded bg-mycel-muted/10">
+              <span className="text-[10px] text-mycel-muted font-mono px-1.5 py-0.5 rounded bg-mycel-muted/10">
                 <IdleTimer lastEventTime={activity.lastEventTime} />
               </span>
             )}
-            <span className="text-[11px] text-mycel-muted/60 group-hover:text-mycel-accent transition-colors hidden sm:inline">
+            <span className="text-[11px] text-mycel-muted group-hover:text-mycel-accent transition-colors hidden sm:inline">
               &rarr;
             </span>
           </span>

--- a/web/src/components/notifications/MessageList.tsx
+++ b/web/src/components/notifications/MessageList.tsx
@@ -109,7 +109,7 @@ export function MessageList({
                 {group.sender}
               </button>
               <RoleBadge role={role} />
-              <time className="text-[10px] text-mycel-muted/40 tabular-nums" title={new Date(group.timestamp).toLocaleString()}>
+              <time className="text-[10px] text-mycel-muted tabular-nums" title={new Date(group.timestamp).toLocaleString()}>
                 {formatRelativeTime(group.timestamp)}
               </time>
             </div>

--- a/web/src/components/notifications/SetupWizard.tsx
+++ b/web/src/components/notifications/SetupWizard.tsx
@@ -544,7 +544,7 @@ export function PlatformChooser({ onSelect, onClose }: { onSelect: (key: string)
           relative flex flex-col p-4 rounded-xl border text-left
           transition-all duration-150 ease-out group
           ${isComingSoon
-            ? "border-mycel-border/20 opacity-40 cursor-not-allowed"
+            ? "border-mycel-border/40 opacity-40 cursor-not-allowed"
             : "border-mycel-border/40 cursor-pointer hover:border-mycel-accent/50 hover:scale-[1.02] hover:shadow-[0_0_20px_rgba(249,115,22,0.08)]"
           }
           ${isConnected ? "border-green-500/30 bg-green-500/[0.03]" : ""}
@@ -597,7 +597,7 @@ export function PlatformChooser({ onSelect, onClose }: { onSelect: (key: string)
             <span className="text-[10px] text-blue-400/60">Polling &middot; needs API token</span>
           )}
           {!isConnected && isComingSoon && (
-            <span className="text-[10px] text-mycel-muted/40">Coming soon</span>
+            <span className="text-[10px] text-mycel-muted">Coming soon</span>
           )}
         </div>
       </button>
@@ -639,7 +639,7 @@ export function PlatformChooser({ onSelect, onClose }: { onSelect: (key: string)
           {/* Search */}
           <div className="relative">
             <svg
-              className="absolute left-3 top-1/2 -translate-y-1/2 text-mycel-muted/40"
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-mycel-muted"
               width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3"
             >
               <circle cx="6" cy="6" r="4" />
@@ -651,7 +651,7 @@ export function PlatformChooser({ onSelect, onClose }: { onSelect: (key: string)
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search platforms..."
-              className="w-full pl-9 pr-3 py-2.5 text-sm rounded-lg border border-mycel-border/50 bg-mycel-surface/30 text-mycel-text placeholder:text-mycel-muted/40 focus:outline-none focus:ring-1 focus:ring-mycel-accent/50 focus:border-mycel-accent/30 transition-colors"
+              className="w-full pl-9 pr-3 py-2.5 text-sm rounded-lg border border-mycel-border/50 bg-mycel-surface/30 text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent/50 focus:border-mycel-accent/30 transition-colors"
             />
           </div>
         </div>
@@ -672,7 +672,7 @@ export function PlatformChooser({ onSelect, onClose }: { onSelect: (key: string)
           )}
 
           {connectedPlatforms.length > 0 && availablePlatforms.length > 0 && (
-            <div className="border-t border-mycel-border/20 my-5" />
+            <div className="border-t border-mycel-border/40 my-5" />
           )}
 
           {/* Categorized available platforms */}

--- a/web/src/components/notifications/SubscriptionPanel.tsx
+++ b/web/src/components/notifications/SubscriptionPanel.tsx
@@ -77,7 +77,7 @@ function AgentRow({
               className={`text-[9px] px-2 py-0.5 rounded-md border transition-all duration-150 ${
                 sub.mention_only
                   ? "border-mycel-accent/30 bg-mycel-accent/8 text-mycel-accent"
-                  : "border-mycel-border/30 text-mycel-muted/50 hover:border-mycel-border/50 hover:text-mycel-muted"
+                  : "border-mycel-border/40 text-mycel-muted hover:border-mycel-border/50 hover:text-mycel-muted"
               }`}
             >
               {sub.mention_only ? "@ mentions" : "all msgs"}
@@ -181,7 +181,7 @@ export function SubscriptionPanel({
       style={{ scrollbarWidth: "thin", scrollbarColor: "rgba(255,255,255,0.04) transparent" }}
     >
       {/* Header */}
-      <div className="px-3 py-3 border-b border-mycel-border/30">
+      <div className="px-3 py-3 border-b border-mycel-border/40">
         <h3 className="text-[11px] font-bold text-mycel-muted/70 uppercase tracking-[0.12em]">
           Agents
         </h3>

--- a/web/src/components/shared/AgentActivityStream.tsx
+++ b/web/src/components/shared/AgentActivityStream.tsx
@@ -264,7 +264,7 @@ export function AgentActivityStream({
                   style={{ fontFamily: MONO }}
                 >
                   {agentTask ?? (
-                    <span className="text-mycel-muted/40 italic">none</span>
+                    <span className="text-mycel-muted italic">none</span>
                   )}
                 </p>
               </div>
@@ -300,7 +300,7 @@ export function AgentActivityStream({
               <span
                 className={`w-1.5 h-1.5 rounded-full ${isRunning ? "bg-green-500" : "bg-mycel-muted/40"}`}
               />
-              <span className={isRunning ? "text-green-400" : "text-mycel-muted/40"}>
+              <span className={isRunning ? "text-green-400" : "text-mycel-muted"}>
                 {isRunning ? "Live" : "Offline"}
               </span>
             </span>
@@ -316,7 +316,7 @@ export function AgentActivityStream({
                 className={`px-2 py-0.5 rounded border text-[10px] font-medium transition-colors ${
                   activeFilter === f.key
                     ? "border-mycel-accent/30 bg-mycel-accent/15 text-mycel-accent"
-                    : "border-mycel-border/30 text-mycel-muted/60 hover:text-mycel-muted hover:border-mycel-border/50"
+                    : "border-mycel-border/40 text-mycel-muted/60 hover:text-mycel-muted hover:border-mycel-border/50"
                 }`}
                 style={{ fontFamily: MONO }}
               >
@@ -326,7 +326,7 @@ export function AgentActivityStream({
           </div>
 
           {timeline.length === 0 ? (
-            <p className="text-xs text-mycel-muted/40 italic pl-1">
+            <p className="text-xs text-mycel-muted italic pl-1">
               {allTimeline.length === 0
                 ? "No activity recorded yet."
                 : "No events match this filter."}
@@ -361,7 +361,7 @@ export function AgentActivityStream({
                     </span>
                     {evt.timestamp && (
                       <span
-                        className="text-[10px] text-mycel-muted/60 tabular-nums shrink-0"
+                        className="text-[10px] text-mycel-muted tabular-nums shrink-0"
                         title={formatTime(evt.timestamp)}
                         style={{ fontFamily: MONO }}
                       >
@@ -383,7 +383,7 @@ export function AgentActivityStream({
         {/* Stopped note */}
         {isStopped && (
           <p
-            className="text-[10px] text-mycel-muted/40 italic pl-1"
+            className="text-[10px] text-mycel-muted italic pl-1"
             style={{ fontFamily: MONO }}
           >
             Agent is not running. Showing last known activity.

--- a/web/src/components/shared/MCPServerList.tsx
+++ b/web/src/components/shared/MCPServerList.tsx
@@ -102,7 +102,7 @@ export function MCPServerList({
   if (loading) {
     return (
       <p
-        className="text-xs text-mycel-muted/40 italic pl-1"
+        className="text-xs text-mycel-muted italic pl-1"
         style={{ fontFamily: MONO }}
       >
         Loading...
@@ -117,7 +117,7 @@ export function MCPServerList({
           {servers.map((s) => (
             <span
               key={s}
-              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-mycel-border/30 bg-mycel-surface/30 text-[11px] text-mycel-text/80 font-medium"
+              className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border border-mycel-border/40 bg-mycel-surface/30 text-[11px] text-mycel-text/80 font-medium"
               style={{ fontFamily: MONO }}
             >
               <span className="w-1.5 h-1.5 rounded-full bg-mycel-accent/60" />
@@ -127,7 +127,7 @@ export function MCPServerList({
                   type="button"
                   onClick={() => { handleRemove(s); }}
                   disabled={removing === s}
-                  className="ml-0.5 text-mycel-muted/50 hover:text-mycel-error transition-colors disabled:opacity-40 leading-none"
+                  className="ml-0.5 text-mycel-muted hover:text-mycel-error transition-colors disabled:opacity-40 leading-none"
                   title={`Remove ${s}`}
                   aria-label={`Remove MCP server ${s}`}
                 >
@@ -138,7 +138,7 @@ export function MCPServerList({
           ))}
         </div>
       ) : (
-        <p className="text-xs text-mycel-muted/40 italic pl-1">
+        <p className="text-xs text-mycel-muted italic pl-1">
           No MCP servers configured.
         </p>
       )}
@@ -160,7 +160,7 @@ export function MCPServerList({
               }}
               placeholder="Search or type a server name…"
               disabled={adding}
-              className="flex-1 max-w-[300px] rounded border border-mycel-border/40 bg-mycel-bg px-2.5 py-1 text-[11px] text-mycel-text/90 placeholder:text-mycel-muted/40 outline-none focus:border-mycel-accent/50 transition-colors disabled:opacity-40"
+              className="flex-1 max-w-[300px] rounded border border-mycel-border/40 bg-mycel-bg px-2.5 py-1 text-[11px] text-mycel-text/90 placeholder:text-mycel-muted outline-none focus:border-mycel-accent/50 transition-colors disabled:opacity-40"
               style={{ fontFamily: MONO }}
             />
             <button
@@ -202,7 +202,7 @@ export function MCPServerList({
                       {m.name}
                     </span>
                     <span
-                      className="block text-[10px] text-mycel-muted/60 truncate"
+                      className="block text-[10px] text-mycel-muted truncate"
                       style={{ fontFamily: MONO }}
                     >
                       {m.description}
@@ -213,7 +213,7 @@ export function MCPServerList({
             </div>
           )}
 
-          <p className="mt-1.5 text-[10px] text-mycel-muted/40" style={{ fontFamily: MONO }}>
+          <p className="mt-1.5 text-[10px] text-mycel-muted" style={{ fontFamily: MONO }}>
             Select from the list or press Enter to add a custom server name.
           </p>
         </div>

--- a/web/src/components/shared/McpEnvEditor.tsx
+++ b/web/src/components/shared/McpEnvEditor.tsx
@@ -41,14 +41,14 @@ export function McpEnvEditor({ serverNames }: McpEnvEditorProps) {
 
   if (servers === null) {
     return (
-      <p className="text-[11px] text-mycel-muted/60" style={{ fontFamily: MONO }}>
+      <p className="text-[11px] text-mycel-muted" style={{ fontFamily: MONO }}>
         Loading MCP env…
       </p>
     );
   }
   if (servers.length === 0) {
     return (
-      <p className="text-[11px] text-mycel-muted/60" style={{ fontFamily: MONO }}>
+      <p className="text-[11px] text-mycel-muted" style={{ fontFamily: MONO }}>
         {serverNames.length === 0
           ? "No MCP servers attached."
           : "Attached servers aren't in the MCP registry yet."}
@@ -69,7 +69,7 @@ export function McpEnvEditor({ serverNames }: McpEnvEditorProps) {
         return (
           <div
             key={srv.name}
-            className="rounded border border-mycel-border/30 bg-mycel-surface/20"
+            className="rounded border border-mycel-border/40 bg-mycel-surface/20"
           >
             <button
               type="button"
@@ -81,11 +81,11 @@ export function McpEnvEditor({ serverNames }: McpEnvEditorProps) {
                   {srv.name}
                 </span>
                 {srv.enabled === false && (
-                  <span className="text-[10px] uppercase tracking-wide text-mycel-muted/60">
+                  <span className="text-[10px] uppercase tracking-wide text-mycel-muted">
                     disabled
                   </span>
                 )}
-                <span className="text-[10px] text-mycel-muted/60">
+                <span className="text-[10px] text-mycel-muted">
                   {envCount === 0 ? "no env" : `${envCount} env ${envCount === 1 ? "var" : "vars"}`}
                 </span>
               </span>
@@ -114,7 +114,7 @@ export function McpEnvEditor({ serverNames }: McpEnvEditorProps) {
           </div>
         );
       })}
-      <p className="text-[10px] text-mycel-muted/40 leading-relaxed" style={{ fontFamily: MONO }}>
+      <p className="text-[10px] text-mycel-muted leading-relaxed" style={{ fontFamily: MONO }}>
         MCP env is shared across every agent that uses the server. To override a
         value per-agent, set it in the agent's Environment section above.
       </p>
@@ -188,9 +188,9 @@ function EnvEditor({
   };
 
   return (
-    <div className="px-3 pb-3 border-t border-mycel-border/20">
+    <div className="px-3 pb-3 border-t border-mycel-border/40">
       {pairs.length === 0 && (
-        <p className="py-2 text-[11px] text-mycel-muted/60" style={{ fontFamily: MONO }}>
+        <p className="py-2 text-[11px] text-mycel-muted" style={{ fontFamily: MONO }}>
           No env variables set.
         </p>
       )}
@@ -211,7 +211,7 @@ function EnvEditor({
           <button
             type="button"
             onClick={() => remove(i)}
-            className="px-2 py-1 text-[11px] text-mycel-muted/60 hover:text-mycel-error"
+            className="px-2 py-1 text-[11px] text-mycel-muted hover:text-mycel-error"
             style={{ fontFamily: MONO }}
           >
             ✕
@@ -254,7 +254,7 @@ function EnvEditor({
             {saveError}
           </span>
         ) : (
-          <span className="text-[10px] text-mycel-muted/40" style={{ fontFamily: MONO }}>
+          <span className="text-[10px] text-mycel-muted" style={{ fontFamily: MONO }}>
             {dirty ? "Unsaved changes" : "Synced"}
           </span>
         )}

--- a/web/src/components/shared/SearchInput.tsx
+++ b/web/src/components/shared/SearchInput.tsx
@@ -16,7 +16,7 @@ export function SearchInput({
     <div className={`relative flex items-center ${className ?? ""}`}>
       {/* Magnifying glass icon */}
       <svg
-        className="absolute left-2.5 w-3.5 h-3.5 text-mycel-muted/50 pointer-events-none"
+        className="absolute left-2.5 w-3.5 h-3.5 text-mycel-muted pointer-events-none"
         viewBox="0 0 16 16"
         fill="none"
         stroke="currentColor"
@@ -33,7 +33,7 @@ export function SearchInput({
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         aria-label={placeholder}
-        className="w-full pl-8 pr-7 py-1.5 rounded border border-mycel-border/40 bg-mycel-surface text-sm text-mycel-text placeholder:text-mycel-muted/40 focus:outline-none focus:border-mycel-accent/50 transition-colors"
+        className="w-full pl-8 pr-7 py-1.5 rounded border border-mycel-border/40 bg-mycel-surface text-sm text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:border-mycel-accent/50 transition-colors"
       />
 
       {/* Clear button */}
@@ -41,7 +41,7 @@ export function SearchInput({
         <button
           type="button"
           onClick={() => onChange("")}
-          className="absolute right-2 text-mycel-muted/50 hover:text-mycel-muted transition-colors leading-none"
+          className="absolute right-2 text-mycel-muted hover:text-mycel-muted transition-colors leading-none"
           aria-label="Clear search"
         >
           <svg

--- a/web/src/components/shared/SectionRule.tsx
+++ b/web/src/components/shared/SectionRule.tsx
@@ -20,7 +20,7 @@ export function SectionRule({
     <div className="flex items-center gap-3 py-2">
       {text && (
         <span
-          className="text-[10px] font-semibold text-mycel-muted/60 uppercase tracking-widest whitespace-nowrap"
+          className="text-[10px] font-semibold text-mycel-muted uppercase tracking-widest whitespace-nowrap"
           style={{ fontFamily: MONO }}
         >
           {text}

--- a/web/src/components/shared/SystemPromptEditor.tsx
+++ b/web/src/components/shared/SystemPromptEditor.tsx
@@ -130,9 +130,9 @@ export function SystemPromptEditor({
       </div>
 
       {loading ? (
-        <div className="rounded-md border border-mycel-border/30 bg-mycel-surface/20 p-4">
+        <div className="rounded-md border border-mycel-border/40 bg-mycel-surface/20 p-4">
           <p
-            className="text-xs text-mycel-muted/40 italic"
+            className="text-xs text-mycel-muted italic"
             style={{ fontFamily: MONO }}
           >
             Loading…

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -200,7 +200,7 @@ export function About() {
     <div className="p-6 flex flex-col gap-6 max-w-3xl mx-auto">
       <header className="flex items-baseline justify-between gap-3">
         <div className="flex items-baseline gap-3">
-          <span className="text-[11px] uppercase tracking-wider text-mycel-muted/60">Installed</span>
+          <span className="text-[11px] uppercase tracking-wider text-mycel-muted">Installed</span>
           <span className="text-2xl font-semibold text-mycel-text font-mono tabular-nums">
             {health?.version ?? "—"}
           </span>
@@ -255,7 +255,7 @@ go install github.com/rpuneet/mycel/cmd/mycel@latest    # from source`}
         </pre>
       </section>
 
-      <footer className="text-[10px] text-mycel-muted/60 font-mono">
+      <footer className="text-[10px] text-mycel-muted font-mono">
         Built from commit <span className="text-mycel-text">{health?.version ?? "?"}</span>.
         Live distribution checks hit github.com / registry.npmjs.org / raw.githubusercontent.com directly.
       </footer>
@@ -291,7 +291,7 @@ function ChannelTile({ channel }: { channel: ChannelStatus }) {
         )}
       </div>
       {channel.href && (
-        <span className="text-[10px] text-mycel-muted/50 shrink-0" aria-hidden>↗</span>
+        <span className="text-[10px] text-mycel-muted shrink-0" aria-hidden>↗</span>
       )}
     </div>
   );

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -542,7 +542,7 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
                 {syncing ? "Syncing…" : "Sync"}
               </button>
             </div>
-            <p className="text-[10px] text-mycel-muted/40 mt-1 leading-relaxed" style={{ fontFamily: MONO }}>
+            <p className="text-[10px] text-mycel-muted mt-1 leading-relaxed" style={{ fontFamily: MONO }}>
               Re-apply template system prompt and MCP configuration
             </p>
           </section>
@@ -557,7 +557,7 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
             onAdd={useLiveMcp ? handleMcpAdd : undefined}
             onRemove={useLiveMcp ? handleMcpRemove : undefined}
           />
-          <p className="mt-2 text-[10px] text-mycel-muted/40 leading-relaxed" style={{ fontFamily: MONO }}>
+          <p className="mt-2 text-[10px] text-mycel-muted leading-relaxed" style={{ fontFamily: MONO }}>
             {isTmux
               ? "For tmux agents, MCPs are managed via the Claude CLI. Changes here write to the agent\u2019s worktree."
               : "Changes write to .mcp.json in the container."}
@@ -612,14 +612,14 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
 
           {/* Placeholder hint when no env vars are set */}
           {envVars.length === 0 && (
-            <p className="mb-3 text-[10px] text-mycel-muted/40 italic" style={{ fontFamily: MONO }}>
+            <p className="mb-3 text-[10px] text-mycel-muted italic" style={{ fontFamily: MONO }}>
               Common: ANTHROPIC_API_KEY, GITHUB_TOKEN, AWS_ACCESS_KEY_ID
             </p>
           )}
 
           {/* Existing env var rows */}
           {envVars.length > 0 && (
-            <div className="mb-3 rounded-md border border-mycel-border/30 overflow-hidden divide-y divide-mycel-border/20">
+            <div className="mb-3 rounded-md border border-mycel-border/40 overflow-hidden divide-y divide-mycel-border/20">
               {envVars.map((ev, i) => (
                 <div
                   key={i}
@@ -672,10 +672,10 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
                 }
               }}
               placeholder="KEY"
-              className="w-32 rounded border border-mycel-border/40 bg-mycel-bg px-2.5 py-1 text-[11px] text-mycel-text/90 placeholder:text-mycel-muted/40 outline-none focus:border-mycel-accent/50 transition-colors"
+              className="w-32 rounded border border-mycel-border/40 bg-mycel-bg px-2.5 py-1 text-[11px] text-mycel-text/90 placeholder:text-mycel-muted outline-none focus:border-mycel-accent/50 transition-colors"
               style={{ fontFamily: MONO }}
             />
-            <span className="text-mycel-muted/40 text-[11px]" style={{ fontFamily: MONO }}>=</span>
+            <span className="text-mycel-muted text-[11px]" style={{ fontFamily: MONO }}>=</span>
             <input
               type="text"
               value={newValue}
@@ -690,7 +690,7 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
                 }
               }}
               placeholder="value"
-              className="flex-1 max-w-[200px] rounded border border-mycel-border/40 bg-mycel-bg px-2.5 py-1 text-[11px] text-mycel-text/90 placeholder:text-mycel-muted/40 outline-none focus:border-mycel-accent/50 transition-colors"
+              className="flex-1 max-w-[200px] rounded border border-mycel-border/40 bg-mycel-bg px-2.5 py-1 text-[11px] text-mycel-text/90 placeholder:text-mycel-muted outline-none focus:border-mycel-accent/50 transition-colors"
               style={{ fontFamily: MONO }}
             />
             <button
@@ -711,23 +711,23 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
             </button>
           </div>
 
-          <p className="mt-2 text-[10px] text-mycel-muted/40 leading-relaxed" style={{ fontFamily: MONO }}>
+          <p className="mt-2 text-[10px] text-mycel-muted leading-relaxed" style={{ fontFamily: MONO }}>
             {isTmux
               ? "Set via provider CLI environment · Env vars are applied on agent restart"
               : "Injected as container environment variables · Env vars are applied on agent restart"}
           </p>
           {agent.tool === "claude" && (
-            <div className="mt-2 text-[10px] text-mycel-muted/50" style={{ fontFamily: MONO }}>
+            <div className="mt-2 text-[10px] text-mycel-muted" style={{ fontFamily: MONO }}>
               <span className="font-medium">Claude requires:</span> ANTHROPIC_API_KEY
             </div>
           )}
           {agent.tool === "gemini" && (
-            <div className="mt-2 text-[10px] text-mycel-muted/50" style={{ fontFamily: MONO }}>
+            <div className="mt-2 text-[10px] text-mycel-muted" style={{ fontFamily: MONO }}>
               <span className="font-medium">Gemini requires:</span> GOOGLE_API_KEY
             </div>
           )}
           {agent.tool === "openai" && (
-            <div className="mt-2 text-[10px] text-mycel-muted/50" style={{ fontFamily: MONO }}>
+            <div className="mt-2 text-[10px] text-mycel-muted" style={{ fontFamily: MONO }}>
               <span className="font-medium">OpenAI requires:</span> OPENAI_API_KEY
             </div>
           )}
@@ -736,7 +736,7 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
         {/* ── ACTIONS ── */}
         <section>
           <SectionRule>Actions</SectionRule>
-          <div className="rounded-md border border-mycel-border/30 bg-mycel-surface/20 px-4 py-3">
+          <div className="rounded-md border border-mycel-border/40 bg-mycel-surface/20 px-4 py-3">
             <div className="flex flex-wrap gap-2 items-center">
               {/* Clone — opens CreateAgentModal pre-seeded with this agent */}
               <button
@@ -933,7 +933,7 @@ function CodeTabPlaceholder({ agent }: { agent: Agent }) {
   return (
     <div className="flex-1 flex items-center justify-center p-6">
       <div className="max-w-md text-center space-y-4" style={{ fontFamily: MONO }}>
-        <p className="text-[11px] text-mycel-muted/50 uppercase tracking-wider">
+        <p className="text-[11px] text-mycel-muted uppercase tracking-wider">
           Agent code — diff view
         </p>
         <p className="text-sm text-mycel-muted leading-relaxed">
@@ -961,7 +961,7 @@ function MetricsTab({ agent }: { agent: Agent }) {
       <div className="max-w-4xl mx-auto space-y-4">
         {isStopped && (
           <p
-            className="text-[10px] text-mycel-muted/40 italic"
+            className="text-[10px] text-mycel-muted italic"
             style={{ fontFamily: MONO }}
           >
             Agent is not running. Stats show last known values.
@@ -1080,7 +1080,7 @@ export function AgentDetail() {
   if (loading && !agent) {
     return (
       <div className="flex items-center justify-center h-full">
-        <span className="text-sm text-mycel-muted/50" style={{ fontFamily: MONO }}>
+        <span className="text-sm text-mycel-muted" style={{ fontFamily: MONO }}>
           loading\u2026
         </span>
       </div>
@@ -1120,7 +1120,7 @@ export function AgentDetail() {
           {/* ── Identity ── */}
           <Link
             to={agentsUrl}
-            className="text-mycel-muted/50 hover:text-mycel-text transition-colors shrink-0"
+            className="text-mycel-muted hover:text-mycel-text transition-colors shrink-0"
             title="Back to agents"
             aria-label="Back to agents"
           >
@@ -1133,7 +1133,7 @@ export function AgentDetail() {
             {agent.name}
           </span>
           {agent.runtime_backend && (
-            <span className="shrink-0 text-mycel-muted/50" title={`Runtime: ${agent.runtime_backend}`}>
+            <span className="shrink-0 text-mycel-muted" title={`Runtime: ${agent.runtime_backend}`}>
               {agent.runtime_backend === "docker" ? (
                 <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
                   <rect x="1" y="4" width="12" height="8" rx="1" />
@@ -1191,7 +1191,7 @@ export function AgentDetail() {
 
           {lastSeen && (
             <span
-              className="text-[10px] text-mycel-muted/40 tabular-nums shrink-0"
+              className="text-[10px] text-mycel-muted tabular-nums shrink-0"
               title={formatTime(lastSeen)}
               style={{ fontFamily: MONO }}
             >

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -22,7 +22,7 @@ import { MONO } from "../utils/typography";
  * tell "how it runs" from "what it runs" without reading the label.
  */
 function RuntimeChip({ runtime }: { runtime?: string | null }) {
-  if (!runtime) return <span className="text-mycel-muted/50">—</span>;
+  if (!runtime) return <span className="text-mycel-muted">—</span>;
   const isDocker = runtime === "docker";
   return (
     <span
@@ -64,7 +64,7 @@ const PROVIDER_DOTS: Record<string, string> = {
 };
 
 function ProviderChip({ tool }: { tool?: string | null }) {
-  if (!tool) return <span className="text-mycel-muted/50">—</span>;
+  if (!tool) return <span className="text-mycel-muted">—</span>;
   const dot = PROVIDER_DOTS[tool] ?? "bg-mycel-muted/50";
   return (
     <span
@@ -322,7 +322,7 @@ export function Agents() {
     title: <TabHeaderTitle>Agents</TabHeaderTitle>,
     actions: (
       <>
-        <span className="text-[10px] text-mycel-muted/40 tabular-nums" style={{ fontFamily: MONO }}>
+        <span className="text-[10px] text-mycel-muted tabular-nums" style={{ fontFamily: MONO }}>
           {agents ? `${String(agents.length)} total` : "\u2014"}
         </span>
         <button
@@ -829,7 +829,7 @@ export function Agents() {
                           .map((s) => s.replace(/^mcp__/, ""))
                           .filter((s) => s !== "bc" && s !== "mycel");
                         if (extras.length === 0) {
-                          return <span className="text-mycel-muted/40 text-[11px]">{"\u2014"}</span>;
+                          return <span className="text-mycel-muted text-[11px]">{"\u2014"}</span>;
                         }
                         const fullList = extras.join(", ");
                         if (extras.length <= 2) {

--- a/web/src/views/Code.tsx
+++ b/web/src/views/Code.tsx
@@ -569,7 +569,7 @@ export function Code() {
             <div className="px-3 py-2 text-[11px] text-mycel-danger/70">{rootError}</div>
           )}
           {!rootLoading && !rootError && rootEntries.length === 0 && (
-            <div className="px-3 py-2 text-[11px] text-mycel-muted/50 italic">
+            <div className="px-3 py-2 text-[11px] text-mycel-muted italic">
               {worktree === "main"
                 ? "No files to display."
                 : "This agent's worktree does not exist or has no files."}
@@ -593,7 +593,7 @@ export function Code() {
         {/* Viewer pane */}
         <section className="flex-1 min-w-0 overflow-hidden relative">
           {!path && (
-            <div className="h-full flex items-center justify-center text-[11px] text-mycel-muted/50 italic">
+            <div className="h-full flex items-center justify-center text-[11px] text-mycel-muted italic">
               Select a file from the tree
             </div>
           )}
@@ -708,14 +708,14 @@ function TreeList({
                   : "text-mycel-text/80"
               }`}
             >
-              <span className="text-mycel-muted/40 shrink-0 w-3 text-center">{icon}</span>
+              <span className="text-mycel-muted shrink-0 w-3 text-center">{icon}</span>
               <span className="truncate">{node.name}</span>
             </button>
             {isExpanded && (
               <>
                 {childLoading && !childEntries && (
                   <div
-                    className="text-[10px] text-mycel-muted/50 italic py-0.5"
+                    className="text-[10px] text-mycel-muted italic py-0.5"
                     style={{ paddingLeft: 12 + (depth + 1) * 12 }}
                   >
                     loading…
@@ -736,7 +736,7 @@ function TreeList({
                 )}
                 {childEntries && childEntries.length === 0 && !childLoading && (
                   <div
-                    className="text-[10px] text-mycel-muted/40 italic py-0.5"
+                    className="text-[10px] text-mycel-muted italic py-0.5"
                     style={{ paddingLeft: 12 + (depth + 1) * 12 }}
                   >
                     (empty)

--- a/web/src/views/CostsGlobal.tsx
+++ b/web/src/views/CostsGlobal.tsx
@@ -82,13 +82,13 @@ export function CostsGlobal() {
           open — the row can accept a donut / spark to its right
           later without another restructure. */}
       <div className="flex flex-col gap-1">
-        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-mycel-muted/60">
+        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-mycel-muted">
           Total
         </span>
         <span className="text-[28px] font-semibold text-mycel-text leading-none tabular-nums">
           {formatCost(total)}
         </span>
-        <span className="text-[11px] text-mycel-muted/60 tabular-nums">
+        <span className="text-[11px] text-mycel-muted tabular-nums">
           {/* Date repeats the value in the picker top-right; show the
               counter only to avoid the DD/MM ↔ ISO format mismatch. */}
           {rows?.length ?? 0} {(rows?.length ?? 0) === 1 ? (groupBy === "workspace" ? "workspace" : "project") : (groupBy === "workspace" ? "workspaces" : "projects")}
@@ -136,7 +136,7 @@ export function CostsGlobal() {
                 return (
                   <tr
                     key={r.key}
-                    className="border-t border-mycel-border/20 hover:bg-mycel-surface/30 transition-colors"
+                    className="border-t border-mycel-border/40 hover:bg-mycel-surface/30 transition-colors"
                   >
                     <td colSpan={3} className="p-0">
                       <Link to={`/w/${r.key}/stats`} className="contents">
@@ -147,7 +147,7 @@ export function CostsGlobal() {
                 );
               }
               return (
-                <tr key={r.key} className="border-t border-mycel-border/20">
+                <tr key={r.key} className="border-t border-mycel-border/40">
                   {content}
                 </tr>
               );

--- a/web/src/views/Notifications.tsx
+++ b/web/src/views/Notifications.tsx
@@ -101,7 +101,7 @@ export function Notifications() {
               <button
                 key={p.name}
                 type="button"
-                className="p-4 border border-mycel-border/30 rounded-xl hover:border-mycel-border/60 hover:bg-mycel-surface/30 transition-all text-center group"
+                className="p-4 border border-mycel-border/40 rounded-xl hover:border-mycel-border/60 hover:bg-mycel-surface/30 transition-all text-center group"
               >
                 <div
                   className="w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold mx-auto mb-2"

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -223,7 +223,7 @@ function TemplateDetailPanel({
         >
           ← Templates
         </button>
-        <span className="text-mycel-muted/40">/</span>
+        <span className="text-mycel-muted">/</span>
         <h1
           className="text-xl font-bold text-mycel-text"
           style={{ fontFamily: MONO }}
@@ -748,7 +748,7 @@ export function Templates() {
         <div className="rounded border border-mycel-border bg-mycel-surface overflow-hidden">
           <table className="w-full">
             <thead>
-              <tr className="text-left text-[11px] font-medium text-mycel-muted/60 uppercase tracking-wide">
+              <tr className="text-left text-[11px] font-medium text-mycel-muted uppercase tracking-wide">
                 <th className="py-2.5 pl-4 pr-6 font-medium">Name</th>
                 <th className="py-2.5 px-4 font-medium">MCPs</th>
                 <th className="py-2.5 px-4 font-medium">Secrets</th>

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -429,7 +429,7 @@ export function Tools() {
           <h2 className="text-[11px] font-medium text-mycel-muted uppercase tracking-[0.14em]">
             AI Model Providers
           </h2>
-          <span className="text-[11px] text-mycel-muted/50 tabular-nums">
+          <span className="text-[11px] text-mycel-muted tabular-nums">
             {providerList.length}
           </span>
           <span className="flex-1 h-px bg-mycel-border/40 self-center" aria-hidden />
@@ -442,7 +442,7 @@ export function Tools() {
           <h2 className="text-[11px] font-medium text-mycel-muted uppercase tracking-[0.14em]">
             CLI Dependencies
           </h2>
-          <span className="text-[11px] text-mycel-muted/50 tabular-nums">
+          <span className="text-[11px] text-mycel-muted tabular-nums">
             {filteredCli.length}{searchLower ? `/${cliTools.length}` : ""}
           </span>
           <span className="flex-1 h-px bg-mycel-border/40 self-center" aria-hidden />

--- a/web/src/views/WorkspacePicker.tsx
+++ b/web/src/views/WorkspacePicker.tsx
@@ -34,7 +34,7 @@ export function WorkspacePicker() {
             Pick a workspace to continue, or add a new one.
           </p>
           {fromPath && (
-            <p className="text-[11px] text-mycel-muted/60 italic">
+            <p className="text-[11px] text-mycel-muted italic">
               The URL {fromPath} is not associated with any known workspace.
             </p>
           )}
@@ -42,10 +42,10 @@ export function WorkspacePicker() {
 
         {/* Registered workspaces list */}
         <section>
-          <div className="text-[10px] text-mycel-muted/50 uppercase tracking-[0.2em] mb-2">
+          <div className="text-[10px] text-mycel-muted uppercase tracking-[0.2em] mb-2">
             Registered
           </div>
-          {loading && <p className="text-[12px] text-mycel-muted/50">loading…</p>}
+          {loading && <p className="text-[12px] text-mycel-muted">loading…</p>}
           {!loading && workspaces.length === 0 && (
             <p className="text-[12px] text-mycel-muted/60 italic">
               No workspaces registered yet. Add one below.
@@ -66,20 +66,20 @@ export function WorkspacePicker() {
                       <span className="text-[13px] font-semibold text-mycel-text">
                         {ws.name || ws.path.split("/").pop() || "unnamed"}
                       </span>
-                      <span className="text-[9px] text-mycel-muted/40 tabular-nums">
+                      <span className="text-[9px] text-mycel-muted tabular-nums">
                         [{ws.id.slice(0, 6)}]
                       </span>
                       {ws.alias && (
-                        <span className="text-[10px] text-mycel-muted/60">@{ws.alias}</span>
+                        <span className="text-[10px] text-mycel-muted">@{ws.alias}</span>
                       )}
                     </div>
-                    <div className="text-[10px] text-mycel-muted/50 truncate" title={ws.path}>
+                    <div className="text-[10px] text-mycel-muted truncate" title={ws.path}>
                       {ws.path}
                     </div>
                   </div>
                   {ws.github_url && (
                     <span
-                      className="text-[9px] text-mycel-muted/40 truncate max-w-[180px]"
+                      className="text-[9px] text-mycel-muted truncate max-w-[180px]"
                       title={ws.github_url}
                     >
                       {ws.github_url.replace(/^https?:\/\/github\.com\//, "gh:")}
@@ -93,7 +93,7 @@ export function WorkspacePicker() {
 
         {/* Add workspace options */}
         <section className="space-y-3">
-          <div className="text-[10px] text-mycel-muted/50 uppercase tracking-[0.2em]">
+          <div className="text-[10px] text-mycel-muted uppercase tracking-[0.2em]">
             Add workspace
           </div>
 
@@ -108,7 +108,7 @@ export function WorkspacePicker() {
               }`}
             >
               <div className="font-semibold mb-0.5">Scan local</div>
-              <div className="text-[10px] text-mycel-muted/60">Find .git repos on disk</div>
+              <div className="text-[10px] text-mycel-muted">Find .git repos on disk</div>
             </button>
             <button
               type="button"
@@ -120,7 +120,7 @@ export function WorkspacePicker() {
               }`}
             >
               <div className="font-semibold mb-0.5">From GitHub</div>
-              <div className="text-[10px] text-mycel-muted/60">List + clone your repos</div>
+              <div className="text-[10px] text-mycel-muted">List + clone your repos</div>
             </button>
             <button
               type="button"
@@ -132,7 +132,7 @@ export function WorkspacePicker() {
               }`}
             >
               <div className="font-semibold mb-0.5">Add manually</div>
-              <div className="text-[10px] text-mycel-muted/60">By absolute path</div>
+              <div className="text-[10px] text-mycel-muted">By absolute path</div>
             </button>
           </div>
 
@@ -245,7 +245,7 @@ function ScanPane({ onDone }: { onDone: () => void }) {
       {err && <p className="text-[11px] text-mycel-error">{err}</p>}
 
       {candidates && candidates.length === 0 && (
-        <p className="text-[11px] text-mycel-muted/60 italic">No repos found under {root}</p>
+        <p className="text-[11px] text-mycel-muted italic">No repos found under {root}</p>
       )}
 
       {candidates && candidates.length > 0 && (
@@ -270,11 +270,11 @@ function ScanPane({ onDone }: { onDone: () => void }) {
                   }}
                 />
                 <span className="font-semibold text-mycel-text/90">{c.name}</span>
-                <span className="text-mycel-muted/50 truncate" title={c.path}>
+                <span className="text-mycel-muted truncate" title={c.path}>
                   {c.path}
                 </span>
                 {c.already_registered && (
-                  <span className="ml-auto text-[9px] text-mycel-muted/40 uppercase">already added</span>
+                  <span className="ml-auto text-[9px] text-mycel-muted uppercase">already added</span>
                 )}
               </label>
             ))}
@@ -303,7 +303,7 @@ function GitHubPane({ onDone: _onDone }: { onDone: () => void }) {
         <span className="text-mycel-text font-semibold"> Scan local</span> or
         <span className="text-mycel-text font-semibold"> Add manually</span>.
       </p>
-      <p className="text-[10px] text-mycel-muted/50">
+      <p className="text-[10px] text-mycel-muted">
         Tracked in: docs/proposals/multi-workspace-and-code-tab.md \u00A7 4.4
       </p>
     </div>


### PR DESCRIPTION
Closes 2 more items on #3205.

## Muted text contrast (WCAG AA)
- Every use of `text-mycel-muted/40` or `text-mycel-muted/50` bumped to full `text-mycel-muted`. At the 10–11px sizes these classes were being paired with (timestamps, ×-count chips, hash chips, workspace path captions in the switcher, sub-labels on stats tiles), 40–50% opacity muted on the body-bg failed AA — estimated 3.2–3.9:1.
- `text-mycel-muted/60` bumped to `text-mycel-muted` only where paired with `text-[10px]` or `text-[11px]` classes on the same span; larger paragraph-scale muted at /60 stays as-is since the contrast headroom is bigger.

## Border opacity system
- Consolidated `border-mycel-border/20` and `/30` (effectively invisible on dark surfaces) into `/40`. The intended pair is now `border-mycel-border` (strong) + `/40` (soft). `/50` kept where it was already used for a distinct third tier.
- 11 files touched by the border sweep, 23 by the muted-text sweep. Both are mechanical rewrites — no visual regression risk on the larger surfaces.

## Test plan
- [x] Full web suite (126) green
- [x] `bun run lint` + `bunx tsc -b --noEmit` clean
- [x] Verified live at http://0.0.0.0:8080 after rebuild + `mycel down/up`.

Part of #3205