### PR TITLE
feat(apps): one-click loopback OAuth for Gmail + GitHub connect

### DIFF
--- a/docs/design/apps-plugin.md
+++ b/docs/design/apps-plugin.md
@@ -131,6 +131,56 @@ and `POST /api/apps/{name}/auth` + `GET .../auth/status?session=<id>`
 drive it; on completion the server persists the returned secrets to the
 vault and hot-starts the adapter.
 
+### Loopback (localhost redirect) flow — Google / Gmail
+
+The generic authorization-code + PKCE flow lives in `pkg/oauth`
+(`LoopbackFlow`). On `BeginAuth` the daemon opens a short-lived listener on
+`http://127.0.0.1:<port>/oauth/callback` (an ephemeral port), returns the
+provider consent URL (`AuthURL`, `Kind == "callback"`), and the web UI opens
+it in the user's browser. Google redirects back to the loopback listener with
+the `code`; `PollAuth` exchanges it (with the PKCE verifier) for access +
+refresh tokens and hands them back as vault secrets. This is fully local — no
+hosted redirect, no cloud — which is exactly what Google "Desktop app" OAuth
+clients permit.
+
+Gmail wires this flow (`pkg/gateway/gmail`) with the `gmail.readonly` +
+`gmail.send` scopes and `access_type=offline` + `prompt=consent` so Google
+always returns a refresh token. The server-side Google client is read from
+`GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET`. When they are unset,
+the plugin's optional `OAuthConfigured` capability reports `false`, so
+`oauth_available` is `false` and the connect UI shows the honest
+client-id/secret/refresh-token paste fallback instead of a button that would
+fail.
+
+```go
+// OAuthConfigured is an optional capability an OAuthFlow plugin implements to
+// report whether its browser flow is usable right now (server-side client
+// creds present). false → the catalog reports oauth_available=false.
+type OAuthConfigured interface {
+    OAuthConfigured() bool
+}
+```
+
+**Registering the Google "Desktop app" client (owner, one-time):**
+
+1. Google Cloud Console → *APIs & Services* → **Enable** the Gmail API for the
+   project.
+2. *APIs & Services* → *OAuth consent screen* → add the scopes
+   `https://www.googleapis.com/auth/gmail.readonly` and
+   `https://www.googleapis.com/auth/gmail.send`; add your Google account as a
+   test user (or publish the app).
+3. *APIs & Services* → *Credentials* → *Create credentials* → *OAuth client ID*
+   → application type **Desktop app**. Desktop clients allow the loopback
+   redirect `http://127.0.0.1:<port>/oauth/callback` (any port), so no fixed
+   redirect URL needs registering.
+4. Export the client on the machine running the daemon:
+   `GOOGLE_OAUTH_CLIENT_ID=<id>.apps.googleusercontent.com` and
+   `GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-…`, then restart `mycel up`. Gmail's
+   connect modal now shows one-click **Sign in with Gmail**.
+
+Slack-type apps that need a fixed HTTPS redirect stay on token paste; real
+Slack OAuth is deferred to a future hosted-redirect ("mycel cloud").
+
 ## Config: generic instances, secrets in the vault
 
 The old `gateways` config section is replaced by `apps` in `prefs.json`:

--- a/pkg/app/oauth.go
+++ b/pkg/app/oauth.go
@@ -74,3 +74,17 @@ type OAuthFlow interface {
 	// session's interval themselves.
 	PollAuth(ctx context.Context, session AuthSession) (AuthResult, error)
 }
+
+// OAuthConfigured is an optional capability on an OAuthFlow plugin. It
+// reports whether the browser flow is actually usable right now — e.g. the
+// server-side OAuth client credentials are present. When it returns false,
+// the catalog reports oauth_available=false so the connect UI shows the
+// honest token-paste fallback instead of a "Connect" button that would fail.
+//
+// A plugin whose flow needs only per-instance config the user pastes (like
+// the GitHub device flow's client ID) does not implement this — its flow is
+// always "available" and BeginAuth surfaces any missing field.
+type OAuthConfigured interface {
+	// OAuthConfigured reports whether the browser sign-in can run now.
+	OAuthConfigured() bool
+}

--- a/pkg/gateway/gmail/oauth.go
+++ b/pkg/gateway/gmail/oauth.go
@@ -1,0 +1,68 @@
+package gmailgw
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	gmail "google.golang.org/api/gmail/v1"
+
+	"github.com/rpuneet/mycel/pkg/app"
+	"github.com/rpuneet/mycel/pkg/oauth"
+)
+
+// Server-side Google "Desktop app" OAuth client, read from the environment.
+// These are the mycel-registered client credentials that make one-click
+// "Connect with Google" work; when unset, the connect UI falls back to the
+// manual client-id/secret/refresh-token paste.
+const (
+	envGoogleClientID     = "GOOGLE_OAUTH_CLIENT_ID"
+	envGoogleClientSecret = "GOOGLE_OAUTH_CLIENT_SECRET" //nolint:gosec // env var name, not a credential
+)
+
+// newGoogleFlow builds the loopback OAuth flow for Gmail: Google's endpoints,
+// the Gmail read + send scopes, and offline+consent so Google always returns
+// a refresh token. On completion it hands the client credentials and refresh
+// token back as the vault secrets the Gmail adapter's Build expects.
+func newGoogleFlow() *oauth.LoopbackFlow {
+	return oauth.NewLoopbackFlow(
+		oauth.Provider{
+			Endpoint: google.Endpoint,
+			Scopes:   []string{gmail.GmailReadonlyScope, gmail.GmailSendScope},
+			// prompt=consent forces the consent screen so a refresh_token is
+			// returned even on re-authorization (AccessTypeOffline alone can
+			// omit it once the user has previously consented).
+			AuthCodeOptions: []oauth2.AuthCodeOption{oauth2.SetAuthURLParam("prompt", "consent")},
+			Secrets: func(clientID, clientSecret string, tok *oauth2.Token) map[string]string {
+				return map[string]string{
+					"client_id":     clientID,
+					"client_secret": clientSecret,
+					"refresh_token": tok.RefreshToken,
+				}
+			},
+		},
+		googleClientCreds,
+	)
+}
+
+// googleClientCreds resolves the server-side Google client from the
+// environment, returning an actionable error (surfaced to the user) when the
+// one-click client is not configured.
+func googleClientCreds(_ app.Instance) (clientID, clientSecret string, err error) {
+	clientID = strings.TrimSpace(os.Getenv(envGoogleClientID))
+	clientSecret = strings.TrimSpace(os.Getenv(envGoogleClientSecret))
+	if clientID == "" || clientSecret == "" {
+		return "", "", fmt.Errorf(
+			"one-click Google sign-in is not configured on this server — set %s and %s to a Google \"Desktop app\" OAuth client, or paste an OAuth refresh token below instead",
+			envGoogleClientID, envGoogleClientSecret)
+	}
+	return clientID, clientSecret, nil
+}
+
+// googleConfigured reports whether one-click Google sign-in is available.
+func googleConfigured() bool {
+	return strings.TrimSpace(os.Getenv(envGoogleClientID)) != "" &&
+		strings.TrimSpace(os.Getenv(envGoogleClientSecret)) != ""
+}

