### PR TITLE
docs(cli): commit generated reference for 'mycel app' subcommands

### DIFF
--- a/docs/reference/cli/mycel_app.md
+++ b/docs/reference/cli/mycel_app.md
@@ -1,0 +1,30 @@
+## mycel app
+
+Manage app (gateway plugin) integrations
+
+### Synopsis
+
+Manage app plugins — the integrations that bridge mycel to external
+platforms (Slack, GitHub, webhooks, ...).
+
+Examples:
+  mycel app scaffold linear      # Generate a new app plugin skeleton
+
+### Options
+
+```
+  -h, --help   help for app
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [mycel](mycel.md)	 - A simpler, more controllable agent orchestrator
+* [mycel app scaffold](mycel_app_scaffold.md)	 - Generate a new app/gateway plugin skeleton
+

--- a/docs/reference/cli/mycel_app_scaffold.md
+++ b/docs/reference/cli/mycel_app_scaffold.md
@@ -1,0 +1,41 @@
+## mycel app scaffold
+
+Generate a new app/gateway plugin skeleton
+
+### Synopsis
+
+Generate a new app plugin skeleton under pkg/gateway/<name>/.
+
+Adding an app today = one new plugin package under pkg/gateway/<name>/
+plus one import line in pkg/app/builtin/builtin.go. This command
+generates the plugin package (a plugin.go implementing app.Plugin and
+a <name>.go adapter implementing gateway.NotificationAdapter) so
+contributors can fill in the TODOs and wire it up.
+
+Examples:
+  mycel app scaffold linear             # pkg/gateway/linear/
+  mycel app scaffold telegram --multi   # allow labeled instances
+
+```
+mycel app scaffold <name> [flags]
+```
+
+### Options
+
+```
+      --dir string   parent directory to generate the plugin package under (default "pkg/gateway")
+  -h, --help         help for scaffold
+      --multi        allow labeled instances (e.g. telegram:alerts)
+```
+
+### Options inherited from parent commands
+
+```
+      --json      Output in JSON format
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [mycel app](mycel_app.md)	 - Manage app (gateway plugin) integrations
+


### PR DESCRIPTION
**Restores green main.** #3444 added the `mycel app` command group but never committed the generated per-command docs (`mycel_app.md`, `mycel_app_scaffold.md`). The docs-freshness gate wipes `mycel*.md` and regenerates, then fails on the untracked files. #3446 only fixed the parent `mycel.md` SEE-ALSO line and missed these two — so main was still red. This commits them; `go run ./cmd/gendocs` is now a no-op.

Part of #3423

🤖 Generated with [Claude Code](https://claude.com/claude-code)