### PR TITLE
fix(landing): remove the mushroom logo from the hero

### DIFF
--- a/landing/src/app/page.tsx
+++ b/landing/src/app/page.tsx
@@ -142,9 +142,6 @@ export default function Home() {
         <section className="pt-28 pb-10 sm:pt-32 sm:pb-14">
           <div className="mx-auto max-w-4xl px-4 text-center sm:px-6">
             <FadeUp>
-              <div className="mb-7 flex justify-center">
-                <SporeLogo size={68} className="drop-shadow-sm" />
-              </div>
               <div className="mb-6 flex justify-center">
                 <ChangelogPill />
               </div>


### PR DESCRIPTION
Per feedback, drop the centered mushroom mark from the hero — it opens with the changelog pill + eyebrow now. The mark still anchors the nav and the section dividers. Part of #2674 (v0.4.0 release wrap-up).

Verified: tsc + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)