### PR TITLE
fix(web): wire up the orphaned dependency manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   detection — the unattended case the guardrails exist for. It now accepts a
   template and, when none is given, inherits the caller's, so omitting the field
   cannot silently mean "unguarded" (#3472).
+- **Optional services are manageable again.** The dependency manager UI existed
+  but nothing imported it, so the whole `/api/deps` lifecycle — list, start,
+  stop, stream logs — had no entry point, and the Code tab's "Edit in VS Code"
+  button could never appear, because it only renders while
+  `mycel-code-server` is running. It now sits under Settings → Providers &
+  Tools → Optional Services. The code-server URL also derives its host from the
+  page instead of hardcoding `localhost`, which broke whenever the UI was opened
+  from another machine (#3473).
 
 ## [0.4.4] - 2026-08-02
 

--- a/web/src/settings/ProvidersToolsSection.tsx
+++ b/web/src/settings/ProvidersToolsSection.tsx
@@ -10,6 +10,7 @@ import { ProvidersTable } from "../components/ProvidersTable";
 import { ProviderDefaults } from "../components/ProviderDefaults";
 import { PackageManagers } from "../components/PackageManagers";
 import { RegistrySearch } from "../components/RegistrySearch";
+import { DependenciesSection } from "../components/settings/Dependencies";
 import { CopyButton } from "../components/CopyButton";
 import { ToastContainer, useToast } from "../components/Toast";
 import type { ToastLevel } from "../components/Toast";
@@ -755,6 +756,24 @@ export function ProvidersToolsSection() {
             </table>
           </div>
         )}
+      </section>
+
+      {/* Optional services (pkg/deps): containers the user can start from here,
+          such as mycel-code-server. This is the only UI for the /api/deps
+          lifecycle — without it the Code tab's "Edit in VS Code" button can
+          never appear, since it renders only while the container is running. */}
+      <section>
+        <div className="flex items-baseline gap-2 mb-3">
+          <h2 className="text-[11px] font-medium text-mycel-muted uppercase tracking-[0.08em]">
+            Optional Services
+          </h2>
+          <span className="flex-1 h-px bg-mycel-border self-center" aria-hidden />
+        </div>
+        <p className="text-[10.5px] text-mycel-muted mb-2">
+          Background containers the daemon can start for you. Starting
+          mycel-code-server enables "Edit in VS Code" on the Code tab.
+        </p>
+        <DependenciesSection />
       </section>
 
       <ToastContainer toasts={toasts} onDismiss={dismiss} />

--- a/web/src/views/Code.tsx
+++ b/web/src/views/Code.tsx
@@ -42,8 +42,11 @@ async function fetchCodeServerStatus(): Promise<{ running: boolean; endpoint: st
     const d = (await r.json()) as { state?: string };
     return {
       running: d.state === "running",
-      // Hardcoded for now — backend exposes on :8100 per pkg/deps/code_server.go
-      endpoint: "http://localhost:8100/?folder=/home/coder/workspace",
+      // The port is fixed by pkg/deps/code_server.go, but the host is not:
+      // "localhost" resolves against whichever machine the browser is on, so it
+      // breaks as soon as the UI is opened from anywhere but the daemon's host.
+      // Scheme stays http because the container serves http.
+      endpoint: `http://${window.location.hostname}:8100/?folder=/home/coder/workspace`,
     };
   } catch {
     return { running: false, endpoint: "" };

--- a/web/src/views/__tests__/Tools.test.tsx
+++ b/web/src/views/__tests__/Tools.test.tsx
@@ -96,6 +96,46 @@ describe("ProvidersToolsSection CLI tools table", () => {
   });
 });
 
+describe("ProvidersToolsSection optional services", () => {
+  // DependenciesSection was written, then left with no importer, so the whole
+  // /api/deps lifecycle had no entry point in the app and the Code tab's "Edit
+  // in VS Code" button — which only renders while mycel-code-server runs — could
+  // never appear. This asserts the component is actually mounted.
+  it("renders the dependency manager, so /api/deps has an entry point", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u === "/api/providers") return jsonResponse([]);
+      if (u === "/api/tools/unified") return jsonResponse([]);
+      if (u === "/api/system/package-managers") return jsonResponse({ os: "darwin", arch: "arm64", managers: [] });
+      if (u === "/api/deps") {
+        return jsonResponse({
+          deps: [{
+            id: "mycel-code-server",
+            name: "mycel-code-server",
+            description: "VS Code in the browser",
+            state: "stopped",
+            deprecated: false,
+          }],
+        });
+      }
+      return jsonResponse({});
+    });
+
+    render(
+      <MemoryRouter>
+        <ProvidersToolsSection />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("Optional Services")).toBeTruthy();
+    // The dependency itself is listed, which means /api/deps was fetched and
+    // rendered rather than the heading merely existing.
+    await waitFor(() => {
+      expect(screen.getAllByText("mycel-code-server").length).toBeGreaterThan(0);
+    });
+  });
+});
+
 describe("ProvidersToolsSection providers list", () => {
   it("renders providers as a list/table with no card/grid view toggle", async () => {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {


### PR DESCRIPTION
Fixes #3473

## The bug

`DependenciesSection` was written and never imported — `rg DependenciesSection web/src`
returned only its own definition at `web/src/components/settings/Dependencies.tsx:248`.

It is the only UI for `GET /api/deps` and the start/stop/logs routes
(`server/handlers/deps.go:42-133`), so the entire optional-dependency lifecycle had
no entry point in the app. `pkg/deps`' own package comment says these are services
"the user can optionally start from the daemon Settings UI" — the UI that was not
mounted.

The user-visible symptom was somewhere else entirely: `Code.tsx:218` renders "Edit
in VS Code" only while `mycel-code-server` is running, and with no way to start it
the button was permanently invisible. The feature read as absent rather than broken,
which is why it never got reported as a dependency problem.

Orphaned during the `bc-*` → `mycel-*` rename (783a38aa), so accidental loss rather
than a deliberate removal.

## The change

Rendered under Providers & Tools as **Optional Services**, next to CLI
Dependencies. Deliberately *inside* the existing section rather than as a new
top-level one, so the progressive-reveal order (#3437) is untouched.

Also stopped hardcoding `localhost` in the code-server URL. The port is fixed by
`pkg/deps/code_server.go`, but `localhost` resolves against whichever machine the
*browser* is on, so the iframe pointed at the viewer's own box whenever the UI was
opened from anywhere but the daemon's host. The host now comes from the page.
Scheme stays `http`, since the container serves `http`.

## Tests

`renders the dependency manager, so /api/deps has an entry point` asserts the
component is mounted *and* that a dependency from a mocked `/api/deps` actually
renders — checking the heading alone would pass if the component were swapped for
an empty div. I got the mock's shape wrong on the first attempt (`display_name`
instead of `name`) and corrected it against the handler's DTO, so the fixture now
matches what the server really returns.

## Verification

`tsc -b` clean, `eslint src` clean, full web suite **422/422**.

## Not in scope

The review that found this also noted four other orphaned components; they are
listed under small cleanups in the v0.4.5 tracker (#3468) rather than swept in
here, since each needs deciding on its own — restore or delete.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restored Optional Services management under Settings.
  * Added controls for managing background services and enabling Code tab editing.
  * Code-server connections now work correctly when accessed through different hosts.

* **Tests**
  * Added coverage for displaying stopped optional services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->