### PR TITLE
fix(about): stop warning about a version mismatch between one build

### DIFF
--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -48,6 +48,23 @@ export function isReleaseVersion(v: string): boolean {
   return /^\d+\.\d+\.\d+$/.test(v);
 }
 
+/**
+ * sameBuild — whether two version strings name the same build.
+ *
+ * The daemon marks a version `.dirty` when the tree it was built from had
+ * uncommitted changes, and the desktop app's version is stamped separately, so
+ * one build of the same commit can present itself as `0.4.5-dev.35.gfbc9a1c`
+ * and `0.4.5-dev.35.gfbc9a1c.dirty` at once. Comparing the strings then warned
+ * of a mismatch between an app and a daemon that were built together, in the
+ * same minute, from the same tree — a warning that cannot be acted on and that
+ * teaches people to disregard the one case it exists for: a new app talking to
+ * a daemon left running from an older build.
+ */
+export function sameBuild(a: string, b: string): boolean {
+  const core = (v: string) => v.replace(/\.dirty$/, "");
+  return core(a) === core(b);
+}
+
 /** withTimeout — caps any one channel-check fetch at `ms` so a hung
  *  request (DNS timeout, GitHub API rate-limit holding the socket open,
  *  slow mirror) can't pin the page in the loading state. Resolves the
@@ -158,7 +175,9 @@ export function About() {
   // do, every version on this page comes from the daemon while the user is
   // looking at a newer app. Surfacing it is the difference between "my update
   // didn't work" and "my daemon is stale".
-  const appDiffersFromDaemon = Boolean(appVersion && health?.version && appVersion !== health.version);
+  const appDiffersFromDaemon = Boolean(
+    appVersion && health?.version && !sameBuild(appVersion, health.version),
+  );
 
   const channels: ChannelStatus[] = [
     ...(appVersion
@@ -238,7 +257,11 @@ export function About() {
           <span className="text-[11px] uppercase tracking-wider text-mycel-muted">
             {appVersion ? "Daemon" : "Installed"}
           </span>
-          <span className="text-2xl font-semibold text-mycel-text font-mono tabular-nums">
+          {/* A source build's version is long and full of hyphens, and wrapping
+              on one split it into "0.4.5-" / "dev.35.gfbc9a1c.dirty" — two
+              lines that read like two different numbers. It is one identifier,
+              so it is kept on one line and shrunk to fit. */}
+          <span className="text-xl sm:text-2xl font-semibold text-mycel-text font-mono tabular-nums whitespace-nowrap">
             {health?.version ?? "—"}
           </span>
           {appDiffersFromDaemon && (

--- a/web/src/views/__tests__/aboutVersion.test.ts
+++ b/web/src/views/__tests__/aboutVersion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isReleaseVersion } from "../About";
+import { isReleaseVersion, sameBuild } from "../About";
 
 /**
  * The About page shows "update available" only when the running build is a
@@ -39,5 +39,35 @@ describe("isReleaseVersion", () => {
   it("rejects a prerelease tag, which is not the latest release", () => {
     expect(isReleaseVersion("0.5.0-rc1")).toBe(false);
     expect(isReleaseVersion("0.1.0-alpha")).toBe(false);
+  });
+});
+
+/**
+ * A build's version can present itself two ways at once: the daemon appends
+ * `.dirty` when its tree had uncommitted changes, and the desktop app's version
+ * is stamped separately. Comparing the raw strings warned of a mismatch between
+ * an app and a daemon built together, from the same tree, in the same minute —
+ * and a warning that cannot be acted on teaches people to ignore the one case
+ * it exists for.
+ */
+describe("sameBuild", () => {
+  it("treats a dirty daemon and its own app as the same build", () => {
+    expect(sameBuild("0.4.5-dev.35.gfbc9a1c", "0.4.5-dev.35.gfbc9a1c.dirty")).toBe(true);
+  });
+
+  it("is not fooled by which side is dirty", () => {
+    expect(sameBuild("0.4.5-dev.35.gfbc9a1c.dirty", "0.4.5-dev.35.gfbc9a1c")).toBe(true);
+  });
+
+  it("still reports the mismatch worth warning about", () => {
+    // A new app talking to a daemon left running from an older build: the whole
+    // reason the comparison exists.
+    expect(sameBuild("0.4.5-dev.35.gfbc9a1c", "0.4.4")).toBe(false);
+    expect(sameBuild("0.4.5-dev.35.gfbc9a1c", "0.4.5-dev.12.g1a2b3c4")).toBe(false);
+  });
+
+  it("holds for identical versions, dirty or not", () => {
+    expect(sameBuild("0.4.4", "0.4.4")).toBe(true);
+    expect(sameBuild("0.4.5-dev.35.gfbc9a1c.dirty", "0.4.5-dev.35.gfbc9a1c.dirty")).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #3543.

## What was wrong

The About page warned `app is 0.4.5-dev.35.gfbc9a1c` and called the app **"newer than the daemon below"** for an app and daemon that were the same build.

The daemon appends `.dirty` when built from a tree with uncommitted changes, and the app's version is stamped separately, so one build of one commit presents itself as `0.4.5-dev.35.gfbc9a1c` and `0.4.5-dev.35.gfbc9a1c.dirty` at the same time. A string comparison reads that as a mismatch.

Nothing can be done about such a warning, and a warning nobody can act on trains people to disregard the case it exists for — a freshly updated app talking to a daemon left running from an older build, where every version on the page comes from the daemon and the update looks like it did not take.

## The fix

`sameBuild` compares versions with a trailing `.dirty` ignored on either side, so the badge fires only when the builds really differ.

Also keeps the version on one line: it was wrapping on a hyphen into `0.4.5-` / `dev.35.gfbc9a1c.dirty`, two lines that read like two different numbers, on the page whose whole job is telling you which version you are running.

## Test plan

- [x] `npx vitest run` — 52 files, 463 tests pass (4 new), `tsc --noEmit` clean
- [x] New tests cover a dirty daemon against its own app (either side dirty), the mismatch that is worth warning about (an older release, and a different source build), and identical versions
- [x] Checked in the running UI: the badge is gone for the current build, and the version renders on one line
