### PR TITLE
docs(landing): document marketplace, secrets, notifications, insights + reveal/install-box fixes

### DIFF
--- a/docs/how-to/browse-the-marketplace.md
+++ b/docs/how-to/browse-the-marketplace.md
@@ -1,0 +1,72 @@
+# Browse the Marketplace
+
+The Marketplace is a live catalog of skills, MCP servers, and templates that you can hand to any running agent to install for itself.
+
+## Overview
+
+The Marketplace aggregates entries from eight sources into a single searchable catalog:
+
+| Source | What it provides |
+|--------|------------------|
+| MCP Registry | Servers listed on `registry.modelcontextprotocol.io` |
+| GitHub | Repositories tagged `mcp-server` and `claude-skill`, gated by star count |
+| mycel | Templates from the local mycel template store |
+| Claude | Skills from `anthropics/claude-plugins-official` |
+| openclaw | Skills from the ClawHub catalog |
+| Google | Extensions from the `gemini-cli-extensions` org |
+| Glama | MCP servers listed on `glama.ai` |
+| Smithery | MCP servers listed on `registry.smithery.ai` |
+
+Each entry is one of three types — **MCP server**, **skill**, or **template**. The catalog is fetched live from the remote sources and cached on the server for one hour, so browsing is fast while listings stay current. The web UI refreshes its view every minute.
+
+## Browse and Filter
+
+Open the Marketplace from the web UI at `http://localhost:9374`. The header shows how many sources are currently active. Three controls narrow the list:
+
+- **Search** — matches an entry's name and description.
+- **Type** — filter to MCP Servers, Skills, or Templates.
+- **Source** — filter to a single source (MCP Registry, Glama, Smithery, Claude skills, openclaw, Google, GitHub, or mycel).
+
+Each card shows the entry's name, a type badge, a colour-coded source badge, its description, a star count for GitHub-sourced entries, and a link to the upstream repository or listing.
+
+## Install to an Agent
+
+The Marketplace does not install anything on the host. Instead, **Add** composes an install instruction and sends it as a message to the agents you pick — each agent then runs the install itself inside its own session.
+
+1. Click **Add** on an entry.
+2. Choose one or more target agents from the picker.
+3. mycel composes the right install steps for that entry's type and source and dispatches them to each agent as a message.
+
+The exact command an agent runs depends on the entry:
+
+| Entry | Command the agent runs |
+|-------|------------------------|
+| MCP server | `claude mcp add "<name>" "<source-url>"` |
+| Skill (openclaw) | `openclaw skills install "<slug>"` |
+| Skill (Claude, GitHub) | `claude plugin marketplace add "<repo-url>"` then `claude plugin install "<name>@<marketplace>"` |
+| Template | `mycel template import "<name>"` |
+
+For a skill sourced from a plugin marketplace, the agent first registers the marketplace and then installs the plugin from it:
+
+```bash
+# Step 1 — register the marketplace (first time only)
+claude plugin marketplace add "https://github.com/owner/repo"
+
+# Step 2 — install the plugin
+claude plugin install "my-skill@repo"
+```
+
+Some Glama listings do not expose a runnable endpoint through their catalog API. For those, the install message contains manual steps instead of a ready-made command: open the listing, find its `npx`/`uvx` invocation or HTTP/SSE URL, and run `claude mcp add "<name>" <command-or-url>` with it.
+
+## API
+
+The same catalog is available over HTTP:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/marketplace` | List catalog entries; filter with `?type=`, `?source=`, and `?q=` |
+| POST | `/api/marketplace/install` | Dispatch install instructions to named agents |
+
+A GET request accepts a type filter, a source filter, and a free-text query. The install request names the entry and a list of agents; the response reports how many agents the instruction was dispatched to, along with any per-agent errors.
+
+> Tip: install to a single agent first, confirm it picked up the skill or server, then roll the same entry out to the rest of your fleet.

--- a/docs/how-to/inject-instructions.md
+++ b/docs/how-to/inject-instructions.md
@@ -1,0 +1,51 @@
+# Inject Instructions
+
+Injected instructions are a block of guidance that mycel appends to every agent's prompt at spawn time — a single place to state conventions that every agent should follow, regardless of role.
+
+## Overview
+
+Each agent's prompt is assembled from its role, then mycel appends two things to the same prompt file:
+
+1. The **injected instructions** text you author.
+2. An auto-generated summary of the resources the agent can reach — the names of its available MCP servers and the names of its credential environment variables (names only, never values).
+
+The result is a `## mycel instructions` block at the end of the agent's `CLAUDE.md`, applied to every agent uniformly and refreshed on each spawn and restart.
+
+## Author the Instructions
+
+The instructions are a single text (or markdown) field. Set them from the web UI Settings page, or over the API:
+
+```bash
+curl -X PUT http://localhost:9374/api/settings/injected-instructions \
+  -H "Content-Type: application/json" \
+  -d '{"injected_instructions": "Report status before and after every task. Never merge without a green check."}'
+```
+
+The text is stored in the repo's runtime configuration and written to disk, but never contains secret values. Whatever you write is appended verbatim to each agent's prompt.
+
+## What an Agent Sees
+
+Given the instruction above and an agent with the `mycel` and `github` MCP servers plus `GH_TOKEN` and `SLACK_BOT_TOKEN` credentials, the block appended to that agent's prompt reads:
+
+```markdown
+## mycel instructions
+
+Report status before and after every task. Never merge without a green check.
+
+### Available resources
+MCP servers: mycel, github
+Credential env vars: GH_TOKEN, SLACK_BOT_TOKEN
+```
+
+The resource summary is generated per agent, so each agent sees the servers and credential names that actually apply to it — the credential values themselves stay in the vault and are only resolved into the agent's environment at spawn.
+
+## Instructions vs. Roles
+
+Injected instructions and role prompts are separate mechanisms that compose:
+
+- **Role prompt** — authored per role, inherited and merged across parent roles, and written first.
+- **Injected instructions** — one workspace-wide text, appended after the role prompt so it applies to every agent.
+
+Use role prompts for what a *kind* of agent should do, and injected instructions for the house rules that hold across your whole fleet.
+
+> Tip: keep injected instructions short and universal. Anything specific to one job belongs in that agent's role prompt, not here.

