### PR TITLE
fix(web): /settings/tools remount loop + in-surface CLI install + wizard provider parity

### DIFF
--- a/server/handlers/deps_install.go
+++ b/server/handlers/deps_install.go
@@ -12,18 +12,30 @@ import (
 	"strings"
 
 	"github.com/rpuneet/mycel/pkg/provider"
+	"github.com/rpuneet/mycel/pkg/tool"
 )
 
 // DepsInstallHandler runs a single dependency's install command on the host
-// and streams its output back to the setup wizard as newline-delimited JSON.
+// and streams its output back to the UI as newline-delimited JSON.
 //
 // Security: this executes a shell command, so it is loopback-only (same
-// gate as the deps start/stop routes) and only ever runs commands from the
-// vetted table in installCommand — never arbitrary user input.
-type DepsInstallHandler struct{}
+// gate as the deps start/stop routes) and only ever runs commands sourced
+// from a vetted table (installCommand) or the persisted tools registry —
+// never a command supplied in the request body.
+type DepsInstallHandler struct {
+	tools *tool.Store
+}
 
 // NewDepsInstallHandler constructs a DepsInstallHandler.
 func NewDepsInstallHandler() *DepsInstallHandler { return &DepsInstallHandler{} }
+
+// SetToolStore wires the tools registry so registered CLI tools (gh, aws, …)
+// can be installed/updated from their stored install_cmd / upgrade_cmd. Nil
+// is fine — resolution then falls back to the vetted table only.
+func (h *DepsInstallHandler) SetToolStore(s *tool.Store) *DepsInstallHandler {
+	h.tools = s
+	return h
+}
 
 // Register mounts POST /api/deps/install. It is a more specific pattern than
 // the DepsHandler's "/api/deps/" prefix, so ServeMux routes it here.
@@ -31,10 +43,12 @@ func (h *DepsInstallHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/deps/install", h.install)
 }
 
-// depInstallRequest is the POST body: the readiness item id to install
-// ("git", "tmux", "claude", …).
+// depInstallRequest is the POST body: the readiness item / tool id to act on
+// ("git", "tmux", "claude", "gh", …) and the action ("install" or "update";
+// empty means install).
 type depInstallRequest struct {
-	ID string `json:"id"`
+	ID   string `json:"id"`
+	Mode string `json:"mode,omitempty"`
 }
 
 // installRunner builds the command that runs a resolved install line. It is
@@ -68,9 +82,13 @@ func (h *DepsInstallHandler) install(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	cmdLine, ok := installCommand(req.ID, runtime.GOOS)
+	cmdLine, ok := h.resolveCommand(r.Context(), req.ID, req.Mode)
 	if !ok {
-		httpError(w, "no automatic installer for "+req.ID, http.StatusBadRequest)
+		verb := "installer"
+		if req.Mode == "update" {
+			verb = "updater"
+		}
+		httpError(w, "no automatic "+verb+" for "+req.ID, http.StatusBadRequest)
 		return
 	}
 
@@ -142,6 +160,50 @@ func streamInstall(ctx context.Context, cmdLine string, emit func(any) bool) {
 		return
 	}
 	emit(map[string]any{"type": "done", "code": 0})
+}
+
+// resolveCommand picks the shell command to run for id + mode.
+//
+//   - update: prefer the registered tool's upgrade_cmd, then its install_cmd,
+//     then the vetted install table.
+//   - install (default): prefer the vetted install table, then the registered
+//     tool's install_cmd.
+//
+// Every command originates from a vetted source (the table or the persisted
+// tools registry), never from the request body.
+func (h *DepsInstallHandler) resolveCommand(ctx context.Context, id, mode string) (string, bool) {
+	if mode == "update" {
+		if t := h.lookupTool(ctx, id); t != nil {
+			if cmd := strings.TrimSpace(t.UpgradeCmd); cmd != "" {
+				return cmd, true
+			}
+			if cmd := strings.TrimSpace(t.InstallCmd); cmd != "" {
+				return cmd, true
+			}
+		}
+	}
+	if cmd, ok := installCommand(id, runtime.GOOS); ok {
+		return cmd, true
+	}
+	if t := h.lookupTool(ctx, id); t != nil {
+		if cmd := strings.TrimSpace(t.InstallCmd); cmd != "" {
+			return cmd, true
+		}
+	}
+	return "", false
+}
+
+// lookupTool returns the registered tool named id, or nil when the store is
+// absent or the tool is unknown.
+func (h *DepsInstallHandler) lookupTool(ctx context.Context, id string) *tool.Tool {
+	if h.tools == nil {
+		return nil
+	}
+	t, err := h.tools.Get(ctx, id)
+	if err != nil {
+		return nil
+	}
+	return t
 }
 
 // installCommand resolves a readiness item id to a runnable install command

