### PR TITLE
fix(cli): report the build's revision instead of "none"

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,6 +4,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/charmbracelet/x/term"
 	"github.com/spf13/cobra"
@@ -18,11 +19,97 @@ var (
 	date    = "unknown"
 )
 
-// SetVersionInfo sets the version information from build flags.
+// SetVersionInfo sets the version information from build flags, filling in
+// from the build's recorded VCS stamp whatever the linker did not supply.
+//
+// A binary from `go build ./cmd/mycel` has no -X flags, so it used to identify
+// itself as version "dev", commit "none" — and since /api/health substitutes the
+// commit for a version of "dev", the About page reported a daemon whose version
+// was literally "none". Go stamps the revision into every binary built inside a
+// repository, so there is no need to report nothing.
 func SetVersionInfo(v, c, d string) {
-	version = v
-	commit = c
-	date = d
+	version, commit, date = resolveVersionInfo(v, c, d)
+}
+
+// resolveVersionInfo fills placeholder build values in from the VCS stamp. Kept
+// separate from the package variables it ends up in so it can be tested without
+// writing to them.
+func resolveVersionInfo(v, c, d string) (outV, outC, outD string) {
+	if unstamped(c) {
+		if rev, modified, ok := vcsStamp(); ok {
+			c = rev
+			if modified {
+				c += "+dirty"
+			}
+		}
+	}
+	if unstamped(d) {
+		if t, ok := vcsTime(); ok {
+			d = t
+		}
+	}
+	return v, c, d
+}
+
+// unstamped reports whether a build value is one of the placeholders that means
+// "the linker did not set this".
+func unstamped(v string) bool {
+	switch v {
+	case "", "none", "unknown", "dev":
+		return true
+	}
+	return false
+}
+
+// vcsStamp returns the short revision Go recorded at build time, and whether the
+// tree had uncommitted changes.
+func vcsStamp() (rev string, modified, ok bool) {
+	info, available := debug.ReadBuildInfo()
+	if !available {
+		return "", false, false
+	}
+	return stampFromSettings(info.Settings)
+}
+
+// stampFromSettings is vcsStamp's logic, separated from where the settings come
+// from: a test cannot choose how its own binary was built, and a stamp read from
+// this binary is absent in exactly the cases (linked worktrees, -buildvcs=false)
+// that would silently turn the test into a skip.
+func stampFromSettings(settings []debug.BuildSetting) (rev string, modified, ok bool) {
+	for _, s := range settings {
+		switch s.Key {
+		case "vcs.revision":
+			rev = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	if rev == "" {
+		return "", false, false
+	}
+	// Short enough to read in a header, long enough to paste into `git show`.
+	if len(rev) > 8 {
+		rev = rev[:8]
+	}
+	return rev, modified, true
+}
+
+// vcsTime returns the commit time Go recorded at build time.
+func vcsTime() (string, bool) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", false
+	}
+	return timeFromSettings(info.Settings)
+}
+
+func timeFromSettings(settings []debug.BuildSetting) (string, bool) {
+	for _, s := range settings {
+		if s.Key == "vcs.time" && s.Value != "" {
+			return s.Value, true
+		}
+	}
+	return "", false
 }
 
 // rootCmd is the base command for mycel.