--- a/docs/how-to/manage-secrets.md
+++ b/docs/how-to/manage-secrets.md
@@ -1,0 +1,73 @@
+# Manage Secrets
+
+Secrets are credentials — API keys, tokens, cloud profiles — kept in an encrypted vault and referenced from agent environment variables so they never live in plain text.
+
+## Overview
+
+The vault is an encrypted store. Values are sealed with AES-256-GCM under a key derived by PBKDF2-SHA256, and the ciphertext lives in `~/.mycel/secrets.vault`. A repo can add its own overrides in a scoped store; when the same name exists in both, the repo-scoped value wins. Agents never read raw secrets from configuration — they reference vault entries by name and mycel resolves them at spawn.
+
+## Store a Secret
+
+Use the `mycel secret` commands. A value can come from a flag, an environment variable, a file, or standard input:
+
+```bash
+# From stdin (keeps the value out of shell history)
+echo "sk-..." | mycel secret set ANTHROPIC_API_KEY
+
+# From an existing environment variable
+mycel secret set GH_TOKEN --from-env GH_TOKEN
+
+# From a file, with a description
+mycel secret set DEPLOY_KEY --from-file ./deploy.key --desc "CD signing key"
+```
+
+List and inspect what is stored — metadata only, never values, unless you explicitly reveal one:
+
+```bash
+mycel secret list                 # names + descriptions, no values
+mycel secret show GH_TOKEN        # metadata (created, updated, description)
+mycel secret show GH_TOKEN --reveal
+mycel secret delete GH_TOKEN
+```
+
+Add `--workspace` to `set` or `delete` to store or remove a repo-scoped override instead of the global entry.
+
+## Reference a Secret from an Agent
+
+Each agent carries an `env` map that mycel injects into its session. Set any value to `${secret:NAME}` to pull it from the vault at spawn:
+
+```
+AWS_PROFILE = ${secret:AWS_PROFILE}
+AWS_REGION  = ${secret:AWS_REGION}
+```
+
+The `${secret:NAME}` placeholder is resolved only when the agent starts — the reference is what's stored on the agent, and the decrypted value never touches configuration or disk. Names reserved to the runtime (the `MYCEL_` prefix) are protected and skipped.
+
+### From the web UI
+
+The **Create Agent** modal and the **Agent Detail** settings panel both include an environment-variable editor with secret autocomplete. Type `${` in a value field (or use the key button) and a dropdown of vault secret names appears; pick one and it inserts the full `${secret:NAME}` reference. Changes to an existing agent's env take effect on its next restart.
+
+### From the API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/api/agents/{name}/env` | List an agent's env vars (references shown verbatim) |
+| PUT | `/api/agents/{name}/env` | Replace an agent's env vars; applies on next restart |
+
+## Worked Example: AWS Bedrock
+
+Reaching a Bedrock-backed model needs AWS credentials in the agent's environment without hardcoding them. Store the profile and region as secrets, then reference them from the agent that talks to Bedrock:
+
+```bash
+mycel secret set AWS_PROFILE --value "default"
+mycel secret set AWS_REGION  --value "us-west-2"
+```
+
+```
+AWS_PROFILE = ${secret:AWS_PROFILE}
+AWS_REGION  = ${secret:AWS_REGION}
+```
+
+At spawn, mycel resolves both references and injects them into that agent's session, so the model provider picks up the credentials while the values stay sealed in the vault. The same pattern works for any provider that reads its configuration from environment variables.
+
+> Tip: keep provider keys in the global vault and only use `--workspace` overrides when a specific repo needs a different value.

