### PR TITLE
feat(slack): attribute outbound messages to the sending agent

### DIFF
--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,20 +24,23 @@ import (
 // Adapter implements gateway.NotificationAdapter for Slack using Socket Mode.
 // It also supports outbound messaging via Send and SendFile methods.
 type Adapter struct {
-	lastMessageAt time.Time
-	api           *slack.Client
-	sm            *socketmode.Client
-	handler       func(gateway.Notification)
-	channelMap    map[string]string
-	userCache     map[string]string
-	botToken      string
-	appToken      string
-	botUserID     string
-	botName       string
-	lastError     string
-	chatMu        sync.RWMutex
-	connected     bool
-	messageCount  atomic.Int64
+	lastMessageAt  time.Time
+	api            *slack.Client
+	sm             *socketmode.Client
+	handler        func(gateway.Notification)
+	channelMap     map[string]string
+	userCache      map[string]string
+	botUserID      string
+	appToken       string
+	botToken       string
+	botName        string
+	lastError      string
+	messageCount   atomic.Int64
+	chatMu         sync.RWMutex
+	scopeWarnOnce  sync.Once
+	customizeScope atomic.Bool
+	scopesSeen     atomic.Bool
+	connected      bool
 }
 
 var _ gateway.NotificationAdapter = (*Adapter)(nil)
@@ -62,6 +67,9 @@ func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification))
 	api := slack.New(
 		a.botToken,
 		slack.OptionAppLevelToken(a.appToken),
+		// Learn the granted OAuth scopes from every response so we can tell
+		// whether per-agent username/icon attribution will actually stick.
+		slack.OptionOnResponseHeaders(a.observeScopes),
 	)
 	a.api = api
 
