### PR TITLE
feat(agent): mycel-authored injected instructions pushed to agents (with MCP/secret summary)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -503,6 +503,11 @@ type Manager struct { //nolint:govet // field order is intentional for readabili
 	// gatewayConfig holds gateway credentials for injection into agent env vars.
 	gatewayConfig *workspace.GatewaysConfig
 
+	// wsConfig points at the live workspace config so spawn paths can read
+	// mycel-authored injected instructions. It is the same pointer the
+	// settings API mutates in place, so edits take effect on the next spawn.
+	wsConfig *workspace.Config
+
 	// providersConfig holds the workspace's provider command overrides
 	// (preferences.json `providers.<tool>.command`). Used by
 	// getAgentCommand to layer a user-supplied command on top of the
@@ -542,6 +547,7 @@ func (m *Manager) ApplyWorkspaceConfig(cfg *workspace.Config) {
 	}
 	m.gatewayConfig = &cfg.Gateways
 	m.providersConfig = &cfg.Providers
+	m.wsConfig = cfg
 }
 
 // notifyStateChange calls the onStateChange callback if set.
@@ -1282,7 +1288,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	injectEnv(env, wsPath, name, existing.EnvFile, existing.Env)
 	injectGatewayEnv(env, m.gatewayConfig)
 	injectProviderEnv(env, toolName, m.providerRegistry)
-	injectVaultSecrets(env, wsPath, resolveRoleSecrets(wsPath, string(existing.Role)))
+	secretEnvKeys := injectVaultSecrets(env, wsPath, resolveRoleSecrets(wsPath, string(existing.Role)))
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -1347,6 +1353,10 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 		log.Warn("role setup failed on restart", "agent", name, "error", setupErr)
 	}
 	appendGatewayPrompt(wtDir, existing.Tool, m.gatewayConfig)
