### PR TITLE
fix(server): say why the UI is missing instead of returning a bare 404

### DIFF
--- a/server/embed.go
+++ b/server/embed.go
@@ -26,3 +26,50 @@ func WebDist() fs.FS {
 	}
 	return nil
 }
+
+// noWebUIPage is served in place of the UI when the running binary was built
+// without it (see WebDist). It exists so that the daemon says which of the
+// things that look identical in a browser has actually happened: the daemon is
+// up and its API is answering on this very address, and only the bundle is
+// missing. Kept to plain inline markup because the moment it is needed is the
+// moment no asset can be served.
+const noWebUIPage = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>mycel — web UI not built</title>
+<style>
+  :root { color-scheme: dark }
+  body { margin:0; min-height:100vh; display:flex; align-items:center; justify-content:center;
+         background:#12100e; color:#e8e3da;
+         font:15px/1.65 ui-sans-serif,-apple-system,"Segoe UI",sans-serif }
+  main { max-width:33rem; padding:2.5rem }
+  h1 { font-size:1.35rem; margin:0 0 .4rem; color:#f0b429 }
+  p { margin:0 0 1.15rem; color:#b8b0a4 }
+  code { font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
+         background:#1e1b17; color:#f0d9a8; padding:.15em .4em; border-radius:4px }
+  pre { background:#1a1714; border:1px solid #2a251f; border-radius:8px;
+        padding:.85rem 1rem; overflow-x:auto; margin:0 0 1.15rem }
+  pre code { background:none; padding:0; color:#e8e3da }
+  a { color:#f0b429 }
+</style>
+</head>
+<body>
+<main>
+  <h1>The daemon is running. Its web UI is not in this binary.</h1>
+  <p>This is not a broken daemon or a wrong port — the API is answering right
+     here, which you can confirm at
+     <a href="/api/agents">/api/agents</a>. The binary was just built without
+     the UI bundle embedded, so there is nothing to serve at this path.</p>
+  <p>To get the UI, build with the target that bundles it, then restart:</p>
+  <pre><code>make build-local</code></pre>
+  <p>Or, if you are working on the UI itself, run the dev server and use that
+     instead — it proxies the API through to this daemon:</p>
+  <pre><code>cd web &amp;&amp; bun run dev   # http://localhost:9375</code></pre>
+  <p>The CLI is unaffected either way: <code>mycel status</code> and every other
+     command talk to the API, not to this page.</p>
+</main>
+</body>
+</html>
+`

--- a/server/no_web_ui_test.go
+++ b/server/no_web_ui_test.go
@@ -1,0 +1,103 @@
+// no_web_ui_test.go — a daemon built without the UI bundle registered no root
+// handler, so a browser got Go's bare "404 page not found": identical to a dead
+// daemon, a wrong port, or a crashed server. It now says which it is.
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fetched is what a browser or client actually sees: the status, the type it
+// was told to expect, and the bytes. Returning these rather than the response
+// keeps the body's lifetime inside the helper that opened it.
+type fetched struct {
+	contentType string
+	body        string
+	status      int
+}
+
+func get(t *testing.T, url string) fetched {
+	t.Helper()
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fetched{
+		status:      resp.StatusCode,
+		contentType: resp.Header.Get("Content-Type"),
+		body:        string(body),
+	}
+}
+
+func TestWithoutTheUIBundleTheRootPathExplainsItself(t *testing.T) {
+	// nil static files is exactly what WebDist returns from a binary built
+	// without the UI.
+	ts := httptest.NewServer(New(Config{Addr: "127.0.0.1:0"}, Services{}, nil, nil).Handler())
+	defer ts.Close()
+
+	got := get(t, ts.URL+"/")
+
+	// 503, not 404: the daemon answered, and this address serves the UI once
+	// the binary carries it.
+	if got.status != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503 — the daemon is up, only its UI is missing", got.status)
+	}
+	if ct := got.contentType; !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("Content-Type = %q, want HTML: a person is reading this in a browser", ct)
+	}
+	// The page has to answer the two questions being asked: is the daemon
+	// alive, and what do I run to fix it.
+	for _, want := range []string{"daemon is running", "make build-local", "/api/agents"} {
+		if !strings.Contains(got.body, want) {
+			t.Errorf("page does not mention %q; it is the only thing standing in for the UI", want)
+		}
+	}
+}
+
+func TestWithoutTheUIBundleAPIPathsStillAnswerJSON(t *testing.T) {
+	ts := httptest.NewServer(New(Config{Addr: "127.0.0.1:0"}, Services{}, nil, nil).Handler())
+	defer ts.Close()
+
+	// An unknown API path must not hand a client an HTML page to parse,
+	// whether or not the UI happens to be bundled.
+	got := get(t, ts.URL+"/api/definitely-not-a-route")
+
+	if got.status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for an unknown API route", got.status)
+	}
+	if ct := got.contentType; !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want JSON for an API path", ct)
+	}
+	if !strings.Contains(got.body, `"error"`) {
+		t.Errorf("body = %q, want a JSON error", got.body)
+	}
+}
+
+// A route the daemon really has must not be shadowed by the explanatory page.
+func TestWithoutTheUIBundleRealRoutesStillWork(t *testing.T) {
+	ts := httptest.NewServer(New(Config{Addr: "127.0.0.1:0"}, Services{}, nil, nil).Handler())
+	defer ts.Close()
+
+	got := get(t, ts.URL+"/api/health")
+
+	if got.status != http.StatusOK {
+		t.Errorf("status = %d, want 200 from /api/health", got.status)
+	}
+	if !strings.Contains(got.body, "status") {
+		t.Errorf("body = %q, want the health payload", got.body)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -530,6 +530,26 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 			r.URL.Path = "/"
 			fileServer.ServeHTTP(w, r)
 		})
+	} else {
+		// A binary built without the UI bundle registered no root handler at
+		// all, so opening the daemon in a browser gave Go's bare
+		// "404 page not found" — indistinguishable from a broken daemon, a
+		// wrong port, or a crashed server, when in fact the daemon is fine and
+		// only its UI is absent. Saying so is the difference between a
+		// two-minute fix and an afternoon.
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/api/") || strings.HasPrefix(r.URL.Path, "/hooks/") || strings.HasPrefix(r.URL.Path, "/_mcp/") {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"error":"not found"}`))
+				return
+			}
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			// 503, not 404: the daemon answered, and this address will serve
+			// the UI once the binary carries it.
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(noWebUIPage))
+		})
 	}
 
 	// Middleware chain (outermost runs first):


