### PR TITLE
chore(release): v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-07-03
+
+Post-v0.3.5 cleanup pass.
+
+### Changed
+- **Delivery log — quiet offline-agent skips.** Sending to a stopped
+  subscriber used to be logged as `StatusFailed`, so a channel with
+  seven subscribers and six stopped agents rendered an alarming
+  `86 failed / 14 delivered`. The routing decision was correct; the
+  agent was just offline. Dispatch now detects the pkg/agent
+  "agent not running" / "is stopped" error text and skips the
+  `LogDelivery` call entirely (debug log only). Failed count on the
+  notifications page reflects genuine send errors again. No schema
+  change.
+
+### Removed
+- **`web/src/components/notifications/GatewayFeed.tsx`** — replaced
+  by `ChannelStream` in v0.3.5, no callers remained.
+- **`web/src/components/AgentPeekPanel.tsx`** — its only caller was
+  GatewayFeed's message-history surface.
+
 ## [0.3.5] - 2026-07-03
 
 Follow-through on the workspace-as-property and

--- a/packages/mycel-agent-runner/package.json
+++ b/packages/mycel-agent-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mycel/agent-runner",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Thin HTTP wrapper around the Claude Agent SDK. Hosts a single Claude agent and exposes it over REST + SSE so bcd can drive it.",
   "license": "MIT",
   "type": "module",

--- a/packages/mycel-cli/package.json
+++ b/packages/mycel-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mycel-cli",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "mycel — AI agent orchestration. Coordinate teams of Claude, Gemini, Cursor, and other AI agents.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
Cuts v0.3.6. Bumps npm packages to 0.3.6 and finalizes CHANGELOG.

Rolls up #3233 (cleanup PR):
- Delivery log skips offline agents so the failed count reflects real send errors.
- Dead GatewayFeed + AgentPeekPanel removed.

Part of #3205.

## Test plan
- [ ] CI green
- [ ] Tag v0.3.6 → GoReleaser + brew tap + npm publish
- [ ] \`brew upgrade mycel\` → 0.3.6
- [ ] /notifications/slack:general shows lower/no 'failed' when agents are offline