### PR TITLE
fix(workspace): implement role inheritance so derived roles inherit the base mycel prompt/MCP/secrets

### DIFF
--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -556,32 +556,177 @@ type ResolvedRole struct { //nolint:govet // field order matches API contract
 	Description  string            // Human-readable role description
 }
 
-// ResolveRole loads a role directly from the store. No inheritance — each role
-// is self-contained with all its own MCP servers, secrets, plugins, etc.
+// ResolveRole returns a fully resolved role after BFS inheritance merge.
+// It walks ParentRoles breadth-first, collecting all ancestors, then merges
+// them in ancestor-first order so the target role's values take precedence:
+//   - Prompt: parent prompts first, child prompt appended last (blank-line separated).
+//   - Lists (MCPServers, Secrets, Plugins, CLITools): parent ∪ child, deduped, stable order.
+//   - Maps (Settings, Rules, Agents, Skills, Commands): child keys override parent keys.
+//   - Lifecycle strings (PromptCreate/Start/Stop/Delete): child wins if non-empty, else nearest ancestor.
+//   - Name, Description, Review: target role always wins.
+//
+// Missing parent roles are skipped silently. Cycles are guarded — no infinite loop.
 func (rm *RoleManager) ResolveRole(name string) (*ResolvedRole, error) {
-	role, err := rm.LoadRole(name)
+	root, err := rm.LoadRole(name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load role %q: %w", name, err)
 	}
 
+	// BFS from the target role outward through ParentRoles.
+	// visited keys are normalised role names.
+	visited := make(map[string]bool)
+	queue := []*Role{root}
+	var order []*Role
+
+	visited[NormalizeRoleName(root.Metadata.Name)] = true
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		order = append(order, cur)
+
+		for _, parentName := range cur.Metadata.ParentRoles {
+			pn := NormalizeRoleName(parentName)
+			if visited[pn] {
+				continue // already queued or visited — cycle/dup guard
+			}
+			visited[pn] = true
+			parent, loadErr := rm.LoadRole(pn)
+			if loadErr != nil {
+				// Missing parent role: skip silently rather than fail.
+				continue
+			}
+			queue = append(queue, parent)
+		}
+	}
+
+	// Reverse so deepest ancestors come first; target role comes last.
+	// This gives us "parent text first, child text last" merge order.
+	for i, j := 0, len(order)-1; i < j; i, j = i+1, j-1 {
+		order[i], order[j] = order[j], order[i]
+	}
+
+	// Merge all roles ancestor-first, target-last.
+	var prompts []string
+
+	mcpSeen := make(map[string]bool)
+	var mcpServers []string
+
+	secretSeen := make(map[string]bool)
+	var secrets []string
+
+	pluginSeen := make(map[string]bool)
+	var plugins []string
+
+	cliToolSeen := make(map[string]bool)
+	var cliTools []string
+
+	var settings map[string]any
+	var rules map[string]string
+	var agents map[string]string
+	var skills map[string]string
+	var commands map[string]string
+
+	var promptCreate, promptStart, promptStop, promptDelete, review string
+
+	for _, r := range order {
+		if r.Prompt != "" {
+			prompts = append(prompts, r.Prompt)
+		}
+
+		for _, s := range r.Metadata.MCPServers {
+			if !mcpSeen[s] {
+				mcpSeen[s] = true
+				mcpServers = append(mcpServers, s)
+			}
+		}
+		for _, s := range r.Metadata.Secrets {
+			if !secretSeen[s] {
+				secretSeen[s] = true
+				secrets = append(secrets, s)
+			}
+		}
+		for _, p := range r.Metadata.Plugins {
+			if !pluginSeen[p] {
+				pluginSeen[p] = true
+				plugins = append(plugins, p)
+			}
+		}
+		for _, t := range r.Metadata.CLITools {
+			if !cliToolSeen[t] {
+				cliToolSeen[t] = true
+				cliTools = append(cliTools, t)
+			}
+		}
+
+		// Maps: later (child) entries override earlier (parent) entries.
+		for k, v := range r.Metadata.Settings {
+			if settings == nil {
+				settings = make(map[string]any)
+			}
+			settings[k] = v
+		}
+		for k, v := range r.Metadata.Rules {
+			if rules == nil {
+				rules = make(map[string]string)
+			}
+			rules[k] = v
+		}
+		for k, v := range r.Metadata.Agents {
+			if agents == nil {
+				agents = make(map[string]string)
+			}
+			agents[k] = v
+		}
+		for k, v := range r.Metadata.Skills {
+			if skills == nil {
+				skills = make(map[string]string)
+			}
+			skills[k] = v
+		}
+		for k, v := range r.Metadata.Commands {
+			if commands == nil {
+				commands = make(map[string]string)
+			}
+			commands[k] = v
+		}
+
+		// Lifecycle strings: last non-empty wins (child comes last so child overrides parent).
+		if r.Metadata.PromptCreate != "" {
+			promptCreate = r.Metadata.PromptCreate
+		}
+		if r.Metadata.PromptStart != "" {
+			promptStart = r.Metadata.PromptStart
+		}
+		if r.Metadata.PromptStop != "" {
+			promptStop = r.Metadata.PromptStop
+		}
+		if r.Metadata.PromptDelete != "" {
+			promptDelete = r.Metadata.PromptDelete
+		}
+		if r.Metadata.Review != "" {
+			review = r.Metadata.Review
+		}
+	}
+
 	return &ResolvedRole{
-		Name:         role.Metadata.Name,
-		Prompt:       role.Prompt,
-		MCPServers:   append([]string{}, role.Metadata.MCPServers...),
-		Secrets:      append([]string{}, role.Metadata.Secrets...),
-		Plugins:      append([]string{}, role.Metadata.Plugins...),
-		CLITools:     append([]string{}, role.Metadata.CLITools...),
-		Description:  role.Metadata.Description,
-		PromptCreate: role.Metadata.PromptCreate,
-		PromptStart:  role.Metadata.PromptStart,
-		PromptStop:   role.Metadata.PromptStop,
-		PromptDelete: role.Metadata.PromptDelete,
-		Settings:     role.Metadata.Settings,
-		Commands:     role.Metadata.Commands,
-		Skills:       role.Metadata.Skills,
-		Agents:       role.Metadata.Agents,
-		Rules:        role.Metadata.Rules,
-		Review:       role.Metadata.Review,
+		Name:         root.Metadata.Name,
+		Description:  root.Metadata.Description,
+		Prompt:       strings.Join(prompts, "\n\n"),
+		MCPServers:   mcpServers,
+		Secrets:      secrets,
+		Plugins:      plugins,
+		CLITools:     cliTools,
+		Settings:     settings,
+		Rules:        rules,
+		Agents:       agents,
+		Skills:       skills,
+		Commands:     commands,
+		PromptCreate: promptCreate,
+		PromptStart:  promptStart,
+		PromptStop:   promptStop,
+		PromptDelete: promptDelete,
+		Review:       review,
 	}, nil
 }
 

