### PR TITLE
fix(marketplace): correct/graceful install commands for glama MCPs and openclaw skills

### DIFF
--- a/server/handlers/marketplace.go
+++ b/server/handlers/marketplace.go
@@ -160,15 +160,35 @@ func composeInstallMessage(req installRequest) string {
 
 	switch marketplace.ItemType(req.ItemType) {
 	case marketplace.TypeMCP:
-		spec := req.ItemSourceURL
-		if spec == "" {
-			spec = req.ItemID
+		if marketplace.Source(req.ItemSource) == marketplace.SourceGlama {
+			// Glama's listing API does not expose the server's runnable endpoint or
+			// command — only the listing-page URL. Emitting "claude mcp add <listing-url>"
+			// would create a broken stdio entry pointing at an HTML page, not a server.
+			// Emit an honest instruction so the agent is not handed a command that fails.
+			listingURL := req.ItemSourceURL
+			if listingURL == "" {
+				listingURL = "https://glama.ai/mcp/servers"
+			}
+			sb.WriteString("  Glama's catalog API does not expose the server's runnable\n")
+			sb.WriteString("  endpoint, so a ready-made install command cannot be composed.\n")
+			sb.WriteString(fmt.Sprintf("  1. Open %s\n", listingURL))
+			sb.WriteString("  2. Find the server's install command (npx/uvx invocation or HTTP/SSE URL).\n")
+			sb.WriteString(fmt.Sprintf("  3. Run: claude mcp add %q <command-or-url>\n", req.ItemName))
+		} else {
+			spec := req.ItemSourceURL
+			if spec == "" {
+				spec = req.ItemID
+			}
+			sb.WriteString(fmt.Sprintf("  claude mcp add %q %q\n", req.ItemName, spec))
 		}
-		sb.WriteString(fmt.Sprintf("  claude mcp add %q %q\n", req.ItemName, spec))
 	case marketplace.TypeSkill:
 		switch marketplace.Source(req.ItemSource) {
 		case marketplace.SourceOpenclaw:
-			sb.WriteString(fmt.Sprintf("  clawhub install %q\n", req.ItemID))
+			// The correct CLI is the openclaw CLI, not the non-existent "clawhub" binary.
+			// Command: openclaw skills install <slug>
+			// The item ID may carry an "openclaw:" prefix; strip it to get the bare slug.
+			slug := strings.TrimPrefix(req.ItemID, "openclaw:")
+			sb.WriteString(fmt.Sprintf("  openclaw skills install %q\n", slug))
 		default:
 			repoURL := req.ItemSourceURL
 			if repoURL == "" {

--- a/server/handlers/marketplace_test.go
+++ b/server/handlers/marketplace_test.go
@@ -216,14 +216,14 @@ func TestMarketplaceHandler_Install_ComposesCorrectMCPMessage(t *testing.T) {
 	}
 }
 
-func TestMarketplaceHandler_Install_OpenclawSkillUsesClawhub(t *testing.T) {
+func TestMarketplaceHandler_Install_OpenclawSkillUsesOpenclawCLI(t *testing.T) {
 	sender := &fakeAgentSender{}
 	h := NewMarketplaceHandler(newTestAggregator(t, nil), sender)
 	mux := http.NewServeMux()
 	h.Register(mux)
 
 	body := `{
-		"item_id":     "couponclaw",
+		"item_id":     "openclaw:couponclaw",
 		"item_name":   "CouponClaw",
 		"item_type":   "skill",
 		"item_source": "openclaw",
@@ -238,8 +238,12 @@ func TestMarketplaceHandler_Install_OpenclawSkillUsesClawhub(t *testing.T) {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 	msg := sender.calls[0].message
-	if !contains(msg, "clawhub install") {
-		t.Errorf("openclaw install message should contain 'clawhub install', got: %s", msg)
+	if !contains(msg, "openclaw skills install") {
+		t.Errorf("openclaw install message should contain 'openclaw skills install', got: %s", msg)
+	}
+	// Must NOT contain the non-existent clawhub binary.
+	if contains(msg, "clawhub install") {
+		t.Errorf("openclaw install message must NOT use clawhub (binary does not exist), got: %s", msg)
 	}
 }
 
@@ -402,17 +406,48 @@ func TestComposeInstallMessage_ClaudeSkill(t *testing.T) {
 }
 
 func TestComposeInstallMessage_OpenclawSkill(t *testing.T) {
+	// Item IDs from the aggregator carry an "openclaw:" prefix; the install
+	// command must use the bare slug and the real openclaw CLI binary.
 	req := installRequest{
-		ItemID:     "couponclaw",
+		ItemID:     "openclaw:couponclaw",
 		ItemName:   "CouponClaw",
 		ItemType:   "skill",
 		ItemSource: "openclaw",
 		Agents:     []string{"a"},
 	}
 	msg := composeInstallMessage(req)
-	// ItemID is quoted with %q, so the command contains the quoted identifier.
-	if !contains(msg, `clawhub install "couponclaw"`) {
-		t.Errorf("openclaw message should contain 'clawhub install \"couponclaw\"', got:\n%s", msg)
+	// Prefix must be stripped; command must use the real openclaw CLI.
+	if !contains(msg, `openclaw skills install "couponclaw"`) {
+		t.Errorf("openclaw message should contain 'openclaw skills install \"couponclaw\"', got:\n%s", msg)
+	}
+	if contains(msg, "clawhub") {
+		t.Errorf("openclaw message must NOT reference clawhub (binary does not exist), got:\n%s", msg)
+	}
+}
+
+func TestComposeInstallMessage_GlamaMCP(t *testing.T) {
+	// Glama's listing API does not expose a runnable server endpoint/command,
+	// so we must emit an honest instruction rather than a broken "claude mcp add <listing-url>".
+	req := installRequest{
+		ItemID:        "glama:modelcontextprotocol/brave-search",
+		ItemName:      "brave-search",
+		ItemSourceURL: "https://glama.ai/mcp/servers/brave-search",
+		ItemType:      "mcp",
+		ItemSource:    "glama",
+		Agents:        []string{"a"},
+	}
+	msg := composeInstallMessage(req)
+	// Must NOT emit a broken "claude mcp add <listing-page-url>".
+	if contains(msg, `claude mcp add "brave-search" "https://glama.ai`) {
+		t.Errorf("glama MCP message must not emit 'claude mcp add <listing-url>' (listing page is not a server endpoint), got:\n%s", msg)
+	}
+	// Must contain the listing URL so the agent knows where to look.
+	if !contains(msg, "https://glama.ai/mcp/servers/brave-search") {
+		t.Errorf("glama MCP message should contain the listing URL, got:\n%s", msg)
+	}
+	// Must instruct the agent to find the real install command.
+	if !contains(msg, "claude mcp add") {
+		t.Errorf("glama MCP message should still reference 'claude mcp add' as the next step, got:\n%s", msg)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Glama MCP items**: Glama's listing API returns the listing-page URL, not a runnable server endpoint or command. The previous code emitted `claude mcp add "name" "https://glama.ai/mcp/servers/..."` which creates a broken stdio entry pointing at an HTML page. Now emits an honest multi-step instruction: open the listing URL, find the real command (npx/uvx/HTTP/SSE), then run `claude mcp add`.
- **Openclaw skill items**: The previous code emitted `clawhub install "<id>"`, but the `clawhub` binary does not exist on any platform. The correct CLI is `openclaw skills install <slug>`. Fixed to strip the `"openclaw:"` ID prefix and emit `openclaw skills install "<slug>"`.
- Tests updated to assert the correct behavior and extended with new `TestComposeInstallMessage_GlamaMCP` and renamed `TestMarketplaceHandler_Install_OpenclawSkillUsesOpenclawCLI`.

Part of #3334

## Test plan

- [ ] `go test ./server/handlers/ ./pkg/marketplace/...` — all pass (verified locally)
- [ ] `golangci-lint run ./server/handlers/ ./pkg/marketplace/...` — 0 issues (verified locally)
- [ ] `make build-local-bc` — passes (verified locally)
- [ ] Manually dispatch an openclaw skill install to an agent; confirm the message contains `openclaw skills install` and not `clawhub install`
- [ ] Manually dispatch a glama MCP install to an agent; confirm the message contains the listing URL and step-by-step instructions, not a broken `claude mcp add <listing-url>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)