### PR TITLE
fix(providers): stop hooks from reporting a task label over the derived task

### DIFF
--- a/pkg/provider/agy_hooks.go
+++ b/pkg/provider/agy_hooks.go
@@ -70,19 +70,26 @@ const agyHookTimeoutSecs = 5
 // If jq is missing or the payload is unparseable, the bare event is still POSTed
 // so state remains correct; only the detail is lost. The stdout contract is
 // honored unconditionally — a reporting failure must never stall a turn.
-func agyHookCommand(event, state, task, stdout string) string {
+//
+// Only event and state are added. These commands used to also send a per-event
+// task ("Thinking...", "Turn complete"), which the daemon stored and the Live
+// feed rendered in the same "task" field that now holds the agent's real task
+// line — a label naming the hook that fired, sitting where the thing the agent
+// was asked to do belongs. The task line is derived from the prompt on a turn
+// start; the lifecycle meaning those strings carried is already in state.
+func agyHookCommand(event, state, stdout string) string {
 	const daemonAddr = "${MYCEL_DAEMON_ADDR:-http://127.0.0.1:9374}"
-	fallback := fmt.Sprintf(`{\"event\":\"%s\",\"state\":\"%s\",\"task\":\"%s\"}`, event, state, task)
+	fallback := fmt.Sprintf(`{\"event\":\"%s\",\"state\":\"%s\"}`, event, state)
 	return fmt.Sprintf(
-		`bash -c 'RAW=$(cat); PAYLOAD=$(echo "$RAW" | jq -c ". + {event:\"%s\",state:\"%s\",task:\"%s\"}" 2>/dev/null || echo "%s"); `+
+		`bash -c 'RAW=$(cat); PAYLOAD=$(echo "$RAW" | jq -c ". + {event:\"%s\",state:\"%s\"}" 2>/dev/null || echo "%s"); `+
 			`curl -sX POST "%s/api/agents/${MYCEL_AGENT_ID}/hook" -H "Content-Type: application/json" -d "$PAYLOAD" >/dev/null 2>&1; `+
 			`printf "%%s" %s'`,
-		event, state, task, fallback, daemonAddr, strconv.Quote(stdout),
+		event, state, fallback, daemonAddr, strconv.Quote(stdout),
 	)
 }
 
-func agyHandler(event, state, task, stdout string) agyHookHandler {
-	return agyHookHandler{Type: "command", Command: agyHookCommand(event, state, task, stdout), Timeout: agyHookTimeoutSecs}
+func agyHandler(event, state, stdout string) agyHookHandler {
+	return agyHookHandler{Type: "command", Command: agyHookCommand(event, state, stdout), Timeout: agyHookTimeoutSecs}
 }
 
 // WriteAgyHookSettings writes .agents/hooks.json into the agent worktree so the
@@ -108,11 +115,11 @@ func WriteAgyHookSettings(worktreeRoot string) error {
 	const empty = `{}`
 
 	bcHook := agyHookSpec{
-		PreInvocation:  []agyHookHandler{agyHandler("PreInvocation", "working", "Thinking...", empty)},
-		PostInvocation: []agyHookHandler{agyHandler("PostInvocation", "", "Response received", empty)},
-		Stop:           []agyHookHandler{agyHandler("Stop", "idle", "Turn complete", empty)},
-		PreToolUse:     []agyHookGroup{{Matcher: "*", Hooks: []agyHookHandler{agyHandler("PreToolUse", "", "Running tool", allow)}}},
-		PostToolUse:    []agyHookGroup{{Matcher: "*", Hooks: []agyHookHandler{agyHandler("PostToolUse", "", "Tool completed", empty)}}},
+		PreInvocation:  []agyHookHandler{agyHandler("PreInvocation", "working", empty)},
+		PostInvocation: []agyHookHandler{agyHandler("PostInvocation", "", empty)},
+		Stop:           []agyHookHandler{agyHandler("Stop", "idle", empty)},
+		PreToolUse:     []agyHookGroup{{Matcher: "*", Hooks: []agyHookHandler{agyHandler("PreToolUse", "", allow)}}},
+		PostToolUse:    []agyHookGroup{{Matcher: "*", Hooks: []agyHookHandler{agyHandler("PostToolUse", "", empty)}}},
 	}
 
 	const hookName = "mycel-activity"

--- a/pkg/provider/agy_test.go
+++ b/pkg/provider/agy_test.go
@@ -450,7 +450,7 @@ func TestAgyHookCommandForwardsStdin(t *testing.T) {
 	pathEnv, payloadFile := agyCurlRecorder(t)
 
 	cmd := exec.CommandContext(t.Context(), "bash", "-c", //nolint:gosec // running the generated command is the point of the test
-		agyHookCommand("PreInvocation", "working", "Thinking...", "{}"))
+		agyHookCommand("PreInvocation", "working", "{}"))
 	cmd.Env = append(os.Environ(),
 		"PATH="+pathEnv,
 		"MYCEL_AGENT_ID=agent-x",
@@ -499,7 +499,7 @@ func TestAgyHookCommandFallsBackWithoutJQ(t *testing.T) {
 	}
 
 	cmd := exec.CommandContext(t.Context(), "bash", "-c", //nolint:gosec // running the generated command is the point of the test
-		agyHookCommand("Stop", "idle", "Turn complete", "{}"))
+		agyHookCommand("Stop", "idle", "{}"))
 	cmd.Env = append(os.Environ(),
 		"PATH="+jqDir+string(os.PathListSeparator)+pathEnv,
 		"MYCEL_AGENT_ID=agent-x",
@@ -529,16 +529,16 @@ func TestAgyHookCommandFallsBackWithoutJQ(t *testing.T) {
 // Every generated agy command must be a runnable shell program. A quoting slip
 // would make each hook a silent no-op with nothing in the UI to explain it.
 func TestAgyHookCommandsAreValidBash(t *testing.T) {
-	for _, tc := range []struct{ event, state, task, stdout string }{
-		{"PreInvocation", "working", "Thinking...", "{}"},
-		{"PostInvocation", "", "Response received", "{}"},
-		{"Stop", "idle", "Turn complete", "{}"},
-		{"PreToolUse", "", "Running tool", `{"decision":"allow"}`},
-		{"PostToolUse", "", "Tool completed", "{}"},
+	for _, tc := range []struct{ event, state, stdout string }{
+		{"PreInvocation", "working", "{}"},
+		{"PostInvocation", "", "{}"},
+		{"Stop", "idle", "{}"},
+		{"PreToolUse", "", `{"decision":"allow"}`},
+		{"PostToolUse", "", "{}"},
 	} {
 		t.Run(tc.event, func(t *testing.T) {
 			cmd := exec.CommandContext(t.Context(), "bash", "-n", "-c", //nolint:gosec // syntax-checking the generated command is the point of the test
-				agyHookCommand(tc.event, tc.state, tc.task, tc.stdout))
+				agyHookCommand(tc.event, tc.state, tc.stdout))
 			if out, err := cmd.CombinedOutput(); err != nil {
 				t.Errorf("bash -n rejected the %s command: %v\n%s", tc.event, err, out)
 			}

--- a/pkg/provider/claude_hooks.go
+++ b/pkg/provider/claude_hooks.go
@@ -54,36 +54,44 @@ func WriteClaudeHookSettings(repoRoot string) error {
 	// hookCmd reads the full raw JSON from Claude Code's stdin, merges in
 	// our event/state fields, and POSTs the complete payload to the daemon.
 	// This preserves all fields Claude sends (tool_name, tool_input, session_id, etc.)
-	hookCmd := func(event, stateTarget, taskDesc string) string {
+	//
+	// Only event and state are added. These commands used to also send a
+	// per-event task ("Processing prompt...", "Turn complete"), which the daemon
+	// stored and the Live feed rendered in the same "task" field that now holds
+	// the agent's real task line — a label describing the hook that fired,
+	// sitting where the thing the agent was asked to do belongs. The task line is
+	// derived from the prompt on a turn start; the lifecycle meaning these
+	// strings carried is already in state.
+	hookCmd := func(event, stateTarget string) string {
 		return fmt.Sprintf(
-			`bash -c 'RAW=$(cat); PAYLOAD=$(echo "$RAW" | jq -c ". + {event:\"%s\",state:\"%s\",task:\"%s\"}" 2>/dev/null || echo "{\"event\":\"%s\",\"state\":\"%s\",\"task\":\"%s\"}"); curl -sX POST %s/api/agents/${MYCEL_AGENT_ID}/hook -H "Content-Type: application/json" -d "$PAYLOAD" 2>/dev/null || true'`,
-			event, stateTarget, taskDesc, event, stateTarget, taskDesc, daemonAddr,
+			`bash -c 'RAW=$(cat); PAYLOAD=$(echo "$RAW" | jq -c ". + {event:\"%s\",state:\"%s\"}" 2>/dev/null || echo "{\"event\":\"%s\",\"state\":\"%s\"}"); curl -sX POST %s/api/agents/${MYCEL_AGENT_ID}/hook -H "Content-Type: application/json" -d "$PAYLOAD" 2>/dev/null || true'`,
+			event, stateTarget, event, stateTarget, daemonAddr,
 		)
 	}
 
 	settings := claudeSettings{
 		Hooks: map[string][]claudeHookMatcher{
-			"SessionStart":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("SessionStart", "idle", "Session started")}}}},
-			"SessionEnd":         {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("SessionEnd", "stopped", "Session ended")}}}},
-			"UserPromptSubmit":   {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("UserPromptSubmit", "working", "Processing prompt...")}}}},
-			"PreToolUse":         {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PreToolUse", "", "Running tool")}}}},
-			"PostToolUse":        {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PostToolUse", "", "Tool completed")}}}},
-			"PostToolUseFailure": {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PostToolUseFailure", "", "Tool failed")}}}},
-			"PermissionRequest":  {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PermissionRequest", "stuck", "Waiting for permission")}}}},
-			"Stop":               {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("Stop", "idle", "Turn complete")}}}},
-			"Notification":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("Notification", "", "")}}}},
-			"SubagentStart":      {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("SubagentStart", "", "Subagent started")}}}},
-			"SubagentStop":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("SubagentStop", "", "Subagent completed")}}}},
-			"TaskCompleted":      {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("TaskCompleted", "done", "Task completed")}}}},
-			"TeammateIdle":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("TeammateIdle", "", "")}}}},
-			"InstructionsLoaded": {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("InstructionsLoaded", "", "")}}}},
-			"ConfigChange":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("ConfigChange", "", "")}}}},
-			"WorktreeCreate":     {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("WorktreeCreate", "", "Creating worktree")}}}},
-			"WorktreeRemove":     {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("WorktreeRemove", "", "")}}}},
-			"PreCompact":         {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PreCompact", "", "Compacting context...")}}}},
-			"PostCompact":        {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PostCompact", "", "Context compacted")}}}},
-			"Elicitation":        {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("Elicitation", "stuck", "MCP input needed")}}}},
-			"ElicitationResult":  {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("ElicitationResult", "working", "MCP input received")}}}},
+			"SessionStart":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("SessionStart", "idle")}}}},
+			"SessionEnd":         {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("SessionEnd", "stopped")}}}},
+			"UserPromptSubmit":   {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("UserPromptSubmit", "working")}}}},
+			"PreToolUse":         {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PreToolUse", "")}}}},
+			"PostToolUse":        {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PostToolUse", "")}}}},
+			"PostToolUseFailure": {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PostToolUseFailure", "")}}}},
+			"PermissionRequest":  {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PermissionRequest", "stuck")}}}},
+			"Stop":               {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("Stop", "idle")}}}},
+			"Notification":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("Notification", "")}}}},
+			"SubagentStart":      {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("SubagentStart", "")}}}},
+			"SubagentStop":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("SubagentStop", "")}}}},
+			"TaskCompleted":      {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("TaskCompleted", "done")}}}},
+			"TeammateIdle":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("TeammateIdle", "")}}}},
+			"InstructionsLoaded": {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("InstructionsLoaded", "")}}}},
+			"ConfigChange":       {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("ConfigChange", "")}}}},
+			"WorktreeCreate":     {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("WorktreeCreate", "")}}}},
+			"WorktreeRemove":     {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("WorktreeRemove", "")}}}},
+			"PreCompact":         {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PreCompact", "")}}}},
+			"PostCompact":        {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("PostCompact", "")}}}},
+			"Elicitation":        {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("Elicitation", "stuck")}}}},
+			"ElicitationResult":  {{Hooks: []claudeHook{{Type: "command", Command: hookCmd("ElicitationResult", "working")}}}},
 		},
 	}
 

