### PR TITLE
feat(github): ship default OAuth client id — one-click sign-in, no setup

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,15 @@
+# gitleaks configuration for mycel.
+#
+# Extends the built-in gitleaks default ruleset and adds a project
+# allowlist. The gitleaks-action (CI "Security" job) auto-detects this
+# file at the repository root.
+[extend]
+useDefault = true
+
+[allowlist]
+description = "mycel allowlisted values that are public, not secrets"
+# Public GitHub device-flow OAuth client ID — not a secret (embedded like
+# the gh CLI does; device-flow client IDs have no paired secret).
+regexes = [
+  '''Ov23liP7jwMEwOZtM2b5''',
+]

--- a/pkg/gateway/github/oauth.go
+++ b/pkg/gateway/github/oauth.go
@@ -27,6 +27,13 @@ const (
 	deviceScope = "repo"
 	// pollTimeout bounds a single upstream poll request.
 	pollTimeout = 15 * time.Second
+	// DefaultOAuthClientID is mycel's own registered GitHub OAuth App
+	// (device flow enabled). Device-flow client IDs are public — like the
+	// gh CLI's own client ID, there is no secret to protect — so shipping
+	// it here gives every user one-click "Sign in with GitHub" with zero
+	// setup. Users may still override it with their own OAuth app's
+	// client ID (advanced: their own org, higher rate limits).
+	DefaultOAuthClientID = "Ov23liP7jwMEwOZtM2b5"
 )
 
 // deviceFlow implements app.OAuthFlow via the GitHub device flow.
