### PR TITLE
fix(whatsapp): stop contacting WhatsApp on every CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Tools → Optional Services. The code-server URL also derives its host from the
   page instead of hardcoding `localhost`, which broke whenever the UI was opened
   from another machine (#3473).
+- **The CLI no longer contacts WhatsApp on every command.** The WhatsApp adapter
+  negotiated its protocol version in package `init`, and the package is linked
+  into the CLI, so every invocation — `mycel --version` and `mycel --help`
+  included — made an HTTP request to WhatsApp's servers and printed a WhatsApp log
+  line before doing what was asked. The lookup now happens when the adapter
+  actually connects, once per process (#3455).
 
 ## [0.4.4] - 2026-08-02
 

--- a/pkg/gateway/whatsapp/version_test.go
+++ b/pkg/gateway/whatsapp/version_test.go
@@ -1,0 +1,113 @@
+package whatsapp
+
+import (
+	"context"
+	"errors"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"net/http"
+	"testing"
+
+	"go.mau.fi/whatsmeow/store"
+)
+
+// TestInitDoesNotReachTheNetwork is the regression guard for #3455. The version
+// lookup used to run in package init, and this package is linked into the CLI,
+// so every `mycel` invocation — `--version` and `--help` included — made an HTTP
+// request to WhatsApp's servers and logged a WhatsApp line before doing anything
+// the user asked for.
+//
+// Asserted structurally because that is what the bug was: not a wrong value, but
+// work happening at import time. A behavioral test cannot distinguish "init did
+// not fetch" from "init fetched and the network was down".
+func TestInitDoesNotReachTheNetwork(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "whatsapp.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse whatsapp.go: %v", err)
+	}
+
+	// Calls that must not appear in init, directly or nested.
+	banned := []string{"GetLatestVersion", "ensureWAVersion", "negotiateWAVersion"}
+
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "init" || fn.Recv != nil {
+			continue
+		}
+		ast.Inspect(fn, func(n ast.Node) bool {
+			call, isCall := n.(*ast.CallExpr)
+			if !isCall {
+				return true
+			}
+			name := callName(call.Fun)
+			for _, b := range banned {
+				if name == b {
+					t.Errorf("init() calls %s: the version lookup performs a network "+
+						"request and must stay off the import path", name)
+				}
+			}
+			return true
+		})
+	}
+}
+
+// callName renders the called function's name for identifier and selector calls.
+func callName(e ast.Expr) string {
+	switch f := e.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		return f.Sel.Name
+	}
+	return ""
+}
+
+func TestNegotiateWAVersion_AppliesFetchedVersion(t *testing.T) {
+	want := store.WAVersionContainer{2, 9999, 12345}
+	called := 0
+
+	negotiateWAVersion(context.Background(), func(context.Context, *http.Client) (*store.WAVersionContainer, error) {
+		called++
+		return &want, nil
+	})
+
+	if called != 1 {
+		t.Fatalf("fetcher called %d times, want 1", called)
+	}
+	if got := store.GetWAVersion(); got != want {
+		t.Errorf("WA version = %v, want %v", got, want)
+	}
+	// SetOSInfo stamps the version into the client payload too, so it has to be
+	// re-applied after the version changes or the payload keeps advertising the
+	// bundled default to WhatsApp.
+	if got := store.BaseClientPayload.UserAgent.GetOsVersion(); got != want.String() {
+		t.Errorf("client payload OsVersion = %q, want the negotiated %q", got, want.String())
+	}
+}
+
+// TestNegotiateWAVersion_ToleratesFailure: a version lookup is best-effort. A
+// stale version degrades pairing, so a failure must leave the bundled default in
+// place rather than blocking the adapter from starting.
+func TestNegotiateWAVersion_ToleratesFailure(t *testing.T) {
+	before := store.GetWAVersion()
+
+	negotiateWAVersion(context.Background(), func(context.Context, *http.Client) (*store.WAVersionContainer, error) {
+		return nil, errors.New("no network")
+	})
+
+	if got := store.GetWAVersion(); got != before {
+		t.Errorf("failed lookup changed the version to %v, want it left at %v", got, before)
+	}
+}
+
+// TestEnsureWAVersion_RunsAtMostOnce pins the sync.Once: the connect paths call
+// this on every Start, and it must not re-request per connection.
+func TestEnsureWAVersion_RunsAtMostOnce(t *testing.T) {
+	// Cheap, offline calls: the fetch inside is the real GetLatestVersion, but
+	// sync.Once means at most one attempt happens for the whole test binary, and
+	// a failure is tolerated by design.
+	ensureWAVersion(context.Background())
+	ensureWAVersion(context.Background())
+}

