### PR TITLE
fix(cursor): trust the worktree so agents don't stall on the prompt

### DIFF
--- a/pkg/provider/cursor.go
+++ b/pkg/provider/cursor.go
@@ -18,11 +18,22 @@ type CursorProvider struct {
 func init() { Register(NewCursorProvider()) }
 
 // NewCursorProvider creates a new Cursor provider.
+//
+// --trust: cursor-agent asks "do you trust the contents of this directory?" on
+// first use of a workspace, and a tmux pane has nobody to answer it. The agent
+// sat at that prompt indefinitely — reporting no events at all, since even
+// SessionStart fires after trust is granted — which reads from the outside as an
+// agent that started fine and a Live tab that doesn't work.
+//
+// Answering it is not a decision being taken away from anyone: mycel created the
+// worktree it is pointing the agent at, moments earlier, from a repo the user
+// had already adopted. The prompt exists for a directory of unknown provenance,
+// which this never is.
 func NewCursorProvider() *CursorProvider {
 	return &CursorProvider{
 		name:        "cursor",
 		description: "Cursor Agent CLI",
-		command:     "cursor-agent",
+		command:     "cursor-agent --trust",
 		binary:      "cursor-agent",
 	}
 }

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -261,8 +261,11 @@ func TestCursorProvider(t *testing.T) {
 	if p.Description() == "" {
 		t.Error("expected non-empty description")
 	}
-	if p.Command() != "cursor-agent" {
-		t.Errorf("expected command 'cursor-agent', got %q", p.Command())
+	// --trust is not optional decoration: without it cursor-agent stops on a
+	// workspace-trust prompt that a tmux pane has nobody to answer, and the agent
+	// reports no events at all while it waits.
+	if p.Command() != "cursor-agent --trust" {
+		t.Errorf("expected command 'cursor-agent --trust', got %q", p.Command())
 	}
 }
 


### PR DESCRIPTION
## Summary

`cursor-agent` asks "Do you trust the contents of this directory?" the first time it opens a workspace. A mycel tmux pane has nobody to answer it, so every new cursor agent sat at that prompt indefinitely.

Nothing surfaced it. The daemon reported `state: idle`, the session existed, and the activity feed held exactly one event — `created` — because even `SessionStart` fires only after trust is granted. From the outside: a working agent with a broken Live tab.

```
$ curl -s .../api/agents/quiet-vole/activity | jq length
1                                    # just "created"

$ tmux capture-pane -t mycel-...-quiet-vole
  Do you trust the contents of this directory?
  ▶ [a] Trust this workspace
```

Sending `a` by hand produced `SessionStart` within seconds and the feed came alive. This is plausibly the whole history of "live doesn't work for cursor agents" — the events were never missing, the session had never started.

`--trust` exists for exactly this. Passing it takes no decision away from anyone: mycel created the worktree moments earlier from a repo the user had already adopted, and the prompt is there for directories of unknown provenance.

## Test plan

- [x] `TestCursorProvider` pins the flag, with a comment on why it isn't decoration
- [x] Verified `BuildCommand` keeps it alongside `--model` and `--resume`
- [x] `go test ./pkg/provider/` passes, `make lint` green
- [ ] Verify live: a freshly created cursor agent reaches `SessionStart` with no manual input

Closes #3529

Made with [Cursor](https://cursor.com)