### PR TITLE
fix(agents): honor runtime.default and stop dropping --runtime

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -927,6 +927,30 @@ func (m *Manager) DefaultTool() string {
 	return m.defaultTool
 }
 
+// SetDefaultBackend chooses the runtime new agents get when they don't name
+// one, reporting false if no such backend is registered.
+//
+// Which backends exist is decided at construction — whether docker could be
+// reached — while which of them is the default is a user's choice, and the two
+// were previously the same decision: a reachable docker daemon made docker the
+// default whatever the config said.
+func (m *Manager) SetDefaultBackend(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.backends[name]; !ok {
+		return false
+	}
+	m.defaultBackend = name
+	return true
+}
+
+// DefaultBackend returns the runtime new agents get when they don't name one.
+func (m *Manager) DefaultBackend() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.defaultBackend
+}
+
 // writeActivityConfig writes the provider's activity configuration into the
 // agent worktree, dispatching on how the provider reports activity:
 //

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -431,8 +431,27 @@ func newAgentManager(h *home.Home) (*agentpkg.Manager, *containerpkg.Backend, st
 		return mgr, nil, reason, nil
 	}
 	mgr := agentpkg.NewManagerWithRuntime(h.AgentsDir(), h.RootDir, be, "docker")
+	applyDefaultRuntime(mgr, runtimeDefault)
 	applyDefaultProvider(mgr, h)
 	return mgr, be, "", nil
+}
+
+// applyDefaultRuntime honors runtime.default, which a reachable docker daemon
+// otherwise overrode.
+//
+// Whether docker could be reached decided both which backends exist and which
+// one is the default, so starting Docker Desktop silently moved every new agent
+// into a container — and container creation then fails outright for any provider
+// without a prebuilt mycel-agent-<tool> image, which is most of them. Docker
+// being available is not a request to use it.
+func applyDefaultRuntime(mgr *agentpkg.Manager, configured string) {
+	if configured == "" || configured == mgr.DefaultBackend() {
+		return
+	}
+	if !mgr.SetDefaultBackend(configured) {
+		log.Warn("configured default runtime is not available — keeping current default",
+			"runtime.default", configured, "using", mgr.DefaultBackend())
+	}
 }
 
 // applyDefaultProvider points the manager at the provider configured as

--- a/server/default_provider_test.go
+++ b/server/default_provider_test.go
@@ -1,11 +1,50 @@
 package server
 
 import (
+	"context"
+	"os/exec"
 	"testing"
 
 	agentpkg "github.com/rpuneet/mycel/pkg/agent"
 	"github.com/rpuneet/mycel/pkg/home"
+	runtimepkg "github.com/rpuneet/mycel/pkg/runtime"
 )
+
+// stubBackend stands in for the docker backend so a manager can be built the
+// way newAgentManager builds it on a machine where docker is reachable. Nothing
+// here is called: these tests only ask which backend is the default.
+type stubBackend struct{}
+
+func (stubBackend) HasSession(context.Context, string) bool { return false }
+func (stubBackend) CreateSession(context.Context, string, string) error {
+	return nil
+}
+func (stubBackend) CreateSessionWithCommand(context.Context, string, string, string) error {
+	return nil
+}
+func (stubBackend) CreateSessionWithEnv(context.Context, string, string, string, map[string]string) error {
+	return nil
+}
+func (stubBackend) KillSession(context.Context, string) error           { return nil }
+func (stubBackend) RenameSession(context.Context, string, string) error { return nil }
+func (stubBackend) SendKeys(context.Context, string, string) error      { return nil }
+func (stubBackend) SendKeysWithSubmit(context.Context, string, string, string) error {
+	return nil
+}
+func (stubBackend) Capture(context.Context, string, int) (string, error) { return "", nil }
+func (stubBackend) ListSessions(context.Context) ([]runtimepkg.Session, error) {
+	return nil, nil
+}
+func (stubBackend) AttachCmd(context.Context, string) *exec.Cmd { return nil }
+func (stubBackend) IsRunning(context.Context) bool              { return true }
+func (stubBackend) KillServer(context.Context) error            { return nil }
+func (stubBackend) SetEnvironment(context.Context, string, string, string) error {
+	return nil
+}
+func (stubBackend) SessionName(name string) string                 { return name }
+func (stubBackend) PipePane(context.Context, string, string) error { return nil }
+
+var _ runtimepkg.Backend = stubBackend{}
 
 // providers.default decides which tool `mycel agent create` uses when no --tool
 // is given. It used to reach only the "default" badge on the providers page,
