### PR TITLE
fix(ci): Trivy scans all severities so stale alerts can auto-close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,10 @@ jobs:
           image-ref: bc-daemon:latest
           format: sarif
           output: trivy-results.sarif
-          severity: CRITICAL,HIGH
+          # Full severity list: analyses must report every level or alerts from
+          # older full scans (1,467 medium + 152 low) can never be superseded
+          # and auto-closed - they linger open forever.
+          severity: CRITICAL,HIGH,MEDIUM,LOW
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v4
         if: always()


### PR DESCRIPTION
The container scan reported only CRITICAL,HIGH — so the 1,619 medium/low CVE alerts from older full-severity scans could never be superseded by a new analysis and have lingered open on the security tab even though the base-image `apt-get upgrade` (#3271) fixed most of them. With the full severity list, the next main scan re-analyzes every level and auto-closes what's fixed.

Part of #3272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)