### PR TITLE
fix(live): show tool-call description as the row title

### DIFF
--- a/server/handlers/agents_activity.go
+++ b/server/handlers/agents_activity.go
@@ -19,15 +19,21 @@ type activityItem struct { //nolint:govet // field order matches JSON contract
 
 // toActivityItem normalizes an events.Event into the timeline DTO consumed by
 // both the per-agent activity timeline and the cross-agent Live hydration
-// endpoint. The mapping rules (tool_name + tool_input.command > message, plus
-// hook./agent. prefix stripping) live here so both surfaces stay in sync.
+// endpoint. The mapping rules (tool_name + tool_input.description/command >
+// message, plus hook./agent. prefix stripping) live here so both surfaces
+// stay in sync.
 func toActivityItem(e events.Event, includeAgent bool) activityItem {
 	msg := ""
 	if e.Data != nil {
 		if toolName, ok := e.Data["tool_name"].(string); ok && toolName != "" {
 			msg = toolName
 			if toolInput, ok2 := e.Data["tool_input"].(map[string]any); ok2 {
-				if cmd, ok3 := toolInput["command"].(string); ok3 && cmd != "" {
+				// Prefer the human-written description (e.g. a Bash call's
+				// one-line summary) over the raw command — it is the richer
+				// title and is what the web UI's row title should show.
+				if desc, ok3 := toolInput["description"].(string); ok3 && desc != "" {
+					msg += ": " + desc
+				} else if cmd, ok3 := toolInput["command"].(string); ok3 && cmd != "" {
 					msg += ": " + cmd
 				}
 			}

--- a/server/handlers/agents_activity_description_test.go
+++ b/server/handlers/agents_activity_description_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/events"
+)
+
+// TestToActivityItem_PrefersDescriptionOverCommand covers the row-title gap
+// from #3423: a Bash tool call carries a human-written `description` in its
+// tool_input (e.g. "Check rebuild completion") alongside the raw `command`.
+// The activity timeline's Message field used to key off tool_name+command
+// only, making rows read as cryptic shell one-liners. It must now prefer
+// the description when present.
+func TestToActivityItem_PrefersDescriptionOverCommand(t *testing.T) {
+	e := events.Event{
+		Type: "hook.PreToolUse",
+		Data: map[string]any{
+			"tool_name": "Bash",
+			"tool_input": map[string]any{
+				"command":     "cd /repo && grep -rn foo .",
+				"description": "Check rebuild completion",
+			},
+		},
+	}
+
+	item := toActivityItem(e, false)
+
+	want := "Bash: Check rebuild completion"
+	if item.Message != want {
+		t.Fatalf("Message = %q, want %q", item.Message, want)
+	}
+}
+
+// TestToActivityItem_FallsBackToCommandWithoutDescription ensures tools (or
+// Bash calls) that don't supply a description keep the previous behavior of
+// surfacing the raw command rather than going blank.
+func TestToActivityItem_FallsBackToCommandWithoutDescription(t *testing.T) {
+	e := events.Event{
+		Type: "hook.PreToolUse",
+		Data: map[string]any{
+			"tool_name": "Bash",
+			"tool_input": map[string]any{
+				"command": "ls -la",
+			},
+		},
+	}
+
+	item := toActivityItem(e, false)
+
+	want := "Bash: ls -la"
+	if item.Message != want {
+		t.Fatalf("Message = %q, want %q", item.Message, want)
+	}
+}
+
+// TestToActivityItem_ToolWithoutInputFallsBackToToolName covers a tool_name
+// with no tool_input at all (e.g. a lifecycle-ish hook) — the row still
+// gets a title rather than an empty Message.
+func TestToActivityItem_ToolWithoutInputFallsBackToToolName(t *testing.T) {
+	e := events.Event{
+		Type: "hook.PreToolUse",
+		Data: map[string]any{
+			"tool_name": "Read",
+		},
+	}
+
+	item := toActivityItem(e, false)
+
+	if item.Message != "Read" {
+		t.Fatalf("Message = %q, want %q", item.Message, "Read")
+	}
+}

--- a/web/src/components/live/AgentCard.test.tsx
+++ b/web/src/components/live/AgentCard.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * AgentCard.test.tsx — the Live page agent card header toolbar (#3423
+ * follow-up).
+ *
+ * Invariants:
+ *   - The running count is shown in exactly ONE place: the pinned
+ *     "Running n" section header. The old redundant "n running" chip in
+ *     the card header toolbar is gone, so the count never renders twice.
+ *   - Cost + tokens render as quiet, tabular-nums secondary metadata.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AgentCard } from "./LiveRenderers";
+import type { AgentActivity, ToolNode } from "./liveTypes";
+
+function runningNode(overrides: Partial<ToolNode> = {}): ToolNode {
+  return {
+    id: "r1",
+    toolName: "Bash",
+    args: "npm run build",
+    fullInput: null,
+    fullOutput: null,
+    status: "running",
+    startTime: Date.now() - 2000,
+    endTime: undefined,
+    children: [],
+    ...overrides,
+  };
+}
+
+function activity(overrides: Partial<AgentActivity> = {}): AgentActivity {
+  return {
+    name: "eng-01",
+    state: "working",
+    task: "",
+    tool: "claude",
+    role: "base",
+    tokens: 12000,
+    inputTokens: 8000,
+    outputTokens: 4000,
+    costUsd: 0.42,
+    lastEventTime: Date.now(),
+    nodes: [runningNode()],
+    collapsed: false,
+    ...overrides,
+  };
+}
+
+function renderCard(a: AgentActivity) {
+  return render(
+    <MemoryRouter>
+      <AgentCard
+        activity={a}
+        onToggle={vi.fn()}
+        onDrillDown={vi.fn()}
+        isFilterActive={false}
+        searchTerm=""
+        typeFilter="all"
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("AgentCard header toolbar", () => {
+  it("shows the running count exactly once — in the pinned section header, not the toolbar", () => {
+    renderCard(activity({ nodes: [runningNode()] }));
+
+    // The pinned "Running" section header labels the running rows once.
+    expect(screen.getByText("Running")).toBeTruthy();
+
+    // The old toolbar chip ("1 running") is gone — no element pairs the
+    // count with the word "running" anywhere in the card.
+    expect(screen.queryByText(/\d+\s+running/i)).toBeNull();
+  });
+
+  it("renders cost and tokens as quiet tabular-nums secondary metadata", () => {
+    renderCard(activity({ costUsd: 0.42, tokens: 12000 }));
+
+    // Both figures live inside the muted, tabular-nums metadata cluster
+    // (font-variant-numeric inherits, so the class sits on the container).
+    const cost = screen.getByText("$0.42");
+    expect(cost).toBeTruthy();
+    expect(cost.closest(".tabular-nums")).not.toBeNull();
+
+    const tokens = screen.getByText("12,000 tok");
+    expect(tokens).toBeTruthy();
+    expect(tokens.closest(".tabular-nums")).not.toBeNull();
+  });
+});

--- a/web/src/components/live/EventRow.test.tsx
+++ b/web/src/components/live/EventRow.test.tsx
@@ -166,10 +166,23 @@ describe("activityItemToNode + historical expansion", () => {
       data: { tool_name: "Bash", tool_input: { command: "git status", description: "Show status" } },
     });
     expect(n.toolName).toBe("Bash");
+    // The description is the richer title (#3423) — the raw command still
+    // rides along in fullInput for the expanded detail view.
+    expect(n.args).toBe("Show status");
     expect(n.fullInput).toEqual({ command: "git status", description: "Show status" });
     expect(n.status).toBe("completed");
     // Duration is genuinely unknown for historical rows.
     expect(n.endTime).toBeUndefined();
+  });
+
+  it("falls back to the raw command when a Bash tool_input has no description", () => {
+    const n = activityItemToNode({
+      timestamp: "2026-07-30T10:00:00.000Z",
+      event: "PreToolUse",
+      message: "Bash: git status",
+      data: { tool_name: "Bash", tool_input: { command: "git status" } },
+    });
+    expect(n.args).toBe("git status");
   });
 
   it("marks a historical row failed when the event recorded an error", () => {

--- a/web/src/components/live/LiveRenderers.tsx
+++ b/web/src/components/live/LiveRenderers.tsx
@@ -429,7 +429,6 @@ export const AgentCard = memo(function AgentCard({
   const shownNodes = restNodes.slice(0, LIVE_CARD_MAX_ROWS);
   const hiddenCount = restNodes.length - shownNodes.length;
 
-  const runningCount = runningNodes.length;
   const errorCount = flatNodes.filter((n) => n.status === "failed").length;
   const matchCount = searchTerm ? visibleNodes.length : 0;
   const showToolNodes = typeFilter !== "state";
@@ -448,7 +447,7 @@ export const AgentCard = memo(function AgentCard({
         <button
           type="button"
           onClick={(e) => { e.stopPropagation(); onToggle(); }}
-          className="flex items-center gap-3 px-3 py-3 hover:bg-mycel-surface-hover transition-colors text-left focus-visible:ring-2 focus-visible:ring-mycel-accent shrink-0"
+          className="flex items-center justify-center min-h-[44px] min-w-[44px] hover:bg-mycel-surface-hover transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent shrink-0"
           aria-label={`${activity.collapsed ? "Expand" : "Collapse"} ${activity.name} tool list`}
         >
           <motion.svg
@@ -522,31 +521,27 @@ export const AgentCard = memo(function AgentCard({
             </span>
           )}
 
-          <span className="ml-auto flex items-center gap-3 shrink-0">
-            {runningCount > 0 && (
-              <span className="text-[11px] text-mycel-accent font-mono tabular-nums">
-                {runningCount} running
-              </span>
-            )}
-            {/* Cost -- prominent */}
+          {/* Quiet secondary metadata — cost + tokens as muted, right-
+              aligned figures (tabular-nums so they don't jitter). The
+              running count is intentionally NOT shown here: the pinned
+              "Running n" section header below already labels it, and
+              duplicating it in the toolbar was noise. */}
+          <span className="ml-auto flex items-center gap-3 shrink-0 text-[11px] font-mono tabular-nums text-mycel-muted">
             {cost > 0 && (
-              <span className="text-xs font-semibold text-mycel-success font-mono tabular-nums px-1.5 py-0.5 rounded bg-mycel-success-subtle" title={activity.costUsd > 0 ? "From API" : "Estimated from tokens"}>
+              <span className="text-mycel-text-2" title={activity.costUsd > 0 ? "From API" : "Estimated from tokens"}>
                 ${cost.toFixed(2)}
               </span>
             )}
-            {/* Tokens */}
             {activity.tokens > 0 && (
-              <span className="text-[11px] text-mycel-muted font-mono tabular-nums">
-                {activity.tokens.toLocaleString()} tok
-              </span>
+              <span>{activity.tokens.toLocaleString()} tok</span>
             )}
             {/* Idle chip */}
             {isIdle && activity.lastEventTime > 0 && (
-              <span className="text-[10px] text-mycel-muted font-mono px-1.5 py-0.5 rounded bg-mycel-surface-hover">
+              <span className="text-[10px] px-1.5 py-0.5 rounded bg-mycel-surface-hover">
                 <IdleTimer lastEventTime={activity.lastEventTime} />
               </span>
             )}
-            <span className="text-[11px] text-mycel-muted group-hover:text-mycel-accent transition-colors hidden sm:inline">
+            <span className="text-mycel-muted group-hover:text-mycel-accent transition-colors hidden sm:inline">
               &rarr;
             </span>
           </span>

--- a/web/src/views/Agents.peekItemToNode.test.tsx
+++ b/web/src/views/Agents.peekItemToNode.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Agents.peekItemToNode.test.tsx — unit tests for the Peek Activity Feed's
+ * historical-row normalization (#3423).
+ *
+ * The Agents list row's "peek" preview used to build its row title from the
+ * server's flat `message` string ("Bash: cd /repo && grep -rn foo ."),
+ * which only ever carried the raw command. Bash tool calls carry a
+ * human-written `tool_input.description` (e.g. "Check rebuild completion")
+ * that was being ignored. `peekItemToNode` now delegates to the shared
+ * `activityItemToNode` (the same normalization the Live/Raw stream uses)
+ * so a row reads identically everywhere and prefers the description.
+ */
+
+import { describe, it, expect } from "vitest";
+import { peekItemToNode } from "./Agents";
+import type { AgentActivityItem } from "../api/client";
+
+describe("peekItemToNode", () => {
+  it("prefers tool_input.description as the row title for a Bash call", () => {
+    const item: AgentActivityItem = {
+      timestamp: "2026-08-01T10:00:00.000Z",
+      event: "PreToolUse",
+      message: "Bash: cd /repo && grep -rn foo .",
+      data: {
+        tool_name: "Bash",
+        tool_input: {
+          command: "cd /repo && grep -rn foo .",
+          description: "Check rebuild completion",
+        },
+      },
+    };
+
+    const node = peekItemToNode(item, 0);
+
+    expect(node.toolName).toBe("Bash");
+    expect(node.args).toBe("Check rebuild completion");
+    // The raw command is not lost — it stays available in the expanded detail.
+    expect(node.fullInput).toEqual({
+      command: "cd /repo && grep -rn foo .",
+      description: "Check rebuild completion",
+    });
+  });
+
+  it("falls back to the raw command when no description is present", () => {
+    const item: AgentActivityItem = {
+      timestamp: "2026-08-01T10:00:00.000Z",
+      event: "PreToolUse",
+      message: "Bash: ls -la",
+      data: { tool_name: "Bash", tool_input: { command: "ls -la" } },
+    };
+
+    const node = peekItemToNode(item, 0);
+
+    expect(node.toolName).toBe("Bash");
+    expect(node.args).toBe("ls -la");
+  });
+
+  it("degrades gracefully to the message when there is no structured tool_input", () => {
+    const item: AgentActivityItem = {
+      timestamp: "2026-08-01T10:00:00.000Z",
+      event: "Stop",
+      message: "Turn complete",
+    };
+
+    const node = peekItemToNode(item, 0);
+
+    // No data.tool_name is present, so the title is derived from the
+    // message (same as the Live/Raw stream's historical hydration path),
+    // and the message doubles as the row summary.
+    expect(node.toolName).toBe("Turn");
+    expect(node.args).toBe("Turn complete");
+  });
+
+  it("re-keys the id per index so peek rows stay stable within the feed", () => {
+    const item: AgentActivityItem = {
+      timestamp: "2026-08-01T10:00:00.000Z",
+      event: "PreToolUse",
+      data: { tool_name: "Read", tool_input: { file_path: "/repo/main.go" } },
+    };
+
+    const node = peekItemToNode(item, 3);
+    expect(node.id).toBe(`peek-${item.timestamp}-3`);
+  });
+});

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -7,6 +7,7 @@ import { useWebSocket } from "../hooks/useWebSocket";
 import { StatusBadge } from "../components/StatusBadge";
 import { EmptyState } from "../components/EmptyState";
 import { EventRow } from "../components/live/EventRow";
+import { activityItemToNode } from "../components/live/liveHelpers";
 import type { ToolNode } from "../components/live/liveTypes";
 import { truncate } from "../utils/text";
 import { formatAbsolute, formatRelative } from "../utils/time";
@@ -162,29 +163,15 @@ function formatCostCompact(n: number): string {
 const PEEK_EVENT_LIMIT = 12;
 
 /** Turn a persisted activity row into a ToolNode for the shared EventRow.
- *  Same normalization the Live hydration path uses: tool_name from the
- *  event data when present, message stripped of its "Tool: " prefix as
- *  the summary, raw event data as the expandable input JSON. */
-function peekItemToNode(item: AgentActivityItem, idx: number): ToolNode {
-  const toolName =
-    typeof item.data?.tool_name === "string" && item.data.tool_name !== ""
-      ? item.data.tool_name
-      : item.event || "unknown";
-  let args = item.message ?? "";
-  if (args.startsWith(`${toolName}: `)) args = args.slice(toolName.length + 2);
-  else if (args === toolName) args = "";
-  const ts = item.timestamp ? Date.parse(item.timestamp) : NaN;
-  return {
-    id: `peek-${item.timestamp}-${String(idx)}`,
-    toolName,
-    args,
-    fullInput: item.data ?? null,
-    fullOutput: item.data?.tool_response ?? null,
-    status: "completed",
-    startTime: Number.isNaN(ts) ? Date.now() : ts,
-    endTime: undefined,
-    children: [],
-  };
+ *  Delegates to the same `activityItemToNode` the Live hydration path uses
+ *  so a row reads identically here and in the full Live/Raw stream —
+ *  preferring the human-written `tool_input.description` (e.g. a Bash
+ *  call's one-line summary) over the raw command, and falling back to the
+ *  historical message only when no structured tool_input is present. Only
+ *  the id is re-keyed so peek rows stay stable within this feed. */
+export function peekItemToNode(item: AgentActivityItem, idx: number): ToolNode {
+  const node = activityItemToNode(item);
+  return { ...node, id: `peek-${item.timestamp}-${String(idx)}` };
 }
 
 /** The ⊕-row content: the agent's recent hook events rendered with the


### PR DESCRIPTION
Part of #3423

This PR bundles two changes to the Live-feed rendering code (they touch the same files, so they ship together to avoid a conflict).

## 1. Show tool-call description as the row title
- The Agents list's Peek Activity Feed rendered its row title from the server's flat activity `Message` field ("Bash: cd /repo && grep -rn foo ."), so rows read as raw shell one-liners instead of the tool call's human-written `description` ("Check rebuild completion"). Its normalizer (`peekItemToNode` in `web/src/views/Agents.tsx`) reimplemented a simpler parse of that string instead of reusing the shared `activityItemToNode`/`extractToolMetadata` path the Live tab and historical hydration already use, which already prefers `tool_input.description`.
- `peekItemToNode` now delegates to `activityItemToNode` (only re-keying the id), so the Peek feed, the Live tab, and the historical-reload path all render a row identically — description as title, raw command still available in the expanded input detail.
- `server/handlers/agents_activity.go`'s `toActivityItem` now prefers `tool_input.description` over `tool_input.command` when building the activity `Message`, matching the web UI's preference (the fallback text used when a row has no structured `tool_input`, and the field returned by the REST activity endpoints).
- Traced that `tool_input.description` survives the full pipeline: the Bash hook payload's full `tool_input` map is captured in `pkg/agent/hook_ingest.go`'s `hookPayloadFields` and lands unmodified in both the event log `Data` and the SSE payload — no gap there.

## 2. Agent card header toolbar: dedupe + redesign
`web/src/components/live/LiveRenderers.tsx` (`AgentCard` header).
- **Deduped the running count:** the header showed a "n running" chip AND the pinned "Running n" section header immediately below — the same info twice. Dropped the toolbar chip; the "Running n" section header (which labels the pinned running rows) is now the single source.
- **Calmer hierarchy:** name + live state stay the primary element; cost + tokens are demoted from a loud green cost chip to quiet, right-aligned, muted `tabular-nums` figures (cost slightly stronger in `text-2`, tokens muted). Removed the redundant free-text status noise; the live rows already show tool status.
- **Accessibility:** the expand/collapse chevron now has a 44x44px minimum touch target; cost/token figures use `tabular-nums`; kept the existing coffee-cream/mushroom design tokens — no new visual language, just less noise and tighter alignment.

## Test plan
- [x] `make build-local-web`
- [x] `bunx vitest run` (web) — 48 files / 389 tests pass
- [x] `go test ./server/handlers/...` — pass
- [x] `golangci-lint run ./server/handlers/...` — 0 issues
- [x] `bun run lint` (eslint) — clean
- [x] New tests:
  - `server/handlers/agents_activity_description_test.go`: Bash event with `tool_input.description` renders the description in `Message`; falls back to `command` when no description; falls back to bare tool name when there's no `tool_input`.
  - `web/src/views/Agents.peekItemToNode.test.tsx`: Peek feed row prefers `tool_input.description` as the title, keeps the raw command in `fullInput`, falls back to command/message when no description.
  - `web/src/components/live/AgentCard.test.tsx`: running count renders exactly once (section header only, no toolbar chip); cost/tokens are `tabular-nums` secondary metadata.
  - `web/src/components/live/EventRow.test.tsx`: added assertions that `activityItemToNode`'s `args` prefers the description, plus a fallback case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)