### PR TITLE
fix(agent): MCP add resolves real server definition (no empty stanzas)

### DIFF
--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rpuneet/mycel/pkg/events"
 	"github.com/rpuneet/mycel/pkg/home"
 	"github.com/rpuneet/mycel/pkg/log"
+	mcppkg "github.com/rpuneet/mycel/pkg/mcp"
 	"github.com/rpuneet/mycel/pkg/stats"
 	"github.com/rpuneet/mycel/pkg/template"
 	"github.com/rpuneet/mycel/pkg/token"
@@ -1343,6 +1344,36 @@ func (h *AgentHandler) addAgentMCP(w http.ResponseWriter, r *http.Request, a *ag
 		return
 	}
 
+	// The web UI's "Add MCP" control sends only a name — resolve the real
+	// command/url/env from the user-global MCP registry
+	// (~/.mycel/mcps.json) rather than writing an empty, non-functional
+	// stanza that can never connect. Callers that already supply a
+	// command or url (e.g. a future advanced form) are trusted as-is.
+	// Unknown names are rejected outright.
+	if req.URL == "" && req.Command == "" {
+		def, resolveErr := resolveGlobalMCPDef(req.Name)
+		if resolveErr != nil {
+			httpInternalError(w, "resolve mcp definition", resolveErr)
+			return
+		}
+		if def == nil {
+			httpError(w, fmt.Sprintf("unknown MCP server %q: no definition in the global MCP registry", req.Name), http.StatusUnprocessableEntity)
+			return
+		}
+		req.URL = def.URL
+		req.Command = def.Command
+		if req.Type == "" {
+			req.Type = string(def.Transport)
+		}
+		if req.Env == nil {
+			req.Env = def.Env
+		}
+		if req.URL == "" && req.Command == "" {
+			httpError(w, fmt.Sprintf("MCP server %q has no command or url configured in the global registry", req.Name), http.StatusUnprocessableEntity)
+			return
+		}
+	}
+
 	cfg, err := readMCPFile(wtDir)
 	if err != nil {
 		httpInternalError(w, "read mcp config", err)
@@ -1384,6 +1415,22 @@ func (h *AgentHandler) addAgentMCP(w http.ResponseWriter, r *http.Request, a *ag
 		Type:    req.Type,
 		Env:     req.Env,
 	})
+}
+
+// resolveGlobalMCPDef looks up name in the user-global MCP registry
+// (~/.mycel/mcps.json). It returns (nil, nil) when the registry has no
+// entry for name — callers must treat that as "unknown server" rather
+// than falling back to an empty definition.
+func resolveGlobalMCPDef(name string) (*mcppkg.ServerConfig, error) {
+	path, err := home.GlobalMCPConfig()
+	if err != nil {
+		return nil, fmt.Errorf("resolve global mcp registry path: %w", err)
+	}
+	cfg, err := mcppkg.NewGlobalStore(path).Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("read global mcp registry: %w", err)
+	}
+	return cfg, nil
 }
 
 // deleteAgentMCP handles DELETE /api/agents/{name}/mcps/{mcp}.

