### PR TITLE
fix(tool): stop a blank MCP command from panicking the health loop

### DIFF
--- a/pkg/tool/health.go
+++ b/pkg/tool/health.go
@@ -21,12 +21,22 @@ func checkOne(t *Tool) HealthResult {
 	r := HealthResult{Name: t.Name, Type: t.Type, Status: "ok"}
 	switch t.Type {
 	case ToolTypeMCP:
-		if t.Transport == "stdio" && t.Command != "" {
-			cmd := strings.Fields(t.Command)[0]
-			if _, err := exec.LookPath(cmd); err != nil {
-				r.Status = "error"
-				r.Error = "command not found: " + cmd
-			}
+		// Only a stdio server runs a local command. An SSE server's endpoint
+		// is not probed here, so it keeps the default "ok".
+		if t.Transport != "stdio" {
+			break
+		}
+		// Length check rather than t.Command != "": a command of only
+		// whitespace is non-empty yet yields no fields to look up.
+		fields := strings.Fields(t.Command)
+		if len(fields) == 0 {
+			r.Status = "error"
+			r.Error = "no command configured"
+			break
+		}
+		if _, err := exec.LookPath(fields[0]); err != nil {
+			r.Status = "error"
+			r.Error = "command not found: " + fields[0]
 		}
 	case ToolTypeCLI, ToolTypeProvider:
 		fields := strings.Fields(t.Command)

--- a/pkg/tool/health_test.go
+++ b/pkg/tool/health_test.go
@@ -91,3 +91,106 @@ func TestUpdateHealth_UnknownTool(t *testing.T) {
 		t.Error("expected error updating health for an unknown tool")
 	}
 }
+
+// TestCheckOne_BlankCommand pins the guard that keeps a misconfigured row from
+// panicking. strings.Fields collapses whitespace, so a command of " " is
+// non-empty yet has no first field: the MCP branch tested only for "" and
+// indexed [0] regardless. Both tool types are covered because the two branches
+// have already drifted apart once.
+func TestCheckOne_BlankCommand(t *testing.T) {
+	blanks := map[string]string{
+		"empty":     "",
+		"space":     " ",
+		"tab":       "\t",
+		"multiline": "  \n ",
+	}
+
+	for _, typ := range []string{ToolTypeMCP, ToolTypeCLI, ToolTypeProvider} {
+		for name, cmd := range blanks {
+			t.Run(typ+"/"+name, func(t *testing.T) {
+				// Transport is only consulted for MCP; harmless on the others.
+				r := checkOne(&Tool{Name: "blank", Type: typ, Transport: "stdio", Command: cmd})
+				if r.Status == "ok" || r.Status == "installed" {
+					t.Errorf("tool with no runnable command reported %q", r.Status)
+				}
+				if r.Error == "" {
+					t.Error("failing status came with no explanation")
+				}
+			})
+		}
+	}
+}
+
+// TestCheckOne_MCPStdio covers both live outcomes for a stdio server, so the
+// blank-command guard above cannot be satisfied by simply failing everything.
+func TestCheckOne_MCPStdio(t *testing.T) {
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh not found on PATH; cannot exercise a deterministic present case")
+	}
+
+	if r := checkOne(&Tool{Name: "present", Type: ToolTypeMCP, Transport: "stdio", Command: shPath}); r.Status != "ok" {
+		t.Errorf("stdio server on PATH = %q (%s), want ok", r.Status, r.Error)
+	}
+	if r := checkOne(&Tool{Name: "absent", Type: ToolTypeMCP, Transport: "stdio", Command: "definitely-not-a-real-binary-xyz"}); r.Status != "error" {
+		t.Errorf("stdio server missing from PATH = %q, want error", r.Status)
+	}
+}
+
+// TestCheckOne_SSEIsNotProbed records that an SSE server is never contacted
+// here, so it keeps the default status rather than being reported unreachable.
+// That default reads as healthy in the UI without anything having been
+// verified, which is tracked separately in #3475 — this test exists to keep the
+// stdio guard from quietly changing SSE handling in the meantime.
+func TestCheckOne_SSEIsNotProbed(t *testing.T) {
+	r := checkOne(&Tool{Name: "sse", Type: ToolTypeMCP, Transport: "sse", URL: "http://127.0.0.1:1/sse"})
+	if r.Status != "ok" {
+		t.Errorf("SSE server = %q, want the unprobed default ok", r.Status)
+	}
+}
+
+// TestCheckAll_SurvivesBlankMCPCommand runs a poisoned row through the batch
+// path the daemon's background loop uses. A panic here escaped CheckAll and,
+// from a bare goroutine, terminated the process — repeatedly, since the row
+// that provoked it survives a restart.
+func TestCheckAll_SurvivesBlankMCPCommand(t *testing.T) {
+	s := NewStore(setupSharedDB(t), "sqlite")
+	if err := s.Open(); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close() //nolint:errcheck // test cleanup
+
+	ctx := context.Background()
+	if err := s.Add(ctx, &Tool{
+		Name: "blank-mcp", Type: ToolTypeMCP, Transport: "stdio", Command: " ", Enabled: true,
+	}); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	results, err := s.CheckAll(ctx)
+	if err != nil {
+		t.Fatalf("CheckAll: %v", err)
+	}
+
+	found := false
+	for _, r := range results {
+		if r.Name == "blank-mcp" {
+			found = true
+			if r.Status != "error" {
+				t.Errorf("blank stdio command = %q, want error", r.Status)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("blank-mcp missing from CheckAll results")
+	}
+
+	// The batch must also persist the verdict, not just return it.
+	got, err := s.Get(ctx, "blank-mcp")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.HealthStatus != "error" {
+		t.Errorf("persisted health = %q, want error", got.HealthStatus)
+	}
+}

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -527,12 +527,19 @@ func runEventPruneLoop(ctx context.Context, prunable *eventspkg.SQLiteLog) {
 // re-verifies install status after its initial boot-time pass.
 const toolHealthCheckInterval = 10 * time.Minute
 
+// toolHealthChecker is the one method of tool.Store the health loop uses.
+// Narrowed to an interface so a checker that panics can be substituted in
+// tests, which is the only way to exercise checkToolsOnce's recovery.
+type toolHealthChecker interface {
+	CheckAll(ctx context.Context) ([]toolpkg.HealthResult, error)
+}
+
 // runToolHealthLoop runs store.CheckAll once immediately (off the request
 // path, so it never delays daemon startup) and then on a fixed interval,
 // keeping every tool's health_status fresh without requiring a manual
 // POST /api/tools/check. See tool.Store.CheckAll for the check itself and
 // ToolHandler.checkAll for the manual force-refresh that shares it.
-func runToolHealthLoop(ctx context.Context, store *toolpkg.Store) {
+func runToolHealthLoop(ctx context.Context, store toolHealthChecker) {
 	checkToolsOnce(ctx, store)
 	ticker := time.NewTicker(toolHealthCheckInterval)
 	defer ticker.Stop()
@@ -551,7 +558,7 @@ func runToolHealthLoop(ctx context.Context, store *toolpkg.Store) {
 // middleware cannot help, so an escaping panic would take the daemon down over
 // a status refresh — and would do so again on the next tick, since whatever
 // stored row provoked it is still there.
-func checkToolsOnce(ctx context.Context, store *toolpkg.Store) {
+func checkToolsOnce(ctx context.Context, store toolHealthChecker) {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Error("tool health auto-check panicked", "recover", r)

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -546,7 +546,17 @@ func runToolHealthLoop(ctx context.Context, store *toolpkg.Store) {
 	}
 }
 
+// checkToolsOnce runs a single health pass. It recovers from a panic in the
+// check itself: this runs on a background goroutine, where the HTTP Recovery
+// middleware cannot help, so an escaping panic would take the daemon down over
+// a status refresh — and would do so again on the next tick, since whatever
+// stored row provoked it is still there.
 func checkToolsOnce(ctx context.Context, store *toolpkg.Store) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("tool health auto-check panicked", "recover", r)
+		}
+	}()
 	if _, err := store.CheckAll(ctx); err != nil {
 		log.Warn("tool health auto-check failed", "error", err)
 	}

--- a/server/tool_health_test.go
+++ b/server/tool_health_test.go
@@ -7,7 +7,9 @@ package server
 import (
 	"context"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	dbpkg "github.com/rpuneet/mycel/pkg/db"
 	toolpkg "github.com/rpuneet/mycel/pkg/tool"
@@ -95,11 +97,26 @@ func TestRunToolHealthLoop_StopsOnContextCanceled(t *testing.T) {
 }
 
 // panickingChecker stands in for a store whose check blows up, the way indexing
-// a blank command's fields used to.
-type panickingChecker struct{ calls int }
+// a blank command's fields used to. calls is atomic because the loop test reads
+// it while the loop's goroutine is still running.
+type panickingChecker struct {
+	// called reports the first CheckAll, letting a test wait for the pass to
+	// have happened instead of racing the goroutine that runs it. Buffered and
+	// sent non-blockingly, so later passes never stall on an unread channel.
+	called chan struct{}
+	calls  atomic.Int32
+}
+
+func newPanickingChecker() *panickingChecker {
+	return &panickingChecker{called: make(chan struct{}, 1)}
+}
 
 func (p *panickingChecker) CheckAll(context.Context) ([]toolpkg.HealthResult, error) {
-	p.calls++
+	p.calls.Add(1)
+	select {
+	case p.called <- struct{}{}:
+	default:
+	}
 	panic("health check exploded")
 }
 
@@ -109,12 +126,12 @@ func (p *panickingChecker) CheckAll(context.Context) ([]toolpkg.HealthResult, er
 // refresh. The test fails by crashing the whole test binary rather than by
 // reporting, which is precisely the production symptom.
 func TestCheckToolsOnce_RecoversFromPanic(t *testing.T) {
-	checker := &panickingChecker{}
+	checker := newPanickingChecker()
 
 	checkToolsOnce(context.Background(), checker)
 
-	if checker.calls != 1 {
-		t.Fatalf("CheckAll called %d times, want 1", checker.calls)
+	if got := checker.calls.Load(); got != 1 {
+		t.Fatalf("CheckAll called %d times, want 1", got)
 	}
 }
 
@@ -123,8 +140,9 @@ func TestCheckToolsOnce_RecoversFromPanic(t *testing.T) {
 // through the loop would leave tool status frozen for the daemon's lifetime,
 // even once the daemon itself stopped dying.
 func TestRunToolHealthLoop_SurvivesPanickingCheck(t *testing.T) {
-	checker := &panickingChecker{}
+	checker := newPanickingChecker()
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan struct{})
 
 	go func() {
@@ -132,13 +150,35 @@ func TestRunToolHealthLoop_SurvivesPanickingCheck(t *testing.T) {
 		close(done)
 	}()
 
-	// Reaching the select after a panicking first pass is what proves the loop
-	// survived: a propagated panic would take the goroutine, and the process,
-	// down before this cancel could be observed.
-	cancel()
-	<-done
+	// Wait for the boot-time pass to have actually panicked. Cancelling without
+	// this could win the race and end the loop before it ever ran a check, so
+	// the test would report success having exercised nothing.
+	select {
+	case <-checker.called:
+	case <-time.After(5 * time.Second):
+		t.Fatal("boot-time health pass never ran")
+	}
 
-	if checker.calls != 1 {
-		t.Errorf("CheckAll called %d times, want 1 boot-time pass", checker.calls)
+	// Still sitting in its select, waiting on the ticker. This is the assertion
+	// that distinguishes a recovered panic from one that unwound the loop: if
+	// the panic had escaped checkToolsOnce, runToolHealthLoop would have
+	// returned and closed done without the context ever being canceled.
+	select {
+	case <-done:
+		t.Fatal("loop returned after a panicking pass instead of continuing")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not return after its context was canceled")
+	}
+
+	// One boot-time pass: the interval is far longer than this test runs, so a
+	// second call would mean the loop is ticking faster than configured.
+	if got := checker.calls.Load(); got != 1 {
+		t.Errorf("CheckAll called %d times, want 1 boot-time pass", got)
 	}
 }

--- a/server/tool_health_test.go
+++ b/server/tool_health_test.go
@@ -93,3 +93,52 @@ func TestRunToolHealthLoop_StopsOnContextCanceled(t *testing.T) {
 	cancel()
 	<-done // must return once ctx is canceled, not block forever on the ticker
 }
+
+// panickingChecker stands in for a store whose check blows up, the way indexing
+// a blank command's fields used to.
+type panickingChecker struct{ calls int }
+
+func (p *panickingChecker) CheckAll(context.Context) ([]toolpkg.HealthResult, error) {
+	p.calls++
+	panic("health check exploded")
+}
+
+// TestCheckToolsOnce_RecoversFromPanic covers the reason the recovery exists:
+// this runs on a background goroutine, where the HTTP Recovery middleware
+// cannot help, so a panic escaping here terminates the daemon over a status
+// refresh. The test fails by crashing the whole test binary rather than by
+// reporting, which is precisely the production symptom.
+func TestCheckToolsOnce_RecoversFromPanic(t *testing.T) {
+	checker := &panickingChecker{}
+
+	checkToolsOnce(context.Background(), checker)
+
+	if checker.calls != 1 {
+		t.Fatalf("CheckAll called %d times, want 1", checker.calls)
+	}
+}
+
+// TestRunToolHealthLoop_SurvivesPanickingCheck: the loop must also keep its
+// ticker after a failed pass. A panic in the boot-time check that unwound
+// through the loop would leave tool status frozen for the daemon's lifetime,
+// even once the daemon itself stopped dying.
+func TestRunToolHealthLoop_SurvivesPanickingCheck(t *testing.T) {
+	checker := &panickingChecker{}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go func() {
+		runToolHealthLoop(ctx, checker)
+		close(done)
+	}()
+
+	// Reaching the select after a panicking first pass is what proves the loop
+	// survived: a propagated panic would take the goroutine, and the process,
+	// down before this cancel could be observed.
+	cancel()
+	<-done
+
+	if checker.calls != 1 {
+		t.Errorf("CheckAll called %d times, want 1 boot-time pass", checker.calls)
+	}
+}

--- a/server/tool_health_test.go
+++ b/server/tool_health_test.go
@@ -150,7 +150,7 @@ func TestRunToolHealthLoop_SurvivesPanickingCheck(t *testing.T) {
 		close(done)
 	}()
 
-	// Wait for the boot-time pass to have actually panicked. Cancelling without
+	// Wait for the boot-time pass to have actually panicked. Canceling without
 	// this could win the race and end the loop before it ever ran a check, so
 	// the test would report success having exercised nothing.
 	select {


### PR DESCRIPTION
Fixes #3471

## The bug

`checkOne` guarded the MCP branch with `t.Command != ""` and then indexed
`strings.Fields(t.Command)[0]`. Whitespace collapses to no fields, so `" "`
passed the guard and panicked:

```
panic: runtime error: index out of range [0] with length 0
```

The `ToolTypeCLI` branch four lines below already checked the slice length, so
the two had drifted and only MCP was exposed.

## Why it mattered beyond a bad status

The check runs on a background ticker started as a bare goroutine
(`server/build_services.go:239`), where the HTTP `Recovery` middleware cannot
help. The panic therefore took the whole daemon down, and did so again on the
next tick after every restart, since the offending row persists. Per #3470 that
row can be written with an unauthenticated cross-origin `POST /api/tools`, which
makes it a remote kill rather than a local misconfiguration.

## The change

- Guard on the field count, matching the CLI branch.
- Report a stdio server with no command as `error` instead of leaving the
  default `"ok"`: it cannot start, so `"ok"` was a false negative. Neither
  seeded server changes status — `playwright` is SSE and `github` has a command
  — so no existing install flips to red.
- `checkToolsOnce` now recovers, so no future panic inside a health check can
  take the process with it. Defence in depth; the guard above is the actual fix.

## Tests

`TestCheckOne_BlankCommand` covers `""`, `" "`, `"\t"` and `"  \n "` across all
three tool types, since the branches have drifted once already. Verified it
reproduces the original panic with the fix reverted:

```
--- FAIL: TestCheckOne_BlankCommand/mcp/space
panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]
```

`TestCheckAll_SurvivesBlankMCPCommand` drives a poisoned row through the real
batch path the background loop uses and asserts the verdict is persisted, not
just returned. `TestCheckOne_MCPStdio` covers both live outcomes so the new
guard cannot be satisfied by failing everything, and
`TestCheckOne_SSEIsNotProbed` keeps the refactor from quietly changing SSE
handling while #3475 is open.

## Verification

`go build ./...`, `go vet`, `golangci-lint run` (0 issues), and
`go test ./pkg/tool/ ./server/` all pass.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool health checks for blank commands and missing executables.
  * Prevented health checks from probing unsupported transports.
  * Ensured batch health checks continue when a tool has an invalid command.
  * Prevented background health monitoring from stopping after an unexpected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->