--- a/pkg/gateway/gmail/oauth_test.go
+++ b/pkg/gateway/gmail/oauth_test.go
@@ -1,0 +1,89 @@
+package gmailgw
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/app"
+)
+
+// newTestPlugin builds a plugin value for tests with the Google loopback flow
+// wired, matching how init() registers it.
+func newTestPlugin() *plugin {
+	return &plugin{oauth: newGoogleFlow()}
+}
+
+// TestPluginImplementsOAuth locks the capability assertions the server relies
+// on to dispatch the browser flow.
+func TestPluginImplementsOAuth(t *testing.T) {
+	var p any = newTestPlugin()
+	if _, ok := p.(app.OAuthFlow); !ok {
+		t.Error("gmail plugin does not implement app.OAuthFlow")
+	}
+	if _, ok := p.(app.OAuthConfigured); !ok {
+		t.Error("gmail plugin does not implement app.OAuthConfigured")
+	}
+}
+
+// TestOAuthConfiguredTracksEnv verifies one-click availability follows the
+// server-side Google client env vars.
+func TestOAuthConfiguredTracksEnv(t *testing.T) {
+	p := newTestPlugin()
+
+	t.Setenv(envGoogleClientID, "")
+	t.Setenv(envGoogleClientSecret, "")
+	if p.OAuthConfigured() {
+		t.Error("OAuthConfigured() = true with no client creds; want false")
+	}
+
+	t.Setenv(envGoogleClientID, "client.apps.googleusercontent.com")
+	t.Setenv(envGoogleClientSecret, "GOCSPX-secret")
+	if !p.OAuthConfigured() {
+		t.Error("OAuthConfigured() = false with client creds set; want true")
+	}
+}
+
+// TestBeginAuthUnconfigured surfaces an actionable error (not a dead flow)
+// when the server has no Google client.
+func TestBeginAuthUnconfigured(t *testing.T) {
+	t.Setenv(envGoogleClientID, "")
+	t.Setenv(envGoogleClientSecret, "")
+	p := newTestPlugin()
+	_, err := p.BeginAuth(context.Background(), app.Instance{Name: "gmail"})
+	if err == nil {
+		t.Fatal("BeginAuth with no client creds returned nil error; want fallback message")
+	}
+}
+
+// TestBeginAuthConfigured produces a Google consent URL carrying the loopback
+// redirect and PKCE challenge.
+func TestBeginAuthConfigured(t *testing.T) {
+	t.Setenv(envGoogleClientID, "client.apps.googleusercontent.com")
+	t.Setenv(envGoogleClientSecret, "GOCSPX-secret")
+	p := newTestPlugin()
+	sess, err := p.BeginAuth(context.Background(), app.Instance{Name: "gmail"})
+	if err != nil {
+		t.Fatalf("BeginAuth: %v", err)
+	}
+	defer p.oauth.PollAuth(context.Background(), app.AuthSession{ID: sess.ID}) //nolint:errcheck // drive teardown
+
+	if sess.Kind != app.AuthKindCallback {
+		t.Errorf("Kind = %q, want %q", sess.Kind, app.AuthKindCallback)
+	}
+	for _, want := range []string{
+		"accounts.google.com",
+		"code_challenge=",
+		"code_challenge_method=S256",
+		"redirect_uri=http%3A%2F%2F127.0.0.1%3A",
+		"%2Foauth%2Fcallback",
+		"access_type=offline",
+		"prompt=consent",
+		"gmail.readonly",
+		"gmail.send",
+	} {
+		if !strings.Contains(sess.AuthURL, want) {
+			t.Errorf("consent URL missing %q\nurl: %s", want, sess.AuthURL)
+		}
+	}
+}

--- a/pkg/gateway/gmail/plugin.go
+++ b/pkg/gateway/gmail/plugin.go
@@ -1,23 +1,35 @@
 package gmailgw
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
 	"github.com/rpuneet/mycel/pkg/app"
 	"github.com/rpuneet/mycel/pkg/gateway"
+	"github.com/rpuneet/mycel/pkg/oauth"
 )
 
