### PR TITLE
fix(web): marketplace filters/picker + secrets date & actions

### DIFF
--- a/web/src/utils/time.test.ts
+++ b/web/src/utils/time.test.ts
@@ -46,12 +46,16 @@ describe("formatRelative", () => {
     const long = new Date(NOW.getTime() - 45 * 86_400_000);
     const result = formatRelative(long);
     expect(result).not.toContain("ago");
-    expect(result).toBe(long.toLocaleDateString());
+    expect(result).toBe(
+      long.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }),
+    );
   });
 
   it("respects a custom maxDays", () => {
     const week = new Date(NOW.getTime() - 8 * 86_400_000);
-    expect(formatRelative(week, { maxDays: 7 })).toBe(week.toLocaleDateString());
+    expect(formatRelative(week, { maxDays: 7 })).toBe(
+      week.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }),
+    );
   });
 
   it("collapses future dates to 'just now' by default", () => {
@@ -81,8 +85,10 @@ describe("formatAbsolute", () => {
     expect(formatAbsolute(NOW)).toBe(NOW.toLocaleString());
   });
 
-  it("returns toLocaleDateString when dateOnly is set", () => {
-    expect(formatAbsolute(NOW, { dateOnly: true })).toBe(NOW.toLocaleDateString());
+  it("returns a short-form date when dateOnly is set", () => {
+    expect(formatAbsolute(NOW, { dateOnly: true })).toBe(
+      NOW.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }),
+    );
   });
 });
 

