### PR TITLE
fix(desktop): serve the workspace the last daemon served, not none

### DIFF
--- a/desktop/server.go
+++ b/desktop/server.go
@@ -146,22 +146,27 @@ func unpublishDaemonAddr(url string) {
 }
 
 // resolveRepoRoot mirrors the CLI's repo resolution: explicit
-// MYCEL_WORKSPACE wins, then the enclosing adopted repo of the
-// current directory. GUI launches usually have neither — empty means
-// a MycelHome-only boot.
+// MYCEL_WORKSPACE wins, then the enclosing adopted repo of the current
+// directory, then the workspace the last daemon served.
+//
+// That last step is not a nicety. Tmux session names carry a hash of the
+// workspace so two of them cannot collide, which means a daemon serving a
+// different workspace cannot see the sessions of agents that are plainly still
+// running. A Finder launch has a working directory of `/`, so the first two
+// steps find nothing and the app used to serve no workspace at all — every
+// agent listed as running, none of them attachable, and nothing in the UI
+// naming the cause (#3569). The workspace the CLI daemon published is the
+// closest thing to an answer the app can have without asking.
 func resolveRepoRoot() string {
 	if p := os.Getenv("MYCEL_WORKSPACE"); p != "" {
 		return p
 	}
-	cwd, err := os.Getwd()
-	if err != nil {
-		return ""
+	if cwd, err := os.Getwd(); err == nil {
+		if h, err := home.Find(cwd); err == nil && h != nil {
+			return h.RootDir
+		}
 	}
-	h, err := home.Find(cwd)
-	if err != nil || h == nil {
-		return ""
-	}
-	return h.RootDir
+	return home.LastDaemonWorkspace()
 }
 
 // resolveListenAddr honors the global preferences (server.host /

--- a/desktop/workspace_test.go
+++ b/desktop/workspace_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/home"
+)
+
+// Launched from Finder, the app's working directory is `/`, so it has nothing to
+// infer a workspace from. It used to serve none — and because tmux session names
+// carry a hash of the workspace, its daemon then looked for sessions under a
+// prefix no running agent used: every agent listed as running, none attachable
+// (#3569). The workspace the CLI daemon published is the answer.
+func TestTheAppAdoptsTheWorkspaceTheLastDaemonServed(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	t.Setenv("MYCEL_WORKSPACE", "")
+	t.Chdir(t.TempDir()) // outside any adopted repo, as a GUI launch is
+
+	ws := t.TempDir()
+	if err := home.PublishDaemonWorkspace(ws); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveRepoRoot(); got != ws {
+		t.Errorf("resolveRepoRoot() = %q, want the published workspace %q", got, ws)
+	}
+}
+
+// An explicit workspace still wins: adopting a previous daemon's is a fallback,
+// not an override.
+func TestAnExplicitWorkspaceBeatsThePublishedOne(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	t.Chdir(t.TempDir())
+
+	published, asked := t.TempDir(), t.TempDir()
+	if err := home.PublishDaemonWorkspace(published); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MYCEL_WORKSPACE", asked)
+
+	if got := resolveRepoRoot(); got != asked {
+		t.Errorf("resolveRepoRoot() = %q, want the requested %q", got, asked)
+	}
+}
+
+// With no record at all the app boots without an anchor repo, as before.
+func TestWithNothingPublishedTheAppServesNoWorkspace(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	t.Setenv("MYCEL_WORKSPACE", "")
+	t.Chdir(t.TempDir())
+
+	if got := resolveRepoRoot(); got != "" {
+		t.Errorf("resolveRepoRoot() = %q, want empty when no daemon has published a workspace", got)
+	}
+}

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -73,6 +73,15 @@ func RunServerCtx(ctx context.Context, addr, repoRoot, corsOrigin, apiKey string
 		}
 	}
 
