### PR TITLE
refactor(provider): drop hardcoded pi AWS env injection — per-agent env config covers it

### DIFF
--- a/docs/explanation/agents.md
+++ b/docs/explanation/agents.md
@@ -177,6 +177,45 @@ lifecycle prompts (`prompt_create`/`prompt_start`/`prompt_stop`/
 | PUT | `/api/roles/{name}` | Update |
 | DELETE | `/api/roles/{name}` | Delete (agents keep config) |
 
+## Per-Agent Environment Variables
+
+Each agent has a configurable `env` map that is injected into its session at spawn time.
+Values support `${secret:NAME}` placeholders: resolved from the secrets vault at spawn, never stored in plain text.
+
+### Priority order (highest → lowest)
+
+1. MYCEL_* system vars — always protected, user config cannot clobber them
+2. Per-agent `env` map (configured via `POST /api/agents` or `PUT /api/agents/{name}/env`)
+3. Agent env-file (legacy `.env` file path stored on agent)
+4. Gateway credential vars (injected by injectGatewayEnv)
+5. Vault-declared role secrets (injected by injectVaultSecrets)
+
+### Secret references
+
+Set a value to `${secret:MY_SECRET_NAME}` to reference a vault secret.
+At spawn, mycel resolves the reference from the layered vault
+(global `~/.mycel/secrets.vault` + workspace `.bc/secrets.db`; workspace wins).
+The reference is stored verbatim — the resolved value never persists to disk.
+
+### Cloud provider credentials (e.g. AWS Bedrock)
+
+There is no special-case AWS injection in mycel. To use a cloud provider:
+1. Store credentials in `~/.aws/credentials` or set `AWS_PROFILE`/`AWS_REGION` in the host environment before starting `bcd`.
+2. Or configure them per-agent via the env map: set `AWS_PROFILE` and `AWS_REGION` in the agent's environment variables panel in the web UI (or via the API).
+
+This works for any cloud provider — AWS, Azure, GCP — without any provider-specific code in mycel.
+
+### API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/api/agents/{name}/env` | List configured env vars (references shown verbatim) |
+| PUT | `/api/agents/{name}/env` | Replace env vars; takes effect on next restart |
+
+### Web UI
+
+The **Create Agent** modal and the **Agent Detail** settings panel both include an environment variable editor with secret autocomplete. Typing `${` in a value field opens a dropdown of vault secret names; selecting one inserts the reference.
+
 ## Notification Delivery
 
 Agents receive notifications from external platforms via `tmux send-keys` -- the only mechanism to inject into a running session. Notifications are delivered as JSON payloads containing both normalized fields (`channel`, `platform`, `sender`, `content`, `mentions`) and a `raw` field with the complete platform-specific JSON payload as received from the gateway adapter.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1287,7 +1287,6 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	}
 	injectEnv(env, wsPath, name, existing.EnvFile, existing.Env)
 	injectGatewayEnv(env, m.gatewayConfig)
-	injectProviderEnv(env, toolName, m.providerRegistry)
 	secretEnvKeys := injectVaultSecrets(env, wsPath, resolveRoleSecrets(wsPath, string(existing.Role)))
 
 	rt := m.runtimeForAgent(name)
@@ -1532,7 +1531,6 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	}
 	injectEnv(env, wsPath, name, opts.EnvFile, opts.Env)
 	injectGatewayEnv(env, m.gatewayConfig)
-	injectProviderEnv(env, effectiveTool, m.providerRegistry)
 	secretEnvKeys := injectVaultSecrets(env, wsPath, resolveRoleSecrets(wsPath, string(role)))
 
 	rt := m.runtimeForAgent(name)
@@ -3773,23 +3771,6 @@ func injectGatewayEnv(env map[string]string, gw *workspace.GatewaysConfig) {
 	}
 }
 
