### PR TITLE
fix(web): scope the desktop app version to the window it describes

### DIFF
--- a/web/src/utils/__tests__/desktopApp.test.ts
+++ b/web/src/utils/__tests__/desktopApp.test.ts
@@ -25,12 +25,15 @@ function setSearch(search: string) {
 }
 
 /**
- * installStorage — this jsdom setup does not provide localStorage (other suites
- * guard it with `window.localStorage?.`), so each case supplies its own. That
- * also lets the failure case be a store whose writes throw, which is what
- * private browsing does.
+ * installStorage — this jsdom setup does not provide storage (other suites guard
+ * it with `window.localStorage?.`), so each case supplies its own. That also
+ * lets the failure case be a store whose writes throw, which is what private
+ * browsing does.
+ *
+ * `which` matters: the marker belongs in sessionStorage, and a case can install
+ * a populated localStorage to prove it is never consulted.
  */
-function installStorage(opts: { throwOnWrite?: boolean } = {}) {
+function installStorage(opts: { throwOnWrite?: boolean; which?: "sessionStorage" | "localStorage" } = {}) {
   const map = new Map<string, string>();
   const stub = {
     getItem: (k: string) => map.get(k) ?? null,
@@ -41,7 +44,7 @@ function installStorage(opts: { throwOnWrite?: boolean } = {}) {
     removeItem: (k: string) => void map.delete(k),
     clear: () => map.clear(),
   };
-  Object.defineProperty(globalThis, "localStorage", {
+  Object.defineProperty(globalThis, opts.which ?? "sessionStorage", {
     value: stub,
     writable: true,
     configurable: true,
@@ -108,8 +111,36 @@ describe("desktopAppVersion", () => {
 
   it("returns empty rather than throwing when storage is absent entirely", async () => {
     // Which is this jsdom setup's actual default, and any environment where the
-    // bare `localStorage` reference is a ReferenceError.
-    Reflect.deleteProperty(globalThis, "localStorage");
+    // bare `sessionStorage` reference is a ReferenceError.
+    Reflect.deleteProperty(globalThis, "sessionStorage");
+    setSearch("");
+    const { desktopAppVersion } = await loadFresh();
+    expect(desktopAppVersion()).toBe("");
+  });
+
+  it("forgets the app once its window is gone", async () => {
+    // The marker outliving the window is how a plain browser tab came to report
+    // a "Desktop app" that was not running: the version was in localStorage, so
+    // every later visit inherited it and About warned of a mismatch against a
+    // build that no longer existed. A new session must start with no claim.
+    const handoff = installStorage();
+    setSearch("?desktop=1&app_version=0.4.5-dev.37.g8c72ca8");
+    const first = await loadFresh();
+    expect(first.desktopAppVersion()).toBe("0.4.5-dev.37.g8c72ca8");
+    expect(handoff.get(STORAGE_KEY)).toBe("0.4.5-dev.37.g8c72ca8");
+
+    // A different visit: same machine, same origin, no app hosting it.
+    installStorage();
+    setSearch("");
+    const later = await loadFresh();
+    expect(later.desktopAppVersion()).toBe("");
+  });
+
+  it("ignores a version left in localStorage by an older build", async () => {
+    // Upgrading does not clear what the previous version wrote, so the value is
+    // still there on the first run of this one. It must not be believed.
+    installStorage({ which: "localStorage" }).set(STORAGE_KEY, "0.4.5-dev.37.g8c72ca8");
+    installStorage();
     setSearch("");
     const { desktopAppVersion } = await loadFresh();
     expect(desktopAppVersion()).toBe("");

--- a/web/src/utils/desktopApp.ts
+++ b/web/src/utils/desktopApp.ts
@@ -13,6 +13,14 @@
  * the only channel that exists. Capture happens at module load rather than on
  * first use because SPA navigation drops the query string: by the time a view
  * asks, the marker may be several routes in the past.
+ *
+ * The marker is held in sessionStorage, whose lifetime — this tab, this visit —
+ * is exactly the claim being made: *this window is hosted by that app*. It was
+ * localStorage, which outlives the window and so outlived the app: any browser
+ * that had ever been handed off went on reporting that version forever, so a
+ * plain tab announced a "Desktop app" that was not running and might not still
+ * be installed, and About warned of a mismatch against a build that no longer
+ * existed (#3562).
  */
 
 const STORAGE_KEY = "mycel.desktopAppVersion";
@@ -22,13 +30,13 @@ function capture(): string {
   try {
     const fromURL = new URLSearchParams(location.search).get("app_version");
     if (fromURL) {
-      localStorage.setItem(STORAGE_KEY, fromURL);
+      sessionStorage.setItem(STORAGE_KEY, fromURL);
       return fromURL;
     }
-    return localStorage.getItem(STORAGE_KEY) ?? "";
+    return sessionStorage.getItem(STORAGE_KEY) ?? "";
   } catch {
-    // Private-mode localStorage throws on write; the URL value is still good
-    // for this page load, so prefer it over reporting nothing.
+    // Private-mode storage throws on write; the URL value is still good for
+    // this page load, so prefer it over reporting nothing.
     try {
       return new URLSearchParams(location.search).get("app_version") ?? "";
     } catch {


### PR DESCRIPTION
Fixes #3562.

## What was wrong

Observed in a plain browser tab, no desktop app running, against the released 0.4.5 daemon:

```
DAEMON 0.4.5   APP IS 0.4.5-DEV.37.G8C72CA8
Desktop app  v0.4.5-dev.37.g8c72ca8  — newer than the daemon below
Daemon       v0.4.5
```

The dev app that wrote that value was gone. `desktopAppVersion()` cached the handoff marker in `localStorage`, which outlives the window and therefore outlived the app, so every later visit inherited the claim.

It also contradicted the function's own documented contract — *"returns the hosting desktop app's version, or `\"\"` when the UI is not running inside one"* — and reintroduced the false-mismatch warning #3543 removed, in a worse form: #3543 compared two builds that both existed.

## The fix

`sessionStorage` instead. Capture at module load stays, because the reason for it is unchanged — SPA navigation drops the query string before any view asks. What changes is the lifetime: this tab, this visit, which is exactly the claim being made. A Wails webview is one such session, so a hard reload inside the app window still reports the app's version; a browser tab that was never handed off reports nothing.

## Test plan

Two tests, both of which fail on the old implementation and pass on this one — verified by reverting the source and re-running:

```
× forgets the app once its window is gone
× ignores a version left in localStorage by an older build
Tests  3 failed | 5 passed (8)
```

- [x] `forgets the app once its window is gone` — a handoff, then a fresh session with no marker, must report `""`
- [x] `ignores a version left in localStorage by an older build` — upgrading does not clear what the previous version wrote, so a populated `localStorage` proves it is never consulted
- [x] The existing case for surviving the router dropping the query string still passes, since that happens within one session
- [x] Full web suite 493 passed, `tsc --noEmit` clean, lint 0 issues

Found while installing the published 0.4.5 app as a user would. Part of #3560.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop app version handoff information now remains limited to the current browser tab session.
  * Prevented outdated version information from being reused across separate visits.
  * Improved handling when session storage is unavailable, including private browsing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->