### PR TITLE
fix(web): notifications page height + settings provider label/value overflow

### DIFF
--- a/web/src/components/notifications/NotificationsHome.tsx
+++ b/web/src/components/notifications/NotificationsHome.tsx
@@ -622,8 +622,7 @@ export function NotificationsHome() {
   const sectionApps = apps.filter((a) => (channelsByApp.get(a.key) ?? []).length > 0);
 
   return (
-    <div className="h-full overflow-y-auto">
-      <div className="p-6 pb-24 space-y-6">
+    <div className="p-6 pb-10 space-y-6">
         {/* ── Apps strip — compact pills ─────────────────────── */}
         <div className="flex flex-wrap gap-2">
           {apps.map((app) => {
@@ -774,7 +773,6 @@ export function NotificationsHome() {
             </div>
           </aside>
         </div>
-      </div>
 
       {/* Connect / reconnect flows — the existing setup components */}
       {chooserOpen && (

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -27,7 +27,7 @@ const INPUT_CLS = "w-full px-2 py-0.5 text-xs rounded-md border border-mycel-bor
 function Field({ label, children, suffix }: { label: string; children: React.ReactNode; suffix?: string }) {
   return (
     <div className="flex items-center gap-2 min-h-[28px]">
-      <label className="text-xs text-mycel-text-2 w-24 shrink-0 text-right">{label}</label>
+      <label className="text-xs text-mycel-text-2 w-28 shrink-0 truncate" title={label}>{label}</label>
       <div className="flex-1 flex items-center gap-1.5 min-w-0">
         {children}
         {suffix && <span className="text-[10px] text-mycel-muted shrink-0">{suffix}</span>}
@@ -248,9 +248,13 @@ function ProvidersSection({ data, onChange }: { data: Record<string, unknown>; o
       </Field>
       {providerKeys.map((k) => (
         <Field key={k} label={k}>
-          <input className={INPUT_CLS} value={String(providers[k]?.command ?? "")}
+          <input
+            className={INPUT_CLS}
+            value={String(providers[k]?.command ?? "")}
+            title={String(providers[k]?.command ?? "") || "command"}
             onChange={(e) => onChange(["providers", "providers", k, "command"], e.target.value)}
-            placeholder="command" />
+            placeholder="command"
+          />
         </Field>
       ))}
     </div>


### PR DESCRIPTION
## Summary

- **Notifications (HIGH):** Remove `h-full overflow-y-auto` from `NotificationsHome`'s root div. The Layout already wraps all page content in `flex-1 overflow-auto`; the extra `h-full` wrapper resolved against the flex-computed parent height rather than content, producing a massive empty scroll region below the actual content. Dropping it lets the Layout's scroll container handle page scrolling — matching the pattern used by Settings and every other page.
- **Settings providers (MED):** Widen the label column (`w-24` → `w-28`) and switch from `text-right` to left-aligned with `truncate` + `title` so long provider keys render correctly instead of clipping to `pl`/`pi`. Add `title` on each provider command input so long values (e.g. bedrock model strings) are readable on hover without clicking into the field.

Part of #3334

## Test plan

- [ ] Navigate to `/notifications` — page should scroll to fit content with no empty black void below the channels list / recent activity panel
- [ ] Navigate to `/notifications/:channel` (GatewayFeed) — channel feed still fills the viewport and scrolls messages internally (unaffected by this change)
- [ ] Open Settings → PROVIDERS section — provider key labels render fully left-aligned; hovering any label or input shows the full text as a native tooltip
- [ ] `make build-local-web` passes (Vite build clean)
- [ ] `tsc --noEmit` passes (0 type errors)
- [ ] `bun run lint` passes (0 ESLint errors)
- [ ] `make test-web` passes (164/164 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)