### PR TITLE
fix(agent): create-path reliability — rollback, runtime-aware MCP, image doctor check

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -550,6 +550,24 @@ func (m *Manager) getAgentLock(name string) *sync.Mutex {
 	return lock
 }
 
+// rollbackCreate undoes a failed createAgent: the in-memory entry AND the
+// store row both go. Background loops (tool health) snapshot m.agents to
+// the store while creation is still in flight, so the row may already be
+// persisted even though createAgent never saved it — without the store
+// delete the name stays reserved by a phantom 'starting' row forever.
+func (m *Manager) rollbackCreate(ctx context.Context, name string) {
+	m.mu.Lock()
+	delete(m.agents, name)
+	store := m.store
+	m.mu.Unlock()
+	if store == nil {
+		return
+	}
+	if err := store.Delete(ctx, name); err != nil {
+		log.Warn("rollback: failed to delete agent row after failed create", "agent", name, "error", err)
+	}
+}
+
 // runtime returns the default runtime backend.
 func (m *Manager) runtime() runtime.Backend {
 	return m.backends[m.defaultBackend]
@@ -1357,9 +1375,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	wtDir, wtErr := wtMgr.Create(ctx, name)
 	if wtErr != nil {
 		agentLock.Unlock()
-		m.mu.Lock()
-		delete(m.agents, name)
-		m.mu.Unlock()
+		m.rollbackCreate(ctx, name)
 		return nil, fmt.Errorf("create worktree: %w", wtErr)
 	}
 	agent.WorktreeDir = wtDir
@@ -1395,9 +1411,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	// Create session IN the worktree directory
 	if err := rt.CreateSessionWithEnv(ctx, name, wtDir, agentCmd, env); err != nil {
 		agentLock.Unlock()
-		m.mu.Lock()
-		delete(m.agents, name)
-		m.mu.Unlock()
+		m.rollbackCreate(ctx, name)
 		return nil, fmt.Errorf("failed to create session: %w", err)
 	}
 

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3777,3 +3777,55 @@ func TestCreateAgent_DockerBackendReceivesAgentRepo(t *testing.T) {
 		})
 	}
 }
