### PR TITLE
fix(container): mount the agent's repo at /workspace, not the boot repo

### DIFF
--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3652,3 +3652,132 @@ func TestWorktreeManagerFor_CreatesWorktreeFromAgentRepo(t *testing.T) {
 		t.Errorf("worktree dir %q not under state dir %q", wtDir, stateDir)
 	}
 }
+
+// --- Docker runtime: the agent's repo reaches the container backend ---
+
+// newDockerMockManager builds a Manager whose default runtime is a mock
+// docker backend, so tests can inspect the dir/env handed to
+// CreateSessionWithEnv without a real Docker daemon.
+func newDockerMockManager(t *testing.T, boot string) (*Manager, *mockBackend) {
+	t.Helper()
+	stateDir := filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(stateDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	store, err := NewSQLiteStore(filepath.Join(stateDir, "state.db"))
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	docker := newMockBackend("docker")
+	m := &Manager{
+		agents:         make(map[string]*Agent),
+		backends:       map[string]runtime.Backend{"docker": docker},
+		defaultBackend: "docker",
+		stateDir:       stateDir,
+		store:          store,
+		agentCmd:       "/bin/true",
+		workspacePath:  boot,
+		worktreeMgr:    worktree.NewManagerWithDataDir(boot, stateDir),
+	}
+	return m, docker
+}
+
+// addMarkerCommit commits a marker file so a repo is distinguishable
+// from the boot repo in worktree checkouts.
+func addMarkerCommit(t *testing.T, repo, marker string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := os.WriteFile(filepath.Join(repo, marker), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", repo, "add", marker},
+		{"git", "-C", repo, "commit", "-m", "marker"},
+	} {
+		//nolint:gosec // test helper
+		if out, err := exec.CommandContext(ctx, args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("git (%v): %s: %v", args, out, err)
+		}
+	}
+}
+
+// TestCreateAgent_DockerBackendReceivesAgentRepo verifies the values the
+// container backend uses to build the /workspace mount and workdir: the
+// session dir must be a worktree checked out from the AGENT's repo, and
+// env BC_WORKSPACE must carry that repo — never the boot repo
+// (regression: docker containers used to always mount the boot repo).
+// A boot-repo agent keeps the boot values unchanged.
+func TestCreateAgent_DockerBackendReceivesAgentRepo(t *testing.T) {
+	ctx := context.Background()
+	boot := t.TempDir()
+	other := t.TempDir()
+	initGitRepo(t, boot)
+	initGitRepo(t, other)
+	addMarkerCommit(t, other, "OTHER_REPO_MARKER")
+
+	tests := []struct {
+		name       string
+		agentName  string
+		repo       string // SpawnOptions.Workspace
+		wantRepo   string // expected Agent.Repo and env BC_WORKSPACE
+		wantMarker bool   // worktree checked out from `other`
+	}{
+		{
+			name:      "boot repo agent unchanged",
+			agentName: "boot-eng",
+			repo:      boot,
+			wantRepo:  boot,
+		},
+		{
+			name:       "cross-repo agent gets its own repo",
+			agentName:  "cross-eng",
+			repo:       other,
+			wantRepo:   other,
+			wantMarker: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, docker := newDockerMockManager(t, boot)
+
+			a, err := m.createAgent(ctx, SpawnOptions{
+				Name:      tt.agentName,
+				Role:      Role("engineer"),
+				Workspace: tt.repo,
+				Runtime:   "docker",
+			})
+			if err != nil {
+				t.Fatalf("createAgent: %v", err)
+			}
+			t.Cleanup(func() {
+				_ = m.worktreeManagerFor(tt.repo).Remove(ctx, tt.agentName)
+			})
+
+			if a.Repo != tt.wantRepo {
+				t.Errorf("Agent.Repo = %q, want %q", a.Repo, tt.wantRepo)
+			}
+
+			dir, env := docker.lastSession()
+
+			// The container backend mounts env["BC_WORKSPACE"] at
+			// /workspace — it must be the agent's repo, not the boot repo.
+			if env["BC_WORKSPACE"] != tt.wantRepo {
+				t.Errorf("env BC_WORKSPACE = %q, want %q", env["BC_WORKSPACE"], tt.wantRepo)
+			}
+
+			// The session dir is the agent's worktree.
+			if dir != a.WorktreeDir {
+				t.Errorf("session dir = %q, want worktree %q", dir, a.WorktreeDir)
+			}
+			_, markerErr := os.Stat(filepath.Join(dir, "OTHER_REPO_MARKER"))
+			if tt.wantMarker && markerErr != nil {
+				t.Errorf("worktree %q not checked out from the agent's repo: %v", dir, markerErr)
+			}
+			if !tt.wantMarker && markerErr == nil {
+				t.Errorf("boot-repo worktree %q unexpectedly contains the cross-repo marker", dir)
+			}
+		})
+	}
+}

