### PR TITLE
fix(up): report the daemon's real pid instead of -1

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -313,15 +313,21 @@ func runUpDaemon(repoRoot string) error {
 	_ = logFile.Close()
 	_ = nullFile.Close()
 
+	// Read the pid before releasing the process: Release invalidates the handle
+	// and leaves Pid as -1, so reporting it afterwards told everyone their
+	// daemon had started as "PID -1" — a number that cannot be signaled or
+	// looked up, from a daemon that had in fact started fine.
+	pid := cmd.Process.Pid
+
 	// Write PID file
-	if writeErr := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", cmd.Process.Pid)), 0600); writeErr != nil {
+	if writeErr := os.WriteFile(pidPath, []byte(fmt.Sprintf("%d\n", pid)), 0600); writeErr != nil {
 		log.Warn("failed to write PID file", "path", pidPath, "error", writeErr)
 	}
 
 	// Detach — don't wait for the process
 	_ = cmd.Process.Release()
 
-	fmt.Printf("  %s mycel server started (PID %d)\n", ui.GreenText("ok"), cmd.Process.Pid)
+	fmt.Printf("  %s mycel server started (PID %d)\n", ui.GreenText("ok"), pid)
 	fmt.Printf("  http://%s\n", upAddr)
 	fmt.Printf("  logs: %s\n", logPath)
 	fmt.Printf("  pid:  %s\n", pidPath)

--- a/web/src/views/__tests__/readiness.test.tsx
+++ b/web/src/views/__tests__/readiness.test.tsx
@@ -69,6 +69,47 @@ describe("deriveReadiness", () => {
     expect(r.groups.find((g) => g.id === "git")!.status).toBe("fail");
   });
 
+  // jq is how an agent's hooks attach tool names, inputs and results to an
+  // event. Without it the reporters post the bare event, so the Live feed keeps
+  // moving while showing only that something happened — a silent partial
+  // failure in the view used to judge whether anything works (#3493).
+  it("warns, with the consequence spelled out, when jq is missing", () => {
+    const r = deriveReadiness(DOCTOR, HEALTH);
+    const reporting = r.groups.find((g) => g.id === "reporting")!;
+    const jq = reporting.items[0]!;
+
+    expect(reporting.status).toBe("warn");
+    expect(jq.status).toBe("warn");
+    // A warning that does not say what breaks is a warning people scroll past.
+    expect(jq.note).toMatch(/live feed/i);
+    expect(jq.fix).toMatch(/install jq/i);
+  });
+
+  it("recognizes jq under the prefix the doctor actually reports", () => {
+    // Tool-store CLIs come back as "cli:jq" while runtime and provider checks
+    // use bare names. Reading only the bare form warned every machine that had
+    // jq installed the whole time.
+    const withJq: DoctorReport = {
+      categories: [
+        {
+          name: "Tools",
+          items: [
+            { name: "tmux", message: "ok", severity: "ok" },
+            { name: "git", message: "ok", severity: "ok" },
+            { name: "claude", message: "ok", severity: "ok" },
+            { name: "cli:jq", message: "/usr/bin/jq", severity: "ok" },
+          ],
+        },
+      ],
+    };
+    const r = deriveReadiness(withJq, { status: "ok" });
+    const reporting = r.groups.find((g) => g.id === "reporting")!;
+
+    expect(reporting.status).toBe("ok");
+    expect(reporting.items[0]!.detail).toBe("/usr/bin/jq");
+    expect(reporting.items[0]!.note).toBeUndefined();
+  });
+
   it("reports installed vs missing providers", () => {
     const r = deriveReadiness(DOCTOR, HEALTH);
     expect(r.providers.claude).toBe(true);

--- a/web/src/views/readiness/readiness.ts
+++ b/web/src/views/readiness/readiness.ts
@@ -30,7 +30,7 @@ export interface ReadinessItem {
 }
 
 export interface ReadinessGroup {
-  id: "runtime" | "git" | "providers";
+  id: "runtime" | "git" | "reporting" | "providers";
   title: string;
   status: RStatus;
   summary: string;
@@ -169,6 +169,39 @@ export function deriveReadiness(
     ],
   };
 
+  // ── Reporting ────────────────────────────────────────────────────
+  // jq is how an agent's hooks turn a provider's event into a payload carrying
+  // the tool's name, input and result. Without it the reporters fall back to
+  // posting the bare event, so agents keep working and the Live feed keeps
+  // moving — while showing only that *something* happened, never what. That is
+  // a silent partial failure in the one view used to judge whether anything is
+  // working, and nothing anywhere said a word about it (#3493).
+  // The doctor lists tool-store CLIs under a "cli:" prefix while the runtime
+  // and provider checks report bare names; accepting both means this reads the
+  // report as it is rather than as one half of it looks.
+  const jqItem = byName("cli:jq") ?? byName("jq");
+  const jqOk = jqItem?.severity === "ok";
+  const reporting: ReadinessGroup = {
+    id: "reporting",
+    title: "Activity reporting",
+    status: jqOk ? "ok" : "warn",
+    summary: jqOk
+      ? "jq is installed — agents report full tool detail."
+      : "Without jq, agents report that events happened but not what they were.",
+    items: [
+      {
+        key: "jq",
+        label: "jq",
+        detail: jqOk ? (jqItem?.message ?? "installed") : "not found",
+        status: jqOk ? "ok" : "warn",
+        fix: jqOk ? undefined : (jqItem?.fix ?? "brew install jq   OR  apt install jq"),
+        note: jqOk
+          ? undefined
+          : "Agents still run. Their hooks fall back to posting the bare event, so the Live feed loses tool names, inputs and results.",
+      },
+    ],
+  };
+
   // ── Providers ────────────────────────────────────────────────────
   const providers: Record<string, boolean> = {};
   const providerItems: ReadinessItem[] = PROVIDER_NAMES.map((name) => {
@@ -221,7 +254,7 @@ export function deriveReadiness(
     headline = "Ready to run agents";
     // Honest subline: reflect the worst *item* below, not just group rollups —
     // an optional missing tool (amber row) shouldn't read as "all clear".
-    const allItems = [runtime, git, providerGroup].flatMap((g) => g.items.map((i) => i.status));
+    const allItems = [runtime, git, reporting, providerGroup].flatMap((g) => g.items.map((i) => i.status));
     subline = worst(...allItems) === "ok"
       ? "Everything checks out."
       : "Essentials are in place. A few optional extras below could smooth things out.";
@@ -233,7 +266,7 @@ export function deriveReadiness(
     overall,
     headline,
     subline,
-    groups: [runtime, git, providerGroup],
+    groups: [runtime, git, reporting, providerGroup],
     providers,
     tmuxOk,
     dockerOk,


### PR DESCRIPTION
Fixes #3511.

## What was wrong

```
$ mycel up -d
  ok mycel server started (PID -1)
```

The pid was read from the process handle **after** `Release()` was called on it. `Release` invalidates the handle and leaves `Pid` as `-1`, so the one number that line exists to give you was a number that cannot be signaled or looked up — from a daemon that had in fact started perfectly well.

Confirmed the mechanism directly:

```
before Release: 32822, after Release: -1
```

## The fix

Read the pid before releasing the handle.

The pid file was always correct, because it was written before the release. Only the message a person reads was wrong — which is the version of this bug that costs someone time.

## Verified

```
$ mycel up -d
  ok mycel server started (PID 33588)
  pid:  /Users/…/.mycel/run/daemon.pid

$ cat ~/.mycel/run/daemon.pid
33588
$ kill -0 33588 && echo signallable
signallable
```

## Test plan

- [x] `go build ./internal/cmd/` and `golangci-lint run internal/cmd/...` clean
- [x] Verified end-to-end with the real command, as above: the printed pid matches the pid file and is a live process
- [x] No unit test: reaching this line means spawning a real detached daemon, and the manual check above exercises exactly the path that was broken


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Activity reporting** readiness check for `jq`.
  - Readiness now shows whether `jq` is installed, identifies its detected path, and explains fallback behavior.
  - Added installation guidance when `jq` is missing, including its impact on Live feed activity.

- **Bug Fixes**
  - Improved daemon startup reporting so the displayed process ID and PID file consistently contain the correct value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->