### PR TITLE
feat(live): pin running rows, expandable history, unified row controls

### DIFF
--- a/web/src/components/live/EventRow.test.tsx
+++ b/web/src/components/live/EventRow.test.tsx
@@ -12,9 +12,10 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { EventRow, compactPath, eventGlyphKind } from "./EventRow";
-import { flattenNodes } from "./liveHelpers";
+import { RunningSection } from "./LiveRenderers";
+import { activityItemToNode, flattenNodes, partitionRunning } from "./liveHelpers";
 import type { ToolNode } from "./liveTypes";
 
 function node(overrides: Partial<ToolNode>): ToolNode {
@@ -108,5 +109,105 @@ describe("EventRow", () => {
     render(<EventRow node={node({ toolName: "mcp__github__create_pr", args: "open PR" })} />);
     expect(screen.getByText("github")).toBeTruthy();
     expect(screen.getByText("create_pr")).toBeTruthy();
+  });
+});
+
+/* ── Fix 1: pinned running section ─────────────────────────────────── */
+
+describe("partitionRunning", () => {
+  it("splits running rows from the rest, preserving order", () => {
+    const nodes = [
+      node({ id: "a", status: "completed" }),
+      node({ id: "b", status: "running", endTime: undefined }),
+      node({ id: "c", status: "failed" }),
+      node({ id: "d", status: "running", endTime: undefined }),
+    ];
+    const { running, rest } = partitionRunning(nodes);
+    expect(running.map((n) => n.id)).toEqual(["b", "d"]);
+    expect(rest.map((n) => n.id)).toEqual(["a", "c"]);
+  });
+
+  it("moves a row out of the running bucket once it completes", () => {
+    const running = node({ id: "x", toolName: "Bash", status: "running", endTime: undefined });
+    expect(partitionRunning([running]).running.map((n) => n.id)).toEqual(["x"]);
+    // Same node id, now completed — it leaves the pinned bucket.
+    const done = { ...running, status: "completed" as const, endTime: Date.now() };
+    const after = partitionRunning([done]);
+    expect(after.running).toEqual([]);
+    expect(after.rest.map((n) => n.id)).toEqual(["x"]);
+  });
+});
+
+describe("RunningSection", () => {
+  it("renders the pinned Running header with a count when rows are running", () => {
+    render(
+      <RunningSection
+        nodes={[node({ id: "r1", toolName: "Bash", status: "running", endTime: undefined })]}
+      />,
+    );
+    expect(screen.getByText("Running")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+  });
+
+  it("renders nothing when there are no running rows", () => {
+    const { container } = render(<RunningSection nodes={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+/* ── Fix 2: historical rows expand with their available details ────── */
+
+describe("activityItemToNode + historical expansion", () => {
+  it("carries tool_input from the persisted event data", () => {
+    const n = activityItemToNode({
+      timestamp: "2026-07-30T10:00:00.000Z",
+      event: "PreToolUse",
+      message: "Bash: git status",
+      data: { tool_name: "Bash", tool_input: { command: "git status", description: "Show status" } },
+    });
+    expect(n.toolName).toBe("Bash");
+    expect(n.fullInput).toEqual({ command: "git status", description: "Show status" });
+    expect(n.status).toBe("completed");
+    // Duration is genuinely unknown for historical rows.
+    expect(n.endTime).toBeUndefined();
+  });
+
+  it("marks a historical row failed when the event recorded an error", () => {
+    const n = activityItemToNode({
+      timestamp: "2026-07-30T10:00:00.000Z",
+      event: "PostToolUseFailure",
+      message: "Bash",
+      data: { tool_name: "Bash", tool_input: { command: "false" }, error: "exit status 1" },
+    });
+    expect(n.status).toBe("failed");
+    expect(n.error).toBe("exit status 1");
+  });
+
+  it("degrades gracefully when only a message is stored (no data)", () => {
+    const n = activityItemToNode({
+      timestamp: "2026-07-30T10:00:00.000Z",
+      event: "Stop",
+      message: "Turn complete",
+    });
+    expect(n.fullInput).toBeNull();
+    expect(n.status).toBe("completed");
+  });
+
+  it("expands a historical row to show its input, a copy control, and no Output section", () => {
+    const n = activityItemToNode({
+      timestamp: "2026-07-30T10:00:00.000Z",
+      event: "PreToolUse",
+      message: "Bash: git status --short",
+      data: { tool_name: "Bash", tool_input: { command: "git status --short", description: "Show status" } },
+    });
+    render(<EventRow node={n} />);
+    // Chevron affordance present (has details) — expand it.
+    fireEvent.click(screen.getByRole("button", { name: /Expand Bash event/ }));
+    expect(screen.getByText("git status --short")).toBeTruthy();
+    expect(screen.getByText("Input")).toBeTruthy();
+    // Copy control present inside the expanded row.
+    expect(screen.getAllByRole("button", { name: "Copy to clipboard" }).length).toBeGreaterThan(0);
+    // No tool_response is persisted historically → no Output section.
+    expect(screen.queryByText("Output")).toBeNull();
   });
 });

--- a/web/src/components/live/LiveRenderers.tsx
+++ b/web/src/components/live/LiveRenderers.tsx
@@ -7,12 +7,14 @@ import type {
   FilterType,
   RawEvent,
   TaskItem,
+  ToolNode,
 } from "./liveTypes";
 import {
   estimateCost,
   flattenNodes,
   idleDuration,
   nodeMatchesSearch,
+  partitionRunning,
   redactValue,
   stateBadgeClass,
 } from "./liveHelpers";
@@ -42,6 +44,53 @@ export function StateDot({ state }: { state: string }) {
   if (state === "error" || state === "stopped")
     return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-mycel-error" />;
   return <span className="inline-flex h-2.5 w-2.5 rounded-full bg-mycel-muted" />;
+}
+
+/* ── Pinned "Running" section ──────────────────────────────────────── */
+
+/**
+ * A pinned band of currently-running rows kept above the chronological
+ * stream, so in-flight tool calls and still-executing subagents stay
+ * visible instead of being pushed down as new events arrive. When a row
+ * completes it drops out of `nodes` (status flips off "running") and
+ * takes its normal chronological place below — rows are keyed by node id,
+ * so React just moves the existing DOM node, no reorder animation.
+ *
+ * `sticky` keeps the band anchored to the top of a scrollable feed (the
+ * agent-detail Live tab). In the compact Live card there is no scroll
+ * container, so it renders inline at the top instead.
+ */
+export function RunningSection({
+  nodes,
+  searchQuery = "",
+  sticky = false,
+}: {
+  nodes: ToolNode[];
+  searchQuery?: string;
+  sticky?: boolean;
+}) {
+  if (nodes.length === 0) return null;
+  return (
+    <div className={sticky ? "sticky top-0 z-10" : ""}>
+      <div className="flex items-center gap-2 px-3 py-1 bg-mycel-surface/95 backdrop-blur-sm border-b border-mycel-border">
+        <span className="relative flex h-2 w-2 shrink-0" aria-hidden>
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-mycel-accent opacity-60 motion-reduce:hidden" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-mycel-accent" />
+        </span>
+        <span className="text-[10px] uppercase tracking-wide font-semibold text-mycel-accent">
+          Running
+        </span>
+        <span className="text-[10px] text-mycel-muted font-mono tabular-nums">
+          {nodes.length}
+        </span>
+      </div>
+      <div className="bg-mycel-accent-subtle/30 border-b-2 border-mycel-accent-subtle">
+        {nodes.map((node) => (
+          <EventRow key={node.id} node={node} searchQuery={searchQuery} />
+        ))}
+      </div>
+    </div>
+  );
 }
 
 /* ── Idle Timer ───────────────────────────────────────────────────── */
@@ -176,6 +225,13 @@ export function AgentDrillDown({
     return flattenNodes(activity.nodes).sort((a, b) => b.startTime - a.startTime);
   }, [activity.nodes]);
 
+  // Running rows are pinned above the chronological stream; a completed
+  // row leaves the pinned band and re-joins the list in time order.
+  const { running: runningNodes, rest: restNodes } = useMemo(
+    () => partitionRunning(allNodes),
+    [allNodes],
+  );
+
   const toggleRawExpanded = useCallback((key: string) => {
     setRawExpanded((prev) => {
       const next = new Set(prev);
@@ -261,9 +317,12 @@ export function AgentDrillDown({
                 No tool events yet for this agent.
               </div>
             ) : (
-              allNodes.map((node) => (
-                <EventRow key={node.id} node={node} />
-              ))
+              <>
+                <RunningSection nodes={runningNodes} sticky />
+                {restNodes.map((node) => (
+                  <EventRow key={node.id} node={node} />
+                ))}
+              </>
             )}
           </div>
         )}
@@ -361,10 +420,16 @@ export const AgentCard = memo(function AgentCard({
     return flatNodes.filter((n) => nodeMatchesSearch(n, q));
   }, [flatNodes, searchTerm]);
 
-  const shownNodes = visibleNodes.slice(0, LIVE_CARD_MAX_ROWS);
-  const hiddenCount = visibleNodes.length - shownNodes.length;
+  // Pin running rows above the chronological list; only the completed
+  // rows are subject to the row cap, so an in-flight call is never hidden.
+  const { running: runningNodes, rest: restNodes } = useMemo(
+    () => partitionRunning(visibleNodes),
+    [visibleNodes],
+  );
+  const shownNodes = restNodes.slice(0, LIVE_CARD_MAX_ROWS);
+  const hiddenCount = restNodes.length - shownNodes.length;
 
-  const runningCount = flatNodes.filter((n) => n.status === "running").length;
+  const runningCount = runningNodes.length;
   const errorCount = flatNodes.filter((n) => n.status === "failed").length;
   const matchCount = searchTerm ? visibleNodes.length : 0;
   const showToolNodes = typeFilter !== "state";
@@ -489,7 +554,7 @@ export const AgentCard = memo(function AgentCard({
       </div>
 
       <AnimatePresence initial={false}>
-        {!activity.collapsed && showToolNodes && shownNodes.length > 0 && (
+        {!activity.collapsed && showToolNodes && (shownNodes.length > 0 || runningNodes.length > 0) && (
           <motion.div
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
@@ -497,9 +562,10 @@ export const AgentCard = memo(function AgentCard({
             transition={{ duration: 0.2, ease: "easeOut" }}
             className="border-t border-mycel-border overflow-hidden"
           >
-            {/* Flat event stream — newest first. Rows are keyed by event
-                id and never animate position, so new events prepend
-                without reflowing everything below them. */}
+            {/* Flat event stream — newest first. Running rows pin to the
+                top; completed rows are keyed by event id and never animate
+                position, so new events prepend without reflowing below. */}
+            <RunningSection nodes={runningNodes} searchQuery={searchTerm} />
             {shownNodes.map((node) => (
               <EventRow key={node.id} node={node} searchQuery={searchTerm} />
             ))}

--- a/web/src/components/live/ToolDetail.tsx
+++ b/web/src/components/live/ToolDetail.tsx
@@ -3,6 +3,9 @@ import { compactPath, redactSecrets, redactValue } from "./liveHelpers";
 
 /* ── Copy button ───────────────────────────────────────────────────── */
 
+/** Compact icon-only copy control: a clipboard glyph that swaps to a
+ *  check on success, then settles back. Shares the row-control sizing so
+ *  it reads as part of the expanded row, not a bolted-on button. */
 export function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
   const handleCopy = useCallback(() => {
@@ -16,10 +19,24 @@ export function CopyButton({ text }: { text: string }) {
     <button
       type="button"
       onClick={(e) => { e.stopPropagation(); handleCopy(); }}
-      className="text-[10px] text-mycel-muted hover:text-mycel-text px-1.5 py-0.5 rounded-md border border-mycel-border hover:border-mycel-accent transition-colors shrink-0"
+      className={`inline-flex items-center justify-center h-[22px] w-[22px] rounded-md transition-colors shrink-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent ${
+        copied
+          ? "text-mycel-success"
+          : "text-mycel-muted hover:text-mycel-text hover:bg-mycel-surface-hover"
+      }`}
       aria-label="Copy to clipboard"
+      title={copied ? "Copied" : "Copy JSON"}
     >
-      {copied ? "Copied" : "Copy"}
+      {copied ? (
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <path d="M3.5 8.5l3 3 6-7" />
+        </svg>
+      ) : (
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+          <rect x="5.5" y="5.5" width="8" height="8" rx="1.5" />
+          <path d="M10.5 5.5V4a1.5 1.5 0 00-1.5-1.5H4A1.5 1.5 0 002.5 4v5A1.5 1.5 0 004 10.5h1.5" />
+        </svg>
+      )}
     </button>
   );
 }
@@ -417,30 +434,45 @@ export function DetailSection({
   children: React.ReactNode;
 }) {
   const [raw, setRaw] = useState(false);
+  const lowerLabel = label.toLowerCase();
   return (
     <div className="text-[11px] font-mono px-3 py-2 bg-mycel-surface mx-3 mb-1 rounded-md overflow-x-auto">
       <div className="flex items-center justify-between mb-1 gap-2">
         <span className={`text-[10px] uppercase tracking-wide font-semibold ${tone === "success" ? "text-mycel-success" : "text-mycel-muted"}`}>
           {label}
         </span>
-        <span className="flex items-center gap-1.5">
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              setRaw((v) => !v);
-            }}
-            aria-pressed={raw}
-            aria-label={`Toggle raw JSON for ${toolName} ${label.toLowerCase()}`}
-            title={raw ? "Show parsed view" : "Show raw JSON"}
-            className={`text-[10px] px-1.5 py-0.5 rounded-md border transition-colors shrink-0 ${
-              raw
-                ? "border-mycel-accent text-mycel-accent"
-                : "border-mycel-border text-mycel-muted hover:text-mycel-text hover:border-mycel-accent"
-            }`}
+        {/* One tidy control set: a segmented Formatted/Raw view switch and
+            an icon copy — grouped so they read as part of the row. */}
+        <span className="flex items-center gap-1">
+          <span
+            role="group"
+            aria-label={`${toolName} ${lowerLabel} view`}
+            className="inline-flex items-center rounded-md border border-mycel-border overflow-hidden text-[10px] leading-none"
           >
-            {"{}"}
-          </button>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); setRaw(false); }}
+              aria-pressed={!raw}
+              title="Formatted view"
+              className={`px-1.5 py-1 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-inset ${
+                raw ? "text-mycel-muted hover:text-mycel-text hover:bg-mycel-surface-hover" : "bg-mycel-accent-subtle text-mycel-accent"
+              }`}
+            >
+              Formatted
+            </button>
+            <button
+              type="button"
+              onClick={(e) => { e.stopPropagation(); setRaw(true); }}
+              aria-pressed={raw}
+              aria-label={`Toggle raw JSON for ${toolName} ${lowerLabel}`}
+              title="Raw JSON"
+              className={`px-1.5 py-1 border-l border-mycel-border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-inset ${
+                raw ? "bg-mycel-accent-subtle text-mycel-accent" : "text-mycel-muted hover:text-mycel-text hover:bg-mycel-surface-hover"
+              }`}
+            >
+              Raw
+            </button>
+          </span>
           <CopyButton text={json} />
         </span>
       </div>

--- a/web/src/components/live/liveHelpers.ts
+++ b/web/src/components/live/liveHelpers.ts
@@ -1,5 +1,6 @@
 import { formatDuration, formatRelative } from "../../utils/time";
 
+import type { AgentActivityItem } from "../../api/client";
 import type {
   AgentActivity,
   HookEvent,
@@ -230,6 +231,70 @@ export function flattenNodes(nodes: ToolNode[]): ToolNode[] {
   };
   walk(nodes);
   return out;
+}
+
+/** Split a flat node list into currently-running rows and everything
+ *  else, preserving input order within each bucket. Running rows get
+ *  pinned above the chronological stream so long feeds never bury an
+ *  in-flight tool call or subagent. */
+export function partitionRunning(nodes: ToolNode[]): { running: ToolNode[]; rest: ToolNode[] } {
+  const running: ToolNode[] = [];
+  const rest: ToolNode[] = [];
+  for (const n of nodes) {
+    if (n.status === "running") running.push(n);
+    else rest.push(n);
+  }
+  return { running, rest };
+}
+
+/* ── Historical activity → ToolNode ─────────────────────────────────── */
+
+/**
+ * Turn a persisted activity row into a ToolNode for the Live feed.
+ *
+ * Historical rows come from the append-only event log, so they carry
+ * whatever the hook recorded — `tool_name`, `tool_input`, `error` — but
+ * never a `tool_response` (results are not persisted) and no Pre/Post
+ * pairing, so duration is unknown. We surface every field that IS stored
+ * and gracefully omit the rest: the row expands to show its input and any
+ * error, and simply has no Output section. This is the same ToolNode shape
+ * the live stream builds, so both render through one EventRow.
+ */
+export function activityItemToNode(item: AgentActivityItem): ToolNode {
+  const data = (item.data ?? {}) as Record<string, unknown>;
+  const dataToolName = typeof data.tool_name === "string" ? data.tool_name : "";
+  const toolName = dataToolName || parseHistoricalToolName(item) || item.event || "unknown";
+
+  const toolInput = data.tool_input ?? null;
+  const error = typeof data.error === "string" && data.error ? data.error : undefined;
+
+  const args = toolInput
+    ? extractToolMetadata(toolName, toolInput)
+    : item.message || "";
+
+  return {
+    id: nextId(),
+    toolName,
+    args,
+    fullInput: toolInput,
+    fullOutput: null,
+    startTime: item.timestamp ? new Date(item.timestamp).getTime() : Date.now(),
+    endTime: undefined,
+    status: error ? "failed" : "completed",
+    error,
+    children: [],
+  };
+}
+
+/** Derive a tool name from a historical row's message ("Bash: cmd" or a
+ *  bare word) when the structured tool_name field is absent. */
+function parseHistoricalToolName(item: AgentActivityItem): string {
+  if (!item.message) return "";
+  const colonIdx = item.message.indexOf(":");
+  if (colonIdx > 0) return item.message.slice(0, colonIdx).trim();
+  const spaceIdx = item.message.indexOf(" ");
+  if (spaceIdx > 0) return item.message.slice(0, spaceIdx).trim();
+  return item.message;
 }
 
 /* ── Task parsing helpers ──────────────────────────────────────────── */

--- a/web/src/hooks/useAgentActivity.ts
+++ b/web/src/hooks/useAgentActivity.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../api/client";
 import { useWebSocket } from "./useWebSocket";
-import type { AgentActivityItem } from "../api/client";
 import type {
   AgentActivity,
   HookEvent,
@@ -9,33 +8,6 @@ import type {
   TaskItem,
   ToolNode,
 } from "../components/live/liveTypes";
-
-// Turn a persisted activity row into a ToolNode for the Live card.
-// Historical rows lack Pre/Post pairing so we mark them completed with
-// unknown duration — same approach as the per-agent hydration path.
-function activityItemToNode(item: AgentActivityItem): ToolNode {
-  const toolName = (() => {
-    if (item.message) {
-      const colonIdx = item.message.indexOf(":");
-      if (colonIdx > 0) return item.message.slice(0, colonIdx).trim();
-      const spaceIdx = item.message.indexOf(" ");
-      if (spaceIdx > 0) return item.message.slice(0, spaceIdx).trim();
-      return item.message;
-    }
-    return item.event || "unknown";
-  })();
-  return {
-    id: nextId(),
-    toolName,
-    args: item.message || "",
-    fullInput: null,
-    fullOutput: null,
-    startTime: item.timestamp ? new Date(item.timestamp).getTime() : Date.now(),
-    endTime: undefined,
-    status: "completed" as const,
-    children: [],
-  };
-}
 import {
   AUTO_COLLAPSE_MS,
   FLUSH_INTERVAL,
@@ -65,6 +37,7 @@ function finalizeRunningNodes(nodes: ToolNode[], endTime: number): ToolNode[] {
 const TERMINAL_STATES = new Set(["idle", "stopped", "done", "error"]);
 
 import {
+  activityItemToNode,
   findLastIdx,
   nextId,
   parseTaskCreate,


### PR DESCRIPTION
Part of #2674

Three owner-requested fixes to the agent **Live activity feed**, all made by modifying the existing shared row/renderer components (`EventRow`, `LiveRenderers`, `ToolDetail`, `liveHelpers`, `useAgentActivity`) — the feed was not rewritten. Streamed (hook/transcript) and historical ("backup") events now flow through one expandable renderer, differing only in how much data each carries.

## 1. Pin running items to the top
**Before:** an in-flight tool call or a still-executing subagent (`Agent: sub`) sat in strict reverse-chronological order and got pushed down / lost as new events streamed in.
**After:** `partitionRunning()` splits `status === "running"` rows into a pinned **Running** band above the chronological list — `sticky` in the agent-detail Live tab, inline at the top of the compact Live card. "Running" is derived from event state (a PreToolUse with no PostToolUse yet / an in-flight subagent). When an item completes it leaves the band and takes its normal chronological place. Rows are keyed by `node.id`, so React moves the existing DOM node — no reorder animation, no full re-render on each tick.

## 2. Make historical events expandable like streamed ones
**Before:** old/backup rows showed a flat `·` and could not expand — `activityItemToNode` discarded the persisted event `data` and set `fullInput/fullOutput` to null.
**After:** `activityItemToNode` hydrates `fullInput`, `error`, and `status` from the persisted event `Data` (`tool_input`, `error`). Historical rows now get the same ▶ affordance and expand through the same `EventRow` → `RichToolInput` path, showing tool name, args, input, and error/status.
**Data-availability limit (honest, not fabricated):** the hook event log persists `tool_input` but **not `tool_response`** (`hookPayloadFields` in `pkg/agent/hook_ingest.go` omits it), and historical rows have no Pre/Post pairing. So an expanded historical row shows its **Input** and any error, has **no Output section**, and unknown duration. No Go change was needed — the `/api/agents/{name}/activity` response already returns `data`; the frontend simply stopped throwing it away.

## 3. Unified copy / JSON controls
**Before:** a text `Copy` button plus a bare `{}` raw toggle — a jarring, bolted-on switch.
**After:** one tidy control set per expanded section: a compact **segmented Formatted / Raw** switch and an **icon copy button** (clipboard → check on success). Consistent 22px sizing, `hover:` and `focus-visible:ring` states, `motion-reduce`-safe. Applied ui-ux-pro-max guidance (visible focus rings, hover feedback, single-purpose motion).

## Tests
- `partitionRunning` splits running from rest and moves a row out of the band once it completes (same id).
- `RunningSection` renders the pinned header + count, and nothing when empty.
- `activityItemToNode` carries `tool_input`, marks failed on `error`, degrades gracefully with message-only rows; a historical row expands to show its Input + copy control and **no** Output section.
- Existing `ToolDetail` raw-toggle / copy tests preserved (aria-labels kept).

## Verify (all green)
- `bunx tsc --noEmit` ✅
- `bun run lint` ✅
- `bun run build` ✅
- `bunx vitest run` ✅ 319 passed (37 files)
- Live: daemon booted on a throwaway `MYCEL_HOME` at `127.0.0.1:8099`, root + activity API returned 200, embedded bundle contains the new controls; torn down. No Go touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)