### PR TITLE
fix(notify,gateway): record outbound messages in channel history

### DIFF
--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -72,7 +72,12 @@ type Manager struct {
 	// adapter cheaply resolved one (empty otherwise → initials fallback).
 	// automated marks machine-generated events that should reach the channel
 	// feed without waking subscribed agents.
-	onInbound    func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage, automated bool)
+	onInbound func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage, automated bool)
+	// onOutbound is called after a message has been successfully handed to a
+	// platform, so the channel's stored history holds both sides of the
+	// conversation. Inbound messages are recorded from onInbound; without this
+	// hook a transcript shows only what arrived, never what an agent replied.
+	onOutbound   func(channel, sender, content string)
 	channelStore ChannelStore
 	mu           sync.RWMutex
 	// adapterWG tracks boot-time and hot-started adapter goroutines so Stop/
@@ -120,6 +125,31 @@ func (m *Manager) SetChannelStore(store ChannelStore) {
 // (notification mail and similar — feed-worthy, but no agent should be woken).
 func (m *Manager) SetInboundHandler(fn func(channel, sender, senderID, senderAvatar, content, messageID string, mentions []string, raw json.RawMessage, automated bool)) {
 	m.onInbound = fn
+}
+
+// SetOutboundHandler sets the callback invoked after a message has been
+// successfully sent to a platform. It receives the mycel channel name, the
+// sender the message was attributed to (an agent name, or "api"), and the text.
+//
+// Wired to the notify store so channel history records replies as well as
+// arrivals. Called synchronously on the send path, so the handler should stay
+// cheap and must not call back into the gateway.
+func (m *Manager) SetOutboundHandler(fn func(channel, sender, content string)) {
+	m.onOutbound = fn
+}
+
+// recordOutbound notifies the outbound handler, if one is wired. A panic in the
+// handler must not fail a send that the platform already accepted.
+func (m *Manager) recordOutbound(channel, sender, content string) {
+	if m.onOutbound == nil {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("gateway: outbound handler panic", "channel", channel, "recover", r)
+		}
+	}()
+	m.onOutbound(channel, sender, content)
 }
 
 // Register adds a NotificationAdapter to the manager.
@@ -485,6 +515,7 @@ func (m *Manager) Send(ctx context.Context, channel, sender, content string) (bo
 				if err := ms.Send(ctx, id, sender, content); err != nil {
 					return true, fmt.Errorf("gateway send to %s: %w", channel, err)
 				}
+				m.recordOutbound(channel, sender, content)
 				return true, nil
 			}
 		}
@@ -503,6 +534,7 @@ func (m *Manager) Send(ctx context.Context, channel, sender, content string) (bo
 	if err := ms.Send(ctx, route.ChannelID, sender, content); err != nil {
 		return true, fmt.Errorf("gateway send to %s: %w", channel, err)
 	}
+	m.recordOutbound(channel, sender, content)
 	return true, nil
 }
 

--- a/pkg/gateway/manager_test.go
+++ b/pkg/gateway/manager_test.go
@@ -537,3 +537,156 @@ func TestStopAdapterAllowsRestart(t *testing.T) {
 		t.Fatal("replacement adapter did not start")
 	}
 }
