### PR TITLE
feat(web): fleet default provider + model manager on /settings/tools

### DIFF
--- a/server/handlers/settings_test.go
+++ b/server/handlers/settings_test.go
@@ -156,6 +156,37 @@ func TestSettingsPatchUpdatesConfig(t *testing.T) {
 	}
 }
 
+// TestSettingsPatchProviderDefaultModel verifies the fleet-default provider
+// picker's contract: a partial providers patch persists default_model and
+// leaves the per-provider `providers` map intact (so it never clobbers
+// command overrides). This backs the /settings/tools default-model UI.
+func TestSettingsPatchProviderDefaultModel(t *testing.T) {
+	h := newTestHome(t)
+	sh := NewSettingsHandler(h)
+	mux := http.NewServeMux()
+	sh.Register(mux)
+
+	body := `{"providers":{"default":"claude","default_model":"claude-sonnet-4"}}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/settings", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	if got := h.Config.Providers.DefaultModel; got != "claude-sonnet-4" {
+		t.Errorf("default_model = %q, want %q", got, "claude-sonnet-4")
+	}
+	if h.Config.Providers.Default != "claude" {
+		t.Errorf("default provider = %q, want claude", h.Config.Providers.Default)
+	}
+	// The partial patch must not wipe the per-provider command map.
+	if _, ok := h.Config.Providers.Providers["claude"]; !ok {
+		t.Error("providers map wiped by a default_model-only patch")
+	}
+}
+
 // TestSettingsAppsPatchMerges verifies the per-instance merge: patching
 // one instance never wipes the others.
 func TestSettingsAppsPatchMerges(t *testing.T) {

--- a/server/handlers/settings_test.go
+++ b/server/handlers/settings_test.go
@@ -185,6 +185,29 @@ func TestSettingsPatchProviderDefaultModel(t *testing.T) {
 	if _, ok := h.Config.Providers.Providers["claude"]; !ok {
 		t.Error("providers map wiped by a default_model-only patch")
 	}
+
+	// A patch that omits `default` must leave the existing default provider
+	// intact. Decoding into the already-populated ProvidersConfig only sets
+	// fields present in the JSON, so `default` is preserved on omission —
+	// this pins that so the map + default survive a model-only update.
+	body2 := `{"providers":{"default_model":"claude-opus-4"}}`
+	req2 := httptest.NewRequest(http.MethodPatch, "/api/settings", strings.NewReader(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	rec2 := httptest.NewRecorder()
+	mux.ServeHTTP(rec2, req2)
+
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("model-only patch status = %d, want 200; body = %s", rec2.Code, rec2.Body.String())
+	}
+	if got := h.Config.Providers.DefaultModel; got != "claude-opus-4" {
+		t.Errorf("default_model after model-only patch = %q, want %q", got, "claude-opus-4")
+	}
+	if h.Config.Providers.Default != "claude" {
+		t.Errorf("default provider changed by a model-only patch: got %q, want claude", h.Config.Providers.Default)
+	}
+	if _, ok := h.Config.Providers.Providers["claude"]; !ok {
+		t.Error("providers map wiped by a default_model-only patch")
+	}
 }
 
 // TestSettingsAppsPatchMerges verifies the per-instance merge: patching

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1266,6 +1266,15 @@ export const api = {
       body: JSON.stringify(patch),
     }),
 
+  /**
+   * Persist the fleet-wide provider defaults — the provider (and optionally
+   * the model) new agents inherit when none is given. A partial providers
+   * patch: the server leaves the per-provider `providers` map untouched, so
+   * this never clobbers per-provider command overrides.
+   */
+  setProviderDefaults: (patch: { default?: string; default_model?: string }) =>
+    api.updateSettings({ providers: patch }),
+
   /** First-run setup state: whether to show the wizard and where to resume. */
   getOnboardingState: () => request<OnboardingState>("/onboarding/state"),
   /** Persist wizard progress. Writes only the onboarding config section. */

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -33,8 +33,17 @@ const SIDEBAR_KEY = "mycel-sidebar-collapsed";
    transition. Honors prefers-reduced-motion. */
 function RouteTransition({ children }: { children: React.ReactNode }) {
   const location = useLocation();
-  const segments = location.pathname.split("/").filter(Boolean).slice(0, 1);
-  const key = "/" + segments.join("/");
+  // Transitions are keyed by the top-level section so navigating *within* a
+  // section (agent → agent, app → app) doesn't re-animate the whole page.
+  // Settings is the exception: its drill-downs (/settings/tools, …) are
+  // full sibling pages, not in-section detail. Keying them only by the
+  // "settings" segment collapsed them onto the Settings page's key, so the
+  // page-transition treated the drill-down as the same page. Keep two
+  // segments under /settings so each drill-down mounts and animates as the
+  // distinct page it is.
+  const parts = location.pathname.split("/").filter(Boolean);
+  const depth = parts[0] === "settings" ? 2 : 1;
+  const key = "/" + parts.slice(0, depth).join("/");
   return (
     <AnimatePresence mode="wait" initial={false}>
       <motion.div

--- a/web/src/components/ProviderDefaults.tsx
+++ b/web/src/components/ProviderDefaults.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion, useReducedMotion } from "framer-motion";
 import { api } from "../api/client";
 import type { ProviderInfo } from "../api/client";
@@ -78,6 +78,17 @@ export function ProviderDefaults({ providers }: { providers: ProviderInfo[] }) {
   // leaving them showing a choice that never persisted.
   const [committed, setCommitted] = useState<{ provider: string; model: string }>({ provider: "", model: "" });
 
+  // Guards against two async hazards on the PATCH path:
+  //  - `mounted`: never setState after unmount (a slow save resolving late).
+  //  - `saveGen`: request-generation counter so an older save that resolves
+  //    after a newer one can't clobber the newer result (out-of-order writes).
+  const mounted = useRef(true);
+  const saveGen = useRef(0);
+  useEffect(() => {
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  }, []);
+
   useEffect(() => {
     let alive = true;
     api
@@ -111,14 +122,21 @@ export function ProviderDefaults({ providers }: { providers: ProviderInfo[] }) {
 
   const persist = useCallback(
     async (next: { provider: string; model: string }) => {
+      const gen = ++saveGen.current;
+      // Only the newest in-flight save may touch state, and only while mounted.
+      const isStale = () => !mounted.current || gen !== saveGen.current;
       setSave("saving");
       setSaveError(null);
       try {
         await api.setProviderDefaults({ default: next.provider, default_model: next.model });
+        if (isStale()) return;
         setCommitted(next);
         setSave("saved");
-        setTimeout(() => setSave("idle"), 1800);
+        setTimeout(() => {
+          if (!isStale()) setSave("idle");
+        }, 1800);
       } catch (err) {
+        if (isStale()) return;
         // Revert to the last value that actually reached disk.
         setDefaultProvider(committed.provider);
         setDefaultModel(committed.model);

--- a/web/src/components/ProviderDefaults.tsx
+++ b/web/src/components/ProviderDefaults.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { api } from "../api/client";
+import type { ProviderInfo } from "../api/client";
+import { PROVIDER_LABELS } from "../views/readiness/readiness";
+
+/* ── ProviderDefaults ────────────────────────────────────────────────
+ *
+ * The fleet-wide defaults every new agent inherits: which provider it runs
+ * on, and which model that provider should use when none is given. Both
+ * persist to prefs.providers via PATCH /api/settings and reload live so the
+ * panel always reflects what is actually on disk.
+ *
+ * Model options come from the provider's own curated list (/api/providers →
+ * ProviderInfo.models). A model marked `available` is confirmed live from the
+ * provider CLI (auth verified); an unavailable one is a static fallback the
+ * user can still pick but which we label honestly as unverified.
+ *
+ * The host line (hostname · os/arch) is folded in here so the Tools &
+ * Providers manager answers "what am I running on?" without a separate page.
+ */
+
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+/** Strip noisy mDNS suffixes ("Foo.local" → "Foo") for the host readout. */
+function prettifyHost(h: string): string {
+  return h.replace(/\.(local|lan)$/i, "");
+}
+
+const SELECT_CLS =
+  "w-full px-2.5 py-1.5 text-[13px] rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:border-mycel-accent focus:ring-1 focus:ring-mycel-accent transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed";
+
+function SavePill({ state, error }: { state: SaveState; error: string | null }) {
+  if (state === "saving") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-[11px] text-mycel-muted" role="status">
+        <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="3" opacity="0.25" />
+          <path d="M21 12a9 9 0 00-9-9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+        </svg>
+        Saving…
+      </span>
+    );
+  }
+  if (state === "saved") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-[11px] text-mycel-success" role="status">
+        <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+        Saved
+      </span>
+    );
+  }
+  if (state === "error") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-[11px] text-mycel-error" role="alert">
+        <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M12 8v4M12 16h.01M10.3 3.9L1.8 18a2 2 0 001.7 3h17a2 2 0 001.7-3L13.7 3.9a2 2 0 00-3.4 0z" />
+        </svg>
+        {error ?? "Save failed"}
+      </span>
+    );
+  }
+  return null;
+}
+
+export function ProviderDefaults({ providers }: { providers: ProviderInfo[] }) {
+  const reduceMotion = useReducedMotion();
+  const [defaultProvider, setDefaultProvider] = useState<string>("");
+  const [defaultModel, setDefaultModel] = useState<string>("");
+  const [loaded, setLoaded] = useState(false);
+  const [save, setSave] = useState<SaveState>("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [host, setHost] = useState<{ hostname: string; os: string; arch: string } | null>(null);
+
+  // Last-known-good, so a failed PATCH reverts the pickers rather than
+  // leaving them showing a choice that never persisted.
+  const [committed, setCommitted] = useState<{ provider: string; model: string }>({ provider: "", model: "" });
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .getSettings()
+      .then((cfg) => {
+        if (!alive) return;
+        const p = cfg.providers?.default ?? "";
+        const m = cfg.providers?.default_model ?? "";
+        setDefaultProvider(p);
+        setDefaultModel(m);
+        setCommitted({ provider: p, model: m });
+        setLoaded(true);
+      })
+      .catch(() => {
+        if (alive) setLoaded(true); // degrade to empty selects rather than a stuck skeleton
+      });
+    api
+      .getSystemInfo()
+      .then((info) => { if (alive) setHost(info); })
+      .catch(() => { /* host line is optional */ });
+    return () => { alive = false; };
+  }, []);
+
+  const byName = useMemo(() => {
+    const m = new Map<string, ProviderInfo>();
+    for (const p of providers) m.set(p.name, p);
+    return m;
+  }, [providers]);
+
+  const models = useMemo(() => byName.get(defaultProvider)?.models ?? [], [byName, defaultProvider]);
+
+  const persist = useCallback(
+    async (next: { provider: string; model: string }) => {
+      setSave("saving");
+      setSaveError(null);
+      try {
+        await api.setProviderDefaults({ default: next.provider, default_model: next.model });
+        setCommitted(next);
+        setSave("saved");
+        setTimeout(() => setSave("idle"), 1800);
+      } catch (err) {
+        // Revert to the last value that actually reached disk.
+        setDefaultProvider(committed.provider);
+        setDefaultModel(committed.model);
+        setSaveError(err instanceof Error ? err.message : "Save failed");
+        setSave("error");
+      }
+    },
+    [committed],
+  );
+
+  const onProviderChange = (name: string) => {
+    // A model only makes sense for its own provider — if the previously
+    // selected model isn't offered by the new provider, drop it so we never
+    // persist a mismatched (provider, model) pair.
+    const nextModels = byName.get(name)?.models ?? [];
+    const keepModel = nextModels.some((m) => m.id === defaultModel) ? defaultModel : "";
+    setDefaultProvider(name);
+    setDefaultModel(keepModel);
+    void persist({ provider: name, model: keepModel });
+  };
+
+  const onModelChange = (id: string) => {
+    setDefaultModel(id);
+    void persist({ provider: defaultProvider, model: id });
+  };
+
+  return (
+    <motion.div
+      initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3, ease: [0.16, 1, 0.3, 1] }}
+      className="rounded-lg border border-mycel-border bg-mycel-surface p-4 mb-4"
+    >
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <div className="min-w-0">
+          <h3 className="text-[13px] font-semibold text-mycel-text">Fleet defaults</h3>
+          <p className="text-[11px] text-mycel-muted mt-0.5">Provider and model new agents inherit when none is set.</p>
+        </div>
+        <div className="shrink-0 min-h-[16px]">
+          <SavePill state={save} error={saveError} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="block">
+          <span className="block text-[11px] text-mycel-text-2 mb-1">Default provider</span>
+          <select
+            className={SELECT_CLS}
+            value={defaultProvider}
+            disabled={!loaded || providers.length === 0}
+            onChange={(e) => onProviderChange(e.target.value)}
+            aria-label="Default provider"
+          >
+            {providers.length === 0 && <option value="">No providers</option>}
+            {providers.map((p) => (
+              <option key={p.name} value={p.name}>
+                {PROVIDER_LABELS[p.name] ?? p.name}
+                {p.installed ? "" : " (not installed)"}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block">
+          <span className="block text-[11px] text-mycel-text-2 mb-1">Default model</span>
+          <select
+            className={SELECT_CLS}
+            value={defaultModel}
+            disabled={!loaded || models.length === 0}
+            onChange={(e) => onModelChange(e.target.value)}
+            aria-label="Default model"
+          >
+            <option value="">Provider default</option>
+            {models.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.id}
+                {m.available ? "" : " · unverified"}
+              </option>
+            ))}
+          </select>
+          <span className="block text-[10.5px] text-mycel-muted mt-1">
+            {models.length === 0
+              ? "This provider exposes no model list — its own default is used."
+              : "“Unverified” models are a static fallback (provider sign-in not confirmed)."}
+          </span>
+        </label>
+      </div>
+
+      {/* Host machine — folded in so the manager answers "what am I on?". */}
+      <div className="flex items-center gap-2 mt-3 pt-3 border-t border-mycel-border text-[11px] text-mycel-muted">
+        <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6} aria-hidden>
+          <rect x="3" y="4" width="18" height="12" rx="1.5" /><path strokeLinecap="round" d="M8 20h8M12 16v4" />
+        </svg>
+        {host?.hostname ? (
+          <span className="tabular-nums">
+            Running on <span className="text-mycel-text-2 font-medium">{prettifyHost(host.hostname)}</span> · {host.os}/{host.arch}
+          </span>
+        ) : (
+          <span>Resolving host machine…</span>
+        )}
+      </div>
+    </motion.div>
+  );
+}

--- a/web/src/components/__tests__/ProviderDefaults.test.tsx
+++ b/web/src/components/__tests__/ProviderDefaults.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * ProviderDefaults.test.tsx — the fleet-default provider/model picker must
+ * persist its choice via PATCH /api/settings under providers.default_model
+ * and reflect what is already on disk. This is the surface behind the
+ * "default model doesn't stick" report, so the persistence contract is
+ * pinned here.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ProviderDefaults } from "../ProviderDefaults";
+import type { ProviderInfo } from "../../api/client";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+}
+
+const providers: ProviderInfo[] = [
+  {
+    name: "claude", description: "", binary: "claude", command: "claude", install_hint: "",
+    version: "1.0", status: "healthy", installed: true, enabled: true,
+    total_cost_usd: 0, total_tokens: 0, agent_count: 0,
+    models: [{ id: "claude-sonnet-4", available: true }, { id: "claude-opus-4", available: false }],
+  },
+  {
+    name: "codex", description: "", binary: "codex", command: "codex", install_hint: "",
+    version: "", status: "not_installed", installed: false, enabled: false,
+    total_cost_usd: 0, total_tokens: 0, agent_count: 0, models: [],
+  },
+];
+
+const settingsBody = {
+  providers: { default: "claude", default_model: "", providers: { claude: { command: "claude" } } },
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+    const u = String(url);
+    if (u.endsWith("/api/settings") && init?.method === "PATCH") return jsonResponse(settingsBody);
+    if (u.endsWith("/api/settings")) return jsonResponse(settingsBody);
+    if (u.endsWith("/api/system/info")) return jsonResponse({ hostname: "test.local", os: "darwin", arch: "arm64" });
+    return jsonResponse({});
+  });
+});
+
+describe("ProviderDefaults", () => {
+  it("loads current defaults and the host line", async () => {
+    render(<ProviderDefaults providers={providers} />);
+    await waitFor(() => expect((screen.getByLabelText("Default provider") as HTMLSelectElement).value).toBe("claude"));
+    // mDNS suffix stripped, os/arch shown.
+    await waitFor(() => expect(screen.getByText(/darwin\/arm64/)).toBeTruthy());
+  });
+
+  it("persists a chosen default model via PATCH providers.default_model", async () => {
+    render(<ProviderDefaults providers={providers} />);
+    const modelSelect = await screen.findByLabelText("Default model");
+    await waitFor(() => expect((screen.getByLabelText("Default provider") as HTMLSelectElement).value).toBe("claude"));
+
+    fireEvent.change(modelSelect, { target: { value: "claude-sonnet-4" } });
+
+    await waitFor(() => {
+      const patch = fetchMock.mock.calls.find(
+        (c) => String(c[0]).endsWith("/api/settings") && (c[1] as RequestInit | undefined)?.method === "PATCH",
+      );
+      expect(patch).toBeTruthy();
+      const body = JSON.parse(String((patch![1] as RequestInit).body));
+      expect(body.providers.default).toBe("claude");
+      expect(body.providers.default_model).toBe("claude-sonnet-4");
+    });
+    await waitFor(() => expect(screen.getByText("Saved")).toBeTruthy());
+  });
+
+  it("drops a model that the newly-selected provider does not offer", async () => {
+    render(<ProviderDefaults providers={providers} />);
+    await waitFor(() => expect((screen.getByLabelText("Default provider") as HTMLSelectElement).value).toBe("claude"));
+    // Seed a model, then switch to codex (no models) — model must clear.
+    fireEvent.change(screen.getByLabelText("Default model"), { target: { value: "claude-opus-4" } });
+    fireEvent.change(screen.getByLabelText("Default provider"), { target: { value: "codex" } });
+
+    await waitFor(() => {
+      const patches = fetchMock.mock.calls.filter(
+        (c) => String(c[0]).endsWith("/api/settings") && (c[1] as RequestInit | undefined)?.method === "PATCH",
+      );
+      const last = JSON.parse(String((patches[patches.length - 1]![1] as RequestInit).body));
+      expect(last.providers.default).toBe("codex");
+      expect(last.providers.default_model).toBe("");
+    });
+  });
+});

--- a/web/src/components/__tests__/ProviderDefaults.test.tsx
+++ b/web/src/components/__tests__/ProviderDefaults.test.tsx
@@ -89,4 +89,34 @@ describe("ProviderDefaults", () => {
       expect(last.providers.default_model).toBe("");
     });
   });
+
+  it("shows the error state and reverts the selection when the PATCH fails", async () => {
+    // GET loads defaults (model ""); the PATCH rejects.
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/api/settings") && init?.method === "PATCH") {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          json: () => Promise.resolve({ error: "boom" }),
+        } as Response);
+      }
+      if (u.endsWith("/api/settings")) return jsonResponse(settingsBody);
+      if (u.endsWith("/api/system/info")) return jsonResponse({ hostname: "test.local", os: "darwin", arch: "arm64" });
+      return jsonResponse({});
+    });
+
+    render(<ProviderDefaults providers={providers} />);
+    const modelSelect = (await screen.findByLabelText("Default model")) as HTMLSelectElement;
+    await waitFor(() => expect((screen.getByLabelText("Default provider") as HTMLSelectElement).value).toBe("claude"));
+
+    // Pick a model that the failing PATCH would have persisted.
+    fireEvent.change(modelSelect, { target: { value: "claude-sonnet-4" } });
+
+    // Error surfaced with the server message …
+    await waitFor(() => expect(screen.getByText("boom")).toBeTruthy());
+    // … and the selection reverted to the last value that reached disk ("").
+    await waitFor(() => expect((screen.getByLabelText("Default model") as HTMLSelectElement).value).toBe(""));
+  });
 });

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -7,6 +7,7 @@ import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { ProvidersTable } from "../components/ProvidersTable";
+import { ProviderDefaults } from "../components/ProviderDefaults";
 import { CopyButton } from "../components/CopyButton";
 import { ToastContainer, useToast } from "../components/Toast";
 import type { ToastLevel } from "../components/Toast";
@@ -454,7 +455,13 @@ export function Tools() {
             onAction={() => navigate("/settings")}
           />
         ) : (
-          <ProvidersTable providers={providerList} search={search} />
+          <>
+            {/* Fleet-wide default provider + model — persists to
+                prefs.providers and reloads live. Rendered only once
+                provider data has arrived (never over a skeleton). */}
+            {providerList.length > 0 && <ProviderDefaults providers={providerList} />}
+            <ProvidersTable providers={providerList} search={search} />
+          </>
         )}
       </section>
 


### PR DESCRIPTION
Part of #2674 — Build 2 of the integrated Tools & Provider manager.

## The /settings/tools bug — root cause & fix
The owner reported `/settings/tools` showing **"0 Providers" with stuck loading skeletons** while `/tools` worked.

**Root cause:** it is *not* a routing/component split — both `/tools` and `/settings/tools` mount the same `<Tools/>` and, off a fresh build, render **identically** (verified live: 6 providers, no stuck skeleton, 0 console errors). The live `:8080` daemon was serving a **stale embedded web bundle** from before the route was pointed at `<Tools/>`.

**Hardening shipped anyway:** `RouteTransition` keyed the page-transition `AnimatePresence` by only the *first* path segment, collapsing `/settings` and its drill-downs (`/settings/tools`) onto one key — so the drill-down was treated as the same page as Settings. It now keys `/settings/*` by two segments, so each drill-down mounts and animates as its own page. This removes any chance of stale/duplicate-key content on that transition.

## What's fully working
- **Default provider + default model persistence (highest priority).** New `ProviderDefaults` panel atop the AI Model Providers section. Reads `prefs.providers.{default,default_model}`, persists via `PATCH /api/settings` (partial `providers` patch — server leaves the per-provider command map intact), and reloads live. Verified end-to-end on a throwaway daemon: selecting a model wrote `default_model=sonnet` to disk with a "Saved" pill.
- **Curated model list** from each provider's `/api/providers` `models`; static-fallback models labelled `· unverified` (honest — provider sign-in not confirmed).
- **Host machine line** (hostname · os/arch) folded into the manager via `/api/system/info`.
- Loading→Saved/Error feedback, revert-on-failure, reduced-motion-gated reveal, SVG-only icons, focus rings, theme-aware mushroom tokens (light + dark).

## Seamed / deferred (honest, no fake data)
- **Inline provider sign-in** (device-flow / API-key paste / CLI-login verify): the existing `ProviderDetail` page already surfaces install/update hints and MCP config; a first-class inline sign-in-with-live-verify flow is **not** built here. `available:false` models are labelled unverified rather than faking an auth state. `// follow-up:`
- **Per-provider plugins/MCP/subcommands mapping** surfaced in the manager: endpoints exist (`/providers/:name/{commands,mcps}`) and `ProviderDetail` consumes them; not folded into the new panel yet.
- **Tools & Dependencies install/update/uninstall via streamed `/api/deps/install`**: endpoint verified present and guarded (GET→405); the CLI-deps table already lists/toggles/removes tools, but wiring the streamed installer with live step progress into this surface is deferred.
- **Wizard `StepProviders` parity (#49):** the wizard is not yet pointed at the shared `ProviderDefaults` logic. Deferred to keep this PR focused on the Settings surface + persistence.

## Test plan
- `bunx tsc --noEmit` → clean
- `bun run lint` (eslint src) → clean
- `bun run build` → built
- `bunx vitest run` → **34 files, 300 tests pass** (incl. new `ProviderDefaults.test.tsx`: persist PATCH, load defaults + host, model-clear on provider switch)
- `go build ./...`, `go vet ./server/handlers/` → clean
- `golangci-lint run ./server/handlers/...` → 0 issues
- `go test ./server/handlers/ ./pkg/home/` → ok (new `TestSettingsPatchProviderDefaultModel`: `default_model` persists, provider map preserved)
- **Live smoke** (throwaway `MYCEL_HOME`, `127.0.0.1:8099`): `/settings/tools` shows 6 providers + defaults panel + host line; `PATCH /api/settings` default_model persists & survives reload; `/api/providers/claude/install`→200, `GET /api/deps/install`→405.

ui-ux-pro-max + frontend-design applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added settings for selecting the default provider and model.
  * Added host machine information to the provider settings area.
  * Added save status feedback and validation for unavailable models.
  * Provider defaults now appear above the provider list when available.

* **Bug Fixes**
  * Improved settings page transitions so drill-down pages animate independently.
  * Switching to a provider without models now clears incompatible model selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->