### PR TITLE
feat(web): collapse stopped agents per repo on the Agents page

### DIFF
--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -109,6 +109,26 @@ function TrashIcon() {
   );
 }
 
+/** Chevron — rotates 90° when the stopped-agents section is expanded. */
+function ChevronRightIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={`transition-transform duration-150 shrink-0${expanded ? " rotate-90" : ""}`}
+    >
+      <path d="M4 2.5l4 3.5-4 3.5" />
+    </svg>
+  );
+}
+
 /** Eye — peek row collapsed; clicking reveals the activity feed. */
 function EyeIcon() {
   return (
@@ -466,6 +486,19 @@ export function Agents() {
     });
   }, []);
 
+  // Per-repo stopped-section expand state.
+  // Default: empty set = all stopped sections collapsed.
+  // Add a repo key to reveal its stopped agents.
+  const [expandedStoppedRepos, setExpandedStoppedRepos] = useState<Set<string>>(new Set());
+  const toggleStoppedExpanded = useCallback((repoKey: string) => {
+    setExpandedStoppedRepos(prev => {
+      const next = new Set(prev);
+      if (next.has(repoKey)) next.delete(repoKey);
+      else next.add(repoKey);
+      return next;
+    });
+  }, []);
+
   // Search + filter + bulk state (URL-synced where useful)
   const [search, setSearch] = useState(searchParams.get("q") ?? "");
   const roleFilter = searchParams.get("role") ?? "";
@@ -672,6 +705,18 @@ export function Agents() {
       stats.set(key, s);
     }
     return stats;
+  }, [displayRows]);
+
+  // Stopped-agent count per repo group — drives the "N stopped" toggle label.
+  const stoppedCountByRepo = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const a of displayRows) {
+      if (a.state === "stopped" || a.state === "error") {
+        const k = a.repo ?? "";
+        m.set(k, (m.get(k) ?? 0) + 1);
+      }
+    }
+    return m;
   }, [displayRows]);
 
   // Clamp focusIndex when displayRows shrinks (e.g. after filtering).
@@ -1101,8 +1146,50 @@ export function Agents() {
                       </td>
                     </tr>
                   )}
-                  {/* Subtle divider between active and stopped groups */}
-                  {rowIdx > 0 &&
+                  {/* Stopped-agents collapse toggle (groupByRepo mode).
+                      Appears at the start of the stopped section within
+                      each repo group. Default: collapsed. */}
+                  {(() => {
+                    if (!groupByRepo) return null;
+                    const repoKey = a.repo ?? "";
+                    const isStopped = a.state === "stopped" || a.state === "error";
+                    if (!isStopped) return null;
+                    const prevRow = displayRows[rowIdx - 1];
+                    const prevStopped = prevRow
+                      ? prevRow.state === "stopped" || prevRow.state === "error"
+                      : false;
+                    const prevRepoKey = prevRow ? (prevRow.repo ?? "") : "";
+                    // Show toggle at the boundary: active→stopped OR new group starting with stopped.
+                    const isFirstStoppedInGroup = !prevStopped || prevRepoKey !== repoKey;
+                    if (!isFirstStoppedInGroup) return null;
+                    const count = stoppedCountByRepo.get(repoKey) ?? 0;
+                    const expanded = expandedStoppedRepos.has(repoKey);
+                    return (
+                      <tr>
+                        <td colSpan={columns.length} className="px-4 py-0 border-b border-mycel-border">
+                          <button
+                            type="button"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              toggleStoppedExpanded(repoKey);
+                            }}
+                            aria-expanded={expanded}
+                            aria-label={expanded ? `Collapse stopped agents` : `Expand ${String(count)} stopped agent${count === 1 ? "" : "s"}`}
+                            className="flex items-center gap-1.5 w-full py-1.5 text-[11px] text-mycel-muted hover:text-mycel-text-2 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent rounded-sm"
+                          >
+                            <ChevronRightIcon expanded={expanded} />
+                            <span>{count} stopped</span>
+                          </button>
+                        </td>
+                      </tr>
+                    );
+                  })()}
+                  {/* When groupByRepo is on, skip stopped rows that are collapsed. */}
+                  {groupByRepo && (a.state === "stopped" || a.state === "error") && !expandedStoppedRepos.has(a.repo ?? "") ? null : (
+                  <>
+                  {/* Subtle divider between active and stopped groups — only
+                      when groupByRepo is OFF (the toggle row replaces it). */}
+                  {!groupByRepo && rowIdx > 0 &&
                     (a.state === "stopped" || a.state === "error") &&
                     displayRows[rowIdx - 1]!.state !== "stopped" &&
                     displayRows[rowIdx - 1]!.state !== "error" && (
@@ -1225,6 +1312,8 @@ export function Agents() {
                         <PeekActivityFeed agentName={a.name} />
                       </td>
                     </tr>
+                  )}
+                  </>
                   )}
                 </Fragment>
               ))}

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -153,6 +153,41 @@ describe("Agents", () => {
       expect(screen.queryByTestId("agents-filters-popover")).not.toBeInTheDocument();
     });
   });