+
+// mockSendingAdapter is a mockNotifAdapter that also implements messageSender,
+// recording what it was asked to send and optionally failing.
+type mockSendingAdapter struct {
+	mockNotifAdapter
+	err  error
+	sent []struct{ ChannelID, Sender, Content string }
+}
+
+func (m *mockSendingAdapter) Send(_ context.Context, channelID, sender, content string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.sent = append(m.sent, struct{ ChannelID, Sender, Content string }{channelID, sender, content})
+	return nil
+}
+
+// TestSendRecordsOutbound pins the fix for one-sided channel history: a
+// successful send has to reach the outbound handler, which is what writes the
+// agent's own message into the transcript. Without it a channel shows only what
+// arrived — a live workspace had 659 inbound messages and no agent replies.
+func TestSendRecordsOutbound(t *testing.T) {
+	m := NewManager()
+	adapter := &mockSendingAdapter{mockNotifAdapter: mockNotifAdapter{name: "slack"}}
+	m.Register(adapter)
+	m.channelMap["slack:general"] = channelRoute{Adapter: adapter, Platform: "slack", ChannelID: "C123"}
+
+	var got []string
+	m.SetOutboundHandler(func(channel, sender, content string) {
+		got = append(got, channel+"|"+sender+"|"+content)
+	})
+
+	sent, err := m.Send(context.Background(), "slack:general", "fast-crane", "shipping the fix")
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if !sent {
+		t.Fatal("Send() reported the channel as unhandled")
+	}
+
+	want := "slack:general|fast-crane|shipping the fix"
+	if len(got) != 1 || got[0] != want {
+		t.Errorf("outbound handler calls = %v, want exactly [%q]", got, want)
+	}
+	// The message must still actually reach the platform, addressed by its
+	// native channel id rather than the mycel name.
+	if len(adapter.sent) != 1 || adapter.sent[0].ChannelID != "C123" {
+		t.Errorf("adapter received %+v, want one send to C123", adapter.sent)
+	}
+}
+
+// TestSendRecordsOutboundOnFallbackRoute covers the "platform:id" path used for
+// destinations that have never produced an inbound message. It sends, so it
+// must be recorded too.
+func TestSendRecordsOutboundOnFallbackRoute(t *testing.T) {
+	m := NewManager()
+	adapter := &mockSendingAdapter{mockNotifAdapter: mockNotifAdapter{name: "whatsapp"}}
+	m.Register(adapter)
+	// Deliberately no channelMap entry.
+
+	var calls int
+	m.SetOutboundHandler(func(_, _, _ string) { calls++ })
+
+	sent, err := m.Send(context.Background(), "whatsapp:919999999999", "bold-falcon", "on my way")
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if !sent {
+		t.Fatal("Send() reported the fallback channel as unhandled")
+	}
+	if calls != 1 {
+		t.Errorf("outbound handler called %d times, want 1", calls)
+	}
+}
+
+// TestSendDoesNotRecordFailedSend is the important negative: recording a
+// message the platform rejected would put a reply in the transcript that the
+// other side never saw.
+func TestSendDoesNotRecordFailedSend(t *testing.T) {
+	m := NewManager()
+	adapter := &mockSendingAdapter{
+		mockNotifAdapter: mockNotifAdapter{name: "slack"},
+		err:              fmt.Errorf("slack: channel_not_found"),
+	}
+	m.Register(adapter)
+	m.channelMap["slack:gone"] = channelRoute{Adapter: adapter, Platform: "slack", ChannelID: "C404"}
+
+	var calls int
+	m.SetOutboundHandler(func(_, _, _ string) { calls++ })
+
+	if _, err := m.Send(context.Background(), "slack:gone", "fast-crane", "hello?"); err == nil {
+		t.Fatal("Send() expected an error from the adapter")
+	}
+	if calls != 0 {
+		t.Errorf("outbound handler called %d times for a failed send, want 0", calls)
+	}
+}
+
+// TestSendDoesNotRecordUnroutableChannel guards the case where the channel is
+// not a gateway channel at all: nothing was sent, so nothing should be logged.
+func TestSendDoesNotRecordUnroutableChannel(t *testing.T) {
+	m := NewManager()
+
+	var calls int
+	m.SetOutboundHandler(func(_, _, _ string) { calls++ })
+
+	sent, err := m.Send(context.Background(), "nosuchplatform:room", "api", "anyone there")
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if sent {
+		t.Error("Send() claimed to handle an unknown platform")
+	}
+	if calls != 0 {
+		t.Errorf("outbound handler called %d times with no route, want 0", calls)
+	}
+}
+
+// TestOutboundHandlerPanicDoesNotFailSend: the message is already delivered by
+// the time the handler runs, so a bug in bookkeeping must not be reported to
+// the caller as a send failure.
+func TestOutboundHandlerPanicDoesNotFailSend(t *testing.T) {
+	m := NewManager()
+	adapter := &mockSendingAdapter{mockNotifAdapter: mockNotifAdapter{name: "slack"}}
+	m.Register(adapter)
+	m.channelMap["slack:general"] = channelRoute{Adapter: adapter, Platform: "slack", ChannelID: "C123"}
+	m.SetOutboundHandler(func(_, _, _ string) { panic("bookkeeping exploded") })
+
+	sent, err := m.Send(context.Background(), "slack:general", "fast-crane", "still delivered")
+	if err != nil {
+		t.Errorf("Send() error = %v, want nil despite the handler panic", err)
+	}
+	if !sent {
+		t.Error("Send() reported failure despite the platform accepting the message")
+	}
+}
+
+// TestSendWithoutOutboundHandler makes sure the hook is optional — a Manager
+// with no handler wired must still send.
+func TestSendWithoutOutboundHandler(t *testing.T) {
+	m := NewManager()
+	adapter := &mockSendingAdapter{mockNotifAdapter: mockNotifAdapter{name: "slack"}}
+	m.Register(adapter)
+	m.channelMap["slack:general"] = channelRoute{Adapter: adapter, Platform: "slack", ChannelID: "C123"}
+
+	sent, err := m.Send(context.Background(), "slack:general", "fast-crane", "no handler wired")
+	if err != nil || !sent {
+		t.Fatalf("Send() = (%v, %v), want (true, nil)", sent, err)
+	}
+	if len(adapter.sent) != 1 {
+		t.Errorf("adapter received %d sends, want 1", len(adapter.sent))
+	}
+}

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -117,6 +117,40 @@ func Automated() DispatchOption {
 	return func(o *dispatchOpts) { o.automated = true }
 }
 