@@ -137,16 +145,31 @@ func (a *Adapter) Status() gateway.AdapterStatus {
 
 // --- MessageSender + FileSender (outbound messaging) ---
 
-// Send delivers a message to a Slack channel.
+// Send delivers a message to a Slack channel, attributed to the sending agent.
+//
+// The agent's name (sender) is used verbatim as the Slack message username so
+// each post shows up as the agent that produced it, not the shared bot. Keeping
+// it byte-identical to the agent name also lets the inbound path
+// (handleMessageEvent) recognize our own bot-impersonation posts and skip the
+// echo back to the sender.
+//
+// The icon is a stable per-agent emoji derived from the agent name.
+//
+// follow-up: show the agent's real mushroom avatar via MsgOptionIconURL once we
+// have a publicly-reachable image URL for it. That URL is part of the future
+// mycel-cloud hosted asset set and isn't available locally, so we deliberately
+// do not fake one here.
 func (a *Adapter) Send(ctx context.Context, channelID, sender, content string) error {
 	if a.api == nil {
 		return fmt.Errorf("slack: not connected")
 	}
 
+	a.warnIfCustomizeMissing(sender)
+
 	_, _, err := a.api.PostMessageContext(ctx, channelID,
 		slack.MsgOptionText(content, false),
 		slack.MsgOptionUsername(sender),
-		slack.MsgOptionIconEmoji(":robot_face:"),
+		slack.MsgOptionIconEmoji(agentIconEmoji(sender)),
 	)
 	if err != nil {
 		return fmt.Errorf("slack: send failed: %w", err)
@@ -154,6 +177,66 @@ func (a *Adapter) Send(ctx context.Context, channelID, sender, content string) e
 
 	log.Info("slack: sent message", "channel_id", channelID, "sender", sender)
 	return nil
+}
+
+// observeScopes records, from an API response's X-OAuth-Scopes header, whether
+// the bot token holds chat:write.customize — the scope required for the
+// per-agent username/icon override to take effect.
+func (a *Adapter) observeScopes(_ string, headers http.Header) {
+	raw := headers.Get("X-OAuth-Scopes")
+	if raw == "" {
+		return
+	}
+	a.scopesSeen.Store(true)
+	for _, s := range strings.Split(raw, ",") {
+		if strings.TrimSpace(s) == "chat:write.customize" {
+			a.customizeScope.Store(true)
+			return
+		}
+	}
+	a.customizeScope.Store(false)
+}
+
+// warnIfCustomizeMissing logs a single honest warning if we have observed the
+// token's scopes and chat:write.customize is absent. In that case Slack ignores
+// the username/icon override and posts under the app's identity, so agent
+// attribution silently degrades. We still send the message.
+func (a *Adapter) warnIfCustomizeMissing(sender string) {
+	if !a.scopesSeen.Load() || a.customizeScope.Load() {
+		return
+	}
+	a.scopeWarnOnce.Do(func() {
+		log.Warn("slack: bot token lacks chat:write.customize scope — "+
+			"per-agent username/icon attribution will be ignored by Slack; "+
+			"messages will post under the app's identity",
+			"sender", sender)
+	})
+}
+
+// agentIconEmoji returns a stable emoji for an agent, chosen deterministically
+// from its name so the same agent always gets the same icon. This is only a
+// placeholder until real avatars land (see the follow-up note on Send).
+func agentIconEmoji(sender string) string {
+	if sender == "" {
+		return ":robot_face:"
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(sender))
+	// Modulo by an untyped constant keeps the index in uint32 space (no
+	// int↔uint32 conversion), which also guards against overflow.
+	return agentEmojiPalette[h.Sum32()%agentEmojiPaletteSize]
+}
+
+// agentEmojiPaletteSize must equal len(agentEmojiPalette); a test asserts it.
+const agentEmojiPaletteSize = 16
+
+// agentEmojiPalette is a small set of neutral, visually distinct emoji used to
+// give each agent a consistent icon. Standard Slack emoji names only.
+var agentEmojiPalette = []string{
+	":fox_face:", ":cat:", ":dog:", ":koala:", ":tiger:",
+	":panda_face:", ":owl:", ":frog:", ":hedgehog:", ":otter:",
+	":rabbit:", ":bear:", ":wolf:", ":unicorn_face:", ":dragon_face:",
+	":robot_face:",
 }
 
 // SendFile uploads a file to a Slack channel.

--- a/pkg/gateway/slack/slack_test.go
+++ b/pkg/gateway/slack/slack_test.go
@@ -1,0 +1,106 @@
+package slackgw
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/slack-go/slack"
+)
+
+// newTestAdapter wires an Adapter to a fake Slack API served by srv so we can
+// inspect the outbound chat.postMessage form without talking to Slack.
+func newTestAdapter(t *testing.T, srvURL string) *Adapter {
+	t.Helper()
+	a := New("xoxb-test", "xapp-test")
+	a.api = slack.New("xoxb-test",
+		slack.OptionAPIURL(srvURL+"/"),
+		slack.OptionOnResponseHeaders(a.observeScopes),
+	)
+	return a
+}
+
+// TestSendAttributesAgentUsername verifies the outbound payload carries the
+// sending agent's name as the Slack message username (agent attribution) and a
+// deterministic per-agent icon.
+func TestSendAttributesAgentUsername(t *testing.T) {
+	const agent = "zen-zebra"
+
+	var got url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Errorf("ParseForm: %v", err)
+		}
+		got = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C1","ts":"1.2"}`))
+	}))
+	defer srv.Close()
+
+	a := newTestAdapter(t, srv.URL)
+	if err := a.Send(context.Background(), "C1", agent, "hello world"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if u := got.Get("username"); u != agent {
+		t.Errorf("username = %q, want %q", u, agent)
+	}
+	if got.Get("text") != "hello world" {
+		t.Errorf("text = %q, want %q", got.Get("text"), "hello world")
+	}
+	if want := agentIconEmoji(agent); got.Get("icon_emoji") != want {
+		t.Errorf("icon_emoji = %q, want %q", got.Get("icon_emoji"), want)
+	}
+}
+
+func TestAgentIconEmojiDeterministic(t *testing.T) {
+	if a, b := agentIconEmoji("zen-zebra"), agentIconEmoji("zen-zebra"); a != b {
+		t.Errorf("agentIconEmoji not deterministic: %q vs %q", a, b)
+	}
+	// Empty sender falls back to the default icon.
+	if e := agentIconEmoji(""); e != ":robot_face:" {
+		t.Errorf("agentIconEmoji(\"\") = %q, want :robot_face:", e)
+	}
+	if len(agentEmojiPalette) != agentEmojiPaletteSize {
+		t.Fatalf("agentEmojiPaletteSize = %d, want len(palette) = %d",
+			agentEmojiPaletteSize, len(agentEmojiPalette))
+	}
+	// Every palette entry is a well-formed :emoji: token.
+	for _, e := range agentEmojiPalette {
+		if len(e) < 3 || e[0] != ':' || e[len(e)-1] != ':' {
+			t.Errorf("malformed palette emoji %q", e)
+		}
+	}
+}
+
+func TestObserveScopes(t *testing.T) {
+	tests := []struct {
+		name       string
+		header     string
+		wantSeen   bool
+		wantCustom bool
+	}{
+		{"missing header", "", false, false},
+		{"has customize", "chat:write, chat:write.customize, channels:read", true, true},
+		{"lacks customize", "chat:write, channels:read", true, false},
+		{"spacing tolerated", "chat:write.customize", true, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := New("xoxb-test", "xapp-test")
+			h := http.Header{}
+			if tc.header != "" {
+				h.Set("X-OAuth-Scopes", tc.header)
+			}
+			a.observeScopes("auth.test", h)
+			if a.scopesSeen.Load() != tc.wantSeen {
+				t.Errorf("scopesSeen = %v, want %v", a.scopesSeen.Load(), tc.wantSeen)
+			}
+			if a.customizeScope.Load() != tc.wantCustom {
+				t.Errorf("customizeScope = %v, want %v", a.customizeScope.Load(), tc.wantCustom)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of #2674

## What's done — name attribution
Outbound Slack messages now post **as the sending agent**, not the shared bot.

- `Send` sets the Slack `chat.postMessage` **`username`** to the agent name (the trusted `sender`/`agentName` that already threads through `Manager.Send` → the adapter). Kept **byte-identical** to the agent name so the inbound bot-impersonation self-skip in `handleMessageEvent` (`ev.Username == agent`) still matches — no round-trip regression.
- **Honest scope handling:** the `username`/icon override only takes effect if the bot token holds `chat:write.customize`. We learn the granted scopes from the `X-OAuth-Scopes` response header (`slack.OptionOnResponseHeaders`) and, if the scope is missing, log a **single** warning that attribution will be ignored by Slack — then still send.
- Each agent gets a **stable, deterministic** `icon_emoji` derived (FNV hash) from its name, replacing the static `:robot_face:`.

## Deferred — avatar
Showing the agent's real mushroom avatar needs a **publicly-reachable image URL**, which we don't have locally (it's part of the future mycel-cloud hosted assets). Not faked — marked with a `// follow-up:` comment on `Send` pointing at `MsgOptionIconURL` + the public-URL requirement. The deterministic emoji stands in for now.

## Test plan
- New `slack_test.go`:
  - `TestSendAttributesAgentUsername` — spins an `httptest` fake Slack API and asserts the outbound POST form carries `username = "zen-zebra"`, the right `text`, and the deterministic `icon_emoji`.
  - `TestObserveScopes` — table-driven: missing header, has/lacks `chat:write.customize`, spacing tolerance.
  - `TestAgentIconEmojiDeterministic` — determinism, empty-sender fallback, palette/size well-formedness.
- `go build ./pkg/...`, `go vet ./pkg/gateway/slack/...`, `golangci-lint run ./pkg/gateway/slack/...` (0 issues), `go test ./pkg/gateway/slack/...` (pass).
- Note: `go build ./...` fails only on a pre-existing `server/embed.go: web/dist` embed target (needs `make build-local-web`) — unrelated to this change; reproduced with the change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack messages now display a consistent emoji icon for each agent.
  * Agent names continue to appear as the message sender.
  * Messages use a safe fallback when no sender name is available.

* **Bug Fixes**
  * Added a one-time warning when Slack permissions do not support customized message appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->