### PR TITLE
fix(desktop): open external links via daemon open-url endpoint (GitHub/Gmail sign-in)

### DIFF
--- a/desktop/bootpage.go
+++ b/desktop/bootpage.go
@@ -64,13 +64,16 @@ const bootPage = `<!doctype html>
 
   function handoff() {
     msg.textContent = "opening…";
-    // Preferred: navigate the webview straight to the localhost URL.
-    window.location.replace(TARGET + "/");
+    // Preferred: navigate the webview straight to the localhost URL. The
+    // ?desktop=1 marker tells the SPA it is running inside the Wails webview
+    // (served from the daemon's http:// origin, where window.runtime is never
+    // injected) so it routes external links through /api/system/open-url.
+    window.location.replace(TARGET + "/?desktop=1");
     // Fallback: if the webview refused the cross-scheme navigation,
     // we are still here after 2s — embed the UI in a full-window iframe.
     setTimeout(function () {
       var f = document.createElement("iframe");
-      f.src = TARGET + "/";
+      f.src = TARGET + "/?desktop=1";
       document.body.appendChild(f);
       document.getElementById("boot").remove();
     }, 2000);

--- a/server/handlers/openurl.go
+++ b/server/handlers/openurl.go
@@ -46,7 +46,7 @@ func realOpenURL(ctx context.Context, rawURL string) error {
 	default:
 		name, args = "xdg-open", []string{rawURL}
 	}
-	// The launch must OUTLIVE the HTTP request: r.Context() is cancelled the
+	// The launch must OUTLIVE the HTTP request: r.Context() is canceled the
 	// instant the handler returns 204, which would kill the opener before it
 	// hands the URL to the browser. Sever cancellation (keep any values) and
 	// give the child a bounded lifetime of its own.

--- a/server/handlers/openurl.go
+++ b/server/handlers/openurl.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os/exec"
 	"runtime"
+	"time"
 )
 
 // OpenURLHandler exposes POST /api/system/open-url, the one reliable way for
@@ -45,9 +46,25 @@ func realOpenURL(ctx context.Context, rawURL string) error {
 	default:
 		name, args = "xdg-open", []string{rawURL}
 	}
+	// The launch must OUTLIVE the HTTP request: r.Context() is cancelled the
+	// instant the handler returns 204, which would kill the opener before it
+	// hands the URL to the browser. Sever cancellation (keep any values) and
+	// give the child a bounded lifetime of its own.
+	launchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
 	// #nosec G204 -- name is a fixed constant; rawURL is validated http/https
 	// and passed as a single argv element, so no shell interprets it.
-	return exec.CommandContext(ctx, name, args...).Start()
+	cmd := exec.CommandContext(launchCtx, name, args...)
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return err
+	}
+	// Reap the child so it doesn't linger as a zombie; cancel frees the
+	// timeout context once the opener exits (it does so near-instantly).
+	go func() {
+		_ = cmd.Wait()
+		cancel()
+	}()
+	return nil
 }
 
 // openURLFunc is the injectable opener so tests can stub the OS call.

--- a/server/handlers/openurl.go
+++ b/server/handlers/openurl.go
@@ -1,0 +1,84 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"runtime"
+)
+
+// OpenURLHandler exposes POST /api/system/open-url, the one reliable way for
+// the desktop app to hand an external link to the OS browser.
+//
+// Why this exists: the Wails webview boots a tiny page that navigates to the
+// in-process daemon's http://127.0.0.1 origin. Wails only injects
+// window.runtime (and BrowserOpenURL) into pages served through its own asset
+// scheme — never into an external http:// origin — so the frontend helper's
+// window.open / <a target="_blank"> fallbacks are no-ops inside the macOS
+// WKWebView. This endpoint lets the web UI ask the daemon to open the link
+// with the host's default browser instead.
+//
+// Security model: loopback-only (the daemon binds loopback by default) and
+// http/https only — the URL is exec'd as a single argv element to a fixed
+// platform opener, never through a shell.
+type OpenURLHandler struct{}
+
+// NewOpenURLHandler constructs an OpenURLHandler.
+func NewOpenURLHandler() *OpenURLHandler { return &OpenURLHandler{} }
+
+// Register mounts POST /api/system/open-url.
+func (h *OpenURLHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/system/open-url", h.open)
+}
+
+// realOpenURL opens url with the platform's default browser. The URL is passed
+// as a single argument to a fixed opener binary — never interpreted by a shell.
+func realOpenURL(ctx context.Context, rawURL string) error {
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		name, args = "open", []string{rawURL}
+	case "windows":
+		name, args = "rundll32", []string{"url.dll,FileProtocolHandler", rawURL}
+	default:
+		name, args = "xdg-open", []string{rawURL}
+	}
+	// #nosec G204 -- name is a fixed constant; rawURL is validated http/https
+	// and passed as a single argv element, so no shell interprets it.
+	return exec.CommandContext(ctx, name, args...).Start()
+}
+
+// openURLFunc is the injectable opener so tests can stub the OS call.
+var openURLFunc = realOpenURL
+
+// open handles POST /api/system/open-url. Body: {"url":"https://…"}.
+func (h *OpenURLHandler) open(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	var req struct {
+		URL string `json:"url"`
+	}
+	if err := decodeJSONBody(r, &req); err != nil {
+		httpError(w, "invalid JSON: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	u, err := url.Parse(req.URL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		httpError(w, "invalid url: only http and https URLs are allowed", http.StatusBadRequest)
+		return
+	}
+
+	if err := openURLFunc(r.Context(), u.String()); err != nil {
+		httpError(w, "failed to open url", http.StatusBadGateway)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/server/handlers/openurl_test.go
+++ b/server/handlers/openurl_test.go
@@ -1,0 +1,94 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func openURLMux() http.Handler {
+	mux := http.NewServeMux()
+	NewOpenURLHandler().Register(mux)
+	return mux
+}
+
+// TestOpenURLValidHTTP asserts a valid http(s) URL returns 204 and invokes the
+// stubbed opener with the exact URL.
+func TestOpenURLValidHTTP(t *testing.T) {
+	orig := openURLFunc
+	t.Cleanup(func() { openURLFunc = orig })
+
+	var got string
+	openURLFunc = func(_ context.Context, u string) error {
+		got = u
+		return nil
+	}
+
+	const want = "https://github.com/login/device"
+	rec := httptest.NewRecorder()
+	openURLMux().ServeHTTP(rec, loopbackPost("/api/system/open-url", `{"url":"`+want+`"}`))
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusNoContent, rec.Body.String())
+	}
+	if got != want {
+		t.Fatalf("opener got %q, want %q", got, want)
+	}
+}
+
+// TestOpenURLRejectsNonHTTPScheme asserts a non-http(s) URL is rejected with
+// 400 before the opener runs.
+func TestOpenURLRejectsNonHTTPScheme(t *testing.T) {
+	orig := openURLFunc
+	t.Cleanup(func() { openURLFunc = orig })
+
+	ran := false
+	openURLFunc = func(_ context.Context, _ string) error {
+		ran = true
+		return nil
+	}
+
+	for _, bad := range []string{
+		`{"url":"file:///etc/passwd"}`,
+		`{"url":"javascript:alert(1)"}`,
+		`{"url":"ftp://example.com"}`,
+		`{"url":"not a url"}`,
+		`{"url":""}`,
+	} {
+		rec := httptest.NewRecorder()
+		openURLMux().ServeHTTP(rec, loopbackPost("/api/system/open-url", bad))
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("body %s: status = %d, want %d", bad, rec.Code, http.StatusBadRequest)
+		}
+	}
+	if ran {
+		t.Fatal("opener ran for a rejected URL")
+	}
+}
+
+// TestOpenURLRejectsNonLoopback asserts a non-loopback remote address is
+// rejected with 403 before the opener runs.
+func TestOpenURLRejectsNonLoopback(t *testing.T) {
+	orig := openURLFunc
+	t.Cleanup(func() { openURLFunc = orig })
+
+	ran := false
+	openURLFunc = func(_ context.Context, _ string) error {
+		ran = true
+		return nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/system/open-url", nil)
+	req.RemoteAddr = "203.0.113.7:44321"
+
+	rec := httptest.NewRecorder()
+	openURLMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	if ran {
+		t.Fatal("opener ran for a non-loopback caller")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -391,6 +391,11 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	// strict input validation, argv-slice exec (no shell), timeouts, result
 	// caps, and a loopback gate. Install streams NDJSON like the deps installer.
 	handlers.NewPackageSearchHandler().Register(mux)
+	// Hand an external link to the host's default browser. The desktop app's
+	// webview lives on the daemon's http:// origin, where Wails never injects
+	// BrowserOpenURL, so window.open is a no-op; the UI posts the URL here
+	// instead. Loopback-only, http/https-only, exec'd as a single argv (no shell).
+	handlers.NewOpenURLHandler().Register(mux)
 	// Per-repo cost rollup. Handler is nil-safe and returns 503 when the
 	// global ledger isn't wired.
 	mux.Handle("/api/global/costs", handlers.NewGlobalCostsHandler(svc.Costs))

--- a/web/src/components/ExternalLink.tsx
+++ b/web/src/components/ExternalLink.tsx
@@ -1,0 +1,35 @@
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from "react";
+import { openExternal } from "../utils/openExternal";
+
+type ExternalLinkProps = {
+  href: string;
+  children: ReactNode;
+} & Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href" | "target" | "rel">;
+
+/**
+ * ExternalLink renders an `<a>` that always hands the URL to {@link openExternal}
+ * instead of relying on `target="_blank"`. A plain `target="_blank"` is a no-op
+ * inside the desktop webview (Wails never injects `window.runtime` on the
+ * daemon's http:// origin), so every external link must go through openExternal.
+ *
+ * The `href` is kept for right-click "copy link", middle-click, and screen
+ * readers on the web build; the click is intercepted so the same code path runs
+ * on both web (new tab) and desktop (daemon open-url).
+ */
+export function ExternalLink({ href, children, onClick, ...rest }: ExternalLinkProps) {
+  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+    // Let modified clicks (open-in-new-tab, etc.) behave natively on web.
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) {
+      onClick?.(e);
+      return;
+    }
+    e.preventDefault();
+    openExternal(href);
+    onClick?.(e);
+  };
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" onClick={handleClick} {...rest}>
+      {children}
+    </a>
+  );
+}

--- a/web/src/components/MessageContent.tsx
+++ b/web/src/components/MessageContent.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { ExternalLink } from "./ExternalLink";
 
 /**
  * Renders message content with basic markdown-like formatting:
@@ -78,11 +79,9 @@ function parseContent(text: string, agentNames?: Set<string>): ReactNode[] {
       const fileId = full.slice(6, -1); // strip [file: and ]
       const fileUrl = `/api/files/${encodeURIComponent(fileId)}`;
       nodes.push(
-        <a
+        <ExternalLink
           key={key}
-          href={fileUrl}
-          target="_blank"
-          rel="noopener noreferrer"
+          href={`${location.origin}${fileUrl}`}
           className="inline-block my-1"
         >
           <img
@@ -100,28 +99,26 @@ function parseContent(text: string, agentNames?: Set<string>): ReactNode[] {
               }
             }}
           />
-        </a>,
+        </ExternalLink>,
       );
     } else if (match[2]) {
       // URL — render images inline
       const url = full;
       if (IMAGE_EXT.test(url)) {
         nodes.push(
-          <a key={key} href={url} target="_blank" rel="noopener noreferrer" className="inline-block my-1">
+          <ExternalLink key={key} href={url} className="inline-block my-1">
             <img src={url} alt="" className="max-w-sm max-h-64 rounded-md border border-mycel-border" loading="lazy" />
-          </a>,
+          </ExternalLink>,
         );
       } else {
         nodes.push(
-          <a
+          <ExternalLink
             key={key}
             href={url}
-            target="_blank"
-            rel="noopener noreferrer"
             className="text-mycel-accent underline-offset-2 hover:underline"
           >
             {url}
-          </a>,
+          </ExternalLink>,
         );
       }
     } else if (match[3]) {

--- a/web/src/components/apps/ConnectApp.tsx
+++ b/web/src/components/apps/ConnectApp.tsx
@@ -25,6 +25,7 @@ import type { Agent, AppAuthSession, AppDescriptor, AppInstance } from "../../ap
 import { AppIcon, presentationFor } from "./PlatformIcons";
 import { StatusDot } from "./appStatus";
 import { openExternal } from "../../utils/openExternal";
+import { ExternalLink } from "../ExternalLink";
 
 /* ── Presentation-only metadata (backend owns the rest) ──────────────
    App icon/color/category/description metadata lives in PlatformIcons.tsx
@@ -570,9 +571,9 @@ function linkifyDoc(text: string): React.ReactNode {
   if (parts.length === 1) return text;
   return parts.map((part, i) =>
     /^https?:\/\//.test(part) ? (
-      <a key={i} href={part} target="_blank" rel="noopener noreferrer" style={{ color: "var(--mycel-accent)", textDecoration: "underline" }}>
+      <ExternalLink key={i} href={part} style={{ color: "var(--mycel-accent)", textDecoration: "underline" }}>
         {part.replace(/^https?:\/\//, "")}
-      </a>
+      </ExternalLink>
     ) : (
       <span key={i}>{part}</span>
     ),

--- a/web/src/components/apps/GatewayFeed.tsx
+++ b/web/src/components/apps/GatewayFeed.tsx
@@ -10,6 +10,7 @@ import type {
 } from "../../api/client";
 import { useWebSocket } from "../../hooks/useWebSocket";
 import { MessageContent } from "../MessageContent";
+import { ExternalLink } from "../ExternalLink";
 import { useHeaderSlot } from "../../context/HeaderSlotContext";
 import {
   gatewayPlatform,
@@ -340,15 +341,13 @@ function GitHubCardView({ card }: { card: GitHubCard }) {
       <div style={{ padding: "2px 12px 10px" }}>
         <div style={{ fontSize: 13, fontWeight: 500, color: "var(--mycel-text)", lineHeight: 1.4 }}>
           {card.url ? (
-            <a
+            <ExternalLink
               href={card.url}
-              target="_blank"
-              rel="noopener noreferrer"
               className="hover:underline"
               style={{ color: "var(--mycel-text)", textDecoration: "none" }}
             >
               {card.title}
-            </a>
+            </ExternalLink>
           ) : (
             card.title
           )}
@@ -395,7 +394,7 @@ function RSSCardView({ card }: { card: RSSCard }) {
       </div>
       <div style={{ padding: "4px 12px 10px" }}>
         <div style={{ fontSize: 13, fontWeight: 500, color: "var(--mycel-text)", lineHeight: 1.4 }}>
-          {card.link ? (<a href={card.link} target="_blank" rel="noopener noreferrer" className="hover:underline" style={{ color: "var(--mycel-text)", textDecoration: "none" }}>{card.title}</a>) : card.title}
+          {card.link ? (<ExternalLink href={card.link} className="hover:underline" style={{ color: "var(--mycel-text)", textDecoration: "none" }}>{card.title}</ExternalLink>) : card.title}
         </div>
         {card.description && <div style={{ fontSize: 12, color: "var(--mycel-text-2)", marginTop: 4, lineHeight: 1.4, maxHeight: 60, overflow: "hidden" }}>{card.description.slice(0, 200)}</div>}
       </div>

--- a/web/src/utils/openExternal.ts
+++ b/web/src/utils/openExternal.ts
@@ -2,21 +2,53 @@
  * openExternal — open a URL in the user's system browser from either the
  * embedded web UI or the Wails desktop app.
  *
- * In the desktop app, `window.open` / `<a target="_blank">` do NOT open
- * the system browser — Wails intercepts navigation inside its webview, so
- * the click silently does nothing (this was the "sign-in link doesn't
- * work" bug). The Wails runtime injects `window.runtime.BrowserOpenURL`
- * into the page at startup; when present, it is the only reliable way to
- * hand a URL to the OS browser. The web build never has `window.runtime`,
- * so it falls back to a plain new-tab open there.
+ * In the desktop app, `window.open` / `<a target="_blank">` do NOT open the
+ * system browser: the Wails webview boots on the daemon's http://127.0.0.1
+ * origin, and Wails only injects `window.runtime` (and `BrowserOpenURL`) into
+ * pages served through its own asset scheme — never into an external http://
+ * origin. So the click silently does nothing (this was the "sign-in link
+ * doesn't work" bug). To detect the desktop shell the boot page appends a
+ * `?desktop=1` marker to the URL it hands the SPA; when present we ask the
+ * daemon to open the link via `POST /api/system/open-url`. The web build has
+ * no marker and no `window.runtime`, so it falls back to a plain new-tab open.
  */
+
+/**
+ * isDesktop reports whether the UI is running inside the Wails desktop shell.
+ * The boot page navigates to `…/?desktop=1`; SPA navigation then drops the
+ * query string, so the first sighting is persisted to localStorage.
+ */
+export function isDesktop(): boolean {
+  try {
+    if (new URLSearchParams(location.search).has("desktop")) {
+      localStorage.setItem("mycel.desktop", "1");
+      return true;
+    }
+    return localStorage.getItem("mycel.desktop") === "1";
+  } catch {
+    return false;
+  }
+}
+
 export function openExternal(url: string): void {
   if (!url) return;
+
+  // If Wails ever does inject its runtime (asset-scheme pages), prefer it.
   const wailsOpen = window.runtime?.BrowserOpenURL;
   if (typeof wailsOpen === "function") {
     wailsOpen(url);
     return;
   }
+
+  if (isDesktop()) {
+    fetch("/api/system/open-url", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ url }),
+    }).catch(() => window.open(url, "_blank", "noopener,noreferrer"));
+    return;
+  }
+
   window.open(url, "_blank", "noopener,noreferrer");
 }
 

--- a/web/src/utils/openExternal.ts
+++ b/web/src/utils/openExternal.ts
@@ -41,11 +41,18 @@ export function openExternal(url: string): void {
   }
 
   if (isDesktop()) {
+    const fallback = () => window.open(url, "_blank", "noopener,noreferrer");
     fetch("/api/system/open-url", {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ url }),
-    }).catch(() => window.open(url, "_blank", "noopener,noreferrer"));
+    })
+      // fetch only rejects on network failure — a 400/403/502 from the daemon
+      // still resolves, so check res.ok explicitly or the failure is silent.
+      .then((res) => {
+        if (!res.ok) fallback();
+      })
+      .catch(fallback);
     return;
   }
 

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+import { ExternalLink } from "../components/ExternalLink";
 
 /* ── Types ──────────────────────────────────────────────────────────── */
 
@@ -293,9 +294,9 @@ function ChannelTile({ channel }: { channel: ChannelStatus }) {
   );
   if (channel.href) {
     return (
-      <a href={channel.href} target="_blank" rel="noreferrer" className="block focus:outline-none focus:ring-1 focus:ring-mycel-accent">
+      <ExternalLink href={channel.href} className="block focus:outline-none focus:ring-1 focus:ring-mycel-accent">
         {body}
-      </a>
+      </ExternalLink>
     );
   }
   return body;

--- a/web/src/views/Marketplace.tsx
+++ b/web/src/views/Marketplace.tsx
@@ -9,6 +9,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
+import { ExternalLink } from "../components/ExternalLink";
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -488,15 +489,13 @@ function ItemCard({ item }: { item: MarketplaceItem }) {
             <StarCount stars={item.stars} />
           )}
           {item.url && (
-            <a
+            <ExternalLink
               href={item.url}
-              target="_blank"
-              rel="noopener noreferrer"
               className="text-xs text-mycel-muted hover:text-mycel-accent transition-colors truncate"
               onClick={(e) => e.stopPropagation()}
             >
               {item.url.replace(/^https?:\/\//, "")}
-            </a>
+            </ExternalLink>
           )}
         </div>
       )}


### PR DESCRIPTION
## The bug
In the **desktop app** every external link is dead: the GitHub device-flow "open browser", the Gmail OAuth auto-open, and manual-setup doc links all silently do nothing.

## Root cause
The Wails webview boots a tiny page (`desktop/bootpage.go`) that navigates the window to the in-process daemon at `http://127.0.0.1:9374`. **Wails only injects `window.runtime` (and `BrowserOpenURL`) into pages served through its own asset scheme — never into an external `http://` origin.** So `openExternal` finds `window.runtime?.BrowserOpenURL === undefined` and falls through to `window.open(...)`, which is a no-op inside the macOS WKWebView. PR #3435's helper was effectively dead code on desktop.

