### PR TITLE
feat(web): notifications pills + full activity page

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ const Live = lazy(() => import("./views/Live").then((m) => ({ default: m.Live })
 const Agents = lazy(() => import("./views/Agents").then((m) => ({ default: m.Agents })));
 const AgentDetail = lazy(() => import("./views/AgentDetail").then((m) => ({ default: m.AgentDetail })));
 const Notifications = lazy(() => import("./views/Notifications").then((m) => ({ default: m.Notifications })));
+const NotificationActivity = lazy(() => import("./views/NotificationActivity").then((m) => ({ default: m.NotificationActivity })));
 const Templates = lazy(() => import("./views/Templates").then((m) => ({ default: m.Templates })));
 const Tools = lazy(() => import("./views/Tools").then((m) => ({ default: m.Tools })));
 const ProviderDetail = lazy(() => import("./views/ProviderDetail").then((m) => ({ default: m.ProviderDetail })));
@@ -59,6 +60,7 @@ export function AppRoutes() {
         <Route path="agents/:name" element={wrap(<AgentDetail />)} />
         <Route path="agents/:name/*" element={wrap(<AgentDetail />)} />
         <Route path="notifications" element={wrap(<Notifications />)} />
+        <Route path="notifications/activity" element={wrap(<NotificationActivity />)} />
         <Route path="notifications/:sourceName" element={wrap(<Notifications />)} />
         <Route path="templates" element={wrap(<Templates />)} />
         <Route path="tools" element={wrap(<Tools />)} />

--- a/web/src/components/notifications/NotificationsHome.tsx
+++ b/web/src/components/notifications/NotificationsHome.tsx
@@ -16,7 +16,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { api } from "../../api/client";
 import type {
   ChannelMessage,
@@ -624,54 +624,59 @@ export function NotificationsHome() {
   return (
     <div className="h-full overflow-y-auto">
       <div className="p-6 pb-24 space-y-6">
-        {/* ── Apps strip ─────────────────────────────────────── */}
-        <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))" }}>
+        {/* ── Apps strip — compact pills ─────────────────────── */}
+        <div className="flex flex-wrap gap-2">
           {apps.map((app) => {
             const ago = app.lastActivity !== null ? formatRelative(app.lastActivity) : null;
+            const selected = appSel.has(app.key);
+            const isError = app.status === "error";
+            const name = app.botName ?? app.label;
+            const statusLabel =
+              app.status === "connected" ? "connected"
+                : app.status === "connecting" ? "connecting"
+                : app.status === "error" ? "disconnected"
+                : "idle";
+            // Icon carries the platform, so the label text is dropped — the
+            // aria-label restores platform + name + status for screen readers.
+            const aria = isError
+              ? `${app.label}${app.botName ? ` (${app.botName})` : ""} — ${app.reason ?? "disconnected"}, reconnect`
+              : `${app.label}${app.botName ? ` (${app.botName})` : ""} — ${statusLabel}${ago ? `, active ${ago}` : ""}`;
             return (
-              <div key={app.key} data-testid={`app-card-${app.key}`} className="rounded-lg border border-mycel-border bg-mycel-surface shadow-mycel-sm p-3 flex flex-col gap-1.5 min-w-0">
-                <div className="flex items-center gap-2 min-w-0">
-                  <AppIcon base={app.base} size={15} />
-                  <span className="truncate text-[13px] font-semibold text-mycel-text">{app.label}</span>
-                  {app.botName && (
-                    <span className="truncate text-[10.5px] text-mycel-muted">· {app.botName}</span>
-                  )}
-                  <span className="ml-auto shrink-0 flex items-center">
-                    <StatusDot status={app.status} title={app.status} />
-                  </span>
-                </div>
-                {app.status === "error" ? (
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span className="truncate text-[11px] text-mycel-error">{app.reason}</span>
-                    <button
-                      type="button"
-                      onClick={() => { setSetupPlatform(app.base); }}
-                      className="ml-auto shrink-0 inline-flex items-center h-6 px-2 text-[11px] font-medium rounded-md border border-mycel-border text-mycel-text-2 hover:text-mycel-text hover:border-mycel-accent transition-colors"
-                    >
-                      Reconnect
-                    </button>
-                  </div>
-                ) : (
-                  <span className="text-[11px] text-mycel-muted">
-                    {app.status === "connected" ? "Connected" : app.status === "connecting" ? "Connecting…" : "Not connected"}
-                  </span>
-                )}
-                <span className="text-[11px] text-mycel-muted tabular-nums">
-                  {String(app.channelCount)} channel{app.channelCount === 1 ? "" : "s"}
-                  {ago ? ` · active ${ago}` : ""}
-                </span>
-              </div>
+              <button
+                key={app.key}
+                type="button"
+                data-testid={`app-pill-${app.key}`}
+                onClick={() => { if (isError) { setSetupPlatform(app.base); } else { toggleApp(app.key); } }}
+                aria-label={aria}
+                aria-pressed={selected}
+                title={aria}
+                className={`inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-sm transition-colors ${
+                  selected
+                    ? "border-mycel-accent bg-mycel-surface-hover text-mycel-text"
+                    : "border-mycel-border bg-mycel-surface hover:bg-mycel-surface-hover text-mycel-text"
+                }`}
+              >
+                <StatusDot status={app.status} title={statusLabel} />
+                <AppIcon base={app.base} size={15} />
+                <span className="truncate max-w-[160px] font-medium">{name}</span>
+                {isError ? (
+                  <span className="truncate max-w-[180px] text-[12px] text-mycel-error">{app.reason}</span>
+                ) : ago ? (
+                  <span className="text-[12px] text-mycel-muted tabular-nums">{ago}</span>
+                ) : null}
+              </button>
             );
           })}
           <button
             type="button"
             onClick={() => { setChooserOpen(true); }}
-            className="rounded-lg border border-dashed border-mycel-border p-3 flex items-center justify-center gap-2 text-xs text-mycel-muted hover:text-mycel-text hover:border-mycel-accent transition-colors min-h-[72px]"
+            aria-label="Connect an app"
+            className="inline-flex items-center gap-1.5 rounded-full border border-dashed border-mycel-border bg-mycel-surface px-3 py-1.5 text-sm text-mycel-muted hover:text-mycel-text hover:border-mycel-accent hover:bg-mycel-surface-hover transition-colors"
           >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" aria-hidden>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden>
               <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
             </svg>
-            Connect an app
+            Connect
           </button>
         </div>
 
@@ -692,9 +697,12 @@ export function NotificationsHome() {
               return (
                 <section key={app.key} aria-label={`${app.label} channels`}>
                   <div className="flex items-center gap-2 mb-1.5">
+                    {/* Icon conveys the platform — the redundant platform word
+                        is dropped; the section aria-label keeps it for a11y. */}
                     <AppIcon base={app.base} size={13} />
                     <h3 className="text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">
-                      {app.label}{app.botName ? ` · ${app.botName}` : ""}
+                      <span className="sr-only">{app.label}</span>
+                      {app.botName ? <span>{app.botName}</span> : null}
                     </h3>
                     <span className="text-[11px] text-mycel-muted tabular-nums">{chs.length}</span>
                   </div>
@@ -731,9 +739,14 @@ export function NotificationsHome() {
 
           {/* Right rail — recent activity across all channels */}
           <aside className="rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden" aria-label="Recent activity">
-            <div className="px-3 py-2 border-b border-mycel-border">
+            <Link
+              to="/notifications/activity"
+              className="flex items-center gap-2 px-3 py-2 border-b border-mycel-border hover:bg-mycel-surface-hover transition-colors"
+              aria-label="View all activity"
+            >
               <h3 className="text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">Recent activity</h3>
-            </div>
+              <span className="ml-auto text-[11px] font-medium text-mycel-accent">View all →</span>
+            </Link>
             <div className="divide-y divide-mycel-border">
               {recent.length === 0 && (
                 <div className="px-3 py-6 text-center text-xs text-mycel-muted">No messages yet</div>

--- a/web/src/views/NotificationActivity.tsx
+++ b/web/src/views/NotificationActivity.tsx
@@ -1,0 +1,248 @@
+/**
+ * NotificationActivity — the full-page view behind the home page's
+ * "Recent activity" rail (#3310 follow-up). It shows a richer, deeper
+ * feed of the newest messages across every gateway channel with more
+ * controls than the inline preview:
+ *
+ *   • filter by app / platform
+ *   • filter by channel
+ *   • free-text search over sender + content
+ *
+ * The controls live in the shared Header via useHeaderSlot, consistent
+ * with the rest of the app. Data reuses the same endpoints and helpers
+ * the home rail composes from — just a wider net (more channels, more
+ * messages each).
+ */
+
+import { useCallback, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { api } from "../api/client";
+import type {
+  ChannelMessage,
+  ChannelStats,
+  NotificationSource,
+} from "../api/client";
+import { usePolling } from "../hooks/usePolling";
+import { useHeaderSlot } from "../context/HeaderSlotContext";
+import { EmptyState } from "../components/EmptyState";
+import { LoadingSkeleton } from "../components/LoadingSkeleton";
+import { MessageContent } from "../components/MessageContent";
+import { DefaultAppIcon, PLATFORM_ICON_MAP } from "../components/notifications/PlatformIcons";
+import { channelLeaf } from "../components/notifications/NotificationsHome";
+import { agentColor, sourcePlatform } from "../components/notifications/messageUtils";
+import { parseActivityTs } from "../components/notifications/appStatus";
+import { formatRelative } from "../utils/time";
+
+/* ── Config ──────────────────────────────────────────────────── */
+
+// Wider net than the home rail's 6×10 preview: pull recent history from
+// more channels and more messages per channel for a real feed.
+const CHANNEL_LIMIT = 24;
+const PER_CHANNEL = 25;
+const MAX_MESSAGES = 300;
+
+interface ActivityMessage extends ChannelMessage {
+  channel: string;
+}
+
+/** Strip "[telegram] " style prefixes for cleaner sender display. */
+function cleanSender(sender: string): string {
+  const match = /^\[[a-z]+\]\s*(.+)$/i.exec(sender);
+  return match?.[1] ?? sender;
+}
+
+function AppIcon({ base, size }: { base: string; size: number }) {
+  const Icon = PLATFORM_ICON_MAP[base] ?? DefaultAppIcon;
+  return <Icon size={size} />;
+}
+
+/* ── Component ───────────────────────────────────────────────── */
+
+export function NotificationActivity() {
+  const navigate = useNavigate();
+
+  const fetcher = useCallback(async (): Promise<ActivityMessage[]> => {
+    const [sources, stats] = await Promise.all([
+      api.listNotificationSources().catch(() => [] as NotificationSource[]),
+      api.getStatsChannels().catch(() => [] as ChannelStats[]),
+    ]);
+    const gwSources = (sources ?? []).filter((s) => sourcePlatform(s.name) !== "internal");
+    const statByName = new Map((stats ?? []).map((s) => [s.name, s]));
+    const ranked = [...gwSources]
+      .sort((a, b) => {
+        const ta = parseActivityTs(statByName.get(a.name)?.last_activity) ?? 0;
+        const tb = parseActivityTs(statByName.get(b.name)?.last_activity) ?? 0;
+        return tb - ta;
+      })
+      .slice(0, CHANNEL_LIMIT);
+    const histories = await Promise.all(
+      ranked.map(async (ch) => {
+        const msgs = await api.getChannelHistory(ch.name, PER_CHANNEL).catch(() => [] as ChannelMessage[]);
+        return (msgs ?? []).map((m) => ({ ...m, channel: ch.name }));
+      }),
+    );
+    return histories
+      .flat()
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, MAX_MESSAGES);
+  }, []);
+
+  const { data, loading, error, refresh } = usePolling(fetcher, 15000);
+  const messages = useMemo(() => data ?? [], [data]);
+
+  const [search, setSearch] = useState("");
+  const [platform, setPlatform] = useState("");
+  const [channel, setChannel] = useState("");
+
+  // Distinct platforms / channels present in the current feed drive the
+  // filter dropdowns — no separate metadata fetch needed.
+  const platforms = useMemo(() => {
+    const set = new Set<string>();
+    for (const m of messages) set.add(sourcePlatform(m.channel));
+    return [...set].sort();
+  }, [messages]);
+
+  const channels = useMemo(() => {
+    const set = new Set<string>();
+    for (const m of messages) {
+      if (!platform || sourcePlatform(m.channel) === platform) set.add(m.channel);
+    }
+    return [...set].sort();
+  }, [messages, platform]);
+
+  const query = search.trim().toLowerCase();
+  const filtered = useMemo(() => {
+    return messages.filter((m) => {
+      if (platform && sourcePlatform(m.channel) !== platform) return false;
+      if (channel && m.channel !== channel) return false;
+      if (query && !m.content.toLowerCase().includes(query) && !m.sender.toLowerCase().includes(query)) return false;
+      return true;
+    });
+  }, [messages, platform, channel, query]);
+
+  const hasFilters = query !== "" || platform !== "" || channel !== "";
+
+  /* ── Header slot: back + count · search · platform · channel ─── */
+  useHeaderSlot({
+    title: (
+      <div className="flex items-center min-w-0 gap-2">
+        <button
+          type="button"
+          onClick={() => { navigate(-1); }}
+          className="flex items-center justify-center shrink-0 w-[22px] h-[22px] rounded-md text-mycel-muted hover:text-mycel-text"
+          title="Go back"
+          aria-label="Go back"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        <span className="truncate text-[13px] font-semibold text-mycel-text">Activity</span>
+        <span className="shrink-0 text-xs text-mycel-muted tabular-nums">
+          {hasFilters ? `${String(filtered.length)} of ${String(messages.length)}` : `${String(messages.length)} message${messages.length === 1 ? "" : "s"}`}
+        </span>
+      </div>
+    ),
+    actions: (
+      <>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); }}
+          placeholder="Search messages"
+          className="flex-1 min-w-[96px] max-w-md h-9 px-3 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
+          aria-label="Search messages"
+        />
+        <select
+          value={platform}
+          onChange={(e) => { setPlatform(e.target.value); setChannel(""); }}
+          className="shrink-0 h-9 px-2 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent"
+          aria-label="Filter by app"
+        >
+          <option value="">All apps</option>
+          {platforms.map((p) => (
+            <option key={p} value={p}>{p}</option>
+          ))}
+        </select>
+        <select
+          value={channel}
+          onChange={(e) => { setChannel(e.target.value); }}
+          className="shrink-0 h-9 px-2 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent max-w-[180px]"
+          aria-label="Filter by channel"
+        >
+          <option value="">All channels</option>
+          {channels.map((c) => (
+            <option key={c} value={c}>{channelLeaf(c)}</option>
+          ))}
+        </select>
+      </>
+    ),
+  });
+
+  /* ── States ─────────────────────────────────────────────────── */
+
+  if (loading && !data) {
+    return (
+      <div className="p-6">
+        <LoadingSkeleton variant="text" rows={10} />
+      </div>
+    );
+  }
+  if (error && !data) {
+    return (
+      <div className="p-6">
+        <EmptyState icon="!" title="Failed to load activity" description={error} actionLabel="Retry" onAction={refresh} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="mx-auto max-w-3xl p-6 pb-24">
+        {filtered.length === 0 ? (
+          <div className="rounded-lg border border-mycel-border p-10 text-center text-sm text-mycel-muted">
+            {hasFilters ? "No messages match the current filters." : "No messages yet."}
+          </div>
+        ) : (
+          <ul className="rounded-lg border border-mycel-border overflow-hidden divide-y divide-mycel-border bg-mycel-surface">
+            {filtered.map((m) => {
+              const color = agentColor(m.sender);
+              const sender = cleanSender(m.sender);
+              return (
+                <li key={`${m.channel}:${String(m.id)}`}>
+                  <Link
+                    to={`/notifications/${m.channel}`}
+                    className="flex gap-3 px-4 py-3 hover:bg-mycel-surface-hover transition-colors"
+                  >
+                    <span
+                      className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-semibold shrink-0"
+                      style={{ backgroundColor: `${color}20`, color }}
+                      aria-hidden
+                    >
+                      {sender.charAt(0).toUpperCase()}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="font-medium text-sm text-mycel-text truncate">{sender}</span>
+                        <span className="flex items-center gap-1 shrink-0 text-[11px] text-mycel-muted min-w-0">
+                          <AppIcon base={sourcePlatform(m.channel)} size={11} />
+                          <span className="truncate max-w-[160px]">{channelLeaf(m.channel)}</span>
+                        </span>
+                        <time className="ml-auto shrink-0 text-[11px] text-mycel-muted tabular-nums" title={new Date(m.created_at).toLocaleString()}>
+                          {formatRelative(m.created_at)}
+                        </time>
+                      </div>
+                      <div className="mt-0.5 text-sm text-mycel-text-2 break-words whitespace-pre-wrap leading-[1.6]">
+                        <MessageContent content={m.content} />
+                      </div>
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/views/__tests__/notificationActivity.test.tsx
+++ b/web/src/views/__tests__/notificationActivity.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HeaderSlotProvider, useHeaderSlotContext } from "../../context/HeaderSlotContext";
+import { NotificationActivity } from "../NotificationActivity";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+const NOW = new Date().toISOString();
+const SLACK_CH = "slack:general";
+const TG_CH = "telegram:standup";
+
+const sources = [
+  { name: SLACK_CH, description: "", members: [], member_count: 0 },
+  { name: TG_CH, description: "", members: [], member_count: 0 },
+];
+const stats = [
+  { name: SLACK_CH, message_count: 2, member_count: 0, last_activity: NOW, top_senders: [] },
+  { name: TG_CH, message_count: 1, member_count: 0, last_activity: NOW, top_senders: [] },
+];
+const slackHistory = [
+  { id: 1, sender: "alice", content: "ship it", created_at: NOW },
+];
+const tgHistory = [
+  { id: 2, sender: "[telegram] Bob", content: "standup in 5", created_at: NOW },
+];
+
+function mockRoutes() {
+  fetchMock.mockImplementation((url: RequestInfo | URL) => {
+    const u = String(url);
+    if (u.includes("/history")) {
+      if (u.includes(encodeURIComponent(SLACK_CH)) || u.includes(SLACK_CH)) return jsonResponse(slackHistory);
+      if (u.includes(encodeURIComponent(TG_CH)) || u.includes(TG_CH)) return jsonResponse(tgHistory);
+      return jsonResponse([]);
+    }
+    if (u.includes("/stats/channels")) return jsonResponse(stats);
+    if (u.includes("/api/channels")) return jsonResponse(sources);
+    return jsonResponse([]);
+  });
+}
+
+function HeaderHost() {
+  const { slot } = useHeaderSlotContext();
+  return (
+    <div data-testid="header-host">
+      {slot.title}
+      {slot.actions}
+    </div>
+  );
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <HeaderSlotProvider>
+        <HeaderHost />
+        <NotificationActivity />
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("NotificationActivity", () => {
+  it("renders messages across channels with search and filter controls", async () => {
+    mockRoutes();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("ship it")).toBeInTheDocument();
+    });
+    expect(screen.getByText("standup in 5")).toBeInTheDocument();
+    // Telegram sender prefix is cleaned.
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+
+    // Controls live in the shared header slot.
+    expect(screen.getByLabelText("Search messages")).toBeInTheDocument();
+    expect(screen.getByLabelText("Filter by app")).toBeInTheDocument();
+    expect(screen.getByLabelText("Filter by channel")).toBeInTheDocument();
+  });
+
+  it("filters by search over sender and content", async () => {
+    mockRoutes();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("ship it")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Search messages"), { target: { value: "standup" } });
+    expect(screen.getByText("standup in 5")).toBeInTheDocument();
+    expect(screen.queryByText("ship it")).not.toBeInTheDocument();
+  });
+
+  it("filters by platform", async () => {
+    mockRoutes();
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("ship it")).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Filter by app"), { target: { value: "telegram" } });
+    expect(screen.getByText("standup in 5")).toBeInTheDocument();
+    expect(screen.queryByText("ship it")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/views/__tests__/notificationsHome.test.tsx
+++ b/web/src/views/__tests__/notificationsHome.test.tsx
@@ -211,14 +211,17 @@ describe("NotificationsHome", () => {
       expect(screen.getByText("Family Group")).toBeInTheDocument();
     });
 
-    // Apps strip: one card per app, connection state + reconnect where broken.
-    const waCard = screen.getByTestId("app-card-whatsapp");
-    expect(within(waCard).getByText("Connected")).toBeInTheDocument();
-    const slackCard = screen.getByTestId("app-card-slack");
-    expect(within(slackCard).getByText("Invalid credentials")).toBeInTheDocument();
-    expect(within(slackCard).getByRole("button", { name: "Reconnect" })).toBeInTheDocument();
+    // Apps strip: one compact pill per app. "Connected"/"N channels" text is
+    // dropped — the status dot + aria-label carry it. Broken apps show their
+    // reason inline and click straight through to reconnect.
+    const waPill = screen.getByTestId("app-pill-whatsapp");
+    expect(waPill).toHaveAttribute("aria-label", expect.stringContaining("connected"));
+    expect(within(waPill).queryByText("Connected")).not.toBeInTheDocument();
+    const slackPill = screen.getByTestId("app-pill-slack");
+    expect(within(slackPill).getByText("Invalid credentials")).toBeInTheDocument();
+    expect(slackPill).toHaveAttribute("aria-label", expect.stringContaining("reconnect"));
 
-    // Connect-an-app card reuses the existing setup flow.
+    // Connect pill reuses the existing setup flow.
     expect(screen.getByRole("button", { name: /Connect an app/ })).toBeInTheDocument();
 
     // Channel rows show resolved display names and counts.
@@ -301,5 +304,15 @@ describe("NotificationsHome", () => {
     });
     // Sender is cleaned of its platform prefix.
     expect(screen.getByText("Mom")).toBeInTheDocument();
+  });
+
+  it("links recent activity out to the full activity page", async () => {
+    mockRoutes();
+    renderHome();
+    await waitFor(() => {
+      expect(screen.getByText("Family Group")).toBeInTheDocument();
+    });
+    const viewAll = screen.getByRole("link", { name: /View all activity/i });
+    expect(viewAll).toHaveAttribute("href", "/notifications/activity");
   });
 });


### PR DESCRIPTION
## Summary

Density pass on the Notifications home plus a real destination for recent activity (Puneet's UI feedback).

### Changes
- **App cards → compact pills.** Each gateway renders as a rounded-full pill: status dot + platform icon + gateway name + relative last-activity. Dropped the redundant "Connected" state text and the "N channels" count. Pills toggle the app's channel filter; broken apps click straight through to reconnect (reason shown inline in error color). Icon-only pills carry an `aria-label` with platform + name + status. Laid out in a `flex flex-wrap gap-2` row.
- **"+ Connect" pill.** The connect-an-app card is now a matching rounded-full pill driving the existing `SetupWizard`/`PlatformChooser` flow.
- **Redundancy removed in the lists.** Channel section headers no longer repeat the platform word next to the platform icon; the platform name is kept as an `sr-only` label so the section heading stays accessible.
- **Recent activity → full page.** The recent-activity rail header links to a new `/notifications/activity` route. The inline preview stays on the home page.
- **New `NotificationActivity` view.** A richer, deeper feed of recent messages across every gateway channel with more controls — search over sender/content, filter by app/platform, filter by channel — all injected into the shared Header via `useHeaderSlot`. Reuses existing endpoints (`listNotificationSources`, `getStatsChannels`, `getChannelHistory`), helpers (`sourcePlatform`, `channelLeaf`, `agentColor`, `parseActivityTs`), `MessageContent`, and `mycel-*` tokens.
- Route wired in `App.tsx` (static `notifications/activity` before `notifications/:sourceName`).

### Files
- `web/src/components/notifications/NotificationsHome.tsx` — pills, connect pill, section-header redundancy removal, View-all link.
- `web/src/views/NotificationActivity.tsx` — new page.
- `web/src/App.tsx` — lazy import + route.
- `web/src/views/__tests__/notificationsHome.test.tsx` — updated pill assertions + View-all link test.
- `web/src/views/__tests__/notificationActivity.test.tsx` — new tests (render, search filter, platform filter).

### Validation
- `bun run test` — 14 files, 162 tests pass.
- `bun run build` — clean.
- `bun run lint` — clean.

Closes #3325

🤖 Generated with [Claude Code](https://claude.com/claude-code)