### PR TITLE
fix(desktop): tell the UI which version is the app's and which is the daemon's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,20 @@ jobs:
         working-directory: desktop
         run: go mod tidy -diff
 
+      # Being a separate module, desktop/ is invisible to the root `go test ./...`
+      # in the Test jobs, so its tests would never run anywhere. Compiling it
+      # needs the same webview headers the release workflow installs.
+      - name: Desktop webview dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+
+      - name: Test desktop module
+        working-directory: desktop
+        # webkit2_41: wails v2 defaults to the 4.0 pkg-config name, which the
+        # ubuntu runners no longer ship.
+        run: go test -tags webkit2_41 ./...
+
   # ── Container Scan (main only) ──────────────────────────────────────
   scan:
     name: Container Scan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,20 +206,6 @@ jobs:
         working-directory: desktop
         run: go mod tidy -diff
 
-      # Being a separate module, desktop/ is invisible to the root `go test ./...`
-      # in the Test jobs, so its tests would never run anywhere. Compiling it
-      # needs the same webview headers the release workflow installs.
-      - name: Desktop webview dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
-
-      - name: Test desktop module
-        working-directory: desktop
-        # webkit2_41: wails v2 defaults to the 4.0 pkg-config name, which the
-        # ubuntu runners no longer ship.
-        run: go test -tags webkit2_41 ./...
-
   # ── Container Scan (main only) ──────────────────────────────────────
   scan:
     name: Container Scan
@@ -245,7 +231,7 @@ jobs:
           # can remove; alerting on them is permanent noise.
           ignore-unfixed: true
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4.37.3
+        uses: github/codeql-action/upload-sarif@v4.37.4
         if: always()
         with:
           sarif_file: trivy-results.sarif

--- a/desktop/bootpage.go
+++ b/desktop/bootpage.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -53,6 +54,7 @@ const bootPage = `<!doctype html>
 </div>
 <script>
   var TARGET = %q;
+  var HANDOFF = %q;
   var msg = document.getElementById("msg");
   var attempts = 0;
 
@@ -68,12 +70,16 @@ const bootPage = `<!doctype html>
     // ?desktop=1 marker tells the SPA it is running inside the Wails webview
     // (served from the daemon's http:// origin, where window.runtime is never
     // injected) so it routes external links through /api/system/open-url.
-    window.location.replace(TARGET + "/?desktop=1");
+    // app_version is the app's own version: the UI is served entirely by the
+    // daemon, which may be an older one this app attached to rather than
+    // started, so the handoff is the only channel through which the app can
+    // tell the page what it is.
+    window.location.replace(TARGET + HANDOFF);
     // Fallback: if the webview refused the cross-scheme navigation,
     // we are still here after 2s — embed the UI in a full-window iframe.
     setTimeout(function () {
       var f = document.createElement("iframe");
-      f.src = TARGET + "/?desktop=1";
+      f.src = TARGET + HANDOFF;
       document.body.appendChild(f);
       document.getElementById("boot").remove();
     }, 2000);
@@ -94,16 +100,28 @@ const bootPage = `<!doctype html>
 </html>
 `
 
