### PR TITLE
fix(apps): clean one-click OAuth sign-in that actually opens the browser

### DIFF
--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -953,10 +953,17 @@ export function DegradedBanner() {
   }, []);
 
   if (!degraded || dismissed) return null;
-  const names = Object.keys(degraded).sort().join(", ");
+  const keys = Object.keys(degraded).sort();
+  const names = keys.join(", ");
   const detail = Object.entries(degraded)
     .map(([name, reason]) => `${name}: ${reason}`)
     .join("\n");
+  // Degraded apps ("app:<name>") get a "Check setup" that reopens that
+  // app's own connect modal so the fix is one click away, instead of the
+  // generic readiness page — this is the thing that's actually broken.
+  // Non-app degradation (deps, runtime, …) keeps routing to /readiness.
+  const degradedAppKey = keys.find((k) => k.startsWith("app:"));
+  const checkSetupTo = degradedAppKey ? `/apps?connect=${encodeURIComponent(degradedAppKey.slice(4))}` : "/readiness";
   return (
     <div
       role="status"
@@ -971,7 +978,7 @@ export function DegradedBanner() {
         Degraded services: <span className="font-medium">{names}</span> — some features are unavailable.
       </span>
       <Link
-        to="/readiness"
+        to={checkSetupTo}
         className="ml-auto shrink-0 underline decoration-dotted underline-offset-2 font-medium hover:opacity-80"
       >
         Check setup

--- a/web/src/components/__tests__/LayoutReadiness.test.tsx
+++ b/web/src/components/__tests__/LayoutReadiness.test.tsx
@@ -68,6 +68,30 @@ describe("Layout readiness surfacing", () => {
     expect(screen.queryByText(/run mycel doctor/i)).not.toBeInTheDocument();
   });
 
+  it("an app's degraded banner routes Check setup to that app's connect modal, not the readiness page", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/health")) {
+        return jsonResponse({
+          status: "degraded",
+          degraded: { "app:gmail": "oauth token expired — reconnect required" },
+        });
+      }
+      if (u.includes("/api/system/info")) return jsonResponse({ hostname: "host", os: "darwin", arch: "arm64" });
+      if (u.includes("/api/doctor")) return jsonResponse({ categories: [] });
+      return jsonResponse([]);
+    });
+    renderLayout();
+    const links = await waitFor(() => {
+      const found = screen.getAllByRole("link", { name: "Check setup" });
+      expect(found.length).toBeGreaterThan(0);
+      return found;
+    });
+    for (const link of links) {
+      expect(link.getAttribute("href")).toBe("/apps?connect=gmail");
+    }
+  });
+
   it("no longer exposes a standalone Setup entry in the drawer footer", async () => {
     renderLayout();
     // Setup folded into Settings (the Setup section) + the /welcome wizard;

--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -385,16 +385,23 @@ export function AppsHome() {
   const [chooserOpen, setChooserOpen] = useState(false);
   const [connectAppId, setConnectAppId] = useState<string | null>(null);
 
-  // Deep links: /apps?action=connect opens the catalog; /apps#custom-keys
-  // (the old /secrets bookmark) scrolls to the Custom Keys section.
+  // Deep links: /apps?action=connect opens the catalog; /apps?connect=<id>
+  // jumps straight to that app's connect modal (used by the degraded-
+  // services banner's "Check setup" so a broken app links to its own fix,
+  // not a generic readiness page); /apps#custom-keys (the old /secrets
+  // bookmark) scrolls to the Custom Keys section.
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
   useEffect(() => {
-    if (searchParams.get("action") === "connect") {
-      setChooserOpen(true);
+    const action = searchParams.get("action");
+    const connect = searchParams.get("connect");
+    if (action === "connect") setChooserOpen(true);
+    if (connect) setConnectAppId(connect);
+    if (action === "connect" || connect) {
       setSearchParams((prev) => {
         const next = new URLSearchParams(prev);
         next.delete("action");
+        next.delete("connect");
         return next;
       }, { replace: true });
     }

--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -395,8 +395,16 @@ export function AppsHome() {
   useEffect(() => {
     const action = searchParams.get("action");
     const connect = searchParams.get("connect");
-    if (action === "connect") setChooserOpen(true);
-    if (connect) setConnectAppId(connect);
+    // Mutually exclusive: a named ?connect=<id> jumps straight to that
+    // app's connect modal and wins over ?action=connect (the catalog
+    // chooser) — opening both would leave the chooser stuck open behind
+    // the wizard after it closes.
+    if (connect) {
+      setChooserOpen(false);
+      setConnectAppId(connect);
+    } else if (action === "connect") {
+      setChooserOpen(true);
+    }
     if (action === "connect" || connect) {
       setSearchParams((prev) => {
         const next = new URLSearchParams(prev);

--- a/web/src/components/apps/ConnectApp.tsx
+++ b/web/src/components/apps/ConnectApp.tsx
@@ -24,6 +24,7 @@ import { api } from "../../api/client";
 import type { Agent, AppAuthSession, AppDescriptor, AppInstance } from "../../api/client";
 import { AppIcon, presentationFor } from "./PlatformIcons";
 import { StatusDot } from "./appStatus";
+import { openExternal } from "../../utils/openExternal";
 
 /* ── Presentation-only metadata (backend owns the rest) ──────────────
    App icon/color/category/description metadata lives in PlatformIcons.tsx
@@ -583,6 +584,20 @@ function humanURL(url: string): string {
   return url.replace(/^https?:\/\//, "").replace(/\/$/, "");
 }
 
+/** Short, display-safe label for an authorization URL: host + path only,
+ *  never the query string. OAuth authorize URLs carry client_id,
+ *  redirect_uri, scope and state as query params — sprawling, useless-to-
+ *  read text that must never be rendered as the button/body copy. The
+ *  full URL (query string included) is still what gets opened. */
+function shortURLLabel(url: string): string {
+  try {
+    const u = new URL(url);
+    return humanURL(`${u.origin}${u.pathname}`);
+  } catch {
+    return humanURL(url).split("?")[0] ?? humanURL(url);
+  }
+}
+
 /** Normalize a user-typed instance label to the id-safe segment after ":". */
 export function sanitizeInstanceLabel(label: string): string {
   return label.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
@@ -751,6 +766,14 @@ export function ConnectWizard({
       const session = await api.beginAppOAuth(instanceName, config);
       setOauthSession(session);
       setOauthState("pending");
+      // One click really means one click: open the system browser the
+      // moment the session exists, instead of making the user find and
+      // click a second link. openExternal itself picks Wails'
+      // BrowserOpenURL vs window.open, so this works in the desktop app
+      // too. The "Reopen browser" control below covers popup blockers /
+      // an accidental close.
+      const authURL = session.verification_url ?? session.auth_url;
+      if (authURL) openExternal(authURL);
       // Poll for completion. The plugin rate-limits upstream calls to the
       // provider's interval, so a snappy local poll is safe.
       const pollId = setInterval(() => {
@@ -879,8 +902,12 @@ export function ConnectWizard({
 
         {step === "setup" ? (
           <>
-            {/* Setup docs from the descriptor */}
-            {descriptor.docs.length > 0 && (
+            {/* Setup docs from the descriptor. When one-click sign-in is
+                available these move into the Advanced disclosure below,
+                collapsed alongside the manual fields — a wall of numbered
+                setup steps must never out-compete a working Sign in
+                button for attention. */}
+            {!oauthAvailable && descriptor.docs.length > 0 && (
               <div className="p-4 border-b border-mycel-border">
                 <h3 className="text-[11px] font-medium text-mycel-muted uppercase tracking-[0.08em] mb-2">
                   Setup Steps
@@ -976,46 +1003,62 @@ export function ConnectWizard({
                 {oauthAvailable && (
                   <div data-testid="oauth-panel" className="rounded-md border border-mycel-border bg-mycel-surface p-4">
                     {oauthState === "pending" && oauthSession ? (
-                      <div className="flex flex-col items-center gap-3">
-                        {oauthSession.user_code ? (
-                          <>
-                            <p className="text-xs text-mycel-muted text-center">
-                              Enter this code in your browser to authorize mycel
-                            </p>
-                            <div
-                              data-testid="oauth-user-code"
-                              className="font-mono text-2xl font-semibold tracking-[0.25em] text-mycel-text bg-mycel-surface-2 border border-mycel-border rounded-md px-5 py-2.5 select-all"
-                            >
-                              {oauthSession.user_code}
+                      (() => {
+                        const authURL = oauthSession.verification_url ?? oauthSession.auth_url ?? "";
+                        return (
+                          <div className="flex flex-col items-center gap-3">
+                            {oauthSession.user_code ? (
+                              <>
+                                <p className="text-xs text-mycel-muted text-center">
+                                  Enter this code in your browser to authorize mycel
+                                </p>
+                                <div
+                                  data-testid="oauth-user-code"
+                                  className="font-mono text-2xl font-semibold tracking-[0.25em] text-mycel-text bg-mycel-surface-2 border border-mycel-border rounded-md px-5 py-2.5 select-all"
+                                >
+                                  {oauthSession.user_code}
+                                </div>
+                              </>
+                            ) : (
+                              <p className="text-xs text-mycel-muted text-center">
+                                Continue the sign-in in your browser
+                              </p>
+                            )}
+                            {authURL !== "" && (
+                              <a
+                                href={authURL}
+                                onClick={(e) => { e.preventDefault(); openExternal(authURL); }}
+                                className="inline-flex items-center justify-center h-11 min-w-[44px] px-4 bg-mycel-accent hover:bg-mycel-accent-hover text-mycel-accent-fg rounded-md font-medium text-sm shadow-mycel-sm transition-colors"
+                              >
+                                Open {shortURLLabel(authURL)} &rarr;
+                              </a>
+                            )}
+                            <div role="status" className="flex items-center gap-2 text-xs text-mycel-muted">
+                              <span className="w-2 h-2 bg-mycel-warning rounded-full animate-pulse" aria-hidden />
+                              Waiting for authorization…
+                              {authURL !== "" && (
+                                <>
+                                  <span aria-hidden>·</span>
+                                  <button
+                                    type="button"
+                                    onClick={() => { openExternal(authURL); }}
+                                    className="text-mycel-accent hover:underline font-medium"
+                                  >
+                                    Reopen browser
+                                  </button>
+                                </>
+                              )}
                             </div>
-                          </>
-                        ) : (
-                          <p className="text-xs text-mycel-muted text-center">
-                            Continue the sign-in in your browser
-                          </p>
-                        )}
-                        {(oauthSession.verification_url ?? oauthSession.auth_url) && (
-                          <a
-                            href={oauthSession.verification_url ?? oauthSession.auth_url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center h-9 px-4 bg-mycel-accent hover:bg-mycel-accent-hover text-mycel-accent-fg rounded-md font-medium text-sm shadow-mycel-sm transition-colors"
-                          >
-                            Open {humanURL(oauthSession.verification_url ?? oauthSession.auth_url ?? "")} &rarr;
-                          </a>
-                        )}
-                        <div className="flex items-center gap-2 text-xs text-mycel-muted">
-                          <span className="w-2 h-2 bg-mycel-warning rounded-full animate-pulse" />
-                          Waiting for authorization...
-                        </div>
-                      </div>
+                          </div>
+                        );
+                      })()
                     ) : (
                       <div className="flex flex-col items-center gap-2">
                         <button
                           type="button"
                           onClick={() => { void startOAuth(); }}
                           disabled={oauthState === "starting"}
-                          className="inline-flex items-center h-9 px-6 bg-mycel-accent hover:bg-mycel-accent-hover text-mycel-accent-fg rounded-md font-medium text-sm shadow-mycel-sm transition-colors disabled:opacity-50"
+                          className="inline-flex items-center justify-center h-11 min-w-[44px] px-6 bg-mycel-accent hover:bg-mycel-accent-hover text-mycel-accent-fg rounded-md font-medium text-sm shadow-mycel-sm transition-colors disabled:opacity-50"
                         >
                           {oauthState === "starting" ? "Starting sign-in..." : oauthState === "error" ? `Retry sign in with ${descriptor.label}` : `Sign in with ${descriptor.label}`}
                         </button>
@@ -1038,6 +1081,16 @@ export function ConnectWizard({
                       <span className="flex-1 border-t border-mycel-border" />
                     </summary>
                     <div className="space-y-3 pt-3">
+                      {descriptor.docs.length > 0 && (
+                        <ol className="space-y-1.5 mb-1">
+                          {descriptor.docs.map((docStep, i) => (
+                            <li key={i} className="flex gap-2 text-xs text-mycel-text-2">
+                              <span className="text-mycel-accent tabular-nums shrink-0">{i + 1}.</span>
+                              <span>{linkifyDoc(docStep)}</span>
+                            </li>
+                          ))}
+                        </ol>
+                      )}
                       {descriptor.fields.map(renderField)}
                     </div>
                   </details>

--- a/web/src/components/apps/__tests__/connectApp.test.tsx
+++ b/web/src/components/apps/__tests__/connectApp.test.tsx
@@ -11,6 +11,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { AppChooser, ConnectWizard, sanitizeInstanceLabel } from "../ConnectApp";
+import { openExternal } from "../../../utils/openExternal";
+
+// openExternal is the one seam that must own "open the system browser" —
+// in the Wails desktop app a plain <a target=_blank> click never reaches
+// the OS browser, so every sign-in affordance routes through here instead.
+// Mocked so tests assert the call without touching window.open/navigation.
+vi.mock("../../../utils/openExternal", () => ({ openExternal: vi.fn() }));
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
 
@@ -72,7 +79,18 @@ const catalog = {
         { key: "client_secret", label: "OAuth Client Secret", placeholder: "GOCSPX-...", secret: true, required: true },
         { key: "refresh_token", label: "OAuth Refresh Token", placeholder: "1//0g...", secret: true, required: true },
       ],
-      docs: [],
+      // The dense manual path: create OAuth creds, OAuth Playground, paste
+      // a refresh token — the seven-step wall that must collapse behind
+      // "Advanced" whenever one-click sign-in is available.
+      docs: [
+        "Create a project in Google Cloud Console",
+        "Enable the Gmail API",
+        "Configure the OAuth consent screen",
+        "Create an OAuth Client ID (Desktop app)",
+        "Open the OAuth 2.0 Playground",
+        "Authorize the Gmail scope and exchange for a refresh token",
+        "Paste the client ID, secret and refresh token below",
+      ],
     },
   ],
   instances: [
@@ -97,6 +115,7 @@ function mockCatalog(overrides: { post?: () => Promise<Response> } = {}) {
 
 beforeEach(() => {
   fetchMock.mockReset();
+  vi.mocked(openExternal).mockReset();
 });
 
 /* ── AppChooser — catalog rendering ──────────────────────────── */
@@ -300,7 +319,20 @@ describe("ConnectWizard OAuth", () => {
     });
     const link = screen.getByRole("link", { name: /\bgithub\.com\/login\/device/ });
     expect(link).toHaveAttribute("href", "https://github.com/login/device");
-    expect(screen.getByText("Waiting for authorization...")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent(/Waiting for authorization/);
+
+    // "Sign in" itself already opened the system browser via openExternal
+    // (not a plain <a target=_blank> navigation — that's a no-op inside
+    // the Wails desktop webview, the original "link doesn't work" bug).
+    expect(openExternal).toHaveBeenCalledWith("https://github.com/login/device");
+    expect(openExternal).toHaveBeenCalledTimes(1);
+
+    // The visible link is still a real, clickable fallback...
+    fireEvent.click(link);
+    expect(openExternal).toHaveBeenCalledTimes(2);
+    // ...and so is "Reopen browser", for a missed/closed/blocked popup.
+    fireEvent.click(screen.getByRole("button", { name: "Reopen browser" }));
+    expect(openExternal).toHaveBeenCalledTimes(3);
 
     const begin = fetchMock.mock.calls.find(
       (c) => String(c[0]) === "/api/apps/github/auth" && (c[1] as RequestInit | undefined)?.method === "POST",
@@ -379,16 +411,45 @@ describe("ConnectWizard OAuth", () => {
     await waitFor(() => {
       expect(screen.getByText("Connect Gmail")).toBeInTheDocument();
     });
-    // Callback flow has no user code — manual fields stay collapsed.
+    // Callback flow has no user code — manual fields, and the seven dense
+    // setup steps, stay collapsed under Advanced by default (native
+    // <details> collapse is the `open` attribute, which jsdom does not
+    // strip content for — so assert the attribute, not text absence).
     expect(screen.getByTestId("manual-config")).toBeInTheDocument();
+    expect(screen.getByTestId("manual-config")).not.toHaveAttribute("open");
+    // The raw authorization URL (with client_id/redirect_uri query params)
+    // must never be dumped into the page as sprawling body text.
+    expect(screen.queryByText(/redirect_uri/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/client_id=x/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Sign in with Gmail" }));
 
-    // Callback-flow UX: a link to open the Google consent page (no code).
+    // Callback-flow UX: a short link (host + path only, no query string)
+    // to open the Google consent page (no device code for this kind).
+    const authURL =
+      "https://accounts.google.com/o/oauth2/auth?client_id=x&redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Foauth%2Fcallback";
+    let link: HTMLElement;
     await waitFor(() => {
-      expect(screen.getByRole("link", { name: /\baccounts\.google\.com\// })).toBeInTheDocument();
+      link = screen.getByRole("link", { name: /\baccounts\.google\.com\// });
+      expect(link).toBeInTheDocument();
     });
+    expect(link!).toHaveTextContent("accounts.google.com/o/oauth2/auth");
+    expect(link!).not.toHaveTextContent("redirect_uri");
     expect(screen.queryByTestId("oauth-user-code")).not.toBeInTheDocument();
+
+    // "Sign in with Gmail" already opened the browser with the full
+    // authorize URL (query string and all) — the shortened label is
+    // display-only, never what's actually opened or posted anywhere.
+    expect(openExternal).toHaveBeenCalledWith(authURL);
+    // The link is still a working manual fallback.
+    fireEvent.click(link!);
+    expect(openExternal).toHaveBeenCalledTimes(2);
+
+    // Advanced disclosure can still be opened manually — nothing was
+    // deleted, just collapsed.
+    fireEvent.click(screen.getByText("Advanced — configure manually or paste a token"));
+    expect(screen.getByTestId("manual-config")).toHaveAttribute("open");
+    expect(screen.getByText("Create a project in Google Cloud Console")).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.getByText("Add agents to Gmail")).toBeInTheDocument();

--- a/web/src/utils/openExternal.ts
+++ b/web/src/utils/openExternal.ts
@@ -1,0 +1,30 @@
+/**
+ * openExternal — open a URL in the user's system browser from either the
+ * embedded web UI or the Wails desktop app.
+ *
+ * In the desktop app, `window.open` / `<a target="_blank">` do NOT open
+ * the system browser — Wails intercepts navigation inside its webview, so
+ * the click silently does nothing (this was the "sign-in link doesn't
+ * work" bug). The Wails runtime injects `window.runtime.BrowserOpenURL`
+ * into the page at startup; when present, it is the only reliable way to
+ * hand a URL to the OS browser. The web build never has `window.runtime`,
+ * so it falls back to a plain new-tab open there.
+ */
+export function openExternal(url: string): void {
+  if (!url) return;
+  const wailsOpen = window.runtime?.BrowserOpenURL;
+  if (typeof wailsOpen === "function") {
+    wailsOpen(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+declare global {
+  interface Window {
+    /** Present only inside the Wails desktop webview. */
+    runtime?: {
+      BrowserOpenURL?: (url: string) => void;
+    };
+  }
+}

--- a/web/src/views/__tests__/appsHome.test.tsx
+++ b/web/src/views/__tests__/appsHome.test.tsx
@@ -415,4 +415,36 @@ describe("AppsHome", () => {
     const viewAll = screen.getByRole("link", { name: /View all/i });
     expect(viewAll).toHaveAttribute("href", "/apps/activity");
   });
+
+  it("?connect=<app> deep-links straight into that app's connect modal (the degraded banner's Check setup target)", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/notifications/overview")) return errorResponse(404);
+      if (u.includes("/history")) return jsonResponse([]);
+      if (u.includes("/api/apps/channels")) return jsonResponse(sources);
+      if (u.includes("/api/apps")) {
+        return jsonResponse({
+          catalog: [
+            ...appsCatalog.catalog,
+            { id: "gmail", label: "Gmail", auth: "token", multi: false, oauth_available: true, fields: [], docs: [] },
+          ],
+          instances: appsCatalog.instances,
+        });
+      }
+      return jsonResponse([]);
+    });
+    render(
+      <MemoryRouter initialEntries={["/apps?connect=gmail"]}>
+        <HeaderSlotProvider>
+          <HeaderHost />
+          <AppsHome />
+        </HeaderSlotProvider>
+      </MemoryRouter>,
+    );
+    // The connect modal for the named app opens directly — no detour
+    // through a generic readiness page or the app-picker catalog.
+    await waitFor(() => {
+      expect(screen.getByText("Connect Gmail")).toBeInTheDocument();
+    });
+  });
 });

--- a/web/src/views/__tests__/appsHome.test.tsx
+++ b/web/src/views/__tests__/appsHome.test.tsx
@@ -416,7 +416,8 @@ describe("AppsHome", () => {
     expect(viewAll).toHaveAttribute("href", "/apps/activity");
   });
 
-  it("?connect=<app> deep-links straight into that app's connect modal (the degraded banner's Check setup target)", async () => {
+  /** Catalog with Gmail added so ?connect=gmail resolves a descriptor. */
+  function mockCatalogWithGmail() {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {
       const u = String(url);
       if (u.includes("/api/notifications/overview")) return errorResponse(404);
@@ -433,18 +434,38 @@ describe("AppsHome", () => {
       }
       return jsonResponse([]);
     });
-    render(
-      <MemoryRouter initialEntries={["/apps?connect=gmail"]}>
+  }
+
+  function renderAt(entry: string) {
+    return render(
+      <MemoryRouter initialEntries={[entry]}>
         <HeaderSlotProvider>
           <HeaderHost />
           <AppsHome />
         </HeaderSlotProvider>
       </MemoryRouter>,
     );
+  }
+
+  it("?connect=<app> deep-links straight into that app's connect modal (the degraded banner's Check setup target)", async () => {
+    mockCatalogWithGmail();
+    renderAt("/apps?connect=gmail");
     // The connect modal for the named app opens directly — no detour
     // through a generic readiness page or the app-picker catalog.
     await waitFor(() => {
       expect(screen.getByText("Connect Gmail")).toBeInTheDocument();
     });
+  });
+
+  it("?connect wins over ?action=connect — only the app modal opens, the chooser stays closed", async () => {
+    mockCatalogWithGmail();
+    renderAt("/apps?connect=gmail&action=connect");
+    await waitFor(() => {
+      expect(screen.getByText("Connect Gmail")).toBeInTheDocument();
+    });
+    // The catalog chooser (AppChooser) must NOT also be open — otherwise it
+    // sits stuck behind the wizard and reappears when the wizard closes.
+    expect(screen.queryByText("Connect an app")).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search apps...")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Part of #3423

## Summary

The Connect-App modal's OAuth sign-in was broken and ugly:
- The raw OAuth authorization URL (client_id, redirect_uri, scope, state — all of it) was rendered as huge, sprawling, selectable body text, overflowing the "Continue the sign-in in your browser" box.
- Seven dense manual "SETUP STEPS" (create OAuth creds → OAuth Playground → paste a refresh token) dominated the modal even when one-click sign-in was available.
- The flow got stuck at "Waiting for authorization…" because the sign-in link relied on `<a target="_blank">` / `window.open` — which is a no-op inside the **Wails desktop app's webview**. That's the actual root cause of "link doesn't work."

## How the desktop browser-open works

Added `web/src/utils/openExternal.ts`:

```ts
export function openExternal(url: string): void {
  const wailsOpen = window.runtime?.BrowserOpenURL;
  if (typeof wailsOpen === "function") { wailsOpen(url); return; }
  window.open(url, "_blank", "noopener,noreferrer");
}
```

Wails v2 injects `window.runtime.BrowserOpenURL` into the native webview at startup (see `desktop/frontend/wailsjs/runtime/runtime.d.ts`) — it's the only reliable way to hand a URL to the OS browser from inside that window; the desktop app boots by navigating the same window to `http://127.0.0.1:<port>` (see `desktop/README.md`/`bootpage.go`), so the injected runtime is present on the real app UI, not just a wails-asset page. The plain web build never has `window.runtime`, so `openExternal` falls back to `window.open`. `ConnectApp.tsx` now routes every sign-in affordance (the primary click, the visible link, and "Reopen browser") through this one helper instead of raw anchor navigation.

`startOAuth()` now calls `openExternal(authURL)` itself the moment the session is created — one click really means one click, no hunting for a second link.

## Other fixes

- `shortURLLabel()` shows only host + path for the on-screen "Open …" label (e.g. `accounts.google.com/o/oauth2/auth`), dropping the query string entirely. The **full** URL (query string included) is still what's actually opened — verified by test.
- The 7-step "Setup Steps" doc list and the manual client-ID/secret/refresh-token fields now live under the existing "Advanced — configure manually" `<details>`, collapsed by default whenever `oauth_available` — same treatment applied to GitHub's device-code flow (still shows the user code + "Open GitHub" button, cleanly).
- `role="status"` on the waiting line, 44px+ touch targets on the sign-in / reopen controls.
- **Degraded-services banner** ("Check setup"): when the degraded item is `app:<name>`, it now deep-links to `/apps?connect=<name>` (opens that app's own connect modal) instead of the generic `/readiness` page. Non-app degradation (deps/runtime) is unchanged. `AppsHome` now honors `?connect=<id>` the same way it already honored `?action=connect`.

## Files

- `web/src/utils/openExternal.ts` (new)
- `web/src/components/apps/ConnectApp.tsx`
- `web/src/components/apps/AppsHome.tsx`
- `web/src/components/Layout.tsx`
- Tests: `web/src/components/apps/__tests__/connectApp.test.tsx`, `web/src/views/__tests__/appsHome.test.tsx`, `web/src/components/__tests__/LayoutReadiness.test.tsx`

## Test plan

- [x] `make build-local-web` — builds clean
- [x] `bunx tsc --noEmit` — no errors
- [x] `bun run lint` (eslint) — clean
- [x] `bunx vitest run` — 404/404 passing, including new/updated cases:
  - clicking Sign-in calls `openExternal` with the full auth URL (device flow + callback/loopback flow)
  - "Reopen browser" re-issues the same `openExternal` call
  - manual config + setup-step docs are collapsed (`<details>` has no `open` attribute) by default when `oauth_available`, and can still be expanded
  - raw query-string URL never appears as page text
  - `app:gmail` degraded banner's "Check setup" links to `/apps?connect=gmail`
  - `/apps?connect=gmail` deep-link opens the Gmail connect modal directly

Not merging — leaving for review per instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * “Check setup” links for degraded app services now open the relevant app connection flow directly.
  * App connection links can open a specific app’s setup modal automatically.
  * OAuth setup now opens in an external browser when available, with a “Reopen browser” option and clearer status messaging.
  * Manual setup instructions are available under Advanced configuration when needed.

* **Bug Fixes**
  * Improved fallback behavior when external browser launching is unavailable.
  * Removed processed connection parameters from the URL after setup begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->