### PR TITLE
feat(tools): close the three Tools/Providers manager seams

### DIFF
--- a/pkg/provider/capabilities.go
+++ b/pkg/provider/capabilities.go
@@ -101,6 +101,20 @@ type Command struct {
 	Description string
 	// Args describes expected arguments, empty when the command takes none.
 	Args string
+	// Interactive is true when the command needs a TTY (login/auth device
+	// flows, TUIs, starting the agent) or mutates session/auth state. Such
+	// commands are never auto-run from the web UI — the surface offers a
+	// copy-command + "run in your terminal" instead. Only commands with
+	// Interactive=false AND no required Args are safe to execute inline.
+	Interactive bool
+}
+
+// Runnable reports whether a command is safe to execute non-interactively
+// from a UI surface: it needs no TTY and takes no required arguments. Callers
+// use this to gate the guarded /api/providers/{name}/run endpoint and to label
+// which commands the browser may run vs. which must be run in a terminal.
+func (c Command) Runnable() bool {
+	return !c.Interactive && c.Args == ""
 }
 
 // CommandLister is optionally implemented by providers that expose a

--- a/pkg/provider/capabilities.go
+++ b/pkg/provider/capabilities.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
@@ -110,11 +111,19 @@ type Command struct {
 }
 
 // Runnable reports whether a command is safe to execute non-interactively
-// from a UI surface: it needs no TTY and takes no required arguments. Callers
-// use this to gate the guarded /api/providers/{name}/run endpoint and to label
-// which commands the browser may run vs. which must be run in a terminal.
+// from a UI surface: it needs no TTY, takes no required arguments, and carries
+// no unresolved placeholder in its invocation. Callers use this to gate the
+// guarded /api/providers/{name}/run endpoint and to label which commands the
+// browser may run vs. which must be run in a terminal.
 func (c Command) Runnable() bool {
-	return !c.Interactive && c.Args == ""
+	if c.Interactive || c.Args != "" {
+		return false
+	}
+	// Defensive: an entry with an angle-bracket placeholder in Command but no
+	// matching Args would otherwise be exec'd with a literal "<name>" token.
+	// Reject it so the gate is self-enforcing rather than relying on authors
+	// keeping Command and Args in sync.
+	return !strings.ContainsAny(c.Command, "<>")
 }
 
 // CommandLister is optionally implemented by providers that expose a

--- a/pkg/provider/claude.go
+++ b/pkg/provider/claude.go
@@ -111,7 +111,7 @@ func (p *ClaudeProvider) Commands() []Command {
 		{Name: "config set", Command: "claude config set <key> <value>", Description: "Set config value", Args: "<key> <value>"},
 		{Name: "config list", Command: "claude config list", Description: "List config values"},
 		{Name: "version", Command: "claude --version", Description: "Show version"},
-		{Name: "resume", Command: "claude --resume <id>", Description: "Resume session", Args: "<session-id>"},
+		{Name: "resume", Command: "claude --resume <id>", Description: "Resume session", Args: "<session-id>", Interactive: true},
 	}
 }
 

--- a/pkg/provider/commands.go
+++ b/pkg/provider/commands.go
@@ -3,24 +3,29 @@ package provider
 // Curated per-provider CLI command lists (the CommandLister capability).
 //
 // These drive the "Available commands" surface on the provider detail page.
