### PR TITLE
fix(cli): resolve roles from the global store, true provider list, bc→mycel leftovers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,12 +53,6 @@ linters:
         linters:
           - gochecknoglobals
 
-      # TODO: re-evaluate after redesign — queue/beads packages have been removed;
-      # keep this exclusion pattern in case channels revamp (#2947) introduces new deprecations
-      # - linters:
-      #     - staticcheck
-      #   text: "SA1019.*pkg/(queue|beads)"
-
 formatters:
   enable:
     - gofmt

--- a/docs/proposals/agent-sdk-architecture.md
+++ b/docs/proposals/agent-sdk-architecture.md
@@ -423,7 +423,7 @@ CMD ["node", "/app/mycel-agent-runner/index.js"]
 - Delete terminal parsing regex
 - Delete tmux session management for SDK agents
 - Delete OAuth volume mount logic
-- Keep tmux for non-SDK providers (aider, opencode)
+- Keep tmux for non-SDK providers (gemini, cursor, codex, pi)
 
 ---
 

--- a/docs/proposals/agents-revamp.md
+++ b/docs/proposals/agents-revamp.md
@@ -38,7 +38,7 @@ An agent is an isolated AI collaborator with:
 2. **A template instance** — materialized config: system prompt, MCPs, secrets, plugins
 3. **An avatar** — icon variant + accent color, persisted on creation
 4. **A runtime** — tmux (local) or Docker (isolated container)
-5. **A provider** — Claude, Gemini, Cursor, Codex, Aider, etc.
+5. **A provider** — Claude, Gemini, Cursor, Codex, or Pi
 
 ### 2.1 Templates Replace Roles
 
@@ -375,7 +375,6 @@ Pattern matching checks for provider-specific indicators:
 - Claude: `Waiting for input`, `Thinking...`, rate limit messages
 - Gemini: `quota` errors
 - Cursor: auth errors
-- Aider: `rate limit`
 
 ---
 

--- a/docs/reference/cli/mycel_agent_create.md
+++ b/docs/reference/cli/mycel_agent_create.md
@@ -32,7 +32,7 @@ mycel agent create [name] [flags]
       --runtime string    Runtime backend override: tmux or docker
       --team string       Team name (alphanumeric)
       --template string   Template name from ~/.mycel/templates/ (e.g. base, engineer)
-      --tool string       Agent tool (claude, gemini, cursor, codex, opencode, openclaw, aider, pi)
+      --tool string       Agent tool (claude, codex, cursor, gemini, pi)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/mycel_completion.md
+++ b/docs/reference/cli/mycel_completion.md
@@ -4,18 +4,18 @@ Generate shell completion scripts
 
 ### Synopsis
 
-Generate shell completion scripts for bc.
+Generate shell completion scripts for mycel.
 
 To load completions:
 
 Bash:
-  $ source <(bc completion bash)
+  $ source <(mycel completion bash)
 
   # To load completions for each session, execute once:
   # Linux:
-  $ bc completion bash > /etc/bash_completion.d/bc
+  $ mycel completion bash > /etc/bash_completion.d/mycel
   # macOS:
-  $ bc completion bash > $(brew --prefix)/etc/bash_completion.d/bc
+  $ mycel completion bash > $(brew --prefix)/etc/bash_completion.d/mycel
 
 Zsh:
   # If shell completion is not already enabled in your environment,
@@ -23,21 +23,21 @@ Zsh:
   $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
   # To load completions for each session, execute once:
-  $ bc completion zsh > "${fpath[1]}/_bc"
+  $ mycel completion zsh > "${fpath[1]}/_mycel"
 
   # You will need to start a new shell for this setup to take effect.
 
 Fish:
-  $ bc completion fish | source
+  $ mycel completion fish | source
 
   # To load completions for each session, execute once:
-  $ bc completion fish > ~/.config/fish/completions/bc.fish
+  $ mycel completion fish > ~/.config/fish/completions/mycel.fish
 
 PowerShell:
-  PS> bc completion powershell | Out-String | Invoke-Expression
+  PS> mycel completion powershell | Out-String | Invoke-Expression
 
   # To load completions for every new session, run:
-  PS> bc completion powershell > bc.ps1
+  PS> mycel completion powershell > mycel.ps1
   # and source this file from your PowerShell profile.
 
 

--- a/docs/reference/cli/mycel_logs.md
+++ b/docs/reference/cli/mycel_logs.md
@@ -4,7 +4,7 @@ Show the event log
 
 ### Synopsis
 
