### PR TITLE
fix(live): working pause, full event coverage, resolving permission rows

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * App.test.tsx — HomeGate first-run flash fix (#2674).
+ *
+ * HomeGate used to render the full Home dashboard immediately and only
+ * redirect to /welcome once the onboarding probe resolved — a visible
+ * flash of the empty dashboard on a fresh install. It should instead show
+ * a blank/skeleton frame while the probe is in flight, then land on either
+ * Home or /welcome once it resolves.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { HomeGate } from "./App";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function renderGate() {
+  return render(
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/" element={<HomeGate />} />
+        <Route path="/welcome" element={<div>Welcome Page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("HomeGate", () => {
+  it("shows a blank/skeleton frame while the onboarding probe is in flight, not Home", async () => {
+    let resolveOnboarding!: (v: Response) => void;
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/onboarding/state")) {
+        return new Promise<Response>((resolve) => {
+          resolveOnboarding = resolve;
+        });
+      }
+      return jsonResponse([]);
+    });
+
+    renderGate();
+
+    // While pending: no live-stream chrome from Home should be present.
+    expect(screen.queryByTestId("live-state-badge")).not.toBeInTheDocument();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+
+    // Resolve as a returning (non-first-run) install: lands on Home.
+    resolveOnboarding(jsonResponse({ firstRun: false }) as unknown as Response);
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("redirects to /welcome on first run without ever rendering Home", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/onboarding/state")) return jsonResponse({ firstRun: true });
+      return jsonResponse([]);
+    });
+
+    renderGate();
+
+    await waitFor(() => {
+      expect(screen.getByText("Welcome Page")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("live-state-badge")).not.toBeInTheDocument();
+  });
+
+  it("falls back to Home when the onboarding probe fails", async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes("/onboarding/state")) return Promise.reject(new Error("network down"));
+      return jsonResponse([]);
+    });
+
+    renderGate();
+
+    await waitFor(() => {
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText("Welcome Page")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,29 +27,31 @@ function Loading() {
 }
 
 /**
- * HomeGate — routes a fresh install to the setup wizard. It renders Home
- * immediately (so the common, already-set-up case never flashes a loader)
- * and only redirects to /welcome once it positively learns this is a first
- * run. Any probe failure falls back to Home, so a daemon hiccup never traps
- * the user in onboarding.
+ * HomeGate — routes a fresh install to the setup wizard. While the
+ * onboarding probe is in flight it renders a blank/skeleton frame — not
+ * the real Home — so a first run never flashes the empty dashboard before
+ * bouncing to /welcome. Any probe failure (or a positive "not first run")
+ * falls through to Home, so a daemon hiccup never traps the user in
+ * onboarding.
  */
-function HomeGate() {
-  const [redirect, setRedirect] = useState(false);
+export function HomeGate() {
+  const [status, setStatus] = useState<"pending" | "home" | "welcome">("pending");
   useEffect(() => {
     let cancelled = false;
     api
       .getOnboardingState()
       .then((s) => {
-        if (!cancelled && s.firstRun) setRedirect(true);
+        if (!cancelled) setStatus(s.firstRun ? "welcome" : "home");
       })
       .catch(() => {
-        /* stay on Home */
+        if (!cancelled) setStatus("home");
       });
     return () => {
       cancelled = true;
     };
   }, []);
-  if (redirect) return <Navigate to="/welcome" replace />;
+  if (status === "pending") return <Loading />;
+  if (status === "welcome") return <Navigate to="/welcome" replace />;
   return <Home />;
 }
 

--- a/web/src/components/live/liveHelpers.ts
+++ b/web/src/components/live/liveHelpers.ts
@@ -129,6 +129,45 @@ export function extractToolMetadata(toolName: string, input: unknown): string {
   return redactSecrets(trunc(s));
 }
 
+/** Compact one-line label for mycel-internal / informational events that
+ *  don't carry a tool_name — channel chatter, cost updates, notifications,
+ *  config/worktree changes, compaction boundaries, etc. Used so every known
+ *  server event surfaces a row in the timeline instead of only being visible
+ *  in the Raw tab (#2674). */
+export function summarizeInternalEvent(evt: HookEvent): string {
+  const trunc = (s: string, max = 100): string => (s.length > max ? s.slice(0, max - 3) + "..." : s);
+
+  switch (evt.event) {
+    case "ChannelMessage":
+    case "ChannelSent": {
+      const who = evt.sender ? `@${evt.sender}` : "";
+      const chan = evt.channel ? `#${evt.channel}` : "";
+      const body = evt.message ? trunc(evt.message) : "";
+      return [chan, who, body].filter(Boolean).join(" ");
+    }
+    case "AgentMessage": {
+      const who = evt.sender ? `from @${evt.sender}` : "";
+      const body = evt.message ? trunc(evt.message) : "";
+      return [who, body].filter(Boolean).join(" ");
+    }
+    case "CostUpdate":
+      return typeof evt.cost_usd === "number" ? `+$${evt.cost_usd.toFixed(4)}` : "";
+    case "Notification":
+      return evt.message ? trunc(evt.message) : "";
+    case "ConfigChange":
+      return evt.file ?? evt.message ?? "";
+    case "WorktreeCreate":
+    case "WorktreeRemove":
+      return evt.file ?? evt.message ?? "";
+    case "PreCompact":
+      return "compacting context…";
+    case "PostCompact":
+      return "context compacted";
+    default:
+      return evt.message ?? evt.task ?? evt.command ?? "";
+  }
+}
+
 export function summarizeArgs(evt: HookEvent): string {
   if (evt.tool_name && evt.tool_input) {
     return extractToolMetadata(evt.tool_name, evt.tool_input);

--- a/web/src/components/live/liveTypes.ts
+++ b/web/src/components/live/liveTypes.ts
@@ -44,6 +44,17 @@ export interface HookEvent {
   input_tokens?: number;
   output_tokens?: number;
   prompt?: string;
+  /** mycel-internal event fields (ChannelMessage/Sent, AgentMessage,
+   *  CostUpdate, Notification, ConfigChange, Worktree*, …). */
+  channel?: string;
+  sender?: string;
+  message?: string;
+  mentions?: string[];
+  cost_usd?: number;
+  file?: string;
+  model?: string;
+  state?: string;
+  task_title?: string;
 }
 
 export interface TaskItem {

--- a/web/src/hooks/__tests__/useAgentActivity.test.ts
+++ b/web/src/hooks/__tests__/useAgentActivity.test.ts
@@ -1,0 +1,184 @@
+/**
+ * useAgentActivity.test.ts — coverage for the code-review fixes to the
+ * live activity stream (#2674):
+ *
+ *   1. Pause actually buffers events (and counts them) instead of being
+ *      decorative, and resume flushes the buffer in order.
+ *   2. Event kinds that used to fall through the event→node switch with no
+ *      rendered row (e.g. Notification) now produce a node.
+ *   3. ElicitationResult finalizes the "waiting for permission" running
+ *      node instead of leaving it pinned forever.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAgentActivity } from "../useAgentActivity";
+import { FLUSH_INTERVAL } from "../../components/live/liveTypes";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+/** Captures every EventSource the hook constructs so tests can push
+ *  messages onto it directly, mirroring the real SSE stream. */
+class TestEventSource {
+  onopen: (() => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(_url: string) {
+    instances.push(this);
+  }
+  close() {
+    /* no-op */
+  }
+}
+let instances: TestEventSource[] = [];
+
+function emit(type: string, data: Record<string, unknown>) {
+  const es = instances[instances.length - 1];
+  es?.onmessage?.({ data: JSON.stringify({ type, data }) } as MessageEvent);
+}
+
+beforeEach(() => {
+  instances = [];
+  (globalThis as unknown as { EventSource: typeof EventSource }).EventSource =
+    TestEventSource as unknown as typeof EventSource;
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(() => jsonResponse([]));
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function tick(ms = FLUSH_INTERVAL) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+describe("useAgentActivity — pause/resume", () => {
+  it("buffers events and counts them while paused, then flushes on resume", async () => {
+    const { result, rerender } = renderHook(
+      ({ paused }: { paused: boolean }) => useAgentActivity(undefined, { paused }),
+      { initialProps: { paused: false } },
+    );
+    await tick(0);
+
+    // Pause the stream.
+    rerender({ paused: true });
+    await tick(0);
+
+    act(() => {
+      emit("agent.hook", { agent: "alice", event: "PreToolUse", tool_name: "Bash", command: "echo hi" });
+    });
+    await tick();
+
+    // Buffered, not applied: no activity entry yet, but pausedCount ticked up.
+    expect(result.current.activities.get("alice")).toBeUndefined();
+    expect(result.current.pausedCount).toBeGreaterThan(0);
+
+    // Resume flushes the buffer through the normal pipeline.
+    rerender({ paused: false });
+    await tick();
+
+    const alice = result.current.activities.get("alice");
+    expect(alice).toBeDefined();
+    expect(alice!.nodes.some((n) => n.toolName === "Bash")).toBe(true);
+    expect(result.current.pausedCount).toBe(0);
+  });
+
+  it("resumes and flushes buffered state_changed events too", async () => {
+    const { result, rerender } = renderHook(
+      ({ paused }: { paused: boolean }) => useAgentActivity(undefined, { paused }),
+      { initialProps: { paused: false } },
+    );
+    await tick(0);
+
+    // Seed an existing agent so the state_changed update has something to merge into.
+    act(() => {
+      emit("agent.hook", { agent: "bob", event: "UserPromptSubmit", prompt: "do work" });
+    });
+    await tick();
+    expect(result.current.activities.get("bob")).toBeDefined();
+
+    rerender({ paused: true });
+    await tick(0);
+
+    act(() => {
+      emit("agent.state_changed", { name: "bob", state: "stuck", task: "waiting" });
+    });
+
+    expect(result.current.activities.get("bob")!.state).not.toBe("stuck");
+    expect(result.current.pausedCount).toBeGreaterThan(0);
+
+    rerender({ paused: false });
+    await tick();
+
+    expect(result.current.activities.get("bob")!.state).toBe("stuck");
+    expect(result.current.pausedCount).toBe(0);
+  });
+});
+
+describe("useAgentActivity — full event coverage", () => {
+  it("renders a node for event kinds that previously had no switch case", async () => {
+    const { result } = renderHook(() => useAgentActivity());
+    await tick(0);
+
+    act(() => {
+      emit("agent.hook", { agent: "carol", event: "Notification", message: "heads up" });
+    });
+    await tick();
+
+    const carol = result.current.activities.get("carol");
+    expect(carol).toBeDefined();
+    expect(carol!.nodes.some((n) => n.toolName === "Notification" && n.args.includes("heads up"))).toBe(true);
+  });
+
+  it("renders a compact row for a totally unhandled-but-known event via the default case", async () => {
+    const { result } = renderHook(() => useAgentActivity());
+    await tick(0);
+
+    act(() => {
+      emit("agent.hook", { agent: "dave", event: "TeammateIdle" });
+    });
+    await tick();
+
+    const dave = result.current.activities.get("dave");
+    expect(dave).toBeDefined();
+    expect(dave!.nodes.some((n) => n.toolName === "TeammateIdle")).toBe(true);
+  });
+});
+
+describe("useAgentActivity — ElicitationResult clears the running node", () => {
+  it("finalizes a pending Elicitation node when its result arrives", async () => {
+    const { result } = renderHook(() => useAgentActivity());
+    await tick(0);
+
+    act(() => {
+      emit("agent.hook", { agent: "erin", event: "Elicitation", tool_name: "AskUser" });
+    });
+    await tick();
+
+    let erin = result.current.activities.get("erin")!;
+    let node = erin.nodes.find((n) => n.toolName === "Elicitation");
+    expect(node?.status).toBe("running");
+
+    act(() => {
+      emit("agent.hook", { agent: "erin", event: "ElicitationResult", message: "approved" });
+    });
+    await tick();
+
+    erin = result.current.activities.get("erin")!;
+    node = erin.nodes.find((n) => n.toolName === "Elicitation");
+    expect(node?.status).toBe("completed");
+  });
+});

--- a/web/src/hooks/useAgentActivity.ts
+++ b/web/src/hooks/useAgentActivity.ts
@@ -44,6 +44,7 @@ import {
   parseTaskListResponse,
   parseTaskUpdate,
   summarizeArgs,
+  summarizeInternalEvent,
   updateSubagentChild,
   updateTopLevelNode,
 } from "../components/live/liveHelpers";
@@ -54,21 +55,41 @@ import {
    events for that agent are processed.
 ─────────────────────────────────────────────────────────────────── */
 
-export function useAgentActivity(agentName?: string): {
+/** A buffered state_changed event, replayed in order on resume. */
+interface PendingStateChange {
+  name: string;
+  state: string;
+  task?: string;
+  role?: string;
+}
+
+export interface UseAgentActivityOptions {
+  /** When true, incoming events are buffered instead of applied — the
+   *  stream keeps counting (via `pausedCount`) but the UI stays frozen
+   *  until `paused` flips back to false, at which point everything
+   *  buffered is flushed through in order. */
+  paused?: boolean;
+}
+
+export function useAgentActivity(agentName?: string, options?: UseAgentActivityOptions): {
   activities: Map<string, AgentActivity>;
   tasks: Map<string, TaskItem>;
   rawEventsRef: React.MutableRefObject<Map<string, RawEvent[]>>;
   connected: boolean;
   reconnecting: boolean;
   eventCount: number;
+  pausedCount: number;
 } {
+  const paused = options?.paused ?? false;
   const [activities, setActivities] = useState<Map<string, AgentActivity>>(new Map());
   const [tasks, setTasks] = useState<Map<string, TaskItem>>(new Map());
   const [eventCount, setEventCount] = useState(0);
+  const [pausedCount, setPausedCount] = useState(0);
   const rawEventsRef = useRef<Map<string, RawEvent[]>>(new Map());
   const eventBuffer = useRef<HookEvent[]>([]);
   const pausedRef = useRef(false);
   const pausedBuffer = useRef<HookEvent[]>([]);
+  const pausedStateBuffer = useRef<PendingStateChange[]>([]);
   const { connected, reconnecting, subscribe } = useWebSocket();
 
   // Seed from agents API + initial logs
@@ -153,6 +174,7 @@ export function useAgentActivity(agentName?: string): {
 
     if (pausedRef.current) {
       pausedBuffer.current.push(...events);
+      setPausedCount((c) => c + events.length);
       return;
     }
 
@@ -365,11 +387,64 @@ export function useAgentActivity(agentName?: string): {
             });
             break;
 
+          // The server resolves a pending PermissionRequest/Elicitation with
+          // ElicitationResult (pkg/agent/hooks.go) — without handling it here
+          // the "waiting for permission" row never clears and stays pinned
+          // as "running" until the turn ends (#2674).
+          case "ElicitationResult": {
+            const matchWaiting = (n: AgentActivity["nodes"][number]): boolean =>
+              (n.toolName === "PermissionRequest" || n.toolName === "Elicitation") && n.status === "running";
+            const markResolved = (n: AgentActivity["nodes"][number]): AgentActivity["nodes"][number] => ({
+              ...n, status: "completed" as const, endTime: Date.now(),
+              fullOutput: evt.message ?? evt.tool_response ?? null,
+            });
+
+            const found = updateSubagentChild(activity, matchWaiting, markResolved);
+            if (!found) {
+              updateTopLevelNode(activity, matchWaiting, markResolved);
+            }
+            break;
+          }
+
           case "SessionStart": case "SessionEnd": case "Stop": case "TaskCompleted":
             // Turn/session boundary: whatever was still "running" is over.
             activity.state = "idle";
             activity.nodes = finalizeRunningNodes(activity.nodes, Date.now());
             activity.activeSubagentIdx = undefined;
+            break;
+
+          // mycel-internal / informational events that previously fell
+          // through the switch unrendered — only visible in the Raw tab
+          // (#2674). Surface each as a compact completed row so the
+          // timeline shows every known server event.
+          case "ChannelMessage":
+          case "ChannelSent":
+          case "AgentMessage":
+          case "CostUpdate":
+          case "Notification":
+          case "ConfigChange":
+          case "WorktreeCreate":
+          case "WorktreeRemove":
+          case "PreCompact":
+          case "PostCompact":
+            activity.nodes.push({
+              id: nextId(), toolName: evt.event, args: summarizeInternalEvent(evt),
+              fullInput: evt.tool_input ?? null, fullOutput: null, status: "completed",
+              startTime: Date.now(), endTime: Date.now(), children: [],
+            });
+            break;
+
+          // Any other known-but-unhandled event (TeammateIdle,
+          // InstructionsLoaded, Pre/PostInvocation, …): render a generic
+          // compact row rather than dropping it silently.
+          default:
+            if (evt.event) {
+              activity.nodes.push({
+                id: nextId(), toolName: evt.event, args: summarizeInternalEvent(evt),
+                fullInput: evt.tool_input ?? null, fullOutput: null, status: "completed",
+                startTime: Date.now(), endTime: Date.now(), children: [],
+              });
+            }
             break;
         }
 
@@ -414,6 +489,30 @@ export function useAgentActivity(agentName?: string): {
     return unsub;
   }, [subscribe, agentName]);
 
+  // Applies one state_changed event to `activities`. Shared by the live
+  // subscription below and by the resume-flush replay so buffered state
+  // changes land exactly as they would have live.
+  const applyStateChange = useCallback((change: PendingStateChange) => {
+    setEventCount((c) => c + 1);
+    setActivities((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(change.name);
+      if (existing) {
+        const updates: Partial<AgentActivity> = { state: change.state, lastEventTime: Date.now() };
+        if (change.task) updates.task = change.task;
+        if (change.role) updates.role = change.role;
+        // Agent went idle/stopped: age out stale "running" rows so the
+        // stream shows the real last events, not a frozen snapshot.
+        if (TERMINAL_STATES.has(change.state)) {
+          updates.nodes = finalizeRunningNodes(existing.nodes, Date.now());
+          updates.activeSubagentIdx = undefined;
+        }
+        next.set(change.name, { ...existing, ...updates });
+      }
+      return next;
+    });
+  }, []);
+
   // Subscribe to agent.state_changed events
   useEffect(() => {
     const unsub = subscribe("agent.state_changed", (wsEvent) => {
@@ -425,32 +524,43 @@ export function useAgentActivity(agentName?: string): {
       // Filter by agentName if provided
       if (agentName && name !== agentName) return;
 
+      const change: PendingStateChange = {
+        name, state,
+        task: d.task as string | undefined,
+        role: d.role as string | undefined,
+      };
+
       if (pausedRef.current) {
-        pausedBuffer.current.push({ agent: name, event: "state_changed", task: d.task as string | undefined });
+        pausedStateBuffer.current.push(change);
+        setPausedCount((c) => c + 1);
         return;
       }
 
-      setEventCount((c) => c + 1);
-      setActivities((prev) => {
-        const next = new Map(prev);
-        const existing = next.get(name);
-        if (existing) {
-          const updates: Partial<AgentActivity> = { state, lastEventTime: Date.now() };
-          if (d.task) updates.task = d.task as string;
-          if (d.role) updates.role = d.role as string;
-          // Agent went idle/stopped: age out stale "running" rows so the
-          // stream shows the real last events, not a frozen snapshot.
-          if (TERMINAL_STATES.has(state)) {
-            updates.nodes = finalizeRunningNodes(existing.nodes, Date.now());
-            updates.activeSubagentIdx = undefined;
-          }
-          next.set(name, { ...existing, ...updates });
-        }
-        return next;
-      });
+      applyStateChange(change);
     });
     return unsub;
-  }, [subscribe, agentName]);
+  }, [subscribe, agentName, applyStateChange]);
+
+  // Resume: flush everything buffered while paused, in order, then reset
+  // the paused counter. Hook events are handed back to the normal buffer
+  // so the next flush tick processes them through the same switch as a
+  // live event would; state changes are replayed directly.
+  const prevPausedRef = useRef(paused);
+  useEffect(() => {
+    pausedRef.current = paused;
+    if (prevPausedRef.current && !paused) {
+      const bufferedHooks = pausedBuffer.current.splice(0);
+      if (bufferedHooks.length > 0) {
+        eventBuffer.current.push(...bufferedHooks);
+      }
+      const bufferedStates = pausedStateBuffer.current.splice(0);
+      for (const change of bufferedStates) {
+        applyStateChange(change);
+      }
+      setPausedCount(0);
+    }
+    prevPausedRef.current = paused;
+  }, [paused, applyStateChange]);
 
   return {
     activities,
@@ -459,5 +569,6 @@ export function useAgentActivity(agentName?: string): {
     connected,
     reconnecting,
     eventCount,
+    pausedCount,
   };
 }

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -148,7 +148,8 @@ function PresenceLine({
 }
 
 export function Home() {
-  const { activities, tasks, rawEventsRef, connected, reconnecting, eventCount } = useAgentActivity();
+  const [paused, setPaused] = useState(false);
+  const { activities, tasks, rawEventsRef, connected, reconnecting, eventCount, pausedCount } = useAgentActivity(undefined, { paused });
   const [typeFilter, setTypeFilter] = useState<FilterType>("all");
   const [searchFilter, setSearchFilter] = useState("");
   const [showStopped, setShowStoppedState] = useState<boolean>(() => readShowStopped());
@@ -160,8 +161,6 @@ export function Home() {
       return next;
     });
   }, []);
-  const [paused, setPaused] = useState(false);
-  const [pausedCount, setPausedCount] = useState(0);
   const [collapsedOverrides, setCollapsedOverrides] = useState<Map<string, boolean>>(new Map());
   const [showJumpToLatest, setShowJumpToLatest] = useState(false);
   const [newEventsSinceScroll, setNewEventsSinceScroll] = useState(0);
@@ -179,9 +178,10 @@ export function Home() {
     setRawEventsVersion((v) => v + 1);
   }, [eventCount]);
 
+  // Resuming just flips the flag threaded into useAgentActivity — the hook
+  // owns the paused buffer and flushes it (and resets pausedCount) itself.
   const handleResume = useCallback(() => {
     setPaused(false);
-    setPausedCount(0);
   }, []);
 
   const summary = useMemo(() => {


### PR DESCRIPTION
Part of #2674

## Summary

Three code-review findings against the Home live activity stream, plus a related first-run flash fix:

- **[P0] Pause was decorative.** `Home.tsx` tracked `paused`/`pausedCount` locally but never threaded them into `useAgentActivity()`. The hook now accepts `{ paused }` and threads it through: hook + `state_changed` events are buffered while paused, `pausedCount` actually increments, and everything buffered is flushed through the normal pipeline (in order) on resume.
- **[integration-gap] Dropped event kinds.** The event→node switch in `useAgentActivity.ts` had no `default` case and silently dropped `ChannelMessage`, `ChannelSent`, `AgentMessage`, `CostUpdate`, `Notification`, `ConfigChange`, `WorktreeCreate`/`WorktreeRemove`, `PreCompact`/`PostCompact` — visible only in the Raw tab. Each now renders a compact row (`summarizeInternalEvent` in `liveHelpers.ts`); any other known-but-unhandled event (e.g. `TeammateIdle`) falls through a generic default renderer instead of vanishing.
- **[bug] Permission rows never cleared.** `ElicitationResult` (the server-side resolution of a `PermissionRequest`/`Elicitation`, see `pkg/agent/hooks.go`) had no handler, so the "waiting for permission" running node stayed pinned until the turn ended. It now finalizes the matching running node.
- **[ux] First-run flash.** `HomeGate` in `App.tsx` rendered the full Home dashboard immediately and only redirected to `/welcome` once `/api/onboarding/state` resolved. It now renders a blank/skeleton frame while the probe is in flight, then resolves to Home or `/welcome`.

## Files touched
- `web/src/hooks/useAgentActivity.ts`
- `web/src/views/Home.tsx`
- `web/src/components/live/liveTypes.ts`
- `web/src/components/live/liveHelpers.ts`
- `web/src/App.tsx` (HomeGate only)

## Tests
- `web/src/hooks/__tests__/useAgentActivity.test.ts` (new): pause buffers events + counts, resume flushes hook events and `state_changed` events in order; a previously-dropped event kind (`Notification`) and a fully-unhandled one (`TeammateIdle`) now produce nodes; `ElicitationResult` finalizes the pending `Elicitation` running node.
- `web/src/App.test.tsx` (new): `HomeGate` shows a skeleton while the onboarding probe is pending (no Home chrome), redirects to `/welcome` on first run without ever rendering Home, and falls back to Home on probe failure.

## Test plan
- [x] `make build-local-web`
- [x] `bunx vitest run` (full web suite — 39 files / 330 tests pass)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint` (eslint) clean

Not merged — for review.