--- a/server/handlers/deps_install_test.go
+++ b/server/handlers/deps_install_test.go
@@ -7,8 +7,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/rpuneet/mycel/pkg/db"
+	"github.com/rpuneet/mycel/pkg/tool"
 )
 
 func TestInstallCommand(t *testing.T) {
@@ -164,5 +168,78 @@ func TestDepsInstallLoopbackGuard(t *testing.T) {
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusForbidden {
 		t.Errorf("status = %d, want 403 for a non-loopback caller", rec.Code)
+	}
+}
+
+// resolveTestStore returns an open tools store seeded with one registered CLI
+// tool that carries both an install and an upgrade command.
+func resolveTestStore(t *testing.T) *tool.Store {
+	t.Helper()
+	d, err := db.Open(filepath.Join(t.TempDir(), "mycel.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	s := tool.NewStore(d, "sqlite")
+	if err := s.Open(); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	if err := s.Add(context.Background(), &tool.Tool{
+		Name:       "acmecli",
+		Type:       tool.ToolTypeCLI,
+		Command:    "acmecli",
+		InstallCmd: "brew install acmecli",
+		UpgradeCmd: "brew upgrade acmecli",
+		Enabled:    true,
+	}); err != nil {
+		t.Fatalf("seed tool: %v", err)
+	}
+	return s
+}
+
+func TestResolveCommand(t *testing.T) {
+	h := NewDepsInstallHandler().SetToolStore(resolveTestStore(t))
+	ctx := context.Background()
+
+	tests := []struct {
+		name, id, mode, want string
+		wantOK               bool
+	}{
+		// Vetted table still wins for install of a table item.
+		{"vetted git install", "git", "install", "", true},
+		// Registered CLI tool: install uses install_cmd (not in the table).
+		{"tool install_cmd", "acmecli", "install", "brew install acmecli", true},
+		// Registered CLI tool: update prefers upgrade_cmd.
+		{"tool upgrade_cmd", "acmecli", "update", "brew upgrade acmecli", true},
+		// Unknown id with no installer.
+		{"unknown", "nonesuch", "install", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := h.resolveCommand(ctx, tt.id, tt.mode)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v (got %q)", ok, tt.wantOK, got)
+			}
+			// For the git case we only assert non-empty (the exact line is
+			// OS-dependent and covered by TestInstallCommand).
+			if tt.want != "" && got != tt.want {
+				t.Errorf("cmd = %q, want %q", got, tt.want)
+			}
+			if tt.wantOK && got == "" {
+				t.Errorf("expected a non-empty command for %q", tt.id)
+			}
+		})
+	}
+}
+
+// A nil tool store must degrade to the vetted table only, never panic.
+func TestResolveCommandNilStore(t *testing.T) {
+	h := NewDepsInstallHandler()
+	if _, ok := h.resolveCommand(context.Background(), "gh", "install"); ok {
+		t.Error("expected no installer for gh without a tool store")
+	}
+	if _, ok := h.resolveCommand(context.Background(), "git", "install"); !ok {
+		t.Error("expected the vetted git installer to still resolve")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -379,9 +379,10 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	// Always registered so the UI can render an empty list when no deps
 	// are configured; the handler is nil-safe internally.
 	handlers.NewDepsHandler(svc.Deps).Register(mux)
-	// Streamed host-dependency installer used by the setup wizard. Loopback
-	// only; runs vetted install commands and streams their output.
-	handlers.NewDepsInstallHandler().Register(mux)
+	// Streamed host-dependency installer used by the setup wizard and the
+	// Tools page. Loopback only; runs vetted install/upgrade commands (from
+	// the table or the tools registry) and streams their output.
+	handlers.NewDepsInstallHandler().SetToolStore(svc.Tools).Register(mux)
 	// Per-repo cost rollup. Handler is nil-safe and returns 503 when the
 	// global ledger isn't wired.
 	mux.Handle("/api/global/costs", handlers.NewGlobalCostsHandler(svc.Costs))

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -64,6 +64,18 @@ function LegacyNotificationsRedirect() {
   return <Navigate to={source ? `/apps/${source}` : "/apps"} replace />;
 }
 
+/**
+ * The Settings "Providers & Tools" drill-down now resolves to the proven
+ * flat /tools routes. Mounting the Tools view under a nested /settings/tools
+ * path caused a remount loop that hammered /api/providers + /api/tools/unified
+ * and left the page stuck on skeletons; the flat /tools route renders cleanly.
+ * These redirects preserve any deep-linked :provider param.
+ */
+function SettingsProviderRedirect() {
+  const { provider } = useParams();
+  return <Navigate to={provider ? `/tools/${provider}` : "/tools"} replace />;
+}
+
 function NotFound() {
   return (
     <div className="flex-1 flex flex-col items-center justify-center p-6">
@@ -110,13 +122,14 @@ export function AppRoutes() {
         <Route path="marketplace" element={wrap(<Marketplace />)} />
         <Route path="tools" element={wrap(<Tools />)} />
         <Route path="tools/:provider" element={wrap(<ProviderDetail />)} />
-        {/* Tools/Providers are now reached FROM Settings (Settings is the
-            config hub). Mounted under /settings/* so the IA reads as a
-            drill-down; the flat /tools routes stay for deep links. */}
-        <Route path="settings/tools" element={wrap(<Tools />)} />
-        <Route path="settings/tools/:provider" element={wrap(<ProviderDetail />)} />
-        <Route path="settings/providers" element={<Navigate to="/settings/tools" replace />} />
-        <Route path="providers" element={<Navigate to="/settings/tools" replace />} />
+        {/* Tools/Providers are reached FROM Settings, but the drill-down
+            resolves to the flat /tools route — the proven single mount. The
+            nested /settings/tools mount remounted in a loop and never settled,
+            so every entry point redirects to /tools. */}
+        <Route path="settings/tools" element={<Navigate to="/tools" replace />} />
+        <Route path="settings/tools/:provider" element={<SettingsProviderRedirect />} />
+        <Route path="settings/providers" element={<Navigate to="/tools" replace />} />
+        <Route path="providers" element={<Navigate to="/tools" replace />} />
         {/* Secrets became the Custom Keys section on the Apps home. */}
         <Route path="secrets" element={<Navigate to="/apps#custom-keys" replace />} />
         <Route path="insights" element={wrap(<Insights />)} />

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -35,15 +35,12 @@ function RouteTransition({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   // Transitions are keyed by the top-level section so navigating *within* a
   // section (agent → agent, app → app) doesn't re-animate the whole page.
-  // Settings is the exception: its drill-downs (/settings/tools, …) are
-  // full sibling pages, not in-section detail. Keying them only by the
-  // "settings" segment collapsed them onto the Settings page's key, so the
-  // page-transition treated the drill-down as the same page. Keep two
-  // segments under /settings so each drill-down mounts and animates as the
-  // distinct page it is.
+  // Settings has no in-app drill-downs anymore — Providers & Tools resolve to
+  // the flat /tools route — so first-segment keying is correct for every
+  // page. (An earlier 2-segment /settings special case fed the nested
+  // /settings/tools mount an unstable key and contributed to a remount loop.)
   const parts = location.pathname.split("/").filter(Boolean);
-  const depth = parts[0] === "settings" ? 2 : 1;
-  const key = "/" + parts.slice(0, depth).join("/");
+  const key = "/" + (parts[0] ?? "");
   return (
     <AnimatePresence mode="wait" initial={false}>
       <motion.div

--- a/web/src/components/ProviderDefaults.tsx
+++ b/web/src/components/ProviderDefaults.tsx
@@ -65,7 +65,19 @@ function SavePill({ state, error }: { state: SaveState; error: string | null }) 
   return null;
 }
 
-export function ProviderDefaults({ providers }: { providers: ProviderInfo[] }) {
+export function ProviderDefaults({
+  providers,
+  onChange,
+  showHost = true,
+}: {
+  providers: ProviderInfo[];
+  /** Notified after a successful persist — lets a host (e.g. the setup
+   *  wizard) mirror the fleet default into its own draft/summary. */
+  onChange?: (next: { provider: string; model: string }) => void;
+  /** The host readout is folded in on the Tools page; the wizard hides it
+   *  (its System step already covers the machine). */
+  showHost?: boolean;
+}) {
   const reduceMotion = useReducedMotion();
   const [defaultProvider, setDefaultProvider] = useState<string>("");
   const [defaultModel, setDefaultModel] = useState<string>("");
@@ -131,6 +143,7 @@ export function ProviderDefaults({ providers }: { providers: ProviderInfo[] }) {
         await api.setProviderDefaults({ default: next.provider, default_model: next.model });
         if (isStale()) return;
         setCommitted(next);
+        onChange?.(next);
         setSave("saved");
         setTimeout(() => {
           if (!isStale()) setSave("idle");
@@ -144,7 +157,7 @@ export function ProviderDefaults({ providers }: { providers: ProviderInfo[] }) {
         setSave("error");
       }
     },
-    [committed],
+    [committed, onChange],
   );
 
   const onProviderChange = (name: string) => {
@@ -226,6 +239,7 @@ export function ProviderDefaults({ providers }: { providers: ProviderInfo[] }) {
       </div>
 
       {/* Host machine — folded in so the manager answers "what am I on?". */}
+      {showHost && (
       <div className="flex items-center gap-2 mt-3 pt-3 border-t border-mycel-border text-[11px] text-mycel-muted">
         <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6} aria-hidden>
           <rect x="3" y="4" width="18" height="12" rx="1.5" /><path strokeLinecap="round" d="M8 20h8M12 16v4" />
@@ -238,6 +252,7 @@ export function ProviderDefaults({ providers }: { providers: ProviderInfo[] }) {
           <span>Resolving host machine…</span>
         )}
       </div>
+      )}
     </motion.div>
   );
 }

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -304,7 +304,7 @@ function ProvidersToolsCard({ data }: { data: Record<string, unknown> }) {
   return (
     <div className="space-y-2.5">
       <LinkCard
-        to="/settings/tools"
+        to="/tools"
         ariaLabel="Open Tools & Providers"
         icon={<path strokeLinecap="round" strokeLinejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />}
         title={`Default: ${PROVIDER_LABELS[defaultProvider] ?? defaultProvider}${counts}`}

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { api } from "../api/client";
 import type { Tool } from "../api/client";
+import { installDep } from "../wizard/installStream";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
@@ -44,9 +45,158 @@ function ChevronIcon({ expanded }: { expanded: boolean }) {
   );
 }
 
-function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, onExpand }: {
+/* ── In-surface install / update ──────────────────────────────────────
+ *
+ * Streams a CLI tool's install (or update) command over POST /api/deps/install
+ * — the same loopback-guarded NDJSON stream the setup wizard uses — into a
+ * live console with an honest running → success/error progression. The stream
+ * carries no percentage, so progress is an indeterminate bar while running and
+ * a resolved (green/red) bar on completion; the line count is the concrete
+ * "how far along" signal. */
+type RunState = "idle" | "running" | "ok" | "error";
+
+function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) {
+  const reduceMotion = useReducedMotion();
+  const [state, setState] = useState<RunState>("idle");
+  const [lines, setLines] = useState<string[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const consoleRef = useRef<HTMLDivElement>(null);
+  const runningRef = useRef(false);
+
+  const isInstalled = tool.status !== "not_installed";
+  const mode: "install" | "update" = isInstalled ? "update" : "install";
+  const canRun = mode === "install"
+    ? Boolean(tool.install_cmd)
+    : Boolean(tool.upgrade_cmd || tool.install_cmd);
+
+  useEffect(() => {
+    const el = consoleRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines]);
+
+  // Guard against setState after unmount when a slow stream resolves late.
+  useEffect(() => () => { runningRef.current = false; }, []);
+
+  const run = async () => {
+    setState("running");
+    setLines([]);
+    setErr(null);
+    runningRef.current = true;
+    try {
+      const code = await installDep(
+        tool.name,
+        (ev) => {
+          if (!runningRef.current) return;
+          if (ev.type === "start") setLines((l) => [...l, `$ ${ev.command}`]);
+          else if (ev.type === "log") setLines((l) => [...l, ev.line]);
+        },
+        { mode },
+      );
+      if (!runningRef.current) return;
+      if (code === 0) {
+        setState("ok");
+        onDone();
+      } else {
+        setState("error");
+        setErr(`${mode === "update" ? "Update" : "Install"} exited with code ${code}.`);
+      }
+    } catch (e) {
+      if (!runningRef.current) return;
+      setState("error");
+      setErr(e instanceof Error ? e.message : `${mode} failed.`);
+    } finally {
+      runningRef.current = false;
+    }
+  };
+
+  const label = mode === "update" ? "Update" : "Install";
+  const barTone = state === "ok" ? "bg-mycel-success" : state === "error" ? "bg-mycel-error" : "bg-mycel-accent";
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        {canRun ? (
+          <button
+            type="button"
+            onClick={() => void run()}
+            disabled={state === "running"}
+            className="inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-1 rounded-md border border-mycel-accent bg-mycel-accent-subtle text-mycel-accent hover:bg-mycel-accent hover:text-mycel-accent-fg transition-colors disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-mycel-accent"
+          >
+            {state === "running" && <Spinner />}
+            {state === "running"
+              ? `${label === "Update" ? "Updating" : "Installing"}…`
+              : state === "ok"
+                ? `${label} again`
+                : state === "error"
+                  ? `Retry ${label.toLowerCase()}`
+                  : label}
+          </button>
+        ) : (
+          <span className="inline-flex items-center gap-1.5 text-[11px] text-mycel-muted">
+            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" aria-hidden>
+              <circle cx="7" cy="7" r="5.5" />
+              <path d="M7 4.5v.01M6 6.5h1v3h1" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            No automatic {mode === "update" ? "updater" : "installer"} — copy the command above to run it yourself.
+          </span>
+        )}
+        {state === "ok" && (
+          <span className="inline-flex items-center gap-1 text-[11px] text-mycel-success" role="status">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M20 6L9 17l-5-5" />
+            </svg>
+            {mode === "update" ? "Updated" : "Installed"}. Re-checking…
+          </span>
+        )}
+        {state === "error" && err && (
+          <span className="inline-flex items-center gap-1 text-[11px] text-mycel-error" role="alert">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+              <path d="M12 8v4M12 16h.01M10.3 3.9L1.8 18a2 2 0 001.7 3h17a2 2 0 001.7-3L13.7 3.9a2 2 0 00-3.4 0z" />
+            </svg>
+            <span className="truncate max-w-xs">{err}</span>
+          </span>
+        )}
+      </div>
+
+      {(state === "running" || state === "ok" || state === "error") && (
+        <div className="space-y-1.5">
+          {/* Progress: indeterminate while running (honest — the stream has no
+              percent), resolved to a full green/red bar on completion. */}
+          <div className="h-1 rounded-full bg-mycel-border overflow-hidden" role="progressbar" aria-label={`${label} progress`} aria-busy={state === "running"}>
+            {state === "running" ? (
+              <div
+                className={`h-full w-1/3 rounded-full ${barTone} ${reduceMotion ? "" : "animate-indeterminate"}`}
+              />
+            ) : (
+              <div className={`h-full w-full rounded-full ${barTone}`} />
+            )}
+          </div>
+          {lines.length > 0 && (
+            <div
+              ref={consoleRef}
+              className="max-h-40 overflow-auto rounded-md border border-mycel-border bg-mycel-bg px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-mycel-text-2 whitespace-pre-wrap"
+            >
+              {lines.map((l, i) => (
+                <div key={i} className={l.startsWith("$ ") ? "text-mycel-accent" : ""}>
+                  {l}
+                </div>
+              ))}
+              {state === "running" && <div className="text-mycel-muted">▍</div>}
+            </div>
+          )}
+          <div className="text-[10.5px] text-mycel-muted tabular-nums">
+            {state === "running" ? `${lines.length} line${lines.length === 1 ? "" : "s"}…` : `${lines.length} line${lines.length === 1 ? "" : "s"}`}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, onExpand, onChanged }: {
   tool: Tool; onToggle: () => void; onRemove: () => void;
   toggling: boolean; removing: boolean; expanded: boolean; onExpand: () => void;
+  onChanged: () => void;
 }) {
   const [confirmRemove, setConfirmRemove] = useState(false);
   const cfg = getStatusConfig(tool.status);
@@ -116,7 +266,9 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
                 transition={{ duration: 0.2, ease: "easeOut" }}
                 className="overflow-hidden bg-mycel-surface"
               >
-                <div className="px-8 py-3 space-y-2">
+                <div className="px-8 py-3 space-y-3">
+                  {/* In-surface install / update — streamed, loopback-guarded. */}
+                  <CLIInstallAction tool={tool} onDone={onChanged} />
                   {tool.install_cmd && (
                     <div className="flex items-center gap-2">
                       <span className="text-xs text-mycel-muted shrink-0">Install:</span>
@@ -509,6 +661,7 @@ export function Tools() {
                     onRemove={() => void handleRemove(t)}
                     toggling={togglingSet.has(t.name)}
                     removing={removingSet.has(t.name)}
+                    onChanged={() => { setCheckedTools(null); refresh(); }}
                   />
                 ))}
               </tbody>

--- a/web/src/views/__tests__/settings.test.tsx
+++ b/web/src/views/__tests__/settings.test.tsx
@@ -81,10 +81,10 @@ describe("Settings redesign", () => {
     expect(screen.getByRole("link", { name: /Manage apps/i })).toBeInTheDocument();
   });
 
-  it("Tools & Providers card drills down under /settings", async () => {
+  it("Tools & Providers card links to the flat /tools page", async () => {
     mockApi();
     renderSettings();
-    expect(await screen.findByRole("link", { name: /Open Tools & Providers/i })).toHaveAttribute("href", "/settings/tools");
+    expect(await screen.findByRole("link", { name: /Open Tools & Providers/i })).toHaveAttribute("href", "/tools");
   });
 
   it("reads onboarding state into the Setup section", async () => {

--- a/web/src/views/__tests__/settingsToolsRedirect.test.tsx
+++ b/web/src/views/__tests__/settingsToolsRedirect.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The Settings "Providers & Tools" drill-down resolves to the flat /tools
+ * route. The nested /settings/tools mount remounted in a loop and never
+ * settled; every entry point now redirects to the proven /tools view.
+ *   /settings/tools            → /tools
+ *   /settings/tools/<provider> → /tools/<provider>
+ *   /settings/providers        → /tools
+ *   /providers                 → /tools
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { AppRoutes } from "../../App";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+let lastLocation = "";
+function LocationSpy() {
+  const loc = useLocation();
+  lastLocation = loc.pathname + loc.hash;
+  return null;
+}
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <LocationSpy />
+      <AppRoutes />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockReturnValue(jsonResponse([]));
+  lastLocation = "";
+});
+
+describe("Settings tools redirects", () => {
+  it("/settings/tools lands on the flat /tools page", async () => {
+    renderAt("/settings/tools");
+    await waitFor(() => {
+      expect(lastLocation).toBe("/tools");
+    });
+  });
+
+  it("/settings/tools/<provider> preserves the provider in the redirect", async () => {
+    renderAt("/settings/tools/claude");
+    await waitFor(() => {
+      expect(lastLocation).toBe("/tools/claude");
+    });
+  });
+
+  it("/settings/providers redirects to /tools", async () => {
+    renderAt("/settings/providers");
+    await waitFor(() => {
+      expect(lastLocation).toBe("/tools");
+    });
+  });
+
+  it("/providers redirects to /tools", async () => {
+    renderAt("/providers");
+    await waitFor(() => {
+      expect(lastLocation).toBe("/tools");
+    });
+  });
+});

--- a/web/src/wizard/installStream.ts
+++ b/web/src/wizard/installStream.ts
@@ -13,21 +13,24 @@ export type InstallEvent =
   | { type: "error"; error: string };
 
 /**
- * installDep streams the install of one readiness item (git, tmux, a
- * provider CLI…). It calls onEvent for every record and resolves with the
- * process exit code (0 = success). Throws on transport errors or an
- * explicit error event.
+ * installDep streams the install (or update) of one readiness item / tool
+ * (git, tmux, a provider CLI, a registered CLI tool…). It calls onEvent for
+ * every record and resolves with the process exit code (0 = success). Throws
+ * on transport errors or an explicit error event.
+ *
+ * mode "update" runs the tool's upgrade command when the registry defines
+ * one; it falls back to the install command otherwise.
  */
 export async function installDep(
   id: string,
   onEvent: (ev: InstallEvent) => void,
-  signal?: AbortSignal,
+  opts?: { signal?: AbortSignal; mode?: "install" | "update" },
 ): Promise<number> {
   const res = await fetch("/api/deps/install", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ id }),
-    signal,
+    body: JSON.stringify({ id, mode: opts?.mode ?? "install" }),
+    signal: opts?.signal,
   });
 
   if (!res.ok || !res.body) {

--- a/web/src/wizard/steps/StepProviders.tsx
+++ b/web/src/wizard/steps/StepProviders.tsx
@@ -1,15 +1,22 @@
 import { useEffect, useState } from "react";
-import { api, type ModelInfo, type ProviderInfo } from "../../api/client";
+import { api, type ProviderInfo } from "../../api/client";
 import { useReadiness } from "../../hooks/useReadiness";
 import { PROVIDER_LABELS, PROVIDER_NAMES } from "../../views/readiness/readiness";
+import { ProviderDefaults } from "../../components/ProviderDefaults";
+import { AdvancedToggle } from "../../settings/controls";
 import { InstallButton } from "../InstallButton";
 import { WizardFooter } from "../WizardFooter";
 import type { StepProps } from "../types";
 
-/* Step 3 — Providers & sign-in. Pick an agent tool, install it (reusing the
- * streamed installer), optionally store its API key in the vault, and set it
- * as the default provider. Cursor's install is a download page, so it shows
- * guidance instead of a button. */
+/* Step 3 — Providers & sign-in. The fleet default (provider + model) is set
+ * through the SAME <ProviderDefaults> control the /tools page ships, so the
+ * wizard and the ongoing manager never drift. Everything else — installing
+ * other tools, a per-provider command override, and stashing an API key in
+ * the vault — lives behind an Advanced expander.
+ *
+ * Provider OAuth sign-in is intentionally deferred (owner decision pending),
+ * so the honest paths are the CLI's own login or an API key in the vault; the
+ * model list still labels unverified models as such. */
 
 const CURSOR = "cursor";
 
@@ -26,53 +33,63 @@ function secretNameFor(provider: string): string {
 
 export function StepProviders({ nav, draft, setDraft, settings, reloadSettings }: StepProps) {
   const { data, refresh } = useReadiness();
-  const [selected, setSelected] = useState(draft.provider || settings?.providers?.default || "claude");
-  const [models, setModels] = useState<Record<string, ModelInfo[]>>({});
-  const [model, setModel] = useState(draft.model);
+  const [providers, setProviders] = useState<ProviderInfo[]>([]);
+  const [advanced, setAdvanced] = useState(false);
+  // The provider the Advanced install / config controls target. Seeded from
+  // the current default; changing the fleet default re-points it.
+  const [focus, setFocus] = useState(draft.provider || settings?.providers?.default || "claude");
+  const [command, setCommand] = useState("");
   const [apiKey, setApiKey] = useState("");
-  const [saving, setSaving] = useState(false);
   const [keySaved, setKeySaved] = useState(false);
+  const [saving, setSaving] = useState(false);
 
   useEffect(() => {
     api
       .listProviders()
-      .then((list: ProviderInfo[]) => {
-        const map: Record<string, ModelInfo[]> = {};
-        for (const p of list) if (p.models) map[p.name] = p.models;
-        setModels(map);
-      })
-      .catch(() => {
-        /* model pickers stay empty; provider default still works */
-      });
+      .then(setProviders)
+      .catch(() => setProviders([]));
   }, []);
 
-  const installed = data?.providers ?? {};
-  const selModels = models[selected] ?? [];
-  const selInstalled = installed[selected];
+  // Seed the command override from prefs whenever the focused provider changes.
+  useEffect(() => {
+    setCommand(settings?.providers?.providers?.[focus]?.command ?? "");
+    setApiKey("");
+    setKeySaved(false);
+  }, [focus, settings]);
 
-  const persist = async () => {
-    setSaving(true);
-    setDraft({ provider: selected, model });
-    try {
-      if (apiKey.trim()) {
-        const name = secretNameFor(selected);
-        try {
-          await api.createSecret(name, apiKey.trim(), `${PROVIDER_LABELS[selected] ?? selected} API key`);
-        } catch {
-          // Already exists → update instead.
-          await api.updateSecret(name, apiKey.trim());
-        }
-        setKeySaved(true);
+  const installed = data?.providers ?? {};
+  const focusInstalled = installed[focus];
+
+  // Persist the focused provider's API key (vault) and command override
+  // (prefs) — merged so we never clobber other providers' overrides.
+  const persistFocused = async () => {
+    if (apiKey.trim()) {
+      const name = secretNameFor(focus);
+      try {
+        await api.createSecret(name, apiKey.trim(), `${PROVIDER_LABELS[focus] ?? focus} API key`);
+      } catch {
+        await api.updateSecret(name, apiKey.trim());
       }
+      setKeySaved(true);
+    }
+    const existing = settings?.providers?.providers ?? {};
+    const current = existing[focus]?.command ?? "";
+    if (command.trim() !== current) {
       await api.updateSettings({
         providers: {
-          default: selected,
-          providers: settings?.providers?.providers ?? {},
+          providers: { ...existing, [focus]: { command: command.trim() } },
         },
       });
+    }
+  };
+
+  const onContinue = async () => {
+    setSaving(true);
+    try {
+      await persistFocused();
       await reloadSettings();
     } catch {
-      /* skippable/resumable */
+      /* skippable/resumable — the fleet default already persisted live */
     } finally {
       setSaving(false);
       nav.next();
@@ -82,104 +99,120 @@ export function StepProviders({ nav, draft, setDraft, settings, reloadSettings }
   return (
     <div className="flex flex-col gap-5">
       <p className="text-[14px] leading-relaxed text-mycel-text-2 max-w-prose">
-        An agent tool is the CLI that actually drives a model (Claude Code, Codex, …). Pick your
-        default — you can add more later and switch per agent.
+        An agent tool is the CLI that actually drives a model (Claude Code, Codex, …). Set your
+        fleet default below — every new agent inherits it. You can add more and switch per agent.
       </p>
 
-      <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
-        {PROVIDER_NAMES.map((name) => {
-          const active = selected === name;
-          const isInstalled = installed[name];
-          return (
-            <button
-              key={name}
-              type="button"
-              onClick={() => {
-                setSelected(name);
-                setModel("");
-              }}
-              aria-pressed={active}
-              className={`flex items-center justify-between gap-2 px-3 py-2.5 rounded-lg border text-left transition-colors ${
-                active ? "border-mycel-accent bg-mycel-accent-subtle" : "border-mycel-border bg-mycel-surface hover:border-mycel-accent"
-              }`}
-            >
-              <span className="text-[13px] font-medium text-mycel-text truncate">
-                {PROVIDER_LABELS[name] ?? name}
+      {/* Fleet default provider + model — the shared control, persisted live
+          to prefs.providers via PATCH /api/settings. The host readout is
+          hidden here (the System step already covers the machine). */}
+      <ProviderDefaults
+        providers={providers}
+        showHost={false}
+        onChange={({ provider, model }) => {
+          setDraft({ provider, model });
+          setFocus(provider);
+        }}
+      />
+
+      <div className="flex flex-col gap-3">
+        <AdvancedToggle open={advanced} onToggle={() => setAdvanced((v) => !v)} label="More tools & keys" />
+        {advanced && (
+          <div className="rounded-lg border border-mycel-border bg-mycel-surface p-4 flex flex-col gap-4">
+            <p className="text-[12px] text-mycel-muted">
+              Install another tool, override its command, or stash an API key. Pick the tool to
+              configure — this doesn&apos;t change your default.
+            </p>
+
+            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+              {PROVIDER_NAMES.map((name) => {
+                const active = focus === name;
+                const isInstalled = installed[name];
+                return (
+                  <button
+                    key={name}
+                    type="button"
+                    onClick={() => setFocus(name)}
+                    aria-pressed={active}
+                    className={`flex items-center justify-between gap-2 px-3 py-2.5 rounded-lg border text-left transition-colors ${
+                      active
+                        ? "border-mycel-accent bg-mycel-accent-subtle"
+                        : "border-mycel-border bg-mycel-bg hover:border-mycel-accent"
+                    }`}
+                  >
+                    <span className="text-[13px] font-medium text-mycel-text truncate">
+                      {PROVIDER_LABELS[name] ?? name}
+                    </span>
+                    <span
+                      className={`shrink-0 w-1.5 h-1.5 rounded-full ${isInstalled ? "bg-mycel-success" : "bg-mycel-muted"}`}
+                      title={isInstalled ? "Installed" : "Not installed"}
+                      aria-hidden
+                    />
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[13px] font-semibold text-mycel-text">{PROVIDER_LABELS[focus] ?? focus}</span>
+              <span className={`inline-flex items-center gap-1.5 text-[11px] ${focusInstalled ? "text-mycel-success" : "text-mycel-warning"}`}>
+                <span className={`w-1.5 h-1.5 rounded-full ${focusInstalled ? "bg-mycel-success" : "bg-mycel-warning"}`} aria-hidden />
+                {focusInstalled ? "Installed" : "Not installed"}
               </span>
-              <span
-                className={`shrink-0 w-1.5 h-1.5 rounded-full ${isInstalled ? "bg-mycel-success" : "bg-mycel-muted"}`}
-                title={isInstalled ? "Installed" : "Not installed"}
-                aria-hidden
-              />
-            </button>
-          );
-        })}
-      </div>
+            </div>
 
-      <div className="rounded-lg border border-mycel-border bg-mycel-surface p-4 flex flex-col gap-4">
-        <div className="flex items-center justify-between gap-2">
-          <span className="text-[13px] font-semibold text-mycel-text">{PROVIDER_LABELS[selected] ?? selected}</span>
-          <span className={`text-[11px] ${selInstalled ? "text-mycel-success" : "text-mycel-warning"}`}>
-            {selInstalled ? "Installed" : "Not installed"}
-          </span>
-        </div>
-
-        {!selInstalled &&
-          (selected === CURSOR ? (
-            <a
-              href="https://cursor.sh"
-              target="_blank"
-              rel="noreferrer"
-              className="self-start text-[12px] px-2.5 py-1 rounded-md border border-mycel-accent text-mycel-accent hover:bg-mycel-accent-subtle transition-colors"
-            >
-              Download Cursor ↗
-            </a>
-          ) : (
-            <InstallButton id={selected} label={PROVIDER_LABELS[selected] ?? selected} onDone={() => void refresh()} />
-          ))}
-
-        {selModels.length > 0 && (
-          <label className="flex flex-col gap-1">
-            <span className="text-[12px] text-mycel-text-2">Default model</span>
-            <select
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-              className="w-full max-w-xs bg-mycel-bg border border-mycel-border rounded-md px-2 py-1.5 text-[13px] text-mycel-text outline-none focus:border-mycel-accent"
-            >
-              <option value="">Provider default</option>
-              {selModels.map((m) => (
-                <option key={m.id} value={m.id}>
-                  {m.id}
-                  {m.available ? "" : " (unverified)"}
-                </option>
+            {!focusInstalled &&
+              (focus === CURSOR ? (
+                <a
+                  href="https://cursor.sh"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="self-start text-[12px] px-2.5 py-1 rounded-md border border-mycel-accent text-mycel-accent hover:bg-mycel-accent-subtle transition-colors"
+                >
+                  Download Cursor ↗
+                </a>
+              ) : (
+                <InstallButton id={focus} label={PROVIDER_LABELS[focus] ?? focus} onDone={() => void refresh()} />
               ))}
-            </select>
-          </label>
-        )}
 
-        <label className="flex flex-col gap-1">
-          <span className="text-[12px] text-mycel-text-2">
-            API key <span className="text-mycel-muted">(optional — stored encrypted in the vault)</span>
-          </span>
-          <input
-            type="password"
-            value={apiKey}
-            onChange={(e) => {
-              setApiKey(e.target.value);
-              setKeySaved(false);
-            }}
-            placeholder={secretNameFor(selected)}
-            className="w-full max-w-sm bg-mycel-bg border border-mycel-border rounded-md px-2.5 py-1.5 text-[13px] text-mycel-text font-mono outline-none focus:border-mycel-accent"
-          />
-          <span className="text-[11px] text-mycel-muted">
-            {keySaved
-              ? "Saved to the vault."
-              : `Or run \`${selected}\` once in a terminal to sign in with the CLI.`}
-          </span>
-        </label>
+            <label className="flex flex-col gap-1">
+              <span className="text-[12px] text-mycel-text-2">
+                Command override <span className="text-mycel-muted">(optional — defaults to the tool&apos;s own binary)</span>
+              </span>
+              <input
+                type="text"
+                value={command}
+                onChange={(e) => setCommand(e.target.value)}
+                placeholder={focus}
+                className="w-full max-w-sm bg-mycel-bg border border-mycel-border rounded-md px-2.5 py-1.5 text-[13px] text-mycel-text font-mono outline-none focus:border-mycel-accent"
+              />
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-[12px] text-mycel-text-2">
+                API key <span className="text-mycel-muted">(optional — stored encrypted in the vault)</span>
+              </span>
+              <input
+                type="password"
+                value={apiKey}
+                onChange={(e) => {
+                  setApiKey(e.target.value);
+                  setKeySaved(false);
+                }}
+                placeholder={secretNameFor(focus)}
+                className="w-full max-w-sm bg-mycel-bg border border-mycel-border rounded-md px-2.5 py-1.5 text-[13px] text-mycel-text font-mono outline-none focus:border-mycel-accent"
+              />
+              <span className="text-[11px] text-mycel-muted">
+                {keySaved
+                  ? "Saved to the vault."
+                  : `Or run \`${focus}\` once in a terminal to sign in with the CLI (auth unverified until then).`}
+              </span>
+            </label>
+          </div>
+        )}
       </div>
 
-      <WizardFooter nav={nav} primaryLabel={saving ? "Saving…" : "Set as default"} onPrimary={persist} primaryDisabled={saving} />
+      <WizardFooter nav={nav} primaryLabel={saving ? "Saving…" : "Continue"} onPrimary={onContinue} primaryDisabled={saving} />
     </div>
   );
 }

--- a/web/tailwind.config.ts
+++ b/web/tailwind.config.ts
@@ -23,12 +23,19 @@ export default {
           '0%': { opacity: '0', transform: 'translateY(6px)' },
           '100%': { opacity: '1', transform: 'none' },
         },
+        // Indeterminate progress: a short segment sweeps left→right while a
+        // streamed task runs (the stream reports no percentage).
+        'indeterminate': {
+          '0%': { transform: 'translateX(-100%)' },
+          '100%': { transform: 'translateX(400%)' },
+        },
       },
       animation: {
         'slide-in': 'slide-in 0.2s ease-out',
         'fade-in': 'fade-in 0.25s ease-out',
         'expand-height': 'expand-height 0.3s ease-out',
         'reveal': 'reveal 0.4s cubic-bezier(0.16, 1, 0.3, 1) both',
+        'indeterminate': 'indeterminate 1.1s ease-in-out infinite',
       },
       colors: {
         mycel: {


### PR DESCRIPTION
Part of #2674

## Priority 1 — confirmed bug: `/settings/tools` stuck loading (fixed)

**Symptom (verified live):** `/tools` rendered perfectly, but `/settings/tools` showed "0 Providers · 0 CLI" with perpetual loading skeletons and hammered `/api/providers` + `/api/tools/unified` in a loop that never settled — same `<Tools/>` component, same `wrap()`.

**Root cause:** the bug was the *nested* `/settings/tools` route mount, not the component or the API. `RouteTransition` (web/src/components/Layout.tsx) special-cased `/settings/*` with a 2-segment `AnimatePresence` key; the nested Tools mount was fed an unstable key and remounted in a loop.

**Fix (ships regardless):**
- `settings/tools` → `<Navigate to="/tools" replace />`; `settings/tools/:provider` → a param-preserving redirect to `/tools/:provider`; `settings/providers` and `providers` → `/tools`.
- The Settings "Providers & Tools" card now links to `/tools`.
- `RouteTransition` drops the `/settings` special case and keys on the first segment only — removing the unstable-key remount path.

**Verification:** new route test (`web/src/views/__tests__/settingsToolsRedirect.test.tsx`) asserts `/settings/tools` → `/tools` and `/settings/tools/claude` → `/tools/claude`. Live smoke on a throwaway daemon (`127.0.0.1:8099`): `/settings/tools` resolves to `/tools`, header reads **6 Providers · 0 CLI**, **0 skeletons**, and only **3** requests each to the two endpoints over ~20s (the 10s poll rate — no loop).

## Priority 2 — in-surface install / update for CLI dependencies

CLI rows on the Tools page now install/update a tool over the existing loopback-guarded NDJSON stream (`POST /api/deps/install`), with a live streamed console, an honest **indeterminate → resolved** progress bar (the stream carries no percentage), a line-count signal, and loading→success/error states.

The installer now resolves commands from a **vetted source only** — the built-in table first, then the persisted tools registry's `install_cmd` / `upgrade_cmd` (update prefers `upgrade_cmd`), **never** request input. A small read-only extension threads the tools store into `DepsInstallHandler`; the loopback + method gates are unchanged. Tools with no automatic installer show a copy-the-command fallback (no faked results).

## Priority 3 — wizard StepProviders parity (#49)

`web/src/wizard/steps/StepProviders.tsx` now sets the fleet default through the **same** `<ProviderDefaults>` control the `/tools` page ships (default provider + model persisted via `PATCH /api/settings`) — shared, not duplicated (`ProviderDefaults` gained optional `onChange` + `showHost` props). An **Advanced** expander adds: install other tools (multiple providers), a per-provider command override, and an API key to the vault. Provider OAuth sign-in is intentionally deferred; the CLI-login / API-key path stays labeled **unverified**.

## Fully working vs. seamed
- **Working:** the redirect fix (live-verified), in-surface install/update for tools with a vetted or registered command, wizard fleet-default parity + Advanced expander.
- **Seamed / honest fallback:** tools with no automatic installer show copy-the-command guidance; provider OAuth deferred (unverified label kept). No registry browse/search was added (no backend) — omitted rather than faked.

## Test plan (commands + results)
- `bunx tsc --noEmit` → clean
- `bun run lint` → clean
- `bun run build` → built
- `bunx vitest run` → **35 files, 305 tests passed**
- `go build ./...` → clean; `go vet ./...` → clean
- `golangci-lint run ./server/handlers/` → **0 issues**
- `go test ./server/... ./pkg/home/...` → **all pass** (incl. new `TestResolveCommand`, `TestResolveCommandNilStore`)
- Live smoke (throwaway `MYCEL_HOME`, `127.0.0.1:8099`): `/settings/tools` → `/tools` (6 providers, 0 skeletons, no loop); deep-link `/settings/tools/claude` → `/tools/claude`; install endpoint guarded — `GET` → 405, unknown id → 400 (`no automatic installer/updater for …`). Daemon torn down.

## ui-ux-pro-max applied
Status chips are icon+label (never color-only); skeleton only while loading then resolves to data/empty/error (never perpetual); install actions show progress + loading→success/error; SVG icons only; focus rings + accessible contrast in both themes; the indeterminate progress + reveal motion respect `prefers-reduced-motion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)