### PR TITLE
docs: align every page with the repo-era architecture

### DIFF
--- a/docs/architecture-notifications.md
+++ b/docs/architecture-notifications.md
@@ -746,12 +746,12 @@ GET    /api/channels/{name}/history                               -- legacy mess
 
 | Package | Purpose |
 |---------|---------|
-| [`pkg/gateway/`](../../pkg/gateway/README.md) | Adapter interface, Manager, platform adapters (Slack, Telegram, Discord) |
-| [`pkg/notify/`](../../pkg/notify/README.md) | Notification types, Store (SQLite/Postgres), Service (dispatch + subscription management) |
+| [`pkg/gateway/`](https://github.com/rpuneet/mycel/tree/main/pkg/gateway) | Adapter interface, Manager, platform adapters (Slack, Telegram, Discord) |
+| [`pkg/notify/`](https://github.com/rpuneet/mycel/tree/main/pkg/notify) | Notification types, Store (SQLite/Postgres), Service (dispatch + subscription management) |
 | `pkg/secret/` | AES-256-GCM encrypted credential storage |
 | `server/handlers/` | REST API handlers for gateway and subscription management |
 
 ## What's Next
 
-- [Agent Lifecycle](../explanation/agents.md) -- how agents start, receive credentials, and run
-- [MCP Protocol](../explanation/mcp.md) -- Model Context Protocol integration
+- [Agent Lifecycle](explanation/agents.md) -- how agents start, receive credentials, and run
+- [MCP Protocol](explanation/mcp.md) -- Model Context Protocol integration

--- a/docs/explanation/agent-lifecycle-redesign.md
+++ b/docs/explanation/agent-lifecycle-redesign.md
@@ -30,7 +30,7 @@ sequenceDiagram
     Note over API,RT: CREATE (persist only)
     API->>Svc: Create(opts)
     Svc->>Mgr: createAgent(opts)
-    Mgr->>Mgr: validate name, role, workspace
+    Mgr->>Mgr: validate name, role, repo
     Mgr->>DB: INSERT INTO agents
     Mgr->>Mgr: git worktree add
     Mgr->>Mgr: write role files (CLAUDE.md, .mcp.json)
@@ -60,8 +60,8 @@ func (m *Manager) deleteAgent(name string, force bool) error {
     // 3. Kill Docker container (docker rm -f)
     // 4. Remove git worktree (git worktree remove --force)
     // 5. Delete worktree branch (git branch -D)
-    // 6. Remove agent state dir (~/.bc/agents/<name>/)
-    // 7. Remove log file (~/.bc/logs/<name>.log)
+    // 6. Remove agent state dir (~/.mycel/workspaces/<id>/agents/<name>/)
+    // 7. Remove log file (~/.mycel/workspaces/<id>/logs/<name>.log)
     // 8. Update children's ParentID to ""
     // 9. Remove from parent's Children list
     // 10. DELETE FROM agents WHERE name = ?

--- a/docs/explanation/agents.md
+++ b/docs/explanation/agents.md
@@ -2,7 +2,7 @@
 
 ## What is an Agent?
 
-An AI coding assistant running in an isolated tmux session or Docker container with its own git worktree. Each agent has a role (defining its prompt and tool access), a workspace (git repo), and optionally belongs to teams.
+An AI coding assistant running in an isolated tmux session or Docker container with its own git worktree. Each agent has a globally unique name, a role (defining its prompt and tool access), a repo (the absolute path of the git repository it works on), and optionally belongs to teams.
 
 ## State Machine
 
@@ -38,12 +38,11 @@ stateDiagram-v2
 
 ### Tmux
 
-Local tmux sessions. Named with the `mycel-` prefix plus a short workspace
-hash for isolation between workspaces (sessions created before the rename
-under the legacy `bc-` prefix are still found via a reader-side fallback):
+Local tmux sessions. Named with the `mycel-` prefix plus a short hash of
+the repo path, so agents on different repos never collide:
 
 ```
-mycel-<ws-hash6>-<agent>
+mycel-<repo-hash6>-<agent>
 Example: mycel-a3f2c1-eng-01
 ```
 
@@ -62,16 +61,16 @@ Messages >500 chars use `load-buffer` + `paste-buffer`.
 Isolated containers with tmux inside. Same naming:
 
 ```
-mycel-<ws-hash6>-<agent>
+mycel-<repo-hash6>-<agent>
 ```
 
 | Setting | Default |
 |---------|---------|
-| Image | `mycel-agent-<tool>:latest` (default: `mycel-agent-claude:latest`; legacy `bc-agent-*` images are used as a fallback) |
+| Image | `mycel-agent-<tool>:latest` (default: `mycel-agent-claude:latest`) |
 | CPUs | 2.0 |
 | Memory | 2048 MB |
 | Network | bridge |
-| Volumes | workspace (rw), auth dir -> `/home/agent/.claude/` |
+| Volumes | repo (rw), auth dir -> `/home/agent/.claude/` |
 
 Communication: `docker exec ... tmux send-keys`.
 
@@ -79,10 +78,9 @@ Communication: `docker exec ... tmux send-keys`.
 
 mycel creates and manages git worktrees for ALL providers uniformly. No provider uses its own worktree flag (avoids nesting).
 
-Worktrees live under the workspace state directory at
-`agents/<name>/bc-<workspace>-<agent>/` (canonical:
-`~/.mycel/workspaces/<id>/agents/...`; legacy layouts keep them under the
-project's `.bc/agents/...`). They are created with `--detach`, so the agent
+Worktrees live under the per-repo runtime directory at
+`~/.mycel/workspaces/<id>/agents/<name>/bc-<repo>-<agent>/`, checked out
+from the agent's repo. They are created with `--detach`, so the agent
 checks out a detached HEAD and no branch is created for it.
 
 ### Flow
@@ -93,7 +91,7 @@ sequenceDiagram
     participant Git as git
     participant RT as Runtime
 
-    Svc->>Git: git worktree add --detach <state-dir>/agents/<name>/bc-<workspace>-<name>
+    Svc->>Git: git worktree add --detach <state-dir>/agents/<name>/bc-<repo>-<name>
     Svc->>Svc: Write role files into worktree/.claude/
     Svc->>RT: cd <worktree> && <provider-command>
 ```
@@ -102,7 +100,7 @@ sequenceDiagram
 
 | Event | Worktree Action |
 |-------|-----------------|
-| Create | `git worktree prune` + `git worktree add --detach` from workspace repo |
+| Create | `git worktree prune` + `git worktree add --detach` from the agent's repo |
 | Restart | `cd <existing-worktree> && <command>` (persists) |
 | Stop | Nothing — worktree stays |
 | Delete | `git worktree remove --force` (detached HEAD — no branch to delete) |
@@ -113,11 +111,11 @@ All started with `cd <worktree> && <command>`:
 
 | Provider | Command |
 |----------|---------|
-| Claude | `claude` (no `-w` — mycel owns worktree) |
-| Gemini | `gemini` |
-| Cursor | `cursor-agent --force --print` |
-| Aider | `aider --yes` |
+| Claude | `claude --dangerously-skip-permissions` (no `-w` — mycel owns the worktree) |
+| Gemini | `gemini --yolo` |
+| Cursor | `cursor-agent` |
 | Codex | `codex --full-auto` |
+| Pi | `pi` |
 
 ### Session Resume
 

--- a/docs/explanation/database.md
+++ b/docs/explanation/database.md
@@ -4,35 +4,36 @@
 
 mycel uses two storage backends behind a single abstraction:
 
-- **SQLite** (default) — zero-configuration, local-first. The shared workspace database lives at `<workspace>/.bc/bc.db`.
+- **SQLite** (default) — zero-configuration, local-first. The single global database lives at `~/.mycel/mycel.db`.
 - **TimescaleDB** (Postgres 17) — implemented and shipping as the `mycel-bcdb` Docker image (`timescale/timescaledb:2.19.1-pg17`). Selected via config or environment (see below).
 
-There is deliberately no single global database. Data is split by scope:
+There is one global database. Isolation between repos comes from data keys (agent name, repo path), not from separate files:
 
 | Scope | Location | Contents |
 |-------|----------|----------|
-| Workspace | `<workspace>/.bc/bc.db` | Shared workspace DB: notifications, cron, MCP servers, tools, events, roles |
-| Per-workspace runtime | `~/.mycel/workspaces/<id>/` | Agent state dirs, per-workspace `costs.db` |
-| User-global | `~/.mycel/` | `secrets.vault` (SQLite vault), `costs.db` (cross-workspace ledger), `workspaces.json` registry, `mcps.json`, `tools.json`, `daemon.{pid,log,addr}` |
+| Global database | `~/.mycel/mycel.db` | Agents, roles, notifications, cron, MCP servers, tools, events |
+| Cost ledger | `~/.mycel/costs.db` | Cost records with per-repo attribution |
+| Secrets | `~/.mycel/secrets.vault` | SQLite vault with encrypted values |
+| Per-repo runtime | `~/.mycel/workspaces/<id>/` | `preferences.json`, agent files, git worktrees, logs |
 
-`~/.mycel/` is resolved by `pkg/workspace.MycelHome()`: `MYCEL_HOME` env var, then `BC_HOME` (deprecated), then `~/.mycel/`, with a one-time migration from a legacy `~/.bc/` tree. Known consolidation work is tracked in issues #3237 and #3238 (folding the remaining per-concern DB files into the shared workspace DB).
+`~/.mycel/` is resolved by `pkg/workspace.MycelHome()`: the `MYCEL_HOME` env var when set, otherwise `~/.mycel/`.
 
 ## Backend Selection
 
-`pkg/db/unified.go` (`OpenWorkspaceDBWithConfig`) picks the backend at startup:
+`pkg/db/unified.go` (`OpenGlobalDBWithConfig`) picks the backend at startup:
 
 1. **`DATABASE_URL` env var** — Postgres/TimescaleDB override for Docker and CI.
-2. **`settings.json` `storage.default`** — `"timescale"` (legacy value `"sql"` also accepted) connects using `storage.timescale.{host,port,user,password,database}`; the password falls back to `BC_DB_PASSWORD`. If TimescaleDB is unreachable, the daemon logs a warning and falls back to SQLite rather than starting with nil stores.
-3. **SQLite default** — `<workspace>/.bc/bc.db` (path overridable via `storage.sqlite.path`).
+2. **`preferences.json` `storage.default`** — `"timescale"` connects using `storage.timescale.{host,port,user,password,database}`; the password falls back to `BC_DB_PASSWORD`. If TimescaleDB is unreachable, the daemon logs a warning and falls back to SQLite rather than starting with nil stores.
+3. **SQLite default** — `~/.mycel/mycel.db`. One process, one file: the `storage.sqlite.path` field is accepted for parsing but the database always lives at the global path.
 
 ## Shared Connection
 
-One connection is opened at startup and registered via `db.SetShared(db, driver)`; the driver string is `"sqlite"` or `"timescale"`. Stores (`pkg/notify`, `pkg/cron`, `pkg/mcp`, `pkg/tool`, `pkg/events`, `pkg/workspace` roles, `pkg/cost`) retrieve it with `db.Shared()` / `db.SharedWrapped()` and never open the same file twice. Stores fall back to opening a dedicated file only when no shared connection is set (e.g., short-lived CLI paths).
+`db.Global(cfg)` opens the process-wide handle lazily on first use and returns it together with the driver string (`"sqlite"` or `"timescale"`). Stores (`pkg/notify`, `pkg/cron`, `pkg/mcp`, `pkg/tool`, `pkg/events`, roles, `pkg/cost`) all share this handle and never open the same file twice; the connection is cached for the life of the process and torn down only by `db.CloseGlobal()` at shutdown.
 
 ```mermaid
 graph LR
     subgraph "mycel process"
-        S["db.SetShared() at startup"]
+        S["db.Global() — lazy, cached"]
         N[notify store]
         C[cron store]
         M[mcp store]
@@ -40,8 +41,8 @@ graph LR
         E[events store]
         R[role store]
     end
-    S --> DB["<workspace>/.bc/bc.db (SQLite WAL)<br/>or TimescaleDB"]
-    N & C & M & T & E & R -->|db.Shared()| S
+    S --> DB["~/.mycel/mycel.db (SQLite WAL)<br/>or TimescaleDB"]
+    N & C & M & T & E & R -->|db.Global()| S
 ```
 
 ## SQLite Connection Settings
@@ -79,7 +80,7 @@ roles(
 )
 ```
 
-The same JSON-column pattern applies elsewhere (provider settings, tool metadata). This keeps reads single-row and writes atomic at the cost of not being able to query membership relationally — acceptable at workspace scale.
+The same JSON-column pattern applies elsewhere (provider settings, tool metadata). This keeps reads single-row and writes atomic at the cost of not being able to query membership relationally — acceptable at single-user scale.
 
 ## Main Table Groups
 
@@ -91,14 +92,14 @@ The same JSON-column pattern applies elsewhere (provider settings, tool metadata
 | Tools | `pkg/tool` | tool registry tables |
 | Events | `pkg/events` | event log |
 | Roles | `pkg/workspace` | `roles` |
-| Costs | `pkg/cost` | cost records (shared DB on TimescaleDB; dedicated `costs.db` fallback on SQLite) |
+| Costs | `pkg/cost` | cost records (hypertable on TimescaleDB; `~/.mycel/costs.db` ledger on SQLite) |
 | Secrets | `pkg/secret` | encrypted secret rows in `~/.mycel/secrets.vault` |
 
 Timestamp conventions vary by store: most tables use `INTEGER` Unix milliseconds; the notification tables use `TEXT` ISO 8601 on SQLite and `TIMESTAMPTZ` on TimescaleDB.
 
 ## TimescaleDB Backend
 
-Postgres support is not planned — it exists:
+Postgres support is fully implemented:
 
 - `pkg/db/postgres.go` — connection handling, `DATABASE_URL` / DSN construction.
 - Per-store Postgres implementations: `pkg/cost/store_postgres.go`, `pkg/cron/store_postgres.go`, `pkg/events/store_postgres.go`, `pkg/mcp/store_postgres.go`, `pkg/secret/store_postgres.go`, `pkg/tool/store_postgres.go`; the role store switches dialect on the shared driver string.
@@ -108,24 +109,20 @@ Postgres support is not planned — it exists:
 ## Filesystem Layout
 
 ```
-~/.mycel/                       # MycelHome (MYCEL_HOME overrides; legacy ~/.bc/ honored)
-  workspaces.json               # Workspace registry
-  secrets.vault                 # User-global secret vault (SQLite, encrypted values)
-  costs.db                      # Cross-workspace cost ledger (records tagged workspace_id)
-  mcps.json                     # User-global MCP server config
-  tools.json                    # User-global tool registry
-  templates/                    # User-global templates
+~/.mycel/                       # MycelHome (MYCEL_HOME overrides)
+  mycel.db                      # THE database: agents, roles, events, notify, cron, mcp, tools
+  costs.db                      # Cost ledger (per-repo attribution)
+  secrets.vault                 # Secret vault (SQLite, encrypted values)
+  mcps.json                     # Global MCP server config
+  tools.json                    # Global tool registry
+  templates/                    # Global agent templates
   daemon.pid / daemon.log / daemon.addr   # Server process state
-  workspaces/<id>/              # Per-workspace runtime dir (pkg/workspace.DataDir)
+  workspaces/<id>/              # Per-repo runtime dir (id = sha256(repo path)[:12])
+    preferences.json            # The one config file mycel reads
     agents/<name>/
       claude/                   # Provider state (mounted into containers as ~/.claude)
       claude.json               # Provider app config (auth persistence)
-    costs.db                    # Per-workspace cost data (SQLite mode)
-
-<workspace>/.bc/                # Workspace sidecar (checked-out project)
-  settings.json                 # Workspace config (v2 JSON)
-  bc.db                         # Shared workspace database
-  templates/                    # Workspace-scoped templates
+    logs/
 ```
 
 ## Secret Encryption
@@ -154,4 +151,4 @@ graph LR
     API --> WEB[Web/TUI dashboards]
 ```
 
-The importer scans agent provider state for session JSONL files, extracts token usage, applies model pricing, and inserts with watermark dedup. On TimescaleDB, cost records go to the shared DB (hypertable); on SQLite they live in the per-workspace `costs.db`, with the user-global `~/.mycel/costs.db` serving cross-workspace rollups.
+The importer scans agent provider state for session JSONL files, extracts token usage, applies model pricing, and inserts with watermark dedup. On TimescaleDB, cost records go to the shared DB (hypertable); on SQLite they live in the `~/.mycel/costs.db` ledger, where every record carries a repo tag so costs roll up per repo and per agent.

--- a/docs/explanation/deployment.md
+++ b/docs/explanation/deployment.md
@@ -66,8 +66,6 @@ graph TD
 | `mycel-bcdb` | `docker/Dockerfile.bcdb` | TimescaleDB (`POSTGRES_USER=bc`, `POSTGRES_DB=bc`, password at runtime), seeds `docker/bcdb/init.sql` |
 | `bc-playwright` | `docker/Dockerfile.playwright` | Playwright MCP server (built separately) |
 
-Agent images are also tagged with the legacy `bc-agent-*` names for one release cycle (v0.3.x rename fallback).
-
 ### Base Image (`docker/Dockerfile.base`)
 
 | Component | Purpose |
@@ -84,10 +82,10 @@ Runs as non-root user `agent` with `WORKDIR /workspace`.
 ### Container Naming
 
 ```
-mycel-<workspace-hash6>-<agent>
+mycel-<repo-hash6>-<agent>
 ```
 
-`workspace-hash6` is the first 6 hex characters of the SHA-256 of the host workspace path (`pkg/container/container.go`). Example: `mycel-a1b2c3-alice`. Containers created under the pre-rename `bc-` prefix remain discoverable via a legacy-prefix fallback.
+`repo-hash6` is the first 6 hex characters of the SHA-256 of the agent's repo path (`pkg/container/container.go`). Example: `mycel-a1b2c3-alice`.
 
 ### Container Lifecycle
 
@@ -102,21 +100,21 @@ stateDiagram-v2
 
 ## Volume Mounts
 
-Ground truth: `pkg/container/container.go`. Agent state lives at `~/.mycel/workspaces/<id>/agents/<name>/` on the host (legacy fallback: `<workspace>/.bc/agents/<name>/`).
+Ground truth: `pkg/container/container.go`. Agent state lives at `~/.mycel/workspaces/<id>/agents/<name>/` on the host.
 
 | Mount | Container path | Purpose |
 |-------|---------------|---------|
-| Host project root | `/workspace` | Full repo mounted so git worktrees resolve (`-w` is set to the agent's worktree subdirectory) |
+| Agent's repo | `/workspace` | Full repo mounted so git worktrees resolve (`-w` is set to the agent's worktree subdirectory) |
 | `<agent-dir>/claude/` | `/home/agent/.claude` | Persistent provider state across restarts |
 | `<agent-dir>/claude.json` | `/home/agent/.claude.json` | Provider app config (OAuth account — auth persistence) |
 | Named volume `bc-shared-tmp` | `/tmp/bc-shared` | Cross-container file exchange (e.g. Playwright screenshots) |
-| `runtime.docker.extra_mounts` | as specified | User-defined mounts, validated against the workspace root |
+| `runtime.docker.extra_mounts` | as specified | User-defined mounts, validated against the repo root |
 
 When the server itself runs in Docker (Docker-in-Docker), `BC_HOST_WORKSPACE` supplies the host-side path so `-v` mounts resolve correctly.
 
 ## Network Topology
 
-Default: the **`bc-net`** Docker network (`runtime.docker.network` in settings.json; the backend falls back to `bridge` when unset).
+Default: the **`bc-net`** Docker network (`runtime.docker.network` in preferences.json; the backend falls back to `bridge` when unset).
 
 | Service | Port | Protocol |
 |---------|------|----------|
@@ -144,4 +142,4 @@ Defaults from `pkg/workspace/config.go`:
 
 ## Local Dev (tmux mode)
 
-Set `runtime.default = "tmux"` in settings.json — agents run as tmux sessions on the host (prefix `mycel-`), no Docker needed, SQLite for all storage. This is the local development fallback; `docker` is the default runtime.
+Set `runtime.default = "tmux"` in preferences.json — agents run as tmux sessions on the host (prefix `mycel-`), no Docker needed, SQLite for all storage. This is the local development fallback; `docker` is the default runtime.

--- a/docs/explanation/design-decisions.md
+++ b/docs/explanation/design-decisions.md
@@ -13,16 +13,17 @@ context, and the reasoning behind each choice.
 secrets, cron jobs, MCP servers, and tools. The storage must work out of the
 box for every developer without any setup steps.
 
-**Decision:** Use SQLite for all persistent storage, with a small number of
-`.db` files per concern (e.g., the unified `bc.db`, plus `state.db` and
-`secrets.db`) stored in the workspace's `.bc/` / state directory.
+**Decision:** Use SQLite for all persistent storage: one global database at
+`~/.mycel/mycel.db` for every store (agents, roles, events, notifications,
+cron, MCP servers, tools), plus a `costs.db` ledger and a `secrets.vault`
+alongside it.
 
 **Rationale:**
 
 - **Zero configuration**: no database server to install, configure, or manage.
 - **Embedded**: the database is a single file linked into the Go binary.
-- **Portable with workspace**: `.bc/` travels with the project (or is
-  `.gitignore`-d for sensitive data). Copying a workspace copies all state.
+- **Repos stay pristine**: all state lives under `~/.mycel/`, never inside
+  the project. State survives repo moves and clones.
 - **Concurrent-safe**: SQLite WAL mode handles the concurrency level mycel
   needs (one server, a few CLI readers).
 - **Tables use `IF NOT EXISTS`**: schema is applied idempotently at startup,
@@ -44,8 +45,8 @@ box for every developer without any setup steps.
 tools (Claude Code, Gemini, etc.) that expect a terminal. The system must
 work for local development and for isolated, reproducible builds.
 
-**Decision:** Support two runtime backends — tmux (local) and Docker
-(isolated) — selectable via `[runtime] backend` in `settings.json`.
+**Decision:** Support two runtime backends — Docker (isolated, the default)
+and tmux (local) — selectable via `runtime.default` in `preferences.json`.
 
 **Rationale:**
 
@@ -110,8 +111,9 @@ WebSockets.
 
 **Status:** Accepted
 
-**Context:** mycel ships a web dashboard for workspace management. It needs
-to be easy to deploy and use without a separate frontend server.
+**Context:** mycel ships a web dashboard for managing agents, repos, and
+costs. It needs to be easy to deploy and use without a separate frontend
+server.
 
 **Decision:** Embed the compiled web UI (from `server/web/dist/`) into the
 `mycel` binary using Go's `embed.FS`, served as static files with SPA
@@ -138,39 +140,40 @@ fallback.
 
 ---
 
-## ADR-5: File-Based Hooks for Agent State Detection
+## ADR-5: HTTP Hooks for Agent State Detection
 
 **Status:** Accepted
 
 **Context:** the mycel server needs to know when agents transition between
-states (working, idle, stopped). Agents run inside tmux sessions or Docker
-containers, potentially without network access to the server.
+states (working, idle, stuck, stopped). Agents run inside tmux sessions or
+Docker containers.
 
-**Decision:** Use file-based hooks where Claude Code lifecycle events
-(`PreToolUse`, `PostToolUse`, `Stop`) write the event name to a well-known
-file path: `.bc/agents/<NAME>/hook_event`.
+**Decision:** Use HTTP hooks: Claude Code lifecycle events (`SessionStart`,
+`UserPromptSubmit`, `PreToolUse`, `Stop`, and others) POST a JSON payload to
+the server's `/api/agents/{name}/hook` endpoint. The server address comes
+from the `BC_BCD_ADDR` env var set per agent.
 
 **Rationale:**
 
-- **Works in Docker**: containers mount the workspace directory, so
-  file writes are visible to the host without network configuration.
-- **Survives restarts**: files on disk persist across server restarts. If
-  the server is down when an event fires, the file is still there when it
-  comes back.
-- **Stateless consumption**: the server's `StatsCollector` reads and deletes the
-  hook event file on each poll cycle via `ConsumeHookEvent()`. No connection
-  state to manage.
+- **Instant updates**: state changes reach the server the moment the event
+  fires — no poll cycle. The server updates `mycel.db` and broadcasts over
+  SSE, so the web UI and TUI stay live.
+- **Full payload preserved**: the hook command reads Claude's raw stdin
+  JSON, merges in mycel's `event`/`state`/`task` fields with `jq`, and
+  POSTs everything — tool names, tool input, and session IDs included.
+- **Works in Docker**: containers reach the host server over the network
+  via `BC_BCD_ADDR`; no shared-filesystem tricks needed.
+- **Fire-and-forget**: each hook ends in `|| true`, so a down or slow
+  server never blocks or breaks the agent.
 - **Claude Code integration**: hooks are configured in
   `.claude/settings.json` using Claude Code's native hook system. The
   `WriteWorkspaceHookSettings()` function generates the settings
   idempotently, merging with any existing user hooks.
-- **Simple command**: each hook runs a single `printf` command to write the
-  event name to the file. No dependencies, no network calls.
 
 **Tradeoffs:**
 
-- Polling-based (not instant) — there is a short delay between the event
-  and detection. Acceptable for status display purposes.
+- Events fired while the server is down are lost; state re-syncs on the
+  next event.
 - Only works with Claude Code's hook system. Other AI tools need different
   state detection mechanisms.
 
@@ -196,7 +199,7 @@ via the `parent_roles` JSON column on the `roles` database table.
 - **No diamond problem**: BFS with visited-set tracking naturally handles
   cases where two parents share a common ancestor. Each role is visited only
   once, and the first encounter wins.
-- **Flat hierarchy in practice**: most workspaces use 2-3 levels at most
+- **Flat hierarchy in practice**: most setups use 2-3 levels at most
   (e.g., `engineer` inherits from `base`, `lead` inherits from `engineer`).
 
 **Tradeoffs:**

--- a/docs/explanation/design-system.md
+++ b/docs/explanation/design-system.md
@@ -1,12 +1,12 @@
 # mycel Design System: Solar Flare
 
-> Unified visual language for all bc frontends and CLI output.
+> Unified visual language for all mycel frontends and CLI output.
 
 ---
 
 ## 1. Overview
 
-**Solar Flare** is the design system for bc. It defines a single visual language -- warm blacks, deep oranges, sky blue accent -- shared across every surface where bc presents itself to users.
+**Solar Flare** is the design system for mycel. It defines a single visual language -- warm blacks, deep oranges, sky blue accent -- shared across every surface where mycel presents itself to users.
 
 ### Consumers
 
@@ -509,7 +509,7 @@ The ANSI 16 mapping serves as a fallback for restricted environments. Runtime de
 
 ## 10. Shared Component Library (`@bc/ui`)
 
-The shared component library provides platform-agnostic component interfaces with platform-specific renderers. Web and TUI share the same component API, ensuring visual and behavioral consistency.
+This section is the design specification for a platform-agnostic component library: shared component interfaces with platform-specific renderers, so web and TUI share the same component API. Today the frontends implement these components locally (only `@bc/design-tokens` is shared under `packages/`); the spec below defines the target API and rendering rules they follow.
 
 ### 10.1 Architecture
 

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,6 +1,6 @@
 # Explanation
 
-Understanding-oriented documentation that explains how and why bc works the way it does.
+Understanding-oriented documentation that explains how and why mycel works the way it does.
 
 ## Architecture
 
@@ -16,7 +16,7 @@ Understanding-oriented documentation that explains how and why bc works the way 
 |----------|-------------|
 | [Agents](agents.md) | Agent state machine, runtime backends, worktree management, and roles |
 | [MCP Server](mcp.md) | Resources, tools, transports, and notifications |
-| [Database](database.md) | Schema, ER diagram, indexes, migrations, encryption, and filesystem layout |
+| [Database](database.md) | Storage backends, schema management, encryption, and filesystem layout |
 | [Networking](networking.md) | Client-server communication protocols, SSE events, MCP transports |
 
 ## Frontend

--- a/docs/explanation/mcp.md
+++ b/docs/explanation/mcp.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-mycel exposes a Model Context Protocol (MCP) server so AI agents can read workspace state and communicate through gateway channels. Protocol version: `2024-11-05`.
+mycel exposes a Model Context Protocol (MCP) server so AI agents can read system state and communicate through gateway channels. Protocol version: `2024-11-05`.
 
 ## Transports
 
@@ -31,16 +31,16 @@ graph LR
 
 ## Sender Identity
 
-The sender identity for outbound tools (`send_message`, `send_file`) is derived server-side from the authenticated SSE connection — either the agent-scoped path `/_mcp/{agent}/...` or the `?agent=` query param on the SSE URL. A client-supplied `sender` value is advisory only: if it disagrees with the connection's agent identity, the server logs a warning and overrides it (spoofing fix, issue #2967). Only unauthenticated legacy connections fall back to the client value.
+The sender identity for outbound tools (`send_message`, `send_file`) is derived server-side from the authenticated SSE connection — either the agent-scoped path `/_mcp/{agent}/...` or the `?agent=` query param on the SSE URL. A client-supplied `sender` value is advisory only: if it disagrees with the connection's agent identity, the server logs a warning and overrides it (spoofing fix, issue #2967). Connections without a server-side agent identity fall back to the client value.
 
 ## Resources (read-only)
 
 | URI | Description |
 |-----|-------------|
-| `bc://workspace/status` | Workspace name, path, state dir, agents dir |
+| `bc://workspace/status` | Repo name, path, state dir, agents dir |
 | `bc://agents` | All agents with state, role, tool, team, worktree, session |
 | `bc://channels` | Channels (currently returns an empty list — channels are managed by pkg/notify) |
-| `bc://costs` | Workspace + per-agent cost/token breakdown |
+| `bc://costs` | Total + per-agent cost/token breakdown |
 | `bc://roles` | Available roles with MCP server and secret associations |
 | `bc://tools` | AI tools (claude, gemini, cursor, codex) with PATH availability check |
 
@@ -51,7 +51,7 @@ The sender identity for outbound tools (`send_message`, `send_file`) is derived 
 | Tool | Args | Description |
 |------|------|-------------|
 | `send_message` | channel, message, sender? | Send text to a gateway channel (e.g., `slack:eng`); sender defaults to the authenticated agent identity |
-| `send_file` | channel, file_path, comment? | Upload a file (max 50MB, path must be under the workspace root or /tmp) to a gateway channel |
+| `send_file` | channel, file_path, comment? | Upload a file (max 50MB, path must be under the repo root or /tmp) to a gateway channel |
 | `list_channels` | — | List all gateway channels with platform |
 | `read_channel` | channel, limit? | Read recent messages (default 20) |
 
@@ -59,8 +59,8 @@ The sender identity for outbound tools (`send_message`, `send_file`) is derived 
 
 | Tool | Args | Description |
 |------|------|-------------|
-| `whoami` | — | Current agent's identity, workspace, role, state, and task |
-| `list_agents` | role? | List workspace agents with status and role, optionally filtered by role |
+| `whoami` | — | Current agent's identity, repo, role, state, and task |
+| `list_agents` | role? | List agents with status and role, optionally filtered by role |
 
 Tool arguments have per-field length caps enforced at handler entry (64KB for message/comment, 256B for channel/sender/role, 4KB for file_path) since the `/_mcp/*` routes are exempt from the global body-size middleware.
 
@@ -78,11 +78,11 @@ mycel manages MCP servers that agents connect to (Playwright, GitHub, etc.):
 
 - Managed via `mycel mcp add|list|show|remove|enable|disable`
 - Stored in the `mcp_servers` table
-- Referenced by roles via the `mcp_servers` list in role metadata (`.bc/roles/*.md`)
+- Referenced by roles via the `mcp_servers` JSON column on the `roles` table
 - Env vars support `${secret:NAME}`
 - Written to agent `.mcp.json` during role setup
 
-`mycel mcp register` adds mycel itself as an MCP server in the workspace preferences so agents automatically get the tools above (stdio by default, `--sse` for the SSE endpoint).
+`mycel mcp register` adds mycel itself as an MCP server in `preferences.json` so agents automatically get the tools above (stdio by default, `--sse` for the SSE endpoint).
 
 ## Code Map
 

--- a/docs/explanation/networking.md
+++ b/docs/explanation/networking.md
@@ -9,7 +9,7 @@ graph TB
     TUI[TUI] -->|mycel CLI| CLI
     AGENT_MCP[AI Agents] -->|MCP stdio/SSE| BCD
 
-    BCD -->|SQL| DB[(.bc/bc.db)]
+    BCD -->|SQL| DB[(~/.mycel/mycel.db)]
     BCD -->|docker exec<br/>tmux send-keys| AGENTS[Agent Containers]
     BCD -->|SSE broadcast| WEB
     BCD -->|SSE broadcast| TUI
@@ -26,7 +26,7 @@ All communication flows through the **mycel server** as the central hub. No comp
 | REST API | HTTP/JSON | `/api/*` (see the [REST API reference](../reference/api-rest.md)) | CRUD for all resources |
 | SSE Events | HTTP SSE | `/api/events` | Real-time state updates |
 | MCP (stdio) | JSON-RPC 2.0 | stdin/stdout | Agent -> server integration |
-| MCP (SSE) | JSON-RPC 2.0 | `/mcp/sse` + `/mcp/message` | Remote MCP clients |
+| MCP (SSE) | JSON-RPC 2.0 | `/_mcp/sse` + `/_mcp/message` | Remote MCP clients |
 | Health | HTTP | `/health` | Liveness probe |
 
 ## Notification Delivery Flow
@@ -84,7 +84,7 @@ sequenceDiagram
 
 ## MCP Integration
 
-AI agents connect to the mycel server's MCP endpoint to read workspace state and take actions:
+AI agents connect to the mycel server's MCP endpoint to read system state and take actions:
 
 ```mermaid
 sequenceDiagram

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -23,12 +23,12 @@ for anything beyond that.
 - TLS — the server is not designed to be exposed to a network directly. If
   you need remote access, put it behind a TLS-terminating reverse proxy and
   enable API-key authentication.
-- Multi-tenant isolation — a single workspace is used by one developer (or
-  one CI job) at a time.
+- Multi-tenant isolation — the server is single-tenant, used by one
+  developer (or one CI job) at a time.
 
 ## Secret Management
 
-Secrets are stored in an SQLite database at `.bc/secrets.db` and encrypted
+Secrets are stored in an SQLite vault at `~/.mycel/secrets.vault` and encrypted
 with **AES-256-GCM**. The encryption key is derived from a master passphrase
 using **PBKDF2-SHA256** with 600,000 iterations (per OWASP 2023 guidance) and
 a random 16-byte salt.
@@ -39,7 +39,7 @@ The passphrase is resolved in priority order:
 
 1. **`BC_SECRET_PASSPHRASE` environment variable** — set this in CI or when
    you want explicit control.
-2. **Auto-generated key file at `~/.bc/secret-key`** — created on first use
+2. **Auto-generated key file at `~/.mycel/secret-key`** — created on first use
    with 32 random bytes (hex-encoded), file permissions `0600`, directory
    permissions `0700`.
 
@@ -66,29 +66,30 @@ with the following isolation measures.
 
 Containers receive exactly two mounts by default:
 
-1. **Workspace directory** → `/workspace` (project source code).
+1. **Agent's repo** → `/workspace` (project source code).
 2. **Persistent Claude state** → `/home/agent/.claude` (auth, plugins,
-   sessions). Stored at `.bc/volumes/<agent>/.claude` on the host.
+   sessions). Stored at `~/.mycel/workspaces/<id>/agents/<name>/claude/` on
+   the host.
 
 ### Mount Validation
 
-Extra mounts (configured via `[runtime.docker] extra_mounts`) are validated
+Extra mounts (configured via `runtime.docker.extra_mounts`) are validated
 by `validateMount()` before being passed to `docker run`:
 
 - **Format check**: must be `src:dst` or `src:dst:opts`.
 - **Path traversal rejection**: source paths containing `..` are rejected.
 - **Absolute path requirement**: source must be an absolute path.
 - **Symlink resolution**: source is resolved via `filepath.EvalSymlinks` to
-  prevent symlink-based escapes (e.g., a symlink inside the workspace
-  pointing to `/etc`).
-- **Workspace containment**: the resolved source path must be within or equal
-  to the workspace root directory.
+  prevent symlink-based escapes (e.g., a symlink inside the repo pointing
+  to `/etc`).
+- **Repo containment**: the resolved source path must be within or equal
+  to the repo root directory.
 
 ### Network
 
-The default Docker network is `bridge`. Network configuration is set via
-`[runtime.docker] network` in `settings.json`. To fully isolate agents from
-the network, set `network = "none"`.
+The default Docker network is `bc-net` (`runtime.docker.network` in
+`preferences.json`; the backend falls back to `bridge` when unset). To fully
+isolate agents from the network, set the network to `none`.
 
 ### Resource Limits
 
@@ -108,7 +109,7 @@ crafted key names.
 The mycel server applies middleware in this order (outermost runs first):
 
 ```
-RateLimit → APIKeyAuth → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → WorkspaceScope → Router
+RateLimit → APIKeyAuth → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → Router
 ```
 
 ### API Key Authentication

--- a/docs/explanation/tui.md
+++ b/docs/explanation/tui.md
@@ -16,8 +16,8 @@ graph TD
     subgraph Server["mycel server (mycel up)"]
         API["REST API\n/api/*"]
         SSE["SSE Endpoint\n/api/events"]
-        DB["Workspace DB\n<workspace>/.bc/bc.db"]
-        Config["Workspace Config\n<workspace>/.bc/settings.json"]
+        DB["Global DB\n~/.mycel/mycel.db"]
+        Config["Config\npreferences.json"]
     end
 
     TUI -->|"HTTP + SSE"| API
@@ -37,7 +37,7 @@ graph TD
 - The TUI calls the server, not the CLI. The CLI is a sibling client, not an intermediary.
 - All four clients share the same REST contract. A feature available in one client can be built in any other without backend changes.
 - Real-time updates (agent state transitions, notifications, cost ticks) arrive via SSE; polling remains as fallback for data without SSE coverage.
-- Workspace configuration lives at `<workspace>/.bc/settings.json`. User-global state (daemon address file, registry, templates) lives under `~/.mycel/`.
+- Configuration lives in `preferences.json` under `~/.mycel/`, alongside the global database, daemon address file, and templates.
 
 ### Tech Stack
 
@@ -281,7 +281,7 @@ An `EventSource` connection to `GET /api/events` receives server-pushed events. 
 | `UnreadContext` | `hooks/UnreadContext.tsx` | Per-source unread counts (provider + consumer hook) |
 | `useCosts` | `hooks/useCosts.ts` | Fetches cost summary data |
 | `useLogs` | `hooks/useLogs.ts` | Fetches event logs with severity and agent filtering |
-| `useStatus` | `hooks/useStatus.ts` | Workspace status summary with agent counts by state |
+| `useStatus` | `hooks/useStatus.ts` | Status summary with agent counts by state |
 | `useDashboard` | `hooks/useDashboard.ts` | Aggregates status + notifications + costs in parallel |
 | `usePolling` | `hooks/usePolling.ts` | Message/agent change detection, coordinated dashboard tick |
 | `useAdaptivePolling` | `hooks/useAdaptivePolling.ts` | 4-mode adaptive intervals: fast/normal/slow/backoff |
@@ -425,7 +425,7 @@ Built-in dark and light themes map semantic slots to ANSI names:
 - Auto-detection via `detectColorScheme.ts` which reads the `COLORFGBG` env var to determine if the terminal background is dark or light.
 - `useTheme()` hook provides: `theme` object, `mode`, `themeName`, `isDark` flag, `color(key)` accessor, `toggleTheme()`, `cycleTheme()`, `setMode()`, `setThemeName()`.
 - `useThemeColor(key)` for single color access, `useThemeColors(keys)` for batch access.
-- `applyOverrides(theme, overrides)` merges custom color patches from workspace config.
+- `applyOverrides(theme, overrides)` merges custom color patches from config.
 
 **Hardcoded color constants (`constants/colors.ts`):**
 - `ROLE_COLORS` -- maps role names to ANSI colors (root=magenta, engineer=green, tech-lead=cyan, manager=yellow, pm=yellow, ux=blue, qa=red).
@@ -521,7 +521,7 @@ The TUI centralizes magic numbers into `tui/src/constants/`:
 | `limits.ts` | `TRUNCATION` lengths, `DISPLAY_LIMITS`, `COLUMN_WIDTHS` |
 | `colors.ts` | `ROLE_COLORS`, `ROLE_PREFIXES`, `ROLE_EMOJIS`, helper functions |
 
-**Runtime-configurable values** come from the server via `ConfigContext` (`GET /api/config`) and can be tuned in the workspace `settings.json` performance section: per-data-type poll intervals plus the adaptive polling tiers (fast/normal/slow/max backoff).
+**Runtime-configurable values** come from the server via `ConfigContext` (`GET /api/config`) and can be tuned in the `preferences.json` performance section: per-data-type poll intervals plus the adaptive polling tiers (fast/normal/slow/max backoff).
 
 ---
 

--- a/docs/explanation/web-ui.md
+++ b/docs/explanation/web-ui.md
@@ -25,8 +25,8 @@ graph TB
     end
 
     subgraph Storage ["Storage Layer"]
-        DB["Workspace DB<br/>&lt;workspace&gt;/.bc/bc.db (SQLite)<br/>or TimescaleDB"]
-        FS["Filesystem<br/>~/.mycel/ global tree,<br/>workspace .bc/ dir"]
+        DB["Global DB<br/>~/.mycel/mycel.db (SQLite)<br/>or TimescaleDB"]
+        FS["Filesystem<br/>~/.mycel/ global tree"]
     end
 
     CLI -->|"HTTP GET/POST"| REST
@@ -71,15 +71,14 @@ graph TB
 ErrorBoundary
 └── ThemeProvider            (3 themes, localStorage persistence)
     └── BrowserRouter
-        └── WorkspaceProvider (active workspace context — routes stay flat)
-            └── Routes
-                └── Layout    (sidebar + header + <Outlet/>)
-                    └── per-route: Suspense → ErrorBoundary → lazy view
+        └── Routes
+            └── Layout    (sidebar + header + <Outlet/>)
+                └── per-route: Suspense → ErrorBoundary → lazy view
 ```
 
 Every view is lazy-loaded (`React.lazy`) and wrapped in its own `Suspense` + `ErrorBoundary` via the `wrap()` helper, so a crash in one view does not take down the shell. A root-level `ErrorBoundary` wraps everything as a last resort.
 
-`WorkspaceProvider` makes the active workspace a piece of context rather than a URL segment — routes are flat (`/agents`, not `/w/<id>/agents`).
+Routes are flat (`/agents`, not `/w/<id>/agents`) — the repo is a property of each agent, not a URL segment.
 
 ### 2.2 Route Map
 
@@ -89,7 +88,7 @@ Ground truth: `web/src/App.tsx`.
 |---|---|---|
 | `/` (index) | `Live` | Live activity feed (default view) |
 | `/live` | `Live` | Same as index |
-| `/agents` | `Agents` | Agent list with actions |
+| `/agents` | `Agents` | Agent list, grouped by repo, with actions |
 | `/agents/:name`, `/agents/:name/*` | `AgentDetail` | Terminal, activity, cost, files per agent |
 | `/notifications` | `Notifications` | Inbound notification stream |
 | `/notifications/:sourceName` | `Notifications` | Filtered to one source |
@@ -100,7 +99,7 @@ Ground truth: `web/src/App.tsx`.
 | `/secrets` | `Secrets` | Secret metadata |
 | `/stats` | `Stats` | Metrics and usage statistics |
 | `/metrics` | `Stats` | Alias for `/stats` |
-| `/costs` | `CostsGlobal` | Cross-workspace cost rollup |
+| `/costs` | `CostsGlobal` | Cost rollup across agents and repos |
 | `/code`, `/code/*` | `Code` | Repository/code browsing |
 | `/settings` | `Settings` | Server and UI settings |
 | `/about` | `About` | Version and build info |
@@ -131,7 +130,7 @@ All components are local to `web/src/components/` — there is no shared cross-f
 | `WebTerminal.tsx`, `InlineTerminal.tsx` | Terminal rendering for agent sessions |
 | `AgentPeekPanel.tsx` | Quick agent inspection panel |
 | `CommandPalette.tsx` (+ `useCommandPalette`) | Keyboard-driven navigation/actions |
-| `CreateAgentModal.tsx`, `RalphLoopModal.tsx` | Modal flows |
+| `CreateAgentModal.tsx` | Agent creation flow — required Repo field with known-repos dropdown and a Browse picker (`POST /api/repos/discover/local`) |
 | `EmptyState.tsx`, `LoadingSkeleton.tsx`, `CopyButton.tsx`, `MessageContent.tsx` | Presentation utilities |
 | `ProviderCard.tsx`, `ProvidersTable.tsx`, `StatsTab.tsx` | Feature-specific pieces |
 | `agent-ui/`, `live/`, `notifications/`, `settings/`, `shared/` | Feature-scoped component subdirectories |
@@ -216,7 +215,7 @@ There is no global data store (no Redux/Zustand/react-query). State falls into t
 |---|---|---|
 | **Server state** (agents, notifications, costs, stats, ...) | Per-view `usePolling` + SSE-triggered refresh | Server is source of truth; no client cache beyond the current fetch |
 | **UI state** (selected row, expanded sections, form input, filters) | Local `useState` in views | Ephemeral, resets on navigation |
-| **Infrastructure state** | Contexts: `ThemeProvider` (theme, `localStorage`), `WorkspaceProvider` (active workspace), react-router (route params), sidebar collapsed (`localStorage`) | Cross-cutting, survives navigation |
+| **Infrastructure state** | Contexts: `ThemeProvider` (theme, `localStorage`), `HeaderSlotContext` (per-view header content), react-router (route params), sidebar collapsed (`localStorage`) | Cross-cutting, survives navigation |
 
 Views that mutate data (start/stop agent, create template, ...) refetch after the mutation or rely on the resulting SSE event.
 
@@ -293,7 +292,7 @@ web/src/  --vite build-->  web/dist/  --cp-->  server/web/dist/  --go:embed-->  
 | `web/src/components/Layout.tsx` | App shell: sidebar nav (`MAIN_NAV_ITEMS`, `UTIL_NAV_ITEMS`) + content outlet |
 | `web/src/components/ErrorBoundary.tsx` | React error boundary with retry UI |
 | `web/src/context/ThemeContext.tsx` | 3-theme provider, `localStorage("bc-theme")` |
-| `web/src/context/WorkspaceContext.tsx` | Active-workspace context (flat routes) |
+| `web/src/context/HeaderSlotContext.tsx` | Lets views render content into the shared header |
 | `web/src/api/client.ts` | REST API client (`request<T>` on `/api`) |
 | `web/src/api/types.ts` | API response and SSE event types |
 | `web/src/hooks/usePolling.ts` | Polling hook (interval + abort + timeout) |

--- a/docs/how-to/configure-workspace.md
+++ b/docs/how-to/configure-workspace.md
@@ -1,16 +1,16 @@
-# Configure a Workspace
+# Configure mycel
 
-This guide shows how to view and change workspace configuration: the config file, the `mycel config` CLI, the HTTP API, and the web UI.
+This guide shows how to view and change mycel configuration: the config file, the `mycel config` CLI, the HTTP API, and the web UI.
 
 ## Where Configuration Lives
 
-Each workspace stores its configuration as JSON in `preferences.json` inside the workspace state directory:
+Configuration is JSON in `preferences.json`, stored in the per-repo runtime state directory under `~/.mycel/`:
 
 ```
-~/.mycel/workspaces/<workspace-id>/preferences.json
+~/.mycel/workspaces/<id>/preferences.json
 ```
 
-The workspace ID is a 12-character hash derived from the workspace root path. If the state directory contains only a `settings.json`, it is read and promoted to `preferences.json` on first load.
+The `<id>` is a 12-character hash derived from the repo path (`sha256(repo path)[:12]`).
 
 You can change configuration four ways:
 
@@ -186,7 +186,7 @@ Validation checks the schema version (`2`), that `providers.default` references 
 
 ## User-Level Configuration
 
-User-level defaults that apply across all workspaces live in `~/.bcrc`:
+User-level defaults that apply everywhere live in `~/.bcrc`:
 
 ```bash
 mycel config user init          # Create ~/.bcrc with guided prompts
@@ -195,7 +195,7 @@ mycel config user show          # Display current user config
 mycel config user path          # Show the file path
 ```
 
-Workspace configuration always takes precedence over user-level defaults.
+`preferences.json` always takes precedence over user-level defaults.
 
 ## Full Example
 

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -4,6 +4,6 @@ Task-oriented guides for common operations.
 
 | Guide | Description |
 |-------|-------------|
-| [Configure your workspace](configure-workspace.md) | Settings file structure, providers, runtime backends, and validation |
+| [Configure mycel](configure-workspace.md) | Settings file structure, providers, runtime backends, and validation |
 | [Set up notifications](set-up-notifications.md) | Connect external platforms and subscribe agents |
 | [Troubleshoot issues](troubleshoot.md) | Common errors and solutions for installation, agents, notifications, and performance |

--- a/docs/how-to/set-up-notifications.md
+++ b/docs/how-to/set-up-notifications.md
@@ -98,8 +98,8 @@ After subscribing, verify that notifications are flowing:
 # Check adapter connection health
 mycel notify status
 
-# View recent notifications for a source
-mycel notify history slack:engineering --last 10
+# View recent delivery activity for a source
+mycel notify activity slack:engineering --limit 10
 
 # Check agent output for received notifications
 mycel agent peek eng-01
@@ -162,11 +162,6 @@ directly with a bot token loaded from its own `env.json`. See the
 [**Outbound cookbook**](../architecture-notifications.md#outbound-cookbook)
 in the Notification architecture doc for the exact curl invocations
 and the `env.json` template.
-
-The legacy `POST /api/gateways/{platform}/channels/{channel}/send`
-endpoint is deprecated (RFC 8594 headers on every response) and will
-return `410 Gone` in v0.4.0 — new integrations should use the
-per-agent cookbook pattern.
 
 ## Next Steps
 

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -61,26 +61,25 @@ make build-local-mycel
 make clean && make build-local-mycel
 ```
 
-## Workspace Issues
+## Repo & Configuration Issues
 
 ### "not in a mycel workspace"
 
-**Cause**: Running a mycel command outside a workspace, or `BC_WORKSPACE` not set.
+**Cause**: Running a repo-scoped mycel command outside a git repo that mycel knows about, or `BC_WORKSPACE` not set.
 
 **Solution**:
 ```bash
-# Start the server from your project directory — it bootstraps the workspace
+# Start the server from your repo (or add the repo in the web UI)
 mycel up
 
-# Or set the environment variable (for agents in worktrees)
-export BC_WORKSPACE=/path/to/workspace
+# Or point at the repo explicitly (for agents in worktrees)
+export BC_WORKSPACE=/path/to/repo
 ```
 
 ### Config File Errors
 
-**Cause**: Invalid JSON in `preferences.json` (workspace config lives at
-`~/.mycel/workspaces/<id>/preferences.json`; `settings.json` is the legacy
-fallback).
+**Cause**: Invalid JSON in `preferences.json` (config lives at
+`~/.mycel/workspaces/<id>/preferences.json`).
 
 **Solution**:
 ```bash
@@ -108,17 +107,17 @@ mycel config reset
 
 **Solutions**:
 ```bash
-# Check for existing session (sessions are prefixed bc-)
-tmux list-sessions | grep bc-
+# Check for existing session (sessions are prefixed mycel-)
+tmux list-sessions | grep mycel-
 
 # Kill stale session
 tmux kill-session -t <session-name>
 
-# Check worktrees
+# Check worktrees (run from the agent's repo)
 git worktree list
 
-# Remove corrupted worktree
-git worktree remove .bc/agents/<name>/worktree --force
+# Remove the corrupted worktree (path from `git worktree list`)
+git worktree remove <worktree-path> --force
 git worktree prune
 
 # Restart the agent
@@ -215,7 +214,7 @@ pgrep -f mycel
 
 ### TUI Won't Start
 
-The TUI opens when you run `mycel` with no arguments inside a workspace.
+The TUI opens when you run `mycel` with no arguments and a server is reachable.
 
 **Causes**:
 1. Node.js or Bun not installed
@@ -264,8 +263,8 @@ NO_COLOR=1 mycel
 # List worktrees
 git worktree list
 
-# Remove stale worktree
-git worktree remove .bc/agents/<name>/worktree --force
+# Remove the stale worktree (path from `git worktree list`)
+git worktree remove <worktree-path> --force
 
 # Prune worktree references
 git worktree prune
@@ -326,15 +325,15 @@ mycel doctor check database
 
 ### Commands Slow
 
-**Cause**: Large workspace or database.
+**Cause**: Large database.
 
 **Solution**:
 ```bash
 # Check database sizes
-du -sh .bc/*.db
+du -sh ~/.mycel/*.db
 
 # Vacuum the database
-sqlite3 .bc/bc.db "VACUUM;"
+sqlite3 ~/.mycel/mycel.db "VACUUM;"
 ```
 
 ### High CPU Usage
@@ -361,12 +360,12 @@ mycel agent stop <name>
 
 **Solution**:
 ```bash
-# Fix .bc directory permissions
-chmod -R u+rw .bc/
+# Fix ~/.mycel directory permissions
+chmod -R u+rw ~/.mycel/
 
 # Check for root-owned files
-ls -la .bc/
-sudo chown -R $USER:$USER .bc/
+ls -la ~/.mycel/
+sudo chown -R $USER:$USER ~/.mycel/
 ```
 
 ### "bcd is not running"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,51 +1,53 @@
 # mycel Documentation
 
-mycel is a CLI-first orchestration system for coordinating teams of AI coding agents across multiple repositories.
+mycel orchestrates teams of AI coding agents across your git repositories. One binary runs the CLI and the server; agents work in isolated sessions with their own git worktrees, and you steer everything from the CLI, the web UI, or the terminal UI.
 
-This documentation is organized following the [Diataxis framework](https://diataxis.fr) into four categories:
+## Start here
 
-## [Tutorials](tutorials/index.md) -- Learning-oriented
+| I want to... | Go to |
+|--------------|-------|
+| Install mycel and bring the server up | [Getting started](tutorials/getting-started.md) |
+| Create and talk to my first agent | [Your first agent](tutorials/first-agent.md) |
+| Route Slack or Telegram messages to agents | [Set up notifications](how-to/set-up-notifications.md) |
+| Understand how the pieces fit together | [Architecture](explanation/architecture.md) |
+| Fix something that broke | [Troubleshoot](how-to/troubleshoot.md) |
 
-Step-by-step guides for getting started with bc.
+## Tutorials — learn by doing
 
-- [Getting Started](tutorials/getting-started.md) -- Install and run your first workspace
-- [Your First Agent](tutorials/first-agent.md) -- Create, monitor, and communicate with an agent
+Step-by-step lessons that take you from zero to a working agent team.
 
-## [How-To Guides](how-to/index.md) -- Task-oriented
+- [Getting started](tutorials/getting-started.md) — install mycel, run `mycel up`, open the dashboard
+- [Your first agent](tutorials/first-agent.md) — create, monitor, and message an agent
 
-Practical guides for accomplishing specific tasks.
+## How-to guides — get things done
 
-- [Configure your workspace](how-to/configure-workspace.md) -- Settings, providers, and runtime backends
-- [Notification Architecture](architecture-notifications.md) -- Notification gateway, platform integrations, and subscriptions
-- [Set Up Notifications](how-to/set-up-notifications.md) -- Connect platforms and subscribe agents
-- [Troubleshoot issues](how-to/troubleshoot.md) -- Common errors and fixes
+Focused recipes for specific tasks.
 
-## [Reference](reference/index.md) -- Information-oriented
+- [Configure mycel](how-to/configure-workspace.md) — preferences, providers, and runtime backends
+- [Set up notifications](how-to/set-up-notifications.md) — connect platforms and subscribe agents
+- [Troubleshoot](how-to/troubleshoot.md) — common errors and their fixes
 
-Technical reference material for APIs, CLI commands, and configuration.
+## Reference — look things up
 
-- [REST API](reference/api-rest.md) -- All HTTP endpoints
-- [Settings API](reference/api-settings.md) -- Configuration endpoints
-- [CLI Reference](reference/cli/mycel.md) -- Auto-generated command documentation
+Exact, verifiable descriptions of every interface.
 
-## [Explanation](explanation/index.md) -- Understanding-oriented
+- [REST API](reference/api-rest.md) — every HTTP endpoint
+- [Settings API](reference/api-settings.md) — configuration shape and endpoints
+- [CLI reference](reference/cli/mycel.md) — every command, auto-generated
 
-Deep dives into architecture, design decisions, and subsystem internals.
+## Explanation — understand the design
 
-- [Architecture](explanation/architecture.md) -- Component diagram, data flow, package dependencies
-- [Design Decisions](explanation/design-decisions.md) -- ADRs for key technical choices
-- [Agents](explanation/agents.md) -- State machine, runtimes, worktrees, roles
-- [MCP Server](explanation/mcp.md) -- Resources, tools, transports, notifications
-- [Database](explanation/database.md) -- Schema, ER diagram, migrations
-- [Web Dashboard](explanation/web-ui.md) -- React SPA architecture
-- [TUI](explanation/tui.md) -- Terminal UI architecture
-- [Design System](explanation/design-system.md) -- Solar Flare palette and tokens
-- [Networking](explanation/networking.md) -- Protocols, SSE, CORS
-- [CI/CD](explanation/ci-cd.md) -- Pipelines and release workflow
-- [Deployment](explanation/deployment.md) -- Docker, networking, volumes
-- [Security](explanation/security.md) -- Threat model, encryption, isolation
+How mycel works under the hood and why it is built this way.
 
-## Other
+- [Architecture](explanation/architecture.md) — the server, clients, and data flow
+- [Agents](explanation/agents.md) — lifecycle, repos, worktrees, and roles
+- [Database](explanation/database.md) — the global store and cost ledger
+- [Notifications](architecture-notifications.md) — gateways, subscriptions, delivery
+- [Web UI](explanation/web-ui.md) · [Terminal UI](explanation/tui.md) · [MCP](explanation/mcp.md)
+- [Networking](explanation/networking.md) · [Security](explanation/security.md) · [Deployment](explanation/deployment.md)
+- [Design decisions](explanation/design-decisions.md) — the reasoning behind key choices
 
-- [Contributing: Testing](contributing/testing.md) -- How to run and write tests
-- [System Overview](overview.md) -- Architecture layers, components, data flow diagrams
+## Contributing
+
+- [Testing guide](contributing/testing.md) — run and write tests
+- [System overview](overview.md) — a condensed tour of components and flows

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,284 +1,189 @@
-# Architecture Overview
+# System Overview
 
-## System Design
+This page gives you a condensed tour of mycel: the components, where state lives, and how the main flows move through the system. For the full treatment, see [Architecture](explanation/architecture.md).
 
-mycel is a CLI-first orchestration system for coordinating teams of AI coding agents. It ships as a single `mycel` binary that contains both the CLI and the server: `mycel up` starts the long-running server, and every other command talks to it over HTTP. The server manages agents across multiple git repositories from a single global installation at `~/.mycel/` (a legacy `~/.bc/` tree is migrated automatically).
+## System design
 
-Key numbers:
-- **44 REST API endpoints** across 14 resource groups
-- **SQLite WAL** database with goose migrations
-- **16 web dashboard views** with Cmd+K command palette
-- **13 TUI views** with k9s-style keyboard navigation
-- **MCP server** with JSON-RPC 2.0 over SSE + stdio transports
-- **7 supported AI providers**: Claude, Gemini, Cursor, Aider, Codex, OpenCode, OpenClaw
-
-### Global Installation
-
-Per-workspace runtime state lives under `~/.mycel/workspaces/<id>/` — the
-canonical config file is `preferences.json` there, alongside `state.db`,
-`agents/`, and `logs/`. mycel also keeps a per-project `.bc/` directory
-inside the workspace root:
-
-```
-project/
-  .bc/
-    settings.json          # Workspace config (providers, runtime, defaults)
-    agents/
-      <name>/
-        .claude/            # Claude config (mounted into containers)
-          CLAUDE.md         # Role prompt
-          settings.json     # Claude Code settings + hooks
-          .mcp.json         # MCP server configs
-        worktree/           # Git worktree checkout
-    roles/                 # Role definitions
-    notifications/         # Notification data
-    prompts/               # Default prompt templates
-```
-
-`mycel up` starts the server and bootstraps the workspace (state directory and workspace registration) automatically — there is no separate init step.
-
-## Architecture Layers
+mycel is a CLI-first orchestration system for teams of AI coding agents. It ships as a single `mycel` binary containing both the CLI and the server: `mycel up` starts the long-running server, and every other command talks to it over HTTP. Agents bind to git repositories — run `mycel up` inside a repo and that repo becomes the anchor; add more repos at any time and place agents on any of them.
 
 ```mermaid
 graph TB
     subgraph Clients
         CLI[mycel CLI<br/>thin HTTP client]
-        WebUI[Web Dashboard<br/>16 views + Cmd+K]
-        TUI[TUI<br/>13 views, k9s-style]
-        AI[AI Agents<br/>Claude, Gemini, etc.]
+        WebUI[Web dashboard]
+        TUI[Terminal UI]
     end
 
     subgraph "mycel server :9374"
-        REST[REST API<br/>44 endpoints]
-        SSE[SSE Hub<br/>real-time events]
-        MCP[MCP Server<br/>JSON-RPC 2.0]
+        REST[REST API<br/>/api/*]
+        SSE[SSE hub<br/>/api/events]
+        MCP[MCP server<br/>JSON-RPC 2.0]
     end
 
-    subgraph Services
-        AgentSvc[Agent Service]
-        NotifySvc[Notify Service]
-        TeamSvc[Team Service]
-        CostSvc[Cost Service]
-        SecretSvc[Secret Service]
-        CronSvc[Cron Service]
-        DaemonSvc[Daemon Manager]
-        EventSvc[Event Log]
-        StatsSvc[Stats Service]
+    subgraph "Agent sessions"
+        A1[agent · tmux<br/>mycel-hash-name]
+        A2[agent · Docker<br/>container]
     end
 
-    subgraph "Runtime Backends"
-        Tmux[Tmux Runtime<br/>local sessions]
-        Docker[Docker Runtime<br/>isolated containers]
+    subgraph "Repos"
+        R1[(repo A)]
+        R2[(repo B)]
     end
 
-    subgraph Storage
-        DB[(.bc/bc.db<br/>SQLite WAL)]
+    subgraph "~/.mycel"
+        DB[(mycel.db<br/>SQLite WAL)]
+        Costs[(costs.db<br/>cost ledger)]
+        Prefs[preferences.json]
     end
 
     CLI -->|HTTP/JSON| REST
     WebUI -->|HTTP + SSE| REST
     TUI -->|HTTP/JSON| REST
-    AI -->|stdio / SSE| MCP
+    A1 & A2 -->|stdio / SSE| MCP
 
-    REST --> AgentSvc & NotifySvc & TeamSvc & CostSvc & SecretSvc & CronSvc & DaemonSvc & EventSvc & StatsSvc
-    MCP --> AgentSvc & NotifySvc & CostSvc
-
-    AgentSvc --> Tmux & Docker
-    DaemonSvc --> Tmux & Docker
-    AgentSvc & NotifySvc & TeamSvc & CostSvc & SecretSvc & CronSvc & DaemonSvc & EventSvc --> DB
-
-    Tmux & Docker --> AI
+    REST --> DB
+    REST --> Costs
+    A1 -->|worktree of| R1
+    A2 -->|worktree of| R2
 ```
+
+Key properties:
+
+- **Single-tenant server** — one instance, flat `/api/<resource>` routes, no per-request scoping.
+- **One state home** — everything lives under `~/.mycel`; your repos stay pristine.
+- **One database** — `~/.mycel/mycel.db` (SQLite WAL) holds every store: agents, roles, events, notifications, cron, and more. `~/.mycel/costs.db` is a separate cost ledger with per-repo attribution.
+- **Repo-bound agents** — each agent carries a `repo` (absolute path) and works in its own git worktree checked out from that repo.
+- **Globally unique agent names** — the name is the database primary key across all repos.
+
+## State on disk
+
+```
+~/.mycel/
+  mycel.db                    # THE database: agents, roles, events, notify, cron, ...
+  costs.db                    # cost ledger (per-repo attribution)
+  daemon.addr                 # server address, written by `mycel up`
+  templates/                  # global agent templates
+  workspaces/<id>/            # per-repo runtime state (id = sha256(repo path)[:12])
+    preferences.json          # the one config file mycel reads
+    agents/<name>/            # agent files + git worktree checkout
+    logs/
+```
+
+`mycel up` bootstraps all of this on first run — there is no separate init step.
 
 ## Components
 
-### mycel CLI (`cmd/mycel/`)
+### CLI (`cmd/mycel`)
 
-Thin HTTP client. All commands are HTTP requests to the daemon -- no direct DB/filesystem access. Opens the TUI if a workspace exists, prompts init if not, shows help in non-interactive mode.
+Thin HTTP client; commands never touch the database or filesystem state directly. The bare `mycel` command opens the TUI when a server is reachable. Clients discover the server via `BC_DAEMON_ADDR`, then `~/.mycel/daemon.addr`, then the `127.0.0.1:9374` default.
 
-### Server (`cmd/mycel/`, `server/`)
+### Server (`server/`)
 
-Long-running HTTP server on `127.0.0.1:9374`, started with `mycel up`. Single process managing all state.
+Long-running HTTP server started by `mycel up` (foreground by default, `-d` for a background daemon).
 
-| Component | Path | Purpose |
-|-----------|------|---------|
-| REST API | `/api/*` | CRUD for all resources (44 endpoints) |
-| SSE Hub | `/api/events` | Real-time event stream |
-| MCP Server | `/mcp/*` | AI agent integration (JSON-RPC 2.0 over SSE + stdio) |
-| Web UI | `/` | Embedded React dashboard (16 views) |
-| Health | `/health`, `/health/ready` | Liveness + readiness probes |
+| Surface | Path | Purpose |
+|---------|------|---------|
+| REST API | `/api/*` | CRUD for all resources |
+| SSE hub | `/api/events` | Real-time event stream |
+| MCP server | `/mcp/*` | Agent integration (JSON-RPC 2.0 over SSE + stdio) |
+| Web UI | `/` | Embedded React dashboard |
+| Health | `/api/health`, `/health/ready` | Liveness + readiness probes |
 
-Middleware chain (outermost first): RateLimit, APIKeyAuth (optional, via `--api-key`/`BC_API_KEY`), RequestID, RequestLogger, Recovery, Gzip, MaxBodySize (1 MB), CORS, WorkspaceScope, Routes.
-
-### Web Dashboard
-
-React SPA with 16 views, embedded in the `mycel` binary via `server/web/dist/`:
-
-- **Dashboard** -- workspace overview with agent/notification/cost summary
-- **Agents** -- list, create, start/stop, send messages, peek output
-- **Agent Detail** -- per-agent terminal output, metrics, sessions
-- **Notifications** -- notification sources, subscriptions, delivery feed
-- **Costs** -- per-agent, per-team, per-model breakdown with daily charts
-- **Cron** -- scheduled jobs with enable/disable, manual trigger, logs
-- **Daemons** -- long-running process management
-- **Doctor** -- health checks and diagnostics
-- **Logs** -- event log with type filtering
-- **MCP** -- external MCP server configuration
-- **Roles** -- role CRUD with prompt editor
-- **Secrets** -- encrypted secret management
-- **Settings** -- workspace configuration editor
-- **Stats** -- system metrics (CPU, memory, disk) and workspace summary
-- **Tools** -- AI tool provider configuration
-
-Features: Cmd+K command palette, dark/light theming, responsive layout, SSE real-time updates, inline terminal output.
-
-### TUI
-
-React Ink terminal UI with 13 views and k9s-style keyboard navigation:
-
-- Dashboard, Agents, Agent Detail, Notifications, Costs, Logs, MCP
-- Processes, Roles, Secrets, Tools, Worktrees, Help
-
-Built with Bun, compiled to CommonJS in `tui/dist/`.
+Middleware chain (outermost first): RateLimit → APIKeyAuth (optional, `--api-key`/`BC_API_KEY`) → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize (1 MB) → CORS → mux.
 
 ### Agents
 
-AI coding assistants running in isolated sessions. Each agent has:
-- A tmux session or Docker container (runtime backend)
-- A git worktree (created and managed by mycel)
-- A role defining its prompt, MCP servers, and secrets
-- An associated workspace (git repo path)
-- Optional team membership for organizational grouping
+AI coding assistants in isolated sessions. Each agent has:
 
-See [explanation/agents.md](explanation/agents.md) for lifecycle, state machine, and runtime details.
+- a **repo** — the absolute path of the git repository it works on
+- a **git worktree** — created and managed by mycel under `~/.mycel/workspaces/<id>/agents/<name>/`
+- a **runtime** — a tmux session (`mycel-<hash>-<name>`) or a Docker container
+- a **role and template** — prompt, MCP servers, and secrets
+- a **provider** — claude, codex, gemini, cursor, or pi
 
-### Teams
+You control the lifecycle from the agent header in the web UI (Start / Stop / Restart) or with `mycel agent start|stop`. See [Agents](explanation/agents.md).
 
-Hierarchical organizational groups for visualizing agents. Decoupled from agent lifecycle:
+### Repos
 
-```mermaid
-graph TD
-    Root[root-team<br/>workspace: ~/repos/main] --> Backend[backend-team<br/>workspace: ~/repos/api]
-    Root --> Frontend[frontend-team<br/>workspace: ~/repos/web]
-    Backend --> E1[eng-01]
-    Backend --> E2[eng-02]
-    Frontend --> E3[eng-03]
-    E5[devops-01<br/>workspace: ~/repos/infra] -.->|member of| Root
-    E5 -.->|member of| Backend
-```
-
-- Teams are **views**, not ownership -- agents exist independently
-- Agents can appear in **multiple teams** (many-to-many via `team_members`)
-- Teams form a tree via `parent_id`
-- Teams can have a default workspace; agents inherit it but can override
-- Deleting a team does NOT delete its agents
+The server tracks the repos agents are bound to. `GET /api/repos` lists them; the web UI adds repos via a folder picker, local filesystem discovery, or GitHub clone (`/api/repos/discover/*`, `/api/repos/clone`).
 
 ### Notifications
 
-Inbound-only gateway that bridges external platforms (Slack, Telegram, GitHub, and others) to agents:
-- Gateway adapters connect via socket, webhook, or polling patterns
-- Agents subscribe to notification sources (`platform:channel`)
-- Mention-only filtering for noisy channels
-- Delivery via `tmux send-keys` with JSON payload
-- Delivery logging with retry for failed dispatches
-- Self-skip filtering prevents agents from receiving their own echoed messages
+Inbound-only gateway bridging external platforms (Slack, Telegram, Discord, webhooks) to agents. Agents subscribe to sources (`platform:channel`); deliveries are injected into the agent session with mention filtering, self-skip, and delivery logging. See [Notification architecture](architecture-notifications.md).
 
 ### Secrets
 
-AES-256-GCM encrypted secret store. Referenced in agent env vars as `${secret:NAME}`, resolved at runtime. Key derived via PBKDF2-SHA256 (600k iterations).
+AES-256-GCM encrypted store. Reference secrets in agent env vars as `${secret:NAME}`; mycel resolves them at runtime.
 
-### Cost Tracking
+### Costs
 
-Automatic import from Claude Code JSONL session files every 5 minutes. Per-agent, per-team, per-model breakdown with budget enforcement.
+Automatic import from Claude Code JSONL session logs, recorded in the global ledger with per-repo and per-agent attribution. Budgets enforce spending limits; `GET /api/global/costs` rolls costs up per repo.
 
-### Daemons
+### Cron, stats, and tools
 
-Long-running processes managed by the mycel server. Support tmux and Docker runtimes with restart policies. Used for workspace infrastructure (databases, services, etc.).
+Scheduled commands with execution history (`/api/cron`), system and per-agent metrics (`/api/stats/*`, `/api/system/*`), and a registry of MCP servers and CLI tools agents can use (`/api/mcp`, `/api/tools`).
 
-### Cron
+## Data flow
 
-Scheduled bash commands that run on a timer. Supports enable/disable, manual trigger, and execution log history.
-
-### Stats
-
-System-level metrics (CPU, memory, disk, uptime, goroutines) and workspace summary (agent counts, notification source counts, cost totals, role/tool counts).
-
-## Data Flow
-
-### Agent Creation
+### Agent creation
 
 ```mermaid
 sequenceDiagram
-    participant CLI as mycel CLI
+    participant C as Client (CLI / web UI)
     participant API as mycel API
-    participant Svc as Agent Service
+    participant Svc as Agent service
     participant RT as Runtime
-    participant DB as SQLite
+    participant DB as mycel.db
 
-    CLI->>API: POST /api/agents
-    API->>Svc: Create(name, role, workspace, team)
-    Svc->>DB: INSERT INTO agents
-    Svc->>RT: git worktree add
-    Svc->>RT: Write role files (CLAUDE.md, .mcp.json)
-    Svc->>RT: Create tmux session / Docker container
-    Svc->>RT: cd worktree && provider-command
-    RT-->>Svc: Session alive
-    Svc->>DB: state = idle
-    Svc-->>CLI: 201 Created
+    C->>API: POST /api/agents {name, repo, ...}
+    API->>Svc: Create
+    Svc->>DB: INSERT agent (repo = absolute path)
+    Svc->>RT: git worktree add (from the agent's repo)
+    Svc->>RT: write role files (CLAUDE.md, .mcp.json)
+    Svc->>RT: create tmux session / Docker container
+    RT-->>Svc: session alive
+    Svc-->>C: 201 Created
 ```
 
-### Notification Delivery
+### Notification delivery
 
 ```mermaid
 sequenceDiagram
-    participant Platform as External Platform
-    participant Adapter as Gateway Adapter
-    participant Notify as notify.Service
-    participant DB as SQLite
-    participant Hub as SSE Hub
-    participant Agent as Subscribed Agent
+    participant P as External platform
+    participant G as Gateway adapter
+    participant N as Notify service
+    participant DB as mycel.db
+    participant A as Subscribed agent
 
-    Platform->>Adapter: Inbound event
-    Adapter->>Notify: Dispatch(channel, sender, content)
-    Notify->>DB: Save to notification_log
-    Notify->>DB: Query subscribers
-    loop Each subscriber (with self-skip + mention filter)
-        Notify->>Agent: tmux send-keys (JSON payload)
-        Notify->>DB: Log delivery status
+    P->>G: inbound event
+    G->>N: Dispatch(channel, sender, content)
+    N->>DB: log notification, query subscribers
+    loop each subscriber (mention filter + self-skip)
+        N->>A: inject into session (JSON payload)
+        N->>DB: log delivery status
     end
-    Notify->>Hub: Publish gateway.message SSE event
+    N-->>P: SSE event published for the web UI
 ```
 
-### Agent State via Hooks
+### Agent state via hooks
 
-```mermaid
-sequenceDiagram
-    participant Claude as Claude Code
-    participant API as mycel API
-    participant DB as SQLite
-    participant Hub as SSE Hub
+Provider hooks report tool activity to the API; the server updates agent state in `mycel.db` and broadcasts `agent.state_changed` over SSE, which keeps the web UI and TUI live without polling.
 
-    Claude->>API: POST /api/agents/{name}/hook (tool_use_start)
-    API->>DB: state = working
-    API->>Hub: agent.state_changed
-    Claude->>API: POST /api/agents/{name}/hook (tool_use_end)
-    API->>DB: state = idle
-    API->>Hub: agent.state_changed
-```
-
-## Key Design Decisions
+## Key design decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Per-project `.bc/` | Per-project directory | Each workspace has its own `.bc/` directory for config, agents, and state |
-| Single binary, CLI + server | `mycel up` runs the server | CLI stays fast; the server process holds state and connections |
-| SQLite WAL | Single database file | Zero-config, local-first, WAL for concurrent reads |
-| Embedded web UI | Single binary | No separate web server; version-locked to API |
-| SSE not WebSocket | Server-sent events | Simpler protocol, sufficient for one-way server push |
-| Teams as views | Decoupled, many-to-many | No lifecycle coupling; pure organization |
-| bc owns worktrees | All providers, uniform | Avoids nesting; consistent across Claude/Gemini/etc. |
-| tmux send-keys | Only delivery mechanism | Hooks are one-way; no other way into agent session |
-| Auth optional | Localhost by default | Local dev tool; optional Bearer auth via `--api-key`/`BC_API_KEY` for anything beyond loopback |
-| MCP curated tools | Subset of API | Agents get key operations, not full admin |
-| INTEGER timestamps | Unix millis | Faster range queries, smaller storage than TEXT ISO8601 |
-| goose migrations | Versioned schema | Proper versioning, rollback support |
+| One state home | Everything under `~/.mycel` | Repos stay pristine; state survives repo moves and clones |
+| Single binary | `mycel up` runs the server | CLI stays fast; one process holds state and connections |
+| Single-tenant server | Flat routes, no request scoping | One server per machine is simpler to reason about and secure |
+| One global database | `mycel.db`, SQLite WAL | Zero-config, local-first, concurrent reads |
+| Separate cost ledger | `costs.db` with repo attribution | Cost history outlives agents and repos |
+| Repo-bound agents | `repo` field, globally unique names | An agent's identity and its checkout are unambiguous |
+| mycel owns worktrees | All providers, uniform | Avoids nesting; consistent across providers |
+| Embedded web UI | Served from the binary | No separate web server; version-locked to the API |
+| SSE, not WebSocket | Server-sent events | Simpler protocol; one-way server push is all that's needed |
+| Session injection delivery | Runtime send-keys | Hooks are one-way; the session is the only way in |
+| Auth optional | Localhost by default | Local-first tool; Bearer auth for anything beyond loopback |
+| MCP curated tools | Subset of the API | Agents get key operations, not full admin |
+
+See [Design decisions](explanation/design-decisions.md) for the full reasoning.

--- a/docs/reference/api-settings.md
+++ b/docs/reference/api-settings.md
@@ -1,6 +1,6 @@
 # Settings API
 
-The Settings API reads and updates the workspace configuration via the bcd HTTP server. The configuration is a JSON document persisted to `preferences.json` in the workspace state directory (`~/.mycel/workspaces/<id>/`).
+The Settings API reads and updates mycel configuration via the bcd HTTP server. The configuration is a JSON document persisted to `preferences.json` in the per-repo runtime state directory (`~/.mycel/workspaces/<id>/`).
 
 Base URL: `http://localhost:9374`
 
@@ -8,7 +8,7 @@ Base URL: `http://localhost:9374`
 
 ### GET /api/settings
 
-Returns the full workspace configuration.
+Returns the full configuration.
 
 **Response:** `200 OK`
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -11,4 +11,4 @@ Auto-generated command documentation. See [cli/mycel.md](cli/mycel.md) for the f
 | Document | Description |
 |----------|-------------|
 | [REST API](api-rest.md) | All HTTP endpoints with parameters, request bodies, and response schemas |
-| [Settings API](api-settings.md) | Endpoints for reading and updating workspace configuration |
+| [Settings API](api-settings.md) | Endpoints for reading and updating mycel configuration |

--- a/docs/tutorials/first-agent.md
+++ b/docs/tutorials/first-agent.md
@@ -4,7 +4,7 @@ This tutorial walks you through creating, running, and communicating with your f
 
 ## Prerequisites
 
-- The mycel server running (`mycel up -d` from your repo — this bootstraps the workspace)
+- The mycel server running (`mycel up -d` from your repo)
 - An AI provider configured (e.g., Claude Code or Gemini)
 
 ## Step 1: Create an agent
@@ -12,12 +12,12 @@ This tutorial walks you through creating, running, and communicating with your f
 Create an engineer agent named `eng-01`:
 
 ```bash
-mycel agent create eng-01 --role engineer
+mycel agent create eng-01 --template engineer
 ```
 
 This creates:
-- A git worktree at `.bc/agents/eng-01/worktree/`
-- A tmux session (or Docker container) for the agent
+- A git worktree under `~/.mycel/`, checked out from the agent's repo
+- A Docker container (or tmux session) for the agent
 - Role-specific configuration files (CLAUDE.md, .mcp.json)
 
 ## Step 2: Verify the agent is running
@@ -100,7 +100,7 @@ mycel agent delete eng-01
 
 ## Next steps
 
-- Learn how to [configure your workspace](../how-to/configure-workspace.md) with providers, runtime backends, and polling settings
+- Learn how to [configure mycel](../how-to/configure-workspace.md) with providers, runtime backends, and polling settings
 - Set up [notifications from external platforms](../how-to/set-up-notifications.md)
 - Read about the [agent lifecycle and state machine](../explanation/agents.md)
 - Browse the [CLI reference](../reference/cli/mycel.md)

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -43,7 +43,7 @@ make install  # Installs to $GOPATH/bin
 mycel version
 ```
 
-## Your First Workspace
+## Your First Agent
 
 ### Step 1: Start the Server
 
@@ -55,25 +55,25 @@ mycel up -d
 ```
 
 This starts the mycel server (API, web UI, MCP, agent management) as a
-background daemon on `127.0.0.1:9374` and bootstraps the workspace
-automatically — there is no separate init step. Run `mycel up` without `-d`
-to keep it in the foreground instead. Running `mycel up` outside a git repo
-starts the server without a workspace; add repos from the web UI.
+background daemon on `127.0.0.1:9374` — there is no separate init step.
+Run `mycel up` without `-d` to keep it in the foreground instead. Running
+`mycel up` inside a git repo makes that repo immediately available for
+agents; add more repos at any time from the web UI.
 
-Workspace configuration lives outside your project directory, at
-`~/.mycel/workspaces/<id>/`:
+All state lives outside your repos, under `~/.mycel/`:
 
-- `preferences.json` — workspace configuration
-- `roles/` — agent role definitions
-- `agents/` — per-agent state files
+- `mycel.db` — the single global database (agents, roles, events,
+  notifications, cron)
+- `costs.db` — cost ledger with per-repo attribution
+- per-agent directories holding each agent's files and git worktree
 
-Agent working copies (git worktrees) are created inside your project under
-`.bc/agents/<name>/`.
+Each agent is bound to a repo and works in its own git worktree checked
+out from that repo — your working copy stays pristine.
 
 ### Step 2: Create an Engineer
 
 ```bash
-mycel agent create eng-01 --role engineer
+mycel agent create eng-01 --template engineer
 ```
 
 ### Step 3: Check Status
@@ -147,14 +147,14 @@ Valid states are `idle`, `working`, `done`, `stuck`, and `error`.
 
 ```bash
 mycel cost show           # Recent cost records
-mycel cost summary        # Workspace cost overview
+mycel cost summary        # Cost overview across agents and repos
 mycel cost dashboard      # Rich cost dashboard
 ```
 
 ## Next Steps
 
 - Learn about the [Architecture](../overview.md) to understand the system
-- Configure [Settings](../how-to/configure-workspace.md) for your workspace
+- [Configure mycel](../how-to/configure-workspace.md) — providers, runtimes, budgets
 - Set up [Notifications](../how-to/set-up-notifications.md) for platform event routing
 - Explore the [REST API](../reference/api-rest.md) for programmatic access
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,8 +1,8 @@
 # Tutorials
 
-Learning-oriented guides that walk you through bc from scratch.
+Learning-oriented guides that walk you through mycel from scratch.
 
 | Tutorial | Description |
 |----------|-------------|
-| [Getting Started](getting-started.md) | Install bc, initialize a workspace, and run your first agent in 5 minutes |
+| [Getting Started](getting-started.md) | Install mycel, start the server, and run your first agent in 5 minutes |
 | [Your First Agent](first-agent.md) | Create, monitor, and communicate with an AI agent step by step |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,7 +76,7 @@ nav:
     - Your first agent: tutorials/first-agent.md
   - How To:
     - how-to/index.md
-    - Configure workspace: how-to/configure-workspace.md
+    - Configure mycel: how-to/configure-workspace.md
     - Set up notifications: how-to/set-up-notifications.md
     - Troubleshoot: how-to/troubleshoot.md
   - Explanation:


### PR DESCRIPTION
## What

Docs-wide accuracy + editorial pass completing the workspace-removal epic's documentation phase. Every claim was verified against source before editing.

- **Tutorials/how-to**: no more `mycel init` or workspace bootstrap framing; correct state layout (`~/.mycel/mycel.db`, per-agent dirs, worktrees from the agent's own repo); `--template` as the documented create path; `mycel notify activity` (the `history` subcommand never existed); troubleshoot targets `~/.mycel/*.db` and the `mycel-` session prefix.
- **Explanation**: database.md rewritten around `db.Global()` and the single global DB; ADR-5 corrected from file-polling hooks to the real HTTP hook pipeline; security.md points at `~/.mycel/secrets.vault` + `bc-net`; web-ui.md drops `WorkspaceProvider`/`RalphLoopModal` (deleted components) and documents the Repo field + group-by-repo; networking.md fixes `/_mcp/*` endpoints; agents.md lists the 5 actual providers.
- **Build health**: fixes the 4 links that failed `mkdocs build --strict`; strict build now passes with 0 warnings.

Generated `docs/reference/cli/` untouched.

## Follow-ups noticed, not in scope
- `--tool` flag help still advertises 8 tools while the registry has 5 (source-side; flows into generated CLI docs).
- design-system.md §10 describes a not-yet-implemented component library; reframed as a spec rather than cut.

Part of #3276

🤖 Generated with [Claude Code](https://claude.com/claude-code)