### PR TITLE
fix(live): agent raw stream shows tool output/response

### DIFF
--- a/pkg/agent/hook_ingest.go
+++ b/pkg/agent/hook_ingest.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"time"
+	"unicode/utf8"
 
 	"github.com/rpuneet/mycel/pkg/events"
 	"github.com/rpuneet/mycel/pkg/log"
@@ -164,7 +165,7 @@ func boundedToolResponse(v any) any {
 		if len(s) <= maxToolResponseBytes {
 			return s
 		}
-		return s[:maxToolResponseBytes] + toolResponseTruncatedSuffix
+		return truncateToRuneBoundary(s, maxToolResponseBytes) + toolResponseTruncatedSuffix
 	}
 	b, err := json.Marshal(v)
 	if err != nil {
@@ -175,7 +176,22 @@ func boundedToolResponse(v any) any {
 	if len(b) <= maxToolResponseBytes {
 		return v
 	}
-	return string(b[:maxToolResponseBytes]) + toolResponseTruncatedSuffix
+	return truncateToRuneBoundary(string(b), maxToolResponseBytes) + toolResponseTruncatedSuffix
+}
+
+// truncateToRuneBoundary returns s cut to at most maxBytes bytes without
+// splitting a multi-byte UTF-8 rune: if the byte cap lands in the middle of
+// a rune, it backs up to the start of that rune so the result is always
+// valid UTF-8.
+func truncateToRuneBoundary(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	cut := maxBytes
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
 }
 
 // hookPayloadFields extracts the optional structured fields shared by the

--- a/pkg/agent/hook_ingest.go
+++ b/pkg/agent/hook_ingest.go
@@ -138,6 +138,46 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 	return nil
 }
 
+// maxToolResponseBytes bounds how much of a tool's response we persist into
+// the event log and broadcast to live subscribers. PostToolUse responses
+// (file contents, command output, MCP results, …) can be arbitrarily large;
+// without a cap a single verbose tool call could bloat the event store or a
+// DB row. 16KB keeps enough of the response to be useful in the raw stream
+// while staying well clear of pathological growth.
+const maxToolResponseBytes = 16 * 1024
+
+// toolResponseTruncatedSuffix is appended when a response is cut down to
+// maxToolResponseBytes, so the UI and any consumer can tell the value was
+// shortened rather than naturally ending there.
+const toolResponseTruncatedSuffix = "…[truncated]"
+
+// boundedToolResponse caps a tool_response value to maxToolResponseBytes
+// before it is persisted or broadcast. String responses are truncated
+// directly; structured responses (maps/arrays) are marshaled to measure
+// their size and, if oversized, replaced with a truncated JSON string so the
+// bound is enforced regardless of shape.
+func boundedToolResponse(v any) any {
+	if v == nil {
+		return nil
+	}
+	if s, ok := v.(string); ok {
+		if len(s) <= maxToolResponseBytes {
+			return s
+		}
+		return s[:maxToolResponseBytes] + toolResponseTruncatedSuffix
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		// Unmarshalable value (shouldn't happen for JSON-decoded payloads) —
+		// pass it through unchanged rather than dropping it.
+		return v
+	}
+	if len(b) <= maxToolResponseBytes {
+		return v
+	}
+	return string(b[:maxToolResponseBytes]) + toolResponseTruncatedSuffix
+}
+
 // hookPayloadFields extracts the optional structured fields shared by the
 // event-log Data map and the SSE payload. Message is intentionally absent:
 // it goes to the event log only, never the SSE payload.
@@ -148,6 +188,9 @@ func hookPayloadFields(payload HookPayload) map[string]any {
 	}
 	if payload.ToolInput != nil {
 		fields["tool_input"] = payload.ToolInput
+	}
+	if payload.ToolResponse != nil {
+		fields["tool_response"] = boundedToolResponse(payload.ToolResponse)
 	}
 	if payload.Error != "" {
 		fields["error"] = payload.Error

--- a/pkg/agent/hook_ingest_test.go
+++ b/pkg/agent/hook_ingest_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/rpuneet/mycel/pkg/events"
 )
