### PR TITLE
fix(gmail,notify): stop notification mail from waking every agent

### DIFF
--- a/docs/explanation/notifications.md
+++ b/docs/explanation/notifications.md
@@ -559,7 +559,9 @@ flowchart TD
     B --> C[Manager dispatches in goroutine]
     C --> D["notify.Service.Dispatch()"]
     D --> E[Save message to notification_log]
-    D --> F[Load subscribers from subscriptions]
+    D --> R{Automated event?}
+    R -->|Yes| S[Feed and SSE only -- no agent woken]
+    R -->|No| F[Load subscribers from subscriptions]
     D --> G["Extract @mentions from content"]
 
     F --> H{For each subscriber}
@@ -577,6 +579,29 @@ flowchart TD
     D --> P[Publish gateway.message to SSE hub]
     D --> Q[Prune old delivery log entries]
 ```
+
+**Automated events** are machine-generated messages that no human is waiting on a
+reply to: GitHub notification mail, newsletters, bounces, out-of-office replies.
+They are saved to the channel feed and published to the web UI like any other
+message, but no subscribed agent is woken for them -- prompting every subscriber
+costs real tokens on a message that cannot be answered.
+
+Adapters decide what qualifies and pass `notify.Automated()` on dispatch. The
+Gmail adapter classifies from standard mail headers rather than address-name
+guesses, preferring the sender's own declaration:
+
+| Signal | Meaning |
+|--------|---------|
+| `Auto-Submitted` other than `no` (RFC 3834) | Sender declares the message was generated automatically |
+| `X-Auto-Response-Suppress` | Only ever set by automated systems |
+| `Precedence: bulk` or `junk` | Bulk mailing rather than a message to you |
+| `List-Unsubscribe` | Mailing to many recipients |
+| No-reply local part (`noreply@`, `notifications@`, `mailer-daemon@`, ...) | Address cannot receive a reply |
+
+Deliberately excluded: `Precedence: list` and `List-Id` on their own, because
+genuine team discussion lists set them, and human-staffed role addresses such as
+`support@` or `info@`. Filtered mail stays visible in the channel, so a
+misclassification hides nothing -- it only means no agent was woken.
 
 **Self-skip** prevents agents from receiving their own messages echoed back by the platform. Each adapter extracts the sender with a single field lookup (`event.User` for Slack, `message.From.UserName` for Telegram, `message.Author.ID` for Discord). The `[platform] ` prefix is stripped before comparison.
 

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -63,6 +63,11 @@ type Notification struct {
 	Content      string          `json:"content"`                 // human-readable text for display/storage
 	MessageID    string          `json:"message_id,omitempty"`    // platform-native message id (for reactions, threading)
 	Mentions     []string        `json:"mentions"`
+	// Automated marks machine-generated events that no human is waiting on a
+	// reply to — notification mail, newsletters, bounces. Adapters set it;
+	// the notify layer ingests such events into the channel feed but does not
+	// wake subscribed agents for them.
+	Automated bool `json:"automated,omitempty"`
 }
 
 // ChannelInfo represents a discovered channel on a platform.

--- a/pkg/gateway/gmail/automated.go
+++ b/pkg/gateway/gmail/automated.go
@@ -1,0 +1,117 @@
+package gmailgw
+
+import "strings"
+
+// Machine-generated mail — GitHub notifications, newsletters, bank alerts,
+// bounces — arrives on the same poll as human mail, but replying to it is
+// pointless and waking every subscribed agent for it is expensive. The
+// adapter classifies each message so the notify layer can ingest it into the
+// channel feed without prompting agents.
+//
+// Classification prefers standard headers over address-name guesses: a
+// sender's local part is a heuristic, whereas Auto-Submitted and Precedence
+// are the sender declaring its own intent.
+
+// automatedHeaders are the headers fetched purely for classification, on top
+// of the display headers parseMessage needs.
+var automatedHeaders = []string{
+	"Auto-Submitted",
+	"Precedence",
+	"List-Unsubscribe",
+	"X-Auto-Response-Suppress",
+}
+
+// noReplyLocalParts are address local parts that never belong to a human
+// mailbox. Deliberately conservative: role addresses like support@, info@ and
+// alerts@ are frequently human-staffed, so they are not listed here.
+var noReplyLocalParts = []string{
+	"noreply",
+	"no-reply",
+	"no_reply",
+	"no.reply",
+	"donotreply",
+	"do-not-reply",
+	"do_not_reply",
+	"notification",
+	"notifications",
+	"mailer-daemon",
+	"postmaster",
+	"bounce",
+	"bounces",
+	"autoreply",
+	"auto-reply",
+}
+
+// bulkPrecedence are Precedence values that mark mail as bulk-sent rather
+// than a person writing to you. "list" is excluded on purpose — genuine team
+// discussion lists (Google Groups and similar) set it, and those are
+// conversations agents should still see.
+var bulkPrecedence = []string{"bulk", "junk"}
+
+// classifyAutomated reports whether a message is machine-generated, plus a
+// short human-readable reason for logs and the stored payload. The reason
+// names the signal that fired so an operator can tell a header declaration
+// from a local-part guess when a message unexpectedly skips agent delivery.
+func classifyAutomated(from string, headers map[string]string) (bool, string) {
+	// RFC 3834: any value other than "no" means the message was generated
+	// automatically. GitHub sets "auto-generated" on notification mail.
+	if v := headerValue(headers, "Auto-Submitted"); v != "" && v != "no" {
+		return true, "auto-submitted: " + v
+	}
+
+	// RFC 3834 §5 suppression hints are only ever set by automated systems.
+	if headerValue(headers, "X-Auto-Response-Suppress") != "" {
+		return true, "x-auto-response-suppress"
+	}
+
+	if v := headerValue(headers, "Precedence"); v != "" {
+		for _, p := range bulkPrecedence {
+			if v == p {
+				return true, "precedence: " + p
+			}
+		}
+	}
+
+	// Anything offering a machine-readable unsubscribe is a mailing to many
+	// recipients, not a message written to this mailbox.
+	if headerValue(headers, "List-Unsubscribe") != "" {
+		return true, "list-unsubscribe"
+	}
+
+	if local := localPart(from); local != "" {
+		for _, np := range noReplyLocalParts {
+			// Exact match, or a prefixed/suffixed variant such as
+			// "github-noreply" or "noreply-bounces".
+			if local == np || strings.HasPrefix(local, np+"-") || strings.HasSuffix(local, "-"+np) {
+				return true, "no-reply sender: " + local
+			}
+		}
+	}
+
+	return false, ""
+}
+
+// headerValue looks up a header case-insensitively and returns it lowercased
+// and trimmed, ready for comparison.
+func headerValue(headers map[string]string, name string) string {
+	if headers == nil {
+		return ""
+	}
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return strings.ToLower(strings.TrimSpace(v))
+		}
+	}
+	return ""
+}
+
+// localPart extracts the lowercased portion before "@" of a From header,
+// tolerating a display name around the address.
+func localPart(from string) string {
+	addr := extractEmail(from)
+	local, _, found := strings.Cut(addr, "@")
+	if !found {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(local))
+}

--- a/pkg/gateway/gmail/automated_test.go
+++ b/pkg/gateway/gmail/automated_test.go
@@ -1,0 +1,178 @@
+package gmailgw
+
+import (
+	"strings"
+	"testing"
+
+	gmail "google.golang.org/api/gmail/v1"
+)
+
+// TestClassifyAutomated covers the senders actually seen in a live mailbox.
+// The false cases matter as much as the true ones: a human writing from a
+// role address must still reach agents.
+func TestClassifyAutomated(t *testing.T) {
+	tests := []struct {
+		headers map[string]string
+		name    string
+		from    string
+		want    bool
+	}{
+		{
+			name:    "github notification",
+			from:    `"coderabbitai[bot]" <notifications@github.com>`,
+			headers: map[string]string{"Auto-Submitted": "auto-generated", "Precedence": "list"},
+			want:    true,
+		},
+		{
+			name:    "github notification without auto-submitted still caught by sender",
+			from:    "notifications@github.com",
+			headers: map[string]string{},
+			want:    true,
+		},
+		{
+			name:    "newsletter",
+			from:    "Market Wrap <wrap@news.example.com>",
+			headers: map[string]string{"Precedence": "bulk", "List-Unsubscribe": "<https://news.example.com/u/1>"},
+			want:    true,
+		},
+		{
+			name:    "bank alert from no-reply",
+			from:    "Example Bank <no-reply@examplebank.com>",
+			headers: map[string]string{},
+			want:    true,
+		},
+		{
+			name:    "vendor-prefixed noreply",
+			from:    "github-noreply@example.com",
+			headers: map[string]string{},
+			want:    true,
+		},
+		{
+			name:    "bounce",
+			from:    "MAILER-DAEMON@mx.example.com",
+			headers: map[string]string{},
+			want:    true,
+		},
+		{
+			name:    "out of office autoreply",
+			from:    "Colleague <colleague@example.com>",
+			headers: map[string]string{"Auto-Submitted": "auto-replied"},
+			want:    true,
+		},
+		{
+			name:    "corporate suppression hint",
+			from:    "hr-system@example.com",
+			headers: map[string]string{"X-Auto-Response-Suppress": "All"},
+			want:    true,
+		},
+		{
+			name:    "header lookup is case-insensitive",
+			from:    "someone@example.com",
+			headers: map[string]string{"list-unsubscribe": "<mailto:u@example.com>"},
+			want:    true,
+		},
+		{
+			name:    "plain human mail",
+			from:    "Puneet <puneet@example.com>",
+			headers: map[string]string{},
+			want:    false,
+		},
+		{
+			name:    "human mail explicitly marked not auto-submitted",
+			from:    "Puneet <puneet@example.com>",
+			headers: map[string]string{"Auto-Submitted": "no"},
+			want:    false,
+		},
+		{
+			name:    "human-staffed role address is not filtered",
+			from:    "Support <support@vendor.com>",
+			headers: map[string]string{},
+			want:    false,
+		},
+		{
+			name:    "team discussion list still reaches agents",
+			from:    "Colleague <colleague@example.com>",
+			headers: map[string]string{"Precedence": "list", "List-Id": "team <team.example.com>"},
+			want:    false,
+		},
+		{
+			name:    "no headers and no address",
+			from:    "",
+			headers: nil,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, reason := classifyAutomated(tt.from, tt.headers)
+			if got != tt.want {
+				t.Errorf("classifyAutomated(%q, %v) = %v (%q), want %v", tt.from, tt.headers, got, reason, tt.want)
+			}
+			// A positive verdict must explain itself — the reason is what an
+			// operator reads when mail unexpectedly skips agent delivery.
+			if got && strings.TrimSpace(reason) == "" {
+				t.Error("automated verdict returned an empty reason")
+			}
+			if !got && reason != "" {
+				t.Errorf("non-automated verdict returned reason %q", reason)
+			}
+		})
+	}
+}
+
+// TestParseMessageClassifiesAutomated proves the classification is wired into
+// the poll path, not just available as a helper.
+func TestParseMessageClassifiesAutomated(t *testing.T) {
+	m := &gmail.Message{
+		Id: "m1",
+		Payload: &gmail.MessagePart{
+			Headers: []*gmail.MessagePartHeader{
+				{Name: "From", Value: `"coderabbitai[bot]" <notifications@github.com>`},
+				{Name: "Subject", Value: "Re: approved this pull request"},
+				{Name: "Auto-Submitted", Value: "auto-generated"},
+			},
+		},
+	}
+	e := parseMessage(m)
+	if !e.Automated {
+		t.Error("GitHub notification mail should be marked automated")
+	}
+	if e.AutomatedReason == "" {
+		t.Error("automated mail should carry a reason for the logs")
+	}
+}
+
+func TestParseMessageHumanMailNotAutomated(t *testing.T) {
+	m := &gmail.Message{
+		Id: "m2",
+		Payload: &gmail.MessagePart{
+			Headers: []*gmail.MessagePartHeader{
+				{Name: "From", Value: "Puneet <puneet@example.com>"},
+				{Name: "Subject", Value: "ready for release"},
+			},
+		},
+	}
+	e := parseMessage(m)
+	if e.Automated {
+		t.Errorf("human mail marked automated: %q", e.AutomatedReason)
+	}
+}
+
+// TestAutomatedHeadersAreFetched guards the coupling between the classifier
+// and the metadata headers the poll requests: a signal the classifier reads
+// but the API call never asks for is dead code.
+func TestAutomatedHeadersAreFetched(t *testing.T) {
+	for _, h := range []string{"Auto-Submitted", "Precedence", "List-Unsubscribe", "X-Auto-Response-Suppress"} {
+		found := false
+		for _, got := range automatedHeaders {
+			if strings.EqualFold(got, h) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("classifier reads %q but it is not in automatedHeaders", h)
+		}
+	}
+}

--- a/pkg/gateway/gmail/gmail.go
+++ b/pkg/gateway/gmail/gmail.go
@@ -60,6 +60,11 @@ type mailEntry struct {
 	Subject  string `json:"subject,omitempty"`
 	Snippet  string `json:"snippet,omitempty"`
 	Date     string `json:"date,omitempty"`
+	// Automated marks machine-generated mail (notifications, newsletters,
+	// bounces). Such mail is ingested into the channel feed but does not
+	// prompt subscribed agents. AutomatedReason names the signal that fired.
+	AutomatedReason string `json:"automated_reason,omitempty"`
+	Automated       bool   `json:"automated,omitempty"`
 }
 
 // Adapter implements gateway.NotificationAdapter for Gmail.
@@ -242,7 +247,7 @@ func (a *Adapter) poll(ctx context.Context) {
 
 		msg, gerr := a.svc.Users.Messages.Get("me", ref.Id).
 			Format("metadata").
-			MetadataHeaders("From", "Subject", "Date").
+			MetadataHeaders(append([]string{"From", "Subject", "Date"}, automatedHeaders...)...).
 			Context(ctx).
 			Do()
 		if gerr != nil {
@@ -293,6 +298,11 @@ func (a *Adapter) dispatch(e mailEntry) {
 		channelName = a.label
 	}
 
+	if e.Automated {
+		log.Debug("gmail: automated mail — feed only, no agent delivery",
+			"adapter", a.name, "from", addr, "reason", e.AutomatedReason)
+	}
+
 	a.handler(gateway.Notification{
 		Timestamp: time.Now(),
 		Raw:       raw,
@@ -303,6 +313,7 @@ func (a *Adapter) dispatch(e mailEntry) {
 		SenderID:  addr,
 		Content:   content,
 		MessageID: e.ID,
+		Automated: e.Automated,
 	})
 }
 
@@ -339,11 +350,14 @@ func (a *Adapter) Send(ctx context.Context, channelID, _, content string) error 
 
 // --- pure helpers (unit-tested) ---
 
-// parseMessage converts a Gmail API message into a normalized mailEntry.
+// parseMessage converts a Gmail API message into a normalized mailEntry,
+// classifying machine-generated mail from its headers.
 func parseMessage(m *gmail.Message) mailEntry {
 	e := mailEntry{ID: m.Id, ThreadID: m.ThreadId, Snippet: m.Snippet}
+	headers := make(map[string]string)
 	if m.Payload != nil {
 		for _, h := range m.Payload.Headers {
+			headers[h.Name] = h.Value
 			switch strings.ToLower(h.Name) {
 			case "from":
 				e.From = h.Value
@@ -354,6 +368,7 @@ func parseMessage(m *gmail.Message) mailEntry {
 			}
 		}
 	}
+	e.Automated, e.AutomatedReason = classifyAutomated(e.From, headers)
 	return e
 }
 

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -70,7 +70,9 @@ type Manager struct {
 	// so callers can use it for follow-up operations such as reactions.
 	// senderAvatar is the raw platform avatar URL for the sender when the
 	// adapter cheaply resolved one (empty otherwise → initials fallback).
-	onInbound    func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage)
+	// automated marks machine-generated events that should reach the channel
+	// feed without waking subscribed agents.
+	onInbound    func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage, automated bool)
 	channelStore ChannelStore
 	mu           sync.RWMutex
 	// adapterWG tracks boot-time and hot-started adapter goroutines so Stop/
@@ -114,8 +116,9 @@ func (m *Manager) SetChannelStore(store ChannelStore) {
 // The callback receives the mycel channel name, sender display name, platform-native
 // sender id (e.g. WhatsApp JID — used for follow-up reactions), text content,
 // platform-native message ID, pre-extracted mentions (e.g. WhatsApp JID user parts),
-// and the raw platform payload.
-func (m *Manager) SetInboundHandler(fn func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage)) {
+// the raw platform payload, and whether the event is machine-generated
+// (notification mail and similar — feed-worthy, but no agent should be woken).
+func (m *Manager) SetInboundHandler(fn func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage, automated bool)) {
 	m.onInbound = fn
 }
 
@@ -768,7 +771,7 @@ func (m *Manager) handleNotification(platform string, n Notification) {
 		content = string(n.Raw)
 	}
 	if m.onInbound != nil {
-		m.onInbound(channel, sender, n.SenderID, n.SenderAvatar, content, n.MessageID, n.Mentions, n.Raw)
+		m.onInbound(channel, sender, n.SenderID, n.SenderAvatar, content, n.MessageID, n.Mentions, n.Raw, n.Automated)
 	}
 }
 

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -101,12 +101,32 @@ func extractMentions(content string) []string {
 	return mentions
 }
 
+// DispatchOption adjusts how a single inbound message is handled.
+type DispatchOption func(*dispatchOpts)
+
+type dispatchOpts struct {
+	automated bool
+}
+
+// Automated marks the message as machine-generated (notification mail,
+// newsletters, bounces). Such messages are still recorded in the channel feed
+// and published to the web UI, but no subscribed agent is woken for them:
+// nobody is waiting on a reply, and prompting every subscriber costs real
+// tokens. Adapters decide what counts as automated.
+func Automated() DispatchOption {
+	return func(o *dispatchOpts) { o.automated = true }
+}
+
 // Dispatch receives a normalized inbound message and delivers it to
 // subscribed agents only. Runs in its own goroutine — never blocks the adapter.
 // extraMentions carries pre-extracted platform mentions (e.g. WhatsApp JID user
 // parts) that the text-based mention regex cannot capture; they are merged with
 // the standard @name extraction from content.
-func (s *Service) Dispatch(channel, platform, sender, senderID, senderAvatar, content, messageID string, extraMentions []string, attachments []Attachment, raw json.RawMessage) {
+func (s *Service) Dispatch(channel, platform, sender, senderID, senderAvatar, content, messageID string, extraMentions []string, attachments []Attachment, raw json.RawMessage, opts ...DispatchOption) {
+	var o dispatchOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
 	s.dispatches.Add(1)
 	go func() {
 		defer s.dispatches.Done()
@@ -143,99 +163,24 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, senderAvatar, co
 			}
 			mentions = merged
 		}
-		n := Notification{
-			Raw:         raw,
-			Timestamp:   time.Now().UTC().Format(time.RFC3339),
-			Channel:     channel,
-			Platform:    platform,
-			Sender:      sender,
-			Content:     content,
-			MessageID:   messageID,
-			Mentions:    mentions,
-			Attachments: attachments,
-		}
-		payload, err := json.Marshal(n)
-		if err != nil {
-			log.Error("notify: marshal notification", "error", err)
-			return
-		}
-
-		// Get subscribers for this channel
-		subs, subErr := s.store.Subscribers(ctx, channel)
-		if subErr != nil {
-			log.Warn("notify: failed to get subscribers", "channel", channel, "error", subErr)
-			return
-		}
-
-		// Setup wizard historically subscribed agents to "{platform}:general"
-		// even when no such channel exists (Telegram DMs arrive as
-		// telegram:<username|chat_id>). Copy placeholder subscriptions onto
-		// the first real channel so legacy installs self-heal.
-		if len(subs) == 0 && platform != "" {
-			if n, mErr := s.migratePlaceholderSubs(ctx, platform, channel); mErr != nil {
-				log.Warn("notify: placeholder migration failed", "platform", platform, "channel", channel, "error", mErr)
-			} else if n > 0 {
-				subs, subErr = s.store.Subscribers(ctx, channel)
-				if subErr != nil {
-					log.Warn("notify: failed to get subscribers after migration", "channel", channel, "error", subErr)
-					return
-				}
-			}
-		}
-
-		log.Info("notify: dispatch", "channel", channel, "sender", sender, "subscribers", len(subs))
-
-		mentionSet := make(map[string]bool, len(mentions))
-		for _, m := range mentions {
-			mentionSet[m] = true
-		}
-
-		// Strip platform prefix from sender for self-skip comparison.
-		// Gateway messages arrive as "[slack] agent-name" but subscriptions
-		// store bare agent names.
-		rawSender := platformPrefixRe.ReplaceAllString(sender, "")
-
-		// Deliver to each subscribed agent
-		for _, sub := range subs {
-			// Self-skip: don't echo agent's own message back
-			if strings.EqualFold(sub.Agent, rawSender) {
-				continue
-			}
-
-			// @mention filter: if mention_only, skip unless agent is mentioned
-			if sub.MentionOnly && !mentionSet[strings.ToLower(sub.Agent)] {
-				continue
-			}
-
-			sendErr := s.agents.Send(ctx, sub.Agent, string(payload))
-			status := StatusDelivered
-			errStr := ""
-			switch {
-			case sendErr == nil:
-				log.Info("notify: delivered", "agent", sub.Agent, "channel", channel)
-			case agentOfflineRe.MatchString(sendErr.Error()):
-				// Subscribed agent was offline when the message arrived
-				// — the routing decision was correct, delivery just
-				// wasn't attempted. Skip the delivery-log write entirely
-				// so the failed-delivery count only reflects genuine
-				// send errors, not routine offline-agent skips.
-				log.Debug("notify: delivery skipped (agent offline)", "agent", sub.Agent, "channel", channel)
-				continue
-			default:
-				status = StatusFailed
-				errStr = sendErr.Error()
-				log.Warn("notify: delivery failed", "agent", sub.Agent, "channel", channel, "error", sendErr)
-			}
-
-			if logErr := s.store.LogDelivery(ctx, DeliveryEntry{
-				Channel: channel,
-				Agent:   sub.Agent,
-				Status:  status,
-				Error:   errStr,
-				Preview: truncate(content, 120),
-			}); logErr != nil {
-				log.Warn("notify: log delivery failed", "error", logErr)
-			}
+		// Machine-generated mail earns a place in the channel feed and the web
+		// UI, but not an agent's attention: nobody is waiting on a reply to a
+		// GitHub notification or a newsletter, and waking every subscriber for
+		// one costs real tokens.
+		if o.automated {
+			log.Info("notify: automated message — feed only, agents not woken",
+				"channel", channel, "sender", sender)
+		} else {
+			s.deliverToSubscribers(ctx, deliverable{
+				Channel:     channel,
+				Platform:    platform,
+				Sender:      sender,
+				Content:     content,
+				MessageID:   messageID,
+				Mentions:    mentions,
+				Attachments: attachments,
+				Raw:         raw,
+			})
 		}
 
 		// Publish to web UI
@@ -254,6 +199,119 @@ func (s *Service) Dispatch(channel, platform, sender, senderID, senderAvatar, co
 			log.Warn("notify: prune failed", "channel", channel, "error", err)
 		}
 	}()
+}
+
+// deliverable is one inbound message resolved far enough to be delivered:
+// mentions are merged and the content is final.
+type deliverable struct {
+	Raw         json.RawMessage
+	Channel     string
+	Platform    string
+	Sender      string
+	Content     string
+	MessageID   string
+	Mentions    []string
+	Attachments []Attachment
+}
+
+// deliverToSubscribers sends the message to every subscribed agent that
+// passes the self-skip and @mention filters, logging each attempt.
+func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
+	channel, platform, sender, content := d.Channel, d.Platform, d.Sender, d.Content
+
+	payload, err := json.Marshal(Notification{
+		Raw:         d.Raw,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Channel:     channel,
+		Platform:    platform,
+		Sender:      sender,
+		Content:     content,
+		MessageID:   d.MessageID,
+		Mentions:    d.Mentions,
+		Attachments: d.Attachments,
+	})
+	if err != nil {
+		log.Error("notify: marshal notification", "error", err)
+		return
+	}
+
+	// Get subscribers for this channel
+	subs, subErr := s.store.Subscribers(ctx, channel)
+	if subErr != nil {
+		log.Warn("notify: failed to get subscribers", "channel", channel, "error", subErr)
+		return
+	}
+
+	// Setup wizard historically subscribed agents to "{platform}:general"
+	// even when no such channel exists (Telegram DMs arrive as
+	// telegram:<username|chat_id>). Copy placeholder subscriptions onto
+	// the first real channel so legacy installs self-heal.
+	if len(subs) == 0 && platform != "" {
+		if n, mErr := s.migratePlaceholderSubs(ctx, platform, channel); mErr != nil {
+			log.Warn("notify: placeholder migration failed", "platform", platform, "channel", channel, "error", mErr)
+		} else if n > 0 {
+			subs, subErr = s.store.Subscribers(ctx, channel)
+			if subErr != nil {
+				log.Warn("notify: failed to get subscribers after migration", "channel", channel, "error", subErr)
+				return
+			}
+		}
+	}
+
+	log.Info("notify: dispatch", "channel", channel, "sender", sender, "subscribers", len(subs))
+
+	mentionSet := make(map[string]bool, len(d.Mentions))
+	for _, m := range d.Mentions {
+		mentionSet[m] = true
+	}
+
+	// Strip platform prefix from sender for self-skip comparison.
+	// Gateway messages arrive as "[slack] agent-name" but subscriptions
+	// store bare agent names.
+	rawSender := platformPrefixRe.ReplaceAllString(sender, "")
+
+	// Deliver to each subscribed agent
+	for _, sub := range subs {
+		// Self-skip: don't echo agent's own message back
+		if strings.EqualFold(sub.Agent, rawSender) {
+			continue
+		}
+
+		// @mention filter: if mention_only, skip unless agent is mentioned
+		if sub.MentionOnly && !mentionSet[strings.ToLower(sub.Agent)] {
+			continue
+		}
+
+		sendErr := s.agents.Send(ctx, sub.Agent, string(payload))
+		status := StatusDelivered
+		errStr := ""
+		switch {
+		case sendErr == nil:
+			log.Info("notify: delivered", "agent", sub.Agent, "channel", channel)
+		case agentOfflineRe.MatchString(sendErr.Error()):
+			// Subscribed agent was offline when the message arrived
+			// — the routing decision was correct, delivery just
+			// wasn't attempted. Skip the delivery-log write entirely
+			// so the failed-delivery count only reflects genuine
+			// send errors, not routine offline-agent skips.
+			log.Debug("notify: delivery skipped (agent offline)", "agent", sub.Agent, "channel", channel)
+			continue
+		default:
+			status = StatusFailed
+			errStr = sendErr.Error()
+			log.Warn("notify: delivery failed", "agent", sub.Agent, "channel", channel, "error", sendErr)
+		}
+
+		if logErr := s.store.LogDelivery(ctx, DeliveryEntry{
+			Channel: channel,
+			Agent:   sub.Agent,
+			Status:  status,
+			Error:   errStr,
+			Preview: truncate(content, 120),
+		}); logErr != nil {
+			log.Warn("notify: log delivery failed", "error", logErr)
+		}
+	}
 }
 
 // migratePlaceholderSubs copies subscriptions from "{platform}:general" onto

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -472,6 +472,84 @@ func TestMigratePlaceholderSubsOnDispatch(t *testing.T) {
 	}
 }
 
+// TestDispatchAutomatedFeedsWithoutWakingAgents pins the notification-mail
+// policy: machine-generated mail still lands in the channel feed and reaches
+// the web UI, but no agent is prompted. Without this, every GitHub
+// notification and newsletter wakes each subscriber and costs tokens on a
+// message nobody can reply to.
+func TestDispatchAutomatedFeedsWithoutWakingAgents(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	hub := &mockHub{}
+	svc := NewService(store, sender, hub)
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "gmail:notificationsgithubcom", "fast-crane", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("gmail:notificationsgithubcom", "gmail",
+		`[gmail] "coderabbitai[bot]" <notifications@github.com>`, "notifications@github.com", "",
+		"Re: [rpuneet/mycel] approved this pull request", "m1", nil, nil, nil, Automated())
+
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+
+	if calls := sender.getCalls(); len(calls) != 0 {
+		t.Fatalf("automated mail must not be delivered to agents, got %d: %+v", len(calls), calls)
+	}
+
+	// Ingested: the message is still readable in the channel feed.
+	msgs, err := store.GetMessages(ctx, "gmail:notificationsgithubcom", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected automated mail to be stored in the feed, got %d messages", len(msgs))
+	}
+
+	// And the web UI is still told about it.
+	if len(hub.events) != 1 || hub.events[0] != "gateway.message" {
+		t.Errorf("expected one gateway.message publish, got %v", hub.events)
+	}
+
+	// No delivery attempt was made, so nothing should be logged as failed.
+	entries, err := store.RecentActivity(ctx, "gmail:notificationsgithubcom", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected no delivery-log entries for automated mail, got %+v", entries)
+	}
+}
+
+// TestDispatchWithoutAutomatedStillDelivers is the control for the test
+// above: the same channel and subscriber, minus the Automated option, must
+// still wake the agent. Guards against the filter swallowing human mail.
+func TestDispatchWithoutAutomatedStillDelivers(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "gmail:notificationsgithubcom", "fast-crane", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("gmail:notificationsgithubcom", "gmail", "[gmail] Puneet <puneet@example.com>",
+		"puneet@example.com", "", "can you ship the release?", "m1", nil, nil, nil)
+
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "fast-crane" {
+		t.Fatalf("expected one delivery to fast-crane, got %+v", calls)
+	}
+}
+
 func TestMigratePlaceholderSubsNoOpWhenRealHasSubs(t *testing.T) {
 	store := setupTestStore(t)
 	sender := &mockSender{}

--- a/server/server.go
+++ b/server/server.go
@@ -273,7 +273,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 	// Wire gateway inbound callback for notify dispatch and SSE publish.
 	if svc.Gateway != nil {
-		svc.Gateway.SetInboundHandler(func(ch, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage) {
+		svc.Gateway.SetInboundHandler(func(ch, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage, automated bool) {
 			// Publish SSE event for web UI (non-blocking)
 			if hub != nil {
 				hub.Publish("channel.message", map[string]any{
@@ -293,7 +293,11 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 				if idx := strings.Index(ch, ":"); idx > 0 {
 					platform = ch[:idx]
 				}
-				svc.Notify.Dispatch(ch, platform, sender, senderID, senderAvatar, content, messageID, mentions, nil, raw)
+				var opts []notify.DispatchOption
+				if automated {
+					opts = append(opts, notify.Automated())
+				}
+				svc.Notify.Dispatch(ch, platform, sender, senderID, senderAvatar, content, messageID, mentions, nil, raw, opts...)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

GitHub notification mail arrives on the same Gmail poll as human mail and is
dispatched identically, so every subscribed agent is woken for it. Today four
notifications from a single PR thread (three of them the same CodeRabbit
approval, replayed) were delivered to an agent as prompts, each costing a turn
on a message nobody can reply to. Newsletters and bank alerts do the same.

## Change

The Gmail adapter classifies machine-generated mail; `notify` skips agent
delivery for it. Automated mail is **still** saved to the channel feed and
published to the web UI — it just doesn't prompt anyone. Nothing is hidden, so
a misclassification is visible and recoverable.

Classification prefers the sender's own declaration over guessing at addresses:

| Signal | Meaning |
|--------|---------|
| `Auto-Submitted` != `no` (RFC 3834) | Sender says the message was auto-generated (GitHub sets this) |
| `X-Auto-Response-Suppress` | Only ever set by automated systems |
| `Precedence: bulk` / `junk` | Bulk mailing |
| `List-Unsubscribe` | Mailing to many recipients |
| No-reply local part | `noreply@`, `notifications@`, `mailer-daemon@`, `github-noreply@`, ... |

Deliberately **not** filtered:

- `Precedence: list` and `List-Id` on their own — genuine team discussion lists
  (Google Groups and similar) set them, and agents should still see those.
- Human-staffed role addresses: `support@`, `info@`, `alerts@`.

Threading: `gateway.Notification` gains an `Automated` flag that adapters set;
`notify.Dispatch` gains a variadic `notify.Automated()` option (matching the
existing `tool.UserInitiated()` pattern), so no existing call site changes.

The subscriber delivery loop moves into `deliverToSubscribers` so the automated
path is one readable branch instead of re-indenting the whole dispatch body.
Side effect: a subscriber-lookup failure no longer skips the SSE publish and
prune, which is the better behaviour.

## Test plan

- [x] `TestClassifyAutomated` — 14 cases from real mailbox traffic, including
      the false cases (human mail, `Auto-Submitted: no`, `support@`, team list).
- [x] `TestDispatchAutomatedFeedsWithoutWakingAgents` — asserts zero agent
      sends, one stored feed message, one SSE publish, zero delivery-log rows.
- [x] `TestDispatchWithoutAutomatedStillDelivers` — control: human mail on the
      same channel still wakes the agent.
- [x] `TestAutomatedHeadersAreFetched` — guards the coupling between the
      classifier and the headers the Gmail API call actually requests.
- [x] Verified the new tests fail with the gate removed (not passing vacuously).
- [x] `go build ./...`, `go test ./pkg/... ./server/...`, `golangci-lint run ./...`, `bun run lint` in `web/` all clean.

## Follow-ups

- #3459 — per-subscription opt-in, for anyone who does want an agent acting on
  notification traffic.
- #3460 — the inbound callback parameter list this change adds a bool to.
- Same classification for the other feed-like adapters (RSS, webhook) if the
  same noise shows up there.

Fixes #3461

Made with [Cursor](https://cursor.com)