### PR TITLE
fix(providers,tools): real install/update, correct versions, CLI-tool detection

### DIFF
--- a/pkg/db/storage_integration_test.go
+++ b/pkg/db/storage_integration_test.go
@@ -545,9 +545,9 @@ func TestStorageToolSmoke(t *testing.T) {
 	if got == nil || got.Name != "smoke-tool" {
 		t.Fatalf("expected 'smoke-tool', got %v", got)
 	}
-	// The internal add() method does not persist Type, so it defaults to "provider".
-	if got.Type != tool.ToolTypeProvider {
-		t.Errorf("Type = %q, want %q", got.Type, tool.ToolTypeProvider)
+	// add() now persists Type (previously omitted → wrongly defaulted to "provider").
+	if got.Type != tool.ToolTypeCLI {
+		t.Errorf("Type = %q, want %q", got.Type, tool.ToolTypeCLI)
 	}
 
 	// Update

--- a/pkg/provider/claude.go
+++ b/pkg/provider/claude.go
@@ -72,7 +72,7 @@ func (p *ClaudeProvider) Binary() string {
 
 // InstallHint returns a human-readable install instruction.
 func (p *ClaudeProvider) InstallHint() string {
-	return "npx -y @anthropic-ai/claude-code"
+	return "npm install -g @anthropic-ai/claude-code"
 }
 
 // BuildCommand returns the full command for a given runtime context.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -163,7 +163,22 @@ func checkBinaryExists(_ context.Context, name string) bool {
 	return err == nil
 }
 
-// getBinaryVersion runs a command and returns the first line of output.
+// semverRe extracts the first semantic-version token (e.g. "2.1.205") from a
+// version line such as "2.1.205 (Claude Code)" or "codex-cli 0.111.0".
+var semverRe = regexp.MustCompile(`(\d+\.\d+\.\d+)`)
+
+// extractSemver returns the first semver token found in line, or the trimmed
+// line unchanged if none is present (so unusual formats never regress to "").
+func extractSemver(line string) string {
+	line = strings.TrimSpace(line)
+	if m := semverRe.FindString(line); m != "" {
+		return m
+	}
+	return line
+}
+
+// getBinaryVersion runs a command and returns the semver extracted from the
+// first line of output. Falls back to the raw first line if no semver matches.
 func getBinaryVersion(ctx context.Context, name string, args ...string) string {
 	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // args are trusted provider names
 	output, err := cmd.Output()
@@ -172,7 +187,7 @@ func getBinaryVersion(ctx context.Context, name string, args ...string) string {
 	}
 	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
 	if len(lines) > 0 {
-		return lines[0]
+		return extractSemver(lines[0])
 	}
 	return ""
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -273,7 +273,7 @@ func TestProviderBinaryAndInstallHint(t *testing.T) {
 		binary      string
 		installHint string
 	}{
-		{"claude", NewClaudeProvider(), "claude", "npx -y @anthropic-ai/claude-code"},
+		{"claude", NewClaudeProvider(), "claude", "npm install -g @anthropic-ai/claude-code"},
 		{"agy", NewAgyProvider(), "agy", "curl -fsSL https://antigravity.google/install.sh | sh"},
 		{"cursor", NewCursorProvider(), "cursor-agent", "https://cursor.sh"},
 		{"codex", NewCodexProvider(), "codex", "npm install -g @openai/codex"},
@@ -536,6 +536,30 @@ func TestSafeSessionID(t *testing.T) {
 	for _, tt := range tests {
 		if got := SafeSessionID(tt.id); got != tt.want {
 			t.Errorf("SafeSessionID(%q) = %v, want %v", tt.id, got, tt.want)
+		}
+	}
+}
+
+// TestExtractSemver covers the version-line normalization shared by every
+// provider's Version() via getBinaryVersion. Guards the claude/cursor/agy
+// regression where the decorated first line ("2.1.205 (Claude Code)") leaked
+// through raw instead of the bare semver.
+func TestExtractSemver(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"2.1.205 (Claude Code)", "2.1.205"},
+		{"cursor-agent 0.4.1", "0.4.1"},
+		{"codex-cli 0.111.0", "0.111.0"},
+		{"v1.2.3", "1.2.3"},
+		{"1.2.3", "1.2.3"},
+		{"  0.9.0  ", "0.9.0"},
+		{"no-version-here", "no-version-here"},
+	}
+	for _, tt := range tests {
+		if got := extractSemver(tt.in); got != tt.want {
+			t.Errorf("extractSemver(%q) = %q, want %q", tt.in, got, tt.want)
 		}
 	}
 }

--- a/pkg/tool/store.go
+++ b/pkg/tool/store.go
@@ -180,7 +180,7 @@ func initSchema(db *sql.DB) error {
 	_, err := db.ExecContext(context.TODO(), `
 		CREATE TABLE IF NOT EXISTS tools (
 			name          TEXT PRIMARY KEY,
-			type          TEXT NOT NULL DEFAULT 'provider',
+			type          TEXT NOT NULL DEFAULT 'cli',
 			command       TEXT NOT NULL DEFAULT '',
 			install_cmd   TEXT,
 			upgrade_cmd   TEXT,
@@ -205,7 +205,7 @@ func initSchema(db *sql.DB) error {
 
 	// Migration: add new columns to existing tables
 	for _, col := range []string{
-		"ALTER TABLE tools ADD COLUMN type TEXT NOT NULL DEFAULT 'provider'",
+		"ALTER TABLE tools ADD COLUMN type TEXT NOT NULL DEFAULT 'cli'",
 		"ALTER TABLE tools ADD COLUMN transport TEXT DEFAULT ''",
 		"ALTER TABLE tools ADD COLUMN url TEXT",
 		"ALTER TABLE tools ADD COLUMN args TEXT DEFAULT '[]'",
@@ -228,11 +228,21 @@ func (s *Store) seedBuiltins(ctx context.Context) error {
 	}
 
 	for _, t := range allBuiltins() {
+		t := t
 		existing, err := s.Get(ctx, t.Name)
 		if err != nil {
 			return fmt.Errorf("failed to check %s: %w", t.Name, err)
 		}
 		if existing != nil {
+			// Correct rows seeded by older code that dropped the type and
+			// version_cmd columns (all builtins landed as type='provider'
+			// with an empty version_cmd). Idempotent: only writes when the
+			// builtin row's type/version_cmd drifts from the definition.
+			if existing.Builtin && (existing.Type != t.Type || existing.VersionCmd != t.VersionCmd) {
+				if err := s.correctBuiltin(ctx, t.Name, t.Type, t.VersionCmd); err != nil {
+					return fmt.Errorf("failed to correct %s: %w", t.Name, err)
+				}
+			}
 			continue
 		}
 		if err := s.add(ctx, &t); err != nil {
@@ -240,6 +250,16 @@ func (s *Store) seedBuiltins(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+// correctBuiltin fixes the type/version_cmd of an existing built-in row that
+// predates the columns being persisted. Idempotent by construction.
+func (s *Store) correctBuiltin(ctx context.Context, name, toolType, versionCmd string) error {
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE tools SET type=?, version_cmd=? WHERE name=? AND builtin=1`,
+		toolType, versionCmd, name,
+	)
+	return err
 }
 
 // allBuiltins returns all built-in tool definitions (providers, MCP servers, CLI tools).
@@ -308,11 +328,25 @@ func (s *Store) add(ctx context.Context, t *Tool) error {
 	if err != nil {
 		return err
 	}
+	args, err := marshalJSON(t.Args)
+	if err != nil {
+		return err
+	}
+	env, err := marshalJSON(t.Env)
+	if err != nil {
+		return err
+	}
+
+	toolType := t.Type
+	if toolType == "" {
+		toolType = ToolTypeCLI
+	}
 
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO tools (name, command, install_cmd, upgrade_cmd, slash_cmds, mcp_servers, config, builtin, enabled)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		t.Name, t.Command, t.InstallCmd, t.UpgradeCmd,
+		`INSERT INTO tools (name, type, command, install_cmd, upgrade_cmd, version_cmd, transport, url, args, env, slash_cmds, mcp_servers, config, builtin, enabled)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.Name, toolType, t.Command, t.InstallCmd, t.UpgradeCmd, t.VersionCmd,
+		t.Transport, t.URL, args, env,
 		slashCmds, mcpServers, config, t.Builtin, t.Enabled,
 	)
 	return err
@@ -457,11 +491,25 @@ func (s *Store) Update(ctx context.Context, t *Tool) error {
 	if err != nil {
 		return err
 	}
+	args, err := marshalJSON(t.Args)
+	if err != nil {
+		return err
+	}
+	env, err := marshalJSON(t.Env)
+	if err != nil {
+		return err
+	}
+
+	toolType := t.Type
+	if toolType == "" {
+		toolType = ToolTypeCLI
+	}
 
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE tools SET command=?, install_cmd=?, upgrade_cmd=?, slash_cmds=?, mcp_servers=?, config=?, enabled=?
+		`UPDATE tools SET type=?, command=?, install_cmd=?, upgrade_cmd=?, version_cmd=?, transport=?, url=?, args=?, env=?, slash_cmds=?, mcp_servers=?, config=?, enabled=?
 		 WHERE name=?`,
-		t.Command, t.InstallCmd, t.UpgradeCmd,
+		toolType, t.Command, t.InstallCmd, t.UpgradeCmd, t.VersionCmd,
+		t.Transport, t.URL, args, env,
 		slashCmds, mcpServers, config, t.Enabled,
 		t.Name,
 	)

--- a/pkg/tool/store_test.go
+++ b/pkg/tool/store_test.go
@@ -279,3 +279,117 @@ func TestTool_JSONSerialization(t *testing.T) {
 		t.Errorf("Config mismatch: %v", got.Config)
 	}
 }
+
+// TestStore_SeededCLIToolRoundTrips guards the SQLite type-column regression:
+// built-in CLI tools must persist with type='cli' and their version_cmd, so
+// the web UI's non-provider/non-mcp filter surfaces them (previously every
+// builtin landed as type='provider' with an empty version_cmd → "0 CLI tools").
+func TestStore_SeededCLIToolRoundTrips(t *testing.T) {
+	s := NewStore(setupSharedDB(t), "sqlite")
+	if err := s.Open(); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close() //nolint:errcheck // test cleanup
+
+	ctx := context.Background()
+
+	gh, err := s.Get(ctx, "gh")
+	if err != nil {
+		t.Fatalf("Get gh: %v", err)
+	}
+	if gh == nil {
+		t.Fatal("expected gh built-in CLI tool to be seeded")
+	}
+	if gh.Type != ToolTypeCLI {
+		t.Errorf("gh.Type = %q, want %q", gh.Type, ToolTypeCLI)
+	}
+	if gh.VersionCmd != "gh --version" {
+		t.Errorf("gh.VersionCmd = %q, want %q", gh.VersionCmd, "gh --version")
+	}
+
+	// A provider builtin must keep its provider type.
+	claude, err := s.Get(ctx, "claude")
+	if err != nil {
+		t.Fatalf("Get claude: %v", err)
+	}
+	if claude.Type != ToolTypeProvider {
+		t.Errorf("claude.Type = %q, want %q", claude.Type, ToolTypeProvider)
+	}
+
+	// At least one tool must be a CLI type so the UI filter is non-empty.
+	tools, err := s.ListWithOptions(ctx, ListOptions{Types: []string{ToolTypeCLI}})
+	if err != nil {
+		t.Fatalf("ListWithOptions: %v", err)
+	}
+	if len(tools) == 0 {
+		t.Fatal("expected at least one type='cli' tool")
+	}
+}
+
+// TestStore_SeedCorrectsMislabeledBuiltins verifies the idempotent startup
+// correction: a builtin row left as type='provider' with empty version_cmd by
+// older code gets rewritten to its true type/version_cmd on the next seed.
+func TestStore_SeedCorrectsMislabeledBuiltins(t *testing.T) {
+	d := setupSharedDB(t)
+	s := NewStore(d, "sqlite")
+	if err := s.Open(); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close() //nolint:errcheck // test cleanup
+
+	ctx := context.Background()
+
+	// Simulate the legacy mislabeling directly in the DB.
+	if _, err := d.ExecContext(ctx,
+		`UPDATE tools SET type='provider', version_cmd='' WHERE name='gh'`); err != nil {
+		t.Fatalf("mislabel gh: %v", err)
+	}
+
+	// Re-seeding (as happens on every Open) must correct it.
+	if err := s.seedBuiltins(ctx); err != nil {
+		t.Fatalf("seedBuiltins: %v", err)
+	}
+
+	gh, err := s.Get(ctx, "gh")
+	if err != nil {
+		t.Fatalf("Get gh: %v", err)
+	}
+	if gh.Type != ToolTypeCLI {
+		t.Errorf("after correction gh.Type = %q, want %q", gh.Type, ToolTypeCLI)
+	}
+	if gh.VersionCmd != "gh --version" {
+		t.Errorf("after correction gh.VersionCmd = %q, want %q", gh.VersionCmd, "gh --version")
+	}
+}
+
+// TestStore_AddCLIToolPersistsType verifies a user-added CLI tool (POST →
+// Add) round-trips with type='cli' and version_cmd — the add-new-tool flow.
+func TestStore_AddCLIToolPersistsType(t *testing.T) {
+	s := NewStore(setupSharedDB(t), "sqlite")
+	if err := s.Open(); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close() //nolint:errcheck // test cleanup
+
+	ctx := context.Background()
+	custom := &Tool{
+		Name:       "ripgrep",
+		Type:       ToolTypeCLI,
+		Command:    "rg",
+		VersionCmd: "rg --version",
+		Enabled:    true,
+	}
+	if err := s.Add(ctx, custom); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	got, err := s.Get(ctx, "ripgrep")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Type != ToolTypeCLI {
+		t.Errorf("Type = %q, want %q", got.Type, ToolTypeCLI)
+	}
+	if got.VersionCmd != "rg --version" {
+		t.Errorf("VersionCmd = %q, want %q", got.VersionCmd, "rg --version")
+	}
+}

--- a/server/handlers/deps_install_test.go
+++ b/server/handlers/deps_install_test.go
@@ -28,7 +28,7 @@ func TestInstallCommand(t *testing.T) {
 		{"tmux", "linux", "sudo apt-get update && sudo apt-get install -y tmux", true},
 		{"docker", "darwin", "", false},
 		{"docker", "linux", "", false},
-		{"claude", "darwin", "npx -y @anthropic-ai/claude-code", true},
+		{"claude", "darwin", "npm install -g @anthropic-ai/claude-code", true},
 		{"codex", "linux", "npm install -g @openai/codex", true},
 		{"cursor", "darwin", "", false}, // hint is a bare URL — not auto-installable
 		{"nonesuch", "linux", "", false},

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -585,9 +586,20 @@ func npmPackageForHint(hint string) (string, bool) {
 	return "", false
 }
 
-// normalizeVersion strips a leading "v" so "v1.2.3" and "1.2.3" compare equal.
+// semverTokenRe extracts the leading semantic-version token from a version
+// string, so decorated output like "2.1.205 (Claude Code)" reduces to the
+// bare "2.1.205" for comparison.
+var semverTokenRe = regexp.MustCompile(`(\d+\.\d+\.\d+)`)
+
+// normalizeVersion reduces a version string to its bare semver token so
+// "v1.2.3", "1.2.3", and "1.2.3 (Claude Code)" all compare equal. Falls back
+// to the "v"-stripped, trimmed string when no semver token is present.
 func normalizeVersion(v string) string {
-	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+	v = strings.TrimSpace(v)
+	if m := semverTokenRe.FindString(v); m != "" {
+		return m
+	}
+	return strings.TrimPrefix(v, "v")
 }
 
 // npmRegistryBaseURL and npmHTTPClient are package vars so tests can point

--- a/server/handlers/providers_update_test.go
+++ b/server/handlers/providers_update_test.go
@@ -109,6 +109,47 @@ func TestCheckUpdate_RealNpmCompareUpToDate(t *testing.T) {
 	}
 }
 
+// TestCheckUpdate_DecoratedCurrentVersionNoFalsePositive guards the claude
+// regression: Version() returns "2.1.205 (Claude Code)" while npm reports the
+// bare "2.1.205". normalizeVersion must reduce both to "2.1.205" so the check
+// reports up-to-date instead of a perpetual false "update available".
+func TestCheckUpdate_DecoratedCurrentVersionNoFalsePositive(t *testing.T) {
+	withNpmRegistryStub(t, "2.1.205", http.StatusOK)
+	mux := newFakeUpdateMux(&fakeUpdateProvider{name: "fakenpm", installHint: "npm install -g fake-cli", version: "2.1.205 (Claude Code)"})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/providers/fakenpm/check-update", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	var result UpdateCheck
+	if err := json.Unmarshal(rec.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !result.Checked {
+		t.Error("Checked = false, want true")
+	}
+	if result.UpdateAvailable {
+		t.Error("UpdateAvailable = true, want false ('2.1.205 (Claude Code)' vs '2.1.205')")
+	}
+}
+
+// TestNormalizeVersion checks the semver-token reduction directly.
+func TestNormalizeVersion(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"2.1.205 (Claude Code)", "2.1.205"},
+		{"v1.2.3", "1.2.3"},
+		{"1.2.3", "1.2.3"},
+		{"  2.1.205  ", "2.1.205"},
+		{"codex-cli 0.111.0", "0.111.0"},
+		{"weird-nonsemver", "weird-nonsemver"},
+	}
+	for _, c := range cases {
+		if got := normalizeVersion(c.in); got != c.want {
+			t.Errorf("normalizeVersion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 // TestCheckUpdate_NonNpmHintIsHonestlyUnverified covers a provider installed
 // via a mechanism with no queryable registry (e.g. cursor's bare download
 // URL). checkUpdate must not claim the version is current — Checked stays

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1358,7 +1358,14 @@ export const api = {
   checkTools: () =>
     request<Tool[]>("/tools/unified/check", { method: "POST" }),
 
-  /** Create or update a CLI tool. */
+  /** Create a new CLI tool (POST → store.Add). Defaults type to "cli". */
+  createTool: (tool: Partial<CLITool> & { name: string }) =>
+    request<CLITool>("/tools", {
+      method: "POST",
+      body: JSON.stringify({ type: "cli", ...tool }),
+    }),
+
+  /** Update an existing CLI tool. */
   upsertTool: (tool: Partial<CLITool> & { name: string }) =>
     request<CLITool>(`/tools/${encodeURIComponent(tool.name)}`, {
       method: "PUT",

--- a/web/src/settings/ProvidersToolsSection.tsx
+++ b/web/src/settings/ProvidersToolsSection.tsx
@@ -388,7 +388,7 @@ function AddCLIToolForm({ onClose, onAdded, onToast }: { onClose: () => void; on
     setSubmitting(true);
     setError(null);
     try {
-      await api.upsertTool({ name: name.trim(), command: command.trim(), install_cmd: installCmd.trim(), enabled: true });
+      await api.createTool({ name: name.trim(), command: command.trim(), install_cmd: installCmd.trim(), enabled: true });
       onToast("info", `Tool '${name.trim()}' added`);
       onAdded();
       onClose();


### PR DESCRIPTION
Fixes five confirmed defects making the Providers/Tools UI show "0 CLI tools", wrong version strings, a perpetual false "update available", and non-working install/update.

## Defects & fixes

1. **SQLite tool store dropped the `type` column → "0 CLI tools".** `pkg/tool/store.go` `add()` and `Update()` omitted `type, version_cmd, transport, url, args, env` from the INSERT/UPDATE, so the schema's `DEFAULT 'provider'` labeled all 12 `builtinCLITools` as `provider` — which the front-end filter (`ProvidersToolsSection.tsx`) drops. `version_cmd` was never persisted either, so the Version column stayed empty. Fixed by writing the full column set (mirroring `store_postgres.go`), flipping the schema default `'provider'`→`'cli'`, and adding an idempotent seed-time correction (`correctBuiltin`) that rewrites already-mislabeled builtin rows.
2. **Version strings not normalized.** `getBinaryVersion` returned the whole first line, so `claude`/`cursor`/`agy` reported `2.1.205 (Claude Code)`. Centralized a shared `extractSemver` helper in `provider.go` so every provider's `Version()` yields the bare semver; falls back to the raw line when no semver is present (already-regexed codex/openclaw/pi still behave).
3. **Perpetual false "update available".** `server/handlers/providers.go` `normalizeVersion` only stripped a leading `v`, so `"2.1.205" != "2.1.205 (Claude Code)"`. Hardened it to extract the leading `(\d+\.\d+\.\d+)` token (fallback to trimmed/`v`-stripped).
4. **Claude install/update used `npx`** (`ClaudeProvider.InstallHint()`), which downloads-and-runs the interactive TUI, never installing/updating the global binary and hanging the stream. Changed to `npm install -g @anthropic-ai/claude-code` (matches the tool-store builtin's InstallCmd); `npmPackageForHint`/`fetchNpmLatestVersion` still parse it.
5. **Add-new-CLI-tool form was PUT-only** → `store.Update` returned "tool not found" for new tools. Added `api.createTool` → `POST /api/tools` → `store.Add` with `type: "cli"`, and pointed the form at it.

## Tests added
- `pkg/tool/store_test.go`: seeded CLI tool round-trips with `type='cli'` and its `version_cmd`; provider builtins keep `type='provider'`; idempotent correction of a mislabeled builtin; user-added CLI tool persists type/version_cmd.
- `pkg/provider/provider_test.go`: `TestExtractSemver` (`2.1.205 (Claude Code)` → `2.1.205`, etc.).
- `server/handlers/providers_update_test.go`: `TestNormalizeVersion` and `TestCheckUpdate_DecoratedCurrentVersionNoFalsePositive` (current `2.1.205 (Claude Code)`, latest `2.1.205` → `update_available=false`). Existing hint-assertion tests updated to the npm hint.

## Verification
`go build ./...`, `go vet`, `gofmt -s -l`, `golangci-lint run` clean on touched packages; `go test ./pkg/tool/... ./pkg/provider/... ./server/...` all green; `make build-local-web` succeeds.

Part of #3423

🤖 Generated with [Claude Code](https://claude.com/claude-code)