### PR TITLE
feat(gateway): message any contact directly via <platform>:<id>

### DIFF
--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -466,6 +466,22 @@ func (m *Manager) Send(ctx context.Context, channel, sender, content string) (bo
 	route, ok := m.channelMap[channel]
 	m.mu.RUnlock()
 	if !ok {
+		// No pre-registered channel. Fall back to routing "<platform>:<id>"
+		// straight to that platform's adapter, so a caller can reach a native
+		// destination that hasn't produced an inbound message yet — e.g. a
+		// WhatsApp 1:1 contact addressed by phone number. The adapter decides
+		// whether the raw id is routable.
+		if platform, id, found := strings.Cut(channel, ":"); found && id != "" {
+			m.mu.RLock()
+			adapter := m.adapters[platform]
+			m.mu.RUnlock()
+			if ms, isSender := adapter.(messageSender); isSender {
+				if err := ms.Send(ctx, id, sender, content); err != nil {
+					return true, fmt.Errorf("gateway send to %s: %w", channel, err)
+				}
+				return true, nil
+			}
+		}
 		return false, nil // not a gateway channel
 	}
 

--- a/pkg/gateway/whatsapp/send_test.go
+++ b/pkg/gateway/whatsapp/send_test.go
@@ -33,9 +33,13 @@ func TestParseSendJID(t *testing.T) {
 			wantSrv:   "g.us",
 		},
 		{
-			name:      "bare id rejected",
-			channelID: "30507219845203",
-			wantErr:   "no JID server",
+			// A bare, all-digit id is treated as a phone number and defaulted
+			// to the user server — this is what lets `whatsapp:<number>` reach
+			// a 1:1 contact directly.
+			name:      "bare phone number → user server",
+			channelID: "918051005416",
+			wantUser:  "918051005416",
+			wantSrv:   "s.whatsapp.net",
 		},
 		{
 			name:      "channel name rejected",

--- a/pkg/gateway/whatsapp/whatsapp.go
+++ b/pkg/gateway/whatsapp/whatsapp.go
@@ -359,6 +359,12 @@ const sendTimeout = 30 * time.Second
 // next inbound message from that chat.
 func parseSendJID(channelID string) (types.JID, error) {
 	if !strings.Contains(channelID, "@") {
+		// A bare, all-digit id is a phone number addressed directly (e.g. a
+		// 1:1 contact the caller wants to message without a prior inbound).
+		// Default it to the standard user server so `whatsapp:<number>` routes.
+		if isPhoneNumber(channelID) {
+			return types.NewJID(channelID, types.DefaultUserServer), nil
+		}
 		return types.JID{}, fmt.Errorf("whatsapp: channel id %q has no JID server — wait for an inbound message to upgrade the route", channelID)
 	}
 	jid, err := types.ParseJID(channelID)
@@ -369,6 +375,20 @@ func parseSendJID(channelID string) (types.JID, error) {
 		return types.JID{}, fmt.Errorf("whatsapp: invalid JID %q: empty user", channelID)
 	}
 	return jid, nil
+}
+
+// isPhoneNumber reports whether s is a non-empty string of ASCII digits — a
+// bare WhatsApp phone-number user part (no server, no '+').
+func isPhoneNumber(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // SendReaction sends a reaction emoji to a previously-received message.


### PR DESCRIPTION
## What
Outbound gateway sends only routed to *pre-registered* channels (created from inbound messages), so messaging a WhatsApp 1:1 contact by phone number returned `sent:false` — you had to wait for them to message first.

Now:
- **Manager** falls back to routing an unknown `<platform>:<id>` straight to that platform's adapter (it decides if the raw id is routable).
- **WhatsApp adapter** resolves a bare all-digit id to `<number>@s.whatsapp.net`.

So `whatsapp:918051005416` reaches that contact directly. (Dogfooding find while doing product outreach.)

## Verify
`go build ./...`, `go vet`, `golangci-lint` (0 issues), and `go test ./pkg/gateway/...` all pass; added a `parseSendJID` case for the bare-phone-number path.

Part of #2674 (v0.4.0 release wrap-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Messages can now be sent through supported platform channels even when the channel isn’t pre-registered.
  * WhatsApp channel IDs containing phone numbers are automatically recognized and converted to valid destinations.

* **Bug Fixes**
  * Improved error handling when message delivery fails.
  * Numeric WhatsApp channel IDs are no longer rejected as invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->