--- a/pkg/provider/cursor_hooks.go
+++ b/pkg/provider/cursor_hooks.go
@@ -87,6 +87,13 @@ const cursorNoState = "none"
 //
 // It always exits 0 and always prints {}: a reporter that failed to reach the
 // daemon must never turn into a stalled or blocked agent.
+//
+// Only event and state are added. The reporter used to also derive a per-event
+// task ("Processing prompt...", "Turn complete"), which the daemon stored and
+// the Live feed rendered in the same "task" field that now holds the agent's
+// real task line — a label naming the hook that fired, sitting where the thing
+// the agent was asked to do belongs. The task line is derived from the prompt on
+// a turn start; the lifecycle meaning those strings carried is already in state.
 const cursorReporterScript = `#!/usr/bin/env bash
 # Managed by mycel. Regenerated whenever an agent starts — edit the generator
 # (pkg/provider/cursor_hooks.go), not this file.
@@ -98,31 +105,17 @@ event="$1"
 state="$2"
 [ "$state" = "` + cursorNoState + `" ] && state=""
 
-case "$event" in
-  SessionStart)       task="Session started" ;;
-  SessionEnd)         task="Session ended" ;;
-  UserPromptSubmit)   task="Processing prompt..." ;;
-  PreToolUse)         task="Running tool" ;;
-  PostToolUse)        task="Tool completed" ;;
-  PostToolUseFailure) task="Tool failed" ;;
-  SubagentStart)      task="Subagent started" ;;
-  SubagentStop)       task="Subagent completed" ;;
-  PreCompact)         task="Compacting context..." ;;
-  Stop)               task="Turn complete" ;;
-  *)                  task="" ;;
-esac
-
 raw=$(cat)
 addr="${MYCEL_DAEMON_ADDR:-http://127.0.0.1:9374}"
 
 payload=$(printf '%s' "$raw" | jq -c \
-  --arg event "$event" --arg state "$state" --arg task "$task" \
-  '. + {event: $event, state: $state, task: $task}
+  --arg event "$event" --arg state "$state" \
+  '. + {event: $event, state: $state}
      + (if .tool_output   then {tool_response: .tool_output}  else {} end)
      + (if .error_message then {error: .error_message}        else {} end)' 2>/dev/null)
 
 if [ -z "$payload" ]; then
-  payload=$(printf '{"event":"%s","state":"%s","task":"%s"}' "$event" "$state" "$task")
+  payload=$(printf '{"event":"%s","state":"%s"}' "$event" "$state")
 fi
 
 curl -sS -m 3 -X POST "$addr/api/agents/${MYCEL_AGENT_ID}/hook" \

--- a/pkg/provider/hook_task_test.go
+++ b/pkg/provider/hook_task_test.go
@@ -1,0 +1,95 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// An agent's task line is derived from the prompt it was handed at the start of
+// a turn — see pkg/agent/hook_ingest.go. Before that, each hook shipped a
+// hand-written label for the event that fired ("Processing prompt...",
+// "Thinking...", "Turn complete") in the payload's task field, and the daemon
+// stores whatever arrives there: the Live feed then showed `task: Thinking...`
+// in the very field that holds the real task line, so a label naming the hook
+// occupied the place reserved for what the agent had been asked to do.
+//
+// The labels are gone from all three hook-writing providers. These tests pin
+// that, because the strings are cheap to reintroduce — they read like helpful
+// UI text at the call site, and nothing else fails when one comes back.
+
+// writeHookConfig writes one provider's activity configuration into a temporary
+// worktree and returns every file it produced there, so a test can assert on
+// what the agent's CLI will actually run.
+func writeHookConfig(t *testing.T, write func(string) error, files ...string) map[string]string {
+	t.Helper()
+	root := t.TempDir()
+	if err := write(root); err != nil {
+		t.Fatalf("write hook config: %v", err)
+	}
+	out := make(map[string]string, len(files))
+	for _, rel := range files {
+		raw, err := os.ReadFile(filepath.Join(root, rel)) //nolint:gosec // test-local temp dir
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		out[rel] = string(raw)
+	}
+	return out
+}
+
+func TestHookConfigsCarryNoHardcodedTask(t *testing.T) {
+	tests := []struct {
+		name  string
+		write func(string) error
+		file  string
+	}{
+		{"claude", WriteClaudeHookSettings, ".claude/settings.json"},
+		{"agy", WriteAgyHookSettings, ".agents/hooks.json"},
+		{"cursor", WriteCursorHookSettings, cursorReporterRelPath},
+	}
+
+	// Every label the three providers used to send. A provider that reports one
+	// of these is overwriting a derived task line with the name of a hook.
+	labels := []string{
+		"Session started", "Session ended", "Processing prompt...", "Running tool",
+		"Tool completed", "Tool failed", "Subagent started", "Subagent completed",
+		"Compacting context...", "Context compacted", "Turn complete", "Thinking...",
+		"Response received", "Task completed", "Creating worktree",
+		"Waiting for permission", "MCP input needed", "MCP input received",
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := writeHookConfig(t, tt.write, tt.file)[tt.file]
+			for _, label := range labels {
+				if strings.Contains(got, label) {
+					t.Errorf("%s reports the hardcoded task %q; the task line is derived from the prompt", tt.file, label)
+				}
+			}
+		})
+	}
+}
+
+// The state field is what carries an event's lifecycle meaning, and removing the
+// task labels must not have taken it with them: without state, nothing moves an
+// agent between idle and working and the Live feed is all the UI has left.
+func TestHookConfigsStillReportState(t *testing.T) {
+	claude := writeHookConfig(t, WriteClaudeHookSettings, ".claude/settings.json")[".claude/settings.json"]
+	if !strings.Contains(claude, `state:\\\"working\\\"`) {
+		t.Errorf("claude settings no longer set state=working:\n%s", claude)
+	}
+
+	agy := writeHookConfig(t, WriteAgyHookSettings, ".agents/hooks.json")[".agents/hooks.json"]
+	if !strings.Contains(agy, `state:\\\"working\\\"`) {
+		t.Errorf("agy hooks no longer set state=working:\n%s", agy)
+	}
+
+	// Cursor's reporter takes the state as an argument, so the hooks file is
+	// where the value appears.
+	cursor := writeHookConfig(t, WriteCursorHookSettings, ".cursor/hooks.json")[".cursor/hooks.json"]
+	if !strings.Contains(cursor, "working") {
+		t.Errorf("cursor hooks no longer pass a working state:\n%s", cursor)
+	}
+}


