### PR TITLE
feat(notify): store connected-app credentials + WhatsApp session in the secrets vault

### DIFF
--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/rpuneet/mycel/pkg/gateway"
 	bcwhatsapp "github.com/rpuneet/mycel/pkg/gateway/whatsapp"
+	"github.com/rpuneet/mycel/pkg/log"
 	"github.com/rpuneet/mycel/pkg/notify"
+	"github.com/rpuneet/mycel/pkg/secret"
 	"github.com/rpuneet/mycel/pkg/workspace"
 )
 
@@ -18,6 +20,7 @@ type GatewayHandler struct {
 	gw        *gateway.Manager
 	ws        *workspace.Workspace
 	notifySvc *notify.Service
+	vault     *secret.Store
 }
 
 // NewGatewayHandler creates a GatewayHandler.
@@ -28,6 +31,27 @@ func NewGatewayHandler(gw *gateway.Manager, ws *workspace.Workspace) *GatewayHan
 // SetNotifyService sets the notification service for subscription management.
 func (h *GatewayHandler) SetNotifyService(svc *notify.Service) {
 	h.notifySvc = svc
+}
+
+// SetSecretStore wires the secrets vault so that gateway credentials are
+// mirrored into the vault under canonical env-var names whenever a platform
+// is connected or updated. The vault write is additive — preferences.json
+// continues to be written for backward compatibility.
+func (h *GatewayHandler) SetSecretStore(s *secret.Store) {
+	h.vault = s
+}
+
+// writeVaultSecret stores key=value in the vault (no-op when no vault is
+// wired or when value is empty). Values are intentionally not logged.
+func (h *GatewayHandler) writeVaultSecret(key, value string) {
+	if h.vault == nil || value == "" {
+		return
+	}
+	if err := h.vault.Set(key, value, "gateway credential"); err != nil {
+		log.Warn("gateway: failed to write secret to vault", "key", key, "error", err)
+		return
+	}
+	log.Debug("gateway: wrote credential to vault", "key", key)
 }
 
 // Register mounts gateway routes.
@@ -487,6 +511,32 @@ func (h *GatewayHandler) updatePlatform(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	// Mirror credentials into the secrets vault under canonical env names so
+	// injectVaultSecrets can pick them up when spinning up a new agent.
+	// Vault write is additive — preferences.json is still the authoritative
+	// source for the gateway manager.
+	switch {
+	case platform == "telegram":
+		if cfg.Gateways.Telegram != nil {
+			h.writeVaultSecret("TELEGRAM_BOT_TOKEN", cfg.Gateways.Telegram.BotToken)
+		}
+	case strings.HasPrefix(platform, "telegram:"):
+		label := strings.TrimPrefix(platform, "telegram:")
+		if tc := cfg.Gateways.Telegrams[label]; tc != nil {
+			key := "TELEGRAM_BOT_TOKEN_" + strings.ToUpper(strings.ReplaceAll(label, "-", "_"))
+			h.writeVaultSecret(key, tc.BotToken)
+		}
+	case platform == "discord":
+		if cfg.Gateways.Discord != nil {
+			h.writeVaultSecret("DISCORD_BOT_TOKEN", cfg.Gateways.Discord.BotToken)
+		}
+	case platform == "slack":
+		if cfg.Gateways.Slack != nil {
+			h.writeVaultSecret("SLACK_BOT_TOKEN", cfg.Gateways.Slack.BotToken)
+			h.writeVaultSecret("SLACK_APP_TOKEN", cfg.Gateways.Slack.AppToken)
+		}
+	}
+
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated", "platform": platform})
 }
 
