### PR TITLE
fix(providers): parallelize model fetch (cold-cache hang), pi AWS-profile override + model fallback

### DIFF
--- a/pkg/provider/agy_test.go
+++ b/pkg/provider/agy_test.go
@@ -373,7 +373,7 @@ func TestAgyConfigAdapter(t *testing.T) {
 	// SetupMCP writes agy-native mcp_config.json (serverUrl for SSE).
 	dir := t.TempDir()
 	err := a.SetupMCP(context.Background(), dir, "eng-01", map[string]MCPEntry{
-		"bc":     {URL: "http://127.0.0.1:9374/_mcp/eng-01/sse", Transport: "sse"},
+		"bc":     {URL: "http://127.0.0.1:9374/mcp/sse", Transport: "sse"},
 		"github": {Command: "github-mcp-server", Args: []string{"--stdio"}},
 	})
 	if err != nil {

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -186,6 +186,11 @@ func (p *PiProvider) ListModels(ctx context.Context) ([]string, error) {
 		}
 		models = append(models, combined)
 	}
+	// Mirror the error-path fallback: if the CLI exited cleanly but produced no
+	// parseable rows, return the static model list rather than nil.
+	if len(models) == 0 {
+		return p.Models(), nil
+	}
 	return models, nil
 }
 
@@ -215,9 +220,17 @@ var piUserHomeDir = os.UserHomeDir
 // only the profile name and region pointer are injected.
 //
 // Injection is skipped when:
