### PR TITLE
fix(gateway): thread sender JID for reactions, allow reaction removal, mention-match clarity

### DIFF
--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -59,7 +59,9 @@ type Manager struct {
 	channelMap map[string]channelRoute
 	// onInbound is called when a message arrives from an external platform.
 	// Typically wired to ChannelService.Send + SSE hub.
-	onInbound    func(bcChannel, sender, content, messageID string, mentions []string, raw json.RawMessage)
+	// senderID carries the platform-native sender identifier (e.g. WhatsApp JID)
+	// so callers can use it for follow-up operations such as reactions.
+	onInbound    func(bcChannel, sender, senderID, content, messageID string, mentions []string, raw json.RawMessage)
 	channelStore ChannelStore
 	mu           sync.RWMutex
 }
@@ -84,10 +86,11 @@ func (m *Manager) SetChannelStore(store ChannelStore) {
 }
 
 // SetInboundHandler sets the callback for inbound messages from external platforms.
-// The callback receives the bc channel name, sender display name, text content,
+// The callback receives the bc channel name, sender display name, platform-native
+// sender id (e.g. WhatsApp JID — used for follow-up reactions), text content,
 // platform-native message ID, pre-extracted mentions (e.g. WhatsApp JID user parts),
 // and the raw platform payload.
-func (m *Manager) SetInboundHandler(fn func(bcChannel, sender, content, messageID string, mentions []string, raw json.RawMessage)) {
+func (m *Manager) SetInboundHandler(fn func(bcChannel, sender, senderID, content, messageID string, mentions []string, raw json.RawMessage)) {
 	m.onInbound = fn
 }
 
@@ -603,7 +606,7 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 		content = string(n.Raw)
 	}
 	if m.onInbound != nil {
-		m.onInbound(bcChannel, sender, content, n.MessageID, n.Mentions, n.Raw)
+		m.onInbound(bcChannel, sender, n.SenderID, content, n.MessageID, n.Mentions, n.Raw)
 	}
 }
 

