### PR TITLE
feat(web): first-run setup wizard

### DIFF
--- a/pkg/home/config.go
+++ b/pkg/home/config.go
@@ -41,10 +41,33 @@ type Config struct { //nolint:govet // field order matches JSON/API contract
 	Server  ServerConfig                 `json:"server"`
 	Logs    LogsConfig                   `json:"logs"`
 	UI      UIConfig                     `json:"ui"`
+	// Onboarding tracks the first-run setup wizard's progress so it can
+	// resume where the user left off. Config-only — the wizard never
+	// touches agents, secrets, or the database.
+	Onboarding OnboardingConfig `json:"onboarding"`
 	// InjectedInstructions is mycel-authored guidance appended to every
 	// agent's prompt file at spawn time. Never contains secret values.
 	InjectedInstructions string `json:"injected_instructions"`
 	Version              int    `json:"version"`
+}
+
+// OnboardingConfig records where the user is in the first-run setup wizard.
+// Step is the id of the last-visited step ("welcome", "runtime", …);
+// Completed lists the steps the user finished, ending with "done" once the
+// wizard is fully complete.
+type OnboardingConfig struct {
+	Step      string   `json:"step"`
+	Completed []string `json:"completed"`
+}
+
+// OnboardingComplete reports whether the wizard has been marked finished.
+func (c *OnboardingConfig) OnboardingComplete() bool {
+	for _, s := range c.Completed {
+		if s == "done" {
+			return true
+		}
+	}
+	return false
 }
 
 // UserConfig holds user identity settings.

--- a/pkg/home/config_test.go
+++ b/pkg/home/config_test.go
@@ -37,6 +37,37 @@ func TestConfigAppsRoundTrip(t *testing.T) {
 	}
 }
 
