### PR TITLE
fix(settings): report tools' real paths and owners, drop the redundant cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A blank MCP command no longer takes the daemon down.** The tool health
+  check indexed the first field of a stored command without checking there was
+  one, so a whitespace-only entry panicked — on a background goroutine, where
+  no HTTP recovery middleware can help, and again on every 30-second tick
+  because the offending row was still there. The check now reports the tool as
+  misconfigured, and the health pass recovers rather than propagating (#3471).
 - **Agent-spawned children are no longer exempt from guardrails.** `spawn_agent`
   over MCP had no `template` field, and the guardrail loop skips any agent
   without one, so every child an agent spawned ran with no cost cap and no stuck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   included — made an HTTP request to WhatsApp's servers and printed a WhatsApp log
   line before doing what was asked. The lookup now happens when the adapter
   actually connects, once per process (#3455).
+- **Tool details report real paths and owners.** An expanded CLI tool row
+  showed "Path: git" — the configured command name under a Path label — and a
+  "Version cmd" box that was just the tool name plus `--version`, both styled
+  like inputs waiting to be filled in. The API now separates `path` (resolved,
+  absolute) from `command` (configured) and infers which package manager owns
+  each tool, following the symlink so a Homebrew binary is attributable. With
+  the owner known, the row names the update command that manager would use
+  instead of saying "copy the command above" with no command above it, and it
+  no longer offers to uninstall OS-provided binaries the backend refuses to
+  touch. The Setup card now appears only while setup is unfinished, rather
+  than permanently restating that the re-run icon exists (#3482).
 
 ## [0.4.4] - 2026-08-02
 

--- a/server/handlers/tools_manager.go
+++ b/server/handlers/tools_manager.go
@@ -1,0 +1,132 @@
+package handlers
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Where a CLI tool came from is inferable, so the UI should not ask for it.
+// Two independent kinds of evidence are available, and they answer slightly
+// different questions:
+//
+//   - The resolved path says what actually installed the binary that is on
+//     PATH right now. Strongest evidence, and the only one that exists for a
+//     tool nobody configured an install command for (git, go, jq…).
+//   - The configured install command says how mycel would install or update
+//     it. Used as a fallback, since a tool that is not installed yet has no
+//     path to inspect.
+//
+// Path wins when both are present: config can be stale or aspirational, while
+// a binary at /opt/homebrew/bin/rg is a fact.
+
+// managerCommands maps the binary that leads an install command to the manager
+// id the rest of the API uses (see searchSpecs / installSpecs). Only managers
+// whose name is unambiguous as a leading token are listed — `go install` is
+// deliberately absent, since "go" is far more often the tool than the manager.
+var managerCommands = map[string]string{
+	"brew":    "brew",
+	"npm":     "npm",
+	"pnpm":    "pnpm",
+	"yarn":    "yarn",
+	"pipx":    "pipx",
+	"pip":     "pip",
+	"pip3":    "pip",
+	"uv":      "uv",
+	"cargo":   "cargo",
+	"gem":     "gem",
+	"apt":     "apt",
+	"apt-get": "apt",
+	"dnf":     "dnf",
+	"yum":     "yum",
+	"pacman":  "pacman",
+	"zypper":  "zypper",
+	"winget":  "winget",
+	"scoop":   "scoop",
+	"choco":   "choco",
+}
+
+// pathMarkers maps a substring of an installed binary's real path to the
+// manager that puts binaries there. Ordered checks live in managerFromPath;
+// this table only covers markers specific enough to be conclusive anywhere in
+// the path.
+var pathMarkers = []struct {
+	marker  string
+	manager string
+}{
+	{"/cellar/", "brew"},       // macOS Homebrew, incl. the symlink target
+	{"/opt/homebrew/", "brew"}, // Apple Silicon Homebrew prefix
+	{"/linuxbrew/", "brew"},    // Homebrew on Linux
+	{"/node_modules/", "npm"},  // a global npm install
+	{"/.cargo/", "cargo"},      // cargo install
+	{"/pipx/", "pipx"},         // pipx venvs
+	{"/.pyenv/", "pyenv"},      // pyenv shims
+	{"/.rbenv/", "rbenv"},      //
+	{"/.nvm/", "nvm"},          // node from nvm — npm-installed globals live under it
+	{"/.volta/", "volta"},      //
+	{"/homebrew/", "brew"},     // non-standard brew prefix
+	{"/scoop/", "scoop"},       //
+	{"/chocolatey/", "choco"},  //
+}
+
+// systemPrefixes are the directories only the OS itself owns. Deliberately
+// excludes /usr/local/bin: Homebrew on Intel macOS installs there, and so do
+// hand-built binaries, so that path proves nothing on its own.
+var systemPrefixes = []string{"/usr/bin/", "/bin/", "/usr/sbin/", "/sbin/"}
+
+// InferToolManager reports which package manager owns a CLI tool, as a manager
+// id ("brew", "npm", …), "system" for an OS-provided binary, or "" when there
+// is no evidence either way. realPath should be the symlink-resolved path (a
+// brew binary on PATH is usually a symlink into the Cellar, and only the target
+// names the manager).
+func InferToolManager(realPath, installCmd string) string {
+	if m := managerFromPath(realPath); m != "" {
+		return m
+	}
+	return managerFromInstallCmd(installCmd)
+}
+
+// managerFromPath infers the manager from where the binary actually lives.
+func managerFromPath(realPath string) string {
+	if realPath == "" {
+		return ""
+	}
+	// Compare in lower case with forward slashes so the markers match on
+	// Windows and on case-insensitive macOS volumes alike.
+	p := strings.ToLower(filepath.ToSlash(realPath))
+	for _, pm := range pathMarkers {
+		if strings.Contains(p, pm.marker) {
+			return pm.manager
+		}
+	}
+	for _, prefix := range systemPrefixes {
+		if strings.HasPrefix(p, prefix) {
+			return "system"
+		}
+	}
+	return ""
+}
+
+// managerFromInstallCmd infers the manager from a configured install command,
+// e.g. "brew install ripgrep" or "sudo apt-get install -y jq". Returns "" when
+// the leading token is not a manager this code recognizes, so a bespoke
+// installer (a curl|sh line, a vendored script) is reported as unknown rather
+// than guessed at.
+func managerFromInstallCmd(installCmd string) string {
+	for _, field := range strings.Fields(installCmd) {
+		// Skip the wrappers and VAR=value prefixes that precede the real
+		// command, so "sudo apt-get install" and "DEBIAN_FRONTEND=noninteractive
+		// apt-get install" both resolve to apt.
+		if field == "sudo" || field == "env" || strings.Contains(field, "=") {
+			continue
+		}
+		// A manager may be invoked by absolute path.
+		if m, ok := managerCommands[strings.ToLower(filepath.Base(filepath.ToSlash(field)))]; ok {
+			return m
+		}
+		// The first token that is not a wrapper decides: anything past it is
+		// a subcommand or a package name, and a package named "npm" must not
+		// make a curl-based installer look like an npm install.
+		return ""
+	}
+	return ""
+}

--- a/server/handlers/tools_manager_test.go
+++ b/server/handlers/tools_manager_test.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestInferToolManager(t *testing.T) {
+	tests := []struct {
+		name       string
+		realPath   string
+		installCmd string
+		want       string
+	}{
+		// Path evidence: what actually installed the binary on PATH.
+		{"brew cellar target", "/opt/homebrew/Cellar/ripgrep/14.1.1/bin/rg", "", "brew"},
+		{"brew apple silicon prefix", "/opt/homebrew/bin/jq", "", "brew"},
+		{"brew on linux", "/home/linuxbrew/.linuxbrew/bin/gh", "", "brew"},
+		{"npm global", "/usr/local/lib/node_modules/npm/bin/npx", "", "npm"},
+		{"cargo install", "/Users/x/.cargo/bin/rg", "", "cargo"},
+		{"pipx venv", "/Users/x/.local/pipx/venvs/black/bin/black", "", "pipx"},
+		{"os provided", "/usr/bin/git", "", "system"},
+		{"os provided sbin", "/sbin/ping", "", "system"},
+
+		// /usr/local/bin proves nothing on its own: Intel Homebrew installs
+		// there, and so does `make install`. Must not be called "system".
+		{"ambiguous usr local", "/usr/local/bin/mytool", "", ""},
+		{"ambiguous usr local falls back to install cmd", "/usr/local/bin/rg", "brew install ripgrep", "brew"},
+
+		// Install-command evidence, for a tool that is not installed yet.
+		{"npm install cmd", "", "npm install -g @openai/codex", "npm"},
+		{"brew install cmd", "", "brew install ripgrep", "brew"},
+		{"sudo wrapper skipped", "", "sudo apt-get install -y jq", "apt"},
+		{"env assignment skipped", "", "DEBIAN_FRONTEND=noninteractive apt-get install -y jq", "apt"},
+		{"manager by absolute path", "", "/opt/homebrew/bin/brew install fd", "brew"},
+		{"pip3 normalises to pip", "", "pip3 install httpie", "pip"},
+
+		// No evidence: a bespoke installer must read as unknown, not be
+		// guessed at from a package name that happens to match a manager.
+		{"curl installer", "", "curl -fsSL https://example.com/i.sh | sh", ""},
+		{"package named like a manager", "", "curl -o /tmp/npm https://example.com/npm", ""},
+		{"nothing at all", "", "", ""},
+
+		// Path wins over config: config can be stale, the binary cannot.
+		{"path beats install cmd", "/opt/homebrew/bin/rg", "npm install -g ripgrep", "brew"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := InferToolManager(tc.realPath, tc.installCmd); got != tc.want {
+				t.Errorf("InferToolManager(%q, %q) = %q, want %q", tc.realPath, tc.installCmd, got, tc.want)
+			}
+		})
+	}
+}
+
+// The markers are matched case-insensitively so they still hold on a
+// case-insensitive macOS volume, where the Cellar can appear as "cellar".
+func TestManagerFromPathIgnoresCase(t *testing.T) {
+	for _, p := range []string{
+		"/opt/homebrew/cellar/ripgrep/14.1.1/bin/rg",
+		"/opt/Homebrew/Cellar/ripgrep/14.1.1/bin/rg",
+	} {
+		if got := managerFromPath(p); got != "brew" {
+			t.Errorf("managerFromPath(%q) = %q, want brew", p, got)
+		}
+	}
+}
+
+// describeBinary must report an absolute path and follow a symlink to identify
+// the owner, which is the whole reason a brew tool is attributable at all.
+func TestDescribeBinaryResolvesSymlinkToFindManager(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink layout is POSIX-specific")
+	}
+	// Lay out a fake Homebrew: a bin/ directory on PATH holding a symlink
+	// into a Cellar, exactly as brew links its formulae.
+	root := t.TempDir()
+	cellar := filepath.Join(root, "Cellar", "faketool", "1.2.3", "bin")
+	if err := os.MkdirAll(cellar, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(cellar, "faketool")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\n"), 0o755); err != nil { //nolint:gosec // test fixture must be executable
+		t.Fatal(err)
+	}
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(binDir, "faketool")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", binDir)
+
+	path, manager := describeBinary("faketool", "")
+	if path != link {
+		t.Errorf("path = %q, want the symlink on PATH %q", path, link)
+	}
+	if manager != "brew" {
+		t.Errorf("manager = %q, want brew (via the Cellar symlink target)", manager)
+	}
+}
+
+// A tool that is not installed has no path, and its manager can only come from
+// the configured install command.
+func TestDescribeBinaryMissingBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	path, manager := describeBinary("definitely-not-a-real-binary", "brew install whatever")
+	if path != "" {
+		t.Errorf("path = %q, want empty for a binary not on PATH", path)
+	}
+	if manager != "brew" {
+		t.Errorf("manager = %q, want brew from the install command", manager)
+	}
+}

