### PR TITLE
feat(agent): inject vault secrets into agent env (github/slack/telegram/discord) + fix empty-passphrase MCP resolution

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1282,6 +1282,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	injectEnv(env, wsPath, name, existing.EnvFile, existing.Env)
 	injectGatewayEnv(env, m.gatewayConfig)
 	injectProviderEnv(env, toolName, m.providerRegistry)
+	injectVaultSecrets(env, wsPath, resolveRoleSecrets(wsPath, string(existing.Role)))
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -1522,6 +1523,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	injectEnv(env, wsPath, name, opts.EnvFile, opts.Env)
 	injectGatewayEnv(env, m.gatewayConfig)
 	injectProviderEnv(env, effectiveTool, m.providerRegistry)
+	injectVaultSecrets(env, wsPath, resolveRoleSecrets(wsPath, string(role)))
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -3717,8 +3719,151 @@ func injectProviderEnv(env map[string]string, toolName string, registry *provide
 	}
 }
 
+// wellKnownVaultTokens lists vault secret names that are automatically injected
+// as agent env vars when present, without requiring explicit role declaration.
+// These are integration/gateway tokens that agents commonly need.
+//
+//nolint:gochecknoglobals // package-level constant slice — read-only
+var wellKnownVaultTokens = []string{
+	"SLACK_BOT_TOKEN",
+	"SLACK_APP_TOKEN",
+	"TELEGRAM_BOT_TOKEN",
+	"DISCORD_BOT_TOKEN",
+}
+
+// openLayeredStore opens the global + workspace vault layers and returns a
+// LayeredStore along with a closer function (never nil when ls != nil).
+// Either layer may be missing/unopenable; at least one must succeed or ls is nil.
+// The caller is responsible for calling closeFunc() when done.
+func openLayeredStore(wsPath, passphrase string) (ls *secret.LayeredStore, closeFunc func()) {
+	globalVaultPath, err := workspace.GlobalSecretsVault()
+	if err != nil {
+		log.Debug("vault injection: global vault path unavailable", "error", err)
+	}
+
+	var globalStore *secret.Store
+	if globalVaultPath != "" {
+		if gs, e := secret.OpenVaultFile(globalVaultPath, passphrase); e == nil {
+			globalStore = gs
+		} else {
+			log.Debug("vault injection: global vault unavailable", "error", e)
+		}
+	}
+
+	var wsStore *secret.Store
+	if wsPath != "" {
+		if ws, e := secret.NewStore(wsPath, passphrase); e == nil {
+			wsStore = ws
+		} else {
+			log.Debug("vault injection: workspace vault unavailable", "error", e)
+		}
+	}
+
+	if globalStore == nil && wsStore == nil {
+		return nil, nil
+	}
+
+	ls = secret.NewLayeredStore(globalStore, wsStore)
+	closeFunc = func() { _ = ls.Close() }
+	return ls, closeFunc
+}
+
+// injectVaultSecrets injects vault secrets into the agent env map.
+//
+// Precedence (highest → lowest):
+//  1. Existing value in env (set by agent env-file, injectGatewayEnv, or injectProviderEnv)
+//  2. Vault value (global ~/.mycel/secrets.vault + workspace <ws>/.bc/secrets.db, workspace wins)
+//
+// Call AFTER injectEnv + injectGatewayEnv + injectProviderEnv so that
+// gateway-config tokens are never overwritten by vault copies.
+//
+// Role-scoped secrets (roleSecrets from ResolvedRole.Secrets) act as an
+// allowlist: vault values are not sprayed across every agent indiscriminately.
+// Well-known integration tokens (SLACK_BOT_TOKEN etc.) are also exported when
+// present as a convenience for agents that don't declare them in their role.
+//
+// GITHUB_PERSONAL_ACCESS_TOKEN and GITHUB_TOKEN in the vault are aliased to
+// both GITHUB_TOKEN and GH_TOKEN so git/gh tooling works without manual wiring.
+//
+// Secret VALUES are never logged.
+func injectVaultSecrets(env map[string]string, wsPath string, roleSecrets []string) {
+	passphrase, err := secret.Passphrase()
+	if err != nil {
+		log.Warn("vault injection skipped: cannot read passphrase", "error", err)
+		return
+	}
+
+	ls, closeLS := openLayeredStore(wsPath, passphrase)
+	if ls == nil {
+		return
+	}
+	defer closeLS()
+
+	// injectIfAbsent sets env[key] from the vault secret "name" only when the
+	// key is not already present. Values are intentionally not logged.
+	injectIfAbsent := func(key, name string) {
+		if _, exists := env[key]; exists {
+			return // existing value wins
+		}
+		val, e := ls.GetValue(name)
+		if e != nil || val == "" {
+			return
+		}
+		env[key] = val
+		log.Debug("injected vault secret into agent env", "key", key)
+	}
+
+	// 1. Role-declared secrets — scoped allowlist so each role controls which
+	//    vault entries it receives.
+	for _, name := range roleSecrets {
+		injectIfAbsent(name, name)
+	}
+
+	// 2. Well-known integration tokens — convenience auto-export regardless of
+	//    role declaration so "connect once → agents have it" works out of the box.
+	for _, name := range wellKnownVaultTokens {
+		injectIfAbsent(name, name)
+	}
+
+	// 3. GitHub PAT aliases: vault GITHUB_PERSONAL_ACCESS_TOKEN or GITHUB_TOKEN
+	//    is exported as both GITHUB_TOKEN and GH_TOKEN so git/gh commands work.
+	for _, src := range []string{"GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_TOKEN"} {
+		val, e := ls.GetValue(src)
+		if e != nil || val == "" {
+			continue
+		}
+		if _, exists := env["GITHUB_TOKEN"]; !exists {
+			env["GITHUB_TOKEN"] = val
+			log.Debug("injected vault secret into agent env", "key", "GITHUB_TOKEN")
+		}
+		if _, exists := env["GH_TOKEN"]; !exists {
+			env["GH_TOKEN"] = val
+			log.Debug("injected vault secret into agent env", "key", "GH_TOKEN")
+		}
+		break // first source wins; don't double-process
+	}
+}
+
+// resolveRoleSecrets returns the Secrets list for a named role via BFS
+// inheritance merge. Returns nil (no error) when the role cannot be loaded
+// so callers can proceed with an empty allowlist.
+func resolveRoleSecrets(wsPath, roleName string) []string {
+	rm, err := workspace.NewGlobalRoleManager(workspaceStateDir(wsPath))
+	if err != nil {
+		log.Debug("resolveRoleSecrets: cannot open role manager", "error", err)
+		return nil
+	}
+	resolved, err := rm.ResolveRole(roleName)
+	if err != nil {
+		log.Debug("resolveRoleSecrets: cannot resolve role", "role", roleName, "error", err)
+		return nil
+	}
+	return resolved.Secrets
+}
+
 // resolveSecretRefs resolves ${secret:NAME} references in env values using the
