### PR TITLE
fix(build): stop the web build from leaving the worktree dirty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,13 @@
 # Source builds and release builds deliberately produce the same format so that
 # `mycel version`, /api/health and the About page's update check never have to
 # know which kind of build they are looking at.
-VERSION ?= $(shell sh scripts/version.sh)
+# Evaluated once, when make starts, rather than on first use: a build writes into
+# the tree (server/web/dist, wails.json) and a recursively-expanded VERSION would
+# be computed after those writes, letting a build's own side effects decide
+# whether it calls itself dirty. `ifeq` keeps `make VERSION=... ` working.
+ifeq ($(origin VERSION),undefined)
+VERSION := $(shell sh scripts/version.sh)
+endif
 COMMIT  ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE    ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 BUILD_DIR ?= bin
@@ -156,6 +162,12 @@ build-local-web: ## Build web UI → server/web/dist/
 	@mkdir -p server/web
 	@rm -rf server/web/dist
 	@cp -r web/dist server/web/dist
+	# server/web/dist/placeholder.txt is tracked (see .gitignore) so that a fresh
+	# checkout has a non-empty directory for //go:embed to accept. The rm above
+	# takes it with the rest of dist, and leaving it deleted marks the worktree
+	# dirty — which then shows up in the version string of every later build, so a
+	# clean checkout of a tag stops reporting itself as that release.
+	@printf 'placeholder\n' > server/web/dist/placeholder.txt
 
 build-local-landing: ## Build landing page
 	cd landing && bun install && bun run build


### PR DESCRIPTION
## Summary

`build-local-web` does `rm -rf server/web/dist`, and that directory holds one **tracked** file: `placeholder.txt`, un-ignored in `.gitignore` on purpose so a fresh checkout has a non-empty directory for `//go:embed` to accept. The deletion was never restored, so after a single build the worktree permanently reported `D server/web/dist/placeholder.txt`.

That defeats the `.dirty` suffix #3495 just added. Build once, and every later build is stamped dirty — including a clean checkout of a release tag, which then stops reporting itself as that release. Independently of versioning, `git status` should be empty after a build.

`VERSION` is now evaluated when make starts rather than on first use, for the same reason at a smaller scale: a build writes into the tree (`server/web/dist`, `wails.json`), and a recursively-expanded `VERSION` was computed *after* those writes, letting a build's own side effects decide whether it called itself dirty. `ifeq ($(origin VERSION),undefined)` keeps `make VERSION=…` overrides working.

## Test plan

Verified in a pristine clone of `main`:

- [x] `git status` is empty after `make build-local-web`, with both `placeholder.txt` and the real `index.html` present in `server/web/dist`
- [x] `git status` is empty after a full `make build-local-mycel`
- [x] `./bin/mycel version` after that build reports `0.4.5-dev.18.ge7a3fac` — no `.dirty`, where before this change the same sequence produced `.dirty`
- [x] `make VERSION=1.2.3 …` still overrides

Closes #3498

Made with [Cursor](https://cursor.com)