### PR TITLE
feat(live): say why the feed is empty instead of always saying "waiting"

### DIFF
--- a/web/src/components/live/AgentToolStream.tsx
+++ b/web/src/components/live/AgentToolStream.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
 import { api } from "../../api/client";
 import { useAgentActivity } from "../../hooks/useAgentActivity";
+import { formatRelative } from "../../utils/time";
 import { AgentDrillDown } from "./LiveRenderers";
 
 /* ── AgentToolStream ────────────────────────────────────────────────
@@ -64,7 +66,111 @@ function useReportsActivity(agentTool?: string): boolean | undefined {
   return mode === undefined || mode !== "none";
 }
 
-export function AgentToolStream({ agentName, agentTool }: AgentToolStreamProps) {
+/**
+ * How long a running agent may report nothing before the empty feed stops
+ * saying "waiting" and starts saying "something is wrong".
+ *
+ * Every provider mycel can capture emits something within seconds of starting
+ * — a session-start hook, or the first transcript line. Minutes of total
+ * silence from a running agent is not a slow start, it is a broken one.
+ */
+const SILENCE_IS_SUSPICIOUS_AFTER_MS = 2 * 60 * 1000;
+
+/**
+ * Re-renders on an interval so a feed that never receives a single event can
+ * still notice that time has passed. Without this, the "waiting for the first
+ * event" copy would be frozen forever on exactly the agents that most need to
+ * be told something is wrong, because no event ever arrives to re-render it.
+ */
+function useElapsingTime(active: boolean, everyMs = 30_000): void {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setTick((n) => n + 1), everyMs);
+    return () => clearInterval(id);
+  }, [active, everyMs]);
+}
+
+/**
+ * What to say when there is nothing to show.
+ *
+ * An empty feed has several very different causes and they are not
+ * interchangeable: a provider mycel cannot observe, an agent that is not
+ * running, an agent that just started, and an agent that is running but whose
+ * CLI is refusing every turn. The last one is the one that gets reported as
+ * "live doesn't work" — the events are missing because the agent is dead, and
+ * the only place that says so is its terminal.
+ */
+function EmptyFeed({
+  agentName,
+  agentTool,
+  agentState,
+  startedAt,
+  reportsActivity,
+}: {
+  agentName: string;
+  agentTool?: string;
+  agentState: string;
+  startedAt?: string;
+  reportsActivity: boolean | undefined;
+}) {
+  const running = agentState !== "stopped" && agentState !== "error";
+  useElapsingTime(running);
+
+  const startedMs = startedAt ? new Date(startedAt).getTime() : NaN;
+  const silentTooLong =
+    running &&
+    Number.isFinite(startedMs) &&
+    Date.now() - startedMs > SILENCE_IS_SUSPICIOUS_AFTER_MS;
+
+  let headline: ReactNode;
+  let detail: ReactNode;
+  let attachLabel: string | null = null;
+
+  if (reportsActivity === false) {
+    headline = <>mycel can&rsquo;t read activity from {agentTool} agents</>;
+    detail =
+      "This provider offers neither hooks nor a transcript to read, so there is nothing to stream. Its terminal is the whole picture.";
+    attachLabel = "Watch the terminal";
+  } else if (!running) {
+    headline = "This agent isn't running";
+    detail =
+      "Start it from the header and its prompts, tool calls, and results will appear here.";
+  } else if (silentTooLong && reportsActivity !== undefined) {
+    headline = <>Nothing reported since this agent started {formatRelative(startedAt)}</>;
+    detail =
+      "An agent that can't reach its model — missing key, spent quota, a model it isn't entitled to — runs but never works, and reports nothing here. Its terminal will name the reason.";
+    attachLabel = "See what the terminal says";
+  } else {
+    headline = "Waiting for the first event";
+    detail =
+      "Prompts, tool calls, and results appear here as the agent works.";
+  }
+
+  return (
+    <div className="flex-1 flex items-center justify-center p-6">
+      <div className="max-w-sm flex flex-col gap-2 text-center">
+        <p className="text-sm font-medium text-mycel-text">{headline}</p>
+        <p className="text-[13px] text-mycel-muted leading-relaxed">{detail}</p>
+        {attachLabel && (
+          <Link
+            to={`/agents/${agentName}/attach`}
+            className="mt-1 self-center text-[12px] text-mycel-accent rounded px-2 py-1 ring-1 ring-inset ring-mycel-border hover:bg-mycel-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent"
+          >
+            {attachLabel}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function AgentToolStream({
+  agentName,
+  agentTool,
+  agentState,
+  startedAt,
+}: AgentToolStreamProps) {
   const { activities, tasks, rawEventsRef } = useAgentActivity(agentName);
   const reportsActivity = useReportsActivity(agentTool);
 
@@ -73,20 +179,13 @@ export function AgentToolStream({ agentName, agentTool }: AgentToolStreamProps) 
 
   if (!activity) {
     return (
-      <div className="flex-1 flex items-center justify-center p-6">
-        <p className="max-w-sm text-center text-sm text-mycel-muted italic leading-relaxed">
-          {reportsActivity === false ? (
-            <>
-              Live capture isn&rsquo;t available for{" "}
-              <span className="not-italic font-medium">{agentTool}</span> agents.
-              Use the <span className="not-italic font-medium">Attach</span> tab
-              to watch this agent&rsquo;s terminal.
-            </>
-          ) : (
-            "No activity yet — waiting for events"
-          )}
-        </p>
-      </div>
+      <EmptyFeed
+        agentName={agentName}
+        agentTool={agentTool}
+        agentState={agentState}
+        startedAt={startedAt}
+        reportsActivity={reportsActivity}
+      />
     );
   }
 

--- a/web/src/components/live/__tests__/AgentToolStream.test.tsx
+++ b/web/src/components/live/__tests__/AgentToolStream.test.tsx
@@ -1,18 +1,22 @@
 /**
- * The Live tab's empty state has to say one of two very different things: "no
- * activity yet, events are coming" or "this provider cannot be captured, go use
- * Attach". It used to choose from a provider list hardcoded in this component,
- * which drifted: cursor was listed as uncapturable long after mycel started
- * ingesting its hooks, so cursor users were sent to the terminal for no reason.
+ * The Live tab's empty state has to distinguish four situations that look
+ * identical on screen but need opposite responses from the reader: events are
+ * coming, this provider can never be captured, the agent isn't running, and the
+ * agent is running but has reported nothing for long enough that it is broken.
  *
- * The verdict now comes from each provider's own declared activity_mode, served
- * by GET /api/providers. These tests pin that wiring, including the two ways it
- * could go wrong quietly — a wrong verdict while the answer is still loading,
- * and a wrong verdict when the lookup fails.
+ * The capture verdict comes from each provider's own declared activity_mode,
+ * served by GET /api/providers. It used to come from a list hardcoded in the
+ * component, which drifted: cursor was listed as uncapturable long after mycel
+ * started ingesting its hooks, so cursor users were sent to the terminal for no
+ * reason. These tests pin that wiring, including the two ways it could go wrong
+ * quietly — a wrong verdict while the answer is still loading, and a wrong
+ * verdict when the lookup fails — plus the silence case, which is what a dead
+ * agent actually looks like.
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { AgentToolStream } from "../AgentToolStream";
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
@@ -42,17 +46,33 @@ function mockApi(providers: unknown, opts: { providersFail?: boolean } = {}) {
   });
 }
 
-const WAITING = /No activity yet/i;
-const UNAVAILABLE = /Live capture isn.t available/i;
+const WAITING = /Waiting for the first event/i;
+const UNAVAILABLE = /can.t read activity from/i;
+const SILENT = /Nothing reported since this agent started/i;
+const NOT_RUNNING = /isn.t running/i;
 
-function renderStream(tool?: string) {
+function renderStream(
+  tool?: string,
+  props: { agentState?: string; startedAt?: string } = {},
+) {
   return render(
-    <AgentToolStream agentName="eng-01" agentState="idle" agentTool={tool} />,
+    <MemoryRouter>
+      <AgentToolStream
+        agentName="eng-01"
+        agentState={props.agentState ?? "idle"}
+        agentTool={tool}
+        startedAt={props.startedAt}
+      />
+    </MemoryRouter>,
   );
 }
 
 beforeEach(() => {
   fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("AgentToolStream capture verdict", () => {
@@ -109,5 +129,55 @@ describe("AgentToolStream capture verdict", () => {
     mockApi([{ name: "legacy" }]);
     renderStream("legacy");
     await waitFor(() => expect(screen.getByText(UNAVAILABLE)).toBeTruthy());
+  });
+});
+
+describe("AgentToolStream empty-feed diagnosis", () => {
+  const HOURS_AGO = new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString();
+  const JUST_NOW = new Date(Date.now() - 5 * 1000).toISOString();
+
+  it("says a long-silent running agent is broken, not starting up", async () => {
+    // The case reported as "live doesn't work": the agent runs, its CLI refuses
+    // every turn, and nothing ever reaches the feed. Telling the reader to keep
+    // waiting sends them to look for a mycel bug that isn't there.
+    mockApi([{ name: "pi", activity_mode: "transcript" }]);
+    renderStream("pi", { agentState: "idle", startedAt: HOURS_AGO });
+    await waitFor(() => expect(screen.getByText(SILENT)).toBeTruthy());
+    expect(screen.queryByText(WAITING)).toBeNull();
+    // The reason only exists in the terminal, so the way there must be offered.
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      "/agents/eng-01/attach",
+    );
+  });
+
+  it("still says 'waiting' for an agent that only just started", async () => {
+    mockApi([{ name: "cursor", activity_mode: "hooks" }]);
+    renderStream("cursor", { agentState: "working", startedAt: JUST_NOW });
+    await waitFor(() => expect(screen.getByText(WAITING)).toBeTruthy());
+    expect(screen.queryByText(SILENT)).toBeNull();
+  });
+
+  it("does not diagnose silence before the capture verdict arrives", () => {
+    // An uncapturable provider is silent by design. Calling that silence broken
+    // before knowing which kind of provider this is would be a false alarm.
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+    renderStream("openclaw", { agentState: "idle", startedAt: HOURS_AGO });
+    expect(screen.queryByText(SILENT)).toBeNull();
+    expect(screen.getByText(WAITING)).toBeTruthy();
+  });
+
+  it("tells a stopped agent's reader to start it rather than to wait", async () => {
+    mockApi([{ name: "cursor", activity_mode: "hooks" }]);
+    renderStream("cursor", { agentState: "stopped", startedAt: HOURS_AGO });
+    await waitFor(() => expect(screen.getByText(NOT_RUNNING)).toBeTruthy());
+    expect(screen.queryByText(SILENT)).toBeNull();
+    expect(screen.queryByText(WAITING)).toBeNull();
+  });
+
+  it("does not mistake an errored agent for one that is still working", async () => {
+    mockApi([{ name: "cursor", activity_mode: "hooks" }]);
+    renderStream("cursor", { agentState: "error", startedAt: HOURS_AGO });
+    await waitFor(() => expect(screen.getByText(NOT_RUNNING)).toBeTruthy());
   });
 });


### PR DESCRIPTION
## Summary

An empty Live feed had one message — "No activity yet — waiting for events" — for four situations that need opposite responses from the reader: events are coming, this provider can never be captured, the agent isn't running, and the agent is running but its CLI is refusing every turn.

The last is the one that gets reported as "live doesn't work". A `pi` agent on my machine showed an empty feed for hours with mycel entirely correct — the transcript glob resolved and the path encoding matched a real session file. pi simply never wrote one:

```
Error: No API key found for amazon-bedrock.
```

That sentence exists only in the agent's terminal. The feed said "waiting for events", so the obvious conclusion was a capture bug while the actual cause sat one tab away, unmentioned.

mycel can't read a CLI's error, but it can notice a running agent has reported nothing since it started and name the terminal as the place that knows why. Two minutes is the threshold — every capturable provider emits something within seconds of starting, so total silence past that isn't a slow start.

Two things that would otherwise fail quietly:

- Silence is only diagnosed once the capture verdict has arrived, so a provider that reports nothing by design is never called broken.
- A feed that never receives an event has nothing to re-render it, so it ticks on an interval. Without that, the copy would stay frozen on "waiting" forever on exactly the agents that need to say something else.

## Test plan

- [x] Five new tests: long-silent running agent, just-started agent, verdict still loading, stopped agent, errored agent
- [x] `bun run test` — 448 tests pass
- [x] `make lint` green
- [x] Reproduced against the real pi agent that prompted this

Closes #3517

Made with [Cursor](https://cursor.com)