-// renderBootPage bakes the server URL into the boot page.
-func renderBootPage(serverURL string) string {
-	return fmt.Sprintf(bootPage, serverURL)
+// handoffPath builds the path the boot page navigates to, carrying the desktop
+// marker and the app's own version. appVersion is URL-encoded because a source
+// build's version is not a bare identifier ("0.4.5-dev.12.g1a2b3c4.dirty") and
+// nothing guarantees a future one will stay query-safe.
+func handoffPath(appVersion string) string {
+	q := url.Values{"desktop": {"1"}}
+	if appVersion != "" {
+		q.Set("app_version", appVersion)
+	}
+	return "/?" + q.Encode()
+}
+
+// renderBootPage bakes the server URL and the handoff path into the boot page.
+func renderBootPage(serverURL, appVersion string) string {
+	return fmt.Sprintf(bootPage, serverURL, handoffPath(appVersion))
 }
 
 // bootMiddleware intercepts the document requests ("/", "/index.html")
 // and serves the boot page with the live server URL; everything else
 // falls through to the embedded assets.
-func bootMiddleware(serverURL string) func(http.Handler) http.Handler {
-	page := []byte(renderBootPage(serverURL))
+func bootMiddleware(serverURL, appVersion string) func(http.Handler) http.Handler {
+	page := []byte(renderBootPage(serverURL, appVersion))
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			path := strings.TrimSuffix(r.URL.Path, "index.html")

--- a/desktop/bootpage_test.go
+++ b/desktop/bootpage_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// The handoff URL is the only channel through which the desktop app can tell the
+// UI what version it is: the page is served entirely by the daemon, which may be
+// an older one the app attached to rather than started.
+
+func TestHandoffPathCarriesDesktopMarkerAndVersion(t *testing.T) {
+	got := handoffPath("0.4.5-dev.12.g1a2b3c4")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("handoffPath produced an unparseable URL %q: %v", got, err)
+	}
+	q := u.Query()
+	if q.Get("desktop") != "1" {
+		t.Errorf("desktop marker missing from %q — external links would stop opening", got)
+	}
+	if q.Get("app_version") != "0.4.5-dev.12.g1a2b3c4" {
+		t.Errorf("app_version = %q, want the version passed in (from %q)", q.Get("app_version"), got)
+	}
+}
+
+// TestHandoffPathEncodesVersion: a source build's version is not a bare
+// identifier, and an unencoded value would truncate or corrupt the query.
+func TestHandoffPathEncodesVersion(t *testing.T) {
+	got := handoffPath("0.0.0-dev.0.g0+weird value&desktop=0")
+
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("unparseable URL %q: %v", got, err)
+	}
+	if v := u.Query().Get("app_version"); v != "0.0.0-dev.0.g0+weird value&desktop=0" {
+		t.Errorf("app_version round-tripped as %q, want the original", v)
+	}
+	// The injected desktop=0 must not have become a second value for the marker.
+	if got := u.Query()["desktop"]; len(got) != 1 || got[0] != "1" {
+		t.Errorf("desktop marker = %v, want exactly [1] — a version must not be able to override it", got)
+	}
+}
+
+// TestHandoffPathWithoutVersion: `go run ./desktop` and any build without
+// ldflags has no version to report, and must not advertise an empty one.
+func TestHandoffPathWithoutVersion(t *testing.T) {
+	u, err := url.Parse(handoffPath(""))
+	if err != nil {
+		t.Fatalf("unparseable URL: %v", err)
+	}
+	if u.Query().Has("app_version") {
+		t.Errorf("app_version present for an unset version: %q", u.RawQuery)
+	}
+	if u.Query().Get("desktop") != "1" {
+		t.Error("desktop marker must survive an unset version")
+	}
+}
+
+// TestBootMiddlewareServesTheHandoffTarget: the boot page is what the webview
+// loads, so the version has to actually reach the rendered document.
+func TestBootMiddlewareServesTheHandoffTarget(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTeapot) // stands in for the embedded assets
+	})
+	h := bootMiddleware("http://127.0.0.1:9374", "0.4.5-dev.12.g1a2b3c4")(next)
+
+	for _, path := range []string{"/", "/index.html"} {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("GET %s = %d, want the boot page", path, rec.Code)
+			continue
+		}
+		body := rec.Body.String()
+		if !strings.Contains(body, "0.4.5-dev.12.g1a2b3c4") {
+			t.Errorf("GET %s: boot page omits the app version, so the UI can never report it", path)
+		}
+		if !strings.Contains(body, "http://127.0.0.1:9374") {
+			t.Errorf("GET %s: boot page omits the server URL", path)
+		}
+	}
+
+	// Non-document requests still fall through to the assets.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/assets/app.js", nil))
+	if rec.Code != http.StatusTeapot {
+		t.Errorf("asset request returned %d, want pass-through to the asset server", rec.Code)
+	}
+}

