### PR TITLE
fix(providers): make Install/Update honest (real, not relabeled)

### DIFF
--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -3,7 +3,10 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -88,11 +91,16 @@ type MCPServer struct {
 }
 
 // UpdateCheck holds the result of a provider version check.
-type UpdateCheck struct {
-	CurrentVersion  string `json:"current_version"`
-	LatestVersion   string `json:"latest_version"`
-	UpdateCommand   string `json:"update_command"`
-	UpdateAvailable bool   `json:"update_available"`
+type UpdateCheck struct { //nolint:govet // field order matches JSON/API contract
+	CurrentVersion string `json:"current_version"`
+	LatestVersion  string `json:"latest_version"`
+	UpdateCommand  string `json:"update_command"`
+	// Checked is true when LatestVersion/UpdateAvailable come from a real,
+	// freshly-fetched registry lookup. False means the provider's install
+	// mechanism has no queryable registry (e.g. a curl-piped script or a
+	// bare download URL) — the UI must not claim "up to date" in that case.
+	Checked         bool `json:"checked"`
+	UpdateAvailable bool `json:"update_available"`
 }
 
 // modelCacheEntry caches DynamicModelLister results to avoid shelling out per request.
@@ -447,7 +455,14 @@ func (h *ProviderHandler) addMCP(w http.ResponseWriter, r *http.Request, name st
 	})
 }
 
