### PR TITLE
fix(landing): stop calling setState synchronously in ScrollReveal's effect

### DIFF
--- a/landing/src/app/_components/Motion.tsx
+++ b/landing/src/app/_components/Motion.tsx
@@ -55,10 +55,18 @@ export function ScrollReveal({
       "(prefers-reduced-motion: reduce)",
     ).matches;
     if (!el || reduced || typeof IntersectionObserver === "undefined") {
-      setRevealed(true);
+      // Nothing to do: `hidden` is false until the animation is armed, so the
+      // content is already visible. Setting `revealed` here would have been a
+      // synchronous state update in an effect — a cascading render — to reach a
+      // state that renders identically.
       return;
     }
-    setArmed(true);
+    // Arm on the next tick rather than synchronously in the effect body, the
+    // same way useMounted does and for the same reason. Should the observer win
+    // the race — an element already in the viewport at load — `revealed` lands
+    // first and the element simply never hides, skipping the animation rather
+    // than the content.
+    const arm = setTimeout(() => setArmed(true), 0);
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((e) => e.isIntersecting)) {
@@ -72,6 +80,7 @@ export function ScrollReveal({
     // Safety net: never leave content hidden if the trigger misfires.
     const failsafe = setTimeout(() => setRevealed(true), 3000);
     return () => {
+      clearTimeout(arm);
       observer.disconnect();
       clearTimeout(failsafe);
     };


### PR DESCRIPTION
## Summary

The `landing` lint job is a required check and has been failing on `main` since ead6b211, so every open PR carries a red check unrelated to its own changes.

Two synchronous state updates in `ScrollReveal`'s effect tripped `react-hooks/set-state-in-effect`:

- The reduced-motion bail-out's `setRevealed(true)` was dead — `hidden` is `armed && !revealed`, so with the animation unarmed the content is already visible and that update reached a state that renders identically.
- `setArmed(true)` now defers by a tick, the idiom `useMounted` in this same file already documents for this same rule.

Arming a tick later means the IntersectionObserver can win the race for an element already in the viewport at load. That resolves the way the component is designed to: `revealed` lands first, the element never hides, and the animation is skipped rather than the content — which is the whole visible-by-default guarantee.

## Test plan

- [x] `cd landing && bun run lint` passes
- [x] `make lint` fully green (go, web, landing)
- [ ] Landing renders with reveal animations intact; content visible with JS disabled

Closes #3513

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll-reveal behavior for users with reduced-motion settings.
  * Prevented content from being unnecessarily hidden when animations cannot run.
  * Improved handling of fast-loading content and animation observer timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->