### PR TITLE
fix(apps): surface all connected apps + real sender identity

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -6,7 +6,7 @@ import { useMediaQuery } from "../hooks/useMediaQuery";
 import { CommandPalette } from "./CommandPalette";
 import { api, instancesToStatuses } from "../api/client";
 import type { NotificationSource, GatewayHealth, GatewayStatus, NotifySubscription } from "../api/client";
-import { sourcePlatform } from "./apps/messageUtils";
+import { registerAppBases, sourcePlatform } from "./apps/messageUtils";
 import { ConnectWizard, AppChooser } from "./apps/ConnectApp";
 import { DefaultAppIcon, PLATFORM_ICON_MAP } from "./apps/PlatformIcons";
 import {
@@ -382,6 +382,10 @@ function AppsNavTree() {
       setGateways(gws);
       setLabels(Object.fromEntries((apps?.catalog ?? []).map((d) => [d.id, d.label])));
       setSubs(subList ?? []);
+      // Keep gateway detection (sourcePlatform/isGatewaySource) in sync
+      // with whatever apps the server actually has registered, so it
+      // can never silently drift out of date from a hardcoded list.
+      registerAppBases((apps?.catalog ?? []).map((d) => d.id));
 
       // Fetch health for each enabled instance, keyed by the instance's
       // own name so compound keys ("telegram:trade_research") stay stable.

--- a/web/src/components/apps/AgentAppsCard.tsx
+++ b/web/src/components/apps/AgentAppsCard.tsx
@@ -12,7 +12,7 @@ import { Link } from "react-router-dom";
 import { api } from "../../api/client";
 import type { NotificationSource, NotifySubscription } from "../../api/client";
 import { sourcePlatform } from "./messageUtils";
-import { DefaultAppIcon, PLATFORM_ICON_MAP } from "./PlatformIcons";
+import { AppIcon } from "./PlatformIcons";
 
 function channelLeaf(ch: string): string {
   const i = ch.lastIndexOf(":");
@@ -20,8 +20,7 @@ function channelLeaf(ch: string): string {
 }
 
 function ChannelGlyph({ channel }: { channel: string }) {
-  const Icon = PLATFORM_ICON_MAP[sourcePlatform(channel)] ?? DefaultAppIcon;
-  return <Icon size={13} />;
+  return <AppIcon base={sourcePlatform(channel)} size={13} />;
 }
 
 export function AgentAppsCard({ agentName }: { agentName: string }) {

--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -34,7 +34,7 @@ import type {
 import { usePolling } from "../../hooks/usePolling";
 import { useHeaderSlot } from "../../context/HeaderSlotContext";
 import { EmptyState } from "../EmptyState";
-import { DefaultAppIcon, PLATFORM_ICON_MAP } from "./PlatformIcons";
+import { AppIcon } from "./PlatformIcons";
 import { ConnectWizard, AppChooser } from "./ConnectApp";
 import { CustomKeysSection } from "./CustomKeys";
 import { sourcePlatform } from "./messageUtils";
@@ -256,11 +256,8 @@ function oneLine(content: string): string {
 }
 
 /* ── Small render helpers ────────────────────────────────────── */
-
-function AppIcon({ base, size }: { base: string; size: number }) {
-  const Icon = PLATFORM_ICON_MAP[base] ?? DefaultAppIcon;
-  return <Icon size={size} />;
-}
+/* AppIcon (brand SVG → emoji → generic dot) now lives in PlatformIcons.tsx
+   so every app-icon consumer shares one fallback chain. */
 
 function SubscriberAvatars({ subscribers, count }: { subscribers: string[]; count: number }) {
   if (count <= 0) return null;

--- a/web/src/components/apps/ConnectApp.tsx
+++ b/web/src/components/apps/ConnectApp.tsx
@@ -22,69 +22,14 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { api } from "../../api/client";
 import type { Agent, AppAuthSession, AppDescriptor, AppInstance } from "../../api/client";
-import { DefaultAppIcon, PLATFORM_ICON_MAP } from "./PlatformIcons";
+import { AppIcon, presentationFor } from "./PlatformIcons";
 import { StatusDot } from "./appStatus";
 
-/* ── Presentation-only metadata (backend owns the rest) ──────── */
-
-export interface AppPresentation {
-  /** Emoji fallback when no brand SVG exists in PLATFORM_ICON_MAP. */
-  icon: string;
-  /** Brand accent color. */
-  color: string;
-  category: string;
-  /** One-line description for the catalog card. */
-  description: string;
-}
-
-export const APP_PRESENTATION: Record<string, AppPresentation> = {
-  // Chat
-  slack: { icon: "\u{1F4AC}", color: "#E01E5A", category: "Chat", description: "Team messaging via Socket Mode" },
-  telegram: { icon: "✈️", color: "#26A5E4", category: "Chat", description: "Bot messages via long polling" },
-  discord: { icon: "\u{1F3AE}", color: "#5865F2", category: "Chat", description: "Bot messages from Discord servers" },
-  whatsapp: { icon: "\u{1F4F1}", color: "#25D366", category: "Chat", description: "Personal WhatsApp via QR code pairing" },
-  signal: { icon: "\u{1F510}", color: "#3A76F0", category: "Chat", description: "Private encrypted messaging" },
-  matrix: { icon: "\u{1F30D}", color: "#0DBD8B", category: "Chat", description: "Decentralized chat via client-server API" },
-  line: { icon: "\u{1F4AC}", color: "#06C755", category: "Chat", description: "Line Messaging API" },
-  mattermost: { icon: "\u{1F5E8}️", color: "#0058CC", category: "Chat", description: "Self-hosted team messaging via WebSocket" },
-  irc: { icon: "\u{1F4DF}", color: "#6B7280", category: "Chat", description: "Connect to any IRC server with TLS" },
-  imessage: { icon: "\u{1F4AC}", color: "#34C759", category: "Chat", description: "iMessage via BlueBubbles API (macOS only)" },
-  // Code & DevOps
-  github: { icon: "\u{1F419}", color: "#8B949E", category: "Code & DevOps", description: "PR, issue, and push webhooks" },
-  gitlab: { icon: "\u{1F98A}", color: "#FC6D26", category: "Code & DevOps", description: "Merge request and pipeline webhooks" },
-  bitbucket: { icon: "\u{1FAA3}", color: "#0052CC", category: "Code & DevOps", description: "Push and PR webhooks" },
-  vercel: { icon: "▲", color: "#9CA3AF", category: "Code & DevOps", description: "Deployment and build webhooks" },
-  netlify: { icon: "◆", color: "#00C7B7", category: "Code & DevOps", description: "Deploy and build notifications" },
-  jira: { icon: "\u{1F4CB}", color: "#0052CC", category: "Code & DevOps", description: "Issue and workflow webhooks" },
-  linear: { icon: "\u{1F4D0}", color: "#5E6AD2", category: "Code & DevOps", description: "Issue tracking webhooks" },
-  // Monitoring
-  sentry: { icon: "\u{1F41B}", color: "#7C6BA8", category: "Monitoring", description: "Error and issue alerts" },
-  pagerduty: { icon: "\u{1F6A8}", color: "#06AC38", category: "Monitoring", description: "Incident and alert webhooks" },
-  datadog: { icon: "\u{1F415}", color: "#632CA6", category: "Monitoring", description: "Monitor and event webhooks" },
-  grafana: { icon: "\u{1F4CA}", color: "#F46800", category: "Monitoring", description: "Alert notifications" },
-  // Payments
-  stripe: { icon: "\u{1F4B3}", color: "#635BFF", category: "Payments", description: "Payment and subscription events" },
-  // Content
-  gmail: { icon: "✉️", color: "#EA4335", category: "Content", description: "Email via one-click Google sign-in (or token)" },
-  rss: { icon: "\u{1F4E1}", color: "#F78422", category: "Content", description: "Subscribe to any RSS or Atom feed" },
-  notion: { icon: "\u{1F4DD}", color: "#9CA3AF", category: "Content", description: "Database and page change polling" },
-  reddit: { icon: "\u{1F4E2}", color: "#FF4500", category: "Content", description: "Subreddit and post monitoring" },
-  twitch: { icon: "\u{1F3AE}", color: "#9146FF", category: "Content", description: "Stream and chat events" },
-  // Custom
-  webhook: { icon: "\u{1F517}", color: "#8c7e72", category: "Custom", description: "Receive any JSON webhook payload" },
-  mqtt: { icon: "\u{1F4E1}", color: "#660066", category: "Custom", description: "Subscribe to any MQTT broker topics" },
-};
-
-const DEFAULT_PRESENTATION: AppPresentation = {
-  icon: "\u{1F50C}",
-  color: "var(--mycel-muted)",
-  category: "Other",
-  description: "",
-};
-
-export function presentationFor(appId: string): AppPresentation {
-  return APP_PRESENTATION[appId] ?? DEFAULT_PRESENTATION;
-}
+/* ── Presentation-only metadata (backend owns the rest) ──────────────
+   App icon/color/category/description metadata lives in PlatformIcons.tsx
+   (APP_PRESENTATION / presentationFor) alongside the brand SVG map, so
+   every app-icon consumer shares one source of truth instead of each
+   view re-deriving its own fallback chain. */
 
 const CATEGORY_ORDER = ["Chat", "Code & DevOps", "Monitoring", "Payments", "Content", "Custom", "Other"];
 
@@ -108,19 +53,11 @@ function authHint(d: AppDescriptor): { label: string; tone: "accent" | "warning"
 }
 
 function AppGlyph({ appId, size }: { appId: string; size: number }) {
-  const Icon = PLATFORM_ICON_MAP[appId];
-  if (Icon) {
-    return (
-      <span className="flex items-center justify-center">
-        <Icon size={size} />
-      </span>
-    );
-  }
-  const pres = APP_PRESENTATION[appId];
-  if (pres) {
-    return <span className="leading-none select-none" style={{ fontSize: size }}>{pres.icon}</span>;
-  }
-  return <DefaultAppIcon size={size} />;
+  return (
+    <span className="flex items-center justify-center">
+      <AppIcon base={appId} size={size} />
+    </span>
+  );
 }
 
 /* ── App chooser — full-screen catalog modal ─────────────────── */
@@ -1119,7 +1056,7 @@ export function ConnectWizard({
 
             {/* Error */}
             {error && (
-              <div className="mx-4 mb-3 px-3 py-2 bg-mycel-error-subtle border border-mycel-error rounded-md text-xs text-mycel-error">
+              <div role="alert" className="mx-4 mb-3 px-3 py-2 bg-mycel-error-subtle border border-mycel-error rounded-md text-xs text-mycel-error">
                 {error}
               </div>
             )}

--- a/web/src/components/apps/CustomKeys.tsx
+++ b/web/src/components/apps/CustomKeys.tsx
@@ -150,7 +150,7 @@ function AddSecretForm({
       </div>
 
       {error && (
-        <p className="text-xs text-mycel-error">{error}</p>
+        <p role="alert" className="text-xs text-mycel-error">{error}</p>
       )}
 
       <button
@@ -354,7 +354,7 @@ function SecretCard({ secret, onChanged }: { secret: Secret; onChanged: () => vo
             >
               Cancel
             </button>
-            {saveError && <span className="text-xs text-mycel-error">{saveError}</span>}
+            {saveError && <span role="alert" className="text-xs text-mycel-error">{saveError}</span>}
           </div>
         </div>
       )}

--- a/web/src/components/apps/GatewayFeed.tsx
+++ b/web/src/components/apps/GatewayFeed.tsx
@@ -23,6 +23,7 @@ import {
   parseWebhookCard,
 } from "./messageUtils";
 import { AgentCharacter, LiveAgentCharacter } from "../agent-ui";
+import { IdentityAvatar } from "./IdentityAvatar";
 import type { GitHubCard, RSSCard, WebhookCard } from "./messageUtils";
 
 /* ── Helpers ──────────────────────────────────────────────────── */
@@ -1090,7 +1091,11 @@ export function GatewayFeed({
                 }}
               >
                 <span className="flex items-center justify-center shrink-0">
-                  <AgentCharacter name={sender} size={18} />
+                  {platform ? (
+                    <IdentityAvatar name={cleanSender(sender)} size={18} />
+                  ) : (
+                    <AgentCharacter name={sender} size={18} />
+                  )}
                 </span>
                 <span className="truncate">{cleanSender(sender)}</span>
               </button>
@@ -1354,32 +1359,55 @@ export function GatewayFeed({
                   <div style={{ paddingTop: 10 }}>
                     {/* Sender line with avatar */}
                     <div className="flex" style={{ padding: "0 18px", gap: 10 }}>
-                      {/* Sender character */}
+                      {/* Sender character — a real chat participant on gateway
+                          channels (identity avatar, never the mycel mushroom),
+                          or an agent on internal channels. */}
                       <span
                         className="flex items-center justify-center shrink-0"
                         style={{ width: 30, height: 30, minWidth: 30, marginTop: 2 }}
                       >
-                        <LiveAgentCharacter name={group.sender} size={30} />
+                        {platform ? (
+                          <IdentityAvatar
+                            name={cleanSender(group.sender)}
+                            src={group.messages[0]?.avatar_url || undefined}
+                            size={30}
+                          />
+                        ) : (
+                          <LiveAgentCharacter name={group.sender} size={30} />
+                        )}
                       </span>
                       <div className="flex-1 min-w-0">
                         {/* Name row */}
                         <div className="flex items-baseline flex-wrap" style={{ gap: 7, marginBottom: 1 }}>
-                          <button
-                            type="button"
-                            onClick={() => onPeekAgent(group.sender)}
-                            className="hover:underline cursor-pointer decoration-1 underline-offset-2"
-                            style={{
-                              fontSize: 13.5,
-                              fontWeight: 600,
-                              color: "var(--mycel-text)",
-                              fontFamily: "'JetBrains Mono', monospace",
-                              background: "none",
-                              border: "none",
-                              padding: 0,
-                            }}
-                          >
-                            {cleanSender(group.sender)}
-                          </button>
+                          {platform ? (
+                            <span
+                              style={{
+                                fontSize: 13.5,
+                                fontWeight: 600,
+                                color: "var(--mycel-text)",
+                                fontFamily: "'JetBrains Mono', monospace",
+                              }}
+                            >
+                              {cleanSender(group.sender)}
+                            </span>
+                          ) : (
+                            <button
+                              type="button"
+                              onClick={() => onPeekAgent(group.sender)}
+                              className="hover:underline cursor-pointer decoration-1 underline-offset-2"
+                              style={{
+                                fontSize: 13.5,
+                                fontWeight: 600,
+                                color: "var(--mycel-text)",
+                                fontFamily: "'JetBrains Mono', monospace",
+                                background: "none",
+                                border: "none",
+                                padding: 0,
+                              }}
+                            >
+                              {cleanSender(group.sender)}
+                            </button>
+                          )}
                           <span
                             style={{
                               fontSize: 11,

--- a/web/src/components/apps/IdentityAvatar.tsx
+++ b/web/src/components/apps/IdentityAvatar.tsx
@@ -7,10 +7,9 @@
  * AgentCharacter mushroom: notifications and channels surface real
  * chat participants, which have nothing to do with mycel agents.
  *
- * No avatar URLs are exposed by the notifications/channels API today,
- * so the initials fallback is what renders in practice — when the
- * backend starts resolving real profile pictures, pass `src` and they
- * appear with zero further changes here.
+ * Platforms that expose a profile photo (e.g. Slack) surface it via
+ * `avatar_url` on the message/source; pass it as `src` and it renders
+ * directly. Platforms that don't fall back to the initials chip.
  */
 
 import { useState } from "react";

--- a/web/src/components/apps/PlatformIcons.tsx
+++ b/web/src/components/apps/PlatformIcons.tsx
@@ -129,3 +129,87 @@ export const PLATFORM_ICON_MAP: Record<string, (props: IconProps) => JSX.Element
   twitter: XIcon,
   x: XIcon,
 };
+
+/* ── App presentation metadata (icon/color/category for apps with no
+   brand SVG above) ──────────────────────────────────────────────── */
+
+export interface AppPresentation {
+  /** Emoji fallback when no brand SVG exists in PLATFORM_ICON_MAP. */
+  icon: string;
+  /** Brand accent color. */
+  color: string;
+  category: string;
+  /** One-line description for the catalog card. */
+  description: string;
+}
+
+export const APP_PRESENTATION: Record<string, AppPresentation> = {
+  // Chat
+  slack: { icon: "\u{1F4AC}", color: "#E01E5A", category: "Chat", description: "Team messaging via Socket Mode" },
+  telegram: { icon: "✈️", color: "#26A5E4", category: "Chat", description: "Bot messages via long polling" },
+  discord: { icon: "\u{1F3AE}", color: "#5865F2", category: "Chat", description: "Bot messages from Discord servers" },
+  whatsapp: { icon: "\u{1F4F1}", color: "#25D366", category: "Chat", description: "Personal WhatsApp via QR code pairing" },
+  signal: { icon: "\u{1F510}", color: "#3A76F0", category: "Chat", description: "Private encrypted messaging" },
+  matrix: { icon: "\u{1F30D}", color: "#0DBD8B", category: "Chat", description: "Decentralized chat via client-server API" },
+  line: { icon: "\u{1F4AC}", color: "#06C755", category: "Chat", description: "Line Messaging API" },
+  mattermost: { icon: "\u{1F5E8}️", color: "#0058CC", category: "Chat", description: "Self-hosted team messaging via WebSocket" },
+  irc: { icon: "\u{1F4DF}", color: "#6B7280", category: "Chat", description: "Connect to any IRC server with TLS" },
+  imessage: { icon: "\u{1F4AC}", color: "#34C759", category: "Chat", description: "iMessage via BlueBubbles API (macOS only)" },
+  // Code & DevOps
+  github: { icon: "\u{1F419}", color: "#8B949E", category: "Code & DevOps", description: "PR, issue, and push webhooks" },
+  gitlab: { icon: "\u{1F98A}", color: "#FC6D26", category: "Code & DevOps", description: "Merge request and pipeline webhooks" },
+  bitbucket: { icon: "\u{1FAA3}", color: "#0052CC", category: "Code & DevOps", description: "Push and PR webhooks" },
+  vercel: { icon: "▲", color: "#9CA3AF", category: "Code & DevOps", description: "Deployment and build webhooks" },
+  netlify: { icon: "◆", color: "#00C7B7", category: "Code & DevOps", description: "Deploy and build notifications" },
+  jira: { icon: "\u{1F4CB}", color: "#0052CC", category: "Code & DevOps", description: "Issue and workflow webhooks" },
+  linear: { icon: "\u{1F4D0}", color: "#5E6AD2", category: "Code & DevOps", description: "Issue tracking webhooks" },
+  // Monitoring
+  sentry: { icon: "\u{1F41B}", color: "#7C6BA8", category: "Monitoring", description: "Error and issue alerts" },
+  pagerduty: { icon: "\u{1F6A8}", color: "#06AC38", category: "Monitoring", description: "Incident and alert webhooks" },
+  datadog: { icon: "\u{1F415}", color: "#632CA6", category: "Monitoring", description: "Monitor and event webhooks" },
+  grafana: { icon: "\u{1F4CA}", color: "#F46800", category: "Monitoring", description: "Alert notifications" },
+  // Payments
+  stripe: { icon: "\u{1F4B3}", color: "#635BFF", category: "Payments", description: "Payment and subscription events" },
+  // Content
+  gmail: { icon: "✉️", color: "#EA4335", category: "Content", description: "Email via one-click Google sign-in (or token)" },
+  rss: { icon: "\u{1F4E1}", color: "#F78422", category: "Content", description: "Subscribe to any RSS or Atom feed" },
+  notion: { icon: "\u{1F4DD}", color: "#9CA3AF", category: "Content", description: "Database and page change polling" },
+  reddit: { icon: "\u{1F4E2}", color: "#FF4500", category: "Content", description: "Subreddit and post monitoring" },
+  twitch: { icon: "\u{1F3AE}", color: "#9146FF", category: "Content", description: "Stream and chat events" },
+  // Custom
+  webhook: { icon: "\u{1F517}", color: "#8c7e72", category: "Custom", description: "Receive any JSON webhook payload" },
+  mqtt: { icon: "\u{1F4E1}", color: "#660066", category: "Custom", description: "Subscribe to any MQTT broker topics" },
+};
+
+const DEFAULT_PRESENTATION: AppPresentation = {
+  icon: "\u{1F50C}",
+  color: "var(--mycel-muted)",
+  category: "Other",
+  description: "",
+};
+
+export function presentationFor(appId: string): AppPresentation {
+  return APP_PRESENTATION[appId] ?? DEFAULT_PRESENTATION;
+}
+
+/**
+ * AppIcon — the one place that resolves "how do we draw this app's
+ * glyph": a brand SVG when PLATFORM_ICON_MAP has one, else the emoji
+ * from APP_PRESENTATION, else the neutral DefaultAppIcon dot. Used
+ * everywhere an app/platform icon is shown (catalog, activity feeds,
+ * channel lists) so every registered app gets a branded glyph instead
+ * of falling straight through to the generic dot.
+ */
+export function AppIcon({ base, size = 14, className }: { base: string } & IconProps) {
+  const Icon = PLATFORM_ICON_MAP[base];
+  if (Icon) return <Icon size={size} className={className} />;
+  const pres = APP_PRESENTATION[base];
+  if (pres) {
+    return (
+      <span className={`leading-none select-none ${className ?? ""}`} style={{ fontSize: size }}>
+        {pres.icon}
+      </span>
+    );
+  }
+  return <DefaultAppIcon size={size} className={className} />;
+}

--- a/web/src/components/apps/__tests__/messageUtils.test.ts
+++ b/web/src/components/apps/__tests__/messageUtils.test.ts
@@ -1,0 +1,75 @@
+/**
+ * messageUtils — gateway detection covers every built-in app (one
+ * gateway package per app, see pkg/app/builtin/builtin.go on the Go
+ * side) so a real human sender's channel/message is never mistaken for
+ * an internal agent channel and hidden from Apps views.
+ */
+
+import { describe, expect, it, afterEach } from "vitest";
+import {
+  GATEWAY_BASES,
+  gatewayPlatform,
+  isGatewaySource,
+  registerAppBases,
+  sourcePlatform,
+} from "../messageUtils";
+
+// Kept in lockstep with the imports in pkg/app/builtin/builtin.go — every
+// built-in app registers exactly one gateway package with this base name.
+const REAL_APP_BASES = [
+  "bitbucket", "datadog", "discord", "github", "gitlab", "gmail", "grafana",
+  "imessage", "irc", "jira", "line", "linear", "matrix", "mattermost", "mqtt",
+  "netlify", "notion", "pagerduty", "reddit", "rss", "sentry", "signal",
+  "slack", "stripe", "telegram", "twitch", "vercel", "webhook", "whatsapp",
+];
+
+describe("GATEWAY_BASES (bootstrap default)", () => {
+  it("covers every built-in app registered in pkg/app/builtin/builtin.go", () => {
+    for (const base of REAL_APP_BASES) {
+      expect(GATEWAY_BASES).toContain(base);
+    }
+  });
+
+  it("does not contain dead/unregistered prefixes", () => {
+    for (const dead of ["twitter", "nostr", "homeassistant"]) {
+      expect(GATEWAY_BASES).not.toContain(dead);
+    }
+  });
+});
+
+describe("sourcePlatform / isGatewaySource / gatewayPlatform (default set)", () => {
+  it.each(REAL_APP_BASES)("recognizes %s: as a gateway source", (base) => {
+    const name = `${base}:general`;
+    expect(isGatewaySource(name)).toBe(true);
+    expect(gatewayPlatform(name)).toBe(base);
+    expect(sourcePlatform(name)).toBe(base);
+  });
+
+  it("buckets internal/agent channel names as internal", () => {
+    expect(sourcePlatform("root")).toBe("internal");
+    expect(sourcePlatform("engineering")).toBe("internal");
+    expect(isGatewaySource("engineering")).toBe(false);
+    expect(gatewayPlatform("engineering")).toBeNull();
+  });
+});
+
+describe("registerAppBases (live /api/apps catalog)", () => {
+  afterEach(() => {
+    // Restore the default set so other tests aren't affected by ordering.
+    registerAppBases(REAL_APP_BASES);
+  });
+
+  it("replaces the known set with whatever the catalog reports", () => {
+    registerAppBases(["slack", "custom_app"]);
+    expect(sourcePlatform("custom_app:channel")).toBe("custom_app");
+    expect(sourcePlatform("slack:general")).toBe("slack");
+    // No longer recognized once the catalog no longer reports it.
+    expect(sourcePlatform("github:repo")).toBe("internal");
+  });
+
+  it("ignores an empty catalog rather than wiping known gateways", () => {
+    registerAppBases(["slack"]);
+    registerAppBases([]);
+    expect(sourcePlatform("slack:general")).toBe("slack");
+  });
+});

--- a/web/src/components/apps/messageUtils.ts
+++ b/web/src/components/apps/messageUtils.ts
@@ -1,31 +1,57 @@
 import type { ChannelMessage } from "../../api/client";
 import { formatRelative } from "../../utils/time";
 
-/** Gateway notification sources are bridges to external platforms — read-only activity feeds. */
-export const GATEWAY_PREFIXES = [
-  "slack:", "telegram:", "discord:", "whatsapp:", "github:", "webhook:",
-  "rss:", "mqtt:", "irc:", "matrix:", "mattermost:", "reddit:", "twitter:",
-  "notion:", "signal:", "nostr:", "homeassistant:", "imessage:",
+/**
+ * Base names of every built-in app gateway (one gateway package per app —
+ * see pkg/app/builtin/builtin.go). Gateway notification sources are
+ * bridges to external platforms — read-only activity feeds — prefixed
+ * "<base>:" on the channel/source name.
+ *
+ * This array is only the bootstrap default, used before the live catalog
+ * has loaded. `registerAppBases()` below replaces it with the actual
+ * GET /api/apps catalog (called once by Layout's AppsNavTree on load), so
+ * this can't silently drift out of sync with the real registry the way a
+ * hardcoded, hand-maintained list did before.
+ */
+export const GATEWAY_BASES = [
+  "bitbucket", "datadog", "discord", "github", "gitlab", "gmail", "grafana",
+  "imessage", "irc", "jira", "line", "linear", "matrix", "mattermost", "mqtt",
+  "netlify", "notion", "pagerduty", "reddit", "rss", "sentry", "signal",
+  "slack", "stripe", "telegram", "twitch", "vercel", "webhook", "whatsapp",
 ];
 
+let knownAppBases = new Set(GATEWAY_BASES);
+
+/**
+ * Replace the known-gateway base set with the app IDs from the live
+ * /api/apps catalog. Called once the catalog has loaded so gateway
+ * detection always reflects whatever apps are actually registered
+ * server-side, instead of a hardcoded list that can go stale.
+ */
+export function registerAppBases(ids: string[]): void {
+  if (ids.length === 0) return;
+  knownAppBases = new Set(ids);
+}
+
+function baseOf(name: string): string | null {
+  const i = name.indexOf(":");
+  if (i === -1) return null;
+  const base = name.slice(0, i);
+  return knownAppBases.has(base) ? base : null;
+}
+
 export function isGatewaySource(name: string): boolean {
-  return GATEWAY_PREFIXES.some((p) => name.startsWith(p));
+  return baseOf(name) !== null;
 }
 
 /** Extract platform name from gateway source for display. */
 export function gatewayPlatform(name: string): string | null {
-  for (const p of GATEWAY_PREFIXES) {
-    if (name.startsWith(p)) return p.slice(0, -1);
-  }
-  return null;
+  return baseOf(name);
 }
 
 /** Derive platform bucket key from source name. */
 export function sourcePlatform(name: string): string {
-  for (const p of GATEWAY_PREFIXES) {
-    if (name.startsWith(p)) return p.slice(0, -1);
-  }
-  return "internal";
+  return baseOf(name) ?? "internal";
 }
 
 export interface MessageGroup {

--- a/web/src/views/AppsActivity.tsx
+++ b/web/src/views/AppsActivity.tsx
@@ -26,7 +26,7 @@ import { usePolling } from "../hooks/usePolling";
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 import { EmptyState } from "../components/EmptyState";
 import { MessageContent } from "../components/MessageContent";
-import { DefaultAppIcon, PLATFORM_ICON_MAP } from "../components/apps/PlatformIcons";
+import { AppIcon } from "../components/apps/PlatformIcons";
 import { channelLeaf } from "../components/apps/AppsHome";
 import { sourcePlatform } from "../components/apps/messageUtils";
 import { IdentityAvatar } from "../components/apps/IdentityAvatar";
@@ -51,10 +51,7 @@ function cleanSender(sender: string): string {
   return match?.[1] ?? sender;
 }
 
-function AppIcon({ base, size }: { base: string; size: number }) {
-  const Icon = PLATFORM_ICON_MAP[base] ?? DefaultAppIcon;
-  return <Icon size={size} />;
-}
+/* AppIcon (brand SVG → emoji → generic dot) lives in PlatformIcons.tsx. */
 
 /* ── Component ───────────────────────────────────────────────── */
 
@@ -245,8 +242,9 @@ export function AppsActivity() {
                     to={`/apps/${m.channel}`}
                     className="flex gap-3 px-4 py-3 hover:bg-mycel-surface-hover transition-colors"
                   >
-                    {/* Real chat participant — initials avatar, never an agent mushroom */}
-                    <IdentityAvatar name={sender} size={30} className="mt-0.5" />
+                    {/* Real chat participant — resolved platform photo when
+                        available, else an initials chip; never an agent mushroom */}
+                    <IdentityAvatar name={sender} src={m.avatar_url || undefined} size={30} className="mt-0.5" />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2 min-w-0">
                         <span className="font-medium text-sm text-mycel-text truncate">{sender}</span>

--- a/web/src/views/home/ActivityFeed.tsx
+++ b/web/src/views/home/ActivityFeed.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { api } from "../../api/client";
 import type { ChannelMessage, ChannelStats, NotificationSource } from "../../api/client";
 import { usePolling } from "../../hooks/usePolling";
-import { DefaultAppIcon, PLATFORM_ICON_MAP } from "../../components/apps/PlatformIcons";
+import { AppIcon } from "../../components/apps/PlatformIcons";
 import { channelLeaf } from "../../components/apps/AppsHome";
 import { sourcePlatform } from "../../components/apps/messageUtils";
 import { parseActivityTs } from "../../components/apps/appStatus";
@@ -38,10 +38,7 @@ function snippet(content: string): string {
   return s.length > 140 ? s.slice(0, 137) + "…" : s;
 }
 
-function AppIcon({ base, size }: { base: string; size: number }) {
-  const Icon = PLATFORM_ICON_MAP[base] ?? DefaultAppIcon;
-  return <Icon size={size} />;
-}
+/* AppIcon (brand SVG → emoji → generic dot) lives in PlatformIcons.tsx. */
 
 export function ActivityFeed() {
   const fetcher = useCallback(async (): Promise<FeedMessage[]> => {


### PR DESCRIPTION
Part of #2674

## Root cause

1. **14 of 28 apps' messages were invisible.** `web/src/components/apps/messageUtils.ts` hardcoded a `GATEWAY_PREFIXES` array that included 3 dead prefixes (`twitter:`, `nostr:`, `homeassistant:` — no such gateway packages exist) and was missing 14 real ones registered in `pkg/app/builtin/builtin.go`: bitbucket, datadog, gitlab, gmail, grafana, jira, line, linear, netlify, pagerduty, sentry, stripe, twitch, vercel. Every `sourcePlatform(x) !== "internal"` filter across AppsHome, AppsActivity, AgentAppsCard, OverviewStrip, and ActivityFeed silently dropped those apps' channels and messages.
2. **Real human senders rendered as the mycel mushroom agent, with a click that 404s.** `GatewayFeed.tsx` used `AgentCharacter`/`LiveAgentCharacter` for message senders and wired the sender name to `onPeekAgent` (an agent-terminal peek) regardless of whether the channel was a gateway (real chat participant) or an internal agent channel.
3. **Real profile photos were dropped on the Activity view** — `AppsActivity.tsx` rendered `IdentityAvatar` without `src`, so it always fell back to initials even when `avatar_url` was available (as `AppsHome.tsx` already correctly does).
4. **16 apps showed a generic dot instead of a branded glyph** — `AppIcon` was duplicated across AppsHome/AppsActivity/ActivityFeed/AgentAppsCard, each falling straight from the brand-SVG map to `DefaultAppIcon` with no emoji fallback tier (unlike `AppGlyph` in `ConnectApp.tsx`, which already had one).
5. Missing `role="alert"` on error banners in `ConnectApp.tsx` and `CustomKeys.tsx`.
6. Stale doc comment in `IdentityAvatar.tsx` claiming no avatar URLs are ever exposed — `avatar_url` exists on `ChannelMessage` today.

## Fix summary

- **messageUtils.ts**: `GATEWAY_PREFIXES` → `GATEWAY_BASES` (correct 28-app default) plus a new `registerAppBases(ids)` that replaces the known-base set at runtime. `Layout.tsx`'s `AppsNavTree` (which already polls `GET /api/apps` every 12s) now calls `registerAppBases()` with the live catalog's app IDs on every fetch, so gateway detection is derived from the real catalog and can't drift again.
- **GatewayFeed.tsx**: sender avatar/name now branches on `gatewayPlatform(channelName)` — gateway channels get `IdentityAvatar` (with `avatar_url` passed through) and a non-interactive name (no more `onPeekAgent` 404); internal agent channels keep `LiveAgentCharacter`/`AgentCharacter` + peek behavior.
- **AppsActivity.tsx**: pass `src={m.avatar_url || undefined}` to `IdentityAvatar`, matching `AppsHome.tsx`.
- **PlatformIcons.tsx**: added a shared `AppIcon` (brand SVG → `APP_PRESENTATION` emoji → `DefaultAppIcon`) and moved `APP_PRESENTATION`/`presentationFor` here from `ConnectApp.tsx`. Replaced the 4 duplicated local `AppIcon`/`ChannelGlyph` implementations (AppsHome, AppsActivity, ActivityFeed, AgentAppsCard) with this one, and `ConnectApp.tsx`'s `AppGlyph` now delegates to it too.
- **a11y**: `role="alert"` added to the ConnectApp connect-form error banner and both CustomKeys error spots.
- **IdentityAvatar.tsx**: doc comment corrected.

## Test plan
- [x] `make build-local-web` — succeeds (`tsc -b && vite build`)
- [x] `make test-web` — 356/356 passing across 38 files
- [x] New `web/src/components/apps/__tests__/messageUtils.test.ts` asserts all 28 real gateway bases (kept in lockstep with `pkg/app/builtin/builtin.go`) are recognized by `sourcePlatform`/`isGatewaySource`/`gatewayPlatform`, that the 3 dead prefixes are gone, and exercises `registerAppBases()` (catalog override + empty-catalog no-op)
- [x] `eslint src` (web) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)