### PR TITLE
fix(ui): honor the Default view preference

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -93,3 +93,73 @@ describe("HomeGate", () => {
     expect(screen.queryByText("Settings Page")).not.toBeInTheDocument();
   });
 });
+
+/**
+ * "Default view" was saved, displayed, and never read: pick Agents or Insights
+ * and you still landed on Home every time (#3474).
+ */
+describe("HomeGate default view", () => {
+  function renderIndex(defaultView: string, firstRun = false) {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/onboarding")) return jsonResponse({ firstRun });
+      if (u.includes("/api/settings")) {
+        return jsonResponse({ ui: { theme: "dark", mode: "auto", default_view: defaultView } });
+      }
+      return jsonResponse({});
+    });
+    return render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<HomeGate honorDefaultView />} />
+          <Route path="/agents" element={<div>Agents Page</div>} />
+          <Route path="/insights" element={<div>Insights Page</div>} />
+          <Route path="/settings" element={<div>Settings Page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it("lands on Agents when that is the chosen default", async () => {
+    renderIndex("agents");
+    await waitFor(() => expect(screen.getByText("Agents Page")).toBeTruthy());
+  });
+
+  it("lands on Insights when that is the chosen default", async () => {
+    renderIndex("insights");
+    await waitFor(() => expect(screen.getByText("Insights Page")).toBeTruthy());
+  });
+
+  it("treats an unrecognized value as Home rather than a dead end", async () => {
+    // "dashboard" is an older spelling still sitting in some prefs files.
+    renderIndex("dashboard");
+    await waitFor(() => expect(screen.queryByText("Agents Page")).toBeNull());
+    expect(screen.queryByText("Insights Page")).toBeNull();
+  });
+
+  it("still sends a fresh install to setup, whatever the preference says", async () => {
+    // Being dropped into an unfinished setup matters more than a view choice.
+    renderIndex("agents", true);
+    await waitFor(() => expect(screen.getByText("Settings Page")).toBeTruthy());
+  });
+
+  it("does not override an explicit request for /home", async () => {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/onboarding")) return jsonResponse({ firstRun: false });
+      if (u.includes("/api/settings")) {
+        return jsonResponse({ ui: { theme: "dark", mode: "auto", default_view: "agents" } });
+      }
+      return jsonResponse({});
+    });
+    render(
+      <MemoryRouter initialEntries={["/home"]}>
+        <Routes>
+          <Route path="/home" element={<HomeGate />} />
+          <Route path="/agents" element={<div>Agents Page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.queryByText("Agents Page")).toBeNull());
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,8 +33,25 @@ function Loading() {
  * Any probe failure (or a positive "not first run") falls through to Home,
  * so a daemon hiccup never traps the user in onboarding.
  */
-export function HomeGate() {
+/** Where "Default view" can actually send you, and the route for each. */
+const DEFAULT_VIEW_ROUTES: Record<string, string> = { agents: "/agents", insights: "/insights" };
+
+/**
+ * HomeGate — what the root path resolves to.
+ *
+ * `honorDefaultView` is set only on the index route. Someone who asks for /home
+ * has named the view they want, so the preference does not override them; it
+ * decides what "no route at all" means, which is the only thing it was ever
+ * offering to do.
+ *
+ * That preference used to be saved, displayed, and never read: you picked Agents
+ * or Insights and always landed on Home (#3474). First run still wins — being
+ * sent to an unfinished setup matters more than a view preference.
+ */
+export function HomeGate({ honorDefaultView = false }: { honorDefaultView?: boolean } = {}) {
   const [status, setStatus] = useState<"pending" | "home" | "settings">("pending");
+  const [defaultRoute, setDefaultRoute] = useState<string | null>(null);
+
   useEffect(() => {
     let cancelled = false;
     api
@@ -49,8 +66,31 @@ export function HomeGate() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!honorDefaultView) return;
+    let cancelled = false;
+    api
+      .getSettings()
+      .then((cfg) => {
+        // Anything unrecognized — including the "home" default and an older
+        // spelling like "dashboard" — means Home, which is what rendering
+        // nothing special does.
+        const choice = cfg.ui?.default_view ?? "";
+        if (!cancelled) setDefaultRoute(DEFAULT_VIEW_ROUTES[choice] ?? null);
+      })
+      .catch(() => {
+        // A preference is not worth blocking the app over.
+        if (!cancelled) setDefaultRoute(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [honorDefaultView]);
+
   if (status === "pending") return <Loading />;
   if (status === "settings") return <Navigate to="/settings" replace />;
+  if (defaultRoute) return <Navigate to={defaultRoute} replace />;
   return <Home />;
 }
 
@@ -108,7 +148,7 @@ export function AppRoutes() {
           Bookmarked /welcome links redirect to Settings. */}
       <Route path="welcome" element={<Navigate to="/settings" replace />} />
       <Route element={<Layout />}>
-        <Route index element={wrap(<HomeGate />)} />
+        <Route index element={wrap(<HomeGate honorDefaultView />)} />
         <Route path="home" element={wrap(<HomeGate />)} />
         {/* Live view became the Home page — old links/bookmarks redirect. */}
         <Route path="live" element={<Navigate to="/" replace />} />


### PR DESCRIPTION
Fixes #3549. Split out of #3474, where six settings that save, display and are never read were grouped; this is the one that is a plumb.

## What was wrong

Settings offers **Default view** — Home / Agents / Insights. Choosing Agents saved fine and showed your choice back on reload, and then you landed on Home every time: `App.tsx` routed the `index` element to `HomeGate` unconditionally, and nothing read `ui.default_view`. Its only reader anywhere was a print in `mycel config show`.

## Decisions worth stating

- **Index route only.** The preference decides what "no route at all" means. Someone who navigates to `/home` has named the view they want, and a stored default should not argue with them.
- **First run still wins.** Being dropped into an unfinished setup matters more than a view preference.
- **Unrecognized means Home.** Including the older `dashboard` spelling still sitting in some prefs files — so an old prefs file cannot strand anyone on a route that no longer exists.
- **A failed prefs fetch is not fatal.** A view preference is not worth blocking the app over; it falls through to Home.

## Test plan

- [x] `npx vitest run` — 54 files, 484 tests pass (5 new), `tsc --noEmit` clean
- [x] Agents and Insights each become the landing view when chosen
- [x] An unrecognized value lands on Home rather than a dead end
- [x] A fresh install still goes to setup with `agents` selected
- [x] `/home` still renders Home with `agents` selected