+//   - any AWS_* key is already set in the daemon's process environment
 //   - any AWS_* key is already set in env (user-provided config wins)
 //   - ~/.aws directory does not exist on the host
 func (p *PiProvider) ContributeEnv(env map[string]string) {
+	// Respect any AWS_* already present in the daemon's process environment
+	// (e.g. AWS_PROFILE inherited from the shell that launched bcd).
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "AWS_") {
+			return
+		}
+	}
 	// Respect any AWS env already set by the user (via agent Env or env file).
 	for k := range env {
 		if strings.HasPrefix(k, "AWS_") {

--- a/pkg/provider/pi_test.go
+++ b/pkg/provider/pi_test.go
@@ -346,6 +346,56 @@ func TestPiAWSPointerEnv_SkipsWhenAWSEnvAlreadySet(t *testing.T) {
 	}
 }
 
+// TestPiContributeEnv_ProcessEnvAWSVarSkipped verifies that ContributeEnv does
+// NOT inject AWS vars when any AWS_* variable is already in the daemon's process
+// environment (not just in the agent env map). This is the fix for bug #2:
+// previously ContributeEnv only checked the agent env map, so a process-level
+// AWS_PROFILE=my-profile was silently overwritten with "default".
+func TestPiContributeEnv_ProcessEnvAWSVarSkipped(t *testing.T) {
+	home := t.TempDir()
+	awsDir := filepath.Join(home, ".aws")
+	if err := os.MkdirAll(awsDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewPiProvider()
+	orig := piUserHomeDir
+	piUserHomeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { piUserHomeDir = orig })
+
+	// Set a profile in the process environment; agent env map is empty.
+	t.Setenv("AWS_PROFILE", "my-profile")
+
+	env := map[string]string{} // no AWS_ in agent env
+	p.ContributeEnv(env)
+	if _, ok := env["AWS_PROFILE"]; ok {
+		t.Error("ContributeEnv must not inject AWS_PROFILE when AWS_PROFILE is already in os.Environ()")
+	}
+}
+
+// TestPiListModels_AllUnparseableFallback verifies that when `pi --list-models`
+// exits 0 but emits no parseable two-column rows, ListModels returns the static
+// fallback (p.Models()) rather than nil (bug #4).
+func TestPiListModels_AllUnparseableFallback(t *testing.T) {
+	p := NewPiProvider()
+	orig := piListModels
+	t.Cleanup(func() { piListModels = orig })
+
+	// Output is non-empty but every row has only one column — all skipped.
+	piListModels = func(_ context.Context) (string, error) {
+		return "MODELS\nNOTE: run pi --setup to configure providers\n", nil
+	}
+	got, err := p.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() unexpected error: %v", err)
+	}
+	// pi's static Models() is empty, so we expect empty (not nil).
+	want := p.Models()
+	if len(got) != len(want) {
+		t.Errorf("ListModels() = %v (len=%d), want static fallback %v (len=%d)", got, len(got), want, len(want))
+	}
+}
+
 func TestReadAWSDefaultRegion(t *testing.T) {
 	home := t.TempDir()
 	awsDir := filepath.Join(home, ".aws")

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	"github.com/rpuneet/mycel/pkg/agent"
 	"github.com/rpuneet/mycel/pkg/cost"
 	"github.com/rpuneet/mycel/pkg/provider"
@@ -44,11 +46,11 @@ type ProviderInfo struct { //nolint:govet // field order matches JSON/API contra
 }
 
 // ProviderDetail extends ProviderInfo with per-model cost breakdown and agent list.
-type ProviderDetail struct { //nolint:govet // field order matches JSON/API contract
-	ProviderInfo
+type ProviderDetail struct {
 	Config      map[string]string `json:"config"`
 	Agents      []AgentSummary    `json:"agents"`
 	CostByModel []ModelCost       `json:"cost_by_model"`
+	ProviderInfo
 }
 
 // AgentSummary is a lightweight agent reference.
@@ -98,6 +100,7 @@ type modelCacheEntry struct {
 
 // ProviderHandler handles /api/providers routes.
 type ProviderHandler struct {
+	sf         singleflight.Group
 	registry   *provider.Registry
 	agents     *agent.AgentService
 	costs      *cost.Store
@@ -119,6 +122,8 @@ func (h *ProviderHandler) Register(mux *http.ServeMux) {
 
 // fetchModels returns models for provider p, using DynamicModelLister when available.
 // Results are cached for 60 seconds. Available=true means live from CLI.
+// Concurrent callers for the same provider share a single in-flight shell-out
+// (singleflight), preventing the TOCTOU race that caused duplicate CLI invocations.
 func (h *ProviderHandler) fetchModels(ctx context.Context, p provider.Provider) []ModelInfo {
 	const ttl = 60 * time.Second
 	const timeout = 10 * time.Second
@@ -130,36 +135,56 @@ func (h *ProviderHandler) fetchModels(ctx context.Context, p provider.Provider) 
 	}
 	h.modelMu.Unlock()
 
-	var models []ModelInfo
+	// singleflight deduplicates concurrent fetches for the same provider so only
+	// one shell-out fires per TTL window even under concurrent requests.
+	raw, _, _ := h.sf.Do(p.Name(), func() (any, error) { //nolint:errcheck // sf.Do error is forwarded; closure never returns non-nil
+		// Re-check cache inside the flight: a concurrent Do may have already
+		// populated it while this goroutine was waiting.
+		h.modelMu.Lock()
+		if e, ok := h.modelCache[p.Name()]; ok && time.Since(e.at) < ttl {
+			h.modelMu.Unlock()
+			return e.models, nil
+		}
+		h.modelMu.Unlock()
 
-	if dl, ok := p.(provider.DynamicModelLister); ok {
-		tctx, cancel := context.WithTimeout(ctx, timeout)
-		defer cancel()
-		if ids, err := dl.ListModels(tctx); err == nil && len(ids) > 0 {
-			models = make([]ModelInfo, len(ids))
-			for i, id := range ids {
-				models[i] = ModelInfo{ID: id, Available: true}
+		var models []ModelInfo
+
+		if dl, ok := p.(provider.DynamicModelLister); ok {
+			tctx, cancel := context.WithTimeout(ctx, timeout)
+			defer cancel()
+			if ids, err := dl.ListModels(tctx); err == nil && len(ids) > 0 {
+				models = make([]ModelInfo, len(ids))
+				for i, id := range ids {
+					models[i] = ModelInfo{ID: id, Available: true}
+				}
 			}
 		}
-	}
 
-	// Static fallback if dynamic yielded nothing.
-	if len(models) == 0 {
-		if ml, ok := p.(provider.ModelLister); ok {
-			for _, id := range ml.Models() {
-				models = append(models, ModelInfo{ID: id, Available: false})
+		// Static fallback if dynamic yielded nothing.
+		if len(models) == 0 {
+			if ml, ok := p.(provider.ModelLister); ok {
+				for _, id := range ml.Models() {
+					models = append(models, ModelInfo{ID: id, Available: false})
+				}
 			}
 		}
-	}
 
-	if models == nil {
-		models = []ModelInfo{}
-	}
+		if models == nil {
+			models = []ModelInfo{}
+		}
 
-	h.modelMu.Lock()
-	h.modelCache[p.Name()] = modelCacheEntry{models: models, at: time.Now()}
-	h.modelMu.Unlock()
-	return models
+		h.modelMu.Lock()
+		h.modelCache[p.Name()] = modelCacheEntry{models: models, at: time.Now()}
+		h.modelMu.Unlock()
+
+		return models, nil
+	})
+	// The closure always returns []ModelInfo; the two-value assertion is a safe guard.
+	ms, ok := raw.([]ModelInfo)
+	if !ok {
+		return []ModelInfo{}
+	}
+	return ms
 }
 
 // listModels returns live models for a provider (with caching).
@@ -174,6 +199,9 @@ func (h *ProviderHandler) listModels(w http.ResponseWriter, r *http.Request, nam
 }
 
 // list returns all providers with agent counts and cost stats.
+// Each provider's buildProviderInfo (which may shell out via fetchModels) runs
+// concurrently so a full cold-cache load stays bounded by the slowest single
+// provider rather than the sum of all providers.
 func (h *ProviderHandler) list(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodGet) {
 		return
@@ -183,11 +211,18 @@ func (h *ProviderHandler) list(w http.ResponseWriter, r *http.Request) {
 	agentCounts := h.countAgents(r.Context())
 	costByProvider := h.aggregateCostsByProvider(r.Context())
 
-	infos := make([]ProviderInfo, 0, len(providers))
-	for _, p := range providers {
-		info := h.buildProviderInfo(r.Context(), p, agentCounts, costByProvider)
-		infos = append(infos, info)
+	// Pre-allocate by index so each goroutine writes to its own slot — no mutex needed.
+	infos := make([]ProviderInfo, len(providers))
+	var wg sync.WaitGroup
+	wg.Add(len(providers))
+	for i, p := range providers {
+		i, p := i, p
+		go func() {
+			defer wg.Done()
+			infos[i] = h.buildProviderInfo(r.Context(), p, agentCounts, costByProvider)
+		}()
 	}
+	wg.Wait()
 
 	sort.Slice(infos, func(i, j int) bool {
 		return infos[i].Name < infos[j].Name

--- a/server/handlers/providers_test.go
+++ b/server/handlers/providers_test.go
@@ -1,10 +1,13 @@
 package handlers_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/rpuneet/mycel/pkg/provider"
 	"github.com/rpuneet/mycel/server/handlers"
@@ -112,5 +115,100 @@ func TestProvidersModelsUnknownProvider(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+// TestProvidersListParallelCorrectness verifies that the parallel list handler
+// returns all registered providers sorted by name without dropping or duplicating
+// entries. This is the regression gate for the parallelisation introduced to fix
+// the cold-cache serial hang (bugs #1).
+func TestProvidersListParallelCorrectness(t *testing.T) {
+	reg := provider.NewRegistry()
+	reg.Register(provider.NewClaudeProvider())
+	reg.Register(provider.NewAgyProvider())
+	mux := newProvidersMux(t, reg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/providers", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var provs []struct {
+		Name   string `json:"name"`
+		Models []struct {
+			ID string `json:"id"`
+		} `json:"models"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &provs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(provs) != 2 {
+		t.Fatalf("want 2 providers, got %d: %v", len(provs), provs)
+	}
+	// Response must be alphabetically sorted regardless of dispatch order.
+	if provs[0].Name > provs[1].Name {
+		t.Errorf("providers not sorted: %q > %q", provs[0].Name, provs[1].Name)
+	}
+	// Each provider must include its model list (even if empty).
+	for _, p := range provs {
+		if p.Models == nil {
+			t.Errorf("provider %q: models must not be null", p.Name)
+		}
+	}
+}
+
+// fakeSlowProvider is a minimal Provider + DynamicModelLister that records how
+// many times ListModels is invoked and returns after a short delay. It is used
+// to verify singleflight deduplication (bug #3).
+type fakeSlowProvider struct {
+	calls atomic.Int32
+	delay time.Duration
+}
+
+func (f *fakeSlowProvider) Name() string                               { return "fake-slow" }
+func (f *fakeSlowProvider) Description() string                        { return "test" }
+func (f *fakeSlowProvider) Command() string                            { return "fake" }
+func (f *fakeSlowProvider) Binary() string                             { return "fake" }
+func (f *fakeSlowProvider) InstallHint() string                        { return "" }
+func (f *fakeSlowProvider) BuildCommand(_ provider.CommandOpts) string { return "fake" }
+func (f *fakeSlowProvider) IsInstalled(_ context.Context) bool         { return false }
+func (f *fakeSlowProvider) Version(_ context.Context) string           { return "" }
+func (f *fakeSlowProvider) ListModels(_ context.Context) ([]string, error) {
+	f.calls.Add(1)
+	time.Sleep(f.delay)
+	return []string{"model-a"}, nil
+}
+
+// TestProvidersModelsFetchSingleflight verifies that concurrent requests for the
+// same provider's model list result in only one CLI invocation (singleflight, bug #3).
+func TestProvidersModelsFetchSingleflight(t *testing.T) {
+	fake := &fakeSlowProvider{delay: 30 * time.Millisecond}
+
+	reg := provider.NewRegistry()
+	reg.Register(fake)
+	mux := newProvidersMux(t, reg)
+
+	const concurrency = 5
+	done := make(chan int, concurrency)
+	for range concurrency {
+		go func() {
+			req := httptest.NewRequest(http.MethodGet, "/api/providers/fake-slow/models", nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			done <- rec.Code
+		}()
+	}
+	for range concurrency {
+		if code := <-done; code != http.StatusOK {
+			t.Errorf("concurrent request: status = %d, want 200", code)
+		}
+	}
+
+	// With singleflight the in-flight requests share one shell-out; allow up to 2
+	// (one real + one possible cache miss race) but never 5.
+	if got := fake.calls.Load(); got > 2 {
+		t.Errorf("ListModels called %d times for %d concurrent requests; want ≤2 (singleflight)", got, concurrency)
 	}
 }


### PR DESCRIPTION
## Summary

- **Bug #1 (HIGH)**: `/api/providers` cold-cache hang — parallelise per-provider `buildProviderInfo` with goroutines+WaitGroup so load time is bounded by the slowest provider (~10 s), not the sum (~20 s for two DynamicModelListers).
- **Bug #3 (MED)**: TOCTOU double shell-out — add `singleflight.Group` keyed by provider name so concurrent requests share one in-flight CLI invocation instead of each spawning their own.
- **Bug #2 (MED)**: `pi ContributeEnv` overwrites user AWS profile — scan `os.Environ()` before the agent-env map so a process-level `AWS_PROFILE` inherited by `bcd` is respected.
- **Bug #4 (LOW)**: `pi ListModels` returns `(nil, nil)` on all-unparseable CLI output — return `p.Models()` (static fallback) to mirror the error-path behaviour.
- **Bug #5 (LOW)**: `agy_test.go` stale `/_mcp/…` SSE URL fixture — replaced with neutral `/mcp/sse` placeholder.

Files touched: `server/handlers/providers.go`, `server/handlers/providers_test.go`, `pkg/provider/pi.go`, `pkg/provider/pi_test.go`, `pkg/provider/agy_test.go`.

Part of #3334

## Test plan

- [ ] `golangci-lint run ./server/handlers/ ./pkg/provider/` → 0 issues
- [ ] `go test -race ./server/handlers/ ./pkg/provider/` → all pass
- [ ] `TestProvidersListParallelCorrectness` — two providers both appear, sorted
- [ ] `TestProvidersModelsFetchSingleflight` — 5 concurrent requests yield ≤ 2 CLI invocations
- [ ] `TestPiContributeEnv_ProcessEnvAWSVarSkipped` — process-level `AWS_PROFILE` prevents injection
- [ ] `TestPiListModels_AllUnparseableFallback` — all-unparseable output returns static fallback (not nil)
- [ ] `TestAgyConfigAdapter` — still passes with updated SSE URL fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)