### PR TITLE
feat(cli): 'mycel app scaffold' — generate a new app/gateway plugin skeleton

### DIFF
--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+// appCmd is the parent command for app/gateway-plugin developer tooling.
+var appCmd = &cobra.Command{
+	Use:   "app",
+	Short: "Manage app (gateway plugin) integrations",
+	Long: `Manage app plugins — the integrations that bridge mycel to external
+platforms (Slack, GitHub, webhooks, ...).
+
+Examples:
+  mycel app scaffold linear      # Generate a new app plugin skeleton`,
+}
+
+// appScaffoldMulti and appScaffoldDir back the scaffold subcommand's flags.
+var (
+	appScaffoldMulti bool
+	appScaffoldDir   string
+)
+
+var appScaffoldCmd = &cobra.Command{
+	Use:   "scaffold <name>",
+	Short: "Generate a new app/gateway plugin skeleton",
+	Long: `Generate a new app plugin skeleton under pkg/gateway/<name>/.
+
+Adding an app today = one new plugin package under pkg/gateway/<name>/
+plus one import line in pkg/app/builtin/builtin.go. This command
+generates the plugin package (a plugin.go implementing app.Plugin and
+a <name>.go adapter implementing gateway.NotificationAdapter) so
+contributors can fill in the TODOs and wire it up.
+
+Examples:
+  mycel app scaffold linear             # pkg/gateway/linear/
+  mycel app scaffold telegram --multi   # allow labeled instances`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAppScaffold,
+}
+
+func init() {
+	appScaffoldCmd.Flags().BoolVar(&appScaffoldMulti, "multi", false, "allow labeled instances (e.g. telegram:alerts)")
+	appScaffoldCmd.Flags().StringVar(&appScaffoldDir, "dir", "pkg/gateway", "parent directory to generate the plugin package under")
+	appCmd.AddCommand(appScaffoldCmd)
+	rootCmd.AddCommand(appCmd)
+}
+
+// appNamePattern enforces lowercase alphanumeric identifiers (optionally
+// with underscores), matching the existing pkg/gateway/<name> packages
+// and valid Go package names.
+var appNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+func runAppScaffold(cmd *cobra.Command, args []string) error {
+	name := args[0]
+	if err := validateAppName(name); err != nil {
+		return err
+	}
+
+	pkgDir := filepath.Join(appScaffoldDir, name)
+	if _, err := os.Stat(pkgDir); err == nil {
+		return fmt.Errorf("refusing to overwrite: %s already exists", pkgDir)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("stat %s: %w", pkgDir, err)
+	}
+
+	if err := os.MkdirAll(pkgDir, 0o750); err != nil {
+		return fmt.Errorf("create %s: %w", pkgDir, err)
+	}
+
+	data := appScaffoldData{
+		Name:  name,
+		Pkg:   name,
+		Label: appScaffoldLabel(name),
+		Multi: appScaffoldMulti,
+	}
+
+	if err := writeGoTemplate(filepath.Join(pkgDir, "plugin.go"), appScaffoldPluginTmpl, data); err != nil {
+		return err
+	}
+	if err := writeGoTemplate(filepath.Join(pkgDir, name+".go"), appScaffoldAdapterTmpl, data); err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	var msg strings.Builder
+	fmt.Fprintf(&msg, "Generated app plugin skeleton at %s\n\n", pkgDir)
+	fmt.Fprintf(&msg, "  %s\n", filepath.Join(pkgDir, "plugin.go"))
+	fmt.Fprintf(&msg, "  %s\n\n", filepath.Join(pkgDir, name+".go"))
+	msg.WriteString("Next steps:\n")
+	msg.WriteString("  1. Add this import to pkg/app/builtin/builtin.go:\n")
+	fmt.Fprintf(&msg, "       _ \"github.com/rpuneet/mycel/pkg/gateway/%s\"\n", name)
+	msg.WriteString("  2. Implement the TODOs in plugin.go and " + name + ".go.\n")
+	msg.WriteString("  3. Run: make build-local-mycel\n")
+
+	if _, err := fmt.Fprint(out, msg.String()); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+	return nil
+}
+
+// appScaffoldData is the template context shared by the plugin and
+// adapter templates.
+type appScaffoldData struct {
+	Name  string // descriptor ID / package import path leaf, e.g. "linear"
+	Pkg   string // Go package name, same as Name (already validated as an identifier)
+	Label string // human-readable label, e.g. "Linear"
+	Multi bool
+}
+
+// validateAppName rejects names that would not make a valid, non-colliding
+// Go package under pkg/gateway.
+func validateAppName(name string) error {
+	if name == "" {
+		return fmt.Errorf("app name cannot be empty")
+	}
+	if strings.ContainsAny(name, " \t\n") {
+		return fmt.Errorf("app name %q must not contain whitespace", name)
+	}
+	if name != strings.ToLower(name) {
+		return fmt.Errorf("app name %q must be lowercase", name)
+	}
+	if !appNamePattern.MatchString(name) {
+		return fmt.Errorf("app name %q must start with a letter and contain only lowercase letters, digits, and underscores", name)
+	}
+	return nil
+}
+
+// appScaffoldLabel turns a package-style name into a human-readable
+// label, e.g. "google_calendar" -> "Google Calendar".
+func appScaffoldLabel(name string) string {
+	parts := strings.Split(name, "_")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+// writeGoTemplate executes tmpl with data, gofmts the result, and writes
+// it to path.
+func writeGoTemplate(path string, tmpl *template.Template, data appScaffoldData) error {
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("render template for %s: %w", path, err)
+	}
+
+	formatted, err := format.Source(buf.Bytes())
+	if err != nil {
+		return fmt.Errorf("gofmt %s: %w", path, err)
+	}
+
+	if err := os.WriteFile(path, formatted, 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/cmd/app_scaffold_templates.go
+++ b/internal/cmd/app_scaffold_templates.go
@@ -1,0 +1,140 @@
+package cmd
+
+import "text/template"
+
+// appScaffoldPluginTmpl generates pkg/gateway/<name>/plugin.go — the
+// app.Plugin implementation (Describe + Build) that registers itself
+// with the default app registry.
+var appScaffoldPluginTmpl = template.Must(template.New("plugin").Parse(`package {{.Pkg}}
+
+import (
+	"github.com/rpuneet/mycel/pkg/app"
+	"github.com/rpuneet/mycel/pkg/gateway"
+)
+
+// plugin implements app.Plugin for {{.Label}}.
+type plugin struct{}
+
+var _ app.Plugin = plugin{}
+
+func init() {
+	app.Register(plugin{})
+}
+
+func (plugin) Describe() app.Descriptor {
+	return app.Descriptor{
+		ID:    "{{.Name}}",
+		Label: "{{.Label}}",
+		// TODO: pick the auth kind that matches {{.Label}}'s API
+		// (app.AuthToken, app.AuthOAuth, app.AuthQR, app.AuthNone).
+		Auth:  app.AuthWebhookSecret,
+		Multi: {{.Multi}},
+		Fields: []app.FieldSpec{
+			// TODO: replace with {{.Label}}'s real config/credential fields.
+			{Key: "api_key", Label: "API Key", Placeholder: "your-api-key", Secret: true, Required: true},
+			{Key: "workspace", Label: "Workspace", Placeholder: "my-workspace"},
+		},
+		Docs: []string{
+			// TODO: replace with real setup instructions.
+			"POST JSON to /hooks/{{.Name}} on your mycel server.",
+			"TODO: describe how to obtain the API key and configure the webhook.",
+		},
+	}
+}
+
+func (plugin) Build(inst app.Instance, _ app.Env) (gateway.NotificationAdapter, error) {
+	// TODO: resolve any additional config/secrets needed to build the adapter.
+	apiKey, err := inst.RequiredSecret("api_key")
+	if err != nil {
+		return nil, err
+	}
+	return New(inst.Name, apiKey), nil
+}
+`))
+
+// appScaffoldAdapterTmpl generates pkg/gateway/<name>/<name>.go — the
+// gateway.NotificationAdapter implementation with TODO stubs for the
+// adapter's actual wire-up.
+var appScaffoldAdapterTmpl = template.Must(template.New("adapter").Parse(`// Package {{.Pkg}} implements a gateway.NotificationAdapter for {{.Label}}.
+package {{.Pkg}}
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rpuneet/mycel/pkg/gateway"
+)
+
+// Adapter implements gateway.NotificationAdapter for {{.Label}}.
+type Adapter struct {
+	lastMessageAt time.Time
+	handler       func(gateway.Notification)
+	name          string
+	apiKey        string
+	lastError     string
+	mu            sync.Mutex
+	connected     bool
+	messageCount  atomic.Int64
+}
+
+var _ gateway.NotificationAdapter = (*Adapter)(nil)
+
+// New creates a new {{.Label}} adapter.
+func New(name, apiKey string) *Adapter {
+	return &Adapter{name: name, apiKey: apiKey}
+}
+
+// Name returns the adapter identifier.
+func (a *Adapter) Name() string { return a.name }
+
+// Type returns the connection pattern for this adapter.
+// TODO: change to gateway.AdapterSocket or gateway.AdapterPoll if
+// {{.Label}} is not webhook-based.
+func (a *Adapter) Type() gateway.AdapterType { return gateway.AdapterWebhook }
+
+// Start connects to {{.Label}} and begins receiving notifications.
+// TODO: for socket/poll adapters, connect and start the receive loop
+// here, calling handler for each inbound event and blocking until ctx
+// is canceled. Webhook adapters can just store the handler.
+func (a *Adapter) Start(_ context.Context, handler func(gateway.Notification)) error {
+	a.handler = handler
+	return nil
+}
+
+// Stop gracefully disconnects from {{.Label}}.
+// TODO: close any open connections/goroutines started in Start.
+func (a *Adapter) Stop() error { return nil }
+
+// HTTPHandler returns an http.Handler for webhook-based adapters, or
+// nil for socket/poll adapters.
+// TODO: implement the actual webhook handler (verify signature/secret,
+// parse the payload, call a.handler with a gateway.Notification).
+func (a *Adapter) HTTPHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not implemented", http.StatusNotImplemented)
+	})
+}
+
+// Channels returns discovered channels/groups the adapter has access to.
+// TODO: return real channels once {{.Label}} exposes them.
+func (a *Adapter) Channels() []gateway.ChannelInfo {
+	return []gateway.ChannelInfo{
+		{ID: a.name, Name: a.name, Platform: "{{.Name}}"},
+	}
+}
+
+// Status returns the adapter's connection state for the web UI.
+func (a *Adapter) Status() gateway.AdapterStatus {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return gateway.AdapterStatus{
+		Connected:     a.connected,
+		LastMessageAt: a.lastMessageAt,
+		Error:         a.lastError,
+		MessageCount:  a.messageCount.Load(),
+	}
+}
+`))

--- a/internal/cmd/app_scaffold_test.go
+++ b/internal/cmd/app_scaffold_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"bytes"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// runScaffold invokes runAppScaffold directly (bypassing the daemon-bound
+// rootCmd.Execute path used elsewhere in this package) with the given
+// flag values, returning stdout and any error.
+func runScaffold(t *testing.T, name, dir string, multi bool) (string, error) {
+	t.Helper()
+
+	origDir, origMulti := appScaffoldDir, appScaffoldMulti
+	appScaffoldDir, appScaffoldMulti = dir, multi
+	t.Cleanup(func() {
+		appScaffoldDir, appScaffoldMulti = origDir, origMulti
+	})
+
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := runAppScaffold(cmd, []string{name})
+	return buf.String(), err
+}
+
+func TestAppScaffoldGeneratesValidGo(t *testing.T) {
+	dir := t.TempDir()
+
+	out, err := runScaffold(t, "scaffoldfoo", dir, false)
+	if err != nil {
+		t.Fatalf("runAppScaffold: %v", err)
+	}
+	if out == "" {
+		t.Fatal("expected non-empty output")
+	}
+
+	pkgDir := filepath.Join(dir, "scaffoldfoo")
+	for _, f := range []string{"plugin.go", "scaffoldfoo.go"} {
+		path := filepath.Join(pkgDir, f)
+		src, readErr := os.ReadFile(path) //nolint:gosec // test-controlled path under t.TempDir()
+		if readErr != nil {
+			t.Fatalf("read %s: %v", path, readErr)
+		}
+		fset := token.NewFileSet()
+		if _, parseErr := parser.ParseFile(fset, path, src, parser.AllErrors); parseErr != nil {
+			t.Fatalf("generated %s is not valid Go: %v\n%s", f, parseErr, src)
+		}
+	}
+}
+
+func TestAppScaffoldMultiFlag(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := runScaffold(t, "scaffoldmulti", dir, true); err != nil {
+		t.Fatalf("runAppScaffold: %v", err)
+	}
+
+	src, err := os.ReadFile(filepath.Join(dir, "scaffoldmulti", "plugin.go")) //nolint:gosec // test-controlled path under t.TempDir()
+	if err != nil {
+		t.Fatalf("read plugin.go: %v", err)
+	}
+	if !bytes.Contains(src, []byte("Multi: true")) {
+		t.Errorf("expected Multi: true in generated plugin.go, got:\n%s", src)
+	}
+}
+
+func TestAppScaffoldRefusesExistingPackage(t *testing.T) {
+	dir := t.TempDir()
+
+	if _, err := runScaffold(t, "scaffolddup", dir, false); err != nil {
+		t.Fatalf("first scaffold: %v", err)
+	}
+
+	if _, err := runScaffold(t, "scaffolddup", dir, false); err == nil {
+		t.Fatal("expected error when scaffolding an existing package, got nil")
+	}
+}
+
+func TestAppScaffoldValidatesName(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []string{"BadName", "bad name", "bad-name", "", "123bad"}
+	for _, name := range cases {
+		if _, err := runScaffold(t, name, dir, false); err == nil {
+			t.Errorf("expected error for invalid name %q, got nil", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `mycel app scaffold <name> [--multi] [--dir pkg/gateway]`, generating a new app plugin package at `<dir>/<name>/`: `plugin.go` (an `app.Plugin` with `Describe()`/`Build()`, registering itself via `init() → app.Register(...)`) and `<name>.go` (a `gateway.NotificationAdapter` stub implementing Name/Type/Start/Stop/HTTPHandler/Channels/Status), following the pattern of the existing `pkg/gateway/webhook` plugin.
- Validates the name (lowercase, `[a-z][a-z0-9_]*`) and refuses to overwrite an existing package directory.
- Generated Go is rendered via `text/template` and passed through `go/format.Source` before being written.
- Does **not** auto-edit `pkg/app/builtin/builtin.go` — it prints the exact import line to add, plus the remaining next steps (implement the TODOs, run `make build-local-mycel`), so nothing in that file gets clobbered.
- Adds `mycel app` as the new parent command for app/gateway-plugin developer tooling.

## Sample output
```
$ mycel app scaffold testfoo --dir /tmp/scaffoldtest
Generated app plugin skeleton at /tmp/scaffoldtest/testfoo

  /tmp/scaffoldtest/testfoo/plugin.go
  /tmp/scaffoldtest/testfoo/testfoo.go

Next steps:
  1. Add this import to pkg/app/builtin/builtin.go:
       _ "github.com/rpuneet/mycel/pkg/gateway/testfoo"
  2. Implement the TODOs in plugin.go and testfoo.go.
  3. Run: make build-local-mycel
```

Refusing to overwrite:
```
$ mycel app scaffold webhook --dir pkg/gateway
Error: refusing to overwrite: pkg/gateway/webhook already exists
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./internal/... ./pkg/...` — 0 issues
- [x] `go test ./internal/cmd/...` — new `TestAppScaffold*` cases: generates valid Go (parsed with `go/parser`), `--multi` sets `Multi: true`, refuses an existing package, rejects invalid names
- [x] Built `./bin/mycel` via `make build-local-mycel` and ran `./bin/mycel app scaffold testfoo --dir /tmp/scaffoldtest`; copied the generated package into `pkg/gateway/testfoo` and confirmed `go build ./pkg/gateway/testfoo/...` compiles clean against the real module, then removed it

Part of #3423

🤖 Generated with [Claude Code](https://claude.com/claude-code)