### PR TITLE
chore(release): keep the changelog for upgrade actions, generate the rest

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,19 +105,31 @@ changelog:
       - '^ci:'
       - Merge pull request
       - Merge branch
+  # A commit joins the first group whose regexp matches, in the order listed
+  # here, while `order` decides where the group is displayed. Breaking and
+  # Security are therefore listed first as well as ordered first: without that,
+  # "fix(security): …" would be claimed by Bug Fixes and buried among the ~30
+  # fixes a release typically carries, which is the one thing a reader must not
+  # have to hunt for.
   groups:
+    - title: Breaking Changes
+      regexp: '^[a-z]+(\(.+\))?!:'
+      order: 0
+    - title: Security
+      regexp: '^(sec|security)(\(.+\))?!?:|^[a-z]+\((sec|security)\)!?:'
+      order: 1
     - title: Features
       regexp: '^feat.*'
-      order: 0
+      order: 2
     - title: Bug Fixes
       regexp: '^fix.*'
-      order: 1
+      order: 3
     - title: Refactoring
       regexp: '^refactor.*'
-      order: 2
+      order: 4
     - title: Performance
       regexp: '^perf.*'
-      order: 3
+      order: 5
     - title: Others
       order: 999
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+This file records only what a reader has to act on or would be surprised by:
+security fixes, breaking changes, and behavior changes that carry an upgrade
+action. The full per-change list is generated from commit history at release
+time and published in the [GitHub release notes](https://github.com/rpuneet/mycel/releases)
+— ordinary fixes and features belong there, not here. See
+[CONTRIBUTING.md](CONTRIBUTING.md#changelog-entries).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -17,45 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   origin, or from a non-browser client such as the CLI. Reads are unchanged
   (#3470).
 
-### Fixed
+### Changed
 
-- **A blank MCP command no longer takes the daemon down.** The tool health
-  check indexed the first field of a stored command without checking there was
-  one, so a whitespace-only entry panicked — on a background goroutine, where
-  no HTTP recovery middleware can help, and again on every 30-second tick
-  because the offending row was still there. The check now reports the tool as
-  misconfigured, and the health pass recovers rather than propagating (#3471).
-- **Agent-spawned children are no longer exempt from guardrails.** `spawn_agent`
-  over MCP had no `template` field, and the guardrail loop skips any agent
-  without one, so every child an agent spawned ran with no cost cap and no stuck
-  detection — the unattended case the guardrails exist for. It now accepts a
-  template and, when none is given, inherits the caller's, so omitting the field
-  cannot silently mean "unguarded" (#3472).
-- **Optional services are manageable again.** The dependency manager UI existed
-  but nothing imported it, so the whole `/api/deps` lifecycle — list, start,
-  stop, stream logs — had no entry point, and the Code tab's "Edit in VS Code"
-  button could never appear, because it only renders while
-  `mycel-code-server` is running. It now sits under Settings → Providers &
-  Tools → Optional Services. The code-server URL also derives its host from the
-  page instead of hardcoding `localhost`, which broke whenever the UI was opened
-  from another machine (#3473).
-- **The CLI no longer contacts WhatsApp on every command.** The WhatsApp adapter
-  negotiated its protocol version in package `init`, and the package is linked
-  into the CLI, so every invocation — `mycel --version` and `mycel --help`
-  included — made an HTTP request to WhatsApp's servers and printed a WhatsApp log
-  line before doing what was asked. The lookup now happens when the adapter
-  actually connects, once per process (#3455).
-- **Tool details report real paths and owners.** An expanded CLI tool row
-  showed "Path: git" — the configured command name under a Path label — and a
-  "Version cmd" box that was just the tool name plus `--version`, both styled
-  like inputs waiting to be filled in. The API now separates `path` (resolved,
-  absolute) from `command` (configured) and infers which package manager owns
-  each tool, following the symlink so a Homebrew binary is attributable. With
-  the owner known, the row names the update command that manager would use
-  instead of saying "copy the command above" with no command above it, and it
-  no longer offers to uninstall OS-provided binaries the backend refuses to
-  touch. The Setup card now appears only while setup is unfinished, rather
-  than permanently restating that the re-run icon exists (#3482).
+- **Optional services moved into the UI.** Starting and stopping
+  `mycel-code-server` and the other `/api/deps` services now lives under
+  Settings → Providers & Tools → Optional Services. The Code tab's "Edit in VS
+  Code" button only appears while code-server is running, so this is where you
+  turn it on (#3473).
 
 ## [0.4.4] - 2026-08-02
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,26 @@ See `CLAUDE.md` (or `.claude/CLAUDE.md`) for detailed architecture patterns and 
 
 5. **Review**: Address all review feedback. If your PR changes `internal/cmd/**`, `pkg/**` public API, or `server/**` without a matching update under `docs/**` or the relevant README, the docs-freshness CI check will leave an advisory comment — update the docs or explain why none are needed.
 
+### Changelog entries
+
+**Most PRs should not touch `CHANGELOG.md`.** Release notes are generated from
+commit history by GoReleaser, and because PRs are squash-merged, each PR already
+becomes one grouped line carrying its title and number. Restating every fix in
+the changelog produces a hand-written second copy of that list — and since every
+entry goes at the top of the same file, it is a reliable source of merge
+conflicts between PRs in flight.
+
+Add an entry only when a reader has to *do* something or would be surprised:
+
+- **Security fixes** — what was exposed and what now blocks it.
+- **Breaking changes** — mark the commit `type(scope)!:` as well.
+- **Behavior changes with an upgrade action** — a removed tool or flag, a renamed
+  path, a changed default, a keybinding that moved. State the action explicitly.
+
+Ordinary bug fixes, features, refactors and internal changes need no entry: your
+commit subject is the release note. Make the subject read as a statement to a
+user rather than a note to yourself.
+
 ## Architecture Overview
 
 Key concepts to understand before contributing:


### PR DESCRIPTION
## Summary

You're right that the changelog duplicates the commit log. GoReleaser already generates release notes from commit history, and because PRs are squash-merged, each PR becomes exactly one grouped line carrying its title and number — so hand-writing an entry per fix produced a second copy of a list we already publish. It also had a running cost: every entry goes at the top of the same file, so it conflicted between PRs in flight (two of the three open PRs were both touching it).

What commits genuinely can't express is what a reader has to *do*. So the file keeps that and drops the rest.

## Changes

**`CHANGELOG.md` now records only** security fixes, breaking changes, and behavior changes with an upgrade action. A note at the top says so and points at the generated notes.

**The `Unreleased` section shrinks from six entries to three.** Five plain bug fixes are dropped; one was rewritten as the navigation note it actually was ("Optional services moved into the UI" — worth keeping because it tells you where to find something).

Nothing is lost. All five dropped entries are commits in the current release range and will appear under **Bug Fixes** in the generated notes:

| Changelog cited | Commit that carries it |
|---|---|
| #3471 | `fix(tool): stop a blank MCP command from panicking the health loop (#3476)` |
| #3472 | `fix(mcp): stop agent-spawned children bypassing the guardrails (#3478)` |
| #3455 | `fix(whatsapp): stop contacting WhatsApp on every CLI command (#3481)` |
| #3482 | `fix(settings): report tools' real paths and owners (#3484)` |
| #3473 | `fix(web): wire up the orphaned dependency manager (#3480)` — kept, rewritten |

Worth noting the reverse case too: `#3469`, `#3464` and `#3457` are in the release range and were **never** in the changelog, which is the clearest sign the file was not the complete record it appeared to be.

**Release notes gain `Breaking Changes` and `Security` groups.** Both are listed ahead of the type-based groups as well as ordered first — GoReleaser assigns a commit to the first group whose regexp matches, so without that a `fix(security):` commit is claimed by `Bug Fixes` and buried among the ~30 fixes a release carries.

**`CONTRIBUTING.md`** gets a "Changelog entries" section stating the policy: most PRs should not touch the file, and your commit subject is the release note — so write it as a statement to a user.

## Test plan

- [x] `.goreleaser.yml` parses; all group regexes compile as Go regexes
- [x] Verified routing against real subject lines: `security:` and `fix(security):` → Security, `feat(agents)!:` → Breaking Changes (beating `feat`), `feat`/`fix`/`refactor`/`perf` → their groups, `chore:` → Others
- [x] Confirmed every dropped entry maps to an in-range commit that the generated notes will include
- [ ] Notes render as expected on the next tag (only observable at release time)

Made with [Cursor](https://cursor.com)


Closes #3492
