### PR TITLE
feat(providers): cache install/version, uninstall endpoint, version/help cmds, tools auto-detect

### DIFF
--- a/pkg/provider/claude.go
+++ b/pkg/provider/claude.go
@@ -111,6 +111,7 @@ func (p *ClaudeProvider) Commands() []Command {
 		{Name: "config set", Command: "claude config set <key> <value>", Description: "Set config value", Args: "<key> <value>"},
 		{Name: "config list", Command: "claude config list", Description: "List config values"},
 		{Name: "version", Command: "claude --version", Description: "Show version"},
+		{Name: "help", Command: "claude --help", Description: "Show CLI help"},
 		{Name: "resume", Command: "claude --resume <id>", Description: "Resume session", Args: "<session-id>", Interactive: true},
 	}
 }

--- a/pkg/provider/commands.go
+++ b/pkg/provider/commands.go
@@ -29,6 +29,7 @@ func (p *CodexProvider) Commands() []Command {
 		{Name: "mcp list", Command: "codex mcp list", Description: "List configured MCP servers"},
 		{Name: "mcp add", Command: "codex mcp add <name> -- <command>", Description: "Add an MCP server", Args: "<name> -- <command>"},
 		{Name: "version", Command: "codex --version", Description: "Show version"},
+		{Name: "help", Command: "codex --help", Description: "Show CLI help"},
 	}
 }
 
@@ -43,6 +44,7 @@ func (p *PiProvider) Commands() []Command {
 		{Name: "resume", Command: "pi --resume", Description: "Pick a session to resume", Interactive: true},
 		{Name: "session", Command: "pi --session <id>", Description: "Resume a specific session", Args: "<session-id>"},
 		{Name: "version", Command: "pi --version", Description: "Show version"},
+		{Name: "help", Command: "pi --help", Description: "Show CLI help"},
 	}
 }
 
@@ -55,6 +57,7 @@ func (p *AgyProvider) Commands() []Command {
 		{Name: "continue", Command: "agy --continue", Description: "Continue the previous conversation", Interactive: true},
 		{Name: "conversation", Command: "agy --conversation <uuid>", Description: "Resume a specific conversation", Args: "<uuid>"},
 		{Name: "version", Command: "agy --version", Description: "Show version"},
+		{Name: "help", Command: "agy --help", Description: "Show CLI help"},
 	}
 }
 
@@ -68,6 +71,7 @@ func (p *CursorProvider) Commands() []Command {
 		{Name: "model", Command: "cursor-agent --model <model>", Description: "Run with a specific model", Args: "<model>"},
 		{Name: "resume", Command: "cursor-agent --resume <id>", Description: "Resume a session", Args: "<session-id>"},
 		{Name: "version", Command: "cursor-agent --version", Description: "Show version"},
+		{Name: "help", Command: "cursor-agent --help", Description: "Show CLI help"},
 	}
 }
 

--- a/pkg/provider/commands_test.go
+++ b/pkg/provider/commands_test.go
@@ -50,3 +50,46 @@ func TestCuratedCommands(t *testing.T) {
 		})
 	}
 }
+
+// TestCuratedCommands_VersionAndHelpRunnable covers PR #3423's fill: every
+// first-party provider must expose a "version" and "help" entry, and both
+// must be Runnable() — no TTY, no args, no unresolved placeholder — so the
+// web UI's guarded POST /api/providers/{name}/run can execute them inline
+// instead of only offering "copy + run in your terminal".
+func TestCuratedCommands_VersionAndHelpRunnable(t *testing.T) {
+	names := []string{"claude", "codex", "pi", "agy", "cursor", "openclaw"}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			p, ok := DefaultRegistry.Get(name)
+			if !ok {
+				t.Fatalf("provider %q not registered", name)
+			}
+			cl, ok := p.(CommandLister)
+			if !ok {
+				t.Fatalf("provider %q does not implement CommandLister", name)
+			}
+			cmds := cl.Commands()
+
+			var version, help *Command
+			for i := range cmds {
+				switch cmds[i].Name {
+				case "version":
+					version = &cmds[i]
+				case "help":
+					help = &cmds[i]
+				}
+			}
+			if version == nil {
+				t.Errorf("provider %q has no %q command", name, "version")
+			} else if !version.Runnable() {
+				t.Errorf("provider %q %q command %+v is not Runnable", name, "version", *version)
+			}
+			if help == nil {
+				t.Errorf("provider %q has no %q command", name, "help")
+			} else if !help.Runnable() {
+				t.Errorf("provider %q %q command %+v is not Runnable", name, "help", *help)
+			}
+		})
+	}
+}