-// injectProviderEnv calls the EnvContributor hook for the named tool so
-// providers can inject additional env vars (e.g. AWS pointer vars for pi).
-// It is a no-op when toolName is empty, the registry is nil, or the provider
-// does not implement EnvContributor.
-func injectProviderEnv(env map[string]string, toolName string, registry *provider.Registry) {
-	if toolName == "" || registry == nil {
-		return
-	}
-	p, ok := registry.Get(toolName)
-	if !ok {
-		return
-	}
-	if ec, ok := p.(provider.EnvContributor); ok {
-		ec.ContributeEnv(env)
-	}
-}
-
 // wellKnownVaultTokens lists vault secret names that are automatically injected
 // as agent env vars when present, without requiring explicit role declaration.
 // These are integration/gateway tokens that agents commonly need.
@@ -3843,11 +3824,11 @@ func openLayeredStore(wsPath, passphrase string) (ls *secret.LayeredStore, close
 // injectVaultSecrets injects vault secrets into the agent env map.
 //
 // Precedence (highest → lowest):
-//  1. Existing value in env (set by agent env-file, injectGatewayEnv, or injectProviderEnv)
+//  1. Existing value in env (set by agent env-file or injectGatewayEnv)
 //  2. Vault value (global ~/.mycel/secrets.vault + workspace <ws>/.bc/secrets.db, workspace wins)
 //
-// Call AFTER injectEnv + injectGatewayEnv + injectProviderEnv so that
-// gateway-config tokens are never overwritten by vault copies.
+// Call AFTER injectEnv + injectGatewayEnv so that gateway-config tokens
+// are never overwritten by vault copies.
 //
 // Role-scoped secrets (roleSecrets from ResolvedRole.Secrets) act as an
 // allowlist: vault values are not sprayed across every agent indiscriminately.

--- a/pkg/provider/capabilities.go
+++ b/pkg/provider/capabilities.go
@@ -55,16 +55,3 @@ type CostSource interface {
 type DynamicModelLister interface {
 	ListModels(ctx context.Context) ([]string, error)
 }
-
-// EnvContributor is optionally implemented by providers that need to inject
-// additional environment variables into the agent session beyond the standard
-// MYCEL_* and gateway vars. Typical use: AWS credential pointer vars for
-// cloud-SDK providers (e.g. pi + AWS Bedrock). Implementations must NOT
-// inject secret key material — only pointer values (profile names, region
-// names) that direct the SDK to credentials stored on disk.
-//
-// ContributeEnv must be idempotent: check whether the key is already set
-// before writing so that user-configured env always wins.
-type EnvContributor interface {
-	ContributeEnv(env map[string]string)
-}

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -1,11 +1,9 @@
 package provider
 
 import (
-	"bufio"
 	"context"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 )
@@ -115,43 +113,11 @@ func (p *PiProvider) Models() []string {
 	return []string{}
 }
 
-// piAWSPointerEnv returns the AWS pointer env vars ("KEY=VALUE") to append to
-// the pi --list-models command environment so Bedrock models (e.g. Kimi 2.5)
-// appear in the Providers UI. Returns nil when injection is not needed:
-//   - any AWS_* key is already set in the daemon's process environment
-//   - ~/.aws directory does not exist on the host
-//
-// Only the two non-secret pointer vars (AWS_PROFILE, AWS_REGION) are returned;
-// secret key material is never fabricated here.
-func piAWSPointerEnv() []string {
-	// Respect any AWS_* already present in the daemon's environment.
-	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "AWS_") {
-			return nil
-		}
-	}
-	home, err := piUserHomeDir()
-	if err != nil {
-		return nil
-	}
-	awsDir := filepath.Join(home, ".aws")
-	if _, err := os.Stat(awsDir); err != nil { //nolint:gosec // awsDir is derived from UserHomeDir, not user input
-		return nil
-	}
-	result := []string{"AWS_PROFILE=default"}
-	if region := readAWSDefaultRegion(home); region != "" {
-		result = append(result, "AWS_REGION="+region)
-	} else if region = os.Getenv("AWS_DEFAULT_REGION"); region != "" {
-		result = append(result, "AWS_REGION="+region)
-	}
-	return result
-}
-
 // piListModels is overridable in tests.
 var piListModels = func(ctx context.Context) (string, error) {
 	//nolint:gosec // "pi" is a trusted provider binary name, not user input
 	cmd := exec.CommandContext(ctx, "pi", "--list-models")
-	cmd.Env = append(os.Environ(), piAWSPointerEnv()...)
+	cmd.Env = os.Environ()
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -211,91 +177,7 @@ func (p *PiProvider) Version(ctx context.Context) string {
 	return raw
 }
 
-// piUserHomeDir is overridable in tests.
-var piUserHomeDir = os.UserHomeDir
-
-// ContributeEnv injects AWS pointer env vars (AWS_PROFILE, AWS_REGION) so
-// pi's AWS SDK can locate credentials in ~/.aws without embedding secret
-// key values in the agent session. Real key material stays in ~/.aws/credentials;
-// only the profile name and region pointer are injected.
-//
-// Injection is skipped when:
-//   - any AWS_* key is already set in the daemon's process environment
-//   - any AWS_* key is already set in env (user-provided config wins)
-//   - ~/.aws directory does not exist on the host
-func (p *PiProvider) ContributeEnv(env map[string]string) {
-	// Respect any AWS_* already present in the daemon's process environment
-	// (e.g. AWS_PROFILE inherited from the shell that launched bcd).
-	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, "AWS_") {
-			return
-		}
-	}
-	// Respect any AWS env already set by the user (via agent Env or env file).
-	for k := range env {
-		if strings.HasPrefix(k, "AWS_") {
-			return
-		}
-	}
-	home, err := piUserHomeDir()
-	if err != nil {
-		return
-	}
-	awsDir := filepath.Join(home, ".aws")
-	if _, err := os.Stat(awsDir); err != nil { //nolint:gosec // awsDir is derived from UserHomeDir, not user input
-		return
-	}
-	env["AWS_PROFILE"] = "default"
-	// Read region from ~/.aws/config; fall back to AWS_DEFAULT_REGION from
-	// the host process environment.
-	if region := readAWSDefaultRegion(home); region != "" {
-		env["AWS_REGION"] = region
-	} else if region = os.Getenv("AWS_DEFAULT_REGION"); region != "" {
-		env["AWS_REGION"] = region
-	}
-}
-
-// readAWSDefaultRegion reads the region for the [default] profile from
-// ~/.aws/config and returns it, or "" if the file is absent or unparseable.
-func readAWSDefaultRegion(home string) string {
-	cfgPath := filepath.Join(home, ".aws", "config")
-	//nolint:gosec // cfgPath is derived from UserHomeDir, not user input
-	f, err := os.Open(cfgPath)
-	if err != nil {
-		return ""
-	}
-	defer f.Close() //nolint:errcheck
-
-	inDefault := false
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
-			continue
-		}
-		if line == "[default]" {
-			inDefault = true
-			continue
-		}
-		if strings.HasPrefix(line, "[") {
-			if inDefault {
-				// Exited the [default] section without finding a region.
-				break
-			}
-			continue
-		}
-		if inDefault {
-			parts := strings.SplitN(line, "=", 2)
-			if len(parts) == 2 && strings.TrimSpace(parts[0]) == "region" {
-				return strings.TrimSpace(parts[1])
-			}
-		}
-	}
-	return ""
-}
-
 // Ensure PiProvider implements all declared interfaces.
 var _ Provider = (*PiProvider)(nil)
 var _ ModelLister = (*PiProvider)(nil)
 var _ DynamicModelLister = (*PiProvider)(nil)