-// checkUpdate checks if a newer version is available for the provider.
+// checkUpdate performs a real latest-version check for the provider and
+// reports whether an update is available. Providers whose InstallHint is an
+// npm/npx install line are checked against the public npm registry — the
+// same "compare a live upstream to the installed version" approach
+// About.tsx uses for the daemon itself (npm + GitHub releases). Providers
+// installed via a non-registry mechanism (curl-piped script, bare download
+// URL) have no queryable source of truth; UpdateCheck.Checked is false for
+// those and the UI must show current-version-only, never a false "latest".
 func (h *ProviderHandler) checkUpdate(w http.ResponseWriter, r *http.Request, name string) {
 	p, ok := h.registry.Get(name)
 	if !ok {
@@ -461,25 +476,153 @@ func (h *ProviderHandler) checkUpdate(w http.ResponseWriter, r *http.Request, na
 		return
 	}
 
-	// Return current version info with install hint as update command.
-	// Actual latest version checking requires network calls to package registries
-	// which can be added per-provider in the future.
-	writeJSON(w, http.StatusOK, UpdateCheck{
-		CurrentVersion:  currentVersion,
-		LatestVersion:   currentVersion,
-		UpdateAvailable: false,
-		UpdateCommand:   p.InstallHint(),
-	})
+	hint := p.InstallHint()
+	result := UpdateCheck{
+		CurrentVersion: currentVersion,
+		UpdateCommand:  hint,
+	}
+
+	if pkg, ok := npmPackageForHint(hint); ok {
+		if latest, err := fetchNpmLatestVersion(r.Context(), pkg); err == nil && latest != "" {
+			result.LatestVersion = latest
+			result.Checked = true
+			result.UpdateAvailable = normalizeVersion(latest) != normalizeVersion(currentVersion)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, result)
 }
 
-// install returns the install hint for the provider.
+// runnableInstallHint reports whether hint is safe to execute directly as a
+// shell command (npm/npx/curl/brew/…) rather than being a bare URL a human
+// must open manually (e.g. cursor's "https://cursor.sh"). Mirrors
+// providerInstallCmd's predicate in deps_install.go so the install and
+// update paths agree on what's automatable.
+func runnableInstallHint(hint string) bool {
+	h := strings.TrimSpace(hint)
+	return h != "" && !strings.HasPrefix(h, "http://") && !strings.HasPrefix(h, "https://")
+}
+
+// npmPackageForHint extracts the npm package name from a provider's install
+// hint when the hint is an npm/npx install line ("npm install -g <pkg>",
+// "npm i -g <pkg>", "npx -y <pkg>", "npx <pkg>"). Returns ok=false for any
+// other install mechanism — those have no npm registry entry to query.
+func npmPackageForHint(hint string) (string, bool) {
+	h := strings.TrimSpace(hint)
+	for _, pfx := range []string{"npm install -g ", "npm i -g ", "npx -y ", "npx "} {
+		if !strings.HasPrefix(h, pfx) {
+			continue
+		}
+		pkg := strings.TrimSpace(strings.TrimPrefix(h, pfx))
+		if sp := strings.IndexByte(pkg, ' '); sp >= 0 {
+			pkg = pkg[:sp]
+		}
+		if pkg != "" {
+			return pkg, true
+		}
+	}
+	return "", false
+}
+
+// normalizeVersion strips a leading "v" so "v1.2.3" and "1.2.3" compare equal.
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// npmRegistryBaseURL and npmHTTPClient are package vars so tests can point
+// checkUpdate at a local httptest.Server instead of the real npm registry.
+var npmRegistryBaseURL = "https://registry.npmjs.org/"
+var npmHTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+// fetchNpmLatestVersion queries the public npm registry for pkg's current
+// "latest" dist-tag version — a real network check, not a guess.
+func fetchNpmLatestVersion(ctx context.Context, pkg string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, npmRegistryBaseURL+url.PathEscape(pkg)+"/latest", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := npmHTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("npm registry returned %d for %s", resp.StatusCode, pkg)
+	}
+
+	var body struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.Version == "" {
+		return "", fmt.Errorf("npm registry: empty version for %s", pkg)
+	}
+	return body.Version, nil
+}
+
+// install returns the install hint for the provider. The web UI prefers the
+// real streamed installer at POST /api/deps/install (id=<provider name>,
+// which resolves the same InstallHint via providerInstallCmd in
+// deps_install.go); this endpoint remains for API callers that just want the
+// hint text.
 func (h *ProviderHandler) install(w http.ResponseWriter, _ *http.Request, name string) {
 	h.hintResponse(w, name, "install")
 }
 
-// update returns the upgrade hint for the provider.
-func (h *ProviderHandler) update(w http.ResponseWriter, _ *http.Request, name string) {
-	h.hintResponse(w, name, "update")
+// update performs a real update by re-running the provider's install command
+// (e.g. "npm install -g <pkg>", which always resolves to the latest
+// published version) and streaming live output back as NDJSON — the same
+// on-host execution model install-via-deps and /api/deps/install use
+// (streamInstall, shared within this package). Loopback-only: it shells out
+// on the host.
+func (h *ProviderHandler) update(w http.ResponseWriter, r *http.Request, name string) {
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	p, ok := h.registry.Get(name)
+	if !ok {
+		httpError(w, "unknown provider: "+name, http.StatusNotFound)
+		return
+	}
+
+	hint := strings.TrimSpace(p.InstallHint())
+	if !runnableInstallHint(hint) {
+		httpError(w, "no automatic updater for "+name, http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		httpError(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+
+	emit := func(v any) bool {
+		payload, mErr := json.Marshal(v)
+		if mErr != nil {
+			return false
+		}
+		if _, wErr := w.Write(append(payload, '\n')); wErr != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	emit(map[string]string{"type": "start", "command": hint})
+	streamInstall(r.Context(), hint, emit)
 }
 
 // hintResponse returns the install/update hint for a provider.

--- a/server/handlers/providers_update_test.go
+++ b/server/handlers/providers_update_test.go
@@ -1,0 +1,298 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/provider"
+)
+
+// fakeUpdateProvider is a minimal provider.Provider stub with a fully
+// controllable version/install-hint pair, so checkUpdate/update can be
+// exercised without shelling out to a real CLI.
+type fakeUpdateProvider struct {
+	name        string
+	installHint string
+	version     string
+}
+
+func (f *fakeUpdateProvider) Name() string                             { return f.name }
+func (f *fakeUpdateProvider) Description() string                      { return "fake" }
+func (f *fakeUpdateProvider) Command() string                          { return f.name }
+func (f *fakeUpdateProvider) Binary() string                           { return f.name }
+func (f *fakeUpdateProvider) InstallHint() string                      { return f.installHint }
+func (f *fakeUpdateProvider) BuildCommand(provider.CommandOpts) string { return f.name }
+func (f *fakeUpdateProvider) IsInstalled(context.Context) bool         { return f.version != "" }
+func (f *fakeUpdateProvider) Version(context.Context) string           { return f.version }
+
+func newFakeUpdateMux(p provider.Provider) http.Handler {
+	reg := provider.NewRegistry()
+	reg.Register(p)
+	mux := http.NewServeMux()
+	NewProviderHandler(reg, nil, nil, nil).Register(mux)
+	return mux
+}
+
+// withNpmRegistryStub points fetchNpmLatestVersion at a local httptest.Server
+// that always returns the given version for "/<pkg>/latest", restoring the
+// real npm registry base URL on cleanup.
+func withNpmRegistryStub(t *testing.T, version string, statusCode int) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if statusCode != http.StatusOK {
+			w.WriteHeader(statusCode)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintf(w, `{"version":%q}`, version)
+	}))
+	t.Cleanup(srv.Close)
+
+	origURL := npmRegistryBaseURL
+	npmRegistryBaseURL = srv.URL + "/"
+	t.Cleanup(func() { npmRegistryBaseURL = origURL })
+}
+
+func TestCheckUpdate_RealNpmCompareUpdateAvailable(t *testing.T) {
+	withNpmRegistryStub(t, "9.9.9", http.StatusOK)
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/check-update", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+	var result UpdateCheck
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !result.Checked {
+		t.Error("Checked = false, want true (npm registry lookup succeeded)")
+	}
+	if !result.UpdateAvailable {
+		t.Error("UpdateAvailable = false, want true (1.0.0 vs 9.9.9)")
+	}
+	if result.LatestVersion != "9.9.9" {
+		t.Errorf("LatestVersion = %q, want 9.9.9", result.LatestVersion)
+	}
+	if result.CurrentVersion != "1.0.0" {
+		t.Errorf("CurrentVersion = %q, want 1.0.0", result.CurrentVersion)
+	}
+}
+
+func TestCheckUpdate_RealNpmCompareUpToDate(t *testing.T) {
+	withNpmRegistryStub(t, "1.0.0", http.StatusOK)
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/check-update", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	var result UpdateCheck
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !result.Checked {
+		t.Error("Checked = false, want true")
+	}
+	if result.UpdateAvailable {
+		t.Error("UpdateAvailable = true, want false when versions match")
+	}
+}
+
+// TestCheckUpdate_NonNpmHintIsHonestlyUnverified covers a provider installed
+// via a mechanism with no queryable registry (e.g. cursor's bare download
+// URL). checkUpdate must not claim the version is current — Checked stays
+// false so the UI shows "can't verify" rather than a false "up to date".
+func TestCheckUpdate_NonNpmHintIsHonestlyUnverified(t *testing.T) {
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakeurl", installHint: "https://example.com/install", version: "1.0.0"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakeurl/check-update", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var result UpdateCheck
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Checked {
+		t.Error("Checked = true, want false — no registry to query for a bare-URL install hint")
+	}
+	if result.UpdateAvailable {
+		t.Error("UpdateAvailable = true, want false when unverified")
+	}
+	if result.LatestVersion != "" {
+		t.Errorf("LatestVersion = %q, want empty when unverified", result.LatestVersion)
+	}
+}
+
+func TestCheckUpdate_NpmRegistryErrorLeavesUnchecked(t *testing.T) {
+	withNpmRegistryStub(t, "", http.StatusInternalServerError)
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/check-update", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	var result UpdateCheck
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if result.Checked {
+		t.Error("Checked = true, want false when the registry call fails")
+	}
+}
+
+func TestCheckUpdate_NotInstalled(t *testing.T) {
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: ""})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/check-update", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a not-installed provider", rec.Code)
+	}
+}
+
+// TestProviderUpdate_StreamsRealCommand exercises the real streamed update
+// path: it stubs installRunner (shared with /api/deps/install) so no process
+// actually runs, and asserts the update handler resolves + streams the
+// provider's install command as NDJSON, exactly like a real update would.
+func TestProviderUpdate_StreamsRealCommand(t *testing.T) {
+	orig := installRunner
+	installRunner = func(ctx context.Context, _ string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c", "printf 'updating…\\n'")
+	}
+	t.Cleanup(func() { installRunner = orig })
+
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/update", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var sawStart, sawDoneZero bool
+	var logs []string
+	sc := bufio.NewScanner(strings.NewReader(rec.Body.String()))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("bad NDJSON line %q: %v", line, err)
+		}
+		switch ev["type"] {
+		case "start":
+			sawStart = true
+			if cmd, _ := ev["command"].(string); cmd != "npm install -g fake-cli" {
+				t.Errorf("start command = %q, want the provider's install hint", cmd)
+			}
+		case "log":
+			if l, ok := ev["line"].(string); ok {
+				logs = append(logs, l)
+			}
+		case "done":
+			if code, ok := ev["code"].(float64); ok && code == 0 {
+				sawDoneZero = true
+			}
+		case "error":
+			t.Fatalf("unexpected error event: %v", ev["error"])
+		}
+	}
+	if !sawStart {
+		t.Error("missing start event")
+	}
+	if !sawDoneZero {
+		t.Error("missing done event with code 0")
+	}
+	if !strings.Contains(strings.Join(logs, "|"), "updating…") {
+		t.Errorf("logs = %v, want stubbed output", logs)
+	}
+}
+
+// TestProviderUpdate_NonRunnableHintRefused covers a provider with a bare-URL
+// install hint (e.g. cursor) — there is nothing to execute, so update must
+// refuse honestly rather than trying to "run" a URL.
+func TestProviderUpdate_NonRunnableHintRefused(t *testing.T) {
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakeurl", installHint: "https://example.com/install", version: "1.0.0"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakeurl/update", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a non-runnable install hint", rec.Code)
+	}
+}
+
+func TestProviderUpdate_LoopbackGuard(t *testing.T) {
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/update", nil)
+	req.RemoteAddr = "10.0.0.5:1234"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for a non-loopback caller", rec.Code)
+	}
+}
+
+// TestProviderUpdate_MethodGuard confirms GET .../update isn't routed at all
+// (byName's switch only wires POST to the update action, matching every
+// other provider sub-action) rather than silently running an update.
+func TestProviderUpdate_MethodGuard(t *testing.T) {
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/providers/fakenpm/update", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestNpmPackageForHint(t *testing.T) {
+	tests := []struct {
+		hint   string
+		want   string
+		wantOK bool
+	}{
+		{"npm install -g @openai/codex", "@openai/codex", true},
+		{"npm i -g foo", "foo", true},
+		{"npx -y @anthropic-ai/claude-code", "@anthropic-ai/claude-code", true},
+		{"npx openclaw", "openclaw", true},
+		{"curl -fsSL https://antigravity.google/install.sh | sh", "", false},
+		{"https://cursor.sh", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		got, ok := npmPackageForHint(tt.hint)
+		if ok != tt.wantOK || got != tt.want {
+			t.Errorf("npmPackageForHint(%q) = (%q, %v), want (%q, %v)", tt.hint, got, ok, tt.want, tt.wantOK)
+		}
+	}
+}

--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -132,3 +132,62 @@ describe("tools seams API", () => {
     expect(res.exit_code).toBe(0);
   });
 });
