### PR TITLE
fix(web): agent Metrics 'By model' panel reads real per-model costs

### DIFF
--- a/pkg/cost/agent_models_test.go
+++ b/pkg/cost/agent_models_test.go
@@ -1,0 +1,37 @@
+package cost
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestAgentModelSummaryFiltersByAgent locks the /api/costs/models?agent=
+// path: only the requested cost-agent's entries aggregate, grouped by model.
+func TestAgentModelSummaryFiltersByAgent(t *testing.T) {
+	svc, _ := newStubService(sampleEntries(), nil)
+
+	sums, err := svc.GetAgentModelSummarySince(context.Background(), "a1", time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(sums) != 2 {
+		t.Fatalf("got %d model rows for a1, want 2", len(sums))
+	}
+	if sums[0].Model != "m2" || sums[0].TotalCostUSD != 2.0 {
+		t.Errorf("top row = %s $%.2f, want m2 $2.00", sums[0].Model, sums[0].TotalCostUSD)
+	}
+	if sums[1].Model != "m1" || sums[1].TotalCostUSD != 1.0 {
+		t.Errorf("second row = %s $%.2f, want m1 $1.00", sums[1].Model, sums[1].TotalCostUSD)
+	}
+
+	all, err := svc.GetAgentModelSummarySince(context.Background(), "", time.Time{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range all {
+		if s.Model == "m1" && s.TotalCostUSD != 5.5 {
+			t.Errorf("unfiltered m1 cost = %.2f, want 5.5", s.TotalCostUSD)
+		}
+	}
+}

--- a/pkg/cost/service.go
+++ b/pkg/cost/service.go
@@ -213,8 +213,40 @@ func (s *Service) SummaryByModel(ctx context.Context) ([]*Summary, error) {
 
 // GetModelSummarySince returns per-model summaries since the given time.
 func (s *Service) GetModelSummarySince(ctx context.Context, since time.Time) ([]*Summary, error) {
-	return s.groupedSummaries(ctx, since, func(e provider.CostEntry) string { return e.Model },
-		func(sum *Summary, key string) { sum.Model = key })
+	return s.GetAgentModelSummarySince(ctx, "", since)
+}
+
+// GetAgentModelSummarySince returns per-model summaries since the given
+// time, restricted to one cost agent id when agentID is non-empty. The id
+// is the recorded session id (plain agent name on fresh installs, a
+// legacy-prefixed id otherwise) — callers resolve it from the per-agent
+// listing, mirroring the web's alias handling.
+func (s *Service) GetAgentModelSummarySince(ctx context.Context, agentID string, since time.Time) ([]*Summary, error) {
+	entries, err := s.Entries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	byKey := map[string]*Summary{}
+	for _, e := range entries {
+		if agentID != "" && e.Agent != agentID {
+			continue
+		}
+		if !since.IsZero() && e.Timestamp.Before(since) {
+			continue
+		}
+		sum, ok := byKey[e.Model]
+		if !ok {
+			sum = &Summary{Model: e.Model}
+			byKey[e.Model] = sum
+		}
+		addEntry(sum, e)
+	}
+	out := make([]*Summary, 0, len(byKey))
+	for _, sum := range byKey {
+		out = append(out, sum)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TotalCostUSD > out[j].TotalCostUSD })
+	return out, nil
 }
 
 // SummaryByTeam returns aggregated costs per team. Provider session

--- a/server/handlers/costs.go
+++ b/server/handlers/costs.go
@@ -85,7 +85,9 @@ func (h *CostHandler) byResource(w http.ResponseWriter, r *http.Request) {
 		})
 
 	case "models":
-		h.summaries(w, r, h.svc.GetModelSummarySince)
+		h.summaries(w, r, func(ctx context.Context, since time.Time) ([]*cost.Summary, error) {
+			return h.svc.GetAgentModelSummarySince(ctx, r.URL.Query().Get("agent"), since)
+		})
 
 	case "daily":
 		h.daily(w, r)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1069,8 +1069,11 @@ export const api = {
       ...(opts.since ? { since: opts.since } : {}),
       ...(opts.limit ? { limit: String(opts.limit) } : {}),
     })}`),
-  getCostByModel: (opts: { since?: string } = {}) =>
-    request<ModelCostSummary[]>(`/costs/models${qs(opts.since ? { since: opts.since } : {})}`),
+  getCostByModel: (opts: { since?: string; agent?: string } = {}) =>
+    request<ModelCostSummary[]>(`/costs/models${qs({
+      ...(opts.since ? { since: opts.since } : {}),
+      ...(opts.agent ? { agent: opts.agent } : {}),
+    })}`),
   getCostDaily: (days = 14) =>
     request<DailyCost[]>(`/costs/daily?days=${days}`),
   // Per-entity drill-down: lifetime summary + last-30d daily ledger for

--- a/web/src/components/StatsTab.tsx
+++ b/web/src/components/StatsTab.tsx
@@ -4,7 +4,7 @@ import {
   XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
 } from "recharts";
 import { api } from "../api/client";
-import type { Agent, AgentStatsSummary, AgentMetricTS, ComputedStats, AgentCostDetail, AgentCostSummary } from "../api/client";
+import type { Agent, AgentStatsSummary, AgentMetricTS, ComputedStats, AgentCostDetail, AgentCostSummary, ModelCostSummary } from "../api/client";
 import { stripAgentPrefix } from "../views/insights/chrome";
 import { usePolling } from "../hooks/usePolling";
 import { Panel, fmtTime, fmtBytes, fmtTokens } from "./shared/stats-primitives";
@@ -86,6 +86,7 @@ interface TabData {
   net: AgentMetricTS[];
   cost: AgentCostDetail | null;
   costSummary: AgentCostSummary | null;
+  models: ModelCostSummary[];
 }
 
 // ── Component ────────────────────────────────────────────────────────────────────
@@ -109,13 +110,14 @@ export function StatsTab({ agent }: { agent: Agent }) {
     );
     const costId = costRow?.agent_id ?? agent.name;
 
-    const [r0, r1, r2, r3, r4, r5] = await Promise.allSettled([
+    const [r0, r1, r2, r3, r4, r5, r6] = await Promise.allSettled([
       api.getAgentStatsSummary(agent.name, { from }),
       api.getAgentStats("cpu", p),
       api.getAgentStats("mem", p),
       api.getAgentStats("net", p),
       api.getAgentComputedStats(agent.name),
       api.getCostAgentDetail(costId),
+      api.getCostByModel({ agent: costId }),
     ]);
     return {
       summary: r0.status === "fulfilled" ? r0.value : null,
@@ -125,6 +127,7 @@ export function StatsTab({ agent }: { agent: Agent }) {
       computed: r4.status === "fulfilled" ? r4.value : null,
       cost: r5.status === "fulfilled" ? r5.value : null,
       costSummary: costRow ?? null,
+      models: r6.status === "fulfilled" ? (r6.value ?? []) : [],
     };
   }, [agent.name, from]);
 
@@ -191,10 +194,13 @@ export function StatsTab({ agent }: { agent: Agent }) {
     [data?.cost],
   );
 
-  // Per-agent model breakdown, most expensive first.
+  // Per-agent model breakdown from the cost engine (the stats summary
+  // never carries models), most expensive first.
   const models = useMemo(() =>
-    [...(s?.models ?? [])].sort((a, b) => b.cost_usd - a.cost_usd),
-    [s?.models],
+    [...(data?.models ?? [])]
+      .map((m) => ({ model: m.model, cost_usd: m.total_cost_usd }))
+      .sort((a, b) => b.cost_usd - a.cost_usd),
+    [data?.models],
   );
 
   // Has any live data? Used to show a helpful banner when the stats store


### PR DESCRIPTION
Found by the release-verification sweep: the agent Metrics tab's "By model" section was dead code — it read `summary.models` from `/api/agents/stats/summary`, a field the stats query never fills (it only computes resource metrics), so the panel rendered for no one.

**Fix**
- `pkg/cost`: `GetAgentModelSummarySince(ctx, agentID, since)` — per-model aggregation filtered to one cost-agent id; the unfiltered path delegates to it.
- `/api/costs/models` accepts optional `?agent=<cost-id>`.
- StatsTab fetches it with the cost-id it already alias-resolves (plain name vs legacy `bc-bc-*` session ids) and feeds the existing panel markup.

**Tests**: `TestAgentModelSummaryFiltersByAgent` (filtering + unfiltered aggregation). Gates: go build/vet/lint 0 issues, pkg/cost + handlers suites green, web 311/311 + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related
Part of #2674 (Q2 roadmap — agent Metrics/costs)

## Test plan
- `TestAgentModelSummaryFiltersByAgent` — green
- go build / vet / lint — 0 issues; pkg/cost + handlers suites green
- web 311/311 + build green