### PR TITLE
chore(release): v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-07-03
+
+Follow-through on the workspace-as-property and
+notifications-are-a-stream arcs started in v0.3.4.
+
+### Removed
+- **WorkspaceDropdown / WorkspacePicker / activate flow** — workspace
+  is a property on the agent, not something the user "switches to",
+  so a switcher was a UX contradiction. Sidebar chip drops its
+  `workspace` subtitle. `Cmd/Ctrl+Shift+W` shortcut retired.
+- **`WorkspaceContext.activate()`** — the dropdown was its only
+  caller. Server-side `POST /api/workspaces/<id>/activate` remains
+  for external callers but is no longer invoked by the SPA.
+- **Client `X-BC-Workspace` header** — routing to a workspace uses
+  `?workspace=<id>` explicitly when needed (currently only for
+  `POST /api/agents` from the new-agent modal).
+
+### Changed
+- **Agents page — default group = workspace** (was: repo). Toggle
+  reads/writes `mycel-agents-group-by-workspace` in localStorage and
+  disables when every visible agent shares one workspace. Group
+  header caption is the workspace path (home-collapsed to `~/…`).
+- **New-agent modal — required Workspace select.** Populated from
+  `GET /api/workspaces`; defaults to the current active workspace;
+  submit hits `POST /api/agents?workspace=<selectedId>`. Can't
+  create an agent without picking a workspace.
+- **Notifications page — replaced `GatewayFeed` chat surface with
+  `ChannelStream`.** New page shows:
+  1. **Subscriptions** table — subscribed agents, `all messages` vs
+     `@-mentions only`, since-when, per-row unsubscribe.
+  2. **Delivery log** — most recent inbound-delivery attempts with
+     status dot (delivered/failed/pending), agent, error, content
+     preview, timestamp. Delivered / failed counts in the header.
+  3. **Outbound note** — link to the outbound cookbook, since mycel
+     does not proxy replies back to the platform.
+  No composer, no message-history threading, no reactions, no
+  avatars — this is a routing + observability surface.
+
 ## [0.3.4] - 2026-07-03
 
 Direction correction. Two decisions surfaced during the v0.3.3

--- a/packages/mycel-agent-runner/package.json
+++ b/packages/mycel-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycel/agent-runner",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Thin HTTP wrapper around the Claude Agent SDK. Hosts a single Claude agent and exposes it over REST + SSE so bcd can drive it.",
   "license": "MIT",
   "type": "module",

--- a/packages/mycel-cli/package.json
+++ b/packages/mycel-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mycel-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "mycel — AI agent orchestration. Coordinate teams of Claude, Gemini, Cursor, and other AI agents.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Cuts v0.3.5. Bumps npm packages to 0.3.5 and finalizes CHANGELOG.

Follow-through on the workspace-as-property + notifications-are-a-stream direction reset (rolled up #3231):
- Rip WorkspaceDropdown + activate flow.
- Agents page: default group = workspace.
- New-agent modal: required Workspace select.
- Notifications page: subscriptions table + delivery log (no chat surface).

Part of #3205.

## Test plan
- [ ] CI green
- [ ] Tag v0.3.5 → GoReleaser + brew tap + npm publish
- [ ] `brew upgrade mycel` → `/opt/homebrew/bin/mycel --version` = 0.3.5
- [ ] Verify `/agents` group-by-workspace + new-agent modal Workspace field + `/notifications/slack:general` subs/delivery layout on 0.3.5