### PR TITLE
feat(web): Agents — group-by-repo toggle (#3076)

### DIFF
--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -316,6 +316,22 @@ export function Agents() {
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
   const [stoppingAll, setStoppingAll] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  // "Group by repo" — inserts a section header row every time the sorted
+  // list crosses a `repo_root` boundary. No-ops when every visible agent
+  // shares a repo (the common single-workspace case), so enabling the
+  // toggle is safe on any workspace. Persist across reloads. #3076.
+  const [groupByRepo, setGroupByRepo] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem("bc-agents-group-by-repo") === "1";
+    } catch { return false; }
+  });
+  const toggleGroupByRepo = useCallback(() => {
+    setGroupByRepo(prev => {
+      const next = !prev;
+      try { localStorage.setItem("bc-agents-group-by-repo", next ? "1" : "0"); } catch { /* ignore */ }
+      return next;
+    });
+  }, []);
 
   // Header slot: title + "Create agent" action
   useHeaderSlot({
@@ -447,10 +463,27 @@ export function Agents() {
   }, [allAgents, search, roleFilter, stateFilter, toolFilter]);
 
   // Sort: working first, then idle, then stopped/error.
+  // When `groupByRepo` is on we sort primarily by `repo_root` so the
+  // table can insert a section header at each boundary.
   const displayRows = useMemo(() => {
     const rank = (s: string) => (s === "working" || s === "starting" ? 0 : s === "idle" ? 1 : 2);
-    return [...filteredAgents].sort((a, b) => rank(a.state) - rank(b.state) || a.name.localeCompare(b.name));
-  }, [filteredAgents]);
+    return [...filteredAgents].sort((a, b) => {
+      if (groupByRepo) {
+        const ra = a.repo_root ?? "";
+        const rb = b.repo_root ?? "";
+        const cmp = ra.localeCompare(rb);
+        if (cmp !== 0) return cmp;
+      }
+      return rank(a.state) - rank(b.state) || a.name.localeCompare(b.name);
+    });
+  }, [filteredAgents, groupByRepo]);
+
+  // How many distinct repos are in view — the toggle collapses to a
+  // read-only info line when there's only one, so users know why
+  // enabling it doesn't change anything.
+  const distinctRepoCount = useMemo(() => {
+    return new Set(displayRows.map(a => a.repo_root ?? "").filter(Boolean)).size;
+  }, [displayRows]);
 
   // Clamp focusIndex when displayRows shrinks (e.g. after filtering).
   useEffect(() => {
@@ -704,6 +737,23 @@ export function Agents() {
               Clear
             </button>
           )}
+          {/* Group-by-repo toggle. Inserts a section header row per
+              `repo_root`. Disabled when every visible agent shares a
+              repo (nothing to group). Persists in localStorage. #3076. */}
+          <button
+            type="button"
+            onClick={toggleGroupByRepo}
+            disabled={distinctRepoCount <= 1}
+            aria-pressed={groupByRepo}
+            className={`px-2 py-1.5 text-xs rounded border transition-colors ${
+              groupByRepo && distinctRepoCount > 1
+                ? "border-mycel-accent text-mycel-accent"
+                : "border-mycel-border text-mycel-muted hover:text-mycel-text disabled:opacity-50 disabled:cursor-not-allowed"
+            }`}
+            title={distinctRepoCount <= 1 ? "All agents share one repo — nothing to group" : `Group by repo (${distinctRepoCount} repos in view)`}
+          >
+            Group by repo
+          </button>
         </div>
       )}
 
@@ -761,6 +811,21 @@ export function Agents() {
             <tbody>
               {displayRows.map((a, rowIdx) => (
                 <Fragment key={a.name}>
+                  {/* Repo section header — rendered whenever the sorted
+                      list crosses a repo_root boundary and grouping is
+                      enabled. Header is a sticky-ish table row with an
+                      uppercase repo path caption so users can visually
+                      chunk agents by which project they belong to. */}
+                  {groupByRepo && distinctRepoCount > 1 &&
+                    (rowIdx === 0 || (displayRows[rowIdx - 1]!.repo_root ?? "") !== (a.repo_root ?? "")) && (
+                    <tr>
+                      <td colSpan={columns.length} className="px-4 pt-4 pb-1 text-[10px] uppercase tracking-[0.12em] text-mycel-muted font-medium">
+                        {a.repo_root
+                          ? a.repo_root.replace(/^\/(?:Users|home)\/[^/]+/, "~")
+                          : "(no repo)"}
+                      </td>
+                    </tr>
+                  )}
                   {/* Subtle divider between active and stopped groups */}
                   {rowIdx > 0 &&
                     (a.state === "stopped" || a.state === "error") &&


### PR DESCRIPTION
Fixes #3076.

Adds a per-page toggle on the Agents table that groups rows by their `repo_root` field, with an uppercase repo-path caption inserted whenever the sorted list crosses a boundary. Path is home-collapsed (`/Users/foo/…` → `~/…`) so the caption stays scannable.

- Toggle sits in the filter row next to `Clear`, disabled when every visible agent shares one repo. Tooltip explains why.
- Persists in localStorage as `bc-agents-group-by-repo`.
- `aria-pressed` reflects state.
- Sort ordering: `repo_root` primary when grouping is on, then existing state-rank + name.

No-op regression: with grouping off, table renders exactly as before. With grouping on but one repo, toggle refuses to enable.

Fixes #3076
Part of #3205