--- a/pkg/provider/mcpconfig_test.go
+++ b/pkg/provider/mcpconfig_test.go
@@ -36,8 +36,8 @@ const mcpJSONFixture = `{
 
 func TestClaudeCommands(t *testing.T) {
 	cmds := NewClaudeProvider().Commands()
-	if len(cmds) != 7 {
-		t.Fatalf("len(Commands()) = %d, want 7", len(cmds))
+	if len(cmds) != 8 {
+		t.Fatalf("len(Commands()) = %d, want 8", len(cmds))
 	}
 	if cmds[0].Name != "mcp add" || cmds[0].Args != "<name> <command|url>" {
 		t.Errorf("first command = %+v, want mcp add", cmds[0])

--- a/pkg/tool/health.go
+++ b/pkg/tool/health.go
@@ -1,0 +1,68 @@
+package tool
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// HealthResult is the outcome of a single tool's health check.
+type HealthResult struct { //nolint:govet // field order matches JSON/API contract
+	Name   string `json:"name"`
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Error  string `json:"error,omitempty"`
+}
+
+// checkOne inspects t's install status via exec.LookPath. It never shells
+// out beyond a PATH lookup, so it is safe to run unattended and frequently.
+func checkOne(t *Tool) HealthResult {
+	r := HealthResult{Name: t.Name, Type: t.Type, Status: "ok"}
+	switch t.Type {
+	case ToolTypeMCP:
+		if t.Transport == "stdio" && t.Command != "" {
+			cmd := strings.Fields(t.Command)[0]
+			if _, err := exec.LookPath(cmd); err != nil {
+				r.Status = "error"
+				r.Error = "command not found: " + cmd
+			}
+		}
+	case ToolTypeCLI, ToolTypeProvider:
+		fields := strings.Fields(t.Command)
+		if len(fields) == 0 {
+			r.Status = "not_installed"
+			r.Error = "no command configured"
+			break
+		}
+		if _, err := exec.LookPath(fields[0]); err != nil {
+			r.Status = "not_installed"
+			r.Error = "not found in PATH"
+		} else {
+			r.Status = "installed"
+		}
+	}
+	return r
+}
+
+// CheckAll runs a health check on every stored tool and persists fresh
+// health_status + last_checked back via UpdateHealth, so subsequent
+// List/Get calls serve recently-verified status rather than the seed-time
+// default. Used by both the manual force-refresh endpoint
+// (POST /api/tools/check) and the background auto-check loop started at
+// daemon boot. A persistence failure for one tool does not abort the batch.
+func (s *Store) CheckAll(ctx context.Context) ([]HealthResult, error) {
+	tools, err := s.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	results := make([]HealthResult, 0, len(tools))
+	for _, t := range tools {
+		r := checkOne(t)
+		results = append(results, r)
+		_ = s.UpdateHealth(ctx, t.Name, r.Status, now) //nolint:errcheck // best-effort per-tool; batch continues regardless
+	}
+	return results, nil
+}

--- a/pkg/tool/health_test.go
+++ b/pkg/tool/health_test.go
@@ -1,0 +1,93 @@
+package tool
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// TestCheckAll_PersistsHealthStatus covers the bug the background
+// auto-check is meant to fix (#3423): CheckAll must not just return
+// ephemeral results, it must persist health_status + last_checked back to
+// the store via UpdateHealth so a subsequent Get/List sees fresh data
+// without requiring a client to have called checkAll first.
+func TestCheckAll_PersistsHealthStatus(t *testing.T) {
+	s := NewStore(setupSharedDB(t), "sqlite")
+	if err := s.Open(); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close() //nolint:errcheck // test cleanup
+
+	ctx := context.Background()
+
+	// A CLI tool pointing at a binary that is guaranteed to be on PATH in
+	// any test environment ("sh"), so CheckAll deterministically marks it
+	// installed rather than depending on what happens to be on the runner.
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not found on PATH; cannot exercise a deterministic installed case")
+	}
+	installedTool := &Tool{Name: "health-check-installed", Type: ToolTypeCLI, Command: shPath, Enabled: true}
+	if addErr := s.Add(ctx, installedTool); addErr != nil {
+		t.Fatalf("Add installed: %v", addErr)
+	}
+	missingTool := &Tool{Name: "health-check-missing", Type: ToolTypeCLI, Command: "definitely-not-a-real-binary-xyz", Enabled: true}
+	if addErr := s.Add(ctx, missingTool); addErr != nil {
+		t.Fatalf("Add missing: %v", addErr)
+	}
+
+	// Before CheckAll, freshly-added tools carry the seed-time default,
+	// never a live-verified status.
+	before, err := s.Get(ctx, installedTool.Name)
+	if err != nil {
+		t.Fatalf("Get before: %v", err)
+	}
+	if before.LastChecked != "" {
+		t.Fatalf("expected no LastChecked before CheckAll, got %q", before.LastChecked)
+	}
+
+	results, err := s.CheckAll(ctx)
+	if err != nil {
+		t.Fatalf("CheckAll: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("CheckAll returned no results")
+	}
+
+	installedAfter, err := s.Get(ctx, installedTool.Name)
+	if err != nil {
+		t.Fatalf("Get installed after: %v", err)
+	}
+	if installedAfter.HealthStatus != "installed" {
+		t.Errorf("installed tool HealthStatus = %q, want %q", installedAfter.HealthStatus, "installed")
+	}
+	if installedAfter.LastChecked == "" {
+		t.Error("installed tool LastChecked was not persisted by CheckAll")
+	}
+
+	missingAfter, err := s.Get(ctx, missingTool.Name)
+	if err != nil {
+		t.Fatalf("Get missing after: %v", err)
+	}
+	if missingAfter.HealthStatus != "not_installed" {
+		t.Errorf("missing tool HealthStatus = %q, want %q", missingAfter.HealthStatus, "not_installed")
+	}
+	if missingAfter.LastChecked == "" {
+		t.Error("missing tool LastChecked was not persisted by CheckAll")
+	}
+}
+
+// TestUpdateHealth_UnknownTool covers the not-found path so callers (the
+// background loop, the manual force-refresh) get a real error rather than a
+// silent no-op when a tool disappears mid-batch.
+func TestUpdateHealth_UnknownTool(t *testing.T) {
+	s := NewStore(setupSharedDB(t), "sqlite")
+	if err := s.Open(); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close() //nolint:errcheck // test cleanup
+
+	if err := s.UpdateHealth(context.Background(), "nonexistent-tool", "installed", "2024-01-01T00:00:00Z"); err == nil {
+		t.Error("expected error updating health for an unknown tool")
+	}
+}

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -478,6 +478,32 @@ func (s *Store) Update(ctx context.Context, t *Tool) error {
 	return nil
 }
 
+// UpdateHealth persists a fresh health_status + last_checked timestamp for
+// a tool without touching its other mutable fields. Used by the manual
+// /api/tools/check force-refresh and the background auto-check loop, so
+// GET /api/tools always serves recently-verified status instead of the
+// seed-time default.
+func (s *Store) UpdateHealth(ctx context.Context, name, status, lastChecked string) error {
+	if s.pg != nil {
+		return s.pg.UpdateHealth(ctx, name, status, lastChecked)
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tools SET health_status=?, last_checked=? WHERE name=?`,
+		status, lastChecked, name,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("tool %q not found", name)
+	}
+	return nil
+}
+
 // Delete removes a tool by name.
 func (s *Store) Delete(ctx context.Context, name string) error {
 	if s.pg != nil {

--- a/pkg/tool/store_postgres.go
+++ b/pkg/tool/store_postgres.go
@@ -50,6 +50,8 @@ func (p *PostgresStore) InitSchema() error {
 		`ALTER TABLE tools ADD COLUMN IF NOT EXISTS version_cmd TEXT`,
 		`ALTER TABLE tools ADD COLUMN IF NOT EXISTS transport TEXT`,
 		`ALTER TABLE tools ADD COLUMN IF NOT EXISTS url TEXT`,
+		`ALTER TABLE tools ADD COLUMN IF NOT EXISTS health_status TEXT DEFAULT 'unknown'`,
+		`ALTER TABLE tools ADD COLUMN IF NOT EXISTS last_checked TEXT`,
 	}
 	for _, m := range migrations {
 		if _, err := p.db.ExecContext(ctx, m); err != nil {
@@ -129,11 +131,14 @@ func (p *PostgresStore) Add(ctx context.Context, t *Tool) error {
 	return p.add(ctx, t)
 }
 
+// pgToolColumns is the shared column list for Get/List so both stay in sync
+// with pgScanToolFrom's Scan order.
+const pgToolColumns = `name, type, command, install_cmd, upgrade_cmd, version_cmd, transport, url, slash_cmds, mcp_servers, config, health_status, last_checked, builtin, enabled, created_at`
+
 // Get returns a tool by name. Returns nil, nil if not found.
 func (p *PostgresStore) Get(ctx context.Context, name string) (*Tool, error) {
 	row := p.db.QueryRowContext(ctx,
-		`SELECT name, type, command, install_cmd, upgrade_cmd, version_cmd, transport, url, slash_cmds, mcp_servers, config, builtin, enabled, created_at
-		 FROM tools WHERE name = $1`, name)
+		`SELECT `+pgToolColumns+` FROM tools WHERE name = $1`, name)
 	return pgScanToolFrom(row)
 }
 
@@ -146,12 +151,14 @@ type pgToolScanner interface {
 func pgScanToolFrom(sc pgToolScanner) (*Tool, error) {
 	var t Tool
 	var toolType, installCmd, upgradeCmd, versionCmd, transport, url, slashCmds, mcpServers, config sql.NullString
+	var healthStatus, lastChecked sql.NullString
 	var createdAt time.Time
 	if err := sc.Scan(
 		&t.Name, &toolType, &t.Command,
 		&installCmd, &upgradeCmd, &versionCmd,
 		&transport, &url,
 		&slashCmds, &mcpServers, &config,
+		&healthStatus, &lastChecked,
 		&t.Builtin, &t.Enabled, &createdAt,
 	); err != nil {
 		if err == sql.ErrNoRows {
@@ -169,14 +176,15 @@ func pgScanToolFrom(sc pgToolScanner) (*Tool, error) {
 	t.SlashCmds = unmarshalStrings(slashCmds.String)
 	t.MCPServers = unmarshalStrings(mcpServers.String)
 	t.Config = unmarshalMap(config.String)
+	t.HealthStatus = healthStatus.String
+	t.LastChecked = lastChecked.String
 	return &t, nil
 }
 
 // List returns all tools.
 func (p *PostgresStore) List(ctx context.Context) ([]*Tool, error) {
 	rows, err := p.db.QueryContext(ctx,
-		`SELECT name, type, command, install_cmd, upgrade_cmd, version_cmd, transport, url, slash_cmds, mcp_servers, config, builtin, enabled, created_at
-		 FROM tools ORDER BY builtin DESC, name ASC`)
+		`SELECT `+pgToolColumns+` FROM tools ORDER BY builtin DESC, name ASC`)
 	if err != nil {
 		return nil, err
 	}
@@ -229,6 +237,26 @@ func (p *PostgresStore) Update(ctx context.Context, t *Tool) error {
 	}
 	if n == 0 {
 		return fmt.Errorf("tool %q not found", t.Name)
+	}
+	return nil
+}
+
+// UpdateHealth persists a fresh health_status + last_checked timestamp for
+// a tool without touching its other mutable fields.
+func (p *PostgresStore) UpdateHealth(ctx context.Context, name, status, lastChecked string) error {
+	res, err := p.db.ExecContext(ctx,
+		`UPDATE tools SET health_status=$1, last_checked=$2 WHERE name=$3`,
+		status, lastChecked, name,
+	)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return fmt.Errorf("tool %q not found", name)
 	}
 	return nil
 }

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -228,6 +228,16 @@ func buildServicesFromHome(ctx context.Context, globals *Globals, h *home.Home) 
 		} else {
 			toolStore = ts
 			addCloser(func() error { return ts.Close() })
+			// Background auto-check: verifies install status for every tool
+			// once at boot and every toolHealthCheckInterval after, so
+			// GET /api/tools always serves recently-verified status instead
+			// of the seed-time default (#3423). Runs in its own goroutine —
+			// BuildServices returns without waiting for the first pass.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				runToolHealthLoop(svcCtx, ts)
+			}()
 		}
 	}
 
@@ -499,6 +509,35 @@ func runEventPruneLoop(ctx context.Context, prunable *eventspkg.SQLiteLog) {
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+// toolHealthCheckInterval is how often the background tool auto-check
+// re-verifies install status after its initial boot-time pass.
+const toolHealthCheckInterval = 10 * time.Minute
+
+// runToolHealthLoop runs store.CheckAll once immediately (off the request
+// path, so it never delays daemon startup) and then on a fixed interval,
+// keeping every tool's health_status fresh without requiring a manual
+// POST /api/tools/check. See tool.Store.CheckAll for the check itself and
+// ToolHandler.checkAll for the manual force-refresh that shares it.
+func runToolHealthLoop(ctx context.Context, store *toolpkg.Store) {
+	checkToolsOnce(ctx, store)
+	ticker := time.NewTicker(toolHealthCheckInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			checkToolsOnce(ctx, store)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func checkToolsOnce(ctx context.Context, store *toolpkg.Store) {
+	if _, err := store.CheckAll(ctx); err != nil {
+		log.Warn("tool health auto-check failed", "error", err)
 	}
 }
 

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -109,20 +109,37 @@ type modelCacheEntry struct {
 	models []ModelInfo
 }
 
+// statusCacheEntry caches a provider's IsInstalled/Version result to avoid
+// re-exec'ing LookPath + "<binary> --version" on every GET /api/providers.
+type statusCacheEntry struct {
+	at        time.Time
+	version   string
+	installed bool
+}
+
 // ProviderHandler handles /api/providers routes.
 type ProviderHandler struct {
-	sf         singleflight.Group
-	registry   *provider.Registry
-	agents     *agent.AgentService
-	costs      *cost.Service
-	h          *home.Home
-	modelCache map[string]modelCacheEntry
-	modelMu    sync.Mutex
+	sf          singleflight.Group
+	registry    *provider.Registry
+	agents      *agent.AgentService
+	costs       *cost.Service
+	h           *home.Home
+	modelCache  map[string]modelCacheEntry
+	statusCache map[string]statusCacheEntry
+	modelMu     sync.Mutex
+	statusMu    sync.Mutex
 }
 
 // NewProviderHandler creates a ProviderHandler.
 func NewProviderHandler(registry *provider.Registry, agents *agent.AgentService, costs *cost.Service, h *home.Home) *ProviderHandler {
-	return &ProviderHandler{registry: registry, agents: agents, costs: costs, h: h, modelCache: make(map[string]modelCacheEntry)}
+	return &ProviderHandler{
+		registry:    registry,
+		agents:      agents,
+		costs:       costs,
+		h:           h,
+		modelCache:  make(map[string]modelCacheEntry),
+		statusCache: make(map[string]statusCacheEntry),
+	}
 }
 
 // Register mounts provider routes on mux.
@@ -196,6 +213,48 @@ func (h *ProviderHandler) fetchModels(ctx context.Context, p provider.Provider) 
 		return []ModelInfo{}
 	}
 	return ms
+}
+
+// fetchInstallStatus returns provider p's IsInstalled/Version, cached for 60
+// seconds so buildProviderInfo doesn't re-exec LookPath + "<binary>
+// --version" on every request. Mirrors fetchModels' cache+singleflight
+// shape: concurrent callers for the same provider share one in-flight
+// check, and a "status:" key prefix keeps this singleflight.Group entry
+// distinct from fetchModels' same-name key on the shared h.sf group.
+func (h *ProviderHandler) fetchInstallStatus(ctx context.Context, p provider.Provider) (installed bool, version string) {
+	const ttl = 60 * time.Second
+
+	h.statusMu.Lock()
+	if e, ok := h.statusCache[p.Name()]; ok && time.Since(e.at) < ttl {
+		h.statusMu.Unlock()
+		return e.installed, e.version
+	}
+	h.statusMu.Unlock()
+
+	raw, _, _ := h.sf.Do("status:"+p.Name(), func() (any, error) { //nolint:errcheck // sf.Do error is forwarded; closure never returns non-nil
+		h.statusMu.Lock()
+		if e, ok := h.statusCache[p.Name()]; ok && time.Since(e.at) < ttl {
+			h.statusMu.Unlock()
+			return e, nil
+		}
+		h.statusMu.Unlock()
+
+		e := statusCacheEntry{at: time.Now(), installed: p.IsInstalled(ctx)}
+		if e.installed {
+			e.version = p.Version(ctx)
+		}
+
+		h.statusMu.Lock()
+		h.statusCache[p.Name()] = e
+		h.statusMu.Unlock()
+
+		return e, nil
+	})
+	e, ok := raw.(statusCacheEntry)
+	if !ok {
+		return false, ""
+	}
+	return e.installed, e.version
 }
 
 // listModels returns live models for a provider (with caching).
@@ -272,6 +331,8 @@ func (h *ProviderHandler) byName(w http.ResponseWriter, r *http.Request) {
 		h.install(w, r, name)
 	case r.Method == http.MethodPost && action == "update":
 		h.update(w, r, name)
+	case r.Method == http.MethodPost && action == "uninstall":
+		h.uninstall(w, r, name)
 	case r.Method == http.MethodPost && action == "check-update":
 		h.checkUpdate(w, r, name)
 	case r.Method == http.MethodPatch && action == "config":
@@ -625,6 +686,74 @@ func (h *ProviderHandler) update(w http.ResponseWriter, r *http.Request, name st
 	streamInstall(r.Context(), hint, emit)
 }
 
+// isRequiredProvider reports whether name is mycel's currently configured
+// default provider (providers.default in prefs.json) — the one every new
+// agent spawns with unless told otherwise. Uninstalling it out from under a
+// running daemon would strand that default, so uninstall refuses it; the
+// user can uninstall it after switching the default provider elsewhere.
+func isRequiredProvider(h *home.Home, name string) bool {
+	if h == nil {
+		return false
+	}
+	return strings.EqualFold(h.DefaultProvider(), name)
+}
+
+// uninstall removes a provider's CLI by deriving a remove command from its
+// vetted InstallHint (npm-global or Homebrew — the same two package
+// managers resolveUninstall in deps_install.go supports) and streaming live
+// output back as NDJSON, mirroring update's execution model. Refuses the
+// configured default provider (isRequiredProvider) and any hint that
+// doesn't map to an unambiguous uninstall command. Loopback-only: it shells
+// out on the host.
+func (h *ProviderHandler) uninstall(w http.ResponseWriter, r *http.Request, name string) {
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	p, ok := h.registry.Get(name)
+	if !ok {
+		httpError(w, "unknown provider: "+name, http.StatusNotFound)
+		return
+	}
+
+	if isRequiredProvider(h.h, name) {
+		httpError(w, name+" is the default provider and cannot be uninstalled", http.StatusBadRequest)
+		return
+	}
+
+	cmd, ok := deriveUninstall(p.InstallHint())
+	if !ok {
+		httpError(w, "no automatic uninstaller for "+name, http.StatusBadRequest)
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		httpError(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/x-ndjson")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(http.StatusOK)
+
+	emit := func(v any) bool {
+		payload, mErr := json.Marshal(v)
+		if mErr != nil {
+			return false
+		}
+		if _, wErr := w.Write(append(payload, '\n')); wErr != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
+	emit(map[string]string{"type": "start", "command": cmd})
+	streamInstall(r.Context(), cmd, emit)
+}
+
 // hintResponse returns the install/update hint for a provider.
 func (h *ProviderHandler) hintResponse(w http.ResponseWriter, name, action string) {
 	p, ok := h.registry.Get(name)
@@ -687,11 +816,7 @@ func (h *ProviderHandler) buildProviderInfo(
 	agentCounts map[string]int,
 	costByProvider map[string]*costAgg,
 ) ProviderInfo {
-	installed := p.IsInstalled(ctx)
-	version := ""
-	if installed {
-		version = p.Version(ctx)
-	}
+	installed, version := h.fetchInstallStatus(ctx, p)
 
 	status := "not_installed"
 	if installed {

--- a/server/handlers/providers_test.go
+++ b/server/handlers/providers_test.go
@@ -244,8 +244,8 @@ func TestProvidersCommandsCurated(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	// Claude implements CommandLister; the curated list must come through.
-	if len(cmds) != 7 {
-		t.Fatalf("want 7 curated commands, got %d: %v", len(cmds), cmds)
+	if len(cmds) != 8 {
+		t.Fatalf("want 8 curated commands, got %d: %v", len(cmds), cmds)
 	}
 	if cmds[0].Name != "mcp add" {
 		t.Errorf("first command = %q, want %q", cmds[0].Name, "mcp add")

--- a/server/handlers/providers_uninstall_test.go
+++ b/server/handlers/providers_uninstall_test.go
@@ -1,0 +1,211 @@
+package handlers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/home"
+	"github.com/rpuneet/mycel/pkg/provider"
+)
+
+// countingInstallProvider counts IsInstalled/Version invocations so tests can
+// assert the TTL cache in fetchInstallStatus actually avoids re-exec'ing on
+// every request instead of just returning a plausible-looking value.
+type countingInstallProvider struct {
+	name            string
+	version         string
+	isInstalledHits atomic.Int32
+	versionHits     atomic.Int32
+	installed       bool
+}
+
+func (f *countingInstallProvider) Name() string        { return f.name }
+func (f *countingInstallProvider) Description() string { return "fake" }
+func (f *countingInstallProvider) Command() string     { return f.name }
+func (f *countingInstallProvider) Binary() string      { return f.name }
+func (f *countingInstallProvider) InstallHint() string { return "npm install -g " + f.name }
+func (f *countingInstallProvider) BuildCommand(provider.CommandOpts) string {
+	return f.name
+}
+func (f *countingInstallProvider) IsInstalled(context.Context) bool {
+	f.isInstalledHits.Add(1)
+	return f.installed
+}
+func (f *countingInstallProvider) Version(context.Context) string {
+	f.versionHits.Add(1)
+	return f.version
+}
+
+// TestFetchInstallStatus_CachedWithinTTL exercises the cache added to
+// buildProviderInfo (server/handlers/providers.go): a provider's
+// IsInstalled/Version must be exec'd once per TTL window, not once per
+// GET /api/providers request, mirroring the existing fetchModels cache.
+func TestFetchInstallStatus_CachedWithinTTL(t *testing.T) {
+	fake := &countingInstallProvider{name: "counted", installed: true, version: "1.2.3"}
+	reg := provider.NewRegistry()
+	reg.Register(fake)
+	mux := http.NewServeMux()
+	NewProviderHandler(reg, nil, nil, nil).Register(mux)
+
+	for range 3 {
+		req := httptest.NewRequest(http.MethodGet, "/api/providers", nil)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+		}
+	}
+
+	if got := fake.isInstalledHits.Load(); got != 1 {
+		t.Errorf("IsInstalled called %d times across 3 requests within TTL, want 1", got)
+	}
+	if got := fake.versionHits.Load(); got != 1 {
+		t.Errorf("Version called %d times across 3 requests within TTL, want 1", got)
+	}
+}
+
+// TestFetchInstallStatus_ReportsInstalledAndVersion is a sanity check that
+// the cached path still returns real data end to end.
+func TestFetchInstallStatus_ReportsInstalledAndVersion(t *testing.T) {
+	fake := &countingInstallProvider{name: "counted2", installed: true, version: "9.9.9"}
+	reg := provider.NewRegistry()
+	reg.Register(fake)
+	mux := http.NewServeMux()
+	NewProviderHandler(reg, nil, nil, nil).Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/providers", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	var infos []ProviderInfo
+	if err := json.Unmarshal(rec.Body.Bytes(), &infos); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(infos) != 1 || !infos[0].Installed || infos[0].Version != "9.9.9" {
+		t.Fatalf("infos = %+v, want installed=true version=9.9.9", infos)
+	}
+}
+
+func newUninstallMux(p provider.Provider, h *home.Home) http.Handler {
+	reg := provider.NewRegistry()
+	reg.Register(p)
+	mux := http.NewServeMux()
+	NewProviderHandler(reg, nil, nil, h).Register(mux)
+	return mux
+}
+
+// TestProviderUninstall_RefusesDefaultProvider covers the "required
+// provider" guard: uninstall must refuse the provider currently configured
+// as providers.default, since a running daemon needs it to spawn agents.
+func TestProviderUninstall_RefusesDefaultProvider(t *testing.T) {
+	h := &home.Home{Config: &home.Config{Providers: home.ProvidersConfig{Default: "fakenpm"}}}
+	mux := newUninstallMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"}, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/uninstall", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 for the default provider: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// TestProviderUninstall_NonDefaultRunsRealCommand covers the happy path: a
+// provider that is not the configured default, with an npm install hint,
+// gets a derived "npm uninstall -g" command streamed as NDJSON.
+func TestProviderUninstall_NonDefaultRunsRealCommand(t *testing.T) {
+	orig := installRunner
+	installRunner = func(ctx context.Context, _ string) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c", "printf 'removing…\\n'")
+	}
+	t.Cleanup(func() { installRunner = orig })
+
+	h := &home.Home{Config: &home.Config{Providers: home.ProvidersConfig{Default: "claude"}}}
+	mux := newUninstallMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"}, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/uninstall", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", rec.Code, rec.Body.String())
+	}
+
+	var sawStart, sawDoneZero bool
+	sc := bufio.NewScanner(strings.NewReader(rec.Body.String()))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var ev map[string]any
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			t.Fatalf("bad NDJSON line %q: %v", line, err)
+		}
+		switch ev["type"] {
+		case "start":
+			sawStart = true
+			if cmd, _ := ev["command"].(string); cmd != "npm uninstall -g fake-cli" {
+				t.Errorf("start command = %q, want derived npm uninstall command", cmd)
+			}
+		case "done":
+			if code, ok := ev["code"].(float64); ok && code == 0 {
+				sawDoneZero = true
+			}
+		case "error":
+			t.Fatalf("unexpected error event: %v", ev["error"])
+		}
+	}
+	if !sawStart {
+		t.Error("missing start event")
+	}
+	if !sawDoneZero {
+		t.Error("missing done event with code 0")
+	}
+}
+
+// TestProviderUninstall_NoAutomaticUninstaller covers an install hint that
+// doesn't map to an unambiguous uninstall command (curl-piped script):
+// uninstall must refuse rather than guessing a destructive command.
+func TestProviderUninstall_NoAutomaticUninstaller(t *testing.T) {
+	h := &home.Home{Config: &home.Config{Providers: home.ProvidersConfig{Default: "claude"}}}
+	mux := newUninstallMux(&fakeUpdateProvider{
+		name:        "fakecurl",
+		installHint: "curl -fsSL https://example.com/install.sh | sh",
+		version:     "1.0.0",
+	}, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakecurl/uninstall", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for a non-derivable uninstall hint", rec.Code)
+	}
+}
+
+// TestProviderUninstall_LoopbackGuard confirms uninstall shares update's
+// loopback-only gate.
+func TestProviderUninstall_LoopbackGuard(t *testing.T) {
+	h := &home.Home{Config: &home.Config{Providers: home.ProvidersConfig{Default: "claude"}}}
+	mux := newUninstallMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "1.0.0"}, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/uninstall", nil)
+	req.RemoteAddr = "10.0.0.5:1234"
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for a non-loopback caller", rec.Code)
+	}
+}

--- a/server/handlers/tools.go
+++ b/server/handlers/tools.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
-	"os/exec"
 	"strings"
 
 	"github.com/rpuneet/mycel/pkg/tool"
@@ -76,53 +75,21 @@ func (h *ToolHandler) list(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// checkAll runs health checks on all tools.
+// checkAll is the manual force-refresh: it runs a fresh health check on
+// every tool right now and persists the result via store.CheckAll,
+// independent of the background auto-check loop's own schedule (see
+// runToolHealthLoop in server/build_services.go).
 func (h *ToolHandler) checkAll(w http.ResponseWriter, r *http.Request) {
-	store := h.store
 	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
-	tools, err := store.List(r.Context())
+	results, err := h.store.CheckAll(r.Context())
 	if err != nil {
-		httpInternalError(w, "list tools", err)
+		httpInternalError(w, "check tools", err)
 		return
 	}
-
-	type checkResult struct {
-		Name   string `json:"name"`
-		Type   string `json:"type"`
-		Status string `json:"status"`
-		Error  string `json:"error,omitempty"`
-	}
-	var results []checkResult
-	for _, t := range tools {
-		r := checkResult{Name: t.Name, Type: t.Type, Status: "ok"}
-		switch t.Type {
-		case tool.ToolTypeMCP:
-			if t.Transport == "stdio" && t.Command != "" {
-				cmd := strings.Fields(t.Command)[0]
-				if _, err := exec.LookPath(cmd); err != nil {
-					r.Status = "error"
-					r.Error = "command not found: " + cmd
-				}
-			}
-		case tool.ToolTypeCLI:
-			if _, err := exec.LookPath(t.Command); err != nil {
-				r.Status = "not_installed"
-				r.Error = "not found in PATH"
-			} else {
-				r.Status = "installed"
-			}
-		case tool.ToolTypeProvider:
-			cmd := strings.Fields(t.Command)[0]
-			if _, err := exec.LookPath(cmd); err != nil {
-				r.Status = "not_installed"
-				r.Error = "not found in PATH"
-			} else {
-				r.Status = "installed"
-			}
-		}
-		results = append(results, r)
+	if results == nil {
+		results = []tool.HealthResult{}
 	}
 	writeJSON(w, http.StatusOK, results)
 }

--- a/server/tool_health_test.go
+++ b/server/tool_health_test.go
@@ -1,0 +1,95 @@
+// tool_health_test.go — the background tool auto-check (#3423): Tools.tsx
+// showed DB-seeded "not_installed" status until a user manually clicked
+// Health Check. runToolHealthLoop/checkToolsOnce close that gap by running
+// the same check the manual endpoint runs, at boot and on an interval.
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	dbpkg "github.com/rpuneet/mycel/pkg/db"
+	toolpkg "github.com/rpuneet/mycel/pkg/tool"
+)
+
+// TestCheckToolsOnce_WritesFreshStatus asserts the boot-time (and
+// per-interval) pass persists health_status/last_checked via the store,
+// exactly like the manual POST /api/tools/check force-refresh, so
+// GET /api/tools serves recently-verified data without requiring a manual
+// check first.
+func TestCheckToolsOnce_WritesFreshStatus(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	d, err := dbpkg.Open(filepath.Join(dir, "mycel.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close() //nolint:errcheck
+
+	store := toolpkg.NewStore(d, "sqlite")
+	if openErr := store.Open(); openErr != nil {
+		t.Fatalf("open store: %v", openErr)
+	}
+	defer store.Close() //nolint:errcheck
+
+	tools, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(tools) == 0 {
+		t.Fatal("expected seeded built-in tools")
+	}
+	for _, tl := range tools {
+		if tl.LastChecked != "" {
+			t.Fatalf("tool %q already has LastChecked before the background check ran", tl.Name)
+		}
+	}
+
+	// checkToolsOnce must not require (or wait on) the interval ticker —
+	// it's the same function the loop calls immediately at boot so the
+	// first daemon-lifetime GET /api/tools already sees verified data.
+	checkToolsOnce(ctx, store)
+
+	after, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("list after: %v", err)
+	}
+	for _, tl := range after {
+		if tl.LastChecked == "" {
+			t.Errorf("tool %q has no LastChecked after checkToolsOnce", tl.Name)
+		}
+		if tl.HealthStatus == "" || tl.HealthStatus == "unknown" {
+			t.Errorf("tool %q HealthStatus = %q, want a verified value", tl.Name, tl.HealthStatus)
+		}
+	}
+}
+
+// TestRunToolHealthLoop_StopsOnContextCanceled confirms the loop's first
+// pass runs before the caller observes it and the goroutine exits promptly
+// when its context is canceled (parity with the other prune-loop tests in
+// this package), so it never blocks BuildServices' Close().
+func TestRunToolHealthLoop_StopsOnContextCanceled(t *testing.T) {
+	dir := t.TempDir()
+	d, err := dbpkg.Open(filepath.Join(dir, "mycel.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer d.Close() //nolint:errcheck
+
+	store := toolpkg.NewStore(d, "sqlite")
+	if openErr := store.Open(); openErr != nil {
+		t.Fatalf("open store: %v", openErr)
+	}
+	defer store.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runToolHealthLoop(ctx, store)
+		close(done)
+	}()
+
+	cancel()
+	<-done // must return once ctx is canceled, not block forever on the ticker
+}


### PR DESCRIPTION
## Summary
Part of #3423 — backend-only PR 1 of the Tools/Providers revamp. No UI changes.

- **Cache provider IsInstalled/Version**: `buildProviderInfo` now goes through `fetchInstallStatus`, a 60s TTL + singleflight cache keyed by provider name (mirrors the existing `fetchModels`/`modelCache` pattern). `GET /api/providers` no longer re-execs `LookPath` + `<binary> --version` on every request; concurrent requests during a cold cache share one shell-out per provider.
- **`POST /api/providers/:name/uninstall`**: derives an uninstall command from the provider's vetted `InstallHint` (npm-global / Homebrew only, same predicate as `deriveUninstall` in `deps_install.go`), streams NDJSON like `update`. Refuses the currently configured default provider (`providers.default`) and any hint with no unambiguous uninstall mapping (curl-piped scripts, bare URLs). Loopback-only.
- **`version` + `help` filled into every provider's `Commands()`**: added `help` to codex, pi, agy, cursor, and claude (each already had `version` except claude gained `help` too). openclaw already had both. All new entries are argument-free and non-interactive, so they're automatically `Runnable()` via the existing guarded `/run` endpoint.
- **Tools background auto-check**: new `pkg/tool.Store.CheckAll` + `UpdateHealth` persist real `health_status`/`last_checked` (previously `checkAll` in `tools.go` computed ephemeral results and threw them away — `Update` never touched those columns for either the SQLite or Postgres backend). A non-blocking goroutine (`runToolHealthLoop`) is started alongside the tool store in `BuildServices`: runs once at boot, then every 10 minutes. `POST /api/tools/check` now shares the same `CheckAll` path as an on-demand force-refresh. Fixes the "0 CLI" bug where `GET /api/tools` served the DB-seeded `not_installed` default until a user manually clicked Health Check.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./server/... ./pkg/...` — 0 issues
- [x] `go test -race ./server/handlers/... ./pkg/provider/... ./pkg/tool/... ./server/...` — all pass
- New tests added:
  - `server/handlers/providers_uninstall_test.go` — install-status cache TTL (counts `IsInstalled`/`Version` calls across repeated requests), uninstall refuses the default provider, uninstall streams a derived npm-uninstall command, uninstall refuses non-derivable hints, uninstall shares the loopback guard.
  - `pkg/provider/commands_test.go` — every first-party provider has runnable `version` + `help` entries.
  - `pkg/tool/health_test.go` — `CheckAll` persists `health_status`/`last_checked` via `UpdateHealth` for both installed and missing tools; `UpdateHealth` errors on an unknown tool.
  - `server/tool_health_test.go` — `checkToolsOnce` writes fresh status for all seeded tools; `runToolHealthLoop` exits promptly on context cancellation.

Not merging — flagged for review per repo convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)