### PR TITLE
feat(web): notifications home hub — apps, channels grouped by app, search/filters, recent activity

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -145,6 +145,37 @@ export interface GatewayHealth {
   last_message_at?: string;
 }
 
+/** One connected/configured app on the notifications overview (#3310). */
+export interface OverviewApp {
+  name: string;
+  platform: string;
+  connected: boolean;
+  disconnect_reason?: string;
+  channel_count: number;
+  last_activity?: string;
+}
+
+/** One channel row on the notifications overview, enriched with the
+ *  display metadata resolved by the platform adapter (#3310). All
+ *  metadata fields are optional — the page degrades to raw channel ids
+ *  when the backend has not resolved identities yet. */
+export interface OverviewChannel {
+  bc_channel: string;
+  platform: string;
+  display_name?: string;
+  /** "group" | "person" when the adapter could classify the channel. */
+  kind?: string;
+  participant_count?: number;
+  subscriber_count?: number;
+  message_count?: number;
+  last_activity?: string;
+}
+
+export interface NotificationsOverview {
+  apps?: OverviewApp[];
+  channels?: OverviewChannel[];
+}
+
 export interface CostSummary {
   input_tokens: number;
   output_tokens: number;
@@ -760,6 +791,11 @@ export const api = {
     request<GatewayStatus[]>("/gateways"),
   getGatewayHealth: (platform: string) =>
     request<GatewayHealth>(`/gateways/${encodeURIComponent(platform)}/health`),
+  /** Aggregated apps + channels for the notifications home (#3310).
+   *  Callers must tolerate the endpoint being absent and fall back to
+   *  composing the same data from the individual endpoints. */
+  getNotificationsOverview: () =>
+    request<NotificationsOverview>("/notifications/overview"),
 
   getCostSummary: () => request<CostSummary>("/costs"),
   getCostByAgent: () => request<AgentCostSummary[]>("/costs/agents"),

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -9,6 +9,13 @@ import type { NotificationSource, GatewayHealth, GatewayStatus, NotifySubscripti
 import { sourcePlatform } from "./notifications/messageUtils";
 import { SetupWizard, PlatformChooser, PLATFORM_MAP } from "./notifications/SetupWizard";
 import { DefaultAppIcon, PLATFORM_ICON_MAP } from "./notifications/PlatformIcons";
+import {
+  disconnectReason,
+  formatAgoShort,
+  getAppStatus,
+  parseActivityTs,
+  StatusDot,
+} from "./notifications/appStatus";
 import { Header } from "./Header";
 import { SidebarToggle } from "./SidebarToggle";
 import { BrandMark } from "./BrandMark";
@@ -340,73 +347,6 @@ function readViewedMap(): Record<string, number> {
   }
 }
 
-// Parse an ISO timestamp, guarding zero / unset / pre-2001 values that
-// produce nonsensical "17753690h ago" strings.
-function parseActivityTs(iso?: string): number | null {
-  if (!iso) return null;
-  const ts = new Date(iso).getTime();
-  return Number.isFinite(ts) && ts > 978307200000 ? ts : null;
-}
-
-/** Compact relative time: "now", "5m", "3h", "2d". */
-function formatAgoShort(ts: number): string {
-  const mins = Math.floor((Date.now() - ts) / 60000);
-  if (mins < 1) return "now";
-  if (mins < 60) return `${mins}m`;
-  if (mins < 1440) return `${Math.floor(mins / 60)}h`;
-  return `${Math.floor(mins / 1440)}d`;
-}
-
-type AppStatus = "connected" | "connecting" | "error" | "idle";
-
-function getAppStatus(gw?: GatewayStatus, h?: GatewayHealth): AppStatus {
-  if (h) {
-    if (h.connected) return "connected";
-    return h.status === "connecting" ? "connecting" : "error";
-  }
-  // Enabled gateway whose health has not reported yet reads as connecting.
-  if (gw?.enabled) return "connecting";
-  return "idle";
-}
-
-/** Map raw gateway errors to a short human-readable reason. */
-function disconnectReason(base: string, h?: GatewayHealth): string {
-  if (base === "whatsapp") return "Scan QR to re-pair";
-  const err = h?.error ?? "";
-  if (/\b402\b|payment required|quota/i.test(err)) return "API quota/payment required";
-  if (/\b401\b|unauthorized|invalid[ _-]?(auth|token|credentials)/i.test(err)) return "Invalid credentials";
-  if (/\b403\b|forbidden/i.test(err)) return "Access denied";
-  if (/\b429\b|rate[ _-]?limit/i.test(err)) return "Rate limited";
-  if (/timeout|timed out|refused|unreachable|network|no such host|dns/i.test(err)) return "Connection failed";
-  return err || "Disconnected";
-}
-
-const STATUS_DOT_TOKEN: Record<AppStatus, string> = {
-  connected: "var(--mycel-success)",
-  connecting: "var(--mycel-warning)",
-  error: "var(--mycel-error)",
-  idle: "var(--mycel-muted)",
-};
-
-/** 6px connection dot — the only status signal a healthy app shows. */
-function StatusDot({ status, title }: { status: AppStatus; title?: string }) {
-  const token = STATUS_DOT_TOKEN[status];
-  return (
-    <span
-      className="shrink-0"
-      title={title}
-      style={{
-        width: 6,
-        height: 6,
-        borderRadius: 999,
-        background: token,
-        opacity: status === "idle" ? 0.35 : 1,
-        boxShadow: status === "connected" ? `0 0 5px color-mix(in srgb, ${token} 50%, transparent)` : "none",
-      }}
-    />
-  );
-}
-
 /* ── Notification tree (inline in nav) ───────────────────────── */
 
 function NotificationNavTree() {
@@ -649,11 +589,6 @@ function NotificationNavTree() {
                     {chs.length}
                   </span>
                 )}
-                {!isCollapsed && ago && (
-                  <span style={{ fontSize: 10, color: "var(--mycel-muted)", fontVariantNumeric: "tabular-nums" }}>
-                    {ago}
-                  </span>
-                )}
                 <StatusDot status={status} title={tooltip} />
                 <svg
                   width="10"
@@ -668,6 +603,24 @@ function NotificationNavTree() {
                 </svg>
               </span>
             </button>
+
+            {/* Per-app summary — channel count · last activity (#3310).
+                Subtle one-liner under the group header, aligned with the
+                channel rows. */}
+            {!isCollapsed && chs.length > 0 && (
+              <div
+                className="truncate"
+                style={{
+                  padding: "0 8px 2px 26px",
+                  fontSize: 10,
+                  color: "var(--mycel-muted)",
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                {chs.length} channel{chs.length === 1 ? "" : "s"}
+                {ago ? ` · active ${ago === "now" ? "now" : `${ago} ago`}` : ""}
+              </div>
+            )}
 
             {/* Disconnected apps get an action row, not a chip */}
             {status === "error" && (

--- a/web/src/components/notifications/NotificationsHome.tsx
+++ b/web/src/components/notifications/NotificationsHome.tsx
@@ -1,0 +1,778 @@
+/**
+ * NotificationsHome — the /notifications hub shown when no channel is
+ * selected (#3310). Three sections built from data we already have:
+ *
+ *   1. Apps strip — one card per connected/configured gateway with the
+ *      same status semantics as the drawer (shared appStatus utils),
+ *      plus a "+ Connect an app" card reusing the existing setup flow.
+ *   2. Channels — all gateway channels grouped by app; WhatsApp splits
+ *      into Groups / People. Search + Filters live in the header slot.
+ *   3. Recent activity — the newest messages across active channels.
+ *
+ * Data comes from GET /api/notifications/overview when available and
+ * degrades gracefully to composing the same model from the individual
+ * endpoints (channels, gateways, health, subscriptions, channel stats)
+ * when the overview endpoint or its metadata fields are missing.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { api } from "../../api/client";
+import type {
+  ChannelMessage,
+  ChannelStats,
+  GatewayHealth,
+  GatewayStatus,
+  NotificationSource,
+  NotificationsOverview,
+  NotifySubscription,
+} from "../../api/client";
+import { usePolling } from "../../hooks/usePolling";
+import { useHeaderSlot } from "../../context/HeaderSlotContext";
+import { EmptyState } from "../EmptyState";
+import { LoadingSkeleton } from "../LoadingSkeleton";
+import { DefaultAppIcon, PLATFORM_ICON_MAP } from "./PlatformIcons";
+import { SetupWizard, PlatformChooser, PLATFORM_MAP } from "./SetupWizard";
+import { agentColor, sourcePlatform } from "./messageUtils";
+import { formatRelative } from "../../utils/time";
+import {
+  disconnectReason,
+  getAppStatus,
+  parseActivityTs,
+  StatusDot,
+  type AppStatus,
+} from "./appStatus";
+
+/* ── Pure helpers (exported for tests) ───────────────────────── */
+
+export type ChannelKind = "group" | "person" | null;
+
+/** Leaf segment of a channel key: "whatsapp:123@g.us" → "123@g.us". */
+export function channelLeaf(name: string): string {
+  const parts = name.split(":");
+  return parts[parts.length - 1] || name;
+}
+
+/** Classify a WhatsApp channel by JID shape when no metadata exists:
+ *  "…@g.us" → group, "…@s.whatsapp.net" → person. */
+export function whatsappKindFromId(name: string): ChannelKind {
+  const id = channelLeaf(name);
+  if (id.endsWith("@g.us")) return "group";
+  if (id.endsWith("@s.whatsapp.net")) return "person";
+  return null;
+}
+
+/** Kind from adapter metadata when present, JID-shape fallback for
+ *  WhatsApp, null (unclassified) otherwise. */
+export function resolveChannelKind(name: string, platform: string, kind?: string): ChannelKind {
+  if (kind === "group" || kind === "person") return kind;
+  if (platform === "whatsapp") return whatsappKindFromId(name);
+  return null;
+}
+
+export interface ChannelItem {
+  name: string;
+  /** App bucket this channel belongs to (gateway platform key). */
+  app: string;
+  platform: string;
+  displayName: string;
+  kind: ChannelKind;
+  participantCount: number | null;
+  subscribers: string[];
+  subscriberCount: number;
+  messageCount: number | null;
+  lastActivity: number | null;
+}
+
+export interface AppItem {
+  /** Bucket key — a gateway platform key, possibly compound ("telegram:bot"). */
+  key: string;
+  base: string;
+  label: string;
+  botName?: string;
+  status: AppStatus;
+  reason: string | null;
+  channelCount: number;
+  lastActivity: number | null;
+}
+
+export interface HomeSnapshot {
+  overview: NotificationsOverview | null;
+  sources: NotificationSource[];
+  gateways: GatewayStatus[];
+  health: Record<string, GatewayHealth>;
+  subs: NotifySubscription[];
+  stats: ChannelStats[];
+}
+
+/** Build the page model, preferring overview metadata and falling back
+ *  to the composed endpoints field by field. Pure — unit tested. */
+export function buildHomeModel(snap: HomeSnapshot): { apps: AppItem[]; channels: ChannelItem[] } {
+  const ovChannels = snap.overview?.channels ?? [];
+  const ovApps = snap.overview?.apps ?? [];
+  const ovByName = new Map(ovChannels.map((c) => [c.bc_channel, c]));
+  const statByName = new Map(snap.stats.map((s) => [s.name, s]));
+
+  const subsByChannel = new Map<string, string[]>();
+  for (const sub of snap.subs) {
+    const list = subsByChannel.get(sub.channel) ?? [];
+    list.push(sub.agent);
+    subsByChannel.set(sub.channel, list);
+  }
+
+  // Union of /channels sources and overview channels.
+  const names: string[] = snap.sources.map((s) => s.name);
+  const seen = new Set(names);
+  for (const c of ovChannels) {
+    if (!seen.has(c.bc_channel)) {
+      seen.add(c.bc_channel);
+      names.push(c.bc_channel);
+    }
+  }
+
+  const appKeyFor = (name: string): string => {
+    const matched = snap.gateways.find((gw) => name.startsWith(gw.platform + ":"));
+    return matched?.platform ?? sourcePlatform(name);
+  };
+
+  const channels: ChannelItem[] = [];
+  for (const name of names) {
+    const app = appKeyFor(name);
+    if (app === "internal") continue;
+    const ov = ovByName.get(name);
+    const st = statByName.get(name);
+    const platform = ov?.platform ?? sourcePlatform(name);
+    const subscribers = subsByChannel.get(name) ?? [];
+    channels.push({
+      name,
+      app,
+      platform,
+      displayName: ov?.display_name?.trim() ? ov.display_name : channelLeaf(name),
+      kind: resolveChannelKind(name, platform, ov?.kind),
+      participantCount: ov?.participant_count ?? null,
+      subscribers,
+      subscriberCount: Math.max(ov?.subscriber_count ?? 0, subscribers.length),
+      messageCount: ov?.message_count ?? st?.message_count ?? null,
+      lastActivity:
+        parseActivityTs(ov?.last_activity) ?? parseActivityTs(st?.last_activity),
+    });
+  }
+
+  // App buckets: every gateway plus every bucket that has channels.
+  const bucketKeys = new Set<string>(snap.gateways.map((g) => g.platform));
+  for (const ch of channels) bucketKeys.add(ch.app);
+
+  const apps: AppItem[] = [...bucketKeys].map((key) => {
+    const base = key.includes(":") ? (key.split(":")[0] ?? key) : key;
+    const gw = snap.gateways.find((g) => g.platform === key);
+    const h = snap.health[key];
+    const ovApp = ovApps.find((a) => a.name === key || a.platform === key || a.platform === base);
+    const chs = channels.filter((c) => c.app === key);
+
+    let status = getAppStatus(gw, h);
+    // No live gateway/health entry — trust the overview's verdict.
+    if (!gw && !h && ovApp) status = ovApp.connected ? "connected" : "error";
+
+    const reason =
+      status === "error"
+        ? (h ? disconnectReason(base, h) : ovApp?.disconnect_reason || disconnectReason(base, h))
+        : null;
+
+    const chActivity = chs.reduce<number | null>(
+      (acc, c) => (c.lastActivity !== null && (acc === null || c.lastActivity > acc) ? c.lastActivity : acc),
+      null,
+    );
+
+    const def = PLATFORM_MAP[base];
+    return {
+      key,
+      base,
+      label: def?.label ?? base,
+      botName: gw?.bot_name,
+      status,
+      reason,
+      channelCount: chs.length > 0 ? chs.length : ovApp?.channel_count ?? 0,
+      lastActivity:
+        parseActivityTs(h?.last_message_at) ??
+        parseActivityTs(ovApp?.last_activity) ??
+        chActivity,
+    };
+  });
+
+  // Connected apps first, then alphabetical — mirrors the drawer.
+  apps.sort((a, b) => {
+    const ra = a.status === "connected" ? 0 : 1;
+    const rb = b.status === "connected" ? 0 : 1;
+    if (ra !== rb) return ra - rb;
+    return a.label.localeCompare(b.label) || a.key.localeCompare(b.key);
+  });
+
+  return { apps, channels };
+}
+
+/* ── Recent activity ─────────────────────────────────────────── */
+
+export interface RecentMessage extends ChannelMessage {
+  channel: string;
+}
+
+/** Strip "[telegram] " style prefixes for cleaner sender display. */
+function cleanSender(sender: string): string {
+  const match = /^\[[a-z]+\]\s*(.+)$/i.exec(sender);
+  return match?.[1] ?? sender;
+}
+
+function oneLine(content: string): string {
+  return content.replace(/\s+/g, " ").trim().slice(0, 140);
+}
+
+/* ── Small render helpers ────────────────────────────────────── */
+
+function AppIcon({ base, size }: { base: string; size: number }) {
+  const Icon = PLATFORM_ICON_MAP[base] ?? DefaultAppIcon;
+  return <Icon size={size} />;
+}
+
+function KindGlyph({ kind }: { kind: ChannelKind }) {
+  if (kind === "group") {
+    return (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+      </svg>
+    );
+  }
+  if (kind === "person") {
+    return (
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+    );
+  }
+  return <span className="font-mono text-[12px] leading-none">#</span>;
+}
+
+function SubscriberAvatars({ subscribers, count }: { subscribers: string[]; count: number }) {
+  if (count <= 0) return null;
+  return (
+    <span className="flex items-center shrink-0" title={`${String(count)} subscribed agent${count === 1 ? "" : "s"}${subscribers.length > 0 ? ": " + subscribers.join(", ") : ""}`}>
+      {subscribers.slice(0, 3).map((a, i) => (
+        <span
+          key={a}
+          className="flex items-center justify-center"
+          style={{
+            width: 16,
+            height: 16,
+            borderRadius: 4,
+            background: agentColor(a),
+            color: "var(--mycel-bg)",
+            fontSize: 8,
+            fontWeight: 700,
+            fontFamily: "'JetBrains Mono', monospace",
+            marginLeft: i === 0 ? 0 : -4,
+            border: "1px solid var(--mycel-surface)",
+          }}
+        >
+          {a.slice(0, 2).toUpperCase()}
+        </span>
+      ))}
+      <span className="ml-1 text-[10.5px] text-mycel-muted tabular-nums">
+        {subscribers.length > 3 ? `+${String(count - 3)}` : count > subscribers.length || subscribers.length === 0 ? String(count) : null}
+      </span>
+    </span>
+  );
+}
+
+function ChannelRowButton({ ch, onOpen }: { ch: ChannelItem; onOpen: (name: string) => void }) {
+  const rawId = channelLeaf(ch.name);
+  const hasDisplayName = ch.displayName !== rawId;
+  return (
+    <button
+      type="button"
+      onClick={() => { onOpen(ch.name); }}
+      className="w-full flex items-center gap-3 px-3 py-2 bg-mycel-surface hover:bg-mycel-surface-hover text-left transition-colors"
+      title={ch.name}
+    >
+      <span className="shrink-0 flex items-center justify-center w-4 text-mycel-muted">
+        <KindGlyph kind={ch.kind} />
+      </span>
+      <span className="min-w-0 flex-1 flex items-baseline gap-2">
+        <span className={`truncate text-[13px] font-medium text-mycel-text ${hasDisplayName ? "" : "font-mono"}`}>
+          {ch.displayName}
+        </span>
+        {hasDisplayName && (
+          <span className="hidden md:inline truncate font-mono text-[10.5px] text-mycel-muted">{rawId}</span>
+        )}
+      </span>
+      <span className="hidden sm:flex items-center gap-3 shrink-0 text-[11px] text-mycel-muted tabular-nums">
+        {ch.kind === "group" && ch.participantCount !== null && (
+          <span>{String(ch.participantCount)} member{ch.participantCount === 1 ? "" : "s"}</span>
+        )}
+        <SubscriberAvatars subscribers={ch.subscribers} count={ch.subscriberCount} />
+        {ch.messageCount !== null && <span>{String(ch.messageCount)} msgs</span>}
+        {ch.lastActivity !== null && <span>{formatRelative(ch.lastActivity)}</span>}
+      </span>
+    </button>
+  );
+}
+
+function SubsectionLabel({ label, count }: { label: string; count: number }) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 bg-mycel-bg">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-mycel-muted">{label}</span>
+      <span className="text-[10px] text-mycel-muted tabular-nums">{count}</span>
+    </div>
+  );
+}
+
+/* ── Component ───────────────────────────────────────────────── */
+
+export function NotificationsHome() {
+  const navigate = useNavigate();
+
+  const fetcher = useCallback(async (): Promise<HomeSnapshot & { recent: RecentMessage[] }> => {
+    const [overview, sources, gateways, subs, stats] = await Promise.all([
+      api.getNotificationsOverview().catch(() => null),
+      api.listNotificationSources().catch(() => [] as NotificationSource[]),
+      api.listGateways().catch(() => [] as GatewayStatus[]),
+      api.listSubscriptions().catch(() => [] as NotifySubscription[]),
+      api.getStatsChannels().catch(() => [] as ChannelStats[]),
+    ]);
+    const gws = gateways ?? [];
+    const healthEntries = await Promise.all(
+      gws.filter((g) => g.enabled).map(async (g) => {
+        const h = await api.getGatewayHealth(g.platform).catch(() => null);
+        return h ? ([g.platform, h] as const) : null;
+      }),
+    );
+    const health: Record<string, GatewayHealth> = {};
+    for (const e of healthEntries) if (e) health[e[0]] = e[1];
+
+    // Recent activity: newest messages from the most recently active
+    // gateway channels (per-channel history is the endpoint we have).
+    const gwSources = (sources ?? []).filter((s) => sourcePlatform(s.name) !== "internal");
+    const statByName = new Map((stats ?? []).map((s) => [s.name, s]));
+    const ranked = [...gwSources]
+      .sort((a, b) => {
+        const ta = parseActivityTs(statByName.get(a.name)?.last_activity) ?? 0;
+        const tb = parseActivityTs(statByName.get(b.name)?.last_activity) ?? 0;
+        return tb - ta;
+      })
+      .slice(0, 6);
+    const histories = await Promise.all(
+      ranked.map(async (ch) => {
+        const msgs = await api.getChannelHistory(ch.name, 10).catch(() => [] as ChannelMessage[]);
+        return (msgs ?? []).map((m) => ({ ...m, channel: ch.name }));
+      }),
+    );
+    const recent = histories
+      .flat()
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, 15);
+
+    return {
+      overview,
+      sources: gwSources,
+      gateways: gws,
+      health,
+      subs: subs ?? [],
+      stats: stats ?? [],
+      recent,
+    };
+  }, []);
+
+  const { data, loading, error, refresh, timedOut } = usePolling(fetcher, 15000);
+
+  const [search, setSearch] = useState("");
+  const [appSel, setAppSel] = useState<Set<string>>(new Set());
+  const [onlySubscribed, setOnlySubscribed] = useState(false);
+  const [onlyActive24h, setOnlyActive24h] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const filtersRef = useRef<HTMLDivElement>(null);
+  const [chooserOpen, setChooserOpen] = useState(false);
+  const [setupPlatform, setSetupPlatform] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!filtersOpen) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (filtersRef.current && !filtersRef.current.contains(e.target as Node)) setFiltersOpen(false);
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFiltersOpen(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [filtersOpen]);
+
+  const model = useMemo(() => (data ? buildHomeModel(data) : { apps: [], channels: [] }), [data]);
+  const { apps, channels } = model;
+  const recent = data?.recent ?? [];
+
+  const query = search.trim().toLowerCase();
+  const hasFilters = query !== "" || appSel.size > 0 || onlySubscribed || onlyActive24h;
+  const activeFilterCount = appSel.size + (onlySubscribed ? 1 : 0) + (onlyActive24h ? 1 : 0);
+
+  const filteredChannels = useMemo(() => {
+    const dayAgo = Date.now() - 24 * 3_600_000;
+    return channels.filter((ch) => {
+      if (query && !ch.displayName.toLowerCase().includes(query) && !ch.name.toLowerCase().includes(query)) return false;
+      if (appSel.size > 0 && !appSel.has(ch.app)) return false;
+      if (onlySubscribed && ch.subscriberCount === 0) return false;
+      if (onlyActive24h && (ch.lastActivity === null || ch.lastActivity < dayAgo)) return false;
+      return true;
+    });
+  }, [channels, query, appSel, onlySubscribed, onlyActive24h]);
+
+  const clearFilters = () => {
+    setSearch("");
+    setAppSel(new Set());
+    setOnlySubscribed(false);
+    setOnlyActive24h(false);
+  };
+
+  const toggleApp = (key: string) => {
+    setAppSel((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  const openChannel = useCallback((name: string) => {
+    navigate(`/notifications/${name}`);
+  }, [navigate]);
+
+  const hasAnything = apps.length > 0 || channels.length > 0;
+
+  /* ── Header slot: count summary · search · Filters chip ─────── */
+  useHeaderSlot({
+    title: hasAnything ? (
+      <span className="text-xs text-mycel-text-2 tabular-nums truncate">
+        {hasFilters
+          ? `${String(filteredChannels.length)} of ${String(channels.length)} channels`
+          : `${String(channels.length)} channel${channels.length === 1 ? "" : "s"} · ${String(apps.length)} app${apps.length === 1 ? "" : "s"}`}
+      </span>
+    ) : undefined,
+    actions: hasAnything ? (
+      <>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); }}
+          placeholder="Search channels"
+          className="flex-1 min-w-[96px] max-w-md h-9 px-3 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
+          aria-label="Search channels"
+        />
+        <div className="relative shrink-0" ref={filtersRef}>
+          <button
+            type="button"
+            onClick={() => { setFiltersOpen((v) => !v); }}
+            aria-label="Filters"
+            aria-haspopup="true"
+            aria-expanded={filtersOpen}
+            className={`inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md border text-xs font-medium transition-colors ${
+              filtersOpen || activeFilterCount > 0
+                ? "border-mycel-accent text-mycel-text bg-mycel-surface"
+                : "border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-text hover:border-mycel-accent"
+            }`}
+          >
+            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M1.5 2.5h11l-4.2 5v4l-2.6-1.5V7.5z" />
+            </svg>
+            Filters
+            {activeFilterCount > 0 && (
+              <span className="inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-mycel-accent text-mycel-accent-fg text-[10px] font-semibold tabular-nums">
+                {activeFilterCount}
+              </span>
+            )}
+          </button>
+          {filtersOpen && (
+            <div
+              data-testid="notifications-filters-popover"
+              className="absolute right-0 top-full mt-1.5 z-50 w-60 rounded-lg border border-mycel-border bg-mycel-surface-2 shadow-mycel-lg p-3 space-y-2.5 text-sm"
+            >
+              {apps.length > 1 && (
+                <div>
+                  <span className="block mb-1 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">Apps</span>
+                  <div className="space-y-1 max-h-40 overflow-y-auto">
+                    {apps.map((app) => (
+                      <label key={app.key} className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={appSel.has(app.key)}
+                          onChange={() => { toggleApp(app.key); }}
+                          className="accent-[var(--mycel-accent)]"
+                        />
+                        <AppIcon base={app.base} size={11} />
+                        <span className="truncate">{app.label}{app.botName ? ` · ${app.botName}` : ""}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+              <label className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={onlySubscribed}
+                  onChange={() => { setOnlySubscribed((v) => !v); }}
+                  className="accent-[var(--mycel-accent)]"
+                />
+                Has subscribers
+              </label>
+              <label className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={onlyActive24h}
+                  onChange={() => { setOnlyActive24h((v) => !v); }}
+                  className="accent-[var(--mycel-accent)]"
+                />
+                Active in last 24h
+              </label>
+              {hasFilters && (
+                <div className="pt-1.5 border-t border-mycel-border flex">
+                  <button
+                    type="button"
+                    onClick={clearFilters}
+                    className="ml-auto px-2 py-1.5 text-xs text-mycel-muted hover:text-mycel-text border border-mycel-border rounded-md focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
+                    aria-label="Clear filters"
+                  >
+                    Clear
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </>
+    ) : undefined,
+  });
+
+  /* ── Loading / error states ─────────────────────────────────── */
+
+  if (loading && !data) {
+    return (
+      <div className="p-6 space-y-4">
+        <div className="h-20 animate-pulse rounded-lg bg-mycel-surface-hover" />
+        <LoadingSkeleton variant="text" rows={6} />
+      </div>
+    );
+  }
+  if (timedOut && !data) {
+    return (
+      <div className="p-6">
+        <EmptyState icon="!" title="Notifications took too long to load" description="The server may be unavailable." actionLabel="Retry" onAction={refresh} />
+      </div>
+    );
+  }
+  if (error && !data) {
+    return (
+      <div className="p-6">
+        <EmptyState icon="!" title="Failed to load notifications" description={error} actionLabel="Retry" onAction={refresh} />
+      </div>
+    );
+  }
+
+  /* ── Empty state: nothing configured yet ────────────────────── */
+  if (!hasAnything) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="max-w-lg text-center px-6">
+          <div className="text-4xl mb-4 opacity-40">#</div>
+          <h2 className="text-xl font-semibold text-mycel-text mb-2">Connect your first app</h2>
+          <p className="text-sm text-mycel-muted mb-6">
+            Link Slack, Telegram, WhatsApp, Discord and more to start routing messages to your agents.
+          </p>
+          <button
+            type="button"
+            onClick={() => { setChooserOpen(true); }}
+            className="inline-flex items-center h-8 px-3 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors"
+          >
+            + Connect an app
+          </button>
+        </div>
+        {chooserOpen && (
+          <PlatformChooser
+            onSelect={(key) => { setChooserOpen(false); setSetupPlatform(key); }}
+            onClose={() => { setChooserOpen(false); }}
+          />
+        )}
+        {setupPlatform && (
+          <SetupWizard platform={setupPlatform} onClose={() => { setSetupPlatform(null); }} onConnected={() => { refresh(); }} />
+        )}
+      </div>
+    );
+  }
+
+  /* ── Channel grouping for render ────────────────────────────── */
+  const channelsByApp = new Map<string, ChannelItem[]>();
+  for (const ch of filteredChannels) {
+    const list = channelsByApp.get(ch.app) ?? [];
+    list.push(ch);
+    channelsByApp.set(ch.app, list);
+  }
+  for (const list of channelsByApp.values()) {
+    list.sort((a, b) => (b.lastActivity ?? 0) - (a.lastActivity ?? 0) || a.displayName.localeCompare(b.displayName));
+  }
+  const sectionApps = apps.filter((a) => (channelsByApp.get(a.key) ?? []).length > 0);
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="p-6 pb-24 space-y-6">
+        {/* ── Apps strip ─────────────────────────────────────── */}
+        <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
+          {apps.map((app) => {
+            const ago = app.lastActivity !== null ? formatRelative(app.lastActivity) : null;
+            return (
+              <div key={app.key} data-testid={`app-card-${app.key}`} className="rounded-lg border border-mycel-border bg-mycel-surface shadow-mycel-sm p-3 flex flex-col gap-1.5 min-w-0">
+                <div className="flex items-center gap-2 min-w-0">
+                  <AppIcon base={app.base} size={15} />
+                  <span className="truncate text-[13px] font-semibold text-mycel-text">{app.label}</span>
+                  {app.botName && (
+                    <span className="truncate text-[10.5px] text-mycel-muted">· {app.botName}</span>
+                  )}
+                  <span className="ml-auto shrink-0 flex items-center">
+                    <StatusDot status={app.status} title={app.status} />
+                  </span>
+                </div>
+                {app.status === "error" ? (
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="truncate text-[11px] text-mycel-error">{app.reason}</span>
+                    <button
+                      type="button"
+                      onClick={() => { setSetupPlatform(app.base); }}
+                      className="ml-auto shrink-0 inline-flex items-center h-6 px-2 text-[11px] font-medium rounded-md border border-mycel-border text-mycel-text-2 hover:text-mycel-text hover:border-mycel-accent transition-colors"
+                    >
+                      Reconnect
+                    </button>
+                  </div>
+                ) : (
+                  <span className="text-[11px] text-mycel-muted">
+                    {app.status === "connected" ? "Connected" : app.status === "connecting" ? "Connecting…" : "Not connected"}
+                  </span>
+                )}
+                <span className="text-[11px] text-mycel-muted tabular-nums">
+                  {String(app.channelCount)} channel{app.channelCount === 1 ? "" : "s"}
+                  {ago ? ` · active ${ago}` : ""}
+                </span>
+              </div>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() => { setChooserOpen(true); }}
+            className="rounded-lg border border-dashed border-mycel-border p-3 flex items-center justify-center gap-2 text-xs text-mycel-muted hover:text-mycel-text hover:border-mycel-accent transition-colors min-h-[72px]"
+          >
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+              <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+            Connect an app
+          </button>
+        </div>
+
+        {/* ── Channels + recent activity ─────────────────────── */}
+        <div className="grid gap-6 items-start lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="space-y-5 min-w-0">
+            {sectionApps.length === 0 && (
+              <div className="rounded-lg border border-mycel-border p-6 text-center text-xs text-mycel-muted">
+                {hasFilters ? "No channels match the current filters." : "No channels yet — messages create channels automatically."}
+              </div>
+            )}
+            {sectionApps.map((app) => {
+              const chs = channelsByApp.get(app.key) ?? [];
+              const groups = chs.filter((c) => c.kind === "group");
+              const people = chs.filter((c) => c.kind === "person");
+              const other = chs.filter((c) => c.kind === null);
+              const split = app.base === "whatsapp" && (groups.length > 0 || people.length > 0);
+              return (
+                <section key={app.key} aria-label={`${app.label} channels`}>
+                  <div className="flex items-center gap-2 mb-1.5">
+                    <AppIcon base={app.base} size={13} />
+                    <h3 className="text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">
+                      {app.label}{app.botName ? ` · ${app.botName}` : ""}
+                    </h3>
+                    <span className="text-[11px] text-mycel-muted tabular-nums">{chs.length}</span>
+                  </div>
+                  <div className="rounded-lg border border-mycel-border overflow-hidden divide-y divide-mycel-border">
+                    {split ? (
+                      <>
+                        {groups.length > 0 && (
+                          <>
+                            <SubsectionLabel label="Groups" count={groups.length} />
+                            {groups.map((ch) => <ChannelRowButton key={ch.name} ch={ch} onOpen={openChannel} />)}
+                          </>
+                        )}
+                        {people.length > 0 && (
+                          <>
+                            <SubsectionLabel label="People" count={people.length} />
+                            {people.map((ch) => <ChannelRowButton key={ch.name} ch={ch} onOpen={openChannel} />)}
+                          </>
+                        )}
+                        {other.length > 0 && (
+                          <>
+                            <SubsectionLabel label="Other" count={other.length} />
+                            {other.map((ch) => <ChannelRowButton key={ch.name} ch={ch} onOpen={openChannel} />)}
+                          </>
+                        )}
+                      </>
+                    ) : (
+                      chs.map((ch) => <ChannelRowButton key={ch.name} ch={ch} onOpen={openChannel} />)
+                    )}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+
+          {/* Right rail — recent activity across all channels */}
+          <aside className="rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden" aria-label="Recent activity">
+            <div className="px-3 py-2 border-b border-mycel-border">
+              <h3 className="text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">Recent activity</h3>
+            </div>
+            <div className="divide-y divide-mycel-border">
+              {recent.length === 0 && (
+                <div className="px-3 py-6 text-center text-xs text-mycel-muted">No messages yet</div>
+              )}
+              {recent.map((m) => (
+                <button
+                  key={`${m.channel}:${String(m.id)}`}
+                  type="button"
+                  onClick={() => { openChannel(m.channel); }}
+                  className="w-full text-left px-3 py-2 hover:bg-mycel-surface-hover transition-colors"
+                >
+                  <div className="flex items-center gap-1.5 mb-0.5 min-w-0">
+                    <AppIcon base={sourcePlatform(m.channel)} size={10} />
+                    <span className="truncate text-[10.5px] text-mycel-text-2">{channelLeaf(m.channel)}</span>
+                    <span className="ml-auto shrink-0 text-[10px] text-mycel-muted tabular-nums">
+                      {formatRelative(m.created_at)}
+                    </span>
+                  </div>
+                  <div className="truncate text-xs text-mycel-text-2">
+                    <span className="font-medium text-mycel-text">{cleanSender(m.sender)}</span>{" "}
+                    {oneLine(m.content)}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </aside>
+        </div>
+      </div>
+
+      {/* Connect / reconnect flows — the existing setup components */}
+      {chooserOpen && (
+        <PlatformChooser
+          onSelect={(key) => { setChooserOpen(false); setSetupPlatform(key); }}
+          onClose={() => { setChooserOpen(false); }}
+        />
+      )}
+      {setupPlatform && (
+        <SetupWizard platform={setupPlatform} onClose={() => { setSetupPlatform(null); }} onConnected={() => { refresh(); }} />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/notifications/appStatus.tsx
+++ b/web/src/components/notifications/appStatus.tsx
@@ -1,0 +1,76 @@
+/**
+ * Shared gateway/app connection-status helpers.
+ *
+ * Extracted from Layout's NotificationNavTree so the notifications home
+ * page and the drawer render the exact same status semantics: one
+ * status ladder, one disconnect-reason mapping, one dot.
+ */
+
+import type { GatewayHealth, GatewayStatus } from "../../api/client";
+
+export type AppStatus = "connected" | "connecting" | "error" | "idle";
+
+export function getAppStatus(gw?: GatewayStatus, h?: GatewayHealth): AppStatus {
+  if (h) {
+    if (h.connected) return "connected";
+    return h.status === "connecting" ? "connecting" : "error";
+  }
+  // Enabled gateway whose health has not reported yet reads as connecting.
+  if (gw?.enabled) return "connecting";
+  return "idle";
+}
+
+/** Map raw gateway errors to a short human-readable reason. */
+export function disconnectReason(base: string, h?: GatewayHealth): string {
+  if (base === "whatsapp") return "Scan QR to re-pair";
+  const err = h?.error ?? "";
+  if (/\b402\b|payment required|quota/i.test(err)) return "API quota/payment required";
+  if (/\b401\b|unauthorized|invalid[ _-]?(auth|token|credentials)/i.test(err)) return "Invalid credentials";
+  if (/\b403\b|forbidden/i.test(err)) return "Access denied";
+  if (/\b429\b|rate[ _-]?limit/i.test(err)) return "Rate limited";
+  if (/timeout|timed out|refused|unreachable|network|no such host|dns/i.test(err)) return "Connection failed";
+  return err || "Disconnected";
+}
+
+export const STATUS_DOT_TOKEN: Record<AppStatus, string> = {
+  connected: "var(--mycel-success)",
+  connecting: "var(--mycel-warning)",
+  error: "var(--mycel-error)",
+  idle: "var(--mycel-muted)",
+};
+
+/** 6px connection dot — the only status signal a healthy app shows. */
+export function StatusDot({ status, title }: { status: AppStatus; title?: string }) {
+  const token = STATUS_DOT_TOKEN[status];
+  return (
+    <span
+      className="shrink-0"
+      title={title}
+      style={{
+        width: 6,
+        height: 6,
+        borderRadius: 999,
+        background: token,
+        opacity: status === "idle" ? 0.35 : 1,
+        boxShadow: status === "connected" ? `0 0 5px color-mix(in srgb, ${token} 50%, transparent)` : "none",
+      }}
+    />
+  );
+}
+
+// Parse an ISO timestamp, guarding zero / unset / pre-2001 values that
+// produce nonsensical "17753690h ago" strings.
+export function parseActivityTs(iso?: string): number | null {
+  if (!iso) return null;
+  const ts = new Date(iso).getTime();
+  return Number.isFinite(ts) && ts > 978307200000 ? ts : null;
+}
+
+/** Compact relative time: "now", "5m", "3h", "2d". */
+export function formatAgoShort(ts: number): string {
+  const mins = Math.floor((Date.now() - ts) / 60000);
+  if (mins < 1) return "now";
+  if (mins < 60) return `${String(mins)}m`;
+  if (mins < 1440) return `${String(Math.floor(mins / 60))}h`;
+  return `${String(Math.floor(mins / 1440))}d`;
+}

--- a/web/src/views/Notifications.tsx
+++ b/web/src/views/Notifications.tsx
@@ -1,110 +1,43 @@
-import { useCallback, useEffect, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useCallback, useState } from "react";
+import { useParams } from "react-router-dom";
 import { api } from "../api/client";
 import type { NotificationSource } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { AgentPeekPanel } from "../components/AgentPeekPanel";
-import { LoadingSkeleton } from "../components/LoadingSkeleton";
-import { EmptyState } from "../components/EmptyState";
 import { GatewayFeed } from "../components/notifications/GatewayFeed";
+import { NotificationsHome } from "../components/notifications/NotificationsHome";
 
+/**
+ * /notifications — the hub (NotificationsHome) when no channel is
+ * selected; the existing channel feed when one is. The hub owns its own
+ * data fetching, loading and empty states.
+ */
 export function Notifications() {
   // No page title in the header — the drawer names the section.
   // GatewayFeed contributes its channel breadcrumb when a channel is active.
   const { sourceName: paramSource } = useParams<{ sourceName: string }>();
-  const navigate = useNavigate();
-
-  const fetcher = useCallback(() => api.listNotificationSources(), []);
-  const { data: sources, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
-
   const selected = paramSource ?? null;
   const [peekAgent, setPeekAgent] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!selected && sources && sources.length > 0) {
-      const gwSource = sources.find((c) => c.name.includes(":"));
-      if (gwSource) {
-        navigate("/notifications/" + gwSource.name, { replace: true });
-      }
-    }
-  }, [selected, sources, navigate]);
+  // Sources are only needed to hand the selected channel's metadata
+  // (description/topic) to the feed; the hub fetches its own data.
+  const fetcher = useCallback(() => api.listNotificationSources(), []);
+  const { data: sources } = usePolling(fetcher, 10000);
 
-  if (loading && !sources) {
-    return (
-      <div className="p-6 space-y-4">
-        <div className="h-6 w-28 animate-pulse rounded bg-mycel-surface-hover" />
-        <LoadingSkeleton variant="text" rows={5} />
-      </div>
-    );
+  if (!selected) {
+    return <NotificationsHome />;
   }
 
-  if (timedOut && !sources) {
-    return (
-      <div className="p-6">
-        <EmptyState
-          icon="!"
-          title="Notifications took too long to load"
-          description="The server may be unavailable."
-          actionLabel="Retry"
-          onAction={refresh}
-        />
-      </div>
-    );
-  }
-
-  if (error && !sources) {
-    return (
-      <div className="p-6">
-        <EmptyState
-          icon="!"
-          title="Failed to load notifications"
-          description={error}
-          actionLabel="Retry"
-          onAction={refresh}
-        />
-      </div>
-    );
-  }
-
-  const sourceList = sources ?? [];
-  const selectedSource = sourceList.find((c: NotificationSource) => c.name === selected);
-
-  const hasGatewaySources = sourceList.some(
-    (c) => c.name.startsWith("slack:") || c.name.startsWith("telegram:") || c.name.startsWith("discord:")
-  );
-
-  if (!hasGatewaySources) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <div className="max-w-lg text-center px-6">
-          <div className="text-4xl mb-4 opacity-40">#</div>
-          <h2 className="text-xl font-semibold text-mycel-text mb-2">Connect your first app</h2>
-          <p className="text-sm text-mycel-muted mb-8">
-            Link Slack, Telegram, or Discord to start receiving messages in your agents.
-          </p>
-        </div>
-      </div>
-    );
-  }
+  const selectedSource = (sources ?? []).find((c: NotificationSource) => c.name === selected);
 
   return (
     <div className="flex h-full">
       <div className="flex-1 flex flex-col min-w-0">
-        {selected ? (
-          <GatewayFeed
-            channelName={selected}
-            channel={selectedSource}
-            onPeekAgent={setPeekAgent}
-          />
-        ) : (
-          <div className="flex-1 flex items-center justify-center">
-            <EmptyState
-              icon="#"
-              title="Select a channel"
-              description="Choose a channel from the sidebar to view its activity feed."
-            />
-          </div>
-        )}
+        <GatewayFeed
+          channelName={selected}
+          channel={selectedSource}
+          onPeekAgent={setPeekAgent}
+        />
       </div>
 
       {peekAgent && (

--- a/web/src/views/__tests__/notificationsHome.test.tsx
+++ b/web/src/views/__tests__/notificationsHome.test.tsx
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HeaderSlotProvider, useHeaderSlotContext } from "../../context/HeaderSlotContext";
+import {
+  NotificationsHome,
+  buildHomeModel,
+  channelLeaf,
+  resolveChannelKind,
+  whatsappKindFromId,
+} from "../../components/notifications/NotificationsHome";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function errorResponse(status: number) {
+  return Promise.resolve({
+    ok: false,
+    status,
+    statusText: "Not Found",
+    json: () => Promise.resolve({ error: "not found" }),
+  } as Response);
+}
+
+/* ── Fixtures ────────────────────────────────────────────────── */
+
+const NOW = new Date().toISOString();
+const GROUP_CH = "whatsapp:12345-67890@g.us";
+const PERSON_CH = "whatsapp:919876543210@s.whatsapp.net";
+const SLACK_CH = "slack:general";
+
+const overview = {
+  apps: [
+    { name: "whatsapp", platform: "whatsapp", connected: true, channel_count: 2, last_activity: NOW },
+    { name: "slack", platform: "slack", connected: false, disconnect_reason: "Invalid credentials", channel_count: 1 },
+  ],
+  channels: [
+    {
+      bc_channel: GROUP_CH,
+      platform: "whatsapp",
+      display_name: "Family Group",
+      kind: "group",
+      participant_count: 12,
+      subscriber_count: 1,
+      message_count: 42,
+      last_activity: NOW,
+    },
+    {
+      bc_channel: PERSON_CH,
+      platform: "whatsapp",
+      display_name: "Puneet Rai",
+      kind: "person",
+      message_count: 7,
+      last_activity: NOW,
+    },
+    { bc_channel: SLACK_CH, platform: "slack", display_name: "general", message_count: 3, last_activity: NOW },
+  ],
+};
+
+const sources = [
+  { name: GROUP_CH, description: "Gateway channel", members: [], member_count: 0 },
+  { name: PERSON_CH, description: "Gateway channel", members: [], member_count: 0 },
+  { name: SLACK_CH, description: "Gateway channel", members: [], member_count: 0 },
+];
+
+const gateways = [
+  { platform: "whatsapp", enabled: true, channels: [] },
+  { platform: "slack", enabled: true, channels: [] },
+];
+
+const subs = [
+  { id: 1, channel: GROUP_CH, agent: "zen-zebra", mention_only: false, created_at: NOW },
+];
+
+const stats = [
+  { name: GROUP_CH, message_count: 42, member_count: 0, last_activity: NOW, top_senders: [] },
+];
+
+const groupHistory = [
+  { id: 1, sender: "[whatsapp] Mom", content: "Dinner at 8", created_at: NOW },
+];
+
+/** Route the fetch mock by URL. `overviewBody: null` simulates a 404 —
+ *  the backend half of #3310 not deployed yet. */
+function mockRoutes({ overviewBody = overview as unknown }: { overviewBody?: unknown } = {}) {
+  fetchMock.mockImplementation((url: RequestInfo | URL) => {
+    const u = String(url);
+    if (u.includes("/api/notifications/overview")) {
+      return overviewBody === null ? errorResponse(404) : jsonResponse(overviewBody);
+    }
+    if (u.includes("/history")) {
+      return jsonResponse(u.includes(encodeURIComponent(GROUP_CH)) || u.includes(GROUP_CH) ? groupHistory : []);
+    }
+    if (/\/api\/gateways\/[^/]+\/health/.test(u)) {
+      if (u.includes("whatsapp")) {
+        return jsonResponse({ platform: "whatsapp", connected: true, status: "connected", last_message_at: NOW });
+      }
+      return jsonResponse({ platform: "slack", connected: false, status: "error", error: "invalid_auth" });
+    }
+    if (u.includes("/api/gateways")) return jsonResponse(gateways);
+    if (u.includes("/notify/subscriptions")) return jsonResponse(subs);
+    if (u.includes("/stats/channels")) return jsonResponse(stats);
+    if (u.includes("/api/channels")) return jsonResponse(sources);
+    return jsonResponse([]);
+  });
+}
+
+/* ── Harness — renders the header slot like Layout does ──────── */
+
+function HeaderHost() {
+  const { slot } = useHeaderSlotContext();
+  return (
+    <div data-testid="header-host">
+      {slot.title}
+      {slot.actions}
+    </div>
+  );
+}
+
+function renderHome() {
+  return render(
+    <MemoryRouter>
+      <HeaderSlotProvider>
+        <HeaderHost />
+        <NotificationsHome />
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+/* ── Pure helpers ────────────────────────────────────────────── */
+
+describe("NotificationsHome helpers", () => {
+  it("classifies WhatsApp channels by JID shape", () => {
+    expect(whatsappKindFromId(GROUP_CH)).toBe("group");
+    expect(whatsappKindFromId(PERSON_CH)).toBe("person");
+    expect(whatsappKindFromId("whatsapp:status")).toBeNull();
+  });
+
+  it("prefers adapter metadata over JID shape", () => {
+    expect(resolveChannelKind(PERSON_CH, "whatsapp", "group")).toBe("group");
+    expect(resolveChannelKind(GROUP_CH, "whatsapp", undefined)).toBe("group");
+    expect(resolveChannelKind(SLACK_CH, "slack", undefined)).toBeNull();
+  });
+
+  it("extracts the leaf channel segment", () => {
+    expect(channelLeaf("discord:Server:general")).toBe("general");
+    expect(channelLeaf(GROUP_CH)).toBe("12345-67890@g.us");
+  });
+
+  it("buildHomeModel merges overview metadata over composed endpoints", () => {
+    const { apps, channels } = buildHomeModel({
+      overview,
+      sources,
+      gateways,
+      health: {
+        whatsapp: { platform: "whatsapp", connected: true, status: "connected", last_message_at: NOW },
+      },
+      subs,
+      stats,
+    });
+    const group = channels.find((c) => c.name === GROUP_CH);
+    expect(group?.displayName).toBe("Family Group");
+    expect(group?.kind).toBe("group");
+    expect(group?.participantCount).toBe(12);
+    expect(group?.subscribers).toEqual(["zen-zebra"]);
+    expect(group?.messageCount).toBe(42);
+    const wa = apps.find((a) => a.key === "whatsapp");
+    expect(wa?.status).toBe("connected");
+    expect(wa?.channelCount).toBe(2);
+  });
+
+  it("buildHomeModel degrades without overview data", () => {
+    const { channels } = buildHomeModel({
+      overview: null,
+      sources,
+      gateways,
+      health: {},
+      subs,
+      stats,
+    });
+    const group = channels.find((c) => c.name === GROUP_CH);
+    expect(group?.displayName).toBe("12345-67890@g.us");
+    expect(group?.kind).toBe("group"); // JID-shape fallback
+    expect(group?.messageCount).toBe(42); // from /stats/channels
+    const person = channels.find((c) => c.name === PERSON_CH);
+    expect(person?.kind).toBe("person");
+  });
+});
+
+/* ── Page ────────────────────────────────────────────────────── */
+
+describe("NotificationsHome", () => {
+  it("renders apps strip and channels grouped by app from overview data", async () => {
+    mockRoutes();
+    renderHome();
+
+    await waitFor(() => {
+      expect(screen.getByText("Family Group")).toBeInTheDocument();
+    });
+
+    // Apps strip: one card per app, connection state + reconnect where broken.
+    const waCard = screen.getByTestId("app-card-whatsapp");
+    expect(within(waCard).getByText("Connected")).toBeInTheDocument();
+    const slackCard = screen.getByTestId("app-card-slack");
+    expect(within(slackCard).getByText("Invalid credentials")).toBeInTheDocument();
+    expect(within(slackCard).getByRole("button", { name: "Reconnect" })).toBeInTheDocument();
+
+    // Connect-an-app card reuses the existing setup flow.
+    expect(screen.getByRole("button", { name: /Connect an app/ })).toBeInTheDocument();
+
+    // Channel rows show resolved display names and counts.
+    expect(screen.getByText("Puneet Rai")).toBeInTheDocument();
+    expect(screen.getByText("general")).toBeInTheDocument();
+    expect(screen.getByText("12 members")).toBeInTheDocument();
+    expect(screen.getByText("42 msgs")).toBeInTheDocument();
+  });
+
+  it("splits WhatsApp channels into Groups and People sections", async () => {
+    mockRoutes();
+    renderHome();
+
+    await waitFor(() => {
+      expect(screen.getByText("Groups")).toBeInTheDocument();
+    });
+    expect(screen.getByText("People")).toBeInTheDocument();
+
+    const waSection = screen.getByRole("region", { name: "WhatsApp channels" });
+    expect(within(waSection).getByText("Family Group")).toBeInTheDocument();
+    expect(within(waSection).getByText("Puneet Rai")).toBeInTheDocument();
+    // Slack channels get no Groups/People split.
+    const slackSection = screen.getByRole("region", { name: "Slack channels" });
+    expect(within(slackSection).queryByText("Groups")).not.toBeInTheDocument();
+  });
+
+  it("degrades gracefully when the overview endpoint is missing", async () => {
+    mockRoutes({ overviewBody: null });
+    renderHome();
+
+    // Raw channel ids stand in for display names… (the id also shows in
+    // the recent-activity channel chip, hence getAllByText)
+    await waitFor(() => {
+      expect(screen.getAllByText("12345-67890@g.us").length).toBeGreaterThan(0);
+    });
+    // …but the Groups/People split still works via JID shape,
+    expect(screen.getByText("Groups")).toBeInTheDocument();
+    expect(screen.getByText("People")).toBeInTheDocument();
+    // and message counts still come from the stats endpoint.
+    expect(screen.getByText("42 msgs")).toBeInTheDocument();
+  });
+
+  it("search in the header filters channels by name", async () => {
+    mockRoutes();
+    renderHome();
+    await waitFor(() => {
+      expect(screen.getByText("Family Group")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Search channels"), { target: { value: "family" } });
+
+    expect(screen.getByText("Family Group")).toBeInTheDocument();
+    expect(screen.queryByText("Puneet Rai")).not.toBeInTheDocument();
+    expect(screen.getByText("1 of 3 channels")).toBeInTheDocument();
+  });
+
+  it("Filters chip narrows to channels with subscribers", async () => {
+    mockRoutes();
+    renderHome();
+    await waitFor(() => {
+      expect(screen.getByText("Family Group")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    fireEvent.click(screen.getByLabelText("Has subscribers"));
+
+    expect(screen.getByText("Family Group")).toBeInTheDocument();
+    expect(screen.queryByText("Puneet Rai")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("general")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders recent activity across channels with click-through chips", async () => {
+    mockRoutes();
+    renderHome();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Dinner at 8/)).toBeInTheDocument();
+    });
+    // Sender is cleaned of its platform prefix.
+    expect(screen.getByText("Mom")).toBeInTheDocument();
+  });
+});

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -296,18 +296,31 @@ describe("Notifications", () => {
     });
   });
 
-  it("renders empty state for gateway notification sources", async () => {
-    // Simulate a slack gateway source — the frontend renders a feed view.
-    fetchMock.mockReturnValue(
-      jsonResponse([
-        { name: "slack:general", description: "Gateway channel", members: [], member_count: 0 },
-      ]),
-    );
+  it("renders the notifications home hub when no channel is selected", async () => {
+    // Simulate a slack gateway source — the hub lists it grouped by app.
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/notifications/overview")) {
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          json: () => Promise.resolve({ error: "not found" }),
+        } as Response);
+      }
+      if (u.includes("/api/channels") && !u.includes("/history")) {
+        return jsonResponse([
+          { name: "slack:general", description: "Gateway channel", members: [], member_count: 0 },
+        ]);
+      }
+      return jsonResponse([]);
+    });
     wrap(<Notifications />);
     await waitFor(() => {
-      // When a gateway source exists but none is selected, shows "Select a channel".
-      expect(screen.getByText("Select a channel")).toBeInTheDocument();
+      // The hub renders the channel row (leaf name) and the connect card.
+      expect(screen.getByText("general")).toBeInTheDocument();
     });
+    expect(screen.getByRole("button", { name: /Connect an app/ })).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

Part of #3310 (frontend half). `/notifications` with no channel selected becomes a comprehensive hub; selecting a channel keeps the existing feed view.

### Apps strip
- One card per connected/configured gateway: platform icon, name, connection dot + human-readable reason (the drawer's `disconnectReason`/`getAppStatus`/`StatusDot` were extracted to a shared `appStatus.tsx` so both surfaces render identical semantics), channel count, last activity.
- **Reconnect** on broken apps opens the existing `SetupWizard`; **+ Connect an app** opens the existing `PlatformChooser` — no new connection flows.

### Channels (main section)
- All gateway channels grouped by app. WhatsApp splits into **Groups** / **People** subsections.
- Rows show `display_name` (fallback: raw `bc_channel` suffix), participant count for groups, subscriber count with agent avatars, message count, and last-activity relative time. Row click → existing channel feed.
- Header slot (Agents-page pattern): count summary, channel search box, **Filters** chip with app multi-select, *Has subscribers*, *Active in last 24h*, and Clear.

### Recent activity (right rail)
- Newest ~15 messages across the most recently active channels, with platform/channel chips and click-through.

### Data & graceful degradation
- Tries `GET /api/notifications/overview` (backend being built in parallel) and merges it field-by-field over the composed model from existing endpoints: `/channels`, `/gateways` (+ per-gateway health), `/notify/subscriptions`, `/stats/channels`, per-channel `/history`.
- Until `display_name`/`kind` exist, WhatsApp section membership is derived client-side from JID shape (`@g.us` → group, `@s.whatsapp.net` → person) and raw ids are displayed — the page is shippable standalone.

### Drawer enrichment
- Compact per-app summary line (*N channels · active Xm ago*) under each app group header, replacing the lone "ago" chip.

## Tests
- New `notificationsHome.test.tsx` (10 tests): pure-helper unit tests (JID classification, kind resolution, `buildHomeModel` merge + fallback) and page tests (sections render from mocked overview, WhatsApp Groups/People split, graceful 404 fallback, header search filtering, Filters chip has-subscribers, recent activity rail).
- Updated the Notifications view tests for the hub (no more auto-redirect / "Select a channel").

## Gates
- `bun run build` ✓ · `bunx tsc --noEmit` ✓ · `bun run test` ✓ (144 passed) · `eslint src` ✓
- Token classes only (`mycel-*` Tailwind tokens / CSS vars) — works in both themes.

Part of #3310

🤖 Generated with [Claude Code](https://claude.com/claude-code)