### PR TITLE
feat(agents): derive the task line from activity and drop report_status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **The `report_status` MCP tool is gone; an agent's task line is now derived
+  from its activity.** *Action required if you have prompts or role
+  instructions that tell agents to call `report_status` — remove them; the tool
+  no longer exists and calls to it will fail.* The task line is now taken from
+  the prompt an agent was given at the start of its turn, for every provider
+  that reports one. Self-reporting made the task line only as accurate as an
+  agent's diligence: one that never called the tool showed nothing, and one that
+  called it once showed that first task all session while the daemon already knew
+  what it had been asked to do. Deriving it also fixed two providers that could
+  never have reported well — the transcript tailer was computing a task from the
+  prompt that ingestion then discarded, and `agy`'s hooks discarded their payload
+  entirely, so no prompt or tool detail ever reached the daemon (#3489).
+
 ### Security
 
 - **Cross-origin writes are refused.** Any page the user had open in another

--- a/docs/explanation/agents.md
+++ b/docs/explanation/agents.md
@@ -34,6 +34,41 @@ stateDiagram-v2
 | stopped | Session terminated |
 | error | Failed to start or unrecoverable |
 
+## The Task Line
+
+Alongside its state, every agent has a one-line task shown in the agents table,
+the dashboard and the TUI. It answers "what is this agent working on".
+
+It is derived, not reported. When a turn starts — `UserPromptSubmit` for claude
+and cursor, `PreInvocation` for agy — the prompt the agent was handed becomes its
+task, truncated to 120 characters. Transcript-mode providers (pi, codex) go
+through the same path: the tailer forwards the parsed user turn's prompt and
+ingestion derives the task from it, so every provider that reports a turn gets an
+identical task line from identical input.
+
+This used to be the agent's own job, via a `report_status` MCP tool. That made
+the task line only as accurate as an agent's diligence: an agent that never
+called it showed nothing, and one that called it once showed that first task for
+the rest of the session while the daemon already knew what it had actually been
+asked to do. Deriving it removes the failure mode entirely — the task cannot go
+stale while an agent works, because it is a property of the observed stream.
+
+Two things do not set the task:
+
+- **Lifecycle labels.** The strings hook commands carry ("Turn complete",
+  "Session ended", "Running tool") describe events, not work. They flow to the
+  activity feed and are never written to the task line — doing so was a real bug
+  (#3259) that clobbered the real task on every turn boundary.
+- **Tool events.** `PreToolUse` fires many times per turn. The task is the turn's
+  subject, not whatever call is in flight; that detail belongs in the Live feed.
+
+`spawn_agent` is the one exception that writes a task directly: a parent hands
+its child a task before that child has run a turn of its own. The child's first
+prompt replaces it.
+
+The task is cleared when an agent stops or restarts, so a dead or fresh agent
+never advertises work from a previous session.
+
 ## Lifecycle Internals
 
 `pkg/agent.Manager` splits agent creation from starting it, so callers can

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -146,8 +146,8 @@ AI Agent (Claude Code)             mycel MCP Server
         |   {channel, message, sender}     |
         |<-- result ----------------------|
         |                                  |
-        |-- tools/call report_status ----->|
-        |   {agent, task}                  |
+        |-- tools/call query_costs ------->|
+        |   {agent?}                       |
         |<-- result ----------------------|
 ```
 

--- a/docs/explanation/mcp.md
+++ b/docs/explanation/mcp.md
@@ -42,10 +42,14 @@ The sender identity for outbound tools (`send_message`, `send_file`) is derived 
 |------|------|-------------|
 | `whoami` | — | Current agent's identity: name, `display_name`, role, state, `provider`/`model`, its `avatar_url` (AgentCharacter), and a `slack` hint for posting as itself |
 | `list_agents` | role? | List agents with status and role, optionally filtered by role |
-| `report_status` | task | Update the agent's current task line |
 | `query_costs` | agent? | Token usage and cost, for one agent or the whole fleet |
 
-Tool arguments have per-field length caps enforced at handler entry (64KB for message/comment, 256B for channel/sender/role, 4KB for file_path, 1KB for task) since the `/_mcp/*` routes are exempt from the global body-size middleware.
+There is deliberately no tool for reporting status. An agent's task line is
+derived from its activity stream — the prompt it was given on its last turn —
+so it reflects what the agent is actually doing without the agent having to
+remember to publish it. See [Agent Architecture](agents.md).
+
+Tool arguments have per-field length caps enforced at handler entry (64KB for message/comment, 256B for channel/sender/role, 4KB for file_path, 1KB for a spawned agent's task) since the `/_mcp/*` routes are exempt from the global body-size middleware.
 
 ## Agent Identity & Avatar
 

--- a/docs/reference/api-rest.md
+++ b/docs/reference/api-rest.md
@@ -436,7 +436,7 @@ Read-only code browsing for agent worktrees. All endpoints take `worktree=<agent
 
 ## MCP Protocol (agent-facing)
 
-The MCP server agents connect to for `send_message` / `report_status` / `query_costs` and friends. These paths bypass API-key auth.
+The MCP server agents connect to for `send_message` / `query_costs` and friends. These paths bypass API-key auth.
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1344,8 +1344,8 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 		existing.State = StateStarting
 		// Clear the task so the UI doesn't render the previous session's
 		// stale task next to a fresh "starting" badge. Lifecycle progress
-		// ("Starting…") is conveyed by State, never by Task — Task holds
-		// only what the agent itself reports via mycel report/report_status.
+		// ("Starting…") is conveyed by State, never by Task — Task holds the
+		// prompt the agent is working on, and it has not been given one yet.
 		existing.Task = ""
 	}
 	existing.UpdatedAt = time.Now()
@@ -2583,8 +2583,10 @@ func (m *Manager) UpdateAgentState(ctx context.Context, name string, state State
 }
 
 // SetAgentTask updates an agent's task line without touching its lifecycle
-// state, so a status report never has to satisfy the state machine. This is
-// the write path for the MCP report_status tool.
+// state, so recording what an agent is working on never has to satisfy the
+// state machine. Two things write here: hook ingestion, which derives the task
+// from the prompt on a user turn, and spawn_agent, which records the task a
+// parent handed its child before that child has run a turn of its own.
 func (m *Manager) SetAgentTask(ctx context.Context, name, task string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -2601,11 +2603,11 @@ func (m *Manager) SetAgentTask(ctx context.Context, name, task string) error {
 }
 
 // SetAgentState updates an agent's state from a lifecycle event while
-// preserving the agent's reported task. Lifecycle descriptions ("Turn
-// complete", "Session ended", …) belong in the activity/event stream, not
-// in the Task field — Task is reserved for the agent's own report
-// (mycel report / report_status). The task is cleared when the agent stops
-// so a dead agent doesn't keep advertising a stale task.
+// preserving the agent's task. Lifecycle descriptions ("Turn complete",
+// "Session ended", …) belong in the activity/event stream, not in the Task
+// field — Task holds what the agent was asked to do, derived from the prompt on
+// its last user turn. The task is cleared when the agent stops so a dead agent
+// doesn't keep advertising a stale task.
 // Returns an error if the transition is invalid per the state machine.
 func (m *Manager) SetAgentState(ctx context.Context, name string, state State) error {
 	var (

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -1236,7 +1236,7 @@ func TestUpdateAgentState_TaskUpdate(t *testing.T) {
 	}
 }
 
-// --- SetAgentTask (MCP report_status write path) ---
+// --- SetAgentTask (hook ingestion and spawn_agent write path) ---
 
 func TestSetAgentTask(t *testing.T) {
 	m := newTestManager(t)
@@ -1806,8 +1806,8 @@ func TestUpdateAgentStateValidation(t *testing.T) {
 }
 
 // SetAgentState is the lifecycle-hook path: it must move state WITHOUT
-// overwriting the agent's reported task (#3259 — lifecycle strings like
-// "Turn complete"/"Session ended" were clobbering report_status tasks).
+// overwriting the agent's task (#3259 — lifecycle strings like
+// "Turn complete"/"Session ended" were clobbering the real task).
 func TestSetAgentState_PreservesReportedTask(t *testing.T) {
 	m := &Manager{
 		agents: make(map[string]*Agent),

--- a/pkg/agent/hook_ingest.go
+++ b/pkg/agent/hook_ingest.go
@@ -85,11 +85,28 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 	if hasState {
 		// State-only update: lifecycle descriptions baked into hook
 		// commands ("Turn complete", "Session ended", "Processing
-		// prompt...") must NOT overwrite the agent's reported task.
-		// They still flow to the event log and SSE stream below.
+		// prompt...") must NOT become the agent's task line. They still
+		// flow to the event log and SSE stream below.
 		if err := s.manager.SetAgentState(ctx, name, targetState); err != nil {
 			log.Debug("hook state update skipped", "agent", name, "error", err)
 			return &HookStateSkippedError{Err: err}
+		}
+	}
+
+	// The prompt an agent was just given is its task. Applying it here is what
+	// makes the task line a property of observed activity rather than something
+	// the agent has to remember to publish: it updates on every turn, for every
+	// provider that reports one, and it cannot go stale while the agent works.
+	//
+	// This runs after the state transition so a prompt on a stopped agent is
+	// dropped with the transition rather than labeling a dead agent with work
+	// it will never do.
+	if isTurnStart(payload.Event) && payload.Prompt != "" {
+		task := truncateRunes(payload.Prompt, maxDerivedTaskLen)
+		if err := s.manager.SetAgentTask(ctx, name, task); err != nil {
+			// Non-fatal: the event itself is still worth logging and
+			// broadcasting even if the task line could not be updated.
+			log.Debug("hook task update skipped", "agent", name, "error", err)
 		}
 	}
 
@@ -139,6 +156,20 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 	return nil
 }
 
+// isTurnStart reports whether an event marks the beginning of a model turn,
+// i.e. the moment the agent is handed something to do. Both events that move an
+// agent to "working" qualify: claude and cursor report UserPromptSubmit, while
+// agy reports PreInvocation. Deriving the task from either means a provider's
+// choice of name does not decide whether its agents get a task line.
+func isTurnStart(ev HookEvent) bool {
+	return ev == HookUserPromptSubmit || ev == HookPreInvocation
+}
+
+// maxDerivedTaskLen bounds the prompt text used as an agent's task line. The
+// task line is a single row in a table and a badge subtitle, so it is cut to
+// something that fits one line rather than to the prompt's own length.
+const maxDerivedTaskLen = 120
+
 // maxToolResponseBytes bounds how much of a tool's response we persist into
 // the event log and broadcast to live subscribers. PostToolUse responses
 // (file contents, command output, MCP results, …) can be arbitrarily large;
@@ -177,6 +208,21 @@ func boundedToolResponse(v any) any {
 		return v
 	}
 	return truncateToRuneBoundary(string(b), maxToolResponseBytes) + toolResponseTruncatedSuffix
+}
+
+// truncateRunes returns s cut to at most max runes, marking a shortened result
+// with an ellipsis. Runes rather than bytes because the result is shown to a
+// person: a task line should be cut to a predictable visible length regardless
+// of how many bytes each character happens to occupy.
+func truncateRunes(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max <= 1 {
+		return string(r[:max])
+	}
+	return string(r[:max-1]) + "…"
 }
 
 // truncateToRuneBoundary returns s cut to at most maxBytes bytes without

--- a/pkg/agent/hook_ingest.go
+++ b/pkg/agent/hook_ingest.go
@@ -98,10 +98,11 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 	// the agent has to remember to publish: it updates on every turn, for every
 	// provider that reports one, and it cannot go stale while the agent works.
 	//
-	// This runs after the state transition so a prompt on a stopped agent is
-	// dropped with the transition rather than labeling a dead agent with work
-	// it will never do.
-	if isTurnStart(payload.Event) && payload.Prompt != "" {
+	// A payload may name a state explicitly, so a turn-start event can arrive
+	// carrying state=stopped. That transition clears the task by design; writing
+	// the prompt afterwards would refill it and leave a dead agent advertising
+	// work it will never do, so nothing is derived when the agent just stopped.
+	if isTurnStart(payload.Event) && payload.Prompt != "" && targetState != StateStopped {
 		task := truncateRunes(payload.Prompt, maxDerivedTaskLen)
 		if err := s.manager.SetAgentTask(ctx, name, task); err != nil {
 			// Non-fatal: the event itself is still worth logging and

--- a/pkg/agent/hook_ingest_test.go
+++ b/pkg/agent/hook_ingest_test.go
@@ -198,3 +198,152 @@ func TestHookPayloadFields_ToolResponseRoundtrip(t *testing.T) {
 		t.Error("hookPayloadFields did not include tool_response")
 	}
 }
+
+// ─── task line derived from the prompt ──────────────────────────────────────
+
+// The task line must come from the activity stream. Before this, the only way
+// an agent's task was ever set was the report_status MCP tool, so an agent that
+// never called it — or forgot to after moving on — showed nothing or something
+// stale while the daemon knew exactly what it had been asked to do.
+func TestIngestHookEvent_UserPromptBecomesTask(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["eng-1"] = &Agent{Name: "eng-1", Role: Role("engineer"), State: StateIdle}
+	svc := NewAgentService(mgr, nil, nil)
+
+	payload := HookPayload{Event: HookUserPromptSubmit, Prompt: "fix the flaky login test"}
+	if err := svc.IngestHookEvent(context.Background(), "eng-1", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+
+	if got := mgr.agents["eng-1"].Task; got != "fix the flaky login test" {
+		t.Errorf("task = %q, want the prompt text", got)
+	}
+	// The event still drives the state transition it always did.
+	if got := mgr.agents["eng-1"].State; got != StateWorking {
+		t.Errorf("state = %q, want %q", got, StateWorking)
+	}
+}
+
+// A long prompt is cut to one line's worth of text rather than pushed whole
+// into a table cell.
+func TestIngestHookEvent_LongPromptIsTruncated(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["eng-1"] = &Agent{Name: "eng-1", Role: Role("engineer"), State: StateIdle}
+	svc := NewAgentService(mgr, nil, nil)
+
+	long := strings.Repeat("a", maxDerivedTaskLen*2)
+	payload := HookPayload{Event: HookUserPromptSubmit, Prompt: long}
+	if err := svc.IngestHookEvent(context.Background(), "eng-1", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+
+	got := mgr.agents["eng-1"].Task
+	if n := utf8.RuneCountInString(got); n != maxDerivedTaskLen {
+		t.Errorf("task length = %d runes, want %d", n, maxDerivedTaskLen)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Error("a truncated task should be marked with an ellipsis")
+	}
+}
+
+// Only a user turn sets the task. Tool events fire many times per turn, and a
+// lifecycle event's canned label ("Turn complete") is not a task — letting
+// either through is how the task line used to get clobbered (#3259).
+func TestIngestHookEvent_OnlyUserPromptSetsTask(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		payload HookPayload
+	}{
+		{"tool call", HookPayload{Event: HookPreToolUse, ToolName: "Bash", Prompt: "ignored"}},
+		{"turn end with canned task", HookPayload{Event: HookStop, Task: "Turn complete"}},
+		{"session start with canned task", HookPayload{Event: HookSessionStart, Task: "Session started"}},
+		{"empty prompt", HookPayload{Event: HookUserPromptSubmit, Prompt: ""}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mgr := newTestManager(t)
+			mgr.agents["eng-1"] = &Agent{
+				Name: "eng-1", Role: Role("engineer"),
+				State: StateWorking, Task: "the real task",
+			}
+			svc := NewAgentService(mgr, nil, nil)
+
+			if err := svc.IngestHookEvent(context.Background(), "eng-1", tc.payload, nil); err != nil {
+				t.Fatalf("IngestHookEvent: %v", err)
+			}
+			// Stop clears the task via the stopped transition; every other
+			// case must leave it exactly as it was.
+			if got := mgr.agents["eng-1"].Task; got != "the real task" {
+				t.Errorf("task = %q, want it left untouched", got)
+			}
+		})
+	}
+}
+
+func TestTruncateRunes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		want string
+		max  int
+	}{
+		{"under the cap is unchanged", "short", "short", 10},
+		{"exactly at the cap is unchanged", "12345", "12345", 5},
+		{"over the cap is elided", "123456", "1234…", 5},
+		// Runes, not bytes: a multi-byte string under the rune cap must
+		// survive whole rather than being cut by its byte length.
+		{"multi-byte under the cap", "héllo wörld", "héllo wörld", 11},
+		{"multi-byte over the cap", "héllo wörld", "héllo…", 6},
+		{"cap of one truncates without an ellipsis", "abc", "a", 1},
+		{"cap of zero is empty", "abc", "", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := truncateRunes(tc.in, tc.max); got != tc.want {
+				t.Errorf("truncateRunes(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+		})
+	}
+}
+
+// A real claude UserPromptSubmit body carries both the user's prompt and the
+// canned label mycel's hook command merges in. The prompt must survive decoding
+// — a field absent from HookPayload is silently dropped by json.Unmarshal, which
+// is exactly how tool_response went missing — and it must win over the label.
+func TestIngestHookEvent_DecodesPromptFromRawHookBody(t *testing.T) {
+	raw := []byte(`{"session_id":"abc","prompt":"add retries to the uploader",` +
+		`"event":"UserPromptSubmit","state":"working","task":"Processing prompt..."}`)
+	var payload HookPayload
+	if err := json.Unmarshal(raw, &payload); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if payload.Prompt != "add retries to the uploader" {
+		t.Fatalf("payload.Prompt = %q, want the prompt text", payload.Prompt)
+	}
+
+	mgr := newTestManager(t)
+	mgr.agents["eng-1"] = &Agent{Name: "eng-1", Role: Role("engineer"), State: StateIdle}
+	svc := NewAgentService(mgr, nil, nil)
+
+	if err := svc.IngestHookEvent(context.Background(), "eng-1", payload, raw); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+	if got := mgr.agents["eng-1"].Task; got != "add retries to the uploader" {
+		t.Errorf("task = %q, want the prompt rather than the canned label", got)
+	}
+}
+
+// agy names its turn-start event PreInvocation. Its agents must get a task line
+// on the same terms as claude's, or removing report_status would leave them with
+// none at all.
+func TestIngestHookEvent_PreInvocationPromptBecomesTask(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["eng-1"] = &Agent{Name: "eng-1", Role: Role("engineer"), State: StateIdle}
+	svc := NewAgentService(mgr, nil, nil)
+
+	payload := HookPayload{Event: HookPreInvocation, Prompt: "audit the auth middleware"}
+	if err := svc.IngestHookEvent(context.Background(), "eng-1", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+	if got := mgr.agents["eng-1"].Task; got != "audit the auth middleware" {
+		t.Errorf("task = %q, want the prompt text", got)
+	}
+}

--- a/pkg/agent/hook_ingest_test.go
+++ b/pkg/agent/hook_ingest_test.go
@@ -347,3 +347,32 @@ func TestIngestHookEvent_PreInvocationPromptBecomesTask(t *testing.T) {
 		t.Errorf("task = %q, want the prompt text", got)
 	}
 }
+
+// A payload may name its state explicitly, so a turn-start event can arrive
+// carrying state=stopped. The stopped transition clears the task by design;
+// deriving the prompt afterwards would refill it and leave a dead agent
+// advertising work it will never do.
+func TestIngestHookEvent_StoppedTurnStartLeavesTaskCleared(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["eng-1"] = &Agent{
+		Name: "eng-1", Role: Role("engineer"),
+		State: StateWorking, Task: "an earlier task",
+	}
+	svc := NewAgentService(mgr, nil, nil)
+
+	payload := HookPayload{
+		Event:  HookUserPromptSubmit,
+		State:  string(StateStopped),
+		Prompt: "this agent is going away",
+	}
+	if err := svc.IngestHookEvent(context.Background(), "eng-1", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+
+	if got := mgr.agents["eng-1"].State; got != StateStopped {
+		t.Fatalf("state = %q, want %q", got, StateStopped)
+	}
+	if got := mgr.agents["eng-1"].Task; got != "" {
+		t.Errorf("task = %q, want it cleared for a stopped agent", got)
+	}
+}

--- a/pkg/agent/hooks.go
+++ b/pkg/agent/hooks.go
@@ -101,22 +101,29 @@ type HookPayload struct {
 	SubagentID   string         `json:"subagent_id,omitempty"`
 	Channel      string         `json:"channel,omitempty"`
 	State        string         `json:"state,omitempty"`
-	Task         string         `json:"task,omitempty"`
-	TaskID       string         `json:"task_id,omitempty"`
-	TaskTitle    string         `json:"task_title,omitempty"`
-	ToolName     string         `json:"tool_name,omitempty"`
-	Command      string         `json:"command,omitempty"`
-	Error        string         `json:"error,omitempty"`
-	Model        string         `json:"model,omitempty"`
-	Event        HookEvent      `json:"event"`
-	Sender       string         `json:"sender,omitempty"`
-	SubagentType string         `json:"subagent_type,omitempty"`
-	Message      string         `json:"message,omitempty"`
-	File         string         `json:"file,omitempty"`
-	Mentions     []string       `json:"mentions,omitempty"`
-	CostUSD      float64        `json:"cost_usd,omitempty"`
-	InputTokens  int64          `json:"input_tokens,omitempty"`
-	OutputTokens int64          `json:"output_tokens,omitempty"`
+	// Prompt is the text the user sent on a UserPromptSubmit event. It is the
+	// source of the agent's task line: what an agent was asked to do is a
+	// better answer to "what is this agent working on" than a summary it has to
+	// remember to publish itself. Providers that forward their hook payload
+	// (claude, cursor) carry it through unchanged; the transcript tailer fills
+	// it from the parsed user turn.
+	Prompt       string    `json:"prompt,omitempty"`
+	Task         string    `json:"task,omitempty"`
+	TaskID       string    `json:"task_id,omitempty"`
+	TaskTitle    string    `json:"task_title,omitempty"`
+	ToolName     string    `json:"tool_name,omitempty"`
+	Command      string    `json:"command,omitempty"`
+	Error        string    `json:"error,omitempty"`
+	Model        string    `json:"model,omitempty"`
+	Event        HookEvent `json:"event"`
+	Sender       string    `json:"sender,omitempty"`
+	SubagentType string    `json:"subagent_type,omitempty"`
+	Message      string    `json:"message,omitempty"`
+	File         string    `json:"file,omitempty"`
+	Mentions     []string  `json:"mentions,omitempty"`
+	CostUSD      float64   `json:"cost_usd,omitempty"`
+	InputTokens  int64     `json:"input_tokens,omitempty"`
+	OutputTokens int64     `json:"output_tokens,omitempty"`
 }
 
 // The Claude Code hook-settings writer that generates .claude/settings.json

--- a/pkg/agent/role_setup.go
+++ b/pkg/agent/role_setup.go
@@ -269,7 +269,7 @@ func writeMCPJSON(ctx context.Context, repoPath, agentName string, resolved *hom
 	}
 
 	// Always ensure the mycel MCP server is included with an agent-scoped URL.
-	// It carries send_message, report_status, and the other agent tools.
+	// It carries send_message, query_costs, and the other agent tools.
 	if _, hasSelf := cfg.MCPServers["mycel"]; !hasSelf {
 		cfg.MCPServers["mycel"] = mcpServerEntry{URL: selfMCPURL(runtimeBackend, agentName), Type: "http"}
 	}

--- a/pkg/provider/agy_hooks.go
+++ b/pkg/provider/agy_hooks.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -53,17 +54,30 @@ type agyHookSpec struct {
 // agent's execution loop.
 const agyHookTimeoutSecs = 5
 
-// agyHookCommand builds the shell command an agy hook runs. It drains stdin
-// (agy pipes the payload in), POSTs a mycel hook event to the daemon, and prints
-// the JSON result agy expects on stdout. daemonAddr and agentID are resolved
-// at runtime from the MYCEL_DAEMON_ADDR / MYCEL_AGENT_ID environment variables
-// set on the agent session, matching the claude provider.
+// agyHookCommand builds the shell command an agy hook runs. It merges mycel's
+// event/state fields into the payload agy pipes in on stdin, POSTs the result to
+// the daemon, and prints the JSON result agy expects on stdout. daemonAddr and
+// agentID are resolved at runtime from the MYCEL_DAEMON_ADDR / MYCEL_AGENT_ID
+// environment variables set on the agent session, matching the claude provider.
+//
+// It previously discarded stdin (`cat >/dev/null`) and POSTed only the three
+// fields known at generation time. Everything agy reports about a turn — the
+// prompt, the tool being called, its input and its result — was thrown away, so
+// agy agents got a Live feed of bare event names and, once the task line began
+// to be derived from the prompt, no task at all. Forwarding the payload is what
+// gives agy the same detail claude and cursor have.
+//
+// If jq is missing or the payload is unparseable, the bare event is still POSTed
+// so state remains correct; only the detail is lost. The stdout contract is
+// honored unconditionally — a reporting failure must never stall a turn.
 func agyHookCommand(event, state, task, stdout string) string {
 	const daemonAddr = "${MYCEL_DAEMON_ADDR:-http://127.0.0.1:9374}"
-	payload := fmt.Sprintf(`{"event":"%s","state":"%s","task":"%s"}`, event, state, task)
+	fallback := fmt.Sprintf(`{\"event\":\"%s\",\"state\":\"%s\",\"task\":\"%s\"}`, event, state, task)
 	return fmt.Sprintf(
-		`cat >/dev/null 2>&1; curl -sX POST "%s/api/agents/${MYCEL_AGENT_ID}/hook" -H "Content-Type: application/json" -d '%s' >/dev/null 2>&1; printf '%%s' '%s'`,
-		daemonAddr, payload, stdout,
+		`bash -c 'RAW=$(cat); PAYLOAD=$(echo "$RAW" | jq -c ". + {event:\"%s\",state:\"%s\",task:\"%s\"}" 2>/dev/null || echo "%s"); `+
+			`curl -sX POST "%s/api/agents/${MYCEL_AGENT_ID}/hook" -H "Content-Type: application/json" -d "$PAYLOAD" >/dev/null 2>&1; `+
+			`printf "%%s" %s'`,
+		event, state, task, fallback, daemonAddr, strconv.Quote(stdout),
 	)
 }
 

--- a/pkg/provider/agy_test.go
+++ b/pkg/provider/agy_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -412,5 +414,134 @@ func TestAgyContainerCommand(t *testing.T) {
 	}
 	if p.DockerImage() != "" {
 		t.Errorf("DockerImage() = %q, want empty", p.DockerImage())
+	}
+}
+
+// agyCurlRecorder builds a PATH in which curl is shadowed by a shim that writes
+// the payload it was handed to a file, so a generated hook command can be run
+// for real and its POST body inspected. The rest of the system PATH is kept so
+// bash, cat and jq resolve normally.
+func agyCurlRecorder(t *testing.T) (pathEnv, payloadFile string) {
+	t.Helper()
+	shimDir := t.TempDir()
+	payloadFile = filepath.Join(t.TempDir(), "payload.json")
+	shim := "#!/usr/bin/env bash\n" +
+		"# Record the value that followed -d, which is the POST body.\n" +
+		"prev=\"\"\n" +
+		"for arg in \"$@\"; do\n" +
+		"  if [ \"$prev\" = \"-d\" ]; then printf '%s' \"$arg\" > " + strconv.Quote(payloadFile) + "; fi\n" +
+		"  prev=\"$arg\"\n" +
+		"done\n" +
+		"exit 0\n"
+	if err := os.WriteFile(filepath.Join(shimDir, "curl"), []byte(shim), 0700); err != nil { //nolint:gosec // shim must be executable
+		t.Fatalf("write curl shim: %v", err)
+	}
+	return shimDir + string(os.PathListSeparator) + os.Getenv("PATH"), payloadFile
+}
+
+// The agy hook must forward the payload agy pipes in on stdin. It used to drain
+// stdin to /dev/null and POST only the three fields known at generation time, so
+// the prompt and every tool detail agy reported was discarded — leaving agy
+// agents with a Live feed of bare event names and no task line.
+func TestAgyHookCommandForwardsStdin(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not available")
+	}
+	pathEnv, payloadFile := agyCurlRecorder(t)
+
+	cmd := exec.CommandContext(t.Context(), "bash", "-c", //nolint:gosec // running the generated command is the point of the test
+		agyHookCommand("PreInvocation", "working", "Thinking...", "{}"))
+	cmd.Env = append(os.Environ(),
+		"PATH="+pathEnv,
+		"MYCEL_AGENT_ID=agent-x",
+		"MYCEL_DAEMON_ADDR=http://127.0.0.1:9374",
+	)
+	cmd.Stdin = strings.NewReader(`{"prompt":"fix the login bug","tool_name":"Bash"}`)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run hook command: %v", err)
+	}
+
+	// agy requires the handler to print its JSON result, whatever else happens.
+	if strings.TrimSpace(string(out)) != "{}" {
+		t.Errorf("stdout = %q, want %q", out, "{}")
+	}
+
+	raw, err := os.ReadFile(payloadFile) //nolint:gosec // test-local temp dir
+	if err != nil {
+		t.Fatalf("no payload was POSTed: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("payload is not valid JSON: %v (%s)", err, raw)
+	}
+	for field, want := range map[string]string{
+		"event":     "PreInvocation",
+		"state":     "working",
+		"prompt":    "fix the login bug",
+		"tool_name": "Bash",
+	} {
+		if got[field] != want {
+			t.Errorf("payload %s = %v, want %q", field, got[field], want)
+		}
+	}
+}
+
+// Without jq the reporter must still POST the bare event so the agent's state
+// stays correct, and must still honor agy's stdout contract. Losing the detail
+// is acceptable; a stalled turn is not.
+func TestAgyHookCommandFallsBackWithoutJQ(t *testing.T) {
+	pathEnv, payloadFile := agyCurlRecorder(t)
+	// Shadow jq with a shim that always fails, in front of the recorder's PATH.
+	jqDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(jqDir, "jq"), []byte("#!/usr/bin/env bash\nexit 1\n"), 0700); err != nil { //nolint:gosec // shim must be executable
+		t.Fatalf("write jq shim: %v", err)
+	}
+
+	cmd := exec.CommandContext(t.Context(), "bash", "-c", //nolint:gosec // running the generated command is the point of the test
+		agyHookCommand("Stop", "idle", "Turn complete", "{}"))
+	cmd.Env = append(os.Environ(),
+		"PATH="+jqDir+string(os.PathListSeparator)+pathEnv,
+		"MYCEL_AGENT_ID=agent-x",
+	)
+	cmd.Stdin = strings.NewReader(`{"prompt":"ignored"}`)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("run hook command: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "{}" {
+		t.Errorf("stdout = %q, want %q", out, "{}")
+	}
+
+	raw, err := os.ReadFile(payloadFile) //nolint:gosec // test-local temp dir
+	if err != nil {
+		t.Fatalf("no payload was POSTed without jq: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("fallback payload is not valid JSON: %v (%s)", err, raw)
+	}
+	if got["event"] != "Stop" || got["state"] != "idle" {
+		t.Errorf("fallback payload = %s, want the bare Stop/idle event", raw)
+	}
+}
+
+// Every generated agy command must be a runnable shell program. A quoting slip
+// would make each hook a silent no-op with nothing in the UI to explain it.
+func TestAgyHookCommandsAreValidBash(t *testing.T) {
+	for _, tc := range []struct{ event, state, task, stdout string }{
+		{"PreInvocation", "working", "Thinking...", "{}"},
+		{"PostInvocation", "", "Response received", "{}"},
+		{"Stop", "idle", "Turn complete", "{}"},
+		{"PreToolUse", "", "Running tool", `{"decision":"allow"}`},
+		{"PostToolUse", "", "Tool completed", "{}"},
+	} {
+		t.Run(tc.event, func(t *testing.T) {
+			cmd := exec.CommandContext(t.Context(), "bash", "-n", "-c", //nolint:gosec // syntax-checking the generated command is the point of the test
+				agyHookCommand(tc.event, tc.state, tc.task, tc.stdout))
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Errorf("bash -n rejected the %s command: %v\n%s", tc.event, err, out)
+			}
+		})
 	}
 }

--- a/server/mcp/server_test.go
+++ b/server/mcp/server_test.go
@@ -137,7 +137,7 @@ func TestE2E_ListTools(t *testing.T) {
 	want := map[string]bool{
 		"whoami": false, "list_agents": false, "list_channels": false,
 		"read_channel": false, "send_message": false, "send_file": false,
-		"report_status": false, "query_costs": false,
+		"query_costs": false,
 		"spawn_agent": false, "send_to_agent": false, "stop_agent": false,
 		"list_children": false,
 	}
@@ -275,7 +275,6 @@ func TestE2E_ToolErrorsWhenDependencyMissing(t *testing.T) {
 		{Name: "read_channel", Arguments: map[string]any{"channel": "slack:eng"}},
 		{Name: "send_message", Arguments: map[string]any{"channel": "slack:eng", "message": "x"}},
 		{Name: "list_agents"},
-		{Name: "report_status", Arguments: map[string]any{"task": "testing"}},
 		{Name: "query_costs"},
 		{Name: "spawn_agent", Arguments: map[string]any{"role": "engineer"}},
 		{Name: "send_to_agent", Arguments: map[string]any{"agent": "someone", "message": "hi"}},

--- a/server/mcp/tools.go
+++ b/server/mcp/tools.go
@@ -24,7 +24,7 @@ const (
 	maxCommentLen = 64 * 1024 // file upload comments
 	maxChannelLen = 256       // gateway channel identifier
 	maxRoleLen    = 256       // role filter on list_agents
-	maxTaskLen    = 1024      // report_status task line
+	maxTaskLen    = 1024      // initial task line on spawn_agent
 	maxPathLen    = 4 * 1024  // file_path on send_file (typical PATH_MAX)
 	// maxTemplateLen bounds a template name on spawn_agent. Names are short
 	// identifiers, so this only exists to reject junk before it reaches the store.
@@ -85,13 +85,6 @@ func addTools(s *sdk.Server, cfg Config, agentName string) {
 		Description: "Upload a file to a gateway channel (e.g., share a screenshot to Slack)",
 	}, func(ctx context.Context, _ *sdk.CallToolRequest, in sendFileIn) (*sdk.CallToolResult, sendFileOut, error) {
 		return sendFile(ctx, cfg, agentName, in)
-	})
-
-	sdk.AddTool(s, &sdk.Tool{
-		Name:        "report_status",
-		Description: "Update this agent's current task line shown in the TUI and web UI",
-	}, func(ctx context.Context, _ *sdk.CallToolRequest, in reportStatusIn) (*sdk.CallToolResult, reportStatusOut, error) {
-		return reportStatus(ctx, cfg, agentName, in)
 	})
 
 	sdk.AddTool(s, &sdk.Tool{
@@ -509,31 +502,6 @@ func detectMIME(filename string, data []byte) string {
 		mimeType = "application/pdf"
 	}
 	return mimeType
-}
-
-// ─── report_status ──────────────────────────────────────────────────────────
-
-type reportStatusIn struct {
-	Task string `json:"task" jsonschema:"one-line description of what the agent is working on"`
-}
-
-type reportStatusOut struct {
-	Agent string `json:"agent"`
-	Task  string `json:"task"`
-}
-
-func reportStatus(ctx context.Context, cfg Config, agentName string, in reportStatusIn) (*sdk.CallToolResult, reportStatusOut, error) {
-	out := reportStatusOut{Agent: agentName, Task: in.Task}
-	if len(in.Task) > maxTaskLen {
-		return nil, out, fmt.Errorf("task too long: %d bytes (max %d)", len(in.Task), maxTaskLen)
-	}
-	if cfg.Agents == nil {
-		return nil, out, fmt.Errorf("agent manager not available")
-	}
-	if err := cfg.Agents.SetAgentTask(ctx, agentName, in.Task); err != nil {
-		return nil, out, fmt.Errorf("update failed: %w", err)
-	}
-	return nil, out, nil
 }
 
 // ─── query_costs ────────────────────────────────────────────────────────────

--- a/server/transcript_tailer.go
+++ b/server/transcript_tailer.go
@@ -37,9 +37,6 @@ const (
 	// transcriptMaxReadPerTick caps the bytes read from one file per tick so a
 	// large backfill can't stall the loop; the remainder is picked up next tick.
 	transcriptMaxReadPerTick = 512 * 1024
-	// transcriptPromptTaskMax bounds the prompt text mirrored into the agent's
-	// task field on a user turn.
-	transcriptPromptTaskMax = 120
 )
 
 // tailCursor tracks how far the tailer has consumed one transcript file.
@@ -314,9 +311,12 @@ func ingestTranscriptActivity(ctx context.Context, agents *agentpkg.AgentService
 	if act.ToolResponse != nil {
 		m["tool_response"] = act.ToolResponse
 	}
+	// Only the prompt is forwarded. Deriving the task line from it is
+	// IngestHookEvent's job, so transcript-mode and hooks-mode providers get an
+	// identical task line from identical input — and setting "task" here would
+	// have had no effect anyway, since ingest reads the prompt.
 	if act.Prompt != "" {
 		m["prompt"] = act.Prompt
-		m["task"] = truncateRunes(act.Prompt, transcriptPromptTaskMax)
 	}
 	if act.Error != "" {
 		m["error"] = act.Error
@@ -336,17 +336,4 @@ func ingestTranscriptActivity(ctx context.Context, agents *agentpkg.AgentService
 		// (e.g. the agent stopped between listing and ingest); log at debug.
 		log.Debug("transcript tailer: ingest failed", "agent", name, "event", act.Event, "error", err)
 	}
-}
-
-// truncateRunes truncates s to at most max runes, appending an ellipsis when
-// it was shortened.
-func truncateRunes(s string, max int) string {
-	r := []rune(s)
-	if len(r) <= max {
-		return s
-	}
-	if max <= 1 {
-		return string(r[:max])
-	}
-	return string(r[:max-1]) + "…"
 }


### PR DESCRIPTION
## Summary

An agent's task line could only be set by the agent itself, through the `report_status` MCP tool, so it was only ever as accurate as an agent's diligence. On the live fleet:

```
lone-osprey     base         idle       89h 12m              -
lucid-meerkat   base         stopped    -                    Session ended
zen-zebra       base         working    29h 52m              -
```

Two agents running for days reported no task at all, while the daemon had already ingested every prompt they were given.

The task is now derived from the prompt at the start of a turn — `UserPromptSubmit` for claude and cursor, `PreInvocation` for agy — truncated to 120 characters. `report_status` is removed along with the docs telling agents to call it. `spawn_agent` still writes a task directly, since a parent hands its child work before the child has run a turn.

## Two providers now report what they always should have

- **pi, codex.** The transcript tailer was already computing a task from the parsed user turn, but `UserPromptSubmit` maps to `working`, so `IngestHookEvent` took the state branch and dropped it. Dead code that made these providers pay for a task line they never received. The tailer now forwards just the prompt and ingestion derives from it, so transcript-mode and hooks-mode providers get an identical task line from identical input.
- **agy.** Its hook command was `cat >/dev/null` followed by a POST of only the three fields known at generation time — the prompt, tool name, tool input and tool output agy reports were all discarded. That gave agy agents a Live feed of bare event names, and would have left them with no task line at all once self-reporting was removed. They now forward the payload the way claude and cursor do.

Lifecycle labels ("Turn complete", "Session ended") and tool events still never become the task line — that regression was #3259 and there is a test pinning it.

## Note for reviewers

Requires no coordination with #3486, but the two are complementary: this derives the task from a prompt, and #3486 is what makes cursor forward one.

`agy`'s payload forwarding is verified by running the generated command for real against a curl shim — including the no-`jq` fallback and `bash -n` on every generated command — but not against a live `agy` binary, which isn't installed here. It is a strict improvement regardless: previously nothing was forwarded at all.

## Test plan

- [x] `make test` — Go + 429 web tests pass
- [x] `go vet ./...`, `make lint` — clean
- [x] Task derived from a real claude-shaped body carrying both `prompt` and the canned `task` label; the prompt wins
- [x] `prompt` survives JSON decoding into `HookPayload` (the failure mode that silently dropped `tool_response`)
- [x] Tool events, lifecycle labels and empty prompts all leave the task untouched
- [x] agy's generated hooks execute, forward stdin, fall back without `jq`, and honor agy's stdout contract

Closes #3489

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * Removed the `report_status` MCP tool from the available toolset and documentation.

* **Improvements**
  * Agent tasks are now derived automatically from turn-start prompts across supported providers.
  * Task labels are consistently truncated to 120 characters and cleared when agents stop or restart.
  * Tool and lifecycle events no longer overwrite prompt-derived tasks.
  * Improved hook payload handling and fallback behavior for provider integrations.

* **Documentation**
  * Updated agent, architecture, MCP, and REST API documentation to reflect prompt-based task tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->