### PR TITLE
feat: report an agent whose provider CLI runs but cannot serve a turn

### DIFF
--- a/pkg/agent/hooks.go
+++ b/pkg/agent/hooks.go
@@ -47,6 +47,13 @@ const (
 	HookChannelSent    HookEvent = "ChannelSent"
 	HookAgentMessage   HookEvent = "AgentMessage"
 	HookCostUpdate     HookEvent = "CostUpdate"
+	// HookProviderFailure reports that an agent's provider CLI is running but
+	// cannot serve a turn — no credential, a spent quota, a model the account
+	// cannot use. It is raised by the daemon from the agent's own terminal,
+	// which is the only place such a provider says so, and carries the reason
+	// in Error. It is the one event whose absence was indistinguishable from a
+	// healthy quiet agent (#3512).
+	HookProviderFailure HookEvent = "ProviderFailure"
 )
 
 // hookEventStateMap maps hook events to the target agent state.
@@ -64,6 +71,7 @@ var hookEventStateMap = map[HookEvent]State{
 	HookElicitationResult: StateWorking,
 	HookStop:              StateIdle,
 	HookTaskCompleted:     StateDone,
+	HookProviderFailure:   StateError,
 }
 
 // StateForHookEvent returns the target agent State for a hook event.

--- a/pkg/provider/agy_failure.go
+++ b/pkg/provider/agy_failure.go
@@ -1,0 +1,22 @@
+package provider
+
+// agyFatalPatterns are agy's refusals to serve a turn at all.
+//
+// Taken verbatim from an agy agent mycel was reporting as starting while it had
+// answered every prompt with a quota error for hours (#3512). A quota that
+// resets in six days is not something the agent recovers from on its own, so it
+// belongs here; a momentary rate limit would not.
+var agyFatalPatterns = []FailurePattern{
+	{
+		// "⚠ Individual quota reached. Please upgrade your subscription to
+		// increase your limits. Resets in 156h34m52s."
+		LineStartsWith: "⚠",
+		Contains:       "quota reached",
+		Reason:         "agy's quota is exhausted — it resets on its own, or raise the limit on the account",
+	},
+}
+
+// DetectFailure implements FailureDetector.
+func (p *AgyProvider) DetectFailure(pane string) (string, bool) {
+	return MatchFailure(pane, paneTailLines, agyFatalPatterns)
+}

--- a/pkg/provider/failure.go
+++ b/pkg/provider/failure.go
@@ -1,0 +1,130 @@
+// failure.go — recognising a provider CLI that is running but cannot work.
+//
+// A provider process can be perfectly alive and still refuse every turn: no API
+// key, a spent quota, a model the account isn't entitled to. mycel used to
+// report those agents as idle or working with an empty Live feed, because
+// nothing they do reaches the daemon — there is nothing to report. The reason is
+// on their terminal, in prose, and that is the only place it exists (#3512).
+//
+// So the terminal is treated as what it is: a last-resort activity source for
+// fatal conditions. Providers declare the lines that mean "this agent cannot
+// serve a turn", and the daemon matches them against recent pane output only
+// when an agent has already gone quiet.
+package provider
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiEscape matches the escape sequences a terminal UI paints its output with.
+//
+// Captured panes are not plain text: providers colour their own error messages,
+// so the line that reads "Error: No API key found for amazon-bedrock" actually
+// begins with a colour sequence. Anything anchoring to the start of a line has
+// to see through that first.
+//
+// Covered: CSI sequences (colour, cursor movement, line clears), OSC sequences
+// (hyperlinks and window titles, which terminate with BEL or ST), and the
+// two-character escapes. An unterminated OSC is left alone rather than risking
+// swallowing the newline that separates two lines.
+var ansiEscape = regexp.MustCompile("\x1b\\[[0-9;?]*[ -/]*[@-~]" +
+	"|\x1b\\][^\x07\x1b\n]*(?:\x07|\x1b\\\\)" +
+	"|\x1b[@-Z\\\\-_]")
+
+// StripANSI removes terminal escape sequences from s, leaving its text and line
+// structure intact.
+func StripANSI(s string) string {
+	if !strings.ContainsRune(s, 0x1b) {
+		return s
+	}
+	return ansiEscape.ReplaceAllString(s, "")
+}
+
+// paneTailLines is how much of an agent's terminal a detector reads.
+//
+// Enough to hold a wrapped error and the prompt line under it, short enough that
+// a message from an earlier, recovered session has scrolled out of range.
+const paneTailLines = 25
+
+// FailureDetector is optionally implemented by providers whose CLI reports
+// fatal, unrecoverable conditions to its terminal and nowhere else.
+//
+// This is deliberately the lowest-confidence signal mycel has, so it is only
+// consulted for agents that have already produced no activity for minutes.
+// Matching prose is unpleasant, but a CLI that prints "No API key found" and
+// then sits there offers nothing else — and leaving the user with a silent feed
+// and no reason is worse than reading its screen.
+type FailureDetector interface {
+	// DetectFailure examines recent terminal output, newest content last, and
+	// returns a short reason when the CLI cannot serve a turn.
+	//
+	// Implementations must only report conditions that will not resolve on
+	// their own: a missing credential, an exhausted quota, a model the account
+	// cannot use. Anything the agent can recover from by itself — a rate limit
+	// it will retry, a tool that failed once — is not a failure here, because
+	// the cost of a false positive is an agent reported broken while it works.
+	DetectFailure(pane string) (reason string, failed bool)
+}
+
+// FailurePattern maps a line of provider output to the reason it implies.
+//
+// Literal fragments rather than regexes: these are matched against terminal
+// text that providers reflow and colour unpredictably, and a fragment short
+// enough to survive that is also short enough to read here and check against the
+// real message.
+type FailurePattern struct {
+	// LineStartsWith is the provider's own error marker — the beginning of the
+	// line it prints the failure on, ignoring leading whitespace (e.g. "error:",
+	// or the glyph a CLI prefixes warnings with).
+	//
+	// It is what separates a provider reporting a failure from an agent
+	// discussing one. An agent reading this very file writes lines containing
+	// "no api key found for"; only the CLI writes a line that starts with
+	// "Error:" and contains it. Empty matches any line, which should be rare —
+	// prefer a marker, since a false positive tells the user a working agent is
+	// broken.
+	LineStartsWith string
+	// Contains is the most distinctive short fragment of the message, matched
+	// case-insensitively within the same line as the marker.
+	Contains string
+	// Reason is what the user is told, in mycel's voice rather than the
+	// provider's: what is wrong and, where it fits, what to do about it.
+	Reason string
+}
+
+// MatchFailure returns the reason for the first pattern found in the tail of
+// pane, or false when none match.
+//
+// Only the tail is searched, because a pane holds scrollback: an error from an
+// hour ago followed by a working session must not mark a healthy agent as
+// broken. tailLines of 0 or less searches the whole pane.
+func MatchFailure(pane string, tailLines int, patterns []FailurePattern) (string, bool) {
+	for _, line := range paneTail(StripANSI(pane), tailLines) {
+		trimmed := strings.ToLower(strings.TrimSpace(line))
+		if trimmed == "" {
+			continue
+		}
+		for _, p := range patterns {
+			if p.Contains == "" {
+				continue
+			}
+			if p.LineStartsWith != "" && !strings.HasPrefix(trimmed, strings.ToLower(p.LineStartsWith)) {
+				continue
+			}
+			if strings.Contains(trimmed, strings.ToLower(p.Contains)) {
+				return p.Reason, true
+			}
+		}
+	}
+	return "", false
+}
+
+// paneTail returns the last n lines of s, in order.
+func paneTail(s string, n int) []string {
+	lines := strings.Split(s, "\n")
+	if n <= 0 || len(lines) <= n {
+		return lines
+	}
+	return lines[len(lines)-n:]
+}

