### PR TITLE
fix(notify): deliver via catch-all instead of copying subscriptions

### DIFF
--- a/docs/explanation/notifications.md
+++ b/docs/explanation/notifications.md
@@ -614,6 +614,18 @@ misclassification hides nothing -- it only means no agent was woken.
 
 Settings are per-agent, per-channel.
 
+**Catch-all subscriptions** cover platforms where the real channel isn't known
+until a message arrives: Telegram DMs land on `telegram:<username|chat_id>`, mail
+on `gmail:<sender-address>`. Connecting such an app subscribes the chosen agents
+to `{platform}:general`, and a message on a channel with no subscribers of its
+own is delivered to the catch-all's subscribers instead.
+
+The catch-all is only ever *read*. Earlier versions copied it onto each new
+channel, which left a permanent subscription behind per correspondent -- on
+platforms that mint a channel per sender or per chat, one catch-all row silently
+became dozens. An explicit subscription on the real channel always takes
+precedence, so per-channel settings such as mention-only still work.
+
 ## Web UI
 
 ### Notifications Settings Page

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -242,19 +242,26 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 		return
 	}
 
-	// Setup wizard historically subscribed agents to "{platform}:general"
-	// even when no such channel exists (Telegram DMs arrive as
-	// telegram:<username|chat_id>). Copy placeholder subscriptions onto
-	// the first real channel so legacy installs self-heal.
+	// The connect-app flow subscribes agents to "{platform}:general" as a
+	// catch-all, because the real channel is not known until a message
+	// arrives (Telegram DMs land on telegram:<username|chat_id>, mail on
+	// gmail:<sender>). When a channel has no subscribers of its own, fall
+	// back to the catch-all's subscribers for this delivery.
+	//
+	// This is deliberately a read, not a write. Copying the catch-all onto
+	// each new channel used to leave a permanent subscription behind, and
+	// platforms that mint a channel per correspondent (Gmail per sender,
+	// WhatsApp per chat) turned one catch-all row into dozens nobody asked
+	// for — see #3463. An explicit subscription on the real channel still
+	// wins, so per-channel settings keep working.
 	if len(subs) == 0 && platform != "" {
-		if n, mErr := s.migratePlaceholderSubs(ctx, platform, channel); mErr != nil {
-			log.Warn("notify: placeholder migration failed", "platform", platform, "channel", channel, "error", mErr)
-		} else if n > 0 {
-			subs, subErr = s.store.Subscribers(ctx, channel)
-			if subErr != nil {
-				log.Warn("notify: failed to get subscribers after migration", "channel", channel, "error", subErr)
-				return
-			}
+		fallback, fErr := s.catchAllSubscribers(ctx, platform, channel)
+		if fErr != nil {
+			log.Warn("notify: catch-all lookup failed", "platform", platform, "channel", channel, "error", fErr)
+		} else if len(fallback) > 0 {
+			subs = fallback
+			log.Info("notify: delivering via catch-all subscription",
+				"channel", channel, "catch_all", platform+catchAllSuffix, "agents", len(fallback))
 		}
 	}
 
@@ -314,41 +321,26 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 	}
 }
 