-var _ EnvContributor = (*PiProvider)(nil)

--- a/pkg/provider/pi_test.go
+++ b/pkg/provider/pi_test.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -33,9 +31,6 @@ func TestPiInterfaces(t *testing.T) {
 	}
 	if _, ok := p.(DynamicModelLister); !ok {
 		t.Error("pi must implement DynamicModelLister")
-	}
-	if _, ok := p.(EnvContributor); !ok {
-		t.Error("pi must implement EnvContributor")
 	}
 }
 
@@ -200,179 +195,6 @@ func TestPiListModels(t *testing.T) {
 	}
 }
 
-func TestPiContributeEnv_NoAWSDir(t *testing.T) {
-	p := NewPiProvider()
-	orig := piUserHomeDir
-	piUserHomeDir = func() (string, error) { return t.TempDir(), nil }
-	t.Cleanup(func() { piUserHomeDir = orig })
-
-	env := map[string]string{}
-	p.ContributeEnv(env)
-	if _, ok := env["AWS_PROFILE"]; ok {
-		t.Error("should not inject AWS_PROFILE when ~/.aws absent")
-	}
-}
-
-func TestPiContributeEnv_WithAWSDir(t *testing.T) {
-	home := t.TempDir()
-	awsDir := filepath.Join(home, ".aws")
-	if err := os.MkdirAll(awsDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	// Write a minimal ~/.aws/config with a region
-	cfgContent := "[default]\nregion = us-west-2\noutput = json\n"
-	if err := os.WriteFile(filepath.Join(awsDir, "config"), []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	p := NewPiProvider()
-	orig := piUserHomeDir
-	piUserHomeDir = func() (string, error) { return home, nil }
-	t.Cleanup(func() { piUserHomeDir = orig })
-
-	env := map[string]string{}
-	p.ContributeEnv(env)
-
-	if env["AWS_PROFILE"] != "default" {
-		t.Errorf("AWS_PROFILE = %q, want default", env["AWS_PROFILE"])
-	}
-	if env["AWS_REGION"] != "us-west-2" {
-		t.Errorf("AWS_REGION = %q, want us-west-2", env["AWS_REGION"])
-	}
-}
-
-func TestPiContributeEnv_ExistingAWSVarSkipped(t *testing.T) {
-	home := t.TempDir()
-	awsDir := filepath.Join(home, ".aws")
-	if err := os.MkdirAll(awsDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	p := NewPiProvider()
-	orig := piUserHomeDir
-	piUserHomeDir = func() (string, error) { return home, nil }
-	t.Cleanup(func() { piUserHomeDir = orig })
-
-	// Pre-existing AWS var must not be overwritten
-	env := map[string]string{"AWS_PROFILE": "prod"}
-	p.ContributeEnv(env)
-	if env["AWS_PROFILE"] != "prod" {
-		t.Errorf("AWS_PROFILE = %q, want prod (user-set value should be preserved)", env["AWS_PROFILE"])
-	}
-}
-
-// TestPiAWSPointerEnv_NoAWSDir verifies no env vars are injected when ~/.aws is absent.
-func TestPiAWSPointerEnv_NoAWSDir(t *testing.T) {
-	orig := piUserHomeDir
-	piUserHomeDir = func() (string, error) { return t.TempDir(), nil }
-	t.Cleanup(func() { piUserHomeDir = orig })
-
-	// Ensure no AWS_* vars bleed in from the test runner's environment.
-	for _, key := range []string{"AWS_PROFILE", "AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"} {
-		t.Setenv(key, "")
-		t.Cleanup(func() { os.Unsetenv(key) }) //nolint:errcheck // cleanup only
-	}
-
-	got := piAWSPointerEnv()
-	if got != nil {
-		t.Errorf("piAWSPointerEnv() = %v, want nil when ~/.aws absent", got)
-	}
-}
-
-// TestPiAWSPointerEnv_WithAWSDir verifies AWS_PROFILE and AWS_REGION are injected
-// when ~/.aws exists and no AWS_* vars are set in the environment.
-func TestPiAWSPointerEnv_WithAWSDir(t *testing.T) {
-	home := t.TempDir()
-	awsDir := filepath.Join(home, ".aws")
-	if err := os.MkdirAll(awsDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	cfgContent := "[default]\nregion = us-east-1\noutput = json\n"
-	if err := os.WriteFile(filepath.Join(awsDir, "config"), []byte(cfgContent), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	orig := piUserHomeDir
-	piUserHomeDir = func() (string, error) { return home, nil }
-	t.Cleanup(func() { piUserHomeDir = orig })
-
-	// Clear any ambient AWS_* from the test environment.
-	for _, key := range []string{"AWS_PROFILE", "AWS_REGION", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"} {
-		os.Unsetenv(key) //nolint:errcheck
-	}
-
-	got := piAWSPointerEnv()
-	if len(got) == 0 {
-		t.Fatal("piAWSPointerEnv() = nil, want non-empty slice when ~/.aws present")
-	}
-	wantProfile := "AWS_PROFILE=default"
-	wantRegion := "AWS_REGION=us-east-1"
-	hasProfile, hasRegion := false, false
-	for _, e := range got {
-		if e == wantProfile {
-			hasProfile = true
-		}
-		if e == wantRegion {
-			hasRegion = true
-		}
-	}
-	if !hasProfile {
-		t.Errorf("piAWSPointerEnv() missing %q; got %v", wantProfile, got)
-	}
-	if !hasRegion {
-		t.Errorf("piAWSPointerEnv() missing %q; got %v", wantRegion, got)
-	}
-}
-
-// TestPiAWSPointerEnv_SkipsWhenAWSEnvAlreadySet verifies no injection occurs
-// when the daemon process already has an AWS_* variable set.
-func TestPiAWSPointerEnv_SkipsWhenAWSEnvAlreadySet(t *testing.T) {
-	home := t.TempDir()
-	awsDir := filepath.Join(home, ".aws")
-	if err := os.MkdirAll(awsDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	orig := piUserHomeDir
-	piUserHomeDir = func() (string, error) { return home, nil }
-	t.Cleanup(func() { piUserHomeDir = orig })
-
-	// Pre-set an AWS env var — injection must be skipped.
-	t.Setenv("AWS_PROFILE", "prod")
-
-	got := piAWSPointerEnv()
-	if got != nil {
-		t.Errorf("piAWSPointerEnv() = %v, want nil when AWS_PROFILE already set", got)
-	}
-}
-
-// TestPiContributeEnv_ProcessEnvAWSVarSkipped verifies that ContributeEnv does
-// NOT inject AWS vars when any AWS_* variable is already in the daemon's process
-// environment (not just in the agent env map). This is the fix for bug #2:
-// previously ContributeEnv only checked the agent env map, so a process-level
-// AWS_PROFILE=my-profile was silently overwritten with "default".
-func TestPiContributeEnv_ProcessEnvAWSVarSkipped(t *testing.T) {
-	home := t.TempDir()
-	awsDir := filepath.Join(home, ".aws")
-	if err := os.MkdirAll(awsDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	p := NewPiProvider()
-	orig := piUserHomeDir
-	piUserHomeDir = func() (string, error) { return home, nil }
-	t.Cleanup(func() { piUserHomeDir = orig })
-
-	// Set a profile in the process environment; agent env map is empty.
-	t.Setenv("AWS_PROFILE", "my-profile")
-
-	env := map[string]string{} // no AWS_ in agent env
-	p.ContributeEnv(env)
-	if _, ok := env["AWS_PROFILE"]; ok {
-		t.Error("ContributeEnv must not inject AWS_PROFILE when AWS_PROFILE is already in os.Environ()")
-	}
-}
-
 // TestPiListModels_AllUnparseableFallback verifies that when `pi --list-models`
 // exits 0 but emits no parseable two-column rows, ListModels returns the static
 // fallback (p.Models()) rather than nil (bug #4).
@@ -393,58 +215,5 @@ func TestPiListModels_AllUnparseableFallback(t *testing.T) {
 	want := p.Models()
 	if len(got) != len(want) {
 		t.Errorf("ListModels() = %v (len=%d), want static fallback %v (len=%d)", got, len(got), want, len(want))
-	}
-}
-
-func TestReadAWSDefaultRegion(t *testing.T) {
-	home := t.TempDir()
-	awsDir := filepath.Join(home, ".aws")
-	if err := os.MkdirAll(awsDir, 0o700); err != nil {
-		t.Fatal(err)
-	}
-
-	tests := []struct {
-		name    string
-		content string
-		want    string
-	}{
-		{
-			name:    "default profile with region",
-			content: "[default]\nregion = eu-central-1\n",
-			want:    "eu-central-1",
-		},
-		{
-			name:    "default profile first then other",
-			content: "[default]\nregion = ap-southeast-1\n\n[profile staging]\nregion = us-east-1\n",
-			want:    "ap-southeast-1",
-		},
-		{
-			name:    "no default profile",
-			content: "[profile staging]\nregion = us-east-1\n",
-			want:    "",
-		},
-		{
-			name:    "empty config",
-			content: "",
-			want:    "",
-		},
-		{
-			name:    "default profile without region",
-			content: "[default]\noutput = json\n",
-			want:    "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfgPath := filepath.Join(awsDir, "config")
-			if err := os.WriteFile(cfgPath, []byte(tt.content), 0o600); err != nil {
-				t.Fatal(err)
-			}
-			got := readAWSDefaultRegion(home)
-			if got != tt.want {
-				t.Errorf("readAWSDefaultRegion() = %q, want %q", got, tt.want)
-			}
-		})
 	}
 }


### PR DESCRIPTION
## Summary

- Removes the hardcoded pi→AWS environment injection (`piAWSPointerEnv`, `ContributeEnv`, `readAWSDefaultRegion`) that automatically set `AWS_PROFILE`/`AWS_REGION` for pi agents — an anti-pattern that violated the generic per-agent env config mechanism
- Users now set `AWS_PROFILE`, `AWS_REGION`, or any cloud credential pointer directly in the agent's env config via the web UI or `PUT /api/agents/{name}/env`; values support `${secret:NAME}` vault references resolved at spawn
- The per-agent env map, API endpoints, and web UI (EnvVarsEditor with secret autocomplete, CreateAgentModal, AgentDetail) were already fully implemented; this PR removes the only path that bypassed them
- Adds a "Per-Agent Environment Variables" section to `docs/explanation/agents.md` documenting the generic mechanism, precedence order, secret references, and cloud provider credential guidance

Part of #3334

## Changes

- `pkg/provider/pi.go` — remove `piAWSPointerEnv`, `ContributeEnv`, `readAWSDefaultRegion`, `piUserHomeDir`; `--list-models` now uses `os.Environ()` unmodified; remove `var _ EnvContributor` assertion
- `pkg/provider/capabilities.go` — remove `EnvContributor` interface (only implemented by pi, no other provider uses it)
- `pkg/agent/agent.go` — remove `injectProviderEnv` call sites and the function itself; update comment on `injectVaultSecrets`
- `pkg/provider/pi_test.go` — remove all AWS-specific tests (`TestPiContributeEnv_*`, `TestPiAWSPointerEnv_*`, `TestReadAWSDefaultRegion`, `TestPiContributeEnv_ProcessEnvAWSVarSkipped`)
- `docs/explanation/agents.md` — add Per-Agent Environment Variables section

## Test plan

- [ ] `make lint-go` passes (0 issues from golangci-lint)
- [ ] `go test -race ./pkg/provider/... ./pkg/agent/...` passes
- [ ] `cd web && bun run lint && bun run test` passes (164 tests)
- [ ] `grep -rn "AWS_PROFILE\|AWS_REGION\|piAWS" pkg/ server/` returns zero results
- [ ] Create a pi agent with `AWS_PROFILE=my-profile` set via the web UI env editor; confirm it appears in the session env at spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)