### PR TITLE
fix(agents): make providers.default decide the tool for new agents

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -917,6 +917,16 @@ func (m *Manager) SetAgentByName(name string) bool {
 	return true
 }
 
+// DefaultTool returns the provider new agents get when none is named. Exported
+// so a caller that configures the default can verify the manager took it: the
+// setting reaching only part of the way through is how it came to be ignored
+// for agent creation in the first place.
+func (m *Manager) DefaultTool() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.defaultTool
+}
+
 // writeActivityConfig writes the provider's activity configuration into the
 // agent worktree, dispatching on how the provider reports activity:
 //

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -425,10 +426,34 @@ func newAgentManager(h *home.Home) (*agentpkg.Manager, *containerpkg.Backend, st
 			// runtime — an explicit tmux default is working as intended.
 			reason = fmt.Sprintf("docker runtime unavailable — agents fall back to tmux: %v", err)
 		}
-		return agentpkg.NewManagerWithRepo(h.AgentsDir(), h.RootDir), nil, reason, nil
+		mgr := agentpkg.NewManagerWithRepo(h.AgentsDir(), h.RootDir)
+		applyDefaultProvider(mgr, h)
+		return mgr, nil, reason, nil
 	}
 	mgr := agentpkg.NewManagerWithRuntime(h.AgentsDir(), h.RootDir, be, "docker")
+	applyDefaultProvider(mgr, h)
 	return mgr, be, "", nil
+}
+
+// applyDefaultProvider points the manager at the provider configured as
+// providers.default, which is what `mycel agent create` uses when no --tool is
+// given.
+//
+// Without this the setting reached only the "default" badge on the providers
+// page: agent creation used the compiled-in DefaultProvider, so someone who
+// switched the default watched every new agent come up on the old tool with
+// nothing to explain why. An unknown or unregistered name leaves the built-in
+// default in place rather than failing the daemon's boot, since a provider can
+// disappear from the registry between one release and the next.
+func applyDefaultProvider(mgr *agentpkg.Manager, h *home.Home) {
+	name := h.DefaultProvider()
+	if name == "" || strings.EqualFold(name, agentpkg.DefaultProvider) {
+		return
+	}
+	if !mgr.SetAgentByName(name) {
+		log.Warn("configured default provider is not registered — keeping built-in default",
+			"providers.default", name, "using", agentpkg.DefaultProvider)
+	}
 }
 
 // buildGatewayManager constructs the gateway.Manager and registers an

--- a/server/default_provider_test.go
+++ b/server/default_provider_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"testing"
+
+	agentpkg "github.com/rpuneet/mycel/pkg/agent"
+	"github.com/rpuneet/mycel/pkg/home"
+)
+
+// providers.default decides which tool `mycel agent create` uses when no --tool
+// is given. It used to reach only the "default" badge on the providers page,
+// while agent creation used the compiled-in default — so switching the default
+// changed a label and nothing else, and every new agent came up on the old tool
+// with nothing on screen to explain why.
+//
+// A setting that silently does nothing is indistinguishable from one that
+// works until you check the result, which is why these assert on the manager's
+// resolved default rather than on the call succeeding.
+
+func managerWithDefault(t *testing.T, configured string) *agentpkg.Manager {
+	t.Helper()
+	mgr := agentpkg.NewManagerWithRepo(t.TempDir(), "")
+	cfg := &home.Config{}
+	cfg.Providers.Default = configured
+	applyDefaultProvider(mgr, &home.Home{Config: cfg})
+	return mgr
+}
+
+func TestApplyDefaultProviderUsesTheConfiguredProvider(t *testing.T) {
+	if got := managerWithDefault(t, "cursor").DefaultTool(); got != "cursor" {
+		t.Errorf("default tool = %q, want cursor", got)
+	}
+}
+
+// An unregistered name must not become the default, or every agent creation
+// would fail with a provider that cannot be looked up. A provider can leave the
+// registry between releases while a config file naming it stays behind, so this
+// falls back rather than failing the daemon's boot.
+func TestApplyDefaultProviderIgnoresUnknownProvider(t *testing.T) {
+	if got := managerWithDefault(t, "not-a-real-provider").DefaultTool(); got != agentpkg.DefaultProvider {
+		t.Errorf("default tool = %q, want the built-in %q", got, agentpkg.DefaultProvider)
+	}
+}
+
+// No configuration at all is the common case and must leave the built-in
+// default alone.
+func TestApplyDefaultProviderLeavesBuiltInDefault(t *testing.T) {
+	if got := managerWithDefault(t, "").DefaultTool(); got != agentpkg.DefaultProvider {
+		t.Errorf("default tool = %q, want the built-in %q", got, agentpkg.DefaultProvider)
+	}
+}
+
+// A nil Config is reachable — the daemon boots with one when no prefs.json
+// exists yet — and must not panic on the way to the built-in default.
+func TestApplyDefaultProviderSurvivesNilConfig(t *testing.T) {
+	mgr := agentpkg.NewManagerWithRepo(t.TempDir(), "")
+	applyDefaultProvider(mgr, &home.Home{})
+	if got := mgr.DefaultTool(); got != agentpkg.DefaultProvider {
+		t.Errorf("default tool = %q, want the built-in %q", got, agentpkg.DefaultProvider)
+	}
+}


### PR DESCRIPTION
## Summary

`providers.default` was read in exactly one place — the badge marking a provider as default on the providers page. Agent creation resolved through `Manager.defaultTool`, set from the compiled-in `DefaultProvider` const and never from config, so `mycel agent create` with no `--tool` ignored the setting:

```
$ mycel agent create swift-otter     # providers.default: cursor
$ curl -s .../api/agents/swift-otter | jq -r .tool
claude
```

The setting saved, the badge moved, and every new agent still came up on the old tool with nothing on screen to explain why — the shape described in #3474.

Switching the default is what someone does when a subscription ends and every new agent has to run on a different CLI, which is exactly when discovering it does nothing costs the most.

An unknown name warns and keeps the built-in default rather than failing the daemon's boot: a provider can leave the registry between releases while a config naming it stays behind, and refusing to start would turn that into an outage.

## Test plan

- [x] Four tests: configured provider is applied, unknown name falls back with a warning, empty config leaves the built-in default, nil config doesn't panic
- [x] `go test ./pkg/agent/ ./server/` passes
- [x] `make lint` green
- [ ] Verify live: with `providers.default: cursor`, `mycel agent create <name>` produces a cursor agent

Closes #3525

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Configured default providers are now applied consistently when creating agent sessions.
  - Users can select the preferred provider through configuration.

- **Bug Fixes**
  - Empty, missing, unknown, or unavailable provider settings now safely retain the built-in default.
  - Invalid provider configuration generates a warning instead of preventing agent startup.

- **Tests**
  - Added coverage for valid selections, fallback behavior, and missing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->