+// TestConfigOnboardingRoundTrip verifies the onboarding section survives a
+// marshal/unmarshal cycle and that OnboardingComplete tracks the "done"
+// sentinel.
+func TestConfigOnboardingRoundTrip(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.Onboarding.OnboardingComplete() {
+		t.Fatal("fresh config should not be marked onboarding-complete")
+	}
+
+	cfg.Onboarding = OnboardingConfig{Step: "runtime", Completed: []string{"welcome", "system"}}
+	data, err := json.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	parsed, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if parsed.Onboarding.Step != "runtime" || len(parsed.Onboarding.Completed) != 2 {
+		t.Errorf("onboarding round-trip mismatch: %+v", parsed.Onboarding)
+	}
+	if parsed.Onboarding.OnboardingComplete() {
+		t.Error("OnboardingComplete = true without a done sentinel")
+	}
+
+	parsed.Onboarding.Completed = append(parsed.Onboarding.Completed, "done")
+	if !parsed.Onboarding.OnboardingComplete() {
+		t.Error("OnboardingComplete = false after appending done")
+	}
+}
+
 // TestConfigAppsAbsent verifies configs without an apps section parse to
 // an empty map-safe zero value.
 func TestConfigAppsAbsent(t *testing.T) {

--- a/server/handlers/deps_install.go
+++ b/server/handlers/deps_install.go
@@ -1,0 +1,186 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/rpuneet/mycel/pkg/provider"
+)
+
+// DepsInstallHandler runs a single dependency's install command on the host
+// and streams its output back to the setup wizard as newline-delimited JSON.
+//
+// Security: this executes a shell command, so it is loopback-only (same
+// gate as the deps start/stop routes) and only ever runs commands from the
+// vetted table in installCommand — never arbitrary user input.
+type DepsInstallHandler struct{}
+
+// NewDepsInstallHandler constructs a DepsInstallHandler.
+func NewDepsInstallHandler() *DepsInstallHandler { return &DepsInstallHandler{} }
+
+// Register mounts POST /api/deps/install. It is a more specific pattern than
+// the DepsHandler's "/api/deps/" prefix, so ServeMux routes it here.
+func (h *DepsInstallHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/deps/install", h.install)
+}
+
+// depInstallRequest is the POST body: the readiness item id to install
+// ("git", "tmux", "claude", …).
+type depInstallRequest struct {
+	ID string `json:"id"`
+}
+
+// installRunner builds the command that runs a resolved install line. It is
+// a package var so tests can substitute a harmless command.
+var installRunner = func(ctx context.Context, shellCmd string) *exec.Cmd {
+	return exec.CommandContext(ctx, "sh", "-c", shellCmd) //nolint:gosec // shellCmd comes from the vetted installCommand table
+}
+
+// install handles POST /api/deps/install.
+func (h *DepsInstallHandler) install(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+	if err != nil {
+		httpError(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	var req depInstallRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		httpError(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	req.ID = strings.TrimSpace(req.ID)
+	if req.ID == "" {
+		httpError(w, "id is required", http.StatusBadRequest)
+		return
+	}
+
+	cmdLine, ok := installCommand(req.ID, runtime.GOOS)
+	if !ok {
+		httpError(w, "no automatic installer for "+req.ID, http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		httpError(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+
+	emit := func(v any) bool {
+		payload, mErr := json.Marshal(v)
+		if mErr != nil {
+			return false
+		}
+		if _, wErr := w.Write(append(payload, '\n')); wErr != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	emit(map[string]string{"type": "start", "command": cmdLine})
+	streamInstall(r.Context(), cmdLine, emit)
+}
+
+// streamInstall runs cmdLine, emitting one {"type":"log","line":…} record
+// per output line and a final {"type":"done","code":N} (or "error").
+func streamInstall(ctx context.Context, cmdLine string, emit func(any) bool) {
+	cmd := installRunner(ctx, cmdLine)
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+
+	if err := cmd.Start(); err != nil {
+		_ = pw.Close()
+		emit(map[string]string{"type": "error", "error": err.Error()})
+		return
+	}
+
+	waitErr := make(chan error, 1)
+	go func() {
+		waitErr <- cmd.Wait()
+		_ = pw.Close()
+	}()
+
+	scanner := bufio.NewScanner(pr)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for scanner.Scan() {
+		if !emit(map[string]string{"type": "log", "line": scanner.Text()}) {
+			// Client disconnected — stop reading; the command keeps
+			// running to completion in the background.
+			return
+		}
+	}
+
+	err := <-waitErr
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			emit(map[string]any{"type": "done", "code": ee.ExitCode()})
+			return
+		}
+		emit(map[string]string{"type": "error", "error": err.Error()})
+		return
+	}
+	emit(map[string]any{"type": "done", "code": 0})
+}
+
+// installCommand resolves a readiness item id to a runnable install command
+// for the given OS (runtime.GOOS). It returns ok=false for items with no
+// safe automatic installer (e.g. Docker, or a provider whose install hint
+// is just a URL) so the UI can fall back to guidance.
+func installCommand(id, goos string) (string, bool) {
+	switch id {
+	case "git":
+		if goos == "darwin" {
+			return "brew install git", true
+		}
+		return "sudo apt-get update && sudo apt-get install -y git", true
+	case "tmux":
+		if goos == "darwin" {
+			return "brew install tmux", true
+		}
+		return "sudo apt-get update && sudo apt-get install -y tmux", true
+	case "docker":
+		// Docker Desktop / engine installation is platform-specific and
+		// interactive; the wizard links out rather than auto-installing.
+		return "", false
+	}
+	return providerInstallCmd(id)
+}
+
+// providerInstallCmd returns a registered provider's install hint when it is
+// a runnable command (npm/npx/curl/…). Hints that are bare URLs are treated
+// as non-installable.
+func providerInstallCmd(name string) (string, bool) {
+	for _, p := range provider.ListProviders() {
+		if p.Name() != name {
+			continue
+		}
+		hint := strings.TrimSpace(p.InstallHint())
+		if hint == "" || strings.HasPrefix(hint, "http://") || strings.HasPrefix(hint, "https://") {
+			return "", false
+		}
+		return hint, true
+	}
+	return "", false
+}

--- a/server/handlers/deps_install_test.go
+++ b/server/handlers/deps_install_test.go
@@ -1,0 +1,168 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestInstallCommand(t *testing.T) {
+	tests := []struct {
+		id     string
+		goos   string
+		want   string
+		wantOK bool
+	}{
+		{"git", "darwin", "brew install git", true},
+		{"git", "linux", "sudo apt-get update && sudo apt-get install -y git", true},
+		{"tmux", "darwin", "brew install tmux", true},
+		{"tmux", "linux", "sudo apt-get update && sudo apt-get install -y tmux", true},
+		{"docker", "darwin", "", false},
+		{"docker", "linux", "", false},
+		{"claude", "darwin", "npx -y @anthropic-ai/claude-code", true},
+		{"codex", "linux", "npm install -g @openai/codex", true},
+		{"cursor", "darwin", "", false}, // hint is a bare URL — not auto-installable
+		{"nonesuch", "linux", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id+"/"+tt.goos, func(t *testing.T) {
+			got, ok := installCommand(tt.id, tt.goos)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got %q)", ok, tt.wantOK, got)
+			}
+			if got != tt.want {
+				t.Errorf("cmd = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// withStubRunner swaps installRunner for a command that ignores the resolved
+// line and runs `sh -c stub` instead, restoring the original on cleanup.
+func withStubRunner(t *testing.T, stub string) {
+	t.Helper()
+	orig := installRunner
+	installRunner = func(ctx context.Context, _ string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c", stub)
+	}
+	t.Cleanup(func() { installRunner = orig })
+}
+
+func postInstall(t *testing.T, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	NewDepsInstallHandler().Register(mux)
+	req := httptest.NewRequest(http.MethodPost, "/api/deps/install", strings.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:54321"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestDepsInstallStream(t *testing.T) {
+	withStubRunner(t, "printf 'line one\\nline two\\n'")
+
+	rec := postInstall(t, `{"id":"git"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+
+	var logs []string
+	var doneCode = -999
+	var sawStart bool
+	sc := bufio.NewScanner(strings.NewReader(rec.Body.String()))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("bad NDJSON line %q: %v", line, err)
+		}
+		switch ev["type"] {
+		case "start":
+			sawStart = true
+			cmd, _ := ev["command"].(string)
+			if !strings.Contains(cmd, "git") {
+				t.Errorf("start command = %q, want the resolved git install line", cmd)
+			}
+		case "log":
+			if line, ok := ev["line"].(string); ok {
+				logs = append(logs, line)
+			}
+		case "done":
+			if code, ok := ev["code"].(float64); ok {
+				doneCode = int(code)
+			}
+		case "error":
+			t.Fatalf("unexpected error event: %v", ev["error"])
+		}
+	}
+
+	if !sawStart {
+		t.Error("missing start event")
+	}
+	if doneCode != 0 {
+		t.Errorf("done code = %d, want 0", doneCode)
+	}
+	joined := strings.Join(logs, "|")
+	if !strings.Contains(joined, "line one") || !strings.Contains(joined, "line two") {
+		t.Errorf("logs = %v, want both output lines", logs)
+	}
+}
+
+func TestDepsInstallNonZeroExit(t *testing.T) {
+	withStubRunner(t, "echo oops; exit 3")
+
+	rec := postInstall(t, `{"id":"tmux"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), `"code":3`) {
+		t.Errorf("body missing exit code 3: %s", rec.Body.String())
+	}
+}
+
+func TestDepsInstallUnknownID(t *testing.T) {
+	rec := postInstall(t, `{"id":"nonesuch"}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for an id with no installer", rec.Code)
+	}
+}
+
+func TestDepsInstallEmptyID(t *testing.T) {
+	rec := postInstall(t, `{"id":""}`)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for empty id", rec.Code)
+	}
+}
+
+func TestDepsInstallMethodGuard(t *testing.T) {
+	mux := http.NewServeMux()
+	NewDepsInstallHandler().Register(mux)
+	req := httptest.NewRequest(http.MethodGet, "/api/deps/install", nil)
+	req.RemoteAddr = "127.0.0.1:1"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestDepsInstallLoopbackGuard(t *testing.T) {
+	mux := http.NewServeMux()
+	NewDepsInstallHandler().Register(mux)
+	req := httptest.NewRequest(http.MethodPost, "/api/deps/install", strings.NewReader(`{"id":"git"}`))
+	req.RemoteAddr = "10.0.0.5:1234"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for a non-loopback caller", rec.Code)
+	}
+}

--- a/server/handlers/onboarding.go
+++ b/server/handlers/onboarding.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/rpuneet/mycel/pkg/home"
+)
+
+// OnboardingHandler serves first-run setup state for the web wizard.
+//
+// The wizard is config-only: it reads whether this is a fresh install and
+// where the user left off, and never inspects or mutates agents, secrets,
+// or the database here.
+type OnboardingHandler struct {
+	home       *home.Home
+	agentCount func() int
+}
+
+// NewOnboardingHandler builds an OnboardingHandler. agentCount reports the
+// number of agents known to the daemon; pass a nil-safe closure over the
+// agent manager. It may be nil, in which case the count is treated as zero.
+func NewOnboardingHandler(h *home.Home, agentCount func() int) *OnboardingHandler {
+	return &OnboardingHandler{home: h, agentCount: agentCount}
+}
+
+// Register mounts the onboarding routes on mux.
+func (h *OnboardingHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/onboarding/state", h.state)
+}
+
+// onboardingState is the JSON shape returned by GET /api/onboarding/state.
+type onboardingState struct {
+	Step       string   `json:"step"`
+	Completed  []string `json:"completed"`
+	FirstRun   bool     `json:"firstRun"`
+	HasAgents  bool     `json:"hasAgents"`
+	PrefsValid bool     `json:"prefsValid"`
+}
+
+// state handles GET /api/onboarding/state.
+//
+// firstRun is true when the home is not yet usable as a set-up install:
+// preferences are missing/invalid, or there are no agents and the wizard
+// has never been completed. The web app routes to /welcome on firstRun.
+func (h *OnboardingHandler) state(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+
+	count := 0
+	if h.agentCount != nil {
+		count = h.agentCount()
+	}
+	hasAgents := count > 0
+
+	prefsValid := false
+	var step string
+	var completed []string
+	completedWizard := false
+	if h.home != nil && h.home.Config != nil {
+		prefsValid = h.home.Config.Validate() == nil
+		step = h.home.Config.Onboarding.Step
+		completed = h.home.Config.Onboarding.Completed
+		completedWizard = h.home.Config.Onboarding.OnboardingComplete()
+	}
+	if completed == nil {
+		completed = []string{}
+	}
+
+	firstRun := !prefsValid || (!hasAgents && !completedWizard)
+
+	writeJSON(w, http.StatusOK, onboardingState{
+		Step:       step,
+		Completed:  completed,
+		FirstRun:   firstRun,
+		HasAgents:  hasAgents,
+		PrefsValid: prefsValid,
+	})
+}

--- a/server/handlers/onboarding_test.go
+++ b/server/handlers/onboarding_test.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func getOnboardingState(t *testing.T, h *OnboardingHandler) onboardingState {
+	t.Helper()
+	mux := http.NewServeMux()
+	h.Register(mux)
+	req := httptest.NewRequest(http.MethodGet, "/api/onboarding/state", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	var st onboardingState
+	if err := json.Unmarshal(rec.Body.Bytes(), &st); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return st
+}
+
+func TestOnboardingState_FreshInstall(t *testing.T) {
+	h := newTestHome(t) // valid prefs, no onboarding progress
+	oh := NewOnboardingHandler(h, func() int { return 0 })
+
+	st := getOnboardingState(t, oh)
+	if !st.PrefsValid {
+		t.Error("prefsValid = false, want true for a valid config")
+	}
+	if st.HasAgents {
+		t.Error("hasAgents = true, want false with zero agents")
+	}
+	if !st.FirstRun {
+		t.Error("firstRun = false, want true (no agents, wizard not completed)")
+	}
+}
+
+func TestOnboardingState_HasAgents(t *testing.T) {
+	h := newTestHome(t)
+	oh := NewOnboardingHandler(h, func() int { return 3 })
+
+	st := getOnboardingState(t, oh)
+	if !st.HasAgents {
+		t.Error("hasAgents = false, want true")
+	}
+	if st.FirstRun {
+		t.Error("firstRun = true, want false once agents exist")
+	}
+}
+
+func TestOnboardingState_CompletedSuppressesFirstRun(t *testing.T) {
+	h := newTestHome(t)
+	h.Config.Onboarding.Completed = []string{"welcome", "done"}
+	h.Config.Onboarding.Step = "done"
+	oh := NewOnboardingHandler(h, func() int { return 0 })
+
+	st := getOnboardingState(t, oh)
+	if st.FirstRun {
+		t.Error("firstRun = true, want false after the wizard was completed")
+	}
+	if st.Step != "done" {
+		t.Errorf("step = %q, want done", st.Step)
+	}
+	if len(st.Completed) != 2 {
+		t.Errorf("completed = %v, want 2 entries", st.Completed)
+	}
+}
+
+func TestOnboardingState_InvalidPrefsIsFirstRun(t *testing.T) {
+	h := newTestHome(t)
+	h.Config.Version = 0 // invalidates the config (Validate requires v2)
+	oh := NewOnboardingHandler(h, func() int { return 5 })
+
+	st := getOnboardingState(t, oh)
+	if st.PrefsValid {
+		t.Error("prefsValid = true, want false for an invalid config")
+	}
+	if !st.FirstRun {
+		t.Error("firstRun = false, want true when prefs are invalid even with agents")
+	}
+}
+
+func TestOnboardingState_MethodGuard(t *testing.T) {
+	h := newTestHome(t)
+	oh := NewOnboardingHandler(h, func() int { return 0 })
+	mux := http.NewServeMux()
+	oh.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/onboarding/state", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+}

--- a/server/handlers/settings.go
+++ b/server/handlers/settings.go
@@ -153,6 +153,11 @@ func (h *SettingsHandler) patch(w http.ResponseWriter, r *http.Request) {
 				httpError(w, "invalid ui config: "+err.Error(), http.StatusBadRequest)
 				return
 			}
+		case "onboarding":
+			if err := json.Unmarshal(raw, &merged.Onboarding); err != nil {
+				httpError(w, "invalid onboarding config: "+err.Error(), http.StatusBadRequest)
+				return
+			}
 		case "injected_instructions":
 			if err := json.Unmarshal(raw, &merged.InjectedInstructions); err != nil {
 				httpError(w, "invalid injected_instructions: "+err.Error(), http.StatusBadRequest)

--- a/server/handlers/settings_test.go
+++ b/server/handlers/settings_test.go
@@ -77,6 +77,11 @@ func TestSettingsPatchSection(t *testing.T) {
 			wantErr:    "unknown section: gateways",
 		},
 		{
+			name:       "patch onboarding section",
+			body:       `{"onboarding":{"step":"runtime","completed":["welcome","system"]}}`,
+			wantStatus: http.StatusOK,
+		},
+		{
 			name:       "patch apps section",
 			body:       `{"apps":{"fakeapp":{"app":"fakeapp","enabled":true,"config":{"region":"eu"}}}}`,
 			wantStatus: http.StatusOK,

--- a/server/server.go
+++ b/server/server.go
@@ -379,6 +379,9 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	// Always registered so the UI can render an empty list when no deps
 	// are configured; the handler is nil-safe internally.
 	handlers.NewDepsHandler(svc.Deps).Register(mux)
+	// Streamed host-dependency installer used by the setup wizard. Loopback
+	// only; runs vetted install commands and streams their output.
+	handlers.NewDepsInstallHandler().Register(mux)
 	// Per-repo cost rollup. Handler is nil-safe and returns 503 when the
 	// global ledger isn't wired.
 	mux.Handle("/api/global/costs", handlers.NewGlobalCostsHandler(svc.Costs))
@@ -396,6 +399,14 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		handlers.NewRolesHandler(svc.Home).Register(mux)
 		handlers.NewDoctorHandler(svc.Home).Register(mux)
 		handlers.NewSettingsHandler(svc.Home).Register(mux)
+		// First-run setup wizard state. Agent count comes from the live
+		// manager (nil-safe closure).
+		handlers.NewOnboardingHandler(svc.Home, func() int {
+			if svc.AgentMgr != nil {
+				return svc.AgentMgr.AgentCount()
+			}
+			return 0
+		}).Register(mux)
 
 		// Templates — prefer the layered store from BuildServices
 		// (global ~/.mycel/templates/ + repo-scoped override). Fallback to

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,8 +1,9 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route, Link, Navigate, useParams } from "react-router-dom";
 import { Layout } from "./components/Layout";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ThemeProvider } from "./context/ThemeContext";
+import { api } from "./api/client";
 
 const Home = lazy(() => import("./views/Home").then((m) => ({ default: m.Home })));
 const Agents = lazy(() => import("./views/Agents").then((m) => ({ default: m.Agents })));
@@ -18,9 +19,37 @@ const Settings = lazy(() => import("./views/Settings").then((m) => ({ default: m
 const Code = lazy(() => import("./views/Code").then((m) => ({ default: m.Code })));
 const About = lazy(() => import("./views/About").then((m) => ({ default: m.About })));
 const Readiness = lazy(() => import("./views/Readiness").then((m) => ({ default: m.Readiness })));
+const Welcome = lazy(() => import("./wizard/Welcome").then((m) => ({ default: m.Welcome })));
 
 function Loading() {
   return <div className="p-6 text-mycel-muted">Loading...</div>;
+}
+
+/**
+ * HomeGate — routes a fresh install to the setup wizard. It renders Home
+ * immediately (so the common, already-set-up case never flashes a loader)
+ * and only redirects to /welcome once it positively learns this is a first
+ * run. Any probe failure falls back to Home, so a daemon hiccup never traps
+ * the user in onboarding.
+ */
+function HomeGate() {
+  const [redirect, setRedirect] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getOnboardingState()
+      .then((s) => {
+        if (!cancelled && s.firstRun) setRedirect(true);
+      })
+      .catch(() => {
+        /* stay on Home */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  if (redirect) return <Navigate to="/welcome" replace />;
+  return <Home />;
 }
 
 function LegacyWorkspaceRedirect() {
@@ -60,9 +89,11 @@ const wrap = (node: React.ReactNode) => (
 export function AppRoutes() {
   return (
     <Routes>
+      {/* Full-screen first-run wizard — lives outside the app chrome. */}
+      <Route path="welcome" element={wrap(<Welcome />)} />
       <Route element={<Layout />}>
-        <Route index element={wrap(<Home />)} />
-        <Route path="home" element={wrap(<Home />)} />
+        <Route index element={wrap(<HomeGate />)} />
+        <Route path="home" element={wrap(<HomeGate />)} />
         {/* Live view became the Home page — old links/bookmarks redirect. */}
         <Route path="live" element={<Navigate to="/" replace />} />
         <Route path="agents" element={wrap(<Agents />)} />

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -710,6 +710,20 @@ export interface SettingsConfig {
   };
   logs: { path: string; max_bytes: number };
   ui: { theme: string; mode: string; default_view: string };
+  onboarding?: { step: string; completed: string[] };
+}
+
+/* ── Onboarding — first-run setup wizard state (/api/onboarding) ─────── */
+
+export interface OnboardingState {
+  /** True when the app should route to /welcome instead of Home. */
+  firstRun: boolean;
+  hasAgents: boolean;
+  prefsValid: boolean;
+  /** Ids of finished steps; ends with "done" once the wizard completes. */
+  completed: string[];
+  /** Id of the last-visited step, for resume. */
+  step: string;
 }
 
 /* ── Doctor / health ──────────────────────────────────────────────────
@@ -1247,6 +1261,12 @@ export const api = {
       method: "PATCH",
       body: JSON.stringify(patch),
     }),
+
+  /** First-run setup state: whether to show the wizard and where to resume. */
+  getOnboardingState: () => request<OnboardingState>("/onboarding/state"),
+  /** Persist wizard progress. Writes only the onboarding config section. */
+  saveOnboarding: (step: string, completed: string[]) =>
+    api.updateSettings({ onboarding: { step, completed } }),
 
   getInjectedInstructions: () =>
     request<{ injected_instructions: string }>("/settings/injected-instructions"),

--- a/web/src/components/SetupNudge.tsx
+++ b/web/src/components/SetupNudge.tsx
@@ -51,10 +51,10 @@ export function SetupNudge() {
         <span className="font-medium">{data.headline}.</span> {data.subline}
       </span>
       <Link
-        to="/readiness"
+        to="/welcome"
         className="ml-auto shrink-0 underline decoration-dotted underline-offset-2 font-medium hover:opacity-80"
       >
-        Check setup
+        Resume setup
       </Link>
       <button
         type="button"

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState, useEffect, useMemo } from "react";
+import { Link } from "react-router-dom";
 import { api } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
@@ -528,6 +529,22 @@ export function Settings() {
       {/* Row 5: Optional dependencies (mycel-db, mycel-code-server, mycel-browser) */}
       <Section title="dependencies" dirty={false}>
         <DependenciesSection />
+      </Section>
+
+      {/* Row 6: Re-run the first-run setup wizard. */}
+      <Section title="setup" dirty={false}>
+        <div className="flex items-center justify-between gap-3 min-h-[28px]">
+          <p className="text-xs text-mycel-text-2">
+            Walk through first-run setup again — checks, runtime, provider, and your first agent.
+            It only writes config; your agents and connected apps are left untouched.
+          </p>
+          <Link
+            to="/welcome"
+            className="shrink-0 inline-flex items-center h-8 px-3 rounded-md text-xs font-medium bg-mycel-surface border border-mycel-border text-mycel-text hover:bg-mycel-surface-hover transition-colors"
+          >
+            Re-run setup
+          </Link>
+        </div>
       </Section>
     </div>
   );

--- a/web/src/wizard/InstallButton.tsx
+++ b/web/src/wizard/InstallButton.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react";
+import { installDep } from "./installStream";
+
+/* ── InstallButton ────────────────────────────────────────────────────
+ *
+ * Runs one dependency's host install command and streams its output into a
+ * small live console. The button click is the consent to run; the resolved
+ * command is echoed as the first line so it's clear what executed. On a
+ * clean exit it calls onDone so the caller can re-check readiness.
+ */
+
+type Status = "idle" | "running" | "ok" | "error";
+
+export function InstallButton({
+  id,
+  label,
+  onDone,
+}: {
+  id: string;
+  label: string;
+  onDone?: () => void;
+}) {
+  const [status, setStatus] = useState<Status>("idle");
+  const [lines, setLines] = useState<string[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const consoleRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = consoleRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines]);
+
+  const run = async () => {
+    setStatus("running");
+    setLines([]);
+    setErr(null);
+    try {
+      const code = await installDep(id, (ev) => {
+        if (ev.type === "start") setLines((l) => [...l, `$ ${ev.command}`]);
+        else if (ev.type === "log") setLines((l) => [...l, ev.line]);
+      });
+      if (code === 0) {
+        setStatus("ok");
+        onDone?.();
+      } else {
+        setStatus("error");
+        setErr(`Install exited with code ${code}.`);
+      }
+    } catch (e) {
+      setStatus("error");
+      setErr(e instanceof Error ? e.message : "Install failed.");
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={run}
+          disabled={status === "running"}
+          className="text-[12px] font-medium px-2.5 py-1 rounded-md border border-mycel-accent bg-mycel-accent-subtle text-mycel-accent hover:bg-mycel-accent hover:text-mycel-accent-fg transition-colors disabled:opacity-60"
+        >
+          {status === "running"
+            ? "Installing…"
+            : status === "ok"
+              ? "Reinstall"
+              : status === "error"
+                ? "Retry install"
+                : `Install ${label}`}
+        </button>
+        {status === "ok" && (
+          <span className="text-[11px] text-mycel-success">Installed. Re-checking…</span>
+        )}
+        {status === "error" && err && (
+          <span className="text-[11px] text-mycel-error truncate">{err}</span>
+        )}
+      </div>
+      {(status === "running" || lines.length > 0) && (
+        <div
+          ref={consoleRef}
+          className="max-h-32 overflow-auto rounded-md border border-mycel-border bg-mycel-bg px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-mycel-text-2 whitespace-pre-wrap"
+        >
+          {lines.map((l, i) => (
+            <div key={i} className={l.startsWith("$ ") ? "text-mycel-accent" : ""}>
+              {l}
+            </div>
+          ))}
+          {status === "running" && <div className="text-mycel-muted">▍</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/wizard/Welcome.tsx
+++ b/web/src/wizard/Welcome.tsx
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { api, type SettingsConfig } from "../api/client";
+import { StepWelcome } from "./steps/StepWelcome";
+import { StepSystem } from "./steps/StepSystem";
+import { StepRuntime } from "./steps/StepRuntime";
+import { StepProviders } from "./steps/StepProviders";
+import { StepPreferences } from "./steps/StepPreferences";
+import { StepApps } from "./steps/StepApps";
+import { StepAgent } from "./steps/StepAgent";
+import { StepDone } from "./steps/StepDone";
+import { WIZARD_STEPS, stepIndex, type StepId, type StepProps, type WizardDraft, type WizardNav } from "./types";
+
+/* ── First-run setup wizard ───────────────────────────────────────────
+ *
+ * A full-screen, skippable, resumable onboarding flow. Its signature is the
+ * mycelial filament rail on the left: steps are spores threaded on a growing
+ * hypha — the thread fills as you progress, echoing mycel's namesake network.
+ * Everything else stays quiet and native to the app's design system.
+ *
+ * The wizard only ever writes config. It never touches agents, secrets it
+ * wasn't given, apps, or the database — the underlying flows it reuses
+ * (Apps connect, New Agent) own those, unchanged.
+ */
+
+const STEP_COMPONENTS: Record<StepId, (p: StepProps) => JSX.Element> = {
+  welcome: StepWelcome,
+  system: StepSystem,
+  runtime: StepRuntime,
+  providers: StepProviders,
+  preferences: StepPreferences,
+  apps: StepApps,
+  agent: StepAgent,
+  done: StepDone,
+};
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** The mycelial filament rail — the wizard's signature element. */
+function FilamentRail({
+  current,
+  maxReached,
+  onJump,
+}: {
+  current: number;
+  maxReached: number;
+  onJump: (i: number) => void;
+}) {
+  return (
+    <nav aria-label="Setup progress" className="hidden md:flex flex-col relative pl-1">
+      {WIZARD_STEPS.map((step, i) => {
+        const done = i < current;
+        const active = i === current;
+        const reachable = i <= maxReached;
+        return (
+          <div key={step.id} className="relative flex items-start gap-3 min-h-[3.25rem]">
+            {/* filament connector to the next node */}
+            {i < WIZARD_STEPS.length - 1 && (
+              <span
+                aria-hidden
+                className={`absolute left-[7px] top-4 w-px h-[calc(100%-0.5rem)] ${
+                  i < current ? "bg-mycel-accent" : "bg-mycel-border"
+                }`}
+              />
+            )}
+            <button
+              type="button"
+              disabled={!reachable}
+              onClick={() => reachable && onJump(i)}
+              aria-current={active ? "step" : undefined}
+              className="relative z-10 mt-0.5 grid place-items-center w-3.5 h-3.5 rounded-full shrink-0 disabled:cursor-default"
+            >
+              {active && (
+                <span className="absolute inline-flex w-full h-full rounded-full bg-mycel-accent opacity-40 animate-ping [animation-duration:2.5s] motion-reduce:hidden" />
+              )}
+              <span
+                className={`relative w-3.5 h-3.5 rounded-full border-2 transition-colors ${
+                  done
+                    ? "bg-mycel-accent border-mycel-accent"
+                    : active
+                      ? "bg-mycel-bg border-mycel-accent"
+                      : "bg-mycel-bg border-mycel-border"
+                }`}
+              />
+            </button>
+            <button
+              type="button"
+              disabled={!reachable}
+              onClick={() => reachable && onJump(i)}
+              className="text-left -mt-0.5 disabled:cursor-default"
+            >
+              <div className={`font-mono text-[10px] tracking-wider ${active ? "text-mycel-accent" : "text-mycel-muted"}`}>
+                {pad(i + 1)}
+              </div>
+              <div className={`text-[12px] leading-tight ${active ? "text-mycel-text font-medium" : done ? "text-mycel-text-2" : "text-mycel-muted"}`}>
+                {step.eyebrow}
+              </div>
+            </button>
+          </div>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function Welcome() {
+  const navigate = useNavigate();
+  const [idx, setIdx] = useState(0);
+  const [maxReached, setMaxReached] = useState(0);
+  const [ready, setReady] = useState(false);
+  const [settings, setSettings] = useState<SettingsConfig | null>(null);
+  const [draft, setDraftState] = useState<WizardDraft>({
+    provider: "claude",
+    model: "",
+    runtime: "docker",
+    name: "",
+  });
+
+  const reloadSettings = useCallback(async () => {
+    try {
+      setSettings(await api.getSettings());
+    } catch {
+      /* wizard still works without it */
+    }
+  }, []);
+
+  // Resume where the user left off + prefill from prefs.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const [state, cfg] = await Promise.all([
+        api.getOnboardingState().catch(() => null),
+        api.getSettings().catch(() => null),
+      ]);
+      if (cancelled) return;
+      if (cfg) {
+        setSettings(cfg);
+        setDraftState((d) => ({
+          ...d,
+          name: cfg.user?.name ?? d.name,
+          provider: cfg.providers?.default ?? d.provider,
+          runtime: (cfg.runtime?.default as WizardDraft["runtime"]) ?? d.runtime,
+        }));
+      }
+      if (state && state.step && state.step !== "done") {
+        const resumeAt = stepIndex(state.step as StepId);
+        if (resumeAt > 0) {
+          setIdx(resumeAt);
+          setMaxReached(resumeAt);
+        }
+      }
+      setReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const persist = useCallback((stepId: StepId, reached: number, done: boolean) => {
+    const completed = WIZARD_STEPS.slice(0, reached).map((s) => s.id) as string[];
+    if (done) completed.push("done");
+    void api.saveOnboarding(stepId, completed).catch(() => {
+      /* progress is best-effort */
+    });
+  }, []);
+
+  const goTo = useCallback(
+    (i: number) => {
+      const clamped = Math.max(0, Math.min(WIZARD_STEPS.length - 1, i));
+      setIdx(clamped);
+      const reached = Math.max(maxReached, clamped);
+      setMaxReached(reached);
+      persist(WIZARD_STEPS[clamped]!.id, reached, false);
+      if (typeof window !== "undefined") window.scrollTo({ top: 0 });
+    },
+    [maxReached, persist],
+  );
+
+  const setDraft = useCallback((patch: Partial<WizardDraft>) => {
+    setDraftState((d) => ({ ...d, ...patch }));
+  }, []);
+
+  const nav: WizardNav = useMemo(
+    () => ({
+      next: () => goTo(idx + 1),
+      back: () => goTo(idx - 1),
+      skip: () => goTo(idx + 1),
+      goTo: (id) => goTo(stepIndex(id)),
+      finish: () => {
+        persist("done", WIZARD_STEPS.length, true);
+        navigate("/");
+      },
+      exit: () => {
+        persist(WIZARD_STEPS[idx]!.id, maxReached, false);
+        navigate("/");
+      },
+      isFirst: idx === 0,
+      isLast: idx === WIZARD_STEPS.length - 1,
+    }),
+    [idx, maxReached, goTo, persist, navigate],
+  );
+
+  const step = WIZARD_STEPS[idx]!;
+  const StepComponent = STEP_COMPONENTS[step.id];
+
+  return (
+    <div className="fixed inset-0 z-40 overflow-y-auto bg-mycel-bg text-mycel-text">
+      <div className="min-h-full flex flex-col">
+        <header className="flex items-center justify-between px-5 sm:px-8 py-4 border-b border-mycel-border">
+          <div className="flex items-center gap-2">
+            <span className="text-[15px] font-semibold tracking-tight text-mycel-text">mycel</span>
+            <span className="text-[11px] text-mycel-muted font-mono">setup</span>
+          </div>
+          <button
+            type="button"
+            onClick={() => nav.exit()}
+            className="text-[12px] text-mycel-muted hover:text-mycel-text transition-colors"
+          >
+            Skip setup →
+          </button>
+        </header>
+
+        {/* Mobile progress bar (rail is desktop-only). */}
+        <div className="md:hidden h-0.5 bg-mycel-border">
+          <div
+            className="h-full bg-mycel-accent transition-all"
+            style={{ width: `${((idx + 1) / WIZARD_STEPS.length) * 100}%` }}
+          />
+        </div>
+
+        <div className="flex-1 w-full max-w-4xl mx-auto px-5 sm:px-8 py-8 grid md:grid-cols-[10rem_1fr] gap-8 md:gap-12">
+          <div className="md:pt-2">
+            <FilamentRail current={idx} maxReached={maxReached} onJump={goTo} />
+          </div>
+
+          <main className="min-w-0 max-w-2xl">
+            <div className="font-mono text-[11px] tracking-widest text-mycel-accent uppercase">
+              Step {pad(idx + 1)} / {pad(WIZARD_STEPS.length)} · {step.eyebrow}
+            </div>
+            <h1 className="mt-2 text-[26px] sm:text-[30px] font-semibold tracking-tight text-mycel-text leading-tight">
+              {step.title}
+            </h1>
+            <div className="mt-6">
+              {ready && (
+                <StepComponent nav={nav} draft={draft} setDraft={setDraft} settings={settings} reloadSettings={reloadSettings} />
+              )}
+              {!ready && <div className="text-sm text-mycel-muted py-8">Loading setup…</div>}
+            </div>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/wizard/WizardFooter.tsx
+++ b/web/src/wizard/WizardFooter.tsx
@@ -1,0 +1,56 @@
+import type { WizardNav } from "./types";
+
+/* ── WizardFooter ─────────────────────────────────────────────────────
+ *
+ * The shared step footer: Back on the left, then Skip and a primary
+ * action on the right. Steps supply their own primary label/handler so the
+ * verb matches what the step actually does ("Continue", "Finish setup").
+ */
+
+export function WizardFooter({
+  nav,
+  primaryLabel = "Continue",
+  onPrimary,
+  primaryDisabled = false,
+  skipLabel = "Skip",
+  hideSkip = false,
+}: {
+  nav: WizardNav;
+  primaryLabel?: string;
+  onPrimary?: () => void;
+  primaryDisabled?: boolean;
+  skipLabel?: string;
+  hideSkip?: boolean;
+}) {
+  return (
+    <div className="mt-8 flex items-center justify-between gap-3 border-t border-mycel-border pt-5">
+      <button
+        type="button"
+        onClick={nav.back}
+        disabled={nav.isFirst}
+        className="text-[13px] px-3 py-2 rounded-md text-mycel-muted hover:text-mycel-text transition-colors disabled:opacity-0 disabled:pointer-events-none"
+      >
+        &larr; Back
+      </button>
+      <div className="flex items-center gap-2">
+        {!hideSkip && (
+          <button
+            type="button"
+            onClick={nav.skip}
+            className="text-[13px] px-3 py-2 rounded-md text-mycel-muted hover:text-mycel-text transition-colors"
+          >
+            {skipLabel}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onPrimary ?? nav.next}
+          disabled={primaryDisabled}
+          className="text-[13px] font-medium px-4 py-2 rounded-md bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors disabled:opacity-50 disabled:pointer-events-none"
+        >
+          {primaryLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/wizard/__tests__/installStream.test.ts
+++ b/web/src/wizard/__tests__/installStream.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { installDep, type InstallEvent } from "../installStream";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+/** Build a streaming Response whose body yields the given chunks in order. */
+function streamResponse(chunks: string[], ok = true, status = 200): Response {
+  const enc = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return { ok, status, body } as unknown as Response;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("installDep", () => {
+  it("parses NDJSON events split across chunk boundaries and returns the exit code", async () => {
+    // The 'log' record is deliberately split mid-line to exercise buffering.
+    fetchMock.mockResolvedValue(
+      streamResponse([
+        '{"type":"start","command":"brew install git"}\n{"type":"log","li',
+        'ne":"downloading"}\n',
+        '{"type":"done","code":0}\n',
+      ]),
+    );
+
+    const events: InstallEvent[] = [];
+    const code = await installDep("git", (ev) => events.push(ev));
+
+    expect(code).toBe(0);
+    expect(events).toEqual([
+      { type: "start", command: "brew install git" },
+      { type: "log", line: "downloading" },
+      { type: "done", code: 0 },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith("/api/deps/install", expect.objectContaining({ method: "POST" }));
+  });
+
+  it("throws on an error event", async () => {
+    fetchMock.mockResolvedValue(streamResponse(['{"type":"error","error":"boom"}\n']));
+    await expect(installDep("git", () => {})).rejects.toThrow("boom");
+  });
+
+  it("surfaces a non-OK response as an error", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      body: null,
+      json: () => Promise.resolve({ error: "no automatic installer for docker" }),
+    } as unknown as Response);
+    await expect(installDep("docker", () => {})).rejects.toThrow("no automatic installer for docker");
+  });
+});

--- a/web/src/wizard/__tests__/wizard.test.tsx
+++ b/web/src/wizard/__tests__/wizard.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Setup wizard — first-run routing + shell.
+ *
+ *   - HomeGate redirects "/" to /welcome when the daemon reports firstRun.
+ *   - HomeGate stays on Home when firstRun is false (the common case).
+ *   - The wizard resumes at the saved step and renders its chrome.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { AppRoutes } from "../../App";
+import { Welcome } from "../Welcome";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+const SETTINGS = {
+  version: 2,
+  user: { name: "" },
+  server: { host: "127.0.0.1", port: 9374, cors_origin: "*" },
+  runtime: { default: "docker", docker: {}, tmux: {} },
+  providers: { default: "claude", providers: {} },
+  storage: { default: "sqlite", sqlite: { path: ".mycel" } },
+  logs: { path: "", max_bytes: 0 },
+  ui: { theme: "dark", mode: "auto", default_view: "dashboard" },
+};
+
+/** Route fetches by URL so onboarding/settings/agents each get sane data. */
+function mockApi(onboarding: Record<string, unknown>) {
+  fetchMock.mockImplementation((url: string) => {
+    if (url.includes("/onboarding/state")) return jsonResponse(onboarding);
+    if (url.includes("/settings")) return jsonResponse(SETTINGS);
+    return jsonResponse([]);
+  });
+}
+
+let lastLocation = "";
+function LocationSpy() {
+  const loc = useLocation();
+  lastLocation = loc.pathname;
+  return null;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  lastLocation = "";
+});
+
+describe("first-run routing", () => {
+  it("redirects home to /welcome on a fresh install", async () => {
+    mockApi({ firstRun: true, hasAgents: false, prefsValid: true, completed: [], step: "" });
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <LocationSpy />
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(lastLocation).toBe("/welcome"));
+  });
+
+  it("stays on Home when not a first run", async () => {
+    mockApi({ firstRun: false, hasAgents: true, prefsValid: true, completed: ["done"], step: "done" });
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <LocationSpy />
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    // Give the gate's probe time to resolve, then assert it never left "/".
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lastLocation).toBe("/");
+  });
+});
+
+describe("wizard shell", () => {
+  it("renders the welcome step and its progress chrome", async () => {
+    mockApi({ firstRun: true, hasAgents: false, prefsValid: true, completed: [], step: "" });
+    render(
+      <MemoryRouter initialEntries={["/welcome"]}>
+        <Welcome />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole("heading", { name: /welcome to mycel/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /get started/i })).toBeInTheDocument();
+    expect(screen.getByText(/skip setup/i)).toBeInTheDocument();
+  });
+
+  it("resumes at the saved step", async () => {
+    mockApi({ firstRun: true, hasAgents: false, prefsValid: true, completed: ["welcome"], step: "runtime" });
+    render(
+      <MemoryRouter initialEntries={["/welcome"]}>
+        <Welcome />
+      </MemoryRouter>,
+    );
+    expect(await screen.findByRole("heading", { name: /where your agents run/i })).toBeInTheDocument();
+  });
+});

--- a/web/src/wizard/installStream.ts
+++ b/web/src/wizard/installStream.ts
@@ -1,0 +1,76 @@
+/* ── installStream ────────────────────────────────────────────────────
+ *
+ * Client for POST /api/deps/install. The server runs the dependency's
+ * install command on the host and streams its output as newline-delimited
+ * JSON; this reads that stream and hands each event to the caller so the
+ * wizard can show live progress.
+ */
+
+export type InstallEvent =
+  | { type: "start"; command: string }
+  | { type: "log"; line: string }
+  | { type: "done"; code: number }
+  | { type: "error"; error: string };
+
+/**
+ * installDep streams the install of one readiness item (git, tmux, a
+ * provider CLI…). It calls onEvent for every record and resolves with the
+ * process exit code (0 = success). Throws on transport errors or an
+ * explicit error event.
+ */
+export async function installDep(
+  id: string,
+  onEvent: (ev: InstallEvent) => void,
+  signal?: AbortSignal,
+): Promise<number> {
+  const res = await fetch("/api/deps/install", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ id }),
+    signal,
+  });
+
+  if (!res.ok || !res.body) {
+    let msg = `Install failed: ${res.status}`;
+    try {
+      const b = await res.json();
+      if (b && typeof b.error === "string") msg = b.error;
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new Error(msg);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let code = -1;
+
+  const handleLine = (raw: string) => {
+    const line = raw.trim();
+    if (!line) return;
+    let ev: InstallEvent;
+    try {
+      ev = JSON.parse(line) as InstallEvent;
+    } catch {
+      return;
+    }
+    onEvent(ev);
+    if (ev.type === "done") code = ev.code;
+    if (ev.type === "error") throw new Error(ev.error);
+  };
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let nl = buf.indexOf("\n");
+    while (nl >= 0) {
+      handleLine(buf.slice(0, nl));
+      buf = buf.slice(nl + 1);
+      nl = buf.indexOf("\n");
+    }
+  }
+  if (buf.trim()) handleLine(buf);
+  return code;
+}

--- a/web/src/wizard/steps/StepAgent.tsx
+++ b/web/src/wizard/steps/StepAgent.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { api, type Agent } from "../../api/client";
+import { CreateAgentModal } from "../../components/CreateAgentModal";
+import { WizardFooter } from "../WizardFooter";
+import type { StepProps } from "../types";
+
+/* Step 6 — First agent. Opens the real CreateAgentModal so name/repo/
+ * provider/model/template all behave exactly as on the Agents page. On
+ * success the modal routes to the new agent's detail view. Skippable. */
+
+export function StepAgent({ nav }: StepProps) {
+  const [open, setOpen] = useState(false);
+  const [agents, setAgents] = useState<Agent[]>([]);
+
+  useEffect(() => {
+    api
+      .listAgents()
+      .then(setAgents)
+      .catch(() => setAgents([]));
+  }, []);
+
+  const hasAgent = agents.length > 0;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
+        Time to grow your first agent. Give it a repo and a template — it gets its own git worktree
+        and starts working. This is the same New Agent flow you'll use from the dashboard.
+      </p>
+
+      {hasAgent ? (
+        <div className="rounded-lg border border-mycel-success bg-mycel-success-subtle px-4 py-3 flex items-center gap-2.5">
+          <span className="w-2 h-2 rounded-full bg-mycel-success" aria-hidden />
+          <span className="text-[13px] text-mycel-text">
+            You already have {agents.length} agent{agents.length === 1 ? "" : "s"}. You can add more any time.
+          </span>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-mycel-border bg-mycel-surface px-4 py-8 flex flex-col items-center gap-3 text-center">
+          <p className="text-[13px] text-mycel-muted max-w-xs">
+            No agents yet. Spawn one to see mycel in action.
+          </p>
+          <button
+            type="button"
+            onClick={() => setOpen(true)}
+            className="text-[13px] font-medium px-4 py-2 rounded-md bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors"
+          >
+            Create your first agent
+          </button>
+        </div>
+      )}
+
+      <CreateAgentModal
+        open={open}
+        onClose={() => setOpen(false)}
+        existingNames={agents.map((a) => a.name)}
+      />
+
+      <WizardFooter nav={nav} primaryLabel="Continue" skipLabel={hasAgent ? "Skip" : "I'll do this later"} />
+    </div>
+  );
+}

--- a/web/src/wizard/steps/StepApps.tsx
+++ b/web/src/wizard/steps/StepApps.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { api, type AppInstance } from "../../api/client";
+import { AppChooser, ConnectWizard } from "../../components/apps/ConnectApp";
+import { WizardFooter } from "../WizardFooter";
+import type { StepProps } from "../types";
+
+/* Step 5 — Connect an app. Reuses the real Apps connect flow (AppChooser →
+ * ConnectWizard) so Slack/Telegram/Discord/WhatsApp/GitHub/Gmail all work
+ * exactly as they do on the Apps page. Fully skippable. */
+
+export function StepApps({ nav }: StepProps) {
+  const [chooserOpen, setChooserOpen] = useState(false);
+  const [connectAppId, setConnectAppId] = useState<string | null>(null);
+  const [instances, setInstances] = useState<AppInstance[]>([]);
+
+  const load = () =>
+    api
+      .getApps()
+      .then((res) => setInstances(res.instances ?? []))
+      .catch(() => setInstances([]));
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const connected = instances.filter((i) => i.connected);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
+        Connect a chat app and your agents can talk to you where you already are — Slack, Telegram,
+        Discord, WhatsApp, GitHub, or Gmail. Optional; connect one now or later from Apps.
+      </p>
+
+      {connected.length > 0 && (
+        <div className="rounded-lg border border-mycel-border bg-mycel-surface divide-y divide-mycel-border overflow-hidden">
+          {connected.map((i) => (
+            <div key={i.name} className="flex items-center justify-between gap-3 px-4 py-2.5">
+              <span className="text-[13px] text-mycel-text font-medium">{i.name}</span>
+              <span className="inline-flex items-center gap-1.5 text-[11px] text-mycel-success">
+                <span className="w-1.5 h-1.5 rounded-full bg-mycel-success" aria-hidden />
+                Connected
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setChooserOpen(true)}
+        className="self-start text-[13px] font-medium px-4 py-2 rounded-md border border-mycel-accent text-mycel-accent bg-mycel-accent-subtle hover:bg-mycel-accent hover:text-mycel-accent-fg transition-colors"
+      >
+        {connected.length > 0 ? "Connect another app" : "Connect an app"}
+      </button>
+
+      {chooserOpen && (
+        <AppChooser
+          onSelect={(key) => {
+            setChooserOpen(false);
+            setConnectAppId(key);
+          }}
+          onClose={() => setChooserOpen(false)}
+        />
+      )}
+      {connectAppId && (
+        <ConnectWizard
+          appId={connectAppId}
+          onClose={() => setConnectAppId(null)}
+          onConnected={() => {
+            void load();
+          }}
+        />
+      )}
+
+      <WizardFooter nav={nav} primaryLabel="Continue" skipLabel="Skip" />
+    </div>
+  );
+}

--- a/web/src/wizard/steps/StepDone.tsx
+++ b/web/src/wizard/steps/StepDone.tsx
@@ -1,0 +1,43 @@
+import { Link } from "react-router-dom";
+import { WizardFooter } from "../WizardFooter";
+import type { StepProps } from "../types";
+
+/* Step 7 — Done. Marks onboarding complete and points at where to go next. */
+
+function NextCard({ to, title, body }: { to: string; title: string; body: string }) {
+  return (
+    <Link
+      to={to}
+      className="flex-1 rounded-lg border border-mycel-border bg-mycel-surface p-4 hover:border-mycel-accent transition-colors group"
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[13px] font-semibold text-mycel-text">{title}</span>
+        <span className="text-mycel-muted group-hover:text-mycel-accent transition-colors">→</span>
+      </div>
+      <p className="mt-1 text-[12px] text-mycel-text-2 leading-relaxed">{body}</p>
+    </Link>
+  );
+}
+
+export function StepDone({ nav }: StepProps) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center gap-3">
+        <span className="relative flex h-3 w-3">
+          <span className="absolute inline-flex h-full w-full rounded-full bg-mycel-success opacity-50 animate-ping [animation-duration:2.5s] motion-reduce:hidden" />
+          <span className="relative inline-flex h-3 w-3 rounded-full bg-mycel-success" />
+        </span>
+        <p className="text-[14px] text-mycel-text-2">
+          Your machine is ready and your defaults are set. mycel grows from here.
+        </p>
+      </div>
+
+      <div className="flex flex-col sm:flex-row gap-3">
+        <NextCard to="/marketplace" title="Marketplace" body="Browse skills, MCP servers, and agent templates to install." />
+        <NextCard to="/templates" title="Templates" body="Reusable agent presets — role, prompt, and tools in one." />
+      </div>
+
+      <WizardFooter nav={nav} primaryLabel="Finish setup" onPrimary={nav.finish} hideSkip />
+    </div>
+  );
+}

--- a/web/src/wizard/steps/StepPreferences.tsx
+++ b/web/src/wizard/steps/StepPreferences.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from "react";
+import { api } from "../../api/client";
+import { PROVIDER_LABELS } from "../../views/readiness/readiness";
+import { WizardFooter } from "../WizardFooter";
+import type { StepProps } from "../types";
+
+/* Step 4 — Preferences. Confirm the defaults chosen so far, set an optional
+ * monthly budget, and (advanced) tune injected instructions and storage. */
+
+function SummaryRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 px-4 py-2.5">
+      <span className="text-[12px] text-mycel-muted">{label}</span>
+      <span className="text-[13px] text-mycel-text font-medium truncate">{value}</span>
+    </div>
+  );
+}
+
+export function StepPreferences({ nav, draft, settings, reloadSettings }: StepProps) {
+  const [advanced, setAdvanced] = useState(false);
+  const [budget, setBudget] = useState("");
+  const [injected, setInjected] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    api
+      .getInjectedInstructions()
+      .then((r) => setInjected(r.injected_instructions))
+      .catch(() => {
+        /* leave blank */
+      });
+  }, []);
+
+  const provider = draft.provider || settings?.providers?.default || "claude";
+  const runtime = draft.runtime || settings?.runtime?.default || "docker";
+  const model = draft.model || "Provider default";
+  const storage = settings?.storage?.default || "sqlite";
+
+  const persist = async () => {
+    setSaving(true);
+    try {
+      await api.updateInjectedInstructions(injected);
+      const limit = Number(budget);
+      if (budget.trim() && limit > 0) {
+        await api
+          .createCostBudget({ scope: "workspace", period: "monthly", limit_usd: limit, alert_at: 0.8 })
+          .catch(() => {
+            /* budget is optional — ignore conflicts */
+          });
+      }
+      await reloadSettings();
+    } catch {
+      /* skippable/resumable */
+    } finally {
+      setSaving(false);
+      nav.next();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
+        Here's what you've set up. Adjust anything now or later in Settings.
+      </p>
+
+      <div className="rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden divide-y divide-mycel-border shadow-mycel">
+        <SummaryRow label="Default agent tool" value={PROVIDER_LABELS[provider] ?? provider} />
+        <SummaryRow label="Default model" value={model} />
+        <SummaryRow label="Runtime" value={runtime === "docker" ? "Docker (containers)" : "tmux (local)"} />
+        <SummaryRow label="Storage" value={storage === "sqlite" ? "SQLite (default)" : storage} />
+      </div>
+
+      <label className="flex flex-col gap-1.5 max-w-sm">
+        <span className="text-[13px] font-medium text-mycel-text">Monthly budget (optional)</span>
+        <div className="flex items-center gap-2">
+          <span className="text-[13px] text-mycel-muted">$</span>
+          <input
+            type="number"
+            min={0}
+            step={5}
+            value={budget}
+            onChange={(e) => setBudget(e.target.value)}
+            placeholder="No limit"
+            className="w-32 bg-mycel-bg border border-mycel-border rounded-md px-2.5 py-1.5 text-[13px] text-mycel-text font-mono outline-none focus:border-mycel-accent"
+          />
+          <span className="text-[11px] text-mycel-muted">alerts at 80%</span>
+        </div>
+      </label>
+
+      <button
+        type="button"
+        onClick={() => setAdvanced((v) => !v)}
+        className="self-start text-[12px] text-mycel-muted hover:text-mycel-text transition-colors"
+      >
+        {advanced ? "▾ Hide advanced" : "▸ Advanced settings"}
+      </button>
+
+      {advanced && (
+        <div className="rounded-lg border border-mycel-border bg-mycel-surface p-4 flex flex-col gap-4">
+          <label className="flex flex-col gap-1.5">
+            <span className="text-[12px] text-mycel-text-2">Injected instructions</span>
+            <textarea
+              value={injected}
+              onChange={(e) => setInjected(e.target.value)}
+              rows={4}
+              placeholder="Guidance appended to every agent's prompt (optional)."
+              className="w-full bg-mycel-bg border border-mycel-border rounded-md px-2.5 py-2 text-[12px] text-mycel-text font-mono outline-none focus:border-mycel-accent resize-y"
+            />
+            <span className="text-[11px] text-mycel-muted">Added to every agent's system prompt at spawn. Never include secrets.</span>
+          </label>
+          <div className="text-[12px] text-mycel-text-2">
+            Storage: <span className="font-mono text-mycel-text">SQLite</span> at{" "}
+            <span className="font-mono text-mycel-muted">~/.mycel/mycel.db</span>. Switch to TimescaleDB
+            later in Settings for time-series metrics.
+          </div>
+        </div>
+      )}
+
+      <WizardFooter nav={nav} primaryLabel={saving ? "Saving…" : "Continue"} onPrimary={persist} primaryDisabled={saving} />
+    </div>
+  );
+}

--- a/web/src/wizard/steps/StepProviders.tsx
+++ b/web/src/wizard/steps/StepProviders.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useState } from "react";
+import { api, type ModelInfo, type ProviderInfo } from "../../api/client";
+import { useReadiness } from "../../hooks/useReadiness";
+import { PROVIDER_LABELS, PROVIDER_NAMES } from "../../views/readiness/readiness";
+import { InstallButton } from "../InstallButton";
+import { WizardFooter } from "../WizardFooter";
+import type { StepProps } from "../types";
+
+/* Step 3 — Providers & sign-in. Pick an agent tool, install it (reusing the
+ * streamed installer), optionally store its API key in the vault, and set it
+ * as the default provider. Cursor's install is a download page, so it shows
+ * guidance instead of a button. */
+
+const CURSOR = "cursor";
+
+// Vault key each provider reads for headless auth. Blank = no standard key
+// (the CLI's own login is the path); those still store under <NAME>_API_KEY.
+const SECRET_KEY: Record<string, string> = {
+  claude: "ANTHROPIC_API_KEY",
+  codex: "OPENAI_API_KEY",
+};
+
+function secretNameFor(provider: string): string {
+  return SECRET_KEY[provider] ?? `${provider.toUpperCase()}_API_KEY`;
+}
+
+export function StepProviders({ nav, draft, setDraft, settings, reloadSettings }: StepProps) {
+  const { data, refresh } = useReadiness();
+  const [selected, setSelected] = useState(draft.provider || settings?.providers?.default || "claude");
+  const [models, setModels] = useState<Record<string, ModelInfo[]>>({});
+  const [model, setModel] = useState(draft.model);
+  const [apiKey, setApiKey] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [keySaved, setKeySaved] = useState(false);
+
+  useEffect(() => {
+    api
+      .listProviders()
+      .then((list: ProviderInfo[]) => {
+        const map: Record<string, ModelInfo[]> = {};
+        for (const p of list) if (p.models) map[p.name] = p.models;
+        setModels(map);
+      })
+      .catch(() => {
+        /* model pickers stay empty; provider default still works */
+      });
+  }, []);
+
+  const installed = data?.providers ?? {};
+  const selModels = models[selected] ?? [];
+  const selInstalled = installed[selected];
+
+  const persist = async () => {
+    setSaving(true);
+    setDraft({ provider: selected, model });
+    try {
+      if (apiKey.trim()) {
+        const name = secretNameFor(selected);
+        try {
+          await api.createSecret(name, apiKey.trim(), `${PROVIDER_LABELS[selected] ?? selected} API key`);
+        } catch {
+          // Already exists → update instead.
+          await api.updateSecret(name, apiKey.trim());
+        }
+        setKeySaved(true);
+      }
+      await api.updateSettings({
+        providers: {
+          default: selected,
+          providers: settings?.providers?.providers ?? {},
+        },
+      });
+      await reloadSettings();
+    } catch {
+      /* skippable/resumable */
+    } finally {
+      setSaving(false);
+      nav.next();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
+        An agent tool is the CLI that actually drives a model (Claude Code, Codex, …). Pick your
+        default — you can add more later and switch per agent.
+      </p>
+
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+        {PROVIDER_NAMES.map((name) => {
+          const active = selected === name;
+          const isInstalled = installed[name];
+          return (
+            <button
+              key={name}
+              type="button"
+              onClick={() => {
+                setSelected(name);
+                setModel("");
+              }}
+              aria-pressed={active}
+              className={`flex items-center justify-between gap-2 px-3 py-2.5 rounded-lg border text-left transition-colors ${
+                active ? "border-mycel-accent bg-mycel-accent-subtle" : "border-mycel-border bg-mycel-surface hover:border-mycel-accent"
+              }`}
+            >
+              <span className="text-[13px] font-medium text-mycel-text truncate">
+                {PROVIDER_LABELS[name] ?? name}
+              </span>
+              <span
+                className={`shrink-0 w-1.5 h-1.5 rounded-full ${isInstalled ? "bg-mycel-success" : "bg-mycel-muted"}`}
+                title={isInstalled ? "Installed" : "Not installed"}
+                aria-hidden
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="rounded-lg border border-mycel-border bg-mycel-surface p-4 flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-[13px] font-semibold text-mycel-text">{PROVIDER_LABELS[selected] ?? selected}</span>
+          <span className={`text-[11px] ${selInstalled ? "text-mycel-success" : "text-mycel-warning"}`}>
+            {selInstalled ? "Installed" : "Not installed"}
+          </span>
+        </div>
+
+        {!selInstalled &&
+          (selected === CURSOR ? (
+            <a
+              href="https://cursor.sh"
+              target="_blank"
+              rel="noreferrer"
+              className="self-start text-[12px] px-2.5 py-1 rounded-md border border-mycel-accent text-mycel-accent hover:bg-mycel-accent-subtle transition-colors"
+            >
+              Download Cursor ↗
+            </a>
+          ) : (
+            <InstallButton id={selected} label={PROVIDER_LABELS[selected] ?? selected} onDone={() => void refresh()} />
+          ))}
+
+        {selModels.length > 0 && (
+          <label className="flex flex-col gap-1">
+            <span className="text-[12px] text-mycel-text-2">Default model</span>
+            <select
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              className="w-full max-w-xs bg-mycel-bg border border-mycel-border rounded-md px-2 py-1.5 text-[13px] text-mycel-text outline-none focus:border-mycel-accent"
+            >
+              <option value="">Provider default</option>
+              {selModels.map((m) => (
+                <option key={m.id} value={m.id}>
+                  {m.id}
+                  {m.available ? "" : " (unverified)"}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <label className="flex flex-col gap-1">
+          <span className="text-[12px] text-mycel-text-2">
+            API key <span className="text-mycel-muted">(optional — stored encrypted in the vault)</span>
+          </span>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(e) => {
+              setApiKey(e.target.value);
+              setKeySaved(false);
+            }}
+            placeholder={secretNameFor(selected)}
+            className="w-full max-w-sm bg-mycel-bg border border-mycel-border rounded-md px-2.5 py-1.5 text-[13px] text-mycel-text font-mono outline-none focus:border-mycel-accent"
+          />
+          <span className="text-[11px] text-mycel-muted">
+            {keySaved
+              ? "Saved to the vault."
+              : `Or run \`${selected}\` once in a terminal to sign in with the CLI.`}
+          </span>
+        </label>
+      </div>
+
+      <WizardFooter nav={nav} primaryLabel={saving ? "Saving…" : "Set as default"} onPrimary={persist} primaryDisabled={saving} />
+    </div>
+  );
+}

--- a/web/src/wizard/steps/StepRuntime.tsx
+++ b/web/src/wizard/steps/StepRuntime.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+import { api } from "../../api/client";
+import { useReadiness } from "../../hooks/useReadiness";
+import { WizardFooter } from "../WizardFooter";
+import type { StepProps } from "../types";
+
+/* Step 2 — Runtime. Docker (isolated containers) or tmux (local sessions),
+ * with an advanced expander. Writes prefs.runtime. */
+
+type RT = "docker" | "tmux";
+
+const NUM = "w-24 bg-mycel-bg border border-mycel-border rounded-md px-2 py-1 text-[12px] text-mycel-text font-mono outline-none focus:border-mycel-accent";
+const TXT = "w-full bg-mycel-bg border border-mycel-border rounded-md px-2 py-1 text-[12px] text-mycel-text font-mono outline-none focus:border-mycel-accent";
+
+export function StepRuntime({ nav, draft, setDraft, settings, reloadSettings }: StepProps) {
+  const { data } = useReadiness();
+  const [choice, setChoice] = useState<RT>(draft.runtime);
+  const [advanced, setAdvanced] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  // Docker knobs
+  const [image, setImage] = useState("mycel-agent-claude:latest");
+  const [cpus, setCpus] = useState(2);
+  const [memoryMB, setMemoryMB] = useState(4096);
+  // tmux knobs
+  const [shell, setShell] = useState("/bin/bash");
+  const [history, setHistory] = useState(10000);
+
+  useEffect(() => {
+    const r = settings?.runtime;
+    if (!r) return;
+    if (r.default === "docker" || r.default === "tmux") setChoice(r.default);
+    if (r.docker) {
+      setImage(r.docker.image || "mycel-agent-claude:latest");
+      setCpus(r.docker.cpus || 2);
+      setMemoryMB(r.docker.memory_mb || 4096);
+    }
+    if (r.tmux) {
+      setShell(r.tmux.default_shell || "/bin/bash");
+      setHistory(r.tmux.history_limit || 10000);
+    }
+  }, [settings]);
+
+  const dockerDown = data && !data.dockerOk;
+
+  const persist = async () => {
+    setSaving(true);
+    setDraft({ runtime: choice });
+    try {
+      const base = settings?.runtime;
+      await api.updateSettings({
+        runtime: {
+          default: choice,
+          docker: {
+            image,
+            network: base?.docker?.network || "mycel-net",
+            docker_socket_path: base?.docker?.docker_socket_path || "/var/run/docker.sock",
+            extra_mounts: base?.docker?.extra_mounts || [],
+            cpus,
+            memory_mb: memoryMB,
+          },
+          tmux: {
+            session_prefix: base?.tmux?.session_prefix || "mycel",
+            history_limit: history,
+            default_shell: shell,
+          },
+        },
+      });
+      await reloadSettings();
+    } catch {
+      /* skippable/resumable */
+    } finally {
+      setSaving(false);
+      nav.next();
+    }
+  };
+
+  const Option = ({ id, title, body, recommended }: { id: RT; title: string; body: string; recommended?: boolean }) => {
+    const active = choice === id;
+    return (
+      <button
+        type="button"
+        onClick={() => setChoice(id)}
+        aria-pressed={active}
+        className={`flex-1 text-left flex flex-col gap-1 rounded-lg border p-4 transition-colors ${
+          active ? "border-mycel-accent bg-mycel-accent-subtle" : "border-mycel-border bg-mycel-surface hover:border-mycel-accent"
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-[14px] font-semibold text-mycel-text">{title}</span>
+          {recommended && (
+            <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-mycel-accent-subtle text-mycel-accent">
+              Recommended
+            </span>
+          )}
+        </div>
+        <span className="text-[12px] text-mycel-text-2 leading-relaxed">{body}</span>
+      </button>
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
+        Agents can run in isolated Docker containers or in local tmux sessions. You can change this
+        any time in Settings.
+      </p>
+
+      <div className="flex flex-col sm:flex-row gap-3">
+        <Option id="docker" title="Docker" recommended body="Each agent gets a clean, isolated container. Safest default." />
+        <Option id="tmux" title="tmux" body="Agents run in local shell sessions on this machine. Lightweight, no Docker needed." />
+      </div>
+
+      {choice === "docker" && dockerDown && (
+        <div className="rounded-md border border-mycel-warning bg-mycel-warning-subtle px-3 py-2 text-[12px] text-mycel-warning">
+          Docker isn't running. Start Docker Desktop (or the engine) before spawning agents, or pick
+          tmux instead.
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setAdvanced((v) => !v)}
+        className="self-start text-[12px] text-mycel-muted hover:text-mycel-text transition-colors"
+      >
+        {advanced ? "▾ Hide advanced" : "▸ Advanced settings"}
+      </button>
+
+      {advanced && (
+        <div className="rounded-lg border border-mycel-border bg-mycel-surface p-4 flex flex-col gap-4">
+          {choice === "docker" ? (
+            <>
+              <label className="flex flex-col gap-1">
+                <span className="text-[12px] text-mycel-text-2">Agent image</span>
+                <input value={image} onChange={(e) => setImage(e.target.value)} className={TXT} />
+              </label>
+              <div className="flex gap-4 flex-wrap">
+                <label className="flex flex-col gap-1">
+                  <span className="text-[12px] text-mycel-text-2">CPUs</span>
+                  <input type="number" min={0.5} step={0.5} value={cpus} onChange={(e) => setCpus(Number(e.target.value))} className={NUM} />
+                </label>
+                <label className="flex flex-col gap-1">
+                  <span className="text-[12px] text-mycel-text-2">Memory (MB)</span>
+                  <input type="number" min={512} step={512} value={memoryMB} onChange={(e) => setMemoryMB(Number(e.target.value))} className={NUM} />
+                </label>
+              </div>
+            </>
+          ) : (
+            <div className="flex gap-4 flex-wrap">
+              <label className="flex flex-col gap-1 flex-1 min-w-[12rem]">
+                <span className="text-[12px] text-mycel-text-2">Default shell</span>
+                <input value={shell} onChange={(e) => setShell(e.target.value)} className={TXT} />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-[12px] text-mycel-text-2">History limit</span>
+                <input type="number" min={1000} step={1000} value={history} onChange={(e) => setHistory(Number(e.target.value))} className={NUM} />
+              </label>
+            </div>
+          )}
+        </div>
+      )}
+
+      <WizardFooter nav={nav} primaryLabel={saving ? "Saving…" : "Continue"} onPrimary={persist} primaryDisabled={saving} />
+    </div>
+  );
+}

--- a/web/src/wizard/steps/StepSystem.tsx
+++ b/web/src/wizard/steps/StepSystem.tsx
@@ -1,0 +1,106 @@
+import { CopyButton } from "../../components/CopyButton";
+import { useReadiness } from "../../hooks/useReadiness";
+import type { RStatus, ReadinessItem } from "../../views/readiness/readiness";
+import { InstallButton } from "../InstallButton";
+import { WizardFooter } from "../WizardFooter";
+import type { StepProps } from "../types";
+
+/* Step 1 — System check & install deps. Reuses the readiness engine and
+ * adds a streamed installer for each missing, auto-installable item. */
+
+const STATUS_DOT: Record<RStatus, string> = {
+  ok: "bg-mycel-success",
+  warn: "bg-mycel-warning",
+  fail: "bg-mycel-error",
+};
+
+// Items the host installer can't safely automate: Docker (platform-specific,
+// interactive) and Cursor (install hint is a download page, not a command).
+const NON_INSTALLABLE = new Set(["docker", "cursor"]);
+
+function ItemRow({ item, onInstalled }: { item: ReadinessItem; onInstalled: () => void }) {
+  const needsWork = item.status !== "ok";
+  const canInstall = needsWork && !NON_INSTALLABLE.has(item.key);
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3">
+      <div className="flex items-start gap-2.5">
+        <span className={`mt-1.5 inline-flex shrink-0 w-2 h-2 rounded-full ${STATUS_DOT[item.status]}`} aria-hidden />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="text-[13px] text-mycel-text font-medium">{item.label}</span>
+            <span className={`text-[11px] ${item.status === "ok" ? "text-mycel-muted" : "text-mycel-text-2"} truncate`}>
+              {item.detail}
+            </span>
+          </div>
+          {item.note && <p className="mt-0.5 text-[11px] text-mycel-muted leading-relaxed">{item.note}</p>}
+        </div>
+      </div>
+      {canInstall && (
+        <div className="ml-[18px]">
+          <InstallButton id={item.key} label={item.label} onDone={onInstalled} />
+        </div>
+      )}
+      {needsWork && !canInstall && item.fix && (
+        <div className="ml-[18px] flex items-center gap-1.5 rounded-md border border-mycel-border bg-mycel-bg pl-2.5 pr-1 py-1">
+          <code className="flex-1 min-w-0 font-mono text-[11px] text-mycel-text overflow-x-auto whitespace-nowrap">
+            {item.fix}
+          </code>
+          <CopyButton text={item.fix} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function StepSystem({ nav }: StepProps) {
+  const { data, loading, loaded, error, refresh } = useReadiness();
+
+  return (
+    <div className="flex flex-col gap-5">
+      <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
+        These are what mycel needs to run agents. Install anything missing right here — output
+        streams live, and we re-check when it finishes. Nothing here is destructive.
+      </p>
+
+      {error && !data && (
+        <div role="alert" className="rounded-md border border-mycel-border bg-mycel-error-subtle px-3 py-2 text-xs text-mycel-error">
+          Couldn't reach the daemon: {error}
+        </div>
+      )}
+      {!loaded && !data && !error && (
+        <div className="text-sm text-mycel-muted py-6 text-center">Checking your machine…</div>
+      )}
+
+      {data && (
+        <div className="flex flex-col gap-3">
+          {data.groups.map((g) => (
+            <section key={g.id} className="rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden shadow-mycel">
+              <header className="flex items-start gap-2.5 px-4 py-2.5 border-b border-mycel-border bg-mycel-bg">
+                <span className={`mt-1.5 inline-flex shrink-0 w-2 h-2 rounded-full ${STATUS_DOT[g.status]}`} aria-hidden />
+                <div className="min-w-0">
+                  <h2 className="text-[13px] font-semibold text-mycel-text">{g.title}</h2>
+                  <p className="mt-0.5 text-[11px] text-mycel-muted leading-relaxed">{g.summary}</p>
+                </div>
+              </header>
+              <div className="divide-y divide-mycel-border">
+                {g.items.map((it) => (
+                  <ItemRow key={it.key} item={it} onInstalled={() => void refresh()} />
+                ))}
+              </div>
+            </section>
+          ))}
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            disabled={loading}
+            className="self-start text-[11px] px-2.5 py-1 rounded border border-mycel-border hover:border-mycel-accent bg-mycel-surface text-mycel-muted hover:text-mycel-text transition-colors disabled:opacity-50"
+          >
+            {loading ? "Checking…" : "Re-check"}
+          </button>
+        </div>
+      )}
+
+      <WizardFooter nav={nav} primaryLabel="Continue" skipLabel="Skip for now" />
+    </div>
+  );
+}

--- a/web/src/wizard/steps/StepWelcome.tsx
+++ b/web/src/wizard/steps/StepWelcome.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { api } from "../../api/client";
+import { useTheme } from "../../context/ThemeContext";
+import { WizardFooter } from "../WizardFooter";
+import type { StepProps } from "../types";
+
+/* Step 0 — Welcome & you. Name (prefilled) and theme. No avatar: the
+ * mushroom characters belong to agents, not the operator. */
+
+type ThemeChoice = "system" | "light" | "dark";
+
+const THEME_CHOICES: { id: ThemeChoice; label: string; hint: string }[] = [
+  { id: "system", label: "System", hint: "Match your OS" },
+  { id: "light", label: "Light", hint: "Bright" },
+  { id: "dark", label: "Dark", hint: "Dim" },
+];
+
+function systemPrefersDark(): boolean {
+  return typeof window !== "undefined" && !!window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+}
+
+export function StepWelcome({ nav, setDraft, settings, reloadSettings }: StepProps) {
+  const { mode, setTheme } = useTheme();
+  const [name, setName] = useState("");
+  const [theme, setThemeChoice] = useState<ThemeChoice>(mode);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (settings?.user?.name) setName(settings.user.name);
+  }, [settings]);
+
+  const pickTheme = (choice: ThemeChoice) => {
+    setThemeChoice(choice);
+    if (choice === "system") setTheme(systemPrefersDark() ? "dark" : "light");
+    else setTheme(choice);
+  };
+
+  const persist = async () => {
+    setSaving(true);
+    setDraft({ name: name.trim() });
+    try {
+      const resolved = theme === "system" ? (systemPrefersDark() ? "dark" : "light") : theme;
+      await api.updateSettings({
+        user: { name: name.trim() },
+        ui: {
+          theme: resolved,
+          mode: theme === "system" ? "auto" : resolved,
+          default_view: settings?.ui?.default_view || "dashboard",
+        },
+      });
+      await reloadSettings();
+    } catch {
+      /* non-fatal — the wizard is skippable and resumable */
+    } finally {
+      setSaving(false);
+      nav.next();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
+        mycel runs a network of AI coding agents — each in its own git worktree, working in
+        parallel. This quick setup gets your machine ready and spawns your first one. You can skip
+        any step and pick up later.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <label htmlFor="wiz-name" className="text-[13px] font-medium text-mycel-text">
+          What should agents call you?
+        </label>
+        <input
+          id="wiz-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={30}
+          placeholder="Your name"
+          className="w-full max-w-sm bg-mycel-bg border border-mycel-border rounded-md px-3 py-2 text-[14px] text-mycel-text placeholder:text-mycel-muted outline-none focus:border-mycel-accent transition-colors"
+        />
+        <p className="text-[11px] text-mycel-muted">Used to address you in the UI. Optional.</p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-[13px] font-medium text-mycel-text">Theme</span>
+        <div className="flex gap-2 flex-wrap">
+          {THEME_CHOICES.map((c) => {
+            const active = theme === c.id;
+            return (
+              <button
+                key={c.id}
+                type="button"
+                onClick={() => pickTheme(c.id)}
+                aria-pressed={active}
+                className={`flex flex-col items-start gap-0.5 px-3.5 py-2 rounded-lg border text-left transition-colors ${
+                  active
+                    ? "border-mycel-accent bg-mycel-accent-subtle"
+                    : "border-mycel-border bg-mycel-surface hover:border-mycel-accent"
+                }`}
+              >
+                <span className="text-[13px] font-medium text-mycel-text">{c.label}</span>
+                <span className="text-[11px] text-mycel-muted">{c.hint}</span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <WizardFooter
+        nav={nav}
+        primaryLabel={saving ? "Saving…" : "Get started"}
+        onPrimary={persist}
+        primaryDisabled={saving}
+        hideSkip
+      />
+    </div>
+  );
+}

--- a/web/src/wizard/types.ts
+++ b/web/src/wizard/types.ts
@@ -1,0 +1,53 @@
+/* Shared types for the first-run setup wizard. */
+
+import type { SettingsConfig } from "../api/client";
+
+export const WIZARD_STEPS = [
+  { id: "welcome", eyebrow: "Welcome", title: "Welcome to mycel" },
+  { id: "system", eyebrow: "System check", title: "Get your machine ready" },
+  { id: "runtime", eyebrow: "Runtime", title: "Where your agents run" },
+  { id: "providers", eyebrow: "Agent tools", title: "Pick an agent tool" },
+  { id: "preferences", eyebrow: "Preferences", title: "A few defaults" },
+  { id: "apps", eyebrow: "Connect", title: "Connect an app" },
+  { id: "agent", eyebrow: "First agent", title: "Spawn your first agent" },
+  { id: "done", eyebrow: "Ready", title: "You're all set" },
+] as const;
+
+export type StepId = (typeof WIZARD_STEPS)[number]["id"];
+
+export function stepIndex(id: StepId): number {
+  return WIZARD_STEPS.findIndex((s) => s.id === id);
+}
+
+/** Cross-step selections carried while the wizard is open. */
+export interface WizardDraft {
+  provider: string;
+  model: string;
+  runtime: "docker" | "tmux";
+  name: string;
+}
+
+/** Navigation + lifecycle handed to every step. */
+export interface WizardNav {
+  next: () => void;
+  back: () => void;
+  /** Advance past this step without acting on it. */
+  skip: () => void;
+  goTo: (id: StepId) => void;
+  /** Mark the wizard complete and return to the dashboard. */
+  finish: () => void;
+  /** Leave setup for the dashboard, keeping resume position. */
+  exit: () => void;
+  isFirst: boolean;
+  isLast: boolean;
+}
+
+export interface StepProps {
+  nav: WizardNav;
+  draft: WizardDraft;
+  setDraft: (patch: Partial<WizardDraft>) => void;
+  /** Live prefs snapshot, loaded once by the shell. Null until first load. */
+  settings: SettingsConfig | null;
+  /** Re-fetch prefs after a step writes to them. */
+  reloadSettings: () => Promise<void>;
+}


### PR DESCRIPTION
Part of #2674 (v0.4.0 release wrap-up).

A full-screen, skippable, resumable first-run setup wizard at `/welcome`. On app load a fresh `~/.mycel` (no agents, or missing/invalid prefs) routes to the wizard instead of Home. It reuses existing surfaces heavily; the only net-new backend is first-run detection plus a streamed dependency installer.

## Data safety
The wizard/reset only ever writes config fields. It never deletes or wipes `~/.mycel/mycel.db`, `agents/`, `secrets.vault`, `apps/`, or the `prefs.apps` map. Existing agents and connected apps are preserved.

## What's new (backend)
- `GET /api/onboarding/state` → `{firstRun, hasAgents, prefsValid, completed[], step}` (agent count from the live manager, prefs validity via `Config.Validate`).
- `POST /api/deps/install` — loopback-only, streams stdout/stderr back as NDJSON while running a **vetted, OS-aware** install command (brew on darwin, apt on linux; provider CLIs use their install hints). Docker and URL-only hints (Cursor) are intentionally non-installable and fall back to guidance.
- `pkg/home` Config gains an `onboarding{step, completed[]}` section; the settings PATCH allowlist accepts it. `ui.theme`/`ui.mode` already existed and are reused.

## What's new (frontend)
- 8-step wizard with a mycelial "filament" progress rail: Welcome & you → System check + streamed installs → Runtime → Providers & sign-in → Preferences → Connect an app → First agent → Done.
- First-run routing gate on Home (renders Home immediately, only redirects on a positive firstRun probe so the common case never flashes).
- `SetupNudge` now says **Resume setup** → `/welcome`; Settings gains a **Re-run setup** entry.

## Fully working vs MVP-wired
Fully working:
- First-run detection + routing, resume-at-saved-step, skip-per-step and top "Skip setup".
- Streamed installer (step 1): live console, re-check on completion, OS-aware command selection, loopback + consent guards.
- Runtime step writes `prefs.runtime` (incl. advanced docker/tmux knobs); Welcome writes name + theme; Providers writes default provider and stores an API key in the vault; Preferences writes injected instructions + optional budget.
- Step 5 opens the **real** Apps `AppChooser`/`ConnectWizard`; step 6 opens the **real** `CreateAgentModal` — both unchanged.
- Done marks onboarding complete.

MVP-wired (intentionally reuses the canonical surface rather than reimplementing):
- Provider sign-in is API-key paste → vault (+ CLI-login hint); no new per-provider device-flow was added. Default model is remembered for the session (no prefs slot exists for it).
- App connect and first-agent creation delegate wholesale to the existing modals; creating an agent navigates to its detail view.

## Test plan
All verify steps pass:
- `cd web && bunx tsc --noEmit` — clean.
- `make test-web` — 289 passed (adds wizard routing/shell/resume + install-stream tests).
- `cd web && bun run build` — OK (Welcome chunk emitted).
- `go build ./...`, `go vet ./...`, `golangci-lint run` (changed packages) — 0 issues.
- `go test ./server/... ./pkg/home/... ./pkg/doctor/...` — pass, incl. new `/api/onboarding/state`, installer command-selection, and streamed-install tests.
- Live runtime smoke against a throwaway `MYCEL_HOME`: onboarding state, install guards (docker/cursor → 400), settings PATCH persistence, and `/welcome` SPA serving all confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)