### PR TITLE
fix(marketplace): stop telling agents to run a command that does not exist

### DIFF
--- a/docs/how-to/browse-the-marketplace.md
+++ b/docs/how-to/browse-the-marketplace.md
@@ -44,7 +44,12 @@ The exact command an agent runs depends on the entry:
 | MCP server | `claude mcp add "<name>" "<source-url>"` |
 | Skill (openclaw) | `openclaw skills install "<slug>"` |
 | Skill (Claude, GitHub) | `claude plugin marketplace add "<repo-url>"` then `claude plugin install "<name>@<marketplace>"` |
-| Template | `mycel template import "<name>"` |
+| Template | `mycel agent create <agent-name> --template "<name>"` |
+
+Templates are the exception: the `mycel` source lists the templates already on
+this machine (`~/.mycel/templates/`), so there is nothing to fetch. Adding one
+tells the agent how to put it to use — creating an agent from it — rather than
+installing anything.
 
 For a skill sourced from a plugin marketplace, the agent first registers the marketplace and then installs the plugin from it:
 

--- a/server/handlers/marketplace.go
+++ b/server/handlers/marketplace.go
@@ -201,7 +201,20 @@ func composeInstallMessage(req installRequest) string {
 			sb.WriteString(fmt.Sprintf("  claude plugin install %q\n", req.ItemName+"@"+marketplaceName))
 		}
 	case marketplace.TypeTemplate:
-		sb.WriteString(fmt.Sprintf("  mycel template import %q\n", req.ItemName))
+		// A template entry names a template that is already on the machine: the
+		// mycel source lists ~/.mycel/templates itself, so there is nothing to
+		// fetch. The old instruction asked for `mycel template import`, a
+		// command that has never existed — an agent that did as it was told got
+		// "unknown command", which is the failure the Glama branch above goes
+		// out of its way to avoid. What a template is *for* is creating an
+		// agent, so that is what is asked for.
+		template := strings.TrimPrefix(req.ItemID, "mycel:")
+		if template == "" {
+			template = req.ItemName
+		}
+		sb.WriteString("  This template is already available locally; use it when creating an agent:\n")
+		sb.WriteString(fmt.Sprintf("  mycel agent create <agent-name> --template %q\n", template))
+		sb.WriteString("  (mycel template list shows every template on this machine.)\n")
 	default:
 		sb.WriteString("  Consult the item URL above for installation instructions.\n")
 	}

--- a/server/handlers/marketplace_test.go
+++ b/server/handlers/marketplace_test.go
@@ -488,16 +488,57 @@ func TestInstall_InjectionStripped(t *testing.T) {
 	}
 }
 
+// A template entry names a template that is already on the machine, so the
+// instruction has to be something an agent can actually run. It used to name
+// `mycel template import`, which has never been a command (#3538).
 func TestComposeInstallMessage_Template(t *testing.T) {
 	req := installRequest{
+		ItemID:     "mycel:engineer",
 		ItemName:   "engineer",
 		ItemType:   "template",
 		ItemSource: "mycel",
 		Agents:     []string{"a"},
 	}
 	msg := composeInstallMessage(req)
-	if !contains(msg, "mycel template import") {
-		t.Errorf("template message should contain 'mycel template import', got:\n%s", msg)
+
+	if !contains(msg, `mycel agent create <agent-name> --template "engineer"`) {
+		t.Errorf("template message should tell the agent to create an agent from the template, got:\n%s", msg)
+	}
+	if contains(msg, "template import") {
+		t.Errorf("template message still names a command that does not exist, got:\n%s", msg)
+	}
+}
+
+// The template's own name is what the flag needs, not the catalog id it is
+// listed under.
+func TestComposeInstallMessage_TemplateStripsTheSourcePrefix(t *testing.T) {
+	msg := composeInstallMessage(installRequest{
+		ItemID:     "mycel:feature-dev",
+		ItemName:   "feature-dev",
+		ItemType:   "template",
+		ItemSource: "mycel",
+		Agents:     []string{"a"},
+	})
+
+	if !contains(msg, `--template "feature-dev"`) {
+		t.Errorf(`want --template "feature-dev" without the catalog prefix, got:\n%s`, msg)
+	}
+	if contains(msg, "mycel:feature-dev") {
+		t.Errorf("the catalog id leaked into the command, got:\n%s", msg)
+	}
+}
+
+// An entry that arrives without an id must still produce a runnable command.
+func TestComposeInstallMessage_TemplateFallsBackToTheName(t *testing.T) {
+	msg := composeInstallMessage(installRequest{
+		ItemName:   "reviewer",
+		ItemType:   "template",
+		ItemSource: "mycel",
+		Agents:     []string{"a"},
+	})
+
+	if !contains(msg, `--template "reviewer"`) {
+		t.Errorf("want the item name used as the template, got:\n%s", msg)
 	}
 }
 


### PR DESCRIPTION
Fixes #3538.

## What was wrong

Adding a template from the marketplace dispatched this instruction to the selected agents:

```
mycel template import "engineer"
```

`mycel template import` has never existed. The template subcommands are `create`, `delete`, `list` and `show`, so an agent that did exactly as it was told got `unknown command` and the install failed. This is the same failure the Glama branch a few lines above goes out of its way to avoid, with a comment explaining why.

## The fix

Templates are also the one entry type with **nothing to install**: the `mycel` source lists `~/.mycel/templates` itself, so the template is already on the machine before anything is dispatched.

What a template is *for* is creating an agent, so that is what the instruction now asks for:

```
This template is already available locally; use it when creating an agent:
mycel agent create <agent-name> --template "engineer"
(mycel template list shows every template on this machine.)
```

The catalog id (`mycel:feature-dev`) is stripped to the template's own name, which is what `--template` takes, and the item name is used when an entry arrives without an id.

`docs/how-to/browse-the-marketplace.md` carried the same wrong command; it now carries the right one and explains why templates need no install step.

## Test plan

- [x] `go test ./server/handlers/` passes, `golangci-lint run server/handlers/...` reports 0 issues
- [x] The existing template test asserted the broken command; it now asserts the runnable one and that `template import` is gone
- [x] Two new tests: the catalog prefix is stripped from the `--template` value, and an entry with no id falls back to its name
- [x] Verified against the running daemon that `mycel agent create --template` exists and `mycel template import` does not