--- a/server/handlers/tools_unified.go
+++ b/server/handlers/tools_unified.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -18,11 +19,19 @@ const maxVersionLen = 80
 
 // UnifiedTool represents a tool (MCP or CLI) with its status.
 type UnifiedTool struct { //nolint:govet // field order matches JSON/API contract
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	Status     string `json:"status"`
-	Transport  string `json:"transport,omitempty"`
-	Command    string `json:"command,omitempty"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	Status    string `json:"status"`
+	Transport string `json:"transport,omitempty"`
+	Command   string `json:"command,omitempty"`
+	// Path is where the binary actually resolved on PATH, absolute. Kept
+	// distinct from Command, which is what was configured: for most tools
+	// Command is a bare name ("git") and calling that a path — as the UI
+	// once did — tells the user nothing they didn't type.
+	Path string `json:"path,omitempty"`
+	// Manager is the package manager that owns this tool, inferred rather
+	// than configured. See InferToolManager.
+	Manager    string `json:"manager,omitempty"`
 	URL        string `json:"url,omitempty"`
 	Version    string `json:"version,omitempty"`
 	Error      string `json:"error,omitempty"`
@@ -119,6 +128,31 @@ func runVersion(ctx context.Context, versionCmd string) string {
 	return cliVersion(string(out))
 }
 
+// describeBinary resolves bin on PATH and reports both where it is and which
+// package manager owns it, so neither has to be configured by hand.
+//
+// Symlinks are resolved for the manager inference only: the path reported is
+// the one PATH actually yields (what the user would run), while its target is
+// what identifies the owner — a Homebrew binary on PATH is typically a symlink
+// and only the Cellar target names brew.
+//
+// When bin is not on PATH there is no path to report, and the manager can only
+// come from the configured install command.
+func describeBinary(bin, installCmd string) (path, manager string) {
+	p, err := exec.LookPath(bin)
+	if err != nil {
+		return "", managerFromInstallCmd(installCmd)
+	}
+	if abs, absErr := filepath.Abs(p); absErr == nil {
+		p = abs
+	}
+	real := p
+	if target, symErr := filepath.EvalSymlinks(p); symErr == nil {
+		real = target
+	}
+	return p, InferToolManager(real, installCmd)
+}
+
 // resolveToolStatus determines a tool's status based on enabled state, type, and binary availability.
 func resolveToolStatus(enabled bool, toolType, command, name string) string {
 	if !enabled {
@@ -178,11 +212,12 @@ func (h *UnifiedToolsHandler) list(w http.ResponseWriter, r *http.Request) {
 				ut := UnifiedTool{
 					Name:     t,
 					Type:     "cli",
+					Command:  t,
 					Required: true,
 				}
-				if path, err := exec.LookPath(t); err == nil {
+				ut.Path, ut.Manager = describeBinary(t, "")
+				if ut.Path != "" {
 					ut.Status = "installed"
-					ut.Command = path
 					ut.Version = runVersion(r.Context(), t+" --version")
 				} else {
 					ut.Status = "not_installed"
@@ -215,6 +250,9 @@ func (h *UnifiedToolsHandler) list(w http.ResponseWriter, r *http.Request) {
 					Status:     status,
 					InstallCmd: t.InstallCmd,
 					UpgradeCmd: t.UpgradeCmd,
+				}
+				if toolType == "cli" {
+					ut.Path, ut.Manager = describeBinary(resolveBinary(t.Command, t.Name), t.InstallCmd)
 				}
 				if toolType == "cli" && status == "installed" && t.VersionCmd != "" {
 					ut.Version = runVersion(r.Context(), t.VersionCmd)
@@ -275,11 +313,12 @@ func (h *UnifiedToolsHandler) checkAll(w http.ResponseWriter, r *http.Request) {
 				ut := UnifiedTool{
 					Name:     t,
 					Type:     "cli",
+					Command:  t,
 					Required: true,
 				}
-				if path, err := exec.LookPath(t); err == nil {
+				ut.Path, ut.Manager = describeBinary(t, "")
+				if ut.Path != "" {
 					ut.Status = "installed"
-					ut.Command = path
 					ut.Version = runVersion(r.Context(), t+" --version")
 				} else {
 					ut.Status = "not_installed"
@@ -313,22 +352,21 @@ func (h *UnifiedToolsHandler) checkAll(w http.ResponseWriter, r *http.Request) {
 					InstallCmd: t.InstallCmd,
 					UpgradeCmd: t.UpgradeCmd,
 				}
-				if !t.Enabled {
+				bin := resolveBinary(t.Command, t.Name)
+				ut.Path, ut.Manager = describeBinary(bin, t.InstallCmd)
+				switch {
+				case !t.Enabled:
 					ut.Status = "disabled"
-				} else {
-					bin := resolveBinary(t.Command, t.Name)
-					if path, lookErr := exec.LookPath(bin); lookErr != nil {
-						ut.Status = "not_installed"
-						ut.Error = bin + " not found in PATH"
-					} else {
-						ut.Status = "installed"
-						ut.Command = path
-						versionCmd := t.VersionCmd
-						if versionCmd == "" {
-							versionCmd = bin + " --version"
-						}
-						ut.Version = runVersion(r.Context(), versionCmd)
+				case ut.Path == "":
+					ut.Status = "not_installed"
+					ut.Error = bin + " not found in PATH"
+				default:
+					ut.Status = "installed"
+					versionCmd := t.VersionCmd
+					if versionCmd == "" {
+						versionCmd = bin + " --version"
 					}
+					ut.Version = runVersion(r.Context(), versionCmd)
 				}
 				results = append(results, ut)
 			}

--- a/server/handlers/tools_unified_facts_test.go
+++ b/server/handlers/tools_unified_facts_test.go
@@ -1,0 +1,136 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/db"
+	"github.com/rpuneet/mycel/pkg/tool"
+)
+
+// unifiedToolsFor serves GET /api/tools/unified over a store holding just the
+// given tools, and returns the tool named want.
+func unifiedToolsFor(t *testing.T, want string, tools ...*tool.Tool) UnifiedTool {
+	t.Helper()
+
+	d, err := db.Open(filepath.Join(t.TempDir(), "mycel.db"))
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	store := tool.NewStore(d, "sqlite")
+	if err := store.Open(); err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	for _, tl := range tools {
+		if err := store.Add(ctx, tl); err != nil {
+			t.Fatalf("add tool %s: %v", tl.Name, err)
+		}
+	}
+
+	h := NewUnifiedToolsHandler(nil, store, nil, nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/tools/unified", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+
+	var got []UnifiedTool
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	for _, ut := range got {
+		if ut.Name == want {
+			return ut
+		}
+	}
+	t.Fatalf("tool %q not in response (%d tools)", want, len(got))
+	return UnifiedTool{}
+}
+
+// The API must report where a binary actually is, separately from what was
+// configured. The UI used to label the configured command as the path, which
+// only ever echoed back the bare name the user had typed.
+func TestUnifiedToolsReportsResolvedPathAndManager(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture relies on a POSIX executable bit and Cellar layout")
+	}
+
+	// A fake brew install: a bin/ on PATH symlinked into a Cellar.
+	root := t.TempDir()
+	cellar := filepath.Join(root, "Cellar", "factfixture", "9.9.9", "bin")
+	if err := os.MkdirAll(cellar, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(cellar, "factfixture")
+	if err := os.WriteFile(target, []byte("#!/bin/sh\necho 9.9.9\n"), 0o755); err != nil { //nolint:gosec // fixture must be executable
+		t.Fatal(err)
+	}
+	binDir := filepath.Join(root, "bin")
+	if err := os.MkdirAll(binDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(binDir, "factfixture")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	got := unifiedToolsFor(t, "factfixture", &tool.Tool{
+		Name:    "factfixture",
+		Type:    "cli",
+		Command: "factfixture",
+		Enabled: true,
+	})
+
+	if got.Status != "installed" {
+		t.Errorf("status = %q, want installed", got.Status)
+	}
+	// Command stays what was configured; Path carries the resolution.
+	if got.Command != "factfixture" {
+		t.Errorf("command = %q, want the configured name", got.Command)
+	}
+	if got.Path != link {
+		t.Errorf("path = %q, want %q", got.Path, link)
+	}
+	if got.Manager != "brew" {
+		t.Errorf("manager = %q, want brew (inferred through the Cellar symlink)", got.Manager)
+	}
+}
+
+// A tool that isn't installed has no path, and its owner can only be inferred
+// from the install command — which is what makes the install hint honest.
+func TestUnifiedToolsMissingBinaryHasNoPath(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	got := unifiedToolsFor(t, "absentfixture", &tool.Tool{
+		Name:       "absentfixture",
+		Type:       "cli",
+		Command:    "absentfixture",
+		InstallCmd: "npm install -g absentfixture",
+		Enabled:    true,
+	})
+
+	if got.Status != "not_installed" {
+		t.Errorf("status = %q, want not_installed", got.Status)
+	}
+	if got.Path != "" {
+		t.Errorf("path = %q, want empty", got.Path)
+	}
+	if got.Manager != "npm" {
+		t.Errorf("manager = %q, want npm from the install command", got.Manager)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -478,7 +478,14 @@ export interface Tool {
   type: "provider" | "mcp" | "cli";
   status: string;
   transport?: string;
+  /** What was configured — usually a bare binary name ("git"). */
   command?: string;
+  /** Absolute path the binary resolved to on PATH. Absent when not installed. */
+  path?: string;
+  /** Package manager that owns this tool, inferred server-side from the
+   *  resolved path (or the install command when it isn't installed yet):
+   *  "brew", "npm", "system", … Absent when there's no evidence either way. */
+  manager?: string;
   url?: string;
   version?: string;
   error?: string;

--- a/web/src/settings/ProvidersToolsSection.tsx
+++ b/web/src/settings/ProvidersToolsSection.tsx
@@ -222,6 +222,85 @@ function StreamedAction({
   );
 }
 
+/* Human name for an inferred package manager id. The API sends the id only —
+ * how to render it is presentation, and belongs here. */
+const MANAGER_LABEL: Record<string, string> = {
+  brew: "Homebrew",
+  npm: "npm (global)",
+  pnpm: "pnpm (global)",
+  yarn: "Yarn (global)",
+  cargo: "cargo",
+  pipx: "pipx",
+  pip: "pip",
+  uv: "uv",
+  gem: "RubyGems",
+  apt: "apt",
+  dnf: "dnf",
+  yum: "yum",
+  pacman: "pacman",
+  zypper: "zypper",
+  winget: "winget",
+  scoop: "Scoop",
+  choco: "Chocolatey",
+  nvm: "nvm (Node)",
+  volta: "Volta",
+  pyenv: "pyenv",
+  rbenv: "rbenv",
+  system: "Your OS",
+};
+
+function managerLabel(id: string | undefined): string {
+  if (!id) return "Unknown";
+  return MANAGER_LABEL[id] ?? id;
+}
+
+/* How each manager updates one of its packages. Used to name a command when the
+ * tool has no updater configured — more use than telling the user to copy a
+ * command that isn't on screen. Shown to copy, never run: the package name is
+ * assumed to equal the tool name, which is right often but not always, and
+ * that's not a good enough guess to execute on someone's behalf. */
+const MANAGER_UPDATE: Record<string, (name: string) => string> = {
+  brew: (n) => `brew upgrade ${n}`,
+  npm: (n) => `npm install -g ${n}@latest`,
+  pnpm: (n) => `pnpm add -g ${n}@latest`,
+  yarn: (n) => `yarn global upgrade ${n}`,
+  cargo: (n) => `cargo install ${n} --force`,
+  pipx: (n) => `pipx upgrade ${n}`,
+  pip: (n) => `pip install --upgrade ${n}`,
+  uv: (n) => `uv tool upgrade ${n}`,
+  gem: (n) => `gem update ${n}`,
+  apt: (n) => `sudo apt-get install --only-upgrade ${n}`,
+  dnf: (n) => `sudo dnf upgrade ${n}`,
+  yum: (n) => `sudo yum update ${n}`,
+  pacman: (n) => `sudo pacman -S ${n}`,
+  zypper: (n) => `sudo zypper update ${n}`,
+  winget: (n) => `winget upgrade ${n}`,
+  scoop: (n) => `scoop update ${n}`,
+  choco: (n) => `choco upgrade ${n}`,
+};
+
+/** The update command to show for a tool: the configured one if there is one,
+ *  else the one its owning manager would use. Empty when neither is known. */
+function updateCommandFor(tool: Tool): string {
+  if (tool.upgrade_cmd) return tool.upgrade_cmd;
+  const recipe = tool.manager ? MANAGER_UPDATE[tool.manager] : undefined;
+  return recipe ? recipe(tool.name) : "";
+}
+
+/** Why the streamed action isn't available, said in terms of this tool. The old
+ *  copy pointed at "the command above" even when no command was displayed. */
+function actionHint(tool: Tool, mode: RunMode): string {
+  if (mode === "install") {
+    return "No install command configured — install it with your package manager, then re-check.";
+  }
+  if (tool.manager === "system") {
+    return "Provided by your OS — update it through the system, not from here.";
+  }
+  return updateCommandFor(tool)
+    ? "No automatic updater — copy the Update command below to run it yourself."
+    : "No automatic updater, and no package manager owns this binary.";
+}
+
 /* Install-or-update for a CLI tool, plus an uninstall path for installed,
  * non-required tools. Mode is chosen from the tool's current status. */
 function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) {
@@ -237,13 +316,15 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
         toolName={tool.name}
         mode={mode}
         canRun={canRun}
-        disabledHint={`No automatic ${mode === "update" ? "updater" : "installer"} — copy the command above to run it yourself.`}
+        disabledHint={actionHint(tool, mode)}
         onDone={onDone}
       />
       {/* Uninstall the binary — distinct from "Remove" (which only forgets the
           registry entry). Offered only for installed, non-required tools; the
-          backend refuses core system deps and returns an honest error. */}
-      {isInstalled && !tool.required && (
+          backend refuses core system deps and returns an honest error.
+          Also withheld for an OS-provided binary: /usr/bin/git is not mycel's
+          to delete, so offering the button could only ever produce that error. */}
+      {isInstalled && !tool.required && tool.manager !== "system" && (
         <StreamedAction
           toolName={tool.name}
           mode="uninstall"
@@ -254,6 +335,49 @@ function CLIInstallAction({ tool, onDone }: { tool: Tool; onDone: () => void }) 
         />
       )}
     </div>
+  );
+}
+
+/* One derived fact about a tool. Deliberately plain text rather than the
+ * bordered box this used to be: these are read-only facts, and the boxed
+ * styling made them read as editable fields the user was meant to fill in. */
+function Fact({ label, value, copy, mono = true }: {
+  label: string;
+  value: string;
+  copy?: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <dt className="text-[11px] text-mycel-muted w-[86px] shrink-0">{label}</dt>
+      <dd className={`text-[11px] text-mycel-text-2 min-w-0 truncate ${mono ? "font-mono" : ""}`} title={value}>
+        {value}
+      </dd>
+      {copy && <CopyButton text={copy} />}
+    </div>
+  );
+}
+
+/* What mycel knows about an installed CLI tool, all of it derived — nothing
+ * here is typed in. Notably this shows the real resolved path: the previous
+ * version labelled the bare command name ("git") as the Path, which told the
+ * user nothing they hadn't already typed. */
+function ToolFacts({ tool }: { tool: Tool }) {
+  const updateCmd = updateCommandFor(tool);
+
+  return (
+    <dl className="space-y-1">
+      <Fact
+        label="Path"
+        value={tool.path ?? "Not found on PATH"}
+        copy={tool.path}
+        mono={Boolean(tool.path)}
+      />
+      <Fact label="Managed by" value={managerLabel(tool.manager)} mono={false} />
+      {tool.version && <Fact label="Version" value={tool.version} />}
+      {tool.install_cmd && <Fact label="Install" value={tool.install_cmd} copy={tool.install_cmd} />}
+      {updateCmd && <Fact label="Update" value={updateCmd} copy={updateCmd} />}
+    </dl>
   );
 }
 
@@ -337,33 +461,7 @@ function CLIDepsRow({ tool, onToggle, onRemove, toggling, removing, expanded, on
                 <div className="px-8 py-3 space-y-3">
                   {/* In-surface install / update — streamed, loopback-guarded. */}
                   <CLIInstallAction tool={tool} onDone={onChanged} />
-                  {tool.install_cmd && (
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs text-mycel-muted shrink-0">Install:</span>
-                      <code className="flex-1 text-xs font-mono text-mycel-text bg-mycel-bg rounded-md px-2 py-1 border border-mycel-border">
-                        {tool.install_cmd}
-                      </code>
-                      <CopyButton text={tool.install_cmd} />
-                    </div>
-                  )}
-                  {tool.command && (
-                    <>
-                      <div className="flex items-center gap-2">
-                        <span className="text-xs text-mycel-muted shrink-0">Version cmd:</span>
-                        <code className="flex-1 text-xs font-mono text-mycel-text bg-mycel-bg rounded-md px-2 py-1 border border-mycel-border">
-                          {tool.command} --version
-                        </code>
-                        <CopyButton text={`${tool.command} --version`} />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <span className="text-xs text-mycel-muted shrink-0">Path:</span>
-                        <code className="flex-1 text-xs font-mono text-mycel-text bg-mycel-bg rounded-md px-2 py-1 border border-mycel-border">
-                          {tool.command}
-                        </code>
-                        <CopyButton text={tool.command} />
-                      </div>
-                    </>
-                  )}
+                  <ToolFacts tool={tool} />
                   {tool.error && (
                     <div className="text-xs text-mycel-error bg-mycel-error-subtle rounded-md px-2 py-1 border border-mycel-error">
                       Error: {tool.error}
@@ -479,6 +577,10 @@ export function ProvidersToolsSection() {
             status: c.status,
             version: c.version ?? t.version,
             command: c.command ?? t.command,
+            // A re-check re-resolves both of these — a tool just installed or
+            // removed changes path and owner, so take the fresh answer.
+            path: c.path ?? t.path,
+            manager: c.manager ?? t.manager,
             error: c.error ?? t.error,
           };
         }

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -293,42 +293,33 @@ function Section({
 /* ------------------------------------------------------------------ */
 
 function SetupSection({
-  hasAgents,
-  allComplete,
   completedCount,
   total,
 }: {
-  hasAgents: boolean;
-  allComplete: boolean;
   completedCount: number;
   total: number;
 }) {
-  const complete = allComplete || hasAgents;
-  const pct = complete ? 100 : Math.round((Math.min(completedCount, total) / total) * 100);
+  // Rendered only while setup is unfinished (see the call site), so there is no
+  // "complete" state to draw here.
+  const pct = Math.round((Math.min(completedCount, total) / total) * 100);
 
   return (
     <div className="space-y-3">
       <p className="text-xs text-mycel-text-2 max-w-prose">
-        {complete
-          ? "Setup is complete. Use the re-run icon above any time to reconfigure — it only re-opens the sections below and never touches your agents or connected apps."
-          : "Sections below unlock one at a time as you finish each — machine checks, runtime, an agent tool, and your first agent. It only writes config; your agents and apps are left untouched."}
+        Sections below unlock one at a time as you finish each — machine checks, runtime, an agent
+        tool, and your first agent. It only writes config; your agents and apps are left untouched.
       </p>
 
       <div className="space-y-1.5">
         <div className="flex items-center justify-between text-[11px]">
-          <span className={`inline-flex items-center gap-1.5 font-medium ${complete ? "text-mycel-success" : "text-mycel-text-2"}`}>
-            {complete && (
-              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                <path d="M20 6L9 17l-5-5" />
-              </svg>
-            )}
-            {complete ? "Complete" : `${String(completedCount)} of ${String(total)} sections done`}
+          <span className="inline-flex items-center gap-1.5 font-medium text-mycel-text-2">
+            {`${String(completedCount)} of ${String(total)} sections done`}
           </span>
           <span className="text-mycel-muted tabular-nums">{pct}%</span>
         </div>
         <div className="h-2 rounded-full bg-mycel-bg border border-mycel-border overflow-hidden">
           <div
-            className={`h-full rounded-full transition-all duration-500 ease-out ${complete ? "bg-mycel-success" : "bg-gradient-to-r from-mycel-accent to-mycel-accent-hover"}`}
+            className="h-full rounded-full transition-all duration-500 ease-out bg-gradient-to-r from-mycel-accent to-mycel-accent-hover"
             style={{ width: `${Math.max(pct, 4)}%` }}
           />
         </div>
@@ -745,6 +736,10 @@ export function Settings() {
   const themeLabelId = useId();
   const reveal = useProgressiveReveal(config, refresh);
 
+  // An install that already runs agents has finished setup by definition, so
+  // it counts as complete however the individual sections read.
+  const setupComplete = reveal.allComplete || reveal.hasAgents;
+
   const [edited, setEdited] = useState<Record<string, unknown> | null>(null);
   const [original, setOriginal] = useState<Record<string, unknown> | null>(null);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
@@ -926,14 +921,19 @@ export function Settings() {
         </div>
       )}
 
-      <Section title="setup" dirty={false} index={0}>
-        <SetupSection
-          hasAgents={reveal.hasAgents}
-          allComplete={reveal.allComplete}
-          completedCount={reveal.completedCount}
-          total={REVEAL_ORDER.length}
-        />
-      </Section>
+      {/* Only while setup is unfinished. Once it's done this card said nothing
+          except "it's done — use the re-run icon", which the icon in the header
+          already offers: a permanent 100% bar at the top of Settings is noise
+          on every visit. Gated on `loaded` so an established install never
+          flashes it before the onboarding state arrives. */}
+      {reveal.loaded && !setupComplete && (
+        <Section title="setup" dirty={false} index={0}>
+          <SetupSection
+            completedCount={reveal.completedCount}
+            total={REVEAL_ORDER.length}
+          />
+        </Section>
+      )}
 
       <Section title="profile" dirty={isDirty("user", "ui")} index={1} reveal={reveal.states.profile}>
         <Field label="Name">

--- a/web/src/views/__tests__/Tools.test.tsx
+++ b/web/src/views/__tests__/Tools.test.tsx
@@ -136,6 +136,129 @@ describe("ProvidersToolsSection optional services", () => {
   });
 });
 
+describe("ProvidersToolsSection expanded tool details", () => {
+  /** Render the table with one CLI tool and expand its row. */
+  async function expandTool(tool: Record<string, unknown>) {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u === "/api/providers") return jsonResponse([]);
+      if (u === "/api/tools/unified") return jsonResponse([tool]);
+      if (u === "/api/system/package-managers") return jsonResponse({ os: "darwin", arch: "arm64", managers: [] });
+      return jsonResponse({});
+    });
+
+    render(
+      <MemoryRouter>
+        <ProvidersToolsSection />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByText(String(tool.name)));
+  }
+
+  it("shows the resolved path and inferred owner, not the bare command name", async () => {
+    await expandTool({
+      name: "rg",
+      type: "cli",
+      status: "installed",
+      version: "14.1.1",
+      required: false,
+      command: "rg",
+      path: "/opt/homebrew/bin/rg",
+      manager: "brew",
+    });
+
+    // The real path — the old UI labelled the bare command "rg" as the Path,
+    // which told the user nothing.
+    expect(await screen.findByText("/opt/homebrew/bin/rg")).toBeInTheDocument();
+    expect(screen.getByText("Homebrew")).toBeInTheDocument();
+    // The version command was pure derivable noise and is gone.
+    expect(screen.queryByText(/Version cmd/)).not.toBeInTheDocument();
+    expect(screen.queryByText("rg --version")).not.toBeInTheDocument();
+  });
+
+  it("names the update command its manager would use when none is configured", async () => {
+    await expandTool({
+      name: "rg",
+      type: "cli",
+      status: "installed",
+      required: false,
+      command: "rg",
+      path: "/opt/homebrew/bin/rg",
+      manager: "brew",
+    });
+
+    // No upgrade_cmd is configured, so the hint must point at something real
+    // instead of "copy the command above" with no command above.
+    expect(await screen.findByText("brew upgrade rg")).toBeInTheDocument();
+    expect(screen.getByText(/copy the Update command below/)).toBeInTheDocument();
+  });
+
+  it("says an OS-provided tool is not mycel's to update", async () => {
+    await expandTool({
+      name: "git",
+      type: "cli",
+      status: "installed",
+      version: "2.50.1",
+      required: false,
+      command: "git",
+      path: "/usr/bin/git",
+      manager: "system",
+    });
+
+    expect(await screen.findByText("/usr/bin/git")).toBeInTheDocument();
+    expect(screen.getByText("Your OS")).toBeInTheDocument();
+    expect(screen.getByText(/update it through the system/i)).toBeInTheDocument();
+    // No manager owns it, so no update command may be suggested.
+    expect(screen.queryByText(/upgrade git/)).not.toBeInTheDocument();
+    // And /usr/bin/git is not mycel's to delete — an Uninstall button here
+    // could only ever produce the backend's refusal.
+    expect(screen.queryByRole("button", { name: /uninstall/i })).not.toBeInTheDocument();
+  });
+
+  it("still offers Uninstall for a tool a package manager owns", async () => {
+    await expandTool({
+      name: "rg",
+      type: "cli",
+      status: "installed",
+      required: false,
+      command: "rg",
+      path: "/opt/homebrew/bin/rg",
+      manager: "brew",
+    });
+
+    expect(await screen.findByRole("button", { name: /uninstall/i })).toBeInTheDocument();
+  });
+
+  it("reports honestly when a tool is not on PATH", async () => {
+    await expandTool({
+      name: "wrangler",
+      type: "cli",
+      status: "not_installed",
+      required: false,
+      command: "wrangler",
+      manager: "npm",
+      install_cmd: "npm install -g wrangler",
+    });
+
+    expect(await screen.findByText("Not found on PATH")).toBeInTheDocument();
+    expect(screen.getByText("npm (global)")).toBeInTheDocument();
+  });
+
+  it("falls back to Unknown when nothing identifies an owner", async () => {
+    await expandTool({
+      name: "mytool",
+      type: "cli",
+      status: "installed",
+      required: false,
+      command: "mytool",
+      path: "/usr/local/bin/mytool",
+    });
+
+    expect(await screen.findByText("Unknown")).toBeInTheDocument();
+  });
+});
+
 describe("ProvidersToolsSection providers list", () => {
   it("renders providers as a list/table with no card/grid view toggle", async () => {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {

--- a/web/src/views/__tests__/settings.test.tsx
+++ b/web/src/views/__tests__/settings.test.tsx
@@ -139,15 +139,32 @@ describe("Settings redesign", () => {
     expect(screen.getByRole("button", { name: /re-run setup/i })).toBeInTheDocument();
   });
 
-  it("treats an install that already runs agents as setup-complete (no nag)", async () => {
+  it("drops the setup card once setup is done — the re-run icon is the entry point", async () => {
     mockApi({
       onboarding: { firstRun: false, hasAgents: true, prefsValid: true, completed: [], step: "" },
       settings: { ...SETTINGS, user: { name: "" }, onboarding: { step: "", completed: [] } },
     });
     renderSettings();
-    // Even with an unfinished reveal, a live fleet means done.
-    await waitFor(() => expect(screen.getAllByText(/Complete/).length).toBeGreaterThan(0));
-    expect(screen.getByRole("button", { name: /re-run setup/i })).toBeInTheDocument();
+
+    // Reconfiguring stays available whether or not the card is showing.
+    expect(await screen.findByRole("button", { name: /re-run setup/i })).toBeInTheDocument();
+
+    // Even with an unfinished reveal, a live fleet means done — and a finished
+    // install gets no card, since all it ever said was "done, use the icon".
+    await waitFor(() => expect(screen.queryByText("setup")).not.toBeInTheDocument());
+    expect(screen.queryByText(/sections done/)).not.toBeInTheDocument();
+    // The sections it used to gate are all still there and reachable.
+    expect(await screen.findByText("providers & tools")).toBeInTheDocument();
+  });
+
+  it("keeps the setup card while setup is genuinely unfinished", async () => {
+    mockApi({
+      settings: { ...SETTINGS, user: { name: "" }, onboarding: { step: "", completed: [] } },
+      onboarding: { firstRun: true, hasAgents: false, prefsValid: true, completed: [], step: "" },
+    });
+    renderSettings();
+    expect(await screen.findByText("setup")).toBeInTheDocument();
+    expect(await screen.findByText(/sections done/)).toBeInTheDocument();
   });
 
   it("never locks a section that is already satisfied", async () => {


### PR DESCRIPTION
Fixes #3482

From UI review of Providers & Tools. Four of the five points in that issue are
the same underlying problem: the row asked for, or made up, things it could
have derived.

## The path was never a path

`GET /api/tools/unified` returned `command` verbatim for a store-registered
tool, so `git` reported `command: "git"` — and the UI rendered that under a
`Path:` label. The same handler already resolved the real path for
role-provided tools (`ut.Command = path`), so one field meant two different
things depending on which branch produced the row, and the UI trusted the
wrong one.

Now `command` is consistently what was configured and `path` carries the
resolution. A new `manager` field names the owning package manager, inferred:

- From the resolved path first, since a binary at `/opt/homebrew/bin/rg` is a
  fact while config can be stale. Symlinks are followed for this inference
  only — a brew binary on PATH is a symlink and only its Cellar target names
  brew — while the path shown stays the one PATH yields.
- From the configured install command as a fallback, which is the only
  evidence available for a tool that isn't installed yet.
- `/usr/local/bin` is deliberately treated as proving nothing: Intel Homebrew
  installs there and so does `make install`.

Verified against a real host — `/usr/bin/git` → Your OS, `/opt/homebrew/bin/gh`
→ Homebrew, and `~/.bun/bin/bun` honestly reports unknown, since bun's own
installer put it there.

## The row now says what it knows

- **Version cmd is gone.** It was the tool name plus a fixed suffix.
- **Facts render as plain text**, not the bordered boxes that made read-only
  values look like inputs waiting to be filled in.
- **The hint points at something real.** With no updater configured the row
  said "copy the command above" while showing no command above it; it now
  names the command the owning manager would use (`brew upgrade gh`). Shown to
  copy, never run: it assumes the package name equals the tool name, which is
  right often but not always (`rg` ↔ `ripgrep`) and isn't a good enough guess
  to execute. #3483 covers doing this for real.
- **Uninstall is withheld for OS-provided binaries.** The row offered to
  uninstall `/usr/bin/git`, which the backend refuses — the button could only
  ever produce that error.

## The Setup card only appears while setup is unfinished

Once complete it said "Setup is complete. Use the re-run icon above…" over a
permanent 100% bar, restating a control already in the header, on every visit
to Settings. An install that already runs agents could never see anything
else, since `hasAgents` alone makes it complete. Gated on `loaded` too, so an
established install never flashes it before onboarding state arrives. The
re-run icon is untouched, and the card still guides a genuine first run.

## Test plan

- [x] `TestInferToolManager` — 20 cases over both evidence kinds, including
      the `/usr/local/bin` ambiguity and a package named like a manager
- [x] `TestDescribeBinaryResolvesSymlinkToFindManager` — fake Cellar + PATH
      symlink, asserting the reported path and the inferred owner
- [x] `TestUnifiedTools*` — API-level, asserting `path` and `manager` on the
      response and that `command` stays the configured name
- [x] Tool row tests: resolved path shown, version cmd absent, derived update
      command, OS-provided tools not offered Uninstall, honest not-on-PATH
      state, Unknown owner fallback
- [x] Settings tests: card dropped when complete, kept when unfinished
- [x] Full web suite (428), `go test ./server/... ./pkg/tool/...`,
      `golangci-lint run ./server/handlers/...`, eslint, tsc
- [x] Verified in the browser against a real daemon, both a brew-managed and
      an OS-provided tool

Follow-up: #3483 (version picker — list and switch versions per manager).

Made with [Cursor](https://cursor.com)