+	if err := appendInjectedInstructions(ctx, injectedPromptFile(wtDir, existing.Tool), m.wsConfig,
+		resolveRoleMCPServers(wsPath, string(existing.Role)), secretEnvKeys); err != nil {
+		log.Warn("failed to append injected instructions", "agent", name, "error", err)
+	}
 
 	if err := rt.CreateSessionWithEnv(ctx, name, wtDir, agentCmd, env); err != nil {
 		agentLock.Unlock()
@@ -1523,7 +1533,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	injectEnv(env, wsPath, name, opts.EnvFile, opts.Env)
 	injectGatewayEnv(env, m.gatewayConfig)
 	injectProviderEnv(env, effectiveTool, m.providerRegistry)
-	injectVaultSecrets(env, wsPath, resolveRoleSecrets(wsPath, string(role)))
+	secretEnvKeys := injectVaultSecrets(env, wsPath, resolveRoleSecrets(wsPath, string(role)))
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -1567,6 +1577,10 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 
 	// Append platform credential instructions to the agent's prompt file
 	appendGatewayPrompt(wtDir, effectiveTool, m.gatewayConfig)
+	if err := appendInjectedInstructions(ctx, injectedPromptFile(wtDir, effectiveTool), m.wsConfig,
+		resolveRoleMCPServers(wsPath, string(role)), secretEnvKeys); err != nil {
+		log.Warn("failed to append injected instructions", "agent", name, "error", err)
+	}
 
 	// Validate required tools before starting — fail fast with clear errors.
 	if toolErrs := validateAgentTools(wsPath, string(role)); len(toolErrs) > 0 {
@@ -3433,6 +3447,64 @@ func appendGatewayPrompt(targetDir, toolName string, cfg *workspace.GatewaysConf
 	}
 }
 
+// injectedPromptFile resolves the prompt file path (CLAUDE.md or the
+// provider-equivalent) inside an agent worktree for the given tool.
+func injectedPromptFile(targetDir, toolName string) string {
+	adapter := resolveConfigAdapter(toolName)
+	return filepath.Join(targetDir, adapter.PromptFile())
+}
+
+// appendInjectedInstructions appends the mycel-authored injected-instructions
+// block to an agent's prompt file. The block carries the authored text plus an
+// auto-generated summary of the MCP servers and credential env var NAMES the
+// agent has access to. Secret VALUES are never written — only key names.
+//
+// It is a no-op (returns nil) when no instructions are configured.
+func appendInjectedInstructions(ctx context.Context, promptFile string, cfg *workspace.Config, mcpServers, secretEnvKeys []string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if cfg == nil || strings.TrimSpace(cfg.InjectedInstructions) == "" {
+		return nil
+	}
+
+	// promptFile is derived from a validated agent worktree path; reject
+	// traversal segments as defense in depth.
+	cleaned := filepath.Clean(promptFile)
+	if strings.Contains(cleaned, "..") {
+		return fmt.Errorf("refusing to write injected instructions to traversal path %q", promptFile)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n## mycel instructions\n\n")
+	sb.WriteString(strings.TrimSpace(cfg.InjectedInstructions))
+	sb.WriteString("\n\n### Available resources\n")
+	sb.WriteString("MCP servers: " + summarizeNames(mcpServers) + "\n")
+	sb.WriteString("Credential env vars: " + summarizeNames(secretEnvKeys) + "\n")
+
+	f, err := os.OpenFile(cleaned, os.O_APPEND|os.O_WRONLY, 0600) //nolint:gosec // controlled agent workspace path
+	if err != nil {
+		return fmt.Errorf("open prompt file: %w", err)
+	}
+	defer f.Close() //nolint:errcheck
+	if _, err := f.WriteString(sb.String()); err != nil {
+		return fmt.Errorf("write injected instructions: %w", err)
+	}
+	return nil
+}
+
+// summarizeNames renders a sorted, comma-separated list of names, or the
+// literal "none" when the list is empty. Used to summarize MCP servers and
+// credential env var NAMES for injected instructions — never values.
+func summarizeNames(names []string) string {
+	if len(names) == 0 {
+		return "none"
+	}
+	sorted := append([]string(nil), names...)
+	sort.Strings(sorted)
+	return strings.Join(sorted, ", ")
+}
+
 // injectGatewayEnv injects platform credentials from gateway config into agent
 // environment variables so agents can call platform APIs directly.
 func injectGatewayEnv(env map[string]string, gw *workspace.GatewaysConfig) {
@@ -3786,18 +3858,24 @@ func openLayeredStore(wsPath, passphrase string) (ls *secret.LayeredStore, close
 // both GITHUB_TOKEN and GH_TOKEN so git/gh tooling works without manual wiring.
 //
 // Secret VALUES are never logged.
-func injectVaultSecrets(env map[string]string, wsPath string, roleSecrets []string) {
+//
+// The returned slice holds the NAMES of env keys populated from the vault
+// (never their values) so callers can summarize available credentials to the
+// agent without ever exposing the secrets themselves.
+func injectVaultSecrets(env map[string]string, wsPath string, roleSecrets []string) []string {
 	passphrase, err := secret.Passphrase()
 	if err != nil {
 		log.Warn("vault injection skipped: cannot read passphrase", "error", err)
-		return
+		return nil
 	}
 
 	ls, closeLS := openLayeredStore(wsPath, passphrase)
 	if ls == nil {
-		return
+		return nil
 	}
 	defer closeLS()
+
+	var injected []string
 
 	// injectIfAbsent sets env[key] from the vault secret "name" only when the
 	// key is not already present. Values are intentionally not logged.
@@ -3810,6 +3888,7 @@ func injectVaultSecrets(env map[string]string, wsPath string, roleSecrets []stri
 			return
 		}
 		env[key] = val
+		injected = append(injected, key)
 		log.Debug("injected vault secret into agent env", "key", key)
 	}
 
@@ -3834,14 +3913,18 @@ func injectVaultSecrets(env map[string]string, wsPath string, roleSecrets []stri
 		}
 		if _, exists := env["GITHUB_TOKEN"]; !exists {
 			env["GITHUB_TOKEN"] = val
+			injected = append(injected, "GITHUB_TOKEN")
 			log.Debug("injected vault secret into agent env", "key", "GITHUB_TOKEN")
 		}
 		if _, exists := env["GH_TOKEN"]; !exists {
 			env["GH_TOKEN"] = val
+			injected = append(injected, "GH_TOKEN")
 			log.Debug("injected vault secret into agent env", "key", "GH_TOKEN")
 		}
 		break // first source wins; don't double-process
 	}
+
+	return injected
 }
 
 // resolveRoleSecrets returns the Secrets list for a named role via BFS
@@ -3859,6 +3942,30 @@ func resolveRoleSecrets(wsPath, roleName string) []string {
 		return nil
 	}
 	return resolved.Secrets
+}
+
+// resolveRoleMCPServers returns the effective MCP server names an agent of the
+// named role receives. It mirrors role_setup: the resolved role's MCPServers
+// plus the always-present "bc" self server. Returns just "bc" when the role
+// cannot be loaded so the summary is never empty for a live agent.
+func resolveRoleMCPServers(wsPath, roleName string) []string {
+	names := []string{"bc"}
+	rm, err := workspace.NewGlobalRoleManager(workspaceStateDir(wsPath))
+	if err != nil {
+		log.Debug("resolveRoleMCPServers: cannot open role manager", "error", err)
+		return names
+	}
+	resolved, err := rm.ResolveRole(roleName)
+	if err != nil {
+		log.Debug("resolveRoleMCPServers: cannot resolve role", "role", roleName, "error", err)
+		return names
+	}
+	for _, n := range resolved.MCPServers {
+		if n != "bc" {
+			names = append(names, n)
+		}
+	}
+	return names
 }
 
 // resolveSecretRefs resolves ${secret:NAME} references in env values using the

--- a/pkg/agent/injected_instructions_test.go
+++ b/pkg/agent/injected_instructions_test.go
@@ -1,0 +1,133 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/workspace"
+)
+
+// writeEmptyPromptFile creates an empty prompt file so appendInjectedInstructions
+// (which opens with O_APPEND|O_WRONLY, no O_CREATE) can write to it.
+func writeEmptyPromptFile(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(p, []byte("# existing prompt\n"), 0o600); err != nil {
+		t.Fatalf("seed prompt file: %v", err)
+	}
+	return p
+}
+
+func TestAppendInjectedInstructions_AppendsBlock(t *testing.T) {
+	p := writeEmptyPromptFile(t)
+	cfg := &workspace.Config{
+		InjectedInstructions: "Always report status before and after work.",
+	}
+
+	err := appendInjectedInstructions(
+		context.Background(),
+		p,
+		cfg,
+		[]string{"github", "bc"},                // intentionally unsorted
+		[]string{"SLACK_BOT_TOKEN", "GH_TOKEN"}, // key NAMES only
+	)
+	if err != nil {
+		t.Fatalf("appendInjectedInstructions: %v", err)
+	}
+
+	data, err := os.ReadFile(p) //nolint:gosec // test file path from t.TempDir
+	if err != nil {
+		t.Fatalf("read prompt file: %v", err)
+	}
+	got := string(data)
+
+	for _, want := range []string{
+		"# existing prompt",                              // pre-existing content preserved
+		"## mycel instructions",                          // block header
+		"Always report status before and after work.",    // authored text
+		"### Available resources",                        // resources sub-header
+		"MCP servers: bc, github",                        // sorted MCP names
+		"Credential env vars: GH_TOKEN, SLACK_BOT_TOKEN", // sorted key NAMES
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("prompt file missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+// TestAppendInjectedInstructions_NoSecretValues proves that only credential env
+// var NAMES are written — a secret VALUE handed to the function via env would
+// never reach the prompt because the function only ever receives names.
+func TestAppendInjectedInstructions_NoSecretValues(t *testing.T) {
+	p := writeEmptyPromptFile(t)
+	cfg := &workspace.Config{InjectedInstructions: "Do the thing."}
+
+	const secretValue = "xoxb-super-secret-token-value" //nolint:gosec // fake token used to assert non-leakage
+
+	// Only the NAME is passed. The value must never be written.
+	if err := appendInjectedInstructions(
+		context.Background(),
+		p,
+		cfg,
+		nil,
+		[]string{"SLACK_BOT_TOKEN"},
+	); err != nil {
+		t.Fatalf("appendInjectedInstructions: %v", err)
+	}
+
+	data, err := os.ReadFile(p) //nolint:gosec // test file path from t.TempDir
+	if err != nil {
+		t.Fatalf("read prompt file: %v", err)
+	}
+	got := string(data)
+
+	if strings.Contains(got, secretValue) {
+		t.Fatalf("secret value leaked into prompt file:\n%s", got)
+	}
+	if !strings.Contains(got, "SLACK_BOT_TOKEN") {
+		t.Errorf("expected credential name in prompt, got:\n%s", got)
+	}
+	if !strings.Contains(got, "MCP servers: none") {
+		t.Errorf("expected empty MCP summary to render as \"none\", got:\n%s", got)
+	}
+}
+
+func TestAppendInjectedInstructions_EmptyIsNoop(t *testing.T) {
+	p := writeEmptyPromptFile(t)
+	before, err := os.ReadFile(p) //nolint:gosec // test file path from t.TempDir
+	if err != nil {
+		t.Fatalf("read prompt file: %v", err)
+	}
+
+	// Empty / whitespace-only instructions must not touch the file.
+	for _, cfg := range []*workspace.Config{
+		nil,
+		{InjectedInstructions: ""},
+		{InjectedInstructions: "   \n\t "},
+	} {
+		if appendErr := appendInjectedInstructions(context.Background(), p, cfg, []string{"bc"}, []string{"GH_TOKEN"}); appendErr != nil {
+			t.Fatalf("appendInjectedInstructions: %v", appendErr)
+		}
+	}
+
+	after, err := os.ReadFile(p) //nolint:gosec // test file path from t.TempDir
+	if err != nil {
+		t.Fatalf("read prompt file: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("prompt file changed on no-op:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+func TestSummariseNames(t *testing.T) {
+	if got := summarizeNames(nil); got != "none" {
+		t.Errorf("summarizeNames(nil) = %q, want none", got)
+	}
+	if got := summarizeNames([]string{"c", "a", "b"}); got != "a, b, c" {
+		t.Errorf("summarizeNames sorted = %q, want \"a, b, c\"", got)
+	}
+}

--- a/pkg/workspace/config.go
+++ b/pkg/workspace/config.go
@@ -29,7 +29,10 @@ type Config struct { //nolint:govet // field order matches JSON/API contract
 	Cron      CronConfig      `json:"cron"`
 	Logs      LogsConfig      `json:"logs"`
 	UI        UIConfig        `json:"ui"`
-	Version   int             `json:"version"`
+	// InjectedInstructions is mycel-authored guidance appended to every
+	// agent's prompt file at spawn time. Never contains secret values.
+	InjectedInstructions string `json:"injected_instructions"`
+	Version              int    `json:"version"`
 }
 
 // UserConfig holds user identity settings.

--- a/server/handlers/settings.go
+++ b/server/handlers/settings.go
@@ -21,6 +21,56 @@ func NewSettingsHandler(ws *workspace.Workspace) *SettingsHandler {
 // Register mounts settings routes on mux.
 func (h *SettingsHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/settings", h.handle)
+	mux.HandleFunc("/api/settings/injected-instructions", h.handleInjected)
+}
+
+// injectedInstructionsBody is the request/response shape for the
+// injected-instructions endpoint.
+type injectedInstructionsBody struct {
+	InjectedInstructions string `json:"injected_instructions"`
+}
+
+func (h *SettingsHandler) handleInjected(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, injectedInstructionsBody{
+			InjectedInstructions: h.ws.Config.InjectedInstructions,
+		})
+	case http.MethodPut:
+		h.putInjected(w, r)
+	default:
+		methodNotAllowed(w)
+	}
+}
+
+func (h *SettingsHandler) putInjected(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	if err != nil {
+		httpError(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	var req injectedInstructionsBody
+	if err := json.Unmarshal(body, &req); err != nil {
+		httpError(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	merged := *h.ws.Config
+	merged.InjectedInstructions = req.InjectedInstructions
+	if err := merged.Validate(); err != nil {
+		httpError(w, "validation failed: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := merged.Save(h.ws.SettingsFile()); err != nil {
+		httpInternalError(w, "save config", err)
+		return
+	}
+	*h.ws.Config = merged
+
+	writeJSON(w, http.StatusOK, injectedInstructionsBody{
+		InjectedInstructions: h.ws.Config.InjectedInstructions,
+	})
 }
 
 func (h *SettingsHandler) handle(w http.ResponseWriter, r *http.Request) {
@@ -103,6 +153,11 @@ func (h *SettingsHandler) patch(w http.ResponseWriter, r *http.Request) {
 		case "ui":
 			if err := json.Unmarshal(raw, &merged.UI); err != nil {
 				httpError(w, "invalid ui config: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+		case "injected_instructions":
+			if err := json.Unmarshal(raw, &merged.InjectedInstructions); err != nil {
+				httpError(w, "invalid injected_instructions: "+err.Error(), http.StatusBadRequest)
 				return
 			}
 		case "version":

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1031,4 +1031,12 @@ export const api = {
       body: JSON.stringify(patch),
     }),
 
+  getInjectedInstructions: () =>
+    request<{ injected_instructions: string }>("/settings/injected-instructions"),
+  updateInjectedInstructions: (text: string) =>
+    request<{ injected_instructions: string }>("/settings/injected-instructions", {
+      method: "PUT",
+      body: JSON.stringify({ injected_instructions: text }),
+    }),
+
 };

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -100,6 +100,10 @@ const SECTION_META: Record<string, { icon: React.ReactNode; desc: string }> = {
     icon: <path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />,
     desc: "Optional supporting services",
   },
+  "injected instructions": {
+    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />,
+    desc: "Sent to every agent at spawn",
+  },
 };
 
 function Section({
@@ -272,6 +276,76 @@ function LogsSection({ data, onChange }: { data: Record<string, unknown>; onChan
       <Field label="Path"><input className={INPUT_CLS} value={String(l.path ?? "")} onChange={(e) => onChange(["logs", "path"], e.target.value)} /></Field>
       <Field label="Max Size" suffix="MB"><input className={INPUT_CLS} type="number" value={maxMB} onChange={(e) => onChange(["logs", "max_bytes"], Number(e.target.value) * 1048576)} /></Field>
     </>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Injected instructions — mycel-authored text pushed to every agent   */
+/* ------------------------------------------------------------------ */
+
+function InjectedInstructionsSection() {
+  const [text, setText] = useState("");
+  const [original, setOriginal] = useState("");
+  const [status, setStatus] = useState<SaveStatus>("idle");
+
+  useEffect(() => {
+    let alive = true;
+    api.getInjectedInstructions()
+      .then((res) => {
+        if (!alive) return;
+        setText(res.injected_instructions ?? "");
+        setOriginal(res.injected_instructions ?? "");
+      })
+      .catch(() => { /* leave empty on load failure */ });
+    return () => { alive = false; };
+  }, []);
+
+  const dirty = text !== original;
+
+  const handleSave = async () => {
+    setStatus("saving");
+    try {
+      const res = await api.updateInjectedInstructions(text);
+      const saved = res.injected_instructions ?? "";
+      setText(saved);
+      setOriginal(saved);
+      setStatus("saved");
+      setTimeout(() => setStatus("idle"), 2000);
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-[11px] text-mycel-muted">
+        Appended to every agent&apos;s prompt file at spawn, followed by an
+        auto-generated summary of its available MCP servers and credential
+        env var names. Secret values are never included.
+      </p>
+      <textarea
+        className={`${INPUT_CLS} h-40 resize-y leading-relaxed`}
+        placeholder="e.g. Always report status before and after work. Prefer small PRs."
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <div className="flex items-center justify-end gap-2">
+        {status === "saved" && (
+          <span className="text-xs text-mycel-success">Saved</span>
+        )}
+        {status === "error" && (
+          <span className="text-xs text-mycel-error">Save failed</span>
+        )}
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={status === "saving" || !dirty}
+          className="inline-flex items-center h-8 px-3 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-all disabled:opacity-50"
+        >
+          {status === "saving" ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -459,7 +533,12 @@ export function Settings() {
         </Section>
       </div>
 
-      {/* Row 4: Optional dependencies (bc-db, bc-code-server, bc-browser) */}
+      {/* Row 4: Injected instructions (sent to every agent) */}
+      <Section title="injected instructions" dirty={false}>
+        <InjectedInstructionsSection />
+      </Section>
+
+      {/* Row 5: Optional dependencies (bc-db, bc-code-server, bc-browser) */}
       <Section title="dependencies" dirty={false}>
         <DependenciesSection />
       </Section>


### PR DESCRIPTION
## Summary

- Add `injected_instructions` field to workspace config (settings.json)
- At agent spawn, append a `## mycel instructions` block to the prompt file containing the authored text plus an auto-generated summary of available MCP servers and credential env var names (never values)
- New `GET/PUT /api/settings/injected-instructions` REST endpoints
- Textarea editor in web Settings page — "Injected instructions (sent to every agent)"

Part of #3334

## Test plan
- [ ] Add `injected_instructions` text in Settings → save → verify it persists in settings.json
- [ ] Spawn a new agent → inspect CLAUDE.md / prompt file → confirm `## mycel instructions` block appears with correct MCP/secret-key summary
- [ ] Confirm secret values are never written to the prompt file
- [ ] `go test ./pkg/agent/ ./pkg/workspace/` passes including the new injection tests
- [ ] `make build-local-bc` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)