### PR TITLE
fix(mcp): stop agent-spawned children bypassing the guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   origin, or from a non-browser client such as the CLI. Reads are unchanged
   (#3470).
 
+### Fixed
+
+- **Agent-spawned children are no longer exempt from guardrails.** `spawn_agent`
+  over MCP had no `template` field, and the guardrail loop skips any agent
+  without one, so every child an agent spawned ran with no cost cap and no stuck
+  detection — the unattended case the guardrails exist for. It now accepts a
+  template and, when none is given, inherits the caller's, so omitting the field
+  cannot silently mean "unguarded" (#3472).
+
 ## [0.4.4] - 2026-08-02
 
 App readiness. The surfaces that looked finished in 0.4.3 became real:

--- a/server/mcp/orchestration_test.go
+++ b/server/mcp/orchestration_test.go
@@ -133,6 +133,95 @@ func TestE2E_SpawnAgent_Success(t *testing.T) {
 	}
 }
 
+// spawnChild runs spawn_agent as "boss" and returns the registered child. The
+// parent is seeded with parentTemplate so inheritance can be observed.
+func spawnChild(t *testing.T, parentTemplate string, args map[string]any) (*agent.Agent, map[string]any) {
+	t.Helper()
+	withRoleHierarchy(t, agent.Role("manager"), agent.Role("engineer"))
+	mgr, svc, h := newOrchestrationSvc(t)
+
+	if err := mgr.RegisterStopped(&agent.Agent{
+		Name: "boss", Role: agent.Role("manager"), Repo: h.RootDir, Template: parentTemplate,
+	}); err != nil {
+		t.Fatalf("seed parent: %v", err)
+	}
+
+	session, _ := newTestSession(t, Config{Home: h, Agents: mgr, AgentSvc: svc}, "boss")
+
+	if args["role"] == nil {
+		args["role"] = "engineer"
+	}
+	if args["provider"] == nil {
+		args["provider"] = "mcp-test-tool"
+	}
+	res, err := session.CallTool(t.Context(), &sdk.CallToolParams{Name: "spawn_agent", Arguments: args})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("spawn_agent errored: %v", errText(t, res))
+	}
+
+	name, _ := args["name"].(string)
+	child := mgr.GetAgent(name)
+	if child == nil {
+		t.Fatalf("%q was not registered in the manager", name)
+	}
+	return child, structured(t, res)
+}
+
+// TestE2E_SpawnAgent_RecordsTemplate covers the guardrail bypass: guardrails are
+// enforced per template and the enforcement loop skips any agent whose Template
+// is empty, so a child spawned without one is exempt from its cost cap and stuck
+// detection. spawn_agent had no template field at all, which made every
+// agent-spawned child unguarded — the unattended case guardrails exist for.
+func TestE2E_SpawnAgent_RecordsTemplate(t *testing.T) {
+	child, out := spawnChild(t, "", map[string]any{"name": "worker-tmpl", "template": "capped"})
+
+	if child.Template != "capped" {
+		t.Errorf("child template = %q, want %q — the guardrail loop skips agents with none",
+			child.Template, "capped")
+	}
+	// Reported back, so a caller can see the child is covered rather than assume it.
+	if out["template"] != "capped" {
+		t.Errorf("reported template = %v, want capped", out["template"])
+	}
+}
+
+// TestE2E_SpawnAgent_InheritsParentTemplate: omitting the field must not mean
+// "unguarded". Every caller written before the field existed omits it, so
+// without inheritance the bypass would survive the fix that added it.
+func TestE2E_SpawnAgent_InheritsParentTemplate(t *testing.T) {
+	child, out := spawnChild(t, "capped", map[string]any{"name": "worker-inherit"})
+
+	if child.Template != "capped" {
+		t.Errorf("child template = %q, want the parent's %q", child.Template, "capped")
+	}
+	if out["template"] != "capped" {
+		t.Errorf("reported template = %v, want capped", out["template"])
+	}
+}
+
+// TestE2E_SpawnAgent_ExplicitTemplateWins keeps inheritance from becoming a
+// straitjacket: a caller may still spawn a child under a different template.
+func TestE2E_SpawnAgent_ExplicitTemplateWins(t *testing.T) {
+	child, _ := spawnChild(t, "capped", map[string]any{"name": "worker-override", "template": "generous"})
+
+	if child.Template != "generous" {
+		t.Errorf("child template = %q, want the explicitly requested %q", child.Template, "generous")
+	}
+}
+
+// TestE2E_SpawnAgent_NoTemplateAnywhere: an unguarded parent still spawns an
+// unguarded child. Inheritance propagates guardrails, it does not invent them.
+func TestE2E_SpawnAgent_NoTemplateAnywhere(t *testing.T) {
+	child, _ := spawnChild(t, "", map[string]any{"name": "worker-none"})
+
+	if child.Template != "" {
+		t.Errorf("child template = %q, want empty when neither side names one", child.Template)
+	}
+}
+
 // TestE2E_SpawnAgent_DeniedWithoutCapability verifies the role-hierarchy
 // gate: a caller whose role has no entry permitting the requested child
 // role is rejected and no agent is created.