@@ -63,8 +70,9 @@ func newDeviceFlow() *deviceFlow {
 func (f *deviceFlow) BeginAuth(ctx context.Context, inst app.Instance) (app.AuthSession, error) {
 	clientID := strings.TrimSpace(inst.Config["oauth_client_id"])
 	if clientID == "" {
-		return app.AuthSession{}, fmt.Errorf(
-			"github: oauth_client_id is not set — create a GitHub OAuth app (github.com/settings/applications/new) and paste its client ID; the device flow needs no client secret")
+		// No override pasted: fall back to mycel's own public OAuth app so
+		// sign-in works out of the box.
+		clientID = DefaultOAuthClientID
 	}
 
 	form := url.Values{"client_id": {clientID}, "scope": {deviceScope}}

--- a/pkg/gateway/github/oauth.go
+++ b/pkg/gateway/github/oauth.go
@@ -33,7 +33,7 @@ const (
 	// it here gives every user one-click "Sign in with GitHub" with zero
 	// setup. Users may still override it with their own OAuth app's
 	// client ID (advanced: their own org, higher rate limits).
-	DefaultOAuthClientID = "Ov23liP7jwMEwOZtM2b5"
+	DefaultOAuthClientID = "Ov23liP7jwMEwOZtM2b5" // gitleaks:allow -- public GitHub device-flow client ID, not a secret
 )
 
 // deviceFlow implements app.OAuthFlow via the GitHub device flow.

--- a/pkg/gateway/github/oauth_test.go
+++ b/pkg/gateway/github/oauth_test.go
@@ -88,11 +88,47 @@ func deviceOK() map[string]any {
 	}
 }
 
-func TestBeginAuthRequiresClientID(t *testing.T) {
-	f := newDeviceFlow()
+func TestBeginAuthDefaultsClientIDWhenUnset(t *testing.T) {
+	stub := &stubGitHub{t: t, deviceResponse: deviceOK()}
+	_, f := stub.start()
+
+	// No oauth_client_id in the instance config: BeginAuth must fall back
+	// to mycel's built-in client ID rather than erroring — this is what
+	// gives users "Sign in with GitHub" with zero setup.
 	_, err := f.BeginAuth(context.Background(), app.Instance{App: "github", Name: "github"})
-	if err == nil || !strings.Contains(err.Error(), "oauth_client_id") {
-		t.Fatalf("err = %v, want oauth_client_id guidance", err)
+	if err != nil {
+		t.Fatalf("BeginAuth: %v, want no error (should default to DefaultOAuthClientID)", err)
+	}
+
+	f.mu.Lock()
+	var gotClientID string
+	for _, s := range f.sessions {
+		gotClientID = s.clientID
+	}
+	f.mu.Unlock()
+	if gotClientID != DefaultOAuthClientID {
+		t.Errorf("session clientID = %q, want %q", gotClientID, DefaultOAuthClientID)
+	}
+}
+
+func TestBeginAuthOverridesDefaultClientID(t *testing.T) {
+	stub := &stubGitHub{t: t, deviceResponse: deviceOK()}
+	_, f := stub.start()
+
+	sess, err := f.BeginAuth(context.Background(), testInstance())
+	if err != nil {
+		t.Fatalf("BeginAuth: %v", err)
+	}
+
+	f.mu.Lock()
+	gotClientID := f.sessions[sess.ID].clientID
+	f.mu.Unlock()
+	const pastedClientID = "Ov23liTESTID"
+	if gotClientID != pastedClientID {
+		t.Errorf("session clientID = %q, want pasted %q (override the default)", gotClientID, pastedClientID)
+	}
+	if gotClientID == DefaultOAuthClientID {
+		t.Error("pasted client ID was overridden by the default — override should win")
 	}
 }
 

--- a/pkg/gateway/github/plugin.go
+++ b/pkg/gateway/github/plugin.go
@@ -31,14 +31,19 @@ func (*plugin) Describe() app.Descriptor {
 		Multi: true,
 		Fields: []app.FieldSpec{
 			{Key: "secret", Label: "Webhook Secret", Placeholder: "your-webhook-secret", Secret: true},
-			{Key: "oauth_client_id", Label: "OAuth Client ID", Placeholder: "Ov23li... (from your GitHub OAuth app)"},
+			{
+				Key:         "oauth_client_id",
+				Label:       "OAuth Client ID (advanced)",
+				Placeholder: "Ov23li... (leave blank to use mycel's built-in sign-in)",
+			},
 			{Key: "api_token", Label: "API Token", Placeholder: "ghp_... (or use Sign in with GitHub)", Secret: true},
 		},
 		Docs: []string{
 			"Create a webhook → your repo → Settings → Webhooks.",
 			"Set the payload URL to your mycel server's /hooks/github endpoint.",
 			"Set the secret here to match the webhook secret.",
-			"Optional API access: sign in with GitHub (device flow) to mint an api_token for outbound calls (comments, statuses). Any GitHub OAuth app's client ID works — create one at https://github.com/settings/applications/new; the device flow needs no client secret and no redirect URL.",
+			"Sign in with GitHub works out of the box — no setup needed — using mycel's built-in OAuth app to mint an api_token for outbound calls (comments, statuses).",
+			"Optional: paste your own GitHub OAuth app's client ID (advanced — for your own org, or higher rate limits). Create one at https://github.com/settings/applications/new; the device flow needs no client secret and no redirect URL. Leave blank to use mycel's built-in sign-in.",
 		},
 	}
 }


### PR DESCRIPTION
Part of #3423

## Summary
- Embed mycel's registered GitHub OAuth App client ID (`Ov23liP7jwMEwOZtM2b5`, device-flow enabled) as `DefaultOAuthClientID` in `pkg/gateway/github/oauth.go`. Device-flow client IDs are public — no secret — same model as the `gh` CLI's own bundled client ID.
- `deviceFlow.BeginAuth` now falls back to `DefaultOAuthClientID` when the instance's `oauth_client_id` config is empty, instead of erroring. A pasted value still overrides the default.
- `plugin.go`'s `oauth_client_id` `FieldSpec` is relabeled "OAuth Client ID (advanced)" with an optional-override placeholder/description; Docs now explain sign-in works out of the box and the paste field is only for advanced use (own org / higher rate limits). It was already `Required: false`, and the connect UI (`ConnectApp.tsx`) already renders non-required fields as optional and never blocked the "Sign in with GitHub" button on it — so end-to-end this ships true zero-setup sign-in.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/gateway/...` (0 issues)
- [x] `go test ./pkg/gateway/... ./server/...` (all pass)
- [x] `make build-local-web`
- [x] `vitest run` on `connectApp.test.tsx` (14 passed)
- [x] New tests: `TestBeginAuthDefaultsClientIDWhenUnset` (empty config → `DefaultOAuthClientID` used) and `TestBeginAuthOverridesDefaultClientID` (pasted client ID wins over the default). Replaced the now-obsolete `TestBeginAuthRequiresClientID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)