### PR TITLE
feat(db): one global mycel.db — wave 1 of the workspace removal

### DIFF
--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -423,11 +423,10 @@ func TestColorStateStr_Default(t *testing.T) {
 // seedEvents writes events to the workspace state.db SQLite database.
 func seedEvents(t *testing.T, wsDir string, evts []events.Event) {
 	t.Helper()
-	d, _, err := db.ForWorkspace(wsDir, nil)
+	d, _, err := db.Global(nil)
 	if err != nil {
-		t.Fatalf("failed to open workspace db: %v", err)
+		t.Fatalf("failed to open global db: %v", err)
 	}
-	t.Cleanup(func() { _ = db.CloseWorkspaceDB(wsDir) })
 	evtLog, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("failed to open event log: %v", err)
@@ -703,11 +702,10 @@ func TestReportDoneInWorkspace(t *testing.T) {
 	}
 
 	// Verify event was logged
-	d, _, err := db.ForWorkspace(wsDir, nil)
+	d, _, err := db.Global(nil)
 	if err != nil {
-		t.Fatalf("failed to open workspace db: %v", err)
+		t.Fatalf("failed to open global db: %v", err)
 	}
-	t.Cleanup(func() { _ = db.CloseWorkspaceDB(wsDir) })
 	evtLog, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("failed to open event log: %v", err)

--- a/internal/cmd/cost_report.go
+++ b/internal/cmd/cost_report.go
@@ -73,33 +73,32 @@ func runCostReport(cmd *cobra.Command, _ []string) error {
 }
 
 func printCostByWorkspace(ctx context.Context, store *cost.Store, since time.Time) error {
-	byWS, err := store.SumByWorkspace(ctx, since)
+	byRepo, err := store.SumByRepo(ctx, since)
 	if err != nil {
 		return err
 	}
 
-	// Resolve workspace ids to names via the registry for friendlier
+	// Resolve repo paths to names via the registry for friendlier
 	// output.
 	names := map[string]string{}
 	if reg, regErr := workspace.LoadRegistry(); regErr == nil && reg != nil {
 		for _, e := range reg.Workspaces {
-			id := workspace.ComputeWorkspaceID(e.Path)
-			names[id] = e.Name
+			names[e.Path] = e.Name
 		}
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "WORKSPACE\tID\tTOTAL")
+	_, _ = fmt.Fprintln(w, "REPO\tPATH\tTOTAL")
 
-	keys := make([]string, 0, len(byWS))
-	for k := range byWS {
+	keys := make([]string, 0, len(byRepo))
+	for k := range byRepo {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool { return byWS[keys[i]] > byWS[keys[j]] })
+	sort.Slice(keys, func(i, j int) bool { return byRepo[keys[i]] > byRepo[keys[j]] })
 
 	var grand float64
 	for _, k := range keys {
-		total := byWS[k]
+		total := byRepo[k]
 		grand += total
 		name := names[k]
 		if name == "" {
@@ -116,13 +115,13 @@ func printCostByWorkspace(ctx context.Context, store *cost.Store, since time.Tim
 }
 
 func printCostByProject(ctx context.Context, store *cost.Store, since time.Time) error {
-	resolve := func(wsID string) string {
+	resolve := func(repo string) string {
 		reg, err := workspace.LoadRegistry()
 		if err != nil || reg == nil {
 			return ""
 		}
 		for _, e := range reg.Workspaces {
-			if workspace.ComputeWorkspaceID(e.Path) == wsID {
+			if e.Path == repo {
 				return e.Name
 			}
 		}

--- a/internal/cmd/logs_test.go
+++ b/internal/cmd/logs_test.go
@@ -47,11 +47,10 @@ func setupLogsWorkspace(t *testing.T) (string, func()) {
 // seedLogsEvents writes events to the workspace state.db SQLite database.
 func seedLogsEvents(t *testing.T, wsDir string, evts []events.Event) {
 	t.Helper()
-	d, _, err := db.ForWorkspace(wsDir, nil)
+	d, _, err := db.Global(nil)
 	if err != nil {
-		t.Fatalf("failed to open workspace db: %v", err)
+		t.Fatalf("failed to open global db: %v", err)
 	}
-	t.Cleanup(func() { _ = db.CloseWorkspaceDB(wsDir) })
 	evtLog, err := events.NewSQLiteLog(d)
 	if err != nil {
 		t.Fatalf("failed to open event log: %v", err)

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -76,23 +76,24 @@ func RunServer(addr, wsRoot, corsOrigin, apiKey string) error {
 		}
 	}
 
-	// Per-workspace databases are opened lazily through the pkg/db
-	// registry (BuildWorkspaceServices resolves each workspace's own
-	// connection) — including for a workspace-less boot where repos are
-	// added later via the API. Warm the launch workspace's connection
-	// eagerly so storage problems surface at boot, and close every
-	// registry connection at shutdown.
-	defer bcdb.CloseAllWorkspaceDBs() //nolint:errcheck
-	if ws != nil {
-		_, driver, dbErr := bcdb.ForWorkspace(ws.RootDir, ws.Config.DBStorageSettings())
-		if dbErr != nil {
-			log.Warn("failed to open workspace db", "error", dbErr, "workspace", ws.RootDir)
+	// The single global database (<MycelHome>/mycel.db) is opened lazily
+	// through pkg/db — including for a workspace-less boot where repos
+	// are added later via the API. Warm the connection eagerly so
+	// storage problems surface at boot, and close it at shutdown.
+	defer bcdb.CloseGlobal() //nolint:errcheck
+	{
+		var cfg *bcdb.StorageSettings
+		if ws != nil {
+			cfg = ws.Config.DBStorageSettings()
+		}
+		if _, driver, dbErr := bcdb.Global(cfg); dbErr != nil {
+			log.Warn("failed to open global db", "error", dbErr)
 		} else {
 			configDriver := ""
-			if ws.Config != nil {
+			if ws != nil && ws.Config != nil {
 				configDriver = ws.Config.Storage.Default
 			}
-			log.Info("workspace database ready", "driver", driver, "config_driver", configDriver, "workspace", ws.RootDir)
+			log.Info("global database ready", "driver", driver, "config_driver", configDriver)
 		}
 	}
 
@@ -181,8 +182,8 @@ func RunServer(addr, wsRoot, corsOrigin, apiKey string) error {
 		mcpGlobal = bcmcp.NewGlobalStore(mcpPath)
 	}
 
-	// User-global cost ledger at ~/.mycel/costs.db. Records carry
-	// workspace_id for cross-workspace analytics. When the ledger
+	// User-global cost ledger at ~/.mycel/costs.db. Records carry the
+	// repo path for cross-repo analytics. When the ledger
 	// cannot be opened, per-workspace stores continue to work via the
 	// build_services.go fallback.
 	var costsGlobal *bccost.Store

--- a/internal/cmd/setup_test.go
+++ b/internal/cmd/setup_test.go
@@ -75,6 +75,14 @@ func TestMain(m *testing.M) {
 	_ = os.Unsetenv("BC_WORKSPACE")
 	_ = os.Unsetenv("BC_AGENT_WORKTREE")
 
+	// Point the single global database (and everything else under
+	// MYCEL_HOME) at a throwaway dir so tests never touch ~/.mycel.
+	var testHome string
+	if home, homeErr := os.MkdirTemp("", "mycel-test-home-*"); homeErr == nil {
+		testHome = home
+		_ = os.Setenv("MYCEL_HOME", home)
+	}
+
 	// Setup roles for tests - mirrors pkg/agent/agent_test.go TestMain
 	agent.RoleCapabilities[agent.Role("engineer")] = []agent.Capability{agent.CapImplementTasks}
 	agent.RoleCapabilities[agent.Role("manager")] = []agent.Capability{agent.CapAssignWork, agent.CapCreateAgents}
@@ -101,5 +109,9 @@ func TestMain(m *testing.M) {
 		agent.Role("tech-lead"),
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	if testHome != "" {
+		_ = os.RemoveAll(testHome)
+	}
+	os.Exit(code)
 }

--- a/internal/cmd/tool.go
+++ b/internal/cmd/tool.go
@@ -199,16 +199,16 @@ func completeToolNames(_ *cobra.Command, _ []string, _ string) ([]string, cobra.
 	return names, cobra.ShellCompDirectiveNoFileComp
 }
 
-// openToolStore opens the tool store for the current workspace, using
-// the per-workspace database registry (works offline, without bcd).
+// openToolStore opens the tool store on the single global database
+// (works offline, without bcd).
 func openToolStore() (*tool.Store, error) {
 	ws, err := getWorkspace()
 	if err != nil {
 		return nil, errNotInWorkspace(err)
 	}
-	wsDB, driver, dbErr := db.ForWorkspace(ws.RootDir, ws.Config.DBStorageSettings())
+	wsDB, driver, dbErr := db.Global(ws.Config.DBStorageSettings())
 	if dbErr != nil {
-		return nil, fmt.Errorf("failed to open workspace database: %w", dbErr)
+		return nil, fmt.Errorf("failed to open global database: %w", dbErr)
 	}
 	s := tool.NewStore(wsDB, driver)
 	if err := s.Open(); err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -354,7 +354,7 @@ type Agent struct {
 	ArchivedAt     *time.Time   `json:"archived_at,omitempty"`
 	RolePrompt     *AgentMemory `json:"memory,omitempty"`
 	Workspace      string       `json:"workspace"`
-	RepoRoot       string       `json:"repo_root,omitempty"`
+	Repo           string       `json:"repo,omitempty"`
 	ID             string       `json:"id"`
 	Name           string       `json:"name"`
 	Task           string       `json:"task,omitempty"`
@@ -868,11 +868,21 @@ func (m *Manager) SpawnAgentWithOptions(ctx context.Context, opts SpawnOptions) 
 
 	m.mu.Lock()
 
-	// Auto-generate name if empty
+	// Auto-generate name if empty. Agent names are globally unique
+	// (name is the primary key of the global agents table), so seed the
+	// collision set with every name in the store, not just this
+	// manager's agents.
 	if name == "" {
 		existing := make(map[string]bool, len(m.agents))
 		for n := range m.agents {
 			existing[n] = true
+		}
+		if m.store != nil {
+			if global, namesErr := m.store.LoadNames(ctx); namesErr == nil {
+				for n := range global {
+					existing[n] = true
+				}
+			}
 		}
 		generated, genErr := names.GenerateUnique(existing, 100)
 		if genErr != nil {
@@ -948,6 +958,15 @@ func (m *Manager) SpawnAgentWithOptions(ctx context.Context, opts SpawnOptions) 
 		// Release global lock; startAgent handles its own locking.
 		m.mu.Unlock()
 		return m.startAgent(ctx, name, opts)
+	}
+
+	// Global uniqueness: the name is not in this manager's state, but it
+	// may belong to an agent from another repo — the agents table is
+	// global and keyed by name, so a blind create would silently
+	// overwrite that row. Reject with a pointer to the owner.
+	if err := m.checkNameAvailable(ctx, name); err != nil {
+		m.mu.Unlock()
+		return nil, err
 	}
 
 	// Fresh create — release global lock; createAgent handles its own locking.
@@ -1223,7 +1242,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 		Role:           role,
 		State:          StateStarting,
 		Workspace:      wsPath,
-		RepoRoot:       wsPath,
+		Repo:           cleanRepoPath(wsPath),
 		Session:        name,
 		Tool:           effectiveTool,
 		ParentID:       parentID,
@@ -2446,11 +2465,18 @@ func (m *Manager) LoadState() error {
 		return nil
 	}
 
-	// Open SQLite store — use the unified bc.db when workspace path is known,
-	// otherwise fall back to state.db in the agents dir (tests / standalone).
+	// Open SQLite store — use the single global mycel.db when the
+	// workspace (repo) path is known, otherwise fall back to state.db in
+	// the agents dir (tests / standalone). Agents from every repo share
+	// the one database; this manager only materializes rows whose repo
+	// matches its own.
 	var dbPath string
 	if m.workspacePath != "" {
-		dbPath = db.BCDBPath(m.workspacePath)
+		p, pathErr := db.GlobalDBPath()
+		if pathErr != nil {
+			return fmt.Errorf("resolve global db path: %w", pathErr)
+		}
+		dbPath = p
 	} else {
 		dbPath = filepath.Join(m.stateDir, "state.db")
 	}
@@ -2468,8 +2494,16 @@ func (m *Manager) LoadState() error {
 		}
 	}
 
-	// Load all agents from SQLite
-	agents, err := store.LoadAll(context.Background())
+	// Load this manager's agents from SQLite. The agents table is
+	// global (one mycel.db for every repo), so a repo-scoped manager
+	// loads only rows tagged with its own repo path; a standalone
+	// manager (no workspace path) loads everything in its private db.
+	var agents map[string]*Agent
+	if m.workspacePath != "" {
+		agents, err = store.LoadByRepo(context.Background(), cleanRepoPath(m.workspacePath))
+	} else {
+		agents, err = store.LoadAll(context.Background())
+	}
 	if err != nil {
 		return fmt.Errorf("load agents: %w", err)
 	}
@@ -2565,9 +2599,15 @@ func (m *Manager) RegisterStopped(a *Agent) error {
 	if _, exists := m.agents[a.Name]; exists {
 		return fmt.Errorf("agent %q already exists", a.Name)
 	}
+	if err := m.checkNameAvailable(context.Background(), a.Name); err != nil {
+		return err
+	}
 
 	now := time.Now()
 	a.State = StateStopped
+	if a.Repo == "" {
+		a.Repo = cleanRepoPath(m.workspacePath)
+	}
 	if a.CreatedAt.IsZero() {
 		a.CreatedAt = now
 	}
@@ -2583,6 +2623,42 @@ func (m *Manager) RegisterStopped(a *Agent) error {
 		return fmt.Errorf("save state: %w", err)
 	}
 	return nil
+}
+
+// cleanRepoPath normalizes a repo path to an absolute cleaned path —
+// the canonical form of the global `repo` attribution key.
+func cleanRepoPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	if abs, err := filepath.Abs(p); err == nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Clean(p)
+}
+
+// checkNameAvailable rejects names already taken in the global agents
+// table by an agent this manager does not know about. Agent names are
+// globally unique across every repo: the name is the primary key of
+// the single mycel.db agents table. Soft-deleted rows do not block
+// reuse. Best-effort: with no store (standalone managers, some tests)
+// the in-memory check in the caller is the only guard.
+func (m *Manager) checkNameAvailable(ctx context.Context, name string) error {
+	if m.store == nil {
+		return nil
+	}
+	other, err := m.store.Load(ctx, name)
+	if err != nil || other == nil || other.DeletedAt != nil {
+		return nil //nolint:nilerr // lookup failure must not block spawning
+	}
+	owner := other.Repo
+	if owner == "" {
+		owner = other.Workspace
+	}
+	if owner == "" {
+		owner = "another workspace"
+	}
+	return fmt.Errorf("agent name %q is already in use by an agent in %s — agent names are global, pick a different name or delete that agent first", name, owner)
 }
 
 // enforceRootSingleton checks if a root agent can be spawned.

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -20,6 +20,14 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Point the single global database (MYCEL_HOME/mycel.db) at a
+	// throwaway dir so tests never touch ~/.mycel.
+	var testHome string
+	if home, err := os.MkdirTemp("", "mycel-test-home-*"); err == nil {
+		testHome = home
+		_ = os.Setenv("MYCEL_HOME", home)
+	}
+
 	// Setup roles for tests
 	RoleCapabilities[Role("engineer")] = []Capability{CapImplementTasks}
 	RoleCapabilities[Role("manager")] = []Capability{CapAssignWork}
@@ -31,7 +39,11 @@ func TestMain(m *testing.M) {
 	RoleHierarchy[Role("product-manager")] = []Role{Role("manager")}
 	RoleHierarchy[RoleRoot] = []Role{Role("product-manager"), Role("manager"), Role("engineer"), Role("qa"), Role("worker")}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	if testHome != "" {
+		_ = os.RemoveAll(testHome)
+	}
+	os.Exit(code)
 }
 
 // initGitRepo initializes a bare-minimum git repo in dir so worktree operations work.
@@ -3497,5 +3509,78 @@ func TestBcdAddrForRuntime_NormalizesEmptyHost(t *testing.T) {
 					tt.runtime, tt.envVal, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestGlobalAgentNameUniqueness covers the single-database semantics:
+// all managers share one agents table (global mycel.db), agents are
+// loaded per repo, and a name taken by another repo is rejected on
+// both the register and spawn paths.
+func TestGlobalAgentNameUniqueness(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	ctx := context.Background()
+
+	repoA, repoB := t.TempDir(), t.TempDir()
+	mA := NewWorkspaceManager(filepath.Join(repoA, "agents"), repoA)
+	if err := mA.LoadState(); err != nil {
+		t.Fatalf("LoadState A: %v", err)
+	}
+	defer func() { _ = mA.Close() }()
+
+	if err := mA.RegisterStopped(&Agent{
+		Name:      "dup-check",
+		Role:      Role("engineer"),
+		Workspace: repoA,
+	}); err != nil {
+		t.Fatalf("RegisterStopped A: %v", err)
+	}
+
+	mB := NewWorkspaceManager(filepath.Join(repoB, "agents"), repoB)
+	if err := mB.LoadState(); err != nil {
+		t.Fatalf("LoadState B: %v", err)
+	}
+	defer func() { _ = mB.Close() }()
+
+	// Repo-key isolation: B's manager must not materialize A's agent.
+	if got := mB.GetAgent("dup-check"); got != nil {
+		t.Errorf("repo B manager loaded repo A's agent: %+v", got)
+	}
+
+	// RegisterStopped path rejects the taken name.
+	err := mB.RegisterStopped(&Agent{
+		Name:      "dup-check",
+		Role:      Role("engineer"),
+		Workspace: repoB,
+	})
+	if err == nil {
+		t.Fatal("expected duplicate name rejection on RegisterStopped")
+	}
+	if !strings.Contains(err.Error(), "already in use") || !strings.Contains(err.Error(), repoA) {
+		t.Errorf("error should mention the owning repo, got: %v", err)
+	}
+
+	// Spawn path rejects the taken name before touching any runtime.
+	_, err = mB.SpawnAgentWithOptions(ctx, SpawnOptions{
+		Name:      "dup-check",
+		Role:      Role("engineer"),
+		Workspace: repoB,
+	})
+	if err == nil {
+		t.Fatal("expected duplicate name rejection on spawn")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("spawn error should explain global uniqueness, got: %v", err)
+	}
+
+	// A restarted manager for repo A still loads its own agent.
+	mA2 := NewWorkspaceManager(filepath.Join(repoA, "agents"), repoA)
+	if err := mA2.LoadState(); err != nil {
+		t.Fatalf("LoadState A2: %v", err)
+	}
+	defer func() { _ = mA2.Close() }()
+	if got := mA2.GetAgent("dup-check"); got == nil {
+		t.Error("repo A manager must reload its own agent from the global table")
+	} else if got.Repo != repoA {
+		t.Errorf("agent repo = %q, want %q", got.Repo, repoA)
 	}
 }

--- a/pkg/agent/migrate.go
+++ b/pkg/agent/migrate.go
@@ -63,8 +63,8 @@ func migrateJSONToSQLite(store *SQLiteStore, stateDir, workspace string) error {
 				if a.Workspace == "" {
 					a.Workspace = workspace
 				}
-				if a.RepoRoot == "" {
-					a.RepoRoot = a.Workspace
+				if a.Repo == "" {
+					a.Repo = cleanRepoPath(a.Workspace)
 				}
 				if a.StartedAt.IsZero() {
 					a.StartedAt = time.Now()

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -158,9 +158,9 @@ func writeMCPJSON(ctx context.Context, workspacePath, agentName string, resolved
 	isDocker := runtimeBackend == "docker"
 	cfg := mcpConfig{MCPServers: make(map[string]mcpServerEntry)}
 
-	// Resolve this workspace's database from the per-workspace registry
-	// (cached when the daemon already opened it with full storage config).
-	wsDB, wsDriver, dbErr := pkgdb.ForWorkspace(workspacePath, nil)
+	// Resolve the single global database (cached when the daemon already
+	// opened it with full storage config).
+	wsDB, wsDriver, dbErr := pkgdb.Global(nil)
 
 	// Try unified tool store first for MCP server configs, fall back to mcp.Store.
 	var toolStore *pkgtool.Store
@@ -509,7 +509,7 @@ func validateAgentTools(workspacePath, roleName string) []string {
 
 	// Check MCP servers from role config — verify definition exists and health check
 	var mcpStore *pkgmcp.Store
-	wsDB, wsDriver, mcpErr := pkgdb.ForWorkspace(workspacePath, nil)
+	wsDB, wsDriver, mcpErr := pkgdb.Global(nil)
 	if mcpErr == nil {
 		mcpStore, mcpErr = pkgmcp.NewStore(wsDB, wsDriver)
 	}

--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -12,8 +12,9 @@ import (
 )
 
 // SQLiteStore provides SQLite-backed persistence for agent state.
-// It replaces the JSON file-based storage (agents.json, root.json, per-agent JSONs)
-// with a single bc.db using WAL mode for safe concurrent access.
+// All agents live in the single global mycel.db; rows are keyed by the
+// globally-unique agent name and carry the agent's repo path so
+// per-repo managers can load only their own agents.
 type SQLiteStore struct {
 	db *db.DB
 }
@@ -36,6 +37,11 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 
 func createAgentsTable(d *db.DB) error {
 	ctx := context.Background()
+	// Clean schema for the global mycel.db — the file starts empty and
+	// the one-time deploy consolidation fills it, so no ALTER-based
+	// migrations are carried here. The legacy `workspace` column is
+	// kept only because the Agent struct still round-trips it; `repo`
+	// (absolute cleaned repo path) is the attribution key.
 	schema := `
 		CREATE TABLE IF NOT EXISTS agents (
 			name          TEXT PRIMARY KEY,
@@ -46,7 +52,9 @@ func createAgentsTable(d *db.DB) error {
 			team          TEXT,
 			task          TEXT,
 			session       TEXT,
-			workspace     TEXT NOT NULL,
+			session_id    TEXT,
+			workspace     TEXT NOT NULL DEFAULT '',
+			repo          TEXT NOT NULL DEFAULT '',
 			worktree_dir  TEXT,
 			log_file      TEXT,
 			env_file      TEXT,
@@ -57,27 +65,22 @@ func createAgentsTable(d *db.DB) error {
 			last_crash_time TEXT,
 			recovered_from  TEXT,
 			runtime_backend TEXT,
+			ttl           INTEGER NOT NULL DEFAULT 0,
+			created_at    TEXT,
+			stopped_at    TEXT,
+			deleted_at    TEXT,
 			started_at    TEXT NOT NULL,
 			updated_at    TEXT NOT NULL
 		);
 		CREATE INDEX IF NOT EXISTS idx_agents_state ON agents(state);
 		CREATE INDEX IF NOT EXISTS idx_agents_role ON agents(role);
 		CREATE INDEX IF NOT EXISTS idx_agents_parent ON agents(parent_id);
+		CREATE INDEX IF NOT EXISTS idx_agents_repo ON agents(repo);
 	`
 	_, err := d.ExecContext(ctx, schema)
 	if err != nil {
 		return fmt.Errorf("create agents table: %w", err)
 	}
-
-	// Migrations: add columns for existing databases
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN runtime_backend TEXT`)           //nolint:errcheck // ignore if already exists
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN session_id TEXT`)                //nolint:errcheck // ignore if already exists
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN env_file TEXT`)                  //nolint:errcheck // ignore if already exists
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN ttl INTEGER NOT NULL DEFAULT 0`) //nolint:errcheck // ignore if already exists
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN created_at TEXT`)                //nolint:errcheck // ignore if already exists
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN stopped_at TEXT`)                //nolint:errcheck // ignore if already exists
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN deleted_at TEXT`)                //nolint:errcheck // ignore if already exists
-	_, _ = d.ExecContext(ctx, `ALTER TABLE agents ADD COLUMN repo_root TEXT DEFAULT ''`)      //nolint:errcheck // ignore if already exists
 
 	// agent_stats: time-series Docker resource samples.
 	statsSchema := `
@@ -121,7 +124,7 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 		 worktree_dir, log_file, env_file, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
-		 started_at, updated_at, repo_root)
+		 started_at, updated_at, repo)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.Name, string(a.Role), string(a.State),
 		nullStr(a.Tool), nullStr(a.ParentID), nullStr(a.Team), nullStr(a.Task),
@@ -132,7 +135,7 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 		nullTime(a.LastCrashTime), nullStr(a.RecoveredFrom),
 		nullStr(a.RuntimeBackend), nullStr(a.SessionID),
 		formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
-		formatTime(a.StartedAt), formatTime(now), nullStr(a.RepoRoot),
+		formatTime(a.StartedAt), formatTime(now), a.Repo,
 	)
 	return err
 }
@@ -201,6 +204,49 @@ func (s *SQLiteStore) LoadAll(ctx context.Context) (map[string]*Agent, error) {
 	return agents, rows.Err()
 }
 
+// LoadByRepo reads every non-deleted agent tagged with the given repo
+// path into a map keyed by name. Used by repo-scoped managers so they
+// only materialize their own agents out of the global agents table.
+func (s *SQLiteStore) LoadByRepo(ctx context.Context, repo string) (map[string]*Agent, error) {
+	rows, err := s.db.QueryContext(ctx,
+		agentSelectCols+` FROM agents WHERE deleted_at IS NULL AND repo = ?`, repo)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	agents := make(map[string]*Agent)
+	for rows.Next() {
+		a, err := scanAgentRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		agents[a.Name] = a
+	}
+	return agents, rows.Err()
+}
+
+// LoadNames returns the names of every non-deleted agent in the global
+// table, across all repos. Used for global-uniqueness checks and
+// collision-free name generation.
+func (s *SQLiteStore) LoadNames(ctx context.Context) (map[string]bool, error) {
+	rows, err := s.db.QueryContext(ctx, `SELECT name FROM agents WHERE deleted_at IS NULL`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	names := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		names[name] = true
+	}
+	return names, rows.Err()
+}
+
 // SaveAll persists every agent in the map inside a single transaction.
 func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) error {
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -215,7 +261,7 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 		 worktree_dir, log_file, env_file, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
-		 started_at, updated_at, repo_root)
+		 started_at, updated_at, repo)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
@@ -242,7 +288,7 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 			nullTime(a.LastCrashTime), nullStr(a.RecoveredFrom),
 			nullStr(a.RuntimeBackend), nullStr(a.SessionID),
 			formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
-			formatTime(a.StartedAt), formatTime(now), nullStr(a.RepoRoot),
+			formatTime(a.StartedAt), formatTime(now), a.Repo,
 		)
 		if err != nil {
 			return fmt.Errorf("save agent %s: %w", a.Name, err)
@@ -304,13 +350,14 @@ const agentSelectCols = `SELECT name, role, state, tool, parent_id, team, task, 
 	       worktree_dir, log_file, env_file, hooked_work, children,
 	       is_root, crash_count, last_crash_time, recovered_from,
 	       runtime_backend, session_id, created_at, stopped_at, deleted_at,
-	       started_at, updated_at, repo_root`
+	       started_at, updated_at, repo`
 
 func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	var a Agent
 	var role, state string
 	var tool, parentID, team, task, session, worktreeDir, logFile, envFile, hookedWork, childrenJSON *string
-	var lastCrashTime, recoveredFrom, runtimeBackend, sessionID, repoRoot *string
+	var lastCrashTime, recoveredFrom, runtimeBackend, sessionID *string
+	var repo string
 	var createdAt, stoppedAt, deletedAt *string
 	var startedAt, updatedAt string
 	var isRoot, crashCount int
@@ -321,7 +368,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 		&worktreeDir, &logFile, &envFile, &hookedWork, &childrenJSON,
 		&isRoot, &crashCount, &lastCrashTime, &recoveredFrom,
 		&runtimeBackend, &sessionID, &createdAt, &stoppedAt, &deletedAt,
-		&startedAt, &updatedAt, &repoRoot,
+		&startedAt, &updatedAt, &repo,
 	)
 	if err != nil {
 		return nil, err
@@ -344,7 +391,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	a.CrashCount = crashCount
 	a.RecoveredFrom = deref(recoveredFrom)
 	a.RuntimeBackend = deref(runtimeBackend)
-	a.RepoRoot = deref(repoRoot)
+	a.Repo = repo
 
 	if childrenJSON != nil && *childrenJSON != "" {
 		_ = json.Unmarshal([]byte(*childrenJSON), &a.Children) //nolint:errcheck // best-effort

--- a/pkg/cost/global.go
+++ b/pkg/cost/global.go
@@ -9,8 +9,8 @@ import (
 )
 
 // OpenGlobalStore opens the user-global cost ledger at vaultPath (eg.
-// ~/.mycel/costs.db). Records inserted through ScopedTo(wsID) carry the
-// workspace id for cross-workspace analytics.
+// ~/.mycel/costs.db). Records inserted through ScopedTo(repo) carry the
+// repo path for cross-repo analytics.
 func OpenGlobalStore(vaultPath string) (*Store, error) {
 	d, err := bcdb.Open(vaultPath)
 	if err != nil {
@@ -25,51 +25,54 @@ func OpenGlobalStore(vaultPath string) (*Store, error) {
 		_ = d.Close()
 		return nil, fmt.Errorf("init importer schema: %w", err)
 	}
-	if err := initWorkspaceIDSchema(d.DB); err != nil {
+	if err := initRepoSchema(d.DB); err != nil {
 		_ = d.Close()
-		return nil, fmt.Errorf("init workspace_id column: %w", err)
+		return nil, fmt.Errorf("init repo column: %w", err)
 	}
 	return s, nil
 }
 
-// initWorkspaceIDSchema makes sure the workspace_id column exists on
-// cost_records and that an index backs the "roll up by workspace"
-// query. The ALTER is idempotent-by-swallow-error: SQLite returns
-// "duplicate column name" when it already exists.
-func initWorkspaceIDSchema(db *sql.DB) error {
+// initRepoSchema makes sure the repo column exists on cost_records and
+// that an index backs the "roll up by repo" query. The ALTER is
+// idempotent-by-swallow-error: SQLite returns "duplicate column name"
+// when it already exists. Rows written before the workspace→repo
+// re-key keep their legacy workspace_id values and show up as
+// unattributed until the one-time deploy consolidation rewrites them.
+func initRepoSchema(db *sql.DB) error {
 	ctx := context.Background()
-	_, _ = db.ExecContext(ctx, `ALTER TABLE cost_records ADD COLUMN workspace_id TEXT`)
+	_, _ = db.ExecContext(ctx, `ALTER TABLE cost_records ADD COLUMN repo TEXT`)
 	_, err := db.ExecContext(ctx,
-		`CREATE INDEX IF NOT EXISTS idx_cost_records_workspace ON cost_records(workspace_id)`,
+		`CREATE INDEX IF NOT EXISTS idx_cost_records_repo ON cost_records(repo)`,
 	)
 	return err
 }
 
-// ScopedStore wraps a *Store with a fixed workspace_id. Every record
-// inserted via ScopedStore.Record populates workspace_id so the global
-// ledger can attribute spend to the right workspace. Reads on a
-// ScopedStore fall through unchanged (they use the underlying *Store
-// methods, returning cross-workspace totals).
+// ScopedStore wraps a *Store with a fixed repo path. Every record
+// inserted via ScopedStore.Record populates repo so the global ledger
+// can attribute spend to the right repo. Reads on a ScopedStore fall
+// through unchanged (they use the underlying *Store methods, returning
+// cross-repo totals).
 type ScopedStore struct {
-	store       *Store
-	workspaceID string
+	store *Store
+	repo  string
 }
 
-// ScopedTo returns a ScopedStore that tags every write with wsID.
-// Passing an empty wsID is legal — it writes NULL, which the
-// SumByWorkspace query reports as the empty-string key.
-func (s *Store) ScopedTo(wsID string) *ScopedStore {
-	return &ScopedStore{store: s, workspaceID: wsID}
+// ScopedTo returns a ScopedStore that tags every write with repo (the
+// absolute cleaned repo path). Passing an empty repo is legal — it
+// writes NULL, which the SumByRepo query reports as the empty-string
+// key.
+func (s *Store) ScopedTo(repo string) *ScopedStore {
+	return &ScopedStore{store: s, repo: repo}
 }
 
-// WorkspaceID returns the workspace id this ScopedStore tags writes with.
-func (sc *ScopedStore) WorkspaceID() string { return sc.workspaceID }
+// Repo returns the repo path this ScopedStore tags writes with.
+func (sc *ScopedStore) Repo() string { return sc.repo }
 
-// Store returns the underlying *Store for direct access to non-workspace
+// Store returns the underlying *Store for direct access to non-repo
 // operations (budgets, summaries, etc.).
 func (sc *ScopedStore) Store() *Store { return sc.store }
 
-// Record inserts a cost record tagged with the scoped workspace id.
+// Record inserts a cost record tagged with the scoped repo path.
 // Delegates to the underlying *Store after the write for parity with
 // existing callers.
 func (sc *ScopedStore) Record(ctx context.Context, agentID, teamID, model string, inputTokens, outputTokens int64, costUSD float64) (*Record, error) {
@@ -77,9 +80,9 @@ func (sc *ScopedStore) Record(ctx context.Context, agentID, teamID, model string
 		return nil, fmt.Errorf("scoped cost store has no backing store")
 	}
 	if sc.store.backend != nil {
-		// The Postgres backend doesn't yet know about workspace_id; fall
-		// back to the unscoped Record path so we don't silently drop
-		// data. Migrating the PG schema is deferred.
+		// The Postgres backend doesn't yet know about repo; fall back to
+		// the unscoped Record path so we don't silently drop data.
+		// Migrating the PG schema is deferred.
 		return sc.store.Record(ctx, agentID, teamID, model, inputTokens, outputTokens, costUSD)
 	}
 
@@ -88,14 +91,14 @@ func (sc *ScopedStore) Record(ctx context.Context, agentID, teamID, model string
 	if teamID != "" {
 		teamPtr = &teamID
 	}
-	var wsPtr *string
-	if sc.workspaceID != "" {
-		wsPtr = &sc.workspaceID
+	var repoPtr *string
+	if sc.repo != "" {
+		repoPtr = &sc.repo
 	}
 	result, err := sc.store.db.ExecContext(ctx,
-		`INSERT INTO cost_records (agent_id, team_id, model, input_tokens, output_tokens, total_tokens, cost_usd, workspace_id)
+		`INSERT INTO cost_records (agent_id, team_id, model, input_tokens, output_tokens, total_tokens, cost_usd, repo)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		agentID, teamPtr, model, inputTokens, outputTokens, totalTokens, costUSD, wsPtr,
+		agentID, teamPtr, model, inputTokens, outputTokens, totalTokens, costUSD, repoPtr,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("record scoped cost: %w", err)
@@ -104,63 +107,63 @@ func (sc *ScopedStore) Record(ctx context.Context, agentID, teamID, model string
 	return sc.store.GetByID(ctx, id)
 }
 
-// SumByWorkspace returns total cost USD aggregated by workspace_id for
-// records since the given time. The empty-string key collects rows that
-// pre-date M8e (workspace_id NULL).
-func (s *Store) SumByWorkspace(ctx context.Context, since interface{ Format(string) string }) (map[string]float64, error) {
+// SumByRepo returns total cost USD aggregated by repo for records since
+// the given time. The empty-string key collects rows that pre-date the
+// repo re-key (repo NULL).
+func (s *Store) SumByRepo(ctx context.Context, since interface{ Format(string) string }) (map[string]float64, error) {
 	if s.db == nil {
 		return map[string]float64{}, nil
 	}
 	rows, err := s.db.QueryContext(ctx, `
-		SELECT COALESCE(workspace_id, '') AS ws, SUM(cost_usd)
+		SELECT COALESCE(repo, '') AS repo, SUM(cost_usd)
 		FROM cost_records
 		WHERE timestamp >= ?
-		GROUP BY COALESCE(workspace_id, '')
+		GROUP BY COALESCE(repo, '')
 	`, since.Format("2006-01-02T15:04:05Z"))
 	if err != nil {
-		return nil, fmt.Errorf("sum by workspace: %w", err)
+		return nil, fmt.Errorf("sum by repo: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
 	out := map[string]float64{}
 	for rows.Next() {
-		var ws string
+		var repo string
 		var total float64
-		if err := rows.Scan(&ws, &total); err != nil {
+		if err := rows.Scan(&repo, &total); err != nil {
 			return nil, fmt.Errorf("scan sum: %w", err)
 		}
-		out[ws] = total
+		out[repo] = total
 	}
 	return out, rows.Err()
 }
 
-// WorkspaceNameResolver converts a workspace id to its human-readable
-// name (typically via *workspace.Registry). SumByProject uses it to
-// group by the workspace's stored name; callers that don't need that
-// grouping can pass a resolver that returns the id unchanged.
-type WorkspaceNameResolver func(wsID string) string
+// RepoNameResolver converts a repo path to its human-readable name
+// (typically via *workspace.Registry). SumByProject uses it to group
+// by the repo's registered name; callers that don't need that grouping
+// can pass a resolver that returns the path unchanged.
+type RepoNameResolver func(repo string) string
 
 // SumByProject returns total cost USD grouped by a project-level key
-// since the given time. Each workspace's id is mapped through resolve()
-// to produce the grouping key — typically the workspace name. Records
-// without a workspace_id are placed under the "unattributed" key.
-func (s *Store) SumByProject(ctx context.Context, since interface{ Format(string) string }, resolve WorkspaceNameResolver) (map[string]float64, error) {
-	byWS, err := s.SumByWorkspace(ctx, since)
+// since the given time. Each repo path is mapped through resolve() to
+// produce the grouping key — typically the repo's registered name.
+// Records without a repo are placed under the "unattributed" key.
+func (s *Store) SumByProject(ctx context.Context, since interface{ Format(string) string }, resolve RepoNameResolver) (map[string]float64, error) {
+	byRepo, err := s.SumByRepo(ctx, since)
 	if err != nil {
 		return nil, err
 	}
 	out := map[string]float64{}
-	for wsID, total := range byWS {
+	for repo, total := range byRepo {
 		key := "unattributed"
-		if wsID != "" {
+		if repo != "" {
 			if resolve != nil {
-				if name := resolve(wsID); name != "" {
+				if name := resolve(repo); name != "" {
 					key = name
 				} else {
-					key = wsID
+					key = repo
 				}
 			} else {
-				key = wsID
+				key = repo
 			}
 		}
 		out[key] += total

--- a/pkg/cost/global_test.go
+++ b/pkg/cost/global_test.go
@@ -24,7 +24,7 @@ func TestOpenGlobalStoreCreatesSchema(t *testing.T) {
 		t.Fatal("store db nil")
 	}
 
-	// The workspace_id column must exist.
+	// The repo column must exist.
 	rows, err := s.db.QueryContext(context.Background(), `PRAGMA table_info(cost_records)`)
 	if err != nil {
 		t.Fatal(err)
@@ -39,19 +39,19 @@ func TestOpenGlobalStoreCreatesSchema(t *testing.T) {
 		if scanErr := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); scanErr != nil {
 			t.Fatal(scanErr)
 		}
-		if name == "workspace_id" {
+		if name == "repo" {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("workspace_id column not created")
+		t.Error("repo column not created")
 	}
 }
 
-func TestScopedRecordTagsWorkspace(t *testing.T) {
+func TestScopedRecordTagsRepo(t *testing.T) {
 	s := mkGlobalStore(t)
 	ctx := context.Background()
-	scoped := s.ScopedTo("ws-alpha")
+	scoped := s.ScopedTo("/repos/alpha")
 
 	if _, err := scoped.Record(ctx, "agent1", "", "claude-3", 100, 50, 0.01); err != nil {
 		t.Fatal(err)
@@ -60,24 +60,24 @@ func TestScopedRecordTagsWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	scopedB := s.ScopedTo("ws-beta")
+	scopedB := s.ScopedTo("/repos/beta")
 	if _, err := scopedB.Record(ctx, "agent2", "", "claude-3", 200, 100, 0.05); err != nil {
 		t.Fatal(err)
 	}
 
-	byWS, err := s.SumByWorkspace(ctx, time.Time{})
+	byRepo, err := s.SumByRepo(ctx, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := byWS["ws-alpha"]; got < 0.0299 || got > 0.0301 {
-		t.Errorf("ws-alpha total = %f, want ~0.03", got)
+	if got := byRepo["/repos/alpha"]; got < 0.0299 || got > 0.0301 {
+		t.Errorf("/repos/alpha total = %f, want ~0.03", got)
 	}
-	if got := byWS["ws-beta"]; got < 0.0499 || got > 0.0501 {
-		t.Errorf("ws-beta total = %f, want ~0.05", got)
+	if got := byRepo["/repos/beta"]; got < 0.0499 || got > 0.0501 {
+		t.Errorf("/repos/beta total = %f, want ~0.05", got)
 	}
 }
 
-func TestSumByWorkspaceIncludesUnattributed(t *testing.T) {
+func TestSumByRepoIncludesUnattributed(t *testing.T) {
 	s := mkGlobalStore(t)
 	ctx := context.Background()
 
@@ -85,20 +85,20 @@ func TestSumByWorkspaceIncludesUnattributed(t *testing.T) {
 	if _, err := scoped.Record(ctx, "a", "", "m", 1, 1, 0.1); err != nil {
 		t.Fatal(err)
 	}
-	scopedA := s.ScopedTo("ws-a")
+	scopedA := s.ScopedTo("/repos/a")
 	if _, err := scopedA.Record(ctx, "a", "", "m", 1, 1, 0.2); err != nil {
 		t.Fatal(err)
 	}
 
-	byWS, err := s.SumByWorkspace(ctx, time.Time{})
+	byRepo, err := s.SumByRepo(ctx, time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := byWS[""]; got < 0.099 || got > 0.101 {
+	if got := byRepo[""]; got < 0.099 || got > 0.101 {
 		t.Errorf("unattributed total = %f", got)
 	}
-	if got := byWS["ws-a"]; got < 0.199 || got > 0.201 {
-		t.Errorf("ws-a total = %f", got)
+	if got := byRepo["/repos/a"]; got < 0.199 || got > 0.201 {
+		t.Errorf("/repos/a total = %f", got)
 	}
 }
 
@@ -106,8 +106,8 @@ func TestSumByProjectUsesResolver(t *testing.T) {
 	s := mkGlobalStore(t)
 	ctx := context.Background()
 
-	sA := s.ScopedTo("wsid-a")
-	sB := s.ScopedTo("wsid-b")
+	sA := s.ScopedTo("/repos/trade-prod")
+	sB := s.ScopedTo("/repos/trade-paper")
 	if _, err := sA.Record(ctx, "x", "", "m", 1, 1, 1.0); err != nil {
 		t.Fatal(err)
 	}
@@ -115,8 +115,8 @@ func TestSumByProjectUsesResolver(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	names := map[string]string{"wsid-a": "trade-prod", "wsid-b": "trade-paper"}
-	resolve := func(wsID string) string { return names[wsID] }
+	names := map[string]string{"/repos/trade-prod": "trade-prod", "/repos/trade-paper": "trade-paper"}
+	resolve := func(repo string) string { return names[repo] }
 
 	got, err := s.SumByProject(ctx, time.Time{}, resolve)
 	if err != nil {

--- a/pkg/cost/importer.go
+++ b/pkg/cost/importer.go
@@ -19,11 +19,11 @@ import (
 type Importer struct {
 	store        *Store
 	workspaceDir string
-	// workspaceID, when non-empty, is written into the workspace_id
-	// column of each cost_records row inserted by this Importer. Used
-	// with the user-global cost ledger (M8e) so imports get attributed
-	// to the right workspace.
-	workspaceID string
+	// repo, when non-empty, is written into the repo column of each
+	// cost_records row inserted by this Importer. Used with the
+	// user-global cost ledger so imports get attributed to the right
+	// repo.
+	repo string
 }
 
 // NewImporter creates an Importer for the given workspace.
@@ -31,11 +31,11 @@ func NewImporter(store *Store, workspaceDir string) *Importer {
 	return &Importer{store: store, workspaceDir: workspaceDir}
 }
 
-// SetWorkspaceID sets the workspace id tagged onto every record
-// imported by this Importer. Pass the empty string to revert to the
-// legacy behavior (untagged rows).
-func (imp *Importer) SetWorkspaceID(wsID string) {
-	imp.workspaceID = wsID
+// SetRepo sets the repo path tagged onto every record imported by this
+// Importer. Pass the empty string to revert to the legacy behavior
+// (untagged rows).
+func (imp *Importer) SetRepo(repo string) {
+	imp.repo = repo
 }
 
 // ImportAll scans all known Claude projects directories and imports new sessions.
@@ -179,12 +179,12 @@ func (imp *Importer) importFile(ctx context.Context, path string) (int, error) {
 
 		var res sql.Result
 		var insertErr error
-		// workspace_id lives as a nullable TEXT column (added by the
-		// importer schema migrations below). When no id is set, pass
-		// nil so pre-M8e rows stay NULL.
-		var wsPtr *string
-		if imp.workspaceID != "" {
-			wsPtr = &imp.workspaceID
+		// repo lives as a nullable TEXT column (added by the importer
+		// schema migrations below). When no repo is set, pass nil so
+		// untagged rows stay NULL.
+		var repoPtr *string
+		if imp.repo != "" {
+			repoPtr = &imp.repo
 		}
 		ts := e.Timestamp.UTC().Format(time.RFC3339Nano)
 		// The WHERE NOT EXISTS guard dedups identical usage entries that
@@ -194,8 +194,8 @@ func (imp *Importer) importFile(ctx context.Context, path string) (int, error) {
 		// sessionId, timestamps and token counts — and the per-file
 		// watermark alone can't catch that.
 		if usePostgres {
-			// Postgres backend has not yet grown the workspace_id column
-			// — deferred to a follow-up. Keep the legacy insert so the
+			// Postgres backend has not yet grown the repo column —
+			// deferred to a follow-up. Keep the legacy insert so the
 			// backend continues to work without schema changes.
 			res, insertErr = tx.ExecContext(ctx,
 				`INSERT INTO cost_records
@@ -220,7 +220,7 @@ func (imp *Importer) importFile(ctx context.Context, path string) (int, error) {
 			res, insertErr = tx.ExecContext(ctx,
 				`INSERT INTO cost_records
 				 (agent_id, model, session_id, input_tokens, output_tokens, total_tokens,
-				  cache_creation_tokens, cache_read_tokens, cost_usd, timestamp, workspace_id)
+				  cache_creation_tokens, cache_read_tokens, cost_usd, timestamp, repo)
 				 SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 				 WHERE NOT EXISTS (
 				   SELECT 1 FROM cost_records
@@ -231,7 +231,7 @@ func (imp *Importer) importFile(ctx context.Context, path string) (int, error) {
 				ie.agentID, e.Model, e.SessionID,
 				e.InputTokens, e.OutputTokens, total,
 				e.CacheCreationTokens, e.CacheReadTokens,
-				ie.costUSD, ts, wsPtr,
+				ie.costUSD, ts, repoPtr,
 				e.SessionID, ts, e.Model,
 				e.InputTokens, e.OutputTokens,
 				e.CacheCreationTokens, e.CacheReadTokens,
@@ -332,9 +332,9 @@ func initImporterSchema(db *sql.DB) error {
 		`ALTER TABLE cost_records ADD COLUMN session_id TEXT`,
 		`ALTER TABLE cost_records ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE cost_records ADD COLUMN cache_read_tokens INTEGER NOT NULL DEFAULT 0`,
-		// M8e: workspace_id tags each row with the owning workspace so
-		// the user-global ledger can roll up cross-workspace spend.
-		`ALTER TABLE cost_records ADD COLUMN workspace_id TEXT`,
+		// repo tags each row with the owning repo path so the
+		// user-global ledger can roll up cross-repo spend.
+		`ALTER TABLE cost_records ADD COLUMN repo TEXT`,
 	}
 	for _, m := range migrations {
 		_, _ = db.ExecContext(ctx, m) // ignore "duplicate column" errors

--- a/pkg/cron/cron.go
+++ b/pkg/cron/cron.go
@@ -6,7 +6,7 @@
 //
 // # Usage
 //
-//	wsDB, driver, err := db.ForWorkspace("/path/to/workspace", nil)
+//	wsDB, driver, err := db.Global(nil)
 //	if err != nil {
 //	    return err
 //	}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -32,7 +32,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3" // SQLite driver
@@ -150,108 +149,4 @@ func applyPragmas(db *sql.DB, cfg Config) error {
 
 	_, err := db.ExecContext(ctx, pragmas)
 	return err
-}
-
-// Registry caches one workspace database connection per workspace root.
-//
-// It is the replacement for the old process-global "shared" connection:
-// instead of every store writing into whichever workspace's bc.db the
-// daemon happened to launch with, each workspace root gets its own
-// connection, opened lazily on first use via OpenWorkspaceDBWithConfig
-// (SQLite at BCDBPath(root) by default, or that workspace's own
-// TimescaleDB with SQLite fallback).
-//
-// Lifecycle: connections stay cached for the life of the process even if
-// the workspace's services are evicted for idleness — a cached idle
-// SQLite handle is cheap (max one conn), and keeping it avoids reopen
-// churn plus use-after-close races with other holders of the handle.
-// Stores treat the handle as borrowed and never close it; only
-// CloseWorkspace / Close tear connections down (process shutdown, or
-// tests).
-type Registry struct {
-	entries map[string]*registryEntry
-	mu      sync.Mutex
-}
-
-type registryEntry struct {
-	db     *DB
-	driver string // "sqlite" or "timescale"
-}
-
-// NewRegistry creates a new empty database registry.
-func NewRegistry() *Registry {
-	return &Registry{entries: make(map[string]*registryEntry)}
-}
-
-// registryKey normalizes a workspace root into a stable map key.
-func registryKey(root string) (string, error) {
-	abs, err := filepath.Abs(root)
-	if err != nil {
-		return "", fmt.Errorf("resolve workspace root %q: %w", root, err)
-	}
-	return filepath.Clean(abs), nil
-}
-
-// Get returns the database connection for the workspace rooted at root,
-// opening (and caching) it on first use. cfg is only consulted on the
-// first open for a given root; later calls return the cached handle and
-// its driver regardless of cfg.
-//
-// The lock is held across the open so concurrent callers for the same
-// root can never race two connections into existence.
-func (r *Registry) Get(root string, cfg *StorageSettings) (*DB, string, error) {
-	key, err := registryKey(root)
-	if err != nil {
-		return nil, "", err
-	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if e, ok := r.entries[key]; ok {
-		return e.db, e.driver, nil
-	}
-
-	sqlDB, driver, err := OpenWorkspaceDBWithConfig(root, cfg)
-	if err != nil {
-		return nil, "", fmt.Errorf("open workspace db %s: %w", root, err)
-	}
-
-	e := &registryEntry{db: &DB{DB: sqlDB}, driver: driver}
-	r.entries[key] = e
-	return e.db, e.driver, nil
-}
-
-// CloseWorkspace closes and evicts the cached connection for root, if
-// any. A subsequent Get reopens it.
-func (r *Registry) CloseWorkspace(root string) error {
-	key, err := registryKey(root)
-	if err != nil {
-		return err
-	}
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	e, ok := r.entries[key]
-	if !ok {
-		return nil // not open
-	}
-	delete(r.entries, key)
-	return e.db.Close()
-}
-
-// Close closes all cached connections and empties the registry.
-func (r *Registry) Close() error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	var firstErr error
-	for key, e := range r.entries {
-		if err := e.db.Close(); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("close workspace db %q: %w", key, err)
-		}
-	}
-	r.entries = make(map[string]*registryEntry)
-	return firstErr
 }

--- a/pkg/db/db_test.go
+++ b/pkg/db/db_test.go
@@ -86,89 +86,90 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
-func TestRegistry(t *testing.T) {
-	t.Run("get opens lazily and caches", func(t *testing.T) {
-		dir := t.TempDir()
-		registry := NewRegistry()
-		t.Cleanup(func() { _ = registry.Close() })
+func TestGlobalSingleton(t *testing.T) {
+	t.Run("global open is a singleton", func(t *testing.T) {
+		t.Setenv("MYCEL_HOME", t.TempDir())
+		t.Cleanup(func() { _ = CloseGlobal() })
 
-		d, driver, err := registry.Get(dir, nil)
+		d1, driver, err := Global(nil)
 		if err != nil {
-			t.Fatalf("Get() error = %v", err)
+			t.Fatalf("Global() error = %v", err)
 		}
 		if driver != "sqlite" {
 			t.Errorf("driver = %q, want sqlite", driver)
 		}
 
-		// Verify same instance is returned
-		d2, _, err := registry.Get(dir, nil)
+		d2, _, err := Global(nil)
 		if err != nil {
-			t.Fatalf("Get() second call error = %v", err)
+			t.Fatalf("Global() second call error = %v", err)
 		}
-		if d != d2 {
-			t.Error("expected same database instance")
+		if d1 != d2 {
+			t.Error("expected the same handle on every Global() call")
 		}
-	})
 
-	t.Run("distinct roots open distinct connections", func(t *testing.T) {
-		registry := NewRegistry()
-		t.Cleanup(func() { _ = registry.Close() })
-
-		dA, _, err := registry.Get(t.TempDir(), nil)
+		path, err := GlobalDBPath()
 		if err != nil {
-			t.Fatalf("Get(A) error = %v", err)
+			t.Fatalf("GlobalDBPath() error = %v", err)
 		}
-		dB, _, err := registry.Get(t.TempDir(), nil)
+		if d1.Path() != path {
+			t.Errorf("handle path = %q, want %q", d1.Path(), path)
+		}
+		if _, statErr := os.Stat(path); statErr != nil {
+			t.Errorf("mycel.db not created at %s: %v", path, statErr)
+		}
+	})
+
+	t.Run("cfg only consulted on first open", func(t *testing.T) {
+		t.Setenv("MYCEL_HOME", t.TempDir())
+		t.Cleanup(func() { _ = CloseGlobal() })
+
+		d1, _, err := Global(nil)
 		if err != nil {
-			t.Fatalf("Get(B) error = %v", err)
+			t.Fatalf("Global() error = %v", err)
 		}
-		if dA == dB {
-			t.Error("expected distinct connections for distinct roots")
+		// Later calls with a different cfg still return the cached handle.
+		d2, driver, err := Global(&StorageSettings{Default: "timescale"})
+		if err != nil {
+			t.Fatalf("Global(cfg) error = %v", err)
 		}
-	})
-
-	t.Run("close all", func(t *testing.T) {
-		registry := NewRegistry()
-
-		if _, _, err := registry.Get(t.TempDir(), nil); err != nil {
-			t.Fatalf("Get(db1) error = %v", err)
-		}
-		if _, _, err := registry.Get(t.TempDir(), nil); err != nil {
-			t.Fatalf("Get(db2) error = %v", err)
-		}
-
-		// Close all
-		if err := registry.Close(); err != nil {
-			t.Errorf("Close() error = %v", err)
+		if d1 != d2 || driver != "sqlite" {
+			t.Error("cfg must be ignored after first open")
 		}
 	})
 
-	t.Run("close workspace then reopen", func(t *testing.T) {
-		dir := t.TempDir()
-		registry := NewRegistry()
-		t.Cleanup(func() { _ = registry.Close() })
+	t.Run("CloseGlobal then Global reopens", func(t *testing.T) {
+		t.Setenv("MYCEL_HOME", t.TempDir())
+		t.Cleanup(func() { _ = CloseGlobal() })
 
-		if _, _, err := registry.Get(dir, nil); err != nil {
-			t.Fatalf("Get() error = %v", err)
+		ctx := context.Background()
+		d1, _, err := Global(nil)
+		if err != nil {
+			t.Fatalf("Global() error = %v", err)
 		}
-
-		if closeErr := registry.CloseWorkspace(dir); closeErr != nil {
-			t.Errorf("CloseWorkspace() error = %v", closeErr)
+		if closeErr := CloseGlobal(); closeErr != nil {
+			t.Fatalf("CloseGlobal() error = %v", closeErr)
 		}
-
-		// Getting again should reopen
-		if _, _, err := registry.Get(dir, nil); err != nil {
-			t.Errorf("Get() after CloseWorkspace error = %v", err)
+		if pingErr := d1.PingContext(ctx); pingErr == nil {
+			t.Error("expected closed handle to fail Ping after CloseGlobal")
+		}
+		d2, _, err := Global(nil)
+		if err != nil {
+			t.Fatalf("Global() after CloseGlobal error = %v", err)
+		}
+		if pingErr := d2.PingContext(ctx); pingErr != nil {
+			t.Errorf("reopened handle Ping: %v", pingErr)
 		}
 	})
 
-	t.Run("close workspace not open is no-op", func(t *testing.T) {
-		registry := NewRegistry()
-		t.Cleanup(func() { _ = registry.Close() })
-
-		// Close without opening - should not error
-		if err := registry.CloseWorkspace(t.TempDir()); err != nil {
-			t.Errorf("CloseWorkspace() error = %v", err)
+	t.Run("GlobalDBPath honors MYCEL_HOME", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("MYCEL_HOME", home)
+		path, err := GlobalDBPath()
+		if err != nil {
+			t.Fatalf("GlobalDBPath() error = %v", err)
+		}
+		if want := filepath.Join(home, GlobalDBFileName); path != want {
+			t.Errorf("GlobalDBPath() = %q, want %q", path, want)
 		}
 	})
 }

--- a/pkg/db/storage_integration_test.go
+++ b/pkg/db/storage_integration_test.go
@@ -17,197 +17,126 @@ import (
 	"github.com/rpuneet/mycel/pkg/tool"
 )
 
-// setupSharedDB opens a temporary workspace database through the
-// per-workspace registry (the production path) and registers cleanup to
-// close it after the test. Returns the workspace root and the handle.
+// setupSharedDB opens the single global database (pinned to a per-test
+// MYCEL_HOME) through the production path and registers cleanup to
+// close it after the test. Returns the mycel home dir and the handle.
 func setupSharedDB(t *testing.T) (string, *db.DB) {
 	t.Helper()
-	dir := t.TempDir()
-	d, driver, err := db.ForWorkspace(dir, nil)
+	home := t.TempDir()
+	t.Setenv("MYCEL_HOME", home)
+	d, driver, err := db.Global(nil)
 	if err != nil {
-		t.Fatalf("db.ForWorkspace: %v", err)
+		t.Fatalf("db.Global: %v", err)
 	}
 	if driver != "sqlite" {
 		t.Fatalf("driver = %q, want sqlite", driver)
 	}
-	t.Cleanup(func() { _ = db.CloseWorkspaceDB(dir) })
-	return dir, d
+	t.Cleanup(func() { _ = db.CloseGlobal() })
+	return home, d
 }
 
 // ---------------------------------------------------------------------------
 // 1. Shared DB lifecycle
 // ---------------------------------------------------------------------------
 
-func TestStorageRegistryLifecycle(t *testing.T) {
-	t.Run("same root twice returns the same handle", func(t *testing.T) {
-		reg := db.NewRegistry()
-		t.Cleanup(func() { _ = reg.Close() })
-
-		dir := t.TempDir()
-		d1, driver1, err := reg.Get(dir, nil)
+func TestStorageGlobalLifecycle(t *testing.T) {
+	t.Run("same process shares one handle", func(t *testing.T) {
+		home, d1 := setupSharedDB(t)
+		d2, driver, err := db.Global(nil)
 		if err != nil {
-			t.Fatalf("Get: %v", err)
+			t.Fatalf("Global (second): %v", err)
 		}
-		if driver1 != "sqlite" {
-			t.Errorf("driver = %q, want sqlite", driver1)
-		}
-		d2, _, err := reg.Get(dir, nil)
-		if err != nil {
-			t.Fatalf("Get (second): %v", err)
+		if driver != "sqlite" {
+			t.Errorf("driver = %q, want sqlite", driver)
 		}
 		if d1 != d2 {
-			t.Error("expected the cached handle on second Get")
+			t.Error("expected the cached global handle on second Global")
+		}
+		if _, statErr := os.Stat(filepath.Join(home, db.GlobalDBFileName)); statErr != nil {
+			t.Errorf("mycel.db missing: %v", statErr)
 		}
 	})
 
-	t.Run("different roots get isolated databases", func(t *testing.T) {
-		reg := db.NewRegistry()
-		t.Cleanup(func() { _ = reg.Close() })
-
-		dirA, dirB := t.TempDir(), t.TempDir()
-		dA, _, err := reg.Get(dirA, nil)
-		if err != nil {
-			t.Fatalf("Get A: %v", err)
-		}
-		dB, _, err := reg.Get(dirB, nil)
-		if err != nil {
-			t.Fatalf("Get B: %v", err)
-		}
-		if dA == dB {
-			t.Fatal("expected distinct handles for distinct workspace roots")
-		}
-
-		ctx := context.Background()
-		if _, execErr := dA.ExecContext(ctx, "CREATE TABLE reg_probe (id INTEGER)"); execErr != nil {
-			t.Fatalf("create probe table in A: %v", execErr)
-		}
-		var n int
-		err = dB.QueryRowContext(ctx,
-			"SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='reg_probe'").Scan(&n)
-		if err != nil {
-			t.Fatalf("query B: %v", err)
-		}
-		if n != 0 {
-			t.Error("table created in workspace A leaked into workspace B's database")
-		}
-	})
-
-	t.Run("CloseWorkspace evicts and Get reopens", func(t *testing.T) {
-		reg := db.NewRegistry()
-		t.Cleanup(func() { _ = reg.Close() })
-
-		dir := t.TempDir()
-		d1, _, err := reg.Get(dir, nil)
-		if err != nil {
-			t.Fatalf("Get: %v", err)
-		}
-		if closeErr := reg.CloseWorkspace(dir); closeErr != nil {
-			t.Fatalf("CloseWorkspace: %v", closeErr)
+	t.Run("CloseGlobal evicts and Global reopens", func(t *testing.T) {
+		_, d1 := setupSharedDB(t)
+		if closeErr := db.CloseGlobal(); closeErr != nil {
+			t.Fatalf("CloseGlobal: %v", closeErr)
 		}
 		if pingErr := d1.Ping(); pingErr == nil {
-			t.Error("expected closed handle to fail Ping after CloseWorkspace")
+			t.Error("expected closed handle to fail Ping after CloseGlobal")
 		}
 		// Closing again is a no-op.
-		if closeErr := reg.CloseWorkspace(dir); closeErr != nil {
-			t.Errorf("second CloseWorkspace: %v", closeErr)
+		if closeErr := db.CloseGlobal(); closeErr != nil {
+			t.Errorf("second CloseGlobal: %v", closeErr)
 		}
 
-		d2, _, err := reg.Get(dir, nil)
+		d2, _, err := db.Global(nil)
 		if err != nil {
-			t.Fatalf("Get after CloseWorkspace: %v", err)
+			t.Fatalf("Global after CloseGlobal: %v", err)
 		}
 		if pingErr := d2.Ping(); pingErr != nil {
 			t.Errorf("reopened handle Ping: %v", pingErr)
 		}
 	})
-
-	t.Run("Close closes everything", func(t *testing.T) {
-		reg := db.NewRegistry()
-		dirA, dirB := t.TempDir(), t.TempDir()
-		dA, _, err := reg.Get(dirA, nil)
-		if err != nil {
-			t.Fatalf("Get A: %v", err)
-		}
-		dB, _, err := reg.Get(dirB, nil)
-		if err != nil {
-			t.Fatalf("Get B: %v", err)
-		}
-		if err := reg.Close(); err != nil {
-			t.Fatalf("Close: %v", err)
-		}
-		if dA.Ping() == nil || dB.Ping() == nil {
-			t.Error("expected all handles closed after registry Close")
-		}
-	})
 }
 
-// TestStorageWorkspaceIsolation is the multi-workspace bleed regression
-// test for issue #3238: stores built for two workspaces in the same
-// process must land in each workspace's own database. Notify
-// subscriptions were the observable symptom (workspace B's Slack
-// subscriptions showed up in workspace A).
-func TestStorageWorkspaceIsolation(t *testing.T) {
+// TestStorageSharedDBKeyIsolation replaces the old per-workspace file
+// isolation test (#3238/#3275): with the single global mycel.db, two
+// "workspaces" now SHARE one database. Isolation is provided by data
+// keys — channel names for subscriptions, globally-unique agent names,
+// and the repo column on agents — not by separate files.
+func TestStorageSharedDBKeyIsolation(t *testing.T) {
 	ctx := context.Background()
+	_, d := setupSharedDB(t)
 
-	wsA, wsB := t.TempDir(), t.TempDir()
-	for _, dir := range []string{wsA, wsB} {
-		t.Cleanup(func() { _ = db.CloseWorkspaceDB(dir) })
+	ns, err := notify.OpenStore(d, "sqlite")
+	if err != nil {
+		t.Fatalf("notify.OpenStore: %v", err)
 	}
 
-	openNotify := func(t *testing.T, root string) *notify.Store {
-		t.Helper()
-		d, driver, err := db.ForWorkspace(root, nil)
-		if err != nil {
-			t.Fatalf("ForWorkspace(%s): %v", root, err)
-		}
-		ns, err := notify.OpenStore(d, driver)
-		if err != nil {
-			t.Fatalf("notify.OpenStore(%s): %v", root, err)
-		}
-		return ns
+	// Subscriptions written by "workspace A" and "workspace B" land in
+	// the same table; they are distinguished by channel and agent keys.
+	if subErr := ns.Subscribe(ctx, "#engineering", "agent-a", false); subErr != nil {
+		t.Fatalf("Subscribe A: %v", subErr)
+	}
+	if subErr := ns.Subscribe(ctx, "#ops", "agent-b", false); subErr != nil {
+		t.Fatalf("Subscribe B: %v", subErr)
 	}
 
-	nsA := openNotify(t, wsA)
-	nsB := openNotify(t, wsB)
-
-	tests := []struct {
-		name    string
-		store   *notify.Store
-		other   *notify.Store
-		channel string
-		agent   string
-	}{
-		{"workspace A subscription stays in A", nsA, nsB, "#engineering", "agent-a"},
-		{"workspace B subscription stays in B", nsB, nsA, "#ops", "agent-b"},
+	eng, err := ns.Subscribers(ctx, "#engineering")
+	if err != nil {
+		t.Fatalf("Subscribers #engineering: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.store.Subscribe(ctx, tt.channel, tt.agent, false); err != nil {
-				t.Fatalf("Subscribe: %v", err)
-			}
-			mine, err := tt.store.Subscribers(ctx, tt.channel)
-			if err != nil {
-				t.Fatalf("Subscribers (own): %v", err)
-			}
-			if len(mine) != 1 || mine[0].Agent != tt.agent {
-				t.Fatalf("own workspace subscribers = %+v, want [%s]", mine, tt.agent)
-			}
-			theirs, err := tt.other.Subscribers(ctx, tt.channel)
-			if err != nil {
-				t.Fatalf("Subscribers (other): %v", err)
-			}
-			if len(theirs) != 0 {
-				t.Errorf("subscription bled into the other workspace: %+v", theirs)
-			}
-		})
+	if len(eng) != 1 || eng[0].Agent != "agent-a" {
+		t.Errorf("#engineering subscribers = %+v, want [agent-a]", eng)
+	}
+	ops, err := ns.Subscribers(ctx, "#ops")
+	if err != nil {
+		t.Fatalf("Subscribers #ops: %v", err)
+	}
+	if len(ops) != 1 || ops[0].Agent != "agent-b" {
+		t.Errorf("#ops subscribers = %+v, want [agent-b]", ops)
 	}
 
-	// The two stores must genuinely sit on different database files.
-	if _, err := os.Stat(filepath.Join(wsA, ".bc", "bc.db")); err != nil {
-		t.Errorf("workspace A bc.db missing: %v", err)
+	// A second Global call from "another workspace" returns the SAME
+	// handle and sees the same data — the single-DB contract.
+	d2, _, err := db.Global(nil)
+	if err != nil {
+		t.Fatalf("Global (workspace B view): %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(wsB, ".bc", "bc.db")); err != nil {
-		t.Errorf("workspace B bc.db missing: %v", err)
+	if d2 != d {
+		t.Fatal("expected both workspaces to share the one global handle")
+	}
+	ns2, err := notify.OpenStore(d2, "sqlite")
+	if err != nil {
+		t.Fatalf("notify.OpenStore (B): %v", err)
+	}
+	shared, err := ns2.Subscribers(ctx, "#engineering")
+	if err != nil {
+		t.Fatalf("Subscribers via B: %v", err)
+	}
+	if len(shared) != 1 || shared[0].Agent != "agent-a" {
+		t.Errorf("workspace B must see the shared subscription, got %+v", shared)
 	}
 }
 
@@ -451,9 +380,9 @@ func TestStorageIsolationConcurrent(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestStorageConfigValidation(t *testing.T) {
-	t.Run("OpenWorkspaceDBWithConfig sqlite default", func(t *testing.T) {
+	t.Run("OpenGlobalDBWithConfig sqlite default", func(t *testing.T) {
 		dir := t.TempDir()
-		sqlDB, driver, err := db.OpenWorkspaceDBWithConfig(dir, &db.StorageSettings{
+		sqlDB, driver, err := db.OpenGlobalDBWithConfig(filepath.Join(dir, db.GlobalDBFileName), &db.StorageSettings{
 			Default: "sqlite",
 		})
 		if err != nil {
@@ -469,9 +398,9 @@ func TestStorageConfigValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("OpenWorkspaceDBWithConfig nil config defaults to sqlite", func(t *testing.T) {
+	t.Run("OpenGlobalDBWithConfig nil config defaults to sqlite", func(t *testing.T) {
 		dir := t.TempDir()
-		sqlDB, driver, err := db.OpenWorkspaceDBWithConfig(dir, nil)
+		sqlDB, driver, err := db.OpenGlobalDBWithConfig(filepath.Join(dir, db.GlobalDBFileName), nil)
 		if err != nil {
 			t.Fatalf("OpenWorkspaceDBWithConfig: %v", err)
 		}
@@ -482,12 +411,12 @@ func TestStorageConfigValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("OpenWorkspaceDBWithConfig timescale without postgres falls back to sqlite", func(t *testing.T) {
+	t.Run("OpenGlobalDBWithConfig timescale without postgres falls back to sqlite", func(t *testing.T) {
 		// Ensure DATABASE_URL is not set so it hits the config path.
 		t.Setenv("DATABASE_URL", "")
 
 		dir := t.TempDir()
-		sqlDB, driver, err := db.OpenWorkspaceDBWithConfig(dir, &db.StorageSettings{
+		sqlDB, driver, err := db.OpenGlobalDBWithConfig(filepath.Join(dir, db.GlobalDBFileName), &db.StorageSettings{
 			Default: "timescale",
 			Timescale: db.TimescaleSettings{
 				Host: "127.0.0.1",
@@ -503,11 +432,11 @@ func TestStorageConfigValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("OpenWorkspaceDBWithConfig legacy sql treated as timescale", func(t *testing.T) {
+	t.Run("OpenGlobalDBWithConfig legacy sql treated as timescale", func(t *testing.T) {
 		t.Setenv("DATABASE_URL", "")
 
 		dir := t.TempDir()
-		sqlDB, driver, err := db.OpenWorkspaceDBWithConfig(dir, &db.StorageSettings{
+		sqlDB, driver, err := db.OpenGlobalDBWithConfig(filepath.Join(dir, db.GlobalDBFileName), &db.StorageSettings{
 			Default: "sql",
 			Timescale: db.TimescaleSettings{
 				Host: "127.0.0.1",
@@ -877,14 +806,14 @@ func TestStorageEventsSmoke(t *testing.T) {
 }
 
 func TestStorageChannelSharedDBReady(t *testing.T) {
-	dir, d := setupSharedDB(t)
+	home, d := setupSharedDB(t)
 
-	// Verify the workspace DB infrastructure is set up correctly for
+	// Verify the global DB infrastructure is set up correctly for
 	// channel use. Full channel CRUD tests live in pkg/notify/*_test.go.
-	if _, err := os.Stat(filepath.Join(dir, ".bc", "bc.db")); err != nil {
-		t.Fatalf("workspace bc.db not created: %v", err)
+	if _, err := os.Stat(filepath.Join(home, db.GlobalDBFileName)); err != nil {
+		t.Fatalf("global mycel.db not created: %v", err)
 	}
 	if err := d.Ping(); err != nil {
-		t.Fatalf("workspace db Ping: %v", err)
+		t.Fatalf("global db Ping: %v", err)
 	}
 }

--- a/pkg/db/unified.go
+++ b/pkg/db/unified.go
@@ -6,9 +6,13 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/rpuneet/mycel/pkg/log"
 )
+
+// GlobalDBFileName is the file name of the single global database.
+const GlobalDBFileName = "mycel.db"
 
 // DefaultPassword returns the database password from BC_DB_PASSWORD env var,
 // falling back to "bc" for local development with a warning log.
@@ -21,40 +25,107 @@ func DefaultPassword() string {
 	return "bc"
 }
 
-// BCDBPath returns the path to the unified bc database for a workspace.
-func BCDBPath(workspaceRoot string) string {
-	return filepath.Join(workspaceRoot, ".bc", "bc.db")
+// mycelHome resolves the global mycel home directory: the MYCEL_HOME
+// env var when set (tests, containers), otherwise ~/.mycel. Kept local
+// to pkg/db to avoid an import cycle with pkg/workspace, which imports
+// this package for StorageSettings.
+func mycelHome() (string, error) {
+	if env := os.Getenv("MYCEL_HOME"); env != "" {
+		return env, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".mycel"), nil
 }
 
-// defaultRegistry is the process-wide per-workspace connection registry.
-// Unlike the old single "shared" connection (which pinned every store to
-// the LAUNCH workspace's bc.db), the registry keys connections by
-// workspace root, so workspace B's stores can never write into
-// workspace A's database.
-var defaultRegistry = NewRegistry()
+// GlobalDBPath returns the path of the single global database file:
+// <MycelHome>/mycel.db. Every store — agents, events, notify, cron,
+// mcp, tools, roles — lives in this one database; isolation between
+// repos comes from data keys (agent name, repo path), not from
+// separate files.
+func GlobalDBPath() (string, error) {
+	home, err := mycelHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, GlobalDBFileName), nil
+}
 
-// ForWorkspace returns the (lazily opened, cached) database connection
-// and driver ("sqlite" or "timescale") for the workspace rooted at root.
-// cfg is only consulted on the first open for that root; pass nil to use
+// globalConns caches the process-wide database handle(s), keyed by the
+// resolved mycel.db path. In production this holds exactly one entry —
+// THE global mycel.db — but keying by path keeps tests that point
+// MYCEL_HOME at different temp dirs isolated from each other.
+//
+// Lifecycle: the handle stays cached for the life of the process even
+// if a workspace's services are evicted for idleness — a cached idle
+// SQLite handle is cheap (max one conn), and keeping it avoids reopen
+// churn plus use-after-close races with other holders. Stores treat
+// the handle as borrowed and never close it; only CloseGlobal tears it
+// down (process shutdown, or tests).
+var globalConns = struct {
+	entries map[string]*globalEntry
+	mu      sync.Mutex
+}{entries: make(map[string]*globalEntry)}
+
+type globalEntry struct {
+	db     *DB
+	driver string // "sqlite" or "timescale"
+}
+
+// Global returns the process-wide database handle and driver ("sqlite"
+// or "timescale"), opening <MycelHome>/mycel.db lazily on first use.
+//
+// cfg selects the backend (DATABASE_URL env > cfg timescale > SQLite
+// at GlobalDBPath) and is only consulted on the first open; later
+// calls return the cached handle regardless of cfg. Pass nil to use
 // DATABASE_URL / SQLite defaults.
-func ForWorkspace(root string, cfg *StorageSettings) (*DB, string, error) {
-	return defaultRegistry.Get(root, cfg)
+//
+// The lock is held across the open so concurrent callers can never
+// race two connections into existence.
+func Global(cfg *StorageSettings) (*DB, string, error) {
+	path, err := GlobalDBPath()
+	if err != nil {
+		return nil, "", err
+	}
+
+	globalConns.mu.Lock()
+	defer globalConns.mu.Unlock()
+
+	if e, ok := globalConns.entries[path]; ok {
+		return e.db, e.driver, nil
+	}
+
+	sqlDB, driver, err := OpenGlobalDBWithConfig(path, cfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("open global db %s: %w", path, err)
+	}
+
+	e := &globalEntry{db: &DB{DB: sqlDB, path: path}, driver: driver}
+	globalConns.entries[path] = e
+	return e.db, e.driver, nil
 }
 
-// CloseWorkspaceDB closes and evicts the cached connection for root from
-// the default registry. A later ForWorkspace reopens it.
-func CloseWorkspaceDB(root string) error {
-	return defaultRegistry.CloseWorkspace(root)
-}
+// CloseGlobal closes every cached global connection and empties the
+// cache. Call at process shutdown; a subsequent Global reopens.
+func CloseGlobal() error {
+	globalConns.mu.Lock()
+	defer globalConns.mu.Unlock()
 
-// CloseAllWorkspaceDBs closes every connection in the default registry.
-// Call at process shutdown.
-func CloseAllWorkspaceDBs() error {
-	return defaultRegistry.Close()
+	var firstErr error
+	for key, e := range globalConns.entries {
+		if err := e.db.Close(); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("close global db %q: %w", key, err)
+		}
+	}
+	globalConns.entries = make(map[string]*globalEntry)
+	return firstErr
 }
 
 // StorageSettings holds the storage configuration from settings.json.
-// Used by OpenWorkspaceDB to determine the database backend.
+// Used by Global / OpenGlobalDBWithConfig to determine the database
+// backend.
 type StorageSettings struct {
 	Default   string // "sqlite" or "timescale"
 	SQLite    SQLiteSettings
@@ -62,8 +133,13 @@ type StorageSettings struct {
 }
 
 // SQLiteSettings configures the SQLite database path.
+//
+// NOTE: with the single global mycel.db the per-workspace SQLite path
+// override is ignored — the database always lives at
+// <MycelHome>/mycel.db. The field is kept so existing settings.json
+// files still parse and map through DBStorageSettings.
 type SQLiteSettings struct {
-	Path string // base directory for bc.db (default: workspace .bc/ dir)
+	Path string
 }
 
 // TimescaleSettings configures the TimescaleDB (Postgres) connection.
@@ -100,16 +176,15 @@ func (p TimescaleSettings) DSN() string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s", user, url.PathEscape(pw), host, port, db)
 }
 
-// OpenWorkspaceDB opens the workspace database based on configuration.
-// Priority: DATABASE_URL env var > settings.json storage config > SQLite default.
-func OpenWorkspaceDB(workspaceRoot string) (*sql.DB, string, error) {
-	return OpenWorkspaceDBWithConfig(workspaceRoot, nil)
-}
-
-// OpenWorkspaceDBWithConfig opens the workspace database using settings.json config.
-// If DATABASE_URL env var is set, it takes priority (for Docker/CI).
-// Otherwise, settings.json storage.default determines the backend.
-func OpenWorkspaceDBWithConfig(workspaceRoot string, cfg *StorageSettings) (*sql.DB, string, error) {
+// OpenGlobalDBWithConfig opens the global database at sqlitePath using
+// the given storage settings to choose the backend.
+// Priority: DATABASE_URL env var (Docker/CI) > cfg timescale > SQLite
+// at sqlitePath.
+//
+// Most callers should use Global instead; this is exported so the
+// backend-choice logic is testable without touching the process-wide
+// singleton.
+func OpenGlobalDBWithConfig(sqlitePath string, cfg *StorageSettings) (*sql.DB, string, error) {
 	// Priority 1: DATABASE_URL env var (Docker/CI override)
 	if IsPostgresEnabled() {
 		db, err := OpenPostgres(PostgresDSN())
@@ -135,23 +210,13 @@ func OpenWorkspaceDBWithConfig(workspaceRoot string, cfg *StorageSettings) (*sql
 			"error", err)
 	}
 
-	// Priority 3: SQLite (default)
-	//
-	// The default settings.json writes sqlite.path = ".bc", which used to
-	// resolve CWD-relative to ".bc/.bc/bc.db" (issue #3237). The default
-	// always means the canonical <workspaceRoot>/.bc/bc.db; custom paths
-	// resolve against the workspace root — never the process CWD.
-	path := BCDBPath(workspaceRoot)
-	if cfg != nil && cfg.SQLite.Path != "" && cfg.SQLite.Path != ".bc" {
-		base := cfg.SQLite.Path
-		if !filepath.IsAbs(base) {
-			base = filepath.Join(workspaceRoot, base)
-		}
-		path = filepath.Join(base, "bc.db")
-	}
-	d, err := Open(path)
+	// Priority 3: SQLite (default). The single global database always
+	// lives at sqlitePath (<MycelHome>/mycel.db for Global callers);
+	// the legacy per-workspace sqlite.path override is intentionally
+	// ignored — one process, one file.
+	d, err := Open(sqlitePath)
 	if err != nil {
-		return nil, "", fmt.Errorf("open sqlite %s: %w", path, err)
+		return nil, "", fmt.Errorf("open sqlite %s: %w", sqlitePath, err)
 	}
 	return d.DB, "sqlite", nil
 }

--- a/pkg/doctor/doctor.go
+++ b/pkg/doctor/doctor.go
@@ -525,7 +525,7 @@ func CheckTools(ctx context.Context, ws *workspace.Workspace) CategoryReport {
 	// Check MCP servers from the workspace tool store (requires a workspace).
 	var toolStore *tool.Store
 	if ws != nil {
-		if wsDB, wsDriver, dbErr := db.ForWorkspace(ws.RootDir, ws.Config.DBStorageSettings()); dbErr == nil {
+		if wsDB, wsDriver, dbErr := db.Global(ws.Config.DBStorageSettings()); dbErr == nil {
 			toolStore = tool.NewStore(wsDB, wsDriver)
 		}
 	}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -46,6 +46,12 @@ type Event struct {
 	Type      EventType      `json:"type"`
 	Agent     string         `json:"agent,omitempty"`
 	Message   string         `json:"message,omitempty"`
+	// Repo is the absolute path of the repo the event belongs to, used
+	// for per-repo filtering in the single global database. Writers that
+	// know the repo set it; otherwise the SQLite store best-effort
+	// resolves it from the agents table (events are agent-keyed and both
+	// tables live in the same mycel.db).
+	Repo string `json:"repo,omitempty"`
 }
 
 // EventStore is the interface for reading and writing events.

--- a/pkg/events/store_postgres.go
+++ b/pkg/events/store_postgres.go
@@ -33,9 +33,12 @@ func (p *PostgresLog) InitSchema() error {
 			agent     TEXT,
 			message   TEXT,
 			data      TEXT,
+			repo      TEXT DEFAULT '',
 			timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW()
 		)`,
+		`ALTER TABLE events ADD COLUMN IF NOT EXISTS repo TEXT DEFAULT ''`,
 		`CREATE INDEX IF NOT EXISTS idx_events_agent     ON events(agent)`,
+		`CREATE INDEX IF NOT EXISTS idx_events_repo      ON events(repo)`,
 		`CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp DESC)`,
 	}
 
@@ -64,11 +67,12 @@ func (p *PostgresLog) Append(event Event) error {
 	}
 
 	_, err := p.db.ExecContext(context.Background(),
-		"INSERT INTO events (type, agent, message, data, timestamp) VALUES ($1, $2, $3, $4, $5)",
+		"INSERT INTO events (type, agent, message, data, repo, timestamp) VALUES ($1, $2, $3, $4, $5, $6)",
 		string(event.Type),
 		pgNilStr(event.Agent),
 		pgNilStr(event.Message),
 		dataJSON,
+		event.Repo,
 		event.Timestamp,
 	)
 	return err
@@ -77,7 +81,7 @@ func (p *PostgresLog) Append(event Event) error {
 // Read returns all events ordered by timestamp.
 func (p *PostgresLog) Read() ([]Event, error) {
 	rows, err := p.db.QueryContext(context.Background(),
-		"SELECT type, agent, message, data, timestamp FROM events ORDER BY id ASC LIMIT 1000",
+		"SELECT type, agent, message, data, repo, timestamp FROM events ORDER BY id ASC LIMIT 1000",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("read events: %w", err)
@@ -90,7 +94,7 @@ func (p *PostgresLog) Read() ([]Event, error) {
 // ReadLast returns the last n events.
 func (p *PostgresLog) ReadLast(n int) ([]Event, error) {
 	rows, err := p.db.QueryContext(context.Background(),
-		"SELECT type, agent, message, data, timestamp FROM events ORDER BY id DESC LIMIT $1", n,
+		"SELECT type, agent, message, data, repo, timestamp FROM events ORDER BY id DESC LIMIT $1", n,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("read last events: %w", err)
@@ -115,7 +119,7 @@ func (p *PostgresLog) ReadLast(n int) ([]Event, error) {
 // like "last active" at whatever the 1000th oldest event was.
 func (p *PostgresLog) ReadByAgent(name string) ([]Event, error) {
 	rows, err := p.db.QueryContext(context.Background(),
-		"SELECT type, agent, message, data, timestamp FROM events WHERE agent = $1 ORDER BY id DESC LIMIT 1000", name,
+		"SELECT type, agent, message, data, repo, timestamp FROM events WHERE agent = $1 ORDER BY id DESC LIMIT 1000", name,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("read events by agent: %w", err)
@@ -146,16 +150,19 @@ func pgScanEventRows(rows *sql.Rows) ([]Event, error) {
 	for rows.Next() {
 		var ev Event
 		var evType string
-		var agent, message, dataJSON *string
+		var agent, message, dataJSON, repo *string
 		var ts time.Time
 
-		if err := rows.Scan(&evType, &agent, &message, &dataJSON, &ts); err != nil {
+		if err := rows.Scan(&evType, &agent, &message, &dataJSON, &repo, &ts); err != nil {
 			return nil, fmt.Errorf("scan event: %w", err)
 		}
 
 		ev.Type = EventType(evType)
 		if agent != nil {
 			ev.Agent = *agent
+		}
+		if repo != nil {
+			ev.Repo = *repo
 		}
 		if message != nil {
 			ev.Message = *message
@@ -176,12 +183,12 @@ func pgNilStr(s string) *string {
 	return &s
 }
 
-// OpenLog opens the event log on the given workspace database. The
-// handle is borrowed: callers (typically the per-workspace db registry)
-// own its lifecycle.
+// OpenLog opens the event log on the given database handle (the single
+// global mycel.db, or its TimescaleDB equivalent). The handle is
+// borrowed: callers own its lifecycle.
 func OpenLog(d *bcdb.DB, driver string) (EventStore, error) {
 	if d == nil {
-		return nil, fmt.Errorf("events store requires a workspace database (nil handle)")
+		return nil, fmt.Errorf("events store requires a database handle (nil handle)")
 	}
 	if driver == "timescale" {
 		pg := NewPostgresLog(d.DB)

--- a/pkg/events/store_sqlite.go
+++ b/pkg/events/store_sqlite.go
@@ -30,9 +30,11 @@ func NewSQLiteLog(d *db.DB) (*SQLiteLog, error) {
 			agent     TEXT,
 			message   TEXT,
 			data      TEXT,
+			repo      TEXT DEFAULT '',
 			timestamp TEXT NOT NULL
 		);
 		CREATE INDEX IF NOT EXISTS idx_events_agent ON events(agent);
+		CREATE INDEX IF NOT EXISTS idx_events_repo ON events(repo);
 		CREATE INDEX IF NOT EXISTS idx_events_timestamp ON events(timestamp DESC);
 	`
 	if _, err := d.ExecContext(context.Background(), schema); err != nil {
@@ -58,12 +60,23 @@ func (l *SQLiteLog) Append(event Event) error {
 		dataJSON = &s
 	}
 
+	repo := event.Repo
+	if repo == "" && event.Agent != "" {
+		// Best-effort attribution: events and agents share the single
+		// global database, so resolve the writer's repo from the agents
+		// table when the caller didn't supply one. Any failure (e.g. no
+		// agents table on a bare test handle) just leaves repo empty.
+		_ = l.db.QueryRowContext(context.Background(),
+			"SELECT repo FROM agents WHERE name = ?", event.Agent).Scan(&repo) //nolint:errcheck // best-effort
+	}
+
 	_, err := l.db.ExecContext(context.Background(),
-		"INSERT INTO events (type, agent, message, data, timestamp) VALUES (?, ?, ?, ?, ?)",
+		"INSERT INTO events (type, agent, message, data, repo, timestamp) VALUES (?, ?, ?, ?, ?, ?)",
 		string(event.Type),
 		nilStr(event.Agent),
 		nilStr(event.Message),
 		dataJSON,
+		repo,
 		event.Timestamp.Format(time.RFC3339),
 	)
 	return err
@@ -72,7 +85,7 @@ func (l *SQLiteLog) Append(event Event) error {
 // Read returns all events ordered by timestamp.
 func (l *SQLiteLog) Read() ([]Event, error) {
 	rows, err := l.db.QueryContext(context.Background(),
-		"SELECT type, agent, message, data, timestamp FROM events ORDER BY id ASC LIMIT 1000",
+		"SELECT type, agent, message, data, repo, timestamp FROM events ORDER BY id ASC LIMIT 1000",
 	)
 	if err != nil {
 		return nil, err
@@ -85,7 +98,7 @@ func (l *SQLiteLog) Read() ([]Event, error) {
 // ReadLast returns the last n events.
 func (l *SQLiteLog) ReadLast(n int) ([]Event, error) {
 	rows, err := l.db.QueryContext(context.Background(),
-		"SELECT type, agent, message, data, timestamp FROM events ORDER BY id DESC LIMIT ?", n,
+		"SELECT type, agent, message, data, repo, timestamp FROM events ORDER BY id DESC LIMIT ?", n,
 	)
 	if err != nil {
 		return nil, err
@@ -110,7 +123,7 @@ func (l *SQLiteLog) ReadLast(n int) ([]Event, error) {
 // like "last active" at whatever the 1000th oldest event was.
 func (l *SQLiteLog) ReadByAgent(name string) ([]Event, error) {
 	rows, err := l.db.QueryContext(context.Background(),
-		"SELECT type, agent, message, data, timestamp FROM events WHERE agent = ? ORDER BY id DESC LIMIT 1000", name,
+		"SELECT type, agent, message, data, repo, timestamp FROM events WHERE agent = ? ORDER BY id DESC LIMIT 1000", name,
 	)
 	if err != nil {
 		return nil, err
@@ -195,16 +208,19 @@ func scanEventRows(rows sqlRows) ([]Event, error) {
 	for rows.Next() {
 		var ev Event
 		var evType string
-		var agent, message, dataJSON *string
+		var agent, message, dataJSON, repo *string
 		var ts string
 
-		if err := rows.Scan(&evType, &agent, &message, &dataJSON, &ts); err != nil {
+		if err := rows.Scan(&evType, &agent, &message, &dataJSON, &repo, &ts); err != nil {
 			return nil, fmt.Errorf("scan event: %w", err)
 		}
 
 		ev.Type = EventType(evType)
 		if agent != nil {
 			ev.Agent = *agent
+		}
+		if repo != nil {
+			ev.Repo = *repo
 		}
 		if message != nil {
 			ev.Message = *message

--- a/pkg/events/store_sqlite_test.go
+++ b/pkg/events/store_sqlite_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -174,4 +175,59 @@ func TestSQLiteLog_ImplementsEventStore(t *testing.T) {
 
 	// Verify it implements EventStore
 	var _ EventStore = log
+}
+
+// TestEventRepoAttribution covers the repo column added for the single
+// global database: explicit Event.Repo round-trips, and when the
+// writer doesn't know the repo the store best-effort resolves it from
+// the agents table living in the same database.
+func TestEventRepoAttribution(t *testing.T) {
+	d := setupSharedDB(t)
+	log, err := NewSQLiteLog(d)
+	if err != nil {
+		t.Fatalf("NewSQLiteLog: %v", err)
+	}
+	defer func() { _ = log.Close() }()
+
+	// Minimal agents table alongside events — in production both live
+	// in the one global mycel.db.
+	ctx := context.Background()
+	if _, execErr := d.ExecContext(ctx,
+		`CREATE TABLE agents (name TEXT PRIMARY KEY, repo TEXT NOT NULL DEFAULT '')`); execErr != nil {
+		t.Fatalf("create agents table: %v", execErr)
+	}
+	if _, execErr := d.ExecContext(ctx,
+		`INSERT INTO agents (name, repo) VALUES ('alice', '/repos/alpha')`); execErr != nil {
+		t.Fatalf("seed agent: %v", execErr)
+	}
+
+	// Explicit repo wins.
+	if appendErr := log.Append(Event{Type: AgentSpawned, Agent: "alice", Repo: "/repos/explicit"}); appendErr != nil {
+		t.Fatalf("append explicit: %v", appendErr)
+	}
+	// No repo supplied: resolved from the agents table.
+	if appendErr := log.Append(Event{Type: AgentReport, Agent: "alice"}); appendErr != nil {
+		t.Fatalf("append resolved: %v", appendErr)
+	}
+	// Unknown agent: repo stays empty.
+	if appendErr := log.Append(Event{Type: AgentReport, Agent: "ghost"}); appendErr != nil {
+		t.Fatalf("append unknown: %v", appendErr)
+	}
+
+	evts, err := log.Read()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(evts) != 3 {
+		t.Fatalf("events = %d, want 3", len(evts))
+	}
+	if evts[0].Repo != "/repos/explicit" {
+		t.Errorf("explicit repo = %q, want /repos/explicit", evts[0].Repo)
+	}
+	if evts[1].Repo != "/repos/alpha" {
+		t.Errorf("resolved repo = %q, want /repos/alpha (from agents table)", evts[1].Repo)
+	}
+	if evts[2].Repo != "" {
+		t.Errorf("unknown agent repo = %q, want empty", evts[2].Repo)
+	}
 }

--- a/pkg/stats/stats_test.go
+++ b/pkg/stats/stats_test.go
@@ -164,19 +164,30 @@ func TestSummaryNoAgentStatsSection(t *testing.T) {
 	}
 }
 
-// seedAgentsFile writes agent data to the unified bc.db for the given workspace root.
-// The workspaceRoot is the parent of the .bc directory.
+// seedAgentsFile writes agent data to the single global mycel.db
+// (pinned to a per-test MYCEL_HOME) tagged with the given workspace
+// root so a repo-scoped manager loads exactly these agents.
 func seedAgentsFile(t *testing.T, workspaceRoot string, agents map[string]*agent.Agent) {
 	t.Helper()
+	t.Setenv("MYCEL_HOME", filepath.Join(workspaceRoot, ".mycel-home"))
 	bcDir := filepath.Join(workspaceRoot, ".bc")
 	if err := os.MkdirAll(filepath.Join(bcDir, "agents"), 0750); err != nil {
 		t.Fatalf("mkdir .bc/agents: %v", err)
 	}
-	store, err := agent.NewSQLiteStore(db.BCDBPath(workspaceRoot))
+	dbPath, err := db.GlobalDBPath()
+	if err != nil {
+		t.Fatalf("GlobalDBPath: %v", err)
+	}
+	store, err := agent.NewSQLiteStore(dbPath)
 	if err != nil {
 		t.Fatalf("NewSQLiteStore: %v", err)
 	}
 	defer func() { _ = store.Close() }()
+	for _, a := range agents {
+		if a.Repo == "" {
+			a.Repo = workspaceRoot
+		}
+	}
 	if err := store.SaveAll(context.Background(), agents); err != nil {
 		t.Fatalf("SaveAll: %v", err)
 	}

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -113,9 +113,8 @@ type TimescaleStorageConfig struct {
 }
 
 // DBStorageSettings converts the workspace storage config into the
-// pkg/db settings shape consumed by the per-workspace connection
-// registry. Returns nil for a nil config so callers can pass it
-// straight to db.ForWorkspace.
+// pkg/db settings shape consumed by the global connection. Returns nil
+// for a nil config so callers can pass it straight to db.Global.
 func (c *Config) DBStorageSettings() *db.StorageSettings {
 	if c == nil {
 		return nil

--- a/pkg/workspace/global.go
+++ b/pkg/workspace/global.go
@@ -69,7 +69,7 @@ func GlobalMCPConfig() (string, error) {
 }
 
 // GlobalCostsDB returns the path to the user-global cost ledger
-// (~/.mycel/costs.db). Every cost record is tagged with a workspace_id so
+// (~/.mycel/costs.db). Every cost record is tagged with a repo path so
 // cross-workspace analytics work without data duplication.
 func GlobalCostsDB() (string, error) {
 	return globalPath(globalCostsFileName)

--- a/pkg/workspace/registry_test.go
+++ b/pkg/workspace/registry_test.go
@@ -221,6 +221,7 @@ func TestLoadRegistryNotFound(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldHome := os.Getenv("HOME")
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MYCEL_HOME", "") // fall back to $HOME/.mycel despite TestMain sandbox
 	defer func() { _ = os.Setenv("HOME", oldHome) }()
 
 	r, err := LoadRegistry()
@@ -239,6 +240,7 @@ func TestLoadRegistryWithFile(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldHome := os.Getenv("HOME")
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MYCEL_HOME", "") // fall back to $HOME/.mycel despite TestMain sandbox
 	defer func() { _ = os.Setenv("HOME", oldHome) }()
 
 	// Create .mycel directory and registry file
@@ -277,6 +279,7 @@ func TestLoadRegistryInvalidJSON(t *testing.T) {
 	tmpDir := t.TempDir()
 	oldHome := os.Getenv("HOME")
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MYCEL_HOME", "") // fall back to $HOME/.mycel despite TestMain sandbox
 	defer func() { _ = os.Setenv("HOME", oldHome) }()
 
 	// Create .mycel directory with invalid JSON

--- a/pkg/workspace/testmain_test.go
+++ b/pkg/workspace/testmain_test.go
@@ -1,0 +1,23 @@
+package workspace
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain pins MYCEL_HOME to a throwaway dir so the single global
+// database (and registry/state dirs) created by Init/Load in tests
+// never touch the developer's real ~/.mycel. Tests that need a
+// specific home still override it per-test via t.Setenv.
+func TestMain(m *testing.M) {
+	var testHome string
+	if home, err := os.MkdirTemp("", "mycel-test-home-*"); err == nil {
+		testHome = home
+		_ = os.Setenv("MYCEL_HOME", home)
+	}
+	code := m.Run()
+	if testHome != "" {
+		_ = os.RemoveAll(testHome)
+	}
+	os.Exit(code)
+}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -102,7 +102,7 @@ func Init(rootDir string) (*Workspace, error) {
 		return nil, fmt.Errorf("failed to save config: %w", saveErr)
 	}
 
-	rm, closeStore, err := initRoleManager(stateDir, absRoot, &cfg)
+	rm, closeStore, err := initRoleManager(stateDir, &cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init role manager: %w", err)
 	}
@@ -177,7 +177,7 @@ func Load(rootDir string) (*Workspace, error) {
 		return nil, fmt.Errorf("invalid %s: %w", PreferencesFileName, valErr)
 	}
 
-	rm, closeStore, err := loadRoleManager(stateDir, absRoot, cfg)
+	rm, closeStore, err := loadRoleManager(stateDir, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load roles: %w", err)
 	}
@@ -382,35 +382,23 @@ func (w *Workspace) GetRolePrompt(name string) string {
 	return role.Prompt
 }
 
-// openRoleStore creates a RoleStore for the workspace. When the
-// workspace is configured for TimescaleDB (or DATABASE_URL forces it),
-// the role store shares the per-workspace registry connection; in
-// SQLite mode it keeps its own file at <stateDir>/bc.db.
-func openRoleStore(stateDir, rootDir string, cfg *Config) (*RoleStore, error) {
-	settings := cfg.DBStorageSettings()
-	wantsTimescale := db.IsPostgresEnabled() ||
-		(settings != nil && settings.Default == "timescale")
-	if wantsTimescale {
-		wsDB, driver, err := db.ForWorkspace(rootDir, settings)
-		if err != nil {
-			return nil, fmt.Errorf("role store: open workspace db: %w", err)
-		}
-		if driver == "timescale" {
-			return NewRoleStoreFromDB(wsDB.DB, "timescale")
-		}
-		// Timescale unreachable — the registry fell back to SQLite;
-		// keep roles in the local role db below as before.
+// openRoleStore creates a RoleStore on the single global database
+// (<MycelHome>/mycel.db, or the configured TimescaleDB). Roles from
+// every workspace share the one roles table; the connection is
+// borrowed from pkg/db and Close on the store is a no-op.
+func openRoleStore(cfg *Config) (*RoleStore, error) {
+	wsDB, driver, err := db.Global(cfg.DBStorageSettings())
+	if err != nil {
+		return nil, fmt.Errorf("role store: open global db: %w", err)
 	}
-
-	dbPath := filepath.Join(stateDir, "bc.db")
-	return NewRoleStore(dbPath)
+	return NewRoleStoreFromDB(wsDB.DB, driver)
 }
 
 // initRoleManager creates a role manager with SQL store for workspace Init.
 // It creates the store, migrates defaults, and migrates any legacy filesystem
 // roles. Returns the manager plus a close function for the store.
-func initRoleManager(stateDir, rootDir string, cfg *Config) (*RoleManager, func() error, error) {
-	store, err := openRoleStore(stateDir, rootDir, cfg)
+func initRoleManager(stateDir string, cfg *Config) (*RoleManager, func() error, error) {
+	store, err := openRoleStore(cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open role store: %w", err)
 	}
@@ -442,8 +430,8 @@ func initRoleManager(stateDir, rootDir string, cfg *Config) (*RoleManager, func(
 // loadRoleManager creates a role manager with SQL store for workspace Load.
 // It opens the store, migrates any new filesystem files, and loads all roles
 // into the cache.
-func loadRoleManager(stateDir, rootDir string, cfg *Config) (*RoleManager, func() error, error) {
-	store, err := openRoleStore(stateDir, rootDir, cfg)
+func loadRoleManager(stateDir string, cfg *Config) (*RoleManager, func() error, error) {
+	store, err := openRoleStore(cfg)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open role store: %w", err)
 	}

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -106,19 +106,20 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 	// "not available".
 	degraded := map[string]string{}
 
-	// Per-workspace database: resolved from the process-wide registry so
-	// each workspace's stores land in that workspace's own bc.db (or its
-	// own TimescaleDB), never in the launch workspace's. The handle is
-	// cached in the registry and stays open across service eviction;
-	// stores borrow it and never close it.
-	wsDB, wsDriver, dbErr := bcdb.ForWorkspace(ws.RootDir, ws.Config.DBStorageSettings())
+	// Single global database: every workspace's stores share the one
+	// mycel.db at <MycelHome>/mycel.db (or the global TimescaleDB).
+	// Isolation between repos comes from data keys (agent name, repo
+	// path), not from separate files. The handle is cached process-wide
+	// and stays open across service eviction; stores borrow it and
+	// never close it.
+	wsDB, wsDriver, dbErr := bcdb.Global(ws.Config.DBStorageSettings())
 	if dbErr != nil {
-		log.Warn("workspace database unavailable", "error", dbErr, "workspace", ws.RootDir)
-		degraded["storage"] = "workspace database unavailable: " + dbErr.Error()
+		log.Warn("global database unavailable", "error", dbErr, "workspace", ws.RootDir)
+		degraded["storage"] = "global database unavailable: " + dbErr.Error()
 	}
 
 	// Storage driver mismatch: pkg/db falls back to SQLite when the
-	// configured TimescaleDB is unreachable (db.OpenWorkspaceDBWithConfig
+	// configured TimescaleDB is unreachable (db.OpenGlobalDBWithConfig
 	// logs "falling back to sqlite"). Compare the configured default
 	// against the driver actually in use so the mismatch is visible.
 	if ws.Config != nil && dbErr == nil {
@@ -179,19 +180,18 @@ func buildWorkspaceServicesFromWS(ctx context.Context, globals *Globals, ws *bcw
 	addCloser(func() error { agentMgr.StopToolHealthLoop(); return nil })
 
 	// Cost store + importer. Prefer the user-global ledger at
-	// ~/.mycel/costs.db (M8e) when Globals.CostsGlobal is supplied — every
-	// record is tagged with the workspace id via ScopedStore /
-	// Importer.SetWorkspaceID so cross-workspace analytics work out of
-	// the box. Fall back to the per-workspace store for legacy callers
-	// / tests that assemble Globals by hand without the global ledger.
+	// ~/.mycel/costs.db when Globals.CostsGlobal is supplied — every
+	// record is tagged with the repo path via ScopedStore /
+	// Importer.SetRepo so cross-repo analytics work out of the box.
+	// Fall back to the per-workspace store for legacy callers / tests
+	// that assemble Globals by hand without the global ledger.
 	var costStore *cost.Store
 	var costImporter *cost.Importer
 	if globals != nil && globals.CostsGlobal != nil {
 		costStore = globals.CostsGlobal
 		// Ownership stays with whoever populated Globals; no closer.
-		wsID := bcworkspace.ComputeWorkspaceID(ws.RootDir)
 		costImporter = cost.NewImporter(costStore, ws.RootDir)
-		costImporter.SetWorkspaceID(wsID)
+		costImporter.SetRepo(ws.RootDir)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -804,10 +804,16 @@ func runCostImportLoop(ctx context.Context, imp *cost.Importer) {
 	}
 }
 
-// runEventPruneLoop prunes stale events (TTL 24h, max 5000 per agent)
-// every hour.
+// eventPruneMaxPerAgent caps retained events per agent. 5,000 was too
+// small — a busy agent burned through it in about an hour and the Live
+// page lost history (#3279). The 24h TTL is the real bound; the cap is
+// a safety net against runaway writers.
+const eventPruneMaxPerAgent = 50000
+
+// runEventPruneLoop prunes stale events (TTL 24h, max
+// eventPruneMaxPerAgent per agent) every hour.
 func runEventPruneLoop(ctx context.Context, prunable *bcevents.SQLiteLog) {
-	if n, err := prunable.Prune(24*time.Hour, 5000); err != nil {
+	if n, err := prunable.Prune(24*time.Hour, eventPruneMaxPerAgent); err != nil {
 		log.Warn("event prune failed", "error", err)
 	} else if n > 0 {
 		log.Info("event prune: deleted stale events", "count", n)
@@ -817,7 +823,7 @@ func runEventPruneLoop(ctx context.Context, prunable *bcevents.SQLiteLog) {
 	for {
 		select {
 		case <-ticker.C:
-			if n, err := prunable.Prune(24*time.Hour, 5000); err != nil {
+			if n, err := prunable.Prune(24*time.Hour, eventPruneMaxPerAgent); err != nil {
 				log.Warn("event prune failed", "error", err)
 			} else if n > 0 {
 				log.Info("event prune: deleted stale events", "count", n)

--- a/server/build_services_db_test.go
+++ b/server/build_services_db_test.go
@@ -1,36 +1,38 @@
-// build_services_db_test.go — issue #3238: per-workspace databases.
+// build_services_db_test.go — single global database.
 //
-// BuildWorkspaceServices must resolve each workspace's OWN database from
-// the pkg/db registry so stores for workspace B never write into
-// workspace A's bc.db, and a workspace-less daemon boot must be able to
-// add a repo later and get a fully-online service bundle (lazy open).
+// BuildWorkspaceServices resolves the ONE global mycel.db for every
+// workspace: two workspaces built in the same process share the same
+// database file, and isolation comes from data keys (agent name, repo
+// path) rather than from separate files. A workspace-less daemon boot
+// must still be able to add a repo later and get a fully-online
+// service bundle (lazy open).
 package server
 
 import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	bcagent "github.com/rpuneet/mycel/pkg/agent"
 	bcdb "github.com/rpuneet/mycel/pkg/db"
 )
 
-// TestBuildWorkspaceServices_NotifyIsolation is the multi-workspace
-// bleed regression test at the factory level: two workspaces built in
-// the same process must keep notify subscriptions (and everything else
-// in bc.db) fully isolated.
-func TestBuildWorkspaceServices_NotifyIsolation(t *testing.T) {
-	t.Setenv("MYCEL_HOME", t.TempDir())
+// TestBuildWorkspaceServices_SharedGlobalDB asserts the single-database
+// semantics: two workspaces in one process share mycel.db (channel
+// subscriptions are global), agents are isolated by repo key, and a
+// duplicate agent name across repos is rejected.
+func TestBuildWorkspaceServices_SharedGlobalDB(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("MYCEL_HOME", home)
 	t.Setenv("BC_SECRET_PASSPHRASE", "unit-test")
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 	ctx := context.Background()
 
 	wsA, wsB := t.TempDir(), t.TempDir()
 	gitInitDir(t, wsA)
 	gitInitDir(t, wsB)
-	t.Cleanup(func() {
-		_ = bcdb.CloseWorkspaceDB(wsA)
-		_ = bcdb.CloseWorkspaceDB(wsB)
-	})
 
 	svcA, err := BuildWorkspaceServices(ctx, &Globals{}, wsA)
 	if err != nil {
@@ -48,10 +50,12 @@ func TestBuildWorkspaceServices_NotifyIsolation(t *testing.T) {
 			svcA.Degraded, svcB.Degraded)
 	}
 
+	// Channel subscriptions live in the ONE shared database: a
+	// subscription made through workspace A's services is visible
+	// through workspace B's — that is the single-DB contract.
 	if subErr := svcA.Notify.Store().Subscribe(ctx, "#engineering", "agent-a", false); subErr != nil {
 		t.Fatalf("subscribe in A: %v", subErr)
 	}
-
 	subsA, err := svcA.Notify.Store().Subscribers(ctx, "#engineering")
 	if err != nil {
 		t.Fatalf("subscribers A: %v", err)
@@ -59,40 +63,72 @@ func TestBuildWorkspaceServices_NotifyIsolation(t *testing.T) {
 	if len(subsA) != 1 || subsA[0].Agent != "agent-a" {
 		t.Fatalf("workspace A subscribers = %+v, want [agent-a]", subsA)
 	}
-
 	subsB, err := svcB.Notify.Store().Subscribers(ctx, "#engineering")
 	if err != nil {
 		t.Fatalf("subscribers B: %v", err)
 	}
-	if len(subsB) != 0 {
-		t.Errorf("workspace A's subscription bled into workspace B: %+v", subsB)
+	if len(subsB) != 1 || subsB[0].Agent != "agent-a" {
+		t.Errorf("shared DB: workspace B must see the same channel subscription, got %+v", subsB)
 	}
 
-	// Each workspace must have its own database file.
+	// Agents are isolated by repo key: an agent registered in A does
+	// not appear in B's manager.
+	if regErr := svcA.AgentMgr.RegisterStopped(&bcagent.Agent{
+		Name:      "shared-db-agent",
+		Role:      bcagent.Role("engineer"),
+		Workspace: wsA,
+		Repo:      wsA,
+	}); regErr != nil {
+		t.Fatalf("register agent in A: %v", regErr)
+	}
+	if got := svcB.AgentMgr.GetAgent("shared-db-agent"); got != nil {
+		t.Error("agent registered in workspace A must not be visible in workspace B's manager")
+	}
+
+	// Agent names are globally unique: reusing the name from another
+	// repo must be rejected with a helpful error.
+	dupErr := svcB.AgentMgr.RegisterStopped(&bcagent.Agent{
+		Name:      "shared-db-agent",
+		Role:      bcagent.Role("engineer"),
+		Workspace: wsB,
+		Repo:      wsB,
+	})
+	if dupErr == nil {
+		t.Fatal("duplicate agent name across repos must be rejected")
+	}
+	if msg := dupErr.Error(); !strings.Contains(msg, "shared-db-agent") || !strings.Contains(msg, "already in use") {
+		t.Errorf("duplicate-name error should identify the conflict, got: %v", dupErr)
+	}
+
+	// One database file at MYCEL_HOME — no per-workspace bc.db files.
+	if _, statErr := os.Stat(filepath.Join(home, "mycel.db")); statErr != nil {
+		t.Errorf("global mycel.db missing: %v", statErr)
+	}
 	for _, dir := range []string{wsA, wsB} {
-		if _, statErr := os.Stat(filepath.Join(dir, ".bc", "bc.db")); statErr != nil {
-			t.Errorf("bc.db missing for %s: %v", dir, statErr)
+		if _, statErr := os.Stat(filepath.Join(dir, ".bc", "bc.db")); statErr == nil {
+			t.Errorf("per-workspace bc.db must not be created anymore (%s)", dir)
 		}
 	}
 }
 
-// TestBuildWorkspaceServices_LazyWorkspaceDB simulates the
-// workspace-less boot path: no database exists anywhere until a repo is
-// added (BuildWorkspaceServices is what POST /api/workspaces invokes),
-// at which point the registry opens that workspace's DB lazily and the
-// stores come up online rather than degraded.
-func TestBuildWorkspaceServices_LazyWorkspaceDB(t *testing.T) {
-	t.Setenv("MYCEL_HOME", t.TempDir())
+// TestBuildWorkspaceServices_LazyGlobalDB simulates the workspace-less
+// boot path: no database exists anywhere until a repo is added
+// (BuildWorkspaceServices is what POST /api/workspaces invokes), at
+// which point the global mycel.db is opened lazily and the stores come
+// up online rather than degraded.
+func TestBuildWorkspaceServices_LazyGlobalDB(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("MYCEL_HOME", home)
 	t.Setenv("BC_SECRET_PASSPHRASE", "unit-test")
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 	ctx := context.Background()
 
 	wsDir := t.TempDir()
 	gitInitDir(t, wsDir)
-	t.Cleanup(func() { _ = bcdb.CloseWorkspaceDB(wsDir) })
 
-	// Nothing pre-opened: the db file must not exist yet.
-	if _, err := os.Stat(filepath.Join(wsDir, ".bc", "bc.db")); err == nil {
-		t.Fatal("bc.db must not exist before services are built")
+	// Nothing pre-opened: the global db file must not exist yet.
+	if _, err := os.Stat(filepath.Join(home, "mycel.db")); err == nil {
+		t.Fatal("mycel.db must not exist before services are built")
 	}
 
 	svc, err := BuildWorkspaceServices(ctx, &Globals{}, wsDir)
@@ -115,7 +151,7 @@ func TestBuildWorkspaceServices_LazyWorkspaceDB(t *testing.T) {
 	if reason, degraded := svc.Degraded["storage"]; degraded {
 		t.Errorf("storage degraded on lazy add: %s", reason)
 	}
-	if _, err := os.Stat(filepath.Join(wsDir, ".bc", "bc.db")); err != nil {
-		t.Errorf("bc.db not created lazily: %v", err)
+	if _, err := os.Stat(filepath.Join(home, "mycel.db")); err != nil {
+		t.Errorf("global mycel.db not created lazily: %v", err)
 	}
 }

--- a/server/concurrent_workspace_test.go
+++ b/server/concurrent_workspace_test.go
@@ -74,13 +74,9 @@ func newConcurrentHarness(t *testing.T, n int) *concurrentHarness {
 		list[i] = wsSetup{id: workspace.ComputeWorkspaceID(p), path: p}
 	}
 
-	// Each workspace's db is opened lazily by BuildWorkspaceServices via
-	// the per-workspace registry; release them after the test.
-	t.Cleanup(func() {
-		for _, w := range list {
-			_ = bcdb.CloseWorkspaceDB(w.path)
-		}
-	})
+	// All workspaces share the single global mycel.db, opened lazily by
+	// BuildWorkspaceServices; release it after the test.
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 
 	reg, regErr := workspace.LoadRegistry()
 	if regErr != nil {

--- a/server/cors_scope_test.go
+++ b/server/cors_scope_test.go
@@ -51,11 +51,9 @@ func TestCORS_WorkspaceScope_Coexist(t *testing.T) {
 	}
 	wsID := workspace.ComputeWorkspaceID(wsDir)
 
-	// BuildWorkspaceServices resolves the workspace db lazily via the
-	// registry; just make sure it is released after the test.
-	t.Cleanup(func() {
-		_ = bcdb.CloseWorkspaceDB(wsDir)
-	})
+	// BuildWorkspaceServices resolves the global db lazily; just make
+	// sure it is released after the test.
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 
 	reg, err := workspace.LoadRegistry()
 	if err != nil {
@@ -157,9 +155,7 @@ func TestCORS_Preflight_Scoped(t *testing.T) {
 	}
 	wsID := workspace.ComputeWorkspaceID(wsDir)
 
-	t.Cleanup(func() {
-		_ = bcdb.CloseWorkspaceDB(wsDir)
-	})
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 
 	reg, err := workspace.LoadRegistry()
 	if err != nil {

--- a/server/degraded_test.go
+++ b/server/degraded_test.go
@@ -93,42 +93,49 @@ func TestAPIHealthOKShapeUnchanged(t *testing.T) {
 	}
 }
 
-// TestBuildWorkspaceServicesDegradedNotify verifies that when the notify
-// store cannot open (no shared database — the exact failure behind the
-// 2026-07-03 Slack-delivery outage), the factory records the reason in
-// Degraded instead of only logging a warning.
-func TestBuildWorkspaceServicesDegradedNotify(t *testing.T) {
-	t.Setenv("MYCEL_HOME", t.TempDir())
+// TestBuildWorkspaceServicesGlobalDBFailure verifies that when the
+// single global database cannot open (broken MYCEL_HOME), the factory
+// fails loudly instead of silently coming up with nil stores. With the
+// per-workspace databases gone, a dead mycel.db is fatal for the
+// workspace bundle — workspace init itself needs the roles table.
+func TestBuildWorkspaceServicesGlobalDBFailure(t *testing.T) {
 	t.Setenv("BC_SECRET_PASSPHRASE", "unit-test")
 
-	// Force the workspace DB open to fail: plant a regular FILE where
-	// the registry wants the .bc database directory, so SQLite's
-	// MkdirAll errors and every store depending on the workspace db
-	// comes up degraded.
+	// Plant a regular FILE at the MYCEL_HOME path so MkdirAll (and
+	// therefore the global mycel.db open) fails.
+	tmp := t.TempDir()
+	homeFile := filepath.Join(tmp, "mycel-home")
+	if err := os.WriteFile(homeFile, []byte("not a dir"), 0o600); err != nil {
+		t.Fatalf("plant home file: %v", err)
+	}
+	t.Setenv("MYCEL_HOME", homeFile)
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
+
 	wsDir := t.TempDir()
 	gitInitDir(t, wsDir)
-	if err := os.WriteFile(filepath.Join(wsDir, ".bc"), []byte("not a dir"), 0o600); err != nil {
-		t.Fatalf("plant .bc file: %v", err)
+	if _, err := BuildWorkspaceServices(context.Background(), &Globals{}, wsDir); err == nil {
+		t.Fatal("expected BuildWorkspaceServices to fail when the global database cannot open")
 	}
-	t.Cleanup(func() { _ = bcdb.CloseWorkspaceDB(wsDir) })
+}
+
+// TestDegradedMapProjection verifies the Degraded map recorded by the
+// factory flows through the projections consumed by handlers.
+func TestDegradedMapProjection(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	t.Setenv("BC_SECRET_PASSPHRASE", "unit-test")
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
+
+	wsDir := t.TempDir()
+	gitInitDir(t, wsDir)
 	svc, err := BuildWorkspaceServices(context.Background(), &Globals{}, wsDir)
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
 	defer svc.Close() //nolint:errcheck
 
-	if svc.Notify != nil {
-		t.Fatal("expected nil Notify service without a shared database")
-	}
-	reason, ok := svc.Degraded["notify"]
-	if !ok || reason == "" {
-		t.Fatalf("Degraded[notify] not populated: %#v", svc.Degraded)
-	}
-	if !strings.Contains(reason, "notify store unavailable") {
-		t.Errorf("Degraded[notify] = %q, want it to explain the store failure", reason)
-	}
+	reason := "notify store unavailable: injected for projection test"
+	svc.Degraded["notify"] = reason
 
-	// The projection consumed by handlers must carry the map through.
 	view := workspaceViewFromServices(svc)
 	if view.Degraded["notify"] != reason {
 		t.Errorf("workspaceViewFromServices dropped Degraded: %#v", view.Degraded)

--- a/server/e2e_test.go
+++ b/server/e2e_test.go
@@ -71,14 +71,12 @@ func newE2EServer(t *testing.T) *e2eServer {
 		t.Fatalf("workspace load: %v", err)
 	}
 
-	// Per-workspace database via the registry (production path).
-	wsDB, wsDriver, dbErr := bcdb.ForWorkspace(ws.RootDir, nil)
+	// Single global database (production path).
+	wsDB, wsDriver, dbErr := bcdb.Global(nil)
 	if dbErr != nil {
-		t.Fatalf("open workspace db: %v", dbErr)
+		t.Fatalf("open global db: %v", dbErr)
 	}
-	t.Cleanup(func() {
-		_ = bcdb.CloseWorkspaceDB(ws.RootDir)
-	})
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 
 	// SSE hub
 	hub := ws_hub(t)

--- a/server/e2e_web_test.go
+++ b/server/e2e_web_test.go
@@ -63,13 +63,11 @@ func newE2EServerWithWebUI(t *testing.T) *e2eServer {
 	}
 
 	// Per-workspace database via the registry (production path).
-	wsDB, wsDriver, dbErr := bcdb.ForWorkspace(ws.RootDir, nil)
+	wsDB, wsDriver, dbErr := bcdb.Global(nil)
 	if dbErr != nil {
 		t.Fatalf("open workspace db: %v", dbErr)
 	}
-	t.Cleanup(func() {
-		_ = bcdb.CloseWorkspaceDB(ws.RootDir)
-	})
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 
 	hub := ws_hub(t)
 	mgr := agent.NewWorkspaceManager(ws.StateDir(), ws.RootDir)

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -196,7 +196,7 @@ type agentDTO struct { //nolint:govet // field order matches JSON/API contract
 	SessionID  string         `json:"session_id,omitempty"`
 	ParentID   string         `json:"parent_id,omitempty"`
 	ID         string         `json:"id,omitempty"`
-	RepoRoot   string         `json:"repo_root,omitempty"`
+	Repo       string         `json:"repo,omitempty"`
 	// Workspace is the absolute path the agent is bound to (#3079).
 	// Clients filter via /api/agents?workspace=<path>.
 	Workspace    string   `json:"workspace,omitempty"`
@@ -237,7 +237,7 @@ func toDTO(a *agent.Agent) agentDTO {
 		UpdatedAt:  a.UpdatedAt,
 		StoppedAt:  a.StoppedAt,
 		ArchivedAt: a.ArchivedAt,
-		RepoRoot:   a.RepoRoot,
+		Repo:       a.Repo,
 		Workspace:  a.Workspace,
 	}
 }

--- a/server/handlers/discovery_test.go
+++ b/server/handlers/discovery_test.go
@@ -15,6 +15,7 @@ import (
 func TestDiscoverLocalHandler(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
+	t.Setenv("MYCEL_HOME", filepath.Join(tmp, ".mycel"))
 	// Build a fake filesystem: one registered repo, one new repo.
 	registered := filepath.Join(tmp, "src", "registered")
 	fresh := filepath.Join(tmp, "src", "fresh")

--- a/server/handlers/global_costs.go
+++ b/server/handlers/global_costs.go
@@ -99,15 +99,15 @@ func (h *GlobalCostsHandler) rollup(r *http.Request, groupBy string, since time.
 	sinceArg := sinceFormatter{t: since}
 
 	if groupBy == "workspace" {
-		byWS, err := h.store.SumByWorkspace(r.Context(), sinceArg)
+		byRepo, err := h.store.SumByRepo(r.Context(), sinceArg)
 		if err != nil {
 			return nil, err
 		}
-		out := make([]CostRow, 0, len(byWS))
-		for wsID, total := range byWS {
-			key := wsID
-			label := h.resolveLabel(wsID)
-			if wsID == "" {
+		out := make([]CostRow, 0, len(byRepo))
+		for repo, total := range byRepo {
+			key := repo
+			label := h.resolveLabel(repo)
+			if repo == "" {
 				key = "unattributed"
 				label = "Unattributed"
 			}
@@ -116,8 +116,8 @@ func (h *GlobalCostsHandler) rollup(r *http.Request, groupBy string, since time.
 		return out, nil
 	}
 
-	// groupBy=project: resolver collapses by workspace name.
-	resolve := func(wsID string) string { return h.resolveLabel(wsID) }
+	// groupBy=project: resolver collapses by repo name.
+	resolve := func(repo string) string { return h.resolveLabel(repo) }
 	byProj, err := h.store.SumByProject(r.Context(), sinceArg, resolve)
 	if err != nil {
 		return nil, err
@@ -129,21 +129,22 @@ func (h *GlobalCostsHandler) rollup(r *http.Request, groupBy string, since time.
 	return out, nil
 }
 
-// resolveLabel maps a workspace id to its registered name, falling
-// back to the id itself when no registry entry is found.
-func (h *GlobalCostsHandler) resolveLabel(wsID string) string {
-	if h.registry == nil || wsID == "" {
-		return wsID
+// resolveLabel maps a repo path to its registered name, falling back
+// to the path itself when no registry entry is found. Legacy rows
+// keyed by workspace id still resolve through entry.ID.
+func (h *GlobalCostsHandler) resolveLabel(repo string) string {
+	if h.registry == nil || repo == "" {
+		return repo
 	}
 	for _, entry := range h.registry.List() {
-		if entry.ID == wsID {
+		if entry.Path == repo || entry.ID == repo {
 			if entry.Name != "" {
 				return entry.Name
 			}
 			return entry.Path
 		}
 	}
-	return wsID
+	return repo
 }
 
 // parseCostStart parses start=... into a time. Accepts RFC3339 or
@@ -168,7 +169,7 @@ type httpErr struct{ Msg string }
 func (e *httpErr) Error() string { return e.Msg }
 
 // sinceFormatter adapts time.Time to the interface{Format(string) string}
-// parameter required by (*cost.Store).SumByWorkspace / SumByProject.
+// parameter required by (*cost.Store).SumByRepo / SumByProject.
 type sinceFormatter struct{ t time.Time }
 
 func (s sinceFormatter) Format(layout string) string { return s.t.Format(layout) }

--- a/server/handlers/registry_guard_test.go
+++ b/server/handlers/registry_guard_test.go
@@ -18,7 +18,18 @@ import (
 func TestMain(m *testing.M) {
 	before, beforePath := snapshotUserRegistry()
 
+	// Default sandbox: pin MYCEL_HOME (and therefore the single global
+	// mycel.db) to a throwaway dir; individual tests may override it.
+	var testHome string
+	if home, err := os.MkdirTemp("", "mycel-test-home-*"); err == nil {
+		testHome = home
+		_ = os.Setenv("MYCEL_HOME", home)
+	}
+
 	code := m.Run()
+	if testHome != "" {
+		_ = os.RemoveAll(testHome)
+	}
 
 	if beforePath != "" {
 		after, _ := snapshotUserRegistry()

--- a/server/handlers/resource_handlers_test.go
+++ b/server/handlers/resource_handlers_test.go
@@ -64,11 +64,11 @@ func setupWorkspaceWithDB(t *testing.T) string {
 // given workspace root, mirroring how BuildWorkspaceServices resolves it.
 func openWSDB(t *testing.T, dir string) (*db.DB, string) {
 	t.Helper()
-	d, driver, err := db.ForWorkspace(dir, nil)
+	d, driver, err := db.Global(nil)
 	if err != nil {
 		t.Fatalf("open workspace db: %v", err)
 	}
-	t.Cleanup(func() { _ = db.CloseWorkspaceDB(dir) })
+	t.Cleanup(func() { _ = db.CloseGlobal() })
 	return d, driver
 }
 

--- a/server/handlers/workspaces_test.go
+++ b/server/handlers/workspaces_test.go
@@ -19,6 +19,9 @@ func newTestRegistry(t *testing.T) (*workspace.Registry, string, string) {
 	t.Helper()
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	// Fresh registry per test — MYCEL_HOME is otherwise pinned
+	// package-wide by TestMain, which would share aliases across tests.
+	t.Setenv("MYCEL_HOME", filepath.Join(tmpDir, ".mycel"))
 
 	a := filepath.Join(tmpDir, "a")
 	b := filepath.Join(tmpDir, "b")
@@ -88,6 +91,7 @@ func TestWorkspacesHandlerList(t *testing.T) {
 func TestWorkspacesHandlerAdd(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
+	t.Setenv("MYCEL_HOME", filepath.Join(tmpDir, ".mycel"))
 
 	reg, err := workspace.LoadRegistry()
 	if err != nil {

--- a/server/m8_wiring_test.go
+++ b/server/m8_wiring_test.go
@@ -10,7 +10,6 @@ import (
 	bcmcp "github.com/rpuneet/mycel/pkg/mcp"
 	bcsecret "github.com/rpuneet/mycel/pkg/secret"
 	bctemplate "github.com/rpuneet/mycel/pkg/template"
-	bcworkspace "github.com/rpuneet/mycel/pkg/workspace"
 )
 
 // TestM8WiringTemplatesGlobalOverride verifies that BuildWorkspaceServices
@@ -187,32 +186,32 @@ func TestM8WiringCostsGlobalLedger(t *testing.T) {
 	if svc.Costs != costs {
 		t.Errorf("svc.Costs does not reference Globals.CostsGlobal")
 	}
-	// The importer should have picked up the workspace id.
-	wsID := bcworkspace.ComputeWorkspaceID(wsDir)
+	// The importer should have picked up the repo path.
 	if svc.CostImporter == nil {
 		t.Fatal("CostImporter nil")
 	}
-	// We can't reach imp.workspaceID directly; indirect verification via
+	// We can't reach imp.repo directly; indirect verification via
 	// inserting a scoped record and rolling up.
-	scoped := svc.Costs.ScopedTo(wsID)
+	scoped := svc.Costs.ScopedTo(wsDir)
 	if _, recErr := scoped.Record(context.Background(), "agent", "", "model", 1, 1, 0.50); recErr != nil {
 		t.Fatalf("Record: %v", recErr)
 	}
-	byWS, err := svc.Costs.SumByWorkspace(context.Background(), timeZero())
+	byRepo, err := svc.Costs.SumByRepo(context.Background(), timeZero())
 	if err != nil {
 		t.Fatal(err)
 	}
 	// The importer may sweep in unrelated JSONL files from the developer's
 	// host ~/.claude directory — we only assert that the scoped record
-	// landed under wsID, not the exact total (host import amplifies it).
-	if _, ok := byWS[wsID]; !ok {
-		t.Errorf("ledger did not attribute scoped record: %+v", byWS)
+	// landed under the repo path, not the exact total (host import
+	// amplifies it).
+	if _, ok := byRepo[wsDir]; !ok {
+		t.Errorf("ledger did not attribute scoped record: %+v", byRepo)
 	}
 }
 
 func timeZero() interface{ Format(string) string } {
 	// A tiny helper so the test can pass an always-before time to
-	// SumByWorkspace without importing "time" at the test call site.
+	// SumByRepo without importing "time" at the test call site.
 	return zeroTime{}
 }
 

--- a/server/multi_tenant_dispatch_test.go
+++ b/server/multi_tenant_dispatch_test.go
@@ -107,14 +107,10 @@ func newDispatchHarness(t *testing.T) *dispatchHarness {
 	wsAID := workspace.ComputeWorkspaceID(wsA)
 	wsBID := workspace.ComputeWorkspaceID(wsB)
 
-	// Each workspace gets its OWN database via the per-workspace
-	// registry (issue #3238): cron/mcp/tool/events/notify rows written
-	// through workspace A's services can never appear in workspace B's
-	// stores. BuildWorkspaceServices opens the connections lazily.
-	t.Cleanup(func() {
-		_ = bcdb.CloseWorkspaceDB(wsA)
-		_ = bcdb.CloseWorkspaceDB(wsB)
-	})
+	// Both workspaces share the single global mycel.db: cron/mcp/tool/
+	// events/notify rows all land in one database, isolated by data
+	// keys. BuildWorkspaceServices opens the connection lazily.
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 
 	reg, loadErr := workspace.LoadRegistry()
 	if loadErr != nil {
@@ -291,9 +287,9 @@ func TestDispatch_Secrets(t *testing.T) {
 // ---------------- Cron (routing + basic CRUD through scoped URL) --
 
 // TestDispatch_Cron verifies that cron CRUD routes through the scoped
-// URL into the handler AND that jobs are isolated per workspace: each
-// workspace has its own database (issue #3238), so a job created via
-// wsA must not be visible through wsB.
+// URL into the handler AND the single-database semantics: cron jobs
+// live in the one global mycel.db, so a job created via wsA is visible
+// through wsB too (no per-workspace files anymore).
 func TestDispatch_Cron(t *testing.T) {
 	h := newDispatchHarness(t)
 	defer h.close()
@@ -320,11 +316,11 @@ func TestDispatch_Cron(t *testing.T) {
 	status, resp = h.api(t, http.MethodGet, "/api/workspaces/"+h.wsBID+"/cron", nil)
 	requireStatus(t, http.StatusOK, status, "list wsB", resp)
 
-	// Isolation: the job created under wsA must NOT exist under wsB —
-	// each workspace persists to its own database (issue #3238).
+	// Shared DB: the job created under wsA IS visible under wsB — cron
+	// jobs live in the single global mycel.db.
 	status, _ = h.api(t, http.MethodGet, "/api/workspaces/"+h.wsBID+"/cron/job-shared", nil)
-	if status != http.StatusNotFound {
-		t.Errorf("wsA's cron job visible via wsB (status=%d, want 404) — workspace db bleed", status)
+	if status != http.StatusOK {
+		t.Errorf("cron job must be shared across workspaces (status=%d, want 200)", status)
 	}
 
 	// Cross-scope fetch for a nonexistent key returns 404.
@@ -400,8 +396,8 @@ func TestDispatch_Tools(t *testing.T) {
 // ---------------- Events / Logs (routing) ----------------
 
 // TestDispatch_Events verifies GET /api/logs routes through the scoped
-// URL and that the SQLite event stores are isolated per workspace
-// (each workspace's events table lives in its own bc.db, issue #3238).
+// URL and the single-database semantics: both workspaces read the same
+// events table in the global mycel.db.
 func TestDispatch_Events(t *testing.T) {
 	h := newDispatchHarness(t)
 	defer h.close()
@@ -420,16 +416,20 @@ func TestDispatch_Events(t *testing.T) {
 		t.Fatalf("append A: %v", err)
 	}
 
-	// Isolation: the event appended via wsA's store must not appear in
-	// wsB's store.
+	// Shared DB: the event appended via wsA's store IS visible through
+	// wsB's store — one events table for the whole process.
 	evtsB, readErr := svcB.Events.Read()
 	if readErr != nil {
 		t.Fatalf("read B: %v", readErr)
 	}
+	found := false
 	for _, ev := range evtsB {
 		if ev.Type == "probe.shared" {
-			t.Errorf("event appended in wsA visible in wsB — workspace db bleed")
+			found = true
 		}
+	}
+	if !found {
+		t.Errorf("event appended in wsA must be visible in wsB — single global database")
 	}
 
 	// Scoped URL reaches the handler for both workspaces.
@@ -444,12 +444,11 @@ func TestDispatch_Events(t *testing.T) {
 
 // TestDispatch_Cost verifies cost CRUD routes through the scoped URL.
 // WorkspaceSummary today does SELECT SUM over every row regardless of
-// workspace_id (pkg/cost/cost.go) so strict per-workspace totals via
-// the /api/costs summary endpoint do not hold. What DOES hold is that
-// the cost store at the SQL level can aggregate by workspace_id via
-// SumByWorkspace — this is asserted separately in
-// pkg/cost/global_test.go TestScopedRecordTagsWorkspace. Here we just
-// assert routing + non-error responses.
+// repo (pkg/cost/cost.go) so strict per-repo totals via the /api/costs
+// summary endpoint do not hold. What DOES hold is that the cost store
+// at the SQL level can aggregate by repo via SumByRepo — this is
+// asserted separately in pkg/cost/global_test.go. Here we just assert
+// routing + non-error responses.
 func TestDispatch_Cost(t *testing.T) {
 	h := newDispatchHarness(t)
 	defer h.close()
@@ -463,15 +462,15 @@ func TestDispatch_Cost(t *testing.T) {
 		t.Skip("cost store not configured — cannot exercise dispatch")
 	}
 
-	// Record scoped to each workspace via the global ledger's ScopedTo.
+	// Record scoped to each repo via the global ledger's ScopedTo.
 	// The per-request svc.Costs pointer is the global store (not yet
-	// pre-scoped) so direct Record() would tag with workspace_id="".
-	// We scope explicitly here to verify the SQL schema supports
-	// per-workspace aggregation; the handler-level summary endpoint
-	// still uses SUM across all rows (known limitation).
+	// pre-scoped) so direct Record() would tag with repo="". We scope
+	// explicitly here to verify the SQL schema supports per-repo
+	// aggregation; the handler-level summary endpoint still uses SUM
+	// across all rows (known limitation).
 	ctx := context.Background()
-	scopedA := svcA.Costs.ScopedTo(h.wsAID)
-	scopedB := svcB.Costs.ScopedTo(h.wsBID)
+	scopedA := svcA.Costs.ScopedTo(h.wsADir)
+	scopedB := svcB.Costs.ScopedTo(h.wsBDir)
 	if _, err := scopedA.Record(ctx, "alice", "", "m", 10, 5, 1.11); err != nil {
 		t.Fatalf("record A: %v", err)
 	}
@@ -488,16 +487,16 @@ func TestDispatch_Cost(t *testing.T) {
 	requireStatus(t, http.StatusOK, status, "summary B", resp)
 	_ = mustFloat(t, resp, "total_cost_usd")
 
-	// SumByWorkspace on the underlying global ledger separates the two.
-	byWS, err := svcA.Costs.SumByWorkspace(ctx, time.Time{})
+	// SumByRepo on the underlying global ledger separates the two.
+	byRepo, err := svcA.Costs.SumByRepo(ctx, time.Time{})
 	if err != nil {
-		t.Fatalf("SumByWorkspace: %v", err)
+		t.Fatalf("SumByRepo: %v", err)
 	}
-	if byWS[h.wsAID] <= 0 {
-		t.Errorf("wsA missing from ledger: %+v", byWS)
+	if byRepo[h.wsADir] <= 0 {
+		t.Errorf("wsA missing from ledger: %+v", byRepo)
 	}
-	if byWS[h.wsBID] <= 0 {
-		t.Errorf("wsB missing from ledger: %+v", byWS)
+	if byRepo[h.wsBDir] <= 0 {
+		t.Errorf("wsB missing from ledger: %+v", byRepo)
 	}
 }
 

--- a/server/multi_tenant_test.go
+++ b/server/multi_tenant_test.go
@@ -5,7 +5,8 @@
 //
 //  1. GET /api/workspaces/<A>/agents only returns A's agents.
 //  2. GET /api/workspaces/<B>/agents only returns B's agents.
-//  3. A hook event appended to A's event store does not show up in B's.
+//  3. A hook event appended through A's services is visible through B's
+//     too — both share the single global mycel.db (events are agent-keyed).
 //  4. Evicting A releases its services; re-loading A preserves disk state.
 //
 // The test deliberately uses the real WorkspaceManager + factory so a
@@ -24,6 +25,7 @@ import (
 	"sort"
 	"testing"
 
+	bcdb "github.com/rpuneet/mycel/pkg/db"
 	bcevents "github.com/rpuneet/mycel/pkg/events"
 	"github.com/rpuneet/mycel/pkg/workspace"
 	"github.com/rpuneet/mycel/server"
@@ -53,9 +55,12 @@ func (h *multiTenantHarness) close() {
 func newMultiTenantHarness(t *testing.T) *multiTenantHarness {
 	t.Helper()
 
-	// Isolate HOME so the test's Registry lives in a fresh ~/.bc.
+	// Isolate HOME and MYCEL_HOME so the test's registry and global
+	// mycel.db live in a fresh sandbox.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("MYCEL_HOME", filepath.Join(home, ".mycel"))
+	t.Cleanup(func() { _ = bcdb.CloseGlobal() })
 
 	wsA := filepath.Join(t.TempDir(), "wsA")
 	wsB := filepath.Join(t.TempDir(), "wsB")
@@ -229,9 +234,11 @@ func TestMultiTenant_AgentsIsolatedPerWorkspace(t *testing.T) {
 	}
 }
 
-// TestMultiTenant_EventsIsolatedPerWorkspace verifies a hook event written
-// to A's event store does not leak into B's.
-func TestMultiTenant_EventsIsolatedPerWorkspace(t *testing.T) {
+// TestMultiTenant_EventsSharedGlobalDB verifies the single-database
+// semantics for events: a hook event written through A's services is
+// visible through B's too, because both share the one global mycel.db.
+// Per-repo filtering happens via the agent/repo keys, not via files.
+func TestMultiTenant_EventsSharedGlobalDB(t *testing.T) {
 	h := newMultiTenantHarness(t)
 	defer h.close()
 
@@ -241,45 +248,47 @@ func TestMultiTenant_EventsIsolatedPerWorkspace(t *testing.T) {
 		t.Fatalf("expected both workspaces loaded, got A=%v B=%v", svcA, svcB)
 	}
 
-	// Count events in B before writing to A.
-	beforeB := 0
-	if svcB.Events != nil {
-		if evts, err := svcB.Events.ReadLast(1000); err == nil {
-			beforeB = len(evts)
-		}
-	}
-
-	// Append one event to A's event store.
+	// Append one event through A's event store.
 	if svcA.Events == nil {
-		t.Skip("event store not configured for wsA — cannot exercise isolation")
+		t.Skip("event store not configured for wsA — cannot exercise shared db")
 	}
 	err := svcA.Events.Append(bcevents.Event{
 		Type:    "hook.test",
 		Agent:   "alice",
-		Message: "isolation probe",
-		Data:    map[string]any{"note": "isolation probe"},
+		Message: "shared db probe",
+		Data:    map[string]any{"note": "shared db probe"},
 	})
 	if err != nil {
 		t.Fatalf("append to wsA events: %v", err)
 	}
 
-	// Verify A's count grew, B's did not.
-	afterA := 0
+	// A sees it.
+	foundA := false
 	if evts, err := svcA.Events.ReadLast(1000); err == nil {
-		afterA = len(evts)
-	}
-	afterB := beforeB
-	if svcB.Events != nil {
-		if evts, err := svcB.Events.ReadLast(1000); err == nil {
-			afterB = len(evts)
+		for _, ev := range evts {
+			if ev.Type == "hook.test" && ev.Agent == "alice" {
+				foundA = true
+			}
 		}
 	}
-
-	if afterA < 1 {
-		t.Errorf("wsA event count = %d, want >=1", afterA)
+	if !foundA {
+		t.Error("wsA does not see its own event")
 	}
-	if afterB != beforeB {
-		t.Errorf("wsB event count changed from %d to %d — cross-contamination", beforeB, afterB)
+
+	// B sees the SAME row — one events table for the whole process.
+	if svcB.Events == nil {
+		t.Skip("event store not configured for wsB")
+	}
+	foundB := false
+	if evts, err := svcB.Events.ReadLast(1000); err == nil {
+		for _, ev := range evts {
+			if ev.Type == "hook.test" && ev.Agent == "alice" {
+				foundB = true
+			}
+		}
+	}
+	if !foundB {
+		t.Error("shared DB: wsB must see the event appended through wsA's services")
 	}
 }
 

--- a/server/testmain_test.go
+++ b/server/testmain_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain pins MYCEL_HOME to a throwaway dir so the single global
+// database created by workspace Init/Load and BuildWorkspaceServices
+// in tests never touches the developer's real ~/.mycel. Tests that
+// need a specific home still override it per-test via t.Setenv.
+func TestMain(m *testing.M) {
+	var testHome string
+	if home, err := os.MkdirTemp("", "mycel-test-home-*"); err == nil {
+		testHome = home
+		_ = os.Setenv("MYCEL_HOME", home)
+	}
+	code := m.Run()
+	if testHome != "" {
+		_ = os.RemoveAll(testHome)
+	}
+	os.Exit(code)
+}

--- a/server/workspace_services.go
+++ b/server/workspace_services.go
@@ -123,12 +123,12 @@ func (ws *WorkspaceServices) LastAccess() time.Time {
 // to exit, then invokes the factory-supplied closer to tear down stores.
 // Safe to call multiple times.
 //
-// The per-workspace database connection is deliberately NOT closed here:
-// stores borrow it from the pkg/db registry, which keeps it cached so an
+// The global database connection is deliberately NOT closed here:
+// stores borrow it from pkg/db, which keeps it cached so an
 // evicted-then-reloaded workspace reuses the same handle (an idle SQLite
 // connection is one pooled conn — cheap) and so other holders (role
-// store, CLI helpers) never see a use-after-close. Registry connections
-// are closed at process shutdown via db.CloseAllWorkspaceDBs.
+// store, CLI helpers) never see a use-after-close. The connection is
+// closed at process shutdown via db.CloseGlobal.
 func (ws *WorkspaceServices) Close() error {
 	ws.mu.Lock()
 	cancel := ws.cancel

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -60,7 +60,7 @@ export interface Agent {
   total_tokens?: number;
   runtime_backend?: string;
   mcp_servers?: string[];
-  repo_root?: string;
+  repo?: string;
   /** Absolute path of the workspace this agent belongs to. Grouping the
    *  Agents page by workspace uses this. */
   workspace?: string;


### PR DESCRIPTION
## What

Wave 1 of #3276 (owner-approved design): ONE global `~/.mycel/mycel.db` replaces per-workspace database files.

- `db.Global(cfg)` lazily opens the single DB (DATABASE_URL > timescale > sqlite fallback preserved); `Registry`/`ForWorkspace`/`BCDBPath` deleted
- **agents.repo** (absolute cleaned path) replaces the unused `repo_root`; `Agent.Repo` throughout incl. web client type
- **Globally-unique agent names** enforced at both create paths with an error naming the owning repo
- **events.repo** self-attributes at write time from the agents table (same DB — zero caller churn); old rows join through agents
- **cost re-key**: `workspace_id` → `repo` (ScopedTo/SumByRepo/importer); ledger location unchanged this wave
- **roles** live in the global DB in both storage modes
- Isolation tests re-semanticized: shared-DB visibility asserted, isolation moved to keys; MYCEL_HOME test sandboxes added
- #3279 server half: event prune cap 5,000 → 50,000 per agent (busy agents kept only ~1h of Live history)

No migration code ships (pre-release rule) — the one-time data consolidation for the dev machine happens at deploy.

## Test plan
`go build ./...` clean · full test suite green (`-race` on core packages) · lint 0 issues · new: global singleton lifecycle, key-isolation suite, name-uniqueness, event repo attribution, cost repo tagging

Wave 2 (server single-bundle + workspace machinery teardown) follows per the epic sequencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Part of #3276
Part of #3279
