### PR TITLE
fix(server): shutdown hygiene — gateway Stop closer, tracked notify dispatches

### DIFF
--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rpuneet/mycel/pkg/log"
@@ -37,7 +38,8 @@ type Service struct {
 	store      *Store
 	agents     AgentSender
 	hub        Broadcaster
-	pruneEvery int // prune delivery log when entries exceed this per channel
+	dispatches sync.WaitGroup // in-flight Dispatch goroutines
+	pruneEvery int            // prune delivery log when entries exceed this per channel
 }
 
 // NewService creates a new notify service.
@@ -56,6 +58,23 @@ func NewServiceWithContext(ctx context.Context, store *Store, agents AgentSender
 		agents:     agents,
 		hub:        hub,
 		pruneEvery: 1000,
+	}
+}
+
+// DrainDispatches blocks until every in-flight Dispatch goroutine has
+// finished, or the timeout elapses. Returns false on timeout. Called at
+// shutdown so deliveries don't race store teardown.
+func (s *Service) DrainDispatches(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		s.dispatches.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
 	}
 }
 
@@ -85,7 +104,9 @@ func extractMentions(content string) []string {
 // Dispatch receives a normalized inbound message and delivers it to
 // subscribed agents only. Runs in its own goroutine — never blocks the adapter.
 func (s *Service) Dispatch(channel, platform, sender, senderID, content, messageID string, attachments []Attachment, raw json.RawMessage) {
+	s.dispatches.Add(1)
 	go func() {
+		defer s.dispatches.Done()
 		defer func() {
 			if r := recover(); r != nil {
 				log.Error("notify: dispatch panic", "recover", r)

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -270,3 +270,44 @@ func TestTruncate(t *testing.T) {
 		t.Errorf("truncate('hi', 5) = %q, want 'hi'", got)
 	}
 }
+
+// slowSender blocks each Send until released, so tests can hold a
+// dispatch in flight deterministically.
+type slowSender struct {
+	release chan struct{}
+}
+
+func (s *slowSender) Send(_ context.Context, _, _ string) error {
+	<-s.release
+	return nil
+}
+
+func (s *slowSender) SendAll(_ context.Context, _ string) (int, error) { return 0, nil }
+
+// TestDrainDispatches covers shutdown draining: DrainDispatches must wait
+// for in-flight dispatch goroutines (they used to be fire-and-forget and
+// could hit the store mid-teardown) and report a timeout when one is stuck.
+func TestDrainDispatches(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	sender := &slowSender{release: make(chan struct{})}
+	svc := NewService(store, sender, nil)
+
+	if err := store.Subscribe(ctx, "slack:eng", "eng-01", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("slack:eng", "slack", "user", "U1", "hello", "m1", nil, nil)
+
+	// The dispatch is blocked inside Send — draining must time out.
+	if svc.DrainDispatches(50 * time.Millisecond) {
+		t.Fatal("DrainDispatches returned true while a dispatch was in flight")
+	}
+
+	// Release the sender; draining must now complete.
+	close(sender.release)
+	if !svc.DrainDispatches(5 * time.Second) {
+		t.Fatal("DrainDispatches timed out after the dispatch was released")
+	}
+}

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -335,8 +335,24 @@ func buildServicesFromWS(ctx context.Context, globals *Globals, ws *bcworkspace.
 		}()
 	}
 
+	if notifyService != nil {
+		svcNotify := notifyService
+		addCloser(func() error {
+			if !svcNotify.DrainDispatches(3 * time.Second) {
+				log.Warn("notify: dispatch goroutines still running at shutdown")
+			}
+			return nil
+		})
+	}
+
 	// Gateway manager (Telegram/Discord/Slack adapters).
 	gwManager := buildGatewayManager(svcCtx, ws, notifyService, &wg)
+	if gwManager != nil {
+		// Registered after the notify closer so it runs BEFORE it (closers
+		// run in reverse): adapters stop feeding messages, then in-flight
+		// dispatches drain, then stores close.
+		addCloser(func() error { gwManager.Stop(context.Background()); return nil })
+	}
 
 	// Provider registry is global but we keep it referenced for parity.
 	_ = provider.DefaultRegistry


### PR DESCRIPTION
Audit outcome for the pre-0.3.10 reliability wave (issue #3244): two of its four findings were still real on main; this PR fixes both. The other two — maybeRalphLoop (removed with the Ralph loop) and swallowed adapter Start errors (now logged in buildGatewayManager) — are already gone.

- **Gateway teardown**: `Manager.Stop` was never invoked at shutdown — adapters only died with the context. It's now registered as a closer, ordered to run before the notify drain and store closers (closers run in reverse), so platform connections stop feeding messages first.
- **Notify dispatch tracking**: `Service.Dispatch` goroutines were fire-and-forget; at shutdown they could race store teardown. They're now WaitGroup-tracked, and `DrainDispatches(3s)` waits for in-flight deliveries before stores close. Deterministic test with a blocking sender covers both the timeout and drained paths.

Closes #3244

Related audit (closed directly with evidence, no code needed): #3241, #3242, #3243 — all mooted by the single-DB consolidation.

## Gate
gofmt/vet/golangci-lint 0 issues; `go test -race ./pkg/notify/ ./server/` ok; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)