### PR TITLE
fix(templates): real 'template import' + marketplace install writes to store

### DIFF
--- a/docs/reference/cli/mycel_template.md
+++ b/docs/reference/cli/mycel_template.md
@@ -12,6 +12,7 @@ Examples:
   mycel template list                    # List all templates
   mycel template show feature-dev        # Show template details
   mycel template create my-template      # Scaffold a new template
+  mycel template import ./my-tmpl.json   # Import a template from a file
   mycel template delete my-template      # Delete a template
 
 ```
@@ -36,6 +37,7 @@ mycel template [flags]
 * [mycel](mycel.md)	 - A simpler, more controllable agent orchestrator
 * [mycel template create](mycel_template_create.md)	 - Create a new template
 * [mycel template delete](mycel_template_delete.md)	 - Delete a template
+* [mycel template import](mycel_template_import.md)	 - Import a template from a file, URL, or the marketplace catalog
 * [mycel template list](mycel_template_list.md)	 - List all templates
 * [mycel template show](mycel_template_show.md)	 - Show template details and system prompt
 

--- a/docs/reference/cli/mycel_template_import.md
+++ b/docs/reference/cli/mycel_template_import.md
@@ -1,0 +1,50 @@
+## mycel template import
+
+Import a template from a file, URL, or the marketplace catalog
+
+### Synopsis
+
+Import a template into the global template store (~/.mycel/templates/).
+
+<source> may be:
+  - a path to a local JSON file describing the template
+  - an http(s) URL to a template JSON document
+  - the name of a template already known to the marketplace catalog
+    (mycel marketplace list --type template)
+
+The JSON document has the same shape as 'mycel template show', plus an
+optional "system_prompt" string field carrying the system prompt text:
+
+  {
+    "name": "my-template",
+    "description": "...",
+    "mcps": ["mycel"],
+    "system_prompt": "You are..."
+  }
+
+Importing a name that already exists in the store updates it in place;
+pass --force to allow the overwrite.
+
+```
+mycel template import <source> [flags]
+```
+
+### Options
+
+```
+      --force         overwrite an existing template with the same name
+  -h, --help          help for import
+      --name string   override the imported template's name
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [mycel template](mycel_template.md)	 - Manage agent templates
+

--- a/internal/cmd/template.go
+++ b/internal/cmd/template.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -23,6 +25,7 @@ Examples:
   mycel template list                    # List all templates
   mycel template show feature-dev        # Show template details
   mycel template create my-template      # Scaffold a new template
+  mycel template import ./my-tmpl.json   # Import a template from a file
   mycel template delete my-template      # Delete a template`,
 	RunE: runTemplateList,
 }
@@ -54,10 +57,41 @@ var templateDeleteCmd = &cobra.Command{
 	RunE:  runTemplateDelete,
 }
 
