### PR TITLE
fix(agent): remove dead bc-MCP refs + activate injected instructions in server

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -154,7 +154,6 @@ AI Agent (Claude Code)             mycel MCP Server
 HTTP transport is mounted under `/_mcp/`:
 - `/_mcp/<agent>/{sse,message}` — SSE stream plus client-request endpoint, agent identity in the path
 - `/_mcp/<wsID>/<agent>/…` — workspace-scoped form, dispatched via the WorkspaceManager
-- A compatibility shim (`server/mcp_compat.go`) keeps older `/_mcp` URL shapes working
 
 stdio transport is used by locally launched agent tooling.
 

--- a/docs/explanation/mcp.md
+++ b/docs/explanation/mcp.md
@@ -24,10 +24,9 @@ graph LR
 
 | Transport | Entry | Limit | Use Case |
 |-----------|-------|-------|----------|
-| stdio | `mycel mcp serve` | 4MB/line | Claude Code direct via .mcp.json |
-| SSE (bcd) | `/_mcp/sse` + `/_mcp/message` | 4MB body | Browser clients, remote |
+| stdio | bcd stdio proxy | 4MB/line | Claude Code direct via .mcp.json |
 | SSE (agent-scoped) | `/_mcp/{agent}/sse` + `/_mcp/{agent}/message` | 4MB body | Agents with server-side identity |
-| SSE (standalone) | `mycel mcp serve --sse` (default `:8811`) | 4MB body | Without a running bcd |
+| SSE (workspace-scoped) | `/_mcp/{wsID}/{agent}/sse` + `/_mcp/{wsID}/{agent}/message` | 4MB body | Multi-workspace bcd instances |
 
 ## Sender Identity
 
@@ -82,7 +81,7 @@ mycel manages MCP servers that agents connect to (Playwright, GitHub, etc.):
 - Env vars support `${secret:NAME}`
 - Written to agent `.mcp.json` during role setup
 
-`mycel mcp register` adds mycel itself as an MCP server in `preferences.json` so agents automatically get the tools above (stdio by default, `--sse` for the SSE endpoint).
+MCP servers declared in a role's `mcp_servers` list are automatically written to the agent's `.mcp.json` on spawn — no manual registration step is needed.
 
 ## Code Map
 
@@ -94,5 +93,5 @@ mycel manages MCP servers that agents connect to (Playwright, GitHub, etc.):
 | `server/mcp/resources.go` | Resource readers |
 | `server/mcp/sse.go` | SSE transport + broker, agent-scoped routing |
 | `server/mcp/stdio.go` | stdio transport |
-| `internal/cmd/mcp.go` | `mycel mcp` CLI (add, serve, register, ...) |
+| `internal/cmd/mcp.go` | `mycel mcp` CLI (add, list, show, remove, enable, disable) |
 | `pkg/mcp/store.go` | External MCP config storage |

--- a/docs/explanation/networking.md
+++ b/docs/explanation/networking.md
@@ -26,7 +26,7 @@ All communication flows through the **mycel server** as the central hub. No comp
 | REST API | HTTP/JSON | `/api/*` (see the [REST API reference](../reference/api-rest.md)) | CRUD for all resources |
 | SSE Events | HTTP SSE | `/api/events` | Real-time state updates |
 | MCP (stdio) | JSON-RPC 2.0 | stdin/stdout | Agent -> server integration |
-| MCP (SSE) | JSON-RPC 2.0 | `/_mcp/sse` + `/_mcp/message` | Remote MCP clients |
+| MCP (SSE) | JSON-RPC 2.0 | `/_mcp/{agent}/sse` + `/_mcp/{agent}/message` | Agent MCP clients |
 | Health | HTTP | `/health` | Liveness probe |
 
 ## Notification Delivery Flow
@@ -110,8 +110,8 @@ sequenceDiagram
 
 | Transport | Connection | Use Case |
 |-----------|-----------|----------|
-| **stdio** | `mycel mcp serve` via `.mcp.json` | Claude Code agents (local) |
-| **SSE** | `GET /_mcp/sse` + `POST /_mcp/message` (agent-scoped: `/_mcp/{agent}/sse\|message`) | Remote/browser MCP clients |
+| **stdio** | bcd stdio proxy via `.mcp.json` | Claude Code agents (local) |
+| **SSE** | `GET /_mcp/{agent}/sse` + `POST /_mcp/{agent}/message` | Remote/browser MCP clients |
 
 Messages sent over the SSE transport go through the server's global HTTP
 middleware, so they are subject to the **1 MB** request body cap