--- a/pkg/provider/failure.go
+++ b/pkg/provider/failure.go
@@ -1,4 +1,4 @@
-// failure.go — recognising a provider CLI that is running but cannot work.
+// failure.go — recognizing a provider CLI that is running but cannot work.
 //
 // A provider process can be perfectly alive and still refuse every turn: no API
 // key, a spent quota, a model the account isn't entitled to. mycel used to
@@ -19,12 +19,12 @@ import (
 
 // ansiEscape matches the escape sequences a terminal UI paints its output with.
 //
-// Captured panes are not plain text: providers colour their own error messages,
+// Captured panes are not plain text: providers color their own error messages,
 // so the line that reads "Error: No API key found for amazon-bedrock" actually
-// begins with a colour sequence. Anything anchoring to the start of a line has
+// begins with a color sequence. Anything anchoring to the start of a line has
 // to see through that first.
 //
-// Covered: CSI sequences (colour, cursor movement, line clears), OSC sequences
+// Covered: CSI sequences (color, cursor movement, line clears), OSC sequences
 // (hyperlinks and window titles, which terminate with BEL or ST), and the
 // two-character escapes. An unterminated OSC is left alone rather than risking
 // swallowing the newline that separates two lines.
@@ -70,7 +70,7 @@ type FailureDetector interface {
 // FailurePattern maps a line of provider output to the reason it implies.
 //
 // Literal fragments rather than regexes: these are matched against terminal
-// text that providers reflow and colour unpredictably, and a fragment short
+// text that providers reflow and color unpredictably, and a fragment short
 // enough to survive that is also short enough to read here and check against the
 // real message.
 type FailurePattern struct {

--- a/pkg/provider/failure_test.go
+++ b/pkg/provider/failure_test.go
@@ -1,8 +1,9 @@
 package provider
 
-import "strings"
-
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // Verbatim panes from agents mycel was reporting as healthy (#3512). They are
 // quoted rather than paraphrased because the whole mechanism rests on matching
@@ -46,13 +47,13 @@ func TestPiDetectFailure(t *testing.T) {
 	tests := []struct {
 		name       string
 		pane       string
-		wantFailed bool
 		wantIn     string
+		wantFailed bool
 	}{
-		{"no api key", piNoKeyPane, true, "no API key"},
-		{"model not entitled", piNoModelAccessPane, true, "model is unavailable"},
-		{"working agent", workingPane, false, ""},
-		{"empty pane", "", false, ""},
+		{"no api key", piNoKeyPane, "no API key", true},
+		{"model not entitled", piNoModelAccessPane, "model is unavailable", true},
+		{"working agent", workingPane, "", false},
+		{"empty pane", "", "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -141,7 +142,7 @@ func TestDetectFailureSeesThroughTerminalColour(t *testing.T) {
 	// and all. This is what a detector is actually handed — the first attempt at
 	// this feature matched nothing in production while every unit test passed,
 	// because the fixtures were hand-typed plain text and the real error line
-	// starts with a colour sequence rather than "Error:".
+	// starts with a color sequence rather than "Error:".
 	pane := " \x1b[38;2;204;102;102mError: No API key found for amazon-bedrock." +
 		"                                               \n" +
 		"\x1b[2K \x1b[38;2;204;102;102mUse /login to log into a provider via OAuth or API key. See:\x1b[0m\x1b]8;;file:///docs\x07\n" +
@@ -149,7 +150,7 @@ func TestDetectFailureSeesThroughTerminalColour(t *testing.T) {
 
 	reason, failed := (&PiProvider{}).DetectFailure(pane)
 	if !failed {
-		t.Fatal("a coloured provider error must be detected — panes are never plain text")
+		t.Fatal("a colored provider error must be detected — panes are never plain text")
 	}
 	if !strings.Contains(reason, "no API key") {
 		t.Errorf("reason = %q, want it to mention the missing key", reason)
@@ -200,11 +201,11 @@ func TestMatchFailureSkipsEmptyPatterns(t *testing.T) {
 // is how the daemon finds them.
 func TestProvidersImplementFailureDetector(t *testing.T) {
 	for _, tt := range []struct {
-		name string
 		p    Provider
+		name string
 	}{
-		{"pi", &PiProvider{}},
-		{"agy", &AgyProvider{}},
+		{&PiProvider{}, "pi"},
+		{&AgyProvider{}, "agy"},
 	} {
 		if _, ok := tt.p.(FailureDetector); !ok {
 			t.Errorf("%s does not implement FailureDetector", tt.name)

--- a/pkg/provider/failure_test.go
+++ b/pkg/provider/failure_test.go
@@ -1,0 +1,213 @@
+package provider
+
+import "strings"
+
+import "testing"
+
+// Verbatim panes from agents mycel was reporting as healthy (#3512). They are
+// quoted rather than paraphrased because the whole mechanism rests on matching
+// what these CLIs actually print, and a paraphrase would keep passing after the
+// real message changed.
+const piNoKeyPane = ` Warning: tmux extended-keys is off. Modified Enter keys may not work.
+────────────────────────────────────────────────────────────────────────
+ Update Available
+ New version 0.83.0 is available. Run pi update
+────────────────────────────────────────────────────────────────────────
+ Error: No API key found for amazon-bedrock.
+ Use /login to log into a provider via OAuth or API key. See:
+ /opt/homebrew/lib/node_modules/@earendil-works/pi-coding-agent/docs/providers.md
+────────────────────────────────────────────────────────────────────────
+~/.mycel/agents/calm-gecko/worktree (detached)
+0.0%/197k (auto)                    (amazon-bedrock) minimax.minimax-m2.5 • high`
+
+const piNoModelAccessPane = ` Error: 404 The model ` + "`qwen/qwen3-32b`" + ` does not exist or you do not have access to it.
+ Model: meta-llama/llama-4-scout-17b-16e-instruct
+ Hi
+ Error: 404 The model ` + "`meta-llama/llama-4-scout-17b-16e-instruct`" + ` does not exist or you do not have access to it.
+~/.mycel/agents/fierce-osprey/worktree (detached)`
+
+const agyQuotaPane = `⚠ Individual quota reached. Please upgrade your subscription to increase your limits. Resets in 156h34m52s.
+Error ID: 08a716f9-72a7-45b4-b26f-b2de551b857f-302
+────────────────────────────────────────────────────────────
+> hi
+? for shortcuts                                    Gemini 3.5 Flash · medium`
+
+// A healthy pane, including one that talks about the very things the patterns
+// look for. An agent editing provider code must never be reported as broken.
+const workingPane = `● Read pkg/provider/pi.go
+● The API key handling looks right. No API key found for is the error string
+  we match on, so the test should assert that exact text.
+● Bash(go test ./pkg/provider/)
+  ok  github.com/rpuneet/mycel/pkg/provider  0.412s
+> `
+
+func TestPiDetectFailure(t *testing.T) {
+	p := &PiProvider{}
+	tests := []struct {
+		name       string
+		pane       string
+		wantFailed bool
+		wantIn     string
+	}{
+		{"no api key", piNoKeyPane, true, "no API key"},
+		{"model not entitled", piNoModelAccessPane, true, "model is unavailable"},
+		{"working agent", workingPane, false, ""},
+		{"empty pane", "", false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, failed := p.DetectFailure(tt.pane)
+			if failed != tt.wantFailed {
+				t.Fatalf("failed = %v, want %v (reason %q)", failed, tt.wantFailed, reason)
+			}
+			if tt.wantIn != "" && !strings.Contains(reason, tt.wantIn) {
+				t.Errorf("reason = %q, want it to mention %q", reason, tt.wantIn)
+			}
+			if !tt.wantFailed && reason != "" {
+				t.Errorf("reason = %q, want empty when not failed", reason)
+			}
+		})
+	}
+}
+
+func TestAgyDetectFailure(t *testing.T) {
+	p := &AgyProvider{}
+
+	reason, failed := p.DetectFailure(agyQuotaPane)
+	if !failed {
+		t.Fatal("a pane reporting an exhausted quota must be reported as failed")
+	}
+	if !strings.Contains(reason, "quota") {
+		t.Errorf("reason = %q, want it to mention the quota", reason)
+	}
+
+	if _, failed := p.DetectFailure(workingPane); failed {
+		t.Error("a working agent must not be reported as failed")
+	}
+}
+
+func TestMatchFailureReadsOnlyTheTail(t *testing.T) {
+	// A pane holds scrollback. An error from an earlier session that has since
+	// recovered must scroll out of reach, or a healthy agent is reported broken
+	// for the rest of its life.
+	patterns := []FailurePattern{{Contains: "no api key found for", Reason: "no key"}}
+	old := "Error: No API key found for amazon-bedrock.\n" + strings.Repeat("● working fine\n", 40)
+
+	if _, failed := MatchFailure(old, 25, patterns); failed {
+		t.Error("an error above the tail window must not count as a current failure")
+	}
+	if _, failed := MatchFailure(old, 0, patterns); !failed {
+		t.Error("tailLines <= 0 must search the whole pane")
+	}
+}
+
+func TestMatchFailureRequiresTheProvidersOwnErrorMarker(t *testing.T) {
+	// This is what keeps an agent that talks about failures apart from a
+	// provider that has one. Both lines contain the fragment; only the
+	// provider's starts with its error marker.
+	patterns := []FailurePattern{{
+		LineStartsWith: "error:",
+		Contains:       "no api key found for",
+		Reason:         "no key",
+	}}
+
+	agentProse := "● The message is \"No API key found for amazon-bedrock\", which we match on."
+	if reason, failed := MatchFailure(agentProse, 25, patterns); failed {
+		t.Errorf("agent prose reported as a provider failure, reason = %q", reason)
+	}
+
+	providerError := " Error: No API key found for amazon-bedrock."
+	if _, failed := MatchFailure(providerError, 25, patterns); !failed {
+		t.Error("the provider's own error line must match despite its indentation")
+	}
+}
+
+func TestMatchFailureNeedsMarkerAndFragmentOnOneLine(t *testing.T) {
+	// A marker on one line and the fragment on another is two unrelated pieces
+	// of output, not a failure report.
+	patterns := []FailurePattern{{
+		LineStartsWith: "error:",
+		Contains:       "quota reached",
+		Reason:         "spent",
+	}}
+	split := "Error: something else entirely\n● the quota reached its limit last week"
+	if reason, failed := MatchFailure(split, 25, patterns); failed {
+		t.Errorf("marker and fragment on separate lines matched, reason = %q", reason)
+	}
+}
+
+func TestDetectFailureSeesThroughTerminalColour(t *testing.T) {
+	// Captured verbatim from GET /api/agents/calm-gecko/peek, escape sequences
+	// and all. This is what a detector is actually handed — the first attempt at
+	// this feature matched nothing in production while every unit test passed,
+	// because the fixtures were hand-typed plain text and the real error line
+	// starts with a colour sequence rather than "Error:".
+	pane := " \x1b[38;2;204;102;102mError: No API key found for amazon-bedrock." +
+		"                                               \n" +
+		"\x1b[2K \x1b[38;2;204;102;102mUse /login to log into a provider via OAuth or API key. See:\x1b[0m\x1b]8;;file:///docs\x07\n" +
+		"\x1b[2K\x1b[38;2;102;102;102m0.0%/197k (auto)\x1b[39m (amazon-bedrock) minimax.minimax-m2.5\n"
+
+	reason, failed := (&PiProvider{}).DetectFailure(pane)
+	if !failed {
+		t.Fatal("a coloured provider error must be detected — panes are never plain text")
+	}
+	if !strings.Contains(reason, "no API key") {
+		t.Errorf("reason = %q, want it to mention the missing key", reason)
+	}
+}
+
+func TestStripANSIKeepsTextAndLines(t *testing.T) {
+	in := "\x1b[2K \x1b[38;2;204;102;102mError: boom\x1b[0m\n\x1b[38;5;9msecond line\x1b[m"
+	want := " Error: boom\nsecond line"
+	if got := StripANSI(in); got != want {
+		t.Errorf("StripANSI = %q, want %q", got, want)
+	}
+}
+
+func TestStripANSILeavesPlainTextUntouched(t *testing.T) {
+	in := "Error: No API key found for amazon-bedrock.\n> "
+	if got := StripANSI(in); got != in {
+		t.Errorf("StripANSI altered plain text: %q", got)
+	}
+}
+
+func TestStripANSIKeepsLineCountWithUnterminatedSequence(t *testing.T) {
+	// A pane is a fixed-width window, so it can cut a sequence in half. Losing a
+	// newline there would join two lines and let a marker on one match a
+	// fragment on the next.
+	in := "Error: boom\n\x1b]8;;http://truncated"
+	if got := strings.Count(StripANSI(in), "\n"); got != 1 {
+		t.Errorf("newline count = %d, want 1", got)
+	}
+}
+
+func TestMatchFailureIsCaseInsensitive(t *testing.T) {
+	patterns := []FailurePattern{{Contains: "Quota Reached", Reason: "spent"}}
+	if _, failed := MatchFailure("⚠ individual QUOTA reached.", 25, patterns); !failed {
+		t.Error("matching must not depend on the casing a provider happens to use")
+	}
+}
+
+func TestMatchFailureSkipsEmptyPatterns(t *testing.T) {
+	// An empty Contains would match every pane and report every agent broken.
+	patterns := []FailurePattern{{Contains: "", Reason: "should never fire"}}
+	if reason, failed := MatchFailure(workingPane, 25, patterns); failed {
+		t.Errorf("empty pattern matched, reason = %q", reason)
+	}
+}
+
+// The detectors must be reachable through the capability interface, since that
+// is how the daemon finds them.
+func TestProvidersImplementFailureDetector(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		p    Provider
+	}{
+		{"pi", &PiProvider{}},
+		{"agy", &AgyProvider{}},
+	} {
+		if _, ok := tt.p.(FailureDetector); !ok {
+			t.Errorf("%s does not implement FailureDetector", tt.name)
+		}
+	}
+}

--- a/pkg/provider/pi_failure.go
+++ b/pkg/provider/pi_failure.go
@@ -1,0 +1,28 @@
+package provider
+
+// piFatalPatterns are pi's refusals to serve a turn at all.
+//
+// Every one of these was taken verbatim from a pi agent that mycel was
+// reporting as idle or working with an empty Live feed (#3512). pi prints the
+// message once, leaves the prompt up, and writes no session transcript — so
+// there is nothing for the tailer to find and no other trace of why.
+var piFatalPatterns = []FailurePattern{
+	{
+		// "Error: No API key found for amazon-bedrock."
+		LineStartsWith: "error:",
+		Contains:       "no api key found for",
+		Reason:         "pi has no API key for its configured provider — run /login in the agent's terminal",
+	},
+	{
+		// "Error: 404 The model `qwen/qwen3-32b` does not exist or you do not
+		// have access to it."
+		LineStartsWith: "error:",
+		Contains:       "do not have access to it",
+		Reason:         "pi's model is unavailable to this account — pick another model for this agent",
+	},
+}
+
+// DetectFailure implements FailureDetector.
+func (p *PiProvider) DetectFailure(pane string) (string, bool) {
+	return MatchFailure(pane, paneTailLines, piFatalPatterns)
+}

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -304,6 +304,16 @@ func buildServicesFromHome(ctx context.Context, globals *Globals, h *home.Home) 
 		runTranscriptTailer(svcCtx, agentSvc)
 	}()
 
+	// Provider failure monitor — reports agents whose provider CLI is running
+	// but cannot serve a turn (no credential, spent quota, unusable model).
+	// Such agents report nothing at all, so without this they keep whatever
+	// state they last had and their Live feed stays empty with no reason.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runProviderFailureMonitor(svcCtx, agentSvc)
+	}()
+
 	// Notify service (channel subscriptions + delivery).
 	var notifyService *notifypkg.Service
 	if ns, err := notifypkg.OpenStore(wsDB, wsDriver); err != nil {

--- a/server/provider_failure_monitor.go
+++ b/server/provider_failure_monitor.go
@@ -1,0 +1,181 @@
+// provider_failure_monitor.go — noticing an agent whose provider CLI runs but
+// cannot work.
+//
+// mycel derives agent state from what an agent reports. That works until the
+// provider refuses every turn: no API key, a spent quota, a model the account
+// isn't entitled to. Such an agent reports nothing, so it keeps whatever state
+// it had — idle, or working since the last prompt it accepted — and its Live
+// feed stays empty with no explanation. Three agents on one machine sat like
+// that for days while mycel called them healthy (#3512).
+//
+// The reason exists only on the agent's terminal, so this monitor reads it: for
+// agents that have already gone quiet, it captures recent pane output and asks
+// the provider whether the text means "cannot serve a turn"
+// (provider.FailureDetector). A match becomes a ProviderFailure event through
+// the same ingest path as any hook, which moves the agent to error and puts the
+// reason in the feed that was empty.
+//
+// Ordering matters here: silence is the cheap gate and the pane is the
+// expensive, lower-confidence check. An agent that is reporting activity is
+// never inspected, so a busy agent that merely mentions an API key cannot be
+// mistaken for a broken one.
+package server
+
+import (
+	"context"
+	"time"
+
+	agentpkg "github.com/rpuneet/mycel/pkg/agent"
+	"github.com/rpuneet/mycel/pkg/log"
+	"github.com/rpuneet/mycel/pkg/provider"
+)
+
+const (
+	// failureSweepInterval is how often the monitor looks for quiet agents.
+	// A stuck agent stays stuck, so there is nothing to gain from checking
+	// often — this only decides how soon the user is told.
+	failureSweepInterval = 30 * time.Second
+
+	// failureQuietFor is how long an agent must have reported nothing before
+	// its terminal is read.
+	//
+	// Long enough that a working agent between two tool calls is never
+	// inspected, short enough that a user who just started a doomed agent
+	// learns why while they are still looking at it.
+	failureQuietFor = 2 * time.Minute
+
+	// failurePaneLines is how much scrollback to capture. The detectors read
+	// less than this; the surplus covers a provider that wraps a long message
+	// above its prompt.
+	failurePaneLines = 60
+)
+
+// failureMonitorDeps is what the sweep needs, narrowed to an interface so the
+// tests can drive it without a tmux session or a real provider registry.
+type failureMonitorDeps interface {
+	List(ctx context.Context, opts agentpkg.ListOptions) ([]*agentpkg.Agent, error)
+	Peek(ctx context.Context, name string, lines int) (string, error)
+	IngestHookEvent(ctx context.Context, name string, payload agentpkg.HookPayload, raw []byte) error
+}
+
+// runProviderFailureMonitor reports agents whose provider CLI is up but cannot
+// serve a turn. It returns when ctx is canceled.
+func runProviderFailureMonitor(ctx context.Context, agents *agentpkg.AgentService) {
+	if agents == nil {
+		return
+	}
+	ticker := time.NewTicker(failureSweepInterval)
+	defer ticker.Stop()
+
+	// Remembers the reason already reported for an agent so one broken agent
+	// produces one event, not one every sweep for as long as it stays broken.
+	reported := make(map[string]string)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweepForFailedProviders(ctx, agents, reported, time.Now())
+		}
+	}
+}
+
+// sweepForFailedProviders runs a single pass over the agent list.
+func sweepForFailedProviders(ctx context.Context, deps failureMonitorDeps, reported map[string]string, now time.Time) {
+	list, err := deps.List(ctx, agentpkg.ListOptions{})
+	if err != nil {
+		log.Debug("failure monitor: agent list failed", "error", err)
+		return
+	}
+
+	live := make(map[string]struct{}, len(list))
+	for _, a := range list {
+		if a == nil {
+			continue
+		}
+		live[a.Name] = struct{}{}
+
+		detector := failureDetectorFor(a)
+		if detector == nil {
+			continue
+		}
+		if !worthReadingTerminal(a, now) {
+			continue
+		}
+
+		pane, err := deps.Peek(ctx, a.Name, failurePaneLines)
+		if err != nil {
+			// A session that cannot be read is not evidence of anything: the
+			// agent may be in a container, or already gone.
+			log.Debug("failure monitor: peek failed", "agent", a.Name, "error", err)
+			continue
+		}
+		reason, failed := detector.DetectFailure(pane)
+		if !failed {
+			// Recovered, or never broken. Forget any earlier reason so a
+			// recurrence is reported again rather than silently deduped.
+			delete(reported, a.Name)
+			continue
+		}
+		if reported[a.Name] == reason {
+			continue
+		}
+		reported[a.Name] = reason
+
+		payload := agentpkg.HookPayload{
+			Event:   agentpkg.HookProviderFailure,
+			Error:   reason,
+			Message: reason,
+		}
+		if err := deps.IngestHookEvent(ctx, a.Name, payload, nil); err != nil {
+			// Let the next sweep try again rather than swallowing the report.
+			delete(reported, a.Name)
+			log.Debug("failure monitor: ingest failed", "agent", a.Name, "error", err)
+			continue
+		}
+		log.Info("agent's provider cannot serve a turn", "agent", a.Name, "tool", a.Tool, "reason", reason)
+	}
+
+	// Drop bookkeeping for agents that no longer exist.
+	for name := range reported {
+		if _, ok := live[name]; !ok {
+			delete(reported, name)
+		}
+	}
+}
+
+// failureDetectorFor returns the failure detector for an agent's provider, or
+// nil when the provider does not offer one.
+func failureDetectorFor(a *agentpkg.Agent) provider.FailureDetector {
+	if a.Tool == "" {
+		return nil
+	}
+	p, ok := provider.DefaultRegistry.Get(a.Tool)
+	if !ok {
+		return nil
+	}
+	d, ok := p.(provider.FailureDetector)
+	if !ok {
+		return nil
+	}
+	return d
+}
+
+// worthReadingTerminal reports whether an agent is quiet enough that reading its
+// terminal is justified.
+//
+// Agents already in a terminal state are skipped: stopped and done agents have
+// nothing to diagnose, and an agent already in error has been reported. Everyone
+// else has to have been silent for failureQuietFor — UpdatedAt moves on every
+// ingested event, so a working agent is never inspected mid-turn.
+func worthReadingTerminal(a *agentpkg.Agent, now time.Time) bool {
+	switch a.State {
+	case agentpkg.StateStopped, agentpkg.StateDone, agentpkg.StateError:
+		return false
+	}
+	if a.UpdatedAt.IsZero() {
+		return false
+	}
+	return now.Sub(a.UpdatedAt) >= failureQuietFor
+}

--- a/server/provider_failure_monitor_test.go
+++ b/server/provider_failure_monitor_test.go
@@ -1,0 +1,227 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	agentpkg "github.com/rpuneet/mycel/pkg/agent"
+)
+
+// fakeFailureDeps stands in for the agent service so a sweep can be driven
+// without a tmux session.
+type fakeFailureDeps struct {
+	agents    []*agentpkg.Agent
+	panes     map[string]string
+	peekErr   map[string]error
+	peeked    []string
+	ingested  []agentpkg.HookPayload
+	ingestErr error
+	listErr   error
+}
+
+func (f *fakeFailureDeps) List(context.Context, agentpkg.ListOptions) ([]*agentpkg.Agent, error) {
+	return f.agents, f.listErr
+}
+
+func (f *fakeFailureDeps) Peek(_ context.Context, name string, _ int) (string, error) {
+	f.peeked = append(f.peeked, name)
+	if err, ok := f.peekErr[name]; ok {
+		return "", err
+	}
+	return f.panes[name], nil
+}
+
+func (f *fakeFailureDeps) IngestHookEvent(_ context.Context, _ string, p agentpkg.HookPayload, _ []byte) error {
+	if f.ingestErr != nil {
+		return f.ingestErr
+	}
+	f.ingested = append(f.ingested, p)
+	return nil
+}
+
+// A pi agent that cannot reach its model, verbatim from #3512.
+const brokenPiPane = ` Error: 404 The model ` + "`qwen/qwen3-32b`" + ` does not exist or you do not have access to it.
+~/.mycel/agents/fierce-osprey/worktree (detached)`
+
+func quietPiAgent(name string, state agentpkg.State, quietFor time.Duration, now time.Time) *agentpkg.Agent {
+	return &agentpkg.Agent{
+		Name:      name,
+		Tool:      "pi",
+		State:     state,
+		UpdatedAt: now.Add(-quietFor),
+	}
+}
+
+func TestSweepReportsAQuietAgentWhoseProviderCannotWork(t *testing.T) {
+	now := time.Now()
+	deps := &fakeFailureDeps{
+		agents: []*agentpkg.Agent{quietPiAgent("osprey", agentpkg.StateWorking, time.Hour, now)},
+		panes:  map[string]string{"osprey": brokenPiPane},
+	}
+
+	sweepForFailedProviders(context.Background(), deps, map[string]string{}, now)
+
+	if len(deps.ingested) != 1 {
+		t.Fatalf("ingested %d events, want 1", len(deps.ingested))
+	}
+	got := deps.ingested[0]
+	if got.Event != agentpkg.HookProviderFailure {
+		t.Errorf("event = %q, want %q", got.Event, agentpkg.HookProviderFailure)
+	}
+	if got.Error == "" {
+		t.Error("the event must carry the reason — it is the only place the user can read it")
+	}
+	// The event has to move the agent out of a state that claims it is fine.
+	if state, ok := agentpkg.StateForHookEvent(got.Event); !ok || state != agentpkg.StateError {
+		t.Errorf("ProviderFailure maps to state %q (ok=%v), want %q", state, ok, agentpkg.StateError)
+	}
+}
+
+func TestSweepLeavesBusyAgentsAlone(t *testing.T) {
+	// An agent that reported something a moment ago is working. Reading its
+	// terminal risks calling a healthy agent broken, and costs a capture per
+	// agent per sweep for nothing.
+	now := time.Now()
+	deps := &fakeFailureDeps{
+		agents: []*agentpkg.Agent{quietPiAgent("busy", agentpkg.StateWorking, 5*time.Second, now)},
+		panes:  map[string]string{"busy": brokenPiPane},
+	}
+
+	sweepForFailedProviders(context.Background(), deps, map[string]string{}, now)
+
+	if len(deps.peeked) != 0 {
+		t.Errorf("peeked %v, want no terminal read for a recently active agent", deps.peeked)
+	}
+	if len(deps.ingested) != 0 {
+		t.Errorf("ingested %d events, want none", len(deps.ingested))
+	}
+}
+
+func TestSweepSkipsAgentsWithNothingToDiagnose(t *testing.T) {
+	now := time.Now()
+	for _, state := range []agentpkg.State{
+		agentpkg.StateStopped,
+		agentpkg.StateDone,
+		agentpkg.StateError,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			deps := &fakeFailureDeps{
+				agents: []*agentpkg.Agent{quietPiAgent("a", state, time.Hour, now)},
+				panes:  map[string]string{"a": brokenPiPane},
+			}
+			sweepForFailedProviders(context.Background(), deps, map[string]string{}, now)
+			if len(deps.peeked) != 0 {
+				t.Errorf("peeked a %s agent", state)
+			}
+		})
+	}
+}
+
+func TestSweepReportsOneEventPerFailure(t *testing.T) {
+	// A broken agent stays broken. Re-reporting it every 30 seconds would bury
+	// the feed it was meant to explain.
+	now := time.Now()
+	deps := &fakeFailureDeps{
+		agents: []*agentpkg.Agent{quietPiAgent("osprey", agentpkg.StateIdle, time.Hour, now)},
+		panes:  map[string]string{"osprey": brokenPiPane},
+	}
+	reported := map[string]string{}
+
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+
+	if len(deps.ingested) != 1 {
+		t.Errorf("ingested %d events across three sweeps, want 1", len(deps.ingested))
+	}
+}
+
+func TestSweepReportsAgainAfterRecovery(t *testing.T) {
+	now := time.Now()
+	deps := &fakeFailureDeps{
+		agents: []*agentpkg.Agent{quietPiAgent("osprey", agentpkg.StateIdle, time.Hour, now)},
+		panes:  map[string]string{"osprey": brokenPiPane},
+	}
+	reported := map[string]string{}
+
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+	// The user fixes the model and the agent goes quiet again for other reasons.
+	deps.panes["osprey"] = "● Read main.go\n> "
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+	// It breaks a second time; the user has to hear about it again.
+	deps.panes["osprey"] = brokenPiPane
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+
+	if len(deps.ingested) != 2 {
+		t.Errorf("ingested %d events, want 2 — one per failure episode", len(deps.ingested))
+	}
+}
+
+func TestSweepRetriesWhenReportingFailed(t *testing.T) {
+	// If the report itself did not land, the agent is still broken and still
+	// unexplained, so the next sweep has to try again.
+	now := time.Now()
+	deps := &fakeFailureDeps{
+		agents:    []*agentpkg.Agent{quietPiAgent("osprey", agentpkg.StateIdle, time.Hour, now)},
+		panes:     map[string]string{"osprey": brokenPiPane},
+		ingestErr: errors.New("store unavailable"),
+	}
+	reported := map[string]string{}
+
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+	if len(reported) != 0 {
+		t.Fatalf("remembered a report that failed to land: %v", reported)
+	}
+
+	deps.ingestErr = nil
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+	if len(deps.ingested) != 1 {
+		t.Errorf("ingested %d events, want the retry to succeed", len(deps.ingested))
+	}
+}
+
+func TestSweepIgnoresAgentsWhoseTerminalCannotBeRead(t *testing.T) {
+	// A container agent, or one whose session has gone: not evidence of a
+	// provider failure.
+	now := time.Now()
+	deps := &fakeFailureDeps{
+		agents:  []*agentpkg.Agent{quietPiAgent("gone", agentpkg.StateIdle, time.Hour, now)},
+		peekErr: map[string]error{"gone": errors.New("no such session")},
+	}
+
+	sweepForFailedProviders(context.Background(), deps, map[string]string{}, now)
+
+	if len(deps.ingested) != 0 {
+		t.Errorf("ingested %d events for an unreadable terminal, want none", len(deps.ingested))
+	}
+}
+
+func TestSweepIgnoresProvidersWithoutADetector(t *testing.T) {
+	now := time.Now()
+	a := quietPiAgent("claude-agent", agentpkg.StateIdle, time.Hour, now)
+	a.Tool = "claude"
+	deps := &fakeFailureDeps{
+		agents: []*agentpkg.Agent{a},
+		panes:  map[string]string{"claude-agent": brokenPiPane},
+	}
+
+	sweepForFailedProviders(context.Background(), deps, map[string]string{}, now)
+
+	if len(deps.peeked) != 0 {
+		t.Errorf("peeked %v, want no read for a provider that declares no patterns", deps.peeked)
+	}
+}
+
+func TestSweepForgetsAgentsThatNoLongerExist(t *testing.T) {
+	now := time.Now()
+	deps := &fakeFailureDeps{}
+	reported := map[string]string{"deleted": "some old reason"}
+
+	sweepForFailedProviders(context.Background(), deps, reported, now)
+
+	if _, ok := reported["deleted"]; ok {
+		t.Error("bookkeeping for a deleted agent must not be kept forever")
+	}
+}

--- a/server/provider_failure_monitor_test.go
+++ b/server/provider_failure_monitor_test.go
@@ -12,13 +12,13 @@ import (
 // fakeFailureDeps stands in for the agent service so a sweep can be driven
 // without a tmux session.
 type fakeFailureDeps struct {
-	agents    []*agentpkg.Agent
 	panes     map[string]string
 	peekErr   map[string]error
-	peeked    []string
-	ingested  []agentpkg.HookPayload
 	ingestErr error
 	listErr   error
+	agents    []*agentpkg.Agent
+	peeked    []string
+	ingested  []agentpkg.HookPayload
 }
 
 func (f *fakeFailureDeps) List(context.Context, agentpkg.ListOptions) ([]*agentpkg.Agent, error) {

--- a/web/src/components/live/liveHelpers.ts
+++ b/web/src/components/live/liveHelpers.ts
@@ -298,8 +298,41 @@ export function partitionRunning(nodes: ToolNode[]): { running: ToolNode[]; rest
  * ToolNode shape the live stream builds, so both render through one
  * EventRow.
  */
+/**
+ * The row for an agent whose provider CLI cannot serve a turn.
+ *
+ * Shared by the live stream and the historical load so both render the same
+ * thing. A provider failure is not a tool call, and left to the generic path
+ * its name is guessed from the first word of the reason — a row titled "pi's".
+ * See #3512.
+ */
+export const PROVIDER_FAILURE_LABEL = "Provider unavailable";
+
+export function providerFailureNode(reason: string, startTime: number): ToolNode {
+  const text = reason || "the provider cannot serve a turn";
+  return {
+    id: nextId(),
+    toolName: PROVIDER_FAILURE_LABEL,
+    args: text,
+    fullInput: null,
+    fullOutput: null,
+    startTime,
+    endTime: startTime,
+    status: "failed",
+    error: text,
+    children: [],
+  };
+}
+
 export function activityItemToNode(item: AgentActivityItem): ToolNode {
   const data = (item.data ?? {}) as Record<string, unknown>;
+  if (item.event === "ProviderFailure") {
+    const reason = (typeof data.error === "string" && data.error) || item.message || "";
+    return providerFailureNode(
+      reason,
+      item.timestamp ? new Date(item.timestamp).getTime() : Date.now(),
+    );
+  }
   const dataToolName = typeof data.tool_name === "string" ? data.tool_name : "";
   const toolName = dataToolName || parseHistoricalToolName(item) || item.event || "unknown";
 

--- a/web/src/hooks/__tests__/useAgentActivity.test.ts
+++ b/web/src/hooks/__tests__/useAgentActivity.test.ts
@@ -158,6 +158,52 @@ describe("useAgentActivity — full event coverage", () => {
   });
 });
 
+describe("useAgentActivity — a provider that cannot serve a turn", () => {
+  it("turns the failure into a row carrying the reason, and marks the agent errored", async () => {
+    // This event is the only thing such an agent ever produces: its CLI refuses
+    // every turn and reports nothing, so without this row the feed stays empty
+    // and the state keeps claiming the agent is fine. See #3512.
+    const { result } = renderHook(() => useAgentActivity());
+    await tick(0);
+
+    act(() => {
+      emit("agent.hook", {
+        agent: "osprey",
+        event: "ProviderFailure",
+        error: "pi's model is unavailable to this account — pick another model for this agent",
+      });
+    });
+    await tick();
+
+    const osprey = result.current.activities.get("osprey");
+    expect(osprey).toBeDefined();
+    expect(osprey!.state).toBe("error");
+
+    const node = osprey!.nodes.find((n) => n.toolName === "Provider unavailable");
+    expect(node).toBeDefined();
+    expect(node!.status).toBe("failed");
+    // The reason has to reach both the row's summary and its error slot, since
+    // the two are rendered in different places.
+    expect(node!.args).toContain("model is unavailable");
+    expect(node!.error).toContain("model is unavailable");
+  });
+
+  it("still says something useful when the reason is missing", async () => {
+    const { result } = renderHook(() => useAgentActivity());
+    await tick(0);
+
+    act(() => {
+      emit("agent.hook", { agent: "gecko", event: "ProviderFailure" });
+    });
+    await tick();
+
+    const node = result.current.activities
+      .get("gecko")!
+      .nodes.find((n) => n.toolName === "Provider unavailable");
+    expect(node!.error).toBeTruthy();
+  });
+});
+
 describe("useAgentActivity — ElicitationResult clears the running node", () => {
   it("finalizes a pending Elicitation node when its result arrives", async () => {
     const { result } = renderHook(() => useAgentActivity());

--- a/web/src/hooks/useAgentActivity.ts
+++ b/web/src/hooks/useAgentActivity.ts
@@ -43,6 +43,7 @@ import {
   parseTaskCreate,
   parseTaskListResponse,
   parseTaskUpdate,
+  providerFailureNode,
   summarizeArgs,
   summarizeInternalEvent,
   updateSubagentChild,
@@ -283,6 +284,18 @@ export function useAgentActivity(agentName?: string, options?: UseAgentActivityO
               fullInput: evt.prompt ?? evt.tool_input, fullOutput: null, status: "completed",
               startTime: Date.now(), endTime: Date.now(), children: [],
             });
+            break;
+
+          // The daemon raises this when an agent's provider CLI is running but
+          // cannot serve a turn — no credential, a spent quota, a model the
+          // account can't use. Such an agent reports nothing else, so this row
+          // is the entire explanation for a feed that would otherwise be empty
+          // and a state that would otherwise claim the agent is fine (#3512).
+          case "ProviderFailure":
+            activity.state = "error";
+            activity.nodes.push(
+              providerFailureNode(evt.error ?? evt.message ?? "", Date.now()),
+            );
             break;
 
           case "PreToolUse": {


### PR DESCRIPTION
Fixes #3512.

## The problem

mycel derives agent state from what an agent reports. That works until the provider refuses every turn — no API key, a spent quota, a model the account isn't entitled to. Such an agent reports nothing at all, so it keeps whatever state it last had and its Live feed stays empty.

Three agents on one machine were in exactly that state, and mycel called them healthy the whole time:

| Agent | mycel said | Its terminal said |
| --- | --- | --- |
| `fierce-osprey` (pi) | working, since 2 July | `Error: 404 The model 'meta-llama/llama-4-scout-17b-16e-instruct' does not exist or you do not have access to it.` |
| `calm-gecko` (pi) | idle | `Error: No API key found for amazon-bedrock.` |
| `hazy-gecko` (agy) | starting | `⚠ Individual quota reached… Resets in 156h34m52s.` |

## The approach

The reason exists only on the terminal, so the terminal becomes what it is — a last-resort activity source for fatal conditions. Providers declare the lines that mean "this agent cannot serve a turn" (`provider.FailureDetector`), and a daemon monitor matches them against recent pane output. A match is ingested as a `ProviderFailure` event through the same path as any hook, so it moves the agent to `error` and lands in the feed that was empty.

Three things keep it from lying:

1. **Silence gates the pane read.** An agent that reported anything in the last two minutes is never inspected, so a busy agent is never judged by its screen — and the expensive check runs only where the cheap one already found something wrong.
2. **A match needs the provider's own error marker at the start of a line.** An agent *discussing* a missing API key writes lines containing that phrase; only the CLI writes a line beginning `Error:` that contains it. There is a test for this, because the first draft of the patterns failed it.
3. **Only unrecoverable conditions count.** A missing credential, an exhausted quota, an unusable model — not a rate limit the agent will retry.

Detectors ship for pi and agy, the providers whose fatal output was observed first-hand. Every pattern and fixture is quoted verbatim from a real stuck agent, so they stop passing if the real message changes. Other providers opt in by implementing the interface.

## Verified end to end

Built, installed, and run against the three agents above. Within one sweep all three moved to `error` with distinct correct reasons, and the three healthy cursor agents were left alone:

```
msg="agent's provider cannot serve a turn" agent=calm-gecko    tool=pi  reason="pi has no API key for its configured provider — run /login in the agent's terminal"
msg="agent's provider cannot serve a turn" agent=fierce-osprey tool=pi  reason="pi's model is unavailable to this account — pick another model for this agent"
msg="agent's provider cannot serve a turn" agent=hazy-gecko    tool=agy reason="agy's quota is exhausted — it resets on its own, or raise the limit on the account"
```

The Live tab for `hazy-gecko` now reads:

> **Provider unavailable** — agy's quota is exhausted — it resets on its own, or raise the limit on the account

Two bugs surfaced only because this was checked against a real daemon rather than unit tests alone: captured panes carry ANSI colour, so the error line does not literally start with `Error:` (the detector now strips escape sequences), and the historical-load path built the row through the generic tool-name guesser, titling it `pi's` after the first word of the reason.

## Test plan

- [x] `go test ./pkg/provider/ ./pkg/agent/ ./server/` — all pass, including false-positive and ANSI cases
- [x] `npx vitest run` — 52 files, 452 tests; `tsc --noEmit` and `npm run lint` clean
- [x] Verified against the three real stuck agents, and against three healthy agents that must not be flagged

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of provider failures, including quota exhaustion, missing API keys, and unavailable models.
  * Quiet agents are now monitored and report detected provider issues automatically.
  * Provider failures appear in activity feeds as “Provider unavailable” errors with actionable details.

* **Bug Fixes**
  * Improved handling of terminal output, including colored and multiline error messages.
  * Prevented duplicate failure reports while allowing reporting again after recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->