### PR TITLE
ci(release): fail when the macOS app cannot be signed, and hash the desktop downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,24 +265,40 @@ jobs:
           esac
 
       # ── macOS code-signing + notarization (gated on secrets) ───────────
-      # When the Developer ID secrets are absent (fork PRs, no-secret runs) the
-      # app ships ad-hoc/self-signed and these steps are skipped — the workflow
-      # never fails for missing secrets. See desktop/README.md for the secret
-      # names the owner must add. The step-output gate is used because the
-      # `secrets` context cannot be referenced from a step-level `if`.
+      # An unsigned .app is refused by Gatekeeper on every machine but the one
+      # that built it, so a release that cannot sign has not produced a mac app
+      # anyone can open. This step therefore fails the job rather than skipping
+      # ahead: v0.4.5 shipped ad-hoc-signed and green, and the only way to find
+      # out was to install it (#3561).
+      #
+      # ALLOW_UNSIGNED_MACOS=true is the deliberate escape hatch — it publishes,
+      # with UNSIGNED in the filename so nobody downloads one by accident. See
+      # desktop/README.md for the secret names the owner must add. The
+      # step-output gate is used because the `secrets` context cannot be
+      # referenced from a step-level `if`.
       - name: Check macOS signing secrets
         id: signing
         if: matrix.os == 'darwin'
         shell: bash
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          ALLOW_UNSIGNED: ${{ vars.ALLOW_UNSIGNED_MACOS }}
         run: |
           if [ -n "$MACOS_CERTIFICATE" ]; then
             echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false (no MACOS_CERTIFICATE secret — shipping ad-hoc)"
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "unsigned_suffix=" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          if [ "$ALLOW_UNSIGNED" = "true" ]; then
+            echo "::warning title=Unsigned macOS app::No MACOS_CERTIFICATE secret. Publishing an ad-hoc-signed app because ALLOW_UNSIGNED_MACOS is set; Gatekeeper will refuse it, and users must run 'xattr -dr com.apple.quarantine' to open it. The asset is named UNSIGNED to say so."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "unsigned_suffix=-UNSIGNED" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::error title=Cannot sign the macOS app::No MACOS_CERTIFICATE secret, so this app would be ad-hoc signed and refused by Gatekeeper on every machine that downloads it. Add the Developer ID secrets (see desktop/README.md), or set the repository variable ALLOW_UNSIGNED_MACOS=true to publish it anyway, marked UNSIGNED."
+          exit 1
 
       - name: Import Developer ID certificate
         if: matrix.os == 'darwin' && steps.signing.outputs.enabled == 'true'
@@ -339,12 +355,15 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+          # Empty unless the app went out unsigned, in which case the filename
+          # carries the warning to wherever the download ends up.
+          UNSIGNED: ${{ steps.signing.outputs.unsigned_suffix }}
         run: |
           VERSION=${RELEASE_TAG#v}
           mkdir -p dist
           case "${{ matrix.os }}" in
             darwin)
-              ditto -c -k --keepParent desktop/build/bin/mycel.app "dist/${{ matrix.artifact }}_${VERSION}.zip" ;;
+              ditto -c -k --keepParent desktop/build/bin/mycel.app "dist/${{ matrix.artifact }}_${VERSION}${UNSIGNED}.zip" ;;
             linux)
               tar -C desktop/build/bin -czf "dist/${{ matrix.artifact }}_${VERSION}.tar.gz" . ;;
             windows)
@@ -434,6 +453,40 @@ jobs:
             -H "Content-Type: application/json" \
             https://api.github.com/repos/rpuneet/homebrew-mycel/contents/Formula/mycel.rb \
             -d "{\"message\":\"chore(formula): bump to ${TAG} (cross-platform)\",\"content\":\"${CONTENT_B64}\",\"sha\":\"${OLD_SHA}\",\"branch\":\"main\"}"