--- a/docs/how-to/read-insights.md
+++ b/docs/how-to/read-insights.md
@@ -1,0 +1,35 @@
+# Read Insights
+
+Insights is a single-page analytics dashboard that puts spend, token usage, agent health, and system load in one scrollable view.
+
+## Overview
+
+Open Insights from the web UI at `http://localhost:9374`. Everything lives on one page: a KPI strip at the top, a sticky anchor-nav below it, and a stack of chart panels grouped into sections. The anchor-nav pills smooth-scroll to each section, and the whole page respects the date range you pick.
+
+## The KPI Strip
+
+Five headline numbers sit across the top:
+
+- **Spend (this range)** — total cost over the selected range, summed from the daily cost ledger.
+- **Tokens** — total tokens over the range.
+- **Active agents** — alive agents over total agents, shown as `X / Y`.
+- **Burn rate** — range spend divided by the window, shown as `$X.XX/hr`.
+- **Top cost driver** — the agent with the highest all-time spend, with its total beside it.
+
+## The Sections
+
+Below the KPI strip, the anchor-nav jumps between five sections:
+
+| Section | What it shows |
+|---------|---------------|
+| **Agents** | A table of every agent — name, role, provider, state, CPU, memory, tokens, and cost. |
+| **Cost** | Cost over time, cost by agent, and cost by model. |
+| **Usage** | Token throughput, model usage by tokens, cache efficiency, and a per-agent token breakdown. |
+| **System** | CPU by agent, memory by agent, network I/O, and disk I/O. |
+| **Activity** | Notification activity for the top ten busiest channels. |
+
+## Where the Numbers Come From
+
+Every panel reads from the daemon's ledger and stats endpoints — the same `/api/costs/*` and `/api/stats/*` data that back the CLI. Cost and token figures come straight from the cost ledger, so per-agent, per-model, and daily dollars and tokens are real recorded usage, not estimates. System panels (CPU, memory, network, disk) come from the per-agent stats collectors, and the Activity section reads channel delivery counts.
+
+> Tip: use the **Top cost driver** KPI and the **Cost by agent** chart together to spot which agent is spending the most, then open that agent in Insights' Agents table to see its live resource use.

--- a/docs/how-to/set-up-notifications.md
+++ b/docs/how-to/set-up-notifications.md
@@ -6,6 +6,19 @@ This guide walks through connecting external platforms to mycel and routing noti
 
 mycel routes inbound events from external platforms (Slack, Telegram, GitHub, and others) to subscribed agents. Agents receive notifications as JSON payloads in their tmux or Docker sessions and respond using platform APIs directly.
 
+## Connect from the Web UI
+
+The fastest path is the setup wizard in the web UI at `http://localhost:9374`. Pick a platform from the connect grid and a two-step modal walks you through it:
+
+1. **Credentials** — enter the platform's tokens (for example a Slack bot token and app token). The tokens are saved to your encrypted vault as secrets and wired into the gateway; nothing is written in plain text.
+2. **Add agents** — choose which agents subscribe to the platform's channels, optionally with mention-only filtering per agent.
+
+Slack, Telegram, Discord, and WhatsApp connect this way, alongside additional platforms such as Matrix, Mattermost, IRC, RSS, and MQTT.
+
+### WhatsApp pairs by QR code
+
+WhatsApp needs no token. Click **Connect** and the wizard generates a QR code; scan it from **WhatsApp → Linked Devices** on your phone. The wizard polls for the pairing to complete and the session persists across restarts, so you scan once. Everything below can also be driven from the CLI and API if you prefer.
+
 ## 1. Add a Notification Source
 
 ### Slack

