### PR TITLE
feat(web): slim, wizard-mirrored Settings redesign + setup integration

### DIFF
--- a/pkg/home/config.go
+++ b/pkg/home/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ConfigVersion is the current config schema version.
-const ConfigVersion = 2
+const ConfigVersion = 3
 
 // PrefsFileName is the global preferences filename. The one and only
 // config file mycel reads lives at ~/.mycel/prefs.json.
@@ -41,6 +41,9 @@ type Config struct { //nolint:govet // field order matches JSON/API contract
 	Server  ServerConfig                 `json:"server"`
 	Logs    LogsConfig                   `json:"logs"`
 	UI      UIConfig                     `json:"ui"`
+	// Notifications holds delivery preferences: which connected channel
+	// should reach the operator, and whether delivery is on at all.
+	Notifications NotificationsConfig `json:"notifications"`
 	// Onboarding tracks the first-run setup wizard's progress so it can
 	// resume where the user left off. Config-only — the wizard never
 	// touches agents, secrets, or the database.
@@ -89,8 +92,7 @@ func (s ServerConfig) Addr() string {
 
 // RuntimeConfig configures the agent session backend.
 type RuntimeConfig struct { //nolint:govet // field order matches JSON/API contract
-	K8s     json.RawMessage     `json:"k8s,omitempty"` // future
-	Default string              `json:"default"`       // "tmux" or "docker"
+	Default string              `json:"default"` // "tmux" or "docker"
 	Docker  DockerRuntimeConfig `json:"docker"`
 	Tmux    TmuxRuntimeConfig   `json:"tmux"`
 }
@@ -114,8 +116,11 @@ type TmuxRuntimeConfig struct {
 
 // ProvidersConfig configures AI agent providers.
 type ProvidersConfig struct { //nolint:govet // field order matches JSON/API contract
-	Default   string                    `json:"default"`
-	Providers map[string]ProviderConfig `json:"providers,omitempty"`
+	Default string `json:"default"`
+	// DefaultModel is the provider model id new agents use when none is
+	// chosen (e.g. "claude-sonnet-4"). Empty = the provider's own default.
+	DefaultModel string                    `json:"default_model,omitempty"`
+	Providers    map[string]ProviderConfig `json:"providers,omitempty"`
 }
 
 // ProviderConfig defines an AI provider's configuration.
@@ -177,6 +182,19 @@ type UIConfig struct {
 	DefaultView string `json:"default_view"`
 }
 
+// NotificationsConfig holds the operator's delivery preferences. It records
+// which connected channel ("slack:general", "telegram:alerts") should reach
+// the operator and whether delivery is enabled. Channel identities and
+// per-agent subscriptions live in the DB — only the top-level preference
+// lives here.
+type NotificationsConfig struct {
+	// DefaultChannel is the "app:channel" key notifications route to by
+	// default. Empty = no default chosen yet ("decide later").
+	DefaultChannel string `json:"default_channel"`
+	// Enabled turns operator delivery on or off globally.
+	Enabled bool `json:"enabled"`
+}
+
 // DefaultConfig returns sensible defaults for a fresh mycel home.
 func DefaultConfig() Config {
 	return Config{
@@ -232,6 +250,9 @@ func DefaultConfig() Config {
 			Theme:       "dark",
 			Mode:        "auto",
 			DefaultView: "dashboard",
+		},
+		Notifications: NotificationsConfig{
+			Enabled: true,
 		},
 	}
 }

--- a/pkg/home/config_test.go
+++ b/pkg/home/config_test.go
@@ -2,6 +2,7 @@ package home
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/rpuneet/mycel/pkg/app"
@@ -65,6 +66,85 @@ func TestConfigOnboardingRoundTrip(t *testing.T) {
 	parsed.Onboarding.Completed = append(parsed.Onboarding.Completed, "done")
 	if !parsed.Onboarding.OnboardingComplete() {
 		t.Error("OnboardingComplete = false after appending done")
+	}
+}
+
+// TestConfigRealignmentNonDestructive proves the v2→v3 realignment is
+// non-destructive: an older prefs blob — carrying the retired
+// runtime.k8s placeholder and none of the new fields (default_model,
+// notifications) — loads cleanly, upgrades its version via FillDefaults,
+// passes Validate, and re-serializes without the dropped k8s field.
+func TestConfigRealignmentNonDestructive(t *testing.T) {
+	// A realistic pre-realignment prefs.json: version 2, a stray
+	// runtime.k8s "future" placeholder, and no new fields.
+	old := `{
+		"version": 2,
+		"user": {"name": "dana"},
+		"providers": {"default": "claude", "providers": {"claude": {"command": "claude"}}},
+		"runtime": {"default": "docker", "k8s": {"cluster": "prod"}},
+		"storage": {"default": "sqlite", "sqlite": {"path": ".mycel"}},
+		"ui": {"theme": "dark", "mode": "auto", "default_view": "dashboard"}
+	}`
+
+	cfg, err := ParseConfig([]byte(old))
+	if err != nil {
+		t.Fatalf("ParseConfig on old prefs: %v", err)
+	}
+	// Unknown fields (k8s) are dropped by the decoder, not an error.
+	if cfg.User.Name != "dana" {
+		t.Errorf("user.name = %q, want dana", cfg.User.Name)
+	}
+	if cfg.Providers.DefaultModel != "" {
+		t.Errorf("default_model should be empty on an old blob, got %q", cfg.Providers.DefaultModel)
+	}
+
+	// FillDefaults upgrades the version and fills the new fields' zero values.
+	cfg.FillDefaults()
+	if cfg.Version != ConfigVersion {
+		t.Errorf("version = %d after FillDefaults, want %d", cfg.Version, ConfigVersion)
+	}
+	if valErr := cfg.Validate(); valErr != nil {
+		t.Fatalf("upgraded config failed Validate: %v", valErr)
+	}
+
+	// Re-serialize: the dropped k8s field must not reappear, and the new
+	// sections round-trip.
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal upgraded config: %v", err)
+	}
+	if strings.Contains(string(data), "k8s") {
+		t.Errorf("re-serialized config still carries k8s: %s", data)
+	}
+	reparsed, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("re-parse upgraded config: %v", err)
+	}
+	if reparsed.Version != ConfigVersion {
+		t.Errorf("reparsed version = %d, want %d", reparsed.Version, ConfigVersion)
+	}
+}
+
+// TestConfigNotificationsRoundTrip verifies the new notifications section
+// survives a marshal/unmarshal cycle.
+func TestConfigNotificationsRoundTrip(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Notifications = NotificationsConfig{DefaultChannel: "slack:general", Enabled: true}
+	cfg.Providers.DefaultModel = "claude-sonnet-4"
+
+	data, err := json.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	parsed, err := ParseConfig(data)
+	if err != nil {
+		t.Fatalf("ParseConfig: %v", err)
+	}
+	if parsed.Notifications.DefaultChannel != "slack:general" || !parsed.Notifications.Enabled {
+		t.Errorf("notifications round-trip mismatch: %+v", parsed.Notifications)
+	}
+	if parsed.Providers.DefaultModel != "claude-sonnet-4" {
+		t.Errorf("default_model round-trip mismatch: %q", parsed.Providers.DefaultModel)
 	}
 }
 

--- a/pkg/home/config_validate.go
+++ b/pkg/home/config_validate.go
@@ -19,7 +19,7 @@ const NameMaxLength = 30
 
 // Validation errors.
 var (
-	ErrInvalidVersion          = errors.New("version must be 2")
+	ErrInvalidVersion          = errors.New("version must be 3")
 	ErrMissingDefaultProvider  = errors.New("providers.default is required")
 	ErrDefaultProviderNotFound = errors.New("providers.default references undefined provider")
 	ErrInvalidTheme            = errors.New("ui.theme must be one of: dark, light, matrix, synthwave, high-contrast")
@@ -32,7 +32,11 @@ var (
 func (c *Config) FillDefaults() {
 	d := DefaultConfig()
 
-	if c.Version == 0 {
+	// Upgrade older (or unset) schema versions to the current one. The
+	// realignment is additive — older prefs decode cleanly and any dropped
+	// fields (e.g. the retired runtime.k8s placeholder) are simply ignored —
+	// so bumping the version keeps a loaded config valid without a migration.
+	if c.Version < d.Version {
 		c.Version = d.Version
 	}
 	if c.Server.Host == "" {

--- a/pkg/home/open_test.go
+++ b/pkg/home/open_test.go
@@ -471,8 +471,8 @@ func TestLoadRestoresRoles(t *testing.T) {
 	if h.Config == nil {
 		t.Fatal("Config is nil after load")
 	}
-	if h.Config.Version != 2 {
-		t.Errorf("ConfigVersion = %d, want 2", h.Config.Version)
+	if h.Config.Version != ConfigVersion {
+		t.Errorf("ConfigVersion = %d, want %d", h.Config.Version, ConfigVersion)
 	}
 	if h.RoleManager == nil {
 		t.Fatal("RoleManager is nil after load")

--- a/server/handlers/settings.go
+++ b/server/handlers/settings.go
@@ -153,6 +153,11 @@ func (h *SettingsHandler) patch(w http.ResponseWriter, r *http.Request) {
 				httpError(w, "invalid ui config: "+err.Error(), http.StatusBadRequest)
 				return
 			}
+		case "notifications":
+			if err := json.Unmarshal(raw, &merged.Notifications); err != nil {
+				httpError(w, "invalid notifications config: "+err.Error(), http.StatusBadRequest)
+				return
+			}
 		case "onboarding":
 			if err := json.Unmarshal(raw, &merged.Onboarding); err != nil {
 				httpError(w, "invalid onboarding config: "+err.Error(), http.StatusBadRequest)

--- a/server/handlers/settings_test.go
+++ b/server/handlers/settings_test.go
@@ -87,6 +87,11 @@ func TestSettingsPatchSection(t *testing.T) {
 			wantStatus: http.StatusOK,
 		},
 		{
+			name:       "patch notifications section",
+			body:       `{"notifications":{"default_channel":"slack:general","enabled":true}}`,
+			wantStatus: http.StatusOK,
+		},
+		{
 			name:       "apps patch with unknown app returns 400",
 			body:       `{"apps":{"ghost":{"app":"ghost","enabled":true}}}`,
 			wantStatus: http.StatusBadRequest,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -695,6 +695,8 @@ export interface SettingsConfig {
   };
   providers: {
     default: string;
+    /** Persisted default model id; empty = provider's own default. */
+    default_model?: string;
     providers: Record<string, { command: string }>;
   };
   gateways: {
@@ -710,6 +712,8 @@ export interface SettingsConfig {
   };
   logs: { path: string; max_bytes: number };
   ui: { theme: string; mode: string; default_view: string };
+  /** Operator delivery preferences: which channel reaches you, on/off. */
+  notifications?: { default_channel: string; enabled: boolean };
   onboarding?: { step: string; completed: string[] };
 }
 

--- a/web/src/settings/controls.tsx
+++ b/web/src/settings/controls.tsx
@@ -1,0 +1,130 @@
+/* Shared setup controls — the single source of truth for the option groups
+ * that appear in BOTH the first-run wizard (web/src/wizard) and the Settings
+ * page (web/src/views/Settings). Keeping them here means the two surfaces
+ * can never drift: the wizard's Theme and Runtime pickers and the matching
+ * Settings sections render the exact same field components.
+ *
+ * These are presentational + controlled: parents own the value and decide
+ * how to persist it (the wizard writes prefs inline; Settings routes it
+ * through the dirty-tracked save bar). */
+
+export type ThemeChoice = "system" | "light" | "dark";
+
+const THEME_CHOICES: { id: ThemeChoice; label: string; hint: string }[] = [
+  { id: "system", label: "System", hint: "Match your OS" },
+  { id: "light", label: "Light", hint: "Bright" },
+  { id: "dark", label: "Dark", hint: "Dim" },
+];
+
+/** Resolve the "system" choice to a concrete theme using the OS preference. */
+export function systemPrefersDark(): boolean {
+  return typeof window !== "undefined" && !!window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+}
+
+/** Segmented theme picker: System / Light / Dark. */
+export function ThemePicker({
+  value,
+  onChange,
+}: {
+  value: ThemeChoice;
+  onChange: (choice: ThemeChoice) => void;
+}) {
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {THEME_CHOICES.map((c) => {
+        const active = value === c.id;
+        return (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => onChange(c.id)}
+            aria-pressed={active}
+            className={`flex flex-col items-start gap-0.5 px-3.5 py-2 rounded-lg border text-left transition-colors ${
+              active
+                ? "border-mycel-accent bg-mycel-accent-subtle"
+                : "border-mycel-border bg-mycel-surface hover:border-mycel-accent"
+            }`}
+          >
+            <span className="text-[13px] font-medium text-mycel-text">{c.label}</span>
+            <span className="text-[11px] text-mycel-muted">{c.hint}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export type RuntimeChoice = "docker" | "tmux";
+
+/** Segmented runtime picker: Docker (recommended) or tmux. */
+export function RuntimePicker({
+  value,
+  onChange,
+}: {
+  value: RuntimeChoice;
+  onChange: (choice: RuntimeChoice) => void;
+}) {
+  const Option = ({
+    id,
+    title,
+    body,
+    recommended,
+  }: {
+    id: RuntimeChoice;
+    title: string;
+    body: string;
+    recommended?: boolean;
+  }) => {
+    const active = value === id;
+    return (
+      <button
+        type="button"
+        onClick={() => onChange(id)}
+        aria-pressed={active}
+        className={`flex-1 text-left flex flex-col gap-1 rounded-lg border p-4 transition-colors ${
+          active ? "border-mycel-accent bg-mycel-accent-subtle" : "border-mycel-border bg-mycel-surface hover:border-mycel-accent"
+        }`}
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-[14px] font-semibold text-mycel-text">{title}</span>
+          {recommended && (
+            <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-mycel-accent-subtle text-mycel-accent">
+              Recommended
+            </span>
+          )}
+        </div>
+        <span className="text-[12px] text-mycel-text-2 leading-relaxed">{body}</span>
+      </button>
+    );
+  };
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-3">
+      <Option id="docker" title="Docker" recommended body="Each agent gets a clean, isolated container. Safest default." />
+      <Option id="tmux" title="tmux" body="Agents run in local shell sessions on this machine. Lightweight, no Docker needed." />
+    </div>
+  );
+}
+
+/** Progressive-disclosure expander — the wizard's "▸ Advanced settings"
+ *  affordance, shared so Settings and the wizard reveal power-user options
+ *  the same way. Controlled by the parent. */
+export function AdvancedToggle({
+  open,
+  onToggle,
+  label = "Advanced settings",
+}: {
+  open: boolean;
+  onToggle: () => void;
+  label?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="self-start text-[12px] text-mycel-muted hover:text-mycel-text transition-colors"
+    >
+      {open ? `▾ Hide ${label.toLowerCase()}` : `▸ ${label}`}
+    </button>
+  );
+}

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -1,15 +1,48 @@
 import { useCallback, useState, useEffect, useMemo } from "react";
 import { Link } from "react-router-dom";
-import { api } from "../api/client";
+import { api, type ProviderInfo, type BudgetStatus, type OnboardingState } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
+import { useTheme } from "../context/ThemeContext";
+import { PROVIDER_LABELS } from "./readiness/readiness";
+import { WIZARD_STEPS } from "../wizard/types";
+import { ThemePicker, RuntimePicker, AdvancedToggle, systemPrefersDark, type ThemeChoice, type RuntimeChoice } from "../settings/controls";
 
-import { DependenciesSection } from "../components/settings/Dependencies";
 type SaveStatus = "idle" | "saving" | "saved" | "error";
 
-const SECTION_ORDER = ["server", "storage", "runtime", "providers", "logs"];
+/* ── Settings ──────────────────────────────────────────────────────────
+ *
+ * The ongoing-control mirror of the first-run wizard: the same options,
+ * grouped for day-to-day use. Each section leads with a simple default and
+ * tucks power-user knobs behind an Advanced expander (the same "▸ Advanced
+ * settings" affordance the wizard uses). Setup lives at the top so the
+ * wizard is a first-class part of Settings, not a link buried elsewhere.
+ *
+ * Settings is deliberately slim: it holds only config that has no other
+ * home. Surfaces that already own a top-level page — Providers/Tools
+ * (/tools) and Apps + notifications + keys (/apps) — appear as compact link
+ * cards that summarize and route out, never as duplicate config UI.
+ *
+ * Dirty-tracking, per-section PATCH, restart detection, and the floating
+ * save bar are preserved: edits to the config-backed sections (Profile,
+ * Runtime, Advanced) flow through handleSaveAll. Budgets and Setup manage
+ * their own state via their own endpoints. */
+
+// Config top-level keys the save bar tracks and PATCHes. Order drives the
+// "Unsaved: …" summary.
+const SECTION_ORDER = ["user", "ui", "runtime", "storage", "server", "logs"];
+// Sections whose changes require a daemon restart to take effect.
 const RESTART_SECTIONS = new Set(["server", "storage", "runtime"]);
+// Friendly names for the save bar (several config keys map to one UI section).
+const SECTION_LABELS: Record<string, string> = {
+  user: "Profile",
+  ui: "Profile",
+  runtime: "Runtime",
+  storage: "Storage",
+  server: "Server",
+  logs: "Logs",
+};
 
 function deepClone<T>(v: T): T {
   return JSON.parse(JSON.stringify(v));
@@ -20,10 +53,11 @@ function deepEqual(a: unknown, b: unknown): boolean {
 }
 
 /* ------------------------------------------------------------------ */
-/*  Shared components                                                   */
+/*  Shared primitives                                                   */
 /* ------------------------------------------------------------------ */
 
 const INPUT_CLS = "w-full px-2 py-0.5 text-xs rounded-md border border-mycel-border bg-mycel-bg text-mycel-text font-mono focus:outline-none focus:ring-1 focus:ring-mycel-accent";
+const LINK_CLS = "inline-flex items-center h-8 px-3 rounded-md text-xs font-medium bg-mycel-surface border border-mycel-border text-mycel-text hover:bg-mycel-surface-hover transition-colors";
 
 function Field({ label, children, suffix }: { label: string; children: React.ReactNode; suffix?: string }) {
   return (
@@ -68,38 +102,51 @@ function PasswordField({ value, onChange }: { value: string; onChange: (v: strin
   );
 }
 
+/** A collapsed power-user block inside a section — the wizard's advanced card. */
+function Advanced({ children, label }: { children: React.ReactNode; label?: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="pt-1 space-y-2">
+      <AdvancedToggle open={open} onToggle={() => setOpen((v) => !v)} label={label} />
+      {open && (
+        <div className="rounded-lg border border-mycel-border bg-mycel-bg p-3 space-y-1.5">{children}</div>
+      )}
+    </div>
+  );
+}
+
 /* ------------------------------------------------------------------ */
 /*  Section wrapper                                                     */
 /* ------------------------------------------------------------------ */
 
 const SECTION_META: Record<string, { icon: React.ReactNode; desc: string }> = {
-  server: {
-    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2" />,
-    desc: "Host, port, and CORS settings",
+  setup: {
+    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />,
+    desc: "First-run wizard",
   },
-  storage: {
-    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4" />,
-    desc: "Database backend configuration",
+  profile: {
+    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />,
+    desc: "Name and theme",
+  },
+  "providers & tools": {
+    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />,
+    desc: "Agent tools and default model",
   },
   runtime: {
     icon: <path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />,
-    desc: "Agent execution environment",
+    desc: "Where agents run",
   },
-  providers: {
-    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />,
-    desc: "AI provider commands",
+  apps: {
+    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />,
+    desc: "Integrations, notifications, keys",
   },
-  logs: {
-    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />,
-    desc: "Log file location and rotation",
+  budgets: {
+    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />,
+    desc: "Cost caps",
   },
-  dependencies: {
-    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />,
-    desc: "Optional supporting services",
-  },
-  "injected instructions": {
-    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />,
-    desc: "Sent to every agent at spawn",
+  advanced: {
+    icon: <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />,
+    desc: "Storage, server, logs, instructions",
   },
 };
 
@@ -107,12 +154,14 @@ function Section({
   title,
   dirty,
   children,
+  defaultOpen = true,
 }: {
   title: string;
   dirty: boolean;
   children: React.ReactNode;
+  defaultOpen?: boolean;
 }) {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(defaultOpen);
   const meta = SECTION_META[title];
 
   return (
@@ -132,42 +181,254 @@ function Section({
           <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
         </svg>
       </button>
-      {open && <div className="px-3 pb-3 pt-1.5 space-y-1.5 border-t border-mycel-border">{children}</div>}
+      {open && <div className="px-3 pb-3 pt-2 space-y-2 border-t border-mycel-border">{children}</div>}
     </div>
   );
 }
 
 /* ------------------------------------------------------------------ */
-/*  Per-section renderers                                               */
+/*  Setup — onboarding progress + resume/re-run                          */
 /* ------------------------------------------------------------------ */
 
-function ServerSection({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
-  const s = (data.server ?? {}) as Record<string, unknown>;
-  const configuredPort = Number(s.port ?? 0);
-  // The Settings page renders the *configured* port from settings.json,
-  // but the daemon may be running on an override (MYCEL_DAEMON_ADDR, --addr flag,
-  // or the legacy 9374 default if neither is set). Surface the actual
-  // listen port from the browser's connection so users see the live
-  // value alongside the editable config value.
-  const actualPort = typeof window !== "undefined" && window.location.port
-    ? Number(window.location.port)
-    : 0;
-  const portDrift = actualPort > 0 && actualPort !== configuredPort;
+function SetupSection() {
+  const [state, setState] = useState<OnboardingState | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api.getOnboardingState()
+      .then((s) => { if (alive) setState(s); })
+      .catch(() => { /* Setup still offers Re-run without live state. */ });
+    return () => { alive = false; };
+  }, []);
+
+  const total = WIZARD_STEPS.length;
+  const done = (state?.completed ?? []).includes("done");
+  const finished = (state?.completed ?? []).filter((s) => s !== "done").length;
+  const pct = done ? 100 : Math.round((Math.min(finished, total) / total) * 100);
+  const complete = done || pct >= 100;
+
   return (
-    <>
-      <Field label="Host"><input className={INPUT_CLS} value={String(s.host ?? "")} onChange={(e) => onChange(["server", "host"], e.target.value)} /></Field>
-      <Field
-        label="Port"
-        suffix={portDrift ? `running on ${actualPort}` : actualPort > 0 ? "live" : undefined}
-      >
-        <input className={INPUT_CLS} type="number" value={configuredPort} onChange={(e) => onChange(["server", "port"], Number(e.target.value))} />
-      </Field>
-      <Field label="CORS Origin"><input className={INPUT_CLS} value={String(s.cors_origin ?? "")} onChange={(e) => onChange(["server", "cors_origin"], e.target.value)} /></Field>
-    </>
+    <div className="space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-xs text-mycel-text-2 max-w-prose">
+          {complete
+            ? "Setup is complete. Re-run it any time to reconfigure — it only rewrites config and never touches your agents or connected apps."
+            : "Finish first-run setup — machine checks, runtime, an agent tool, and your first agent. It only writes config; your agents and apps are left untouched."}
+        </p>
+        <Link to="/welcome" className={`${LINK_CLS} shrink-0`}>
+          {complete ? "Re-run setup" : "Resume setup"}
+        </Link>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="flex items-center justify-between text-[10px] text-mycel-muted">
+          <span>{complete ? "Complete" : `Step ${Math.min(finished + 1, total)} of ${total}`}</span>
+          <span>{pct}%</span>
+        </div>
+        <div className="h-1.5 rounded-full bg-mycel-bg border border-mycel-border overflow-hidden">
+          <div className="h-full bg-mycel-accent transition-all" style={{ width: `${pct}%` }} />
+        </div>
+      </div>
+    </div>
   );
 }
 
-function StorageSection({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
+/* ------------------------------------------------------------------ */
+/*  Link cards — surfaces that own a top-level page. Settings summarizes  */
+/*  and points; it never duplicates their config UI.                     */
+/* ------------------------------------------------------------------ */
+
+function ProvidersToolsCard({ data }: { data: Record<string, unknown> }) {
+  const p = (data.providers ?? {}) as Record<string, unknown>;
+  const defaultProvider = String(p.default ?? "claude");
+  const [installed, setInstalled] = useState<number | null>(null);
+  const [total, setTotal] = useState<number | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api.listProviders()
+      .then((list: ProviderInfo[]) => {
+        if (!alive) return;
+        setTotal(list.length);
+        setInstalled(list.filter((pi) => pi.installed).length);
+      })
+      .catch(() => { /* summary degrades to the default provider alone */ });
+    return () => { alive = false; };
+  }, []);
+
+  const counts = installed !== null && total !== null ? ` · ${installed}/${total} installed` : "";
+
+  return (
+    <div className="flex items-center justify-between gap-3 min-h-[28px]">
+      <p className="text-xs text-mycel-text-2">
+        <span className="text-mycel-text font-medium">Default: {PROVIDER_LABELS[defaultProvider] ?? defaultProvider}</span>
+        {counts}. Install tools, sign in, and set the default model on the Tools page.
+      </p>
+      <Link to="/tools" className={`${LINK_CLS} shrink-0`}>Open Tools &amp; Providers →</Link>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Runtime                                                             */
+/* ------------------------------------------------------------------ */
+
+function RuntimeSection({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
+  const r = (data.runtime ?? {}) as Record<string, unknown>;
+  const mode = (String(r.default ?? "docker") === "docker" ? "docker" : "tmux") as RuntimeChoice;
+  const docker = (r.docker ?? {}) as Record<string, unknown>;
+  const tmux = (r.tmux ?? {}) as Record<string, unknown>;
+
+  // The runtime pref stores "local" for tmux historically; map picker → pref.
+  const setRuntime = (choice: RuntimeChoice) =>
+    onChange(["runtime", "default"], choice === "docker" ? "docker" : "tmux");
+
+  return (
+    <div className="space-y-3">
+      <RuntimePicker value={mode} onChange={setRuntime} />
+      <Advanced label={mode === "docker" ? "Docker tuning" : "tmux tuning"}>
+        {mode === "docker" ? (
+          <>
+            <Field label="Image"><input className={INPUT_CLS} value={String(docker.image ?? "")} onChange={(e) => onChange(["runtime", "docker", "image"], e.target.value)} /></Field>
+            <Field label="Network"><input className={INPUT_CLS} value={String(docker.network ?? "")} onChange={(e) => onChange(["runtime", "docker", "network"], e.target.value)} /></Field>
+            <Field label="Docker Socket"><input className={INPUT_CLS} value={String(docker.docker_socket_path ?? "")} onChange={(e) => onChange(["runtime", "docker", "docker_socket_path"], e.target.value)} /></Field>
+            <Field label="CPUs"><input className={INPUT_CLS} type="number" value={Number(docker.cpus ?? 2)} onChange={(e) => onChange(["runtime", "docker", "cpus"], Number(e.target.value))} /></Field>
+            <Field label="Memory" suffix="MB"><input className={INPUT_CLS} type="number" value={Number(docker.memory_mb ?? 4096)} onChange={(e) => onChange(["runtime", "docker", "memory_mb"], Number(e.target.value))} /></Field>
+          </>
+        ) : (
+          <>
+            <Field label="Session Prefix"><input className={INPUT_CLS} value={String(tmux.session_prefix ?? "")} onChange={(e) => onChange(["runtime", "tmux", "session_prefix"], e.target.value)} /></Field>
+            <Field label="History Limit"><input className={INPUT_CLS} type="number" value={Number(tmux.history_limit ?? 10000)} onChange={(e) => onChange(["runtime", "tmux", "history_limit"], Number(e.target.value))} /></Field>
+            <Field label="Default Shell"><input className={INPUT_CLS} value={String(tmux.default_shell ?? "")} onChange={(e) => onChange(["runtime", "tmux", "default_shell"], e.target.value)} /></Field>
+          </>
+        )}
+      </Advanced>
+    </div>
+  );
+}
+
+function AppsCard() {
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api.getApps()
+      .then((res) => { if (alive) setCount((res.instances ?? []).filter((i) => i.connected).length); })
+      .catch(() => { if (alive) setCount(0); });
+    return () => { alive = false; };
+  }, []);
+
+  const summary =
+    count === null ? "Loading…"
+      : count === 0 ? "No apps connected"
+        : `${count} app${count === 1 ? "" : "s"} connected`;
+
+  return (
+    <div className="flex items-center justify-between gap-3 min-h-[28px]">
+      <p className="text-xs text-mycel-text-2">
+        <span className="text-mycel-text font-medium">{summary}.</span>{" "}
+        Manage integrations, notification delivery, and API keys on the Apps page.
+      </p>
+      <Link to="/apps" className={`${LINK_CLS} shrink-0`}>Manage apps →</Link>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Budgets — cost caps (own endpoints, not the settings PATCH)         */
+/* ------------------------------------------------------------------ */
+
+function BudgetsSection() {
+  const fetcher = useCallback(() => api.getCostBudgets(), []);
+  const { data, refresh } = usePolling<BudgetStatus[]>(fetcher, 30000);
+  const budgets = data ?? [];
+  const workspace = budgets.find((b) => b.scope === "workspace");
+
+  const [limit, setLimit] = useState("");
+  const [status, setStatus] = useState<SaveStatus>("idle");
+
+  const wsLimit = workspace?.limit_usd;
+  useEffect(() => {
+    if (wsLimit !== undefined) setLimit(String(wsLimit));
+  }, [wsLimit]);
+
+  const save = async () => {
+    const value = Number(limit);
+    setStatus("saving");
+    try {
+      if (!limit.trim() || value <= 0) {
+        await api.deleteCostBudget("workspace").catch(() => { /* nothing to remove */ });
+      } else {
+        await api.createCostBudget({ scope: "workspace", period: "monthly", limit_usd: value, alert_at: 0.8 });
+      }
+      refresh();
+      setStatus("saved");
+      setTimeout(() => setStatus("idle"), 2000);
+    } catch {
+      setStatus("error");
+    }
+  };
+
+  const perAgent = budgets.filter((b) => b.scope.startsWith("agent:"));
+
+  return (
+    <div className="space-y-3">
+      <Field label="Monthly cap" suffix="alerts at 80%">
+        <div className="flex items-center gap-1.5 flex-1">
+          <span className="text-xs text-mycel-muted">$</span>
+          <input
+            type="number"
+            min={0}
+            step={5}
+            value={limit}
+            placeholder="No limit"
+            onChange={(e) => setLimit(e.target.value)}
+            className={INPUT_CLS}
+          />
+          <button
+            type="button"
+            onClick={save}
+            disabled={status === "saving"}
+            className="shrink-0 inline-flex items-center h-7 px-2.5 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-all disabled:opacity-50"
+          >
+            {status === "saving" ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </Field>
+      {status === "saved" && <p className="text-[11px] text-mycel-success">Budget saved.</p>}
+      {status === "error" && <p className="text-[11px] text-mycel-error">Couldn&apos;t save the budget.</p>}
+
+      {perAgent.length > 0 && (
+        <div className="rounded-lg border border-mycel-border bg-mycel-bg divide-y divide-mycel-border overflow-hidden">
+          {perAgent.map((b) => (
+            <div key={b.scope} className="flex items-center justify-between gap-3 px-3 py-2 text-xs">
+              <span className="text-mycel-text truncate">{b.scope.replace(/^agent:/, "")}</span>
+              <span className="text-mycel-muted shrink-0">${b.limit_usd}/{b.period}</span>
+              <button
+                type="button"
+                onClick={() => void api.deleteCostBudget(b.scope).then(refresh)}
+                className="text-mycel-muted hover:text-mycel-error shrink-0"
+                title="Remove cap"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      <p className="text-[11px] text-mycel-muted">
+        Set per-agent caps from an agent&apos;s page. Caps compare against spend computed from provider
+        usage.
+      </p>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Advanced — storage, server, logs, injected instructions             */
+/* ------------------------------------------------------------------ */
+
+function StorageFields({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
   const s = (data.storage ?? {}) as Record<string, unknown>;
   const backend = String(s.default ?? "sqlite");
   const ts = (s.timescale ?? {}) as Record<string, unknown>;
@@ -177,8 +438,8 @@ function StorageSection({ data, onChange }: { data: Record<string, unknown>; onC
     <>
       <Field label="Backend">
         <select value={backend} onChange={(e) => onChange(["storage", "default"], e.target.value)} className={INPUT_CLS}>
+          <option value="sqlite">SQLite (default)</option>
           <option value="timescale">TimescaleDB</option>
-          <option value="sqlite">SQLite</option>
         </select>
       </Field>
       {backend === "timescale" ? (
@@ -196,69 +457,27 @@ function StorageSection({ data, onChange }: { data: Record<string, unknown>; onC
   );
 }
 
-function RuntimeSection({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
-  const r = (data.runtime ?? {}) as Record<string, unknown>;
-  const mode = String(r.default ?? "docker");
-  const docker = (r.docker ?? {}) as Record<string, unknown>;
-  const tmux = (r.tmux ?? {}) as Record<string, unknown>;
-
+function ServerFields({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
+  const s = (data.server ?? {}) as Record<string, unknown>;
+  const configuredPort = Number(s.port ?? 0);
+  const actualPort = typeof window !== "undefined" && window.location.port ? Number(window.location.port) : 0;
+  const portDrift = actualPort > 0 && actualPort !== configuredPort;
   return (
     <>
-      <Field label="Runtime">
-        <select value={mode} onChange={(e) => onChange(["runtime", "default"], e.target.value)} className={INPUT_CLS}>
-          <option value="docker">Docker</option>
-          <option value="local">Local (tmux)</option>
-          <option disabled>Kubernetes (coming soon)</option>
-        </select>
+      <p className="text-[11px] text-mycel-muted">
+        The daemon binds loopback (127.0.0.1) by default and the desktop app fixes it there. Only
+        change these if you run mycel as a shared server.
+      </p>
+      <Field label="Host"><input className={INPUT_CLS} value={String(s.host ?? "")} onChange={(e) => onChange(["server", "host"], e.target.value)} /></Field>
+      <Field label="Port" suffix={portDrift ? `running on ${actualPort}` : actualPort > 0 ? "live" : undefined}>
+        <input className={INPUT_CLS} type="number" value={configuredPort} onChange={(e) => onChange(["server", "port"], Number(e.target.value))} />
       </Field>
-      {mode === "docker" ? (
-        <>
-          <Field label="Image"><input className={INPUT_CLS} value={String(docker.image ?? "")} onChange={(e) => onChange(["runtime", "docker", "image"], e.target.value)} /></Field>
-          <Field label="Network"><input className={INPUT_CLS} value={String(docker.network ?? "")} onChange={(e) => onChange(["runtime", "docker", "network"], e.target.value)} /></Field>
-          <Field label="Docker Socket"><input className={INPUT_CLS} value={String(docker.docker_socket_path ?? "")} onChange={(e) => onChange(["runtime", "docker", "docker_socket_path"], e.target.value)} /></Field>
-          <Field label="CPUs"><input className={INPUT_CLS} type="number" value={Number(docker.cpus ?? 2)} onChange={(e) => onChange(["runtime", "docker", "cpus"], Number(e.target.value))} /></Field>
-          <Field label="Memory" suffix="MB"><input className={INPUT_CLS} type="number" value={Number(docker.memory_mb ?? 4096)} onChange={(e) => onChange(["runtime", "docker", "memory_mb"], Number(e.target.value))} /></Field>
-        </>
-      ) : (
-        <>
-          <Field label="Session Prefix"><input className={INPUT_CLS} value={String(tmux.session_prefix ?? "")} onChange={(e) => onChange(["runtime", "tmux", "session_prefix"], e.target.value)} /></Field>
-          <Field label="History Limit"><input className={INPUT_CLS} type="number" value={Number(tmux.history_limit ?? 10000)} onChange={(e) => onChange(["runtime", "tmux", "history_limit"], Number(e.target.value))} /></Field>
-          <Field label="Default Shell"><input className={INPUT_CLS} value={String(tmux.default_shell ?? "")} onChange={(e) => onChange(["runtime", "tmux", "default_shell"], e.target.value)} /></Field>
-        </>
-      )}
+      <Field label="CORS Origin"><input className={INPUT_CLS} value={String(s.cors_origin ?? "")} onChange={(e) => onChange(["server", "cors_origin"], e.target.value)} /></Field>
     </>
   );
 }
 
-function ProvidersSection({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
-  const p = (data.providers ?? {}) as Record<string, unknown>;
-  const defaultProvider = String(p.default ?? "claude");
-  const providers = (p.providers ?? {}) as Record<string, Record<string, unknown>>;
-  const providerKeys = Object.keys(providers);
-
-  return (
-    <div className="space-y-1.5">
-      <Field label="Default">
-        <select value={defaultProvider} onChange={(e) => onChange(["providers", "default"], e.target.value)} className={INPUT_CLS}>
-          {providerKeys.map((k) => <option key={k} value={k}>{k}</option>)}
-        </select>
-      </Field>
-      {providerKeys.map((k) => (
-        <Field key={k} label={k}>
-          <input
-            className={INPUT_CLS}
-            value={String(providers[k]?.command ?? "")}
-            title={String(providers[k]?.command ?? "") || "command"}
-            onChange={(e) => onChange(["providers", "providers", k, "command"], e.target.value)}
-            placeholder="command"
-          />
-        </Field>
-      ))}
-    </div>
-  );
-}
-
-function LogsSection({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
+function LogsFields({ data, onChange }: { data: Record<string, unknown>; onChange: (path: string[], v: unknown) => void }) {
   const l = (data.logs ?? {}) as Record<string, unknown>;
   const maxBytes = Number(l.max_bytes ?? 0);
   const maxMB = Math.round(maxBytes / 1048576);
@@ -269,10 +488,6 @@ function LogsSection({ data, onChange }: { data: Record<string, unknown>; onChan
     </>
   );
 }
-
-/* ------------------------------------------------------------------ */
-/*  Injected instructions — mycel-authored text pushed to every agent   */
-/* ------------------------------------------------------------------ */
 
 function InjectedInstructionsSection() {
   const [text, setText] = useState("");
@@ -310,23 +525,18 @@ function InjectedInstructionsSection() {
   return (
     <div className="space-y-2">
       <p className="text-[11px] text-mycel-muted">
-        Appended to every agent&apos;s prompt file at spawn, followed by an
-        auto-generated summary of its available MCP servers and credential
-        env var names. Secret values are never included.
+        Appended to every agent&apos;s prompt file at spawn, followed by an auto-generated summary of
+        its MCP servers and credential env var names. Secret values are never included.
       </p>
       <textarea
-        className={`${INPUT_CLS} h-40 resize-y leading-relaxed`}
+        className={`${INPUT_CLS} h-32 resize-y leading-relaxed`}
         placeholder="e.g. Always report status before and after work. Prefer small PRs."
         value={text}
         onChange={(e) => setText(e.target.value)}
       />
       <div className="flex items-center justify-end gap-2">
-        {status === "saved" && (
-          <span className="text-xs text-mycel-success">Saved</span>
-        )}
-        {status === "error" && (
-          <span className="text-xs text-mycel-error">Save failed</span>
-        )}
+        {status === "saved" && <span className="text-xs text-mycel-success">Saved</span>}
+        {status === "error" && <span className="text-xs text-mycel-error">Save failed</span>}
         <button
           type="button"
           onClick={handleSave}
@@ -347,6 +557,7 @@ function InjectedInstructionsSection() {
 export function Settings() {
   const fetcher = useCallback(() => api.getSettings(), []);
   const { data: config, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
+  const { setTheme } = useTheme();
 
   const [edited, setEdited] = useState<Record<string, unknown> | null>(null);
   const [original, setOriginal] = useState<Record<string, unknown> | null>(null);
@@ -368,6 +579,12 @@ export function Settings() {
     );
   }, [edited, original]);
 
+  // De-duplicated friendly labels for the save bar (user+ui → one "Profile").
+  const dirtyLabels = useMemo(
+    () => Array.from(new Set(dirtySections.map((k) => SECTION_LABELS[k] ?? k))),
+    [dirtySections],
+  );
+
   const handleChange = (path: string[], newValue: unknown) => {
     if (!edited || path.length === 0) return;
     const next = deepClone(edited);
@@ -381,6 +598,31 @@ export function Settings() {
     }
     cursor[path[path.length - 1]!] = newValue;
     setEdited(next);
+  };
+
+  // Theme lives in two coupled fields (ui.theme + ui.mode). Set both in one
+  // clone and preview live so the page reflects the choice immediately.
+  const handleThemeChange = (choice: ThemeChoice) => {
+    if (!edited) return;
+    const resolved = choice === "system" ? (systemPrefersDark() ? "dark" : "light") : choice;
+    setTheme(resolved);
+    const next = deepClone(edited);
+    const ui = (typeof next.ui === "object" && next.ui !== null ? next.ui : {}) as Record<string, unknown>;
+    next.ui = { ...ui, theme: resolved, mode: choice === "system" ? "auto" : resolved };
+    setEdited(next);
+  };
+
+  const currentThemeChoice = ((): ThemeChoice => {
+    const ui = (edited?.ui ?? {}) as Record<string, unknown>;
+    if (String(ui.mode ?? "") === "auto") return "system";
+    const t = String(ui.theme ?? "dark");
+    return t === "light" ? "light" : "dark";
+  })();
+
+  const revertTheme = () => {
+    const ui = (original?.ui ?? {}) as Record<string, unknown>;
+    const t = String(ui.theme ?? "dark");
+    setTheme(t === "light" ? "light" : "dark");
   };
 
   const handleSaveAll = async () => {
@@ -419,13 +661,11 @@ export function Settings() {
   if (!config || !edited || !original) return null;
 
   const version = edited.version;
+  const isDirty = (...keys: string[]) => keys.some((k) => dirtySections.includes(k));
+  const userName = String(((edited.user ?? {}) as Record<string, unknown>).name ?? "");
 
   return (
-    <div className="p-4 md:p-6 space-y-3">
-      {/* File metadata badge — the source of truth for what these
-          settings map to on disk. Small chip with a bordered file
-          glyph so it reads as chrome, not as a subtitle competing
-          with the page header above. */}
+    <div className="p-4 md:p-6 space-y-3 max-w-3xl mx-auto">
       <div className="flex items-center gap-2">
         <span className="inline-flex items-center gap-1.5 text-[10px] font-mono px-2 py-1 rounded-md border border-mycel-border bg-mycel-surface-hover text-mycel-muted">
           <svg width="10" height="10" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round">
@@ -436,8 +676,6 @@ export function Settings() {
         </span>
       </div>
 
-      {/* Saved confirmation toast — visible briefly after a successful save
-          when no other sections are dirty. */}
       {saveStatus === "saved" && dirtySections.length === 0 && (
         <div className="fixed bottom-4 right-4 z-30 rounded-lg border border-mycel-success bg-mycel-success-subtle px-3 py-2 text-xs text-mycel-success shadow-mycel-lg">
           Saved
@@ -449,7 +687,7 @@ export function Settings() {
         <div className="sticky top-0 z-20 rounded-lg border border-mycel-accent bg-mycel-accent-subtle backdrop-blur px-3 py-2 flex items-center justify-between gap-3 shadow-mycel">
           <div className="text-xs text-mycel-text min-w-0">
             <span className="font-medium">Unsaved:</span>{" "}
-            <span className="text-mycel-muted">{dirtySections.join(", ")}</span>
+            <span className="text-mycel-muted">{dirtyLabels.join(", ")}</span>
             {dirtySections.some((k) => RESTART_SECTIONS.has(k)) && (
               <span className="ml-2 text-mycel-accent">Restart required after save</span>
             )}
@@ -459,6 +697,7 @@ export function Settings() {
               type="button"
               onClick={() => {
                 if (original) setEdited(deepClone(original));
+                revertTheme();
                 setSaveStatus("idle");
               }}
               disabled={saveStatus === "saving"}
@@ -482,69 +721,67 @@ export function Settings() {
         </div>
       )}
 
-      {saveStatus === "saved" && dirtySections.length === 0 && !restartWarning && (
-        <div className="rounded-md border border-mycel-success bg-mycel-success-subtle px-3 py-1.5 text-xs text-mycel-success">
-          Changes saved.
-        </div>
-      )}
-
       {restartWarning && (
         <div className="rounded-md border border-mycel-error bg-mycel-error-subtle px-3 py-1.5 text-xs text-mycel-error">
           Changes saved. Restart mycel to apply (<code className="font-mono">mycel down &amp;&amp; mycel up -d</code>)
         </div>
       )}
 
-      {/* Row 1: Server + Storage side by side */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        <Section title="server" dirty={dirtySections.includes("server")}>
-          <ServerSection data={edited} onChange={handleChange} />
-        </Section>
-        <Section title="storage" dirty={dirtySections.includes("storage")}>
-          <StorageSection data={edited} onChange={handleChange} />
-        </Section>
-      </div>
-
-      {/* Row 2: Runtime + Providers side by side */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
-        <Section title="runtime" dirty={dirtySections.includes("runtime")}>
-          <RuntimeSection data={edited} onChange={handleChange} />
-        </Section>
-        <Section title="providers" dirty={dirtySections.includes("providers")}>
-          <ProvidersSection data={edited} onChange={handleChange} />
-        </Section>
-      </div>
-
-      {/* Row 3: Logs */}
-      <div className="grid grid-cols-1 gap-3">
-        <Section title="logs" dirty={dirtySections.includes("logs")}>
-          <LogsSection data={edited} onChange={handleChange} />
-        </Section>
-      </div>
-
-      {/* Row 4: Injected instructions (sent to every agent) */}
-      <Section title="injected instructions" dirty={false}>
-        <InjectedInstructionsSection />
-      </Section>
-
-      {/* Row 5: Optional dependencies (mycel-db, mycel-code-server, mycel-browser) */}
-      <Section title="dependencies" dirty={false}>
-        <DependenciesSection />
-      </Section>
-
-      {/* Row 6: Re-run the first-run setup wizard. */}
       <Section title="setup" dirty={false}>
-        <div className="flex items-center justify-between gap-3 min-h-[28px]">
-          <p className="text-xs text-mycel-text-2">
-            Walk through first-run setup again — checks, runtime, provider, and your first agent.
-            It only writes config; your agents and connected apps are left untouched.
-          </p>
-          <Link
-            to="/welcome"
-            className="shrink-0 inline-flex items-center h-8 px-3 rounded-md text-xs font-medium bg-mycel-surface border border-mycel-border text-mycel-text hover:bg-mycel-surface-hover transition-colors"
-          >
-            Re-run setup
-          </Link>
+        <SetupSection />
+      </Section>
+
+      <Section title="profile" dirty={isDirty("user", "ui")}>
+        <Field label="Name">
+          <input
+            className={INPUT_CLS}
+            value={userName}
+            maxLength={30}
+            placeholder="Your name"
+            onChange={(e) => handleChange(["user", "name"], e.target.value)}
+          />
+        </Field>
+        <div className="flex items-start gap-2 min-h-[28px] pt-1">
+          <label className="text-xs text-mycel-text-2 w-28 shrink-0">Theme</label>
+          <ThemePicker value={currentThemeChoice} onChange={handleThemeChange} />
         </div>
+      </Section>
+
+      {/* Providers/Tools own the /tools page; Settings only summarizes. The
+          default-model + per-provider controls that write prefs.providers
+          live there (follow-up PR). */}
+      <Section title="providers & tools" dirty={false}>
+        <ProvidersToolsCard data={edited} />
+      </Section>
+
+      <Section title="runtime" dirty={isDirty("runtime")}>
+        <RuntimeSection data={edited} onChange={handleChange} />
+      </Section>
+
+      <Section title="budgets" dirty={false}>
+        <BudgetsSection />
+      </Section>
+
+      {/* Apps owns integrations, notification delivery, and API keys on the
+          /apps page; Settings only summarizes and links out. The
+          prefs.notifications{} controls surface there (follow-up PR). */}
+      <Section title="apps" dirty={false}>
+        <AppsCard />
+      </Section>
+
+      <Section title="advanced" dirty={isDirty("storage", "server", "logs")} defaultOpen={false}>
+        <Advanced label="Storage">
+          <StorageFields data={edited} onChange={handleChange} />
+        </Advanced>
+        <Advanced label="Server">
+          <ServerFields data={edited} onChange={handleChange} />
+        </Advanced>
+        <Advanced label="Logs">
+          <LogsFields data={edited} onChange={handleChange} />
+        </Advanced>
+        <Advanced label="Injected instructions">
+          <InjectedInstructionsSection />
+        </Advanced>
       </Section>
     </div>
   );

--- a/web/src/views/__tests__/settings.test.tsx
+++ b/web/src/views/__tests__/settings.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Settings — the wizard-mirrored redesign.
+ *
+ *   - Renders every redesigned section (Setup, Profile, Providers, Runtime,
+ *     Tools, Apps, Notifications, Budgets, Advanced).
+ *   - The Setup section reads onboarding state and shows progress.
+ *   - Editing a field raises the floating save bar; Save PATCHes /api/settings.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Settings } from "../Settings";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+const SETTINGS = {
+  version: 3,
+  user: { name: "dana" },
+  server: { host: "127.0.0.1", port: 9374, cors_origin: "*" },
+  runtime: { default: "docker", docker: { image: "img", network: "n", docker_socket_path: "/s", extra_mounts: [], cpus: 2, memory_mb: 4096 }, tmux: { session_prefix: "mycel", history_limit: 10000, default_shell: "/bin/bash" } },
+  providers: { default: "claude", default_model: "", providers: { claude: { command: "claude" } } },
+  storage: { default: "sqlite", sqlite: { path: ".mycel" } },
+  logs: { path: "", max_bytes: 0 },
+  ui: { theme: "dark", mode: "auto", default_view: "dashboard" },
+  notifications: { default_channel: "", enabled: true },
+};
+
+const ONBOARDING = { firstRun: false, hasAgents: true, prefsValid: true, completed: ["welcome", "system", "runtime"], step: "providers" };
+
+/** Route every GET the page fans out to a sane payload. */
+function mockApi(overrides: Record<string, unknown> = {}) {
+  fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+    if (init?.method === "PATCH") return jsonResponse({ ...SETTINGS, ...(overrides.patched as object) });
+    if (url.includes("/onboarding/state")) return jsonResponse(ONBOARDING);
+    if (url.includes("/settings/injected-instructions")) return jsonResponse({ injected_instructions: "" });
+    if (url.includes("/settings")) return jsonResponse(SETTINGS);
+    if (url.includes("/providers")) return jsonResponse([{ name: "claude", models: [{ id: "claude-sonnet-4", available: true }] }]);
+    if (url.includes("/costs/budgets")) return jsonResponse([]);
+    if (url.includes("/apps")) return jsonResponse({ catalog: [], instances: [] });
+    if (url.includes("/deps")) return jsonResponse({ deps: [] });
+    return jsonResponse([]);
+  });
+}
+
+function renderSettings() {
+  return render(
+    <MemoryRouter>
+      <Settings />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("Settings redesign", () => {
+  it("renders the slim section set (5 config sections + 2 link cards)", async () => {
+    mockApi();
+    renderSettings();
+    for (const label of ["setup", "profile", "providers & tools", "runtime", "budgets", "apps", "advanced"]) {
+      expect(await screen.findByText(label)).toBeInTheDocument();
+    }
+    // Link cards route out instead of duplicating config.
+    expect(screen.getByRole("link", { name: /Open Tools & Providers/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Manage apps/i })).toBeInTheDocument();
+  });
+
+  it("reads onboarding state into the Setup section", async () => {
+    mockApi();
+    renderSettings();
+    // 3 of 8 steps completed → "Step 4 of 8".
+    expect(await screen.findByText(/Step 4 of 8/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /resume setup/i })).toBeInTheDocument();
+  });
+
+  it("raises the save bar and PATCHes on edit + save", async () => {
+    mockApi();
+    renderSettings();
+
+    const nameInput = (await screen.findByPlaceholderText("Your name")) as HTMLInputElement;
+    expect(nameInput.value).toBe("dana");
+    fireEvent.change(nameInput, { target: { value: "dana-2" } });
+
+    // Floating save bar surfaces the dirty Profile section.
+    const bar = (await screen.findByText(/Unsaved:/)).closest("div.sticky") as HTMLElement;
+    expect(within(bar).getByText(/Profile/)).toBeInTheDocument();
+
+    fireEvent.click(within(bar).getByRole("button", { name: /^Save$/ }));
+
+    await waitFor(() => {
+      const patched = fetchMock.mock.calls.find(
+        ([url, init]) => String(url).includes("/settings") && (init as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(patched).toBeTruthy();
+      const body = JSON.parse(((patched?.[1] as RequestInit).body) as string);
+      expect(body.user.name).toBe("dana-2");
+    });
+  });
+});

--- a/web/src/wizard/steps/StepRuntime.tsx
+++ b/web/src/wizard/steps/StepRuntime.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api/client";
 import { useReadiness } from "../../hooks/useReadiness";
+import { AdvancedToggle, RuntimePicker, type RuntimeChoice as RT } from "../../settings/controls";
 import { WizardFooter } from "../WizardFooter";
 import type { StepProps } from "../types";
 
 /* Step 2 — Runtime. Docker (isolated containers) or tmux (local sessions),
- * with an advanced expander. Writes prefs.runtime. */
-
-type RT = "docker" | "tmux";
+ * with an advanced expander. The runtime picker + advanced toggle are shared
+ * with Settings → Runtime (web/src/settings/controls). Writes prefs.runtime. */
 
 const NUM = "w-24 bg-mycel-bg border border-mycel-border rounded-md px-2 py-1 text-[12px] text-mycel-text font-mono outline-none focus:border-mycel-accent";
 const TXT = "w-full bg-mycel-bg border border-mycel-border rounded-md px-2 py-1 text-[12px] text-mycel-text font-mono outline-none focus:border-mycel-accent";
@@ -75,30 +75,6 @@ export function StepRuntime({ nav, draft, setDraft, settings, reloadSettings }: 
     }
   };
 
-  const Option = ({ id, title, body, recommended }: { id: RT; title: string; body: string; recommended?: boolean }) => {
-    const active = choice === id;
-    return (
-      <button
-        type="button"
-        onClick={() => setChoice(id)}
-        aria-pressed={active}
-        className={`flex-1 text-left flex flex-col gap-1 rounded-lg border p-4 transition-colors ${
-          active ? "border-mycel-accent bg-mycel-accent-subtle" : "border-mycel-border bg-mycel-surface hover:border-mycel-accent"
-        }`}
-      >
-        <div className="flex items-center gap-2">
-          <span className="text-[14px] font-semibold text-mycel-text">{title}</span>
-          {recommended && (
-            <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-mycel-accent-subtle text-mycel-accent">
-              Recommended
-            </span>
-          )}
-        </div>
-        <span className="text-[12px] text-mycel-text-2 leading-relaxed">{body}</span>
-      </button>
-    );
-  };
-
   return (
     <div className="flex flex-col gap-5">
       <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
@@ -106,10 +82,7 @@ export function StepRuntime({ nav, draft, setDraft, settings, reloadSettings }: 
         any time in Settings.
       </p>
 
-      <div className="flex flex-col sm:flex-row gap-3">
-        <Option id="docker" title="Docker" recommended body="Each agent gets a clean, isolated container. Safest default." />
-        <Option id="tmux" title="tmux" body="Agents run in local shell sessions on this machine. Lightweight, no Docker needed." />
-      </div>
+      <RuntimePicker value={choice} onChange={setChoice} />
 
       {choice === "docker" && dockerDown && (
         <div className="rounded-md border border-mycel-warning bg-mycel-warning-subtle px-3 py-2 text-[12px] text-mycel-warning">
@@ -118,13 +91,7 @@ export function StepRuntime({ nav, draft, setDraft, settings, reloadSettings }: 
         </div>
       )}
 
-      <button
-        type="button"
-        onClick={() => setAdvanced((v) => !v)}
-        className="self-start text-[12px] text-mycel-muted hover:text-mycel-text transition-colors"
-      >
-        {advanced ? "▾ Hide advanced" : "▸ Advanced settings"}
-      </button>
+      <AdvancedToggle open={advanced} onToggle={() => setAdvanced((v) => !v)} />
 
       {advanced && (
         <div className="rounded-lg border border-mycel-border bg-mycel-surface p-4 flex flex-col gap-4">

--- a/web/src/wizard/steps/StepWelcome.tsx
+++ b/web/src/wizard/steps/StepWelcome.tsx
@@ -1,23 +1,13 @@
 import { useEffect, useState } from "react";
 import { api } from "../../api/client";
 import { useTheme } from "../../context/ThemeContext";
+import { ThemePicker, systemPrefersDark, type ThemeChoice } from "../../settings/controls";
 import { WizardFooter } from "../WizardFooter";
 import type { StepProps } from "../types";
 
 /* Step 0 — Welcome & you. Name (prefilled) and theme. No avatar: the
- * mushroom characters belong to agents, not the operator. */
-
-type ThemeChoice = "system" | "light" | "dark";
-
-const THEME_CHOICES: { id: ThemeChoice; label: string; hint: string }[] = [
-  { id: "system", label: "System", hint: "Match your OS" },
-  { id: "light", label: "Light", hint: "Bright" },
-  { id: "dark", label: "Dark", hint: "Dim" },
-];
-
-function systemPrefersDark(): boolean {
-  return typeof window !== "undefined" && !!window.matchMedia?.("(prefers-color-scheme: dark)").matches;
-}
+ * mushroom characters belong to agents, not the operator. The theme picker
+ * is shared with Settings → Profile (web/src/settings/controls). */
 
 export function StepWelcome({ nav, setDraft, settings, reloadSettings }: StepProps) {
   const { mode, setTheme } = useTheme();
@@ -82,27 +72,7 @@ export function StepWelcome({ nav, setDraft, settings, reloadSettings }: StepPro
 
       <div className="flex flex-col gap-2">
         <span className="text-[13px] font-medium text-mycel-text">Theme</span>
-        <div className="flex gap-2 flex-wrap">
-          {THEME_CHOICES.map((c) => {
-            const active = theme === c.id;
-            return (
-              <button
-                key={c.id}
-                type="button"
-                onClick={() => pickTheme(c.id)}
-                aria-pressed={active}
-                className={`flex flex-col items-start gap-0.5 px-3.5 py-2 rounded-lg border text-left transition-colors ${
-                  active
-                    ? "border-mycel-accent bg-mycel-accent-subtle"
-                    : "border-mycel-border bg-mycel-surface hover:border-mycel-accent"
-                }`}
-              >
-                <span className="text-[13px] font-medium text-mycel-text">{c.label}</span>
-                <span className="text-[11px] text-mycel-muted">{c.hint}</span>
-              </button>
-            );
-          })}
-        </div>
+        <ThemePicker value={theme} onChange={pickTheme} />
       </div>
 
       <WizardFooter


### PR DESCRIPTION
Part of #2674

Folds the first-run setup into Settings and replaces the dev-flavored raw-config page with a slim, wizard-aligned layout. Settings now holds only config that has no other home; surfaces that already own a top-level page appear as compact **link cards** that summarize and route out, never duplicate config UI.

## What changed

**Slim Settings (`web/src/views/Settings.tsx`)**
- **Setup** (top) — onboarding progress bar read from `GET /api/onboarding/state`, with Resume / Re-run routing to `/welcome`.
- **Profile** — name + theme (System/Light/Dark), live preview.
- **Providers & Tools** — link card → `/tools` (default provider + install counts).
- **Runtime** — Docker/tmux picker + docker/tmux tuning behind an Advanced expander.
- **Budgets** — global monthly cap (+ per-agent caps), via the cost-budget API.
- **Apps** — link card → `/apps` (connected count; integrations, notification delivery, keys all live there).
- **Advanced** — server (loopback note), storage (SQLite/Timescale), logs, injected instructions.

Dirty-tracking, per-section PATCH, restart detection, and the floating save bar are **preserved** across the new layout (Profile / Runtime / Advanced flow through it; Budgets + Setup own their endpoints).

**Shared, single-source-of-truth controls (`web/src/settings/controls.tsx`)** — `ThemePicker`, `RuntimePicker`, `AdvancedToggle` — now used by BOTH the wizard steps (`StepWelcome`, `StepRuntime`, refactored to consume them) and Settings, so the two surfaces can't drift.

## preferences.json realignment (v2 → v3, non-destructive)
- **Remove** the retired `runtime.k8s` `// future` placeholder from the schema.
- **Add** `providers.default_model` (persisted default model).
- **Add** `notifications{default_channel, enabled}` (delivery preferences).
- **Demote** `server{}` into the Advanced section.
- `FillDefaults` upgrades older versions in place; a v2 prefs blob carrying a stray `k8s` and none of the new fields loads, upgrades to v3, validates, and re-serializes cleanly. Agents / apps / vault / DB are never touched.

> Note: the default-model and notification-delivery **controls** land on `/tools` and `/apps` in follow-up PRs — but the prefs fields and the `/api/settings` PATCH allowlist for `providers` + `notifications` ship now so those surfaces can write them.

## Design-doc coverage (§ Settings redesign + § realignment)
- Setup integrated into Settings ✅
- Progressive disclosure (simple default + Advanced expander) ✅
- Profile / Runtime / Budgets / Advanced as real config sections ✅
- Providers/Tools + Apps/Notifications/Secrets converged to their existing homes via link cards ✅
- k8s removed, `default_model` + `notifications{}` added, server demoted, version bumped, non-destructive ✅

## Out-of-scope follow-ups (clean seams left)
- Full Tools/Dependencies manager (registry search, install/update, package-manager autodetect) — lives on `/tools`.
- Provider device-flow/OAuth sign-in beyond API-key paste.
- App one-click OAuth connect.
- Default-model picker + per-agent notification-delivery controls (on `/tools` and `/apps`).

## Test plan (commands + results)
- `cd web && bunx tsc --noEmit` → clean
- `cd web && bun run lint` → clean (0 problems)
- `cd web && bun run build` → succeeds
- `make test-web` (vitest) → **33 files, 292 tests pass** (incl. new `settings.test.tsx`: renders the slim section set, reads onboarding state, save/dirty PATCHes; refactored wizard steps still green)
- `go build ./...`, `go vet ./pkg/home/... ./server/handlers/...` → clean
- `golangci-lint run ./pkg/home/... ./server/handlers/...` → **0 issues**
- `go test ./pkg/home/... ./server/handlers/...` → pass, incl. new `TestConfigRealignmentNonDestructive` (old v2+k8s blob round-trips) and `TestConfigNotificationsRoundTrip`
- Live smoke against a throwaway `MYCEL_HOME` on `127.0.0.1`: prefs write `version: 3`; `GET /api/onboarding/state` serves; `PATCH /api/settings` accepts `providers.default_model` + `notifications{}` (HTTP 200, persisted); a seeded v2 prefs with a stray `k8s` loads, upgrades to v3, and preserves `user.name`; `k8s` absent from re-serialized prefs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)