### PR TITLE
feat(gateway): channel identity resolution — real names for WhatsApp channels

### DIFF
--- a/pkg/gateway/discord/discord.go
+++ b/pkg/gateway/discord/discord.go
@@ -141,6 +141,7 @@ func (a *Adapter) Channels() []gateway.ChannelInfo {
 			ID:       id,
 			Name:     name,
 			Platform: "discord",
+			Kind:     gateway.ChannelKindChannel,
 		})
 	}
 	return channels

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -55,6 +55,7 @@ type Notification struct {
 	Timestamp time.Time       `json:"timestamp"`
 	Raw       json.RawMessage `json:"raw"`
 	Channel   string          `json:"channel"`
+	ChannelID string          `json:"channel_id,omitempty"` // platform-native channel id (e.g. WhatsApp JID), if known
 	Platform  string          `json:"platform"`
 	Sender    string          `json:"sender"`
 	Content   string          `json:"content"` // human-readable text for display/storage
@@ -66,6 +67,30 @@ type ChannelInfo struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
 	Platform string `json:"platform"`
+	Kind     string `json:"kind,omitempty"` // group | person | channel | feed | other
+}
+
+// Channel kind values stored in channel metadata.
+const (
+	ChannelKindGroup   = "group"
+	ChannelKindPerson  = "person"
+	ChannelKindChannel = "channel"
+	ChannelKindFeed    = "feed"
+	ChannelKindOther   = "other"
+)
+
+// ChannelMeta is human-readable display metadata for a platform channel.
+type ChannelMeta struct {
+	DisplayName      string
+	Kind             string // group | person | channel | feed | other
+	ParticipantCount int
+}
+
+// ChannelIdentity is optionally implemented by adapters that can resolve
+// human-readable channel metadata (names, kinds) from their platform.
+type ChannelIdentity interface {
+	// ResolveChannel returns display metadata for a platform channel id.
+	ResolveChannel(ctx context.Context, platformID string) (ChannelMeta, error)
 }
 
 // AdapterStatus reports connection state for the web UI.

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -30,6 +30,10 @@ type ChannelStore interface {
 	SaveChannel(ctx context.Context, bcChannel, platform, platformID string) error
 	LoadChannels(ctx context.Context) ([]PersistedChannel, error)
 	UpsertChannelMeta(ctx context.Context, bcChannel, displayName, kind string, participantCount int) error
+	// UpdateChannelPlatformID force-overwrites a channel's platform id —
+	// used when a fallback route is upgraded to a native id (SaveChannel
+	// deliberately preserves existing non-empty ids).
+	UpdateChannelPlatformID(ctx context.Context, bcChannel, platformID string) error
 }
 
 // messageSender is checked at runtime for adapters that support outbound messaging.