### PR DESCRIPTION
## Summary

Since #3490 an agent's task line is derived from the prompt it was handed at the start of a turn. All three hook-writing providers still sent a hand-written label for the event that fired, in the payload's `task` field — and `hookPayloadFields` stores whatever arrives there. Observed on a live agy agent:

```json
{"event":"PreInvocation","data":{"event":"PreInvocation","task":"Thinking..."}}
```

The field holding *what the agent was asked to do* instead showed *the name of the hook that fired*. It reads as a task line and isn't one, on precisely the agents whose real task line is missing — which is what made "Live only shows state changes" hard to diagnose.

Removed from claude, cursor and agy. The lifecycle meaning those strings carried is already in `state`, which is what actually moves an agent between idle and working, so nothing is lost.

## Test plan

- [x] New `TestHookConfigsCarryNoHardcodedTask` writes each provider's config into a temp worktree and asserts none of the retired labels appear
- [x] Companion `TestHookConfigsStillReportState` pins that `state` is still reported, so removing the labels can't quietly take it too
- [x] `go test ./pkg/... ./server/...` passes
- [x] `make lint` green
- [x] Verified live on a cursor agent: task line derives from the real prompt, `PreToolUse`/`PostToolUse` carry `tool_name`/`tool_input`/`tool_response`

Closes #3515

Made with [Cursor](https://cursor.com)