### PR TITLE
feat(web): header-owned brand column, resizable drawer, single header

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -3,8 +3,11 @@
  * pane. One continuous strip across the whole viewport, single h-12 row.
  *
  * Slots:
- *   left     : mobile-only drawer opener (owned by Layout; empty on
- *              desktop — brand + drawer toggle live inside the drawer)
+ *   left     : the brand / drawer column — mycel mark + wordmark + the
+ *              drawer toggle, sized to match the drawer's width and
+ *              collapsing with it. Owned by Layout, rendered flush so its
+ *              right border lines up with the drawer's. On mobile it is
+ *              just the drawer opener while the overlay drawer is closed.
  *   center   : per-view summary / presence line / breadcrumb — NOT a
  *              page title; the drawer's active nav item already names
  *              the section
@@ -36,23 +39,32 @@ export interface HeaderProps {
 export function Header({ left, center, actions }: HeaderProps) {
   return (
     <header className="relative z-30 shrink-0 border-b border-mycel-border bg-[color-mix(in_srgb,var(--mycel-surface)_70%,transparent)] backdrop-blur-sm">
-      <div className="flex items-center min-w-0 gap-3 px-3 sm:px-4 h-12">
-        {/* Left slot — mobile-only drawer opener */}
-        {left && <div className="flex items-center gap-2 shrink-0">{left}</div>}
+      {/* items-stretch so the brand column's right border spans the full
+          row height and continues the drawer's border below it. */}
+      <div className="flex items-stretch h-12">
+        {/* Left slot — the brand/drawer column. Rendered FLUSH (no row
+            padding) and self-contained: it brings its own width, padding
+            and right border so it sits directly above the drawer and
+            shares its edge. */}
+        {left}
 
-        {/* Center slot — per-view summary / presence. */}
-        <div className="flex-1 min-w-0 flex items-center gap-2 text-sm text-mycel-text">
-          {center}
-        </div>
-
-        {/* Right slot — per-view actions. flex-1 so search inputs inside
-            can flex-grow toward their max-w caps; justify-end keeps
-            button-only views pinned right. */}
-        {actions && (
-          <div className="flex flex-1 items-center justify-end gap-2 min-w-0">
-            {actions}
+        {/* Per-view region — everything the drawer column doesn't own.
+            Padded so its content aligns above the main pane. */}
+        <div className="flex flex-1 items-center min-w-0 gap-3 px-3 sm:px-4">
+          {/* Center slot — per-view summary / presence. */}
+          <div className="flex-1 min-w-0 flex items-center gap-2 text-sm text-mycel-text">
+            {center}
           </div>
-        )}
+
+          {/* Right slot — per-view actions. flex-1 so search inputs inside
+              can flex-grow toward their max-w caps; justify-end keeps
+              button-only views pinned right. */}
+          {actions && (
+            <div className="flex flex-1 items-center justify-end gap-2 min-w-0">
+              {actions}
+            </div>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -769,6 +769,33 @@ function writeCollapsed(v: boolean) {
   try { localStorage.setItem(SIDEBAR_KEY, String(v)); } catch { /* */ }
 }
 
+/* ── Drawer width (user-resizable) ───────────────────────────────
+   The expanded drawer can be dragged wider so long agent names /
+   channel labels aren't clipped. Width is clamped and persisted; the
+   header's brand column mirrors it so the two stay edge-aligned. The
+   collapsed icon rail (RAIL_WIDTH) and the mobile overlay use fixed
+   widths and ignore this value. */
+const DRAWER_WIDTH_KEY = "mycel-drawer-width";
+const DRAWER_MIN = 176;
+const DRAWER_MAX = 400;
+const DRAWER_DEFAULT = 208;
+const RAIL_WIDTH = 56; // matches the collapsed w-14 rail
+const MOBILE_WIDTH = 208;
+
+function clampDrawerWidth(px: number): number {
+  if (Number.isNaN(px)) return DRAWER_DEFAULT;
+  return Math.min(DRAWER_MAX, Math.max(DRAWER_MIN, Math.round(px)));
+}
+function readDrawerWidth(): number {
+  try {
+    const raw = localStorage.getItem(DRAWER_WIDTH_KEY);
+    return raw ? clampDrawerWidth(parseInt(raw, 10)) : DRAWER_DEFAULT;
+  } catch { return DRAWER_DEFAULT; }
+}
+function writeDrawerWidth(px: number) {
+  try { localStorage.setItem(DRAWER_WIDTH_KEY, String(px)); } catch { /* */ }
+}
+
 /* ── Nav list ────────────────────────────────────────────────── */
 
 function NavList({
@@ -929,6 +956,36 @@ export function Layout() {
     setCollapsed((prev) => { const next = !prev; writeCollapsed(next); return next; });
   }, []);
 
+  // Resizable drawer — drag the right edge to widen the expanded drawer
+  // so long names aren't clipped. Width persists; the header brand column
+  // mirrors it. Tracked on the document so the drag survives the cursor
+  // leaving the thin handle.
+  const [drawerWidth, setDrawerWidth] = useState(readDrawerWidth);
+  const [resizing, setResizing] = useState(false);
+  const startResize = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setResizing(true);
+    const prevCursor = document.body.style.cursor;
+    const prevSelect = document.body.style.userSelect;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    const onMove = (ev: MouseEvent) => {
+      // Drawer's left edge is the viewport edge on desktop, so clientX is
+      // the width directly.
+      setDrawerWidth(clampDrawerWidth(ev.clientX));
+    };
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = prevCursor;
+      document.body.style.userSelect = prevSelect;
+      setResizing(false);
+      setDrawerWidth((w) => { writeDrawerWidth(w); return w; });
+    };
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }, []);
+
   // Host machine name for the /tools nav item — resolved from the daemon
   // (/api/system/info carries os.Hostname()); "Host" until it arrives.
   const [hostLabel, setHostLabel] = useState(HOST_LABEL_FALLBACK);
@@ -951,7 +1008,10 @@ export function Layout() {
   useEffect(() => { setMobileOpen(false); }, [location.pathname]);
 
   const isIconOnly = collapsed && !isMobile;
-  const sidebarWidth = isIconOnly ? "w-14" : "w-48";
+  // Pixel width the drawer (and the header's brand column) occupies in the
+  // current state: fixed rail when collapsed, fixed overlay on mobile,
+  // otherwise the user-resized width.
+  const drawerPx = isIconOnly ? RAIL_WIDTH : isMobile ? MOBILE_WIDTH : drawerWidth;
 
   // The drawer owns its own toggle (top-right of the brand row when
   // expanded, top of the icon rail when collapsed). On mobile the same
@@ -968,8 +1028,13 @@ export function Layout() {
       {/* Full-width top bar — one continuous strip across the viewport.
           The drawer sits BELOW it. */}
       <LayoutHeader
+        isMobile={isMobile}
         showMobileToggle={isMobile && !mobileOpen}
         onOpenMobile={() => setMobileOpen(true)}
+        brandWidth={drawerPx}
+        iconOnly={isIconOnly}
+        resizing={resizing}
+        onToggle={handleDrawerToggle}
       />
       <DegradedBanner />
 
@@ -977,27 +1042,25 @@ export function Layout() {
       {mobileOpen && <div className="fixed inset-0 z-40 bg-mycel-overlay md:hidden" onClick={() => setMobileOpen(false)} />}
 
       {/* Drawer — collapses to an icon rail with a 200ms ease-out width
-          transition; labels fade/slide in via .mycel-fade-slide-in. */}
+          transition; labels fade/slide in via .mycel-fade-slide-in. The
+          brand + toggle now live in the header's brand column (desktop);
+          the drawer starts straight at the nav. Width is driven inline so
+          it can be dragged; the transition is suppressed mid-drag. */}
       <nav
-        className={`fixed inset-y-0 left-0 z-50 ${sidebarWidth} shrink-0 border-r border-mycel-border bg-mycel-surface shadow-mycel flex flex-col transition-all duration-200 ease-out md:relative md:inset-y-auto md:translate-x-0 ${
-          isMobile ? (mobileOpen ? "translate-x-0 w-48" : "-translate-x-full") : ""
-        }`}
-        style={{ scrollbarWidth: "thin", scrollbarColor: "var(--mycel-scrollbar-thumb) transparent" }}
+        className={`fixed inset-y-0 left-0 z-50 shrink-0 border-r border-mycel-border bg-mycel-surface shadow-mycel flex flex-col md:relative md:inset-y-auto md:translate-x-0 ${
+          resizing ? "" : "transition-all duration-200 ease-out"
+        } ${isMobile ? (mobileOpen ? "translate-x-0" : "-translate-x-full") : ""}`}
+        style={{
+          width: drawerPx,
+          scrollbarWidth: "thin",
+          scrollbarColor: "var(--mycel-scrollbar-thumb) transparent",
+        }}
       >
-        {/* Brand row — first row of the drawer. Mark + wordmark sit on
-            the nav items' icon grid (border-l-2 + pl-4); the drawer
-            toggle rides top-right of the same row. Collapsed rail:
-            mark on top, explicit toggle below it (the mark itself is
-            NOT the toggle — it stays the home link). */}
-        {isIconOnly ? (
-          <div className="shrink-0 flex flex-col items-center gap-1 pt-3 pb-1">
-            <NavLink to="/" aria-label="mycel home" className="flex items-center justify-center h-7 text-mycel-text">
-              <BrandMark />
-            </NavLink>
-            <SidebarToggle collapsed onToggle={handleDrawerToggle} />
-          </div>
-        ) : (
-          <div className="shrink-0 flex items-center h-12 border-l-2 border-transparent pl-4 pr-2">
+        {/* Mobile-only brand row — the overlay drawer keeps its own brand
+            since the mobile header shows only the opener. On desktop the
+            brand lives in the header's brand column. */}
+        {isMobile && (
+          <div className="shrink-0 flex items-center h-12 pl-4 pr-2 border-b border-mycel-border">
             <NavLink
               to="/"
               aria-label="mycel home"
@@ -1006,9 +1069,7 @@ export function Layout() {
               <span className="shrink-0 flex items-center justify-center w-4">
                 <BrandMark size={18} />
               </span>
-              <span className="text-sm font-semibold tracking-tight truncate mycel-fade-slide-in">
-                mycel
-              </span>
+              <span className="text-sm font-semibold tracking-tight truncate">mycel</span>
             </NavLink>
             <span className="ml-auto">
               <SidebarToggle collapsed={false} onToggle={handleDrawerToggle} />
@@ -1030,6 +1091,28 @@ export function Layout() {
         {/* Footer — Theme toggle, Settings and About pinned at the
             bottom behind a top divider; icon-only in the rail. */}
         <DrawerFooter iconOnly={isIconOnly} />
+
+        {/* Resize handle — drag the right edge to widen the expanded
+            drawer. Desktop + expanded only; the rail and mobile overlay
+            use fixed widths. A wider invisible hit area sits over a thin
+            hairline that lights up on hover / during a drag. */}
+        {!isIconOnly && !isMobile && (
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize sidebar"
+            onMouseDown={startResize}
+            onDoubleClick={() => { setDrawerWidth(DRAWER_DEFAULT); writeDrawerWidth(DRAWER_DEFAULT); }}
+            title="Drag to resize · double-click to reset"
+            className="group absolute inset-y-0 right-0 w-2 translate-x-1/2 cursor-col-resize z-10"
+          >
+            <span
+              className={`absolute inset-y-0 right-1 w-px transition-colors ${
+                resizing ? "bg-mycel-accent" : "bg-transparent group-hover:bg-mycel-accent/60"
+              }`}
+            />
+          </div>
+        )}
       </nav>
 
       <main className="flex-1 flex flex-col overflow-hidden bg-mycel-bg">
@@ -1105,31 +1188,100 @@ function DrawerFooter({ iconOnly }: { iconOnly: boolean }) {
 }
 
 /* ── LayoutHeader ───────────────────────────────────────────────
-   The full-width top bar. Brand + drawer toggle moved INTO the drawer,
-   so the header carries only per-view content (summary/search/actions
-   via HeaderSlotContext) — plus, on <md when the overlay drawer is
-   closed, a small opener at the far left so the drawer stays
-   reachable. Views that render their own top band (AgentDetail's HUD
-   bar) set `hidden` — the bar stays but carries no per-view content. */
+   The full-width top bar. Its left region is the brand / drawer column:
+   mycel mark + wordmark + drawer toggle, sized to the drawer's current
+   width so the two share an edge and collapse together. The rest of the
+   header is per-view content (summary/search/actions via
+   HeaderSlotContext) contributed by whichever page is mounted. On <md the
+   brand column becomes a bare opener while the overlay drawer is closed.
+   Views that render their own top band set `hidden`. */
 function LayoutHeader({
+  isMobile,
   showMobileToggle,
   onOpenMobile,
+  brandWidth,
+  iconOnly,
+  resizing,
+  onToggle,
 }: {
+  isMobile: boolean;
   showMobileToggle: boolean;
   onOpenMobile: () => void;
+  brandWidth: number;
+  iconOnly: boolean;
+  resizing: boolean;
+  onToggle: () => void;
 }) {
   const { slot } = useHeaderSlotContext();
   return (
     <Header
       left={
-        showMobileToggle ? (
-          <span className="md:hidden">
-            <SidebarToggle collapsed onToggle={onOpenMobile} />
-          </span>
-        ) : undefined
+        isMobile ? (
+          showMobileToggle ? (
+            <div className="flex items-center h-12 pl-2 pr-1 md:hidden">
+              <SidebarToggle collapsed onToggle={onOpenMobile} />
+            </div>
+          ) : undefined
+        ) : (
+          <BrandColumn
+            widthPx={brandWidth}
+            iconOnly={iconOnly}
+            resizing={resizing}
+            onToggle={onToggle}
+          />
+        )
       }
       center={slot.hidden ? undefined : slot.title}
       actions={slot.hidden ? undefined : slot.actions}
     />
+  );
+}
+
+/* ── BrandColumn ─────────────────────────────────────────────────
+   The header's left region, aligned above the drawer. Expanded: mycel
+   mark + wordmark (home link) with the drawer toggle pinned right.
+   Collapsed rail: just the toggle, centered — the wordmark goes away and
+   nothing spills past the rail edge. Width mirrors the drawer and only
+   animates when the user isn't actively dragging the resize handle. */
+function BrandColumn({
+  widthPx,
+  iconOnly,
+  resizing,
+  onToggle,
+}: {
+  widthPx: number;
+  iconOnly: boolean;
+  resizing: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <div
+      className={`flex items-center h-12 shrink-0 border-r border-mycel-border overflow-hidden ${
+        resizing ? "" : "transition-all duration-200 ease-out"
+      }`}
+      style={{ width: widthPx }}
+    >
+      {iconOnly ? (
+        <div className="flex items-center justify-center w-full">
+          <SidebarToggle collapsed onToggle={onToggle} />
+        </div>
+      ) : (
+        <>
+          <NavLink
+            to="/"
+            aria-label="mycel home"
+            className="flex items-center gap-2.5 select-none text-mycel-text min-w-0 pl-4"
+          >
+            <span className="shrink-0 flex items-center justify-center w-4">
+              <BrandMark size={18} />
+            </span>
+            <span className="text-sm font-semibold tracking-tight truncate">mycel</span>
+          </NavLink>
+          <span className="ml-auto pr-2">
+            <SidebarToggle collapsed={false} onToggle={onToggle} />
+          </span>
+        </>
+      )}
+    </div>
   );
 }

--- a/web/src/components/__tests__/Layout.test.tsx
+++ b/web/src/components/__tests__/Layout.test.tsx
@@ -57,37 +57,47 @@ describe("prettifyHostname", () => {
 });
 
 describe("Layout chrome", () => {
-  it("puts the brand and the drawer toggle inside the drawer, not the header", async () => {
+  it("puts the brand and the drawer toggle in the header, above the drawer", async () => {
     mockApi("test-host");
     renderLayout();
 
-    const nav = screen.getByRole("navigation");
-    // Brand row is the drawer's first row.
-    expect(within(nav).getByText("mycel")).toBeInTheDocument();
-    // Explicit toggle button lives in the drawer.
-    expect(within(nav).getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
-
-    // Header carries no brand, no toggle, no utility menu.
+    // Brand + toggle now live in the header's brand column, sized to the
+    // drawer so the two share an edge.
     const header = screen.getByRole("banner");
-    expect(within(header).queryByText("mycel")).not.toBeInTheDocument();
-    expect(within(header).queryByRole("button", { name: /sidebar/i })).not.toBeInTheDocument();
-    expect(within(header).queryByRole("button", { name: "Utilities" })).not.toBeInTheDocument();
+    expect(within(header).getByText("mycel")).toBeInTheDocument();
+    expect(within(header).getByRole("button", { name: "Collapse sidebar" })).toBeInTheDocument();
+
+    // The desktop drawer no longer carries its own brand row.
+    const nav = screen.getByRole("navigation");
+    expect(within(nav).queryByText("mycel")).not.toBeInTheDocument();
 
     await waitFor(() => expect(screen.getByText("test-host")).toBeInTheDocument());
   });
 
-  it("collapses to an icon rail via the drawer toggle; toggle stays available", async () => {
+  it("collapses to an icon rail via the header toggle; the wordmark hides", async () => {
     mockApi("test-host");
     renderLayout();
 
-    const nav = screen.getByRole("navigation");
-    within(nav).getByRole("button", { name: "Collapse sidebar" }).click();
+    const header = screen.getByRole("banner");
+    within(header).getByRole("button", { name: "Collapse sidebar" }).click();
     await waitFor(() =>
-      expect(within(nav).getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument(),
+      expect(within(header).getByRole("button", { name: "Expand sidebar" })).toBeInTheDocument(),
     );
-    // Wordmark hides in the rail; the mark (home link) stays.
-    expect(within(nav).queryByText("mycel")).not.toBeInTheDocument();
-    expect(within(nav).getByRole("link", { name: "mycel home" })).toBeInTheDocument();
+    // Collapsed rail: the mycel wordmark goes away, leaving just the toggle.
+    expect(within(header).queryByText("mycel")).not.toBeInTheDocument();
+  });
+
+  it("exposes a drawer resize handle when expanded, hidden when collapsed", async () => {
+    mockApi("test-host");
+    renderLayout();
+
+    expect(screen.getByRole("separator", { name: "Resize sidebar" })).toBeInTheDocument();
+
+    const header = screen.getByRole("banner");
+    within(header).getByRole("button", { name: "Collapse sidebar" }).click();
+    await waitFor(() =>
+      expect(screen.queryByRole("separator", { name: "Resize sidebar" })).not.toBeInTheDocument(),
+    );
   });
 
   it("renders the flattened nav: Marketplace + Insights, no group captions", async () => {

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1111,12 +1111,6 @@ export function AgentDetail() {
   const location = useLocation();
   const agentsUrl = "/agents";
 
-  // AgentDetail renders its own comprehensive HUD bar (back link + agent
-  // icon + name + state + task + tabs). `hidden` keeps the full-width
-  // top bar as bare chrome (drawer toggle only) so no per-view slot
-  // content competes with our own header band.
-  useHeaderSlot({ hidden: true });
-
   // Derive active tab from URL sub-path: /agents/<name>/<tab>
   // Defaults to "attach" when no sub-path is present.
   const tabFromPath = useMemo<Tab>(() => {
@@ -1199,6 +1193,142 @@ export function AgentDetail() {
     };
   }, [navigate, selectTab, agentsUrl]);
 
+  // The comprehensive HUD (back link + agent icon + name + state + task)
+  // now lives in the shared header's center slot; the tabs live in the
+  // right-aligned actions slot. Fresh JSX each render keeps the state
+  // chip and active tab live — that's the intended HeaderSlot usage.
+  const hudLastSeen =
+    agent && (agent.updated_at ?? agent.started_at ?? agent.created_at);
+  useHeaderSlot(
+    agent
+      ? {
+          // ── center slot: identity + status ──
+          title: (
+            <div className="flex items-center gap-3 min-w-0">
+              {/* ── Identity ── */}
+              <Link
+                to={agentsUrl}
+                className="text-mycel-muted hover:text-mycel-text transition-colors shrink-0"
+                title="Back to agents"
+                aria-label="Back to agents"
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M9 3l-4 4 4 4" />
+                </svg>
+              </Link>
+              <AgentIcon state={agent.state} size={28} tool={agent.tool} />
+              <span className="text-lg font-semibold text-mycel-text tracking-tight shrink-0">
+                {agent.name}
+              </span>
+              {agent.runtime_backend && (
+                <span className="shrink-0 text-mycel-muted" title={`Runtime: ${agent.runtime_backend}`}>
+                  {agent.runtime_backend === "docker" ? (
+                    <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+                      <rect x="1" y="4" width="12" height="8" rx="1" />
+                      <path d="M4 4V2h6v2" />
+                      <path d="M5 7h4M5 9.5h4" opacity="0.5" />
+                    </svg>
+                  ) : (
+                    <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
+                      <rect x="1.5" y="1.5" width="11" height="8" rx="1.5" />
+                      <path d="M7 9.5v2.5M4 12h6" />
+                    </svg>
+                  )}
+                </span>
+              )}
+
+              {/* Hairline separator — identity ↔ status */}
+              <span className="hidden sm:block h-4 w-px bg-mycel-border shrink-0" aria-hidden />
+
+              {/* ── Status ── state chip + task line */}
+              <span
+                className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[10px] font-medium tracking-wide uppercase ring-1 ring-inset ring-mycel-border shrink-0 ${
+                  agent.state === "working" ? "bg-mycel-success-subtle text-mycel-success" :
+                  agent.state === "idle" ? "bg-mycel-warning-subtle text-mycel-warning" :
+                  agent.state === "stuck" ? "bg-mycel-warning-subtle text-mycel-warning" :
+                  agent.state === "error" ? "bg-mycel-error-subtle text-mycel-error" :
+                  agent.state === "starting" ? "bg-mycel-success-subtle text-mycel-success" :
+                  agent.state === "done" ? "bg-mycel-info-subtle text-mycel-info" :
+                  "bg-mycel-surface-hover text-mycel-text-2"
+                }`}
+                title={agent.state}
+              >
+                <span
+                  className={`w-1.5 h-1.5 rounded-full ${
+                    agent.state === "working" ? "bg-mycel-success animate-pulse" :
+                    agent.state === "starting" ? "bg-mycel-success animate-pulse" :
+                    agent.state === "stuck" ? "bg-mycel-warning animate-pulse" :
+                    agent.state === "error" ? "bg-mycel-error" :
+                    "bg-current opacity-60"
+                  }`}
+                  aria-hidden
+                />
+                {agent.state}
+              </span>
+
+              <LifecycleControls agent={agent} onAction={() => void refresh()} />
+
+              {agent.task && (
+                <span
+                  className="text-xs text-mycel-text-2 truncate min-w-0 flex-shrink"
+                  title={agent.task}
+                >
+                  {agent.task}
+                </span>
+              )}
+
+              {hudLastSeen && (
+                <span
+                  className="text-xs text-mycel-muted tabular-nums shrink-0"
+                  title={formatTime(hudLastSeen)}
+                >
+                  {formatRelative(hudLastSeen)}
+                </span>
+              )}
+            </div>
+          ),
+          // ── actions slot: tabs ──
+          actions: (
+            <div className="flex items-center gap-0.5">
+              {TABS.map((tab) => {
+                const isActive = activeTab === tab.key;
+                return (
+                  <button
+                    key={tab.key}
+                    onClick={() => selectTab(tab.key)}
+                    className={`relative px-2.5 py-1.5 text-[11px] font-medium tracking-wide uppercase transition-colors shrink-0 ${
+                      isActive
+                        ? "text-mycel-accent"
+                        : "text-mycel-muted hover:text-mycel-text"
+                    }`}
+                  >
+                    <span className="inline-flex items-center gap-1.5">
+                      {tab.label}
+                      <span
+                        className={`inline-flex items-center justify-center min-w-[16px] h-[15px] rounded px-1 text-[9px] leading-none font-mono transition-colors ${
+                          isActive
+                            ? "bg-mycel-accent-subtle text-mycel-accent"
+                            : "bg-mycel-surface-hover text-mycel-muted"
+                        }`}
+                        aria-hidden
+                      >
+                        {tab.shortcut}
+                      </span>
+                    </span>
+                    {/* Active indicator — clean underline instead of the
+                        old glow-bar; matches the surrounding restraint. */}
+                    {isActive && (
+                      <span className="absolute -bottom-px left-2 right-2 h-[2px] bg-mycel-accent rounded-full" />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          ),
+        }
+      : { hidden: true },
+  );
+
   /* ─── Loading / Error ─── */
 
   if (loading && !agent) {
@@ -1227,141 +1357,10 @@ export function AgentDetail() {
   }
   if (!agent) return null;
 
-  const lastSeen =
-    agent.updated_at ?? agent.started_at ?? agent.created_at;
-
   /* ─── Render ─── */
 
   return (
     <div className="flex flex-col h-full">
-      {/* ═══ HEADER — HUD status bar ═══
-          Three-section rhythm: identity → status → tabs. Hairline
-          separators between sections give the row explicit structure
-          instead of the previous run-on gap-2.5 line. */}
-      <header className="shrink-0 border-b border-mycel-border bg-mycel-surface backdrop-blur-sm">
-        <div className="flex items-center gap-3 min-w-0 px-4 sm:px-6 h-[48px]">
-          {/* ── Identity ── */}
-          <Link
-            to={agentsUrl}
-            className="text-mycel-muted hover:text-mycel-text transition-colors shrink-0"
-            title="Back to agents"
-            aria-label="Back to agents"
-          >
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M9 3l-4 4 4 4" />
-            </svg>
-          </Link>
-          <AgentIcon state={agent.state} size={28} tool={agent.tool} />
-          <span className="text-lg font-semibold text-mycel-text tracking-tight shrink-0">
-            {agent.name}
-          </span>
-          {agent.runtime_backend && (
-            <span className="shrink-0 text-mycel-muted" title={`Runtime: ${agent.runtime_backend}`}>
-              {agent.runtime_backend === "docker" ? (
-                <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="1" y="4" width="12" height="8" rx="1" />
-                  <path d="M4 4V2h6v2" />
-                  <path d="M5 7h4M5 9.5h4" opacity="0.5" />
-                </svg>
-              ) : (
-                <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
-                  <rect x="1.5" y="1.5" width="11" height="8" rx="1.5" />
-                  <path d="M7 9.5v2.5M4 12h6" />
-                </svg>
-              )}
-            </span>
-          )}
-
-          {/* Hairline separator — identity ↔ status */}
-          <span className="hidden sm:block h-4 w-px bg-mycel-border shrink-0" aria-hidden />
-
-          {/* ── Status ── state chip + task line */}
-          <span
-            className={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[10px] font-medium tracking-wide uppercase ring-1 ring-inset ring-mycel-border shrink-0 ${
-              agent.state === "working" ? "bg-mycel-success-subtle text-mycel-success" :
-              agent.state === "idle" ? "bg-mycel-warning-subtle text-mycel-warning" :
-              agent.state === "stuck" ? "bg-mycel-warning-subtle text-mycel-warning" :
-              agent.state === "error" ? "bg-mycel-error-subtle text-mycel-error" :
-              agent.state === "starting" ? "bg-mycel-success-subtle text-mycel-success" :
-              agent.state === "done" ? "bg-mycel-info-subtle text-mycel-info" :
-              "bg-mycel-surface-hover text-mycel-text-2"
-            }`}
-            title={agent.state}
-          >
-            <span
-              className={`w-1.5 h-1.5 rounded-full ${
-                agent.state === "working" ? "bg-mycel-success animate-pulse" :
-                agent.state === "starting" ? "bg-mycel-success animate-pulse" :
-                agent.state === "stuck" ? "bg-mycel-warning animate-pulse" :
-                agent.state === "error" ? "bg-mycel-error" :
-                "bg-current opacity-60"
-              }`}
-              aria-hidden
-            />
-            {agent.state}
-          </span>
-
-          <LifecycleControls agent={agent} onAction={() => void refresh()} />
-
-          {agent.task && (
-            <span
-              className="text-xs text-mycel-text-2 truncate min-w-0 flex-shrink"
-              title={agent.task}
-            >
-              {agent.task}
-            </span>
-          )}
-
-          {lastSeen && (
-            <span
-              className="text-xs text-mycel-muted tabular-nums shrink-0"
-              title={formatTime(lastSeen)}
-            >
-              {formatRelative(lastSeen)}
-            </span>
-          )}
-
-          {/* Hairline separator — status ↔ tabs. ml-auto pushes tabs to
-              the right edge. */}
-          <span className="ml-auto hidden sm:block h-4 w-px bg-mycel-border shrink-0" aria-hidden />
-
-          {/* ── Tabs ── */}
-          {TABS.map((tab) => {
-            const isActive = activeTab === tab.key;
-            return (
-              <button
-                key={tab.key}
-                onClick={() => selectTab(tab.key)}
-                className={`relative px-2.5 py-1.5 text-[11px] font-medium tracking-wide uppercase transition-colors shrink-0 ${
-                  isActive
-                    ? "text-mycel-accent"
-                    : "text-mycel-muted hover:text-mycel-text"
-                }`}
-              >
-                <span className="inline-flex items-center gap-1.5">
-                  {tab.label}
-                  <span
-                    className={`inline-flex items-center justify-center min-w-[16px] h-[15px] rounded px-1 text-[9px] leading-none font-mono transition-colors ${
-                      isActive
-                        ? "bg-mycel-accent-subtle text-mycel-accent"
-                        : "bg-mycel-surface-hover text-mycel-muted"
-                    }`}
-                    aria-hidden
-                  >
-                    {tab.shortcut}
-                  </span>
-                </span>
-                {/* Active indicator — clean underline instead of the
-                    old glow-bar; matches the surrounding restraint. */}
-                {isActive && (
-                  <span className="absolute -bottom-px left-2 right-2 h-[2px] bg-mycel-accent rounded-full" />
-                )}
-              </button>
-            );
-          })}
-        </div>
-      </header>
-
       {/* ═══ TAB CONTENT ═══ */}
       <div className="flex-1 min-h-0 flex flex-col">
         {activeTab === "live" && (

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -155,6 +155,19 @@ describe("Agents", () => {
   });
 });
 
+/** Renders the header slot the way Layout's full-width bar does, so
+ *  content a view contributes via useHeaderSlot (AgentDetail's identity,
+ *  lifecycle controls and tabs) is present in the DOM under test. */
+function HeaderSlotHost() {
+  const { slot } = useHeaderSlotContext();
+  return (
+    <div data-testid="header-host">
+      {slot.title}
+      {slot.actions}
+    </div>
+  );
+}
+
 describe("AgentDetail tab navigation", () => {
   function LocationProbe() {
     const location = useLocation();
@@ -181,11 +194,14 @@ describe("AgentDetail tab navigation", () => {
 
     render(
       <MemoryRouter initialEntries={["/agents/bot-1"]}>
-        <Routes>
-          <Route path="agents/:name" element={<AgentDetail />} />
-          <Route path="agents/:name/*" element={<AgentDetail />} />
-        </Routes>
-        <LocationProbe />
+        <HeaderSlotProvider>
+          <HeaderSlotHost />
+          <Routes>
+            <Route path="agents/:name" element={<AgentDetail />} />
+            <Route path="agents/:name/*" element={<AgentDetail />} />
+          </Routes>
+          <LocationProbe />
+        </HeaderSlotProvider>
       </MemoryRouter>,
     );
 
@@ -263,10 +279,13 @@ describe("AgentDetail lifecycle controls", () => {
 
     render(
       <MemoryRouter initialEntries={["/agents/bot-1"]}>
-        <Routes>
-          <Route path="agents/:name" element={<AgentDetail />} />
-          <Route path="agents/:name/*" element={<AgentDetail />} />
-        </Routes>
+        <HeaderSlotProvider>
+          <HeaderSlotHost />
+          <Routes>
+            <Route path="agents/:name" element={<AgentDetail />} />
+            <Route path="agents/:name/*" element={<AgentDetail />} />
+          </Routes>
+        </HeaderSlotProvider>
       </MemoryRouter>,
     );
 


### PR DESCRIPTION
## Summary
Addresses three chrome issues Puneet found testing 0.3.12-dev, verified with Playwright screenshots in the expanded / collapsed / resized states.

- **Brand into the header.** The mycel mark + wordmark + drawer toggle leave the drawer's first row and become the header's left *brand column*, sized to the drawer so the two share an edge and collapse together. Collapsed rail shows just the toggle — wordmark gone, nothing spilling past the edge. This is the "header has a drawer part that resizes with drawer state, the rest is per-page" model.
- **Resizable drawer.** A hairline handle on the drawer's right edge drags the width (clamped 176–400px, persisted to localStorage; double-click resets to default). The header brand column mirrors the width so the two stay aligned — animates on collapse, instant during a drag. Fixes long agent / channel names getting clipped.
- **Single header everywhere.** AgentDetail stops rendering its own HUD band and feeds the shared header via `useHeaderSlot` — identity + state + lifecycle controls in the center slot, tabs in the actions slot. Every page now drives one header.

## Testing
- Playwright: verified expanded (brand aligned above drawer, toggle at column edge), collapsed (wordmark hidden, toggle centered in rail), drag-resize (drawer + header column widen in lockstep, persists), and AgentDetail (identity + tabs in the shared header).
- `bun run test` — 157 passed (updated Layout + views tests for the new architecture; added a resize-handle test).
- `bun run lint` clean; `bun run build` clean.

Closes #3316

🤖 Generated with [Claude Code](https://claude.com/claude-code)