### PR TITLE
fix(agent): stop double-persisting hook events (main Test failure)

### DIFF
--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -482,8 +482,10 @@ func (s *AgentService) publishEvent(eventType string, data map[string]any) {
 	// Persist agent lifecycle events so every agent has an activity
 	// timeline from birth — hook-less providers (cursor, agy, pi) would
 	// otherwise show an empty Live section forever (#37). Hook events
-	// persist separately in IngestHookEvent.
-	if s.hookStore == nil {
+	// (agent.hook) are persisted separately in IngestHookEvent with richer
+	// structured Data (tool_input/tool_response), so skip them here — else
+	// each hook event lands in the timeline twice.
+	if s.hookStore == nil || eventType == "agent.hook" {
 		return
 	}
 	agentName, _ := data["name"].(string)


### PR DESCRIPTION
## What
main's `Test` and `Test (full)` jobs are red: `TestIngestHookEvent_PersistsToolResponse` and `_NoToolResponse` fail with `expected 1 persisted event, got 2`.

## Root cause
A merge interaction between two PRs that were each green alone:
- **#3397** made `publishEvent` persist agent-keyed events (so hook-less providers get a timeline).
- **#3410** added `tool_response` persistence inside `IngestHookEvent`.

`IngestHookEvent` `Append()`s the hook event explicitly, then calls `publishEvent("agent.hook", …)` for the live broadcast — and post-#3397 that call **also** persisted, double-writing every hook event. `publishEvent`'s comment already said hook events persist separately, but the guard was missing.

## Fix
Skip persistence for the `agent.hook` event type in `publishEvent`. The explicit `Append` in `IngestHookEvent` — which carries the richer structured `Data` (tool_input/tool_response) — stays the single source of truth. Live SSE/hub broadcast is unchanged.

Fixes #3414

## Test plan
`go test -race ./pkg/agent/` — was FAIL on main, now `ok` (71s). The two regressed tests pass.