### PR TITLE
feat(agent): flat worktree layout — ~/.mycel/worktrees + ~/.mycel/agents

### DIFF
--- a/docs/explanation/agents.md
+++ b/docs/explanation/agents.md
@@ -78,10 +78,17 @@ Communication: `docker exec ... tmux send-keys`.
 
 mycel creates and manages git worktrees for ALL providers uniformly. No provider uses its own worktree flag (avoids nesting).
 
-Worktrees live under the per-repo runtime directory at
-`~/.mycel/workspaces/<id>/agents/<name>/bc-<repo>-<agent>/`, checked out
-from the agent's repo. They are created with `--detach`, so the agent
-checks out a detached HEAD and no branch is created for it.
+Worktrees live at `~/.mycel/worktrees/<agent-name>/`, checked out from
+the agent's repo. Agent state (Claude config, session logs) lives
+separately at `~/.mycel/agents/<agent-name>/`. Agent names are globally
+unique (database primary key), so flat name-keyed directories are safe.
+Worktrees are created with `--detach`, so the agent checks out a
+detached HEAD and no branch is created for it.
+
+Agents created under the previous nested layout
+(`~/.mycel/workspaces/<id>/agents/<name>/bc-<repo>-<agent>/`) keep
+working from their stored worktree path until migrated with
+`scripts/migrate-worktree-layout.sh`.
 
 ### Flow
 
@@ -91,7 +98,7 @@ sequenceDiagram
     participant Git as git
     participant RT as Runtime
 