--- a/internal/cmd/template.go
+++ b/internal/cmd/template.go
@@ -212,7 +212,7 @@ func runTemplateCreate(_ *cobra.Command, args []string) error {
 	t := template.Template{
 		Name:        name,
 		Description: "",
-		MCPs:        []string{"bc"},
+		MCPs:        []string{},
 	}
 	if err := store.Create(t, "", scope); err != nil {
 		return err

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3800,6 +3800,7 @@ var wellKnownVaultTokens = []string{
 	"SLACK_APP_TOKEN",
 	"TELEGRAM_BOT_TOKEN",
 	"DISCORD_BOT_TOKEN",
+	"WHATSAPP_SESSION",
 }
 
 // openLayeredStore opens the global + workspace vault layers and returns a
@@ -3944,27 +3945,20 @@ func resolveRoleSecrets(wsPath, roleName string) []string {
 }
 
 // resolveRoleMCPServers returns the effective MCP server names an agent of the
-// named role receives. It mirrors role_setup: the resolved role's MCPServers
-// plus the always-present "bc" self server. Returns just "bc" when the role
-// cannot be loaded so the summary is never empty for a live agent.
+// named role receives. It returns the resolved role's MCPServers list only —
+// no implicit servers are added. Returns nil when the role cannot be loaded.
 func resolveRoleMCPServers(wsPath, roleName string) []string {
-	names := []string{"bc"}
 	rm, err := workspace.NewGlobalRoleManager(workspaceStateDir(wsPath))
 	if err != nil {
 		log.Debug("resolveRoleMCPServers: cannot open role manager", "error", err)
-		return names
+		return nil
 	}
 	resolved, err := rm.ResolveRole(roleName)
 	if err != nil {
 		log.Debug("resolveRoleMCPServers: cannot resolve role", "role", roleName, "error", err)
-		return names
+		return nil
 	}
-	for _, n := range resolved.MCPServers {
-		if n != "bc" {
-			names = append(names, n)
-		}
-	}
-	return names
+	return resolved.MCPServers
 }
 
 // resolveSecretRefs resolves ${secret:NAME} references in env values using the

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -15,7 +15,7 @@ import (
 // ToolType classifies a tool.
 const (
 	ToolTypeCLI      = "cli"      // CLI binary (gh, aws, wrangler)
-	ToolTypeMCP      = "mcp"      // MCP server (bc, playwright, github)
+	ToolTypeMCP      = "mcp"      // MCP server (playwright, github, etc.)
 	ToolTypeProvider = "provider" // AI provider (claude, agy, cursor)
 )
 
@@ -84,14 +84,6 @@ var builtinTools = []Tool{
 
 // builtinMCPServers contains default MCP server definitions.
 var builtinMCPServers = []Tool{
-	{
-		Name:      "bc",
-		Type:      ToolTypeMCP,
-		Transport: "sse",
-		URL:       "http://host.docker.internal:9374/_mcp/sse",
-		Enabled:   true,
-		Builtin:   true,
-	},
 	{
 		Name:       "playwright",
 		Type:       ToolTypeMCP,

--- a/pkg/workspace/roles.go
+++ b/pkg/workspace/roles.go
@@ -67,38 +67,29 @@ type RoleManager struct {
 }
 
 // DefaultBaseRole is the foundational role all other roles inherit from.
-// It provides the bc MCP server so every agent can communicate with the workspace.
+// It provides shared channel etiquette and commands to all agents.
 const DefaultBaseRole = `---
 name: base
-description: Base role — provides bc MCP server, workspace communication, and shared commands to all agents
-mcp_servers:
-  - bc
+description: Base role — shared channel etiquette and commands for all agents
 prompt_create: |
   You have been created as a new agent in a mycel workspace.
-  Use the report_status MCP tool to set your initial task.
-  Check #all and #engineering channels for context.
+  Check #all and #engineering channels for context and your initial assignment.
 prompt_start: |
-  You are online. Use report_status to update your current task.
-  Check channels for any messages sent while you were offline.
+  You are online. Check channels for any messages sent while you were offline.
 prompt_stop: |
   You are being stopped. Save any important state.
   Post a status update to #engineering if you have work in progress.
 commands:
   status: |
     Check all channels for recent messages addressed to you.
-    Report your current task using the report_status MCP tool.
-    Query workspace costs using query_costs.
+    Summarize your current task and any blockers.
   notify: |
     Check recent notifications across all subscribed channels.
     Summarize any messages that are relevant to your current work.
   announce: |
-    Send an announcement to the #all channel using send_message.
+    Send an announcement to the #all channel.
     Include your agent name as the sender.
 rules:
-  workspace-communication: |
-    All workspace operations MUST use bc MCP tools. Never use mycel CLI commands directly.
-    Available MCP tools: send_message, report_status, query_costs.
-    Always include your agent name as sender when sending messages.
   channel-etiquette: |
     Use the right channel for the right purpose:
     - #all for broadcast announcements only
@@ -113,16 +104,6 @@ rules:
 
 You are an agent in a **bc** workspace — a CLI-first AI agent orchestration system.
 
-## MCP Tools
-
-All workspace operations use bc MCP tools (never CLI commands):
-
-| Tool | Purpose | Parameters |
-|------|---------|------------|
-| **send_message** | Send messages to channels | {channel, message, sender} |
-| **report_status** | Update your current task | {agent, task} |
-| **query_costs** | Check workspace costs | {agent?} |
-
 ## Channels
 
 - **#all** — Broadcast announcements
@@ -133,7 +114,6 @@ All workspace operations use bc MCP tools (never CLI commands):
 
 ## Guidelines
 
-- Report your status when starting or finishing work
 - Post to the appropriate channel, not #all, for routine updates
 - Use #merge when a PR is ready for review
 - Check channels for messages before starting new work
@@ -151,15 +131,11 @@ secrets:
   - GITHUB_PERSONAL_ACCESS_TOKEN
 prompt_start: |
   You are back online. Check #all channel for any messages you missed.
-  Report your status using the report_status MCP tool.
 ---
 
 # Root Agent
 
 You are the root agent for this mycel workspace.
-
-## Additional MCP Tools
-- **create_agent**: Create new agents {name, role, tool}
 
 ## Responsibilities
 - Oversee all workspace operations
@@ -707,6 +683,12 @@ func (rm *RoleManager) ResolveRole(name string) (*ResolvedRole, error) {
 		if r.Metadata.Review != "" {
 			review = r.Metadata.Review
 		}
+	}
+
+	// Review: target role always wins (per docstring). Override the
+	// ancestor-last-non-empty-wins value with the root's own Review field.
+	if root.Metadata.Review != "" {
+		review = root.Metadata.Review
 	}
 
 	return &ResolvedRole{

--- a/pkg/workspace/roles_test.go
+++ b/pkg/workspace/roles_test.go
@@ -680,7 +680,7 @@ func TestResolveRole_NoParents(t *testing.T) {
 }
 
 // TestResolveRole_DefaultRootInheritsBase ensures the default root role, which has
-// parent_roles: [base], inherits the base prompt, bc MCP server, and no duplicate secrets.
+// parent_roles: [base], inherits the base prompt and github MCP server, and no duplicate secrets.
 func TestResolveRole_DefaultRootInheritsBase(t *testing.T) {
 	rm := newTestRoleManager(t)
 
@@ -712,18 +712,16 @@ func TestResolveRole_DefaultRootInheritsBase(t *testing.T) {
 		t.Errorf("base prompt section (idx %d) should precede root prompt section (idx %d)", baseIdx, rootIdx)
 	}
 
-	// MCPServers must include "bc" (from base) and "github" (from root) — unioned.
-	hasBc, hasGithub := false, false
+	// MCPServers must include "github" (from root). The base role no longer
+	// declares any MCP servers — the old "bc" server was removed.
+	hasGithub := false
 	for _, s := range resolved.MCPServers {
-		if s == "bc" {
-			hasBc = true
-		}
 		if s == "github" {
 			hasGithub = true
 		}
-	}
-	if !hasBc {
-		t.Errorf("MCPServers missing 'bc' (from base); got %v", resolved.MCPServers)
+		if s == "bc" {
+			t.Errorf("MCPServers must not contain removed 'bc' server; got %v", resolved.MCPServers)
+		}
 	}
 	if !hasGithub {
 		t.Errorf("MCPServers missing 'github' (from root); got %v", resolved.MCPServers)

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -164,6 +164,9 @@ func buildServicesFromWS(ctx context.Context, globals *Globals, ws *bcworkspace.
 	if ws.RoleManager != nil {
 		agentMgr.SetRoleManager(ws.RoleManager)
 	}
+	if ws.Config != nil {
+		agentMgr.ApplyWorkspaceConfig(ws.Config)
+	}
 	addCloser(func() error { return agentMgr.Close() })
 
 	// Background container metrics collector (Docker backend only).

--- a/web/src/components/shared/MCPServerList.tsx
+++ b/web/src/components/shared/MCPServerList.tsx
@@ -10,7 +10,6 @@ interface MCPServerListProps {
 }
 
 const KNOWN_MCPS = [
-  { name: "bc", description: "mycel workspace tools (send_message, report_status, query_costs)" },
   { name: "github", description: "GitHub API (create_pr, list_issues, authenticate)" },
   { name: "slack", description: "Slack messaging" },
   { name: "linear", description: "Linear issue tracker" },

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -403,7 +403,7 @@ function CreateTemplateForm({
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
-  const [mcpsRaw, setMcpsRaw] = useState("bc");
+  const [mcpsRaw, setMcpsRaw] = useState("");
   const [secretsRaw, setSecretsRaw] = useState("");
   const [pluginsRaw, setPluginsRaw] = useState("");
   const [status, setStatus] = useState<SaveStatus>({ type: "idle" });


### PR DESCRIPTION
Part of #3334

## Summary

- Removes the dead `"bc"` MCP server entry from `builtinMCPServers` (was seeding a 404 endpoint into every fresh-install agent's `.mcp.json`)
- Scrubs `DefaultBaseRole` of `mcp_servers: [bc]` and all references to removed tools (`send_message`, `report_status`, `query_costs`); updates `DefaultRootRole` similarly
- Calls `agentMgr.ApplyWorkspaceConfig(ws.Config)` in `build_services.go` after `LoadState` — previously `appendInjectedInstructions` was always a no-op in bcd because `wsConfig` was never set on the server path
- Removes the hardcoded `"bc"` seed from `resolveRoleMCPServers`; returns only what the resolved role declares
- Adds `WHATSAPP_SESSION` to `wellKnownVaultTokens` for auto-injection
- Pins `Review` in `ResolveRole` to `root.Metadata.Review` (target role always wins, per docstring)
- Removes `"bc"` from web `KNOWN_MCPS` autocomplete, default `useState` in Templates, and default MCPs in `internal/cmd/template.go`
- Fixes stale docs (`mcp.md`, `networking.md`, `architecture.md`) removing references to removed `mycel mcp serve`/`mycel mcp register` subcommands and `server/mcp_compat.go` shim

## Test plan

- [ ] `go build ./cmd/mycel` passes
- [ ] `golangci-lint run ./pkg/agent/ ./pkg/workspace/ ./pkg/tool/ ./server/...` — 0 issues
- [ ] `go test ./pkg/agent/ ./pkg/workspace/ ./pkg/tool/` — all pass (including updated `TestResolveRole_DefaultRootInheritsBase`)
- [ ] `bun run test` in `web/` — 164 tests pass
- [ ] `bun run lint` in `web/` — clean
- [ ] Spawn a fresh agent and verify `.mcp.json` no longer contains a `"bc"` entry
- [ ] Spawn an agent via bcd (not CLI) and confirm injected instructions file is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server routing now uses agent-scoped SSE endpoints and updated transport options.
  * Workspace role settings are applied automatically when a workspace loads, and role-declared MCP servers are added on agent spawn.

* **Bug Fixes**
  * Removed the default built-in workspace tool from new templates and role inheritance, so new setups start cleaner.
  * Updated role resolution so inherited review settings consistently follow the target role.

* **Documentation**
  * Refreshed MCP, networking, and architecture docs to match the latest transport and management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->