### PR TITLE
fix(ci): nightly Trivy matches ci.yml — all severities, ignore unfixed

### DIFF
--- a/.github/workflows/security-nightly.yml
+++ b/.github/workflows/security-nightly.yml
@@ -69,7 +69,10 @@ jobs:
           image-ref: bc-daemon:latest
           format: sarif
           output: trivy-results.sarif
-          severity: CRITICAL,HIGH
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          # Match ci.yml: report all severities so analyses supersede older
+          # ones, and skip unfixed-upstream CVEs that no rebuild can remove.
+          ignore-unfixed: true
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v4
         if: always()


### PR DESCRIPTION
The nightly Trivy scan uploads under its own SARIF category (`security-nightly.yml:trivy`) holding the same 1,691 unfixed-upstream CVE alerts. Without the identical severity + `ignore-unfixed` config, that category keeps the wall open on the security tab no matter what the ci.yml scan reports.

Part of #3272

🤖 Generated with [Claude Code](https://claude.com/claude-code)