### PR TITLE
feat(agent): enforce MaxCostUSD/StuckTimeoutMin guardrails (auto-stop runaways)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -382,19 +382,25 @@ type Agent struct {
 	// Model is the provider model identifier the agent runs with (e.g.
 	// "fable" for claude). Empty means the provider default — no model
 	// flag is injected. Restarts reuse the stored value.
-	Model          string     `json:"model,omitempty"`
-	ParentID       string     `json:"parent_id,omitempty"`
-	HookedWork     string     `json:"hooked_work,omitempty"`
-	WorktreeDir    string     `json:"worktree_dir,omitempty"`
-	LogFile        string     `json:"log_file,omitempty"`
-	Team           string     `json:"team,omitempty"`
-	RecoveredFrom  string     `json:"recovered_from,omitempty"`
-	EnvFile        string     `json:"env_file,omitempty"`
-	RuntimeBackend string     `json:"runtime_backend,omitempty"`
-	LastCrashTime  *time.Time `json:"last_crash_time,omitempty"`
-	Role           Role       `json:"role"`
-	State          State      `json:"state"`
-	Children       []string   `json:"children,omitempty"`
+	Model          string `json:"model,omitempty"`
+	ParentID       string `json:"parent_id,omitempty"`
+	HookedWork     string `json:"hooked_work,omitempty"`
+	WorktreeDir    string `json:"worktree_dir,omitempty"`
+	LogFile        string `json:"log_file,omitempty"`
+	Team           string `json:"team,omitempty"`
+	RecoveredFrom  string `json:"recovered_from,omitempty"`
+	EnvFile        string `json:"env_file,omitempty"`
+	RuntimeBackend string `json:"runtime_backend,omitempty"`
+	// Template is the name of the template this agent was spawned from
+	// (empty when spawned without one). Guardrails read the template's
+	// MaxCostUSD / StuckTimeoutMin by this name at check time rather than
+	// copying the limits onto the agent row, so template edits apply to
+	// already-running agents without a respawn.
+	Template      string     `json:"template,omitempty"`
+	LastCrashTime *time.Time `json:"last_crash_time,omitempty"`
+	Role          Role       `json:"role"`
+	State         State      `json:"state"`
+	Children      []string   `json:"children,omitempty"`
 	// CPUs is a per-agent Docker CPU cap (cores, e.g. 1.5). Zero means
 	// inherit the fleet default (prefs runtime.docker.cpus). Enforced only
 	// for the Docker runtime — tmux agents run unconstrained on the host.
@@ -993,6 +999,10 @@ type SpawnOptions struct {
 	Runtime   string // override runtime backend ("tmux" or "docker"); empty uses manager default
 	Team      string // optional team assignment
 	SessionID string // Explicit session ID to resume (overrides stored session_id)
+	// Template is the name of the template this agent is spawned from.
+	// Recorded on the agent row so the guardrail loop can look up
+	// MaxCostUSD / StuckTimeoutMin at check time. Empty disables guardrails.
+	Template string
 }
 
 // SpawnAgent creates and starts a new agent.
@@ -1459,6 +1469,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 		RuntimeBackend: agentRuntime,
 		Children:       []string{},
 		IsRoot:         role == RoleRoot,
+		Template:       opts.Template,
 		CreatedAt:      now,
 		StartedAt:      now,
 		UpdatedAt:      now,

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -59,6 +59,10 @@ type CreateOptions struct {
 	// Repo is the absolute path of the git repo the agent is bound to.
 	// Empty means "the repo the daemon was booted against" (the default repo).
 	Repo string
+	// Template is the name of the template this agent is spawned from.
+	// Recorded on the agent row so the guardrail loop can enforce the
+	// template's MaxCostUSD / StuckTimeoutMin. Empty disables guardrails.
+	Template string
 }
 
 // StartOptions configures agent start behavior.
@@ -221,6 +225,7 @@ func (s *AgentService) Create(ctx context.Context, opts CreateOptions) (*Agent, 
 		Env:       opts.Env,
 		Runtime:   opts.Runtime,
 		Team:      opts.Team,
+		Template:  opts.Template,
 	})
 	if err != nil {
 		return nil, err
@@ -291,6 +296,28 @@ func (s *AgentService) Stop(ctx context.Context, name string) error {
 	s.publishEvent("agent.stopped", map[string]any{
 		"name":   name,
 		"reason": "user_request",
+	})
+
+	return nil
+}
+
+// StopForGuardrail stops a running agent on behalf of an automated
+// guardrail (e.g. a template's MaxCostUSD limit) rather than a direct user
+// request. reason is a short human-readable string surfaced in the
+// published event and stored as the agent's Task so the UI shows WHY the
+// agent was stopped.
+func (s *AgentService) StopForGuardrail(ctx context.Context, name, reason string) error {
+	if err := s.manager.SetAgentTask(ctx, name, reason); err != nil {
+		log.Warn("guardrail: failed to record stop reason before stopping", "agent", name, "error", err)
+	}
+	if err := s.manager.StopAgent(ctx, name); err != nil {
+		return err
+	}
+
+	s.publishEvent("agent.stopped", map[string]any{
+		"name":   name,
+		"reason": "guardrail",
+		"detail": reason,
 	})
 
 	return nil

--- a/pkg/agent/service_test.go
+++ b/pkg/agent/service_test.go
@@ -104,6 +104,48 @@ func TestAgentService_StopNonexistent(t *testing.T) {
 	}
 }
 
+// TestAgentService_StopForGuardrail verifies the guardrail-specific stop
+// path: the agent is stopped, the reason is recorded as its Task (visible
+// in the UI even after the agent is gone), and the published event tags
+// the reason as "guardrail" rather than "user_request" so the two are
+// distinguishable in the activity timeline.
+func TestAgentService_StopForGuardrail(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["eng-1"] = &Agent{Name: "eng-1", Role: Role("engineer"), State: StateWorking, Children: []string{}}
+
+	pub := &mockEventPublisher{}
+	svc := NewAgentService(mgr, pub, nil)
+
+	const reason = "guardrail: cost limit $2.50 reached ($5.00 spent), stopped"
+	if err := svc.StopForGuardrail(context.Background(), "eng-1", reason); err != nil {
+		t.Fatalf("StopForGuardrail: %v", err)
+	}
+
+	if mgr.agents["eng-1"].State != StateStopped {
+		t.Fatalf("state = %s, want stopped", mgr.agents["eng-1"].State)
+	}
+	if mgr.agents["eng-1"].Task != reason {
+		t.Fatalf("task = %q, want %q", mgr.agents["eng-1"].Task, reason)
+	}
+
+	var found bool
+	for _, e := range pub.events {
+		if e.eventType != "agent.stopped" {
+			continue
+		}
+		found = true
+		if e.data["reason"] != "guardrail" {
+			t.Errorf("published reason = %v, want %q", e.data["reason"], "guardrail")
+		}
+		if e.data["detail"] != reason {
+			t.Errorf("published detail = %v, want %q", e.data["detail"], reason)
+		}
+	}
+	if !found {
+		t.Fatal("expected an agent.stopped event to be published")
+	}
+}
+
 func TestAgentService_DeleteReconcilesDead(t *testing.T) {
 	// An agent with StateIdle but no actual session should be reconciled
 	// to StateStopped and deleted successfully (not stuck in catch-22).

--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -70,6 +70,7 @@ func createAgentsTable(d *db.DB) error {
 			cpus          REAL    NOT NULL DEFAULT 0,
 			memory_mb     INTEGER NOT NULL DEFAULT 0,
 			ttl           INTEGER NOT NULL DEFAULT 0,
+			template      TEXT,
 			created_at    TEXT,
 			stopped_at    TEXT,
 			deleted_at    TEXT,
@@ -145,6 +146,7 @@ func ensureAgentColumns(ctx context.Context, d *db.DB) error {
 	for _, add := range []struct{ col, ddl string }{
 		{"cpus", "ALTER TABLE agents ADD COLUMN cpus REAL NOT NULL DEFAULT 0"},
 		{"memory_mb", "ALTER TABLE agents ADD COLUMN memory_mb INTEGER NOT NULL DEFAULT 0"},
+		{"template", "ALTER TABLE agents ADD COLUMN template TEXT"},
 	} {
 		if have[add.col] {
 			continue
@@ -178,8 +180,8 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 		 worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
-		 started_at, updated_at, repo, model, cpus, memory_mb)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 started_at, updated_at, repo, model, cpus, memory_mb, template)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.Name, string(a.Role), string(a.State),
 		nullStr(a.Tool), nullStr(a.ParentID), nullStr(a.Team), nullStr(a.Task),
 		nullStr(a.Session), a.Workspace,
@@ -190,6 +192,7 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 		nullStr(a.RuntimeBackend), nullStr(a.SessionID),
 		formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
 		formatTime(a.StartedAt), formatTime(now), a.Repo, a.Model, a.CPUs, a.MemoryMB,
+		nullStr(a.Template),
 	)
 	return err
 }
@@ -315,8 +318,8 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 		 worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
-		 started_at, updated_at, repo, model, cpus, memory_mb)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		 started_at, updated_at, repo, model, cpus, memory_mb, template)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -347,6 +350,7 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 			nullStr(a.RuntimeBackend), nullStr(a.SessionID),
 			formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
 			formatTime(a.StartedAt), formatTime(now), a.Repo, a.Model, a.CPUs, a.MemoryMB,
