### PR TITLE
fix(a11y): touch targets, focus rings, label associations, keyboard-reachable controls

### DIFF
--- a/web/src/components/CopyButton.tsx
+++ b/web/src/components/CopyButton.tsx
@@ -25,7 +25,7 @@ export function CopyButton({ text, className = "" }: CopyButtonProps) {
         e.stopPropagation();
         void handleCopy();
       }}
-      className={`inline-flex items-center justify-center w-6 h-6 rounded-md transition-colors hover:bg-mycel-surface-hover focus-visible:ring-2 focus-visible:ring-mycel-accent ${className}`}
+      className={`relative inline-flex items-center justify-center w-6 h-6 rounded-md transition-colors hover:bg-mycel-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2.5 before:content-[''] ${className}`}
       aria-label={copied ? "Copied" : "Copy to clipboard"}
     >
       {copied ? (

--- a/web/src/components/apps/ConnectApp.tsx
+++ b/web/src/components/apps/ConnectApp.tsx
@@ -962,7 +962,7 @@ export function ConnectWizard({
                 )}
                 {pairState === "connected" && (
                   <div className="flex flex-col items-center gap-3">
-                    <div className="flex items-center gap-2 text-sm text-mycel-success">
+                    <div aria-live="polite" className="flex items-center gap-2 text-sm text-mycel-success">
                       <span className="text-lg">✓</span> {descriptor.label} connected!
                     </div>
                     <button

--- a/web/src/components/apps/GatewayFeed.tsx
+++ b/web/src/components/apps/GatewayFeed.tsx
@@ -851,7 +851,7 @@ export function GatewayFeed({
         <button
           type="button"
           onClick={() => { setSearchOpen((v) => !v); if (searchOpen) setSearchQuery(""); }}
-          className="flex items-center justify-center"
+          className="relative flex items-center justify-center outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2 before:content-['']"
           style={{
             width: 26,
             height: 26,
@@ -862,6 +862,7 @@ export function GatewayFeed({
             border: "none",
           }}
           title="Search messages"
+          aria-label="Search messages"
         >
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
             <circle cx="11" cy="11" r="7" /><line x1="21" y1="21" x2="16.65" y2="16.65" />
@@ -873,7 +874,7 @@ export function GatewayFeed({
           <button
             type="button"
             onClick={() => setFilterOpen((v) => !v)}
-            className="flex items-center justify-center"
+            className="relative flex items-center justify-center outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2 before:content-['']"
             style={{
               width: 26,
               height: 26,
@@ -884,6 +885,7 @@ export function GatewayFeed({
               border: "none",
             }}
             title="Filter messages"
+            aria-label="Filter messages"
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
@@ -1124,7 +1126,9 @@ export function GatewayFeed({
           <button
             type="button"
             onClick={() => { setSearchOpen(false); setSearchQuery(""); }}
-            style={{ background: "none", border: "none", color: "var(--mycel-muted)", cursor: "pointer", padding: 2 }}
+            className="relative outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2 before:content-['']"
+            style={{ background: "none", border: "none", color: "var(--mycel-muted)", cursor: "pointer", padding: 2, borderRadius: 4 }}
+            aria-label="Close search"
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
@@ -1151,8 +1155,10 @@ export function GatewayFeed({
           <button
             type="button"
             onClick={() => setFilterAgent(null)}
-            style={{ background: "none", border: "none", color: "var(--mycel-muted)", cursor: "pointer", padding: 2, marginLeft: "auto" }}
+            className="relative outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2 before:content-['']"
+            style={{ background: "none", border: "none", color: "var(--mycel-muted)", cursor: "pointer", padding: 2, marginLeft: "auto", borderRadius: 4 }}
             title="Clear filter"
+            aria-label="Clear filter"
           >
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
@@ -1209,6 +1215,7 @@ export function GatewayFeed({
           <button
             type="button"
             onClick={() => setTopicDismissed(true)}
+            className="relative outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2 before:content-['']"
             style={{
               background: "none",
               border: "none",
@@ -1217,8 +1224,10 @@ export function GatewayFeed({
               padding: 2,
               flexShrink: 0,
               marginTop: 1,
+              borderRadius: 4,
             }}
             title="Dismiss"
+            aria-label="Dismiss"
           >
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />

--- a/web/src/settings/controls.tsx
+++ b/web/src/settings/controls.tsx
@@ -39,7 +39,7 @@ export function ThemePicker({
             type="button"
             onClick={() => onChange(c.id)}
             aria-pressed={active}
-            className={`relative flex flex-col items-start gap-0.5 px-3.5 py-2 rounded-lg border text-left cursor-pointer transition-all active:scale-[0.98] ${
+            className={`relative flex flex-col items-start gap-0.5 px-3.5 py-2 rounded-lg border text-left cursor-pointer transition-all active:scale-[0.98] outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent ${
               active
                 ? "border-mycel-accent bg-mycel-accent-subtle shadow-mycel-sm"
                 : "border-mycel-border bg-mycel-surface hover:border-mycel-accent hover:bg-mycel-surface-hover"
@@ -86,7 +86,7 @@ export function RuntimePicker({
         type="button"
         onClick={() => onChange(id)}
         aria-pressed={active}
-        className={`flex-1 text-left flex flex-col gap-1 rounded-lg border p-4 cursor-pointer transition-all active:scale-[0.99] ${
+        className={`flex-1 text-left flex flex-col gap-1 rounded-lg border p-4 cursor-pointer transition-all active:scale-[0.99] outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent ${
           active ? "border-mycel-accent bg-mycel-accent-subtle shadow-mycel-sm" : "border-mycel-border bg-mycel-surface hover:border-mycel-accent hover:bg-mycel-surface-hover"
         }`}
       >
@@ -130,7 +130,7 @@ export function AdvancedToggle({
     <button
       type="button"
       onClick={onToggle}
-      className="self-start text-[12px] text-mycel-muted hover:text-mycel-text transition-colors"
+      className="self-start text-[12px] text-mycel-muted hover:text-mycel-text transition-colors outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent rounded-sm"
     >
       {open ? `▾ Hide ${label.toLowerCase()}` : `▸ ${label}`}
     </button>

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -418,7 +418,7 @@ export function Home() {
             onClick={() => setMenuOpen((v) => !v)}
             aria-label="More options"
             aria-expanded={menuOpen}
-            className={`inline-flex items-center justify-center h-8 w-8 rounded-md border text-base leading-none transition-colors ${menuOpen ? "border-mycel-accent text-mycel-text bg-mycel-surface-hover" : "border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-text hover:border-mycel-accent"}`}
+            className={`relative inline-flex items-center justify-center h-8 w-8 rounded-md border text-base leading-none transition-colors outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2 before:content-[''] ${menuOpen ? "border-mycel-accent text-mycel-text bg-mycel-surface-hover" : "border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-text hover:border-mycel-accent"}`}
           >
             &#x22EF;
           </button>
@@ -517,7 +517,8 @@ export function Home() {
                 <button
                   type="button"
                   onClick={() => setShowShortcuts(false)}
-                  className="text-mycel-muted hover:text-mycel-text text-sm"
+                  aria-label="Close keyboard shortcuts"
+                  className="relative text-mycel-muted hover:text-mycel-text text-sm outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent rounded-sm before:absolute before:-inset-2.5 before:content-['']"
                 >
                   &times;
                 </button>

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
 import { motion } from "framer-motion";
 import { api } from "../api/client";
@@ -527,6 +527,7 @@ function ConfigPanel({
   const [command, setCommand] = useState(provider.config?.command ?? provider.command ?? "");
   const [saving, setSaving] = useState(false);
   const [dirty, setDirty] = useState(false);
+  const commandFieldId = useId();
 
   useEffect(() => {
     setCommand(provider.config?.command ?? provider.command ?? "");
@@ -556,14 +557,16 @@ function ConfigPanel({
       <div className="rounded border border-mycel-border bg-mycel-surface p-4 space-y-4">
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
-            <label className="text-xs text-mycel-muted block mb-1">Binary</label>
+            {/* Static value, not a form control \u2014 a <span> avoids an orphan <label>. */}
+            <span className="text-xs text-mycel-muted block mb-1">Binary</span>
             <div className="text-sm font-mono text-mycel-text-2 px-2.5 py-1.5 rounded bg-mycel-bg border border-mycel-border">
               {provider.binary || "\u2014"}
             </div>
           </div>
           <div>
-            <label className="text-xs text-mycel-muted block mb-1">Command</label>
+            <label htmlFor={commandFieldId} className="text-xs text-mycel-muted block mb-1">Command</label>
             <input
+              id={commandFieldId}
               type="text"
               value={command}
               onChange={(e) => {
@@ -574,13 +577,13 @@ function ConfigPanel({
             />
           </div>
           <div>
-            <label className="text-xs text-mycel-muted block mb-1">Description</label>
+            <span className="text-xs text-mycel-muted block mb-1">Description</span>
             <div className="text-sm text-mycel-text-2 px-2.5 py-1.5 rounded bg-mycel-bg border border-mycel-border">
               {provider.description || "\u2014"}
             </div>
           </div>
           <div>
-            <label className="text-xs text-mycel-muted block mb-1">Install Hint</label>
+            <span className="text-xs text-mycel-muted block mb-1">Install Hint</span>
             <div className="flex items-center gap-1">
               <div className="flex-1 text-sm font-mono text-mycel-text-2 px-2.5 py-1.5 rounded bg-mycel-bg border border-mycel-border truncate">
                 {provider.install_hint || "\u2014"}
@@ -755,6 +758,9 @@ function MCPSection({
   const [mcpName, setMcpName] = useState("");
   const [mcpTransport, setMcpTransport] = useState<"stdio" | "sse">("stdio");
   const [mcpValue, setMcpValue] = useState("");
+  const mcpNameFieldId = useId();
+  const mcpTransportFieldId = useId();
+  const mcpValueFieldId = useId();
   const [adding, setAdding] = useState(false);
   const [checking, setChecking] = useState(false);
   const [healthMap, setHealthMap] = useState<Record<string, { status: string; error?: string }>>({});
@@ -836,8 +842,9 @@ function MCPSection({
         <div className="rounded border border-mycel-accent bg-mycel-surface p-4 space-y-3 mb-4">
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
             <div>
-              <label className="text-xs text-mycel-muted block mb-1">Name</label>
+              <label htmlFor={mcpNameFieldId} className="text-xs text-mycel-muted block mb-1">Name</label>
               <input
+                id={mcpNameFieldId}
                 type="text"
                 value={mcpName}
                 onChange={(e) => setMcpName(e.target.value)}
@@ -846,8 +853,9 @@ function MCPSection({
               />
             </div>
             <div>
-              <label className="text-xs text-mycel-muted block mb-1">Transport</label>
+              <label htmlFor={mcpTransportFieldId} className="text-xs text-mycel-muted block mb-1">Transport</label>
               <select
+                id={mcpTransportFieldId}
                 value={mcpTransport}
                 onChange={(e) => setMcpTransport(e.target.value as "stdio" | "sse")}
                 className={inputCls}
@@ -857,10 +865,11 @@ function MCPSection({
               </select>
             </div>
             <div>
-              <label className="text-xs text-mycel-muted block mb-1">
+              <label htmlFor={mcpValueFieldId} className="text-xs text-mycel-muted block mb-1">
                 {mcpTransport === "sse" ? "URL" : "Command"}
               </label>
               <input
+                id={mcpValueFieldId}
                 type="text"
                 value={mcpValue}
                 onChange={(e) => setMcpValue(e.target.value)}

--- a/web/src/views/Readiness.tsx
+++ b/web/src/views/Readiness.tsx
@@ -161,7 +161,7 @@ export function Readiness() {
           type="button"
           onClick={() => void refresh()}
           disabled={loading}
-          className="shrink-0 text-[11px] px-2.5 py-1 rounded border border-mycel-border hover:border-mycel-accent bg-mycel-surface text-mycel-muted hover:text-mycel-text transition-colors disabled:opacity-50"
+          className="relative shrink-0 text-[11px] px-2.5 py-1 rounded border border-mycel-border hover:border-mycel-accent bg-mycel-surface text-mycel-muted hover:text-mycel-text transition-colors disabled:opacity-50 outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2 before:content-['']"
         >
           {loading ? "Checking…" : "Re-check"}
         </button>

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, useEffect, useMemo } from "react";
+import { useCallback, useState, useEffect, useMemo, useId, Children, isValidElement, cloneElement, type ReactElement } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { api, type AppInstance, type BudgetStatus } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
@@ -58,28 +58,45 @@ function deepEqual(a: unknown, b: unknown): boolean {
 
 // Sans by default — a settings page is read prose, not a config dump. Taller
 // hit target, a border that firms up and an accent ring on focus.
-const INPUT_CLS = "w-full px-2.5 py-1.5 text-[13px] rounded-md border border-mycel-border bg-mycel-bg text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:border-mycel-accent focus:ring-1 focus:ring-mycel-accent transition-colors";
+const INPUT_CLS = "w-full px-2.5 py-1.5 text-[13px] rounded-md border border-mycel-border bg-mycel-bg text-mycel-text placeholder:text-mycel-muted outline-none focus-visible:border-mycel-accent focus-visible:ring-2 focus-visible:ring-mycel-accent transition-colors";
 // Mono variant — reserved for genuinely technical values (paths, images,
 // sockets, shells) where character alignment actually helps.
 const MONO_INPUT_CLS = `${INPUT_CLS} font-mono`;
 
+// Form elements a Field can auto-associate its label with via `htmlFor` —
+// native controls get the id cloned straight on; PasswordField forwards it
+// to its own internal <input> (see below).
+const FIELD_CONTROL_TAGS = new Set(["input", "select", "textarea"]);
+
 function Field({ label, children, suffix }: { label: string; children: React.ReactNode; suffix?: string }) {
+  const autoId = useId();
+  let assigned = false;
+  const kids = Children.map(children, (child) => {
+    if (assigned || !isValidElement(child)) return child;
+    const isNativeControl = typeof child.type === "string" && FIELD_CONTROL_TAGS.has(child.type);
+    const isPasswordField = child.type === PasswordField;
+    if (!isNativeControl && !isPasswordField) return child;
+    assigned = true;
+    const props = child.props as { id?: string };
+    return cloneElement(child as ReactElement<{ id?: string }>, { id: props.id ?? autoId });
+  });
   return (
     <div className="flex items-center gap-3 min-h-[34px]">
-      <label className="text-[12px] text-mycel-text-2 w-28 shrink-0 truncate" title={label}>{label}</label>
+      <label htmlFor={autoId} className="text-[12px] text-mycel-text-2 w-28 shrink-0 truncate" title={label}>{label}</label>
       <div className="flex-1 flex items-center gap-1.5 min-w-0">
-        {children}
+        {kids}
         {suffix && <span className="text-[10px] text-mycel-muted shrink-0">{suffix}</span>}
       </div>
     </div>
   );
 }
 
-function PasswordField({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+function PasswordField({ value, onChange, id }: { value: string; onChange: (v: string) => void; id?: string }) {
   const [visible, setVisible] = useState(false);
   return (
     <div className="relative w-full">
       <input
+        id={id}
         type={visible ? "text" : "password"}
         value={value}
         onChange={(e) => onChange(e.target.value)}
@@ -88,8 +105,9 @@ function PasswordField({ value, onChange }: { value: string; onChange: (v: strin
       <button
         type="button"
         onClick={() => setVisible(!visible)}
-        className="absolute inset-y-0 right-0 flex items-center px-2 text-mycel-muted hover:text-mycel-text"
-        tabIndex={-1}
+        aria-label={visible ? "Hide password" : "Show password"}
+        aria-pressed={visible}
+        className="absolute inset-y-0 right-0 flex items-center px-2 text-mycel-muted hover:text-mycel-text outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent rounded-md before:absolute before:-inset-2.5 before:content-['']"
       >
         <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
           {visible ? (
@@ -562,8 +580,8 @@ function BudgetsSection() {
           {status === "saving" ? "Saving…" : "Save"}
         </button>
       </Field>
-      {status === "saved" && <p className="text-[11px] text-mycel-success">Saved</p>}
-      {status === "error" && <p className="text-[11px] text-mycel-error">Couldn&apos;t save the cap.</p>}
+      {status === "saved" && <p aria-live="polite" className="text-[11px] text-mycel-success">Saved</p>}
+      {status === "error" && <p role="alert" className="text-[11px] text-mycel-error">Couldn&apos;t save the cap.</p>}
 
       {perAgent.length > 0 && (
         <div className="rounded-lg border border-mycel-border bg-mycel-bg divide-y divide-mycel-border overflow-hidden">
@@ -701,8 +719,8 @@ function InjectedInstructionsSection() {
         onChange={(e) => setText(e.target.value)}
       />
       <div className="flex items-center justify-end gap-2">
-        {status === "saved" && <span className="text-xs text-mycel-success">Saved</span>}
-        {status === "error" && <span className="text-xs text-mycel-error">Save failed</span>}
+        {status === "saved" && <span aria-live="polite" className="text-xs text-mycel-success">Saved</span>}
+        {status === "error" && <span role="alert" className="text-xs text-mycel-error">Save failed</span>}
         <button
           type="button"
           onClick={handleSave}
@@ -724,6 +742,7 @@ export function Settings() {
   const fetcher = useCallback(() => api.getSettings(), []);
   const { data: config, loading, error, refresh, timedOut } = usePolling(fetcher, 30000);
   const { setTheme } = useTheme();
+  const themeLabelId = useId();
   const reveal = useProgressiveReveal(config, refresh);
 
   const [edited, setEdited] = useState<Record<string, unknown> | null>(null);
@@ -842,7 +861,7 @@ export function Settings() {
           onClick={() => { void reveal.replay(); }}
           title="Re-run setup — replays the guided reveal below without blanking anything you've already set"
           aria-label="Re-run setup"
-          className="shrink-0 grid place-items-center w-9 h-9 rounded-full border border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors active:scale-95"
+          className="relative shrink-0 grid place-items-center w-9 h-9 rounded-full border border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-1.5 before:content-['']"
         >
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
             <path d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
@@ -851,7 +870,7 @@ export function Settings() {
       </header>
 
       {saveStatus === "saved" && dirtySections.length === 0 && (
-        <div className="fixed bottom-4 right-4 z-30 rounded-lg border border-mycel-success bg-mycel-success-subtle px-3 py-2 text-xs text-mycel-success shadow-mycel-lg">
+        <div aria-live="polite" className="fixed bottom-4 right-4 z-30 rounded-lg border border-mycel-success bg-mycel-success-subtle px-3 py-2 text-xs text-mycel-success shadow-mycel-lg">
           Saved
         </div>
       )}
@@ -902,7 +921,7 @@ export function Settings() {
       )}
 
       {restartWarning && (
-        <div className="rounded-md border border-mycel-error bg-mycel-error-subtle px-3 py-1.5 text-xs text-mycel-error">
+        <div role="alert" className="rounded-md border border-mycel-error bg-mycel-error-subtle px-3 py-1.5 text-xs text-mycel-error">
           Changes saved. Restart mycel to apply (<code className="font-mono">mycel down &amp;&amp; mycel up -d</code>)
         </div>
       )}
@@ -927,8 +946,10 @@ export function Settings() {
           />
         </Field>
         <div className="flex items-start gap-2 min-h-[28px] pt-1">
-          <label className="text-xs text-mycel-text-2 w-28 shrink-0">Theme</label>
-          <ThemePicker value={currentThemeChoice} onChange={handleThemeChange} />
+          <span id={themeLabelId} className="text-xs text-mycel-text-2 w-28 shrink-0">Theme</span>
+          <div role="group" aria-labelledby={themeLabelId}>
+            <ThemePicker value={currentThemeChoice} onChange={handleThemeChange} />
+          </div>
         </div>
         <Field label="Default view">
           <select

--- a/web/src/views/__tests__/settings.test.tsx
+++ b/web/src/views/__tests__/settings.test.tsx
@@ -167,6 +167,32 @@ describe("Settings redesign", () => {
     });
   });
 
+  it("associates the Name field's label with its input via htmlFor/id", async () => {
+    mockApi();
+    renderSettings();
+    // getByLabelText only resolves through a real htmlFor → id link (or
+    // wrapping) — this fails if Field() ever regresses to an orphan label.
+    const nameInput = (await screen.findByLabelText("Name")) as HTMLInputElement;
+    expect(nameInput.value).toBe("dana");
+  });
+
+  it("keeps the password-reveal toggle keyboard-reachable", async () => {
+    mockApi();
+    renderSettings();
+
+    // Reveal the Advanced > Storage fields and switch to TimescaleDB, whose
+    // password field renders the show/hide toggle under test.
+    fireEvent.click(await screen.findByText("advanced"));
+    fireEvent.click(await screen.findByRole("button", { name: "▸ Storage" }));
+    const backendSelect = (await screen.findByLabelText("Backend")) as HTMLSelectElement;
+    fireEvent.change(backendSelect, { target: { value: "timescale" } });
+
+    const toggle = await screen.findByRole("button", { name: /show password/i });
+    expect(toggle).not.toHaveAttribute("tabindex", "-1");
+    toggle.focus();
+    expect(toggle).toHaveFocus();
+  });
+
   it("raises the save bar and PATCHes on edit + save", async () => {
     mockApi();
     renderSettings();


### PR DESCRIPTION
Part of #3423

## What changed

**Touch targets (<44px hit area, visual size unchanged via invisible `::before` slop):**
- `CopyButton` (24px → slop to 44px+)
- Home's `⋯` menu button and its keyboard-shortcuts-overlay close `×`
- Readiness's "Re-check" button
- Settings' re-run-setup icon button (36px → slop to 48px)
- The password-reveal toggle in `Settings.tsx`
- Remaining small `GatewayFeed` icon buttons: search toggle, filter toggle, search-close `×`, filter-clear `×`, topic-dismiss `×` (also added missing `aria-label`s)

**Focus indicators** — replaced border-color-only focus with `focus-visible:ring-2` (matching `CopyButton`'s existing pattern):
- `settings/controls.tsx`: `ThemePicker`, `RuntimePicker`, `AdvancedToggle`
- `views/Settings.tsx`: shared `INPUT_CLS`, plus the re-run-setup button

**`Field()` label association** (`views/Settings.tsx`):
- `Field()` now generates an id via `useId()` and clones it onto its child control (native `input`/`select`/`textarea`, or `PasswordField`'s inner input), giving every field a real `htmlFor`/`id` pair instead of an orphan `<label>`.
- The Theme picker (a button-group, not a single control) now uses a `<span id>` + `role="group" aria-labelledby` instead of an unassociated `<label>`.
- `ProviderDetail.tsx` ConfigPanel: `Command` field now has `id`/`htmlFor`; `Binary`/`Description`/`Install Hint` (read-only, non-control rows) moved from `<label>` to `<span>`. Add-MCP form's Name/Transport/URL-Command fields also got real associations.

**PasswordField reveal toggle** (`views/Settings.tsx`): removed `tabIndex={-1}`, added `aria-label` ("Show password"/"Hide password") and `aria-pressed`.

**Missing `aria-live`/`role="alert"`** — added to the handful of `Settings.tsx` status strings that were still silent: budget-save error, injected-instructions save error/success, the restart-required banner, and the floating "Saved" toast. Also added `aria-live="polite"` to ConnectApp's "connected!" status line.

**RuntimePicker** — verified the "Recommended" label already matches the tmux default (fixed previously); no change needed.

## Explicitly left untouched (already fixed)
- `CustomKeys.tsx` and ConnectApp's main error banner already carry `role="alert"` (from #3420/#3435).
- `AppsActivity.tsx` has no buttons.
- GatewayFeed's agents-popover trigger is a labeled text button (not icon-only), left as-is.

## Test plan
- [x] `make build-local-web` — clean build, no TS errors
- [x] `make test-web` (`vitest run`) — 413/413 passing across 49 files
- [x] `bun run lint` (web) — clean
- [x] Added targeted tests in `views/__tests__/settings.test.tsx`: `Field()` label/`htmlFor` association via `getByLabelText`, and the password toggle being keyboard-focusable (no `tabindex="-1"`, `.focus()` lands on it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)