### PR TITLE
fix(live): pair a tool call's start and finish when rebuilding a feed

### DIFF
--- a/web/src/components/live/EventRow.test.tsx
+++ b/web/src/components/live/EventRow.test.tsx
@@ -15,7 +15,7 @@ import { describe, it, expect } from "vitest";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { EventRow, compactPath, eventGlyphKind } from "./EventRow";
 import { RunningSection } from "./LiveRenderers";
-import { activityItemToNode, flattenNodes, partitionRunning } from "./liveHelpers";
+import { activityItemToNode, activityItemsToNodes, flattenNodes, partitionRunning } from "./liveHelpers";
 import type { ToolNode } from "./liveTypes";
 
 function node(overrides: Partial<ToolNode>): ToolNode {
@@ -223,6 +223,117 @@ describe("activityItemToNode + historical expansion", () => {
     });
     expect(n.status).toBe("failed");
     expect(n.error).toBe("exit status 1");
+  });
+
+  it("pairs a tool call's start and finish into one row with a duration", () => {
+    // Newest first, exactly as /api/agents/<id>/activity returns it. Shapes
+    // copied from a real cursor agent's feed.
+    const nodes = activityItemsToNodes([
+      {
+        timestamp: "2026-08-03T14:18:13.000Z",
+        event: "PostToolUse",
+        message: "Shell: curl -sS …",
+        data: { tool_name: "Shell", tool_input: { command: "curl -sS …" }, tool_response: "ok" },
+      },
+      {
+        timestamp: "2026-08-03T14:18:11.000Z",
+        event: "PreToolUse",
+        message: "Shell: curl -sS …",
+        data: { tool_name: "Shell", tool_input: { command: "curl -sS …" } },
+      },
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.toolName).toBe("Shell");
+    expect(nodes[0]?.status).toBe("completed");
+    expect(nodes[0]?.fullOutput).toBe("ok");
+    // 14:18:11 → 14:18:13. Without pairing this was two rows and no duration.
+    expect((nodes[0]?.endTime ?? 0) - (nodes[0]?.startTime ?? 0)).toBe(2000);
+  });
+
+  it("pairs each of several calls with its own finish, in order", () => {
+    const at = (s: string) => `2026-08-03T14:18:${s}.000Z`;
+    const call = (event: string, tool: string, ts: string) => ({
+      timestamp: at(ts),
+      event,
+      message: `${tool}: x`,
+      data: { tool_name: tool, tool_input: { command: "x" } },
+    });
+    // Read starts and finishes, then Shell starts and finishes — newest first.
+    const nodes = activityItemsToNodes([
+      call("PostToolUse", "Shell", "40"),
+      call("PreToolUse", "Shell", "30"),
+      call("PostToolUse", "Read", "20"),
+      call("PreToolUse", "Read", "10"),
+    ]);
+
+    expect(nodes.map((n) => n.toolName)).toEqual(["Read", "Shell"]);
+    expect(nodes.every((n) => n.endTime !== undefined)).toBe(true);
+    expect((nodes[0]?.endTime ?? 0) - (nodes[0]?.startTime ?? 0)).toBe(10_000);
+  });
+
+  it("keeps a failure's error and marks the paired row failed", () => {
+    const nodes = activityItemsToNodes([
+      {
+        timestamp: "2026-08-03T14:18:13.000Z",
+        event: "PostToolUseFailure",
+        message: "Shell",
+        data: { tool_name: "Shell", tool_input: { command: "false" }, error: "exit status 1" },
+      },
+      {
+        timestamp: "2026-08-03T14:18:11.000Z",
+        event: "PreToolUse",
+        message: "Shell: false",
+        data: { tool_name: "Shell", tool_input: { command: "false" } },
+      },
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.status).toBe("failed");
+    expect(nodes[0]?.error).toBe("exit status 1");
+  });
+
+  it("claims no duration for a call whose finish was never recorded, and does not leave it running", () => {
+    // A timer ticking up from a start time hours in the past is #3267, and a
+    // reloaded feed is where it would happen every time.
+    const nodes = activityItemsToNodes([
+      {
+        timestamp: "2026-08-03T14:18:11.000Z",
+        event: "PreToolUse",
+        message: "Shell: sleep 600",
+        data: { tool_name: "Shell", tool_input: { command: "sleep 600" } },
+      },
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.endTime).toBeUndefined();
+    expect(nodes[0]?.status).toBe("completed");
+  });
+
+  it("keeps a finish that has no start rather than dropping the event", () => {
+    // History is a window: a call that began before it opened still finished.
+    const nodes = activityItemsToNodes([
+      {
+        timestamp: "2026-08-03T14:18:13.000Z",
+        event: "PostToolUse",
+        message: "Shell: curl",
+        data: { tool_name: "Shell", tool_input: { command: "curl" }, tool_response: "ok" },
+      },
+    ]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.toolName).toBe("Shell");
+  });
+
+  it("leaves non-tool events alone, and returns them oldest first", () => {
+    const nodes = activityItemsToNodes([
+      { timestamp: "2026-08-03T14:18:20.000Z", event: "Stop", message: "Turn complete" },
+      { timestamp: "2026-08-03T14:18:10.000Z", event: "UserPromptSubmit", message: "fix the login bug" },
+    ]);
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0]?.startTime).toBeLessThan(nodes[1]?.startTime ?? 0);
+    expect(nodes.every((n) => n.endTime === undefined)).toBe(true);
   });
 
   it("degrades gracefully when only a message is stored (no data)", () => {

--- a/web/src/components/live/liveHelpers.ts
+++ b/web/src/components/live/liveHelpers.ts
@@ -358,6 +358,72 @@ export function activityItemToNode(item: AgentActivityItem): ToolNode {
   };
 }
 
+/**
+ * Rebuild a feed from stored activity, pairing each tool call's start with its
+ * finish. Takes the REST feed's own order (newest first) and returns nodes
+ * oldest first.
+ *
+ * A tool call is reported as two events, and mapping one node per event made
+ * every call in a reloaded feed appear twice — once for `PreToolUse`, once for
+ * `PostToolUse` — with no duration on either, since a duration needs both
+ * halves. The live stream never showed this because it holds the call it just
+ * saw start and completes it in place; only a reload went through the mapping
+ * path, which is to say the feed most people look at was the wrong one (#3535).
+ *
+ * The events carry no id tying a finish to its start, so a finish is matched to
+ * the most recent unfinished call of the same tool — the same rule the live
+ * stream applies, for the same reason. It is exact for the sequential tool use
+ * these providers emit, and where it cannot be sure it errs toward keeping
+ * events: an unmatched finish becomes its own row rather than being dropped.
+ *
+ * A call whose finish was never recorded keeps no end time, so it renders
+ * without a duration instead of claiming one. It is deliberately not left
+ * "running": an elapsed timer ticking up from a start time hours in the past is
+ * the stale-snapshot bug of #3267, and history is exactly where that would
+ * happen on every reload.
+ */
+export function activityItemsToNodes(items: AgentActivityItem[]): ToolNode[] {
+  const nodes: ToolNode[] = [];
+  const isFinish = (event: string) => event === "PostToolUse" || event === "PostToolUseFailure";
+
+  for (const item of [...items].reverse()) {
+    const node = activityItemToNode(item);
+
+    if (isFinish(item.event)) {
+      const startIdx = findLastIdx(
+        nodes,
+        (n) => n.toolName === node.toolName && n.status === "running",
+      );
+      const start = startIdx >= 0 ? nodes[startIdx] : undefined;
+      if (start) {
+        nodes[startIdx] = {
+          ...start,
+          // The call's own input and summary describe it better than the
+          // result does, so only the outcome is taken from the finish.
+          status: item.event === "PostToolUseFailure" || node.error ? "failed" : "completed",
+          endTime: node.startTime,
+          fullOutput: node.fullOutput ?? start.fullOutput,
+          error: node.error ?? start.error,
+        };
+        continue;
+      }
+      nodes.push(node);
+      continue;
+    }
+
+    if (item.event === "PreToolUse") {
+      // "running" marks it as awaiting a finish while folding; anything still
+      // marked at the end had none, and is settled below.
+      nodes.push({ ...node, status: "running" });
+      continue;
+    }
+
+    nodes.push(node);
+  }
+
+  return nodes.map((n) => (n.status === "running" ? { ...n, status: "completed" as const } : n));
+}
+
 /** Derive a tool name from a historical row's message ("Bash: cmd" or a
  *  bare word) when the structured tool_name field is absent. */
 function parseHistoricalToolName(item: AgentActivityItem): string {

--- a/web/src/hooks/useAgentActivity.ts
+++ b/web/src/hooks/useAgentActivity.ts
@@ -37,7 +37,7 @@ function finalizeRunningNodes(nodes: ToolNode[], endTime: number): ToolNode[] {
 const TERMINAL_STATES = new Set(["idle", "stopped", "done", "error"]);
 
 import {
-  activityItemToNode,
+  activityItemsToNodes,
   findLastIdx,
   nextId,
   parseTaskCreate,
@@ -130,7 +130,9 @@ export function useAgentActivity(agentName?: string, options?: UseAgentActivityO
             const next = new Map(prev);
             const existing = next.get(agentName);
             if (existing && existing.nodes.length === 0 && items.length > 0) {
-              const nodes: ToolNode[] = items.map(activityItemToNode);
+              // Newest first here, as the detail feed reads; paired first so a
+              // tool call is one row with a duration rather than two without.
+              const nodes: ToolNode[] = activityItemsToNodes(items).reverse();
               next.set(agentName, { ...existing, nodes });
             }
             return next;
@@ -151,10 +153,7 @@ export function useAgentActivity(agentName?: string, options?: UseAgentActivityO
               const existing = next.get(a.name);
               if (!existing || existing.nodes.length > 0) return prev;
               // Oldest-first inside each card; the REST feed is newest-first.
-              const nodes: ToolNode[] = items
-                .slice()
-                .reverse()
-                .map(activityItemToNode);
+              const nodes: ToolNode[] = activityItemsToNodes(items);
               next.set(a.name, { ...existing, nodes });
               return next;
             });


### PR DESCRIPTION
Fixes #3535.

## What was wrong

A tool call is reported as two events, and hydrating history mapped one node per event. Every call in a reloaded feed appeared **twice** — once for `PreToolUse`, once for `PostToolUse` — and neither row had a duration, because a duration needs both halves.

The live stream never showed this, because it holds the call it just saw start and completes it in place. Only a reload went through the mapping path — which is to say the feed most people look at was the wrong one.

## The fix

Hydration folds the feed instead of mapping it, matching each finish to the most recent unfinished call of the same tool. That is the rule the live stream already applies, and it is exact for the sequential tool use these providers emit.

The events carry no id tying the halves together. Adding one is worth doing, but it would only help feeds recorded after it shipped, while this repairs every feed already stored.

Where it cannot be certain, it keeps events rather than guessing:

- **A finish with no start** still becomes a row. History is a window, and a call may have begun before it opened.
- **A call whose finish was never recorded** keeps no end time, so it renders without a duration instead of claiming one. It is deliberately not left `running` either: an elapsed timer ticking up from a start time hours in the past is #3267, and a reloaded feed is exactly where that would happen on every load.

## Verified on a real feed

Same agent, same stored events, before and after.

Before — each call twice, no durations:

```
Write  /tmp/mycel-main/web/src/components/live/EventRow.test.tsx     3m ago
Write  /tmp/mycel-main/web/src/components/live/EventRow.test.tsx     3m ago
Read   /tmp/mycel-main/web/src/components/live/EventRow.test.tsx     3m ago
Read   /tmp/mycel-main/web/src/components/live/EventRow.test.tsx     3m ago
```

After — one row each, with the time it took:

```
Write  /tmp/mycel-main/web/src/components/live/EventRow.test.tsx   1.0s   2m ago
Read   /tmp/mycel-main/web/src/components/live/EventRow.test.tsx   4.0s   2m ago
Shell  cd /tmp/mycel-main && make build-local …                   44.0s   1m ago
```

Durations round to whole seconds because that is the resolution the timestamps are stored at; live rows stay millisecond-exact.

## Test plan

- [x] `npx vitest run` — 52 files, 459 tests pass (6 new), `tsc --noEmit` clean
- [x] New tests use event shapes copied from a real cursor agent's feed and cover: a pair becoming one row with the right duration, several interleaved calls each pairing with their own finish, a failure keeping its error and marking the row failed, an unfinished call claiming no duration and not being left running, an unmatched finish surviving as its own row, and non-tool events passing through oldest-first
- [x] Verified in the running UI against stored history, as above

Made with [Cursor](https://cursor.com)