--- a/desktop/main.go
+++ b/desktop/main.go
@@ -41,7 +41,7 @@ func main() {
 		MinHeight: 600,
 		AssetServer: &assetserver.Options{
 			Assets:     assets,
-			Middleware: bootMiddleware(srv.URL()),
+			Middleware: bootMiddleware(srv.URL(), version),
 		},
 		OnStartup:  func(context.Context) { srv.Start() },
 		OnShutdown: func(context.Context) { srv.Stop() },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
 
+// Imported for its module-load side effect: it reads the desktop shell's version
+// out of the handoff URL, which router navigation would otherwise discard before
+// the About page ever asks for it.
+import "./utils/desktopApp";
+
 // Geist Sans + Geist Mono via @fontsource. We import only the weights the
 // dashboard actually uses (400 normal, 500 medium, 600 semibold for sans;
 // 400 + 600 for mono) to keep the initial bundle slim and avoid a FOIT.

--- a/web/src/utils/__tests__/desktopApp.test.ts
+++ b/web/src/utils/__tests__/desktopApp.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+/**
+ * The desktop app's version reaches the UI only through the handoff URL, and SPA
+ * navigation drops the query string moments later. These tests pin the capture,
+ * because losing it silently reverts the page to showing one number that a user
+ * reasonably reads as the app's when it is the daemon's.
+ */
+
+const STORAGE_KEY = "mycel.desktopAppVersion";
+
+// The module captures at load, so each case needs a fresh import.
+async function loadFresh() {
+  vi.resetModules();
+  return import("../desktopApp");
+}
+
+function setSearch(search: string) {
+  // location is not writable in jsdom; replace just what the module reads.
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, search },
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * installStorage — this jsdom setup does not provide localStorage (other suites
+ * guard it with `window.localStorage?.`), so each case supplies its own. That
+ * also lets the failure case be a store whose writes throw, which is what
+ * private browsing does.
+ */
+function installStorage(opts: { throwOnWrite?: boolean } = {}) {
+  const map = new Map<string, string>();
+  const stub = {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      if (opts.throwOnWrite) throw new Error("QuotaExceededError");
+      map.set(k, v);
+    },
+    removeItem: (k: string) => void map.delete(k),
+    clear: () => map.clear(),
+  };
+  Object.defineProperty(globalThis, "localStorage", {
+    value: stub,
+    writable: true,
+    configurable: true,
+  });
+  return map;
+}
+
+const realLocation = window.location;
+
+beforeEach(() => {
+  setSearch("");
+});
+
+afterEach(() => {
+  Object.defineProperty(window, "location", {
+    value: realLocation,
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("desktopAppVersion", () => {
+  it("captures the version from the handoff URL", async () => {
+    installStorage();
+    setSearch("?desktop=1&app_version=0.4.5-dev.12.g1a2b3c4");
+    const { desktopAppVersion } = await loadFresh();
+    expect(desktopAppVersion()).toBe("0.4.5-dev.12.g1a2b3c4");
+  });
+
+  it("survives the router dropping the query string", async () => {
+    const store = installStorage();
+    setSearch("?desktop=1&app_version=0.4.5-dev.12.g1a2b3c4");
+    await loadFresh();
+    expect(store.get(STORAGE_KEY)).toBe("0.4.5-dev.12.g1a2b3c4");
+
+    // A later page load with no query string left, as after SPA navigation.
+    setSearch("");
+    const { desktopAppVersion } = await loadFresh();
+    expect(desktopAppVersion()).toBe("0.4.5-dev.12.g1a2b3c4");
+  });
+
+  it("returns empty in a plain browser tab", async () => {
+    installStorage();
+    const { desktopAppVersion } = await loadFresh();
+    expect(desktopAppVersion()).toBe("");
+  });
+
+  it("prefers the URL over a stale stored value", async () => {
+    // An app updated between launches must not keep reporting the version it
+    // wrote last time.
+    const store = installStorage();
+    store.set(STORAGE_KEY, "0.4.4");
+    setSearch("?desktop=1&app_version=0.4.5-dev.12.g1a2b3c4");
+    const { desktopAppVersion } = await loadFresh();
+    expect(desktopAppVersion()).toBe("0.4.5-dev.12.g1a2b3c4");
+  });
+
+  it("still reports the version when storage writes throw", async () => {
+    installStorage({ throwOnWrite: true });
+    setSearch("?desktop=1&app_version=0.4.5-dev.12.g1a2b3c4");
+    const { desktopAppVersion } = await loadFresh();
+    expect(desktopAppVersion()).toBe("0.4.5-dev.12.g1a2b3c4");
+  });
+
+  it("returns empty rather than throwing when storage is absent entirely", async () => {
+    // Which is this jsdom setup's actual default, and any environment where the
+    // bare `localStorage` reference is a ReferenceError.
+    Reflect.deleteProperty(globalThis, "localStorage");
+    setSearch("");
+    const { desktopAppVersion } = await loadFresh();
+    expect(desktopAppVersion()).toBe("");
+  });
+});

--- a/web/src/utils/desktopApp.ts
+++ b/web/src/utils/desktopApp.ts
@@ -1,0 +1,49 @@
+/**
+ * desktopApp — the version of the Wails desktop shell hosting this UI, when
+ * there is one.
+ *
+ * The desktop app attaches to an already-running daemon when it finds one
+ * (desktop/server.go), and the window is then a pure client of it. Everything
+ * the page loads — including /api/health, which is where every version on the
+ * About page comes from — is served by that daemon, so an app can be newer than
+ * the daemon answering it and the UI has no way to tell. Someone who updates the
+ * app then sees the old daemon's version and concludes the update did not take.
+ *
+ * The boot page therefore passes the app's own version through the handoff URL,
+ * the only channel that exists. Capture happens at module load rather than on
+ * first use because SPA navigation drops the query string: by the time a view
+ * asks, the marker may be several routes in the past.
+ */
+
+const STORAGE_KEY = "mycel.desktopAppVersion";
+
+/** Read the handoff marker before the router can drop it. */
+function capture(): string {
+  try {
+    const fromURL = new URLSearchParams(location.search).get("app_version");
+    if (fromURL) {
+      localStorage.setItem(STORAGE_KEY, fromURL);
+      return fromURL;
+    }
+    return localStorage.getItem(STORAGE_KEY) ?? "";
+  } catch {
+    // Private-mode localStorage throws on write; the URL value is still good
+    // for this page load, so prefer it over reporting nothing.
+    try {
+      return new URLSearchParams(location.search).get("app_version") ?? "";
+    } catch {
+      return "";
+    }
+  }
+}
+
+const captured = capture();
+
+/**
+ * desktopAppVersion returns the hosting desktop app's version, or "" when the UI
+ * is not running inside one (a plain browser tab, where the daemon's version is
+ * the only one that exists and nothing needs disambiguating).
+ */
+export function desktopAppVersion(): string {
+  return captured;
+}

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { ExternalLink } from "../components/ExternalLink";
+import { desktopAppVersion } from "../utils/desktopApp";
 
 /* ── Types ──────────────────────────────────────────────────────────── */
 
@@ -151,7 +152,25 @@ export function About() {
 
   const latestTag = latest?.tag_name?.replace(/^v/, "") ?? null;
 
+  const appVersion = desktopAppVersion();
+  // The desktop app attaches to an already-running daemon rather than starting
+  // its own when it finds one, so these two genuinely can differ — and when they
+  // do, every version on this page comes from the daemon while the user is
+  // looking at a newer app. Surfacing it is the difference between "my update
+  // didn't work" and "my daemon is stale".
+  const appDiffersFromDaemon = Boolean(appVersion && health?.version && appVersion !== health.version);
+
   const channels: ChannelStatus[] = [
+    ...(appVersion
+      ? [
+          {
+            label: "Desktop app",
+            version: appVersion,
+            detail: appDiffersFromDaemon ? "newer than the daemon below" : "matches the daemon",
+            state: (appDiffersFromDaemon ? "stale" : "ok") as ChannelStatus["state"],
+          },
+        ]
+      : []),
     {
       label: "Daemon",
       version: health?.version ?? undefined,
@@ -212,10 +231,24 @@ export function About() {
     <div className="p-6 flex flex-col gap-6 max-w-3xl mx-auto">
       <header className="flex items-baseline justify-between gap-3">
         <div className="flex items-baseline gap-3">
-          <span className="text-[11px] uppercase tracking-wider text-mycel-muted">Installed</span>
+          {/* Named for what it actually is. This number always comes from the
+              daemon's /api/health; calling it "Installed" inside the desktop app
+              invited reading it as the app's own version, which is a different
+              number whenever the app attached to a daemon it did not start. */}
+          <span className="text-[11px] uppercase tracking-wider text-mycel-muted">
+            {appVersion ? "Daemon" : "Installed"}
+          </span>
           <span className="text-2xl font-semibold text-mycel-text font-mono tabular-nums">
             {health?.version ?? "—"}
           </span>
+          {appDiffersFromDaemon && (
+            <span
+              className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-warning-subtle text-mycel-warning ring-1 ring-inset ring-mycel-border"
+              title={`This desktop app is ${appVersion}, but it is using a separately running daemon on ${health?.version}. Restart the daemon from the newer build to match.`}
+            >
+              app is {appVersion}
+            </span>
+          )}
           {/* Compare like-with-like. `latestTag` is a released version
               ("0.3.1"), so only a build that claims to *be* a release can
               meaningfully be behind one. Fixes #3212. */}


### PR DESCRIPTION
## Summary

Reported from real use: the desktop app was updated, About still showed the previous day's version, and the conclusion was that the build was wrong. It wasn't.

```
$ /usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" ~/Downloads/mycel.app/Contents/Info.plist
0.4.5
$ strings ~/Downloads/mycel.app/Contents/MacOS/mycel-desktop | grep -o '0\.4\.5-dev[^ ]*' | head -1
0.4.5-dev.18.g6f68917

$ curl -s http://127.0.0.1:8080/api/health
{"status":"ok","db":"ok","version":"2026.08.02.48266874","commit":"48266874"}
```

The app was new; the daemon it attached to was a day old.

## Why the UI couldn't tell

The desktop app attaches to an already-running daemon instead of starting its own (`desktop/server.go`, `Start`) — by design, so closing the window leaves someone else's daemon alone. The boot page then hands the webview off to the *daemon's* URL, so all UI including `/api/health` is served by that daemon. The app's own version had no channel to the page whatsoever.

The About header rendered that single number under the label **INSTALLED**. Inside a desktop app that reads as the app's version, and the failure mode is silent: update, see no change, distrust the build.

## Changes

- The app's version rides the handoff URL next to the existing `?desktop=1` marker — the only channel that exists. URL-encoded, since a source build's version is not a bare identifier.
- Captured at module load, because SPA navigation drops the query string before About mounts. Same persistence approach as `isDesktop()`.
- Header labelled for what it shows: `Daemon` when hosted by a desktop app (two versions exist), `Installed` in a browser tab (one does).
- When they differ, a chip on the header and a "Desktop app" row above the daemon row state it, with the remedy in the tooltip.
- **CI now runs the desktop module's tests.** Being a separate module it is invisible to the root `go test ./...`, so nothing in it was executing anywhere — which is why this was a comfortable place for the bug to sit. Needs the same webview headers the release workflow installs.

## Test plan

- [x] `desktop/bootpage_test.go` — the marker and version both survive into the rendered boot page; the version is URL-encoded so a value containing `&desktop=0` cannot override the marker; an unset version omits `app_version` rather than advertising an empty one; asset requests still fall through
- [x] `web/src/utils/__tests__/desktopApp.test.ts` — capture from the handoff URL, survival across the router dropping the query string, empty in a plain tab, URL preferred over a stale stored value, and the two storage-unavailable paths (writes throw; `localStorage` absent entirely, which is this jsdom setup's actual default)
- [x] Full web suite green (443 tests), eslint clean, `tsc -b` clean
- [x] `go build`/`go vet` on both modules, `go test ./...` in `desktop/`, `golangci-lint run ./...` → 0 issues

Closes #3504

Made with [Cursor](https://cursor.com)