+	// Publish the workspace alongside the address, so the next process to start
+	// a daemon — the desktop app, which has no working directory to infer one
+	// from — serves the same one rather than a namespace matching no running
+	// agent's tmux session (#3569).
+	if wsErr := home.PublishDaemonWorkspace(h.RootDir); wsErr != nil {
+		log.Warn("could not record which workspace this daemon serves — the desktop app may start one that cannot see these agents",
+			"workspace", h.RootDir, "error", wsErr)
+	}
+
 	pidPath, pidErr := home.DaemonPidPath()
 	if pidErr != nil {
 		log.Warn("failed to resolve daemon pid path", "error", pidErr)

--- a/pkg/home/daemon_workspace_test.go
+++ b/pkg/home/daemon_workspace_test.go
@@ -1,0 +1,97 @@
+package home
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPublishDaemonWorkspaceRoundTrips(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	ws := t.TempDir()
+
+	if err := PublishDaemonWorkspace(ws); err != nil {
+		t.Fatalf("PublishDaemonWorkspace: %v", err)
+	}
+
+	if got := LastDaemonWorkspace(); got != ws {
+		t.Errorf("LastDaemonWorkspace() = %q, want %q", got, ws)
+	}
+}
+
+// A daemon serving no workspace has to be distinguishable from no daemon having
+// run: the app must not adopt a workspace nobody chose.
+func TestPublishingNoWorkspaceReadsBackAsNone(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+
+	if err := PublishDaemonWorkspace(""); err != nil {
+		t.Fatalf("PublishDaemonWorkspace: %v", err)
+	}
+
+	if got := LastDaemonWorkspace(); got != "" {
+		t.Errorf("LastDaemonWorkspace() = %q, want empty", got)
+	}
+}
+
+func TestLastDaemonWorkspaceWithNoRecord(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+
+	if got := LastDaemonWorkspace(); got != "" {
+		t.Errorf("LastDaemonWorkspace() = %q, want empty when nothing was published", got)
+	}
+}
+
+// Adopting a workspace that has since been moved or deleted reproduces the same
+// invisible-session mismatch from the other side, so a stale record counts as no
+// record.
+func TestLastDaemonWorkspaceIgnoresAVanishedDirectory(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	gone := filepath.Join(t.TempDir(), "moved-away")
+	if err := os.Mkdir(gone, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishDaemonWorkspace(gone); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(gone); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LastDaemonWorkspace(); got != "" {
+		t.Errorf("LastDaemonWorkspace() = %q, want empty for a directory that is gone", got)
+	}
+}
+
+// A file where the workspace should be is not a workspace.
+func TestLastDaemonWorkspaceIgnoresANonDirectory(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	f := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(f, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishDaemonWorkspace(f); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LastDaemonWorkspace(); got != "" {
+		t.Errorf("LastDaemonWorkspace() = %q, want empty for a path that is not a directory", got)
+	}
+}
+
+// Restarting into a different workspace has to replace the record, not append to
+// it, or the app adopts whichever one it happens to read first.
+func TestPublishDaemonWorkspaceReplacesThePreviousOne(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	first, second := t.TempDir(), t.TempDir()
+
+	if err := PublishDaemonWorkspace(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := PublishDaemonWorkspace(second); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := LastDaemonWorkspace(); got != second {
+		t.Errorf("LastDaemonWorkspace() = %q, want the most recent %q", got, second)
+	}
+}

--- a/pkg/home/global.go
+++ b/pkg/home/global.go
@@ -22,21 +22,23 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Subdirectories and files relative to MycelHome().
 const (
-	globalTemplatesDirName = "templates"
-	globalSecretsFileName  = "secrets.vault"
-	globalMCPFileName      = "mcps.json"
-	globalToolsFileName    = "tools.json"
-	globalAgentsDirName    = "agents"
-	globalAppsDirName      = "apps"
-	globalLogsDirName      = "logs"
-	globalRunDirName       = "run"
-	globalDaemonPidName    = "daemon.pid"
-	globalDaemonLogName    = "daemon.log"
-	globalDaemonAddrName   = "daemon.addr"
+	globalTemplatesDirName    = "templates"
+	globalSecretsFileName     = "secrets.vault"
+	globalMCPFileName         = "mcps.json"
+	globalToolsFileName       = "tools.json"
+	globalAgentsDirName       = "agents"
+	globalAppsDirName         = "apps"
+	globalLogsDirName         = "logs"
+	globalRunDirName          = "run"
+	globalDaemonPidName       = "daemon.pid"
+	globalDaemonLogName       = "daemon.log"
+	globalDaemonAddrName      = "daemon.addr"
+	globalDaemonWorkspaceName = "workspace"
 )
 
 // Agent entity subdirectories under agents/<name>/.
@@ -203,6 +205,62 @@ func DaemonAddrPath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, globalDaemonAddrName), nil
+}
+
+// DaemonWorkspacePath returns the path to the file recording which workspace
+// the daemon is serving (~/.mycel/run/workspace), or an empty line when it is
+// serving none.
+//
+// A daemon's workspace is not cosmetic: tmux session names include a hash of it
+// so two workspaces cannot collide, so a process that guesses a different
+// workspace cannot find the sessions of the agents already running. The desktop
+// app has no way to guess — launched from Finder its working directory is `/` —
+// and reading a directory it was never told about is how every agent came to be
+// listed as running and none could be attached to (#3569). Publishing it here
+// lets the next process adopt the workspace instead of inventing one.
+func DaemonWorkspacePath() (string, error) {
+	dir, err := RunDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, globalDaemonWorkspaceName), nil
+}
+
+// PublishDaemonWorkspace records the workspace the running daemon serves. An
+// empty root is written as an empty file rather than left stale, so a reader
+// can tell "serving no workspace" from "no daemon has ever run".
+func PublishDaemonWorkspace(root string) error {
+	path, err := DaemonWorkspacePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(root+"\n"), 0o600)
+}
+
+// LastDaemonWorkspace returns the workspace the most recent daemon served, or
+// "" when there is no record or the directory has since gone away.
+func LastDaemonWorkspace() string {
+	path, err := DaemonWorkspacePath()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from MycelHome
+	if err != nil {
+		return ""
+	}
+	root := strings.TrimSpace(string(data))
+	if root == "" {
+		return ""
+	}
+	// A workspace that has been moved or deleted is worse than none: adopting it
+	// would produce the same invisible-session mismatch from the other side.
+	if info, err := os.Stat(root); err != nil || !info.IsDir() {
+		return ""
+	}
+	return root
 }
 
 // EnsureGlobalDir makes sure ~/.mycel/ exists with 0750 permissions. It is