@@ -151,6 +152,29 @@ func TestBoundedToolResponse(t *testing.T) {
 		}
 		if len(s) != maxToolResponseBytes+len(toolResponseTruncatedSuffix) {
 			t.Errorf("truncated length = %d, want %d", len(s), maxToolResponseBytes+len(toolResponseTruncatedSuffix))
+		}
+	})
+
+	t.Run("oversized multi-byte string stays valid UTF-8", func(t *testing.T) {
+		// "тест" is 4 Cyrillic runes = 8 bytes; repeating it past the cap
+		// guarantees the byte cap lands mid-rune, so a naive byte slice
+		// would emit invalid UTF-8.
+		big := strings.Repeat("тест", maxToolResponseBytes/8+100)
+		got, ok := boundedToolResponse(big).(string)
+		if !ok {
+			t.Fatalf("expected string result, got %T", got)
+		}
+		if !utf8.ValidString(got) {
+			t.Error("truncated multi-byte string is not valid UTF-8")
+		}
+		if !strings.HasSuffix(got, toolResponseTruncatedSuffix) {
+			t.Errorf("truncated string missing suffix marker: %q", got[len(got)-30:])
+		}
+		// The body (minus the multi-byte suffix marker) must not exceed the
+		// byte cap — the rune-boundary backup only ever shrinks it.
+		body := strings.TrimSuffix(got, toolResponseTruncatedSuffix)
+		if len(body) > maxToolResponseBytes {
+			t.Errorf("truncated body length = %d, exceeds cap %d", len(body), maxToolResponseBytes)
 		}
 	})
 }

