### PR TITLE
feat(agents): activity Timeline tab — persisted lifecycle history

### DIFF
--- a/server/handlers/agents_activity.go
+++ b/server/handlers/agents_activity.go
@@ -15,6 +15,10 @@ type activityItem struct { //nolint:govet // field order matches JSON contract
 	Event     string         `json:"event"`
 	Message   string         `json:"message,omitempty"`
 	Agent     string         `json:"agent,omitempty"`
+	// ID is the underlying event store row id, exposed so callers can page
+	// backwards through an agent's full history via before=<id> (the
+	// Timeline tab, #3423) without a second lookup.
+	ID int64 `json:"id,omitempty"`
 }
 
 // toActivityItem normalizes an events.Event into the timeline DTO consumed by
@@ -46,6 +50,7 @@ func toActivityItem(e events.Event, includeAgent bool) activityItem {
 		Event:     strings.TrimPrefix(strings.TrimPrefix(string(e.Type), "hook."), "agent."),
 		Message:   msg,
 		Data:      e.Data,
+		ID:        e.ID,
 	}
 	if includeAgent {
 		out.Agent = e.Agent

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -79,6 +79,9 @@ export interface AgentActivityItem {
   // Omitted on the per-agent /api/agents/{name}/activity response since
   // the agent is implied by the URL.
   agent?: string;
+  // Event store row id — the opaque cursor for before=<id> paging further
+  // back through an agent's full history (the Timeline tab, #3423).
+  id?: number;
 }
 
 export interface Agent {
@@ -1023,8 +1026,13 @@ export const api = {
     }),
 
   // Agent activity timeline — newest first, capped at `limit` entries (default 50, max 1000).
-  getAgentActivity: (name: string, limit = 50) =>
-    request<AgentActivityItem[]>(`/agents/${encodeURIComponent(name)}/activity?limit=${limit}`),
+  // `before` pages backwards through full history via the event store's
+  // cursor (the row id of the oldest item already loaded) — the Timeline
+  // tab's "load older" pagination (#3423).
+  getAgentActivity: (name: string, limit = 50, before?: number) =>
+    request<AgentActivityItem[]>(
+      `/agents/${encodeURIComponent(name)}/activity?limit=${limit}${before ? `&before=${before}` : ""}`,
+    ),
   // Cross-agent recent activity for Live page hydration (#3138). Newest
   // first; each item carries an `agent` field so callers can route to
   // the right card.

--- a/web/src/components/agent-ui/AgentTimeline.tsx
+++ b/web/src/components/agent-ui/AgentTimeline.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../../api/client";
+import type { AgentActivityItem } from "../../api/client";
+import { EventRow } from "../live/EventRow";
+import { activityItemToNode } from "../live/liveHelpers";
+import type { ToolNode } from "../live/liveTypes";
+import { EmptyState } from "../EmptyState";
+import { formatAbsolute } from "../../utils/time";
+
+/* ── AgentTimeline ────────────────────────────────────────────────────
+   The durable, scrollable record of an agent's whole lifecycle — spawn,
+   tasks, tool calls, state changes, stop — built entirely from the
+   append-only events store via GET /api/agents/{name}/activity. Unlike
+   the Live tab (ephemeral, current-session WebSocket stream) this is
+   read-only history: it loads a page on mount and pages backwards in
+   time with "load older", never re-fetching what's already on screen.
+
+   Rows reuse the same EventRow/activityItemToNode path as Live so a tool
+   call reads identically in both places — same title, same expandable
+   input/output.
+─────────────────────────────────────────────────────────────────── */
+
+const PAGE_SIZE = 50;
+
+interface TimelineRow {
+  node: ToolNode;
+  id: number;
+  dayKey: string;
+}
+
+function toRow(item: AgentActivityItem): TimelineRow {
+  return {
+    node: activityItemToNode(item),
+    id: item.id ?? 0,
+    dayKey: formatAbsolute(item.timestamp, { dateOnly: true }),
+  };
+}
+
+export function AgentTimeline({ agentName }: { agentName: string }) {
+  const [rows, setRows] = useState<TimelineRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const cursorRef = useRef<number | undefined>(undefined);
+  const requestIdRef = useRef(0);
+
+  const loadInitial = useCallback(() => {
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+    api.getAgentActivity(agentName, PAGE_SIZE)
+      .then((items) => {
+        if (requestIdRef.current !== requestId) return;
+        const next = items.map(toRow);
+        setRows(next);
+        const oldest = items[items.length - 1];
+        cursorRef.current = oldest?.id;
+        setHasMore(items.length === PAGE_SIZE && oldest?.id !== undefined);
+      })
+      .catch(() => {
+        if (requestIdRef.current !== requestId) return;
+        setError("Couldn't load activity history");
+      })
+      .finally(() => {
+        if (requestIdRef.current !== requestId) return;
+        setLoading(false);
+      });
+  }, [agentName]);
+
+  useEffect(() => {
+    loadInitial();
+  }, [loadInitial]);
+
+  const loadOlder = useCallback(() => {
+    if (loadingMore || !hasMore || cursorRef.current === undefined) return;
+    setLoadingMore(true);
+    api.getAgentActivity(agentName, PAGE_SIZE, cursorRef.current)
+      .then((items) => {
+        const next = items.map(toRow);
+        setRows((prev) => [...prev, ...next]);
+        const oldest = items[items.length - 1];
+        cursorRef.current = oldest?.id;
+        setHasMore(items.length === PAGE_SIZE && oldest?.id !== undefined);
+      })
+      .catch(() => {
+        setError("Couldn't load older activity");
+      })
+      .finally(() => {
+        setLoadingMore(false);
+      });
+  }, [agentName, hasMore, loadingMore]);
+
+  if (loading) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-6">
+        <p className="text-sm text-mycel-muted italic">Loading activity…</p>
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center p-6">
+        <EmptyState
+          icon="~"
+          title="No recorded activity yet"
+          description="This agent's spawn, tasks, tool calls, and state changes will appear here as they happen — the durable record survives restarts and session boundaries."
+        />
+      </div>
+    );
+  }
+
+  // Group consecutive rows by day so a long history reads as day
+  // sections rather than one undifferentiated column of rows.
+  let lastDayKey = "";
+
+  return (
+    <div className="flex flex-col h-full overflow-y-auto p-6 gap-0">
+      <div className="rounded-lg border border-mycel-border overflow-hidden">
+        {rows.map((row) => {
+          const showDayHeader = row.dayKey !== lastDayKey;
+          lastDayKey = row.dayKey;
+          return (
+            <div key={row.node.id}>
+              {showDayHeader && (
+                <div className="px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-mycel-muted bg-mycel-surface border-b border-mycel-border">
+                  {row.dayKey}
+                </div>
+              )}
+              <EventRow node={row.node} />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-col items-center gap-2 py-4">
+        {error && <p className="text-xs text-mycel-error">{error}</p>}
+        {hasMore ? (
+          <button
+            type="button"
+            onClick={loadOlder}
+            disabled={loadingMore}
+            className="h-8 px-3 inline-flex items-center rounded-md border border-mycel-border-strong text-[13px] text-mycel-text hover:bg-mycel-surface-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loadingMore ? "Loading…" : "Load older"}
+          </button>
+        ) : (
+          <p className="text-xs text-mycel-muted">Beginning of recorded history</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/agent-ui/AgentTimeline.tsx
+++ b/web/src/components/agent-ui/AgentTimeline.tsx
@@ -74,9 +74,15 @@ export function AgentTimeline({ agentName }: { agentName: string }) {
 
   const loadOlder = useCallback(() => {
     if (loadingMore || !hasMore || cursorRef.current === undefined) return;
+    // Capture the current requestId so a page that resolves after the agent
+    // switched (loadInitial bumped requestIdRef) is discarded rather than
+    // appended to the new agent's rows / overwriting its cursor.
+    const requestId = requestIdRef.current;
     setLoadingMore(true);
+    setError(null);
     api.getAgentActivity(agentName, PAGE_SIZE, cursorRef.current)
       .then((items) => {
+        if (requestIdRef.current !== requestId) return;
         const next = items.map(toRow);
         setRows((prev) => [...prev, ...next]);
         const oldest = items[items.length - 1];
@@ -84,9 +90,11 @@ export function AgentTimeline({ agentName }: { agentName: string }) {
         setHasMore(items.length === PAGE_SIZE && oldest?.id !== undefined);
       })
       .catch(() => {
+        if (requestIdRef.current !== requestId) return;
         setError("Couldn't load older activity");
       })
       .finally(() => {
+        if (requestIdRef.current !== requestId) return;
         setLoadingMore(false);
       });
   }, [agentName, hasMore, loadingMore]);

--- a/web/src/components/agent-ui/__tests__/AgentTimeline.test.tsx
+++ b/web/src/components/agent-ui/__tests__/AgentTimeline.test.tsx
@@ -94,4 +94,49 @@ describe("AgentTimeline", () => {
     const secondUrl = fetchMock.mock.calls[1]?.[0] as string;
     expect(secondUrl).toContain("before=51");
   });
+
+  it("discards a load-older page that resolves after the agent switched", async () => {
+    const agentAFirst = Array.from({ length: 50 }, (_, i) =>
+      activityItem(200 - i, "Bash", `a-cmd ${200 - i}`),
+    );
+    const agentAOlder = [activityItem(140, "Bash", "stale agent-A row")];
+    const agentBFirst = [activityItem(300, "Read", "agent-B row")];
+
+    // Hold agent A's older page open so it resolves *after* we switch to B.
+    let releaseAOlder!: (v: Response) => void;
+    const aOlderPromise = new Promise<Response>((res) => {
+      releaseAOlder = res;
+    });
+
+    fetchMock
+      .mockImplementationOnce(() => jsonResponse(agentAFirst)) // A initial
+      .mockImplementationOnce(() => aOlderPromise) // A "load older" (deferred)
+      .mockImplementationOnce(() => jsonResponse(agentBFirst)); // B initial
+
+    const { rerender } = render(<AgentTimeline agentName="agent-a" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Load older")).toBeInTheDocument();
+    });
+
+    // Kick off the older fetch (deferred), then switch agents before it lands.
+    fireEvent.click(screen.getByText("Load older"));
+    rerender(<AgentTimeline agentName="agent-b" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("agent-B row")).toBeInTheDocument();
+    });
+
+    // Now let agent A's stale older page resolve — it must be discarded.
+    releaseAOlder(
+      await jsonResponse(agentAOlder).then((r) => r),
+    );
+
+    await Promise.resolve();
+    await waitFor(() => {
+      expect(screen.queryByText("stale agent-A row")).not.toBeInTheDocument();
+    });
+    // Agent B's rows remain intact.
+    expect(screen.getByText("agent-B row")).toBeInTheDocument();
+  });
 });

--- a/web/src/components/agent-ui/__tests__/AgentTimeline.test.tsx
+++ b/web/src/components/agent-ui/__tests__/AgentTimeline.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * AgentTimeline.test.tsx — the persisted, scrollable lifecycle history tab
+ * (#3423). Built from GET /api/agents/{name}/activity; unlike the Live tab
+ * it is read-only history with no WebSocket subscription.
+ *
+ * Invariants:
+ *   - Renders activity rows fetched from the endpoint via the shared
+ *     EventRow/activityItemToNode path (same look as Live).
+ *   - "Load older" pages backwards using before=<id> and appends rows.
+ *   - An agent with no history shows the honest empty state.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { AgentTimeline } from "../AgentTimeline";
+
+const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function activityItem(id: number, event: string, message: string) {
+  return {
+    id,
+    timestamp: new Date(2026, 0, 1, 12, 0, id).toISOString(),
+    event,
+    message,
+    data: { tool_name: event },
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+});
+
+describe("AgentTimeline", () => {
+  it("shows the empty state when there is no recorded activity", async () => {
+    fetchMock.mockImplementationOnce(() => jsonResponse([]));
+
+    render(<AgentTimeline agentName="eng-01" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No recorded activity yet")).toBeInTheDocument();
+    });
+  });
+
+  it("renders activity rows fetched from the per-agent endpoint", async () => {
+    const items = [
+      activityItem(3, "Bash", "Bash: ls -la"),
+      activityItem(2, "Read", "Read"),
+      activityItem(1, "agent.spawned", "spawned"),
+    ];
+    fetchMock.mockImplementationOnce(() => jsonResponse(items));
+
+    render(<AgentTimeline agentName="eng-01" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Bash")).toBeInTheDocument();
+    });
+    expect(screen.getAllByText("Read").length).toBeGreaterThan(0);
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    expect(url).toContain("/agents/eng-01/activity");
+  });
+
+  it("pages backwards through history with load older", async () => {
+    const firstPage = Array.from({ length: 50 }, (_, i) =>
+      activityItem(100 - i, "Bash", `cmd ${100 - i}`),
+    );
+    const secondPage = [activityItem(49, "Read", "older read")];
+
+    fetchMock
+      .mockImplementationOnce(() => jsonResponse(firstPage))
+      .mockImplementationOnce(() => jsonResponse(secondPage));
+
+    render(<AgentTimeline agentName="eng-01" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Load older")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Load older"));
+
+    await waitFor(() => {
+      expect(screen.getByText("older read")).toBeInTheDocument();
+    });
+
+    const secondUrl = fetchMock.mock.calls[1]?.[0] as string;
+    expect(secondUrl).toContain("before=51");
+  });
+});

--- a/web/src/components/agent-ui/index.ts
+++ b/web/src/components/agent-ui/index.ts
@@ -10,6 +10,7 @@ export type { AgentSelectProps, AgentOption } from "./AgentSelect";
 export { AgentCard } from "./AgentCard";
 export type { AgentCardProps } from "./AgentCard";
 export { AgentStatusBadge } from "./AgentStatusBadge";
+export { AgentTimeline } from "./AgentTimeline";
 export { deriveIdentity, hashName, stateAnimClass, ALL_FORMS } from "./identity";
 export type { AgentIdentity, BodyForm, EyeStyle } from "./identity";
 export { useAgentPulse, prefersReducedMotion, PULSE_MS } from "./useAgentPulse";

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -8,7 +8,7 @@ import { usePolling } from "../hooks/usePolling";
 import { useWebSocket } from "../hooks/useWebSocket";
 import { StatsTab as StatsTabComponent } from "../components/StatsTab";
 import { WebTerminal, type TerminalConnectionState, type TerminalConnectionDetail } from "../components/WebTerminal";
-import { LiveAgentCharacter } from "../components/agent-ui";
+import { LiveAgentCharacter, AgentTimeline } from "../components/agent-ui";
 import { MCPServerList } from "../components/shared/MCPServerList";
 import { McpEnvEditor } from "../components/shared/McpEnvEditor";
 import { SystemPromptEditor } from "../components/shared/SystemPromptEditor";
@@ -28,21 +28,22 @@ const formatRelative = (t?: string): string => sharedFormatRelative(t, { emptyLa
    Tab types — v3: Live / Attach / Settings / Metrics
    ═══════════════════════════════════════════════════════════════════ */
 
-type Tab = "attach" | "live" | "settings" | "metrics" | "code";
+type Tab = "attach" | "live" | "timeline" | "settings" | "metrics" | "code";
 
 const TABS: { key: Tab; label: string; shortcut: string }[] = [
   { key: "attach", label: "Attach", shortcut: "1" },
   { key: "live", label: "Live", shortcut: "2" },
-  { key: "settings", label: "Settings", shortcut: "3" },
-  { key: "metrics", label: "Metrics", shortcut: "4" },
-  { key: "code", label: "Code", shortcut: "5" },
+  { key: "timeline", label: "Timeline", shortcut: "3" },
+  { key: "settings", label: "Settings", shortcut: "4" },
+  { key: "metrics", label: "Metrics", shortcut: "5" },
+  { key: "code", label: "Code", shortcut: "6" },
 ];
 
 /** Map a URL sub-path segment to a tab. The legacy `config` segment
  *  resolves to the renamed Settings tab so old deep links keep working. */
 function tabForSegment(seg: string | undefined): Tab | null {
   if (seg === "config") return "settings";
-  const known: Tab[] = ["attach", "live", "settings", "metrics", "code"];
+  const known: Tab[] = ["attach", "live", "timeline", "settings", "metrics", "code"];
   return known.includes(seg as Tab) ? (seg as Tab) : null;
 }
 
@@ -1501,7 +1502,7 @@ export function AgentDetail() {
     return subscribe("agent.state_changed", () => void refresh());
   }, [subscribe, refresh]);
 
-  // Keyboard shortcuts: 1-4 for tabs, s for start/stop, Esc for back
+  // Keyboard shortcuts: 1-6 for tabs, s for start/stop, Esc for back
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement | null)?.tagName;
@@ -1515,12 +1516,15 @@ export function AgentDetail() {
           selectTab("live");
           break;
         case "3":
-          selectTab("settings");
+          selectTab("timeline");
           break;
         case "4":
-          selectTab("metrics");
+          selectTab("settings");
           break;
         case "5":
+          selectTab("metrics");
+          break;
+        case "6":
           selectTab("code");
           break;
         case "Escape":
@@ -1717,6 +1721,7 @@ export function AgentDetail() {
           />
         )}
         {activeTab === "attach" && <AttachTab agent={agent} />}
+        {activeTab === "timeline" && <AgentTimeline agentName={agent.name} />}
         {activeTab === "settings" && <SettingsTab agent={agent} agentsUrl={agentsUrl} />}
         {activeTab === "metrics" && <MetricsTab agent={agent} />}
         {activeTab === "code" && <CodeTab agent={agent} />}


### PR DESCRIPTION
Part of #3423

## Summary
- Adds a **Timeline** tab to `AgentDetail` — a persisted, scrollable record of an agent's whole lifecycle (spawn -> tasks -> tool calls -> state changes -> stop), built from the existing `pkg/events` store. This is distinct from the **Live** tab, which only shows the ephemeral current-session WebSocket stream.
- Backend (`server/handlers/agents_activity.go`): `GET /api/agents/{name}/activity` already supported full historical cursor paging via `ReadByAgentPage`/`before=<id>` (bounded per page, up to 1000) — but the DTO never exposed the event's row id, so the frontend had no cursor to page with. Added `id` to the `activityItem` JSON response so the client can walk backwards through the complete history.
- Frontend: `web/src/components/agent-ui/AgentTimeline.tsx` loads a page via `api.getAgentActivity`, renders newest-first with day-grouping, and pages older with a "Load older" button using the new `before` cursor. Reuses `EventRow`/`activityItemToNode` so rows render identically to the Live tab (title from tool_name/description, expandable input/output). Honest empty state ("No recorded activity yet") when there's no history.
- Wired into `AgentDetail.tsx` as a new tab (keyboard shortcut renumbered 1-6 to fit Timeline in as slot 3).

## Test plan
- [x] `make build-local-web`
- [x] `make test-web` (416 tests passing, including new `AgentTimeline.test.tsx`)
- [x] `go test ./server/handlers/...`
- [x] `go vet ./server/handlers/...`, `golangci-lint run ./server/handlers/...` (0 issues)
- [x] `bunx tsc --noEmit`, `bun run lint` (eslint) clean
- New tests cover: rows render from the endpoint, "Load older" pages via `before=<id>` and appends, empty state renders when there's no activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Timeline tab to agent details for viewing activity history.
  * Activity history is grouped by day and includes loading, empty, and end-of-history states.
  * Added “Load older” pagination for browsing previous activity records.
  * Updated tab shortcuts to include the new Timeline tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->