## The fix
- **Backend** — new `POST /api/system/open-url` (`server/handlers/openurl.go`): loopback-only, accepts only `http`/`https` URLs (parsed with `net/url`), and execs the platform browser opener (`open` / `xdg-open` / `rundll32 url.dll,FileProtocolHandler`) with the URL as a single argv element — never a shell string. The opener is an injectable package var (`openURLFunc`) for testing. Returns `204` success / `400` bad url / `403` non-loopback / `502` opener error. Registered next to the other `/api/system/...` routes.
- **Desktop detection** — `desktop/bootpage.go` now hands the SPA `http://127.0.0.1:9374/?desktop=1`. `openExternal.ts` gains `isDesktop()` (reads the `?desktop=1` marker, persisting it to `localStorage` since SPA nav drops the query string) and routes links through the endpoint on desktop, falling back to `window.open` on web.
- **Link sweep** — raw `target="_blank"` anchors bypass `openExternal` and were also dead on desktop. Routed them through a shared `ExternalLink` component (keeps `href` for right-click / accessibility, intercepts the click):
  - `web/src/components/apps/ConnectApp.tsx` (linkifyDoc)
  - `web/src/components/MessageContent.tsx` (URLs + file attachments)
  - `web/src/components/apps/GatewayFeed.tsx` (GitHub + RSS cards)
  - `web/src/views/About.tsx` (community channels)
  - `web/src/views/Marketplace.tsx` (item URLs)

Out of scope: the Gmail 403 (Google console config).

## Verification
- `go build ./...` — OK
- `go vet ./server/...` — OK
- `go test ./server/...` — OK (new `TestOpenURL*`: valid http → 204 + opener invoked; non-http scheme → 400; non-loopback → 403)
- `golangci-lint run ./server/handlers/...` — 0 issues
- `make build-local-web` (typecheck + build) — OK
- `cd web && bun run lint` — clean

Part of #3423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External links now open through the desktop application’s default browser.
  * Web users continue opening links in a new browser tab.
  * Added consistent external-link behavior across messages, attachments, feeds, marketplace items, and informational pages.
  * Desktop navigation now reliably identifies the application context when loading the server directly or through a fallback.

* **Bug Fixes**
  * External link handling preserves expected behavior for modified clicks, keyboard navigation, and accessibility.
  * Only valid HTTP and HTTPS links can be opened through the desktop application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->