### PR TITLE
feat(gateway): outbound WhatsApp messages via whatsmeow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	go.mau.fi/whatsmeow v0.0.0-20260416104156-3ff20cd3462a
 	golang.org/x/crypto v0.53.0
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -50,5 +51,4 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/pkg/gateway/whatsapp/send_test.go
+++ b/pkg/gateway/whatsapp/send_test.go
@@ -1,0 +1,76 @@
+package whatsapp
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestParseSendJID(t *testing.T) {
+	tests := []struct {
+		name      string
+		channelID string
+		wantUser  string
+		wantSrv   string
+		wantErr   string
+	}{
+		{
+			name:      "phone jid",
+			channelID: "918051005416@s.whatsapp.net",
+			wantUser:  "918051005416",
+			wantSrv:   "s.whatsapp.net",
+		},
+		{
+			name:      "hidden lid jid",
+			channelID: "30507219845203@lid",
+			wantUser:  "30507219845203",
+			wantSrv:   "lid",
+		},
+		{
+			name:      "group jid",
+			channelID: "120363123456789012@g.us",
+			wantUser:  "120363123456789012",
+			wantSrv:   "g.us",
+		},
+		{
+			name:      "bare id rejected",
+			channelID: "30507219845203",
+			wantErr:   "no JID server",
+		},
+		{
+			name:      "channel name rejected",
+			channelID: "general",
+			wantErr:   "no JID server",
+		},
+		{
+			name:      "empty user rejected",
+			channelID: "@lid",
+			wantErr:   "empty user",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jid, err := parseSendJID(tt.channelID)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("parseSendJID(%q) error = %v, want containing %q", tt.channelID, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSendJID(%q) unexpected error: %v", tt.channelID, err)
+			}
+			if jid.User != tt.wantUser || jid.Server != tt.wantSrv {
+				t.Fatalf("parseSendJID(%q) = %s@%s, want %s@%s", tt.channelID, jid.User, jid.Server, tt.wantUser, tt.wantSrv)
+			}
+		})
+	}
+}
+
+func TestSendNotConnected(t *testing.T) {
+	a := New(t.TempDir())
+	err := a.Send(context.Background(), "918051005416@s.whatsapp.net", "zen-zebra", "hello")
+	if err == nil || !strings.Contains(err.Error(), "not connected") {
+		t.Fatalf("Send on disconnected adapter = %v, want not-connected error", err)
+	}
+}

--- a/pkg/gateway/whatsapp/whatsapp.go
+++ b/pkg/gateway/whatsapp/whatsapp.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -25,6 +26,7 @@ import (
 	"go.mau.fi/whatsmeow/types"
 	"go.mau.fi/whatsmeow/types/events"
 	waLog "go.mau.fi/whatsmeow/util/log"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/rpuneet/mycel/pkg/gateway"
 	"github.com/rpuneet/mycel/pkg/log"
@@ -310,6 +312,50 @@ func (a *Adapter) Stop() error {
 	a.connected = false
 	a.mu.Unlock()
 	return nil
+}
+
+// Send delivers an outbound text message to a WhatsApp chat. channelID must
+// be a platform-native JID (e.g. "1234@s.whatsapp.net", "1234@lid" or
+// "1234@g.us"); the gateway manager stores it on the channel route from
+// inbound messages. The sender name is ignored — messages go out from the
+// paired personal account, so callers should attribute the author in the
+// content itself.
+func (a *Adapter) Send(ctx context.Context, channelID, _, content string) error {
+	a.mu.Lock()
+	client := a.client
+	connected := a.connected
+	a.mu.Unlock()
+	if client == nil || !connected {
+		return fmt.Errorf("whatsapp: not connected")
+	}
+
+	jid, err := parseSendJID(channelID)
+	if err != nil {
+		return err
+	}
+
+	if _, err := client.SendMessage(ctx, jid, &waE2E.Message{Conversation: proto.String(content)}); err != nil {
+		return fmt.Errorf("whatsapp: send to %s: %w", jid, err)
+	}
+	return nil
+}
+
+// parseSendJID converts a stored channel id into a routable JID. Bare ids
+// without a server part are ambiguous between phone-number and hidden-lid
+// chats, so they are rejected: the route upgrades to a native JID on the
+// next inbound message from that chat.
+func parseSendJID(channelID string) (types.JID, error) {
+	if !strings.Contains(channelID, "@") {
+		return types.JID{}, fmt.Errorf("whatsapp: channel id %q has no JID server — wait for an inbound message to upgrade the route", channelID)
+	}
+	jid, err := types.ParseJID(channelID)
+	if err != nil {
+		return types.JID{}, fmt.Errorf("whatsapp: invalid JID %q: %w", channelID, err)
+	}
+	if jid.User == "" {
+		return types.JID{}, fmt.Errorf("whatsapp: invalid JID %q: empty user", channelID)
+	}
+	return jid, nil
 }
 
 // Channels returns discovered chats (empty until connected).

--- a/pkg/gateway/whatsapp/whatsapp.go
+++ b/pkg/gateway/whatsapp/whatsapp.go
@@ -334,11 +334,24 @@ func (a *Adapter) Send(ctx context.Context, channelID, _, content string) error 
 		return err
 	}
 
+	// Bound the send so a stalled network round-trip can't block the caller
+	// indefinitely. Only apply the fallback when the caller's context carries
+	// no deadline of its own, so an explicit deadline is always respected.
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, sendTimeout)
+		defer cancel()
+	}
+
 	if _, err := client.SendMessage(ctx, jid, &waE2E.Message{Conversation: proto.String(content)}); err != nil {
 		return fmt.Errorf("whatsapp: send to %s: %w", jid, err)
 	}
 	return nil
 }
+
+// sendTimeout bounds a single outbound WhatsApp send when the caller supplies
+// no deadline of its own.
+const sendTimeout = 30 * time.Second
 
 // parseSendJID converts a stored channel id into a routable JID. Bare ids
 // without a server part are ambiguous between phone-number and hidden-lid


### PR DESCRIPTION
Closes #3315

## Summary
- Implement `Send()` on the WhatsApp gateway adapter (the `messageSender` interface Manager.Send checks at runtime) — until now WhatsApp was inbound-only and any agent send to a `whatsapp:*` channel errored with "adapter does not support outbound messaging".
- `parseSendJID` accepts only platform-native JIDs (`@s.whatsapp.net`, `@lid`, `@g.us`). Bare numeric ids (legacy routes persisted before native-id upgrades) are rejected with a clear error — the route self-heals on the next inbound message from that chat.
- Sender name is ignored by design: a WhatsApp Web session can only send as the paired personal account, so callers attribute the author inside the content.

## Testing
- Table-driven `TestParseSendJID` (phone/lid/group accepted; bare id, channel name, empty user rejected)
- `TestSendNotConnected` guards the disconnected path
- `go test -race ./pkg/gateway/whatsapp`, `go vet`, `golangci-lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp channels can now send outbound text messages.

* **Bug Fixes**
  * Improved validation for WhatsApp channel identifiers, with clearer errors for invalid or incomplete values.
  * Sending now returns a helpful error when attempted before a connection is established.

* **Tests**
  * Added coverage for valid and invalid WhatsApp identifier parsing and disconnected send behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->