### PR TITLE
ci: make the documented release path work — allowlist known-safe gitleaks history findings

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,34 @@
+# Known-safe gitleaks findings, allowlisted by fingerprint.
+#
+# Why this file exists: on pull_request and push events the gitleaks action
+# scans only the pushed commits, but on workflow_dispatch it scans the whole
+# repository history. That made the documented "Actions -> Release -> Run
+# workflow" path fail the Security gate every time while tag-push releases
+# passed, because these findings live in history and cannot be edited out of
+# it without a rewrite.
+#
+# Each entry below was inspected individually. None is a live credential.
+# Fingerprints are commit:file:rule:startline — an entry stops applying if the
+# secret ever moves or changes, so a genuine new leak in these files still fails.
+
+# server/ws/redact_test.go — fixtures for RedactSecrets(). These tests exist to
+# prove tokens get scrubbed, so they must contain token-shaped strings. The
+# values are synthetic (line 20 is a literal A-Z alphabet) and the file is
+# already annotated //nolint:gosec // test fixture data.
+db272a3894bd374560e37a5e80ccd4bfec02a85e:server/ws/redact_test.go:github-fine-grained-pat:9
+cbeca3b6439242c727092570a721934ef1b3c081:server/ws/redact_test.go:github-fine-grained-pat:9
+7598f146c647d6c6cd870f0eadead742fbeabf4f:server/ws/redact_test.go:github-fine-grained-pat:9
+6687c799a252d24375aa698569116049c65b5e52:server/ws/redact_test.go:github-fine-grained-pat:9
+6687c799a252d24375aa698569116049c65b5e52:server/ws/redact_test.go:github-pat:20
+7598f146c647d6c6cd870f0eadead742fbeabf4f:server/ws/redact_test.go:github-pat:20
+
+# landing/src/app/layout.tsx — Cloudflare Web Analytics beacon token in a
+# data-cf-beacon attribute. These are public by design: the value ships in the
+# HTML of every page and is visible to any visitor. It identifies a site, it
+# does not authenticate anything.
+afdb3acd24986762118f51701ae4babec37adb65:landing/src/app/layout.tsx:generic-api-key:86
+56d0ce47b8ee12b34429f4b8359e7a61848a0550:landing/src/app/layout.tsx:generic-api-key:86
+
+# internal/tui/queueitem_test.go — a padded display string in a TUI queue-item
+# test, matched by the generic-api-key heuristic on entropy alone.
+0f4fdf6d06281221e38c5cd65fad8a63297beb46:internal/tui/queueitem_test.go:generic-api-key:65

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,26 +268,57 @@ Open an issue or discussion on GitHub.
 
 ## Releasing
 
-Releases are cut manually via GitHub Actions. CI/CD is fully automated from tag onwards.
+Releases are cut manually by pushing a tag. Everything from the tag onwards —
+CI, builds for every platform, the GitHub release, Homebrew and the SBOM — is
+automated.
 
 ### Steps
 
 1. Ensure `main` is green. Check https://github.com/rpuneet/mycel/actions/workflows/ci.yml
-2. Go to **Actions → Release → Run workflow**
-3. Enter version in semver format: `vMAJOR.MINOR.PATCH` (e.g. `v0.4.4`)
-   - Alpha/RC allowed: `v0.5.0-alpha`, `v1.0.0-rc.1`
-4. Click **Run workflow**
+2. Tag the commit you want to ship and push the tag:
+
+   ```bash
+   git tag -a v0.4.4 -m "v0.4.4"
+   git push origin v0.4.4
+   ```
+
+   Use semver: `vMAJOR.MINOR.PATCH`. Alpha/RC allowed: `v0.5.0-alpha`, `v1.0.0-rc.1`.
+
+Pushing the tag is what triggers the release. **Actions → Release → Run workflow**
+also works and tags for you, but push the tag by hand when you want the released
+artifacts to come from a specific commit you have already verified.
+
+> **If you use Run workflow and it fails at the Security gate:** the `Prepare` job
+> creates and pushes the tag *before* CI runs, so a later failure leaves a tag with
+> no release attached. Because that tag was pushed by `GITHUB_TOKEN` it does not
+> trigger a workflow run of its own. Delete and re-push it from your own account to
+> start a real release from the same commit:
+>
+> ```bash
+> git push origin :refs/tags/v0.4.4
+> git tag -a v0.4.4 <sha> -m "v0.4.4" && git push origin v0.4.4
+> ```
 
 ### What happens
 
-The release workflow:
+The release workflow (`.github/workflows/release.yml`):
 
