### PR TITLE
fix(nav): correct browser back/forward across the app, no phantom pages

### DIFF
--- a/web/src/components/apps/GatewayFeed.tsx
+++ b/web/src/components/apps/GatewayFeed.tsx
@@ -758,12 +758,15 @@ export function GatewayFeed({
     (a) => a.state === "running" || a.state === "working",
   ).length;
 
+  // Navigates to the known parent (/apps) rather than navigate(-1): a
+  // channel can be reached by direct deep link (/apps/:sourceName) with no
+  // prior in-app history entry, so history.back() could pop out of the SPA.
   const headerTitle = useMemo(
     () => (
       <div className="flex items-center min-w-0" style={{ gap: 8 }}>
         <button
           type="button"
-          onClick={() => navigate(-1)}
+          onClick={() => navigate("/apps")}
           className="flex items-center justify-center shrink-0"
           style={{
             width: 22,

--- a/web/src/components/apps/__tests__/gatewayFeedBack.test.tsx
+++ b/web/src/components/apps/__tests__/gatewayFeedBack.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * GatewayFeed's "Go back" control must land on a known page, not rely on
+ * history.back(). A channel view (/apps/:sourceName) is reachable via a
+ * direct deep link or bookmark, so there is no guaranteed prior in-app
+ * history entry — navigate(-1) could pop the user out of the SPA entirely.
+ * navigate("/apps") always resolves to the Apps hub.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
+import { HeaderSlotProvider, useHeaderSlotContext } from "../../../context/HeaderSlotContext";
+import { GatewayFeed } from "../GatewayFeed";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function HeaderHost() {
+  const { slot } = useHeaderSlotContext();
+  return (
+    <div data-testid="header-host">
+      {slot.title}
+      {slot.actions}
+    </div>
+  );
+}
+
+// jsdom has no IntersectionObserver; GatewayFeed's infinite-scroll sentinel
+// only needs a no-op stand-in for this test.
+class FakeIntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockReturnValue(jsonResponse([]));
+  vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
+});
+
+describe("GatewayFeed", () => {
+  it("'Go back' navigates to /apps directly, even with no prior in-app history entry", async () => {
+    let lastPathname = "";
+    function LocationSpy() {
+      lastPathname = useLocation().pathname;
+      return null;
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/apps/slack:general"]}>
+        <LocationSpy />
+        <HeaderSlotProvider>
+          <HeaderHost />
+          <Routes>
+            <Route path="/apps" element={<div>Apps Home</div>} />
+            <Route
+              path="/apps/:sourceName"
+              element={<GatewayFeed channelName="slack:general" onPeekAgent={() => {}} />}
+            />
+          </Routes>
+        </HeaderSlotProvider>
+      </MemoryRouter>,
+    );
+
+    const backBtn = await screen.findByRole("button", { name: "Go back" });
+    fireEvent.click(backBtn);
+
+    await waitFor(() => {
+      expect(lastPathname).toBe("/apps");
+    });
+    expect(screen.getByText("Apps Home")).toBeInTheDocument();
+  });
+});

--- a/web/src/views/AppsActivity.tsx
+++ b/web/src/views/AppsActivity.tsx
@@ -126,12 +126,16 @@ export function AppsActivity() {
   }, []);
 
   /* ── Header slot: back + count · search · platform · channel ─── */
+  // Navigates to the known parent (/apps) rather than navigate(-1): this
+  // view is reachable via a replace-redirect (/notifications/activity) and
+  // via direct deep link, so there is no guaranteed prior in-app history
+  // entry — history.back() could pop the user out of the SPA entirely.
   useHeaderSlot({
     title: (
       <div className="flex items-center min-w-0 gap-2">
         <button
           type="button"
-          onClick={() => { navigate(-1); }}
+          onClick={() => { navigate("/apps"); }}
           className="flex items-center justify-center shrink-0 w-[22px] h-[22px] rounded-md text-mycel-muted hover:text-mycel-text"
           title="Go back"
           aria-label="Go back"

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { api } from "../api/client";
 import type {
@@ -984,6 +984,7 @@ function CommandsSection({ providerName, commands }: { providerName: string; com
 
 export function ProviderDetail() {
   const { provider: providerName } = useParams<{ provider: string }>();
+  const navigate = useNavigate();
   const { toasts, addToast, dismiss } = useToast();
   const [checkingUpdate, setCheckingUpdate] = useState(false);
   const [updateResult, setUpdateResult] = useState<{ checked: boolean; current: string; latest: string; available: boolean } | null>(null);
@@ -1071,7 +1072,11 @@ export function ProviderDetail() {
           title="Failed to load provider"
           description={error}
           actionLabel="Back to Tools"
-          onAction={() => window.history.back()}
+          // Navigate to the known parent (/tools) instead of
+          // window.history.back(): a deep-linked or bookmarked
+          // /tools/:provider URL has no guaranteed prior in-app history
+          // entry, so history.back() could exit the SPA entirely.
+          onAction={() => navigate("/tools")}
         />
       </div>
     );

--- a/web/src/views/__tests__/ProviderDetail.test.tsx
+++ b/web/src/views/__tests__/ProviderDetail.test.tsx
@@ -12,7 +12,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import { ProviderDetail } from "../ProviderDetail";
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
@@ -170,5 +170,43 @@ describe("ProviderDetail update", () => {
     fireEvent.click(checkBtn);
 
     await waitFor(() => expect(screen.getByText(/couldn't verify the latest release automatically/)).toBeTruthy());
+  });
+});
+
+describe("ProviderDetail error state", () => {
+  it("'Back to Tools' navigates to /tools directly instead of relying on history.back()", async () => {
+    // A deep-linked / bookmarked /tools/:provider URL has no guaranteed
+    // prior in-app history entry (single-entry MemoryRouter simulates
+    // that). window.history.back() would have no in-app destination to
+    // land on; navigate("/tools") always resolves to a known page.
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u === "/api/providers/ghost") return Promise.reject(new Error("not found"));
+      return jsonResponse([]);
+    });
+
+    let lastPathname = "";
+    function LocationSpy() {
+      lastPathname = useLocation().pathname;
+      return null;
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/tools/ghost"]}>
+        <LocationSpy />
+        <Routes>
+          <Route path="/tools" element={<div>Tools Page</div>} />
+          <Route path="/tools/:provider" element={<ProviderDetail />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const backBtn = await screen.findByRole("button", { name: "Back to Tools" });
+    fireEvent.click(backBtn);
+
+    await waitFor(() => {
+      expect(lastPathname).toBe("/tools");
+    });
+    expect(screen.getByText("Tools Page")).toBeInTheDocument();
   });
 });

--- a/web/src/views/__tests__/appsActivity.test.tsx
+++ b/web/src/views/__tests__/appsActivity.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter, Routes, Route, useLocation } from "react-router-dom";
 import { HeaderSlotProvider, useHeaderSlotContext } from "../../context/HeaderSlotContext";
 import { AppsActivity } from "../AppsActivity";
 
@@ -116,5 +116,39 @@ describe("AppsActivity", () => {
     fireEvent.change(screen.getByLabelText("Filter by app"), { target: { value: "telegram" } });
     expect(screen.getByText("standup in 5")).toBeInTheDocument();
     expect(screen.queryByText("ship it")).not.toBeInTheDocument();
+  });
+
+  it("'Go back' navigates to /apps directly, not history.back(), even with no prior in-app entry", async () => {
+    // /apps/activity is reachable via a replace-redirect (/notifications/activity)
+    // and via direct deep link — a single-entry MemoryRouter simulates that.
+    // navigate(-1) would have nowhere in-app to land; navigate("/apps") always
+    // resolves to a known page.
+    mockRoutes();
+    let lastPathname = "";
+    function LocationSpy() {
+      lastPathname = useLocation().pathname;
+      return null;
+    }
+
+    render(
+      <MemoryRouter initialEntries={["/apps/activity"]}>
+        <LocationSpy />
+        <HeaderSlotProvider>
+          <HeaderHost />
+          <Routes>
+            <Route path="/apps" element={<div>Apps Home</div>} />
+            <Route path="/apps/activity" element={<AppsActivity />} />
+          </Routes>
+        </HeaderSlotProvider>
+      </MemoryRouter>,
+    );
+
+    const backBtn = await screen.findByRole("button", { name: "Go back" });
+    fireEvent.click(backBtn);
+
+    await waitFor(() => {
+      expect(lastPathname).toBe("/apps");
+    });
+    expect(screen.getByText("Apps Home")).toBeInTheDocument();
   });
 });

--- a/web/src/views/__tests__/backSkipsRedirects.test.tsx
+++ b/web/src/views/__tests__/backSkipsRedirects.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * Every alias/redirect route (/live, /stats, /metrics, /costs, /notifications,
+ * /settings/tools, /providers, /secrets, /setup, ...) must resolve with
+ * `<Navigate replace>` so it never becomes a history entry the user can land
+ * back on. This suite proves that end-to-end with a real navigation stack:
+ * push a page, follow a link to an alias route, let it redirect, then press
+ * Back — the user must land on the page *before* the alias, in one step,
+ * never on the dead alias route itself (the "phantom page" bug).
+ *
+ * If a redirect ever regresses to a plain `navigate(x)` (push) or a
+ * `<Navigate>` without `replace`, these tests fail because Back would need
+ * two presses, or would land back on the alias route.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
+import { AppRoutes } from "../../App";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+let lastLocation = "";
+function LocationSpy() {
+  const loc = useLocation();
+  lastLocation = loc.pathname + loc.hash;
+  return null;
+}
+
+/** Stand-in for the browser's Back button, exercised through react-router's
+ *  own history stack (equivalent to a real Back press for a MemoryRouter). */
+function BackTrigger() {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate(-1)}>
+      test-back
+    </button>
+  );
+}
+
+function renderStack(entries: string[], initialIndex: number) {
+  return render(
+    <MemoryRouter initialEntries={entries} initialIndex={initialIndex}>
+      <LocationSpy />
+      <BackTrigger />
+      <AppRoutes />
+    </MemoryRouter>,
+  );
+}
+
+async function pressBackOnceAndExpect(path: string) {
+  fireEvent.click(screen.getByText("test-back"));
+  await waitFor(() => {
+    expect(lastLocation).toBe(path);
+  });
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockReturnValue(jsonResponse([]));
+  lastLocation = "";
+});
+
+describe("Back skips redirect/alias routes", () => {
+  it("/stats -> /insights: Back from /insights lands on the page before /stats, not on /stats", async () => {
+    renderStack(["/home", "/stats"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/insights"));
+
+    await pressBackOnceAndExpect("/home");
+  });
+
+  it("/metrics -> /insights: Back lands on the prior page in one step", async () => {
+    renderStack(["/home", "/metrics"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/insights"));
+
+    await pressBackOnceAndExpect("/home");
+  });
+
+  it("/costs -> /insights: Back lands on the prior page in one step", async () => {
+    renderStack(["/home", "/costs"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/insights"));
+
+    await pressBackOnceAndExpect("/home");
+  });
+
+  it("/live -> /: Back lands on the page before /live, not on the dead /live entry", async () => {
+    renderStack(["/agents", "/live"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/"));
+
+    await pressBackOnceAndExpect("/agents");
+  });
+
+  it("/notifications -> /apps: Back lands on the prior page in one step", async () => {
+    renderStack(["/home", "/notifications"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/apps"));
+
+    await pressBackOnceAndExpect("/home");
+  });
+
+  it("/settings/tools -> /tools: Back lands on the prior page in one step", async () => {
+    renderStack(["/settings", "/settings/tools"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/tools"));
+
+    await pressBackOnceAndExpect("/settings");
+  });
+
+  it("/providers -> /tools: Back lands on the prior page in one step", async () => {
+    renderStack(["/home", "/providers"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/tools"));
+
+    await pressBackOnceAndExpect("/home");
+  });
+
+  it("/secrets -> /apps#custom-keys: Back lands on the prior page in one step", async () => {
+    renderStack(["/home", "/secrets"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/apps#custom-keys"));
+
+    await pressBackOnceAndExpect("/home");
+  });
+
+  it("/setup -> /readiness: Back lands on the prior page in one step", async () => {
+    renderStack(["/home", "/setup"], 1);
+    await waitFor(() => expect(lastLocation).toBe("/readiness"));
+
+    await pressBackOnceAndExpect("/home");
+  });
+});


### PR DESCRIPTION
Part of #3423

## Root cause

The route table's redirect/alias routes (`/live`, `/stats`, `/metrics`, `/costs`, `/notifications*`, `/settings/tools*`, `/providers`, `/secrets`, `/setup`) already resolve via `<Navigate replace>`, and `Layout.tsx`'s `RouteTransition` already keys the fade/lift animation on the first path segment (not on an unstable per-drill-down key), so those two commonly-blamed sources of "phantom page" bugs were already fixed in earlier PRs.

The actual remaining bug: three **in-app "Go back" controls** used `navigate(-1)` / `window.history.back()` instead of navigating to a known route:

- `web/src/components/apps/GatewayFeed.tsx` — the channel-view back button (`/apps/:sourceName`)
- `web/src/views/AppsActivity.tsx` — the `/apps/activity` back button
- `web/src/views/ProviderDetail.tsx` — the error-state "Back to Tools" action (`/tools/:provider`)

All three of those routes are reachable via a **direct deep link/bookmark** or via a **replace-redirect** (e.g. `/notifications/<source>` → `/apps/<source>`, `/settings/tools/<provider>` → `/tools/<provider>`). In either case there is no guaranteed prior *in-app* history entry. Pressing the in-app Back button in that state either did nothing (MemoryRouter/no-op) or popped the user out of the SPA entirely to whatever page preceded it in the tab's real history — read by the owner as "back doesn't work" and landing on a phantom/wrong page.

## Fix

Replaced all three with a direct `navigate(...)` to the known parent route:
- `GatewayFeed` → `navigate("/apps")`
- `AppsActivity` → `navigate("/apps")`
- `ProviderDetail` error state → `navigate("/tools")` (added `useNavigate`, replacing `window.history.back()`)

This makes those back buttons deterministic regardless of how the page was reached (browser Back/Forward continue to work as before via the browser chrome itself — this only fixes the app's own back *button*).

## Specific scenarios now correct
- Deep-link/bookmark `/apps/slack:general` → click in-app "Go back" → lands on `/apps` (previously: no-op / left the SPA).
- `/notifications/general` → replace-redirect to `/apps/general` → click "Go back" → lands on `/apps` (previously: could exit the SPA since the replaced entry left no in-app "before" state).
- Deep-link `/tools/ghost` (fetch fails) → click "Back to Tools" → lands on `/tools` (previously used `window.history.back()`).
- `/apps/activity` reached via `/notifications/activity` replace-redirect → click "Go back" → lands on `/apps`.

## Tests
- `web/src/views/__tests__/backSkipsRedirects.test.tsx` (new) — drives `AppRoutes` through a real react-router history stack (`MemoryRouter` with a 2-entry stack) for every alias route (`/stats`, `/metrics`, `/costs`, `/live`, `/notifications`, `/settings/tools`, `/providers`, `/secrets`, `/setup`) and asserts Back lands on the page *before* the alias in exactly one press — proven to catch a regression (temporarily reverted one route to non-`replace` and confirmed the test fails, landing back on the dead alias route instead).
- `web/src/components/apps/__tests__/gatewayFeedBack.test.tsx` (new) — single-entry `MemoryRouter` (simulates a deep link with no prior in-app history) asserts the channel view's "Go back" lands on `/apps`.
- `web/src/views/__tests__/appsActivity.test.tsx` — added the same case for `/apps/activity`.
- `web/src/views/__tests__/ProviderDetail.test.tsx` — added the case for the error-state "Back to Tools" button.

`make build-local-web` and `make test-web` (394 tests, 48 files) both pass; `bun run lint` clean.

## Test plan
- [x] `make build-local-web`
- [x] `make test-web` (all 394 tests pass)
- [x] `bun run lint` (clean)
- [x] Manually confirmed the new redirect-regression test fails when a redirect route is changed to non-`replace`, then restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)