+
+/** Build a streaming Response whose body yields the given chunks in order —
+ *  mirrors src/wizard/__tests__/installStream.test.ts since streamProviderUpdate
+ *  parses the same NDJSON event shape over a different endpoint. */
+function streamResponse(chunks: string[], ok = true, status = 200): Response {
+  const enc = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return { ok, status, body } as unknown as Response;
+}
+
+describe("api.streamProviderUpdate", () => {
+  it("POSTs to the provider's update endpoint and parses the NDJSON stream", async () => {
+    fetchMock.mockReturnValue(
+      streamResponse([
+        '{"type":"start","command":"npm install -g @openai/codex"}\n',
+        '{"type":"log","line":"+ codex@1.2.4"}\n',
+        '{"type":"done","code":0}\n',
+      ]),
+    );
+
+    const events: unknown[] = [];
+    const code = await api.streamProviderUpdate("codex", (ev) => events.push(ev));
+
+    expect(code).toBe(0);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/providers/codex/update",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(events).toEqual([
+      { type: "start", command: "npm install -g @openai/codex" },
+      { type: "log", line: "+ codex@1.2.4" },
+      { type: "done", code: 0 },
+    ]);
+  });
+
+  it("throws on an error event", async () => {
+    fetchMock.mockReturnValue(streamResponse(['{"type":"error","error":"no automatic updater for cursor"}\n']));
+    await expect(api.streamProviderUpdate("cursor", () => {})).rejects.toThrow(
+      "no automatic updater for cursor",
+    );
+  });
+
+  it("surfaces a non-OK response as an error", async () => {
+    fetchMock.mockReturnValue({
+      ok: false,
+      status: 400,
+      body: null,
+      json: () => Promise.resolve({ error: "no automatic updater for cursor" }),
+    } as unknown as Response);
+    await expect(api.streamProviderUpdate("cursor", () => {})).rejects.toThrow(
+      "no automatic updater for cursor",
+    );
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -602,11 +602,79 @@ export interface ProviderMCPServer {
   error?: string;
 }
 
+/** One NDJSON record from the provider update stream (POST
+ *  /providers/:name/update) — the same event shape /api/deps/install emits
+ *  (see web/src/wizard/installStream.ts), duplicated here rather than
+ *  imported since the two streams hit different endpoints for a
+ *  provider-scoped vs. generic-dependency action. */
+export type ProviderInstallEvent =
+  | { type: "start"; command: string }
+  | { type: "log"; line: string }
+  | { type: "done"; code: number }
+  | { type: "error"; error: string };
+
+/** Reads an NDJSON stream from a provider action (update), dispatching each
+ *  event and resolving with the process exit code. Throws on transport
+ *  errors or an explicit error event. */
+async function consumeProviderStream(
+  res: Response,
+  onEvent: (ev: ProviderInstallEvent) => void,
+): Promise<number> {
+  if (!res.ok || !res.body) {
+    let msg = `Update failed: ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body && typeof body.error === "string") msg = body.error;
+    } catch {
+      // non-JSON error body
+    }
+    throw new Error(msg);
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buf = "";
+  let code = -1;
+
+  const handleLine = (raw: string) => {
+    const line = raw.trim();
+    if (!line) return;
+    let ev: ProviderInstallEvent;
+    try {
+      ev = JSON.parse(line) as ProviderInstallEvent;
+    } catch {
+      return;
+    }
+    onEvent(ev);
+    if (ev.type === "done") code = ev.code;
+    if (ev.type === "error") throw new Error(ev.error);
+  };
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += decoder.decode(value, { stream: true });
+    let nl = buf.indexOf("\n");
+    while (nl >= 0) {
+      handleLine(buf.slice(0, nl));
+      buf = buf.slice(nl + 1);
+      nl = buf.indexOf("\n");
+    }
+  }
+  if (buf.trim()) handleLine(buf);
+  return code;
+}
+
 export interface ProviderUpdateCheck {
   current_version: string;
   latest_version: string;
   update_available: boolean;
   update_command: string;
+  /** true when latest_version/update_available came from a real, freshly
+   *  fetched registry lookup (npm today). false means the provider's install
+   *  mechanism has no queryable registry (bare URL, curl script) — the UI
+   *  must show "can't verify" rather than a false "up to date". */
+  checked: boolean;
 }
 
 export interface EventLogEntry {
@@ -1193,18 +1261,27 @@ export const api = {
       method: "POST",
       body: JSON.stringify(mcp),
     }),
-  installProvider: (name: string) =>
-    request<{ status: string; provider: string; install_cmd: string }>(`/providers/${encodeURIComponent(name)}/install`, {
-      method: "POST",
-    }),
-  updateProvider: (name: string) =>
-    request<{ status: string; provider: string; update_cmd: string }>(`/providers/${encodeURIComponent(name)}/update`, {
-      method: "POST",
-    }),
   checkProviderUpdate: (name: string) =>
     request<ProviderUpdateCheck>(`/providers/${encodeURIComponent(name)}/check-update`, {
       method: "POST",
     }),
+  /**
+   * streamProviderUpdate runs a REAL update for a provider: POST
+   * /api/providers/:name/update re-executes the provider's install command
+   * on the host (e.g. "npm install -g <pkg>", which always resolves to the
+   * latest published version) and streams live NDJSON output back, exactly
+   * like the /api/deps/install mechanism Tools.tsx uses. Resolves with the
+   * process exit code (0 = success); throws on transport or stream errors.
+   */
+  streamProviderUpdate: async (
+    name: string,
+    onEvent: (ev: ProviderInstallEvent) => void,
+  ): Promise<number> => {
+    const res = await fetch(`${BASE}/providers/${encodeURIComponent(name)}/update`, {
+      method: "POST",
+    });
+    return consumeProviderStream(res, onEvent);
+  },
   updateProviderConfig: (name: string, config: Record<string, string>) =>
     request<{ status: string; provider: string; command: string }>(`/providers/${encodeURIComponent(name)}/config`, {
       method: "PATCH",

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { motion } from "framer-motion";
 import { api } from "../api/client";
@@ -6,7 +6,9 @@ import type {
   ProviderDetailResponse,
   ProviderCommand,
   ProviderMCPServer,
+  ProviderInstallEvent,
 } from "../api/client";
+import { installDep } from "../wizard/installStream";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
@@ -30,24 +32,221 @@ function providerStatus(provider: ProviderDetailResponse): string {
   return "stopped";
 }
 
+/* ── Real install / update actions ────────────────────────────────────
+ *
+ * canAutoInstall mirrors the server's providerInstallCmd predicate
+ * (deps_install.go): a hint is executable when it isn't empty and isn't a
+ * bare download URL (e.g. cursor's "https://cursor.sh" — a GUI installer
+ * with no runnable command). Install and update both stream through
+ * installDep-compatible NDJSON endpoints, so the two share one console UI. */
+function canAutoInstall(hint: string | undefined | null): boolean {
+  if (!hint) return false;
+  const h = hint.trim();
+  return h !== "" && !h.startsWith("http://") && !h.startsWith("https://");
+}
+
+type RunState = "idle" | "running" | "ok" | "error";
+
+/* Live NDJSON console shared by the real install and update actions —
+ * an aria-live region so screen readers hear progress as it streams in,
+ * not just the final state. */
+function StreamConsole({ state, lines, err }: { state: RunState; lines: string[]; err: string | null }) {
+  const consoleRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = consoleRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [lines]);
+
+  if (state === "idle") return null;
+  return (
+    <div
+      ref={consoleRef}
+      role="status"
+      aria-live="polite"
+      className="max-h-32 overflow-auto rounded border border-mycel-border bg-mycel-bg px-2 py-1.5 font-mono text-[10.5px] leading-relaxed text-mycel-text-2 whitespace-pre-wrap max-w-sm"
+    >
+      {err ? (
+        <span className="text-mycel-error">{err}</span>
+      ) : (
+        <>
+          {lines.map((l, i) => (
+            <div key={i} className={l.startsWith("$ ") ? "text-mycel-accent" : ""}>{l}</div>
+          ))}
+          {state === "running" && <div className="text-mycel-muted">▍</div>}
+          {state === "ok" && <div className="text-mycel-success">Done.</div>}
+        </>
+      )}
+    </div>
+  );
+}
+
+/* Installs a provider for real via the same streamed POST /api/deps/install
+ * path Tools.tsx uses for CLI dependencies (the server resolves the
+ * provider's vetted install command by name — see providerInstallCmd in
+ * deps_install.go), with live NDJSON output. When the install hint is a bare
+ * URL there is no command to execute — that one case honestly falls back to
+ * a copyable hint instead of a fake "Install" button. */
+function InstallAction({
+  providerName,
+  installHint,
+  onInstalled,
+}: {
+  providerName: string;
+  installHint: string;
+  onInstalled: () => void;
+}) {
+  const [state, setState] = useState<RunState>("idle");
+  const [lines, setLines] = useState<string[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const runningRef = useRef(false);
+  useEffect(() => () => { runningRef.current = false; }, []);
+
+  if (!canAutoInstall(installHint)) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <span
+          className="px-3 py-1.5 text-sm rounded bg-mycel-warning-subtle text-mycel-warning font-mono truncate max-w-xs"
+          title={installHint || undefined}
+        >
+          {installHint || "No install command available"}
+        </span>
+        {installHint && <CopyButton text={installHint} />}
+      </div>
+    );
+  }
+
+  const run = async () => {
+    setState("running");
+    setLines([]);
+    setErr(null);
+    runningRef.current = true;
+    try {
+      const code = await installDep(
+        providerName,
+        (ev) => {
+          if (!runningRef.current) return;
+          if (ev.type === "start") setLines((l) => [...l, `$ ${ev.command}`]);
+          else if (ev.type === "log") setLines((l) => [...l, ev.line]);
+        },
+        { mode: "install" },
+      );
+      if (!runningRef.current) return;
+      if (code === 0) {
+        setState("ok");
+        onInstalled();
+      } else {
+        setState("error");
+        setErr(`Install exited with code ${code}.`);
+      }
+    } catch (e) {
+      if (!runningRef.current) return;
+      setState("error");
+      setErr(e instanceof Error ? e.message : "Install failed.");
+    } finally {
+      runningRef.current = false;
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <button
+        type="button"
+        onClick={() => void run()}
+        disabled={state === "running"}
+        className="px-3 py-1.5 text-sm rounded bg-mycel-warning-subtle text-mycel-warning transition-colors disabled:opacity-50"
+      >
+        {state === "running" ? "Installing…" : state === "ok" ? "Install again" : state === "error" ? "Retry install" : "Install"}
+      </button>
+      <StreamConsole state={state} lines={lines} err={err} />
+    </div>
+  );
+}
+
+/* Updates an already-installed provider for real via POST
+ * /api/providers/:name/update, which re-runs the provider's install command
+ * on the host (e.g. "npm install -g <pkg>" always resolves to the latest
+ * published version) and streams live NDJSON output — the same console UX
+ * as InstallAction. Only offered when the hint is runnable; see
+ * canAutoInstall. */
+function UpdateAction({
+  providerName,
+  installHint,
+  onUpdated,
+}: {
+  providerName: string;
+  installHint: string;
+  onUpdated: () => void;
+}) {
+  const [state, setState] = useState<RunState>("idle");
+  const [lines, setLines] = useState<string[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const runningRef = useRef(false);
+  useEffect(() => () => { runningRef.current = false; }, []);
+
+  if (!canAutoInstall(installHint)) return null;
+
+  const run = async () => {
+    setState("running");
+    setLines([]);
+    setErr(null);
+    runningRef.current = true;
+    try {
+      const code = await api.streamProviderUpdate(providerName, (ev: ProviderInstallEvent) => {
+        if (!runningRef.current) return;
+        if (ev.type === "start") setLines((l) => [...l, `$ ${ev.command}`]);
+        else if (ev.type === "log") setLines((l) => [...l, ev.line]);
+      });
+      if (!runningRef.current) return;
+      if (code === 0) {
+        setState("ok");
+        onUpdated();
+      } else {
+        setState("error");
+        setErr(`Update exited with code ${code}.`);
+      }
+    } catch (e) {
+      if (!runningRef.current) return;
+      setState("error");
+      setErr(e instanceof Error ? e.message : "Update failed.");
+    } finally {
+      runningRef.current = false;
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <button
+        type="button"
+        onClick={() => void run()}
+        disabled={state === "running"}
+        className="px-3 py-1.5 text-sm rounded bg-mycel-accent-subtle text-mycel-accent transition-colors disabled:opacity-50"
+      >
+        {state === "running" ? "Updating…" : state === "ok" ? "Update again" : state === "error" ? "Retry update" : "Update now"}
+      </button>
+      <StreamConsole state={state} lines={lines} err={err} />
+    </div>
+  );
+}
 
 /* ── Section: Header ── */
 
 function ProviderHeader({
   provider,
-  onInstall,
-  onUpdate,
-  installing,
-  updating,
+  onInstalled,
+  onCheckUpdate,
+  onUpdated,
+  checking,
+  updateResult,
 }: {
   provider: ProviderDetailResponse;
-  onInstall: () => void;
-  onUpdate: () => void;
-  installing: boolean;
-  updating: boolean;
+  onInstalled: () => void;
+  onCheckUpdate: () => void;
+  onUpdated: () => void;
+  checking: boolean;
+  updateResult: { checked: boolean; current: string; latest: string; available: boolean } | null;
 }) {
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+    <div className="flex flex-col sm:flex-row sm:items-start justify-between gap-4">
       <div className="flex items-center gap-3">
         <Link
           to="/tools"
@@ -73,39 +272,46 @@ function ProviderHeader({
           )}
         </div>
       </div>
-      <div className="flex items-center gap-2">
-        {!provider.installed && provider.install_hint && (
-          <button
-            type="button"
-            onClick={onInstall}
-            disabled={installing}
-            className="px-3 py-1.5 text-sm rounded bg-mycel-warning-subtle text-mycel-warning transition-colors disabled:opacity-50"
-          >
-            {installing ? "Installing..." : "Install"}
-          </button>
-        )}
-        {provider.installed && provider.install_hint && (
-          <button
-            type="button"
-            onClick={onUpdate}
-            disabled={updating}
-            className="px-3 py-1.5 text-sm rounded bg-mycel-info-subtle text-mycel-info transition-colors disabled:opacity-50"
-          >
-            {updating ? "Checking..." : "Check for Update"}
-          </button>
-        )}
-        <span
-          className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium ${
-            provider.enabled
-              ? "bg-mycel-success-subtle text-mycel-success"
-              : "bg-mycel-surface-hover text-mycel-text-2"
-          }`}
-        >
+      <div className="flex flex-col items-end gap-2">
+        <div className="flex items-center gap-2">
+          {!provider.installed && (
+            <InstallAction providerName={provider.name} installHint={provider.install_hint} onInstalled={onInstalled} />
+          )}
+          {provider.installed && (
+            <>
+              <button
+                type="button"
+                onClick={onCheckUpdate}
+                disabled={checking}
+                className="px-3 py-1.5 text-sm rounded bg-mycel-info-subtle text-mycel-info transition-colors disabled:opacity-50"
+              >
+                {checking ? "Checking..." : "Check for Update"}
+              </button>
+              <UpdateAction providerName={provider.name} installHint={provider.install_hint} onUpdated={onUpdated} />
+            </>
+          )}
           <span
-            className={`w-2 h-2 rounded-full ${provider.enabled ? "bg-mycel-success" : "bg-mycel-muted"}`}
-          />
-          {provider.enabled ? "Enabled" : "Disabled"}
-        </span>
+            className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium ${
+              provider.enabled
+                ? "bg-mycel-success-subtle text-mycel-success"
+                : "bg-mycel-surface-hover text-mycel-text-2"
+            }`}
+          >
+            <span
+              className={`w-2 h-2 rounded-full ${provider.enabled ? "bg-mycel-success" : "bg-mycel-muted"}`}
+            />
+            {provider.enabled ? "Enabled" : "Disabled"}
+          </span>
+        </div>
+        {updateResult && (
+          <p className="text-xs text-mycel-muted text-right">
+            {!updateResult.checked
+              ? `Current v${updateResult.current} — couldn't verify the latest release automatically.`
+              : updateResult.available
+                ? `Update available: v${updateResult.latest} (current v${updateResult.current})`
+                : `Up to date (v${updateResult.current}).`}
+          </p>
+        )}
       </div>
     </div>
   );
