### PR TITLE
fix(web): codebase quality sweep — stale "bc" MCP-server name in user-facing UI

### DIFF
--- a/web/src/components/code/CodeBrowser.tsx
+++ b/web/src/components/code/CodeBrowser.tsx
@@ -63,7 +63,7 @@ const EMPTY_FILE: FileResult = {
 // Users can still inspect them by toggling `Show hidden`.
 const HIDDEN_DIRS = new Set([
   ".git",
-  ".bc",
+  ".mycel",
   "node_modules",
   "dist",
   "build",
@@ -234,7 +234,7 @@ export function HiddenToggle({
       className={`text-[10px] uppercase tracking-wider transition-colors ${
         showHidden ? "text-mycel-accent" : "text-mycel-muted hover:text-mycel-text"
       }`}
-      title="Toggle .git / .bc entries"
+      title="Toggle .git / .mycel entries"
     >
       {showHidden ? "Hide hidden" : "Show hidden"}
     </button>

--- a/web/src/components/live/liveHelpers.ts
+++ b/web/src/components/live/liveHelpers.ts
@@ -49,7 +49,7 @@ export function parseToolName(name: string): ParsedTool {
 export function mcpBadgeColors(server: string): string {
   if (server === "playwright" || server === "playwright2") return "bg-mycel-info-subtle text-mycel-info";
   if (server === "github") return "bg-mycel-surface-hover text-mycel-text-2";
-  if (server === "bc") return "bg-mycel-accent-subtle text-mycel-accent";
+  if (server === "mycel") return "bg-mycel-accent-subtle text-mycel-accent";
   return "bg-mycel-surface-hover text-mycel-text-2";
 }
 

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -281,7 +281,7 @@ function TemplateDetailPanel({
               value={mcpsRaw}
               onChange={(e) => setMcpsRaw(e.target.value)}
               className="w-full px-3 py-2 rounded-md border border-mycel-border bg-mycel-bg text-mycel-text text-sm focus:outline-none focus:ring-2 focus:ring-mycel-accent"
-              placeholder="bc, github"
+              placeholder="mycel, github"
               aria-label="MCP servers (comma-separated)"
               style={{ fontFamily: MONO }}
             />
@@ -432,7 +432,7 @@ function CreateTemplateForm({
       setName("");
       setDescription("");
       setSystemPrompt("");
-      setMcpsRaw("bc");
+      setMcpsRaw("mycel");
       setSecretsRaw("");
       setPluginsRaw("");
       onClose();
@@ -507,7 +507,7 @@ function CreateTemplateForm({
             type="text"
             value={mcpsRaw}
             onChange={(e) => setMcpsRaw(e.target.value)}
-            placeholder="bc, github"
+            placeholder="mycel, github"
             className="w-full px-3 py-2 rounded-md border border-mycel-border bg-mycel-bg text-mycel-text text-sm focus:outline-none focus:ring-2 focus:ring-mycel-accent"
             style={{ fontFamily: MONO }}
           />


### PR DESCRIPTION
Part of #2674

A quality/consistency pass hunting the class of low-effort, high-embarrassment "stupidity" bugs — wrong/stale names and paths in user-visible strings — of which the recently-fixed `preferences.json → prefs.json` Settings badge was one. Targeted string/label fixes only; no refactors, no behavior changes beyond corrected display.

## Root cause
The daemon's self MCP server was renamed from `bc` to `mycel` (see `server/mcp/server.go:101` `Name: "mycel"` and `pkg/agent/role_setup.go:198,274` registering `MCPServers["mycel"]`). Several web surfaces still hard-coded the old `bc` name, and the code browser still referenced the old `.bc` runtime dir.

## Fixes by category

### wrong-name (stale `bc`/`.bc` → `mycel`/`.mycel`)
- `web/src/components/live/liveHelpers.ts:52` — `mcpBadgeColors`: `server === "bc"` → `server === "mycel"`. The daemon's own tools stopped getting the accent-color badge in Live once the server was renamed; this restores it.
- `web/src/views/Templates.tsx:284` — MCP-servers input placeholder `"bc, github"` → `"mycel, github"`.
- `web/src/views/Templates.tsx:510` — same placeholder in the create form.
- `web/src/views/Templates.tsx:435` — post-create reset default `setMcpsRaw("bc")` → `setMcpsRaw("mycel")` (pre-fills the daemon server every agent gets).
- `web/src/components/code/CodeBrowser.tsx:66` — clutter `HIDDEN_DIRS` entry `".bc"` → `".mycel"` (mycel's runtime dir is `~/.mycel`; repos are never written to).
- `web/src/components/code/CodeBrowser.tsx:237` — hidden-toggle tooltip `"Toggle .git / .bc entries"` → `".mycel"`.

## Found but out of scope
- **`.bcrc` is still the literal runtime config filename.** `pkg/home/userconfig.go:17` joins `~/.bcrc`, and the `mycel config user` help text (`internal/cmd/config.go`) correctly matches it — so the help is *not* a name mismatch. Renaming the actual file is a runtime-contract/behavior change (pinned by `pkg/home/userconfig_test.go`), out of scope for a string sweep.
- **`MYCEL_WORKSPACE` env var** (`internal/cmd/repo_helpers.go`) — internal env-var contract, not user copy; renaming is a behavior change.
- **`scope: "workspace"`** budget scope (`BudgetPanel.tsx`, `StepPreferences.tsx`) — an API contract value sent to `/api/costs/budgets`, never shown as a label. Left as-is.
- **`docker run … -v \$(pwd):/workspace`** in landing install snippets and `/home/coder/workspace` in `Code.tsx` — generic container mount paths, not the removed "workspace" product concept.
- **"Coming soon" badges** in `Templates.tsx` / `ResourcePanel.tsx` — intentional feature-state design copy, not unfilled placeholders.

## Test plan
- `bunx tsc --noEmit` — clean
- `bun run lint` (eslint) — clean
- `bun run build` — succeeds
- `bunx vitest run` — 37 files, 319 tests pass
- No Go touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)