+// RecordOutbound stores a message an agent sent out to a platform channel, so
+// channel history reads as a conversation rather than only the half that came
+// in. Inbound messages are stored by Dispatch; outbound ones have no dispatch
+// to hang off, because nothing needs delivering — they are already on their way
+// to the platform.
+//
+// Called after the gateway reports a successful send. Errors are logged rather
+// than returned: the message has already left, so failing the caller's send
+// would misreport what happened.
+func (s *Service) RecordOutbound(channel, sender, content string) {
+	if channel == "" || content == "" {
+		return
+	}
+	ctx := s.ctx
+
+	if err := s.store.SaveMessage(ctx, channel, sender, "", content); err != nil {
+		log.Warn("notify: save outbound message failed", "channel", channel, "sender", sender, "error", err)
+		return
+	}
+
+	// Same event shape the inbound path publishes, so an open channel view
+	// appends the message live instead of waiting for a refetch.
+	if s.hub != nil {
+		s.hub.Publish("channel.message", map[string]any{
+			"channel": channel,
+			"message": map[string]any{
+				"sender":  sender,
+				"content": content,
+				"type":    "text",
+			},
+		})
+	}
+}
+
 // Dispatch receives a normalized inbound message and delivers it to
 // subscribed agents only. Runs in its own goroutine — never blocks the adapter.
 // extraMentions carries pre-extracted platform mentions (e.g. WhatsApp JID user

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -44,14 +44,16 @@ func (m *mockSender) getCalls() []sendCall {
 
 // mockHub records Publish calls.
 type mockHub struct {
-	events []string
-	mu     sync.Mutex
+	events   []string
+	payloads []map[string]any
+	mu       sync.Mutex
 }
 
-func (m *mockHub) Publish(eventType string, _ map[string]any) {
+func (m *mockHub) Publish(eventType string, payload map[string]any) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.events = append(m.events, eventType)
+	m.payloads = append(m.payloads, payload)
 }
 
 func setupTestStore(t *testing.T) *Store {
@@ -671,5 +673,112 @@ func TestMigratePlaceholderSubsNoOpWhenRealHasSubs(t *testing.T) {
 	calls := sender.getCalls()
 	if len(calls) != 1 || calls[0].Name != "real-agent" {
 		t.Fatalf("expected delivery only to real-agent, got %+v", calls)
+	}
+}
+
+// TestRecordOutboundStoresAndPublishes covers the other half of the
+// conversation. Channel history is built from notify_messages, and only inbound
+// messages were ever written there, so a transcript showed the question and
+// never the answer.
+func TestRecordOutboundStoresAndPublishes(t *testing.T) {
+	store := setupTestStore(t)
+	hub := &mockHub{}
+	sender := &mockSender{}
+	svc := NewService(store, sender, hub)
+	ctx := context.Background()
+
+	svc.RecordOutbound("slack:general", "fast-crane", "merged both PRs, tracker is #3468")
+
+	msgs, err := store.GetMessages(ctx, "slack:general", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected the outbound message to be stored, got %d", len(msgs))
+	}
+	if msgs[0].Sender != "fast-crane" {
+		t.Errorf("stored sender = %q, want fast-crane", msgs[0].Sender)
+	}
+	if msgs[0].Content != "merged both PRs, tracker is #3468" {
+		t.Errorf("stored content = %q", msgs[0].Content)
+	}
+
+	// An open channel view appends from channel.message, so the payload has to
+	// carry a nested message object or the UI silently ignores the event.
+	if len(hub.events) != 1 || hub.events[0] != "channel.message" {
+		t.Fatalf("published events = %v, want [channel.message]", hub.events)
+	}
+	p := hub.payloads[0]
+	if p["channel"] != "slack:general" {
+		t.Errorf("payload channel = %v, want slack:general", p["channel"])
+	}
+	msg, ok := p["message"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload has no nested message object: %+v", p)
+	}
+	if msg["sender"] != "fast-crane" || msg["content"] != "merged both PRs, tracker is #3468" {
+		t.Errorf("published message = %+v", msg)
+	}
+	if msg["type"] != "text" {
+		t.Errorf("published message type = %v, want text", msg["type"])
+	}
+
+	// Recording an outbound message must never prompt an agent: the message
+	// came *from* one.
+	if calls := sender.getCalls(); len(calls) != 0 {
+		t.Errorf("recording an outbound message woke %d agent(s): %+v", len(calls), calls)
+	}
+}
+
+// TestRecordOutboundIgnoresEmpty keeps blank rows out of the transcript.
+func TestRecordOutboundIgnoresEmpty(t *testing.T) {
+	store := setupTestStore(t)
+	hub := &mockHub{}
+	svc := NewService(store, &mockSender{}, hub)
+	ctx := context.Background()
+
+	svc.RecordOutbound("", "fast-crane", "no channel")
+	svc.RecordOutbound("slack:general", "fast-crane", "")
+
+	for _, ch := range []string{"", "slack:general"} {
+		msgs, err := store.GetMessages(ctx, ch, 10, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(msgs) != 0 {
+			t.Errorf("channel %q stored %d message(s), want 0", ch, len(msgs))
+		}
+	}
+	if len(hub.events) != 0 {
+		t.Errorf("published %v for an empty message, want nothing", hub.events)
+	}
+}
+
+// TestRecordOutboundThenInboundReadsAsConversation is the end-to-end shape the
+// bug report asked for: history in order, both sides present.
+func TestRecordOutboundThenInboundReadsAsConversation(t *testing.T) {
+	store := setupTestStore(t)
+	svc := NewService(store, &mockSender{}, &mockHub{})
+	ctx := context.Background()
+
+	svc.Dispatch("slack:general", "slack", "[slack] Puneet Rai", "U1", "", "??", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+	svc.RecordOutbound("slack:general", "fast-crane", "answered in Slack a minute ago")
+
+	msgs, err := store.GetMessages(ctx, "slack:general", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 2 {
+		t.Fatalf("expected both sides of the exchange, got %d message(s)", len(msgs))
+	}
+	// GetMessages returns newest first.
+	if msgs[0].Sender != "fast-crane" {
+		t.Errorf("newest message sender = %q, want the agent's reply", msgs[0].Sender)
+	}
+	if msgs[1].Sender != "[slack] Puneet Rai" {
+		t.Errorf("older message sender = %q, want the human's question", msgs[1].Sender)
 	}
 }

--- a/server/outbound_wiring_test.go
+++ b/server/outbound_wiring_test.go
@@ -1,0 +1,102 @@
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/db"
+	"github.com/rpuneet/mycel/pkg/gateway"
+	"github.com/rpuneet/mycel/pkg/notify"
+	"github.com/rpuneet/mycel/server"
+)
+
+// stubSendingAdapter is a minimal gateway adapter that accepts outbound
+// messages, standing in for Slack or WhatsApp.
+type stubSendingAdapter struct {
+	name string
+	sent int
+}
+
+func (s *stubSendingAdapter) Name() string                                            { return s.name }
+func (s *stubSendingAdapter) Type() gateway.AdapterType                               { return gateway.AdapterSocket }
+func (s *stubSendingAdapter) Start(context.Context, func(gateway.Notification)) error { return nil }
+func (s *stubSendingAdapter) Stop() error                                             { return nil }
+func (s *stubSendingAdapter) HTTPHandler() http.Handler                               { return nil }
+func (s *stubSendingAdapter) Channels() []gateway.ChannelInfo                         { return nil }
+func (s *stubSendingAdapter) Status() gateway.AdapterStatus                           { return gateway.AdapterStatus{} }
+
+func (s *stubSendingAdapter) Send(_ context.Context, _, _, _ string) error {
+	s.sent++
+	return nil
+}
+
+// TestServerWiresOutboundRecording covers the one line of production code that
+// connects gateway sends to notify's message store (server.New →
+// SetOutboundHandler). The unit tests on either side of that seam both pass
+// even if the wiring is deleted, which would silently restore the one-sided
+// history of #3462 — so the seam itself needs a test.
+func TestServerWiresOutboundRecording(t *testing.T) {
+	d, err := db.Open(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	store, err := notify.OpenStore(d, "sqlite")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gw := gateway.NewManager()
+	adapter := &stubSendingAdapter{name: "slack"}
+	gw.Register(adapter)
+
+	// server.New performs the wiring under test.
+	_ = server.New(
+		server.Config{Addr: "127.0.0.1:0"},
+		server.Services{Gateway: gw, Notify: notify.NewService(store, nil, nil)},
+		nil, nil,
+	)
+
+	sent, err := gw.Send(context.Background(), "slack:general", "fast-crane", "wired end to end")
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if !sent {
+		t.Fatal("Send() reported the channel as unhandled")
+	}
+	if adapter.sent != 1 {
+		t.Fatalf("adapter received %d sends, want 1", adapter.sent)
+	}
+
+	msgs, err := store.GetMessages(context.Background(), "slack:general", 10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("outbound message was not recorded: got %d rows in channel history", len(msgs))
+	}
+	if msgs[0].Sender != "fast-crane" || msgs[0].Content != "wired end to end" {
+		t.Errorf("recorded message = %q from %q", msgs[0].Content, msgs[0].Sender)
+	}
+}
+
+// TestServerOutboundWiringToleratesMissingNotify: a degraded boot can leave
+// Notify nil, and a send must still work rather than panic on the hook.
+func TestServerOutboundWiringToleratesMissingNotify(t *testing.T) {
+	gw := gateway.NewManager()
+	adapter := &stubSendingAdapter{name: "slack"}
+	gw.Register(adapter)
+
+	_ = server.New(
+		server.Config{Addr: "127.0.0.1:0"},
+		server.Services{Gateway: gw},
+		nil, nil,
+	)
+
+	sent, err := gw.Send(context.Background(), "slack:general", "fast-crane", "no notify service")
+	if err != nil || !sent {
+		t.Fatalf("Send() = (%v, %v), want (true, nil) with Notify nil", sent, err)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -300,6 +300,12 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 				svc.Notify.Dispatch(ch, platform, sender, senderID, senderAvatar, content, messageID, mentions, nil, raw, opts...)
 			}
 		})
+
+		// Record what agents send, not just what arrives, so channel history
+		// reads as a conversation instead of a one-sided log.
+		if svc.Notify != nil {
+			svc.Gateway.SetOutboundHandler(svc.Notify.RecordOutbound)
+		}
 	}
 	if svc.Costs != nil {
 		handlers.NewCostHandler(svc.Costs).Register(mux)


### PR DESCRIPTION
## Problem

Channel history is built from `notify_messages`, and only the inbound path ever
wrote to it (`notify.Dispatch` → `SaveMessage`). Agent replies went out to the
platform and disappeared, so a transcript showed the question and never the
answer.

From the live workspace, `slack:general`:

| Sender | Messages |
|--------|---------:|
| `[slack] Puneet Rai` | 659 |
| agent replies | 3 (two from 2026-07-03, one from 07-06) |

Months of two-way conversation recorded as one-sided. This came up because a
reply I sent was accepted by Slack (`{"sent":true}`) and was nowhere in the
channel's own history.

Fixes #3462.

## Change

`Manager.Send` is the single choke point every outbound text passes through — the
HTTP endpoint (`POST /api/channels/send`, which the CLI uses), the MCP
`send_message` tool, and the comment path in `server/mcp/tools.go` all reach it —
so one hook there covers all of them:

```go
func (m *Manager) SetOutboundHandler(fn func(channel, sender, content string))
```

- Fires **only after** the adapter accepts the message, on both the routed and
  the `platform:id` fallback path. Recording a rejected send would put a reply in
  the transcript that nobody received.
- A panic in the handler cannot fail a send the platform already accepted.
- Persistence stays in `notify`, which owns the table and the SSE hub.
  `RecordOutbound` publishes the same `channel.message` event the inbound path
  publishes, so an open channel view appends the reply live instead of waiting
  for a refetch (`GatewayFeed.tsx` appends from exactly that event).

## On duplicate risk

Worth flagging for review, since it decides whether a dedup guard is needed.
Slack's inbound handler deliberately lets agent bot-impersonation posts back in
(`subtype="bot_message"` with a `Username` override) so *other* agents see them —
`pkg/gateway/slack/slack.go`. If such an echo were stored, an outbound record
would duplicate it.

Empirically it is not being stored: 3 agent-sender rows in `slack:general` across
five months, versus continuous agent activity. The echo appears to be dropped
because a bot post carries `BotID` rather than `ev.User == botUserID`. I chose not
to add a dedup query on that evidence — it would cost a SELECT per inbound
message on a high-volume path to guard a case that does not currently occur. If a
reviewer knows of a platform that does echo, say so and I'll add the guard.

`SendFile` and `SendReaction` are not covered: an attachment has no text content
to store, and a reaction is not a message.

## Test plan

- [x] `TestSendRecordsOutbound` — routed send reaches the handler with the
      channel, sender and content, and still reaches the platform by native id.
- [x] `TestSendRecordsOutboundOnFallbackRoute` — the `platform:id` path is
      recorded too (easy to miss; there are two success paths in `Send`).
- [x] `TestSendDoesNotRecordFailedSend` — a rejected send records nothing.
- [x] `TestSendDoesNotRecordUnroutableChannel` — no route, no record.
- [x] `TestOutboundHandlerPanicDoesNotFailSend` — bookkeeping bugs don't surface
      as send failures.
- [x] `TestSendWithoutOutboundHandler` — the hook is optional.
- [x] `TestRecordOutboundStoresAndPublishes` — stored with the right sender, and
      the published payload carries the nested `message` object the UI needs.
      Also asserts no agent is woken by an outbound record.
- [x] `TestRecordOutboundIgnoresEmpty` — no blank rows.
- [x] `TestRecordOutboundThenInboundReadsAsConversation` — both sides present, in
      order.
- [x] Verified the tests fail without the fix: removing the two `recordOutbound`
      calls fails `TestSendRecordsOutbound` and
      `TestSendRecordsOutboundOnFallbackRoute`.
- [x] `go test ./pkg/... ./server/...` and `golangci-lint run ./...` clean.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Outgoing messages sent through configured channels are now recorded in conversation history.
  * Connected clients receive real-time updates for successfully delivered outgoing messages.
  * Outgoing messages support both direct platform routing and registered channel routing.

* **Bug Fixes**
  * Failed or empty sends are excluded from conversation history.
  * Handler errors no longer affect the result of a completed send.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->