### PR TITLE
fix(live): give a row's duration and timestamp columns that hold their place

### DIFF
--- a/web/src/components/live/EventRow.test.tsx
+++ b/web/src/components/live/EventRow.test.tsx
@@ -105,6 +105,35 @@ describe("EventRow", () => {
     expect(screen.getByText("fix the login bug")).toBeTruthy();
   });
 
+  it("puts how long it took before when it happened, in columns that hold their place", () => {
+    // A row with a duration and one without have to agree on where the
+    // timestamp sits, or the column of times moves from row to row and stops
+    // being readable as a column.
+    const timed = render(<EventRow node={node({ startTime: Date.now() - 5000, endTime: Date.now() - 1000 })} />);
+    const timedMeta = timed.container.querySelector("button > span:last-child");
+    const untimed = render(<EventRow node={node({ toolName: "state_changed", endTime: undefined })} />);
+    const untimedMeta = untimed.container.querySelector("button > span:last-child");
+
+    const cells = (meta: Element | null) => Array.from(meta?.children ?? []);
+    expect(cells(timedMeta)).toHaveLength(2);
+    expect(cells(untimedMeta)).toHaveLength(2);
+
+    // Duration first, and it keeps its width when there is nothing to show.
+    const [timedDuration, timedAgo] = cells(timedMeta);
+    const [untimedDuration, untimedAgo] = cells(untimedMeta);
+    if (!timedDuration || !timedAgo || !untimedDuration || !untimedAgo) {
+      throw new Error("a row is missing its duration or timestamp column");
+    }
+    expect(timedDuration.textContent).toMatch(/\d/);
+    expect(untimedDuration.textContent).toBe("");
+    expect(untimedDuration.className).toBe(timedDuration.className);
+
+    // The timestamp is last, and identically sized in both rows.
+    expect(timedAgo.textContent).toMatch(/ago|now/);
+    expect(untimedAgo.textContent).toMatch(/ago|now/);
+    expect(untimedAgo.className).toBe(timedAgo.className);
+  });
+
   it("shows the MCP server chip and function name", () => {
     render(<EventRow node={node({ toolName: "mcp__github__create_pr", args: "open PR" })} />);
     expect(screen.getByText("github")).toBeTruthy();

--- a/web/src/components/live/EventRow.tsx
+++ b/web/src/components/live/EventRow.tsx
@@ -40,14 +40,17 @@ export function ElapsedTimer({ start }: { start: number }) {
   return <>{elapsed(start)}</>;
 }
 
-export function RelativeTimestamp({ ts }: { ts: number }) {
+export function RelativeTimestamp({ ts, className = "" }: { ts: number; className?: string }) {
   const [, setTick] = useState(0);
   useEffect(() => {
     const id = setInterval(() => setTick((t) => t + 1), 1000);
     return () => clearInterval(id);
   }, []);
   return (
-    <span title={new Date(ts).toISOString()} className="text-[10px] text-mycel-muted font-mono tabular-nums">
+    <span
+      title={new Date(ts).toISOString()}
+      className={`text-[10px] text-mycel-muted font-mono tabular-nums ${className}`}
+    >
       {relativeTime(ts)}
     </span>
   );
@@ -348,17 +351,26 @@ export function EventRow({ node, searchQuery = "" }: { node: ToolNode; searchQue
         <EventName node={node} kind={kind} query={searchQuery} />
         <EventSummary node={node} kind={kind} query={searchQuery} />
 
+        {/* How long it took, then when it happened. Two columns, not two
+            adjacent labels: an event with no duration — a state change, a
+            prompt — would otherwise let its timestamp slide right into the
+            space a duration pill occupies on the rows above and below it, and
+            a column of times that moves is a column you have to read one row
+            at a time. Both are fixed-width and right-aligned so they line up
+            whether or not a row has a duration to show. */}
         <span className="flex items-center gap-2 shrink-0 ml-auto pl-2">
-          <RelativeTimestamp ts={node.startTime} />
-          {node.status === "running" ? (
-            <span className="text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md bg-mycel-accent-subtle text-mycel-accent">
-              <ElapsedTimer start={node.startTime} />
-            </span>
-          ) : node.endTime != null ? (
-            <span className={`text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md ${durationPillClass(node.startTime, node.endTime)}`}>
-              {elapsed(node.startTime, node.endTime)}
-            </span>
-          ) : null}
+          <span className="w-14 flex justify-end">
+            {node.status === "running" ? (
+              <span className="text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md bg-mycel-accent-subtle text-mycel-accent">
+                <ElapsedTimer start={node.startTime} />
+              </span>
+            ) : node.endTime != null ? (
+              <span className={`text-[11px] tabular-nums font-mono px-1.5 py-0.5 rounded-md ${durationPillClass(node.startTime, node.endTime)}`}>
+                {elapsed(node.startTime, node.endTime)}
+              </span>
+            ) : null}
+          </span>
+          <RelativeTimestamp ts={node.startTime} className="w-16 text-right" />
         </span>
       </button>
 


### PR DESCRIPTION
Fixes #3537.

An event row ended with its relative time followed by its duration, both sized to their contents. Rows without a duration — a state change, a prompt — left that last slot empty, so their timestamp slid right into the space a duration pill occupies on the rows above and below it. Scanning down the feed, the column of times moved from row to row.

Duration now comes first and the timestamp last, each in a fixed-width right-aligned cell, so the two line up whether or not a row has a duration to show. The order also reads the way the row does: what it did, how long it took, when it happened.

Reported against a screenshot where `19s ago  899ms` and a bare `9m ago`, three rows apart, ended at different x positions.

## Verified

In the running UI at `:9374`, every row's `ago` is now flush right, including rows with no duration — previously those were the ones that drifted.

## Test plan

- [x] `npx vitest run src/components/live/EventRow.test.tsx` — 21 tests pass, including a new one that renders a row with a duration and one without, then asserts both end with two cells of identical class, duration first and timestamp last
- [x] `tsc -b` clean
- [x] Checked against the live feed of a running cursor agent
