### PR TITLE
fix(ui): keep Home reachable when a default view is set

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -13,6 +13,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import { HomeGate } from "./App";
+import { __resetDefaultViewForTests } from "./utils/defaultView";
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
 
@@ -99,6 +100,11 @@ describe("HomeGate", () => {
  * and you still landed on Home every time (#3474).
  */
 describe("HomeGate default view", () => {
+  beforeEach(() => {
+    // The entry decision is per document, so it outlives a render tree.
+    __resetDefaultViewForTests("/");
+  });
+
   function renderIndex(defaultView: string, firstRun = false) {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {
       const u = String(url);
@@ -161,5 +167,75 @@ describe("HomeGate default view", () => {
       </MemoryRouter>,
     );
     await waitFor(() => expect(screen.queryByText("Agents Page")).toBeNull());
+  });
+});
+
+/**
+ * The preference decides where the app opens, not where it goes once open. The
+ * navigation's Home link points at "/", so honoring the preference on every
+ * mount of the root route made clicking Home land on Agents — Home became
+ * unreachable, and the back button bounced you forward again (#3556).
+ */
+describe("HomeGate default view only redirects the entry navigation", () => {
+  function mockPrefs(defaultView: string) {
+    fetchMock.mockImplementation((url: RequestInfo | URL) => {
+      const u = String(url);
+      if (u.includes("/api/onboarding")) return jsonResponse({ firstRun: false });
+      if (u.includes("/api/settings")) {
+        return jsonResponse({ ui: { theme: "dark", mode: "auto", default_view: defaultView } });
+      }
+      return jsonResponse({});
+    });
+  }
+
+  function renderRoot() {
+    return render(
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route path="/" element={<HomeGate honorDefaultView />} />
+          <Route path="/agents" element={<div>Agents Page</div>} />
+          <Route path="/settings" element={<div>Settings Page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it("leaves Home alone when the app was opened somewhere else", async () => {
+    // Someone opened /agents directly and then clicked Home. Nothing about that
+    // is an app launch.
+    __resetDefaultViewForTests("/agents");
+    mockPrefs("agents");
+
+    renderRoot();
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByText("Agents Page")).toBeNull();
+  });
+
+  it("redirects once, then lets Home be reached", async () => {
+    __resetDefaultViewForTests("/");
+    mockPrefs("agents");
+
+    const first = renderRoot();
+    await waitFor(() => expect(screen.getByText("Agents Page")).toBeTruthy());
+    first.unmount();
+
+    // This is the Home click, and the back button: same route, second visit.
+    renderRoot();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByText("Agents Page")).toBeNull();
+  });
+
+  it("counts the decision as made even when the preference is Home", async () => {
+    __resetDefaultViewForTests("/");
+    mockPrefs("home");
+
+    const first = renderRoot();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    first.unmount();
+
+    renderRoot();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByText("Agents Page")).toBeNull();
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { BootGate } from "./components/boot/BootGate";
 import { ThemeProvider } from "./context/ThemeContext";
 import { api } from "./api/client";
+import { shouldApplyDefaultView, markDefaultViewApplied } from "./utils/defaultView";
 
 const Home = lazy(() => import("./views/Home").then((m) => ({ default: m.Home })));
 const Agents = lazy(() => import("./views/Agents").then((m) => ({ default: m.Agents })));
@@ -68,7 +69,10 @@ export function HomeGate({ honorDefaultView = false }: { honorDefaultView?: bool
   }, []);
 
   useEffect(() => {
-    if (!honorDefaultView) return;
+    // Only the entry that opened the app may be redirected. A click on Home, or
+    // a back navigation to "/", is the user saying where they want to be — see
+    // utils/defaultView.
+    if (!honorDefaultView || !shouldApplyDefaultView()) return;
     let cancelled = false;
     api
       .getSettings()
@@ -77,7 +81,10 @@ export function HomeGate({ honorDefaultView = false }: { honorDefaultView?: bool
         // spelling like "dashboard" — means Home, which is what rendering
         // nothing special does.
         const choice = cfg.ui?.default_view ?? "";
-        if (!cancelled) setDefaultRoute(DEFAULT_VIEW_ROUTES[choice] ?? null);
+        const route = DEFAULT_VIEW_ROUTES[choice] ?? null;
+        if (cancelled) return;
+        markDefaultViewApplied();
+        setDefaultRoute(route);
       })
       .catch(() => {
         // A preference is not worth blocking the app over.

--- a/web/src/utils/defaultView.ts
+++ b/web/src/utils/defaultView.ts
@@ -1,0 +1,44 @@
+/**
+ * defaultView — when the "Default view" preference may redirect, and when it
+ * must keep quiet.
+ *
+ * The preference decides where the app opens. It must not decide where the app
+ * goes once it is open, because the navigation's Home link points at "/": making
+ * "/" obey the preference made clicking Home send you to Agents, so Home became
+ * unreachable (#3556). The same mistake also broke the back button — returning
+ * from Agents to "/" bounced forward to Agents again, with no way out.
+ *
+ * So the rule is: honor it once, for the entry that opened the app, and never
+ * again in that document.
+ */
+
+/**
+ * The path the document was opened with, read once at module load — before any
+ * client-side navigation can change it.
+ */
+let entryPath = typeof window === "undefined" ? "" : window.location.pathname;
+
+let applied = false;
+
+/**
+ * shouldApplyDefaultView reports whether a mount of the root route is the one
+ * that opened the app.
+ *
+ * False for a click on Home, for a back navigation to "/", and for every mount
+ * after the first — all of which are the user saying where they want to be.
+ */
+export function shouldApplyDefaultView(): boolean {
+  if (applied) return false;
+  return entryPath === "/" || entryPath === "";
+}
+
+/** markDefaultViewApplied records that the entry redirect has happened. */
+export function markDefaultViewApplied(): void {
+  applied = true;
+}
+
+/** Test seam: module state outlives a single render tree. */
+export function __resetDefaultViewForTests(path = "/"): void {
+  applied = false;
+  entryPath = path;
+}


### PR DESCRIPTION
Fixes #3556. Regression from #3551, mine.

## What broke

I made the index route honor `ui.default_view`, reasoning that the index route is only reached on a cold start. The navigation's Home link is `{ to: "/", label: "Home" }`, so every Home click **is** the index route. With the preference set to Agents, clicking Home landed on Agents and Home was unreachable from the UI.

The back button was worse: from Agents, going back to `/` bounced forward to Agents again — a history loop with no escape.

## The fix

The preference decides where the app *opens*, not where it goes once open. It now applies only to the navigation that opened the document: the entry path is read once at module load, and the decision is marked spent the first time it is used. A Home click, a back navigation, and every later mount of the root route all render Home.

Keeping this in one small module rather than inline in `HomeGate` is deliberate — the state is per document, outliving any render tree, and that is the property the bug came from not being explicit.

## Verified on a real build, with the preference set to Agents

| Action | Result |
|---|---|
| Open the app | lands on `/agents` — preference honored |
| Click Home | stays on `/`, title `Home — mycel` — previously bounced to Agents |
| Back | `/agents`, as the history says, with no forward bounce |

## Test plan

- [x] `npx vitest run` — 491 pass (3 new), `tsc --noEmit` clean, `make lint` clean
- [x] **Confirmed both regression tests fail with the guard removed** — Home-click and opened-elsewhere cases
- [x] Existing default-view behavior still covered: Agents and Insights land, unrecognized value means Home, first run still wins, `/home` untouched
- [x] Verified live as tabulated above