### PR TITLE
feat(web): branded daemon boot sequence — mushroom draws in, readiness streams, mark rises into header

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useEffect, useState } from "react";
 import { BrowserRouter, Routes, Route, Link, Navigate, useParams } from "react-router-dom";
 import { Layout } from "./components/Layout";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { BootGate } from "./components/boot/BootGate";
 import { ThemeProvider } from "./context/ThemeContext";
 import { api } from "./api/client";
 
@@ -160,7 +161,9 @@ export function App() {
     <ErrorBoundary>
       <ThemeProvider>
         <BrowserRouter>
-          <AppRoutes />
+          <BootGate>
+            <AppRoutes />
+          </BootGate>
         </BrowserRouter>
       </ThemeProvider>
     </ErrorBoundary>

--- a/web/src/components/boot/BootGate.tsx
+++ b/web/src/components/boot/BootGate.tsx
@@ -1,0 +1,29 @@
+import { useState, type ReactNode } from "react";
+import { BootSplash, type SplashTimings } from "./BootSplash";
+
+/**
+ * BootGate — shows the branded {@link BootSplash} while the daemon boots,
+ * then reveals the app. Wrap the route tree with it: children stay
+ * unmounted (so no app-level API calls fire) until the splash hands off,
+ * at which point the router's current URL takes over — including the
+ * existing first-run gate (`HomeGate` → `/welcome`), which we deliberately
+ * do NOT duplicate here.
+ *
+ * `skip` bypasses the splash entirely (used by tests/embeds that don't
+ * want the sequence); `timings` lets tests collapse the phase durations.
+ */
+export function BootGate({
+  children,
+  skip = false,
+  timings,
+}: {
+  children: ReactNode;
+  skip?: boolean;
+  timings?: SplashTimings;
+}) {
+  const [ready, setReady] = useState(skip);
+  if (!ready) {
+    return <BootSplash onReady={() => setReady(true)} timings={timings} />;
+  }
+  return <>{children}</>;
+}

--- a/web/src/components/boot/BootMark.tsx
+++ b/web/src/components/boot/BootMark.tsx
@@ -1,0 +1,64 @@
+/**
+ * BootMark — the boot sequence's mushroom mark.
+ *
+ * Same silhouette and geometry as {@link BrandMark} (the drawer/header
+ * logo), so the rise-into-header hand-off reads as one continuous element.
+ * The difference is purely presentational: each part carries a `boot-*`
+ * class that boot.css uses to draw the mark in — hyphae trace, cap + stem
+ * grow up from the stem base, spores pop — all disabled under
+ * `prefers-reduced-motion`, where the mark just appears.
+ */
+
+export function BootMark() {
+  return (
+    <svg viewBox="0 0 512 512" fill="none" aria-hidden="true">
+      {/* Hyphae threads reaching down from the stem */}
+      <g
+        className="boot-hyphae"
+        stroke="var(--mycel-accent)"
+        strokeWidth="34"
+        strokeLinecap="round"
+        fill="none"
+        opacity="0.7"
+      >
+        <path d="M256 400 C 235 429 200 436 165 451" />
+        <path d="M256 400 C 260 435 280 445 305 459" />
+        <path d="M256 400 C 280 423 320 426 353 442" />
+      </g>
+
+      {/* Stem */}
+      <path
+        className="boot-stem"
+        d="M224 294 L288 294 L280 382 C 278 403 267 412 256 412 C 245 412 234 403 232 382 Z"
+        fill="currentColor"
+        opacity="0.8"
+      />
+
+      {/* Cap */}
+      <path
+        className="boot-cap"
+        d="M99 264
+           C 99 165 168 109 256 109
+           C 344 109 413 165 413 264
+           C 413 286 390 294 358 294
+           L 154 294
+           C 122 294 99 286 99 264 Z"
+        fill="currentColor"
+      />
+
+      {/* Spore speckles on the cap — chanterelle amber */}
+      <g fill="var(--mycel-accent)" opacity="0.95">
+        <circle className="boot-spore" cx="190" cy="200" r="30" />
+        <circle className="boot-spore" cx="280" cy="162" r="25" />
+        <circle className="boot-spore" cx="338" cy="230" r="21" />
+      </g>
+
+      {/* Drifting spores */}
+      <g fill="var(--mycel-accent)">
+        <circle className="boot-spore" cx="103" cy="373" r="20" />
+        <circle className="boot-spore" cx="412" cy="378" r="20" />
+        <circle className="boot-spore" cx="434" cy="330" r="13" opacity="0.75" />
+      </g>
+    </svg>
+  );
+}

--- a/web/src/components/boot/BootSplash.tsx
+++ b/web/src/components/boot/BootSplash.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useRef, useState } from "react";
+import { prefersReducedMotion } from "../agent-ui/useAgentPulse";
+import { BootMark } from "./BootMark";
+import {
+  useBootSequence,
+  type BootTimings,
+  DEFAULT_BOOT_TIMINGS,
+} from "./useBootSequence";
+import "./boot.css";
+
+/**
+ * BootSplash — the full-screen branded boot sequence.
+ *
+ * A four-phase machine:
+ *   draw   — the mushroom mark draws itself in, centred and full-screen;
+ *   stream — real server-readiness lines stream in below it (see
+ *            {@link useBootSequence}); held for a minimum so the console is
+ *            legible even when the daemon is already up;
+ *   rise   — once the daemon is healthy AND the minimum is met, the mark
+ *            travels up into the header brand position (shared-element);
+ *   fade   — the splash fades out and {@link onReady} hands off to the app.
+ *
+ * `prefers-reduced-motion` collapses the drawing/travel to plain opacity
+ * (via boot.css) and zeroes the motion timers here, so the sequence still
+ * runs — just without animation.
+ */
+
+export interface SplashTimings {
+  /** How long the mark draws in before the console appears. */
+  drawMs: number;
+  /** Minimum time the readiness console stays up before the rise. */
+  minStreamMs: number;
+  /** Duration of the rise-into-header travel. */
+  riseMs: number;
+  /** Fade-out before hand-off. */
+  fadeMs: number;
+  boot: BootTimings;
+}
+
+export const DEFAULT_SPLASH_TIMINGS: SplashTimings = {
+  drawMs: 850,
+  minStreamMs: 650,
+  riseMs: 720,
+  fadeMs: 480,
+  boot: DEFAULT_BOOT_TIMINGS,
+};
+
+type Phase = "draw" | "stream" | "rise" | "fade";
+
+export function BootSplash({
+  onReady,
+  timings = DEFAULT_SPLASH_TIMINGS,
+}: {
+  onReady: () => void;
+  timings?: SplashTimings;
+}) {
+  const reduce = prefersReducedMotion();
+  const drawMs = reduce ? 0 : timings.drawMs;
+  const riseMs = reduce ? 0 : timings.riseMs;
+  const fadeMs = reduce ? 60 : timings.fadeMs;
+
+  const { healthy, lines } = useBootSequence(timings.boot);
+  const [phase, setPhase] = useState<Phase>("draw");
+  const [minReached, setMinReached] = useState(false);
+  const onReadyRef = useRef(onReady);
+  onReadyRef.current = onReady;
+
+  // draw → stream, and arm the minimum-stream gate.
+  useEffect(() => {
+    const toStream = setTimeout(() => setPhase("stream"), drawMs);
+    const minGate = setTimeout(() => setMinReached(true), drawMs + timings.minStreamMs);
+    return () => {
+      clearTimeout(toStream);
+      clearTimeout(minGate);
+    };
+  }, [drawMs, timings.minStreamMs]);
+
+  // stream → rise, once the daemon is healthy and the minimum is met.
+  // (Split from the rise-duration timer below: mutating `phase` here while
+  // also holding the fade timer would clear that timer before it fired.)
+  useEffect(() => {
+    if (phase === "stream" && healthy && minReached) setPhase("rise");
+  }, [phase, healthy, minReached]);
+
+  // rise → fade after the travel completes.
+  useEffect(() => {
+    if (phase !== "rise") return;
+    const toFade = setTimeout(() => setPhase("fade"), riseMs);
+    return () => clearTimeout(toFade);
+  }, [phase, riseMs]);
+
+  // fade → hand off to the app.
+  useEffect(() => {
+    if (phase !== "fade") return;
+    const done = setTimeout(() => onReadyRef.current(), fadeMs);
+    return () => clearTimeout(done);
+  }, [phase, fadeMs]);
+
+  const rising = phase === "rise" || phase === "fade";
+  const consoleHidden = rising;
+
+  return (
+    <div
+      className="boot-splash"
+      data-fading={phase === "fade"}
+      role="status"
+      aria-live="polite"
+      aria-label="Starting mycel"
+    >
+      <div className="boot-mark" data-rising={rising}>
+        <BootMark />
+      </div>
+
+      <div className="boot-wordmark font-display" data-hidden={consoleHidden}>
+        mycel
+      </div>
+
+      <div className="boot-stream" data-hidden={consoleHidden} data-testid="boot-stream">
+        {/* column-reverse: render newest first so it pins to the bottom
+            and older lines scroll up out of the mask. */}
+        {[...lines].reverse().map((line) => (
+          <div className="boot-line" key={line.id}>
+            <span className="boot-line-status" data-s={line.status} aria-hidden="true" />
+            <span className="boot-line-label">{line.label}</span>
+            {line.detail && <span className="boot-line-detail">{line.detail}</span>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/boot/__tests__/BootGate.test.tsx
+++ b/web/src/components/boot/__tests__/BootGate.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useEffect, useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BootGate } from "../BootGate";
+import type { SplashTimings } from "../BootSplash";
+import { api } from "../../../api/client";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return Promise.resolve({
+    ok,
+    status,
+    statusText: ok ? "OK" : "ERR",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+// Collapse every phase so the sequence completes near-instantly in tests.
+const FAST: SplashTimings = {
+  drawMs: 0,
+  minStreamMs: 0,
+  riseMs: 0,
+  fadeMs: 0,
+  boot: { pollMs: 5, paceMs: 0 },
+};
+
+/** Mirrors App.tsx's HomeGate: probe onboarding, redirect fresh installs. */
+function GateProbe() {
+  const [toWelcome, setToWelcome] = useState(false);
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getOnboardingState()
+      .then((s) => {
+        if (!cancelled && s.firstRun) setToWelcome(true);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return toWelcome ? <Navigate to="/welcome" replace /> : <div data-testid="home">home</div>;
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("BootGate", () => {
+  it("shows the splash, then hands off to the app once the daemon is healthy", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/health")) return jsonResponse({ status: "ok" });
+      if (u.includes("/api/doctor")) return jsonResponse({ categories: [] });
+      if (u.includes("/api/logs")) return jsonResponse([]);
+      return jsonResponse([]);
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <BootGate timings={FAST}>
+          <div data-testid="app">the app</div>
+        </BootGate>
+      </MemoryRouter>,
+    );
+
+    // Splash renders first.
+    expect(screen.getByLabelText("Starting mycel")).toBeInTheDocument();
+
+    // Then hands off to the wrapped app.
+    await waitFor(() => expect(screen.getByTestId("app")).toBeInTheDocument());
+  });
+
+  it("streams REAL readiness lines derived from /api/doctor (no fake logs)", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/health")) return jsonResponse({ status: "ok" });
+      if (u.includes("/api/doctor"))
+        return jsonResponse({
+          categories: [
+            { name: "Tools", items: [{ name: "git", message: "git 2.44", severity: "ok" }] },
+          ],
+        });
+      if (u.includes("/api/logs")) return jsonResponse([]);
+      return jsonResponse([]);
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        {/* Slow rise so the console is still visible when we assert. */}
+        <BootGate timings={{ ...FAST, minStreamMs: 50, riseMs: 300 }}>
+          <div data-testid="app">the app</div>
+        </BootGate>
+      </MemoryRouter>,
+    );
+
+    // The real git readiness line (label "git", detail "git 2.44") streams in.
+    await waitFor(() => expect(screen.getByText("git 2.44")).toBeInTheDocument());
+    expect(screen.getByText("daemon online")).toBeInTheDocument();
+  });
+
+  it("first-run hand-off lands on /welcome via the existing HomeGate", async () => {
+    // The boot splash does not itself route; the app's HomeGate reads
+    // /api/onboarding/state and redirects a fresh install to /welcome.
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/onboarding/state"))
+        return jsonResponse({
+          firstRun: true,
+          hasAgents: false,
+          prefsValid: false,
+          completed: [],
+          step: "",
+        });
+      if (u.includes("/api/health")) return jsonResponse({ status: "ok" });
+      if (u.includes("/api/doctor")) return jsonResponse({ categories: [] });
+      if (u.includes("/api/logs")) return jsonResponse([]);
+      return jsonResponse([]);
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <BootGate timings={FAST}>
+          <Routes>
+            <Route index element={<GateProbe />} />
+            <Route path="welcome" element={<div data-testid="welcome">welcome wizard</div>} />
+          </Routes>
+        </BootGate>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("welcome")).toBeInTheDocument());
+  });
+});

--- a/web/src/components/boot/boot.css
+++ b/web/src/components/boot/boot.css
@@ -1,0 +1,223 @@
+/*
+ * boot.css — the branded boot sequence.
+ *
+ * The mushroom mark draws itself in (hyphae strokes trace, cap + stem
+ * grow up from the stem base, spores pop), server-readiness lines stream
+ * in below, then the whole mark rises into the header brand position and
+ * the splash fades to reveal the app.
+ *
+ * Every animation is gated by `@media (prefers-reduced-motion: reduce)`:
+ * in that mode the mark simply appears at full opacity and the stream +
+ * fade still run (with motion reduced to opacity), so the sequence stays
+ * legible without any drawing/scaling/sliding.
+ */
+
+/* ── Full-screen scaffold ─────────────────────────────────────────────── */
+
+.boot-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1.75rem;
+  background: var(--mycel-bg);
+  color: var(--mycel-text);
+  /* Warm radial wash so the espresso ground isn't flat. */
+  background-image: radial-gradient(
+    120% 90% at 50% 38%,
+    color-mix(in srgb, var(--mycel-accent) 8%, transparent),
+    transparent 60%
+  );
+  transition: opacity 480ms ease;
+}
+
+.boot-splash[data-fading="true"] {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* ── The mark: hero → header shared-element rise ──────────────────────── */
+
+.boot-mark {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--mycel-text);
+  /* Hero: dead-centre of the viewport. The wrapper is `fixed` so the same
+     element can travel to the header corner without a layout reflow. */
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: 120px;
+  height: 120px;
+  transform: translate(-50%, -50%);
+  transition:
+    top 720ms cubic-bezier(0.22, 1, 0.36, 1),
+    left 720ms cubic-bezier(0.22, 1, 0.36, 1),
+    width 720ms cubic-bezier(0.22, 1, 0.36, 1),
+    height 720ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Header target — matches Layout's brand column: 20px mark, ~16px left
+   padding, centred in the 48px header row. The offsets place the mark's
+   centre where the real BrandMark sits, so the hand-off reads as one
+   continuous element. */
+.boot-mark[data-rising="true"] {
+  top: 24px;
+  left: 26px;
+  width: 20px;
+  height: 20px;
+}
+
+.boot-mark svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Draw-in of the mark parts ────────────────────────────────────────── */
+
+/* Hyphae threads trace themselves via stroke-dashoffset. */
+.boot-hyphae path {
+  stroke-dasharray: 200;
+  stroke-dashoffset: 200;
+  animation: boot-trace 620ms ease forwards;
+}
+.boot-hyphae path:nth-child(1) { animation-delay: 340ms; }
+.boot-hyphae path:nth-child(2) { animation-delay: 440ms; }
+.boot-hyphae path:nth-child(3) { animation-delay: 540ms; }
+
+@keyframes boot-trace {
+  to { stroke-dashoffset: 0; }
+}
+
+/* Cap + stem grow up from the rooted stem base. */
+.boot-cap,
+.boot-stem {
+  transform-box: fill-box;
+  transform-origin: 50% 100%;
+  animation: boot-grow 560ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+  opacity: 0;
+}
+.boot-stem { animation-delay: 60ms; }
+.boot-cap { animation-delay: 140ms; }
+
+@keyframes boot-grow {
+  from { transform: scaleY(0.15); opacity: 0; }
+  60%  { opacity: 1; }
+  to   { transform: scaleY(1); opacity: 1; }
+}
+
+/* Spores pop in once the cap has settled. */
+.boot-spore {
+  transform-box: fill-box;
+  transform-origin: center;
+  transform: scale(0);
+  opacity: 0;
+  animation: boot-pop 380ms cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+}
+.boot-spore:nth-child(1) { animation-delay: 420ms; }
+.boot-spore:nth-child(2) { animation-delay: 500ms; }
+.boot-spore:nth-child(3) { animation-delay: 560ms; }
+.boot-spore:nth-child(4) { animation-delay: 620ms; }
+.boot-spore:nth-child(5) { animation-delay: 680ms; }
+.boot-spore:nth-child(6) { animation-delay: 740ms; }
+
+@keyframes boot-pop {
+  to { transform: scale(1); opacity: 1; }
+}
+
+/* ── Streaming server-readiness console ───────────────────────────────── */
+
+.boot-stream {
+  position: fixed;
+  top: calc(50% + 96px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(560px, 88vw);
+  max-height: 34vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column-reverse; /* newest pinned to bottom, older scroll up */
+  gap: 0.25rem;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--mycel-text-2);
+  transition: opacity 320ms ease;
+  -webkit-mask-image: linear-gradient(to bottom, transparent, #000 24%);
+  mask-image: linear-gradient(to bottom, transparent, #000 24%);
+}
+
+.boot-stream[data-hidden="true"] {
+  opacity: 0;
+}
+
+.boot-line {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  animation: boot-line-in 260ms ease both;
+}
+
+@keyframes boot-line-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.boot-line-status {
+  flex-shrink: 0;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  align-self: center;
+}
+.boot-line-status[data-s="ok"] { background: var(--mycel-success, #7c9c5a); }
+.boot-line-status[data-s="warn"] { background: var(--mycel-accent); }
+.boot-line-status[data-s="fail"] { background: var(--mycel-danger, #c4622d); }
+.boot-line-status[data-s="info"] {
+  background: color-mix(in srgb, var(--mycel-text-2) 60%, transparent);
+}
+
+.boot-line-label { color: var(--mycel-text); }
+.boot-line-detail { color: var(--mycel-text-2); overflow: hidden; text-overflow: ellipsis; }
+
+.boot-wordmark {
+  position: fixed;
+  top: calc(50% + 60px);
+  left: 50%;
+  transform: translateX(-50%);
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: 0.04em;
+  color: var(--mycel-text);
+  transition: opacity 300ms ease;
+}
+.boot-wordmark[data-hidden="true"] { opacity: 0; }
+
+/* ── Reduced motion ───────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .boot-mark {
+    transition: opacity 300ms ease;
+  }
+  .boot-hyphae path {
+    stroke-dashoffset: 0;
+    animation: none;
+  }
+  .boot-cap,
+  .boot-stem,
+  .boot-spore {
+    opacity: 1;
+    transform: none;
+    animation: none;
+  }
+  .boot-line {
+    animation: none;
+  }
+}

--- a/web/src/components/boot/useBootSequence.ts
+++ b/web/src/components/boot/useBootSequence.ts
@@ -1,0 +1,160 @@
+import { useEffect, useRef, useState } from "react";
+import { api, type DoctorReport, type HealthReport } from "../../api/client";
+import { deriveReadiness } from "../../views/readiness/readiness";
+
+/* ── Boot stream model ────────────────────────────────────────────────
+ *
+ * The boot console shows REAL daemon state, never invented log lines:
+ *   1. a "connecting" line while /api/health is still refused;
+ *   2. "daemon online" the moment the health probe first answers;
+ *   3. one line per readiness check derived from /api/doctor + /api/health
+ *      (runtime, git, each agent CLI) — the same model the Readiness page
+ *      renders, so every status/detail is a live machine fact;
+ *   4. any recent daemon event-log entries (/api/logs) appended verbatim.
+ *
+ * The daemon has no dedicated startup-log SSE stream, so the readiness
+ * probe results ARE the boot content — which is the honest signal a boot
+ * splash exists to convey ("is the machine ready to run agents yet?").
+ */
+
+export type BootStatus = "ok" | "warn" | "fail" | "info";
+
+export interface BootLine {
+  id: number;
+  status: BootStatus;
+  label: string;
+  detail?: string;
+}
+
+export interface BootSequence {
+  /** True once /api/health has answered — the app can be handed off. */
+  healthy: boolean;
+  /** Newest-last stream of real readiness/log lines. */
+  lines: BootLine[];
+}
+
+export interface BootTimings {
+  /** Delay between health probes while the daemon is still booting. */
+  pollMs: number;
+  /** Stagger between appended readiness lines, for the streaming cascade. */
+  paceMs: number;
+}
+
+export const DEFAULT_BOOT_TIMINGS: BootTimings = { pollMs: 500, paceMs: 130 };
+
+function rStatusToBoot(s: "ok" | "warn" | "fail"): BootStatus {
+  return s;
+}
+
+/**
+ * useBootSequence — polls the daemon to readiness and streams real status
+ * lines. Returns `healthy` (flips true on the first successful health
+ * probe) plus the growing `lines` array. Self-contained and idempotent:
+ * every probe/timer is torn down on unmount.
+ */
+export function useBootSequence(
+  timings: BootTimings = DEFAULT_BOOT_TIMINGS,
+): BootSequence {
+  const [healthy, setHealthy] = useState(false);
+  const [lines, setLines] = useState<BootLine[]>([]);
+  const idRef = useRef(0);
+  // Guards so React 18 StrictMode's double-invoke doesn't double-stream.
+  const readyHandled = useRef(false);
+  const startedWaiting = useRef(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    const push = (line: Omit<BootLine, "id">) => {
+      if (cancelled) return;
+      setLines((prev) => [...prev, { id: idRef.current++, ...line }]);
+    };
+
+    // A paced cascade so a fast, already-up daemon still reads as a
+    // sequence rather than a single flash of every line at once.
+    const pushPaced = (items: Omit<BootLine, "id">[], base: number) => {
+      items.forEach((line, i) => {
+        timers.push(setTimeout(() => push(line), base + i * timings.paceMs));
+      });
+    };
+
+    if (!startedWaiting.current) {
+      startedWaiting.current = true;
+      push({ status: "info", label: "connecting to the mycel daemon" });
+    }
+
+    async function onReady() {
+      if (readyHandled.current) return;
+      readyHandled.current = true;
+      if (cancelled) return;
+      setHealthy(true);
+      push({ status: "ok", label: "daemon online", detail: "http responding" });
+
+      // Derive the real readiness model and stream it line by line.
+      const [report, health] = await Promise.all([
+        api.getDoctor().catch(() => null) as Promise<DoctorReport | null>,
+        api.getHealth().catch(() => null) as Promise<HealthReport | null>,
+      ]);
+      if (cancelled) return;
+
+      const readinessLines: Omit<BootLine, "id">[] = [];
+      if (report) {
+        const r = deriveReadiness(report, health);
+        for (const group of r.groups) {
+          for (const item of group.items) {
+            readinessLines.push({
+              status: rStatusToBoot(item.status),
+              label: item.label,
+              detail: item.detail,
+            });
+          }
+        }
+      }
+      readinessLines.push({
+        status: health?.status === "degraded" ? "warn" : "ok",
+        label: "readiness",
+        detail:
+          health?.status === "degraded"
+            ? Object.values(health.degraded ?? {})[0] ?? "running degraded"
+            : "all systems go",
+      });
+      pushPaced(readinessLines, timings.paceMs);
+
+      // Append any real recent daemon events verbatim, after the checks.
+      const logs = await api.getLogs(8).catch(() => []);
+      if (cancelled || logs.length === 0) return;
+      pushPaced(
+        logs.map((l) => ({
+          status: "info" as BootStatus,
+          label: l.type || "event",
+          detail: l.message,
+        })),
+        readinessLines.length * timings.paceMs + timings.paceMs,
+      );
+    }
+
+    async function poll() {
+      if (cancelled || readyHandled.current) return;
+      try {
+        await api.getHealth();
+        await onReady();
+      } catch {
+        // Daemon not up yet — probe again shortly.
+        if (!cancelled) timers.push(setTimeout(() => void poll(), timings.pollMs));
+      }
+    }
+
+    void poll();
+
+    return () => {
+      cancelled = true;
+      for (const t of timers) clearTimeout(t);
+    };
+    // Timings are stable module constants in practice; re-running on a new
+    // object would restart the probe needlessly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { healthy, lines };
+}


### PR DESCRIPTION
Part of #2674 (issue #50 — the boot experience the owner described).

## What this does
A full-screen branded boot sequence shown while the daemon is booting, in **both** the web UI and the desktop app (which loads the same embedded UI). Four phases:

1. **Draw-in** — the mushroom mark (identical geometry to the existing `BrandMark`) draws itself in, centred and full-screen: hyphae threads trace via `stroke-dashoffset`, cap + stem grow up from the stem base, spores pop. Fully gated by `prefers-reduced-motion` (mark just appears; stream + fade still run).
2. **Stream** — real server-readiness lines stream in below the mark and scroll up: `connecting to the mycel daemon` → `daemon online` → one line per readiness check derived from `/api/doctor` + `/api/health` via the existing `deriveReadiness` model (runtime/tmux/Docker, git, each agent CLI, degraded reasons). Recent `/api/logs` events are appended verbatim when present.
3. **Rise** — once the daemon is healthy the mark travels up into the header brand position (shared-element style, matching Layout's 20px mark at the drawer's left padding).
4. **Fade / hand-off** — the splash fades and hands off to the app.

First-run routing is **not duplicated**: `BootGate` hands off to the normal router, and the existing `HomeGate` reads `/api/onboarding/state` and redirects a fresh / no-agents / invalid `~/.mycel` to `/welcome`.

## What's real vs seamed
- **Real**: health probe (`/api/health`), the readiness lines (live `/api/doctor` machine facts), first-run detection (`/api/onboarding/state`), and any `/api/logs` events — all live daemon data.
- **Seam**: the daemon exposes no dedicated *startup-log SSE stream*, so the readiness-probe results **are** the streamed boot content (exactly the fallback the issue calls for: "show the readiness/health probe steps as the streaming content rather than faking logs"). No invented log lines anywhere.
- **Desktop**: `desktop/bootpage.go` (the Wails pre-webview holding screen that waits for `/api/health` then loads the real UI) is left unchanged — it shares the same mushroom + espresso palette, so it flows straight into this React splash. No Go/desktop code was touched.

## Files
- `web/src/components/boot/BootMark.tsx` — animated mushroom (BrandMark geometry + draw-in hooks)
- `web/src/components/boot/boot.css` — keyframes, the hero→header rise, reduced-motion overrides
- `web/src/components/boot/useBootSequence.ts` — health polling + real readiness/log stream
- `web/src/components/boot/BootSplash.tsx` — the phase machine (draw→stream→rise→fade)
- `web/src/components/boot/BootGate.tsx` — gates the route tree until healthy
- `web/src/App.tsx` — wraps `AppRoutes` in `BootGate`
- `web/src/components/boot/__tests__/BootGate.test.tsx` — new tests

## Test plan
- `bunx tsc --noEmit` — clean
- `bun run lint` — clean
- `bun run build` — clean
- `bunx vitest run` — **309 passed** (3 new: splash→app hand-off, real-readiness stream / no fake logs, first-run→/welcome)
- Live: built `bin/mycel` (embeds web), ran on a throwaway `MYCEL_HOME` at `127.0.0.1:8099`, loaded the UI in a browser — confirmed the splash renders the mushroom SVG + `mycel` wordmark + real streamed lines (`connecting…` → `daemon online / http responding`), then hands off and routes a fresh home to `/welcome`. Torn down.

## Design
ui-ux-pro-max motion guidance applied: kept the sequence short (<~2.7s), reveal easing `power1`/spring, `stroke-dashoffset` trace over opacity pulsing, timers explicitly cleared on unmount to avoid orphaned loops. Coffee-cream/mushroom identity kept, theme-aware (currentColor ink + chanterelle-amber accent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)