@@ -457,7 +461,11 @@ func (m *Manager) RefreshChannelMeta(ctx context.Context) (int, error) {
 		if !ok {
 			continue
 		}
-		meta, err := resolver.ResolveChannel(ctx, e.route.ChannelID)
+		// Per-channel timeout: one stuck adapter call must not hold the
+		// whole refresh (mirrors persistChannelMeta's bound).
+		resolveCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		meta, err := resolver.ResolveChannel(resolveCtx, e.route.ChannelID)
+		cancel()
 		if err != nil || meta == (ChannelMeta{}) {
 			continue
 		}
@@ -516,6 +524,7 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 	m.mu.Lock()
 	route, exists := m.channelMap[bcChannel]
 	needMeta := false
+	upgradedID := ""
 	if !exists {
 		route = channelRoute{
 			Platform:  platform,
@@ -529,11 +538,23 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 		route.ChannelID = n.ChannelID
 		m.channelMap[bcChannel] = route
 		needMeta = true
+		upgradedID = n.ChannelID
 		log.Info("gateway: upgraded channel route to native id", "bc_channel", bcChannel, "channel_id", n.ChannelID)
 	}
 	m.mu.Unlock()
 	if !exists {
 		m.persistChannel(bcChannel, platform, channelID)
+	}
+	if upgradedID != "" && m.channelStore != nil {
+		// Persist the upgrade — without this a quiet channel reloads the
+		// stale fallback id after restart and identity resolution breaks.
+		go func(bc, id string) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := m.channelStore.UpdateChannelPlatformID(ctx, bc, id); err != nil {
+				log.Warn("gateway: failed to persist upgraded channel id", "channel", bc, "error", err)
+			}
+		}(bcChannel, upgradedID)
 	}
 	if needMeta {
 		m.persistChannelMeta(route.Adapter, bcChannel, route.ChannelID, ChannelMeta{})

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -13,11 +13,15 @@ import (
 	"github.com/rpuneet/mycel/pkg/log"
 )
 
-// PersistedChannel is a saved bc_channel → platform_id mapping.
+// PersistedChannel is a saved bc_channel → platform_id mapping with
+// optional display metadata.
 type PersistedChannel struct {
-	BCChannel  string
-	Platform   string
-	PlatformID string
+	BCChannel        string
+	Platform         string
+	PlatformID       string
+	DisplayName      string
+	Kind             string
+	ParticipantCount int
 }
 
 // ChannelStore persists channel mappings so they survive server restarts.
@@ -25,6 +29,7 @@ type PersistedChannel struct {
 type ChannelStore interface {
 	SaveChannel(ctx context.Context, bcChannel, platform, platformID string) error
 	LoadChannels(ctx context.Context) ([]PersistedChannel, error)
+	UpsertChannelMeta(ctx context.Context, bcChannel, displayName, kind string, participantCount int) error
 }
 
 // messageSender is checked at runtime for adapters that support outbound messaging.
@@ -152,7 +157,10 @@ func (m *Manager) restorePersistedChannels(ctx context.Context) {
 // discoverChannels discovers channels from an adapter.
 func (m *Manager) discoverChannels(a NotificationAdapter) {
 	channels := a.Channels()
-	type discovered struct{ bc, platform, id string }
+	type discovered struct {
+		bc, platform, id string
+		meta             ChannelMeta
+	}
 	toPersist := make([]discovered, 0, len(channels))
 	m.mu.Lock()
 	for _, ch := range channels {
@@ -162,12 +170,13 @@ func (m *Manager) discoverChannels(a NotificationAdapter) {
 			ChannelID: ch.ID,
 			Adapter:   a,
 		}
-		toPersist = append(toPersist, discovered{bcName, a.Name(), ch.ID})
+		toPersist = append(toPersist, discovered{bcName, a.Name(), ch.ID, ChannelMeta{DisplayName: ch.Name, Kind: ch.Kind}})
 		log.Info("gateway: discovered channel", "bc_channel", bcName, "platform_id", ch.ID)
 	}
 	m.mu.Unlock()
 	for _, d := range toPersist {
 		m.persistChannel(d.bc, d.platform, d.id)
+		m.persistChannelMeta(a, d.bc, d.id, d.meta)
 	}
 }
 
@@ -188,7 +197,10 @@ func (m *Manager) lateDiscovery(ctx context.Context) {
 
 	for _, a := range adapterList {
 		channels := a.Channels()
-		type lateDiscovered struct{ bc, platform, id string }
+		type lateDiscovered struct {
+			bc, platform, id string
+			meta             ChannelMeta
+		}
 		var latePersist []lateDiscovered
 		m.mu.Lock()
 		for _, ch := range channels {
@@ -199,14 +211,49 @@ func (m *Manager) lateDiscovery(ctx context.Context) {
 					ChannelID: ch.ID,
 					Adapter:   a,
 				}
-				latePersist = append(latePersist, lateDiscovered{bcName, a.Name(), ch.ID})
+				latePersist = append(latePersist, lateDiscovered{bcName, a.Name(), ch.ID, ChannelMeta{DisplayName: ch.Name, Kind: ch.Kind}})
 				log.Info("gateway: late-discovered channel", "bc_channel", bcName, "platform_id", ch.ID)
 			}
 		}
 		m.mu.Unlock()
 		for _, d := range latePersist {
 			m.persistChannel(d.bc, d.platform, d.id)
+			m.persistChannelMeta(a, d.bc, d.id, d.meta)
 		}
+	}
+
+	// Backfill display metadata for restored channels that predate identity
+	// resolution (rows persisted without a display_name). Runs synchronously
+	// in this goroutine so platform lookups stay sequential — WhatsApp rate
+	// limits info queries.
+	m.resolveMissingMeta(ctx)
+}
+
+// resolveMissingMeta resolves display metadata for persisted channels that
+// lack a display name, using adapters that implement ChannelIdentity.
+func (m *Manager) resolveMissingMeta(ctx context.Context) {
+	if m.channelStore == nil {
+		return
+	}
+	saved, err := m.channelStore.LoadChannels(ctx)
+	if err != nil {
+		log.Warn("gateway: failed to load channels for meta backfill", "error", err)
+		return
+	}
+	for _, ch := range saved {
+		if ch.DisplayName != "" || ctx.Err() != nil {
+			continue
+		}
+		m.mu.RLock()
+		route, ok := m.channelMap[ch.BCChannel]
+		m.mu.RUnlock()
+		if !ok {
+			continue
+		}
+		if _, isResolver := route.Adapter.(ChannelIdentity); !isResolver {
+			continue
+		}
+		m.resolveAndStoreMeta(ctx, route.Adapter, ch.BCChannel, route.ChannelID, ChannelMeta{})
 	}
 }
 
@@ -329,6 +376,100 @@ func (m *Manager) persistChannel(bcChannel, platform, platformID string) {
 	}()
 }
 
+// persistChannelMeta resolves and saves display metadata for a channel
+// (non-blocking, best-effort). If the adapter implements ChannelIdentity the
+// resolved values win; otherwise the fallback (from discovery) is stored.
+func (m *Manager) persistChannelMeta(a NotificationAdapter, bcChannel, platformID string, fallback ChannelMeta) {
+	if m.channelStore == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		m.resolveAndStoreMeta(ctx, a, bcChannel, platformID, fallback)
+	}()
+}
+
+// resolveAndStoreMeta synchronously resolves channel metadata and upserts it.
+func (m *Manager) resolveAndStoreMeta(ctx context.Context, a NotificationAdapter, bcChannel, platformID string, fallback ChannelMeta) {
+	meta := m.resolveChannelMeta(ctx, a, platformID, fallback)
+	if meta == (ChannelMeta{}) {
+		return
+	}
+	if err := m.channelStore.UpsertChannelMeta(ctx, bcChannel, meta.DisplayName, meta.Kind, meta.ParticipantCount); err != nil {
+		log.Warn("gateway: failed to persist channel meta", "channel", bcChannel, "error", err)
+	}
+}
+
+// resolveChannelMeta asks the adapter for channel identity, falling back to
+// discovery-time metadata when the adapter cannot resolve.
+func (m *Manager) resolveChannelMeta(ctx context.Context, a NotificationAdapter, platformID string, fallback ChannelMeta) ChannelMeta {
+	meta := fallback
+	if a == nil {
+		return meta
+	}
+	resolver, ok := a.(ChannelIdentity)
+	if !ok {
+		return meta
+	}
+	resolved, err := resolver.ResolveChannel(ctx, platformID)
+	if err != nil {
+		log.Debug("gateway: channel identity resolution failed", "adapter", a.Name(), "platform_id", platformID, "error", err)
+		return meta
+	}
+	if resolved.DisplayName != "" {
+		meta.DisplayName = resolved.DisplayName
+	}
+	if resolved.Kind != "" {
+		meta.Kind = resolved.Kind
+	}
+	if resolved.ParticipantCount > 0 {
+		meta.ParticipantCount = resolved.ParticipantCount
+	}
+	return meta
+}
+
+// RefreshChannelMeta re-resolves display metadata for all known channels
+// whose adapter implements ChannelIdentity, and persists the results.
+// Returns the number of channels refreshed.
+func (m *Manager) RefreshChannelMeta(ctx context.Context) (int, error) {
+	if m.channelStore == nil {
+		return 0, nil
+	}
+
+	type entry struct {
+		bc    string
+		route channelRoute
+	}
+	m.mu.RLock()
+	entries := make([]entry, 0, len(m.channelMap))
+	for bc, route := range m.channelMap {
+		entries = append(entries, entry{bc, route})
+	}
+	m.mu.RUnlock()
+
+	refreshed := 0
+	for _, e := range entries {
+		if err := ctx.Err(); err != nil {
+			return refreshed, err
+		}
+		resolver, ok := e.route.Adapter.(ChannelIdentity)
+		if !ok {
+			continue
+		}
+		meta, err := resolver.ResolveChannel(ctx, e.route.ChannelID)
+		if err != nil || meta == (ChannelMeta{}) {
+			continue
+		}
+		if err := m.channelStore.UpsertChannelMeta(ctx, e.bc, meta.DisplayName, meta.Kind, meta.ParticipantCount); err != nil {
+			log.Warn("gateway: failed to refresh channel meta", "channel", e.bc, "error", err)
+			continue
+		}
+		refreshed++
+	}
+	return refreshed, nil
+}
+
 // DiscoveredSources returns all discovered external channels.
 func (m *Manager) DiscoveredSources() []string {
 	m.mu.RLock()
@@ -348,38 +489,54 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 	}
 	bcChannel := platform + ":" + sanitizeChannelName(channelName)
 
-	// Determine the channel ID for routing. For platforms that need a
-	// numeric ID (e.g., Telegram chat_id), extract it from the raw payload.
-	// Fall back to the channel name if extraction fails.
-	channelID := channelName
-	if len(n.Raw) > 0 {
-		var rawMsg struct {
-			Message struct {
-				Chat struct {
-					ID int64 `json:"id"`
-				} `json:"chat"`
-			} `json:"message"`
-		}
-		if err := json.Unmarshal(n.Raw, &rawMsg); err == nil && rawMsg.Message.Chat.ID != 0 {
-			channelID = strconv.FormatInt(rawMsg.Message.Chat.ID, 10)
+	// Determine the channel ID for routing. Prefer the platform-native id
+	// supplied by the adapter (e.g., WhatsApp JID). Otherwise, for platforms
+	// that need a numeric ID (e.g., Telegram chat_id), extract it from the
+	// raw payload. Fall back to the channel name if extraction fails.
+	channelID := n.ChannelID
+	if channelID == "" {
+		channelID = channelName
+		if len(n.Raw) > 0 {
+			var rawMsg struct {
+				Message struct {
+					Chat struct {
+						ID int64 `json:"id"`
+					} `json:"chat"`
+				} `json:"message"`
+			}
+			if err := json.Unmarshal(n.Raw, &rawMsg); err == nil && rawMsg.Message.Chat.ID != 0 {
+				channelID = strconv.FormatInt(rawMsg.Message.Chat.ID, 10)
+			}
 		}
 	}
 
-	// Ensure channel is in the map — only persist when first created
+	// Ensure channel is in the map — only persist when first created. An
+	// adapter-supplied native id also upgrades a route that was created (or
+	// restored) with a fallback id, so identity resolution can work.
 	m.mu.Lock()
-	_, exists := m.channelMap[bcChannel]
+	route, exists := m.channelMap[bcChannel]
+	needMeta := false
 	if !exists {
-		adapter := m.adapters[platform]
-		m.channelMap[bcChannel] = channelRoute{
+		route = channelRoute{
 			Platform:  platform,
 			ChannelID: channelID,
-			Adapter:   adapter,
+			Adapter:   m.adapters[platform],
 		}
+		m.channelMap[bcChannel] = route
+		needMeta = true
 		log.Info("gateway: dynamically mapped notification channel", "bc_channel", bcChannel, "platform", platform, "channel_id", channelID)
+	} else if n.ChannelID != "" && route.ChannelID != n.ChannelID {
+		route.ChannelID = n.ChannelID
+		m.channelMap[bcChannel] = route
+		needMeta = true
+		log.Info("gateway: upgraded channel route to native id", "bc_channel", bcChannel, "channel_id", n.ChannelID)
 	}
 	m.mu.Unlock()
 	if !exists {
 		m.persistChannel(bcChannel, platform, channelID)
+	}
+	if needMeta {
+		m.persistChannelMeta(route.Adapter, bcChannel, route.ChannelID, ChannelMeta{})
 	}
 
 	sender := fmt.Sprintf("[%s] %s", platform, n.Sender)

--- a/pkg/gateway/manager_test.go
+++ b/pkg/gateway/manager_test.go
@@ -2,8 +2,11 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestSanitizeChannelName(t *testing.T) {
@@ -128,5 +131,237 @@ func TestAdapterStatusUnknown(t *testing.T) {
 	status := m.AdapterStatus("unknown")
 	if status.Error != "adapter not registered" {
 		t.Errorf("expected 'adapter not registered' error, got %q", status.Error)
+	}
+}
+
+// fakeChannelStore records SaveChannel/UpsertChannelMeta calls in memory.
+type fakeChannelStore struct {
+	saved map[string]PersistedChannel
+	mu    sync.Mutex
+}
+
+func newFakeChannelStore() *fakeChannelStore {
+	return &fakeChannelStore{saved: make(map[string]PersistedChannel)}
+}
+
+func (f *fakeChannelStore) SaveChannel(_ context.Context, bcChannel, platform, platformID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ch := f.saved[bcChannel]
+	ch.BCChannel, ch.Platform, ch.PlatformID = bcChannel, platform, platformID
+	f.saved[bcChannel] = ch
+	return nil
+}
+
+func (f *fakeChannelStore) LoadChannels(_ context.Context) ([]PersistedChannel, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]PersistedChannel, 0, len(f.saved))
+	for _, ch := range f.saved {
+		out = append(out, ch)
+	}
+	return out, nil
+}
+
+func (f *fakeChannelStore) UpsertChannelMeta(_ context.Context, bcChannel, displayName, kind string, participantCount int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ch := f.saved[bcChannel]
+	ch.BCChannel = bcChannel
+	if displayName != "" {
+		ch.DisplayName = displayName
+	}
+	if kind != "" {
+		ch.Kind = kind
+	}
+	if participantCount != 0 {
+		ch.ParticipantCount = participantCount
+	}
+	f.saved[bcChannel] = ch
+	return nil
+}
+
+func (f *fakeChannelStore) get(bcChannel string) (PersistedChannel, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ch, ok := f.saved[bcChannel]
+	return ch, ok
+}
+
+// identityAdapter is a mock adapter that also implements ChannelIdentity.
+type identityAdapter struct {
+	meta map[string]ChannelMeta
+	mockNotifAdapter
+	channels []ChannelInfo
+}
+
+func (a *identityAdapter) Channels() []ChannelInfo { return a.channels }
+
+func (a *identityAdapter) ResolveChannel(_ context.Context, platformID string) (ChannelMeta, error) {
+	m, ok := a.meta[platformID]
+	if !ok {
+		return ChannelMeta{}, fmt.Errorf("unresolvable: %s", platformID)
+	}
+	return m, nil
+}
+
+// waitFor polls until cond returns true or the deadline passes.
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met within deadline")
+}
+
+// TestDiscoverChannels_PersistsResolvedMeta asserts that discovery stores
+// identity-resolved metadata for adapters implementing ChannelIdentity.
+func TestDiscoverChannels_PersistsResolvedMeta(t *testing.T) {
+	store := newFakeChannelStore()
+	m := NewManager()
+	m.SetChannelStore(store)
+
+	a := &identityAdapter{
+		mockNotifAdapter: mockNotifAdapter{name: "whatsapp"},
+		channels:         []ChannelInfo{{ID: "1234@g.us", Name: "family", Platform: "whatsapp"}},
+		meta: map[string]ChannelMeta{
+			"1234@g.us": {DisplayName: "Family Group", Kind: ChannelKindGroup, ParticipantCount: 12},
+		},
+	}
+	m.Register(a)
+	m.discoverChannels(a)
+
+	waitFor(t, func() bool {
+		ch, ok := store.get("whatsapp:family")
+		return ok && ch.DisplayName == "Family Group" && ch.Kind == "group" && ch.ParticipantCount == 12
+	})
+}
+
+// TestDiscoverChannels_FallbackMetaFromDiscovery asserts that adapters
+// without ChannelIdentity still persist discovery-time name/kind.
+func TestDiscoverChannels_FallbackMetaFromDiscovery(t *testing.T) {
+	store := newFakeChannelStore()
+	m := NewManager()
+	m.SetChannelStore(store)
+
+	a := &identityAdapter{
+		mockNotifAdapter: mockNotifAdapter{name: "slack"},
+		channels:         []ChannelInfo{{ID: "C01", Name: "general", Platform: "slack", Kind: ChannelKindChannel}},
+		meta:             map[string]ChannelMeta{}, // resolution always fails → fallback
+	}
+	m.Register(a)
+	m.discoverChannels(a)
+
+	waitFor(t, func() bool {
+		ch, ok := store.get("slack:general")
+		return ok && ch.DisplayName == "general" && ch.Kind == "channel"
+	})
+}
+
+// TestHandleNotification_NativeChannelIDAndMeta asserts that an inbound
+// notification carrying a platform-native channel id maps the route with
+// that id and persists resolved metadata.
+func TestHandleNotification_NativeChannelIDAndMeta(t *testing.T) {
+	store := newFakeChannelStore()
+	m := NewManager()
+	m.SetChannelStore(store)
+
+	a := &identityAdapter{
+		mockNotifAdapter: mockNotifAdapter{name: "whatsapp"},
+		meta: map[string]ChannelMeta{
+			"1234@g.us": {DisplayName: "Family Group", Kind: ChannelKindGroup, ParticipantCount: 4},
+		},
+	}
+	m.Register(a)
+
+	m.handleNotification("whatsapp", Notification{
+		Channel:   "family",
+		ChannelID: "1234@g.us",
+		Platform:  "whatsapp",
+		Sender:    "alice",
+		Content:   "hi",
+	})
+
+	m.mu.RLock()
+	route, ok := m.channelMap["whatsapp:family"]
+	m.mu.RUnlock()
+	if !ok {
+		t.Fatal("channel not mapped")
+	}
+	if route.ChannelID != "1234@g.us" {
+		t.Fatalf("route ChannelID = %q, want native JID", route.ChannelID)
+	}
+
+	waitFor(t, func() bool {
+		ch, ok := store.get("whatsapp:family")
+		return ok && ch.PlatformID == "1234@g.us" && ch.DisplayName == "Family Group"
+	})
+}
+
+// TestHandleNotification_UpgradesFallbackRoute asserts that a route created
+// with a fallback id is upgraded once a native channel id arrives.
+func TestHandleNotification_UpgradesFallbackRoute(t *testing.T) {
+	m := NewManager()
+	a := &identityAdapter{mockNotifAdapter: mockNotifAdapter{name: "whatsapp"}}
+	m.Register(a)
+
+	// Restored/legacy route with a name-based fallback id.
+	m.mu.Lock()
+	m.channelMap["whatsapp:family"] = channelRoute{Platform: "whatsapp", ChannelID: "family", Adapter: a}
+	m.mu.Unlock()
+
+	m.handleNotification("whatsapp", Notification{
+		Channel:   "family",
+		ChannelID: "1234@g.us",
+		Platform:  "whatsapp",
+	})
+
+	m.mu.RLock()
+	route := m.channelMap["whatsapp:family"]
+	m.mu.RUnlock()
+	if route.ChannelID != "1234@g.us" {
+		t.Fatalf("route not upgraded: ChannelID = %q", route.ChannelID)
+	}
+}
+
+// TestRefreshChannelMeta re-resolves and persists metadata for all channels
+// whose adapter implements ChannelIdentity.
+func TestRefreshChannelMeta(t *testing.T) {
+	store := newFakeChannelStore()
+	m := NewManager()
+	m.SetChannelStore(store)
+
+	wa := &identityAdapter{
+		mockNotifAdapter: mockNotifAdapter{name: "whatsapp"},
+		meta: map[string]ChannelMeta{
+			"1234@g.us":                  {DisplayName: "Family Group", Kind: ChannelKindGroup, ParticipantCount: 12},
+			"14155551234@s.whatsapp.net": {DisplayName: "Alice", Kind: ChannelKindPerson},
+		},
+	}
+	plain := &mockNotifAdapter{name: "slack"}
+
+	m.mu.Lock()
+	m.channelMap["whatsapp:family"] = channelRoute{Platform: "whatsapp", ChannelID: "1234@g.us", Adapter: wa}
+	m.channelMap["whatsapp:alice"] = channelRoute{Platform: "whatsapp", ChannelID: "14155551234@s.whatsapp.net", Adapter: wa}
+	m.channelMap["whatsapp:unknown"] = channelRoute{Platform: "whatsapp", ChannelID: "nope", Adapter: wa}
+	m.channelMap["slack:general"] = channelRoute{Platform: "slack", ChannelID: "C01", Adapter: plain}
+	m.mu.Unlock()
+
+	n, err := m.RefreshChannelMeta(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshChannelMeta: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("refreshed = %d, want 2", n)
+	}
+	if ch, _ := store.get("whatsapp:family"); ch.DisplayName != "Family Group" || ch.ParticipantCount != 12 {
+		t.Fatalf("family meta not refreshed: %+v", ch)
+	}
+	if ch, _ := store.get("whatsapp:alice"); ch.DisplayName != "Alice" || ch.Kind != "person" {
+		t.Fatalf("alice meta not refreshed: %+v", ch)
 	}
 }

--- a/pkg/gateway/manager_test.go
+++ b/pkg/gateway/manager_test.go
@@ -181,6 +181,16 @@ func (f *fakeChannelStore) UpsertChannelMeta(_ context.Context, bcChannel, displ
 	return nil
 }
 
+func (f *fakeChannelStore) UpdateChannelPlatformID(_ context.Context, bcChannel, platformID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if c, ok := f.saved[bcChannel]; ok {
+		c.PlatformID = platformID
+		f.saved[bcChannel] = c
+	}
+	return nil
+}
+
 func (f *fakeChannelStore) get(bcChannel string) (PersistedChannel, bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -116,6 +116,7 @@ func (a *Adapter) Channels() []gateway.ChannelInfo {
 			ID:       id,
 			Name:     name,
 			Platform: "slack",
+			Kind:     gateway.ChannelKindChannel,
 		})
 	}
 	return channels

--- a/pkg/gateway/telegram/telegram.go
+++ b/pkg/gateway/telegram/telegram.go
@@ -198,10 +198,17 @@ func (a *Adapter) Channels() []gateway.ChannelInfo {
 
 	channels := make([]gateway.ChannelInfo, 0, len(a.chatMap))
 	for id, name := range a.chatMap {
+		// Telegram group/supergroup/channel chat ids are negative; positive
+		// ids are private chats with a person.
+		kind := gateway.ChannelKindPerson
+		if id < 0 {
+			kind = gateway.ChannelKindGroup
+		}
 		channels = append(channels, gateway.ChannelInfo{
 			ID:       strconv.FormatInt(id, 10),
 			Name:     name,
 			Platform: a.name,
+			Kind:     kind,
 		})
 	}
 	return channels

--- a/pkg/gateway/whatsapp/identity.go
+++ b/pkg/gateway/whatsapp/identity.go
@@ -1,0 +1,164 @@
+package whatsapp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+
+	"github.com/rpuneet/mycel/pkg/gateway"
+)
+
+// metaCacheTTL bounds how long resolved channel metadata is cached in the
+// adapter. WhatsApp rate-limits info queries, so resolution is lazy and
+// cached; a manual refresh after the TTL re-fetches from the platform.
+const metaCacheTTL = 15 * time.Minute
+
+// identityClient is the subset of whatsmeow.Client used for identity
+// resolution, extracted so tests can inject a fake without a live session.
+type identityClient interface {
+	GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error)
+	GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error)
+}
+
+// waIdentityClient adapts *whatsmeow.Client to identityClient.
+type waIdentityClient struct {
+	c *whatsmeow.Client
+}
+
+func (w waIdentityClient) GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error) {
+	return w.c.GetGroupInfo(ctx, jid)
+}
+
+func (w waIdentityClient) GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error) {
+	return w.c.Store.Contacts.GetContact(ctx, jid)
+}
+
+// cachedMeta is a resolved ChannelMeta with its resolution time.
+type cachedMeta struct {
+	at   time.Time
+	meta gateway.ChannelMeta
+}
+
+var _ gateway.ChannelIdentity = (*Adapter)(nil)
+
+// identity returns the identity client: an injected fake in tests, otherwise
+// the live whatsmeow client (nil until connected/paired).
+func (a *Adapter) identity() identityClient {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.idClient != nil {
+		return a.idClient
+	}
+	if a.client != nil {
+		return waIdentityClient{a.client}
+	}
+	return nil
+}
+
+// ResolveChannel implements gateway.ChannelIdentity. platformID must be a
+// WhatsApp JID: group JIDs (@g.us) resolve to the group subject and
+// participant count; user JIDs (@s.whatsapp.net, @lid) resolve to the
+// contact's name, falling back to a formatted phone number. Results are
+// cached in-adapter because WhatsApp rate-limits info queries.
+func (a *Adapter) ResolveChannel(ctx context.Context, platformID string) (gateway.ChannelMeta, error) {
+	if !strings.Contains(platformID, "@") {
+		return gateway.ChannelMeta{}, fmt.Errorf("whatsapp: %q is not a JID", platformID)
+	}
+	jid, err := types.ParseJID(platformID)
+	if err != nil {
+		return gateway.ChannelMeta{}, fmt.Errorf("whatsapp: parse JID %q: %w", platformID, err)
+	}
+
+	a.metaMu.Lock()
+	if c, ok := a.metaCache[platformID]; ok && time.Since(c.at) < metaCacheTTL {
+		a.metaMu.Unlock()
+		return c.meta, nil
+	}
+	a.metaMu.Unlock()
+
+	client := a.identity()
+	if client == nil {
+		return gateway.ChannelMeta{}, fmt.Errorf("whatsapp: not connected")
+	}
+
+	meta, err := resolveJID(ctx, client, jid)
+	if err != nil {
+		return gateway.ChannelMeta{}, err
+	}
+
+	a.metaMu.Lock()
+	if a.metaCache == nil {
+		a.metaCache = make(map[string]cachedMeta)
+	}
+	a.metaCache[platformID] = cachedMeta{at: time.Now(), meta: meta}
+	a.metaMu.Unlock()
+	return meta, nil
+}
+
+// resolveJID resolves a single JID to display metadata.
+func resolveJID(ctx context.Context, client identityClient, jid types.JID) (gateway.ChannelMeta, error) {
+	switch jid.Server {
+	case types.GroupServer:
+		info, err := client.GetGroupInfo(ctx, jid)
+		if err != nil {
+			return gateway.ChannelMeta{}, fmt.Errorf("whatsapp: group info %s: %w", jid, err)
+		}
+		count := len(info.Participants)
+		if count == 0 {
+			count = info.ParticipantCount
+		}
+		name := info.Name
+		if name == "" {
+			name = jid.User
+		}
+		return gateway.ChannelMeta{
+			DisplayName:      name,
+			Kind:             gateway.ChannelKindGroup,
+			ParticipantCount: count,
+		}, nil
+
+	case types.DefaultUserServer, types.HiddenUserServer:
+		meta := gateway.ChannelMeta{Kind: gateway.ChannelKindPerson}
+		if info, err := client.GetContact(ctx, jid); err == nil {
+			meta.DisplayName = firstNonEmpty(info.FullName, info.BusinessName, info.PushName)
+		}
+		if meta.DisplayName == "" {
+			meta.DisplayName = formatPhone(jid.User)
+		}
+		return meta, nil
+
+	default:
+		return gateway.ChannelMeta{
+			DisplayName: jid.User,
+			Kind:        gateway.ChannelKindOther,
+		}, nil
+	}
+}
+
+// firstNonEmpty returns the first non-empty string.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// formatPhone renders the user part of a JID as an international phone
+// number ("+14155551234"). Non-numeric ids are returned unchanged.
+func formatPhone(user string) string {
+	if user == "" {
+		return ""
+	}
+	for _, r := range user {
+		if r < '0' || r > '9' {
+			return user
+		}
+	}
+	return "+" + user
+}

