### PR TITLE
fix(gateway): strip channel platform prefix — was silently indexing wrong key (#3219)

### DIFF
--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -155,7 +155,16 @@ func (h *GatewayHandler) gatewayChannels(w http.ResponseWriter, r *http.Request,
 
 	// /api/gateways/{platform}/channels/{channel}/...
 	channelParts := strings.SplitN(subpath, "/", 2)
-	channelName := platform + ":" + channelParts[0]
+	// Defensive against callers who pre-prefix the channel with the
+	// platform (e.g. `POST /api/gateways/slack/channels/slack:general/agents`).
+	// Without this guard the channel key gets written as
+	// `slack:slack:general` — silently indexed on the wrong key so
+	// inbound messages on `slack:general` bypass the subscription lookup
+	// and never reach the agent. That's how the notify subscriptions
+	// "vanished" after they were added earlier this session.
+	rawChannel := channelParts[0]
+	rawChannel = strings.TrimPrefix(rawChannel, platform+":")
+	channelName := platform + ":" + rawChannel
 	channelRest := ""
 	if len(channelParts) > 1 {
 		channelRest = channelParts[1]


### PR DESCRIPTION
Fixes #3219.

## What broke
`POST /api/gateways/slack/channels/slack:general/agents` was building
```go
channelName := platform + ":" + channelParts[0]  // → "slack:slack:general"
```
so the notify_subscriptions row was indexed on a key that no inbound gateway event ever matched. The subscription silently didn't route. GET on the same endpoint returned an empty list because the read was correctly keyed on `slack:general` while the write went to `slack:slack:general`. Discovered when a user reported their previously-added agents "got reset".

## Fix
Idempotent leading-platform-prefix strip in `gatewayChannels` before rebuilding `channelName`:
```go
rawChannel := strings.TrimPrefix(channelParts[0], platform+":")
channelName := platform + ":" + rawChannel
```
Both URL shapes now write the same key:
- `.../channels/general/agents` → `slack:general` ✓
- `.../channels/slack:general/agents` → `slack:general` ✓ (was `slack:slack:general`)

## Cleanup
Phantom rows are handled at runtime by an SQL delete + re-subscribe against the live DB in this session; no migration.

## Test plan
- [x] `go build ./...` clean
- [x] Existing gateway handler tests pass (`go test ./server/handlers/... -run Gateway`)
- [x] Live verified: subscribing zen-zebra now writes `slack:general` in the DB (was `slack:slack:general`); `GET .../agents` returns the subscription.

Fixes #3219
EOF