-1. **Prepare** — validates version format, creates and pushes git tag
-2. **CI** — full test suite (lint, test, web, landing, build gate, security, container scan)
-3. **Release Linux** — GoReleaser builds `linux/amd64`, creates archive + checksums, publishes GitHub release
-4. **Release macOS** — Native CGO builds for `darwin/amd64` and `darwin/arm64`, uploads to release
-5. **Release Docker** — Pushes `ghcr.io/rpuneet/mycel:<version>` and `:latest` to GHCR
-6. **SBOM** — Generates and uploads `sbom.spdx.json` to release
+1. **Prepare** — validates version format; creates and pushes the git tag when
+   started via **Run workflow** (on a tag push the tag already exists)
+2. **CI** — full suite: lint, test, test (full), web, landing, build gate, security
+3. **Release Linux + Windows** — GoReleaser builds `linux/{amd64,arm64}` and
+   `windows/{amd64,arm64}`, plus `.deb` and `.rpm` packages, and publishes the
+   GitHub release with `checksums.txt`
+4. **Release macOS** — native CGO builds for `darwin/amd64` and `darwin/arm64`,
+   uploaded with `checksums-macos.txt`
+5. **Release Desktop** — Wails desktop app for macOS, Linux and Windows
+6. **Update Homebrew Formula** — see below
+7. **SBOM** — generates and uploads `sbom.spdx.json`
+
+Docker images are **not** built here. `cd-main.yml` publishes
+`ghcr.io/rpuneet/mycel:main` and `:main-<sha>` on every merge to `main`, so there
+is no `:<version>` image per release — see
+[Continuous deployment](#continuous-deployment).
 
 ### Homebrew tap publish
 


### PR DESCRIPTION
The documented release path does not work, and it never has. Found the hard way while cutting v0.4.4.

## What happens today

| release run | trigger | Security gate |
|---|---|---|
| v0.4.1 | tag push | pass |
| v0.4.2 | tag push | pass |
| v0.4.3 | tag push | pass |
| 31 Jul | `workflow_dispatch` | **fail** |
| 2 Aug (v0.4.4, 1st attempt) | `workflow_dispatch` | **fail** |

`CONTRIBUTING.md` tells you to use **Actions → Release → Run workflow**. That is `workflow_dispatch`, and it has failed every time it has been used. Every release that actually shipped went out via a tag push instead. When Security fails it gates every publish job, so nothing is released — but `Prepare` has already created and pushed the tag by then, leaving an orphaned tag with no release. Because that tag is pushed by `GITHUB_TOKEN` it does not trigger a workflow of its own, so the release cannot simply retry itself.

## Why it fails

Scan scope, not a real secret. The gitleaks action scans only the pushed commits on `pull_request` and `push`, but on `workflow_dispatch` it runs a full-history `detect` — 4,409 commits here — and finds 9 hits in old commits.

I inspected all 9. None is a live credential:

- **`server/ws/redact_test.go`** (6 hits) — fixtures for `RedactSecrets()`. These tests exist to prove tokens get scrubbed, so they have to contain token-shaped strings. The values are synthetic; line 20 is a literal `ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl`. The file is already annotated `//nolint:gosec // test fixture data`.
- **`landing/src/app/layout.tsx`** (2 hits) — a Cloudflare Web Analytics `data-cf-beacon` token. Public by design: it ships in the HTML of every page and is visible to any visitor. It identifies a site, it does not authenticate anything.
- **`internal/tui/queueitem_test.go`** (1 hit) — a padded display string matched by the `generic-api-key` entropy heuristic.

They are in history, so they cannot be edited out without rewriting it.

## The fix

`.gitleaksignore` allowlisting those 9 by fingerprint (`commit:file:rule:startline`). Deliberately **not** disabling the scan, muting the rules, or adding path excludes — a fingerprint stops applying the moment the secret moves or changes, so a genuine new leak in these same files still fails the build.

Note CI runs gitleaks 8.24.3, which reports 9; 8.30.1 reports 7 (it no longer flags the two `github-pat` hits at line 20). The allowlist covers the union, so it works on both.

## Docs

The release section had drifted from reality on four counts, all corrected:

- Described a **Release Docker** job publishing `ghcr.io/rpuneet/mycel:<version>` and `:latest`. No such job exists in `release.yml`. GHCR is published from `cd-main.yml` as `:main` and `:main-<sha>`, so there is no per-version image at all.
- Said **Release Linux** builds `linux/amd64`. GoReleaser also builds `linux/arm64`, `windows/{amd64,arm64}`, `.deb` and `.rpm`.
- Omitted the **Release Desktop** and **Update Homebrew Formula** jobs entirely.
- Gave no tag-push recipe, despite that being the only path that has ever worked.

Also documented how to recover the orphaned tag, since anyone hitting the dispatch failure before this merges will need it.

## Test plan

- [x] Full-history scan with the allowlist: `4409 commits scanned` → **no leaks found** (was 7 locally / 9 in CI)
- [x] Planted a fresh correctly-formed `ghp_` token and confirmed it is **still caught** (`github-pat leak_probe.go:3`), proving the allowlist is not a blanket disable
- [x] Every fingerprint traced to its commit and the surrounding code read before allowlisting
- [ ] Real proof lands with the next release: `workflow_dispatch` should reach the publish jobs

Part of #3423
