### PR TITLE
fix(ports): use one port everywhere and keep the dev server off the daemon's

### DIFF
--- a/docs/explanation/web-ui.md
+++ b/docs/explanation/web-ui.md
@@ -275,7 +275,7 @@ web/src/  --vite build-->  web/dist/  --cp-->  server/web/dist/  --go:embed-->  
 - `make build-local-mycel` builds the web UI first, then the Go binary — always build the web UI before shipping the binary, or the embedded frontend goes stale.
 - At runtime, `mycel up` serves the SPA at `/`, with API routes under `/api/` taking precedence. Unknown paths fall through to `index.html` so client-side routing works on refresh.
 
-**Dev mode:** `make run-web` starts the Vite dev server with hot reload; `web/vite.config.ts` proxies `/api` to a locally running server (`http://localhost:9375` by default in the proxy config — point a dev server instance there, or adjust).
+**Dev mode:** `make run-web` starts the Vite dev server with hot reload on <http://localhost:5173>, proxying `/api` to a daemon on its normal port — so `mycel up` in another terminal is all the setup needed. Set `MYCEL_API_PROXY` to point at a daemon somewhere else. 9374 is the daemon's port and the dev server stays off it; sharing it forced the daemon onto a second port and made mycel look like it had two.
 
 ---
 

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -44,7 +44,7 @@ func RunServer(addr, repoRoot, corsOrigin, apiKey string) error {
 // PID file removed). Used by embedders that own the process lifecycle —
 // e.g. the desktop app, which cancels ctx when the window closes.
 func RunServerCtx(ctx context.Context, addr, repoRoot, corsOrigin, apiKey string) error {
-	// Normalize addr: ":8080" → "127.0.0.1:8080"
+	// Normalize addr: ":9374" → "127.0.0.1:9374"
 	addr = normalizeAddr(addr)
 
 	// Bootstrap-or-load the global mycel state. repoRoot may be empty —

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -18,7 +18,7 @@ import (
 )
 
 // normalizeAddr ensures the host part of a host:port address is not empty.
-// If the host is missing (e.g. ":8080"), it defaults to "127.0.0.1".
+// If the host is missing (e.g. ":9374"), it defaults to "127.0.0.1".
 func normalizeAddr(addr string) string {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
@@ -104,7 +104,7 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Normalize addr: ":8080" → "127.0.0.1:8080"
+	// Normalize addr: ":9374" → "127.0.0.1:9374"
 	upAddr = normalizeAddr(upAddr)
 
 	// Daemon mode: re-exec mycel up in background

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -3109,7 +3109,7 @@ func (m *Manager) enforceRootSingleton(_ string) error {
 // (with host.docker.internal substituted for Docker runtimes).
 func daemonAddrForRuntime(rt string) string {
 	if addr := os.Getenv("MYCEL_DAEMON_ADDR"); addr != "" {
-		// Normalize empty hostname: "http://:8080" → "http://127.0.0.1:8080"
+		// Normalize empty hostname: "http://:9374" → "http://127.0.0.1:9374"
 		if u, parseErr := url.Parse(addr); parseErr == nil && u.Hostname() == "" && u.Port() != "" {
 			u.Host = net.JoinHostPort("127.0.0.1", u.Port())
 			addr = u.String()

--- a/pkg/home/global.go
+++ b/pkg/home/global.go
@@ -194,9 +194,9 @@ func DaemonLogPath() (string, error) {
 
 // DaemonAddrPath returns the path to the daemon address file
 // (~/.mycel/run/daemon.addr). `mycel up` writes the currently-listening
-// address (scheme + host:port, e.g. "http://127.0.0.1:8080") so the CLI
-// and agents can locate the daemon without requiring MYCEL_DAEMON_ADDR
-// when the daemon runs on a non-default port.
+// address as scheme + host:port — "http://127.0.0.1:9374" for a default
+// listen, or whatever --addr overrode it with — so the CLI and agents can
+// locate the daemon without requiring MYCEL_DAEMON_ADDR.
 func DaemonAddrPath() (string, error) {
 	dir, err := RunDir()
 	if err != nil {

--- a/scripts/rename-to-mycel.sh
+++ b/scripts/rename-to-mycel.sh
@@ -43,6 +43,10 @@ sqlite3 "$MYCEL_DB" "SELECT DISTINCT workspace FROM agents WHERE deleted_at IS N
 echo "== restarting daemon"
 "$BIN" up -d
 sleep 3
-curl -s -m 5 http://127.0.0.1:8080/api/health || true
+# Health-check the address the daemon just published rather than a guessed port.
+# This probed :8080 while `up -d` above listens on 9374 unless overridden, so it
+# reported nothing however well the restart had gone.
+ADDR=$(cat "$HOME/.mycel/run/daemon.addr" 2>/dev/null || echo http://127.0.0.1:9374)
+curl -s -m 5 "${ADDR%/}/api/health" || true
 echo
 echo "done. Restart agent sessions started from the old path."

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,11 +4,15 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 9374,
+    // Vite's own default. 9374 is the daemon's port: taking it here meant the
+    // dev server and the thing it proxies to wanted the same socket, so the
+    // daemon had to be moved aside to a second port and mycel appeared to have
+    // two of them.
+    port: 5173,
     proxy: {
-      // MYCEL_API_PROXY lets dev sessions point at any running daemon
-      // (e.g. http://127.0.0.1:8080) without editing this file.
-      '/api': process.env.MYCEL_API_PROXY ?? 'http://localhost:9375',
+      // The daemon on its default port, so a plain `mycel up` needs no
+      // arrangement. MYCEL_API_PROXY overrides it for a daemon elsewhere.
+      '/api': process.env.MYCEL_API_PROXY ?? 'http://localhost:9374',
     },
   },
   build: {


### PR DESCRIPTION
## Summary

Reported as "why are there 2 ports 9374 and 8080 can we make sure we only reference 1 port". mycel listens on **9374** and nothing else — but we made it look otherwise.

## Changes

**8080 as the illustrative address.** `up.go`, `serve.go` and `agent.go` used `":8080"` to show host-less normalisation, and `pkg/home/global.go` documented `daemon.addr`'s contents as `"http://127.0.0.1:8080"` — the example for the file that records the listen address named a port mycel never listens on. All now use 9374.

**A real bug in `scripts/rename-to-mycel.sh`.** It starts the daemon with `up -d` (9374), then health-checks `http://127.0.0.1:8080/api/health`. The check could not succeed however well the restart went. It now reads the address the daemon published, falling back to 9374.

**A genuine third port.** `web/vite.config.ts` had the dev server on **9374** — the daemon's own port — proxying `/api` to **9375**, since the two cannot share a socket. That is precisely how a project ends up appearing to have several ports. Dev now mirrors production: Vite on its own 5173, proxying to the daemon on 9374, so `mycel up` in another terminal is the entire setup.

The remaining 8080s belong to genuinely external services (the code-server container's internal port, the signal-cli REST API) and are left alone.

## Note for anyone running the dev server

`make run-web` now serves <http://localhost:5173> instead of `:9374`, and needs no `MYCEL_API_PROXY` for a default daemon. `docs/explanation/web-ui.md` updated to match.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...` → 0 issues
- [x] Web suite green (443 tests), eslint clean, `tsc -b` clean
- [x] `bash -n scripts/rename-to-mycel.sh`
- [x] Grep confirms the only remaining 8080s are the external services above, and the only remaining 9375 is an unrelated test fixture host

Closes #3508

Made with [Cursor](https://cursor.com)