### PR TITLE
feat(web): agent Settings tab + per-agent CPU/memory budgeting

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -62,6 +62,7 @@ import (
 	"regexp"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -394,8 +395,17 @@ type Agent struct {
 	Role           Role       `json:"role"`
 	State          State      `json:"state"`
 	Children       []string   `json:"children,omitempty"`
-	CrashCount     int        `json:"crash_count,omitempty"`
-	IsRoot         bool       `json:"is_root,omitempty"`
+	// CPUs is a per-agent Docker CPU cap (cores, e.g. 1.5). Zero means
+	// inherit the fleet default (prefs runtime.docker.cpus). Enforced only
+	// for the Docker runtime — tmux agents run unconstrained on the host.
+	// Applied at the next session (re)start via the --cpus docker flag.
+	CPUs float64 `json:"cpus,omitempty"`
+	// MemoryMB is a per-agent Docker memory cap (MB). Zero means inherit
+	// the fleet default (prefs runtime.docker.memory_mb). Docker-only,
+	// like CPUs; applied at the next session (re)start via --memory.
+	MemoryMB   int64 `json:"memory_mb,omitempty"`
+	CrashCount int   `json:"crash_count,omitempty"`
+	IsRoot     bool  `json:"is_root,omitempty"`
 }
 
 // HasCapability checks if this agent has a specific capability.
@@ -1232,6 +1242,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	if apiKey := os.Getenv("MYCEL_API_KEY"); apiKey != "" {
 		env["MYCEL_API_KEY"] = apiKey
 	}
+	injectResourceLimits(env, existing.CPUs, existing.MemoryMB)
 	injectEnv(env, repoPath, name, existing.EnvFile, existing.Env)
 	injectAppEnv(env, m.appsConfig)
 	secretEnvKeys := injectVaultSecrets(env, repoPath, resolveRoleSecrets(repoPath, string(existing.Role)), m.appsConfig)
@@ -1476,6 +1487,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	if apiKey := os.Getenv("MYCEL_API_KEY"); apiKey != "" {
 		env["MYCEL_API_KEY"] = apiKey
 	}
+	injectResourceLimits(env, agent.CPUs, agent.MemoryMB)
 	injectEnv(env, repoPath, name, opts.EnvFile, opts.Env)
 	injectAppEnv(env, m.appsConfig)
 	secretEnvKeys := injectVaultSecrets(env, repoPath, resolveRoleSecrets(repoPath, string(role)), m.appsConfig)
@@ -2452,6 +2464,50 @@ func (m *Manager) SetAgentEnv(ctx context.Context, name string, env map[string]s
 	return nil
 }
 
+// SetAgentResources sets a per-agent Docker CPU/memory cap. Values of 0
+// clear the override and fall back to the fleet default. The new caps
+// take effect on the next session (re)start — a running container is not
+// resized in place. Docker-only; stored regardless of runtime so a later
+// switch to Docker honors them.
+func (m *Manager) SetAgentResources(ctx context.Context, name string, cpus float64, memoryMB int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	a, exists := m.agents[name]
+	if !exists {
+		return fmt.Errorf("agent %s: %w", name, ErrNotFound)
+	}
+	a.CPUs = cpus
+	a.MemoryMB = memoryMB
+	a.UpdatedAt = time.Now()
+
+	if err := m.saveState(ctx); err != nil {
+		return fmt.Errorf("save agent state: %w", err)
+	}
+	return nil
+}
+
+// SetAgentModel sets the provider model identifier the agent runs with.
+// An empty string clears the override, restoring the provider default. The
+// new model is reused on the next session (re)start — the running session
+// is not re-launched in place.
+func (m *Manager) SetAgentModel(ctx context.Context, name, model string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	a, exists := m.agents[name]
+	if !exists {
+		return fmt.Errorf("agent %s: %w", name, ErrNotFound)
+	}
+	a.Model = model
+	a.UpdatedAt = time.Now()
+
+	if err := m.saveState(ctx); err != nil {
+		return fmt.Errorf("save agent state: %w", err)
+	}
+	return nil
+}
+
 // UpdateAgentState updates an agent's state and task.
 // Returns an error if the transition is invalid per the state machine.
 func (m *Manager) UpdateAgentState(ctx context.Context, name string, state State, task string) error {
@@ -3013,6 +3069,20 @@ func daemonAddrForRuntime(rt string) string {
 		return "http://host.docker.internal:9374"
 	}
 	return "http://127.0.0.1:9374"
+}
+
+// injectResourceLimits exposes an agent's per-agent Docker CPU/memory caps
+// to the runtime backend via MYCEL_CPUS / MYCEL_MEMORY_MB. The Docker
+// backend reads these to override the fleet-default --cpus/--memory flags
+// for this one container. Zero values are omitted so the backend keeps the
+// fleet default. tmux ignores them (limits are not enforced there).
+func injectResourceLimits(env map[string]string, cpus float64, memoryMB int64) {
+	if cpus > 0 {
+		env["MYCEL_CPUS"] = strconv.FormatFloat(cpus, 'f', -1, 64)
+	}
+	if memoryMB > 0 {
+		env["MYCEL_MEMORY_MB"] = strconv.FormatInt(memoryMB, 10)
+	}
 }
 
 // injectEnv merges environment variables from the agent env file and the

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2487,6 +2487,34 @@ func (m *Manager) SetAgentResources(ctx context.Context, name string, cpus float
 	return nil
 }
 
+// SetAgentResourcesPartial atomically merges the supplied CPU/memory
+// overrides into the agent's current stored values under a single lock.
+// Nil pointers leave the corresponding field untouched, so two concurrent
+// partial updates (one setting only cpus, the other only memory_mb) cannot
+// lose each other's change — the read and write happen inside the same lock,
+// never against a snapshot taken before it. Returns the merged values.
+func (m *Manager) SetAgentResourcesPartial(ctx context.Context, name string, cpus *float64, memoryMB *int64) (resolvedCPUs float64, resolvedMemoryMB int64, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	a, exists := m.agents[name]
+	if !exists {
+		return 0, 0, fmt.Errorf("agent %s: %w", name, ErrNotFound)
+	}
+	if cpus != nil {
+		a.CPUs = *cpus
+	}
+	if memoryMB != nil {
+		a.MemoryMB = *memoryMB
+	}
+	a.UpdatedAt = time.Now()
+
+	if saveErr := m.saveState(ctx); saveErr != nil {
+		return 0, 0, fmt.Errorf("save agent state: %w", saveErr)
+	}
+	return a.CPUs, a.MemoryMB, nil
+}
+
 // SetAgentModel sets the provider model identifier the agent runs with.
 // An empty string clears the override, restoring the provider default. The
 // new model is reused on the next session (re)start — the running session

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -433,6 +433,21 @@ func (s *AgentService) SetEnv(ctx context.Context, name string, env map[string]s
 	return nil
 }
 
+// SetResources sets a per-agent Docker CPU/memory cap (cores / MB). Zero
+// clears the override, restoring the fleet default. Takes effect on the
+// next agent (re)start.
+func (s *AgentService) SetResources(ctx context.Context, name string, cpus float64, memoryMB int64) error {
+	if err := s.manager.SetAgentResources(ctx, name, cpus, memoryMB); err != nil {
+		return err
+	}
+	s.publishEvent("agent.resources_updated", map[string]any{
+		"name":      name,
+		"cpus":      cpus,
+		"memory_mb": memoryMB,
+	})
+	return nil
+}
+
 // Get returns a single agent by name.
 func (s *AgentService) Get(ctx context.Context, name string) (*Agent, error) {
 	a := s.manager.GetAgent(name)

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -448,6 +448,23 @@ func (s *AgentService) SetResources(ctx context.Context, name string, cpus float
 	return nil
 }
 
+// SetResourcesPartial atomically merges the supplied CPU/memory overrides
+// into the agent's current caps (nil = leave that field untouched). Unlike
+// SetResources, the merge happens under the manager lock, so concurrent
+// partial PATCHes cannot clobber each other. Publishes the merged values.
+func (s *AgentService) SetResourcesPartial(ctx context.Context, name string, cpus *float64, memoryMB *int64) error {
+	resolvedCPUs, resolvedMemoryMB, err := s.manager.SetAgentResourcesPartial(ctx, name, cpus, memoryMB)
+	if err != nil {
+		return err
+	}
+	s.publishEvent("agent.resources_updated", map[string]any{
+		"name":      name,
+		"cpus":      resolvedCPUs,
+		"memory_mb": resolvedMemoryMB,
+	})
+	return nil
+}
+
 // Get returns a single agent by name.
 func (s *AgentService) Get(ctx context.Context, name string) (*Agent, error) {
 	a := s.manager.GetAgent(name)

--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -67,6 +67,8 @@ func createAgentsTable(d *db.DB) error {
 			last_crash_time TEXT,
 			recovered_from  TEXT,
 			runtime_backend TEXT,
+			cpus          REAL    NOT NULL DEFAULT 0,
+			memory_mb     INTEGER NOT NULL DEFAULT 0,
 			ttl           INTEGER NOT NULL DEFAULT 0,
 			created_at    TEXT,
 			stopped_at    TEXT,
@@ -130,8 +132,8 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 		 worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
-		 started_at, updated_at, repo, model)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 started_at, updated_at, repo, model, cpus, memory_mb)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.Name, string(a.Role), string(a.State),
 		nullStr(a.Tool), nullStr(a.ParentID), nullStr(a.Team), nullStr(a.Task),
 		nullStr(a.Session), a.Workspace,
@@ -141,7 +143,7 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 		nullTime(a.LastCrashTime), nullStr(a.RecoveredFrom),
 		nullStr(a.RuntimeBackend), nullStr(a.SessionID),
 		formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
-		formatTime(a.StartedAt), formatTime(now), a.Repo, a.Model,
+		formatTime(a.StartedAt), formatTime(now), a.Repo, a.Model, a.CPUs, a.MemoryMB,
 	)
 	return err
 }
