### PR TITLE
feat(web): Notifications primary on Home + Apps; slim channels list

### DIFF
--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -5,9 +5,11 @@
  *   1. Apps strip — one pill per connected app instance with the same
  *      status semantics as the drawer (shared appStatus utils), plus a
  *      "+ Connect" pill opening the catalog-driven connect flow.
- *   2. Channels — all app channels grouped by instance; WhatsApp splits
- *      into Groups / People. Search + Filters live in the header slot.
- *   3. Recent activity — the newest messages across active channels.
+ *   2. Notifications — the newest messages across active channels; the
+ *      primary column on the left.
+ *   3. Channels — all app channels grouped by instance (slim secondary
+ *      column); WhatsApp splits into Groups / People. Search + Filters
+ *      live in the header slot.
  *   4. Custom Keys — the encrypted vault keys agents reference via
  *      ${secret:NAME} (absorbed from the old standalone Secrets page).
  *
@@ -700,8 +702,46 @@ export function AppsHome() {
           </button>
         </div>
 
-        {/* ── Channels + recent activity ─────────────────────── */}
-        <div className="grid gap-6 items-start lg:grid-cols-[minmax(0,1fr)_320px]">
+        {/* ── Notifications (primary) + channels (secondary) ─── */}
+        <div className="grid gap-6 items-start lg:grid-cols-[minmax(0,1fr)_340px]">
+          {/* Notifications — the primary stream: newest messages across every channel */}
+          <aside className="rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden" aria-label="Notifications">
+            <Link
+              to="/apps/activity"
+              className="flex items-center gap-2 px-4 py-2.5 border-b border-mycel-border hover:bg-mycel-surface-hover transition-colors"
+              aria-label="View all"
+            >
+              <h3 className="text-xs font-semibold uppercase tracking-[0.08em] text-mycel-text">Notifications</h3>
+              <span className="ml-auto text-[11px] font-medium text-mycel-accent">View all →</span>
+            </Link>
+            <div className="divide-y divide-mycel-border">
+              {recent.length === 0 && (
+                <div className="px-4 py-10 text-center text-xs text-mycel-muted">No messages yet</div>
+              )}
+              {recent.map((m) => (
+                <button
+                  key={`${m.channel}:${String(m.id)}`}
+                  type="button"
+                  onClick={() => { openChannel(m.channel); }}
+                  className="w-full text-left px-4 py-2.5 hover:bg-mycel-surface-hover transition-colors"
+                >
+                  <div className="flex items-center gap-1.5 mb-0.5 min-w-0">
+                    <AppIcon base={sourcePlatform(m.channel)} size={11} />
+                    <span className="truncate text-[11px] text-mycel-text-2">{channelLeaf(m.channel)}</span>
+                    <span className="ml-auto shrink-0 text-[10.5px] text-mycel-muted tabular-nums">
+                      {formatRelative(m.created_at)}
+                    </span>
+                  </div>
+                  <div className="truncate text-[13px] text-mycel-text-2">
+                    <span className="font-medium text-mycel-text">{cleanSender(m.sender)}</span>{" "}
+                    {oneLine(m.content)}
+                  </div>
+                </button>
+              ))}
+            </div>
+          </aside>
+
+          {/* Channels — slim secondary column, grouped by app */}
           <div className="space-y-5 min-w-0">
             {sectionApps.length === 0 && (
               <div className="rounded-lg border border-mycel-border p-6 text-center text-xs text-mycel-muted">
@@ -756,43 +796,6 @@ export function AppsHome() {
               );
             })}
           </div>