--- a/pkg/workspace/roles_test.go
+++ b/pkg/workspace/roles_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -642,6 +643,327 @@ func TestRoleManager_DeleteRole_NotFound(t *testing.T) {
 	err := rm.DeleteRole("nonexistent")
 	if err == nil {
 		t.Error("DeleteRole should fail for nonexistent role")
+	}
+}
+
+// TestResolveRole_NoParents verifies a role with no parents is returned unchanged
+// (single-role resolved prompt equals the raw role prompt).
+func TestResolveRole_NoParents(t *testing.T) {
+	rm := newTestRoleManager(t)
+
+	role := &Role{
+		Metadata: RoleMetadata{
+			Name:       "standalone",
+			MCPServers: []string{"bc"},
+			Secrets:    []string{"MY_SECRET"},
+		},
+		Prompt: "# Standalone\n\nI have no parents.",
+	}
+	if err := rm.store.Save(role); err != nil {
+		t.Fatal(err)
+	}
+
+	resolved, err := rm.ResolveRole("standalone")
+	if err != nil {
+		t.Fatalf("ResolveRole: %v", err)
+	}
+
+	if resolved.Prompt != role.Prompt {
+		t.Errorf("Prompt = %q, want %q", resolved.Prompt, role.Prompt)
+	}
+	if len(resolved.MCPServers) != 1 || resolved.MCPServers[0] != "bc" {
+		t.Errorf("MCPServers = %v, want [bc]", resolved.MCPServers)
+	}
+	if len(resolved.Secrets) != 1 || resolved.Secrets[0] != "MY_SECRET" {
+		t.Errorf("Secrets = %v, want [MY_SECRET]", resolved.Secrets)
+	}
+}
+
+// TestResolveRole_DefaultRootInheritsBase ensures the default root role, which has
+// parent_roles: [base], inherits the base prompt, bc MCP server, and no duplicate secrets.
+func TestResolveRole_DefaultRootInheritsBase(t *testing.T) {
+	rm := newTestRoleManager(t)
+
+	if _, err := rm.EnsureDefaultRoot(); err != nil {
+		t.Fatalf("EnsureDefaultRoot: %v", err)
+	}
+
+	resolved, err := rm.ResolveRole("root")
+	if err != nil {
+		t.Fatalf("ResolveRole(root): %v", err)
+	}
+
+	// Prompt must contain a distinctive base-role substring.
+	const baseSubstr = "bc Agent"
+	if !strings.Contains(resolved.Prompt, baseSubstr) {
+		t.Errorf("resolved root prompt missing base substring %q", baseSubstr)
+	}
+
+	// Prompt must also contain a distinctive root substring.
+	const rootSubstr = "Root Agent"
+	if !strings.Contains(resolved.Prompt, rootSubstr) {
+		t.Errorf("resolved root prompt missing root substring %q", rootSubstr)
+	}
+
+	// Base prompt must come BEFORE root prompt (parent first).
+	baseIdx := strings.Index(resolved.Prompt, baseSubstr)
+	rootIdx := strings.Index(resolved.Prompt, rootSubstr)
+	if baseIdx >= rootIdx {
+		t.Errorf("base prompt section (idx %d) should precede root prompt section (idx %d)", baseIdx, rootIdx)
+	}
+
+	// MCPServers must include "bc" (from base) and "github" (from root) — unioned.
+	hasBc, hasGithub := false, false
+	for _, s := range resolved.MCPServers {
+		if s == "bc" {
+			hasBc = true
+		}
+		if s == "github" {
+			hasGithub = true
+		}
+	}
+	if !hasBc {
+		t.Errorf("MCPServers missing 'bc' (from base); got %v", resolved.MCPServers)
+	}
+	if !hasGithub {
+		t.Errorf("MCPServers missing 'github' (from root); got %v", resolved.MCPServers)
+	}
+
+	// Secrets must include GITHUB_PERSONAL_ACCESS_TOKEN (from root).
+	hasToken := false
+	for _, s := range resolved.Secrets {
+		if s == "GITHUB_PERSONAL_ACCESS_TOKEN" {
+			hasToken = true
+		}
+	}
+	if !hasToken {
+		t.Errorf("Secrets missing GITHUB_PERSONAL_ACCESS_TOKEN; got %v", resolved.Secrets)
+	}
+
+	// No duplicates in MCPServers or Secrets.
+	mcpCount := make(map[string]int)
+	for _, s := range resolved.MCPServers {
+		mcpCount[s]++
+		if mcpCount[s] > 1 {
+			t.Errorf("duplicate MCP server %q in resolved.MCPServers", s)
+		}
+	}
+	secretCount := make(map[string]int)
+	for _, s := range resolved.Secrets {
+		secretCount[s]++
+		if secretCount[s] > 1 {
+			t.Errorf("duplicate secret %q in resolved.Secrets", s)
+		}
+	}
+}
+
+// TestResolveRole_DeepInheritance verifies multi-level inheritance merges correctly.
+// Chain: child -> mid -> grandparent
+func TestResolveRole_DeepInheritance(t *testing.T) {
+	rm := newTestRoleManager(t)
+
+	grandparent := &Role{
+		Metadata: RoleMetadata{
+			Name:       "grandparent",
+			MCPServers: []string{"gp-mcp"},
+			Secrets:    []string{"GP_SECRET"},
+		},
+		Prompt: "# Grandparent\n\nRoot context.",
+	}
+	mid := &Role{
+		Metadata: RoleMetadata{
+			Name:        "mid",
+			ParentRoles: []string{"grandparent"},
+			MCPServers:  []string{"mid-mcp"},
+		},
+		Prompt: "# Mid\n\nMid context.",
+	}
+	child := &Role{
+		Metadata: RoleMetadata{
+			Name:        "child",
+			ParentRoles: []string{"mid"},
+			MCPServers:  []string{"child-mcp"},
+		},
+		Prompt: "# Child\n\nChild context.",
+	}
+
+	for _, r := range []*Role{grandparent, mid, child} {
+		if err := rm.store.Save(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resolved, err := rm.ResolveRole("child")
+	if err != nil {
+		t.Fatalf("ResolveRole(child): %v", err)
+	}
+
+	// All prompts must appear; grandparent text must come before child text.
+	for _, substr := range []string{"Grandparent", "Mid", "Child"} {
+		if !strings.Contains(resolved.Prompt, substr) {
+			t.Errorf("resolved prompt missing %q; full prompt: %q", substr, resolved.Prompt)
+		}
+	}
+	gpIdx := strings.Index(resolved.Prompt, "Grandparent")
+	childIdx := strings.Index(resolved.Prompt, "Child context")
+	if gpIdx >= childIdx {
+		t.Errorf("grandparent section should precede child section")
+	}
+
+	// MCPServers must be union of all three levels, deduped.
+	wantMCP := map[string]bool{"gp-mcp": true, "mid-mcp": true, "child-mcp": true}
+	if len(resolved.MCPServers) != len(wantMCP) {
+		t.Errorf("MCPServers = %v, want %v", resolved.MCPServers, wantMCP)
+	}
+	for _, s := range resolved.MCPServers {
+		if !wantMCP[s] {
+			t.Errorf("unexpected MCP server %q", s)
+		}
+	}
+
+	// Secrets from grandparent must flow through to child.
+	hasGPSecret := false
+	for _, s := range resolved.Secrets {
+		if s == "GP_SECRET" {
+			hasGPSecret = true
+		}
+	}
+	if !hasGPSecret {
+		t.Errorf("Secrets missing GP_SECRET from grandparent; got %v", resolved.Secrets)
+	}
+}
+
+// TestResolveRole_CycleDoesNotHang verifies that a role referencing itself
+// (or a mutual cycle) does not cause an infinite loop.
+func TestResolveRole_CycleDoesNotHang(t *testing.T) {
+	rm := newTestRoleManager(t)
+
+	// A -> B -> A  (mutual cycle)
+	roleA := &Role{
+		Metadata: RoleMetadata{
+			Name:        "cycle-a",
+			ParentRoles: []string{"cycle-b"},
+			MCPServers:  []string{"mcp-a"},
+		},
+		Prompt: "Cycle A.",
+	}
+	roleB := &Role{
+		Metadata: RoleMetadata{
+			Name:        "cycle-b",
+			ParentRoles: []string{"cycle-a"},
+			MCPServers:  []string{"mcp-b"},
+		},
+		Prompt: "Cycle B.",
+	}
+
+	for _, r := range []*Role{roleA, roleB} {
+		if err := rm.store.Save(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Must terminate without hanging.
+	resolved, err := rm.ResolveRole("cycle-a")
+	if err != nil {
+		t.Fatalf("ResolveRole(cycle-a): %v", err)
+	}
+
+	// Both prompts should appear exactly once despite the cycle.
+	if !strings.Contains(resolved.Prompt, "Cycle A") {
+		t.Error("resolved prompt missing 'Cycle A'")
+	}
+	if !strings.Contains(resolved.Prompt, "Cycle B") {
+		t.Error("resolved prompt missing 'Cycle B'")
+	}
+}
+
+// TestResolveRole_MissingParentSkipped verifies that a missing parent role is
+// skipped gracefully rather than causing an error.
+func TestResolveRole_MissingParentSkipped(t *testing.T) {
+	rm := newTestRoleManager(t)
+
+	role := &Role{
+		Metadata: RoleMetadata{
+			Name:        "orphan",
+			ParentRoles: []string{"does-not-exist"},
+			MCPServers:  []string{"mcp-own"},
+		},
+		Prompt: "# Orphan\n\nMy parent is missing.",
+	}
+	if err := rm.store.Save(role); err != nil {
+		t.Fatal(err)
+	}
+
+	// Must not error out because of the missing parent.
+	resolved, err := rm.ResolveRole("orphan")
+	if err != nil {
+		t.Fatalf("ResolveRole(orphan) should succeed even with missing parent: %v", err)
+	}
+
+	if !strings.Contains(resolved.Prompt, "Orphan") {
+		t.Errorf("resolved prompt = %q, want it to contain 'Orphan'", resolved.Prompt)
+	}
+	if len(resolved.MCPServers) != 1 || resolved.MCPServers[0] != "mcp-own" {
+		t.Errorf("MCPServers = %v, want [mcp-own]", resolved.MCPServers)
+	}
+}
+
+// TestResolveRole_MapInheritance verifies that map fields (Rules, Commands, Settings)
+// are merged with child values overriding parent values for the same key.
+func TestResolveRole_MapInheritance(t *testing.T) {
+	rm := newTestRoleManager(t)
+
+	parent := &Role{
+		Metadata: RoleMetadata{
+			Name: "map-parent",
+			Rules: map[string]string{
+				"shared-rule": "parent version",
+				"parent-only": "only in parent",
+			},
+			Commands: map[string]string{
+				"status": "parent status command",
+			},
+		},
+		Prompt: "Parent prompt.",
+	}
+	child := &Role{
+		Metadata: RoleMetadata{
+			Name:        "map-child",
+			ParentRoles: []string{"map-parent"},
+			Rules: map[string]string{
+				"shared-rule": "child version",
+				"child-only":  "only in child",
+			},
+		},
+		Prompt: "Child prompt.",
+	}
+
+	for _, r := range []*Role{parent, child} {
+		if err := rm.store.Save(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	resolved, err := rm.ResolveRole("map-child")
+	if err != nil {
+		t.Fatalf("ResolveRole(map-child): %v", err)
+	}
+
+	// Child value overrides parent for shared key.
+	if resolved.Rules["shared-rule"] != "child version" {
+		t.Errorf("Rules[shared-rule] = %q, want 'child version'", resolved.Rules["shared-rule"])
+	}
+	// Parent-only key is inherited.
+	if resolved.Rules["parent-only"] != "only in parent" {
+		t.Errorf("Rules[parent-only] = %q, want 'only in parent'", resolved.Rules["parent-only"])
+	}
+	// Child-only key is present.
+	if resolved.Rules["child-only"] != "only in child" {
+		t.Errorf("Rules[child-only] = %q, want 'only in child'", resolved.Rules["child-only"])
+	}
+	// Commands from parent are inherited.
+	if resolved.Commands["status"] != "parent status command" {
+		t.Errorf("Commands[status] = %q, want 'parent status command'", resolved.Commands["status"])
 	}
 }
 


### PR DESCRIPTION
Implements real role inheritance. `ResolveRole` previously returned only a role's own data despite a comment claiming a BFS inheritance merge; `parent_roles` was parsed and stored but never applied, so derived roles (root/engineer/manager) did NOT inherit the base mycel prompt, the `bc` MCP server, or base secrets — booting with a thin system prompt. This walks ancestors BFS (cycle-safe), merges prompts (parent first, child appended), unions MCPServers/Secrets/Plugins/CLITools, and merges maps child-overrides-parent.

Fixes the "system prompt for these agents" bug. Part of #3334

## Test plan
- `make build-local-go` ✓ · `go test ./pkg/workspace/...` ✓ (6 new tests: passthrough, root→base inheritance, 3-level chain, cycle termination, missing-parent skip, map override) · `golangci-lint run ./pkg/workspace/` = 0 issues ✓