--- a/internal/cmd/version_stamp_test.go
+++ b/internal/cmd/version_stamp_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+func TestUnstampedRecognizesThePlaceholders(t *testing.T) {
+	for _, v := range []string{"", "none", "unknown", "dev"} {
+		if !unstamped(v) {
+			t.Errorf("unstamped(%q) = false, want true", v)
+		}
+	}
+	for _, v := range []string{"0.4.5", "e581ce75", "2026-08-03T12:15:10Z"} {
+		if unstamped(v) {
+			t.Errorf("unstamped(%q) = true, want false", v)
+		}
+	}
+}
+
+// A release build passes real values; the fallback must not touch them.
+func TestAStampedBuildIsLeftAlone(t *testing.T) {
+	v, c, d := resolveVersionInfo("0.4.5", "32aa30bb", "2026-08-04T00:00:00Z")
+
+	if v != "0.4.5" || c != "32aa30bb" || d != "2026-08-04T00:00:00Z" {
+		t.Errorf("resolveVersionInfo = %q, %q, %q — a stamped build was rewritten", v, c, d)
+	}
+}
+
+// `go build ./cmd/mycel` passes no -X flags, so the commit arrives as "none" —
+// and because /api/health substitutes the commit when the version is "dev", the
+// About page reported a daemon whose version was literally "none". Go records the
+// revision in every binary built inside a repository, so there is something to
+// report.
+func TestTheRevisionIsUsedWhenTheLinkerSuppliedNothing(t *testing.T) {
+	rev, modified, ok := stampFromSettings([]debug.BuildSetting{
+		{Key: "vcs.revision", Value: "e581ce7512ab34cd56ef7890abcdef1234567890"},
+		{Key: "vcs.modified", Value: "false"},
+	})
+
+	if !ok {
+		t.Fatal("a build with a recorded revision reported no stamp")
+	}
+	if rev != "e581ce75" {
+		t.Errorf("rev = %q, want the first 8 characters", rev)
+	}
+	if modified {
+		t.Error("a clean tree was reported as modified")
+	}
+}
+
+// A build from a dirty tree has to say so, or a local change is indistinguishable
+// from the commit it was based on — which is how a stale daemon passes for a
+// fresh one.
+func TestADirtyTreeIsReportedAsModified(t *testing.T) {
+	_, modified, ok := stampFromSettings([]debug.BuildSetting{
+		{Key: "vcs.revision", Value: "e581ce75"},
+		{Key: "vcs.modified", Value: "true"},
+	})
+
+	if !ok {
+		t.Fatal("no stamp read")
+	}
+	if !modified {
+		t.Error("a dirty tree was reported as clean")
+	}
+}
+
+// Linked worktrees and -buildvcs=false produce no stamp at all. That has to read
+// as "nothing to add", not as an empty commit hash.
+func TestNoRecordedRevisionMeansNoStamp(t *testing.T) {
+	if _, _, ok := stampFromSettings(nil); ok {
+		t.Error("settings without a revision reported a stamp")
+	}
+	if _, _, ok := stampFromSettings([]debug.BuildSetting{{Key: "vcs.modified", Value: "true"}}); ok {
+		t.Error("a modified flag with no revision reported a stamp")
+	}
+}
+
+func TestTheBuildTimeIsReadFromTheStamp(t *testing.T) {
+	got, ok := timeFromSettings([]debug.BuildSetting{{Key: "vcs.time", Value: "2026-08-03T12:15:10Z"}})
+	if !ok || got != "2026-08-03T12:15:10Z" {
+		t.Errorf("timeFromSettings = %q, %v; want the recorded time", got, ok)
+	}
+	if _, ok := timeFromSettings([]debug.BuildSetting{{Key: "vcs.time", Value: ""}}); ok {
+		t.Error("an empty recorded time was accepted")
+	}
+}
+
+// Whichever way this binary was built — with a stamp, or from a linked worktree
+// that has none — the result is either a revision or the placeholder it started
+// as, never something unusable like a bare "+dirty".
+func TestPlaceholdersNeverResolveToAHalfIdentifier(t *testing.T) {
+	_, c, _ := resolveVersionInfo("dev", "none", "unknown")
+
+	if strings.HasPrefix(c, "+") {
+		t.Errorf("commit = %q — a dirty marker with no revision behind it", c)
+	}
+	if c != "none" && unstamped(strings.TrimSuffix(c, "+dirty")) {
+		t.Errorf("commit = %q — neither a revision nor the original placeholder", c)
+	}
+}


### PR DESCRIPTION
## Why

@rpuneet asked why the About page showed the daemon version as `None`. Because it was:

```
{"status":"ok","db":"ok","version":"none","commit":"none"}
```

`cmd/mycel/main.go` defaults to `version = "dev"`, `commit = "none"`, and only the Makefile and release workflow pass the `-X` flags that replace them. `/api/health` substitutes the commit when the version is `dev`, so any binary from a plain `go build` reports `none` — which is indistinguishable from a broken build, and makes the app/daemon mismatch warning meaningless.

Fixes #3580

## What changed

`SetVersionInfo` fills placeholder values from `debug.ReadBuildInfo`'s VCS stamp: `vcs.revision` short-form for the commit, `vcs.time` for the date, `+dirty` when the tree had uncommitted changes. Release builds pass real values and are untouched.

The resolution lives in a pure `resolveVersionInfo` so it can be tested without writing to package variables.

## Note for the reviewer

There is latent `shadow` lint in `internal/cmd/tool.go` (four `installed, version, path :=` locals shadowing the package `version`). It only surfaces when a test touches those package variables, which is why the tests here target the pure function instead. Left alone rather than mixed into this change.

## Test plan

- [x] Placeholder recognition; a stamped build is left alone; the revision is shortened to 8 characters; a dirty tree is marked; no recorded revision reads as no stamp rather than an empty hash; the build time is read; placeholders never resolve to a bare `+dirty`
- [x] `go test ./internal/cmd/` passes, `make lint` 0 issues
- [x] Verified `go build` in a normal clone records `vcs.revision` (a linked worktree does not, which is why this is a fallback and not a replacement)

Made with [Cursor](https://cursor.com)