### PR TITLE
fix(agent): stop double-persisting hook events (unblocks main CI + CVE scan)

### DIFF
--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -482,8 +482,10 @@ func (s *AgentService) publishEvent(eventType string, data map[string]any) {
 	// Persist agent lifecycle events so every agent has an activity
 	// timeline from birth — hook-less providers (cursor, agy, pi) would
 	// otherwise show an empty Live section forever (#37). Hook events
-	// persist separately in IngestHookEvent.
-	if s.hookStore == nil {
+	// persist separately in IngestHookEvent, which also broadcasts them
+	// here via publishEvent("agent.hook", ...) for the web UI hub — skip
+	// them so they aren't double-appended to the event store.
+	if s.hookStore == nil || eventType == "agent.hook" {
 		return
 	}
 	agentName, _ := data["name"].(string)


### PR DESCRIPTION
Part of #2674

## Root cause — the ticket's premise was wrong, here's the real one

The task as filed assumed `packages/mycel-cli/bin/mycel` is a committed
prebuilt Go binary that Trivy scans stale. It isn't: that file is an
83-byte POSIX shell placeholder (`bin/mycel: not installed, run npm
install`) — the real binary is downloaded per-platform from GitHub
Releases by `install.mjs`'s postinstall hook. `.gitignore` already
excludes the real binary from that package. So there was nothing to
rebuild there.

The actual location Trivy/CodeQL flags in all 12 open alerts
(#2393–#2404) is `usr/local/bin/mycel` — the binary built **from
source** inside `docker/Dockerfile.daemon`, which `.github/workflows/ci.yml`'s
`scan` job builds fresh and scans on every push to `main`. That stage
already uses `golang:1.25.12` and the repo's current `go.mod`/`go.sum`
— so once `golang.org/x/image` was bumped to v0.44.0 (#3412, merged
2026-08-01), a fresh CI run should have produced a clean scan
automatically. No stale artifact was involved.

**Why the alerts persisted anyway:** the commit right after #3412
(current `main` HEAD, 52bdfc32, "agent raw stream shows tool
output/response" #3410) broke `pkg/agent`'s hook-ingestion tests
deterministically — not flakily, reproduced on every local run:

```
--- FAIL: TestIngestHookEvent_PersistsToolResponse
    hook_ingest_test.go:55: expected 1 persisted event, got 2
--- FAIL: TestIngestHookEvent_NoToolResponse
    hook_ingest_test.go:96: expected 1 persisted event, got 2
```

`ci.yml`'s `build` and `scan` jobs both `need: [Test, ...]`, so this
test failure has been skipping `Build` and `Container Scan` on every
push to `main` since #3410 landed — including the push that carried
the x/image fix. Trivy simply never got to re-run against a binary
built with the patched dependency, so the 12 alerts opened against the
last-known-vulnerable scan are still sitting open.

## The actual bug

`AgentService.publishEvent` (added in #3397) has a lifecycle-event
persistence fallback: whenever `hookStore != nil` and an agent name can
be resolved from the event data, it appends the event to the hook
store, with the comment "Hook events persist separately in
IngestHookEvent" — i.e. it was meant to *not* apply to hook events.
#3410 then added `s.publishEvent("agent.hook", rawMap)` inside
`IngestHookEvent` itself (to fan the raw hook JSON out to the web UI
hub), but `rawMap` always carries an `agent` key. So every hook event
now gets appended to the store twice: once directly in
`IngestHookEvent`, once again via the `publishEvent` fallback.

## Fix

`pkg/agent/service.go`: skip the fallback persistence when
`eventType == "agent.hook"`, restoring single-append behavior. One
line of logic, matches the original comment's stated intent.

## Verification

- `go build ./...` and `go vet ./...`: clean (after `make
  build-local-web` — the daemon package embeds `server/web/dist`).
- `go test -race ./pkg/agent/...`: was failing 2/2 deterministically
  (3 repeated runs, same failure every time — not flaky), now green
  (70s, race detector clean).
- Built `bin/mycel` via `make build-local-mycel` and ran `./bin/mycel
  version` — exits 0, prints the version banner.
- `go version -m ./bin/mycel` confirms `go1.25.12` and
  `golang.org/x/image v0.44.0` embedded in the binary — the exact
  toolchain/dependency versions the task said should clear
  CVE-2024-24792 and the x/image CVEs (2022-41727, 2023-29407,
  2023-29408).
- Trivy is not installed in this environment, so I could not run a
  local scan to directly confirm all 12 alerts clear — that
  confirmation is pending the next `ci.yml` run against `main` once
  this merges and the `Test`/`Test (full)` jobs go green, unblocking
  `Build` → `Container Scan`. Given the alerts trace to
  `usr/local/bin/mycel` built fresh each run from `go.mod` (already
  patched by #3412) with `golang:1.25.12`, and the only thing blocking
  that job from running was this deterministic test failure, I'm
  confident but not 100% certain until CI confirms it.

No changes were needed to `packages/mycel-cli/` — it's already
correctly set up (Option B from the original brief) and was never
part of the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate persistence of agent hook events while continuing to broadcast them normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->