-
-          {/* Right rail — recent activity across all channels */}
-          <aside className="rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden" aria-label="Recent activity">
-            <Link
-              to="/apps/activity"
-              className="flex items-center gap-2 px-3 py-2 border-b border-mycel-border hover:bg-mycel-surface-hover transition-colors"
-              aria-label="View all activity"
-            >
-              <h3 className="text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">Recent activity</h3>
-              <span className="ml-auto text-[11px] font-medium text-mycel-accent">View all →</span>
-            </Link>
-            <div className="divide-y divide-mycel-border">
-              {recent.length === 0 && (
-                <div className="px-3 py-6 text-center text-xs text-mycel-muted">No messages yet</div>
-              )}
-              {recent.map((m) => (
-                <button
-                  key={`${m.channel}:${String(m.id)}`}
-                  type="button"
-                  onClick={() => { openChannel(m.channel); }}
-                  className="w-full text-left px-3 py-2 hover:bg-mycel-surface-hover transition-colors"
-                >
-                  <div className="flex items-center gap-1.5 mb-0.5 min-w-0">
-                    <AppIcon base={sourcePlatform(m.channel)} size={10} />
-                    <span className="truncate text-[10.5px] text-mycel-text-2">{channelLeaf(m.channel)}</span>
-                    <span className="ml-auto shrink-0 text-[10px] text-mycel-muted tabular-nums">
-                      {formatRelative(m.created_at)}
-                    </span>
-                  </div>
-                  <div className="truncate text-xs text-mycel-text-2">
-                    <span className="font-medium text-mycel-text">{cleanSender(m.sender)}</span>{" "}
-                    {oneLine(m.content)}
-                  </div>
-                </button>
-              ))}
-            </div>
-          </aside>
         </div>
 
       {/* Custom Keys — encrypted vault keys agents reference via

--- a/web/src/views/AppsActivity.tsx
+++ b/web/src/views/AppsActivity.tsx
@@ -1,6 +1,6 @@
 /**
  * AppsActivity — the full-page view behind the Apps home's
- * "Recent activity" rail (#3310 follow-up). It shows a richer, deeper
+ * "Notifications" column (#3310 follow-up). It shows a richer, deeper
  * feed of the newest messages across every gateway channel with more
  * controls than the inline preview:
  *
@@ -138,7 +138,7 @@ export function AppsActivity() {
             <polyline points="15 18 9 12 15 6" />
           </svg>
         </button>
-        <span className="truncate text-[13px] font-semibold text-mycel-text">Activity</span>
+        <span className="truncate text-[13px] font-semibold text-mycel-text">Notifications</span>
         <span className="shrink-0 text-xs text-mycel-muted tabular-nums">
           {hasFilters ? `${String(filtered.length)} of ${String(messages.length)}` : `${String(messages.length)} message${messages.length === 1 ? "" : "s"}`}
         </span>

--- a/web/src/views/__tests__/appsActivity.test.tsx
+++ b/web/src/views/__tests__/appsActivity.test.tsx
@@ -85,6 +85,9 @@ describe("AppsActivity", () => {
     // Telegram sender prefix is cleaned.
     expect(screen.getByText("Bob")).toBeInTheDocument();
 
+    // The page is titled "Notifications" in the header slot.
+    expect(screen.getByText("Notifications")).toBeInTheDocument();
+
     // Controls live in the shared header slot.
     expect(screen.getByLabelText("Search messages")).toBeInTheDocument();
     expect(screen.getByLabelText("Filter by app")).toBeInTheDocument();

--- a/web/src/views/__tests__/appsHome.test.tsx
+++ b/web/src/views/__tests__/appsHome.test.tsx
@@ -323,13 +323,15 @@ describe("AppsHome", () => {
     expect(screen.getByText("Mom")).toBeInTheDocument();
   });
 
-  it("links recent activity out to the full activity page", async () => {
+  it("links the Notifications column out to the full notifications page", async () => {
     mockRoutes();
     renderHome();
     await waitFor(() => {
       expect(screen.getByText("Family Group")).toBeInTheDocument();
     });
-    const viewAll = screen.getByRole("link", { name: /View all activity/i });
+    // The primary column is labelled "Notifications".
+    expect(screen.getByRole("complementary", { name: "Notifications" })).toBeInTheDocument();
+    const viewAll = screen.getByRole("link", { name: /View all/i });
     expect(viewAll).toHaveAttribute("href", "/apps/activity");
   });
 });

--- a/web/src/views/home/ActivityFeed.tsx
+++ b/web/src/views/home/ActivityFeed.tsx
@@ -11,10 +11,11 @@ import { formatRelative } from "../../utils/time";
 import { HomeModule } from "./Module";
 
 /* ── ActivityFeed ───────────────────────────────────────────────────
-   The Home right-rail feed: newest messages across every connected
+   The Home "Notifications" feed: newest messages across every connected
    app channel, compact one-line rows (app icon · sender · channel ·
-   snippet · relative time). Same endpoints as the Apps Activity page,
-   just a narrower net; the header links to the full feed. Polls 15s.
+   snippet · relative time). Same endpoints as the Apps Notifications
+   page, just a narrower net; the header links to the full feed. Polls
+   15s.
 ─────────────────────────────────────────────────────────────────── */
 
 const CHANNEL_LIMIT = 10;
@@ -75,7 +76,7 @@ export function ActivityFeed() {
   const messages = data ?? [];
 
   return (
-    <HomeModule label="Activity" to="/apps/activity" testId="home-activity" fill>
+    <HomeModule label="Notifications" to="/apps/activity" testId="home-activity" fill>
       {data === null ? (
         <div className="py-4 text-center text-[11px] text-mycel-muted">Loading…</div>
       ) : messages.length === 0 ? (
@@ -85,7 +86,7 @@ export function ActivityFeed() {
               <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
             </svg>
           </span>
-          <span className="text-[11px] text-mycel-muted">No app activity yet</span>
+          <span className="text-[11px] text-mycel-muted">No notifications yet</span>
           <Link to="/apps" className="text-[11px] text-mycel-accent hover:underline">
             Connect an app →
           </Link>


### PR DESCRIPTION
## What

Renames the user-facing **Activity / Recent Activity** label to **Notifications** on both the Home and Apps pages, and reworks the Apps page layout so the notifications stream is the primary column.

### Rename (visible labels only)
- **Apps page** (`AppsHome.tsx`): "Recent activity" column heading → **Notifications**; `aria-label="Recent activity"` → `Notifications`; `aria-label="View all activity"` → `View all`.
- **Full page** (`AppsActivity.tsx`): header title "Activity" → **Notifications**.
- **Home** (`home/ActivityFeed.tsx`): right-rail module label "Activity" → **Notifications**; empty state "No app activity yet" → "No notifications yet".

Internal component/file names (`AppsActivity`, `ActivityFeed`) are intentionally left unchanged to keep the diff tight.

### Layout swap (Apps page)
- **Notifications** is now the **primary** column: wide (`1fr`) on the **left**, with a slightly more prominent header and roomier rows.
- **Channels** list moves to a **slim 340px secondary** column on the **right**, reclaiming the empty horizontal space it used to leave.
- Columns stack (Notifications first) on narrow widths.

Data and behavior are unchanged — feed content and channel grouping are identical. This is layout + labels only. Existing `mycel-*` design tokens/classes are reused throughout.

## Test plan
- `cd web && bunx tsc --noEmit` — clean
- `make test-web` — 282 tests pass (updated the touched assertions in `appsHome.test.tsx` / `appsActivity.test.tsx`)
- `cd web && bun run build` — succeeds

Part of #2674 (v0.4.0 release wrap-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized the Apps home page with Notifications as the primary section and channels as the secondary section.
  * Added a prominent “View all” link to the Notifications page.
* **Updates**
  * Renamed “Recent activity” and “Activity” to “Notifications” across headers, descriptions, labels, and empty states.
  * Updated the activity feed messaging to direct users to the Notifications page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->