### PR TITLE
fix(tmux): stop namespacing sessions by the workspace path

### DIFF
--- a/docs/explanation/agents.md
+++ b/docs/explanation/agents.md
@@ -106,13 +106,18 @@ regenerates role files under the new name, and updates child agents'
 
 ### Tmux
 
-Local tmux sessions. Named with the `mycel-` prefix plus a short hash of
-the repo path, so agents on different repos never collide:
+Local tmux sessions, named with the `mycel-` prefix plus the agent name:
 
 ```
-mycel-<repo-hash6>-<agent>
-Example: mycel-a3f2c1-eng-01
+mycel-<agent>
+Example: mycel-eng-01
 ```
+
+The name used to carry a short hash of the repo path. That is gone: agent
+names are already unique across the one `~/.mycel` home, and encoding the
+path meant a daemon started from anywhere else could not find a running
+session and reported the agent as stopped. Sessions left over from the old
+scheme are renamed on daemon startup.
 
 | Operation | Implementation |
 |-----------|---------------|

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -106,7 +106,7 @@ AI coding assistants in isolated sessions. Each agent has:
 
 - a **repo** — the absolute path of the git repository it works on
 - a **git worktree** — created and managed by mycel under `~/.mycel/agents/<name>/worktree/`
-- a **runtime** — a tmux session (`mycel-<hash>-<name>`) or a Docker container
+- a **runtime** — a tmux session (`mycel-<name>`) or a Docker container
 - a **role and template** — prompt, MCP servers, and secrets
 - a **provider** — claude, codex, gemini, cursor, pi, or openclaw
 

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -18,6 +18,7 @@ import (
 	secretpkg "github.com/rpuneet/mycel/pkg/secret"
 	statspkg "github.com/rpuneet/mycel/pkg/stats"
 	templatepkg "github.com/rpuneet/mycel/pkg/template"
+	"github.com/rpuneet/mycel/pkg/tmux"
 	"github.com/rpuneet/mycel/server"
 	wspkg "github.com/rpuneet/mycel/server/ws"
 )
@@ -205,6 +206,13 @@ func RunServerCtx(ctx context.Context, addr, repoRoot, corsOrigin, apiKey string
 		if n := svc.AgentMgr.RefreshActivityConfigs(); n > 0 {
 			log.Info("refreshed agent activity configs", "agents", n)
 		}
+	}
+
+	// Sessions created before session names dropped the repo hash are still
+	// running under the old name. Rename them before anything looks for an
+	// agent, or a running agent reads as stopped.
+	if n := tmux.NewManager(tmux.DefaultPrefix).AdoptLegacySessions(ctx); n > 0 {
+		log.Info("adopted tmux sessions named by an older version", "sessions", n)
 	}
 
 	srv := server.New(cfg, svc, globalHub, server.WebDist())

