### PR TITLE
fix(api): implement GET /api/stats/channels for the Metrics notification panel

### DIFF
--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -233,6 +233,12 @@ func (s *Service) ChannelMessages(ctx context.Context, channel string, limit int
 	return s.store.GetMessages(ctx, channel, limit, before)
 }
 
+// ChannelStats returns aggregated per-channel activity stats (message
+// counts, member counts, last activity, top senders).
+func (s *Service) ChannelStats(ctx context.Context) ([]ChannelStat, error) {
+	return s.store.ChannelStats(ctx)
+}
+
 // PruneOldActivity removes old delivery log entries for every channel,
 // keeping the most recent keepPerChannel entries in each.
 func (s *Service) PruneOldActivity(ctx context.Context, keepPerChannel int) error {

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -324,6 +325,119 @@ func (s *Store) TotalMessageCount(ctx context.Context) (int, error) {
 	var count int
 	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM notify_messages`).Scan(&count)
 	return count, err
+}
+
+// TopSender is a sender ranked by message count within a channel.
+type TopSender struct {
+	Sender string `json:"sender"`
+	Count  int    `json:"count"`
+}
+
+// ChannelStat aggregates per-channel notification activity for the
+// /api/stats/channels endpoint: message volume, subscriber count, last
+// activity, and the most active senders.
+type ChannelStat struct {
+	LastActivity time.Time   `json:"last_activity"`
+	Name         string      `json:"name"`
+	TopSenders   []TopSender `json:"top_senders"`
+	MessageCount int         `json:"message_count"`
+	MemberCount  int         `json:"member_count"`
+}
+
+// channelStatsTopSenders caps the per-channel top_senders list.
+const channelStatsTopSenders = 5
+
+// ChannelStats returns aggregated per-channel activity: message counts and
+// last activity from notify_messages, subscriber counts from
+// notify_subscriptions, and the top senders per channel. Channels with
+// subscriptions but no messages are included with a zero message count.
+// Results are sorted by message count (descending), then by name.
+func (s *Store) ChannelStats(ctx context.Context) ([]ChannelStat, error) {
+	byName := make(map[string]*ChannelStat)
+	get := func(name string) *ChannelStat {
+		cs, ok := byName[name]
+		if !ok {
+			cs = &ChannelStat{Name: name}
+			byName[name] = cs
+		}
+		return cs
+	}
+
+	// Message counts + last activity per channel.
+	msgRows, err := s.db.QueryContext(ctx,
+		`SELECT channel, COUNT(*), MAX(created_at) FROM notify_messages GROUP BY channel`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = msgRows.Close() }()
+	for msgRows.Next() {
+		var name, last string
+		var count int
+		if err = msgRows.Scan(&name, &count, &last); err != nil {
+			return nil, err
+		}
+		cs := get(name)
+		cs.MessageCount = count
+		cs.LastActivity, _ = time.Parse(time.RFC3339, last) //nolint:errcheck // DB-written timestamp
+	}
+	if err = msgRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Subscriber counts per channel.
+	subRows, err := s.db.QueryContext(ctx,
+		`SELECT channel, COUNT(*) FROM notify_subscriptions GROUP BY channel`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = subRows.Close() }()
+	for subRows.Next() {
+		var name string
+		var count int
+		if err = subRows.Scan(&name, &count); err != nil {
+			return nil, err
+		}
+		get(name).MemberCount = count
+	}
+	if err = subRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Top senders per channel: rows arrive ordered by count, so the first
+	// channelStatsTopSenders rows per channel are its top senders.
+	senderRows, err := s.db.QueryContext(ctx,
+		`SELECT channel, sender, COUNT(*) AS c FROM notify_messages
+		 GROUP BY channel, sender ORDER BY c DESC, sender ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = senderRows.Close() }()
+	for senderRows.Next() {
+		var name, sender string
+		var count int
+		if err = senderRows.Scan(&name, &sender, &count); err != nil {
+			return nil, err
+		}
+		cs := get(name)
+		if len(cs.TopSenders) < channelStatsTopSenders {
+			cs.TopSenders = append(cs.TopSenders, TopSender{Sender: sender, Count: count})
+		}
+	}
+	if err = senderRows.Err(); err != nil {
+		return nil, err
+	}
+
+	out := make([]ChannelStat, 0, len(byName))
+	for _, cs := range byName {
+		out = append(out, *cs)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].MessageCount != out[j].MessageCount {
+			return out[i].MessageCount > out[j].MessageCount
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
 }
 
 // MessageRecord is a stored inbound gateway message for the activity feed.

--- a/pkg/notify/store_test.go
+++ b/pkg/notify/store_test.go
@@ -70,3 +70,129 @@ func TestSaveChannel_FillsEmptyPlatformID(t *testing.T) {
 		t.Fatalf("platform_id not filled: got %q, want %q", got, "C0123ABC")
 	}
 }