--- a/web/src/utils/time.ts
+++ b/web/src/utils/time.ts
@@ -74,7 +74,17 @@ export function formatAbsolute(input: TimeInput, opts: FormatAbsoluteOptions = {
   const emptyLabel = opts.emptyLabel ?? "—";
   const d = toDate(input);
   if (!d) return emptyLabel;
-  return opts.dateOnly ? d.toLocaleDateString() : d.toLocaleString();
+  if (opts.dateOnly) {
+    // Use a readable, consistent format ("Feb 5, 2026") instead of the
+    // locale-default short form ("2/5/2026") so it pairs well with the
+    // relative style ("3d ago", "just now") used elsewhere in the UI.
+    return d.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  }
+  return d.toLocaleString();
 }
 
 export interface FormatDurationOptions {

--- a/web/src/views/Marketplace.tsx
+++ b/web/src/views/Marketplace.tsx
@@ -180,6 +180,93 @@ function StarCount({ stars }: { stars: number }) {
   );
 }
 
+// ─── Custom Filter Select ─────────────────────────────────────────────────────
+// Replaces native <select> so the dropdown chrome matches the dark theme.
+
+interface FilterSelectProps {
+  value: string;
+  options: Array<{ value: string; label: string }>;
+  onChange: (val: string) => void;
+}
+
+function FilterSelect({ value, options, onChange }: FilterSelectProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const current = options.find((o) => o.value === value) ?? options[0];
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouse = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onMouse);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onMouse);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex items-center gap-1.5 px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent hover:border-mycel-border-strong transition-colors whitespace-nowrap"
+      >
+        <span>{current?.label}</span>
+        <svg
+          viewBox="0 0 16 16"
+          width="12"
+          height="12"
+          fill="currentColor"
+          className="text-mycel-muted shrink-0"
+          aria-hidden
+        >
+          <path d="M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z" />
+        </svg>
+      </button>
+      <AnimatePresence>
+        {open && (
+          <motion.ul
+            role="listbox"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.1 }}
+            className="absolute left-0 top-full mt-1 z-20 min-w-full rounded-lg border border-mycel-border bg-mycel-surface shadow-xl py-1"
+          >
+            {options.map((o) => (
+              <li key={o.value} role="option" aria-selected={o.value === value}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onChange(o.value);
+                    setOpen(false);
+                  }}
+                  className={`w-full text-left px-3 py-1.5 text-sm transition-colors hover:bg-mycel-surface-hover ${
+                    o.value === value
+                      ? "text-mycel-accent"
+                      : "text-mycel-text"
+                  }`}
+                >
+                  {o.label}
+                </button>
+              </li>
+            ))}
+          </motion.ul>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
 // ─── Inline Agent Dropdown ────────────────────────────────────────────────────
 
 interface InlineAgentPickerProps {
@@ -252,6 +339,14 @@ function InlineAgentPicker({
       transition={{ duration: 0.1 }}
       className="absolute right-0 top-full mt-1 z-20 w-56 rounded-lg border border-mycel-border bg-mycel-surface shadow-xl"
     >
+      {/* Heading */}
+      <div className="px-3 pt-2.5 pb-1.5 border-b border-mycel-border">
+        <p className="text-xs font-semibold text-mycel-text">Send to agent(s)</p>
+        <p className="text-[10px] text-mycel-muted mt-0.5">
+          Selected agents get an install instruction.
+        </p>
+      </div>
+
       {/* Agent list */}
       <div className="px-3 py-2 max-h-44 overflow-y-auto">
         {loading && (
@@ -306,6 +401,11 @@ function InlineAgentPicker({
 
 // ─── Item Card ────────────────────────────────────────────────────────────────
 
+// Returns true when a string is a bare URL (no real description text).
+function isRawUrl(s: string): boolean {
+  return /^https?:\/\//.test(s.trim());
+}
+
 function ItemCard({ item }: { item: MarketplaceItem }) {
   const [showPicker, setShowPicker] = useState(false);
   const [sentCount, setSentCount] = useState<number | null>(null);
@@ -316,6 +416,11 @@ function ItemCard({ item }: { item: MarketplaceItem }) {
     // Clear confirmation after 4 s so the button is reusable.
     setTimeout(() => setSentCount(null), 4000);
   }
+
+  // Only render a description when there is meaningful text (not a raw URL —
+  // the source badge already implies the repo).
+  const showDescription =
+    !!item.description && !isRawUrl(item.description);
 
   return (
     <motion.div
@@ -342,7 +447,7 @@ function ItemCard({ item }: { item: MarketplaceItem }) {
               className={SOURCE_COLORS[item.source] ?? "bg-mycel-border text-mycel-muted"}
             />
           </div>
-          {item.description && (
+          {showDescription && (
             <p className="mt-1 text-xs text-mycel-muted line-clamp-2">
               {item.description}
             </p>
@@ -376,23 +481,25 @@ function ItemCard({ item }: { item: MarketplaceItem }) {
         </div>
       </div>
 
-      {/* Footer row */}
-      <div className="flex items-center gap-3 mt-auto">
-        {typeof item.stars === "number" && item.stars > 0 && (
-          <StarCount stars={item.stars} />
-        )}
-        {item.url && (
-          <a
-            href={item.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-mycel-muted hover:text-mycel-accent transition-colors truncate"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {item.url.replace(/^https?:\/\//, "")}
-          </a>
-        )}
-      </div>
+      {/* Footer row — only rendered when there's content */}
+      {(typeof item.stars === "number" && item.stars > 0 || !!item.url) && (
+        <div className="flex items-center gap-3 mt-auto">
+          {typeof item.stars === "number" && item.stars > 0 && (
+            <StarCount stars={item.stars} />
+          )}
+          {item.url && (
+            <a
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-mycel-muted hover:text-mycel-accent transition-colors truncate"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {item.url.replace(/^https?:\/\//, "")}
+            </a>
+          )}
+        </div>
+      )}
     </motion.div>
   );
 }
@@ -435,8 +542,6 @@ export function Marketplace() {
 
   const inputCls =
     "px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent";
-  const selectCls =
-    "px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent";
 
   return (
     <div className="flex flex-col gap-4 p-4 max-w-4xl mx-auto w-full">
@@ -449,28 +554,16 @@ export function Marketplace() {
           onChange={(e) => setQuery(e.target.value)}
           className={`${inputCls} flex-1 min-w-[180px]`}
         />
-        <select
+        <FilterSelect
           value={typeFilter}
-          onChange={(e) => setTypeFilter(e.target.value)}
-          className={selectCls}
-        >
-          {ALL_TYPES.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
-        <select
+          options={ALL_TYPES}
+          onChange={setTypeFilter}
+        />
+        <FilterSelect
           value={sourceFilter}
-          onChange={(e) => setSourceFilter(e.target.value)}
-          className={selectCls}
-        >
-          {ALL_SOURCES.map((o) => (
-            <option key={o.value} value={o.value}>
-              {o.label}
-            </option>
-          ))}
-        </select>
+          options={ALL_SOURCES}
+          onChange={setSourceFilter}
+        />
       </div>
 
       {/* Content */}

--- a/web/src/views/Secrets.tsx
+++ b/web/src/views/Secrets.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../api/client";
 import type { Secret } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
@@ -167,6 +167,26 @@ function SecretCard({ secret, onChanged }: { secret: Secret; onChanged: () => vo
   const [saveError, setSaveError] = useState<string | null>(null);
   const [confirming, setConfirming] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close the actions menu when clicking outside.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node))
+        setMenuOpen(false);
+    };
+    const keyHandler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    document.addEventListener("keydown", keyHandler);
+    return () => {
+      document.removeEventListener("mousedown", handler);
+      document.removeEventListener("keydown", keyHandler);
+    };
+  }, [menuOpen]);
 
   const handleUpdate = async () => {
     const trimmed = newValue.trim();
@@ -220,6 +240,46 @@ function SecretCard({ secret, onChanged }: { secret: Secret; onChanged: () => vo
             </svg>
             Encrypted
           </span>
+          {/* Three-dot actions menu */}
+          {!editing && (
+            <div ref={menuRef} className="relative">
+              <button
+                type="button"
+                onClick={() => setMenuOpen((v) => !v)}
+                aria-label="Secret actions"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                className="inline-flex items-center justify-center w-6 h-6 rounded-md text-mycel-muted hover:text-mycel-text hover:bg-mycel-surface-hover transition-colors focus:outline-none focus:ring-1 focus:ring-mycel-accent"
+              >
+                <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden>
+                  <path d="M8 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3ZM1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Zm13 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" />
+                </svg>
+              </button>
+              {menuOpen && (
+                <div
+                  role="menu"
+                  className="absolute right-0 top-full mt-1 z-20 w-40 rounded-lg border border-mycel-border bg-mycel-surface shadow-xl py-1"
+                >
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => { setMenuOpen(false); setEditing(true); }}
+                    className="w-full text-left px-3 py-1.5 text-sm text-mycel-text hover:bg-mycel-surface-hover transition-colors"
+                  >
+                    Update value
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => { setMenuOpen(false); setConfirming(true); }}
+                    className="w-full text-left px-3 py-1.5 text-sm text-mycel-error hover:bg-mycel-error-subtle transition-colors"
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
@@ -292,44 +352,25 @@ function SecretCard({ secret, onChanged }: { secret: Secret; onChanged: () => vo
         </div>
       )}
 
-      {/* Actions */}
-      {!editing && (
+      {/* Confirm-delete row — shown when the three-dot menu triggers deletion. */}
+      {!editing && confirming && (
         <div className="flex items-center gap-2 pt-1">
           <button
             type="button"
-            onClick={() => setEditing(true)}
-            className="inline-flex items-center h-8 px-3 rounded-md bg-mycel-surface border border-mycel-border text-xs text-mycel-text-2 hover:text-mycel-text hover:bg-mycel-surface-hover transition-colors"
+            onClick={handleDelete}
+            disabled={deleting}
+            className="inline-flex items-center h-8 px-3 rounded-md bg-mycel-error text-white text-xs font-medium hover:opacity-90 shadow-mycel-sm disabled:opacity-50 transition-opacity"
           >
-            Update Value
+            {deleting ? "Deleting..." : "Confirm Delete"}
           </button>
-          {confirming ? (
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={handleDelete}
-                disabled={deleting}
-                className="inline-flex items-center h-8 px-3 rounded-md bg-mycel-error text-white text-xs font-medium hover:opacity-90 shadow-mycel-sm disabled:opacity-50 transition-opacity"
-              >
-                {deleting ? "Deleting..." : "Confirm Delete"}
-              </button>
-              <button
-                type="button"
-                onClick={() => setConfirming(false)}
-                disabled={deleting}
-                className="inline-flex items-center h-8 px-3 rounded-md bg-mycel-surface border border-mycel-border text-mycel-text-2 text-xs hover:text-mycel-text hover:bg-mycel-surface-hover transition-colors"
-              >
-                Cancel
-              </button>
-            </div>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setConfirming(true)}
-              className="inline-flex items-center h-8 px-3 rounded-md text-xs text-mycel-error border border-mycel-border hover:bg-mycel-error-subtle hover:border-mycel-error transition-colors"
-            >
-              Delete
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => setConfirming(false)}
+            disabled={deleting}
+            className="inline-flex items-center h-8 px-3 rounded-md bg-mycel-surface border border-mycel-border text-mycel-text-2 text-xs hover:text-mycel-text hover:bg-mycel-surface-hover transition-colors"
+          >
+            Cancel
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
Part of #3334

## Summary

- **Marketplace filters (HIGH):** Replace native `<select>` elements with a custom `FilterSelect` component (button + framer-motion popover list). Matches the dark theme exactly — no OS-native chrome bleeding in. Keyboard-accessible: Escape closes, outside-click closes, aria-haspopup/expanded on trigger.
- **Agent picker heading (MED):** Add "Send to agent(s)" heading + "Selected agents get an install instruction." hint inside the `InlineAgentPicker` popover.
- **Star/description card rhythm (MED/LOW):** Footer row now only rendered when stars or URL are present (no empty `mt-auto` div). Description line suppressed when value is a bare URL — new `isRawUrl` guard.
- **Secrets date format (HIGH):** `formatAbsolute(dateOnly)` now renders "Jul 1, 2026" via `toLocaleDateString(undefined, {month:'short',day:'numeric',year:'numeric'})` instead of locale-default short form. Consistent with relative-time style ("3d ago"). Test assertions updated.
- **Secrets actions (MED):** "Update Value" + "Delete" buttons replaced with a three-dot (⋯) actions menu in the card header. Resting state is calm. Destructive path unchanged (Confirm Delete row still shows inline). Menu accessible via keyboard (Escape, aria-haspopup/expanded, role=menu/menuitem).

## Test plan

- [ ] `cd web && bun run build` — clean (verified locally ✓)
- [ ] `cd web && bun run test` — 164/164 pass (verified locally ✓)
- [ ] `cd web && bun run lint` — clean (verified locally ✓)
- [ ] Marketplace: open in browser, verify "All types" / "All sources" dropdowns render with dark background and accent highlight on selected item
- [ ] Marketplace: click "Add" on any card, verify popover shows "Send to agent(s)" heading and hint text
- [ ] Marketplace: verify cards with 0 stars / no URL show no footer row; cards with stars show count
- [ ] Marketplace: verify items whose description is a raw GitHub URL show no description text
- [ ] Secrets: verify created-at date shows as "Jul 1, 2026" style (not "7/1/2026")
- [ ] Secrets: verify resting card shows no Update/Delete buttons; three-dot (⋯) icon visible
- [ ] Secrets: click ⋯ → "Update value" opens inline edit form; "Delete" → confirm row appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)