--- a/pkg/agent/runtime_test.go
+++ b/pkg/agent/runtime_test.go
@@ -14,8 +14,10 @@ import (
 
 // mockBackend implements runtime.Backend for testing runtime routing.
 type mockBackend struct {
-	name     string
 	sessions map[string]bool
+	lastEnv  map[string]string
+	name     string
+	lastDir  string
 	sent     []string
 	mu       sync.Mutex
 }
@@ -41,11 +43,21 @@ func (m *mockBackend) CreateSessionWithCommand(_ context.Context, name, _, _ str
 	m.sessions[name] = true
 	return nil
 }
-func (m *mockBackend) CreateSessionWithEnv(_ context.Context, name, _, _ string, _ map[string]string) error {
+func (m *mockBackend) CreateSessionWithEnv(_ context.Context, name, dir, _ string, env map[string]string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.sessions[name] = true
+	m.lastDir = dir
+	m.lastEnv = env
 	return nil
+}
+
+// lastSession returns the dir and env of the most recent
+// CreateSessionWithEnv call.
+func (m *mockBackend) lastSession() (dir string, env map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastDir, m.lastEnv
 }
 func (m *mockBackend) KillSession(_ context.Context, name string) error {
 	m.mu.Lock()

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -193,6 +193,53 @@ func (b *Backend) hostAgentDir(agentName, hostRoot string) string {
 	return filepath.Join(hostRoot, rel)
 }
 
+// resolveRepoMount picks the repository mounted at /workspace and the
+// container working directory for an agent session.
+//
+// The agent's repo arrives via env["BC_WORKSPACE"], which the agent
+// manager sets from Agent.Repo (mirroring worktreeManagerFor on the
+// tmux path). An empty value — or the boot workspace path itself —
+// means the boot repo. Any other repo is mounted instead, so agents
+// bound to a different repo get THEIR repo at /workspace, not the
+// boot repo.
+//
+// Returns the host-side mount source (for -v) and the container
+// workdir (for -w). dir is the agent's worktree as bcd sees it; when
+// it lives under the mounted repo, the workdir points at it.
+func (b *Backend) resolveRepoMount(dir string, env map[string]string) (hostRepo, workdir string, err error) {
+	// Boot repo defaults. BC_HOST_WORKSPACE (Docker-in-Docker) only
+	// translates the boot workspace path.
+	repoRoot := b.workspacePath
+	hostRepo = b.hostWorkspacePath
+	if hostRepo == "" {
+		hostRepo = b.workspacePath
+	}
+
+	if agentRepo := env["BC_WORKSPACE"]; agentRepo != "" && filepath.Clean(agentRepo) != filepath.Clean(b.workspacePath) {
+		// The repo value originates from the create-agent API — require
+		// an absolute, traversal-free path before it becomes a -v mount
+		// source. Like validateMount, ".." is checked on the raw value
+		// so traversal cannot be smuggled past filepath.Clean.
+		cleaned := filepath.Clean(agentRepo)
+		if !filepath.IsAbs(cleaned) || strings.Contains(agentRepo, "..") {
+			return "", "", fmt.Errorf("agent repo %q must be an absolute path without traversal", agentRepo)
+		}
+		repoRoot = cleaned
+		// Cross-repo paths are host paths already; no BC_HOST_WORKSPACE
+		// translation applies.
+		hostRepo = cleaned
+	}
+
+	workdir = "/workspace"
+	if dir != "" && dir != repoRoot {
+		// Agent has an isolated worktree — set working directory to it.
+		if rel, relErr := filepath.Rel(repoRoot, dir); relErr == nil && !strings.HasPrefix(rel, "..") {
+			workdir = filepath.Join("/workspace", rel)
+		}
+	}
+	return hostRepo, workdir, nil
+}
+
 // imageForTool returns the Docker image for a given agent tool name.
 func (b *Backend) imageForTool(toolName string) string {
 	if toolName == "" {
@@ -269,7 +316,7 @@ func (b *Backend) CreateSessionWithCommand(ctx context.Context, name, dir, comma
 // CreateSessionWithEnv creates a fully isolated Docker container for an agent.
 //
 // Mounts:
-//   - workspace dir → /workspace (project code)
+//   - agent's repo → /workspace (project code; env BC_WORKSPACE, boot workspace when unset)
 //   - .bc/volumes/<agent>/.claude → /home/agent/.claude (persistent Claude state)
 //   - bc-shared-tmp → /tmp/bc-shared (shared volume for cross-container file exchange)
 //
@@ -360,25 +407,26 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 	// Ensure host.docker.internal resolves on Linux (macOS/Windows get this automatically)
 	args = append(args, "--add-host=host.docker.internal:host-gateway")
 
-	// Mount 1: Project root at /workspace.
-	// The full project is mounted so git worktrees resolve naturally
+	// Mount 1: The agent's repo at /workspace.
+	// The full repo is mounted so git worktrees resolve naturally
 	// (worktree .git files can traverse back to .git/ for objects/refs).
-	// If the agent has an isolated worktree, we set -w to that subdirectory.
+	// Agents bound to a different repo (env BC_WORKSPACE) get that repo
+	// mounted — never the boot repo. If the agent has an isolated
+	// worktree under the repo, we set -w to that subdirectory.
+	hostRepo, containerWorkdir, mountErr := b.resolveRepoMount(dir, env)
+	if mountErr != nil {
+		return mountErr
+	}
+	args = append(args, "-v", hostRepo+":/workspace")
+	args = append(args, "-w", containerWorkdir)
+
+	// Agent state (Mounts 2–3) always lives in the BOOT workspace's data
+	// dir regardless of which repo the agent is bound to, so state-dir
+	// host translation keys off the boot host root, not the repo mount.
 	hostRoot := b.hostWorkspacePath
 	if hostRoot == "" {
 		hostRoot = b.workspacePath
 	}
-	args = append(args, "-v", hostRoot+":/workspace")
-
-	containerWorkdir := "/workspace"
-	if dir != "" && dir != b.workspacePath {
-		// Agent has an isolated worktree — set working directory to it.
-		rel, relErr := filepath.Rel(b.workspacePath, dir)
-		if relErr == nil && !strings.HasPrefix(rel, "..") {
-			containerWorkdir = filepath.Join("/workspace", rel)
-		}
-	}
-	args = append(args, "-w", containerWorkdir)
 
 	// Mount 2: Persistent Claude state (~/.claude/ dir)
 	// Use local (container) path for mkdir, host path for -v mount.

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -541,3 +541,148 @@ func TestWorkspaceHashDeterministic(t *testing.T) {
 		t.Error("different workspace paths should produce different hashes")
 	}
 }
+
+func TestResolveRepoMount(t *testing.T) {
+	boot := "/host/boot-repo"
+	other := "/host/other-repo"
+
+	tests := []struct {
+		env         map[string]string
+		name        string
+		hostWS      string
+		dir         string
+		wantRepo    string
+		wantWorkdir string
+		wantErr     string
+	}{
+		{
+			name:        "boot repo, no env, dir is repo root",
+			dir:         boot,
+			wantRepo:    boot,
+			wantWorkdir: "/workspace",
+		},
+		{
+			name:        "boot repo, empty dir",
+			dir:         "",
+			wantRepo:    boot,
+			wantWorkdir: "/workspace",
+		},
+		{
+			name:        "boot repo, worktree under repo (legacy sidecar)",
+			dir:         boot + "/.bc/agents/zed/bc-boot-repo-zed",
+			wantRepo:    boot,
+			wantWorkdir: "/workspace/.bc/agents/zed/bc-boot-repo-zed",
+		},
+		{
+			name:        "boot repo, worktree outside repo (M11 data dir)",
+			dir:         "/home/user/.mycel/workspaces/ws1/agents/zed/bc-boot-repo-zed",
+			wantRepo:    boot,
+			wantWorkdir: "/workspace",
+		},
+		{
+			name:        "BC_WORKSPACE equal to boot repo behaves like boot",
+			env:         map[string]string{"BC_WORKSPACE": boot},
+			dir:         boot + "/.bc/agents/zed/wt",
+			wantRepo:    boot,
+			wantWorkdir: "/workspace/.bc/agents/zed/wt",
+		},
+		{
+			name:        "boot repo honors BC_HOST_WORKSPACE translation",
+			hostWS:      "/real/host/boot-repo",
+			dir:         boot,
+			wantRepo:    "/real/host/boot-repo",
+			wantWorkdir: "/workspace",
+		},
+		{
+			name:        "cross repo mounts the agent repo, not boot",
+			env:         map[string]string{"BC_WORKSPACE": other},
+			dir:         "/home/user/.mycel/workspaces/ws1/agents/zed/bc-other-repo-zed",
+			wantRepo:    other,
+			wantWorkdir: "/workspace",
+		},
+		{
+			name:        "cross repo with worktree under the agent repo",
+			env:         map[string]string{"BC_WORKSPACE": other},
+			dir:         other + "/.bc/agents/zed/bc-other-repo-zed",
+			wantRepo:    other,
+			wantWorkdir: "/workspace/.bc/agents/zed/bc-other-repo-zed",
+		},
+		{
+			name:        "cross repo ignores boot BC_HOST_WORKSPACE translation",
+			env:         map[string]string{"BC_WORKSPACE": other},
+			hostWS:      "/real/host/boot-repo",
+			dir:         other,
+			wantRepo:    other,
+			wantWorkdir: "/workspace",
+		},
+		{
+			name:    "cross repo rejects relative path",
+			env:     map[string]string{"BC_WORKSPACE": "relative/repo"},
+			dir:     boot,
+			wantErr: "absolute path",
+		},
+		{
+			name:    "cross repo rejects traversal",
+			env:     map[string]string{"BC_WORKSPACE": "/host/boot-repo/../../etc"},
+			dir:     boot,
+			wantErr: "absolute path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Backend{
+				prefix:            "bc-",
+				workspaceHash:     "aabbcc",
+				workspacePath:     boot,
+				hostWorkspacePath: tt.hostWS,
+				cfg:               Config{Image: "mycel-agent-claude:latest"},
+				logCancels:        make(map[string]context.CancelFunc),
+			}
+			hostRepo, workdir, err := b.resolveRepoMount(tt.dir, tt.env)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("resolveRepoMount() error = nil, want containing %q", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("resolveRepoMount() error = %q, want containing %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveRepoMount() unexpected error: %v", err)
+			}
+			if hostRepo != tt.wantRepo {
+				t.Errorf("hostRepo = %q, want %q", hostRepo, tt.wantRepo)
+			}
+			if workdir != tt.wantWorkdir {
+				t.Errorf("workdir = %q, want %q", workdir, tt.wantWorkdir)
+			}
+		})
+	}
+}
+
+func TestCreateSessionWithEnv_RejectsUnsafeAgentRepo(t *testing.T) {
+	// Worktree dir with .git so workspace validation passes.
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	b := &Backend{
+		prefix:        "bc-",
+		workspaceHash: "aabbcc",
+		workspacePath: "/host/boot-repo",
+		cfg:           Config{Image: "mycel-agent-claude:latest", Network: "bridge", CPUs: 2.0, MemoryMB: 2048},
+		logCancels:    make(map[string]context.CancelFunc),
+	}
+
+	env := map[string]string{"BC_WORKSPACE": "not/absolute"}
+	err := b.CreateSessionWithEnv(context.Background(), "test-agent", dir, "bash", env)
+	if err == nil {
+		t.Fatal("expected error for relative agent repo path")
+	}
+	if !strings.Contains(err.Error(), "absolute path") {
+		t.Errorf("error = %q, want to contain 'absolute path'", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

Closes the last gap from the workspace-removal epic: Docker-runtime agents mounted the **boot** repo into the container regardless of which repo the agent was bound to. The tmux path was already fixed (`worktreeManagerFor` checks out worktrees from the agent's repo); the container backend still built the `-v` mount and `-w` workdir from the boot workspace path captured at `NewBackend` construction time.

Part of #3276

## Root cause

`container.Backend` is constructed once with the boot `workspacePath`/`hostWorkspacePath` and `CreateSessionWithEnv` unconditionally used those for the `/workspace` mount and for the workdir `Rel` base. The agent's repo binding (`Agent.Repo`) never influenced the container's mounts.

## Fix

- New `Backend.resolveRepoMount(dir, env)` resolves the `/workspace` mount source and container workdir per session from `env["BC_WORKSPACE"]`, which the agent manager already sets from `Agent.Repo` in both `createAgent` and `startAgent` (mirrors the `worktreeManagerFor` pattern).
- Empty repo, or repo == boot workspace, means the boot repo — behavior unchanged, including `BC_HOST_WORKSPACE` Docker-in-Docker translation (which only applies to the boot path).
- A cross-repo path must be absolute and traversal-free (checked on the raw value like `validateMount`) before it becomes a `-v` mount source; otherwise session creation fails fast.
- Agent state mounts (`claude/`, `claude.json`) stay keyed to the boot workspace data dir — that is where `worktreeManagerFor` anchors cross-repo worktree state too.

## Tests (no Docker needed — mount/config construction only)

- `TestResolveRepoMount` (table-driven, 11 cases): boot repo defaults, legacy sidecar worktree workdir, M11 out-of-repo worktree, `BC_WORKSPACE == boot` equivalence, `BC_HOST_WORKSPACE` translation applied to boot only, cross-repo mount + workdir, relative/traversal rejection.
- `TestCreateSessionWithEnv_RejectsUnsafeAgentRepo`: fail-fast on unsafe repo env.
- `TestCreateAgent_DockerBackendReceivesAgentRepo` (pkg/agent, table-driven): docker agent bound to repo != boot gets a session dir that is a worktree checked out from its OWN repo (marker-commit verified) and `BC_WORKSPACE` = its repo; boot-repo agent unchanged.

## Quality gate

- `gofmt -s -l` clean, `go vet` clean, `golangci-lint run ./pkg/container/... ./pkg/agent/...` → 0 issues
- `go test -race ./pkg/container/ ./pkg/agent/` → ok
- `go build ./...` → ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)