+
+// TestCreateAgent_FailedCreateRollsBackStoreRow covers the orphan-row bug:
+// a background loop (tool health) snapshots m.agents to the store while
+// creation is still in flight; when session creation then fails, the
+// in-memory entry was removed but the persisted row survived — leaving a
+// phantom 'starting' agent that reserved the name forever.
+func TestCreateAgent_FailedCreateRollsBackStoreRow(t *testing.T) {
+	ctx := context.Background()
+	boot := t.TempDir()
+	initGitRepo(t, boot)
+	m, docker := newDockerMockManager(t, boot)
+
+	// Fail session creation, and persist the half-created agent first —
+	// exactly what the periodic tool-health save does mid-creation.
+	docker.createErr = fmt.Errorf("image missing")
+	docker.onCreate = func() {
+		snapshot := map[string]*Agent{
+			"doomed": {ID: "doomed", Name: "doomed", Role: Role("engineer"), State: StateStarting, Workspace: boot, Repo: boot},
+		}
+		if err := m.store.SaveAll(ctx, snapshot); err != nil {
+			t.Errorf("mid-create SaveAll: %v", err)
+		}
+	}
+
+	_, err := m.SpawnAgentWithOptions(ctx, SpawnOptions{
+		Name:      "doomed",
+		Role:      Role("engineer"),
+		Workspace: boot,
+	})
+	if err == nil {
+		t.Fatal("expected create failure")
+	}
+
+	// The persisted row must be rolled back with the in-memory entry.
+	row, loadErr := m.store.Load(ctx, "doomed")
+	if loadErr != nil {
+		t.Fatalf("Load: %v", loadErr)
+	}
+	if row != nil {
+		t.Fatalf("store row survived failed create: %+v", row)
+	}
+	if got := m.GetAgent("doomed"); got != nil {
+		t.Fatalf("in-memory agent survived failed create: %+v", got)
+	}
+
+	// The name is immediately reusable.
+	docker.createErr = nil
+	docker.onCreate = nil
+	if err := m.RegisterStopped(&Agent{Name: "doomed", Role: Role("engineer"), Workspace: boot}); err != nil {
+		t.Fatalf("name not reusable after failed create: %v", err)
+	}
+}

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -190,6 +190,13 @@ func writeMCPJSON(ctx context.Context, workspacePath, agentName string, resolved
 	}
 
 	for _, name := range resolved.MCPServers {
+		// The bc server is this daemon itself — its address depends on the
+		// live bind address and the agent's runtime, never on the store.
+		if name == "bc" {
+			cfg.MCPServers["bc"] = mcpServerEntry{URL: bcSelfURL(runtimeBackend, agentName), Type: "sse"}
+			continue
+		}
+
 		// Try unified tool store first
 		var transport, command, url string
 		var args []string
@@ -262,17 +269,7 @@ func writeMCPJSON(ctx context.Context, workspacePath, agentName string, resolved
 	// Always ensure the bc MCP server is included with agent-scoped URL.
 	// This is required for send_message, report_status, and other bc tools.
 	if _, hasBc := cfg.MCPServers["bc"]; !hasBc {
-		bcDef, bcErr := mcpStore.Get("bc")
-		if bcErr == nil && bcDef != nil {
-			bcURL := bcDef.URL
-			if isDocker && bcURL != "" {
-				bcURL = rewriteDockerURL(bcURL)
-			}
-			if bcURL != "" && strings.Contains(bcURL, "/_mcp/sse") {
-				bcURL = strings.Replace(bcURL, "/_mcp/sse", "/_mcp/"+agentName+"/sse", 1)
-			}
-			cfg.MCPServers["bc"] = mcpServerEntry{URL: bcURL, Type: "sse"}
-		}
+		cfg.MCPServers["bc"] = mcpServerEntry{URL: bcSelfURL(runtimeBackend, agentName), Type: "sse"}
 	}
 
 	// Prefer claude CLI for MCP setup; fall back to .mcp.json file write.
@@ -292,6 +289,15 @@ func rewriteDockerURL(u string) string {
 	u = strings.Replace(u, "localhost", "host.docker.internal", 1)
 	u = strings.Replace(u, "127.0.0.1", "host.docker.internal", 1)
 	return u
+}
+
+// bcSelfURL returns this daemon's agent-scoped MCP SSE endpoint for the
+// given runtime. A URL stored in mcp_servers can't be right for both
+// runtimes at once (tmux needs 127.0.0.1, docker needs
+// host.docker.internal) nor track the actual bind port, so the self
+// endpoint is always derived from the live daemon address.
+func bcSelfURL(runtimeBackend, agentName string) string {
+	return bcdAddrForRuntime(runtimeBackend) + "/_mcp/" + agentName + "/sse"
 }
 
 // ── Secrets ─────────────────────────────────────────────────────────────────
@@ -528,6 +534,16 @@ func validateAgentTools(workspacePath, roleName string) []string {
 	defer mcpStore.Close() //nolint:errcheck
 
 	for _, name := range resolved.MCPServers {
+		// The bc server is this daemon — health-check the address agents
+		// will actually be given (derived per runtime), not the store row.
+		// From the daemon's own process the tmux-shaped address applies.
+		if name == "bc" {
+			if err := checkSSEEndpoint(bcdAddrForRuntime("tmux") + "/_mcp/sse"); err != nil {
+				issues = append(issues, fmt.Sprintf("bc MCP endpoint unreachable: %v", err))
+			}
+			continue
+		}
+
 		def, getErr := mcpStore.Get(name)
 		if getErr != nil || def == nil {
 			issues = append(issues, fmt.Sprintf("MCP server %q not defined in store", name))

--- a/pkg/agent/role_setup_test.go
+++ b/pkg/agent/role_setup_test.go
@@ -89,3 +89,31 @@ func TestRewriteDockerURL(t *testing.T) {
 		})
 	}
 }
+
+// TestBcSelfURL verifies the bc MCP endpoint is derived from the live
+// daemon address per runtime — never from the mcp_servers store, whose
+// single static URL can't be right for both tmux and docker at once.
+func TestBcSelfURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		bcdAddr string // BC_BCD_ADDR of the daemon process
+		runtime string
+		agent   string
+		want    string
+	}{
+		{"tmux uses host loopback", "http://127.0.0.1:8080", "tmux", "zeta", "http://127.0.0.1:8080/_mcp/zeta/sse"},
+		{"docker rewrites loopback", "http://127.0.0.1:8080", "docker", "zeta", "http://host.docker.internal:8080/_mcp/zeta/sse"},
+		{"docker rewrites localhost", "http://localhost:9000", "docker", "a1", "http://host.docker.internal:9000/_mcp/a1/sse"},
+		{"empty hostname normalized", "http://:8080", "tmux", "a1", "http://127.0.0.1:8080/_mcp/a1/sse"},
+		{"no env falls back to default port tmux", "", "tmux", "a1", "http://127.0.0.1:9374/_mcp/a1/sse"},
+		{"no env falls back to default port docker", "", "docker", "a1", "http://host.docker.internal:9374/_mcp/a1/sse"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BC_BCD_ADDR", tt.bcdAddr)
+			if got := bcSelfURL(tt.runtime, tt.agent); got != tt.want {
+				t.Errorf("bcSelfURL(%q, %q) = %q, want %q", tt.runtime, tt.agent, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/agent/runtime_test.go
+++ b/pkg/agent/runtime_test.go
@@ -14,12 +14,14 @@ import (
 
 // mockBackend implements runtime.Backend for testing runtime routing.
 type mockBackend struct {
-	sessions map[string]bool
-	lastEnv  map[string]string
-	name     string
-	lastDir  string
-	sent     []string
-	mu       sync.Mutex
+	sessions  map[string]bool
+	lastEnv   map[string]string
+	onCreate  func()
+	createErr error
+	name      string
+	lastDir   string
+	sent      []string
+	mu        sync.Mutex
 }
 
 func newMockBackend(name string) *mockBackend {
@@ -44,6 +46,15 @@ func (m *mockBackend) CreateSessionWithCommand(_ context.Context, name, _, _ str
 	return nil
 }
 func (m *mockBackend) CreateSessionWithEnv(_ context.Context, name, dir, _ string, env map[string]string) error {
+	m.mu.Lock()
+	onCreate, createErr := m.onCreate, m.createErr
+	m.mu.Unlock()
+	if onCreate != nil {
+		onCreate()
+	}
+	if createErr != nil {
+		return createErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.sessions[name] = true

--- a/pkg/doctor/doctor.go
+++ b/pkg/doctor/doctor.go
@@ -522,6 +522,10 @@ func CheckTools(ctx context.Context, ws *workspace.Workspace) CategoryReport {
 		cat.Items = append(cat.Items, item)
 	}
 
+	// Docker agent images — the default runtime is docker, so a provider
+	// without its mycel-agent-<name> image fails at container creation.
+	cat.Items = append(cat.Items, checkAgentImages(ctx)...)
+
 	// Check MCP servers from the workspace tool store (requires a workspace).
 	var toolStore *tool.Store
 	if ws != nil {
@@ -594,6 +598,55 @@ func checkEnvVar(name string) Item {
 		masked = value[:4] + "..." + value[len(value)-4:]
 	}
 	return Item{Name: name, Message: masked, Severity: SeverityOK}
+}
+
+// listDockerImages returns the local docker image refs, or nil when docker
+// is unavailable. Overridable in tests.
+var listDockerImages = func(ctx context.Context) []string {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return nil
+	}
+	out, err := exec.CommandContext(ctx, "docker", "images", "--format", "{{.Repository}}:{{.Tag}}").Output()
+	if err != nil {
+		return nil
+	}
+	return strings.Fields(string(out))
+}
+
+// checkAgentImages warns for each registered provider whose agent image
+// (mycel-agent-<name>, or the legacy bc-agent-<name>) is missing locally.
+// No docker → no items; tmux-only setups shouldn't fail doctor over it.
+func checkAgentImages(ctx context.Context) []Item {
+	images := listDockerImages(ctx)
+	if images == nil {
+		return nil
+	}
+	have := make(map[string]bool, len(images))
+	for _, img := range images {
+		have[img] = true
+	}
+
+	var items []Item
+	for _, p := range provider.ListProviders() {
+		name := p.Name()
+		modern := "mycel-agent-" + name + ":latest"
+		legacy := "bc-agent-" + name + ":latest"
+		item := Item{Name: "image:" + modern}
+		switch {
+		case have[modern]:
+			item.Message = "present"
+			item.Severity = SeverityOK
+		case have[legacy]:
+			item.Message = fmt.Sprintf("using legacy %s", legacy)
+			item.Severity = SeverityOK
+		default:
+			item.Message = "missing — docker agents with this tool cannot start"
+			item.Severity = SeverityWarn
+			item.Fix = "make build-docker-agents  (or make build-docker-agent for claude only)"
+		}
+		items = append(items, item)
+	}
+	return items
 }
 
 // checkBinary checks whether a binary is in PATH.

--- a/pkg/doctor/doctor_test.go
+++ b/pkg/doctor/doctor_test.go
@@ -658,3 +658,47 @@ func TestFix_WorkspaceDir_Creates(t *testing.T) {
 		t.Errorf("agents/ should have been created: %v", err)
 	}
 }
+
+// TestCheckAgentImages covers the docker agent-image doctor check: a
+// provider without its mycel-agent image (or the legacy bc-agent name)
+// warns with a build hint; no docker → no items at all.
+func TestCheckAgentImages(t *testing.T) {
+	ctx := context.Background()
+	orig := listDockerImages
+	t.Cleanup(func() { listDockerImages = orig })
+
+	t.Run("no docker yields no items", func(t *testing.T) {
+		listDockerImages = func(context.Context) []string { return nil }
+		if items := checkAgentImages(ctx); items != nil {
+			t.Errorf("expected no items without docker, got %d", len(items))
+		}
+	})
+
+	t.Run("missing and present images", func(t *testing.T) {
+		listDockerImages = func(context.Context) []string {
+			return []string{"mycel-agent-claude:latest", "bc-agent-gemini:latest", "ubuntu:24.04"}
+		}
+		items := checkAgentImages(ctx)
+		if len(items) == 0 {
+			t.Fatal("expected one item per provider")
+		}
+		bySeverity := map[string]Severity{}
+		for _, it := range items {
+			bySeverity[it.Name] = it.Severity
+		}
+		if got := bySeverity["image:mycel-agent-claude:latest"]; got != SeverityOK {
+			t.Errorf("claude image severity = %v, want OK", got)
+		}
+		if got := bySeverity["image:mycel-agent-gemini:latest"]; got != SeverityOK {
+			t.Errorf("gemini legacy image severity = %v, want OK", got)
+		}
+		if got := bySeverity["image:mycel-agent-cursor:latest"]; got != SeverityWarn {
+			t.Errorf("cursor missing image severity = %v, want Warn", got)
+		}
+		for _, it := range items {
+			if it.Severity == SeverityWarn && it.Fix == "" {
+				t.Errorf("warn item %q has no fix hint", it.Name)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Three fixes

**Transactional create.** A failed docker create left a phantom `starting` row: the periodic tool-health loop snapshots `m.agents` to the store while creation is in flight, so when session creation then failed, the in-memory delete wasn't enough — the persisted row reserved the name forever (DELETE 404s because the manager doesn't know it). Failure paths now call `rollbackCreate`, which removes the in-memory entry AND hard-deletes the store row. Regression test reproduces the exact race via a mid-create SaveAll hook.

**Runtime-aware bc MCP endpoint.** The `mcp_servers` store had `bc → http://host.docker.internal:9374/_mcp/sse` — unreachable from the host (tmux agents got phantom `tool validation` warnings) and pinned to the default port. The bc server is this daemon: its URL is now always derived via `bcdAddrForRuntime` (BC_BCD_ADDR-aware, docker rewrite included) in both `.mcp.json` generation and validation; the store row is no longer consulted for `bc`. Table-driven tests cover tmux/docker × addr shapes.

**Agent-image doctor check.** After the `mycel-agent-*` rename, docker agent creation fails with a raw docker error when images are missing locally. `mycel doctor` now reports per-provider image presence (accepting the legacy `bc-agent-*` name) with a `make build-docker-agents` fix hint. Skips cleanly when docker isn't installed.

Closes #3297
Closes #3296

## Gate
gofmt -s / vet / golangci-lint 0 issues; `go test -race ./pkg/agent/ ./pkg/doctor/` ok; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent creation so failed starts no longer leave behind reserved names or stale “starting” records.
  * Improved MCP setup so the `bc` endpoint is resolved consistently from the live runtime address, and health checks are more reliable.

* **New Features**
  * Added Docker image diagnostics to the health check, showing whether required agent images are present and flagging missing or legacy images with helpful guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->