### PR TITLE
fix(provider): claude restarts resume the previous session — only when one exists

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -853,18 +853,35 @@ func (m *Manager) getAgentCommand(toolName, agentName string, resume bool, sessi
 // appendSessionFlags adds the same --continue / --session flags the
 // provider's BuildCommand would, but to an arbitrary base command. We
 // keep the logic in one place so workspace overrides cooperate with
-// resume cleanly.
+// resume cleanly. Session IDs land in a `bash -c` line, where quoting
+// alone can't stop `$()` expansion — unsafe IDs are dropped.
 func appendSessionFlags(base string, opts provider.CommandOpts) string {
 	cmd := base
-	if opts.SessionID != "" {
-		// Quote SessionID to handle potential spaces / special chars,
-		// matching PiProvider.BuildCommand's approach.
-		cmd += fmt.Sprintf(" --session %q", opts.SessionID)
+	if provider.SafeSessionID(opts.SessionID) {
+		cmd += " --session " + opts.SessionID
 	}
 	if opts.Resume {
 		cmd += " --continue"
 	}
 	return cmd
+}
+
+// toolHasResumableSession consults the tool's provider about whether the
+// working directory holds a session a bare continue flag would pick up.
+// Providers without a detector keep the permissive default.
+func (m *Manager) toolHasResumableSession(toolName, dir string) bool {
+	if m.providerRegistry == nil {
+		return true
+	}
+	p, ok := m.providerRegistry.Get(toolName)
+	if !ok {
+		return true
+	}
+	det, ok := p.(provider.ResumableSessionDetector)
+	if !ok {
+		return true
+	}
+	return det.HasResumableSession(dir)
 }
 
 // listAvailableTools returns tool names from the manager's provider registry.
@@ -1138,10 +1155,21 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 				return nil, fmt.Errorf("worktree for %s is already in use by active session on %s backend", name, beName)
 			}
 		}
-		// Worktree exists with no active session — enable resume
+		// Worktree exists with no active session — enable resume, but
+		// only when the tool actually has a session to continue: some
+		// tools (Claude Code) exit instead of starting fresh when the
+		// continue flag finds nothing.
 		if !resume && sessionID == "" {
-			resume = true
-			log.Debug("worktree exists, will use --continue", "agent", name)
+			wtPath := existing.WorktreeDir
+			if wtPath == "" {
+				wtPath = wtMgr.Path(name)
+			}
+			if m.toolHasResumableSession(existing.Tool, wtPath) {
+				resume = true
+				log.Debug("prior session found, will use --continue", "agent", name)
+			} else {
+				log.Debug("no prior session transcript — starting fresh", "agent", name, "worktree", wtPath)
+			}
 		}
 	}
 

