### PR TITLE
feat(provider): pi runs on a chosen model + AWS Bedrock (Kimi 2.5) env injection

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1281,6 +1281,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	}
 	injectEnv(env, wsPath, name, existing.EnvFile, existing.Env)
 	injectGatewayEnv(env, m.gatewayConfig)
+	injectProviderEnv(env, toolName, m.providerRegistry)
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -1520,6 +1521,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	}
 	injectEnv(env, wsPath, name, opts.EnvFile, opts.Env)
 	injectGatewayEnv(env, m.gatewayConfig)
+	injectProviderEnv(env, effectiveTool, m.providerRegistry)
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -3695,6 +3697,23 @@ func injectGatewayEnv(env map[string]string, gw *workspace.GatewaysConfig) {
 			}
 			env[key] = gc.Password
 		}
+	}
+}
+
+// injectProviderEnv calls the EnvContributor hook for the named tool so
+// providers can inject additional env vars (e.g. AWS pointer vars for pi).
+// It is a no-op when toolName is empty, the registry is nil, or the provider
+// does not implement EnvContributor.
+func injectProviderEnv(env map[string]string, toolName string, registry *provider.Registry) {
+	if toolName == "" || registry == nil {
+		return
+	}
+	p, ok := registry.Get(toolName)
+	if !ok {
+		return
+	}
+	if ec, ok := p.(provider.EnvContributor); ok {
+		ec.ContributeEnv(env)
 	}
 }
 

