### PR TITLE
feat(doctor): MCP server health checks

### DIFF
--- a/pkg/doctor/doctor.go
+++ b/pkg/doctor/doctor.go
@@ -16,6 +16,7 @@
 //	cat := doctor.CheckDatabase(ctx, h)
 //	cat := doctor.CheckAgents(ctx, h)
 //	cat := doctor.CheckTools(ctx)
+//	cat := doctor.CheckMCP(ctx, h)
 //	cat := doctor.CheckGit(ctx, h)
 package doctor
 
@@ -140,6 +141,7 @@ func RunAll(ctx context.Context, h *home.Home) *Report {
 		CheckDatabase(ctx, h),
 		CheckAgents(ctx, h),
 		CheckTools(ctx, h),
+		CheckMCP(ctx, h),
 		CheckGit(ctx, h),
 		CheckDaemon(ctx),
 	}
@@ -162,6 +164,9 @@ func CategoryByName(ctx context.Context, h *home.Home, name string) *CategoryRep
 	case "tools", "tool":
 		c := CheckTools(ctx, h)
 		return &c
+	case "mcp", "mcp servers":
+		c := CheckMCP(ctx, h)
+		return &c
 	case "git":
 		c := CheckGit(ctx, h)
 		return &c
@@ -175,7 +180,7 @@ func CategoryByName(ctx context.Context, h *home.Home, name string) *CategoryRep
 
 // ValidCategories returns the list of valid category names.
 func ValidCategories() []string {
-	return []string{"home", "database", "agents", "tools", "git", "daemon"}
+	return []string{"home", "database", "agents", "tools", "mcp", "git", "daemon"}
 }
 
 // ─── Home ────────────────────────────────────────────────────────────────────

--- a/pkg/doctor/doctor_test.go
+++ b/pkg/doctor/doctor_test.go
@@ -99,6 +99,7 @@ func TestValidCategories(t *testing.T) {
 		"database": true,
 		"agents":   true,
 		"tools":    true,
+		"mcp":      true,
 		"git":      true,
 		"daemon":   true,
 	}

