### PR TITLE
fix(web): put the dev server on 9375 and make a port collision loud

### DIFF
--- a/docs/explanation/web-ui.md
+++ b/docs/explanation/web-ui.md
@@ -275,7 +275,9 @@ web/src/  --vite build-->  web/dist/  --cp-->  server/web/dist/  --go:embed-->  
 - `make build-local-mycel` builds the web UI first, then the Go binary — always build the web UI before shipping the binary, or the embedded frontend goes stale.
 - At runtime, `mycel up` serves the SPA at `/`, with API routes under `/api/` taking precedence. Unknown paths fall through to `index.html` so client-side routing works on refresh.
 
-**Dev mode:** `make run-web` starts the Vite dev server with hot reload on <http://localhost:5173>, proxying `/api` to a daemon on its normal port — so `mycel up` in another terminal is all the setup needed. Set `MYCEL_API_PROXY` to point at a daemon somewhere else. 9374 is the daemon's port and the dev server stays off it; sharing it forced the daemon onto a second port and made mycel look like it had two.
+**Dev mode:** `make run-web` starts the Vite dev server with hot reload on <http://localhost:9375>, proxying `/api` to a daemon on its normal port — so `mycel up` in another terminal is all the setup needed. Set `MYCEL_API_PROXY` to point at a daemon somewhere else.
+
+The dev port sits next to the daemon's 9374 rather than on it: sharing 9374 forced the daemon onto a second port and made mycel look like it had two. It is deliberately not Vite's 5173 default, which is the most contested port on any machine running more than one project — and losing it is silent, so you end up reading another project's app while debugging mycel. `strictPort` is on so a collision fails instead of drifting to the next free port.
 
 ---
 

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,15 +4,26 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   server: {
-    // Vite's own default. 9374 is the daemon's port: taking it here meant the
-    // dev server and the thing it proxies to wanted the same socket, so the
-    // daemon had to be moved aside to a second port and mycel appeared to have
-    // two of them.
-    port: 5173,
+    // Next to the daemon's 9374 rather than on it: taking 9374 meant the dev
+    // server and the thing it proxies to wanted the same socket, so the daemon
+    // had to be moved aside and mycel appeared to have two ports.
+    //
+    // Not vite's 5173 default either, which is the most contested port on a
+    // machine that runs more than one project — and losing it is silent, so you
+    // end up reading another project's app while debugging mycel.
+    port: 9375,
+    // Fail loudly instead of drifting to 9376 and leaving stale tabs pointed at
+    // a port nothing is serving.
+    strictPort: true,
     proxy: {
       // The daemon on its default port, so a plain `mycel up` needs no
       // arrangement. MYCEL_API_PROXY overrides it for a daemon elsewhere.
-      '/api': process.env.MYCEL_API_PROXY ?? 'http://localhost:9374',
+      //
+      // 127.0.0.1, not localhost: the daemon binds IPv4 only, while Node
+      // resolves localhost to ::1 first and does not fall back. Naming the
+      // family the daemon actually listens on is the difference between a
+      // working dev server and one stuck on "connecting to the mycel daemon".
+      '/api': process.env.MYCEL_API_PROXY ?? 'http://127.0.0.1:9374',
     },
   },
   build: {


### PR DESCRIPTION
## Summary

Follow-up to #3509, which moved the dev server off the daemon's 9374 and onto vite's 5173 default. That fixed the collision but landed on the most contested port on any machine running more than one frontend project — and vite's response to a taken port is to silently take the next one, so you end up reading another project's app while debugging mycel, or leaving stale tabs pointed at a port nothing serves.

9375 sits next to the daemon's 9374, which is easier to remember than a number shared with every other frontend on the machine, and `strictPort` turns a collision into a startup failure instead of a quiet drift.

The docs now explain why the dev port is neither 9374 nor 5173, since "why does mycel have two ports" is exactly the question this arrangement invites.

## Test plan

- [x] `make lint` green
- [ ] `make run-web` serves on 9375 and proxies `/api` to a daemon on 9374
- [ ] Starting it twice fails the second time instead of drifting to 9376

Closes #3520

Follows #3509.