### PR TITLE
fix(agent): show the message, not its envelope, as a task line

### DIFF
--- a/pkg/agent/hook_ingest.go
+++ b/pkg/agent/hook_ingest.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 	"unicode/utf8"
 
@@ -103,7 +104,7 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 	// the prompt afterwards would refill it and leave a dead agent advertising
 	// work it will never do, so nothing is derived when the agent just stopped.
 	if isTurnStart(payload.Event) && payload.Prompt != "" && targetState != StateStopped {
-		task := truncateRunes(payload.Prompt, maxDerivedTaskLen)
+		task := truncateRunes(taskFromPrompt(payload.Prompt), maxDerivedTaskLen)
 		if err := s.manager.SetAgentTask(ctx, name, task); err != nil {
 			// Non-fatal: the event itself is still worth logging and
 			// broadcasting even if the task line could not be updated.
@@ -164,6 +165,43 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 // choice of name does not decide whether its agents get a task line.
 func isTurnStart(ev HookEvent) bool {
 	return ev == HookUserPromptSubmit || ev == HookPreInvocation
+}
+
+// taskFromPrompt returns the part of a prompt worth showing as a task line.
+//
+// Usually that is the whole prompt. But an agent driven through a gateway is
+// handed the platform's entire delivery envelope, so its prompt is JSON, and the
+// task line read `{"raw":{"client_m…` — a correct derivation from something no
+// one wants to read. The sentence a person actually typed is a field inside it
+// (#3536).
+//
+// The envelope is recognized rather than assumed: a JSON object needs a
+// non-empty `content` alongside at least one delivery field to be treated as
+// one. A prompt that merely happens to be JSON is left alone, which matters
+// because pasting JSON to an agent is an ordinary thing to do.
+func taskFromPrompt(prompt string) string {
+	trimmed := strings.TrimSpace(prompt)
+	if !strings.HasPrefix(trimmed, "{") {
+		return prompt
+	}
+
+	var envelope struct {
+		Content  string `json:"content"`
+		Platform string `json:"platform"`
+		Channel  string `json:"channel"`
+		Sender   string `json:"sender"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &envelope); err != nil {
+		return prompt
+	}
+	content := strings.TrimSpace(envelope.Content)
+	if content == "" {
+		return prompt
+	}
+	if envelope.Platform == "" && envelope.Channel == "" && envelope.Sender == "" {
+		return prompt
+	}
+	return content
 }
 
 // maxDerivedTaskLen bounds the prompt text used as an agent's task line. The

--- a/pkg/agent/hook_ingest_test.go
+++ b/pkg/agent/hook_ingest_test.go
@@ -376,3 +376,89 @@ func TestIngestHookEvent_StoppedTurnStartLeavesTaskCleared(t *testing.T) {
 		t.Errorf("task = %q, want it cleared for a stopped agent", got)
 	}
 }
+
+// An agent driven through a gateway is handed the platform's whole delivery
+// envelope, so its prompt is JSON and its task line read `{"raw":{"client_m…`.
+// The envelope is what the transport needs; the sentence inside it is what a
+// person typed and the only part worth showing (#3536).
+func TestTaskFromPrompt(t *testing.T) {
+	// Trimmed from a real Slack delivery, keeping the shape and field order.
+	slackEnvelope := `{"raw":{"client_msg_id":"1232B1A4","type":"message",` +
+		`"user":"U0AN7GW037H","text":"Update when you have something"},` +
+		`"timestamp":"2026-08-03T14:36:15Z","channel":"slack:general",` +
+		`"platform":"slack","sender":"[slack] Puneet Rai",` +
+		`"content":"Update when you have something"}`
+
+	tests := []struct {
+		name   string
+		prompt string
+		want   string
+		why    string
+	}{
+		{
+			name:   "a delivery envelope yields the message",
+			prompt: slackEnvelope,
+			want:   "Update when you have something",
+			why:    "the task line should read as the request, not as its transport",
+		},
+		{
+			name:   "an ordinary prompt is untouched",
+			prompt: "fix the login bug",
+			want:   "fix the login bug",
+			why:    "most prompts are not JSON and must pass through unchanged",
+		},
+		{
+			name:   "JSON a person pasted is left alone",
+			prompt: `{"content":"some config value","other":"field"}`,
+			want:   `{"content":"some config value","other":"field"}`,
+			why:    "without a delivery field this is data the agent was given, not an envelope",
+		},
+		{
+			name:   "an envelope with an empty message keeps the whole prompt",
+			prompt: `{"platform":"slack","sender":"someone","content":"   "}`,
+			want:   `{"platform":"slack","sender":"someone","content":"   "}`,
+			why:    "an empty task line is worse than an ugly one",
+		},
+		{
+			name:   "malformed JSON keeps the whole prompt",
+			prompt: `{"platform":"slack","content":"truncated`,
+			want:   `{"platform":"slack","content":"truncated`,
+			why:    "a parse failure must not lose the prompt",
+		},
+		{
+			name:   "a prompt that merely starts with a brace is untouched",
+			prompt: "{ this is not json at all",
+			want:   "{ this is not json at all",
+			why:    "the brace alone means nothing",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := taskFromPrompt(tt.prompt); got != tt.want {
+				t.Errorf("taskFromPrompt() = %q, want %q — %s", got, tt.want, tt.why)
+			}
+		})
+	}
+}
+
+// The derivation runs through ingestion, so the task an agent ends up
+// advertising is the readable one.
+func TestIngestHookEvent_GatewayEnvelopeBecomesAReadableTask(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["eng-1"] = &Agent{Name: "eng-1", Role: Role("engineer"), State: StateIdle}
+	svc := NewAgentService(mgr, nil, nil)
+
+	payload := HookPayload{
+		Event: HookUserPromptSubmit,
+		Prompt: `{"timestamp":"2026-08-03T14:36:15Z","channel":"slack:general",` +
+			`"platform":"slack","sender":"[slack] Puneet Rai",` +
+			`"content":"review both trackers and make sure main is good"}`,
+	}
+	if err := svc.IngestHookEvent(context.Background(), "eng-1", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+
+	if got := mgr.agents["eng-1"].Task; got != "review both trackers and make sure main is good" {
+		t.Errorf("task = %q, want the message rather than its envelope", got)
+	}
+}


### PR DESCRIPTION
Fixes #3536.

## What was wrong

An agent driven through a gateway is handed the platform's **entire delivery envelope** as its prompt. Since the task line is derived from the prompt, it read:

```
{"raw":{"client_msg_id":"1232B1A4-1782-48FD-8275-891C2132F99C","type":"message","user":"U0…
```

A faithful derivation from something no one wants to read — and it is the first thing you see on the agents list and in an agent's header.

## The fix

The sentence a person actually typed is a field inside that envelope, so the derivation takes it.

The envelope is **recognized, not assumed**: a JSON object needs a non-empty `content` alongside at least one delivery field (`platform`, `channel` or `sender`). Everything else passes through untouched:

- **JSON a person pasted** stays as-is. Handing an agent a config blob is an ordinary thing to do, and its `content` field is not a message.
- **An envelope whose `content` is empty**, or **whose JSON does not parse**, keeps the whole prompt. An empty or lost task line is worse than an ugly one.

This happens at ingestion rather than at delivery, so every provider that reports a prompt benefits, and the envelope the transport needs stays intact.

## Verified on the running daemon

Posting a real Slack envelope to `/api/agents/{name}/hook`:

```
$ curl -X POST .../api/agents/fast-crane/hook -d '{"event":"UserPromptSubmit","prompt":"{\"raw\":…,\"platform\":\"slack\",\"content\":\"Update when you have something don stay idle\"}"}'
{"ok":true}

$ curl .../api/agents | …
TASK NOW: Update when you have something don stay idle
```

In the agents list this shows as a direct before/after — the agent that took a message after the fix reads `Update when you have something …`, while two agents whose task lines were stored before it still read `{"raw":{"client_msg_id":"5de264c…`.

Existing stale lines are not rewritten; each agent's next turn replaces its own.

## Test plan

- [x] `go test ./pkg/agent/` passes, `golangci-lint run pkg/agent/...` reports 0 issues
- [x] New table test covers the envelope, an ordinary prompt, pasted JSON, an empty `content`, malformed JSON, and a prompt that merely starts with a brace — each case naming why that outcome is the right one
- [x] New ingestion test asserts the readable task reaches the agent through `IngestHookEvent`
- [x] Verified end-to-end against the running daemon, as above

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Gateway delivery-envelope prompts are now converted into readable task text.
  - Ordinary prompts, unrelated JSON, malformed input, and empty content continue to display unchanged.
  - Readable task text is preserved when task length limits are applied.

- **Tests**
  - Added coverage for envelope handling and ingestion behavior across valid and invalid prompt formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->