### PR TITLE
feat(live): capture Live activity for codex via transcript tailing

### DIFF
--- a/pkg/provider/codex_transcript.go
+++ b/pkg/provider/codex_transcript.go
@@ -1,0 +1,355 @@
+package provider
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// codex transcript capture.
+//
+// The codex CLI writes one JSONL "rollout" file per session under
+// <codexHome>/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl (codexHome defaults
+// to ~/.codex). Unlike pi the path is date-keyed, not cwd-keyed: the working
+// directory lives inside the file, in the first `session_meta` record. So codex
+// implements TranscriptFileSelector (match the agent's cwd against session_meta
+// and pick the newest matching rollout) rather than a cwd-encoded path glob, and
+// TranscriptSessionParser (its tool-result lines carry only a call_id, no tool
+// name, so a per-file session resolves each result against the earlier call).
+//
+// Each line is {"timestamp":…,"type":…,"payload":{…}}. The records that map onto
+// the daemon hook vocabulary are:
+//
+//	{"type":"session_meta","payload":{"cwd":"…", …}}                      → SessionStart
+//	{"type":"event_msg","payload":{"type":"user_message","message":"…"}}  → UserPromptSubmit
+//	{"type":"event_msg","payload":{"type":"task_complete", …}}            → Stop
+//	{"type":"response_item","payload":{"type":"function_call","name":"…","arguments":"{…}","call_id":"…"}}       → PreToolUse
+//	{"type":"response_item","payload":{"type":"custom_tool_call","name":"…","input":"…","call_id":"…"}}          → PreToolUse
+//	{"type":"response_item","payload":{"type":"function_call_output","call_id":"…","output":"Exit code: N\n…"}}  → PostToolUse / …Failure
+//	{"type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"…","output":"{\"metadata\":{\"exit_code\":N}}"}} → PostToolUse / …Failure
+//
+// Assistant text and reasoning have no hook-event equivalent and are skipped, as
+// in the pi parser. Verified against real rollout files under ~/.codex/sessions
+// on the dev machine (including mycel-spawned codex agents).
+
+// codexSessionsRoot resolves codex's sessions directory. codex honors CODEX_HOME
+// (sessions live under <CODEX_HOME>/sessions); otherwise the default under the
+// user home is authoritative for mycel-spawned tmux agents. Overridable in tests.
+var codexSessionsRoot = func() string {
+	if dir := os.Getenv("CODEX_HOME"); dir != "" {
+		return filepath.Join(dir, "sessions")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".codex", "sessions")
+}
+
+// ActivityMode reports that codex exposes activity via an on-disk session
+// transcript the daemon tails, not via hook commands.
+func (p *CodexProvider) ActivityMode() string { return ActivityModeTranscript }
+
+// WriteHookConfig is a no-op: codex has no hook mechanism, activity is sourced
+// by tailing its rollout transcript (ActivityModeTranscript).
+func (p *CodexProvider) WriteHookConfig(_, _, _ string) error { return nil }
+
+// TranscriptGlobs returns nil: codex's active file is located by SelectTranscript
+// (session_meta cwd match), not a cwd-encoded path glob.
+func (p *CodexProvider) TranscriptGlobs(_ string) []string { return nil }
+
+// NewTranscriptSession returns a fresh per-file session for the tailer.
+func (p *CodexProvider) NewTranscriptSession() TranscriptSession {
+	return &codexSession{calls: make(map[string]string)}
+}
+
+// SelectTranscript returns the newest rollout file whose session_meta records
+// the given cwd, or "" when none matches. Candidate rollouts are ranked
+// newest-first by mtime and their session_meta read lazily, so an active agent
+// resolves after reading only the first (most recent) file's header.
+func (p *CodexProvider) SelectTranscript(cwd string) string {
+	root := codexSessionsRoot()
+	if root == "" || cwd == "" {
+		return ""
+	}
+	matches, err := filepath.Glob(filepath.Join(root, "*", "*", "*", "rollout-*.jsonl"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+
+	type candidate struct {
+		mod  time.Time
+		path string
+	}
+	cands := make([]candidate, 0, len(matches))
+	for _, m := range matches {
+		fi, statErr := os.Stat(m)
+		if statErr != nil {
+			continue
+		}
+		cands = append(cands, candidate{mod: fi.ModTime(), path: m})
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].mod.After(cands[j].mod) })
+
+	// Bound header reads so an unusually large sessions dir can't stall a tick;
+	// the active agent's file is near the top by mtime.
+	const maxProbe = 256
+	for i := range cands {
+		if i >= maxProbe {
+			break
+		}
+		if codexSessionCWD(cands[i].path) == cwd {
+			return cands[i].path
+		}
+	}
+	return ""
+}
+
+// codexSessionCWD reads a rollout file's first line and returns its session_meta
+// cwd, or "" when the file is unreadable or its first line is not a session_meta
+// record. The first line embeds base_instructions and can be several KB, so the
+// read is bounded to 1 MiB.
+func codexSessionCWD(path string) string {
+	f, err := os.Open(path) //nolint:gosec // path comes from a glob of the user's own codex sessions dir
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = f.Close() }() //nolint:errcheck // read-only handle
+
+	line, err := bufio.NewReaderSize(io.LimitReader(f, 1<<20), 64*1024).ReadBytes('\n')
+	if len(line) == 0 && err != nil {
+		return ""
+	}
+	var top codexLine
+	if json.Unmarshal(line, &top) != nil || top.Type != "session_meta" {
+		return ""
+	}
+	var pl codexPayload
+	if json.Unmarshal(top.Payload, &pl) != nil {
+		return ""
+	}
+	return pl.CWD
+}
+
+// codexLine is the envelope of one rollout JSONL entry.
+type codexLine struct {
+	Type      string          `json:"type"`
+	Timestamp string          `json:"timestamp"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+// codexPayload is the union of the payload fields across the record types codex
+// emits; each record populates only the subset relevant to it.
+type codexPayload struct {
+	Type      string `json:"type"`
+	Name      string `json:"name"`
+	CallID    string `json:"call_id"`
+	Arguments string `json:"arguments"`
+	Input     string `json:"input"`
+	Output    string `json:"output"`
+	Message   string `json:"message"`
+	CWD       string `json:"cwd"`
+}
+
+// codexSession holds the per-file state for parsing one rollout: the map from a
+// tool call's id to its tool name (codex result lines carry only the id), and
+// whether SessionStart has been emitted so a forked session's second
+// session_meta record does not double-fire it.
+type codexSession struct {
+	calls        map[string]string
+	startEmitted bool
+}
+
+// ParseLine turns one codex rollout line into zero or more activity events.
+// Unrecognized or malformed lines yield (nil, nil).
+func (s *codexSession) ParseLine(line []byte) ([]TranscriptActivity, error) {
+	line = trimSpaceBytes(line)
+	if len(line) == 0 {
+		return nil, nil
+	}
+	var top codexLine
+	if err := json.Unmarshal(line, &top); err != nil {
+		return nil, nil //nolint:nilerr // tolerate malformed lines mid-stream
+	}
+	ts, _ := time.Parse(time.RFC3339Nano, top.Timestamp) //nolint:errcheck // zero time is an acceptable fallback
+
+	var pl codexPayload
+	if len(top.Payload) > 0 {
+		_ = json.Unmarshal(top.Payload, &pl) //nolint:errcheck // tolerate; unknown payloads yield no events
+	}
+
+	switch top.Type {
+	case "session_meta":
+		if s.startEmitted {
+			return nil, nil
+		}
+		s.startEmitted = true
+		return []TranscriptActivity{{Event: "SessionStart", Timestamp: ts}}, nil
+	case "event_msg":
+		return s.eventMsg(&pl, ts), nil
+	case "response_item":
+		return s.responseItem(&pl, ts), nil
+	default:
+		return nil, nil
+	}
+}
+
+// eventMsg maps codex UI events onto activity. Only genuine user turns and
+// turn-completion map to hook events; reasoning, agent messages, token counts
+// and the like are informational and skipped.
+func (s *codexSession) eventMsg(pl *codexPayload, ts time.Time) []TranscriptActivity {
+	switch pl.Type {
+	case "user_message":
+		if pl.Message == "" {
+			return nil
+		}
+		return []TranscriptActivity{{Event: "UserPromptSubmit", Prompt: pl.Message, Timestamp: ts}}
+	case "task_complete":
+		return []TranscriptActivity{{Event: "Stop", Timestamp: ts}}
+	default:
+		return nil
+	}
+}
+
+// responseItem maps codex model items onto activity: tool calls to PreToolUse
+// (recording call_id→name), tool outputs to the paired PostToolUse/…Failure.
+func (s *codexSession) responseItem(pl *codexPayload, ts time.Time) []TranscriptActivity {
+	switch pl.Type {
+	case "function_call":
+		if pl.Name == "" {
+			return nil
+		}
+		if pl.CallID != "" {
+			s.calls[pl.CallID] = pl.Name
+		}
+		return []TranscriptActivity{{Event: "PreToolUse", ToolName: pl.Name, ToolInput: decodeCodexArgs(pl.Arguments), Timestamp: ts}}
+	case "custom_tool_call":
+		if pl.Name == "" {
+			return nil
+		}
+		if pl.CallID != "" {
+			s.calls[pl.CallID] = pl.Name
+		}
+		return []TranscriptActivity{{Event: "PreToolUse", ToolName: pl.Name, ToolInput: pl.Input, Timestamp: ts}}
+	case "function_call_output":
+		name := s.takeCall(pl.CallID)
+		if name == "" {
+			return nil
+		}
+		code, ok := codexShellExitCode(pl.Output)
+		return codexToolResult(name, pl.Output, ok && code != 0, ts)
+	case "custom_tool_call_output":
+		name := s.takeCall(pl.CallID)
+		if name == "" {
+			return nil
+		}
+		out, failed := codexCustomOutput(pl.Output)
+		return codexToolResult(name, out, failed, ts)
+	default:
+		return nil
+	}
+}
+
+// takeCall resolves and consumes the tool name recorded for a call id. Consuming
+// keeps the map bounded (each call has exactly one output). Returns "" when the
+// originating call was not seen — e.g. it predates the tailer's seed at EOF — so
+// the orphan output is skipped rather than emitted as an unpaired node.
+func (s *codexSession) takeCall(callID string) string {
+	if callID == "" {
+		return ""
+	}
+	name := s.calls[callID]
+	if name != "" {
+		delete(s.calls, callID)
+	}
+	return name
+}
+
+// codexToolResult builds the PostToolUse (or PostToolUseFailure) activity for a
+// completed tool call.
+func codexToolResult(name, resp string, failed bool, ts time.Time) []TranscriptActivity {
+	if failed {
+		return []TranscriptActivity{{
+			Event:        "PostToolUseFailure",
+			ToolName:     name,
+			ToolResponse: resp,
+			Error:        resp,
+			Timestamp:    ts,
+		}}
+	}
+	return []TranscriptActivity{{
+		Event:        "PostToolUse",
+		ToolName:     name,
+		ToolResponse: resp,
+		Timestamp:    ts,
+	}}
+}
+
+// decodeCodexArgs decodes a function_call's arguments (a JSON-encoded string)
+// into a structured value for the tool_input field, falling back to the raw
+// string when it is not valid JSON.
+func decodeCodexArgs(s string) any {
+	if s == "" {
+		return nil
+	}
+	var v any
+	if json.Unmarshal([]byte(s), &v) == nil {
+		return v
+	}
+	return s
+}
+
+// codexShellExitCode parses the leading "Exit code: N" of a shell tool output.
+// Returns the code and true when present, (0,false) when the output does not
+// carry one (treated as success by the caller).
+func codexShellExitCode(output string) (int, bool) {
+	const prefix = "Exit code: "
+	if !strings.HasPrefix(output, prefix) {
+		return 0, false
+	}
+	rest := output[len(prefix):]
+	if nl := strings.IndexByte(rest, '\n'); nl >= 0 {
+		rest = rest[:nl]
+	}
+	code, err := strconv.Atoi(strings.TrimSpace(rest))
+	if err != nil {
+		return 0, false
+	}
+	return code, true
+}
+
+// codexCustomOutput decodes a custom-tool output (a JSON string with an inner
+// "output" and "metadata.exit_code"), returning the inner output text and
+// whether the tool failed. Falls back to the raw output on a decode failure.
+func codexCustomOutput(output string) (string, bool) {
+	if output == "" {
+		return "", false
+	}
+	var wrapped struct {
+		Output   string `json:"output"`
+		Metadata struct {
+			ExitCode int `json:"exit_code"`
+		} `json:"metadata"`
+	}
+	if json.Unmarshal([]byte(output), &wrapped) != nil {
+		return output, false
+	}
+	text := wrapped.Output
+	if text == "" {
+		text = output
+	}
+	return text, wrapped.Metadata.ExitCode != 0
+}
+
+// Ensure CodexProvider satisfies the activity/transcript capabilities.
+var (
+	_ ActivitySource          = (*CodexProvider)(nil)
+	_ TranscriptSessionParser = (*CodexProvider)(nil)
+	_ TranscriptFileSelector  = (*CodexProvider)(nil)
+)

--- a/pkg/provider/codex_transcript_test.go
+++ b/pkg/provider/codex_transcript_test.go
@@ -1,0 +1,202 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// mtime returns a deterministic, strictly increasing timestamp for ordering
+// test fixture files by modification time.
+func mtime(n int) time.Time {
+	return time.Date(2026, 5, 1, 0, 0, n, 0, time.UTC)
+}
+
+func codexProvider(t *testing.T) *CodexProvider {
+	t.Helper()
+	p, ok := DefaultRegistry.Get("codex")
+	if !ok {
+		t.Fatal("codex provider not registered")
+	}
+	cp, ok := p.(*CodexProvider)
+	if !ok {
+		t.Fatalf("registered codex provider is %T, want *CodexProvider", p)
+	}
+	return cp
+}
+
+func TestCodexActivityMode(t *testing.T) {
+	p := codexProvider(t)
+	if p.ActivityMode() != ActivityModeTranscript {
+		t.Errorf("ActivityMode = %q, want %q", p.ActivityMode(), ActivityModeTranscript)
+	}
+	if globs := p.TranscriptGlobs("/x"); globs != nil {
+		t.Errorf("TranscriptGlobs = %v, want nil (codex uses SelectTranscript)", globs)
+	}
+	if err := p.WriteHookConfig("/wt", "http://d", "a"); err != nil {
+		t.Errorf("WriteHookConfig = %v, want nil", err)
+	}
+}
+
+// parse is a helper that runs a session over lines and returns all activities.
+func parseCodex(t *testing.T, lines ...string) []TranscriptActivity {
+	t.Helper()
+	sess := codexProvider(t).NewTranscriptSession()
+	out := make([]TranscriptActivity, 0, len(lines))
+	for _, l := range lines {
+		acts, err := sess.ParseLine([]byte(l))
+		if err != nil {
+			t.Fatalf("ParseLine(%q) error: %v", l, err)
+		}
+		out = append(out, acts...)
+	}
+	return out
+}
+
+// TestCodexParsePairing feeds real-shape codex rollout lines (a shell tool call
+// and its output, then a failing one) and asserts correctly-paired Pre/Post with
+// the tool name carried across from the call to the output line.
+func TestCodexParsePairing(t *testing.T) {
+	lines := []string{
+		`{"timestamp":"2026-05-02T08:29:51.690Z","type":"session_meta","payload":{"cwd":"/wt/eng","originator":"codex-tui"}}`,
+		`{"timestamp":"2026-05-02T08:30:00.000Z","type":"event_msg","payload":{"type":"user_message","message":"list files"}}`,
+		`{"timestamp":"2026-05-02T08:30:01.000Z","type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"ls\",\"workdir\":\"/wt/eng\"}","call_id":"call_A"}}`,
+		`{"timestamp":"2026-05-02T08:30:02.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_A","output":"Exit code: 0\nWall time: 0.1 seconds\nOutput:\nREADME.md\n"}}`,
+		`{"timestamp":"2026-05-02T08:30:03.000Z","type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"go test\"}","call_id":"call_B"}}`,
+		`{"timestamp":"2026-05-02T08:30:09.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_B","output":"Exit code: 1\nWall time: 6s\nOutput:\nFAIL\n"}}`,
+		`{"timestamp":"2026-05-02T08:30:10.000Z","type":"event_msg","payload":{"type":"task_complete"}}`,
+	}
+	acts := parseCodex(t, lines...)
+
+	wantEvents := []string{"SessionStart", "UserPromptSubmit", "PreToolUse", "PostToolUse", "PreToolUse", "PostToolUseFailure", "Stop"}
+	if len(acts) != len(wantEvents) {
+		t.Fatalf("got %d activities %v, want %d", len(acts), eventList(acts), len(wantEvents))
+	}
+	for i, want := range wantEvents {
+		if acts[i].Event != want {
+			t.Errorf("activity[%d].Event = %q, want %q", i, acts[i].Event, want)
+		}
+	}
+
+	if acts[1].Prompt != "list files" {
+		t.Errorf("UserPromptSubmit prompt = %q", acts[1].Prompt)
+	}
+	// Pre carries decoded arguments as a structured object.
+	if acts[2].ToolName != "shell_command" {
+		t.Errorf("PreToolUse tool = %q, want shell_command", acts[2].ToolName)
+	}
+	if m, ok := acts[2].ToolInput.(map[string]any); !ok || m["command"] != "ls" {
+		t.Errorf("PreToolUse input = %#v, want decoded map with command=ls", acts[2].ToolInput)
+	}
+	// Post pairs with its call by id and carries the tool name from the call.
+	if acts[3].ToolName != "shell_command" {
+		t.Errorf("PostToolUse tool = %q, want shell_command (paired via call_id)", acts[3].ToolName)
+	}
+	// Non-zero exit → failure.
+	if acts[5].ToolName != "shell_command" || acts[5].Error == "" {
+		t.Errorf("PostToolUseFailure = %#v, want shell_command with error", acts[5])
+	}
+}
+
+// TestCodexCustomToolExit covers the custom-tool (apply_patch) output shape whose
+// exit code lives in a JSON metadata object.
+func TestCodexCustomToolExit(t *testing.T) {
+	ok := parseCodex(t,
+		`{"type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","input":"*** Begin Patch","call_id":"c1"}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"c1","output":"{\"output\":\"Success\",\"metadata\":{\"exit_code\":0}}"}}`,
+	)
+	if len(ok) != 2 || ok[0].Event != "PreToolUse" || ok[1].Event != "PostToolUse" {
+		t.Fatalf("ok case = %v, want Pre+PostToolUse", eventList(ok))
+	}
+	if ok[1].ToolResponse != "Success" {
+		t.Errorf("PostToolUse response = %q, want inner output 'Success'", ok[1].ToolResponse)
+	}
+
+	bad := parseCodex(t,
+		`{"type":"response_item","payload":{"type":"custom_tool_call","name":"apply_patch","input":"*** Begin Patch","call_id":"c2"}}`,
+		`{"type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"c2","output":"{\"output\":\"boom\",\"metadata\":{\"exit_code\":1}}"}}`,
+	)
+	if len(bad) != 2 || bad[1].Event != "PostToolUseFailure" {
+		t.Fatalf("bad case = %v, want Pre+PostToolUseFailure", eventList(bad))
+	}
+}
+
+// TestCodexOrphanOutputSkipped verifies that a tool output whose originating
+// call was never seen (e.g. it predates the tailer's seed at EOF) is skipped
+// rather than emitted as an unpaired node.
+func TestCodexOrphanOutputSkipped(t *testing.T) {
+	acts := parseCodex(t,
+		`{"type":"response_item","payload":{"type":"function_call_output","call_id":"unknown","output":"Exit code: 0\n"}}`,
+	)
+	if len(acts) != 0 {
+		t.Fatalf("orphan output produced %v, want none", eventList(acts))
+	}
+}
+
+// TestCodexSessionStartOnce ensures a forked session's second session_meta record
+// does not double-fire SessionStart.
+func TestCodexSessionStartOnce(t *testing.T) {
+	acts := parseCodex(t,
+		`{"type":"session_meta","payload":{"cwd":"/wt"}}`,
+		`{"type":"session_meta","payload":{"cwd":"/wt"}}`,
+	)
+	if len(acts) != 1 || acts[0].Event != "SessionStart" {
+		t.Fatalf("got %v, want single SessionStart", eventList(acts))
+	}
+}
+
+// TestCodexSelectTranscript writes real-shape rollout files under a temp
+// CODEX_HOME and asserts SelectTranscript matches on the session_meta cwd and
+// returns the newest matching rollout.
+func TestCodexSelectTranscript(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("CODEX_HOME", home)
+
+	mkRollout := func(day, id, cwd string) string {
+		dir := filepath.Join(home, "sessions", "2026", "05", day)
+		if err := os.MkdirAll(dir, 0o750); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "rollout-2026-05-"+day+"T00-00-00-"+id+".jsonl")
+		body := `{"timestamp":"2026-05-` + day + `T00:00:00Z","type":"session_meta","payload":{"cwd":"` + cwd + `","originator":"codex-tui"}}` + "\n" +
+			`{"type":"event_msg","payload":{"type":"user_message","message":"hi"}}` + "\n"
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	other := mkRollout("01", "aaaa", "/wt/other")
+	oldMatch := mkRollout("02", "bbbb", "/wt/eng")
+	newMatch := mkRollout("03", "cccc", "/wt/eng")
+
+	// Order mtimes: other (oldest) < oldMatch < newMatch (newest).
+	must := func(err error) {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(os.Chtimes(other, mtime(1), mtime(1)))
+	must(os.Chtimes(oldMatch, mtime(2), mtime(2)))
+	must(os.Chtimes(newMatch, mtime(3), mtime(3)))
+
+	p := codexProvider(t)
+	if got := p.SelectTranscript("/wt/eng"); got != newMatch {
+		t.Errorf("SelectTranscript(/wt/eng) = %q, want newest match %q", got, newMatch)
+	}
+	if got := p.SelectTranscript("/wt/nope"); got != "" {
+		t.Errorf("SelectTranscript(/wt/nope) = %q, want empty (no cwd match)", got)
+	}
+	if got := p.SelectTranscript(""); got != "" {
+		t.Errorf("SelectTranscript(\"\") = %q, want empty", got)
+	}
+}
+
+func eventList(acts []TranscriptActivity) []string {
+	out := make([]string, len(acts))
+	for i := range acts {
+		out[i] = acts[i].Event
+	}
+	return out
+}

--- a/pkg/provider/transcript.go
+++ b/pkg/provider/transcript.go
@@ -49,3 +49,40 @@ type TranscriptParser interface {
 	// can skip them without aborting the stream.
 	ParseTranscriptLine(line []byte) ([]TranscriptActivity, error)
 }
+
+// TranscriptSession parses one provider transcript file with per-file state.
+// Unlike TranscriptParser (stateless, each line independent), the tailer
+// creates one session per file it follows and feeds that file's lines to it in
+// order, so the session can correlate lines that reference each other. codex
+// needs this: its tool-result lines carry only the originating call's id and no
+// tool name, so the session resolves each result against the call it recorded
+// earlier to emit a correctly-paired PostToolUse.
+type TranscriptSession interface {
+	// ParseLine parses one transcript line into zero or more activity events.
+	// Like TranscriptParser it must tolerate malformed or unrecognized lines by
+	// returning (nil, nil) rather than an error.
+	ParseLine(line []byte) ([]TranscriptActivity, error)
+}
+
+// TranscriptSessionParser is implemented by transcript providers that need
+// per-file state to parse correctly (e.g. codex). Providers whose lines are
+// independently parseable implement the simpler stateless TranscriptParser
+// instead; a provider implements at most one of the two.
+type TranscriptSessionParser interface {
+	// NewTranscriptSession returns a fresh session bound to a single transcript
+	// file. The tailer calls it once when it starts following a file and again
+	// when the file rotates, never sharing a session across files.
+	NewTranscriptSession() TranscriptSession
+}
+
+// TranscriptFileSelector is implemented by transcript providers whose active
+// session file cannot be located by a cwd-encoded path glob because the working
+// directory is recorded inside the file rather than in its path. codex keys its
+// files by date (sessions/YYYY/MM/DD/rollout-*.jsonl) and records the cwd in a
+// session_meta line, so the tailer calls SelectTranscript to resolve the file
+// instead of globbing TranscriptGlobs.
+type TranscriptFileSelector interface {
+	// SelectTranscript returns the path to the newest transcript belonging to
+	// the agent working in cwd, or "" when none matches.
+	SelectTranscript(cwd string) string
+}

--- a/server/transcript_tailer.go
+++ b/server/transcript_tailer.go
@@ -3,11 +3,18 @@
 //
 // Hook-based providers (Claude, agy) POST lifecycle events to the daemon's
 // /api/agents/{name}/hook endpoint, which flow into the Live feed via
-// AgentService.IngestHookEvent. Providers in ActivityModeTranscript (e.g. pi)
+// AgentService.IngestHookEvent. Providers in ActivityModeTranscript (pi, codex)
 // have no such push channel — they write a JSONL session log on disk. This
 // collector tails those logs, parses newly-appended lines into the same hook
-// events (via provider.TranscriptParser), and ingests them through the exact
-// same path, so both kinds of provider feed one Live feed with no parallel UI.
+// events, and ingests them through the exact same path, so both kinds of
+// provider feed one Live feed with no parallel UI.
+//
+// A provider's transcript is turned into events by either a stateless
+// provider.TranscriptParser (pi — each line self-describing) or a stateful
+// provider.TranscriptSession created per file (codex — its result lines
+// reference an earlier call by id and carry no tool name). The file to follow is
+// located by a cwd-encoded path glob (pi) or a provider.TranscriptFileSelector
+// that reads the cwd out of the file (codex).
 package server
 
 import (
@@ -36,9 +43,13 @@ const (
 )
 
 // tailCursor tracks how far the tailer has consumed one transcript file.
+// session holds per-file parse state for session-based providers (codex) and is
+// nil for stateless ones (pi); it is recreated whenever the followed file
+// rotates so state never leaks across sessions.
 type tailCursor struct {
-	path   string
-	offset int64
+	session provider.TranscriptSession
+	path    string
+	offset  int64
 }
 
 // runTranscriptTailer polls transcript-mode agents and ingests newly-written
@@ -75,15 +86,15 @@ func tailTranscriptsOnce(ctx context.Context, agents *agentpkg.AgentService, cur
 	live := make(map[string]struct{}, len(list))
 	for _, a := range list {
 		live[a.Name] = struct{}{}
-		parser, globs := transcriptParserFor(a)
-		if parser == nil || len(globs) == 0 {
+		p := transcriptProviderFor(a)
+		if p == nil {
 			continue
 		}
-		newest := newestMatch(globs)
-		if newest == "" {
+		file := resolveTranscriptFile(p, a.WorktreeDir)
+		if file == "" {
 			continue
 		}
-		tailAgentFile(ctx, agents, cursors, a.Name, newest, parser)
+		tailAgentFile(ctx, agents, cursors, a.Name, file, p)
 	}
 	// Drop cursors for agents that no longer exist so the map can't grow
 	// unbounded across the daemon's lifetime.
@@ -94,26 +105,62 @@ func tailTranscriptsOnce(ctx context.Context, agents *agentpkg.AgentService, cur
 	}
 }
 
-// transcriptParserFor returns the transcript parser and glob patterns for an
-// agent, or (nil, nil) when the agent's provider is not a parseable
-// transcript source.
-func transcriptParserFor(a *agentpkg.Agent) (provider.TranscriptParser, []string) {
+// transcriptProviderFor returns the agent's provider when it is a parseable
+// transcript source (ActivityModeTranscript with a stateless TranscriptParser or
+// a stateful TranscriptSessionParser), or nil otherwise.
+func transcriptProviderFor(a *agentpkg.Agent) provider.Provider {
 	if a == nil || a.Tool == "" || a.WorktreeDir == "" {
-		return nil, nil
+		return nil
 	}
 	p, ok := provider.DefaultRegistry.Get(a.Tool)
 	if !ok {
-		return nil, nil
+		return nil
 	}
 	src, ok := p.(provider.ActivitySource)
 	if !ok || src.ActivityMode() != provider.ActivityModeTranscript {
-		return nil, nil
+		return nil
 	}
-	parser, ok := p.(provider.TranscriptParser)
-	if !ok {
-		return nil, nil
+	_, stateless := p.(provider.TranscriptParser)
+	_, session := p.(provider.TranscriptSessionParser)
+	if !stateless && !session {
+		return nil
 	}
-	return parser, src.TranscriptGlobs(a.WorktreeDir)
+	return p
+}
+
+// resolveTranscriptFile locates the transcript file to tail for a provider whose
+// agent works in cwd. Providers that record cwd inside the file implement
+// TranscriptFileSelector (codex); the rest are located by a cwd-encoded path
+// glob (pi).
+func resolveTranscriptFile(p provider.Provider, cwd string) string {
+	if sel, ok := p.(provider.TranscriptFileSelector); ok {
+		return sel.SelectTranscript(cwd)
+	}
+	if src, ok := p.(provider.ActivitySource); ok {
+		return newestMatch(src.TranscriptGlobs(cwd))
+	}
+	return ""
+}
+
+// newTranscriptSession returns a fresh per-file session for a session-based
+// provider, or nil for a stateless one.
+func newTranscriptSession(p provider.Provider) provider.TranscriptSession {
+	if sp, ok := p.(provider.TranscriptSessionParser); ok {
+		return sp.NewTranscriptSession()
+	}
+	return nil
+}
+
+// parseTranscriptLine dispatches one line to the cursor's per-file session
+// (session-based providers) or the provider's stateless parser.
+func parseTranscriptLine(cur *tailCursor, p provider.Provider, line []byte) ([]provider.TranscriptActivity, error) {
+	if cur.session != nil {
+		return cur.session.ParseLine(line)
+	}
+	if sp, ok := p.(provider.TranscriptParser); ok {
+		return sp.ParseTranscriptLine(line)
+	}
+	return nil, nil
 }
 
 // newestMatch returns the most-recently-modified file matching any glob, or
@@ -151,7 +198,7 @@ func tailAgentFile(
 	agents *agentpkg.AgentService,
 	cursors map[string]*tailCursor,
 	name, path string,
-	parser provider.TranscriptParser,
+	p provider.Provider,
 ) {
 	fi, err := os.Stat(path)
 	if err != nil {
@@ -164,15 +211,19 @@ func tailAgentFile(
 	case !ok:
 		// First sighting for this agent: start at EOF so we don't backfill a
 		// pre-existing session's history as if it just happened.
-		cursors[name] = &tailCursor{path: path, offset: size}
+		cursors[name] = &tailCursor{path: path, offset: size, session: newTranscriptSession(p)}
 		return
 	case cur.path != path:
-		// A newer session file appeared: capture it from the start.
+		// A newer session file appeared: capture it from the start with fresh
+		// per-file state.
 		cur.path = path
 		cur.offset = 0
+		cur.session = newTranscriptSession(p)
 	case cur.offset > size:
-		// File was truncated/rotated in place: restart from the top.
+		// File was truncated/rotated in place: restart from the top and reset
+		// per-file state.
 		cur.offset = 0
+		cur.session = newTranscriptSession(p)
 	}
 
 	if cur.offset >= size {
@@ -186,7 +237,7 @@ func tailAgentFile(
 	}
 
 	for _, line := range lines {
-		acts, perr := parser.ParseTranscriptLine(line)
+		acts, perr := parseTranscriptLine(cur, p, line)
 		if perr != nil || len(acts) == 0 {
 			continue
 		}

--- a/server/transcript_tailer_test.go
+++ b/server/transcript_tailer_test.go
@@ -143,7 +143,7 @@ func TestTranscriptTailer_LiveCapture(t *testing.T) {
 	}
 }
 
-// TestTranscriptTailer_CodexLiveCapture is the codex analogue of the pi live
+// TestTranscriptTailer_CodexLiveCapture is the codex counterpart of the pi live
 // check: it seeds a real-shape codex rollout at EOF, appends a user turn plus a
 // paired shell tool call/output (whose result line carries only the call_id),
 // and asserts the session-based path publishes PreToolUse/PostToolUse with the

--- a/server/transcript_tailer_test.go
+++ b/server/transcript_tailer_test.go
@@ -72,8 +72,7 @@ func TestTranscriptTailer_LiveCapture(t *testing.T) {
 	if !ok {
 		t.Fatal("pi provider not registered")
 	}
-	parser, ok := pi.(provider.TranscriptParser)
-	if !ok {
+	if _, isParser := pi.(provider.TranscriptParser); !isParser {
 		t.Fatal("pi provider does not implement TranscriptParser")
 	}
 
@@ -91,7 +90,7 @@ func TestTranscriptTailer_LiveCapture(t *testing.T) {
 	cursors := map[string]*tailCursor{}
 
 	// First tick: seeds the cursor at EOF, captures nothing.
-	tailAgentFile(ctx, svc, cursors, "pilot", transcript, parser)
+	tailAgentFile(ctx, svc, cursors, "pilot", transcript, pi)
 	if got := pub.snapshot(); len(got) != 0 {
 		t.Fatalf("first tick published %d events, want 0 (seed-at-EOF)", len(got))
 	}
@@ -110,7 +109,7 @@ func TestTranscriptTailer_LiveCapture(t *testing.T) {
 	_ = f.Close()
 
 	// Second tick: captures the appended activity.
-	tailAgentFile(ctx, svc, cursors, "pilot", transcript, parser)
+	tailAgentFile(ctx, svc, cursors, "pilot", transcript, pi)
 
 	got := pub.snapshot()
 	byEvent := map[string]map[string]any{}
@@ -141,6 +140,78 @@ func TestTranscriptTailer_LiveCapture(t *testing.T) {
 	}
 	if post["tool_name"] != "bash" {
 		t.Errorf("PostToolUse tool_name = %v, want bash", post["tool_name"])
+	}
+}
+
+// TestTranscriptTailer_CodexLiveCapture is the codex analogue of the pi live
+// check: it seeds a real-shape codex rollout at EOF, appends a user turn plus a
+// paired shell tool call/output (whose result line carries only the call_id),
+// and asserts the session-based path publishes PreToolUse/PostToolUse with the
+// tool name correctly carried across onto the agent.hook feed.
+func TestTranscriptTailer_CodexLiveCapture(t *testing.T) {
+	repo := t.TempDir()
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	mgr := agentpkg.NewManagerWithRepo(filepath.Join(t.TempDir(), "agents"), repo)
+	pub := &recordingPublisher{}
+	svc := agentpkg.NewAgentService(mgr, pub, nil)
+
+	codex, ok := provider.DefaultRegistry.Get("codex")
+	if !ok {
+		t.Fatal("codex provider not registered")
+	}
+	if _, isSession := codex.(provider.TranscriptSessionParser); !isSession {
+		t.Fatal("codex provider does not implement TranscriptSessionParser")
+	}
+
+	transcript := filepath.Join(t.TempDir(), "rollout.jsonl")
+	// Seed with the session_meta header already present — the tailer must start
+	// at EOF and not replay it.
+	seed := `{"timestamp":"2026-05-02T08:29:51.690Z","type":"session_meta","payload":{"cwd":"/wt/eng","originator":"codex-tui"}}` + "\n"
+	if err := os.WriteFile(transcript, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	cursors := map[string]*tailCursor{}
+
+	tailAgentFile(ctx, svc, cursors, "pilot", transcript, codex)
+	if got := pub.snapshot(); len(got) != 0 {
+		t.Fatalf("first tick published %d events, want 0 (seed-at-EOF)", len(got))
+	}
+
+	appended := `{"timestamp":"2026-05-02T08:30:00Z","type":"event_msg","payload":{"type":"user_message","message":"list files"}}` + "\n" +
+		`{"timestamp":"2026-05-02T08:30:01Z","type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"ls\"}","call_id":"call_A"}}` + "\n" +
+		`{"timestamp":"2026-05-02T08:30:02Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_A","output":"Exit code: 0\nWall time: 0.1 seconds\nOutput:\nREADME.md\n"}}` + "\n"
+	f, err := os.OpenFile(transcript, os.O_APPEND|os.O_WRONLY, 0o600) //nolint:gosec // test-controlled temp path
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(appended); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	tailAgentFile(ctx, svc, cursors, "pilot", transcript, codex)
+
+	byEvent := map[string]map[string]any{}
+	for _, e := range pub.snapshot() {
+		if ev, _ := e["event"].(string); ev != "" {
+			byEvent[ev] = e
+		}
+	}
+	pre, ok := byEvent["PreToolUse"]
+	if !ok {
+		t.Fatalf("missing PreToolUse; got %v", eventNames(pub.snapshot()))
+	}
+	if pre["tool_name"] != "shell_command" {
+		t.Errorf("PreToolUse tool_name = %v, want shell_command", pre["tool_name"])
+	}
+	post, ok := byEvent["PostToolUse"]
+	if !ok {
+		t.Fatalf("missing PostToolUse; got %v", eventNames(pub.snapshot()))
+	}
+	if post["tool_name"] != "shell_command" {
+		t.Errorf("PostToolUse tool_name = %v, want shell_command (paired via call_id)", post["tool_name"])
 	}
 }
 

--- a/web/src/components/live/AgentToolStream.tsx
+++ b/web/src/components/live/AgentToolStream.tsx
@@ -19,10 +19,15 @@ interface AgentToolStreamProps {
 
 // Providers whose activity mycel captures for the Live feed: hook-based
 // providers (claude, agy) POST lifecycle events; transcript-based providers
-// (pi) have their session log tailed by the daemon. Providers not listed here
-// expose no readable activity yet, so the stream stays empty — say so honestly
-// instead of pretending events are coming.
-const CAPTURE_PROVIDERS = new Set(["claude", "agy", "pi"]);
+// (pi, codex) have their session log tailed by the daemon. Providers not listed
+// here expose no readable activity yet, so the stream stays empty — say so
+// honestly instead of pretending events are coming.
+//
+// cursor is deliberately absent: cursor-agent writes an on-disk transcript, but
+// it records user prompts and tool *invocations* only — never tool *results* or
+// a reliable turn-completion marker — so it cannot yield paired PreToolUse/
+// PostToolUse activity (tool calls would appear stuck "running" forever).
+const CAPTURE_PROVIDERS = new Set(["claude", "agy", "pi", "codex"]);
 
 export function AgentToolStream({ agentName, agentTool }: AgentToolStreamProps) {
   const { activities, tasks, rawEventsRef } = useAgentActivity(agentName);


### PR DESCRIPTION
Part of #2674

Extends the Live activity transcript tailer (merged in #3400, which covered pi) to **codex**, and settles the cursor question with an honest empty-state.

## Providers now covered
| provider | mode | how |
|---|---|---|
| claude, agy | hooks | POST lifecycle events (unchanged) |
| pi | transcript | cwd-keyed glob, stateless parser (unchanged) |
| **codex** | transcript | **new: session_meta cwd match + per-file stateful parser** |

## Still honest empty-state
- **cursor** — cursor-agent *does* write a tailable JSONL transcript (`~/.cursor/projects/<enc>/agent-transcripts/<uuid>/<uuid>.jsonl`), but inspecting real files shows it records user prompts and assistant tool **invocations** only — **never tool results, and no reliable turn-completion marker** in real sessions. Without results there is no `PostToolUse`, so tool calls would render stuck "running" forever. That is worse than empty, so cursor keeps the empty-state; the web comment says so plainly.
- **openclaw** — no transcript; left empty-state. **agy** — hook-based; unchanged.

## Why codex needed new capabilities
pi's model (cwd-encoded path glob + stateless per-line parser) did not fit codex:
1. **File selection** — codex files are date-keyed (`sessions/YYYY/MM/DD/rollout-*.jsonl`); the cwd lives inside a `session_meta` record, not the path. New `provider.TranscriptFileSelector` lets codex glob all rollouts, match `session_meta.cwd` to the agent's worktree, and pick the newest (handles rotation).
2. **Pairing** — codex tool-result lines carry only the originating `call_id`, no tool name. New `provider.TranscriptSessionParser` gives codex a per-file session that records `call_id→toolName` on the call and resolves it on the output, emitting a correctly-named paired `PostToolUse`/`PostToolUseFailure`.

The tailer now picks the stateless-vs-session path and the glob-vs-selector path per provider; pi is unchanged behaviourally.

## Mapping (codex → hook vocabulary)
`session_meta`→SessionStart · `user_message`→UserPromptSubmit · `function_call`/`custom_tool_call`→PreToolUse · `function_call_output` (exit code) / `custom_tool_call_output` (metadata.exit_code)→PostToolUse or …Failure · `task_complete`→Stop. Assistant text/reasoning skipped (as pi). Seeded at EOF — no history replay.

## Grounded against real files
Parser + selector reverse-engineered and verified against real rollouts under `~/.codex/sessions` on the dev machine, including actual mycel-spawned codex agents (cwd under the agent worktree). No format guessing.

## Test plan
- `pkg/provider` unit tests: Pre/Post pairing with tool-name carried across the id-only output line; shell exit-code + custom-tool `metadata.exit_code` failure detection; orphan-output (unseen call) skipped; SessionStart-once on forked sessions; `SelectTranscript` cwd-matching + newest-of-duplicates + no-match, on real-shape fixture rollouts under a temp `CODEX_HOME`.
- `server` in-process live-capture test: seed a real-shape codex rollout at EOF, append a user turn + paired shell call/output, assert `PreToolUse`/`PostToolUse` publish on the `agent.hook` feed (the exact path the web Live tab renders) with `tool_name` correctly paired.
- web: `tsc --noEmit`, eslint, `vitest run` (311 pass), `bun run build` all green.
- go: `go build ./...`, `go vet`, `golangci-lint run` (0 issues), `go test -race ./pkg/provider/... ./server/...` all green.
- Live daemon smoke: booted the built binary on a throwaway `MYCEL_HOME` at `127.0.0.1:8099` — daemon + transcript tailer start clean, API responds, torn down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)