-    Svc->>Git: git worktree add --detach <state-dir>/agents/<name>/bc-<repo>-<name>
+    Svc->>Git: git worktree add --detach ~/.mycel/worktrees/<name>
     Svc->>Svc: Write role files into worktree/.claude/
     Svc->>RT: cd <worktree> && <provider-command>
 ```

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -65,7 +65,8 @@ All state lives outside your repos, under `~/.mycel/`:
 - `mycel.db` — the single global database (agents, roles, events,
   notifications, cron)
 - `costs.db` — cost ledger with per-repo attribution
-- per-agent directories holding each agent's files and git worktree
+- `worktrees/<agent-name>/` — each agent's git worktree
+- `agents/<agent-name>/` — each agent's state (Claude config, logs)
 
 Each agent is bound to a repo and works in its own git worktree checked
 out from that repo — your working copy stays pristine.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -617,8 +617,9 @@ func NewManager(stateDir string) *Manager {
 // Session names will be unique per workspace to avoid collisions.
 //
 // stateDir is the per-workspace runtime directory (pre-M11: <project>/.bc/;
-// M11+: ~/.mycel/workspaces/<id>/). Agents are written to <stateDir>/agents/
-// and their worktrees at <stateDir>/agents/<name>/bc-<ws>-<name>/.
+// M11+: ~/.mycel/workspaces/<id>/). New agents use the flat layout:
+// worktrees at <MycelHome>/worktrees/<name>/ and agent state at
+// <MycelHome>/agents/<name>/.
 func NewWorkspaceManager(stateDir, workspacePath string) *Manager {
 	cmd, tool := defaultAgentCmd()
 	tmuxBe := runtime.NewTmuxBackend(tmux.NewWorkspaceManager(DefaultSessionPrefix, workspacePath))
@@ -633,7 +634,7 @@ func NewWorkspaceManager(stateDir, workspacePath string) *Manager {
 		defaultTool:      tool,
 		workspacePath:    workspacePath,
 		maxLogBytes:      DefaultMaxLogBytes,
-		worktreeMgr:      worktree.NewManagerWithDataDir(workspacePath, parentOfAgentsDir(stateDir)),
+		worktreeMgr:      flatWorktreeManager(workspacePath, stateDir),
 	}
 }
 
@@ -657,8 +658,25 @@ func NewWorkspaceManagerWithRuntime(stateDir, workspacePath string, rt runtime.B
 		defaultTool:      tool,
 		workspacePath:    workspacePath,
 		maxLogBytes:      DefaultMaxLogBytes,
-		worktreeMgr:      worktree.NewManagerWithDataDir(workspacePath, parentOfAgentsDir(stateDir)),
+		worktreeMgr:      flatWorktreeManager(workspacePath, stateDir),
 	}
+}
+
+// flatWorktreeManager builds a worktree manager for the flat layout:
+// worktrees at <MycelHome>/worktrees/<name>/ and agent state (claude/,
+// claude.json, logs/) at <MycelHome>/agents/<name>/. Agent names are
+// globally unique (mycel.db primary key), so flat name-keyed dirs are
+// safe. Falls back to the nested per-workspace layout only when the
+// mycel home cannot be resolved.
+func flatWorktreeManager(repoRoot, stateDir string) *worktree.Manager {
+	home, err := workspace.MycelHome()
+	if err != nil {
+		log.Warn("cannot resolve mycel home — using nested worktree layout", "error", err)
+		return worktree.NewManagerWithDataDir(repoRoot, parentOfAgentsDir(stateDir))
+	}
+	return worktree.NewFlatManager(repoRoot,
+		filepath.Join(home, "worktrees"),
+		filepath.Join(home, "agents"))
 }
 
 // parentOfAgentsDir returns the workspace runtime data dir given an agents
@@ -701,7 +719,40 @@ func (m *Manager) worktreeManagerFor(repo string) *worktree.Manager {
 		log.Warn("agent repo is not a git repository — using boot repo for worktree", "repo", repo)
 		return m.worktreeMgr
 	}
-	return worktree.NewManagerWithDataDir(repo, parentOfAgentsDir(m.stateDir))
+	// Cross-repo managers share the same flat dirs — only repoRoot differs.
+	return flatWorktreeManager(repo, m.stateDir)
+}
+
+// seedHostClaudeTrust pre-trusts an agent's worktree in the claude.json a
+// host (tmux) claude agent will read — $HOME/.claude.json — so fresh
+// agents don't hang at Claude Code's interactive "trust this folder"
+// prompt. Docker agents are seeded separately with the container-side
+// path by the container backend.
+func seedHostClaudeTrust(tool, worktreeDir string) {
+	if tool != "claude" || worktreeDir == "" {
+		return
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Warn("cannot resolve home dir for claude trust seeding", "error", err)
+		return
+	}
+	if err := container.SeedClaudeTrust(filepath.Join(home, ".claude.json"), worktreeDir); err != nil {
+		log.Warn("failed to seed claude trust", "worktree", worktreeDir, "error", err)
+	}
+}
+
+// storedWorktreeExists reports whether an existing agent's worktree is
+// present on disk. The stored worktreeDir (DB column) wins — agents
+// created under older layouts keep working from their old paths until
+// migrated. Only when no dir is recorded does the manager-computed path
+// serve as fallback.
+func storedWorktreeExists(worktreeDir string, wtMgr *worktree.Manager, name string) bool {
+	if worktreeDir != "" {
+		_, err := os.Stat(worktreeDir)
+		return err == nil
+	}
+	return wtMgr.Exists(name)
 }
 
 // workspaceStateDir returns the best-guess workspace runtime dir for a
@@ -1074,9 +1125,12 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	isRealSessionID := len(sessionID) == 36 && sessionID[8] == '-'
 	resume := isRealSessionID
 
-	// Check if existing worktree can be reused for resume (tmux only)
+	// Check if existing worktree can be reused for resume (tmux only).
+	// Existing agents keep working from their stored WorktreeDir (which
+	// may predate the current flat layout) — only fall back to the
+	// manager-computed path when no dir is recorded.
 	agentRuntime := existing.RuntimeBackend
-	if wtMgr.Exists(name) && agentRuntime == "tmux" {
+	if storedWorktreeExists(existing.WorktreeDir, wtMgr, name) && agentRuntime == "tmux" {
 		// Worktree exists — check for active session conflict
 		for beName, be := range m.backends {
 			if be.HasSession(ctx, name) {
@@ -1113,13 +1167,19 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 		}
 	}
 
+	// Worktree name follows the stored dir for existing agents so the
+	// in-container tmux session name stays stable across layouts.
+	worktreeName := wtMgr.Name(name)
+	if existing.WorktreeDir != "" {
+		worktreeName = filepath.Base(existing.WorktreeDir)
+	}
 	env := map[string]string{
 		"BC_AGENT_ID":      name,
 		"BC_AGENT_ROLE":    string(existing.Role),
 		"BC_WORKSPACE":     wsPath,
 		"BC_AGENT_RUNTIME": agentRuntime,
 		"BC_BCD_ADDR":      bcdAddrForRuntime(agentRuntime),
-		"BC_WORKTREE_NAME": wtMgr.Name(name),
+		"BC_WORKTREE_NAME": worktreeName,
 	}
 	if toolName != "" {
 		env["BC_AGENT_TOOL"] = toolName
@@ -1144,8 +1204,11 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 
 	// Ensure worktree exists and is valid (may have been cleaned up, moved,
 	// or corrupted by runtime changes like Docker→localhost migration).
+	// The stored WorktreeDir is authoritative — never recompute it from
+	// the manager for an existing agent (pre-migration agents live at
+	// older paths). The stat checks below decide whether it is usable.
 	wtDir := existing.WorktreeDir
-	needsRecreate := wtDir == "" || !wtMgr.Exists(name)
+	needsRecreate := wtDir == ""
 
 	// Also check that the worktree has a valid .git reference
 	if !needsRecreate && wtDir != "" {
@@ -1178,6 +1241,12 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 		}
 		existing.WorktreeDir = wtDir
 		log.Info("worktree recreated", "agent", name, "path", wtDir)
+	}
+
+	// Pre-trust the worktree so a restarted tmux claude agent doesn't
+	// hang at the interactive trust prompt.
+	if agentRuntime == "tmux" {
+		seedHostClaudeTrust(toolName, wtDir)
 	}
 
 	// Write hook settings and role files to worktree (regenerate on every start
@@ -1385,6 +1454,13 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 		log.Warn("failed to ensure Claude dir", "agent", name, "error", claudeErr)
 	}
 
+	// Pre-trust the worktree so a fresh tmux claude agent doesn't hang
+	// at the interactive trust prompt (docker agents are seeded with the
+	// container-side path by the container backend).
+	if agentRuntime == "tmux" {
+		seedHostClaudeTrust(effectiveTool, wtDir)
+	}
+
 	// Write hook settings to the worktree
 	if err := WriteWorkspaceHookSettings(wtDir); err != nil {
 		log.Warn("failed to write hook settings", "dir", wtDir, "error", err)
@@ -1444,18 +1520,26 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 
 // setupLogPipe creates the logs directory and starts pipe-pane for the agent.
 // Returns the log file path.
-func (m *Manager) setupLogPipe(ctx context.Context, name, workspace string) string {
+func (m *Manager) setupLogPipe(ctx context.Context, name, wsPath string) string {
 	// The agent name becomes a filename below — never let a crafted
 	// name escape the logs directory.
 	if !IsValidAgentName(name) {
 		log.Warn("refusing to pipe logs for unsafe agent name", "agent", name)
 		return ""
 	}
-	base := workspaceStateDir(workspace)
-	if base == "" {
-		return ""
+	// Flat layout: logs live with the rest of the agent's state at
+	// <MycelHome>/agents/<name>/logs/. Fall back to the per-workspace
+	// logs dir only when the mycel home cannot be resolved.
+	var logsDir string
+	if home, err := workspace.MycelHome(); err == nil {
+		logsDir = filepath.Join(home, "agents", name, "logs")
+	} else {
+		base := workspaceStateDir(wsPath)
+		if base == "" {
+			return ""
+		}
+		logsDir = filepath.Join(base, "logs")
 	}
-	logsDir := filepath.Join(base, "logs")
 	if err := os.MkdirAll(logsDir, 0750); err != nil {
 		log.Warn("failed to create logs dir", "error", err)
 		return ""
@@ -1875,8 +1959,15 @@ func (m *Manager) DeleteAgentWithOptions(ctx context.Context, name string, opts 
 	}
 
 	// 4. Remove git worktree — via the repo the agent is bound to, so
-	// cross-repo agents unregister from THEIR repo's worktree list.
-	if err := m.worktreeManagerFor(agent.Repo).Remove(ctx, name); err != nil {
+	// cross-repo agents unregister from THEIR repo's worktree list. The
+	// stored WorktreeDir wins over the manager-computed path: agents
+	// created under older layouts live at their old dirs until migrated.
+	wtMgr := m.worktreeManagerFor(agent.Repo)
+	if agent.WorktreeDir != "" {
+		if err := wtMgr.RemoveAt(ctx, name, agent.WorktreeDir); err != nil {
+			log.Warn("failed to remove worktree", "agent", name, "error", err)
+		}
+	} else if err := wtMgr.Remove(ctx, name); err != nil {
 		log.Warn("failed to remove worktree", "agent", name, "error", err)
 	}
 
@@ -1897,12 +1988,31 @@ func (m *Manager) DeleteAgentWithOptions(ctx context.Context, name string, opts 
 		log.Warn("delete: failed to remove agent state dir", "agent", name, "path", agentStateDir, "error", err)
 	}
 
+	// 7. Remove flat-layout dirs: <MycelHome>/agents/<name>/ (state) and
+	// <MycelHome>/worktrees/<name>/ (worktree leftovers — git-level
+	// removal already happened in step 4).
+	if home, homeErr := workspace.MycelHome(); homeErr == nil {
+		for _, dir := range []string{
+			filepath.Join(home, "agents", name),
+			filepath.Join(home, "worktrees", name),
+		} {
+			dir = filepath.Clean(dir)
+			if strings.Contains(dir, "..") {
+				log.Warn("delete: refusing unsafe flat state path", "agent", name, "path", dir)
+				continue
+			}
+			if err := os.RemoveAll(dir); err != nil {
+				log.Warn("delete: failed to remove flat agent dir", "agent", name, "path", dir, "error", err)
+			}
+		}
+	}
+
 	agentLock.Unlock()
 
 	// Phase 3: global lock — update maps, orphan children, persist
 	m.mu.Lock()
 
-	// 7. Update children's ParentID to "" (orphan them cleanly)
+	// 8. Update children's ParentID to "" (orphan them cleanly)
 	for _, childName := range agent.Children {
 		if child, ok := m.agents[childName]; ok {
 			child.ParentID = ""
@@ -1910,10 +2020,10 @@ func (m *Manager) DeleteAgentWithOptions(ctx context.Context, name string, opts 
 		}
 	}
 
-	// 8. Remove from parent's children list
+	// 9. Remove from parent's children list
 	m.removeFromParent(name)
 
-	// 9. Soft-delete in SQLite first (set deleted_at) so the agent won't be
+	// 10. Soft-delete in SQLite first (set deleted_at) so the agent won't be
 	// resurrected by LoadAll even if bcd crashes before the hard delete.
 	if m.store != nil {
 		if err := m.store.SoftDelete(ctx, name); err != nil {
@@ -1921,7 +2031,7 @@ func (m *Manager) DeleteAgentWithOptions(ctx context.Context, name string, opts 
 		}
 	}
 
-	// 10. Delete from state map and clean up per-agent lock
+	// 11. Delete from state map and clean up per-agent lock
 	delete(m.agents, name)
 	delete(m.agentLocks, name)
 
@@ -1929,7 +2039,7 @@ func (m *Manager) DeleteAgentWithOptions(ctx context.Context, name string, opts 
 		log.Warn("delete: failed to save state", "agent", name, "error", err)
 	}
 
-	// 11. Hard-delete the row from SQLite. The soft-delete above already
+	// 12. Hard-delete the row from SQLite. The soft-delete above already
 	// prevents resurrection; this removes the row entirely for cleanliness.
 	if m.store != nil {
 		if err := m.store.Delete(ctx, name); err != nil {
@@ -1982,7 +2092,12 @@ func (m *Manager) RenameAgent(ctx context.Context, oldName, newName string) erro
 	if strings.Contains(wsPath, "..") || strings.Contains(stateDir, "..") {
 		return fmt.Errorf("rename: unsafe workspace paths")
 	}
-	oldPath := m.worktreeMgr.Path(oldName)
+	// The stored WorktreeDir wins for the source — pre-migration agents
+	// live at older layouts; the destination uses the current layout.
+	oldPath := filepath.Clean(agent.WorktreeDir)
+	if agent.WorktreeDir == "" {
+		oldPath = m.worktreeMgr.Path(oldName)
+	}
 	newPath := m.worktreeMgr.Path(newName)
 	if strings.Contains(oldPath, "..") || strings.Contains(newPath, "..") {
 		return fmt.Errorf("rename: unsafe worktree paths")
@@ -2032,7 +2147,7 @@ func (m *Manager) RenameAgent(ctx context.Context, oldName, newName string) erro
 		}
 	}
 
-	// Rename log file
+	// Rename log file (legacy shared logs dir)
 	oldLogDir := filepath.Join(workspaceStateDir(wsPath), "logs")
 	oldLogFile := filepath.Join(oldLogDir, oldName+".log")
 	newLogFile := filepath.Join(oldLogDir, newName+".log")
@@ -2040,11 +2155,28 @@ func (m *Manager) RenameAgent(ctx context.Context, oldName, newName string) erro
 		log.Warn("rename: failed to rename log file", "error", err)
 	}
 
-	// Rename agent state directory
+	// Rename agent state directory (legacy nested layout)
 	oldStateDir := filepath.Join(stateDir, "agents", oldName)
 	newStateDir := filepath.Join(stateDir, "agents", newName)
 	if err := os.Rename(oldStateDir, newStateDir); err != nil && !os.IsNotExist(err) {
 		log.Warn("rename: failed to rename state dir", "error", err)
+	}
+
+	// Rename flat-layout state dir (<MycelHome>/agents/<name>/) and the
+	// log file inside it, tracking the agent's recorded log path.
+	var flatOldLog, flatNewLog string
+	if home, homeErr := workspace.MycelHome(); homeErr == nil {
+		oldFlat := filepath.Join(home, "agents", oldName)
+		newFlat := filepath.Join(home, "agents", newName)
+		if err := os.Rename(oldFlat, newFlat); err != nil && !os.IsNotExist(err) {
+			log.Warn("rename: failed to rename flat state dir", "error", err)
+		}
+		flatOldLog = filepath.Join(oldFlat, "logs", oldName+".log")
+		flatNewLog = filepath.Join(newFlat, "logs", newName+".log")
+		movedLog := filepath.Join(newFlat, "logs", oldName+".log")
+		if err := os.Rename(movedLog, flatNewLog); err != nil && !os.IsNotExist(err) {
+			log.Warn("rename: failed to rename flat log file", "error", err)
+		}
 	}
 
 	agentLock.Unlock()
@@ -2063,6 +2195,8 @@ func (m *Manager) RenameAgent(ctx context.Context, oldName, newName string) erro
 	}
 	if agent.LogFile == oldLogFile {
 		agent.LogFile = newLogFile
+	} else if flatOldLog != "" && agent.LogFile == flatOldLog {
+		agent.LogFile = flatNewLog
 	}
 
 	// Update maps

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3643,9 +3643,14 @@ func TestWorktreeManagerFor_CreatesWorktreeFromAgentRepo(t *testing.T) {
 		t.Errorf("worktree HEAD = %s, want agent repo HEAD %s", got, want)
 	}
 
-	// The worktree still lands in the shared data-dir layout.
-	if !strings.HasPrefix(wtDir, stateDir) {
-		t.Errorf("worktree dir %q not under state dir %q", wtDir, stateDir)
+	// The worktree lands in the shared flat layout under the mycel home,
+	// keyed by bare agent name.
+	home, homeErr := workspace.MycelHome()
+	if homeErr != nil {
+		t.Fatalf("MycelHome: %v", homeErr)
+	}
+	if want := filepath.Join(home, "worktrees", "cross-repo-agent"); wtDir != want {
+		t.Errorf("worktree dir = %q, want %q", wtDir, want)
 	}
 }
 
@@ -3827,5 +3832,61 @@ func TestCreateAgent_FailedCreateRollsBackStoreRow(t *testing.T) {
 	docker.onCreate = nil
 	if err := m.RegisterStopped(&Agent{Name: "doomed", Role: Role("engineer"), Workspace: boot}); err != nil {
 		t.Fatalf("name not reusable after failed create: %v", err)
+	}
+}
+
+// Tmux runtime: trust is seeded into $HOME/.claude.json keyed by the
+// host-side worktree path.
+func TestSeedHostClaudeTrust_TmuxHostPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	wt := "/home/user/.mycel/worktrees/eng-01"
+	seedHostClaudeTrust("claude", wt)
+
+	data, err := os.ReadFile(filepath.Join(home, ".claude.json")) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("claude.json not written: %v", err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(data, &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	projects, _ := root["projects"].(map[string]any)
+	entry, _ := projects[wt].(map[string]any)
+	if entry == nil {
+		t.Fatalf("worktree %q not in projects: %v", wt, root)
+	}
+	if accepted, _ := entry["hasTrustDialogAccepted"].(bool); !accepted {
+		t.Error("hasTrustDialogAccepted not true")
+	}
+}
+
+func TestSeedHostClaudeTrust_NonClaudeToolIsNoop(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	seedHostClaudeTrust("gemini", "/some/worktree")
+
+	if _, err := os.Stat(filepath.Join(home, ".claude.json")); !os.IsNotExist(err) {
+		t.Error("claude.json written for a non-claude tool")
+	}
+}
+
+// The flat worktree manager must root worktrees and state under the
+// mycel home, not the per-workspace state dir.
+func TestFlatWorktreeManagerLayout(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("MYCEL_HOME", home)
+
+	m := flatWorktreeManager("/repo", "/unused/agents")
+	if got, want := m.Path("eng-01"), filepath.Join(home, "worktrees", "eng-01"); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+	if got, want := m.ClaudeDir("eng-01"), filepath.Join(home, "agents", "eng-01", "claude"); got != want {
+		t.Errorf("ClaudeDir() = %q, want %q", got, want)
+	}
+	if got, want := m.Name("eng-01"), "eng-01"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
 	}
 }

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -149,25 +149,36 @@ func (b *Backend) containerName(name string) string {
 var validContainerAgentName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // containerAgentDir returns the agent's state directory inside the
-// container (bcd side). Prefers the M11 global runtime dir; falls back
-// to the legacy <root>/.bc/agents/<name>/ for pre-M11 workspaces.
+// container (bcd side). The flat layout at <MycelHome>/agents/<name>/
+// is canonical; agents whose state still lives at an older location
+// (nested per-workspace dir or the legacy <root>/.bc/ sidecar) keep
+// using it until migrated.
 func (b *Backend) containerAgentDir(agentName string) string {
 	if !validContainerAgentName.MatchString(agentName) {
 		return ""
 	}
+	var flat string
+	if home, err := workspace.MycelHome(); err == nil {
+		flat = filepath.Join(home, "agents", agentName)
+		if _, statErr := os.Stat(flat); statErr == nil {
+			return flat
+		}
+	}
+	// Existing agents may still live in older layouts.
 	if globalDir, err := workspace.GlobalStateDir(b.workspacePath); err == nil {
-		candidate := filepath.Join(globalDir, "agents", agentName)
-		if _, statErr := os.Stat(candidate); statErr == nil {
-			return candidate
+		nested := filepath.Join(globalDir, "agents", agentName)
+		if _, statErr := os.Stat(nested); statErr == nil {
+			return nested
 		}
-		// Global dir is the canonical location; use it even if empty.
-		legacy := filepath.Join(b.workspacePath, ".bc", "agents", agentName)
-		if _, legacyErr := os.Stat(legacy); legacyErr != nil {
-			return candidate
-		}
+	}
+	legacy := filepath.Join(b.workspacePath, ".bc", "agents", agentName)
+	if _, statErr := os.Stat(legacy); statErr == nil {
 		return legacy
 	}
-	return filepath.Join(b.workspacePath, ".bc", "agents", agentName)
+	if flat != "" {
+		return flat // canonical location for fresh agents
+	}
+	return legacy
 }
 
 // hostAgentDir returns the host path that maps to the agent's state
@@ -431,10 +442,11 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 	// Mount 2: Persistent Claude state (~/.claude/ dir)
 	// Use local (container) path for mkdir, host path for -v mount.
 	//
-	// M11: agent state lives at <DataDir>/agents/<name>/ where DataDir
-	// is ~/.mycel/workspaces/<id>/. The host DataDir may differ from the
-	// container DataDir when bcd runs in Docker-in-Docker; honor
-	// BC_HOST_BC_HOME (if set) for the host-side BC_HOME.
+	// Agent state lives at <MycelHome>/agents/<name>/ (flat layout);
+	// containerAgentDir keeps pre-migration agents on their older
+	// per-workspace dirs. The host path may differ when bcd runs in
+	// Docker-in-Docker; honor BC_HOST_BC_HOME (if set) for the
+	// host-side mycel home.
 	localAgentDir := b.containerAgentDir(name)
 	hostAgentDir := b.hostAgentDir(name, hostRoot)
 	if err := os.MkdirAll(filepath.Join(localAgentDir, "claude"), 0750); err != nil {
@@ -447,6 +459,11 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 	localClaudeJSON := filepath.Join(localAgentDir, "claude.json")
 	if _, statErr := os.Stat(localClaudeJSON); os.IsNotExist(statErr) {
 		_ = os.WriteFile(localClaudeJSON, []byte("{}"), 0600) //nolint:errcheck // best-effort
+	}
+	// Pre-trust the working directory (container-side path) so Claude
+	// Code never hangs at the interactive "trust this folder" prompt.
+	if err := SeedClaudeTrust(localClaudeJSON, containerWorkdir); err != nil {
+		log.Warn("failed to seed claude trust", "agent", name, "error", err)
 	}
 	args = append(args, "-v", filepath.Join(hostAgentDir, "claude.json")+":/home/agent/.claude.json")
 

--- a/pkg/container/settings.go
+++ b/pkg/container/settings.go
@@ -54,3 +54,52 @@ func SeedClaudeSettings(volumeDir string) error {
 
 	return os.WriteFile(settingsPath, data, 0600)
 }
+
+// SeedClaudeTrust marks projectPath as trusted in the claude.json at
+// claudeJSONPath so Claude Code skips the interactive "trust this folder"
+// prompt that hangs headless agents. It merges
+//
+//	{"projects": {"<projectPath>": {"hasTrustDialogAccepted": true}}}
+//
+// into the file — creating it when missing and never clobbering other
+// keys (auth, oauthAccount, other projects). For Docker agents the
+// projectPath must be the container-side path (/workspace); for tmux
+// agents it is the host worktree path.
+func SeedClaudeTrust(claudeJSONPath, projectPath string) error {
+	claudeJSONPath = filepath.Clean(claudeJSONPath)
+	if claudeJSONPath == "" || claudeJSONPath == "." || strings.Contains(claudeJSONPath, "..") {
+		return fmt.Errorf("invalid claude.json path %q", claudeJSONPath)
+	}
+	if projectPath == "" {
+		return fmt.Errorf("project path is required")
+	}
+
+	root := map[string]any{}
+	if data, err := os.ReadFile(claudeJSONPath); err == nil { //nolint:gosec // trusted path
+		_ = json.Unmarshal(data, &root)
+	}
+
+	projects, _ := root["projects"].(map[string]any)
+	if projects == nil {
+		projects = map[string]any{}
+	}
+	entry, _ := projects[projectPath].(map[string]any)
+	if entry == nil {
+		entry = map[string]any{}
+	}
+	if accepted, _ := entry["hasTrustDialogAccepted"].(bool); accepted {
+		return nil // already trusted — leave the file untouched
+	}
+	entry["hasTrustDialogAccepted"] = true
+	projects[projectPath] = entry
+	root["projects"] = projects
+
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(claudeJSONPath), 0750); err != nil {
+		return err
+	}
+	return os.WriteFile(claudeJSONPath, data, 0600)
+}

--- a/pkg/container/settings_test.go
+++ b/pkg/container/settings_test.go
@@ -63,3 +63,106 @@ func TestSeedClaudeSettings_PreservesExisting(t *testing.T) {
 		t.Errorf("custom = %v, want %q (should preserve user value)", settings["custom"], "value")
 	}
 }
+
+func readClaudeJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("read claude.json: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal claude.json: %v", err)
+	}
+	return m
+}
+
+func trustedEntry(t *testing.T, root map[string]any, project string) map[string]any {
+	t.Helper()
+	projects, ok := root["projects"].(map[string]any)
+	if !ok {
+		t.Fatalf("projects key missing: %v", root)
+	}
+	entry, ok := projects[project].(map[string]any)
+	if !ok {
+		t.Fatalf("project %q missing: %v", project, projects)
+	}
+	return entry
+}
+
+// Docker runtime: the trusted key must be the container-side path.
+func TestSeedClaudeTrust_CreatesFileWithContainerPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claude.json")
+
+	if err := SeedClaudeTrust(path, "/workspace"); err != nil {
+		t.Fatalf("SeedClaudeTrust() error = %v", err)
+	}
+
+	entry := trustedEntry(t, readClaudeJSON(t, path), "/workspace")
+	if accepted, _ := entry["hasTrustDialogAccepted"].(bool); !accepted {
+		t.Error("hasTrustDialogAccepted not true for /workspace")
+	}
+}
+
+// Tmux runtime: the trusted key is the host worktree path, and existing
+// keys (auth, other projects) must survive the merge.
+func TestSeedClaudeTrust_MergesWithoutClobbering(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claude.json")
+	seed := `{
+		"oauthAccount": {"email": "user@example.com"},
+		"projects": {
+			"/existing": {"hasTrustDialogAccepted": true, "history": ["x"]}
+		}
+	}`
+	if err := os.WriteFile(path, []byte(seed), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	worktree := "/home/user/.mycel/worktrees/eng-01"
+	if err := SeedClaudeTrust(path, worktree); err != nil {
+		t.Fatalf("SeedClaudeTrust() error = %v", err)
+	}
+
+	root := readClaudeJSON(t, path)
+	if _, ok := root["oauthAccount"].(map[string]any); !ok {
+		t.Error("oauthAccount was clobbered")
+	}
+	existing := trustedEntry(t, root, "/existing")
+	if _, ok := existing["history"]; !ok {
+		t.Error("existing project entry was clobbered")
+	}
+	entry := trustedEntry(t, root, worktree)
+	if accepted, _ := entry["hasTrustDialogAccepted"].(bool); !accepted {
+		t.Errorf("hasTrustDialogAccepted not true for %q", worktree)
+	}
+}
+
+func TestSeedClaudeTrust_IdempotentWhenAlreadyTrusted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claude.json")
+	seed := `{"projects": {"/workspace": {"hasTrustDialogAccepted": true}}, "custom": 1}`
+	if err := os.WriteFile(path, []byte(seed), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SeedClaudeTrust(path, "/workspace"); err != nil {
+		t.Fatalf("SeedClaudeTrust() error = %v", err)
+	}
+
+	// Already trusted — the file must be left byte-for-byte untouched.
+	data, err := os.ReadFile(path) //nolint:gosec // test path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != seed {
+		t.Errorf("file rewritten despite already-trusted entry: %s", data)
+	}
+}
+
+func TestSeedClaudeTrust_RejectsInvalidInputs(t *testing.T) {
+	if err := SeedClaudeTrust("", "/workspace"); err == nil {
+		t.Error("accepted empty claude.json path")
+	}
+	if err := SeedClaudeTrust(filepath.Join(t.TempDir(), "claude.json"), ""); err == nil {
+		t.Error("accepted empty project path")
+	}
+}

--- a/pkg/worktree/manager.go
+++ b/pkg/worktree/manager.go
@@ -1,8 +1,14 @@
 // Package worktree manages git worktree lifecycle for agent isolation.
-// Each agent gets its own worktree at <DataDir>/agents/<name>/bc-<ws>-<name>/.
-// Before M11 the worktrees lived under <repoRoot>/.bc/agents/...; after
-// M11 they move to ~/.mycel/workspaces/<id>/agents/... so the project
-// directory stays a pristine git repo.
+//
+// Two layouts are supported:
+//
+//   - Flat (current): worktrees at <worktreesDir>/<name>/ and Claude state
+//     at <stateDir>/<name>/claude/. Agent names are globally unique (DB
+//     primary key), so flat name-keyed directories are safe. The daemon
+//     uses ~/.mycel/worktrees/ and ~/.mycel/agents/ for these.
+//   - Nested (legacy): worktrees at <dataDir>/agents/<name>/bc-<ws>-<name>/
+//     with Claude state alongside at <dataDir>/agents/<name>/claude/.
+//     Kept so existing agents and tests keep working from their old paths.
 package worktree
 
 import (
@@ -11,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/rpuneet/mycel/pkg/log"
@@ -19,9 +26,12 @@ import (
 // Manager handles git worktree lifecycle for agent isolation.
 type Manager struct {
 	repoRoot     string
-	agentsDir    string
+	agentsDir    string // nested layout: worktrees under <agentsDir>/<name>/
+	worktreesDir string // flat layout: worktrees at <worktreesDir>/<name>/
+	stateDir     string // flat layout: Claude state at <stateDir>/<name>/claude/
 	hostBaseName string
 	mu           sync.Mutex
+	flat         bool
 }
 
 // NewManager creates a worktree manager whose worktrees live under the
@@ -56,15 +66,37 @@ func NewManagerWithDataDir(repoRoot, dataDir string) *Manager {
 	}
 }
 
-// Name returns the worktree name for an agent: bc-<hostBaseName>-<agentName>.
+// NewFlatManager creates a worktree manager using the flat layout:
+// worktrees at <worktreesDir>/<agent>/ and Claude state at
+// <stateDir>/<agent>/claude/. Agent names are globally unique, so the
+// directories are keyed by bare agent name. This is the layout the
+// daemon uses: worktreesDir = ~/.mycel/worktrees, stateDir =
+// ~/.mycel/agents.
+func NewFlatManager(repoRoot, worktreesDir, stateDir string) *Manager {
+	return &Manager{
+		repoRoot:     repoRoot,
+		worktreesDir: worktreesDir,
+		stateDir:     stateDir,
+		flat:         true,
+	}
+}
+
+// Name returns the worktree name for an agent. Flat layout uses the bare
+// agent name; the nested legacy layout uses bc-<hostBaseName>-<agentName>.
 func (m *Manager) Name(agentName string) string {
+	if m.flat {
+		return agentName
+	}
 	return fmt.Sprintf("bc-%s-%s", m.hostBaseName, agentName)
 }
 
-// Path returns the filesystem path for an agent's worktree.
-// The directory is named bc-<workspace>-<agent> so git's internal
-// worktree name matches the naming convention.
+// Path returns the filesystem path for an agent's worktree:
+// <worktreesDir>/<agent> in the flat layout, or the nested
+// <agentsDir>/<agent>/bc-<ws>-<agent> in the legacy layout.
 func (m *Manager) Path(agentName string) string {
+	if m.flat {
+		return filepath.Join(m.worktreesDir, agentName)
+	}
 	return filepath.Join(m.agentsDir, agentName, m.Name(agentName))
 }
 
@@ -130,11 +162,28 @@ func (m *Manager) Remove(ctx context.Context, agentName string) error {
 	if !filepath.IsLocal(agentName) {
 		return fmt.Errorf("invalid agent name %q", agentName)
 	}
+	return m.removeAt(ctx, agentName, m.Path(agentName))
+}
 
+// RemoveAt removes the git worktree at an explicit path — used for agents
+// whose stored WorktreeDir predates the current layout, so deletion targets
+// the directory the agent actually used instead of a recomputed path.
+func (m *Manager) RemoveAt(ctx context.Context, agentName, path string) error {
+	// ".." is checked on the raw value so traversal cannot be smuggled
+	// past filepath.Clean.
+	if strings.Contains(path, "..") {
+		return fmt.Errorf("invalid worktree path %q", path)
+	}
+	path = filepath.Clean(path)
+	if !filepath.IsAbs(path) {
+		return fmt.Errorf("invalid worktree path %q", path)
+	}
+	return m.removeAt(ctx, agentName, path)
+}
+
+func (m *Manager) removeAt(ctx context.Context, agentName, path string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-
-	path := m.Path(agentName)
 
 	//nolint:gosec // trusted paths
 	rm := exec.CommandContext(ctx, "git", "-C", m.repoRoot, "worktree", "remove", "--force", path)
@@ -181,8 +230,13 @@ func (m *Manager) Prune(ctx context.Context) error {
 	return nil
 }
 
-// ClaudeDir returns the path to the Claude home directory for the given agent.
+// ClaudeDir returns the path to the Claude home directory for the given
+// agent: <stateDir>/<agent>/claude in the flat layout, or the nested
+// <agentsDir>/<agent>/claude in the legacy layout.
 func (m *Manager) ClaudeDir(agentName string) string {
+	if m.flat {
+		return filepath.Join(m.stateDir, agentName, "claude")
+	}
 	return filepath.Join(m.agentsDir, agentName, "claude")
 }
 

--- a/pkg/worktree/manager_test.go
+++ b/pkg/worktree/manager_test.go
@@ -246,3 +246,93 @@ func TestEnsureClaudeDir(t *testing.T) {
 		t.Fatalf("second EnsureClaudeDir() error: %v", err)
 	}
 }
+
+// --- flat layout ---
+
+func TestFlatManagerPaths(t *testing.T) {
+	wt := "/data/worktrees"
+	st := "/data/agents"
+	m := NewFlatManager("/repo", wt, st)
+
+	if got, want := m.Name("eng-01"), "eng-01"; got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+	if got, want := m.Path("eng-01"), filepath.Join(wt, "eng-01"); got != want {
+		t.Errorf("Path() = %q, want %q", got, want)
+	}
+	if got, want := m.ClaudeDir("eng-01"), filepath.Join(st, "eng-01", "claude"); got != want {
+		t.Errorf("ClaudeDir() = %q, want %q", got, want)
+	}
+}
+
+func TestFlatManagerCreateRemove(t *testing.T) {
+	repo := setupTestRepo(t)
+	base := t.TempDir()
+	m := NewFlatManager(repo, filepath.Join(base, "worktrees"), filepath.Join(base, "agents"))
+
+	ctx := context.Background()
+	path, err := m.Create(ctx, "eng-01")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if want := filepath.Join(base, "worktrees", "eng-01"); path != want {
+		t.Errorf("Create path = %q, want %q", path, want)
+	}
+	if !m.Exists("eng-01") {
+		t.Error("Exists() = false after Create")
+	}
+	if _, err := os.Stat(filepath.Join(path, ".git")); err != nil {
+		t.Errorf(".git missing in flat worktree: %v", err)
+	}
+
+	if err := m.Remove(ctx, "eng-01"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if m.Exists("eng-01") {
+		t.Error("Exists() = true after Remove")
+	}
+}
+
+func TestFlatManagerEnsureClaudeDir(t *testing.T) {
+	base := t.TempDir()
+	m := NewFlatManager("/repo", filepath.Join(base, "worktrees"), filepath.Join(base, "agents"))
+
+	if err := m.EnsureClaudeDir("eng-01"); err != nil {
+		t.Fatalf("EnsureClaudeDir: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(base, "agents", "eng-01", "claude"))
+	if err != nil || !info.IsDir() {
+		t.Fatalf("claude dir not created: %v", err)
+	}
+}
+
+func TestManagerRemoveAt(t *testing.T) {
+	repo := setupTestRepo(t)
+	base := t.TempDir()
+	// Create with a nested manager, remove via a flat one using the
+	// stored path — mirrors deleting a pre-migration agent.
+	nested := NewManagerWithDataDir(repo, base)
+	ctx := context.Background()
+	oldPath, err := nested.Create(ctx, "eng-01")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	flat := NewFlatManager(repo, filepath.Join(base, "worktrees"), filepath.Join(base, "agents"))
+	if err := flat.RemoveAt(ctx, "eng-01", oldPath); err != nil {
+		t.Fatalf("RemoveAt: %v", err)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Errorf("old worktree still present at %q", oldPath)
+	}
+}
+
+func TestManagerRemoveAtRejectsUnsafePaths(t *testing.T) {
+	m := NewFlatManager("/repo", "/data/worktrees", "/data/agents")
+	if err := m.RemoveAt(context.Background(), "eng-01", "relative/path"); err == nil {
+		t.Error("RemoveAt accepted a relative path")
+	}
+	if err := m.RemoveAt(context.Background(), "eng-01", "/data/../etc"); err == nil {
+		t.Error("RemoveAt accepted a traversal path")
+	}
+}

--- a/scripts/migrate-worktree-layout.sh
+++ b/scripts/migrate-worktree-layout.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# migrate-worktree-layout.sh — move agents from the nested per-workspace
+# layout to the flat mycel-home layout.
+#
+# Old layout (per agent):
+#   ~/.mycel/workspaces/<id>/agents/<name>/bc-<repo>-<name>/   worktree
+#   ~/.mycel/workspaces/<id>/agents/<name>/claude/             Claude state
+#   ~/.mycel/workspaces/<id>/agents/<name>/claude.json         Claude config
+#   ~/.mycel/workspaces/<id>/logs/<name>.log                   session log
+#
+# New layout:
+#   ~/.mycel/worktrees/<name>/                                 worktree
+#   ~/.mycel/agents/<name>/claude/                             Claude state
+#   ~/.mycel/agents/<name>/claude.json                         Claude config
+#   ~/.mycel/agents/<name>/logs/<name>.log                     session log
+#
+# For each agents row in ~/.mycel/mycel.db whose worktree_dir is under
+# */workspaces/*/agents/*:
+#   - skip if a tmux session mycel-*-<name> is running ("restart required")
+#   - move the worktree dir to ~/.mycel/worktrees/<name>
+#   - move sibling state (claude/, claude.json, logs) to ~/.mycel/agents/<name>/
+#   - git -C <repo> worktree repair <new-path> (repo from the agents row)
+#   - UPDATE agents SET worktree_dir/log_file accordingly
+#
+# Modes:
+#   Default        dry run — prints what WOULD happen, touches nothing.
+#   --apply        actually migrate.
+#
+# Usage:
+#   scripts/migrate-worktree-layout.sh              # dry run
+#   scripts/migrate-worktree-layout.sh --apply      # migrate
+#
+# Flags:
+#   --apply        perform the migration (default is dry run)
+#   --home <dir>   mycel home (default: $HOME/.mycel)
+
+set -euo pipefail
+
+MYCEL_HOME="${HOME}/.mycel"
+APPLY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply) APPLY=1; shift ;;
+    --home) MYCEL_HOME="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown flag: $1 (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+DB="${MYCEL_HOME}/mycel.db"
+NEW_WORKTREES="${MYCEL_HOME}/worktrees"
+NEW_AGENTS="${MYCEL_HOME}/agents"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "error: sqlite3 is required" >&2
+  exit 1
+fi
+if [[ ! -f "$DB" ]]; then
+  echo "error: $DB does not exist — nothing to migrate" >&2
+  exit 1
+fi
+
+run() { # print in dry-run, execute in apply
+  if [[ "$APPLY" -eq 1 ]]; then
+    "$@"
+  else
+    echo "  would: $*"
+  fi
+}
+
+MIGRATED=0
+SKIPPED_RUNNING=0
+SKIPPED_MISSING=0
+FAILED=0
+
+# Rows: name|worktree_dir|repo|log_file for agents still on the nested layout.
+while IFS='|' read -r name wt_dir repo log_file; do
+  [[ -z "$name" ]] && continue
+
+  echo "== agent: $name"
+  echo "  old worktree: $wt_dir"
+
+  # Skip agents with a live tmux session (mycel-*-<name>) — moving a
+  # directory out from under a running agent would corrupt its session.
+  if command -v tmux >/dev/null 2>&1 && \
+     tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -q "^mycel-.*-${name}$"; then
+    echo "  SKIP: tmux session running — restart required (stop the agent, then re-run)"
+    SKIPPED_RUNNING=$((SKIPPED_RUNNING + 1))
+    continue
+  fi
+
+  if [[ ! -d "$wt_dir" ]]; then
+    echo "  SKIP: worktree dir missing on disk (will be recreated on next start)"
+    SKIPPED_MISSING=$((SKIPPED_MISSING + 1))
+    continue
+  fi
+
+  old_agent_dir="$(dirname "$wt_dir")"           # .../workspaces/<id>/agents/<name>
+  old_state_dir="$(dirname "$(dirname "$old_agent_dir")")"  # .../workspaces/<id>
+  new_wt="${NEW_WORKTREES}/${name}"
+  new_agent_dir="${NEW_AGENTS}/${name}"
+
+  if [[ -e "$new_wt" ]]; then
+    echo "  SKIP: $new_wt already exists — resolve manually"
+    FAILED=$((FAILED + 1))
+    continue
+  fi
+
+  # 1. Move the worktree.
+  run mkdir -p "$NEW_WORKTREES"
+  run mv "$wt_dir" "$new_wt"
+
+  # 2. Move sibling state: claude/, claude.json, anything else in the
+  #    old per-agent dir except the (already moved) worktree.
+  run mkdir -p "$new_agent_dir"
+  if [[ -d "$old_agent_dir" ]]; then
+    while IFS= read -r entry; do
+      base="$(basename "$entry")"
+      [[ "$entry" == "$wt_dir" ]] && continue
+      run mv "$entry" "${new_agent_dir}/${base}"
+    done < <(find "$old_agent_dir" -mindepth 1 -maxdepth 1 ! -path "$wt_dir" 2>/dev/null)
+    run rmdir "$old_agent_dir" 2>/dev/null || true
+  fi
+
+  # 3. Move the session log into the agent's logs dir.
+  new_log_file=""
+  if [[ -n "$log_file" && -f "$log_file" ]]; then
+    new_log_file="${new_agent_dir}/logs/${name}.log"
+    run mkdir -p "${new_agent_dir}/logs"
+    run mv "$log_file" "$new_log_file"
+  fi
+
+  # 4. Repair git worktree metadata from the agent's repo.
+  if [[ -n "$repo" && -e "$repo/.git" ]]; then
+    run git -C "$repo" worktree repair "$new_wt"
+  else
+    echo "  warn: repo '$repo' not found — skipping git worktree repair"
+  fi
+
+  # 5. Update the DB row.
+  esc_name="${name//\'/\'\'}"
+  sql="UPDATE agents SET worktree_dir = '${new_wt//\'/\'\'}'"
+  if [[ -n "$new_log_file" ]]; then
+    sql+=", log_file = '${new_log_file//\'/\'\'}'"
+  fi
+  sql+=" WHERE name = '${esc_name}';"
+  if [[ "$APPLY" -eq 1 ]]; then
+    sqlite3 "$DB" "$sql"
+  else
+    echo "  would: sqlite3 $DB \"$sql\""
+  fi
+
+  echo "  new worktree: $new_wt"
+  echo "  new state:    $new_agent_dir"
+  MIGRATED=$((MIGRATED + 1))
+done < <(sqlite3 -separator '|' "$DB" \
+  "SELECT name, worktree_dir, COALESCE(repo, ''), COALESCE(log_file, '')
+     FROM agents
+    WHERE deleted_at IS NULL
+      AND worktree_dir LIKE '%/workspaces/%/agents/%';")
+
+echo
+echo "== summary =="
+[[ "$APPLY" -eq 0 ]] && echo "-- DRY RUN (pass --apply to migrate) --"
+echo "migrated:          $MIGRATED"
+echo "skipped (running): $SKIPPED_RUNNING"
+echo "skipped (missing): $SKIPPED_MISSING"
+echo "needs attention:   $FAILED"


### PR DESCRIPTION
## Summary

Final filesystem layout change: agent worktrees move to flat, name-keyed directories under the mycel home. Agent names are globally unique (mycel.db primary key), so flat dirs are safe.

| | Old | New |
|---|---|---|
| Worktree | `~/.mycel/workspaces/<id>/agents/<name>/bc-<repo>-<name>/` | `~/.mycel/worktrees/<name>/` |
| Claude state | `~/.mycel/workspaces/<id>/agents/<name>/claude/` | `~/.mycel/agents/<name>/claude/` |
| claude.json | `~/.mycel/workspaces/<id>/agents/<name>/claude.json` | `~/.mycel/agents/<name>/claude.json` |
| Session log | `~/.mycel/workspaces/<id>/logs/<name>.log` | `~/.mycel/agents/<name>/logs/<name>.log` |

## Changes

- **pkg/worktree**: `NewFlatManager(repoRoot, worktreesDir, stateDir)` — flat `Path`/`Name`/`ClaudeDir`; `Create`/`Remove`/`Exists` identical in both modes; `RemoveAt` targets a stored path. Nested constructors kept for existing call sites/tests.
- **pkg/agent**: daemon + cross-repo managers switch to flat via `workspace.MycelHome()`. Reads of an existing agent's worktree use the stored `agent.WorktreeDir`, never a recomputed path — startAgent resume/recreate, delete, and rename all honor it, so pre-migration agents keep working from their old paths until migrated. Delete also removes `~/.mycel/agents/<name>` and `~/.mycel/worktrees/<name>`. Logs move to the flat state dir for new agents.
- **pkg/container**: `containerAgentDir` prefers the flat dir with fallback to older layouts for existing agents; claude/ + claude.json mounts follow.
- **Trust pre-seeding**: `SeedClaudeTrust` merges `{"projects": {"<path>": {"hasTrustDialogAccepted": true}}}` into the agent's claude.json (create-or-merge, never clobbers) — `/workspace` (container-side) for docker, host worktree path in `$HOME/.claude.json` for tmux — so fresh claude agents never hang at the trust prompt.
- **scripts/migrate-worktree-layout.sh**: dry-run by default, `--apply` to migrate. Moves worktree + sibling state, `git worktree repair` from the agents row's repo, updates `worktree_dir`/`log_file` in mycel.db, skips agents with a live `mycel-*-<name>` tmux session ("restart required"), prints a summary.
- **Docs**: `docs/explanation/agents.md` + `docs/tutorials/getting-started.md` updated.

## Testing

- `gofmt -s -l` clean, `go vet ./...` clean, `golangci-lint run` on worktree/agent/container: 0 issues
- `go test -race ./pkg/worktree/ ./pkg/agent/ ./pkg/container/` — all pass (new tests: flat layout paths, flat create/remove, RemoveAt, trust seeding per runtime, idempotence/no-clobber)
- `go test ./internal/cmd/ ./server/...` — all pass
- Migration script verified end-to-end against a fabricated `~/.mycel` (dry run touches nothing; apply moves, repairs, updates DB; `git status` works in the migrated worktree)

Part of #3276

🤖 Generated with [Claude Code](https://claude.com/claude-code)