### PR TITLE
docs(design): Phase 2 — marketplace installer + templates as bundles

### DIFF
--- a/docs/design/marketplace.md
+++ b/docs/design/marketplace.md
@@ -1,0 +1,223 @@
+# Marketplace: from catalog to installer
+
+Status: **design — awaiting sign-off** (Phase 2 of the plugin-era program,
+board #39). Companion doc: [templates-bundles.md](templates-bundles.md).
+
+The marketplace today is a good catalog and a weak installer. `pkg/marketplace`
+aggregates eight live sources into one browsable list; "install" composes a
+free-text message and fires it at an agent, hoping the agent runs the right
+CLI command. This doc turns install into a first-class, deterministic,
+reversible daemon operation — with trust tiers, consent previews, and receipts.
+
+## Where we are (honest audit)
+
+What ships today:
+
+- **Catalog** (`pkg/marketplace/aggregator.go`): concurrent fan-out over
+  MCP registry, GitHub (stars ≥ 1000, topics `mcp-server`/`claude-skill`),
+  local mycel templates, Anthropic claude-plugins-official, ClawHub
+  (openclaw skills), gemini-cli-extensions, Glama, Smithery. In-memory
+  cache, 1 h TTL, stale-on-error, dedupe by ID. Three item types:
+  `mcp`, `skill`, `template`.
+- **Install** (`server/handlers/marketplace.go`): `POST
+  /api/marketplace/install` sends a formatted instruction message to each
+  selected agent via `AgentSender` — the same path as a chat message. The
+  agent is asked to run `claude mcp add …`, `claude plugin install …`,
+  `openclaw skills install …`, or `mycel template import …`.
+
+The warts, named:
+
+1. **Install is fire-and-forget prose.** No record of what was installed,
+   where, or whether it succeeded. Uninstall does not exist.
+2. **`mycel template import` does not exist** — `internal/cmd/template.go`
+   registers only list/show/create/delete. Template installs instruct the
+   agent to run a command that fails.
+3. **Config clobbering has already bitten us.** `applyTemplate` in
+   `server/handlers/agents.go` used to write `.mcp.json` stubs that wiped
+   the role-generated MCP config; the fix was a hand-rolled read-merge-write.
+   That fix is local to one call site. Nothing prevents the next writer from
+   clobbering again — merge semantics must live in one place.
+4. **No trust signal.** A 12-star repo from GitHub search renders the same
+   card as the official MCP registry entry. `InstallSpec` is whatever the
+   source gave us.
+5. **Cache is memory-only** — cold daemon boot blocks the marketplace view
+   on eight network calls.
+
+## Item taxonomy (what mycel can actually install)
+
+| Type | Installable today? | Install target | P |
+|---|---|---|---|
+| `mcp` — MCP server | Yes (deterministic) | agent worktree `.mcp.json`, or user-global `~/.mycel/mcps.json` | P0 |
+| `template` — agent bundle | Yes (deterministic) | `~/.mycel/templates/` (then create-agent-from-template) | P0 |
+| `skill` — Claude skill / plugin | Partially — only via the agent's own CLI (`claude plugin install`) inside its session | agent worktree `.claude/` | P1 |
+| `app-preset` — pre-filled Apps connect config | Link-out only. Apps are **compiled-in Go plugins** (`pkg/app/builtin`); the marketplace cannot install code into the binary. A card deep-links to the Apps connect flow with config pre-filled — never secrets. | `prefs.json` `apps` via existing `/api/apps` | P2 |
+| `provider-preset` — model/params defaults | Not an install at all; it is a settings PATCH. Deferred until a real need appears. | — | — |
+
+Non-goals: installing Go app plugins at runtime (no dynamic loading — an app
+is a PR), paid items, and any hosted mycel-run registry service.
+
+## Registry model
+
+Three source classes, surfaced as a `tier` on every item:
+
+- **`verified`** — the first-party mycel index: a curated
+  `marketplace.json` manifest in a mycel-owned GitHub repo (same pattern as
+  `anthropics/claude-plugins-official`). Entries are hand-reviewed, carry a
+  full install spec (exact command/URL/transport — no guessing), a pinned
+  version, and a content hash where the artifact is fetchable. Small by
+  design: tens of items, not thousands.
+- **`community`** — the existing aggregated registries (MCP registry,
+  Glama, Smithery, ClawHub, claude-plugins, gemini extensions, GitHub
+  stars-gated). Known indexes, unreviewed content. Provenance shown:
+  source registry, repo URL, stars, publisher.
+- **`unlisted`** — a raw URL or name the user pastes ("install from URL").
+  Rendered with an explicit warning; requires typing the agent name to
+  confirm. Exists because power users will do this anyway — better in a
+  flow with receipts than in a terminal we can't see.
+
+Indexing and freshness:
+
+- Keep the fan-out aggregator; add an **on-disk cache**
+  `~/.mycel/marketplace/cache.json` written after each successful
+  aggregate. Boot serves disk cache instantly, refreshes in the background.
+  TTL stays 1 h; `?refresh=1` forces.
+- The verified manifest is fetched like any other source but never
+  stale-dropped: last good copy is always kept on disk.
+- Dedupe across tiers prefers the higher tier: a server present in both
+  the verified manifest and Glama renders once, as verified.
+
+## Trust and consent: the install plan
+
+The core fix for warts 1–3 is architectural, not per-callsite: **every
+install flows through one `Installer` in a new `pkg/marketplace/install`,
+and every install is two-phase** — plan, then apply.
+
+```go
+// Plan computes exactly what an install would change, without writing.
+type Plan struct {
+    Item     Item
+    Targets  []TargetPlan // one per selected agent, or one fleet-wide target
+}
+
+type TargetPlan struct {
+    Agent   string       // "" for fleet-wide (user-global) installs
+    Changes []FileChange // every file/keys touched, with before/after
+    Warns   []string     // "key 'github' already exists with a different command — will keep yours"
+}
+
+type FileChange struct {
+    Path    string // absolute: ~/.mycel/agents/<name>/worktree/.mcp.json, ~/.mycel/mcps.json, …
+    Op      string // "create" | "merge" | "none"
+    Diff    string // unified diff of the exact bytes that would be written
+}
+```
+
+Merge semantics (the applyTemplate wart, fixed once, centrally):
+
+- JSON maps (`.mcp.json` `mcpServers`, env maps): **add-only by default**.
+  An existing key is never overwritten; a colliding key with different
+  content becomes a `Warn` in the plan, and the UI offers an explicit
+  per-key "replace" checkbox. No silent clobber, ever.
+- Whole files the item owns (a skill directory, a template file): written
+  only if absent, or if the on-disk content still hash-matches what a
+  previous install wrote (recorded in the receipt) — i.e. user-edited
+  files are never overwritten without the plan flagging it.
+- `Plan` is also the consent UI: the install modal renders the diffs and
+  warns per agent before the user confirms. `dry_run` is not a flag —
+  planning **is** the first request; apply references the plan.
+
+## Install-to-agent, receipts, uninstall
+
+Scope choice at install time: **selected agent(s)** or **fleet-wide**.
+
+- Per-agent installs write only inside the agent's entity dir
+  (`~/.mycel/agents/<name>/`) — worktree `.mcp.json`, `.claude/skills/…`.
+  Deleting the agent deletes the install, consistent with the entity-dir
+  contract.
+- Fleet-wide installs write user-global state (`~/.mycel/mcps.json`,
+  `~/.mycel/templates/`) and apply to future agents; existing agents get
+  it via the same plan/apply flow per agent.
+
+Every apply writes a **receipt** — a new `installs` table in the global DB
+(`db.Global`, `IF NOT EXISTS`, same pattern as every store):
+
+```sql
+CREATE TABLE IF NOT EXISTS installs (
+  id         TEXT PRIMARY KEY,   -- ulid
+  item_id    TEXT NOT NULL,      -- "mcp-registry:io.github.foo/bar"
+  version    TEXT NOT NULL,      -- pinned version or content hash at install time
+  tier       TEXT NOT NULL,      -- verified | community | unlisted
+  agent      TEXT NOT NULL,      -- "" = fleet-wide
+  changes    TEXT NOT NULL,      -- JSON: [{path, op, keys_added, sha256_after}]
+  created_at TIMESTAMP NOT NULL
+);
+```
+
+Uninstall inverts the receipt: remove only the keys/files the receipt
+added, and only where the current hash still matches `sha256_after`
+(user-modified → plan warns, asks). Rollback of a bad install is just
+uninstall; no snapshotting beyond the receipt.
+
+Agent-native installs (skills via `claude plugin install`) can't be
+daemon-written — the provider CLI owns that state. They keep the
+message-dispatch path, but the message becomes structured, the dispatch is
+recorded as a receipt with `op: "delegated"`, and the agent is asked to
+confirm via its MCP (`report_status`) so the receipt can be marked
+succeeded/failed. Honest limitation: delegated installs have weaker
+uninstall (a delegated uninstall message).
+
+## Integration with Apps and Templates
+
+- **Apps**: marketplace never installs app code. An `app-preset` card
+  resolves to "open the Apps connect modal for descriptor X with these
+  non-secret config fields pre-filled". Secrets always go through the
+  normal vault flow.
+- **Templates** ([templates-bundles.md](templates-bundles.md)): a template
+  bundle references marketplace items by `id@version`
+  (`mcp-registry:io.github.foo/bar@1.2.0`). Creating an agent from a
+  template drives the same `Installer` plan/apply per referenced item —
+  one merge engine, one receipt trail, whether the trigger was a
+  marketplace card or a template.
+
+## API sketch
+
+| Route | Purpose |
+|---|---|
+| `GET  /api/marketplace?type=&source=&tier=&q=&refresh=` | catalog (existing, + tier filter) |
+| `GET  /api/marketplace/items/{id}` | item detail: provenance, versions, install spec |
+| `POST /api/marketplace/plan` | `{item_id, agents[], fleet_wide, overrides{}}` → `Plan` (no writes) |
+| `POST /api/marketplace/install` | `{plan_id, confirmed_replacements[]}` → receipts; 409 if state changed since plan |
+| `GET  /api/marketplace/installs?agent=` | receipts (what's installed where) |
+| `DELETE /api/marketplace/installs/{id}` | uninstall via receipt inversion (plan/confirm for dirty files) |
+
+The existing `POST /api/marketplace/install` free-text body is replaced,
+not kept alongside — one install path (per the no-legacy rule); delegated
+dispatch survives as an internal strategy of the Installer, not a
+separate API.
+
+## Delivery plan
+
+- **P0 — deterministic installs + receipts** (~1.5 wk): `pkg/marketplace/install`
+  (Plan/Apply/merge engine + tests), `installs` table, MCP + template
+  install paths daemon-side, plan-diff modal in the web UI, on-disk
+  catalog cache. Kill the fake `mycel template import` instruction.
+- **P1 — trust** (~1 wk): first-party verified manifest repo + fetcher,
+  tier badges + provenance panel, install-from-URL (unlisted) with
+  confirm, uninstall UI, delegated-skill receipts with agent confirmation.
+- **P2 — breadth** (~1 wk, after templates ship): app-preset deep links,
+  per-item version pinning + upgrade check against the verified manifest,
+  fleet-wide → per-agent backfill flow.
+
+## Open questions for Puneet
+
+1. Verified manifest location: a public `rpuneet/mycel-marketplace` repo
+   (community PRs possible), or a `marketplace/` dir inside the main repo
+   (simpler, but a catalog change means a mycel commit)?
+2. Community tier default: show all eight sources by default, or default
+   the catalog view to verified+MCP-registry with community behind a
+   filter toggle? (Signal vs. breadth on first impression.)
+3. Delegated skill installs (P1): acceptable that their uninstall is
+   best-effort via agent message, or should skills be deferred entirely
+   until a daemon-side skill writer exists?
+4. Is fleet-wide install worth having in P0, or is per-agent-only enough
+   for the 2-agent fleets we actually run today?

--- a/docs/design/templates-bundles.md
+++ b/docs/design/templates-bundles.md
@@ -1,0 +1,229 @@
+# Templates as one-stop bundles
+
+Status: **design — awaiting sign-off** (Phase 2 of the plugin-era program,
+board #40). Companion doc: [marketplace.md](marketplace.md).
+
+A template should answer one question completely: *"if I create an agent
+from this, what do I get?"* Today it answers a fifth of it. This doc grows
+`pkg/template` from a name + prompt + MCP-name-list into a **complete agent
+recipe** — provider, prompt, MCP servers, skills, tool policy, app channel
+subscriptions, secret references, budgets — applied through one merge
+engine with a diff preview, versioned, and shareable via the marketplace.
+
+## Where we are (honest audit)
+
+- `pkg/template.Template`: name, description, prompt file, MCP **names**
+  (no specs), secrets, plugins, context files, tool policies, cost/stuck
+  budgets. Stored as `<name>.json` + `<name>.md` pair; two-layer store
+  (global `~/.mycel/templates/` + repo override) with override-wins.
+- Apply exists only at create time: `applyTemplate`
+  (`server/handlers/agents.go`) writes `CLAUDE.md` and merges **empty stub
+  entries** into `.mcp.json` — the template knows MCP names but not how to
+  run them, so it writes `{"github": {}}` and hopes the role config or the
+  user fills it in. The stub-clobber bug this caused is patched at that
+  one call site.
+- Provider, model, runtime, env, app channels are all chosen manually in
+  `CreateAgentModal` — the template doesn't carry them, so "template" is
+  really "prompt preset".
+- Roles (`pkg/home/roles.go`, DB-backed) carry a second, overlapping
+  recipe: prompt, MCP server names, secrets, plugins, skills, rules,
+  commands, lifecycle prompts, with BFS inheritance. `role_setup` writes
+  these into the worktree on spawn. Two systems write the same files.
+
+## The bundle
+
+One template = one complete recipe. Everything is a **reference, never a
+value** where secrets or machine-local state are involved.
+
+```yaml
+---
+name: feature-dev
+version: 1.2.0
+description: Full-stack feature development
+provider: claude          # provider registry ID
+model: claude-sonnet-4-6  # optional; provider default when empty
+runtime: docker           # optional; prefs default when empty
+
+role: feature-dev         # capability reference (see "Roles" below)
+
+mcps:                     # full specs or marketplace refs — no name-only stubs
+  - name: mycel
+    builtin: true         # daemon-provided /_mcp/{agent}
+  - name: github
+    ref: "mcp-registry:io.github.github/github-mcp-server@1.4.0"
+  - name: playwright
+    command: npx
+    args: ["-y", "@playwright/mcp"]
+
+skills:
+  - ref: "claude:code-review@2.0.1"   # marketplace item, delegated install
+
+tools:
+  allowed: ["Bash(make *)", "Bash(go test *)"]
+  denied:  ["Bash(rm -rf *)"]
+
+apps:                     # channel subscriptions wired via pkg/notify
+  - instance: slack
+    channels: ["#engineering", "#merge"]
+
+env:
+  GITHUB_TOKEN: "secret:app:github:token"   # vault reference — never a value
+  GOFLAGS: "-mod=mod"                       # plain values allowed for non-secrets
+
+budgets:
+  max_cost_usd: 25
+  stuck_timeout_min: 30
+---
+
+# Feature Developer
+
+You implement features, fix bugs, and write tests in an isolated worktree.
+…system prompt is the markdown body…
+```
+
+### File format: markdown + YAML frontmatter
+
+One file, `templates/<name>.md`. Chosen over the alternatives deliberately:
+
+- **Roles already use exactly this format** (`ParseRoleFile` in
+  `pkg/home/roles.go`) — one parser, one authoring convention, and the
+  role→template migration below becomes nearly mechanical.
+- The system prompt is the body — no `system_prompt_file` indirection, no
+  `.json`+`.md` pair to keep in sync (today's store juggles both).
+- It renders on GitHub, which is what "share a template" mostly means.
+- TOML/JSON lose on multiline prompts; a separate YAML doc loses the
+  prompt-is-body property and adds a second convention beside roles.
+
+The store keeps its two layers (global + repo override) and grows a
+loader for `.md` bundles. Existing `.json`+`.md` pairs are folded into
+single `.md` files by a one-time local migration (per the no-legacy rule:
+the pair format does not survive in tree).
+
+## Apply semantics
+
+All applies — create-time and apply-to-existing — run through the same
+`Installer` plan/apply engine from [marketplace.md](marketplace.md).
+A template apply is a batch of item applies plus template-owned files.
+
+**Create-time** (the common case): render the full recipe into the fresh
+entity dir — `CLAUDE.md` from the body, real `.mcp.json` entries (specs
+resolved from the bundle or the marketplace ref — stub entries are gone),
+tool policy into settings, env refs resolved at session start (values
+never land on disk), app subscriptions registered via `pkg/notify`,
+budgets onto the agent record. Marketplace-ref items (`ref:`) resolve
+through the marketplace installer and produce receipts.
+
+**Apply-to-existing** — the merge rules, stated once:
+
+- On every apply, write a lock:
+  `~/.mycel/agents/<name>/template.lock` — `{template, version,
+  content_hash, files: [{path, sha256_after}], keys: {...}}`.
+- A later apply (same template new version, or a different template) does
+  a **three-way plan**: base = what the lock says the template wrote,
+  ours = current on-disk state, theirs = the new bundle.
+    - Base == ours (user untouched) → update to theirs silently.
+    - Ours != base (user customized) → keep ours, flag in the diff
+      preview with an opt-in "replace" per file/key.
+    - New keys/files → add.
+- The plan (exact diffs + warnings) is always shown before writing;
+  `dry_run` is the default first request, apply confirms a plan ID.
+  No template apply ever silently clobbers user state — this retires the
+  applyTemplate wart class entirely.
+
+**Versioning / upgrade**: `version` is semver, bumped by the author; the
+lock pins what an agent got. "Upgrade available" = lock version < store
+version. Upgrade is just apply-to-existing with the three-way plan. No
+auto-upgrades.
+
+## Relationship to roles: templates absorb the recipe, roles keep capabilities
+
+Three options considered:
+
+1. *Orthogonal* (status quo): both write the worktree; collisions patched
+   per call site. This is the bug factory — rejected.
+2. *Templates reference roles for everything*: keeps two overlapping
+   recipe formats forever — rejected.
+3. **Templates absorb the recipe; roles shrink to what only roles do**
+   — recommended.
+
+Concretely: prompt content, MCP servers, skills, plugins, secrets, rules,
+commands move to the template (the bundle above already holds them). The
+role keeps what the runtime genuinely keys on: **capabilities and
+hierarchy** (`RoleCapabilities` / `RoleHierarchy`, parent/child agent
+permissions) plus lifecycle prompts. A template names its role in one
+field (`role: feature-dev`); `role_setup` stops writing prompt/MCP files
+and only enforces capabilities.
+
+Migration implications: each built-in role's recipe half is regenerated as
+a built-in template (mostly mechanical — same frontmatter format);
+`SeedDefaults` seeds bundles instead of stubs; the roles table keeps
+name/capabilities/parents/lifecycle and drops the content columns. One-time
+local migration, no compatibility layer in tree. Role inheritance for
+*content* is not replicated in templates — bundles stay flat; if
+composition proves necessary later, a single `extends:` is the escape
+hatch (explicit non-goal for now).
+
+## UI
+
+- **Gallery** (`Templates.tsx` grows up): cards with name, description,
+  provider badge, version, scope (global/repo), "used by N agents".
+- **Detail — the "what you get" manifest**: the rendered plan for a
+  hypothetical agent — provider+model, prompt preview, each MCP with its
+  real spec and trust tier (marketplace refs show provenance), skills,
+  tool policy, channels, env *references*, budgets. This is the same
+  `Plan` structure the installer produces — the manifest is not a second
+  rendering path.
+- **One-click create**: "Create agent" on the detail page opens
+  `CreateAgentModal` fully pre-filled (name suggestion + everything from
+  the bundle); user can override any field; overrides are recorded in the
+  lock so later upgrades respect them.
+- **Agent detail**: shows the applied template + version, drift indicator
+  (lock hash vs current files), "upgrade available" affordance.
+
+## API sketch
+
+| Route | Purpose |
+|---|---|
+| `GET  /api/templates` | list (existing), + version, scope, usage count |
+| `GET  /api/templates/{name}` | bundle + rendered "what you get" manifest |
+| `POST /api/templates` / `PUT /api/templates/{name}` | author (body = the .md bundle) |
+| `POST /api/templates/{name}/plan` | `{agent}` → three-way `Plan` (dry run; also serves create preview with `agent: null`) |
+| `POST /api/agents` with `template` | create-from-template — applies via the installer, writes the lock |
+| `POST /api/agents/{name}/template/apply` | `{plan_id, confirmed_replacements[]}` — apply/upgrade on existing agent |
+| `GET  /api/agents/{name}/template` | lock status: template@version, drift, upgrade availability |
+
+Sharing: publishing a template to the marketplace is the marketplace's
+verified-manifest PR flow (an entry pointing at the raw `.md`); importing
+one is a normal marketplace template install into
+`~/.mycel/templates/`. No separate sharing infrastructure.
+
+## Delivery plan
+
+- **P0 — the bundle** (~1.5 wk): `.md` bundle format + parser (reusing the
+  role frontmatter parser), store migration off the json/md pair, full
+  create-time apply through the installer (real MCP specs, env refs,
+  budgets; kills stub entries), `template.lock`, pre-filled
+  CreateAgentModal.
+- **P1 — apply-to-existing** (~1 wk): three-way plan + diff preview,
+  upgrade flow, drift indicator, "what you get" manifest on the detail
+  page, app subscriptions + skills refs in the bundle.
+- **P2 — roles absorption** (~1 wk): regenerate built-in roles as
+  templates, shrink role storage to capabilities+hierarchy+lifecycle,
+  `role_setup` stops writing content files. Gated on P0/P1 proving the
+  bundle in real use.
+
+## Open questions for Puneet
+
+1. Roles absorption (P2): sign off on shrinking roles to
+   capabilities+hierarchy+lifecycle now, or ship P0/P1 and revisit? It
+   deletes the role content columns — cheap today, pricier after more
+   roles accumulate.
+2. Should a template pin `provider` at all, or only recommend it? Pinning
+   makes bundles complete but couples shared templates to whichever
+   providers the receiving machine has configured.
+3. Repo-scoped (override-layer) templates: keep the second layer, or is
+   user-global-only enough now that agents bind to repos per-agent? The
+   layer exists but the workspace era it served is gone.
+4. Create-time overrides in the lock: when a user overrides a bundle field
+   at create (say model), should upgrades ever propose reverting to the
+   template value, or is an override permanent until manually cleared?


### PR DESCRIPTION
Design docs for Puneet's sign-off (no implementation): `docs/design/marketplace.md` + `docs/design/templates-bundles.md`.

Headlines: honest install taxonomy (only mcp+template deterministic today), trust tiers (verified/community/unlisted), a central two-phase Installer (plan→apply with per-agent diffs, add-only merges, receipts + hash-guarded uninstall — kills the applyTemplate-clobber class), templates as complete markdown-frontmatter recipes with three-way upgrade semantics and lock files, and roles shrinking to capabilities-only in P2.

`mkdocs build --strict` green. 8 open questions for Puneet are at the end of each doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related
Part of #3016 (template marketplace — this is the design spec for it)

## Test plan
- `mkdocs build --strict` — green
- Docs-only PR (no code paths touched)