@@ -701,7 +907,7 @@ function CommandRow({ providerName, command }: { providerName: string; command: 
         <tr className="border-b border-mycel-border bg-mycel-bg">
           <td colSpan={4} className="px-4 py-2">
             {errMsg ? (
-              <p className="text-xs text-mycel-error">{errMsg}</p>
+              <p className="text-xs text-mycel-error" role="alert">{errMsg}</p>
             ) : (
               <div className="space-y-1">
                 <div className="flex items-center gap-2 text-[10.5px] text-mycel-muted flex-wrap">
@@ -715,7 +921,13 @@ function CommandRow({ providerName, command }: { providerName: string; command: 
                   )}
                   {truncated && <span className="text-mycel-warning">output truncated</span>}
                 </div>
-                <pre className="max-h-56 overflow-auto rounded border border-mycel-border bg-mycel-surface px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-mycel-text-2 whitespace-pre-wrap">
+                {/* aria-live so screen readers hear the "Running…" → output
+                    transition, not just a silent DOM swap. */}
+                <pre
+                  role="status"
+                  aria-live="polite"
+                  className="max-h-56 overflow-auto rounded border border-mycel-border bg-mycel-surface px-2.5 py-1.5 font-mono text-[11px] leading-relaxed text-mycel-text-2 whitespace-pre-wrap"
+                >
                   {state === "running" ? "Running…" : output || (timedOut ? "(no output — command timed out)" : "(no output)")}
                 </pre>
               </div>
@@ -773,8 +985,8 @@ function CommandsSection({ providerName, commands }: { providerName: string; com
 export function ProviderDetail() {
   const { provider: providerName } = useParams<{ provider: string }>();
   const { toasts, addToast, dismiss } = useToast();
-  const [installing, setInstalling] = useState(false);
-  const [updating, setUpdating] = useState(false);
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
+  const [updateResult, setUpdateResult] = useState<{ checked: boolean; current: string; latest: string; available: boolean } | null>(null);
 
   const detailFetcher = useCallback(async () => {
     if (!providerName) throw new Error("No provider name");
@@ -799,26 +1011,26 @@ export function ProviderDetail() {
   }, [providerName]);
   const { data: mcpServers, refresh: refreshMCPs } = usePolling<ProviderMCPServer[]>(mcpFetcher, 15000);
 
-  const handleInstall = async () => {
-    if (!providerName) return;
-    setInstalling(true);
-    try {
-      const result = await api.installProvider(providerName);
-      addToast("info", `Install: ${result.install_cmd}`);
-      refresh();
-    } catch (err) {
-      addToast("error", err instanceof Error ? err.message : "Install failed");
-    } finally {
-      setInstalling(false);
-    }
-  };
+  // The install/update actions themselves (InstallAction / UpdateAction) run
+  // for real via the streamed NDJSON endpoints; this just refreshes the
+  // provider detail once they land so version/status pick up immediately.
+  const handleInstalled = () => refresh();
+  const handleUpdated = () => { setUpdateResult(null); refresh(); };
 
-  const handleUpdate = async () => {
+  const handleCheckUpdate = async () => {
     if (!providerName) return;
-    setUpdating(true);
+    setCheckingUpdate(true);
     try {
       const result = await api.checkProviderUpdate(providerName);
-      if (result.update_available) {
+      setUpdateResult({
+        checked: result.checked,
+        current: result.current_version,
+        latest: result.latest_version,
+        available: result.update_available,
+      });
+      if (!result.checked) {
+        addToast("info", `Current version: ${result.current_version}. Couldn't verify the latest release automatically.`);
+      } else if (result.update_available) {
         addToast("info", `Update available: ${result.latest_version} (current: ${result.current_version})`);
       } else {
         addToast("success", `Already on latest version: ${result.current_version}`);
@@ -826,7 +1038,7 @@ export function ProviderDetail() {
     } catch (err) {
       addToast("error", err instanceof Error ? err.message : "Update check failed");
     } finally {
-      setUpdating(false);
+      setCheckingUpdate(false);
     }
   };
 
@@ -871,10 +1083,11 @@ export function ProviderDetail() {
     <div className="p-6 space-y-8">
       <ProviderHeader
         provider={provider}
-        onInstall={() => void handleInstall()}
-        onUpdate={() => void handleUpdate()}
-        installing={installing}
-        updating={updating}
+        onInstalled={handleInstalled}
+        onCheckUpdate={() => void handleCheckUpdate()}
+        onUpdated={handleUpdated}
+        checking={checkingUpdate}
+        updateResult={updateResult}
       />
 
       {/* 2-column layout on desktop */}

--- a/web/src/views/Tools.tsx
+++ b/web/src/views/Tools.tsx
@@ -251,6 +251,7 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
   const [confirmRemove, setConfirmRemove] = useState(false);
   const cfg = getStatusConfig(tool.status);
   const isDisabled = tool.status === "disabled";
+  const isNotInstalled = tool.status === "not_installed";
 
   return (
     <>
@@ -281,10 +282,11 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
         <td className="px-4 py-2.5 text-right" onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-end gap-1.5">
             <button type="button" onClick={onToggle} disabled={toggling}
-              role="switch" aria-checked={!isDisabled}
-              aria-label={isDisabled ? `Enable ${tool.name}` : `Disable ${tool.name}`}
-              className={`text-[11px] px-2 py-0.5 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent disabled:opacity-50 ${isDisabled ? "bg-mycel-surface-hover text-mycel-text-2 hover:bg-mycel-border" : "bg-mycel-success-subtle text-mycel-success"}`}>
-              {toggling ? "..." : isDisabled ? "Enable" : "Disable"}
+              role="switch" aria-checked={!isDisabled && !isNotInstalled}
+              aria-label={isNotInstalled ? `Install and enable ${tool.name}` : isDisabled ? `Enable ${tool.name}` : `Disable ${tool.name}`}
+              title={isNotInstalled ? "Not installed — installs the binary, then enables it" : undefined}
+              className={`text-[11px] px-2 py-0.5 rounded-md transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent disabled:opacity-50 ${isDisabled || isNotInstalled ? "bg-mycel-surface-hover text-mycel-text-2 hover:bg-mycel-border" : "bg-mycel-success-subtle text-mycel-success"}`}>
+              {toggling ? "..." : isNotInstalled ? "Install" : isDisabled ? "Enable" : "Disable"}
             </button>
             {!tool.required && (
               confirmRemove ? (
@@ -574,8 +576,33 @@ export function Tools() {
   }
 
   const handleToggle = async (tool: Tool) => {
-    const wasDisabled = tool.status === "disabled" || tool.status === "not_installed";
-    const newStatus = wasDisabled ? "installed" : "disabled";
+    // A not-installed tool has nothing to "enable" — flipping the DB flag
+    // would just lie about its state. Route through the real streamed
+    // installer first (same mechanism CLIInstallAction uses), then enable
+    // once the binary actually lands.
+    if (tool.status === "not_installed") {
+      setTogglingSet((prev) => new Set(prev).add(tool.name));
+      try {
+        const code = await installDep(tool.name, () => {}, { mode: "install" });
+        if (code !== 0) {
+          addToast("error", `Install failed (exit ${code}) — ${tool.name} was not enabled`);
+          return;
+        }
+        await api.enableTool(tool.name);
+        addToast("success", `${tool.name} installed and enabled`);
+        setCheckedTools(null);
+        refresh();
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : `Failed to install ${tool.name}`;
+        addToast("error", msg);
+      } finally {
+        setTogglingSet((prev) => { const next = new Set(prev); next.delete(tool.name); return next; });
+      }
+      return;
+    }
+
+    const wasDisabled = tool.status === "disabled";
+    const newStatus = "installed";
     const oldStatus = tool.status;
 
     setOptimisticToggles((prev) => new Map(prev).set(tool.name, newStatus));

--- a/web/src/views/__tests__/ProviderDetail.test.tsx
+++ b/web/src/views/__tests__/ProviderDetail.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * ProviderDetail's Install / Update controls must be real, not decorative.
+ *
+ *  - Install streams the provider's install command through the same
+ *    POST /api/deps/install NDJSON path Tools.tsx uses (installDep), with
+ *    live output — never a "toast that echoes a hint" stub.
+ *  - When the install hint is a bare URL (no runnable command — e.g. a GUI
+ *    download page) there is nothing to execute, so the control honestly
+ *    falls back to a copyable hint instead of a fake "Install" button.
+ *  - Update streams a real re-install through POST /api/providers/:name/update.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { ProviderDetail } from "../ProviderDetail";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function streamResponse(chunks: string[]): Response {
+  const enc = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+
+function baseProvider(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "codex",
+    description: "OpenAI Codex CLI",
+    binary: "codex",
+    command: "codex",
+    install_hint: "npm install -g @openai/codex",
+    version: "",
+    status: "not_installed",
+    models: [],
+    total_cost_usd: 0,
+    total_tokens: 0,
+    agent_count: 0,
+    installed: false,
+    enabled: false,
+    config: {},
+    agents: [],
+    cost_by_model: [],
+    ...overrides,
+  };
+}
+
+function renderDetail(provider: ReturnType<typeof baseProvider>) {
+  fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+    const u = String(url);
+    if (u.endsWith("/commands")) return jsonResponse([]);
+    if (u.endsWith("/mcps")) return jsonResponse([]);
+    if (u === "/api/deps/install" && init?.method === "POST") {
+      return streamResponse([
+        '{"type":"start","command":"npm install -g @openai/codex"}\n',
+        '{"type":"log","line":"+ codex@1.2.4"}\n',
+        '{"type":"done","code":0}\n',
+      ]);
+    }
+    if (u.endsWith("/update") && init?.method === "POST") {
+      return streamResponse([
+        '{"type":"start","command":"npm install -g @openai/codex"}\n',
+        '{"type":"done","code":0}\n',
+      ]);
+    }
+    if (u === `/api/providers/${provider.name}`) return jsonResponse(provider);
+    return jsonResponse(provider);
+  });
+
+  return render(
+    <MemoryRouter initialEntries={[`/tools/${provider.name}`]}>
+      <Routes>
+        <Route path="/tools/:provider" element={<ProviderDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("ProviderDetail install", () => {
+  it("streams a real install via /api/deps/install for a runnable hint", async () => {
+    renderDetail(baseProvider());
+
+    const installBtn = await screen.findByRole("button", { name: "Install" });
+    fireEvent.click(installBtn);
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.filter(([u]) => u === "/api/deps/install");
+      expect(calls.length).toBe(1);
+    });
+    const [, init] = fetchMock.mock.calls.find(([u]) => u === "/api/deps/install") as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ id: "codex", mode: "install" });
+
+    // Live output renders in an aria-live region, and the button reflects
+    // real completion rather than an instant fake toast.
+    await waitFor(() => expect(screen.getByText("+ codex@1.2.4")).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole("button", { name: "Install again" })).toBeTruthy());
+  });
+
+  it("falls back to a copyable hint (not a fake Install button) when the hint is a bare URL", async () => {
+    renderDetail(baseProvider({ name: "cursor", install_hint: "https://cursor.sh" }));
+
+    await waitFor(() => expect(screen.getAllByText("https://cursor.sh").length).toBeGreaterThan(0));
+    expect(screen.queryByRole("button", { name: "Install" })).toBeNull();
+  });
+});
+
+describe("ProviderDetail update", () => {
+  it("streams a real update via POST /api/providers/:name/update", async () => {
+    renderDetail(baseProvider({ installed: true, version: "1.0.0", status: "healthy" }));
+
+    const updateBtn = await screen.findByRole("button", { name: "Update now" });
+    fireEvent.click(updateBtn);
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.filter(([u]) => u === "/api/providers/codex/update");
+      expect(calls.length).toBe(1);
+    });
+    const [, init] = fetchMock.mock.calls.find(([u]) => u === "/api/providers/codex/update") as [string, RequestInit];
+    expect(init.method).toBe("POST");
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Update again" })).toBeTruthy());
+  });
+
+  it("does not offer an Update action for a non-runnable install hint", async () => {
+    renderDetail(baseProvider({ name: "cursor", install_hint: "https://cursor.sh", installed: true, version: "1.0.0", status: "healthy" }));
+
+    await screen.findByText("cursor");
+    expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
+  it("check-update surfaces an honest 'couldn't verify' message when the server reports checked=false", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith("/commands")) return jsonResponse([]);
+      if (u.endsWith("/mcps")) return jsonResponse([]);
+      if (u.endsWith("/check-update") && init?.method === "POST") {
+        return jsonResponse({ current_version: "1.0.0", latest_version: "", update_command: "npm install -g @openai/codex", update_available: false, checked: false });
+      }
+      if (u === "/api/providers/codex") return jsonResponse(baseProvider({ installed: true, version: "1.0.0", status: "healthy" }));
+      return jsonResponse({});
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/tools/codex"]}>
+        <Routes>
+          <Route path="/tools/:provider" element={<ProviderDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const checkBtn = await screen.findByRole("button", { name: "Check for Update" });
+    fireEvent.click(checkBtn);
+
+    await waitFor(() => expect(screen.getByText(/couldn't verify the latest release automatically/)).toBeTruthy());
+  });
+});

--- a/web/src/views/__tests__/Tools.test.tsx
+++ b/web/src/views/__tests__/Tools.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Tools.tsx's "Enable" toggle for a not-installed CLI tool must not just
+ * flip a DB flag — there is nothing installed to enable. Clicking it should
+ * route through the real streamed installer (the same POST /api/deps/install
+ * mechanism CLIInstallAction uses) and only call enableTool once the
+ * install actually succeeds.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Tools } from "../Tools";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function streamResponse(chunks: string[]): Response {
+  const enc = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return { ok: true, status: 200, body } as unknown as Response;
+}
+
+const notInstalledTool = {
+  name: "wrangler",
+  type: "cli",
+  status: "not_installed",
+  required: false,
+  install_cmd: "npm install -g wrangler",
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+function renderTools() {
+  fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+    const u = String(url);
+    if (u === "/api/providers") return jsonResponse([]);
+    if (u === "/api/tools/unified") return jsonResponse([notInstalledTool]);
+    if (u === "/api/system/package-managers") return jsonResponse({ os: "darwin", arch: "arm64", managers: [] });
+    if (u === "/api/deps/install" && init?.method === "POST") {
+      return streamResponse([
+        '{"type":"start","command":"npm install -g wrangler"}\n',
+        '{"type":"done","code":0}\n',
+      ]);
+    }
+    if (u === "/api/tools/wrangler/enable" && init?.method === "POST") {
+      return jsonResponse({ enabled: true });
+    }
+    return jsonResponse({});
+  });
+
+  return render(
+    <MemoryRouter>
+      <Tools />
+    </MemoryRouter>,
+  );
+}
+
+describe("Tools CLI dependency toggle", () => {
+  it("routes a not-installed tool's Enable through a real install, then enables it", async () => {
+    renderTools();
+
+    const installBtn = await screen.findByRole("switch", { name: "Install and enable wrangler" });
+    expect(installBtn.textContent).toBe("Install");
+    fireEvent.click(installBtn);
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.filter(([u]) => u === "/api/deps/install");
+      expect(calls.length).toBe(1);
+    });
+    const [, installInit] = fetchMock.mock.calls.find(([u]) => u === "/api/deps/install") as [string, RequestInit];
+    expect(JSON.parse(installInit.body as string)).toEqual({ id: "wrangler", mode: "install" });
+
+    // enableTool only fires after the install stream reports success.
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.filter(([u]) => u === "/api/tools/wrangler/enable");
+      expect(calls.length).toBe(1);
+    });
+  });
+
+  it("does not call enableTool when the install fails", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
+      const u = String(url);
+      if (u === "/api/providers") return jsonResponse([]);
+      if (u === "/api/tools/unified") return jsonResponse([notInstalledTool]);
+      if (u === "/api/system/package-managers") return jsonResponse({ os: "darwin", arch: "arm64", managers: [] });
+      if (u === "/api/deps/install" && init?.method === "POST") {
+        return streamResponse(['{"type":"start","command":"npm install -g wrangler"}\n', '{"type":"done","code":1}\n']);
+      }
+      return jsonResponse({});
+    });
+
+    render(
+      <MemoryRouter>
+        <Tools />
+      </MemoryRouter>,
+    );
+
+    const installBtn = await screen.findByRole("switch", { name: "Install and enable wrangler" });
+    fireEvent.click(installBtn);
+
+    await waitFor(() => {
+      const calls = fetchMock.mock.calls.filter(([u]) => u === "/api/deps/install");
+      expect(calls.length).toBe(1);
+    });
+    // Give any (incorrect) enable call a chance to fire before asserting it didn't.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fetchMock.mock.calls.some(([u]) => u === "/api/tools/wrangler/enable")).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of #2674

## What changed

Per code review feedback (this PR started from a "relabel the dead buttons" plan, then was redirected mid-flight to "build the real feature instead" — the final PR does the latter throughout):

1. **Install (P0)** — `ProviderDetail`'s Install button now streams a genuine install through `POST /api/deps/install`, the exact NDJSON mechanism `Tools.tsx`'s `CLIInstallAction` already uses for CLI deps (the server resolves the provider's install hint via `providerInstallCmd` in `deps_install.go` — zero backend changes needed for this path). Live output renders in an `aria-live` console. When a provider's install hint is a bare URL (no runnable command — e.g. cursor's `https://cursor.sh` download page) there's nothing to execute; that one case honestly falls back to a copyable hint instead of a fake "Install" button.

2. **Check for Update (P0)** — `checkUpdate` now does a **real** npm-registry lookup: it parses the npm/npx package name out of the provider's `InstallHint` and queries `registry.npmjs.org` for the `latest` dist-tag (mirroring how `About.tsx` checks the daemon's own latest version). A new `checked` field on `UpdateCheck` is `true` only when a live comparison actually happened — for providers with no queryable registry (bare URL / curl-piped install) the UI shows an honest "couldn't verify the latest release automatically" instead of ever claiming "already on latest".

3. **Update — wired up, not deleted** — `POST /api/providers/:name/update` now genuinely re-runs the provider's install command (e.g. `npm install -g <pkg>`, which always resolves to the latest published version) and streams it as NDJSON via the same `streamInstall` engine `deps_install.go` already uses (in-package reuse, no duplicated process-running logic). The web UI gained a real streamed **"Update now"** action next to "Check for Update". `client.ts`'s old `updateProvider()` (a stub that only echoed the install hint back as a toast) is replaced by `streamProviderUpdate()`, which actually consumes the NDJSON stream.

4. **Tools "Enable" on a not-installed tool (bug)** — clicking "Enable" on a `not_installed` CLI tool now really installs it first (same streamed `/api/deps/install` path), and only calls `enableTool` once the install exits 0. The toggle's label/aria-label say "Install" for that state instead of pretending it's already enable-able.

5. **a11y** — `ProviderDetail`'s command-run `<pre>` output now has `role="status" aria-live="polite"`, matching the pattern already used in `Tools.tsx`.

## Design note

Both Install and Update stream through the *same* engine already proven in `deps_install.go` (`streamInstall`/`installRunner`, unit-tested there) — Update gets its own provider-scoped endpoint (`/api/providers/:name/update`) per direction to keep it a first-class, wired-up feature rather than overloading the generic deps endpoint, but it shares the actual process-execution code so there's no duplicated logic to drift.

## Files touched
- `server/handlers/providers.go` — real `checkUpdate` (npm registry), real streamed `update`, `UpdateCheck.Checked`, `runnableInstallHint`/`npmPackageForHint`/`fetchNpmLatestVersion` helpers
- `server/handlers/providers_update_test.go` (new) — checkUpdate (real compare / honest-unverified / registry-failure / not-installed) and update (streams real command / non-runnable refusal / loopback + method guards)
- `web/src/api/client.ts` — `ProviderUpdateCheck.checked`, `streamProviderUpdate` (replaces the old hint-echo `updateProvider`), removed dead `installProvider` (superseded by the shared `/api/deps/install` path)
- `web/src/api/__tests__/client.test.ts` — `streamProviderUpdate` NDJSON parsing tests
- `web/src/views/ProviderDetail.tsx` — real `InstallAction`/`UpdateAction` streamed controls, honest check-update messaging, aria-live command output
- `web/src/views/__tests__/ProviderDetail.test.tsx` (new)
- `web/src/views/Tools.tsx` — `not_installed` toggle routes through real install-then-enable
- `web/src/views/__tests__/Tools.test.tsx` (new)

## Test plan
- [x] `make build-local-web`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./server/...` → 0 issues
- [x] `go test ./server/handlers/... -race` → pass
- [x] `bun run test` (full vitest suite, 39 files / 332 tests) → pass
- [x] `bun run tsc --noEmit` / `bun run lint` → clean

Not merging — leaving for review per team policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)