### PR TITLE
feat(github): outbound PR/issue comments + commit status via OAuth token

### DIFF
--- a/pkg/gateway/github/github.go
+++ b/pkg/gateway/github/github.go
@@ -30,12 +30,21 @@ var commonEventTypes = []string{
 	"workflow_run",
 }
 
-// Adapter implements gateway.NotificationAdapter for GitHub webhooks.
+// apiBaseURL is the default GitHub REST API host. Overridden in tests via
+// Adapter.apiBase so an httptest server can stand in for api.github.com.
+const apiBaseURL = "https://api.github.com"
+
+// Adapter implements gateway.NotificationAdapter for GitHub webhooks, plus
+// outbound REST calls (PR/issue comments, commit statuses) authenticated
+// with the OAuth device-flow api_token.
 type Adapter struct {
-	lastMessageAt time.Time
 	handler       func(gateway.Notification)
+	httpc         *http.Client
+	lastMessageAt time.Time
 	name          string
 	secret        string
+	apiToken      string
+	apiBase       string
 	lastError     string
 	mu            sync.Mutex
 	connected     bool
@@ -45,21 +54,33 @@ type Adapter struct {
 var _ gateway.NotificationAdapter = (*Adapter)(nil)
 
 // New creates a new GitHub webhook adapter with the given HMAC secret.
-// If secret is empty, signature validation is skipped.
+// If secret is empty, signature validation is skipped. It has no api_token,
+// so outbound calls (Comment, SetStatus) fail with a clear sign-in error.
 func New(secret string) *Adapter {
-	return &Adapter{
-		name:   "github",
-		secret: secret,
-	}
+	return NewNamed("github", secret, "")
 }
 
 // NewNamed creates a named GitHub adapter for multi-repo setups
-// (e.g. "github:mycel", "github:trade").
-func NewNamed(name, secret string) *Adapter {
+// (e.g. "github:mycel", "github:trade"). apiToken is the OAuth device-flow
+// token (scope "repo") used for outbound REST calls; pass "" if the app
+// instance hasn't signed in yet.
+func NewNamed(name, secret, apiToken string) *Adapter {
 	return &Adapter{
-		name:   name,
-		secret: secret,
+		name:     name,
+		secret:   secret,
+		apiToken: apiToken,
+		httpc:    &http.Client{Timeout: 15 * time.Second},
+		apiBase:  apiBaseURL,
 	}
+}
+
+// SetAPIBaseForTest overrides the GitHub REST API host, e.g. pointing it at
+// an httptest server. Exported for use by other packages' tests (server
+// handlers); production code never calls this.
+func (a *Adapter) SetAPIBaseForTest(base string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.apiBase = base
 }
 
 func (a *Adapter) Name() string { return a.name }

--- a/pkg/gateway/github/github_test.go
+++ b/pkg/gateway/github/github_test.go
@@ -183,7 +183,7 @@ func TestAdapterInterface(t *testing.T) {
 }
 
 func TestNamedAdapter(t *testing.T) {
-	a := NewNamed("github:mycel", "secret")
+	a := NewNamed("github:mycel", "secret", "")
 	if a.Name() != "github:mycel" {
 		t.Errorf("Name() = %q, want %q", a.Name(), "github:mycel")
 	}

--- a/pkg/gateway/github/outbound.go
+++ b/pkg/gateway/github/outbound.go
@@ -1,0 +1,124 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// Comment posts a comment on a GitHub issue or pull request. GitHub treats
+// PRs as issues for the comments API, so one call serves both.
+func (a *Adapter) Comment(ctx context.Context, owner, repo string, number int, body string) error {
+	if owner == "" || repo == "" || number <= 0 {
+		return fmt.Errorf("github: comment requires owner, repo, and a positive issue/PR number")
+	}
+	if body == "" {
+		return fmt.Errorf("github: comment body is required")
+	}
+	path := fmt.Sprintf("/repos/%s/%s/issues/%d/comments", owner, repo, number)
+	return a.postJSON(ctx, path, map[string]string{"body": body})
+}
+
+// SetStatus sets a commit status on a specific SHA (POST
+// /repos/{owner}/{repo}/statuses/{sha}). state must be one of GitHub's
+// accepted values: "error", "failure", "pending", "success". description
+// and targetURL are optional and may be passed as "".
+func (a *Adapter) SetStatus(ctx context.Context, owner, repo, sha, state, description, targetURL, statusContext string) error {
+	if owner == "" || repo == "" || sha == "" {
+		return fmt.Errorf("github: status requires owner, repo, and sha")
+	}
+	switch state {
+	case "error", "failure", "pending", "success":
+	default:
+		return fmt.Errorf("github: invalid status state %q (want error, failure, pending, or success)", state)
+	}
+	payload := map[string]string{"state": state}
+	if description != "" {
+		payload["description"] = description
+	}
+	if targetURL != "" {
+		payload["target_url"] = targetURL
+	}
+	if statusContext != "" {
+		payload["context"] = statusContext
+	}
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
+	return a.postJSON(ctx, path, payload)
+}
+
+// Send implements the gateway package's outbound messageSender capability
+// so a GitHub comment can be posted through the same generic channel-send
+// path used by Slack/Telegram/WhatsApp (POST /api/apps/channels/send and
+// the send_message MCP tool). Since GitHub has no single "channel" concept,
+// the channel id doubles as an issue/PR reference: "owner/repo#123".
+func (a *Adapter) Send(ctx context.Context, channelID, _, content string) error {
+	owner, repo, number, err := parseIssueRef(channelID)
+	if err != nil {
+		return err
+	}
+	return a.Comment(ctx, owner, repo, number, content)
+}
+
+// parseIssueRef parses "owner/repo#123" into its parts.
+func parseIssueRef(ref string) (owner, repo string, number int, err error) {
+	ownerRepo, numStr, ok := strings.Cut(ref, "#")
+	if !ok {
+		return "", "", 0, fmt.Errorf("github: target %q must be \"owner/repo#number\"", ref)
+	}
+	owner, repo, ok = strings.Cut(ownerRepo, "/")
+	if !ok || owner == "" || repo == "" {
+		return "", "", 0, fmt.Errorf("github: target %q must be \"owner/repo#number\"", ref)
+	}
+	number, err = strconv.Atoi(numStr)
+	if err != nil || number <= 0 {
+		return "", "", 0, fmt.Errorf("github: target %q has an invalid issue/PR number", ref)
+	}
+	return owner, repo, number, nil
+}
+
+// postJSON POSTs a JSON body to the GitHub REST API using the stored
+// api_token as a Bearer credential. It returns a clear error when no token
+// is configured, and surfaces GitHub's own error message on non-2xx status.
+func (a *Adapter) postJSON(ctx context.Context, path string, payload any) error {
+	a.mu.Lock()
+	token := a.apiToken
+	base := a.apiBase
+	a.mu.Unlock()
+
+	if token == "" {
+		return fmt.Errorf("github: no API token configured — sign in to GitHub first")
+	}
+	if base == "" {
+		base = apiBaseURL
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("github: encode request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+path, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("github: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	res, err := a.httpc.Do(req)
+	if err != nil {
+		return fmt.Errorf("github: request %s: %w", path, err)
+	}
+	defer res.Body.Close() //nolint:errcheck // read-only body
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(res.Body, 1<<16))
+		return fmt.Errorf("github: %s returned %d: %s", path, res.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}

--- a/pkg/gateway/github/outbound_test.go
+++ b/pkg/gateway/github/outbound_test.go
@@ -1,0 +1,140 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// newTestAdapter builds an adapter wired to a fake GitHub API server.
+func newTestAdapter(t *testing.T, token string, handler http.HandlerFunc) *Adapter {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	a := NewNamed("github:test", "", token)
+	a.apiBase = srv.URL
+	return a
+}
+
+func TestCommentPostsToCorrectURLWithBearerToken(t *testing.T) {
+	var gotPath, gotAuth, gotBody string
+	a := newTestAdapter(t, "gh-token-123", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		var payload struct {
+			Body string `json:"body"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		gotBody = payload.Body
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":1}`))
+	})
+
+	if err := a.Comment(context.Background(), "rpuneet", "mycel", 42, "nice PR"); err != nil {
+		t.Fatalf("Comment() error = %v", err)
+	}
+	if gotPath != "/repos/rpuneet/mycel/issues/42/comments" {
+		t.Errorf("path = %q, want /repos/rpuneet/mycel/issues/42/comments", gotPath)
+	}
+	if gotAuth != "Bearer gh-token-123" {
+		t.Errorf("Authorization = %q, want Bearer gh-token-123", gotAuth)
+	}
+	if gotBody != "nice PR" {
+		t.Errorf("body = %q, want %q", gotBody, "nice PR")
+	}
+}
+
+func TestCommentMissingTokenReturnsSignInError(t *testing.T) {
+	a := NewNamed("github:test", "", "")
+	err := a.Comment(context.Background(), "rpuneet", "mycel", 1, "hi")
+	if err == nil {
+		t.Fatal("expected error for missing token")
+	}
+	if !strings.Contains(err.Error(), "sign in to GitHub first") {
+		t.Errorf("error = %q, want mention of signing in", err.Error())
+	}
+}
+
+func TestCommentAPIErrorSurfaced(t *testing.T) {
+	a := newTestAdapter(t, "tok", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration"}`))
+	})
+
+	err := a.Comment(context.Background(), "rpuneet", "mycel", 1, "hi")
+	if err == nil {
+		t.Fatal("expected error for 403 response")
+	}
+	if !strings.Contains(err.Error(), "403") || !strings.Contains(err.Error(), "Resource not accessible") {
+		t.Errorf("error = %q, want it to surface status + body", err.Error())
+	}
+}
+
+func TestCommentValidatesArguments(t *testing.T) {
+	a := NewNamed("github:test", "", "tok")
+	if err := a.Comment(context.Background(), "", "mycel", 1, "hi"); err == nil {
+		t.Error("expected error for missing owner")
+	}
+	if err := a.Comment(context.Background(), "rpuneet", "mycel", 0, "hi"); err == nil {
+		t.Error("expected error for non-positive number")
+	}
+	if err := a.Comment(context.Background(), "rpuneet", "mycel", 1, ""); err == nil {
+		t.Error("expected error for empty body")
+	}
+}
+
+func TestSetStatusPostsToCorrectURL(t *testing.T) {
+	var gotPath string
+	var gotPayload map[string]string
+	a := newTestAdapter(t, "tok", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&gotPayload)
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	err := a.SetStatus(context.Background(), "rpuneet", "mycel", "abc123", "success", "all good", "https://ci.example.com/1", "mycel-ci")
+	if err != nil {
+		t.Fatalf("SetStatus() error = %v", err)
+	}
+	if gotPath != "/repos/rpuneet/mycel/statuses/abc123" {
+		t.Errorf("path = %q, want /repos/rpuneet/mycel/statuses/abc123", gotPath)
+	}
+	if gotPayload["state"] != "success" || gotPayload["description"] != "all good" || gotPayload["context"] != "mycel-ci" {
+		t.Errorf("payload = %+v, missing expected fields", gotPayload)
+	}
+}
+
+func TestSetStatusRejectsInvalidState(t *testing.T) {
+	a := NewNamed("github:test", "", "tok")
+	if err := a.SetStatus(context.Background(), "rpuneet", "mycel", "sha", "bogus", "", "", ""); err == nil {
+		t.Error("expected error for invalid state")
+	}
+}
+
+func TestSendParsesIssueRefAndComments(t *testing.T) {
+	var gotPath string
+	a := newTestAdapter(t, "tok", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	if err := a.Send(context.Background(), "rpuneet/mycel#7", "agent", "hello from an agent"); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if gotPath != "/repos/rpuneet/mycel/issues/7/comments" {
+		t.Errorf("path = %q, want /repos/rpuneet/mycel/issues/7/comments", gotPath)
+	}
+}
+
+func TestSendRejectsMalformedTarget(t *testing.T) {
+	a := NewNamed("github:test", "", "tok")
+	for _, ref := range []string{"nofragment", "owner#1", "owner/repo#notanumber", "owner/repo#0"} {
+		if err := a.Send(context.Background(), ref, "agent", "hi"); err == nil {
+			t.Errorf("Send(%q) expected error, got nil", ref)
+		}
+	}
+}

--- a/pkg/gateway/github/plugin.go
+++ b/pkg/gateway/github/plugin.go
@@ -49,7 +49,7 @@ func (*plugin) Describe() app.Descriptor {
 }
 
 func (*plugin) Build(inst app.Instance, _ app.Env) (gateway.NotificationAdapter, error) {
-	return NewNamed(inst.Name, inst.OptionalSecret("secret")), nil
+	return NewNamed(inst.Name, inst.OptionalSecret("secret"), inst.OptionalSecret("api_token")), nil
 }
 
 // BeginAuth starts the GitHub device flow for this instance.

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -73,6 +74,8 @@ func (h *GatewayHandler) appScopedRoute(w http.ResponseWriter, r *http.Request, 
 		h.gatewayAPIProxy(w, r, platform, strings.TrimPrefix(rest, "api"))
 	case rest == "react":
 		h.gatewayReact(w, r, platform)
+	case rest == "status":
+		h.gatewayCommitStatus(w, r, platform)
 	default:
 		httpError(w, "not found", http.StatusNotFound)
 	}
@@ -656,4 +659,72 @@ func (h *GatewayHandler) gatewayReact(w http.ResponseWriter, r *http.Request, pl
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok", "channel": req.Channel})
+}
+
+// commitStatusSetter is checked at runtime for adapters that can set a
+// commit status/check (currently only the GitHub adapter). It doesn't fit
+// the generic channel-Send model — a status targets a repo+sha, not a
+// mycel channel — so it's a focused capability behind its own route
+// instead of being routed through gateway.Manager.
+type commitStatusSetter interface {
+	SetStatus(ctx context.Context, owner, repo, sha, state, description, targetURL, statusContext string) error
+}
+
+// gatewayCommitStatus handles POST /api/apps/{name}/status — sets a commit
+// status (e.g. GitHub's POST /repos/{owner}/{repo}/statuses/{sha}) via the
+// gateway adapter's outbound capability.
+//
+// Request body:
+//
+//	{
+//	  "owner":       "rpuneet",
+//	  "repo":        "mycel",
+//	  "sha":         "abc123",
+//	  "state":       "success",           // error | failure | pending | success
+//	  "description": "all checks passed", // optional
+//	  "target_url":  "https://...",       // optional
+//	  "context":     "mycel-ci"           // optional
+//	}
+func (h *GatewayHandler) gatewayCommitStatus(w http.ResponseWriter, r *http.Request, platform string) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if h.gw == nil {
+		serviceUnavailable(w, r, "gateway", "gateway manager not available")
+		return
+	}
+	adapter := h.gw.GetAdapter(platform)
+	if adapter == nil {
+		httpError(w, "adapter not found: "+platform, http.StatusNotFound)
+		return
+	}
+	setter, ok := adapter.(commitStatusSetter)
+	if !ok {
+		httpError(w, "adapter "+platform+" does not support commit statuses", http.StatusNotImplemented)
+		return
+	}
+
+	var req struct {
+		Owner       string `json:"owner"`
+		Repo        string `json:"repo"`
+		SHA         string `json:"sha"`
+		State       string `json:"state"`
+		Description string `json:"description"`
+		TargetURL   string `json:"target_url"`
+		Context     string `json:"context"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpError(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.Owner == "" || req.Repo == "" || req.SHA == "" || req.State == "" {
+		httpError(w, "owner, repo, sha, and state are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := setter.SetStatus(r.Context(), req.Owner, req.Repo, req.SHA, req.State, req.Description, req.TargetURL, req.Context); err != nil {
+		httpInternalError(w, "set commit status", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }

--- a/server/handlers/gateways_github_send_test.go
+++ b/server/handlers/gateways_github_send_test.go
@@ -1,0 +1,97 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	ghadapter "github.com/rpuneet/mycel/pkg/gateway/github"
+
+	"github.com/rpuneet/mycel/pkg/gateway"
+)
+
+// TestChannelSend_GitHubIssueRefFallback verifies the real GitHub adapter's
+// outbound comment posting through the generic gateway send path: since
+// GitHub has no pre-discovered "channel" (its Channels() are webhook event
+// types, not repos), Manager.Send's "<platform>:<id>" fallback routes
+// channel "github:owner/repo#123" straight to the adapter with id =
+// "owner/repo#123" — the same POST /api/channels/send and send_message MCP
+// tool other platforms use.
+func TestChannelSend_GitHubIssueRefFallback(t *testing.T) {
+	var gotPath, gotAuth string
+	fakeGitHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer fakeGitHub.Close()
+
+	adapter := ghadapter.NewNamed("github", "", "gh-token")
+	adapter.SetAPIBaseForTest(fakeGitHub.URL)
+
+	mgr := gateway.NewManager()
+	mgr.Register(adapter)
+
+	h := NewGatewayHandler(mgr, nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	body, _ := json.Marshal(map[string]string{ //nolint:errcheck
+		"channel": "github:rpuneet/mycel#123",
+		"message": "posted by an agent",
+		"sender":  "zen-zebra",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/channels/send", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	var resp map[string]bool
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp["sent"] {
+		t.Error("expected sent=true")
+	}
+	if gotPath != "/repos/rpuneet/mycel/issues/123/comments" {
+		t.Errorf("path = %q, want /repos/rpuneet/mycel/issues/123/comments", gotPath)
+	}
+	if gotAuth != "Bearer gh-token" {
+		t.Errorf("Authorization = %q, want Bearer gh-token", gotAuth)
+	}
+}
+
+// TestChannelSend_GitHubNoToken verifies the "sign in to GitHub first" error
+// surfaces through the HTTP layer when no api_token is configured.
+func TestChannelSend_GitHubNoToken(t *testing.T) {
+	adapter := ghadapter.NewNamed("github", "", "")
+
+	mgr := gateway.NewManager()
+	mgr.Register(adapter)
+
+	h := NewGatewayHandler(mgr, nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	body, _ := json.Marshal(map[string]string{ //nolint:errcheck
+		"channel": "github:rpuneet/mycel#123",
+		"message": "posted by an agent",
+		"sender":  "zen-zebra",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/channels/send", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502; body: %s", rr.Code, rr.Body.String())
+	}
+	if !bytes.Contains(rr.Body.Bytes(), []byte("sign in to GitHub first")) {
+		t.Errorf("body = %q, want it to mention signing in", rr.Body.String())
+	}
+}

--- a/server/handlers/gateways_status_test.go
+++ b/server/handlers/gateways_status_test.go
@@ -1,0 +1,151 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/gateway"
+)
+
+// statusStub wraps stubAdapter and records SetStatus calls, exercising the
+// commitStatusSetter capability (GitHub's outbound commit-status endpoint).
+//
+//nolint:govet // fieldalignment: test-only struct, compactness is not a concern
+type statusStub struct {
+	stubAdapter
+	calls []statusCall
+	err   error
+	mu    sync.Mutex
+}
+
+type statusCall struct {
+	Owner, Repo, SHA, State, Description, TargetURL, Context string
+}
+
+func (s *statusStub) SetStatus(_ context.Context, owner, repo, sha, state, description, targetURL, statusContext string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, statusCall{owner, repo, sha, state, description, targetURL, statusContext})
+	return s.err
+}
+
+// statusMux registers the apps + gateway routes for /api/apps/{name}/status.
+func statusMux(mgr *gateway.Manager) *http.ServeMux {
+	h := NewGatewayHandler(mgr, nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+	NewAppsHandler(h, mgr, nil, nil).Register(mux)
+	return mux
+}
+
+func buildStatusRequest(t *testing.T, platform string, body map[string]any) *http.Request {
+	t.Helper()
+	b, _ := json.Marshal(body) //nolint:errcheck
+	req := httptest.NewRequest(http.MethodPost, "/api/apps/"+platform+"/status", bytes.NewReader(b))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+func TestGatewayCommitStatus_OK(t *testing.T) {
+	stub := &statusStub{stubAdapter: stubAdapter{name: "github"}}
+	mgr := gateway.NewManager()
+	mgr.Register(stub)
+
+	mux := statusMux(mgr)
+	req := buildStatusRequest(t, "github", map[string]any{
+		"owner":       "rpuneet",
+		"repo":        "mycel",
+		"sha":         "abc123",
+		"state":       "success",
+		"description": "all checks passed",
+		"target_url":  "https://ci.example.com/1",
+		"context":     "mycel-ci",
+	})
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rr.Code, rr.Body.String())
+	}
+	if len(stub.calls) != 1 {
+		t.Fatalf("expected 1 SetStatus call, got %d", len(stub.calls))
+	}
+	got := stub.calls[0]
+	want := statusCall{"rpuneet", "mycel", "abc123", "success", "all checks passed", "https://ci.example.com/1", "mycel-ci"}
+	if got != want {
+		t.Errorf("call = %+v, want %+v", got, want)
+	}
+}
+
+func TestGatewayCommitStatus_MissingFields(t *testing.T) {
+	mgr := gateway.NewManager()
+	mgr.Register(&statusStub{stubAdapter: stubAdapter{name: "github"}})
+	mux := statusMux(mgr)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, buildStatusRequest(t, "github", map[string]any{"owner": "rpuneet", "repo": "mycel"}))
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGatewayCommitStatus_UnknownAdapter(t *testing.T) {
+	mgr := gateway.NewManager()
+	mux := statusMux(mgr)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, buildStatusRequest(t, "github", map[string]any{
+		"owner": "rpuneet", "repo": "mycel", "sha": "abc123", "state": "success",
+	}))
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGatewayCommitStatus_UnsupportedAdapter(t *testing.T) {
+	mgr := gateway.NewManager()
+	mgr.Register(&stubAdapter{name: "telegram"})
+	mux := statusMux(mgr)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, buildStatusRequest(t, "telegram", map[string]any{
+		"owner": "rpuneet", "repo": "mycel", "sha": "abc123", "state": "success",
+	}))
+	if rr.Code != http.StatusNotImplemented {
+		t.Errorf("status = %d, want 501; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGatewayCommitStatus_AdapterError(t *testing.T) {
+	stub := &statusStub{stubAdapter: stubAdapter{name: "github"}, err: fmt.Errorf("github: 403 forbidden")}
+	mgr := gateway.NewManager()
+	mgr.Register(stub)
+	mux := statusMux(mgr)
+
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, buildStatusRequest(t, "github", map[string]any{
+		"owner": "rpuneet", "repo": "mycel", "sha": "abc123", "state": "success",
+	}))
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500; body: %s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestGatewayCommitStatus_MethodNotAllowed(t *testing.T) {
+	mgr := gateway.NewManager()
+	mgr.Register(&statusStub{stubAdapter: stubAdapter{name: "github"}})
+	mux := statusMux(mgr)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/apps/github/status", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET /status: status = %d, want 405", rr.Code)
+	}
+}


### PR DESCRIPTION
Part of #3423

## What
The GitHub app's device-flow OAuth already mints an `api_token` (scope `repo`), but nothing ever used it outbound — the adapter (`pkg/gateway/github/`) was inbound-webhook-only. This wires the token up for real:

- `Adapter.Comment(ctx, owner, repo, number, body)` → `POST /repos/{owner}/{repo}/issues/{number}/comments` (works for both issues and PRs — GitHub treats PRs as issues for comments)
- `Adapter.SetStatus(ctx, owner, repo, sha, state, description, targetURL, context)` → `POST /repos/{owner}/{repo}/statuses/{sha}`
- `plugin.go`'s `Build()` now threads `inst.OptionalSecret("api_token")` into the adapter (previously only the webhook `secret` was passed through — the OAuth token was minted and stored but never read back out).

## Surface chosen — and why
Two different surfaces, because the two actions have fundamentally different addressing:

1. **Comments → the existing generic channel-send mechanism.** The adapter implements the `messageSender` capability (`Send(ctx, channelID, sender, content)`) that Slack/Telegram/WhatsApp already implement, dispatched by `gateway.Manager.Send`. GitHub has no native "channel" (its `Channels()` are webhook event types like `pull_request`, `issues`, not per-repo), so this reuses `Manager.Send`'s existing `"<platform>:<id>"` fallback route: the channel id doubles as an issue/PR reference, `"owner/repo#123"`. That means an agent posts a PR comment exactly the way it'd message any other channel:
   - `POST /api/apps/channels/send` (or the legacy `/api/channels/send`) with `{"channel": "github:rpuneet/mycel#123", "message": "...", "sender": "agent-name"}`
   - the `send_message` MCP tool, channel `"github:owner/repo#123"`

2. **Commit status → its own focused route**, since a status targets a repo+sha, not a channel, and doesn't fit `Manager.Send` at all. Added `commitStatusSetter` capability interface (mirrors the existing `reactionSender`/`SendReaction` pattern) and a new handler `gatewayCommitStatus` wired at `POST /api/apps/{name}/status`:
   ```json
   {"owner": "rpuneet", "repo": "mycel", "sha": "abc123", "state": "success", "description": "...", "target_url": "...", "context": "mycel-ci"}
   ```

## Errors
- No `api_token` configured → `"github: no API token configured — sign in to GitHub first"` (surfaced through the handler as-is).
- GitHub API 4xx/5xx → surfaced with status code + response body.

## Files
- `pkg/gateway/github/github.go` — `Adapter` gains `apiToken`/`httpc`/`apiBase`; `NewNamed` takes a third `apiToken` arg; `New` unchanged externally.
- `pkg/gateway/github/outbound.go` — new: `Comment`, `SetStatus`, `Send` (messageSender), `parseIssueRef`, `postJSON`.
- `pkg/gateway/github/plugin.go` — `Build()` now passes `api_token` through.
- `server/handlers/gateways.go` — new `commitStatusSetter` interface + `gatewayCommitStatus` handler, wired into `appScopedRoute`'s `status` case.
- Tests: `pkg/gateway/github/outbound_test.go` (httptest fake GitHub API — correct URL, Bearer token, body; missing-token error; 4xx surfaced; malformed `owner/repo#number` refs rejected), `server/handlers/gateways_status_test.go`, `server/handlers/gateways_github_send_test.go` (end-to-end through the real HTTP mux + real adapter, not just stubs).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./pkg/... ./server/...` (0 issues)
- [x] `go test -race ./pkg/gateway/... ./server/...` (all pass)

Not merging — flagging for review per the branch's isolation instructions.