-// plugin implements app.Plugin for Gmail.
-type plugin struct{}
-
-var _ app.Plugin = plugin{}
-
-func init() {
-	app.Register(plugin{})
+// plugin implements app.Plugin for Gmail, plus app.OAuthFlow: one-click
+// "Connect with Google" runs a local loopback OAuth flow that mints the
+// refresh token. When the server-side Google client isn't configured the
+// flow reports unavailable (OAuthConfigured) and the UI falls back to the
+// manual client-id/secret/refresh-token paste below.
+type plugin struct {
+	oauth *oauth.LoopbackFlow
 }
 
-func (plugin) Describe() app.Descriptor {
+var (
+	_ app.Plugin          = (*plugin)(nil)
+	_ app.OAuthFlow       = (*plugin)(nil)
+	_ app.OAuthConfigured = (*plugin)(nil)
+)
+
+func init() {
+	app.Register(&plugin{oauth: newGoogleFlow()})
+}
+
+func (*plugin) Describe() app.Descriptor {
 	return app.Descriptor{
 		ID:    "gmail",
 		Label: "Gmail",
@@ -31,7 +43,8 @@ func (plugin) Describe() app.Descriptor {
 			{Key: "interval", Label: "Poll Interval (seconds)", Placeholder: "60"},
 		},
 		Docs: []string{
-			"Create OAuth credentials in Google Cloud Console → APIs & Services → Credentials.",
+			"Fastest path: if this server has a Google OAuth client configured, click \"Sign in with Gmail\" above — mycel opens Google in your browser and stores the token locally, no pasting.",
+			"Manual path (no server client): create OAuth credentials in Google Cloud Console → APIs & Services → Credentials.",
 			"Enable the Gmail API for the project, then create an OAuth 2.0 Client ID (type: Desktop app).",
 			"Grant the scopes https://www.googleapis.com/auth/gmail.readonly and https://www.googleapis.com/auth/gmail.send on the consent screen.",
 			"Run the OAuth consent flow once (e.g. via the OAuth Playground with your own client) to obtain a refresh token for offline access.",
@@ -41,7 +54,24 @@ func (plugin) Describe() app.Descriptor {
 	}
 }
 
-func (plugin) Build(inst app.Instance, _ app.Env) (gateway.NotificationAdapter, error) {
+// BeginAuth starts the loopback Google sign-in for this instance.
+func (p *plugin) BeginAuth(ctx context.Context, inst app.Instance) (app.AuthSession, error) {
+	return p.oauth.BeginAuth(ctx, inst)
+}
+
+// PollAuth reports sign-in progress; on success it returns the client
+// credentials + refresh token for the server to persist to the vault.
+func (p *plugin) PollAuth(ctx context.Context, session app.AuthSession) (app.AuthResult, error) {
+	return p.oauth.PollAuth(ctx, session)
+}
+
+// OAuthConfigured reports whether one-click Google sign-in is available on
+// this server (the GOOGLE_OAUTH_CLIENT_ID/SECRET client is set).
+func (*plugin) OAuthConfigured() bool {
+	return googleConfigured()
+}
+
+func (*plugin) Build(inst app.Instance, _ app.Env) (gateway.NotificationAdapter, error) {
 	clientID, err := inst.RequiredSecret("client_id")
 	if err != nil {
 		return nil, err

--- a/pkg/gateway/gmail/plugin_test.go
+++ b/pkg/gateway/gmail/plugin_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestPluginDescribe(t *testing.T) {
-	d := plugin{}.Describe()
+	d := newTestPlugin().Describe()
 	if d.ID != "gmail" || d.Label == "" {
 		t.Errorf("Describe() = ID %q, Label %q; want gmail, non-empty", d.ID, d.Label)
 	}
@@ -68,7 +68,7 @@ func TestPluginBuild(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inst := app.Instance{App: "gmail", Name: "gmail", Config: tt.cfg, Secrets: tt.secrets}
-			adapter, err := plugin{}.Build(inst, app.Env{})
+			adapter, err := newTestPlugin().Build(inst, app.Env{})
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Build error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/oauth/loopback.go
+++ b/pkg/oauth/loopback.go
@@ -1,0 +1,325 @@
+// Package oauth provides a generic loopback (localhost redirect) OAuth 2.0
+// authorization-code + PKCE flow that runs entirely on the local machine.
+//
+// The daemon opens a short-lived listener on http://127.0.0.1:<port>/oauth/callback,
+// the user authorizes in their system browser (the web UI opens the consent
+// URL), and the daemon exchanges the returned code for access + refresh
+// tokens which it hands back to the caller to persist in the vault. No hosted
+// redirect and no cloud are involved — this is the flow "Desktop app" OAuth
+// clients (e.g. Google) permit via loopback redirects.
+//
+// It implements app.OAuthFlow (AuthKindCallback), so it slots into the same
+// /api/apps/{name}/auth begin+poll endpoints as the GitHub device flow.
+// Sessions live in memory only and expire within minutes: a daemon restart
+// aborts a pending sign-in and the user simply starts over.
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/rpuneet/mycel/pkg/app"
+)
+
+const (
+	// callbackPath is the loopback redirect path. The full redirect URI is
+	// http://127.0.0.1:<port>/oauth/callback with a per-session ephemeral port.
+	callbackPath = "/oauth/callback"
+	// sessionTTL bounds how long a begun flow stays pollable.
+	sessionTTL = 5 * time.Minute
+	// pollInterval is the minimum client poll spacing reported to the UI.
+	pollInterval = 2 * time.Second
+)
+
+// Provider is the static description of one provider's loopback flow.
+type Provider struct {
+	// Endpoint is the provider's authorization + token endpoints.
+	Endpoint oauth2.Endpoint
+	// Secrets maps a granted token into the vault secret keys the app's
+	// Build expects (e.g. {"refresh_token": ..., "client_id": ...}).
+	Secrets func(clientID, clientSecret string, tok *oauth2.Token) map[string]string
+	// Scopes requested on the consent screen.
+	Scopes []string
+	// AuthCodeOptions are appended to the consent URL — e.g. offline access
+	// and a consent prompt to force a refresh token on Google.
+	AuthCodeOptions []oauth2.AuthCodeOption
+}
+
+// CredsFunc resolves the OAuth client_id + client_secret for an instance.
+// It returns a clear, actionable error when the server-side client is not
+// configured, so the caller surfaces the token-paste fallback.
+type CredsFunc func(inst app.Instance) (clientID, clientSecret string, err error)
+
+// LoopbackFlow implements app.OAuthFlow for a single provider using loopback
+// redirects. It is safe for concurrent use.
+type LoopbackFlow struct {
+	creds    CredsFunc
+	sessions map[string]*loopbackSession
+	provider Provider
+	mu       sync.Mutex
+}
+
+// loopbackSession is one in-flight authorization. The callback listener runs
+// on its own goroutine and records the code (or error) under the flow mutex;
+// PollAuth reads it and performs the token exchange.
+type loopbackSession struct {
+	conf       *oauth2.Config
+	srv        *http.Server
+	expiresAt  time.Time
+	verifier   string
+	state      string
+	code       string
+	errMsg     string
+	exchanging bool
+	closed     bool // listener already shut down
+}
+
+// NewLoopbackFlow builds a flow for a provider with a client-credential
+// resolver.
+func NewLoopbackFlow(provider Provider, creds CredsFunc) *LoopbackFlow {
+	return &LoopbackFlow{
+		provider: provider,
+		creds:    creds,
+		sessions: make(map[string]*loopbackSession),
+	}
+}
+
+// BeginAuth resolves the client credentials, starts a loopback listener, and
+// returns the consent URL for the user to open in a browser.
+func (f *LoopbackFlow) BeginAuth(ctx context.Context, inst app.Instance) (app.AuthSession, error) {
+	clientID, clientSecret, err := f.creds(inst)
+	if err != nil {
+		return app.AuthSession{}, err
+	}
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	if err != nil {
+		return app.AuthSession{}, fmt.Errorf("start loopback listener: %w", err)
+	}
+	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = ln.Close() //nolint:errcheck // best-effort cleanup on error
+		return app.AuthSession{}, fmt.Errorf("loopback listener has no TCP address")
+	}
+	redirectURL := fmt.Sprintf("http://127.0.0.1:%d%s", tcpAddr.Port, callbackPath)
+
+	id, err := randToken()
+	if err != nil {
+		_ = ln.Close() //nolint:errcheck // best-effort cleanup on error
+		return app.AuthSession{}, fmt.Errorf("session id: %w", err)
+	}
+	state, err := randToken()
+	if err != nil {
+		_ = ln.Close() //nolint:errcheck // best-effort cleanup on error
+		return app.AuthSession{}, fmt.Errorf("state: %w", err)
+	}
+
+	conf := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Endpoint:     f.provider.Endpoint,
+		Scopes:       f.provider.Scopes,
+		RedirectURL:  redirectURL,
+	}
+	verifier := oauth2.GenerateVerifier()
+
+	sess := &loopbackSession{
+		conf:      conf,
+		verifier:  verifier,
+		state:     state,
+		expiresAt: time.Now().Add(sessionTTL),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(callbackPath, func(w http.ResponseWriter, r *http.Request) {
+		f.handleCallback(w, r, id)
+	})
+	srv := &http.Server{Handler: mux, ReadHeaderTimeout: 10 * time.Second}
+	sess.srv = srv
+
+	f.mu.Lock()
+	f.pruneLocked()
+	f.sessions[id] = sess
+	f.mu.Unlock()
+
+	go func() { _ = srv.Serve(ln) }() //nolint:errcheck // Serve returns on Shutdown
+
+	opts := make([]oauth2.AuthCodeOption, 0, len(f.provider.AuthCodeOptions)+2)
+	opts = append(opts, oauth2.S256ChallengeOption(verifier), oauth2.AccessTypeOffline)
+	opts = append(opts, f.provider.AuthCodeOptions...)
+	authURL := conf.AuthCodeURL(state, opts...)
+
+	return app.AuthSession{
+		ID:        id,
+		Kind:      app.AuthKindCallback,
+		AuthURL:   authURL,
+		ExpiresAt: sess.expiresAt,
+		Interval:  pollInterval,
+	}, nil
+}
+
+// handleCallback validates state, records the authorization code (or error),
+// renders a browser page, and tears down the listener.
+func (f *LoopbackFlow) handleCallback(w http.ResponseWriter, r *http.Request, id string) {
+	q := r.URL.Query()
+
+	f.mu.Lock()
+	sess, ok := f.sessions[id]
+	if !ok {
+		f.mu.Unlock()
+		writePage(w, "This sign-in session has expired. Return to mycel and start again.")
+		return
+	}
+
+	switch {
+	case q.Get("error") != "":
+		sess.errMsg = oauthErr(q.Get("error"), q.Get("error_description"))
+	case q.Get("state") != sess.state:
+		sess.errMsg = "state mismatch — the sign-in could not be verified; start again"
+	case q.Get("code") == "":
+		sess.errMsg = "no authorization code returned"
+	default:
+		sess.code = q.Get("code")
+	}
+	msg := sess.errMsg
+	f.mu.Unlock()
+
+	// The listener has done its job either way; shut it down in the
+	// background so the response flushes first. The session stays in the map
+	// until PollAuth reads the code (or error) and reaches a terminal state.
+	go f.closeListener(id)
+
+	if msg != "" {
+		writePage(w, "Sign-in failed: "+msg+" You can close this window.")
+		return
+	}
+	writePage(w, "Sign-in complete. You can close this window and return to mycel.")
+}
+
+// PollAuth reports progress and, once the code has arrived, exchanges it for
+// tokens. The exchange runs at most once per session.
+func (f *LoopbackFlow) PollAuth(ctx context.Context, session app.AuthSession) (app.AuthResult, error) {
+	f.mu.Lock()
+	sess, ok := f.sessions[session.ID]
+	if !ok {
+		f.mu.Unlock()
+		return app.AuthResult{State: app.AuthStateError, Error: "unknown or expired sign-in session — start the sign-in again (a daemon restart aborts pending sign-ins)"}, nil
+	}
+	if time.Now().After(sess.expiresAt) {
+		f.mu.Unlock()
+		f.drop(session.ID)
+		return app.AuthResult{State: app.AuthStateError, Error: "the sign-in timed out — start the sign-in again"}, nil
+	}
+	if sess.errMsg != "" {
+		msg := sess.errMsg
+		f.mu.Unlock()
+		f.drop(session.ID)
+		return app.AuthResult{State: app.AuthStateError, Error: msg}, nil
+	}
+	if sess.code == "" || sess.exchanging {
+		f.mu.Unlock()
+		return app.AuthResult{State: app.AuthStatePending}, nil
+	}
+	sess.exchanging = true
+	conf, verifier, code := sess.conf, sess.verifier, sess.code
+	f.mu.Unlock()
+
+	tok, err := conf.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		f.drop(session.ID)
+		return app.AuthResult{State: app.AuthStateError, Error: "exchange authorization code: " + err.Error()}, nil
+	}
+	secrets := f.provider.Secrets(conf.ClientID, conf.ClientSecret, tok)
+	f.drop(session.ID)
+	return app.AuthResult{State: app.AuthStateComplete, Secrets: secrets}, nil
+}
+
+// closeListener shuts a session's listener down but keeps the session in the
+// map so PollAuth can still read the recorded code or error.
+func (f *LoopbackFlow) closeListener(id string) {
+	f.mu.Lock()
+	sess, ok := f.sessions[id]
+	if !ok || sess.closed {
+		f.mu.Unlock()
+		return
+	}
+	sess.closed = true
+	srv := sess.srv
+	f.mu.Unlock()
+	shutdownServer(srv)
+}
+
+// drop stops a session's listener and removes it from the map.
+func (f *LoopbackFlow) drop(id string) {
+	f.mu.Lock()
+	sess, ok := f.sessions[id]
+	delete(f.sessions, id)
+	f.mu.Unlock()
+	if ok && !sess.closed {
+		shutdownServer(sess.srv)
+	}
+}
+
+// shutdownServer gracefully stops an HTTP server, ignoring teardown errors.
+func shutdownServer(srv *http.Server) {
+	if srv == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_ = srv.Shutdown(ctx) //nolint:errcheck // best-effort teardown
+}
+
+// pruneLocked shuts down and drops expired sessions. Callers hold f.mu.
+func (f *LoopbackFlow) pruneLocked() {
+	now := time.Now()
+	for id, sess := range f.sessions {
+		if now.After(sess.expiresAt) {
+			srv := sess.srv
+			closed := sess.closed
+			delete(f.sessions, id)
+			if !closed {
+				go shutdownServer(srv)
+			}
+		}
+	}
+}
+
+// writePage renders a minimal HTML page shown in the user's browser after the
+// redirect.
+func writePage(w http.ResponseWriter, msg string) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprintf(w, //nolint:errcheck // browser-facing page, nothing to do on write error
+		"<!doctype html><html><head><meta charset=utf-8><title>mycel</title></head>"+
+			"<body style=\"font-family:system-ui,sans-serif;background:#f5efe6;color:#3a2f28;"+
+			"display:flex;align-items:center;justify-content:center;height:100vh;margin:0\">"+
+			"<p style=\"max-width:28rem;text-align:center;font-size:1rem;line-height:1.5\">%s</p>"+
+			"</body></html>", msg)
+}
+
+// randToken returns a random 128-bit hex token for session/state IDs.
+func randToken() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// oauthErr formats an OAuth error code with its optional description.
+func oauthErr(code, desc string) string {
+	if desc != "" {
+		return code + ": " + desc
+	}
+	return code
+}

--- a/pkg/oauth/loopback.go
+++ b/pkg/oauth/loopback.go
@@ -19,6 +19,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"sync"
@@ -176,12 +177,15 @@ func (f *LoopbackFlow) handleCallback(w http.ResponseWriter, r *http.Request, id
 	sess, ok := f.sessions[id]
 	if !ok {
 		f.mu.Unlock()
-		writePage(w, "This sign-in session has expired. Return to mycel and start again.")
+		writePage(w, pageExpired)
 		return
 	}
 
 	switch {
 	case q.Get("error") != "":
+		// The provider error/description are attacker-influenced query params.
+		// Keep them daemon-side only (surfaced via PollAuth → auth/status,
+		// a trusted JSON path); never reflect them into the browser HTML.
 		sess.errMsg = oauthErr(q.Get("error"), q.Get("error_description"))
 	case q.Get("state") != sess.state:
 		sess.errMsg = "state mismatch — the sign-in could not be verified; start again"
@@ -190,7 +194,7 @@ func (f *LoopbackFlow) handleCallback(w http.ResponseWriter, r *http.Request, id
 	default:
 		sess.code = q.Get("code")
 	}
-	msg := sess.errMsg
+	failed := sess.errMsg != ""
 	f.mu.Unlock()
 
 	// The listener has done its job either way; shut it down in the
@@ -198,11 +202,14 @@ func (f *LoopbackFlow) handleCallback(w http.ResponseWriter, r *http.Request, id
 	// until PollAuth reads the code (or error) and reaches a terminal state.
 	go f.closeListener(id)
 
-	if msg != "" {
-		writePage(w, "Sign-in failed: "+msg+" You can close this window.")
+	// The browser page is always one of a fixed set of static strings — no
+	// query input is ever echoed (guards against reflected XSS on the
+	// OAuth callback).
+	if failed {
+		writePage(w, pageFailed)
 		return
 	}
-	writePage(w, "Sign-in complete. You can close this window and return to mycel.")
+	writePage(w, pageComplete)
 }
 
 // PollAuth reports progress and, once the code has arrived, exchanges it for
@@ -294,8 +301,17 @@ func (f *LoopbackFlow) pruneLocked() {
 	}
 }
 
+// Static browser-facing messages for the callback page. These are the only
+// strings writePage ever renders — no request input is echoed.
+const (
+	pageComplete = "Sign-in complete. You can close this window and return to mycel."
+	pageFailed   = "Sign-in failed. Return to mycel for details, then start the sign-in again."
+	pageExpired  = "This sign-in session has expired. Return to mycel and start again."
+)
+
 // writePage renders a minimal HTML page shown in the user's browser after the
-// redirect.
+// redirect. The message is HTML-escaped as defense-in-depth so no caller can
+// ever reflect untrusted input into the response.
 func writePage(w http.ResponseWriter, msg string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
@@ -304,7 +320,7 @@ func writePage(w http.ResponseWriter, msg string) {
 			"<body style=\"font-family:system-ui,sans-serif;background:#f5efe6;color:#3a2f28;"+
 			"display:flex;align-items:center;justify-content:center;height:100vh;margin:0\">"+
 			"<p style=\"max-width:28rem;text-align:center;font-size:1rem;line-height:1.5\">%s</p>"+
-			"</body></html>", msg)
+			"</body></html>", html.EscapeString(msg))
 }
 
 // randToken returns a random 128-bit hex token for session/state IDs.

--- a/pkg/oauth/loopback_test.go
+++ b/pkg/oauth/loopback_test.go
@@ -161,6 +161,46 @@ func TestLoopbackProviderError(t *testing.T) {
 	}
 }
 
+// TestLoopbackCallbackNoReflectedInput proves the browser-facing callback
+// page never reflects attacker-controlled query params (reflected XSS): a
+// crafted error/error_description must not appear in the HTML, while the
+// error stays available on the trusted daemon-side poll path.
+func TestLoopbackCallbackNoReflectedInput(t *testing.T) {
+	f := testFlow("https://unused.test/token", fixedCreds)
+	sess, err := f.BeginAuth(context.Background(), app.Instance{Name: "x"})
+	if err != nil {
+		t.Fatalf("BeginAuth: %v", err)
+	}
+
+	const marker = "XSSMARKER_31337"
+	inject := url.Values{
+		"error":             {"<script>alert('" + marker + "')</script>"},
+		"error_description": {"<img src=x onerror=alert('" + marker + "')>"},
+		"state":             {stateOf(t, sess.AuthURL)},
+	}.Encode()
+	cb := callbackURL(t, sess.AuthURL, inject)
+	resp, err := http.Get(cb) //nolint:noctx,gosec // test loopback URL
+	if err != nil {
+		t.Fatalf("callback GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+
+	page := string(body)
+	if strings.Contains(page, marker) {
+		t.Errorf("callback page reflected injected input:\n%s", page)
+	}
+	if strings.Contains(page, "<script>alert") || strings.Contains(page, "onerror=") {
+		t.Errorf("callback page contains an unescaped injected tag:\n%s", page)
+	}
+
+	// The real error is still surfaced on the trusted poll path.
+	res, _ := pollUntil(t, f, sess.ID, app.AuthStateError)
+	if res.State != app.AuthStateError || !strings.Contains(res.Error, marker) {
+		t.Errorf("poll error = %+v, want the raw provider error daemon-side", res)
+	}
+}
+
 // TestLoopbackUnknownSession reports an error for an unknown session ID.
 func TestLoopbackUnknownSession(t *testing.T) {
 	f := testFlow("https://unused.test/token", fixedCreds)

--- a/pkg/oauth/loopback_test.go
+++ b/pkg/oauth/loopback_test.go
@@ -1,0 +1,227 @@
+package oauth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/rpuneet/mycel/pkg/app"
+)
+
+// testProvider builds a flow whose endpoints point at a stub server and whose
+// credentials resolve from a fixed pair.
+func testFlow(tokenURL string, creds CredsFunc) *LoopbackFlow {
+	return NewLoopbackFlow(Provider{
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  "https://auth.example.test/authorize",
+			TokenURL: tokenURL,
+		},
+		Scopes:          []string{"scope.read", "scope.send"},
+		AuthCodeOptions: []oauth2.AuthCodeOption{oauth2.SetAuthURLParam("prompt", "consent")},
+		Secrets: func(clientID, clientSecret string, tok *oauth2.Token) map[string]string {
+			return map[string]string{
+				"client_id":     clientID,
+				"client_secret": clientSecret,
+				"refresh_token": tok.RefreshToken,
+				"access_token":  tok.AccessToken,
+			}
+		},
+	}, creds)
+}
+
+func fixedCreds(inst app.Instance) (string, string, error) {
+	return "the-client", "the-secret", nil
+}
+
+// callbackURL derives the loopback callback URL for a begun session from its
+// consent URL's redirect_uri.
+func callbackURL(t *testing.T, authURL, query string) string {
+	t.Helper()
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse auth url: %v", err)
+	}
+	redirect := u.Query().Get("redirect_uri")
+	if redirect == "" {
+		t.Fatal("consent URL missing redirect_uri")
+	}
+	return redirect + "?" + query
+}
+
+// TestLoopbackHappyPath drives the full flow: begin → browser redirect with a
+// valid code → poll exchanges it against a stub token endpoint → secrets.
+func TestLoopbackHappyPath(t *testing.T) {
+	// Stub token endpoint returns a token bundle for the exchange.
+	var gotVerifier, gotCode, gotRedirect string
+	stub := http.NewServeMux()
+	stub.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotVerifier = r.FormValue("code_verifier")
+		gotCode = r.FormValue("code")
+		gotRedirect = r.FormValue("redirect_uri")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"at-123","refresh_token":"rt-456","token_type":"Bearer","expires_in":3600}`)
+	})
+	ts := startTestServer(t, stub)
+
+	f := testFlow(ts+"/token", fixedCreds)
+	sess, err := f.BeginAuth(context.Background(), app.Instance{Name: "x"})
+	if err != nil {
+		t.Fatalf("BeginAuth: %v", err)
+	}
+	if sess.Kind != app.AuthKindCallback || sess.AuthURL == "" {
+		t.Fatalf("unexpected session %+v", sess)
+	}
+
+	// Poll before the code arrives → pending.
+	res, err := f.PollAuth(context.Background(), app.AuthSession{ID: sess.ID})
+	if err != nil || res.State != app.AuthStatePending {
+		t.Fatalf("pre-code poll = %+v, %v; want pending", res, err)
+	}
+
+	// Simulate the browser hitting the loopback redirect with the code.
+	cb := callbackURL(t, sess.AuthURL, "code=auth-code-789&state="+stateOf(t, sess.AuthURL))
+	resp, err := http.Get(cb) //nolint:noctx,gosec // test loopback URL
+	if err != nil {
+		t.Fatalf("callback GET: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if !strings.Contains(string(body), "complete") {
+		t.Errorf("callback page = %q, want success", body)
+	}
+
+	// Poll now completes with the exchanged secrets.
+	res, err = pollUntil(t, f, sess.ID, app.AuthStateComplete)
+	if err != nil {
+		t.Fatalf("poll: %v", err)
+	}
+	if res.Secrets["refresh_token"] != "rt-456" || res.Secrets["access_token"] != "at-123" {
+		t.Errorf("secrets = %+v, want rt-456/at-123", res.Secrets)
+	}
+	if res.Secrets["client_id"] != "the-client" || res.Secrets["client_secret"] != "the-secret" {
+		t.Errorf("client creds not propagated: %+v", res.Secrets)
+	}
+	// PKCE verifier and loopback redirect were sent in the exchange.
+	if gotVerifier == "" {
+		t.Error("token exchange sent no code_verifier (PKCE)")
+	}
+	if gotCode != "auth-code-789" {
+		t.Errorf("exchange code = %q, want auth-code-789", gotCode)
+	}
+	if !strings.HasPrefix(gotRedirect, "http://127.0.0.1:") {
+		t.Errorf("exchange redirect_uri = %q, want loopback", gotRedirect)
+	}
+}
+
+// TestLoopbackStateMismatch rejects a callback whose state does not match.
+func TestLoopbackStateMismatch(t *testing.T) {
+	f := testFlow("https://unused.test/token", fixedCreds)
+	sess, err := f.BeginAuth(context.Background(), app.Instance{Name: "x"})
+	if err != nil {
+		t.Fatalf("BeginAuth: %v", err)
+	}
+	cb := callbackURL(t, sess.AuthURL, "code=c&state=wrong")
+	resp, err := http.Get(cb) //nolint:noctx,gosec // test loopback URL
+	if err != nil {
+		t.Fatalf("callback GET: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	res, _ := pollUntil(t, f, sess.ID, app.AuthStateError)
+	if !strings.Contains(res.Error, "state") {
+		t.Errorf("error = %q, want state mismatch", res.Error)
+	}
+}
+
+// TestLoopbackProviderError surfaces an error= param from the redirect.
+func TestLoopbackProviderError(t *testing.T) {
+	f := testFlow("https://unused.test/token", fixedCreds)
+	sess, err := f.BeginAuth(context.Background(), app.Instance{Name: "x"})
+	if err != nil {
+		t.Fatalf("BeginAuth: %v", err)
+	}
+	cb := callbackURL(t, sess.AuthURL, "error=access_denied&error_description=user+said+no&state="+stateOf(t, sess.AuthURL))
+	resp, err := http.Get(cb) //nolint:noctx,gosec // test loopback URL
+	if err != nil {
+		t.Fatalf("callback GET: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	res, _ := pollUntil(t, f, sess.ID, app.AuthStateError)
+	if !strings.Contains(res.Error, "access_denied") {
+		t.Errorf("error = %q, want access_denied", res.Error)
+	}
+}
+
+// TestLoopbackUnknownSession reports an error for an unknown session ID.
+func TestLoopbackUnknownSession(t *testing.T) {
+	f := testFlow("https://unused.test/token", fixedCreds)
+	res, err := f.PollAuth(context.Background(), app.AuthSession{ID: "nope"})
+	if err != nil {
+		t.Fatalf("PollAuth: %v", err)
+	}
+	if res.State != app.AuthStateError {
+		t.Errorf("state = %q, want error", res.State)
+	}
+}
+
+// TestLoopbackCredsError propagates the resolver's fallback error verbatim.
+func TestLoopbackCredsError(t *testing.T) {
+	f := testFlow("https://unused.test/token", func(app.Instance) (string, string, error) {
+		return "", "", errNotConfigured
+	})
+	_, err := f.BeginAuth(context.Background(), app.Instance{Name: "x"})
+	if err != errNotConfigured { //nolint:errorlint // sentinel identity is the assertion
+		t.Fatalf("BeginAuth err = %v, want errNotConfigured", err)
+	}
+}
+
+var errNotConfigured = errString("client not configured")
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// --- helpers ---
+
+func startTestServer(t *testing.T, h http.Handler) string {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// stateOf extracts the state param from a consent URL.
+func stateOf(t *testing.T, authURL string) string {
+	t.Helper()
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("parse auth url: %v", err)
+	}
+	return u.Query().Get("state")
+}
+
+// pollUntil polls up to ~2s for the target terminal state.
+func pollUntil(t *testing.T, f *LoopbackFlow, id, want string) (app.AuthResult, error) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		res, err := f.PollAuth(context.Background(), app.AuthSession{ID: id})
+		if err != nil {
+			return res, err
+		}
+		if res.State == want || res.State == app.AuthStateError {
+			return res, nil
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return app.AuthResult{}, nil
+}

--- a/server/handlers/apps.go
+++ b/server/handlers/apps.go
@@ -101,6 +101,15 @@ func descriptorJSON(p app.Plugin) appDescriptorJSON {
 		docs = []string{}
 	}
 	_, oauthAvailable := p.(app.OAuthFlow)
+	// A flow that can report its own readiness (server-side client creds
+	// present) gates oauth_available on that — so the UI never shows a
+	// browser-sign-in button that would immediately fail, and falls back to
+	// honest token paste instead.
+	if oauthAvailable {
+		if cfg, ok := p.(app.OAuthConfigured); ok {
+			oauthAvailable = cfg.OAuthConfigured()
+		}
+	}
 	return appDescriptorJSON{
 		ID:             d.ID,
 		Label:          d.Label,

--- a/web/src/components/apps/ConnectApp.tsx
+++ b/web/src/components/apps/ConnectApp.tsx
@@ -65,6 +65,7 @@ export const APP_PRESENTATION: Record<string, AppPresentation> = {
   // Payments
   stripe: { icon: "\u{1F4B3}", color: "#635BFF", category: "Payments", description: "Payment and subscription events" },
   // Content
+  gmail: { icon: "✉️", color: "#EA4335", category: "Content", description: "Email via one-click Google sign-in (or token)" },
   rss: { icon: "\u{1F4E1}", color: "#F78422", category: "Content", description: "Subscribe to any RSS or Atom feed" },
   notion: { icon: "\u{1F4DD}", color: "#9CA3AF", category: "Content", description: "Database and page change polling" },
   reddit: { icon: "\u{1F4E2}", color: "#FF4500", category: "Content", description: "Subreddit and post monitoring" },
@@ -740,6 +741,34 @@ export function ConnectWizard({
   const hasStoredSecret = (key: string): boolean =>
     existing?.config?.[`has_${key}`] === true;
 
+  /** One descriptor field → labeled input (secret fields are password
+   *  inputs with replace-only, never-echoed semantics). */
+  const renderField = (field: AppDescriptor["fields"][number]) => {
+    const configured = field.secret && hasStoredSecret(field.key);
+    return (
+      <div key={field.key}>
+        <label className="block text-sm font-medium text-mycel-text-2 mb-1">
+          {field.label}
+          {!field.required && <span className="text-mycel-muted ml-1 font-normal">(optional)</span>}
+          {configured && (
+            <span className="ml-2 inline-flex items-center gap-1 text-[10px] font-medium text-mycel-success">
+              <span className="w-1 h-1 rounded-full bg-mycel-success" />
+              configured
+            </span>
+          )}
+        </label>
+        <input
+          type={field.secret ? "password" : "text"}
+          value={values[field.key] ?? ""}
+          onChange={(e) => { setValues((v) => ({ ...v, [field.key]: e.target.value })); }}
+          placeholder={configured ? "•••••• — leave blank to keep" : field.placeholder}
+          autoComplete={field.secret ? "new-password" : "off"}
+          className="w-full px-3 py-2 bg-mycel-surface border border-mycel-border rounded-md text-sm text-mycel-text placeholder:text-mycel-muted focus:border-mycel-accent focus:outline-none transition-colors"
+        />
+      </div>
+    );
+  };
+
   const startQRPairing = async () => {
     setPairState("loading");
     setError(null);
@@ -1060,44 +1089,30 @@ export function ConnectWizard({
                     )}
                   </div>
                 )}
-                {oauthAvailable && (
-                  <div className="flex items-center gap-3 text-[10px] uppercase tracking-[0.08em] text-mycel-muted">
-                    <span className="flex-1 border-t border-mycel-border" />
-                    or configure manually
-                    <span className="flex-1 border-t border-mycel-border" />
-                  </div>
-                )}
-
-                {descriptor.fields.map((field) => {
-                  const configured = field.secret && hasStoredSecret(field.key);
-                  return (
-                    <div key={field.key}>
-                      <label className="block text-sm font-medium text-mycel-text-2 mb-1">
-                        {field.label}
-                        {!field.required && <span className="text-mycel-muted ml-1 font-normal">(optional)</span>}
-                        {configured && (
-                          <span className="ml-2 inline-flex items-center gap-1 text-[10px] font-medium text-mycel-success">
-                            <span className="w-1 h-1 rounded-full bg-mycel-success" />
-                            configured
-                          </span>
-                        )}
-                      </label>
-                      <input
-                        type={field.secret ? "password" : "text"}
-                        value={values[field.key] ?? ""}
-                        onChange={(e) => { setValues((v) => ({ ...v, [field.key]: e.target.value })); }}
-                        placeholder={configured ? "•••••• — leave blank to keep" : field.placeholder}
-                        autoComplete={field.secret ? "new-password" : "off"}
-                        className="w-full px-3 py-2 bg-mycel-surface border border-mycel-border rounded-md text-sm text-mycel-text placeholder:text-mycel-muted focus:border-mycel-accent focus:outline-none transition-colors"
-                      />
+                {/* Manual config fields. When browser sign-in is available
+                    they collapse under an Advanced disclosure so the
+                    one-click path stays front-and-centre; otherwise they are
+                    the primary path and render inline. */}
+                {oauthAvailable ? (
+                  <details data-testid="manual-config" className="mycel-disclosure">
+                    <summary className="flex items-center gap-3 text-[10px] uppercase tracking-[0.08em] text-mycel-muted cursor-pointer select-none list-none marker:content-none hover:text-mycel-text-2 transition-colors">
+                      <span className="flex-1 border-t border-mycel-border" />
+                      <span className="whitespace-nowrap">Advanced — configure manually or paste a token</span>
+                      <span className="flex-1 border-t border-mycel-border" />
+                    </summary>
+                    <div className="space-y-3 pt-3">
+                      {descriptor.fields.map(renderField)}
                     </div>
-                  );
-                })}
-
-                {descriptor.fields.length === 0 && (
-                  <p className="text-xs text-mycel-muted">
-                    No configuration needed — connect to start receiving events.
-                  </p>
+                  </details>
+                ) : (
+                  <>
+                    {descriptor.fields.map(renderField)}
+                    {descriptor.fields.length === 0 && (
+                      <p className="text-xs text-mycel-muted">
+                        No configuration needed — connect to start receiving events.
+                      </p>
+                    )}
+                  </>
                 )}
               </div>
             )}

--- a/web/src/components/apps/__tests__/connectApp.test.tsx
+++ b/web/src/components/apps/__tests__/connectApp.test.tsx
@@ -298,7 +298,7 @@ describe("ConnectWizard OAuth", () => {
     await waitFor(() => {
       expect(screen.getByTestId("oauth-user-code")).toHaveTextContent("ABCD-1234");
     });
-    const link = screen.getByRole("link", { name: /github.com\/login\/device/ });
+    const link = screen.getByRole("link", { name: /\bgithub\.com\/login\/device/ });
     expect(link).toHaveAttribute("href", "https://github.com/login/device");
     expect(screen.getByText("Waiting for authorization...")).toBeInTheDocument();
 
@@ -386,7 +386,7 @@ describe("ConnectWizard OAuth", () => {
 
     // Callback-flow UX: a link to open the Google consent page (no code).
     await waitFor(() => {
-      expect(screen.getByRole("link", { name: /accounts.google.com/ })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /\baccounts\.google\.com\// })).toBeInTheDocument();
     });
     expect(screen.queryByTestId("oauth-user-code")).not.toBeInTheDocument();
 

--- a/web/src/components/apps/__tests__/connectApp.test.tsx
+++ b/web/src/components/apps/__tests__/connectApp.test.tsx
@@ -61,6 +61,19 @@ const catalog = {
       ],
       docs: [],
     },
+    {
+      id: "gmail",
+      label: "Gmail",
+      auth: "token",
+      multi: false,
+      oauth_available: true,
+      fields: [
+        { key: "client_id", label: "OAuth Client ID", placeholder: "xxxx.apps.googleusercontent.com", secret: true, required: true },
+        { key: "client_secret", label: "OAuth Client Secret", placeholder: "GOCSPX-...", secret: true, required: true },
+        { key: "refresh_token", label: "OAuth Refresh Token", placeholder: "1//0g...", secret: true, required: true },
+      ],
+      docs: [],
+    },
   ],
   instances: [
     { name: "slack", app: "slack", enabled: true, connected: true, config: { has_bot_token: true, has_app_token: false, mode: "socket" }, channels: [] },
@@ -273,8 +286,9 @@ describe("ConnectWizard OAuth", () => {
     await waitFor(() => {
       expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
     });
-    // Manual fields remain available alongside the sign-in.
-    expect(screen.getByText("or configure manually")).toBeInTheDocument();
+    // Manual fields remain available, collapsed under an Advanced disclosure.
+    expect(screen.getByTestId("manual-config")).toBeInTheDocument();
+    expect(screen.getByText("Advanced — configure manually or paste a token")).toBeInTheDocument();
 
     // Typed plain fields ride along with the begin request.
     fireEvent.change(screen.getByPlaceholderText("Ov23li..."), { target: { value: "Ov23liTEST" } });
@@ -341,6 +355,45 @@ describe("ConnectWizard OAuth", () => {
       expect(screen.getByText("access_denied")).toBeInTheDocument();
     }, { timeout: 4000 });
     expect(screen.getByRole("button", { name: "Retry sign in with GitHub" })).toBeInTheDocument();
+  }, 10000);
+
+  it("runs the loopback callback flow: sign in → open consent link → poll → agents", async () => {
+    const onConnected = vi.fn();
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u === "/api/apps" && (!init?.method || init.method === "GET")) return jsonResponse(catalog);
+      if (u === "/api/apps/gmail/auth" && init?.method === "POST") {
+        return jsonResponse({
+          id: "sess-cb",
+          kind: "callback",
+          state: "pending",
+          auth_url: "https://accounts.google.com/o/oauth2/auth?client_id=x&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Foauth%2Fcallback",
+          interval_seconds: 2,
+        });
+      }
+      if (u.startsWith("/api/apps/gmail/auth/status?session=")) return jsonResponse({ state: "complete" });
+      return jsonResponse([]);
+    });
+    render(<ConnectWizard appId="gmail" onClose={() => undefined} onConnected={onConnected} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Connect Gmail")).toBeInTheDocument();
+    });
+    // Callback flow has no user code — manual fields stay collapsed.
+    expect(screen.getByTestId("manual-config")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Sign in with Gmail" }));
+
+    // Callback-flow UX: a link to open the Google consent page (no code).
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /accounts.google.com/ })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("oauth-user-code")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("Add agents to Gmail")).toBeInTheDocument();
+    }, { timeout: 4000 });
+    expect(onConnected).toHaveBeenCalled();
   }, 10000);
 
   it("keeps token apps without oauth_available on the manual path only", async () => {


### PR DESCRIPTION
Part of #2674. References the OAuth credential-manager history #1962.

## What this adds
One-click **"Connect with Google/GitHub"** in the Apps connect modal using a **loopback (localhost) redirect** so it works fully local — no cloud, no hosted redirect. Tokens live in the local vault; nothing leaves the machine. The existing token/API-key paste stays as a labeled fallback.

## What's fully working out of the box
- **GitHub** one-click device flow — already implemented in the codebase; this PR reuses the same `/api/apps/{name}/auth` begin+poll endpoints and confirms the UX (the user pastes only their own OAuth app client ID, no client secret / redirect needed).
- **Generic loopback flow** (`pkg/oauth.LoopbackFlow`): authorization-code + PKCE, ephemeral `http://127.0.0.1:<port>/oauth/callback` listener, token exchange, vault storage, clean timeout/cancel/error handling. Fits the existing `app.OAuthFlow` (`AuthKindCallback`) contract — no new endpoints.
- **Not-configured fallback**: new optional `app.OAuthConfigured` capability. When the server-side Google client is absent, `oauth_available` is `false` and the UI shows the token-paste fields — never a dead Connect button. Verified live.
- **Connect UI**: manual fields collapse under an **"Advanced — configure manually or paste a token"** disclosure when browser sign-in is available; callback flow renders an "Open Google consent" link (no user code); device flow renders the user code. Slack-type stays token-paste, labeled honestly.

## What's config-gated (needs the owner's Google client)
**Gmail one-click** activates once the owner registers a Google **"Desktop app"** OAuth client and sets `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` on the daemon. No fake creds are shipped — the slot is wired and gated. Scopes: `gmail.readonly` + `gmail.send`; `access_type=offline` + `prompt=consent` so Google always returns a refresh token.

### Google Cloud Console setup (one-time, owner)
1. *APIs & Services* → **Enable** the Gmail API.
2. *OAuth consent screen* → add scopes `.../auth/gmail.readonly` and `.../auth/gmail.send`; add yourself as a test user (or publish).
3. *Credentials* → *Create credentials* → *OAuth client ID* → application type **Desktop app**. Desktop clients allow the loopback redirect `http://127.0.0.1:<port>/oauth/callback` (any port) — nothing to register.
4. `export GOOGLE_OAUTH_CLIENT_ID=<id>.apps.googleusercontent.com` and `GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-…`, restart `mycel up`. Gmail's modal now shows **Sign in with Gmail**.

Slack real OAuth (fixed HTTPS redirect) is explicitly deferred to a future hosted redirect ("mycel cloud") and labeled as such.

## Test plan (all pass)
- **web**: `bunx tsc --noEmit` clean · `bun run lint` clean · `bun run build` ok · `bunx vitest run` → **306 passed** (incl. new callback-flow + Advanced-disclosure tests).
- **go**: `go build ./...` ok · `go vet ./...` clean · `golangci-lint run` on changed pkgs → **0 issues** · `go test -race ./pkg/oauth/... ./pkg/gateway/gmail/... ./pkg/app/... ./server/handlers/...` → **ok** (loopback code-exchange vs stub token endpoint, callback state/error parsing, creds gating).
- **Live smoke** (throwaway `MYCEL_HOME`, `--addr 127.0.0.1:8099`):
  - With Google creds set: `/api/apps` shows `gmail oauth_available=true`; `POST /api/apps/gmail/auth` returns a Google consent URL carrying the loopback `redirect_uri` + PKCE `code_challenge`; simulated browser callback stores the code and the success page renders; poll then performs a real token exchange (Google rejects the stub code with `invalid_client`, proving the exchange path).
  - With creds absent: `gmail oauth_available=false` and the start endpoint returns the actionable "not configured — paste a refresh token instead" error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)