### PR DESCRIPTION
## Why

Quit `mycel up`, open mycel.app, and every agent is listed as running with none of them attachable — terminal websocket `409 no active session`, "Connection lost" in the UI, and nothing anywhere naming the cause. Nothing has actually stopped: `tmux ls` shows every session and `tmux attach` works by hand. This cost an hour of debugging on @rpuneet's machine.

Tmux session names carry a 3-byte hash of the workspace so two workspaces cannot collide (`pkg/tmux/session.go`). The desktop app resolved its workspace from `MYCEL_WORKSPACE`, else the adopted repo enclosing the **current working directory** — and a Finder-launched app has a cwd of `/`. So it served no workspace, computed a different session prefix, and could not see the sessions of agents created by a daemon started in the user's repo.

Fixes #3569

## What changed

- `home.PublishDaemonWorkspace` / `home.LastDaemonWorkspace`: the daemon records the workspace it serves in `~/.mycel/run/workspace`, beside the address it already publishes.
- `internal/cmd/serve.go` publishes it at startup, so both `mycel up` and the app's own daemon record it.
- `desktop/server.go:resolveRepoRoot()` falls back to the published workspace. Explicit `MYCEL_WORKSPACE` and a cwd inside an adopted repo still win, in that order.
- A workspace that has since moved or been deleted counts as none — adopting it would produce the same invisible-session mismatch from the other side.

## Not in this PR

The second half of #3569: when there genuinely is no workspace, the UI should say so rather than presenting an empty daemon as a working one. The issue stays open for it.

## Test plan

- [x] `pkg/home`: publish/read round trip; empty publish reads back as none (distinguishable from no daemon having run); no record; a directory that has vanished; a path that is not a directory; a second publish replacing the first
- [x] `desktop`: adopts the published workspace from a cwd outside any repo (the GUI case); an explicit `MYCEL_WORKSPACE` still wins; nothing published still means no anchor repo
- [x] `go test ./pkg/home/ ./internal/cmd/` and `cd desktop && go test ./...` pass
- [x] `make lint` — 0 issues
- [ ] Verify on the app: quit `mycel up`, launch mycel.app, attach to an existing agent

Made with [Cursor](https://cursor.com)