### PR TITLE
fix(marketplace): correct skill-install command + bc→mycel naming sweep

### DIFF
--- a/server/handlers/marketplace.go
+++ b/server/handlers/marketplace.go
@@ -170,17 +170,36 @@ func composeInstallMessage(req installRequest) string {
 		case marketplace.SourceOpenclaw:
 			sb.WriteString(fmt.Sprintf("  clawhub install %q\n", req.ItemID))
 		default:
-			spec := req.ItemSourceURL
-			if spec == "" {
-				spec = req.ItemID
+			repoURL := req.ItemSourceURL
+			if repoURL == "" {
+				repoURL = req.ItemID
 			}
-			sb.WriteString(fmt.Sprintf("  claude skill install %q\n", spec))
+			marketplaceName := marketplaceNameFromURL(repoURL)
+			sb.WriteString("Step 1 — register the marketplace (first time only):\n")
+			sb.WriteString(fmt.Sprintf("  claude plugin marketplace add %q\n", repoURL))
+			sb.WriteString("Step 2 — install the plugin:\n")
+			sb.WriteString(fmt.Sprintf("  claude plugin install %q\n", req.ItemName+"@"+marketplaceName))
 		}
 	case marketplace.TypeTemplate:
-		sb.WriteString(fmt.Sprintf("  bc template import %q\n", req.ItemName))
+		sb.WriteString(fmt.Sprintf("  mycel template import %q\n", req.ItemName))
 	default:
 		sb.WriteString("  Consult the item URL above for installation instructions.\n")
 	}
 
 	return sb.String()
+}
+
+// marketplaceNameFromURL extracts the GitHub repository name from a URL such as
+// https://github.com/owner/repo[/tree/…] → "repo".
+// Falls back to the full rawURL when the pattern is not recognized.
+func marketplaceNameFromURL(rawURL string) string {
+	// Strip scheme + host, then split on "/" to get path segments.
+	u := strings.TrimPrefix(rawURL, "https://")
+	u = strings.TrimPrefix(u, "http://")
+	// Segments: ["github.com", "owner", "repo", …]
+	parts := strings.SplitN(u, "/", 4)
+	if len(parts) >= 3 && parts[2] != "" {
+		return parts[2]
+	}
+	return rawURL
 }

--- a/server/handlers/marketplace_test.go
+++ b/server/handlers/marketplace_test.go
@@ -387,8 +387,17 @@ func TestComposeInstallMessage_ClaudeSkill(t *testing.T) {
 		Agents:        []string{"a"},
 	}
 	msg := composeInstallMessage(req)
-	if !contains(msg, "claude skill install") {
-		t.Errorf("Claude skill message should contain 'claude skill install', got:\n%s", msg)
+	// Step 1: register the marketplace via the correct plugin command.
+	if !contains(msg, "claude plugin marketplace add") {
+		t.Errorf("Claude skill message should contain 'claude plugin marketplace add', got:\n%s", msg)
+	}
+	// Step 2: install the specific plugin.
+	if !contains(msg, "claude plugin install") {
+		t.Errorf("Claude skill message should contain 'claude plugin install', got:\n%s", msg)
+	}
+	// The plugin install reference should be scoped to the marketplace (name@marketplace).
+	if !contains(msg, "pdf@skills") {
+		t.Errorf("Claude skill message should contain 'pdf@skills', got:\n%s", msg)
 	}
 }
 
@@ -452,8 +461,8 @@ func TestComposeInstallMessage_Template(t *testing.T) {
 		Agents:     []string{"a"},
 	}
 	msg := composeInstallMessage(req)
-	if !contains(msg, "bc template import") {
-		t.Errorf("template message should contain 'bc template import', got:\n%s", msg)
+	if !contains(msg, "mycel template import") {
+		t.Errorf("template message should contain 'mycel template import', got:\n%s", msg)
 	}
 }
 

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -476,7 +476,7 @@ export function Tools() {
             <EmptyState
               icon=">"
               title="No CLI dependencies tracked"
-              description='Run "bc tool add <name>" or use the "+ CLI Tool" button above to register tools like gh, aws, or wrangler.'
+              description='Run "mycel tool add <name>" or use the "+ CLI Tool" button above to register tools like gh, aws, or wrangler.'
             />
           )
         ) : (


### PR DESCRIPTION
## Summary

- Fix `composeInstallMessage` in `server/handlers/marketplace.go`: skill/plugin install now emits the correct two-step flow instead of the non-existent `claude skill install`:
  1. `claude plugin marketplace add "<repo-url>"` — register the marketplace (first time only)
  2. `claude plugin install "<name>@<marketplace>"` — install the specific plugin (marketplace name derived from repo URL)
- Rename `bc template import` → `mycel template import` in the same function (binary is `mycel`, not `bc`)
- `web/src/views/Tools.tsx`: fix empty-state hint `bc tool add <name>` → `mycel tool add <name>`
- Updated `TestComposeInstallMessage_ClaudeSkill` and `TestComposeInstallMessage_Template` to match

## BC_* env var status

Searched exhaustively for `BC_AGENT_ID`, `BC_WORKSPACE`, `BC_BCD_ADDR`, `BC_AGENT_ROLE`, `BC_AGENT_RUNTIME`, `BC_WORKTREE_NAME`, `BC_AGENT_TOOL` across all Go, TypeScript, Markdown, shell, and Dockerfile files. **Zero occurrences found** — nothing to rename; all deferred as N/A.

## Test plan
- [x] `make build-local-bc` passes
- [x] `golangci-lint run ./server/handlers/...` = 0 issues
- [x] `go test ./server/handlers/...` passes (marketplace tests updated)
- [x] `make test-web` passes (164 tests)
- [x] Marketplace skill install instructions now show correct two-step `claude plugin marketplace add` + `claude plugin install` commands
- [x] Tools.tsx shows `mycel tool add` hint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Marketplace-installed skills now guide users through registering a marketplace before installing, using a marketplace-scoped plugin name.
  * Template imports now use the updated `mycel` command.
  * CLI help text now points to `mycel tool add <name>` for adding tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #3334