+
+  # ── Checksums for the desktop downloads ──────────────────────────────
+  # The CLI archives are hashed inside the jobs that build them, but each
+  # desktop artifact is built by a different matrix leg, so one job cannot see
+  # the others' files. Hashing them from the release afterwards is what gives
+  # every desktop download something to verify against: through v0.4.5 neither
+  # manifest mentioned a mycel-desktop_* file, so an unsigned app was also an
+  # unverifiable one (#3561).
+  desktop-checksums:
+    name: Checksum desktop artifacts
+    runs-on: ubuntu-latest
+    needs: [release-desktop, prepare]
+    steps:
+      - name: Hash every desktop asset on the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          mkdir -p desktop-assets && cd desktop-assets
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'mycel-desktop_*' --clobber
+          # Fail rather than publish an empty manifest that reads as "verified".
+          if ! ls mycel-desktop_* >/dev/null 2>&1; then
+            echo "::error title=No desktop assets::The release has no mycel-desktop_* files to hash."
+            exit 1
+          fi
+          shasum -a 256 mycel-desktop_* > ../checksums-desktop.txt
+          cat ../checksums-desktop.txt
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          files: checksums-desktop.txt
 
   # ── SBOM generation ──────────────────────────────────────────────────
   sbom:

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -107,9 +107,16 @@ one deferred target.
 ## Code-signing & notarization (release secrets)
 
 The macOS legs of `release-desktop` sign and notarize `mycel.app` **only
-when the signing secrets are present**. On fork PRs or any run without the
-secrets the app ships ad-hoc and the signing steps are skipped — the
-workflow never fails for missing secrets.
+when the signing secrets are present**, and **fail when they are not**. An
+ad-hoc-signed `.app` is refused by Gatekeeper on every machine except the one
+that built it, so a release that cannot sign has not produced a mac app anyone
+can open — it used to skip ahead and publish one anyway, reporting success
+(#3561).
+
+To publish without a certificate on purpose, set the repository variable
+`ALLOW_UNSIGNED_MACOS=true`. The run then warns instead of failing and names
+the asset `..._UNSIGNED.zip`, so nobody downloads one without knowing they will
+have to clear the quarantine flag themselves.
 
 To enable signed + notarized macOS builds, the owner adds these repository
 secrets (Settings → Secrets and variables → Actions):


### PR DESCRIPTION
Part of #3561 — the pipeline half. The certificate itself is yours to add; this makes the pipeline stop pretending it did not need one.

## What happened in v0.4.5

Job `Release Desktop (darwin)` in [run 30853077215](https://github.com/rpuneet/mycel/actions/runs/30853077215):

```
success  Build desktop app
success  Check macOS signing secrets
skipped  Import Developer ID certificate
skipped  Sign macOS app
skipped  Notarize and staple macOS app
success  Package
success  Upload to release
```

`Check macOS signing secrets` found none, every later `if` evaluated false, and the job went green having uploaded an app that macOS refuses to open:

```
$ spctl -a -vv /Applications/mycel.app
/Applications/mycel.app: rejected     (Signature=adhoc, TeamIdentifier=not set)
```

Skipping is right for a fork PR and wrong for a tag. Nothing in the release notes, the run summary, or the filename said the app was unsigned; the only way to find out was to install it.

## What this changes

**Missing secrets fail the job.** With an `::error` naming both ways forward, so the failure is self-explanatory rather than a puzzle at release time.

**`ALLOW_UNSIGNED_MACOS=true` is the escape hatch.** The run warns instead of failing and the asset becomes `mycel-desktop_darwin_arm64_0.4.6_UNSIGNED.zip`. The property then travels with the file to wherever it is downloaded, instead of living in a CI log nobody reads. Set the variable to keep releasing before the certificate exists; unset it once the secrets are in, and the suffix disappears on its own.

**Desktop artifacts get checksums.** `checksums.txt` covers the Linux and Windows CLI archives and `checksums-macos.txt` the two macOS ones; no manifest has ever mentioned a `mycel-desktop_*` file, so a desktop download could be neither signature-checked nor hash-checked. Each artifact is built by a different matrix leg, so no build job can see the others' files — a `desktop-checksums` job after them hashes what the release actually holds and uploads `checksums-desktop.txt`. It fails rather than publishing an empty manifest, which would read as "verified".

## Test plan

- [x] `yaml.safe_load` parses the file; job graph is `ci, prepare, release-linux, release-macos, release-desktop, release-formula, desktop-checksums, sbom`
- [x] `desktop-checksums` needs `release-desktop`, so it cannot run before the assets exist
- [x] The three signing branches are exercised by the shell logic alone: secret present → `enabled=true`, no suffix; absent with the variable → warning, `-UNSIGNED`; absent without → `exit 1`
- [x] `desktop/README.md` no longer documents the old "never fails for missing secrets" behavior

The first release after this merges is the real test, and it will be visible immediately: either the desktop job fails (no certificate, no variable) or the asset says UNSIGNED. **Merging this without doing one or the other will block the next release**, which is the intent — nothing unsigned should reach a user silently again.

Note for whoever merges: this touches `.github/workflows/`, so it needs a token with `workflow` scope.
