### PR TITLE
feat(tools): pkg-manager autodetect, per-provider subcommands, working uninstall + streamed-install fix

### DIFF
--- a/pkg/provider/commands.go
+++ b/pkg/provider/commands.go
@@ -1,0 +1,80 @@
+package provider
+
+// Curated per-provider CLI command lists (the CommandLister capability).
+//
+// These drive the "Available commands" surface on the provider detail page.
+// They are copyable references, not executed from the browser: several are
+// interactive (login/auth open a device flow or prompt) and cannot be
+// meaningfully streamed to a web UI. Each list is drawn from the provider
+// CLI's own documented subcommands/flags — see each provider file's header
+// comment for the source of truth. Providers whose CLI genuinely lacks a
+// category (e.g. OpenClaw has no --model flag) simply omit it rather than
+// showing a dead control.
+//
+// Claude's Commands() lives in claude.go alongside its other richer wiring.
+
+// Commands returns the curated CLI command list for OpenAI Codex.
+func (p *CodexProvider) Commands() []Command {
+	return []Command{
+		{Name: "login", Command: "codex login", Description: "Sign in to OpenAI (device flow)"},
+		{Name: "login status", Command: "codex login status", Description: "Show current auth status"},
+		{Name: "logout", Command: "codex logout", Description: "Sign out"},
+		{Name: "exec", Command: "codex exec <prompt>", Description: "Run one non-interactive task", Args: "<prompt>"},
+		{Name: "resume", Command: "codex resume", Description: "Resume a previous session"},
+		{Name: "mcp list", Command: "codex mcp list", Description: "List configured MCP servers"},
+		{Name: "mcp add", Command: "codex mcp add <name> -- <command>", Description: "Add an MCP server", Args: "<name> -- <command>"},
+		{Name: "version", Command: "codex --version", Description: "Show version"},
+	}
+}
+
+// Commands returns the curated CLI command list for the pi coding agent.
+// pi is flag-driven (no subcommands): model routing and session control are
+// all flags on the base invocation.
+func (p *PiProvider) Commands() []Command {
+	return []Command{
+		{Name: "run", Command: "pi", Description: "Start the pi agent"},
+		{Name: "model", Command: "pi --model <provider/model>", Description: "Run with a specific model", Args: "<provider/model>"},
+		{Name: "continue", Command: "pi --continue", Description: "Continue the previous session"},
+		{Name: "resume", Command: "pi --resume", Description: "Pick a session to resume"},
+		{Name: "session", Command: "pi --session <id>", Description: "Resume a specific session", Args: "<session-id>"},
+		{Name: "version", Command: "pi --version", Description: "Show version"},
+	}
+}
+
+// Commands returns the curated CLI command list for the Antigravity CLI (agy).
+func (p *AgyProvider) Commands() []Command {
+	return []Command{
+		{Name: "run", Command: "agy", Description: "Start the Antigravity agent"},
+		{Name: "models", Command: "agy models", Description: "List available Gemini models"},
+		{Name: "model", Command: "agy --model '<model>'", Description: "Run with a specific model", Args: "<model>"},
+		{Name: "continue", Command: "agy --continue", Description: "Continue the previous conversation"},
+		{Name: "conversation", Command: "agy --conversation <uuid>", Description: "Resume a specific conversation", Args: "<uuid>"},
+		{Name: "version", Command: "agy --version", Description: "Show version"},
+	}
+}
+
+// Commands returns the curated CLI command list for Cursor Agent.
+func (p *CursorProvider) Commands() []Command {
+	return []Command{
+		{Name: "login", Command: "cursor-agent login", Description: "Sign in to Cursor"},
+		{Name: "logout", Command: "cursor-agent logout", Description: "Sign out"},
+		{Name: "status", Command: "cursor-agent status", Description: "Show auth and account status"},
+		{Name: "list models", Command: "cursor-agent --list-models", Description: "List available models"},
+		{Name: "model", Command: "cursor-agent --model <model>", Description: "Run with a specific model", Args: "<model>"},
+		{Name: "resume", Command: "cursor-agent --resume <id>", Description: "Resume a session", Args: "<session-id>"},
+		{Name: "version", Command: "cursor-agent --version", Description: "Show version"},
+	}
+}
+
+// Commands returns the curated CLI command list for OpenClaw.
+// OpenClaw drives model selection in the TUI or via per-agent routing, so no
+// --model flag is surfaced (see the provider header comment).
+func (p *OpenclawProvider) Commands() []Command {
+	return []Command{
+		{Name: "tui", Command: "openclaw tui --local", Description: "Start the local TUI agent"},
+		{Name: "session", Command: "openclaw tui --local --session <key>", Description: "Reattach to a session", Args: "<session-key>"},
+		{Name: "agents add", Command: "openclaw agents add --model <provider/model>", Description: "Add a routed agent with a model", Args: "<provider/model>"},
+		{Name: "version", Command: "openclaw --version", Description: "Show version"},
+		{Name: "help", Command: "openclaw --help", Description: "Show help"},
+	}
+}

--- a/pkg/provider/commands_test.go
+++ b/pkg/provider/commands_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCuratedCommands asserts every first-party provider surfaces a curated,
+// non-empty command list via the CommandLister capability, and that each
+// command's invocation starts with the provider's own binary — so the UI never
+// shows a dead or mislabelled control.
+func TestCuratedCommands(t *testing.T) {
+	// binary prefix each provider's commands must start with.
+	cases := map[string]string{
+		"claude":   "claude",
+		"codex":    "codex",
+		"pi":       "pi",
+		"agy":      "agy",
+		"cursor":   "cursor-agent",
+		"openclaw": "openclaw",
+	}
+
+	for name, prefix := range cases {
+		t.Run(name, func(t *testing.T) {
+			p, ok := DefaultRegistry.Get(name)
+			if !ok {
+				t.Fatalf("provider %q not registered", name)
+			}
+			cl, ok := p.(CommandLister)
+			if !ok {
+				t.Fatalf("provider %q does not implement CommandLister", name)
+			}
+			cmds := cl.Commands()
+			if len(cmds) == 0 {
+				t.Fatalf("provider %q returned no commands", name)
+			}
+			seen := map[string]bool{}
+			for _, c := range cmds {
+				if c.Name == "" || c.Command == "" || c.Description == "" {
+					t.Errorf("provider %q has an incomplete command: %+v", name, c)
+				}
+				if !strings.HasPrefix(c.Command, prefix) {
+					t.Errorf("provider %q command %q does not start with binary %q", name, c.Command, prefix)
+				}
+				if seen[c.Name] {
+					t.Errorf("provider %q has duplicate command name %q", name, c.Name)
+				}
+				seen[c.Name] = true
+			}
+		})
+	}
+}

--- a/server/handlers/deps_install.go
+++ b/server/handlers/deps_install.go
@@ -44,8 +44,8 @@ func (h *DepsInstallHandler) Register(mux *http.ServeMux) {
 }
 
 // depInstallRequest is the POST body: the readiness item / tool id to act on
