### PR TITLE
refactor(db): per-workspace database registry — one DB per workspace

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/rpuneet/mycel/pkg/agent"
+	"github.com/rpuneet/mycel/pkg/db"
 	"github.com/rpuneet/mycel/pkg/events"
 	"github.com/rpuneet/mycel/pkg/ui"
 	"github.com/rpuneet/mycel/pkg/workspace"
@@ -422,7 +423,12 @@ func TestColorStateStr_Default(t *testing.T) {
 // seedEvents writes events to the workspace state.db SQLite database.
 func seedEvents(t *testing.T, wsDir string, evts []events.Event) {
 	t.Helper()
-	evtLog, err := events.NewSQLiteLog(filepath.Join(wsDir, ".bc", "state.db"))
+	d, _, err := db.ForWorkspace(wsDir, nil)
+	if err != nil {
+		t.Fatalf("failed to open workspace db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.CloseWorkspaceDB(wsDir) })
+	evtLog, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("failed to open event log: %v", err)
 	}
@@ -697,7 +703,12 @@ func TestReportDoneInWorkspace(t *testing.T) {
 	}
 
 	// Verify event was logged
-	evtLog, err := events.NewSQLiteLog(filepath.Join(wsDir, ".bc", "state.db"))
+	d, _, err := db.ForWorkspace(wsDir, nil)
+	if err != nil {
+		t.Fatalf("failed to open workspace db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.CloseWorkspaceDB(wsDir) })
+	evtLog, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("failed to open event log: %v", err)
 	}

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -99,7 +99,7 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		fmt.Println()
 		fmt.Println(ui.YellowText("⚠") + " No workspace found — running tools check only")
 		fmt.Println()
-		cat := doctor.CheckTools(ctx)
+		cat := doctor.CheckTools(ctx, nil)
 		printCategory(cat)
 		fmt.Println()
 		return nil
@@ -147,7 +147,7 @@ func runDoctorCheck(cmd *cobra.Command, args []string) error {
 
 	var cat *doctor.CategoryReport
 	if wsErr != nil {
-		c := doctor.CheckTools(ctx)
+		c := doctor.CheckTools(ctx, nil)
 		cat = &c
 	} else {
 		cat = doctor.CategoryByName(ctx, ws, name)

--- a/internal/cmd/logs_test.go
+++ b/internal/cmd/logs_test.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"encoding/json"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/spf13/pflag"
 
+	"github.com/rpuneet/mycel/pkg/db"
 	"github.com/rpuneet/mycel/pkg/events"
 	"github.com/rpuneet/mycel/pkg/ui"
 	"github.com/rpuneet/mycel/pkg/workspace"
@@ -47,7 +47,12 @@ func setupLogsWorkspace(t *testing.T) (string, func()) {
 // seedLogsEvents writes events to the workspace state.db SQLite database.
 func seedLogsEvents(t *testing.T, wsDir string, evts []events.Event) {
 	t.Helper()
-	evtLog, err := events.NewSQLiteLog(filepath.Join(wsDir, ".bc", "state.db"))
+	d, _, err := db.ForWorkspace(wsDir, nil)
+	if err != nil {
+		t.Fatalf("failed to open workspace db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.CloseWorkspaceDB(wsDir) })
+	evtLog, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("failed to open event log: %v", err)
 	}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -76,33 +76,23 @@ func RunServer(addr, wsRoot, corsOrigin, apiKey string) error {
 		}
 	}
 
-	// Set up shared database connection for all stores.
+	// Per-workspace databases are opened lazily through the pkg/db
+	// registry (BuildWorkspaceServices resolves each workspace's own
+	// connection) — including for a workspace-less boot where repos are
+	// added later via the API. Warm the launch workspace's connection
+	// eagerly so storage problems surface at boot, and close every
+	// registry connection at shutdown.
+	defer bcdb.CloseAllWorkspaceDBs() //nolint:errcheck
 	if ws != nil {
-		var storageCfg *bcdb.StorageSettings
-		if ws.Config != nil {
-			storageCfg = &bcdb.StorageSettings{
-				Default: ws.Config.Storage.Default,
-				SQLite:  bcdb.SQLiteSettings{Path: ws.Config.Storage.SQLite.Path},
-				Timescale: bcdb.TimescaleSettings{
-					Host:     ws.Config.Storage.Timescale.Host,
-					Port:     ws.Config.Storage.Timescale.Port,
-					User:     ws.Config.Storage.Timescale.User,
-					Password: ws.Config.Storage.Timescale.Password,
-					Database: ws.Config.Storage.Timescale.Database,
-				},
-			}
-		}
-		sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDBWithConfig(ws.RootDir, storageCfg)
+		_, driver, dbErr := bcdb.ForWorkspace(ws.RootDir, ws.Config.DBStorageSettings())
 		if dbErr != nil {
-			log.Warn("failed to open shared workspace db", "error", dbErr)
+			log.Warn("failed to open workspace db", "error", dbErr, "workspace", ws.RootDir)
 		} else {
-			bcdb.SetShared(sharedDB, sharedDriver)
-			defer bcdb.CloseShared() //nolint:errcheck
 			configDriver := ""
 			if ws.Config != nil {
 				configDriver = ws.Config.Storage.Default
 			}
-			log.Info("shared database ready", "driver", sharedDriver, "config_driver", configDriver)
+			log.Info("workspace database ready", "driver", driver, "config_driver", configDriver, "workspace", ws.RootDir)
 		}
 	}
 

--- a/internal/cmd/tool.go
+++ b/internal/cmd/tool.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/mycel/pkg/client"
+	"github.com/rpuneet/mycel/pkg/db"
 	"github.com/rpuneet/mycel/pkg/provider"
 	"github.com/rpuneet/mycel/pkg/tool"
 	"github.com/rpuneet/mycel/pkg/ui"
@@ -198,13 +199,18 @@ func completeToolNames(_ *cobra.Command, _ []string, _ string) ([]string, cobra.
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
-// openToolStore opens the tool store for the current workspace.
+// openToolStore opens the tool store for the current workspace, using
+// the per-workspace database registry (works offline, without bcd).
 func openToolStore() (*tool.Store, error) {
 	ws, err := getWorkspace()
 	if err != nil {
 		return nil, errNotInWorkspace(err)
 	}
-	s := tool.NewStore(ws.StateDir())
+	wsDB, driver, dbErr := db.ForWorkspace(ws.RootDir, ws.Config.DBStorageSettings())
+	if dbErr != nil {
+		return nil, fmt.Errorf("failed to open workspace database: %w", dbErr)
+	}
+	s := tool.NewStore(wsDB, driver)
 	if err := s.Open(); err != nil {
 		return nil, fmt.Errorf("failed to open tool store: %w", err)
 	}

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	pkgdb "github.com/rpuneet/mycel/pkg/db"
 	"github.com/rpuneet/mycel/pkg/log"
 	pkgmcp "github.com/rpuneet/mycel/pkg/mcp"
 	"github.com/rpuneet/mycel/pkg/provider"
@@ -157,15 +158,26 @@ func writeMCPJSON(ctx context.Context, workspacePath, agentName string, resolved
 	isDocker := runtimeBackend == "docker"
 	cfg := mcpConfig{MCPServers: make(map[string]mcpServerEntry)}
 
+	// Resolve this workspace's database from the per-workspace registry
+	// (cached when the daemon already opened it with full storage config).
+	wsDB, wsDriver, dbErr := pkgdb.ForWorkspace(workspacePath, nil)
+
 	// Try unified tool store first for MCP server configs, fall back to mcp.Store.
-	toolStore := pkgtool.NewStore(workspaceStateDir(workspacePath))
+	var toolStore *pkgtool.Store
 	var toolStoreOpen bool
-	if openErr := toolStore.Open(); openErr == nil {
-		toolStoreOpen = true
-		defer toolStore.Close() //nolint:errcheck
+	if dbErr == nil {
+		toolStore = pkgtool.NewStore(wsDB, wsDriver)
+		if openErr := toolStore.Open(); openErr == nil {
+			toolStoreOpen = true
+			defer toolStore.Close() //nolint:errcheck
+		}
 	}
 
-	mcpStore, mcpErr := pkgmcp.NewStore(workspacePath)
+	var mcpStore *pkgmcp.Store
+	mcpErr := dbErr
+	if dbErr == nil {
+		mcpStore, mcpErr = pkgmcp.NewStore(wsDB, wsDriver)
+	}
 	if mcpErr != nil && !toolStoreOpen {
 		log.Debug("both tool and MCP stores unavailable", "error", mcpErr)
 		return writeJSONFile(targetDir, ".mcp.json", cfg)
@@ -496,7 +508,11 @@ func validateAgentTools(workspacePath, roleName string) []string {
 	}
 
 	// Check MCP servers from role config — verify definition exists and health check
-	mcpStore, mcpErr := pkgmcp.NewStore(workspacePath)
+	var mcpStore *pkgmcp.Store
+	wsDB, wsDriver, mcpErr := pkgdb.ForWorkspace(workspacePath, nil)
+	if mcpErr == nil {
+		mcpStore, mcpErr = pkgmcp.NewStore(wsDB, wsDriver)
+	}
 	if mcpErr != nil {
 		issues = append(issues, fmt.Sprintf("MCP store unavailable: %v", mcpErr))
 		return issues

--- a/pkg/cost/cost.go
+++ b/pkg/cost/cost.go
@@ -245,16 +245,13 @@ func (s *Store) initSchema(db *sql.DB) error {
 	return nil
 }
 
-// OpenStore opens the cost store using the shared workspace database.
-// Uses the shared driver type to determine the backend (timescale or sqlite).
-func OpenStore(workspacePath string) (*Store, error) {
-	driver := bcdb.SharedDriver()
-	if driver == "timescale" {
-		shared := bcdb.Shared()
-		if shared == nil {
-			return nil, fmt.Errorf("cost store: shared timescale connection is nil")
-		}
-		pg := NewPostgresStore(shared)
+// OpenStore opens the cost store on the given workspace database. The
+// handle is borrowed: callers (typically the per-workspace db registry)
+// own its lifecycle. When d is nil (workspace DB unavailable), the store
+// falls back to a dedicated costs.db under workspacePath.
+func OpenStore(d *bcdb.DB, driver string, workspacePath string) (*Store, error) {
+	if d != nil && driver == "timescale" {
+		pg := NewPostgresStore(d.DB)
 		if schemaErr := pg.InitSchema(); schemaErr != nil {
 			return nil, fmt.Errorf("cost store: init timescale schema: %w", schemaErr)
 		}
@@ -262,28 +259,27 @@ func OpenStore(workspacePath string) (*Store, error) {
 		return &Store{backend: pg}, nil
 	}
 
-	// SQLite via shared DB — fall back to dedicated costs.db if shared DB is unavailable.
-	shared := bcdb.SharedWrapped()
-	if shared == nil {
-		log.Info("cost store: shared DB unavailable, falling back to dedicated costs.db")
+	// SQLite via workspace DB — fall back to dedicated costs.db if unavailable.
+	if d == nil {
+		log.Info("cost store: workspace DB unavailable, falling back to dedicated costs.db")
 		s := NewStore(workspacePath)
 		if err := s.Open(); err != nil {
 			return nil, fmt.Errorf("cost store: open dedicated costs.db: %w", err)
 		}
 		return s, nil
 	}
-	s := &Store{db: shared}
-	if err := s.initSchema(shared.DB); err != nil {
+	s := &Store{db: d}
+	if err := s.initSchema(d.DB); err != nil {
 		return nil, fmt.Errorf("cost store: init sqlite schema: %w", err)
 	}
-	if err := initImporterSchema(shared.DB); err != nil {
+	if err := initImporterSchema(d.DB); err != nil {
 		return nil, fmt.Errorf("cost store: init importer schema: %w", err)
 	}
 	return s, nil
 }
 
-// Close is a no-op — the shared DB is owned by the caller.
-// The Postgres backend also uses the shared connection now.
+// Close is a no-op — the workspace DB is owned by the caller.
+// The Postgres backend also uses the workspace connection.
 func (s *Store) Close() error {
 	return nil
 }

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -6,7 +6,11 @@
 //
 // # Usage
 //
-//	store, err := cron.Open("/path/to/workspace")
+//	wsDB, driver, err := db.ForWorkspace("/path/to/workspace", nil)
+//	if err != nil {
+//	    return err
+//	}
+//	store, err := cron.Open(wsDB, driver)
 //	if err != nil {
 //	    return err
 //	}

--- a/pkg/cron/scheduler_test.go
+++ b/pkg/cron/scheduler_test.go
@@ -18,12 +18,8 @@ func openTestStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
-	store, err := Open("")
+	t.Cleanup(func() { _ = d.Close() })
+	store, err := Open(d, "sqlite")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/pkg/cron/store.go
+++ b/pkg/cron/store.go
@@ -17,27 +17,31 @@ type Store struct {
 	pg *PostgresStore // non-nil when using Postgres via OpenStore
 }
 
-// Open opens the cron store using the shared workspace database.
-// Returns an error if no shared database is available.
-func Open(workspacePath string) (*Store, error) {
-	shared := db.SharedWrapped()
-	if shared == nil {
-		return nil, fmt.Errorf("cron store requires shared database (none available for workspace %s)", workspacePath)
+// Open opens the cron store on the given workspace database. The handle
+// is borrowed: callers (typically the per-workspace db registry) own its
+// lifecycle.
+func Open(d *db.DB, driver string) (*Store, error) {
+	if d == nil {
+		return nil, fmt.Errorf("cron store requires a workspace database (nil handle)")
 	}
 
-	s := &Store{db: shared}
-	if db.SharedDriver() == "timescale" {
+	s := &Store{db: d}
+	if driver == "timescale" {
 		// Use PostgresStore for proper $1 placeholder queries.
-		s.pg = NewPostgresStore(db.Shared())
+		pg := NewPostgresStore(d.DB)
+		if schemaErr := pg.InitSchema(); schemaErr != nil {
+			return nil, fmt.Errorf("init cron schema on timescale: %w", schemaErr)
+		}
+		s.pg = pg
 	} else {
 		if err := s.initSchema(); err != nil {
-			return nil, fmt.Errorf("init cron schema on shared db: %w", err)
+			return nil, fmt.Errorf("init cron schema: %w", err)
 		}
 	}
 	return s, nil
 }
 
-// Close is a no-op — the shared DB is owned by the caller.
+// Close is a no-op — the workspace DB is owned by the caller.
 func (s *Store) Close() error {
 	if s.pg != nil {
 		return s.pg.Close()

--- a/pkg/cron/store_postgres.go
+++ b/pkg/cron/store_postgres.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	bcdb "github.com/rpuneet/mycel/pkg/db"
 	"github.com/rpuneet/mycel/pkg/log"
 )
 
@@ -270,23 +269,3 @@ func (p *PostgresStore) GetLogs(ctx context.Context, jobName string, last int) (
 }
 
 // scanJob, nullStr, nullTime reuse the shared helpers from store.go.
-
-// OpenStore opens the cron store using the shared workspace database.
-// Uses the shared driver type to determine the backend (timescale or sqlite).
-func OpenStore(workspacePath string) (*Store, error) {
-	driver := bcdb.SharedDriver()
-	if driver == "timescale" {
-		shared := bcdb.Shared()
-		if shared == nil {
-			return nil, fmt.Errorf("cron store: shared timescale connection is nil")
-		}
-		pg := NewPostgresStore(shared)
-		if schemaErr := pg.InitSchema(); schemaErr != nil {
-			return nil, fmt.Errorf("cron store: init timescale schema: %w", schemaErr)
-		}
-		log.Debug("cron store: using TimescaleDB backend")
-		return &Store{pg: pg}, nil
-	}
-
-	return Open(workspacePath)
-}

--- a/pkg/cron/store_test.go
+++ b/pkg/cron/store_test.go
@@ -8,23 +8,19 @@ import (
 	"github.com/rpuneet/mycel/pkg/db"
 )
 
-func setupSharedDB(t *testing.T) {
+func setupSharedDB(t *testing.T) *db.DB {
 	t.Helper()
 	dir := t.TempDir()
 	d, err := db.Open(dir + "/bc.db")
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
+	t.Cleanup(func() { _ = d.Close() })
+	return d
 }
 
 func TestStore_AddGetList(t *testing.T) {
-	setupSharedDB(t)
-	store, err := Open("")
+	store, err := Open(setupSharedDB(t), "sqlite")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -85,8 +81,7 @@ func TestStore_AddGetList(t *testing.T) {
 }
 
 func TestStore_SetEnabled(t *testing.T) {
-	setupSharedDB(t)
-	store, err := Open("")
+	store, err := Open(setupSharedDB(t), "sqlite")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -134,8 +129,7 @@ func TestStore_SetEnabled(t *testing.T) {
 }
 
 func TestStore_Delete(t *testing.T) {
-	setupSharedDB(t)
-	store, err := Open("")
+	store, err := Open(setupSharedDB(t), "sqlite")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -168,8 +162,7 @@ func TestStore_Delete(t *testing.T) {
 }
 
 func TestStore_RecordManualTrigger(t *testing.T) {
-	setupSharedDB(t)
-	store, err := Open("")
+	store, err := Open(setupSharedDB(t), "sqlite")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -201,8 +194,7 @@ func TestStore_RecordManualTrigger(t *testing.T) {
 }
 
 func TestStore_GetLogs(t *testing.T) {
-	setupSharedDB(t)
-	store, err := Open("")
+	store, err := Open(setupSharedDB(t), "sqlite")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -152,86 +152,106 @@ func applyPragmas(db *sql.DB, cfg Config) error {
 	return err
 }
 
-// Registry manages multiple named database connections.
-// Use this when you need to share connections across packages.
+// Registry caches one workspace database connection per workspace root.
+//
+// It is the replacement for the old process-global "shared" connection:
+// instead of every store writing into whichever workspace's bc.db the
+// daemon happened to launch with, each workspace root gets its own
+// connection, opened lazily on first use via OpenWorkspaceDBWithConfig
+// (SQLite at BCDBPath(root) by default, or that workspace's own
+// TimescaleDB with SQLite fallback).
+//
+// Lifecycle: connections stay cached for the life of the process even if
+// the workspace's services are evicted for idleness — a cached idle
+// SQLite handle is cheap (max one conn), and keeping it avoids reopen
+// churn plus use-after-close races with other holders of the handle.
+// Stores treat the handle as borrowed and never close it; only
+// CloseWorkspace / Close tear connections down (process shutdown, or
+// tests).
 type Registry struct {
-	dbs   map[string]*DB
-	paths map[string]string // Maps name to path
-	mu    sync.RWMutex
+	entries map[string]*registryEntry
+	mu      sync.Mutex
 }
 
-// NewRegistry creates a new database registry.
+type registryEntry struct {
+	db     *DB
+	driver string // "sqlite" or "timescale"
+}
+
+// NewRegistry creates a new empty database registry.
 func NewRegistry() *Registry {
-	return &Registry{
-		dbs:   make(map[string]*DB),
-		paths: make(map[string]string),
-	}
+	return &Registry{entries: make(map[string]*registryEntry)}
 }
 
-// Register registers a database path with a name.
-// The database is not opened until Get is called.
-func (r *Registry) Register(name, path string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.paths[name] = path
-}
-
-// Get returns a database connection by name, opening it if needed.
-func (r *Registry) Get(name string) (*DB, error) {
-	r.mu.RLock()
-	if db, ok := r.dbs[name]; ok {
-		r.mu.RUnlock()
-		return db, nil
-	}
-	r.mu.RUnlock()
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	// Double-check after acquiring write lock
-	if db, ok := r.dbs[name]; ok {
-		return db, nil
-	}
-
-	path, ok := r.paths[name]
-	if !ok {
-		return nil, fmt.Errorf("database %q not registered", name)
-	}
-
-	db, err := Open(path)
+// registryKey normalizes a workspace root into a stable map key.
+func registryKey(root string) (string, error) {
+	abs, err := filepath.Abs(root)
 	if err != nil {
-		return nil, fmt.Errorf("open database %q: %w", name, err)
+		return "", fmt.Errorf("resolve workspace root %q: %w", root, err)
 	}
-
-	r.dbs[name] = db
-	return db, nil
+	return filepath.Clean(abs), nil
 }
 
-// Close closes all open database connections.
+// Get returns the database connection for the workspace rooted at root,
+// opening (and caching) it on first use. cfg is only consulted on the
+// first open for a given root; later calls return the cached handle and
+// its driver regardless of cfg.
+//
+// The lock is held across the open so concurrent callers for the same
+// root can never race two connections into existence.
+func (r *Registry) Get(root string, cfg *StorageSettings) (*DB, string, error) {
+	key, err := registryKey(root)
+	if err != nil {
+		return nil, "", err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if e, ok := r.entries[key]; ok {
+		return e.db, e.driver, nil
+	}
+
+	sqlDB, driver, err := OpenWorkspaceDBWithConfig(root, cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("open workspace db %s: %w", root, err)
+	}
+
+	e := &registryEntry{db: &DB{DB: sqlDB}, driver: driver}
+	r.entries[key] = e
+	return e.db, e.driver, nil
+}
+
+// CloseWorkspace closes and evicts the cached connection for root, if
+// any. A subsequent Get reopens it.
+func (r *Registry) CloseWorkspace(root string) error {
+	key, err := registryKey(root)
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	e, ok := r.entries[key]
+	if !ok {
+		return nil // not open
+	}
+	delete(r.entries, key)
+	return e.db.Close()
+}
+
+// Close closes all cached connections and empties the registry.
 func (r *Registry) Close() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	var firstErr error
-	for name, db := range r.dbs {
-		if err := db.Close(); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("close database %q: %w", name, err)
+	for key, e := range r.entries {
+		if err := e.db.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close workspace db %q: %w", key, err)
 		}
 	}
-	r.dbs = make(map[string]*DB)
+	r.entries = make(map[string]*registryEntry)
 	return firstErr
-}
-
-// CloseOne closes a specific database connection by name.
-func (r *Registry) CloseOne(name string) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	db, ok := r.dbs[name]
-	if !ok {
-		return nil // Not open
-	}
-
-	delete(r.dbs, name)
-	return db.Close()
 }

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -87,54 +87,53 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestRegistry(t *testing.T) {
-	t.Run("register and get", func(t *testing.T) {
+	t.Run("get opens lazily and caches", func(t *testing.T) {
 		dir := t.TempDir()
 		registry := NewRegistry()
 		t.Cleanup(func() { _ = registry.Close() })
 
-		dbPath := filepath.Join(dir, "test.db")
-		registry.Register("test", dbPath)
-
-		db, err := registry.Get("test")
+		d, driver, err := registry.Get(dir, nil)
 		if err != nil {
 			t.Fatalf("Get() error = %v", err)
 		}
+		if driver != "sqlite" {
+			t.Errorf("driver = %q, want sqlite", driver)
+		}
 
 		// Verify same instance is returned
-		db2, err := registry.Get("test")
+		d2, _, err := registry.Get(dir, nil)
 		if err != nil {
 			t.Fatalf("Get() second call error = %v", err)
 		}
-
-		if db != db2 {
+		if d != d2 {
 			t.Error("expected same database instance")
 		}
 	})
 
-	t.Run("get unregistered returns error", func(t *testing.T) {
+	t.Run("distinct roots open distinct connections", func(t *testing.T) {
 		registry := NewRegistry()
 		t.Cleanup(func() { _ = registry.Close() })
 
-		_, err := registry.Get("nonexistent")
-		if err == nil {
-			t.Error("expected error for unregistered database")
+		dA, _, err := registry.Get(t.TempDir(), nil)
+		if err != nil {
+			t.Fatalf("Get(A) error = %v", err)
+		}
+		dB, _, err := registry.Get(t.TempDir(), nil)
+		if err != nil {
+			t.Fatalf("Get(B) error = %v", err)
+		}
+		if dA == dB {
+			t.Error("expected distinct connections for distinct roots")
 		}
 	})
 
 	t.Run("close all", func(t *testing.T) {
-		dir := t.TempDir()
 		registry := NewRegistry()
 
-		registry.Register("db1", filepath.Join(dir, "db1.db"))
-		registry.Register("db2", filepath.Join(dir, "db2.db"))
-
-		// Open both
-		_, err := registry.Get("db1")
-		if err != nil {
+		if _, _, err := registry.Get(t.TempDir(), nil); err != nil {
 			t.Fatalf("Get(db1) error = %v", err)
 		}
-		_, err = registry.Get("db2")
-		if err != nil {
+		if _, _, err := registry.Get(t.TempDir(), nil); err != nil {
 			t.Fatalf("Get(db2) error = %v", err)
 		}
 
@@ -144,39 +143,32 @@ func TestRegistry(t *testing.T) {
 		}
 	})
 
-	t.Run("close one", func(t *testing.T) {
+	t.Run("close workspace then reopen", func(t *testing.T) {
 		dir := t.TempDir()
 		registry := NewRegistry()
 		t.Cleanup(func() { _ = registry.Close() })
 
-		registry.Register("test", filepath.Join(dir, "test.db"))
-
-		_, err := registry.Get("test")
-		if err != nil {
+		if _, _, err := registry.Get(dir, nil); err != nil {
 			t.Fatalf("Get() error = %v", err)
 		}
 
-		closeErr := registry.CloseOne("test")
-		if closeErr != nil {
-			t.Errorf("CloseOne() error = %v", closeErr)
+		if closeErr := registry.CloseWorkspace(dir); closeErr != nil {
+			t.Errorf("CloseWorkspace() error = %v", closeErr)
 		}
 
 		// Getting again should reopen
-		_, err = registry.Get("test")
-		if err != nil {
-			t.Errorf("Get() after CloseOne error = %v", err)
+		if _, _, err := registry.Get(dir, nil); err != nil {
+			t.Errorf("Get() after CloseWorkspace error = %v", err)
 		}
 	})
 
-	t.Run("close one not open is no-op", func(t *testing.T) {
+	t.Run("close workspace not open is no-op", func(t *testing.T) {
 		registry := NewRegistry()
 		t.Cleanup(func() { _ = registry.Close() })
 
-		registry.Register("test", "/tmp/test.db")
-
 		// Close without opening - should not error
-		if err := registry.CloseOne("test"); err != nil {
-			t.Errorf("CloseOne() error = %v", err)
+		if err := registry.CloseWorkspace(t.TempDir()); err != nil {
+			t.Errorf("CloseWorkspace() error = %v", err)
 		}
 	})
 }

--- a/pkg/db/storage_integration_test.go
+++ b/pkg/db/storage_integration_test.go
@@ -13,106 +13,202 @@ import (
 	"github.com/rpuneet/mycel/pkg/db"
 	"github.com/rpuneet/mycel/pkg/events"
 	"github.com/rpuneet/mycel/pkg/mcp"
+	"github.com/rpuneet/mycel/pkg/notify"
 	"github.com/rpuneet/mycel/pkg/tool"
 )
 
-// setupSharedDB opens a temporary SQLite database and sets it as the shared DB.
-// It registers cleanup to reset the shared state after the test.
-func setupSharedDB(t *testing.T) string {
+// setupSharedDB opens a temporary workspace database through the
+// per-workspace registry (the production path) and registers cleanup to
+// close it after the test. Returns the workspace root and the handle.
+func setupSharedDB(t *testing.T) (string, *db.DB) {
 	t.Helper()
 	dir := t.TempDir()
-	dbPath := filepath.Join(dir, "bc.db")
-	d, err := db.Open(dbPath)
+	d, driver, err := db.ForWorkspace(dir, nil)
 	if err != nil {
-		t.Fatalf("open test db: %v", err)
+		t.Fatalf("db.ForWorkspace: %v", err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
-	return dir
+	if driver != "sqlite" {
+		t.Fatalf("driver = %q, want sqlite", driver)
+	}
+	t.Cleanup(func() { _ = db.CloseWorkspaceDB(dir) })
+	return dir, d
 }
 
 // ---------------------------------------------------------------------------
 // 1. Shared DB lifecycle
 // ---------------------------------------------------------------------------
 
-func TestStorageSharedLifecycle(t *testing.T) {
-	t.Run("SetShared and Shared return expected values", func(t *testing.T) {
+func TestStorageRegistryLifecycle(t *testing.T) {
+	t.Run("same root twice returns the same handle", func(t *testing.T) {
+		reg := db.NewRegistry()
+		t.Cleanup(func() { _ = reg.Close() })
+
 		dir := t.TempDir()
-		d, err := db.Open(filepath.Join(dir, "lifecycle.db"))
+		d1, driver1, err := reg.Get(dir, nil)
 		if err != nil {
-			t.Fatalf("open: %v", err)
+			t.Fatalf("Get: %v", err)
 		}
-		defer func() { _ = d.Close() }()
-
-		// Before setting, should be nil.
-		db.SetShared(nil, "")
-		if got := db.Shared(); got != nil {
-			t.Error("expected Shared() to be nil before SetShared")
+		if driver1 != "sqlite" {
+			t.Errorf("driver = %q, want sqlite", driver1)
 		}
-
-		db.SetShared(d.DB, "sqlite")
-		defer db.SetShared(nil, "")
-
-		if got := db.Shared(); got == nil {
-			t.Fatal("expected Shared() to be non-nil after SetShared")
+		d2, _, err := reg.Get(dir, nil)
+		if err != nil {
+			t.Fatalf("Get (second): %v", err)
 		}
-		if got := db.SharedDriver(); got != "sqlite" {
-			t.Errorf("SharedDriver() = %q, want %q", got, "sqlite")
+		if d1 != d2 {
+			t.Error("expected the cached handle on second Get")
 		}
 	})
 
-	t.Run("SharedWrapped returns nil when no shared DB", func(t *testing.T) {
-		db.SetShared(nil, "")
-		if got := db.SharedWrapped(); got != nil {
-			t.Error("expected SharedWrapped() to return nil when no shared DB")
+	t.Run("different roots get isolated databases", func(t *testing.T) {
+		reg := db.NewRegistry()
+		t.Cleanup(func() { _ = reg.Close() })
+
+		dirA, dirB := t.TempDir(), t.TempDir()
+		dA, _, err := reg.Get(dirA, nil)
+		if err != nil {
+			t.Fatalf("Get A: %v", err)
+		}
+		dB, _, err := reg.Get(dirB, nil)
+		if err != nil {
+			t.Fatalf("Get B: %v", err)
+		}
+		if dA == dB {
+			t.Fatal("expected distinct handles for distinct workspace roots")
+		}
+
+		ctx := context.Background()
+		if _, execErr := dA.ExecContext(ctx, "CREATE TABLE reg_probe (id INTEGER)"); execErr != nil {
+			t.Fatalf("create probe table in A: %v", execErr)
+		}
+		var n int
+		err = dB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='reg_probe'").Scan(&n)
+		if err != nil {
+			t.Fatalf("query B: %v", err)
+		}
+		if n != 0 {
+			t.Error("table created in workspace A leaked into workspace B's database")
 		}
 	})
 
-	t.Run("SharedWrapped returns wrapper when shared DB set", func(t *testing.T) {
+	t.Run("CloseWorkspace evicts and Get reopens", func(t *testing.T) {
+		reg := db.NewRegistry()
+		t.Cleanup(func() { _ = reg.Close() })
+
 		dir := t.TempDir()
-		d, err := db.Open(filepath.Join(dir, "wrapped.db"))
+		d1, _, err := reg.Get(dir, nil)
 		if err != nil {
-			t.Fatalf("open: %v", err)
+			t.Fatalf("Get: %v", err)
 		}
-		defer func() { _ = d.Close() }()
-
-		db.SetShared(d.DB, "sqlite")
-		defer db.SetShared(nil, "")
-
-		wrapped := db.SharedWrapped()
-		if wrapped == nil {
-			t.Fatal("expected SharedWrapped() to return non-nil")
+		if closeErr := reg.CloseWorkspace(dir); closeErr != nil {
+			t.Fatalf("CloseWorkspace: %v", closeErr)
 		}
-		if wrapped.DB != d.DB {
-			t.Error("wrapped.DB should point to the same *sql.DB")
+		if pingErr := d1.Ping(); pingErr == nil {
+			t.Error("expected closed handle to fail Ping after CloseWorkspace")
+		}
+		// Closing again is a no-op.
+		if closeErr := reg.CloseWorkspace(dir); closeErr != nil {
+			t.Errorf("second CloseWorkspace: %v", closeErr)
+		}
+
+		d2, _, err := reg.Get(dir, nil)
+		if err != nil {
+			t.Fatalf("Get after CloseWorkspace: %v", err)
+		}
+		if pingErr := d2.Ping(); pingErr != nil {
+			t.Errorf("reopened handle Ping: %v", pingErr)
 		}
 	})
 
-	t.Run("CloseShared cleans up", func(t *testing.T) {
-		dir := t.TempDir()
-		d, err := db.Open(filepath.Join(dir, "closeshared.db"))
+	t.Run("Close closes everything", func(t *testing.T) {
+		reg := db.NewRegistry()
+		dirA, dirB := t.TempDir(), t.TempDir()
+		dA, _, err := reg.Get(dirA, nil)
 		if err != nil {
-			t.Fatalf("open: %v", err)
+			t.Fatalf("Get A: %v", err)
 		}
-
-		db.SetShared(d.DB, "sqlite")
-
-		if err := db.CloseShared(); err != nil {
-			t.Fatalf("CloseShared() error: %v", err)
+		dB, _, err := reg.Get(dirB, nil)
+		if err != nil {
+			t.Fatalf("Get B: %v", err)
 		}
-
-		if got := db.Shared(); got != nil {
-			t.Error("expected Shared() to be nil after CloseShared")
+		if err := reg.Close(); err != nil {
+			t.Fatalf("Close: %v", err)
 		}
-
-		// Calling CloseShared again should be a no-op.
-		if err := db.CloseShared(); err != nil {
-			t.Errorf("second CloseShared() error: %v", err)
+		if dA.Ping() == nil || dB.Ping() == nil {
+			t.Error("expected all handles closed after registry Close")
 		}
 	})
+}
+
+// TestStorageWorkspaceIsolation is the multi-workspace bleed regression
+// test for issue #3238: stores built for two workspaces in the same
+// process must land in each workspace's own database. Notify
+// subscriptions were the observable symptom (workspace B's Slack
+// subscriptions showed up in workspace A).
+func TestStorageWorkspaceIsolation(t *testing.T) {
+	ctx := context.Background()
+
+	wsA, wsB := t.TempDir(), t.TempDir()
+	for _, dir := range []string{wsA, wsB} {
+		t.Cleanup(func() { _ = db.CloseWorkspaceDB(dir) })
+	}
+
+	openNotify := func(t *testing.T, root string) *notify.Store {
+		t.Helper()
+		d, driver, err := db.ForWorkspace(root, nil)
+		if err != nil {
+			t.Fatalf("ForWorkspace(%s): %v", root, err)
+		}
+		ns, err := notify.OpenStore(d, driver)
+		if err != nil {
+			t.Fatalf("notify.OpenStore(%s): %v", root, err)
+		}
+		return ns
+	}
+
+	nsA := openNotify(t, wsA)
+	nsB := openNotify(t, wsB)
+
+	tests := []struct {
+		name    string
+		store   *notify.Store
+		other   *notify.Store
+		channel string
+		agent   string
+	}{
+		{"workspace A subscription stays in A", nsA, nsB, "#engineering", "agent-a"},
+		{"workspace B subscription stays in B", nsB, nsA, "#ops", "agent-b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.store.Subscribe(ctx, tt.channel, tt.agent, false); err != nil {
+				t.Fatalf("Subscribe: %v", err)
+			}
+			mine, err := tt.store.Subscribers(ctx, tt.channel)
+			if err != nil {
+				t.Fatalf("Subscribers (own): %v", err)
+			}
+			if len(mine) != 1 || mine[0].Agent != tt.agent {
+				t.Fatalf("own workspace subscribers = %+v, want [%s]", mine, tt.agent)
+			}
+			theirs, err := tt.other.Subscribers(ctx, tt.channel)
+			if err != nil {
+				t.Fatalf("Subscribers (other): %v", err)
+			}
+			if len(theirs) != 0 {
+				t.Errorf("subscription bled into the other workspace: %+v", theirs)
+			}
+		})
+	}
+
+	// The two stores must genuinely sit on different database files.
+	if _, err := os.Stat(filepath.Join(wsA, ".bc", "bc.db")); err != nil {
+		t.Errorf("workspace A bc.db missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wsB, ".bc", "bc.db")); err != nil {
+		t.Errorf("workspace B bc.db missing: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -120,29 +216,30 @@ func TestStorageSharedLifecycle(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestStorageCrossStoreIntegration(t *testing.T) {
-	dir := setupSharedDB(t)
+	dir, d := setupSharedDB(t)
+	_ = dir
 	ctx := context.Background()
 
-	// Initialize all stores against the shared DB.
-	cronStore, err := cron.Open(dir)
+	// Initialize all stores against the workspace DB.
+	cronStore, err := cron.Open(d, "sqlite")
 	if err != nil {
 		t.Fatalf("cron.Open: %v", err)
 	}
 	t.Cleanup(func() { _ = cronStore.Close() })
 
-	mcpStore, err := mcp.NewStore(dir)
+	mcpStore, err := mcp.NewStore(d, "sqlite")
 	if err != nil {
 		t.Fatalf("mcp.NewStore: %v", err)
 	}
 	t.Cleanup(func() { _ = mcpStore.Close() })
 
-	toolStore := tool.NewStore(dir)
+	toolStore := tool.NewStore(d, "sqlite")
 	if openErr := toolStore.Open(); openErr != nil {
 		t.Fatalf("tool.Open: %v", openErr)
 	}
 	t.Cleanup(func() { _ = toolStore.Close() })
 
-	eventsStore, err := events.NewSQLiteLog(filepath.Join(dir, "events.db"))
+	eventsStore, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("events.NewSQLiteLog: %v", err)
 	}
@@ -227,13 +324,9 @@ func TestStorageCrossStoreIntegration(t *testing.T) {
 	_ = toolStore.Close()
 	_ = eventsStore.Close()
 
-	// The shared DB should still be usable after store Close calls.
-	shared := db.Shared()
-	if shared == nil {
-		t.Fatal("shared DB should still be set after store Close calls")
-	}
-	if err := shared.Ping(); err != nil {
-		t.Fatalf("shared DB should still be pingable after store Close calls: %v", err)
+	// The workspace DB should still be usable after store Close calls.
+	if err := d.Ping(); err != nil {
+		t.Fatalf("workspace DB should still be pingable after store Close calls: %v", err)
 	}
 }
 
@@ -242,22 +335,23 @@ func TestStorageCrossStoreIntegration(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestStorageIsolationConcurrent(t *testing.T) {
-	dir := setupSharedDB(t)
+	dir, d := setupSharedDB(t)
+	_ = dir
 	ctx := context.Background()
 
-	cronStore, err := cron.Open(dir)
+	cronStore, err := cron.Open(d, "sqlite")
 	if err != nil {
 		t.Fatalf("cron.Open: %v", err)
 	}
 	t.Cleanup(func() { _ = cronStore.Close() })
 
-	mcpStore, err := mcp.NewStore(dir)
+	mcpStore, err := mcp.NewStore(d, "sqlite")
 	if err != nil {
 		t.Fatalf("mcp.NewStore: %v", err)
 	}
 	t.Cleanup(func() { _ = mcpStore.Close() })
 
-	eventsStore, err := events.NewSQLiteLog(filepath.Join(dir, "events.db"))
+	eventsStore, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("events.NewSQLiteLog: %v", err)
 	}
@@ -477,10 +571,10 @@ func TestStorageConfigValidation(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestStorageCronSmoke(t *testing.T) {
-	dir := setupSharedDB(t)
+	_, d := setupSharedDB(t)
 	ctx := context.Background()
 
-	store, err := cron.Open(dir)
+	store, err := cron.Open(d, "sqlite")
 	if err != nil {
 		t.Fatalf("cron.Open: %v", err)
 	}
@@ -582,9 +676,9 @@ func TestStorageCronSmoke(t *testing.T) {
 }
 
 func TestStorageMCPSmoke(t *testing.T) {
-	dir := setupSharedDB(t)
+	_, d := setupSharedDB(t)
 
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(d, "sqlite")
 	if err != nil {
 		t.Fatalf("mcp.NewStore: %v", err)
 	}
@@ -650,10 +744,10 @@ func TestStorageMCPSmoke(t *testing.T) {
 }
 
 func TestStorageToolSmoke(t *testing.T) {
-	dir := setupSharedDB(t)
+	_, d := setupSharedDB(t)
 	ctx := context.Background()
 
-	store := tool.NewStore(dir)
+	store := tool.NewStore(d, "sqlite")
 	if err := store.Open(); err != nil {
 		t.Fatalf("tool.Open: %v", err)
 	}
@@ -722,9 +816,9 @@ func TestStorageToolSmoke(t *testing.T) {
 }
 
 func TestStorageEventsSmoke(t *testing.T) {
-	dir := setupSharedDB(t)
+	_, d := setupSharedDB(t)
 
-	store, err := events.NewSQLiteLog(filepath.Join(dir, "events.db"))
+	store, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("events.NewSQLiteLog: %v", err)
 	}
@@ -783,24 +877,14 @@ func TestStorageEventsSmoke(t *testing.T) {
 }
 
 func TestStorageChannelSharedDBReady(t *testing.T) {
-	dir := setupSharedDB(t)
+	dir, d := setupSharedDB(t)
 
-	// Channel SQLiteStore opens its own connection to .bc/bc.db.
-	// Verify the shared DB infrastructure is set up correctly for channel use.
-	// Full channel CRUD tests live in pkg/notify/*_test.go.
-	bcDir := filepath.Join(dir, ".bc")
-	if mkErr := os.MkdirAll(bcDir, 0750); mkErr != nil {
-		t.Fatalf("mkdir .bc: %v", mkErr)
+	// Verify the workspace DB infrastructure is set up correctly for
+	// channel use. Full channel CRUD tests live in pkg/notify/*_test.go.
+	if _, err := os.Stat(filepath.Join(dir, ".bc", "bc.db")); err != nil {
+		t.Fatalf("workspace bc.db not created: %v", err)
 	}
-
-	shared := db.Shared()
-	if shared == nil {
-		t.Fatal("Shared() should be non-nil for channel store")
-	}
-	if db.SharedDriver() != "sqlite" {
-		t.Errorf("SharedDriver() = %q, want %q", db.SharedDriver(), "sqlite")
-	}
-	if err := shared.Ping(); err != nil {
-		t.Fatalf("shared.Ping: %v", err)
+	if err := d.Ping(); err != nil {
+		t.Fatalf("workspace db Ping: %v", err)
 	}
 }

--- a/pkg/db/unified.go
+++ b/pkg/db/unified.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"sync"
 
 	"github.com/rpuneet/mycel/pkg/log"
 )
@@ -27,47 +26,31 @@ func BCDBPath(workspaceRoot string) string {
 	return filepath.Join(workspaceRoot, ".bc", "bc.db")
 }
 
-// shared holds the workspace-wide database connection.
-// Set via SetShared() at app startup, used by all stores.
-var (
-	sharedDB     *sql.DB
-	sharedDriver string // "sqlite" or "timescale"
-	sharedMu     sync.RWMutex
-)
+// defaultRegistry is the process-wide per-workspace connection registry.
+// Unlike the old single "shared" connection (which pinned every store to
+// the LAUNCH workspace's bc.db), the registry keys connections by
+// workspace root, so workspace B's stores can never write into
+// workspace A's database.
+var defaultRegistry = NewRegistry()
 
-// SetShared sets the shared workspace database connection.
-// Call once at startup (in cmd/bcd or CLI init).
-func SetShared(db *sql.DB, driver string) {
-	sharedMu.Lock()
-	defer sharedMu.Unlock()
-	sharedDB = db
-	sharedDriver = driver
+// ForWorkspace returns the (lazily opened, cached) database connection
+// and driver ("sqlite" or "timescale") for the workspace rooted at root.
+// cfg is only consulted on the first open for that root; pass nil to use
+// DATABASE_URL / SQLite defaults.
+func ForWorkspace(root string, cfg *StorageSettings) (*DB, string, error) {
+	return defaultRegistry.Get(root, cfg)
 }
 
-// Shared returns the shared workspace database connection.
-// Returns nil if not set (stores should fall back to opening their own).
-func Shared() *sql.DB {
-	sharedMu.RLock()
-	defer sharedMu.RUnlock()
-	return sharedDB
+// CloseWorkspaceDB closes and evicts the cached connection for root from
+// the default registry. A later ForWorkspace reopens it.
+func CloseWorkspaceDB(root string) error {
+	return defaultRegistry.CloseWorkspace(root)
 }
 
-// SharedWrapped returns the shared database as a *DB wrapper.
-// Returns nil if no shared connection is set.
-func SharedWrapped() *DB {
-	sharedMu.RLock()
-	defer sharedMu.RUnlock()
-	if sharedDB == nil {
-		return nil
-	}
-	return &DB{DB: sharedDB}
-}
-
-// SharedDriver returns "sqlite" or "timescale".
-func SharedDriver() string {
-	sharedMu.RLock()
-	defer sharedMu.RUnlock()
-	return sharedDriver
+// CloseAllWorkspaceDBs closes every connection in the default registry.
+// Call at process shutdown.
+func CloseAllWorkspaceDBs() error {
+	return defaultRegistry.Close()
 }
 
 // StorageSettings holds the storage configuration from settings.json.
@@ -171,16 +154,4 @@ func OpenWorkspaceDBWithConfig(workspaceRoot string, cfg *StorageSettings) (*sql
 		return nil, "", fmt.Errorf("open sqlite %s: %w", path, err)
 	}
 	return d.DB, "sqlite", nil
-}
-
-// CloseShared closes the shared connection.
-func CloseShared() error {
-	sharedMu.Lock()
-	defer sharedMu.Unlock()
-	if sharedDB != nil {
-		err := sharedDB.Close()
-		sharedDB = nil
-		return err
-	}
-	return nil
 }

--- a/pkg/doctor/doctor.go
+++ b/pkg/doctor/doctor.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/mattn/go-sqlite3" // SQLite driver
 
 	"github.com/rpuneet/mycel/pkg/agent"
+	"github.com/rpuneet/mycel/pkg/db"
 	"github.com/rpuneet/mycel/pkg/provider"
 	"github.com/rpuneet/mycel/pkg/tool"
 	"github.com/rpuneet/mycel/pkg/workspace"
@@ -138,7 +139,7 @@ func RunAll(ctx context.Context, ws *workspace.Workspace) *Report {
 		CheckWorkspace(ws),
 		CheckDatabase(ctx, ws),
 		CheckAgents(ctx, ws),
-		CheckTools(ctx),
+		CheckTools(ctx, ws),
 		CheckGit(ctx, ws),
 		CheckDaemon(ctx),
 	}
@@ -159,7 +160,7 @@ func CategoryByName(ctx context.Context, ws *workspace.Workspace, name string) *
 		c := CheckAgents(ctx, ws)
 		return &c
 	case "tools", "tool":
-		c := CheckTools(ctx)
+		c := CheckTools(ctx, ws)
 		return &c
 	case "git":
 		c := CheckGit(ctx, ws)
@@ -483,7 +484,9 @@ func CheckAgents(ctx context.Context, ws *workspace.Workspace) CategoryReport {
 // ─── Tools ───────────────────────────────────────────────────────────────────
 
 // CheckTools checks binary installations: tmux, git, registered providers, and env vars.
-func CheckTools(ctx context.Context) CategoryReport {
+// ws may be nil (tools-only check outside a workspace) — the MCP server
+// section is skipped in that case since it needs the workspace database.
+func CheckTools(ctx context.Context, ws *workspace.Workspace) CategoryReport {
 	cat := CategoryReport{Name: "Tools"}
 
 	// Required tools
@@ -519,14 +522,14 @@ func CheckTools(ctx context.Context) CategoryReport {
 		cat.Items = append(cat.Items, item)
 	}
 
-	// Check MCP servers from tool store.
-	// Tool store state lives under the mycel home (~/.mycel).
-	stateDir, homeErr := workspace.MycelHome()
-	if homeErr != nil {
-		return cat
+	// Check MCP servers from the workspace tool store (requires a workspace).
+	var toolStore *tool.Store
+	if ws != nil {
+		if wsDB, wsDriver, dbErr := db.ForWorkspace(ws.RootDir, ws.Config.DBStorageSettings()); dbErr == nil {
+			toolStore = tool.NewStore(wsDB, wsDriver)
+		}
 	}
-	toolStore := tool.NewStore(stateDir)
-	if err := toolStore.Open(); err == nil {
+	if toolStore != nil && toolStore.Open() == nil {
 		defer toolStore.Close() //nolint:errcheck
 		tools, listErr := toolStore.ListWithOptions(ctx, tool.ListOptions{Types: []string{tool.ToolTypeMCP}})
 		if listErr == nil {

--- a/pkg/doctor/doctor_test.go
+++ b/pkg/doctor/doctor_test.go
@@ -404,7 +404,7 @@ func createTestDB(t *testing.T, path string, tables ...string) error {
 
 func TestCheckTools_ReturnsItems(t *testing.T) {
 	ctx := context.Background()
-	cat := CheckTools(ctx)
+	cat := CheckTools(ctx, nil)
 
 	if cat.Name != "Tools" {
 		t.Errorf("category name = %q, want %q", cat.Name, "Tools")
@@ -439,7 +439,7 @@ func TestCheckTools_ReturnsItems(t *testing.T) {
 func TestCheckTools_ANTHROPICAPIKey_Warn(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "")
 	ctx := context.Background()
-	cat := CheckTools(ctx)
+	cat := CheckTools(ctx, nil)
 
 	for _, item := range cat.Items {
 		if item.Name == "ANTHROPIC_API_KEY" {
@@ -455,7 +455,7 @@ func TestCheckTools_ANTHROPICAPIKey_Warn(t *testing.T) {
 func TestCheckTools_ANTHROPICAPIKey_OK(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-1234567890abcdef")
 	ctx := context.Background()
-	cat := CheckTools(ctx)
+	cat := CheckTools(ctx, nil)
 
 	for _, item := range cat.Items {
 		if item.Name == "ANTHROPIC_API_KEY" {

--- a/pkg/events/store_postgres.go
+++ b/pkg/events/store_postgres.go
@@ -176,16 +176,15 @@ func pgNilStr(s string) *string {
 	return &s
 }
 
-// OpenLog opens the event log for the workspace using the shared database.
-// Uses the shared driver type to determine the backend (timescale or sqlite).
-func OpenLog(workspacePath string, dbPath string) (EventStore, error) {
-	driver := bcdb.SharedDriver()
+// OpenLog opens the event log on the given workspace database. The
+// handle is borrowed: callers (typically the per-workspace db registry)
+// own its lifecycle.
+func OpenLog(d *bcdb.DB, driver string) (EventStore, error) {
+	if d == nil {
+		return nil, fmt.Errorf("events store requires a workspace database (nil handle)")
+	}
 	if driver == "timescale" {
-		shared := bcdb.Shared()
-		if shared == nil {
-			return nil, fmt.Errorf("events store: shared timescale connection is nil")
-		}
-		pg := NewPostgresLog(shared)
+		pg := NewPostgresLog(d.DB)
 		if schemaErr := pg.InitSchema(); schemaErr != nil {
 			return nil, fmt.Errorf("events store: init timescale schema: %w", schemaErr)
 		}
@@ -193,6 +192,6 @@ func OpenLog(workspacePath string, dbPath string) (EventStore, error) {
 		return pg, nil
 	}
 
-	// SQLite via shared DB
-	return NewSQLiteLog(dbPath)
+	// SQLite
+	return NewSQLiteLog(d)
 }

--- a/pkg/events/store_sqlite.go
+++ b/pkg/events/store_sqlite.go
@@ -15,12 +15,12 @@ type SQLiteLog struct {
 	db *db.DB
 }
 
-// NewSQLiteLog opens the events table using the shared workspace database.
-// Returns an error if no shared database is available.
-func NewSQLiteLog(dbPath string) (*SQLiteLog, error) {
-	d := db.SharedWrapped()
+// NewSQLiteLog opens the events table on the given workspace database.
+// The handle is borrowed: callers (typically the per-workspace db
+// registry) own its lifecycle.
+func NewSQLiteLog(d *db.DB) (*SQLiteLog, error) {
 	if d == nil {
-		return nil, fmt.Errorf("events store requires shared database (none available, path hint: %s)", dbPath)
+		return nil, fmt.Errorf("events store requires a workspace database (nil handle)")
 	}
 
 	schema := `
@@ -36,7 +36,6 @@ func NewSQLiteLog(dbPath string) (*SQLiteLog, error) {
 		CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp DESC);
 	`
 	if _, err := d.ExecContext(context.Background(), schema); err != nil {
-		_ = d.Close()
 		return nil, fmt.Errorf("create events table: %w", err)
 	}
 

--- a/pkg/events/store_sqlite_test.go
+++ b/pkg/events/store_sqlite_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // setupSharedDB creates a temporary SQLite shared database for tests.
-func setupSharedDB(t *testing.T) {
+func setupSharedDB(t *testing.T) *db.DB {
 	t.Helper()
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "bc.db")
@@ -17,16 +17,12 @@ func setupSharedDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
+	t.Cleanup(func() { _ = d.Close() })
+	return d
 }
 
 func TestSQLiteLog_AppendAndRead(t *testing.T) {
-	setupSharedDB(t)
-	log, err := NewSQLiteLog("unused")
+	log, err := NewSQLiteLog(setupSharedDB(t))
 	if err != nil {
 		t.Fatalf("NewSQLiteLog: %v", err)
 	}
@@ -59,8 +55,7 @@ func TestSQLiteLog_AppendAndRead(t *testing.T) {
 }
 
 func TestSQLiteLog_ReadLast(t *testing.T) {
-	setupSharedDB(t)
-	log, err := NewSQLiteLog("unused")
+	log, err := NewSQLiteLog(setupSharedDB(t))
 	if err != nil {
 		t.Fatalf("NewSQLiteLog: %v", err)
 	}
@@ -89,8 +84,7 @@ func TestSQLiteLog_ReadLast(t *testing.T) {
 }
 
 func TestSQLiteLog_ReadByAgent(t *testing.T) {
-	setupSharedDB(t)
-	log, err := NewSQLiteLog("unused")
+	log, err := NewSQLiteLog(setupSharedDB(t))
 	if err != nil {
 		t.Fatalf("NewSQLiteLog: %v", err)
 	}
@@ -113,8 +107,7 @@ func TestSQLiteLog_ReadByAgent(t *testing.T) {
 // than DefaultReadLimit — the old ORDER BY id ASC froze derived stats like
 // "last active" at the 1000th oldest event (#3259).
 func TestSQLiteLog_ReadByAgent_NewestWindowOldestFirst(t *testing.T) {
-	setupSharedDB(t)
-	log, err := NewSQLiteLog("unused")
+	log, err := NewSQLiteLog(setupSharedDB(t))
 	if err != nil {
 		t.Fatalf("NewSQLiteLog: %v", err)
 	}
@@ -150,8 +143,7 @@ func TestSQLiteLog_ReadByAgent_NewestWindowOldestFirst(t *testing.T) {
 }
 
 func TestSQLiteLog_EventData(t *testing.T) {
-	setupSharedDB(t)
-	log, err := NewSQLiteLog("unused")
+	log, err := NewSQLiteLog(setupSharedDB(t))
 	if err != nil {
 		t.Fatalf("NewSQLiteLog: %v", err)
 	}
@@ -174,8 +166,7 @@ func TestSQLiteLog_EventData(t *testing.T) {
 }
 
 func TestSQLiteLog_ImplementsEventStore(t *testing.T) {
-	setupSharedDB(t)
-	log, err := NewSQLiteLog("unused")
+	log, err := NewSQLiteLog(setupSharedDB(t))
 	if err != nil {
 		t.Fatalf("NewSQLiteLog: %v", err)
 	}

--- a/pkg/mcp/store.go
+++ b/pkg/mcp/store.go
@@ -57,21 +57,25 @@ func (s *Store) SetConfigLookup(fn ConfigLookupFunc) {
 	}
 }
 
-// NewStore creates a new MCP store for the given workspace path.
-// Uses the shared workspace database; returns an error if unavailable.
-func NewStore(workspacePath string) (*Store, error) {
-	shared := db.SharedWrapped()
-	if shared == nil {
-		return nil, fmt.Errorf("mcp store requires shared database (none available for workspace %s)", workspacePath)
+// NewStore creates a new MCP store on the given workspace database. The
+// handle is borrowed: callers (typically the per-workspace db registry)
+// own its lifecycle.
+func NewStore(d *db.DB, driver string) (*Store, error) {
+	if d == nil {
+		return nil, fmt.Errorf("mcp store requires a workspace database (nil handle)")
 	}
 
-	s := &Store{db: shared, shared: true}
-	if db.SharedDriver() == "timescale" {
+	s := &Store{db: d, shared: true}
+	if driver == "timescale" {
 		// Use PostgresStore for proper $1 placeholder queries.
-		s.pg = NewPostgresStore(db.Shared())
+		pg := NewPostgresStore(d.DB)
+		if schemaErr := pg.InitSchema(); schemaErr != nil {
+			return nil, fmt.Errorf("init mcp schema on timescale: %w", schemaErr)
+		}
+		s.pg = pg
 	} else {
 		if err := s.initSchema(); err != nil {
-			return nil, fmt.Errorf("init mcp schema on shared db: %w", err)
+			return nil, fmt.Errorf("init mcp schema: %w", err)
 		}
 	}
 	return s, nil
@@ -100,7 +104,8 @@ func (s *Store) initSchema() error {
 }
 
 // Close closes the database connection.
-// No-op when using shared bc.db — CloseShared() handles that.
+// No-op when using the borrowed workspace DB — its owner (the
+// per-workspace registry) handles closing.
 func (s *Store) Close() error {
 	if s.pg != nil {
 		return s.pg.Close()

--- a/pkg/mcp/store_postgres.go
+++ b/pkg/mcp/store_postgres.go
@@ -7,9 +7,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	bcdb "github.com/rpuneet/mycel/pkg/db"
-	"github.com/rpuneet/mycel/pkg/log"
 )
 
 // PostgresStore provides Postgres-backed MCP server config storage.
@@ -240,25 +237,4 @@ func pgScanMCPInto(sc scanner) (*ServerConfig, error) {
 	}
 
 	return &cfg, nil
-}
-
-// OpenStore opens the MCP store using the shared workspace database.
-// Uses the shared driver type to determine the backend (timescale or sqlite).
-func OpenStore(workspacePath string) (*Store, error) {
-	driver := bcdb.SharedDriver()
-	if driver == "timescale" {
-		shared := bcdb.Shared()
-		if shared == nil {
-			return nil, fmt.Errorf("mcp store: shared timescale connection is nil")
-		}
-		pg := NewPostgresStore(shared)
-		if schemaErr := pg.InitSchema(); schemaErr != nil {
-			return nil, fmt.Errorf("mcp store: init timescale schema: %w", schemaErr)
-		}
-		log.Debug("mcp store: using TimescaleDB backend")
-		return &Store{pg: pg}, nil
-	}
-
-	// SQLite via shared DB
-	return NewStore(workspacePath)
 }

--- a/pkg/mcp/store_test.go
+++ b/pkg/mcp/store_test.go
@@ -15,13 +15,9 @@ func setupTestStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
+	t.Cleanup(func() { _ = d.Close() })
 
-	s, err := NewStore(dir)
+	s, err := NewStore(d, "sqlite")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/notify/api_test.go
+++ b/pkg/notify/api_test.go
@@ -74,12 +74,8 @@ func setupStore(t *testing.T) *notify.Store {
 	if err != nil {
 		t.Fatalf("db.Open: %v", err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
-	store, err := notify.OpenStore("/tmp/test-notify-api")
+	t.Cleanup(func() { _ = d.Close() })
+	store, err := notify.OpenStore(d, "sqlite")
 	if err != nil {
 		t.Fatalf("OpenStore: %v", err)
 	}

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -60,12 +60,8 @@ func setupTestStore(t *testing.T) *Store {
 	if err != nil {
 		t.Fatal(err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
-	store, err := OpenStore("/tmp/test-workspace")
+	t.Cleanup(func() { _ = d.Close() })
+	store, err := OpenStore(d, "sqlite")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -11,27 +11,28 @@ import (
 )
 
 // Store is the SQLite/Postgres-backed persistence layer for subscriptions
-// and the delivery log. Uses the shared workspace database.
+// and the delivery log. It borrows the workspace database handle passed
+// to OpenStore and never closes it.
 type Store struct {
 	db     *db.DB
 	driver string // "sqlite" or "timescale"
 }
 
-// OpenStore opens the notify store using the shared workspace database.
-func OpenStore(workspacePath string) (*Store, error) {
-	shared := db.SharedWrapped()
-	if shared == nil {
-		return nil, fmt.Errorf("notify store requires shared database (none available for workspace %s)", workspacePath)
+// OpenStore opens the notify store on the given workspace database.
+// The handle is borrowed: callers (typically the per-workspace db
+// registry) own its lifecycle.
+func OpenStore(d *db.DB, driver string) (*Store, error) {
+	if d == nil {
+		return nil, fmt.Errorf("notify store requires a workspace database (nil handle)")
 	}
-	driver := db.SharedDriver()
-	s := &Store{db: shared, driver: driver}
+	s := &Store{db: d, driver: driver}
 	if err := s.initSchema(); err != nil {
 		return nil, fmt.Errorf("init notify schema: %w", err)
 	}
 	return s, nil
 }
 
-// Close is a no-op — the shared DB is owned by the caller.
+// Close is a no-op — the workspace DB is owned by the caller.
 func (s *Store) Close() error { return nil }
 
 // q converts ? placeholders to $1, $2, ... for Postgres. No-op for SQLite.

--- a/pkg/secret/store_postgres.go
+++ b/pkg/secret/store_postgres.go
@@ -253,17 +253,13 @@ func findIndex(s, substr string) int {
 	return -1
 }
 
-// OpenStore opens the secrets store using the shared workspace database.
-// Uses the shared driver type to determine the backend (timescale or sqlite).
-// The secret store keeps encryption isolation — its own salt and key derivation.
-func OpenStore(workspacePath, passphrase string) (*Store, error) {
-	driver := bcdb.SharedDriver()
-	if driver == "timescale" {
-		shared := bcdb.Shared()
-		if shared == nil {
-			return nil, fmt.Errorf("secrets store: shared timescale connection is nil")
-		}
-		pg := NewPostgresStore(shared)
+// OpenStore opens the secrets store on the given workspace database.
+// The handle is borrowed: callers own its lifecycle. The secret store
+// keeps encryption isolation — its own salt and key derivation. In
+// SQLite mode it still uses its own file under workspacePath.
+func OpenStore(d *bcdb.DB, driver, workspacePath, passphrase string) (*Store, error) {
+	if d != nil && driver == "timescale" {
+		pg := NewPostgresStore(d.DB)
 		if schemaErr := pg.InitSchema(); schemaErr != nil {
 			return nil, fmt.Errorf("secrets store: init timescale schema: %w", schemaErr)
 		}

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -131,30 +131,35 @@ var builtinCLITools = []Tool{
 
 // Store provides tool management backed by SQLite or TimescaleDB (Postgres).
 type Store struct {
-	db *db.DB
-	pg *PostgresStore // non-nil when using Postgres via OpenStore
+	db     *db.DB
+	pg     *PostgresStore // non-nil when using the timescale driver
+	driver string         // "sqlite" or "timescale"
 }
 
-// NewStore creates a new tool store for the given workspace state directory.
-func NewStore(stateDir string) *Store {
-	return &Store{}
+// NewStore creates a new tool store on the given workspace database. The
+// handle is borrowed: callers (typically the per-workspace db registry)
+// own its lifecycle. Call Open to initialize the schema and seed
+// built-in tools.
+func NewStore(d *db.DB, driver string) *Store {
+	return &Store{db: d, driver: driver}
 }
 
-// Open initializes the database and seeds built-in tools.
-// Uses the shared workspace database; returns an error if unavailable.
+// Open initializes the database schema and seeds built-in tools.
+// Returns an error if the store was constructed without a database.
 func (s *Store) Open() error {
-	shared := db.SharedWrapped()
-	if shared == nil {
-		return fmt.Errorf("tool store requires shared database (none available)")
+	if s.db == nil {
+		return fmt.Errorf("tool store requires a workspace database (nil handle)")
 	}
 
-	s.db = shared
-
-	if db.SharedDriver() == "timescale" {
+	if s.driver == "timescale" {
 		// Use PostgresStore for proper $1 placeholder queries.
-		s.pg = NewPostgresStore(db.Shared())
+		pg := NewPostgresStore(s.db.DB)
+		if err := pg.InitSchema(); err != nil {
+			return fmt.Errorf("failed to initialize timescale schema: %w", err)
+		}
+		s.pg = pg
 	} else {
-		if err := initSchema(shared.DB); err != nil {
+		if err := initSchema(s.db.DB); err != nil {
 			return fmt.Errorf("failed to initialize schema: %w", err)
 		}
 	}
@@ -166,7 +171,7 @@ func (s *Store) Open() error {
 	return nil
 }
 
-// Close is a no-op — the shared DB is owned by the caller.
+// Close is a no-op — the workspace DB is owned by the caller.
 func (s *Store) Close() error {
 	if s.pg != nil {
 		return s.pg.Close()

--- a/pkg/tool/store_postgres.go
+++ b/pkg/tool/store_postgres.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	bcdb "github.com/rpuneet/mycel/pkg/db"
 	"github.com/rpuneet/mycel/pkg/log"
 )
 
@@ -268,32 +267,4 @@ func (p *PostgresStore) SetEnabled(ctx context.Context, name string, enabled boo
 		return fmt.Errorf("tool %q not found", name)
 	}
 	return nil
-}
-
-// OpenStore opens the tool store using the shared workspace database.
-// Uses the shared driver type to determine the backend (timescale or sqlite).
-func OpenStore(stateDir string) (*Store, error) {
-	driver := bcdb.SharedDriver()
-	if driver == "timescale" {
-		shared := bcdb.Shared()
-		if shared == nil {
-			return nil, fmt.Errorf("tool store: shared timescale connection is nil")
-		}
-		pg := NewPostgresStore(shared)
-		if schemaErr := pg.InitSchema(); schemaErr != nil {
-			return nil, fmt.Errorf("tool store: init timescale schema: %w", schemaErr)
-		}
-		if seedErr := pg.SeedBuiltins(context.Background()); seedErr != nil {
-			return nil, fmt.Errorf("tool store: seed builtins: %w", seedErr)
-		}
-		log.Debug("tool store: using TimescaleDB backend")
-		return &Store{pg: pg}, nil
-	}
-
-	// SQLite via shared DB
-	s := NewStore(stateDir)
-	if err := s.Open(); err != nil {
-		return nil, err
-	}
-	return s, nil
 }

--- a/pkg/tool/store_test.go
+++ b/pkg/tool/store_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/rpuneet/mycel/pkg/db"
 )
 
-// setupSharedDB creates a temporary SQLite shared database for tests.
-func setupSharedDB(t *testing.T) {
+// setupSharedDB creates a temporary SQLite workspace database for tests.
+func setupSharedDB(t *testing.T) *db.DB {
 	t.Helper()
 	dir := t.TempDir()
 	dbPath := filepath.Join(dir, "bc.db")
@@ -18,16 +18,12 @@ func setupSharedDB(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open test db: %v", err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
+	t.Cleanup(func() { _ = d.Close() })
+	return d
 }
 
 func TestStore_CRUD(t *testing.T) {
-	setupSharedDB(t)
-	s := NewStore("")
+	s := NewStore(setupSharedDB(t), "sqlite")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -158,11 +154,11 @@ func TestStore_CRUD(t *testing.T) {
 }
 
 func TestStore_SeededOnce(t *testing.T) {
-	setupSharedDB(t)
+	d := setupSharedDB(t)
 
 	// Open twice — built-ins should not duplicate
 	for i := range 2 {
-		s := NewStore("")
+		s := NewStore(d, "sqlite")
 		if err := s.Open(); err != nil {
 			t.Fatalf("Open %d: %v", i, err)
 		}
@@ -187,8 +183,7 @@ func TestStore_SeededOnce(t *testing.T) {
 }
 
 func TestStore_ListOrdering(t *testing.T) {
-	setupSharedDB(t)
-	s := NewStore("")
+	s := NewStore(setupSharedDB(t), "sqlite")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -220,8 +215,7 @@ func TestStore_ListOrdering(t *testing.T) {
 }
 
 func TestStore_RequiredFields(t *testing.T) {
-	setupSharedDB(t)
-	s := NewStore("")
+	s := NewStore(setupSharedDB(t), "sqlite")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -238,16 +232,15 @@ func TestStore_RequiredFields(t *testing.T) {
 }
 
 func TestStore_SharedDBRequired(t *testing.T) {
-	// Without a shared DB, Open should return an error
-	db.SetShared(nil, "")
-	s := NewStore("")
+	// Without a workspace DB handle, Open should return an error
+	s := NewStore(nil, "")
 	if err := s.Open(); err == nil {
-		t.Error("expected error when shared DB is not available")
+		t.Error("expected error when no workspace DB is provided")
 	}
 }
 
 func TestTool_JSONSerialization(t *testing.T) {
-	setupSharedDB(t)
+	d := setupSharedDB(t)
 	original := &Tool{
 		Name:       "test",
 		Command:    "test --yes",
@@ -260,7 +253,7 @@ func TestTool_JSONSerialization(t *testing.T) {
 		CreatedAt:  time.Now().Truncate(time.Second),
 	}
 
-	s := NewStore("")
+	s := NewStore(d, "sqlite")
 	if err := s.Open(); err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/rpuneet/mycel/pkg/db"
 )
 
 // ConfigVersion is the current config schema version.
@@ -108,6 +110,27 @@ type TimescaleStorageConfig struct {
 	Password string `json:"password"`
 	Database string `json:"database"`
 	Port     int    `json:"port"`
+}
+
+// DBStorageSettings converts the workspace storage config into the
+// pkg/db settings shape consumed by the per-workspace connection
+// registry. Returns nil for a nil config so callers can pass it
+// straight to db.ForWorkspace.
+func (c *Config) DBStorageSettings() *db.StorageSettings {
+	if c == nil {
+		return nil
+	}
+	return &db.StorageSettings{
+		Default: c.Storage.Default,
+		SQLite:  db.SQLiteSettings{Path: c.Storage.SQLite.Path},
+		Timescale: db.TimescaleSettings{
+			Host:     c.Storage.Timescale.Host,
+			Port:     c.Storage.Timescale.Port,
+			User:     c.Storage.Timescale.User,
+			Password: c.Storage.Timescale.Password,
+			Database: c.Storage.Timescale.Database,
+		},
+	}
 }
 
 // LogsConfig configures persistent session log streaming.

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -102,7 +102,7 @@ func Init(rootDir string) (*Workspace, error) {
 		return nil, fmt.Errorf("failed to save config: %w", saveErr)
 	}
 
-	rm, closeStore, err := initRoleManager(stateDir)
+	rm, closeStore, err := initRoleManager(stateDir, absRoot, &cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init role manager: %w", err)
 	}
@@ -177,7 +177,7 @@ func Load(rootDir string) (*Workspace, error) {
 		return nil, fmt.Errorf("invalid %s: %w", PreferencesFileName, valErr)
 	}
 
-	rm, closeStore, err := loadRoleManager(stateDir)
+	rm, closeStore, err := loadRoleManager(stateDir, absRoot, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load roles: %w", err)
 	}
@@ -382,16 +382,24 @@ func (w *Workspace) GetRolePrompt(name string) string {
 	return role.Prompt
 }
 
-// openRoleStore creates a RoleStore using the shared database connection.
-// Uses the shared driver type to determine the backend (timescale or sqlite).
-func openRoleStore(stateDir string) (*RoleStore, error) {
-	driver := db.SharedDriver()
-	if driver == "timescale" {
-		shared := db.Shared()
-		if shared == nil {
-			return nil, fmt.Errorf("role store: shared timescale connection is nil")
+// openRoleStore creates a RoleStore for the workspace. When the
+// workspace is configured for TimescaleDB (or DATABASE_URL forces it),
+// the role store shares the per-workspace registry connection; in
+// SQLite mode it keeps its own file at <stateDir>/bc.db.
+func openRoleStore(stateDir, rootDir string, cfg *Config) (*RoleStore, error) {
+	settings := cfg.DBStorageSettings()
+	wantsTimescale := db.IsPostgresEnabled() ||
+		(settings != nil && settings.Default == "timescale")
+	if wantsTimescale {
+		wsDB, driver, err := db.ForWorkspace(rootDir, settings)
+		if err != nil {
+			return nil, fmt.Errorf("role store: open workspace db: %w", err)
 		}
-		return NewRoleStoreFromDB(shared, "timescale")
+		if driver == "timescale" {
+			return NewRoleStoreFromDB(wsDB.DB, "timescale")
+		}
+		// Timescale unreachable — the registry fell back to SQLite;
+		// keep roles in the local role db below as before.
 	}
 
 	dbPath := filepath.Join(stateDir, "bc.db")
@@ -401,8 +409,8 @@ func openRoleStore(stateDir string) (*RoleStore, error) {
 // initRoleManager creates a role manager with SQL store for workspace Init.
 // It creates the store, migrates defaults, and migrates any legacy filesystem
 // roles. Returns the manager plus a close function for the store.
-func initRoleManager(stateDir string) (*RoleManager, func() error, error) {
-	store, err := openRoleStore(stateDir)
+func initRoleManager(stateDir, rootDir string, cfg *Config) (*RoleManager, func() error, error) {
+	store, err := openRoleStore(stateDir, rootDir, cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open role store: %w", err)
 	}
@@ -434,8 +442,8 @@ func initRoleManager(stateDir string) (*RoleManager, func() error, error) {
 // loadRoleManager creates a role manager with SQL store for workspace Load.
 // It opens the store, migrates any new filesystem files, and loads all roles
 // into the cache.
-func loadRoleManager(stateDir string) (*RoleManager, func() error, error) {
-	store, err := openRoleStore(stateDir)
+func loadRoleManager(stateDir, rootDir string, cfg *Config) (*RoleManager, func() error, error) {
+	store, err := openRoleStore(stateDir, rootDir, cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open role store: %w", err)
 	}

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -106,21 +106,31 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 	// "not available".
 	degraded := map[string]string{}
 
+	// Per-workspace database: resolved from the process-wide registry so
+	// each workspace's stores land in that workspace's own bc.db (or its
+	// own TimescaleDB), never in the launch workspace's. The handle is
+	// cached in the registry and stays open across service eviction;
+	// stores borrow it and never close it.
+	wsDB, wsDriver, dbErr := bcdb.ForWorkspace(ws.RootDir, ws.Config.DBStorageSettings())
+	if dbErr != nil {
+		log.Warn("workspace database unavailable", "error", dbErr, "workspace", ws.RootDir)
+		degraded["storage"] = "workspace database unavailable: " + dbErr.Error()
+	}
+
 	// Storage driver mismatch: pkg/db falls back to SQLite when the
 	// configured TimescaleDB is unreachable (db.OpenWorkspaceDBWithConfig
 	// logs "falling back to sqlite"). Compare the configured default
 	// against the driver actually in use so the mismatch is visible.
-	if ws.Config != nil {
+	if ws.Config != nil && dbErr == nil {
 		configured := ws.Config.Storage.Default
-		if configured == "timescale" || configured == "sql" {
-			if active := bcdb.SharedDriver(); active != "timescale" {
-				if active == "" {
-					active = "none"
-				}
-				degraded["storage"] = fmt.Sprintf(
-					"configured %s database is not active (running on %s) — timescale unreachable, data is going to the fallback store and will not sync back",
-					configured, active)
+		if (configured == "timescale" || configured == "sql") && wsDriver != "timescale" {
+			active := wsDriver
+			if active == "" {
+				active = "none"
 			}
+			degraded["storage"] = fmt.Sprintf(
+				"configured %s database is not active (running on %s) — timescale unreachable, data is going to the fallback store and will not sync back",
+				configured, active)
 		}
 	}
 
@@ -187,7 +197,7 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 			defer wg.Done()
 			runCostImportLoop(svcCtx, costImporter)
 		}()
-	} else if cs, err := cost.OpenStore(ws.RootDir); err != nil {
+	} else if cs, err := cost.OpenStore(wsDB, wsDriver, ws.RootDir); err != nil {
 		log.Warn("cost store unavailable", "error", err, "workspace", ws.RootDir)
 		degraded["costs"] = "cost store unavailable: " + err.Error()
 	} else {
@@ -212,7 +222,7 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 	// Cron store + scheduler.
 	var cronStore *cron.Store
 	var cronSched *cron.Scheduler
-	if cr, err := cron.Open(ws.RootDir); err != nil {
+	if cr, err := cron.Open(wsDB, wsDriver); err != nil {
 		log.Warn("cron store unavailable", "error", err, "workspace", ws.RootDir)
 		degraded["cron"] = "cron store unavailable: " + err.Error()
 	} else {
@@ -251,7 +261,7 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 
 	// MCP store.
 	var mcpStore *bcmcp.Store
-	if ms, err := bcmcp.NewStore(ws.RootDir); err != nil {
+	if ms, err := bcmcp.NewStore(wsDB, wsDriver); err != nil {
 		log.Warn("mcp store unavailable", "error", err, "workspace", ws.RootDir)
 		degraded["mcp"] = "mcp store unavailable: " + err.Error()
 	} else {
@@ -262,7 +272,7 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 	// Tool store.
 	var toolStore *bctool.Store
 	{
-		ts := bctool.NewStore(ws.StateDir())
+		ts := bctool.NewStore(wsDB, wsDriver)
 		if err := ts.Open(); err != nil {
 			log.Warn("tool store unavailable", "error", err, "workspace", ws.RootDir)
 			degraded["tools"] = "tool store unavailable: " + err.Error()
@@ -286,7 +296,7 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 
 	// Event log (SQLite) + pruning loop.
 	var eventLog bcevents.EventStore
-	if el, err := bcevents.OpenLog(ws.RootDir, filepath.Join(ws.StateDir(), "state.db")); err != nil {
+	if el, err := bcevents.OpenLog(wsDB, wsDriver); err != nil {
 		log.Warn("event log unavailable", "error", err, "workspace", ws.RootDir)
 		degraded["events"] = "event log unavailable: " + err.Error()
 	} else {
@@ -313,7 +323,7 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 
 	// Notify service (channel subscriptions + delivery).
 	var notifyService *bcnotify.Service
-	if ns, err := bcnotify.OpenStore(ws.RootDir); err != nil {
+	if ns, err := bcnotify.OpenStore(wsDB, wsDriver); err != nil {
 		log.Warn("notify store unavailable", "error", err, "workspace", ws.RootDir)
 		degraded["notify"] = "notify store unavailable: " + err.Error()
 	} else {

--- a/server/build_services_db_test.go
+++ b/server/build_services_db_test.go
@@ -1,0 +1,121 @@
+// build_services_db_test.go — issue #3238: per-workspace databases.
+//
+// BuildWorkspaceServices must resolve each workspace's OWN database from
+// the pkg/db registry so stores for workspace B never write into
+// workspace A's bc.db, and a workspace-less daemon boot must be able to
+// add a repo later and get a fully-online service bundle (lazy open).
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	bcdb "github.com/rpuneet/mycel/pkg/db"
+)
+
+// TestBuildWorkspaceServices_NotifyIsolation is the multi-workspace
+// bleed regression test at the factory level: two workspaces built in
+// the same process must keep notify subscriptions (and everything else
+// in bc.db) fully isolated.
+func TestBuildWorkspaceServices_NotifyIsolation(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	t.Setenv("BC_SECRET_PASSPHRASE", "unit-test")
+	ctx := context.Background()
+
+	wsA, wsB := t.TempDir(), t.TempDir()
+	gitInitDir(t, wsA)
+	gitInitDir(t, wsB)
+	t.Cleanup(func() {
+		_ = bcdb.CloseWorkspaceDB(wsA)
+		_ = bcdb.CloseWorkspaceDB(wsB)
+	})
+
+	svcA, err := BuildWorkspaceServices(ctx, &Globals{}, wsA)
+	if err != nil {
+		t.Fatalf("build A: %v", err)
+	}
+	defer svcA.Close() //nolint:errcheck
+	svcB, err := BuildWorkspaceServices(ctx, &Globals{}, wsB)
+	if err != nil {
+		t.Fatalf("build B: %v", err)
+	}
+	defer svcB.Close() //nolint:errcheck
+
+	if svcA.Notify == nil || svcB.Notify == nil {
+		t.Fatalf("notify services must be online (degraded A=%v B=%v)",
+			svcA.Degraded, svcB.Degraded)
+	}
+
+	if subErr := svcA.Notify.Store().Subscribe(ctx, "#engineering", "agent-a", false); subErr != nil {
+		t.Fatalf("subscribe in A: %v", subErr)
+	}
+
+	subsA, err := svcA.Notify.Store().Subscribers(ctx, "#engineering")
+	if err != nil {
+		t.Fatalf("subscribers A: %v", err)
+	}
+	if len(subsA) != 1 || subsA[0].Agent != "agent-a" {
+		t.Fatalf("workspace A subscribers = %+v, want [agent-a]", subsA)
+	}
+
+	subsB, err := svcB.Notify.Store().Subscribers(ctx, "#engineering")
+	if err != nil {
+		t.Fatalf("subscribers B: %v", err)
+	}
+	if len(subsB) != 0 {
+		t.Errorf("workspace A's subscription bled into workspace B: %+v", subsB)
+	}
+
+	// Each workspace must have its own database file.
+	for _, dir := range []string{wsA, wsB} {
+		if _, statErr := os.Stat(filepath.Join(dir, ".bc", "bc.db")); statErr != nil {
+			t.Errorf("bc.db missing for %s: %v", dir, statErr)
+		}
+	}
+}
+
+// TestBuildWorkspaceServices_LazyWorkspaceDB simulates the
+// workspace-less boot path: no database exists anywhere until a repo is
+// added (BuildWorkspaceServices is what POST /api/workspaces invokes),
+// at which point the registry opens that workspace's DB lazily and the
+// stores come up online rather than degraded.
+func TestBuildWorkspaceServices_LazyWorkspaceDB(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	t.Setenv("BC_SECRET_PASSPHRASE", "unit-test")
+	ctx := context.Background()
+
+	wsDir := t.TempDir()
+	gitInitDir(t, wsDir)
+	t.Cleanup(func() { _ = bcdb.CloseWorkspaceDB(wsDir) })
+
+	// Nothing pre-opened: the db file must not exist yet.
+	if _, err := os.Stat(filepath.Join(wsDir, ".bc", "bc.db")); err == nil {
+		t.Fatal("bc.db must not exist before services are built")
+	}
+
+	svc, err := BuildWorkspaceServices(ctx, &Globals{}, wsDir)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	defer svc.Close() //nolint:errcheck
+
+	for name, present := range map[string]bool{
+		"notify": svc.Notify != nil,
+		"cron":   svc.Cron != nil,
+		"mcp":    svc.MCP != nil,
+		"tools":  svc.Tools != nil,
+		"events": svc.Events != nil,
+	} {
+		if !present {
+			t.Errorf("%s store not online after lazy add (degraded: %v)", name, svc.Degraded)
+		}
+	}
+	if reason, degraded := svc.Degraded["storage"]; degraded {
+		t.Errorf("storage degraded on lazy add: %s", reason)
+	}
+	if _, err := os.Stat(filepath.Join(wsDir, ".bc", "bc.db")); err != nil {
+		t.Errorf("bc.db not created lazily: %v", err)
+	}
+}

--- a/server/concurrent_workspace_test.go
+++ b/server/concurrent_workspace_test.go
@@ -74,15 +74,12 @@ func newConcurrentHarness(t *testing.T, n int) *concurrentHarness {
 		list[i] = wsSetup{id: workspace.ComputeWorkspaceID(p), path: p}
 	}
 
-	// Shared bc.db anchored to ws0 (mirrors production boot).
-	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDBWithConfig(list[0].path, nil)
-	if dbErr != nil {
-		t.Fatalf("open shared db: %v", dbErr)
-	}
-	bcdb.SetShared(sharedDB, sharedDriver)
+	// Each workspace's db is opened lazily by BuildWorkspaceServices via
+	// the per-workspace registry; release them after the test.
 	t.Cleanup(func() {
-		bcdb.SetShared(nil, "")
-		_ = bcdb.CloseShared()
+		for _, w := range list {
+			_ = bcdb.CloseWorkspaceDB(w.path)
+		}
 	})
 
 	reg, regErr := workspace.LoadRegistry()

--- a/server/cors_scope_test.go
+++ b/server/cors_scope_test.go
@@ -51,15 +51,10 @@ func TestCORS_WorkspaceScope_Coexist(t *testing.T) {
 	}
 	wsID := workspace.ComputeWorkspaceID(wsDir)
 
-	// Open the shared db (required by BuildWorkspaceServices).
-	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDBWithConfig(wsDir, nil)
-	if dbErr != nil {
-		t.Fatalf("open shared db: %v", dbErr)
-	}
-	bcdb.SetShared(sharedDB, sharedDriver)
+	// BuildWorkspaceServices resolves the workspace db lazily via the
+	// registry; just make sure it is released after the test.
 	t.Cleanup(func() {
-		bcdb.SetShared(nil, "")
-		_ = bcdb.CloseShared()
+		_ = bcdb.CloseWorkspaceDB(wsDir)
 	})
 
 	reg, err := workspace.LoadRegistry()
@@ -162,14 +157,8 @@ func TestCORS_Preflight_Scoped(t *testing.T) {
 	}
 	wsID := workspace.ComputeWorkspaceID(wsDir)
 
-	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDBWithConfig(wsDir, nil)
-	if dbErr != nil {
-		t.Fatalf("open shared db: %v", dbErr)
-	}
-	bcdb.SetShared(sharedDB, sharedDriver)
 	t.Cleanup(func() {
-		bcdb.SetShared(nil, "")
-		_ = bcdb.CloseShared()
+		_ = bcdb.CloseWorkspaceDB(wsDir)
 	})
 
 	reg, err := workspace.LoadRegistry()

--- a/server/degraded_test.go
+++ b/server/degraded_test.go
@@ -9,6 +9,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -99,14 +101,16 @@ func TestBuildWorkspaceServicesDegradedNotify(t *testing.T) {
 	t.Setenv("MYCEL_HOME", t.TempDir())
 	t.Setenv("BC_SECRET_PASSPHRASE", "unit-test")
 
-	// Force the shared DB to be absent so notify's OpenStore fails,
-	// restoring whatever a previous test installed.
-	prevDB, prevDriver := bcdb.Shared(), bcdb.SharedDriver()
-	bcdb.SetShared(nil, "")
-	t.Cleanup(func() { bcdb.SetShared(prevDB, prevDriver) })
-
+	// Force the workspace DB open to fail: plant a regular FILE where
+	// the registry wants the .bc database directory, so SQLite's
+	// MkdirAll errors and every store depending on the workspace db
+	// comes up degraded.
 	wsDir := t.TempDir()
 	gitInitDir(t, wsDir)
+	if err := os.WriteFile(filepath.Join(wsDir, ".bc"), []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("plant .bc file: %v", err)
+	}
+	t.Cleanup(func() { _ = bcdb.CloseWorkspaceDB(wsDir) })
 	svc, err := BuildWorkspaceServices(context.Background(), &Globals{}, wsDir)
 	if err != nil {
 		t.Fatalf("build: %v", err)

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -71,14 +71,13 @@ func newE2EServer(t *testing.T) *e2eServer {
 		t.Fatalf("workspace load: %v", err)
 	}
 
-	// Set up shared database for all stores
-	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDBWithConfig(ws.RootDir, nil)
+	// Per-workspace database via the registry (production path).
+	wsDB, wsDriver, dbErr := bcdb.ForWorkspace(ws.RootDir, nil)
 	if dbErr != nil {
-		t.Fatalf("open shared db: %v", dbErr)
+		t.Fatalf("open workspace db: %v", dbErr)
 	}
-	bcdb.SetShared(sharedDB, sharedDriver)
 	t.Cleanup(func() {
-		_ = bcdb.CloseShared()
+		_ = bcdb.CloseWorkspaceDB(ws.RootDir)
 	})
 
 	// SSE hub
@@ -99,21 +98,21 @@ func newE2EServer(t *testing.T) *e2eServer {
 
 	// Cron store
 	var cronStore *cron.Store
-	if cr, err := cron.Open(ws.RootDir); err == nil {
+	if cr, err := cron.Open(wsDB, wsDriver); err == nil {
 		cronStore = cr
 		t.Cleanup(func() { _ = cr.Close() })
 	}
 
 	// MCP store
 	var mcpStore *pkgmcp.Store
-	if ms, err := pkgmcp.NewStore(ws.RootDir); err == nil {
+	if ms, err := pkgmcp.NewStore(wsDB, wsDriver); err == nil {
 		mcpStore = ms
 		t.Cleanup(func() { _ = ms.Close() })
 	}
 
 	// Tool store
 	var toolStore *tool.Store
-	ts := tool.NewStore(ws.StateDir())
+	ts := tool.NewStore(wsDB, wsDriver)
 	if err := ts.Open(); err == nil {
 		toolStore = ts
 		t.Cleanup(func() { _ = ts.Close() })
@@ -121,14 +120,14 @@ func newE2EServer(t *testing.T) *e2eServer {
 
 	// Event log
 	var eventLog events.EventStore
-	if el, err := events.NewSQLiteLog(filepath.Join(ws.StateDir(), "state.db")); err == nil {
+	if el, err := events.NewSQLiteLog(wsDB); err == nil {
 		eventLog = el
 		t.Cleanup(func() { _ = el.Close() })
 	}
 
 	// Notify service (backed by shared SQLite DB set up above)
 	var notifySvc *notify.Service
-	if ns, err := notify.OpenStore(ws.RootDir); err == nil {
+	if ns, err := notify.OpenStore(wsDB, wsDriver); err == nil {
 		notifySvc = notify.NewService(ns, nil, nil)
 	}
 

--- a/server/e2e_web_test.go
+++ b/server/e2e_web_test.go
@@ -62,14 +62,13 @@ func newE2EServerWithWebUI(t *testing.T) *e2eServer {
 		t.Fatalf("workspace load: %v", err)
 	}
 
-	// Set up shared database for all stores
-	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDBWithConfig(ws.RootDir, nil)
+	// Per-workspace database via the registry (production path).
+	wsDB, wsDriver, dbErr := bcdb.ForWorkspace(ws.RootDir, nil)
 	if dbErr != nil {
-		t.Fatalf("open shared db: %v", dbErr)
+		t.Fatalf("open workspace db: %v", dbErr)
 	}
-	bcdb.SetShared(sharedDB, sharedDriver)
 	t.Cleanup(func() {
-		_ = bcdb.CloseShared()
+		_ = bcdb.CloseWorkspaceDB(ws.RootDir)
 	})
 
 	hub := ws_hub(t)
@@ -85,26 +84,26 @@ func newE2EServerWithWebUI(t *testing.T) *e2eServer {
 	}
 
 	var cronStore *cron.Store
-	if cr, err := cron.Open(ws.RootDir); err == nil {
+	if cr, err := cron.Open(wsDB, wsDriver); err == nil {
 		cronStore = cr
 		t.Cleanup(func() { _ = cr.Close() })
 	}
 
 	var mcpStore *pkgmcp.Store
-	if ms, err := pkgmcp.NewStore(ws.RootDir); err == nil {
+	if ms, err := pkgmcp.NewStore(wsDB, wsDriver); err == nil {
 		mcpStore = ms
 		t.Cleanup(func() { _ = ms.Close() })
 	}
 
 	var toolStore *tool.Store
-	ts := tool.NewStore(ws.StateDir())
+	ts := tool.NewStore(wsDB, wsDriver)
 	if err := ts.Open(); err == nil {
 		toolStore = ts
 		t.Cleanup(func() { _ = ts.Close() })
 	}
 
 	var eventLog events.EventStore
-	if el, err := events.NewSQLiteLog(filepath.Join(ws.StateDir(), "state.db")); err == nil {
+	if el, err := events.NewSQLiteLog(wsDB); err == nil {
 		eventLog = el
 		t.Cleanup(func() { _ = el.Close() })
 	}

--- a/server/handlers/mcp_test.go
+++ b/server/handlers/mcp_test.go
@@ -18,12 +18,8 @@ func newTestMCPStore(t *testing.T) *mcp.Store {
 	if err != nil {
 		t.Fatalf("db.Open: %v", err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		_ = d.Close()
-	})
-	store, err := mcp.NewStore(dir)
+	t.Cleanup(func() { _ = d.Close() })
+	store, err := mcp.NewStore(d, "sqlite")
 	if err != nil {
 		t.Fatalf("NewStore: %v", err)
 	}

--- a/server/handlers/resource_handlers_test.go
+++ b/server/handlers/resource_handlers_test.go
@@ -53,23 +53,31 @@ func setupWorkspace(t *testing.T) string {
 	return dir
 }
 
-// setupWorkspaceWithDB sets up a workspace with a shared SQLite database,
-// required for stores that use db.SharedWrapped() (cron, mcp, etc.).
+// setupWorkspaceWithDB sets up a workspace whose database is opened
+// lazily via the per-workspace registry (see openWSDB).
 func setupWorkspaceWithDB(t *testing.T) string {
 	t.Helper()
-	dir := setupWorkspace(t)
-	d, err := db.Open(filepath.Join(dir, "bc.db"))
+	return setupWorkspace(t)
+}
+
+// openWSDB returns the per-workspace database handle + driver for the
+// given workspace root, mirroring how BuildWorkspaceServices resolves it.
+func openWSDB(t *testing.T, dir string) (*db.DB, string) {
+	t.Helper()
+	d, driver, err := db.ForWorkspace(dir, nil)
 	if err != nil {
-		t.Fatalf("open shared db: %v", err)
+		t.Fatalf("open workspace db: %v", err)
 	}
-	db.SetShared(d.DB, "sqlite")
-	t.Cleanup(func() {
-		db.SetShared(nil, "")
-		if closeErr := d.Close(); closeErr != nil {
-			t.Errorf("close shared db: %v", closeErr)
-		}
-	})
-	return dir
+	t.Cleanup(func() { _ = db.CloseWorkspaceDB(dir) })
+	return d, driver
+}
+
+// openWSSQLite returns just the SQLite handle for stores that take a
+// bare *db.DB (events).
+func openWSSQLite(t *testing.T, dir string) *db.DB {
+	t.Helper()
+	d, _ := openWSDB(t, dir)
+	return d
 }
 
 func buildTestServerWithServices(t *testing.T, svc server.Services) *httptest.Server {
@@ -349,7 +357,7 @@ func TestCostHandler_BudgetNotFound(t *testing.T) {
 
 func TestCronHandler_ListEmpty(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -369,7 +377,7 @@ func TestCronHandler_ListEmpty(t *testing.T) {
 
 func TestCronHandler_CreateAndGet(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -400,7 +408,7 @@ func TestCronHandler_CreateAndGet(t *testing.T) {
 
 func TestCronHandler_CreateMissingCommandAndPrompt(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -417,7 +425,7 @@ func TestCronHandler_CreateMissingCommandAndPrompt(t *testing.T) {
 
 func TestCronHandler_CreateInvalidBody(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -433,7 +441,7 @@ func TestCronHandler_CreateInvalidBody(t *testing.T) {
 
 func TestCronHandler_Delete(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -453,7 +461,7 @@ func TestCronHandler_Delete(t *testing.T) {
 
 func TestCronHandler_EnableDisable(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -487,7 +495,7 @@ func TestCronHandler_EnableDisable(t *testing.T) {
 
 func TestCronHandler_RunDisabledJob(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -509,7 +517,7 @@ func TestCronHandler_RunDisabledJob(t *testing.T) {
 
 func TestCronHandler_RunEnabledJob(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -535,7 +543,7 @@ func TestCronHandler_RunEnabledJob(t *testing.T) {
 
 func TestCronHandler_RunNonexistent(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -551,7 +559,7 @@ func TestCronHandler_RunNonexistent(t *testing.T) {
 
 func TestCronHandler_Logs(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -576,7 +584,7 @@ func TestCronHandler_Logs(t *testing.T) {
 
 func TestCronHandler_MethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -592,7 +600,7 @@ func TestCronHandler_MethodNotAllowed(t *testing.T) {
 
 func TestCronHandler_EmptyName(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -608,7 +616,7 @@ func TestCronHandler_EmptyName(t *testing.T) {
 
 func TestCronHandler_UnknownSub(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -628,7 +636,7 @@ func TestCronHandler_UnknownSub(t *testing.T) {
 
 func TestCronHandler_JobMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -648,7 +656,7 @@ func TestCronHandler_JobMethodNotAllowed(t *testing.T) {
 
 func TestCronHandler_EnableMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -668,7 +676,7 @@ func TestCronHandler_EnableMethodNotAllowed(t *testing.T) {
 
 func TestCronHandler_RunMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -684,7 +692,7 @@ func TestCronHandler_RunMethodNotAllowed(t *testing.T) {
 
 func TestCronHandler_LogsMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}
@@ -867,7 +875,7 @@ func TestSecretHandler_ByNameMethodNotAllowed(t *testing.T) {
 
 func TestMCPHandler_ListEmpty(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -887,7 +895,7 @@ func TestMCPHandler_ListEmpty(t *testing.T) {
 
 func TestMCPHandler_CRUD(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -940,7 +948,7 @@ func TestMCPHandler_CRUD(t *testing.T) {
 
 func TestMCPHandler_GetNotFound(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -956,7 +964,7 @@ func TestMCPHandler_GetNotFound(t *testing.T) {
 
 func TestMCPHandler_MethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -972,7 +980,7 @@ func TestMCPHandler_MethodNotAllowed(t *testing.T) {
 
 func TestMCPHandler_EmptyName(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -988,7 +996,7 @@ func TestMCPHandler_EmptyName(t *testing.T) {
 
 func TestMCPHandler_UnknownSub(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -1008,7 +1016,7 @@ func TestMCPHandler_UnknownSub(t *testing.T) {
 
 func TestMCPHandler_CreateInvalidBody(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -1024,7 +1032,7 @@ func TestMCPHandler_CreateInvalidBody(t *testing.T) {
 
 func TestMCPHandler_ServerMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -1046,7 +1054,7 @@ func TestMCPHandler_ServerMethodNotAllowed(t *testing.T) {
 
 func TestMCPHandler_EnableMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := mcp.NewStore(dir)
+	store, err := mcp.NewStore(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("create mcp store: %v", err)
 	}
@@ -1064,8 +1072,7 @@ func TestMCPHandler_EnableMethodNotAllowed(t *testing.T) {
 
 func TestToolHandler_List(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -1083,8 +1090,7 @@ func TestToolHandler_List(t *testing.T) {
 
 func TestToolHandler_GetNotFound(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -1100,8 +1106,7 @@ func TestToolHandler_GetNotFound(t *testing.T) {
 
 func TestToolHandler_MethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -1119,8 +1124,7 @@ func TestToolHandler_MethodNotAllowed(t *testing.T) {
 
 func TestToolHandler_EmptyName(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -1136,8 +1140,7 @@ func TestToolHandler_EmptyName(t *testing.T) {
 
 func TestToolHandler_UnknownSub(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -1153,8 +1156,7 @@ func TestToolHandler_UnknownSub(t *testing.T) {
 
 func TestToolHandler_EnableDisableMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -1170,8 +1172,7 @@ func TestToolHandler_EnableDisableMethodNotAllowed(t *testing.T) {
 
 func TestToolHandler_PutInvalidBody(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -1187,8 +1188,7 @@ func TestToolHandler_PutInvalidBody(t *testing.T) {
 
 func TestToolHandler_ToolMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -1208,8 +1208,7 @@ func TestToolHandler_ToolMethodNotAllowed(t *testing.T) {
 
 func TestEventHandler_ListEmpty(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	logPath := filepath.Join(dir, ".bc", "events.db")
-	store, _ := events.NewSQLiteLog(logPath)
+	store, _ := events.NewSQLiteLog(openWSSQLite(t, dir))
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1226,8 +1225,7 @@ func TestEventHandler_ListEmpty(t *testing.T) {
 
 func TestEventHandler_AppendAndList(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	logPath := filepath.Join(dir, ".bc", "events.db")
-	store, _ := events.NewSQLiteLog(logPath)
+	store, _ := events.NewSQLiteLog(openWSSQLite(t, dir))
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1255,8 +1253,7 @@ func TestEventHandler_AppendAndList(t *testing.T) {
 
 func TestEventHandler_ByAgent(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	logPath := filepath.Join(dir, ".bc", "events.db")
-	store, _ := events.NewSQLiteLog(logPath)
+	store, _ := events.NewSQLiteLog(openWSSQLite(t, dir))
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1283,8 +1280,7 @@ func TestEventHandler_ByAgent(t *testing.T) {
 
 func TestEventHandler_MethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	logPath := filepath.Join(dir, ".bc", "events.db")
-	store, _ := events.NewSQLiteLog(logPath)
+	store, _ := events.NewSQLiteLog(openWSSQLite(t, dir))
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1297,8 +1293,7 @@ func TestEventHandler_MethodNotAllowed(t *testing.T) {
 
 func TestEventHandler_AppendInvalidBody(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	logPath := filepath.Join(dir, ".bc", "events.db")
-	store, _ := events.NewSQLiteLog(logPath)
+	store, _ := events.NewSQLiteLog(openWSSQLite(t, dir))
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1311,8 +1306,7 @@ func TestEventHandler_AppendInvalidBody(t *testing.T) {
 
 func TestEventHandler_EmptyAgentName(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	logPath := filepath.Join(dir, ".bc", "events.db")
-	store, _ := events.NewSQLiteLog(logPath)
+	store, _ := events.NewSQLiteLog(openWSSQLite(t, dir))
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1325,8 +1319,7 @@ func TestEventHandler_EmptyAgentName(t *testing.T) {
 
 func TestEventHandler_ByAgentMethodNotAllowed(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	logPath := filepath.Join(dir, ".bc", "events.db")
-	store, _ := events.NewSQLiteLog(logPath)
+	store, _ := events.NewSQLiteLog(openWSSQLite(t, dir))
 	t.Cleanup(func() { _ = store.Close() })
 
 	ts := buildTestServerWithServices(t, server.Services{EventLog: store})
@@ -1686,8 +1679,7 @@ func TestStatsHandler_SummaryWithServices(t *testing.T) {
 	t.Cleanup(func() { _ = costStore.Close() })
 
 	// Set up tools
-	stateDir := filepath.Join(dir, ".bc")
-	toolStore := tool.NewStore(stateDir)
+	toolStore := tool.NewStore(openWSDB(t, dir))
 	if err := toolStore.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -2539,8 +2531,7 @@ func TestWorkspaceHandler_UpInvalidBody(t *testing.T) {
 
 func TestToolHandler_CRUD(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	stateDir := filepath.Join(dir, ".bc")
-	store := tool.NewStore(stateDir)
+	store := tool.NewStore(openWSDB(t, dir))
 	if err := store.Open(); err != nil {
 		t.Fatalf("open tool store: %v", err)
 	}
@@ -2780,7 +2771,7 @@ func TestAgentHandler_CreateAgent(t *testing.T) {
 
 func TestCronHandler_GetNotFound(t *testing.T) {
 	dir := setupWorkspaceWithDB(t)
-	store, err := cron.Open(dir)
+	store, err := cron.Open(openWSDB(t, dir))
 	if err != nil {
 		t.Fatalf("open cron store: %v", err)
 	}

--- a/server/multi_tenant_dispatch_test.go
+++ b/server/multi_tenant_dispatch_test.go
@@ -107,24 +107,13 @@ func newDispatchHarness(t *testing.T) *dispatchHarness {
 	wsAID := workspace.ComputeWorkspaceID(wsA)
 	wsBID := workspace.ComputeWorkspaceID(wsB)
 
-	// Share one SQLite DB across both workspaces so stores that require
-	// db.SharedWrapped() (cron, mcp, tool, events SQLite) come online.
-	// This mirrors production: bcd opens ONE shared DB for the active
-	// workspace; stores from every workspace route through it. Complete
-	// per-workspace isolation for those tables is a known gap (no
-	// workspace_id column) tracked for a future phase. Our dispatch
-	// tests below assert that routing works and that where a store
-	// does have workspace scoping (cost_records.workspace_id,
-	// per-workspace templates dir, per-workspace events.jsonl) the
-	// isolation holds.
-	sharedDB, sharedDriver, dbErr := bcdb.OpenWorkspaceDBWithConfig(wsA, nil)
-	if dbErr != nil {
-		t.Fatalf("open shared db: %v", dbErr)
-	}
-	bcdb.SetShared(sharedDB, sharedDriver)
+	// Each workspace gets its OWN database via the per-workspace
+	// registry (issue #3238): cron/mcp/tool/events/notify rows written
+	// through workspace A's services can never appear in workspace B's
+	// stores. BuildWorkspaceServices opens the connections lazily.
 	t.Cleanup(func() {
-		bcdb.SetShared(nil, "")
-		_ = bcdb.CloseShared()
+		_ = bcdb.CloseWorkspaceDB(wsA)
+		_ = bcdb.CloseWorkspaceDB(wsB)
 	})
 
 	reg, loadErr := workspace.LoadRegistry()
@@ -302,11 +291,9 @@ func TestDispatch_Secrets(t *testing.T) {
 // ---------------- Cron (routing + basic CRUD through scoped URL) --
 
 // TestDispatch_Cron verifies that cron CRUD routes through the scoped
-// URL into the handler. Because the cron_jobs table has no
-// workspace_id column today, two workspaces sharing the bc.db see the
-// same rows — strict data isolation is a known gap. The assertion
-// here is routing: both scoped URLs serve the cron handler without
-// error, and an entry created via wsA is reachable via its key.
+// URL into the handler AND that jobs are isolated per workspace: each
+// workspace has its own database (issue #3238), so a job created via
+// wsA must not be visible through wsB.
 func TestDispatch_Cron(t *testing.T) {
 	h := newDispatchHarness(t)
 	defer h.close()
@@ -329,11 +316,16 @@ func TestDispatch_Cron(t *testing.T) {
 	status, resp = h.api(t, http.MethodGet, "/api/workspaces/"+h.wsAID+"/cron/job-shared", nil)
 	requireStatus(t, http.StatusOK, status, "GET wsA", resp)
 
-	// wsB's scoped URL also reaches the cron handler. Data isolation for
-	// cron_jobs is a known gap; we assert the handler responds and the
-	// route does not collide with a different resource.
+	// wsB's scoped URL also reaches the cron handler.
 	status, resp = h.api(t, http.MethodGet, "/api/workspaces/"+h.wsBID+"/cron", nil)
 	requireStatus(t, http.StatusOK, status, "list wsB", resp)
+
+	// Isolation: the job created under wsA must NOT exist under wsB —
+	// each workspace persists to its own database (issue #3238).
+	status, _ = h.api(t, http.MethodGet, "/api/workspaces/"+h.wsBID+"/cron/job-shared", nil)
+	if status != http.StatusNotFound {
+		t.Errorf("wsA's cron job visible via wsB (status=%d, want 404) — workspace db bleed", status)
+	}
 
 	// Cross-scope fetch for a nonexistent key returns 404.
 	status, _ = h.api(t, http.MethodGet, "/api/workspaces/"+h.wsBID+"/cron/nonexistent-xyz", nil)
@@ -408,10 +400,8 @@ func TestDispatch_Tools(t *testing.T) {
 // ---------------- Events / Logs (routing) ----------------
 
 // TestDispatch_Events verifies GET /api/logs routes through the scoped
-// URL. Like cron/mcp/tool, the events table in bc.db is shared across
-// workspaces today. Per-workspace isolation exists at the JSONL writer
-// level (events.jsonl under each ws.StateDir) but the SQLite
-// EventStore is a single table — we only assert routing here.
+// URL and that the SQLite event stores are isolated per workspace
+// (each workspace's events table lives in its own bc.db, issue #3238).
 func TestDispatch_Events(t *testing.T) {
 	h := newDispatchHarness(t)
 	defer h.close()
@@ -428,6 +418,18 @@ func TestDispatch_Events(t *testing.T) {
 
 	if err := svcA.Events.Append(bcevents.Event{Type: "probe.shared", Agent: "alice"}); err != nil {
 		t.Fatalf("append A: %v", err)
+	}
+
+	// Isolation: the event appended via wsA's store must not appear in
+	// wsB's store.
+	evtsB, readErr := svcB.Events.Read()
+	if readErr != nil {
+		t.Fatalf("read B: %v", readErr)
+	}
+	for _, ev := range evtsB {
+		if ev.Type == "probe.shared" {
+			t.Errorf("event appended in wsA visible in wsB — workspace db bleed")
+		}
 	}
 
 	// Scoped URL reaches the handler for both workspaces.

--- a/server/workspace_services.go
+++ b/server/workspace_services.go
@@ -120,8 +120,15 @@ func (ws *WorkspaceServices) LastAccess() time.Time {
 }
 
 // Close stops background goroutines started by the factory, waits for them
-// to exit, then invokes the factory-supplied closer to tear down stores and
-// close DB connections. Safe to call multiple times.
+// to exit, then invokes the factory-supplied closer to tear down stores.
+// Safe to call multiple times.
+//
+// The per-workspace database connection is deliberately NOT closed here:
+// stores borrow it from the pkg/db registry, which keeps it cached so an
+// evicted-then-reloaded workspace reuses the same handle (an idle SQLite
+// connection is one pooled conn — cheap) and so other holders (role
+// store, CLI helpers) never see a use-after-close. Registry connections
+// are closed at process shutdown via db.CloseAllWorkspaceDBs.
 func (ws *WorkspaceServices) Close() error {
 	ws.mu.Lock()
 	cancel := ws.cancel


### PR DESCRIPTION
## What

Closes #3238 — the last large storage-epic item. The process-global shared DB connection (opened for the launch workspace, written into by every other workspace's stores) is replaced by a per-workspace-root connection registry.

- `db.Registry.Get(root, cfg)` opens via the existing `OpenWorkspaceDBWithConfig` semantics (SQLite default, per-workspace Timescale with fallback), caches by cleaned absolute root; `db.ForWorkspace`/`CloseWorkspaceDB` replace `SetShared`/`Shared*`, which are **deleted with zero references**
- Store constructors take the handle explicitly: notify/cron/mcp/tool/events/cost/secret (dead per-store `OpenStore` postgres shims deleted)
- `BuildWorkspaceServices` resolves each workspace's DB lazily — the workspace-less `mycel up` boot adds repos whose stores come up fully online on demand
- Eviction policy documented: connections stay cached across service eviction (no refcounting churn/use-after-close), all closed at daemon shutdown
- **#3242 fallout fixed naturally:** `mycel tool`, doctor tools/MCP checks, and agent-spawn role setup open the workspace DB directly instead of hard-failing on the absent global

## Test plan
- New: registry lifecycle (cache/evict/reopen/close-all), **two-workspace notify isolation** at store AND factory level (the bleed regression), cron/events multi-tenant dispatch isolation upgraded from routing-only to real isolation asserts, lazy workspace-less boot
- `go build ./...` clean · `go test` green across pkg/server/internal (`-race` on changed pkg packages) · lint 0 issues

Part of #3262 (storage epic) and #3242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)