### PR TITLE
feat(web): Live event stream v2 — flat hook-stream rows, rich summaries, real glyphs

### DIFF
--- a/web/src/components/live/EventRow.test.tsx
+++ b/web/src/components/live/EventRow.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * EventRow.test.tsx — unit tests for the shared hook-event row used by
+ * the Live page agent cards and the agent-detail Activity tab (#3267).
+ *
+ * Invariants:
+ *   - eventGlyphKind maps tool names to monochrome glyph kinds
+ *     (lifecycle beats the Task* prefix; MCP tools detected by name).
+ *   - compactPath keeps the basename intact and shortens long dirs.
+ *   - flattenNodes lifts subagent children into the flat stream.
+ *   - EventRow renders name + summary without emoji; failed rows lead
+ *     with the error text.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EventRow, compactPath, eventGlyphKind } from "./EventRow";
+import { flattenNodes } from "./liveHelpers";
+import type { ToolNode } from "./liveTypes";
+
+function node(overrides: Partial<ToolNode>): ToolNode {
+  return {
+    id: "n-1",
+    toolName: "Bash",
+    args: "",
+    fullInput: null,
+    fullOutput: null,
+    status: "completed",
+    startTime: Date.now() - 5000,
+    endTime: Date.now() - 4000,
+    children: [],
+    ...overrides,
+  };
+}
+
+describe("eventGlyphKind", () => {
+  it("maps tool names to glyph kinds", () => {
+    expect(eventGlyphKind("Bash")).toBe("terminal");
+    expect(eventGlyphKind("Edit")).toBe("edit");
+    expect(eventGlyphKind("Write")).toBe("edit");
+    expect(eventGlyphKind("Read")).toBe("read");
+    expect(eventGlyphKind("Grep")).toBe("search");
+    expect(eventGlyphKind("WebFetch")).toBe("web");
+    expect(eventGlyphKind("Agent")).toBe("agent");
+    expect(eventGlyphKind("Agent: sub-1")).toBe("agent");
+    expect(eventGlyphKind("mcp__github__create_pr")).toBe("mcp");
+    expect(eventGlyphKind("SomethingElse")).toBe("tool");
+  });
+
+  it("classifies lifecycle events before the Task* prefix", () => {
+    expect(eventGlyphKind("TaskCompleted")).toBe("lifecycle");
+    expect(eventGlyphKind("TaskCreate")).toBe("task");
+    expect(eventGlyphKind("SessionStart")).toBe("lifecycle");
+    expect(eventGlyphKind("Stop")).toBe("lifecycle");
+    expect(eventGlyphKind("UserPromptSubmit")).toBe("prompt");
+    expect(eventGlyphKind("PermissionRequest")).toBe("permission");
+  });
+});
+
+describe("compactPath", () => {
+  it("splits dir and basename", () => {
+    expect(compactPath("src/views/Live.tsx")).toEqual({ dir: "src/views/", base: "Live.tsx" });
+  });
+
+  it("compacts long directories to the last two segments", () => {
+    const { dir, base } = compactPath("/Users/someone/Projects/bc/web/src/components/live/EventRow.tsx");
+    expect(base).toBe("EventRow.tsx");
+    expect(dir).toBe("…/components/live/");
+  });
+
+  it("passes through non-paths", () => {
+    expect(compactPath("README")).toEqual({ dir: "", base: "README" });
+  });
+});
+
+describe("flattenNodes", () => {
+  it("lifts subagent children into the flat stream", () => {
+    const child = node({ id: "c-1", toolName: "Read", args: "/tmp/a.txt" });
+    const parent = node({ id: "p-1", toolName: "Agent", children: [child] });
+    const flat = flattenNodes([parent]);
+    expect(flat.map((n) => n.id)).toEqual(["p-1", "c-1"]);
+  });
+});
+
+describe("EventRow", () => {
+  it("renders file paths with the basename emphasized and no emoji", () => {
+    const { container } = render(
+      <EventRow node={node({ toolName: "Read", args: "/Users/x/Projects/bc/web/src/views/Live.tsx" })} />,
+    );
+    expect(screen.getByText("Live.tsx")).toBeTruthy();
+    // Monochrome glyphs only — no emoji anywhere in the row.
+    expect(container.textContent).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}]/u);
+  });
+
+  it("leads with the error text on failed events", () => {
+    render(
+      <EventRow node={node({ toolName: "Bash", status: "failed", error: "command not found: foo", args: "run build" })} />,
+    );
+    expect(screen.getByText("command not found: foo")).toBeTruthy();
+  });
+
+  it("uses human phrasing for lifecycle events", () => {
+    render(<EventRow node={node({ toolName: "UserPromptSubmit", args: "fix the login bug" })} />);
+    expect(screen.getByText("Prompt")).toBeTruthy();
+    expect(screen.getByText("fix the login bug")).toBeTruthy();
+  });
+
+  it("shows the MCP server chip and function name", () => {
+    render(<EventRow node={node({ toolName: "mcp__github__create_pr", args: "open PR" })} />);
+    expect(screen.getByText("github")).toBeTruthy();
+    expect(screen.getByText("create_pr")).toBeTruthy();
+  });
+});

