### PR TITLE
fix(slack): mycel mushroom icon for agent posts (not a random animal)

### DIFF
--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"net/http"
 	"strings"
 	"sync"
@@ -221,30 +220,12 @@ func (a *Adapter) warnIfCustomizeMissing(sender string) {
 	})
 }
 
-// agentIconEmoji returns a stable emoji for an agent, chosen deterministically
-// from its name so the same agent always gets the same icon. This is only a
-// placeholder until real avatars land (see the follow-up note on Send).
-func agentIconEmoji(sender string) string {
-	if sender == "" {
-		return ":robot_face:"
-	}
-	h := fnv.New32a()
-	_, _ = h.Write([]byte(sender))
-	// Modulo by an untyped constant keeps the index in uint32 space (no
-	// int↔uint32 conversion), which also guards against overflow.
-	return agentEmojiPalette[h.Sum32()%agentEmojiPaletteSize]
-}
-
-// agentEmojiPaletteSize must equal len(agentEmojiPalette); a test asserts it.
-const agentEmojiPaletteSize = 16
-
-// agentEmojiPalette is a small set of neutral, visually distinct emoji used to
-// give each agent a consistent icon. Standard Slack emoji names only.
-var agentEmojiPalette = []string{
-	":fox_face:", ":cat:", ":dog:", ":koala:", ":tiger:",
-	":panda_face:", ":owl:", ":frog:", ":hedgehog:", ":otter:",
-	":rabbit:", ":bear:", ":wolf:", ":unicorn_face:", ":dragon_face:",
-	":robot_face:",
+// agentIconEmoji returns the mycel mushroom for every agent so outbound Slack
+// posts read as mycel rather than a random animal. The real per-agent avatar —
+// each agent's mushroom-character image — needs a publicly reachable URL and is
+// deferred to the hosted-avatar follow-up (see the note on Send).
+func agentIconEmoji(string) string {
+	return ":mushroom:"
 }
 
 // SendFile uploads a file to a Slack channel.

--- a/pkg/gateway/slack/slack_test.go
+++ b/pkg/gateway/slack/slack_test.go
@@ -55,22 +55,11 @@ func TestSendAttributesAgentUsername(t *testing.T) {
 	}
 }
 
-func TestAgentIconEmojiDeterministic(t *testing.T) {
-	if a, b := agentIconEmoji("zen-zebra"), agentIconEmoji("zen-zebra"); a != b {
-		t.Errorf("agentIconEmoji not deterministic: %q vs %q", a, b)
-	}
-	// Empty sender falls back to the default icon.
-	if e := agentIconEmoji(""); e != ":robot_face:" {
-		t.Errorf("agentIconEmoji(\"\") = %q, want :robot_face:", e)
-	}
-	if len(agentEmojiPalette) != agentEmojiPaletteSize {
-		t.Fatalf("agentEmojiPaletteSize = %d, want len(palette) = %d",
-			agentEmojiPaletteSize, len(agentEmojiPalette))
-	}
-	// Every palette entry is a well-formed :emoji: token.
-	for _, e := range agentEmojiPalette {
-		if len(e) < 3 || e[0] != ':' || e[len(e)-1] != ':' {
-			t.Errorf("malformed palette emoji %q", e)
+func TestAgentIconEmojiMushroom(t *testing.T) {
+	// Every agent posts under the mycel mushroom, regardless of name.
+	for _, name := range []string{"zen-zebra", "lucid-meerkat", ""} {
+		if got := agentIconEmoji(name); got != ":mushroom:" {
+			t.Errorf("agentIconEmoji(%q) = %q, want :mushroom:", name, got)
 		}
 	}
 }


### PR DESCRIPTION
Outbound Slack messages were attributed with a per-agent **animal** emoji from a palette (zen-zebra deterministically landed on 🐸). Post every agent under the mycel **🍄 `:mushroom:`** so it reads as mycel, not a random animal.

The true per-agent avatar — each agent's mushroom-*character* image — needs a publicly reachable image URL (Slack fetches `icon_url` from the internet; the daemon is loopback-only). That's part of the hosted-avatar / mycel-cloud follow-up and is deliberately not faked.

- `agentIconEmoji` → always `:mushroom:`; removed the animal palette + `hash/fnv`.
- Test updated to assert the mushroom for any agent name.

`go build`/`vet` clean · `go test ./pkg/gateway/slack/` pass.

Part of #2674

🤖 Generated with [Claude Code](https://claude.com/claude-code)