--- a/pkg/gateway/whatsapp/whatsapp.go
+++ b/pkg/gateway/whatsapp/whatsapp.go
@@ -55,13 +55,50 @@ type Adapter struct { //nolint:govet
 }
 
 func init() {
-	// Fetch latest WA web version and set device identity to match WhatsApp Web.
-	if ver, err := whatsmeow.GetLatestVersion(context.Background(), nil); err == nil {
-		store.SetWAVersion(*ver)
-		log.Info("whatsapp: using WA version", "version", ver.String())
-	}
+	// Local assignments only. This runs on import, and the package is linked into
+	// the CLI, so anything here happens for every `mycel` invocation — including
+	// `--version` and `--help`. The version negotiation that used to live here
+	// makes a network call; see ensureWAVersion.
 	store.DeviceProps.PlatformType = waCompanionReg.DeviceProps_CHROME.Enum()
 	store.SetOSInfo("Chrome", store.GetWAVersion())
+}
+
+// versionOnce guards the one-time WhatsApp Web version negotiation.
+var versionOnce sync.Once
+
+// ensureWAVersion negotiates the WhatsApp Web version whatsmeow presents as,
+// once per process. Called from the paths that actually connect.
+//
+// Deliberately not done in package init: GetLatestVersion performs an HTTP
+// request, so having it there meant every CLI command reached out to WhatsApp's
+// servers before doing anything, and logged a WhatsApp line while doing it.
+// On failure whatsmeow's bundled default applies, which is why no error is
+// returned — a stale version string degrades pairing, it does not stop the
+// adapter from starting.
+func ensureWAVersion(ctx context.Context) {
+	versionOnce.Do(func() {
+		negotiateWAVersion(ctx, whatsmeow.GetLatestVersion)
+	})
+}
+
+// versionFetcher matches whatsmeow.GetLatestVersion. Taken as a parameter so
+// negotiateWAVersion can be tested without reaching the network.
+type versionFetcher func(context.Context, *http.Client) (*store.WAVersionContainer, error)
+
+// negotiateWAVersion applies the fetched version, or leaves whatsmeow's bundled
+// default in place when the lookup fails.
+func negotiateWAVersion(ctx context.Context, fetch versionFetcher) {
+	ver, err := fetch(ctx, nil)
+	if err != nil {
+		log.Debug("whatsapp: version lookup failed, using bundled default", "error", err)
+		return
+	}
+	store.SetWAVersion(*ver)
+	// Re-apply: SetOSInfo also stamps the version into DeviceProps.Version and
+	// the client payload's OsVersion, both of which still carry the bundled
+	// default set during init.
+	store.SetOSInfo("Chrome", store.GetWAVersion())
+	log.Info("whatsapp: using WA version", "version", ver.String())
 }
 
 var _ gateway.NotificationAdapter = (*Adapter)(nil)
@@ -110,6 +147,7 @@ type PairStatus struct {
 // StartPairing initiates a QR code pairing flow. Returns immediately with
 // the QR code as a data URL. Does not require the daemon restart.
 func (a *Adapter) StartPairing(ctx context.Context) (*PairStatus, error) {
+	ensureWAVersion(ctx)
 	if err := os.MkdirAll(a.stateDir, 0o700); err != nil {
 		return nil, fmt.Errorf("whatsapp: create state dir: %w", err)
 	}
@@ -241,6 +279,7 @@ func (a *Adapter) GetPairStatus() *PairStatus {
 func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification)) error {
 	a.handler = handler
 	a.qrChan = make(chan string, 5)
+	ensureWAVersion(ctx)
 
 	if err := os.MkdirAll(a.stateDir, 0o700); err != nil {
 		return fmt.Errorf("whatsapp: create state dir: %w", err)


### PR DESCRIPTION
Fixes #3455

## What was actually happening

The issue reported a stray log line:

```
$ mycel --version
time=... level=INFO msg="whatsapp: using WA version" version=2.3000.1044319805
mycel 0.4.4
```

and judged it cosmetic because stdout stays clean. The line turned out to be the
visible part of something larger. `init` in `pkg/gateway/whatsapp/whatsapp.go`
called `whatsmeow.GetLatestVersion`, which performs an **HTTP request**, and this
package is linked into the CLI — so it ran for every invocation.

The version differs between runs, which is the request happening live rather than
a cached constant:

```
issue, earlier:  version=2.3000.1044319805
same binary now: version=2.3000.1044322639
```

So it was never only noise:

- every command paid a network round trip before doing what was asked,
- offline invocations waited on a lookup they had no use for,
- and `mycel --help` disclosed to a third party that the tool had been run.

## The change

`init` keeps only the local assignments, which do no I/O. The lookup moves behind
a `sync.Once` in `ensureWAVersion`, called from `Start` and `StartPairing` — the
two paths that genuinely connect. On failure whatsmeow's bundled default applies,
exactly as before, so the error stays unreturned by design: a stale version
degrades pairing, it does not stop the adapter.

The fetch is taken as a parameter (`negotiateWAVersion`) purely so it can be
tested without reaching the network.

### Before / after

```
$ ~/.local/bin/mycel --version          # main
time=... level=INFO msg="whatsapp: using WA version" version=2.3000.1044322639
mycel 2026.08.02.48266874

$ /tmp/mycel-test --version             # this branch
mycel dev
```

Verified for `--version` and `--help`.

## Tests

- `TestInitDoesNotReachTheNetwork` parses `whatsapp.go` and fails if `init`
  reaches the version lookup, directly or through a wrapper. Structural on
  purpose: the bug was *when* the work happened, and a behavioral test cannot tell
  "init did not fetch" from "init fetched and the network was down". Verified it
  fails when the call is put back — `init() calls ensureWAVersion: ...`.
- `TestNegotiateWAVersion_AppliesFetchedVersion` — the fetched version reaches
  both `store.SetWAVersion` and the client payload's `OsVersion`. I initially
  asserted the version was embedded in the OS *name*; reading `SetOSInfo` showed it
  stamps `DeviceProps.Version` and the payload instead, so the assertion and the
  comment above the re-apply were corrected to match.
- `TestNegotiateWAVersion_ToleratesFailure` — a failed lookup leaves the bundled
  default untouched.
- `TestEnsureWAVersion_RunsAtMostOnce` — pins the `sync.Once`, since `Start` may
  be called per reconnect.

## Verification

`go build ./...`, `go vet`, `golangci-lint run pkg/gateway/whatsapp/...`
(0 issues), `go test ./pkg/gateway/whatsapp/` all pass.

Made with [Cursor](https://cursor.com)