### PR DESCRIPTION
Fixes #3542.

## What was wrong

A binary built without the UI bundle registered **no root handler at all**, so opening the daemon in a browser gave Go's bare:

```
404 page not found
```

That page is indistinguishable from a wrong port, a dead daemon, or a server that crashed on startup — and it shows up at exactly the moment someone is trying to work out which of those happened. It cost real time to track down to "this binary has no `web/dist` embedded in it".

## The fix

The daemon now answers with a page that says which situation this is:

- the API **is** answering on this very address, with a link to `/api/agents` to prove it
- the missing thing is the UI bundle, not the daemon
- `make build-local` is the command that fixes it
- and if you are working on the UI, `bun run dev` on `:9375` is offered instead, since that is what you actually want

It answers **503, not 404**: the daemon is up, and this address serves the UI as soon as the binary carries it.

API, hook and MCP paths keep their JSON 404, so no client is ever handed HTML to parse, and every real route still answers — the page is a fallback, not a catch-all.

The markup is inline and asset-free deliberately: the moment this page is needed is the moment no asset can be served.

## Test plan

- [x] `go test ./server/` passes, `golangci-lint run server/...` reports 0 issues
- [x] Three new tests: the root path explains itself with 503 + HTML and names both the daemon's health and the build command; an unknown `/api/` path still answers JSON 404; and `/api/health` still answers 200, so the fallback shadows nothing
- [x] Rendered in a browser to check it reads clearly and matches mycel's palette (screenshot in the issue)

Made with [Cursor](https://cursor.com)