--- a/web/src/components/live/EventRow.tsx
+++ b/web/src/components/live/EventRow.tsx
@@ -1,0 +1,424 @@
+import { useCallback, useEffect, useState } from "react";
+import { motion } from "framer-motion";
+import type { ToolNode } from "./liveTypes";
+import {
+  elapsed,
+  durationPillClass,
+  mcpBadgeColors,
+  parseToolName,
+  redactSecrets,
+  redactValue,
+  relativeTime,
+} from "./liveHelpers";
+
+/* ── EventRow ────────────────────────────────────────────────────────
+   The shared hook-event row used by both the Live page agent cards and
+   the agent-detail Activity tab. One event = one line:
+
+     glyph · name · rich summary · relative time · duration
+
+   Rows are flat and chronologically stable — they never reorder or
+   regroup as statuses change. Expanding a row reveals the raw
+   input/output JSON. All glyphs are monochrome stroke-currentColor
+   SVGs in the mycel token style (no emoji).
+─────────────────────────────────────────────────────────────────── */
+
+/* ── Ticking timestamps ────────────────────────────────────────────── */
+
+export function ElapsedTimer({ start }: { start: number }) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 200);
+    return () => clearInterval(id);
+  }, []);
+  return <>{elapsed(start)}</>;
+}
+
+export function RelativeTimestamp({ ts }: { ts: number }) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <span title={new Date(ts).toISOString()} className="text-[10px] text-mycel-muted font-mono tabular-nums">
+      {relativeTime(ts)}
+    </span>
+  );
+}
+
+/* ── Copy button ───────────────────────────────────────────────────── */
+
+export function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    }).catch(() => {});
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); handleCopy(); }}
+      className="text-[10px] text-mycel-muted hover:text-mycel-text px-1.5 py-0.5 rounded border border-mycel-border/40 hover:border-mycel-accent transition-colors shrink-0"
+      aria-label="Copy to clipboard"
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}
+
+/* ── Search highlight ──────────────────────────────────────────────── */
+
+export function SearchHighlight({ text, query }: { text: string; query: string }) {
+  if (!query || !text) return <>{text}</>;
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  const idx = lower.indexOf(q);
+  if (idx === -1) return <>{text}</>;
+  return (
+    <>
+      {text.slice(0, idx)}
+      <mark className="bg-mycel-warning/20 text-inherit rounded px-0.5">{text.slice(idx, idx + q.length)}</mark>
+      {text.slice(idx + q.length)}
+    </>
+  );
+}
+
+/* ── Event kind classification ─────────────────────────────────────── */
+
+export type EventKind =
+  | "terminal"
+  | "edit"
+  | "read"
+  | "search"
+  | "agent"
+  | "web"
+  | "task"
+  | "prompt"
+  | "lifecycle"
+  | "permission"
+  | "mcp"
+  | "tool";
+
+export const LIFECYCLE_LABELS: Record<string, string> = {
+  UserPromptSubmit: "Prompt",
+  SessionStart: "Session started",
+  SessionEnd: "Session ended",
+  Stop: "Turn complete",
+  TaskCompleted: "Task completed",
+  PermissionRequest: "Waiting for permission",
+  Elicitation: "Waiting for input",
+  SubagentStart: "Subagent started",
+  SubagentStop: "Subagent stopped",
+};
+
+export function eventGlyphKind(toolName: string): EventKind {
+  if (toolName === "Bash" || toolName === "bash" || toolName === "BashOutput") return "terminal";
+  if (toolName === "Edit" || toolName === "Write" || toolName === "NotebookEdit") return "edit";
+  if (toolName === "Read") return "read";
+  if (toolName === "Grep" || toolName === "Glob" || toolName === "ToolSearch" || toolName === "LSP") return "search";
+  if (toolName === "WebFetch" || toolName === "WebSearch") return "web";
+  if (toolName === "UserPromptSubmit") return "prompt";
+  // Lifecycle before the Task* prefix check — TaskCompleted is lifecycle.
+  if (toolName === "SessionStart" || toolName === "SessionEnd" || toolName === "Stop" || toolName === "TaskCompleted") return "lifecycle";
+  if (toolName === "PermissionRequest" || toolName === "Elicitation") return "permission";
+  if (toolName === "Agent" || toolName.startsWith("Agent:") || toolName === "SubagentStart" || toolName === "SubagentStop") return "agent";
+  if (toolName.startsWith("Task")) return "task";
+  if (toolName.startsWith("mcp__") || toolName.includes("__")) return "mcp";
+  return "tool";
+}
+
+/* ── Monochrome event glyphs ───────────────────────────────────────── */
+
+export function EventGlyph({ kind, size = 13, className }: { kind: EventKind; size?: number; className?: string }) {
+  const common = {
+    width: size,
+    height: size,
+    viewBox: "0 0 16 16",
+    fill: "none",
+    stroke: "currentColor",
+    strokeWidth: 1.5,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    className,
+    "aria-hidden": true,
+  };
+  switch (kind) {
+    case "terminal":
+      return (
+        <svg {...common}>
+          <path d="M3 4l3.5 4L3 12" />
+          <path d="M8.5 12H13" />
+        </svg>
+      );
+    case "edit":
+      return (
+        <svg {...common}>
+          <path d="M11.3 2.7l2 2L6 12l-2.8.8.8-2.8z" />
+        </svg>
+      );
+    case "read":
+      return (
+        <svg {...common}>
+          <path d="M3 3.7c1.6-1 3.4-1 5 0 1.6-1 3.4-1 5 0v8.6c-1.6-1-3.4-1-5 0-1.6-1-3.4-1-5 0z" />
+          <path d="M8 3.7v8.6" />
+        </svg>
+      );
+    case "search":
+      return (
+        <svg {...common}>
+          <circle cx="7" cy="7" r="4" />
+          <path d="M10 10l3.5 3.5" />
+        </svg>
+      );
+    case "agent":
+      return (
+        <svg {...common}>
+          <circle cx="4" cy="4" r="1.7" />
+          <circle cx="4" cy="12" r="1.7" />
+          <circle cx="12" cy="4" r="1.7" />
+          <path d="M4 5.7v4.6M12 5.7c0 3-3.5 2.6-6.3 3.3" />
+        </svg>
+      );
+    case "web":
+      return (
+        <svg {...common}>
+          <circle cx="8" cy="8" r="5.5" />
+          <path d="M8 2.5c2 1.6 2 9.4 0 11M8 2.5c-2 1.6-2 9.4 0 11M2.5 8h11" />
+        </svg>
+      );
+    case "task":
+      return (
+        <svg {...common}>
+          <path d="M6 4h7M6 8h7M6 12h7" />
+          <path d="M3 4h.01M3 8h.01M3 12h.01" />
+        </svg>
+      );
+    case "prompt":
+      return (
+        <svg {...common}>
+          <path d="M3 3.5h10v7H8.5l-3 2.8v-2.8H3z" />
+        </svg>
+      );
+    case "lifecycle":
+      return (
+        <svg {...common}>
+          <path d="M4 14V2.5" />
+          <path d="M4 3h8L10.3 5.5 12 8H4" />
+        </svg>
+      );
+    case "permission":
+      return (
+        <svg {...common}>
+          <path d="M8 2.8l5.8 10.2H2.2z" />
+          <path d="M8 7v3M8 11.6v.01" />
+        </svg>
+      );
+    case "mcp":
+      return (
+        <svg {...common}>
+          <path d="M6 2v3M10 2v3" />
+          <path d="M4.5 5h7v3a3.5 3.5 0 01-7 0z" />
+          <path d="M8 11.5V14" />
+        </svg>
+      );
+    default:
+      return (
+        <svg {...common}>
+          <path d="M13.6 4.6a3.4 3.4 0 01-4.5 4.1l-4.9 4.9a1.35 1.35 0 01-1.9-1.9l4.9-4.9a3.4 3.4 0 014.1-4.5L9.2 4.4l2.4 2.4z" />
+        </svg>
+      );
+  }
+}
+
+/* ── Rich summaries ────────────────────────────────────────────────── */
+
+/** Compact a long absolute path: keep the basename intact, shorten the
+ *  directory to its last two segments. */
+export function compactPath(path: string): { dir: string; base: string } {
+  const idx = path.lastIndexOf("/");
+  if (idx <= 0) return { dir: "", base: path };
+  let dir = path.slice(0, idx + 1);
+  const base = path.slice(idx + 1);
+  if (dir.length > 40) {
+    const segs = dir.split("/").filter(Boolean);
+    dir = "…/" + segs.slice(-2).join("/") + "/";
+  }
+  return { dir, base };
+}
+
+/** True when args look like a single filesystem path. */
+function looksLikePath(args: string): boolean {
+  return args.length > 0 && args.includes("/") && !args.includes(" ") && !args.includes("\n");
+}
+
+function PathSummary({ path, query }: { path: string; query: string }) {
+  // With an active search, fall back to a flat highlighted string so the
+  // match is visible wherever it lands in the path.
+  if (query) {
+    return (
+      <span className="font-mono text-[12px] text-mycel-muted min-w-0 truncate" title={path}>
+        <SearchHighlight text={path} query={query} />
+      </span>
+    );
+  }
+  const { dir, base } = compactPath(path);
+  return (
+    <span className="font-mono text-[12px] min-w-0 truncate" title={path}>
+      <span className="text-mycel-muted/70">{dir}</span>
+      <span className="text-mycel-text">{base}</span>
+    </span>
+  );
+}
+
+function EventSummary({ node, kind, query }: { node: ToolNode; kind: EventKind; query: string }) {
+  // Failed events lead with the error — that's the load-bearing bit.
+  if (node.status === "failed" && node.error) {
+    const err = redactSecrets(node.error.length > 160 ? node.error.slice(0, 157) + "…" : node.error);
+    return (
+      <span className="font-mono text-[12px] text-mycel-error min-w-0 truncate" title={err}>
+        <SearchHighlight text={err} query={query} />
+      </span>
+    );
+  }
+
+  const args = redactSecrets(node.args ?? "");
+  if (!args) return null;
+
+  if ((kind === "edit" || kind === "read") && looksLikePath(args)) {
+    return <PathSummary path={args} query={query} />;
+  }
+  if (kind === "prompt") {
+    return (
+      <span className="text-[12px] text-mycel-text/90 min-w-0 truncate" title={args}>
+        <SearchHighlight text={args} query={query} />
+      </span>
+    );
+  }
+  return (
+    <span className="font-mono text-[12px] text-mycel-muted min-w-0 truncate" title={args}>
+      <SearchHighlight text={args} query={query} />
+    </span>
+  );
+}
+
+/* ── Event name ────────────────────────────────────────────────────── */
+
+function EventName({ node, kind, query }: { node: ToolNode; kind: EventKind; query: string }) {
+  const label = LIFECYCLE_LABELS[node.toolName];
+  if (label) {
+    return (
+      <span className="text-[12px] text-mycel-text font-medium shrink-0">
+        {label}
+      </span>
+    );
+  }
+  if (kind === "mcp") {
+    const parsed = parseToolName(node.toolName);
+    if (parsed.mcpServer && parsed.mcpFunction) {
+      return (
+        <span className="inline-flex items-center gap-1.5 shrink-0 min-w-0">
+          <span className={`px-1.5 py-0.5 rounded-full text-[10px] font-mono leading-none ${mcpBadgeColors(parsed.mcpServer)}`}>
+            {parsed.mcpServer}
+          </span>
+          <span className="font-mono text-[12px] text-mycel-text font-medium">
+            <SearchHighlight text={parsed.mcpFunction} query={query} />
+          </span>
+        </span>
+      );
+    }
+  }
+  return (
+    <span className="font-mono text-[12px] text-mycel-text font-semibold shrink-0">
+      <SearchHighlight text={parseToolName(node.toolName).display} query={query} />
+    </span>
+  );
+}
+
+/* ── The row ───────────────────────────────────────────────────────── */
+
+function glyphColorClass(status: ToolNode["status"]): string {
+  if (status === "running") return "text-mycel-accent animate-pulse";
+  if (status === "failed") return "text-mycel-error";
+  return "text-mycel-muted";
+}
+
+export function EventRow({ node, searchQuery = "" }: { node: ToolNode; searchQuery?: string }) {
+  const [expanded, setExpanded] = useState(false);
+  const kind = eventGlyphKind(node.toolName);
+  const hasDetails = !!(node.fullInput || node.fullOutput || node.error);
+  const inputJson = node.fullInput ? JSON.stringify(redactValue(node.fullInput), null, 2) : "";
+  const outputJson = node.fullOutput ? JSON.stringify(redactValue(node.fullOutput), null, 2) : "";
+
+  return (
+    <div className={`border-b border-mycel-border/40 last:border-b-0 ${node.status === "failed" ? "bg-mycel-error/5" : ""}`}>
+      <button
+        type="button"
+        className="group flex items-center gap-2.5 py-1.5 px-3 w-full text-left hover:bg-mycel-surface-hover cursor-pointer transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent"
+        onClick={() => setExpanded(!expanded)}
+        aria-label={`${expanded ? "Collapse" : "Expand"} ${node.toolName} event`}
+        aria-expanded={expanded}
+      >
+        {/* Expand affordance — dot when there is nothing to expand */}
+        <motion.span
+          className="text-mycel-muted/70 text-[9px] select-none shrink-0 w-2.5 text-center"
+          animate={{ rotate: hasDetails && expanded ? 90 : 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          {hasDetails ? "▶" : "·"}
+        </motion.span>
+
+        {/* Kind glyph — monochrome, colored by status */}
+        <span className={`inline-flex items-center justify-center shrink-0 ${glyphColorClass(node.status)}`}>
+          <EventGlyph kind={kind} />
+        </span>
+
+        <EventName node={node} kind={kind} query={searchQuery} />
+        <EventSummary node={node} kind={kind} query={searchQuery} />
+
+        <span className="flex items-center gap-2 shrink-0 ml-auto pl-2">
+          <RelativeTimestamp ts={node.startTime} />
+          {node.status === "running" ? (
+            <span className="text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md bg-mycel-accent/10 text-mycel-accent">
+              <ElapsedTimer start={node.startTime} />
+            </span>
+          ) : node.endTime != null ? (
+            <span className={`text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md ${durationPillClass(node.startTime, node.endTime)}`}>
+              {elapsed(node.startTime, node.endTime)}
+            </span>
+          ) : null}
+        </span>
+      </button>
+
+      {expanded && node.error && (
+        <div className="text-[11px] font-mono px-3 py-2 bg-mycel-surface mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto">
+          <span className="text-[10px] text-mycel-error uppercase tracking-wide font-semibold block mb-1">Error</span>
+          <pre className="whitespace-pre-wrap break-all text-mycel-error/90">{redactSecrets(node.error)}</pre>
+        </div>
+      )}
+
+      {expanded && !!node.fullInput && (
+        <div className="text-[11px] font-mono px-3 py-2 bg-mycel-surface mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-[10px] text-mycel-muted uppercase tracking-wide font-semibold">Input</span>
+            <CopyButton text={inputJson} />
+          </div>
+          <pre className="whitespace-pre-wrap break-all text-mycel-muted">{inputJson}</pre>
+        </div>
+      )}
+
+      {expanded && !!node.fullOutput && (
+        <div className="text-[11px] font-mono px-3 py-2 bg-mycel-surface mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto">
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-[10px] text-mycel-success uppercase tracking-wide font-semibold">Output</span>
+            <CopyButton text={outputJson} />
+          </div>
+          <pre className="whitespace-pre-wrap break-all text-mycel-success/80">{outputJson}</pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/live/LiveRenderers.tsx
+++ b/web/src/components/live/LiveRenderers.tsx
@@ -1,34 +1,25 @@
 import { useCallback, useEffect, useMemo, useState, memo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { Link } from "react-router-dom";
 import type {
   AgentActivity,
-  AggregatedNode,
-  DisplayNode,
   DrillDownTab,
   FilterType,
   RawEvent,
   TaskItem,
-  ToolNode,
 } from "./liveTypes";
-import { isAggregatedNode, AUTO_COLLAPSE_MS } from "./liveTypes";
 import {
-  aggregateNodes,
-  durationColorClass,
-  durationPillClass,
-  elapsed,
   estimateCost,
+  flattenNodes,
   idleDuration,
-  mcpBadgeColors,
-  mcpServerIcon,
   nodeMatchesSearch,
-  parseToolName,
-  redactSecrets,
   redactValue,
-  relativeTime,
-  sortNodes,
   stateBadgeClass,
-  toolIcon,
 } from "./liveHelpers";
+import { CopyButton, EventRow } from "./EventRow";
+
+// Shared row primitives live in EventRow.tsx; re-export for compatibility.
+export { CopyButton, ElapsedTimer, EventRow, RelativeTimestamp, SearchHighlight } from "./EventRow";
 
 /* ── State Dots ────────────────────────────────────────────────────── */
 
@@ -52,45 +43,6 @@ export function StateDot({ state }: { state: string }) {
   return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-mycel-muted/40" />;
 }
 
-export function ToolDot({ status }: { status: ToolNode["status"] }) {
-  if (status === "running")
-    return (
-      <span className="relative flex h-2 w-2 mt-[5px] shrink-0">
-        <span className="absolute inline-flex h-full w-full animate-pulse rounded-full bg-mycel-accent opacity-75" />
-        <span className="relative inline-flex h-2 w-2 rounded-full bg-mycel-accent" />
-      </span>
-    );
-  if (status === "failed")
-    return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-mycel-error" />;
-  return <span className="inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full bg-mycel-success" />;
-}
-
-/* ── Elapsed Timer ─────────────────────────────────────────────────── */
-
-export function ElapsedTimer({ start }: { start: number }) {
-  const [, setTick] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setTick((t) => t + 1), 200);
-    return () => clearInterval(id);
-  }, []);
-  return <>{elapsed(start)}</>;
-}
-
-/* ── Relative Timestamp ───────────────────────────────────────────── */
-
-export function RelativeTimestamp({ ts }: { ts: number }) {
-  const [, setTick] = useState(0);
-  useEffect(() => {
-    const id = setInterval(() => setTick((t) => t + 1), 1000);
-    return () => clearInterval(id);
-  }, []);
-  return (
-    <span title={new Date(ts).toISOString()} className="text-[10px] text-mycel-muted font-mono tabular-nums">
-      {relativeTime(ts)}
-    </span>
-  );
-}
-
 /* ── Idle Timer ───────────────────────────────────────────────────── */
 
 export function IdleTimer({ lastEventTime }: { lastEventTime: number }) {
@@ -100,382 +52,6 @@ export function IdleTimer({ lastEventTime }: { lastEventTime: number }) {
     return () => clearInterval(id);
   }, []);
   return <>{idleDuration(lastEventTime)}</>;
-}
-
-/* ── Copy Button ───────────────────────────────────────────────────── */
-
-export function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    }).catch(() => {});
-  }, [text]);
-
-  return (
-    <button
-      type="button"
-      onClick={(e) => { e.stopPropagation(); handleCopy(); }}
-      className="text-[10px] text-mycel-muted hover:text-mycel-text px-1.5 py-0.5 rounded border border-mycel-border/40 hover:border-mycel-accent transition-colors shrink-0"
-      aria-label="Copy to clipboard"
-    >
-      {copied ? "Copied" : "Copy"}
-    </button>
-  );
-}
-
-/* ── MCP Badge ─────────────────────────────────────────────────────── */
-
-export function McpBadge({ server, func }: { server: string; func: string }) {
-  return (
-    <span className="inline-flex items-center gap-1">
-      <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-mono ${mcpBadgeColors(server)}`}>
-        <span aria-hidden="true">{mcpServerIcon(server)}</span>
-        <span>{server}</span>
-      </span>
-      <span className="font-mono text-[13px] text-mycel-text font-medium">{func}</span>
-    </span>
-  );
-}
-
-/* ── Search Highlight ──────────────────────────────────────────────── */
-
-export function SearchHighlight({ text, query }: { text: string; query: string }) {
-  if (!query || !text) return <>{text}</>;
-  const lower = text.toLowerCase();
-  const q = query.toLowerCase();
-  const idx = lower.indexOf(q);
-  if (idx === -1) return <>{text}</>;
-  return (
-    <>
-      {text.slice(0, idx)}
-      <mark className="bg-yellow-500/20 text-inherit rounded px-0.5">{text.slice(idx, idx + q.length)}</mark>
-      {text.slice(idx + q.length)}
-    </>
-  );
-}
-
-/* ── Tool Name Display ─────────────────────────────────────────────── */
-
-export function ToolNameDisplay({ toolName, searchQuery }: { toolName: string; searchQuery?: string }) {
-  const parsed = parseToolName(toolName);
-  if (parsed.type === "mcp" && parsed.mcpServer && parsed.mcpFunction) {
-    return <McpBadge server={parsed.mcpServer} func={parsed.mcpFunction} />;
-  }
-  return (
-    <span className="inline-flex items-center gap-1">
-      <span className="text-[12px]" aria-hidden="true">{toolIcon(toolName)}</span>
-      <span className="font-mono text-[13px] text-mycel-text font-semibold">
-        {searchQuery ? <SearchHighlight text={parsed.display} query={searchQuery} /> : parsed.display}
-      </span>
-    </span>
-  );
-}
-
-/* ── Tool Node Row ─────────────────────────────────────────────────── */
-
-export function ToolNodeRow({ node, depth = 0, searchQuery = "" }: { node: ToolNode; depth?: number; searchQuery?: string }) {
-  const [expanded, setExpanded] = useState(false);
-  const indent = depth * 20;
-  const hasDetails = !!(node.fullInput || node.fullOutput || node.children.length > 0);
-  const isSubagentSpawn = node.toolName === "Agent" || node.toolName.startsWith("Agent:");
-
-  // Subagent tree: use AgentTreeNode for nested rendering
-  if (isSubagentSpawn) {
-    return <AgentTreeNode node={node} depth={depth} />;
-  }
-
-  const inputJson = node.fullInput ? JSON.stringify(redactValue(node.fullInput), null, 2) : "";
-  const outputJson = node.fullOutput ? JSON.stringify(redactValue(node.fullOutput), null, 2) : "";
-
-  return (
-    <>
-      <button
-        type="button"
-        className={`group flex items-center gap-2 py-1.5 px-3 w-full text-left hover:bg-mycel-surface-hover cursor-pointer transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent ${node.status === "failed" ? "!bg-mycel-error/5 hover:!bg-mycel-error/10" : ""}`}
-        style={{ paddingLeft: `${indent + 12}px` }}
-        onClick={() => setExpanded(!expanded)}
-        aria-label={`${expanded ? "Collapse" : "Expand"} tool ${node.toolName}`}
-      >
-        <span className="text-mycel-muted text-xs select-none shrink-0">
-          {depth > 0 ? "\u251C\u2500" : ""}
-        </span>
-        {/* Animated chevron */}
-        <motion.span
-          className="text-mycel-muted text-[10px] select-none shrink-0 w-3 text-center group-hover:text-mycel-muted"
-          animate={{ rotate: hasDetails ? (expanded ? 90 : 0) : 0 }}
-          transition={{ duration: 0.15 }}
-        >
-          {hasDetails ? "\u25B6" : "\u00B7"}
-        </motion.span>
-        {/* Status dot — inline, no border container. The chevron + this
-            dot together carry all the "row status" signal; the previous
-            bordered pill was one glyph too many per row. #3205 P1c. */}
-        <ToolDot status={node.status} />
-        <span className="shrink-0 font-semibold">
-          <ToolNameDisplay toolName={node.toolName} searchQuery={searchQuery} />
-        </span>
-        {node.args && (
-          <span className="text-[12px] text-mycel-muted/80 font-mono min-w-0 flex-1 break-words" title={redactSecrets(node.args)}>
-            {searchQuery ? <SearchHighlight text={redactSecrets(node.args)} query={searchQuery} /> : redactSecrets(node.args)}
-          </span>
-        )}
-        <span className="flex items-center gap-2 shrink-0">
-          <RelativeTimestamp ts={node.startTime} />
-          {/* Duration pill with color-coded background — hidden for historical events without timing */}
-          {node.status === "running" ? (
-            <span className="text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md bg-mycel-muted/10 text-mycel-muted">
-              <ElapsedTimer start={node.startTime} />
-            </span>
-          ) : node.endTime != null ? (
-            <span className={`text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md ${durationPillClass(node.startTime, node.endTime)}`}>
-              {elapsed(node.startTime, node.endTime)}
-            </span>
-          ) : null}
-        </span>
-      </button>
-
-      {node.error && (
-        <div
-          className="text-[11px] text-mycel-error/80 font-mono px-3 py-0.5"
-          style={{ paddingLeft: `${indent + 40}px` }}
-        >
-          {redactSecrets(node.error.length > 120 ? node.error.slice(0, 117) + "..." : node.error)}
-        </div>
-      )}
-
-      {expanded && node.fullInput && (
-        <div
-          className="text-[11px] font-mono px-3 py-1 bg-mycel-surface mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto"
-          style={{ marginLeft: `${indent + 12}px` }}
-        >
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-[10px] text-mycel-muted uppercase tracking-wide font-semibold">Input</span>
-            <CopyButton text={inputJson} />
-          </div>
-          <pre className="whitespace-pre-wrap break-all text-mycel-muted">
-            {inputJson}
-          </pre>
-        </div>
-      )}
-
-      {expanded && node.fullOutput && (
-        <div
-          className="text-[11px] font-mono px-3 py-1 bg-mycel-surface mx-3 mb-1 rounded overflow-x-auto max-h-48 overflow-y-auto"
-          style={{ marginLeft: `${indent + 12}px` }}
-        >
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-[10px] text-mycel-success uppercase tracking-wide font-semibold">Output</span>
-            <CopyButton text={outputJson} />
-          </div>
-          <pre className="whitespace-pre-wrap break-all text-mycel-success/80">
-            {outputJson}
-          </pre>
-        </div>
-      )}
-
-      {node.children.map((child) => (
-        <ToolNodeRow key={child.id} node={child} depth={depth + 1} searchQuery={searchQuery} />
-      ))}
-    </>
-  );
-}
-
-/* ── Agent Tree Node (recursive subagent nesting) ──────────────────── */
-
-export function AgentTreeNode({ node, depth = 0 }: { node: ToolNode; depth?: number }) {
-  const [expanded, setExpanded] = useState(true);
-  const indent = depth * 16;
-  const duration = node.endTime ? elapsed(node.startTime, node.endTime) : undefined;
-  const childCount = node.children.length;
-
-  const subagentChildren = node.children.filter(
-    (c) => c.toolName === "Agent" || c.toolName.startsWith("Agent:"),
-  );
-  const toolChildren = node.children.filter(
-    (c) => c.toolName !== "Agent" && !c.toolName.startsWith("Agent:"),
-  );
-
-  return (
-    <div style={{ marginLeft: `${indent}px` }}>
-      {/* Subagent header */}
-      <button
-        type="button"
-        className="group flex items-start gap-2 py-1.5 px-3 w-full text-left hover:bg-mycel-surface-hover cursor-pointer transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent bg-blue-950/20 rounded-md my-0.5"
-        onClick={() => setExpanded(!expanded)}
-        aria-label={`${expanded ? "Collapse" : "Expand"} subagent ${node.toolName}`}
-      >
-        <span className="text-mycel-muted text-[10px] select-none mt-[3px] shrink-0 w-3 text-center group-hover:text-mycel-muted">
-          {childCount > 0 ? (expanded ? "\u25BC" : "\u25B6") : "\u00B7"}
-        </span>
-        <ToolDot status={node.status} />
-        <span className="text-[13px]" aria-hidden="true">{"\uD83E\uDD16"}</span>
-        <span className="font-mono text-[13px] text-mycel-text font-semibold">{node.toolName}</span>
-        {node.args && (
-          <span className="text-[12px] text-mycel-muted truncate max-w-[300px] font-mono italic">
-            &ldquo;{node.args}&rdquo;
-          </span>
-        )}
-        <span className="ml-auto flex items-center gap-2 shrink-0">
-          <RelativeTimestamp ts={node.startTime} />
-          {node.status === "running" ? (
-            <span className="text-[11px] text-blue-400 font-mono tabular-nums">
-              {"\u23F1"} <ElapsedTimer start={node.startTime} />
-            </span>
-          ) : duration ? (
-            <span className={`text-[11px] font-mono tabular-nums ${durationColorClass(node.startTime, node.endTime)}`}>
-              {"\u23F1"} {duration}
-            </span>
-          ) : null}
-          {node.status === "completed" && (
-            <span className="text-[10px] text-mycel-success font-mono">{"\u2713"}</span>
-          )}
-          {node.status === "failed" && (
-            <span className="text-[10px] text-mycel-error font-mono">{"\u2717"}</span>
-          )}
-        </span>
-      </button>
-
-      {/* Tree children with connector lines */}
-      {expanded && childCount > 0 && (
-        <div className="border-l-2 border-mycel-muted/30 ml-4 pl-3">
-          {toolChildren.map((child, idx) => {
-            const isLast = idx === toolChildren.length - 1 && subagentChildren.length === 0;
-            return (
-              <div key={child.id} className="flex items-start gap-0">
-                <span className="text-mycel-muted/30 text-xs select-none mt-[3px] shrink-0 w-4">
-                  {isLast ? "\u2514\u2500" : "\u251C\u2500"}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <ToolNodeRow node={child} depth={0} />
-                </div>
-              </div>
-            );
-          })}
-
-          {/* Nested subagent children (recursive) */}
-          {subagentChildren.map((child, idx) => {
-            const isLast = idx === subagentChildren.length - 1;
-            return (
-              <div key={child.id} className="flex items-start gap-0">
-                <span className="text-mycel-muted/30 text-xs select-none mt-[3px] shrink-0 w-4">
-                  {isLast ? "\u2514\u2500" : "\u251C\u2500"}
-                </span>
-                <div className="flex-1 min-w-0">
-                  <AgentTreeNode node={child} depth={0} />
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-/* ── Aggregated Node Row ───────────────────────────────────────────── */
-
-export function AggregatedChildRow({ child, searchQuery = "" }: { child: ToolNode; searchQuery?: string }) {
-  const [showRawJson, setShowRawJson] = useState(false);
-
-  const fullEventJson = JSON.stringify(redactValue({
-    id: child.id,
-    toolName: child.toolName,
-    args: child.args,
-    status: child.status,
-    startTime: child.startTime,
-    endTime: child.endTime,
-    error: child.error,
-    fullInput: child.fullInput,
-    fullOutput: child.fullOutput,
-  }), null, 2);
-
-  return (
-    <div>
-      <ToolNodeRow node={child} depth={1} searchQuery={searchQuery} />
-      {!!(child.fullInput || child.fullOutput) && (
-        <div className="ml-8 mb-1">
-          <button
-            type="button"
-            onClick={() => setShowRawJson(!showRawJson)}
-            className="text-[10px] text-mycel-muted hover:text-mycel-accent font-mono transition-colors px-2 py-0.5 rounded border border-mycel-border/40 hover:border-mycel-accent/50"
-          >
-            {showRawJson ? "Hide Raw JSON" : "Raw JSON"}
-          </button>
-          {showRawJson && (
-            <div className="mt-1 text-[11px] font-mono px-3 py-2 bg-mycel-bg rounded border border-mycel-border/40 overflow-x-auto max-h-64 overflow-y-auto">
-              <div className="flex justify-end mb-1">
-                <CopyButton text={fullEventJson} />
-              </div>
-              <pre className="whitespace-pre-wrap break-all text-mycel-muted">
-                {fullEventJson}
-              </pre>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-export function AggregatedNodeRow({ node, searchQuery = "" }: { node: AggregatedNode; searchQuery?: string }) {
-  const [expanded, setExpanded] = useState(false);
-
-  return (
-    <>
-      <button
-        type="button"
-        className="group flex items-start gap-2 py-1 px-3 w-full text-left hover:bg-mycel-surface-hover cursor-pointer transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent bg-mycel-surface/50"
-        onClick={() => setExpanded(!expanded)}
-        aria-label={`${expanded ? "Collapse" : "Expand"} aggregated ${node.toolName} (${node.count} calls)`}
-      >
-        <span className="text-mycel-muted text-xs select-none mt-[3px] shrink-0">
-          {expanded ? "\u25BC" : "\u25B6"}
-        </span>
-        <span className={`inline-flex h-2 w-2 mt-[5px] shrink-0 rounded-full ${
-          node.failCount > 0 ? "bg-mycel-warning" : "bg-mycel-success"
-        }`} />
-        <ToolNameDisplay toolName={node.toolName} />
-        <span className="text-[12px] font-mono font-semibold text-mycel-accent px-1.5 py-0 rounded bg-mycel-accent/10">
-          &times;{node.count}
-        </span>
-        {/* At-rest summary is intentionally sparse — total count + failure
-            call-out only. avg/total-duration/ok-ratio move behind the
-            expand chevron (#3205 P1c) so the log row reads as a scannable
-            line rather than a paragraph. */}
-        <span className="text-[11px] text-mycel-muted font-mono tabular-nums flex-1 min-w-0">
-          {node.count} total
-          {node.failCount > 0 && (
-            <span className="text-mycel-error"> &middot; {node.failCount} failed</span>
-          )}
-          {expanded && node.totalDuration > 0 && <> &middot; {elapsed(0, node.totalDuration)}</>}
-          {expanded && node.totalDuration > 0 && node.count > 1 && (
-            <> &middot; avg {elapsed(0, Math.round(node.totalDuration / node.count))}</>
-          )}
-          {expanded && node.totalTokens > 0 && <> &middot; {node.totalTokens.toLocaleString()} tok</>}
-          {expanded && <> &middot; {node.successCount}/{node.count} ok</>}
-        </span>
-      </button>
-
-      {expanded && (
-        <div className="border-l-2 border-mycel-border/40 ml-6">
-          {node.children.map((child) => (
-            <AggregatedChildRow key={child.id} child={child} searchQuery={searchQuery} />
-          ))}
-        </div>
-      )}
-    </>
-  );
-}
-
-/* ── Display Node Row ──────────────────────────────────────────────── */
-
-export function DisplayNodeRow({ node, searchQuery = "" }: { node: DisplayNode; searchQuery?: string }) {
-  if (isAggregatedNode(node)) {
-    return <AggregatedNodeRow node={node} searchQuery={searchQuery} />;
-  }
-  return <ToolNodeRow node={node} searchQuery={searchQuery} />;
 }
 
 /* ── Agent Drill-Down View ─────────────────────────────────────────── */
@@ -507,9 +83,8 @@ export function DrillDownTasksSection({ tasks, agentName }: { tasks: Map<string,
         className="flex items-center gap-2 w-full px-4 py-2.5 text-left hover:bg-mycel-surface-hover transition-colors"
       >
         <span className="text-mycel-muted text-[10px] select-none w-3 text-center">
-          {collapsed ? "\u25B6" : "\u25BC"}
+          {collapsed ? "▶" : "▼"}
         </span>
-        <span className="text-[13px]">{"\u2705"}</span>
         <span className="text-sm font-semibold text-mycel-text">Tasks</span>
         <span className="text-xs text-mycel-muted font-mono tabular-nums">
           ({completedCount}/{total} complete)
@@ -562,83 +137,6 @@ export function DrillDownTasksSection({ tasks, agentName }: { tasks: Map<string,
   );
 }
 
-/* ── Drill-Down: Full-width individual event row ──────────────────── */
-
-export function DrillDownEventRow({ node }: { node: ToolNode }) {
-  const [expanded, setExpanded] = useState(false);
-  const hasDetails = !!(node.fullInput || node.fullOutput);
-  const inputJson = node.fullInput ? JSON.stringify(redactValue(node.fullInput), null, 2) : "";
-  const outputJson = node.fullOutput ? JSON.stringify(redactValue(node.fullOutput), null, 2) : "";
-
-  return (
-    <div className={`border-b border-mycel-border/40 ${node.status === "failed" ? "bg-mycel-error/5" : ""}`}>
-      <button
-        type="button"
-        className="group flex items-center gap-3 py-2.5 px-4 w-full text-left hover:bg-mycel-surface-hover cursor-pointer transition-colors"
-        onClick={() => setExpanded(!expanded)}
-        aria-label={`${expanded ? "Collapse" : "Expand"} ${node.toolName} event`}
-      >
-        {/* Animated chevron */}
-        <motion.span
-          className="text-mycel-muted text-[10px] select-none shrink-0 w-3 text-center group-hover:text-mycel-muted"
-          animate={{ rotate: hasDetails ? (expanded ? 90 : 0) : 0 }}
-          transition={{ duration: 0.15 }}
-        >
-          {hasDetails ? "\u25B6" : "\u00B7"}
-        </motion.span>
-        {/* Icon container */}
-        <span className="inline-flex items-center justify-center h-6 w-6 rounded-md bg-mycel-surface border border-mycel-border/60 shrink-0">
-          <ToolDot status={node.status} />
-        </span>
-        <span className="shrink-0">
-          <ToolNameDisplay toolName={node.toolName} />
-        </span>
-        <span className="text-[12px] text-mycel-muted font-mono min-w-0 flex-1 break-words">
-          {redactSecrets(node.args)}
-        </span>
-        <span className="flex items-center gap-2 shrink-0">
-          <RelativeTimestamp ts={node.startTime} />
-          {node.status === "running" ? (
-            <span className="text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md bg-mycel-muted/10 text-mycel-muted">
-              <ElapsedTimer start={node.startTime} />
-            </span>
-          ) : node.endTime != null ? (
-            <span className={`text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md ${durationPillClass(node.startTime, node.endTime)}`}>
-              {elapsed(node.startTime, node.endTime)}
-            </span>
-          ) : null}
-        </span>
-      </button>
-
-      {node.error && (
-        <div className="text-[11px] text-mycel-error/80 font-mono px-4 py-0.5 ml-8">
-          {redactSecrets(node.error.length > 200 ? node.error.slice(0, 197) + "..." : node.error)}
-        </div>
-      )}
-
-      {expanded && !!node.fullInput && (
-        <div className="text-[11px] font-mono px-4 py-2 bg-mycel-surface mx-4 mb-1 rounded overflow-x-auto max-h-64 overflow-y-auto">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-[10px] text-mycel-muted uppercase tracking-wide font-semibold">Input</span>
-            <CopyButton text={inputJson} />
-          </div>
-          <pre className="whitespace-pre-wrap break-all text-mycel-muted">{inputJson}</pre>
-        </div>
-      )}
-
-      {expanded && !!node.fullOutput && (
-        <div className="text-[11px] font-mono px-4 py-2 bg-mycel-surface mx-4 mb-1 rounded overflow-x-auto max-h-64 overflow-y-auto">
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-[10px] text-mycel-success uppercase tracking-wide font-semibold">Output</span>
-            <CopyButton text={outputJson} />
-          </div>
-          <pre className="whitespace-pre-wrap break-all text-mycel-success/80">{outputJson}</pre>
-        </div>
-      )}
-    </div>
-  );
-}
-
 /* ── Drill-Down: Raw event type badge colors ──────────────────────── */
 
 export function rawEventBadgeColor(eventType: string): string {
@@ -670,9 +168,11 @@ export function AgentDrillDown({
 
   const cost = estimateCost(activity);
 
-  // Show ALL events individually in drill-down — no aggregation
+  // Show ALL events individually — flat, newest at top, no aggregation.
+  // Subagent child tool calls are flattened into the same stream so
+  // nothing hides inside a nested tree.
   const allNodes = useMemo(() => {
-    return [...activity.nodes].sort((a, b) => b.startTime - a.startTime);
+    return flattenNodes(activity.nodes).sort((a, b) => b.startTime - a.startTime);
   }, [activity.nodes]);
 
   const toggleRawExpanded = useCallback((key: string) => {
@@ -752,7 +252,7 @@ export function AgentDrillDown({
 
       {/* Tab content */}
       <div className="flex-1 overflow-y-auto min-h-0">
-        {/* Live Stream tab — ALL events individually, no aggregation */}
+        {/* Live Stream tab — flat rows, newest first */}
         {activeTab === "live" && (
           <div>
             {allNodes.length === 0 ? (
@@ -761,7 +261,7 @@ export function AgentDrillDown({
               </div>
             ) : (
               allNodes.map((node) => (
-                <DrillDownEventRow key={node.id} node={node} />
+                <EventRow key={node.id} node={node} />
               ))
             )}
           </div>
@@ -787,7 +287,7 @@ export function AgentDrillDown({
                       className="flex items-center gap-2 w-full px-3 py-1.5 text-left hover:bg-mycel-surface-hover transition-colors"
                     >
                       <span className="text-mycel-muted text-[10px] select-none w-3 text-center">
-                        {isOpen ? "\u25BC" : "\u25B6"}
+                        {isOpen ? "▼" : "▶"}
                       </span>
                       <span className="text-[10px] text-mycel-muted font-mono tabular-nums shrink-0">
                         {new Date(evt.timestamp).toISOString().replace("T", " ").slice(0, 23)}
@@ -828,6 +328,10 @@ export function AgentDrillDown({
 
 /* ── Agent Activity Card ───────────────────────────────────────────── */
 
+/** Cap on visible rows in a Live card — the full stream lives in the
+ *  agent detail page (linked below the stream). */
+export const LIVE_CARD_MAX_ROWS = 30;
+
 export const AgentCard = memo(function AgentCard({
   activity,
   onToggle,
@@ -835,7 +339,6 @@ export const AgentCard = memo(function AgentCard({
   isFilterActive,
   searchTerm,
   typeFilter,
-  isPaused,
 }: {
   activity: AgentActivity;
   onToggle: () => void;
@@ -843,23 +346,27 @@ export const AgentCard = memo(function AgentCard({
   isFilterActive: boolean;
   searchTerm: string;
   typeFilter: FilterType;
-  isPaused: boolean;
 }) {
-  const [collapseOld, setCollapseOld] = useState(true);
+  // Flat hook-event stream — same visual language as the agent detail
+  // page. Newest at top, stable keys, no aggregation, no reordering:
+  // a finished tool call updates in place, it never moves.
+  const flatNodes = useMemo(() => {
+    return flattenNodes(activity.nodes).sort((a, b) => b.startTime - a.startTime);
+  }, [activity.nodes]);
 
-  const visibleNodes = searchTerm
-    ? activity.nodes.filter((n) => nodeMatchesSearch(n, searchTerm.toLowerCase()))
-    : activity.nodes;
+  const visibleNodes = useMemo(() => {
+    if (!searchTerm) return flatNodes;
+    const q = searchTerm.toLowerCase();
+    return flatNodes.filter((n) => nodeMatchesSearch(n, q));
+  }, [flatNodes, searchTerm]);
 
-  const sortedNodes = sortNodes(visibleNodes);
+  const shownNodes = visibleNodes.slice(0, LIVE_CARD_MAX_ROWS);
+  const hiddenCount = visibleNodes.length - shownNodes.length;
 
-  const runningCount = sortedNodes.filter((n) => n.status === "running").length;
-  const errorCount = activity.nodes.filter((n) => n.status === "failed").length;
-  const displayNodes = aggregateNodes(sortedNodes, collapseOld ? AUTO_COLLAPSE_MS : undefined, activity.nodes.length);
+  const runningCount = flatNodes.filter((n) => n.status === "running").length;
+  const errorCount = flatNodes.filter((n) => n.status === "failed").length;
   const matchCount = searchTerm ? visibleNodes.length : 0;
   const showToolNodes = typeFilter !== "state";
-
-  const skipAnimation = isPaused || visibleNodes.length > 5;
 
   const monogram = (activity.name ?? "?").charAt(0).toUpperCase();
   const cost = estimateCost(activity);
@@ -977,52 +484,39 @@ export const AgentCard = memo(function AgentCard({
       </div>
 
       <AnimatePresence initial={false}>
-        {!activity.collapsed && showToolNodes && displayNodes.length > 0 && (
+        {!activity.collapsed && showToolNodes && shownNodes.length > 0 && (
           <motion.div
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="border-t border-mycel-border/60 py-1 overflow-hidden"
+            className="border-t border-mycel-border/60 overflow-hidden"
           >
-            {visibleNodes.length > 3 && (
-              <div className="flex justify-end px-3 py-1">
-                <button
-                  type="button"
-                  onClick={() => setCollapseOld((prev) => !prev)}
-                  className="text-[10px] text-mycel-muted hover:text-mycel-accent font-mono transition-colors"
+            {/* Flat event stream — newest first. Rows are keyed by event
+                id and never animate position, so new events prepend
+                without reflowing everything below them. */}
+            {shownNodes.map((node) => (
+              <EventRow key={node.id} node={node} searchQuery={searchTerm} />
+            ))}
+            {hiddenCount > 0 && (
+              <div className="flex justify-center border-t border-mycel-border/40">
+                <Link
+                  to={`/agents/${activity.name}/live`}
+                  className="text-[11px] text-mycel-muted hover:text-mycel-accent font-mono py-1.5 px-3 transition-colors"
                 >
-                  {collapseOld ? "Show all" : "Collapse old"}
-                </button>
+                  {hiddenCount} more — view all in {activity.name} &rarr;
+                </Link>
               </div>
             )}
-            <AnimatePresence mode="popLayout" initial={false}>
-              {displayNodes.map((node) => {
-                const nodeKey = node.id;
-                if (skipAnimation) {
-                  return (
-                    <div key={nodeKey}>
-                      <DisplayNodeRow node={node} searchQuery={searchTerm} />
-                    </div>
-                  );
-                }
-                return (
-                  <motion.div
-                    key={nodeKey}
-                    initial={{ opacity: 0, y: -20, height: 0 }}
-                    animate={{ opacity: 1, y: 0, height: "auto" }}
-                    exit={{ opacity: 0, height: 0 }}
-                    transition={{ duration: 0.2, ease: "easeOut" }}
-                    layout
-                  >
-                    <DisplayNodeRow node={node} searchQuery={searchTerm} />
-                  </motion.div>
-                );
-              })}
-            </AnimatePresence>
           </motion.div>
         )}
       </AnimatePresence>
+
+      {!activity.collapsed && showToolNodes && visibleNodes.length === 0 && searchTerm && (
+        <div className="border-t border-mycel-border/60 py-3 px-4 text-[12px] text-mycel-muted italic">
+          No events match &ldquo;{searchTerm}&rdquo;
+        </div>
+      )}
 
       {!activity.collapsed && showToolNodes && visibleNodes.length === 0 && !searchTerm && (
         <div className="border-t border-mycel-border/60 py-3 px-4 text-[12px] text-mycel-muted italic flex items-center gap-2">

--- a/web/src/components/live/liveHelpers.ts
+++ b/web/src/components/live/liveHelpers.ts
@@ -2,19 +2,11 @@ import { formatDuration, formatRelative } from "../../utils/time";
 
 import type {
   AgentActivity,
-  AggregatedNode,
-  DisplayNode,
   HookEvent,
   TaskItem,
   ToolNode,
 } from "./liveTypes";
-import {
-  AGGREGATION_WINDOW_MS,
-  FAILED_NEVER_AGGREGATE_MS,
-  isAggregatedNode,
-  MAX_INDIVIDUAL_NODES,
-  TASK_STATUS_MAP,
-} from "./liveTypes";
+import { TASK_STATUS_MAP } from "./liveTypes";
 
 /* ── ID generator ──────────────────────────────────────────────────── */
 
@@ -51,28 +43,6 @@ export function parseToolName(name: string): ParsedTool {
     return { display: action, type: "mcp", mcpServer: parts[0], mcpFunction: action };
   }
   return { display: name, type: "internal" };
-}
-
-export function toolIcon(name: string): string {
-  if (name === "Bash" || name === "BashOutput") return "\u2328\uFE0F";
-  if (name === "Read") return "\uD83D\uDCD6";
-  if (name === "Write" || name === "Edit") return "\u270F\uFE0F";
-  if (name === "Glob" || name === "Grep") return "\uD83D\uDD0D";
-  if (name === "Agent") return "\uD83E\uDD16";
-  if (name === "WebFetch" || name === "WebSearch") return "\uD83C\uDF10";
-  if (name.startsWith("Task")) return "\u2705";
-  if (name === "NotebookEdit") return "\uD83D\uDCD3";
-  if (name === "LSP" || name === "ToolSearch") return "\u2699\uFE0F";
-  if (name === "AskUserQuestion") return "\u2753";
-  if (name === "Skill") return "\uD83C\uDFAF";
-  return "\u2699\uFE0F";
-}
-
-export function mcpServerIcon(server: string): string {
-  if (server === "playwright" || server === "playwright2") return "\uD83C\uDFAD";
-  if (server === "github") return "\uD83D\uDC19";
-  if (server === "bc") return "\u26A1";
-  return "\uD83D\uDD0C";
 }
 
 export function mcpBadgeColors(server: string): string {
@@ -121,17 +91,13 @@ export function extractToolMetadata(toolName: string, input: unknown): string {
   const trunc = (s: string, max = 80): string => s.length > max ? s.slice(0, max - 3) + "..." : s;
 
   if (toolName === "Bash" || toolName === "bash") {
+    // Prefer the human-written description over the raw command — it is
+    // the richer one-line summary when the hook payload carries it.
+    if (typeof obj.description === "string" && obj.description) return redactSecrets(trunc(obj.description, 60));
     if (typeof obj.command === "string") return redactSecrets(trunc(obj.command));
   }
-  if ((toolName === "Read" || toolName === "Write") && typeof obj.file_path === "string") {
-    return trunc(obj.file_path);
-  }
-  if (toolName === "Edit") {
-    let s = typeof obj.file_path === "string" ? obj.file_path : "";
-    if (typeof obj.old_string === "string") {
-      s += " " + trunc(obj.old_string, 40);
-    }
-    return trunc(s);
+  if ((toolName === "Read" || toolName === "Write" || toolName === "Edit" || toolName === "NotebookEdit") && typeof obj.file_path === "string") {
+    return obj.file_path;
   }
   if ((toolName === "Grep" || toolName === "Glob") && typeof obj.pattern === "string") {
     return trunc(obj.pattern);
@@ -193,14 +159,6 @@ export function elapsed(start: number, end?: number): string {
   return `${(ms / 60_000).toFixed(1)}m`;
 }
 
-export function durationColorClass(start: number, end?: number): string {
-  const ms = (end ?? Date.now()) - start;
-  if (ms < 500) return "text-mycel-success";
-  if (ms < 2000) return "text-mycel-warning";
-  if (ms < 10000) return "text-mycel-accent";
-  return "text-mycel-error";
-}
-
 export function durationPillClass(start: number, end?: number): string {
   const ms = (end ?? Date.now()) - start;
   if (ms < 500) return "bg-mycel-success/15 text-mycel-success";
@@ -237,284 +195,25 @@ export function idleDuration(lastEventTime: number): string {
   return formatDuration(Date.now() - lastEventTime, { prefix: "Idle " });
 }
 
-/* ── Node search / sort ────────────────────────────────────────────── */
+/* ── Node search / flatten ──────────────────────────────────────── */
 
 export function nodeMatchesSearch(node: ToolNode, query: string): boolean {
   const hay = `${node.toolName} ${node.args}`.toLowerCase();
   return hay.includes(query);
 }
 
-export function sortNodes(nodes: ToolNode[]): ToolNode[] {
-  return [...nodes].sort((a, b) => {
-    // Running first (newest first among running)
-    if (a.status === "running" && b.status !== "running") return -1;
-    if (b.status === "running" && a.status !== "running") return 1;
-    if (a.status === "running" && b.status === "running") return b.startTime - a.startTime;
-    // Failed second (newest first among failed)
-    if (a.status === "failed" && b.status !== "failed") return -1;
-    if (b.status === "failed" && a.status !== "failed") return 1;
-    if (a.status === "failed" && b.status === "failed") return b.startTime - a.startTime;
-    // Completed: sort by duration (longest first)
-    const aDur = (a.endTime ?? a.startTime) - a.startTime;
-    const bDur = (b.endTime ?? b.startTime) - b.startTime;
-    return bDur - aDur;
-  });
-}
-
-/* ── Aggregation ──────────────────────────────────────────────────── */
-
-const AGGREGATION_MIN_COUNT = 3;
-
-export const NEVER_AGGREGATE_EVENTS = new Set([
-  "SubagentStart", "SubagentStop", "Agent",
-  "PermissionRequest", "Elicitation",
-  "UserPromptSubmit", "SessionStart", "SessionEnd",
-  "Stop", "TaskCompleted",
-]);
-
-export function shouldNeverAggregate(node: ToolNode, now?: number): boolean {
-  // Failed tools: never aggregate for 2 minutes after creation
-  if (node.status === "failed") {
-    const ts = now ?? Date.now();
-    if (ts - node.startTime < FAILED_NEVER_AGGREGATE_MS) return true;
-  }
-  if (NEVER_AGGREGATE_EVENTS.has(node.toolName)) return true;
-  if (node.toolName.startsWith("Agent:")) return true;
-  return false;
-}
-
-export interface AggStats {
-  totalDuration: number;
-  totalTokens: number;
-  successCount: number;
-  failCount: number;
-  minStart: number;
-  maxEnd: number;
-}
-
-export function computeToolNodeStats(nodes: ToolNode[]): AggStats {
-  let totalDuration = 0;
-  let successCount = 0;
-  let failCount = 0;
-  let minStart = Infinity;
-  let maxEnd = 0;
-
-  for (const n of nodes) {
-    totalDuration += n.endTime ? n.endTime - n.startTime : 0;
-    if (n.status === "completed") successCount++;
-    if (n.status === "failed") failCount++;
-    if (n.startTime < minStart) minStart = n.startTime;
-    if (n.endTime && n.endTime > maxEnd) maxEnd = n.endTime;
-  }
-
-  return { totalDuration, totalTokens: 0, successCount, failCount, minStart, maxEnd };
-}
-
-export function buildAggregatedNode(idPrefix: string, toolName: string, children: ToolNode[], stats: AggStats): AggregatedNode {
-  return {
-    type: "aggregate",
-    id: `${idPrefix}-${children[0]!.id}`,
-    toolName,
-    count: children.length,
-    children,
-    totalDuration: stats.totalDuration,
-    totalTokens: stats.totalTokens,
-    successCount: stats.successCount,
-    failCount: stats.failCount,
-    startTime: stats.minStart,
-    endTime: stats.maxEnd || Date.now(),
+/** Flatten a node tree (subagent children nest under their parent) into
+ *  a single flat list so every hook event renders as one stream row. */
+export function flattenNodes(nodes: ToolNode[]): ToolNode[] {
+  const out: ToolNode[] = [];
+  const walk = (list: ToolNode[]) => {
+    for (const n of list) {
+      out.push(n);
+      if (n.children.length > 0) walk(n.children);
+    }
   };
-}
-
-export function flattenDisplayNodes(group: DisplayNode[]): { children: ToolNode[]; stats: AggStats } {
-  const allChildren: ToolNode[] = [];
-  let totalDuration = 0;
-  let totalTokens = 0;
-  let successCount = 0;
-  let failCount = 0;
-  let minStart = Infinity;
-  let maxEnd = 0;
-
-  for (const g of group) {
-    if (isAggregatedNode(g)) {
-      allChildren.push(...g.children);
-      totalDuration += g.totalDuration;
-      totalTokens += g.totalTokens;
-      successCount += g.successCount;
-      failCount += g.failCount;
-      if (g.startTime < minStart) minStart = g.startTime;
-      if (g.endTime > maxEnd) maxEnd = g.endTime;
-    } else {
-      allChildren.push(g);
-      totalDuration += g.endTime ? g.endTime - g.startTime : 0;
-      if (g.status === "completed") successCount++;
-      if (g.status === "failed") failCount++;
-      if (g.startTime < minStart) minStart = g.startTime;
-      if (g.endTime && g.endTime > maxEnd) maxEnd = g.endTime;
-    }
-  }
-
-  return { children: allChildren, stats: { totalDuration, totalTokens, successCount, failCount, minStart, maxEnd } };
-}
-
-export function aggregateNodes(nodes: ToolNode[], collapseOlderThan?: number, totalNodeCount?: number): DisplayNode[] {
-  if (nodes.length === 0) return [];
-
-  const now = Date.now();
-  const threshold = collapseOlderThan ?? 0;
-  const agentTotalNodes = totalNodeCount ?? nodes.length;
-
-  // If agent has fewer than MAX_INDIVIDUAL_NODES total calls, show all individually
-  if (agentTotalNodes < MAX_INDIVIDUAL_NODES) {
-    return nodes;
-  }
-
-  if (threshold > 0) {
-    const recentNodes: ToolNode[] = [];
-    const oldByTool = new Map<string, ToolNode[]>();
-
-    for (const n of nodes) {
-      const age = now - n.startTime;
-      if (age <= threshold || n.status === "running" || shouldNeverAggregate(n, now)) {
-        recentNodes.push(n);
-      } else {
-        const key = n.toolName;
-        if (!oldByTool.has(key)) oldByTool.set(key, []);
-        oldByTool.get(key)!.push(n);
-      }
-    }
-
-    const oldAggregated: DisplayNode[] = [];
-    for (const [toolName, group] of oldByTool) {
-      if (group.length >= 2) {
-        const stats = computeToolNodeStats(group);
-        oldAggregated.push(buildAggregatedNode("agg-old", toolName, group, stats));
-      } else {
-        oldAggregated.push(...group);
-      }
-    }
-
-    oldAggregated.sort((a, b) => b.startTime - a.startTime);
-
-    const recentAggregated = aggregateConsecutive(recentNodes);
-    return aggregateByType([...recentAggregated, ...oldAggregated], agentTotalNodes);
-  }
-
-  return aggregateByType(aggregateConsecutive(nodes), agentTotalNodes);
-}
-
-/** Post-completion aggregation: collapse completed tool calls of the same type
- *  across non-consecutive positions when count >= AGGREGATION_MIN_COUNT.
- *  Running events are always shown individually.
- *  Failed events are pinned (shown individually) for FAILED_NEVER_AGGREGATE_MS,
- *  then become eligible for type-based aggregation. */
-export function aggregateByType(displayNodes: DisplayNode[], totalNodeCount?: number): DisplayNode[] {
-  // If agent has fewer than MAX_INDIVIDUAL_NODES total calls, skip aggregation
-  if (totalNodeCount !== undefined && totalNodeCount < MAX_INDIVIDUAL_NODES) {
-    return displayNodes;
-  }
-
-  const now = Date.now();
-  const pinned: DisplayNode[] = [];
-  const candidates: DisplayNode[] = [];
-
-  for (const node of displayNodes) {
-    if (isAggregatedNode(node)) {
-      candidates.push(node);
-    } else {
-      const tn = node as ToolNode;
-      if (tn.status === "running") {
-        pinned.push(node);
-      } else if (tn.status === "failed" && (now - tn.startTime) < FAILED_NEVER_AGGREGATE_MS) {
-        // Failed events within 2 minutes are always pinned individually
-        pinned.push(node);
-      } else {
-        candidates.push(node);
-      }
-    }
-  }
-
-  const byTool = new Map<string, DisplayNode[]>();
-  const ungroupable: DisplayNode[] = [];
-
-  for (const node of candidates) {
-    if (isAggregatedNode(node)) {
-      const key = node.toolName;
-      if (!byTool.has(key)) byTool.set(key, []);
-      byTool.get(key)!.push(node);
-    } else {
-      const tn = node as ToolNode;
-      if (shouldNeverAggregate(tn, now)) {
-        ungroupable.push(node);
-      } else {
-        const key = tn.toolName;
-        if (!byTool.has(key)) byTool.set(key, []);
-        byTool.get(key)!.push(node);
-      }
-    }
-  }
-
-  const aggregated: DisplayNode[] = [];
-  for (const [toolName, group] of byTool) {
-    let totalIndividual = 0;
-    for (const g of group) {
-      totalIndividual += isAggregatedNode(g) ? g.count : 1;
-    }
-
-    if (totalIndividual >= AGGREGATION_MIN_COUNT) {
-      const { children: allChildren, stats } = flattenDisplayNodes(group);
-      aggregated.push(buildAggregatedNode("agg-type", toolName, allChildren, stats));
-    } else {
-      ungroupable.push(...group);
-    }
-  }
-
-  // Pinned (running/failed) first, then ungroupable individuals, then aggregated summaries at bottom
-  return [...pinned, ...ungroupable, ...aggregated];
-}
-
-export function aggregateConsecutive(nodes: ToolNode[]): DisplayNode[] {
-  if (nodes.length === 0) return [];
-
-  const now = Date.now();
-  const result: DisplayNode[] = [];
-  let i = 0;
-
-  while (i < nodes.length) {
-    const current = nodes[i];
-    if (!current) { i++; continue; }
-
-    if (shouldNeverAggregate(current, now) || current.status === "running") {
-      result.push(current);
-      i++;
-      continue;
-    }
-
-    const group: ToolNode[] = [current];
-    let j = i + 1;
-    while (j < nodes.length) {
-      const next = nodes[j];
-      if (!next) break;
-      if (next.toolName !== current.toolName) break;
-      if (shouldNeverAggregate(next, now) || next.status === "running") break;
-      const prev = group[group.length - 1];
-      if (!prev) break;
-      if (Math.abs(next.startTime - prev.startTime) > AGGREGATION_WINDOW_MS) break;
-      group.push(next);
-      j++;
-    }
-
-    if (group.length >= 2) {
-      const stats = computeToolNodeStats(group);
-      result.push(buildAggregatedNode("agg", current.toolName, group, stats));
-      i = j;
-    } else {
-      result.push(current);
-      i++;
-    }
-  }
-
-  return result;
+  walk(nodes);
+  return out;
 }
 
 /* ── Task parsing helpers ──────────────────────────────────────────── */

--- a/web/src/components/live/liveTypes.ts
+++ b/web/src/components/live/liveTypes.ts
@@ -13,26 +13,6 @@ export interface ToolNode {
   children: ToolNode[];
 }
 
-export interface AggregatedNode {
-  type: "aggregate";
-  id: string;
-  toolName: string;
-  count: number;
-  children: ToolNode[];
-  totalDuration: number;
-  totalTokens: number;
-  successCount: number;
-  failCount: number;
-  startTime: number;
-  endTime: number;
-}
-
-export type DisplayNode = ToolNode | AggregatedNode;
-
-export function isAggregatedNode(node: DisplayNode): node is AggregatedNode {
-  return "type" in node && node.type === "aggregate";
-}
-
 export interface AgentActivity {
   name: string;
   state: string;
@@ -90,9 +70,6 @@ export interface RawEvent {
 export const MAX_NODES = 50;
 export const AUTO_COLLAPSE_MS = 30_000;
 export const FLUSH_INTERVAL = 150;
-export const AGGREGATION_WINDOW_MS = 5_000;
-export const FAILED_NEVER_AGGREGATE_MS = 120_000;
-export const MAX_INDIVIDUAL_NODES = 50;
 
 export const TASK_STATUS_MAP: Record<string, TaskItem["status"]> = {
   pending: "pending",

--- a/web/src/hooks/useAgentActivity.ts
+++ b/web/src/hooks/useAgentActivity.ts
@@ -41,6 +41,29 @@ import {
   FLUSH_INTERVAL,
   MAX_NODES,
 } from "../components/live/liveTypes";
+// Close out any still-"running" nodes. Called when an agent's turn or
+// session ends (or its state flips to idle/stopped): without a matching
+// PostToolUse the node would stay "running" forever, leaving a stale
+// frozen snapshot with a ticking elapsed timer (#3267).
+function finalizeRunningNodes(nodes: ToolNode[], endTime: number): ToolNode[] {
+  let changed = false;
+  const result = nodes.map((n) => {
+    const children = n.children.length > 0 ? finalizeRunningNodes(n.children, endTime) : n.children;
+    if (n.status === "running") {
+      changed = true;
+      return { ...n, children, status: "completed" as const, endTime };
+    }
+    if (children !== n.children) {
+      changed = true;
+      return { ...n, children };
+    }
+    return n;
+  });
+  return changed ? result : nodes;
+}
+
+const TERMINAL_STATES = new Set(["idle", "stopped", "done", "error"]);
+
 import {
   findLastIdx,
   nextId,
@@ -373,9 +396,12 @@ export function useAgentActivity(agentName?: string): {
             });
             break;
 
-          case "SessionStart": activity.state = "idle"; break;
-          case "SessionEnd": case "Stop": activity.state = "idle"; break;
-          case "TaskCompleted": activity.state = "idle"; break;
+          case "SessionStart": case "SessionEnd": case "Stop": case "TaskCompleted":
+            // Turn/session boundary: whatever was still "running" is over.
+            activity.state = "idle";
+            activity.nodes = finalizeRunningNodes(activity.nodes, Date.now());
+            activity.activeSubagentIdx = undefined;
+            break;
         }
 
         if (activity.nodes.length > MAX_NODES) {
@@ -443,6 +469,12 @@ export function useAgentActivity(agentName?: string): {
           const updates: Partial<AgentActivity> = { state, lastEventTime: Date.now() };
           if (d.task) updates.task = d.task as string;
           if (d.role) updates.role = d.role as string;
+          // Agent went idle/stopped: age out stale "running" rows so the
+          // stream shows the real last events, not a frozen snapshot.
+          if (TERMINAL_STATES.has(state)) {
+            updates.nodes = finalizeRunningNodes(existing.nodes, Date.now());
+            updates.activeSubagentIdx = undefined;
+          }
           next.set(name, { ...existing, ...updates });
         }
         return next;

--- a/web/src/views/Live.tsx
+++ b/web/src/views/Live.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAgentActivity } from "../hooks/useAgentActivity";
 import { EmptyState } from "../components/EmptyState";
 import type { FilterType } from "../components/live/liveTypes";
-import { nodeMatchesSearch } from "../components/live/liveHelpers";
+import { flattenNodes, nodeMatchesSearch } from "../components/live/liveHelpers";
 import { AgentCard, AgentDrillDown } from "../components/live/LiveRenderers";
 
 import { useHeaderSlot } from "../context/HeaderSlotContext";
@@ -201,7 +201,7 @@ export function Live() {
           const q = searchFilter.toLowerCase();
           const cardHay = `${a.name} ${a.role} ${a.task} ${a.tool}`.toLowerCase();
           if (cardHay.includes(q)) return true;
-          const hasMatchingNode = a.nodes.some((n) => nodeMatchesSearch(n, q));
+          const hasMatchingNode = flattenNodes(a.nodes).some((n) => nodeMatchesSearch(n, q));
           if (!hasMatchingNode) return false;
         }
         return true;
@@ -534,7 +534,6 @@ export function Live() {
                 isFilterActive={false}
                 searchTerm={searchFilter}
                 typeFilter={typeFilter}
-                isPaused={paused}
               />
             </div>
           ))


### PR DESCRIPTION
## What

Iteration 2 on the Live page, consolidating three rounds of direct feedback: the per-agent event area now uses the agent-detail hook-stream UI (the pattern the user called out as better).

- **Flat, newest-at-top, stable**: sorted purely by start time with stable keys and no position animation — the old comparator ordered completed calls by *duration*, so rows reshuffled on every status flip
- **×N aggregation buckets gone** (Bash ×184 etc.), subagent children flattened into the stream; 30-row cap with 'view all in agent →'
- **Emoji icons → 12 monochrome SVG glyphs** (terminal/pencil/book/branch/globe/…), status colored via tokens
- **Rich summaries from the hook JSON**: Bash → command description, Read/Write/Edit → path (basename emphasized), Task → subagent description, WebFetch/WebSearch → hostname/query, MCP → server chip + function, lifecycle → human phrasing, errors lead in red — each row expandable to raw Input/Output/Error JSON
- **Staleness fixed** in useAgentActivity: running nodes finalize on SessionEnd/Stop/state-change — no more frozen snapshots with eternally ticking timers on idle agents

Shared `EventRow` component now renders both Live cards and the agent-detail drill-down, so the two surfaces stay visually identical.

## Verification
lint clean · 118/118 web tests (new EventRow suite included) · production build green · tokens only, all three themes

Closes #3267, part of the #3264 epic and the held v0.3.9 batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)