### PR TITLE
fix(settings,tools): unlock satisfied setup sections, real tool versions, honest Status column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ links work inside the desktop window; and the stubs that presented
 invented data as real are gone.
 
 ### Added
+
 - **Progressive-disclosure setup.** Setup is the Settings page revealing
   itself section by section as each one is satisfied — no separate
   `/welcome` wizard, and a re-run icon replays the reveal without
@@ -42,6 +43,7 @@ invented data as real are gone.
   buttons (#3434).
 
 ### Changed
+
 - **Providers & Tools live in Settings** as a list-only section; the
   standalone `/tools` page is gone and per-provider drill-down stays at
   `/settings/providers/:name`. tmux is the recommended and default
@@ -54,6 +56,7 @@ invented data as real are gone.
   they can't silently drift again (#3430, #3432).
 
 ### Fixed
+
 - **Providers/Tools actually work.** Install and update run for real via
   streamed NDJSON instead of echoing a hint; versions render clean
   (`v2.1.205`); CLI-tool detection no longer reports "0 CLI tools" (a
@@ -89,6 +92,7 @@ doing, and outbound messages started looking like the agent that sent
 them.
 
 ### Added
+
 - **Agent identity everywhere.** A `whoami` MCP tool, a server-rendered
   public AgentCharacter avatar, and real per-agent icons on outbound
   Slack messages (#3408, #3395).
@@ -108,6 +112,7 @@ them.
 - **Direct messaging** to any contact via `<platform>:<id>` (#3380).
 
 ### Changed
+
 - Settings slimmed and mirrored to the wizard, with setup folded in
   (#3386); craft passes over Settings, Apps, and Notifications (#3387,
   #3388, #3382).
@@ -116,6 +121,7 @@ them.
   bundles (#3399).
 
 ### Fixed
+
 - Agent lifecycle events persist, so new agents have a timeline (#3397),
   without double-persisting hook events (#3415).
 - The agent raw stream shows tool output and responses again (#3410).
@@ -130,18 +136,21 @@ them.
   dropped (#3417).
 
 ### Security
+
 - `golang.org/x/image` bumped to v0.44.0, clearing 12 CodeQL alerts
   (#3412).
 
 ## [0.4.2] - 2026-07-31
 
 ### Fixed
+
 - CD injects the release version into the desktop build, so packaged
   apps no longer report a dev version (#3381).
 
 ## [0.4.1] - 2026-07-31
 
 ### Added
+
 - Message any contact directly via `<platform>:<id>`, without a
   pre-existing channel (#3380).
 
@@ -154,6 +163,7 @@ web UI is the product's single rich surface, and a native desktop app
 ships for macOS, Linux, and Windows. The fleet got faces.
 
 ### Added
+
 - **Apps platform.** Notifications becomes Apps: 28 real integrations,
   each a self-registering plugin (descriptor + build factory) with
   auth-kind-aware connect flows — token, webhook-secret, QR pairing
@@ -180,6 +190,7 @@ ships for macOS, Linux, and Windows. The fleet got faces.
   Agent flow and manage them from the agent's Config tab.
 
 ### Changed
+
 - **Entity-scoped home.** `~/.mycel` flattens: one `prefs.json`, one
   `mycel.db`, one vault; each agent owns `agents/<name>/{worktree,
   session,logs,tmp}`; stateful apps own `apps/<name>/`. `mycel up`
@@ -197,6 +208,7 @@ ships for macOS, Linux, and Windows. The fleet got faces.
   from code and docs.
 
 ### Removed
+
 - **The TUI.** The web UI is the only rich surface; `mycel` with no
   arguments starts the daemon and opens the dashboard.
 - **Cron.** Agents schedule their own work.
@@ -208,10 +220,10 @@ ships for macOS, Linux, and Windows. The fleet got faces.
   screenshots, and the `costs.db` ledger.
 
 ### Security
+
 - govulncheck clean in called code (Go 1.25.12, x/text 0.39); landing
   and web dependency audits at zero known-vulnerable resolutions
   (one documented N/A: react-router RSC-server CSRF — client-only SPA).
-
 
 ## [0.3.12] - 2026-07-05
 
@@ -220,6 +232,7 @@ every page drives, the analytics page becomes a real dashboard wired to
 the cost ledger, and agents can now talk back over WhatsApp.
 
 ### Added
+
 - **Outbound WhatsApp.** Agents can reply on WhatsApp — the gateway
   adapter implements `Send()` over the paired whatsmeow session, routed
   by native JID with a bounded send timeout (#3314).
@@ -231,6 +244,7 @@ the cost ledger, and agents can now talk back over WhatsApp.
   clipping (#3317).
 
 ### Changed
+
 - **One shared header.** The mycel brand + drawer toggle move into the
   header as a column that resizes with the drawer and collapses to an
   icon rail; every page — agent detail, Tools, Code, Secrets, Insights —
@@ -253,6 +267,7 @@ the cost ledger, and agents can now talk back over WhatsApp.
   rather than provider-side detection (#3309).
 
 ### Removed
+
 - **Dead stats-store token/cost path.** The per-agent token/cost
   timeseries (`/api/agents/stats/{tokens,cost}`, the misrouted collector
   block, and the `token_metrics` table with its query/record code) is
@@ -265,6 +280,7 @@ The visual release: the entire web UI rebuilt on a real design system,
 plus model and environment as first-class agent parameters.
 
 ### Changed
+
 - **Two themes, one palette.** Dark (default) and light, every color an
   exact Radix scale step (Sand neutrals + Orange accent); Solar Flare
   retired with stored preferences migrating. Three-step layered
@@ -286,6 +302,7 @@ plus model and environment as first-class agent parameters.
   newest-first feed.
 
 ### Added
+
 - **Model as an agent parameter.** Per-provider dropdown in the create
   modal (lists verified against each live CLI), stored on the agent,
   injected with the right flag per provider, preserved across restarts,
@@ -296,6 +313,7 @@ plus model and environment as first-class agent parameters.
   protected from both config and env files.
 
 ### Fixed
+
 - **Per-agent cost was broken end-to-end**: the client read a field the
   server never sent, and the server looked up the ledger by bare agent
   name while entries key by session name. Costs are real everywhere now
@@ -313,6 +331,7 @@ flat name-keyed state, and an agent create path that survives every
 failure mode we could find.
 
 ### Removed
+
 - **The workspace concept.** Per-workspace databases, registries,
   service bundles, idle eviction, `/w/` URLs, and workspace-scoped
   API surfaces are all deleted. bcd is single-tenant: one `Services`
@@ -323,6 +342,7 @@ failure mode we could find.
   controls in the agent header.
 
 ### Added
+
 - **Repo as the unit of work.** The create-agent modal grows a
   required Repo field (known-repos dropdown + local discovery), the
   agents list groups by repo, and `GET /api/repos` lists every repo
@@ -343,6 +363,7 @@ failure mode we could find.
   provider, with the build command.
 
 ### Fixed
+
 - **Agents survive daemon restarts regardless of repo.** The manager
   loaded only boot-repo agents at startup, orphaning everything else
   (row and tmux session alive, API blind). It now loads the whole
@@ -364,6 +385,7 @@ failure mode we could find.
   calculator, and the last `bc` → `mycel` help strings are fixed.
 
 ### Documentation
+
 - Every page realigned with the repo-era architecture and verified
   against source — tutorials, how-to, reference, and explanation.
   `mkdocs build --strict` passes clean.
@@ -376,6 +398,7 @@ removed, the security backlog is cleared, and the Live page event stream
 was rebuilt around the agent-detail hook-stream UI.
 
 ### Removed
+
 - **`mycel init`.** `mycel up` bootstraps everything: run it inside a git
   repo and the repo is adopted automatically; run it anywhere else and
   the daemon serves the web UI with an add-repo flow. The wizard,
@@ -389,6 +412,7 @@ was rebuilt around the agent-detail hook-stream UI.
   and completed one-shot store migrations are all removed.
 
 ### Security
+
 - Resolved 86 CodeQL alerts with real taint barriers: path-injection
   guards across agent/worktree/template/attachment/file handling, three
   command-injection fixes (unvalidated worktree param reaching `git -C`;
@@ -397,6 +421,7 @@ was rebuilt around the agent-detail hook-stream UI.
   upgrade clearing ~1,700 stale container-scan CVEs.
 
 ### Changed
+
 - **Live event stream v2.** Flat newest-first hook-event rows shared
   with the agent-detail page: rich one-line summaries extracted from
   event JSON (commands, file paths, subagent descriptions, durations),
@@ -409,6 +434,7 @@ was rebuilt around the agent-detail hook-stream UI.
   unread accents, and a channel filter.
 
 ### Fixed
+
 - **Multi-workspace data bleed.** Every workspace now has its own database
   connection (per-workspace registry with explicit store handles) — one
   workspace's subscriptions, cron jobs, and events can no longer land in
@@ -427,6 +453,7 @@ documentation set was rewritten from source and now deploys reliably to
 bc-infra.com.
 
 ### Fixed
+
 - **Storage resilience.** The daemon falls back to SQLite (with a loud
   warning) when the configured TimescaleDB is unreachable, instead of
   silently disabling notify/cron/MCP/tools/events.
@@ -452,6 +479,7 @@ bc-infra.com.
 - **Security.** Go 1.25.11 clears GO-2026-5039/5037/4971/4918.
 
 ### Added
+
 - **Degraded-services surfacing.** `/api/health` reports failed stores
   with reasons, 503s carry the cause, `mycel doctor` gains a daemon
   check, and the web UI shows a degraded banner.
@@ -461,6 +489,7 @@ bc-infra.com.
   Cobra command tree.
 
 ### Changed
+
 - **Live page redesigned** around a single presence line, search, and a
   ⋯ menu — the stats grid, dual filter dropdowns, and five-button toolbar
   are gone.
@@ -477,6 +506,7 @@ bc-infra.com.
 Course-correct on the v0.3.6 notifications rewrite.
 
 ### Reverted
+
 - **Restore `GatewayFeed.tsx` + `AgentPeekPanel.tsx`.** The v0.3.6
   `ChannelStream` rewrite over-corrected the notifications-are-a-stream
   arc. The header "N/N agents" dropdown (Listening / Available with
@@ -488,6 +518,7 @@ Course-correct on the v0.3.6 notifications rewrite.
   `GatewayFeed` again; `ChannelStream.tsx` deleted.
 
 ### Added
+
 - **Slack mrkdwn client-side normalization** in `MessageContent`.
   Slack sends messages with raw angle-bracket tokens that rendered
   broken in the UI (`<@U0AP1U92T3K>` for @-mentions,
@@ -510,6 +541,7 @@ Course-correct on the v0.3.6 notifications rewrite.
 Post-v0.3.5 cleanup pass.
 
 ### Changed
+
 - **Delivery log — quiet offline-agent skips.** Sending to a stopped
   subscriber used to be logged as `StatusFailed`, so a channel with
   seven subscribers and six stopped agents rendered an alarming
@@ -521,6 +553,7 @@ Post-v0.3.5 cleanup pass.
   change.
 
 ### Removed
+
 - **`web/src/components/notifications/GatewayFeed.tsx`** — replaced
   by `ChannelStream` in v0.3.5, no callers remained.
 - **`web/src/components/AgentPeekPanel.tsx`** — its only caller was
@@ -532,6 +565,7 @@ Follow-through on the workspace-as-property and
 notifications-are-a-stream arcs started in v0.3.4.
 
 ### Removed
+
 - **WorkspaceDropdown / WorkspacePicker / activate flow** — workspace
   is a property on the agent, not something the user "switches to",
   so a switcher was a UX contradiction. Sidebar chip drops its
@@ -544,6 +578,7 @@ notifications-are-a-stream arcs started in v0.3.4.
   `POST /api/agents` from the new-agent modal).
 
 ### Changed
+
 - **Agents page — default group = workspace** (was: repo). Toggle
   reads/writes `mycel-agents-group-by-workspace` in localStorage and
   disables when every visible agent shares one workspace. Group
@@ -577,6 +612,7 @@ post-release audit:
    agents — not a chat surface with reactions or persistent history.
 
 ### Changed
+
 - **Flatten SPA routes** — dropped the `/w/<workspaceId>/…` URL
   segment across the entire web UI. `/live`, `/agents`,
   `/agents/:name`, `/notifications`, `/notifications/:src`,
@@ -589,6 +625,7 @@ post-release audit:
   flat paths → `/w/<id>/…`) deleted.
 
 ### Removed
+
 - **`server/legacy_scope.go`** and its test.
 - **`web/src/context/WorkspaceContext.test.tsx`**, **`web/src/components/WorkspaceDropdown.test.tsx`**,
   **`web/src/views/AgentDetail.test.tsx`** — all asserted the old
@@ -597,6 +634,7 @@ post-release audit:
   **`RedirectToActiveWorkspace`** — no longer needed with flat routes.
 
 ### Reverted
+
 - **Emoji reactions in notifications** (#3075, #3226 batch 12) —
   wrong direction. Notifications don't need reactions, thread state,
   or a chat rendering layer. The `reactions` column, `extractReactions()`
@@ -616,6 +654,7 @@ end-to-end (#3075), and #3178 phase 2 landing as a direct-API
 outbound cookbook rather than mycel-side wrapper tools.
 
 ### Added
+
 - **Emoji reactions** (#3075, #3226 batch 12) — end-to-end pipeline for
   Slack + Discord reactions. New `reactions TEXT` column on
   `notify_messages` stores a JSON-encoded `[{name, count}]` array;
@@ -638,6 +677,7 @@ outbound cookbook rather than mycel-side wrapper tools.
   rate-limit / retry.
 
 ### Changed
+
 - **Chart palette + dash-pattern a11y** (batch 8) — repalette every
   Recharts series to the tokenized 6-swatch mycel palette; add dashed
   stroke patterns so series remain distinguishable in monochrome /
@@ -650,12 +690,14 @@ outbound cookbook rather than mycel-side wrapper tools.
   cascade across theme variants.
 
 ### Deprecated
+
 - **`POST /api/gateways/{platform}/channels/{channel}/send`** — RFC 8594
   `Deprecation` + `Sunset` headers on every response. Will return
   `410 Gone` in v0.4.0. New integrations use the per-agent outbound
   cookbook.
 
 ### Docs
+
 - **Notification architecture doc rehabilitated** — renamed
   `docs/_architecture-notifications.md` → `docs/architecture-notifications.md`,
   wired into mkdocs nav under Explanation, and fixed the stale
@@ -666,6 +708,7 @@ outbound cookbook rather than mycel-side wrapper tools.
   like `github:bc` / `slack:all-bc` left alone).
 
 ### Fixed
+
 - **Gateway channel double-prefix** (#3219, #3220) — inbound Slack
   messages were being stored under `slack:slack:general` due to a
   double-prefix silently added by the gateway handler. Defensive
@@ -680,6 +723,7 @@ review (design / a11y / dataviz / UX / FE-eng) tracked in #3205, plus
 one server-side accuracy fix.
 
 ### Added
+
 - **Global keyboard focus ring** — WCAG 2.4.7. Two new tokens
   `--mycel-focus-ring` + `--mycel-focus-ring-offset` in `tokens.css`
   cascade from the theme accent; every interactive element gets a
@@ -693,6 +737,7 @@ one server-side accuracy fix.
   differ (#3212, #3213).
 
 ### Changed
+
 - **Theme-aware `agentColor()`** — hash bucket 0 uses `var(--mycel-accent)`
   so the most-prominent chart series follows the theme accent
   (emerald under Dark, tangerine under Solar Flare / Light) instead
@@ -751,6 +796,7 @@ one server-side accuracy fix.
   11 files touched (#3205 batch 6, #3217).
 
 ### Fixed
+
 - **About page `UPDATE AVAILABLE` false positive** — comparing the
   daemon's commit hash to the release tag semver never matched.
   Now compares like-with-like via the new `/api/health` `version`
@@ -762,6 +808,7 @@ one server-side accuracy fix.
   now fall to the italic `system` label (#3205 batch 5, #3216).
 
 ### Deferred to v0.3.3 (or later)
+
 - Interactive chart legend (hover-to-highlight, click-to-toggle).
 - Chart palette rework for 6+ distinct series that survive both
   dark and light backgrounds.
@@ -773,14 +820,17 @@ one server-side accuracy fix.
 ## [0.3.1] - 2026-07-03
 
 ### Renamed
+
 - **Docker image tags**: `bc-agent-*` → `mycel-agent-*` (base/claude/gemini/codex/cursor/infra). Every agent build target dual-tags the produced image so pre-v0.3.1 configs that still reference `bc-agent-*` keep working for one release cycle (#3187 pt 1, #3197).
 - **tmux session + Docker container prefix**: `bc-<hash>-<name>` → `mycel-<hash>-<name>`. Reader-side legacy fallback (`Manager.HasSession` / `Manager.ListSessions` / `Backend.ListSessions`) still finds `bc-<hash>-*` sessions and containers, so upgraded workspaces don't lose pre-existing agents (#3187 pt 2, #3198).
 
 ### Added
+
 - **RFC 8594 Deprecation headers** on `POST /api/gateways/{platform}/channels/{channel}/send` — signals the endpoint's sunset (target v0.4.0) so callers can migrate to per-agent platform SDKs. See #3178 for the tracking epic (#3201).
 - **Theme tokens** — `--mycel-accent-fg`, `--mycel-text-2`, `--mycel-live` per theme, wired through `tailwind.config.ts` so the brand tile stays readable across Solar Flare, Dark, and Light and the pulsing "live" indicator follows the theme (#3202).
 
 ### Changed
+
 - **Web: consolidated 6 divergent time-format helpers** into `web/src/utils/time.ts` (`formatRelative` / `formatAbsolute` / `formatDuration`); 16 new colocated tests (#3181, #3199).
 - **Web: header + drawer alignment** — both use 48px min-height. Active nav item now uses `bg-mycel-surface-hover`; section labels + workspace caption bumped from 9px @ 40% opacity to 10px muted (#3203, #3202).
 - **Web: sidebar flattened** — `GLOBAL`/`SYSTEM` section headers removed. Costs merged into main nav; Settings moved to footer next to About + theme toggle (#3205 P1a, #3208).
@@ -792,6 +842,7 @@ one server-side accuracy fix.
 - **Web: CSS namespace sweep** — `Stats.tsx` + `StatsTab.tsx` corrected from incorrect `var(--color-mycel-*)` to canonical `--mycel-*` (#3205 P0.3, #3206).
 
 ### Fixed
+
 - **Metrics CPU chart rendered empty despite data.** Two independent bugs: (a) `server/stats_collector.go` still keyed `isAgentContainer` / `isSystemContainer` / `extractAgentName` on the `bc-` prefix so docker-runtime agents stopped being classified post-rename; (b) `pivotAgentMetric` left `undefined` for agents with sample gaps, collapsing the stacked area to the baseline. Both fixed + unit tests (#3182, #3200).
 - **CPU chart y-axis + tooltip** — un-stacked, auto-scale with `min 5%`, per-agent tooltip (#3205 P0.2, #3207).
 - **npm CD pipeline** — `--allow-same-version` on `npm version` so the tag drives the publish, not the working tree (#3196).
@@ -801,6 +852,7 @@ one server-side accuracy fix.
 - **`GatewayFeed` hover states** — five `hover:bg-white/[…]` sites invisible under Light theme; now `hover:bg-mycel-surface-hover` (#3202).
 
 ### Deferred to v0.3.2
+
 - **#3178 phase 2** — per-agent outbound integration. Landing in v0.3.3 as a docs-only cookbook (env.json + direct `chat.postMessage` / `sendMessage` / webhook curl recipes), not as mycel-side wrapper tools — keeps the daemon out of the platform auth / rate-limit / retry business and lets agents hit each platform's official REST API directly.
 - **#3205 P1c** — Live event row visual simplification (collapse dual status dots, defer avg/ok-ratio behind expand).
 - **#3205 P2 + P3** — chart palette rework, interactive legend, global focus-ring token, remaining opacity sprinkle cleanup.
@@ -808,6 +860,7 @@ one server-side accuracy fix.
 ## [0.3.0] - 2026-07-02
 
 ### Renamed
+
 - **State root**: `~/.bc/` → `~/.mycel/`. Existing installs are migrated silently on the first invocation of any `mycel` command — no user action required. `~/.bc/` still resolves as a read-only fallback if the migration cannot run (permissions, etc.), so no state is silently lost (#3184).
 - **Environment variables**: `MYCEL_HOME` / `MYCEL_STATE_DIR` are canonical. `BC_HOME` / `BC_STATE_DIR` are still honored, with a deprecation warn.
 - **User-facing CLI copy**: every help / error / example string that referenced `bc <verb>` is now `mycel <verb>`; `bc CLI` / `bc server` / `bc daemon` prose rebranded (#3185).
@@ -815,11 +868,13 @@ one server-side accuracy fix.
 - Deferred to v0.3.1: `bc-agent-*` Docker image names and `bc-<hash>-<name>` tmux session prefix — both need coordinated backward-compat migration (#3187).
 
 ### Added
+
 - **Pi provider** — new agent tool option, wired end-to-end (backend + web modal) (#3135).
 - **About page** (`/about`) — installed version, dist-channel availability, live daemon health checks (#3137).
 - **Live page activity hydration** — cards pre-fill from the persisted event store on mount; no longer empty on reload (#3138, #3164).
 
 ### Changed
+
 - **Workspace-as-property (RFC #3079)** — every workspace-scoped `/api/*` route now resolves scope via `X-BC-Workspace` header or `?workspace=<id>` query param. The `/api/workspaces/{id}/<rest>` path-rewrite is deleted; only registry self-routes (`/api/workspaces`, `…/{id}`, `…/activate`, `…/discover/*`, `…/clone`) remain (#3147, #3148, #3149, #3150).
 - Live page scroll uses pinned anchor (`overflow-anchor: none`, `scrollbar-gutter: stable`) so card updates no longer jump the viewport (#3139, #3140).
 - `AgentDetail` no longer stacks two headers — the global `LayoutHeader` is suppressed entirely on that route (#3129).
@@ -827,6 +882,7 @@ one server-side accuracy fix.
 - Landing `/pricing` and `/waitlist` now render `Nav` + `Footer` (#3078, #3167).
 
 ### Fixed
+
 - Fresh install + `mycel init` followed by any command errored with "not in a mycel workspace". `workspace.Init` now surfaces registry-save errors instead of swallowing them, and `workspace.Find` self-heals by probing `~/.mycel/workspaces/<id>/preferences.json` for the walked directory (#3173).
 - Inter-agent DMs silently no-op'd — `POST /api/agents/{name}/send` now uses `DisallowUnknownFields` and rejects empty message bodies with 400 instead of typing an empty string into the target session (#3174).
 - Agent state wedged at `starting` — `AgentService.Send` now reconciles both `stopped` and `starting` when a live session is detected (#3175).
@@ -835,10 +891,12 @@ one server-side accuracy fix.
 - `go install github.com/rpuneet/mycel/cmd/mycel` was broken because `//go:embed web/dist` had nothing to embed on a fresh checkout. Track `server/web/dist/placeholder.txt` in git (#3036, #3165).
 
 ### Removed
+
 - Dead `mycel env` command and hidden `tool check` alias (#3143, #3146).
 - Historical `/api/workspaces/{id}/<rest>` path-scoped route family (see workspace-as-property above).
 
 ### Deferred to v0.3.1+
+
 - npm Trusted Publishing (OIDC) migration for `cd-npm.yml` — pending Trusted Publisher registration on npmjs.com (#3166).
 - Gateway → per-agent platform-tool rearchitecture: outbound Slack / Telegram / Discord / WhatsApp will move from `POST /api/gateways/{platform}/…/send` into per-agent tools using the official platform APIs. Also fixes the recurring "mycel gateway" attribution issue on Slack file uploads (#3178).
 - Docker image names `bc-agent-*` → `mycel-agent-*` and tmux session prefix `bc-<hash>-<name>` → `mycel-<hash>-<name>` — deferred so v0.3.0 doesn't break existing agent sessions on upgrade (#3187).
@@ -847,10 +905,12 @@ one server-side accuracy fix.
 ## [0.2.3] - 2026-05-02
 
 ### Added
+
 - SDK runner skeleton (`packages/mycel-agent-runner`) — Phase 1 of the Claude Agent SDK migration; thin HTTP wrapper exposing one Claude agent over REST + SSE (#2990).
 - Mycel-branded landing site at mycel.dev (#3004).
 
 ### Changed
+
 - Rebranded `bc` to `mycel` across the binary (`bin/mycel`), release tarballs (`mycel_*`), npm package (`mycel-cli`), Go module (`github.com/rpuneet/mycel`), and install paths (#3053, #3059, #3060, #3062).
 - Restored the original particle background animation on the landing site (#3055).
 - Backend cleanup: SOLID refactor of server services, dedicated error types, config split, repo_root plumbing, and broad context propagation across notify/cron/tool/doctor/provider/agent stores (#3038, #3046).
@@ -859,6 +919,7 @@ one server-side accuracy fix.
 - Dependency bumps across web/tui/landing: TypeScript 6, ESLint 10, react-router-dom 7, GitHub Actions group, @types/node, and lockfile regeneration to unblock CD (#3018, #3020, #3021, #3022, #3023, #3024, #3025, #3028, #3039, #3050).
 
 ### Fixed
+
 - MCP sender spoof vulnerability and SSE CORS wildcard tightened (#2967, #2960, #3048).
 - MCP tool input fields now have length caps to prevent abuse (#2961, #3045).
 - Cron commands run in their own process group so they cannot accidentally signal-kill bcd (#2964, #3052).
@@ -866,6 +927,7 @@ one server-side accuracy fix.
 - Stale `RevealSection` import and vitals TODO removed from landing (#3043).
 
 ### Security
+
 - MCP sender spoof patched (#2967).
 - SSE CORS wildcard replaced with scoped allowlist (#2960).
 - MCP tool input length caps mitigate resource-exhaustion abuse (#2961).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,144 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4] - 2026-08-02
+
+App readiness. The surfaces that looked finished in 0.4.3 became real:
+Providers and Tools genuinely install, update, and report true versions;
+setup is Settings revealing itself section by section; external sign-in
+links work inside the desktop window; and the stubs that presented
+invented data as real are gone.
+
+### Added
+- **Progressive-disclosure setup.** Setup is the Settings page revealing
+  itself section by section as each one is satisfied — no separate
+  `/welcome` wizard, and a re-run icon replays the reveal without
+  blanking anything already configured (#3437).
+- **Agent orchestration over MCP.** Agents can `spawn_agent`,
+  `send_to_agent`, `stop_agent`, and `list_children`, each
+  permission-gated and role-checked (#3441).
+- **Agent guardrails.** `MaxCostUSD` and `StuckTimeoutMin` are enforced
+  for real — runaway agents auto-stop, stuck ones get flagged — instead
+  of being config that was only stored and displayed (#3439).
+- **Agent activity Timeline** tab, sourced from persisted lifecycle
+  events (#3443).
+- **GitHub two-way.** Outbound PR/issue comments and commit statuses via
+  the OAuth token, plus `GH_TOKEN`/`GITHUB_TOKEN` injection so `gh` and
+  `git` authenticate inside agents with no per-agent setup (#3445,
+  #3436).
+- **One-click sign-in.** A default GitHub OAuth client ships with the
+  binary (device flow, no secret) and Gmail's Google client is embedded
+  at build time, so both connect with zero setup (#3429, #3438).
+- **`mycel app scaffold`** generates an app/gateway plugin skeleton
+  (#3444, docs #3446, #3447).
+- **MCP health checks in `doctor`** (#3440).
+- **Unified header back/forward** control, replacing per-page back
+  buttons (#3434).
+
+### Changed
+- **Providers & Tools live in Settings** as a list-only section; the
+  standalone `/tools` page is gone and per-provider drill-down stays at
+  `/settings/providers/:name`. tmux is the recommended and default
+  runtime (#3431).
+- **Providers surface revamp** — real brand logos, a logo hero on the
+  detail page, descriptions, and a cleaner hierarchy in both themes
+  (#3450), on top of a comprehensive `ProviderDetail` with sign-in,
+  uninstall, models, and version/help commands (#3433).
+- **Docs** restructured for accuracy, with a PR docs-freshness check so
+  they can't silently drift again (#3430, #3432).
+
+### Fixed
+- **Providers/Tools actually work.** Install and update run for real via
+  streamed NDJSON instead of echoing a hint; versions render clean
+  (`v2.1.205`); CLI-tool detection no longer reports "0 CLI tools" (a
+  dropped `type` column); Claude installs with `npm -g`, not `npx`
+  (#3424, #3427, #3449).
+- **Desktop external links.** Wails never injects `BrowserOpenURL` into
+  the daemon's HTTP origin, so GitHub/Gmail sign-in links were dead in
+  the app window. External links now route through a loopback-only
+  `POST /api/system/open-url` that rejects non-http(s) schemes (#3448,
+  #3435).
+- **Apps showed only half your connected apps.** A stale hardcoded
+  prefix list hid messages from 14 of 28 apps; senders now resolve to
+  real identities (#3420).
+- **Honest numbers.** Insights no longer invents an 80/20 token split,
+  reports live resource usage, and the unrouted `CostsGlobal` view is
+  gone (#3421).
+- **Live feed.** Pause works for real, event coverage is complete,
+  permission rows resolve, and rows title themselves with the tool-call
+  description (#3419, #3426).
+- **Add MCP** resolves a real server definition instead of writing an
+  empty stanza that could never connect (#3422).
+- Browser back/forward behaves across the app, with no phantom pages
+  (#3425); Templates/Marketplace tell the truth about each other and the
+  boot splash has a stall fallback (#3418).
+- Accessibility sweep: touch targets, focus rings, label associations,
+  and keyboard-reachable controls (#3442).
+
+## [0.4.3] - 2026-08-02
+
+Craft and truth pass over the 0.4.0 platform: the Tools/Providers
+manager became real, Live started showing what agents are actually
+doing, and outbound messages started looking like the agent that sent
+them.
+
+### Added
+- **Agent identity everywhere.** A `whoami` MCP tool, a server-rendered
+  public AgentCharacter avatar, and real per-agent icons on outbound
+  Slack messages (#3408, #3395).
+- **Live activity for more providers** — codex and pi via transcript
+  tailing (#3404, #3400) — plus pinned running rows, expandable
+  history, and unified row controls (#3407).
+- **First-run setup wizard** and a branded daemon boot sequence with a
+  live readiness stream (#3384, #3396).
+- **Gmail app** (inbound + send via the Gmail API) and one-click
+  loopback OAuth for Gmail and GitHub connect (#3383, #3392).
+- **Real profile photos** for channels and senders (#3401), and
+  identity avatars across Apps (#3385).
+- **Agent Settings tab** with per-agent CPU/memory budgeting (#3391),
+  and a fleet default provider + model manager (#3389).
+- **Tools manager**: package-manager autodetect, per-provider
+  subcommands, working uninstall, streamed install (#3394, #3403).
+- **Direct messaging** to any contact via `<platform>:<id>` (#3380).
+
+### Changed
+- Settings slimmed and mirrored to the wizard, with setup folded in
+  (#3386); craft passes over Settings, Apps, and Notifications (#3387,
+  #3388, #3382).
+- Landing heroes replaced with live-recorded product motion (#3402).
+- Phase 2 design docs for the marketplace installer and templates as
+  bundles (#3399).
+
+### Fixed
+- Agent lifecycle events persist, so new agents have a timeline (#3397),
+  without double-persisting hook events (#3415).
+- The agent raw stream shows tool output and responses again (#3410).
+- `cpus`/`memory_mb` columns migrate onto existing databases — a
+  release blocker that put running agents at risk (#3393).
+- The agent Metrics "By model" panel reads real data (#3398).
+- `/settings/tools` remount loop, in-surface CLI install, and wizard
+  provider parity (#3390).
+- Stale `bc` MCP-server naming in user-facing surfaces (#3409); dev-only
+  `preferences.json · v3` badge removed from Settings (#3406).
+- Repo hygiene: stray binaries gitignored, dead component directories
+  dropped (#3417).
+
+### Security
+- `golang.org/x/image` bumped to v0.44.0, clearing 12 CodeQL alerts
+  (#3412).
+
+## [0.4.2] - 2026-07-31
+
+### Fixed
+- CD injects the release version into the desktop build, so packaged
+  apps no longer report a dev version (#3381).
+
+## [0.4.1] - 2026-07-31
+
+### Added
+- Message any contact directly via `<platform>:<id>`, without a
+  pre-existing channel (#3380).
+
 ## [0.4.0] - 2026-07-31
 
 The plugin era. mycel becomes a platform: every integration — the AI

--- a/server/handlers/tools_unified.go
+++ b/server/handlers/tools_unified.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/rpuneet/mycel/pkg/agent"
@@ -58,6 +59,38 @@ func truncVersion(ver string) string {
 	return ver
 }
 
+// looseVersionRe matches two-part versions with an optional qualifier, for
+// CLIs that never print a third component ("tmux 3.5a", "GNU Make 3.81").
+var looseVersionRe = regexp.MustCompile(`\d+\.\d+[A-Za-z0-9.+-]*`)
+
+// cliVersion reduces a `--version` banner to the version itself. Banners are
+// chatty and often multi-line ("aws-cli/2.36.14 Python/3.14.6 Darwin/...", GNU
+// Make's version followed by its license), so truncating the raw text left the
+// Tools table showing a sentence sliced mid-word.
+//
+// Lines are considered in order and the earliest one carrying any version wins,
+// because the version is what a CLI leads with. Preferring a full semver token
+// across the whole banner instead would mine later lines for junk: GNU Make
+// prints "GNU Make 3.81" and, six lines down, "built for i386-apple-darwin11.3.0"
+// — reporting make as 11.3.0.
+func cliVersion(out string) string {
+	lines := strings.Split(out, "\n")
+	for _, line := range lines {
+		if m := semverTokenRe.FindString(line); m != "" {
+			return m
+		}
+		if m := looseVersionRe.FindString(line); m != "" {
+			return m
+		}
+	}
+	for _, line := range lines {
+		if line = strings.TrimSpace(line); line != "" {
+			return truncVersion(line)
+		}
+	}
+	return ""
+}
+
 // resolveBinary extracts the binary name from a command string, falling back to name.
 func resolveBinary(command, name string) string {
 	bin := command
@@ -70,17 +103,20 @@ func resolveBinary(command, name string) string {
 	return bin
 }
 
-// runVersion runs a version command and returns the truncated output.
+// runVersion runs a version command and returns just the version it printed.
+// Output is read combined and parsed even on a non-zero exit, because some
+// CLIs report their version on stderr or fail a later check after printing it
+// (`docker --version` with the daemon down).
 func runVersion(ctx context.Context, versionCmd string) string {
 	parts := strings.Fields(versionCmd)
 	if len(parts) == 0 {
 		return ""
 	}
-	out, err := exec.CommandContext(ctx, parts[0], parts[1:]...).Output() //nolint:gosec // tool names from config
-	if err != nil {
+	out, err := exec.CommandContext(ctx, parts[0], parts[1:]...).CombinedOutput() //nolint:gosec // tool names from config
+	if err != nil && len(out) == 0 {
 		return ""
 	}
-	return truncVersion(string(out))
+	return cliVersion(string(out))
 }
 
 // resolveToolStatus determines a tool's status based on enabled state, type, and binary availability.

--- a/server/handlers/tools_unified_version_test.go
+++ b/server/handlers/tools_unified_version_test.go
@@ -1,0 +1,102 @@
+package handlers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCLIVersion covers the Tools table showing mangled version banners: the
+// old behavior truncated raw `--version` output at 80 characters, so `curl`
+// rendered as "curl 8.7.1 (x86_64-apple-darwin25.0) libcurl/8.7.1
+// (SecureTransport) LibreSSL/3." — a sentence cut mid-token. Banners below are
+// real output captured from a developer machine.
+func TestCLIVersion(t *testing.T) {
+	for _, tc := range []struct {
+		name, banner, want string
+	}{
+		{"aws", "aws-cli/2.36.14 Python/3.14.6 Darwin/25.5.0 source/arm64\n", "2.36.14"},
+		{"curl", "curl 8.7.1 (x86_64-apple-darwin25.0) libcurl/8.7.1 (SecureTransport) LibreSSL/3.3.6\n", "8.7.1"},
+		{"bun already bare", "1.3.6\n", "1.3.6"},
+		{"git", "git version 2.39.5\n", "2.39.5"},
+		{"go", "go version go1.24.2 darwin/arm64\n", "1.24.2"},
+		{"jq", "jq-1.7.1\n", "1.7.1"},
+		{"python", "Python 3.13.1\n", "3.13.1"},
+		{"docker with trailing build", "Docker version 27.3.1, build ce12230\n", "27.3.1"},
+		{"node", "v22.14.0\n", "22.14.0"},
+		// Two-part versions have no semver token; keep the version, not the banner.
+		{"tmux", "tmux 3.5a\n", "3.5a"},
+		// The full macOS banner: a later line carries "darwin11.3.0", which must
+		// not outrank the two-part version make actually leads with.
+		{
+			"gnu make full banner",
+			"GNU Make 3.81\n" +
+				"Copyright (C) 2006  Free Software Foundation, Inc.\n" +
+				"This is free software; see the source for copying conditions.\n" +
+				"There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A\n" +
+				"PARTICULAR PURPOSE.\n\n" +
+				"This program built for i386-apple-darwin11.3.0\n",
+			"3.81",
+		},
+		// A warning ahead of the version must not become the answer.
+		{"warning precedes version", "warning: config is deprecated\nmytool 1.4.2\n", "1.4.2"},
+		{"no version at all falls back to first line", "unknown build\n", "unknown build"},
+		{"blank", "\n\n", ""},
+		{"empty", "", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cliVersion(tc.banner); got != tc.want {
+				t.Errorf("cliVersion(%q) = %q, want %q", tc.banner, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCLIVersionNeverExceedsMaxLen: the fallback path still has to respect the
+// response's version budget.
+func TestCLIVersionNeverExceedsMaxLen(t *testing.T) {
+	long := ""
+	for i := 0; i < 40; i++ {
+		long += "verbose-banner-"
+	}
+	if got := cliVersion(long); len(got) > maxVersionLen {
+		t.Errorf("cliVersion returned %d chars, want <= %d", len(got), maxVersionLen)
+	}
+}
+
+// writeStub creates an executable printing the given script body.
+func writeStub(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stub-cli")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o700); err != nil { //nolint:gosec // test fixture must be executable
+		t.Fatalf("write stub: %v", err)
+	}
+	return path
+}
+
+// TestRunVersionReadsStderrAndNonZeroExit: CLIs that print their version to
+// stderr, or print it and then fail a later check (`docker --version` with the
+// daemon down), previously reported no version at all.
+func TestRunVersionReadsStderrAndNonZeroExit(t *testing.T) {
+	ctx := context.Background()
+
+	stderrOnly := writeStub(t, "echo 'mytool 2.5.1' >&2\n")
+	if got := runVersion(ctx, stderrOnly+" --version"); got != "2.5.1" {
+		t.Errorf("stderr-only version = %q, want %q", got, "2.5.1")
+	}
+
+	printsThenFails := writeStub(t, "echo 'mytool 3.1.4'\nexit 1\n")
+	if got := runVersion(ctx, printsThenFails+" --version"); got != "3.1.4" {
+		t.Errorf("non-zero-exit version = %q, want %q", got, "3.1.4")
+	}
+
+	silentFailure := writeStub(t, "exit 1\n")
+	if got := runVersion(ctx, silentFailure+" --version"); got != "" {
+		t.Errorf("silent failure version = %q, want empty", got)
+	}
+
+	if got := runVersion(ctx, ""); got != "" {
+		t.Errorf("empty command version = %q, want empty", got)
+	}
+}

--- a/web/src/settings/ProvidersToolsSection.tsx
+++ b/web/src/settings/ProvidersToolsSection.tsx
@@ -281,7 +281,9 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
         <td className="px-4 py-2.5 text-sm">
           <span className="inline-flex items-center gap-1.5">
             <span className={`w-2 h-2 rounded-full ${cfg.dot}`} />
-            <span className={`text-xs ${cfg.textColor}`}>{tool.version || cfg.label}</span>
+            {/* The status label, not the version — Version is its own column
+                right beside this one. */}
+            <span className={`text-xs ${cfg.textColor}`}>{cfg.label}</span>
           </span>
         </td>
         <td className="px-4 py-2.5 text-xs text-mycel-muted font-mono max-w-[180px] truncate" title={tool.version || ""}>{tool.version || "—"}</td>

--- a/web/src/settings/useProgressiveReveal.ts
+++ b/web/src/settings/useProgressiveReveal.ts
@@ -16,9 +16,10 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { api, type SettingsConfig } from "../api/client";
 import { useReadiness } from "../hooks/useReadiness";
 
-/** Reveal order mirrors the Settings section order. "advanced" is
- *  deliberately excluded — it is never gated. */
-export const REVEAL_ORDER = ["profile", "runtime", "providers & tools", "apps", "budgets"] as const;
+/** Reveal order mirrors the Settings section order, so the guided reveal
+ *  always walks top-down: the "active" card is never below a locked one.
+ *  "advanced" is deliberately excluded — it is never gated. */
+export const REVEAL_ORDER = ["profile", "providers & tools", "runtime", "apps", "budgets"] as const;
 export type RevealSectionId = (typeof REVEAL_ORDER)[number];
 
 export type RevealState = "locked" | "active" | "complete";
@@ -117,16 +118,19 @@ export function useProgressiveReveal(
       for (const id of REVEAL_ORDER) result[id] = "complete";
       return result;
     }
+    // A section that is already satisfied is never locked, wherever it
+    // sits in the order: locking it would hide real, reachable config
+    // behind a padlock (e.g. providers & tools with a CLI already
+    // installed, or budgets, which is optional and always complete).
+    // Only *unsatisfied* sections after the first one are gated.
     let seenIncomplete = false;
     for (const id of REVEAL_ORDER) {
-      if (seenIncomplete) {
-        result[id] = "locked";
-      } else if (complete[id]) {
+      if (complete[id]) {
         result[id] = "complete";
-      } else {
-        result[id] = "active";
-        seenIncomplete = true;
+        continue;
       }
+      result[id] = seenIncomplete ? "locked" : "active";
+      seenIncomplete = true;
     }
     return result;
   }, [loaded, allComplete, complete]);

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -971,7 +971,10 @@ function StatTile({ label, value, icon, accent }: { label: string; value: string
 
 /* ── StatBar (4 tiles) ── */
 function StatBar({ provider }: { provider: ProviderDetailResponse }) {
-  const models = provider.cost_by_model ?? [];
+  // Models that actually billed — not the provider's curated model list,
+  // which the Models section counts. Two different numbers, so this tile
+  // says "used" rather than contradicting that heading.
+  const billedModels = provider.cost_by_model ?? [];
   return (
     <div className="grid grid-cols-2 gap-3">
       <StatTile
@@ -1003,8 +1006,8 @@ function StatBar({ provider }: { provider: ProviderDetailResponse }) {
         }
       />
       <StatTile
-        label="Models"
-        value={String(models.length)}
+        label="Models used"
+        value={String(billedModels.length)}
         icon={
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z" />

--- a/web/src/views/__tests__/ProviderDetail.test.tsx
+++ b/web/src/views/__tests__/ProviderDetail.test.tsx
@@ -242,6 +242,32 @@ describe("ProviderDetail models", () => {
 
     await waitFor(() => expect(screen.getByText("No models")).toBeTruthy());
   });
+
+  it("labels the billed-model tile distinctly from the curated model list", async () => {
+    // The stat tile counts models that actually billed (cost_by_model),
+    // the Models section counts the curated list. They legitimately differ,
+    // so the tile must not also be called plain "Models".
+    renderDetail(
+      baseProvider({
+        installed: true,
+        status: "healthy",
+        models: [
+          { id: "gpt-5-codex", available: true },
+          { id: "gpt-5-mini", available: false },
+        ],
+        cost_by_model: [
+          { model: "gpt-5-codex", total_cost_usd: 1, total_tokens: 10 },
+          { model: "gpt-5-mini", total_cost_usd: 2, total_tokens: 20 },
+          { model: "gpt-5-legacy", total_cost_usd: 3, total_tokens: 30 },
+        ],
+      }),
+    );
+
+    // The tile reports the 3 billed models under its own label, so it no
+    // longer contradicts the "Models 2" curated-list heading beside it.
+    const tile = await screen.findByText("Models used");
+    expect(tile.closest("div")?.parentElement?.textContent).toContain("3");
+  });
 });
 
 describe("ProviderDetail sign-in", () => {

--- a/web/src/views/__tests__/Tools.test.tsx
+++ b/web/src/views/__tests__/Tools.test.tsx
@@ -70,6 +70,32 @@ function renderSection() {
   );
 }
 
+describe("ProvidersToolsSection CLI tools table", () => {
+  it("shows the status in Status and the version in Version, not the version twice", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u === "/api/providers") return jsonResponse([]);
+      if (u === "/api/tools/unified") {
+        return jsonResponse([{ name: "git", type: "cli", status: "installed", version: "2.50.1", required: false }]);
+      }
+      if (u === "/api/system/package-managers") return jsonResponse({ os: "darwin", arch: "arm64", managers: [] });
+      return jsonResponse({});
+    });
+
+    render(
+      <MemoryRouter>
+        <ProvidersToolsSection />
+      </MemoryRouter>,
+    );
+
+    const nameCell = await screen.findByText("git");
+    const cells = Array.from(nameCell.closest("tr")!.querySelectorAll("td")).map((td) => td.textContent?.trim());
+    // Tool | Status | Version | Required | Actions
+    expect(cells[1]).toBe("Installed");
+    expect(cells[2]).toBe("2.50.1");
+  });
+});
+
 describe("ProvidersToolsSection providers list", () => {
   it("renders providers as a list/table with no card/grid view toggle", async () => {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {

--- a/web/src/views/__tests__/settings.test.tsx
+++ b/web/src/views/__tests__/settings.test.tsx
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor, fireEvent, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { Settings } from "../Settings";
+import { REVEAL_ORDER } from "../../settings/useProgressiveReveal";
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
 
@@ -147,6 +148,42 @@ describe("Settings redesign", () => {
     // Even with an unfinished reveal, a live fleet means done.
     await waitFor(() => expect(screen.getAllByText(/Complete/).length).toBeGreaterThan(0));
     expect(screen.getByRole("button", { name: /re-run setup/i })).toBeInTheDocument();
+  });
+
+  it("never locks a section that is already satisfied", async () => {
+    // Profile has no name, so setup is genuinely unfinished — but a provider
+    // is installed, so "providers & tools" is satisfied and must stay
+    // reachable. Locking it would hide real config (and the optional
+    // budgets section) behind a padlock on a first run.
+    mockApi({
+      settings: { ...SETTINGS, user: { name: "" }, onboarding: { step: "", completed: [] } },
+      onboarding: { firstRun: true, hasAgents: false, prefsValid: true, completed: [], step: "" },
+    });
+    renderSettings();
+
+    await waitFor(() =>
+      expect(screen.getByText("profile").closest("[data-reveal]")).toHaveAttribute("data-reveal", "active"),
+    );
+    expect(screen.getByText("providers & tools").closest("[data-reveal]")).toHaveAttribute("data-reveal", "complete");
+    expect(screen.getByText("budgets").closest("[data-reveal]")).toHaveAttribute("data-reveal", "complete");
+    // Satisfied means usable: the body mounted, so the provider row renders.
+    expect(await screen.findByText("claude")).toBeInTheDocument();
+    // Sections that genuinely aren't done yet still gate behind profile.
+    expect(screen.getByText("runtime").closest("[data-reveal]")).toHaveAttribute("data-reveal", "locked");
+  });
+
+  it("walks the reveal top-down — gated sections match the rendered order", async () => {
+    mockApi();
+    const { container } = renderSettings();
+    await screen.findByText("budgets");
+
+    const rendered = Array.from(container.querySelectorAll<HTMLElement>("[data-reveal]")).map(
+      (card) => card.querySelector("button")?.textContent ?? "",
+    );
+    const positions = REVEAL_ORDER.map((id) => rendered.findIndex((text) => text.startsWith(id)));
+    expect(positions).not.toContain(-1);
+    // Ascending — otherwise the "active" card can land below a locked one.
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
   });
 
   it("the re-run icon clears onboarding.completed without touching other config", async () => {


### PR DESCRIPTION
Part of #3423

Found while independently verifying release readiness for v0.4.4 against a build of latest `main`, driving the real UI in a browser rather than trusting the tracker's checkboxes. Four genuine user-visible bugs, each verified live before and after.

## 1. Progressive-disclosure setup locked sections that were already satisfied

`useProgressiveReveal` marked *every* section after the first incomplete one as `locked`, even when that section's own predicate said it was complete. On a first run where a provider CLI is already installed (the common case), the reveal computed:

| card | actually satisfied? | rendered as |
|---|---|---|
| profile | no (no name yet) | active |
| providers & tools | **yes** (provider installed) | **locked** |
| runtime | no | locked |
| apps | no | locked |
| budgets | **yes** (optional, always complete) | **locked** |

Locked sections never mount their body, so real, reachable config sat behind a padlock until the user typed a name into Profile. Reproduced on a clean `MYCEL_HOME`: the Setup card read "2 of 5 sections done" while both satisfied sections showed Locked.

**Also:** `REVEAL_ORDER` listed `runtime` before `providers & tools`; Settings renders them the other way round, so the guided "active" card could sit *below* a locked one — despite the comment claiming the two orders mirrored each other. The new test pins it: unfixed code yields positions `[0, 2, 1, 3, 4]`.

Fix: only lock sections that are genuinely outstanding, and align the reveal order with the rendered order.

## 2. Tool versions were sliced `--version` banners

`runVersion` truncated raw banner output at 80 characters, so the Tools table showed sentences cut mid-token inside a 180px column that truncated them again:

```
aws    aws-cli/2.36.14 Python/3.14.6 Darwin/25.5.0 source/arm64
curl   curl 8.7.1 (x86_64-apple-darwin25.0) libcurl/8.7.1 (SecureTransport) LibreSSL/3.
```

Only CLIs that happen to print a bare version (bun, node) looked right. Now the version is extracted, reusing the same `semverTokenRe` the provider surface already normalizes with, plus a two-part pattern for CLIs that never print a third component.

Lines are considered in order and the earliest version wins, rather than preferring a full semver token anywhere in the banner — GNU Make prints `GNU Make 3.81` and, six lines later, `built for i386-apple-darwin11.3.0`, so a whole-banner preference reports make as **11.3.0**. I hit exactly that bug in my first attempt and caught it by diffing against real output; the test now uses make's complete banner.

Version output is also read combined and parsed on non-zero exit, so CLIs that print to stderr — or print and then fail a later check, like `docker --version` with the daemon down — stop reporting nothing.

Verified live, all 12 detected tools against their own banners:

```
aws 2.36.14 · bun 1.3.6 · curl 8.7.1 · docker 29.1.3 · gh 2.83.1 · git 2.50.1
go 1.25.12 · jq 1.7.1 · make 3.81 · node 26.4.0 · python3 3.14.6 · tmux 3.5a
```

## 3. The Status column printed the version

The CLI tools row rendered `tool.version || cfg.label` in its **Status** cell, so any tool reporting a version showed that version twice — beside the status dot and again in the Version column next to it — while the status word ("Installed") never appeared. It survived because the only fixture in the tests is a `not_installed` tool, which has no version and so fell through to the label.

## 4. `CHANGELOG.md` stopped at 0.4.0

0.4.1, 0.4.2 and 0.4.3 shipped with no entry and `[Unreleased]` was empty going into 0.4.4. Backfilled all four from the commits in each tag range.

## Test plan

- [x] 6 new tests. Each verified to **fail** against the unfixed code and pass after — including the `[0,2,1,3,4]` ordering assertion and `expected '2.50.1' to be 'Installed'`.
- [x] `bun run test` — 50 files, 421 tests pass. `bunx tsc -b --noEmit` and `bun run lint` clean.
- [x] `go test ./...` full suite passes; `go vet ./...` clean; `golangci-lint run ./server/...` 0 issues.
- [x] Verified in a browser against a live daemon running this branch, with real fleet data: satisfied sections open, Status reads "Installed", versions match ground truth.

No behaviour was removed — the guided flow still gates unfinished work, and the full banner is still what gets parsed rather than discarded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved onboarding progression so completed settings remain accessible while unfinished sections unlock in the correct order.
  * CLI tool detection now recognizes versions from standard output, error output, and common banner formats.
* **Bug Fixes**
  * Clarified provider statistics by labeling billed-model counts as “Models used.”
  * Corrected CLI tools tables so status and version appear in their respective columns.
* **Documentation**
  * Added changelog entries covering recent releases, updates, fixes, security improvements, and packaging changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->