### PR TITLE
feat(web): Insights single-page dashboard with real cost data

### DIFF
--- a/pkg/stats/query.go
+++ b/pkg/stats/query.go
@@ -146,49 +146,6 @@ func (s *Store) queryAgent(ctx context.Context, f AgentFilter, tr TimeRange) ([]
 	return result, rows.Err()
 }
 
-// QueryAgentTokens returns token usage metrics for agents.
-func (s *Store) QueryAgentTokens(ctx context.Context, f AgentFilter, tr TimeRange) ([]TokenMetric, error) {
-	query := `SELECT time_bucket($1::interval, time) AS bucket,
-		agent_name, MAX(model),
-		SUM(input_tokens), SUM(output_tokens), SUM(cache_read), SUM(cache_create), SUM(cost_usd)
-	FROM token_metrics
-	WHERE time >= $2 AND time < $3`
-
-	args := []any{tr.PGInterval(), tr.From, tr.To}
-
-	if len(f.Agent) > 0 {
-		ph := make([]string, len(f.Agent))
-		for i, a := range f.Agent {
-			args = append(args, a)
-			ph[i] = fmt.Sprintf("$%d", len(args))
-		}
-		query += ` AND agent_name IN (` + strings.Join(ph, ",") + `)`
-	}
-
-	query += ` GROUP BY bucket, agent_name ORDER BY bucket`
-
-	rows, err := s.db.QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, fmt.Errorf("query token metrics: %w", err)
-	}
-	defer rows.Close() //nolint:errcheck
-
-	var result []TokenMetric
-	for rows.Next() {
-		var m TokenMetric
-		if err := rows.Scan(&m.Time, &m.AgentName, &m.Model, &m.InputTokens, &m.OutputTokens, &m.CacheRead, &m.CacheCreate, &m.CostUSD); err != nil {
-			return nil, fmt.Errorf("scan token metric: %w", err)
-		}
-		result = append(result, m)
-	}
-	return result, rows.Err()
-}
-
-// QueryAgentCost returns cost metrics for agents.
-func (s *Store) QueryAgentCost(ctx context.Context, f AgentFilter, tr TimeRange) ([]TokenMetric, error) {
-	return s.QueryAgentTokens(ctx, f, tr) // same data, different view
-}
-
 // ChannelFilter specifies which channels to query.
 type ChannelFilter struct {
 	Channel []string
@@ -312,8 +269,10 @@ type ModelCostBreakdown struct {
 	OutputTokens int64   `json:"output_tokens"`
 }
 
-// QueryAgentSummary returns a combined resource + token + cost summary for a single agent.
-// It runs two queries: one for resource metrics (avg/max over period) and one for token totals.
+// QueryAgentSummary returns a resource-metrics summary (avg/max over period)
+// for a single agent. Token and cost totals are sourced from the cost ledger
+// (pkg/cost, /api/costs/*) rather than the stats store, so the Tokens, Cost,
+// and Models fields are left zero-valued here.
 func (s *Store) QueryAgentSummary(ctx context.Context, agentName string, tr TimeRange) (*AgentSummary, error) {
 	summary := &AgentSummary{AgentName: agentName}
 
@@ -336,46 +295,6 @@ func (s *Store) QueryAgentSummary(ctx context.Context, agentName string, tr Time
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query agent resource summary: %w", err)
-	}
-
-	// Query token totals (aggregated over period)
-	usageQuery := `SELECT
-		COALESCE(SUM(input_tokens), 0), COALESCE(SUM(output_tokens), 0),
-		COALESCE(SUM(cache_read), 0), COALESCE(SUM(cache_create), 0),
-		COALESCE(SUM(cost_usd), 0)
-	FROM token_metrics
-	WHERE agent_name = $1 AND time >= $2 AND time < $3`
-
-	err = s.db.QueryRowContext(ctx, usageQuery, agentName, tr.From, tr.To).Scan(
-		&summary.Tokens.Input, &summary.Tokens.Output,
-		&summary.Tokens.CacheRead, &summary.Tokens.CacheCreate,
-		&summary.Cost.TotalUSD,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query agent token summary: %w", err)
-	}
-
-	// Query per-model cost breakdown
-	modelQuery := `SELECT model, SUM(cost_usd), SUM(input_tokens), SUM(output_tokens)
-	FROM token_metrics
-	WHERE agent_name = $1 AND time >= $2 AND time < $3
-	GROUP BY model ORDER BY SUM(cost_usd) DESC`
-
-	rows, err := s.db.QueryContext(ctx, modelQuery, agentName, tr.From, tr.To)
-	if err != nil {
-		return nil, fmt.Errorf("query agent model breakdown: %w", err)
-	}
-	defer rows.Close() //nolint:errcheck
-
-	for rows.Next() {
-		var m ModelCostBreakdown
-		if err := rows.Scan(&m.Model, &m.CostUSD, &m.InputTokens, &m.OutputTokens); err != nil {
-			return nil, fmt.Errorf("scan model breakdown: %w", err)
-		}
-		summary.Models = append(summary.Models, m)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
 	}
 
 	return summary, nil

--- a/pkg/stats/record.go
+++ b/pkg/stats/record.go
@@ -31,22 +31,6 @@ func (s *Store) RecordAgent(ctx context.Context, m AgentMetric) error {
 	return nil
 }
 
-// RecordToken inserts a token usage sample. Duplicate entries (same time,
-// agent, model) are silently skipped via ON CONFLICT, making this idempotent
-// across bcd restarts.
-func (s *Store) RecordToken(ctx context.Context, m TokenMetric) error {
-	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO token_metrics (time, agent_name, model, input_tokens, output_tokens, cache_read, cache_create, cost_usd)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-		 ON CONFLICT (time, agent_name, model) DO NOTHING`,
-		m.Time, m.AgentName, m.Model, m.InputTokens, m.OutputTokens, m.CacheRead, m.CacheCreate, m.CostUSD,
-	)
-	if err != nil {
-		return fmt.Errorf("record token metric: %w", err)
-	}
-	return nil
-}
-
 // RecordChannel inserts a channel activity sample.
 func (s *Store) RecordChannel(ctx context.Context, m ChannelMetric) error {
 	_, err := s.db.ExecContext(ctx,

--- a/pkg/stats/store.go
+++ b/pkg/stats/store.go
@@ -102,20 +102,6 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 			disk_read_bytes BIGINT NOT NULL DEFAULT 0,
 			disk_write_bytes BIGINT NOT NULL DEFAULT 0
 		)`,
-		// Token metrics — per-agent token consumption from JSONL
-		// UNIQUE constraint on (time, agent_name, model) makes inserts
-		// idempotent so bcd restarts don't duplicate historical entries.
-		`CREATE TABLE IF NOT EXISTS token_metrics (
-			time          TIMESTAMPTZ NOT NULL,
-			agent_name    TEXT NOT NULL DEFAULT '',
-			model         TEXT NOT NULL DEFAULT '',
-			input_tokens  BIGINT NOT NULL DEFAULT 0,
-			output_tokens BIGINT NOT NULL DEFAULT 0,
-			cache_read    BIGINT NOT NULL DEFAULT 0,
-			cache_create  BIGINT NOT NULL DEFAULT 0,
-			cost_usd      DOUBLE PRECISION NOT NULL DEFAULT 0,
-			UNIQUE (time, agent_name, model)
-		)`,
 		// Channel metrics — message/member/reaction counts
 		`CREATE TABLE IF NOT EXISTS channel_metrics (
 			time           TIMESTAMPTZ NOT NULL,
@@ -135,7 +121,6 @@ func (s *Store) ensureSchema(ctx context.Context) error {
 	hypertables := []string{
 		`SELECT create_hypertable('system_metrics', 'time', if_not_exists => TRUE)`,
 		`SELECT create_hypertable('agent_metrics', 'time', if_not_exists => TRUE)`,
-		`SELECT create_hypertable('token_metrics', 'time', if_not_exists => TRUE)`,
 		`SELECT create_hypertable('channel_metrics', 'time', if_not_exists => TRUE)`,
 	}
 
@@ -206,18 +191,6 @@ type AgentMetric struct {
 	DiskWriteBytes int64     `json:"disk_write_bytes"`
 }
 
-// TokenMetric represents token consumption at a point in time.
-type TokenMetric struct {
-	Time         time.Time `json:"time"`
-	AgentName    string    `json:"agent_name"`
-	Model        string    `json:"model"`
-	InputTokens  int64     `json:"input_tokens"`
-	OutputTokens int64     `json:"output_tokens"`
-	CacheRead    int64     `json:"cache_read"`
-	CacheCreate  int64     `json:"cache_create"`
-	CostUSD      float64   `json:"cost_usd"`
-}
-
 // ChannelMetric represents channel activity at a point in time.
 type ChannelMetric struct {
 	Time          time.Time `json:"time"`
@@ -238,7 +211,6 @@ func (s *Store) migrateStaleSchemas(ctx context.Context) error {
 	}{
 		{"system_metrics", "system_name"},
 		{"agent_metrics", "tool"},
-		{"token_metrics", "cache_read"},
 		{"channel_metrics", "message_count"},
 	}
 

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -323,7 +323,7 @@ func buildServicesFromWS(ctx context.Context, globals *Globals, ws *bcworkspace.
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			runStatsCollector(svcCtx, globals.Stats, agentSvc, ws)
+			runStatsCollector(svcCtx, globals.Stats, agentSvc)
 		}()
 	}
 

--- a/server/handlers/stats_agents.go
+++ b/server/handlers/stats_agents.go
@@ -14,8 +14,6 @@ func (h *StatsHandler) RegisterAgentStats(mux *http.ServeMux) {
 	mux.HandleFunc("/api/agents/stats/mem", h.agentMem)
 	mux.HandleFunc("/api/agents/stats/disk", h.agentDisk)
 	mux.HandleFunc("/api/agents/stats/net", h.agentNet)
-	mux.HandleFunc("/api/agents/stats/tokens", h.agentTokens)
-	mux.HandleFunc("/api/agents/stats/cost", h.agentCost)
 	mux.HandleFunc("/api/agents/stats/summary/", h.agentSummary)
 }
 
@@ -173,56 +171,6 @@ func (h *StatsHandler) agentNet(w http.ResponseWriter, r *http.Request) {
 	}
 	if metrics == nil {
 		metrics = []stats.AgentMetric{}
-	}
-	writeJSON(w, http.StatusOK, metrics)
-}
-
-func (h *StatsHandler) agentTokens(w http.ResponseWriter, r *http.Request) {
-	if !requireMethod(w, r, http.MethodGet) {
-		return
-	}
-	sq := parseStatsQuery(r, "agent", "model")
-	f := stats.AgentFilter{
-		Agent: sq.Filters["agent"],
-	}
-
-	if h.statsStore == nil {
-		writeJSON(w, http.StatusOK, []stats.TokenMetric{})
-		return
-	}
-
-	metrics, err := h.statsStore.QueryAgentTokens(r.Context(), f, sq.TimeRange)
-	if err != nil {
-		httpInternalError(w, "query agent tokens", err)
-		return
-	}
-	if metrics == nil {
-		metrics = []stats.TokenMetric{}
-	}
-	writeJSON(w, http.StatusOK, metrics)
-}
-
-func (h *StatsHandler) agentCost(w http.ResponseWriter, r *http.Request) {
-	if !requireMethod(w, r, http.MethodGet) {
-		return
-	}
-	sq := parseStatsQuery(r, "agent", "team")
-	f := stats.AgentFilter{
-		Agent: sq.Filters["agent"],
-	}
-
-	if h.statsStore == nil {
-		writeJSON(w, http.StatusOK, []stats.TokenMetric{})
-		return
-	}
-
-	metrics, err := h.statsStore.QueryAgentCost(r.Context(), f, sq.TimeRange)
-	if err != nil {
-		httpInternalError(w, "query agent cost", err)
-		return
-	}
-	if metrics == nil {
-		metrics = []stats.TokenMetric{}
 	}
 	writeJSON(w, http.StatusOK, metrics)
 }

--- a/server/stats_collector.go
+++ b/server/stats_collector.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"encoding/json"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -21,8 +20,6 @@ import (
 	bccontainer "github.com/rpuneet/mycel/pkg/container"
 	"github.com/rpuneet/mycel/pkg/log"
 	bcstats "github.com/rpuneet/mycel/pkg/stats"
-	bctoken "github.com/rpuneet/mycel/pkg/token"
-	bcworkspace "github.com/rpuneet/mycel/pkg/workspace"
 )
 
 // tmuxSampler is shared across sampling ticks so the one-time
@@ -44,11 +41,9 @@ type dockerStatsEntry struct {
 // runStatsCollector periodically samples system and agent metrics into TimescaleDB.
 //
 //nolint:gocyclo // Single pass over docker stats output; splitting obscures flow.
-func runStatsCollector(ctx context.Context, ss *bcstats.Store, agents *bcagent.AgentService, ws *bcworkspace.Workspace) {
+func runStatsCollector(ctx context.Context, ss *bcstats.Store, agents *bcagent.AgentService) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
-
-	tokenWatermarks := make(map[string]time.Time)
 
 	agentLookup := func() map[string]*bcagent.Agent {
 		if agents == nil {
@@ -138,37 +133,6 @@ func runStatsCollector(ctx context.Context, ss *bcstats.Store, agents *bcagent.A
 				}
 				if err := ss.RecordAgent(ctx, *metric); err != nil {
 					log.Debug("stats: record tmux agent metric", "agent", agentName, "error", err)
-				}
-			}
-
-			if ws != nil {
-				agentsDir := filepath.Join(ws.RootDir, ".bc", "agents")
-				for agentName := range agentsByName {
-					entries, tokenErr := bctoken.CollectAgentSince(agentsDir, agentName, tokenWatermarks[agentName])
-					if tokenErr != nil || len(entries) == 0 {
-						continue
-					}
-					var latestSuccess time.Time
-					for _, e := range entries {
-						if err := ss.RecordToken(ctx, bcstats.TokenMetric{
-							Time:         e.Timestamp,
-							AgentName:    e.AgentName,
-							Model:        e.Model,
-							InputTokens:  e.InputTokens,
-							OutputTokens: e.OutputTokens,
-							CacheRead:    e.CacheRead,
-							CacheCreate:  e.CacheCreate,
-						}); err != nil {
-							log.Debug("stats: record token metric", "agent", agentName, "error", err)
-							continue
-						}
-						if e.Timestamp.After(latestSuccess) {
-							latestSuccess = e.Timestamp
-						}
-					}
-					if !latestSuccess.IsZero() {
-						tokenWatermarks[agentName] = latestSuccess
-					}
 				}
 			}
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -66,10 +66,11 @@ export function AppRoutes() {
         <Route path="cron" element={wrap(<Cron />)} />
         <Route path="secrets" element={wrap(<Secrets />)} />
         <Route path="insights" element={wrap(<Insights />)} />
-        {/* Metrics + Costs merged into /insights — old links redirect. */}
-        <Route path="stats" element={<Navigate to="/insights?tab=metrics" replace />} />
-        <Route path="metrics" element={<Navigate to="/insights?tab=metrics" replace />} />
-        <Route path="costs" element={<Navigate to="/insights?tab=costs" replace />} />
+        {/* Metrics + Costs merged into the single /insights dashboard —
+            old links redirect. */}
+        <Route path="stats" element={<Navigate to="/insights" replace />} />
+        <Route path="metrics" element={<Navigate to="/insights" replace />} />
+        <Route path="costs" element={<Navigate to="/insights" replace />} />
         <Route path="code" element={wrap(<Code />)} />
         <Route path="code/*" element={wrap(<Code />)} />
         <Route path="settings" element={wrap(<Settings />)} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -263,7 +263,9 @@ export interface FileAttachment {
 
 export interface DailyCost {
   date: string;
-  total_cost_usd: number;
+  // The /costs/daily endpoint emits this as `cost_usd` (unlike the agent /
+  // model summaries, which use total_cost_usd).
+  cost_usd: number;
   total_tokens: number;
   record_count: number;
   input_tokens: number;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -194,6 +194,8 @@ export interface AgentCostSummary {
   output_tokens: number;
   cache_read_tokens?: number;
   cache_write_tokens?: number;
+  /** input + output; cache tokens excluded. */
+  total_tokens: number;
   record_count: number;
 }
 
@@ -534,17 +536,6 @@ export interface AgentMetricTS {
   net_tx_bytes: number;
   disk_read_bytes: number;
   disk_write_bytes: number;
-}
-
-export interface TokenMetricTS {
-  time: string;
-  agent_name: string;
-  model: string;
-  input_tokens: number;
-  output_tokens: number;
-  cache_read: number;
-  cache_create: number;
-  total_cost_usd: number;
 }
 
 export interface ChannelMetricTS {
@@ -996,10 +987,6 @@ export const api = {
     request<AgentMetricTS[]>(`/agents/stats/${metric}${qs(params)}`),
   getAgentStatsLatest: () =>
     request<AgentMetricTS[]>("/agents/stats/latest"),
-  getAgentTokenStats: (params?: Record<string, string>) =>
-    request<TokenMetricTS[]>(`/agents/stats/tokens${qs(params)}`),
-  getAgentCostStats: (params?: Record<string, string>) =>
-    request<TokenMetricTS[]>(`/agents/stats/cost${qs(params)}`),
   getChannelStats: (metric: string, params?: Record<string, string>) =>
     request<ChannelMetricTS[]>(`/channels/stats/${metric}${qs(params)}`),
 

--- a/web/src/components/StatsTab.tsx
+++ b/web/src/components/StatsTab.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useMemo, useState } from "react";
 import {
-  AreaChart, Area, BarChart, Bar, Cell,
+  AreaChart, Area,
   XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
 } from "recharts";
 import { api } from "../api/client";
-import type { Agent, AgentStatsSummary, AgentMetricTS, TokenMetricTS, ComputedStats } from "../api/client";
+import type { Agent, AgentStatsSummary, AgentMetricTS, ComputedStats } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
-import { calculateCost } from "../views/Stats";
 import { Panel, fmtTime, fmtBytes, fmtTokens } from "./shared/stats-primitives";
 
 // ── Constants ────────────────────────────────────────────────────────────────────
@@ -50,7 +49,6 @@ const fmtCost = (v: number): string => {
   if (!isFinite(v)) return "$0.00";
   return formatCost(v);
 };
-const trunc = (s: string, n: number) => s.length > n ? s.slice(0, n) + "\u2026" : s;
 const fromParam = (seconds: number) => new Date(Date.now() - seconds * 1000).toISOString();
 
 // ── Primitives ───────────────────────────────────────────────────────────────────
@@ -73,7 +71,6 @@ interface TabData {
   cpu: AgentMetricTS[];
   mem: AgentMetricTS[];
   net: AgentMetricTS[];
-  tokens: TokenMetricTS[];
 }
 
 // ── Component ────────────────────────────────────────────────────────────────────
@@ -84,12 +81,11 @@ export function StatsTab({ agent }: { agent: Agent }) {
 
   const fetcher = useCallback(async (): Promise<TabData> => {
     const p = { from, agent: agent.name };
-    const [r0, r1, r2, r3, r4, r5] = await Promise.allSettled([
+    const [r0, r1, r2, r3, r4] = await Promise.allSettled([
       api.getAgentStatsSummary(agent.name, { from }),
       api.getAgentStats("cpu", p),
       api.getAgentStats("mem", p),
       api.getAgentStats("net", p),
-      api.getAgentTokenStats(p),
       api.getAgentComputedStats(agent.name),
     ]);
     return {
@@ -97,8 +93,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
       cpu: r1.status === "fulfilled" ? (r1.value ?? []) : [],
       mem: r2.status === "fulfilled" ? (r2.value ?? []) : [],
       net: r3.status === "fulfilled" ? (r3.value ?? []) : [],
-      tokens: r4.status === "fulfilled" ? (r4.value ?? []) : [],
-      computed: r5.status === "fulfilled" ? r5.value : null,
+      computed: r4.status === "fulfilled" ? r4.value : null,
     };
   }, [agent.name, from]);
 
@@ -157,30 +152,6 @@ export function StatsTab({ agent }: { agent: Agent }) {
     [data?.net],
   );
 
-  const tokenChart = useMemo(() => {
-    const buckets = new Map<string, { time: string; input: number; output: number }>();
-    for (const t of data?.tokens ?? []) {
-      const k = fmtTime(t.time);
-      const b = buckets.get(k) ?? { time: k, input: 0, output: 0 };
-      b.input += t.input_tokens;
-      b.output += t.output_tokens;
-      buckets.set(k, b);
-    }
-    return Array.from(buckets.values());
-  }, [data?.tokens]);
-
-  const costBarData = useMemo(() =>
-    (s?.models ?? [])
-      .map(m => ({
-        name: trunc(m.model || "unknown", 24),
-        cost: parseFloat(calculateCost(m.model, m.input_tokens, m.output_tokens).toFixed(4)),
-      }))
-      .filter(d => d.cost > 0)
-      .sort((a, b) => b.cost - a.cost)
-      .slice(0, 8),
-    [s?.models],
-  );
-
   // Has any live data? Used to show a helpful banner when the stats store
   // is empty (e.g. TimescaleDB not configured, or agent never ran).
   const hasTimescaleData =
@@ -200,7 +171,6 @@ export function StatsTab({ agent }: { agent: Agent }) {
   const hasAnyData =
     hasTimescaleData ||
     hasComputedData ||
-    tokenChart.length > 0 ||
     totalIn > 0 ||
     totalOut > 0 ||
     totalCost > 0;
@@ -404,41 +374,25 @@ export function StatsTab({ agent }: { agent: Agent }) {
         </div>
       )}
 
-      {/* Row 3: Network I/O + Token Usage — only shown when data exists */}
-      {(netChart.length >= 2 || tokenChart.length >= 2) && (
+      {/* Row 3: Network I/O — only shown when data exists */}
+      {netChart.length >= 2 && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-          {netChart.length >= 2 && (
-            <Panel title="Network I/O">
-              <ResponsiveContainer width="100%" height={200}>
-                <AreaChart data={netChart} margin={{ top: 4, right: 8, left: -10, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
-                  <XAxis dataKey="time" tick={TICK} {...AX} />
-                  <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
-                  <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
-                  <Area type="monotone" dataKey="rx" name="RX" stroke="#10B981" fill="#10B981" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
-                  <Area type="monotone" dataKey="tx" name="TX" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} dot={false} />
-                </AreaChart>
-              </ResponsiveContainer>
-            </Panel>
-          )}
-          {tokenChart.length >= 2 && (
-            <Panel title="Token Usage">
-              <ResponsiveContainer width="100%" height={200}>
-                <AreaChart data={tokenChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
-                  <XAxis dataKey="time" tick={TICK} {...AX} />
-                  <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
-                  <Tooltip contentStyle={TT} formatter={(v, n) => [Number(v ?? 0).toLocaleString(), n === "input" ? "Input" : "Output"]} />
-                  <Area type="monotone" dataKey="input" name="Input" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
-                  <Area type="monotone" dataKey="output" name="Output" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} stackId="1" dot={false} />
-                </AreaChart>
-              </ResponsiveContainer>
-            </Panel>
-          )}
+          <Panel title="Network I/O">
+            <ResponsiveContainer width="100%" height={200}>
+              <AreaChart data={netChart} margin={{ top: 4, right: 8, left: -10, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
+                <XAxis dataKey="time" tick={TICK} {...AX} />
+                <YAxis tick={TICK} {...AX} tickFormatter={(v: number) => fmtBytes(v)} />
+                <Tooltip contentStyle={TT} formatter={(v) => [fmtBytes(Number(v ?? 0))]} />
+                <Area type="monotone" dataKey="rx" name="RX" stroke="#10B981" fill="#10B981" fillOpacity={0.12} strokeWidth={1.5} dot={false} />
+                <Area type="monotone" dataKey="tx" name="TX" stroke={ACCENT} fill={ACCENT} fillOpacity={0.12} strokeWidth={1.5} dot={false} />
+              </AreaChart>
+            </ResponsiveContainer>
+          </Panel>
         </div>
       )}
 
-      {/* Row 4: Cost by Model + I/O Summary — only shown when data exists */}
+      {/* Row 4: I/O Summary — only shown when data exists */}
       {(() => {
         const hasIoData = s && (
           (s.network?.rx_bytes ?? 0) > 0 ||
@@ -446,28 +400,10 @@ export function StatsTab({ agent }: { agent: Agent }) {
           (s.disk?.read_bytes ?? 0) > 0 ||
           (s.disk?.write_bytes ?? 0) > 0
         );
-        const showCost = costBarData.length > 0;
-        const showIo = hasIoData;
-        if (!showCost && !showIo) return null;
+        if (!hasIoData || !s) return null;
         return (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {showCost && (
-              <Panel title="Cost by Model">
-                <ResponsiveContainer width="100%" height={200}>
-                  <BarChart layout="vertical" data={costBarData} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
-                    <XAxis type="number" tick={TICK} {...AX} tickFormatter={(v: number) => `$${v}`} />
-                    <YAxis type="category" dataKey="name" tick={{ ...TICK, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
-                    <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
-                    <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
-                      {costBarData.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
-                    </Bar>
-                  </BarChart>
-                </ResponsiveContainer>
-              </Panel>
-            )}
-            {showIo && s && (
-              <Panel title="I/O Summary">
+            <Panel title="I/O Summary">
                 <div className="grid grid-cols-2 gap-3 py-4">
                   <div className="text-center">
                     <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">Net RX</p>
@@ -486,8 +422,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
                     <p className="text-lg font-bold tabular-nums text-[#A855F7]">{fmtBytes(s.disk?.write_bytes ?? 0)}</p>
                   </div>
                 </div>
-              </Panel>
-            )}
+            </Panel>
           </div>
         );
       })()}

--- a/web/src/views/Insights.tsx
+++ b/web/src/views/Insights.tsx
@@ -1,62 +1,16 @@
 /**
- * Insights — Metrics + Costs merged behind one nav item.
+ * Insights — a single-page analytics dashboard.
  *
- * Two tabs (?tab=metrics | ?tab=costs) rendering the existing Stats and
- * CostsGlobal views unchanged as tab content. Only the active tab is
- * mounted so each view's useHeaderSlot (range picker / date picker)
- * owns the header without fighting the other. /stats, /metrics and
- * /costs redirect here (see App.tsx) so old links keep working.
- *
- * Tab styling follows AgentDetail's HUD tabs: small uppercase buttons
- * with an accent underline on the active tab.
+ * Metrics and Costs used to live behind a tab bar; they are now one
+ * scrollable dashboard rendered by <Stats/>, which owns the KPI strip,
+ * the sticky section anchor-nav and every chart panel. The range picker
+ * is slotted into the page header via Stats' useHeaderSlot. /stats,
+ * /metrics and /costs redirect here (see App.tsx) so old links keep
+ * working.
  */
 
-import { useSearchParams } from "react-router-dom";
 import { Stats } from "./Stats";
-import { CostsGlobal } from "./CostsGlobal";
-
-const TABS = [
-  { key: "metrics", label: "Metrics" },
-  { key: "costs", label: "Costs" },
-] as const;
-
-type TabKey = (typeof TABS)[number]["key"];
 
 export function Insights() {
-  const [params, setParams] = useSearchParams();
-  const tab: TabKey = params.get("tab") === "costs" ? "costs" : "metrics";
-
-  return (
-    <div className="flex flex-col h-full min-h-0">
-      <div
-        role="tablist"
-        aria-label="Insights sections"
-        className="shrink-0 flex items-center gap-1 px-4 pt-1 border-b border-mycel-border"
-      >
-        {TABS.map((t) => {
-          const isActive = tab === t.key;
-          return (
-            <button
-              key={t.key}
-              type="button"
-              role="tab"
-              aria-selected={isActive}
-              onClick={() => setParams({ tab: t.key }, { replace: true })}
-              className={`relative px-2.5 py-2 text-[11px] font-medium tracking-wide uppercase transition-colors shrink-0 ${
-                isActive ? "text-mycel-accent" : "text-mycel-muted hover:text-mycel-text"
-              }`}
-            >
-              {t.label}
-              {isActive && (
-                <span className="absolute -bottom-px left-2 right-2 h-[2px] bg-mycel-accent rounded-full" />
-              )}
-            </button>
-          );
-        })}
-      </div>
-      <div className="flex-1 min-h-0 overflow-auto">
-        {tab === "metrics" ? <Stats /> : <CostsGlobal />}
-      </div>
-    </div>
-  );
+  return <Stats />;
 }

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -7,7 +7,7 @@ import {
 import { api } from "../api/client";
 import type {
   SystemStats, StatsSummary, CostSummary, ModelCostSummary, AgentCostSummary,
-  AgentMetricTS, TokenMetricTS, ChannelStats, DailyCost,
+  AgentMetricTS, ChannelStats, DailyCost,
 } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
@@ -231,7 +231,6 @@ interface StatsData {
   agentMem: AgentMetricTS[];
   agentNet: AgentMetricTS[];
   agentDisk: AgentMetricTS[];
-  tokenMetrics: TokenMetricTS[];
   notificationStats: ChannelStats[];
   costDaily: DailyCost[];
 }
@@ -350,7 +349,7 @@ export function Stats() {
 
   const fetcher = useCallback(async (): Promise<StatsData> => {
     const p = { from };
-    const [r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11] = await Promise.allSettled([
+    const [r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10] = await Promise.allSettled([
       api.getStatsSystem(),
       api.getStatsSummary(),
       api.getCostSummary(),
@@ -360,7 +359,6 @@ export function Stats() {
       api.getAgentStats("mem", p),
       api.getAgentStats("net", p),
       api.getAgentStats("disk", p),
-      api.getAgentTokenStats(p),
       api.getStatsChannels(),
       api.getCostDaily(daysForRange),
     ]);
@@ -374,9 +372,8 @@ export function Stats() {
       agentMem: r6.status === "fulfilled" ? (r6.value ?? []) : [],
       agentNet: r7.status === "fulfilled" ? (r7.value ?? []) : [],
       agentDisk: r8.status === "fulfilled" ? (r8.value ?? []) : [],
-      tokenMetrics: r9.status === "fulfilled" ? (r9.value ?? []) : [],
-      notificationStats: r10.status === "fulfilled" ? (r10.value ?? []) : [],
-      costDaily: r11.status === "fulfilled" && Array.isArray(r11.value) ? r11.value : [],
+      notificationStats: r9.status === "fulfilled" ? (r9.value ?? []) : [],
+      costDaily: r10.status === "fulfilled" && Array.isArray(r10.value) ? r10.value : [],
     };
   }, [from, daysForRange]);
 
@@ -388,52 +385,81 @@ export function Stats() {
   const memChart = useMemo(() => pivotAgentMetric(data?.agentMem ?? [], "mem_mb"), [data?.agentMem]);
   const netChart = useMemo(() => pivotNetOrDisk(data?.agentNet ?? [], "net"), [data?.agentNet]);
   const diskChart = useMemo(() => pivotNetOrDisk(data?.agentDisk ?? [], "disk"), [data?.agentDisk]);
-  const tokenChart = useMemo(() => pivotTokens(data?.tokenMetrics ?? []), [data?.tokenMetrics]);
-  const costOverTime = useMemo(() => pivotCostOverTime(data?.tokenMetrics ?? []), [data?.tokenMetrics]);
-  const tokensByAgent = useMemo(() => pivotTokensByAgent(data?.tokenMetrics ?? []), [data?.tokenMetrics]);
-  const tokensByModel = useMemo(() => pivotTokensByModel(data?.tokenMetrics ?? []), [data?.tokenMetrics]);
+  // ── Cost + token charts (cost ledger is the single source of truth) ──────────
+  // The stats-store token timeseries (/agents/stats/tokens) is vestigial and
+  // always empty, so every cost/token view derives directly from the cost
+  // ledger: /costs (summary), /costs/agents, /costs/models, /costs/daily.
 
-  // Cost-ledger fallbacks: when the token-metric timeseries is empty the
-  // derived charts above collapse to "No cost data", so fall back to the
-  // all-time cost ledger (/costs/*) which is populated independently.
-  const costOverTimeData = useMemo(() => {
-    if (costOverTime.length) return costOverTime;
-    return (data?.costDaily ?? []).map(d => ({ time: d.date, cost: d.cost_usd }));
-  }, [costOverTime, data?.costDaily]);
+  // Cost Over Time — daily ledger, one point per day.
+  const costOverTimeData = useMemo(
+    () => (data?.costDaily ?? []).map(d => ({ time: d.date, cost: d.cost_usd })),
+    [data?.costDaily],
+  );
 
-  const costByAgentData = useMemo(() => {
-    if (tokensByAgent.length) {
-      return tokensByAgent.slice(0, 8).map(a => ({ name: trunc(a.name, 20), cost: parseFloat(a.cost.toFixed(4)) }));
-    }
-    return (data?.costByAgent ?? [])
+  // Token Throughput over time — daily ledger, input/output stacked.
+  const tokenChart = useMemo(
+    () => (data?.costDaily ?? []).map(d => ({ time: d.date, input: d.input_tokens, output: d.output_tokens })),
+    [data?.costDaily],
+  );
+
+  // Cost by Agent — per-agent ledger, top 8 by spend.
+  const costByAgentData = useMemo(
+    () => (data?.costByAgent ?? [])
       .map(a => ({ name: stripAgentPrefix(a.agent_id), cost: a.total_cost_usd }))
       .filter(a => a.cost > 0)
       .sort((a, b) => b.cost - a.cost)
-      .slice(0, 8);
-  }, [tokensByAgent, data?.costByAgent]);
+      .slice(0, 8),
+    [data?.costByAgent],
+  );
 
-  // Time-range-filtered cost from token metrics
-  const timeRangeCost = useMemo(() => {
-    let total = 0;
-    for (const t of data?.tokenMetrics ?? []) {
-      total += calculateCost(t.model, t.input_tokens, t.output_tokens);
-    }
-    return total;
-  }, [data?.tokenMetrics]);
+  // Cost by Model — per-model ledger, top 8 by spend.
+  const costByModelBar = useMemo(
+    () => (data?.costByModel ?? [])
+      .map(m => ({ name: trunc(m.model, 24), cost: m.total_cost_usd }))
+      .filter(m => m.cost > 0)
+      .sort((a, b) => b.cost - a.cost)
+      .slice(0, 8),
+    [data?.costByModel],
+  );
 
-  const hasCacheData = useMemo(() => (data?.tokenMetrics ?? []).some(t => t.cache_read > 0 || t.cache_create > 0), [data?.tokenMetrics]);
-  const cacheChart = useMemo(() => {
-    if (!hasCacheData) return [];
-    const buckets = new Map<string, { time: string; cache_read: number; cache_create: number }>();
-    for (const t of data?.tokenMetrics ?? []) {
-      const k = fmtTime(t.time);
-      const b = buckets.get(k) ?? { time: k, cache_read: 0, cache_create: 0 };
-      b.cache_read += t.cache_read;
-      b.cache_create += t.cache_create;
-      buckets.set(k, b);
-    }
-    return Array.from(buckets.values());
-  }, [data?.tokenMetrics, hasCacheData]);
+  // Model Usage (Tokens) — per-model ledger, top 8 by total tokens.
+  const tokensByModel = useMemo(
+    () => (data?.costByModel ?? [])
+      .map(m => ({ name: trunc(m.model, 24), tokens: m.total_tokens }))
+      .filter(m => m.tokens > 0)
+      .sort((a, b) => b.tokens - a.tokens)
+      .slice(0, 8),
+    [data?.costByModel],
+  );
+
+  // Agent Token Breakdown — per-agent ledger, input/output split, top 8.
+  const tokensByAgent = useMemo(
+    () => (data?.costByAgent ?? [])
+      .map(a => ({ name: stripAgentPrefix(a.agent_id), input: a.input_tokens, output: a.output_tokens, total: a.total_tokens }))
+      .filter(a => a.total > 0)
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 8),
+    [data?.costByAgent],
+  );
+
+  // Cache Efficiency — the ledger exposes only aggregate cache totals (no
+  // per-time series), so this is a summary view: read vs write tokens plus a
+  // hit ratio = cache_read / (cache_read + input_tokens).
+  const cacheStats = useMemo(() => {
+    const s = data?.costSummary;
+    const read = s?.cache_read_tokens ?? 0;
+    const write = s?.cache_write_tokens ?? 0;
+    const input = s?.input_tokens ?? 0;
+    const ratio = read + input > 0 ? read / (read + input) : 0;
+    return { read, write, ratio, hasData: read > 0 || write > 0 };
+  }, [data?.costSummary]);
+  const cacheBar = useMemo(
+    () => [
+      { name: "Read", tokens: cacheStats.read },
+      { name: "Write", tokens: cacheStats.write },
+    ],
+    [cacheStats],
+  );
 
   const notificationBarData = useMemo(() => {
     return [...(data?.notificationStats ?? [])]
@@ -441,19 +467,6 @@ export function Stats() {
       .slice(0, 10)
       .map(c => ({ name: trunc(c.name, 16), fullName: c.name, messages: c.message_count }));
   }, [data?.notificationStats]);
-
-  const costByModelBar = useMemo(() => {
-    const fromTokens = tokensByModel
-      .filter(m => m.cost > 0)
-      .slice(0, 8)
-      .map(m => ({ name: trunc(m.name, 24), cost: parseFloat(m.cost.toFixed(4)) }));
-    if (fromTokens.length) return fromTokens;
-    // Fallback to the all-time model cost ledger when the timeseries is empty.
-    return (data?.costByModel ?? [])
-      .map(m => ({ name: trunc(m.model, 24), cost: m.total_cost_usd }))
-      .filter(m => m.cost > 0)
-      .slice(0, 8);
-  }, [tokensByModel, data?.costByModel]);
 
   const agentTable = useMemo(() => buildAgentTable(data, sortKey, sortAsc), [data, sortKey, sortAsc]);
 
@@ -468,41 +481,33 @@ export function Stats() {
   const avgCpu = agentTable.length > 0 ? agentTable.reduce((s, a) => s + a.cpu, 0) / agentTable.length : 0;
   const totalMem = agentTable.reduce((s, a) => s + a.mem, 0);
   const totalTokens = agentTable.reduce((s, a) => s + a.tokens, 0);
+  const totalCost = agentTable.reduce((s, a) => s + a.cost, 0);
 
   // ── KPI strip values ─────────────────────────────────────────────────────────
+  // Every KPI is range-scoped off the cost ledger. Spend and tokens sum the
+  // daily ledger for the selected window; burn is that spend over the window's
+  // hours; the top cost driver is the per-agent ledger's biggest spender.
   const aliveCount = agentTable.filter((a) => ALIVE_STATES.has(a.state)).length;
-  const rangeHours = (RANGES[range]?.seconds ?? 0) / 3600;
-  // Range-scoped spend from the daily cost ledger (used when the per-minute
-  // token timeseries is empty on this deployment). Daily granularity means
-  // sub-day ranges resolve to "today".
   const rangeSpend = useMemo(
     () => (data?.costDaily ?? []).reduce((s, d) => s + (d.cost_usd ?? 0), 0),
     [data?.costDaily],
   );
-  // Prefer the timeseries-derived spend/tokens; else the range-scoped daily
-  // ledger; else the all-time ledger total as a last resort.
-  const displaySpend =
-    timeRangeCost > 0 ? timeRangeCost : rangeSpend > 0 ? rangeSpend : (data?.costSummary?.total_cost_usd ?? 0);
-  const kpiTokens = totalTokens > 0 ? totalTokens : (data?.costSummary?.total_tokens ?? 0);
-  // Burn rate is spend over the window it actually covers: the token
-  // timeseries spans rangeHours; the daily fallback spans daysForRange*24h.
-  // With only an all-time total (no daily data), a rate is meaningless → "—".
-  const burnHours = timeRangeCost > 0 ? rangeHours : rangeSpend > 0 ? daysForRange * 24 : 0;
-  const burnBase = timeRangeCost > 0 ? timeRangeCost : rangeSpend;
-  const burnRate = burnHours > 0 ? burnBase / burnHours : null;
-  const topCostDriver = agentTable.reduce<AgentRow | null>(
-    (top, a) => (a.cost > 0 && (!top || a.cost > top.cost) ? a : top),
-    null,
+  const rangeTokens = useMemo(
+    () => (data?.costDaily ?? []).reduce((s, d) => s + (d.total_tokens ?? 0), 0),
+    [data?.costDaily],
   );
-  const topDriverFallback = (data?.costByAgent ?? []).reduce<AgentCostSummary | null>(
-    (top, a) => (a.total_cost_usd > 0 && (!top || a.total_cost_usd > top.total_cost_usd) ? a : top),
-    null,
-  );
-  const topDriver = topCostDriver && topCostDriver.cost > 0
-    ? { name: topCostDriver.name, cost: topCostDriver.cost }
-    : topDriverFallback
-      ? { name: stripAgentPrefix(topDriverFallback.agent_id), cost: topDriverFallback.total_cost_usd }
-      : null;
+  const displaySpend = rangeSpend;
+  const kpiTokens = rangeTokens;
+  // Burn rate = range spend over the window the daily ledger covers
+  // (daysForRange * 24h). With no spend a rate is meaningless → "—".
+  const burnRate = rangeSpend > 0 ? rangeSpend / (daysForRange * 24) : null;
+  const topDriver = useMemo(() => {
+    const top = (data?.costByAgent ?? []).reduce<AgentCostSummary | null>(
+      (t, a) => (a.total_cost_usd > 0 && (!t || a.total_cost_usd > t.total_cost_usd) ? a : t),
+      null,
+    );
+    return top ? { name: stripAgentPrefix(top.agent_id), cost: top.total_cost_usd } : null;
+  }, [data?.costByAgent]);
 
   // ── Render ──────────────────────────────────────────────────────────────────
 
@@ -524,7 +529,7 @@ export function Stats() {
     { key: "cpu", label: "CPU%", agg: `avg ${avgCpu.toFixed(1)}` },
     { key: "mem", label: "Mem MB", agg: `total ${totalMem >= 1024 ? `${(totalMem / 1024).toFixed(1)}G` : `${totalMem.toFixed(0)}M`}` },
     { key: "tokens", label: "Tokens", agg: fmtTokens(totalTokens) },
-    { key: "cost", label: "Cost", agg: fmtCost(timeRangeCost) },
+    { key: "cost", label: "Cost", agg: fmtCost(totalCost) },
   ];
 
   return (
@@ -698,30 +703,51 @@ export function Stats() {
         <Panel title="Model Usage (Tokens)">
           {tokensByModel.length === 0 ? <Empty msg="No model data" /> : (
             <ResponsiveContainer width="100%" height={200}>
-              <BarChart layout="vertical" data={tokensByModel.slice(0, 8).map(m => ({ name: trunc(m.name, 24), tokens: m.tokens }))} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
+              <BarChart layout="vertical" data={tokensByModel} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
                 <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
                 <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
                 <Tooltip contentStyle={TT} formatter={(v) => [fmtTokens(Number(v ?? 0))]} />
                 <Bar dataKey="tokens" radius={[0, 3, 3, 0]}>
-                  {tokensByModel.slice(0, 8).map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+                  {tokensByModel.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
                 </Bar>
               </BarChart>
             </ResponsiveContainer>
           )}
         </Panel>
         <Panel title="Cache Efficiency">
-          {!hasCacheData ? <Empty msg="Cache data — coming soon" /> : (
-            <ResponsiveContainer width="100%" height={200}>
-              <AreaChart data={cacheChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
-                <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
-                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
-                <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "cache_read" ? "Cache Read" : "Cache Create"]} />
-                <Area type="monotone" dataKey="cache_read" name="Cache Read" stroke="#10B981" fill="#10B981" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
-                <Area type="monotone" dataKey="cache_create" name="Cache Create" stroke="#F59E0B" fill="#F59E0B" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
-              </AreaChart>
-            </ResponsiveContainer>
+          {!cacheStats.hasData ? <Empty msg="No cache data" /> : (
+            <div className="flex flex-col gap-3">
+              {/* Cache hit ratio headline + read/write token totals. The ledger
+                  reports only aggregate cache counts (no per-time series), so
+                  this is a summary rather than a time chart. */}
+              <div className="flex items-baseline gap-6 px-1">
+                <div>
+                  <div className="text-[10px] font-medium text-mycel-muted uppercase tracking-[0.08em]">Hit ratio</div>
+                  <div className="mt-0.5 text-2xl font-semibold tabular-nums text-mycel-accent">{(cacheStats.ratio * 100).toFixed(1)}%</div>
+                </div>
+                <div>
+                  <div className="text-[10px] font-medium text-mycel-muted uppercase tracking-[0.08em]">Cache read</div>
+                  <div className="mt-0.5 text-lg font-semibold tabular-nums text-mycel-text">{fmtTokens(cacheStats.read)}</div>
+                </div>
+                <div>
+                  <div className="text-[10px] font-medium text-mycel-muted uppercase tracking-[0.08em]">Cache write</div>
+                  <div className="mt-0.5 text-lg font-semibold tabular-nums text-mycel-text">{fmtTokens(cacheStats.write)}</div>
+                </div>
+              </div>
+              <ResponsiveContainer width="100%" height={120}>
+                <BarChart layout="vertical" data={cacheBar} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
+                  <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
+                  <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={60} />
+                  <Tooltip contentStyle={TT} formatter={(v) => [fmtTokens(Number(v ?? 0))]} />
+                  <Bar dataKey="tokens" radius={[0, 3, 3, 0]}>
+                    <Cell fill="#10B981" />
+                    <Cell fill="#F59E0B" />
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
           )}
         </Panel>
         <Panel title="Agent Token Breakdown">
@@ -924,52 +950,6 @@ function pivotNetOrDisk(metrics: AgentMetricTS[], kind: "net" | "disk") {
   return Array.from(buckets.values());
 }
 
-function pivotTokens(tokens: TokenMetricTS[]) {
-  const buckets = new Map<string, { time: string; input: number; output: number }>();
-  for (const t of tokens) {
-    const k = fmtTime(t.time);
-    const b = buckets.get(k) ?? { time: k, input: 0, output: 0 };
-    b.input += t.input_tokens;
-    b.output += t.output_tokens;
-    buckets.set(k, b);
-  }
-  return Array.from(buckets.values());
-}
-
-function pivotCostOverTime(tokens: TokenMetricTS[]) {
-  const buckets = new Map<string, { time: string; cost: number }>();
-  for (const t of tokens) {
-    const k = fmtTime(t.time);
-    const b = buckets.get(k) ?? { time: k, cost: 0 };
-    b.cost += calculateCost(t.model, t.input_tokens, t.output_tokens);
-    buckets.set(k, b);
-  }
-  return Array.from(buckets.values());
-}
-
-function pivotTokensByAgent(tokens: TokenMetricTS[]) {
-  const agents = new Map<string, { name: string; input: number; output: number; cost: number }>();
-  for (const t of tokens) {
-    const a = agents.get(t.agent_name) ?? { name: t.agent_name, input: 0, output: 0, cost: 0 };
-    a.input += t.input_tokens;
-    a.output += t.output_tokens;
-    a.cost += calculateCost(t.model, t.input_tokens, t.output_tokens);
-    agents.set(t.agent_name, a);
-  }
-  return Array.from(agents.values()).sort((a, b) => b.cost - a.cost);
-}
-
-function pivotTokensByModel(tokens: TokenMetricTS[]) {
-  const models = new Map<string, { name: string; tokens: number; cost: number }>();
-  for (const t of tokens) {
-    const m = models.get(t.model) ?? { name: t.model, tokens: 0, cost: 0 };
-    m.tokens += t.input_tokens + t.output_tokens;
-    m.cost += calculateCost(t.model, t.input_tokens, t.output_tokens);
-    models.set(t.model, m);
-  }
-  return Array.from(models.values()).sort((a, b) => b.cost - a.cost);
-}
-
 interface AgentRow { name: string; role: string; provider: string; state: string; cpu: number; mem: number; tokens: number; cost: number }
 
 function buildAgentTable(data: StatsData | null, sortKey: SortKey, sortAsc: boolean): AgentRow[] {
@@ -977,23 +957,25 @@ function buildAgentTable(data: StatsData | null, sortKey: SortKey, sortAsc: bool
   const latest = new Map<string, AgentMetricTS>();
   for (const m of data.agentCpu) { if (!isInfra(m.agent_name)) latest.set(m.agent_name, m); }
 
-  // Cost from time-range-filtered token metrics (not all-time costByAgent)
-  const costMap = new Map<string, number>();
-  for (const t of data.tokenMetrics) {
-    costMap.set(t.agent_name, (costMap.get(t.agent_name) ?? 0) + calculateCost(t.model, t.input_tokens, t.output_tokens));
+  // Per-agent tokens + cost come straight from the cost ledger. Ledger ids are
+  // namespaced ("bc-bc-zen-zebra") while the metrics agent_name is the bare
+  // name ("zen-zebra"), so key the lookup by stripAgentPrefix(agent_id).
+  const ledgerByName = new Map<string, { tokens: number; cost: number }>();
+  for (const a of data.costByAgent) {
+    ledgerByName.set(stripAgentPrefix(a.agent_id), { tokens: a.total_tokens, cost: a.total_cost_usd });
   }
-
-  const tokenMap = new Map<string, number>();
-  for (const t of data.tokenMetrics) tokenMap.set(t.agent_name, (tokenMap.get(t.agent_name) ?? 0) + t.input_tokens + t.output_tokens);
 
   const memLatest = new Map<string, number>();
   for (const m of data.agentMem) { if (!isInfra(m.agent_name)) memLatest.set(m.agent_name, m.mem_used_bytes / 1024 / 1024); }
 
-  const rows: AgentRow[] = Array.from(latest.values()).map(m => ({
-    name: m.agent_name, role: m.role, provider: m.tool || "unknown", state: m.state,
-    cpu: m.cpu_percent, mem: memLatest.get(m.agent_name) ?? 0,
-    tokens: tokenMap.get(m.agent_name) ?? 0, cost: costMap.get(m.agent_name) ?? 0,
-  }));
+  const rows: AgentRow[] = Array.from(latest.values()).map(m => {
+    const ledger = ledgerByName.get(m.agent_name);
+    return {
+      name: m.agent_name, role: m.role, provider: m.tool || "unknown", state: m.state,
+      cpu: m.cpu_percent, mem: memLatest.get(m.agent_name) ?? 0,
+      tokens: ledger?.tokens ?? 0, cost: ledger?.cost ?? 0,
+    };
+  });
 
   const dir = sortAsc ? 1 : -1;
   rows.sort((a, b) => {

--- a/web/src/views/Stats.tsx
+++ b/web/src/views/Stats.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import {
   AreaChart, Area, BarChart, Bar, Cell,
   XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
@@ -7,7 +7,7 @@ import {
 import { api } from "../api/client";
 import type {
   SystemStats, StatsSummary, CostSummary, ModelCostSummary, AgentCostSummary,
-  AgentMetricTS, TokenMetricTS, ChannelStats,
+  AgentMetricTS, TokenMetricTS, ChannelStats, DailyCost,
 } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
@@ -203,6 +203,18 @@ import { formatCost } from "../utils/format";
 const fmtCost = (n: number) => formatCost(n);
 const trunc = (s: string, n: number) => s.length > n ? s.slice(0, n) + "\u2026" : s;
 
+// Cost-ledger agent ids are namespaced "bc-<workspace>-<agent>" (e.g.
+// "bc-bc-zen-zebra"). Drop the "bc-" prefix and the workspace segment to
+// show the bare agent name ("zen-zebra"); fall back to the raw id if that
+// leaves nothing.
+function stripAgentPrefix(id: string): string {
+  if (id.startsWith("bc-")) {
+    const rest = id.split("-").slice(2).join("-");
+    return rest || id;
+  }
+  return id;
+}
+
 function fromParam(seconds: number): string {
   return new Date(Date.now() - seconds * 1000).toISOString();
 }
@@ -221,9 +233,67 @@ interface StatsData {
   agentDisk: AgentMetricTS[];
   tokenMetrics: TokenMetricTS[];
   notificationStats: ChannelStats[];
+  costDaily: DailyCost[];
 }
 
 type SortKey = "name" | "role" | "provider" | "state" | "cpu" | "mem" | "tokens" | "cost";
+
+// ── Dashboard chrome ──────────────────────────────────────────────────────────────
+
+// Single-page dashboard sections. Order drives both the sticky anchor-nav
+// and the on-page render order. Each id is the scroll target for its pill.
+const SECTIONS = [
+  { id: "agents", label: "Agents" },
+  { id: "cost", label: "Cost" },
+  { id: "usage", label: "Usage" },
+  { id: "system", label: "System" },
+  { id: "activity", label: "Activity" },
+] as const;
+
+// States that count as a live agent for the "Active agents" KPI.
+const ALIVE_STATES = new Set(["working", "idle", "running", "starting"]);
+
+/** Sticky anchor-nav — quiet pills that smooth-scroll to each section. */
+function AnchorNav() {
+  return (
+    <div className="sticky top-0 z-10 -mx-6 px-6 py-2 bg-mycel-bg/80 backdrop-blur-sm border-b border-mycel-border flex items-center gap-1.5 flex-wrap">
+      {SECTIONS.map((s) => (
+        <button
+          key={s.id}
+          type="button"
+          onClick={() => document.getElementById(s.id)?.scrollIntoView({ behavior: "smooth", block: "start" })}
+          className="px-2.5 py-1 text-[11px] font-medium rounded-full border border-mycel-border text-mycel-muted hover:text-mycel-text hover:border-mycel-muted transition-colors"
+        >
+          {s.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Section header matching the Tools.tsx pattern: label + count + rule. */
+function SectionHeader({ label, count }: { label: string; count: number | string }) {
+  return (
+    <div className="flex items-baseline gap-2 mb-3">
+      <h2 className="text-[11px] font-medium text-mycel-muted uppercase tracking-[0.08em]">{label}</h2>
+      <span className="text-[11px] text-mycel-muted tabular-nums">{count}</span>
+      <span className="flex-1 h-px bg-mycel-border self-center" aria-hidden />
+    </div>
+  );
+}
+
+/** Compact KPI tile for the top strip; a Link when `to` is provided. */
+function KpiTile({ label, value, sub, to }: { label: string; value: React.ReactNode; sub?: string; to?: string }) {
+  const cls = `block bg-mycel-surface border border-mycel-border rounded-lg shadow-mycel-sm p-3${to ? " hover:border-mycel-accent transition-colors" : ""}`;
+  const body = (
+    <>
+      <div className="text-[10px] font-medium text-mycel-muted uppercase tracking-[0.08em] truncate">{label}</div>
+      <div className="mt-1 text-lg font-semibold tabular-nums text-mycel-text truncate">{value}</div>
+      {sub && <div className="text-[10px] text-mycel-muted truncate">{sub}</div>}
+    </>
+  );
+  return to ? <Link to={to} className={cls}>{body}</Link> : <div className={cls}>{body}</div>;
+}
 
 // ── Main ────────────────────────────────────────────────────────────────────────
 
@@ -271,10 +341,16 @@ export function Stats() {
   });
 
   const from = useMemo(() => fromParam(RANGES[range]?.seconds ?? 3600), [range]);
+  // Daily cost ledger window sized to the selected range: sub-day ranges
+  // still pull a single day so the fallback chart has something to show.
+  const daysForRange = useMemo(
+    () => Math.max(1, Math.ceil((RANGES[range]?.seconds ?? 3600) / 86400)),
+    [range],
+  );
 
   const fetcher = useCallback(async (): Promise<StatsData> => {
     const p = { from };
-    const [r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10] = await Promise.allSettled([
+    const [r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11] = await Promise.allSettled([
       api.getStatsSystem(),
       api.getStatsSummary(),
       api.getCostSummary(),
@@ -286,6 +362,7 @@ export function Stats() {
       api.getAgentStats("disk", p),
       api.getAgentTokenStats(p),
       api.getStatsChannels(),
+      api.getCostDaily(daysForRange),
     ]);
     return {
       system: r0.status === "fulfilled" ? r0.value : null,
@@ -299,8 +376,9 @@ export function Stats() {
       agentDisk: r8.status === "fulfilled" ? (r8.value ?? []) : [],
       tokenMetrics: r9.status === "fulfilled" ? (r9.value ?? []) : [],
       notificationStats: r10.status === "fulfilled" ? (r10.value ?? []) : [],
+      costDaily: r11.status === "fulfilled" && Array.isArray(r11.value) ? r11.value : [],
     };
-  }, [from]);
+  }, [from, daysForRange]);
 
   const { data, loading, error, refresh, timedOut } = usePolling(fetcher, 10000);
 
@@ -314,6 +392,25 @@ export function Stats() {
   const costOverTime = useMemo(() => pivotCostOverTime(data?.tokenMetrics ?? []), [data?.tokenMetrics]);
   const tokensByAgent = useMemo(() => pivotTokensByAgent(data?.tokenMetrics ?? []), [data?.tokenMetrics]);
   const tokensByModel = useMemo(() => pivotTokensByModel(data?.tokenMetrics ?? []), [data?.tokenMetrics]);
+
+  // Cost-ledger fallbacks: when the token-metric timeseries is empty the
+  // derived charts above collapse to "No cost data", so fall back to the
+  // all-time cost ledger (/costs/*) which is populated independently.
+  const costOverTimeData = useMemo(() => {
+    if (costOverTime.length) return costOverTime;
+    return (data?.costDaily ?? []).map(d => ({ time: d.date, cost: d.cost_usd }));
+  }, [costOverTime, data?.costDaily]);
+
+  const costByAgentData = useMemo(() => {
+    if (tokensByAgent.length) {
+      return tokensByAgent.slice(0, 8).map(a => ({ name: trunc(a.name, 20), cost: parseFloat(a.cost.toFixed(4)) }));
+    }
+    return (data?.costByAgent ?? [])
+      .map(a => ({ name: stripAgentPrefix(a.agent_id), cost: a.total_cost_usd }))
+      .filter(a => a.cost > 0)
+      .sort((a, b) => b.cost - a.cost)
+      .slice(0, 8);
+  }, [tokensByAgent, data?.costByAgent]);
 
   // Time-range-filtered cost from token metrics
   const timeRangeCost = useMemo(() => {
@@ -342,15 +439,21 @@ export function Stats() {
     return [...(data?.notificationStats ?? [])]
       .sort((a, b) => b.message_count - a.message_count)
       .slice(0, 10)
-      .map(c => ({ name: trunc(c.name, 16), messages: c.message_count }));
+      .map(c => ({ name: trunc(c.name, 16), fullName: c.name, messages: c.message_count }));
   }, [data?.notificationStats]);
 
   const costByModelBar = useMemo(() => {
-    return tokensByModel
+    const fromTokens = tokensByModel
       .filter(m => m.cost > 0)
       .slice(0, 8)
       .map(m => ({ name: trunc(m.name, 24), cost: parseFloat(m.cost.toFixed(4)) }));
-  }, [tokensByModel]);
+    if (fromTokens.length) return fromTokens;
+    // Fallback to the all-time model cost ledger when the timeseries is empty.
+    return (data?.costByModel ?? [])
+      .map(m => ({ name: trunc(m.model, 24), cost: m.total_cost_usd }))
+      .filter(m => m.cost > 0)
+      .slice(0, 8);
+  }, [tokensByModel, data?.costByModel]);
 
   const agentTable = useMemo(() => buildAgentTable(data, sortKey, sortAsc), [data, sortKey, sortAsc]);
 
@@ -365,6 +468,41 @@ export function Stats() {
   const avgCpu = agentTable.length > 0 ? agentTable.reduce((s, a) => s + a.cpu, 0) / agentTable.length : 0;
   const totalMem = agentTable.reduce((s, a) => s + a.mem, 0);
   const totalTokens = agentTable.reduce((s, a) => s + a.tokens, 0);
+
+  // ── KPI strip values ─────────────────────────────────────────────────────────
+  const aliveCount = agentTable.filter((a) => ALIVE_STATES.has(a.state)).length;
+  const rangeHours = (RANGES[range]?.seconds ?? 0) / 3600;
+  // Range-scoped spend from the daily cost ledger (used when the per-minute
+  // token timeseries is empty on this deployment). Daily granularity means
+  // sub-day ranges resolve to "today".
+  const rangeSpend = useMemo(
+    () => (data?.costDaily ?? []).reduce((s, d) => s + (d.cost_usd ?? 0), 0),
+    [data?.costDaily],
+  );
+  // Prefer the timeseries-derived spend/tokens; else the range-scoped daily
+  // ledger; else the all-time ledger total as a last resort.
+  const displaySpend =
+    timeRangeCost > 0 ? timeRangeCost : rangeSpend > 0 ? rangeSpend : (data?.costSummary?.total_cost_usd ?? 0);
+  const kpiTokens = totalTokens > 0 ? totalTokens : (data?.costSummary?.total_tokens ?? 0);
+  // Burn rate is spend over the window it actually covers: the token
+  // timeseries spans rangeHours; the daily fallback spans daysForRange*24h.
+  // With only an all-time total (no daily data), a rate is meaningless → "—".
+  const burnHours = timeRangeCost > 0 ? rangeHours : rangeSpend > 0 ? daysForRange * 24 : 0;
+  const burnBase = timeRangeCost > 0 ? timeRangeCost : rangeSpend;
+  const burnRate = burnHours > 0 ? burnBase / burnHours : null;
+  const topCostDriver = agentTable.reduce<AgentRow | null>(
+    (top, a) => (a.cost > 0 && (!top || a.cost > top.cost) ? a : top),
+    null,
+  );
+  const topDriverFallback = (data?.costByAgent ?? []).reduce<AgentCostSummary | null>(
+    (top, a) => (a.total_cost_usd > 0 && (!top || a.total_cost_usd > top.total_cost_usd) ? a : top),
+    null,
+  );
+  const topDriver = topCostDriver && topCostDriver.cost > 0
+    ? { name: topCostDriver.name, cost: topCostDriver.cost }
+    : topDriverFallback
+      ? { name: stripAgentPrefix(topDriverFallback.agent_id), cost: topDriverFallback.total_cost_usd }
+      : null;
 
   // ── Render ──────────────────────────────────────────────────────────────────
 
@@ -390,7 +528,31 @@ export function Stats() {
   ];
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-6">
+      {/* KPI strip — compact derived tiles across the top of the dashboard. */}
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+        <KpiTile label="Spend (this range)" value={fmtCost(displaySpend)} />
+        <KpiTile label="Tokens" value={fmtTokens(kpiTokens)} />
+        <KpiTile label="Active agents" value={`${aliveCount} / ${agentTable.length}`} />
+        <KpiTile label="Burn rate" value={burnRate === null ? "—" : `$${burnRate.toFixed(2)}/hr`} />
+        {topDriver ? (
+          <KpiTile
+            label="Top cost driver"
+            value={topDriver.name}
+            sub={`$${topDriver.cost.toFixed(2)}`}
+            to={`/agents/${encodeURIComponent(topDriver.name)}`}
+          />
+        ) : (
+          <KpiTile label="Top cost driver" value="—" />
+        )}
+      </div>
+
+      {/* Sticky anchor-nav — smooth-scrolls to each section. */}
+      <AnchorNav />
+
+      {/* ── Agents ── */}
+      <section id="agents" className="scroll-mt-16">
+        <SectionHeader label="Agents" count={agentTable.length} />
       {/* Agent Table */}
       {agentTable.length > 0 && (
         <Panel title={`Agents (${agentTable.length})`}>
@@ -463,26 +625,141 @@ export function Stats() {
         </Panel>
       )}
 
-      {/* Legend removed — agent names + swatches are already in the
-          Agents table's Name column immediately above. Interactive legend
-          (hover-to-highlight, click-to-toggle) tracked as P2 on #3205. */}
+      </section>
 
-      {/* Interactive shared legend for the CPU + Memory charts. Hover
-          raises the paired series, click toggles visibility. Both charts
-          key off the same agent set so one legend controls both. */}
-      {(cpuChart.agents.length > 0 || memChart.agents.length > 0) && (
-        <InteractiveLegend
-          agents={cpuChart.agents.length > 0 ? cpuChart.agents : memChart.agents}
-          colors={agentColors}
-          hovered={hoveredAgent}
-          hidden={hiddenAgents}
-          onHover={setHoveredAgent}
-          onToggle={toggleAgent}
-        />
-      )}
+      {/* ── Cost ── */}
+      <section id="cost" className="scroll-mt-16">
+        <SectionHeader label="Cost" count={3} />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <Panel title="Cost Over Time">
+          {costOverTimeData.length === 0 ? <Empty msg="No cost data" /> : (
+            <ResponsiveContainer width="100%" height={200}>
+              <AreaChart data={costOverTimeData} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
+                <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
+                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v.toFixed(2)}`} />
+                <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
+                <Area type="monotone" dataKey="cost" name="Cost" stroke={ACCENT} fill={ACCENT} fillOpacity={0.15} strokeWidth={1.5} dot={false} />
+              </AreaChart>
+            </ResponsiveContainer>
+          )}
+        </Panel>
+        <Panel title="Cost by Agent">
+          {costByAgentData.length === 0 ? <Empty msg="No cost data" /> : (
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart layout="vertical" data={costByAgentData} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
+                <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v}`} />
+                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={100} />
+                <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
+                <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
+                  {costByAgentData.map((a, i) => <Cell key={i} fill={agentColors[a.name] ?? COLORS[i % COLORS.length]} />)}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </Panel>
+        <Panel title="Cost by Model">
+          {costByModelBar.length === 0 ? <Empty msg="No cost data" /> : (
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart layout="vertical" data={costByModelBar} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
+                <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v}`} />
+                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
+                <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
+                <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
+                  {costByModelBar.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </Panel>
+        </div>
+      </section>
 
-      {/* Row 1: CPU + Memory */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      {/* ── Usage ── */}
+      <section id="usage" className="scroll-mt-16">
+        <SectionHeader label="Usage" count={4} />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <Panel title="Token Throughput">
+          {tokenChart.length === 0 ? <Empty msg="No token data" /> : (
+            <ResponsiveContainer width="100%" height={200}>
+              <AreaChart data={tokenChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
+                <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
+                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
+                <Tooltip contentStyle={TT} formatter={(v, n) => [Number(v ?? 0).toLocaleString(), n === "input" ? "Input" : "Output"]} />
+                <Area type="monotone" dataKey="input" name="Input" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.20} strokeWidth={1.75} stackId="1" dot={false} />
+                <Area type="monotone" dataKey="output" name="Output" stroke={ACCENT} fill={ACCENT} fillOpacity={0.20} strokeWidth={1.75} stackId="1" dot={false} />
+              </AreaChart>
+            </ResponsiveContainer>
+          )}
+        </Panel>
+        <Panel title="Model Usage (Tokens)">
+          {tokensByModel.length === 0 ? <Empty msg="No model data" /> : (
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart layout="vertical" data={tokensByModel.slice(0, 8).map(m => ({ name: trunc(m.name, 24), tokens: m.tokens }))} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
+                <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
+                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
+                <Tooltip contentStyle={TT} formatter={(v) => [fmtTokens(Number(v ?? 0))]} />
+                <Bar dataKey="tokens" radius={[0, 3, 3, 0]}>
+                  {tokensByModel.slice(0, 8).map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </Panel>
+        <Panel title="Cache Efficiency">
+          {!hasCacheData ? <Empty msg="Cache data — coming soon" /> : (
+            <ResponsiveContainer width="100%" height={200}>
+              <AreaChart data={cacheChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
+                <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
+                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
+                <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "cache_read" ? "Cache Read" : "Cache Create"]} />
+                <Area type="monotone" dataKey="cache_read" name="Cache Read" stroke="#10B981" fill="#10B981" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
+                <Area type="monotone" dataKey="cache_create" name="Cache Create" stroke="#F59E0B" fill="#F59E0B" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
+              </AreaChart>
+            </ResponsiveContainer>
+          )}
+        </Panel>
+        <Panel title="Agent Token Breakdown">
+          {tokensByAgent.length === 0 ? <Empty msg="No token data" /> : (
+            <ResponsiveContainer width="100%" height={200}>
+              <BarChart data={tokensByAgent.slice(0, 8).map(a => ({ name: trunc(a.name, 12), input: a.input, output: a.output }))} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
+                <XAxis dataKey="name" tick={{ ...TICK_STYLE, fontSize: 9 }} {...AX} />
+                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
+                <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "input" ? "Input" : "Output"]} />
+                <Bar dataKey="input" name="Input" fill="#3B82F6" radius={[3, 3, 0, 0]} />
+                <Bar dataKey="output" name="Output" fill={ACCENT} radius={[3, 3, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </Panel>
+        </div>
+      </section>
+
+      {/* ── System ── */}
+      <section id="system" className="scroll-mt-16">
+        <SectionHeader label="System" count={4} />
+        {/* Interactive shared legend for the CPU + Memory charts. Hover
+            raises the paired series, click toggles visibility. Both charts
+            key off the same agent set so one legend controls both. */}
+        {(cpuChart.agents.length > 0 || memChart.agents.length > 0) && (
+          <div className="mb-3">
+            <InteractiveLegend
+              agents={cpuChart.agents.length > 0 ? cpuChart.agents : memChart.agents}
+              colors={agentColors}
+              hovered={hoveredAgent}
+              hidden={hiddenAgents}
+              onHover={setHoveredAgent}
+              onToggle={toggleAgent}
+            />
+          </div>
+        )}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <Panel title="CPU by Agent (%)">
           {cpuChart.data.length === 0 ? <Empty msg="No CPU data" /> : (
             <ResponsiveContainer width="100%" height={200}>
@@ -543,41 +820,6 @@ export function Stats() {
             </ResponsiveContainer>
           )}
         </Panel>
-      </div>
-
-      {/* Row 2: Token Flow */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <Panel title="Token Throughput">
-          {tokenChart.length === 0 ? <Empty msg="No token data" /> : (
-            <ResponsiveContainer width="100%" height={200}>
-              <AreaChart data={tokenChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
-                <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
-                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
-                <Tooltip contentStyle={TT} formatter={(v, n) => [Number(v ?? 0).toLocaleString(), n === "input" ? "Input" : "Output"]} />
-                <Area type="monotone" dataKey="input" name="Input" stroke="#3B82F6" fill="#3B82F6" fillOpacity={0.20} strokeWidth={1.75} stackId="1" dot={false} />
-                <Area type="monotone" dataKey="output" name="Output" stroke={ACCENT} fill={ACCENT} fillOpacity={0.20} strokeWidth={1.75} stackId="1" dot={false} />
-              </AreaChart>
-            </ResponsiveContainer>
-          )}
-        </Panel>
-        <Panel title="Cost Over Time">
-          {costOverTime.length === 0 ? <Empty msg="No cost data" /> : (
-            <ResponsiveContainer width="100%" height={200}>
-              <AreaChart data={costOverTime} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
-                <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
-                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v.toFixed(2)}`} />
-                <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
-                <Area type="monotone" dataKey="cost" name="Cost" stroke={ACCENT} fill={ACCENT} fillOpacity={0.15} strokeWidth={1.5} dot={false} />
-              </AreaChart>
-            </ResponsiveContainer>
-          )}
-        </Panel>
-      </div>
-
-      {/* Row 3: I/O */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <Panel title="Network I/O">
           {netChart.length === 0 ? <Empty msg="No network data" /> : (
             <ResponsiveContainer width="100%" height={200}>
@@ -606,43 +848,13 @@ export function Stats() {
             </ResponsiveContainer>
           )}
         </Panel>
-      </div>
+        </div>
+      </section>
 
-      {/* Row 4: Model & Cache */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <Panel title="Model Usage (Tokens)">
-          {tokensByModel.length === 0 ? <Empty msg="No model data" /> : (
-            <ResponsiveContainer width="100%" height={200}>
-              <BarChart layout="vertical" data={tokensByModel.slice(0, 8).map(m => ({ name: trunc(m.name, 24), tokens: m.tokens }))} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
-                <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
-                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
-                <Tooltip contentStyle={TT} formatter={(v) => [fmtTokens(Number(v ?? 0))]} />
-                <Bar dataKey="tokens" radius={[0, 3, 3, 0]}>
-                  {tokensByModel.slice(0, 8).map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </Panel>
-        <Panel title="Cache Efficiency">
-          {!hasCacheData ? <Empty msg="Cache data — coming soon" /> : (
-            <ResponsiveContainer width="100%" height={200}>
-              <AreaChart data={cacheChart} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
-                <XAxis dataKey="time" tick={TICK_STYLE} {...AX} />
-                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
-                <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "cache_read" ? "Cache Read" : "Cache Create"]} />
-                <Area type="monotone" dataKey="cache_read" name="Cache Read" stroke="#10B981" fill="#10B981" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
-                <Area type="monotone" dataKey="cache_create" name="Cache Create" stroke="#F59E0B" fill="#F59E0B" fillOpacity={0.20} strokeWidth={1.75} dot={false} />
-              </AreaChart>
-            </ResponsiveContainer>
-          )}
-        </Panel>
-      </div>
-
-      {/* Row 5: Notifications & Cost Breakdown */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      {/* ── Activity ── */}
+      <section id="activity" className="scroll-mt-16">
+        <SectionHeader label="Activity" count={notificationBarData.length} />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <Panel title="Notification Activity (Top 10)">
           {notificationBarData.length === 0 ? <Empty msg="No notification data" /> : (
             <ResponsiveContainer width="100%" height={200}>
@@ -651,62 +863,25 @@ export function Stats() {
                 <XAxis type="number" tick={TICK_STYLE} {...AX} />
                 <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={100} />
                 <Tooltip contentStyle={TT} formatter={(v) => [Number(v ?? 0).toLocaleString(), "Messages"]} />
-                <Bar dataKey="messages" radius={[0, 3, 3, 0]}>
+                {/* Bars drill into the channel's notification feed, matching
+                    the agents table → agent detail pattern. */}
+                <Bar
+                  dataKey="messages"
+                  radius={[0, 3, 3, 0]}
+                  cursor="pointer"
+                  onClick={(entry) => {
+                    const full = (entry as { fullName?: string }).fullName;
+                    if (full) navigate(`/notifications/${encodeURIComponent(full)}`);
+                  }}
+                >
                   {notificationBarData.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
                 </Bar>
               </BarChart>
             </ResponsiveContainer>
           )}
         </Panel>
-        <Panel title="Cost by Agent">
-          {tokensByAgent.length === 0 ? <Empty msg="No cost data" /> : (
-            <ResponsiveContainer width="100%" height={200}>
-              <BarChart layout="vertical" data={tokensByAgent.slice(0, 8).map(a => ({ name: trunc(a.name, 20), cost: parseFloat(a.cost.toFixed(4)) }))} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
-                <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v}`} />
-                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={100} />
-                <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
-                <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
-                  {tokensByAgent.slice(0, 8).map((a, i) => <Cell key={i} fill={agentColors[a.name] ?? COLORS[i % COLORS.length]} />)}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </Panel>
-      </div>
-
-      {/* Row 6: Agent Tokens & Cost by Model */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <Panel title="Agent Token Breakdown">
-          {tokensByAgent.length === 0 ? <Empty msg="No token data" /> : (
-            <ResponsiveContainer width="100%" height={200}>
-              <BarChart data={tokensByAgent.slice(0, 8).map(a => ({ name: trunc(a.name, 12), input: a.input, output: a.output }))} margin={{ top: 4, right: 8, left: -8, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" vertical={false} />
-                <XAxis dataKey="name" tick={{ ...TICK_STYLE, fontSize: 9 }} {...AX} />
-                <YAxis tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => fmtTokens(v)} />
-                <Tooltip contentStyle={TT} formatter={(v, n) => [fmtTokens(Number(v ?? 0)), n === "input" ? "Input" : "Output"]} />
-                <Bar dataKey="input" name="Input" fill="#3B82F6" radius={[3, 3, 0, 0]} />
-                <Bar dataKey="output" name="Output" fill={ACCENT} radius={[3, 3, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </Panel>
-        <Panel title="Cost by Model">
-          {costByModelBar.length === 0 ? <Empty msg="No cost data" /> : (
-            <ResponsiveContainer width="100%" height={200}>
-              <BarChart layout="vertical" data={costByModelBar} margin={{ top: 0, right: 8, left: 4, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="var(--mycel-border)" horizontal={false} />
-                <XAxis type="number" tick={TICK_STYLE} {...AX} tickFormatter={(v: number) => `$${v}`} />
-                <YAxis type="category" dataKey="name" tick={{ ...TICK_STYLE, fill: "var(--mycel-text)", fontSize: 9 }} {...AX} width={120} />
-                <Tooltip contentStyle={TT} formatter={(v) => [`$${Number(v ?? 0).toFixed(4)}`]} />
-                <Bar dataKey="cost" radius={[0, 3, 3, 0]}>
-                  {costByModelBar.map((_, i) => <Cell key={i} fill={COLORS[i % COLORS.length]} />)}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
-          )}
-        </Panel>
-      </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/web/src/views/__tests__/insights.test.tsx
+++ b/web/src/views/__tests__/insights.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { Insights } from "../Insights";
 import { AppRoutes } from "../../App";
@@ -17,13 +17,10 @@ function jsonResponse(body: unknown) {
   } as Response);
 }
 
-/** Route-aware API mock covering both the Stats and Costs tab data. */
+/** Route-aware API mock for the single-page Stats dashboard. */
 function mockApi() {
   fetchMock.mockImplementation((url: RequestInfo | URL) => {
     const u = String(url);
-    if (u.includes("/api/global/costs")) {
-      return jsonResponse({ range: { start: "2026-06-05T00:00:00Z" }, groupBy: "repo", rows: [] });
-    }
     if (u.includes("/api/costs/agents") || u.includes("/api/costs/models")) {
       return jsonResponse([]);
     }
@@ -66,37 +63,36 @@ beforeEach(() => {
 });
 
 describe("Insights", () => {
-  it("defaults to the Metrics tab and renders the Stats view", async () => {
+  it("renders one dashboard with no tab bar", async () => {
     renderInsights();
 
-    expect(screen.getByRole("tab", { name: "Metrics" })).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByRole("tab", { name: "Costs" })).toHaveAttribute("aria-selected", "false");
-    // Stats view content (empty-data panels) arrives once polling settles.
+    // The old Metrics/Costs tab bar is gone.
+    expect(screen.queryByRole("tablist")).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+
+    // Chart panels arrive once polling settles.
     await waitFor(() => expect(screen.getByText("No CPU data")).toBeInTheDocument());
   });
 
-  it("renders the Costs view (with token stats) on ?tab=costs", async () => {
-    renderInsights("/insights?tab=costs");
-
-    expect(screen.getByRole("tab", { name: "Costs" })).toHaveAttribute("aria-selected", "true");
-    await waitFor(() => expect(screen.getByText("No cost data in range.")).toBeInTheDocument());
-    // Token usage presented alongside dollar costs.
-    await waitFor(() => expect(screen.getByText("Total tokens")).toBeInTheDocument());
-    expect(screen.getByText("1.5M")).toBeInTheDocument();
-    expect(screen.getByText("Input tokens")).toBeInTheDocument();
-    expect(screen.getByText("Output tokens")).toBeInTheDocument();
-  });
-
-  it("switches tabs on click", async () => {
+  it("shows the KPI strip", async () => {
     renderInsights();
 
-    fireEvent.click(screen.getByRole("tab", { name: "Costs" }));
-    expect(screen.getByRole("tab", { name: "Costs" })).toHaveAttribute("aria-selected", "true");
-    await waitFor(() => expect(screen.getByText("No cost data in range.")).toBeInTheDocument());
+    // The dashboard mounts once the first poll settles (a skeleton shows
+    // until then), so wait for a KPI tile label to appear.
+    await waitFor(() => expect(screen.getByText("Spend (this range)")).toBeInTheDocument());
+    expect(screen.getByText("Active agents")).toBeInTheDocument();
+    expect(screen.getByText("Burn rate")).toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByRole("tab", { name: "Metrics" }));
-    expect(screen.getByRole("tab", { name: "Metrics" })).toHaveAttribute("aria-selected", "true");
+  it("renders the grouped section headers", async () => {
+    renderInsights();
+
+    // Section headers double as anchor-nav targets; the pill labels and
+    // the headers share text, so each label appears at least once.
     await waitFor(() => expect(screen.getByText("No CPU data")).toBeInTheDocument());
+    for (const label of ["Cost", "Usage", "System", "Activity"]) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0);
+    }
   });
 });
 
@@ -112,23 +108,23 @@ describe("Insights redirects", () => {
     );
   }
 
-  it("redirects /costs to /insights?tab=costs", async () => {
+  it("redirects /costs to /insights", async () => {
     renderApp("/costs");
     await waitFor(() =>
-      expect(screen.getByTestId("loc")).toHaveTextContent("/insights?tab=costs"),
+      expect(screen.getByTestId("loc")).toHaveTextContent("/insights"),
     );
   });
 
-  it("redirects /stats and /metrics to /insights?tab=metrics", async () => {
+  it("redirects /stats and /metrics to /insights", async () => {
     const { unmount } = renderApp("/stats");
     await waitFor(() =>
-      expect(screen.getByTestId("loc")).toHaveTextContent("/insights?tab=metrics"),
+      expect(screen.getByTestId("loc")).toHaveTextContent("/insights"),
     );
     unmount();
 
     renderApp("/metrics");
     await waitFor(() =>
-      expect(screen.getByTestId("loc")).toHaveTextContent("/insights?tab=metrics"),
+      expect(screen.getByTestId("loc")).toHaveTextContent("/insights"),
     );
   });
 });

--- a/web/src/views/__tests__/insights.test.tsx
+++ b/web/src/views/__tests__/insights.test.tsx
@@ -21,13 +21,67 @@ function jsonResponse(body: unknown) {
 function mockApi() {
   fetchMock.mockImplementation((url: RequestInfo | URL) => {
     const u = String(url);
-    if (u.includes("/api/costs/agents") || u.includes("/api/costs/models")) {
-      return jsonResponse([]);
+    // Per-agent cost ledger — the single source of truth for the agents
+    // table token/cost columns, Cost by Agent, and Agent Token Breakdown.
+    if (u.includes("/api/costs/agents")) {
+      return jsonResponse([
+        {
+          agent_id: "bc-bc-bot-1",
+          total_cost_usd: 8.5,
+          input_tokens: 800_000,
+          output_tokens: 200_000,
+          cache_read_tokens: 400_000,
+          cache_write_tokens: 50_000,
+          total_tokens: 1_000_000,
+          record_count: 30,
+        },
+        {
+          agent_id: "bc-bc-bot-2",
+          total_cost_usd: 3.84,
+          input_tokens: 400_000,
+          output_tokens: 100_000,
+          cache_read_tokens: 100_000,
+          cache_write_tokens: 20_000,
+          total_tokens: 500_000,
+          record_count: 12,
+        },
+      ]);
     }
+    // Per-model cost ledger — Cost by Model + Model Usage (Tokens).
+    if (u.includes("/api/costs/models")) {
+      return jsonResponse([
+        {
+          model: "claude-opus-4-6",
+          total_cost_usd: 10.0,
+          input_tokens: 900_000,
+          output_tokens: 250_000,
+          total_tokens: 1_150_000,
+          record_count: 24,
+        },
+        {
+          model: "claude-sonnet-4-6",
+          total_cost_usd: 2.34,
+          input_tokens: 300_000,
+          output_tokens: 50_000,
+          total_tokens: 350_000,
+          record_count: 18,
+        },
+      ]);
+    }
+    // Daily cost ledger — Cost Over Time, Token Throughput, Spend/Tokens/Burn.
+    if (u.includes("/api/costs/daily")) {
+      return jsonResponse([
+        { date: "2026-07-04", cost_usd: 5.0, total_tokens: 700_000, input_tokens: 560_000, output_tokens: 140_000, record_count: 20 },
+        { date: "2026-07-05", cost_usd: 7.34, total_tokens: 800_000, input_tokens: 640_000, output_tokens: 160_000, record_count: 22 },
+      ]);
+    }
+    // Cost summary — cache efficiency headline + totals.
     if (u.includes("/api/costs")) {
       return jsonResponse({
         input_tokens: 1_200_000,
         output_tokens: 300_000,
+        cache_read_tokens: 500_000,
+        cache_write_tokens: 70_000,
         total_tokens: 1_500_000,
         total_cost_usd: 12.34,
         record_count: 42,
@@ -82,6 +136,16 @@ describe("Insights", () => {
     await waitFor(() => expect(screen.getByText("Spend (this range)")).toBeInTheDocument());
     expect(screen.getByText("Active agents")).toBeInTheDocument();
     expect(screen.getByText("Burn rate")).toBeInTheDocument();
+  });
+
+  it("wires KPIs off the cost ledger", async () => {
+    renderInsights();
+
+    // Spend sums the daily ledger (5.00 + 7.34 = 12.34); the top cost driver
+    // is the biggest per-agent spender with its "bc-bc-" prefix stripped.
+    await waitFor(() => expect(screen.getByText("Top cost driver")).toBeInTheDocument());
+    expect(screen.getByText("bot-1")).toBeInTheDocument();
+    expect(screen.getByText("$12.34")).toBeInTheDocument();
   });
 
   it("renders the grouped section headers", async () => {


### PR DESCRIPTION
## Summary
Redesigns Insights into ONE single-page dashboard (no tabs), sources **all** cost/token data from the cost ledger, and **deletes the dead stats-store token/cost path** so it can't mislead future readers.

### Dashboard
- KPI strip (Spend · Tokens · Active agents · Burn rate · Top cost driver) + sticky Agents·Cost·Usage·System·Activity anchor-nav; range picker in header; regrouped panels under labeled sections.
- Drill-downs: agents table → `/agents/:name`; notification bars → `/notifications/:channel`.

### Proper cost/token data (was a pre-existing bug — the old tabbed view showed empty charts too)
The cost/token charts read `/api/agents/stats/{tokens,cost}` — a per-agent timeseries whose collector was misrouted and never computed cost, so it always returned `[]`. The real data is in the cost ledger `/api/costs/*`. Now everything sources from the ledger: cost over time / by agent / by model, Usage (token throughput, model/agent tokens, aggregate Cache Efficiency), the agents-table token/cost columns, and the KPIs. Fixed `DailyCost.cost_usd` (was `total_cost_usd` — every daily read was `undefined`). Spend + burn are range-scoped.

### Dead code deleted
- `server/stats_collector.go` token-collection block (resource sampling kept); `build_services.go` call site.
- `/api/agents/stats/{tokens,cost}` handlers + routes.
- `pkg/stats`: `RecordToken`, `QueryAgentTokens`, `QueryAgentCost`, the `TokenMetric` type and `token_metrics` table; `QueryAgentSummary` is resource-only now.
- Frontend `getAgentTokenStats`/`getAgentCostStats` + `TokenMetricTS`, and the two `StatsTab` charts that fed on them (its resource + activity views and summary cards stay).

## Testing
- Playwright (light + dark, 1h/7d/30d): every Insights panel shows real ledger data — Cost, Usage (incl. 99.9% cache hit ratio), Agent Token Breakdown, Model Usage; agents table tokens/cost populated; anchor-nav + drill-downs work. AgentDetail Metrics tab renders resource + activity data with no dead empty charts.
- `go build ./...` + `go vet` clean; `bun run build/test/lint` — 158 tests pass, clean.
- Net −245 lines.

Closes #3320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Insights dashboard now opens as a single, streamlined analytics view.
  * Cost and usage visuals were reorganized into clearer sections with updated summary cards and drill-down navigation.

* **Bug Fixes**
  * Legacy stats and cost links now redirect cleanly to Insights without extra tab parameters.
  * Some cost and token displays now use more consistent totals and labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->