### PR TITLE
fix: resolve the daemon address when a hook fires, not when it is written

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"syscall"
 
 	dbpkg "github.com/rpuneet/mycel/pkg/db"
@@ -190,49 +189,17 @@ func RunServerCtx(ctx context.Context, addr, repoRoot, corsOrigin, apiKey string
 		BuiltAt: date,
 	}
 
-	// Rewrite agent hook settings to point at the actual the daemon address.
-	updateAgentHookPorts(h, cfg.Addr)
+	// Bring existing agents' hook configs up to date with the current
+	// generators, so agents created against an older daemon stop reporting to
+	// the address that was current when they were made.
+	if svc.AgentMgr != nil {
+		if n := svc.AgentMgr.RefreshActivityConfigs(); n > 0 {
+			log.Info("refreshed agent activity configs", "agents", n)
+		}
+	}
 
 	srv := server.New(cfg, svc, globalHub, server.WebDist())
 	return srv.Start(ctx)
-}
-
-// updateAgentHookPorts rewrites agent hook settings to use the current the daemon address.
-// This is necessary because existing tmux sessions don't inherit the MYCEL_DAEMON_ADDR
-// environment variable that is set in the daemon process env.
-func updateAgentHookPorts(h *home.Home, listenAddr string) {
-	daemonURL := "http://" + listenAddr
-	agentsDir := filepath.Join(h.StateDir(), "agents")
-	entries, err := os.ReadDir(agentsDir)
-	if err != nil {
-		return
-	}
-
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		agentName := e.Name()
-		settingsGlob := filepath.Join(agentsDir, agentName, "*", ".claude", "settings.json")
-		matches, _ := filepath.Glob(settingsGlob) //nolint:errcheck // Glob only errors on bad pattern
-		for _, settingsPath := range matches {
-			data, readErr := os.ReadFile(settingsPath) //nolint:gosec // path is the result of filepath.Glob under the agents dir
-			if readErr != nil {
-				continue
-			}
-			content := string(data)
-			updated := strings.ReplaceAll(content, "http://127.0.0.1:9374", daemonURL)
-			updated = strings.ReplaceAll(updated, "${MYCEL_DAEMON_ADDR:-http://127.0.0.1:9374}", daemonURL)
-
-			if updated != content {
-				if writeErr := os.WriteFile(settingsPath, []byte(updated), 0644); writeErr != nil { //nolint:gosec // agent settings file
-					log.Warn("failed to update hook port", "path", settingsPath, "error", writeErr)
-					continue
-				}
-				log.Info("updated hook port", "agent", agentName, "addr", daemonURL)
-			}
-		}
-	}
 }
 
 func writePID(path string) error {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -984,6 +984,49 @@ func (m *Manager) writeActivityConfig(toolName, wtDir, agentName string) error {
 	return provider.WriteClaudeHookSettings(wtDir)
 }
 
+// RefreshActivityConfigs regenerates every existing agent's activity config from
+// the current generators, and reports how many it rewrote.
+//
+// New configs resolve the daemon address per event, but the ones already on disk
+// were written by older versions of mycel and hold a literal: an agent created
+// while the daemon listened on :8080 has :8080 in its hook config, and agents old
+// enough to predate the rename still reference BC_BCD_ADDR, a variable nothing
+// sets any more. Those hooks fire, fail to connect, and are dropped in silence —
+// the agent's state still updates from what the daemon observes, so it looks
+// present while everything a hook would have carried (the prompt, each tool call,
+// its result) never arrives (#3510).
+//
+// Regenerating is preferred over patching the addresses in place: the provider's
+// own writer is the definition of a correct config, so this needs no list of
+// past mistakes to recognize, and it is idempotent for an agent already correct.
+// A worktree that has since been deleted is skipped rather than recreated.
+func (m *Manager) RefreshActivityConfigs() int {
+	m.mu.Lock()
+	type target struct{ name, tool, worktree string }
+	targets := make([]target, 0, len(m.agents))
+	for name, a := range m.agents {
+		if a == nil || a.WorktreeDir == "" {
+			continue
+		}
+		targets = append(targets, target{name: name, tool: a.Tool, worktree: a.WorktreeDir})
+	}
+	m.mu.Unlock()
+
+	refreshed := 0
+	for _, t := range targets {
+		if _, err := os.Stat(t.worktree); err != nil {
+			continue
+		}
+		if err := m.writeActivityConfig(t.tool, t.worktree, t.name); err != nil {
+			log.Warn("could not refresh agent activity config — its hooks may still report to a stale address",
+				"agent", t.name, "tool", t.tool, "error", err)
+			continue
+		}
+		refreshed++
+	}
+	return refreshed
+}
+
 // SetBootstrapDelay sets the delay before sending bootstrap prompts.
 func (m *Manager) SetBootstrapDelay(d time.Duration) {
 	m.mu.Lock()
@@ -1287,8 +1330,10 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 		"MYCEL_AGENT_ROLE":    string(existing.Role),
 		"MYCEL_WORKSPACE":     repoPath,
 		"MYCEL_AGENT_RUNTIME": agentRuntime,
-		"MYCEL_DAEMON_ADDR":   daemonAddrForRuntime(agentRuntime),
 		"MYCEL_WORKTREE_NAME": worktreeName,
+	}
+	if addr := daemonAddrEnvForRuntime(agentRuntime); addr != "" {
+		env["MYCEL_DAEMON_ADDR"] = addr
 	}
 	if toolName != "" {
 		env["MYCEL_AGENT_TOOL"] = toolName
@@ -1533,8 +1578,10 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 		"MYCEL_AGENT_ROLE":    string(role),
 		"MYCEL_WORKSPACE":     repoPath,
 		"MYCEL_AGENT_RUNTIME": agentRuntime,
-		"MYCEL_DAEMON_ADDR":   daemonAddrForRuntime(agentRuntime),
 		"MYCEL_WORKTREE_NAME": name,
+	}
+	if addr := daemonAddrEnvForRuntime(agentRuntime); addr != "" {
+		env["MYCEL_DAEMON_ADDR"] = addr
 	}
 	if effectiveTool != "" {
 		env["MYCEL_AGENT_TOOL"] = effectiveTool
@@ -3137,26 +3184,69 @@ func (m *Manager) enforceRootSingleton(_ string) error {
 	return nil
 }
 
-// daemonAddrForRuntime returns the daemon server address for the given runtime.
-// Docker containers reach the host via host.docker.internal.
-// If MYCEL_DAEMON_ADDR is set in the environment, it is used as the base address
-// (with host.docker.internal substituted for Docker runtimes).
-func daemonAddrForRuntime(rt string) string {
-	if addr := os.Getenv("MYCEL_DAEMON_ADDR"); addr != "" {
-		// Normalize empty hostname: "http://:9374" → "http://127.0.0.1:9374"
-		if u, parseErr := url.Parse(addr); parseErr == nil && u.Hostname() == "" && u.Port() != "" {
-			u.Host = net.JoinHostPort("127.0.0.1", u.Port())
-			addr = u.String()
-		}
-		if rt == "docker" {
-			// Replace localhost/127.0.0.1 with host.docker.internal for Docker
-			addr = strings.ReplaceAll(addr, "127.0.0.1", "host.docker.internal")
-			addr = strings.ReplaceAll(addr, "localhost", "host.docker.internal")
-		}
-		return addr
+// daemonAddrEnvForRuntime returns the daemon address to export into an agent's
+// environment, and "" when the agent should discover it for itself.
+//
+// A local agent shares the daemon's home directory, so it can read the address
+// the running daemon publishes at run/daemon.addr. Exporting a literal instead
+// hands it an address that is only true on the day the agent is created: the
+// daemon later restarts on another port, the exported value keeps pointing at
+// the old one, and every hook the agent fires goes to a port nobody is
+// listening on. Nothing reports that — curl fails silently, so the agent simply
+// looks quiet (#3510). Exporting nothing is what makes it resolve the daemon per
+// call instead of remembering one.
+//
+// A Docker agent has no such option: it does not share the home directory, so
+// there the address is exported, translated to the container's view of the host.
+func daemonAddrEnvForRuntime(rt string) string {
+	if rt != "docker" {
+		return ""
 	}
+	return daemonAddrForRuntime(rt)
+}
+
+// daemonAddrForRuntime returns a concrete, dialable base URL for this daemon as
+// seen from the given runtime. Callers that must write a fixed address into a
+// config file need this; anything that can defer resolution to call time should.
+func daemonAddrForRuntime(rt string) string {
+	addr := publishedDaemonAddr()
+	// Normalize an empty hostname ("http://:9374") before rewriting the host,
+	// so the port is not the only thing the container is told.
+	if u, err := url.Parse(addr); err == nil && u.Hostname() == "" && u.Port() != "" {
+		u.Host = net.JoinHostPort("127.0.0.1", u.Port())
+		addr = u.String()
+	}
+	// A wildcard bind is what the daemon listens on, not something anything can
+	// dial; from inside a container the host's own names for itself mean the
+	// container.
+	target := "127.0.0.1"
 	if rt == "docker" {
-		return "http://host.docker.internal:9374"
+		target = "host.docker.internal"
+	}
+	for _, hostLocal := range []string{"0.0.0.0", "localhost", "127.0.0.1"} {
+		if hostLocal == target {
+			continue
+		}
+		addr = strings.ReplaceAll(addr, hostLocal, target)
+	}
+	return addr
+}
+
+// publishedDaemonAddr returns where the daemon is listening, preferring the
+// address the running daemon published over the one this process was started
+// with. The port is not a constant — `mycel up --addr` chooses it — so assuming
+// the default here would hand a container the wrong port whenever an operator
+// picked their own.
+func publishedDaemonAddr() string {
+	if path, err := home.DaemonAddrPath(); err == nil {
+		if data, readErr := os.ReadFile(path); readErr == nil { //nolint:gosec // path comes from home, not user input
+			if addr := strings.TrimSpace(string(data)); addr != "" {
+				return addr
+			}
+		}
+	}
+	if addr := os.Getenv("MYCEL_DAEMON_ADDR"); addr != "" {
+		return addr
 	}
 	return "http://127.0.0.1:9374"
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -3470,6 +3470,118 @@ func TestEffectiveToolExplicit(t *testing.T) {
 	}
 }
 
+// TestRefreshActivityConfigsHealsAStaleAddress covers the migration half of
+// #3510: agents already on disk hold a hook config written by an older mycel,
+// pointing at whichever port was current then — or, for agents old enough,
+// referencing BC_BCD_ADDR, a variable the rename left behind and nothing sets.
+// Their hooks fire into nothing, and because state still comes from what the
+// daemon observes, the agent looks fine while every prompt, tool call and result
+// a hook would have carried is lost.
+func TestRefreshActivityConfigsHealsAStaleAddress(t *testing.T) {
+	m := newTestManager(t)
+
+	worktree := t.TempDir()
+	claudeDir := filepath.Join(worktree, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o750); err != nil {
+		t.Fatalf("create .claude: %v", err)
+	}
+	settings := filepath.Join(claudeDir, "settings.json")
+	// Verbatim shape of the configs found on a real machine, where 25 of 27
+	// agents pointed at a port nothing had listened on for weeks.
+	stale := `{"hooks":{"SessionStart":[{"hooks":[{"type":"command",` +
+		`"command":"bash -c 'curl -sX POST ${BC_BCD_ADDR:-http://0.0.0.0:8080}/api/agents/${MYCEL_AGENT_ID}/hook'"}]}]}}`
+	if err := os.WriteFile(settings, []byte(stale), 0o600); err != nil {
+		t.Fatalf("write stale settings: %v", err)
+	}
+
+	m.mu.Lock()
+	m.agents["ghost"] = &Agent{Name: "ghost", Tool: "claude", WorktreeDir: worktree}
+	m.mu.Unlock()
+
+	if n := m.RefreshActivityConfigs(); n != 1 {
+		t.Fatalf("refreshed %d configs, want 1", n)
+	}
+
+	data, err := os.ReadFile(settings) //nolint:gosec // test-owned path
+	if err != nil {
+		t.Fatalf("read refreshed settings: %v", err)
+	}
+	got := string(data)
+	if strings.Contains(got, "BC_BCD_ADDR") {
+		t.Error("the refreshed config still reads BC_BCD_ADDR, a variable nothing sets — its hooks would keep falling back to the baked address")
+	}
+	if strings.Contains(got, "8080") {
+		t.Error("the refreshed config still points at the stale port 8080")
+	}
+	if !strings.Contains(got, "run/daemon.addr") {
+		t.Errorf("the refreshed config does not consult the published address, so it will go stale again:\n%s", got)
+	}
+}
+
+// TestRefreshActivityConfigsSkipsAMissingWorktree keeps the refresh from
+// resurrecting directories: an agent whose worktree was deleted should be passed
+// over, not rebuilt as a side effect of starting the daemon.
+func TestRefreshActivityConfigsSkipsAMissingWorktree(t *testing.T) {
+	m := newTestManager(t)
+
+	gone := filepath.Join(t.TempDir(), "deleted-worktree")
+	m.mu.Lock()
+	m.agents["vanished"] = &Agent{Name: "vanished", Tool: "claude", WorktreeDir: gone}
+	m.mu.Unlock()
+
+	if n := m.RefreshActivityConfigs(); n != 0 {
+		t.Errorf("refreshed %d configs, want 0 for a worktree that no longer exists", n)
+	}
+	if _, err := os.Stat(gone); err == nil {
+		t.Error("the refresh recreated a deleted worktree")
+	}
+}
+
+// TestDaemonAddrEnvForRuntime covers what mycel exports into an agent's session.
+// A local agent must be told nothing, because anything it is told it remembers:
+// an address exported at creation stays in the session after the daemon restarts
+// elsewhere, and every hook then POSTs to a port nobody is listening on with no
+// sign that anything is wrong (#3510). A container cannot read the published
+// address, so it is the one case that still needs telling.
+func TestDaemonAddrEnvForRuntime(t *testing.T) {
+	t.Setenv("MYCEL_DAEMON_ADDR", "http://127.0.0.1:8080")
+
+	if got := daemonAddrEnvForRuntime("tmux"); got != "" {
+		t.Errorf("a local agent was handed %q; it must resolve the daemon per call instead of remembering one", got)
+	}
+	if got := daemonAddrEnvForRuntime("docker"); got != "http://host.docker.internal:8080" {
+		t.Errorf("a container was handed %q, want http://host.docker.internal:8080", got)
+	}
+}
+
+// TestPublishedDaemonAddrPrefersTheAddrFile pins the precedence that makes the
+// stale-address bug impossible: the file is written by whichever daemon is
+// running now, while the environment preserves whatever was true when this
+// process started.
+func TestPublishedDaemonAddrPrefersTheAddrFile(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	t.Setenv("MYCEL_DAEMON_ADDR", "http://127.0.0.1:8080")
+
+	if got := publishedDaemonAddr(); got != "http://127.0.0.1:8080" {
+		t.Fatalf("with nothing published, got %q, want the environment's http://127.0.0.1:8080", got)
+	}
+
+	addrPath, err := home.DaemonAddrPath()
+	if err != nil {
+		t.Fatalf("resolve daemon.addr path: %v", err)
+	}
+	if mkErr := os.MkdirAll(filepath.Dir(addrPath), 0o750); mkErr != nil {
+		t.Fatalf("create run dir: %v", mkErr)
+	}
+	if wErr := os.WriteFile(addrPath, []byte("http://127.0.0.1:9374\n"), 0o600); wErr != nil {
+		t.Fatalf("publish address: %v", wErr)
+	}
+
+	if got := publishedDaemonAddr(); got != "http://127.0.0.1:9374" {
+		t.Errorf("got %q, want the published http://127.0.0.1:9374 — a running daemon outranks a remembered address", got)
+	}
+}
+
 func TestDaemonAddrForRuntime_NormalizesEmptyHost(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/provider/agy_hooks.go
+++ b/pkg/provider/agy_hooks.go
@@ -56,9 +56,9 @@ const agyHookTimeoutSecs = 5
 
 // agyHookCommand builds the shell command an agy hook runs. It merges mycel's
 // event/state fields into the payload agy pipes in on stdin, POSTs the result to
-// the daemon, and prints the JSON result agy expects on stdout. daemonAddr and
-// agentID are resolved at runtime from the MYCEL_DAEMON_ADDR / MYCEL_AGENT_ID
-// environment variables set on the agent session, matching the claude provider.
+// the daemon, and prints the JSON result agy expects on stdout. The agent ID is
+// resolved at runtime from MYCEL_AGENT_ID and the daemon address through
+// DaemonAddrShell, matching the claude provider.
 //
 // It previously discarded stdin (`cat >/dev/null`) and POSTed only the three
 // fields known at generation time. Everything agy reports about a turn — the
@@ -78,7 +78,7 @@ const agyHookTimeoutSecs = 5
 // was asked to do belongs. The task line is derived from the prompt on a turn
 // start; the lifecycle meaning those strings carried is already in state.
 func agyHookCommand(event, state, stdout string) string {
-	const daemonAddr = "${MYCEL_DAEMON_ADDR:-http://127.0.0.1:9374}"
+	const daemonAddr = DaemonAddrShell
 	fallback := fmt.Sprintf(`{\"event\":\"%s\",\"state\":\"%s\"}`, event, state)
 	return fmt.Sprintf(
 		`bash -c 'RAW=$(cat); PAYLOAD=$(echo "$RAW" | jq -c ". + {event:\"%s\",state:\"%s\"}" 2>/dev/null || echo "%s"); `+

--- a/pkg/provider/claude_hooks.go
+++ b/pkg/provider/claude_hooks.go
@@ -47,9 +47,9 @@ func WriteClaudeHookSettings(repoRoot string) error {
 		return fmt.Errorf("create .claude dir: %w", err)
 	}
 
-	// Hook commands use $MYCEL_DAEMON_ADDR env var (set per-agent based on runtime).
-	// Falls back to localhost for backward compat.
-	daemonAddr := "${MYCEL_DAEMON_ADDR:-http://127.0.0.1:9374}"
+	// Hook commands resolve the daemon per event — see DaemonAddrShell for why
+	// the published address is trusted over the inherited env var.
+	daemonAddr := DaemonAddrShell
 
 	// hookCmd reads the full raw JSON from Claude Code's stdin, merges in
 	// our event/state fields, and POSTs the complete payload to the daemon.

--- a/pkg/provider/cursor_hooks.go
+++ b/pkg/provider/cursor_hooks.go
@@ -106,7 +106,7 @@ state="$2"
 [ "$state" = "` + cursorNoState + `" ] && state=""
 
 raw=$(cat)
-addr="${MYCEL_DAEMON_ADDR:-http://127.0.0.1:9374}"
+addr="` + DaemonAddrShell + `"
 
 payload=$(printf '%s' "$raw" | jq -c \
   --arg event "$event" --arg state "$state" \

--- a/pkg/provider/daemon_addr.go
+++ b/pkg/provider/daemon_addr.go
@@ -1,0 +1,30 @@
+package provider
+
+// DaemonAddrShell is the shell expression a hook reporter uses to find the
+// daemon it should report to. Every provider's reporter resolves the address
+// through this one expression, evaluated per event rather than baked in when
+// the hook was written.
+//
+// The order matters, and it is the opposite of what the rest of mycel does.
+//
+// A running daemon publishes its address to <mycel home>/run/daemon.addr on
+// every start, so that file cannot be stale: if it exists, a daemon wrote it,
+// and it wrote it last time it started. MYCEL_DAEMON_ADDR is consulted second
+// because in an agent's session it is not the operator's choice — mycel
+// exported it when the agent was created, so it preserves whichever address
+// was current on that day. An agent created while the daemon listened on :8080
+// keeps POSTing to :8080 for the rest of its life, long after the daemon moved,
+// and nothing says so: the hook fires, curl fails, the event is dropped, and
+// the agent looks quiet rather than misconfigured (#3510).
+//
+// The env var still wins where the file cannot exist, which is the case that
+// actually needs it: an agent in a container or on another host does not share
+// the daemon's home directory, and there the exported address is the only way
+// to know where the daemon is.
+//
+// Written for /bin/sh. sed -n 1p yields the first line and nothing on a missing
+// file; grep . rejects a present-but-empty file, which is what a half-written
+// or truncated addr file looks like. It contains no single quotes on purpose:
+// claude's reporter is embedded inside a single-quoted bash -c command, and one
+// quote here would end that string instead of substituting into it.
+const DaemonAddrShell = `$(sed -n 1p "${MYCEL_HOME:-$HOME/.mycel}/run/daemon.addr" 2>/dev/null | grep . || echo "${MYCEL_DAEMON_ADDR:-http://127.0.0.1:9374}")`

--- a/pkg/provider/daemon_addr_test.go
+++ b/pkg/provider/daemon_addr_test.go
@@ -15,7 +15,7 @@ import (
 // all shell behavior.
 func resolveAddr(t *testing.T, mycelHome, envAddr string) string {
 	t.Helper()
-	cmd := exec.Command("/bin/sh", "-c", `addr=`+DaemonAddrShell+`; printf '%s' "$addr"`)
+	cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", `addr=`+DaemonAddrShell+`; printf '%s' "$addr"`)
 	cmd.Env = []string{
 		"HOME=" + t.TempDir(), // never the real home, whatever the case under test
 		"PATH=" + os.Getenv("PATH"),
@@ -135,7 +135,7 @@ func TestDaemonAddrShellSurvivesClaudeQuoting(t *testing.T) {
 	home := homeWithAddrFile(t, "http://127.0.0.1:9374\n")
 	// Exactly how claude_hooks.go nests it: single-quoted outer command.
 	script := `bash -c 'addr=` + DaemonAddrShell + `; printf "%s" "$addr"'`
-	cmd := exec.Command("/bin/sh", "-c", script)
+	cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", script)
 	cmd.Env = []string{"HOME=" + t.TempDir(), "PATH=" + os.Getenv("PATH"), "MYCEL_HOME=" + home}
 
 	out, err := cmd.Output()

--- a/pkg/provider/daemon_addr_test.go
+++ b/pkg/provider/daemon_addr_test.go
@@ -1,0 +1,168 @@
+package provider
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolveAddr runs DaemonAddrShell the way a reporter does — under /bin/sh, with
+// the environment an agent session has — and returns what it resolved to. The
+// expression is only ever evaluated by a shell, so testing the Go string would
+// test nothing that matters: quoting, the pipeline, and the fallback order are
+// all shell behavior.
+func resolveAddr(t *testing.T, mycelHome, envAddr string) string {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c", `addr=`+DaemonAddrShell+`; printf '%s' "$addr"`)
+	cmd.Env = []string{
+		"HOME=" + t.TempDir(), // never the real home, whatever the case under test
+		"PATH=" + os.Getenv("PATH"),
+	}
+	if mycelHome != "" {
+		cmd.Env = append(cmd.Env, "MYCEL_HOME="+mycelHome)
+	}
+	if envAddr != "" {
+		cmd.Env = append(cmd.Env, "MYCEL_DAEMON_ADDR="+envAddr)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("resolving the daemon address failed: %v (output %q)", err, out)
+	}
+	return string(out)
+}
+
+// homeWithAddrFile builds a mycel home whose run/daemon.addr holds contents,
+// which is what a running daemon leaves behind.
+func homeWithAddrFile(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runDir := filepath.Join(dir, "run")
+	if err := os.MkdirAll(runDir, 0o750); err != nil {
+		t.Fatalf("create run dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "daemon.addr"), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write daemon.addr: %v", err)
+	}
+	return dir
+}
+
+// TestDaemonAddrShellPrefersPublishedAddress is the regression test for #3510:
+// an agent created while the daemon listened on one port carries that port in
+// its session environment forever, so a reporter that trusts the environment
+// POSTs to a dead port for the rest of the agent's life. The address the running
+// daemon published has to win.
+func TestDaemonAddrShellPrefersPublishedAddress(t *testing.T) {
+	home := homeWithAddrFile(t, "http://127.0.0.1:9374\n")
+
+	got := resolveAddr(t, home, "http://0.0.0.0:8080")
+
+	if got != "http://127.0.0.1:9374" {
+		t.Errorf("resolved %q, want the published address http://127.0.0.1:9374 — a stale session env must not win", got)
+	}
+}
+
+func TestDaemonAddrShellFallsBack(t *testing.T) {
+	tests := []struct {
+		name    string
+		home    func(t *testing.T) string
+		envAddr string
+		want    string
+		wantWhy string
+	}{
+		{
+			name:    "no published address falls back to the environment",
+			home:    func(t *testing.T) string { return t.TempDir() },
+			envAddr: "http://10.0.0.5:9374",
+			want:    "http://10.0.0.5:9374",
+			wantWhy: "an agent that does not share the daemon's home — a container, another host — has only the exported address",
+		},
+		{
+			name:    "nothing at all falls back to the default",
+			home:    func(t *testing.T) string { return t.TempDir() },
+			envAddr: "",
+			want:    "http://127.0.0.1:9374",
+			wantWhy: "the default port is the last resort",
+		},
+		{
+			name:    "an empty published address is not an address",
+			home:    func(t *testing.T) string { return homeWithAddrFile(t, "") },
+			envAddr: "http://10.0.0.5:9374",
+			want:    "http://10.0.0.5:9374",
+			wantWhy: "a truncated or half-written addr file must not resolve to the empty string",
+		},
+		{
+			name:    "a blank line is not an address either",
+			home:    func(t *testing.T) string { return homeWithAddrFile(t, "\n") },
+			envAddr: "http://10.0.0.5:9374",
+			want:    "http://10.0.0.5:9374",
+			wantWhy: "grep . rejects a blank first line",
+		},
+		{
+			name:    "only the first line is read",
+			home:    func(t *testing.T) string { return homeWithAddrFile(t, "http://127.0.0.1:9374\ntrailing junk\n") },
+			envAddr: "http://0.0.0.0:8080",
+			want:    "http://127.0.0.1:9374",
+			wantWhy: "extra lines must not be appended to the address",
+		},
+		{
+			name:    "a published address with no trailing newline still reads",
+			home:    func(t *testing.T) string { return homeWithAddrFile(t, "http://127.0.0.1:9999") },
+			envAddr: "",
+			want:    "http://127.0.0.1:9999",
+			wantWhy: "the daemon is not required to newline-terminate what it publishes",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAddr(t, tt.home(t), tt.envAddr); got != tt.want {
+				t.Errorf("resolved %q, want %q — %s", got, tt.want, tt.wantWhy)
+			}
+		})
+	}
+}
+
+// TestDaemonAddrShellSurvivesClaudeQuoting guards the constraint that is easy to
+// break and impossible to notice: claude's reporter embeds this expression inside
+// a single-quoted bash -c command, so a single quote here would end that command
+// rather than substitute into it.
+func TestDaemonAddrShellSurvivesClaudeQuoting(t *testing.T) {
+	if strings.Contains(DaemonAddrShell, "'") {
+		t.Fatalf("DaemonAddrShell contains a single quote, which breaks claude's single-quoted bash -c command: %s", DaemonAddrShell)
+	}
+
+	home := homeWithAddrFile(t, "http://127.0.0.1:9374\n")
+	// Exactly how claude_hooks.go nests it: single-quoted outer command.
+	script := `bash -c 'addr=` + DaemonAddrShell + `; printf "%s" "$addr"'`
+	cmd := exec.Command("/bin/sh", "-c", script)
+	cmd.Env = []string{"HOME=" + t.TempDir(), "PATH=" + os.Getenv("PATH"), "MYCEL_HOME=" + home}
+
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("nested in a single-quoted bash -c, resolution failed: %v (output %q)", err, out)
+	}
+	if string(out) != "http://127.0.0.1:9374" {
+		t.Errorf("nested resolution gave %q, want http://127.0.0.1:9374", out)
+	}
+}
+
+// TestReportersResolveTheAddressAtCallTime pins that no provider bakes a literal
+// address into the hook config it writes. A baked address is correct only until
+// the daemon restarts on another port, and nothing reports the breakage: the hook
+// fires, curl fails, and the agent merely looks quiet.
+func TestReportersResolveTheAddressAtCallTime(t *testing.T) {
+	for _, tt := range []struct {
+		provider string
+		config   string
+	}{
+		{"cursor", cursorReporterScript},
+		{"agy", agyHookCommand("UserPromptSubmit", "working", "{}")},
+	} {
+		t.Run(tt.provider, func(t *testing.T) {
+			if !strings.Contains(tt.config, "run/daemon.addr") {
+				t.Errorf("%s's reporter never consults the published address, so it cannot survive a daemon restart:\n%s", tt.provider, tt.config)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3510.

## What was wrong

An agent's hook config held whichever daemon address was current on the day the agent was created. The daemon later restarts on another port; the config keeps pointing at the old one. Every hook that agent fires then lands on a port nobody is listening on, and nothing says so — curl fails, the event is dropped, and state still updates from what the daemon *observes*. The agent looks present while everything a hook carries (the prompt, each tool call, each result) is lost.

This is what "I only see state changed events" was. On the machine it was found on, **25 of 27 agents were posting to :8080**, where no daemon had listened for weeks:

| Hook target on disk | Agents |
| --- | --- |
| `${BC_BCD_ADDR:-http://0.0.0.0:8080}` | 10 |
| `${MYCEL_DAEMON_ADDR:-http://127.0.0.1:8080}` | 10 |
| `http://127.0.0.1:8080` (frozen literal) | 3 |
| `${BC_BCD_ADDR:-http://127.0.0.1:8080}` | 2 |
| **correct (`:9374`)** | **2** |

`BC_BCD_ADDR` is a variable the `bc` → `mycel` rename left behind and nothing sets, so a third of the fleet had been falling back to a baked default ever since.

## The fix

Hooks resolve the address per event through `provider.DaemonAddrShell`, preferring what the running daemon publishes at `run/daemon.addr` over an inherited env var.

That order is inverted from the CLI's, deliberately. In an agent's session `MYCEL_DAEMON_ADDR` is not an operator's choice — mycel exported it at creation, so it preserves an address that was true once. The file is written by whichever daemon is running now. The env var still wins where the file cannot exist, which is the case that actually needs it: a container or another host that does not share the daemon's home directory.

Three things followed:

- **Nothing stale is exported any more.** Local sessions get no literal, so there is nothing to go out of date. Docker still gets one — it can't read the file — now derived from the published address instead of assuming `:9374`, which was wrong for anyone who chose their own port with `--addr`.
- **`updateAgentHookPorts` is deleted.** It only ever touched claude, matched only the default literal, and rewrote `${MYCEL_DAEMON_ADDR:-…}` into a frozen literal. It was manufacturing the staleness it existed to repair — the 3 hardcoded configs above are its work.
- **Existing agents are healed on daemon start**, by regenerating each config from the provider's own writer rather than patching addresses. That needs no list of past mistakes to recognize, fixes the `BC_BCD_ADDR` generation too, and is idempotent for an agent already correct.

## Verified on the affected machine

After installing this and restarting the daemon, every live config resolves dynamically — 4 cursor reporters, agy's hooks, and the claude settings of every claude-tooled agent. (The `.claude/settings.json` left in cursor and pi worktrees by older versions stays as it is; no process reads it.)

A running cursor agent's feed carries full detail again, seconds after the restart. The `Shell` call that queried the feed appears in the feed:

```json
{
  "event": "PreToolUse",
  "data": {
    "tool_name": "Shell",
    "tool_input": { "command": "curl -sS \"http://127.0.0.1:9374/api/agents/fast-crane/activity?limit=3\" …" }
  },
  "timestamp": "2026-08-03T14:18:11.000Z"
}
```

## Test plan

- [x] `go test ./pkg/provider/ ./pkg/agent/ ./internal/cmd/ ./server/` — all pass
- [x] New tests execute `DaemonAddrShell` under `/bin/sh` rather than asserting on the Go string, since quoting and fallback order are shell behavior: published address beats a stale env var, empty/blank/multi-line addr files fall back correctly, and it survives being nested in claude's single-quoted `bash -c` (a single quote there would end the command — the reason this expression uses `echo` and not `printf '%s'`)
- [x] Migration tested both ways: a `BC_BCD_ADDR`-era config is healed, and a deleted worktree is skipped rather than recreated
- [x] Verified end to end on the machine from #3510, as above

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon connectivity by consistently using the published runtime address.
  * Added fallback handling when the published address is missing, empty, or unreadable.
  * Automatically refreshes activity configurations for existing agents.
  * Skips agents with missing worktrees during refresh.
  * Applies runtime-specific daemon address settings more reliably.

* **Tests**
  * Added coverage for stale address recovery, address precedence, fallback behavior, and runtime-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->