@@ -57,5 +96,44 @@ func TestApplyDefaultProviderSurvivesNilConfig(t *testing.T) {
 	applyDefaultProvider(mgr, &home.Home{})
 	if got := mgr.DefaultTool(); got != agentpkg.DefaultProvider {
 		t.Errorf("default tool = %q, want the built-in %q", got, agentpkg.DefaultProvider)
+	}
+}
+
+// runtime.default was ignored whenever docker could be reached: whether the
+// docker backend existed decided which backend was the default, so starting
+// Docker Desktop moved every new agent into a container. Container creation then
+// fails outright for any provider without a prebuilt mycel-agent-<tool> image,
+// so the consequence is not a different-but-working runtime, it is agent
+// creation that stops working.
+func TestApplyDefaultRuntimeHonorsTmuxWhenDockerIsAvailable(t *testing.T) {
+	// A manager built the way newAgentManager builds it when docker is
+	// reachable: docker registered and default, tmux registered alongside.
+	mgr := agentpkg.NewManagerWithRuntime(t.TempDir(), "", stubBackend{}, "docker")
+	if got := mgr.DefaultBackend(); got != "docker" {
+		t.Fatalf("precondition: default backend = %q, want docker", got)
+	}
+
+	applyDefaultRuntime(mgr, "tmux")
+
+	if got := mgr.DefaultBackend(); got != "tmux" {
+		t.Errorf("default backend = %q, want tmux — the configured default was ignored", got)
+	}
+}
+
+// An unavailable runtime must not become the default, or every creation would
+// fail against a backend that isn't registered.
+func TestApplyDefaultRuntimeIgnoresUnavailableRuntime(t *testing.T) {
+	mgr := agentpkg.NewManagerWithRepo(t.TempDir(), "")
+	applyDefaultRuntime(mgr, "docker")
+	if got := mgr.DefaultBackend(); got != "tmux" {
+		t.Errorf("default backend = %q, want tmux — docker was never registered", got)
+	}
+}
+
+func TestApplyDefaultRuntimeLeavesDefaultWhenUnset(t *testing.T) {
+	mgr := agentpkg.NewManagerWithRuntime(t.TempDir(), "", stubBackend{}, "docker")
+	applyDefaultRuntime(mgr, "")
+	if got := mgr.DefaultBackend(); got != "docker" {
+		t.Errorf("default backend = %q, want docker left alone", got)
 	}
 }

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -379,14 +379,21 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 			// Env holds user-configured environment variables. Values may
 			// contain ${secret:NAME} references, stored verbatim and
 			// resolved against the vault at spawn time.
-			Env      map[string]string `json:"env,omitempty"`
-			Name     string            `json:"name"`
-			Role     string            `json:"role"`
-			Tool     string            `json:"tool"`
-			Model    string            `json:"model,omitempty"`
-			Runtime  string            `json:"runtime_backend"`
-			Parent   string            `json:"parent"`
-			Template string            `json:"template,omitempty"`
+			Env     map[string]string `json:"env,omitempty"`
+			Name    string            `json:"name"`
+			Role    string            `json:"role"`
+			Tool    string            `json:"tool"`
+			Model   string            `json:"model,omitempty"`
+			Runtime string            `json:"runtime_backend"`
+			// RuntimeAlt is the same field under the name the CLI sends.
+			// `mycel agent create --runtime tmux` marshals "runtime", which this
+			// handler did not read, so the flag was accepted and discarded — and
+			// on a machine where docker was reachable the agent silently went
+			// into a container instead. Reading both keeps older installed CLIs
+			// working rather than requiring everyone to upgrade in lockstep.
+			RuntimeAlt string `json:"runtime,omitempty"`
+			Parent     string `json:"parent"`
+			Template   string `json:"template,omitempty"`
 			// Repo is the absolute path of the git repo the agent binds
 			// to. Empty defaults to the repo the daemon was booted against.
 			Repo string `json:"repo,omitempty"`