--- a/pkg/provider/claude.go
+++ b/pkg/provider/claude.go
@@ -3,6 +3,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -61,11 +63,18 @@ func (p *ClaudeProvider) InstallHint() string {
 func (p *ClaudeProvider) BuildCommand(opts CommandOpts) string {
 	cmd := "claude --dangerously-skip-permissions"
 	switch {
-	case opts.SessionID != "":
+	case claudeSessionIDPattern.MatchString(opts.SessionID):
 		cmd += " --resume " + opts.SessionID
+	case opts.Resume:
+		cmd += " --continue"
 	}
 	return cmd
 }
+
+// claudeSessionIDPattern is the full-string UUID shape of a Claude session
+// ID. The ID is spliced into a shell command line, so anything else —
+// including an empty string — is rejected rather than quoted.
+var claudeSessionIDPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 // AdjustSessionCommand is a no-op for native tmux sessions.
 // Claude auto-detects the tmux environment when running inside a bc-managed tmux session.
@@ -132,6 +141,33 @@ var claudeResumePattern = regexp.MustCompile(`claude --resume ([0-9a-f]{8}-[0-9a
 
 // SupportsResume reports that Claude Code supports resuming sessions by ID.
 func (p *ClaudeProvider) SupportsResume() bool { return true }
+
+// claudeHomeDir is overridable in tests.
+var claudeHomeDir = os.UserHomeDir
+
+// HasResumableSession reports whether Claude Code has a prior session
+// transcript for the given working directory. `claude --continue` EXITS
+// (instead of starting fresh) when the project has no session, so the
+// flag must only be passed when a transcript exists. Claude keys
+// transcripts by the project path with `/` and `.` replaced by `-`:
+// ~/.claude/projects/<encoded>/<session-uuid>.jsonl.
+func (p *ClaudeProvider) HasResumableSession(dir string) bool {
+	home, err := claudeHomeDir()
+	if err != nil || dir == "" {
+		return false
+	}
+	encoded := strings.NewReplacer("/", "-", ".", "-").Replace(dir)
+	entries, err := os.ReadDir(filepath.Join(home, ".claude", "projects", encoded))
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
+			return true
+		}
+	}
+	return false
+}
 
 // ParseSessionID scans tool output for Claude's resume hint and returns the session UUID.
 // Returns "" if no session ID is found.

--- a/pkg/provider/cursor.go
+++ b/pkg/provider/cursor.go
@@ -50,10 +50,11 @@ func (p *CursorProvider) InstallHint() string {
 }
 
 // BuildCommand returns the full command for a given runtime context.
-// Supports --resume with session ID for session continuation.
+// Supports --resume with session ID for session continuation. The ID is
+// spliced into a shell command line, so unsafe values are dropped.
 func (p *CursorProvider) BuildCommand(opts CommandOpts) string {
 	cmd := p.command
-	if opts.SessionID != "" {
+	if SafeSessionID(opts.SessionID) {
 		cmd += " --resume " + opts.SessionID
 	}
 	return cmd

--- a/pkg/provider/gemini.go
+++ b/pkg/provider/gemini.go
@@ -51,10 +51,11 @@ func (p *GeminiProvider) InstallHint() string {
 }
 
 // BuildCommand returns the full command for a given runtime context.
-// Supports --resume with session ID for session continuation.
+// Supports --resume with session ID for session continuation. The ID is
+// spliced into a shell command line, so unsafe values are dropped.
 func (p *GeminiProvider) BuildCommand(opts CommandOpts) string {
 	cmd := p.command
-	if opts.SessionID != "" {
+	if SafeSessionID(opts.SessionID) {
 		cmd += " --resume " + opts.SessionID
 	}
 	return cmd

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 	"strings"
 )
@@ -66,12 +65,12 @@ func (p *PiProvider) InstallHint() string {
 
 // BuildCommand returns the full command for a given runtime context.
 // For pi, we start with base command and add session flags as needed.
-// SessionID is quoted to prevent potential shell injection issues.
+// The session ID is spliced into a shell command line — double quotes
+// don't stop `$()` expansion, so unsafe values are dropped instead.
 func (p *PiProvider) BuildCommand(opts CommandOpts) string {
 	cmd := p.Command()
-	if opts.SessionID != "" {
-		// Quote SessionID to handle potential spaces/special chars
-		cmd += fmt.Sprintf(" --session \"%s\"", opts.SessionID)
+	if SafeSessionID(opts.SessionID) {
+		cmd += " --session " + opts.SessionID
 	}
 	if opts.Resume {
 		cmd += " --continue"

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -196,4 +197,25 @@ func ListProviders() []Provider {
 // ListInstalledProviders returns all installed providers.
 func ListInstalledProviders(ctx context.Context) []Provider {
 	return DefaultRegistry.ListInstalled(ctx)
+}
+
+// safeSessionIDPattern is the conservative charset allowed in a session
+// ID that gets spliced into a provider command line (which runs under
+// `bash -c`). Quoting alone is not enough — `$()` expands inside double
+// quotes — so anything outside this shape is dropped, not escaped.
+var safeSessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// SafeSessionID reports whether a session ID is safe to interpolate
+// into a shell command line.
+func SafeSessionID(id string) bool {
+	return safeSessionIDPattern.MatchString(id)
+}
+
+// ResumableSessionDetector is optionally implemented by providers that
+// can tell whether a working directory holds a prior session that a
+// bare continue flag would pick up. Callers must not emit a "continue
+// last session" flag when the detector reports false — some tools
+// (Claude Code) exit instead of starting fresh.
+type ResumableSessionDetector interface {
+	HasResumableSession(dir string) bool
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -626,16 +628,33 @@ func TestClaudeBuildCommandSessionID(t *testing.T) {
 			want: "claude --dangerously-skip-permissions --resume cc78cadf-89ce-4820-ab6e-950afd2b6838",
 		},
 		{
-			name: "resume flag without session ID — no special flag",
+			name: "resume flag without session ID — continue last session",
 			opts: CommandOpts{
 				AgentName: "eng-01",
 				Resume:    true,
 			},
-			want: "claude --dangerously-skip-permissions",
+			want: "claude --dangerously-skip-permissions --continue",
 		},
 		{
 			name: "no resume flags — fresh session",
 			opts: CommandOpts{AgentName: "eng-01"},
+			want: "claude --dangerously-skip-permissions",
+		},
+		{
+			name: "malformed session ID is dropped, resume flag wins",
+			opts: CommandOpts{
+				AgentName: "eng-01",
+				SessionID: "$(rm -rf /)",
+				Resume:    true,
+			},
+			want: "claude --dangerously-skip-permissions --continue",
+		},
+		{
+			name: "malformed session ID without resume — fresh session",
+			opts: CommandOpts{
+				AgentName: "eng-01",
+				SessionID: "not-a-uuid-shape!",
+			},
 			want: "claude --dangerously-skip-permissions",
 		},
 	}
@@ -647,5 +666,42 @@ func TestClaudeBuildCommandSessionID(t *testing.T) {
 				t.Errorf("BuildCommand() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestClaudeHasResumableSession covers the --continue gate: Claude Code
+// exits instead of starting fresh when the project has no session, so
+// the detector must only report true when a transcript exists.
+func TestClaudeHasResumableSession(t *testing.T) {
+	p := NewClaudeProvider()
+	home := t.TempDir()
+	orig := claudeHomeDir
+	claudeHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { claudeHomeDir = orig })
+
+	wt := "/Users/u/.mycel/worktrees/eng-01"
+	encoded := "-Users-u--mycel-worktrees-eng-01"
+	projDir := filepath.Join(home, ".claude", "projects", encoded)
+
+	if p.HasResumableSession(wt) {
+		t.Error("no projects dir — must report false")
+	}
+
+	if err := os.MkdirAll(projDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if p.HasResumableSession(wt) {
+		t.Error("empty projects dir — must report false")
+	}
+
+	if err := os.WriteFile(filepath.Join(projDir, "cc78cadf-89ce-4820-ab6e-950afd2b6838.jsonl"), []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !p.HasResumableSession(wt) {
+		t.Error("transcript present — must report true")
+	}
+
+	if p.HasResumableSession("") {
+		t.Error("empty dir must report false")
 	}
 }


### PR DESCRIPTION
Found by Puneet during release verification: restarting an agent started a fresh conversation instead of resuming.

## Root cause
`ClaudeProvider.BuildCommand`'s docstring promised `Resume priority: SessionID (--resume <id>) > Resume flag (--continue)` — but the switch had no `Resume` case. startAgent correctly decided to resume; the flag was silently dropped for claude (the existing unit test even enshrined the bug: "resume flag without session ID — no special flag").

## Fix, with the fresh-agent guard
- `--continue` is emitted for `Resume` — but ONLY when a session transcript actually exists for the worktree. Verified empirically: `claude --continue` in a project with no prior session **exits** instead of starting fresh, which would brick fresh/never-conversed agents on restart. New `ResumableSessionDetector` interface; `ClaudeProvider.HasResumableSession` checks `~/.claude/projects/<encoded-path>/*.jsonl`; `startAgent` consults it before enabling resume (providers without a detector keep the permissive default).
- **Session-ID injection hardening**: IDs are spliced into a `bash -c` line where double-quoting does not stop `$()` expansion. Claude accepts only UUID-shaped IDs; cursor/gemini/pi/workspace-override paths gate on a conservative `SafeSessionID` charset; malformed IDs are dropped (falling back to `--continue`/fresh), never quoted.

## Tests
- BuildCommand table extended: resume→`--continue`, sessionID priority, `$(rm -rf /)` dropped with resume fallback, malformed ID → fresh.
- `TestClaudeHasResumableSession`: no dir / empty dir / transcript present / empty path.
- Full `go test -race ./pkg/provider/ ./pkg/agent/` green; gofmt/vet/golangci-lint 0 issues.

Part of #3276

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Safer session handling when launching or resuming commands, reducing the risk of invalid session values being passed through.
  * Improved resume behavior for existing worktrees so the app only resumes when a prior session is actually available.
  * Commands now fall back more reliably to continuing an existing session when a valid session ID isn’t present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->