--- a/landing/src/app/_components/InstallSection.tsx
+++ b/landing/src/app/_components/InstallSection.tsx
@@ -121,7 +121,10 @@ function CodeBlock({ lines, id }: { lines: string[]; id: string }) {
       </button>
       <pre className="overflow-x-auto text-[13px] leading-relaxed text-[#c9d1d9]">
         {lines.map((line, i) => (
-          <div key={`${id}-${i}`} className={line.startsWith("#") ? "text-[#8b949e]" : ""}>
+          <div
+            key={`${id}-${i}`}
+            className={`w-max min-w-full whitespace-pre ${line.startsWith("#") ? "text-[#8b949e]" : ""}`}
+          >
             {line.startsWith("#") ? line : <><span className="text-primary">$</span>{" "}{line}</>}
           </div>
         ))}

--- a/landing/src/app/_components/Motion.tsx
+++ b/landing/src/app/_components/Motion.tsx
@@ -1,6 +1,27 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { useEffect, useState } from "react";
+
+/**
+ * Returns true once the component has mounted in the browser.
+ *
+ * Reveal animations start from `opacity: 0`, so a section stays invisible until
+ * its viewport trigger fires. If hydration never runs or the trigger misfires,
+ * the content would be permanently blank. Gating the hidden `initial` state on
+ * mount keeps the server-rendered markup fully visible and treats the animation
+ * as a pure enhancement: content first, motion second.
+ */
+function useMounted(): boolean {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    // Flip on the next tick rather than synchronously in the effect body,
+    // which the React compiler's set-state-in-effect rule flags.
+    const id = setTimeout(() => setMounted(true), 0);
+    return () => clearTimeout(id);
+  }, []);
+  return mounted;
+}
 
 /** Fade-in on scroll using whileInView */
 export function RevealSection({
@@ -12,9 +33,10 @@ export function RevealSection({
   className?: string;
   delay?: number;
 }) {
+  const mounted = useMounted();
   return (
     <motion.section
-      initial={{ opacity: 0 }}
+      initial={mounted ? { opacity: 0 } : false}
       whileInView={{ opacity: 1 }}
       viewport={{ once: true, margin: "-80px" }}
       transition={{ duration: 0.6, ease: "easeOut", delay }}
@@ -37,9 +59,10 @@ export function FadeUp({
   delay?: number;
   distance?: number;
 }) {
+  const mounted = useMounted();
   return (
     <motion.div
-      initial={{ opacity: 0, y: distance }}
+      initial={mounted ? { opacity: 0, y: distance } : false}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true, margin: "-80px" }}
       transition={{ duration: 0.6, ease: "easeOut", delay }}
@@ -66,9 +89,10 @@ export function StaggerChildren({
   stagger?: number;
   delay?: number;
 }) {
+  const mounted = useMounted();
   return (
     <motion.div
-      initial="hidden"
+      initial={mounted ? "hidden" : false}
       whileInView="visible"
       viewport={{ once: true, margin: "-60px" }}
       variants={{
@@ -124,9 +148,10 @@ export function SlideIn({
   distance?: number;
 }) {
   const x = direction === "left" ? -distance : distance;
+  const mounted = useMounted();
   return (
     <motion.div
-      initial={{ opacity: 0, x }}
+      initial={mounted ? { opacity: 0, x } : false}
       whileInView={{ opacity: 1, x: 0 }}
       viewport={{ once: true, margin: "-60px" }}
       transition={{ duration: 0.6, ease: "easeOut", delay }}

--- a/landing/src/app/docs/DocsContent.tsx
+++ b/landing/src/app/docs/DocsContent.tsx
@@ -1583,7 +1583,7 @@ export default function DocsContent({
             <div className="mb-5 flex items-center gap-2">
               <SporeLogo size={24} />
               <span className="font-headline text-sm font-bold tracking-tight text-foreground">mycel</span>
-              <span className="ml-auto rounded-full border border-border bg-muted px-2 py-0.5 font-mono text-[10px] text-muted-foreground">v0.3.12</span>
+              <span className="ml-auto rounded-full border border-border bg-muted px-2 py-0.5 font-mono text-[10px] text-muted-foreground">v0.3.13</span>
             </div>
             {/* Search */}
             <div className="relative mb-5 group/search">

--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -310,7 +310,7 @@ export default function Home() {
 
                 <div className="flex items-center gap-2 rounded-lg border border-outline-variant/30 bg-surface-container px-4 py-3 shadow-[0_0_60px_rgba(234,88,12,0.08),0_0_20px_rgba(234,88,12,0.04)]">
                   <span className="select-none font-label text-on-surface-variant">$</span>
-                  <code className="scrollbar-none flex-1 overflow-x-auto whitespace-nowrap font-label text-sm text-on-surface">
+                  <code className="scrollbar-none block min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-label text-sm text-on-surface">
                     {installCommands[platform]}
                   </code>
                   <CopyButton text={installCommands[platform]} />


### PR DESCRIPTION
## Summary

Refreshes the product docs page (`/docs`) so it reflects the current feature set, and lands two small landing-page robustness fixes in the same PR.

**Docs added** (as markdown in `docs/how-to/`, auto-registered in the docs nav via the docs-loader):

- **Browse the Marketplace** — the live catalog of skills, MCP servers, and templates aggregated from eight sources (MCP Registry, GitHub, mycel, Claude, openclaw, Google, Glama, Smithery), cached server-side for an hour. Documents search/type/source filters and the **Add** flow: install instructions are composed per entry type and dispatched as a message to chosen agents, which run the install themselves (`claude mcp add`, `claude plugin marketplace add` + `claude plugin install`, `openclaw skills install`, `mycel template import`). Includes the `/api/marketplace` endpoints.
- **Manage Secrets** — the encrypted vault (AES-256-GCM, PBKDF2-SHA256) at `~/.mycel/secrets.vault`, `mycel secret` CLI, per-agent `env` map with `${secret:NAME}` references resolved at spawn, the web env-var editor with secret autocomplete, and a worked AWS Bedrock example.
- **Set Up Notifications** (existing doc, extended) — a new "Connect from the Web UI" section covering the two-step setup wizard, tokens stored as vault secrets, and WhatsApp QR pairing.
- **Read Insights** — the single-page dashboard: KPI strip (Spend, Tokens, Active agents, Burn rate, Top cost driver), sticky anchor-nav, and the Agents / Cost / Usage / System / Activity sections, all sourced from the ledger and stats endpoints.
- **Inject Instructions** — workspace-authored guidance appended to every agent's prompt at spawn, plus the auto-generated resource summary; how it composes with role prompts.

Also bumps the docs version badge to **v0.3.13**.

**Landing fixes:**

1. **Reveal fallback** (`_components/Motion.tsx`) — reveal components (`RevealSection`, `FadeUp`, `SlideIn`, `StaggerChildren`) now render visible until mounted via a `useMounted` flag: before mount `initial={false}`, so neither the server-rendered markup nor the pre-hydration DOM is `opacity: 0`. A failed hydration or missed viewport trigger can no longer leave a section permanently invisible; the animation is a post-mount enhancement.
2. **Install-box curl truncation** (`_components/InstallSection.tsx`, `page.tsx`) — the hero and install-section command boxes now scroll horizontally (`block min-w-0` on the inline `<code>`; `w-max whitespace-pre` per line) so the full `curl … | bash` command is always readable and copyable instead of clipping at "…rpuneet/myce".

## Test plan

- `cd landing && bun install && bun run build` — passes; TypeScript clean; all 8 static pages generated including `/docs`:
  ```
  ✓ Compiled successfully in 1709ms
    Finished TypeScript in 1389ms
  ✓ Generating static pages using 9 workers (8/8)
  ```
- `bun run lint` — passes clean (no errors). The `useMounted` hook flips state on the next tick (`setTimeout(…, 0)`) to satisfy the React-compiler `set-state-in-effect` rule, matching the existing `ThemeContext` pattern.
- Verified the four new docs and the `v0.3.13` badge appear in the built `/docs` output, and that no "bc " branding, "previously", or version-history language was introduced in any added content.

Part of #3334