### PR TITLE
feat(apps): real identity avatars, cleaner chats, no pseudo-app pills

### DIFF
--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -161,7 +161,9 @@ export function buildHomeModel(snap: HomeSnapshot): { apps: AppItem[]; channels:
   const channels: ChannelItem[] = [];
   for (const name of names) {
     const app = appKeyFor(name);
-    if (app === "internal") continue;
+    // Skip every non-connectable pseudo-app (internal, notifications,
+    // secrets) — the same guard that keeps them out of the pill list.
+    if (!isConnectableApp(app)) continue;
     const ov = ovByName.get(name);
     const st = statByName.get(name);
     const platform = ov?.platform ?? sourcePlatform(name);

--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -39,7 +39,7 @@ import { DefaultAppIcon, PLATFORM_ICON_MAP } from "./PlatformIcons";
 import { ConnectWizard, AppChooser } from "./ConnectApp";
 import { CustomKeysSection } from "./CustomKeys";
 import { sourcePlatform } from "./messageUtils";
-import { AgentCharacter } from "../agent-ui";
+import { IdentityAvatar } from "./IdentityAvatar";
 import { formatRelative } from "../../utils/time";
 import {
   disconnectReason,
@@ -118,6 +118,16 @@ function fallbackLabel(base: string): string {
   return base.charAt(0).toUpperCase() + base.slice(1);
 }
 
+/** Internal, non-connectable surfaces that must never show up as an app
+ *  pill or filter option — they are page sections, not external apps. */
+const NON_CONNECTABLE_APPS = new Set(["notifications", "secrets", "internal"]);
+
+/** True when a bucket key is a real, connectable external app. */
+export function isConnectableApp(keyOrBase: string): boolean {
+  const base = keyOrBase.includes(":") ? (keyOrBase.split(":")[0] ?? keyOrBase) : keyOrBase;
+  return !NON_CONNECTABLE_APPS.has(keyOrBase) && !NON_CONNECTABLE_APPS.has(base);
+}
+
 /** Build the page model, preferring overview metadata and falling back
  *  to the composed endpoints field by field. Pure — unit tested. */
 export function buildHomeModel(snap: HomeSnapshot): { apps: AppItem[]; channels: ChannelItem[] } {
@@ -172,8 +182,10 @@ export function buildHomeModel(snap: HomeSnapshot): { apps: AppItem[]; channels:
   }
 
   // App buckets: every gateway plus every bucket that has channels.
-  const bucketKeys = new Set<string>(snap.gateways.map((g) => g.platform));
-  for (const ch of channels) bucketKeys.add(ch.app);
+  // Internal surfaces (notifications, secrets) are page sections, not
+  // connectable apps — they never earn a pill or a filter option.
+  const bucketKeys = new Set<string>(snap.gateways.map((g) => g.platform).filter(isConnectableApp));
+  for (const ch of channels) if (isConnectableApp(ch.app)) bucketKeys.add(ch.app);
 
   const apps: AppItem[] = [...bucketKeys].map((key) => {
     const base = key.includes(":") ? (key.split(":")[0] ?? key) : key;
@@ -245,34 +257,13 @@ function AppIcon({ base, size }: { base: string; size: number }) {
   return <Icon size={size} />;
 }
 
-function KindGlyph({ kind }: { kind: ChannelKind }) {
-  if (kind === "group") {
-    return (
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-        <circle cx="9" cy="7" r="4" />
-        <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
-      </svg>
-    );
-  }
-  if (kind === "person") {
-    return (
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-        <circle cx="12" cy="7" r="4" />
-      </svg>
-    );
-  }
-  return <span className="font-mono text-[12px] leading-none">#</span>;
-}
-
 function SubscriberAvatars({ subscribers, count }: { subscribers: string[]; count: number }) {
   if (count <= 0) return null;
   return (
     <span className="flex items-center shrink-0" title={`${String(count)} subscribed agent${count === 1 ? "" : "s"}${subscribers.length > 0 ? ": " + subscribers.join(", ") : ""}`}>
       {subscribers.slice(0, 3).map((a, i) => (
-        <span key={a} style={{ marginLeft: i === 0 ? 0 : -4 }}>
-          <AgentCharacter name={a} size={16} />
+        <span key={a} className="ring-1 ring-mycel-surface rounded-full" style={{ marginLeft: i === 0 ? 0 : -5 }}>
+          <IdentityAvatar name={a} size={16} />
         </span>
       ))}
       <span className="ml-1 text-[10.5px] text-mycel-muted tabular-nums">
@@ -292,9 +283,7 @@ function ChannelRowButton({ ch, onOpen }: { ch: ChannelItem; onOpen: (name: stri
       className="w-full flex items-center gap-3 px-3 py-2 bg-mycel-surface hover:bg-mycel-surface-hover text-left transition-colors"
       title={ch.name}
     >
-      <span className="shrink-0 flex items-center justify-center w-4 text-mycel-muted">
-        <KindGlyph kind={ch.kind} />
-      </span>
+      <IdentityAvatar name={ch.displayName} kind={ch.kind} size={28} />
       <span className="min-w-0 flex-1 flex items-baseline gap-2">
         <span className={`truncate text-[13px] font-medium text-mycel-text ${hasDisplayName ? "" : "font-mono"}`}>
           {ch.displayName}
@@ -317,9 +306,9 @@ function ChannelRowButton({ ch, onOpen }: { ch: ChannelItem; onOpen: (name: stri
 
 function SubsectionLabel({ label, count }: { label: string; count: number }) {
   return (
-    <div className="flex items-center gap-2 px-3 py-1.5 bg-mycel-bg">
-      <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-mycel-muted">{label}</span>
-      <span className="text-[10px] text-mycel-muted tabular-nums">{count}</span>
+    <div className="flex items-center gap-2 px-3 py-2 bg-mycel-bg">
+      <span className="text-[10.5px] font-semibold uppercase tracking-[0.09em] text-mycel-text-2">{label}</span>
+      <span className="inline-flex items-center justify-center min-w-[18px] h-[16px] px-1 rounded-full bg-mycel-surface-hover text-[10px] font-medium text-mycel-muted tabular-nums">{count}</span>
     </div>
   );
 }
@@ -718,34 +707,46 @@ export function AppsHome() {
               {recent.length === 0 && (
                 <div className="px-4 py-10 text-center text-xs text-mycel-muted">No messages yet</div>
               )}
-              {recent.map((m) => (
-                <button
-                  key={`${m.channel}:${String(m.id)}`}
-                  type="button"
-                  onClick={() => { openChannel(m.channel); }}
-                  className="w-full text-left px-4 py-2.5 hover:bg-mycel-surface-hover transition-colors"
-                >
-                  <div className="flex items-center gap-1.5 mb-0.5 min-w-0">
-                    <AppIcon base={sourcePlatform(m.channel)} size={11} />
-                    <span className="truncate text-[11px] text-mycel-text-2">{channelLeaf(m.channel)}</span>
-                    <span className="ml-auto shrink-0 text-[10.5px] text-mycel-muted tabular-nums">
-                      {formatRelative(m.created_at)}
-                    </span>
-                  </div>
-                  <div className="truncate text-[13px] text-mycel-text-2">
-                    <span className="font-medium text-mycel-text">{cleanSender(m.sender)}</span>{" "}
-                    {oneLine(m.content)}
-                  </div>
-                </button>
-              ))}
+              {recent.map((m) => {
+                const sender = cleanSender(m.sender);
+                return (
+                  <button
+                    key={`${m.channel}:${String(m.id)}`}
+                    type="button"
+                    onClick={() => { openChannel(m.channel); }}
+                    className="w-full text-left px-4 py-2.5 flex items-start gap-2.5 hover:bg-mycel-surface-hover transition-colors"
+                  >
+                    {/* Real chat participant — initials avatar, never an agent mushroom */}
+                    <IdentityAvatar name={sender} size={26} className="mt-0.5" />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-1.5 mb-0.5 min-w-0">
+                        <AppIcon base={sourcePlatform(m.channel)} size={11} />
+                        <span className="truncate text-[11px] text-mycel-text-2">{channelLeaf(m.channel)}</span>
+                        <span className="ml-auto shrink-0 text-[10.5px] text-mycel-muted tabular-nums">
+                          {formatRelative(m.created_at)}
+                        </span>
+                      </div>
+                      <div className="truncate text-[13px] text-mycel-text-2">
+                        <span className="font-medium text-mycel-text">{sender}</span>{" "}
+                        {oneLine(m.content)}
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
             </div>
           </aside>
 
           {/* Channels — slim secondary column, grouped by app */}
           <div className="space-y-5 min-w-0">
             {sectionApps.length === 0 && (
-              <div className="rounded-lg border border-mycel-border p-6 text-center text-xs text-mycel-muted">
-                {hasFilters ? "No channels match the current filters." : "No channels yet — messages create channels automatically."}
+              <div className="rounded-lg border border-dashed border-mycel-border bg-mycel-surface px-6 py-10 text-center">
+                <p className="text-sm font-medium text-mycel-text-2">
+                  {hasFilters ? "No chats match your filters" : "No chats yet"}
+                </p>
+                <p className="mt-1 text-xs text-mycel-muted">
+                  {hasFilters ? "Try clearing a filter or search term." : "Chats appear here automatically as messages arrive."}
+                </p>
               </div>
             )}
             {sectionApps.map((app) => {
@@ -771,7 +772,7 @@ export function AppsHome() {
                       <>
                         {groups.length > 0 && (
                           <>
-                            <SubsectionLabel label="Groups" count={groups.length} />
+                            <SubsectionLabel label="Group chats" count={groups.length} />
                             {groups.map((ch) => <ChannelRowButton key={ch.name} ch={ch} onOpen={openChannel} />)}
                           </>
                         )}

--- a/web/src/components/apps/IdentityAvatar.tsx
+++ b/web/src/components/apps/IdentityAvatar.tsx
@@ -13,27 +13,36 @@
  * appear with zero further changes here.
  */
 
+import { useState } from "react";
 import { hashName } from "../agent-ui/identity";
 import type { ChannelKind } from "./AppsHome";
 
-/** First one-or-two letters of a human name: "Puneet Rai" → "PR",
+/** First code point of a word, Unicode-safe (handles emoji/multibyte). */
+function firstCodePoint(word: string): string {
+  return Array.from(word)[0] ?? "";
+}
+
+/** First one-or-two glyphs of a human name: "Puneet Rai" → "PR",
  *  "zen-zebra" → "ZZ", "general" → "GE". Non-alphanumerics separate
- *  words; a single word contributes its first two letters. */
+ *  words; a single word contributes its first two code points. Uses
+ *  code-point iteration so multibyte/emoji names never split a glyph. */
 export function initialsFor(name: string): string {
   const words = name.trim().split(/[^\p{L}\p{N}]+/u).filter(Boolean);
   if (words.length === 0) return "?";
   if (words.length === 1) {
-    const w = words[0] ?? "";
-    return (w.slice(0, 2) || "?").toUpperCase();
+    const w = Array.from(words[0] ?? "").slice(0, 2).join("");
+    return (w || "?").toUpperCase();
   }
-  return ((words[0]?.[0] ?? "") + (words[1]?.[0] ?? "")).toUpperCase();
+  return (firstCodePoint(words[0] ?? "") + firstCodePoint(words[1] ?? "")).toUpperCase();
 }
 
-/** Deterministic mid-tone HSL that keeps white text legible in both
- *  light and dark themes (fixed saturation/lightness, hue from name). */
+/** Deterministic HSL that keeps white text legible in both light and
+ *  dark themes: hue/saturation come from the name hash, but lightness is
+ *  clamped dark enough (38%) that even the yellow band (hue ≈ 60) clears
+ *  contrast against the white initials. */
 export function avatarColor(name: string): string {
   const hue = hashName(name) % 360;
-  return `hsl(${String(hue)} 52% 45%)`;
+  return `hsl(${String(hue)} 52% 38%)`;
 }
 
 export interface IdentityAvatarProps {
@@ -49,6 +58,8 @@ export interface IdentityAvatarProps {
 }
 
 export function IdentityAvatar({ name, src, size = 20, kind = null, title, className = "" }: IdentityAvatarProps) {
+  // A broken/failed profile-picture URL falls back to the initials chip.
+  const [imgFailed, setImgFailed] = useState(false);
   const radius = kind === "group" ? Math.round(size * 0.28) : size / 2;
   const shared = {
     width: size,
@@ -56,13 +67,14 @@ export function IdentityAvatar({ name, src, size = 20, kind = null, title, class
     borderRadius: radius,
   } as const;
 
-  if (src) {
+  if (src && !imgFailed) {
     return (
       <img
         src={src}
         alt={name}
         title={title ?? name}
         loading="lazy"
+        onError={() => { setImgFailed(true); }}
         className={`shrink-0 object-cover bg-mycel-surface-hover ${className}`}
         style={shared}
       />

--- a/web/src/components/apps/IdentityAvatar.tsx
+++ b/web/src/components/apps/IdentityAvatar.tsx
@@ -1,0 +1,87 @@
+/**
+ * IdentityAvatar — a real-identity avatar for people, chats and app
+ * participants shown on the Apps page. Renders the platform's own
+ * profile picture when a URL is available; otherwise a deterministic
+ * initials chip whose colour is derived from the name (same name →
+ * same colour everywhere). This is deliberately NOT the mycel
+ * AgentCharacter mushroom: notifications and channels surface real
+ * chat participants, which have nothing to do with mycel agents.
+ *
+ * No avatar URLs are exposed by the notifications/channels API today,
+ * so the initials fallback is what renders in practice — when the
+ * backend starts resolving real profile pictures, pass `src` and they
+ * appear with zero further changes here.
+ */
+
+import { hashName } from "../agent-ui/identity";
+import type { ChannelKind } from "./AppsHome";
+
+/** First one-or-two letters of a human name: "Puneet Rai" → "PR",
+ *  "zen-zebra" → "ZZ", "general" → "GE". Non-alphanumerics separate
+ *  words; a single word contributes its first two letters. */
+export function initialsFor(name: string): string {
+  const words = name.trim().split(/[^\p{L}\p{N}]+/u).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) {
+    const w = words[0] ?? "";
+    return (w.slice(0, 2) || "?").toUpperCase();
+  }
+  return ((words[0]?.[0] ?? "") + (words[1]?.[0] ?? "")).toUpperCase();
+}
+
+/** Deterministic mid-tone HSL that keeps white text legible in both
+ *  light and dark themes (fixed saturation/lightness, hue from name). */
+export function avatarColor(name: string): string {
+  const hue = hashName(name) % 360;
+  return `hsl(${String(hue)} 52% 45%)`;
+}
+
+export interface IdentityAvatarProps {
+  /** Human-readable name — drives initials and fallback colour. */
+  name: string;
+  /** Real profile-picture URL when the platform provides one. */
+  src?: string;
+  size?: number;
+  /** Round for people, rounded-square for group chats. */
+  kind?: ChannelKind;
+  title?: string;
+  className?: string;
+}
+
+export function IdentityAvatar({ name, src, size = 20, kind = null, title, className = "" }: IdentityAvatarProps) {
+  const radius = kind === "group" ? Math.round(size * 0.28) : size / 2;
+  const shared = {
+    width: size,
+    height: size,
+    borderRadius: radius,
+  } as const;
+
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        title={title ?? name}
+        loading="lazy"
+        className={`shrink-0 object-cover bg-mycel-surface-hover ${className}`}
+        style={shared}
+      />
+    );
+  }
+
+  return (
+    <span
+      aria-hidden={title ? undefined : true}
+      title={title ?? name}
+      className={`shrink-0 inline-flex items-center justify-center font-semibold text-white select-none ${className}`}
+      style={{
+        ...shared,
+        backgroundColor: avatarColor(name),
+        fontSize: Math.max(9, Math.round(size * 0.42)),
+        lineHeight: 1,
+      }}
+    >
+      {initialsFor(name)}
+    </span>
+  );
+}

--- a/web/src/views/__tests__/appsHome.test.tsx
+++ b/web/src/views/__tests__/appsHome.test.tsx
@@ -10,7 +10,7 @@ import {
   resolveChannelKind,
   whatsappKindFromId,
 } from "../../components/apps/AppsHome";
-import { avatarColor, initialsFor } from "../../components/apps/IdentityAvatar";
+import { IdentityAvatar, avatarColor, initialsFor } from "../../components/apps/IdentityAvatar";
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
 
@@ -208,9 +208,14 @@ describe("AppsHome helpers", () => {
     expect(isConnectableApp("slack")).toBe(true);
     expect(isConnectableApp("telegram:alerts")).toBe(true);
 
-    const { apps } = buildHomeModel({
+    // A pseudo-app source with a matching gateway must be excluded from
+    // BOTH the app buckets and the channel list.
+    const { apps, channels } = buildHomeModel({
       overview: null,
-      sources,
+      sources: [
+        ...sources,
+        { name: "secrets:vault", description: "", members: [], member_count: 0 },
+      ],
       gateways: [
         ...gateways,
         { platform: "notifications", enabled: true, channels: [] },
@@ -225,16 +230,48 @@ describe("AppsHome helpers", () => {
     expect(keys).toContain("slack");
     expect(keys).not.toContain("notifications");
     expect(keys).not.toContain("secrets");
+    // The secrets:vault "channel" never enters the channel list.
+    expect(channels.some((c) => c.app === "secrets")).toBe(false);
+    expect(channels.some((c) => c.name === "secrets:vault")).toBe(false);
   });
 
-  it("derives deterministic initials and colours for real identities", () => {
+  it("derives deterministic, Unicode-safe initials and legible colours", () => {
     expect(initialsFor("Puneet Rai")).toBe("PR");
     expect(initialsFor("zen-zebra")).toBe("ZZ");
     expect(initialsFor("general")).toBe("GE");
     expect(initialsFor("  ")).toBe("?");
+    // Multibyte names select whole code points, never half a glyph.
+    // 𝐀𝐁𝐂 are astral (surrogate-pair) letters — a raw slice(0,2) would
+    // return a broken half-pair; Array.from keeps them intact.
+    expect(initialsFor("𝐀𝐁𝐂")).toBe("𝐀𝐁");
+    expect(initialsFor("𝐀lpha 𝐁eta")).toBe("𝐀𝐁");
+    expect(initialsFor("日本語")).toBe("日本");
     // Stable across calls, differs by name.
     expect(avatarColor("Puneet Rai")).toBe(avatarColor("Puneet Rai"));
     expect(avatarColor("Puneet Rai")).not.toBe(avatarColor("Someone Else"));
+    // Lightness stays dark enough for white text — including the yellow
+    // hue band that a naive 45%+ lightness would wash out.
+    for (const n of ["a", "b", "yellowish", "Puneet Rai", "zzz"]) {
+      const m = /hsl\(\d+ \d+% (\d+)%\)/.exec(avatarColor(n));
+      expect(m).not.toBeNull();
+      expect(Number(m?.[1])).toBeLessThanOrEqual(42);
+    }
+  });
+
+  it("IdentityAvatar falls back to initials when the image fails to load", () => {
+    const { container } = render(<IdentityAvatar name="Puneet Rai" src="https://example.com/broken.png" />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    // Successful load keeps the <img> — only onError swaps to initials.
+    expect(screen.queryByText("PR")).not.toBeInTheDocument();
+    fireEvent.error(img as HTMLImageElement);
+    expect(container.querySelector("img")).toBeNull();
+    expect(screen.getByText("PR")).toBeInTheDocument();
+  });
+
+  it("IdentityAvatar renders initials directly when no src is given", () => {
+    render(<IdentityAvatar name="zen-zebra" />);
+    expect(screen.getByText("ZZ")).toBeInTheDocument();
   });
 
   it("buildHomeModel degrades without overview data", () => {

--- a/web/src/views/__tests__/appsHome.test.tsx
+++ b/web/src/views/__tests__/appsHome.test.tsx
@@ -6,9 +6,11 @@ import {
   AppsHome,
   buildHomeModel,
   channelLeaf,
+  isConnectableApp,
   resolveChannelKind,
   whatsappKindFromId,
 } from "../../components/apps/AppsHome";
+import { avatarColor, initialsFor } from "../../components/apps/IdentityAvatar";
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
 
@@ -198,6 +200,43 @@ describe("AppsHome helpers", () => {
     expect(wa?.channelCount).toBe(2);
   });
 
+  it("excludes internal pseudo-apps from the app pill/filter list", () => {
+    // notifications + secrets are page sections, not connectable apps.
+    expect(isConnectableApp("notifications")).toBe(false);
+    expect(isConnectableApp("secrets")).toBe(false);
+    expect(isConnectableApp("internal")).toBe(false);
+    expect(isConnectableApp("slack")).toBe(true);
+    expect(isConnectableApp("telegram:alerts")).toBe(true);
+
+    const { apps } = buildHomeModel({
+      overview: null,
+      sources,
+      gateways: [
+        ...gateways,
+        { platform: "notifications", enabled: true, channels: [] },
+        { platform: "secrets", enabled: true, channels: [] },
+      ],
+      labels,
+      health: {},
+      subs,
+      stats,
+    });
+    const keys = apps.map((a) => a.key);
+    expect(keys).toContain("slack");
+    expect(keys).not.toContain("notifications");
+    expect(keys).not.toContain("secrets");
+  });
+
+  it("derives deterministic initials and colours for real identities", () => {
+    expect(initialsFor("Puneet Rai")).toBe("PR");
+    expect(initialsFor("zen-zebra")).toBe("ZZ");
+    expect(initialsFor("general")).toBe("GE");
+    expect(initialsFor("  ")).toBe("?");
+    // Stable across calls, differs by name.
+    expect(avatarColor("Puneet Rai")).toBe(avatarColor("Puneet Rai"));
+    expect(avatarColor("Puneet Rai")).not.toBe(avatarColor("Someone Else"));
+  });
+
   it("buildHomeModel degrades without overview data", () => {
     const { channels } = buildHomeModel({
       overview: null,
@@ -253,16 +292,16 @@ describe("AppsHome", () => {
     renderHome();
 
     await waitFor(() => {
-      expect(screen.getByText("Groups")).toBeInTheDocument();
+      expect(screen.getByText("Group chats")).toBeInTheDocument();
     });
     expect(screen.getByText("People")).toBeInTheDocument();
 
     const waSection = screen.getByRole("region", { name: "WhatsApp channels" });
     expect(within(waSection).getByText("Family Group")).toBeInTheDocument();
     expect(within(waSection).getByText("Puneet Rai")).toBeInTheDocument();
-    // Slack channels get no Groups/People split.
+    // Slack channels get no Group chats/People split.
     const slackSection = screen.getByRole("region", { name: "Slack channels" });
-    expect(within(slackSection).queryByText("Groups")).not.toBeInTheDocument();
+    expect(within(slackSection).queryByText("Group chats")).not.toBeInTheDocument();
   });
 
   it("degrades gracefully when the overview endpoint is missing", async () => {
@@ -274,8 +313,8 @@ describe("AppsHome", () => {
     await waitFor(() => {
       expect(screen.getAllByText("12345-67890@g.us").length).toBeGreaterThan(0);
     });
-    // …but the Groups/People split still works via JID shape,
-    expect(screen.getByText("Groups")).toBeInTheDocument();
+    // …but the Group chats/People split still works via JID shape,
+    expect(screen.getByText("Group chats")).toBeInTheDocument();
     expect(screen.getByText("People")).toBeInTheDocument();
     // and message counts still come from the stats endpoint.
     expect(screen.getByText("42 msgs")).toBeInTheDocument();


### PR DESCRIPTION
Part of #2674

Polish for the Apps page (`web/src/components/apps/AppsHome.tsx`) after the "Notifications primary" redesign, addressing three pieces of owner feedback.

## What changed

**1. Real people/app identity — never the agent mushroom.**
New `IdentityAvatar` component (`web/src/components/apps/IdentityAvatar.tsx`): renders a real profile picture when a URL is available (`src` prop), otherwise a deterministic initials chip whose colour is derived from the name via the existing `hashName` FNV-1a hash (same name → same colour everywhere). It replaces `AgentCharacter` in three surfaces:
- **Notifications stream rows** — leading avatar for the real message sender (`cleanSender(m.sender)`).
- **Channel rows** (`ChannelRowButton`) — per-item avatar keyed off `ch.displayName`, round for people / rounded-square for group chats (replacing the generic kind glyph).
- **Subscriber stacks** (`SubscriberAvatars`) — initials chips instead of mushrooms.

**Honest note on data:** I traced the notifications/channels payload end-to-end (`OverviewChannel` in `client.ts`, `notifications_overview.go`, `pkg/notify/store.go`, `ChannelMessage`). It exposes `display_name`, `kind`, `participant_count`, `subscriber_count`, `message_count`, `last_activity` — **but no avatar URL and no per-participant identity**. Message senders are plain strings; subscribers are mycel agent names. So the initials fallback is what renders today; `IdentityAvatar` already accepts `src` so real pictures light up the moment the backend resolves them, with zero further UI change.

**2. Pseudo-apps excluded from the pill/filter list.**
New exported `isConnectableApp` guard filters `notifications`, `secrets`, `internal` out of the app buckets inside `buildHomeModel`, so they never appear as a pill in the strip or as an option in the Filters popover.

**3. "Groups" → "Group chats" + cleaner UI.**
WhatsApp subsection renamed for clarity (its sibling "People" already covers DMs, so the group-only subsection reads clearest as "Group chats"). `SubsectionLabel` restyled (pill-style count, tighter spacing); channel rows now carry real avatars; the channels empty state rewritten into a legible two-line dashed-card state.

All changes reuse existing mycel theme tokens and are theme-aware (light + dark). Web-only — no Go touched.

## Test plan

| Command | Result |
| --- | --- |
| `cd web && bunx tsc --noEmit` | clean (exit 0) |
| `cd web && bun run lint` | clean (exit 0) |
| `cd web && bun run build` | succeeds |
| `make test-web` | 32 files / 291 tests passed |

Added tests in `web/src/views/__tests__/appsHome.test.tsx`: `isConnectableApp` filtering (incl. a `buildHomeModel` case with injected `notifications`/`secrets` gateways), and `initialsFor` / `avatarColor` determinism. Updated the WhatsApp-split tests for the "Group chats" label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added identity-based avatars with profile images or consistent initials and colors.
  * Improved participant, channel, subscriber, and notification displays with updated avatar styling.
  * Added clearer subsection labels and renamed WhatsApp’s section to “Group chats.”

* **Bug Fixes**
  * Internal-only apps are no longer shown in app pills or filter options.
  * Updated empty-channel messaging and layout for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->