--- a/server/handlers/agents_mcp_add_test.go
+++ b/server/handlers/agents_mcp_add_test.go
@@ -1,0 +1,150 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/agent"
+	"github.com/rpuneet/mycel/pkg/home"
+	"github.com/rpuneet/mycel/pkg/mcp"
+	"github.com/rpuneet/mycel/server"
+)
+
+// setupAgentForMCPAdd registers a stopped agent with a real worktree dir
+// (so addAgentMCP has somewhere to write .mcp.json) and returns the test
+// server plus the worktree path.
+func setupAgentForMCPAdd(t *testing.T) (ts string, wtDir string, closeFn func()) {
+	t.Helper()
+	dir := setupHome(t)
+	stateDir := filepath.Join(dir, ".mycel")
+	if err := os.MkdirAll(filepath.Join(stateDir, "agents"), 0750); err != nil {
+		t.Fatalf("mkdir agents: %v", err)
+	}
+
+	wt := filepath.Join(dir, "wt", "zen-zebra")
+	if err := os.MkdirAll(wt, 0750); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+
+	mgr := agent.NewManager(stateDir)
+	svc := agent.NewAgentService(mgr, nil, nil)
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name:           "zen-zebra",
+		Role:           agent.Role("engineer"),
+		Workspace:      dir,
+		Tool:           "claude",
+		RuntimeBackend: "docker", // avoid the tmux "claude mcp add" side-effect goroutine
+		WorktreeDir:    wt,
+	}); err != nil {
+		t.Fatalf("register agent: %v", err)
+	}
+
+	server := buildTestServerWithServices(t, server.Services{Agents: svc})
+	return server.URL, wt, server.Close
+}
+
+// seedGlobalMCP writes a real, connectable definition into the user-global
+// MCP registry (~/.mycel/mcps.json) so addAgentMCP has something to resolve
+// req.Name against.
+func seedGlobalMCP(t *testing.T, cfg *mcp.ServerConfig) {
+	t.Helper()
+	path, err := home.GlobalMCPConfig()
+	if err != nil {
+		t.Fatalf("resolve global mcp config path: %v", err)
+	}
+	if err := mcp.NewGlobalStore(path).Add(cfg); err != nil {
+		t.Fatalf("seed global mcp registry: %v", err)
+	}
+}
+
+// TestAddAgentMCP_ResolvesRealDefinitionFromRegistry is a regression test
+// for the bug where "Add MCP" wrote an empty {} stanza into .mcp.json: the
+// web UI only sends a bare name, so the server must resolve the real
+// command/url/env from the global MCP registry before persisting.
+func TestAddAgentMCP_ResolvesRealDefinitionFromRegistry(t *testing.T) {
+	tsURL, wtDir, closeFn := setupAgentForMCPAdd(t)
+	defer closeFn()
+
+	seedGlobalMCP(t, &mcp.ServerConfig{
+		Name:      "github",
+		Transport: mcp.TransportStdio,
+		Command:   "npx -y @modelcontextprotocol/server-github",
+		Env:       map[string]string{"GITHUB_TOKEN": "${secret:github_token}"},
+		Enabled:   true,
+	})
+
+	body, err := json.Marshal(map[string]string{"name": "github"})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	resp := post(t, tsURL+"/api/agents/zen-zebra/mcps", "application/json", string(body))
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusCreated)
+	got := readJSON(t, resp)
+
+	if got["command"] != "npx -y @modelcontextprotocol/server-github" {
+		t.Errorf("command = %v, want the resolved registry command", got["command"])
+	}
+	env, _ := got["env"].(map[string]any)
+	if env["GITHUB_TOKEN"] != "${secret:github_token}" {
+		t.Errorf("env = %v, want GITHUB_TOKEN carried over from the registry", got["env"])
+	}
+
+	// The persisted .mcp.json must carry the same real entry — not an
+	// empty stanza.
+	raw, err := os.ReadFile(filepath.Join(wtDir, ".mcp.json")) //nolint:gosec // test fixture path
+	if err != nil {
+		t.Fatalf("read .mcp.json: %v", err)
+	}
+	var onDisk struct {
+		MCPServers map[string]struct {
+			Env     map[string]string `json:"env"`
+			Command string            `json:"command"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("parse .mcp.json: %v", err)
+	}
+	entry, ok := onDisk.MCPServers["github"]
+	if !ok {
+		t.Fatalf(".mcp.json missing github entry: %s", raw)
+	}
+	if entry.Command == "" {
+		t.Errorf(".mcp.json github entry has empty command — wrote a non-functional stanza: %s", raw)
+	}
+	if entry.Command != "npx -y @modelcontextprotocol/server-github" {
+		t.Errorf(".mcp.json command = %q, want resolved registry command", entry.Command)
+	}
+}
+
+// TestAddAgentMCP_RejectsUnknownName verifies that a name with no
+// definition in the global registry is rejected rather than silently
+// written as an empty, non-functional stanza.
+func TestAddAgentMCP_RejectsUnknownName(t *testing.T) {
+	tsURL, wtDir, closeFn := setupAgentForMCPAdd(t)
+	defer closeFn()
+
+	body, err := json.Marshal(map[string]string{"name": "totally-unknown-mcp"})
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	resp := post(t, tsURL+"/api/agents/zen-zebra/mcps", "application/json", string(body))
+	defer func() { _ = resp.Body.Close() }()
+	assertStatus(t, resp, http.StatusUnprocessableEntity)
+
+	// Nothing should have been written to .mcp.json for the rejected name.
+	raw, readErr := os.ReadFile(filepath.Join(wtDir, ".mcp.json")) //nolint:gosec // test fixture path
+	if readErr == nil {
+		var onDisk struct {
+			MCPServers map[string]json.RawMessage `json:"mcpServers"`
+		}
+		if err := json.Unmarshal(raw, &onDisk); err == nil {
+			if _, ok := onDisk.MCPServers["totally-unknown-mcp"]; ok {
+				t.Errorf(".mcp.json should not contain an entry for the rejected name: %s", raw)
+			}
+		}
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -886,7 +886,7 @@ export const api = {
     ),
   renameAgent: (name: string, newName: string) =>
     tap(
-      request<Agent>(`/agents/${encodeURIComponent(name)}/rename`, {
+      request<{ status: string; name: string }>(`/agents/${encodeURIComponent(name)}/rename`, {
         method: "POST",
         body: JSON.stringify({ new_name: newName }),
       }),

--- a/web/src/components/shared/MCPServerList.tsx
+++ b/web/src/components/shared/MCPServerList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { MCPServer } from "../../api/client";
 import { MONO } from "../../utils/typography";
 
 interface MCPServerListProps {
@@ -7,27 +8,22 @@ interface MCPServerListProps {
   onAdd?: (name: string) => Promise<void>;
   onRemove?: (name: string) => Promise<void>;
   className?: string;
+  /** Real MCP server definitions from the global registry (`GET /api/mcp`).
+   *  Drives the autocomplete — only names with an actual command/url can
+   *  ever connect, so the picker should never suggest anything else. */
+  registry?: MCPServer[];
+  /** Surfaces the most recent add failure (e.g. an unknown server name
+   *  the backend rejected rather than writing an empty stanza). */
+  addError?: string | null;
 }
 
-const KNOWN_MCPS = [
-  { name: "github", description: "GitHub API (create_pr, list_issues, authenticate)" },
-  { name: "slack", description: "Slack messaging" },
-  { name: "linear", description: "Linear issue tracker" },
-  { name: "notion", description: "Notion pages and databases" },
-  { name: "postgres", description: "PostgreSQL database queries" },
-  { name: "sqlite", description: "SQLite database queries" },
-  { name: "filesystem", description: "File system operations" },
-  { name: "fetch", description: "HTTP fetch/API calls" },
-  { name: "puppeteer", description: "Browser automation" },
-  { name: "playwright", description: "Browser testing" },
-  { name: "docker", description: "Docker container management" },
-  { name: "kubernetes", description: "Kubernetes cluster operations" },
-  { name: "aws", description: "AWS CLI operations" },
-  { name: "gcp", description: "Google Cloud operations" },
-  { name: "stripe", description: "Stripe payment API" },
-  { name: "sentry", description: "Sentry error tracking" },
-  { name: "datadog", description: "Datadog monitoring" },
-];
+/** One-line summary of how a registry entry connects, shown as the
+ *  suggestion subtitle in place of a hardcoded description. */
+function summarize(m: MCPServer): string {
+  if (m.command) return `stdio · ${m.command}`;
+  if (m.url) return `${m.transport || "sse"} · ${m.url}`;
+  return m.transport || "";
+}
 
 export function MCPServerList({
   servers,
@@ -35,23 +31,28 @@ export function MCPServerList({
   onAdd,
   onRemove,
   className,
+  registry = [],
+  addError,
 }: MCPServerListProps) {
   const [input, setInput] = useState("");
   const [adding, setAdding] = useState(false);
   const [removing, setRemoving] = useState<string | null>(null);
   const [showDropdown, setShowDropdown] = useState(false);
+  const [localError, setLocalError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   // Normalise server names for comparison (strip mcp__ prefix)
   const normalised = servers.map((s) => s.replace(/^mcp__/, ""));
 
-  const suggestions = KNOWN_MCPS.filter((m) => {
+  const suggestions = registry.filter((m) => {
     if (normalised.includes(m.name)) return false;
     if (!input.trim()) return true;
     const q = input.toLowerCase();
-    return m.name.includes(q) || m.description.toLowerCase().includes(q);
+    return m.name.toLowerCase().includes(q) || summarize(m).toLowerCase().includes(q);
   });
+
+  const error = addError ?? localError;
 
   // Close dropdown on outside click
   useEffect(() => {
@@ -74,12 +75,13 @@ export function MCPServerList({
     if (!trimmed || !onAdd) return;
     setAdding(true);
     setShowDropdown(false);
+    setLocalError(null);
     onAdd(trimmed)
       .then(() => {
         setInput("");
       })
-      .catch(() => {
-        /* best-effort */
+      .catch((err: unknown) => {
+        setLocalError(err instanceof Error ? err.message : "Failed to add MCP server");
       })
       .finally(() => {
         setAdding(false);
@@ -151,6 +153,7 @@ export function MCPServerList({
               onChange={(e) => {
                 setInput(e.target.value);
                 setShowDropdown(true);
+                if (localError) setLocalError(null);
               }}
               onFocus={() => setShowDropdown(true)}
               onKeyDown={(e) => {
@@ -159,7 +162,10 @@ export function MCPServerList({
               }}
               placeholder="Search or type a server name…"
               disabled={adding}
-              className="flex-1 max-w-[300px] rounded border border-mycel-border bg-mycel-bg px-2.5 py-1 text-[11px] text-mycel-text placeholder:text-mycel-muted outline-none focus:border-mycel-accent transition-colors disabled:opacity-40"
+              aria-invalid={error ? true : undefined}
+              className={`flex-1 max-w-[300px] rounded border bg-mycel-bg px-2.5 py-1 text-[11px] text-mycel-text placeholder:text-mycel-muted outline-none transition-colors disabled:opacity-40 ${
+                error ? "border-mycel-error focus:border-mycel-error" : "border-mycel-border focus:border-mycel-accent"
+              }`}
               style={{ fontFamily: MONO }}
             />
             <button
@@ -204,7 +210,7 @@ export function MCPServerList({
                       className="block text-[10px] text-mycel-muted truncate"
                       style={{ fontFamily: MONO }}
                     >
-                      {m.description}
+                      {summarize(m)}
                     </span>
                   </div>
                 </button>
@@ -212,9 +218,15 @@ export function MCPServerList({
             </div>
           )}
 
-          <p className="mt-1.5 text-[10px] text-mycel-muted" style={{ fontFamily: MONO }}>
-            Select from the list or press Enter to add a custom server name.
-          </p>
+          {error ? (
+            <p className="mt-1.5 text-[10px] text-mycel-error" style={{ fontFamily: MONO }} role="alert">
+              {error}
+            </p>
+          ) : (
+            <p className="mt-1.5 text-[10px] text-mycel-muted" style={{ fontFamily: MONO }}>
+              Select a server from the registry — only names with a real command or url can connect.
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, Link, useLocation, useNavigate } from "react-router-dom";
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 import { api } from "../api/client";
-import type { Agent, AgentConfig } from "../api/client";
+import type { Agent, AgentConfig, MCPServer } from "../api/client";
 import { AgentAppsCard } from "../components/apps/AgentAppsCard";
 import { usePolling } from "../hooks/usePolling";
 import { useWebSocket } from "../hooks/useWebSocket";
@@ -723,6 +723,8 @@ function SettingsTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) 
   // MCP server management state
   const [mcpList, setMcpList] = useState<string[] | null>(null);
   const [mcpLoading, setMcpLoading] = useState(true);
+  const [mcpRegistry, setMcpRegistry] = useState<MCPServer[]>([]);
+  const [mcpAddError, setMcpAddError] = useState<string | null>(null);
 
   // Env vars state — persisted via API to .mycel/agents/<name>/env.json
   const [envVars, setEnvVars] = useState<Array<{ key: string; value: string }>>([]);
@@ -787,6 +789,23 @@ function SettingsTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) 
   useEffect(() => {
     fetchMcps();
   }, [fetchMcps]);
+
+  // Real MCP server definitions from the global registry — used to power
+  // the "Add MCP" suggestions instead of a hardcoded, disconnected list.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .listMCP()
+      .then((servers) => {
+        if (!cancelled) setMcpRegistry(servers);
+      })
+      .catch(() => {
+        if (!cancelled) setMcpRegistry([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Load templates list on mount.
   useEffect(() => {
@@ -884,8 +903,18 @@ function SettingsTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) 
   };
 
   const handleMcpAdd = async (mcpName: string) => {
-    await api.addAgentMcp(agent.name, mcpName);
-    fetchMcps();
+    setMcpAddError(null);
+    try {
+      await api.addAgentMcp(agent.name, mcpName);
+      fetchMcps();
+    } catch (err) {
+      // The backend resolves mcpName against the global MCP registry and
+      // rejects names with no known command/url definition rather than
+      // writing an empty stanza — surface that (or any other) failure
+      // instead of swallowing it.
+      setMcpAddError(err instanceof Error ? err.message : "Failed to add MCP server");
+      throw err;
+    }
   };
 
   const handleMcpRemove = async (mcpName: string) => {
@@ -1005,6 +1034,8 @@ function SettingsTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) 
             loading={mcpLoading}
             onAdd={useLiveMcp ? handleMcpAdd : undefined}
             onRemove={useLiveMcp ? handleMcpRemove : undefined}
+            registry={mcpRegistry}
+            addError={mcpAddError}
           />
           <p className="mt-2 text-xs text-mycel-muted leading-relaxed">
             {isTmux

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -239,22 +239,27 @@ function InlineAgentName({
   const [editing, setEditing] = useState(false);
   const [newName, setNewName] = useState(agent.name);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSave = async () => {
     const trimmed = newName.trim();
     if (!trimmed || trimmed === agent.name) {
       setEditing(false);
       setNewName(agent.name);
+      setError(null);
       return;
     }
     setSaving(true);
     try {
       await api.renameAgent(agent.name, trimmed);
       setEditing(false);
+      setError(null);
       onRenamed();
-    } catch {
-      setNewName(agent.name);
-      setEditing(false);
+    } catch (err) {
+      // Keep editing open with the attempted name so the failure is
+      // visible and the user can correct or retry rather than having
+      // their edit silently discarded.
+      setError(err instanceof Error ? err.message : "Rename failed");
     } finally {
       setSaving(false);
     }
@@ -262,24 +267,42 @@ function InlineAgentName({
 
   if (editing) {
     return (
-      <input
-        type="text"
-        value={newName}
-        onChange={(e) => setNewName(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") handleSave();
-          if (e.key === "Escape") {
-            setEditing(false);
-            setNewName(agent.name);
-          }
-        }}
-        onBlur={handleSave}
-        disabled={saving}
-        autoFocus
-        onClick={(e) => e.stopPropagation()}
-        className="px-1 py-0.5 text-sm font-medium rounded-md border border-mycel-accent bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent w-32"
-        aria-label="Rename agent"
-      />
+      <span className="inline-flex flex-col">
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => {
+            setNewName(e.target.value);
+            if (error) setError(null);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSave();
+            if (e.key === "Escape") {
+              setEditing(false);
+              setNewName(agent.name);
+              setError(null);
+            }
+          }}
+          onBlur={() => {
+            if (!error) handleSave();
+          }}
+          disabled={saving}
+          autoFocus
+          onClick={(e) => e.stopPropagation()}
+          className={`px-1 py-0.5 text-sm font-medium rounded-md border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 w-32 ${
+            error
+              ? "border-mycel-error focus:ring-mycel-error"
+              : "border-mycel-accent focus:ring-mycel-accent"
+          }`}
+          aria-label="Rename agent"
+          aria-invalid={error ? true : undefined}
+        />
+        {error && (
+          <span className="mt-0.5 text-[10px] text-mycel-error" role="alert">
+            {error}
+          </span>
+        )}
+      </span>
     );
   }
 


### PR DESCRIPTION
Part of #2674

## Root cause

The web UI's "Add MCP" control (`AgentDetail.tsx`'s `handleMcpAdd`) only ever sent a bare server name — `api.addAgentMcp(name, mcpName)` posts `{name}`. `addAgentMCP` (`server/handlers/agents.go`) wrote that name straight into `.mcp.json` with no `command`/`url`/`env`, producing a stanza that can never actually connect. The real MCP definitions already live in the global MCP registry (`GET /api/mcp`, backed by `GlobalStore` at `~/.mycel/mcps.json`) but were never consulted for this flow, and `MCPServerList`'s autocomplete offered a hardcoded, disconnected `KNOWN_MCPS` list instead of the real registry.

## Fix

- `addAgentMCP` now resolves `req.Name` against the user-global MCP registry (`~/.mycel/mcps.json` via `pkg/mcp.GlobalStore`) whenever the caller supplies no `command`/`url`, filling in the real `command`/`url`/`type`/`env`. Names with no registry definition are rejected with `422` instead of being written as an empty stanza.
- `MCPServerList`'s autocomplete now sources suggestions from the real registry (passed down from `AgentDetail`'s `api.listMCP()` call) instead of the hardcoded `KNOWN_MCPS` array, and surfaces add failures inline instead of swallowing them.
- `Agents.tsx`'s inline rename control now surfaces failures inline (stays in edit mode with an error message) instead of silently reverting the input and closing.
- `client.ts`'s `renameAgent` is retyped to match what the backend actually returns (`{status, name}`), not `Agent`.

## Files

- `server/handlers/agents.go` — `addAgentMCP` resolution + new `resolveGlobalMCPDef` helper
- `web/src/views/AgentDetail.tsx` — loads the registry, surfaces add errors
- `web/src/components/shared/MCPServerList.tsx` — real registry-backed autocomplete, error display
- `web/src/views/Agents.tsx` — inline rename error surfacing
- `web/src/api/client.ts` — `renameAgent` return type fix

## Test plan

- [x] `make build-local-web` — builds clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./server/...` — 0 issues
- [x] `go test ./server/handlers/...` — all pass, including new `TestAddAgentMCP_ResolvesRealDefinitionFromRegistry` and `TestAddAgentMCP_RejectsUnknownName`
- [x] `make test-web` (vitest) — 322/322 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)