### PR TITLE
fix(server): refuse cross-origin writes to the daemon API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Cross-origin writes are refused.** Any page the user had open in another
+  tab could call the daemon's API — loopback keeps other machines out, not
+  other websites — and `POST /api/tools` accepted an arbitrary `install_cmd`
+  that `POST /api/deps/install` then handed to `sh -c`. State-changing
+  requests now have to come from an origin the daemon serves, from a loopback
+  origin, or from a non-browser client such as the CLI. Reads are unchanged
+  (#3470).
+
 ## [0.4.4] - 2026-08-02
 
 App readiness. The surfaces that looked finished in 0.4.3 became real:

--- a/docs/explanation/security.md
+++ b/docs/explanation/security.md
@@ -108,7 +108,7 @@ crafted key names.
 The mycel server applies middleware in this order (outermost runs first):
 
 ```
-RateLimit → APIKeyAuth → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → Router
+RateLimit → APIKeyAuth → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → RejectCrossOriginMutations → Router
 ```
 
 ### API Key Authentication
@@ -154,8 +154,42 @@ instead of crashing the server or exposing stack traces.
 
 ### CORS
 
-CORS is enabled by default with origin `*` (safe because the server only
-listens on localhost). The origin can be restricted via `Config.CORSOrigin`.
+CORS is enabled by default with origin `*`, and the origin can be restricted via
+`Config.CORSOrigin`.
+
+Listening only on localhost does **not** make `*` safe on its own. A web page the
+user has open in another tab can call `http://127.0.0.1:9374`, and the request
+arrives from a loopback address carrying the user's full authority — the browser
+acts as a confused deputy, so binding to loopback keeps other machines out but
+not other websites.
+
+### Cross-origin mutations
+
+`RejectCrossOriginMutations` answers that. Any request whose method is not `GET`,
+`HEAD` or `OPTIONS` must show that it came from an origin the daemon serves, or
+from something that is not a browser:
+
+- **No `Origin` header** — allowed. A browser sets `Origin` on every request whose
+  method is not `GET` or `HEAD`, even a same-origin one, so its absence means the
+  caller is the CLI, the SDK, or another server. A `Sec-Fetch-Site: cross-site`
+  header still rejects the request, since a browser sets that one itself and page
+  script cannot forge it.
+- **The daemon's own origin** — allowed.
+- **Any loopback origin** — allowed, whatever the port. The dev server proxies
+  `/api` while forwarding the browser's `Origin`, and the desktop shell serves its
+  boot page from a separate loopback origin; a page from a remote site can never
+  present a loopback origin. The residual risk is a hostile server running on the
+  user's own machine, which is a far narrower threat than any website they visit.
+- **The configured `CORSOrigin`**, when set to a specific origin rather than `*` —
+  allowed, so a separately hosted UI can still write.
+- **Anything else** — `403`.
+
+Reads are deliberately untouched: what a foreign origin may *read* is a privacy
+question that CORS already governs, whereas a write can store a tool's install
+command and have it executed. The middleware is applied even when CORS headers
+are disabled, because a request needing no preflight is sent regardless of what
+headers come back — turning CORS off hides the response from an attacker without
+preventing the write.
 
 ### Request IDs
 

--- a/server/crossorigin_wiring_test.go
+++ b/server/crossorigin_wiring_test.go
@@ -1,0 +1,105 @@
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/mycel/server"
+)
+
+// postTools issues the write that the vulnerability turned into remote code
+// execution: storing a tool whose install_cmd is later handed to sh -c. It
+// returns the status and response headers, closing the body before it does.
+func postTools(t *testing.T, baseURL, origin string) (int, http.Header) {
+	t.Helper()
+	body := `{"name":"pwned","type":"cli","command":"sh","install_cmd":"touch /tmp/pwned"}`
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodPost, baseURL+"/api/tools", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+	return resp.StatusCode, resp.Header.Clone()
+}
+
+// TestCrossOriginMutationsAreRejectedEndToEnd exercises the middleware through
+// the real chain in the default configuration. The unit tests in
+// server/handlers pass whether or not the middleware is ever installed, so
+// without this the wiring could be dropped and nothing would notice.
+func TestCrossOriginMutationsAreRejectedEndToEnd(t *testing.T) {
+	svc := buildTestBundle(t)
+
+	// The shape `mycel up` produces: CORS on, origin "*".
+	srv := server.New(server.Config{Addr: "127.0.0.1:0", CORS: true, CORSOrigin: "*"}, svc, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	status, header := postTools(t, ts.URL, "https://evil.example.com")
+	if status != http.StatusForbidden {
+		t.Fatalf("POST /api/tools from a foreign origin = %d, want %d", status, http.StatusForbidden)
+	}
+
+	// The refusal still carries CORS headers, so the middleware sits inside the
+	// CORS wrapper and the browser sees a real status rather than a network
+	// error it cannot explain.
+	if got := header.Get("Access-Control-Allow-Origin"); got == "" {
+		t.Error("403 came back without CORS headers — ordering regression")
+	}
+}
+
+// TestLocalClientsCanStillMutate is the control: the fix must not break the
+// clients that legitimately write. A CLI request carries no Origin at all, and
+// the web UI's carries the daemon's own.
+func TestLocalClientsCanStillMutate(t *testing.T) {
+	svc := buildTestBundle(t)
+	srv := server.New(server.Config{Addr: "127.0.0.1:0", CORS: true, CORSOrigin: "*"}, svc, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	// CLI / SDK: no Origin header.
+	if status, _ := postTools(t, ts.URL, ""); status == http.StatusForbidden {
+		t.Error("a client sending no Origin was rejected — this breaks the CLI")
+	}
+
+	// Web UI: same origin as the daemon. ts.URL is the loopback address the
+	// test server is listening on, which is exactly what the browser would send.
+	if status, _ := postTools(t, ts.URL, ts.URL); status == http.StatusForbidden {
+		t.Error("the daemon's own origin was rejected — this breaks the web UI")
+	}
+}
+
+// TestReadsAreUnaffected keeps the fix scoped: GET is governed by CORS, and
+// tightening writes must not start refusing reads.
+func TestReadsAreUnaffected(t *testing.T) {
+	svc := buildTestBundle(t)
+	srv := server.New(server.Config{Addr: "127.0.0.1:0", CORS: true, CORSOrigin: "*"}, svc, nil, nil)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+"/api/tools", nil)
+	if err != nil {
+		t.Fatalf("new req: %v", err)
+	}
+	req.Header.Set("Origin", "https://evil.example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer resp.Body.Close() //nolint:errcheck // test cleanup
+
+	if resp.StatusCode == http.StatusForbidden {
+		t.Errorf("GET /api/tools was rejected as cross-origin: %d", resp.StatusCode)
+	}
+}

--- a/server/handlers/crossorigin.go
+++ b/server/handlers/crossorigin.go
@@ -1,0 +1,111 @@
+package handlers
+
+import (
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Loopback is not a trust boundary against a web browser. The daemon binds to
+// 127.0.0.1 and answers with Access-Control-Allow-Origin: *, so any page the
+// user happens to have open can call this API, and the call arrives from
+// 127.0.0.1 carrying the user's full authority — the browser acts as a confused
+// deputy. Read-only access is a privacy question that CORS already governs;
+// a state change is the dangerous one, because storing a tool's install command
+// and then triggering an install amounts to remote code execution.
+//
+// So a mutating request has to show it came from an origin this daemon serves,
+// or from something that is not a browser at all.
+
+// safeMethods do not change state, so CORS alone governs them.
+var safeMethods = map[string]bool{
+	http.MethodGet:     true,
+	http.MethodHead:    true,
+	http.MethodOptions: true,
+}
+
+// RejectCrossOriginMutations refuses state-changing requests that a browser
+// began from an origin the daemon does not serve. allowedOrigin is the
+// configured CORS origin: when it names a specific origin rather than "*", that
+// origin may mutate too, which is what keeps a separately hosted UI working.
+//
+// Applied whether or not CORS headers are enabled. A request that needs no
+// preflight is sent regardless of the response's CORS headers, so turning CORS
+// off only hides the reply from the attacker — it does not prevent the write.
+func RejectCrossOriginMutations(allowedOrigin string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if safeMethods[r.Method] || mutationAllowed(r, allowedOrigin) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		httpError(w, "forbidden: cross-origin request", http.StatusForbidden)
+	})
+}
+
+// mutationAllowed reports whether r is permitted to change state.
+func mutationAllowed(r *http.Request, allowedOrigin string) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		// No Origin means no browser sent this: per the Fetch standard a browser
+		// sets Origin on every request whose method is not GET or HEAD, even a
+		// same-origin one. So this is the CLI, the SDK, curl, or another server.
+		//
+		// Sec-Fetch-Site is set by the browser and cannot be forged from page
+		// script, so it still catches a browser that omitted Origin.
+		return r.Header.Get("Sec-Fetch-Site") != "cross-site"
+	}
+
+	// A specific configured origin is trusted. "*" is not: it is the default,
+	// so it means "origin unspecified" rather than "anyone may write".
+	if allowedOrigin != "" && allowedOrigin != "*" && strings.EqualFold(origin, allowedOrigin) {
+		return true
+	}
+
+	host := originHost(origin)
+	if host == "" {
+		// Opaque origin — a sandboxed iframe, or a file:// page — sends
+		// "null", which names nothing this daemon serves.
+		return false
+	}
+
+	// This daemon served the page.
+	if strings.EqualFold(host, r.Host) {
+		return true
+	}
+
+	// Or something else on this machine did. The dev server proxies /api while
+	// forwarding the browser's own Origin, and the desktop shell serves its
+	// boot page from a separate loopback origin, so both look cross-origin to
+	// the strict test while both are in fact local tooling. A page from a
+	// remote site can never present a loopback origin, which is the case this
+	// exists to stop.
+	return isLoopbackHost(host)
+}
+
+// originHost returns the host[:port] of an Origin header value, or "" if the
+// value does not name a host.
+func originHost(origin string) string {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	return u.Host
+}
+
+// isLoopbackHost reports whether host[:port] names this machine.
+func isLoopbackHost(host string) bool {
+	h, _, err := net.SplitHostPort(host)
+	if err != nil {
+		// No port to split off.
+		h = host
+	}
+	h = strings.Trim(h, "[]")
+	if strings.EqualFold(h, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(h); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}

--- a/server/handlers/crossorigin_test.go
+++ b/server/handlers/crossorigin_test.go
@@ -1,0 +1,197 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRejectCrossOriginMutations covers the decision table directly, because
+// every row is a policy choice rather than an implementation detail: the false
+// rows are the vulnerability and the true rows are the clients that must keep
+// working.
+func TestRejectCrossOriginMutations(t *testing.T) {
+	const daemonHost = "127.0.0.1:9374"
+
+	tests := []struct {
+		name          string
+		method        string
+		host          string
+		origin        string
+		secFetchSite  string
+		allowedOrigin string
+		wantAllowed   bool
+	}{
+		{
+			name:        "attack: mutation from an unrelated website",
+			method:      http.MethodPost,
+			host:        daemonHost,
+			origin:      "https://evil.example.com",
+			wantAllowed: false,
+		},
+		{
+			name:         "attack: sec-fetch-site betrays a browser that sent no origin",
+			method:       http.MethodPost,
+			host:         daemonHost,
+			secFetchSite: "cross-site",
+			wantAllowed:  false,
+		},
+		{
+			name:        "attack: opaque origin from a sandboxed frame",
+			method:      http.MethodPost,
+			host:        daemonHost,
+			origin:      "null",
+			wantAllowed: false,
+		},
+		{
+			name:        "attack: hostname merely containing localhost",
+			method:      http.MethodPost,
+			host:        daemonHost,
+			origin:      "http://localhost.evil.example.com",
+			wantAllowed: false,
+		},
+		{
+			name:        "attack: delete from an unrelated website",
+			method:      http.MethodDelete,
+			host:        daemonHost,
+			origin:      "https://evil.example.com",
+			wantAllowed: false,
+		},
+		{
+			name:        "web UI: same origin as the daemon",
+			method:      http.MethodPost,
+			host:        daemonHost,
+			origin:      "http://127.0.0.1:9374",
+			wantAllowed: true,
+		},
+		{
+			name:        "CLI: no origin, no sec-fetch-site",
+			method:      http.MethodPost,
+			host:        daemonHost,
+			wantAllowed: true,
+		},
+		{
+			name:        "dev server: browser origin forwarded through the vite proxy",
+			method:      http.MethodPost,
+			host:        "localhost:9375",
+			origin:      "http://localhost:9374",
+			wantAllowed: true,
+		},
+		{
+			name:        "desktop shell: another loopback origin on this machine",
+			method:      http.MethodPost,
+			host:        daemonHost,
+			origin:      "http://localhost:9374",
+			wantAllowed: true,
+		},
+		{
+			name:          "hosted UI: the explicitly configured origin may write",
+			method:        http.MethodPost,
+			host:          "mycel.internal",
+			origin:        "https://ui.example.com",
+			allowedOrigin: "https://ui.example.com",
+			wantAllowed:   true,
+		},
+		{
+			name:          "wildcard does not confer write permission",
+			method:        http.MethodPost,
+			host:          "mycel.internal",
+			origin:        "https://evil.example.com",
+			allowedOrigin: "*",
+			wantAllowed:   false,
+		},
+		{
+			name:        "reads are left to CORS: GET from anywhere passes through",
+			method:      http.MethodGet,
+			host:        daemonHost,
+			origin:      "https://evil.example.com",
+			wantAllowed: true,
+		},
+		{
+			name:        "preflight is not a mutation",
+			method:      http.MethodOptions,
+			host:        daemonHost,
+			origin:      "https://evil.example.com",
+			wantAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reached := false
+			h := RejectCrossOriginMutations(tt.allowedOrigin, http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					reached = true
+					w.WriteHeader(http.StatusOK)
+				}))
+
+			req := httptest.NewRequest(tt.method, "http://"+tt.host+"/api/tools", nil)
+			req.Host = tt.host
+			if tt.origin != "" {
+				req.Header.Set("Origin", tt.origin)
+			}
+			if tt.secFetchSite != "" {
+				req.Header.Set("Sec-Fetch-Site", tt.secFetchSite)
+			}
+
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if reached != tt.wantAllowed {
+				t.Errorf("handler reached = %v, want %v (status %d)", reached, tt.wantAllowed, rec.Code)
+			}
+			if !tt.wantAllowed && rec.Code != http.StatusForbidden {
+				t.Errorf("rejected request answered %d, want %d", rec.Code, http.StatusForbidden)
+			}
+		})
+	}
+}
+
+// TestRejectCrossOriginMutationsCoversEveryWriteMethod guards against a method
+// being overlooked: anything that is not a documented safe method has to be
+// gated, so adding PATCH support to a route cannot silently reopen this.
+func TestRejectCrossOriginMutationsCoversEveryWriteMethod(t *testing.T) {
+	for _, m := range []string{
+		http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodConnect, http.MethodTrace,
+	} {
+		t.Run(m, func(t *testing.T) {
+			reached := false
+			h := RejectCrossOriginMutations("*", http.HandlerFunc(
+				func(http.ResponseWriter, *http.Request) { reached = true }))
+
+			req := httptest.NewRequest(m, "http://127.0.0.1:9374/api/tools", nil)
+			req.Host = "127.0.0.1:9374"
+			req.Header.Set("Origin", "https://evil.example.com")
+
+			h.ServeHTTP(httptest.NewRecorder(), req)
+			if reached {
+				t.Errorf("%s from a foreign origin reached the handler", m)
+			}
+		})
+	}
+}
+
+func TestIsLoopbackHost(t *testing.T) {
+	loopback := []string{
+		"localhost", "localhost:9374", "LocalHost:9374",
+		"127.0.0.1", "127.0.0.1:8080", "127.0.0.53",
+		"[::1]", "[::1]:9374",
+	}
+	for _, h := range loopback {
+		if !isLoopbackHost(h) {
+			t.Errorf("isLoopbackHost(%q) = false, want true", h)
+		}
+	}
+
+	remote := []string{
+		"", "evil.example.com", "localhost.evil.example.com",
+		"127.0.0.1.evil.example.com", "10.0.0.5", "8.8.8.8:80",
+		"notlocalhost",
+	}
+	for _, h := range remote {
+		if isLoopbackHost(h) {
+			t.Errorf("isLoopbackHost(%q) = true, want false", h)
+		}
+	}
+}

