### PR TITLE
fix(ci): stop Dependabot targeting /tui and have it cover the desktop module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,23 +39,6 @@ updates:
       actions:
         patterns: ["*"]
 
-  # npm — TUI
-  - package-ecosystem: npm
-    directory: /tui
-    schedule:
-      interval: weekly
-      day: monday
-    labels:
-      - dependencies
-    commit-message:
-      prefix: "deps(tui):"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-    groups:
-      tui-deps:
-        update-types: [minor, patch]
-
   # npm — Web UI
   - package-ecosystem: npm
     directory: /web

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,16 @@
 version: 2
 
 updates:
-  # Go modules
+  # Go modules. Both are listed because desktop/go.mod carries
+  # `replace github.com/rpuneet/mycel => ../`, so its indirect requirements are
+  # derived from the root module's and go stale the moment a root dependency
+  # moves — which CI now fails on (`go mod tidy -diff`, #3497). Grouping the two
+  # directories keeps a bump in one PR that updates both, instead of a root-only
+  # PR that cannot pass.
   - package-ecosystem: gomod
-    directory: /
+    directories:
+      - /
+      - /desktop
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## Summary

Two Dependabot config problems, both producing failures nobody can act on.

**1. It still targets `/tui`, deleted on 2026-07-30** by 80c6aaea (`feat!: retire the Ink TUI`). Dependabot has failed on every weekly run since:

```
npm_and_yarn in /tui - Update #1501179193: failure
```

That failure appears alongside the real runs on `main`, so the run list is permanently part-red and a genuine failure in `/`, `/web` or `/landing` is easy to miss.

**2. It only manages the root Go module.** `desktop/go.mod` carries `replace github.com/rpuneet/mycel => ../`, so its indirect requirements are derived from the root module's and go stale the moment a root dependency moves. The `go mod tidy -diff` check added in #3497 fails on exactly that — which is not hypothetical: #3500 (a one-line `go-sqlite3` patch bump) failed CI at *Verify desktop module is tidy* and needed the desktop module tidied by hand before it could merge. Left alone, every future Go bump would have arrived unmergeable.

Listing both directories under one group keeps a bump in a single PR that updates both modules together.

## Test plan

- [x] Config parses; ecosystems are now `gomod ['/', '/desktop']`, `github-actions ['/']`, `npm ['/web']`, `npm ['/landing']` — matching the directories that actually exist
- [x] No other reference to `/tui` remains under `.github/`
- [x] Verified the coupling is real: tidying `desktop/go.mod` on #3500's branch moved `go-sqlite3` to `v1.14.49` and cleared the failing check

Closes #3502
