### PR TITLE
docs(v0.3.3 batch 13): #3178 phase 2 outbound cookbook + doc realignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Outbound cookbook** (#3178 phase 2) — per-agent Slack / Telegram / Discord / WhatsApp
+  outbound documented as a direct-API pattern: agents load bot tokens from their own
+  `env.json` (with `${secret:NAME}` refs) and call each platform's official REST endpoint
+  (`chat.postMessage`, `sendMessage`, webhook, local WhatsApp daemon) with per-agent
+  `username` / `icon_emoji`. Full recipe lives in
+  `docs/architecture-notifications.md#outbound-cookbook`; the how-to in
+  `docs/how-to/set-up-notifications.md` cross-links it. No mycel-side wrapper tools —
+  the daemon stays out of platform auth / rate-limit / retry.
+
+### Docs
+- **Notification architecture doc rehabilitated** — renamed
+  `docs/_architecture-notifications.md` → `docs/architecture-notifications.md`, wired
+  into mkdocs nav under Explanation, and fixed the stale
+  `../architecture/notifications.md` cross-links in `docs/explanation/networking.md`,
+  `docs/reference/api-rest.md`, `docs/README.md`, `docs/index.md`, and the notifications
+  how-to. `bc <verb>` → `mycel <verb>` sweep on the how-to (channel names like
+  `github:bc` / `slack:all-bc` left alone).
+
 ## [0.3.2] - 2026-07-03
 
 Six-batch UI polish pass on top of v0.3.1 driven by the 5-lead design
