### PR TITLE
fix(live+ci): per-agent Live hydration; Trivy ignores unfixable CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,10 @@ jobs:
           # older full scans (1,467 medium + 152 low) can never be superseded
           # and auto-closed - they linger open forever.
           severity: CRITICAL,HIGH,MEDIUM,LOW
+          # Only alert on CVEs with an available fix — Ubuntu base images
+          # carry hundreds of unfixed-upstream CVEs that no image rebuild
+          # can remove; alerting on them is permanent noise.
+          ignore-unfixed: true
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/web/src/hooks/useAgentActivity.ts
+++ b/web/src/hooks/useAgentActivity.ts
@@ -142,33 +142,29 @@ export function useAgentActivity(agentName?: string): {
           });
         }).catch(() => { /* best effort */ });
       } else {
-        // Multi-agent view (Live page): hydrate from the cross-agent
-        // /api/agents/activity feed so cards aren't empty on reload (#3138).
-        api.getActivity(400).then((items) => {
-          if (items.length === 0) return;
-          const byAgent = new Map<string, AgentActivityItem[]>();
-          for (const it of items) {
-            const who = it.agent || "";
-            if (!who) continue;
-            const list = byAgent.get(who);
-            if (list) list.push(it);
-            else byAgent.set(who, [it]);
-          }
-          setActivities((prev) => {
-            const next = new Map(prev);
-            for (const [who, rows] of byAgent) {
-              const existing = next.get(who);
-              if (!existing || existing.nodes.length > 0) continue;
+        // Multi-agent view (Live page): hydrate each agent from its own
+        // activity feed. A single shared cross-agent fetch (the old
+        // getActivity(400)) collapses to minutes of history when one busy
+        // agent floods the event stream, leaving quieter agents' cards
+        // empty after a reload (#3279).
+        const active = agentList.filter((a) => a.state !== "stopped");
+        for (const a of active) {
+          api.getAgentActivity(a.name, 100).then((items) => {
+            if (items.length === 0) return;
+            setActivities((prev) => {
+              const next = new Map(prev);
+              const existing = next.get(a.name);
+              if (!existing || existing.nodes.length > 0) return prev;
               // Oldest-first inside each card; the REST feed is newest-first.
-              const nodes: ToolNode[] = rows
+              const nodes: ToolNode[] = items
                 .slice()
                 .reverse()
                 .map(activityItemToNode);
-              next.set(who, { ...existing, nodes });
-            }
-            return next;
-          });
-        }).catch(() => { /* best effort */ });
+              next.set(a.name, { ...existing, nodes });
+              return next;
+            });
+          }).catch(() => { /* best effort */ });
+        }
       }
     }).catch(() => {});
 


### PR DESCRIPTION
## What

**Live history (#3279, web half):** the Live page re-seeded from one shared 400-event cross-agent fetch — under tonight's event volume that's minutes of coverage, and quieter agents' cards hydrate empty after reload ('stream vanishes'). Each active agent now hydrates from its own activity feed (100 events apiece). The DB-side half (5,000-per-agent prune cap ≈ 1h horizon for a busy agent → 50,000) lands on the wave-1 branch which owns build_services.go.

**Trivy (#3272):** `ignore-unfixed: true` — Ubuntu base images carry hundreds of CVEs with no upstream fix; no rebuild can remove them and alerting on them is permanent noise. Combined with the full-severity scan (#3278), the security tab converges to actionable items only.

## Test plan
web: lint clean, 118/118 tests, build green (verified before commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #3279
Part of #3272