+var templateImportCmd = &cobra.Command{
+	Use:   "import <source>",
+	Short: "Import a template from a file, URL, or the marketplace catalog",
+	Long: `Import a template into the global template store (~/.mycel/templates/).
+
+<source> may be:
+  - a path to a local JSON file describing the template
+  - an http(s) URL to a template JSON document
+  - the name of a template already known to the marketplace catalog
+    (mycel marketplace list --type template)
+
+The JSON document has the same shape as 'mycel template show', plus an
+optional "system_prompt" string field carrying the system prompt text:
+
+  {
+    "name": "my-template",
+    "description": "...",
+    "mcps": ["mycel"],
+    "system_prompt": "You are..."
+  }
+
+Importing a name that already exists in the store updates it in place;
+pass --force to allow the overwrite.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runTemplateImport,
+}
+
 func init() {
+	templateImportCmd.Flags().Bool("force", false, "overwrite an existing template with the same name")
+	templateImportCmd.Flags().String("name", "", "override the imported template's name")
+
 	templateCmd.AddCommand(templateListCmd)
 	templateCmd.AddCommand(templateShowCmd)
 	templateCmd.AddCommand(templateCreateCmd)
+	templateCmd.AddCommand(templateImportCmd)
 	templateCmd.AddCommand(templateDeleteCmd)
 	rootCmd.AddCommand(templateCmd)
 }
@@ -204,4 +238,92 @@ func runTemplateDelete(_ *cobra.Command, args []string) error {
 
 	fmt.Printf("Deleted template %s\n", name)
 	return nil
+}
+
+// runTemplateImport implements `mycel template import <source>`. source can
+// be a local JSON file path, an http(s) URL to a template JSON document, or
+// the name of a template already listed in the marketplace catalog.
+func runTemplateImport(cmd *cobra.Command, args []string) error {
+	source := args[0]
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+	nameOverride, err := cmd.Flags().GetString("name")
+	if err != nil {
+		return err
+	}
+
+	store, err := openTemplateStore()
+	if err != nil {
+		return err
+	}
+	if _, dirErr := home.EnsureGlobalDir(); dirErr != nil {
+		return dirErr
+	}
+
+	t, prompt, err := resolveImportSource(cmd.Context(), store, source)
+	if err != nil {
+		return err
+	}
+
+	if nameOverride != "" {
+		t.Name = nameOverride
+	}
+	if t.Name == "" {
+		return fmt.Errorf("imported template has no name; pass --name to set one")
+	}
+	t.Scope = ""
+
+	if _, _, getErr := store.Get(t.Name); getErr == nil {
+		if !force {
+			return fmt.Errorf("template %q already exists; re-run with --force to update it", t.Name)
+		}
+		if err := store.Update(t.Name, t, prompt); err != nil {
+			return fmt.Errorf("update template %q: %w", t.Name, err)
+		}
+		fmt.Printf("Updated template %q from %s\n", t.Name, source)
+		return nil
+	}
+
+	if err := store.Create(t, prompt, template.ScopeGlobal); err != nil {
+		return fmt.Errorf("import template %q: %w", t.Name, err)
+	}
+	fmt.Printf("Imported template %q from %s\n", t.Name, source)
+	return nil
+}
+
+// resolveImportSource resolves source into a Template + system prompt. It
+// tries, in order: an http(s) URL, a local file path, and finally a lookup
+// by name against this store directly. The last case covers "known
+// marketplace item name": the marketplace catalog's "mycel" source (see
+// pkg/marketplace.Aggregator.fetchMycel) lists exactly this store's own
+// templates, so resolving a bare name against the store is equivalent to
+// resolving it via the aggregator today, without paying for a live fetch
+// across every other registry the aggregator knows about.
+func resolveImportSource(ctx context.Context, store *template.Store, source string) (template.Template, string, error) {
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		t, prompt, err := template.FetchImportDoc(ctx, nil, source)
+		if err != nil {
+			return template.Template{}, "", fmt.Errorf("fetch template from %s: %w", source, err)
+		}
+		return t, prompt, nil
+	}
+
+	if info, statErr := os.Stat(source); statErr == nil && !info.IsDir() {
+		data, err := os.ReadFile(source) //nolint:gosec // source is an explicit user-supplied CLI argument
+		if err != nil {
+			return template.Template{}, "", fmt.Errorf("read %s: %w", source, err)
+		}
+		t, prompt, err := template.ParseImportDoc(data)
+		if err != nil {
+			return template.Template{}, "", fmt.Errorf("%s: %w", source, err)
+		}
+		return t, prompt, nil
+	}
+
+	if t, prompt, err := store.Get(source); err == nil {
+		return *t, prompt, nil
+	}
+	return template.Template{}, "", fmt.Errorf("%q is not a local file, a URL, or a known template in the store", source)
 }

--- a/internal/cmd/template_import_test.go
+++ b/internal/cmd/template_import_test.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/template"
+)
+
+// writeImportFile writes an ImportDoc as JSON to a temp file and returns
+// its path.
+func writeImportFile(t *testing.T, doc template.ImportDoc) string {
+	t.Helper()
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal import doc: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), doc.Name+".json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write import file: %v", err)
+	}
+	return path
+}
+
+func TestTemplateImport_FromFile_Creates(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	defer resetFlags(templateCmd)
+
+	path := writeImportFile(t, template.ImportDoc{
+		Template: template.Template{
+			Name:        "my-template",
+			Description: "from a file",
+			MCPs:        []string{"mycel"},
+		},
+		SystemPrompt: "You are a test agent.",
+	})
+
+	out, _, err := executeIntegrationCmd("template", "import", path)
+	if err != nil {
+		t.Fatalf("template import failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, `Imported template "my-template"`) {
+		t.Errorf("expected success line, got: %s", out)
+	}
+
+	store, storeErr := openTemplateStore()
+	if storeErr != nil {
+		t.Fatalf("open store: %v", storeErr)
+	}
+	got, prompt, getErr := store.Get("my-template")
+	if getErr != nil {
+		t.Fatalf("get imported template: %v", getErr)
+	}
+	if got.Description != "from a file" {
+		t.Errorf("description = %q, want %q", got.Description, "from a file")
+	}
+	if prompt != "You are a test agent." {
+		t.Errorf("system prompt = %q, want %q", prompt, "You are a test agent.")
+	}
+}
+
+func TestTemplateImport_ExistingName_IsIdempotentWithForce(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	defer resetFlags(templateCmd)
+
+	path := writeImportFile(t, template.ImportDoc{
+		Template: template.Template{Name: "dup-template", Description: "v1"},
+	})
+
+	if _, _, err := executeIntegrationCmd("template", "import", path); err != nil {
+		t.Fatalf("first import failed: %v", err)
+	}
+	resetFlags(templateCmd)
+
+	// Re-importing without --force should fail rather than silently clobber.
+	if _, _, err := executeIntegrationCmd("template", "import", path); err == nil {
+		t.Fatalf("expected second import without --force to fail")
+	}
+	resetFlags(templateCmd)
+
+	// Update the source doc and re-import with --force: should succeed and
+	// update the stored template (idempotent re-run).
+	path2 := writeImportFile(t, template.ImportDoc{
+		Template: template.Template{Name: "dup-template", Description: "v2"},
+	})
+	out, _, err := executeIntegrationCmd("template", "import", path2, "--force")
+	if err != nil {
+		t.Fatalf("forced re-import failed: %v\noutput: %s", err, out)
+	}
+	if !strings.Contains(out, `Updated template "dup-template"`) {
+		t.Errorf("expected update success line, got: %s", out)
+	}
+	resetFlags(templateCmd)
+
+	store, storeErr := openTemplateStore()
+	if storeErr != nil {
+		t.Fatalf("open store: %v", storeErr)
+	}
+	got, _, getErr := store.Get("dup-template")
+	if getErr != nil {
+		t.Fatalf("get template: %v", getErr)
+	}
+	if got.Description != "v2" {
+		t.Errorf("description = %q, want %q (forced update should win)", got.Description, "v2")
+	}
+
+	// A second forced re-import of the same content must also succeed
+	// (true idempotency, not just a one-time overwrite).
+	if _, _, err := executeIntegrationCmd("template", "import", path2, "--force"); err != nil {
+		t.Fatalf("repeated forced import failed: %v", err)
+	}
+}
+
+func TestTemplateImport_FromURL(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	defer resetFlags(templateCmd)
+
+	doc := template.ImportDoc{
+		Template:     template.Template{Name: "url-template", Description: "from a url", MCPs: []string{"mycel"}},
+		SystemPrompt: "Prompt from URL",
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	out, _, err := executeIntegrationCmd("template", "import", srv.URL)
+	if err != nil {
+		t.Fatalf("template import from URL failed: %v\noutput: %s", err, out)
+	}
+
+	store, storeErr := openTemplateStore()
+	if storeErr != nil {
+		t.Fatalf("open store: %v", storeErr)
+	}
+	got, _, getErr := store.Get("url-template")
+	if getErr != nil {
+		t.Fatalf("get imported template: %v", getErr)
+	}
+	if got.Description != "from a url" {
+		t.Errorf("description = %q, want %q", got.Description, "from a url")
+	}
+}
+
+func TestTemplateImport_KnownLocalName_IsIdempotent(t *testing.T) {
+	// A "marketplace item name" that is already a template in this store
+	// (the only TypeTemplate source today is this same store) should
+	// resolve without a file or URL argument, and re-running with --force
+	// should be a safe no-op.
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	defer resetFlags(templateCmd)
+
+	store, storeErr := openTemplateStore()
+	if storeErr != nil {
+		t.Fatalf("open store: %v", storeErr)
+	}
+	if err := store.Create(template.Template{Name: "already-local", Description: "seed"}, "seed prompt", template.ScopeGlobal); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+
+	if _, _, err := executeIntegrationCmd("template", "import", "already-local", "--force"); err != nil {
+		t.Fatalf("import of known local name failed: %v", err)
+	}
+	resetFlags(templateCmd)
+
+	if _, _, err := executeIntegrationCmd("template", "import", "already-local", "--force"); err != nil {
+		t.Fatalf("repeated import of known local name failed: %v", err)
+	}
+}
+
+func TestTemplateImport_UnknownSource_Fails(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	defer resetFlags(templateCmd)
+
+	if _, _, err := executeIntegrationCmd("template", "import", "not-a-file-or-url-or-known-template"); err == nil {
+		t.Fatalf("expected import of an unknown source to fail")
+	}
+}
+
+func TestTemplateImport_NameOverride(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	defer resetFlags(templateCmd)
+
+	path := writeImportFile(t, template.ImportDoc{
+		Template: template.Template{Name: "original-name"},
+	})
+
+	if _, _, err := executeIntegrationCmd("template", "import", path, "--name", "renamed"); err != nil {
+		t.Fatalf("import with --name failed: %v", err)
+	}
+
+	store, storeErr := openTemplateStore()
+	if storeErr != nil {
+		t.Fatalf("open store: %v", storeErr)
+	}
+	if _, _, err := store.Get("renamed"); err != nil {
+		t.Errorf("expected template stored under overridden name %q: %v", "renamed", err)
+	}
+}

--- a/pkg/template/import.go
+++ b/pkg/template/import.go
@@ -1,0 +1,66 @@
+package template
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ImportDoc is the on-the-wire JSON shape accepted by template import
+// (the `mycel template import` CLI command and the marketplace install
+// endpoint). It mirrors Template plus a plain-text SystemPrompt field,
+// since the on-disk Store keeps the prompt in a sibling .md file rather
+// than inside the template's JSON.
+type ImportDoc struct { //nolint:govet // embedding Template; reordering would obscure the JSON shape
+	Template
+	SystemPrompt string `json:"system_prompt,omitempty"`
+}
+
+// maxImportBytes caps how much of a remote or local import document is
+// read, guarding against runaway files/responses.
+const maxImportBytes = 1 << 20 // 1 MiB
+
+// ParseImportDoc decodes raw JSON bytes describing a template into a
+// Template plus its system prompt text.
+func ParseImportDoc(data []byte) (Template, string, error) {
+	var doc ImportDoc
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return Template{}, "", fmt.Errorf("parse template import document: %w", err)
+	}
+	if doc.Name == "" {
+		return Template{}, "", fmt.Errorf(`template import document is missing required "name" field`)
+	}
+	// Scope is runtime-only and must never be sourced from an import doc.
+	doc.Scope = ""
+	return doc.Template, doc.SystemPrompt, nil
+}
+
+// FetchImportDoc fetches an import document from rawURL and parses it.
+// client may be nil, in which case http.DefaultClient is used.
+func FetchImportDoc(ctx context.Context, client *http.Client, rawURL string) (Template, string, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return Template{}, "", fmt.Errorf("build request for %s: %w", rawURL, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Template{}, "", fmt.Errorf("GET %s: %w", rawURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return Template{}, "", fmt.Errorf("GET %s: HTTP %d", rawURL, resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxImportBytes))
+	if err != nil {
+		return Template{}, "", fmt.Errorf("read response from %s: %w", rawURL, err)
+	}
+	return ParseImportDoc(data)
+}

--- a/pkg/template/import.go
+++ b/pkg/template/import.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"time"
 )
 
 // ImportDoc is the on-the-wire JSON shape accepted by template import
@@ -21,6 +23,28 @@ type ImportDoc struct { //nolint:govet // embedding Template; reordering would o
 // maxImportBytes caps how much of a remote or local import document is
 // read, guarding against runaway files/responses.
 const maxImportBytes = 1 << 20 // 1 MiB
+
+// importFetchTimeout bounds a remote import. Without one, a server that accepts
+// the connection and then says nothing holds the import open indefinitely.
+const importFetchTimeout = 20 * time.Second
+
+// checkImportScheme rejects anything but http(s). A bare path is a local file,
+// which the caller handles before reaching here, and any other scheme —
+// file://, gopher://, and the rest — has no business being handed to an HTTP
+// client.
+func checkImportScheme(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("template import needs an http or https URL, or a local file path; got scheme %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("template import URL %q names no host", rawURL)
+	}
+	return nil
+}
 
 // ParseImportDoc decodes raw JSON bytes describing a template into a
 // Template plus its system prompt text.
@@ -38,10 +62,19 @@ func ParseImportDoc(data []byte) (Template, string, error) {
 }
 
 // FetchImportDoc fetches an import document from rawURL and parses it.
-// client may be nil, in which case http.DefaultClient is used.
+// client may be nil, in which case a client with a timeout is used.
+//
+// This is for a URL a person typed: `mycel template import <url>`. It is
+// deliberately not reachable from an HTTP request, because a URL chosen by a
+// request would let the caller aim the daemon at loopback services or a cloud
+// metadata endpoint. The marketplace install path resolves templates from the
+// local store only, and dispatches remote ones to an agent to import here.
 func FetchImportDoc(ctx context.Context, client *http.Client, rawURL string) (Template, string, error) {
+	if err := checkImportScheme(rawURL); err != nil {
+		return Template{}, "", err
+	}
 	if client == nil {
-		client = http.DefaultClient
+		client = &http.Client{Timeout: importFetchTimeout}
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {

--- a/pkg/template/import_test.go
+++ b/pkg/template/import_test.go
@@ -76,3 +76,22 @@ func TestFetchImportDoc_HTTPError(t *testing.T) {
 		t.Fatalf("expected error for HTTP 404")
 	}
 }
+
+// A URL scheme that is not http(s) has no business reaching an HTTP client.
+func TestFetchImportDocRejectsANonHTTPScheme(t *testing.T) {
+	for _, raw := range []string{
+		"file:///etc/passwd",
+		"gopher://example.com/1",
+		"ftp://example.com/t.json",
+	} {
+		if _, _, err := FetchImportDoc(context.Background(), nil, raw); err == nil {
+			t.Errorf("FetchImportDoc(%q) = nil error, want a refusal", raw)
+		}
+	}
+}
+
+func TestFetchImportDocRejectsAURLWithNoHost(t *testing.T) {
+	if _, _, err := FetchImportDoc(context.Background(), nil, "http://"); err == nil {
+		t.Error("FetchImportDoc with no host = nil error, want a refusal")
+	}
+}

--- a/pkg/template/import_test.go
+++ b/pkg/template/import_test.go
@@ -1,0 +1,78 @@
+package template
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseImportDoc_Valid(t *testing.T) {
+	data := []byte(`{"name":"foo","description":"desc","mcps":["mycel"],"system_prompt":"hello"}`)
+	tmpl, prompt, err := ParseImportDoc(data)
+	if err != nil {
+		t.Fatalf("ParseImportDoc: %v", err)
+	}
+	if tmpl.Name != "foo" || tmpl.Description != "desc" {
+		t.Errorf("unexpected template: %+v", tmpl)
+	}
+	if len(tmpl.MCPs) != 1 || tmpl.MCPs[0] != "mycel" {
+		t.Errorf("MCPs = %v", tmpl.MCPs)
+	}
+	if prompt != "hello" {
+		t.Errorf("prompt = %q", prompt)
+	}
+}
+
+func TestParseImportDoc_MissingName(t *testing.T) {
+	data := []byte(`{"description":"desc"}`)
+	if _, _, err := ParseImportDoc(data); err == nil {
+		t.Fatalf("expected error for missing name")
+	}
+}
+
+func TestParseImportDoc_InvalidJSON(t *testing.T) {
+	if _, _, err := ParseImportDoc([]byte("not json")); err == nil {
+		t.Fatalf("expected error for invalid JSON")
+	}
+}
+
+func TestParseImportDoc_ScopeIsStripped(t *testing.T) {
+	data := []byte(`{"name":"foo","scope":"workspace"}`)
+	tmpl, _, err := ParseImportDoc(data)
+	if err != nil {
+		t.Fatalf("ParseImportDoc: %v", err)
+	}
+	if tmpl.Scope != "" {
+		t.Errorf("scope should be stripped from import docs, got %q", tmpl.Scope)
+	}
+}
+
+func TestFetchImportDoc_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"name":"remote","description":"from remote","system_prompt":"prompt text"}`))
+	}))
+	defer srv.Close()
+
+	tmpl, prompt, err := FetchImportDoc(context.Background(), nil, srv.URL)
+	if err != nil {
+		t.Fatalf("FetchImportDoc: %v", err)
+	}
+	if tmpl.Name != "remote" || tmpl.Description != "from remote" {
+		t.Errorf("unexpected template: %+v", tmpl)
+	}
+	if prompt != "prompt text" {
+		t.Errorf("prompt = %q", prompt)
+	}
+}
+
+func TestFetchImportDoc_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if _, _, err := FetchImportDoc(context.Background(), nil, srv.URL); err == nil {
+		t.Fatalf("expected error for HTTP 404")
+	}
+}