@@ -135,7 +154,7 @@ one server-side accuracy fix.
 - **`GatewayFeed` hover states** — five `hover:bg-white/[…]` sites invisible under Light theme; now `hover:bg-mycel-surface-hover` (#3202).
 
 ### Deferred to v0.3.2
-- **#3178 phase 2** — per-agent outbound tools (`slack_post`, `telegram_send`, `discord_send`, `whatsapp_send`).
+- **#3178 phase 2** — per-agent outbound integration. Landing in v0.3.3 as a docs-only cookbook (env.json + direct `chat.postMessage` / `sendMessage` / webhook curl recipes), not as mycel-side wrapper tools — keeps the daemon out of the platform auth / rate-limit / retry business and lets agents hit each platform's official REST API directly.
 - **#3205 P1c** — Live event row visual simplification (collapse dual status dots, defer avg/ok-ratio behind expand).
 - **#3205 P2 + P3** — chart palette rework, interactive legend, global focus-ring token, remaining opacity sprinkle cleanup.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ Step-by-step guides for getting started with bc.
 Practical guides for accomplishing specific tasks.
 
 - [Configure your workspace](how-to/configure-workspace.md) -- Settings, providers, and runtime backends
-- [Notification Architecture](architecture/notifications.md) -- Notification gateway, platform integrations, and subscriptions
+- [Notification Architecture](architecture-notifications.md) -- Notification gateway, platform integrations, and subscriptions
 - [Set Up Notifications](how-to/set-up-notifications.md) -- Connect platforms and subscribe agents
 - [Troubleshoot issues](how-to/troubleshoot.md) -- Common errors and fixes
 

--- a/docs/architecture-notifications.md
+++ b/docs/architecture-notifications.md
@@ -48,6 +48,117 @@ from `prefs.json` / the workspace secret store. Examples:
 - **Slack**: `chat.postMessage` via the Slack Web API using `$SLACK_BOT_TOKEN`
 - **WhatsApp**: `whatsmeow` library directly — the gateway only listens; agents send
 
+## Outbound cookbook
+
+The four platforms below all follow the same pattern: the agent reads a
+bot token from its own `.bc/agents/<name>/env.json` via `${secret:NAME}`
+refs, and posts to the platform's official REST API with the agent's
+own `Bash` / `WebFetch` tool. No mycel-side wrapper is needed — this
+is what agents can already do, formalized as a cookbook so every role
+knows the shape.
+
+### env.json — per-agent token slots
+
+Set once per agent. Values are `${secret:NAME}` refs; the actual
+secret lives in the workspace secret store (`.bc/secrets.json` or
+whichever backend the workspace is configured to use).
+
+```json
+{
+  "SLACK_BOT_TOKEN":     "${secret:SLACK_BOT_TOKEN}",
+  "TELEGRAM_BOT_TOKEN":  "${secret:TELEGRAM_BOT_TOKEN}",
+  "DISCORD_BOT_TOKEN":   "${secret:DISCORD_BOT_TOKEN}",
+  "WHATSAPP_BOT_TOKEN":  "${secret:WHATSAPP_BOT_TOKEN}"
+}
+```
+
+Only fill the platforms an agent actually needs — mycel doesn't care
+about the ones you leave out.
+
+### Slack — `chat.postMessage`
+
+```bash
+curl -s -X POST https://slack.com/api/chat.postMessage \
+  -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json; charset=utf-8" \
+  --data '{
+    "channel":     "C0123456789",
+    "text":        "hello from <agent-name>",
+    "username":    "<agent-name>",
+    "icon_emoji":  ":robot_face:"
+  }'
+```
+
+Set `username` + `icon_emoji` on every call — that's how you get the
+agent-specific attribution on Slack file uploads and reactions instead
+of the gateway bot's default identity. The alternative pattern
+(upload-then-post-permalink) is documented in the "Slack screenshot
+attribution" reference note.
+
+### Telegram — `sendMessage`
+
+```bash
+curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+  --data-urlencode "chat_id=<CHAT_ID>" \
+  --data-urlencode "text=hello from <agent-name>"
+```
+
+Telegram uses one bot token per bot; agents share a bot but distinguish
+themselves in the `text` prefix.
+
+### Discord — `webhooks` or bot REST
+
+Preferred: per-agent Discord webhooks (each agent has its own webhook
+URL, so username/avatar are fully agent-controlled).
+
+```bash
+curl -s -X POST "$DISCORD_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "content":     "hello from <agent-name>",
+    "username":    "<agent-name>",
+    "avatar_url":  "https://…"
+  }'
+```
+
+Falls back to `POST /channels/<id>/messages` with a bot token when the
+agent needs to post to a channel that doesn't have a webhook.
+
+### WhatsApp — `whatsmeow` HTTP shim
+
+The bcd `pkg/gateway/whatsapp` package exposes a **local-only** HTTP
+endpoint on the daemon for agents to post text. Agents call:
+
+```bash
+curl -s -X POST http://localhost:9374/api/gateways/whatsapp/send \
+  -H "Authorization: Bearer $WHATSAPP_BOT_TOKEN" \
+  --data '{"chat_id":"<JID>","text":"hello from <agent-name>"}'
+```
+
+This is the one platform where the pattern isn't a pure external API
+call — whatsmeow needs the persisted device session and is easiest to
+share via the daemon. Discussed further in
+[#3178](https://github.com/rpuneet/mycel/issues/3178).
+
+### Why not wrap these as mycel-side tools?
+
+The tempting shape is `pkg/tool/platform/slack.go` exposing
+`slack_post` as a first-class MCP tool. We deliberately don't:
+
+1. Every agent already has `Bash` / `WebFetch` — curl on `chat.postMessage`
+   is a one-liner, and the docs above are the whole spec.
+2. Wrappers would need a corresponding schema, versioning, and would
+   have to be updated for every new endpoint the platforms add
+   (uploads, reactions, threading). curl doesn't.
+3. Per-agent token isolation is already handled by `env.json` —
+   nothing about a wrapper would change that boundary.
+4. Removing the wrapper layer keeps the mycel surface smaller and the
+   platform API surface fully discoverable to the agent.
+
+The only exception is WhatsApp, where the persistent session lives
+inside the daemon and a local endpoint is more ergonomic than
+whatsmeow-in-agent-process.
+
 The existing `Send` methods on the Slack, Telegram, and Discord adapters
 are a **legacy convenience** used internally by bcd's notify dispatch
 path (e.g. when a local channel relays to an external platform via the

--- a/docs/explanation/networking.md
+++ b/docs/explanation/networking.md
@@ -55,7 +55,7 @@ sequenceDiagram
     end
 ```
 
-See [Notification Architecture](../architecture/notifications.md) for the full notification system design.
+See [Notification Architecture](../architecture-notifications.md) for the full notification system design.
 
 ## Agent Hook Event Flow
 

--- a/docs/how-to/set-up-notifications.md
+++ b/docs/how-to/set-up-notifications.md
@@ -1,10 +1,10 @@
 # Set Up Notifications
 
-This guide walks through connecting external platforms to bc and routing notifications to agents.
+This guide walks through connecting external platforms to mycel and routing notifications to agents.
 
 ## Overview
 
-bc routes inbound events from external platforms (Slack, Telegram, GitHub, and others) to subscribed agents. Agents receive notifications as JSON payloads in their tmux or Docker sessions and respond using platform APIs directly.
+mycel routes inbound events from external platforms (Slack, Telegram, GitHub, and others) to subscribed agents. Agents receive notifications as JSON payloads in their tmux or Docker sessions and respond using platform APIs directly.
 
 ## 1. Add a Notification Source
 
@@ -19,8 +19,8 @@ bc routes inbound events from external platforms (Slack, Telegram, GitHub, and o
 
 ```bash
 # Store credentials
-bc secret set SLACK_BOT_TOKEN "xoxb-..."
-bc secret set SLACK_APP_TOKEN "xapp-..."
+mycel secret set SLACK_BOT_TOKEN "xoxb-..."
+mycel secret set SLACK_APP_TOKEN "xapp-..."
 ```
 
 Use the web UI at `http://localhost:9374` to connect the Slack gateway, or call the API directly:
@@ -39,7 +39,7 @@ curl -X POST http://localhost:9374/api/gateways \
 4. Optionally disable privacy mode so the bot can read all group messages (not just commands).
 
 ```bash
-bc secret set TELEGRAM_BOT_TOKEN "123456:ABC-..."
+mycel secret set TELEGRAM_BOT_TOKEN "123456:ABC-..."
 ```
 
 Connect via the web UI or API:
@@ -58,8 +58,8 @@ curl -X POST http://localhost:9374/api/gateways \
 4. Copy the token and webhook secret.
 
 ```bash
-bc secret set GITHUB_TOKEN "ghp_..."
-bc secret set GITHUB_WEBHOOK_SECRET "whsec_..."
+mycel secret set GITHUB_TOKEN "ghp_..."
+mycel secret set GITHUB_WEBHOOK_SECRET "whsec_..."
 ```
 
 ## 2. Subscribe Agents
@@ -68,16 +68,16 @@ Once a gateway is connected and sources are discovered, subscribe agents to rece
 
 ```bash
 # List available notification sources
-bc notify list
+mycel notify list
 
 # Subscribe an agent to all messages on a source
-bc notify subscribe slack:engineering eng-01
+mycel notify subscribe slack:engineering eng-01
 
 # Subscribe with mention-only filtering (noisy channels)
-bc notify subscribe --mention-only slack:engineering lead-01
+mycel notify subscribe --mention-only slack:engineering lead-01
 
 # Subscribe to GitHub events
-bc notify subscribe github:bc eng-02
+mycel notify subscribe github:bc eng-02
 ```
 
 ### Mention-Only Filtering
@@ -85,7 +85,7 @@ bc notify subscribe github:bc eng-02
 For high-traffic channels, use `--mention-only` so the agent only receives notifications where it is explicitly @mentioned:
 
 ```bash
-bc notify subscribe --mention-only slack:all-bc eng-01
+mycel notify subscribe --mention-only slack:all-bc eng-01
 ```
 
 The agent receives messages containing `@eng-01` and ignores all other traffic.
@@ -96,13 +96,13 @@ After subscribing, verify that notifications are flowing:
 
 ```bash
 # Check adapter connection health
-bc notify status
+mycel notify status
 
 # View recent notifications for a source
-bc notify history slack:engineering --last 10
+mycel notify history slack:engineering --last 10
 
 # Check agent output for received notifications
-bc agent peek eng-01
+mycel agent peek eng-01
 ```
 
 The web dashboard at `http://localhost:9374` provides a real-time activity feed showing inbound notifications and delivery status.
@@ -112,29 +112,29 @@ The web dashboard at `http://localhost:9374` provides a real-time activity feed 
 ### Adapter shows "disconnected"
 
 ```bash
-bc notify status
+mycel notify status
 ```
 
 If an adapter shows disconnected:
 
-- Verify the credentials are correct: `bc secret list`
+- Verify the credentials are correct: `mycel secret list`
 - Check that the bot is still invited to the platform channels.
 - For Slack: ensure Socket Mode is enabled and the app token is valid.
 - For Telegram: verify the bot token with `curl https://api.telegram.org/bot<TOKEN>/getMe`.
-- Restart bcd: `bc down && bc up`.
+- Restart bcd: `mycel down && mycel up`.
 
 ### Agent not receiving notifications
 
 1. Confirm the subscription exists:
 
    ```bash
-   bc notify list
+   mycel notify list
    ```
 
 2. Confirm the agent is running:
 
    ```bash
-   bc status
+   mycel status
    ```
 3. Check the delivery log in the web UI for failed deliveries.
 4. If using `--mention-only`, ensure the sender is using the correct @mention format (`@agent-name`).
@@ -148,13 +148,27 @@ Agents do not receive notifications they themselves sent. If an agent posts a me
 If an agent receives the same notification multiple times, check for duplicate subscriptions:
 
 ```bash
-bc notify list
+mycel notify list
 ```
 
-Remove duplicates with `bc notify unsubscribe`.
+Remove duplicates with `mycel notify unsubscribe`.
+
+## Sending back to a platform
+
+Notifications are one-way in — mycel does not proxy agent replies back
+to the platform. When an agent needs to post to Slack / Telegram /
+Discord / WhatsApp, it calls the platform's official REST API
+directly with a bot token loaded from its own `env.json`. See the
+[**Outbound cookbook**](../architecture-notifications.md#outbound-cookbook)
+in the Notification architecture doc for the exact curl invocations
+and the `env.json` template.
+
+The legacy `POST /api/gateways/{platform}/channels/{channel}/send`
+endpoint is deprecated (RFC 8594 headers on every response) and will
+return `410 Gone` in v0.4.0 — new integrations should use the
+per-agent cookbook pattern.
 
 ## Next Steps
 
-- Read the [Notifications architecture](../architecture/notifications.md) for the full system design.
-- Browse the [CLI reference](../reference/cli/bc_notify.md) for all notification commands.
+- Read the [Notifications architecture](../architecture-notifications.md) for the full system design + outbound cookbook.
 - See the [REST API reference](../reference/api-rest.md) for gateway and subscription endpoints.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Step-by-step guides for getting started with bc.
 Practical guides for accomplishing specific tasks.
 
 - [Configure your workspace](how-to/configure-workspace.md) -- Settings, providers, and runtime backends
-- [Notification Architecture](architecture/notifications.md) -- Notification gateway, platform integrations, and subscriptions
+- [Notification Architecture](architecture-notifications.md) -- Notification gateway, platform integrations, and subscriptions
 - [Set Up Notifications](how-to/set-up-notifications.md) -- Connect platforms and subscribe agents
 - [Troubleshoot issues](how-to/troubleshoot.md) -- Common errors and fixes
 

--- a/docs/reference/api-rest.md
+++ b/docs/reference/api-rest.md
@@ -219,7 +219,7 @@ Delete role. Agents keep their current config.
 
 ## Gateways & Channels
 
-Notification gateways bridge external platforms to bc agents. See [Channel Architecture](../architecture/notifications.md) for full design.
+Notification gateways bridge external platforms to bc agents. See [Channel Architecture](../architecture-notifications.md) for full design.
 
 ### `GET /api/gateways`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,12 +57,11 @@ markdown_extensions:
   - toc:
       permalink: true
 
-# Skip the parked notifications page (pygments NoneType filename bug
-# in one of its code fences) and any other underscore-prefixed archive
-# files until they can be rehabilitated.
+# Skip underscore-prefixed archive drafts (rehabilitated notifications
+# page has been renamed to architecture-notifications.md and is wired
+# into the nav below).
 exclude_docs: |
   _*
-  _archive-notifications.md
 
 nav:
   - Home: index.md
@@ -82,6 +81,7 @@ nav:
     - Terminal UI: explanation/tui.md
     - Design system: explanation/design-system.md
     - Networking: explanation/networking.md
+    - Notification architecture: architecture-notifications.md
     - Security: explanation/security.md
     - Deployment: explanation/deployment.md
     - CI / CD: explanation/ci-cd.md

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -92,10 +92,10 @@ func extractReactions(raw json.RawMessage) []MessageReaction {
 	var envelope struct {
 		Reactions []struct {
 			Name  string `json:"name"`
-			Count int    `json:"count"`
 			Emoji struct {
 				Name string `json:"name"`
 			} `json:"emoji"`
+			Count int `json:"count"`
 		} `json:"reactions"`
 	}
 	if err := json.Unmarshal(raw, &envelope); err != nil {
@@ -120,7 +120,6 @@ func extractReactions(raw json.RawMessage) []MessageReaction {
 	}
 	return out
 }
-
 
 // Dispatch receives a normalized inbound message and delivers it to
 // subscribed agents only. Runs in its own goroutine — never blocks the adapter.

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -332,12 +332,12 @@ func (s *Store) TotalMessageCount(ctx context.Context) (int, error) {
 
 // MessageRecord is a stored inbound gateway message for the activity feed.
 type MessageRecord struct {
-	CreatedAt time.Time     `json:"created_at"`
-	Channel   string        `json:"channel"`
-	Sender    string        `json:"sender"`
-	Content   string        `json:"content"`
+	CreatedAt time.Time         `json:"created_at"`
+	Channel   string            `json:"channel"`
+	Sender    string            `json:"sender"`
+	Content   string            `json:"content"`
 	Reactions []MessageReaction `json:"reactions,omitempty"`
-	ID        int64         `json:"id"`
+	ID        int64             `json:"id"`
 }
 
 // MessageReaction is a per-emoji count on a message. Populated from the


### PR DESCRIPTION
## Summary
- Per-agent Slack/Telegram/Discord/WhatsApp outbound documented as a **direct-API cookbook** (env.json + curl to `chat.postMessage` / `sendMessage` / webhooks) — no mycel-side wrapper tools. Daemon stays out of platform auth/rate-limit/retry.
- Rehabilitates `docs/architecture-notifications.md` (renamed from underscore-prefixed archive), wires it into mkdocs nav, and fixes 4 broken `../architecture/notifications.md` cross-links.
- Finishes the `bc <verb>` → `mycel <verb>` sweep in `docs/how-to/set-up-notifications.md`.

Closes #3178 (phase 2).

## Test plan
- [x] `grep slack_post|telegram_send|discord_send|whatsapp_send` shows only the intentional "why not wrappers" mention
- [x] Broken links `../architecture/notifications.md` removed across docs
- [ ] `mkdocs build` renders new page in nav (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Outbound cookbook” to the notification architecture guide, covering per-agent outbound messaging to Slack, Telegram, Discord, and WhatsApp via direct platform REST calls using per-agent `env.json` `${secret:NAME}` references.
* **Documentation**
  * Updated notification setup to use `mycel` commands and revised outbound guidance/links accordingly.
  * Renamed and relinked the “Notification Architecture” documentation across the site navigation and related references.
* **Bug Fixes**
  * Corrected outdated notification documentation links and legacy path/command references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->