--- a/pkg/provider/capabilities.go
+++ b/pkg/provider/capabilities.go
@@ -55,3 +55,16 @@ type CostSource interface {
 type DynamicModelLister interface {
 	ListModels(ctx context.Context) ([]string, error)
 }
+
+// EnvContributor is optionally implemented by providers that need to inject
+// additional environment variables into the agent session beyond the standard
+// MYCEL_* and gateway vars. Typical use: AWS credential pointer vars for
+// cloud-SDK providers (e.g. pi + AWS Bedrock). Implementations must NOT
+// inject secret key material — only pointer values (profile names, region
+// names) that direct the SDK to credentials stored on disk.
+//
+// ContributeEnv must be idempotent: check whether the key is already set
+// before writing so that user-configured env always wins.
+type EnvContributor interface {
+	ContributeEnv(env map[string]string)
+}

--- a/pkg/provider/model_test.go
+++ b/pkg/provider/model_test.go
@@ -79,7 +79,8 @@ func TestProviderModels(t *testing.T) {
 		{"claude", NewClaudeProvider(), []string{"fable", "opus", "opusplan", "sonnet", "haiku"}},
 		{"cursor", NewCursorProvider(), []string{"auto", "gpt-5.3-codex", "gpt-5.3-codex-high", "gpt-5.2", "sonnet-4-thinking"}},
 		{"codex", NewCodexProvider(), []string{"gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.2"}},
-		{"pi", NewPiProvider(), []string{"amazon-bedrock/moonshotai.kimi-k2.5", "groq/llama-3.3-70b-versatile", "groq/llama-3.1-8b-instant"}},
+		// pi has no static curated list — ListModels (DynamicModelLister) provides the live list from pi --list-models.
+		{"pi", NewPiProvider(), []string{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/model_test.go
+++ b/pkg/provider/model_test.go
@@ -47,7 +47,8 @@ func TestBuildCommandModelFlag(t *testing.T) {
 		{"agy injects quoted --model", NewAgyProvider(), "Gemini 3 Flash", " --model 'Gemini 3 Flash'", ""},
 		{"cursor injects --model", NewCursorProvider(), "sonnet-4-thinking", " --model sonnet-4-thinking", ""},
 		{"codex injects --model", NewCodexProvider(), "gpt-5.3-codex", " --model gpt-5.3-codex", ""},
-		{"pi injects --model slash form", NewPiProvider(), "anthropic/claude-sonnet-4-6", " --model anthropic/claude-sonnet-4-6", ""},
+		// pi splits "provider/model" into separate --provider + --model flags for unambiguous routing.
+		{"pi injects --model slash form", NewPiProvider(), "anthropic/claude-sonnet-4-6", " --provider anthropic --model claude-sonnet-4-6", ""},
 		{"claude drops unsafe model", NewClaudeProvider(), "$(id)", "", "id"},
 		{"agy drops unsafe model", NewAgyProvider(), "a$(id)", "", "id"},
 		{"cursor drops leading dash", NewCursorProvider(), "--yolo", "", "--yolo"},
@@ -78,7 +79,7 @@ func TestProviderModels(t *testing.T) {
 		{"claude", NewClaudeProvider(), []string{"fable", "opus", "opusplan", "sonnet", "haiku"}},
 		{"cursor", NewCursorProvider(), []string{"auto", "gpt-5.3-codex", "gpt-5.3-codex-high", "gpt-5.2", "sonnet-4-thinking"}},
 		{"codex", NewCodexProvider(), []string{"gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.2"}},
-		{"pi", NewPiProvider(), []string{"google/gemini-2.5-pro", "anthropic/claude-sonnet-4-6", "openai/gpt-5.2"}},
+		{"pi", NewPiProvider(), []string{"amazon-bedrock/moonshotai.kimi-k2.5", "groq/llama-3.3-70b-versatile", "groq/llama-3.1-8b-instant"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -85,6 +85,8 @@ func SafePiModelName(model string) bool {
 // explicit --provider + --model split, which this function uses when a slash
 // is present so the provider routing is unambiguous. Both values are spliced
 // into a shell command line — unsafe values are dropped, never escaped.
+// When no model is given, pi uses its own configured default — mycel does
+// not override that default.
 func (p *PiProvider) BuildCommand(opts CommandOpts) string {
 	cmd := p.Command()
 	if SafePiModelName(opts.Model) {
@@ -105,15 +107,46 @@ func (p *PiProvider) BuildCommand(opts CommandOpts) string {
 	return cmd
 }
 
-// Models returns the curated model list for the pi CLI. The Bedrock Kimi
-// model is listed first as the recommended default when AWS creds are present.
-// pi's --model flag accepts a "provider/model" string or a bare model id.
+// Models returns an empty static fallback: the live list comes from ListModels
+// (DynamicModelLister) which queries `pi --list-models` at runtime. This keeps
+// mycel free of baked-in model choices — the user picks from whatever pi reports.
 func (p *PiProvider) Models() []string {
-	return []string{
-		"amazon-bedrock/moonshotai.kimi-k2.5",
-		"groq/llama-3.3-70b-versatile",
-		"groq/llama-3.1-8b-instant",
+	return []string{}
+}
+
+// piListModels is overridable in tests.
+var piListModels = func(ctx context.Context) (string, error) {
+	return runProviderCommand(ctx, "pi", "--list-models")
+}
+
+// ListModels queries `pi --list-models` and returns models in "provider/model"
+// form. pi prints two-column rows ("provider  model"); this function joins them
+// with a slash so the result is a valid BuildCommand input. Only rows whose
+// joined form passes SafePiModelName are included — all others are silently
+// skipped. When the CLI is unavailable the empty static list is returned.
+func (p *PiProvider) ListModels(ctx context.Context) ([]string, error) {
+	out, err := piListModels(ctx)
+	if err != nil {
+		return p.Models(), nil
 	}
+	var models []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// "provider  model" — split on any run of whitespace.
+		fields := strings.Fields(line)
+		if len(fields) < 2 { //nolint:mnd // 2 is the expected column count, not a magic number
+			continue
+		}
+		combined := fields[0] + "/" + fields[1]
+		if !SafePiModelName(combined) {
+			continue
+		}
+		models = append(models, combined)
+	}
+	return models, nil
 }
 
 // IsInstalled checks if the provider binary is available.
@@ -211,4 +244,5 @@ func readAWSDefaultRegion(home string) string {
 // Ensure PiProvider implements all declared interfaces.
 var _ Provider = (*PiProvider)(nil)
 var _ ModelLister = (*PiProvider)(nil)
+var _ DynamicModelLister = (*PiProvider)(nil)
 var _ EnvContributor = (*PiProvider)(nil)

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -1,8 +1,12 @@
 package provider
 
 import (
+	"bufio"
 	"context"
+	"os"
+	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 // PiProvider implements the Provider interface for pi CLI.
@@ -62,14 +66,35 @@ func (p *PiProvider) InstallHint() string {
 	return "npm install -g @earendil-works/pi-coding-agent"
 }
 
+// safePiModelPattern is the charset allowed in a pi model name. pi's model
+// identifiers follow the "provider/id" form (e.g. "amazon-bedrock/moonshotai.kimi-k2.5",
+// "groq/llama-3.3-70b-versatile"). The charset covers letters, digits, dots,
+// hyphens, and slashes — no spaces or shell metacharacters. The first character
+// must be alphanumeric to prevent argument injection via a leading dash.
+var safePiModelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+
+// SafePiModelName reports whether a pi model name is safe to interpolate
+// into a shell command line.
+func SafePiModelName(model string) bool {
+	return safePiModelPattern.MatchString(model)
+}
+
 // BuildCommand returns the full command for a given runtime context.
-// For pi, we start with base command and add model/session flags as
-// needed. Both values are spliced into a shell command line — double
-// quotes don't stop `$()` expansion, so unsafe values are dropped.
+// When opts.Model is set and passes SafePiModelName, it is appended as flags.
+// pi accepts "provider/model" as a single --model value, but also supports
+// explicit --provider + --model split, which this function uses when a slash
+// is present so the provider routing is unambiguous. Both values are spliced
+// into a shell command line — unsafe values are dropped, never escaped.
 func (p *PiProvider) BuildCommand(opts CommandOpts) string {
 	cmd := p.Command()
-	if SafeModelName(opts.Model) {
-		cmd += " --model " + opts.Model
+	if SafePiModelName(opts.Model) {
+		if idx := strings.Index(opts.Model, "/"); idx > 0 {
+			providerPart := opts.Model[:idx]
+			modelPart := opts.Model[idx+1:]
+			cmd += " --provider " + providerPart + " --model " + modelPart
+		} else {
+			cmd += " --model " + opts.Model
+		}
 	}
 	if SafeSessionID(opts.SessionID) {
 		cmd += " --session " + opts.SessionID
@@ -80,10 +105,15 @@ func (p *PiProvider) BuildCommand(opts CommandOpts) string {
 	return cmd
 }
 
-// Models returns the curated model list for the pi CLI. pi's --model
-// takes a "provider/id" pattern with an optional ":<thinking>" suffix.
+// Models returns the curated model list for the pi CLI. The Bedrock Kimi
+// model is listed first as the recommended default when AWS creds are present.
+// pi's --model flag accepts a "provider/model" string or a bare model id.
 func (p *PiProvider) Models() []string {
-	return []string{"google/gemini-2.5-pro", "anthropic/claude-sonnet-4-6", "openai/gpt-5.2"}
+	return []string{
+		"amazon-bedrock/moonshotai.kimi-k2.5",
+		"groq/llama-3.3-70b-versatile",
+		"groq/llama-3.1-8b-instant",
+	}
 }
 
 // IsInstalled checks if the provider binary is available.
@@ -103,6 +133,82 @@ func (p *PiProvider) Version(ctx context.Context) string {
 	return raw
 }
 
-// Ensure PiProvider implements Provider interface.
+// piUserHomeDir is overridable in tests.
+var piUserHomeDir = os.UserHomeDir
+
+// ContributeEnv injects AWS pointer env vars (AWS_PROFILE, AWS_REGION) so
+// pi's AWS SDK can locate credentials in ~/.aws without embedding secret
+// key values in the agent session. Real key material stays in ~/.aws/credentials;
+// only the profile name and region pointer are injected.
+//
+// Injection is skipped when:
+//   - any AWS_* key is already set in env (user-provided config wins)
+//   - ~/.aws directory does not exist on the host
+func (p *PiProvider) ContributeEnv(env map[string]string) {
+	// Respect any AWS env already set by the user (via agent Env or env file).
+	for k := range env {
+		if strings.HasPrefix(k, "AWS_") {
+			return
+		}
+	}
+	home, err := piUserHomeDir()
+	if err != nil {
+		return
+	}
+	awsDir := filepath.Join(home, ".aws")
+	if _, err := os.Stat(awsDir); err != nil { //nolint:gosec // awsDir is derived from UserHomeDir, not user input
+		return
+	}
+	env["AWS_PROFILE"] = "default"
+	// Read region from ~/.aws/config; fall back to AWS_DEFAULT_REGION from
+	// the host process environment.
+	if region := readAWSDefaultRegion(home); region != "" {
+		env["AWS_REGION"] = region
+	} else if region = os.Getenv("AWS_DEFAULT_REGION"); region != "" {
+		env["AWS_REGION"] = region
+	}
+}
+
+// readAWSDefaultRegion reads the region for the [default] profile from
+// ~/.aws/config and returns it, or "" if the file is absent or unparseable.
+func readAWSDefaultRegion(home string) string {
+	cfgPath := filepath.Join(home, ".aws", "config")
+	//nolint:gosec // cfgPath is derived from UserHomeDir, not user input
+	f, err := os.Open(cfgPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close() //nolint:errcheck
+
+	inDefault := false
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if line == "[default]" {
+			inDefault = true
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			if inDefault {
+				// Exited the [default] section without finding a region.
+				break
+			}
+			continue
+		}
+		if inDefault {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 && strings.TrimSpace(parts[0]) == "region" {
+				return strings.TrimSpace(parts[1])
+			}
+		}
+	}
+	return ""
+}
+
+// Ensure PiProvider implements all declared interfaces.
 var _ Provider = (*PiProvider)(nil)
 var _ ModelLister = (*PiProvider)(nil)
+var _ EnvContributor = (*PiProvider)(nil)

--- a/pkg/provider/pi_test.go
+++ b/pkg/provider/pi_test.go
@@ -1,0 +1,267 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPiProviderIdentity(t *testing.T) {
+	p := NewPiProvider()
+	if p.Name() != "pi" {
+		t.Errorf("Name() = %q, want pi", p.Name())
+	}
+	if p.Binary() != "pi" {
+		t.Errorf("Binary() = %q, want pi", p.Binary())
+	}
+	if p.Command() != "pi" {
+		t.Errorf("Command() = %q, want pi", p.Command())
+	}
+	if p.Description() == "" {
+		t.Error("expected non-empty description")
+	}
+	if p.InstallHint() == "" {
+		t.Error("expected non-empty install hint")
+	}
+}
+
+func TestPiInterfaces(t *testing.T) {
+	var p Provider = NewPiProvider()
+	if _, ok := p.(ModelLister); !ok {
+		t.Error("pi must implement ModelLister")
+	}
+	if _, ok := p.(EnvContributor); !ok {
+		t.Error("pi must implement EnvContributor")
+	}
+}
+
+func TestSafePiModelName(t *testing.T) {
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"amazon-bedrock/moonshotai.kimi-k2.5", true},
+		{"groq/llama-3.3-70b-versatile", true},
+		{"groq/llama-3.1-8b-instant", true},
+		{"anthropic/claude-sonnet-4-6", true},
+		{"google/gemini-2.5-pro", true},
+		{"moonshotai.kimi-k2.5", true},    // bare model without provider
+		{"llama-3.3-70b-versatile", true}, // bare model with dashes
+		{"", false},
+		{"$(rm -rf /)", false},
+		{"a b c", false},
+		{"-model", false},            // leading dash = arg injection
+		{"--provider amazon", false}, // spaces
+		{"model;cat /etc/passwd", false},
+		{"model`whoami`", false},
+	}
+	for _, tt := range tests {
+		if got := SafePiModelName(tt.model); got != tt.want {
+			t.Errorf("SafePiModelName(%q) = %v, want %v", tt.model, got, tt.want)
+		}
+	}
+}
+
+func TestPiBuildCommand(t *testing.T) {
+	p := NewPiProvider()
+	tests := []struct { //nolint:govet // test struct, field order matches literal values
+		name string
+		want string
+		opts CommandOpts
+	}{
+		{
+			name: "no opts — base command",
+			opts: CommandOpts{},
+			want: "pi",
+		},
+		{
+			name: "bedrock provider/model splits into --provider and --model",
+			opts: CommandOpts{Model: "amazon-bedrock/moonshotai.kimi-k2.5"},
+			want: "pi --provider amazon-bedrock --model moonshotai.kimi-k2.5",
+		},
+		{
+			name: "groq provider/model splits correctly",
+			opts: CommandOpts{Model: "groq/llama-3.3-70b-versatile"},
+			want: "pi --provider groq --model llama-3.3-70b-versatile",
+		},
+		{
+			name: "bare model without slash — single --model flag",
+			opts: CommandOpts{Model: "llama-3.3-70b-versatile"},
+			want: "pi --model llama-3.3-70b-versatile",
+		},
+		{
+			name: "unsafe model is dropped",
+			opts: CommandOpts{Model: "$(rm -rf /)"},
+			want: "pi",
+		},
+		{
+			name: "leading-dash model is dropped (arg injection prevention)",
+			opts: CommandOpts{Model: "-continue"},
+			want: "pi",
+		},
+		{
+			name: "session ID appended",
+			opts: CommandOpts{SessionID: "abc123"},
+			want: "pi --session abc123",
+		},
+		{
+			name: "resume flag",
+			opts: CommandOpts{Resume: true},
+			want: "pi --continue",
+		},
+		{
+			name: "model + session + resume — all three flags",
+			opts: CommandOpts{
+				Model:     "groq/llama-3.3-70b-versatile",
+				SessionID: "abc123",
+				Resume:    true,
+			},
+			want: "pi --provider groq --model llama-3.3-70b-versatile --session abc123 --continue",
+		},
+		{
+			name: "model with dots in model id",
+			opts: CommandOpts{Model: "anthropic/claude-sonnet-4-6"},
+			want: "pi --provider anthropic --model claude-sonnet-4-6",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.BuildCommand(tt.opts)
+			if got != tt.want {
+				t.Errorf("BuildCommand() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPiModels(t *testing.T) {
+	p := NewPiProvider()
+	models := p.Models()
+	if len(models) == 0 {
+		t.Fatal("Models() must return at least one model")
+	}
+	// Bedrock Kimi model must be first (recommended default)
+	if models[0] != "amazon-bedrock/moonshotai.kimi-k2.5" {
+		t.Errorf("first model = %q, want amazon-bedrock/moonshotai.kimi-k2.5", models[0])
+	}
+	// All models must pass SafePiModelName
+	for _, m := range models {
+		if !SafePiModelName(m) {
+			t.Errorf("model %q fails SafePiModelName", m)
+		}
+	}
+}
+
+func TestPiContributeEnv_NoAWSDir(t *testing.T) {
+	p := NewPiProvider()
+	orig := piUserHomeDir
+	piUserHomeDir = func() (string, error) { return t.TempDir(), nil }
+	t.Cleanup(func() { piUserHomeDir = orig })
+
+	env := map[string]string{}
+	p.ContributeEnv(env)
+	if _, ok := env["AWS_PROFILE"]; ok {
+		t.Error("should not inject AWS_PROFILE when ~/.aws absent")
+	}
+}
+
+func TestPiContributeEnv_WithAWSDir(t *testing.T) {
+	home := t.TempDir()
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Write a minimal ~/.aws/config with a region
+	cfgContent := "[default]\nregion = us-west-2\noutput = json\n"
+	if err := os.WriteFile(filepath.Join(awsDir, "config"), []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewPiProvider()
+	orig := piUserHomeDir
+	piUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { piUserHomeDir = orig })
+
+	env := map[string]string{}
+	p.ContributeEnv(env)
+
+	if env["AWS_PROFILE"] != "default" {
+		t.Errorf("AWS_PROFILE = %q, want default", env["AWS_PROFILE"])
+	}
+	if env["AWS_REGION"] != "us-west-2" {
+		t.Errorf("AWS_REGION = %q, want us-west-2", env["AWS_REGION"])
+	}
+}
+
+func TestPiContributeEnv_ExistingAWSVarSkipped(t *testing.T) {
+	home := t.TempDir()
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewPiProvider()
+	orig := piUserHomeDir
+	piUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { piUserHomeDir = orig })
+
+	// Pre-existing AWS var must not be overwritten
+	env := map[string]string{"AWS_PROFILE": "prod"}
+	p.ContributeEnv(env)
+	if env["AWS_PROFILE"] != "prod" {
+		t.Errorf("AWS_PROFILE = %q, want prod (user-set value should be preserved)", env["AWS_PROFILE"])
+	}
+}
+
+func TestReadAWSDefaultRegion(t *testing.T) {
+	home := t.TempDir()
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "default profile with region",
+			content: "[default]\nregion = eu-central-1\n",
+			want:    "eu-central-1",
+		},
+		{
+			name:    "default profile first then other",
+			content: "[default]\nregion = ap-southeast-1\n\n[profile staging]\nregion = us-east-1\n",
+			want:    "ap-southeast-1",
+		},
+		{
+			name:    "no default profile",
+			content: "[profile staging]\nregion = us-east-1\n",
+			want:    "",
+		},
+		{
+			name:    "empty config",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "default profile without region",
+			content: "[default]\noutput = json\n",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfgPath := filepath.Join(awsDir, "config")
+			if err := os.WriteFile(cfgPath, []byte(tt.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			got := readAWSDefaultRegion(home)
+			if got != tt.want {
+				t.Errorf("readAWSDefaultRegion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/provider/pi_test.go
+++ b/pkg/provider/pi_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,6 +30,9 @@ func TestPiInterfaces(t *testing.T) {
 	var p Provider = NewPiProvider()
 	if _, ok := p.(ModelLister); !ok {
 		t.Error("pi must implement ModelLister")
+	}
+	if _, ok := p.(DynamicModelLister); !ok {
+		t.Error("pi must implement DynamicModelLister")
 	}
 	if _, ok := p.(EnvContributor); !ok {
 		t.Error("pi must implement EnvContributor")
@@ -136,19 +140,63 @@ func TestPiBuildCommand(t *testing.T) {
 
 func TestPiModels(t *testing.T) {
 	p := NewPiProvider()
+	// Static Models() returns empty — live list comes from ListModels.
+	// Mycel must not bake in model choices; the user picks from what pi reports.
 	models := p.Models()
-	if len(models) == 0 {
-		t.Fatal("Models() must return at least one model")
+	if len(models) != 0 {
+		t.Errorf("Models() = %v, want empty static list (use ListModels for live list)", models)
 	}
-	// Bedrock Kimi model must be first (recommended default)
-	if models[0] != "amazon-bedrock/moonshotai.kimi-k2.5" {
-		t.Errorf("first model = %q, want amazon-bedrock/moonshotai.kimi-k2.5", models[0])
+}
+
+func TestPiListModels(t *testing.T) {
+	p := NewPiProvider()
+	orig := piListModels
+	t.Cleanup(func() { piListModels = orig })
+
+	tests := []struct {
+		name   string
+		output string
+		want   []string
+	}{
+		{
+			name: "two-column rows joined with slash",
+			output: "groq           llama-3.3-70b-versatile\n" +
+				"anthropic      claude-sonnet-4-6\n" +
+				"amazon-bedrock moonshotai.kimi-k2.5\n",
+			want: []string{
+				"groq/llama-3.3-70b-versatile",
+				"anthropic/claude-sonnet-4-6",
+				"amazon-bedrock/moonshotai.kimi-k2.5",
+			},
+		},
+		{
+			name:   "empty output returns empty list",
+			output: "",
+			want:   []string{},
+		},
+		{
+			name:   "single-column rows are skipped",
+			output: "header\ngroq  llama-3.3-70b-versatile\n",
+			want:   []string{"groq/llama-3.3-70b-versatile"},
+		},
 	}
-	// All models must pass SafePiModelName
-	for _, m := range models {
-		if !SafePiModelName(m) {
-			t.Errorf("model %q fails SafePiModelName", m)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			captured := tt.output
+			piListModels = func(_ context.Context) (string, error) { return captured, nil }
+			got, err := p.ListModels(t.Context())
+			if err != nil {
+				t.Fatalf("ListModels() error = %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ListModels() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ListModels()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Part of #3334

## Summary

- **Model routing**: `BuildCommand` splits `provider/model` (e.g. `amazon-bedrock/moonshotai.kimi-k2.5`) into separate `--provider` and `--model` flags so pi routes to the correct backend unambiguously. Bare model ids (no slash) pass through as a single `--model` flag. When no model is given, pi uses its own configured default — mycel does not override it.
- **Live model list via `DynamicModelLister`**: `ListModels` shells `pi --list-models`, parses the two-column `provider  model` output verbatim, and returns `provider/model` strings. This includes `amazon-bedrock` rows when AWS creds are visible to pi. The static `Models()` returns empty — no baked-in model choices.
- **AWS env injection (no secrets)**: New `EnvContributor` interface in `pkg/provider/capabilities.go` lets providers contribute session env vars. `PiProvider` implements it: when `~/.aws` exists and no `AWS_*` vars are already set, injects `AWS_PROFILE=default` and `AWS_REGION` (read from `~/.aws/config [default]`; falls back to `AWS_DEFAULT_REGION`). Real key material stays in `~/.aws/credentials` — only the profile pointer and region enter the agent session.
- `injectProviderEnv` in `pkg/agent/agent.go` calls the `EnvContributor` hook after `injectGatewayEnv` in both the new-agent and restart spawn paths.

## Test plan

- [x] `go test ./pkg/provider/ -race` — all pass: `TestSafePiModelName`, `TestPiBuildCommand` (10 cases), `TestPiListModels` (3 cases), `TestPiContributeEnv_*` (3 cases), `TestReadAWSDefaultRegion` (5 cases)
- [x] `go test ./pkg/agent/ -race` — all pass
- [x] `golangci-lint run ./pkg/provider/ ./pkg/agent/` — 0 issues
- [x] `make build-local-bc` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)