### PR TITLE
feat(gmail): build-time embedded Google client for zero-setup desktop sign-in

### DIFF
--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -55,6 +55,14 @@ jobs:
             org.opencontainers.image.source=https://github.com/rpuneet/mycel
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.description=mycel AI agent orchestration (main branch)
+          # mycel's registered Google "Desktop app" OAuth client, baked into
+          # the daemon binary so Gmail "Sign in with Google" works
+          # zero-setup. Empty when the repo secrets aren't set (e.g. forks)
+          # — the image then behaves exactly as an unconfigured server. See
+          # pkg/gateway/gmail/oauth.go for why this is safe to embed.
+          build-args: |
+            GOOGLE_OAUTH_CLIENT_ID=${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+            GOOGLE_OAUTH_CLIENT_SECRET=${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # mycel's registered Google "Desktop app" OAuth client, baked in at
+          # build time so Gmail "Sign in with Google" works zero-setup on
+          # official release binaries. Empty when the repo secrets aren't
+          # set — the built binary then behaves exactly as an unconfigured
+          # server (manual paste path only). See pkg/gateway/gmail/oauth.go.
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
 
   # ── macOS release (native CGO builds on both architectures) ─────────
   release-macos:
@@ -133,11 +140,18 @@ jobs:
       - name: Build macOS binaries
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          # mycel's registered Google "Desktop app" OAuth client — see the
+          # GoReleaser job above for the full rationale. Empty when repo
+          # secrets aren't set; behavior is then unchanged.
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
         run: |
           VERSION=${RELEASE_TAG#v}
           COMMIT=$(git rev-parse --short HEAD)
           DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           LDFLAGS="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}"
+          LDFLAGS="${LDFLAGS} -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID=${GOOGLE_OAUTH_CLIENT_ID}"
+          LDFLAGS="${LDFLAGS} -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret=${GOOGLE_OAUTH_CLIENT_SECRET}"
 
           # arm64 (native on macos-latest)
           CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 go build -ldflags="${LDFLAGS}" -o dist/mycel ./cmd/mycel
@@ -213,11 +227,18 @@ jobs:
           PLATFORM: ${{ matrix.os }}/${{ matrix.arch }}
           VERSION: ${{ needs.prepare.outputs.version }}
           COMMIT: ${{ github.sha }}
+          # mycel's registered Google "Desktop app" OAuth client — see the
+          # GoReleaser job above for the full rationale. Empty when repo
+          # secrets aren't set; behavior is then unchanged.
+          GOOGLE_OAUTH_CLIENT_ID: ${{ secrets.GOOGLE_OAUTH_CLIENT_ID }}
+          GOOGLE_OAUTH_CLIENT_SECRET: ${{ secrets.GOOGLE_OAUTH_CLIENT_SECRET }}
         run: |
           # Inject the release version so the app's About/info shows it instead
           # of the "dev" default, and sync the Wails product version so the
           # bundle metadata (macOS Info.plist / Windows file info) matches.
           LDFLAGS="-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          LDFLAGS="${LDFLAGS} -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID=${GOOGLE_OAUTH_CLIENT_ID}"
+          LDFLAGS="${LDFLAGS} -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret=${GOOGLE_OAUTH_CLIENT_SECRET}"
           sed -i.bak "s/\"productVersion\": \"[^\"]*\"/\"productVersion\": \"${VERSION}\"/" wails.json && rm -f wails.json.bak
           case "${{ matrix.os }}" in
             linux)

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,8 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
       - -X main.date={{.Date}}
+      - -X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID={{.Env.GOOGLE_OAUTH_CLIENT_ID}}'
+      - -X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret={{.Env.GOOGLE_OAUTH_CLIENT_SECRET}}'
     goos:
       - linux
     goarch:
@@ -43,6 +45,8 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
       - -X main.date={{.Date}}
+      - -X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID={{.Env.GOOGLE_OAUTH_CLIENT_ID}}'
+      - -X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret={{.Env.GOOGLE_OAUTH_CLIENT_SECRET}}'
     goos:
       - linux
     goarch:
@@ -59,6 +63,8 @@ builds:
       - -X main.version={{.Version}}
       - -X main.commit={{.ShortCommit}}
       - -X main.date={{.Date}}
+      - -X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID={{.Env.GOOGLE_OAUTH_CLIENT_ID}}'
+      - -X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret={{.Env.GOOGLE_OAUTH_CLIENT_SECRET}}'
     goos:
       - windows
     goarch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,19 @@ Naming convention: `make <verb>-<runtime>-<component>` where `verb` = `build` | 
 | `make build-docker-agent-base` | Build the agent base image |
 | `make build-docker-playwright` | Build the Playwright MCP Docker image |
 
+### Optional: embedding the Google OAuth client for Gmail
+
+`make build-local-mycel`, `make release-local-mycel`, and `make build-local-desktop` all read `GOOGLE_OAUTH_CLIENT_ID` / `GOOGLE_OAUTH_CLIENT_SECRET` from the environment and inject them into the binary via `-ldflags -X` so that Gmail's "Sign in with Google" works with zero setup. Nothing is hardcoded in source — if the variables are unset the build is unaffected and Gmail falls back to the manual client-id/secret/refresh-token paste, exactly as before.
+
+- **Official releases**: the maintainer sets `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` as repo Actions secrets (used by `release.yml`, `cd-main.yml`, and `.goreleaser.yml`).
+- **Local dev**: `export GOOGLE_OAUTH_CLIENT_ID=... GOOGLE_OAUTH_CLIENT_SECRET=...` before running the build commands above to test one-click sign-in locally.
+
+This is safe to embed because the client is registered as a Google "Desktop app" (installed application) OAuth client — Google's own docs treat the client secret for that client type as non-confidential (it can't be kept secret in a distributed binary), so baking it in at build time is the standard, supported pattern rather than a workaround. See `pkg/gateway/gmail/oauth.go` for the resolution order (env var override → build-injected default → unconfigured).
+
 ### Test
 
 | Command | Description |
 |---------|-------------|
-| `make test` | Run all tests (go + ts) |
 | `make test-go` | Run Go tests with race detector |
 | `make test-go-fast` | Go tests excluding slow packages (tmux, secret, doctor, internal/cmd) |
 | `make test-ts` | Run all TS tests (web + landing) |

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,18 @@ IMAGE_TAG ?= latest
 AGENT_PROVIDERS := claude agy codex cursor openclaw pi
 
 LDFLAGS_VERSION = -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
-LDFLAGS_RELEASE = -s -w $(LDFLAGS_VERSION)
+
+# Official mycel builds embed the registered Google "Desktop app" OAuth
+# client so Gmail "Sign in with Google" works zero-setup. GOOGLE_OAUTH_CLIENT_ID
+# / GOOGLE_OAUTH_CLIENT_SECRET are sourced from the environment (maintainer
+# exports them locally, or CI reads them from repo Actions secrets); when
+# unset both ldflags args are empty and the built binary behaves exactly as
+# before (one-click sign-in reports unconfigured, manual paste path still
+# works). Nothing secret is ever committed — see pkg/gateway/gmail/oauth.go.
+GMAIL_PKG := github.com/rpuneet/mycel/pkg/gateway/gmail
+LDFLAGS_GMAIL = -X '$(GMAIL_PKG).defaultGoogleClientID=$(GOOGLE_OAUTH_CLIENT_ID)' -X '$(GMAIL_PKG).defaultGoogleClientSecret=$(GOOGLE_OAUTH_CLIENT_SECRET)'
+
+LDFLAGS_RELEASE = -s -w $(LDFLAGS_VERSION) $(LDFLAGS_GMAIL)
 
 _CYAN  := \033[36m
 _GREEN := \033[32m
@@ -108,11 +119,11 @@ build-local-go: build-local-mycel ## Build all Go binaries
 build-local-mycel: build-local-web ## Build mycel (embeds web UI, server)
 	@mkdir -p $(BUILD_DIR)
 	@if [ ! -f server/web/dist/index.html ]; then mkdir -p server/web/dist && echo "<!-- stub -->" > server/web/dist/index.html; fi
-	$(GO) build -ldflags="$(LDFLAGS_VERSION)" -o $(BUILD_DIR)/mycel ./cmd/mycel
+	$(GO) build -ldflags="$(LDFLAGS_VERSION) $(LDFLAGS_GMAIL)" -o $(BUILD_DIR)/mycel ./cmd/mycel
 
 
 build-local-desktop: build-local-web ## Build desktop app for the host OS (requires wails CLI)
-	cd desktop && wails build -ldflags "$(LDFLAGS_VERSION)"
+	cd desktop && wails build -ldflags "$(LDFLAGS_VERSION) $(LDFLAGS_GMAIL)"
 
 
 # =============================================================================
@@ -282,6 +293,7 @@ release-local-mycel: ## Build optimized mycel binary (embeds web UI)
 	@mkdir -p $(BUILD_DIR)
 	@if [ ! -f server/web/dist/index.html ]; then mkdir -p server/web/dist && echo "<!-- stub -->" > server/web/dist/index.html; fi
 	$(GO) build -ldflags="$(LDFLAGS_RELEASE)" -o $(BUILD_DIR)/mycel ./cmd/mycel
+	# LDFLAGS_RELEASE already includes LDFLAGS_GMAIL (see Variables section).
 
 
 # =============================================================================

--- a/docker/Dockerfile.daemon
+++ b/docker/Dockerfile.daemon
@@ -25,7 +25,19 @@ COPY server/ server/
 COPY internal/ internal/
 COPY --from=web /app/web/dist /app/server/web/dist
 
-RUN CGO_ENABLED=1 go build -ldflags="-s -w" -o /mycel ./cmd/mycel
+# mycel's registered Google "Desktop app" OAuth client, baked in at build
+# time so Gmail "Sign in with Google" works zero-setup. Passed as build args
+# (not secrets) because for a Google "installed application" OAuth client the
+# secret is explicitly documented as non-confidential — see
+# pkg/gateway/gmail/oauth.go. Left unset, these default to empty and the
+# built binary behaves exactly as an unconfigured server (manual paste path
+# only).
+ARG GOOGLE_OAUTH_CLIENT_ID=""
+ARG GOOGLE_OAUTH_CLIENT_SECRET=""
+RUN CGO_ENABLED=1 go build -ldflags="-s -w \
+    -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID=${GOOGLE_OAUTH_CLIENT_ID} \
+    -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret=${GOOGLE_OAUTH_CLIENT_SECRET}" \
+    -o /mycel ./cmd/mycel
 
 # Stage 3: Runtime (bundles the Go toolchain so tmux-mode agents can build
 # Go projects in-container; see pkg/tool "go" tool)

--- a/pkg/gateway/gmail/oauth.go
+++ b/pkg/gateway/gmail/oauth.go
@@ -13,13 +13,39 @@ import (
 	"github.com/rpuneet/mycel/pkg/oauth"
 )
 
-// Server-side Google "Desktop app" OAuth client, read from the environment.
-// These are the mycel-registered client credentials that make one-click
-// "Connect with Google" work; when unset, the connect UI falls back to the
-// manual client-id/secret/refresh-token paste.
+// Server-side Google "Desktop app" OAuth client. These are the
+// mycel-registered client credentials that make one-click "Connect with
+// Google" work; when neither source below is set, the connect UI falls back
+// to the manual client-id/secret/refresh-token paste.
+//
+// Resolution order:
+//  1. GOOGLE_OAUTH_CLIENT_ID / GOOGLE_OAUTH_CLIENT_SECRET environment
+//     variables — always wins, lets anyone override at runtime.
+//  2. defaultGoogleClientID / defaultGoogleClientSecret — empty in source
+//     (nothing secret is committed) and injected at build time via
+//     `-ldflags -X` for official mycel release builds. For a Google
+//     "installed application" (Desktop app) OAuth client, Google's own docs
+//     say the client secret is "not treated as confidential" — see
+//     https://developers.google.com/identity/protocols/oauth2#installed —
+//     so baking it into the binary is the standard, supported pattern.
 const (
 	envGoogleClientID     = "GOOGLE_OAUTH_CLIENT_ID"
 	envGoogleClientSecret = "GOOGLE_OAUTH_CLIENT_SECRET" //nolint:gosec // env var name, not a credential
+)
+
+// defaultGoogleClientID and defaultGoogleClientSecret are empty by default so
+// nothing secret is ever committed to source. The official release build
+// injects mycel's registered Google Desktop-app OAuth client via:
+//
+//	-ldflags "-X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID=...' \
+//	          -X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret=...'"
+//
+// A local build with neither the env vars nor these ldflags set behaves
+// exactly as before: one-click sign-in reports unconfigured and the UI falls
+// back to the manual paste path.
+var (
+	defaultGoogleClientID     string //nolint:gochecknoglobals // ldflags injection target, empty by default
+	defaultGoogleClientSecret string //nolint:gochecknoglobals // ldflags injection target, empty by default
 )
 
 // newGoogleFlow builds the loopback OAuth flow for Gmail: Google's endpoints,
@@ -47,12 +73,11 @@ func newGoogleFlow() *oauth.LoopbackFlow {
 	)
 }
 
-// googleClientCreds resolves the server-side Google client from the
-// environment, returning an actionable error (surfaced to the user) when the
-// one-click client is not configured.
+// googleClientCreds resolves the server-side Google client — environment
+// variables first, then the build-time embedded default — returning an
+// actionable error (surfaced to the user) when neither is configured.
 func googleClientCreds(_ app.Instance) (clientID, clientSecret string, err error) {
-	clientID = strings.TrimSpace(os.Getenv(envGoogleClientID))
-	clientSecret = strings.TrimSpace(os.Getenv(envGoogleClientSecret))
+	clientID, clientSecret = resolveGoogleClientCreds()
 	if clientID == "" || clientSecret == "" {
 		return "", "", fmt.Errorf(
 			"one-click Google sign-in is not configured on this server — set %s and %s to a Google \"Desktop app\" OAuth client, or paste an OAuth refresh token below instead",
@@ -61,8 +86,23 @@ func googleClientCreds(_ app.Instance) (clientID, clientSecret string, err error
 	return clientID, clientSecret, nil
 }
 
-// googleConfigured reports whether one-click Google sign-in is available.
+// resolveGoogleClientCreds applies the resolution order documented above the
+// default* vars: env override, then the build-injected default.
+func resolveGoogleClientCreds() (clientID, clientSecret string) {
+	clientID = strings.TrimSpace(os.Getenv(envGoogleClientID))
+	clientSecret = strings.TrimSpace(os.Getenv(envGoogleClientSecret))
+	if clientID == "" {
+		clientID = strings.TrimSpace(defaultGoogleClientID)
+	}
+	if clientSecret == "" {
+		clientSecret = strings.TrimSpace(defaultGoogleClientSecret)
+	}
+	return clientID, clientSecret
+}
+
+// googleConfigured reports whether one-click Google sign-in is available,
+// whether via env vars or the build-time embedded default client.
 func googleConfigured() bool {
-	return strings.TrimSpace(os.Getenv(envGoogleClientID)) != "" &&
-		strings.TrimSpace(os.Getenv(envGoogleClientSecret)) != ""
+	clientID, clientSecret := resolveGoogleClientCreds()
+	return clientID != "" && clientSecret != ""
 }

--- a/pkg/gateway/gmail/oauth_test.go
+++ b/pkg/gateway/gmail/oauth_test.go
@@ -44,6 +44,46 @@ func TestOAuthConfiguredTracksEnv(t *testing.T) {
 	}
 }
 
+// TestOAuthConfiguredTracksBuildDefault verifies one-click availability also
+// follows the ldflags-injected default* vars (simulated here by setting them
+// directly, since the real injection happens via `go build -ldflags -X` and
+// can't be exercised from within a test binary).
+func TestOAuthConfiguredTracksBuildDefault(t *testing.T) {
+	p := newTestPlugin()
+
+	t.Setenv(envGoogleClientID, "")
+	t.Setenv(envGoogleClientSecret, "")
+	t.Cleanup(func() { defaultGoogleClientID, defaultGoogleClientSecret = "", "" })
+
+	// Neither env nor build default set: unconfigured.
+	defaultGoogleClientID, defaultGoogleClientSecret = "", ""
+	if p.OAuthConfigured() {
+		t.Error("OAuthConfigured() = true with no creds at all; want false")
+	}
+
+	// Build-time default set, no env override: configured, and the flow
+	// resolves to the injected default values.
+	defaultGoogleClientID = "default.apps.googleusercontent.com"
+	defaultGoogleClientSecret = "GOCSPX-default" //nolint:gosec // test fixture, not a real credential
+
+	if !p.OAuthConfigured() {
+		t.Error("OAuthConfigured() = false with build default set; want true")
+	}
+	gotID, gotSecret := resolveGoogleClientCreds()
+	if gotID != defaultGoogleClientID || gotSecret != defaultGoogleClientSecret {
+		t.Errorf("resolveGoogleClientCreds() = (%q, %q), want build defaults (%q, %q)",
+			gotID, gotSecret, defaultGoogleClientID, defaultGoogleClientSecret)
+	}
+
+	// Env var set alongside a build default: env wins.
+	t.Setenv(envGoogleClientID, "env.apps.googleusercontent.com")
+	t.Setenv(envGoogleClientSecret, "GOCSPX-env")
+	gotID, gotSecret = resolveGoogleClientCreds()
+	if gotID != "env.apps.googleusercontent.com" || gotSecret != "GOCSPX-env" { //nolint:gosec // test fixture, not a real credential
+		t.Errorf("resolveGoogleClientCreds() = (%q, %q), want env override", gotID, gotSecret)
+	}
+}
+
 // TestBeginAuthUnconfigured surfaces an actionable error (not a dead flow)
 // when the server has no Google client.
 func TestBeginAuthUnconfigured(t *testing.T) {

--- a/pkg/gateway/gmail/oauth_test.go
+++ b/pkg/gateway/gmail/oauth_test.go
@@ -53,7 +53,11 @@ func TestOAuthConfiguredTracksBuildDefault(t *testing.T) {
 
 	t.Setenv(envGoogleClientID, "")
 	t.Setenv(envGoogleClientSecret, "")
-	t.Cleanup(func() { defaultGoogleClientID, defaultGoogleClientSecret = "", "" })
+
+	// Capture and restore the linker-injected defaults so a binary built with
+	// real embedded values isn't left cleared for later tests.
+	origID, origSecret := defaultGoogleClientID, defaultGoogleClientSecret
+	t.Cleanup(func() { defaultGoogleClientID, defaultGoogleClientSecret = origID, origSecret })
 
 	// Neither env nor build default set: unconfigured.
 	defaultGoogleClientID, defaultGoogleClientSecret = "", ""


### PR DESCRIPTION
Part of #3423

## Summary

Makes Gmail "Sign in with Google" work zero-setup in the mycel desktop app by baking mycel's official Google Desktop-app OAuth client in **at build time** — not committed to git.

- `pkg/gateway/gmail/oauth.go`: added `defaultGoogleClientID` / `defaultGoogleClientSecret` package vars, empty in source. Resolution order is now: `GOOGLE_OAUTH_CLIENT_ID`/`GOOGLE_OAUTH_CLIENT_SECRET` env vars (override) → these ldflags-injected defaults → not-configured (falls back to the existing manual client-id/secret/refresh-token paste UI). `OAuthConfigured()` / `googleConfigured()` updated accordingly.
- Wired `-ldflags -X ...defaultGoogleClientID=... -X ...defaultGoogleClientSecret=...` into:
  - `Makefile`: `build-local-mycel`, `release-local-mycel` (via `LDFLAGS_RELEASE`), `build-local-desktop`
  - `.goreleaser.yml`: all three build entries (linux-amd64, linux-arm64, windows), via `{{.Env.GOOGLE_OAUTH_CLIENT_ID}}` / `{{.Env.GOOGLE_OAUTH_CLIENT_SECRET}}`
  - `.github/workflows/release.yml`: GoReleaser job env, the macOS binary build step, and the Wails desktop build step (all matrix OSes)
  - `.github/workflows/cd-main.yml`: passed as Docker `build-args` to `docker/Dockerfile.daemon`, which now accepts `ARG GOOGLE_OAUTH_CLIENT_ID` / `ARG GOOGLE_OAUTH_CLIENT_SECRET` (default `""`) and forwards them into the Go build's ldflags
- Left the GitHub OAuth default (`pkg/gateway/github/oauth.go`'s `DefaultOAuthClientID`) as-is — it's a public device-flow client ID with no secret involved, so the ldflags pattern doesn't apply there.

When the env vars/secrets are unset (e.g. a contributor's local build, or a fork's CI run), the ldflags args resolve to empty strings and behavior is byte-for-byte unchanged: one-click sign-in reports unconfigured, manual paste path works as before. Verified this explicitly (see Test plan).

## Maintainer setup (for the official release)

Set `GOOGLE_OAUTH_CLIENT_ID` and `GOOGLE_OAUTH_CLIENT_SECRET` as **repo Actions secrets** in `rpuneet/mycel` (Settings → Secrets and variables → Actions). For local dev/testing, `export GOOGLE_OAUTH_CLIENT_ID=... GOOGLE_OAUTH_CLIENT_SECRET=...` before running the build targets above.

This is safe per Google's own docs: for a "Desktop app" (installed application) OAuth client type, the client secret is explicitly **not treated as confidential** (https://developers.google.com/identity/protocols/oauth2#installed) — baking it into a distributed binary is the standard, supported pattern, not a workaround.

Documented in `CONTRIBUTING.md` under a new "Optional: embedding the Google OAuth client for Gmail" section.

## Test plan

- [x] `go build ./...` — passes
- [x] `go vet ./...` — passes
- [x] `golangci-lint run ./pkg/gateway/...` — 0 issues
- [x] `go test ./pkg/gateway/gmail/...` — all pass, including new tests:
  - `TestOAuthConfiguredTracksBuildDefault`: unconfigured with nothing set → configured with build-default vars set (simulating ldflags injection) → env override wins when both are set
  - existing `TestOAuthConfiguredTracksEnv`, `TestBeginAuthUnconfigured`, `TestBeginAuthConfigured` still pass unchanged
- [x] `go build -ldflags "-X 'github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID=test'" ./cmd/mycel` — compiles
- [x] `GOOGLE_OAUTH_CLIENT_ID=dummyid GOOGLE_OAUTH_CLIENT_SECRET=dummysecret make build-local-mycel` — builds; confirmed via `strings bin/mycel` that both dummy values land in the binary
- [x] Plain `make build-local-mycel` (no env vars) — confirmed via `strings bin/mycel` that neither dummy value (nor anything) is embedded; ldflags resolve to empty strings
- [x] `gitleaks detect` — no new findings from this change (source vars are empty; secrets only ever come from CI secrets / local env at build time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gmail OAuth credentials can now be optionally embedded in local, desktop, daemon, and release builds.
  * OAuth settings prioritize environment-provided credentials while retaining build-time defaults.
  * Gmail continues to support manual token configuration when credentials are unavailable.

* **Documentation**
  * Added setup guidance for configuring OAuth credentials and securing release secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->