--- a/pkg/gateway/whatsapp/whatsapp.go
+++ b/pkg/gateway/whatsapp/whatsapp.go
@@ -41,7 +41,7 @@ type Adapter struct { //nolint:govet
 	name                string
 	stateDir            string
 	lastError           string
-	mu                  sync.Mutex
+	mu                  sync.RWMutex
 	connected           bool
 	includeSelfMessages bool
 	messageCount        atomic.Int64
@@ -321,10 +321,10 @@ func (a *Adapter) Stop() error {
 // paired personal account, so callers should attribute the author in the
 // content itself.
 func (a *Adapter) Send(ctx context.Context, channelID, _, content string) error {
-	a.mu.Lock()
+	a.mu.RLock()
 	client := a.client
 	connected := a.connected
-	a.mu.Unlock()
+	a.mu.RUnlock()
 	if client == nil || !connected {
 		return fmt.Errorf("whatsapp: not connected")
 	}
@@ -377,10 +377,10 @@ func parseSendJID(channelID string) (types.JID, error) {
 // is the platform message ID (from Notification.MessageID), and emoji is the
 // reaction character (empty string removes any existing reaction).
 func (a *Adapter) SendReaction(ctx context.Context, channelID, senderJID, messageID, emoji string) error {
-	a.mu.Lock()
+	a.mu.RLock()
 	client := a.client
 	connected := a.connected
-	a.mu.Unlock()
+	a.mu.RUnlock()
 	if client == nil || !connected {
 		return fmt.Errorf("whatsapp: not connected")
 	}
@@ -496,10 +496,16 @@ func (a *Adapter) handleMessage(msg *events.Message) {
 	}
 }
 
-// extractWAMentions returns the JID user parts from a WhatsApp message's ContextInfo.
-// WhatsApp stores @mention targets in ContextInfo.MentionedJID as full JID strings
-// (e.g. "1234567890@s.whatsapp.net"); we return the user part (phone number) so the
-// notify layer can match them against subscriber identities.
+// extractWAMentions returns the JID user parts (phone numbers) from a WhatsApp
+// message's ContextInfo.MentionedJID (e.g. "1234567890@s.whatsapp.net" → "1234567890").
+//
+// These phone numbers are passed as extraMentions to notify.Dispatch but will NOT
+// match bc agent names in the mention_only gate — agent names are strings like
+// "zen-zebra", not phone numbers. Agent mention filtering uses the text @name
+// extraction path (extractMentions in notify/service.go), which parses typed
+// "@agentname" tokens from the message content. The JID user parts are included in
+// the merged mention set for any future use cases where a subscriber is registered
+// under a phone-number identity.
 func extractWAMentions(msg *waE2E.Message) []string {
 	if msg == nil {
 		return nil

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -334,6 +334,52 @@ func TestDispatchExtraMentions(t *testing.T) {
 	}
 }
 
+// TestMentionOnlyTextName proves that a mention_only subscriber IS delivered a message
+// when the agent name appears as a typed "@agentname" token in the content.
+// This is the primary agent-mention path — WhatsApp JID user parts (phone numbers)
+// are phone numbers that never match agent names like "zen-zebra".
+func TestMentionOnlyTextName(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	sender := &mockSender{}
+	svc := NewService(store, sender, nil)
+
+	// zen-zebra is mention-only; helper-bot receives all messages.
+	if err := store.Subscribe(ctx, "whatsapp:family", "zen-zebra", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Subscribe(ctx, "whatsapp:family", "helper-bot", false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Message with no @mention — zen-zebra must be skipped, helper-bot delivered.
+	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "good morning", "m1", nil, nil, nil)
+	time.Sleep(80 * time.Millisecond)
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "helper-bot" {
+		t.Fatalf("no-mention: expected only helper-bot, got %v", calls)
+	}
+
+	// Message with typed "@zen-zebra" — both must be delivered.
+	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "hey @zen-zebra check this", "m2", nil, nil, nil)
+	time.Sleep(80 * time.Millisecond)
+	calls = sender.getCalls()
+	// Expect 2 more calls (total 3): helper-bot and zen-zebra for m2.
+	if len(calls) != 3 {
+		t.Fatalf("typed @mention: expected 3 total deliveries, got %d: %v", len(calls), calls)
+	}
+	hasZenZebra := false
+	for _, c := range calls[1:] {
+		if c.Name == "zen-zebra" {
+			hasZenZebra = true
+		}
+	}
+	if !hasZenZebra {
+		t.Errorf("expected zen-zebra to receive m2 via typed @mention, got calls: %v", calls)
+	}
+}
+
 func TestTruncate(t *testing.T) {
 	if got := truncate("hello world", 5); got != "hello..." {
 		t.Errorf("truncate('hello world', 5) = %q, want 'hello...'", got)

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -900,7 +900,7 @@ func (h *GatewayHandler) notifyActivity(w http.ResponseWriter, r *http.Request) 
 //	  "sender_jid": "<platform_sender>", // required by WhatsApp; omit for other platforms
 //	  "emoji":      "👍"                 // empty string removes the reaction
 //	}
-func (h *GatewayHandler) gatewayReact(w http.ResponseWriter, r *http.Request, _ string) {
+func (h *GatewayHandler) gatewayReact(w http.ResponseWriter, r *http.Request, platform string) {
 	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
@@ -923,14 +923,17 @@ func (h *GatewayHandler) gatewayReact(w http.ResponseWriter, r *http.Request, _ 
 		httpError(w, "channel is required", http.StatusBadRequest)
 		return
 	}
+	// Validate that the channel belongs to the platform in the URL path.
+	if !strings.HasPrefix(req.Channel, platform+":") {
+		httpError(w, "channel does not belong to platform "+platform, http.StatusBadRequest)
+		return
+	}
 	if req.MessageID == "" {
 		httpError(w, "message_id is required", http.StatusBadRequest)
 		return
 	}
-	if req.Emoji == "" {
-		httpError(w, "emoji is required", http.StatusBadRequest)
-		return
-	}
+	// Note: empty emoji is intentional — it removes an existing reaction
+	// (whatsmeow BuildReaction("", ...) sends a removal).
 
 	sent, err := h.gw.SendReaction(r.Context(), req.Channel, req.SenderJID, req.MessageID, req.Emoji)
 	if err != nil {

--- a/server/handlers/gateways_react_test.go
+++ b/server/handlers/gateways_react_test.go
@@ -114,6 +114,8 @@ type reactMissingFieldCase struct {
 }
 
 // TestGatewayReact_MissingFields verifies 400 on missing required fields.
+// Note: empty emoji is intentionally NOT a validation error — empty string
+// is the documented way to remove a reaction (whatsmeow BuildReaction(..., "")).
 func TestGatewayReact_MissingFields(t *testing.T) {
 	mgr := gateway.NewManager()
 	h := NewGatewayHandler(mgr, nil)
@@ -123,16 +125,68 @@ func TestGatewayReact_MissingFields(t *testing.T) {
 	tests := []reactMissingFieldCase{
 		{map[string]any{"message_id": "mid", "emoji": "👍"}, "missing channel"},
 		{map[string]any{"channel": "whatsapp:family", "emoji": "👍"}, "missing message_id"},
-		{map[string]any{"channel": "whatsapp:family", "message_id": "mid"}, "missing emoji"},
+		{map[string]any{"channel": "whatsapp:family", "message_id": "mid", "emoji": "👍"}, "platform mismatch"},
 	}
+	// Override URL for the platform-mismatch case: POST to /api/gateways/telegram/react
+	// while body says channel="whatsapp:family".
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var req *http.Request
+			if tt.name == "platform mismatch" {
+				b, _ := json.Marshal(tt.body) //nolint:errcheck
+				req = httptest.NewRequest(http.MethodPost, "/api/gateways/telegram/react", bytes.NewReader(b))
+				req.Header.Set("Content-Type", "application/json")
+			} else {
+				req = buildReactRequest(t, tt.body)
+			}
 			rr := httptest.NewRecorder()
-			mux.ServeHTTP(rr, buildReactRequest(t, tt.body))
+			mux.ServeHTTP(rr, req)
 			if rr.Code != http.StatusBadRequest {
-				t.Errorf("%s: status = %d, want 400", tt.name, rr.Code)
+				t.Errorf("%s: status = %d, want 400; body: %s", tt.name, rr.Code, rr.Body.String())
 			}
 		})
+	}
+}
+
+// TestGatewayReact_RemoveReaction verifies that an empty emoji (reaction removal) is
+// accepted and forwarded to the adapter — it must NOT be rejected with 400.
+func TestGatewayReact_RemoveReaction(t *testing.T) {
+	stub := &reactionStub{
+		stubAdapter: stubAdapter{name: "whatsapp"},
+	}
+
+	mgr := gateway.NewManager()
+	mgr.Register(stub)
+	mgr.HandleNotification("whatsapp", gateway.Notification{
+		Channel:   "family",
+		ChannelID: "1234@g.us",
+		Platform:  "whatsapp",
+		Sender:    "alice",
+		Content:   "hi",
+	})
+
+	h := NewGatewayHandler(mgr, nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := buildReactRequest(t, map[string]any{
+		"channel":    "whatsapp:family",
+		"message_id": "msg-abc-123",
+		"sender_jid": "9876543210@s.whatsapp.net",
+		"emoji":      "", // empty = remove reaction
+	})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("remove reaction: status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	calls := stub.getCalls()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 SendReaction call, got %d", len(calls))
+	}
+	if calls[0].Emoji != "" {
+		t.Errorf("emoji = %q, want empty string for removal", calls[0].Emoji)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -286,7 +286,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 	// Wire gateway inbound callback for notify dispatch and SSE publish.
 	if svc.Gateway != nil {
-		svc.Gateway.SetInboundHandler(func(ch, sender, content, messageID string, mentions []string, raw json.RawMessage) {
+		svc.Gateway.SetInboundHandler(func(ch, sender, senderID, content, messageID string, mentions []string, raw json.RawMessage) {
 			// Publish SSE event for web UI (non-blocking)
 			if hub != nil {
 				hub.Publish("channel.message", map[string]any{
@@ -305,7 +305,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 				if idx := strings.Index(ch, ":"); idx > 0 {
 					platform = ch[:idx]
 				}
-				svc.Notify.Dispatch(ch, platform, sender, "", content, messageID, mentions, nil, raw)
+				svc.Notify.Dispatch(ch, platform, sender, senderID, content, messageID, mentions, nil, raw)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- **Bug 1 (MED):** Thread `senderID` through the `onInbound` callback signature and into `notify.Dispatch` so WhatsApp's sender JID is no longer dropped on inbound messages — required for reactions to target the correct message author.
- **Bug 2 (MED):** Drop the empty-emoji guard in `gatewayReact` so callers can pass `""` to remove a reaction (`whatsmeow BuildReaction(..., "")` is the documented removal mechanism).
- **Bug 3 (LOW):** Validate that `req.Channel` carries the platform prefix matching the URL path param — return 400 on mismatch instead of silently routing to the wrong adapter.
- **Bug 4 (LOW):** Upgrade `sync.Mutex` → `sync.RWMutex` in the WhatsApp adapter; use `RLock`/`RUnlock` in `Send` and `SendReaction` which are read-only snapshots of `client`/`connected`.
- **Bug 5 (mention matching):** Add comment to `extractWAMentions` clarifying that JID user parts are phone numbers and will not match agent names in the `mention_only` gate — agents are matched via typed `@agentname` tokens extracted from message content. Add `TestMentionOnlyTextName` to cover the text-`@name` mention_only delivery path end-to-end.

Part of #3334

## Test plan

- [ ] `make build-local-bc` passes (verified locally)
- [ ] `golangci-lint run ./pkg/gateway/... ./pkg/notify/ ./server/...` — 0 issues (verified locally)
- [ ] `go test ./pkg/gateway/... ./pkg/notify/ ./server/handlers/` — all pass (verified locally)
- [ ] `TestGatewayReact_RemoveReaction` — new test verifying empty-emoji removal works (200)
- [ ] `TestGatewayReact_MissingFields/platform_mismatch` — new case verifying 400 on wrong platform prefix
- [ ] `TestMentionOnlyTextName` — new test verifying typed `@agentname` mention_only delivery and non-mention skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)