--- a/pkg/doctor/mcp_health.go
+++ b/pkg/doctor/mcp_health.go
@@ -1,0 +1,197 @@
+// mcp_health.go — health checks for registered MCP servers.
+//
+// A stale or misconfigured MCP server (a stdio command that no longer
+// exists on PATH, an SSE URL that stopped responding) is otherwise
+// silently skipped at agent spawn time with only a debug log. This
+// category surfaces that state so `mycel doctor` catches it before an
+// agent does.
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rpuneet/mycel/pkg/home"
+	"github.com/rpuneet/mycel/pkg/mcp"
+)
+
+const (
+	// mcpProbeTimeout bounds a single SSE/URL reachability probe.
+	mcpProbeTimeout = 3 * time.Second
+	// mcpTotalTimeout bounds the whole MCP category so doctor stays fast
+	// even with a large registry or several unreachable servers — probes
+	// run in parallel, not serially, so this is not N * mcpProbeTimeout.
+	mcpTotalTimeout = 8 * time.Second
+)
+
+// CheckMCP checks every MCP server registered in the user-global
+// registry (~/.mycel/mcps.json): stdio servers must have a command that
+// resolves on PATH, SSE/url servers must be reachable within a short,
+// bounded timeout. Checks run in parallel. An empty registry reports ok
+// ("no MCP servers configured"), not an error.
+func CheckMCP(ctx context.Context, h *home.Home) CategoryReport {
+	cat := CategoryReport{Name: "MCP"}
+
+	path := mcpConfigPath(h)
+	store := mcp.NewGlobalStore(path)
+	servers, err := store.List()
+	if err != nil {
+		cat.Items = append(cat.Items, Item{
+			Name:     "mcp servers",
+			Message:  fmt.Sprintf("cannot read %s: %v", path, err),
+			Severity: SeverityFail,
+			Fix:      fmt.Sprintf("check %s for corruption, or remove it to reset the registry", path),
+		})
+		return cat
+	}
+
+	if len(servers) == 0 {
+		cat.Items = append(cat.Items, Item{
+			Name:     "mcp servers",
+			Message:  "no MCP servers configured",
+			Severity: SeverityOK,
+		})
+		return cat
+	}
+
+	// Stable, deterministic ordering for output and tests.
+	sort.Slice(servers, func(i, j int) bool { return servers[i].Name < servers[j].Name })
+
+	probeCtx, cancel := context.WithTimeout(ctx, mcpTotalTimeout)
+	defer cancel()
+
+	problems := make([]*Item, len(servers))
+	var wg sync.WaitGroup
+	for i, s := range servers {
+		wg.Add(1)
+		go func(i int, s *mcp.ServerConfig) {
+			defer wg.Done()
+			problems[i] = checkMCPServer(probeCtx, s)
+		}(i, s)
+	}
+	wg.Wait()
+
+	okCount := 0
+	var problemMsgs []string
+	for i, item := range problems {
+		if item == nil {
+			okCount++
+			continue
+		}
+		problemMsgs = append(problemMsgs, fmt.Sprintf("%s: %s", servers[i].Name, item.Message))
+		cat.Items = append(cat.Items, *item)
+	}
+
+	summary := fmt.Sprintf("%d of %d MCP servers OK", okCount, len(servers))
+	if len(problemMsgs) > 0 {
+		summary += "; " + strings.Join(problemMsgs, "; ")
+	}
+	cat.Items = append([]Item{{
+		Name:     "mcp servers",
+		Message:  summary,
+		Severity: SeverityOK,
+	}}, cat.Items...)
+
+	return cat
+}
+
+// mcpConfigPath returns the path to the user-global MCP registry. Falls
+// back to home.GlobalMCPConfig() (MYCEL_HOME-aware) when h is nil or its
+// state dir can't be resolved, so the check still degrades gracefully
+// outside a repo.
+func mcpConfigPath(h *home.Home) string {
+	if h != nil {
+		if stateDir := h.StateDir(); stateDir != "" {
+			return filepath.Join(stateDir, "mcps.json")
+		}
+	}
+	if p, err := home.GlobalMCPConfig(); err == nil {
+		return p
+	}
+	return "mcps.json"
+}
+
+// checkMCPServer checks one MCP server's health. Returns nil when
+// healthy, or an Item describing the problem otherwise.
+func checkMCPServer(ctx context.Context, s *mcp.ServerConfig) *Item {
+	name := "mcp:" + s.Name
+
+	switch s.Transport {
+	case mcp.TransportStdio:
+		if s.Command == "" {
+			return &Item{
+				Name:     name,
+				Message:  "stdio server has no command configured",
+				Severity: SeverityFail,
+			}
+		}
+		if _, err := exec.LookPath(s.Command); err != nil {
+			return &Item{
+				Name:     name,
+				Message:  fmt.Sprintf("command %q not found on PATH", s.Command),
+				Severity: SeverityFail,
+				Fix:      fmt.Sprintf("install %q, or run 'mycel mcp remove %s' if it's no longer needed", s.Command, s.Name),
+			}
+		}
+		return nil
+
+	case mcp.TransportSSE:
+		if s.URL == "" {
+			return &Item{
+				Name:     name,
+				Message:  "sse server has no url configured",
+				Severity: SeverityFail,
+			}
+		}
+		if err := probeMCPURL(ctx, s.URL); err != nil {
+			return &Item{
+				Name:     name,
+				Message:  fmt.Sprintf("url %s unreachable: %v", s.URL, err),
+				Severity: SeverityWarn,
+				Fix:      fmt.Sprintf("verify %s is running and reachable, or run 'mycel mcp remove %s' if it's stale", s.URL, s.Name),
+			}
+		}
+		return nil
+
+	default:
+		return &Item{
+			Name:     name,
+			Message:  fmt.Sprintf("unknown transport %q", s.Transport),
+			Severity: SeverityWarn,
+		}
+	}
+}
+
+// probeMCPURL performs a lightweight reachability probe against an SSE
+// server URL: HEAD first, falling back to GET for servers that reject
+// HEAD. Any response (including non-2xx) counts as reachable — this
+// checks network reachability, not protocol correctness.
+func probeMCPURL(ctx context.Context, rawURL string) error {
+	ctx, cancel := context.WithTimeout(ctx, mcpProbeTimeout)
+	defer cancel()
+
+	if err := doProbeRequest(ctx, http.MethodHead, rawURL); err == nil {
+		return nil
+	}
+	return doProbeRequest(ctx, http.MethodGet, rawURL)
+}
+
+func doProbeRequest(ctx context.Context, method, rawURL string) error {
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return nil
+}