--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -26,8 +26,11 @@ const (
 	maxRoleLen    = 256       // role filter on list_agents
 	maxTaskLen    = 1024      // report_status task line
 	maxPathLen    = 4 * 1024  // file_path on send_file (typical PATH_MAX)
-	maxFileSize   = 50 * 1024 * 1024
-	maxReadLimit  = 200 // read_channel page size cap
+	// maxTemplateLen bounds a template name on spawn_agent. Names are short
+	// identifiers, so this only exists to reject junk before it reaches the store.
+	maxTemplateLen = 256
+	maxFileSize    = 50 * 1024 * 1024
+	maxReadLimit   = 200 // read_channel page size cap
 )
 
 // readOnly marks tools with no side effects so MCP clients can skip
@@ -611,6 +614,7 @@ type spawnAgentIn struct {
 	Task     string `json:"task,omitempty" jsonschema:"one-line initial task description recorded on the new agent (shown in the TUI/web UI)"`
 	Provider string `json:"provider,omitempty" jsonschema:"AI provider/tool for the new agent (e.g. claude); empty uses the fleet default"`
 	Repo     string `json:"repo,omitempty" jsonschema:"absolute path of the git repo to bind the new agent to; empty binds it to this agent's own repo"`
+	Template string `json:"template,omitempty" jsonschema:"template to spawn the new agent from; recorded on the agent so the template's guardrails (max cost, stuck timeout) are enforced against it. Empty inherits this agent's own template"`
 }
 
 type spawnAgentOut struct {
@@ -618,6 +622,10 @@ type spawnAgentOut struct {
 	Role     string `json:"role"`
 	State    string `json:"state"`
 	ParentID string `json:"parent_id,omitempty"`
+	// Template reports what the child was actually spawned with, which is not
+	// always what was asked for: an omitted template is inherited from the
+	// caller. Reported so guardrail coverage is visible rather than assumed.
+	Template string `json:"template,omitempty"`
 }
 
 func spawnAgent(ctx context.Context, cfg Config, agentName string, in spawnAgentIn) (*sdk.CallToolResult, spawnAgentOut, error) {
@@ -637,16 +645,30 @@ func spawnAgent(ctx context.Context, cfg Config, agentName string, in spawnAgent
 	if len(in.Repo) > maxPathLen {
 		return nil, out, fmt.Errorf("repo too long: %d bytes (max %d)", len(in.Repo), maxPathLen)
 	}
+	if len(in.Template) > maxTemplateLen {
+		return nil, out, fmt.Errorf("template too long: %d bytes (max %d)", len(in.Template), maxTemplateLen)
+	}
 	if cfg.AgentSvc == nil || cfg.Agents == nil {
 		return nil, out, fmt.Errorf("agent orchestration not available")
 	}
 
-	// Default to the caller's own repo so a spawned child shares the
-	// caller's worktree root unless a different repo is explicitly named.
-	repo := in.Repo
-	if repo == "" {
+	// Default to the caller's own repo so a spawned child shares the caller's
+	// worktree root unless a different repo is explicitly named.
+	//
+	// Inherit the caller's template for a different reason: guardrails
+	// (MaxCostUSD, StuckTimeoutMin) are enforced per template, and an agent with
+	// no template recorded is exempt from them entirely. Without inheritance a
+	// child would be unguarded whenever the field was simply left out — which is
+	// every existing caller, since the field did not exist until now.
+	repo, template := in.Repo, in.Template
+	if repo == "" || template == "" {
 		if caller := cfg.Agents.GetAgent(agentName); caller != nil {
-			repo = caller.Repo
+			if repo == "" {
+				repo = caller.Repo
+			}
+			if template == "" {
+				template = caller.Template
+			}
 		}
 	}
 
@@ -656,11 +678,12 @@ func spawnAgent(ctx context.Context, cfg Config, agentName string, in spawnAgent
 	// whose role isn't permitted to create the requested role gets a
 	// clear error and no agent is spawned.
 	child, err := cfg.AgentSvc.Create(ctx, agent.CreateOptions{
-		Name:   in.Name,
-		Role:   agent.Role(in.Role),
-		Tool:   in.Provider,
-		Repo:   repo,
-		Parent: agentName,
+		Name:     in.Name,
+		Role:     agent.Role(in.Role),
+		Tool:     in.Provider,
+		Repo:     repo,
+		Parent:   agentName,
+		Template: template,
 	})
 	if err != nil {
 		return nil, out, fmt.Errorf("spawn failed: %w", err)
@@ -670,6 +693,7 @@ func spawnAgent(ctx context.Context, cfg Config, agentName string, in spawnAgent
 	out.Role = string(child.Role)
 	out.State = string(child.State)
 	out.ParentID = child.ParentID
+	out.Template = child.Template
 
 	if in.Task != "" {
 		if taskErr := cfg.Agents.SetAgentTask(ctx, child.Name, in.Task); taskErr != nil {


### PR DESCRIPTION
Fixes #3472

## The bug

`spawnAgentIn` accepted `name`, `role`, `task`, `provider` and `repo` — but not
`template`. The guardrail loop skips any agent without one:

```go
for _, a := range list {
    if a.Template == "" {
        continue
    }
```

`server/guardrails.go:82-87`. So every child an agent spawned over MCP ran with no
`max_cost_usd` and no stuck detection. The REST handler passes `Template` through
(`server/handlers/agents.go:418`), which means the exemption applied to exactly
one path: the unattended one, where an agent spawns children with nobody
watching. That is the runaway-cost scenario the guardrails were built for.

Reproduced before fixing — with the change reverted:

```
--- FAIL: TestE2E_SpawnAgent_InheritsParentTemplate
    child template = "", want the parent's "capped"
```

## The change

Accept `template` and pass it to `CreateOptions`. When none is given, **inherit
the caller's** rather than treating absence as "no guardrails".

That second half is the part that matters. Every existing caller omits the field,
because it did not exist until now, so a fix that only added the field would have
left the bypass in place for all of them. An explicit template still wins, and an
unguarded parent still spawns an unguarded child — inheritance propagates
guardrails, it does not invent them.

The child's template is also reported in the result, so a caller can see the
coverage it actually got instead of assuming the one it asked for.

## Tests

Four cases in `server/mcp/orchestration_test.go`, driven through a real
`Manager.SpawnAgentWithOptions` like the existing spawn tests:

| Test | Asserts |
|---|---|
| `RecordsTemplate` | an explicit template is recorded and reported |
| `InheritsParentTemplate` | omitting it inherits the caller's — the actual bypass |
| `ExplicitTemplateWins` | inheritance is not a straitjacket |
| `NoTemplateAnywhere` | an unguarded parent still yields an unguarded child |

## Deliberately out of scope

Template *files* (`CLAUDE.md`, `.mcp.json`) are still not written on this path:
`mcp.Config` has no template store, and `applyTemplate` is a method on the REST
`AgentHandler`, so sharing it is a refactor rather than a plumb. Filed separately
rather than widened into a guardrail fix. Guardrails do not depend on it — they
resolve the template by name from their own store — so this PR closes the
security-relevant half completely.

## Verification

`go build ./...`, `go vet ./server/mcp/`, `golangci-lint run server/mcp/...`
(0 issues), `go test ./server/mcp/` all pass.

Made with [Cursor](https://cursor.com)