### PR TITLE
fix(security): cd-npm only publishes from this repo's own Release runs

### DIFF
--- a/.github/workflows/cd-npm.yml
+++ b/.github/workflows/cd-npm.yml
@@ -26,7 +26,13 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    # workflow_run path: only publish from successful Release runs of THIS
+    # repository's default branch — never from fork-originated runs, since
+    # this job holds NPM_TOKEN and checks out the run's head SHA.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
       - name: Validate dispatch tag
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
CodeQL critical `actions/untrusted-checkout` (alert #2359, surfaced when default setup re-enabled with the full language set): the `workflow_run` path checked out the triggering run's head SHA into a job holding `NPM_TOKEN` without verifying provenance — a fork-originated Release run could publish its code to npm. The job now requires `head_repository.full_name == github.repository`. The dispatch path already validates tag format + existence.

Part of #3272

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the publishing workflow so release publishing only runs from trusted repository builds.
  * Manual publishing is still available, while automated publishing now avoids runs originating from forked sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->