-// workspace secret store. If the store cannot be opened, references are left as-is.
+// layered vault (global + workspace). If neither vault can be opened, references
+// are left as-is.
 func resolveSecretRefs(env map[string]string, workspacePath string) {
 	// Check if any values contain secret references before opening the store
 	hasRefs := false
@@ -3738,14 +3883,14 @@ func resolveSecretRefs(env map[string]string, workspacePath string) {
 		return
 	}
 
-	store, err := secret.NewStore(workspacePath, passphrase)
-	if err != nil {
-		log.Warn("failed to open secret store for env resolution", "error", err)
+	ls, closeLS := openLayeredStore(workspacePath, passphrase)
+	if ls == nil {
+		log.Warn("failed to open secret store for env resolution")
 		return
 	}
-	defer func() { _ = store.Close() }()
+	defer closeLS()
 
-	resolved := store.ResolveEnv(env)
+	resolved := ls.ResolveEnv(env)
 	for k, v := range resolved {
 		env[k] = v
 	}

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -302,18 +302,31 @@ func bcSelfURL(runtimeBackend, agentName string) string {
 
 // ── Secrets ─────────────────────────────────────────────────────────────────
 
+// loadSecrets fetches secret values by name from the layered vault
+// (global ~/.mycel/secrets.vault + workspace <ws>/.bc/secrets.db, workspace wins).
+// Uses the real passphrase so encrypted vaults are readable; an empty passphrase
+// was the previous bug that caused MCP ${secret:NAME} references to silently fail.
 func loadSecrets(workspacePath string, names []string) map[string]string {
 	m := make(map[string]string)
 	if len(names) == 0 {
 		return m
 	}
-	ss, err := secret.NewStore(workspacePath, "")
+	passphrase, err := secret.Passphrase()
 	if err != nil {
+		log.Warn("loadSecrets: cannot read passphrase", "error", err)
 		return m
 	}
-	defer ss.Close() //nolint:errcheck
+
+	ls, closeLS := openLayeredStore(workspacePath, passphrase)
+	if closeLS != nil {
+		defer closeLS()
+	}
+	if ls == nil {
+		return m
+	}
+
 	for _, n := range names {
-		if v, e := ss.GetValue(n); e == nil {
+		if v, e := ls.GetValue(n); e == nil {
 			m[n] = v
 		}
 	}

--- a/pkg/agent/vault_inject_test.go
+++ b/pkg/agent/vault_inject_test.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/secret"
+)
+
+// seedWorkspaceVault writes a secret into the workspace vault under wsPath/.bc/secrets.db.
+func seedWorkspaceVault(t *testing.T, wsPath, name, value string) {
+	t.Helper()
+	ss, err := secret.NewStore(wsPath, "test-passphrase")
+	if err != nil {
+		t.Fatalf("seedWorkspaceVault: NewStore: %v", err)
+	}
+	defer func() { _ = ss.Close() }()
+	if err := ss.Set(name, value, ""); err != nil {
+		t.Fatalf("seedWorkspaceVault: Set %q: %v", name, err)
+	}
+}
+
+// seedGlobalVault writes a secret into the global vault at globalVaultPath.
+func seedGlobalVault(t *testing.T, globalVaultPath, name, value string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(globalVaultPath), 0700); err != nil {
+		t.Fatalf("seedGlobalVault: MkdirAll: %v", err)
+	}
+	gs, err := secret.OpenVaultFile(globalVaultPath, "test-passphrase")
+	if err != nil {
+		t.Fatalf("seedGlobalVault: OpenVaultFile: %v", err)
+	}
+	defer func() { _ = gs.Close() }()
+	if err := gs.Set(name, value, ""); err != nil {
+		t.Fatalf("seedGlobalVault: Set %q: %v", name, err)
+	}
+}
+
+// TestInjectVaultSecrets covers the vault→env injection helper.
+func TestInjectVaultSecrets(t *testing.T) {
+	// Pin the passphrase and home dir so all sub-tests share the same key.
+	mycelHome := t.TempDir()
+	t.Setenv("MYCEL_HOME", mycelHome)
+	t.Setenv(secret.PassphraseEnvVar, "test-passphrase")
+
+	wsPath := t.TempDir()
+	globalVaultPath := filepath.Join(mycelHome, "secrets.vault")
+
+	seedWorkspaceVault(t, wsPath, "WS_SECRET", "ws-value")
+	seedWorkspaceVault(t, wsPath, "SLACK_BOT_TOKEN", "slack-ws-token")
+	seedWorkspaceVault(t, wsPath, "GITHUB_PERSONAL_ACCESS_TOKEN", "ghp-token-123")
+	seedGlobalVault(t, globalVaultPath, "GLOBAL_SECRET", "global-value")
+	seedGlobalVault(t, globalVaultPath, "SHARED_SECRET", "global-shared")
+	seedWorkspaceVault(t, wsPath, "SHARED_SECRET", "ws-wins")
+
+	tests := []struct {
+		name        string
+		preEnv      map[string]string // env already set before injection
+		roleSecrets []string
+		wantKey     string
+		wantValue   string
+		wantAbsent  []string
+	}{
+		{
+			name:        "role-declared secret injected from workspace vault",
+			preEnv:      map[string]string{},
+			roleSecrets: []string{"WS_SECRET"},
+			wantKey:     "WS_SECRET",
+			wantValue:   "ws-value",
+		},
+		{
+			name:        "role-declared secret injected from global vault",
+			preEnv:      map[string]string{},
+			roleSecrets: []string{"GLOBAL_SECRET"},
+			wantKey:     "GLOBAL_SECRET",
+			wantValue:   "global-value",
+		},
+		{
+			name:        "workspace vault wins over global for same name",
+			preEnv:      map[string]string{},
+			roleSecrets: []string{"SHARED_SECRET"},
+			wantKey:     "SHARED_SECRET",
+			wantValue:   "ws-wins",
+		},
+		{
+			name:   "well-known gateway token auto-injected without role declaration",
+			preEnv: map[string]string{},
+			// SLACK_BOT_TOKEN not in roleSecrets — should still inject via wellKnownVaultTokens
+			roleSecrets: nil,
+			wantKey:     "SLACK_BOT_TOKEN",
+			wantValue:   "slack-ws-token",
+		},
+		{
+			name: "existing env wins over vault (precedence)",
+			preEnv: map[string]string{
+				"SLACK_BOT_TOKEN": "gateway-token", // set by injectGatewayEnv
+			},
+			roleSecrets: []string{"SLACK_BOT_TOKEN"},
+			wantKey:     "SLACK_BOT_TOKEN",
+			wantValue:   "gateway-token", // vault must NOT overwrite
+		},
+		{
+			name:        "missing secret skipped — no key inserted",
+			preEnv:      map[string]string{},
+			roleSecrets: []string{"DOES_NOT_EXIST"},
+			wantAbsent:  []string{"DOES_NOT_EXIST"},
+		},
+		{
+			name:        "GITHUB_PAT aliased to GITHUB_TOKEN and GH_TOKEN",
+			preEnv:      map[string]string{},
+			roleSecrets: []string{"GITHUB_PERSONAL_ACCESS_TOKEN"},
+			wantKey:     "GITHUB_TOKEN",
+			wantValue:   "ghp-token-123",
+		},
+		{
+			name:        "GH_TOKEN also aliased from GITHUB_PAT",
+			preEnv:      map[string]string{},
+			roleSecrets: []string{"GITHUB_PERSONAL_ACCESS_TOKEN"},
+			wantKey:     "GH_TOKEN",
+			wantValue:   "ghp-token-123",
+		},
+		{
+			name: "existing GITHUB_TOKEN wins over vault alias",
+			preEnv: map[string]string{
+				"GITHUB_TOKEN": "existing-gh-token",
+			},
+			roleSecrets: []string{"GITHUB_PERSONAL_ACCESS_TOKEN"},
+			wantKey:     "GITHUB_TOKEN",
+			wantValue:   "existing-gh-token",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := make(map[string]string, len(tc.preEnv))
+			for k, v := range tc.preEnv {
+				env[k] = v
+			}
+
+			injectVaultSecrets(env, wsPath, tc.roleSecrets)
+
+			if tc.wantKey != "" {
+				if got := env[tc.wantKey]; got != tc.wantValue {
+					t.Errorf("env[%q] = %q, want %q", tc.wantKey, got, tc.wantValue)
+				}
+			}
+			for _, absent := range tc.wantAbsent {
+				if _, ok := env[absent]; ok {
+					t.Errorf("env[%q] should be absent but is present", absent)
+				}
+			}
+		})
+	}
+}
+
+// TestLoadSecrets_RealPassphrase proves loadSecrets resolves values correctly
+// when the vault is encrypted with a real passphrase (BUG 1 regression test).
+// Previously loadSecrets opened with empty passphrase "" which silently returned
+// empty values on encrypted vaults.
+func TestLoadSecrets_RealPassphrase(t *testing.T) {
+	mycelHome := t.TempDir()
+	t.Setenv("MYCEL_HOME", mycelHome)
+	t.Setenv(secret.PassphraseEnvVar, "strong-passphrase")
+
+	wsPath := t.TempDir()
+	// Seed with the REAL passphrase.
+	ss, err := secret.NewStore(wsPath, "strong-passphrase")
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+	if err := ss.Set("MCP_API_KEY", "the-real-value", ""); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	_ = ss.Close()
+
+	got := loadSecrets(wsPath, []string{"MCP_API_KEY"})
+
+	if got["MCP_API_KEY"] != "the-real-value" {
+		t.Errorf("loadSecrets with real passphrase: MCP_API_KEY = %q, want %q",
+			got["MCP_API_KEY"], "the-real-value")
+	}
+}
+
+// TestResolveSecretRefs_LayeredStore ensures resolveSecretRefs resolves refs
+// from the layered (global+workspace) vault, not just the workspace vault.
+func TestResolveSecretRefs_LayeredStore(t *testing.T) {
+	mycelHome := t.TempDir()
+	t.Setenv("MYCEL_HOME", mycelHome)
+	t.Setenv(secret.PassphraseEnvVar, "test-passphrase")
+
+	wsPath := t.TempDir()
+	globalVaultPath := filepath.Join(mycelHome, "secrets.vault")
+
+	// Secret lives ONLY in the global vault.
+	seedGlobalVault(t, globalVaultPath, "GLOBAL_API_KEY", "global-resolved-value")
+
+	env := map[string]string{
+		"MYCEL_AGENT_ID": "agent1",
+		"API_KEY":        "${secret:GLOBAL_API_KEY}",
+	}
+	resolveSecretRefs(env, wsPath)
+
+	if env["API_KEY"] != "global-resolved-value" {
+		t.Errorf("resolveSecretRefs from global vault: API_KEY = %q, want %q",
+			env["API_KEY"], "global-resolved-value")
+	}
+	// System vars must be untouched.
+	if env["MYCEL_AGENT_ID"] != "agent1" {
+		t.Errorf("MYCEL_AGENT_ID clobbered: %q", env["MYCEL_AGENT_ID"])
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix BUG 1** (`loadSecrets` in `role_setup.go`): was opening the vault with an empty passphrase `""`, silently returning empty values for every MCP `${secret:NAME}` reference on encrypted vaults. Now uses `secret.Passphrase()` and `LayeredStore` (global + workspace, workspace wins).
- **Fix BUG 2** (no auto-export): adds `injectVaultSecrets` called in both spawn paths (create + restart) after `injectGatewayEnv`/`injectProviderEnv`. Exports role-declared secrets (scoped allowlist from `ResolvedRole.Secrets`) plus well-known gateway tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `TELEGRAM_BOT_TOKEN`, `DISCORD_BOT_TOKEN`) from the vault into agent env when not already set.
- **Fix BUG 3** (no `GITHUB_TOKEN`): `GITHUB_PERSONAL_ACCESS_TOKEN` or `GITHUB_TOKEN` in the vault is aliased to both `GITHUB_TOKEN` and `GH_TOKEN` so `git`/`gh` work inside agents without manual wiring.
- **Fix BUG 4** (`resolveSecretRefs` workspace-only): `${secret:NAME}` refs in env values now resolve from the layered vault (global + workspace), not just the workspace store.

**Precedence**: explicit env-file > gateway-config (preferences.json) > vault. Vault only fills absent keys; never overwrites. Secret values are never logged.

Part of #3334

## Test plan

- [ ] `go test ./pkg/agent/ ./pkg/secret/` — all pass
- [ ] `golangci-lint run ./pkg/agent/ ./pkg/secret/ ./pkg/workspace/` — 0 issues
- [ ] `make build-local-bc` — compiles clean
- [ ] `TestInjectVaultSecrets` — 9 table cases: workspace/global injection, layered precedence, well-known token auto-export, missing secret skipped, GitHub PAT aliasing, existing-env wins
- [ ] `TestLoadSecrets_RealPassphrase` — regression: empty-passphrase bug does not regress
- [ ] `TestResolveSecretRefs_LayeredStore` — global vault refs resolve via `${secret:NAME}`
- [ ] Manual: set `GITHUB_PERSONAL_ACCESS_TOKEN` in the vault → spawn an agent → verify `GITHUB_TOKEN` + `GH_TOKEN` are in the session env
- [ ] Manual: set `SLACK_BOT_TOKEN` in the vault → spawn any agent → verify the token reaches the session without gateway-config entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)