+			nullStr(a.Template),
 		)
 		if err != nil {
 			return fmt.Errorf("save agent %s: %w", a.Name, err)
@@ -408,13 +412,13 @@ const agentSelectCols = `SELECT name, role, state, tool, parent_id, team, task, 
 	       worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 	       is_root, crash_count, last_crash_time, recovered_from,
 	       runtime_backend, session_id, created_at, stopped_at, deleted_at,
-	       started_at, updated_at, repo, model, cpus, memory_mb`
+	       started_at, updated_at, repo, model, cpus, memory_mb, template`
 
 func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	var a Agent
 	var role, state string
 	var tool, parentID, team, task, session, worktreeDir, logFile, envFile, hookedWork, childrenJSON *string
-	var lastCrashTime, recoveredFrom, runtimeBackend, sessionID *string
+	var lastCrashTime, recoveredFrom, runtimeBackend, sessionID, template *string
 	var repo, model, envVars string
 	var createdAt, stoppedAt, deletedAt *string
 	var startedAt, updatedAt string
@@ -428,7 +432,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 		&worktreeDir, &logFile, &envFile, &envVars, &hookedWork, &childrenJSON,
 		&isRoot, &crashCount, &lastCrashTime, &recoveredFrom,
 		&runtimeBackend, &sessionID, &createdAt, &stoppedAt, &deletedAt,
-		&startedAt, &updatedAt, &repo, &model, &cpus, &memoryMB,
+		&startedAt, &updatedAt, &repo, &model, &cpus, &memoryMB, &template,
 	)
 	if err != nil {
 		return nil, err
@@ -458,6 +462,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	a.Model = model
 	a.CPUs = cpus
 	a.MemoryMB = memoryMB
+	a.Template = deref(template)
 
 	if childrenJSON != nil && *childrenJSON != "" {
 		_ = json.Unmarshal([]byte(*childrenJSON), &a.Children) //nolint:errcheck // best-effort

--- a/pkg/agent/tool_health.go
+++ b/pkg/agent/tool_health.go
@@ -59,17 +59,21 @@ func (m *Manager) CheckToolHealth(ctx context.Context, agentName string) error {
 	)
 
 	task := fmt.Sprintf("tool unavailable: %s binary not found", toolName)
-	if err := m.updateStateForToolHealth(ctx, agentName, task); err != nil {
+	if err := m.MarkStuck(ctx, agentName, task); err != nil {
 		return fmt.Errorf("failed to mark agent %q as stuck: %w", agentName, err)
 	}
 
 	return nil
 }
 
-// updateStateForToolHealth sets an agent to StateStuck when its tool is
-// unavailable. It validates the transition and notifies state-change
-// listeners.
-func (m *Manager) updateStateForToolHealth(ctx context.Context, name, task string) error {
+// MarkStuck sets an agent to StateStuck with the given reason recorded as
+// its Task, so the UI shows WHY the agent stopped making progress. It
+// validates the transition (a no-op if the agent is already stopped/errored)
+// and notifies state-change listeners exactly once, on the transition into
+// StateStuck. Used by the tool health loop (binary went missing) and the
+// cost/stuck guardrail loop (no activity within the template's
+// StuckTimeoutMin).
+func (m *Manager) MarkStuck(ctx context.Context, name, task string) error {
 	var changed bool
 
 	m.mu.Lock()
@@ -91,7 +95,7 @@ func (m *Manager) updateStateForToolHealth(ctx context.Context, name, task strin
 	changed = prevState != StateStuck
 
 	if err := m.saveState(ctx); err != nil {
-		log.Warn("failed to save agent state after tool health check", "error", err)
+		log.Warn("failed to save agent state after marking stuck", "error", err)
 	}
 	m.mu.Unlock()
 

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -272,6 +272,17 @@ func buildServicesFromHome(ctx context.Context, globals *Globals, h *home.Home) 
 		agentSvc.SetHookEventStore(eventLog)
 	}
 
+	// Agent guardrail loop: enforces Template.MaxCostUSD (auto-stop) and
+	// Template.StuckTimeoutMin (auto-flag) for every agent spawned from a
+	// template (#3423). Runs regardless of whether the event log is
+	// available — eventLog may be nil (degraded), in which case the stuck
+	// check falls back to the agent's own UpdatedAt.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runGuardrailLoop(svcCtx, agentSvc, tmplStore, eventLog, DefaultGuardrailInterval)
+	}()
+
 	// Stats collector — only runs if a TSDB stats store is configured
 	// globally. Uses the current agentSvc.
 	if globals != nil && globals.Stats != nil {

--- a/server/guardrails.go
+++ b/server/guardrails.go
@@ -1,0 +1,180 @@
+// guardrails.go — background enforcement of template-defined agent
+// guardrails (#3423): Template.MaxCostUSD and Template.StuckTimeoutMin were
+// persisted and shown in the CLI/UI but never read anywhere, so a runaway or
+// hung agent ran forever unless a human noticed. This loop closes that gap.
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	agentpkg "github.com/rpuneet/mycel/pkg/agent"
+	eventspkg "github.com/rpuneet/mycel/pkg/events"
+	"github.com/rpuneet/mycel/pkg/log"
+	templatepkg "github.com/rpuneet/mycel/pkg/template"
+)
+
+// DefaultGuardrailInterval is how often the guardrail loop re-evaluates
+// running agents against their template's MaxCostUSD / StuckTimeoutMin.
+// Cost lookups ride the cost.Service's own cache (see costServiceAdapter),
+// so a 60s tick does not translate into re-scanning provider session files
+// every minute.
+const DefaultGuardrailInterval = 60 * time.Second
+
+// runGuardrailLoop periodically enforces template-defined guardrails for
+// every active agent that carries a Template name (agent.Template, set at
+// spawn from CreateOptions.Template — see server/handlers/agents.go):
+//
+//   - MaxCostUSD: once the agent's cumulative session spend reaches the
+//     limit, the agent is stopped via AgentService.StopForGuardrail so a
+//     runaway session can't keep burning money unattended. This is a hard
+//     stop — cost overrun is an unambiguous signal.
+//   - StuckTimeoutMin: once a StateWorking agent has produced no new event
+//     (prompt, tool call, hook) for the timeout, it is flagged StateStuck
+//     via Manager.MarkStuck — NOT stopped. Idle-detection is inherently
+//     fuzzier than a cost overrun (a slow tool call, a long-running test
+//     suite, or a permission prompt can all look identical to "hung" from
+//     the outside), so the default here is flag + notify: the state change
+//     publishes an SSE event and lands in the agent's activity timeline for
+//     a human (or #ops loop) to act on, while leaving the agent free to
+//     resume — any further hook event flips it back to StateWorking and
+//     resets the idle timer. Auto-stopping a possibly-still-useful agent on
+//     a heuristic is a worse failure mode than leaving it flagged.
+//
+// A limit of 0 (the Template zero value) disables that guardrail for that
+// template. Agents with no Template (spawned without one) are never
+// touched — MaxCostUSD/StuckTimeoutMin are opt-in per template, not global
+// defaults.
+func runGuardrailLoop(ctx context.Context, agents *agentpkg.AgentService, tmplStore *templatepkg.Store, eventLog eventspkg.EventStore, interval time.Duration) {
+	if agents == nil || tmplStore == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = DefaultGuardrailInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	log.Info("agent guardrail loop started", "interval", interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info("agent guardrail loop stopped")
+			return
+		case <-ticker.C:
+			checkAllGuardrails(ctx, agents, tmplStore, eventLog)
+		}
+	}
+}
+
+// checkAllGuardrails evaluates every active, templated agent once. Template
+// lookups are cached for the duration of the tick since a fleet commonly
+// spawns many agents off a handful of templates.
+func checkAllGuardrails(ctx context.Context, agents *agentpkg.AgentService, tmplStore *templatepkg.Store, eventLog eventspkg.EventStore) {
+	list, err := agents.List(ctx, agentpkg.ListOptions{})
+	if err != nil {
+		log.Debug("guardrail: agent list failed", "error", err)
+		return
+	}
+
+	templates := map[string]*templatepkg.Template{}
+
+	for _, a := range list {
+		if a.Template == "" {
+			continue
+		}
+		// Nothing to enforce on an agent that isn't actually running.
+		if a.State == agentpkg.StateStopped || a.State == agentpkg.StateError {
+			continue
+		}
+
+		tmpl, cached := templates[a.Template]
+		if !cached {
+			t, _, getErr := tmplStore.Get(a.Template)
+			if getErr != nil {
+				log.Debug("guardrail: template lookup failed", "agent", a.Name, "template", a.Template, "error", getErr)
+			}
+			tmpl = t
+			templates[a.Template] = tmpl
+		}
+		if tmpl == nil {
+			continue
+		}
+
+		if checkCostGuardrail(ctx, agents, a, tmpl) {
+			// Agent was just stopped — skip the stuck check this tick.
+			continue
+		}
+		checkStuckGuardrail(ctx, agents, eventLog, a, tmpl)
+	}
+}
+
+// checkCostGuardrail stops the agent once its cumulative session spend
+// reaches the template's MaxCostUSD. Returns true when the agent was
+// stopped (so the caller can skip the now-moot stuck check).
+func checkCostGuardrail(ctx context.Context, agents *agentpkg.AgentService, a *agentpkg.Agent, tmpl *templatepkg.Template) bool {
+	if tmpl.MaxCostUSD <= 0 {
+		return false
+	}
+
+	summary, err := agents.Cost(ctx, a.Name)
+	if err != nil {
+		log.Debug("guardrail: cost lookup failed", "agent", a.Name, "error", err)
+		return false
+	}
+	if summary.TotalCostUSD < tmpl.MaxCostUSD {
+		return false
+	}
+
+	reason := fmt.Sprintf("guardrail: cost limit $%.2f reached ($%.2f spent), stopped", tmpl.MaxCostUSD, summary.TotalCostUSD)
+	if err := agents.StopForGuardrail(ctx, a.Name, reason); err != nil {
+		log.Warn("guardrail: failed to stop agent over cost limit", "agent", a.Name, "template", a.Template, "error", err)
+		return false
+	}
+	log.Info("guardrail: stopped agent over cost limit",
+		"agent", a.Name, "template", a.Template, "limit_usd", tmpl.MaxCostUSD, "spent_usd", summary.TotalCostUSD)
+	return true
+}
+
+// checkStuckGuardrail flags (never stops) a StateWorking agent that has
+// produced no new event for at least the template's StuckTimeoutMin. Only
+// StateWorking agents are considered: one already flagged StateStuck is left
+// alone until a fresh event moves it back to StateWorking, which naturally
+// restarts the idle clock and avoids re-flagging (and re-notifying) every
+// tick.
+func checkStuckGuardrail(ctx context.Context, agents *agentpkg.AgentService, eventLog eventspkg.EventStore, a *agentpkg.Agent, tmpl *templatepkg.Template) {
+	if tmpl.StuckTimeoutMin <= 0 || a.State != agentpkg.StateWorking {
+		return
+	}
+
+	// Last activity: the newest persisted event for this agent (prompts,
+	// tool calls, and other hooks all append a row — see
+	// AgentService.IngestHookEvent) — falling back to the agent's own
+	// UpdatedAt when there is no event log wired or no events yet (e.g.
+	// right after spawn).
+	lastActivity := a.UpdatedAt
+	if eventLog != nil {
+		if latest, readErr := eventLog.ReadByAgentPage(a.Name, 1, 0); readErr == nil && len(latest) > 0 {
+			lastActivity = latest[0].Timestamp
+		}
+	}
+	if lastActivity.IsZero() {
+		return
+	}
+
+	idleFor := time.Since(lastActivity)
+	timeout := time.Duration(tmpl.StuckTimeoutMin) * time.Minute
+	if idleFor < timeout {
+		return
+	}
+
+	reason := fmt.Sprintf("guardrail: no activity for %s (stuck timeout %dm), flagged stuck", idleFor.Round(time.Second), tmpl.StuckTimeoutMin)
+	if err := agents.Manager().MarkStuck(ctx, a.Name, reason); err != nil {
+		log.Debug("guardrail: failed to flag stuck agent", "agent", a.Name, "error", err)
+		return
+	}
+	log.Info("guardrail: flagged agent stuck",
+		"agent", a.Name, "template", a.Template, "idle_for", idleFor, "timeout_min", tmpl.StuckTimeoutMin)
+}

--- a/server/guardrails_test.go
+++ b/server/guardrails_test.go
@@ -1,0 +1,272 @@
+package server
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	agentpkg "github.com/rpuneet/mycel/pkg/agent"
+	dbpkg "github.com/rpuneet/mycel/pkg/db"
+	eventspkg "github.com/rpuneet/mycel/pkg/events"
+	templatepkg "github.com/rpuneet/mycel/pkg/template"
+)
+
+// fakeCostQuerier returns a fixed spend for every agent, keyed by name so a
+// single test can give different agents different totals.
+type fakeCostQuerier struct {
+	byAgent map[string]float64
+}
+
+func (f *fakeCostQuerier) AgentCostSummary(agentID string) (*agentpkg.CostSummary, error) {
+	return &agentpkg.CostSummary{AgentID: agentID, TotalCostUSD: f.byAgent[agentID]}, nil
+}
+
+// fakeEventStore is a minimal eventspkg.EventStore stub. Only
+// ReadByAgentPage is meaningful; it returns the configured events for the
+// requested agent (newest first, matching the real store's contract).
+type fakeEventStore struct {
+	byAgent map[string][]eventspkg.Event
+}
+
+func (f *fakeEventStore) Append(eventspkg.Event) error            { return nil }
+func (f *fakeEventStore) Read() ([]eventspkg.Event, error)        { return nil, nil }
+func (f *fakeEventStore) ReadLast(int) ([]eventspkg.Event, error) { return nil, nil }
+func (f *fakeEventStore) ReadByAgent(name string) ([]eventspkg.Event, error) {
+	return f.byAgent[name], nil
+}
+func (f *fakeEventStore) ReadByAgentPage(name string, limit int, _ int64) ([]eventspkg.Event, error) {
+	evs := f.byAgent[name]
+	if len(evs) > limit {
+		evs = evs[:limit]
+	}
+	return evs, nil
+}
+func (f *fakeEventStore) Close() error { return nil }
+
+// guardrailTestSetup wires a real Manager (SQLite-backed via MYCEL_HOME, tmux
+// runtime — never actually started) + AgentService, and seeds one agent
+// through the exported Save/LoadState path so the test only exercises
+// guardrails.go, not agent spawning.
+func guardrailTestSetup(t *testing.T, a *agentpkg.Agent, cost *fakeCostQuerier) (*agentpkg.AgentService, *templatepkg.Store) {
+	t.Helper()
+	t.Setenv("MYCEL_HOME", t.TempDir())
+
+	repo := t.TempDir()
+	gitInitDir(t, repo)
+
+	dbPath, err := dbpkg.GlobalDBPath()
+	if err != nil {
+		t.Fatalf("GlobalDBPath: %v", err)
+	}
+	store, err := agentpkg.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("NewSQLiteStore: %v", err)
+	}
+	if err := store.Save(context.Background(), a); err != nil {
+		t.Fatalf("seed agent: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close seed store: %v", err)
+	}
+
+	mgr := agentpkg.NewManagerWithRepo(filepath.Join(t.TempDir(), "agents"), repo)
+	if err := mgr.LoadState(); err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	var cq agentpkg.CostQuerier
+	if cost != nil {
+		cq = cost
+	}
+	svc := agentpkg.NewAgentService(mgr, nil, cq)
+
+	tmplStore := templatepkg.NewStore(t.TempDir())
+	return svc, tmplStore
+}
+
+func mustCreateTemplate(t *testing.T, store *templatepkg.Store, tmpl templatepkg.Template) {
+	t.Helper()
+	if err := store.Create(tmpl, "", templatepkg.ScopeGlobal); err != nil {
+		t.Fatalf("create template %q: %v", tmpl.Name, err)
+	}
+}
+
+// TestGuardrail_CostOverLimit_StopsAgent verifies that an agent whose
+// session spend has reached its template's MaxCostUSD is stopped, with a
+// task/reason recorded explaining why.
+func TestGuardrail_CostOverLimit_StopsAgent(t *testing.T) {
+	agent := &agentpkg.Agent{
+		Name: "spendy", State: agentpkg.StateWorking, Template: "costly",
+		StartedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	svc, tmplStore := guardrailTestSetup(t, agent, &fakeCostQuerier{byAgent: map[string]float64{"spendy": 5.00}})
+	mustCreateTemplate(t, tmplStore, templatepkg.Template{Name: "costly", MaxCostUSD: 2.50})
+
+	checkAllGuardrails(context.Background(), svc, tmplStore, nil)
+
+	got, err := svc.Get(context.Background(), "spendy")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != agentpkg.StateStopped {
+		t.Fatalf("state = %s, want stopped", got.State)
+	}
+	if got.Task == "" {
+		t.Fatal("expected task/reason to be recorded explaining the stop")
+	}
+}
+
+// TestGuardrail_UnderCostLimit_NotStopped verifies an agent whose spend has
+// not yet reached MaxCostUSD is left running.
+func TestGuardrail_UnderCostLimit_NotStopped(t *testing.T) {
+	agent := &agentpkg.Agent{
+		Name: "frugal", State: agentpkg.StateWorking, Template: "costly",
+		StartedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	svc, tmplStore := guardrailTestSetup(t, agent, &fakeCostQuerier{byAgent: map[string]float64{"frugal": 0.10}})
+	mustCreateTemplate(t, tmplStore, templatepkg.Template{Name: "costly", MaxCostUSD: 2.50})
+
+	checkAllGuardrails(context.Background(), svc, tmplStore, nil)
+
+	got, err := svc.Get(context.Background(), "frugal")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != agentpkg.StateWorking {
+		t.Fatalf("state = %s, want working (under budget must not be touched)", got.State)
+	}
+}
+
+// TestGuardrail_StuckTimeout_FlagsAgent verifies a StateWorking agent whose
+// last persisted event is older than StuckTimeoutMin is flagged StateStuck
+// (not stopped).
+func TestGuardrail_StuckTimeout_FlagsAgent(t *testing.T) {
+	staleTime := time.Now().Add(-10 * time.Minute)
+	agent := &agentpkg.Agent{
+		Name: "hung", State: agentpkg.StateWorking, Template: "patient",
+		StartedAt: staleTime, UpdatedAt: staleTime,
+	}
+	svc, tmplStore := guardrailTestSetup(t, agent, nil)
+	mustCreateTemplate(t, tmplStore, templatepkg.Template{Name: "patient", StuckTimeoutMin: 5})
+
+	events := &fakeEventStore{byAgent: map[string][]eventspkg.Event{
+		"hung": {{Agent: "hung", Type: "hook.PostToolUse", Timestamp: staleTime}},
+	}}
+
+	checkAllGuardrails(context.Background(), svc, tmplStore, events)
+
+	got, err := svc.Get(context.Background(), "hung")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != agentpkg.StateStuck {
+		t.Fatalf("state = %s, want stuck", got.State)
+	}
+	if got.Task == "" {
+		t.Fatal("expected task/reason to be recorded explaining the stuck flag")
+	}
+}
+
+// TestGuardrail_StuckTimeout_FallsBackToUpdatedAt verifies that when no
+// event log is available (e.g. degraded mode), the stuck check falls back
+// to the agent's own UpdatedAt instead of silently never firing. This
+// drives checkStuckGuardrail directly (rather than through
+// checkAllGuardrails/List) because Save() always stamps updated_at with
+// "now", so a stale UpdatedAt can't survive a seed-and-reload round trip —
+// the fallback value has to come from the Agent snapshot the caller holds,
+// exactly as production's checkAllGuardrails passes the List() snapshot.
+func TestGuardrail_StuckTimeout_FallsBackToUpdatedAt(t *testing.T) {
+	seed := &agentpkg.Agent{
+		Name: "hung2", State: agentpkg.StateWorking, Template: "patient",
+		StartedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	svc, _ := guardrailTestSetup(t, seed, nil)
+	tmpl := &templatepkg.Template{Name: "patient", StuckTimeoutMin: 5}
+
+	stale := &agentpkg.Agent{
+		Name: "hung2", State: agentpkg.StateWorking,
+		UpdatedAt: time.Now().Add(-10 * time.Minute),
+	}
+	checkStuckGuardrail(context.Background(), svc, nil, stale, tmpl)
+
+	got, err := svc.Get(context.Background(), "hung2")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != agentpkg.StateStuck {
+		t.Fatalf("state = %s, want stuck (fallback to UpdatedAt when no event log)", got.State)
+	}
+}
+
+// TestGuardrail_ActivelyProgressing_NotFlaggedStuck verifies that a recent
+// event in the event log overrides a stale Agent.UpdatedAt — an agent that
+// is actively producing tool events must never be flagged stuck just
+// because its lifecycle state hasn't transitioned recently.
+func TestGuardrail_ActivelyProgressing_NotFlaggedStuck(t *testing.T) {
+	staleTime := time.Now().Add(-10 * time.Minute)
+	agent := &agentpkg.Agent{
+		Name: "busy", State: agentpkg.StateWorking, Template: "patient",
+		StartedAt: staleTime, UpdatedAt: staleTime,
+	}
+	svc, tmplStore := guardrailTestSetup(t, agent, nil)
+	mustCreateTemplate(t, tmplStore, templatepkg.Template{Name: "patient", StuckTimeoutMin: 5})
+
+	events := &fakeEventStore{byAgent: map[string][]eventspkg.Event{
+		"busy": {{Agent: "busy", Type: "hook.PostToolUse", Timestamp: time.Now()}},
+	}}
+
+	checkAllGuardrails(context.Background(), svc, tmplStore, events)
+
+	got, err := svc.Get(context.Background(), "busy")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != agentpkg.StateWorking {
+		t.Fatalf("state = %s, want working (recent tool event must prevent a stuck flag)", got.State)
+	}
+}
+
+// TestGuardrail_ZeroLimits_Untouched verifies that a template with both
+// guardrails disabled (the Template zero value) never touches the agent,
+// no matter how much it has spent or how long it has been idle.
+func TestGuardrail_ZeroLimits_Untouched(t *testing.T) {
+	staleTime := time.Now().Add(-24 * time.Hour)
+	agent := &agentpkg.Agent{
+		Name: "unlimited", State: agentpkg.StateWorking, Template: "no-limits",
+		StartedAt: staleTime, UpdatedAt: staleTime,
+	}
+	svc, tmplStore := guardrailTestSetup(t, agent, &fakeCostQuerier{byAgent: map[string]float64{"unlimited": 999.99}})
+	mustCreateTemplate(t, tmplStore, templatepkg.Template{Name: "no-limits"})
+
+	checkAllGuardrails(context.Background(), svc, tmplStore, nil)
+
+	got, err := svc.Get(context.Background(), "unlimited")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != agentpkg.StateWorking {
+		t.Fatalf("state = %s, want working (zero limits must disable both guardrails)", got.State)
+	}
+}
+
+// TestGuardrail_NoTemplate_Untouched verifies agents spawned without a
+// template (Agent.Template == "") are never evaluated at all.
+func TestGuardrail_NoTemplate_Untouched(t *testing.T) {
+	staleTime := time.Now().Add(-24 * time.Hour)
+	agent := &agentpkg.Agent{
+		Name: "templateless", State: agentpkg.StateWorking,
+		StartedAt: staleTime, UpdatedAt: staleTime,
+	}
+	svc, tmplStore := guardrailTestSetup(t, agent, &fakeCostQuerier{byAgent: map[string]float64{"templateless": 999.99}})
+
+	checkAllGuardrails(context.Background(), svc, tmplStore, nil)
+
+	got, err := svc.Get(context.Background(), "templateless")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.State != agentpkg.StateWorking {
+		t.Fatalf("state = %s, want working (no template means no guardrails)", got.State)
+	}
+}

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -407,14 +407,15 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 			role = "base"
 		}
 		a, err := svc.Create(r.Context(), agent.CreateOptions{
-			Name:    req.Name,
-			Role:    agent.Role(role),
-			Tool:    req.Tool,
-			Model:   req.Model,
-			Runtime: req.Runtime,
-			Parent:  req.Parent,
-			Repo:    req.Repo,
-			Env:     req.Env,
+			Name:     req.Name,
+			Role:     agent.Role(role),
+			Tool:     req.Tool,
+			Model:    req.Model,
+			Runtime:  req.Runtime,
+			Parent:   req.Parent,
+			Repo:     req.Repo,
+			Env:      req.Env,
+			Template: req.Template,
 		})
 		if err != nil {
 			httpError(w, err.Error(), http.StatusBadRequest)

--- a/server/web/dist/placeholder.txt
+++ b/server/web/dist/placeholder.txt
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
Part of #3423

## Problem

`Template.MaxCostUSD` and `Template.StuckTimeoutMin` (`pkg/template/template.go`) were persisted, shown in the CLI/UI, and read **nowhere else** — a runaway or hung agent ran forever unless a human happened to notice.

## What changed

**Template name now flows from spawn onto the agent record**, since previously it was used only transiently to write `CLAUDE.md`/`.mcp.json` and returned in the create response DTO — never persisted:
- `Agent.Template`, `SpawnOptions.Template`, `CreateOptions.Template` (`pkg/agent`)
- new `agents.template` SQLite column (`pkg/agent/store_sqlite.go`, added via the existing `ensureAgentColumns` idempotent-ALTER pattern)
- `server/handlers/agents.go` POST `/api/agents` now passes `req.Template` through to `CreateOptions.Template`

Guardrails look the template up **by name at check time** (`template.Store.Get`) rather than copying the limits onto the agent row, so editing a template's limits applies to already-running agents without a respawn.

**New background guardrail loop** — `server/guardrails.go`, wired into `server/build_services.go` alongside the existing tool-health loop, ticking every 60s (`DefaultGuardrailInterval`):

- **MaxCostUSD** (hard stop): once an agent's cumulative session spend (`AgentService.Cost`, backed by `cost.Service`'s own cache — no extra provider-file scanning) reaches the limit, it's stopped via a new `AgentService.StopForGuardrail`, which records the reason as the agent's `Task` (visible in the UI even after the agent is gone) and publishes an `agent.stopped` event tagged `reason: "guardrail"` (vs. `"user_request"` for a manual stop) so the two are distinguishable in the activity timeline.
- **StuckTimeoutMin** (flag, not stop): once a `StateWorking` agent has produced no new event (prompt/tool-call/hook — read via `eventLog.ReadByAgentPage(name, 1, 0)`, falling back to `Agent.UpdatedAt` if no event log is wired) for the timeout, it's flagged `StateStuck` via a generalized `Manager.MarkStuck` (lifted out of the tool-health-loop's `updateStateForToolHealth`, which now calls the same exported method).

### Stop vs. flag decision

Idle-detection is inherently fuzzier than a cost overrun (a slow tool call, a long test run, or a permission prompt can all look identical to "hung" from the outside), so **stuck agents are flag + notify by default, not auto-stopped**. The state transition publishes an SSE event and lands in the agent's activity timeline for a human or `#ops` loop to act on, while leaving the agent free to resume — any further hook event flips it back to `StateWorking` and resets the idle clock. Only the unambiguous `MaxCostUSD` signal triggers a hard stop.

A limit of `0` (the `Template` zero value) disables that guardrail. Agents with no `Template` (`Agent.Template == ""`) are never evaluated.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/... ./server/...` — 0 issues
- [x] `go test -race ./pkg/agent/... ./pkg/cost/... ./server/...` — all pass
- [x] New tests:
  - `pkg/agent/service_test.go`: `TestAgentService_StopForGuardrail` — stop + task + `reason: "guardrail"` event
  - `server/guardrails_test.go`:
    - `TestGuardrail_CostOverLimit_StopsAgent` / `TestGuardrail_UnderCostLimit_NotStopped`
    - `TestGuardrail_StuckTimeout_FlagsAgent` / `TestGuardrail_StuckTimeout_FallsBackToUpdatedAt` / `TestGuardrail_ActivelyProgressing_NotFlaggedStuck`
    - `TestGuardrail_ZeroLimits_Untouched` / `TestGuardrail_NoTemplate_Untouched`

Not merging — for review.