-// They are copyable references, not executed from the browser: several are
-// interactive (login/auth open a device flow or prompt) and cannot be
-// meaningfully streamed to a web UI. Each list is drawn from the provider
-// CLI's own documented subcommands/flags — see each provider file's header
-// comment for the source of truth. Providers whose CLI genuinely lacks a
-// category (e.g. OpenClaw has no --model flag) simply omit it rather than
-// showing a dead control.
+// Read-only, no-argument entries (version, status, list models, mcp list, …)
+// are safe to run inline from the web UI via the guarded
+// POST /api/providers/{name}/run endpoint — the request only *selects* an
+// entry from this allowlist; the executed argv comes verbatim from the table
+// here, never from the request body. Entries flagged Interactive (login/auth
+// device flows, TUIs, starting the agent) or that require Args are never
+// auto-run: the UI offers a copy-command + "run in your terminal" instead.
+//
+// Each list is drawn from the provider CLI's own documented subcommands/flags
+// — see each provider file's header comment for the source of truth. Providers
+// whose CLI genuinely lacks a category (e.g. OpenClaw has no --model flag)
+// simply omit it rather than showing a dead control.
 //
 // Claude's Commands() lives in claude.go alongside its other richer wiring.
 
 // Commands returns the curated CLI command list for OpenAI Codex.
 func (p *CodexProvider) Commands() []Command {
 	return []Command{
-		{Name: "login", Command: "codex login", Description: "Sign in to OpenAI (device flow)"},
+		{Name: "login", Command: "codex login", Description: "Sign in to OpenAI (device flow)", Interactive: true},
 		{Name: "login status", Command: "codex login status", Description: "Show current auth status"},
-		{Name: "logout", Command: "codex logout", Description: "Sign out"},
+		{Name: "logout", Command: "codex logout", Description: "Sign out", Interactive: true},
 		{Name: "exec", Command: "codex exec <prompt>", Description: "Run one non-interactive task", Args: "<prompt>"},
-		{Name: "resume", Command: "codex resume", Description: "Resume a previous session"},
+		{Name: "resume", Command: "codex resume", Description: "Resume a previous session", Interactive: true},
 		{Name: "mcp list", Command: "codex mcp list", Description: "List configured MCP servers"},
 		{Name: "mcp add", Command: "codex mcp add <name> -- <command>", Description: "Add an MCP server", Args: "<name> -- <command>"},
 		{Name: "version", Command: "codex --version", Description: "Show version"},
@@ -32,10 +37,10 @@ func (p *CodexProvider) Commands() []Command {
 // all flags on the base invocation.
 func (p *PiProvider) Commands() []Command {
 	return []Command{
-		{Name: "run", Command: "pi", Description: "Start the pi agent"},
+		{Name: "run", Command: "pi", Description: "Start the pi agent", Interactive: true},
 		{Name: "model", Command: "pi --model <provider/model>", Description: "Run with a specific model", Args: "<provider/model>"},
-		{Name: "continue", Command: "pi --continue", Description: "Continue the previous session"},
-		{Name: "resume", Command: "pi --resume", Description: "Pick a session to resume"},
+		{Name: "continue", Command: "pi --continue", Description: "Continue the previous session", Interactive: true},
+		{Name: "resume", Command: "pi --resume", Description: "Pick a session to resume", Interactive: true},
 		{Name: "session", Command: "pi --session <id>", Description: "Resume a specific session", Args: "<session-id>"},
 		{Name: "version", Command: "pi --version", Description: "Show version"},
 	}
@@ -44,10 +49,10 @@ func (p *PiProvider) Commands() []Command {
 // Commands returns the curated CLI command list for the Antigravity CLI (agy).
 func (p *AgyProvider) Commands() []Command {
 	return []Command{
-		{Name: "run", Command: "agy", Description: "Start the Antigravity agent"},
+		{Name: "run", Command: "agy", Description: "Start the Antigravity agent", Interactive: true},
 		{Name: "models", Command: "agy models", Description: "List available Gemini models"},
 		{Name: "model", Command: "agy --model '<model>'", Description: "Run with a specific model", Args: "<model>"},
-		{Name: "continue", Command: "agy --continue", Description: "Continue the previous conversation"},
+		{Name: "continue", Command: "agy --continue", Description: "Continue the previous conversation", Interactive: true},
 		{Name: "conversation", Command: "agy --conversation <uuid>", Description: "Resume a specific conversation", Args: "<uuid>"},
 		{Name: "version", Command: "agy --version", Description: "Show version"},
 	}
@@ -56,8 +61,8 @@ func (p *AgyProvider) Commands() []Command {
 // Commands returns the curated CLI command list for Cursor Agent.
 func (p *CursorProvider) Commands() []Command {
 	return []Command{
-		{Name: "login", Command: "cursor-agent login", Description: "Sign in to Cursor"},
-		{Name: "logout", Command: "cursor-agent logout", Description: "Sign out"},
+		{Name: "login", Command: "cursor-agent login", Description: "Sign in to Cursor", Interactive: true},
+		{Name: "logout", Command: "cursor-agent logout", Description: "Sign out", Interactive: true},
 		{Name: "status", Command: "cursor-agent status", Description: "Show auth and account status"},
 		{Name: "list models", Command: "cursor-agent --list-models", Description: "List available models"},
 		{Name: "model", Command: "cursor-agent --model <model>", Description: "Run with a specific model", Args: "<model>"},
@@ -71,7 +76,7 @@ func (p *CursorProvider) Commands() []Command {
 // --model flag is surfaced (see the provider header comment).
 func (p *OpenclawProvider) Commands() []Command {
 	return []Command{
-		{Name: "tui", Command: "openclaw tui --local", Description: "Start the local TUI agent"},
+		{Name: "tui", Command: "openclaw tui --local", Description: "Start the local TUI agent", Interactive: true},
 		{Name: "session", Command: "openclaw tui --local --session <key>", Description: "Reattach to a session", Args: "<session-key>"},
 		{Name: "agents add", Command: "openclaw agents add --model <provider/model>", Description: "Add a routed agent with a model", Args: "<provider/model>"},
 		{Name: "version", Command: "openclaw --version", Description: "Show version"},

--- a/server/handlers/deps_install.go
+++ b/server/handlers/deps_install.go
@@ -125,7 +125,16 @@ func (h *DepsInstallHandler) install(w http.ResponseWriter, r *http.Request) {
 // streamInstall runs cmdLine, emitting one {"type":"log","line":…} record
 // per output line and a final {"type":"done","code":N} (or "error").
 func streamInstall(ctx context.Context, cmdLine string, emit func(any) bool) {
-	cmd := installRunner(ctx, cmdLine)
+	streamCmd(installRunner(ctx, cmdLine), emit)
+}
+
+// streamCmd runs an already-built *exec.Cmd, emitting one
+// {"type":"log","line":…} record per output line and a final
+// {"type":"done","code":N} (or {"type":"error",…}). It is the shared engine
+// behind both the vetted-table installer (streamInstall, via `sh -c`) and the
+// registry package installer (pkgsearch, via a direct argv), so both surface
+// identical NDJSON progress to the UI.
+func streamCmd(cmd *exec.Cmd, emit func(any) bool) {
 	pr, pw := io.Pipe()
 	cmd.Stdout = pw
 	cmd.Stderr = pw

--- a/server/handlers/deps_install.go
+++ b/server/handlers/deps_install.go
@@ -136,6 +136,12 @@ func streamInstall(ctx context.Context, cmdLine string, emit func(any) bool) {
 // identical NDJSON progress to the UI.
 func streamCmd(cmd *exec.Cmd, emit func(any) bool) {
 	pr, pw := io.Pipe()
+	// Closing the reader on the way out makes any further child writes fail
+	// with io.ErrClosedPipe instead of blocking forever — so when a client
+	// disconnects mid-stream (emit returns false and we return early), the
+	// child's next write errors, cmd.Wait() completes, and the waiter
+	// goroutine + process don't leak.
+	defer func() { _ = pr.Close() }()
 	cmd.Stdout = pw
 	cmd.Stderr = pw
 

--- a/server/handlers/pkgmanagers.go
+++ b/server/handlers/pkgmanagers.go
@@ -44,6 +44,11 @@ type PackageManager struct {
 	// UI can drive (e.g. `brew search`, `npm search`). Honest metadata:
 	// managers without a usable search are labeled so rather than faked.
 	Searchable bool `json:"searchable"`
+	// DirectInstall is true when the server can install a searched package
+	// via this manager directly (no sudo, non-interactive — brew/npm/cargo).
+	// The UI reads this instead of hard-coding the set, so its Install
+	// affordance never drifts from the backend installSpecs.
+	DirectInstall bool `json:"direct_install"`
 }
 
 // pmCandidate describes a manager to probe: its binary and the args that print
@@ -126,11 +131,12 @@ func (h *PackageManagersHandler) detect(ctx context.Context) []PackageManager {
 			version = v
 		}
 		found = append(found, PackageManager{
-			ID:         c.id,
-			Name:       c.name,
-			Version:    version,
-			Available:  true,
-			Searchable: pkgManagerSearchable(c.id),
+			ID:            c.id,
+			Name:          c.name,
+			Version:       version,
+			Available:     true,
+			Searchable:    pkgManagerSearchable(c.id),
+			DirectInstall: pkgManagerDirectInstall(c.id),
 		})
 	}
 	sort.Slice(found, func(i, j int) bool { return found[i].ID < found[j].ID })

--- a/server/handlers/pkgmanagers.go
+++ b/server/handlers/pkgmanagers.go
@@ -46,30 +46,31 @@ type PackageManager struct {
 	Searchable bool `json:"searchable"`
 }
 
-// pmCandidate describes a manager to probe: its binary, the args that print a
-// version, and whether it has a searchable registry.
+// pmCandidate describes a manager to probe: its binary and the args that print
+// a version. Whether it has a searchable registry is not stored here — it is
+// derived from pkgManagerSearchable (searchSpecs) so the "searchable" bit can
+// never drift from what the search endpoint actually wires.
 type pmCandidate struct {
 	id, name, binary, versionArg string
 	// oses restricts a candidate to specific runtime.GOOS values; empty
 	// means every OS.
-	oses       []string
-	searchable bool
+	oses []string
 }
 
 // pmCandidates is the vetted set of managers we probe. Cross-platform tools
 // (npm, pipx, cargo) are probed everywhere; OS-native managers are gated to
 // the platforms they ship on so a Linux box isn't asked about winget.
 var pmCandidates = []pmCandidate{
-	{id: "brew", name: "Homebrew", binary: "brew", versionArg: "--version", searchable: true, oses: []string{"darwin", "linux"}},
-	{id: "apt", name: "APT", binary: "apt-get", versionArg: "--version", searchable: true, oses: []string{"linux"}},
-	{id: "dnf", name: "DNF", binary: "dnf", versionArg: "--version", searchable: true, oses: []string{"linux"}},
-	{id: "yum", name: "YUM", binary: "yum", versionArg: "--version", searchable: true, oses: []string{"linux"}},
-	{id: "pacman", name: "pacman", binary: "pacman", versionArg: "--version", searchable: true, oses: []string{"linux"}},
-	{id: "zypper", name: "Zypper", binary: "zypper", versionArg: "--version", searchable: true, oses: []string{"linux"}},
-	{id: "winget", name: "winget", binary: "winget", versionArg: "--version", searchable: true, oses: []string{"windows"}},
-	{id: "npm", name: "npm", binary: "npm", versionArg: "--version", searchable: true},
-	{id: "pipx", name: "pipx", binary: "pipx", versionArg: "--version", searchable: false},
-	{id: "cargo", name: "Cargo", binary: "cargo", versionArg: "--version", searchable: true},
+	{id: "brew", name: "Homebrew", binary: "brew", versionArg: "--version", oses: []string{"darwin", "linux"}},
+	{id: "apt", name: "APT", binary: "apt-get", versionArg: "--version", oses: []string{"linux"}},
+	{id: "dnf", name: "DNF", binary: "dnf", versionArg: "--version", oses: []string{"linux"}},
+	{id: "yum", name: "YUM", binary: "yum", versionArg: "--version", oses: []string{"linux"}},
+	{id: "pacman", name: "pacman", binary: "pacman", versionArg: "--version", oses: []string{"linux"}},
+	{id: "zypper", name: "Zypper", binary: "zypper", versionArg: "--version", oses: []string{"linux"}},
+	{id: "winget", name: "winget", binary: "winget", versionArg: "--version", oses: []string{"windows"}},
+	{id: "npm", name: "npm", binary: "npm", versionArg: "--version"},
+	{id: "pipx", name: "pipx", binary: "pipx", versionArg: "--version"},
+	{id: "cargo", name: "Cargo", binary: "cargo", versionArg: "--version"},
 }
 
 // pmLookPath and pmRunVersion are package vars so tests can inject a stub host
@@ -129,7 +130,7 @@ func (h *PackageManagersHandler) detect(ctx context.Context) []PackageManager {
 			Name:       c.name,
 			Version:    version,
 			Available:  true,
-			Searchable: c.searchable,
+			Searchable: pkgManagerSearchable(c.id),
 		})
 	}
 	sort.Slice(found, func(i, j int) bool { return found[i].ID < found[j].ID })

--- a/server/handlers/pkgsearch.go
+++ b/server/handlers/pkgsearch.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -55,9 +56,16 @@ const (
 var pkgQueryPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$`)
 
 // pkgNamePattern is the charset an installable package name must match. It
-// additionally allows a leading '@' and an internal '/' for npm scoped
-// packages (e.g. @scope/pkg).
-var pkgNamePattern = regexp.MustCompile(`^@?[A-Za-z0-9][A-Za-z0-9._+/-]{0,127}$`)
+// accepts exactly two documented shapes and nothing else:
+//   - a plain package name: leading alphanumeric, then name characters (no '/')
+//   - a proper npm scope: "@scope/name", a single '/' separating one anchored
+//     scope segment from one anchored name segment
+//
+// Because each segment must start with an alphanumeric and '/' only appears
+// between an anchored scope and name, this rejects leading '-' (argv flag
+// injection like "-g"/"--force"), bare or duplicate '/', trailing '/', '..'
+// path traversal ("a/../../b"), and absolute/relative paths ("/etc/x", "./x").
+var pkgNamePattern = regexp.MustCompile(`^(@[A-Za-z0-9][A-Za-z0-9._-]{0,63}/)?[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$`)
 
 // searchResult is one registry hit.
 type searchResult struct {
@@ -113,16 +121,60 @@ func pkgManagerSearchable(id string) bool {
 	return ok
 }
 
-// pkgSearchRunner runs a search command and returns capped combined output.
+// pkgManagerDirectInstall reports whether the server can install a searched
+// package via this manager directly (no sudo). Single source of truth for the
+// UI's Install affordance, derived from installSpecs so it can't drift.
+func pkgManagerDirectInstall(id string) bool {
+	_, ok := installSpecs[id]
+	return ok
+}
+
+// limitedWriter writes at most n bytes to w and silently discards the rest,
+// always reporting a full write so the child process is never killed by a
+// short-write error. It bounds captured memory *during* the read rather than
+// buffering the whole subprocess output and truncating afterwards.
+type limitedWriter struct {
+	w         io.Writer
+	n         int
+	truncated bool
+}
+
+func (l *limitedWriter) Write(p []byte) (int, error) {
+	keep := p
+	if len(keep) > l.n {
+		keep = keep[:l.n]
+		l.truncated = true
+	}
+	if l.n > 0 {
+		if _, err := l.w.Write(keep); err != nil {
+			return 0, err
+		}
+		l.n -= len(keep)
+	}
+	return len(p), nil
+}
+
+// runCapped runs cmd, capturing at most limit bytes of combined stdout+stderr
+// via a limitedWriter so a chatty subprocess can't balloon memory, and reports
+// whether output was truncated. WaitDelay bounds the wait so a killed child that
+// leaked a pipe to a grandchild can't wedge the read indefinitely.
+func runCapped(cmd *exec.Cmd, limit int) (out []byte, truncated bool, err error) {
+	var buf bytes.Buffer
+	lw := &limitedWriter{w: &buf, n: limit}
+	cmd.Stdout = lw
+	cmd.Stderr = lw
+	cmd.WaitDelay = 2 * time.Second
+	err = cmd.Run()
+	return buf.Bytes(), lw.truncated, err
+}
+
+// pkgSearchRunner runs a search command and returns bounded combined output.
 // Package var so tests can inject a stub host.
 var pkgSearchRunner = func(ctx context.Context, bin string, args []string) ([]byte, error) {
 	cctx, cancel := context.WithTimeout(ctx, pkgSearchTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(cctx, bin, args...) //nolint:gosec // bin is a constant from searchSpecs; args carry a charset-validated query as a slice element (no shell)
-	out, err := cmd.CombinedOutput()
-	if len(out) > pkgSearchOutputCap {
-		out = out[:pkgSearchOutputCap]
-	}
+	out, _, err := runCapped(cmd, pkgSearchOutputCap)
 	return out, err
 }
 

--- a/server/handlers/pkgsearch.go
+++ b/server/handlers/pkgsearch.go
@@ -1,0 +1,402 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// PackageSearchHandler exposes a guarded registry search + install for the
+// host's package managers, feeding the Tools page's "search the registry"
+// surface.
+//
+// Security model (this shells out, so it is hardened accordingly):
+//   - The manager id must resolve to a vetted spec in searchSpecs / installSpecs
+//     — never a name from the request drives the binary.
+//   - The query / package name must match a strict charset (pkgQueryPattern /
+//     pkgNamePattern); anything with shell metacharacters, whitespace, or
+//     control bytes is rejected with 400 before any exec.
+//   - Every command is exec'd directly with an argument slice (never `sh -c`),
+//     so the validated token is passed as one argv element and no request data
+//     is ever interpreted by a shell. This is the CodeQL-recommended shape for
+//     go/command-line-injection.
+//   - Both endpoints are loopback-only and time-bounded; results are capped.
+type PackageSearchHandler struct{}
+
+// NewPackageSearchHandler constructs a PackageSearchHandler.
+func NewPackageSearchHandler() *PackageSearchHandler { return &PackageSearchHandler{} }
+
+// Register mounts the search + install routes. Both are more specific than any
+// prefix route, so ServeMux dispatches them here.
+func (h *PackageSearchHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/system/package-search", h.search)
+	mux.HandleFunc("/api/system/package-install", h.install)
+}
+
+const (
+	// pkgSearchTimeout bounds a registry search (searches hit the network).
+	pkgSearchTimeout = 20 * time.Second
+	// pkgSearchOutputCap limits bytes read from a search command.
+	pkgSearchOutputCap = 1 << 20 // 1 MiB
+	// pkgSearchResultCap limits how many parsed results are returned.
+	pkgSearchResultCap = 50
+)
+
+// pkgQueryPattern is the strict charset a search term must match: a leading
+// alphanumeric, then package-name-ish characters only. No whitespace, no shell
+// metacharacters, no path traversal. Deliberately conservative — a package
+// name, not a free-text query.
+var pkgQueryPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$`)
+
+// pkgNamePattern is the charset an installable package name must match. It
+// additionally allows a leading '@' and an internal '/' for npm scoped
+// packages (e.g. @scope/pkg).
+var pkgNamePattern = regexp.MustCompile(`^@?[A-Za-z0-9][A-Za-z0-9._+/-]{0,127}$`)
+
+// searchResult is one registry hit.
+type searchResult struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// searchSpec describes how to search one manager's registry.
+type searchSpec struct {
+	// args builds the argv for a validated query.
+	args func(query string) []string
+	// parse extracts results from the command's combined output.
+	parse func(raw string) []searchResult
+	// bin is the binary to exec (a constant, never request-derived).
+	bin string
+}
+
+// installSpec describes how to install a validated package via one manager.
+// Only managers whose install is non-interactive and needs no sudo are listed
+// — the rest surface a copyable command in the UI instead.
+type installSpec struct {
+	args func(pkg string) []string
+	bin  string
+}
+
+// searchSpecs is the vetted set of managers whose registry the UI can search.
+// A manager absent here is honestly labeled "search unavailable".
+var searchSpecs = map[string]searchSpec{
+	"brew":   {bin: "brew", args: func(q string) []string { return []string{"search", q} }, parse: parseLineNames},
+	"npm":    {bin: "npm", args: func(q string) []string { return []string{"search", "--no-color", "--parseable", q} }, parse: parseNpmParseable},
+	"apt":    {bin: "apt-cache", args: func(q string) []string { return []string{"search", q} }, parse: parseColonDesc},
+	"dnf":    {bin: "dnf", args: func(q string) []string { return []string{"--quiet", "search", q} }, parse: parseColonDesc},
+	"yum":    {bin: "yum", args: func(q string) []string { return []string{"--quiet", "search", q} }, parse: parseColonDesc},
+	"pacman": {bin: "pacman", args: func(q string) []string { return []string{"-Ss", q} }, parse: parsePacman},
+	"zypper": {bin: "zypper", args: func(q string) []string { return []string{"--quiet", "search", q} }, parse: parseLineNames},
+	"cargo":  {bin: "cargo", args: func(q string) []string { return []string{"search", q} }, parse: parseCargo},
+	"winget": {bin: "winget", args: func(q string) []string { return []string{"search", q} }, parse: parseLineNames},
+}
+
+// installSpecs is the subset of managers whose install we run directly (no
+// sudo, non-interactive). Others: the UI shows a copyable command.
+var installSpecs = map[string]installSpec{
+	"brew":  {bin: "brew", args: func(pkg string) []string { return []string{"install", pkg} }},
+	"npm":   {bin: "npm", args: func(pkg string) []string { return []string{"install", "-g", pkg} }},
+	"cargo": {bin: "cargo", args: func(pkg string) []string { return []string{"install", pkg} }},
+}
+
+// pkgManagerSearchable reports whether the UI can drive a registry search for
+// this manager id. Single source of truth for the detect surface's Searchable
+// flag, so the picture never drifts from what's actually wired.
+func pkgManagerSearchable(id string) bool {
+	_, ok := searchSpecs[id]
+	return ok
+}
+
+// pkgSearchRunner runs a search command and returns capped combined output.
+// Package var so tests can inject a stub host.
+var pkgSearchRunner = func(ctx context.Context, bin string, args []string) ([]byte, error) {
+	cctx, cancel := context.WithTimeout(ctx, pkgSearchTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, bin, args...) //nolint:gosec // bin is a constant from searchSpecs; args carry a charset-validated query as a slice element (no shell)
+	out, err := cmd.CombinedOutput()
+	if len(out) > pkgSearchOutputCap {
+		out = out[:pkgSearchOutputCap]
+	}
+	return out, err
+}
+
+// pkgInstallRunner builds the *exec.Cmd for a package install. Package var so
+// tests can substitute a harmless command.
+var pkgInstallRunner = func(ctx context.Context, bin string, args []string) *exec.Cmd {
+	return exec.CommandContext(ctx, bin, args...) //nolint:gosec // bin is a constant from installSpecs; args carry a charset-validated package name as a slice element (no shell)
+}
+
+// search handles POST /api/system/package-search.
+func (h *PackageSearchHandler) search(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	var req struct {
+		Manager string `json:"manager"`
+		Query   string `json:"query"`
+	}
+	if !decodePkgBody(w, r, &req) {
+		return
+	}
+	req.Manager = strings.TrimSpace(req.Manager)
+	req.Query = strings.TrimSpace(req.Query)
+
+	spec, ok := searchSpecs[req.Manager]
+	if !ok {
+		httpError(w, "search unavailable for manager: "+req.Manager, http.StatusBadRequest)
+		return
+	}
+	if !pkgQueryPattern.MatchString(req.Query) {
+		httpError(w, "invalid query: must be a package name (letters, digits, . _ + -), 1-64 chars", http.StatusBadRequest)
+		return
+	}
+
+	out, err := pkgSearchRunner(r.Context(), spec.bin, spec.args(req.Query))
+	results := spec.parse(string(out))
+	if len(results) > pkgSearchResultCap {
+		results = results[:pkgSearchResultCap]
+	}
+	// A non-zero exit with zero results is a real failure (e.g. brew/apt
+	// found nothing or the binary errored); surface it honestly. A non-zero
+	// exit that still parsed results (some managers exit 1 on "no matches"
+	// after printing a header) is treated as an empty/normal result set.
+	if err != nil && len(results) == 0 {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"manager": req.Manager,
+			"query":   req.Query,
+			"results": []searchResult{},
+			"error":   "no results (the search command reported an error or found nothing)",
+		})
+		return
+	}
+
+	if results == nil {
+		results = []searchResult{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"manager": req.Manager,
+		"query":   req.Query,
+		"results": results,
+	})
+}
+
+// install handles POST /api/system/package-install: streams the install of a
+// validated package via an allowlisted manager as NDJSON, reusing the same
+// stream engine as the vetted-table installer.
+func (h *PackageSearchHandler) install(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	var req struct {
+		Manager string `json:"manager"`
+		Package string `json:"package"`
+	}
+	if !decodePkgBody(w, r, &req) {
+		return
+	}
+	req.Manager = strings.TrimSpace(req.Manager)
+	req.Package = strings.TrimSpace(req.Package)
+
+	spec, ok := installSpecs[req.Manager]
+	if !ok {
+		httpError(w, "no direct installer for manager: "+req.Manager+" (copy the command and run it yourself)", http.StatusBadRequest)
+		return
+	}
+	if !pkgNamePattern.MatchString(req.Package) {
+		httpError(w, "invalid package name", http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		httpError(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+
+	emit := func(v any) bool {
+		payload, mErr := json.Marshal(v)
+		if mErr != nil {
+			return false
+		}
+		if _, wErr := w.Write(append(payload, '\n')); wErr != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	args := spec.args(req.Package)
+	emit(map[string]string{"type": "start", "command": strings.Join(append([]string{spec.bin}, args...), " ")})
+	streamCmd(pkgInstallRunner(r.Context(), spec.bin, args), emit)
+}
+
+// decodePkgBody reads and JSON-decodes a small request body into dst, writing
+// a 400 and returning false on failure.
+func decodePkgBody(w http.ResponseWriter, r *http.Request, dst any) bool {
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+	if err != nil {
+		httpError(w, "failed to read body", http.StatusBadRequest)
+		return false
+	}
+	if err := json.Unmarshal(body, dst); err != nil {
+		httpError(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+// ── parsers ───────────────────────────────────────────────────────────
+// Each converts one manager's search output into name/description pairs.
+// They tolerate headers, blank lines, and formatting noise rather than
+// assuming a rigid layout.
+
+// parseLineNames treats each non-empty, single-token line as a package name
+// (brew/zypper/winget style). Lines with spaces (headers, "==> Formulae") are
+// skipped so section banners don't leak in.
+func parseLineNames(raw string) []searchResult {
+	var out []searchResult
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "==>") {
+			continue
+		}
+		if strings.ContainsAny(line, " \t") {
+			continue
+		}
+		out = append(out, searchResult{Name: line})
+	}
+	return out
+}
+
+// parseNpmParseable parses `npm search --parseable` output: tab-separated
+// name, description, author, date, version.
+func parseNpmParseable(raw string) []searchResult {
+	var out []searchResult
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		cols := strings.Split(line, "\t")
+		name := strings.TrimSpace(cols[0])
+		if name == "" {
+			continue
+		}
+		desc := ""
+		if len(cols) > 1 {
+			desc = strings.TrimSpace(cols[1])
+		}
+		out = append(out, searchResult{Name: name, Description: desc})
+	}
+	return out
+}
+
+// parseColonDesc parses "name - description" lines (apt-cache / dnf / yum).
+func parseColonDesc(raw string) []searchResult {
+	var out []searchResult
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "=") {
+			continue
+		}
+		name, desc, found := strings.Cut(line, " - ")
+		name = strings.TrimSpace(name)
+		if name == "" || strings.ContainsAny(name, " \t") {
+			// dnf prints "name.arch : desc"; fall back to that shape.
+			if n, d, ok := strings.Cut(line, " : "); ok {
+				name, desc, found = strings.TrimSpace(n), d, true
+			}
+		}
+		if !found || name == "" || strings.ContainsAny(name, " \t") {
+			continue
+		}
+		out = append(out, searchResult{Name: name, Description: strings.TrimSpace(desc)})
+	}
+	return out
+}
+
+// parsePacman parses `pacman -Ss` output: a "repo/name version" header line
+// followed by an indented description line.
+func parsePacman(raw string) []searchResult {
+	var out []searchResult
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	var pending *searchResult
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+			if pending != nil {
+				pending.Description = strings.TrimSpace(line)
+				out = append(out, *pending)
+				pending = nil
+			}
+			continue
+		}
+		if pending != nil {
+			out = append(out, *pending)
+			pending = nil
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		name := fields[0]
+		if i := strings.IndexByte(name, '/'); i >= 0 {
+			name = name[i+1:]
+		}
+		pending = &searchResult{Name: name}
+	}
+	if pending != nil {
+		out = append(out, *pending)
+	}
+	return out
+}
+
+// parseCargo parses `cargo search` output: `name = "version"    # description`.
+func parseCargo(raw string) []searchResult {
+	var out []searchResult
+	sc := bufio.NewScanner(strings.NewReader(raw))
+	sc.Buffer(make([]byte, 0, 64*1024), 1<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "...") {
+			continue
+		}
+		name, rest, ok := strings.Cut(line, "=")
+		name = strings.TrimSpace(name)
+		if !ok || name == "" || strings.ContainsAny(name, " \t") {
+			continue
+		}
+		desc := ""
+		if _, d, ok := strings.Cut(rest, "#"); ok {
+			desc = strings.TrimSpace(d)
+		}
+		out = append(out, searchResult{Name: name, Description: desc})
+	}
+	return out
+}

--- a/server/handlers/pkgsearch_test.go
+++ b/server/handlers/pkgsearch_test.go
@@ -132,7 +132,14 @@ func TestPackageInstallRejectsInjection(t *testing.T) {
 	}
 
 	mux := pkgSearchMux()
-	for _, pkg := range []string{"foo; rm -rf /", "$(id)", "foo bar", "foo|sh", ""} {
+	// Includes argv-level attacks the charset must stop: leading-hyphen flag
+	// injection (-g / --force), bare or traversal paths (owner/repo, a/../../b,
+	// ./x, /etc/x) — none are the documented plain-name or @scope/name forms.
+	for _, pkg := range []string{
+		"foo; rm -rf /", "$(id)", "foo bar", "foo|sh", "",
+		"--force", "-g", "a/../../b", "owner/repo", "./x", "/etc/x",
+		"foo/", "/foo", "a//b", "@/x", "@scope//pkg",
+	} {
 		body, _ := json.Marshal(map[string]string{"manager": "brew", "package": pkg})
 		rec := httptest.NewRecorder()
 		mux.ServeHTTP(rec, loopbackPost("/api/system/package-install", string(body)))
@@ -142,6 +149,16 @@ func TestPackageInstallRejectsInjection(t *testing.T) {
 	}
 	if ran {
 		t.Fatalf("install command ran despite an invalid package name")
+	}
+	// The two documented shapes must still pass validation (they reach the
+	// stubbed runner, so no real install happens).
+	for _, pkg := range []string{"ripgrep", "@scope/pkg", "foo.bar_baz+1"} {
+		body, _ := json.Marshal(map[string]string{"manager": "npm", "package": pkg})
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, loopbackPost("/api/system/package-install", string(body)))
+		if rec.Code != http.StatusOK {
+			t.Errorf("valid package %q: status = %d, want 200", pkg, rec.Code)
+		}
 	}
 }
 

--- a/server/handlers/pkgsearch_test.go
+++ b/server/handlers/pkgsearch_test.go
@@ -1,0 +1,211 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func pkgSearchMux() http.Handler {
+	mux := http.NewServeMux()
+	NewPackageSearchHandler().Register(mux)
+	return mux
+}
+
+// loopbackPost builds a POST request that passes the loopback guard.
+func loopbackPost(path, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.RemoteAddr = "127.0.0.1:54321"
+	return req
+}
+
+// TestPackageSearchRejectsInjection asserts that queries carrying shell
+// metacharacters or whitespace are rejected before any command runs.
+func TestPackageSearchRejectsInjection(t *testing.T) {
+	origRun := pkgSearchRunner
+	t.Cleanup(func() { pkgSearchRunner = origRun })
+
+	ran := false
+	pkgSearchRunner = func(_ context.Context, _ string, _ []string) ([]byte, error) {
+		ran = true
+		return nil, nil
+	}
+
+	mux := pkgSearchMux()
+	injections := []string{
+		"foo; rm -rf /",
+		"foo && curl evil.sh",
+		"foo | sh",
+		"$(whoami)",
+		"`id`",
+		"foo bar",
+		"../../etc/passwd",
+		"foo\nbar",
+		"",
+		"foo;",
+		"--flag",
+	}
+	for _, q := range injections {
+		body, _ := json.Marshal(map[string]string{"manager": "brew", "query": q})
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, loopbackPost("/api/system/package-search", string(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("query %q: status = %d, want 400", q, rec.Code)
+		}
+	}
+	if ran {
+		t.Fatalf("search command ran despite an invalid query — sanitization bypassed")
+	}
+}
+
+// TestPackageSearchUnknownManager rejects a manager with no vetted search spec.
+func TestPackageSearchUnknownManager(t *testing.T) {
+	mux := pkgSearchMux()
+	body, _ := json.Marshal(map[string]string{"manager": "evil", "query": "ripgrep"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, loopbackPost("/api/system/package-search", string(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestPackageSearchHappyPath runs a valid query against a stubbed brew and
+// checks the parsed results and the exact argv the handler built.
+func TestPackageSearchHappyPath(t *testing.T) {
+	origRun := pkgSearchRunner
+	t.Cleanup(func() { pkgSearchRunner = origRun })
+
+	var gotBin string
+	var gotArgs []string
+	pkgSearchRunner = func(_ context.Context, bin string, args []string) ([]byte, error) {
+		gotBin, gotArgs = bin, args
+		return []byte("ripgrep\nripgrep-all\n==> Casks\n"), nil
+	}
+
+	mux := pkgSearchMux()
+	body, _ := json.Marshal(map[string]string{"manager": "brew", "query": "ripgrep"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, loopbackPost("/api/system/package-search", string(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if gotBin != "brew" || len(gotArgs) != 2 || gotArgs[0] != "search" || gotArgs[1] != "ripgrep" {
+		t.Fatalf("argv = %q %q, want brew [search ripgrep]", gotBin, gotArgs)
+	}
+	var resp struct {
+		Results []searchResult `json:"results"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Results) != 2 || resp.Results[0].Name != "ripgrep" {
+		t.Fatalf("results = %+v, want [ripgrep ripgrep-all]", resp.Results)
+	}
+}
+
+// TestPackageSearchLoopbackGuard rejects non-loopback callers.
+func TestPackageSearchLoopbackGuard(t *testing.T) {
+	mux := pkgSearchMux()
+	body, _ := json.Marshal(map[string]string{"manager": "brew", "query": "ripgrep"})
+	req := httptest.NewRequest(http.MethodPost, "/api/system/package-search", strings.NewReader(string(body)))
+	req.RemoteAddr = "203.0.113.5:9999"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+// TestPackageInstallRejectsInjection asserts install package names are
+// charset-validated before any command runs.
+func TestPackageInstallRejectsInjection(t *testing.T) {
+	origRun := pkgInstallRunner
+	t.Cleanup(func() { pkgInstallRunner = origRun })
+	ran := false
+	pkgInstallRunner = func(ctx context.Context, _ string, _ []string) *exec.Cmd {
+		ran = true
+		return exec.CommandContext(ctx, "true")
+	}
+
+	mux := pkgSearchMux()
+	for _, pkg := range []string{"foo; rm -rf /", "$(id)", "foo bar", "foo|sh", ""} {
+		body, _ := json.Marshal(map[string]string{"manager": "brew", "package": pkg})
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, loopbackPost("/api/system/package-install", string(body)))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("package %q: status = %d, want 400", pkg, rec.Code)
+		}
+	}
+	if ran {
+		t.Fatalf("install command ran despite an invalid package name")
+	}
+}
+
+// TestPackageInstallUnknownManager rejects managers without a direct installer.
+func TestPackageInstallUnknownManager(t *testing.T) {
+	mux := pkgSearchMux()
+	// apt has a search spec but no direct installer (needs sudo) — must 400.
+	body, _ := json.Marshal(map[string]string{"manager": "apt", "package": "ripgrep"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, loopbackPost("/api/system/package-install", string(body)))
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestPackageInstallStreams runs a valid install against a stubbed command and
+// checks the NDJSON stream carries the exact argv and completes.
+func TestPackageInstallStreams(t *testing.T) {
+	origRun := pkgInstallRunner
+	t.Cleanup(func() { pkgInstallRunner = origRun })
+
+	var gotBin string
+	var gotArgs []string
+	pkgInstallRunner = func(ctx context.Context, bin string, args []string) *exec.Cmd {
+		gotBin, gotArgs = bin, args
+		// Harmless stand-in that emits a line and exits 0.
+		return exec.CommandContext(ctx, "printf", "installing\\n")
+	}
+
+	mux := pkgSearchMux()
+	body, _ := json.Marshal(map[string]string{"manager": "npm", "package": "@scope/pkg"})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, loopbackPost("/api/system/package-install", string(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if gotBin != "npm" || strings.Join(gotArgs, " ") != "install -g @scope/pkg" {
+		t.Fatalf("argv = %q %q, want npm [install -g @scope/pkg]", gotBin, gotArgs)
+	}
+	if !strings.Contains(rec.Body.String(), `"type":"done"`) {
+		t.Fatalf("stream missing done event: %s", rec.Body.String())
+	}
+}
+
+func TestPkgManagerSearchable(t *testing.T) {
+	if !pkgManagerSearchable("brew") || !pkgManagerSearchable("npm") {
+		t.Fatalf("brew/npm should be searchable")
+	}
+	if pkgManagerSearchable("pipx") {
+		t.Fatalf("pipx has no search spec and must not be searchable")
+	}
+}
+
+func TestPkgSearchParsers(t *testing.T) {
+	if got := parseNpmParseable("react\tA library\tfoo\t2020\t18.0\n\nreact-dom\tDOM\n"); len(got) != 2 || got[0].Name != "react" || got[0].Description != "A library" {
+		t.Fatalf("npm parse = %+v", got)
+	}
+	if got := parseColonDesc("ripgrep - fast grep\nheader\n"); len(got) != 1 || got[0].Name != "ripgrep" || got[0].Description != "fast grep" {
+		t.Fatalf("apt parse = %+v", got)
+	}
+	if got := parsePacman("extra/ripgrep 13.0-1\n    Fast grep\ncore/foo 1.0\n    A foo\n"); len(got) != 2 || got[0].Name != "ripgrep" || got[0].Description != "Fast grep" {
+		t.Fatalf("pacman parse = %+v", got)
+	}
+	if got := parseCargo("ripgrep = \"13.0.0\"    # fast grep\n... and more\n"); len(got) != 1 || got[0].Name != "ripgrep" || got[0].Description != "fast grep" {
+		t.Fatalf("cargo parse = %+v", got)
+	}
+}

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -70,6 +70,12 @@ type ProviderCommand struct {
 	Command     string `json:"command"`
 	Description string `json:"description"`
 	Args        string `json:"args,omitempty"`
+	// Interactive is true when the command needs a TTY or mutates auth/session
+	// state; the UI must not auto-run it (offer copy + "run in your terminal").
+	Interactive bool `json:"interactive"`
+	// Runnable is true when the command is safe to execute inline via the
+	// guarded run endpoint (no TTY, no required args).
+	Runnable bool `json:"runnable"`
 }
 
 // MCPServer describes an MCP server configured for a provider.
@@ -248,6 +254,8 @@ func (h *ProviderHandler) byName(w http.ResponseWriter, r *http.Request) {
 		h.listModels(w, r, name)
 	case r.Method == http.MethodGet && action == "commands":
 		h.commands(w, r, name)
+	case r.Method == http.MethodPost && action == "run":
+		h.runCommand(w, r, name)
 	case r.Method == http.MethodGet && action == "mcps":
 		h.listMCPs(w, r, name)
 	case r.Method == http.MethodPost && action == "mcps":
@@ -303,24 +311,37 @@ func (h *ProviderHandler) commands(w http.ResponseWriter, _ *http.Request, name 
 		return
 	}
 
-	var cmds []ProviderCommand
+	writeJSON(w, http.StatusOK, providerCommands(p, name))
+}
+
+// providerCommands returns p's curated command list (or a generic default),
+// with Interactive/Runnable resolved for the UI. Shared by the commands and
+// run endpoints so both agree on which entries exist and which are runnable.
+func providerCommands(p provider.Provider, name string) []ProviderCommand {
+	var listed []provider.Command
 	if cl, ok := p.(provider.CommandLister); ok {
-		listed := cl.Commands()
-		cmds = make([]ProviderCommand, 0, len(listed))
-		for _, c := range listed {
-			cmds = append(cmds, ProviderCommand{Name: c.Name, Command: c.Command, Description: c.Description, Args: c.Args})
-		}
+		listed = cl.Commands()
 	} else {
 		// Generic default for providers without a curated command list.
 		binary := name
-		cmds = []ProviderCommand{
-			{Name: "run", Command: binary, Description: "Run " + name},
+		listed = []provider.Command{
+			{Name: "run", Command: binary, Description: "Run " + name, Interactive: true},
 			{Name: "version", Command: binary + " --version", Description: "Show version"},
 			{Name: "help", Command: binary + " --help", Description: "Show help"},
 		}
 	}
-
-	writeJSON(w, http.StatusOK, cmds)
+	cmds := make([]ProviderCommand, 0, len(listed))
+	for _, c := range listed {
+		cmds = append(cmds, ProviderCommand{
+			Name:        c.Name,
+			Command:     c.Command,
+			Description: c.Description,
+			Args:        c.Args,
+			Interactive: c.Interactive,
+			Runnable:    c.Runnable(),
+		})
+	}
+	return cmds
 }
 
 // listMCPs returns MCP servers configured for a provider. Providers

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -314,12 +314,19 @@ func (h *ProviderHandler) commands(w http.ResponseWriter, _ *http.Request, name 
 	writeJSON(w, http.StatusOK, providerCommands(p, name))
 }
 
-// providerCommands returns p's curated command list (or a generic default),
-// with Interactive/Runnable resolved for the UI. Shared by the commands and
-// run endpoints so both agree on which entries exist and which are runnable.
+// providerCommands returns p's curated command list (or a generic default) for
+// display. Interactive/Runnable are resolved for the UI.
+//
+// Only providers exposing a curated CommandLister get runnable=true entries:
+// their commands are constant literals safe to execute via the guarded /run
+// endpoint. The generic default interpolates the provider name into its command
+// strings, so those entries are always reported runnable=false — the run
+// endpoint (resolveRunnableArgv) likewise refuses non-CommandLister providers,
+// keeping the display flag and the execution policy in lockstep.
 func providerCommands(p provider.Provider, name string) []ProviderCommand {
+	cl, isCurated := p.(provider.CommandLister)
 	var listed []provider.Command
-	if cl, ok := p.(provider.CommandLister); ok {
+	if isCurated {
 		listed = cl.Commands()
 	} else {
 		// Generic default for providers without a curated command list.
@@ -338,7 +345,7 @@ func providerCommands(p provider.Provider, name string) []ProviderCommand {
 			Description: c.Description,
 			Args:        c.Args,
 			Interactive: c.Interactive,
-			Runnable:    c.Runnable(),
+			Runnable:    isCurated && c.Runnable(),
 		})
 	}
 	return cmds

--- a/server/handlers/providers_run.go
+++ b/server/handlers/providers_run.go
@@ -96,7 +96,7 @@ func (h *ProviderHandler) runCommand(w http.ResponseWriter, r *http.Request, nam
 		return
 	}
 
-	bin, args, ok := resolveRunnable(p, name, req.Command)
+	bin, args, ok := resolveRunnableArgv(p, req.Command)
 	if !ok {
 		httpError(w, "command is not runnable from the UI (unknown, interactive, or requires arguments): "+req.Command, http.StatusBadRequest)
 		return
@@ -122,19 +122,34 @@ func (h *ProviderHandler) runCommand(w http.ResponseWriter, r *http.Request, nam
 	})
 }
 
-// resolveRunnable finds the curated command entry named cmdName for provider p
-// and, if it is Runnable() (not interactive, no required args), returns the
-// binary and argument slice to exec. It looks the entry up by its display Name
-// in the provider's own allowlist, so the request only ever selects a
-// pre-vetted command — it can never inject a binary or arguments.
-func resolveRunnable(p provider.Provider, name, cmdName string) (string, []string, bool) {
-	for _, c := range providerCommands(p, name) {
+// resolveRunnableArgv returns the exact binary + argument slice to exec for the
+// curated command whose display Name equals cmdName.
+//
+// CodeQL barrier (go/command-injection): the executed argv is built ONLY from
+// the provider's own curated Commands() literals — constant strings compiled
+// into the binary (see commands.go / claude.go). The request-derived cmdName is
+// used solely in the `c.Name != cmdName` equality check to *select* an entry;
+// it never populates the returned bin/args. The generic default in
+// providerCommands (which interpolates the request-derived provider name into a
+// command string) is deliberately NOT consulted here — providers without a
+// CommandLister expose no runnable commands, so no request-derived string can
+// ever reach exec. This makes the taint barrier explicit for the analyzer.
+func resolveRunnableArgv(p provider.Provider, cmdName string) (string, []string, bool) {
+	cl, ok := p.(provider.CommandLister)
+	if !ok {
+		// Only curated constant command lists are executable. Providers with
+		// only the generic (name-interpolated) default are never run.
+		return "", nil, false
+	}
+	for _, c := range cl.Commands() {
 		if c.Name != cmdName {
 			continue
 		}
-		if !c.Runnable {
+		if !c.Runnable() {
 			return "", nil, false
 		}
+		// c.Command is a constant literal from the curated table; splitting it
+		// yields a constant argv with no request-derived data.
 		fields := strings.Fields(c.Command)
 		if len(fields) == 0 {
 			return "", nil, false

--- a/server/handlers/providers_run.go
+++ b/server/handlers/providers_run.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/rpuneet/mycel/pkg/provider"
+)
+
+// providerRunTimeout bounds a single subcommand run so a hung CLI can't wedge
+// the request.
+const providerRunTimeout = 20 * time.Second
+
+// providerRunOutputCap limits captured output so a chatty command can't
+// balloon the response.
+const providerRunOutputCap = 64 * 1024
+
+// providerRunResponse is the result of executing one allowlisted, runnable
+// provider subcommand.
+type providerRunResponse struct { //nolint:govet // field order matches JSON/API contract
+	Command   string `json:"command"`
+	Output    string `json:"output"`
+	ExitCode  int    `json:"exit_code"`
+	Truncated bool   `json:"truncated"`
+	TimedOut  bool   `json:"timed_out"`
+}
+
+// providerRunRunner executes bin with args and returns combined output and the
+// exit code. It is a package var so tests can substitute a harmless command
+// without shelling out to a real provider CLI.
+//
+// Security: bin and args come verbatim from the provider's curated Commands()
+// table (see resolveRunnable) — never from the request body, which only
+// selects which allowlisted entry to run. The command is exec'd directly with
+// an argument slice (no shell, no `sh -c`), so no request data is ever
+// interpreted by a shell. This is the CodeQL-recommended shape for
+// go/command-line-injection.
+var providerRunRunner = func(ctx context.Context, bin string, args []string) (string, int, error) {
+	cctx, cancel := context.WithTimeout(ctx, providerRunTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(cctx, bin, args...) //nolint:gosec // bin+args are a constant argv from the provider's curated Commands() allowlist, not request input
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			code = ee.ExitCode()
+		} else {
+			return string(out), -1, err
+		}
+	}
+	return string(out), code, nil
+}
+
+// runCommand handles POST /api/providers/{name}/run. It executes a single
+// allowlisted, non-interactive, no-argument subcommand from the provider's
+// curated Commands() list and returns its output inline.
+//
+// Guards, in order: loopback-only, provider must exist, the requested command
+// must resolve to a curated entry that is Runnable() (not interactive, no
+// required args), and the executed argv comes from that entry — never the
+// request body. Interactive/arg commands are refused with 400 so the UI shows
+// the honest "run in your terminal" path instead.
+func (h *ProviderHandler) runCommand(w http.ResponseWriter, r *http.Request, name string) {
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	p, ok := h.registry.Get(name)
+	if !ok {
+		httpError(w, "unknown provider: "+name, http.StatusNotFound)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<16))
+	if err != nil {
+		httpError(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	var req struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		httpError(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	req.Command = strings.TrimSpace(req.Command)
+	if req.Command == "" {
+		httpError(w, "command is required", http.StatusBadRequest)
+		return
+	}
+
+	bin, args, ok := resolveRunnable(p, name, req.Command)
+	if !ok {
+		httpError(w, "command is not runnable from the UI (unknown, interactive, or requires arguments): "+req.Command, http.StatusBadRequest)
+		return
+	}
+
+	out, code, runErr := providerRunRunner(r.Context(), bin, args)
+	if runErr != nil {
+		httpError(w, "failed to run command: "+runErr.Error(), http.StatusBadGateway)
+		return
+	}
+
+	truncated := false
+	if len(out) > providerRunOutputCap {
+		out = out[:providerRunOutputCap]
+		truncated = true
+	}
+
+	writeJSON(w, http.StatusOK, providerRunResponse{
+		Command:   strings.Join(append([]string{bin}, args...), " "),
+		Output:    out,
+		ExitCode:  code,
+		Truncated: truncated,
+	})
+}
+
+// resolveRunnable finds the curated command entry named cmdName for provider p
+// and, if it is Runnable() (not interactive, no required args), returns the
+// binary and argument slice to exec. It looks the entry up by its display Name
+// in the provider's own allowlist, so the request only ever selects a
+// pre-vetted command — it can never inject a binary or arguments.
+func resolveRunnable(p provider.Provider, name, cmdName string) (string, []string, bool) {
+	for _, c := range providerCommands(p, name) {
+		if c.Name != cmdName {
+			continue
+		}
+		if !c.Runnable {
+			return "", nil, false
+		}
+		fields := strings.Fields(c.Command)
+		if len(fields) == 0 {
+			return "", nil, false
+		}
+		return fields[0], fields[1:], true
+	}
+	return "", nil, false
+}

--- a/server/handlers/providers_run.go
+++ b/server/handlers/providers_run.go
@@ -31,31 +31,37 @@ type providerRunResponse struct { //nolint:govet // field order matches JSON/API
 	TimedOut  bool   `json:"timed_out"`
 }
 
-// providerRunRunner executes bin with args and returns combined output and the
-// exit code. It is a package var so tests can substitute a harmless command
-// without shelling out to a real provider CLI.
+// providerRunRunner executes bin with args and returns combined output, the
+// exit code, and whether the run hit the timeout. It is a package var so tests
+// can substitute a harmless command without shelling out to a real provider CLI.
 //
 // Security: bin and args come verbatim from the provider's curated Commands()
-// table (see resolveRunnable) — never from the request body, which only
+// table (see resolveRunnableArgv) — never from the request body, which only
 // selects which allowlisted entry to run. The command is exec'd directly with
 // an argument slice (no shell, no `sh -c`), so no request data is ever
 // interpreted by a shell. This is the CodeQL-recommended shape for
 // go/command-line-injection.
-var providerRunRunner = func(ctx context.Context, bin string, args []string) (string, int, error) {
+//
+// Output is captured through a bounded writer (runCapped) so a chatty command
+// can't balloon memory, and WaitDelay bounds the wait so a leaked grandchild
+// pipe can't wedge the read.
+var providerRunRunner = func(ctx context.Context, bin string, args []string) (out string, code int, timedOut, truncated bool, err error) {
 	cctx, cancel := context.WithTimeout(ctx, providerRunTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(cctx, bin, args...) //nolint:gosec // bin+args are a constant argv from the provider's curated Commands() allowlist, not request input
-	out, err := cmd.CombinedOutput()
-	code := 0
-	if err != nil {
+	raw, trunc, runErr := runCapped(cmd, providerRunOutputCap)
+	timedOut = errors.Is(cctx.Err(), context.DeadlineExceeded)
+	code = 0
+	if runErr != nil {
 		var ee *exec.ExitError
-		if errors.As(err, &ee) {
+		if errors.As(runErr, &ee) {
 			code = ee.ExitCode()
-		} else {
-			return string(out), -1, err
+		} else if !timedOut {
+			// A non-timeout failure to even start/collect the command.
+			return string(raw), -1, false, trunc, runErr
 		}
 	}
-	return string(out), code, nil
+	return string(raw), code, timedOut, trunc, nil
 }
 
 // runCommand handles POST /api/providers/{name}/run. It executes a single
@@ -102,16 +108,10 @@ func (h *ProviderHandler) runCommand(w http.ResponseWriter, r *http.Request, nam
 		return
 	}
 
-	out, code, runErr := providerRunRunner(r.Context(), bin, args)
+	out, code, timedOut, truncated, runErr := providerRunRunner(r.Context(), bin, args)
 	if runErr != nil {
 		httpError(w, "failed to run command: "+runErr.Error(), http.StatusBadGateway)
 		return
-	}
-
-	truncated := false
-	if len(out) > providerRunOutputCap {
-		out = out[:providerRunOutputCap]
-		truncated = true
 	}
 
 	writeJSON(w, http.StatusOK, providerRunResponse{
@@ -119,6 +119,7 @@ func (h *ProviderHandler) runCommand(w http.ResponseWriter, r *http.Request, nam
 		Output:    out,
 		ExitCode:  code,
 		Truncated: truncated,
+		TimedOut:  timedOut,
 	})
 }
 

--- a/server/handlers/providers_run_test.go
+++ b/server/handlers/providers_run_test.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/provider"
+)
+
+func providerRunMux() http.Handler {
+	reg := provider.NewRegistry()
+	reg.Register(provider.NewClaudeProvider())
+	mux := http.NewServeMux()
+	NewProviderHandler(reg, nil, nil, nil).Register(mux)
+	return mux
+}
+
+func runReq(command string) *http.Request {
+	body, _ := json.Marshal(map[string]string{"command": command})
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/claude/run", strings.NewReader(string(body)))
+	req.RemoteAddr = "127.0.0.1:5555"
+	return req
+}
+
+// TestProviderRunRunnable executes an allowlisted, non-interactive, no-arg
+// command and checks the exact argv came from the curated table.
+func TestProviderRunRunnable(t *testing.T) {
+	orig := providerRunRunner
+	t.Cleanup(func() { providerRunRunner = orig })
+
+	var gotBin string
+	var gotArgs []string
+	providerRunRunner = func(_ context.Context, bin string, args []string) (string, int, error) {
+		gotBin, gotArgs = bin, args
+		return "claude 1.2.3\n", 0, nil
+	}
+
+	rec := httptest.NewRecorder()
+	providerRunMux().ServeHTTP(rec, runReq("version"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	if gotBin != "claude" || strings.Join(gotArgs, " ") != "--version" {
+		t.Fatalf("argv = %q %q, want claude [--version]", gotBin, gotArgs)
+	}
+	var resp struct {
+		Output   string `json:"output"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(resp.Output, "claude 1.2.3") {
+		t.Fatalf("output = %q", resp.Output)
+	}
+}
+
+// TestProviderRunRejectsInteractiveAndArgs asserts the allowlist gate: only
+// runnable entries execute; interactive, arg-taking, and unknown commands are
+// refused without ever invoking the runner.
+func TestProviderRunRejectsInteractiveAndArgs(t *testing.T) {
+	orig := providerRunRunner
+	t.Cleanup(func() { providerRunRunner = orig })
+	ran := false
+	providerRunRunner = func(_ context.Context, _ string, _ []string) (string, int, error) {
+		ran = true
+		return "", 0, nil
+	}
+
+	mux := providerRunMux()
+	for _, name := range []string{
+		"resume",  // interactive + args
+		"mcp add", // requires args
+		"nope",    // not in the allowlist
+		"",        // empty
+	} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, runReq(name))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("command %q: status = %d, want 400", name, rec.Code)
+		}
+	}
+	if ran {
+		t.Fatalf("runner executed a non-runnable command — allowlist bypassed")
+	}
+}
+
+// TestProviderRunLoopbackGuard rejects non-loopback callers.
+func TestProviderRunLoopbackGuard(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"command": "version"})
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/claude/run", strings.NewReader(string(body)))
+	req.RemoteAddr = "203.0.113.9:8080"
+	rec := httptest.NewRecorder()
+	providerRunMux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", rec.Code)
+	}
+}
+
+// TestProviderRunUnknownProvider 404s for an unregistered provider.
+func TestProviderRunUnknownProvider(t *testing.T) {
+	body, _ := json.Marshal(map[string]string{"command": "version"})
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/ghost/run", strings.NewReader(string(body)))
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	providerRunMux().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+}

--- a/server/handlers/providers_run_test.go
+++ b/server/handlers/providers_run_test.go
@@ -34,9 +34,9 @@ func TestProviderRunRunnable(t *testing.T) {
 
 	var gotBin string
 	var gotArgs []string
-	providerRunRunner = func(_ context.Context, bin string, args []string) (string, int, error) {
+	providerRunRunner = func(_ context.Context, bin string, args []string) (string, int, bool, bool, error) {
 		gotBin, gotArgs = bin, args
-		return "claude 1.2.3\n", 0, nil
+		return "claude 1.2.3\n", 0, false, false, nil
 	}
 
 	rec := httptest.NewRecorder()
@@ -66,9 +66,9 @@ func TestProviderRunRejectsInteractiveAndArgs(t *testing.T) {
 	orig := providerRunRunner
 	t.Cleanup(func() { providerRunRunner = orig })
 	ran := false
-	providerRunRunner = func(_ context.Context, _ string, _ []string) (string, int, error) {
+	providerRunRunner = func(_ context.Context, _ string, _ []string) (string, int, bool, bool, error) {
 		ran = true
-		return "", 0, nil
+		return "", 0, false, false, nil
 	}
 
 	mux := providerRunMux()
@@ -100,10 +100,10 @@ func TestProviderRunArgvIsConstant(t *testing.T) {
 	var calls int
 	var gotBin string
 	var gotArgs []string
-	providerRunRunner = func(_ context.Context, bin string, args []string) (string, int, error) {
+	providerRunRunner = func(_ context.Context, bin string, args []string) (string, int, bool, bool, error) {
 		calls++
 		gotBin, gotArgs = bin, args
-		return "ok", 0, nil
+		return "ok", 0, false, false, nil
 	}
 
 	mux := providerRunMux()
@@ -134,6 +134,79 @@ func TestProviderRunArgvIsConstant(t *testing.T) {
 	}
 	if gotBin != "claude" || strings.Join(gotArgs, " ") != "--version" {
 		t.Fatalf("argv = %q %q, want exactly claude [--version]", gotBin, gotArgs)
+	}
+}
+
+// TestProviderRunNonZeroExit returns the CLI's exit code without failing the
+// request — a non-zero exit is a legitimate command result, not a 5xx.
+func TestProviderRunNonZeroExit(t *testing.T) {
+	orig := providerRunRunner
+	t.Cleanup(func() { providerRunRunner = orig })
+	providerRunRunner = func(_ context.Context, _ string, _ []string) (string, int, bool, bool, error) {
+		return "not logged in\n", 3, false, false, nil
+	}
+
+	rec := httptest.NewRecorder()
+	providerRunMux().ServeHTTP(rec, runReq("version"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		ExitCode int  `json:"exit_code"`
+		TimedOut bool `json:"timed_out"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ExitCode != 3 || resp.TimedOut {
+		t.Fatalf("exit_code = %d timed_out = %v, want 3 / false", resp.ExitCode, resp.TimedOut)
+	}
+}
+
+// TestProviderRunTruncated propagates the runner's truncation flag.
+func TestProviderRunTruncated(t *testing.T) {
+	orig := providerRunRunner
+	t.Cleanup(func() { providerRunRunner = orig })
+	providerRunRunner = func(_ context.Context, _ string, _ []string) (string, int, bool, bool, error) {
+		return strings.Repeat("x", providerRunOutputCap), 0, false, true, nil
+	}
+
+	rec := httptest.NewRecorder()
+	providerRunMux().ServeHTTP(rec, runReq("version"))
+	var resp struct {
+		Output    string `json:"output"`
+		Truncated bool   `json:"truncated"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Output) != providerRunOutputCap || !resp.Truncated {
+		t.Fatalf("output len = %d, truncated = %v; want cap / true", len(resp.Output), resp.Truncated)
+	}
+}
+
+// TestProviderRunTimedOut surfaces a timeout as timed_out=true (not a bogus
+// exit code) so the UI can explain the cause.
+func TestProviderRunTimedOut(t *testing.T) {
+	orig := providerRunRunner
+	t.Cleanup(func() { providerRunRunner = orig })
+	providerRunRunner = func(_ context.Context, _ string, _ []string) (string, int, bool, bool, error) {
+		return "", -1, true, false, nil
+	}
+
+	rec := httptest.NewRecorder()
+	providerRunMux().ServeHTTP(rec, runReq("version"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var resp struct {
+		TimedOut bool `json:"timed_out"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.TimedOut {
+		t.Fatalf("timed_out = false, want true")
 	}
 }
 

--- a/server/handlers/providers_run_test.go
+++ b/server/handlers/providers_run_test.go
@@ -89,6 +89,54 @@ func TestProviderRunRejectsInteractiveAndArgs(t *testing.T) {
 	}
 }
 
+// TestProviderRunArgvIsConstant asserts the executed argv comes only from the
+// curated Commands() literal — a crafted command field (extra tokens, shell
+// metacharacters, or a name that merely resembles a real one) can never alter
+// or extend the argv. The request only ever *selects* an allowlisted entry.
+func TestProviderRunArgvIsConstant(t *testing.T) {
+	orig := providerRunRunner
+	t.Cleanup(func() { providerRunRunner = orig })
+
+	var calls int
+	var gotBin string
+	var gotArgs []string
+	providerRunRunner = func(_ context.Context, bin string, args []string) (string, int, error) {
+		calls++
+		gotBin, gotArgs = bin, args
+		return "ok", 0, nil
+	}
+
+	mux := providerRunMux()
+
+	// Crafted selectors that must NOT match any curated entry Name → 400, no exec.
+	for _, crafted := range []string{
+		"version; rm -rf /",
+		"version --dangerous",
+		"version\n--evil",
+		"VERSION",
+		"claude --version",
+	} {
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, runReq(crafted))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("crafted %q: status = %d, want 400 (no match)", crafted, rec.Code)
+		}
+	}
+	if calls != 0 {
+		t.Fatalf("runner executed for a crafted selector — argv could be influenced by the request")
+	}
+
+	// The exact allowlisted name runs the exact constant argv, nothing more.
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, runReq("version"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if gotBin != "claude" || strings.Join(gotArgs, " ") != "--version" {
+		t.Fatalf("argv = %q %q, want exactly claude [--version]", gotBin, gotArgs)
+	}
+}
+
 // TestProviderRunLoopbackGuard rejects non-loopback callers.
 func TestProviderRunLoopbackGuard(t *testing.T) {
 	body, _ := json.Marshal(map[string]string{"command": "version"})

--- a/server/server.go
+++ b/server/server.go
@@ -387,6 +387,10 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	// Read-only autodetect of host OS + package managers (brew/apt/npm/…)
 	// with versions. Shells out only to each manager's own --version probe.
 	handlers.NewPackageManagersHandler().Register(mux)
+	// Guarded registry search + install: `brew search`/`npm search`/… behind
+	// strict input validation, argv-slice exec (no shell), timeouts, result
+	// caps, and a loopback gate. Install streams NDJSON like the deps installer.
+	handlers.NewPackageSearchHandler().Register(mux)
 	// Per-repo cost rollup. Handler is nil-safe and returns 503 when the
 	// global ledger isn't wired.
 	mux.Handle("/api/global/costs", handlers.NewGlobalCostsHandler(svc.Costs))

--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -111,3 +111,24 @@ describe("shared cache wiring", () => {
     expect(listCalls).toHaveLength(2);
   });
 });
+
+describe("tools seams API", () => {
+  it("searchPackages POSTs manager + query to the guarded endpoint", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ manager: "brew", query: "ripgrep", results: [] }));
+    await api.searchPackages("brew", "ripgrep");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/system/package-search");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ manager: "brew", query: "ripgrep" });
+  });
+
+  it("runProviderCommand POSTs the selected command name to the run endpoint", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ command: "claude --version", output: "1.0", exit_code: 0, truncated: false, timed_out: false }));
+    const res = await api.runProviderCommand("claude", "version");
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/providers/claude/run");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({ command: "version" });
+    expect(res.exit_code).toBe(0);
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -492,6 +492,10 @@ export interface PackageManager {
   available: boolean;
   /** true = this manager exposes a registry search the UI could drive. */
   searchable: boolean;
+  /** true = the server can install a searched package via this manager directly
+   *  (no sudo, non-interactive). Authoritative — the UI reads this instead of
+   *  hard-coding a manager set, so its Install affordance can't drift. */
+  direct_install: boolean;
 }
 
 export interface PackageManagersResponse {
@@ -513,10 +517,6 @@ export interface PackageSearchResponse {
   /** Present when the search command errored or found nothing. */
   error?: string;
 }
-
-/** Managers whose install the server runs directly (no sudo, non-interactive).
- *  Others surface a copyable command instead. Mirrors the backend installSpecs. */
-export const DIRECT_INSTALL_MANAGERS = new Set(["brew", "npm", "cargo"]);
 
 /** A provider model with live availability status. */
 export interface ModelInfo {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -500,6 +500,24 @@ export interface PackageManagersResponse {
   managers: PackageManager[];
 }
 
+/** One registry search hit. */
+export interface PackageSearchResult {
+  name: string;
+  description: string;
+}
+
+export interface PackageSearchResponse {
+  manager: string;
+  query: string;
+  results: PackageSearchResult[];
+  /** Present when the search command errored or found nothing. */
+  error?: string;
+}
+
+/** Managers whose install the server runs directly (no sudo, non-interactive).
+ *  Others surface a copyable command instead. Mirrors the backend installSpecs. */
+export const DIRECT_INSTALL_MANAGERS = new Set(["brew", "npm", "cargo"]);
+
 /** A provider model with live availability status. */
 export interface ModelInfo {
   id: string;
@@ -559,6 +577,19 @@ export interface ProviderCommand {
   command: string;
   description: string;
   args?: string;
+  /** true = needs a TTY / mutates auth state; the UI must not auto-run it. */
+  interactive: boolean;
+  /** true = safe to execute inline via runProviderCommand (no TTY, no args). */
+  runnable: boolean;
+}
+
+/** Result of running one allowlisted provider subcommand inline. */
+export interface ProviderRunResult {
+  command: string;
+  output: string;
+  exit_code: number;
+  truncated: boolean;
+  timed_out: boolean;
 }
 
 export interface ProviderMCPServer {
@@ -1296,6 +1327,26 @@ export const api = {
   /** Autodetected host package managers (brew/apt/npm/…) with versions. */
   getPackageManagers: () =>
     request<PackageManagersResponse>("/system/package-managers"),
+  /**
+   * Guarded registry search. The server validates the query charset, runs the
+   * manager's own `search` subcommand with an argv slice (no shell), times it
+   * out, and caps results. Managers without a vetted search spec 400.
+   */
+  searchPackages: (manager: string, query: string) =>
+    request<PackageSearchResponse>("/system/package-search", {
+      method: "POST",
+      body: JSON.stringify({ manager, query }),
+    }),
+  /**
+   * Run one allowlisted, non-interactive, no-argument provider subcommand and
+   * return its output inline. Interactive/arg commands are refused by the
+   * server (the UI must not offer Run for them).
+   */
+  runProviderCommand: (name: string, command: string) =>
+    request<ProviderRunResult>(`/providers/${encodeURIComponent(name)}/run`, {
+      method: "POST",
+      body: JSON.stringify({ command }),
+    }),
   getSettings: () => request<SettingsConfig>("/settings"),
   updateSettings: (patch: Record<string, unknown>) =>
     request<SettingsConfig>("/settings", {

--- a/web/src/components/RegistrySearch.tsx
+++ b/web/src/components/RegistrySearch.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
-import { api, DIRECT_INSTALL_MANAGERS } from "../api/client";
+import { api } from "../api/client";
 import type { PackageManager, PackageSearchResult } from "../api/client";
 import { installPackage } from "../wizard/installStream";
 import { CopyButton } from "./CopyButton";
@@ -22,8 +22,10 @@ import { CopyButton } from "./CopyButton";
 // explain why before making a doomed request.
 const QUERY_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
 
-// Copyable install command for managers we don't run directly. Honest,
-// terminal-ready lines; `{p}` is replaced with the (already validated) name.
+// Copyable install command per manager, for the ones the server won't install
+// directly (sudo / non-standard). Honest, terminal-ready lines; `{p}` is
+// replaced with the (already validated) name. The trailing default covers any
+// manager not listed so a copy never yields a bare package name.
 const COPY_INSTALL: Record<string, string> = {
   apt: "sudo apt-get install -y {p}",
   dnf: "sudo dnf install {p}",
@@ -33,10 +35,15 @@ const COPY_INSTALL: Record<string, string> = {
   winget: "winget install {p}",
 };
 
+function copyInstallCmd(manager: string, name: string): string {
+  return (COPY_INSTALL[manager] ?? `${manager} install {p}`).replace("{p}", name);
+}
+
 type SearchState = "idle" | "searching" | "done" | "error";
 
 export function RegistrySearch() {
   const [managers, setManagers] = useState<PackageManager[]>([]);
+  const [loadingManagers, setLoadingManagers] = useState(true);
   const [manager, setManager] = useState("");
   const [query, setQuery] = useState("");
   const [state, setState] = useState<SearchState>("idle");
@@ -53,9 +60,12 @@ export function RegistrySearch() {
         setManagers(searchable);
         if (searchable.length > 0 && searchable[0]) setManager(searchable[0].id);
       })
-      .catch(() => { /* leave picker empty — the empty-state copy covers it */ });
+      .catch(() => { /* leave picker empty — the empty-state copy covers it */ })
+      .finally(() => { if (alive) setLoadingManagers(false); });
     return () => { alive = false; };
   }, []);
+
+  const directInstall = managers.find((m) => m.id === manager)?.direct_install ?? false;
 
   const queryValid = QUERY_RE.test(query.trim());
 
@@ -75,6 +85,12 @@ export function RegistrySearch() {
       setState("error");
     }
   };
+
+  if (loadingManagers) {
+    return (
+      <div className="h-8 w-64 animate-pulse rounded-md bg-mycel-surface-hover" aria-busy aria-label="Detecting package managers" />
+    );
+  }
 
   if (managers.length === 0) {
     return (
@@ -135,8 +151,8 @@ export function RegistrySearch() {
 
       {results.length > 0 && (
         <ul className="rounded-lg border border-mycel-border divide-y divide-mycel-border overflow-hidden">
-          {results.map((r) => (
-            <ResultRow key={`${manager}:${r.name}`} manager={manager} result={r} />
+          {results.map((r, i) => (
+            <ResultRow key={`${manager}:${r.name}:${i}`} manager={manager} direct={directInstall} result={r} />
           ))}
         </ul>
       )}
@@ -144,9 +160,8 @@ export function RegistrySearch() {
   );
 }
 
-function ResultRow({ manager, result }: { manager: string; result: PackageSearchResult }) {
-  const direct = DIRECT_INSTALL_MANAGERS.has(manager);
-  const copyCmd = (COPY_INSTALL[manager] ?? "{p}").replace("{p}", result.name);
+function ResultRow({ manager, direct, result }: { manager: string; direct: boolean; result: PackageSearchResult }) {
+  const copyCmd = copyInstallCmd(manager, result.name);
 
   return (
     <li className="px-3 py-2 bg-mycel-surface">

--- a/web/src/components/RegistrySearch.tsx
+++ b/web/src/components/RegistrySearch.tsx
@@ -1,0 +1,257 @@
+import { useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { api, DIRECT_INSTALL_MANAGERS } from "../api/client";
+import type { PackageManager, PackageSearchResult } from "../api/client";
+import { installPackage } from "../wizard/installStream";
+import { CopyButton } from "./CopyButton";
+
+/* ── RegistrySearch ───────────────────────────────────────────────────
+ *
+ * Seam 1: a guarded browse/search over the host's package registries. Pick a
+ * detected, searchable manager, type a package name, and the daemon runs that
+ * manager's own `search` subcommand (validated charset, argv-slice exec, no
+ * shell, timeout, capped results). Each hit gets an Install action:
+ *   - brew / npm / cargo  → streamed install (no sudo, non-interactive)
+ *   - everything else      → a copyable command, honestly "run in your terminal"
+ *
+ * Managers with no vetted search spec are never offered here — the picker only
+ * lists searchable ones, and an empty picker says so plainly.
+ */
+
+// Client mirror of the server's pkgQueryPattern so we can disable Search and
+// explain why before making a doomed request.
+const QUERY_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
+
+// Copyable install command for managers we don't run directly. Honest,
+// terminal-ready lines; `{p}` is replaced with the (already validated) name.
+const COPY_INSTALL: Record<string, string> = {
+  apt: "sudo apt-get install -y {p}",
+  dnf: "sudo dnf install {p}",
+  yum: "sudo yum install {p}",
+  pacman: "sudo pacman -S {p}",
+  zypper: "sudo zypper install {p}",
+  winget: "winget install {p}",
+};
+
+type SearchState = "idle" | "searching" | "done" | "error";
+
+export function RegistrySearch() {
+  const [managers, setManagers] = useState<PackageManager[]>([]);
+  const [manager, setManager] = useState("");
+  const [query, setQuery] = useState("");
+  const [state, setState] = useState<SearchState>("idle");
+  const [results, setResults] = useState<PackageSearchResult[]>([]);
+  const [note, setNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api
+      .getPackageManagers()
+      .then((res) => {
+        if (!alive) return;
+        const searchable = (res.managers ?? []).filter((m) => m.searchable);
+        setManagers(searchable);
+        if (searchable.length > 0 && searchable[0]) setManager(searchable[0].id);
+      })
+      .catch(() => { /* leave picker empty — the empty-state copy covers it */ });
+    return () => { alive = false; };
+  }, []);
+
+  const queryValid = QUERY_RE.test(query.trim());
+
+  const runSearch = async () => {
+    const q = query.trim();
+    if (!manager || !queryValid) return;
+    setState("searching");
+    setResults([]);
+    setNote(null);
+    try {
+      const res = await api.searchPackages(manager, q);
+      setResults(res.results ?? []);
+      setNote(res.error ?? null);
+      setState("done");
+    } catch (e) {
+      setNote(e instanceof Error ? e.message : "Search failed.");
+      setState("error");
+    }
+  };
+
+  if (managers.length === 0) {
+    return (
+      <p className="text-[11px] text-mycel-muted">
+        No searchable package manager detected on this host. Registry search needs one of
+        brew, npm, apt, dnf, pacman, cargo… on PATH.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          value={manager}
+          onChange={(e) => { setManager(e.target.value); setResults([]); setState("idle"); setNote(null); }}
+          aria-label="Registry to search"
+          className="px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent"
+        >
+          {managers.map((m) => (
+            <option key={m.id} value={m.id}>{m.name}</option>
+          ))}
+        </select>
+        <div className="relative flex-1 min-w-[180px]">
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => { if (e.key === "Enter") void runSearch(); }}
+            placeholder="Search the registry (e.g. ripgrep)…"
+            aria-label="Package search query"
+            className="w-full px-2.5 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => void runSearch()}
+          disabled={!queryValid || state === "searching"}
+          className="inline-flex items-center gap-1.5 h-8 px-3 text-sm font-medium rounded-md bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-mycel-accent"
+        >
+          {state === "searching" ? "Searching…" : "Search"}
+        </button>
+      </div>
+
+      {query.trim() !== "" && !queryValid && (
+        <p className="text-[11px] text-mycel-warning">
+          Enter a single package name — letters, digits and . _ + - only (no spaces or shell characters).
+        </p>
+      )}
+
+      {note && (
+        <p className={`text-[11px] ${state === "error" ? "text-mycel-error" : "text-mycel-muted"}`}>{note}</p>
+      )}
+
+      {state === "done" && results.length === 0 && !note && (
+        <p className="text-[11px] text-mycel-muted">No packages matched “{query.trim()}”.</p>
+      )}
+
+      {results.length > 0 && (
+        <ul className="rounded-lg border border-mycel-border divide-y divide-mycel-border overflow-hidden">
+          {results.map((r) => (
+            <ResultRow key={`${manager}:${r.name}`} manager={manager} result={r} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ResultRow({ manager, result }: { manager: string; result: PackageSearchResult }) {
+  const direct = DIRECT_INSTALL_MANAGERS.has(manager);
+  const copyCmd = (COPY_INSTALL[manager] ?? "{p}").replace("{p}", result.name);
+
+  return (
+    <li className="px-3 py-2 bg-mycel-surface">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <span className="text-sm font-medium text-mycel-text font-mono">{result.name}</span>
+          {result.description && (
+            <p className="text-[11px] text-mycel-muted truncate max-w-md">{result.description}</p>
+          )}
+        </div>
+        <div className="shrink-0">
+          {direct ? (
+            <PackageInstallButton manager={manager} pkg={result.name} />
+          ) : (
+            <div className="flex items-center gap-1" title="Needs sudo / a terminal — run it yourself">
+              <code className="text-[11px] font-mono text-mycel-text-2 bg-mycel-bg rounded-md px-2 py-1 border border-mycel-border">{copyCmd}</code>
+              <CopyButton text={copyCmd} />
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+type RunState = "idle" | "running" | "ok" | "error";
+
+/* Streamed install of one searched package. Mirrors the deps installer's
+ * honest state machine: indeterminate bar + live line count while running,
+ * resolved green/red on completion. */
+function PackageInstallButton({ manager, pkg }: { manager: string; pkg: string }) {
+  const reduceMotion = useReducedMotion();
+  const [state, setState] = useState<RunState>("idle");
+  const [lines, setLines] = useState<string[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const consoleRef = useRef<HTMLDivElement>(null);
+  const runningRef = useRef(false);
+
+  useEffect(() => {
+    const el = consoleRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines]);
+  useEffect(() => () => { runningRef.current = false; }, []);
+
+  const run = async () => {
+    setState("running");
+    setLines([]);
+    setErr(null);
+    runningRef.current = true;
+    try {
+      const code = await installPackage(manager, pkg, (ev) => {
+        if (!runningRef.current) return;
+        if (ev.type === "start") setLines((l) => [...l, `$ ${ev.command}`]);
+        else if (ev.type === "log") setLines((l) => [...l, ev.line]);
+      });
+      if (!runningRef.current) return;
+      if (code === 0) setState("ok");
+      else { setState("error"); setErr(`Install exited with code ${code}.`); }
+    } catch (e) {
+      if (!runningRef.current) return;
+      setState("error");
+      setErr(e instanceof Error ? e.message : "Install failed.");
+    } finally {
+      runningRef.current = false;
+    }
+  };
+
+  const barTone = state === "ok" ? "bg-mycel-success" : state === "error" ? "bg-mycel-error" : "bg-mycel-accent";
+
+  return (
+    <div className="flex flex-col items-end gap-1.5">
+      <button
+        type="button"
+        onClick={() => void run()}
+        disabled={state === "running"}
+        className="inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-1 rounded-md border border-mycel-accent bg-mycel-accent-subtle text-mycel-accent hover:bg-mycel-accent hover:text-mycel-accent-fg transition-colors disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-mycel-accent"
+      >
+        {state === "running" ? "Installing…" : state === "ok" ? "Installed ✓" : state === "error" ? "Retry install" : "Install"}
+      </button>
+      {(state === "running" || state === "ok" || state === "error") && (
+        <div className="w-56 space-y-1.5">
+          <div className="h-1 rounded-full bg-mycel-border overflow-hidden" role="progressbar" aria-busy={state === "running"} aria-label="Install progress">
+            {state === "running" ? (
+              <div className={`h-full w-1/3 rounded-full ${barTone} ${reduceMotion ? "" : "animate-indeterminate"}`} />
+            ) : (
+              <div className={`h-full w-full rounded-full ${barTone}`} />
+            )}
+          </div>
+          <AnimatePresence>
+            {lines.length > 0 && (
+              <motion.div
+                ref={consoleRef}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="max-h-32 overflow-auto rounded-md border border-mycel-border bg-mycel-bg px-2 py-1 font-mono text-[10.5px] leading-relaxed text-mycel-text-2 whitespace-pre-wrap text-left"
+              >
+                {lines.map((l, i) => (
+                  <div key={i} className={l.startsWith("$ ") ? "text-mycel-accent" : ""}>{l}</div>
+                ))}
+              </motion.div>
+            )}
+          </AnimatePresence>
+          {err && <p className="text-[10.5px] text-mycel-error">{err}</p>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -570,6 +570,17 @@ function ProviderModelSection({
         Switching provider isn’t supported in place — clone the agent onto a different
         provider instead.
         {/* follow-up: a real per-agent provider switch needs a container re-image. */}
+        {tool && (
+          <>
+            {" "}
+            <Link
+              to={`/tools/${encodeURIComponent(tool)}`}
+              className="text-mycel-accent hover:underline"
+            >
+              Manage {tool} (commands, MCP, install) →
+            </Link>
+          </>
+        )}
       </p>
     </section>
   );

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -619,12 +619,110 @@ function AgentsSidebar({
 
 /* ── Section: Commands ── */
 
-function CommandsSection({ commands }: { commands: ProviderCommand[] }) {
+/* One command row. Runnable (non-interactive, no-arg) commands get a Run
+ * button that executes them via the guarded /run endpoint and shows the output
+ * inline. Interactive commands (login/auth/TUI) and arg-taking commands are
+ * never auto-run — they carry an honest "run in your terminal" label and a
+ * copy button. */
+function CommandRow({ providerName, command }: { providerName: string; command: ProviderCommand }) {
+  const fullCmd = command.args ? `${command.command} ${command.args}` : command.command;
+  const [state, setState] = useState<"idle" | "running" | "done" | "error">("idle");
+  const [output, setOutput] = useState<string>("");
+  const [exitCode, setExitCode] = useState<number | null>(null);
+  const [errMsg, setErrMsg] = useState<string | null>(null);
+
+  const run = async () => {
+    setState("running");
+    setOutput("");
+    setErrMsg(null);
+    setExitCode(null);
+    try {
+      const res = await api.runProviderCommand(providerName, command.name);
+      setOutput(res.output.trimEnd());
+      setExitCode(res.exit_code);
+      setState(res.exit_code === 0 ? "done" : "error");
+    } catch (e) {
+      setErrMsg(e instanceof Error ? e.message : "Command failed to run.");
+      setState("error");
+    }
+  };
+
+  return (
+    <>
+      <tr className="border-b border-mycel-border hover:bg-mycel-surface-hover transition-colors">
+        <td className="px-4 py-2.5 font-medium align-top">{command.name}</td>
+        <td className="px-4 py-2.5 text-mycel-muted align-top">{command.description}</td>
+        <td className="px-4 py-2.5 align-top">
+          <div className="flex items-center gap-1">
+            <code className="font-mono text-xs text-mycel-text-2">
+              {command.command}
+              {command.args && <span className="text-mycel-muted ml-1">{command.args}</span>}
+            </code>
+            <CopyButton text={fullCmd} />
+          </div>
+        </td>
+        <td className="px-4 py-2.5 align-top text-right">
+          {command.runnable ? (
+            <button
+              type="button"
+              onClick={() => void run()}
+              disabled={state === "running"}
+              className="inline-flex items-center gap-1.5 text-[11px] font-medium px-2.5 py-1 rounded border border-mycel-accent bg-mycel-accent-subtle text-mycel-accent hover:bg-mycel-accent hover:text-mycel-accent-fg transition-colors disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-mycel-accent"
+            >
+              {state === "running" ? "Running…" : state === "done" || state === "error" ? "Run again" : "Run"}
+            </button>
+          ) : (
+            <span
+              className="inline-flex items-center gap-1 text-[10.5px] text-mycel-muted"
+              title={command.interactive ? "Needs a terminal (interactive / auth). Copy and run it yourself." : "Takes arguments — copy and run it yourself."}
+            >
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+                <rect x="3" y="4" width="18" height="16" rx="2" /><path strokeLinecap="round" strokeLinejoin="round" d="M7 9l3 3-3 3M13 15h4" />
+              </svg>
+              {command.interactive ? "Terminal" : "Args"}
+            </span>
+          )}
+        </td>
+      </tr>
+      {state !== "idle" && (
+        <tr className="border-b border-mycel-border bg-mycel-bg">
+          <td colSpan={4} className="px-4 py-2">
+            {errMsg ? (
+              <p className="text-xs text-mycel-error">{errMsg}</p>
+            ) : (
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 text-[10.5px] text-mycel-muted">
+                  <span className="font-mono text-mycel-accent">$ {command.command}</span>
+                  {exitCode !== null && (
+                    <span className={exitCode === 0 ? "text-mycel-success" : "text-mycel-error"}>
+                      exit {exitCode}
+                    </span>
+                  )}
+                </div>
+                <pre className="max-h-56 overflow-auto rounded border border-mycel-border bg-mycel-surface px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-mycel-text-2 whitespace-pre-wrap">
+                  {state === "running" ? "Running…" : output || "(no output)"}
+                </pre>
+              </div>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function CommandsSection({ providerName, commands }: { providerName: string; commands: ProviderCommand[] }) {
+  const runnableCount = commands.filter((c) => c.runnable).length;
   return (
     <section>
-      <h2 className="text-xs font-medium text-mycel-muted uppercase tracking-widest mb-3">
-        Available Commands ({commands.length})
-      </h2>
+      <div className="flex items-baseline gap-2 mb-3">
+        <h2 className="text-xs font-medium text-mycel-muted uppercase tracking-widest">
+          Available Commands ({commands.length})
+        </h2>
+        {commands.length > 0 && (
+          <span className="text-[10.5px] text-mycel-muted">{runnableCount} runnable · rest open a terminal</span>
+        )}
+      </div>
       {commands.length === 0 ? (
         <EmptyState
           icon=">"
@@ -639,27 +737,13 @@ function CommandsSection({ commands }: { commands: ProviderCommand[] }) {
                 <th className="px-4 py-2 font-medium text-left">Command</th>
                 <th className="px-4 py-2 font-medium text-left">Description</th>
                 <th className="px-4 py-2 font-medium text-left">Usage</th>
+                <th className="px-4 py-2 font-medium text-right">Action</th>
               </tr>
             </thead>
             <tbody>
-              {commands.map((c) => {
-                const fullCmd = c.args ? `${c.command} ${c.args}` : c.command;
-                return (
-                  <tr key={c.name} className="border-b border-mycel-border hover:bg-mycel-surface-hover transition-colors">
-                    <td className="px-4 py-2.5 font-medium">{c.name}</td>
-                    <td className="px-4 py-2.5 text-mycel-muted">{c.description}</td>
-                    <td className="px-4 py-2.5">
-                      <div className="flex items-center gap-1">
-                        <code className="font-mono text-xs text-mycel-text-2">
-                          {c.command}
-                          {c.args && <span className="text-mycel-muted ml-1">{c.args}</span>}
-                        </code>
-                        <CopyButton text={fullCmd} />
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
+              {commands.map((c) => (
+                <CommandRow key={c.name} providerName={providerName} command={c} />
+              ))}
             </tbody>
           </table>
         </div>
@@ -790,7 +874,7 @@ export function ProviderDetail() {
             onToast={addToast}
           />
 
-          <CommandsSection commands={commands ?? []} />
+          <CommandsSection providerName={provider.name} commands={commands ?? []} />
         </div>
 
         {/* Right column: Stats + Cost bars + Agents */}

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -629,18 +629,30 @@ function CommandRow({ providerName, command }: { providerName: string; command: 
   const [state, setState] = useState<"idle" | "running" | "done" | "error">("idle");
   const [output, setOutput] = useState<string>("");
   const [exitCode, setExitCode] = useState<number | null>(null);
+  const [truncated, setTruncated] = useState(false);
+  const [timedOut, setTimedOut] = useState(false);
   const [errMsg, setErrMsg] = useState<string | null>(null);
+
+  // The reason a command can't be run inline — used as both the visible/aria
+  // explanation and the pointer tooltip (title alone isn't keyboard/SR-accessible).
+  const notRunnableReason = command.interactive
+    ? "Interactive command (needs a terminal / auth) — copy and run it yourself."
+    : "Takes arguments — copy and run it yourself.";
 
   const run = async () => {
     setState("running");
     setOutput("");
     setErrMsg(null);
     setExitCode(null);
+    setTruncated(false);
+    setTimedOut(false);
     try {
       const res = await api.runProviderCommand(providerName, command.name);
       setOutput(res.output.trimEnd());
       setExitCode(res.exit_code);
-      setState(res.exit_code === 0 ? "done" : "error");
+      setTruncated(res.truncated);
+      setTimedOut(res.timed_out);
+      setState(res.exit_code === 0 && !res.timed_out ? "done" : "error");
     } catch (e) {
       setErrMsg(e instanceof Error ? e.message : "Command failed to run.");
       setState("error");
@@ -674,7 +686,8 @@ function CommandRow({ providerName, command }: { providerName: string; command: 
           ) : (
             <span
               className="inline-flex items-center gap-1 text-[10.5px] text-mycel-muted"
-              title={command.interactive ? "Needs a terminal (interactive / auth). Copy and run it yourself." : "Takes arguments — copy and run it yourself."}
+              aria-label={notRunnableReason}
+              title={notRunnableReason}
             >
               <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
                 <rect x="3" y="4" width="18" height="16" rx="2" /><path strokeLinecap="round" strokeLinejoin="round" d="M7 9l3 3-3 3M13 15h4" />
@@ -691,16 +704,19 @@ function CommandRow({ providerName, command }: { providerName: string; command: 
               <p className="text-xs text-mycel-error">{errMsg}</p>
             ) : (
               <div className="space-y-1">
-                <div className="flex items-center gap-2 text-[10.5px] text-mycel-muted">
+                <div className="flex items-center gap-2 text-[10.5px] text-mycel-muted flex-wrap">
                   <span className="font-mono text-mycel-accent">$ {command.command}</span>
-                  {exitCode !== null && (
+                  {timedOut ? (
+                    <span className="text-mycel-error">timed out</span>
+                  ) : exitCode !== null && (
                     <span className={exitCode === 0 ? "text-mycel-success" : "text-mycel-error"}>
                       exit {exitCode}
                     </span>
                   )}
+                  {truncated && <span className="text-mycel-warning">output truncated</span>}
                 </div>
                 <pre className="max-h-56 overflow-auto rounded border border-mycel-border bg-mycel-surface px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-mycel-text-2 whitespace-pre-wrap">
-                  {state === "running" ? "Running…" : output || "(no output)"}
+                  {state === "running" ? "Running…" : output || (timedOut ? "(no output — command timed out)" : "(no output)")}
                 </pre>
               </div>
             )}

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from "../components/EmptyState";
 import { ProvidersTable } from "../components/ProvidersTable";
 import { ProviderDefaults } from "../components/ProviderDefaults";
 import { PackageManagers } from "../components/PackageManagers";
+import { RegistrySearch } from "../components/RegistrySearch";
 import { CopyButton } from "../components/CopyButton";
 import { ToastContainer, useToast } from "../components/Toast";
 import type { ToastLevel } from "../components/Toast";
@@ -681,6 +682,13 @@ export function Tools() {
         <div className="mb-3">
           <p className="text-[10.5px] text-mycel-muted uppercase tracking-[0.08em] mb-1.5">Detected package managers</p>
           <PackageManagers />
+        </div>
+        {/* Guarded registry search — browse a manager's registry and install a
+            hit. brew/npm/cargo install inline; the rest give a copyable
+            terminal command (honest about sudo). */}
+        <div className="mb-4">
+          <p className="text-[10.5px] text-mycel-muted uppercase tracking-[0.08em] mb-1.5">Search a registry</p>
+          <RegistrySearch />
         </div>
         {filteredCli.length === 0 ? (
           searchLower ? (

--- a/web/src/wizard/installStream.ts
+++ b/web/src/wizard/installStream.ts
@@ -33,6 +33,36 @@ export async function installDep(
     signal: opts?.signal,
   });
 
+  return consumeInstallStream(res, onEvent);
+}
+
+/**
+ * installPackage streams the install of a registry-searched package via an
+ * allowlisted manager (brew / npm / cargo) over POST /api/system/package-install
+ * — the same NDJSON stream shape as installDep. The server validates the
+ * package-name charset and execs the manager directly with an argv slice.
+ */
+export async function installPackage(
+  manager: string,
+  pkg: string,
+  onEvent: (ev: InstallEvent) => void,
+  opts?: { signal?: AbortSignal },
+): Promise<number> {
+  const res = await fetch("/api/system/package-install", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ manager, package: pkg }),
+    signal: opts?.signal,
+  });
+  return consumeInstallStream(res, onEvent);
+}
+
+/** Reads an NDJSON install stream, dispatching each event and resolving with
+ *  the process exit code. Throws on transport errors or an error event. */
+async function consumeInstallStream(
+  res: Response,
+  onEvent: (ev: InstallEvent) => void,
+): Promise<number> {
   if (!res.ok || !res.body) {
     let msg = `Install failed: ${res.status}`;
     try {


### PR DESCRIPTION
Part of #2674 — closes the three seams PR #3394 left open: **registry search / subcommand execution / cross-page consistency**, with hard security guards.

## Fully working

### Seam 1 — Guarded registry browse/search + install
- `POST /api/system/package-search` runs each manager's own `search` subcommand — brew, npm, apt (`apt-cache`), dnf, yum, pacman, zypper, cargo, winget — behind: manager allowlist, strict query charset validation, **argv-slice exec (never `sh -c`)**, timeout, output + result caps, loopback gate. Managers with no vetted search spec are honestly labelled "search unavailable".
- `POST /api/system/package-install` streams an install for **brew/npm/cargo** (no sudo, non-interactive) as NDJSON, reusing the deps installer's stream engine; other managers surface a copyable terminal command (honest about sudo).
- Web: `RegistrySearch` on the Tools page — pick a searchable manager → search → Install inline (direct managers) or copy the command (the rest). The `searchable` flag is now derived from the actual search specs, so it can't drift.

### Seam 2 — Runnable provider subcommands
- `provider.Command` gains `Interactive`; `Runnable()` = `!Interactive && no args`. Curated `Commands()` tables mark login/auth/TUI/run as interactive.
- `POST /api/providers/{name}/run` executes **only allowlisted, runnable** entries: the request selects a curated entry by name; the executed argv comes verbatim from that entry, exec'd directly (no shell). Interactive / arg-taking / unknown commands → 400.
- Web: ProviderDetail commands table gains a **Run** button with inline output for runnable commands; interactive ones are labelled "Terminal" + copy.

### Seam 3 — Cross-page consistency
- `ProviderDefaults` is already the shared control on both the Tools page and the wizard `StepProviders` (no divergent copy). AgentDetail's per-agent **Provider & Model** section now links to the canonical `/tools/{provider}` surface (commands, MCP, install) rather than duplicating it.

## Security-guard approach
Command execution never interpolates request data into a shell:
- **Allowlists**: manager ids resolve to vetted specs; provider subcommands resolve to curated `Commands()` entries — the request only *selects* an entry, never supplies the binary/args.
- **arg-slices**: every exec is `exec.CommandContext(ctx, bin, args...)` with a constant `bin` and the validated token as one arg element — the CodeQL-recommended shape for `go/command-line-injection`.
- **Charset validation**: search query `^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$`; install package adds `@`/`/` for npm scopes. Rejected before any exec.
- **Timeouts, output/result caps, loopback gate** on all executing endpoints.

## Test plan
- Go: `go build ./...`, `go vet`, `golangci-lint` (0 issues), `go test ./server/... ./pkg/provider/...` — new tests assert 11 injection queries + injection package names are rejected, the subcommand allowlist refuses interactive/arg/unknown, parsers, and loopback guards.
- Web: `tsc --noEmit`, `bun run lint`, `bun run build`, `vitest run` (313 passed) — added client-call tests for the two new endpoints.
- Live smoke on a throwaway `MYCEL_HOME` at `127.0.0.1:8099`: `brew`/`npm` search returned real results; injection + unknown-manager queries → 400; `claude version` ran and returned real output; `resume` (interactive) + unknown command → 400; install guards → 400. Torn down.

## Deferred (honest)
- In-place per-agent provider switch still isn't supported (needs a container re-image) — unchanged, labelled in AgentDetail with a `// follow-up:`.
- Install-from-search is limited to brew/npm/cargo; sudo-requiring managers intentionally give a copyable command rather than running privileged installs from the browser.

## CodeQL considerations
All command execution uses fixed binaries + arg-slices sourced from allowlists (never request-derived strings, never `sh -c` with interpolation), so the command-injection/SSRF surface should not trip `go/command-line-injection`. The pre-existing vetted-table `sh -c` installer is untouched and already annotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search package registries from the CLI Dependencies section.
  * Install supported packages with live progress, output, cancellation, and retry support.
  * Run safe, non-interactive provider commands directly from the provider details page.
  * View command status, output, exit codes, and guidance for commands requiring terminal interaction.
  * Access configured tool management pages from agent settings.

* **Bug Fixes**
  * Improved command execution validation, error handling, output limits, and loopback-only access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->