### PR TITLE
feat(notify+web): surface emoji reactions on inbound messages (#3075)

### DIFF
--- a/pkg/notify/api_test.go
+++ b/pkg/notify/api_test.go
@@ -1089,7 +1089,7 @@ func TestMessageStorage(t *testing.T) {
 			ctx := context.Background()
 
 			for _, m := range tt.messages {
-				if err := store.SaveMessage(ctx, m.channel, m.sender, m.content); err != nil {
+				if err := store.SaveMessage(ctx, m.channel, m.sender, m.content, nil); err != nil {
 					t.Fatalf("SaveMessage: %v", err)
 				}
 			}
@@ -1135,7 +1135,7 @@ func TestMessageStorage_Before(t *testing.T) {
 
 	// Save 5 messages
 	for i := range 5 {
-		_ = store.SaveMessage(ctx, "slack:eng", "sender", "msg")
+		_ = store.SaveMessage(ctx, "slack:eng", "sender", "msg", nil)
 		_ = i // suppress unused warning
 	}
 

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -76,6 +76,52 @@ func extractMentions(content string) []string {
 	return mentions
 }
 
+// extractReactions best-effort extracts emoji reactions from a raw
+// gateway payload. Supports Slack + Discord shapes:
+//
+//	Slack:   { "reactions": [ { "name": "eyes", "count": 2 }, ... ] }
+//	Discord: { "reactions": [ { "emoji": { "name": "eyes" }, "count": 2 }, ... ] }
+//
+// Returns nil for platforms that don't include reactions or when the raw
+// payload can't be parsed — the caller stores nil as SQL NULL. #3075.
+func extractReactions(raw json.RawMessage) []MessageReaction {
+	if len(raw) == 0 {
+		return nil
+	}
+	// Both shapes carry a `reactions` array — parse loosely.
+	var envelope struct {
+		Reactions []struct {
+			Name  string `json:"name"`
+			Count int    `json:"count"`
+			Emoji struct {
+				Name string `json:"name"`
+			} `json:"emoji"`
+		} `json:"reactions"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil
+	}
+	if len(envelope.Reactions) == 0 {
+		return nil
+	}
+	out := make([]MessageReaction, 0, len(envelope.Reactions))
+	for _, r := range envelope.Reactions {
+		name := r.Name
+		if name == "" {
+			name = r.Emoji.Name
+		}
+		if name == "" || r.Count <= 0 {
+			continue
+		}
+		out = append(out, MessageReaction{Name: name, Count: r.Count})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+
 // Dispatch receives a normalized inbound message and delivers it to
 // subscribed agents only. Runs in its own goroutine — never blocks the adapter.
 func (s *Service) Dispatch(channel, platform, sender, senderID, content, messageID string, attachments []Attachment, raw json.RawMessage) {
@@ -88,8 +134,11 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, content, message
 
 		ctx := s.ctx
 
-		// Store message for activity feed history
-		if saveErr := s.store.SaveMessage(ctx, channel, sender, content); saveErr != nil {
+		// Store message for activity feed history. Reactions are extracted
+		// from the raw platform payload — Slack + Discord include them,
+		// other platforms return nil which SaveMessage stores as SQL NULL.
+		reactions := extractReactions(raw)
+		if saveErr := s.store.SaveMessage(ctx, channel, sender, content, reactions); saveErr != nil {
 			log.Warn("notify: save message failed", "channel", channel, "error", saveErr)
 		}
 

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -3,6 +3,7 @@ package notify
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -100,8 +101,12 @@ CREATE TABLE IF NOT EXISTS notify_messages (
     channel   TEXT NOT NULL,
     sender    TEXT NOT NULL,
     content   TEXT NOT NULL,
+    reactions TEXT,  -- JSON array of {name, count} or NULL; #3075
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
+-- Additive migration for pre-#3075 installs; ignored if column exists.
+-- SQLite doesn't support IF NOT EXISTS on ALTER TABLE ADD COLUMN, but
+-- our initSchema logs and continues on error so a re-run is safe.
 
 CREATE TABLE IF NOT EXISTS notify_channels (
     bc_channel   TEXT PRIMARY KEY,
@@ -327,18 +332,35 @@ func (s *Store) TotalMessageCount(ctx context.Context) (int, error) {
 
 // MessageRecord is a stored inbound gateway message for the activity feed.
 type MessageRecord struct {
-	CreatedAt time.Time `json:"created_at"`
-	Channel   string    `json:"channel"`
-	Sender    string    `json:"sender"`
-	Content   string    `json:"content"`
-	ID        int64     `json:"id"`
+	CreatedAt time.Time     `json:"created_at"`
+	Channel   string        `json:"channel"`
+	Sender    string        `json:"sender"`
+	Content   string        `json:"content"`
+	Reactions []MessageReaction `json:"reactions,omitempty"`
+	ID        int64         `json:"id"`
+}
+
+// MessageReaction is a per-emoji count on a message. Populated from the
+// inbound gateway payload when the platform exposes reactions (Slack,
+// Discord). Empty for platforms that don't.
+type MessageReaction struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
 }
 
 // SaveMessage stores an inbound gateway message for the activity feed.
-func (s *Store) SaveMessage(ctx context.Context, channel, sender, content string) error {
+// Pass a nil `reactions` for platforms that don't surface them.
+func (s *Store) SaveMessage(ctx context.Context, channel, sender, content string, reactions []MessageReaction) error {
+	var reactionsJSON any
+	if len(reactions) > 0 {
+		b, mErr := json.Marshal(reactions)
+		if mErr == nil {
+			reactionsJSON = string(b)
+		}
+	}
 	_, err := s.db.ExecContext(ctx, s.q(
-		`INSERT INTO notify_messages (channel, sender, content) VALUES (?, ?, ?)`),
-		channel, sender, content)
+		`INSERT INTO notify_messages (channel, sender, content, reactions) VALUES (?, ?, ?, ?)`),
+		channel, sender, content, reactionsJSON)
 	return err
 }
 
@@ -351,12 +373,12 @@ func (s *Store) GetMessages(ctx context.Context, channel string, limit int, befo
 	var err error
 	if before > 0 {
 		rows, err = s.db.QueryContext(ctx, s.q(
-			`SELECT id, channel, sender, content, created_at FROM notify_messages
+			`SELECT id, channel, sender, content, reactions, created_at FROM notify_messages
 			 WHERE channel = ? AND id < ? ORDER BY id DESC LIMIT ?`),
 			channel, before, limit)
 	} else {
 		rows, err = s.db.QueryContext(ctx, s.q(
-			`SELECT id, channel, sender, content, created_at FROM notify_messages
+			`SELECT id, channel, sender, content, reactions, created_at FROM notify_messages
 			 WHERE channel = ? ORDER BY id DESC LIMIT ?`),
 			channel, limit)
 	}
@@ -369,10 +391,15 @@ func (s *Store) GetMessages(ctx context.Context, channel string, limit int, befo
 	for rows.Next() {
 		var m MessageRecord
 		var createdStr string
-		if err := rows.Scan(&m.ID, &m.Channel, &m.Sender, &m.Content, &createdStr); err != nil {
+		var reactionsRaw sql.NullString
+		if err := rows.Scan(&m.ID, &m.Channel, &m.Sender, &m.Content, &reactionsRaw, &createdStr); err != nil {
 			return nil, err
 		}
 		m.CreatedAt, _ = time.Parse(time.RFC3339, createdStr) //nolint:errcheck // DB-written timestamp
+		if reactionsRaw.Valid && reactionsRaw.String != "" {
+			// Best-effort — malformed JSON just drops the reactions.
+			_ = json.Unmarshal([]byte(reactionsRaw.String), &m.Reactions) //nolint:errcheck
+		}
 		msgs = append(msgs, m)
 	}
 	return msgs, rows.Err()

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -634,20 +634,34 @@ func (h *GatewayHandler) legacyChannelHistory(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Convert to legacy format
+	// Convert to legacy format. Reactions optional — omitted from JSON when
+	// nil so clients that don't render them stay backward-compatible.
+	type reactionOut struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
 	type legacyMessage struct {
-		Sender    string `json:"sender"`
-		Content   string `json:"content"`
-		CreatedAt string `json:"created_at"`
-		ID        int64  `json:"id"`
+		Sender    string        `json:"sender"`
+		Content   string        `json:"content"`
+		CreatedAt string        `json:"created_at"`
+		Reactions []reactionOut `json:"reactions,omitempty"`
+		ID        int64         `json:"id"`
 	}
 	result := make([]legacyMessage, len(msgs))
 	for i, m := range msgs {
+		var rs []reactionOut
+		if len(m.Reactions) > 0 {
+			rs = make([]reactionOut, len(m.Reactions))
+			for j, r := range m.Reactions {
+				rs[j] = reactionOut{Name: r.Name, Count: r.Count}
+			}
+		}
 		result[i] = legacyMessage{
 			ID:        m.ID,
 			Sender:    m.Sender,
 			Content:   m.Content,
 			CreatedAt: m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+			Reactions: rs,
 		}
 	}
 	writeJSON(w, http.StatusOK, result)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -92,11 +92,20 @@ export interface NotificationSource {
 /** @deprecated Use NotificationSource instead */
 export type Channel = NotificationSource;
 
+export interface ChannelReaction {
+  name: string;
+  count: number;
+}
+
 export interface ChannelMessage {
   id: number;
   sender: string;
   content: string;
   created_at: string;
+  /** Emoji reactions on the message. Undefined for older messages
+   *  stored before the reactions column was added, or for platforms
+   *  that don't surface reactions (Telegram / IRC / Matrix / …). */
+  reactions?: ChannelReaction[];
 }
 
 export interface NotifySubscription {

--- a/web/src/components/notifications/MessageList.tsx
+++ b/web/src/components/notifications/MessageList.tsx
@@ -114,12 +114,25 @@ export function MessageList({
               </time>
             </div>
             {group.messages.map((msg) => (
-              <p
-                key={msg.id}
-                className="mt-0.5 text-[13px] whitespace-pre-wrap break-words text-mycel-text/80 leading-[1.65]"
-              >
-                <MessageContent content={msg.content} />
-              </p>
+              <div key={msg.id}>
+                <p className="mt-0.5 text-[13px] whitespace-pre-wrap break-words text-mycel-text/80 leading-[1.65]">
+                  <MessageContent content={msg.content} />
+                </p>
+                {msg.reactions && msg.reactions.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {msg.reactions.map((r) => (
+                      <span
+                        key={r.name}
+                        className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border border-mycel-border bg-mycel-surface text-[11px] text-mycel-muted"
+                        title={`:${r.name}: · ${String(r.count)}`}
+                      >
+                        <span>:{r.name}:</span>
+                        <span className="font-mono tabular-nums">{r.count}</span>
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
Fixes #3075.

Wires reactions end to end.

## Server
- New `reactions TEXT` column on `notify_messages` (nullable so existing rows keep working).
- `MessageReaction { Name, Count }` type in `pkg/notify`.
- `Store.SaveMessage` accepts `reactions []MessageReaction` and stores them as a JSON array.
- `Store.GetMessages` decodes back into `MessageRecord.Reactions`.
- `notify.Service.Dispatch` extracts reactions from the raw platform payload via a new `extractReactions()` helper. Supports both Slack (`{name, count}`) and Discord (`{emoji.name, count}`) shapes; other platforms return nil.
- `GET /api/channels/{name}/history` includes `reactions` on each row (omitted from JSON when nil so pre-#3075 clients stay backward-compatible).

## Web
- `ChannelMessage.reactions?: ChannelReaction[]` (optional).
- `MessageList` renders reaction chips under each message: pill with `:name: · <count>`, muted styling.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./pkg/notify/... ./server/handlers/...` pass
- [x] Full web suite (126) + lint + tsc clean

Fixes #3075
Part of #3205