+
+  it("collapses stopped agents per repo by default and expands on toggle", async () => {
+    // Two repos: repo-a has 1 active + 1 stopped; repo-b has 1 stopped only.
+    fetchMock.mockReturnValue(
+      jsonResponse([
+        { name: "active-1", role: "engineer", tool: "claude", state: "working", repo: "org/repo-a", total_cost_usd: 0, started_at: "" },
+        { name: "stopped-1", role: "engineer", tool: "claude", state: "stopped", repo: "org/repo-a", total_cost_usd: 0, started_at: "" },
+        { name: "stopped-2", role: "engineer", tool: "agy",    state: "stopped", repo: "org/repo-b", total_cost_usd: 0, started_at: "" },
+      ]),
+    );
+
+    wrap(<Agents />);
+    await waitFor(() => {
+      expect(screen.getByText("active-1")).toBeInTheDocument();
+    });
+
+    // Stopped agents are hidden by default when groupByRepo is on.
+    expect(screen.queryByText("stopped-1")).not.toBeInTheDocument();
+    expect(screen.queryByText("stopped-2")).not.toBeInTheDocument();
+
+    // Toggle rows exist — one per repo with stopped agents.
+    const toggles = screen.getAllByRole("button", { name: /stopped/ });
+    expect(toggles.length).toBeGreaterThanOrEqual(1);
+
+    // Expanding repo-a's stopped section reveals stopped-1.
+    const repoAToggle = toggles.find((b) => b.getAttribute("aria-expanded") === "false");
+    if (repoAToggle) {
+      fireEvent.click(repoAToggle);
+      await waitFor(() => {
+        // At least one stopped agent is now visible.
+        const visible = screen.queryByText("stopped-1") ?? screen.queryByText("stopped-2");
+        expect(visible).toBeInTheDocument();
+      });
+    }
+  });
 });
 
 /** Renders the header slot the way Layout's full-width bar does, so

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -177,16 +177,17 @@ describe("Agents", () => {
     const toggles = screen.getAllByRole("button", { name: /stopped/ });
     expect(toggles.length).toBeGreaterThanOrEqual(1);
 
-    // Expanding repo-a's stopped section reveals stopped-1.
+    // Expanding repo-a's stopped section reveals stopped-1. Assert the
+    // collapsed toggle exists first so a regression that stops emitting it
+    // fails the test rather than silently skipping the reveal check.
     const repoAToggle = toggles.find((b) => b.getAttribute("aria-expanded") === "false");
-    if (repoAToggle) {
-      fireEvent.click(repoAToggle);
-      await waitFor(() => {
-        // At least one stopped agent is now visible.
-        const visible = screen.queryByText("stopped-1") ?? screen.queryByText("stopped-2");
-        expect(visible).toBeInTheDocument();
-      });
-    }
+    expect(repoAToggle).toBeDefined();
+    fireEvent.click(repoAToggle!);
+    await waitFor(() => {
+      // At least one stopped agent is now visible.
+      const visible = screen.queryByText("stopped-1") ?? screen.queryByText("stopped-2");
+      expect(visible).toBeInTheDocument();
+    });
   });
 });
 


### PR DESCRIPTION
Collapses stopped agents behind a per-repo `▸ N stopped` toggle on the Agents page. Active/running/idle agents stay visible; stopped ones are hidden by default and expand on click. Per-repo independent collapse state, muted styling, accessible toggle button.

Part of #3334

## Test plan
- `make build-local-web` ✓ · `make test-web` 163/163 ✓ (added a vitest asserting stopped agents hidden by default and shown on toggle) · `bun run lint` ✓