### PR TITLE
feat(agent): inject GitHub token as GH_TOKEN/GITHUB_TOKEN so agents can use gh/git

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3362,6 +3362,8 @@ func openLayeredStore(repoPath, passphrase string) (ls *secret.LayeredStore, clo
 //
 // GITHUB_PERSONAL_ACCESS_TOKEN and GITHUB_TOKEN in the vault are aliased to
 // both GITHUB_TOKEN and GH_TOKEN so git/gh tooling works without manual wiring.
+// The connected GitHub app's api_token (app:<instance>:api_token, populated
+// by "Sign in with GitHub" or pasted manually) is aliased the same way.
 //
 // Secret VALUES are never logged.
 //
@@ -3407,6 +3409,17 @@ func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []st
 	// 1.5. Connected-app credentials — descriptor Secret fields resolve from
 	//      the vault under app:<instance>:<key> into conventional env names
 	//      (SLACK_BOT_TOKEN, TELEGRAM_BOT_TOKEN_ALERTS, ...).
+	//
+	//      Special case: the GitHub app's "api_token" field (populated by the
+	//      device-flow "Sign in with GitHub" OAuth, or pasted manually) is
+	//      additionally aliased to GH_TOKEN/GITHUB_TOKEN so `gh` and git's
+	//      credential helper authenticate automatically — same convenience as
+	//      the GITHUB_PERSONAL_ACCESS_TOKEN vault alias below (step 3), just
+	//      sourced from a connected app instead of a hand-set vault secret.
+	//      Scoping matches every other connected-app credential here: any
+	//      enabled instance's token is available to all agents (the same
+	//      model as SLACK_BOT_TOKEN etc.) — there is no per-agent app
+	//      subscription in this codebase to scope against.
 	for name, ic := range apps {
 		if !ic.Enabled {
 			continue
@@ -3416,8 +3429,13 @@ func injectVaultSecrets(env map[string]string, repoPath string, roleSecrets []st
 			continue
 		}
 		for _, f := range plugin.Describe().Fields {
-			if f.Secret {
-				injectIfAbsent(app.EnvKey(name, f.Key), app.SecretName(name, f.Key))
+			if !f.Secret {
+				continue
+			}
+			injectIfAbsent(app.EnvKey(name, f.Key), app.SecretName(name, f.Key))
+			if ic.App == "github" && f.Key == "api_token" {
+				injectIfAbsent("GITHUB_TOKEN", app.SecretName(name, f.Key))
+				injectIfAbsent("GH_TOKEN", app.SecretName(name, f.Key))
 			}
 		}
 	}

--- a/pkg/agent/vault_inject_test.go
+++ b/pkg/agent/vault_inject_test.go
@@ -196,6 +196,76 @@ func TestInjectVaultSecretsAppCredentials(t *testing.T) {
 	}
 }
 
+// TestInjectVaultSecrets_GitHubAppToken proves a connected GitHub app
+// instance's api_token (as populated by the device-flow "Sign in with
+// GitHub", or pasted manually) is made available to agents as both
+// GH_TOKEN and GITHUB_TOKEN — so `gh` and git's credential helper
+// authenticate with zero per-agent setup — while an agent with no
+// connected GitHub app instance gets neither key.
+func TestInjectVaultSecrets_GitHubAppToken(t *testing.T) {
+	mycelHome := t.TempDir()
+	t.Setenv("MYCEL_HOME", mycelHome)
+	t.Setenv(secret.PassphraseEnvVar, "test-passphrase")
+
+	repoPath := t.TempDir()
+	seedRepoVault(t, repoPath, "app:github:api_token", "gho_devflow_token")
+
+	t.Run("connected instance yields GH_TOKEN and GITHUB_TOKEN", func(t *testing.T) {
+		apps := map[string]app.InstanceConfig{
+			"github": {App: "github", Enabled: true},
+		}
+		env := map[string]string{}
+		injected := injectVaultSecrets(env, repoPath, nil, apps)
+
+		if env["GH_TOKEN"] != "gho_devflow_token" {
+			t.Errorf("GH_TOKEN = %q, want gho_devflow_token", env["GH_TOKEN"])
+		}
+		if env["GITHUB_TOKEN"] != "gho_devflow_token" {
+			t.Errorf("GITHUB_TOKEN = %q, want gho_devflow_token", env["GITHUB_TOKEN"])
+		}
+		// The generic connected-app env name is still populated too.
+		if env["GITHUB_API_TOKEN"] != "gho_devflow_token" {
+			t.Errorf("GITHUB_API_TOKEN = %q, want gho_devflow_token", env["GITHUB_API_TOKEN"])
+		}
+		found := false
+		for _, k := range injected {
+			if k == "GH_TOKEN" {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("GH_TOKEN should be reported in the injected key names")
+		}
+	})
+
+	t.Run("disabled instance yields neither key", func(t *testing.T) {
+		apps := map[string]app.InstanceConfig{
+			"github": {App: "github", Enabled: false},
+		}
+		env := map[string]string{}
+		injectVaultSecrets(env, repoPath, nil, apps)
+
+		if _, ok := env["GH_TOKEN"]; ok {
+			t.Error("GH_TOKEN should be absent when no github app instance is enabled")
+		}
+		if _, ok := env["GITHUB_TOKEN"]; ok {
+			t.Error("GITHUB_TOKEN should be absent when no github app instance is enabled")
+		}
+	})
+
+	t.Run("no github app configured yields neither key", func(t *testing.T) {
+		env := map[string]string{}
+		injectVaultSecrets(env, repoPath, nil, nil)
+
+		if _, ok := env["GH_TOKEN"]; ok {
+			t.Error("GH_TOKEN should be absent with no apps configured")
+		}
+		if _, ok := env["GITHUB_TOKEN"]; ok {
+			t.Error("GITHUB_TOKEN should be absent with no apps configured")
+		}
+	})
+}
+
 // TestAppEnvAndPromptInstructions covers plain-field env injection and the
 // descriptor-driven prompt documentation.
 func TestAppEnvAndPromptInstructions(t *testing.T) {


### PR DESCRIPTION
## Summary
- Connected GitHub app instances already store their OAuth token (device-flow "Sign in with GitHub", or a pasted PAT) as the `api_token` secret field, at vault key `app:<instance>:api_token`, and already export it generically as `GITHUB_API_TOKEN` (or `GITHUB_API_TOKEN_<label>` for a labeled instance) — but that name isn't what `gh`/git tooling looks for.
- `injectVaultSecrets` (pkg/agent/agent.go) now special-cases the github app's `api_token` field: in addition to the existing generic env name, it aliases the same vault value to both `GH_TOKEN` and `GITHUB_TOKEN`, so `gh` (reads `GH_TOKEN`) and git's credential helper via `gh auth setup-git` (reads `GITHUB_TOKEN`/`GH_TOKEN`) authenticate with zero per-agent setup once "Sign in with GitHub" is connected.
- Existing env values still win (precedence unchanged): an agent-set `GH_TOKEN`/`GITHUB_TOKEN`, or the pre-existing `GITHUB_PERSONAL_ACCESS_TOKEN` vault-secret alias, is never overwritten.

## Scoping decision
This follows the exact model already used for every other connected-app credential and for the well-known gateway tokens (`SLACK_BOT_TOKEN`, etc.) in `injectVaultSecrets`: any **enabled** app instance's secret is exported to **all** agents. There is no per-agent app subscription in this codebase to scope tighter against — apps are configured once (globally, in `cfg.Apps`) and every spawned agent's env is built from that same map. A disabled instance, or no github app instance at all, yields neither `GH_TOKEN` nor `GITHUB_TOKEN`.

## Where it's wired
- `pkg/agent/agent.go`: `injectVaultSecrets`, connected-app credential loop (step "1.5"), called from `SpawnAgentWithOptions`/agent-restart paths after `injectEnv`/`injectAppEnv` so precedence holds.
- Vault key read: `app:<instance>:api_token` (e.g. `app:github:api_token` for the default unlabeled instance), via `pkg/app.SecretName`.
- New keys exported: `GH_TOKEN`, `GITHUB_TOKEN` (alongside the pre-existing generic `GITHUB_API_TOKEN`).

Part of #3423

## Test plan
- [x] `go build ./pkg/...`
- [x] `go vet ./pkg/...`
- [x] `golangci-lint run ./pkg/...` — 0 issues
- [x] `go test -race ./pkg/agent/... ./pkg/secret/... ./pkg/app/...` — all pass
- [x] New test `TestInjectVaultSecrets_GitHubAppToken` (pkg/agent/vault_inject_test.go): connected github app instance → `GH_TOKEN`+`GITHUB_TOKEN` set; disabled instance → neither; no github app configured → neither

🤖 Generated with [Claude Code](https://claude.com/claude-code)