### PR TITLE
fix(web): honest empty Live state for non-hook providers

### DIFF
--- a/web/src/components/live/AgentToolStream.tsx
+++ b/web/src/components/live/AgentToolStream.tsx
@@ -10,23 +10,39 @@ interface AgentToolStreamProps {
   agentName: string;
   agentState: string;
   agentTask?: string;
+  agentTool?: string;
   createdAt?: string;
   startedAt?: string;
   updatedAt?: string;
   stoppedAt?: string;
 }
 
-export function AgentToolStream({ agentName }: AgentToolStreamProps) {
+// Providers that emit lifecycle/tool hooks the Live feed is built from
+// (ActivityMode: hooks). Other providers don't report activity yet, so the
+// stream stays empty — say so honestly instead of "waiting for events".
+const HOOK_PROVIDERS = new Set(["claude", "agy"]);
+
+export function AgentToolStream({ agentName, agentTool }: AgentToolStreamProps) {
   const { activities, tasks, rawEventsRef } = useAgentActivity(agentName);
 
   const activity = activities.get(agentName);
   const rawEvents = rawEventsRef.current.get(agentName) ?? [];
 
   if (!activity) {
+    const reportsActivity = !agentTool || HOOK_PROVIDERS.has(agentTool);
     return (
       <div className="flex-1 flex items-center justify-center p-6">
-        <p className="text-sm text-mycel-muted italic">
-          No activity yet — waiting for events
+        <p className="max-w-sm text-center text-sm text-mycel-muted italic leading-relaxed">
+          {reportsActivity ? (
+            "No activity yet — waiting for events"
+          ) : (
+            <>
+              Live activity isn&rsquo;t reported by{" "}
+              <span className="not-italic font-medium">{agentTool}</span> agents
+              yet. Use the <span className="not-italic font-medium">Attach</span>{" "}
+              tab to watch this agent&rsquo;s terminal.
+            </>
+          )}
         </p>
       </div>
     );

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1375,6 +1375,7 @@ export function AgentDetail() {
             agentName={agent.name}
             agentState={agent.state}
             agentTask={agent.task}
+            agentTool={agent.tool}
             stoppedAt={agent.stopped_at}
             updatedAt={agent.updated_at}
             startedAt={agent.started_at}


### PR DESCRIPTION
## What
A cursor agent's **Live** tab sat forever on "waiting for events". Root cause: only `claude` and `agy` implement `ActivityMode: hooks` (`pkg/provider/*_hooks.go`); cursor/codex/pi/openclaw don't emit the lifecycle/tool events the Live feed is built from, so it's genuinely empty.

This shows an **accurate** empty state for those providers ("Live activity isn't reported by <tool> agents yet — use the Attach tab") instead of implying events are coming.

Full activity capture for non-hook providers (wiring `ActivityModeTranscript` transcript-tailing) is a follow-up.

## Verify
tsc + build + `make test-web` (282) pass.

Part of #2674 (v0.4.0 release wrap-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)