### PR TITLE
fix(providers): offer only the actions the daemon can actually perform

### DIFF
--- a/web/src/components/ProvidersTable.tsx
+++ b/web/src/components/ProvidersTable.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import type { ProviderInfo } from "../api/client";
+import { canAutoInstall } from "../utils/providerActions";
 import { formatCost, formatTokens } from "../utils/format";
 import { PROVIDER_LABELS } from "../views/readiness/readiness";
 import { ProviderLogo } from "./ProviderLogo";
@@ -182,7 +183,7 @@ export function ProvidersTable({ providers, search }: Props) {
                 <td className="px-4 py-3 text-right tabular-nums">{formatCost(p.total_cost_usd)}</td>
                 <td className="px-4 py-3 text-right">
                   <div className="flex items-center justify-end gap-1.5" onClick={(e) => e.stopPropagation()}>
-                    {!p.installed && p.install_hint && (
+                    {!p.installed && canAutoInstall(p.install_hint) && (
                       <button
                         type="button"
                         onClick={() => navigate(to)}
@@ -191,7 +192,7 @@ export function ProvidersTable({ providers, search }: Props) {
                         Install
                       </button>
                     )}
-                    {p.installed && p.install_hint && (
+                    {p.installed && canAutoInstall(p.install_hint) && (
                       <button
                         type="button"
                         onClick={() => navigate(to)}

--- a/web/src/components/__tests__/ProvidersTable.test.tsx
+++ b/web/src/components/__tests__/ProvidersTable.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * ProvidersTable.test — the table must not offer an action the provider's detail
+ * page knows is impossible.
+ *
+ * The table showed Install/Update whenever an install hint was non-empty, while
+ * the detail page gated the real control on the hint being runnable. So Install
+ * for cursor led to a page that only offers the URL as copyable text: a button
+ * that promises an installation and delivers a link (#3475).
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import type { ProviderInfo } from "../../api/client";
+import { ProvidersTable } from "../ProvidersTable";
+
+function provider(overrides: Partial<ProviderInfo> = {}): ProviderInfo {
+  return {
+    name: "codex",
+    description: "OpenAI Codex CLI",
+    binary: "codex",
+    command: "codex",
+    install_hint: "npm install -g @openai/codex",
+    version: "",
+    status: "not_installed",
+    models: [],
+    total_cost_usd: 0,
+    total_tokens: 0,
+    agent_count: 0,
+    installed: false,
+    enabled: false,
+    ...overrides,
+  } as ProviderInfo;
+}
+
+function renderTable(providers: ProviderInfo[]) {
+  return render(
+    <MemoryRouter>
+      <ProvidersTable providers={providers} search="" />
+    </MemoryRouter>,
+  );
+}
+
+describe("ProvidersTable install actions", () => {
+  it("offers Install when the hint is a command the daemon can run", () => {
+    renderTable([provider()]);
+    expect(screen.getByRole("button", { name: "Install" })).toBeTruthy();
+  });
+
+  it("offers Update for an installed provider with a runnable hint", () => {
+    renderTable([provider({ installed: true, version: "1.0.0", status: "healthy" })]);
+    expect(screen.getByRole("button", { name: "Update" })).toBeTruthy();
+  });
+
+  it("offers neither for a hint that is only a download page", () => {
+    // cursor's real hint. There is no command here to run.
+    renderTable([
+      provider({ name: "cursor", binary: "cursor-agent", install_hint: "https://cursor.sh" }),
+    ]);
+
+    expect(screen.queryByRole("button", { name: "Install" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Update" })).toBeNull();
+    // The row is still reachable — the detail page is where the URL is shown.
+    expect(screen.getByRole("button", { name: /configure/i })).toBeTruthy();
+  });
+
+  it("still offers Configure for a provider it cannot install", () => {
+    renderTable([
+      provider({ name: "cursor", install_hint: "https://cursor.sh", installed: true, version: "2026.07.23" }),
+    ]);
+    expect(screen.getByRole("button", { name: /configure/i })).toBeTruthy();
+  });
+});

--- a/web/src/utils/__tests__/providerActions.test.ts
+++ b/web/src/utils/__tests__/providerActions.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { canAutoInstall, canAutoUninstall } from "../providerActions";
+
+/**
+ * These predicates exist to keep the UI from offering an action the daemon will
+ * refuse. The refusal arrives after the click — and for Remove, after a two-click
+ * destructive confirm — so a wrong answer here is not cosmetic (#3475).
+ *
+ * The hints below are the real ones the providers ship.
+ */
+describe("canAutoInstall", () => {
+  it("accepts a hint that is a command", () => {
+    expect(canAutoInstall("npm install -g @anthropic-ai/claude-code")).toBe(true);
+    expect(canAutoInstall("brew install codex")).toBe(true);
+    expect(canAutoInstall("curl -fsSL https://agy.sh/install | sh")).toBe(true);
+  });
+
+  it("refuses a bare download URL", () => {
+    // cursor's hint is literally this: a page a person visits, not a command.
+    expect(canAutoInstall("https://cursor.sh")).toBe(false);
+    expect(canAutoInstall("http://example.com/download")).toBe(false);
+  });
+
+  it("refuses nothing at all", () => {
+    expect(canAutoInstall("")).toBe(false);
+    expect(canAutoInstall("   ")).toBe(false);
+    expect(canAutoInstall(null)).toBe(false);
+    expect(canAutoInstall(undefined)).toBe(false);
+  });
+});
+
+describe("canAutoUninstall", () => {
+  it("accepts the three forms the daemon can invert", () => {
+    expect(canAutoUninstall("npm install -g @anthropic-ai/claude-code")).toBe(true);
+    expect(canAutoUninstall("npm i -g mycel-cli")).toBe(true);
+    expect(canAutoUninstall("brew install tmux")).toBe(true);
+  });
+
+  it("refuses an installer with nothing to invert", () => {
+    // agy installs by piping a script into sh; there is no uninstall to derive,
+    // and the daemon answers HTTP 400. The button used to be rendered anyway.
+    expect(canAutoUninstall("curl -fsSL https://agy.sh/install | sh")).toBe(false);
+    expect(canAutoUninstall("https://cursor.sh")).toBe(false);
+    expect(canAutoUninstall("go install github.com/foo/bar@latest")).toBe(false);
+  });
+
+  it("refuses a package manager prefix with no package after it", () => {
+    expect(canAutoUninstall("npm install -g ")).toBe(false);
+    expect(canAutoUninstall("brew install")).toBe(false);
+  });
+
+  it("refuses nothing at all", () => {
+    expect(canAutoUninstall("")).toBe(false);
+    expect(canAutoUninstall(null)).toBe(false);
+    expect(canAutoUninstall(undefined)).toBe(false);
+  });
+});

--- a/web/src/utils/providerActions.ts
+++ b/web/src/utils/providerActions.ts
@@ -1,0 +1,50 @@
+/**
+ * providerActions — whether the daemon can actually carry out an install or
+ * uninstall for a given install hint.
+ *
+ * The daemon derives both commands from a provider's install hint, and it
+ * refuses the cases it cannot derive. The UI has to know the same rules, because
+ * offering an action the server will refuse is worse than not offering it: the
+ * refusal arrives after the click, and for Remove that is after a two-click
+ * destructive confirm (#3475).
+ *
+ * These predicates therefore mirror the server deliberately, and are kept in one
+ * place so a table and a detail page cannot drift into disagreeing about what is
+ * possible — which is exactly how the table came to offer Install for a provider
+ * whose detail page knew better.
+ */
+
+/**
+ * canAutoInstall mirrors the daemon's providerInstallCmd/runnableInstallHint
+ * predicate: a hint is executable unless it is empty or a bare download URL.
+ *
+ * Cursor's hint is literally "https://cursor.sh" — a page a human visits, not a
+ * command. Offering Install for it led to a screen showing the URL as copyable
+ * text, which is a fine thing to show and a poor thing to promise.
+ */
+export function canAutoInstall(hint: string | undefined | null): boolean {
+  if (!hint) return false;
+  const h = hint.trim();
+  return h !== "" && !h.startsWith("http://") && !h.startsWith("https://");
+}
+
+/**
+ * canAutoUninstall mirrors the daemon's deriveUninstall: only a global npm
+ * install or a brew install can be turned into an uninstall command, and only
+ * when a package name follows.
+ *
+ * Everything else — agy's `curl -fsSL … | sh`, cursor's URL — leaves nothing to
+ * derive, and the daemon answers HTTP 400. The Remove button was styled
+ * destructively and rendered anyway, so the only way to learn this was to
+ * confirm twice and read an error.
+ */
+export function canAutoUninstall(hint: string | undefined | null): boolean {
+  if (!hint) return false;
+  const cmd = hint.trim();
+  for (const prefix of ["npm install -g ", "npm i -g ", "brew install "]) {
+    if (cmd.startsWith(prefix)) {
+      return cmd.slice(prefix.length).trim() !== "";
+    }
+  }
+  return false;
+}

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -10,6 +10,7 @@ import type {
   ModelInfo,
 } from "../api/client";
 import { installDep } from "../wizard/installStream";
+import { canAutoInstall, canAutoUninstall } from "../utils/providerActions";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
@@ -62,16 +63,10 @@ function providerStatus(provider: ProviderDetailResponse): string {
 
 /* ── Real install / update actions ────────────────────────────────────
  *
- * canAutoInstall mirrors the server's providerInstallCmd predicate
- * (deps_install.go): a hint is executable when it isn't empty and isn't a
- * bare download URL (e.g. cursor's "https://cursor.sh" — a GUI installer
- * with no runnable command). Install and update both stream through
- * installDep-compatible NDJSON endpoints, so the two share one console UI. */
-function canAutoInstall(hint: string | undefined | null): boolean {
-  if (!hint) return false;
-  const h = hint.trim();
-  return h !== "" && !h.startsWith("http://") && !h.startsWith("https://");
-}
+ * Install and update both stream through installDep-compatible NDJSON
+ * endpoints, so the two share one console UI. Whether either is possible at
+ * all is decided by canAutoInstall — see utils/providerActions, which is where
+ * the table reads the same rule from. */
 
 type RunState = "idle" | "running" | "ok" | "error";
 
@@ -260,9 +255,11 @@ function UpdateAction({
  * /api/providers/:name/uninstall, which derives an uninstall command from
  * the provider's vetted install hint and streams live NDJSON output — same
  * console UX as Install/Update. Destructive, so it sits behind the shared
- * two-click ConfirmButton. Only ever rendered for installed, non-default
- * providers — see the `installed && !isDefault` guard at the call site,
- * which mirrors the server's own isRequiredProvider refusal. */
+ * two-click ConfirmButton. The call site renders it only for an installed,
+ * non-default provider whose hint an uninstall can be derived from, mirroring
+ * both of the server's refusals — isRequiredProvider and deriveUninstall.
+ * Mirroring only the first one meant agy and cursor showed a destructive Remove
+ * that answered HTTP 400 after both clicks. */
 function UninstallAction({
   providerName,
   onUninstalled,
@@ -522,7 +519,7 @@ function ProviderHeader({
             </>
           )}
           <SignInAction provider={provider} onToast={onToast} />
-          {provider.installed && !isDefault && (
+          {provider.installed && !isDefault && canAutoUninstall(provider.install_hint) && (
             <UninstallAction providerName={provider.name} onUninstalled={onUninstalled} />
           )}
         </div>
@@ -741,6 +738,24 @@ function resolveMCPHealth(server: ProviderMCPServer, healthMap: Record<string, {
 function MCPHealthSummary({ servers, healthMap }: { servers: ProviderMCPServer[]; healthMap: Record<string, { status: string; error?: string }> }) {
   if (servers.length === 0) return null;
 
+  // healthMap is only populated by "Check All MCPs", so before that every server
+  // resolves to unknown. Counting them as unhealthy rendered a red "0/2 healthy"
+  // for servers that were perfectly fine and had simply never been asked — a
+  // false negative dressed as a measurement (#3475). Nothing has been measured
+  // yet, so the bar says exactly that.
+  const checked = Object.keys(healthMap).length > 0;
+  if (!checked) {
+    return (
+      <div className="mb-3">
+        <div className="flex items-center justify-between text-xs text-mycel-muted mb-1">
+          <span>MCP Health</span>
+          <span className="tabular-nums">—/{servers.length} checked</span>
+        </div>
+        <div className="h-1.5 rounded-full bg-mycel-border overflow-hidden" />
+      </div>
+    );
+  }
+
   const healthy = servers.filter((s) => {
     const h = resolveMCPHealth(s, healthMap);
     return h.status === "connected";
@@ -751,7 +766,7 @@ function MCPHealthSummary({ servers, healthMap }: { servers: ProviderMCPServer[]
     <div className="mb-3">
       <div className="flex items-center justify-between text-xs text-mycel-muted mb-1">
         <span>MCP Health</span>
-        <span>{healthy}/{servers.length} healthy</span>
+        <span className="tabular-nums">{healthy}/{servers.length} healthy</span>
       </div>
       <div className="h-1.5 rounded-full bg-mycel-border overflow-hidden">
         <motion.div

--- a/web/src/views/__tests__/ProviderDetail.test.tsx
+++ b/web/src/views/__tests__/ProviderDetail.test.tsx
@@ -59,11 +59,14 @@ function baseProvider(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function renderDetail(provider: ReturnType<typeof baseProvider>) {
+function renderDetail(
+  provider: ReturnType<typeof baseProvider>,
+  mcps: Array<Record<string, unknown>> = [],
+) {
   fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
     const u = String(url);
     if (u.endsWith("/commands")) return jsonResponse([]);
-    if (u.endsWith("/mcps")) return jsonResponse([]);
+    if (u.endsWith("/mcps")) return jsonResponse(mcps);
     if (u.endsWith("/models")) return jsonResponse(provider.models ?? []);
     if (u === "/api/deps/install" && init?.method === "POST") {
       return streamResponse([
@@ -132,6 +135,23 @@ describe("ProviderDetail install", () => {
   });
 });
 
+// The health map is only filled by "Check All MCPs". Counting an unasked server
+// as unhealthy rendered a red "0/2 healthy" for servers that were fine — a false
+// negative presented as a measurement (#3475).
+describe("ProviderDetail MCP health summary", () => {
+  const servers = [
+    { name: "context7", command: "npx", args: ["-y", "@upstash/context7-mcp"], type: "stdio", status: "ok" },
+    { name: "playwright", command: "npx", args: ["-y", "@playwright/mcp"], type: "stdio", status: "ok" },
+  ];
+
+  it("says nothing has been checked yet instead of reporting zero healthy", async () => {
+    renderDetail(baseProvider({ installed: true, version: "1.0.0", status: "healthy" }), servers);
+
+    expect(await screen.findByText("—/2 checked")).toBeTruthy();
+    expect(screen.queryByText("0/2 healthy")).toBeNull();
+  });
+});
+
 describe("ProviderDetail update", () => {
   it("streams a real update via POST /api/providers/:name/update", async () => {
     renderDetail(baseProvider({ installed: true, version: "1.0.0", status: "healthy" }));
@@ -154,6 +174,35 @@ describe("ProviderDetail update", () => {
 
     await screen.findByText("cursor");
     expect(screen.queryByRole("button", { name: "Update now" })).toBeNull();
+  });
+
+  // The daemon derives an uninstall command from the install hint and refuses
+  // when it cannot. The UI mirrored only the other refusal (default providers),
+  // so agy — installed by piping a script into sh — showed a destructive Remove
+  // that answered HTTP 400 after both confirm clicks (#3475).
+  it("does not offer Remove when no uninstall can be derived from the hint", async () => {
+    renderDetail(baseProvider({
+      name: "agy",
+      install_hint: "curl -fsSL https://agy.sh/install | sh",
+      installed: true,
+      version: "1.1.10",
+      status: "healthy",
+    }));
+
+    await screen.findByText("agy");
+    expect(screen.queryByRole("button", { name: /remove/i })).toBeNull();
+  });
+
+  it("still offers Remove when the hint is a global npm install", async () => {
+    renderDetail(baseProvider({
+      name: "codex",
+      install_hint: "npm install -g @openai/codex",
+      installed: true,
+      version: "1.0.0",
+      status: "healthy",
+    }));
+
+    expect(await screen.findByRole("button", { name: /remove/i })).toBeTruthy();
   });
 
   it("check-update surfaces an honest 'couldn't verify' message when the server reports checked=false", async () => {


### PR DESCRIPTION
Fixes #3475 (the three UI defects; the SSE health probe noted at the end of that issue is server-side and left for a follow-up).

Three defects of one shape: the interface asserted something it had not established.

## 1. Install / Update offered for hints that are not commands

The table showed both whenever `install_hint` was non-empty, while the detail page gated the real control on the hint being *runnable*. Cursor's hint is literally `https://cursor.sh`, so Install led to a page offering the URL as copyable text — a button that promises an installation and delivers a link.

The predicate already existed three times (`canAutoInstall` in the UI, `runnableInstallHint` and `providerInstallCmd` on the server). It now lives in one module that both surfaces read, so a table and a detail page cannot drift into disagreeing about what is possible — which is how this happened.

## 2. Remove offered where no uninstaller can be derived

The call site mirrored only the server's default-provider refusal, not `deriveUninstall`, which inverts a global `npm install` or a `brew install` and nothing else. So `agy` — installed by piping a script into `sh` — showed a **destructively styled Remove that answered HTTP 400 after both clicks of the confirm**.

## 3. "0/N healthy" in red before anything was checked

The health map is only populated by "Check All MCPs", so until then every server resolves to `unknown`. Counting those as unhealthy rendered a red `0/2 healthy` for servers that were fine and had simply never been asked — a false negative dressed as a measurement. It now reads `—/2 checked` in grey.

## Verified against the running daemon

| Provider | Hint | Before | After |
|---|---|---|---|
| cursor | `https://cursor.sh` | Update in the table, Update + Remove on detail | neither; Check for Update remains |
| agy | `curl -fsSL … \| sh` | Remove → HTTP 400 after confirm | Update kept, Remove gone |
| codex | `npm install -g @openai/codex` | both | both, unchanged |

In the real table, cursor's action cell is now empty while agy, claude, codex, openclaw and pi all keep Update.

## Test plan

- [x] `npx vitest run` — 54 files, 479 tests pass (13 new), `tsc --noEmit` clean
- [x] New `providerActions` tests cover every real provider hint shape, including a package-manager prefix with no package after it
- [x] New `ProvidersTable` tests: Install/Update appear for a runnable hint, neither appears for a download page, and Configure stays reachable either way
- [x] New `ProviderDetail` tests: no Remove for a curl-pipe-sh installer, Remove kept for a global npm install, and the MCP bar reports "—/2 checked" rather than "0/2 healthy" before any check
- [x] Verified in the running UI against all six installed providers, as tabulated above


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Install and Update actions now appear only when automatic installation is supported.
  * Remove actions are hidden when automatic uninstallation is unavailable.
  * MCP health summaries now distinguish unchecked servers from unhealthy servers.
  * Providers installed through supported package managers retain the Remove option.

* **Tests**
  * Added coverage for supported and unsupported installation, uninstallation, and MCP health scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->