### PR TITLE
feat(mcp): agent orchestration tools — spawn/send/stop/list_children

### DIFF
--- a/server/mcp/orchestration_test.go
+++ b/server/mcp/orchestration_test.go
@@ -1,0 +1,412 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/rpuneet/mycel/pkg/agent"
+	"github.com/rpuneet/mycel/pkg/home"
+	"github.com/rpuneet/mycel/pkg/provider"
+)
+
+// stubProvider is a minimal provider.Provider that "runs" as /bin/true so
+// spawn_agent tests exercise a real Manager.SpawnAgentWithOptions call
+// without depending on any real AI CLI being installed.
+type stubProvider struct{ name string }
+
+// The stub command sleeps rather than exiting immediately: tests that send
+// keystrokes to the spawned session (send_to_agent) need it to still be
+// alive by the time the tool call reaches SendKeys.
+const stubProviderCmd = "sleep 100"
+
+func (p stubProvider) Name() string                               { return p.name }
+func (p stubProvider) Description() string                        { return "test stub" }
+func (p stubProvider) Command() string                            { return stubProviderCmd }
+func (p stubProvider) Binary() string                             { return "sleep" }
+func (p stubProvider) InstallHint() string                        { return "" }
+func (p stubProvider) BuildCommand(_ provider.CommandOpts) string { return stubProviderCmd }
+func (p stubProvider) IsInstalled(_ context.Context) bool         { return true }
+func (p stubProvider) Version(_ context.Context) string           { return "stub" }
+
+func init() {
+	// Registered once for the whole test binary — harmless to share since
+	// tests pick a unique agent/repo dir per case.
+	provider.DefaultRegistry.Register(stubProvider{name: "mcp-test-tool"})
+}
+
+// withRoleHierarchy sets agent.RoleHierarchy[parent] for the duration of the
+// test and restores the previous value on cleanup. RoleHierarchy is a
+// package-level map read by agent.CanCreateRole — the same mechanism the
+// daemon uses (via ParentID) to gate --parent-based agent creation, and
+// what spawn_agent inherits by always passing the caller as parent.
+func withRoleHierarchy(t *testing.T, parent agent.Role, children ...agent.Role) {
+	t.Helper()
+	prev, had := agent.RoleHierarchy[parent]
+	agent.RoleHierarchy[parent] = children
+	t.Cleanup(func() {
+		if had {
+			agent.RoleHierarchy[parent] = prev
+		} else {
+			delete(agent.RoleHierarchy, parent)
+		}
+	})
+}
+
+// errText extracts the text of a tool error result for readable test
+// failure messages.
+func errText(t *testing.T, res *sdk.CallToolResult) string {
+	t.Helper()
+	if len(res.Content) == 0 {
+		return "<no content>"
+	}
+	tc, ok := res.Content[0].(*sdk.TextContent)
+	if !ok {
+		return "<non-text content>"
+	}
+	return tc.Text
+}
+
+// newOrchestrationSvc builds a real Manager+AgentService rooted at a fresh
+// repo, for tests that need actual spawn/send/stop behavior rather than
+// gateway/notify stubs.
+func newOrchestrationSvc(t *testing.T) (*agent.Manager, *agent.AgentService, *home.Home) {
+	t.Helper()
+	h := testRepo(t)
+	mgr := agent.NewManagerWithRepo(h.AgentsDir(), h.RootDir)
+	svc := agent.NewAgentService(mgr, nil, nil)
+	return mgr, svc, h
+}
+
+// ─── spawn_agent ────────────────────────────────────────────────────────────
+
+func TestE2E_SpawnAgent_Success(t *testing.T) {
+	withRoleHierarchy(t, agent.Role("manager"), agent.Role("engineer"))
+	mgr, svc, h := newOrchestrationSvc(t)
+
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name: "boss", Role: agent.Role("manager"), Repo: h.RootDir,
+	}); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "boss")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{
+		Name: "spawn_agent",
+		Arguments: map[string]any{
+			"name":     "worker-1",
+			"role":     "engineer",
+			"task":     "implement the thing",
+			"provider": "mcp-test-tool",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("spawn_agent errored: %v", errText(t, res))
+	}
+	out := structured(t, res)
+	if out["agent"] != "worker-1" {
+		t.Errorf("agent = %v, want worker-1", out["agent"])
+	}
+	if out["role"] != "engineer" {
+		t.Errorf("role = %v, want engineer", out["role"])
+	}
+	if out["parent_id"] != "boss" {
+		t.Errorf("parent_id = %v, want boss", out["parent_id"])
+	}
+
+	child := mgr.GetAgent("worker-1")
+	if child == nil {
+		t.Fatal("worker-1 was not registered in the manager")
+	}
+	if child.Task != "implement the thing" {
+		t.Errorf("child task = %q, want the spawn_agent task", child.Task)
+	}
+
+	children := mgr.ListChildren("boss")
+	if len(children) != 1 || children[0].Name != "worker-1" {
+		t.Errorf("boss's children = %+v, want [worker-1]", children)
+	}
+}
+
+// TestE2E_SpawnAgent_DeniedWithoutCapability verifies the role-hierarchy
+// gate: a caller whose role has no entry permitting the requested child
+// role is rejected and no agent is created.
+func TestE2E_SpawnAgent_DeniedWithoutCapability(t *testing.T) {
+	// "intern" is not granted permission to create any role.
+	withRoleHierarchy(t, agent.Role("intern"))
+	mgr, svc, h := newOrchestrationSvc(t)
+
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name: "junior", Role: agent.Role("intern"), Repo: h.RootDir,
+	}); err != nil {
+		t.Fatalf("seed caller: %v", err)
+	}
+
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "junior")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{
+		Name:      "spawn_agent",
+		Arguments: map[string]any{"role": "engineer", "provider": "mcp-test-tool"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("spawn_agent should be denied for a role with no create permission")
+	}
+	if got := mgr.ListAgents(); len(got) != 1 {
+		t.Errorf("expected no child to be created, agents = %+v", got)
+	}
+}
+
+func TestE2E_SpawnAgent_MissingRole(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "boss")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{Name: "spawn_agent", Arguments: map[string]any{}})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("spawn_agent with no role should be a tool error")
+	}
+}
+
+// ─── send_to_agent ──────────────────────────────────────────────────────────
+
+func TestE2E_SendToAgent_Delivers(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	if _, err := svc.Create(t.Context(), agent.CreateOptions{
+		Name: "sender", Role: agent.Role("manager"), Tool: "mcp-test-tool", Repo: h.RootDir,
+	}); err != nil {
+		t.Fatalf("seed sender: %v", err)
+	}
+	// Give send_to_agent a genuinely running session to write into —
+	// AgentService.Send dispatches straight to tmux SendKeys once the
+	// agent isn't stopped/starting, so a stub RegisterStopped entry
+	// without a real session would fail with "session not found".
+	if _, err := svc.Create(t.Context(), agent.CreateOptions{
+		Name: "receiver", Role: agent.Role("engineer"), Tool: "mcp-test-tool", Repo: h.RootDir,
+	}); err != nil {
+		t.Fatalf("seed receiver: %v", err)
+	}
+
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "sender")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{
+		Name:      "send_to_agent",
+		Arguments: map[string]any{"agent": "receiver", "message": "please review PR #1"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("send_to_agent errored: %v", errText(t, res))
+	}
+	out := structured(t, res)
+	if out["agent"] != "receiver" {
+		t.Errorf("agent = %v, want receiver", out["agent"])
+	}
+}
+
+func TestE2E_SendToAgent_UnknownTarget(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "sender")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{
+		Name:      "send_to_agent",
+		Arguments: map[string]any{"agent": "ghost", "message": "hello?"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("send_to_agent to an unknown agent should be a tool error")
+	}
+}
+
+// ─── stop_agent ─────────────────────────────────────────────────────────────
+
+func TestE2E_StopAgent_PermittedForOwnChild(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name: "boss", Role: agent.Role("manager"), Repo: h.RootDir, Children: []string{"worker-1"},
+	}); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name: "worker-1", Role: agent.Role("engineer"), Repo: h.RootDir, ParentID: "boss",
+	}); err != nil {
+		t.Fatalf("seed child: %v", err)
+	}
+	if err := mgr.UpdateAgentState(t.Context(), "worker-1", agent.StateIdle, ""); err != nil {
+		t.Fatalf("mark idle: %v", err)
+	}
+
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "boss")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{
+		Name:      "stop_agent",
+		Arguments: map[string]any{"agent": "worker-1"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("stop_agent on own child should succeed: %v", res.Content)
+	}
+	child := mgr.GetAgent("worker-1")
+	if child == nil || child.State != agent.StateStopped {
+		t.Errorf("worker-1 state = %+v, want stopped", child)
+	}
+}
+
+func TestE2E_StopAgent_DeniedForUnrelatedAgent(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "peer-a", Role: agent.Role("engineer"), Repo: h.RootDir}); err != nil {
+		t.Fatalf("seed peer-a: %v", err)
+	}
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "peer-b", Role: agent.Role("engineer"), Repo: h.RootDir}); err != nil {
+		t.Fatalf("seed peer-b: %v", err)
+	}
+	if err := mgr.UpdateAgentState(t.Context(), "peer-b", agent.StateIdle, ""); err != nil {
+		t.Fatalf("mark idle: %v", err)
+	}
+
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "peer-a")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{
+		Name:      "stop_agent",
+		Arguments: map[string]any{"agent": "peer-b"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("stop_agent on an unrelated peer should be denied")
+	}
+	if peerB := mgr.GetAgent("peer-b"); peerB == nil || peerB.State != agent.StateIdle {
+		t.Errorf("peer-b should be untouched, got %+v", peerB)
+	}
+}
+
+func TestE2E_StopAgent_RootCanStopAnyone(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "root", Role: agent.RoleRoot, Repo: h.RootDir}); err != nil {
+		t.Fatalf("seed root: %v", err)
+	}
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "stranger", Role: agent.Role("engineer"), Repo: h.RootDir}); err != nil {
+		t.Fatalf("seed stranger: %v", err)
+	}
+	if err := mgr.UpdateAgentState(t.Context(), "stranger", agent.StateIdle, ""); err != nil {
+		t.Fatalf("mark idle: %v", err)
+	}
+
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "root")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{
+		Name:      "stop_agent",
+		Arguments: map[string]any{"agent": "stranger"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("root should be permitted to stop any agent: %v", res.Content)
+	}
+}
+
+func TestE2E_StopAgent_DeniedForSelf(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "solo", Role: agent.Role("engineer"), Repo: h.RootDir}); err != nil {
+		t.Fatalf("seed solo: %v", err)
+	}
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "solo")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{
+		Name:      "stop_agent",
+		Arguments: map[string]any{"agent": "solo"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("stop_agent on self should be rejected")
+	}
+}
+
+// ─── list_children ──────────────────────────────────────────────────────────
+
+func TestE2E_ListChildren(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name: "boss", Role: agent.Role("manager"), Repo: h.RootDir,
+		Children: []string{"worker-1", "worker-2"},
+	}); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "worker-1", Role: agent.Role("engineer"), Repo: h.RootDir, ParentID: "boss"}); err != nil {
+		t.Fatalf("seed worker-1: %v", err)
+	}
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "worker-2", Role: agent.Role("qa"), Repo: h.RootDir, ParentID: "boss"}); err != nil {
+		t.Fatalf("seed worker-2: %v", err)
+	}
+	// A sibling with no relation to "boss" must not leak into the listing.
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "unrelated", Role: agent.Role("engineer"), Repo: h.RootDir}); err != nil {
+		t.Fatalf("seed unrelated: %v", err)
+	}
+
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "boss")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{Name: "list_children"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("list_children errored: %v", res.Content)
+	}
+	out := structured(t, res)
+	children, _ := out["children"].([]any)
+	if len(children) != 2 {
+		t.Fatalf("children = %v, want 2 entries", children)
+	}
+	names := map[string]bool{}
+	for _, c := range children {
+		m, _ := c.(map[string]any)
+		name, _ := m["name"].(string)
+		names[name] = true
+	}
+	if !names["worker-1"] || !names["worker-2"] {
+		t.Errorf("children names = %v, want worker-1 and worker-2", names)
+	}
+	if names["unrelated"] {
+		t.Error("list_children leaked an unrelated agent")
+	}
+}
+
+func TestE2E_ListChildren_NoneSpawned(t *testing.T) {
+	mgr, svc, h := newOrchestrationSvc(t)
+	if err := mgr.RegisterStopped(&agent.Agent{Name: "loner", Role: agent.Role("engineer"), Repo: h.RootDir}); err != nil {
+		t.Fatalf("seed loner: %v", err)
+	}
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "loner")
+
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{Name: "list_children"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("list_children errored: %v", res.Content)
+	}
+	out := structured(t, res)
+	if children, ok := out["children"]; ok && children != nil {
+		if arr, _ := children.([]any); len(arr) != 0 {
+			t.Errorf("children = %v, want none", children)
+		}
+	}
+}

