### PR TITLE
fix(ui): templates↔marketplace truth, templates nav, boot stall fallback

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -744,6 +744,7 @@ function buildNavGroups(): readonly (readonly NavItem[])[] {
       { to: "/", label: "Home", icon: "home" },
       { to: "/agents", label: "Agents", icon: "agents" },
       { to: "/apps", label: "Apps", icon: "apps" },
+      { to: "/templates", label: "Templates", icon: "roles" },
       { to: "/marketplace", label: "Marketplace", icon: "templates" },
     ],
   ];

--- a/web/src/components/__tests__/Layout.test.tsx
+++ b/web/src/components/__tests__/Layout.test.tsx
@@ -104,6 +104,9 @@ describe("Layout chrome", () => {
 
     expect(screen.getByRole("link", { name: /Marketplace/ })).toHaveAttribute("href", "/marketplace");
     expect(screen.getByRole("link", { name: /Insights/ })).toHaveAttribute("href", "/insights");
+    // Templates is a real CRUD feature and gets its own primary-nav entry,
+    // distinct from the community Marketplace.
+    expect(screen.getByRole("link", { name: /Templates/ })).toHaveAttribute("href", "/templates");
     // Old separate items and captions are gone.
     expect(screen.queryByText("Configure")).not.toBeInTheDocument();
     expect(screen.queryByRole("link", { name: "Metrics" })).not.toBeInTheDocument();

--- a/web/src/components/boot/BootSplash.tsx
+++ b/web/src/components/boot/BootSplash.tsx
@@ -59,7 +59,7 @@ export function BootSplash({
   const riseMs = reduce ? 0 : timings.riseMs;
   const fadeMs = reduce ? 60 : timings.fadeMs;
 
-  const { healthy, lines } = useBootSequence(timings.boot);
+  const { healthy, lines, stalled, retry } = useBootSequence(timings.boot);
   const [phase, setPhase] = useState<Phase>("draw");
   const [minReached, setMinReached] = useState(false);
   const onReadyRef = useRef(onReady);
@@ -126,6 +126,67 @@ export function BootSplash({
           </div>
         ))}
       </div>
+
+      {/* Stall fallback — the daemon never answered a health probe within
+          the stall window. Escape the silent spinner with a clear message
+          plus a way forward, instead of retrying invisibly forever. */}
+      {stalled && !healthy && (
+        <div
+          data-testid="boot-stall"
+          style={{
+            position: "fixed",
+            top: "calc(50% + 96px)",
+            left: "50%",
+            transform: "translateX(-50%)",
+            width: "min(420px, 88vw)",
+            textAlign: "center",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "0.75rem",
+          }}
+        >
+          <p style={{ margin: 0, fontSize: 13, color: "var(--mycel-text-2)" }}>
+            Still trying to reach the daemon&hellip; it may have failed to start.
+          </p>
+          <div style={{ display: "flex", gap: "0.5rem" }}>
+            <button
+              type="button"
+              onClick={retry}
+              style={{
+                font: "inherit",
+                fontSize: 12.5,
+                fontWeight: 600,
+                padding: "0.4rem 0.9rem",
+                borderRadius: 6,
+                border: "1px solid var(--mycel-border)",
+                background: "var(--mycel-surface)",
+                color: "var(--mycel-text)",
+                cursor: "pointer",
+              }}
+            >
+              Retry
+            </button>
+            <button
+              type="button"
+              onClick={() => onReadyRef.current()}
+              style={{
+                font: "inherit",
+                fontSize: 12.5,
+                padding: "0.4rem 0.9rem",
+                borderRadius: 6,
+                border: "1px solid transparent",
+                background: "transparent",
+                color: "var(--mycel-text-2)",
+                cursor: "pointer",
+                textDecoration: "underline",
+              }}
+            >
+              Continue anyway
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/boot/__tests__/BootStall.test.tsx
+++ b/web/src/components/boot/__tests__/BootStall.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
 import { BootSplash, type SplashTimings } from "../BootSplash";
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
@@ -70,5 +70,25 @@ describe("BootSplash stall fallback", () => {
 
     await waitFor(() => expect(screen.queryByTestId("boot-stall")).not.toBeInTheDocument());
     await waitFor(() => expect(screen.getByText("daemon online")).toBeInTheDocument());
+  });
+
+  it("re-arms the stall timeout when the caller changes timing props", async () => {
+    // Daemon never answers, so the stall timer is what governs the UI.
+    fetchMock.mockImplementation(() => Promise.reject(new Error("connection refused")));
+
+    // Mount with a long stall window — no fallback should appear yet.
+    const LONG: SplashTimings = { ...STALL_FAST, boot: { pollMs: 5, paceMs: 0, stallMs: 100000 } };
+    const { rerender } = render(<BootSplash onReady={vi.fn()} timings={LONG} />);
+
+    await waitFor(() => expect(screen.getByText(/connecting to the mycel daemon/i)).toBeInTheDocument());
+    expect(screen.queryByTestId("boot-stall")).not.toBeInTheDocument();
+
+    // Re-render with a tiny stall window: the probe effect must restart and
+    // surface the fallback quickly, proving timing changes take effect.
+    act(() => {
+      rerender(<BootSplash onReady={vi.fn()} timings={STALL_FAST} />);
+    });
+
+    await waitFor(() => expect(screen.getByTestId("boot-stall")).toBeInTheDocument());
   });
 });

--- a/web/src/components/boot/__tests__/BootStall.test.tsx
+++ b/web/src/components/boot/__tests__/BootStall.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { BootSplash, type SplashTimings } from "../BootSplash";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+// Collapse the draw/rise/fade phases and use a tiny stall window so the
+// fallback state appears almost immediately in tests, while still probing
+// on a real (short) interval.
+const STALL_FAST: SplashTimings = {
+  drawMs: 0,
+  minStreamMs: 0,
+  riseMs: 0,
+  fadeMs: 0,
+  boot: { pollMs: 5, paceMs: 0, stallMs: 20 },
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("BootSplash stall fallback", () => {
+  it("surfaces a stall state with retry/continue instead of spinning forever", async () => {
+    // The daemon never answers.
+    fetchMock.mockImplementation(() => Promise.reject(new Error("connection refused")));
+
+    const onReady = vi.fn();
+    render(<BootSplash onReady={onReady} timings={STALL_FAST} />);
+
+    // Initially just the "connecting" state — no stall UI yet.
+    expect(screen.queryByTestId("boot-stall")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(screen.getByTestId("boot-stall")).toBeInTheDocument());
+    expect(
+      screen.getByText(/still trying to reach the daemon/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+
+    const continueBtn = screen.getByRole("button", { name: "Continue anyway" });
+    continueBtn.click();
+    expect(onReady).toHaveBeenCalled();
+  });
+
+  it("clears the stall state once a retry succeeds", async () => {
+    let fail = true;
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (fail) return Promise.reject(new Error("connection refused"));
+      if (u.includes("/api/health"))
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: () => Promise.resolve({ status: "ok" }),
+        } as Response);
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: () => Promise.resolve([]),
+      } as Response);
+    });
+
+    render(<BootSplash onReady={vi.fn()} timings={STALL_FAST} />);
+
+    await waitFor(() => expect(screen.getByTestId("boot-stall")).toBeInTheDocument());
+
+    fail = false;
+    screen.getByRole("button", { name: "Retry" }).click();
+
+    await waitFor(() => expect(screen.queryByTestId("boot-stall")).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("daemon online")).toBeInTheDocument());
+  });
+});

