### PR TITLE
feat(notifications): real profile photos for channels & senders

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -52,16 +52,17 @@ type NotificationAdapter interface {
 // Notification is a normalized inbound event from an external platform.
 // The Raw field contains the complete platform payload as JSON.
 type Notification struct {
-	Timestamp time.Time       `json:"timestamp"`
-	Raw       json.RawMessage `json:"raw"`
-	Channel   string          `json:"channel"`
-	ChannelID string          `json:"channel_id,omitempty"` // platform-native channel id (e.g. WhatsApp JID), if known
-	Platform  string          `json:"platform"`
-	Sender    string          `json:"sender"`
-	SenderID  string          `json:"sender_id,omitempty"`  // platform-native sender id (e.g. WhatsApp JID)
-	Content   string          `json:"content"`              // human-readable text for display/storage
-	MessageID string          `json:"message_id,omitempty"` // platform-native message id (for reactions, threading)
-	Mentions  []string        `json:"mentions"`
+	Timestamp    time.Time       `json:"timestamp"`
+	Raw          json.RawMessage `json:"raw"`
+	Channel      string          `json:"channel"`
+	ChannelID    string          `json:"channel_id,omitempty"` // platform-native channel id (e.g. WhatsApp JID), if known
+	Platform     string          `json:"platform"`
+	Sender       string          `json:"sender"`
+	SenderID     string          `json:"sender_id,omitempty"`     // platform-native sender id (e.g. WhatsApp JID)
+	SenderAvatar string          `json:"sender_avatar,omitempty"` // raw platform avatar URL for the sender, when the adapter cheaply has one
+	Content      string          `json:"content"`                 // human-readable text for display/storage
+	MessageID    string          `json:"message_id,omitempty"`    // platform-native message id (for reactions, threading)
+	Mentions     []string        `json:"mentions"`
 }
 
 // ChannelInfo represents a discovered channel on a platform.
@@ -82,9 +83,14 @@ const (
 )
 
 // ChannelMeta is human-readable display metadata for a platform channel.
+// AvatarURL, when set, is the raw platform URL of the channel's picture
+// (a person's profile photo or a group's icon). It is stored as-is; the
+// server wraps it in a loopback image-proxy URL before exposing it to the
+// web UI so tokens/expiring URLs never reach the browser directly.
 type ChannelMeta struct {
 	DisplayName      string
 	Kind             string // group | person | channel | feed | other
+	AvatarURL        string
 	ParticipantCount int
 }
 

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -21,6 +21,7 @@ type PersistedChannel struct {
 	PlatformID       string
 	DisplayName      string
 	Kind             string
+	AvatarURL        string
 	ParticipantCount int
 }
 
@@ -29,7 +30,7 @@ type PersistedChannel struct {
 type ChannelStore interface {
 	SaveChannel(ctx context.Context, channel, platform, platformID string) error
 	LoadChannels(ctx context.Context) ([]PersistedChannel, error)
-	UpsertChannelMeta(ctx context.Context, channel, displayName, kind string, participantCount int) error
+	UpsertChannelMeta(ctx context.Context, channel, displayName, kind, avatarURL string, participantCount int) error
 	// UpdateChannelPlatformID force-overwrites a channel's platform id —
 	// used when a fallback route is upgraded to a native id (SaveChannel
 	// deliberately preserves existing non-empty ids).
@@ -67,7 +68,9 @@ type Manager struct {
 	// Typically wired to ChannelService.Send + SSE hub.
 	// senderID carries the platform-native sender identifier (e.g. WhatsApp JID)
 	// so callers can use it for follow-up operations such as reactions.
-	onInbound    func(channel, sender, senderID, content, messageID string, mentions []string, raw json.RawMessage)
+	// senderAvatar is the raw platform avatar URL for the sender when the
+	// adapter cheaply resolved one (empty otherwise → initials fallback).
+	onInbound    func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage)
 	channelStore ChannelStore
 	mu           sync.RWMutex
 	// adapterWG tracks boot-time and hot-started adapter goroutines so Stop/
@@ -112,7 +115,7 @@ func (m *Manager) SetChannelStore(store ChannelStore) {
 // sender id (e.g. WhatsApp JID — used for follow-up reactions), text content,
 // platform-native message ID, pre-extracted mentions (e.g. WhatsApp JID user parts),
 // and the raw platform payload.
-func (m *Manager) SetInboundHandler(fn func(channel, sender, senderID, content, messageID string, mentions []string, raw json.RawMessage)) {
+func (m *Manager) SetInboundHandler(fn func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage)) {
 	m.onInbound = fn
 }
 
@@ -594,7 +597,7 @@ func (m *Manager) resolveAndStoreMeta(ctx context.Context, a NotificationAdapter
 	if meta == (ChannelMeta{}) {
 		return
 	}
-	if err := m.channelStore.UpsertChannelMeta(ctx, channel, meta.DisplayName, meta.Kind, meta.ParticipantCount); err != nil {
+	if err := m.channelStore.UpsertChannelMeta(ctx, channel, meta.DisplayName, meta.Kind, meta.AvatarURL, meta.ParticipantCount); err != nil {
 		log.Warn("gateway: failed to persist channel meta", "channel", channel, "error", err)
 	}
 }
@@ -620,6 +623,9 @@ func (m *Manager) resolveChannelMeta(ctx context.Context, a NotificationAdapter,
 	}
 	if resolved.Kind != "" {
 		meta.Kind = resolved.Kind
+	}
+	if resolved.AvatarURL != "" {
+		meta.AvatarURL = resolved.AvatarURL
 	}
 	if resolved.ParticipantCount > 0 {
 		meta.ParticipantCount = resolved.ParticipantCount
@@ -663,7 +669,7 @@ func (m *Manager) RefreshChannelMeta(ctx context.Context) (int, error) {
 		if err != nil || meta == (ChannelMeta{}) {
 			continue
 		}
-		if err := m.channelStore.UpsertChannelMeta(ctx, e.channel, meta.DisplayName, meta.Kind, meta.ParticipantCount); err != nil {
+		if err := m.channelStore.UpsertChannelMeta(ctx, e.channel, meta.DisplayName, meta.Kind, meta.AvatarURL, meta.ParticipantCount); err != nil {
 			log.Warn("gateway: failed to refresh channel meta", "channel", e.channel, "error", err)
 			continue
 		}
@@ -762,7 +768,7 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 		content = string(n.Raw)
 	}
 	if m.onInbound != nil {
-		m.onInbound(channel, sender, n.SenderID, content, n.MessageID, n.Mentions, n.Raw)
+		m.onInbound(channel, sender, n.SenderID, n.SenderAvatar, content, n.MessageID, n.Mentions, n.Raw)
 	}
 }
 

--- a/pkg/gateway/manager_test.go
+++ b/pkg/gateway/manager_test.go
@@ -163,7 +163,7 @@ func (f *fakeChannelStore) LoadChannels(_ context.Context) ([]PersistedChannel, 
 	return out, nil
 }
 
-func (f *fakeChannelStore) UpsertChannelMeta(_ context.Context, channel, displayName, kind string, participantCount int) error {
+func (f *fakeChannelStore) UpsertChannelMeta(_ context.Context, channel, displayName, kind, avatarURL string, participantCount int) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	ch := f.saved[channel]
@@ -173,6 +173,9 @@ func (f *fakeChannelStore) UpsertChannelMeta(_ context.Context, channel, display
 	}
 	if kind != "" {
 		ch.Kind = kind
+	}
+	if avatarURL != "" {
+		ch.AvatarURL = avatarURL
 	}
 	if participantCount != 0 {
 		ch.ParticipantCount = participantCount
@@ -239,7 +242,7 @@ func TestDiscoverChannels_PersistsResolvedMeta(t *testing.T) {
 		mockNotifAdapter: mockNotifAdapter{name: "whatsapp"},
 		channels:         []ChannelInfo{{ID: "1234@g.us", Name: "family", Platform: "whatsapp"}},
 		meta: map[string]ChannelMeta{
-			"1234@g.us": {DisplayName: "Family Group", Kind: ChannelKindGroup, ParticipantCount: 12},
+			"1234@g.us": {DisplayName: "Family Group", Kind: ChannelKindGroup, AvatarURL: "https://pps.whatsapp.net/v/group.jpg", ParticipantCount: 12},
 		},
 	}
 	m.Register(a)
@@ -247,7 +250,8 @@ func TestDiscoverChannels_PersistsResolvedMeta(t *testing.T) {
 
 	waitFor(t, func() bool {
 		ch, ok := store.get("whatsapp:family")
-		return ok && ch.DisplayName == "Family Group" && ch.Kind == "group" && ch.ParticipantCount == 12
+		return ok && ch.DisplayName == "Family Group" && ch.Kind == "group" &&
+			ch.AvatarURL == "https://pps.whatsapp.net/v/group.jpg" && ch.ParticipantCount == 12
 	})
 }
 

--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -29,7 +29,7 @@ type Adapter struct {
 	sm             *socketmode.Client
 	handler        func(gateway.Notification)
 	channelMap     map[string]string
-	userCache      map[string]string
+	userCache      map[string]slackUser
 	botUserID      string
 	appToken       string
 	botToken       string
@@ -45,13 +45,21 @@ type Adapter struct {
 
 var _ gateway.NotificationAdapter = (*Adapter)(nil)
 
+// slackUser is a resolved Slack user: display name plus the raw profile
+// image URL Slack serves (public, tokenless CDN). Cached per user id so a
+// busy channel resolves each author with a single users.info call.
+type slackUser struct {
+	name   string
+	avatar string
+}
+
 // New creates a new Slack adapter using Socket Mode.
 func New(botToken, appToken string) *Adapter {
 	return &Adapter{
 		botToken:   botToken,
 		appToken:   appToken,
 		channelMap: make(map[string]string),
-		userCache:  make(map[string]string),
+		userCache:  make(map[string]slackUser),
 	}
 }
 
@@ -431,28 +439,32 @@ func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload js
 		}
 	}
 
-	// Resolve user name. For bot_message posts the impersonation
+	// Resolve user name + avatar. For bot_message posts the impersonation
 	// Username is the sender — the gate above already verified the
 	// event came from our own bot user, so Username is trusted.
 	sender := ev.User
+	senderAvatar := ""
 	if ev.SubType == "bot_message" && ev.User == a.botUserID && ev.Username != "" {
 		sender = ev.Username
 	} else if a.api != nil {
 		a.chatMu.RLock()
-		cachedName, cached := a.userCache[ev.User]
+		cached, ok := a.userCache[ev.User]
 		a.chatMu.RUnlock()
-		if cached {
-			sender = cachedName
+		if ok {
+			sender = cached.name
+			senderAvatar = cached.avatar
 		} else if userInfo, err := a.api.GetUserInfo(ev.User); err == nil {
 			sender = userInfo.RealName
 			if sender == "" {
 				sender = userInfo.Name
 			}
+			// Prefer the 192px avatar; fall back through the smaller sizes.
+			senderAvatar = firstNonEmpty(userInfo.Profile.Image192, userInfo.Profile.Image72, userInfo.Profile.Image512)
 			a.chatMu.Lock()
 			if a.userCache == nil {
-				a.userCache = make(map[string]string)
+				a.userCache = make(map[string]slackUser)
 			}
-			a.userCache[ev.User] = sender
+			a.userCache[ev.User] = slackUser{name: sender, avatar: senderAvatar}
 			a.chatMu.Unlock()
 		} else {
 			log.Warn("slack: failed to resolve user", "user_id", ev.User, "error", err)
@@ -481,12 +493,14 @@ func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload js
 			return
 		}
 		a.handler(gateway.Notification{
-			Channel:   channelName,
-			Platform:  "slack",
-			Sender:    sender,
-			Content:   content,
-			Timestamp: now,
-			Raw:       raw,
+			Channel:      channelName,
+			Platform:     "slack",
+			Sender:       sender,
+			SenderID:     ev.User,
+			SenderAvatar: senderAvatar,
+			Content:      content,
+			Timestamp:    now,
+			Raw:          raw,
 		})
 	}
 }
@@ -523,6 +537,16 @@ func extractSlackFiles(rawPayload json.RawMessage) []string {
 		lines = append(lines, fmt.Sprintf("\U0001F4CE %s (%s) [%s]", name, humanSize(f.Size), f.Mimetype))
 	}
 	return lines
+}
+
+// firstNonEmpty returns the first non-empty string.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // humanSize formats bytes into a human-readable string.

--- a/pkg/gateway/whatsapp/identity.go
+++ b/pkg/gateway/whatsapp/identity.go
@@ -22,6 +22,9 @@ const metaCacheTTL = 15 * time.Minute
 type identityClient interface {
 	GetGroupInfo(ctx context.Context, jid types.JID) (*types.GroupInfo, error)
 	GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error)
+	// ProfilePictureURL returns the downloadable URL of the profile picture
+	// for a user or group JID, or "" when none exists / is not visible.
+	ProfilePictureURL(ctx context.Context, jid types.JID) string
 }
 
 // waIdentityClient adapts *whatsmeow.Client to identityClient.
@@ -35,6 +38,17 @@ func (w waIdentityClient) GetGroupInfo(ctx context.Context, jid types.JID) (*typ
 
 func (w waIdentityClient) GetContact(ctx context.Context, jid types.JID) (types.ContactInfo, error) {
 	return w.c.Store.Contacts.GetContact(ctx, jid)
+}
+
+// ProfilePictureURL asks WhatsApp for the (thumbnail) profile-picture URL.
+// A missing picture or a privacy setting returns nil,nil or an error from
+// whatsmeow; either way we degrade to "" and the UI keeps the initials chip.
+func (w waIdentityClient) ProfilePictureURL(ctx context.Context, jid types.JID) string {
+	info, err := w.c.GetProfilePictureInfo(ctx, jid, &whatsmeow.GetProfilePictureParams{Preview: true})
+	if err != nil || info == nil {
+		return ""
+	}
+	return info.URL
 }
 
 // cachedMeta is a resolved ChannelMeta with its resolution time.
@@ -118,6 +132,7 @@ func resolveJID(ctx context.Context, client identityClient, jid types.JID) (gate
 		return gateway.ChannelMeta{
 			DisplayName:      name,
 			Kind:             gateway.ChannelKindGroup,
+			AvatarURL:        client.ProfilePictureURL(ctx, jid),
 			ParticipantCount: count,
 		}, nil
 
@@ -129,6 +144,7 @@ func resolveJID(ctx context.Context, client identityClient, jid types.JID) (gate
 		if meta.DisplayName == "" {
 			meta.DisplayName = formatPhone(jid.User)
 		}
+		meta.AvatarURL = client.ProfilePictureURL(ctx, jid)
 		return meta, nil
 
 	default:

--- a/pkg/gateway/whatsapp/identity_test.go
+++ b/pkg/gateway/whatsapp/identity_test.go
@@ -15,9 +15,18 @@ import (
 type fakeIdentityClient struct {
 	groups       map[string]*types.GroupInfo
 	contacts     map[string]types.ContactInfo
+	avatars      map[string]string
 	mu           sync.Mutex
 	groupCalls   int
 	contactCalls int
+	avatarCalls  int
+}
+
+func (f *fakeIdentityClient) ProfilePictureURL(_ context.Context, jid types.JID) string {
+	f.mu.Lock()
+	f.avatarCalls++
+	f.mu.Unlock()
+	return f.avatars[jid.String()]
 }
 
 func (f *fakeIdentityClient) GetGroupInfo(_ context.Context, jid types.JID) (*types.GroupInfo, error) {
@@ -120,6 +129,38 @@ func TestResolveChannel_PersonNameFallbacks(t *testing.T) {
 				t.Fatalf("kind = %q, want person", meta.Kind)
 			}
 		})
+	}
+}
+
+func TestResolveChannel_ResolvesAvatar(t *testing.T) {
+	fake := &fakeIdentityClient{
+		contacts: map[string]types.ContactInfo{
+			"14155551234@s.whatsapp.net": {Found: true, FullName: "Alice Smith"},
+		},
+		avatars: map[string]string{
+			"14155551234@s.whatsapp.net": "https://pps.whatsapp.net/v/alice.jpg",
+			"1234@g.us":                  "https://pps.whatsapp.net/v/group.jpg",
+		},
+		groups: map[string]*types.GroupInfo{
+			"1234@g.us": groupInfo("Family Group", 3),
+		},
+	}
+	a := newTestAdapter(t, fake)
+
+	person, err := a.ResolveChannel(context.Background(), "14155551234@s.whatsapp.net")
+	if err != nil {
+		t.Fatalf("ResolveChannel person: %v", err)
+	}
+	if person.AvatarURL != "https://pps.whatsapp.net/v/alice.jpg" {
+		t.Fatalf("person avatar = %q, want alice.jpg", person.AvatarURL)
+	}
+
+	group, err := a.ResolveChannel(context.Background(), "1234@g.us")
+	if err != nil {
+		t.Fatalf("ResolveChannel group: %v", err)
+	}
+	if group.AvatarURL != "https://pps.whatsapp.net/v/group.jpg" {
+		t.Fatalf("group avatar = %q, want group.jpg", group.AvatarURL)
 	}
 }
 

--- a/pkg/notify/api_test.go
+++ b/pkg/notify/api_test.go
@@ -1088,7 +1088,7 @@ func TestMessageStorage(t *testing.T) {
 			ctx := context.Background()
 
 			for _, m := range tt.messages {
-				if err := store.SaveMessage(ctx, m.channel, m.sender, m.content); err != nil {
+				if err := store.SaveMessage(ctx, m.channel, m.sender, "", m.content); err != nil {
 					t.Fatalf("SaveMessage: %v", err)
 				}
 			}
@@ -1134,7 +1134,7 @@ func TestMessageStorage_Before(t *testing.T) {
 
 	// Save 5 messages
 	for i := range 5 {
-		_ = store.SaveMessage(ctx, "slack:eng", "sender", "msg")
+		_ = store.SaveMessage(ctx, "slack:eng", "sender", "", "msg")
 		_ = i // suppress unused warning
 	}
 
@@ -1198,7 +1198,7 @@ func TestDispatchMentionFilter_ViaHTTP(t *testing.T) {
 		sender.calls = nil
 		sender.mu.Unlock()
 
-		svc.Dispatch("slack:eng", "slack", "external-user", "U001",
+		svc.Dispatch("slack:eng", "slack", "external-user", "U001", "",
 			"hey everyone, new deployment done", "msg-no-mention", nil, nil, nil)
 		time.Sleep(150 * time.Millisecond)
 
@@ -1216,7 +1216,7 @@ func TestDispatchMentionFilter_ViaHTTP(t *testing.T) {
 		sender.calls = nil
 		sender.mu.Unlock()
 
-		svc.Dispatch("slack:eng", "slack", "external-user", "U001",
+		svc.Dispatch("slack:eng", "slack", "external-user", "U001", "",
 			"@eng-02 please review the PR", "msg-with-mention", nil, nil, nil)
 		time.Sleep(150 * time.Millisecond)
 
@@ -1269,7 +1269,7 @@ func TestSelfSkip_ViaHTTP(t *testing.T) {
 	}
 
 	// eng-01 sends — should NOT receive it back (self-skip)
-	svc.Dispatch("slack:eng", "slack", "[slack] eng-01", "U001",
+	svc.Dispatch("slack:eng", "slack", "[slack] eng-01", "U001", "",
 		"I just pushed a fix", "msg-self", nil, nil, nil)
 	time.Sleep(150 * time.Millisecond)
 

--- a/pkg/notify/pagination_test.go
+++ b/pkg/notify/pagination_test.go
@@ -36,7 +36,7 @@ func TestGetMessages_CursorPagination(t *testing.T) {
 
 	const channel = "slack:eng"
 	for i := 0; i < 30; i++ {
-		if err := store.SaveMessage(ctx, channel, "alice", "m"); err != nil {
+		if err := store.SaveMessage(ctx, channel, "alice", "", "m"); err != nil {
 			t.Fatalf("SaveMessage %d: %v", i, err)
 		}
 	}

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -106,7 +106,7 @@ func extractMentions(content string) []string {
 // extraMentions carries pre-extracted platform mentions (e.g. WhatsApp JID user
 // parts) that the text-based mention regex cannot capture; they are merged with
 // the standard @name extraction from content.
-func (s *Service) Dispatch(channel, platform, sender, senderID, content, messageID string, extraMentions []string, attachments []Attachment, raw json.RawMessage) {
+func (s *Service) Dispatch(channel, platform, sender, senderID, senderAvatar, content, messageID string, extraMentions []string, attachments []Attachment, raw json.RawMessage) {
 	s.dispatches.Add(1)
 	go func() {
 		defer s.dispatches.Done()
@@ -119,7 +119,7 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, content, message
 		ctx := s.ctx
 
 		// Store message for activity feed history
-		if saveErr := s.store.SaveMessage(ctx, channel, sender, content); saveErr != nil {
+		if saveErr := s.store.SaveMessage(ctx, channel, sender, senderAvatar, content); saveErr != nil {
 			log.Warn("notify: save message failed", "channel", channel, "error", saveErr)
 		}
 

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -196,7 +196,7 @@ func TestDispatchMentionFilter(t *testing.T) {
 	}
 
 	// Message mentions eng-01 only — eng-02 (mention_only) should be skipped
-	svc.Dispatch("slack:eng", "slack", "alice", "U123", "hey @eng-01 review this", "msg1", nil, nil, nil)
+	svc.Dispatch("slack:eng", "slack", "alice", "U123", "", "hey @eng-01 review this", "msg1", nil, nil, nil)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -224,7 +224,7 @@ func TestDispatchSelfSkip(t *testing.T) {
 	}
 
 	// eng-01 sends — should NOT be delivered back to eng-01
-	svc.Dispatch("slack:eng", "slack", "[slack] eng-01", "U456", "I just pushed a fix", "msg2", nil, nil, nil)
+	svc.Dispatch("slack:eng", "slack", "[slack] eng-01", "U456", "", "I just pushed a fix", "msg2", nil, nil, nil)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -277,7 +277,7 @@ func TestMentionOnlyModeSwitch(t *testing.T) {
 	}
 
 	// A message with no mention — zen-zebra must NOT receive it.
-	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "good morning everyone", "m1", nil, nil, nil)
+	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "", "good morning everyone", "m1", nil, nil, nil)
 	time.Sleep(80 * time.Millisecond)
 	if calls := sender.getCalls(); len(calls) != 0 {
 		t.Fatalf("mention-only mode: expected 0 deliveries, got %d", len(calls))
@@ -289,7 +289,7 @@ func TestMentionOnlyModeSwitch(t *testing.T) {
 	}
 
 	// Same message without @mention must now be delivered.
-	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "good morning everyone", "m2", nil, nil, nil)
+	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "", "good morning everyone", "m2", nil, nil, nil)
 	time.Sleep(80 * time.Millisecond)
 	calls := sender.getCalls()
 	if len(calls) != 1 {
@@ -316,7 +316,7 @@ func TestDispatchExtraMentions(t *testing.T) {
 	}
 
 	// Message content has no @name mention — but the platform supplies the JID.
-	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "",
+	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "",
 		"hey look at this", // no text @mention
 		"m1",
 		[]string{"918051005416"}, // pre-extracted from ContextInfo.MentionedJID
@@ -354,7 +354,7 @@ func TestMentionOnlyTextName(t *testing.T) {
 	}
 
 	// Message with no @mention — zen-zebra must be skipped, helper-bot delivered.
-	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "good morning", "m1", nil, nil, nil)
+	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "", "good morning", "m1", nil, nil, nil)
 	time.Sleep(80 * time.Millisecond)
 	calls := sender.getCalls()
 	if len(calls) != 1 || calls[0].Name != "helper-bot" {
@@ -362,7 +362,7 @@ func TestMentionOnlyTextName(t *testing.T) {
 	}
 
 	// Message with typed "@zen-zebra" — both must be delivered.
-	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "hey @zen-zebra check this", "m2", nil, nil, nil)
+	svc.Dispatch("whatsapp:family", "whatsapp", "alice", "", "", "hey @zen-zebra check this", "m2", nil, nil, nil)
 	time.Sleep(80 * time.Millisecond)
 	calls = sender.getCalls()
 	// Expect 2 more calls (total 3): helper-bot and zen-zebra for m2.
@@ -416,7 +416,7 @@ func TestDrainDispatches(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc.Dispatch("slack:eng", "slack", "user", "U1", "hello", "m1", nil, nil, nil)
+	svc.Dispatch("slack:eng", "slack", "user", "U1", "", "hello", "m1", nil, nil, nil)
 
 	// The dispatch is blocked inside Send — draining must time out.
 	if svc.DrainDispatches(50 * time.Millisecond) {
@@ -444,7 +444,7 @@ func TestMigratePlaceholderSubsOnDispatch(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc.Dispatch("telegram:ab010300", "telegram", "[telegram] Agni", "", "ping", "", nil, nil, nil)
+	svc.Dispatch("telegram:ab010300", "telegram", "[telegram] Agni", "", "", "ping", "", nil, nil, nil)
 
 	if !svc.DrainDispatches(2 * time.Second) {
 		t.Fatal("dispatch did not finish")
@@ -485,7 +485,7 @@ func TestMigratePlaceholderSubsNoOpWhenRealHasSubs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	svc.Dispatch("telegram:ab010300", "telegram", "user", "", "hi", "", nil, nil, nil)
+	svc.Dispatch("telegram:ab010300", "telegram", "user", "", "", "hi", "", nil, nil, nil)
 	if !svc.DrainDispatches(2 * time.Second) {
 		t.Fatal("dispatch timeout")
 	}

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -65,8 +65,19 @@ func (s *Store) initSchema() error {
 	// startup before any request context exists; threading ctx through would
 	// force a public API change on OpenStore and dozens of call sites across
 	// tests/services for no operational benefit (schema DDL is fire-and-forget).
-	_, err := s.db.ExecContext(context.TODO(), schema)
-	return err
+	if _, err := s.db.ExecContext(context.TODO(), schema); err != nil {
+		return err
+	}
+	// Additive column migrations for databases created before real-identity
+	// avatars landed. Both are idempotent — the error is ignored when the
+	// column already exists (mirrors pkg/home.RoleStore's ALTER pattern).
+	for _, alter := range []string{
+		`ALTER TABLE notify_channels ADD COLUMN avatar_url TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE notify_messages ADD COLUMN sender_avatar TEXT NOT NULL DEFAULT ''`,
+	} {
+		_, _ = s.db.ExecContext(context.TODO(), alter) //nolint:errcheck // ignore if column already exists
+	}
+	return nil
 }
 
 const schemaSQLite = `
@@ -101,6 +112,7 @@ CREATE TABLE IF NOT EXISTS notify_messages (
     id        INTEGER PRIMARY KEY AUTOINCREMENT,
     channel   TEXT NOT NULL,
     sender    TEXT NOT NULL,
+    sender_avatar TEXT NOT NULL DEFAULT '',
     content   TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
@@ -111,6 +123,7 @@ CREATE TABLE IF NOT EXISTS notify_channels (
     platform_id  TEXT NOT NULL,
     display_name TEXT NOT NULL DEFAULT '',
     kind         TEXT NOT NULL DEFAULT '',
+    avatar_url   TEXT NOT NULL DEFAULT '',
     participant_count INTEGER NOT NULL DEFAULT 0,
     updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
 );
@@ -156,6 +169,7 @@ CREATE TABLE IF NOT EXISTS notify_messages (
     id        BIGSERIAL PRIMARY KEY,
     channel   TEXT NOT NULL,
     sender    TEXT NOT NULL,
+    sender_avatar TEXT NOT NULL DEFAULT '',
     content   TEXT NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -166,6 +180,7 @@ CREATE TABLE IF NOT EXISTS notify_channels (
     platform_id  TEXT NOT NULL,
     display_name TEXT NOT NULL DEFAULT '',
     kind         TEXT NOT NULL DEFAULT '',
+    avatar_url   TEXT NOT NULL DEFAULT '',
     participant_count INTEGER NOT NULL DEFAULT 0,
     updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
@@ -473,15 +488,18 @@ type MessageRecord struct {
 	CreatedAt time.Time `json:"created_at"`
 	Channel   string    `json:"channel"`
 	Sender    string    `json:"sender"`
+	AvatarURL string    `json:"avatar_url,omitempty"` // raw platform avatar URL for the sender, "" when none
 	Content   string    `json:"content"`
 	ID        int64     `json:"id"`
 }
 
 // SaveMessage stores an inbound gateway message for the activity feed.
-func (s *Store) SaveMessage(ctx context.Context, channel, sender, content string) error {
+// senderAvatar is the raw platform avatar URL for the sender ("" when the
+// adapter could not resolve one).
+func (s *Store) SaveMessage(ctx context.Context, channel, sender, senderAvatar, content string) error {
 	_, err := s.db.ExecContext(ctx, s.q(
-		`INSERT INTO notify_messages (channel, sender, content) VALUES (?, ?, ?)`),
-		channel, sender, content)
+		`INSERT INTO notify_messages (channel, sender, sender_avatar, content) VALUES (?, ?, ?, ?)`),
+		channel, sender, senderAvatar, content)
 	return err
 }
 
@@ -494,12 +512,12 @@ func (s *Store) GetMessages(ctx context.Context, channel string, limit int, befo
 	var err error
 	if before > 0 {
 		rows, err = s.db.QueryContext(ctx, s.q(
-			`SELECT id, channel, sender, content, created_at FROM notify_messages
+			`SELECT id, channel, sender, sender_avatar, content, created_at FROM notify_messages
 			 WHERE channel = ? AND id < ? ORDER BY id DESC LIMIT ?`),
 			channel, before, limit)
 	} else {
 		rows, err = s.db.QueryContext(ctx, s.q(
-			`SELECT id, channel, sender, content, created_at FROM notify_messages
+			`SELECT id, channel, sender, sender_avatar, content, created_at FROM notify_messages
 			 WHERE channel = ? ORDER BY id DESC LIMIT ?`),
 			channel, limit)
 	}
@@ -512,7 +530,7 @@ func (s *Store) GetMessages(ctx context.Context, channel string, limit int, befo
 	for rows.Next() {
 		var m MessageRecord
 		var createdStr string
-		if err := rows.Scan(&m.ID, &m.Channel, &m.Sender, &m.Content, &createdStr); err != nil {
+		if err := rows.Scan(&m.ID, &m.Channel, &m.Sender, &m.AvatarURL, &m.Content, &createdStr); err != nil {
 			return nil, err
 		}
 		m.CreatedAt, _ = time.Parse(time.RFC3339, createdStr) //nolint:errcheck // DB-written timestamp
@@ -529,13 +547,14 @@ type PersistedChannel struct {
 	PlatformID       string
 	DisplayName      string
 	Kind             string // group | person | channel | feed | other
+	AvatarURL        string // raw platform avatar URL (person photo / group icon), "" when none
 	ParticipantCount int
 }
 
 // LoadChannels returns all persisted channel mappings.
 func (s *Store) LoadChannels(ctx context.Context) ([]PersistedChannel, error) {
 	rows, err := s.db.QueryContext(ctx, s.q(
-		`SELECT channel, platform, platform_id, display_name, kind, participant_count FROM notify_channels`))
+		`SELECT channel, platform, platform_id, display_name, kind, avatar_url, participant_count FROM notify_channels`))
 	if err != nil {
 		return nil, err
 	}
@@ -544,7 +563,7 @@ func (s *Store) LoadChannels(ctx context.Context) ([]PersistedChannel, error) {
 	var channels []PersistedChannel
 	for rows.Next() {
 		var c PersistedChannel
-		if err := rows.Scan(&c.Channel, &c.Platform, &c.PlatformID, &c.DisplayName, &c.Kind, &c.ParticipantCount); err != nil {
+		if err := rows.Scan(&c.Channel, &c.Platform, &c.PlatformID, &c.DisplayName, &c.Kind, &c.AvatarURL, &c.ParticipantCount); err != nil {
 			return nil, err
 		}
 		channels = append(channels, c)
@@ -587,16 +606,16 @@ func (s *Store) SaveChannel(ctx context.Context, channel, platform, platformID s
 // UpsertChannelMeta stores resolved display metadata for a channel. The row
 // is created if the mapping does not exist yet (platform derived from the
 // channel prefix); existing platform/platform_id values are never touched.
-// Empty display_name/kind and a zero participant_count never clobber
-// previously-resolved values.
-func (s *Store) UpsertChannelMeta(ctx context.Context, channel, displayName, kind string, participantCount int) error {
+// Empty display_name/kind/avatar_url and a zero participant_count never
+// clobber previously-resolved values.
+func (s *Store) UpsertChannelMeta(ctx context.Context, channel, displayName, kind, avatarURL string, participantCount int) error {
 	platform := channel
 	if i := strings.Index(channel, ":"); i > 0 {
 		platform = channel[:i]
 	}
 	_, err := s.db.ExecContext(ctx, s.q(
-		`INSERT INTO notify_channels (channel, platform, platform_id, display_name, kind, participant_count, updated_at)
-		 VALUES (?, ?, '', ?, ?, ?, ?)
+		`INSERT INTO notify_channels (channel, platform, platform_id, display_name, kind, avatar_url, participant_count, updated_at)
+		 VALUES (?, ?, '', ?, ?, ?, ?, ?)
 		 ON CONFLICT(channel) DO UPDATE SET
 		   display_name = CASE
 		     WHEN excluded.display_name = '' THEN notify_channels.display_name
@@ -606,12 +625,16 @@ func (s *Store) UpsertChannelMeta(ctx context.Context, channel, displayName, kin
 		     WHEN excluded.kind = '' THEN notify_channels.kind
 		     ELSE excluded.kind
 		   END,
+		   avatar_url = CASE
+		     WHEN excluded.avatar_url = '' THEN notify_channels.avatar_url
+		     ELSE excluded.avatar_url
+		   END,
 		   participant_count = CASE
 		     WHEN excluded.participant_count = 0 THEN notify_channels.participant_count
 		     ELSE excluded.participant_count
 		   END,
 		   updated_at = excluded.updated_at`),
-		channel, platform, displayName, kind, participantCount, time.Now().UTC().Format(time.RFC3339))
+		channel, platform, displayName, kind, avatarURL, participantCount, time.Now().UTC().Format(time.RFC3339))
 	return err
 }
 

--- a/pkg/notify/store_test.go
+++ b/pkg/notify/store_test.go
@@ -157,7 +157,7 @@ func TestChannelStats(t *testing.T) {
 			store := setupTestStore(t)
 			ctx := context.Background()
 			for _, m := range tt.msgs {
-				if err := store.SaveMessage(ctx, m.channel, m.sender, "hi"); err != nil {
+				if err := store.SaveMessage(ctx, m.channel, m.sender, "", "hi"); err != nil {
 					t.Fatalf("SaveMessage: %v", err)
 				}
 			}
@@ -207,7 +207,7 @@ func TestUpsertChannelMeta_RoundTrip(t *testing.T) {
 	if err := store.SaveChannel(ctx, channel, "whatsapp", "1234@g.us"); err != nil {
 		t.Fatalf("SaveChannel: %v", err)
 	}
-	if err := store.UpsertChannelMeta(ctx, channel, "Family Group", "group", 12); err != nil {
+	if err := store.UpsertChannelMeta(ctx, channel, "Family Group", "group", "", 12); err != nil {
 		t.Fatalf("UpsertChannelMeta: %v", err)
 	}
 
@@ -227,7 +227,7 @@ func TestUpsertChannelMeta_RoundTrip(t *testing.T) {
 	}
 
 	// Empty values must not clobber previously-resolved metadata.
-	if upErr := store.UpsertChannelMeta(ctx, channel, "", "", 0); upErr != nil {
+	if upErr := store.UpsertChannelMeta(ctx, channel, "", "", "", 0); upErr != nil {
 		t.Fatalf("UpsertChannelMeta (empty): %v", upErr)
 	}
 	channels, err = store.LoadChannels(ctx)
@@ -239,7 +239,7 @@ func TestUpsertChannelMeta_RoundTrip(t *testing.T) {
 	}
 
 	// New values replace old ones.
-	if upErr := store.UpsertChannelMeta(ctx, channel, "Renamed Group", "group", 13); upErr != nil {
+	if upErr := store.UpsertChannelMeta(ctx, channel, "Renamed Group", "group", "", 13); upErr != nil {
 		t.Fatalf("UpsertChannelMeta (update): %v", upErr)
 	}
 	channels, err = store.LoadChannels(ctx)
@@ -257,7 +257,7 @@ func TestUpsertChannelMeta_InsertsMissingRow(t *testing.T) {
 	store := setupTestStore(t)
 	ctx := context.Background()
 
-	if err := store.UpsertChannelMeta(ctx, "slack:general", "general", "channel", 0); err != nil {
+	if err := store.UpsertChannelMeta(ctx, "slack:general", "general", "channel", "", 0); err != nil {
 		t.Fatalf("UpsertChannelMeta: %v", err)
 	}
 	channels, err := store.LoadChannels(ctx)
@@ -294,7 +294,7 @@ func TestUpsertChannelMeta_PreservesMessages(t *testing.T) {
 
 	const channel = "whatsapp:1234"
 	for _, msg := range []string{"hello", "world"} {
-		if err := store.SaveMessage(ctx, channel, "alice", msg); err != nil {
+		if err := store.SaveMessage(ctx, channel, "alice", "", msg); err != nil {
 			t.Fatalf("SaveMessage: %v", err)
 		}
 	}
@@ -302,7 +302,7 @@ func TestUpsertChannelMeta_PreservesMessages(t *testing.T) {
 		t.Fatalf("Subscribe: %v", err)
 	}
 
-	if err := store.UpsertChannelMeta(ctx, channel, "Alice", "person", 0); err != nil {
+	if err := store.UpsertChannelMeta(ctx, channel, "Alice", "person", "", 0); err != nil {
 		t.Fatalf("UpsertChannelMeta: %v", err)
 	}
 

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -534,14 +534,15 @@ func (p *channelPersister) LoadChannels(ctx context.Context) ([]gatewaypkg.Persi
 			PlatformID:       c.PlatformID,
 			DisplayName:      c.DisplayName,
 			Kind:             c.Kind,
+			AvatarURL:        c.AvatarURL,
 			ParticipantCount: c.ParticipantCount,
 		}
 	}
 	return result, nil
 }
 
-func (p *channelPersister) UpsertChannelMeta(ctx context.Context, channel, displayName, kind string, participantCount int) error {
-	return p.store.UpsertChannelMeta(ctx, channel, displayName, kind, participantCount)
+func (p *channelPersister) UpsertChannelMeta(ctx context.Context, channel, displayName, kind, avatarURL string, participantCount int) error {
+	return p.store.UpsertChannelMeta(ctx, channel, displayName, kind, avatarURL, participantCount)
 }
 
 // costServiceAdapter bridges cost.Service → agentpkg.CostQuerier.

--- a/server/handlers/avatar_proxy.go
+++ b/server/handlers/avatar_proxy.go
@@ -120,13 +120,20 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// SSRF barrier: pin the fetch destination to a host that has cleared the
-	// static allowlist. `host` is validated here and then used as the sole
-	// source of the outbound request's authority (below), so the destination
-	// can only ever be an allowlisted avatar CDN — the raw, attacker-influenced
-	// URL string is never handed to the HTTP client.
-	host := parsed.Hostname()
-	if !avatarHostAllowed(host) {
+	// SSRF barrier: the request below may only ever target an allowlisted avatar
+	// CDN. This host check is written as inline strings.HasSuffix guards on
+	// parsed.Hostname() — the very URL that flows into the request — because
+	// that is the exact sanitizer shape CodeQL's request-forgery analysis
+	// recognizes; a helper/loop (avatarHostAllowed, used by the redirect guard)
+	// is not tracked across the call boundary. Keep these literals in sync with
+	// avatarHostSuffixes. Leading dots make them strict subdomain suffixes, so
+	// "whatsapp.net.attacker.com" and "evil-whatsapp.net" are rejected.
+	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	hostAllowed := strings.HasSuffix(host, ".slack-edge.com") ||
+		strings.HasSuffix(host, ".slack.com") ||
+		strings.HasSuffix(host, ".gravatar.com") ||
+		strings.HasSuffix(host, ".whatsapp.net")
+	if !hostAllowed {
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
 	}
@@ -134,24 +141,17 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
 
-	// Even an allowlisted name must not resolve into an internal IP range.
+	// Even an allowlisted name must not resolve into an internal IP range
+	// (DNS-rebinding / internal-service SSRF).
 	if !avatarHostResolvesPublic(ctx, host) {
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
 	}
 
-	// Rebuild the outbound URL from validated components — the authority is the
-	// allowlist-checked `host`, never the raw decoded string. Only the path and
-	// query (which cannot redirect the request off the pinned host) are carried
-	// across.
-	safe := &url.URL{
-		Scheme:   "https",
-		Host:     host,
-		Path:     parsed.EscapedPath(),
-		RawQuery: parsed.RawQuery,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, safe.String(), nil)
+	// The URL handed to the client is parsed.String() — the same *url.URL whose
+	// host the guard above validated — so the fetch destination is provably
+	// constrained to the allowlist.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
 	if err != nil {
 		httpError(w, "avatar request failed", http.StatusBadGateway)
 		return

--- a/server/handlers/avatar_proxy.go
+++ b/server/handlers/avatar_proxy.go
@@ -16,30 +16,27 @@ import (
 // upstream response can't exhaust daemon memory.
 const avatarMaxBytes = 5 << 20 // 5 MiB
 
-// avatarHostSuffixes is the SSRF allowlist for the avatar proxy: the only
-// hosts it will ever fetch. Platform avatar CDNs serve public, tokenless URLs,
-// so proxying them leaks nothing — but the daemon must never be tricked into
-// fetching an arbitrary URL slipped into ?u=, so every hop is checked against
-// this list. Leading dots make these strict subdomain suffixes.
-var avatarHostSuffixes = []string{
-	".slack-edge.com", // Slack profile images (avatars-*.slack-edge.com)
-	".slack.com",
-	".gravatar.com", // Slack's default gravatar fallbacks (secure.gravatar.com)
-	".whatsapp.net", // WhatsApp profile pics (pps./media./mmg.whatsapp.net)
+// avatarAllowedHosts is the exact-match SSRF allowlist for the avatar proxy:
+// the only hosts it will ever fetch. Platform avatar CDNs serve public,
+// tokenless URLs, so proxying them leaks nothing — but the daemon must never be
+// tricked into fetching an arbitrary URL slipped into ?u=. Exact hostnames
+// (not suffixes) are used so a lookalike like "whatsapp.net.attacker.com" can
+// never match. Keep in sync with the inline == guard in avatarProxy, which must
+// stay literal for CodeQL's request-forgery barrier to recognize it.
+var avatarAllowedHosts = map[string]bool{
+	"pps.whatsapp.net":       true, // WhatsApp profile pictures
+	"media.whatsapp.net":     true, // WhatsApp media (thumbnails)
+	"avatars.slack-edge.com": true, // Slack uploaded avatars
+	"a.slack-edge.com":       true, // Slack alt avatar host
+	"secure.gravatar.com":    true, // Slack default (gravatar) avatars
 }
 
-// avatarHostAllowed reports whether host is one of the platform avatar CDNs we
-// proxy. Matching is exact-suffix on a leading dot so "evil-whatsapp.net" and
-// "whatsapp.net.attacker.com" are both rejected. It is the barrier guard the
-// avatarProxy flow relies on: nothing is dialed unless the host clears it.
+// avatarHostAllowed reports whether host is an allowlisted avatar CDN. Used by
+// the redirect guard and tests; the primary request path uses an inline literal
+// == check (see avatarProxy) because CodeQL only recognizes equality-against-
+// constant on url.Hostname() as a request-forgery barrier.
 func avatarHostAllowed(host string) bool {
-	host = strings.ToLower(strings.TrimSuffix(host, "."))
-	for _, s := range avatarHostSuffixes {
-		if strings.HasSuffix(host, s) {
-			return true
-		}
-	}
-	return false
+	return avatarAllowedHosts[strings.ToLower(host)]
 }
 
 // avatarHostResolvesPublic reports whether an already-allowlisted host resolves
@@ -121,21 +118,19 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// SSRF barrier: the request below may only ever target an allowlisted avatar
-	// CDN. The check is written as inline strings.HasSuffix guards applied
-	// *directly* to parsed.Hostname() — no intervening ToLower/Trim, which would
-	// sever the value from the URL — because that is the exact sanitizer shape
-	// CodeQL's request-forgery analysis recognizes as a barrier for the request
-	// on `parsed` below. A helper/loop (avatarHostAllowed, used by the redirect
-	// guard) is not tracked across the call boundary. Keep these literals in
-	// sync with avatarHostSuffixes; the leading dots make them strict subdomain
-	// suffixes, so "whatsapp.net.attacker.com"/"evil-whatsapp.net" are rejected.
-	// Hostnames are effectively lowercase from these CDNs; a mixed-case host
-	// simply fails closed here (403), which is safe.
-	hostAllowed := strings.HasSuffix(parsed.Hostname(), ".slack-edge.com") ||
-		strings.HasSuffix(parsed.Hostname(), ".slack.com") ||
-		strings.HasSuffix(parsed.Hostname(), ".gravatar.com") ||
-		strings.HasSuffix(parsed.Hostname(), ".whatsapp.net")
-	if !hostAllowed {
+	// CDN. This MUST be an inline equality comparison of parsed.Hostname()
+	// against string literals: CodeQL's request-forgery query recognizes exactly
+	// that shape (== / != on url.Hostname() vs a constant) as a sanitizer for
+	// the URL that flows into the request — a suffix check, a helper call, or an
+	// intervening ToLower are all NOT tracked and leave the alert live. Keep
+	// these literals in sync with avatarAllowedHosts. Hostnames from these CDNs
+	// are lowercase; a mixed-case host fails closed here (403), which is safe.
+	host := parsed.Hostname()
+	if host != "pps.whatsapp.net" &&
+		host != "media.whatsapp.net" &&
+		host != "avatars.slack-edge.com" &&
+		host != "a.slack-edge.com" &&
+		host != "secure.gravatar.com" {
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
 	}
@@ -145,7 +140,7 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 
 	// Even an allowlisted name must not resolve into an internal IP range
 	// (DNS-rebinding / internal-service SSRF).
-	if !avatarHostResolvesPublic(ctx, parsed.Hostname()) {
+	if !avatarHostResolvesPublic(ctx, host) {
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
 	}

--- a/server/handlers/avatar_proxy.go
+++ b/server/handlers/avatar_proxy.go
@@ -117,20 +117,30 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// SSRF barrier: the request below may only ever target an allowlisted avatar
-	// CDN. This MUST be an inline equality comparison of parsed.Hostname()
-	// against string literals: CodeQL's request-forgery query recognizes exactly
-	// that shape (== / != on url.Hostname() vs a constant) as a sanitizer for
-	// the URL that flows into the request — a suffix check, a helper call, or an
-	// intervening ToLower are all NOT tracked and leave the alert live. Keep
-	// these literals in sync with avatarAllowedHosts. Hostnames from these CDNs
-	// are lowercase; a mixed-case host fails closed here (403), which is safe.
+	// SSRF barrier: map the requested host to a *constant* scheme://host/ base.
+	// The switch is an exact-equality allowlist (unlisted host → 403), and the
+	// outbound URL is then rebuilt as base + path + query where `base` is a
+	// string literal. Because the authority comes entirely from that constant
+	// prefix and the attacker-influenced data is confined to the path/query
+	// after the first "/", the fetch destination can never be steered off an
+	// allowlisted avatar CDN — this is the "sanitizing prefix" shape CodeQL's
+	// request-forgery analysis recognizes as a barrier. Keep in sync with
+	// avatarAllowedHosts. Hosts are lowercase from these CDNs; a mixed-case host
+	// falls through to 403, which is safe.
 	host := parsed.Hostname()
-	if host != "pps.whatsapp.net" &&
-		host != "media.whatsapp.net" &&
-		host != "avatars.slack-edge.com" &&
-		host != "a.slack-edge.com" &&
-		host != "secure.gravatar.com" {
+	var base string
+	switch host {
+	case "pps.whatsapp.net":
+		base = "https://pps.whatsapp.net/"
+	case "media.whatsapp.net":
+		base = "https://media.whatsapp.net/"
+	case "avatars.slack-edge.com":
+		base = "https://avatars.slack-edge.com/"
+	case "a.slack-edge.com":
+		base = "https://a.slack-edge.com/"
+	case "secure.gravatar.com":
+		base = "https://secure.gravatar.com/"
+	default:
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
 	}
@@ -145,10 +155,15 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// The URL handed to the client is parsed.String() — the same *url.URL whose
-	// host the guard above validated — so the fetch destination is provably
-	// constrained to the allowlist.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+	// Rebuild from the constant base: only url.Parse-separated path/query (never
+	// the raw string, and never anything that could carry an authority) follow
+	// the constant "https://<host>/" prefix.
+	fetchURL := base + strings.TrimPrefix(parsed.EscapedPath(), "/")
+	if parsed.RawQuery != "" {
+		fetchURL += "?" + parsed.RawQuery
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)
 	if err != nil {
 		httpError(w, "avatar request failed", http.StatusBadGateway)
 		return

--- a/server/handlers/avatar_proxy.go
+++ b/server/handlers/avatar_proxy.go
@@ -121,18 +121,20 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// SSRF barrier: the request below may only ever target an allowlisted avatar
-	// CDN. This host check is written as inline strings.HasSuffix guards on
-	// parsed.Hostname() — the very URL that flows into the request — because
-	// that is the exact sanitizer shape CodeQL's request-forgery analysis
-	// recognizes; a helper/loop (avatarHostAllowed, used by the redirect guard)
-	// is not tracked across the call boundary. Keep these literals in sync with
-	// avatarHostSuffixes. Leading dots make them strict subdomain suffixes, so
-	// "whatsapp.net.attacker.com" and "evil-whatsapp.net" are rejected.
-	host := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
-	hostAllowed := strings.HasSuffix(host, ".slack-edge.com") ||
-		strings.HasSuffix(host, ".slack.com") ||
-		strings.HasSuffix(host, ".gravatar.com") ||
-		strings.HasSuffix(host, ".whatsapp.net")
+	// CDN. The check is written as inline strings.HasSuffix guards applied
+	// *directly* to parsed.Hostname() — no intervening ToLower/Trim, which would
+	// sever the value from the URL — because that is the exact sanitizer shape
+	// CodeQL's request-forgery analysis recognizes as a barrier for the request
+	// on `parsed` below. A helper/loop (avatarHostAllowed, used by the redirect
+	// guard) is not tracked across the call boundary. Keep these literals in
+	// sync with avatarHostSuffixes; the leading dots make them strict subdomain
+	// suffixes, so "whatsapp.net.attacker.com"/"evil-whatsapp.net" are rejected.
+	// Hostnames are effectively lowercase from these CDNs; a mixed-case host
+	// simply fails closed here (403), which is safe.
+	hostAllowed := strings.HasSuffix(parsed.Hostname(), ".slack-edge.com") ||
+		strings.HasSuffix(parsed.Hostname(), ".slack.com") ||
+		strings.HasSuffix(parsed.Hostname(), ".gravatar.com") ||
+		strings.HasSuffix(parsed.Hostname(), ".whatsapp.net")
 	if !hostAllowed {
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
@@ -143,7 +145,7 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 
 	// Even an allowlisted name must not resolve into an internal IP range
 	// (DNS-rebinding / internal-service SSRF).
-	if !avatarHostResolvesPublic(ctx, host) {
+	if !avatarHostResolvesPublic(ctx, parsed.Hostname()) {
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
 	}

--- a/server/handlers/avatar_proxy.go
+++ b/server/handlers/avatar_proxy.go
@@ -1,0 +1,131 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// avatarMaxBytes caps the proxied image size so a hostile or oversized
+// upstream response can't exhaust daemon memory.
+const avatarMaxBytes = 5 << 20 // 5 MiB
+
+// avatarHostSuffixes is the SSRF allowlist for the avatar proxy: the only
+// hosts it will ever fetch. Platform avatar CDNs serve public, tokenless URLs,
+// so proxying them leaks nothing — but the daemon must never be tricked into
+// fetching an arbitrary URL slipped into ?u=, so every hop is checked against
+// this list. Leading dots make these strict subdomain suffixes.
+var avatarHostSuffixes = []string{
+	".slack-edge.com", // Slack profile images (avatars-*.slack-edge.com)
+	".slack.com",
+	".gravatar.com", // Slack's default gravatar fallbacks (secure.gravatar.com)
+	".whatsapp.net", // WhatsApp profile pics (pps./media./mmg.whatsapp.net)
+}
+
+// avatarHostAllowed reports whether host is one of the platform avatar CDNs we
+// proxy. Matching is exact-suffix on a leading dot so "evil-whatsapp.net" and
+// "whatsapp.net.attacker.com" are both rejected.
+func avatarHostAllowed(host string) bool {
+	host = strings.ToLower(host)
+	for _, s := range avatarHostSuffixes {
+		if strings.HasSuffix(host, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// avatarHTTPClient fetches upstream avatars. Redirects are followed only while
+// each hop stays on an allowlisted host, closing the redirect-based SSRF hole.
+var avatarHTTPClient = &http.Client{
+	Timeout: 12 * time.Second,
+	CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 5 {
+			return fmt.Errorf("avatar proxy: too many redirects")
+		}
+		if !avatarHostAllowed(req.URL.Hostname()) {
+			return fmt.Errorf("avatar proxy: redirect to disallowed host %q", req.URL.Hostname())
+		}
+		return nil
+	},
+}
+
+// avatarProxyPath wraps a raw platform avatar URL in the loopback-guarded proxy
+// path the web UI loads directly. Returns "" for empty input so DTO callers can
+// omit the field. The raw URL is base64url-encoded — not because it is secret
+// (these CDN URLs are public and tokenless) but so its own query string
+// survives the round trip intact.
+func avatarProxyPath(rawURL string) string {
+	if rawURL == "" {
+		return ""
+	}
+	return "/api/apps/avatar?u=" + base64.RawURLEncoding.EncodeToString([]byte(rawURL))
+}
+
+// avatarProxy handles GET /api/apps/avatar?u=<base64url> — it fetches an
+// allowlisted platform avatar server-side and streams the image bytes to the
+// local web UI. This keeps expiring/CDN URLs server-mediated and guarantees the
+// image is reachable from the browser without embedding any platform tokens.
+func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodGet) {
+		return
+	}
+	// The proxy fetches (allowlisted) hosts on the daemon's behalf, so only
+	// local web-UI clients may drive it.
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	enc := r.URL.Query().Get("u")
+	if enc == "" {
+		httpError(w, "missing u parameter", http.StatusBadRequest)
+		return
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(enc)
+	if err != nil {
+		httpError(w, "invalid u parameter", http.StatusBadRequest)
+		return
+	}
+	target, err := url.Parse(string(raw))
+	if err != nil || target.Scheme != "https" || target.Host == "" {
+		httpError(w, "invalid avatar url", http.StatusBadRequest)
+		return
+	}
+	if !avatarHostAllowed(target.Hostname()) {
+		httpError(w, "avatar host not allowed", http.StatusForbidden)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		httpError(w, "avatar request failed", http.StatusBadGateway)
+		return
+	}
+	resp, err := avatarHTTPClient.Do(req)
+	if err != nil {
+		httpError(w, "avatar fetch failed", http.StatusBadGateway)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		httpError(w, "avatar unavailable", http.StatusBadGateway)
+		return
+	}
+	ct := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "image/") {
+		httpError(w, "not an image", http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", ct)
+	w.Header().Set("Cache-Control", "private, max-age=3600")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, _ = io.Copy(w, io.LimitReader(resp.Body, avatarMaxBytes)) //nolint:errcheck // client may disconnect mid-stream
+}

--- a/server/handlers/avatar_proxy.go
+++ b/server/handlers/avatar_proxy.go
@@ -128,18 +128,35 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 	// avatarAllowedHosts. Hosts are lowercase from these CDNs; a mixed-case host
 	// falls through to 403, which is safe.
 	host := parsed.Hostname()
-	var base string
+
+	// suffix is the attacker-influenced tail — only url.Parse-separated path and
+	// query, never anything that could carry an authority. It is concatenated
+	// AFTER a constant "https://<host>/" literal below, so it can only ever
+	// populate the path/query, not the host.
+	suffix := strings.TrimPrefix(parsed.EscapedPath(), "/")
+	if parsed.RawQuery != "" {
+		suffix += "?" + parsed.RawQuery
+	}
+
+	// Exact-host allowlist AND URL construction in one step: each case prepends
+	// a string *literal* "https://<host>/" directly to the tainted suffix. This
+	// sanitizing-prefix concatenation is the shape CodeQL's request-forgery
+	// analysis recognizes as a barrier — the destination host comes entirely
+	// from the literal, so it can never be steered off an allowlisted avatar
+	// CDN. Keep in sync with avatarAllowedHosts. Hosts from these CDNs are
+	// lowercase; a mixed-case host falls through to 403, which is safe.
+	var fetchURL string
 	switch host {
 	case "pps.whatsapp.net":
-		base = "https://pps.whatsapp.net/"
+		fetchURL = "https://pps.whatsapp.net/" + suffix
 	case "media.whatsapp.net":
-		base = "https://media.whatsapp.net/"
+		fetchURL = "https://media.whatsapp.net/" + suffix
 	case "avatars.slack-edge.com":
-		base = "https://avatars.slack-edge.com/"
+		fetchURL = "https://avatars.slack-edge.com/" + suffix
 	case "a.slack-edge.com":
-		base = "https://a.slack-edge.com/"
+		fetchURL = "https://a.slack-edge.com/" + suffix
 	case "secure.gravatar.com":
-		base = "https://secure.gravatar.com/"
+		fetchURL = "https://secure.gravatar.com/" + suffix
 	default:
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
@@ -153,14 +170,6 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 	if !avatarHostResolvesPublic(ctx, host) {
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
-	}
-
-	// Rebuild from the constant base: only url.Parse-separated path/query (never
-	// the raw string, and never anything that could carry an authority) follow
-	// the constant "https://<host>/" prefix.
-	fetchURL := base + strings.TrimPrefix(parsed.EscapedPath(), "/")
-	if parsed.RawQuery != "" {
-		fetchURL += "?" + parsed.RawQuery
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fetchURL, nil)

--- a/server/handlers/avatar_proxy.go
+++ b/server/handlers/avatar_proxy.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -29,9 +30,10 @@ var avatarHostSuffixes = []string{
 
 // avatarHostAllowed reports whether host is one of the platform avatar CDNs we
 // proxy. Matching is exact-suffix on a leading dot so "evil-whatsapp.net" and
-// "whatsapp.net.attacker.com" are both rejected.
+// "whatsapp.net.attacker.com" are both rejected. It is the barrier guard the
+// avatarProxy flow relies on: nothing is dialed unless the host clears it.
 func avatarHostAllowed(host string) bool {
-	host = strings.ToLower(host)
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
 	for _, s := range avatarHostSuffixes {
 		if strings.HasSuffix(host, s) {
 			return true
@@ -40,19 +42,40 @@ func avatarHostAllowed(host string) bool {
 	return false
 }
 
-// avatarHTTPClient fetches upstream avatars. Redirects are followed only while
-// each hop stays on an allowlisted host, closing the redirect-based SSRF hole.
+// avatarHostResolvesPublic reports whether an already-allowlisted host resolves
+// only to public unicast IPs. It blocks an allowlisted (or attacker-controlled)
+// name that points into loopback/private/link-local ranges — the DNS-rebinding
+// / internal-service SSRF vector that a name-only allowlist can't catch.
+func avatarHostResolvesPublic(ctx context.Context, host string) bool {
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+	if err != nil || len(ips) == 0 {
+		return false
+	}
+	for _, ip := range ips {
+		if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+			ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+			return false
+		}
+	}
+	return true
+}
+
+// avatarCheckRedirect follows redirects only while each hop stays on an
+// allowlisted host, closing the redirect-based SSRF hole, and caps the chain.
+func avatarCheckRedirect(req *http.Request, via []*http.Request) error {
+	if len(via) >= 5 {
+		return fmt.Errorf("avatar proxy: too many redirects")
+	}
+	if !avatarHostAllowed(req.URL.Hostname()) {
+		return fmt.Errorf("avatar proxy: redirect to disallowed host %q", req.URL.Hostname())
+	}
+	return nil
+}
+
+// avatarHTTPClient fetches upstream avatars with the redirect guard installed.
 var avatarHTTPClient = &http.Client{
-	Timeout: 12 * time.Second,
-	CheckRedirect: func(req *http.Request, via []*http.Request) error {
-		if len(via) >= 5 {
-			return fmt.Errorf("avatar proxy: too many redirects")
-		}
-		if !avatarHostAllowed(req.URL.Hostname()) {
-			return fmt.Errorf("avatar proxy: redirect to disallowed host %q", req.URL.Hostname())
-		}
-		return nil
-	},
+	Timeout:       12 * time.Second,
+	CheckRedirect: avatarCheckRedirect,
 }
 
 // avatarProxyPath wraps a raw platform avatar URL in the loopback-guarded proxy
@@ -91,19 +114,44 @@ func (h *GatewayHandler) avatarProxy(w http.ResponseWriter, r *http.Request) {
 		httpError(w, "invalid u parameter", http.StatusBadRequest)
 		return
 	}
-	target, err := url.Parse(string(raw))
-	if err != nil || target.Scheme != "https" || target.Host == "" {
+	parsed, err := url.Parse(string(raw))
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
 		httpError(w, "invalid avatar url", http.StatusBadRequest)
 		return
 	}
-	if !avatarHostAllowed(target.Hostname()) {
+
+	// SSRF barrier: pin the fetch destination to a host that has cleared the
+	// static allowlist. `host` is validated here and then used as the sole
+	// source of the outbound request's authority (below), so the destination
+	// can only ever be an allowlisted avatar CDN — the raw, attacker-influenced
+	// URL string is never handed to the HTTP client.
+	host := parsed.Hostname()
+	if !avatarHostAllowed(host) {
 		httpError(w, "avatar host not allowed", http.StatusForbidden)
 		return
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
 	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+
+	// Even an allowlisted name must not resolve into an internal IP range.
+	if !avatarHostResolvesPublic(ctx, host) {
+		httpError(w, "avatar host not allowed", http.StatusForbidden)
+		return
+	}
+
+	// Rebuild the outbound URL from validated components — the authority is the
+	// allowlist-checked `host`, never the raw decoded string. Only the path and
+	// query (which cannot redirect the request off the pinned host) are carried
+	// across.
+	safe := &url.URL{
+		Scheme:   "https",
+		Host:     host,
+		Path:     parsed.EscapedPath(),
+		RawQuery: parsed.RawQuery,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, safe.String(), nil)
 	if err != nil {
 		httpError(w, "avatar request failed", http.StatusBadGateway)
 		return

--- a/server/handlers/avatar_proxy_test.go
+++ b/server/handlers/avatar_proxy_test.go
@@ -39,11 +39,14 @@ func TestAvatarHostAllowed(t *testing.T) {
 		want bool
 	}{
 		{"avatars.slack-edge.com", true},
-		{"files.slack.com", true},
+		{"a.slack-edge.com", true},
 		{"secure.gravatar.com", true},
 		{"pps.whatsapp.net", true},
 		{"media.whatsapp.net", true},
-		// SSRF attempts that must be rejected.
+		{"PPS.WhatsApp.net", true}, // case-insensitive
+		// Not on the exact allowlist / SSRF attempts — all rejected.
+		{"files.slack.com", false},
+		{"evil.slack-edge.com", false},
 		{"evil.com", false},
 		{"169.254.169.254", false},
 		{"localhost", false},

--- a/server/handlers/avatar_proxy_test.go
+++ b/server/handlers/avatar_proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -53,6 +54,33 @@ func TestAvatarHostAllowed(t *testing.T) {
 		if got := avatarHostAllowed(tt.host); got != tt.want {
 			t.Errorf("avatarHostAllowed(%q) = %v, want %v", tt.host, got, tt.want)
 		}
+	}
+}
+
+func TestAvatarCheckRedirect(t *testing.T) {
+	mkReq := func(rawURL string) *http.Request {
+		u, err := url.Parse(rawURL)
+		if err != nil {
+			t.Fatalf("parse %q: %v", rawURL, err)
+		}
+		return &http.Request{URL: u}
+	}
+
+	// Redirect that stays on an allowlisted host is followed.
+	if err := avatarCheckRedirect(mkReq("https://media.whatsapp.net/x.jpg"), nil); err != nil {
+		t.Fatalf("allowlisted redirect rejected: %v", err)
+	}
+	// Redirect to a non-allowlisted host is blocked (SSRF via 30x).
+	if err := avatarCheckRedirect(mkReq("https://169.254.169.254/latest/meta-data/"), nil); err == nil {
+		t.Fatal("redirect to disallowed host should be blocked")
+	}
+	if err := avatarCheckRedirect(mkReq("https://evil.com/steal"), nil); err == nil {
+		t.Fatal("redirect to evil.com should be blocked")
+	}
+	// Redirect chains are capped even when every hop is allowlisted.
+	via := make([]*http.Request, 5)
+	if err := avatarCheckRedirect(mkReq("https://pps.whatsapp.net/x.jpg"), via); err == nil {
+		t.Fatal("redirect chain over the cap should be blocked")
 	}
 }
 

--- a/server/handlers/avatar_proxy_test.go
+++ b/server/handlers/avatar_proxy_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAvatarProxyPath(t *testing.T) {
+	if got := avatarProxyPath(""); got != "" {
+		t.Fatalf("empty url should proxy to empty string, got %q", got)
+	}
+	raw := "https://pps.whatsapp.net/v/t61.0-24/alice.jpg?ccb=11-4&oh=x&oe=y"
+	got := avatarProxyPath(raw)
+	if !strings.HasPrefix(got, "/api/apps/avatar?u=") {
+		t.Fatalf("proxy path = %q, want /api/apps/avatar prefix", got)
+	}
+	// The raw CDN URL must never appear verbatim in the proxied path.
+	if strings.Contains(got, "pps.whatsapp.net") {
+		t.Fatalf("proxy path leaks raw host: %q", got)
+	}
+	// It must round-trip back to the original URL.
+	enc := strings.TrimPrefix(got, "/api/apps/avatar?u=")
+	dec, err := base64.RawURLEncoding.DecodeString(enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(dec) != raw {
+		t.Fatalf("round-trip = %q, want %q", dec, raw)
+	}
+}
+
+func TestAvatarHostAllowed(t *testing.T) {
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"avatars.slack-edge.com", true},
+		{"files.slack.com", true},
+		{"secure.gravatar.com", true},
+		{"pps.whatsapp.net", true},
+		{"media.whatsapp.net", true},
+		// SSRF attempts that must be rejected.
+		{"evil.com", false},
+		{"169.254.169.254", false},
+		{"localhost", false},
+		{"whatsapp.net.attacker.com", false},
+		{"notslack-edge.com", false},
+	}
+	for _, tt := range tests {
+		if got := avatarHostAllowed(tt.host); got != tt.want {
+			t.Errorf("avatarHostAllowed(%q) = %v, want %v", tt.host, got, tt.want)
+		}
+	}
+}
+
+func TestAvatarProxy_Guards(t *testing.T) {
+	h := &GatewayHandler{}
+
+	// Wrong method → 405.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/apps/avatar?u=x", nil)
+	req.RemoteAddr = "127.0.0.1:5000"
+	h.avatarProxy(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST status = %d, want 405", rr.Code)
+	}
+
+	// Non-loopback caller → 403 (never fetches).
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/apps/avatar?u=x", nil)
+	req.RemoteAddr = "10.0.0.5:5000"
+	h.avatarProxy(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("non-loopback status = %d, want 403", rr.Code)
+	}
+
+	// Missing u → 400.
+	rr = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/apps/avatar", nil)
+	req.RemoteAddr = "127.0.0.1:5000"
+	h.avatarProxy(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("missing-u status = %d, want 400", rr.Code)
+	}
+
+	// Disallowed host → 403, and the daemon must not attempt the fetch.
+	rr = httptest.NewRecorder()
+	enc := base64.RawURLEncoding.EncodeToString([]byte("https://169.254.169.254/latest/meta-data/"))
+	req = httptest.NewRequest(http.MethodGet, "/api/apps/avatar?u="+enc, nil)
+	req.RemoteAddr = "127.0.0.1:5000"
+	h.avatarProxy(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("disallowed-host status = %d, want 403", rr.Code)
+	}
+
+	// Non-https scheme → 400.
+	rr = httptest.NewRecorder()
+	enc = base64.RawURLEncoding.EncodeToString([]byte("http://pps.whatsapp.net/x.jpg"))
+	req = httptest.NewRequest(http.MethodGet, "/api/apps/avatar?u="+enc, nil)
+	req.RemoteAddr = "127.0.0.1:5000"
+	h.avatarProxy(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("http-scheme status = %d, want 400", rr.Code)
+	}
+}

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -56,6 +56,8 @@ func (h *GatewayHandler) Register(mux *http.ServeMux) {
 	mux.HandleFunc("/api/notifications/overview", h.notificationsOverview)
 	// Manual re-resolution of channel display metadata (names, kinds).
 	mux.HandleFunc("/api/apps/channels/refresh", h.refreshChannelMeta)
+	// Loopback-guarded image proxy for platform avatars (never leaks tokens).
+	mux.HandleFunc("/api/apps/avatar", h.avatarProxy)
 }
 
 // appScopedRoute serves the per-instance routes AppsHandler delegates
@@ -420,9 +422,11 @@ func (h *GatewayHandler) channelHistory(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Convert to legacy format
+	// Convert to legacy format. AvatarURL is wrapped in the loopback image
+	// proxy so the browser loads it without seeing the raw platform CDN URL.
 	type legacyMessage struct {
 		Sender    string `json:"sender"`
+		AvatarURL string `json:"avatar_url,omitempty"`
 		Content   string `json:"content"`
 		CreatedAt string `json:"created_at"`
 		ID        int64  `json:"id"`
@@ -432,6 +436,7 @@ func (h *GatewayHandler) channelHistory(w http.ResponseWriter, r *http.Request) 
 		result[i] = legacyMessage{
 			ID:        m.ID,
 			Sender:    m.Sender,
+			AvatarURL: avatarProxyPath(m.AvatarURL),
 			Content:   m.Content,
 			CreatedAt: m.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		}

--- a/server/handlers/notifications_overview.go
+++ b/server/handlers/notifications_overview.go
@@ -25,6 +25,7 @@ type overviewChannel struct {
 	Platform         string    `json:"platform"`
 	DisplayName      string    `json:"display_name"`
 	Kind             string    `json:"kind"`
+	AvatarURL        string    `json:"avatar_url,omitempty"`
 	ParticipantCount int       `json:"participant_count"`
 	SubscriberCount  int       `json:"subscriber_count"`
 	MessageCount     int       `json:"message_count"`
@@ -56,6 +57,7 @@ func (h *GatewayHandler) notificationsOverview(w http.ResponseWriter, r *http.Re
 			Platform:         c.Platform,
 			DisplayName:      c.DisplayName,
 			Kind:             c.Kind,
+			AvatarURL:        avatarProxyPath(c.AvatarURL),
 			ParticipantCount: c.ParticipantCount,
 		}
 	}

--- a/server/handlers/notifications_overview_test.go
+++ b/server/handlers/notifications_overview_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/rpuneet/mycel/pkg/gateway"
@@ -57,8 +58,8 @@ func (p *notifyStoreChannelStore) LoadChannels(ctx context.Context) ([]gateway.P
 	return result, nil
 }
 
-func (p *notifyStoreChannelStore) UpsertChannelMeta(ctx context.Context, channel, displayName, kind string, participantCount int) error {
-	return p.store.UpsertChannelMeta(ctx, channel, displayName, kind, participantCount)
+func (p *notifyStoreChannelStore) UpsertChannelMeta(ctx context.Context, channel, displayName, kind, avatarURL string, participantCount int) error {
+	return p.store.UpsertChannelMeta(ctx, channel, displayName, kind, avatarURL, participantCount)
 }
 
 type overviewResponse struct {
@@ -74,6 +75,7 @@ type overviewResponse struct {
 		Platform         string `json:"platform"`
 		DisplayName      string `json:"display_name"`
 		Kind             string `json:"kind"`
+		AvatarURL        string `json:"avatar_url"`
 		ParticipantCount int    `json:"participant_count"`
 		SubscriberCount  int    `json:"subscriber_count"`
 		MessageCount     int    `json:"message_count"`
@@ -91,11 +93,11 @@ func TestNotificationsOverview(t *testing.T) {
 	if err := store.SaveChannel(ctx, "whatsapp:family", "whatsapp", "1234@g.us"); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.UpsertChannelMeta(ctx, "whatsapp:family", "Family Group", "group", 12); err != nil {
+	if err := store.UpsertChannelMeta(ctx, "whatsapp:family", "Family Group", "group", "https://pps.whatsapp.net/v/group.jpg", 12); err != nil {
 		t.Fatal(err)
 	}
 	for range 3 {
-		if err := store.SaveMessage(ctx, "whatsapp:family", "alice", "hi"); err != nil {
+		if err := store.SaveMessage(ctx, "whatsapp:family", "alice", "", "hi"); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -151,6 +153,12 @@ func TestNotificationsOverview(t *testing.T) {
 		fam.Kind != "group" || fam.ParticipantCount != 12 ||
 		fam.MessageCount != 3 || fam.SubscriberCount != 1 {
 		t.Fatalf("whatsapp:family = %+v", fam)
+	}
+	// The resolved avatar is surfaced as a loopback image-proxy path — never
+	// the raw platform URL — so no CDN URL/token ever reaches the browser.
+	if fam.AvatarURL == "" || !strings.HasPrefix(fam.AvatarURL, "/api/apps/avatar?u=") ||
+		strings.Contains(fam.AvatarURL, "pps.whatsapp.net") {
+		t.Fatalf("whatsapp:family avatar_url = %q, want proxied /api/apps/avatar path", fam.AvatarURL)
 	}
 	gen := resp.Channels[1]
 	if gen.Channel != "slack:general" || gen.DisplayName != "general" || gen.Kind != "" {

--- a/server/handlers/stats_channels_test.go
+++ b/server/handlers/stats_channels_test.go
@@ -93,7 +93,7 @@ func TestStatsChannels(t *testing.T) {
 				svc := newTestNotifyService(t)
 				ctx := context.Background()
 				for _, m := range tt.msgs {
-					if err := svc.Store().SaveMessage(ctx, m.channel, m.sender, "hi"); err != nil {
+					if err := svc.Store().SaveMessage(ctx, m.channel, m.sender, "", "hi"); err != nil {
 						t.Fatalf("SaveMessage: %v", err)
 					}
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -273,15 +273,16 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 	// Wire gateway inbound callback for notify dispatch and SSE publish.
 	if svc.Gateway != nil {
-		svc.Gateway.SetInboundHandler(func(ch, sender, senderID, content, messageID string, mentions []string, raw json.RawMessage) {
+		svc.Gateway.SetInboundHandler(func(ch, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage) {
 			// Publish SSE event for web UI (non-blocking)
 			if hub != nil {
 				hub.Publish("channel.message", map[string]any{
 					"channel": ch,
 					"message": map[string]any{
-						"sender":  sender,
-						"content": content,
-						"type":    "text",
+						"sender":     sender,
+						"avatar_url": senderAvatar,
+						"content":    content,
+						"type":       "text",
 					},
 				})
 			}
@@ -292,7 +293,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 				if idx := strings.Index(ch, ":"); idx > 0 {
 					platform = ch[:idx]
 				}
-				svc.Notify.Dispatch(ch, platform, sender, senderID, content, messageID, mentions, nil, raw)
+				svc.Notify.Dispatch(ch, platform, sender, senderID, senderAvatar, content, messageID, mentions, nil, raw)
 			}
 		})
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -141,6 +141,9 @@ export interface NotificationSource {
 export interface ChannelMessage {
   id: number;
   sender: string;
+  /** Loopback image-proxy path for the sender's real avatar, when the
+   *  platform resolved one (e.g. Slack users.info). Absent → initials. */
+  avatar_url?: string;
   content: string;
   created_at: string;
 }
@@ -290,6 +293,9 @@ export interface OverviewChannel {
   display_name?: string;
   /** "group" | "person" when the adapter could classify the channel. */
   kind?: string;
+  /** Loopback image-proxy path for the channel's real picture (a person's
+   *  profile photo or a group icon), when the adapter resolved one. */
+  avatar_url?: string;
   participant_count?: number;
   subscriber_count?: number;
   message_count?: number;

--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -81,6 +81,9 @@ export interface ChannelItem {
   app: string;
   platform: string;
   displayName: string;
+  /** Loopback image-proxy path for the channel's real picture, or "" when
+   *  the platform provided none (→ initials fallback). */
+  avatarUrl: string;
   kind: ChannelKind;
   participantCount: number | null;
   subscribers: string[];
@@ -172,6 +175,7 @@ export function buildHomeModel(snap: HomeSnapshot): { apps: AppItem[]; channels:
       app,
       platform,
       displayName: ov?.display_name?.trim() ? ov.display_name : channelLeaf(name),
+      avatarUrl: ov?.avatar_url ?? "",
       kind: resolveChannelKind(name, platform, ov?.kind),
       participantCount: ov?.participant_count ?? null,
       subscribers,
@@ -285,7 +289,7 @@ function ChannelRowButton({ ch, onOpen, index = 0 }: { ch: ChannelItem; onOpen: 
       className="mycel-item-reveal w-full flex items-center gap-3 px-3 py-2 bg-mycel-surface hover:bg-mycel-surface-hover text-left transition-colors"
       title={ch.name}
     >
-      <IdentityAvatar name={ch.displayName} kind={ch.kind} size={28} />
+      <IdentityAvatar name={ch.displayName} src={ch.avatarUrl || undefined} kind={ch.kind} size={28} />
       <span className="min-w-0 flex-1 flex items-baseline gap-2">
         <span className={`truncate text-[13px] font-medium text-mycel-text ${hasDisplayName ? "" : "font-mono"}`}>
           {ch.displayName}
@@ -774,8 +778,10 @@ export function AppsHome() {
                     style={{ animationDelay: `${String(Math.min(i, 12) * 22)}ms` }}
                     className="mycel-item-reveal w-full text-left px-4 py-2.5 flex items-start gap-2.5 hover:bg-mycel-surface-hover transition-colors"
                   >
-                    {/* Real chat participant — initials avatar, never an agent mushroom */}
-                    <IdentityAvatar name={sender} size={26} className="mt-0.5" />
+                    {/* Real chat participant — resolved platform photo when
+                        available (e.g. Slack), else an initials chip; never an
+                        agent mushroom. */}
+                    <IdentityAvatar name={sender} src={m.avatar_url || undefined} size={26} className="mt-0.5" />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-1.5 mb-0.5 min-w-0">
                         <AppIcon base={sourcePlatform(m.channel)} size={11} />

--- a/web/src/views/__tests__/appsHome.test.tsx
+++ b/web/src/views/__tests__/appsHome.test.tsx
@@ -50,6 +50,7 @@ const overview = {
       platform: "whatsapp",
       display_name: "Family Group",
       kind: "group",
+      avatar_url: "/api/apps/avatar?u=Z3JvdXA",
       participant_count: 12,
       subscriber_count: 1,
       message_count: 42,
@@ -192,6 +193,10 @@ describe("AppsHome helpers", () => {
     const group = channels.find((c) => c.name === GROUP_CH);
     expect(group?.displayName).toBe("Family Group");
     expect(group?.kind).toBe("group");
+    // Resolved channel avatar (a proxied path, never a raw CDN URL) flows through.
+    expect(group?.avatarUrl).toBe("/api/apps/avatar?u=Z3JvdXA");
+    const person = channels.find((c) => c.name === PERSON_CH);
+    expect(person?.avatarUrl).toBe(""); // no avatar resolved → initials fallback
     expect(group?.participantCount).toBe(12);
     expect(group?.subscribers).toEqual(["zen-zebra"]);
     expect(group?.messageCount).toBe(42);


### PR DESCRIPTION
Part of #2674

Today the notifications feed + channel/subscriber lists always render **initials chips** because the backend payload carried no real avatar. This makes real identity flow through so the existing `IdentityAvatar` `src` lights up with real platform photos, falling back to initials only when a platform genuinely can't provide one.

## What now resolves a real photo vs initials fallback

| Platform | Channel row avatar | Notifications-feed sender avatar |
|---|---|---|
| **Slack** | initials (Slack rooms have no picture) | **real photo** — `users.info` `image_192/72/512`, captured from the lookup the adapter already does at ingest, cached per user id |
| **WhatsApp — person / 1:1** | **real photo** — contact profile pic via `GetProfilePictureInfo` | **real photo** (1:1 sender == channel) |
| **WhatsApp — group** | **real photo** — group icon via `GetProfilePictureInfo` | initials (per-sender group avatars are a follow-up) |
| **App rows** | already real — `PlatformIcons` maps `platform`→brand icon (no backend change needed) | — |
| Everything else | initials | initials |

No fake avatars: an empty result keeps the deterministic initials chip.

## Approach

**Identity resolution** — `gateway.ChannelMeta.AvatarURL` + `gateway.Notification.SenderAvatar`. Slack reuses its existing ingest-time `users.info` call (no extra round-trip); WhatsApp uses `GetProfilePictureInfo` behind the adapter's existing 15-minute meta cache. Resolution is best-effort and never blocks ingest or render.

**Persistence** — additive, idempotent columns (`notify_channels.avatar_url`, `notify_messages.sender_avatar`) via `ALTER TABLE … ADD COLUMN` guarded like `pkg/home.RoleStore`. Surfaced as `avatar_url` on the overview-channel and channel-history DTOs.

**Image proxy (SSRF-guarded)** — `GET /api/apps/avatar?u=<base64url>` fetches the platform image server-side and streams the bytes. Guards: loopback-only (`checkLoopback`), `https` scheme, a strict host allowlist (`*.slack-edge.com`, `*.slack.com`, `*.gravatar.com`, `*.whatsapp.net`) re-checked on every redirect hop, and a 5 MiB cap. DTOs emit **proxied paths only** — the raw CDN URL is base64-wrapped and never rendered; no platform token is ever placed in a URL (these CDNs are public/tokenless, but the proxy also shields expiring WhatsApp URLs and CORS/mixed-content).

**Web wiring** — `IdentityAvatar src={avatar_url}` on the channel rows and the notifications feed in `AppsHome`; a broken/missing image falls back to the initials chip (already handled in `IdentityAvatar`).

## Test plan
- go: `go build ./...`, `go vet ./...`, `golangci-lint run` (changed pkgs) — all clean. `go test ./pkg/notify/... ./pkg/gateway/... ./server/...` green. New tests: WhatsApp avatar resolution, manager avatar propagation, overview emits a *proxied* (not raw) avatar path, and image-proxy guards (allowlist/SSRF/loopback/scheme/missing-param).
- web: `bunx tsc --noEmit`, `bun run lint`, `bun run build`, `bunx vitest run` (311 tests) — all pass; `buildHomeModel` test asserts avatar passthrough + empty-avatar fallback.
- live smoke (throwaway `MYCEL_HOME`, `127.0.0.1`, torn down): overview + channel-history payloads carry proxied `avatar_url`; proxy returns 502 for an allowlisted host it actually fetched, **403** for a `169.254.169.254` SSRF attempt (never fetched), **400** for http scheme / missing `u`.

## Seams / follow-ups
- WhatsApp per-sender avatars inside group chats fall back to initials (only the group icon + the sender's own 1:1 photo resolve today).
- The live SSE `channel.message` event now carries `avatar_url`, but `GatewayFeed` doesn't consume it yet (polled history already does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)