### PR TITLE
feat(web): drawer-owned chrome, Insights tabs, Marketplace, host-named tools, token-aware costs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,10 +13,9 @@ const Tools = lazy(() => import("./views/Tools").then((m) => ({ default: m.Tools
 const ProviderDetail = lazy(() => import("./views/ProviderDetail").then((m) => ({ default: m.ProviderDetail })));
 const Cron = lazy(() => import("./views/Cron").then((m) => ({ default: m.Cron })));
 const Secrets = lazy(() => import("./views/Secrets").then((m) => ({ default: m.Secrets })));
-const Stats = lazy(() => import("./views/Stats").then((m) => ({ default: m.Stats })));
+const Insights = lazy(() => import("./views/Insights").then((m) => ({ default: m.Insights })));
 const Settings = lazy(() => import("./views/Settings").then((m) => ({ default: m.Settings })));
 const Code = lazy(() => import("./views/Code").then((m) => ({ default: m.Code })));
-const CostsGlobal = lazy(() => import("./views/CostsGlobal").then((m) => ({ default: m.CostsGlobal })));
 const About = lazy(() => import("./views/About").then((m) => ({ default: m.About })));
 
 function Loading() {
@@ -46,39 +45,51 @@ const wrap = (node: React.ReactNode) => (
   </Suspense>
 );
 
+/**
+ * AppRoutes — the route table, split from App so tests can mount it
+ * inside a MemoryRouter (App owns the BrowserRouter).
+ */
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={wrap(<Live />)} />
+        <Route path="live" element={wrap(<Live />)} />
+        <Route path="agents" element={wrap(<Agents />)} />
+        <Route path="agents/:name" element={wrap(<AgentDetail />)} />
+        <Route path="agents/:name/*" element={wrap(<AgentDetail />)} />
+        <Route path="notifications" element={wrap(<Notifications />)} />
+        <Route path="notifications/:sourceName" element={wrap(<Notifications />)} />
+        <Route path="templates" element={wrap(<Templates />)} />
+        <Route path="tools" element={wrap(<Tools />)} />
+        <Route path="tools/:provider" element={wrap(<ProviderDetail />)} />
+        <Route path="cron" element={wrap(<Cron />)} />
+        <Route path="secrets" element={wrap(<Secrets />)} />
+        <Route path="insights" element={wrap(<Insights />)} />
+        {/* Metrics + Costs merged into /insights — old links redirect. */}
+        <Route path="stats" element={<Navigate to="/insights?tab=metrics" replace />} />
+        <Route path="metrics" element={<Navigate to="/insights?tab=metrics" replace />} />
+        <Route path="costs" element={<Navigate to="/insights?tab=costs" replace />} />
+        <Route path="code" element={wrap(<Code />)} />
+        <Route path="code/*" element={wrap(<Code />)} />
+        <Route path="settings" element={wrap(<Settings />)} />
+        <Route path="about" element={wrap(<About />)} />
+
+        {/* Old builds 301'd /<page> → /w/<hash>/<page>; browsers
+            cached that redirect, so route it back to flat URLs. */}
+        <Route path="w/:ws/*" element={<LegacyWorkspaceRedirect />} />
+        <Route path="*" element={<NotFound />} />
+      </Route>
+    </Routes>
+  );
+}
+
 export function App() {
   return (
     <ErrorBoundary>
       <ThemeProvider>
         <BrowserRouter>
-          <Routes>
-            <Route element={<Layout />}>
-              <Route index element={wrap(<Live />)} />
-              <Route path="live" element={wrap(<Live />)} />
-              <Route path="agents" element={wrap(<Agents />)} />
-              <Route path="agents/:name" element={wrap(<AgentDetail />)} />
-              <Route path="agents/:name/*" element={wrap(<AgentDetail />)} />
-              <Route path="notifications" element={wrap(<Notifications />)} />
-              <Route path="notifications/:sourceName" element={wrap(<Notifications />)} />
-              <Route path="templates" element={wrap(<Templates />)} />
-              <Route path="tools" element={wrap(<Tools />)} />
-              <Route path="tools/:provider" element={wrap(<ProviderDetail />)} />
-              <Route path="cron" element={wrap(<Cron />)} />
-              <Route path="secrets" element={wrap(<Secrets />)} />
-              <Route path="stats" element={wrap(<Stats />)} />
-              <Route path="metrics" element={wrap(<Stats />)} />
-              <Route path="costs" element={wrap(<CostsGlobal />)} />
-              <Route path="code" element={wrap(<Code />)} />
-              <Route path="code/*" element={wrap(<Code />)} />
-              <Route path="settings" element={wrap(<Settings />)} />
-              <Route path="about" element={wrap(<About />)} />
-
-              {/* Old builds 301'd /<page> → /w/<hash>/<page>; browsers
-                  cached that redirect, so route it back to flat URLs. */}
-              <Route path="w/:ws/*" element={<LegacyWorkspaceRedirect />} />
-              <Route path="*" element={<NotFound />} />
-            </Route>
-          </Routes>
+          <AppRoutes />
         </BrowserRouter>
       </ThemeProvider>
     </ErrorBoundary>

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -3,15 +3,15 @@
  * pane. One continuous strip across the whole viewport, single h-12 row.
  *
  * Slots:
- *   left     : drawer toggle + brand (owned by Layout)
+ *   left     : mobile-only drawer opener (owned by Layout; empty on
+ *              desktop — brand + drawer toggle live inside the drawer)
  *   center   : per-view summary / presence line / breadcrumb — NOT a
  *              page title; the drawer's active nav item already names
  *              the section
  *   actions  : per-view controls (search box, filters, primary CTA)
- *              plus the app-level utility menu appended by Layout
  *
  * Views contribute center/actions through HeaderSlotContext; the left
- * slot is owned by the Layout so toggle + brand stay consistent.
+ * slot is owned by the Layout.
  *
  * `relative z-30` is load-bearing: `backdrop-blur` forces a stacking
  * context, and without an explicit z-index the positioned content
@@ -37,7 +37,7 @@ export function Header({ left, center, actions }: HeaderProps) {
   return (
     <header className="relative z-30 shrink-0 border-b border-mycel-border bg-[color-mix(in_srgb,var(--mycel-surface)_70%,transparent)] backdrop-blur-sm">
       <div className="flex items-center min-w-0 gap-3 px-3 sm:px-4 h-12">
-        {/* Left slot — drawer toggle + brand, far left */}
+        {/* Left slot — mobile-only drawer opener */}
         {left && <div className="flex items-center gap-2 shrink-0">{left}</div>}
 
         {/* Center slot — per-view summary / presence. */}

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { NavLink, Outlet, useLocation, useMatch } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTheme, THEME_LABELS } from "../context/ThemeContext";
@@ -753,61 +753,61 @@ function NotificationNavTree() {
 
 /* ── Nav items ───────────────────────────────────────────────── */
 
-// Primary nav — repo-scoped surfaces + one cross-repo surface (Costs),
-// grouped into quiet labeled sections: the daily surfaces ride unlabeled
-// at the top, configuration surfaces under CONFIGURE, and read-only
-// analytics under INSIGHTS. Labels collapse away in icon-only mode.
-// Settings, About and the theme toggle live in the header's utility
-// menu (UtilityMenu), so the drawer stays pure nav.
+// Primary nav — divider-separated groups, no captions. Group 1 holds the
+// daily surfaces; group 2 the configuration surfaces (Marketplace, the
+// host machine's tools, Cron, Secrets); group 3 the read-only analytics
+// (Metrics + Costs merged behind one "Insights" item). The /tools item
+// is labeled with the daemon host machine's name, resolved at runtime
+// from /api/system/info (fallback "Host" while loading/unavailable).
+// Settings, About and the theme toggle live in the drawer footer.
 type NavItem = { to: string; label: string; icon: string };
-type NavSection = { label: string | null; items: readonly NavItem[] };
 
-const NAV_SECTIONS: readonly NavSection[] = [
-  {
-    label: null,
-    items: [
+const HOST_LABEL_FALLBACK = "Host";
+
+/** Strip noisy mDNS suffixes ("Foo.local" → "Foo"); otherwise keep as-is. */
+export function prettifyHostname(h: string): string {
+  return h.replace(/\.(local|lan)$/i, "");
+}
+
+function buildNavGroups(hostLabel: string): readonly (readonly NavItem[])[] {
+  return [
+    [
       { to: "/live", label: "Live", icon: "live" },
       { to: "/agents", label: "Agents", icon: "agents" },
       { to: "/notifications", label: "Notifications", icon: "notifications" },
       { to: "/code", label: "Code", icon: "code" },
     ],
-  },
-  {
-    label: "Configure",
-    items: [
-      { to: "/templates", label: "Templates", icon: "templates" },
-      { to: "/tools", label: "Tools", icon: "tools" },
+    [
+      { to: "/templates", label: "Marketplace", icon: "templates" },
+      { to: "/tools", label: hostLabel, icon: "tools" },
       { to: "/cron", label: "Cron", icon: "cron" },
       { to: "/secrets", label: "Secrets", icon: "secrets" },
     ],
-  },
-  {
-    label: "Insights",
-    items: [
-      { to: "/stats", label: "Metrics", icon: "metrics" },
-      { to: "/costs", label: "Costs", icon: "metrics" },
-    ],
-  },
-];
-
-const MAIN_NAV_ITEMS: readonly NavItem[] = NAV_SECTIONS.flatMap((s) => s.items);
-
-// Retained so external callers (TITLE_ITEMS, /settings header) that still
-// walk a flat nav list keep working. Settings + Costs both appear here
-// even though they're rendered elsewhere in the sidebar chrome.
-const UTIL_NAV_ITEMS = [
-  { to: "/settings", label: "Settings", icon: "settings" },
-] as const;
-
-const NAV_ITEMS = [...MAIN_NAV_ITEMS, ...UTIL_NAV_ITEMS];
+    [{ to: "/insights", label: "Insights", icon: "metrics" }],
+  ];
+}
 
 /**
- * TITLE_ITEMS — extends NAV_ITEMS with surfaces that resolve to a
- * document title but live outside the sidebar nav lists (e.g. /about
- * sits in the sidebar footer next to the theme toggle, not in any
- * NavList). Keep this list in sync with non-nav top-level routes.
+ * Resolve the document title for a pathname. Covers every nav group
+ * plus the non-nav top-level routes (Settings/About in the drawer
+ * footer, and the /stats /metrics /costs redirects into /insights).
  */
-const TITLE_ITEMS = [...NAV_ITEMS, { to: "/about", label: "About" }];
+function titleFor(pathname: string, hostLabel: string): string {
+  // Compare ONLY the first URL segment so sub-routes such as
+  // /agents/<name>/live keep their parent ("Agents") title rather than
+  // incorrectly resolving to a same-named top-level tab ("Live").
+  const firstSeg = pathname.replace(/^\//, "").split("/")[0] ?? "";
+  const items = [
+    ...buildNavGroups(hostLabel).flat(),
+    { to: "/settings", label: "Settings" },
+    { to: "/about", label: "About" },
+    { to: "/stats", label: "Insights" },
+    { to: "/metrics", label: "Insights" },
+    { to: "/costs", label: "Insights" },
+  ];
+  const match = items.find((item) => item.to.replace(/^\//, "") === firstSeg);
+  return match ? `${match.label} — mycel` : "mycel";
+}
 
 function readCollapsed(): boolean {
   try { return localStorage.getItem(SIDEBAR_KEY) === "true"; } catch { return false; }
@@ -819,16 +819,13 @@ function writeCollapsed(v: boolean) {
 /* ── Nav list ────────────────────────────────────────────────── */
 
 function NavList({
-  sections,
+  groups,
   collapsed,
   isMobile,
   notificationsExpanded,
   onToggleNotifications,
 }: {
-  sections: ReadonlyArray<{
-    label: string | null;
-    items: ReadonlyArray<{ to: string; label: string; icon: string; global?: boolean }>;
-  }>;
+  groups: ReadonlyArray<ReadonlyArray<NavItem>>;
   collapsed: boolean;
   isMobile: boolean;
   notificationsExpanded?: boolean;
@@ -839,19 +836,14 @@ function NavList({
 
   return (
     <>
-      {sections.map((section, sectionIdx) => (
-        <li key={section.label ?? `section-${sectionIdx}`}>
-          {section.label !== null &&
-            (isIconOnly ? (
-              // Icon-only mode: the caption collapses to a bare hairline.
-              <div className="mx-3 my-2 border-t border-mycel-border" aria-hidden />
-            ) : (
-              <div className="px-4 pt-4 pb-1 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted select-none mycel-fade-slide-in">
-                {section.label}
-              </div>
-            ))}
+      {groups.map((items, groupIdx) => (
+        <li key={`group-${groupIdx}`}>
+          {/* Groups separate with a bare hairline — no captions. */}
+          {groupIdx > 0 && (
+            <div className="mx-3 my-2 border-t border-mycel-border" aria-hidden />
+          )}
           <ul>
-            {section.items.map(({ to, label, icon }) => {
+            {items.map(({ to, label, icon }) => {
               const isNotifications = label === "Notifications";
               const scopedTo = to;
               return (
@@ -984,27 +976,36 @@ export function Layout() {
     setCollapsed((prev) => { const next = !prev; writeCollapsed(next); return next; });
   }, []);
 
+  // Host machine name for the /tools nav item — resolved from the daemon
+  // (/api/system/info carries os.Hostname()); "Host" until it arrives.
+  const [hostLabel, setHostLabel] = useState(HOST_LABEL_FALLBACK);
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getSystemInfo()
+      .then((info) => {
+        if (!cancelled && info?.hostname) setHostLabel(prettifyHostname(info.hostname));
+      })
+      .catch(() => { /* keep fallback label */ });
+    return () => { cancelled = true; };
+  }, []);
+  const navGroups = useMemo(() => buildNavGroups(hostLabel), [hostLabel]);
+
   useEffect(() => { if (isMobile) setCollapsed(true); }, [isMobile]);
   useEffect(() => {
-    // Compare ONLY the first URL segment so sub-routes such as
-    // /agents/<name>/live keep their parent ("Agents") title rather than
-    // incorrectly resolving to a same-named top-level tab ("Live").
-    const firstSeg = location.pathname.replace(/^\//, "").split("/")[0] ?? "";
-    const match = TITLE_ITEMS.find((item) => {
-      const seg = item.to.replace(/^\//, "");
-      return seg === firstSeg;
-    });
-    document.title = match ? `${match.label} \u2014 mycel` : "mycel";
-  }, [location.pathname]);
+    document.title = titleFor(location.pathname, hostLabel);
+  }, [location.pathname, hostLabel]);
   useEffect(() => { setMobileOpen(false); }, [location.pathname]);
 
-  const sidebarWidth = collapsed && !isMobile ? "w-14" : "w-48";
+  const isIconOnly = collapsed && !isMobile;
+  const sidebarWidth = isIconOnly ? "w-14" : "w-48";
 
-  // The header owns the ONE drawer toggle. On mobile it opens/closes the
-  // overlay drawer; on desktop it collapses/expands the rail.
-  const headerToggleCollapsed = isMobile ? !mobileOpen : collapsed;
-  const handleHeaderToggle = useCallback(() => {
-    if (isMobile) setMobileOpen((prev) => !prev);
+  // The drawer owns its own toggle (top-right of the brand row when
+  // expanded, top of the icon rail when collapsed). On mobile the same
+  // button closes the overlay drawer; the header only shows an opener
+  // on <md while the drawer is hidden.
+  const handleDrawerToggle = useCallback(() => {
+    if (isMobile) setMobileOpen(false);
     else toggleCollapsed();
   }, [isMobile, toggleCollapsed]);
 
@@ -1013,7 +1014,10 @@ export function Layout() {
     <div className="flex flex-col h-screen">
       {/* Full-width top bar — one continuous strip across the viewport.
           The drawer sits BELOW it. */}
-      <LayoutHeader collapsed={headerToggleCollapsed} onToggleCollapsed={handleHeaderToggle} />
+      <LayoutHeader
+        showMobileToggle={isMobile && !mobileOpen}
+        onOpenMobile={() => setMobileOpen(true)}
+      />
       <DegradedBanner />
 
       <div className="flex flex-1 min-h-0 relative">
@@ -1027,15 +1031,42 @@ export function Layout() {
         }`}
         style={{ scrollbarWidth: "thin", scrollbarColor: "var(--mycel-scrollbar-thumb) transparent" }}
       >
-        {/* Pure nav — the brand moved into the full-width header, so the
-            groups start right at the top of the drawer. */}
-        {/* Nav — sectioned. Labeled captions replace the anonymous
-            dividers so the grouping (fleet items vs global items vs
-            system items) is explicit; the captions collapse to a bare
-            hairline when the sidebar is icon-only. */}
+        {/* Brand row — first row of the drawer. Mark + wordmark sit on
+            the nav items' icon grid (border-l-2 + pl-4); the drawer
+            toggle rides top-right of the same row. Collapsed rail:
+            mark on top, explicit toggle below it (the mark itself is
+            NOT the toggle — it stays the home link). */}
+        {isIconOnly ? (
+          <div className="shrink-0 flex flex-col items-center gap-1 pt-3 pb-1">
+            <NavLink to="/" aria-label="mycel home" className="flex items-center justify-center h-7 text-mycel-text">
+              <BrandMark />
+            </NavLink>
+            <SidebarToggle collapsed onToggle={handleDrawerToggle} />
+          </div>
+        ) : (
+          <div className="shrink-0 flex items-center h-12 border-l-2 border-transparent pl-4 pr-2">
+            <NavLink
+              to="/"
+              aria-label="mycel home"
+              className="flex items-center gap-2.5 select-none text-mycel-text min-w-0"
+            >
+              <span className="shrink-0 flex items-center justify-center w-4">
+                <BrandMark size={18} />
+              </span>
+              <span className="text-sm font-semibold tracking-tight truncate mycel-fade-slide-in">
+                mycel
+              </span>
+            </NavLink>
+            <span className="ml-auto">
+              <SidebarToggle collapsed={false} onToggle={handleDrawerToggle} />
+            </span>
+          </div>
+        )}
+
+        {/* Nav — divider-separated groups, captions gone. */}
         <ul className="flex-1 py-2 overflow-y-auto" style={{ scrollbarWidth: "thin" }}>
           <NavList
-            sections={NAV_SECTIONS}
+            groups={navGroups}
             collapsed={collapsed}
             isMobile={isMobile}
             notificationsExpanded={notificationsExpanded}
@@ -1043,8 +1074,9 @@ export function Layout() {
           />
         </ul>
 
-        {/* No footer — Settings, About and the theme toggle live in the
-            header's utility menu (UtilityMenu), so the drawer is pure nav. */}
+        {/* Footer — Theme toggle, Settings and About pinned at the
+            bottom behind a top divider; icon-only in the rail. */}
+        <DrawerFooter iconOnly={isIconOnly} />
       </nav>
 
       <main className="flex-1 flex flex-col overflow-hidden bg-mycel-bg">
@@ -1061,138 +1093,90 @@ export function Layout() {
   );
 }
 
-/* ── UtilityMenu ────────────────────────────────────────────────
-   The app-level utility dropdown at the far right of the header:
-   theme toggle (showing the current mode), Settings and About links.
-   These moved out of the drawer footer so the drawer is pure nav.
-   Styled like the other popovers (bg-mycel-surface-2, shadow-mycel-lg,
-   rounded-lg); closes on outside click, Escape and navigation. The
-   theme toggle keeps the menu open so the switch is observable. */
-function UtilityMenu() {
+/* ── DrawerFooter ───────────────────────────────────────────────
+   Theme toggle (showing the current mode), Settings and About, pinned
+   at the bottom of the drawer behind a top divider. Styled exactly
+   like the nav items (icon column + label on the border-l-2/pl-4
+   grid, same hover treatment); icon-only in the collapsed rail. */
+function DrawerFooter({ iconOnly }: { iconOnly: boolean }) {
   const { mode, toggle } = useTheme();
-  const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (!open) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", onMouseDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [open]);
-
-  const itemClass =
-    "flex w-full items-center gap-2.5 px-3 py-1.5 text-sm text-mycel-text hover:bg-mycel-surface-hover transition-colors";
+  const linkClass = ({ isActive }: { isActive: boolean }) =>
+    `relative flex items-center gap-2.5 ${iconOnly ? "justify-center px-2" : "pl-4 pr-3"} py-[7px] text-sm outline-none transition-colors duration-75 border-l-2 ${
+      isActive
+        ? "text-mycel-text font-medium border-mycel-accent bg-mycel-surface-hover"
+        : "text-mycel-text-2 hover:text-mycel-text hover:bg-[color-mix(in_srgb,var(--mycel-surface-hover)_60%,transparent)] border-transparent"
+    }`;
+  const buttonClass = `w-full relative flex items-center gap-2.5 ${iconOnly ? "justify-center px-2" : "pl-4 pr-3"} py-[7px] text-sm outline-none transition-colors duration-75 border-l-2 border-transparent text-mycel-text-2 hover:text-mycel-text hover:bg-[color-mix(in_srgb,var(--mycel-surface-hover)_60%,transparent)]`;
 
   return (
-    <div className="relative shrink-0" ref={menuRef}>
+    <div className="shrink-0 border-t border-mycel-border py-2">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-label="Utilities"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        title="Theme, Settings, About"
-        className={`inline-flex items-center justify-center h-8 w-8 rounded-md transition-colors ${
-          open
-            ? "text-mycel-text bg-mycel-surface-hover"
-            : "text-mycel-muted hover:text-mycel-text hover:bg-mycel-surface-hover"
-        }`}
+        onClick={toggle}
+        className={buttonClass}
+        title={`Theme: ${THEME_LABELS[mode]} — click to switch`}
+        aria-label={`Switch theme — currently ${THEME_LABELS[mode]}`}
       >
-        <Icon name="settings" size={16} />
-      </button>
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full mt-1.5 z-50 w-52 rounded-lg border border-mycel-border bg-mycel-surface-2 shadow-mycel-lg py-1.5"
-        >
-          <button
-            type="button"
-            role="menuitem"
-            onClick={toggle}
-            className={itemClass}
-            title={`Theme: ${THEME_LABELS[mode]} — click to switch`}
-            aria-label={`Switch theme — currently ${THEME_LABELS[mode]}`}
-          >
-            {/* Half-shaded circle — semantically "theme mode". */}
-            <span className="shrink-0 flex items-center justify-center w-4 opacity-70">
-              <svg width="15" height="15" viewBox="0 0 14 14" fill="none">
-                <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.4" />
-                <path d="M7 2a5 5 0 010 10z" fill="currentColor" />
-              </svg>
-            </span>
-            <span>Theme</span>
+        {/* Half-shaded circle — semantically "theme mode". */}
+        <span className="shrink-0 flex items-center justify-center w-4 opacity-70">
+          <svg width="15" height="15" viewBox="0 0 14 14" fill="none">
+            <circle cx="7" cy="7" r="5" stroke="currentColor" strokeWidth="1.4" />
+            <path d="M7 2a5 5 0 010 10z" fill="currentColor" />
+          </svg>
+        </span>
+        {!iconOnly && (
+          <>
+            <span className="truncate mycel-fade-slide-in">Theme</span>
             <span className="ml-auto text-xs text-mycel-muted">{THEME_LABELS[mode]}</span>
-          </button>
-          <div className="my-1 border-t border-mycel-border" />
-          <NavLink to="/settings" role="menuitem" onClick={() => setOpen(false)} className={itemClass}>
-            <span className="shrink-0 flex items-center justify-center w-4 opacity-70">
-              <Icon name="settings" size={15} />
-            </span>
-            Settings
-          </NavLink>
-          <NavLink to="/about" role="menuitem" onClick={() => setOpen(false)} className={itemClass}>
-            <span className="shrink-0 flex items-center justify-center w-4 opacity-70">
-              <svg width="15" height="15" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
-                <circle cx="7" cy="7" r="5.5" />
-                <path d="M7 4.5v.01M6 6.5h1v3h1" strokeLinecap="round" strokeLinejoin="round" />
-              </svg>
-            </span>
-            About
-          </NavLink>
-        </div>
-      )}
+          </>
+        )}
+      </button>
+      <NavLink to="/settings" className={linkClass} title={iconOnly ? "Settings" : undefined}>
+        <span className="shrink-0 flex items-center justify-center w-4 opacity-70">
+          <Icon name="settings" size={15} />
+        </span>
+        {!iconOnly && <span className="truncate mycel-fade-slide-in">Settings</span>}
+      </NavLink>
+      <NavLink to="/about" className={linkClass} title={iconOnly ? "About" : undefined}>
+        <span className="shrink-0 flex items-center justify-center w-4 opacity-70">
+          <svg width="15" height="15" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <circle cx="7" cy="7" r="5.5" />
+            <path d="M7 4.5v.01M6 6.5h1v3h1" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        </span>
+        {!iconOnly && <span className="truncate mycel-fade-slide-in">About</span>}
+      </NavLink>
     </div>
   );
 }
 
 /* ── LayoutHeader ───────────────────────────────────────────────
-   The full-width top bar. Owns the far-left cluster (drawer toggle +
-   BrandMark wordmark) and the far-right utility menu; per-view
-   summary/search/actions arrive via HeaderSlotContext. Views that
-   render their own top band (AgentDetail's HUD bar) set `hidden` —
-   the bar stays (it is app chrome: toggle, brand, utilities) but
-   carries no per-view content. */
+   The full-width top bar. Brand + drawer toggle moved INTO the drawer,
+   so the header carries only per-view content (summary/search/actions
+   via HeaderSlotContext) — plus, on <md when the overlay drawer is
+   closed, a small opener at the far left so the drawer stays
+   reachable. Views that render their own top band (AgentDetail's HUD
+   bar) set `hidden` — the bar stays but carries no per-view content. */
 function LayoutHeader({
-  collapsed,
-  onToggleCollapsed,
+  showMobileToggle,
+  onOpenMobile,
 }: {
-  collapsed: boolean;
-  onToggleCollapsed: () => void;
+  showMobileToggle: boolean;
+  onOpenMobile: () => void;
 }) {
   const { slot } = useHeaderSlotContext();
   return (
     <Header
       left={
-        <>
-          <SidebarToggle collapsed={collapsed} onToggle={onToggleCollapsed} />
-          <NavLink
-            to="/"
-            aria-label="mycel home"
-            className="flex items-center gap-2 select-none text-mycel-text"
-          >
-            <BrandMark />
-            <span className="text-sm font-semibold tracking-tight hidden sm:inline">
-              mycel
-            </span>
-          </NavLink>
-        </>
+        showMobileToggle ? (
+          <span className="md:hidden">
+            <SidebarToggle collapsed onToggle={onOpenMobile} />
+          </span>
+        ) : undefined
       }
       center={slot.hidden ? undefined : slot.title}
-      actions={
-        <>
-          {!slot.hidden && slot.actions}
-          <UtilityMenu />
-        </>
-      }
+      actions={slot.hidden ? undefined : slot.actions}
     />
   );
 }

--- a/web/src/components/__tests__/Layout.test.tsx
+++ b/web/src/components/__tests__/Layout.test.tsx
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { Layout, prettifyHostname } from "../Layout";
+import { ThemeProvider } from "../../context/ThemeContext";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+/** Mock every API the chrome touches; hostname=null makes /system/info fail. */
+function mockApi(hostname: string | null) {
+  fetchMock.mockImplementation((url: RequestInfo | URL) => {
+    const u = String(url);
+    if (u.includes("/api/system/info")) {
+      if (hostname === null) return Promise.reject(new Error("network down"));
+      return jsonResponse({ hostname, os: "darwin", arch: "arm64" });
+    }
+    if (u.includes("/api/health")) return jsonResponse({ status: "ok" });
+    return jsonResponse([]);
+  });
+}
+
+function renderLayout() {
+  return render(
+    <ThemeProvider>
+      <MemoryRouter initialEntries={["/live"]}>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="live" element={<div data-testid="page" />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  window.localStorage?.clear();
+});
+
+describe("prettifyHostname", () => {
+  it("strips mDNS suffixes and keeps everything else as-is", () => {
+    expect(prettifyHostname("Puneets-MacBook-Pro.local")).toBe("Puneets-MacBook-Pro");
+    expect(prettifyHostname("nas.lan")).toBe("nas");
+    expect(prettifyHostname("build.example.com")).toBe("build.example.com");
+    expect(prettifyHostname("plainhost")).toBe("plainhost");
+  });
+});
+
+describe("Layout chrome", () => {
+  it("puts the brand and the drawer toggle inside the drawer, not the header", async () => {
+    mockApi("test-host");
+    renderLayout();
+
+    const nav = screen.getByRole("navigation");
+    // Brand row is the drawer's first row.
+    expect(within(nav).getByText("mycel")).toBeInTheDocument();
+    // Explicit toggle button lives in the drawer.
+    expect(within(nav).getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
+
+    // Header carries no brand, no toggle, no utility menu.
+    const header = screen.getByRole("banner");
+    expect(within(header).queryByText("mycel")).not.toBeInTheDocument();
+    expect(within(header).queryByRole("button", { name: /sidebar/i })).not.toBeInTheDocument();
+    expect(within(header).queryByRole("button", { name: "Utilities" })).not.toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByText("test-host")).toBeInTheDocument());
+  });
+
+  it("collapses to an icon rail via the drawer toggle; toggle stays available", async () => {
+    mockApi("test-host");
+    renderLayout();
+
+    const nav = screen.getByRole("navigation");
+    within(nav).getByRole("button", { name: "Collapse sidebar" }).click();
+    await waitFor(() =>
+      expect(within(nav).getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument(),
+    );
+    // Wordmark hides in the rail; the mark (home link) stays.
+    expect(within(nav).queryByText("mycel")).not.toBeInTheDocument();
+    expect(within(nav).getByRole("link", { name: "mycel home" })).toBeInTheDocument();
+  });
+
+  it("renders the flattened nav: Marketplace + Insights, no group captions", async () => {
+    mockApi("test-host");
+    renderLayout();
+
+    expect(screen.getByRole("link", { name: /Marketplace/ })).toHaveAttribute("href", "/templates");
+    expect(screen.getByRole("link", { name: /Insights/ })).toHaveAttribute("href", "/insights");
+    // Old separate items and captions are gone.
+    expect(screen.queryByText("Configure")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Metrics" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Costs" })).not.toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("test-host")).toBeInTheDocument());
+  });
+
+  it("labels the tools item with the prettified hostname from /api/system/info", async () => {
+    mockApi("Puneets-MacBook-Pro.local");
+    renderLayout();
+
+    const link = await screen.findByRole("link", { name: /Puneets-MacBook-Pro/ });
+    expect(link).toHaveAttribute("href", "/tools");
+    expect(screen.queryByText("Puneets-MacBook-Pro.local")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the 'Host' label when system info is unavailable", async () => {
+    mockApi(null);
+    renderLayout();
+
+    const link = screen.getByRole("link", { name: /Host/ });
+    expect(link).toHaveAttribute("href", "/tools");
+    // Stays on the fallback after the failed fetch settles.
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: /Host/ })).toBeInTheDocument(),
+    );
+  });
+
+  it("keeps Theme, Settings and About in the drawer footer", async () => {
+    mockApi("test-host");
+    renderLayout();
+
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).getByRole("button", { name: /Switch theme/ })).toBeInTheDocument();
+    expect(within(nav).getByRole("link", { name: "Settings" })).toHaveAttribute("href", "/settings");
+    expect(within(nav).getByRole("link", { name: "About" })).toHaveAttribute("href", "/about");
+    await waitFor(() => expect(screen.getByText("test-host")).toBeInTheDocument());
+  });
+});

--- a/web/src/hooks/useCommandPalette.ts
+++ b/web/src/hooks/useCommandPalette.ts
@@ -45,12 +45,14 @@ export function useCommandPalette() {
       { id: "nav-agents", label: "Agents", section: "Navigate", icon: "A", action: () => navigate("/agents") },
       { id: "nav-notifications", label: "Notifications", section: "Navigate", icon: "N", action: () => navigate("/notifications") },
       { id: "nav-code", label: "Code", section: "Navigate", icon: "<", action: () => navigate("/code") },
-      { id: "nav-templates", label: "Templates", section: "Navigate", icon: "T", action: () => navigate("/templates") },
-      { id: "nav-tools", label: "Tools", section: "Navigate", icon: "t", action: () => navigate("/tools") },
+      { id: "nav-templates", label: "Marketplace", section: "Navigate", icon: "T", action: () => navigate("/templates") },
+      // Host tools — the sidebar shows the host machine's name; the
+      // palette keeps a static label since it doesn't fetch system info.
+      { id: "nav-tools", label: "Host", section: "Navigate", icon: "t", action: () => navigate("/tools") },
       { id: "nav-cron", label: "Cron", section: "Navigate", icon: "@", action: () => navigate("/cron") },
       { id: "nav-secrets", label: "Secrets", section: "Navigate", icon: "#", action: () => navigate("/secrets") },
-      { id: "nav-metrics", label: "Metrics", section: "Navigate", icon: "M", action: () => navigate("/metrics") },
-      { id: "nav-costs", label: "Costs", section: "Navigate", icon: "$", action: () => navigate("/costs") },
+      { id: "nav-metrics", label: "Insights: Metrics", section: "Navigate", icon: "M", action: () => navigate("/insights?tab=metrics") },
+      { id: "nav-costs", label: "Insights: Costs", section: "Navigate", icon: "$", action: () => navigate("/insights?tab=costs") },
       { id: "nav-settings", label: "Settings", section: "Navigate", icon: "\u2699", action: () => navigate("/settings") },
       // Actions
       { id: "act-create-agent", label: "Create Agent", section: "Action", icon: "+", action: () => navigate("/agents?action=create") },

--- a/web/src/views/CostsGlobal.tsx
+++ b/web/src/views/CostsGlobal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../api/client";
-import { formatCost } from "../utils/format";
+import type { CostSummary, AgentCostSummary, ModelCostSummary } from "../api/client";
+import { formatCost, formatTokens } from "../utils/format";
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 
 type GroupBy = "repo" | "project";
@@ -18,12 +19,40 @@ function defaultStart(): string {
   return d.toISOString().slice(0, 10); // YYYY-MM-DD
 }
 
+/** Small stat cell for the token/cost summary strip. */
+function Stat({ label, value, title }: { label: string; value: string; title?: string }) {
+  return (
+    <div className="flex flex-col gap-0.5" title={title}>
+      <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-mycel-muted">
+        {label}
+      </span>
+      <span className="text-[18px] font-semibold text-mycel-text leading-tight tabular-nums">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+const thLeft = "text-left font-normal px-3 py-2";
+const thRight = "text-right font-normal px-3 py-2";
+const tdMono = "px-3 py-2 text-right font-mono";
+
 export function CostsGlobal() {
   const [start, setStart] = useState<string>(defaultStart);
   const groupBy: GroupBy = "repo";
   const [rows, setRows] = useState<CostRow[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // Ledger summaries — costs are computed FROM tokens, so token usage is
+  // shown alongside every dollar figure. These endpoints (/costs,
+  // /costs/agents, /costs/models) carry input/output token fields; the
+  // cross-repo rollup (/api/global/costs) does NOT expose tokens per
+  // repo row, so the repo table stays dollars-only (noted, not an API
+  // change in this pass).
+  const [summary, setSummary] = useState<CostSummary | null>(null);
+  const [byAgent, setByAgent] = useState<AgentCostSummary[]>([]);
+  const [byModel, setByModel] = useState<ModelCostSummary[]>([]);
 
   const total = useMemo(
     () => (rows ? rows.reduce((acc, r) => acc + r.total, 0) : 0),
@@ -48,6 +77,34 @@ export function CostsGlobal() {
   useEffect(() => {
     load();
   }, [load]);
+
+  // Token-bearing ledger summaries load independently of the repo rollup —
+  // a failure here degrades to the dollars-only view instead of erroring.
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.allSettled([
+      api.getCostSummary(),
+      api.getCostByAgent(),
+      api.getCostByModel(),
+    ]).then(([s, a, m]) => {
+      if (cancelled) return;
+      if (s.status === "fulfilled") setSummary(s.value);
+      if (a.status === "fulfilled") setByAgent(a.value ?? []);
+      if (m.status === "fulfilled") setByModel(m.value ?? []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const agentRows = useMemo(
+    () => [...byAgent].sort((a, b) => b.total_cost_usd - a.total_cost_usd),
+    [byAgent],
+  );
+  const modelRows = useMemo(
+    () => [...byModel].sort((a, b) => b.total_cost_usd - a.total_cost_usd),
+    [byModel],
+  );
 
   useHeaderSlot({
     actions: (
@@ -93,15 +150,43 @@ export function CostsGlobal() {
         </span>
       </div>
 
+      {/* Token usage strip — costs derive from tokens, so the ledger's
+          token totals sit right beside the dollar headline. All-time
+          ledger figures (the /costs summary has no range parameter). */}
+      {summary && (
+        <div className="rounded-md border border-mycel-border bg-mycel-surface px-4 py-3 grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <Stat
+            label="Total tokens"
+            value={formatTokens(summary.total_tokens)}
+            title={`${summary.total_tokens.toLocaleString()} tokens (input + output, all time)`}
+          />
+          <Stat
+            label="Input tokens"
+            value={formatTokens(summary.input_tokens)}
+            title={`${summary.input_tokens.toLocaleString()} input tokens`}
+          />
+          <Stat
+            label="Output tokens"
+            value={formatTokens(summary.output_tokens)}
+            title={`${summary.output_tokens.toLocaleString()} output tokens`}
+          />
+          <Stat
+            label="Ledger cost"
+            value={formatCost(summary.total_cost_usd)}
+            title="All-time cost computed from the token ledger"
+          />
+        </div>
+      )}
+
       <div className="rounded-md border border-mycel-border overflow-hidden shadow-mycel">
         <table className="w-full text-[13px]">
           <thead className="bg-mycel-surface text-mycel-muted">
             <tr>
-              <th className="text-left font-normal px-3 py-2">
+              <th className={thLeft}>
                 {groupBy === "repo" ? "Repo" : "Project"}
               </th>
-              <th className="text-right font-normal px-3 py-2">Cost</th>
-              <th className="text-right font-normal px-3 py-2 w-24">Share</th>
+              <th className={thRight}>Cost</th>
+              <th className={`${thRight} w-24`}>Share</th>
             </tr>
           </thead>
           <tbody>
@@ -150,6 +235,74 @@ export function CostsGlobal() {
           </tbody>
         </table>
       </div>
+
+      {/* By agent — token columns beside every dollar figure. */}
+      {agentRows.length > 0 && (
+        <div className="rounded-md border border-mycel-border overflow-hidden shadow-mycel">
+          <table className="w-full text-[13px]">
+            <thead className="bg-mycel-surface text-mycel-muted">
+              <tr>
+                <th className={thLeft}>Agent</th>
+                <th className={thRight}>Input</th>
+                <th className={thRight}>Output</th>
+                <th className={thRight}>Tokens</th>
+                <th className={thRight}>Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agentRows.map((a) => (
+                <tr key={a.agent_id} className="border-t border-mycel-border hover:bg-mycel-surface-hover transition-colors">
+                  <td className="px-3 py-2 text-mycel-text truncate max-w-[40%]">{a.agent_id}</td>
+                  <td className={`${tdMono} text-mycel-text-2`} title={a.input_tokens.toLocaleString()}>
+                    {formatTokens(a.input_tokens)}
+                  </td>
+                  <td className={`${tdMono} text-mycel-text-2`} title={a.output_tokens.toLocaleString()}>
+                    {formatTokens(a.output_tokens)}
+                  </td>
+                  <td className={`${tdMono} text-mycel-text`} title={(a.input_tokens + a.output_tokens).toLocaleString()}>
+                    {formatTokens(a.input_tokens + a.output_tokens)}
+                  </td>
+                  <td className={`${tdMono} text-mycel-text`}>{formatCost(a.total_cost_usd)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* By model — same token-beside-cost treatment. */}
+      {modelRows.length > 0 && (
+        <div className="rounded-md border border-mycel-border overflow-hidden shadow-mycel">
+          <table className="w-full text-[13px]">
+            <thead className="bg-mycel-surface text-mycel-muted">
+              <tr>
+                <th className={thLeft}>Model</th>
+                <th className={thRight}>Input</th>
+                <th className={thRight}>Output</th>
+                <th className={thRight}>Tokens</th>
+                <th className={thRight}>Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {modelRows.map((m) => (
+                <tr key={m.model} className="border-t border-mycel-border hover:bg-mycel-surface-hover transition-colors">
+                  <td className="px-3 py-2 text-mycel-text truncate max-w-[40%]">{m.model}</td>
+                  <td className={`${tdMono} text-mycel-text-2`} title={m.input_tokens.toLocaleString()}>
+                    {formatTokens(m.input_tokens)}
+                  </td>
+                  <td className={`${tdMono} text-mycel-text-2`} title={m.output_tokens.toLocaleString()}>
+                    {formatTokens(m.output_tokens)}
+                  </td>
+                  <td className={`${tdMono} text-mycel-text`} title={m.total_tokens.toLocaleString()}>
+                    {formatTokens(m.total_tokens)}
+                  </td>
+                  <td className={`${tdMono} text-mycel-text`}>{formatCost(m.total_cost_usd)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/views/Insights.tsx
+++ b/web/src/views/Insights.tsx
@@ -1,0 +1,62 @@
+/**
+ * Insights — Metrics + Costs merged behind one nav item.
+ *
+ * Two tabs (?tab=metrics | ?tab=costs) rendering the existing Stats and
+ * CostsGlobal views unchanged as tab content. Only the active tab is
+ * mounted so each view's useHeaderSlot (range picker / date picker)
+ * owns the header without fighting the other. /stats, /metrics and
+ * /costs redirect here (see App.tsx) so old links keep working.
+ *
+ * Tab styling follows AgentDetail's HUD tabs: small uppercase buttons
+ * with an accent underline on the active tab.
+ */
+
+import { useSearchParams } from "react-router-dom";
+import { Stats } from "./Stats";
+import { CostsGlobal } from "./CostsGlobal";
+
+const TABS = [
+  { key: "metrics", label: "Metrics" },
+  { key: "costs", label: "Costs" },
+] as const;
+
+type TabKey = (typeof TABS)[number]["key"];
+
+export function Insights() {
+  const [params, setParams] = useSearchParams();
+  const tab: TabKey = params.get("tab") === "costs" ? "costs" : "metrics";
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div
+        role="tablist"
+        aria-label="Insights sections"
+        className="shrink-0 flex items-center gap-1 px-4 pt-1 border-b border-mycel-border"
+      >
+        {TABS.map((t) => {
+          const isActive = tab === t.key;
+          return (
+            <button
+              key={t.key}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => setParams({ tab: t.key }, { replace: true })}
+              className={`relative px-2.5 py-2 text-[11px] font-medium tracking-wide uppercase transition-colors shrink-0 ${
+                isActive ? "text-mycel-accent" : "text-mycel-muted hover:text-mycel-text"
+              }`}
+            >
+              {t.label}
+              {isActive && (
+                <span className="absolute -bottom-px left-2 right-2 h-[2px] bg-mycel-accent rounded-full" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+      <div className="flex-1 min-h-0 overflow-auto">
+        {tab === "metrics" ? <Stats /> : <CostsGlobal />}
+      </div>
+    </div>
+  );
+}

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -220,7 +220,7 @@ function TemplateDetailPanel({
           className="text-xs text-mycel-muted hover:text-mycel-text transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg rounded-md"
           aria-label="Back to templates list"
         >
-          ← Templates
+          ← Marketplace
         </button>
         <span className="text-mycel-muted">/</span>
         <h1 className="text-xl font-semibold tracking-tight text-mycel-text">
@@ -750,8 +750,13 @@ export function Templates() {
         />
       )}
 
-      {/* Table */}
+      {/* Table — local templates, distinguished from the (future)
+          community marketplace content below. */}
       {filteredTemplates !== null && filteredTemplates.length > 0 && (
+        <div>
+          <div className="pb-2 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted select-none">
+            Your templates
+          </div>
         <div className="rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden">
           <table className="w-full">
             <thead>
@@ -773,7 +778,70 @@ export function Templates() {
             </tbody>
           </table>
         </div>
+        </div>
       )}
+
+      {/* Marketplace preview — the community marketplace ships in a
+          later release; these quiet placeholder cards frame the page
+          without dominating it. */}
+      <MarketplacePreview />
+    </div>
+  );
+}
+
+/* ── Marketplace preview ─────────────────────────────────────────────
+   Restrained coming-soon strip for the future community features.
+   Muted cards on the token system — an appetite-whetter, not an
+   empty state. */
+const MARKETPLACE_PREVIEWS = [
+  {
+    title: "Browse community templates",
+    description: "Discover agent templates shared by other mycel users.",
+  },
+  {
+    title: "Install shared roles & workflows",
+    description: "Pull ready-made roles and multi-agent workflows into your fleet.",
+  },
+] as const;
+
+function MarketplacePreview() {
+  return (
+    <div className="pt-2">
+      <div className="pb-2 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted select-none">
+        Marketplace
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {MARKETPLACE_PREVIEWS.map((p) => (
+          <div
+            key={p.title}
+            className="flex items-start gap-3 rounded-lg border border-dashed border-mycel-border bg-mycel-surface px-4 py-3"
+          >
+            {/* Small mark — a quiet node glyph, not a hero icon. */}
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 14 14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.3"
+              className="shrink-0 mt-0.5 text-mycel-muted"
+              aria-hidden
+            >
+              <circle cx="7" cy="7" r="2" />
+              <path d="M8.5 5.5L11 3M5.5 8.5L3 11M9 8.5l2.5 1.5" strokeLinecap="round" opacity="0.6" />
+            </svg>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-mycel-text-2 truncate">{p.title}</span>
+                <span className="shrink-0 rounded-full border border-mycel-border bg-mycel-bg px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.06em] text-mycel-muted">
+                  Coming soon
+                </span>
+              </div>
+              <p className="mt-0.5 text-xs text-mycel-muted">{p.description}</p>
+            </div>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/web/src/views/__tests__/insights.test.tsx
+++ b/web/src/views/__tests__/insights.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { Insights } from "../Insights";
+import { AppRoutes } from "../../App";
+import { HeaderSlotProvider } from "../../context/HeaderSlotContext";
+import { ThemeProvider } from "../../context/ThemeContext";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+/** Route-aware API mock covering both the Stats and Costs tab data. */
+function mockApi() {
+  fetchMock.mockImplementation((url: RequestInfo | URL) => {
+    const u = String(url);
+    if (u.includes("/api/global/costs")) {
+      return jsonResponse({ range: { start: "2026-06-05T00:00:00Z" }, groupBy: "repo", rows: [] });
+    }
+    if (u.includes("/api/costs/agents") || u.includes("/api/costs/models")) {
+      return jsonResponse([]);
+    }
+    if (u.includes("/api/costs")) {
+      return jsonResponse({
+        input_tokens: 1_200_000,
+        output_tokens: 300_000,
+        total_tokens: 1_500_000,
+        total_cost_usd: 12.34,
+        record_count: 42,
+      });
+    }
+    if (u.includes("/api/system/info")) {
+      return jsonResponse({ hostname: "test-host", os: "darwin", arch: "arm64" });
+    }
+    if (u.includes("/api/health")) return jsonResponse({ status: "ok" });
+    return jsonResponse([]);
+  });
+}
+
+function renderInsights(entry = "/insights") {
+  return render(
+    <MemoryRouter initialEntries={[entry]}>
+      <HeaderSlotProvider>
+        <Insights />
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="loc">{loc.pathname + loc.search}</div>;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  window.localStorage?.clear();
+  mockApi();
+});
+
+describe("Insights", () => {
+  it("defaults to the Metrics tab and renders the Stats view", async () => {
+    renderInsights();
+
+    expect(screen.getByRole("tab", { name: "Metrics" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("tab", { name: "Costs" })).toHaveAttribute("aria-selected", "false");
+    // Stats view content (empty-data panels) arrives once polling settles.
+    await waitFor(() => expect(screen.getByText("No CPU data")).toBeInTheDocument());
+  });
+
+  it("renders the Costs view (with token stats) on ?tab=costs", async () => {
+    renderInsights("/insights?tab=costs");
+
+    expect(screen.getByRole("tab", { name: "Costs" })).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(screen.getByText("No cost data in range.")).toBeInTheDocument());
+    // Token usage presented alongside dollar costs.
+    await waitFor(() => expect(screen.getByText("Total tokens")).toBeInTheDocument());
+    expect(screen.getByText("1.5M")).toBeInTheDocument();
+    expect(screen.getByText("Input tokens")).toBeInTheDocument();
+    expect(screen.getByText("Output tokens")).toBeInTheDocument();
+  });
+
+  it("switches tabs on click", async () => {
+    renderInsights();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Costs" }));
+    expect(screen.getByRole("tab", { name: "Costs" })).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(screen.getByText("No cost data in range.")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("tab", { name: "Metrics" }));
+    expect(screen.getByRole("tab", { name: "Metrics" })).toHaveAttribute("aria-selected", "true");
+    await waitFor(() => expect(screen.getByText("No CPU data")).toBeInTheDocument());
+  });
+});
+
+describe("Insights redirects", () => {
+  function renderApp(entry: string) {
+    return render(
+      <ThemeProvider>
+        <MemoryRouter initialEntries={[entry]}>
+          <LocationProbe />
+          <AppRoutes />
+        </MemoryRouter>
+      </ThemeProvider>,
+    );
+  }
+
+  it("redirects /costs to /insights?tab=costs", async () => {
+    renderApp("/costs");
+    await waitFor(() =>
+      expect(screen.getByTestId("loc")).toHaveTextContent("/insights?tab=costs"),
+    );
+  });
+
+  it("redirects /stats and /metrics to /insights?tab=metrics", async () => {
+    const { unmount } = renderApp("/stats");
+    await waitFor(() =>
+      expect(screen.getByTestId("loc")).toHaveTextContent("/insights?tab=metrics"),
+    );
+    unmount();
+
+    renderApp("/metrics");
+    await waitFor(() =>
+      expect(screen.getByTestId("loc")).toHaveTextContent("/insights?tab=metrics"),
+    );
+  });
+});


### PR DESCRIPTION
Round 5 of the owner-requested drawer/nav fixes (from the drawer screenshot). Part of #3305

## Fix 1 — drawer toggle + brand placement
- The drawer toggle moved OUT of the header and INTO the drawer: expanded state shows it at the top-right of the drawer's first row; the collapsed icon rail shows the BrandMark on top with an explicit toggle button below it (the mark stays the home link, not the toggle). The 200ms width transition is unchanged.
- BrandMark + "mycel" wordmark are back in the drawer as its first row, left-aligned on the nav items' icon grid (`border-l-2` + `pl-4`).
- The header now starts directly with per-view controls (summary / search / actions via HeaderSlotContext). On `<md` a small opener appears at the header's left ONLY while the overlay drawer is closed.

## Owner addition — utility menu removed
The header's utility dropdown is gone. Theme (showing the current Dark/Light mode), Settings and About live in the **drawer footer**, styled as regular nav items (same icon column, hover treatment), pinned at the bottom behind a top divider; icon-only in the collapsed rail.

## Fix 2 — nav structure
- CONFIGURE and INSIGHTS captions removed; groups now separate with bare hairline dividers.
- Metrics + Costs merged into one **Insights** nav item: `/insights` renders the existing `Stats` and `CostsGlobal` views unchanged as tab content (`?tab=metrics` / `?tab=costs`, AgentDetail-style underline tabs; only the active tab mounts so each view's header slot works as before).
- `/stats`, `/metrics` and `/costs` redirect to the matching Insights tab so old links keep working.

## Fix 3 — renames
- **Templates → Marketplace**: nav label, document title, command-palette entry and page framing. Route stays `/templates` (label-only change, as requested). Per the owner addition, the page keeps all existing template functionality under a "Your templates" section header and gains a restrained coming-soon card row ("Browse community templates", "Install shared roles & workflows") for the future community marketplace — muted dashed cards on the token system, not a giant empty state.
- **Tools → host machine name**: the nav item shows the daemon's hostname with the existing tools icon. Source: the existing `/api/system/info` endpoint (already carries `os.Hostname()`), so **no Go change was needed**; `.local`/`.lan` suffixes are stripped client-side (`prettifyHostname`), fallback label "Host" while loading/unavailable. The command palette keeps a static "Host" label since it doesn't fetch system info.

## Fix 4 — Costs page shows token usage
- Token summary strip beside the dollar headline: total / input / output tokens + ledger cost from `/api/costs` (`CostSummary` carries the token fields).
- New **by-agent** and **by-model** tables with Input / Output / Tokens columns next to each Cost (from `/api/costs/agents` and `/api/costs/models`; exact counts in tooltips).
- Note: the cross-repo rollup endpoint `/api/global/costs` does **not** carry token fields per repo row, so the repo table stays dollars-only — noted rather than changing the API in this pass.

## Tests
- New `Layout.test.tsx`: brand + toggle live in the drawer (not the header), collapse-to-rail behavior, flattened nav (Marketplace/Insights, no captions), hostname label + "Host" fallback, drawer-footer Theme/Settings/About.
- New `insights.test.tsx`: default Metrics tab renders Stats, `?tab=costs` renders Costs with the token stats, tab switching, and `/costs` `/stats` `/metrics` redirects (via the extracted `AppRoutes`).

## Gates
- `bunx tsc --noEmit` ✅  · `eslint src` ✅ · `vitest` 145/145 ✅ · `bun run build` ✅
- No Go files touched (hostname already exposed server-side), so Go gates don't apply.
- Rebased over origin/main (#3308); #3311's notifications summary line hadn't landed at push time — no conflict to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)