-View the bc event log showing agent spawns, stops, work assignments, and reports.
+View the mycel event log showing agent spawns, stops, work assignments, and reports.
 
 Examples:
   mycel logs                     # Show all events

--- a/docs/reference/cli/mycel_mcp.md
+++ b/docs/reference/cli/mycel_mcp.md
@@ -40,8 +40,8 @@ Examples:
 * [mycel mcp disable](mycel_mcp_disable.md)	 - Disable an MCP server configuration
 * [mycel mcp enable](mycel_mcp_enable.md)	 - Enable an MCP server configuration
 * [mycel mcp list](mycel_mcp_list.md)	 - List MCP server configurations
-* [mycel mcp register](mycel_mcp_register.md)	 - Register bc as an MCP server in agent settings.json
+* [mycel mcp register](mycel_mcp_register.md)	 - Register mycel as an MCP server in agent settings.json
 * [mycel mcp remove](mycel_mcp_remove.md)	 - Remove an MCP server configuration
-* [mycel mcp serve](mycel_mcp_serve.md)	 - Start bc as an MCP server
+* [mycel mcp serve](mycel_mcp_serve.md)	 - Start mycel as an MCP server
 * [mycel mcp show](mycel_mcp_show.md)	 - Show MCP server configuration details
 

--- a/docs/reference/cli/mycel_mcp_register.md
+++ b/docs/reference/cli/mycel_mcp_register.md
@@ -1,13 +1,13 @@
 ## mycel mcp register
 
-Register bc as an MCP server in agent settings.json
+Register mycel as an MCP server in agent settings.json
 
 ### Synopsis
 
-Automatically add bc to the Claude Code MCP server configuration.
+Automatically add mycel to the Claude Code MCP server configuration.
 
 This writes (or updates) the mcp.servers entry in the workspace
-settings.json so that agents automatically have access to bc MCP tools.
+settings.json so that agents automatically have access to mycel MCP tools.
 
 Examples:
   mycel mcp register               # Register with stdio transport

--- a/docs/reference/cli/mycel_mcp_serve.md
+++ b/docs/reference/cli/mycel_mcp_serve.md
@@ -1,12 +1,12 @@
 ## mycel mcp serve
 
-Start bc as an MCP server
+Start mycel as an MCP server
 
 ### Synopsis
 
-Start bc as an MCP (Model Context Protocol) server.
+Start mycel as an MCP (Model Context Protocol) server.
 
-AI tools like Claude Code and Cursor can connect to bc via MCP to query
+AI tools like Claude Code and Cursor can connect to mycel via MCP to query
 workspace state and control agents natively.
 
 Default transport is stdio (newline-delimited JSON on stdin/stdout).

--- a/docs/reference/cli/mycel_status.md
+++ b/docs/reference/cli/mycel_status.md
@@ -4,7 +4,7 @@ Show agent status
 
 ### Synopsis
 
-Show the status of all bc agents.
+Show the status of all mycel agents.
 
 Examples:
   mycel status                   # Show all agents

--- a/docs/reference/cli/mycel_template.md
+++ b/docs/reference/cli/mycel_template.md
@@ -7,9 +7,9 @@ Manage agent templates
 Manage agent templates — reusable configurations for spawning agents.
 
 Templates are stored in ~/.mycel/templates/ (user-global) and each workspace
-may override a template by placing a file with the same name under
-<ws>/.bc/templates/. List/show/edit see the union; create defaults to
-writing the user-global copy.
+may override a template by placing a file with the same name under its
+state dir (~/.mycel/workspaces/<id>/templates/). List/show/edit see the
+union; create defaults to writing the user-global copy.
 
 Examples:
   mycel template list                    # List all templates (global + workspace overrides)

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -326,8 +326,10 @@ var (
 )
 
 func init() {
-	// Create flags
-	agentCreateCmd.Flags().StringVar(&agentCreateTool, "tool", "", "Agent tool (claude, gemini, cursor, codex, opencode, openclaw, aider, pi)")
+	// Create flags — the --tool help derives from the provider registry so
+	// the listed tools always match what is actually registered.
+	agentCreateCmd.Flags().StringVar(&agentCreateTool, "tool", "",
+		fmt.Sprintf("Agent tool (%s)", strings.Join(provider.DefaultRegistry.Names(), ", ")))
 	agentCreateCmd.Flags().StringVar(&agentCreateRole, "role", "", "Agent role (default: base)")
 	agentCreateCmd.Flags().StringVar(&agentCreateTemplate, "template", "", "Template name from ~/.mycel/templates/ (e.g. base, engineer)")
 	agentCreateCmd.Flags().StringVar(&agentCreateCopy, "copy", "", "Copy settings from an existing agent")

--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -230,7 +230,7 @@ func TestAgentReportNoAgentID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when BC_AGENT_ID not set, got nil")
 	}