--- a/server/mcp/server.go
+++ b/server/mcp/server.go
@@ -25,12 +25,19 @@ import (
 // Config holds the daemon-owned dependencies the tool handlers dispatch to.
 // All stores are shared with the daemon; the MCP layer owns no connections.
 type Config struct {
-	Home    *home.Home
-	Agents  *agent.Manager
-	Costs   *cost.Service
-	Gateway *gateway.Manager
-	Notify  *notify.Service
-	Version string
+	Home   *home.Home
+	Agents *agent.Manager
+	// AgentSvc is the application-level agent API (spawn/send/stop with
+	// event publishing). Orchestration tools (spawn_agent, send_to_agent,
+	// stop_agent) dispatch through it instead of Agents directly so agent
+	// lifecycle events fire the same way they do for CLI/API-driven
+	// operations. May be nil (those tools degrade with a tool error);
+	// read-only tools (list_agents, list_children, whoami) only need Agents.
+	AgentSvc *agent.AgentService
+	Costs    *cost.Service
+	Gateway  *gateway.Manager
+	Notify   *notify.Service
+	Version  string
 }
 
 // Handler serves the agent-scoped MCP endpoints. It lazily builds one

--- a/server/mcp/server_test.go
+++ b/server/mcp/server_test.go
@@ -108,6 +108,18 @@ func testRepo(t *testing.T) *home.Home {
 	if out, err := exec.CommandContext(t.Context(), "git", "init", dir).CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v: %s", err, out)
 	}
+	// An initial commit so HEAD exists — orchestration tests spawn real
+	// child agents, and `git worktree add` needs a real ref to branch from.
+	for _, args := range [][]string{
+		{"-C", dir, "config", "user.email", "test@test.com"},
+		{"-C", dir, "config", "user.name", "Test"},
+		{"-C", dir, "commit", "--allow-empty", "-m", "init"},
+	} {
+		//nolint:gosec // args are fixed test constants
+		if out, err := exec.CommandContext(t.Context(), "git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
 	h, err := home.Open(dir)
 	if err != nil {
 		t.Fatalf("home.Open: %v", err)
@@ -126,6 +138,8 @@ func TestE2E_ListTools(t *testing.T) {
 		"whoami": false, "list_agents": false, "list_channels": false,
 		"read_channel": false, "send_message": false, "send_file": false,
 		"report_status": false, "query_costs": false,
+		"spawn_agent": false, "send_to_agent": false, "stop_agent": false,
+		"list_children": false,
 	}
 	for _, tool := range res.Tools {
 		if _, ok := want[tool.Name]; !ok {
@@ -263,6 +277,10 @@ func TestE2E_ToolErrorsWhenDependencyMissing(t *testing.T) {
 		{Name: "list_agents"},
 		{Name: "report_status", Arguments: map[string]any{"task": "testing"}},
 		{Name: "query_costs"},
+		{Name: "spawn_agent", Arguments: map[string]any{"role": "engineer"}},
+		{Name: "send_to_agent", Arguments: map[string]any{"agent": "someone", "message": "hi"}},
+		{Name: "stop_agent", Arguments: map[string]any{"agent": "someone"}},
+		{Name: "list_children"},
 	} {
 		res, err := session.CallTool(t.Context(), call)
 		if err != nil {

--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -10,6 +10,7 @@ import (
 
 	sdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/rpuneet/mycel/pkg/agent"
 	"github.com/rpuneet/mycel/pkg/avatar"
 	"github.com/rpuneet/mycel/pkg/home"
 	"github.com/rpuneet/mycel/pkg/log"
@@ -96,6 +97,35 @@ func addTools(s *sdk.Server, cfg Config, agentName string) {
 		Annotations: readOnly,
 	}, func(ctx context.Context, _ *sdk.CallToolRequest, in queryCostsIn) (*sdk.CallToolResult, queryCostsOut, error) {
 		return queryCosts(ctx, cfg, in)
+	})
+
+	sdk.AddTool(s, &sdk.Tool{
+		Name:        "spawn_agent",
+		Description: "Spawn a new child agent under this agent. This agent's role must be permitted to create the requested role (the same role-hierarchy check the daemon enforces for --parent-based creation); an unpermitted role is rejected.",
+	}, func(ctx context.Context, _ *sdk.CallToolRequest, in spawnAgentIn) (*sdk.CallToolResult, spawnAgentOut, error) {
+		return spawnAgent(ctx, cfg, agentName, in)
+	})
+
+	sdk.AddTool(s, &sdk.Tool{
+		Name:        "send_to_agent",
+		Description: "Send a message or task instruction to another agent's session, as this agent",
+	}, func(ctx context.Context, _ *sdk.CallToolRequest, in sendToAgentIn) (*sdk.CallToolResult, sendToAgentOut, error) {
+		return sendToAgent(ctx, cfg, agentName, in)
+	})
+
+	sdk.AddTool(s, &sdk.Tool{
+		Name:        "stop_agent",
+		Description: "Stop a running agent. Restricted to the root agent or an ancestor (direct or indirect parent) of the target — an agent cannot stop a peer or an unrelated agent.",
+	}, func(ctx context.Context, _ *sdk.CallToolRequest, in stopAgentIn) (*sdk.CallToolResult, stopAgentOut, error) {
+		return stopAgent(ctx, cfg, agentName, in)
+	})
+
+	sdk.AddTool(s, &sdk.Tool{
+		Name:        "list_children",
+		Description: "List agents directly spawned by this agent",
+		Annotations: readOnly,
+	}, func(ctx context.Context, _ *sdk.CallToolRequest, _ emptyIn) (*sdk.CallToolResult, listChildrenOut, error) {
+		return listChildren(cfg, agentName)
 	})
 }
 
@@ -562,6 +592,194 @@ func queryCosts(ctx context.Context, cfg Config, in queryCostsIn) (*sdk.CallTool
 			OutputTokens: s.OutputTokens,
 			TotalTokens:  s.TotalTokens,
 			TotalCostUSD: s.TotalCostUSD,
+		})
+	}
+	return nil, out, nil
+}
+
+// ─── spawn_agent ────────────────────────────────────────────────────────────
+//
+// Generalizes the root-agent/merge-queue pattern (see the workspace root
+// CLAUDE.md's create_agent MCP tool) so ANY agent — not just a hardcoded
+// root — can spawn children, subject to the same role-hierarchy check the
+// daemon already enforces for --parent-based creation
+// (Manager.SpawnAgentWithOptions → agent.CanCreateRole via ParentID).
+
+type spawnAgentIn struct {
+	Name     string `json:"name,omitempty" jsonschema:"name for the new agent (letters, numbers, dash, underscore); omit to auto-generate a unique name"`
+	Role     string `json:"role" jsonschema:"role for the new agent; this agent's role must be permitted to create it (role hierarchy), or the spawn is rejected"`
+	Task     string `json:"task,omitempty" jsonschema:"one-line initial task description recorded on the new agent (shown in the TUI/web UI)"`
+	Provider string `json:"provider,omitempty" jsonschema:"AI provider/tool for the new agent (e.g. claude); empty uses the fleet default"`
+	Repo     string `json:"repo,omitempty" jsonschema:"absolute path of the git repo to bind the new agent to; empty binds it to this agent's own repo"`
+}
+
+type spawnAgentOut struct {
+	Agent    string `json:"agent"`
+	Role     string `json:"role"`
+	State    string `json:"state"`
+	ParentID string `json:"parent_id,omitempty"`
+}
+
+func spawnAgent(ctx context.Context, cfg Config, agentName string, in spawnAgentIn) (*sdk.CallToolResult, spawnAgentOut, error) {
+	var out spawnAgentOut
+	if in.Role == "" {
+		return nil, out, fmt.Errorf("role is required")
+	}
+	if len(in.Role) > maxRoleLen {
+		return nil, out, fmt.Errorf("role too long: %d bytes (max %d)", len(in.Role), maxRoleLen)
+	}
+	if in.Name != "" && !agent.IsValidAgentName(in.Name) {
+		return nil, out, fmt.Errorf("agent name %q is invalid: use letters, numbers, dash, underscore (max %d chars)", in.Name, agent.MaxAgentNameLength)
+	}
+	if len(in.Task) > maxTaskLen {
+		return nil, out, fmt.Errorf("task too long: %d bytes (max %d)", len(in.Task), maxTaskLen)
+	}
+	if len(in.Repo) > maxPathLen {
+		return nil, out, fmt.Errorf("repo too long: %d bytes (max %d)", len(in.Repo), maxPathLen)
+	}
+	if cfg.AgentSvc == nil || cfg.Agents == nil {
+		return nil, out, fmt.Errorf("agent orchestration not available")
+	}
+
+	// Default to the caller's own repo so a spawned child shares the
+	// caller's worktree root unless a different repo is explicitly named.
+	repo := in.Repo
+	if repo == "" {
+		if caller := cfg.Agents.GetAgent(agentName); caller != nil {
+			repo = caller.Repo
+		}
+	}
+
+	// Parent is always the authenticated caller — never client-supplied —
+	// so AgentService.Create → SpawnAgentWithOptions enforces
+	// agent.CanCreateRole(caller.Role, requested role) for us. A caller
+	// whose role isn't permitted to create the requested role gets a
+	// clear error and no agent is spawned.
+	child, err := cfg.AgentSvc.Create(ctx, agent.CreateOptions{
+		Name:   in.Name,
+		Role:   agent.Role(in.Role),
+		Tool:   in.Provider,
+		Repo:   repo,
+		Parent: agentName,
+	})
+	if err != nil {
+		return nil, out, fmt.Errorf("spawn failed: %w", err)
+	}
+
+	out.Agent = child.Name
+	out.Role = string(child.Role)
+	out.State = string(child.State)
+	out.ParentID = child.ParentID
+
+	if in.Task != "" {
+		if taskErr := cfg.Agents.SetAgentTask(ctx, child.Name, in.Task); taskErr != nil {
+			log.Warn("spawn_agent: failed to set initial task", "agent", child.Name, "error", taskErr)
+		}
+	}
+	return nil, out, nil
+}
+
+// ─── send_to_agent ──────────────────────────────────────────────────────────
+
+type sendToAgentIn struct {
+	Agent   string `json:"agent" jsonschema:"name of the target agent"`
+	Message string `json:"message" jsonschema:"message or task instruction text to send"`
+}
+
+type sendToAgentOut struct {
+	Agent string `json:"agent"`
+}
+
+func sendToAgent(ctx context.Context, cfg Config, agentName string, in sendToAgentIn) (*sdk.CallToolResult, sendToAgentOut, error) {
+	out := sendToAgentOut{Agent: in.Agent}
+	if in.Agent == "" || in.Message == "" {
+		return nil, out, fmt.Errorf("agent and message are required")
+	}
+	if len(in.Agent) > agent.MaxAgentNameLength {
+		return nil, out, fmt.Errorf("agent name too long: %d bytes (max %d)", len(in.Agent), agent.MaxAgentNameLength)
+	}
+	if len(in.Message) > maxMessageLen {
+		return nil, out, fmt.Errorf("message too long: %d bytes (max %d)", len(in.Message), maxMessageLen)
+	}
+	if cfg.AgentSvc == nil {
+		return nil, out, fmt.Errorf("agent orchestration not available")
+	}
+	log.Debug("mcp: send_to_agent", "from", agentName, "to", in.Agent)
+	if err := cfg.AgentSvc.Send(ctx, in.Agent, in.Message); err != nil {
+		return nil, out, fmt.Errorf("send failed: %w", err)
+	}
+	return nil, out, nil
+}
+
+// ─── stop_agent ─────────────────────────────────────────────────────────────
+
+type stopAgentIn struct {
+	Agent string `json:"agent" jsonschema:"name of the agent to stop"`
+}
+
+type stopAgentOut struct {
+	Agent string `json:"agent"`
+}
+
+func stopAgent(ctx context.Context, cfg Config, agentName string, in stopAgentIn) (*sdk.CallToolResult, stopAgentOut, error) {
+	out := stopAgentOut(in)
+	if in.Agent == "" {
+		return nil, out, fmt.Errorf("agent is required")
+	}
+	if len(in.Agent) > agent.MaxAgentNameLength {
+		return nil, out, fmt.Errorf("agent name too long: %d bytes (max %d)", len(in.Agent), agent.MaxAgentNameLength)
+	}
+	if cfg.AgentSvc == nil || cfg.Agents == nil {
+		return nil, out, fmt.Errorf("agent orchestration not available")
+	}
+	if in.Agent == agentName {
+		return nil, out, fmt.Errorf("cannot stop yourself via stop_agent")
+	}
+	if !canStopAgent(cfg, agentName, in.Agent) {
+		return nil, out, fmt.Errorf("agent %q is not permitted to stop %q: only the root agent or an ancestor of the target may stop it", agentName, in.Agent)
+	}
+	if err := cfg.AgentSvc.Stop(ctx, in.Agent); err != nil {
+		return nil, out, fmt.Errorf("stop failed: %w", err)
+	}
+	return nil, out, nil
+}
+
+// canStopAgent enforces the permission model for stop_agent: there is no
+// per-agent "can_stop" capability today (pkg/agent's Permission enum is
+// unwired for MCP callers), so this gates on the same parent/child
+// relationship the daemon already tracks via Agent.ParentID — the root
+// agent (singleton, workspace owner) may stop anyone; any other agent may
+// only stop its own descendants (children, grandchildren, ...), never a
+// peer or an unrelated agent.
+func canStopAgent(cfg Config, caller, target string) bool {
+	if c := cfg.Agents.GetAgent(caller); c != nil && c.Role == agent.RoleRoot {
+		return true
+	}
+	for _, d := range cfg.Agents.ListDescendants(caller) {
+		if d.Name == target {
+			return true
+		}
+	}
+	return false
+}
+
+// ─── list_children ──────────────────────────────────────────────────────────
+
+type listChildrenOut struct {
+	Children []agentInfo `json:"children"`
+}
+
+func listChildren(cfg Config, agentName string) (*sdk.CallToolResult, listChildrenOut, error) {
+	var out listChildrenOut
+	if cfg.Agents == nil {
+		return nil, out, fmt.Errorf("agent manager not available")
+	}
+	for _, c := range cfg.Agents.ListChildren(agentName) {
+		out.Children = append(out.Children, agentInfo{
+			Name:  c.Name,
+			Role:  string(c.Role),
+			State: string(c.State),
+			Task:  c.Task,
 		})
 	}
 	return nil, out, nil

--- a/server/server.go
+++ b/server/server.go
@@ -472,6 +472,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		}
 		if svc.Agents != nil {
 			mcpCfg.Agents = svc.Agents.Manager()
+			mcpCfg.AgentSvc = svc.Agents
 		}
 		if mcpSrv, mcpErr := servermcp.New(mcpCfg); mcpErr != nil {
 			log.Warn("MCP server unavailable", "error", mcpErr)


### PR DESCRIPTION
Part of #3423

## Summary

Adds four agent-orchestration tools to the agent-facing MCP server (`/_mcp/{agent}`, `server/mcp/tools.go`), generalizing the root-agent/merge-queue pattern (CLAUDE.md) so any agent — not just a hardcoded root — can spawn, message, and stop other agents from inside its own session.

- **`spawn_agent`** — `{name?, role, task?, provider?, repo?}`. Wraps `AgentService.Create` with the caller always set as `Parent`, so it inherits `Manager.SpawnAgentWithOptions`'s existing role-hierarchy check (`agent.CanCreateRole(caller.Role, requested role)`) — the same gate `--parent`-based creation already goes through for CLI/API callers. `repo` defaults to the caller's own repo. `task` sets the new agent's initial task line.
- **`send_to_agent`** — `{agent, message}`. Wraps `AgentService.Send` (reconciles stale stopped/starting state, same as CLI/API send).
- **`stop_agent`** — `{agent}`. Wraps `AgentService.Stop`, gated in the tool layer (see permission model below). Self-stop is rejected.
- **`list_children`** — no input. Wraps `Manager.ListChildren(agentName)`, returning only the caller's direct children.

## Permission model

- **spawn_agent**: no new gate was added — the tool always passes the calling agent as `ParentID`, so the existing `Manager.SpawnAgentWithOptions` → `agent.CanCreateRole(parent.Role, child.Role)` check (via the package-level `agent.RoleHierarchy` map) applies exactly as it does for `--parent`-based creation today. A caller whose role isn't permitted to create the requested role gets a clear error and no agent is spawned.

  **Known pre-existing gap** (not introduced by this PR, discovered while implementing it): `agent.RoleHierarchy` is only ever populated in test `TestMain` functions — no production code path populates it from `.mycel/roles/*.md`. In production today this means `CanCreateRole` is effectively deny-by-default for *any* parent/child pair whenever `ParentID` is supplied, root included. This is a platform-level gap in the existing `--parent` flag / role-hierarchy design, not something this PR's tools introduce — flagging it since it affects `spawn_agent`'s real-world usability until fixed separately.

- **stop_agent**: there is no per-agent "can_stop" capability today (`pkg/agent`'s `Permission` enum has no MCP-facing caller), so this PR adds a purpose-built gate (`canStopAgent` in `server/mcp/tools.go`) mirroring the parent/child relationship the daemon already tracks via `Agent.ParentID`: the root agent (singleton workspace owner) may stop anyone; any other agent may only stop its own descendants (`Manager.ListDescendants`) — never a peer or unrelated agent. Stopping yourself via this tool is explicitly rejected.

- **send_to_agent / list_children**: no additional gate beyond the authenticated caller identity (the `/_mcp/{agent}` path segment, per #2967) — mirrors `send_message`'s "any agent can post to any channel" model. `list_children` only ever returns the caller's own direct children, so there's no cross-agent read here to gate.

`Config` gained a new `AgentSvc *agent.AgentService` field (wired in `server/server.go`) alongside the existing `Agents *agent.Manager`, so orchestration tools dispatch through the application-level API (event publishing, state reconciliation) the same way CLI/HTTP callers do, while read-only tools keep using `Agents` directly.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./server/... ./pkg/...` — 0 issues
- [x] `go test -race ./server/mcp/... ./pkg/agent/...` — all pass
- New tests in `server/mcp/orchestration_test.go`:
  - `TestE2E_SpawnAgent_Success` / `_DeniedWithoutCapability` / `_MissingRole`
  - `TestE2E_SendToAgent_Delivers` / `_UnknownTarget`
  - `TestE2E_StopAgent_PermittedForOwnChild` / `_DeniedForUnrelatedAgent` / `_RootCanStopAnyone` / `_DeniedForSelf`
  - `TestE2E_ListChildren` / `_NoneSpawned`
- Extended `TestE2E_ListTools` and `TestE2E_ToolErrorsWhenDependencyMissing` in `server/mcp/server_test.go` to cover the four new tools.

Not merging — leaving this open for review per standing instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)