### PR TITLE
fix(agent): persist lifecycle events so new agents have a timeline

### DIFF
--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rpuneet/mycel/pkg/events"
 	"github.com/rpuneet/mycel/pkg/log"
 	"github.com/rpuneet/mycel/pkg/names"
 )
@@ -478,6 +479,26 @@ func (s *AgentService) publishEvent(eventType string, data map[string]any) {
 	if s.events != nil {
 		s.events.Publish(eventType, data)
 	}
+	// Persist agent lifecycle events so every agent has an activity
+	// timeline from birth — hook-less providers (cursor, agy, pi) would
+	// otherwise show an empty Live section forever (#37). Hook events
+	// persist separately in IngestHookEvent.
+	if s.hookStore == nil {
+		return
+	}
+	agentName, _ := data["name"].(string)
+	if agentName == "" {
+		agentName, _ = data["agent"].(string)
+	}
+	if agentName == "" {
+		return
+	}
+	_ = s.hookStore.Append(events.Event{ //nolint:errcheck // best-effort logging
+		Timestamp: time.Now().UTC(),
+		Type:      events.EventType(eventType),
+		Agent:     agentName,
+		Data:      data,
+	})
 }
 
 // SyncSessions reconciles in-memory agent state with actual runtime sessions.

--- a/pkg/agent/service_events_test.go
+++ b/pkg/agent/service_events_test.go
@@ -1,0 +1,45 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/events"
+)
+
+// appendRecorder captures events persisted through the HookEventAppender.
+type appendRecorder struct {
+	evts []events.Event
+}
+
+func (r *appendRecorder) Append(e events.Event) error {
+	r.evts = append(r.evts, e)
+	return nil
+}
+
+// TestPublishEventPersistsLifecycle locks the #37 fix: lifecycle events
+// must land in the event store keyed by agent, so hook-less providers
+// (cursor, agy, pi) still get an activity timeline from birth.
+func TestPublishEventPersistsLifecycle(t *testing.T) {
+	rec := &appendRecorder{}
+	svc := &AgentService{hookStore: rec}
+
+	svc.publishEvent("agent.created", map[string]any{"name": "keen-lemur", "tool": "cursor"})
+	svc.publishEvent("agent.state_changed", map[string]any{"name": "keen-lemur", "state": "idle"})
+	// No agent name — must not persist a row with an empty agent key.
+	svc.publishEvent("agents.stopped_all", map[string]any{"count": 3})
+
+	if len(rec.evts) != 2 {
+		t.Fatalf("persisted %d events, want 2", len(rec.evts))
+	}
+	for _, e := range rec.evts {
+		if e.Agent != "keen-lemur" {
+			t.Errorf("event %s agent = %q, want keen-lemur", e.Type, e.Agent)
+		}
+		if e.Timestamp.IsZero() {
+			t.Errorf("event %s has zero timestamp", e.Type)
+		}
+	}
+	if rec.evts[0].Type != "agent.created" || rec.evts[1].Type != "agent.state_changed" {
+		t.Errorf("types = %s, %s", rec.evts[0].Type, rec.evts[1].Type)
+	}
+}


### PR DESCRIPTION
Fixes the permanently empty Live/activity section for agents on hook-less providers (cursor, agy, pi) — the keen-lemur case (board item #37).

**Root cause**: lifecycle events (`agent.created`/`started`/`state_changed`) only reached the SSE stream and the JSONL log. The events DB — which feeds `/api/agents/{name}/activity` and the Live hydration endpoint — was populated exclusively by claude hook ingestion, so any agent that never emits hooks had zero rows forever.

**Fix**: `publishEvent` now also appends agent-keyed events to the store (same best-effort semantics as hook ingestion; events without an agent name, e.g. `agents.stopped_all`, are not persisted per-agent). Hook events keep their separate path.

**Tests**: new `TestPublishEventPersistsLifecycle` locks the behavior (persists with agent key + timestamp; skips agent-less events). `go test ./pkg/agent/` green, `golangci-lint` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related
Part of #2674 (Q2 roadmap — Live/activity reliability; board item #37)

## Test plan
- `go test ./pkg/agent/` — green (new `TestPublishEventPersistsLifecycle`)
- `golangci-lint` — 0 issues
- `go build ./...` — clean