### PR TITLE
feat(web): move Tools / Code / Secrets toolbars into the shared header

### DIFF
--- a/web/src/views/Code.tsx
+++ b/web/src/views/Code.tsx
@@ -21,6 +21,7 @@ import Editor, { DiffEditor } from "@monaco-editor/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { api } from "../api/client";
+import { useHeaderSlot } from "../context/HeaderSlotContext";
 import { useTheme } from "../context/ThemeContext";
 import { languageFromPath } from "../utils/lang";
 import { MONO } from "../utils/typography";
@@ -405,14 +406,11 @@ export function Code() {
   const rootEntries = treeCache[rootKey] ?? [];
   const language = languageFromPath(path);
 
-  return (
-    <div className="flex flex-col h-full" style={{ fontFamily: MONO }}>
-      {/* Header */}
-      <header className="shrink-0 border-b border-mycel-border px-6 h-[42px] flex items-center gap-3">
-        <span className="text-[11px] font-bold text-mycel-text uppercase tracking-[0.2em]">
-          Code
-        </span>
-
+  // Contribute the CODE band (repo selector + breadcrumb, and the
+  // show-hidden / edit-in-vscode controls) to the single shared Header.
+  useHeaderSlot({
+    title: (
+      <>
         {/* Worktree dropdown */}
         <select
           value={worktree}
@@ -476,7 +474,10 @@ export function Code() {
             </span>
           ))}
         </div>
-
+      </>
+    ),
+    actions: (
+      <>
         {/* Download patch (diff mode, path set, worktree != main) */}
         {worktree !== "main" && viewMode === "diff" && path && (
           <button
@@ -511,7 +512,7 @@ export function Code() {
               else next.set("mode", "vscode");
               setSearchParams(next);
             }}
-            className={`text-[10px] uppercase tracking-wider transition-colors border px-2 py-1 rounded ${
+            className={`h-8 inline-flex items-center text-[10px] uppercase tracking-wider transition-colors border px-2 rounded ${
               vscodeMode
                 ? "bg-mycel-accent-subtle text-mycel-accent border-mycel-accent"
                 : "text-mycel-muted border-mycel-border hover:text-mycel-text hover:border-mycel-muted"
@@ -521,8 +522,12 @@ export function Code() {
             {vscodeMode ? "Exit VS Code" : "Edit in VS Code"}
           </button>
         )}
-      </header>
+      </>
+    ),
+  });
 
+  return (
+    <div className="flex flex-col h-full" style={{ fontFamily: MONO }}>
       {/* VS Code iframe mode — replaces body when toggled on */}
       {vscodeMode && codeServer.running && (
         <div className="flex-1 min-h-0 flex flex-col">

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -349,12 +349,17 @@ export function Secrets() {
   } = usePolling(fetcher, 30000);
   const [addOpen, setAddOpen] = useState(false);
 
-  // Header slot — count summary center-left, primary CTA right,
-  // following the Agents pattern.
+  // Header slot — count + encryption note center-left, primary CTA
+  // right, following the Agents pattern. The encryption note moved up
+  // here from the page body so the header carries the full context.
   useHeaderSlot({
     title: secrets ? (
-      <span className="text-xs text-mycel-text-2 tabular-nums truncate">
-        {String(secrets.length)} secrets
+      <span className="flex items-center gap-2 min-w-0 text-xs text-mycel-text-2">
+        <span className="tabular-nums shrink-0">{String(secrets.length)} secrets</span>
+        <span className="hidden sm:inline-flex items-center gap-2 text-mycel-muted min-w-0">
+          <span className="h-3 w-px bg-mycel-border shrink-0" aria-hidden />
+          <span className="truncate">AES-256-GCM encrypted · values never exposed via API</span>
+        </span>
       </span>
     ) : undefined,
     actions: (
@@ -410,12 +415,8 @@ export function Secrets() {
 
   return (
     <div className="p-6 space-y-5">
-      {/* Page note (title + count live in the top-bar chip) */}
-      <p className="text-xs text-mycel-muted">
-        AES-256-GCM encrypted &middot; values never exposed via API
-      </p>
-
-      {/* Add form — opened from the + Add Secret button in the top bar */}
+      {/* Add form — opened from the + Add Secret button in the top bar.
+          Title, count and the encryption note all live in the header. */}
       <AddSecretForm
         open={addOpen}
         onClose={() => setAddOpen(false)}

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -9,6 +9,7 @@ import { ProvidersTable } from "../components/ProvidersTable";
 import { CopyButton } from "../components/CopyButton";
 import { ToastContainer, useToast } from "../components/Toast";
 import type { ToastLevel } from "../components/Toast";
+import { useHeaderSlot } from "../context/HeaderSlotContext";
 
 const STATUS_CONFIG: Record<string, { dot: string; label: string; textColor: string }> = {
   connected:     { dot: "bg-mycel-success", label: "Connected",     textColor: "text-mycel-success" },
@@ -295,6 +296,63 @@ export function Tools() {
 
   const providerList = providers ?? [];
 
+  const totalCount = providerList.length + allTools.length;
+  const matchCount = providerList.filter((p) => !searchLower || p.name.toLowerCase().includes(searchLower)).length + filteredCli.length;
+
+  useHeaderSlot({
+    title: (
+      <span className="text-xs text-mycel-text-2 tabular-nums truncate">
+        {searchLower
+          ? `${matchCount} of ${totalCount} tools`
+          : <>{providerList.length} Providers &middot; {cliTools.length} CLI{checkedTools && " · checked"}</>
+        }
+      </span>
+    ),
+    actions: (
+      <div className="flex items-center gap-2">
+        {/* Search with magnifying glass icon */}
+        <div className="relative">
+          <svg
+            className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-mycel-muted pointer-events-none"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <circle cx="11" cy="11" r="8" />
+            <path strokeLinecap="round" d="M21 21l-4.35-4.35" />
+          </svg>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search tools..."
+            className="w-40 sm:w-52 pl-7 pr-7 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch("")}
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 text-mycel-muted hover:text-mycel-text text-sm leading-none px-1"
+              aria-label="Clear search"
+            >
+              &times;
+            </button>
+          )}
+        </div>
+        <button type="button" onClick={() => void handleCheck()} disabled={checking}
+          className="inline-flex items-center gap-1.5 h-8 px-3 text-sm rounded-md bg-mycel-surface border border-mycel-border text-mycel-text-2 hover:text-mycel-text hover:bg-mycel-surface-hover transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-mycel-accent">
+          {checking ? <Spinner /> : null}
+          {checking ? "Checking..." : "Health Check"}
+        </button>
+        <button type="button" onClick={() => setShowAddForm(!showAddForm)}
+          className="inline-flex items-center h-8 px-3 text-sm font-medium rounded-md bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent">
+          + CLI Tool
+        </button>
+      </div>
+    ),
+  });
+
   if (loading && !tools && providersLoading && !providers) {
     return (
       <div className="p-6 space-y-6">
@@ -309,9 +367,6 @@ export function Tools() {
   if (error && !tools) {
     return <div className="p-6"><EmptyState icon="!" title="Failed to load tools" description={error} actionLabel="Retry" onAction={refresh} /></div>;
   }
-
-  const totalCount = providerList.length + allTools.length;
-  const matchCount = providerList.filter((p) => !searchLower || p.name.toLowerCase().includes(searchLower)).length + filteredCli.length;
 
   const handleToggle = async (tool: Tool) => {
     const wasDisabled = tool.status === "disabled" || tool.status === "not_installed";
@@ -363,56 +418,6 @@ export function Tools() {
 
   return (
     <div className="p-6 space-y-8">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-xs text-mycel-muted hidden sm:block">
-          {searchLower
-            ? `${matchCount} of ${totalCount} tools`
-            : <>{providerList.length} Providers &middot; {cliTools.length} CLI{checkedTools && " \u00b7 checked"}</>
-          }
-        </p>
-        <div className="flex items-center gap-2">
-          {/* Search with magnifying glass icon */}
-          <div className="relative">
-            <svg
-              className="absolute left-2 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-mycel-muted pointer-events-none"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={2}
-            >
-              <circle cx="11" cy="11" r="8" />
-              <path strokeLinecap="round" d="M21 21l-4.35-4.35" />
-            </svg>
-            <input
-              type="text"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder="Search tools..."
-              className="w-40 sm:w-52 pl-7 pr-7 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
-            />
-            {search && (
-              <button
-                type="button"
-                onClick={() => setSearch("")}
-                className="absolute right-1.5 top-1/2 -translate-y-1/2 text-mycel-muted hover:text-mycel-text text-sm leading-none px-1"
-                aria-label="Clear search"
-              >
-                &times;
-              </button>
-            )}
-          </div>
-          <button type="button" onClick={() => void handleCheck()} disabled={checking}
-            className="inline-flex items-center gap-1.5 h-9 px-3 text-sm rounded-md bg-mycel-surface border border-mycel-border text-mycel-text-2 hover:text-mycel-text hover:bg-mycel-surface-hover transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-mycel-accent">
-            {checking ? <Spinner /> : null}
-            {checking ? "Checking..." : "Health Check"}
-          </button>
-          <button type="button" onClick={() => setShowAddForm(!showAddForm)}
-            className="inline-flex items-center h-9 px-3 text-sm font-medium rounded-md bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent">
-            + CLI Tool
-          </button>
-        </div>
-      </div>
-
       <AnimatePresence>
         {showAddForm && <AddCLIToolForm onClose={() => setShowAddForm(false)} onAdded={() => { setCheckedTools(null); refresh(); }} onToast={addToast} />}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
Continues the single-header work (#3317). Three more pages stop rendering their own toolbar bands and feed the shared header via `useHeaderSlot`:

- **Tools** — providers/CLI summary → header center; Search + Health Check + CLI Tool → header actions.
- **Code** — repo selector + view-mode toggle + `/` breadcrumb → center; Download patch + Show hidden + Edit in VS Code → actions. Drops the redundant `CODE` wordmark (the drawer already names the section).
- **Secrets** — the `AES-256-GCM encrypted · values never exposed via API` note joins the count in the header; the body caption is removed.

Buttons normalized to the header's `h-8`. All page behavior unchanged.

## Testing
- Playwright screenshots of all three pages: toolbars render in the shared header, bodies start clean.
- `bun run test` 157 passed, `bun run lint` clean, `bun run build` clean.

Closes #3318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moved page headers into a shared layout for Code and Tools, keeping titles, counts, search, breadcrumbs, and action buttons in a consistent top bar.
  * Updated the Secrets header to show the encryption note alongside the secret count on larger screens.

* **Bug Fixes**
  * Improved header/button layout and spacing for the “Edit in VS Code” action.
  * Removed a redundant in-page encryption note from Secrets to reduce duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->