### PR TITLE
fix(provider): inject AWS env into pi --list-models so Bedrock/Kimi appear in the Providers UI

### DIFF
--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -114,9 +115,48 @@ func (p *PiProvider) Models() []string {
 	return []string{}
 }
 
+// piAWSPointerEnv returns the AWS pointer env vars ("KEY=VALUE") to append to
+// the pi --list-models command environment so Bedrock models (e.g. Kimi 2.5)
+// appear in the Providers UI. Returns nil when injection is not needed:
+//   - any AWS_* key is already set in the daemon's process environment
+//   - ~/.aws directory does not exist on the host
+//
+// Only the two non-secret pointer vars (AWS_PROFILE, AWS_REGION) are returned;
+// secret key material is never fabricated here.
+func piAWSPointerEnv() []string {
+	// Respect any AWS_* already present in the daemon's environment.
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "AWS_") {
+			return nil
+		}
+	}
+	home, err := piUserHomeDir()
+	if err != nil {
+		return nil
+	}
+	awsDir := filepath.Join(home, ".aws")
+	if _, err := os.Stat(awsDir); err != nil { //nolint:gosec // awsDir is derived from UserHomeDir, not user input
+		return nil
+	}
+	result := []string{"AWS_PROFILE=default"}
+	if region := readAWSDefaultRegion(home); region != "" {
+		result = append(result, "AWS_REGION="+region)
+	} else if region = os.Getenv("AWS_DEFAULT_REGION"); region != "" {
+		result = append(result, "AWS_REGION="+region)
+	}
+	return result
+}
+
 // piListModels is overridable in tests.
 var piListModels = func(ctx context.Context) (string, error) {
-	return runProviderCommand(ctx, "pi", "--list-models")
+	//nolint:gosec // "pi" is a trusted provider binary name, not user input
+	cmd := exec.CommandContext(ctx, "pi", "--list-models")
+	cmd.Env = append(os.Environ(), piAWSPointerEnv()...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
 }
 
 // ListModels queries `pi --list-models` and returns models in "provider/model"

--- a/pkg/provider/pi_test.go
+++ b/pkg/provider/pi_test.go
@@ -261,6 +261,91 @@ func TestPiContributeEnv_ExistingAWSVarSkipped(t *testing.T) {
 	}
 }
 
+// TestPiAWSPointerEnv_NoAWSDir verifies no env vars are injected when ~/.aws is absent.
+func TestPiAWSPointerEnv_NoAWSDir(t *testing.T) {
+	orig := piUserHomeDir
+	piUserHomeDir = func() (string, error) { return t.TempDir(), nil }
+	t.Cleanup(func() { piUserHomeDir = orig })
+
+	// Ensure no AWS_* vars bleed in from the test runner's environment.
+	for _, key := range []string{"AWS_PROFILE", "AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"} {
+		t.Setenv(key, "")
+		t.Cleanup(func() { os.Unsetenv(key) }) //nolint:errcheck // cleanup only
+	}
+
+	got := piAWSPointerEnv()
+	if got != nil {
+		t.Errorf("piAWSPointerEnv() = %v, want nil when ~/.aws absent", got)
+	}
+}
+
+// TestPiAWSPointerEnv_WithAWSDir verifies AWS_PROFILE and AWS_REGION are injected
+// when ~/.aws exists and no AWS_* vars are set in the environment.
+func TestPiAWSPointerEnv_WithAWSDir(t *testing.T) {
+	home := t.TempDir()
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfgContent := "[default]\nregion = us-east-1\noutput = json\n"
+	if err := os.WriteFile(filepath.Join(awsDir, "config"), []byte(cfgContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := piUserHomeDir
+	piUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { piUserHomeDir = orig })
+
+	// Clear any ambient AWS_* from the test environment.
+	for _, key := range []string{"AWS_PROFILE", "AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"} {
+		os.Unsetenv(key) //nolint:errcheck
+	}
+
+	got := piAWSPointerEnv()
+	if len(got) == 0 {
+		t.Fatal("piAWSPointerEnv() = nil, want non-empty slice when ~/.aws present")
+	}
+	wantProfile := "AWS_PROFILE=default"
+	wantRegion := "AWS_REGION=us-east-1"
+	hasProfile, hasRegion := false, false
+	for _, e := range got {
+		if e == wantProfile {
+			hasProfile = true
+		}
+		if e == wantRegion {
+			hasRegion = true
+		}
+	}
+	if !hasProfile {
+		t.Errorf("piAWSPointerEnv() missing %q; got %v", wantProfile, got)
+	}
+	if !hasRegion {
+		t.Errorf("piAWSPointerEnv() missing %q; got %v", wantRegion, got)
+	}
+}
+
+// TestPiAWSPointerEnv_SkipsWhenAWSEnvAlreadySet verifies no injection occurs
+// when the daemon process already has an AWS_* variable set.
+func TestPiAWSPointerEnv_SkipsWhenAWSEnvAlreadySet(t *testing.T) {
+	home := t.TempDir()
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := piUserHomeDir
+	piUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { piUserHomeDir = orig })
+
+	// Pre-set an AWS env var — injection must be skipped.
+	t.Setenv("AWS_PROFILE", "prod")
+
+	got := piAWSPointerEnv()
+	if got != nil {
+		t.Errorf("piAWSPointerEnv() = %v, want nil when AWS_PROFILE already set", got)
+	}
+}
+
 func TestReadAWSDefaultRegion(t *testing.T) {
 	home := t.TempDir()
 	awsDir := filepath.Join(home, ".aws")


### PR DESCRIPTION
## Summary

- `piListModels` (the `pi --list-models` exec) previously ran in the daemon's bare environment, so Amazon Bedrock models (including `moonshotai/kimi-k2.5` / Kimi 2.5) never appeared in the Providers UI — the AWS SDK saw no credentials.
- Added `piAWSPointerEnv()` that mirrors the existing `EnvContributor` logic: reads `AWS_PROFILE=default` and `AWS_REGION` (from `~/.aws/config`) and returns them as `[]string` for appending to `os.Environ()` on the exec.
- Injection is skipped when any `AWS_*` var is already in the daemon's environment (user config wins) or `~/.aws` is absent — no secret key material is fabricated.

Part of #3334

## Test plan

- [ ] `TestPiAWSPointerEnv_NoAWSDir` — nil returned when `~/.aws` absent (temp HOME, no real filesystem hit)
- [ ] `TestPiAWSPointerEnv_WithAWSDir` — `AWS_PROFILE=default` and `AWS_REGION=us-east-1` returned when `~/.aws/config` present
- [ ] `TestPiAWSPointerEnv_SkipsWhenAWSEnvAlreadySet` — nil returned when `AWS_PROFILE` already set in process env
- [ ] All existing `pi_test.go` tests (identity, interfaces, BuildCommand, ListModels, ContributeEnv, readAWSDefaultRegion) continue to pass
- [ ] `go test -race ./pkg/provider/` passes
- [ ] `golangci-lint run ./pkg/provider/` = 0 issues
- [ ] `go build ./cmd/mycel/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)