### PR TITLE
docs(cli): regenerate reference for 'mycel app' command group

### DIFF
--- a/docs/reference/cli/mycel.md
+++ b/docs/reference/cli/mycel.md
@@ -63,6 +63,7 @@ mycel [flags]
 ### SEE ALSO
 
 * [mycel agent](mycel_agent.md)	 - Manage mycel agents
+* [mycel app](mycel_app.md)	 - Manage app (gateway plugin) integrations
 * [mycel channel](mycel_channel.md)	 - Manage communication channels
 * [mycel completion](mycel_completion.md)	 - Generate shell completion scripts
 * [mycel config](mycel_config.md)	 - Manage repo configuration


### PR DESCRIPTION
#3444 added the `mycel app` top-level command group but did not regenerate the CLI reference (`docs/reference/cli/mycel.md`), turning **main red** on the docs-freshness gate. This regenerates it via `go run ./cmd/gendocs` — a one-line SEE-ALSO addition, no code change.

Part of #3423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `mycel app` to the CLI reference’s related commands for managing app gateway integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->