+
+// TestChannelStats exercises the /api/stats/channels aggregation: message
+// counts, member counts, top senders, ordering, and the subscription-only
+// channel case.
+func TestChannelStats(t *testing.T) {
+	type msg struct{ channel, sender string }
+	type sub struct{ channel, agent string }
+
+	tests := []struct {
+		name string
+		msgs []msg
+		subs []sub
+		want []ChannelStat
+	}{
+		{
+			name: "empty store",
+			want: []ChannelStat{},
+		},
+		{
+			name: "messages only, sorted by count desc then name",
+			msgs: []msg{
+				{"slack:eng", "alice"},
+				{"slack:eng", "alice"},
+				{"slack:eng", "bob"},
+				{"telegram:ops", "carol"},
+			},
+			want: []ChannelStat{
+				{
+					Name:         "slack:eng",
+					MessageCount: 3,
+					TopSenders:   []TopSender{{Sender: "alice", Count: 2}, {Sender: "bob", Count: 1}},
+				},
+				{
+					Name:         "telegram:ops",
+					MessageCount: 1,
+					TopSenders:   []TopSender{{Sender: "carol", Count: 1}},
+				},
+			},
+		},
+		{
+			name: "subscription-only channel appears with zero messages",
+			msgs: []msg{{"slack:eng", "alice"}},
+			subs: []sub{
+				{"slack:eng", "eng-01"},
+				{"slack:eng", "eng-02"},
+				{"discord:quiet", "ops-01"},
+			},
+			want: []ChannelStat{
+				{
+					Name:         "slack:eng",
+					MessageCount: 1,
+					MemberCount:  2,
+					TopSenders:   []TopSender{{Sender: "alice", Count: 1}},
+				},
+				{
+					Name:        "discord:quiet",
+					MemberCount: 1,
+				},
+			},
+		},
+		{
+			name: "top senders capped at five",
+			msgs: []msg{
+				{"slack:eng", "s1"}, {"slack:eng", "s1"}, {"slack:eng", "s1"},
+				{"slack:eng", "s2"}, {"slack:eng", "s2"},
+				{"slack:eng", "s3"}, {"slack:eng", "s4"},
+				{"slack:eng", "s5"}, {"slack:eng", "s6"},
+			},
+			want: []ChannelStat{
+				{
+					Name:         "slack:eng",
+					MessageCount: 9,
+					TopSenders: []TopSender{
+						{Sender: "s1", Count: 3}, {Sender: "s2", Count: 2},
+						{Sender: "s3", Count: 1}, {Sender: "s4", Count: 1},
+						{Sender: "s5", Count: 1},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := setupTestStore(t)
+			ctx := context.Background()
+			for _, m := range tt.msgs {
+				if err := store.SaveMessage(ctx, m.channel, m.sender, "hi"); err != nil {
+					t.Fatalf("SaveMessage: %v", err)
+				}
+			}
+			for _, s := range tt.subs {
+				if err := store.Subscribe(ctx, s.channel, s.agent, false); err != nil {
+					t.Fatalf("Subscribe: %v", err)
+				}
+			}
+
+			got, err := store.ChannelStats(ctx)
+			if err != nil {
+				t.Fatalf("ChannelStats: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d channels, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i, w := range tt.want {
+				g := got[i]
+				if g.Name != w.Name || g.MessageCount != w.MessageCount || g.MemberCount != w.MemberCount {
+					t.Errorf("channel[%d] = {%s %d msgs %d members}, want {%s %d msgs %d members}",
+						i, g.Name, g.MessageCount, g.MemberCount, w.Name, w.MessageCount, w.MemberCount)
+				}
+				if len(g.TopSenders) != len(w.TopSenders) {
+					t.Errorf("channel[%d] top_senders = %+v, want %+v", i, g.TopSenders, w.TopSenders)
+					continue
+				}
+				for j, ws := range w.TopSenders {
+					if g.TopSenders[j] != ws {
+						t.Errorf("channel[%d] top_senders[%d] = %+v, want %+v", i, j, g.TopSenders[j], ws)
+					}
+				}
+				if g.MessageCount > 0 && g.LastActivity.IsZero() {
+					t.Errorf("channel[%d] %s: last_activity is zero despite %d messages", i, g.Name, g.MessageCount)
+				}
+			}
+		})
+	}
+}

--- a/server/handlers/stats.go
+++ b/server/handlers/stats.go
@@ -69,6 +69,7 @@ func (h *StatsHandler) Register(mux *http.ServeMux) {
 	// Legacy summary endpoints
 	mux.HandleFunc("/api/stats/system", h.system)
 	mux.HandleFunc("/api/stats/summary", h.summary)
+	mux.HandleFunc("/api/stats/channels", h.statsChannels)
 
 	// System info endpoint
 	mux.HandleFunc("/api/system/info", h.systemInfo)

--- a/server/handlers/stats_channels.go
+++ b/server/handlers/stats_channels.go
@@ -3,8 +3,32 @@ package handlers
 import (
 	"net/http"
 
+	"github.com/rpuneet/mycel/pkg/notify"
 	"github.com/rpuneet/mycel/pkg/stats"
 )
+
+// statsChannels serves GET /api/stats/channels — per-channel notification
+// activity (message counts, member counts, last activity, top senders)
+// aggregated from the notify store. Powers the Metrics page notification
+// panel in the web UI.
+func (h *StatsHandler) statsChannels(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.notifySvc == nil {
+		writeJSON(w, http.StatusOK, []notify.ChannelStat{})
+		return
+	}
+	channelStats, err := h.notifySvc.ChannelStats(r.Context())
+	if err != nil {
+		httpInternalError(w, "channel stats", err)
+		return
+	}
+	if channelStats == nil {
+		channelStats = []notify.ChannelStat{}
+	}
+	writeJSON(w, http.StatusOK, channelStats)
+}
 
 // RegisterChannelStats mounts channel stats routes on the mux.
 func (h *StatsHandler) RegisterChannelStats(mux *http.ServeMux) {

--- a/server/handlers/stats_channels_test.go
+++ b/server/handlers/stats_channels_test.go
@@ -1,0 +1,144 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/db"
+	"github.com/rpuneet/mycel/pkg/notify"
+)
+
+// newTestNotifyService opens an in-memory notify store wrapped in a Service.
+func newTestNotifyService(t *testing.T) *notify.Service {
+	t.Helper()
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	store, err := notify.OpenStore(d, "sqlite")
+	if err != nil {
+		t.Fatalf("open notify store: %v", err)
+	}
+	return notify.NewService(store, nil, nil)
+}
+
+// TestStatsChannels exercises GET /api/stats/channels: method guard,
+// nil-service fallback, empty store, and aggregation of seeded messages
+// and subscriptions.
+func TestStatsChannels(t *testing.T) {
+	type seedMsg struct{ channel, sender string }
+	type seedSub struct{ channel, agent string }
+
+	tests := []struct {
+		name       string
+		method     string
+		msgs       []seedMsg
+		subs       []seedSub
+		want       []notify.ChannelStat
+		wantStatus int
+		nilService bool
+	}{
+		{
+			name:       "method not allowed",
+			method:     http.MethodPost,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "nil notify service returns empty array",
+			method:     http.MethodGet,
+			nilService: true,
+			wantStatus: http.StatusOK,
+			want:       []notify.ChannelStat{},
+		},
+		{
+			name:       "empty store returns empty array",
+			method:     http.MethodGet,
+			wantStatus: http.StatusOK,
+			want:       []notify.ChannelStat{},
+		},
+		{
+			name:   "aggregates messages and subscriptions",
+			method: http.MethodGet,
+			msgs: []seedMsg{
+				{"slack:eng", "alice"},
+				{"slack:eng", "bob"},
+				{"telegram:ops", "carol"},
+			},
+			subs:       []seedSub{{"slack:eng", "eng-01"}},
+			wantStatus: http.StatusOK,
+			want: []notify.ChannelStat{
+				{
+					Name:         "slack:eng",
+					MessageCount: 2,
+					MemberCount:  1,
+					TopSenders:   []notify.TopSender{{Sender: "alice", Count: 1}, {Sender: "bob", Count: 1}},
+				},
+				{
+					Name:         "telegram:ops",
+					MessageCount: 1,
+					TopSenders:   []notify.TopSender{{Sender: "carol", Count: 1}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &StatsHandler{}
+			if !tt.nilService {
+				svc := newTestNotifyService(t)
+				ctx := context.Background()
+				for _, m := range tt.msgs {
+					if err := svc.Store().SaveMessage(ctx, m.channel, m.sender, "hi"); err != nil {
+						t.Fatalf("SaveMessage: %v", err)
+					}
+				}
+				for _, s := range tt.subs {
+					if err := svc.Subscribe(ctx, s.channel, s.agent, false); err != nil {
+						t.Fatalf("Subscribe: %v", err)
+					}
+				}
+				h.SetNotify(svc)
+			}
+
+			req := httptest.NewRequest(tt.method, "/api/stats/channels", nil)
+			rr := httptest.NewRecorder()
+			h.statsChannels(rr, req)
+
+			if rr.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d (body: %s)", rr.Code, tt.wantStatus, rr.Body.String())
+			}
+			if tt.wantStatus != http.StatusOK {
+				return
+			}
+
+			var got []notify.ChannelStat
+			if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+				t.Fatalf("unmarshal response: %v (body: %s)", err, rr.Body.String())
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d channels, want %d: %+v", len(got), len(tt.want), got)
+			}
+			for i, w := range tt.want {
+				g := got[i]
+				if g.Name != w.Name || g.MessageCount != w.MessageCount || g.MemberCount != w.MemberCount {
+					t.Errorf("channel[%d] = {%s %d msgs %d members}, want {%s %d msgs %d members}",
+						i, g.Name, g.MessageCount, g.MemberCount, w.Name, w.MessageCount, w.MemberCount)
+				}
+				if len(g.TopSenders) != len(w.TopSenders) {
+					t.Errorf("channel[%d] top_senders = %+v, want %+v", i, g.TopSenders, w.TopSenders)
+					continue
+				}
+				for j, ws := range w.TopSenders {
+					if g.TopSenders[j] != ws {
+						t.Errorf("channel[%d] top_senders[%d] = %+v, want %+v", i, j, g.TopSenders[j], ws)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The web UI (`web/src/api/client.ts` `getStatsChannels`, rendered by the Stats page "Notification Activity (Top 10)" panel) calls `GET /api/stats/channels`, but no such route existed server-side — so the panel silently showed "No notification data" forever. The SPA-fallback half of the issue (unknown `/api/*` returning index.html with 200) was already fixed; this PR closes the remaining gap by implementing the endpoint against real `pkg/notify` data rather than deleting the panel, since the backing data (notify_messages, notify_subscriptions) and the UI rendering genuinely exist.

Closes #3257

## Changes

- **pkg/notify**: new `Store.ChannelStats(ctx)` aggregating per channel:
  - message count + last activity from `notify_messages`
  - member count from `notify_subscriptions` (subscription-only channels included with zero messages)
  - top senders (capped at 5) per channel
  - sorted by message count desc, then name
  plus a `Service.ChannelStats` wrapper following the existing service delegation pattern.
- **server/handlers**: `statsChannels` handler in `stats_channels.go`, registered in `StatsHandler.Register` next to `/api/stats/system` and `/api/stats/summary`. Returns `[]` when the notify service is unavailable. Response matches the client's `ChannelStats[]` shape exactly (`name`, `message_count`, `member_count`, `last_activity`, `top_senders: [{sender, count}]`).

No web changes needed — the client and panel already exist with the correct shape.

## Tests

- `pkg/notify`: table-driven `TestChannelStats` (empty store, ordering, subscription-only channels, top-sender cap).
- `server/handlers`: table-driven `TestStatsChannels` (method guard, nil notify service, empty store, seeded aggregation via httptest).
- Quality gate: `gofmt -s -l` clean, `go vet` clean, `golangci-lint run` 0 issues, `go test -race ./pkg/notify/ ./server/handlers/` pass, `go build ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel-level activity statistics, including message counts, member counts, last activity, and top senders.
  * Introduced a new API endpoint to view aggregated channel stats.
* **Bug Fixes**
  * Channels with subscribers but no messages now appear in stats.
  * Empty results are returned consistently as an empty list.
* **Tests**
  * Added coverage for stats aggregation and the new endpoint, including method handling and result ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->