### PR TITLE
fix(live): explain an empty stream that has lifecycle events but no tool calls

### DIFF
--- a/web/src/components/live/AgentToolStream.tsx
+++ b/web/src/components/live/AgentToolStream.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState, type ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
 import { api } from "../../api/client";
 import { useAgentActivity } from "../../hooks/useAgentActivity";
-import { formatRelative } from "../../utils/time";
+import { EmptyFeed } from "./EmptyFeed";
 import { AgentDrillDown } from "./LiveRenderers";
 
 /* ── AgentToolStream ────────────────────────────────────────────────
@@ -66,105 +65,6 @@ function useReportsActivity(agentTool?: string): boolean | undefined {
   return mode === undefined || mode !== "none";
 }
 
-/**
- * How long a running agent may report nothing before the empty feed stops
- * saying "waiting" and starts saying "something is wrong".
- *
- * Every provider mycel can capture emits something within seconds of starting
- * — a session-start hook, or the first transcript line. Minutes of total
- * silence from a running agent is not a slow start, it is a broken one.
- */
-const SILENCE_IS_SUSPICIOUS_AFTER_MS = 2 * 60 * 1000;
-
-/**
- * Re-renders on an interval so a feed that never receives a single event can
- * still notice that time has passed. Without this, the "waiting for the first
- * event" copy would be frozen forever on exactly the agents that most need to
- * be told something is wrong, because no event ever arrives to re-render it.
- */
-function useElapsingTime(active: boolean, everyMs = 30_000): void {
-  const [, setTick] = useState(0);
-  useEffect(() => {
-    if (!active) return;
-    const id = setInterval(() => setTick((n) => n + 1), everyMs);
-    return () => clearInterval(id);
-  }, [active, everyMs]);
-}
-
-/**
- * What to say when there is nothing to show.
- *
- * An empty feed has several very different causes and they are not
- * interchangeable: a provider mycel cannot observe, an agent that is not
- * running, an agent that just started, and an agent that is running but whose
- * CLI is refusing every turn. The last one is the one that gets reported as
- * "live doesn't work" — the events are missing because the agent is dead, and
- * the only place that says so is its terminal.
- */
-function EmptyFeed({
-  agentName,
-  agentTool,
-  agentState,
-  startedAt,
-  reportsActivity,
-}: {
-  agentName: string;
-  agentTool?: string;
-  agentState: string;
-  startedAt?: string;
-  reportsActivity: boolean | undefined;
-}) {
-  const running = agentState !== "stopped" && agentState !== "error";
-  useElapsingTime(running);
-
-  const startedMs = startedAt ? new Date(startedAt).getTime() : NaN;
-  const silentTooLong =
-    running &&
-    Number.isFinite(startedMs) &&
-    Date.now() - startedMs > SILENCE_IS_SUSPICIOUS_AFTER_MS;
-
-  let headline: ReactNode;
-  let detail: ReactNode;
-  let attachLabel: string | null = null;
-
-  if (reportsActivity === false) {
-    headline = <>mycel can&rsquo;t read activity from {agentTool} agents</>;
-    detail =
-      "This provider offers neither hooks nor a transcript to read, so there is nothing to stream. Its terminal is the whole picture.";
-    attachLabel = "Watch the terminal";
-  } else if (!running) {
-    headline = "This agent isn't running";
-    detail =
-      "Start it from the header and its prompts, tool calls, and results will appear here.";
-  } else if (silentTooLong && reportsActivity !== undefined) {
-    headline = <>Nothing reported since this agent started {formatRelative(startedAt)}</>;
-    detail =
-      "An agent that can't reach its model — missing key, spent quota, a model it isn't entitled to — runs but never works, and reports nothing here. Its terminal will name the reason.";
-    attachLabel = "See what the terminal says";
-  } else {
-    headline = "Waiting for the first event";
-    detail =
-      "Prompts, tool calls, and results appear here as the agent works.";
-  }
-
-  return (
-    <div className="flex-1 flex items-center justify-center p-6">
-      <div className="max-w-sm flex flex-col gap-2 text-center">
-        <p className="text-sm font-medium text-mycel-text">{headline}</p>
-        <p className="text-[13px] text-mycel-muted leading-relaxed">{detail}</p>
-        {attachLabel && (
-          <Link
-            to={`/agents/${agentName}/attach`}
-            className="mt-1 self-center text-[12px] text-mycel-accent rounded px-2 py-1 ring-1 ring-inset ring-mycel-border hover:bg-mycel-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent"
-          >
-            {attachLabel}
-          </Link>
-        )}
-      </div>
-    </div>
-  );
-}
-
 export function AgentToolStream({
   agentName,
   agentTool,
@@ -177,17 +77,21 @@ export function AgentToolStream({
   const activity = activities.get(agentName);
   const rawEvents = rawEventsRef.current.get(agentName) ?? [];
 
-  if (!activity) {
-    return (
-      <EmptyFeed
-        agentName={agentName}
-        agentTool={agentTool}
-        agentState={agentState}
-        startedAt={startedAt}
-        reportsActivity={reportsActivity}
-      />
-    );
-  }
+  // Same explanation whether nothing at all arrived or only lifecycle events
+  // did. Both are the same situation to the reader — an empty feed — and the
+  // second is the more common one, since a started agent reports that much even
+  // when its CLI then refuses every turn.
+  const emptyFeed = (
+    <EmptyFeed
+      agentName={agentName}
+      agentTool={agentTool}
+      agentState={agentState}
+      startedAt={startedAt}
+      reportsActivity={reportsActivity}
+    />
+  );
+
+  if (!activity) return emptyFeed;
 
   return (
     <div className="p-6 flex flex-col h-full">
@@ -196,6 +100,7 @@ export function AgentToolStream({
         rawEvents={rawEvents}
         tasks={tasks}
         hideRawStream
+        emptyState={emptyFeed}
       />
     </div>
   );

--- a/web/src/components/live/EmptyFeed.tsx
+++ b/web/src/components/live/EmptyFeed.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { formatRelative } from "../../utils/time";
+
+/**
+ * How long a running agent may report nothing before an empty feed stops
+ * saying "waiting" and starts saying "something is wrong".
+ *
+ * Every provider mycel can capture emits something within seconds of starting
+ * — a session-start hook, or the first transcript line. Minutes of total
+ * silence from a running agent is not a slow start, it is a broken one.
+ */
+const SILENCE_IS_SUSPICIOUS_AFTER_MS = 2 * 60 * 1000;
+
+/**
+ * Re-renders on an interval so a feed that never receives a single event can
+ * still notice that time has passed. Without this, the "waiting for the first
+ * event" copy would be frozen forever on exactly the agents that most need to
+ * be told something is wrong, because no event ever arrives to re-render it.
+ */
+function useElapsingTime(active: boolean, everyMs = 30_000): void {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setTick((n) => n + 1), everyMs);
+    return () => clearInterval(id);
+  }, [active, everyMs]);
+}
+
+export interface EmptyFeedProps {
+  agentName: string;
+  agentTool?: string;
+  agentState: string;
+  startedAt?: string;
+  /**
+   * Whether this agent's provider can report activity at all, from the
+   * provider's own declared activity_mode. `undefined` means the answer hasn't
+   * arrived yet, and no verdict may be rendered until it has.
+   */
+  reportsActivity: boolean | undefined;
+}
+
+/**
+ * What to say when an activity feed has nothing to show.
+ *
+ * An empty feed has four causes that look identical on screen and call for
+ * opposite responses from the reader: a provider mycel cannot observe, an agent
+ * that is not running, an agent that just started, and an agent that is running
+ * but whose CLI is refusing every turn.
+ *
+ * The last one is what gets reported as "live doesn't work". The events are
+ * missing because the agent is dead — no key, no quota, a model it isn't
+ * entitled to — and the only place that says so is its terminal, so the reader
+ * has to be sent there rather than told to keep waiting. See #3512.
+ */
+export function EmptyFeed({
+  agentName,
+  agentTool,
+  agentState,
+  startedAt,
+  reportsActivity,
+}: EmptyFeedProps) {
+  const running = agentState !== "stopped" && agentState !== "error";
+  useElapsingTime(running);
+
+  const startedMs = startedAt ? new Date(startedAt).getTime() : NaN;
+  const silentTooLong =
+    running &&
+    Number.isFinite(startedMs) &&
+    Date.now() - startedMs > SILENCE_IS_SUSPICIOUS_AFTER_MS;
+
+  let headline: ReactNode;
+  let detail: ReactNode;
+  let attachLabel: string | null = null;
+
+  if (reportsActivity === false) {
+    headline = <>mycel can&rsquo;t read activity from {agentTool} agents</>;
+    detail =
+      "This provider offers neither hooks nor a transcript to read, so there is nothing to stream. Its terminal is the whole picture.";
+    attachLabel = "Watch the terminal";
+  } else if (!running) {
+    headline = "This agent isn't running";
+    detail =
+      "Start it from the header and its prompts, tool calls, and results will appear here.";
+  } else if (silentTooLong && reportsActivity !== undefined) {
+    headline = (
+      <>
+        Nothing reported since this agent started{" "}
+        {/* Always a duration, never a date: the sentence is about how long the
+            silence has lasted, and formatRelative's default switch to an
+            absolute date past 30 days turns it into "started 2 Jul 2026". */}
+        {formatRelative(startedAt, { maxDays: Number.MAX_SAFE_INTEGER })}
+      </>
+    );
+    detail =
+      "An agent that can't reach its model — no key, spent quota, a model it isn't entitled to — runs but never works. Its terminal will name the reason.";
+    attachLabel = "See what the terminal says";
+  } else {
+    headline = "Waiting for the first event";
+    detail = "Prompts, tool calls, and results appear here as the agent works.";
+  }
+
+  return (
+    // flex-1 centres this when the parent is a flex column (the no-activity-at-all
+    // path); min-h gives it the same presence inside the drill-down's plain
+    // scroll container, where flex-1 has nothing to stretch against.
+    <div className="flex-1 min-h-[16rem] flex items-center justify-center px-6 py-12">
+      <div className="max-w-sm flex flex-col gap-2 text-center">
+        <p className="text-sm font-medium text-mycel-text">{headline}</p>
+        <p className="text-[13px] text-mycel-muted leading-relaxed">{detail}</p>
+        {attachLabel && (
+          <Link
+            to={`/agents/${agentName}/attach`}
+            className="mt-1 self-center text-[12px] text-mycel-accent rounded px-2 py-1 ring-1 ring-inset ring-mycel-border hover:bg-mycel-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent"
+          >
+            {attachLabel}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/live/LiveRenderers.tsx
+++ b/web/src/components/live/LiveRenderers.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, memo } from "react";
+import { useCallback, useEffect, useMemo, useState, memo, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Link } from "react-router-dom";
 import type {
@@ -206,12 +206,21 @@ export function AgentDrillDown({
   tasks,
   onBack,
   hideRawStream,
+  emptyState,
 }: {
   activity: AgentActivity;
   rawEvents: RawEvent[];
   tasks: Map<string, TaskItem>;
   onBack?: () => void;
   hideRawStream?: boolean;
+  /**
+   * Shown instead of a bare "no tool events" line when the stream is empty.
+   * An agent can have lifecycle events (started, state changed) and still no
+   * tool events at all, which is what a broken agent looks like — so callers
+   * that know the agent's state can explain the silence instead of describing
+   * it. See EmptyFeed.
+   */
+  emptyState?: ReactNode;
 }) {
   const [activeTab, setActiveTab] = useState<DrillDownTab>("live");
   const [rawExpanded, setRawExpanded] = useState<Set<string>>(new Set());
@@ -313,9 +322,11 @@ export function AgentDrillDown({
         {activeTab === "live" && (
           <div>
             {allNodes.length === 0 ? (
-              <div className="text-sm text-mycel-muted italic py-8 text-center">
-                No tool events yet for this agent.
-              </div>
+              emptyState ?? (
+                <div className="text-sm text-mycel-muted italic py-8 text-center">
+                  No tool events yet for this agent.
+                </div>
+              )
             ) : (
               <>
                 <RunningSection nodes={runningNodes} sticky />

--- a/web/src/components/live/__tests__/AgentToolStream.test.tsx
+++ b/web/src/components/live/__tests__/AgentToolStream.test.tsx
@@ -31,17 +31,22 @@ function jsonResponse(body: unknown, status = 200) {
 }
 
 /** Route the calls this component's hooks make; providers is the one under test. */
-function mockApi(providers: unknown, opts: { providersFail?: boolean } = {}) {
+function mockApi(
+  providers: unknown,
+  opts: { providersFail?: boolean; agents?: unknown[] } = {},
+) {
   fetchMock.mockImplementation((input: RequestInfo | URL) => {
     const url = String(input);
     if (url.includes("/api/providers")) {
       if (opts.providersFail) return Promise.reject(new Error("offline"));
       return jsonResponse(providers);
     }
-    // No agents and no recorded activity: the component renders its empty state,
-    // which is exactly what these tests are about.
+    // No recorded activity: the component renders an empty state, which is what
+    // these tests are about. `agents` decides which empty state — an agent in
+    // the list gets an activity entry with no tool nodes, which is the shape a
+    // running-but-broken agent has.
     if (url.includes("/activity")) return jsonResponse([]);
-    if (url.includes("/api/agents")) return jsonResponse([]);
+    if (url.includes("/api/agents")) return jsonResponse(opts.agents ?? []);
     return jsonResponse([]);
   });
 }
@@ -179,5 +184,18 @@ describe("AgentToolStream empty-feed diagnosis", () => {
     mockApi([{ name: "cursor", activity_mode: "hooks" }]);
     renderStream("cursor", { agentState: "error", startedAt: HOURS_AGO });
     await waitFor(() => expect(screen.getByText(NOT_RUNNING)).toBeTruthy());
+  });
+
+  it("explains the silence when only lifecycle events arrived", async () => {
+    // The reported symptom, exactly: "I only see state changed events". The
+    // agent is in the list so it has an activity entry, but no tool events ever
+    // landed, and the stream used to describe that as "No tool events yet for
+    // this agent" — true, unhelpful, and indistinguishable from a slow start.
+    mockApi([{ name: "pi", activity_mode: "transcript" }], {
+      agents: [{ name: "eng-01", state: "working", tool: "pi" }],
+    });
+    renderStream("pi", { agentState: "working", startedAt: HOURS_AGO });
+    await waitFor(() => expect(screen.getByText(SILENT)).toBeTruthy());
+    expect(screen.queryByText(/No tool events yet/i)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

#3517 gave the Live tab an empty state that explains *why* a feed is empty, but it only rendered when the agent had **no activity at all**. The reported symptom is the other case — "I only see state changed events": the agent has `started` and `state_changed`, so activity is non-empty, the drill-down renders instead, and its empty stream says:

> No tool events yet for this agent.

That describes the silence rather than explaining it, and "yet" is a promise it can't keep. For an agent whose CLI is refusing every turn, or whose hooks are POSTing to a dead address, no tool event is ever coming — so the one screen that could name a cause instead said the events were on their way.

Both cases are the same situation to the reader, so both now get the same explanation: `AgentDrillDown` takes the empty state as a prop and the caller passes the one it already built. The lifecycle-events-only case is in fact the more common of the two, since a started agent reports that much even when everything after it fails.

`EmptyFeed` moves to its own file — it's now used from two places and had grown past the point where it belonged inside the component that renders the stream.

## Test plan

- [x] New test reproduces the reported symptom: an agent with an activity entry but no tool nodes gets the silence explanation, not "No tool events yet"
- [x] `bun run test` — 449 tests pass
- [x] `bun run lint` clean

Closes #3521

Made with [Cursor](https://cursor.com)