### PR TITLE
fix(marketplace): dedupe catalog items by ID (popular servers flooded the grid)

### DIFF
--- a/pkg/marketplace/aggregator.go
+++ b/pkg/marketplace/aggregator.go
@@ -127,7 +127,26 @@ func (a *Aggregator) aggregate(ctx context.Context) ([]Item, error) {
 		log.Info("marketplace: source loaded", "source", r.source, "count", len(r.items))
 		all = append(all, r.items...)
 	}
-	return all, nil
+	return dedupeByID(all), nil
+}
+
+// dedupeByID collapses items that share an ID, keeping the first occurrence.
+// The MCP registry (and others) can return one row per published version of a
+// server, so a popular server would otherwise appear as dozens of identical
+// cards; this guarantees one catalog entry per unique item across all sources.
+func dedupeByID(items []Item) []Item {
+	seen := make(map[string]struct{}, len(items))
+	out := make([]Item, 0, len(items))
+	for _, it := range items {
+		if it.ID != "" {
+			if _, dup := seen[it.ID]; dup {
+				continue
+			}
+			seen[it.ID] = struct{}{}
+		}
+		out = append(out, it)
+	}
+	return out
 }
 
 // ── MCP registry ──────────────────────────────────────────────────────────────

--- a/pkg/marketplace/aggregator_test.go
+++ b/pkg/marketplace/aggregator_test.go
@@ -291,3 +291,27 @@ func TestItemIDFormat(t *testing.T) {
 		t.Errorf("empty store should yield 0 items, got %d", len(items))
 	}
 }
+
+func TestDedupeByID(t *testing.T) {
+	in := []Item{
+		{ID: "mcp-registry:ai.bowmark/bowmark", Name: "bowmark"},
+		{ID: "mcp-registry:ai.bowmark/bowmark", Name: "bowmark"}, // dup version
+		{ID: "mcp-registry:ai.bowmark/bowmark", Name: "bowmark"}, // dup version
+		{ID: "github:foo/bar", Name: "bar"},
+		{ID: "", Name: "no-id-a"}, // empty IDs are kept as-is
+		{ID: "", Name: "no-id-b"},
+	}
+	out := dedupeByID(in)
+	if len(out) != 4 {
+		t.Fatalf("expected 4 items after dedup, got %d", len(out))
+	}
+	var bowmark int
+	for _, it := range out {
+		if it.ID == "mcp-registry:ai.bowmark/bowmark" {
+			bowmark++
+		}
+	}
+	if bowmark != 1 {
+		t.Errorf("bowmark should collapse to 1 entry, got %d", bowmark)
+	}
+}


### PR DESCRIPTION
The Marketplace showed the same item repeated dozens of times (e.g. `ai.bowmark/bowmark` × 153) — 611 catalog items but only 292 unique. Root cause: the MCP registry returns one row per published *version* of a server, and the aggregator never deduped.

Fix: a global `dedupeByID` pass in `aggregate()` keeps the first occurrence of each item ID across all sources, so every unique item appears once. Defends against any source double-listing, not just the MCP registry.

Part of #3334

## Test plan
- `go build ./pkg/marketplace/` ✓ · `go test ./pkg/marketplace/` ✓ (added `TestDedupeByID`: 3 bowmark versions → 1, empty-ID items preserved) · `golangci-lint run ./pkg/marketplace/` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)