### PR TITLE
fix(readiness): warn when jq is missing, and say what it costs

### DIFF
--- a/web/src/views/__tests__/readiness.test.tsx
+++ b/web/src/views/__tests__/readiness.test.tsx
@@ -69,6 +69,47 @@ describe("deriveReadiness", () => {
     expect(r.groups.find((g) => g.id === "git")!.status).toBe("fail");
   });
 
+  // jq is how an agent's hooks attach tool names, inputs and results to an
+  // event. Without it the reporters post the bare event, so the Live feed keeps
+  // moving while showing only that something happened — a silent partial
+  // failure in the view used to judge whether anything works (#3493).
+  it("warns, with the consequence spelled out, when jq is missing", () => {
+    const r = deriveReadiness(DOCTOR, HEALTH);
+    const reporting = r.groups.find((g) => g.id === "reporting")!;
+    const jq = reporting.items[0]!;
+
+    expect(reporting.status).toBe("warn");
+    expect(jq.status).toBe("warn");
+    // A warning that does not say what breaks is a warning people scroll past.
+    expect(jq.note).toMatch(/live feed/i);
+    expect(jq.fix).toMatch(/install jq/i);
+  });
+
+  it("recognizes jq under the prefix the doctor actually reports", () => {
+    // Tool-store CLIs come back as "cli:jq" while runtime and provider checks
+    // use bare names. Reading only the bare form warned every machine that had
+    // jq installed the whole time.
+    const withJq: DoctorReport = {
+      categories: [
+        {
+          name: "Tools",
+          items: [
+            { name: "tmux", message: "ok", severity: "ok" },
+            { name: "git", message: "ok", severity: "ok" },
+            { name: "claude", message: "ok", severity: "ok" },
+            { name: "cli:jq", message: "/usr/bin/jq", severity: "ok" },
+          ],
+        },
+      ],
+    };
+    const r = deriveReadiness(withJq, { status: "ok" });
+    const reporting = r.groups.find((g) => g.id === "reporting")!;
+
+    expect(reporting.status).toBe("ok");
+    expect(reporting.items[0]!.detail).toBe("/usr/bin/jq");
+    expect(reporting.items[0]!.note).toBeUndefined();
+  });
+
   it("reports installed vs missing providers", () => {
     const r = deriveReadiness(DOCTOR, HEALTH);
     expect(r.providers.claude).toBe(true);

--- a/web/src/views/readiness/readiness.ts
+++ b/web/src/views/readiness/readiness.ts
@@ -30,7 +30,7 @@ export interface ReadinessItem {
 }
 
 export interface ReadinessGroup {
-  id: "runtime" | "git" | "providers";
+  id: "runtime" | "git" | "reporting" | "providers";
   title: string;
   status: RStatus;
   summary: string;
@@ -169,6 +169,39 @@ export function deriveReadiness(
     ],
   };
 
+  // ── Reporting ────────────────────────────────────────────────────
+  // jq is how an agent's hooks turn a provider's event into a payload carrying
+  // the tool's name, input and result. Without it the reporters fall back to
+  // posting the bare event, so agents keep working and the Live feed keeps
+  // moving — while showing only that *something* happened, never what. That is
+  // a silent partial failure in the one view used to judge whether anything is
+  // working, and nothing anywhere said a word about it (#3493).
+  // The doctor lists tool-store CLIs under a "cli:" prefix while the runtime
+  // and provider checks report bare names; accepting both means this reads the
+  // report as it is rather than as one half of it looks.
+  const jqItem = byName("cli:jq") ?? byName("jq");
+  const jqOk = jqItem?.severity === "ok";
+  const reporting: ReadinessGroup = {
+    id: "reporting",
+    title: "Activity reporting",
+    status: jqOk ? "ok" : "warn",
+    summary: jqOk
+      ? "jq is installed — agents report full tool detail."
+      : "Without jq, agents report that events happened but not what they were.",
+    items: [
+      {
+        key: "jq",
+        label: "jq",
+        detail: jqOk ? (jqItem?.message ?? "installed") : "not found",
+        status: jqOk ? "ok" : "warn",
+        fix: jqOk ? undefined : (jqItem?.fix ?? "brew install jq   OR  apt install jq"),
+        note: jqOk
+          ? undefined
+          : "Agents still run. Their hooks fall back to posting the bare event, so the Live feed loses tool names, inputs and results.",
+      },
+    ],
+  };
+
   // ── Providers ────────────────────────────────────────────────────
   const providers: Record<string, boolean> = {};
   const providerItems: ReadinessItem[] = PROVIDER_NAMES.map((name) => {
@@ -221,7 +254,7 @@ export function deriveReadiness(
     headline = "Ready to run agents";
     // Honest subline: reflect the worst *item* below, not just group rollups —
     // an optional missing tool (amber row) shouldn't read as "all clear".
-    const allItems = [runtime, git, providerGroup].flatMap((g) => g.items.map((i) => i.status));
+    const allItems = [runtime, git, reporting, providerGroup].flatMap((g) => g.items.map((i) => i.status));
     subline = worst(...allItems) === "ok"
       ? "Everything checks out."
       : "Essentials are in place. A few optional extras below could smooth things out.";
@@ -233,7 +266,7 @@ export function deriveReadiness(
     overall,
     headline,
     subline,
-    groups: [runtime, git, providerGroup],
+    groups: [runtime, git, reporting, providerGroup],
     providers,
     tmuxOk,
     dockerOk,


### PR DESCRIPTION
Fixes #3493.

## What was wrong

`jq` is how an agent's hooks turn a provider's event into a payload carrying the tool's name, input and result. Without it the reporters fall back to posting the bare event, so agents keep running and the Live feed keeps moving — while showing only that *something* happened, never what.

That is the worst shape a failure can take: silent, partial, and in the one view people use to judge whether anything is working at all.

The machine already knew: the doctor checks jq and reports it. But the readiness model — which drives both the Readiness page and the boot console that streams from it — never mentioned it. So nothing anywhere said a word.

## The fix

Readiness carries a new **Activity reporting** group. Its note says what breaks, not just that something is missing:

> Agents still run. Their hooks fall back to posting the bare event, so the Live feed loses tool names, inputs and results.

It warns rather than fails, because agents genuinely do still run, and it offers `brew install jq   OR  apt install jq`.

Because the boot console streams every readiness item, this now also surfaces at startup rather than only on a page someone has to think to visit.

## One trap worth noting

The lookup accepts **both** `cli:jq` and `jq`. Tool-store CLIs are reported under a `cli:` prefix (`{"name":"cli:jq","message":"/usr/bin/jq","severity":"ok"}`) while the runtime and provider checks use bare names. Reading only the bare form would have warned every machine that had jq installed the whole time — a false alarm worse than the silence it replaced. There is a test for exactly that.

## Test plan

- [x] `npx vitest run` — 52 files, 465 tests pass (2 new), `tsc --noEmit` clean
- [x] New tests: a missing jq warns with the consequence and a fix, and a jq reported as `cli:jq` reads as ok with no note
- [x] Verified against the running daemon's real `/api/doctor`, which reports `cli:jq` → the group reads ok, as it should on this machine
