### PR TITLE
test(handlers): assert the version fallback's value, not just its length

### DIFF
--- a/server/handlers/tools_unified_version_test.go
+++ b/server/handlers/tools_unified_version_test.go
@@ -54,14 +54,22 @@ func TestCLIVersion(t *testing.T) {
 }
 
 // TestCLIVersionNeverExceedsMaxLen: the fallback path still has to respect the
-// response's version budget.
+// response's version budget. The banner carries no digits, so no version token
+// matches and cliVersion falls through to the first non-empty line.
 func TestCLIVersionNeverExceedsMaxLen(t *testing.T) {
 	long := ""
 	for i := 0; i < 40; i++ {
 		long += "verbose-banner-"
 	}
-	if got := cliVersion(long); len(got) > maxVersionLen {
-		t.Errorf("cliVersion returned %d chars, want <= %d", len(got), maxVersionLen)
+	got := cliVersion(long)
+	// Assert the value, not just its length: a length-only check also passes
+	// when the fallback returns nothing at all.
+	if want := truncVersion(long); got != want {
+		t.Errorf("cliVersion() = %q, want %q", got, want)
+	}
+	if len(got) != maxVersionLen {
+		t.Errorf("fallback returned %d chars for a %d-char banner, want exactly %d",
+			len(got), len(long), maxVersionLen)
 	}
 }
 


### PR DESCRIPTION
Addresses the second review comment on #3451, which I resolved without acting on — I ran `@coderabbitai resolve` to clear the changelog thread and that dismissed this one too. It was a valid point, so here it is.

## The problem

`TestCLIVersionNeverExceedsMaxLen` asserted only a length bound:

```go
if got := cliVersion(long); len(got) > maxVersionLen {
```

`len("") > 80` is false, so the test passed whether `cliVersion` truncated correctly or returned nothing at all. It could not distinguish a working fallback from a broken one — the same class of weak assertion that let the Status-column bug in #3451 survive, where the only fixture was an uninstalled tool.

## The fix

Assert the value, and that truncation actually happened:

```go
got := cliVersion(long)
if want := truncVersion(long); got != want { ... }
if len(got) != maxVersionLen { ... }
```

The 600-char banner contains no digits, so no version token matches and `cliVersion` falls through to its first-non-empty-line path — which must come back cut to exactly 80 characters.

## Test plan

- [x] Passes against current code: `ok github.com/rpuneet/mycel/server/handlers`
- [x] **Proved it is stronger.** Sabotaged the fallback to `return ""` and re-ran:

  ```
  --- FAIL: TestCLIVersionNeverExceedsMaxLen
      cliVersion() = "", want "verbose-banner-verbose-banner-...verbo"
      fallback returned 0 chars for a 600-char banner, want exactly 80
  ```

  The previous assertion passed against that same sabotage. `tools_unified.go` was restored afterwards and is untouched by this PR.
- [x] Full `./server/handlers` package passes, `go vet` clean, `golangci-lint` 0 issues

Note CodeRabbit's suggested diff referenced `truncVersion`, which does still exist and is exactly the right helper here, so the suggestion needed no adaptation beyond adding the length check.

Part of #3423


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened validation for CLI version fallback output.
  * Confirmed fallback versions are non-empty, correctly truncated, and match the maximum allowed length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->