@@ -267,8 +269,8 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 		 worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
-		 started_at, updated_at, repo, model)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		 started_at, updated_at, repo, model, cpus, memory_mb)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -298,7 +300,7 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 			nullTime(a.LastCrashTime), nullStr(a.RecoveredFrom),
 			nullStr(a.RuntimeBackend), nullStr(a.SessionID),
 			formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
-			formatTime(a.StartedAt), formatTime(now), a.Repo, a.Model,
+			formatTime(a.StartedAt), formatTime(now), a.Repo, a.Model, a.CPUs, a.MemoryMB,
 		)
 		if err != nil {
 			return fmt.Errorf("save agent %s: %w", a.Name, err)
@@ -360,7 +362,7 @@ const agentSelectCols = `SELECT name, role, state, tool, parent_id, team, task, 
 	       worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 	       is_root, crash_count, last_crash_time, recovered_from,
 	       runtime_backend, session_id, created_at, stopped_at, deleted_at,
-	       started_at, updated_at, repo, model`
+	       started_at, updated_at, repo, model, cpus, memory_mb`
 
 func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	var a Agent
@@ -371,6 +373,8 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	var createdAt, stoppedAt, deletedAt *string
 	var startedAt, updatedAt string
 	var isRoot, crashCount int
+	var cpus float64
+	var memoryMB int64
 
 	err := s.Scan(
 		&a.Name, &role, &state,
@@ -378,7 +382,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 		&worktreeDir, &logFile, &envFile, &envVars, &hookedWork, &childrenJSON,
 		&isRoot, &crashCount, &lastCrashTime, &recoveredFrom,
 		&runtimeBackend, &sessionID, &createdAt, &stoppedAt, &deletedAt,
-		&startedAt, &updatedAt, &repo, &model,
+		&startedAt, &updatedAt, &repo, &model, &cpus, &memoryMB,
 	)
 	if err != nil {
 		return nil, err
@@ -406,6 +410,8 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	a.RuntimeBackend = deref(runtimeBackend)
 	a.Repo = repo
 	a.Model = model
+	a.CPUs = cpus
+	a.MemoryMB = memoryMB
 
 	if childrenJSON != nil && *childrenJSON != "" {
 		_ = json.Unmarshal([]byte(*childrenJSON), &a.Children) //nolint:errcheck // best-effort

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -373,12 +374,26 @@ func (b *Backend) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 		"--label", "mycel.agent=" + name,
 	}
 
-	// Resource limits
-	if b.cfg.CPUs > 0 {
-		args = append(args, "--cpus", fmt.Sprintf("%.1f", b.cfg.CPUs))
+	// Resource limits. Default to the fleet-wide config, but let a
+	// per-agent override (plumbed via MYCEL_CPUS / MYCEL_MEMORY_MB by the
+	// agent manager) take precedence for this one container.
+	cpus := b.cfg.CPUs
+	if v, ok := env["MYCEL_CPUS"]; ok {
+		if parsed, perr := strconv.ParseFloat(v, 64); perr == nil && parsed > 0 {
+			cpus = parsed
+		}
 	}
-	if b.cfg.MemoryMB > 0 {
-		args = append(args, "--memory", fmt.Sprintf("%dm", b.cfg.MemoryMB))
+	memoryMB := b.cfg.MemoryMB
+	if v, ok := env["MYCEL_MEMORY_MB"]; ok {
+		if parsed, perr := strconv.ParseInt(v, 10, 64); perr == nil && parsed > 0 {
+			memoryMB = parsed
+		}
+	}
+	if cpus > 0 {
+		args = append(args, "--cpus", strconv.FormatFloat(cpus, 'f', -1, 64))
+	}
+	if memoryMB > 0 {
+		args = append(args, "--memory", fmt.Sprintf("%dm", memoryMB))
 	}
 
 	// Network

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -196,6 +196,11 @@ type agentDTO struct { //nolint:govet // field order matches JSON/API contract
 	Children     []string          `json:"children,omitempty"`
 	TotalCostUSD float64           `json:"total_cost_usd"`
 	TotalTokens  int64             `json:"total_tokens"`
+	// CPUs / MemoryMB are the agent's per-agent Docker resource caps (0 =
+	// inherit the fleet default). Surfaced so the Insights resource panel
+	// can total configured caps without a per-agent config fetch.
+	CPUs     float64 `json:"cpus,omitempty"`
+	MemoryMB int64   `json:"memory_mb,omitempty"`
 }
 
 // agentStatsDTO holds resource metrics included when ?include=stats is set.
@@ -232,6 +237,8 @@ func toDTO(a *agent.Agent) agentDTO {
 		ArchivedAt: a.ArchivedAt,
 		Repo:       a.Repo,
 		Env:        a.Env,
+		CPUs:       a.CPUs,
+		MemoryMB:   a.MemoryMB,
 	}
 }
 

--- a/server/handlers/agents_config.go
+++ b/server/handlers/agents_config.go
@@ -37,8 +37,14 @@ type agentConfigDTO struct { //nolint:govet // field order matches JSON/API cont
 	SystemPrompt   string   `json:"system_prompt"`
 	RuntimeBackend string   `json:"runtime_backend,omitempty"`
 	Tool           string   `json:"tool,omitempty"`
+	Model          string   `json:"model,omitempty"`
 	Session        string   `json:"session,omitempty"`
 	MCPServers     []string `json:"mcp_servers,omitempty"`
+	// CPUs / MemoryMB are the agent's per-agent Docker resource caps.
+	// Zero means "inherit the fleet default" — the UI shows the fleet
+	// value as the placeholder in that case. Enforced only for Docker.
+	CPUs     float64 `json:"cpus"`
+	MemoryMB int64   `json:"memory_mb"`
 }
 
 // getAgentConfig handles GET /api/agents/{name}/config.
@@ -61,8 +67,11 @@ func (h *AgentHandler) getAgentConfig(w http.ResponseWriter, r *http.Request, na
 		WorktreePath:   wtDir,
 		RuntimeBackend: a.RuntimeBackend,
 		Tool:           a.Tool,
+		Model:          a.Model,
 		Session:        a.Session,
 		MCPServers:     []string{},
+		CPUs:           a.CPUs,
+		MemoryMB:       a.MemoryMB,
 	}
 
 	// Read the per-tool prompt file (CLAUDE.md / GEMINI.md / .cursorrules / ...)
@@ -96,11 +105,28 @@ func (h *AgentHandler) patchAgentConfig(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	// All fields are optional so a caller can update just the resource caps
+	// without clobbering the system prompt (and vice-versa). Pointers let us
+	// tell "field omitted" apart from "field set to zero/empty".
 	var req struct {
-		SystemPrompt string `json:"system_prompt"`
+		SystemPrompt *string  `json:"system_prompt"`
+		Model        *string  `json:"model"`
+		CPUs         *float64 `json:"cpus"`
+		MemoryMB     *int64   `json:"memory_mb"`
 	}
 	if decErr := json.NewDecoder(r.Body).Decode(&req); decErr != nil {
 		httpError(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// Reject nonsensical caps up front — a negative limit would silently
+	// disable the docker flag, which is not what the caller asked for.
+	if req.CPUs != nil && *req.CPUs < 0 {
+		httpError(w, "cpus must be >= 0", http.StatusBadRequest)
+		return
+	}
+	if req.MemoryMB != nil && *req.MemoryMB < 0 {
+		httpError(w, "memory_mb must be >= 0", http.StatusBadRequest)
 		return
 	}
 
@@ -109,28 +135,58 @@ func (h *AgentHandler) patchAgentConfig(w http.ResponseWriter, r *http.Request, 
 	if wtDir == "" {
 		wtDir = svc.Manager().WorktreePath(name)
 	}
-	if wtDir == "" {
-		httpError(w, "worktree path not available for this agent", http.StatusUnprocessableEntity)
-		return
-	}
 	wtDir = filepath.Clean(wtDir)
 	if strings.Contains(wtDir, "..") {
 		httpError(w, "unsafe worktree path", http.StatusBadRequest)
 		return
 	}
 
-	// Ensure directory exists.
-	if mkErr := os.MkdirAll(wtDir, 0750); mkErr != nil {
-		httpInternalError(w, "create worktree dir", mkErr)
-		return
+	// System prompt — only touched when provided (writes the per-tool file).
+	if req.SystemPrompt != nil {
+		if wtDir == "" || wtDir == "." {
+			httpError(w, "worktree path not available for this agent", http.StatusUnprocessableEntity)
+			return
+		}
+		if mkErr := os.MkdirAll(wtDir, 0750); mkErr != nil {
+			httpInternalError(w, "create worktree dir", mkErr)
+			return
+		}
+		promptFile := promptFileForTool(a.Tool)
+		promptPath := filepath.Join(wtDir, promptFile)
+		//nolint:gosec // trusted path under repo root
+		if writeErr := os.WriteFile(promptPath, []byte(*req.SystemPrompt), 0600); writeErr != nil {
+			httpInternalError(w, "write "+promptFile, writeErr)
+			return
+		}
 	}
 
-	promptFile := promptFileForTool(a.Tool)
-	promptPath := filepath.Join(wtDir, promptFile)
-	//nolint:gosec // trusted path under repo root
-	if writeErr := os.WriteFile(promptPath, []byte(req.SystemPrompt), 0600); writeErr != nil {
-		httpInternalError(w, "write "+promptFile, writeErr)
-		return
+	// Model override — persisted on the agent record; reused on next restart.
+	if req.Model != nil {
+		if setErr := svc.Manager().SetAgentModel(r.Context(), name, *req.Model); setErr != nil {
+			httpInternalError(w, "set agent model", setErr)
+			return
+		}
+	}
+
+	// Resource caps — persisted on the agent record; applied on next restart.
+	if req.CPUs != nil || req.MemoryMB != nil {
+		cpus := a.CPUs
+		if req.CPUs != nil {
+			cpus = *req.CPUs
+		}
+		memoryMB := a.MemoryMB
+		if req.MemoryMB != nil {
+			memoryMB = *req.MemoryMB
+		}
+		if setErr := svc.SetResources(r.Context(), name, cpus, memoryMB); setErr != nil {
+			httpInternalError(w, "set agent resources", setErr)
+			return
+		}
+	}
+
+	// Re-read so the response reflects the persisted record (model/caps).
+	if updated, getErr := svc.Get(r.Context(), name); getErr == nil {
+		a = updated
 	}
 
 	// Return the updated config as the response body.
@@ -138,9 +194,14 @@ func (h *AgentHandler) patchAgentConfig(w http.ResponseWriter, r *http.Request, 
 		WorktreePath:   wtDir,
 		RuntimeBackend: a.RuntimeBackend,
 		Tool:           a.Tool,
+		Model:          a.Model,
 		Session:        a.Session,
-		SystemPrompt:   req.SystemPrompt,
 		MCPServers:     []string{},
+		CPUs:           a.CPUs,
+		MemoryMB:       a.MemoryMB,
+	}
+	if req.SystemPrompt != nil {
+		dto.SystemPrompt = *req.SystemPrompt
 	}
 	if hm != nil && hm.RoleManager != nil && string(a.Role) != "" {
 		if resolved, resolveErr := hm.RoleManager.ResolveRole(string(a.Role)); resolveErr == nil && len(resolved.MCPServers) > 0 {

--- a/server/handlers/agents_config.go
+++ b/server/handlers/agents_config.go
@@ -169,16 +169,10 @@ func (h *AgentHandler) patchAgentConfig(w http.ResponseWriter, r *http.Request, 
 	}
 
 	// Resource caps — persisted on the agent record; applied on next restart.
+	// The partial merge happens under the manager lock (not against the
+	// snapshot `a`), so two concurrent partial PATCHes can't lose an update.
 	if req.CPUs != nil || req.MemoryMB != nil {
-		cpus := a.CPUs
-		if req.CPUs != nil {
-			cpus = *req.CPUs
-		}
-		memoryMB := a.MemoryMB
-		if req.MemoryMB != nil {
-			memoryMB = *req.MemoryMB
-		}
-		if setErr := svc.SetResources(r.Context(), name, cpus, memoryMB); setErr != nil {
+		if setErr := svc.SetResourcesPartial(r.Context(), name, req.CPUs, req.MemoryMB); setErr != nil {
 			httpInternalError(w, "set agent resources", setErr)
 			return
 		}

--- a/server/handlers/agents_config_test.go
+++ b/server/handlers/agents_config_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/rpuneet/mycel/pkg/agent"
@@ -253,6 +254,73 @@ func TestPatchAgentConfig_Resources(t *testing.T) {
 	}
 	defer func() { _ = resp2.Body.Close() }()
 	assertStatus(t, resp2, http.StatusBadRequest)
+}
+
+// TestPatchAgentConfig_ConcurrentPartial verifies that two concurrent
+// partial PATCHes — one setting only cpus, the other only memory_mb —
+// both survive. This is the regression guard for the lost-update race:
+// the merge must happen under the manager lock, not against a snapshot
+// read before the write.
+func TestPatchAgentConfig_ConcurrentPartial(t *testing.T) {
+	dir := setupHome(t)
+	stateDir := filepath.Join(dir, ".mycel")
+	if err := os.MkdirAll(filepath.Join(stateDir, "agents"), 0750); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	wtDir := filepath.Join(dir, "wt", "zen-zebra")
+	if err := os.MkdirAll(wtDir, 0750); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+
+	mgr := agent.NewManager(stateDir)
+	svc := agent.NewAgentService(mgr, nil, nil)
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name:           "zen-zebra",
+		Role:           agent.Role("engineer"),
+		Workspace:      dir,
+		Tool:           "claude",
+		RuntimeBackend: "docker",
+		WorktreeDir:    wtDir,
+	}); err != nil {
+		t.Fatalf("register agent: %v", err)
+	}
+
+	ts := buildTestServerWithServices(t, server.Services{Agents: svc})
+	defer ts.Close()
+
+	patch := func(body string) {
+		req, _ := http.NewRequestWithContext(context.Background(), http.MethodPatch,
+			ts.URL+"/api/agents/zen-zebra/config", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Errorf("patch %s: %v", body, err)
+			return
+		}
+		_ = resp.Body.Close()
+	}
+
+	// Hammer cpus-only and memory-only PATCHes concurrently. Under the old
+	// snapshot-merge, the later writer overwrote the other field back to its
+	// stale value; under the locked partial merge, both must stick.
+	var wg sync.WaitGroup
+	for i := 0; i < 25; i++ {
+		wg.Add(2)
+		go func() { defer wg.Done(); patch(`{"cpus":3}`) }()
+		go func() { defer wg.Done(); patch(`{"memory_mb":5120}`) }()
+	}
+	wg.Wait()
+
+	a := mgr.GetAgent("zen-zebra")
+	if a == nil {
+		t.Fatal("agent gone after concurrent patch")
+	}
+	if a.CPUs != 3 {
+		t.Errorf("cpus = %v, want 3 (lost update)", a.CPUs)
+	}
+	if a.MemoryMB != 5120 {
+		t.Errorf("memory_mb = %v, want 5120 (lost update)", a.MemoryMB)
+	}
 }
 
 // TestAgentHandler_GetConfigNotFound verifies /config returns 404 for an

--- a/server/handlers/agents_config_test.go
+++ b/server/handlers/agents_config_test.go
@@ -166,6 +166,95 @@ func TestPatchAgentConfig(t *testing.T) {
 	}
 }
 
+// TestPatchAgentConfig_Resources verifies PATCH /api/agents/{name}/config
+// persists the per-agent Docker CPU/memory caps and the model override,
+// echoes them back, and leaves an unrelated field (system prompt) untouched
+// when it is omitted from the request.
+func TestPatchAgentConfig_Resources(t *testing.T) {
+	dir := setupHome(t)
+	stateDir := filepath.Join(dir, ".mycel")
+	if err := os.MkdirAll(filepath.Join(stateDir, "agents"), 0750); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+	wtDir := filepath.Join(dir, "wt", "zen-zebra")
+	if err := os.MkdirAll(wtDir, 0750); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	const prompt = "keep me"
+	if err := os.WriteFile(filepath.Join(wtDir, "CLAUDE.md"), []byte(prompt), 0600); err != nil {
+		t.Fatalf("write CLAUDE.md: %v", err)
+	}
+
+	mgr := agent.NewManager(stateDir)
+	svc := agent.NewAgentService(mgr, nil, nil)
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name:           "zen-zebra",
+		Role:           agent.Role("engineer"),
+		Workspace:      dir,
+		Tool:           "claude",
+		RuntimeBackend: "docker",
+		WorktreeDir:    wtDir,
+	}); err != nil {
+		t.Fatalf("register agent: %v", err)
+	}
+
+	ts := buildTestServerWithServices(t, server.Services{Agents: svc})
+	defer ts.Close()
+
+	// PATCH only cpus/memory_mb/model — system_prompt omitted.
+	payload := `{"cpus":1.5,"memory_mb":3072,"model":"fable"}`
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPatch,
+		ts.URL+"/api/agents/zen-zebra/config", strings.NewReader(payload))
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusOK)
+
+	var dto struct {
+		Model    string  `json:"model"`
+		CPUs     float64 `json:"cpus"`
+		MemoryMB int64   `json:"memory_mb"`
+	}
+	if decErr := json.NewDecoder(resp.Body).Decode(&dto); decErr != nil {
+		t.Fatalf("decode config dto: %v", decErr)
+	}
+	if dto.CPUs != 1.5 || dto.MemoryMB != 3072 || dto.Model != "fable" {
+		t.Fatalf("response = %+v, want cpus=1.5 mem=3072 model=fable", dto)
+	}
+
+	// Persisted on the in-memory record.
+	a := mgr.GetAgent("zen-zebra")
+	if a == nil {
+		t.Fatal("agent gone after patch")
+	}
+	if a.CPUs != 1.5 || a.MemoryMB != 3072 || a.Model != "fable" {
+		t.Fatalf("record = {cpus:%v mem:%v model:%q}, want {1.5 3072 fable}", a.CPUs, a.MemoryMB, a.Model)
+	}
+
+	// Omitted system_prompt must be left untouched on disk.
+	got, err := os.ReadFile(filepath.Join(wtDir, "CLAUDE.md")) //nolint:gosec // trusted test path
+	if err != nil || string(got) != prompt {
+		t.Fatalf("CLAUDE.md = %q (err=%v), want it unchanged (%q)", string(got), err, prompt)
+	}
+
+	// A negative cap is rejected.
+	req2, _ := http.NewRequestWithContext(context.Background(), http.MethodPatch,
+		ts.URL+"/api/agents/zen-zebra/config", strings.NewReader(`{"cpus":-1}`))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("do negative: %v", err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	assertStatus(t, resp2, http.StatusBadRequest)
+}
+
 // TestAgentHandler_GetConfigNotFound verifies /config returns 404 for an
 // unknown agent (not a generic handler 404 leak).
 func TestAgentHandler_GetConfigNotFound(t *testing.T) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -109,6 +109,10 @@ export interface Agent {
    *  `${secret:NAME}` references are returned as the reference — the
    *  daemon never sends resolved secret values. */
   env?: Record<string, string>;
+  /** Per-agent Docker CPU cap in cores (0/absent = inherit fleet default). */
+  cpus?: number;
+  /** Per-agent Docker memory cap in MB (0/absent = inherit fleet default). */
+  memory_mb?: number;
 }
 
 export interface AgentConfig {
@@ -116,10 +120,15 @@ export interface AgentConfig {
   mcp_servers: string[];
   runtime_backend: string;
   tool: string;
+  model: string;
   session: string;
   worktree_path: string;
   created_at: string;
   started_at: string;
+  /** Per-agent Docker CPU cap in cores; 0 = inherit the fleet default. */
+  cpus: number;
+  /** Per-agent Docker memory cap in MB; 0 = inherit the fleet default. */
+  memory_mb: number;
 }
 
 export interface NotificationSource {
@@ -898,8 +907,11 @@ export const api = {
 
   getAgentConfig: (name: string) =>
     request<AgentConfig>(`/agents/${encodeURIComponent(name)}/config`),
-  patchAgentConfig: (name: string, patch: { system_prompt?: string }) =>
-    request<void>(`/agents/${encodeURIComponent(name)}/config`, { method: "PATCH", body: JSON.stringify(patch) }),
+  patchAgentConfig: (
+    name: string,
+    patch: { system_prompt?: string; model?: string; cpus?: number; memory_mb?: number },
+  ) =>
+    request<AgentConfig>(`/agents/${encodeURIComponent(name)}/config`, { method: "PATCH", body: JSON.stringify(patch) }),
   getAgentMcps: (name: string) =>
     request<Array<{ name: string }>>(`/agents/${encodeURIComponent(name)}/mcps`),
   addAgentMcp: (name: string, mcpName: string) =>

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -25,18 +25,26 @@ const formatTime = (t?: string): string => formatAbsolute(t);
 const formatRelative = (t?: string): string => sharedFormatRelative(t, { emptyLabel: "" });
 
 /* ═══════════════════════════════════════════════════════════════════
-   Tab types — v3: Live / Attach / Config / Metrics
+   Tab types — v3: Live / Attach / Settings / Metrics
    ═══════════════════════════════════════════════════════════════════ */
 
-type Tab = "attach" | "live" | "config" | "metrics" | "code";
+type Tab = "attach" | "live" | "settings" | "metrics" | "code";
 
 const TABS: { key: Tab; label: string; shortcut: string }[] = [
   { key: "attach", label: "Attach", shortcut: "1" },
   { key: "live", label: "Live", shortcut: "2" },
-  { key: "config", label: "Config", shortcut: "3" },
+  { key: "settings", label: "Settings", shortcut: "3" },
   { key: "metrics", label: "Metrics", shortcut: "4" },
   { key: "code", label: "Code", shortcut: "5" },
 ];
+
+/** Map a URL sub-path segment to a tab. The legacy `config` segment
+ *  resolves to the renamed Settings tab so old deep links keep working. */
+function tabForSegment(seg: string | undefined): Tab | null {
+  if (seg === "config") return "settings";
+  const known: Tab[] = ["attach", "live", "settings", "metrics", "code"];
+  return known.includes(seg as Tab) ? (seg as Tab) : null;
+}
 
 /* ═══════════════════════════════════════════════════════════════════
    Section chrome
@@ -421,12 +429,273 @@ function AttachOverlay({
   );
 }
 
-/* ═══════════════════════════════════════════════════════════════════
-   Tab 3 — Config
-   System prompt, MCP servers, metadata, danger zone
-   ═══════════════════════════════════════════════════════════════════ */
+/* ── shared save-pill for the Settings sub-panels ──────────────────── */
 
-function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
+type SaveState = "idle" | "saving" | "saved" | "error";
+
+function SavePill({ state, error }: { state: SaveState; error?: string | null }) {
+  if (state === "saving") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-[11px] text-mycel-muted" role="status">
+        <svg className="w-3 h-3 animate-spin" viewBox="0 0 24 24" fill="none" aria-hidden>
+          <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="3" opacity="0.25" />
+          <path d="M21 12a9 9 0 00-9-9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+        </svg>
+        Saving…
+      </span>
+    );
+  }
+  if (state === "saved") {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-[11px] text-mycel-success" role="status">
+        <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+        Saved
+      </span>
+    );
+  }
+  if (state === "error") {
+    return (
+      <span className="text-[11px] text-mycel-error" role="alert">
+        {error ?? "Save failed"}
+      </span>
+    );
+  }
+  return null;
+}
+
+const SETTINGS_SELECT_CLS =
+  "w-full rounded-md border border-mycel-border-strong bg-mycel-bg px-2.5 py-1.5 text-[13px] text-mycel-text outline-none focus:border-mycel-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+const SETTINGS_INPUT_CLS =
+  "w-32 rounded-md border border-mycel-border-strong bg-mycel-bg px-2.5 py-1.5 text-[13px] tabular-nums text-mycel-text placeholder:text-mycel-muted outline-none focus:border-mycel-accent transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
+
+/* ── Provider & Model override ──────────────────────────────────────
+ * The provider (tool) is fixed for an agent's lifetime — switching it
+ * would need a fresh container image, so it's shown read-only with an
+ * honest note. The model, however, is genuinely re-read on restart, so
+ * it is a live picker bound to PATCH /config { model }.
+ */
+function ProviderModelSection({
+  agentName,
+  tool,
+  model,
+  onSaved,
+}: {
+  agentName: string;
+  tool: string;
+  model: string;
+  onSaved: () => void;
+}) {
+  const [models, setModels] = useState<Array<{ id: string; available: boolean }>>([]);
+  const [selected, setSelected] = useState(model);
+  const [save, setSave] = useState<SaveState>("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => { setSelected(model); }, [model]);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .listProviders()
+      .then((providers) => {
+        if (!alive) return;
+        const p = providers.find((x) => x.name === tool);
+        setModels((p?.models ?? []).map((m) => ({ id: m.id, available: m.available })));
+      })
+      .catch(() => { /* degrade to no model list */ });
+    return () => { alive = false; };
+  }, [tool]);
+
+  const persist = useCallback(
+    async (next: string) => {
+      setSelected(next);
+      setSave("saving");
+      setSaveError(null);
+      try {
+        await api.patchAgentConfig(agentName, { model: next });
+        setSave("saved");
+        onSaved();
+        setTimeout(() => setSave("idle"), 1800);
+      } catch (err) {
+        setSelected(model);
+        setSaveError(err instanceof Error ? err.message : "Save failed");
+        setSave("error");
+      }
+    },
+    [agentName, model, onSaved],
+  );
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-1">
+        <SectionRule>Provider &amp; Model</SectionRule>
+        <div className="min-h-[16px]"><SavePill state={save} error={saveError} /></div>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="block">
+          <span className="block text-[11px] text-mycel-text-2 mb-1">Provider</span>
+          <input
+            type="text"
+            value={tool || "—"}
+            disabled
+            aria-label="Provider (fixed for this agent)"
+            className={SETTINGS_SELECT_CLS}
+            style={{ fontFamily: MONO }}
+          />
+        </label>
+        <label className="block">
+          <span className="block text-[11px] text-mycel-text-2 mb-1">Model override</span>
+          <select
+            className={SETTINGS_SELECT_CLS}
+            value={selected}
+            disabled={save === "saving" || models.length === 0}
+            onChange={(e) => { void persist(e.target.value); }}
+            aria-label="Model override"
+            style={{ fontFamily: MONO }}
+          >
+            <option value="">Provider default</option>
+            {models.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.id}{m.available ? "" : " · unverified"}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <p className="mt-2 text-xs text-mycel-muted leading-relaxed">
+        {models.length === 0
+          ? "This provider exposes no model list — its own default is used."
+          : "Model applies on the agent’s next restart. "}
+        Switching provider isn’t supported in place — clone the agent onto a different
+        provider instead.
+        {/* follow-up: a real per-agent provider switch needs a container re-image. */}
+      </p>
+    </section>
+  );
+}
+
+/* ── Resource limits (CPU / Memory) ─────────────────────────────────
+ * Per-agent Docker caps, bound to PATCH /config { cpus, memory_mb }.
+ * Blank inputs clear the override (send 0) so the fleet default applies.
+ * For tmux agents the limits are stored but not enforced — labelled so.
+ */
+function ResourceLimitsSection({
+  agentName,
+  isDocker,
+  cpus,
+  memoryMB,
+  onSaved,
+}: {
+  agentName: string;
+  isDocker: boolean;
+  cpus: number;
+  memoryMB: number;
+  onSaved: () => void;
+}) {
+  const [cpuInput, setCpuInput] = useState(cpus > 0 ? String(cpus) : "");
+  const [memInput, setMemInput] = useState(memoryMB > 0 ? String(memoryMB) : "");
+  const [defaults, setDefaults] = useState<{ cpus: number; memory_mb: number } | null>(null);
+  const [save, setSave] = useState<SaveState>("idle");
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  useEffect(() => { setCpuInput(cpus > 0 ? String(cpus) : ""); }, [cpus]);
+  useEffect(() => { setMemInput(memoryMB > 0 ? String(memoryMB) : ""); }, [memoryMB]);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .getSettings()
+      .then((cfg) => { if (alive) setDefaults({ cpus: cfg.runtime?.docker?.cpus ?? 0, memory_mb: cfg.runtime?.docker?.memory_mb ?? 0 }); })
+      .catch(() => { /* placeholder stays generic */ });
+    return () => { alive = false; };
+  }, []);
+
+  const dirty =
+    (cpuInput.trim() === "" ? 0 : Number(cpuInput)) !== cpus ||
+    (memInput.trim() === "" ? 0 : Number(memInput)) !== memoryMB;
+  const cpuNum = cpuInput.trim() === "" ? 0 : Number(cpuInput);
+  const memNum = memInput.trim() === "" ? 0 : Number(memInput);
+  const invalid =
+    (cpuInput.trim() !== "" && (!Number.isFinite(cpuNum) || cpuNum < 0)) ||
+    (memInput.trim() !== "" && (!Number.isFinite(memNum) || memNum < 0 || !Number.isInteger(memNum)));
+
+  const handleSave = useCallback(async () => {
+    if (invalid) return;
+    setSave("saving");
+    setSaveError(null);
+    try {
+      await api.patchAgentConfig(agentName, { cpus: cpuNum, memory_mb: memNum });
+      setSave("saved");
+      onSaved();
+      setTimeout(() => setSave("idle"), 1800);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed");
+      setSave("error");
+    }
+  }, [agentName, cpuNum, memNum, invalid, onSaved]);
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-1">
+        <SectionRule>Resource Limits</SectionRule>
+        <div className="min-h-[16px]"><SavePill state={save} error={saveError} /></div>
+      </div>
+      <div className="flex flex-wrap items-end gap-4">
+        <label className="block">
+          <span className="block text-[11px] text-mycel-text-2 mb-1">CPU (cores)</span>
+          <input
+            type="number"
+            min={0}
+            step={0.5}
+            value={cpuInput}
+            disabled={!isDocker}
+            onChange={(e) => setCpuInput(e.target.value)}
+            placeholder={defaults ? `default ${defaults.cpus}` : "default"}
+            aria-label="CPU cores cap"
+            className={SETTINGS_INPUT_CLS}
+            style={{ fontFamily: MONO }}
+          />
+        </label>
+        <label className="block">
+          <span className="block text-[11px] text-mycel-text-2 mb-1">Memory (MB)</span>
+          <input
+            type="number"
+            min={0}
+            step={256}
+            value={memInput}
+            disabled={!isDocker}
+            onChange={(e) => setMemInput(e.target.value)}
+            placeholder={defaults ? `default ${defaults.memory_mb}` : "default"}
+            aria-label="Memory MB cap"
+            className={SETTINGS_INPUT_CLS}
+            style={{ fontFamily: MONO }}
+          />
+        </label>
+        <button
+          type="button"
+          disabled={!isDocker || !dirty || invalid || save === "saving"}
+          onClick={() => { void handleSave(); }}
+          className="inline-flex items-center h-9 px-3 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover active:scale-[0.98] shadow-mycel-sm transition-all disabled:opacity-40 disabled:pointer-events-none"
+        >
+          {save === "saving" ? "Saving…" : "Save limits"}
+        </button>
+      </div>
+      {invalid && (
+        <p className="mt-2 text-xs text-mycel-error">
+          CPU must be a non-negative number; memory must be a whole number of MB.
+        </p>
+      )}
+      <p className="mt-2 text-xs text-mycel-muted leading-relaxed">
+        {isDocker
+          ? "Applied to the container on the agent’s next restart. Leave blank to inherit the fleet default. Caps prevent one agent from starving the host."
+          : "This agent runs under tmux on the host, where per-agent CPU/memory caps are not enforced. Limits are saved and will apply if the agent moves to the Docker runtime."}
+      </p>
+    </section>
+  );
+}
+
+function SettingsTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
   const navigate = useNavigate();
   const [config, setConfig] = useState<AgentConfig | null>(null);
   const [configLoading, setConfigLoading] = useState(true);
@@ -474,6 +743,15 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
       .finally(() => {
         setMcpLoading(false);
       });
+  }, [agent.name]);
+
+  // Re-fetch the agent config (system prompt, model, resource caps) after a
+  // sub-panel persists a change so the surface reflects what's on disk.
+  const reloadConfig = useCallback(() => {
+    api
+      .getAgentConfig(agent.name)
+      .then((data) => setConfig(data))
+      .catch(() => { /* best-effort */ });
   }, [agent.name]);
 
   useEffect(() => {
@@ -654,6 +932,23 @@ function ConfigTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) {
           value={config?.system_prompt ?? ""}
           loading={configLoading}
           onSave={handleSystemPromptSave}
+        />
+
+        {/* ── PROVIDER & MODEL ── */}
+        <ProviderModelSection
+          agentName={agent.name}
+          tool={agent.tool ?? config?.tool ?? ""}
+          model={config?.model ?? agent.model ?? ""}
+          onSaved={reloadConfig}
+        />
+
+        {/* ── RESOURCE LIMITS ── */}
+        <ResourceLimitsSection
+          agentName={agent.name}
+          isDocker={isDocker}
+          cpus={config?.cpus ?? agent.cpus ?? 0}
+          memoryMB={config?.memory_mb ?? agent.memory_mb ?? 0}
+          onSaved={reloadConfig}
         />
 
         {/* ── TEMPLATE ── */}
@@ -1123,8 +1418,7 @@ export function AgentDetail() {
   const tabFromPath = useMemo<Tab>(() => {
     const segments = location.pathname.split("/");
     const last = segments[segments.length - 1];
-    const candidates: Tab[] = ["attach", "live", "config", "metrics", "code"];
-    return (candidates.includes(last as Tab) ? (last as Tab) : "attach");
+    return tabForSegment(last) ?? "attach";
   }, [location.pathname]);
   const [activeTab, setActiveTab] = useState<Tab>(tabFromPath);
 
@@ -1181,7 +1475,7 @@ export function AgentDetail() {
           selectTab("live");
           break;
         case "3":
-          selectTab("config");
+          selectTab("settings");
           break;
         case "4":
           selectTab("metrics");
@@ -1383,7 +1677,7 @@ export function AgentDetail() {
           />
         )}
         {activeTab === "attach" && <AttachTab agent={agent} />}
-        {activeTab === "config" && <ConfigTab agent={agent} agentsUrl={agentsUrl} />}
+        {activeTab === "settings" && <SettingsTab agent={agent} agentsUrl={agentsUrl} />}
         {activeTab === "metrics" && <MetricsTab agent={agent} />}
         {activeTab === "code" && <CodeTab agent={agent} />}
       </div>

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -565,7 +565,7 @@ function ProviderModelSection({
       </div>
       <p className="mt-2 text-xs text-mycel-muted leading-relaxed">
         {models.length === 0
-          ? "This provider exposes no model list — its own default is used."
+          ? "This provider exposes no model list — its own default is used. "
           : "Model applies on the agent’s next restart. "}
         Switching provider isn’t supported in place — clone the agent onto a different
         provider instead.
@@ -649,7 +649,6 @@ function ResourceLimitsSection({
             min={0}
             step={0.5}
             value={cpuInput}
-            disabled={!isDocker}
             onChange={(e) => setCpuInput(e.target.value)}
             placeholder={defaults ? `default ${defaults.cpus}` : "default"}
             aria-label="CPU cores cap"
@@ -664,7 +663,6 @@ function ResourceLimitsSection({
             min={0}
             step={256}
             value={memInput}
-            disabled={!isDocker}
             onChange={(e) => setMemInput(e.target.value)}
             placeholder={defaults ? `default ${defaults.memory_mb}` : "default"}
             aria-label="Memory MB cap"
@@ -674,7 +672,7 @@ function ResourceLimitsSection({
         </label>
         <button
           type="button"
-          disabled={!isDocker || !dirty || invalid || save === "saving"}
+          disabled={!dirty || invalid || save === "saving"}
           onClick={() => { void handleSave(); }}
           className="inline-flex items-center h-9 px-3 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover active:scale-[0.98] shadow-mycel-sm transition-all disabled:opacity-40 disabled:pointer-events-none"
         >

--- a/web/src/views/Insights.tsx
+++ b/web/src/views/Insights.tsx
@@ -594,9 +594,11 @@ export function Insights() {
   if (!hasLedger && data.daily.length === 0 && data.byAgent.length === 0) {
     // A quiet period on a fleet with history is real data (zeros), but a
     // window with no ledger at all gets one clear explanation instead of
-    // four empty panels.
+    // four empty cost panels. The resource budget is independent of cost —
+    // a brand-new fleet can already have configured Docker caps — so it
+    // still renders here.
     return (
-      <div className="p-6">
+      <div className="p-6 max-w-6xl mx-auto space-y-8">
         <EmptyState
           icon="$"
           title={isAll ? "No cost data yet" : `No spend in the ${periodLabel}`}
@@ -604,6 +606,7 @@ export function Insights() {
           actionLabel={isAll ? undefined : "View all time"}
           onAction={isAll ? undefined : () => setPeriod("all")}
         />
+        <ResourcePanel />
       </div>
     );
   }

--- a/web/src/views/Insights.tsx
+++ b/web/src/views/Insights.tsx
@@ -46,6 +46,7 @@ import { SystemRow } from "./insights/SystemRow";
 import { TokenPanel, buildTokenSeries } from "./insights/TokenPanel";
 import { AgentDetail, ModelDetail, RepoDetail } from "./insights/BreakdownDetail";
 import { BudgetPanel } from "./insights/BudgetPanel";
+import { ResourcePanel } from "./insights/ResourcePanel";
 
 // ── Periods ─────────────────────────────────────────────────────────────────
 //
@@ -645,6 +646,10 @@ export function Insights() {
       {/* ── Budget cap — moved here from Settings; it governs the spend
           shown above. ── */}
       <BudgetPanel />
+
+      {/* ── Resource budget — committed CPU/memory caps per agent, the
+          compute counterpart to the cost cap above. ── */}
+      <ResourcePanel />
 
       {/* ── Spend over time ── */}
       <section>

--- a/web/src/views/__tests__/views.test.tsx
+++ b/web/src/views/__tests__/views.test.tsx
@@ -253,14 +253,14 @@ describe("AgentDetail tab navigation", () => {
       expect(screen.getByText("bot-1")).toBeInTheDocument();
     });
 
-    // Attach (default) → Config
-    fireEvent.click(screen.getByRole("button", { name: "Config" }));
+    // Attach (default) → Settings
+    fireEvent.click(screen.getByRole("button", { name: "Settings" }));
     await waitFor(() => {
-      expect(screen.getByTestId("location")).toHaveTextContent("/agents/bot-1/config");
+      expect(screen.getByTestId("location")).toHaveTextContent("/agents/bot-1/settings");
     });
 
-    // Config → Metrics: the old relative builder produced
-    // /agents/bot-1/config/metrics here.
+    // Settings → Metrics: the old relative builder produced
+    // /agents/bot-1/settings/metrics here.
     fireEvent.click(screen.getByRole("button", { name: "Metrics" }));
     await waitFor(() => {
       expect(screen.getByTestId("location").textContent).toBe("/agents/bot-1/metrics");
@@ -459,7 +459,7 @@ describe("AgentDetail lifecycle controls", () => {
     expect(restart).toBeEnabled();
   });
 
-  it("Config tab renders the Apps card with the agent's subscriptions", async () => {
+  it("Settings tab renders the Apps card with the agent's subscriptions", async () => {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {
       const u = String(url);
       if (u.endsWith("/api/agents/bot-1")) {

--- a/web/src/views/insights/ResourcePanel.tsx
+++ b/web/src/views/insights/ResourcePanel.tsx
@@ -1,0 +1,122 @@
+/**
+ * ResourcePanel — the fleet's compute budget, living in Insights next to
+ * the cost budget. It answers "how much CPU/memory have I committed across
+ * agents, and where?" from the per-agent Docker caps (set on each agent's
+ * Settings tab). Agents with no override inherit the fleet default, shown
+ * for context.
+ *
+ * Live per-agent CPU/memory *usage* is sampled for the Docker runtime
+ * (agent_stats) but not yet aggregated into a fleet figure — so this panel
+ * is honest about showing configured caps, with a clear seam for usage.
+ */
+
+import { useCallback } from "react";
+import { api, type Agent, type SettingsConfig } from "../../api/client";
+import { usePolling } from "../../hooks/usePolling";
+import { SectionRule } from "../../components/shared/SectionRule";
+import { stripAgentPrefix } from "./chrome";
+
+interface ResourceData {
+  agents: Agent[];
+  settings: SettingsConfig | null;
+}
+
+/** MB → human ("2048 MB" → "2.0 GB"). */
+function fmtMem(mb: number): string {
+  if (mb <= 0) return "—";
+  if (mb >= 1024) return `${(mb / 1024).toFixed(mb % 1024 === 0 ? 0 : 1)} GB`;
+  return `${mb} MB`;
+}
+
+export function ResourcePanel() {
+  const fetcher = useCallback(async (): Promise<ResourceData> => {
+    const [agents, settings] = await Promise.allSettled([
+      api.listAgents(),
+      api.getSettings(),
+    ]);
+    return {
+      agents: agents.status === "fulfilled" && Array.isArray(agents.value) ? agents.value : [],
+      settings: settings.status === "fulfilled" ? settings.value : null,
+    };
+  }, []);
+
+  const { data } = usePolling<ResourceData>(fetcher, 30000);
+  const agents = data?.agents ?? [];
+  const settings = data?.settings ?? null;
+
+  const defCpu = settings?.runtime?.docker?.cpus ?? 0;
+  const defMem = settings?.runtime?.docker?.memory_mb ?? 0;
+
+  // Only Docker agents are actually constrained; tmux agents run
+  // unconstrained on the host, so they don't count toward the committed
+  // budget (but we still surface them honestly, unconstrained).
+  const dockerAgents = agents.filter((a) => (a.runtime_backend ?? "docker") === "docker");
+
+  // Effective cap per agent = its override, else the fleet default.
+  const rows = dockerAgents.map((a) => ({
+    name: stripAgentPrefix(a.name),
+    cpus: a.cpus && a.cpus > 0 ? a.cpus : defCpu,
+    memoryMB: a.memory_mb && a.memory_mb > 0 ? a.memory_mb : defMem,
+    overridden: (a.cpus ?? 0) > 0 || (a.memory_mb ?? 0) > 0,
+  }));
+
+  const totalCpu = rows.reduce((s, r) => s + r.cpus, 0);
+  const totalMem = rows.reduce((s, r) => s + r.memoryMB, 0);
+
+  return (
+    <section>
+      <SectionRule
+        label="Resource budget"
+        trailing={<span className="text-[11px] text-mycel-muted">committed caps · Docker agents</span>}
+      />
+      <div className="rounded-lg border border-mycel-border bg-mycel-surface shadow-mycel-sm p-4 space-y-3">
+        {/* Committed totals */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 gap-px bg-mycel-border rounded-md overflow-hidden">
+          <div className="bg-mycel-surface p-3">
+            <div className="text-[10px] font-medium text-mycel-muted uppercase tracking-[0.08em]">CPU committed</div>
+            <div className="mt-1 text-lg font-semibold tabular-nums text-mycel-text">
+              {totalCpu > 0 ? `${totalCpu.toFixed(1)} cores` : "—"}
+            </div>
+          </div>
+          <div className="bg-mycel-surface p-3">
+            <div className="text-[10px] font-medium text-mycel-muted uppercase tracking-[0.08em]">Memory committed</div>
+            <div className="mt-1 text-lg font-semibold tabular-nums text-mycel-text">{fmtMem(totalMem)}</div>
+          </div>
+          <div className="bg-mycel-surface p-3">
+            <div className="text-[10px] font-medium text-mycel-muted uppercase tracking-[0.08em]">Fleet default</div>
+            <div className="mt-1 text-sm tabular-nums text-mycel-text-2">
+              {defCpu > 0 ? `${defCpu} cores` : "—"} · {fmtMem(defMem)}
+            </div>
+          </div>
+        </div>
+
+        {/* Per-agent breakdown */}
+        {rows.length > 0 ? (
+          <div className="rounded-lg border border-mycel-border bg-mycel-bg divide-y divide-mycel-border overflow-hidden">
+            {rows.map((r) => (
+              <div key={r.name} className="flex items-center justify-between gap-3 px-3 py-2 text-xs">
+                <span className="text-mycel-text truncate">{r.name}</span>
+                <span className="flex items-center gap-2 shrink-0 tabular-nums text-mycel-muted">
+                  <span>{r.cpus > 0 ? `${r.cpus} CPU` : "—"}</span>
+                  <span className="text-mycel-border">·</span>
+                  <span>{fmtMem(r.memoryMB)}</span>
+                  {!r.overridden && (
+                    <span className="text-[10px] text-mycel-muted/70 italic">default</span>
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-xs text-mycel-muted">No Docker agents to budget yet.</p>
+        )}
+
+        <p className="text-[11px] text-mycel-muted leading-relaxed">
+          Set per-agent CPU/memory caps from an agent&apos;s Settings tab. Live usage metrics
+          (actual CPU/memory consumed) are coming soon — this panel shows committed caps.
+          {/* follow-up: aggregate agent_stats samples into a live fleet usage figure. */}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/web/src/views/insights/ResourcePanel.tsx
+++ b/web/src/views/insights/ResourcePanel.tsx
@@ -10,7 +10,7 @@
  * is honest about showing configured caps, with a clear seam for usage.
  */
 
-import { useCallback } from "react";
+import { useCallback, type ReactNode } from "react";
 import { api, type Agent, type SettingsConfig } from "../../api/client";
 import { usePolling } from "../../hooks/usePolling";
 import { SectionRule } from "../../components/shared/SectionRule";
@@ -18,7 +18,7 @@ import { stripAgentPrefix } from "./chrome";
 
 interface ResourceData {
   agents: Agent[];
-  settings: SettingsConfig | null;
+  settings: SettingsConfig;
 }
 
 /** MB → human ("2048 MB" → "2.0 GB"). */
@@ -28,19 +28,68 @@ function fmtMem(mb: number): string {
   return `${mb} MB`;
 }
 
+/** Frame the panel with its section header so error/loading states keep the
+ *  same shell as the loaded panel. */
+function ResourceShell({ children }: { children: ReactNode }) {
+  return (
+    <section>
+      <SectionRule
+        label="Resource budget"
+        trailing={<span className="text-[11px] text-mycel-muted">committed caps · Docker agents</span>}
+      />
+      <div className="rounded-lg border border-mycel-border bg-mycel-surface shadow-mycel-sm p-4 space-y-3">
+        {children}
+      </div>
+    </section>
+  );
+}
+
 export function ResourcePanel() {
+  // Both sources must succeed: a failed listAgents would understate agents,
+  // and a failed getSettings would drop the fleet defaults and understate
+  // committed caps. Reject on either so usePolling exposes the error state
+  // instead of silently rendering "no resources".
   const fetcher = useCallback(async (): Promise<ResourceData> => {
-    const [agents, settings] = await Promise.allSettled([
+    const [agents, settings] = await Promise.all([
       api.listAgents(),
       api.getSettings(),
     ]);
     return {
-      agents: agents.status === "fulfilled" && Array.isArray(agents.value) ? agents.value : [],
-      settings: settings.status === "fulfilled" ? settings.value : null,
+      agents: Array.isArray(agents) ? agents : [],
+      settings,
     };
   }, []);
 
-  const { data } = usePolling<ResourceData>(fetcher, 30000);
+  const { data, loading, error, refresh } = usePolling<ResourceData>(fetcher, 30000);
+
+  // First-load error (no data yet) → an explicit unavailable state with a
+  // retry, never a misleading empty panel.
+  if (error && !data) {
+    return (
+      <ResourceShell>
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-xs text-mycel-muted">Couldn&apos;t load resource budget.</p>
+          <button
+            type="button"
+            onClick={refresh}
+            className="inline-flex items-center h-7 px-2.5 rounded-md text-[11px] font-medium border border-mycel-border text-mycel-text-2 hover:text-mycel-text hover:border-mycel-muted transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      </ResourceShell>
+    );
+  }
+
+  // First load in flight → a quiet placeholder, not a "no agents" claim.
+  if (loading && !data) {
+    return (
+      <ResourceShell>
+        <p className="text-xs text-mycel-muted">Loading resource budget…</p>
+      </ResourceShell>
+    );
+  }
+
   const agents = data?.agents ?? [];
   const settings = data?.settings ?? null;
 
@@ -64,12 +113,8 @@ export function ResourcePanel() {
   const totalMem = rows.reduce((s, r) => s + r.memoryMB, 0);
 
   return (
-    <section>
-      <SectionRule
-        label="Resource budget"
-        trailing={<span className="text-[11px] text-mycel-muted">committed caps · Docker agents</span>}
-      />
-      <div className="rounded-lg border border-mycel-border bg-mycel-surface shadow-mycel-sm p-4 space-y-3">
+    <ResourceShell>
+      <>
         {/* Committed totals */}
         <div className="grid grid-cols-2 sm:grid-cols-3 gap-px bg-mycel-border rounded-md overflow-hidden">
           <div className="bg-mycel-surface p-3">
@@ -116,7 +161,7 @@ export function ResourcePanel() {
           (actual CPU/memory consumed) are coming soon — this panel shows committed caps.
           {/* follow-up: aggregate agent_stats samples into a live fleet usage figure. */}
         </p>
-      </div>
-    </section>
+      </>
+    </ResourceShell>
   );
 }


### PR DESCRIPTION
Part of #2674 (Build 3). Renames the agent detail **Config** tab to **Settings** and grows it into a real per-agent settings surface, plus adds per-agent Docker CPU/memory budgeting end to end and a committed-caps view in Insights.

## Part A (#52) — Agent Settings

**Fully working**
- Tab **Config → Settings** (label, URL key `settings`, keyboard shortcut). Legacy `/agents/<name>/config` deep links still resolve to Settings via an alias.
- **Model override** — live `<select>` bound to `PATCH /config { model }`. The model is persisted on the agent record and re-read on the next restart (genuinely backed). Save→loading→success pill.
- **Resource Limits** (CPU cores / Memory MB) — see Part B. Docker-enforced; tmux shows an honest "not enforced" note.
- **System prompt**, **MCP servers** (add/remove), **channel subscriptions** (`AgentAppsCard`), **environment** — pre-existing real wiring, retained under the renamed tab.

**Seamed (honest)**
- **Provider switch** — shown read-only with a note to clone onto a different provider; switching in place needs a container re-image (`// follow-up:` in `ProviderModelSection`).

## Part B (#53) — Per-agent resource budgeting

**Fully working**
- Agent record gains `cpus` / `memory_mb` — new SQLite columns, round-tripped through `Save`/`SaveAll`/scan (verified surviving a daemon restart).
- `Manager.SetAgentResources` / `SetAgentModel`; `AgentService.SetResources` (publishes `agent.resources_updated`).
- Docker backend applies per-agent caps: the manager plumbs `MYCEL_CPUS` / `MYCEL_MEMORY_MB` into the session env at spawn, and `container.go` uses them to override the fleet-default `--cpus`/`--memory` for that one container. tmux ignores them.
- `PATCH /api/agents/{name}/config` now takes optional `system_prompt` / `model` / `cpus` / `memory_mb` as pointer fields — an omitted field is left untouched (a cpus-only PATCH no longer wipes the prompt). Negative caps → 400.
- `agentDTO` (list/get) carries `cpus`/`memory_mb` so Insights totals caps without a per-agent fetch.
- **Insights → ResourcePanel**: committed CPU/memory totals + per-agent breakdown vs the fleet default.

**Seamed (honest)**
- **Live CPU/memory usage** in Insights — the panel shows *committed caps* and a clear "live usage metrics coming soon" note (`// follow-up:` to aggregate `agent_stats` samples). No fabricated usage numbers.

## Real backend fields bound to
- `agent.Agent.SystemPrompt` (per-tool prompt file), `.Model`, `.CPUs`, `.MemoryMB`, `.MCPServers`, channel subs (existing notify machinery), env.
- Fleet defaults read from `prefs runtime.docker.{cpus,memory_mb}` for placeholders.

## Test plan (commands + results)
- `bunx tsc --noEmit` → clean
- `bun run lint` → clean
- `bun run build` → built
- `bunx vitest run` → **305 passed / 35 files** (added Settings-rename assertions)
- `go build ./...` / `go vet ./...` → clean
- `golangci-lint run` (agent, container, handlers) → **0 issues**
- `go test ./server/handlers/ ./pkg/agent/ ./pkg/container/` → ok (added `TestPatchAgentConfig_Resources`: resource+model PATCH persists, omitted prompt untouched, negative cap → 400)
- **Live smoke** on a throwaway `MYCEL_HOME` at `127.0.0.1:8099`: created a tmux agent, `PATCH /config {cpus,memory_mb,model}` → echoed + persisted on GET + agent DTO; cpus-only PATCH preserved the system prompt; negative cap → HTTP 400; **values survived a daemon restart** (DB round-trip). Torn down after.

## ui-ux-pro-max applied
Coffee-cream/mushroom tokens throughout; save→loading→success pill with spinner; disabled/invalid states on inputs and buttons; honest empty/seam states; MONO for identifiers; both-theme contrast via mycel tokens; no unguarded animations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-agent CPU and memory limit controls in Settings.
  * Added provider model selection and persistence for agent configurations.
  * Added an Insights resource panel showing defaults, committed totals, and per-agent allocations.
  * Agent details now use the “Settings” tab, with legacy configuration links preserved.
* **Improvements**
  * Agent configuration responses display current resource limits and model settings.
  * Resource values are validated and persisted across agent restarts.
* **Bug Fixes**
  * Prevented invalid or non-positive resource values from overriding configured defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->