-	if !strings.Contains(err.Error(), "this command can only be run by agents in the bc system") {
+	if !strings.Contains(err.Error(), "this command can only be run by agents in the mycel system") {
 		t.Errorf("expected agent-only command error, got: %v", err)
 	}
 }

--- a/internal/cmd/completion.go
+++ b/internal/cmd/completion.go
@@ -72,18 +72,18 @@ func CompleteRoleNames(cmd *cobra.Command, args []string, toComplete string) ([]
 var completionCmd = &cobra.Command{
 	Use:   "completion [bash|zsh|fish|powershell]",
 	Short: "Generate shell completion scripts",
-	Long: `Generate shell completion scripts for bc.
+	Long: `Generate shell completion scripts for mycel.
 
 To load completions:
 
 Bash:
-  $ source <(bc completion bash)
+  $ source <(mycel completion bash)
 
   # To load completions for each session, execute once:
   # Linux:
-  $ bc completion bash > /etc/bash_completion.d/bc
+  $ mycel completion bash > /etc/bash_completion.d/mycel
   # macOS:
-  $ bc completion bash > $(brew --prefix)/etc/bash_completion.d/bc
+  $ mycel completion bash > $(brew --prefix)/etc/bash_completion.d/mycel
 
 Zsh:
   # If shell completion is not already enabled in your environment,
@@ -91,21 +91,21 @@ Zsh:
   $ echo "autoload -U compinit; compinit" >> ~/.zshrc
 
   # To load completions for each session, execute once:
-  $ bc completion zsh > "${fpath[1]}/_bc"
+  $ mycel completion zsh > "${fpath[1]}/_mycel"
 
   # You will need to start a new shell for this setup to take effect.
 
 Fish:
-  $ bc completion fish | source
+  $ mycel completion fish | source
 
   # To load completions for each session, execute once:
-  $ bc completion fish > ~/.config/fish/completions/bc.fish
+  $ mycel completion fish > ~/.config/fish/completions/mycel.fish
 
 PowerShell:
-  PS> bc completion powershell | Out-String | Invoke-Expression
+  PS> mycel completion powershell | Out-String | Invoke-Expression
 
   # To load completions for every new session, run:
-  PS> bc completion powershell > bc.ps1
+  PS> mycel completion powershell > mycel.ps1
   # and source this file from your PowerShell profile.
 `,
 	DisableFlagsInUseLine: true,

--- a/internal/cmd/cron.go
+++ b/internal/cmd/cron.go
@@ -239,7 +239,7 @@ func runCronList(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(jobs) == 0 {
-		fmt.Println("No cron jobs. Add one with: bc cron add NAME --schedule \"* * * * *\" --agent AGENT --prompt \"...\"")
+		fmt.Println("No cron jobs. Add one with: mycel cron add NAME --schedule \"* * * * *\" --agent AGENT --prompt \"...\"")
 		return nil
 	}
 

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -16,7 +16,7 @@ import (
 var logsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "Show the event log",
-	Long: `View the bc event log showing agent spawns, stops, work assignments, and reports.
+	Long: `View the mycel event log showing agent spawns, stops, work assignments, and reports.
 
 Examples:
   mycel logs                     # Show all events

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -96,10 +96,10 @@ var mcpDisableCmd = &cobra.Command{
 // Issue #1985: bc-as-MCP-server commands
 var mcpServeCmd = &cobra.Command{
 	Use:   "serve",
-	Short: "Start bc as an MCP server",
-	Long: `Start bc as an MCP (Model Context Protocol) server.
+	Short: "Start mycel as an MCP server",
+	Long: `Start mycel as an MCP (Model Context Protocol) server.
 
-AI tools like Claude Code and Cursor can connect to bc via MCP to query
+AI tools like Claude Code and Cursor can connect to mycel via MCP to query
 workspace state and control agents natively.
 
 Default transport is stdio (newline-delimited JSON on stdin/stdout).
@@ -130,11 +130,11 @@ Examples:
 
 var mcpRegisterCmd = &cobra.Command{
 	Use:   "register",
-	Short: "Register bc as an MCP server in agent settings.json",
-	Long: `Automatically add bc to the Claude Code MCP server configuration.
+	Short: "Register mycel as an MCP server in agent settings.json",
+	Long: `Automatically add mycel to the Claude Code MCP server configuration.
 
 This writes (or updates) the mcp.servers entry in the workspace
-settings.json so that agents automatically have access to bc MCP tools.
+settings.json so that agents automatically have access to mycel MCP tools.
 
 Examples:
   mycel mcp register               # Register with stdio transport
@@ -481,9 +481,9 @@ func runMCPRegister(cmd *cobra.Command, _ []string) error {
 			"url":       sseURL,
 		}
 	} else {
-		bcPath, lookErr := exec.LookPath("bc")
+		bcPath, lookErr := exec.LookPath("mycel")
 		if lookErr != nil {
-			bcPath = "bc"
+			bcPath = "mycel"
 		}
 		mcpEntry = map[string]any{
 			"name":    "bc",
@@ -530,9 +530,9 @@ func runMCPRegister(cmd *cobra.Command, _ []string) error {
 	if mcpServeSSE {
 		transport = "sse (" + mcpServeAddr + ")"
 	}
-	fmt.Printf("✓ Registered bc MCP server in %s\n", settingsPath)
+	fmt.Printf("✓ Registered mycel MCP server in %s\n", settingsPath)
 	fmt.Printf("  Transport: %s\n", transport)
-	fmt.Println("\nAgents will automatically have access to bc MCP tools.")
+	fmt.Println("\nAgents will automatically have access to mycel MCP tools.")
 
 	return nil
 }

--- a/internal/cmd/repo_helpers.go
+++ b/internal/cmd/repo_helpers.go
@@ -27,7 +27,7 @@ func getRepo() (*workspace.Workspace, error) {
 
 // errorAgentNotRunning returns an error message for commands that require BC_AGENT_ID.
 func errorAgentNotRunning(commandUsage string) error {
-	return fmt.Errorf("this command can only be run by agents in the bc system (use: bc agent send <agent-name> %q)", commandUsage)
+	return fmt.Errorf("this command can only be run by agents in the mycel system (use: mycel agent send <agent-name> %q)", commandUsage)
 }
 
 // newDaemonClient creates a client connected to the bcd daemon.

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -21,7 +21,7 @@ var statusActivity bool
 var statusCmd = &cobra.Command{
 	Use:   "status",
 	Short: "Show agent status",
-	Long: `Show the status of all bc agents.
+	Long: `Show the status of all mycel agents.
 
 Examples:
   mycel status                   # Show all agents
@@ -189,9 +189,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 
 	fmt.Println()
 	fmt.Println("Commands:")
-	fmt.Println("  bc agent attach <agent>  # Attach to agent's session")
-	fmt.Println("  bc agent health    # Check agent health status")
-	fmt.Println("  bc down            # Stop all agents")
+	fmt.Println("  mycel agent attach <agent>  # Attach to agent's session")
+	fmt.Println("  mycel agent health    # Check agent health status")
+	fmt.Println("  mycel down            # Stop all agents")
 
 	return nil
 }

--- a/internal/cmd/template.go
+++ b/internal/cmd/template.go
@@ -19,9 +19,9 @@ var templateCmd = &cobra.Command{
 	Long: `Manage agent templates — reusable configurations for spawning agents.
 
 Templates are stored in ~/.mycel/templates/ (user-global) and each workspace
-may override a template by placing a file with the same name under
-<ws>/.bc/templates/. List/show/edit see the union; create defaults to
-writing the user-global copy.
+may override a template by placing a file with the same name under its
+state dir (~/.mycel/workspaces/<id>/templates/). List/show/edit see the
+union; create defaults to writing the user-global copy.
 
 Examples:
   mycel template list                    # List all templates (global + workspace overrides)

--- a/internal/cmd/tool.go
+++ b/internal/cmd/tool.go
@@ -541,7 +541,7 @@ func runToolStatus(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s %s is not installed\n", ui.RedText("✗"), name)
 		if t.InstallCmd != "" {
 			fmt.Printf("  Install: %s\n", ui.DimText(t.InstallCmd))
-			fmt.Printf("  Run:     bc tool setup %s\n", name)
+			fmt.Printf("  Run:     mycel tool setup %s\n", name)
 		}
 	}
 
@@ -680,7 +680,7 @@ func runToolSetup(cmd *cobra.Command, args []string) error {
 
 	// Step 2: run install command
 	if t.InstallCmd == "" {
-		return fmt.Errorf("no install command configured for %q; add one with: bc tool edit %s --install <cmd>", name, name)
+		return fmt.Errorf("no install command configured for %q; add one with: mycel tool edit %s --install <cmd>", name, name)
 	}
 
 	fmt.Printf("Installing %s...\n", name)
@@ -833,7 +833,7 @@ func runToolEdit(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if t == nil {
-		return fmt.Errorf("tool %q not found — add it with: bc tool add %s", name, name)
+		return fmt.Errorf("tool %q not found — add it with: mycel tool add %s", name, name)
 	}
 
 	changed := false
@@ -896,7 +896,7 @@ func runToolDelete(cmd *cobra.Command, args []string) error {
 	apiTool, apiErr := c.Tools.Get(ctx, name)
 	if apiErr == nil && apiTool != nil {
 		if apiTool.Builtin {
-			return fmt.Errorf("cannot delete built-in tool %q — disable it instead: bc tool edit %s --enabled false", name, name)
+			return fmt.Errorf("cannot delete built-in tool %q — disable it instead: mycel tool edit %s --enabled false", name, name)
 		}
 		if delErr := c.Tools.Delete(ctx, name); delErr != nil {
 			return fmt.Errorf("failed to delete tool: %w", delErr)
@@ -920,7 +920,7 @@ func runToolDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("tool %q not found", name)
 	}
 	if t.Builtin {
-		return fmt.Errorf("cannot delete built-in tool %q — disable it instead: bc tool edit %s --enabled false", name, name)
+		return fmt.Errorf("cannot delete built-in tool %q — disable it instead: mycel tool edit %s --enabled false", name, name)
 	}
 
 	if err := s.Delete(ctx, name); err != nil {

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -14,15 +14,12 @@
 
 ## Supported AI Tools
 
-mycel works with any CLI-based AI coding assistant:
+mycel ships built-in providers for:
 - Claude Code
+- Codex
 - Cursor
-- GitHub Copilot
 - Gemini
-- Aider
-- OpenCode
-- Cline
-- Any custom CLI tool
+- Pi
 
 ## Pages
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -413,11 +413,13 @@ func LoadRoleMemory(workspacePath string, role Role) *AgentMemory {
 		}
 	}
 
-	// Load role via RoleManager. Prefer the M11 global runtime dir
-	// (~/.mycel/workspaces/<id>/); fall back to the legacy <root>/.bc/
-	// sidecar when the global dir is missing or unavailable.
-	stateDir := workspaceStateDir(workspacePath)
-	rm := workspace.NewRoleManager(stateDir)
+	// Load role via a RoleManager backed by the single global database —
+	// roles are global, not per-repo state.
+	rm, err := workspace.NewGlobalRoleManager(workspaceStateDir(workspacePath))
+	if err != nil {
+		log.Debug("failed to open global role store", "role", role, "error", err)
+		return nil
+	}
 	roleObj, err := rm.LoadRole(string(role))
 	if err != nil {
 		log.Debug("failed to load role prompt", "role", role, "error", err)
@@ -2654,15 +2656,6 @@ func (m *Manager) RuntimeForAgent(name string) runtime.Backend {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	return m.runtimeForAgent(name)
-}
-
-// Tmux returns the underlying tmux manager if the default backend is tmux.
-// Deprecated: Use Runtime() instead. This is kept for backward compatibility.
-func (m *Manager) Tmux() *tmux.Manager {
-	if tb, ok := m.runtime().(*runtime.TmuxBackend); ok {
-		return tb.TmuxManager()
-	}
-	return nil
 }
 
 // QueryAgentStats returns up to limit recent stats records for the named agent.

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1181,10 +1181,6 @@ func TestRuntime(t *testing.T) {
 	if m.Runtime() == nil {
 		t.Error("Runtime() should not return nil")
 	}
-	// Tmux() should return the underlying tmux.Manager when backend is tmux
-	if m.Tmux() == nil {
-		t.Error("Tmux() should not return nil for tmux backend")
-	}
 }
 
 // --- UpdateAgentState with task update ---

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -51,8 +51,11 @@ func SetupAgentFromRole(ctx context.Context, workspacePath, agentName, roleName,
 }
 
 func setupAgentFromRole(ctx context.Context, workspacePath, agentName, roleName, targetDir, runtimeBackend, toolName string) error {
-	stateDir := workspaceStateDir(workspacePath)
-	rm := workspace.NewRoleManager(stateDir)
+	rm, err := workspace.NewGlobalRoleManager(workspaceStateDir(workspacePath))
+	if err != nil {
+		log.Warn("failed to open global role store, skipping setup", "role", roleName, "error", err)
+		return nil
+	}
 
 	resolved, err := rm.ResolveRole(roleName)
 	if err != nil {
@@ -490,8 +493,13 @@ func validateAgentTools(workspacePath, roleName string) []string {
 		return nil
 	}
 
-	stateDir := workspaceStateDir(workspacePath)
-	rm := workspace.NewRoleManager(stateDir)
+	// Roles live in the single global database, not in the target repo's
+	// local state dir — resolve them from the global store so agents created
+	// against any repo validate correctly.
+	rm, err := workspace.NewGlobalRoleManager(workspaceStateDir(workspacePath))
+	if err != nil {
+		return []string{fmt.Sprintf("role store unavailable: %v", err)}
+	}
 
 	resolved, err := rm.ResolveRole(roleName)
 	if err != nil {

--- a/pkg/agent/role_setup_test.go
+++ b/pkg/agent/role_setup_test.go
@@ -1,6 +1,46 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	pkgdb "github.com/rpuneet/mycel/pkg/db"
+	"github.com/rpuneet/mycel/pkg/workspace"
+)
+
+// TestValidateAgentToolsResolvesGlobalRoles is a regression test for the
+// role-validation path reading the wrong store: roles live in the single
+// global database, so validating an agent created against a repo with no
+// local .bc/roles must still resolve a globally defined role.
+func TestValidateAgentToolsResolvesGlobalRoles(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+
+	// Seed the role in the global store (the only place roles live).
+	wsDB, driver, err := pkgdb.Global(nil)
+	if err != nil {
+		t.Fatalf("db.Global: %v", err)
+	}
+	store, err := workspace.NewRoleStoreFromDB(wsDB.DB, driver)
+	if err != nil {
+		t.Fatalf("NewRoleStoreFromDB: %v", err)
+	}
+	if err := store.Save(&workspace.Role{Metadata: workspace.RoleMetadata{Name: "base"}}); err != nil {
+		t.Fatalf("save role: %v", err)
+	}
+
+	// A repo with no .bc/roles at all — validation must still resolve the
+	// global "base" role instead of reporting "role not found".
+	repo := t.TempDir()
+	issues := validateAgentTools(repo, "base")
+	for _, issue := range issues {
+		if strings.Contains(issue, "cannot resolve role") {
+			t.Fatalf("validateAgentTools resolved roles from the repo-local store: %q", issue)
+		}
+	}
+	if len(issues) != 0 {
+		t.Fatalf("validateAgentTools reported unexpected issues: %v", issues)
+	}
+}
 
 func TestRewriteDockerURL(t *testing.T) {
 	tests := []struct {

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,8 +1,9 @@
-// Package events provides an append-only event log for bc.
+// Package events provides an append-only event log for mycel.
 //
-// Events are stored as JSONL (one JSON object per line) at .bc/events.jsonl.
-// This provides an audit trail for agent spawns, stops, work assignments,
-// status reports, and messages.
+// Events are stored in the events table of the single global database
+// (see SQLiteLog); JSONLWriter additionally mirrors SSE events to a
+// per-workspace events.jsonl. This provides an audit trail for agent
+// spawns, stops, work assignments, status reports, and messages.
 package events
 
 import (
@@ -21,7 +22,6 @@ const (
 	WorkCompleted   EventType = "work.completed"
 	WorkFailed      EventType = "work.failed"
 	MessageSent     EventType = "message.sent"
-	QueueLoaded     EventType = "queue.loaded"
 	HealthCheck     EventType = "health.check"
 	HealthFailed    EventType = "health.failed"
 	HealthRecovered EventType = "health.recovered"
@@ -55,7 +55,7 @@ type Event struct {
 }
 
 // EventStore is the interface for reading and writing events.
-// Both the file-based Log and SQLiteLog implement this interface.
+// Implemented by SQLiteLog (and its Postgres variant).
 type EventStore interface {
 	Append(event Event) error
 	Read() ([]Event, error)
@@ -63,7 +63,3 @@ type EventStore interface {
 	ReadByAgent(name string) ([]Event, error)
 	Close() error
 }
-
-// Log manages the append-only event log file.
-// Deprecated: Log is retained for reference; use JSONLWriter or SQLiteLog instead.
-type Log struct{}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,19 +1,17 @@
 // Package provider implements AI agent provider integrations.
-// Issue #1451: OpenCode support
-// Issue #1452: Cursor Agent support
-// Epic #1429: Multi-Agent Integration
 package provider
 
 import (
 	"context"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 )
 
 // Provider represents an AI agent provider that can run in a bc workspace.
 type Provider interface {
-	// Name returns the provider's unique identifier (e.g., "opencode", "cursor")
+	// Name returns the provider's unique identifier (e.g., "claude", "cursor")
 	Name() string
 
 	// Description returns a human-readable description
@@ -126,6 +124,18 @@ func (r *Registry) List() []Provider {
 	return providers
 }
 
+// Names returns the sorted names of all registered providers. User-facing
+// provider lists (e.g., CLI flag help) derive from this so the registry
+// stays the single source of truth.
+func (r *Registry) Names() []string {
+	names := make([]string, 0, len(r.providers))
+	for name := range r.providers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // ListInstalled returns all installed providers.
 func (r *Registry) ListInstalled(ctx context.Context) []Provider {
 	var installed []Provider
@@ -141,7 +151,7 @@ func (r *Registry) ListInstalled(ctx context.Context) []Provider {
 var DefaultRegistry = NewRegistry()
 
 func init() {
-	// Register built-in providers (aider, opencode, openclaw removed per #2921)
+	// Register built-in providers.
 	DefaultRegistry.Register(NewClaudeProvider())
 	DefaultRegistry.Register(NewCodexProvider())
 	DefaultRegistry.Register(NewGeminiProvider())

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -50,21 +50,16 @@ func TestRegistryList(t *testing.T) {
 }
 
 func TestDefaultRegistryHasProviders(t *testing.T) {
-	// Default registry should have built-in providers
-	if len(DefaultRegistry.providers) == 0 {
-		t.Error("expected default registry to have providers")
+	// The default registry holds exactly the built-in providers — nothing
+	// more, nothing less. Names() is sorted, so compare directly.
+	want := []string{"claude", "codex", "cursor", "gemini", "pi"}
+	got := DefaultRegistry.Names()
+	if len(got) != len(want) {
+		t.Fatalf("expected providers %v, got %v", want, got)
 	}
-
-	// Check for expected providers (aider, opencode, openclaw removed per #2921)
-	for _, name := range []string{"claude", "codex", "gemini", "cursor"} {
-		if _, ok := DefaultRegistry.Get(name); !ok {
-			t.Errorf("expected %s provider in default registry", name)
-		}
-	}
-	// Verify removed providers are gone
-	for _, name := range []string{"aider", "opencode", "openclaw"} {
-		if _, ok := DefaultRegistry.Get(name); ok {
-			t.Errorf("expected %s provider to be removed from default registry", name)
+	for i, name := range want {
+		if got[i] != name {
+			t.Fatalf("expected providers %v, got %v", want, got)
 		}
 	}
 }

--- a/pkg/workspace/global.go
+++ b/pkg/workspace/global.go
@@ -49,7 +49,8 @@ func DataDir(id string) (string, error) {
 // GlobalTemplatesDir returns the user-global templates directory
 // (~/.mycel/templates/). Templates here apply across all workspaces; each
 // workspace may override a template by placing a file with the same name
-// under <ws>/.bc/templates/.
+// under its state dir's templates/ directory
+// (~/.mycel/workspaces/<id>/templates/).
 func GlobalTemplatesDir() (string, error) {
 	return globalPath(globalTemplatesDirName)
 }

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -305,6 +305,21 @@ func openRoleStore(cfg *Config) (*RoleStore, error) {
 	return NewRoleStoreFromDB(wsDB.DB, driver)
 }
 
+// NewGlobalRoleManager creates a role manager backed by the single global
+// database, where roles for every workspace live. stateDir is only used to
+// migrate any legacy filesystem roles under <stateDir>/roles into the store.
+// Package-level helpers that resolve roles without a *Workspace must use
+// this constructor — building a manager on a per-workspace bc.db reads the
+// wrong store and reports every role as missing.
+func NewGlobalRoleManager(stateDir string) (*RoleManager, error) {
+	store, err := openRoleStore(nil)
+	if err != nil {
+		return nil, err
+	}
+	_, _ = store.MigrateFromFiles(filepath.Join(stateDir, "roles")) //nolint:errcheck // best-effort
+	return NewRoleManagerWithStore(stateDir, store), nil
+}
+
 // initRoleManager creates a role manager with SQL store for workspace Init.
 // It creates the store, migrates defaults, and migrates any legacy filesystem
 // roles. Returns the manager plus a close function for the store.

--- a/server/mcp/resources.go
+++ b/server/mcp/resources.go
@@ -122,7 +122,17 @@ type rolePayload struct {
 }
 
 func (s *Server) readRoles() (string, error) {
-	rm := workspace.NewRoleManager(s.ws.StateDir())
+	// Roles live in the single global database — reuse the workspace's role
+	// manager (already backed by the global store) rather than opening a
+	// per-workspace bc.db that holds no roles.
+	rm := s.ws.RoleManager
+	if rm == nil {
+		var err error
+		rm, err = workspace.NewGlobalRoleManager(s.ws.StateDir())
+		if err != nil {
+			return marshalJSON([]rolePayload{})
+		}
+	}
 	roles, err := rm.LoadAllRoles()
 	if err != nil {
 		return marshalJSON([]rolePayload{})

--- a/tui/FIGMA_DESIGN_PROMPT.md
+++ b/tui/FIGMA_DESIGN_PROMPT.md
@@ -651,7 +651,7 @@ No wasted space. Single-column. Inline metrics. Activity fills the screen.
  ▸ claude       3.2.1      ✓ ready      8
    gemini       1.5.0      ✓ ready      2
    cursor       0.42       ✓ ready      1
-   aider        0.55.0     ✗ error      0
+   codex        0.42.0     ✗ error      0
 ```
 
 ### 10. Help View

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -58,9 +58,6 @@ const PROVIDER_DOTS: Record<string, string> = {
   cursor:   "bg-fuchsia-400/70",
   codex:    "bg-emerald-400/70",
   pi:       "bg-teal-400/70",
-  aider:    "bg-amber-400/70",
-  opencode: "bg-indigo-400/70",
-  openclaw: "bg-rose-400/70",
 };
 
 function ProviderChip({ tool }: { tool?: string | null }) {


### PR DESCRIPTION
## Summary

Batch of small "truth" fixes across the CLI and agent orchestrator.

### Role validation reads the wrong store
`validateAgentTools` (and three sibling call sites) built `workspace.NewRoleManager(workspaceStateDir(...))`, resolving roles from the target repo's per-workspace `bc.db`. Roles live in the single global database, so every agent created against a repo other than the bc repo got `tool validation: 1 issue(s)` from `cannot resolve role "base": role not found`.

- Added `workspace.NewGlobalRoleManager(stateDir)` — opens the role store on `db.Global` (the same path `initRoleManager`/`loadRoleManager` use), with best-effort legacy filesystem migration.
- Switched `validateAgentTools`, `setupAgentFromRole` (the `SetupAgentFromRoleWithRuntime` path had the same repo-local assumption), `LoadRoleMemory`, and `server/mcp.readRoles` (now reuses `ws.RoleManager`).
- Regression test `TestValidateAgentToolsResolvesGlobalRoles`: a repo with no `.bc/roles` validates a globally defined role with zero issues (verified it fails on pre-fix code).

### Provider list truth
The registry has exactly 5 providers: claude, codex, cursor, gemini, pi.

- `--tool` help now derives from the registry via new `Registry.Names()` (sorted) — it can never drift again.
- Removed opencode/openclaw/aider remnants: web `PROVIDER_DOTS`, landing `llms.txt` supported-tools list, TUI Figma design doc example, proposals prose. No docker/ Dockerfiles or Makefile targets existed for them.
- `TestDefaultRegistryHasProviders` now asserts the exact 5-provider set.
- `docs/proposals/agent-sdk-research.md` still names OpenCode/Aider — it is a survey of external market products, not a claim of mycel support, so it stays.

### bc→mycel leftovers + dead code
- Fixed user-visible `bc <verb>` references to `mycel` in completion, status, logs, mcp (serve/register help + output), tool, cron, template, and the agent-only-command error.
- `mycel mcp register` (stdio) now looks up the `mycel` binary — `exec.LookPath("bc")` would have registered the Unix calculator.
- Dead code removed per the issue's confirmed-dead list (remaining items): `events.QueueLoaded`, deprecated `events.Log`, `agent.Manager.Tmux()` (+ its only test ref), commented-out queue/beads exclusion in `.golangci.yml`. `BCHome`/`EnsureBCHome` were already gone.
- Corrected stale `~/.bc` path comments/help (`workspace/global.go`, `internal/cmd/template.go`, events package doc). Intentional legacy identifiers (`bc.db`, `bc-*` session names, `bc://` URIs, MCP server name `bc`, `BC_*` env vars) untouched.

Regenerated `docs/reference/cli/` via gendocs (8 files updated, verified non-empty).

## Testing
- `gofmt -s -l` clean, `go vet ./...` clean, `golangci-lint run ./...` 0 issues
- `go test -race` on pkg/agent, pkg/workspace, pkg/events, pkg/provider, internal/cmd, server/mcp — all pass
- web vitest: 122 passed
- `go build ./...` clean

Closes #3290
Closes #3292
Closes #2921
Closes #3245

🤖 Generated with [Claude Code](https://claude.com/claude-code)