--- a/web/src/components/boot/useBootSequence.ts
+++ b/web/src/components/boot/useBootSequence.ts
@@ -185,11 +185,12 @@ export function useBootSequence(
       cancelled = true;
       for (const t of timers) clearTimeout(t);
     };
-    // Timings are stable module constants in practice; re-running on a new
-    // object would restart the probe needlessly. retryNonce is the one
-    // deliberate re-run trigger, bumped by retry().
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [retryNonce]);
+    // Depend on the primitive timing fields (not the `timings` object,
+    // which callers may recreate each render) so a genuine change to
+    // polling/pacing/stall restarts the probe with the new values.
+    // retryNonce is the one deliberate manual re-run trigger, bumped by
+    // retry().
+  }, [retryNonce, timings.pollMs, timings.paceMs, timings.stallMs]);
 
   return { healthy, lines, stalled, retry };
 }

--- a/web/src/components/boot/useBootSequence.ts
+++ b/web/src/components/boot/useBootSequence.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api, type DoctorReport, type HealthReport } from "../../api/client";
 import { deriveReadiness } from "../../views/readiness/readiness";
 
@@ -31,6 +31,14 @@ export interface BootSequence {
   healthy: boolean;
   /** Newest-last stream of real readiness/log lines. */
   lines: BootLine[];
+  /**
+   * True once health probes have failed for `stallMs` without a single
+   * success. Lets the splash escape the "connecting…" spinner instead of
+   * retrying silently forever when the daemon never comes up.
+   */
+  stalled: boolean;
+  /** Reset the stall flag and restart the probe loop immediately. */
+  retry: () => void;
 }
 
 export interface BootTimings {
@@ -38,9 +46,15 @@ export interface BootTimings {
   pollMs: number;
   /** Stagger between appended readiness lines, for the streaming cascade. */
   paceMs: number;
+  /**
+   * Time with no successful health probe before surfacing a stall state.
+   * Optional so existing partial timing objects (e.g. in tests) keep
+   * compiling; defaults to 9s when omitted.
+   */
+  stallMs?: number;
 }
 
-export const DEFAULT_BOOT_TIMINGS: BootTimings = { pollMs: 500, paceMs: 130 };
+export const DEFAULT_BOOT_TIMINGS: BootTimings = { pollMs: 500, paceMs: 130, stallMs: 9000 };
 
 function rStatusToBoot(s: "ok" | "warn" | "fail"): BootStatus {
   return s;
@@ -57,10 +71,20 @@ export function useBootSequence(
 ): BootSequence {
   const [healthy, setHealthy] = useState(false);
   const [lines, setLines] = useState<BootLine[]>([]);
+  const [stalled, setStalled] = useState(false);
+  // Bumped by retry() to restart the probe effect below.
+  const [retryNonce, setRetryNonce] = useState(0);
   const idRef = useRef(0);
   // Guards so React 18 StrictMode's double-invoke doesn't double-stream.
   const readyHandled = useRef(false);
   const startedWaiting = useRef(false);
+
+  const retry = useCallback(() => {
+    readyHandled.current = false;
+    startedWaiting.current = false;
+    setStalled(false);
+    setRetryNonce((n) => n + 1);
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -84,11 +108,21 @@ export function useBootSequence(
       push({ status: "info", label: "connecting to the mycel daemon" });
     }
 
+    // Surface a fallback state after a long stretch of failed probes —
+    // otherwise a daemon that never comes up leaves the splash spinning
+    // silently forever with no escape.
+    const stallMs = timings.stallMs ?? 9000;
+    const stallTimer = setTimeout(() => {
+      if (!cancelled && !readyHandled.current) setStalled(true);
+    }, stallMs);
+    timers.push(stallTimer);
+
     async function onReady() {
       if (readyHandled.current) return;
       readyHandled.current = true;
       if (cancelled) return;
       setHealthy(true);
+      setStalled(false);
       push({ status: "ok", label: "daemon online", detail: "http responding" });
 
       // Derive the real readiness model and stream it line by line.
@@ -152,9 +186,10 @@ export function useBootSequence(
       for (const t of timers) clearTimeout(t);
     };
     // Timings are stable module constants in practice; re-running on a new
-    // object would restart the probe needlessly.
+    // object would restart the probe needlessly. retryNonce is the one
+    // deliberate re-run trigger, bumped by retry().
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [retryNonce]);
 
-  return { healthy, lines };
+  return { healthy, lines, stalled, retry };
 }

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { usePolling } from "../hooks/usePolling";
@@ -750,8 +751,8 @@ export function Templates() {
         />
       )}
 
-      {/* Table — local templates, distinguished from the (future)
-          community marketplace content below. */}
+      {/* Table — local templates, distinguished from the marketplace
+          link below. */}
       {filteredTemplates !== null && filteredTemplates.length > 0 && (
         <div>
           <div className="pb-2 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted select-none">
@@ -781,67 +782,47 @@ export function Templates() {
         </div>
       )}
 
-      {/* Marketplace preview — the community marketplace ships in a
-          later release; these quiet placeholder cards frame the page
-          without dominating it. */}
-      <MarketplacePreview />
+      {/* Marketplace link — community templates & shared roles/workflows
+          are a real, shipped feature at /marketplace, not a future one. */}
+      <MarketplaceLink />
     </div>
   );
 }
 
-/* ── Marketplace preview ─────────────────────────────────────────────
-   Restrained coming-soon strip for the future community features.
-   Muted cards on the token system — an appetite-whetter, not an
-   empty state. */
-const MARKETPLACE_PREVIEWS = [
-  {
-    title: "Browse community templates",
-    description: "Discover agent templates shared by other mycel users.",
-  },
-  {
-    title: "Install shared roles & workflows",
-    description: "Pull ready-made roles and multi-agent workflows into your fleet.",
-  },
-] as const;
-
-function MarketplacePreview() {
+/* ── Marketplace link ─────────────────────────────────────────────────
+   Points at the real /marketplace route (community templates, shared
+   roles & workflows) instead of duplicating or mis-stating its status. */
+function MarketplaceLink() {
   return (
     <div className="pt-2">
       <div className="pb-2 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted select-none">
         Marketplace
       </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-        {MARKETPLACE_PREVIEWS.map((p) => (
-          <div
-            key={p.title}
-            className="flex items-start gap-3 rounded-lg border border-dashed border-mycel-border bg-mycel-surface px-4 py-3"
-          >
-            {/* Small mark — a quiet node glyph, not a hero icon. */}
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 14 14"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.3"
-              className="shrink-0 mt-0.5 text-mycel-muted"
-              aria-hidden
-            >
-              <circle cx="7" cy="7" r="2" />
-              <path d="M8.5 5.5L11 3M5.5 8.5L3 11M9 8.5l2.5 1.5" strokeLinecap="round" opacity="0.6" />
-            </svg>
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <span className="text-sm font-medium text-mycel-text-2 truncate">{p.title}</span>
-                <span className="shrink-0 rounded-full border border-mycel-border bg-mycel-bg px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.06em] text-mycel-muted">
-                  Coming soon
-                </span>
-              </div>
-              <p className="mt-0.5 text-xs text-mycel-muted">{p.description}</p>
-            </div>
-          </div>
-        ))}
-      </div>
+      <Link
+        to="/marketplace"
+        className="flex items-start gap-3 rounded-lg border border-mycel-border bg-mycel-surface px-4 py-3 hover:bg-mycel-surface-hover transition-colors"
+      >
+        {/* Small mark — a quiet node glyph, not a hero icon. */}
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 14 14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.3"
+          className="shrink-0 mt-0.5 text-mycel-muted"
+          aria-hidden
+        >
+          <circle cx="7" cy="7" r="2" />
+          <path d="M8.5 5.5L11 3M5.5 8.5L3 11M9 8.5l2.5 1.5" strokeLinecap="round" opacity="0.6" />
+        </svg>
+        <div className="min-w-0">
+          <span className="text-sm font-medium text-mycel-text-2">Browse the marketplace</span>
+          <p className="mt-0.5 text-xs text-mycel-muted">
+            Discover community templates and install shared roles & workflows into your fleet.
+          </p>
+        </div>
+      </Link>
     </div>
   );
 }

--- a/web/src/views/__tests__/templates.test.tsx
+++ b/web/src/views/__tests__/templates.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { HeaderSlotProvider } from "../../context/HeaderSlotContext";
+import { Templates } from "../Templates";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function renderTemplates() {
+  return render(
+    <MemoryRouter initialEntries={["/templates"]}>
+      <HeaderSlotProvider>
+        <Templates />
+      </HeaderSlotProvider>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("Templates marketplace section", () => {
+  it("links to the real /marketplace route instead of claiming it is coming soon", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/templates")) {
+        return jsonResponse([
+          { name: "reviewer", description: "Code review agent", mcps: [], secrets: [], plugins: [] },
+        ]);
+      }
+      return jsonResponse([]);
+    });
+
+    renderTemplates();
+
+    await waitFor(() => expect(screen.getByText("reviewer")).toBeInTheDocument());
+
+    // The marketplace already ships at /marketplace — the page must link
+    // to it, not claim it's a future feature.
+    const link = screen.getByRole("link", { name: /Browse the marketplace/ });
+    expect(link).toHaveAttribute("href", "/marketplace");
+
+    // No leftover "coming soon" placeholder copy.
+    expect(screen.queryByText(/coming soon/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Browse community templates/)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Part of #2674

## Summary
- **Templates ↔ Marketplace truth**: `Templates.tsx`'s `MarketplacePreview` rendered two "Coming soon" cards ("Browse community templates", "Install shared roles & workflows") even though `/marketplace` already ships exactly that. Replaced with a real link card pointing to `/marketplace`.
- **Templates nav entry**: `/templates` is a full CRUD feature but had no primary-nav entry — only reachable via the create-agent wizard's final step. Added a `Templates` item to `buildNavGroups()` in `Layout.tsx` (between Apps and Marketplace, using the existing unused `roles` icon). `/code` was left untouched, as instructed.
- **Boot stall fallback**: `useBootSequence`'s `poll()` retried `/api/health` forever with no backoff/limit, and `BootSplash` showed only an indefinite "connecting to the mycel daemon" spinner if the daemon never came up. Added a `stallMs` (default 9s) timer — after that many ms of failed probes with no success, `useBootSequence` now exposes `stalled` + a `retry()` function, and `BootSplash` renders a fallback message ("Still trying to reach the daemon… it may have failed to start") with **Retry** and **Continue anyway** actions. The happy path (fast or eventual health) is unchanged; `stallMs` is optional on `BootTimings` so existing partial timing objects in tests keep compiling.

## Test plan
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx eslint` on all touched + new files — clean
- [x] `make build-local-web` — builds successfully
- [x] `bunx vitest run` — 325/325 tests pass across 39 files, including:
  - new `web/src/views/__tests__/templates.test.tsx` — Templates links to `/marketplace`, no "coming soon" copy
  - `web/src/components/__tests__/Layout.test.tsx` — updated to assert the new Templates nav link (`href="/templates"`)
  - new `web/src/components/boot/__tests__/BootStall.test.tsx` — stall fallback appears after the timeout with Retry/Continue actions; a successful retry clears the stall state and reaches "daemon online"
  - existing `BootGate.test.tsx` happy-path tests still pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Templates** link to the primary navigation.
  - Updated the Templates page with a direct link to the Marketplace and descriptive content.
  - Added boot recovery options when startup health checks stall: **Retry** and **Continue anyway**.
  - Retry now resumes startup checks and can recover automatically when the service becomes available.

- **Bug Fixes**
  - Improved handling of stalled application startup.

- **Tests**
  - Added coverage for Templates navigation, Marketplace linking, and boot recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->