### PR TITLE
fix(cli): send channel messages to the route the daemon actually serves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mycel channel send` works again.** Every send failed with
+  `405 method not allowed`, and so did `mycel agent health`'s alert delivery:
+  the Go client posted to `/api/channels/{name}/messages`, a path no route
+  serves. `/api/channels/` is handled by the history endpoint, which accepts GET
+  only. Both now use `POST /api/channels/send` — the endpoint the web UI and the
+  `send_message` MCP tool have been using all along, which is why sending
+  appeared to work everywhere except the CLI. An unroutable channel is also no
+  longer reported as sent: the endpoint answers `{"sent": false}` without an
+  error, and both commands now say so instead of printing success over a message
+  that went nowhere (#3487).
 - **A blank MCP command no longer takes the daemon down.** The tool health
   check indexed the first field of a stored command without checking there was
   one, so a whitespace-only entry panicked — on a background goroutine, where

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,16 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`mycel channel send` works again.** Every send failed with
-  `405 method not allowed`, and so did `mycel agent health`'s alert delivery:
-  the Go client posted to `/api/channels/{name}/messages`, a path no route
-  serves. `/api/channels/` is handled by the history endpoint, which accepts GET
-  only. Both now use `POST /api/channels/send` — the endpoint the web UI and the
-  `send_message` MCP tool have been using all along, which is why sending
-  appeared to work everywhere except the CLI. An unroutable channel is also no
-  longer reported as sent: the endpoint answers `{"sent": false}` without an
-  error, and both commands now say so instead of printing success over a message
-  that went nowhere (#3487).
 - **A blank MCP command no longer takes the daemon down.** The tool health
   check indexed the first field of a stored command without checking there was
   one, so a whitespace-only entry panicked — on a background goroutine, where

--- a/internal/cmd/agent_health.go
+++ b/internal/cmd/agent_health.go
@@ -263,10 +263,15 @@ func sendStuckAlertViaClient(ctx context.Context, c *client.Client, channelName 
 
 	message := sb.String()
 
-	// Send via daemon channel API
-	_, sendErr := c.Channels.Send(ctx, channelName, "mycel-health", message)
+	// Send via daemon channel API. An unroutable channel comes back as
+	// not-sent rather than as an error, and a health alert that silently went
+	// nowhere is the worst possible outcome for this command — so say so.
+	sent, sendErr := c.Channels.Send(ctx, channelName, "mycel-health", message)
 	if sendErr != nil {
 		return fmt.Errorf("failed to send alert to channel %q: %w", channelName, sendErr)
+	}
+	if !sent {
+		return fmt.Errorf("alert not delivered: channel %q has no delivery route configured", channelName)
 	}
 
 	fmt.Printf("Alert sent to channel %q\n", channelName)

--- a/internal/cmd/channel.go
+++ b/internal/cmd/channel.go
@@ -430,8 +430,15 @@ func runChannelSend(cmd *cobra.Command, args []string) error {
 	}
 
 	sender := getUserSenderCtx(cmd.Context())
-	if _, err := c.Channels.Send(cmd.Context(), channelName, sender, message); err != nil {
+	sent, err := c.Channels.Send(cmd.Context(), channelName, sender, message)
+	if err != nil {
 		return err
+	}
+	// The daemon reports an unroutable channel as not-sent rather than as an
+	// error. Printing success there would leave the user believing a message
+	// was delivered that nothing ever carried.
+	if !sent {
+		return fmt.Errorf("channel %q has no delivery route configured; run 'mycel channel list' to see reachable channels", channelName)
 	}
 
 	fmt.Printf("Sent message to #%s\n", channelName)

--- a/pkg/client/channels.go
+++ b/pkg/client/channels.go
@@ -94,14 +94,25 @@ func (ch *ChannelsClient) RemoveMember(ctx context.Context, chanName, agentName 
 	return ch.client.delete(ctx, "/api/channels/"+chanName+"/members/"+agentName)
 }
 
-// Send sends a message to a channel.
-func (ch *ChannelsClient) Send(ctx context.Context, chanName, sender, message string) (*MessageInfo, error) {
-	body := map[string]string{"sender": sender, "content": message}
-	var msg MessageInfo
-	if err := ch.client.post(ctx, "/api/channels/"+chanName+"/messages", body, &msg); err != nil {
-		return nil, err
+// Send delivers a message to a channel as sender, reporting whether the
+// daemon's gateway actually routed it. A channel with no configured route
+// returns false with no error — that is the endpoint's contract, not a failure,
+// so callers must check the flag before telling a user the message was sent.
+//
+// This posts to /api/channels/send, the same endpoint the web UI and the
+// send_message MCP tool use. It previously posted to
+// /api/channels/{name}/messages, which no route serves: /api/channels/ is
+// handled by the history endpoint, which accepts GET only, so every CLI send
+// failed with 405.
+func (ch *ChannelsClient) Send(ctx context.Context, chanName, sender, message string) (bool, error) {
+	body := map[string]string{"channel": chanName, "sender": sender, "message": message}
+	var res struct {
+		Sent bool `json:"sent"`
 	}
-	return &msg, nil
+	if err := ch.client.post(ctx, "/api/channels/send", body, &res); err != nil {
+		return false, err
+	}
+	return res.Sent, nil
 }
 
 // History returns message history for a channel.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -829,20 +829,48 @@ func TestChannels_RemoveMember(t *testing.T) {
 	}
 }
 
+// Send must hit the one endpoint the daemon actually serves, with the field
+// names it actually reads. Asserting only the body is what let this ship broken:
+// the client posted to /api/channels/{name}/messages, which no route handles, and
+// a fake server answering every path never noticed.
 func TestChannels_Send(t *testing.T) {
-	handler, cap := capturingHandler(t, http.MethodPost, 200, MessageInfo{Channel: "general", Sender: "alice", Content: "hi"})
+	handler, cap := capturingHandler(t, http.MethodPost, 200, map[string]bool{"sent": true})
 	ts := mockServer(t, handler)
 	c := New(ts.URL)
 
-	result, err := c.Channels.Send(context.Background(), "general", "alice", "hi")
+	sent, err := c.Channels.Send(context.Background(), "slack:general", "alice", "hi")
 	if err != nil {
 		t.Fatalf("Send() error = %v", err)
 	}
-	if result.Content != "hi" {
-		t.Errorf("Content = %q, want hi", result.Content)
+	if !sent {
+		t.Error("sent = false, want true")
 	}
-	if cap.Body["sender"] != "alice" {
-		t.Errorf("body sender = %v, want alice", cap.Body["sender"])
+	if cap.Path != "/api/channels/send" {
+		t.Errorf("path = %q, want /api/channels/send", cap.Path)
+	}
+	for field, want := range map[string]string{
+		"channel": "slack:general",
+		"sender":  "alice",
+		"message": "hi",
+	} {
+		if got := cap.Body[field]; got != want {
+			t.Errorf("body %s = %v, want %q", field, got, want)
+		}
+	}
+}
+
+// An unroutable channel is reported by the daemon as {"sent":false} with a 200,
+// so the client must surface that rather than treating a 200 as delivery.
+func TestChannels_SendReportsUndelivered(t *testing.T) {
+	ts := mockServer(t, jsonHandler(200, map[string]bool{"sent": false}))
+	c := New(ts.URL)
+
+	sent, err := c.Channels.Send(context.Background(), "slack:nowhere", "alice", "hi")
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+	if sent {
+		t.Error("sent = true, want false for a channel with no route")
 	}
 }
 

--- a/server/e2e_roundtrip_test.go
+++ b/server/e2e_roundtrip_test.go
@@ -7,6 +7,7 @@
 package server_test
 
 import (
+	"net/http"
 	"testing"
 )
 
@@ -178,4 +179,25 @@ func TestE2E_ChannelCreateDeleteVerify(t *testing.T) {
 		t.Fatalf("list channels: want 200, got %d", channelsCode)
 	}
 	_ = channels // fresh home has no active gateway channels
+}
+
+// The route the Go client sends on must be mounted for POST. It was not: the
+// client posted to /api/channels/{name}/messages, which falls through to the
+// GET-only history handler, so every `mycel channel send` failed with 405 while
+// the client's own unit test — a fake server answering any path — stayed green.
+//
+// This E2E server has no gateway configured, so a mounted route answers 503
+// ("gateway not available"). Anything is acceptable here except 405 and 404,
+// which mean the route is missing or method-mismatched.
+func TestE2E_ChannelSendRouteAcceptsPost(t *testing.T) {
+	s := newE2EServer(t)
+
+	code, _ := s.postJSON(t, "/api/channels/send", map[string]any{
+		"channel": "slack:general",
+		"sender":  "alice",
+		"message": "hi",
+	})
+	if code == http.StatusMethodNotAllowed || code == http.StatusNotFound {
+		t.Fatalf("POST /api/channels/send returned %d — the send route the CLI uses is not mounted", code)
+	}
 }


### PR DESCRIPTION
## Summary

`mycel channel send` failed with `405 method not allowed` every time, and so did `mycel agent health`'s alert delivery. The Go client posted to `/api/channels/{name}/messages`, which no route handles — `/api/channels/` belongs to the history endpoint, and that accepts GET only. Both now use `POST /api/channels/send`, the endpoint the web UI and the `send_message` MCP tool already use, which is why sending appeared to work everywhere except the CLI.

An unroutable channel is no longer reported as sent either. That endpoint answers `{"sent": false}` with a 200 rather than an error, so the client returns the flag and both commands say the message went nowhere instead of printing success over it.

I found this while working on #3486 — the command `.cursorrules` tells every agent to use for posting to channels has been dead.

## Why the tests didn't catch it

`TestChannels_Send` used a fake server that answers any path, so it asserted the request body and never the route. It now asserts both, and a new E2E test fails if `POST /api/channels/send` is not mounted on the real daemon mux (the E2E server has no gateway, so a mounted route answers 503 — the test rejects only 405 and 404).

## Test plan

- [x] `go test ./pkg/client/ ./internal/cmd/ ./server/`
- [x] `go vet ./...`, `make lint` — clean
- [x] Verified against a live daemon: `mycel channel send slack:general "..."` delivers and prints success
- [x] Verified the honest-failure path: an unknown channel now errors with `no delivery route configured` instead of claiming success

Fixes #3487

Made with [Cursor](https://cursor.com)