### PR TITLE
fix(agent): migrate cpus/memory_mb columns onto existing DBs (release blocker)

### DIFF
--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -86,6 +86,15 @@ func createAgentsTable(d *db.DB) error {
 		return fmt.Errorf("create agents table: %w", err)
 	}
 
+	// Pre-resource-limits DBs (created before cpus/memory_mb existed) keep
+	// their old columns — CREATE TABLE IF NOT EXISTS is a no-op on an existing
+	// table. Add any missing columns idempotently so agent reads don't break
+	// on upgrade (otherwise every SELECT referencing cpus/memory_mb errors and
+	// the whole fleet vanishes from the API).
+	if err := ensureAgentColumns(ctx, d); err != nil {
+		return err
+	}
+
 	// agent_stats: time-series Docker resource samples.
 	statsSchema := `
 		CREATE TABLE IF NOT EXISTS agent_stats (
@@ -107,6 +116,43 @@ func createAgentsTable(d *db.DB) error {
 		return fmt.Errorf("create agent_stats table: %w", err)
 	}
 
+	return nil
+}
+
+// ensureAgentColumns adds columns introduced after the original schema to a
+// pre-existing agents table. SQLite has no ADD COLUMN IF NOT EXISTS, so we
+// inspect the current columns via PRAGMA and ALTER only the missing ones.
+func ensureAgentColumns(ctx context.Context, d *db.DB) error {
+	rows, err := d.QueryContext(ctx, `PRAGMA table_info(agents)`)
+	if err != nil {
+		return fmt.Errorf("inspect agents columns: %w", err)
+	}
+	have := map[string]bool{}
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt sql.NullString
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan agents column: %w", err)
+		}
+		have[name] = true
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate agents columns: %w", err)
+	}
+	for _, add := range []struct{ col, ddl string }{
+		{"cpus", "ALTER TABLE agents ADD COLUMN cpus REAL NOT NULL DEFAULT 0"},
+		{"memory_mb", "ALTER TABLE agents ADD COLUMN memory_mb INTEGER NOT NULL DEFAULT 0"},
+	} {
+		if have[add.col] {
+			continue
+		}
+		if _, err := d.ExecContext(ctx, add.ddl); err != nil {
+			return fmt.Errorf("add agents.%s column: %w", add.col, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/agent/store_sqlite_test.go
+++ b/pkg/agent/store_sqlite_test.go
@@ -5,7 +5,58 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/rpuneet/mycel/pkg/db"
 )
+
+// TestEnsureAgentColumns_Migration guards the regression where an existing
+// mycel.db (created before the cpus/memory_mb columns) would break every agent
+// SELECT — CREATE TABLE IF NOT EXISTS is a no-op on an existing table, so the
+// new columns must be added via ALTER.
+func TestEnsureAgentColumns_Migration(t *testing.T) {
+	ctx := context.Background()
+	d, err := db.Open(filepath.Join(t.TempDir(), "old.db"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	// A pre-resource-limits agents table: no cpus/memory_mb.
+	if _, err := d.ExecContext(ctx, `CREATE TABLE agents (
+		name TEXT PRIMARY KEY, role TEXT NOT NULL DEFAULT '',
+		started_at TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL DEFAULT '')`); err != nil {
+		t.Fatalf("create legacy table: %v", err)
+	}
+	if err := ensureAgentColumns(ctx, d); err != nil {
+		t.Fatalf("ensureAgentColumns: %v", err)
+	}
+	cols := agentTableColumns(ctx, t, d)
+	if !cols["cpus"] || !cols["memory_mb"] {
+		t.Fatalf("migration did not add columns: %v", cols)
+	}
+	// Idempotent: a second run against the now-migrated table must not error.
+	if err := ensureAgentColumns(ctx, d); err != nil {
+		t.Fatalf("ensureAgentColumns not idempotent: %v", err)
+	}
+}
+
+func agentTableColumns(ctx context.Context, t *testing.T, d *db.DB) map[string]bool {
+	t.Helper()
+	rows, err := d.QueryContext(ctx, `PRAGMA table_info(agents)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	cols := map[string]bool{}
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt any
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("scan column: %v", err)
+		}
+		cols[name] = true
+	}
+	return cols
+}
 
 func TestSQLiteStore_SaveLoadDelete(t *testing.T) {
 	dir := t.TempDir()


### PR DESCRIPTION
## Problem (release blocker for v0.4.3)
#3391 added `cpus`/`memory_mb` to the agents `CREATE TABLE`, but `CREATE TABLE IF NOT EXISTS` is a **no-op on a pre-existing `mycel.db`**. So on any existing install, the columns were never added and every agent `SELECT` (which now references them) fails — **the entire fleet disappears from `/api/agents`** on upgrade. Reproduced live: a real DB with 24 agents returned 0.

## Fix
- `ensureAgentColumns` runs after the `CREATE TABLE`: inspects `PRAGMA table_info(agents)` and `ALTER TABLE ADD COLUMN` only the missing ones (`cpus`, `memory_mb`). Idempotent; safe on fresh and existing DBs.
- Regression test `TestEnsureAgentColumns_Migration`: seeds a legacy table without the columns, migrates, asserts the columns exist and the second run is a no-op.

## Verify
- `go test ./pkg/agent/` — pass (incl. new test) · `go vet ./pkg/agent/` clean
- **Live**: rebuilt + restarted the local daemon against the real `~/.mycel/mycel.db` → **24 agents restored**, `cpus`/`memory_mb` columns present.

Part of #2674

🤖 Generated with [Claude Code](https://claude.com/claude-code)