--- a/server/handlers/marketplace.go
+++ b/server/handlers/marketplace.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/rpuneet/mycel/pkg/marketplace"
+	"github.com/rpuneet/mycel/pkg/template"
 )
 
 // AgentSender is the minimal interface needed to dispatch a message to a named
@@ -18,8 +19,9 @@ type AgentSender interface {
 
 // MarketplaceHandler handles /api/marketplace routes.
 type MarketplaceHandler struct { //nolint:govet // readability over fieldalignment
-	agg    *marketplace.Aggregator
-	sender AgentSender // may be nil; install endpoint returns 503 when nil
+	agg       *marketplace.Aggregator
+	sender    AgentSender     // may be nil; agent-dispatch install path returns 503 when nil
+	tmplStore *template.Store // may be nil; when set, template installs write directly instead of dispatching
 }
 
 // NewMarketplaceHandler creates a MarketplaceHandler backed by the given
@@ -27,6 +29,15 @@ type MarketplaceHandler struct { //nolint:govet // readability over fieldalignme
 // no sender is wired (e.g. during integration tests that omit the agent service).
 func NewMarketplaceHandler(agg *marketplace.Aggregator, sender AgentSender) *MarketplaceHandler {
 	return &MarketplaceHandler{agg: agg, sender: sender}
+}
+
+// WithTemplateStore wires a template store into the handler so that
+// installs of TypeTemplate items write directly to the store — a
+// deterministic action — instead of dispatching a command an agent must
+// run. Returns the receiver for chaining.
+func (h *MarketplaceHandler) WithTemplateStore(store *template.Store) *MarketplaceHandler {
+	h.tmplStore = store
+	return h
 }
 
 // Register mounts marketplace routes on mux.
@@ -80,18 +91,16 @@ type installResponse struct { //nolint:govet // field order matches API contract
 
 // install handles POST /api/marketplace/install.
 //
-// It composes a clear install-instruction message for the item and dispatches
-// it to each named agent via the existing AgentSender (same code path as
-// POST /api/agents/{name}/send). The agent then runs the install using its
-// own native command.
+// For TypeTemplate items with a template store wired (WithTemplateStore),
+// the install writes directly to the global template store — a
+// deterministic action that does not depend on any agent being reachable.
+// Every other item type falls back to the original behavior: composing a
+// clear install-instruction message and dispatching it to each named agent
+// via the existing AgentSender (same code path as POST /api/agents/{name}/send),
+// which then runs the install using its own native command.
 func (h *MarketplaceHandler) install(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		methodNotAllowed(w)
-		return
-	}
-
-	if h.sender == nil {
-		httpError(w, "agent service unavailable", http.StatusServiceUnavailable)
 		return
 	}
 
@@ -118,6 +127,20 @@ func (h *MarketplaceHandler) install(w http.ResponseWriter, r *http.Request) {
 	req.ItemSourceURL = newlineReplacer.Replace(req.ItemSourceURL)
 	req.ItemID = newlineReplacer.Replace(req.ItemID)
 
+	if marketplace.ItemType(req.ItemType) == marketplace.TypeTemplate && h.tmplStore != nil {
+		if err := h.installTemplate(r.Context(), req); err != nil {
+			httpError(w, "install template: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		writeJSON(w, http.StatusOK, installResponse{Dispatched: len(req.Agents)})
+		return
+	}
+
+	if h.sender == nil {
+		httpError(w, "agent service unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
 	msg := composeInstallMessage(req)
 
 	dispatched := 0
@@ -139,6 +162,38 @@ func (h *MarketplaceHandler) install(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, installResponse{Dispatched: dispatched, Errors: sendErrs})
+}
+
+// installTemplate resolves req into a Template and upserts it into the
+// wired template store. When req.ItemSourceURL is set it is fetched as an
+// import document (see pkg/template.FetchImportDoc); otherwise req.ItemName
+// is looked up directly in the store, since the "mycel" marketplace source
+// only ever lists templates that already live there.
+func (h *MarketplaceHandler) installTemplate(ctx context.Context, req installRequest) error {
+	var (
+		t      template.Template
+		prompt string
+	)
+
+	if req.ItemSourceURL != "" {
+		fetched, fetchedPrompt, err := template.FetchImportDoc(ctx, nil, req.ItemSourceURL)
+		if err != nil {
+			return fmt.Errorf("fetch %s: %w", req.ItemSourceURL, err)
+		}
+		t, prompt = fetched, fetchedPrompt
+	} else {
+		existing, existingPrompt, err := h.tmplStore.Get(req.ItemName)
+		if err != nil {
+			return fmt.Errorf("no source URL provided and %q is not a known template: %w", req.ItemName, err)
+		}
+		t, prompt = *existing, existingPrompt
+	}
+	t.Scope = ""
+
+	if _, _, err := h.tmplStore.Get(t.Name); err == nil {
+		return h.tmplStore.Update(t.Name, t, prompt)
+	}
+	return h.tmplStore.Create(t, prompt, template.ScopeGlobal)
 }
 
 // composeInstallMessage builds the human-readable install instruction sent to
@@ -201,13 +256,23 @@ func composeInstallMessage(req installRequest) string {
 			sb.WriteString(fmt.Sprintf("  claude plugin install %q\n", req.ItemName+"@"+marketplaceName))
 		}
 	case marketplace.TypeTemplate:
-		// A template entry names a template that is already on the machine: the
-		// mycel source lists ~/.mycel/templates itself, so there is nothing to
-		// fetch. The old instruction asked for `mycel template import`, a
-		// command that has never existed — an agent that did as it was told got
-		// "unknown command", which is the failure the Glama branch above goes
-		// out of its way to avoid. What a template is *for* is creating an
-		// agent, so that is what is asked for.
+		// This is the fallback for when no template store is wired; with one,
+		// install writes to the store itself and never composes a message.
+		//
+		// Which command depends on where the template is. An entry from the
+		// mycel source names a template already in ~/.mycel/templates, so
+		// importing it is a no-op and what is actually wanted is an agent made
+		// from it. An entry from anywhere else has to be fetched first.
+		//
+		// Either way the command has to exist: this used to name `mycel
+		// template import` when there was no such subcommand, so an agent that
+		// did as it was told got "unknown command" (#3538).
+		if req.ItemSourceURL != "" {
+			sb.WriteString("  Import the template, then create an agent from it:\n")
+			sb.WriteString(fmt.Sprintf("  mycel template import %q\n", req.ItemSourceURL))
+			sb.WriteString("  mycel agent create <agent-name> --template <imported-name>\n")
+			break
+		}
 		template := strings.TrimPrefix(req.ItemID, "mycel:")
 		if template == "" {
 			template = req.ItemName

--- a/server/handlers/marketplace.go
+++ b/server/handlers/marketplace.go
@@ -127,8 +127,20 @@ func (h *MarketplaceHandler) install(w http.ResponseWriter, r *http.Request) {
 	req.ItemSourceURL = newlineReplacer.Replace(req.ItemSourceURL)
 	req.ItemID = newlineReplacer.Replace(req.ItemID)
 
-	if marketplace.ItemType(req.ItemType) == marketplace.TypeTemplate && h.tmplStore != nil {
-		if err := h.installTemplate(r.Context(), req); err != nil {
+	// A template the daemon already has can be installed outright, which is
+	// worth doing because it needs no agent to be reachable and cannot half
+	// succeed.
+	//
+	// A template from somewhere else deliberately does not go this way. Fetching
+	// a URL out of a request body would make this endpoint — reachable from any
+	// page the browser has open — a way to have the daemon issue requests on the
+	// caller's behalf, to a cloud metadata service or to whatever else is
+	// listening on the loopback interface. The agent imports those itself with
+	// `mycel template import`, where the URL is something a person typed rather
+	// than something a page supplied.
+	if marketplace.ItemType(req.ItemType) == marketplace.TypeTemplate &&
+		h.tmplStore != nil && req.ItemSourceURL == "" {
+		if err := h.installTemplate(req); err != nil {
 			httpError(w, "install template: "+err.Error(), http.StatusBadGateway)
 			return
 		}
@@ -164,30 +176,15 @@ func (h *MarketplaceHandler) install(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, installResponse{Dispatched: dispatched, Errors: sendErrs})
 }
 
-// installTemplate resolves req into a Template and upserts it into the
-// wired template store. When req.ItemSourceURL is set it is fetched as an
-// import document (see pkg/template.FetchImportDoc); otherwise req.ItemName
-// is looked up directly in the store, since the "mycel" marketplace source
-// only ever lists templates that already live there.
-func (h *MarketplaceHandler) installTemplate(ctx context.Context, req installRequest) error {
-	var (
-		t      template.Template
-		prompt string
-	)
-
-	if req.ItemSourceURL != "" {
-		fetched, fetchedPrompt, err := template.FetchImportDoc(ctx, nil, req.ItemSourceURL)
-		if err != nil {
-			return fmt.Errorf("fetch %s: %w", req.ItemSourceURL, err)
-		}
-		t, prompt = fetched, fetchedPrompt
-	} else {
-		existing, existingPrompt, err := h.tmplStore.Get(req.ItemName)
-		if err != nil {
-			return fmt.Errorf("no source URL provided and %q is not a known template: %w", req.ItemName, err)
-		}
-		t, prompt = *existing, existingPrompt
+// installTemplate upserts a template the daemon already holds. Only the local
+// store is consulted: the caller is an HTTP request, and a request must not be
+// able to choose an address for the daemon to fetch (see install).
+func (h *MarketplaceHandler) installTemplate(req installRequest) error {
+	existing, prompt, err := h.tmplStore.Get(req.ItemName)
+	if err != nil {
+		return fmt.Errorf("%q is not a template on this machine: %w", req.ItemName, err)
 	}
+	t := *existing
 	t.Scope = ""
 
 	if _, _, err := h.tmplStore.Get(t.Name); err == nil {

--- a/server/handlers/marketplace_test.go
+++ b/server/handlers/marketplace_test.go
@@ -488,24 +488,165 @@ func TestInstall_InjectionStripped(t *testing.T) {
 	}
 }
 
-// A template entry names a template that is already on the machine, so the
-// instruction has to be something an agent can actually run. It used to name
-// `mycel template import`, which has never been a command (#3538).
-func TestComposeInstallMessage_Template(t *testing.T) {
-	req := installRequest{
+// ── template install: direct store write ─────────────────────────────────────
+
+func TestMarketplaceHandler_Install_TemplateWritesToStoreDirectly(t *testing.T) {
+	dir := t.TempDir()
+	store := template.NewStore(dir)
+	if err := store.Create(template.Template{Name: "engineer", Description: "v1"}, "prompt v1", template.ScopeGlobal); err != nil {
+		t.Fatalf("seed template: %v", err)
+	}
+	agg := marketplace.NewAggregator(store, &fakeFetcherHandler{})
+
+	// No sender wired: a direct-write install must not depend on any agent
+	// being reachable.
+	h := NewMarketplaceHandler(agg, nil).WithTemplateStore(store)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	body := `{
+		"item_id":     "mycel:engineer",
+		"item_name":   "engineer",
+		"item_type":   "template",
+		"item_source": "mycel",
+		"agents":      ["alpha"]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/marketplace/install", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp installResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Dispatched != 1 {
+		t.Errorf("want dispatched=1, got %d", resp.Dispatched)
+	}
+
+	got, prompt, err := store.Get("engineer")
+	if err != nil {
+		t.Fatalf("get template after install: %v", err)
+	}
+	if got.Description != "v1" || prompt != "prompt v1" {
+		t.Errorf("template content changed unexpectedly: description=%q prompt=%q", got.Description, prompt)
+	}
+}
+
+func TestMarketplaceHandler_Install_TemplateFromURLWritesToStore(t *testing.T) {
+	dir := t.TempDir()
+	store := template.NewStore(dir)
+	agg := marketplace.NewAggregator(store, &fakeFetcherHandler{})
+
+	doc := template.ImportDoc{
+		Template:     template.Template{Name: "remote-tmpl", Description: "from URL"},
+		SystemPrompt: "remote prompt",
+	}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}))
+	defer srv.Close()
+
+	h := NewMarketplaceHandler(agg, nil).WithTemplateStore(store)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	body, err := json.Marshal(installRequest{
+		ItemName:      "remote-tmpl",
+		ItemType:      "template",
+		ItemSourceURL: srv.URL,
+		Agents:        []string{"alpha"},
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/marketplace/install", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	got, prompt, err := store.Get("remote-tmpl")
+	if err != nil {
+		t.Fatalf("get template written from URL: %v", err)
+	}
+	if got.Description != "from URL" || prompt != "remote prompt" {
+		t.Errorf("description=%q prompt=%q, want %q / %q", got.Description, prompt, "from URL", "remote prompt")
+	}
+}
+
+func TestMarketplaceHandler_Install_TemplateUnresolvableFails(t *testing.T) {
+	dir := t.TempDir()
+	store := template.NewStore(dir)
+	agg := marketplace.NewAggregator(store, &fakeFetcherHandler{})
+	h := NewMarketplaceHandler(agg, nil).WithTemplateStore(store)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	body := `{"item_name":"does-not-exist","item_type":"template","agents":["alpha"]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/marketplace/install", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusOK {
+		t.Fatalf("want a non-200 status for an unresolvable template install, got 200: %s", rec.Body.String())
+	}
+}
+
+func TestMarketplaceHandler_Install_TemplateNoStoreFallsBackToDispatch(t *testing.T) {
+	// Without WithTemplateStore, template installs must still fall back to
+	// the original agent-dispatch behavior rather than erroring out.
+	sender := &fakeAgentSender{}
+	h := NewMarketplaceHandler(newTestAggregator(t, nil), sender)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	body := `{"item_name":"engineer","item_type":"template","item_source":"mycel","agents":["alpha"]}`
+	req := httptest.NewRequest(http.MethodPost, "/api/marketplace/install", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(sender.calls) != 1 {
+		t.Fatalf("want 1 dispatched Send call, got %d", len(sender.calls))
+	}
+	if !contains(sender.calls[0].message, "mycel agent create") {
+		t.Errorf("expected dispatched message to name a command that exists, got: %s", sender.calls[0].message)
+	}
+}
+
+// A template from the mycel source is already in ~/.mycel/templates, so
+// importing it would achieve nothing. What a template is for is creating an
+// agent, so that is what the instruction asks for.
+func TestComposeInstallMessage_TemplateAlreadyLocal(t *testing.T) {
+	msg := composeInstallMessage(installRequest{
 		ItemID:     "mycel:engineer",
 		ItemName:   "engineer",
 		ItemType:   "template",
 		ItemSource: "mycel",
 		Agents:     []string{"a"},
-	}
-	msg := composeInstallMessage(req)
+	})
 
 	if !contains(msg, `mycel agent create <agent-name> --template "engineer"`) {
-		t.Errorf("template message should tell the agent to create an agent from the template, got:\n%s", msg)
+		t.Errorf("want the create command for a local template, got:\n%s", msg)
 	}
 	if contains(msg, "template import") {
-		t.Errorf("template message still names a command that does not exist, got:\n%s", msg)
+		t.Errorf("a local template does not need importing, got:\n%s", msg)
 	}
 }
 
@@ -521,7 +662,7 @@ func TestComposeInstallMessage_TemplateStripsTheSourcePrefix(t *testing.T) {
 	})
 
 	if !contains(msg, `--template "feature-dev"`) {
-		t.Errorf(`want --template "feature-dev" without the catalog prefix, got:\n%s`, msg)
+		t.Errorf("want --template \"feature-dev\" without the catalog prefix, got:\n%s", msg)
 	}
 	if contains(msg, "mycel:feature-dev") {
 		t.Errorf("the catalog id leaked into the command, got:\n%s", msg)
@@ -538,7 +679,26 @@ func TestComposeInstallMessage_TemplateFallsBackToTheName(t *testing.T) {
 	})
 
 	if !contains(msg, `--template "reviewer"`) {
-		t.Errorf("want the item name used as the template, got:\n%s", msg)
+		t.Errorf("want the name used when no id was given, got:\n%s", msg)
+	}
+}
+
+// A template from anywhere but the local store has to be fetched before it can
+// be used, and `mycel template import` is the command that does it.
+func TestComposeInstallMessage_TemplateFromElsewhereIsImportedFirst(t *testing.T) {
+	msg := composeInstallMessage(installRequest{
+		ItemName:      "trader",
+		ItemType:      "template",
+		ItemSource:    "community",
+		ItemSourceURL: "https://example.com/trader.json",
+		Agents:        []string{"a"},
+	})
+
+	if !contains(msg, `mycel template import "https://example.com/trader.json"`) {
+		t.Errorf("want the import command for a remote template, got:\n%s", msg)
+	}
+	if !contains(msg, "mycel agent create") {
+		t.Errorf("import alone leaves nothing running — want the create step too, got:\n%s", msg)
 	}
 }
 

--- a/server/handlers/marketplace_test.go
+++ b/server/handlers/marketplace_test.go
@@ -536,26 +536,26 @@ func TestMarketplaceHandler_Install_TemplateWritesToStoreDirectly(t *testing.T) 
 	}
 }
 
-func TestMarketplaceHandler_Install_TemplateFromURLWritesToStore(t *testing.T) {
+// The daemon must not fetch an address chosen by a request. This endpoint is
+// reachable from any page the browser has open, so a fetch here is a way to make
+// the daemon issue requests on the caller's behalf — to a cloud metadata service,
+// or to whatever else is listening on loopback. A remote template is imported by
+// the agent instead, from a URL a person typed.
+func TestMarketplaceHandler_Install_TemplateFromAURLIsNotFetchedByTheDaemon(t *testing.T) {
 	dir := t.TempDir()
 	store := template.NewStore(dir)
 	agg := marketplace.NewAggregator(store, &fakeFetcherHandler{})
 
-	doc := template.ImportDoc{
-		Template:     template.Template{Name: "remote-tmpl", Description: "from URL"},
-		SystemPrompt: "remote prompt",
-	}
-	data, err := json.Marshal(doc)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
+	fetched := false
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetched = true
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write(data)
+		_, _ = w.Write([]byte(`{"name":"remote-tmpl","system_prompt":"remote prompt"}`))
 	}))
 	defer srv.Close()
 
-	h := NewMarketplaceHandler(agg, nil).WithTemplateStore(store)
+	sender := &fakeAgentSender{}
+	h := NewMarketplaceHandler(agg, sender).WithTemplateStore(store)
 	mux := http.NewServeMux()
 	h.Register(mux)
 
@@ -576,13 +576,17 @@ func TestMarketplaceHandler_Install_TemplateFromURLWritesToStore(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
 	}
-
-	got, prompt, err := store.Get("remote-tmpl")
-	if err != nil {
-		t.Fatalf("get template written from URL: %v", err)
+	if fetched {
+		t.Error("the daemon fetched a URL supplied in a request body")
 	}
-	if got.Description != "from URL" || prompt != "remote prompt" {
-		t.Errorf("description=%q prompt=%q, want %q / %q", got.Description, prompt, "from URL", "remote prompt")
+	if _, _, err := store.Get("remote-tmpl"); err == nil {
+		t.Error("a template arrived in the store from a URL the daemon should not have read")
+	}
+	if len(sender.calls) != 1 {
+		t.Fatalf("want the import dispatched to the agent instead, got %d Send calls", len(sender.calls))
+	}
+	if !contains(sender.calls[0].message, "mycel template import") {
+		t.Errorf("expected the agent to be told to import it, got: %s", sender.calls[0].message)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -450,14 +450,16 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		handlers.NewTemplateHandler(tmplStore).Register(mux)
 
 		// Marketplace — live catalog aggregating MCP registry, GitHub, vendor skill
-		// sources (Claude/openclaw/Gemini), and local templates. The install
-		// endpoint reuses the agent-message path (AgentService.Send) to dispatch
-		// install instructions; sender may be nil when agents are unavailable.
+		// sources (Claude/openclaw/Gemini), and local templates. Template
+		// installs write directly to tmplStore (deterministic); every other
+		// item type dispatches an install instruction via the agent-message
+		// path (AgentService.Send); sender may be nil when agents are unavailable.
 		var mktSender handlers.AgentSender
 		if svc.Agents != nil {
 			mktSender = svc.Agents
 		}
-		handlers.NewMarketplaceHandler(marketplace.NewAggregator(tmplStore, nil), mktSender).Register(mux)
+		handlers.NewMarketplaceHandler(marketplace.NewAggregator(tmplStore, nil), mktSender).
+			WithTemplateStore(tmplStore).Register(mux)
 
 		// File upload/download for channel attachments + shared screenshots
 		fileStore := attachment.NewStore(svc.Home.StateDir())


### PR DESCRIPTION
## Summary
- The marketplace's template-install path dispatched `mycel template import "<name>"` to an agent, but that subcommand did not exist (`internal/cmd/template.go` only registered create/delete/list/show) — every template install from the marketplace failed.
- Added a real `mycel template import <source>` subcommand: source may be a local JSON file path, an http(s) URL to a template JSON document, or an existing template name already in the store (the marketplace catalog's `mycel` source is exactly this store, so name resolution is a fast local lookup, no network round-trip). Re-importing an existing name requires `--force`, so repeated imports are idempotent.
- Added `pkg/template.ImportDoc`, `ParseImportDoc`, and `FetchImportDoc`, shared by the CLI command and the marketplace handler.
- `server/handlers/marketplace.go`: template installs now write directly to the global template store (deterministic) instead of only dispatching prose an agent has to run. `MarketplaceHandler` gains `WithTemplateStore()`; when no store is wired (or for every other item type — MCP/skill), the original agent-dispatch path is used unchanged.
- Verified the seeded built-in templates (`feature-dev`/`reviewer`/`manager`/`blank`) already list the `mycel` MCP server, not a stale `bc` name — no change needed there.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/... ./pkg/... ./server/...`
- [x] `golangci-lint run ./internal/... ./server/... ./pkg/template/...` — 0 issues
- [x] `go test ./internal/cmd/... ./pkg/template/... ./server/handlers/...` — all pass
- [x] Built `./bin/mycel` and ran `template import` on a sample JSON file end-to-end (create, idempotency with `--force`, rejection of unknown sources) — see PR description output below
- [x] `./bin/mycel template list` confirms seeded templates use `mycel`, not `bc`

```
$ ./bin/mycel template import /tmp/sample-template.json
Imported template "demo-import" from /tmp/sample-template.json

$ ./bin/mycel template show demo-import
Name:        demo-import
Scope:       global
Description: Imported via mycel template import for verification
MCPs:        mycel

System Prompt:
----------------------------------------
You are a demo agent imported from a marketplace JSON file.
```

Part of #3423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `template import` support for importing templates from URLs, local JSON files, or existing template names.
  * Added options to override template names and force updates to existing templates.
  * Marketplace template installations now save templates directly to the template store.
* **Bug Fixes**
  * Improved validation and error handling for invalid, missing, or unreachable template sources.
  * Preserved existing installation behavior for non-template marketplace items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->