### PR TITLE
fix(build): derive every version from git tags so there is only one format

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,10 +248,12 @@ jobs:
           LDFLAGS="-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           LDFLAGS="${LDFLAGS} -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID=${GOOGLE_OAUTH_CLIENT_ID}"
           LDFLAGS="${LDFLAGS} -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret=${GOOGLE_OAUTH_CLIENT_SECRET}"
-          # CFBundleShortVersionString must be a plain X.Y.Z, so a prerelease tag
+          # CFBundleShortVersionString must be a plain X.Y.Z, so a pre-release tag
           # (v0.5.0-rc1) contributes only its numeric core to bundle metadata.
           # The full version still reaches the app via -X main.version above.
-          VERSION_CORE=$(printf '%s' "${VERSION}" | cut -d- -f1)
+          # Reduced by the same script the Makefile uses, so a local desktop build
+          # and a released one cannot disagree about an edge case.
+          VERSION_CORE=$(sh ../scripts/version.sh --core "${VERSION}")
           sed -i.bak "s/\"productVersion\": \"[^\"]*\"/\"productVersion\": \"${VERSION_CORE}\"/" wails.json && rm -f wails.json.bak
           case "${{ matrix.os }}" in
             linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,12 +51,21 @@ jobs:
         run: |
           echo "tag=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "version=${RELEASE_VERSION#v}" >> "$GITHUB_OUTPUT"
+          # Validated on both triggers: a tag pushed by hand is just as capable
+          # of being malformed as one typed into the dispatch form, and a bad tag
+          # propagates into artifact names, the npm version and the Homebrew
+          # formula before anyone notices.
+          if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Invalid version format: $RELEASE_VERSION (expected vX.Y.Z)"
+            exit 1
+          fi
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [[ ! "$RELEASE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-              echo "Invalid version format: $RELEASE_VERSION (expected vX.Y.Z)"
-              exit 1
-            fi
-            git tag "$RELEASE_VERSION"
+            # Annotated, matching the documented manual procedure. `git describe`
+            # prefers annotated tags, so a lightweight release tag makes source
+            # builds describe themselves against an older release than they
+            # actually contain.
+            git -c user.name=github-actions -c user.email=github-actions@github.com \
+              tag -a "$RELEASE_VERSION" -m "$RELEASE_VERSION"
             git push origin "$RELEASE_VERSION"
           fi
 
@@ -239,7 +248,11 @@ jobs:
           LDFLAGS="-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           LDFLAGS="${LDFLAGS} -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientID=${GOOGLE_OAUTH_CLIENT_ID}"
           LDFLAGS="${LDFLAGS} -X github.com/rpuneet/mycel/pkg/gateway/gmail.defaultGoogleClientSecret=${GOOGLE_OAUTH_CLIENT_SECRET}"
-          sed -i.bak "s/\"productVersion\": \"[^\"]*\"/\"productVersion\": \"${VERSION}\"/" wails.json && rm -f wails.json.bak
+          # CFBundleShortVersionString must be a plain X.Y.Z, so a prerelease tag
+          # (v0.5.0-rc1) contributes only its numeric core to bundle metadata.
+          # The full version still reaches the app via -X main.version above.
+          VERSION_CORE=$(printf '%s' "${VERSION}" | cut -d- -f1)
+          sed -i.bak "s/\"productVersion\": \"[^\"]*\"/\"productVersion\": \"${VERSION_CORE}\"/" wails.json && rm -f wails.json.bak
           case "${{ matrix.os }}" in
             linux)
               # webkit2gtk 4.1 on the ubuntu runners; wails v2 defaults to 4.0 pkg-config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -371,8 +371,8 @@ report the same shape and anything that compares versions — the About page's
 | With uncommitted changes | `0.4.5-dev.12.g1a2b3c4.dirty` |
 | No tags reachable (CI clones at depth 1) | `dev` |
 
-Off a tag the *patch is incremented* and the distance recorded as a prerelease.
-Semver ranks a prerelease below the release it names, so a literal `git describe`
+Off a tag the *patch is incremented* and the distance recorded as a pre-release.
+Semver ranks a pre-release below the release it names, so a literal `git describe`
 string like `0.4.4-12-g1a2b3c4` would sort *below* 0.4.4 and make a build twelve
 commits newer look older. This matches how GoReleaser names snapshots.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,6 +303,9 @@ automated.
    ```
 
    Use semver: `vMAJOR.MINOR.PATCH`. Alpha/RC allowed: `v0.5.0-alpha`, `v1.0.0-rc.1`.
+   Always annotate (`-a`): `git describe` prefers annotated tags, so a lightweight
+   release tag makes every later source build describe itself against an older
+   release than it actually contains.
 
 Pushing the tag is what triggers the release. **Actions → Release → Run workflow**
 also works and tags for you, but push the tag by hand when you want the released
@@ -353,6 +356,37 @@ Every merge to `main` also publishes `ghcr.io/rpuneet/mycel:main` via `.github/w
 - `v0.x.y` — pre-1.0, any breaking changes allowed, document in release notes
 - `v1.0.0+` — semver discipline: breaking → major, features → minor, fixes → patch
 - Pre-releases: `-alpha`, `-beta`, `-rc.N` suffixes
+
+#### One format, derived from tags
+
+Git tags are the only place a version is written down. Every build derives its
+version from them via `scripts/version.sh`, so a source build and a release build
+report the same shape and anything that compares versions — the About page's
+"update available" check, npm, the Homebrew formula — can compare them directly:
+
+| Build | Version |
+| --- | --- |
+| Clean checkout of a tag | `0.4.4` |
+| 12 commits past a tag | `0.4.5-dev.12.g1a2b3c4` |
+| With uncommitted changes | `0.4.5-dev.12.g1a2b3c4.dirty` |
+| No tags reachable (CI clones at depth 1) | `dev` |
+
+Off a tag the *patch is incremented* and the distance recorded as a prerelease.
+Semver ranks a prerelease below the release it names, so a literal `git describe`
+string like `0.4.4-12-g1a2b3c4` would sort *below* 0.4.4 and make a build twelve
+commits newer look older. This matches how GoReleaser names snapshots.
+
+Consequences worth knowing:
+
+- Only an exact `X.Y.Z` counts as a release. The About page decides between
+  "update available" and the "dev build" chip on that alone.
+- macOS bundle metadata (`CFBundleShortVersionString`) must be plain `X.Y.Z`, so
+  it gets the numeric core only. `desktop/wails.json` holds `0.0.0` as a
+  placeholder; both the Makefile and the release workflow substitute the real
+  value at build time. A version of `0.0.0` on an installed app means it was
+  built by calling `wails build` directly instead of `make build-local-desktop`.
+- Never hardcode a version in a tracked file. `internal/cmd/version_script_test.go`
+  pins the shapes above.
 
 ### Rollback
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,11 @@
 # Variables
 # =============================================================================
 
-VERSION ?= $(shell date -u +%Y.%m.%d).$(shell git rev-parse --short HEAD 2>/dev/null || echo "dev")
+# Semver derived from git tags — see scripts/version.sh for the exact shapes.
+# Source builds and release builds deliberately produce the same format so that
+# `mycel version`, /api/health and the About page's update check never have to
+# know which kind of build they are looking at.
+VERSION ?= $(shell sh scripts/version.sh)
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_DIR ?= bin
@@ -60,6 +64,12 @@ IMAGE_TAG ?= latest
 AGENT_PROVIDERS := claude agy codex cursor openclaw pi
 
 LDFLAGS_VERSION = -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+
+# CFBundleShortVersionString has to be a plain X.Y.Z, so the macOS bundle gets
+# the numeric core while the precise build string still reaches the app through
+# -X main.version. Anything unparseable (VERSION=dev) becomes 0.0.0, which reads
+# as "unstamped" rather than as a plausible-looking release number.
+VERSION_CORE = $(shell printf '%s' '$(VERSION)' | awk -F- '{print $$1}' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' || echo 0.0.0)
 
 # Official mycel builds embed the registered Google "Desktop app" OAuth
 # client so Gmail "Sign in with Google" works zero-setup. GOOGLE_OAUTH_CLIENT_ID
@@ -122,8 +132,16 @@ build-local-mycel: build-local-web ## Build mycel (embeds web UI, server)
 	$(GO) build -ldflags="$(LDFLAGS_VERSION) $(LDFLAGS_GMAIL)" -o $(BUILD_DIR)/mycel ./cmd/mycel
 
 
+# wails reads the bundle version from wails.json rather than a flag, so the
+# committed placeholder is swapped for the real one and restored afterwards —
+# without this a locally built .app advertises the placeholder in Finder and
+# About This Mac while the binary inside reports the true version. The release
+# workflow does the same substitution.
 build-local-desktop: build-local-web ## Build desktop app for the host OS (requires wails CLI)
-	cd desktop && wails build -ldflags "$(LDFLAGS_VERSION) $(LDFLAGS_GMAIL)"
+	cd desktop && cp wails.json wails.json.orig && \
+		trap 'mv -f wails.json.orig wails.json' EXIT INT TERM && \
+		sed -i.bak 's/"productVersion": "[^"]*"/"productVersion": "$(VERSION_CORE)"/' wails.json && rm -f wails.json.bak && \
+		wails build -ldflags "$(LDFLAGS_VERSION) $(LDFLAGS_GMAIL)"
 
 
 # =============================================================================

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,9 @@ LDFLAGS_VERSION = -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.da
 
 # CFBundleShortVersionString has to be a plain X.Y.Z, so the macOS bundle gets
 # the numeric core while the precise build string still reaches the app through
-# -X main.version. Anything unparseable (VERSION=dev) becomes 0.0.0, which reads
-# as "unstamped" rather than as a plausible-looking release number.
-VERSION_CORE = $(shell printf '%s' '$(VERSION)' | awk -F- '{print $$1}' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$$' || echo 0.0.0)
+# -X main.version. The release workflow reduces its tag the same way, through the
+# same script, so the two cannot disagree about an edge case.
+VERSION_CORE = $(shell sh scripts/version.sh --core '$(VERSION)')
 
 # Official mycel builds embed the registered Google "Desktop app" OAuth
 # client so Gmail "Sign in with Google" works zero-setup. GOOGLE_OAUTH_CLIENT_ID

--- a/desktop/wails.json
+++ b/desktop/wails.json
@@ -12,7 +12,7 @@
   },
   "info": {
     "productName": "mycel",
-    "productVersion": "0.1.0",
+    "productVersion": "0.0.0",
     "copyright": "Copyright © 2026 mycel",
     "comments": "mycel desktop — runs the mycel server and shows the web UI"
   }

--- a/internal/cmd/version_script_test.go
+++ b/internal/cmd/version_script_test.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// scripts/version.sh produces the string this package prints as `mycel version`
+// and the daemon reports on /api/health, and the About page decides whether an
+// update is available by comparing it against the latest release tag. These
+// tests pin the shapes that contract depends on.
+
+const versionScript = "../../scripts/version.sh"
+
+// gitRepo is a throwaway repository the version script can be run against.
+type gitRepo struct {
+	t   *testing.T
+	dir string
+}
+
+func newGitRepo(t *testing.T) *gitRepo {
+	t.Helper()
+	r := &gitRepo{t: t, dir: t.TempDir()}
+	r.git("init", "-q")
+	r.git("config", "user.email", "test@example.com")
+	r.git("config", "user.name", "test")
+	r.git("config", "commit.gpgsign", "false")
+	r.git("config", "tag.gpgsign", "false")
+	r.commit("initial")
+	return r
+}
+
+func (r *gitRepo) git(args ...string) string {
+	r.t.Helper()
+	cmd := exec.CommandContext(r.t.Context(), "git", args...)
+	cmd.Dir = r.dir
+	// A developer's commit.gpgsign / init.defaultBranch settings must not decide
+	// whether this test passes.
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		r.t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// commit writes a tracked file and commits it, leaving the tree clean.
+func (r *gitRepo) commit(name string) {
+	r.t.Helper()
+	if err := os.WriteFile(filepath.Join(r.dir, name), []byte(name), 0o600); err != nil {
+		r.t.Fatalf("write %s: %v", name, err)
+	}
+	r.git("add", name)
+	r.git("commit", "-qm", name)
+}
+
+// write drops a file in the worktree without committing it.
+func (r *gitRepo) write(name, content string) {
+	r.t.Helper()
+	if err := os.WriteFile(filepath.Join(r.dir, name), []byte(content), 0o600); err != nil {
+		r.t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func (r *gitRepo) shortSHA() string {
+	r.t.Helper()
+	return r.git("rev-parse", "--short=7", "HEAD")
+}
+
+// version runs the script inside the repo and returns what it printed.
+func (r *gitRepo) version() string {
+	r.t.Helper()
+	abs, err := filepath.Abs(versionScript)
+	if err != nil {
+		r.t.Fatalf("resolve script: %v", err)
+	}
+	cmd := exec.CommandContext(r.t.Context(), "sh", abs) //nolint:gosec // abs resolves the constant versionScript path
+	cmd.Dir = r.dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		r.t.Fatalf("version.sh: %v\n%s", err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestVersionOnTagIsTheBareRelease: a clean checkout of a release tag must
+// report exactly what the release artifacts report, with no decoration. This is
+// the equality the About page's "update available" check relies on — any extra
+// suffix here would tell every user of that release that they are out of date.
+func TestVersionOnTagIsTheBareRelease(t *testing.T) {
+	r := newGitRepo(t)
+	r.git("tag", "-a", "v0.4.4", "-m", "v0.4.4")
+
+	if got := r.version(); got != "0.4.4" {
+		t.Errorf("on tag v0.4.4 got %q, want %q", got, "0.4.4")
+	}
+}
+
+// TestVersionAcceptsLightweightTags: most of this repo's early tags are
+// lightweight rather than annotated, so releases cut from them must still
+// resolve to their own version instead of describing against an older tag.
+func TestVersionAcceptsLightweightTags(t *testing.T) {
+	r := newGitRepo(t)
+	r.git("tag", "v0.4.4")
+
+	if got := r.version(); got != "0.4.4" {
+		t.Errorf("on lightweight tag v0.4.4 got %q, want %q", got, "0.4.4")
+	}
+}
+
+// TestVersionAfterTagIncrementsPatch: the distance from the tag goes into a
+// prerelease on the *next* patch, not on the tag itself. Semver ranks a
+// prerelease below the release it names, so "0.4.4-dev.2..." would sort below
+// 0.4.4 and make a build two commits newer look older than the release it
+// contains; "0.4.5-dev.2..." sorts above 0.4.4 and below 0.4.5, where it belongs.
+func TestVersionAfterTagIncrementsPatch(t *testing.T) {
+	r := newGitRepo(t)
+	r.git("tag", "-a", "v0.4.4", "-m", "v0.4.4")
+	r.commit("second")
+	r.commit("third")
+
+	want := "0.4.5-dev.2.g" + r.shortSHA()
+	if got := r.version(); got != want {
+		t.Errorf("two commits past v0.4.4 got %q, want %q", got, want)
+	}
+}
+
+// TestVersionIgnoresUntrackedFiles: untracked files are not a different build of
+// the tree. Editor scratch files or a stray log must not flip a release build's
+// version and make it look modified.
+func TestVersionIgnoresUntrackedFiles(t *testing.T) {
+	r := newGitRepo(t)
+	r.git("tag", "-a", "v0.4.4", "-m", "v0.4.4")
+	r.write("scratch.log", "noise")
+
+	if got := r.version(); got != "0.4.4" {
+		t.Errorf("with an untracked file got %q, want %q", got, "0.4.4")
+	}
+}
+
+// TestVersionMarksModifiedTreeDirty: a build with uncommitted changes is not the
+// release it sits on, and saying so is the whole point — "which build am I
+// running" has to be answerable from the version string alone.
+func TestVersionMarksModifiedTreeDirty(t *testing.T) {
+	r := newGitRepo(t)
+	r.git("tag", "-a", "v0.4.4", "-m", "v0.4.4")
+	r.write("initial", "modified")
+
+	want := "0.4.5-dev.0.g" + r.shortSHA() + ".dirty"
+	if got := r.version(); got != want {
+		t.Errorf("on a modified tag checkout got %q, want %q", got, want)
+	}
+}
+
+// TestVersionFromPrereleaseTag: describing against a tag that is itself a
+// prerelease (v0.1.0-alpha) must not stack prereleases into something
+// unparseable — the tag's numeric core is what gets incremented.
+func TestVersionFromPrereleaseTag(t *testing.T) {
+	r := newGitRepo(t)
+	r.git("tag", "-a", "v0.1.0-alpha", "-m", "alpha")
+	r.commit("second")
+
+	want := "0.1.1-dev.1.g" + r.shortSHA()
+	if got := r.version(); got != want {
+		t.Errorf("one commit past v0.1.0-alpha got %q, want %q", got, want)
+	}
+}
+
+// TestVersionWithoutTagsIsDev: CI checks out at depth 1 with no tags, so the
+// tagless path is the common case for test builds and must not fail the build or
+// emit something that reads as a real release.
+func TestVersionWithoutTagsIsDev(t *testing.T) {
+	r := newGitRepo(t)
+
+	if got := r.version(); got != "dev" {
+		t.Errorf("with no tags got %q, want %q", got, "dev")
+	}
+}
+
+// TestVersionOutsideGitIsDev: unpacked source tarballs have no git metadata.
+func TestVersionOutsideGitIsDev(t *testing.T) {
+	dir := t.TempDir()
+	abs, err := filepath.Abs(versionScript)
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+	cmd := exec.CommandContext(t.Context(), "sh", abs) //nolint:gosec // abs resolves the constant versionScript path
+	cmd.Dir = dir
+	// GIT_CEILING_DIRECTORIES stops git walking up into whatever repository the
+	// system temp directory might live under.
+	cmd.Env = append(os.Environ(), "GIT_CEILING_DIRECTORIES="+dir, "GIT_CONFIG_GLOBAL=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("version.sh: %v\n%s", err, out)
+	}
+	if got := strings.TrimSpace(string(out)); got != "dev" {
+		t.Errorf("outside a git repo got %q, want %q", got, "dev")
+	}
+}
+
+// TestVersionIsAlwaysValidSemver: every shape the script can emit except the
+// "dev" sentinel has to parse as semver, because the About page distinguishes a
+// release from a source build by testing for exactly X.Y.Z and the npm and
+// Homebrew publishers feed the version straight into tools that reject anything
+// else.
+func TestVersionIsAlwaysValidSemver(t *testing.T) {
+	// Same grammar as the About page's release test, extended with the optional
+	// prerelease a source build carries.
+	semverRe := regexp.MustCompile(`^\d+\.\d+\.\d+(-[0-9A-Za-z.]+)?$`)
+
+	tagged := newGitRepo(t)
+	tagged.git("tag", "-a", "v2.10.9", "-m", "v2.10.9")
+	onTag := tagged.version()
+	tagged.commit("next")
+	pastTag := tagged.version()
+
+	for _, v := range []string{onTag, pastTag} {
+		if !semverRe.MatchString(v) {
+			t.Errorf("version %q is not valid semver", v)
+		}
+	}
+	// Only the on-tag version may look like a release; the About page would
+	// otherwise offer an update to a build that is already ahead of one.
+	releaseRe := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	if !releaseRe.MatchString(onTag) {
+		t.Errorf("on-tag version %q should read as a release", onTag)
+	}
+	if releaseRe.MatchString(pastTag) {
+		t.Errorf("past-tag version %q must not read as a release", pastTag)
+	}
+}

--- a/internal/cmd/version_script_test.go
+++ b/internal/cmd/version_script_test.go
@@ -203,6 +203,42 @@ func TestVersionOutsideGitIsDev(t *testing.T) {
 	}
 }
 
+// TestVersionCoreReducesToXYZ: --core exists because CFBundleShortVersionString
+// rejects anything but X.Y.Z. The Makefile and the release workflow both call it
+// rather than each reducing the version themselves, so this is the one place the
+// edge cases are decided.
+func TestVersionCoreReducesToXYZ(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"0.4.4", "0.4.4"},
+		{"0.4.5-dev.12.g1a2b3c4", "0.4.5"},
+		{"0.4.5-dev.0.g1a2b3c4.dirty", "0.4.5"},
+		{"0.5.0-rc1", "0.5.0"},
+		// No numeric core to salvage: 0.0.0 reads as unstamped, where a
+		// plausible-looking number would have a developer chasing a release that
+		// does not exist.
+		{"dev", "0.0.0"},
+		{"", "0.0.0"},
+		{"garbage", "0.0.0"},
+	}
+
+	abs, err := filepath.Abs(versionScript)
+	if err != nil {
+		t.Fatalf("resolve script: %v", err)
+	}
+	for _, tt := range tests {
+		cmd := exec.CommandContext(t.Context(), "sh", abs, "--core", tt.in) //nolint:gosec // abs resolves the constant versionScript path
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("--core %q: %v\n%s", tt.in, err, out)
+		}
+		if got := strings.TrimSpace(string(out)); got != tt.want {
+			t.Errorf("--core %q = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
 // TestVersionIsAlwaysValidSemver: every shape the script can emit except the
 // "dev" sentinel has to parse as semver, because the About page distinguishes a
 // release from a source build by testing for exactly X.Y.Z and the npm and

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env sh
+# version.sh — print the build version for this checkout.
+#
+# There is one version format: semver, derived from git tags. A release build
+# and a source build of the same tree therefore report the same shape, and
+# anything that compares versions (the About page's "update available" check,
+# npm, the Homebrew tap) can compare them without special cases.
+#
+#   on a tag, clean      0.4.4
+#   after a tag          0.4.5-dev.12.g1a2b3c4
+#   uncommitted changes   ...-dev.12.g1a2b3c4.dirty
+#   no tags reachable    dev
+#
+# Off a tag the *patch is incremented* and the distance recorded as a
+# prerelease. That ordering is the point: semver ranks a prerelease below the
+# release it names, so a literal `git describe` string like "0.4.4-12-g1a2b3c4"
+# would sort *below* 0.4.4 and make a build that is twelve commits newer look
+# older. Incrementing first makes it sort above 0.4.4 and below 0.4.5, which is
+# where it actually belongs. This is the same convention goreleaser uses for
+# snapshots (`version_template: {{ incpatch .Version }}-next`).
+set -eu
+
+# Not a git checkout (release tarball, vendored source): nothing to derive from.
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+	echo dev
+	exit 0
+fi
+
+# Tracked modifications only, matching `git describe --dirty`. Untracked files
+# are not a different build of the tree, so they must not change the version.
+dirty=''
+if ! git diff --quiet HEAD 2>/dev/null; then
+	dirty='.dirty'
+fi
+
+# Exactly on a tag with nothing modified: this *is* that release.
+if [ -z "$dirty" ]; then
+	if tag=$(git describe --tags --exact-match HEAD 2>/dev/null); then
+		echo "${tag#v}"
+		exit 0
+	fi
+fi
+
+# --long forces the "<tag>-<distance>-g<sha>" form even when HEAD is the tag,
+# so a dirty tagged build still gets a distinguishable prerelease version.
+if ! desc=$(git describe --tags --long --abbrev=7 HEAD 2>/dev/null); then
+	# Shallow clone or a fork with no tags fetched — CI checks out at depth 1.
+	echo dev
+	exit 0
+fi
+
+sha=${desc##*-}          # g1a2b3c4
+rest=${desc%-*}          # v0.4.4-12
+distance=${rest##*-}     # 12
+base=${rest%-*}          # v0.4.4
+base=${base#v}
+core=${base%%-*}         # drop any prerelease on the tag itself (v0.1.0-alpha)
+
+# An unparseable tag still has to yield valid semver, or the consumers this
+# script exists to unify would need the special case back.
+next=$(printf '%s' "$core" | awk -F. 'NF==3 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $3 ~ /^[0-9]+$/ { printf "%d.%d.%d", $1, $2, $3 + 1 }')
+if [ -z "$next" ]; then
+	next=0.0.0
+fi
+
+echo "${next}-dev.${distance}.${sha}${dirty}"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env sh
 # version.sh — print the build version for this checkout.
 #
+# Usage:
+#   version.sh                  print the derived version
+#   version.sh --core [VERSION]  print just the X.Y.Z core of VERSION (default:
+#                                the derived version), for consumers that cannot
+#                                accept a prerelease suffix — macOS bundle
+#                                metadata being the one that forced this.
+#
 # There is one version format: semver, derived from git tags. A release build
 # and a source build of the same tree therefore report the same shape, and
 # anything that compares versions (the About page's "update available" check,
@@ -20,9 +27,36 @@
 # snapshots (`version_template: {{ incpatch .Version }}-next`).
 set -eu
 
+# core prints the leading X.Y.Z of a version, or 0.0.0 when there isn't one.
+# 0.0.0 reads as "unstamped" rather than as a plausible-looking release number.
+core() {
+	printf '%s' "$1" | awk -F- '{print $1}' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' || echo 0.0.0
+}
+
+want_core=''
+if [ "${1:-}" = "--core" ]; then
+	want_core=1
+	shift
+	# An explicit version to reduce (the release workflow passes the tag it is
+	# building, which is authoritative there and needs no derivation).
+	if [ $# -gt 0 ]; then
+		core "$1"
+		exit 0
+	fi
+fi
+
+# emit prints the final version, reduced to its core when --core was given.
+emit() {
+	if [ -n "$want_core" ]; then
+		core "$1"
+	else
+		printf '%s\n' "$1"
+	fi
+}
+
 # Not a git checkout (release tarball, vendored source): nothing to derive from.
 if ! git rev-parse --git-dir >/dev/null 2>&1; then
-	echo dev
+	emit dev
 	exit 0
 fi
 
@@ -36,7 +70,7 @@ fi
 # Exactly on a tag with nothing modified: this *is* that release.
 if [ -z "$dirty" ]; then
 	if tag=$(git describe --tags --exact-match HEAD 2>/dev/null); then
-		echo "${tag#v}"
+		emit "${tag#v}"
 		exit 0
 	fi
 fi
@@ -45,7 +79,7 @@ fi
 # so a dirty tagged build still gets a distinguishable prerelease version.
 if ! desc=$(git describe --tags --long --abbrev=7 HEAD 2>/dev/null); then
 	# Shallow clone or a fork with no tags fetched — CI checks out at depth 1.
-	echo dev
+	emit dev
 	exit 0
 fi
 
@@ -54,13 +88,13 @@ rest=${desc%-*}          # v0.4.4-12
 distance=${rest##*-}     # 12
 base=${rest%-*}          # v0.4.4
 base=${base#v}
-core=${base%%-*}         # drop any prerelease on the tag itself (v0.1.0-alpha)
+tag_core=${base%%-*}     # drop any prerelease on the tag itself (v0.1.0-alpha)
 
 # An unparseable tag still has to yield valid semver, or the consumers this
 # script exists to unify would need the special case back.
-next=$(printf '%s' "$core" | awk -F. 'NF==3 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $3 ~ /^[0-9]+$/ { printf "%d.%d.%d", $1, $2, $3 + 1 }')
+next=$(printf '%s' "$tag_core" | awk -F. 'NF==3 && $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ && $3 ~ /^[0-9]+$/ { printf "%d.%d.%d", $1, $2, $3 + 1 }')
 if [ -z "$next" ]; then
 	next=0.0.0
 fi
 
-echo "${next}-dev.${distance}.${sha}${dirty}"
+emit "${next}-dev.${distance}.${sha}${dirty}"

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -32,6 +32,21 @@ interface ChannelStatus {
 
 const GITHUB_REPO = "rpuneet/mycel";
 
+/**
+ * isReleaseVersion — whether a version string names a published release, which
+ * is the only case where being "behind" the latest tag is meaningful.
+ *
+ * A release build's version is exactly X.Y.Z. Everything else is a source build:
+ * `dev` when no tag was reachable, otherwise the `0.4.5-dev.12.g1a2b3c4` form
+ * from scripts/version.sh. Testing for the absence of a prerelease suffix rather
+ * than for a particular dev-build spelling is deliberate — the previous check
+ * tested for a date-prefixed format and would have started calling source builds
+ * releases the moment that spelling changed (#3212).
+ */
+export function isReleaseVersion(v: string): boolean {
+  return /^\d+\.\d+\.\d+$/.test(v);
+}
+
 /** withTimeout — caps any one channel-check fetch at `ms` so a hung
  *  request (DNS timeout, GitHub API rate-limit holding the socket open,
  *  slow mirror) can't pin the page in the loading state. Resolves the
@@ -201,19 +216,12 @@ export function About() {
           <span className="text-2xl font-semibold text-mycel-text font-mono tabular-nums">
             {health?.version ?? "—"}
           </span>
-          {/* Compare like-with-like. `latestTag` is a semver ("0.3.1"). The
-              daemon's version is either the same shape (release binaries) or
-              a `YYYY.MM.DD.<sha>` dev-build string. Only surface "update
-              available" when both look like semver — for dev builds render a
-              "dev build" chip instead. Fixes #3212. */}
+          {/* Compare like-with-like. `latestTag` is a released version
+              ("0.3.1"), so only a build that claims to *be* a release can
+              meaningfully be behind one. Fixes #3212. */}
           {(() => {
             if (!latestTag || !health?.version) return null;
-            // Semver = up to 3-digit major.minor.patch, optionally followed
-            // by a pre-release or metadata suffix. Rejects the date-hash
-            // dev-build format `YYYY.MM.DD.<sha>` since it starts with a
-            // 4-digit year.
-            const looksLikeSemver = /^\d{1,3}\.\d{1,3}\.\d{1,3}(?:[-+][A-Za-z0-9.]+)?$/.test(health.version);
-            if (!looksLikeSemver) {
+            if (!isReleaseVersion(health.version)) {
               return (
                 <span className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-info-subtle text-mycel-info ring-1 ring-inset ring-mycel-border">
                   dev build

--- a/web/src/views/__tests__/aboutVersion.test.ts
+++ b/web/src/views/__tests__/aboutVersion.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { isReleaseVersion } from "../About";
+
+/**
+ * The About page shows "update available" only when the running build is a
+ * release older than the latest tag. Getting this wrong is user-visible in both
+ * directions: a false positive nags every developer running from source (#3212),
+ * and a false negative hides a real update from someone on an old release.
+ */
+describe("isReleaseVersion", () => {
+  it("accepts a plain release version", () => {
+    expect(isReleaseVersion("0.4.4")).toBe(true);
+    expect(isReleaseVersion("1.0.0")).toBe(true);
+    // Multi-digit components must not be mistaken for something else — 0.3.13
+    // is a real tag in this repo's history.
+    expect(isReleaseVersion("0.3.13")).toBe(true);
+    expect(isReleaseVersion("12.34.567")).toBe(true);
+  });
+
+  it("rejects the source-build version from scripts/version.sh", () => {
+    expect(isReleaseVersion("0.4.5-dev.12.g1a2b3c4")).toBe(false);
+    expect(isReleaseVersion("0.4.5-dev.0.g1a2b3c4.dirty")).toBe(false);
+  });
+
+  it("rejects the tagless sentinel and a bare commit hash", () => {
+    // /api/health substitutes the commit when the build has no version at all.
+    expect(isReleaseVersion("dev")).toBe(false);
+    expect(isReleaseVersion("12029d9f")).toBe(false);
+    expect(isReleaseVersion("")).toBe(false);
+  });
+
+  it("rejects the retired YYYY.MM.DD.<sha> format", () => {
+    // Source builds no longer produce this, but binaries built before the
+    // formats were unified are still installed on people's machines and must
+    // keep reading as dev builds rather than as a release from the year 2026.
+    expect(isReleaseVersion("2026.08.02.48266874")).toBe(false);
+  });
+
+  it("rejects a prerelease tag, which is not the latest release", () => {
+    expect(isReleaseVersion("0.5.0-rc1")).toBe(false);
+    expect(isReleaseVersion("0.1.0-alpha")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Source builds and release builds reported different version formats. `make build` stamped `YYYY.MM.DD.<sha>`; every release path stamped the semver tag. So the binary you build reports `2026.08.02.48266874` and the one you download reports `0.4.4` — you cannot tell which release a source build is near, and the two cannot be compared.

Now there is one format, derived from git tags:

| Build | Version |
| --- | --- |
| Clean checkout of a tag | `0.4.4` |
| 12 commits past a tag | `0.4.5-dev.12.g1a2b3c4` |
| Uncommitted changes | `0.4.5-dev.12.g1a2b3c4.dirty` |
| No tags reachable (CI clones at depth 1) | `dev` |

Off a tag the **patch is incremented** and the distance recorded as a prerelease. Semver ranks a prerelease below the release it names, so a literal `git describe` string like `0.4.4-12-g1a2b3c4` would sort *below* 0.4.4 and make a build twelve commits newer look older. `0.4.5-dev.12…` sorts above 0.4.4 and below 0.4.5, where it belongs — the same convention GoReleaser uses for snapshots.

## Why it mattered

The second format had already cost a bug. #3212 was the About page showing "update available" on every source build, because it compared the date string against the latest release tag. It was closed by teaching the page a regex that recognises and rejects `YYYY.MM.DD.<sha>` — a workaround that keys on the *specific* dev spelling, so the badge would have come back the moment that spelling changed. The check now tests for exactly `X.Y.Z`: a release is the only thing that can meaningfully be behind a release.

## Also fixed

- **Tag objects were inconsistent.** `CONTRIBUTING.md` documents `git tag -a`, but the Prepare job created a *lightweight* tag when the release was started from the Actions form — 14 of 32 existing tags are lightweight. `git describe` prefers annotated tags, so a lightweight release tag makes later source builds describe themselves against an older release than they actually contain. The workflow now annotates.
- **Tag format was only validated on `workflow_dispatch`.** A malformed tag pushed by hand flowed unchecked into artifact names, the npm version and the Homebrew formula. Validated on both triggers now.
- **`desktop/wails.json` hardcoded `productVersion: 0.1.0`.** Releases substitute the real value, but a locally built `.app` advertised `0.1.0` in Finder and About This Mac. `make build-local-desktop` now substitutes it the same way the release workflow does, and the committed placeholder drops to `0.0.0` so an unstamped build is obvious rather than plausible. `CFBundleShortVersionString` must be plain `X.Y.Z`, so the bundle gets the numeric core while the precise string still reaches the app via `-X main.version`.

## Test plan

- [x] `internal/cmd/version_script_test.go` — 9 tests building throwaway git repos: exact tag, lightweight tag, distance past a tag, untracked files ignored, dirty tree, prerelease tag as the base, no tags, no repo, and that every output is valid semver with only the on-tag one reading as a release
- [x] Mutation-checked: removing the patch increment fails `TestVersionAfterTagIncrementsPatch`
- [x] `web/src/views/__tests__/aboutVersion.test.ts` — the release/dev decision, including that the retired date format still reads as a dev build (binaries built before this change are still installed on people's machines)
- [x] `go build ./... && go vet ./...`, `go test ./internal/... ./pkg/... ./server/...` green
- [x] Web suite green (437 tests), `golangci-lint run ./internal/...` clean, eslint clean
- [x] Verified end to end: `make build-local-mycel` then `./bin/mycel version` → `mycel 0.4.5-dev.16.g12029d9.dirty`
- [x] Verified the desktop substitution injects and restores `wails.json` with no leftover files

Closes #3494

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cursor activity tracking through lifecycle hooks.
  * Provider activity capabilities are now reported through the provider API.
  * About now distinguishes release versions from development builds.

* **Changes**
  * Removed the standalone Timeline tab; Live is now the primary activity view.
  * Updated agent navigation and keyboard shortcuts, with legacy Timeline links redirected to Live.
  * Activity tracking availability now reflects each provider’s capabilities.

* **Documentation**
  * Documented provider activity modes and improved release/versioning guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->