--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -210,9 +210,12 @@ func RunServerCtx(ctx context.Context, addr, repoRoot, corsOrigin, apiKey string
 
 	// Sessions created before session names dropped the repo hash are still
 	// running under the old name. Rename them before anything looks for an
-	// agent, or a running agent reads as stopped.
-	if n := tmux.NewManager(tmux.DefaultPrefix).AdoptLegacySessions(ctx); n > 0 {
-		log.Info("adopted tmux sessions named by an older version", "sessions", n)
+	// agent, or a running agent reads as stopped. The registry decides what is
+	// a hash and what is part of an agent's name, which shape alone cannot.
+	if svc.AgentMgr != nil {
+		if n := tmux.NewManager(tmux.DefaultPrefix).AdoptLegacySessions(ctx, svc.AgentMgr.HasAgent); n > 0 {
+			log.Info("adopted tmux sessions named by an older version", "sessions", n)
+		}
 	}
 
 	srv := server.New(cfg, svc, globalHub, server.WebDist())

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -652,7 +652,7 @@ func NewManager(stateDir string) *Manager {
 // repoPath is the anchor repo new agents default to (may be "").
 func NewManagerWithRepo(stateDir, repoPath string) *Manager {
 	cmd, tool := defaultAgentCmd()
-	tmuxBe := runtime.NewTmuxBackend(tmux.NewManagerWithRepo(DefaultSessionPrefix, repoPath))
+	tmuxBe := runtime.NewTmuxBackend(tmux.NewManager(DefaultSessionPrefix))
 	return &Manager{
 		agents:           make(map[string]*Agent),
 		agentLocks:       make(map[string]*sync.Mutex),
@@ -675,7 +675,7 @@ func NewManagerWithRuntime(stateDir, repoPath string, rt runtime.Backend, rtName
 	bes := map[string]runtime.Backend{rtName: rt}
 	// Always register a tmux backend so agents with RuntimeBackend="tmux" work
 	if rtName != "tmux" {
-		bes["tmux"] = runtime.NewTmuxBackend(tmux.NewManagerWithRepo(DefaultSessionPrefix, repoPath))
+		bes["tmux"] = runtime.NewTmuxBackend(tmux.NewManager(DefaultSessionPrefix))
 	}
 	return &Manager{
 		agents:           make(map[string]*Agent),

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -2388,6 +2388,15 @@ func (m *Manager) GetAgent(name string) *Agent {
 	return &copy
 }
 
+// HasAgent reports whether an agent by this name is registered. Cheaper than
+// GetAgent when only existence matters, and it copies nothing.
+func (m *Manager) HasAgent(name string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, exists := m.agents[name]
+	return exists
+}
+
 // SetArchived stamps (or clears) ArchivedAt on an in-memory agent and
 // persists the whole agent map. Returns an error if the named agent is
 // missing. Safe to call concurrently — uses m.mu for write serialization.

--- a/pkg/tmux/adopt_legacy.go
+++ b/pkg/tmux/adopt_legacy.go
@@ -24,10 +24,17 @@ var legacySessionName = regexp.MustCompile(`^([0-9a-f]{6})-(.+)$`)
 // nothing, and report an agent as gone while tmux still had it. Renaming keeps
 // the process alive — tmux rename-session only changes the label.
 //
+// knownAgent reports whether a name belongs to an agent mycel has. It settles a
+// genuine ambiguity: an agent may legally be *named* "13c6e9-fast-crane", whose
+// session is "mycel-13c6e9-fast-crane" under the current scheme and identical in
+// shape to a legacy name. Renaming it would hand its session to a different
+// agent, so the name is checked before the shape. Pass nil only where no
+// registry is available, which falls back to shape alone.
+//
 // Returns the number of sessions adopted. Errors are logged and skipped rather
 // than returned: one session that cannot be renamed must not stop the rest from
 // being found.
-func (m *Manager) AdoptLegacySessions(ctx context.Context) int {
+func (m *Manager) AdoptLegacySessions(ctx context.Context, knownAgent func(string) bool) int {
 	sessions, err := m.listAllSessionNames(ctx)
 	if err != nil {
 		log.Warn("could not list tmux sessions to adopt older ones — agents from a previous version may appear stopped", "error", err)
@@ -39,11 +46,25 @@ func (m *Manager) AdoptLegacySessions(ctx context.Context) int {
 		if len(full) <= len(m.SessionPrefix) || full[:len(m.SessionPrefix)] != m.SessionPrefix {
 			continue
 		}
-		match := legacySessionName.FindStringSubmatch(full[len(m.SessionPrefix):])
+		suffix := full[len(m.SessionPrefix):]
+		match := legacySessionName.FindStringSubmatch(suffix)
 		if match == nil {
 			continue
 		}
 		agent := match[2]
+
+		// The whole suffix naming a real agent means this is that agent's current
+		// session, not a legacy one, whatever it looks like.
+		if knownAgent != nil && knownAgent(suffix) {
+			continue
+		}
+		// And a remainder that names no agent is nothing to adopt: renaming it
+		// would only invent a session for an agent mycel does not have.
+		if knownAgent != nil && !knownAgent(agent) {
+			log.Debug("leaving a session that looks legacy but names no agent mycel has", "session", full)
+			continue
+		}
+
 		want := m.SessionName(agent)
 
 		// A session already under the new name is the one the daemon will use, so

--- a/pkg/tmux/adopt_legacy.go
+++ b/pkg/tmux/adopt_legacy.go
@@ -1,0 +1,97 @@
+package tmux
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/rpuneet/mycel/pkg/log"
+)
+
+// legacySessionName matches a session named the way mycel named them when
+// session names carried a hash of the repo the daemon booted in:
+// "mycel-13c6e9-fast-crane". The hash is the first three bytes of a SHA-256,
+// hex-encoded, so exactly six hex digits.
+var legacySessionName = regexp.MustCompile(`^([0-9a-f]{6})-(.+)$`)
+
+// AdoptLegacySessions renames sessions left over from repo-scoped naming so the
+// running agents inside them are found again.
+//
+// Without this, dropping the repo hash from session names would orphan every
+// session already running: the daemon would look for "mycel-fast-crane", find
+// nothing, and report an agent as gone while tmux still had it. Renaming keeps
+// the process alive — tmux rename-session only changes the label.
+//
+// Returns the number of sessions adopted. Errors are logged and skipped rather
+// than returned: one session that cannot be renamed must not stop the rest from
+// being found.
+func (m *Manager) AdoptLegacySessions(ctx context.Context) int {
+	sessions, err := m.listAllSessionNames(ctx)
+	if err != nil {
+		log.Warn("could not list tmux sessions to adopt older ones — agents from a previous version may appear stopped", "error", err)
+		return 0
+	}
+
+	adopted := 0
+	for _, full := range sessions {
+		if len(full) <= len(m.SessionPrefix) || full[:len(m.SessionPrefix)] != m.SessionPrefix {
+			continue
+		}
+		match := legacySessionName.FindStringSubmatch(full[len(m.SessionPrefix):])
+		if match == nil {
+			continue
+		}
+		agent := match[2]
+		want := m.SessionName(agent)
+
+		// A session already under the new name is the one the daemon will use, so
+		// renaming onto it would fail and, worse, would leave two sessions for one
+		// agent if tmux allowed it.
+		if m.HasSession(ctx, agent) {
+			log.Warn("two tmux sessions for one agent — leaving the older one alone",
+				"agent", agent, "older", full, "current", want)
+			continue
+		}
+
+		// Renamed by full name on both sides: RenameSession applies the prefix to
+		// what it is given, and a legacy name is precisely one that does not fit
+		// prefix-plus-agent.
+		out, err := m.command(ctx, "tmux", "rename-session", "-t", full, want).CombinedOutput()
+		if err != nil {
+			log.Warn("could not adopt a tmux session from an older version — that agent will look stopped until it is restarted",
+				"session", full, "agent", agent, "error", err, "output", strings.TrimSpace(string(out)))
+			continue
+		}
+		m.invalidateCache()
+		log.Info("adopted a tmux session named by an older version", "from", full, "to", want, "agent", agent)
+		adopted++
+	}
+	return adopted
+}
+
+// listAllSessionNames returns every session on the tmux server, unfiltered.
+// ListSessions only reports sessions matching this manager's prefix and strips
+// it, which is precisely what the legacy names do not match.
+func (m *Manager) listAllSessionNames(ctx context.Context) ([]string, error) {
+	cmd := m.command(ctx, "tmux", "list-sessions", "-F", "#{session_name}")
+	output, err := cmd.Output()
+	if err != nil {
+		// tmux exits non-zero when no server is running, which means no sessions
+		// rather than a failure to list them.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line != "" {
+			names = append(names, line)
+		}
+	}
+	return names, nil
+}

--- a/pkg/tmux/adopt_legacy_test.go
+++ b/pkg/tmux/adopt_legacy_test.go
@@ -1,0 +1,205 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// tmuxStub answers tmux subcommands and records what was asked of it, so a test
+// can assert which sessions were renamed rather than only how many.
+type tmuxStub struct {
+	sessions map[string]bool // session names tmux reports as existing
+	calls    []string        // full argument lines, in order
+	mu       sync.Mutex
+	failNext bool // make the next rename fail
+}
+
+func (s *tmuxStub) exec(name string, args ...string) *exec.Cmd {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, strings.Join(args, " "))
+
+	stdout, exit := "", 0
+	switch {
+	case len(args) > 0 && args[0] == "list-sessions":
+		names := make([]string, 0, len(s.sessions))
+		for n := range s.sessions {
+			names = append(names, n)
+		}
+		if len(names) == 0 {
+			exit = 1 // tmux exits non-zero when there is no server
+			break
+		}
+		stdout = strings.Join(names, "\n") + "\n"
+	case len(args) > 0 && args[0] == "has-session":
+		target := ""
+		for i, a := range args {
+			if a == "-t" && i+1 < len(args) {
+				target = args[i+1]
+			}
+		}
+		if !s.sessions[target] {
+			exit = 1
+		}
+	case len(args) > 0 && args[0] == "rename-session":
+		if s.failNext {
+			s.failNext = false
+			exit = 1
+			break
+		}
+		if len(args) >= 4 {
+			delete(s.sessions, args[2])
+			s.sessions[args[3]] = true
+		}
+	}
+
+	cs := append([]string{"-test.run=TestHelperProcess", "--", name}, args...)
+	cmd := exec.CommandContext(context.Background(), os.Args[0], cs...) //nolint:gosec // test helper
+	cmd.Env = []string{
+		"GO_WANT_HELPER_PROCESS=1",
+		"MOCK_STDOUT=" + stdout,
+		fmt.Sprintf("MOCK_EXIT_CODE=%d", exit),
+	}
+	return cmd
+}
+
+func (s *tmuxStub) renamed() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []string
+	for _, c := range s.calls {
+		if strings.HasPrefix(c, "rename-session") {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+func stubManager(sessions ...string) (*Manager, *tmuxStub) {
+	stub := &tmuxStub{sessions: map[string]bool{}}
+	for _, s := range sessions {
+		stub.sessions[s] = true
+	}
+	m := &Manager{SessionPrefix: DefaultPrefix, execCommand: stub.exec, hasSessionCache: map[string]bool{}}
+	return m, stub
+}
+
+// The whole point: a session running under the old repo-scoped name is found
+// again. Without this the daemon looks for "mycel-fast-crane", finds nothing,
+// and reports a running agent as stopped.
+func TestAdoptRenamesARepoScopedSession(t *testing.T) {
+	m, stub := stubManager("mycel-13c6e9-fast-crane")
+
+	if n := m.AdoptLegacySessions(t.Context()); n != 1 {
+		t.Fatalf("adopted %d sessions, want 1", n)
+	}
+
+	if got := stub.renamed(); len(got) != 1 || !strings.Contains(got[0], "mycel-13c6e9-fast-crane mycel-fast-crane") {
+		t.Errorf("rename calls = %v, want the legacy name renamed to mycel-fast-crane", got)
+	}
+	if !stub.sessions["mycel-fast-crane"] {
+		t.Error("the session is not under the new name")
+	}
+}
+
+// An agent name containing a hyphen must survive: the hash is the first segment,
+// the rest is the agent, however many hyphens it has.
+func TestAdoptKeepsTheWholeAgentName(t *testing.T) {
+	m, stub := stubManager("mycel-13c6e9-bright-finch-2")
+
+	if n := m.AdoptLegacySessions(t.Context()); n != 1 {
+		t.Fatalf("adopted %d sessions, want 1", n)
+	}
+	if !stub.sessions["mycel-bright-finch-2"] {
+		t.Errorf("sessions = %v, want mycel-bright-finch-2", stub.sessions)
+	}
+}
+
+// Running twice must not rename anything the second time, or a daemon restart
+// churns tmux for no reason.
+func TestAdoptIsIdempotent(t *testing.T) {
+	m, stub := stubManager("mycel-13c6e9-fast-crane")
+
+	m.AdoptLegacySessions(t.Context())
+	first := len(stub.renamed())
+
+	m.invalidateCache()
+	if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+		t.Errorf("second run adopted %d sessions, want 0", n)
+	}
+	if len(stub.renamed()) != first {
+		t.Errorf("second run renamed again: %v", stub.renamed())
+	}
+}
+
+// A session already under the new name is the one the daemon will use. Renaming
+// the older one onto it would fail, and must not be attempted.
+func TestAdoptLeavesADuplicateAlone(t *testing.T) {
+	m, stub := stubManager("mycel-13c6e9-fast-crane", "mycel-fast-crane")
+
+	if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+		t.Errorf("adopted %d sessions, want 0 when the new name is taken", n)
+	}
+	if got := stub.renamed(); len(got) != 0 {
+		t.Errorf("attempted a rename onto an existing session: %v", got)
+	}
+	if !stub.sessions["mycel-13c6e9-fast-crane"] {
+		t.Error("the older session was lost")
+	}
+}
+
+// Sessions that are not mycel's, and mycel sessions already correctly named, are
+// left exactly as they are.
+func TestAdoptTouchesNothingElse(t *testing.T) {
+	m, stub := stubManager("mycel-fast-crane", "bc-13c6e9-old", "my-editor", "mycel-agent")
+
+	if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+		t.Errorf("adopted %d sessions, want 0", n)
+	}
+	if got := stub.renamed(); len(got) != 0 {
+		t.Errorf("renamed something it should not have: %v", got)
+	}
+}
+
+// A name that merely looks like a hash — wrong length, or not hex — is an agent
+// name, not a namespace, and renaming it would lose the agent.
+func TestAdoptIgnoresSomethingThatIsNotAHash(t *testing.T) {
+	for _, session := range []string{
+		"mycel-13c6e-fast-crane",   // five hex digits
+		"mycel-13c6e9a-fast-crane", // seven
+		"mycel-13c6eg-fast-crane",  // g is not hex
+		"mycel-abcdef",             // no agent after it
+	} {
+		m, stub := stubManager(session)
+		if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+			t.Errorf("%s: adopted %d, want 0", session, n)
+		}
+		if got := stub.renamed(); len(got) != 0 {
+			t.Errorf("%s: renamed %v", session, got)
+		}
+	}
+}
+
+// One session that cannot be renamed must not stop the others from being found.
+func TestAdoptContinuesPastAFailedRename(t *testing.T) {
+	m, stub := stubManager("mycel-13c6e9-fast-crane", "mycel-13c6e9-cool-otter")
+	stub.failNext = true
+
+	if n := m.AdoptLegacySessions(t.Context()); n != 1 {
+		t.Errorf("adopted %d sessions, want 1 of the two", n)
+	}
+}
+
+// No tmux server at all is not a failure.
+func TestAdoptWithNoSessions(t *testing.T) {
+	m, _ := stubManager()
+
+	if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+		t.Errorf("adopted %d sessions, want 0", n)
+	}
+}

--- a/pkg/tmux/adopt_legacy_test.go
+++ b/pkg/tmux/adopt_legacy_test.go
@@ -80,6 +80,11 @@ func (s *tmuxStub) renamed() []string {
 	return out
 }
 
+// noRegistry stands for "no agent registry available", which makes adoption
+// decide on the session name alone. Tests that pass it are asserting the shape
+// rules; the registry's part is covered separately below.
+var noRegistry func(string) bool
+
 func stubManager(sessions ...string) (*Manager, *tmuxStub) {
 	stub := &tmuxStub{sessions: map[string]bool{}}
 	for _, s := range sessions {
@@ -95,7 +100,7 @@ func stubManager(sessions ...string) (*Manager, *tmuxStub) {
 func TestAdoptRenamesARepoScopedSession(t *testing.T) {
 	m, stub := stubManager("mycel-13c6e9-fast-crane")
 
-	if n := m.AdoptLegacySessions(t.Context()); n != 1 {
+	if n := m.AdoptLegacySessions(t.Context(), noRegistry); n != 1 {
 		t.Fatalf("adopted %d sessions, want 1", n)
 	}
 
@@ -112,7 +117,7 @@ func TestAdoptRenamesARepoScopedSession(t *testing.T) {
 func TestAdoptKeepsTheWholeAgentName(t *testing.T) {
 	m, stub := stubManager("mycel-13c6e9-bright-finch-2")
 
-	if n := m.AdoptLegacySessions(t.Context()); n != 1 {
+	if n := m.AdoptLegacySessions(t.Context(), noRegistry); n != 1 {
 		t.Fatalf("adopted %d sessions, want 1", n)
 	}
 	if !stub.sessions["mycel-bright-finch-2"] {
@@ -125,11 +130,11 @@ func TestAdoptKeepsTheWholeAgentName(t *testing.T) {
 func TestAdoptIsIdempotent(t *testing.T) {
 	m, stub := stubManager("mycel-13c6e9-fast-crane")
 
-	m.AdoptLegacySessions(t.Context())
+	m.AdoptLegacySessions(t.Context(), noRegistry)
 	first := len(stub.renamed())
 
 	m.invalidateCache()
-	if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+	if n := m.AdoptLegacySessions(t.Context(), noRegistry); n != 0 {
 		t.Errorf("second run adopted %d sessions, want 0", n)
 	}
 	if len(stub.renamed()) != first {
@@ -142,7 +147,7 @@ func TestAdoptIsIdempotent(t *testing.T) {
 func TestAdoptLeavesADuplicateAlone(t *testing.T) {
 	m, stub := stubManager("mycel-13c6e9-fast-crane", "mycel-fast-crane")
 
-	if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+	if n := m.AdoptLegacySessions(t.Context(), noRegistry); n != 0 {
 		t.Errorf("adopted %d sessions, want 0 when the new name is taken", n)
 	}
 	if got := stub.renamed(); len(got) != 0 {
@@ -158,7 +163,7 @@ func TestAdoptLeavesADuplicateAlone(t *testing.T) {
 func TestAdoptTouchesNothingElse(t *testing.T) {
 	m, stub := stubManager("mycel-fast-crane", "bc-13c6e9-old", "my-editor", "mycel-agent")
 
-	if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+	if n := m.AdoptLegacySessions(t.Context(), noRegistry); n != 0 {
 		t.Errorf("adopted %d sessions, want 0", n)
 	}
 	if got := stub.renamed(); len(got) != 0 {
@@ -176,7 +181,7 @@ func TestAdoptIgnoresSomethingThatIsNotAHash(t *testing.T) {
 		"mycel-abcdef",             // no agent after it
 	} {
 		m, stub := stubManager(session)
-		if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+		if n := m.AdoptLegacySessions(t.Context(), noRegistry); n != 0 {
 			t.Errorf("%s: adopted %d, want 0", session, n)
 		}
 		if got := stub.renamed(); len(got) != 0 {
@@ -190,7 +195,7 @@ func TestAdoptContinuesPastAFailedRename(t *testing.T) {
 	m, stub := stubManager("mycel-13c6e9-fast-crane", "mycel-13c6e9-cool-otter")
 	stub.failNext = true
 
-	if n := m.AdoptLegacySessions(t.Context()); n != 1 {
+	if n := m.AdoptLegacySessions(t.Context(), noRegistry); n != 1 {
 		t.Errorf("adopted %d sessions, want 1 of the two", n)
 	}
 }
@@ -199,7 +204,50 @@ func TestAdoptContinuesPastAFailedRename(t *testing.T) {
 func TestAdoptWithNoSessions(t *testing.T) {
 	m, _ := stubManager()
 
-	if n := m.AdoptLegacySessions(t.Context()); n != 0 {
+	if n := m.AdoptLegacySessions(t.Context(), noRegistry); n != 0 {
 		t.Errorf("adopted %d sessions, want 0", n)
+	}
+}
+
+// An agent may legally be named "13c6e9-fast-crane". Its session is already
+// correct, and renaming it would hand the session to whatever "fast-crane" is —
+// a different agent, or nothing at all.
+func TestAdoptLeavesAnAgentWhoseNameLooksLikeAHash(t *testing.T) {
+	m, stub := stubManager("mycel-13c6e9-fast-crane")
+	knows := func(name string) bool { return name == "13c6e9-fast-crane" }
+
+	if n := m.AdoptLegacySessions(t.Context(), knows); n != 0 {
+		t.Errorf("adopted %d sessions, want 0 when the whole suffix is the agent's name", n)
+	}
+	if got := stub.renamed(); len(got) != 0 {
+		t.Errorf("renamed a current session: %v", got)
+	}
+}
+
+// A leftover session for an agent mycel no longer has is not adopted: renaming
+// it would invent a session under a name nothing will ever look for.
+func TestAdoptSkipsASessionForAnAgentThatIsGone(t *testing.T) {
+	m, stub := stubManager("mycel-13c6e9-deleted-agent")
+	knows := func(string) bool { return false }
+
+	if n := m.AdoptLegacySessions(t.Context(), knows); n != 0 {
+		t.Errorf("adopted %d sessions, want 0", n)
+	}
+	if got := stub.renamed(); len(got) != 0 {
+		t.Errorf("renamed %v", got)
+	}
+}
+
+// Both names plausible — the agent is "fast-crane", and no agent is called
+// "13c6e9-fast-crane" — is the ordinary migration, and it must still happen.
+func TestAdoptRenamesWhenOnlyTheRemainderNamesAnAgent(t *testing.T) {
+	m, stub := stubManager("mycel-13c6e9-fast-crane")
+	knows := func(name string) bool { return name == "fast-crane" }
+
+	if n := m.AdoptLegacySessions(t.Context(), knows); n != 1 {
+		t.Fatalf("adopted %d sessions, want 1", n)
+	}
+	if !stub.sessions["mycel-fast-crane"] {
+		t.Errorf("sessions = %v, want mycel-fast-crane", stub.sessions)
 	}
 }

--- a/pkg/tmux/benchmark_test.go
+++ b/pkg/tmux/benchmark_test.go
@@ -21,14 +21,6 @@ func BenchmarkSessionName_NoHash(b *testing.B) {
 	}
 }
 
-func BenchmarkSessionName_WithHash(b *testing.B) {
-	m := NewManagerWithRepo("mycel-", "/path/to/workspace")
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		_ = m.SessionName("test-agent")
-	}
-}
-
 func BenchmarkGenerateBufferName(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = generateBufferName()
@@ -86,12 +78,6 @@ func BenchmarkValidEnvVarName_LongName(b *testing.B) {
 func BenchmarkNewManager(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = NewManager("mycel-")
-	}
-}
-
-func BenchmarkNewManagerWithRepo(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		_ = NewManagerWithRepo("mycel-", "/path/to/workspace")
 	}
 }
 

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -43,7 +43,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -88,7 +87,6 @@ type Manager struct {
 	sessionLocks    map[string]*sync.Mutex
 	hasSessionCache map[string]bool // Cached session existence checks
 	SessionPrefix   string          // Prepended to all session names (e.g., "mycel-")
-	repoHash        string          // Included in session names for repo isolation
 	sessionsCache   []Session       // Cached list of sessions
 	cacheTTL        time.Duration   // Cache TTL (default: 2 seconds)
 	cacheMu         sync.RWMutex    // Protects cache fields
@@ -139,19 +137,6 @@ func NewManager(prefix string) *Manager {
 	}
 }
 
-// NewManagerWithRepo creates a tmux manager scoped to a repo.
-// Session names include a short hash of the repo path for isolation.
-func NewManagerWithRepo(prefix, repoPath string) *Manager {
-	h := sha256.Sum256([]byte(repoPath))
-	return &Manager{
-		SessionPrefix:   prefix,
-		repoHash:        fmt.Sprintf("%x", h[:3]),
-		execCommand:     exec.Command,
-		hasSessionCache: make(map[string]bool),
-		cacheTTL:        DefaultCacheTTL,
-	}
-}
-
 // NewDefaultManager creates a new tmux manager with the canonical prefix.
 func NewDefaultManager() *Manager {
 	return &Manager{
@@ -169,11 +154,16 @@ func (m *Manager) WithExecCommand(fn func(string, ...string) *exec.Cmd) *Manager
 	return m
 }
 
-// SessionName returns the full session name with prefix (and repo hash if set).
+// SessionName returns the full session name with prefix.
+//
+// Deliberately not namespaced by anything else. Session names used to carry a
+// hash of the repo the daemon booted in, from when state lived in a directory
+// inside each project and two projects could genuinely collide. State is one
+// ~/.mycel now, agent names are unique across it, and the hash only meant that
+// two daemons started in different directories could not see each other's
+// sessions — so opening the desktop app left every running agent listed and
+// unreachable (#3569).
 func (m *Manager) SessionName(name string) string {
-	if m.repoHash != "" {
-		return m.SessionPrefix + m.repoHash + "-" + name
-	}
 	return m.SessionPrefix + name
 }
 
@@ -483,11 +473,7 @@ func (m *Manager) ListSessions(ctx context.Context) ([]Session, error) {
 		return nil, err
 	}
 
-	// Build the full prefix once — it doesn't depend on the current line.
 	fullPrefix := m.SessionPrefix
-	if m.repoHash != "" {
-		fullPrefix = m.SessionPrefix + m.repoHash + "-"
-	}
 
 	var sessions []Session
 	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {

--- a/pkg/tmux/session_test.go
+++ b/pkg/tmux/session_test.go
@@ -173,9 +173,6 @@ func TestNewManager(t *testing.T) {
 	if m.SessionPrefix != "test-" {
 		t.Errorf("SessionPrefix = %q, want %q", m.SessionPrefix, "test-")
 	}
-	if m.repoHash != "" {
-		t.Errorf("repoHash = %q, want empty", m.repoHash)
-	}
 	if m.execCommand == nil {
 		t.Error("execCommand should not be nil")
 	}
@@ -191,32 +188,15 @@ func TestNewDefaultManager(t *testing.T) {
 	}
 }
 
-func TestNewManagerWithRepo(t *testing.T) {
-	m := NewManagerWithRepo("mycel-", "/some/repo")
-	if m.SessionPrefix != "mycel-" {
-		t.Errorf("SessionPrefix = %q, want %q", m.SessionPrefix, "mycel-")
+// A session name is the prefix and the agent, and nothing else: two daemons
+// started in different directories have to arrive at the same name for the same
+// agent, or one of them cannot see the other's sessions (#3569).
+func TestSessionNamesDoNotDependOnWhereTheDaemonStarted(t *testing.T) {
+	if got := NewManager("mycel-").SessionName("fast-crane"); got != "mycel-fast-crane" {
+		t.Errorf("SessionName = %q, want %q", got, "mycel-fast-crane")
 	}
-	if m.repoHash == "" {
-		t.Error("repoHash should not be empty")
-	}
-	if m.execCommand == nil {
-		t.Error("execCommand should not be nil")
-	}
-}
-
-func TestNewManagerWithRepo_DifferentPaths(t *testing.T) {
-	m1 := NewManagerWithRepo("mycel-", "/path/one")
-	m2 := NewManagerWithRepo("mycel-", "/path/two")
-	if m1.repoHash == m2.repoHash {
-		t.Error("different paths should produce different hashes")
-	}
-}
-
-func TestNewManagerWithRepo_SamePath(t *testing.T) {
-	m1 := NewManagerWithRepo("mycel-", "/same/path")
-	m2 := NewManagerWithRepo("mycel-", "/same/path")
-	if m1.repoHash != m2.repoHash {
-		t.Error("same paths should produce same hash")
+	if got := NewDefaultManager().SessionName("fast-crane"); got != "mycel-fast-crane" {
+		t.Errorf("SessionName = %q, want %q", got, "mycel-fast-crane")
 	}
 }
 
@@ -357,12 +337,6 @@ func TestSessionName(t *testing.T) {
 			input: "agent1",
 			want:  "mycel-agent1",
 		},
-		{
-			name:  "repo-scoped manager",
-			mgr:   NewManagerWithRepo("mycel-", "/some/path"),
-			input: "agent1",
-			want:  "mycel-" + NewManagerWithRepo("mycel-", "/some/path").repoHash + "-agent1",
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -382,17 +356,15 @@ func TestSessionName_EmptyName(t *testing.T) {
 	}
 }
 
-func TestSessionName_RepoHashPrefix(t *testing.T) {
-	m := NewManagerWithRepo("mycel-", "/repo")
-	name := m.SessionName("agent1")
-	if !strings.HasPrefix(name, "mycel-") {
-		t.Errorf("session name should start with prefix: %s", name)
+// The name carries nothing between the prefix and the agent. A hash used to sit
+// there, which is what made a session invisible to a daemon started elsewhere.
+func TestSessionNameCarriesNothingBetweenPrefixAndAgent(t *testing.T) {
+	name := NewManager("mycel-").SessionName("agent1")
+	if name != "mycel-agent1" {
+		t.Errorf("SessionName = %q, want %q", name, "mycel-agent1")
 	}
-	if !strings.HasSuffix(name, "-agent1") {
-		t.Errorf("session name should end with -agent1: %s", name)
-	}
-	if !strings.Contains(name, m.repoHash) {
-		t.Errorf("session name should contain the repo hash: %s", name)
+	if strings.Count(name, "-") != 1 {
+		t.Errorf("session name has an extra segment in it: %s", name)
 	}
 }
 
@@ -890,11 +862,11 @@ func TestListSessions_Success(t *testing.T) {
 	}
 }
 
-func TestListSessions_RepoIsolation(t *testing.T) {
-	m := NewManagerWithRepo("mycel-", "/workspace/one")
-	hash := m.repoHash
-	sessionOutput := fmt.Sprintf("mycel-%s-agent1|Thu Jan  1|0|1|/workspace\nbc-otheragent2|Thu Jan  1|0|1|/workspace\n", hash)
-	m.execCommand = mockCmd(sessionOutput, "", 0)
+// Sessions belonging to something else on the same tmux server stay out of the
+// list; the prefix is the whole of the filter now.
+func TestListSessionsIgnoresSessionsWithAnotherPrefix(t *testing.T) {
+	m := newTestManager("mycel-", mockCmd(
+		"mycel-agent1|Thu Jan  1|0|1|/workspace\nbc-otheragent2|Thu Jan  1|0|1|/workspace\n", "", 0))
 
 	sessions, err := m.ListSessions(testCtx())
 	if err != nil {
@@ -902,7 +874,7 @@ func TestListSessions_RepoIsolation(t *testing.T) {
 	}
 
 	if len(sessions) != 1 {
-		t.Fatalf("expected 1 session (workspace-scoped), got %d", len(sessions))
+		t.Fatalf("expected 1 session, got %d", len(sessions))
 	}
 	if sessions[0].Name != "agent1" {
 		t.Errorf("session name = %q, want %q", sessions[0].Name, "agent1")
@@ -985,8 +957,8 @@ func TestAttachCmd(t *testing.T) {
 	}
 }
 
-func TestAttachCmd_WorkspaceManager(t *testing.T) {
-	m := NewManagerWithRepo("mycel-", "/repo")
+func TestAttachCmd_UsesTheFullSessionName(t *testing.T) {
+	m := NewManager("mycel-")
 	m.execCommand = exec.Command
 	cmd := m.AttachCmd(testCtx(), "agent1")
 	expectedName := m.SessionName("agent1")


### PR DESCRIPTION
Fixes #3583

## Summary

Agent tmux sessions were named `mycel-<repoHash>-<agent>`, where the hash came from the workspace path the daemon was started in. Any change to that path changed the hash, and every running agent went invisible — the daemon looked for a session name nobody had created, reported working agents as stopped, and terminal attach returned `409 Conflict`. That is the failure Puneet hit in #3569; #3579 removed the trigger, this removes the coupling.

The namespace predates a single `~/.mycel`. With one home and one agent registry, agent names are already unique, so the hash isolated nothing that the registry does not guarantee.

- Sessions are now `mycel-<agent>`. `Manager` no longer carries a `repoHash`, and `NewManagerWithRepo` is gone.
- On daemon startup, `AdoptLegacySessions` renames any surviving `mycel-<hex6>-<agent>` session to `mycel-<agent>`. A tmux rename does not disturb the process in the pane, so agents running under the old scheme are adopted, not orphaned or restarted.
- A name that only resembles a hash (wrong length, non-hex, nothing after it) is treated as an agent name and left alone, so an agent legitimately called `abcdef-worker` is not mangled.

## Test plan

- [x] `go test ./pkg/tmux/ ./pkg/agent/ ./internal/cmd/` passes
- [x] `make lint` reports 0 issues
- [x] New tests cover: a legacy session is renamed; a hyphenated agent name survives intact; running twice renames nothing the second time; a session already under the new name is not clobbered; unrelated tmux sessions are untouched; near-miss hashes are ignored; one failed rename does not abort the rest; no tmux server is not an error

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically adopts existing legacy terminal sessions when the server starts.
  * Renames eligible sessions to the current naming format while preserving agent names.
  * Safely avoids duplicates and continues processing if an individual session cannot be renamed.

* **Bug Fixes**
  * Improved session discovery and isolation using consistent session names.
  * Handles environments without an active terminal session server gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->