### PR TITLE
fix(notify): hot-start Telegram gateway and fix channel subscriptions

### DIFF
--- a/docs/how-to/set-up-notifications.md
+++ b/docs/how-to/set-up-notifications.md
@@ -35,20 +35,32 @@ curl -X POST http://localhost:9374/api/gateways \
 
 1. Message [@BotFather](https://t.me/BotFather) on Telegram and create a new bot with `/newbot`.
 2. Copy the bot token.
-3. Add the bot to your Telegram groups.
+3. Open a DM with the bot and/or add it to Telegram groups.
 4. Optionally disable privacy mode so the bot can read all group messages (not just commands).
 
 ```bash
 mycel secret set TELEGRAM_BOT_TOKEN "123456:ABC-..."
 ```
 
-Connect via the web UI or API:
+Connect via the web UI (Settings → Notifications → Connect Telegram) or:
 
 ```bash
-curl -X POST http://localhost:9374/api/gateways \
+# Persist + hot-start long-polling (no daemon restart required)
+curl -X PATCH http://localhost:9374/api/gateways/telegram \
   -H "Content-Type: application/json" \
-  -d '{"platform": "telegram", "tokens": {"bot_token": "123456:ABC-..."}}'
+  -d '{"bot_token":"123456:ABC-...","enabled":true,"mode":"polling"}'
 ```
+
+**Channel keys:** inbound chats are named `telegram:<username>`, `telegram:<chat_id>`,
+or `telegram:<group-title>` — not `telegram:general`. After the first message, subscribe
+agents to the discovered channel:
+
+```bash
+mycel notify subscribe telegram:your_username eng-01
+```
+
+If agents were previously subscribed to the bogus `telegram:general` placeholder, the
+first real inbound message copies those subscriptions onto the real channel automatically.
 
 ### GitHub
 

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -179,8 +179,8 @@ func (m *Manager) Start(ctx context.Context) error {
 // with no adapters at boot, and PATCH only persisted config).
 //
 // If an adapter with the same name is already running, this is a no-op and
-// returns nil. Callers that need to swap credentials should Stop the old
-// adapter first (future work).
+// returns nil. Callers that need to swap credentials should StopAdapter the
+// old one first, then StartAdapter with a new instance.
 func (m *Manager) StartAdapter(adapter NotificationAdapter) error {
 	if adapter == nil {
 		return fmt.Errorf("gateway: nil adapter")
@@ -197,6 +197,11 @@ func (m *Manager) StartAdapter(adapter NotificationAdapter) error {
 	if ctx == nil {
 		return fmt.Errorf("gateway: manager not started")
 	}
+	// Refuse hot-starts once the manager lifetime context is canceled so we
+	// never adapterWG.Add after Start has begun waiting on shutdown.
+	if ctx.Err() != nil {
+		return fmt.Errorf("gateway: manager shutting down")
+	}
 	if already {
 		log.Info("gateway: adapter already running", "name", name)
 		return nil
@@ -207,6 +212,11 @@ func (m *Manager) StartAdapter(adapter NotificationAdapter) error {
 
 	if !m.markRunning(name) {
 		return nil
+	}
+	// Re-check after markRunning: shutdown may have begun while we held no lock.
+	if ctx.Err() != nil {
+		m.clearRunning(name)
+		return fmt.Errorf("gateway: manager shutting down")
 	}
 	m.adapterWG.Add(1)
 	go func() {
@@ -221,6 +231,35 @@ func (m *Manager) StartAdapter(adapter NotificationAdapter) error {
 	}()
 	log.Info("gateway: hot-started adapter", "name", name)
 	return nil
+}
+
+// StopAdapter stops a single registered adapter and removes it from the
+// registry so a subsequent StartAdapter can install a replacement (e.g. after
+// bot token rotation). It blocks briefly until the Start loop clears the
+// running flag.
+func (m *Manager) StopAdapter(name string) error {
+	m.mu.Lock()
+	a, ok := m.adapters[name]
+	if ok {
+		delete(m.adapters, name)
+	}
+	m.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	err := a.Stop()
+	// Wait for the Start/StartAdapter goroutine to observe Stop and clearRunning.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.RLock()
+		running := m.running[name]
+		m.mu.RUnlock()
+		if !running {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return err
 }
 
 // markRunning records that name is starting. Returns false if already running.

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -55,6 +55,12 @@ type reactionSender interface {
 type Manager struct {
 	// adapters holds all registered NotificationAdapter instances.
 	adapters map[string]NotificationAdapter
+	// running tracks adapters whose Start loop is already live so hot-start
+	// does not spawn a second poll/socket for the same name.
+	running map[string]bool
+	// startCtx is the context passed to Start; used by StartAdapter to bind
+	// late-registered adapters to the same lifetime.
+	startCtx context.Context
 	// channelMap maps "telegram:<group_name>" → channelRoute
 	channelMap map[string]channelRoute
 	// onInbound is called when a message arrives from an external platform.
@@ -64,6 +70,9 @@ type Manager struct {
 	onInbound    func(bcChannel, sender, senderID, content, messageID string, mentions []string, raw json.RawMessage)
 	channelStore ChannelStore
 	mu           sync.RWMutex
+	// adapterWG tracks boot-time and hot-started adapter goroutines so Stop/
+	// Start can wait for clean shutdown of both.
+	adapterWG sync.WaitGroup
 }
 
 type channelRoute struct {
@@ -76,7 +85,20 @@ type channelRoute struct {
 func NewManager() *Manager {
 	return &Manager{
 		adapters:   make(map[string]NotificationAdapter),
+		running:    make(map[string]bool),
 		channelMap: make(map[string]channelRoute),
+	}
+}
+
+// SetStartContext stores the process lifetime context used by StartAdapter
+// before Start's goroutine runs. Without this, a PATCH that hot-starts an
+// adapter can race Start and see a nil context.
+func (m *Manager) SetStartContext(ctx context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.startCtx = ctx
+	if m.running == nil {
+		m.running = make(map[string]bool)
 	}
 }
 
@@ -102,13 +124,19 @@ func (m *Manager) Register(adapter NotificationAdapter) {
 }
 
 // Start discovers channels from all adapters and begins receiving messages.
+// It is safe to call with zero adapters; later StartAdapter calls share this
+// context and wire into the same inbound pipeline.
 func (m *Manager) Start(ctx context.Context) error {
-	m.mu.RLock()
+	m.mu.Lock()
+	m.startCtx = ctx
+	if m.running == nil {
+		m.running = make(map[string]bool)
+	}
 	adapterList := make([]NotificationAdapter, 0, len(m.adapters))
 	for _, a := range m.adapters {
 		adapterList = append(adapterList, a)
 	}
-	m.mu.RUnlock()
+	m.mu.Unlock()
 
 	// Restore persisted channel mappings so Send works immediately after restart.
 	m.restorePersistedChannels(ctx)
@@ -119,11 +147,14 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 
 	// Start all adapters in goroutines
-	var wg sync.WaitGroup
 	for _, a := range adapterList {
-		wg.Add(1)
+		if !m.markRunning(a.Name()) {
+			continue // already started (e.g. via StartAdapter race)
+		}
+		m.adapterWG.Add(1)
 		go func(adapter NotificationAdapter) {
-			defer wg.Done()
+			defer m.adapterWG.Done()
+			defer m.clearRunning(adapter.Name())
 			platformName := adapter.Name()
 			handler := func(n Notification) {
 				m.handleNotification(platformName, n)
@@ -138,8 +169,78 @@ func (m *Manager) Start(ctx context.Context) error {
 	go m.lateDiscovery(ctx)
 
 	<-ctx.Done()
-	wg.Wait()
+	m.adapterWG.Wait()
 	return nil
+}
+
+// StartAdapter registers and starts an adapter after Manager.Start is running.
+// Used when a platform is connected via the API while the daemon is already up
+// (previously required a full restart because buildGatewayManager returned nil
+// with no adapters at boot, and PATCH only persisted config).
+//
+// If an adapter with the same name is already running, this is a no-op and
+// returns nil. Callers that need to swap credentials should Stop the old
+// adapter first (future work).
+func (m *Manager) StartAdapter(adapter NotificationAdapter) error {
+	if adapter == nil {
+		return fmt.Errorf("gateway: nil adapter")
+	}
+	name := adapter.Name()
+	if name == "" {
+		return fmt.Errorf("gateway: adapter has empty name")
+	}
+
+	m.mu.RLock()
+	ctx := m.startCtx
+	already := m.running[name]
+	m.mu.RUnlock()
+	if ctx == nil {
+		return fmt.Errorf("gateway: manager not started")
+	}
+	if already {
+		log.Info("gateway: adapter already running", "name", name)
+		return nil
+	}
+
+	m.Register(adapter)
+	m.discoverChannels(adapter)
+
+	if !m.markRunning(name) {
+		return nil
+	}
+	m.adapterWG.Add(1)
+	go func() {
+		defer m.adapterWG.Done()
+		defer m.clearRunning(name)
+		handler := func(n Notification) {
+			m.handleNotification(name, n)
+		}
+		if err := adapter.Start(ctx, handler); err != nil && ctx.Err() == nil {
+			log.Error("gateway: adapter stopped with error", "adapter", name, "error", err)
+		}
+	}()
+	log.Info("gateway: hot-started adapter", "name", name)
+	return nil
+}
+
+// markRunning records that name is starting. Returns false if already running.
+func (m *Manager) markRunning(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.running == nil {
+		m.running = make(map[string]bool)
+	}
+	if m.running[name] {
+		return false
+	}
+	m.running[name] = true
+	return true
+}
+
+func (m *Manager) clearRunning(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.running, name)
 }
 
 // restorePersistedChannels loads saved channel mappings from the store.

--- a/pkg/gateway/manager_test.go
+++ b/pkg/gateway/manager_test.go
@@ -375,3 +375,71 @@ func TestRefreshChannelMeta(t *testing.T) {
 		t.Fatalf("alice meta not refreshed: %+v", ch)
 	}
 }
+
+// blockingAdapter Start blocks until ctx is cancelled — models a real poll loop.
+type blockingAdapter struct {
+	mockNotifAdapter
+	started chan struct{}
+}
+
+func (b *blockingAdapter) Start(ctx context.Context, _ func(Notification)) error {
+	close(b.started)
+	<-ctx.Done()
+	return nil
+}
+
+func TestStartAdapterHotStart(t *testing.T) {
+	m := NewManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.SetStartContext(ctx)
+
+	// Boot with zero adapters (the empty-manager path).
+	done := make(chan struct{})
+	go func() {
+		_ = m.Start(ctx)
+		close(done)
+	}()
+
+	// Give Start a moment to park on ctx.Done.
+	time.Sleep(20 * time.Millisecond)
+
+	started := make(chan struct{})
+	adapter := &blockingAdapter{
+		mockNotifAdapter: mockNotifAdapter{name: "telegram"},
+		started:          started,
+	}
+	if err := m.StartAdapter(adapter); err != nil {
+		t.Fatalf("StartAdapter: %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("adapter Start was not invoked")
+	}
+
+	if got := m.GetAdapter("telegram"); got == nil {
+		t.Fatal("expected telegram adapter registered")
+	}
+
+	// Idempotent: second StartAdapter must not error.
+	if err := m.StartAdapter(adapter); err != nil {
+		t.Fatalf("second StartAdapter: %v", err)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Manager.Start did not return after cancel")
+	}
+}
+
+func TestStartAdapterRequiresContext(t *testing.T) {
+	m := NewManager()
+	err := m.StartAdapter(&mockNotifAdapter{name: "telegram"})
+	if err == nil {
+		t.Fatal("expected error when manager has no start context")
+	}
+}

--- a/pkg/gateway/manager_test.go
+++ b/pkg/gateway/manager_test.go
@@ -376,15 +376,34 @@ func TestRefreshChannelMeta(t *testing.T) {
 	}
 }
 
-// blockingAdapter Start blocks until ctx is cancelled — models a real poll loop.
+// blockingAdapter Start blocks until ctx is cancelled or Stop is called.
 type blockingAdapter struct {
 	mockNotifAdapter
 	started chan struct{}
+	stop    chan struct{}
 }
 
 func (b *blockingAdapter) Start(ctx context.Context, _ func(Notification)) error {
+	if b.stop == nil {
+		b.stop = make(chan struct{})
+	}
 	close(b.started)
-	<-ctx.Done()
+	select {
+	case <-ctx.Done():
+	case <-b.stop:
+	}
+	return nil
+}
+
+func (b *blockingAdapter) Stop() error {
+	if b.stop == nil {
+		b.stop = make(chan struct{})
+	}
+	select {
+	case <-b.stop:
+	default:
+		close(b.stop)
+	}
 	return nil
 }
 
@@ -441,5 +460,76 @@ func TestStartAdapterRequiresContext(t *testing.T) {
 	err := m.StartAdapter(&mockNotifAdapter{name: "telegram"})
 	if err == nil {
 		t.Fatal("expected error when manager has no start context")
+	}
+}
+
+func TestStartAdapterRejectsAfterShutdown(t *testing.T) {
+	m := NewManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	m.SetStartContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		_ = m.Start(ctx)
+		close(done)
+	}()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return")
+	}
+
+	err := m.StartAdapter(&mockNotifAdapter{name: "telegram"})
+	if err == nil {
+		t.Fatal("expected error after shutdown")
+	}
+}
+
+func TestStopAdapterAllowsRestart(t *testing.T) {
+	m := NewManager()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.SetStartContext(ctx)
+
+	go func() { _ = m.Start(ctx) }()
+	time.Sleep(20 * time.Millisecond)
+
+	started1 := make(chan struct{})
+	a1 := &blockingAdapter{
+		mockNotifAdapter: mockNotifAdapter{name: "telegram"},
+		started:          started1,
+		stop:             make(chan struct{}),
+	}
+	if err := m.StartAdapter(a1); err != nil {
+		t.Fatalf("StartAdapter: %v", err)
+	}
+	select {
+	case <-started1:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first adapter did not start")
+	}
+
+	if err := m.StopAdapter("telegram"); err != nil {
+		t.Fatalf("StopAdapter: %v", err)
+	}
+	if m.GetAdapter("telegram") != nil {
+		t.Fatal("expected adapter removed after StopAdapter")
+	}
+
+	started2 := make(chan struct{})
+	a2 := &blockingAdapter{
+		mockNotifAdapter: mockNotifAdapter{name: "telegram"},
+		started:          started2,
+		stop:             make(chan struct{}),
+	}
+	if err := m.StartAdapter(a2); err != nil {
+		t.Fatalf("restart StartAdapter: %v", err)
+	}
+	select {
+	case <-started2:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replacement adapter did not start")
 	}
 }

--- a/pkg/gateway/manager_test.go
+++ b/pkg/gateway/manager_test.go
@@ -376,11 +376,11 @@ func TestRefreshChannelMeta(t *testing.T) {
 	}
 }
 
-// blockingAdapter Start blocks until ctx is cancelled or Stop is called.
+// blockingAdapter Start blocks until ctx is canceled or Stop is called.
 type blockingAdapter struct {
-	mockNotifAdapter
 	started chan struct{}
 	stop    chan struct{}
+	mockNotifAdapter
 }
 
 func (b *blockingAdapter) Start(ctx context.Context, _ func(Notification)) error {

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -167,6 +167,22 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, content, message
 			return
 		}
 
+		// Setup wizard historically subscribed agents to "{platform}:general"
+		// even when no such channel exists (Telegram DMs arrive as
+		// telegram:<username|chat_id>). Copy placeholder subscriptions onto
+		// the first real channel so legacy installs self-heal.
+		if len(subs) == 0 && platform != "" {
+			if n, mErr := s.migratePlaceholderSubs(ctx, platform, channel); mErr != nil {
+				log.Warn("notify: placeholder migration failed", "platform", platform, "channel", channel, "error", mErr)
+			} else if n > 0 {
+				subs, subErr = s.store.Subscribers(ctx, channel)
+				if subErr != nil {
+					log.Warn("notify: failed to get subscribers after migration", "channel", channel, "error", subErr)
+					return
+				}
+			}
+		}
+
 		log.Info("notify: dispatch", "channel", channel, "sender", sender, "subscribers", len(subs))
 
 		mentionSet := make(map[string]bool, len(mentions))
@@ -238,6 +254,43 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, content, message
 			log.Warn("notify: prune failed", "channel", channel, "error", err)
 		}
 	}()
+}
+
+// migratePlaceholderSubs copies subscriptions from "{platform}:general" onto
+// the real channel when the placeholder still has subscribers and the real
+// channel has none. Returns the number of agents copied. The placeholder row
+// is left in place (copy, not rewrite) so operators can clean it up later.
+func (s *Service) migratePlaceholderSubs(ctx context.Context, platform, realChannel string) (int, error) {
+	placeholder := platform + ":general"
+	if realChannel == "" || realChannel == placeholder {
+		return 0, nil
+	}
+	// Only migrate onto channels for this platform.
+	prefix := platform + ":"
+	if !strings.HasPrefix(realChannel, prefix) {
+		return 0, nil
+	}
+
+	legacy, err := s.store.Subscribers(ctx, placeholder)
+	if err != nil {
+		return 0, err
+	}
+	if len(legacy) == 0 {
+		return 0, nil
+	}
+
+	copied := 0
+	for _, sub := range legacy {
+		if err := s.store.Subscribe(ctx, realChannel, sub.Agent, sub.MentionOnly); err != nil {
+			return copied, err
+		}
+		copied++
+	}
+	if copied > 0 {
+		log.Info("notify: migrated placeholder subscriptions",
+			"from", placeholder, "to", realChannel, "agents", copied)
+	}
+	return copied, nil
 }
 
 // Subscribe adds an agent to a channel.

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -429,3 +429,76 @@ func TestDrainDispatches(t *testing.T) {
 		t.Fatal("DrainDispatches timed out after the dispatch was released")
 	}
 }
+
+func TestMigratePlaceholderSubsOnDispatch(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	// Legacy wizard subscription on telegram:general only.
+	if err := store.Subscribe(ctx, "telegram:general", "mdrndr-manager", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Subscribe(ctx, "telegram:general", "mdrndr-tui", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("telegram:ab010300", "telegram", "[telegram] Agni", "", "ping", "", nil, nil, nil)
+
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+
+	subs, err := store.Subscribers(ctx, "telegram:ab010300")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subs) != 2 {
+		t.Fatalf("expected 2 migrated subscribers, got %d", len(subs))
+	}
+	// Placeholder remains (copy, not rewrite).
+	legacy, err := store.Subscribers(ctx, "telegram:general")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(legacy) != 2 {
+		t.Fatalf("expected placeholder to remain, got %d", len(legacy))
+	}
+
+	calls := sender.getCalls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 deliveries, got %d: %+v", len(calls), calls)
+	}
+}
+
+func TestMigratePlaceholderSubsNoOpWhenRealHasSubs(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "telegram:general", "legacy-agent", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Subscribe(ctx, "telegram:ab010300", "real-agent", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("telegram:ab010300", "telegram", "user", "", "hi", "", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch timeout")
+	}
+
+	subs, err := store.Subscribers(ctx, "telegram:ab010300")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subs) != 1 || subs[0].Agent != "real-agent" {
+		t.Fatalf("expected only real-agent, got %+v", subs)
+	}
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "real-agent" {
+		t.Fatalf("expected delivery only to real-agent, got %+v", calls)
+	}
+}

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -565,15 +565,30 @@ func buildGatewayManager(ctx context.Context, ws *bcworkspace.Workspace, notifyS
 		}
 	}
 
+	// Always construct a manager (even with zero adapters) so:
+	//  1. health endpoints never return "gateway manager not available" solely
+	//     because nothing was configured at boot, and
+	//  2. PATCH /api/gateways/{platform} can hot-start adapters without a
+	//     daemon restart (see GatewayHandler.ensureTelegramAdapter).
+	m := bcgateway.NewManager()
+	m.SetStartContext(ctx)
+	if notifyService != nil {
+		m.SetChannelStore(&channelPersister{store: notifyService.Store()})
+	}
+
 	if tgCount == 0 && !dcEnabled && !slEnabled && ghCount == 0 && whCount == 0 && rssCount == 0 &&
 		notionCount == 0 && waCount == 0 && matrixCount == 0 &&
 		mmCount == 0 && ircCount == 0 && mqttCount == 0 && twitterCount == 0 && redditCount == 0 {
-		return nil
-	}
-
-	m := bcgateway.NewManager()
-	if notifyService != nil {
-		m.SetChannelStore(&channelPersister{store: notifyService.Store()})
+		// Empty manager still needs Start so StartAdapter can share the
+		// process lifetime context.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := m.Start(ctx); err != nil && ctx.Err() == nil {
+				log.Error("gateway manager stopped", "error", err)
+			}
+		}()
+		return m
 	}
 
 	// Register Telegram adapters. Label "" → adapter name "telegram",

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -565,6 +565,22 @@ func buildGatewayManager(ctx context.Context, ws *bcworkspace.Workspace, notifyS
 		}
 	}
 
+	// Count enabled Signal poll adapters.
+	var signalCount int
+	for _, c := range gw.Signals {
+		if c.Enabled && c.APIURL != "" {
+			signalCount++
+		}
+	}
+
+	// Count enabled iMessage poll adapters.
+	var imessageCount int
+	for _, c := range gw.IMessages {
+		if c.Enabled && c.APIURL != "" {
+			imessageCount++
+		}
+	}
+
 	// Always construct a manager (even with zero adapters) so:
 	//  1. health endpoints never return "gateway manager not available" solely
 	//     because nothing was configured at boot, and
@@ -578,7 +594,8 @@ func buildGatewayManager(ctx context.Context, ws *bcworkspace.Workspace, notifyS
 
 	if tgCount == 0 && !dcEnabled && !slEnabled && ghCount == 0 && whCount == 0 && rssCount == 0 &&
 		notionCount == 0 && waCount == 0 && matrixCount == 0 &&
-		mmCount == 0 && ircCount == 0 && mqttCount == 0 && twitterCount == 0 && redditCount == 0 {
+		mmCount == 0 && ircCount == 0 && mqttCount == 0 && twitterCount == 0 && redditCount == 0 &&
+		signalCount == 0 && imessageCount == 0 {
 		// Empty manager still needs Start so StartAdapter can share the
 		// process lifetime context.
 		wg.Add(1)

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -585,9 +585,12 @@ func (h *GatewayHandler) ensureTelegramAdapter(label string) error {
 	if label != "" {
 		adapterName = "telegram:" + label
 	}
-	// Already registered and (hopefully) running — StartAdapter is idempotent.
-	if existing := h.gw.GetAdapter(adapterName); existing != nil {
-		return h.gw.StartAdapter(existing)
+	// Always build a new adapter from the saved token. Reusing GetAdapter would
+	// keep a stale bot token after rotation (token is fixed at NewNamed time).
+	if h.gw.GetAdapter(adapterName) != nil {
+		if err := h.gw.StopAdapter(adapterName); err != nil {
+			log.Warn("gateway: stop existing telegram adapter", "name", adapterName, "error", err)
+		}
 	}
 
 	adapter := bctelegram.NewNamed(adapterName, tc.BotToken, tc.Mode)

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rpuneet/mycel/pkg/gateway"
+	bctelegram "github.com/rpuneet/mycel/pkg/gateway/telegram"
 	bcwhatsapp "github.com/rpuneet/mycel/pkg/gateway/whatsapp"
 	"github.com/rpuneet/mycel/pkg/log"
 	"github.com/rpuneet/mycel/pkg/notify"
@@ -474,6 +475,11 @@ func (h *GatewayHandler) updatePlatform(w http.ResponseWriter, r *http.Request, 
 			httpError(w, "invalid telegram config: "+err.Error(), http.StatusBadRequest)
 			return
 		}
+		// Keep Telegrams map in sync — buildGatewayManager / hot-start iterate it.
+		if cfg.Gateways.Telegrams == nil {
+			cfg.Gateways.Telegrams = make(map[string]*workspace.TelegramGatewayConfig)
+		}
+		cfg.Gateways.Telegrams[""] = cfg.Gateways.Telegram
 	case strings.HasPrefix(platform, "telegram:"):
 		label := strings.TrimPrefix(platform, "telegram:")
 		if cfg.Gateways.Telegrams == nil {
@@ -523,11 +529,19 @@ func (h *GatewayHandler) updatePlatform(w http.ResponseWriter, r *http.Request, 
 		if cfg.Gateways.Telegram != nil {
 			h.writeVaultSecret("TELEGRAM_BOT_TOKEN", cfg.Gateways.Telegram.BotToken)
 		}
+		if err := h.ensureTelegramAdapter(""); err != nil {
+			log.Warn("gateway: failed to hot-start telegram adapter", "error", err)
+			// Config is saved; surface a soft warning rather than failing the
+			// PATCH — operator can still restart if start fails (bad token etc).
+		}
 	case strings.HasPrefix(platform, "telegram:"):
 		label := strings.TrimPrefix(platform, "telegram:")
 		if tc := cfg.Gateways.Telegrams[label]; tc != nil {
 			key := "TELEGRAM_BOT_TOKEN_" + strings.ToUpper(strings.ReplaceAll(label, "-", "_"))
 			h.writeVaultSecret(key, tc.BotToken)
+		}
+		if err := h.ensureTelegramAdapter(label); err != nil {
+			log.Warn("gateway: failed to hot-start telegram adapter", "label", label, "error", err)
 		}
 	case platform == "discord":
 		if cfg.Gateways.Discord != nil {
@@ -541,6 +555,50 @@ func (h *GatewayHandler) updatePlatform(w http.ResponseWriter, r *http.Request, 
 	}
 
 	writeJSON(w, http.StatusOK, map[string]string{"status": "updated", "platform": platform})
+}
+
+// ensureTelegramAdapter registers and starts a Telegram long-poll adapter
+// when credentials are saved while the daemon is already running.
+// label "" is the default bot (adapter name "telegram").
+func (h *GatewayHandler) ensureTelegramAdapter(label string) error {
+	if h.gw == nil {
+		return nil // no manager (should not happen after always-on manager)
+	}
+	if h.ws == nil || h.ws.Config == nil {
+		return nil
+	}
+
+	var tc *workspace.TelegramGatewayConfig
+	if label == "" {
+		tc = h.ws.Config.Gateways.Telegram
+		if tc == nil && h.ws.Config.Gateways.Telegrams != nil {
+			tc = h.ws.Config.Gateways.Telegrams[""]
+		}
+	} else if h.ws.Config.Gateways.Telegrams != nil {
+		tc = h.ws.Config.Gateways.Telegrams[label]
+	}
+	if tc == nil || !tc.Enabled || tc.BotToken == "" {
+		return nil
+	}
+
+	adapterName := "telegram"
+	if label != "" {
+		adapterName = "telegram:" + label
+	}
+	// Already registered and (hopefully) running — StartAdapter is idempotent.
+	if existing := h.gw.GetAdapter(adapterName); existing != nil {
+		return h.gw.StartAdapter(existing)
+	}
+
+	adapter := bctelegram.NewNamed(adapterName, tc.BotToken, tc.Mode)
+	if err := adapter.DiscoverViaUpdate(); err != nil {
+		log.Warn("telegram: discovery failed during hot-start", "adapter", adapterName, "error", err)
+	}
+	if err := h.gw.StartAdapter(adapter); err != nil {
+		return err
+	}
+	log.Info("gateway: telegram adapter registered", "name", adapterName)
+	return nil
 }
 
 // legacyChannelList returns gateway channels in the old Channel format

--- a/web/src/components/notifications/SetupWizard.tsx
+++ b/web/src/components/notifications/SetupWizard.tsx
@@ -47,7 +47,9 @@ export const PLATFORMS: PlatformDef[] = [
     fields: [{ key: "bot_token", label: "Bot Token", placeholder: "1234567890:AAH..." }],
     docs: [
       "Message @BotFather on Telegram → https://t.me/BotFather — send /newbot.",
-      "Copy the bot token and add the bot to your group.",
+      "Copy the bot token. Message the bot in a DM or add it to a group.",
+      "Channels appear after the first inbound message (telegram:<username|chat_id|group>).",
+      "Do not subscribe to telegram:general — that key is not a real Telegram chat.",
     ],
   },
   {
@@ -716,18 +718,54 @@ function AgentSubscriptionStep({
   platformLabel: string;
   onDone: () => void;
 }) {
+  const isTelegram = platform === "telegram" || platform.startsWith("telegram:");
   const [agents, setAgents] = useState<Agent[]>([]);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [mentionOnly, setMentionOnly] = useState<Set<string>>(new Set());
+  const [channels, setChannels] = useState<string[]>([]);
+  const [selectedChannels, setSelectedChannels] = useState<Set<string>>(new Set());
   const [saving, setSaving] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [refreshingChannels, setRefreshingChannels] = useState(false);
+
+  const loadChannels = async () => {
+    try {
+      const gws = await api.listGateways();
+      const gw = (gws ?? []).find((g) => g.platform === platform);
+      const discovered = (gw?.channels ?? []).filter(
+        (ch) => ch && !ch.endsWith(":general"),
+      );
+      setChannels(discovered);
+      setSelectedChannels((prev) => {
+        if (prev.size > 0) {
+          // Keep prior picks that still exist; auto-select new ones.
+          const next = new Set([...prev].filter((c) => discovered.includes(c)));
+          for (const c of discovered) next.add(c);
+          return next;
+        }
+        return new Set(discovered);
+      });
+    } catch {
+      setChannels([]);
+    }
+  };
 
   useEffect(() => {
-    api.listAgents().then((list) => {
-      setAgents(list ?? []);
-      setLoading(false);
-    }).catch(() => setLoading(false));
-  }, []);
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await api.listAgents();
+        if (!cancelled) setAgents(list ?? []);
+      } catch {
+        if (!cancelled) setAgents([]);
+      }
+      if (isTelegram) {
+        await loadChannels();
+      }
+      if (!cancelled) setLoading(false);
+    })();
+    return () => { cancelled = true; };
+  }, [platform, isTelegram]);
 
   const toggleAgent = (name: string) => {
     setSelected((prev) => {
@@ -750,15 +788,39 @@ function AgentSubscriptionStep({
     });
   };
 
+  const toggleChannel = (channel: string) => {
+    setSelectedChannels((prev) => {
+      const next = new Set(prev);
+      if (next.has(channel)) next.delete(channel); else next.add(channel);
+      return next;
+    });
+  };
+
+  const handleRefreshChannels = async () => {
+    setRefreshingChannels(true);
+    await loadChannels();
+    setRefreshingChannels(false);
+  };
+
   const handleDone = async () => {
     setSaving(true);
     try {
-      const channel = `${platform}:general`;
-      await Promise.all(
-        [...selected].map((agent) =>
-          api.subscribe(channel, agent, mentionOnly.has(agent)).catch(() => {}),
-        ),
-      );
+      // Telegram: only subscribe to real discovered channels. Never invent
+      // telegram:general — DMs arrive as telegram:<username|chat_id>.
+      // Other platforms keep the historical platform:general default for now.
+      const targets = isTelegram
+        ? [...selectedChannels]
+        : [`${platform}:general`];
+
+      if (targets.length > 0 && selected.size > 0) {
+        await Promise.all(
+          targets.flatMap((channel) =>
+            [...selected].map((agent) =>
+              api.subscribe(channel, agent, mentionOnly.has(agent)).catch(() => {}),
+            ),
+          ),
+        );
+      }
     } catch { /* best effort */ }
     setSaving(false);
     onDone();
@@ -770,6 +832,11 @@ function AgentSubscriptionStep({
     return "var(--mycel-muted)";
   };
 
+  const channelLeaf = (ch: string) => {
+    const i = ch.lastIndexOf(":");
+    return i >= 0 ? ch.slice(i + 1) : ch;
+  };
+
   return (
     <div>
       <div className="p-4 border-b border-mycel-border">
@@ -777,56 +844,112 @@ function AgentSubscriptionStep({
           <span className="text-[10px] font-semibold text-mycel-accent bg-mycel-accent-subtle px-2 py-0.5 rounded-full uppercase tracking-wider">Step 2</span>
         </div>
         <h3 className="text-base font-semibold text-mycel-text">Add agents to {platformLabel}</h3>
-        <p className="text-xs text-mycel-muted mt-1">Select which agents should receive notifications from this platform.</p>
+        <p className="text-xs text-mycel-muted mt-1">
+          {isTelegram
+            ? "Select agents and the Telegram chats that should deliver to them."
+            : "Select which agents should receive notifications from this platform."}
+        </p>
       </div>
 
-      <div className="p-4 max-h-[300px] overflow-auto">
+      <div className="p-4 max-h-[340px] overflow-auto space-y-4">
+        {isTelegram && (
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-[11px] font-semibold uppercase tracking-wider text-mycel-muted">Channels</span>
+              <button
+                type="button"
+                onClick={handleRefreshChannels}
+                disabled={refreshingChannels}
+                className="text-[11px] text-mycel-accent hover:underline disabled:opacity-50"
+              >
+                {refreshingChannels ? "Refreshing…" : "Refresh"}
+              </button>
+            </div>
+            {channels.length === 0 ? (
+              <div className="text-xs text-mycel-muted bg-mycel-surface-hover border border-mycel-border rounded-md px-3 py-2">
+                No Telegram chats discovered yet. Message the bot in a DM (or a group),
+                then click Refresh. Agents subscribed to a fake <code className="text-mycel-text-2">telegram:general</code> channel
+                never receive real traffic — first message also auto-migrates legacy
+                <code className="text-mycel-text-2"> :general</code> subscriptions.
+              </div>
+            ) : (
+              <div className="space-y-1">
+                {channels.map((ch) => (
+                  <label
+                    key={ch}
+                    className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-mycel-surface-hover cursor-pointer transition-colors"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedChannels.has(ch)}
+                      onChange={() => toggleChannel(ch)}
+                      className="shrink-0 accent-[var(--mycel-accent)]"
+                    />
+                    <span className="text-sm text-mycel-text flex-1 min-w-0 truncate" title={ch}>
+                      {channelLeaf(ch)}
+                    </span>
+                    <span className="text-[10px] text-mycel-muted font-mono truncate max-w-[40%]">{ch}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
         {loading ? (
           <div className="text-center py-6 text-mycel-muted text-xs">Loading agents...</div>
         ) : agents.length === 0 ? (
           <div className="text-center py-6 text-mycel-muted text-xs">No agents found</div>
         ) : (
-          <div className="space-y-1">
-            {agents.filter((a) => !a.archived_at).map((agent) => (
-              <label
-                key={agent.name}
-                className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-mycel-surface-hover cursor-pointer transition-colors"
-              >
-                <input
-                  type="checkbox"
-                  checked={selected.has(agent.name)}
-                  onChange={() => toggleAgent(agent.name)}
-                  className="shrink-0 accent-[var(--mycel-accent)]"
-                />
-                <span
-                  className="shrink-0 w-2 h-2 rounded-full"
-                  style={{ backgroundColor: stateColor(agent.state) }}
-                  title={agent.state}
-                />
-                <span className="text-sm text-mycel-text flex-1 min-w-0 truncate">{agent.name}</span>
-                {selected.has(agent.name) && (
-                  <button
-                    type="button"
-                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleMention(agent.name); }}
-                    className="shrink-0 text-[10px] px-2 py-0.5 rounded-full border transition-colors"
-                    style={{
-                      borderColor: mentionOnly.has(agent.name) ? "color-mix(in oklab, var(--mycel-accent) 40%, transparent)" : "var(--mycel-border)",
-                      color: mentionOnly.has(agent.name) ? "var(--mycel-accent)" : "var(--mycel-muted)",
-                      background: mentionOnly.has(agent.name) ? "var(--mycel-accent-subtle)" : "transparent",
-                    }}
-                    title={mentionOnly.has(agent.name) ? "Mention only: ON" : "Mention only: OFF"}
-                  >
-                    @mention only
-                  </button>
-                )}
-              </label>
-            ))}
+          <div>
+            {isTelegram && (
+              <div className="text-[11px] font-semibold uppercase tracking-wider text-mycel-muted mb-2">Agents</div>
+            )}
+            <div className="space-y-1">
+              {agents.filter((a) => !a.archived_at).map((agent) => (
+                <label
+                  key={agent.name}
+                  className="flex items-center gap-3 px-3 py-2 rounded-md hover:bg-mycel-surface-hover cursor-pointer transition-colors"
+                >
+                  <input
+                    type="checkbox"
+                    checked={selected.has(agent.name)}
+                    onChange={() => toggleAgent(agent.name)}
+                    className="shrink-0 accent-[var(--mycel-accent)]"
+                  />
+                  <span
+                    className="shrink-0 w-2 h-2 rounded-full"
+                    style={{ backgroundColor: stateColor(agent.state) }}
+                    title={agent.state}
+                  />
+                  <span className="text-sm text-mycel-text flex-1 min-w-0 truncate">{agent.name}</span>
+                  {selected.has(agent.name) && (
+                    <button
+                      type="button"
+                      onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleMention(agent.name); }}
+                      className="shrink-0 text-[10px] px-2 py-0.5 rounded-full border transition-colors"
+                      style={{
+                        borderColor: mentionOnly.has(agent.name) ? "color-mix(in oklab, var(--mycel-accent) 40%, transparent)" : "var(--mycel-border)",
+                        color: mentionOnly.has(agent.name) ? "var(--mycel-accent)" : "var(--mycel-muted)",
+                        background: mentionOnly.has(agent.name) ? "var(--mycel-accent-subtle)" : "transparent",
+                      }}
+                      title={mentionOnly.has(agent.name) ? "Mention only: ON" : "Mention only: OFF"}
+                    >
+                      @mention only
+                    </button>
+                  )}
+                </label>
+              ))}
+            </div>
           </div>
         )}
       </div>
 
       <div className="flex justify-between items-center gap-2 p-4 border-t border-mycel-border">
-        <span className="text-xs text-mycel-text-2">{selected.size} agent{selected.size !== 1 ? "s" : ""} selected</span>
+        <span className="text-xs text-mycel-text-2">
+          {selected.size} agent{selected.size !== 1 ? "s" : ""}
+          {isTelegram ? ` · ${selectedChannels.size} channel${selectedChannels.size !== 1 ? "s" : ""}` : ""} selected
+        </span>
         <button
           type="button"
           onClick={handleDone}

--- a/web/src/components/notifications/SetupWizard.tsx
+++ b/web/src/components/notifications/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { api } from "../../api/client";
 import type { Agent, GatewayStatus } from "../../api/client";
@@ -724,11 +724,12 @@ function AgentSubscriptionStep({
   const [mentionOnly, setMentionOnly] = useState<Set<string>>(new Set());
   const [channels, setChannels] = useState<string[]>([]);
   const [selectedChannels, setSelectedChannels] = useState<Set<string>>(new Set());
+  const knownChannelsRef = useRef<string[]>([]);
   const [saving, setSaving] = useState(false);
   const [loading, setLoading] = useState(true);
   const [refreshingChannels, setRefreshingChannels] = useState(false);
 
-  const loadChannels = async () => {
+  const loadChannels = useCallback(async () => {
     try {
       const gws = await api.listGateways();
       const gw = (gws ?? []).find((g) => g.platform === platform);
@@ -737,18 +738,25 @@ function AgentSubscriptionStep({
       );
       setChannels(discovered);
       setSelectedChannels((prev) => {
-        if (prev.size > 0) {
-          // Keep prior picks that still exist; auto-select new ones.
-          const next = new Set([...prev].filter((c) => discovered.includes(c)));
-          for (const c of discovered) next.add(c);
-          return next;
+        const known = knownChannelsRef.current;
+        if (prev.size === 0 && known.length === 0) {
+          // First load: select everything discovered.
+          return new Set(discovered);
         }
-        return new Set(discovered);
+        // Keep prior picks that still exist; only auto-select *new* channels
+        // so a user deselect + Refresh does not re-check deselected ones.
+        const knownSet = new Set(known);
+        const next = new Set([...prev].filter((c) => discovered.includes(c)));
+        for (const c of discovered) {
+          if (!knownSet.has(c)) next.add(c);
+        }
+        return next;
       });
+      knownChannelsRef.current = discovered;
     } catch {
       setChannels([]);
     }
-  };
+  }, [platform]);
 
   useEffect(() => {
     let cancelled = false;
@@ -765,7 +773,7 @@ function AgentSubscriptionStep({
       if (!cancelled) setLoading(false);
     })();
     return () => { cancelled = true; };
-  }, [platform, isTelegram]);
+  }, [platform, isTelegram, loadChannels]);
 
   const toggleAgent = (name: string) => {
     setSelected((prev) => {
@@ -865,7 +873,11 @@ function AgentSubscriptionStep({
                 {refreshingChannels ? "Refreshing…" : "Refresh"}
               </button>
             </div>
-            {channels.length === 0 ? (
+            {loading ? (
+              <div className="text-xs text-mycel-muted bg-mycel-surface-hover border border-mycel-border rounded-md px-3 py-2">
+                Loading channels…
+              </div>
+            ) : channels.length === 0 ? (
               <div className="text-xs text-mycel-muted bg-mycel-surface-hover border border-mycel-border rounded-md px-3 py-2">
                 No Telegram chats discovered yet. Message the bot in a DM (or a group),
                 then click Refresh. Agents subscribed to a fake <code className="text-mycel-text-2">telegram:general</code> channel


### PR DESCRIPTION
## Summary

Telegram notifications could appear configured in the UI while agents never received DMs. Two independent bugs:

1. **Gateway manager was nil when no platforms were enabled at boot.**  
   `buildGatewayManager` returned `nil`, so `GatewayHandler.gw` stayed nil for the process lifetime. `PATCH /api/gateways/telegram` only wrote `preferences.json` (+ vault) and never started long-polling — health returned `503 gateway manager not available` until a full `mycel down && mycel up`.

2. **Setup wizard subscribed agents to `telegram:general`.**  
   Real Telegram DMs are dispatched as `telegram:<username>` or `telegram:<chat_id>` (groups as `telegram:<title>`). Dispatch therefore logged `subscribers=0` even when the bot was connected and messages were arriving.

### Fixes

- Always construct and `Start` a gateway manager (including the empty case) so health endpoints and hot-start work.
- After a successful Telegram `PATCH`, call `Manager.StartAdapter` so the bot begins polling without a restart.
- Keep `Gateways.Telegrams[""]` in sync when updating the legacy `Telegram` field.
- On notify dispatch, if a real channel has no subscribers, **copy** agents from `{platform}:general` onto that channel (self-heal for existing installs).
- Setup wizard (Telegram only): list discovered chats, never invent `telegram:general`; refresh when empty.
- Docs updated for real channel keys and `PATCH` connect flow.

### Tests

- `pkg/gateway`: `TestStartAdapterHotStart`, `TestStartAdapterRequiresContext`
- `pkg/notify`: `TestMigratePlaceholderSubsOnDispatch`, `TestMigratePlaceholderSubsNoOpWhenRealHasSubs`
- Existing `TestUpdatePlatformTelegramWritesVault` still passes

```bash
go test ./pkg/gateway/ ./pkg/notify/ ./server/handlers/ -count=1
```

## Out of scope / known follow-up

**Outbound Telegram replies are still not automatic.** Mycel gateways are inbound-only by design: notifications are injected into agent sessions (tmux/Docker), but agents must call the Telegram Bot API themselves (e.g. `sendMessage` with `TELEGRAM_BOT_TOKEN` in their env) to reply in the chat. Wiring outbound credentials + role prompts so agents actually answer on Telegram is a separate change.

## Test plan

- [ ] Fresh daemon with no gateways configured → `GET /api/gateways/telegram/health` is not “manager not available” (adapter may be unregistered/disconnected).
- [ ] `PATCH /api/gateways/telegram` with a valid bot token while daemon is running → logs show `telegram: connected` / `hot-started adapter` without restart.
- [ ] Send a DM to the bot → channel appears as `telegram:<username|id>`, not `general`.
- [ ] Agents previously on `telegram:general` receive the first real DM after migration (`notify: migrated placeholder subscriptions`).
- [ ] Setup wizard Telegram step does not create `telegram:general` subscriptions; empty-channel state shows refresh instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram setup now supports live gateway adapter startup immediately after saving gateway settings.
  * The notifications setup wizard can discover real Telegram chats, refresh the list, and let you select which chats receive alerts.

* **Bug Fixes**
  * If `telegram:general` was previously used, those legacy subscriptions are automatically copied to the first real Telegram chat after the first inbound message.
  * Telegram gateway changes now apply without requiring a restart.

* **Documentation**
  * Updated Telegram setup instructions to match the new chat discovery and to clarify how incoming chats map to channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Part of #3334