### PR TITLE
chore(release): v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-03
+
+Direction correction. Two decisions surfaced during the v0.3.3
+post-release audit:
+
+1. **Workspace is a property on the agent, not a route tenant** —
+   every SPA page is served at a flat top-level path. Global pages
+   (costs, tools, secrets, gateways, settings) carry no workspace
+   concept at all.
+2. **Notifications is a one-way inbound stream** routed to subscribed
+   agents — not a chat surface with reactions or persistent history.
+
+### Changed
+- **Flatten SPA routes** — dropped the `/w/<workspaceId>/…` URL
+  segment across the entire web UI. `/live`, `/agents`,
+  `/agents/:name`, `/notifications`, `/notifications/:src`,
+  `/templates`, `/tools`, `/tools/:provider`, `/cron`, `/secrets`,
+  `/stats`, `/metrics`, `/costs`, `/code`, `/settings`, `/about` all
+  render at their bare paths. Workspace switching is now a server-side
+  `POST /api/workspaces/<id>/activate` triggered by the dropdown; the
+  URL never changes. `WorkspaceContext` shed its route guard +
+  redirect helpers; server-side `LegacyUIScope` (which used to rewrite
+  flat paths → `/w/<id>/…`) deleted.
+
+### Removed
+- **`server/legacy_scope.go`** and its test.
+- **`web/src/context/WorkspaceContext.test.tsx`**, **`web/src/components/WorkspaceDropdown.test.tsx`**,
+  **`web/src/views/AgentDetail.test.tsx`** — all asserted the old
+  `/w/<id>/…` behavior.
+- **`useWorkspacePath`**, **`ActiveWorkspaceGuard`**,
+  **`RedirectToActiveWorkspace`** — no longer needed with flat routes.
+
+### Reverted
+- **Emoji reactions in notifications** (#3075, #3226 batch 12) —
+  wrong direction. Notifications don't need reactions, thread state,
+  or a chat rendering layer. The `reactions` column, `extractReactions()`
+  helper, `MessageReaction` type, `SaveMessage`/`GetMessages` reaction
+  plumbing, `legacyChannelHistory` reaction emission, `client.ts`
+  `ChannelReaction` type, and the (already-dead) `MessageList.tsx`
+  reaction rendering are all gone. Half-migrated installs keep an
+  orphan SQLite column harmlessly — no destructive drop.
+
 ## [0.3.3] - 2026-07-03
 
 Seven-batch continuation of the v0.3.2 design review pass — chart

--- a/packages/mycel-agent-runner/package.json
+++ b/packages/mycel-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycel/agent-runner",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Thin HTTP wrapper around the Claude Agent SDK. Hosts a single Claude agent and exposes it over REST + SSE so bcd can drive it.",
   "license": "MIT",
   "type": "module",

--- a/packages/mycel-cli/package.json
+++ b/packages/mycel-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mycel-cli",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "mycel — AI agent orchestration. Coordinate teams of Claude, Gemini, Cursor, and other AI agents.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Cuts v0.3.4. Bumps npm packages to 0.3.4 and finalizes CHANGELOG.

Direction-correction release covering #3229:
- Flatten SPA routes — drop `/w/<hash>/…` everywhere.
- Revert #3075 emoji reactions (WONTFIX — notifications is a stream, not a chat surface).

Fixes #3075. Part of #3205.

## Test plan
- [ ] CI green
- [ ] Tag v0.3.4 → GoReleaser + brew tap + npm publish
- [ ] `brew upgrade mycel` → `/opt/homebrew/bin/mycel --version` = 0.3.4
- [ ] Verify `/agents` renders at bare path on 0.3.4