--- a/pkg/agent/hook_ingest_test.go
+++ b/pkg/agent/hook_ingest_test.go
@@ -1,0 +1,176 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rpuneet/mycel/pkg/events"
+)
+
+// fakeHookAppender records events passed to Append, standing in for the
+// real event store so ingestion tests can assert on persisted Data without
+// touching disk.
+type fakeHookAppender struct {
+	events []events.Event
+}
+
+func (f *fakeHookAppender) Append(event events.Event) error {
+	f.events = append(f.events, event)
+	return nil
+}
+
+// TestIngestHookEvent_PersistsToolResponse verifies the fix for the "no
+// output in the raw stream" bug: a PostToolUse hook payload carrying
+// tool_response must land in the persisted event's Data map (consumed by
+// /api/agents/{name}/activity) and in the live SSE payload (onHookEvent),
+// not just the WebSocket hub broadcast.
+func TestIngestHookEvent_PersistsToolResponse(t *testing.T) {
+	mgr := newTestManager(t)
+	svc := NewAgentService(mgr, nil, nil)
+
+	appender := &fakeHookAppender{}
+	svc.SetHookEventStore(appender)
+
+	var ssePayloads []map[string]any
+	svc.SetOnHookEvent(func(_ string, _ time.Time, payload map[string]any) {
+		ssePayloads = append(ssePayloads, payload)
+	})
+
+	payload := HookPayload{
+		Event:        HookPostToolUse,
+		ToolName:     "Bash",
+		ToolInput:    map[string]any{"command": "echo hi"},
+		ToolResponse: map[string]any{"stdout": "hi\n", "stderr": ""},
+	}
+
+	if err := svc.IngestHookEvent(context.Background(), "does-not-exist", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+
+	if len(appender.events) != 1 {
+		t.Fatalf("expected 1 persisted event, got %d", len(appender.events))
+	}
+	got, ok := appender.events[0].Data["tool_response"]
+	if !ok {
+		t.Fatal("persisted event Data missing tool_response")
+	}
+	gotMap, ok := got.(map[string]any)
+	if !ok {
+		t.Fatalf("tool_response type = %T, want map[string]any", got)
+	}
+	if gotMap["stdout"] != "hi\n" {
+		t.Errorf("tool_response.stdout = %v, want %q", gotMap["stdout"], "hi\n")
+	}
+
+	if len(ssePayloads) != 1 {
+		t.Fatalf("expected 1 SSE payload, got %d", len(ssePayloads))
+	}
+	if _, ok := ssePayloads[0]["tool_response"]; !ok {
+		t.Error("live SSE payload missing tool_response")
+	}
+}
+
+// TestIngestHookEvent_NoToolResponse verifies events without a
+// tool_response (e.g. PreToolUse) don't gain a spurious key.
+func TestIngestHookEvent_NoToolResponse(t *testing.T) {
+	mgr := newTestManager(t)
+	svc := NewAgentService(mgr, nil, nil)
+
+	appender := &fakeHookAppender{}
+	svc.SetHookEventStore(appender)
+
+	payload := HookPayload{
+		Event:     HookPreToolUse,
+		ToolName:  "Bash",
+		ToolInput: map[string]any{"command": "echo hi"},
+	}
+
+	if err := svc.IngestHookEvent(context.Background(), "does-not-exist", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+	if len(appender.events) != 1 {
+		t.Fatalf("expected 1 persisted event, got %d", len(appender.events))
+	}
+	if _, ok := appender.events[0].Data["tool_response"]; ok {
+		t.Error("Data should not contain tool_response when payload has none")
+	}
+}
+
+func TestBoundedToolResponse(t *testing.T) {
+	t.Run("nil passthrough", func(t *testing.T) {
+		if got := boundedToolResponse(nil); got != nil {
+			t.Errorf("boundedToolResponse(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("small string unchanged", func(t *testing.T) {
+		s := "hello world"
+		if got := boundedToolResponse(s); got != s {
+			t.Errorf("got %v, want %q", got, s)
+		}
+	})
+
+	t.Run("oversized string truncated", func(t *testing.T) {
+		big := strings.Repeat("a", maxToolResponseBytes+500)
+		got, ok := boundedToolResponse(big).(string)
+		if !ok {
+			t.Fatalf("expected string result, got %T", got)
+		}
+		if !strings.HasSuffix(got, toolResponseTruncatedSuffix) {
+			t.Errorf("truncated string missing suffix marker: %q", got[len(got)-30:])
+		}
+		if len(got) != maxToolResponseBytes+len(toolResponseTruncatedSuffix) {
+			t.Errorf("truncated length = %d, want %d", len(got), maxToolResponseBytes+len(toolResponseTruncatedSuffix))
+		}
+	})
+
+	t.Run("small structured value unchanged", func(t *testing.T) {
+		v := map[string]any{"stdout": "ok", "stderr": ""}
+		got := boundedToolResponse(v)
+		gotMap, ok := got.(map[string]any)
+		if !ok {
+			t.Fatalf("expected map passthrough, got %T", got)
+		}
+		if gotMap["stdout"] != "ok" {
+			t.Errorf("stdout = %v, want ok", gotMap["stdout"])
+		}
+	})
+
+	t.Run("oversized structured value truncated to string", func(t *testing.T) {
+		v := map[string]any{"stdout": strings.Repeat("b", maxToolResponseBytes+500)}
+		got := boundedToolResponse(v)
+		s, ok := got.(string)
+		if !ok {
+			t.Fatalf("expected string fallback for oversized structured value, got %T", got)
+		}
+		if !strings.HasSuffix(s, toolResponseTruncatedSuffix) {
+			t.Errorf("missing truncation suffix")
+		}
+		if len(s) != maxToolResponseBytes+len(toolResponseTruncatedSuffix) {
+			t.Errorf("truncated length = %d, want %d", len(s), maxToolResponseBytes+len(toolResponseTruncatedSuffix))
+		}
+	})
+}
+
+// TestHookPayloadFields_ToolResponseRoundtrip verifies HookPayload correctly
+// decodes tool_response from raw hook JSON — this is the field that was
+// previously silently dropped by json.Unmarshal because HookPayload had no
+// matching struct field.
+func TestHookPayloadFields_ToolResponseRoundtrip(t *testing.T) {
+	raw := []byte(`{"event":"PostToolUse","tool_name":"Bash","tool_response":{"stdout":"ok"}}`)
+	var payload HookPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload.ToolResponse == nil {
+		t.Fatal("payload.ToolResponse is nil after unmarshal")
+	}
+
+	fields := hookPayloadFields(payload)
+	if _, ok := fields["tool_response"]; !ok {
+		t.Error("hookPayloadFields did not include tool_response")
+	}
+}

--- a/pkg/agent/hooks.go
+++ b/pkg/agent/hooks.go
@@ -96,6 +96,7 @@ func IsKnownEvent(ev HookEvent) bool {
 // Different events populate different fields.
 type HookPayload struct {
 	ToolInput    any            `json:"tool_input,omitempty"`
+	ToolResponse any            `json:"tool_response,omitempty"`
 	Metadata     map[string]any `json:"metadata,omitempty"`
 	SubagentID   string         `json:"subagent_id,omitempty"`
 	Channel      string         `json:"channel,omitempty"`

--- a/web/src/components/live/EventRow.test.tsx
+++ b/web/src/components/live/EventRow.test.tsx
@@ -207,7 +207,27 @@ describe("activityItemToNode + historical expansion", () => {
     expect(screen.getByText("Input")).toBeTruthy();
     // Copy control present inside the expanded row.
     expect(screen.getAllByRole("button", { name: "Copy to clipboard" }).length).toBeGreaterThan(0);
-    // No tool_response is persisted historically → no Output section.
+    // This row's persisted event data has no tool_response → no Output section.
     expect(screen.queryByText("Output")).toBeNull();
+  });
+
+  it("carries tool_response from the persisted event data and renders an Output section", () => {
+    const n = activityItemToNode({
+      timestamp: "2026-07-30T10:00:00.000Z",
+      event: "PostToolUse",
+      message: "Bash: echo hi",
+      data: {
+        tool_name: "Bash",
+        tool_input: { command: "echo hi" },
+        tool_response: { stdout: "hi\n", stderr: "" },
+      },
+    });
+    expect(n.fullOutput).toEqual({ stdout: "hi\n", stderr: "" });
+
+    render(<EventRow node={n} />);
+    fireEvent.click(screen.getByRole("button", { name: /Expand Bash event/ }));
+    expect(screen.getByText("Input")).toBeTruthy();
+    expect(screen.getByText("Output")).toBeTruthy();
+    expect(screen.getByText("hi")).toBeTruthy();
   });
 });

--- a/web/src/components/live/liveHelpers.ts
+++ b/web/src/components/live/liveHelpers.ts
@@ -253,12 +253,11 @@ export function partitionRunning(nodes: ToolNode[]): { running: ToolNode[]; rest
  * Turn a persisted activity row into a ToolNode for the Live feed.
  *
  * Historical rows come from the append-only event log, so they carry
- * whatever the hook recorded — `tool_name`, `tool_input`, `error` — but
- * never a `tool_response` (results are not persisted) and no Pre/Post
- * pairing, so duration is unknown. We surface every field that IS stored
- * and gracefully omit the rest: the row expands to show its input and any
- * error, and simply has no Output section. This is the same ToolNode shape
- * the live stream builds, so both render through one EventRow.
+ * whatever the hook recorded — `tool_name`, `tool_input`, `tool_response`,
+ * `error` — but no Pre/Post pairing, so duration is unknown. We surface
+ * every field that IS stored and gracefully omit the rest. This is the same
+ * ToolNode shape the live stream builds, so both render through one
+ * EventRow.
  */
 export function activityItemToNode(item: AgentActivityItem): ToolNode {
   const data = (item.data ?? {}) as Record<string, unknown>;
@@ -266,6 +265,7 @@ export function activityItemToNode(item: AgentActivityItem): ToolNode {
   const toolName = dataToolName || parseHistoricalToolName(item) || item.event || "unknown";
 
   const toolInput = data.tool_input ?? null;
+  const toolResponse = data.tool_response ?? null;
   const error = typeof data.error === "string" && data.error ? data.error : undefined;
 
   const args = toolInput
@@ -277,7 +277,7 @@ export function activityItemToNode(item: AgentActivityItem): ToolNode {
     toolName,
     args,
     fullInput: toolInput,
-    fullOutput: null,
+    fullOutput: toolResponse,
     startTime: item.timestamp ? new Date(item.timestamp).getTime() : Date.now(),
     endTime: undefined,
     status: error ? "failed" : "completed",

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -179,7 +179,7 @@ function peekItemToNode(item: AgentActivityItem, idx: number): ToolNode {
     toolName,
     args,
     fullInput: item.data ?? null,
-    fullOutput: null,
+    fullOutput: item.data?.tool_response ?? null,
     status: "completed",
     startTime: Number.isNaN(ts) ? Date.now() : ts,
     endTime: undefined,


### PR DESCRIPTION
## Summary

- Historical/reloaded agent raw-stream rows showed the tool call (name + input) but never its output — `HookPayload` had no `tool_response` field, so `json.Unmarshal` silently dropped it from both the persisted event log and the per-agent SSE payload, even though the raw hook JSON (from Claude Code and the pi/codex transcript tailer) carries it.
- The live WebSocket hub broadcast (`agent.hook`) happened to survive because `hook_ingest.go` separately re-parses the raw bytes into a generic map for that path — which is why output appeared while an agent was actively streaming but vanished the moment history was rehydrated from `/api/agents/{name}/activity` (e.g. after a page reload). `activityItemToNode` in the web UI even hardcoded `fullOutput: null` with a comment noting responses "are not persisted".
- Fix: add `ToolResponse` to `HookPayload`, persist it (capped at 16KB with a truncation marker to bound event-log growth) via `hookPayloadFields` into both the stored event `Data` and the live SSE payload, and read `data.tool_response` instead of `null` in the two historical-row builders (`liveHelpers.activityItemToNode`, `Agents.tsx`'s `peekItemToNode`). The `Output` `DetailSection` in `EventRow`/`ToolDetail` already existed and needed no UI changes — it was just waiting on real data to arrive.
- Verified the pi/codex transcript-tailer path shares the exact same `HookPayload`/`IngestHookEvent` pipeline, so the same fix covers it (transcript tailer already captures `ToolResponse` on `TranscriptActivity` and marshals it into the raw JSON it feeds through).

Part of #2674

## Root cause (files/lines)

- `pkg/agent/hooks.go` — `HookPayload` struct had no `ToolResponse` field, so the field was dropped at decode time.
- `pkg/agent/hook_ingest.go` — `hookPayloadFields()` never included `tool_response`, so it never reached persisted `eventData` or the `onHookEvent` SSE payload.
- `web/src/components/live/liveHelpers.ts` — `activityItemToNode` hardcoded `fullOutput: null` for historical rows.
- `web/src/views/Agents.tsx` — `peekItemToNode` had the same hardcoded `null`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/agent/... ./pkg/events/... ./server/...` — 0 issues
- [x] `go test -race ./pkg/events/... ./pkg/agent/... ./server/...` — all pass
- [x] `make build-local-web` — builds clean
- [x] `bun run test` (web) — 322 tests pass, including new coverage for `tool_response` persistence/rendering
- [x] New Go tests: `pkg/agent/hook_ingest_test.go` (`TestIngestHookEvent_PersistsToolResponse`, `TestIngestHookEvent_NoToolResponse`, `TestBoundedToolResponse`, `TestHookPayloadFields_ToolResponseRoundtrip`)
- [x] New web test: `EventRow.test.tsx` — historical row with `tool_response` renders an Output section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool responses are now persisted and available in live and historical activity views.
  * Historical tool activity displays an Output section with the recorded response.
  * Large responses are safely truncated with an indicator when they exceed the supported size limit.

* **Bug Fixes**
  * Structured and string tool responses now appear consistently in event payloads and the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->