@@ -406,12 +413,16 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 		if role == "" && req.Template != "" {
 			role = "base"
 		}
+		runtimeBackend := req.Runtime
+		if runtimeBackend == "" {
+			runtimeBackend = req.RuntimeAlt
+		}
 		a, err := svc.Create(r.Context(), agent.CreateOptions{
 			Name:     req.Name,
 			Role:     agent.Role(role),
 			Tool:     req.Tool,
 			Model:    req.Model,
-			Runtime:  req.Runtime,
+			Runtime:  runtimeBackend,
 			Parent:   req.Parent,
 			Repo:     req.Repo,
 			Env:      req.Env,

--- a/server/handlers/create_runtime_field_test.go
+++ b/server/handlers/create_runtime_field_test.go
@@ -1,0 +1,42 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/client"
+)
+
+// `mycel agent create --runtime tmux` marshals its request through
+// client.CreateAgentReq, which names the field "runtime". POST /api/agents read
+// only "runtime_backend", so the flag was accepted by the CLI, sent, and
+// discarded by the daemon — and on a machine where docker was reachable the
+// agent silently went into a container instead of the tmux session that was
+// asked for.
+//
+// Nothing failed: no error, no warning, just a different runtime than the one
+// requested. This pins the contract that made it possible, mirroring the
+// handler's decode so a rename on either side has to break here.
+func TestCreateAgentRequestRuntimeUsesAKeyTheHandlerReads(t *testing.T) {
+	raw, err := json.Marshal(client.CreateAgentReq{Name: "eng-01", Runtime: "tmux"})
+	if err != nil {
+		t.Fatalf("marshal create request: %v", err)
+	}
+
+	// Both names the create handler accepts.
+	var decoded struct {
+		Runtime    string `json:"runtime_backend"`
+		RuntimeAlt string `json:"runtime"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal into the handler's shape: %v", err)
+	}
+
+	got := decoded.Runtime
+	if got == "" {
+		got = decoded.RuntimeAlt
+	}
+	if got != "tmux" {
+		t.Errorf("the runtime the CLI sent reaches the handler as %q, want %q\nrequest body: %s", got, "tmux", raw)
+	}
+}


### PR DESCRIPTION
## Summary

Two settings that never reached the code acting on them. Together they break agent creation for most providers the moment Docker Desktop is running.

**`runtime.default` was ignored when docker was reachable.** `newAgentManager` passed `"docker"` as the default backend on success and read `runtime.default` only to phrase a degradation message — so whether docker could be reached decided both which backends exist *and* which one is the default. Starting Docker Desktop moved every new agent into a container, and container creation fails outright for any provider without a prebuilt `mycel-agent-<tool>` image:

```
$ mycel agent create quiet-vole      # runtime.default: tmux, providers.default: cursor
Error: Unable to find image 'mycel-agent-cursor:latest' locally
docker: pull access denied for mycel-agent-cursor
```

**`--runtime`, the escape hatch, was dropped on the way.** `client.CreateAgentReq` marshals `"runtime"`; the create handler read only `"runtime_backend"`. The flag was accepted, sent, and discarded with no error and no warning — which is why problem 1 had no workaround from the CLI. The handler now reads both names, so already-installed CLIs keep working instead of everyone having to upgrade in lockstep.

Docker being available is not a request to use it.

## Test plan

- [x] `applyDefaultRuntime` tests: tmux wins over a reachable docker, an unavailable runtime falls back with a warning, an unset value leaves the default alone
- [x] A contract test pins that the field name the CLI sends is one the handler reads, mirroring the handler's decode so a rename on either side breaks it
- [x] `go test ./server/... ./pkg/agent/ ./pkg/client/` passes
- [x] `make lint` green
- [ ] Verify live: `mycel agent create <name>` with `runtime.default: tmux` produces a tmux agent while Docker is running

Closes #3527

Made with [Cursor](https://cursor.com)