--- a/pkg/doctor/mcp_health.go
+++ b/pkg/doctor/mcp_health.go
@@ -121,6 +121,12 @@ func mcpConfigPath(h *home.Home) string {
 // checkMCPServer checks one MCP server's health. Returns nil when
 // healthy, or an Item describing the problem otherwise.
 func checkMCPServer(ctx context.Context, s *mcp.ServerConfig) *Item {
+	// Disabled servers are never spawned, so their command/URL health is
+	// irrelevant — don't flag a stale disabled entry as a problem.
+	if !s.Enabled {
+		return nil
+	}
+
 	name := "mcp:" + s.Name
 
 	switch s.Transport {

--- a/pkg/doctor/mcp_health_test.go
+++ b/pkg/doctor/mcp_health_test.go
@@ -94,6 +94,30 @@ func TestCheckMCP_StdioCommandMissing(t *testing.T) {
 	}
 }
 
+func TestCheckMCP_DisabledServerSkipped(t *testing.T) {
+	h, homeDir := newBootstrappedHome(t)
+	// A disabled server with a bogus command must NOT be flagged — it is
+	// never spawned, so its command/URL health is irrelevant.
+	writeMCPServers(t, homeDir, &mcp.ServerConfig{
+		Name: "disabled-ghost", Transport: mcp.TransportStdio, Command: "no-such-binary-abc", Enabled: false,
+	})
+
+	cat := CheckMCP(context.Background(), h)
+
+	_, warn, fail := cat.Counts()
+	if warn != 0 || fail != 0 {
+		t.Fatalf("disabled server should raise no problems, got %+v", cat.Items)
+	}
+	for _, item := range cat.Items {
+		if item.Name == "mcp:disabled-ghost" {
+			t.Errorf("disabled server should not produce a problem item: %+v", item)
+		}
+	}
+	if !strings.Contains(cat.Items[0].Message, "1 of 1 MCP servers OK") {
+		t.Errorf("summary = %q", cat.Items[0].Message)
+	}
+}
+
 func TestCheckMCP_URLUnreachable(t *testing.T) {
 	h, homeDir := newBootstrappedHome(t)
 	// A URL nothing listens on — connection should fail fast.

--- a/pkg/doctor/mcp_health_test.go
+++ b/pkg/doctor/mcp_health_test.go
@@ -1,0 +1,171 @@
+package doctor
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/mcp"
+)
+
+func writeMCPServers(t *testing.T, homeDir string, servers ...*mcp.ServerConfig) {
+	t.Helper()
+	store := mcp.NewGlobalStore(filepath.Join(homeDir, "mcps.json"))
+	for _, s := range servers {
+		if err := store.Add(s); err != nil {
+			t.Fatalf("seed mcp server %q: %v", s.Name, err)
+		}
+	}
+}
+
+func TestCheckMCP_EmptyRegistry(t *testing.T) {
+	h, _ := newBootstrappedHome(t)
+	cat := CheckMCP(context.Background(), h)
+
+	if len(cat.Items) != 1 {
+		t.Fatalf("expected exactly one item, got %d: %+v", len(cat.Items), cat.Items)
+	}
+	if cat.Items[0].Severity != SeverityOK {
+		t.Errorf("severity = %s, want ok", cat.Items[0].Severity)
+	}
+	if cat.Items[0].Message != "no MCP servers configured" {
+		t.Errorf("message = %q", cat.Items[0].Message)
+	}
+}
+
+func TestCheckMCP_StdioCommandFound(t *testing.T) {
+	h, homeDir := newBootstrappedHome(t)
+	// "sh" is present on every CI runner / dev machine this test targets.
+	present, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not on PATH, cannot test the happy path")
+	}
+	writeMCPServers(t, homeDir, &mcp.ServerConfig{
+		Name: "shell", Transport: mcp.TransportStdio, Command: present, Enabled: true,
+	})
+
+	cat := CheckMCP(context.Background(), h)
+
+	ok, warn, fail := cat.Counts()
+	if fail != 0 || warn != 0 {
+		t.Fatalf("expected no problems, got warn=%d fail=%d items=%+v", warn, fail, cat.Items)
+	}
+	if ok != 1 {
+		t.Errorf("ok = %d, want 1", ok)
+	}
+	if !strings.Contains(cat.Items[0].Message, "1 of 1 MCP servers OK") {
+		t.Errorf("summary message = %q", cat.Items[0].Message)
+	}
+}
+
+func TestCheckMCP_StdioCommandMissing(t *testing.T) {
+	h, homeDir := newBootstrappedHome(t)
+	writeMCPServers(t, homeDir, &mcp.ServerConfig{
+		Name: "ghost", Transport: mcp.TransportStdio, Command: "definitely-not-a-real-binary-xyz", Enabled: true,
+	})
+
+	cat := CheckMCP(context.Background(), h)
+
+	var found bool
+	for _, item := range cat.Items {
+		if item.Name == "mcp:ghost" {
+			found = true
+			if item.Severity != SeverityFail {
+				t.Errorf("severity = %s, want fail", item.Severity)
+			}
+			if !strings.Contains(item.Message, "not found on PATH") {
+				t.Errorf("message = %q", item.Message)
+			}
+			if item.Fix == "" {
+				t.Errorf("expected a Fix hint")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected an item for mcp:ghost, got %+v", cat.Items)
+	}
+	// Summary item should mention the failing server.
+	if !strings.Contains(cat.Items[0].Message, "ghost") {
+		t.Errorf("summary should mention the failing server, got %q", cat.Items[0].Message)
+	}
+}
+
+func TestCheckMCP_URLUnreachable(t *testing.T) {
+	h, homeDir := newBootstrappedHome(t)
+	// A URL nothing listens on — connection should fail fast.
+	writeMCPServers(t, homeDir, &mcp.ServerConfig{
+		Name: "deadserver", Transport: mcp.TransportSSE, URL: "http://127.0.0.1:1/sse", Enabled: true,
+	})
+
+	cat := CheckMCP(context.Background(), h)
+
+	var found bool
+	for _, item := range cat.Items {
+		if item.Name == "mcp:deadserver" {
+			found = true
+			if item.Severity != SeverityWarn {
+				t.Errorf("severity = %s, want warn", item.Severity)
+			}
+			if !strings.Contains(item.Message, "unreachable") {
+				t.Errorf("message = %q", item.Message)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected an item for mcp:deadserver, got %+v", cat.Items)
+	}
+}
+
+func TestCheckMCP_URLReachable(t *testing.T) {
+	h, homeDir := newBootstrappedHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	writeMCPServers(t, homeDir, &mcp.ServerConfig{
+		Name: "liveserver", Transport: mcp.TransportSSE, URL: srv.URL, Enabled: true,
+	})
+
+	cat := CheckMCP(context.Background(), h)
+
+	_, warn, fail := cat.Counts()
+	if warn != 0 || fail != 0 {
+		t.Fatalf("expected no problems for a reachable url, got %+v", cat.Items)
+	}
+}
+
+func TestCheckMCP_MixedRegistry(t *testing.T) {
+	h, homeDir := newBootstrappedHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	present, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not on PATH")
+	}
+
+	writeMCPServers(t, homeDir,
+		&mcp.ServerConfig{Name: "a-good-stdio", Transport: mcp.TransportStdio, Command: present, Enabled: true},
+		&mcp.ServerConfig{Name: "b-bad-stdio", Transport: mcp.TransportStdio, Command: "no-such-binary-abc", Enabled: true},
+		&mcp.ServerConfig{Name: "c-good-url", Transport: mcp.TransportSSE, URL: srv.URL, Enabled: true},
+		&mcp.ServerConfig{Name: "d-bad-url", Transport: mcp.TransportSSE, URL: "http://127.0.0.1:1/sse", Enabled: true},
+	)
+
+	cat := CheckMCP(context.Background(), h)
+
+	if !strings.Contains(cat.Items[0].Message, "2 of 4 MCP servers OK") {
+		t.Errorf("summary = %q", cat.Items[0].Message)
+	}
+	ok, warn, fail := cat.Counts()
+	// Summary item itself is OK, plus 2 problem items (1 warn, 1 fail).
+	if ok != 1 || warn != 1 || fail != 1 {
+		t.Errorf("counts ok=%d warn=%d fail=%d, want 1/1/1", ok, warn, fail)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds an "MCP" category to `mycel doctor` that checks every server registered in the user-global MCP registry (`~/.mycel/mcps.json`): stdio servers must resolve their `command` on `PATH`; SSE/url servers get a bounded, parallel HTTP HEAD/GET reachability probe.
- Previously a stale or misconfigured MCP server was silently skipped at agent spawn with only a debug log — this surfaces it in `mycel doctor` output, `mycel doctor check mcp`, and `/api/doctor` (no server-specific changes needed there since the handler already runs `doctor.RunAll` generically).
- Checks run in parallel with an overall bounded timeout (8s) and a per-URL probe timeout (3s), so a large registry or an unreachable server can't stall `mycel doctor`.
- Empty registry reports ok/info ("no MCP servers configured"), not an error.

Part of #3423

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/...` — 0 issues
- [x] `go test -race ./pkg/doctor/... ./pkg/mcp/...` — all pass
- [x] New tests in `pkg/doctor/mcp_health_test.go`: empty registry → ok/info; stdio command present → ok; stdio command missing → fail; SSE url unreachable → warn; SSE url reachable (httptest server) → ok; mixed registry → correct aggregate counts and summary message
- [x] Built `make build-local-mycel` and exercised `doctor.CheckMCP` directly against a seeded temp `MYCEL_HOME` to confirm real output (see PR description below)

Sample output against a registry with one good stdio server, one missing-command stdio server, and one unreachable SSE url:

```
MCP
  ✓ mcp servers          1 of 3 MCP servers OK; bad-stdio: command "no-such-binary-xyz" not found on PATH; bad-url: url http://127.0.0.1:1/sse unreachable: ...
  ✗ mcp:bad-stdio        command "no-such-binary-xyz" not found on PATH
      fix: install "no-such-binary-xyz", or run 'mycel mcp remove bad-stdio' if it's no longer needed
  ⚠ mcp:bad-url          url http://127.0.0.1:1/sse unreachable: ...
      fix: verify http://127.0.0.1:1/sse is running and reachable, or run 'mycel mcp remove bad-url' if it's stale
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP as a supported category in the doctor command.
  * Added health checks for configured MCP servers, including command, URL, transport, and connectivity validation.
  * Reports actionable diagnostics for missing, unreachable, invalid, or unconfigured MCP servers.
  * Supports checking multiple MCP servers concurrently with bounded timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->