--- a/pkg/gateway/whatsapp/identity_test.go
+++ b/pkg/gateway/whatsapp/identity_test.go
@@ -1,0 +1,171 @@
+package whatsapp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+
+	"github.com/rpuneet/mycel/pkg/gateway"
+)
+
+// fakeIdentityClient implements identityClient for tests — no live session.
+type fakeIdentityClient struct {
+	groups       map[string]*types.GroupInfo
+	contacts     map[string]types.ContactInfo
+	mu           sync.Mutex
+	groupCalls   int
+	contactCalls int
+}
+
+func (f *fakeIdentityClient) GetGroupInfo(_ context.Context, jid types.JID) (*types.GroupInfo, error) {
+	f.mu.Lock()
+	f.groupCalls++
+	f.mu.Unlock()
+	gi, ok := f.groups[jid.String()]
+	if !ok {
+		return nil, fmt.Errorf("group not found: %s", jid)
+	}
+	return gi, nil
+}
+
+func (f *fakeIdentityClient) GetContact(_ context.Context, jid types.JID) (types.ContactInfo, error) {
+	f.mu.Lock()
+	f.contactCalls++
+	f.mu.Unlock()
+	info, ok := f.contacts[jid.String()]
+	if !ok {
+		return types.ContactInfo{}, nil // whatsmeow returns Found=false, not an error
+	}
+	return info, nil
+}
+
+func newTestAdapter(t *testing.T, fake *fakeIdentityClient) *Adapter {
+	t.Helper()
+	a := New(t.TempDir())
+	a.idClient = fake
+	return a
+}
+
+func groupInfo(name string, participants int) *types.GroupInfo {
+	gi := &types.GroupInfo{}
+	gi.Name = name
+	gi.Participants = make([]types.GroupParticipant, participants)
+	return gi
+}
+
+func TestResolveChannel_Group(t *testing.T) {
+	fake := &fakeIdentityClient{
+		groups: map[string]*types.GroupInfo{
+			"1234@g.us": groupInfo("Family Group", 12),
+		},
+	}
+	a := newTestAdapter(t, fake)
+
+	meta, err := a.ResolveChannel(context.Background(), "1234@g.us")
+	if err != nil {
+		t.Fatalf("ResolveChannel: %v", err)
+	}
+	want := gateway.ChannelMeta{DisplayName: "Family Group", Kind: "group", ParticipantCount: 12}
+	if meta != want {
+		t.Fatalf("got %+v, want %+v", meta, want)
+	}
+}
+
+func TestResolveChannel_PersonContactName(t *testing.T) {
+	fake := &fakeIdentityClient{
+		contacts: map[string]types.ContactInfo{
+			"14155551234@s.whatsapp.net": {Found: true, FullName: "Alice Smith", PushName: "alice"},
+		},
+	}
+	a := newTestAdapter(t, fake)
+
+	meta, err := a.ResolveChannel(context.Background(), "14155551234@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("ResolveChannel: %v", err)
+	}
+	if meta.DisplayName != "Alice Smith" || meta.Kind != "person" {
+		t.Fatalf("got %+v, want Alice Smith/person", meta)
+	}
+}
+
+func TestResolveChannel_PersonNameFallbacks(t *testing.T) {
+	tests := []struct {
+		name    string
+		contact types.ContactInfo
+		want    string
+	}{
+		{"business name", types.ContactInfo{Found: true, BusinessName: "Acme Corp"}, "Acme Corp"},
+		{"push name", types.ContactInfo{Found: true, PushName: "bob"}, "bob"},
+		{"phone number", types.ContactInfo{}, "+14155551234"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeIdentityClient{
+				contacts: map[string]types.ContactInfo{
+					"14155551234@s.whatsapp.net": tt.contact,
+				},
+			}
+			a := newTestAdapter(t, fake)
+			meta, err := a.ResolveChannel(context.Background(), "14155551234@s.whatsapp.net")
+			if err != nil {
+				t.Fatalf("ResolveChannel: %v", err)
+			}
+			if meta.DisplayName != tt.want {
+				t.Fatalf("display_name = %q, want %q", meta.DisplayName, tt.want)
+			}
+			if meta.Kind != "person" {
+				t.Fatalf("kind = %q, want person", meta.Kind)
+			}
+		})
+	}
+}
+
+func TestResolveChannel_NotAJID(t *testing.T) {
+	a := newTestAdapter(t, &fakeIdentityClient{})
+	if _, err := a.ResolveChannel(context.Background(), "family-group"); err == nil {
+		t.Fatal("expected error for non-JID platform id")
+	}
+}
+
+func TestResolveChannel_CachesResults(t *testing.T) {
+	fake := &fakeIdentityClient{
+		groups: map[string]*types.GroupInfo{
+			"1234@g.us": groupInfo("Family Group", 3),
+		},
+	}
+	a := newTestAdapter(t, fake)
+
+	for range 3 {
+		if _, err := a.ResolveChannel(context.Background(), "1234@g.us"); err != nil {
+			t.Fatalf("ResolveChannel: %v", err)
+		}
+	}
+	if fake.groupCalls != 1 {
+		t.Fatalf("expected 1 platform lookup (cached), got %d", fake.groupCalls)
+	}
+}
+
+func TestResolveChannel_GroupLookupError(t *testing.T) {
+	a := newTestAdapter(t, &fakeIdentityClient{})
+	if _, err := a.ResolveChannel(context.Background(), "999@g.us"); err == nil {
+		t.Fatal("expected error when group info lookup fails")
+	}
+}
+
+func TestFormatPhone(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"14155551234", "+14155551234"},
+		{"", ""},
+		{"not-a-number", "not-a-number"},
+	}
+	for _, tt := range tests {
+		if got := formatPhone(tt.in); got != tt.want {
+			t.Errorf("formatPhone(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/pkg/gateway/whatsapp/whatsapp.go
+++ b/pkg/gateway/whatsapp/whatsapp.go
@@ -46,6 +46,10 @@ type Adapter struct { //nolint:govet
 	// qrChan receives QR codes during pairing.
 	qrChan     chan string
 	groupCache map[string]string
+	// idClient overrides the whatsmeow-backed identity client in tests.
+	idClient  identityClient
+	metaMu    sync.Mutex
+	metaCache map[string]cachedMeta
 }
 
 func init() {
@@ -384,6 +388,7 @@ func (a *Adapter) handleMessage(msg *events.Message) {
 		raw, _ := json.Marshal(msg) //nolint:errcheck
 		a.handler(gateway.Notification{
 			Channel:   channel,
+			ChannelID: msg.Info.Chat.String(), // native JID so identity resolution works
 			Platform:  "whatsapp",
 			Sender:    sender,
 			Content:   content,

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -260,6 +260,12 @@ func (s *Service) ChannelStats(ctx context.Context) ([]ChannelStat, error) {
 	return s.store.ChannelStats(ctx)
 }
 
+// Channels returns all persisted gateway channel mappings with their
+// resolved display metadata (name, kind, participant count).
+func (s *Service) Channels(ctx context.Context) ([]PersistedChannel, error) {
+	return s.store.LoadChannels(ctx)
+}
+
 // PruneOldActivity removes old delivery log entries for every channel,
 // keeping the most recent keepPerChannel entries in each.
 func (s *Service) PruneOldActivity(ctx context.Context, keepPerChannel int) error {

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -109,6 +109,9 @@ CREATE TABLE IF NOT EXISTS notify_channels (
     bc_channel   TEXT PRIMARY KEY,
     platform     TEXT NOT NULL,
     platform_id  TEXT NOT NULL,
+    display_name TEXT NOT NULL DEFAULT '',
+    kind         TEXT NOT NULL DEFAULT '',
+    participant_count INTEGER NOT NULL DEFAULT 0,
     updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
 
@@ -158,6 +161,9 @@ CREATE TABLE IF NOT EXISTS notify_channels (
     bc_channel   TEXT PRIMARY KEY,
     platform     TEXT NOT NULL,
     platform_id  TEXT NOT NULL,
+    display_name TEXT NOT NULL DEFAULT '',
+    kind         TEXT NOT NULL DEFAULT '',
+    participant_count INTEGER NOT NULL DEFAULT 0,
     updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -497,17 +503,21 @@ func (s *Store) GetMessages(ctx context.Context, channel string, limit int, befo
 	return msgs, rows.Err()
 }
 
-// PersistedChannel is a saved bc_channel → platform_id mapping.
+// PersistedChannel is a saved bc_channel → platform_id mapping with
+// resolved display metadata.
 type PersistedChannel struct {
-	BCChannel  string
-	Platform   string
-	PlatformID string
+	BCChannel        string
+	Platform         string
+	PlatformID       string
+	DisplayName      string
+	Kind             string // group | person | channel | feed | other
+	ParticipantCount int
 }
 
 // LoadChannels returns all persisted channel mappings.
 func (s *Store) LoadChannels(ctx context.Context) ([]PersistedChannel, error) {
 	rows, err := s.db.QueryContext(ctx, s.q(
-		`SELECT bc_channel, platform, platform_id FROM notify_channels`))
+		`SELECT bc_channel, platform, platform_id, display_name, kind, participant_count FROM notify_channels`))
 	if err != nil {
 		return nil, err
 	}
@@ -516,7 +526,7 @@ func (s *Store) LoadChannels(ctx context.Context) ([]PersistedChannel, error) {
 	var channels []PersistedChannel
 	for rows.Next() {
 		var c PersistedChannel
-		if err := rows.Scan(&c.BCChannel, &c.Platform, &c.PlatformID); err != nil {
+		if err := rows.Scan(&c.BCChannel, &c.Platform, &c.PlatformID, &c.DisplayName, &c.Kind, &c.ParticipantCount); err != nil {
 			return nil, err
 		}
 		channels = append(channels, c)
@@ -543,6 +553,37 @@ func (s *Store) SaveChannel(ctx context.Context, bcChannel, platform, platformID
 		   END,
 		   updated_at = excluded.updated_at`),
 		bcChannel, platform, platformID, time.Now().UTC().Format(time.RFC3339))
+	return err
+}
+
+// UpsertChannelMeta stores resolved display metadata for a channel. The row
+// is created if the mapping does not exist yet (platform derived from the
+// bc_channel prefix); existing platform/platform_id values are never touched.
+// Empty display_name/kind and a zero participant_count never clobber
+// previously-resolved values.
+func (s *Store) UpsertChannelMeta(ctx context.Context, bcChannel, displayName, kind string, participantCount int) error {
+	platform := bcChannel
+	if i := strings.Index(bcChannel, ":"); i > 0 {
+		platform = bcChannel[:i]
+	}
+	_, err := s.db.ExecContext(ctx, s.q(
+		`INSERT INTO notify_channels (bc_channel, platform, platform_id, display_name, kind, participant_count, updated_at)
+		 VALUES (?, ?, '', ?, ?, ?, ?)
+		 ON CONFLICT(bc_channel) DO UPDATE SET
+		   display_name = CASE
+		     WHEN excluded.display_name = '' THEN notify_channels.display_name
+		     ELSE excluded.display_name
+		   END,
+		   kind = CASE
+		     WHEN excluded.kind = '' THEN notify_channels.kind
+		     ELSE excluded.kind
+		   END,
+		   participant_count = CASE
+		     WHEN excluded.participant_count = 0 THEN notify_channels.participant_count
+		     ELSE excluded.participant_count
+		   END,
+		   updated_at = excluded.updated_at`),
+		bcChannel, platform, displayName, kind, participantCount, time.Now().UTC().Format(time.RFC3339))
 	return err
 }
 

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -540,6 +540,16 @@ func (s *Store) LoadChannels(ctx context.Context) ([]PersistedChannel, error) {
 // non-empty value. This prevents a later event with a fallback platform_id
 // (e.g., the channel name when a numeric chat_id couldn't be extracted from
 // the raw payload) from clobbering a previously-stored real platform_id.
+// UpdateChannelPlatformID force-overwrites a channel's platform id.
+// SaveChannel deliberately preserves existing non-empty ids; this is the
+// explicit upgrade path for fallback→native id promotions.
+func (s *Store) UpdateChannelPlatformID(ctx context.Context, bcChannel, platformID string) error {
+	_, err := s.db.ExecContext(ctx, s.q(
+		`UPDATE notify_channels SET platform_id = ?, updated_at = ? WHERE bc_channel = ?`),
+		platformID, time.Now().UTC().Format(time.RFC3339), bcChannel)
+	return err
+}
+
 func (s *Store) SaveChannel(ctx context.Context, bcChannel, platform, platformID string) error {
 	_, err := s.db.ExecContext(ctx, s.q(
 		`INSERT INTO notify_channels (bc_channel, platform, platform_id, updated_at)

--- a/pkg/notify/store_test.go
+++ b/pkg/notify/store_test.go
@@ -196,3 +196,128 @@ func TestChannelStats(t *testing.T) {
 		})
 	}
 }
+
+// TestUpsertChannelMeta_RoundTrip asserts that resolved display metadata is
+// stored, survives empty re-writes, and can be updated with new values.
+func TestUpsertChannelMeta_RoundTrip(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	const bcChannel = "whatsapp:family-group"
+	if err := store.SaveChannel(ctx, bcChannel, "whatsapp", "1234@g.us"); err != nil {
+		t.Fatalf("SaveChannel: %v", err)
+	}
+	if err := store.UpsertChannelMeta(ctx, bcChannel, "Family Group", "group", 12); err != nil {
+		t.Fatalf("UpsertChannelMeta: %v", err)
+	}
+
+	channels, err := store.LoadChannels(ctx)
+	if err != nil {
+		t.Fatalf("LoadChannels: %v", err)
+	}
+	if len(channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(channels))
+	}
+	got := channels[0]
+	if got.DisplayName != "Family Group" || got.Kind != "group" || got.ParticipantCount != 12 {
+		t.Fatalf("meta round-trip failed: %+v", got)
+	}
+	if got.PlatformID != "1234@g.us" {
+		t.Fatalf("platform_id clobbered by meta upsert: %q", got.PlatformID)
+	}
+
+	// Empty values must not clobber previously-resolved metadata.
+	if upErr := store.UpsertChannelMeta(ctx, bcChannel, "", "", 0); upErr != nil {
+		t.Fatalf("UpsertChannelMeta (empty): %v", upErr)
+	}
+	channels, err = store.LoadChannels(ctx)
+	if err != nil {
+		t.Fatalf("LoadChannels: %v", err)
+	}
+	if got := channels[0]; got.DisplayName != "Family Group" || got.Kind != "group" || got.ParticipantCount != 12 {
+		t.Fatalf("empty upsert clobbered meta: %+v", got)
+	}
+
+	// New values replace old ones.
+	if upErr := store.UpsertChannelMeta(ctx, bcChannel, "Renamed Group", "group", 13); upErr != nil {
+		t.Fatalf("UpsertChannelMeta (update): %v", upErr)
+	}
+	channels, err = store.LoadChannels(ctx)
+	if err != nil {
+		t.Fatalf("LoadChannels: %v", err)
+	}
+	if got := channels[0]; got.DisplayName != "Renamed Group" || got.ParticipantCount != 13 {
+		t.Fatalf("meta update failed: %+v", got)
+	}
+}
+
+// TestUpsertChannelMeta_InsertsMissingRow asserts that meta for a channel
+// with no prior mapping creates the row, deriving platform from the prefix.
+func TestUpsertChannelMeta_InsertsMissingRow(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	if err := store.UpsertChannelMeta(ctx, "slack:general", "general", "channel", 0); err != nil {
+		t.Fatalf("UpsertChannelMeta: %v", err)
+	}
+	channels, err := store.LoadChannels(ctx)
+	if err != nil {
+		t.Fatalf("LoadChannels: %v", err)
+	}
+	if len(channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(channels))
+	}
+	got := channels[0]
+	if got.Platform != "slack" || got.DisplayName != "general" || got.Kind != "channel" {
+		t.Fatalf("inserted row wrong: %+v", got)
+	}
+
+	// A later SaveChannel fills the platform_id without touching meta.
+	if saveErr := store.SaveChannel(ctx, "slack:general", "slack", "C0123ABC"); saveErr != nil {
+		t.Fatalf("SaveChannel: %v", saveErr)
+	}
+	channels, err = store.LoadChannels(ctx)
+	if err != nil {
+		t.Fatalf("LoadChannels: %v", err)
+	}
+	got = channels[0]
+	if got.PlatformID != "C0123ABC" || got.DisplayName != "general" || got.Kind != "channel" {
+		t.Fatalf("SaveChannel disturbed meta: %+v", got)
+	}
+}
+
+// TestUpsertChannelMeta_PreservesMessages asserts that storing metadata
+// never disturbs the channel's stored messages or subscriptions.
+func TestUpsertChannelMeta_PreservesMessages(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	const bcChannel = "whatsapp:1234"
+	for _, msg := range []string{"hello", "world"} {
+		if err := store.SaveMessage(ctx, bcChannel, "alice", msg); err != nil {
+			t.Fatalf("SaveMessage: %v", err)
+		}
+	}
+	if err := store.Subscribe(ctx, bcChannel, "eng-01", false); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	if err := store.UpsertChannelMeta(ctx, bcChannel, "Alice", "person", 0); err != nil {
+		t.Fatalf("UpsertChannelMeta: %v", err)
+	}
+
+	msgs, err := store.GetMessages(ctx, bcChannel, 10, 0)
+	if err != nil {
+		t.Fatalf("GetMessages: %v", err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected 2 messages after meta upsert, got %d", len(msgs))
+	}
+	subs, err := store.Subscribers(ctx, bcChannel)
+	if err != nil {
+		t.Fatalf("Subscribers: %v", err)
+	}
+	if len(subs) != 1 {
+		t.Fatalf("expected 1 subscription after meta upsert, got %d", len(subs))
+	}
+}

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -881,12 +881,19 @@ func (p *channelPersister) LoadChannels(ctx context.Context) ([]bcgateway.Persis
 	result := make([]bcgateway.PersistedChannel, len(ncs))
 	for i, c := range ncs {
 		result[i] = bcgateway.PersistedChannel{
-			BCChannel:  c.BCChannel,
-			Platform:   c.Platform,
-			PlatformID: c.PlatformID,
+			BCChannel:        c.BCChannel,
+			Platform:         c.Platform,
+			PlatformID:       c.PlatformID,
+			DisplayName:      c.DisplayName,
+			Kind:             c.Kind,
+			ParticipantCount: c.ParticipantCount,
 		}
 	}
 	return result, nil
+}
+
+func (p *channelPersister) UpsertChannelMeta(ctx context.Context, bcChannel, displayName, kind string, participantCount int) error {
+	return p.store.UpsertChannelMeta(ctx, bcChannel, displayName, kind, participantCount)
 }
 
 // costStoreAdapter bridges cost.Store → bcagent.CostQuerier.

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -873,6 +873,10 @@ func (p *channelPersister) SaveChannel(ctx context.Context, bcChannel, platform,
 	return p.store.SaveChannel(ctx, bcChannel, platform, platformID)
 }
 
+func (p *channelPersister) UpdateChannelPlatformID(ctx context.Context, bcChannel, platformID string) error {
+	return p.store.UpdateChannelPlatformID(ctx, bcChannel, platformID)
+}
+
 func (p *channelPersister) LoadChannels(ctx context.Context) ([]bcgateway.PersistedChannel, error) {
 	ncs, err := p.store.LoadChannels(ctx)
 	if err != nil {

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -43,6 +43,11 @@ func (h *GatewayHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/notify/subscriptions/", h.notifySubscriptionByChannel)
 	mux.HandleFunc("/api/notify/activity/", h.notifyActivity)
 
+	// Notifications home: connected apps + channels with resolved identities.
+	mux.HandleFunc("/api/notifications/overview", h.notificationsOverview)
+	// Manual re-resolution of channel display metadata (names, kinds).
+	mux.HandleFunc("/api/gateways/channels/refresh", h.refreshChannelMeta)
+
 	// Gateway-scoped routes (proposal-aligned)
 	mux.HandleFunc("/api/gateways/", h.gatewayRouter)
 }

--- a/server/handlers/notifications_overview.go
+++ b/server/handlers/notifications_overview.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"sort"
 	"strings"
@@ -149,7 +150,11 @@ func (h *GatewayHandler) refreshChannelMeta(w http.ResponseWriter, r *http.Reque
 		serviceUnavailable(w, r, "gateway", "gateway manager not available")
 		return
 	}
-	n, err := h.gw.RefreshChannelMeta(r.Context())
+	// Bound the whole refresh — a slow adapter must not pin the request
+	// past a sane ceiling even with per-channel timeouts underneath.
+	refreshCtx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+	n, err := h.gw.RefreshChannelMeta(refreshCtx)
 	if err != nil {
 		httpInternalError(w, "refresh channel meta", err)
 		return

--- a/server/handlers/notifications_overview.go
+++ b/server/handlers/notifications_overview.go
@@ -1,0 +1,158 @@
+package handlers
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// overviewApp summarizes one gateway adapter for the notifications home page.
+type overviewApp struct {
+	LastActivity     time.Time `json:"last_activity"`
+	Name             string    `json:"name"`
+	Platform         string    `json:"platform"`
+	DisconnectReason string    `json:"disconnect_reason"`
+	ChannelCount     int       `json:"channel_count"`
+	Connected        bool      `json:"connected"`
+}
+
+// overviewChannel is one gateway channel with resolved identity and activity.
+type overviewChannel struct {
+	LastActivity     time.Time `json:"last_activity"`
+	BCChannel        string    `json:"bc_channel"`
+	Platform         string    `json:"platform"`
+	DisplayName      string    `json:"display_name"`
+	Kind             string    `json:"kind"`
+	ParticipantCount int       `json:"participant_count"`
+	SubscriberCount  int       `json:"subscriber_count"`
+	MessageCount     int       `json:"message_count"`
+}
+
+// notificationsOverview handles GET /api/notifications/overview — the data
+// source for the notifications home page: connected apps (gateway adapter
+// status) and all known channels with resolved display metadata, message
+// counts, subscriber counts, and last activity.
+func (h *GatewayHandler) notificationsOverview(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	if h.notifySvc == nil {
+		serviceUnavailable(w, r, "notify", "notify service not available")
+		return
+	}
+
+	// Persisted channel mappings carry the resolved identity metadata.
+	persisted, err := h.notifySvc.Channels(r.Context())
+	if err != nil {
+		httpInternalError(w, "load channels", err)
+		return
+	}
+	byName := make(map[string]*overviewChannel, len(persisted))
+	for _, c := range persisted {
+		byName[c.BCChannel] = &overviewChannel{
+			BCChannel:        c.BCChannel,
+			Platform:         c.Platform,
+			DisplayName:      c.DisplayName,
+			Kind:             c.Kind,
+			ParticipantCount: c.ParticipantCount,
+		}
+	}
+
+	// In-memory discovered channels not yet persisted.
+	if h.gw != nil {
+		for _, name := range h.gw.DiscoveredSources() {
+			if _, ok := byName[name]; ok {
+				continue
+			}
+			platform := name
+			if i := strings.Index(name, ":"); i > 0 {
+				platform = name[:i]
+			}
+			byName[name] = &overviewChannel{BCChannel: name, Platform: platform}
+		}
+	}
+
+	// Enrich with message counts, subscriber counts, and last activity.
+	stats, err := h.notifySvc.ChannelStats(r.Context())
+	if err != nil {
+		httpInternalError(w, "channel stats", err)
+		return
+	}
+	for _, st := range stats {
+		ch, ok := byName[st.Name]
+		if !ok {
+			continue // not a gateway channel
+		}
+		ch.MessageCount = st.MessageCount
+		ch.SubscriberCount = st.MemberCount
+		ch.LastActivity = st.LastActivity
+	}
+
+	channels := make([]overviewChannel, 0, len(byName))
+	for _, ch := range byName {
+		if ch.DisplayName == "" {
+			// Never show a blank name: fall back to the bc channel suffix.
+			ch.DisplayName = strings.TrimPrefix(ch.BCChannel, ch.Platform+":")
+		}
+		channels = append(channels, *ch)
+	}
+	sort.Slice(channels, func(i, j int) bool {
+		if channels[i].MessageCount != channels[j].MessageCount {
+			return channels[i].MessageCount > channels[j].MessageCount
+		}
+		return channels[i].BCChannel < channels[j].BCChannel
+	})
+
+	apps := []overviewApp{}
+	if h.gw != nil {
+		channelCount := make(map[string]int)
+		lastActivity := make(map[string]time.Time)
+		for _, ch := range channels {
+			channelCount[ch.Platform]++
+			if ch.LastActivity.After(lastActivity[ch.Platform]) {
+				lastActivity[ch.Platform] = ch.LastActivity
+			}
+		}
+		for _, name := range h.gw.AdapterNames() {
+			status := h.gw.AdapterStatus(name)
+			last := status.LastMessageAt
+			if lastActivity[name].After(last) {
+				last = lastActivity[name]
+			}
+			apps = append(apps, overviewApp{
+				Name:             name,
+				Platform:         name,
+				Connected:        status.Connected,
+				DisconnectReason: status.Error,
+				ChannelCount:     channelCount[name],
+				LastActivity:     last,
+			})
+		}
+		sort.Slice(apps, func(i, j int) bool { return apps[i].Name < apps[j].Name })
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"apps":     apps,
+		"channels": channels,
+	})
+}
+
+// refreshChannelMeta handles POST /api/gateways/channels/refresh — re-resolves
+// display metadata (names, kinds, participant counts) for all known gateway
+// channels via adapters that support identity resolution.
+func (h *GatewayHandler) refreshChannelMeta(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if h.gw == nil {
+		serviceUnavailable(w, r, "gateway", "gateway manager not available")
+		return
+	}
+	n, err := h.gw.RefreshChannelMeta(r.Context())
+	if err != nil {
+		httpInternalError(w, "refresh channel meta", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"refreshed": n})
+}

--- a/server/handlers/notifications_overview_test.go
+++ b/server/handlers/notifications_overview_test.go
@@ -1,0 +1,241 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/gateway"
+	"github.com/rpuneet/mycel/pkg/notify"
+)
+
+// identityStubAdapter is a stubAdapter that also resolves channel identities.
+type identityStubAdapter struct {
+	meta map[string]gateway.ChannelMeta
+	stubAdapter
+}
+
+func (s *identityStubAdapter) ResolveChannel(_ context.Context, platformID string) (gateway.ChannelMeta, error) {
+	if m, ok := s.meta[platformID]; ok {
+		return m, nil
+	}
+	return gateway.ChannelMeta{}, http.ErrMissingFile
+}
+
+// notifyStoreChannelStore adapts notify.Store to gateway.ChannelStore for tests
+// (mirrors the server's channelPersister wiring).
+type notifyStoreChannelStore struct {
+	store *notify.Store
+}
+
+func (p *notifyStoreChannelStore) SaveChannel(ctx context.Context, bcChannel, platform, platformID string) error {
+	return p.store.SaveChannel(ctx, bcChannel, platform, platformID)
+}
+
+func (p *notifyStoreChannelStore) LoadChannels(ctx context.Context) ([]gateway.PersistedChannel, error) {
+	ncs, err := p.store.LoadChannels(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]gateway.PersistedChannel, len(ncs))
+	for i, c := range ncs {
+		result[i] = gateway.PersistedChannel{
+			BCChannel:        c.BCChannel,
+			Platform:         c.Platform,
+			PlatformID:       c.PlatformID,
+			DisplayName:      c.DisplayName,
+			Kind:             c.Kind,
+			ParticipantCount: c.ParticipantCount,
+		}
+	}
+	return result, nil
+}
+
+func (p *notifyStoreChannelStore) UpsertChannelMeta(ctx context.Context, bcChannel, displayName, kind string, participantCount int) error {
+	return p.store.UpsertChannelMeta(ctx, bcChannel, displayName, kind, participantCount)
+}
+
+type overviewResponse struct {
+	Apps []struct {
+		Name             string `json:"name"`
+		Platform         string `json:"platform"`
+		DisconnectReason string `json:"disconnect_reason"`
+		ChannelCount     int    `json:"channel_count"`
+		Connected        bool   `json:"connected"`
+	} `json:"apps"`
+	Channels []struct {
+		BCChannel        string `json:"bc_channel"`
+		Platform         string `json:"platform"`
+		DisplayName      string `json:"display_name"`
+		Kind             string `json:"kind"`
+		ParticipantCount int    `json:"participant_count"`
+		SubscriberCount  int    `json:"subscriber_count"`
+		MessageCount     int    `json:"message_count"`
+	} `json:"channels"`
+}
+
+// TestNotificationsOverview exercises GET /api/notifications/overview:
+// channel metadata, message/subscriber counts, and adapter status.
+func TestNotificationsOverview(t *testing.T) {
+	svc := newTestNotifyService(t)
+	store := svc.Store()
+	ctx := context.Background()
+
+	// Seed a resolved WhatsApp group channel with messages + a subscription.
+	if err := store.SaveChannel(ctx, "whatsapp:family", "whatsapp", "1234@g.us"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpsertChannelMeta(ctx, "whatsapp:family", "Family Group", "group", 12); err != nil {
+		t.Fatal(err)
+	}
+	for range 3 {
+		if err := store.SaveMessage(ctx, "whatsapp:family", "alice", "hi"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.Subscribe(ctx, "whatsapp:family", "eng-01", false); err != nil {
+		t.Fatal(err)
+	}
+	// A channel persisted without resolved metadata falls back to its suffix.
+	if err := store.SaveChannel(ctx, "slack:general", "slack", "C01"); err != nil {
+		t.Fatal(err)
+	}
+
+	gw := gateway.NewManager()
+	gw.Register(&stubAdapter{name: "whatsapp", status: gateway.AdapterStatus{Connected: true}})
+	gw.Register(&stubAdapter{name: "slack", status: gateway.AdapterStatus{Connected: false, Error: "invalid_auth"}})
+
+	h := NewGatewayHandler(gw, nil)
+	h.SetNotifyService(svc)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/notifications/overview", nil)
+	rr := httptest.NewRecorder()
+	h.notificationsOverview(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp overviewResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.Apps) != 2 {
+		t.Fatalf("apps = %d, want 2: %+v", len(resp.Apps), resp.Apps)
+	}
+	appsByName := map[string]int{}
+	for i, a := range resp.Apps {
+		appsByName[a.Name] = i
+	}
+	wa := resp.Apps[appsByName["whatsapp"]]
+	if !wa.Connected || wa.ChannelCount != 1 {
+		t.Fatalf("whatsapp app = %+v, want connected with 1 channel", wa)
+	}
+	sl := resp.Apps[appsByName["slack"]]
+	if sl.Connected || sl.DisconnectReason != "invalid_auth" || sl.ChannelCount != 1 {
+		t.Fatalf("slack app = %+v, want disconnected/invalid_auth with 1 channel", sl)
+	}
+
+	if len(resp.Channels) != 2 {
+		t.Fatalf("channels = %d, want 2: %+v", len(resp.Channels), resp.Channels)
+	}
+	// Sorted by message count desc: whatsapp:family first.
+	fam := resp.Channels[0]
+	if fam.BCChannel != "whatsapp:family" || fam.DisplayName != "Family Group" ||
+		fam.Kind != "group" || fam.ParticipantCount != 12 ||
+		fam.MessageCount != 3 || fam.SubscriberCount != 1 {
+		t.Fatalf("whatsapp:family = %+v", fam)
+	}
+	gen := resp.Channels[1]
+	if gen.BCChannel != "slack:general" || gen.DisplayName != "general" || gen.Kind != "" {
+		t.Fatalf("slack:general = %+v", gen)
+	}
+}
+
+// TestNotificationsOverview_MethodAndNilService covers the guards.
+func TestNotificationsOverview_MethodAndNilService(t *testing.T) {
+	h := &GatewayHandler{}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/notifications/overview", nil)
+	rr := httptest.NewRecorder()
+	h.notificationsOverview(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST status = %d, want 405", rr.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/notifications/overview", nil)
+	rr = httptest.NewRecorder()
+	h.notificationsOverview(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("nil-service status = %d, want 503", rr.Code)
+	}
+}
+
+// TestRefreshChannelMetaEndpoint exercises POST /api/gateways/channels/refresh:
+// an inbound notification maps a channel, refresh re-resolves its identity.
+func TestRefreshChannelMetaEndpoint(t *testing.T) {
+	svc := newTestNotifyService(t)
+	store := svc.Store()
+
+	gw := gateway.NewManager()
+	gw.SetChannelStore(&notifyStoreChannelStore{store: store})
+	gw.Register(&identityStubAdapter{
+		stubAdapter: stubAdapter{name: "whatsapp"},
+		meta: map[string]gateway.ChannelMeta{
+			"1234@g.us": {DisplayName: "Family Group", Kind: "group", ParticipantCount: 7},
+		},
+	})
+	gw.HandleNotification("whatsapp", gateway.Notification{
+		Channel:   "family",
+		ChannelID: "1234@g.us",
+		Platform:  "whatsapp",
+		Sender:    "alice",
+		Content:   "hello",
+	})
+
+	h := NewGatewayHandler(gw, nil)
+	h.SetNotifyService(svc)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/gateways/channels/refresh", nil)
+	rr := httptest.NewRecorder()
+	h.refreshChannelMeta(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Refreshed int `json:"refreshed"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Refreshed != 1 {
+		t.Fatalf("refreshed = %d, want 1", resp.Refreshed)
+	}
+
+	channels, err := store.LoadChannels(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, c := range channels {
+		if c.BCChannel == "whatsapp:family" {
+			found = true
+			if c.DisplayName != "Family Group" || c.Kind != "group" || c.ParticipantCount != 7 {
+				t.Fatalf("meta not refreshed: %+v", c)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("whatsapp:family not persisted")
+	}
+
+	// GET is rejected.
+	rr = httptest.NewRecorder()
+	h.refreshChannelMeta(rr, httptest.NewRequest(http.MethodGet, "/api/gateways/channels/refresh", nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET status = %d, want 405", rr.Code)
+	}
+}

--- a/server/handlers/notifications_overview_test.go
+++ b/server/handlers/notifications_overview_test.go
@@ -34,6 +34,10 @@ func (p *notifyStoreChannelStore) SaveChannel(ctx context.Context, bcChannel, pl
 	return p.store.SaveChannel(ctx, bcChannel, platform, platformID)
 }
 
+func (p *notifyStoreChannelStore) UpdateChannelPlatformID(ctx context.Context, bcChannel, platformID string) error {
+	return p.store.UpdateChannelPlatformID(ctx, bcChannel, platformID)
+}
+
 func (p *notifyStoreChannelStore) LoadChannels(ctx context.Context) ([]gateway.PersistedChannel, error) {
 	ncs, err := p.store.LoadChannels(ctx)
 	if err != nil {


### PR DESCRIPTION
Part of #3310 — backend half (channel identity resolution). WhatsApp channels stop showing raw JIDs; every adapter can now supply human-readable channel metadata.

## What's in here

### 1. Channel metadata storage (`pkg/notify`)
- `notify_channels` gains `display_name TEXT NOT NULL DEFAULT ''`, `kind TEXT NOT NULL DEFAULT ''` (group|person|channel|feed|other), `participant_count INTEGER NOT NULL DEFAULT 0` — in both SQLite and Postgres schemas.
- `Store.UpsertChannelMeta(ctx, bcChannel, displayName, kind, participantCount)`: meta-only upsert. Creates the row if missing (platform derived from the `platform:` prefix), never touches `platform_id`, and empty values never clobber previously-resolved metadata. `SaveChannel` conversely never touches meta columns.
- `LoadChannels` / `Service.Channels` return the new fields.

**One-time ops migration for live DBs** (no in-tree migrations by project policy) — run once against the existing workspace DB (SQLite `.bc/bc.db`; same statements on Postgres/TimescaleDB):

```sql
ALTER TABLE notify_channels ADD COLUMN display_name TEXT NOT NULL DEFAULT '';
ALTER TABLE notify_channels ADD COLUMN kind TEXT NOT NULL DEFAULT '';
ALTER TABLE notify_channels ADD COLUMN participant_count INTEGER NOT NULL DEFAULT 0;
```

### 2. Adapter identity interface (`pkg/gateway`)
```go
type ChannelIdentity interface {
    ResolveChannel(ctx context.Context, platformID string) (ChannelMeta, error)
}
type ChannelMeta struct { DisplayName string; Kind string; ParticipantCount int }
```
- Manager resolves identities at channel discovery, late discovery, first inbound message on a new channel, and a startup backfill for persisted rows missing a display name (sequential, WhatsApp-rate-limit friendly).
- `Manager.RefreshChannelMeta(ctx)` re-resolves all routed channels for adapters implementing `ChannelIdentity`.
- `Notification.ChannelID` (new, optional): adapters supply the platform-native channel id; routes created/restored with fallback ids get upgraded when a native id arrives.
- `ChannelInfo.Kind` (new, optional): discovery-time kind for adapters that already know it.

### 3. WhatsApp implementation (flagship)
- Group JIDs (`@g.us`) → `client.GetGroupInfo`: group subject + participant count, kind `group`.
- User JIDs (`@s.whatsapp.net`, `@lid`) → contact store `GetContact`: FullName → BusinessName → PushName, falling back to formatted phone number (`+14155551234`), kind `person`.
- Lazy resolution with in-adapter cache (15 min TTL) — WhatsApp rate-limits info queries; manual refresh after TTL re-fetches.
- whatsmeow calls wrapped behind a tiny `identityClient` interface so tests inject a fake (no live session needed).
- Inbound messages now carry the chat JID as `Notification.ChannelID`.
- Slack/Discord/Telegram: discovery paths populate `display_name`/`kind` from data already in hand — no new API calls (telegram kind from chat-id sign: negative = group, positive = person).

### 4. API surface (frontend contract)
**`GET /api/notifications/overview`** →
```jsonc
{
  "apps": [{"name":"whatsapp","platform":"whatsapp","connected":true,"disconnect_reason":"","channel_count":12,"last_activity":"2026-07-05T09:00:00Z"}],
  "channels": [{"bc_channel":"whatsapp:family","platform":"whatsapp","display_name":"Family Group","kind":"group","participant_count":12,"subscriber_count":2,"message_count":345,"last_activity":"..."}]
}
```
- `apps`: one entry per registered adapter (gateway manager status), sorted by name. `last_activity` = max(adapter last message, per-channel last activity).
- `channels`: persisted `notify_channels` meta ∪ in-memory discovered channels, joined with `ChannelStats` (message counts, last activity, subscriber counts), sorted by message count desc then name. `display_name` falls back to the bc-channel suffix so it is never blank.

**`POST /api/gateways/channels/refresh`** → `{"refreshed": <n>}` — re-resolves display metadata for all known channels.

## Tests
- Store: meta round-trip, empty-value preservation, insert-on-missing, SaveChannel/meta isolation, messages+subscriptions untouched by meta upserts.
- Manager: discovery persists resolved meta, discovery fallback meta, native-ChannelID mapping + route upgrade, RefreshChannelMeta counts.
- WhatsApp: resolver against a fake `identityClient` — group/person resolution, name fallbacks, phone formatting, caching, error paths.
- Handlers: overview endpoint (seeded store + stub adapters), method/nil-service guards, refresh endpoint end-to-end through a real `gateway.Manager`.

Gates: `gofmt -s -l` clean · `go vet ./...` clean · `golangci-lint run` on touched pkgs: 0 issues · `go test -race` on pkg/notify, pkg/gateway/..., server/handlers: all pass · `go build ./...` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel identity metadata across connected apps, including display name, type, and participant count.
  * Added a notifications overview page/API with channel and app summaries.
  * Added a manual channel metadata refresh action.

* **Bug Fixes**
  * Improved channel matching by using native platform channel IDs when available.
  * Existing channel routes now upgrade to more accurate identifiers and metadata over time.
  * Messaging platforms now report more consistent channel types in channel lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->