@@ -848,6 +898,12 @@ func (h *GatewayHandler) whatsappPair(w http.ResponseWriter, r *http.Request, ro
 		if err != nil {
 			httpError(w, err.Error(), http.StatusInternalServerError)
 			return
+		}
+		// When pairing completes synchronously (device already paired / reconnect),
+		// write the authenticated JID (phone number) into the vault so agents can
+		// reference the session. Values are never logged.
+		if status.State == "connected" && status.Phone != "" {
+			h.writeVaultSecret("WHATSAPP_SESSION", status.Phone)
 		}
 		writeJSON(w, http.StatusOK, status)
 

--- a/server/handlers/gateways_test.go
+++ b/server/handlers/gateways_test.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/rpuneet/mycel/pkg/gateway"
+	"github.com/rpuneet/mycel/pkg/secret"
+	"github.com/rpuneet/mycel/pkg/workspace"
 )
 
 // stubAdapter implements gateway.NotificationAdapter for testing.
@@ -304,5 +308,150 @@ func TestNotify503FallsBackWithoutReason(t *testing.T) {
 	}
 	if !strings.Contains(rr.Body.String(), "notify service not available") {
 		t.Errorf("unexpected 503 body: %s", rr.Body.String())
+	}
+}
+
+// --- Vault write tests ---
+
+// openTestVault creates a temporary secrets vault for testing and returns it
+// along with a cleanup function.
+func openTestVault(t *testing.T) *secret.Store {
+	t.Helper()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.vault")
+	v, err := secret.OpenVaultFile(vaultPath, "test-passphrase")
+	if err != nil {
+		t.Fatalf("open test vault: %v", err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	return v
+}
+
+// setupTestWorkspace creates a minimal workspace directory suitable for
+// gateway config updates. Uses a sandboxed MYCEL_HOME to avoid polluting the
+// caller's real registry.
+func setupTestWorkspace(t *testing.T) *workspace.Workspace {
+	t.Helper()
+	// Sandbox global state so workspace.Init doesn't write to the real registry.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("MYCEL_HOME", filepath.Join(home, ".bc"))
+
+	dir := t.TempDir()
+	// workspace.Init requires a git repository.
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o750); err != nil {
+		t.Fatalf("create .git: %v", err)
+	}
+	wks, err := workspace.Init(dir)
+	if err != nil {
+		t.Fatalf("workspace.Init: %v", err)
+	}
+	return wks
+}
+
+// TestUpdatePlatformSlackWritesVault verifies that a Slack PATCH persists
+// SLACK_BOT_TOKEN and SLACK_APP_TOKEN in the vault.
+func TestUpdatePlatformSlackWritesVault(t *testing.T) {
+	wks := setupTestWorkspace(t)
+	vault := openTestVault(t)
+
+	h := &GatewayHandler{ws: wks, vault: vault}
+
+	body := `{"bot_token":"xoxb-bot-token","app_token":"xapp-app-token","enabled":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/gateways/slack", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.updatePlatform(rr, req, "slack")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	if got, err := vault.GetValue("SLACK_BOT_TOKEN"); err != nil || got != "xoxb-bot-token" {
+		t.Errorf("SLACK_BOT_TOKEN = %q (err %v), want %q", got, err, "xoxb-bot-token")
+	}
+	if got, err := vault.GetValue("SLACK_APP_TOKEN"); err != nil || got != "xapp-app-token" {
+		t.Errorf("SLACK_APP_TOKEN = %q (err %v), want %q", got, err, "xapp-app-token")
+	}
+}
+
+// TestUpdatePlatformDiscordWritesVault verifies that a Discord PATCH persists
+// DISCORD_BOT_TOKEN in the vault.
+func TestUpdatePlatformDiscordWritesVault(t *testing.T) {
+	wks := setupTestWorkspace(t)
+	vault := openTestVault(t)
+
+	h := &GatewayHandler{ws: wks, vault: vault}
+
+	body := `{"bot_token":"discord-bot-token","enabled":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/gateways/discord", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.updatePlatform(rr, req, "discord")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	if got, err := vault.GetValue("DISCORD_BOT_TOKEN"); err != nil || got != "discord-bot-token" {
+		t.Errorf("DISCORD_BOT_TOKEN = %q (err %v), want %q", got, err, "discord-bot-token")
+	}
+}
+
+// TestUpdatePlatformTelegramWritesVault verifies that a plain Telegram PATCH
+// persists TELEGRAM_BOT_TOKEN in the vault.
+func TestUpdatePlatformTelegramWritesVault(t *testing.T) {
+	wks := setupTestWorkspace(t)
+	vault := openTestVault(t)
+
+	h := &GatewayHandler{ws: wks, vault: vault}
+
+	body := `{"bot_token":"tg-bot-token","enabled":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/gateways/telegram", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.updatePlatform(rr, req, "telegram")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	if got, err := vault.GetValue("TELEGRAM_BOT_TOKEN"); err != nil || got != "tg-bot-token" {
+		t.Errorf("TELEGRAM_BOT_TOKEN = %q (err %v), want %q", got, err, "tg-bot-token")
+	}
+}
+
+// TestUpdatePlatformTelegramLabelWritesVault verifies that a labeled Telegram
+// PATCH persists TELEGRAM_BOT_TOKEN_<LABEL> in the vault.
+func TestUpdatePlatformTelegramLabelWritesVault(t *testing.T) {
+	wks := setupTestWorkspace(t)
+	vault := openTestVault(t)
+
+	h := &GatewayHandler{ws: wks, vault: vault}
+
+	body := `{"bot_token":"tg-label-token","enabled":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/gateways/telegram:mybot", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.updatePlatform(rr, req, "telegram:mybot")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
+	}
+
+	if got, err := vault.GetValue("TELEGRAM_BOT_TOKEN_MYBOT"); err != nil || got != "tg-label-token" {
+		t.Errorf("TELEGRAM_BOT_TOKEN_MYBOT = %q (err %v), want %q", got, err, "tg-label-token")
+	}
+}
+
+// TestUpdatePlatformNoVaultIsNoop verifies that updatePlatform succeeds and
+// does not panic when no vault is wired.
+func TestUpdatePlatformNoVaultIsNoop(t *testing.T) {
+	wks := setupTestWorkspace(t)
+
+	h := &GatewayHandler{ws: wks} // no vault
+
+	body := `{"bot_token":"xoxb-no-vault","app_token":"xapp-no-vault","enabled":true}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/gateways/slack", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.updatePlatform(rr, req, "slack")
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rr.Code, rr.Body.String())
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -374,6 +374,9 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		if svc.Notify != nil {
 			gh.SetNotifyService(svc.Notify)
 		}
+		if svc.Secrets != nil {
+			gh.SetSecretStore(svc.Secrets)
+		}
 		gh.Register(mux)
 	}
 	// Repo listing + discovery scanners for the folder picker. The repos


### PR DESCRIPTION
## Summary

- Adds a `vault *secret.Store` field to `GatewayHandler` with a `SetSecretStore` setter, wired from `server.go` via `svc.Secrets`
- In `updatePlatform`, after saving `preferences.json`, mirrors credentials into the vault under canonical env names (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `DISCORD_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_TOKEN_<LABEL>`)
- In `whatsappPair`, writes `WHATSAPP_SESSION = phone/JID` when `StartPairing` returns a synchronous "connected" state (already-paired reconnect)

Part of #3334

## Test plan

- [x] `TestUpdatePlatformSlackWritesVault` — Slack PATCH → `SLACK_BOT_TOKEN` + `SLACK_APP_TOKEN` in vault
- [x] `TestUpdatePlatformDiscordWritesVault` — Discord PATCH → `DISCORD_BOT_TOKEN` in vault
- [x] `TestUpdatePlatformTelegramWritesVault` — Telegram PATCH → `TELEGRAM_BOT_TOKEN` in vault
- [x] `TestUpdatePlatformTelegramLabelWritesVault` — `telegram:mybot` PATCH → `TELEGRAM_BOT_TOKEN_MYBOT` in vault
- [x] `TestUpdatePlatformNoVaultIsNoop` — handler succeeds and doesn't panic when no vault is wired
- [x] `make build-local-bc` passes
- [x] `golangci-lint run ./server/handlers/ ./server/ ./pkg/secret/` = 0 issues
- [x] `go test ./server/handlers/ ./pkg/secret/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)