### PR TITLE
fix(build): create server/web before copying web dist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,7 @@ build-local-tui: ## Build TUI
 
 build-local-web: ## Build web UI → server/web/dist/
 	cd web && bun install && bun run build
+	@mkdir -p server/web
 	@rm -rf server/web/dist
 	@cp -r web/dist server/web/dist
 


### PR DESCRIPTION
make build-local-web fails in fresh clones/worktrees with `cp: server/web/dist: No such file or directory` because the `server/web/` parent directory only exists once the daemon embed stub has been created. Add `mkdir -p server/web` before the copy so the target builds from a pristine checkout.

Part of #3334

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local web builds by automatically creating the required web directory before assembling build files.
  * Prevented build failures when the target directory does not already exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->