### PR TITLE
refactor(web): reduce range picker accent glow (#3205 batch 10)

### DIFF
--- a/web/src/components/StatsTab.tsx
+++ b/web/src/components/StatsTab.tsx
@@ -345,7 +345,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
             <button key={r.label} type="button" onClick={() => setRange(i)}
               className={`px-2.5 py-1 text-xs rounded border transition-colors ${
                 i === range
-                  ? "border-mycel-accent bg-mycel-accent/10 text-mycel-accent"
+                  ? "border-mycel-accent text-mycel-accent"
                   : "border-mycel-border text-mycel-muted hover:text-mycel-text hover:border-mycel-muted"
               }`}
             >{r.label}</button>

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -257,8 +257,12 @@ export function Stats() {
         {RANGES.map((r, i) => (
           <button key={r.label} type="button" onClick={() => setRange(i)}
             className={`px-2 py-0.5 text-[11px] rounded border transition-colors ${
+              /* Selected state uses accent text + border only — the
+                 tinted accent bg was a triple-accent that competed
+                 with the sidebar brand tile + active nav under Dark
+                 (#3205 batch 10). */
               i === range
-                ? "border-mycel-accent bg-mycel-accent/10 text-mycel-accent"
+                ? "border-mycel-accent text-mycel-accent"
                 : "border-mycel-border text-mycel-muted hover:text-mycel-text hover:border-mycel-muted"
             }`}
           >{r.label}</button>


### PR DESCRIPTION
Small accent-overuse fix on #3205.

The Metrics range picker selected state used `border-mycel-accent bg-mycel-accent/10 text-mycel-accent` — three accent layers. Combined with the sidebar brand tile + active nav item, the same emerald slot fired 4× under Dark in a single viewport.

Dropped the tinted `bg-mycel-accent/10` layer; accent border + accent text alone read as "selected". Applied to `StatsTab.tsx` too for consistency.

Full accent-role audit (brand tile vs nav vs range vs Live pulse) tracked on #3205 for a design pass; this is the quick reduce-the-glow win.

Part of #3205