-// ("git", "tmux", "claude", "gh", …) and the action ("install" or "update";
-// empty means install).
+// ("git", "tmux", "claude", "gh", …) and the action ("install", "update", or
+// "uninstall"; empty means install).
 type depInstallRequest struct {
 	ID   string `json:"id"`
 	Mode string `json:"mode,omitempty"`
@@ -85,8 +85,11 @@ func (h *DepsInstallHandler) install(w http.ResponseWriter, r *http.Request) {
 	cmdLine, ok := h.resolveCommand(r.Context(), req.ID, req.Mode)
 	if !ok {
 		verb := "installer"
-		if req.Mode == "update" {
+		switch req.Mode {
+		case "update":
 			verb = "updater"
+		case "uninstall":
+			verb = "uninstaller"
 		}
 		httpError(w, "no automatic "+verb+" for "+req.ID, http.StatusBadRequest)
 		return
@@ -166,13 +169,17 @@ func streamInstall(ctx context.Context, cmdLine string, emit func(any) bool) {
 //
 //   - update: prefer the registered tool's upgrade_cmd, then its install_cmd,
 //     then the vetted install table.
+//   - uninstall: derive a remove command from the vetted install source
+//     (npm/brew only); core system deps (git/tmux/docker) are never
+//     auto-uninstalled.
 //   - install (default): prefer the vetted install table, then the registered
 //     tool's install_cmd.
 //
 // Every command originates from a vetted source (the table or the persisted
 // tools registry), never from the request body.
 func (h *DepsInstallHandler) resolveCommand(ctx context.Context, id, mode string) (string, bool) {
-	if mode == "update" {
+	switch mode {
+	case "update":
 		if t := h.lookupTool(ctx, id); t != nil {
 			if cmd := strings.TrimSpace(t.UpgradeCmd); cmd != "" {
 				return cmd, true
@@ -181,6 +188,8 @@ func (h *DepsInstallHandler) resolveCommand(ctx context.Context, id, mode string
 				return cmd, true
 			}
 		}
+	case "uninstall":
+		return h.resolveUninstall(ctx, id)
 	}
 	if cmd, ok := installCommand(id, runtime.GOOS); ok {
 		return cmd, true
@@ -189,6 +198,68 @@ func (h *DepsInstallHandler) resolveCommand(ctx context.Context, id, mode string
 		if cmd := strings.TrimSpace(t.InstallCmd); cmd != "" {
 			return cmd, true
 		}
+	}
+	return "", false
+}
+
+// coreSystemDeps are host tools mycel itself relies on. Auto-uninstalling them
+// would break the daemon, so uninstall is refused for these ids.
+var coreSystemDeps = map[string]bool{"git": true, "tmux": true, "docker": true}
+
+// resolveUninstall derives a remove command for id from its vetted install
+// source. Only npm-global and Homebrew installs map cleanly to an uninstall;
+// curl-piped and apt installers return false so the UI shows an honest
+// "no automatic uninstaller" rather than guessing a destructive command.
+func (h *DepsInstallHandler) resolveUninstall(ctx context.Context, id string) (string, bool) {
+	if coreSystemDeps[id] {
+		return "", false
+	}
+	// Registered tool first (gh, aws, wrangler, …), then a provider CLI.
+	if t := h.lookupTool(ctx, id); t != nil {
+		if cmd, ok := deriveUninstall(t.InstallCmd); ok {
+			return cmd, true
+		}
+	}
+	if hint, ok := providerInstallCmd(id); ok {
+		if cmd, ok := deriveUninstall(hint); ok {
+			return cmd, true
+		}
+	}
+	return "", false
+}
+
+// deriveUninstall converts a vetted install command into its uninstall
+// counterpart for the two package managers whose grammar is unambiguous:
+//
+//	npm install -g <pkg>   → npm uninstall -g <pkg>
+//	brew install <pkg>     → brew uninstall <pkg>
+//
+// Anything else (curl | sh, apt-get, pip, …) returns false — we never invent a
+// remove command we can't be sure is safe.
+func deriveUninstall(installCmd string) (string, bool) {
+	cmd := strings.TrimSpace(installCmd)
+	if cmd == "" {
+		return "", false
+	}
+	switch {
+	case strings.HasPrefix(cmd, "npm install -g "):
+		pkg := strings.TrimSpace(strings.TrimPrefix(cmd, "npm install -g "))
+		if pkg == "" {
+			return "", false
+		}
+		return "npm uninstall -g " + pkg, true
+	case strings.HasPrefix(cmd, "npm i -g "):
+		pkg := strings.TrimSpace(strings.TrimPrefix(cmd, "npm i -g "))
+		if pkg == "" {
+			return "", false
+		}
+		return "npm uninstall -g " + pkg, true
+	case strings.HasPrefix(cmd, "brew install "):
+		pkg := strings.TrimSpace(strings.TrimPrefix(cmd, "brew install "))
+		if pkg == "" {
+			return "", false
+		}
+		return "brew uninstall " + pkg, true
 	}
 	return "", false
 }

--- a/server/handlers/deps_install_test.go
+++ b/server/handlers/deps_install_test.go
@@ -212,6 +212,12 @@ func TestResolveCommand(t *testing.T) {
 		{"tool install_cmd", "acmecli", "install", "brew install acmecli", true},
 		// Registered CLI tool: update prefers upgrade_cmd.
 		{"tool upgrade_cmd", "acmecli", "update", "brew upgrade acmecli", true},
+		// Registered CLI tool: uninstall derives from its brew install_cmd.
+		{"tool uninstall", "acmecli", "uninstall", "brew uninstall acmecli", true},
+		// Provider CLI: uninstall derives from its npm install hint.
+		{"provider uninstall", "codex", "uninstall", "npm uninstall -g @openai/codex", true},
+		// Core system deps are never auto-uninstalled.
+		{"core dep uninstall refused", "git", "uninstall", "", false},
 		// Unknown id with no installer.
 		{"unknown", "nonesuch", "install", "", false},
 	}
@@ -230,6 +236,28 @@ func TestResolveCommand(t *testing.T) {
 				t.Errorf("expected a non-empty command for %q", tt.id)
 			}
 		})
+	}
+}
+
+func TestDeriveUninstall(t *testing.T) {
+	tests := []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"npm install -g @openai/codex", "npm uninstall -g @openai/codex", true},
+		{"npm i -g cursor-agent", "npm uninstall -g cursor-agent", true},
+		{"brew install acmecli", "brew uninstall acmecli", true},
+		{"curl -fsSL https://antigravity.google/install.sh | sh", "", false},
+		{"sudo apt-get update && sudo apt-get install -y git", "", false},
+		{"", "", false},
+		{"npm install -g ", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := deriveUninstall(tt.in)
+		if ok != tt.wantOK || got != tt.want {
+			t.Errorf("deriveUninstall(%q) = (%q,%v), want (%q,%v)", tt.in, got, ok, tt.want, tt.wantOK)
+		}
 	}
 }
 

--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -195,6 +195,14 @@ func isSSERequest(r *http.Request) bool {
 	if r.URL.Path == "/api/events" || strings.HasPrefix(r.URL.Path, "/_mcp/") {
 		return true
 	}
+	// The dependency installer streams NDJSON and relies on http.Flusher to
+	// push each line as it arrives. gzipResponseWriter doesn't implement
+	// Flusher, so wrapping this route would make the handler fall back to
+	// "streaming not supported" for any browser (which always sends
+	// Accept-Encoding: gzip). Exempt it so install/update/uninstall stream.
+	if r.URL.Path == "/api/deps/install" {
+		return true
+	}
 	// /api/agents/{name}/output and /api/agents/{name}/events are SSE streams
 	if strings.HasPrefix(r.URL.Path, "/api/agents/") &&
 		(strings.HasSuffix(r.URL.Path, "/output") || strings.HasSuffix(r.URL.Path, "/events")) {

--- a/server/handlers/helpers_test.go
+++ b/server/handlers/helpers_test.go
@@ -214,6 +214,7 @@ func TestIsSSERequest(t *testing.T) {
 		{"mcp message", "/_mcp/message", "", true},
 		{"agent output", "/api/agents/alice/output", "", true},
 		{"accept event-stream", "/api/anything", "text/event-stream", true},
+		{"deps install stream", "/api/deps/install", "", true},
 		{"normal API", "/api/agents", "", false},
 		{"health", "/health", "", false},
 		{"agent non-output", "/api/agents/alice/stats", "", false},

--- a/server/handlers/pkgmanagers.go
+++ b/server/handlers/pkgmanagers.go
@@ -1,0 +1,164 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"os/exec"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// PackageManagersHandler serves a read-only autodetect of the host OS and the
+// package managers available on PATH. It shells out only to run each manager's
+// own `--version` probe (never a user-supplied command), so it is safe to
+// expose without the loopback gate the install stream requires.
+//
+// The result feeds the Tools page ("detected managers") and gives install/
+// search flows an honest picture of what the host can actually do.
+type PackageManagersHandler struct {
+	cached time.Time
+	cache  []PackageManager
+	mu     sync.Mutex
+}
+
+// NewPackageManagersHandler constructs a PackageManagersHandler.
+func NewPackageManagersHandler() *PackageManagersHandler { return &PackageManagersHandler{} }
+
+// Register mounts GET /api/system/package-managers.
+func (h *PackageManagersHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/system/package-managers", h.list)
+}
+
+// PackageManager is one detected (or candidate) package manager.
+type PackageManager struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	// Available is true when the binary resolves on PATH.
+	Available bool `json:"available"`
+	// Searchable is true when this manager exposes a registry search the
+	// UI can drive (e.g. `brew search`, `npm search`). Honest metadata:
+	// managers without a usable search are labeled so rather than faked.
+	Searchable bool `json:"searchable"`
+}
+
+// pmCandidate describes a manager to probe: its binary, the args that print a
+// version, and whether it has a searchable registry.
+type pmCandidate struct {
+	id, name, binary, versionArg string
+	// oses restricts a candidate to specific runtime.GOOS values; empty
+	// means every OS.
+	oses       []string
+	searchable bool
+}
+
+// pmCandidates is the vetted set of managers we probe. Cross-platform tools
+// (npm, pipx, cargo) are probed everywhere; OS-native managers are gated to
+// the platforms they ship on so a Linux box isn't asked about winget.
+var pmCandidates = []pmCandidate{
+	{id: "brew", name: "Homebrew", binary: "brew", versionArg: "--version", searchable: true, oses: []string{"darwin", "linux"}},
+	{id: "apt", name: "APT", binary: "apt-get", versionArg: "--version", searchable: true, oses: []string{"linux"}},
+	{id: "dnf", name: "DNF", binary: "dnf", versionArg: "--version", searchable: true, oses: []string{"linux"}},
+	{id: "yum", name: "YUM", binary: "yum", versionArg: "--version", searchable: true, oses: []string{"linux"}},
+	{id: "pacman", name: "pacman", binary: "pacman", versionArg: "--version", searchable: true, oses: []string{"linux"}},
+	{id: "zypper", name: "Zypper", binary: "zypper", versionArg: "--version", searchable: true, oses: []string{"linux"}},
+	{id: "winget", name: "winget", binary: "winget", versionArg: "--version", searchable: true, oses: []string{"windows"}},
+	{id: "npm", name: "npm", binary: "npm", versionArg: "--version", searchable: true},
+	{id: "pipx", name: "pipx", binary: "pipx", versionArg: "--version", searchable: false},
+	{id: "cargo", name: "Cargo", binary: "cargo", versionArg: "--version", searchable: true},
+}
+
+// pmLookPath and pmRunVersion are package vars so tests can inject a stub host
+// without shelling out to real binaries.
+var (
+	pmLookPath   = exec.LookPath
+	pmRunVersion = func(ctx context.Context, binary, arg string) (string, bool) {
+		cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		defer cancel()
+		out, err := exec.CommandContext(cctx, binary, arg).CombinedOutput() //nolint:gosec // binary+arg come from the vetted pmCandidates table
+		if err != nil {
+			return "", false
+		}
+		return firstLine(string(out)), true
+	}
+)
+
+// firstLine returns the first non-empty, trimmed line of s.
+func firstLine(s string) string {
+	sc := bufio.NewScanner(strings.NewReader(s))
+	for sc.Scan() {
+		if line := strings.TrimSpace(sc.Text()); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// detect probes every OS-relevant candidate and returns those found on PATH,
+// each with its reported version. Results are cached briefly so the polling UI
+// doesn't re-shell every few seconds.
+func (h *PackageManagersHandler) detect(ctx context.Context) []PackageManager {
+	const ttl = 30 * time.Second
+	h.mu.Lock()
+	if h.cache != nil && time.Since(h.cached) < ttl {
+		out := h.cache
+		h.mu.Unlock()
+		return out
+	}
+	h.mu.Unlock()
+
+	goos := runtime.GOOS
+	found := make([]PackageManager, 0, len(pmCandidates))
+	for _, c := range pmCandidates {
+		if len(c.oses) > 0 && !pmOSMatch(c.oses, goos) {
+			continue
+		}
+		if _, err := pmLookPath(c.binary); err != nil {
+			continue
+		}
+		version := ""
+		if v, ok := pmRunVersion(ctx, c.binary, c.versionArg); ok {
+			version = v
+		}
+		found = append(found, PackageManager{
+			ID:         c.id,
+			Name:       c.name,
+			Version:    version,
+			Available:  true,
+			Searchable: c.searchable,
+		})
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].ID < found[j].ID })
+
+	h.mu.Lock()
+	h.cache = found
+	h.cached = time.Now()
+	h.mu.Unlock()
+	return found
+}
+
+func pmOSMatch(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// list handles GET /api/system/package-managers.
+func (h *PackageManagersHandler) list(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	managers := h.detect(r.Context())
+	writeJSON(w, http.StatusOK, map[string]any{
+		"os":       runtime.GOOS,
+		"arch":     runtime.GOARCH,
+		"managers": managers,
+	})
+}

--- a/server/handlers/pkgmanagers_test.go
+++ b/server/handlers/pkgmanagers_test.go
@@ -1,0 +1,87 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestPackageManagersDetect stubs the host so the probe is deterministic:
+// only "npm" and "brew" resolve on PATH, each reporting a canned version.
+func TestPackageManagersDetect(t *testing.T) {
+	origLook, origVer := pmLookPath, pmRunVersion
+	t.Cleanup(func() { pmLookPath, pmRunVersion = origLook, origVer })
+
+	present := map[string]string{
+		"npm":  "10.2.4",
+		"brew": "Homebrew 4.2.0",
+	}
+	pmLookPath = func(binary string) (string, error) {
+		if _, ok := present[binary]; ok {
+			return "/usr/local/bin/" + binary, nil
+		}
+		return "", errors.New("not found")
+	}
+	pmRunVersion = func(_ context.Context, binary, _ string) (string, bool) {
+		v, ok := present[binary]
+		return v, ok
+	}
+
+	h := NewPackageManagersHandler()
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/system/package-managers", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var got struct {
+		OS       string           `json:"os"`
+		Arch     string           `json:"arch"`
+		Managers []PackageManager `json:"managers"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.OS == "" || got.Arch == "" {
+		t.Fatalf("os/arch missing: %+v", got)
+	}
+
+	byID := map[string]PackageManager{}
+	for _, m := range got.Managers {
+		byID[m.ID] = m
+	}
+	// npm is probed on every OS, so it must always appear with our stub.
+	npm, ok := byID["npm"]
+	if !ok {
+		t.Fatalf("npm not detected; managers=%+v", got.Managers)
+	}
+	if npm.Version != "10.2.4" || !npm.Available || !npm.Searchable {
+		t.Fatalf("npm entry wrong: %+v", npm)
+	}
+	// A manager not on PATH must never be reported.
+	if _, ok := byID["pacman"]; ok {
+		t.Fatalf("pacman reported despite not being on PATH")
+	}
+}
+
+// TestPackageManagersMethodGuard rejects non-GET.
+func TestPackageManagersMethodGuard(t *testing.T) {
+	h := NewPackageManagersHandler()
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/system/package-managers", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code == http.StatusOK {
+		t.Fatalf("POST should be rejected, got %d", rec.Code)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -383,6 +383,9 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	// Tools page. Loopback only; runs vetted install/upgrade commands (from
 	// the table or the tools registry) and streams their output.
 	handlers.NewDepsInstallHandler().SetToolStore(svc.Tools).Register(mux)
+	// Read-only autodetect of host OS + package managers (brew/apt/npm/…)
+	// with versions. Shells out only to each manager's own --version probe.
+	handlers.NewPackageManagersHandler().Register(mux)
 	// Per-repo cost rollup. Handler is nil-safe and returns 503 when the
 	// global ledger isn't wired.
 	mux.Handle("/api/global/costs", handlers.NewGlobalCostsHandler(svc.Costs))

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -478,6 +478,22 @@ export interface Tool {
   upgrade_cmd?: string;
 }
 
+/** One detected host package manager. */
+export interface PackageManager {
+  id: string;
+  name: string;
+  version: string;
+  available: boolean;
+  /** true = this manager exposes a registry search the UI could drive. */
+  searchable: boolean;
+}
+
+export interface PackageManagersResponse {
+  os: string;
+  arch: string;
+  managers: PackageManager[];
+}
+
 /** A provider model with live availability status. */
 export interface ModelInfo {
   id: string;
@@ -1271,6 +1287,9 @@ export const api = {
   getHealth: () => request<HealthReport>("/health"),
 
   getSystemInfo: () => request<{ hostname: string; os: string; arch: string }>("/system/info"),
+  /** Autodetected host package managers (brew/apt/npm/…) with versions. */
+  getPackageManagers: () =>
+    request<PackageManagersResponse>("/system/package-managers"),
   getSettings: () => request<SettingsConfig>("/settings"),
   updateSettings: (patch: Record<string, unknown>) =>
     request<SettingsConfig>("/settings", {

--- a/web/src/components/PackageManagers.tsx
+++ b/web/src/components/PackageManagers.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+import type { PackageManager } from "../api/client";
+
+/* ── PackageManagers ──────────────────────────────────────────────────
+ *
+ * A compact, honest readout of the host's package managers — what mycel
+ * actually detected on PATH, with each manager's reported version. Feeds the
+ * Tools page so an install failure ("no brew here") is legible before it
+ * happens. Read-only: the data comes from GET /api/system/package-managers,
+ * which only ever runs each manager's own --version probe.
+ */
+
+type LoadState = "loading" | "ready" | "error";
+
+export function PackageManagers() {
+  const [state, setState] = useState<LoadState>("loading");
+  const [managers, setManagers] = useState<PackageManager[]>([]);
+  const [os, setOs] = useState<string>("");
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .getPackageManagers()
+      .then((res) => {
+        if (!alive) return;
+        setManagers(res.managers ?? []);
+        setOs(res.os ?? "");
+        setState("ready");
+      })
+      .catch(() => {
+        if (alive) setState("error");
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (state === "loading") {
+    return (
+      <div className="flex flex-wrap gap-2" aria-busy>
+        {[0, 1, 2].map((i) => (
+          <div key={i} className="h-7 w-28 animate-pulse rounded-md bg-mycel-surface-hover" />
+        ))}
+      </div>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <p className="text-[11px] text-mycel-muted">
+        Could not detect package managers on this host.
+      </p>
+    );
+  }
+
+  if (managers.length === 0) {
+    return (
+      <p className="text-[11px] text-mycel-muted">
+        No supported package managers detected on this {os || "host"}. Install commands that rely
+        on one (brew, apt, npm…) will need it on PATH first.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {managers.map((m) => (
+        <span
+          key={m.id}
+          className="inline-flex items-center gap-1.5 rounded-md border border-mycel-border bg-mycel-bg px-2 py-1 text-[11px]"
+          title={m.searchable ? `${m.name} — registry search supported` : `${m.name} — no registry search`}
+        >
+          <span className="w-1.5 h-1.5 rounded-full bg-mycel-success shrink-0" aria-hidden />
+          <span className="font-medium text-mycel-text">{m.name}</span>
+          {m.version && (
+            <span className="font-mono text-mycel-muted tabular-nums max-w-[140px] truncate">
+              {m.version}
+            </span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/__tests__/PackageManagers.test.tsx
+++ b/web/src/components/__tests__/PackageManagers.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * PackageManagers.test.tsx — the Tools-page package-manager readout must show
+ * exactly the managers the backend reports (name + version) and degrade to an
+ * honest "none detected" line when the host has none. No fabricated managers.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { PackageManagers } from "../PackageManagers";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(body) } as Response);
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("PackageManagers", () => {
+  it("renders detected managers with versions", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      if (String(url).endsWith("/api/system/package-managers")) {
+        return jsonResponse({
+          os: "darwin",
+          arch: "arm64",
+          managers: [
+            { id: "brew", name: "Homebrew", version: "Homebrew 4.2.0", available: true, searchable: true },
+            { id: "npm", name: "npm", version: "10.2.4", available: true, searchable: true },
+          ],
+        });
+      }
+      return jsonResponse({});
+    });
+
+    render(<PackageManagers />);
+    await waitFor(() => expect(screen.getByText("Homebrew")).toBeTruthy());
+    expect(screen.getByText("npm")).toBeTruthy();
+    expect(screen.getByText("10.2.4")).toBeTruthy();
+  });
+
+  it("shows an honest empty state when no managers are detected", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      if (String(url).endsWith("/api/system/package-managers")) {
+        return jsonResponse({ os: "linux", arch: "amd64", managers: [] });
+      }
+      return jsonResponse({});
+    });
+
+    render(<PackageManagers />);
+    await waitFor(() => expect(screen.getByText(/No supported package managers detected/)).toBeTruthy());
+  });
+});

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState, useEffect, useMemo } from "react";
-import { Link } from "react-router-dom";
-import { api, type ProviderInfo, type OnboardingState } from "../api/client";
+import { Link, useNavigate } from "react-router-dom";
+import { api, type ProviderInfo, type OnboardingState, type AppInstance, type Tool } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
@@ -277,41 +277,156 @@ function SetupSection() {
 /*  and points; it never duplicates their config UI.                     */
 /* ------------------------------------------------------------------ */
 
+/* A quiet status dot + label for the compact summary tables. */
+function MiniStatus({ ok, label }: { ok: boolean; label: string }) {
+  return (
+    <span className={`inline-flex items-center gap-1.5 text-[11px] ${ok ? "text-mycel-success" : "text-mycel-muted"}`}>
+      <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${ok ? "bg-mycel-success" : "bg-mycel-muted"}`} aria-hidden />
+      {label}
+    </span>
+  );
+}
+
+/* The compact table shell used by every drilldown summary: a bordered,
+ * rounded table whose header sits on the surface tint. */
+function SummaryTable({ head, children }: { head: React.ReactNode; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-mycel-border overflow-hidden">
+      <table className="w-full text-left">
+        <thead>
+          <tr className="bg-mycel-bg border-b border-mycel-border text-[10px] text-mycel-muted uppercase tracking-[0.08em]">
+            {head}
+          </tr>
+        </thead>
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}
+
+/* The "Open the full manager →" footer link every summary table drills into. */
+function DrilldownFooter({ to, label }: { to: string; label: string }) {
+  return (
+    <Link
+      to={to}
+      className="group flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-[11.5px] text-mycel-text-2 hover:text-mycel-accent hover:bg-mycel-surface-hover transition-colors"
+    >
+      <span>{label}</span>
+      <span className="text-mycel-muted group-hover:text-mycel-accent group-hover:translate-x-0.5 transition-all" aria-hidden>→</span>
+    </Link>
+  );
+}
+
+/* Providers + CLI tools drilldown: two compact tables that summarize the
+ * /tools manager. Provider rows drill into per-provider detail; the whole
+ * area drills into /tools. The fleet-default provider is marked with its
+ * model so Settings answers "what runs by default?" at a glance. */
 function ProvidersToolsCard({ data }: { data: Record<string, unknown> }) {
+  const navigate = useNavigate();
   const p = (data.providers ?? {}) as Record<string, unknown>;
   const defaultProvider = String(p.default ?? "claude");
-  const [installed, setInstalled] = useState<number | null>(null);
-  const [total, setTotal] = useState<number | null>(null);
+  const defaultModel = String(p.default_model ?? "");
+  const [providers, setProviders] = useState<ProviderInfo[] | null>(null);
+  const [tools, setTools] = useState<Tool[] | null>(null);
   const [host, setHost] = useState<{ hostname: string; os: string; arch: string } | null>(null);
 
   useEffect(() => {
     let alive = true;
     api.listProviders()
-      .then((list: ProviderInfo[]) => {
-        if (!alive) return;
-        setTotal(list.length);
-        setInstalled(list.filter((pi) => pi.installed).length);
-      })
-      .catch(() => { /* summary degrades to the default provider alone */ });
+      .then((list) => { if (alive) setProviders(list); })
+      .catch(() => { if (alive) setProviders([]); });
+    api.listTools()
+      .then((list) => { if (alive) setTools(list.filter((t) => t.type !== "provider" && t.type !== "mcp")); })
+      .catch(() => { if (alive) setTools([]); });
     api.getSystemInfo()
       .then((info) => { if (alive) setHost(info); })
       .catch(() => { /* host line is optional */ });
     return () => { alive = false; };
   }, []);
 
-  const counts = installed !== null && total !== null ? ` · ${installed}/${total} installed` : "";
-
   return (
-    <div className="space-y-2.5">
-      <LinkCard
-        to="/tools"
-        ariaLabel="Open Tools & Providers"
-        icon={<path strokeLinecap="round" strokeLinejoin="round" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />}
-        title={`Default: ${PROVIDER_LABELS[defaultProvider] ?? defaultProvider}${counts}`}
-        body="Install tools, sign in, and set the default model."
-      />
+    <div className="space-y-3">
+      {/* Providers table */}
+      <div className="space-y-1.5">
+        <p className="text-[10.5px] text-mycel-muted uppercase tracking-[0.08em]">Providers</p>
+        {providers === null ? (
+          <div className="h-16 animate-pulse rounded-lg bg-mycel-surface-hover" />
+        ) : providers.length === 0 ? (
+          <p className="text-[11.5px] text-mycel-muted px-1">No providers found.</p>
+        ) : (
+          <SummaryTable
+            head={<>
+              <th className="px-3 py-1.5 font-medium">Provider</th>
+              <th className="px-3 py-1.5 font-medium">Status</th>
+              <th className="px-3 py-1.5 font-medium">Default</th>
+            </>}
+          >
+            {providers.map((pi) => {
+              const isDefault = pi.name === defaultProvider;
+              return (
+                <tr
+                  key={pi.name}
+                  onClick={() => navigate(`/tools/${encodeURIComponent(pi.name)}`)}
+                  className="border-b border-mycel-border last:border-0 hover:bg-mycel-surface-hover cursor-pointer transition-colors"
+                >
+                  <td className="px-3 py-1.5 text-[12px] font-medium text-mycel-text">{PROVIDER_LABELS[pi.name] ?? pi.name}</td>
+                  <td className="px-3 py-1.5"><MiniStatus ok={pi.installed} label={pi.installed ? "Installed" : "Not installed"} /></td>
+                  <td className="px-3 py-1.5 text-[11px]">
+                    {isDefault ? (
+                      <span className="inline-flex items-center gap-1.5">
+                        <span className="px-1.5 py-0.5 rounded bg-mycel-accent-subtle text-mycel-accent text-[10px] font-medium">Default</span>
+                        <span className="text-mycel-muted font-mono truncate max-w-[120px]" title={defaultModel || "provider default"}>
+                          {defaultModel || "provider default"}
+                        </span>
+                      </span>
+                    ) : (
+                      <span className="text-mycel-muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </SummaryTable>
+        )}
+      </div>
+
+      {/* CLI tools table */}
+      <div className="space-y-1.5">
+        <p className="text-[10.5px] text-mycel-muted uppercase tracking-[0.08em]">CLI tools</p>
+        {tools === null ? (
+          <div className="h-10 animate-pulse rounded-lg bg-mycel-surface-hover" />
+        ) : tools.length === 0 ? (
+          <p className="text-[11.5px] text-mycel-muted px-1">No CLI tools tracked.</p>
+        ) : (
+          <SummaryTable
+            head={<>
+              <th className="px-3 py-1.5 font-medium">Tool</th>
+              <th className="px-3 py-1.5 font-medium">Status</th>
+              <th className="px-3 py-1.5 font-medium">Version</th>
+            </>}
+          >
+            {tools.map((t) => {
+              const ok = t.status !== "not_installed" && t.status !== "error";
+              return (
+                <tr
+                  key={t.name}
+                  onClick={() => navigate("/tools")}
+                  className="border-b border-mycel-border last:border-0 hover:bg-mycel-surface-hover cursor-pointer transition-colors"
+                >
+                  <td className="px-3 py-1.5 text-[12px] font-medium text-mycel-text">{t.name}</td>
+                  <td className="px-3 py-1.5"><MiniStatus ok={ok} label={ok ? "Installed" : t.status === "error" ? "Error" : "Not installed"} /></td>
+                  <td className="px-3 py-1.5 text-[11px] font-mono text-mycel-muted truncate max-w-[140px]" title={t.version || ""}>{t.version || "—"}</td>
+                </tr>
+              );
+            })}
+          </SummaryTable>
+        )}
+      </div>
+
+      <DrilldownFooter to="/tools" label="Install tools, sign in, set the default model" />
+
       {/* Host machine — folded in from the old hostname nav item. */}
-      <div className="flex items-center gap-2 px-3 text-[11px] text-mycel-muted">
+      <div className="flex items-center gap-2 px-1 text-[11px] text-mycel-muted">
         <svg className="w-3.5 h-3.5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6} aria-hidden>
           <rect x="3" y="4" width="18" height="12" rx="1.5" /><path strokeLinecap="round" d="M8 20h8M12 16v4" />
         </svg>
@@ -324,27 +439,6 @@ function ProvidersToolsCard({ data }: { data: Record<string, unknown> }) {
         )}
       </div>
     </div>
-  );
-}
-
-/* A whole-card link to a surface that owns its own page. Mirrors the
- * wizard's NextCard so Settings and setup feel like one product. */
-function LinkCard({ to, ariaLabel, icon, title, body }: { to: string; ariaLabel: string; icon: React.ReactNode; title: string; body: string }) {
-  return (
-    <Link
-      to={to}
-      aria-label={`${ariaLabel} — ${title}`}
-      className="group flex items-center gap-3 rounded-lg border border-mycel-border bg-mycel-bg px-3 py-2.5 hover:border-mycel-accent hover:bg-mycel-surface-hover transition-colors"
-    >
-      <span className="grid place-items-center w-8 h-8 rounded-lg bg-mycel-surface text-mycel-text-2 shrink-0 group-hover:text-mycel-accent transition-colors">
-        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.6}>{icon}</svg>
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block text-[13px] font-medium text-mycel-text truncate">{title}</span>
-        <span className="block text-[11.5px] text-mycel-muted truncate">{body}</span>
-      </span>
-      <span className="shrink-0 text-mycel-muted group-hover:text-mycel-accent group-hover:translate-x-0.5 transition-all" aria-hidden>→</span>
-    </Link>
   );
 }
 
@@ -386,30 +480,51 @@ function RuntimeSection({ data, onChange }: { data: Record<string, unknown>; onC
   );
 }
 
+/* Apps drilldown: a compact table of connected integrations (platform ·
+ * status), summarizing the /apps manager. Rows and footer drill into /apps. */
 function AppsCard() {
-  const [count, setCount] = useState<number | null>(null);
+  const navigate = useNavigate();
+  const [instances, setInstances] = useState<AppInstance[] | null>(null);
 
   useEffect(() => {
     let alive = true;
     api.getApps()
-      .then((res) => { if (alive) setCount((res.instances ?? []).filter((i) => i.connected).length); })
-      .catch(() => { if (alive) setCount(0); });
+      .then((res) => { if (alive) setInstances(res.instances ?? []); })
+      .catch(() => { if (alive) setInstances([]); });
     return () => { alive = false; };
   }, []);
 
-  const summary =
-    count === null ? "Loading…"
-      : count === 0 ? "No apps connected"
-        : `${count} app${count === 1 ? "" : "s"} connected`;
-
   return (
-    <LinkCard
-      to="/apps"
-      ariaLabel="Manage apps"
-      icon={<path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6zM13.5 15.75a2.25 2.25 0 012.25-2.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-2.25A2.25 2.25 0 0113.5 18v-2.25z" />}
-      title={summary}
-      body="Integrations, notification delivery, and API keys."
-    />
+    <div className="space-y-2.5">
+      {instances === null ? (
+        <div className="h-16 animate-pulse rounded-lg bg-mycel-surface-hover" />
+      ) : instances.length === 0 ? (
+        <p className="text-[11.5px] text-mycel-muted px-1">No apps connected yet.</p>
+      ) : (
+        <SummaryTable
+          head={<>
+            <th className="px-3 py-1.5 font-medium">App</th>
+            <th className="px-3 py-1.5 font-medium">Platform</th>
+            <th className="px-3 py-1.5 font-medium">Status</th>
+          </>}
+        >
+          {instances.map((inst) => (
+            <tr
+              key={inst.name}
+              onClick={() => navigate("/apps")}
+              className="border-b border-mycel-border last:border-0 hover:bg-mycel-surface-hover cursor-pointer transition-colors"
+            >
+              <td className="px-3 py-1.5 text-[12px] font-medium text-mycel-text">{inst.name}</td>
+              <td className="px-3 py-1.5 text-[11px] text-mycel-muted">{inst.app}</td>
+              <td className="px-3 py-1.5">
+                <MiniStatus ok={inst.connected} label={inst.connected ? "Connected" : inst.error ? "Error" : "Disconnected"} />
+              </td>
+            </tr>
+          ))}
+        </SummaryTable>
+      )}
+      <DrilldownFooter to="/apps" label="Integrations, notification delivery, and API keys" />
+    </div>
   );
 }
 

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -9,6 +9,7 @@ import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { ProvidersTable } from "../components/ProvidersTable";
 import { ProviderDefaults } from "../components/ProviderDefaults";
+import { PackageManagers } from "../components/PackageManagers";
 import { CopyButton } from "../components/CopyButton";
 import { ToastContainer, useToast } from "../components/Toast";
 import type { ToastLevel } from "../components/Toast";
@@ -45,29 +46,47 @@ function ChevronIcon({ expanded }: { expanded: boolean }) {
   );
 }
 
-/* ── In-surface install / update ──────────────────────────────────────
+/* ── In-surface streamed command ──────────────────────────────────────
  *
- * Streams a CLI tool's install (or update) command over POST /api/deps/install
- * — the same loopback-guarded NDJSON stream the setup wizard uses — into a
- * live console with an honest running → success/error progression. The stream
- * carries no percentage, so progress is an indeterminate bar while running and
- * a resolved (green/red) bar on completion; the line count is the concrete
- * "how far along" signal. */
+ * Streams a CLI tool's install / update / uninstall command over POST
+ * /api/deps/install — the same loopback-guarded NDJSON stream the setup
+ * wizard uses — into a live console with an honest running → success/error
+ * progression. The stream carries no percentage, so progress is an
+ * indeterminate bar while running and a resolved (green/red) bar on
+ * completion; the line count is the concrete "how far along" signal. */
 type RunState = "idle" | "running" | "ok" | "error";
+type RunMode = "install" | "update" | "uninstall";
 
-function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) {
+const RUN_VERBS: Record<RunMode, { idle: string; gerund: string; done: string }> = {
+  install: { idle: "Install", gerund: "Installing", done: "Installed" },
+  update: { idle: "Update", gerund: "Updating", done: "Updated" },
+  uninstall: { idle: "Uninstall", gerund: "Uninstalling", done: "Uninstalled" },
+};
+
+/* A single streamed action button + live console. Reused for install,
+ * update, and uninstall so all three share one honest state machine. */
+function StreamedAction({
+  toolName,
+  mode,
+  canRun,
+  disabledHint,
+  destructive = false,
+  onDone,
+}: {
+  toolName: string;
+  mode: RunMode;
+  canRun: boolean;
+  disabledHint: string;
+  destructive?: boolean;
+  onDone: () => void;
+}) {
   const reduceMotion = useReducedMotion();
   const [state, setState] = useState<RunState>("idle");
   const [lines, setLines] = useState<string[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const consoleRef = useRef<HTMLDivElement>(null);
   const runningRef = useRef(false);
-
-  const isInstalled = tool.status !== "not_installed";
-  const mode: "install" | "update" = isInstalled ? "update" : "install";
-  const canRun = mode === "install"
-    ? Boolean(tool.install_cmd)
-    : Boolean(tool.upgrade_cmd || tool.install_cmd);
+  const verbs = RUN_VERBS[mode];
 
   useEffect(() => {
     const el = consoleRef.current;
@@ -84,7 +103,7 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
     runningRef.current = true;
     try {
       const code = await installDep(
-        tool.name,
+        toolName,
         (ev) => {
           if (!runningRef.current) return;
           if (ev.type === "start") setLines((l) => [...l, `$ ${ev.command}`]);
@@ -98,7 +117,7 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
         onDone();
       } else {
         setState("error");
-        setErr(`${mode === "update" ? "Update" : "Install"} exited with code ${code}.`);
+        setErr(`${verbs.idle} exited with code ${code}.`);
       }
     } catch (e) {
       if (!runningRef.current) return;
@@ -109,27 +128,24 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
     }
   };
 
-  const label = mode === "update" ? "Update" : "Install";
-  const barTone = state === "ok" ? "bg-mycel-success" : state === "error" ? "bg-mycel-error" : "bg-mycel-accent";
+  const barTone = state === "ok" ? "bg-mycel-success" : state === "error" ? "bg-mycel-error" : destructive ? "bg-mycel-error" : "bg-mycel-accent";
+  const btnCls = destructive
+    ? "inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-1 rounded-md border border-mycel-error text-mycel-error hover:bg-mycel-error hover:text-white transition-colors disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-mycel-error"
+    : "inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-1 rounded-md border border-mycel-accent bg-mycel-accent-subtle text-mycel-accent hover:bg-mycel-accent hover:text-mycel-accent-fg transition-colors disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-mycel-accent";
 
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2 flex-wrap">
         {canRun ? (
-          <button
-            type="button"
-            onClick={() => void run()}
-            disabled={state === "running"}
-            className="inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-1 rounded-md border border-mycel-accent bg-mycel-accent-subtle text-mycel-accent hover:bg-mycel-accent hover:text-mycel-accent-fg transition-colors disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-mycel-accent"
-          >
+          <button type="button" onClick={() => void run()} disabled={state === "running"} className={btnCls}>
             {state === "running" && <Spinner />}
             {state === "running"
-              ? `${label === "Update" ? "Updating" : "Installing"}…`
+              ? `${verbs.gerund}…`
               : state === "ok"
-                ? `${label} again`
+                ? `${verbs.idle} again`
                 : state === "error"
-                  ? `Retry ${label.toLowerCase()}`
-                  : label}
+                  ? `Retry ${verbs.idle.toLowerCase()}`
+                  : verbs.idle}
           </button>
         ) : (
           <span className="inline-flex items-center gap-1.5 text-[11px] text-mycel-muted">
@@ -137,7 +153,7 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
               <circle cx="7" cy="7" r="5.5" />
               <path d="M7 4.5v.01M6 6.5h1v3h1" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
-            No automatic {mode === "update" ? "updater" : "installer"} — copy the command above to run it yourself.
+            {disabledHint}
           </span>
         )}
         {state === "ok" && (
@@ -145,7 +161,7 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
               <path d="M20 6L9 17l-5-5" />
             </svg>
-            {mode === "update" ? "Updated" : "Installed"}. Re-checking…
+            {verbs.done}. Re-checking…
           </span>
         )}
         {state === "error" && err && (
@@ -162,11 +178,9 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
         <div className="space-y-1.5">
           {/* Progress: indeterminate while running (honest — the stream has no
               percent), resolved to a full green/red bar on completion. */}
-          <div className="h-1 rounded-full bg-mycel-border overflow-hidden" role="progressbar" aria-label={`${label} progress`} aria-busy={state === "running"}>
+          <div className="h-1 rounded-full bg-mycel-border overflow-hidden" role="progressbar" aria-label={`${verbs.idle} progress`} aria-busy={state === "running"}>
             {state === "running" ? (
-              <div
-                className={`h-full w-1/3 rounded-full ${barTone} ${reduceMotion ? "" : "animate-indeterminate"}`}
-              />
+              <div className={`h-full w-1/3 rounded-full ${barTone} ${reduceMotion ? "" : "animate-indeterminate"}`} />
             ) : (
               <div className={`h-full w-full rounded-full ${barTone}`} />
             )}
@@ -185,9 +199,44 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
             </div>
           )}
           <div className="text-[10.5px] text-mycel-muted tabular-nums">
-            {state === "running" ? `${lines.length} line${lines.length === 1 ? "" : "s"}…` : `${lines.length} line${lines.length === 1 ? "" : "s"}`}
+            {`${lines.length} line${lines.length === 1 ? "" : "s"}${state === "running" ? "…" : ""}`}
           </div>
         </div>
+      )}
+    </div>
+  );
+}
+
+/* Install-or-update for a CLI tool, plus an uninstall path for installed,
+ * non-required tools. Mode is chosen from the tool's current status. */
+function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) {
+  const isInstalled = tool.status !== "not_installed";
+  const mode: RunMode = isInstalled ? "update" : "install";
+  const canRun = mode === "install"
+    ? Boolean(tool.install_cmd)
+    : Boolean(tool.upgrade_cmd || tool.install_cmd);
+
+  return (
+    <div className="space-y-2">
+      <StreamedAction
+        toolName={tool.name}
+        mode={mode}
+        canRun={canRun}
+        disabledHint={`No automatic ${mode === "update" ? "updater" : "installer"} — copy the command above to run it yourself.`}
+        onDone={onDone}
+      />
+      {/* Uninstall the binary — distinct from "Remove" (which only forgets the
+          registry entry). Offered only for installed, non-required tools; the
+          backend refuses core system deps and returns an honest error. */}
+      {isInstalled && !tool.required && (
+        <StreamedAction
+          toolName={tool.name}
+          mode="uninstall"
+          canRun
+          disabledHint=""
+          destructive
+          onDone={onDone}
+        />
       )}
     </div>
   );
@@ -626,6 +675,12 @@ export function Tools() {
             {filteredCli.length}{searchLower ? `/${cliTools.length}` : ""}
           </span>
           <span className="flex-1 h-px bg-mycel-border self-center" aria-hidden />
+        </div>
+        {/* Detected host package managers — the honest picture of what
+            install/update/uninstall commands can actually use. */}
+        <div className="mb-3">
+          <p className="text-[10.5px] text-mycel-muted uppercase tracking-[0.08em] mb-1.5">Detected package managers</p>
+          <PackageManagers />
         </div>
         {filteredCli.length === 0 ? (
           searchLower ? (

--- a/web/src/views/__tests__/settings.test.tsx
+++ b/web/src/views/__tests__/settings.test.tsx
@@ -76,15 +76,20 @@ describe("Settings redesign", () => {
     }
     // Budgets moved to Insights — it is no longer a Settings section.
     expect(screen.queryByText("budgets")).not.toBeInTheDocument();
-    // Link cards route out instead of duplicating config.
-    expect(screen.getByRole("link", { name: /Open Tools & Providers/i })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /Manage apps/i })).toBeInTheDocument();
+    // Drilldown summaries route out to the full managers instead of
+    // duplicating config: a footer link per surface.
+    const toolsLinks = screen.getAllByRole("link").filter((a) => a.getAttribute("href") === "/tools");
+    expect(toolsLinks.length).toBeGreaterThan(0);
+    const appsLinks = screen.getAllByRole("link").filter((a) => a.getAttribute("href") === "/apps");
+    expect(appsLinks.length).toBeGreaterThan(0);
   });
 
-  it("Tools & Providers card links to the flat /tools page", async () => {
+  it("Tools & Providers summary drills into the flat /tools page", async () => {
     mockApi();
     renderSettings();
-    expect(await screen.findByRole("link", { name: /Open Tools & Providers/i })).toHaveAttribute("href", "/tools");
+    await screen.findByText("providers & tools");
+    const toolsLinks = screen.getAllByRole("link").filter((a) => a.getAttribute("href") === "/tools");
+    expect(toolsLinks.length).toBeGreaterThan(0);
   });
 
   it("reads onboarding state into the Setup section", async () => {

--- a/web/src/wizard/installStream.ts
+++ b/web/src/wizard/installStream.ts
@@ -24,7 +24,7 @@ export type InstallEvent =
 export async function installDep(
   id: string,
   onEvent: (ev: InstallEvent) => void,
-  opts?: { signal?: AbortSignal; mode?: "install" | "update" },
+  opts?: { signal?: AbortSignal; mode?: "install" | "update" | "uninstall" },
 ): Promise<number> {
   const res = await fetch("/api/deps/install", {
     method: "POST",


### PR DESCRIPTION
Part of #2674

The Tools/Providers area was reviewed and found incomplete. This is a coherent, **fully-working** slice of the owner's 7-item list — no fake data, seams enumerated honestly below. It deliberately does the highest-value pieces completely rather than shipping all seven half-built.

## Fully working (verified live + tested)

**Item 2 — Package-manager autodetect** ✅
`GET /api/system/package-managers` detects the host OS and every package manager on PATH (brew/apt/dnf/yum/pacman/zypper/winget/npm/pipx/cargo) with its reported version. Read-only, cached 30s, shells out only to each manager's own `--version`. Surfaced as a "Detected package managers" strip on the Tools page. Live smoke on this host returned `brew 6.0.13`, `npm 11.17.0`, `pipx 1.11.1`.

**Item 4 — Install / Update / Uninstall that actually works** ✅
- Install/update already streamed via `/api/deps/install`; **found and fixed a real bug**: the gzip middleware wraps this route and `gzipResponseWriter` has no `Flusher`, so every browser (always `Accept-Encoding: gzip`) got `"streaming not supported"` — the in-surface install was broken in the actual app. Exempted the streaming route from gzip.
- Added **uninstall** (`mode=uninstall`): derives a vetted remove command (`npm uninstall -g …` / `brew uninstall …`) from the tool's install source; core system deps (git/tmux/docker) are refused. New streamed "Uninstall" action on each CLI tool row (loading→success/error).
- Live-verified end-to-end: install, update, and uninstall all streamed `start → log → done code 0` (with and without gzip). The uninstall derivation ran a real `brew uninstall` against the host, proving it's not a no-op.

**Item 5 — Per-provider subcommands** ✅ (surfaced) / ⚠️ (executed — see seams)
Curated `Commands()` (the `CommandLister` capability) now implemented for **codex, pi, agy, cursor, openclaw** (claude already had one), drawn from each CLI's own documented subcommands — auth/login, mcp list/add, models, resume, config. Drives `/api/providers/{name}/commands`, so the provider-detail "Available commands" is real per provider instead of a generic run/version/help stub. Live-verified for codex/cursor/openclaw.

**Item 1 — Table summaries in Settings drilldown cards** ✅
The one-line LinkCards became compact TABLE summaries: Providers (provider · installed status · default+model), CLI tools (tool · status · version), Apps (app · platform · status). Rows and a footer link drill into the full `/tools` and `/apps` managers. Host line preserved.

**Item 7 — Cross-page consistency** ✅ (partial)
All surfaces read the same `/api/providers`, `/api/tools/unified`, `/api/apps`, and `/api/system/*` sources. `ProviderDefaults`/`ProvidersTable`/`ProviderCard` remain the single shared provider components; the new `PackageManagers` component is reused-ready. No divergent copies introduced.

## Remaining seams (honest — not built here, with reasons)

- **Item 3 — registry browse/search (`brew search`/`npm search`)**: **not built.** It needs a guarded backend endpoint that runs an arbitrary search term through a package manager — a meaningful security surface I didn't want to ship half-vetted. The `PackageManager.searchable` flag is already returned per manager so the UI can honestly label which managers *could* support search. `// follow-up:` add `/api/system/package-search?manager=&q=` with strict arg validation.
- **Item 5 — *running* provider subcommands from the browser**: subcommands are surfaced as copyable curated commands, **not executed**. Most relevant ones (login/auth) are interactive device flows that can't be meaningfully streamed to a web UI, and running arbitrary provider subcommands is a security surface beyond this slice. `// follow-up:` a guarded `/api/providers/{name}/run` whitelisting non-interactive read-only subcommands (e.g. `mcp list`, `--version`).
- **Item 4 — uninstall coverage**: only `npm -g` and `brew` installs derive a safe uninstall. `curl | sh` and `apt-get` installers return an honest "no automatic uninstaller" rather than guessing a destructive command.
- **Item 7 — AgentDetail / StepProviders / New-Agent**: left unchanged this pass; they already consume the shared provider/model data. Deeper per-agent tool controls are a follow-up.

## Test plan (all pass)

Web (`cd web`):
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun run build` — built
- `bunx vitest run` — **308 passed** (added `PackageManagers.test.tsx`; updated `settings.test.tsx` for the new drilldown tables)

Go:
- `go build ./...` — OK
- `go vet ./server/... ./pkg/provider/...` — OK
- `golangci-lint run ./server/handlers/ ./pkg/provider/` — 0 issues
- `go test ./server/... ./pkg/provider/ ./pkg/deps/ ./pkg/tool/` — all OK (added `pkgmanagers_test.go`, provider `commands_test.go`, `deriveUninstall`/uninstall cases in `deps_install_test.go`, gzip-exemption case in `helpers_test.go`)

Live smoke (throwaway `MYCEL_HOME`, `127.0.0.1:8099`, torn down):
- package-managers returned real managers+versions
- codex/cursor/openclaw `/commands` returned curated subcommands
- install + update + uninstall streamed to completion (verified with browser-like `Accept-Encoding: gzip`)
- providers list returned all 6; real embedded UI served

## ui-ux-pro-max applied
Compact density, quiet type hierarchy, status dots with contrast in both themes, SVG icons (no emoji), streamed action shows save→loading→success/error with an indeterminate bar (honest — the stream carries no percent), reduced-motion respected, real empty/loading/error states throughout (package-manager panel, summary tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)