-// migratePlaceholderSubs copies subscriptions from "{platform}:general" onto
-// the real channel when the placeholder still has subscribers and the real
-// channel has none. Returns the number of agents copied. The placeholder row
-// is left in place (copy, not rewrite) so operators can clean it up later.
-func (s *Service) migratePlaceholderSubs(ctx context.Context, platform, realChannel string) (int, error) {
-	placeholder := platform + ":general"
-	if realChannel == "" || realChannel == placeholder {
-		return 0, nil
-	}
-	// Only migrate onto channels for this platform.
-	prefix := platform + ":"
-	if !strings.HasPrefix(realChannel, prefix) {
-		return 0, nil
-	}
+// catchAllSuffix is the channel the connect-app flow subscribes agents to when
+// the real per-conversation channel cannot be known in advance.
+const catchAllSuffix = ":general"
 
-	legacy, err := s.store.Subscribers(ctx, placeholder)
-	if err != nil {
-		return 0, err
+// catchAllSubscribers returns the subscribers of "{platform}:general" so a
+// channel with no subscribers of its own can still be delivered. It only
+// reads: writing a subscription per channel is what produced the runaway
+// subscription lists in #3463.
+//
+// Returns nothing when realChannel is the catch-all itself (already handled by
+// the normal lookup) or belongs to another platform.
+func (s *Service) catchAllSubscribers(ctx context.Context, platform, realChannel string) ([]Subscription, error) {
+	catchAll := platform + catchAllSuffix
+	if realChannel == "" || realChannel == catchAll {
+		return nil, nil
 	}
-	if len(legacy) == 0 {
-		return 0, nil
+	if !strings.HasPrefix(realChannel, platform+":") {
+		return nil, nil
 	}
-
-	copied := 0
-	for _, sub := range legacy {
-		if err := s.store.Subscribe(ctx, realChannel, sub.Agent, sub.MentionOnly); err != nil {
-			return copied, err
-		}
-		copied++
-	}
-	if copied > 0 {
-		log.Info("notify: migrated placeholder subscriptions",
-			"from", placeholder, "to", realChannel, "agents", copied)
-	}
-	return copied, nil
+	return s.store.Subscribers(ctx, catchAll)
 }
 
 // Subscribe adds an agent to a channel.

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -430,13 +430,16 @@ func TestDrainDispatches(t *testing.T) {
 	}
 }
 
-func TestMigratePlaceholderSubsOnDispatch(t *testing.T) {
+// TestCatchAllDeliversWithoutCreatingSubscriptions covers the connect-app
+// flow: agents are subscribed to "{platform}:general" because the real
+// per-conversation channel isn't known until a message arrives. Delivery must
+// work — and must not leave a subscription behind on the real channel.
+func TestCatchAllDeliversWithoutCreatingSubscriptions(t *testing.T) {
 	store := setupTestStore(t)
 	sender := &mockSender{}
 	svc := NewService(store, sender, &mockHub{})
 	ctx := context.Background()
 
-	// Legacy wizard subscription on telegram:general only.
 	if err := store.Subscribe(ctx, "telegram:general", "mdrndr-manager", false); err != nil {
 		t.Fatal(err)
 	}
@@ -450,25 +453,115 @@ func TestMigratePlaceholderSubsOnDispatch(t *testing.T) {
 		t.Fatal("dispatch did not finish")
 	}
 
+	if calls := sender.getCalls(); len(calls) != 2 {
+		t.Fatalf("expected 2 deliveries via the catch-all, got %d: %+v", len(calls), calls)
+	}
+
+	// The real channel must stay clean: the catch-all is read, never copied.
 	subs, err := store.Subscribers(ctx, "telegram:ab010300")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(subs) != 2 {
-		t.Fatalf("expected 2 migrated subscribers, got %d", len(subs))
+	if len(subs) != 0 {
+		t.Errorf("catch-all delivery created %d subscription(s) on the real channel: %+v", len(subs), subs)
 	}
-	// Placeholder remains (copy, not rewrite).
-	legacy, err := store.Subscribers(ctx, "telegram:general")
+
+	// And the catch-all itself is untouched.
+	catchAll, err := store.Subscribers(ctx, "telegram:general")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(legacy) != 2 {
-		t.Fatalf("expected placeholder to remain, got %d", len(legacy))
+	if len(catchAll) != 2 {
+		t.Errorf("expected the catch-all to remain with 2 agents, got %d", len(catchAll))
+	}
+}
+
+// TestCatchAllDoesNotFanOutAcrossChannels is the #3463 regression test.
+// Platforms that mint a channel per correspondent (Gmail per sender address,
+// WhatsApp per chat) used to turn one catch-all row into one permanent
+// subscription per correspondent — a live workspace had accumulated 7 Gmail and
+// 53 WhatsApp subscriptions nobody created, each of them prompting an agent.
+func TestCatchAllDoesNotFanOutAcrossChannels(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "gmail:general", "fast-crane", false); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mail from five different senders — five channels, as Gmail names a
+	// channel after the sender address.
+	senders := []string{
+		"gmail:alertshdfcbankbankin",
+		"gmail:hellonewsexpressvpncom",
+		"gmail:newslettereconomictimesnewscom",
+		"gmail:supportnpmjscom",
+		"gmail:puneetexamplecom",
+	}
+	for i, ch := range senders {
+		svc.Dispatch(ch, "gmail", "someone", "", "", "message", string(rune('a'+i)), nil, nil, nil)
+	}
+	if !svc.DrainDispatches(3 * time.Second) {
+		t.Fatal("dispatches did not finish")
+	}
+
+	all, err := store.AllSubscriptions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 1 {
+		t.Fatalf("expected the single gmail:general subscription to remain the only one, got %d: %+v",
+			len(all), all)
+	}
+	if all[0].Channel != "gmail:general" {
+		t.Errorf("surviving subscription is %q, want gmail:general", all[0].Channel)
+	}
+
+	// Delivery still reached the agent for every sender.
+	if calls := sender.getCalls(); len(calls) != len(senders) {
+		t.Errorf("expected %d deliveries via the catch-all, got %d", len(senders), len(calls))
+	}
+}
+
+// TestExplicitChannelSubscriptionWinsOverCatchAll proves the fallback is only
+// a fallback: a per-channel subscription with its own settings still governs
+// that channel, so mention-only on one noisy chat keeps working.
+func TestExplicitChannelSubscriptionWinsOverCatchAll(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	// Catch-all would deliver everything to broad-agent...
+	if err := store.Subscribe(ctx, "gmail:general", "broad-agent", false); err != nil {
+		t.Fatal(err)
+	}
+	// ...but this channel has its own explicit, mention-only subscription.
+	if err := store.Subscribe(ctx, "gmail:noisysendercom", "focused-agent", true); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("gmail:noisysendercom", "gmail", "someone", "", "", "no mention here", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+
+	// focused-agent is mention-only and wasn't mentioned; broad-agent must not
+	// be pulled in by the catch-all, because the channel has a subscriber.
+	if calls := sender.getCalls(); len(calls) != 0 {
+		t.Fatalf("expected no deliveries, got %+v", calls)
+	}
+
+	svc.Dispatch("gmail:noisysendercom", "gmail", "someone", "", "", "hey @focused-agent look", "m2", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
 	}
 
 	calls := sender.getCalls()
-	if len(calls) != 2 {
-		t.Fatalf("expected 2 deliveries, got %d: %+v", len(calls), calls)
+	if len(calls) != 1 || calls[0].Name != "focused-agent" {
+		t.Fatalf("expected one delivery to focused-agent, got %+v", calls)
 	}
 }
 


### PR DESCRIPTION
## Problem

Connecting a non-Telegram app subscribes the chosen agents to
`{platform}:general` — the connect flow can't name the real channel, because it
doesn't exist until a message arrives (`web/src/components/apps/ConnectApp.tsx`
still does this today). Dispatch then *copied* that row onto whatever channel the
first message landed on, and left it there permanently.

On platforms that mint a channel per correspondent this compounds without bound.
Gmail names a channel after the sender address; WhatsApp after the chat. So every
new correspondent permanently subscribes an agent.

Measured on a live workspace:

| Platform | Channels | Auto-created subscriptions |
|----------|---------:|---------------------------:|
| Gmail | 9 | 7 (bank alerts, 2 newsletters, a VPN vendor, npm, GitHub notifications) |
| WhatsApp | 142 | 53 (all numeric JIDs — personal chats and groups) |

Nobody subscribed an agent to ExpressVPN marketing. One catch-all row became 60.

Consequences: every one of those messages wakes an agent and costs a turn; the
notify settings page drifts from what the operator configured; and anyone who
knows the mailbox address can get their text delivered into an agent session as a
prompt.

Fixes #3463.

## Change

The catch-all is **read** at delivery time instead of copied:

```go
if len(subs) == 0 && platform != "" {
    fallback, err := s.catchAllSubscribers(ctx, platform, channel)
    ...
}
```

- Delivery behaviour is unchanged — the same agents receive the same messages.
- No subscription rows are created, so the list stays what the operator set.
- Unsubscribing from the catch-all now actually stops delivery. Previously you
  had to find and remove every copied row.
- An explicit subscription on the real channel still takes precedence, so
  per-channel settings such as mention-only keep working.

`migratePlaceholderSubs` is replaced by `catchAllSubscribers`, which only reads.

## Deliberately not in scope

- **Existing rows are left alone** (#3465). There's no provenance column, so an
  auto-created subscription is indistinguishable from a deliberate one; deleting
  by heuristic could remove something wanted. Cleanup stays manual for now.
- **Muting one channel while the catch-all is on** isn't expressible (#3466):
  there's no row to remove. It was previously possible by accident, via the
  copied row. Workaround: subscribe explicitly to the channels you want and drop
  the catch-all.
- **`slack:general` is both a real channel and the catch-all name** (#3467). That
  conflation predates this change and is unaffected by it.

## Test plan

- [x] `TestCatchAllDeliversWithoutCreatingSubscriptions` — delivery works, and
      asserts zero rows created on the real channel.
- [x] `TestCatchAllDoesNotFanOutAcrossChannels` — the regression test: five
      senders, five channels, still exactly one subscription afterwards, and all
      five messages delivered.
- [x] `TestExplicitChannelSubscriptionWinsOverCatchAll` — a per-channel
      mention-only subscription still governs its channel and the catch-all does
      not leak in.
- [x] The pre-existing test that asserted the copy behaviour was rewritten
      rather than deleted, so the delivery guarantee it covered is still pinned.
- [x] `go build ./...`, `go test ./pkg/... ./server/...`, `golangci-lint run ./...` clean.

Made with [Cursor](https://cursor.com)