--- a/server/handlers/helpers.go
+++ b/server/handlers/helpers.go
@@ -251,8 +251,13 @@ func (w *gzipResponseWriter) Write(b []byte) (int, error) {
 }
 
 // CORSWithOrigin returns a middleware that adds CORS headers with the specified
-// allowed origin. Use "*" for permissive (safe on loopback) or a specific
-// origin like "http://localhost:9374" when exposed beyond loopback.
+// allowed origin. Use "*" for permissive, or a specific origin like
+// "http://localhost:9374" when exposed beyond loopback.
+//
+// "*" governs what a foreign origin may read; it is not what keeps one from
+// writing. Loopback is no defense against a browser, since a page in another tab
+// reaches 127.0.0.1 with the user's authority — see RejectCrossOriginMutations,
+// which gates every state-changing request.
 func CORSWithOrigin(allowedOrigin string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
@@ -267,7 +272,7 @@ func CORSWithOrigin(allowedOrigin string, next http.Handler) http.Handler {
 }
 
 // CORS returns a middleware with permissive CORS headers (Allow-Origin: *).
-// Safe because the daemon only binds to loopback by default.
+// Mutations are gated separately by RejectCrossOriginMutations.
 func CORS(next http.Handler) http.Handler {
 	return CORSWithOrigin("*", next)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -533,13 +533,18 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	}
 
 	// Middleware chain (outermost runs first):
-	// RateLimit → APIKeyAuth → RequestID → RequestLogger → Recovery → Gzip → MaxBodySize → CORS → mux
+	// RateLimit → APIKeyAuth → RequestID → RequestLogger → Recovery → Gzip →
+	// MaxBodySize → CORS → RejectCrossOriginMutations → mux
 	var handler http.Handler = mux
+	origin := cfg.CORSOrigin
+	if origin == "" {
+		origin = "*"
+	}
+	// Inside CORS so a preflight is still answered and the 403 carries CORS
+	// headers, but applied even when CORS is off: a request that needs no
+	// preflight reaches the mux regardless of what headers come back.
+	handler = handlers.RejectCrossOriginMutations(origin, handler)
 	if cfg.CORS {
-		origin := cfg.CORSOrigin
-		if origin == "" {
-			origin = "*"
-		}
 		handler = handlers.CORSWithOrigin(origin, handler)
 	}
 	handler = handlers.MaxBodySize(1 << 20)(handler) // 1MB request body limit


### PR DESCRIPTION
Fixes #3470

## The vulnerability

The daemon binds to loopback and answers `Access-Control-Allow-Origin: *`, which
the code comment and `docs/explanation/security.md` both justified as "safe
because the server only listens on localhost". Loopback keeps *other machines*
out. It does nothing about *other websites*: a page open in any tab can call
`127.0.0.1`, and the request arrives from a loopback address with the user's full
authority.

Two facts turn that into code execution:

- `POST /api/tools` has no authentication and no validation of `install_cmd`
  (`rg checkLoopback server/handlers/tools.go` returns nothing).
- `POST /api/deps/install` resolves a stored `install_cmd` and hands it to
  `sh -c`. Its doc comment says commands come "from a vetted table … never a
  command supplied in the request body" — which stops being true once the
  registry is writable this way. Its `checkLoopback` does not help, because a
  browser-driven request *is* loopback.

The end-to-end test demonstrates it. With the middleware removed, a `POST` from
`https://evil.example.com` storing `install_cmd: touch /tmp/pwned` returns:

```
--- FAIL: TestCrossOriginMutationsAreRejectedEndToEnd
    POST /api/tools from a foreign origin = 201, want 403
```

## The fix

`RejectCrossOriginMutations` gates every request whose method is not `GET`,
`HEAD` or `OPTIONS`. It is allowed when it carries:

| | Why |
|---|---|
| no `Origin` | Browsers set `Origin` on every non-`GET`/`HEAD` request, even same-origin ones, so its absence rules a browser out — this is the CLI, the SDK, another server. `Sec-Fetch-Site: cross-site` still rejects, since page script cannot forge it. |
| the daemon's own origin | The UI it serves. |
| any loopback origin | See below. |
| the configured `--cors-origin`, when specific | Lets a separately hosted UI write. `*` confers nothing: it is the default and means "unspecified". |

Anything else gets a `403`.

**On accepting any loopback origin.** The strict `Origin == Host` test breaks two
real clients: the Vite dev server proxies `/api` while forwarding the browser's
own `Origin` (`web/vite.config.ts:11`), and the desktop shell serves its boot page
from a separate loopback origin before handing off (`desktop/bootpage.go:71-79`).
A remote site can never present a loopback origin, so the case this exists to stop
is still stopped. The residual risk is a hostile server on the user's own machine,
which is far narrower than any website they visit. Both trade-offs are written down
in the middleware and in the security doc rather than left implicit.

**Scope.** Reads are untouched — what a foreign origin may read is a privacy
question CORS already governs, whereas a write can store a command and have it
run. The middleware applies even when CORS is disabled, because a request needing
no preflight is sent regardless of what headers come back; turning CORS off hides
the reply from the attacker without preventing the write.

## Tests

- `TestRejectCrossOriginMutations` — the decision table: 5 attack rows (foreign
  origin, `Sec-Fetch-Site` with no `Origin`, opaque `null`, a hostname merely
  *containing* `localhost`, cross-origin `DELETE`) and 8 rows for clients that
  must keep working.
- `TestRejectCrossOriginMutationsCoversEveryWriteMethod` — `PATCH`, `CONNECT` and
  `TRACE` included, so adding a method to a route cannot silently reopen this.
- `TestIsLoopbackHost` — including `localhost.evil.example.com` and
  `127.0.0.1.evil.example.com`, which must not pass.
- `TestCrossOriginMutationsAreRejectedEndToEnd` — through the real middleware
  chain in the `mycel up` configuration, and asserts the `403` still carries CORS
  headers so the ordering is right. **Verified it fails when the wiring is
  removed** (the `201` above); the handler unit tests pass either way, which is
  the lesson from #3462.
- `TestLocalClientsCanStillMutate` / `TestReadsAreUnaffected` — the controls.

## Verification

`go build ./...`, `go vet ./server/...`, `golangci-lint run server/...` (0 issues),
and the **full** `go test ./...` all pass — worth running whole, since this touches
every mutating request in the API.

## Docs

`docs/explanation/security.md` had the wrong reasoning written down as fact, so it
is corrected rather than merely extended: it now states plainly that loopback is
not a defense against a browser, documents the allow-list, and explains why reads
are excluded. The two comments in `helpers.go` that claimed `*` was "safe on
loopback" are fixed for the same reason.

## Related

#3471 (blank MCP command panics the daemon) is remotely reachable *through* this
endpoint; it is fixed separately in #3476.

Made with [Cursor](https://cursor.com)