### PR TITLE
feat(agents): show an agent waiting on a person as stuck, with the question

### DIFF
--- a/pkg/agent/hook_ingest.go
+++ b/pkg/agent/hook_ingest.go
@@ -83,12 +83,30 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 		hasState = true
 	}
 
+	// Whether the provider is blocked on a person outranks any of the above:
+	// the hook that carries it is one a provider also fires while it considers
+	// itself mid-turn (claude's Notification is registered with no state at
+	// all), so the mapped state describes the turn while this describes who is
+	// holding it up.
+	waiting, question := classifyHumanWait(payload)
+	switch waiting {
+	case humanWaitBlocked:
+		targetState, hasState = StateStuck, true
+	case humanWaitAnswered:
+		targetState, hasState = StateWorking, true
+	case humanWaitUnchanged:
+		if !hasState && provesTurnInProgress(payload.Event) && s.agentState(name) == StateStuck {
+			targetState, hasState = StateWorking, true
+		}
+	}
+
 	if hasState {
 		// State-only update: lifecycle descriptions baked into hook
 		// commands ("Turn complete", "Session ended", "Processing
 		// prompt...") must NOT become the agent's task line. They still
-		// flow to the event log and SSE stream below.
-		if err := s.manager.SetAgentState(ctx, name, targetState); err != nil {
+		// flow to the event log and SSE stream below. A question the agent
+		// is blocked on is the one exception — see applyHookState.
+		if err := s.applyHookState(ctx, name, targetState, question); err != nil {
 			log.Debug("hook state update skipped", "agent", name, "error", err)
 			return &HookStateSkippedError{Err: err}
 		}
@@ -156,6 +174,29 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 	}
 
 	return nil
+}
+
+// applyHookState moves an agent to the state a hook event implies.
+//
+// question is non-empty only when the provider is blocked on a person, in
+// which case MarkStuck records it as the agent's task — the field the agent
+// list and detail header already render beside the state, so "needs you" and
+// "about what" arrive together with nothing new to plumb.
+func (s *AgentService) applyHookState(ctx context.Context, name string, state State, question string) error {
+	if state == StateStuck && question != "" {
+		return s.manager.MarkStuck(ctx, name, question)
+	}
+	return s.manager.SetAgentState(ctx, name, state)
+}
+
+// agentState returns an agent's current state, or the empty state when no such
+// agent exists.
+func (s *AgentService) agentState(name string) State {
+	a := s.manager.GetAgent(name)
+	if a == nil {
+		return ""
+	}
+	return a.State
 }
 
 // isTurnStart reports whether an event marks the beginning of a model turn,

--- a/pkg/agent/hooks.go
+++ b/pkg/agent/hooks.go
@@ -54,6 +54,15 @@ const (
 	// in Error. It is the one event whose absence was indistinguishable from a
 	// healthy quiet agent (#3512).
 	HookProviderFailure HookEvent = "ProviderFailure"
+	// HookAwaitingInput reports that an agent's provider CLI is holding a
+	// prompt open and will not proceed until a person answers it. It is raised
+	// by the daemon from the agent's terminal for providers that have no hook
+	// for this (see provider.QuestionDetector) and carries the question in
+	// Message (#3582).
+	HookAwaitingInput HookEvent = "AwaitingInput"
+	// HookInputProvided reports that the prompt an agent was holding open is
+	// gone, so whatever it asked has been answered.
+	HookInputProvided HookEvent = "InputProvided"
 )
 
 // hookEventStateMap maps hook events to the target agent state.
@@ -72,6 +81,8 @@ var hookEventStateMap = map[HookEvent]State{
 	HookStop:              StateIdle,
 	HookTaskCompleted:     StateDone,
 	HookProviderFailure:   StateError,
+	HookAwaitingInput:     StateStuck,
+	HookInputProvided:     StateWorking,
 }
 
 // StateForHookEvent returns the target agent State for a hook event.
@@ -127,11 +138,17 @@ type HookPayload struct {
 	Sender       string    `json:"sender,omitempty"`
 	SubagentType string    `json:"subagent_type,omitempty"`
 	Message      string    `json:"message,omitempty"`
-	File         string    `json:"file,omitempty"`
-	Mentions     []string  `json:"mentions,omitempty"`
-	CostUSD      float64   `json:"cost_usd,omitempty"`
-	InputTokens  int64     `json:"input_tokens,omitempty"`
-	OutputTokens int64     `json:"output_tokens,omitempty"`
+	// NotificationType is claude's own classification of a Notification event
+	// (permission_prompt, idle_prompt, elicitation_dialog, …). It is what
+	// separates a notification meaning "someone has to answer me" from one that
+	// is merely news, so it decides whether the event moves the agent to stuck
+	// — see waiting.go.
+	NotificationType string   `json:"notification_type,omitempty"`
+	File             string   `json:"file,omitempty"`
+	Mentions         []string `json:"mentions,omitempty"`
+	CostUSD          float64  `json:"cost_usd,omitempty"`
+	InputTokens      int64    `json:"input_tokens,omitempty"`
+	OutputTokens     int64    `json:"output_tokens,omitempty"`
 }
 
 // The Claude Code hook-settings writer that generates .claude/settings.json

--- a/pkg/agent/waiting.go
+++ b/pkg/agent/waiting.go
@@ -1,0 +1,107 @@
+// waiting.go — telling an agent that is working apart from one that has
+// stopped to ask its user something.
+//
+// A provider holding a permission prompt or a choice menu open is neither
+// working nor idle: it will do nothing at all until a person answers it, which
+// is what stuck already means. mycel used to read such an agent as working —
+// silently spending its template's StuckTimeoutMin until the guardrail loop
+// noticed the silence half an hour later and blamed a timer for it (#3582).
+//
+// The signal is there for the asking. claude classifies its own Notification
+// events, so which ones block on a person is its statement rather than mycel's
+// guess; the events raised from an agent's terminal (see
+// provider.QuestionDetector) say so by construction. Both arrive here.
+package agent
+
+import "strings"
+
+// claude's notification_type values, as declared by the Notification hook
+// input schema in claude-code 2.1.205:
+//
+//	{hook_event_name, message, title?, notification_type}
+//
+// Only the two that mean "this session is blocked until you answer" are named
+// here, plus the two that mean the answer arrived. The rest are deliberately
+// absent and stay informational — most importantly idle_prompt, which claude
+// fires a minute after a turn ends. That agent is idle, has already reported
+// Stop, and is waiting for work rather than for an answer; treating it as
+// stuck would flag every quiet agent in the fleet and make the state
+// meaningless.
+const (
+	notifyPermissionPrompt    = "permission_prompt"
+	notifyElicitationDialog   = "elicitation_dialog"
+	notifyElicitationComplete = "elicitation_complete"
+	notifyElicitationResponse = "elicitation_response"
+)
+
+// humanWait is what a hook event says about whether its agent is blocked on a
+// person.
+type humanWait int
+
+const (
+	// humanWaitUnchanged means the event says nothing either way.
+	humanWaitUnchanged humanWait = iota
+	// humanWaitBlocked means the provider is holding a prompt open.
+	humanWaitBlocked
+	// humanWaitAnswered means the prompt it was holding is gone.
+	humanWaitAnswered
+)
+
+// waitingReasonPrefix labels the agent's task line while it is blocked, so a
+// question sitting where the task normally goes reads as a question rather
+// than as work the agent claims to be doing.
+const waitingReasonPrefix = "waiting for an answer"
+
+// classifyHumanWait reports whether a hook event means its agent has stopped
+// to ask its user something, and what it asked.
+//
+// The reason is returned only for humanWaitBlocked, where it becomes the
+// agent's task line: knowing an agent needs you is worth much less than
+// knowing what it wants, since the second tells you whether to answer now or
+// after lunch.
+func classifyHumanWait(payload HookPayload) (humanWait, string) {
+	switch payload.Event {
+	case HookAwaitingInput, HookPermissionRequest, HookElicitation:
+		return humanWaitBlocked, waitingReason(payload.Message)
+	case HookInputProvided, HookElicitationResult:
+		return humanWaitAnswered, ""
+	case HookNotification:
+		switch payload.NotificationType {
+		case notifyPermissionPrompt, notifyElicitationDialog:
+			return humanWaitBlocked, waitingReason(payload.Message)
+		case notifyElicitationComplete, notifyElicitationResponse:
+			return humanWaitAnswered, ""
+		}
+	}
+	return humanWaitUnchanged, ""
+}
+
+// waitingReason renders a provider's question as an agent task line, falling
+// back to the bare label for a provider that reports being blocked without
+// saying on what.
+func waitingReason(question string) string {
+	question = strings.TrimSpace(question)
+	if question == "" {
+		return waitingReasonPrefix
+	}
+	return truncateRunes(waitingReasonPrefix+": "+question, maxDerivedTaskLen)
+}
+
+// provesTurnInProgress reports whether an event could only have been emitted
+// by a provider that is actively running a turn.
+//
+// This is the ordinary way out of stuck. Every event that follows an answered
+// prompt — the tool the user just approved, the subagent it spawned — is one
+// the state map treats as informational, so an agent flagged stuck used to
+// stay stuck for the rest of its turn no matter how much work it did, and the
+// guardrail loop's promise that "any further hook event flips it back to
+// StateWorking" was not kept by anything. A CLI cannot run a tool while it is
+// holding a prompt open, so these events are proof the question is settled.
+func provesTurnInProgress(ev HookEvent) bool {
+	switch ev {
+	case HookPreToolUse, HookPostToolUse, HookPostToolUseFailure,
+		HookSubagentStart, HookSubagentStop, HookPostInvocation:
+		return true
+	}
+	return false
+}

--- a/pkg/agent/waiting_test.go
+++ b/pkg/agent/waiting_test.go
@@ -1,0 +1,165 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// serviceWithAgent builds a service around a single agent in a known state,
+// which is all the ingestion path needs to be driven.
+func serviceWithAgent(state State, task string) (*AgentService, *Manager) {
+	mgr := &Manager{agents: map[string]*Agent{
+		"eng-1": {Name: "eng-1", Role: Role("engineer"), State: state, Task: task},
+	}}
+	return NewAgentService(mgr, nil, nil), mgr
+}
+
+// The bug: claude reports "I cannot continue without you" through its
+// Notification hook, mycel registered that hook, ingested it, and threw it
+// away. The agent kept reading as working while it sat there.
+func TestIngestHookEvent_PermissionNotificationMarksAgentStuck(t *testing.T) {
+	svc, mgr := serviceWithAgent(StateWorking, "implementing issue #3582")
+
+	payload := HookPayload{
+		Event:            HookNotification,
+		NotificationType: notifyPermissionPrompt,
+		Message:          "Claude needs your permission to use Bash",
+	}
+	if err := svc.IngestHookEvent(context.Background(), "eng-1", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+
+	got := mgr.agents["eng-1"]
+	if got.State != StateStuck {
+		t.Errorf("state = %q, want %q — an agent waiting on permission is not working", got.State, StateStuck)
+	}
+	if !strings.Contains(got.Task, "permission to use Bash") {
+		t.Errorf("task = %q, want the question the agent is blocked on", got.Task)
+	}
+}
+
+// A notification that is not a question must stay informational. idle_prompt is
+// the one that matters: claude fires it a minute after every turn ends, so
+// treating it as stuck would flag the whole fleet.
+func TestIngestHookEvent_InformationalNotificationLeavesStateAlone(t *testing.T) {
+	for _, notificationType := range []string{"idle_prompt", "auth_success", "agent_completed", ""} {
+		t.Run(notificationType, func(t *testing.T) {
+			svc, mgr := serviceWithAgent(StateIdle, "implementing issue #3582")
+
+			payload := HookPayload{
+				Event:            HookNotification,
+				NotificationType: notificationType,
+				Message:          "Claude is waiting for your input",
+			}
+			if err := svc.IngestHookEvent(context.Background(), "eng-1", payload, nil); err != nil {
+				t.Fatalf("IngestHookEvent: %v", err)
+			}
+
+			got := mgr.agents["eng-1"]
+			if got.State != StateIdle {
+				t.Errorf("state = %q, want %q — this notification asks nothing of anyone", got.State, StateIdle)
+			}
+			if got.Task != "implementing issue #3582" {
+				t.Errorf("task = %q, want the real task untouched", got.Task)
+			}
+		})
+	}
+}
+
+// An agent that gets stuck and never recovers is worse than one that never
+// showed stuck: the answer arrives, the CLI runs the tool it asked about, and
+// nothing in the events that follow used to move it back.
+func TestIngestHookEvent_AnsweredQuestionReturnsAgentToWorking(t *testing.T) {
+	svc, mgr := serviceWithAgent(StateWorking, "implementing issue #3582")
+	ctx := context.Background()
+
+	ask := HookPayload{
+		Event:            HookNotification,
+		NotificationType: notifyPermissionPrompt,
+		Message:          "Claude needs your permission to use Bash",
+	}
+	if err := svc.IngestHookEvent(ctx, "eng-1", ask, nil); err != nil {
+		t.Fatalf("IngestHookEvent(ask): %v", err)
+	}
+	if mgr.agents["eng-1"].State != StateStuck {
+		t.Fatalf("state = %q, want the agent stuck before it is answered", mgr.agents["eng-1"].State)
+	}
+
+	// Permission granted: claude runs the tool it was asking about. That event
+	// carries no state of its own, and it is the only thing the agent sends.
+	if err := svc.IngestHookEvent(ctx, "eng-1", HookPayload{Event: HookPreToolUse, ToolName: "Bash"}, nil); err != nil {
+		t.Fatalf("IngestHookEvent(resume): %v", err)
+	}
+	if got := mgr.agents["eng-1"].State; got != StateWorking {
+		t.Errorf("state = %q, want %q — the tool it asked about is running", got, StateWorking)
+	}
+}
+
+// The pane monitor's own way out, for an answer that leads to something quiet
+// enough that no tool event follows.
+func TestIngestHookEvent_InputProvidedReleasesStuckAgent(t *testing.T) {
+	svc, mgr := serviceWithAgent(StateStuck, "waiting for an answer: pick a branch")
+
+	if err := svc.IngestHookEvent(context.Background(), "eng-1", HookPayload{Event: HookInputProvided}, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+	if got := mgr.agents["eng-1"].State; got != StateWorking {
+		t.Errorf("state = %q, want %q", got, StateWorking)
+	}
+}
+
+// A tool event must not drag an idle or done agent into working — it is only
+// evidence about an agent that was flagged stuck.
+func TestIngestHookEvent_ToolEventDoesNotDisturbUnflaggedAgents(t *testing.T) {
+	for _, state := range []State{StateIdle, StateDone} {
+		t.Run(string(state), func(t *testing.T) {
+			svc, mgr := serviceWithAgent(state, "implementing issue #3582")
+
+			if err := svc.IngestHookEvent(context.Background(), "eng-1", HookPayload{Event: HookPostToolUse}, nil); err != nil {
+				t.Fatalf("IngestHookEvent: %v", err)
+			}
+			if got := mgr.agents["eng-1"].State; got != state {
+				t.Errorf("state = %q, want %q unchanged", got, state)
+			}
+		})
+	}
+}
+
+func TestClassifyHumanWait(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload HookPayload
+		want    humanWait
+	}{
+		{"permission prompt", HookPayload{Event: HookNotification, NotificationType: notifyPermissionPrompt}, humanWaitBlocked},
+		{"elicitation dialog", HookPayload{Event: HookNotification, NotificationType: notifyElicitationDialog}, humanWaitBlocked},
+		{"elicitation answered", HookPayload{Event: HookNotification, NotificationType: notifyElicitationComplete}, humanWaitAnswered},
+		{"idle prompt", HookPayload{Event: HookNotification, NotificationType: "idle_prompt"}, humanWaitUnchanged},
+		{"teammate needs input", HookPayload{Event: HookNotification, NotificationType: "agent_needs_input"}, humanWaitUnchanged},
+		{"permission request hook", HookPayload{Event: HookPermissionRequest}, humanWaitBlocked},
+		{"pane detector", HookPayload{Event: HookAwaitingInput, Message: "pick a branch"}, humanWaitBlocked},
+		{"tool call", HookPayload{Event: HookPreToolUse}, humanWaitUnchanged},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, _ := classifyHumanWait(tt.payload); got != tt.want {
+				t.Errorf("classifyHumanWait = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitingReason(t *testing.T) {
+	if got := waitingReason("  Claude needs your permission to use Bash  "); got != "waiting for an answer: Claude needs your permission to use Bash" {
+		t.Errorf("waitingReason = %q", got)
+	}
+	if got := waitingReason(""); got != waitingReasonPrefix {
+		t.Errorf("waitingReason(empty) = %q, want %q", got, waitingReasonPrefix)
+	}
+	// The reason lands in a task line, which is one row of a table.
+	long := waitingReason(strings.Repeat("why", 200))
+	if len([]rune(long)) > maxDerivedTaskLen {
+		t.Errorf("reason is %d runes, want at most %d", len([]rune(long)), maxDerivedTaskLen)
+	}
+}

--- a/pkg/provider/cursor_question.go
+++ b/pkg/provider/cursor_question.go
@@ -1,0 +1,89 @@
+package provider
+
+import "strings"
+
+// cursor-agent's "I am waiting for you" chrome.
+//
+// cursor has no hook for this and is not shy about it: its binary carries an
+// explicit translation table from claude's hook vocabulary to its own, and both
+// of the relevant entries are null —
+//
+//	{PreToolUse: preToolUse, PermissionRequest: null, PostToolUse: postToolUse,
+//	 UserPromptSubmit: beforeSubmitPrompt, Stop: stop, …, Notification: null}
+//
+// None of its twenty-one events fire while it holds a prompt open, so a cursor
+// agent waiting on a person reports exactly what a cursor agent thinking hard
+// reports: nothing.
+//
+// What it does do is redraw the placeholder inside its input box to say which
+// answer it wants. Those strings are fixed, one per blocking mode, and the
+// fragments below are them (verified against cursor-agent 2026.07.23).
+//
+// Matching the provider's own chrome rather than the shape of a question is
+// what keeps this honest, and the chrome is the box rather than the sentence:
+// an agent whose work is about prompts puts every fragment below on its screen,
+// down to the "→" gutter, and that is not hypothetical — it is what the agent
+// writing this file did. Only the input box is cursor speaking.
+var cursorQuestionPatterns = []QuestionPattern{
+	{
+		LineStartsWith: "→",
+		Contains:       "answer questions (enter to select",
+		Question:       "cursor is asking a question — answer it in the agent's terminal",
+	},
+	{
+		LineStartsWith: "→",
+		Contains:       "waiting for decision (y/n/p)",
+		Question:       "cursor is waiting for a decision (y/n/p)",
+	},
+	{
+		LineStartsWith: "→",
+		Contains:       "approve mode switch (y/n)",
+		Question:       "cursor is waiting for approval to switch mode",
+	},
+	{
+		LineStartsWith: "→",
+		Contains:       "tell the agent what to do instead",
+		Question:       "cursor is waiting to be told what to do instead",
+	},
+	{
+		LineStartsWith: "→",
+		Contains:       "describe how to revise the plan",
+		Question:       "cursor is waiting for the plan to be revised",
+	},
+	{
+		LineStartsWith: "→",
+		Contains:       "edit the image prompt, then press enter",
+		Question:       "cursor is waiting for an image prompt",
+	},
+}
+
+// cursorInputBoxTop is the rule cursor draws above its input box. Anything
+// above the last one is the agent's own output.
+const cursorInputBoxTop = "▄▄▄▄"
+
+// DetectQuestion implements QuestionDetector.
+//
+// When cursor's input box is not on screen at all its placeholders cannot
+// legitimately appear either, so only the provider-independent shapes are
+// tried — which is what covers the prompts cursor puts up before its interface
+// exists, like the workspace trust question.
+func (p *CursorProvider) DetectQuestion(pane string) (string, bool) {
+	if box, ok := cursorPromptBox(pane); ok {
+		if question, waiting := MatchQuestion(box, 0, cursorQuestionPatterns); waiting {
+			return question, true
+		}
+	}
+	return MatchCommonQuestion(pane)
+}
+
+// cursorPromptBox returns the tail of pane from cursor's input box downwards,
+// or false when the box is not on screen.
+func cursorPromptBox(pane string) (string, bool) {
+	lines := paneTail(StripANSI(pane), questionTailLines)
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), cursorInputBoxTop) {
+			return strings.Join(lines[i+1:], "\n"), true
+		}
+	}
+	return "", false
+}

--- a/pkg/provider/question.go
+++ b/pkg/provider/question.go
@@ -1,0 +1,173 @@
+// question.go — recognizing a provider CLI that has stopped to ask its user
+// something.
+//
+// Providers that report this through a hook are handled where state is derived
+// (pkg/agent/waiting.go). This is for the ones that do not: cursor-agent has no
+// hook that fires while it holds a prompt open, so the only place it says so is
+// the screen (#3582).
+//
+// A sibling of failure.go rather than part of it. The two read the same
+// terminal for opposite kinds of condition: a failure is terminal and wants
+// reporting once, a question resolves the moment someone answers and has to be
+// watched until it does.
+package provider
+
+import (
+	"regexp"
+	"strings"
+)
+
+// questionTailLines is how much of an agent's terminal a question detector
+// reads.
+//
+// Shorter than paneTailLines, and the difference is the point: a CLI's failure
+// message is prose that can be several lines above its prompt, while the chrome
+// it draws to say it is waiting sits at the bottom of the screen. Reading
+// further up only offers more of the agent's own output to trip over.
+const questionTailLines = 20
+
+// QuestionDetector is optionally implemented by providers whose CLI blocks on
+// prompts it never reports.
+//
+// This is a low-confidence signal read from an agent's screen, so it is only
+// consulted for agents that have already gone quiet, and implementations should
+// prefer precision to recall. The two errors are not symmetric: missing a
+// question costs the delay until the guardrail timeout notices the silence,
+// while inventing one puts a working agent in front of a person who then finds
+// nothing to answer — and a state that cries wolf gets ignored, which is the
+// failure this whole capability exists to fix.
+type QuestionDetector interface {
+	// DetectQuestion examines recent terminal output, newest content last, and
+	// returns a short description of what the CLI is waiting to be told.
+	DetectQuestion(pane string) (question string, waiting bool)
+}
+
+// QuestionPattern maps a line of provider output to the question it implies.
+//
+// Literal fragments rather than regexes, for the same reason FailurePattern
+// uses them: these are matched against text a terminal reflows and colors
+// unpredictably, and a fragment short enough to survive that is also short
+// enough to check by eye against the string the provider actually prints.
+type QuestionPattern struct {
+	// LineStartsWith is the gutter or marker the provider draws the prompt
+	// with, matched against the line ignoring leading whitespace.
+	//
+	// It is what separates a CLI asking a question from an agent writing about
+	// one. Empty matches any line and should be paired with AtPaneEnd.
+	LineStartsWith string
+	// Contains is the most distinctive short fragment of the prompt, matched
+	// case-insensitively within the same line as the marker.
+	Contains string
+	// Question is what the user is told they are being asked, in mycel's voice
+	// — enough to decide whether to go and answer it now.
+	Question string
+	// AtPaneEnd restricts the match to the last non-blank line of the pane.
+	//
+	// For a CLI that prints its prompt and waits, that line is the prompt, and
+	// nothing the agent writes afterwards can be mistaken for one. It is the
+	// only thing making the provider-independent shapes below safe to match at
+	// all, since "(y/n)" appears in plenty of output that is not a prompt.
+	AtPaneEnd bool
+}
+
+// commonQuestionPatterns are the prompt shapes that are not any one provider's,
+// matched only as the last thing on the screen.
+//
+// A full-screen TUI always draws its own footer below the prompt, so these
+// never fire for one — which is deliberate. They cover the CLI that writes a
+// question to the terminal and blocks on a read, where the question really is
+// the final line, and they stay quiet everywhere else.
+var commonQuestionPatterns = []QuestionPattern{
+	{Contains: "(y/n)", Question: "waiting for a yes/no answer", AtPaneEnd: true},
+	{Contains: "[y/n]", Question: "waiting for a yes/no answer", AtPaneEnd: true},
+	{Contains: "do you want to proceed?", Question: "waiting for permission to proceed", AtPaneEnd: true},
+	{Contains: "press enter to continue", Question: "waiting for someone to press enter", AtPaneEnd: true},
+}
+
+// menuOption and menuCursor match a numbered choice menu: any of its options,
+// and the one the CLI has highlighted.
+//
+// The number is what makes the cursor glyph usable. On its own it is just an
+// input prompt — claude and cursor both draw one permanently — but pointing at
+// "1." it only appears while a menu is open.
+var (
+	menuOption = regexp.MustCompile(`^[❯›»▸]?\s*\d+[.)]\s+\S`)
+	menuCursor = regexp.MustCompile(`^[❯›»▸]\s*\d+[.)]\s+\S`)
+)
+
+// choiceMenuQuestion reports whether the screen ends inside an open numbered
+// choice menu.
+//
+// Both halves are required: the last visible line has to be one of the options,
+// so a menu the agent scrolled past cannot count, and one of the options has to
+// carry the selection cursor, so a numbered list the agent merely printed
+// cannot either.
+func choiceMenuQuestion(lines []string) bool {
+	end := lastNonBlankLine(lines)
+	if end < 0 || !menuOption.MatchString(strings.TrimSpace(lines[end])) {
+		return false
+	}
+	for _, line := range lines[:end+1] {
+		if menuCursor.MatchString(strings.TrimSpace(line)) {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchCommonQuestion reports whether pane ends on one of the prompt shapes
+// that belong to no provider in particular.
+func MatchCommonQuestion(pane string) (string, bool) {
+	if question, waiting := MatchQuestion(pane, questionTailLines, commonQuestionPatterns); waiting {
+		return question, true
+	}
+	if choiceMenuQuestion(paneTail(StripANSI(pane), questionTailLines)) {
+		return "waiting for a choice from a menu", true
+	}
+	return "", false
+}
+
+// MatchQuestion returns the question implied by the first pattern found in the
+// tail of pane, or false when none match.
+//
+// Only the tail is searched: a pane holds scrollback, and a prompt someone
+// answered an hour ago must not keep an agent flagged. tailLines of 0 or less
+// searches the whole pane.
+func MatchQuestion(pane string, tailLines int, patterns []QuestionPattern) (string, bool) {
+	lines := paneTail(StripANSI(pane), tailLines)
+	end := lastNonBlankLine(lines)
+	for i, line := range lines {
+		trimmed := strings.ToLower(strings.TrimSpace(line))
+		if trimmed == "" {
+			continue
+		}
+		for _, p := range patterns {
+			if p.Contains == "" {
+				continue
+			}
+			if p.AtPaneEnd && i != end {
+				continue
+			}
+			if p.LineStartsWith != "" && !strings.HasPrefix(trimmed, strings.ToLower(p.LineStartsWith)) {
+				continue
+			}
+			if strings.Contains(trimmed, strings.ToLower(p.Contains)) {
+				return p.Question, true
+			}
+		}
+	}
+	return "", false
+}
+
+// lastNonBlankLine returns the index of the last line with content, or -1 when
+// there is none. Captured panes are padded to the terminal's height, so the
+// last line of the capture is usually empty and the last line the user can see
+// is not.
+func lastNonBlankLine(lines []string) int {
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.TrimSpace(lines[i]) != "" {
+			return i
+		}
+	}
+	return -1
+}

--- a/pkg/provider/question_test.go
+++ b/pkg/provider/question_test.go
@@ -1,0 +1,170 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+// A cursor agent mid-turn, captured verbatim from a tmux pane. Every fixture
+// below is the bottom of a real cursor screen, because that is the only part a
+// question detector looks at and hand-typed approximations of it are how the
+// first attempt at pane reading passed its tests and matched nothing in
+// production (see TestDetectFailureSeesThroughTerminalColour).
+const cursorWorkingPane = `  $ npm run dev 14m 55s in current dir
+    … 23 output lines hidden · ctrl+o to expand
+    ✓ Running next.config.ts took 27ms
+
+ ⠰⠰ Waiting  26.02k tokens
+    Tip: Use /config to customize Cursor settings and behavior.
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Add a follow-up                                  ctrl+c to stop
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  2 tasks
+  GPT-5.6 Sol 272K Medium · 23.6% · 20 files edited      Run Everything
+  ~/.mycel/agents/eager-fox/worktree · 3b4b167
+
+`
+
+// The same screen with cursor's input box in a mode that blocks on a person.
+const cursorAskingPane = `  I found two candidate fixes and need you to pick one.
+
+ ⠰⠰ Waiting for you  26.02k tokens
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Answer questions (Enter to select/next, Esc to skip)
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  2 tasks
+  GPT-5.6 Sol 272K Medium · 23.6% · 20 files edited      Run Everything
+  ~/.mycel/agents/eager-fox/worktree · 3b4b167
+
+`
+
+const cursorDecisionPane = `  Ready to apply the migration.
+
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Waiting for decision (y/n/p)...
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  Auto · 32.7% · 1 file edited                           Run Everything
+  ~/.mycel/agents/keen-lemur/worktree · main
+
+`
+
+func TestCursorDetectQuestion(t *testing.T) {
+	p := &CursorProvider{}
+
+	question, waiting := p.DetectQuestion(cursorAskingPane)
+	if !waiting {
+		t.Fatal("cursor's ask-question placeholder must be read as waiting on a person")
+	}
+	if !strings.Contains(question, "cursor is asking a question") {
+		t.Errorf("question = %q, want it to say what is being waited on", question)
+	}
+
+	if _, waiting := p.DetectQuestion(cursorDecisionPane); !waiting {
+		t.Error("cursor's decision placeholder must be read as waiting on a person")
+	}
+}
+
+// The whole capability is worth less than nothing if it flags working agents:
+// a state that cries wolf is a state people stop looking at.
+func TestCursorDetectQuestionIgnoresWorkingAgents(t *testing.T) {
+	p := &CursorProvider{}
+
+	falsePositives := map[string]string{
+		// The bottom of a real, busy cursor screen. Note the status line
+		// already says "Waiting" while the agent is working — a detector
+		// matching that word alone would flag every agent in the fleet.
+		"cursor mid-turn": cursorWorkingPane,
+
+		// An agent whose work is about prompts. Every fragment the detector
+		// looks for is on screen, in the agent's own output rather than in
+		// cursor's input box.
+		"agent writing about prompts": `  Added the pane detector patterns:
+
+    → Answer questions (Enter to select/next, Esc to skip)
+    → Waiting for decision (y/n/p)
+    Do you want to proceed? (y/n)
+
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Add a follow-up                                  ctrl+c to stop
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  ~/.mycel/agents/eager-fox/worktree · 3b4b167
+
+`,
+
+		// A diff, which is where "(y/n)" turns up in ordinary work.
+		"a diff containing a prompt": `  +	fmt.Print("Overwrite the file? (y/n) ")
+  +	if answer := readLine(); answer != "y" {
+
+ ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Add a follow-up                                  ctrl+c to stop
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  ~/.mycel/agents/eager-fox/worktree · main
+
+`,
+
+		// A numbered list the agent wrote, with no selection cursor on it.
+		"a numbered list in the output": `  Three options:
+
+  1. Rewrite the parser
+  2. Patch the caller
+  3. Leave it alone
+`,
+
+		// A prompt from an earlier, already-answered turn, scrolled up.
+		"an answered prompt in scrollback": `  Do you want to proceed? (y/n)
+  y
+  Applied 3 files.
+`,
+		"empty pane": "",
+	}
+
+	for name, pane := range falsePositives {
+		t.Run(name, func(t *testing.T) {
+			if question, waiting := p.DetectQuestion(pane); waiting {
+				t.Errorf("a working agent was reported as waiting on %q", question)
+			}
+		})
+	}
+}
+
+// The provider-independent shapes, for a CLI that prints its question and
+// blocks on a read rather than drawing a screen around it.
+func TestMatchCommonQuestion(t *testing.T) {
+	tests := []struct {
+		name string
+		pane string
+		want bool
+	}{
+		{"yes/no at the prompt", "Building…\nOverwrite config.toml? (y/n) ", true},
+		{"bracketed yes/no", "Detected 2 worktrees.\nRemove them? [y/N]", true},
+		{"proceed", "This will drop the table.\nDo you want to proceed?", true},
+		{"press enter", "Review the plan above.\nPress Enter to continue", true},
+		{"open menu", "Which fix?\n❯ 1. Rewrite the parser\n  2. Patch the caller", true},
+		{"menu with the cursor above the end", "❯ 1. Rewrite the parser\n  2. Patch the caller\n  3. Leave it", true},
+		{"numbered list, no cursor", "Options:\n  1. Rewrite the parser\n  2. Patch the caller", false},
+		{"bare prompt cursor", "Done.\n❯ ", false},
+		{"prompt followed by more output", "Do you want to proceed? (y/n)\ny\nDone in 4s.", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, waiting := MatchCommonQuestion(tt.pane); waiting != tt.want {
+				t.Errorf("waiting = %v, want %v", waiting, tt.want)
+			}
+		})
+	}
+}
+
+// Panes are never plain text — the same lesson failure detection learned the
+// hard way.
+func TestDetectQuestionSeesThroughTerminalColor(t *testing.T) {
+	pane := "\x1b[2K \x1b[38;2;80;80;80m▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄\x1b[0m\n" +
+		"\x1b[2K  \x1b[38;2;102;102;102m→\x1b[0m Answer questions (Enter to select/next, Esc to skip)\x1b[39m\n" +
+		"\x1b[2K  ~/.mycel/agents/eager-fox/worktree · main\n"
+
+	if _, waiting := (&CursorProvider{}).DetectQuestion(pane); !waiting {
+		t.Fatal("a colored prompt must be detected — panes are never plain text")
+	}
+}
+
+// Ensure CursorProvider satisfies the capability the monitor looks for.
+var _ QuestionDetector = (*CursorProvider)(nil)

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -332,6 +332,16 @@ func buildServicesFromHome(ctx context.Context, globals *Globals, h *home.Home) 
 		runSessionReconciler(svcCtx, agentSvc)
 	}()
 
+	// Provider question monitor — flags agents whose provider CLI is holding a
+	// prompt open for a person. Providers that report this through a hook are
+	// handled during ingestion; this covers the ones (cursor) that report it
+	// nowhere but their own screen.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runProviderQuestionMonitor(svcCtx, agentSvc)
+	}()
+
 	// Notify service (channel subscriptions + delivery).
 	var notifyService *notifypkg.Service
 	if ns, err := notifypkg.OpenStore(wsDB, wsDriver); err != nil {

--- a/server/provider_question_monitor.go
+++ b/server/provider_question_monitor.go
@@ -1,0 +1,207 @@
+// provider_question_monitor.go — noticing an agent that has stopped to ask its
+// user something.
+//
+// A provider holding a permission prompt or a choice menu open is blocked until
+// a person answers it, and mycel has a state for that. The ones that say so
+// through a hook never reach this file. cursor does not: nothing it emits fires
+// while it waits, so an agent sitting on a question looks exactly like an agent
+// thinking, right up until the guardrail loop flags it stuck half an hour later
+// and blames its own timer (#3582).
+//
+// So the terminal is read, the same way provider_failure_monitor.go reads it,
+// and with the same ordering: silence first because it is cheap, the pane
+// second because it is the low-confidence part. An agent still reporting
+// activity is never inspected, which is most of what keeps a working agent that
+// happens to print "(y/n)" from being flagged.
+//
+// Unlike a failure, a question ends. Agents already flagged here keep being
+// read, so the moment their prompt is gone they are handed back to working
+// rather than left flagged for a turn they are busy serving.
+package server
+
+import (
+	"context"
+	"time"
+
+	agentpkg "github.com/rpuneet/mycel/pkg/agent"
+	"github.com/rpuneet/mycel/pkg/log"
+	"github.com/rpuneet/mycel/pkg/provider"
+)
+
+const (
+	// questionSweepInterval is how often the monitor looks for agents that
+	// have gone quiet. Tighter than the failure sweep, because this decides
+	// how long a person is not told that an agent is waiting on them.
+	questionSweepInterval = 15 * time.Second
+
+	// questionQuietFor is how long an agent must have reported nothing before
+	// its terminal is read.
+	//
+	// Long enough that a working agent between two tool calls is never
+	// inspected; short enough that "your agent needs you" arrives while the
+	// person who started it is still nearby.
+	questionQuietFor = 45 * time.Second
+
+	// questionPaneLines is how much scrollback to capture. The detectors read
+	// less; the surplus covers a provider that wraps a long question above the
+	// prompt it is waiting on.
+	questionPaneLines = 40
+)
+
+// questionMonitorDeps is what the sweep needs, narrowed to an interface so the
+// tests can drive it without a tmux session or a real provider registry.
+type questionMonitorDeps interface {
+	List(ctx context.Context, opts agentpkg.ListOptions) ([]*agentpkg.Agent, error)
+	Peek(ctx context.Context, name string, lines int) (string, error)
+	IngestHookEvent(ctx context.Context, name string, payload agentpkg.HookPayload, raw []byte) error
+}
+
+// runProviderQuestionMonitor flags agents whose provider CLI is waiting for a
+// person, and unflags them once it is not. It returns when ctx is canceled.
+func runProviderQuestionMonitor(ctx context.Context, agents *agentpkg.AgentService) {
+	if agents == nil {
+		return
+	}
+	ticker := time.NewTicker(questionSweepInterval)
+	defer ticker.Stop()
+
+	// The question each agent was last reported as waiting on, which is both
+	// how one open prompt produces one event rather than one per sweep, and
+	// how the sweep knows to keep watching an agent it already flagged.
+	asked := make(map[string]string)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweepForOpenQuestions(ctx, agents, asked, time.Now())
+		}
+	}
+}
+
+// sweepForOpenQuestions runs a single pass over the agent list.
+func sweepForOpenQuestions(ctx context.Context, deps questionMonitorDeps, asked map[string]string, now time.Time) {
+	list, err := deps.List(ctx, agentpkg.ListOptions{})
+	if err != nil {
+		log.Debug("question monitor: agent list failed", "error", err)
+		return
+	}
+
+	live := make(map[string]struct{}, len(list))
+	for _, a := range list {
+		if a == nil {
+			continue
+		}
+		live[a.Name] = struct{}{}
+
+		detector := questionDetectorFor(a)
+		if detector == nil {
+			continue
+		}
+		previous, flagged := asked[a.Name]
+		if !answerableState(a.State) {
+			delete(asked, a.Name)
+			continue
+		}
+		// A flagged agent is read every sweep regardless of how recently its
+		// state changed: flagging it moved its own clock, so the quiet gate
+		// would otherwise stop the monitor noticing the answer it is watching
+		// for.
+		if !flagged && now.Sub(a.UpdatedAt) < questionQuietFor {
+			continue
+		}
+
+		pane, err := deps.Peek(ctx, a.Name, questionPaneLines)
+		if err != nil {
+			// A session that cannot be read is not evidence of anything: the
+			// agent may be in a container, or already gone.
+			log.Debug("question monitor: peek failed", "agent", a.Name, "error", err)
+			continue
+		}
+
+		question, waiting := detector.DetectQuestion(pane)
+		switch {
+		case !waiting && flagged:
+			delete(asked, a.Name)
+			releaseAnsweredAgent(ctx, deps, a)
+		case !waiting:
+		case previous == question:
+		default:
+			asked[a.Name] = question
+			payload := agentpkg.HookPayload{
+				Event:   agentpkg.HookAwaitingInput,
+				Message: question,
+			}
+			if err := deps.IngestHookEvent(ctx, a.Name, payload, nil); err != nil {
+				// Let the next sweep try again rather than swallowing the
+				// report.
+				delete(asked, a.Name)
+				log.Debug("question monitor: ingest failed", "agent", a.Name, "error", err)
+				continue
+			}
+			log.Info("agent is waiting for a person", "agent", a.Name, "tool", a.Tool, "question", question)
+		}
+	}
+
+	// Drop bookkeeping for agents that no longer exist.
+	for name := range asked {
+		if _, ok := live[name]; !ok {
+			delete(asked, name)
+		}
+	}
+}
+
+// releaseAnsweredAgent hands an agent back to working once the prompt it was
+// holding open is gone.
+//
+// Only an agent still sitting in stuck is moved. Anything else has already been
+// corrected by its own hooks — a cursor agent that answers a question and
+// finishes reports Stop, which is idle, and overwriting that with working would
+// be the monitor undoing a fact with an inference.
+func releaseAnsweredAgent(ctx context.Context, deps questionMonitorDeps, a *agentpkg.Agent) {
+	if a.State != agentpkg.StateStuck {
+		return
+	}
+	payload := agentpkg.HookPayload{
+		Event:   agentpkg.HookInputProvided,
+		Message: "the prompt the provider was waiting on is gone",
+	}
+	if err := deps.IngestHookEvent(ctx, a.Name, payload, nil); err != nil {
+		log.Debug("question monitor: release failed", "agent", a.Name, "error", err)
+		return
+	}
+	log.Info("agent's question was answered", "agent", a.Name, "tool", a.Tool)
+}
+
+// questionDetectorFor returns the question detector for an agent's provider, or
+// nil when the provider does not offer one.
+func questionDetectorFor(a *agentpkg.Agent) provider.QuestionDetector {
+	if a.Tool == "" {
+		return nil
+	}
+	p, ok := provider.DefaultRegistry.Get(a.Tool)
+	if !ok {
+		return nil
+	}
+	d, ok := p.(provider.QuestionDetector)
+	if !ok {
+		return nil
+	}
+	return d
+}
+
+// answerableState reports whether an agent in this state could be sitting on a
+// question worth flagging.
+//
+// Terminal states have nobody left to answer. starting is excluded for a
+// different reason: the state machine does not allow starting → stuck, so
+// flagging one would be rejected anyway, and an agent that has not finished
+// booting has not asked anything yet.
+func answerableState(s agentpkg.State) bool {
+	switch s {
+	case agentpkg.StateIdle, agentpkg.StateWorking, agentpkg.StateStuck:
+		return true
+	}
+	return false
+}

--- a/server/provider_question_monitor_test.go
+++ b/server/provider_question_monitor_test.go
@@ -1,0 +1,197 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentpkg "github.com/rpuneet/mycel/pkg/agent"
+)
+
+// fakeQuestionDeps stands in for the agent service so a sweep can be driven
+// without a tmux session.
+type fakeQuestionDeps struct {
+	panes    map[string]string
+	agents   []*agentpkg.Agent
+	peeked   []string
+	ingested []agentpkg.HookPayload
+}
+
+func (f *fakeQuestionDeps) List(context.Context, agentpkg.ListOptions) ([]*agentpkg.Agent, error) {
+	return f.agents, nil
+}
+
+func (f *fakeQuestionDeps) Peek(_ context.Context, name string, _ int) (string, error) {
+	f.peeked = append(f.peeked, name)
+	return f.panes[name], nil
+}
+
+func (f *fakeQuestionDeps) IngestHookEvent(_ context.Context, _ string, p agentpkg.HookPayload, _ []byte) error {
+	f.ingested = append(f.ingested, p)
+	return nil
+}
+
+// The bottom of a cursor screen whose input box is waiting for an answer.
+const cursorAskingPane = ` ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Answer questions (Enter to select/next, Esc to skip)
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  ~/.mycel/agents/eager-fox/worktree · main
+`
+
+// The same screen once someone has answered.
+const cursorResumedPane = ` ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  → Add a follow-up                        ctrl+c to stop
+ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
+  ~/.mycel/agents/eager-fox/worktree · main
+`
+
+func quietCursorAgent(name string, state agentpkg.State, quietFor time.Duration, now time.Time) *agentpkg.Agent {
+	return &agentpkg.Agent{
+		Name:      name,
+		Tool:      "cursor",
+		State:     state,
+		UpdatedAt: now.Add(-quietFor),
+	}
+}
+
+func TestSweepFlagsAnAgentWaitingForAnAnswer(t *testing.T) {
+	now := time.Now()
+	deps := &fakeQuestionDeps{
+		agents: []*agentpkg.Agent{quietCursorAgent("fox", agentpkg.StateWorking, 5*time.Minute, now)},
+		panes:  map[string]string{"fox": cursorAskingPane},
+	}
+
+	sweepForOpenQuestions(context.Background(), deps, map[string]string{}, now)
+
+	if len(deps.ingested) != 1 {
+		t.Fatalf("ingested %d events, want 1", len(deps.ingested))
+	}
+	got := deps.ingested[0]
+	if got.Event != agentpkg.HookAwaitingInput {
+		t.Errorf("event = %q, want %q", got.Event, agentpkg.HookAwaitingInput)
+	}
+	if got.Message == "" {
+		t.Error("the event must carry the question — knowing what is asked is the point")
+	}
+	if state, ok := agentpkg.StateForHookEvent(got.Event); !ok || state != agentpkg.StateStuck {
+		t.Errorf("AwaitingInput maps to state %q (ok=%v), want %q", state, ok, agentpkg.StateStuck)
+	}
+}
+
+// An agent that gets flagged and never unflagged is worse than one that is
+// never flagged: the state stops meaning anything.
+func TestSweepReleasesAnAgentOnceItsQuestionIsAnswered(t *testing.T) {
+	now := time.Now()
+	agent := quietCursorAgent("fox", agentpkg.StateWorking, 5*time.Minute, now)
+	deps := &fakeQuestionDeps{
+		agents: []*agentpkg.Agent{agent},
+		panes:  map[string]string{"fox": cursorAskingPane},
+	}
+	asked := map[string]string{}
+
+	sweepForOpenQuestions(context.Background(), deps, asked, now)
+	if len(asked) != 1 {
+		t.Fatalf("the agent was not flagged: %v", asked)
+	}
+
+	// Someone answers. Flagging moved the agent's own clock, so this is also
+	// the case where the quiet gate would hide the recovery if it applied.
+	agent.State = agentpkg.StateStuck
+	agent.UpdatedAt = now
+	deps.panes["fox"] = cursorResumedPane
+
+	sweepForOpenQuestions(context.Background(), deps, asked, now)
+
+	if len(asked) != 0 {
+		t.Errorf("the agent is still flagged as waiting: %v", asked)
+	}
+	if len(deps.ingested) != 2 {
+		t.Fatalf("ingested %d events, want 2", len(deps.ingested))
+	}
+	release := deps.ingested[1]
+	if release.Event != agentpkg.HookInputProvided {
+		t.Errorf("event = %q, want %q", release.Event, agentpkg.HookInputProvided)
+	}
+	if state, ok := agentpkg.StateForHookEvent(release.Event); !ok || state != agentpkg.StateWorking {
+		t.Errorf("InputProvided maps to state %q (ok=%v), want %q", state, ok, agentpkg.StateWorking)
+	}
+}
+
+// Silence is the cheap gate and the pane is the expensive, low-confidence one.
+// An agent that is still reporting activity is never read at all, which is most
+// of what keeps a busy agent from being flagged over something in its output.
+func TestSweepLeavesActiveAgentsAlone(t *testing.T) {
+	now := time.Now()
+	deps := &fakeQuestionDeps{
+		agents: []*agentpkg.Agent{quietCursorAgent("fox", agentpkg.StateWorking, 5*time.Second, now)},
+		panes:  map[string]string{"fox": cursorAskingPane},
+	}
+
+	sweepForOpenQuestions(context.Background(), deps, map[string]string{}, now)
+
+	if len(deps.peeked) != 0 {
+		t.Errorf("peeked %v, want an agent reporting activity to be left alone", deps.peeked)
+	}
+	if len(deps.ingested) != 0 {
+		t.Errorf("ingested %d events, want none", len(deps.ingested))
+	}
+}
+
+// One open prompt is one event, however long it stays open.
+func TestSweepReportsTheSameQuestionOnce(t *testing.T) {
+	now := time.Now()
+	agent := quietCursorAgent("fox", agentpkg.StateWorking, 5*time.Minute, now)
+	deps := &fakeQuestionDeps{
+		agents: []*agentpkg.Agent{agent},
+		panes:  map[string]string{"fox": cursorAskingPane},
+	}
+	asked := map[string]string{}
+
+	sweepForOpenQuestions(context.Background(), deps, asked, now)
+	agent.State = agentpkg.StateStuck
+	sweepForOpenQuestions(context.Background(), deps, asked, now)
+	sweepForOpenQuestions(context.Background(), deps, asked, now)
+
+	if len(deps.ingested) != 1 {
+		t.Errorf("ingested %d events, want 1", len(deps.ingested))
+	}
+}
+
+// The state machine has no starting → stuck edge, and an agent that has not
+// finished booting has not asked anything.
+func TestSweepSkipsStatesThatCannotBeWaiting(t *testing.T) {
+	now := time.Now()
+	for _, state := range []agentpkg.State{
+		agentpkg.StateStarting, agentpkg.StateStopped, agentpkg.StateDone, agentpkg.StateError,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			deps := &fakeQuestionDeps{
+				agents: []*agentpkg.Agent{quietCursorAgent("fox", state, time.Hour, now)},
+				panes:  map[string]string{"fox": cursorAskingPane},
+			}
+			sweepForOpenQuestions(context.Background(), deps, map[string]string{}, now)
+			if len(deps.ingested) != 0 {
+				t.Errorf("ingested %d events for a %s agent, want none", len(deps.ingested), state)
+			}
+		})
+	}
+}
+
+// Providers that report waiting through a hook must never have their screens
+// read: the hook is the better signal and reading as well would double-report.
+func TestSweepIgnoresProvidersWithoutAQuestionDetector(t *testing.T) {
+	now := time.Now()
+	deps := &fakeQuestionDeps{
+		agents: []*agentpkg.Agent{{
+			Name: "cheetah", Tool: "claude",
+			State: agentpkg.StateWorking, UpdatedAt: now.Add(-time.Hour),
+		}},
+		panes: map[string]string{"cheetah": cursorAskingPane},
+	}
+
+	sweepForOpenQuestions(context.Background(), deps, map[string]string{}, now)
+
+	if len(deps.peeked) != 0 {
+		t.Errorf("peeked %v, want claude left to its hooks", deps.peeked)
+	}
+}


### PR DESCRIPTION
Fixes #3582

An agent whose provider CLI has stopped to ask a question now reads as `stuck` — with the existing drooping animation, and with the question itself on the task line beside it, so the dashboard says both "this one needs you" and "about what".

## Which providers, and how

| Provider | Waiting-on-a-human reported | Works |
| --- | --- | --- |
| **claude** | hooks — `Notification` classified by its own `notification_type` | yes |
| **cursor** | pane detection — it has no hook for this | yes |
| agy, pi, others | nothing yet; unchanged | no (see below) |

**claude** was already telling us. The `Notification` hook is registered, ingested, and was then discarded as informational. Its input schema in claude-code 2.1.205 is `{hook_event_name, message, title?, notification_type}`, and mycel's hook command forwards the whole payload, so the classification is claude's statement rather than mycel's guess about prose:

- `permission_prompt`, `elicitation_dialog` → `stuck`, with `message` as the reason.
- `elicitation_complete`, `elicitation_response` → back to `working`.
- everything else stays informational. `idle_prompt` matters most: claude fires it a minute after every turn ends, when the agent has already reported `Stop` and is idle. Treating it as stuck would flag every quiet agent in the fleet and make the state worthless. `agent_needs_input` is also excluded — it is about a *teammate* of claude's being blocked, not about this session, so the agent it would flag is still working.

`PermissionRequest` and `Elicitation` already mapped to `stuck`; they now also carry their message through as the reason.

**cursor** has no such hook, and is explicit about it. Its binary carries a translation table from claude's hook vocabulary to its own, and both relevant entries are null:

```js
{PreToolUse: preToolUse, PermissionRequest: null, PostToolUse: postToolUse,
 UserPromptSubmit: beforeSubmitPrompt, Stop: stop, …, Notification: null}
```

None of its twenty-one events fire while it holds a prompt open. So a `provider.QuestionDetector` capability — a sibling of `FailureDetector`, not an extension of it — reads its screen, and `server/provider_question_monitor.go` sweeps quiet agents the way the failure monitor does.

## False positives: why this does not flag working agents

Precision matters more than recall here, and asymmetrically. Missing a question costs the delay until the guardrail notices the silence anyway. Inventing one sends a person to an agent with nothing to answer, and a state that cries wolf is a state people stop looking at — which is the failure this is meant to fix.

Five things have to line up before an agent is flagged:

1. **Silence first, screen second.** An agent that is still reporting hook events is never peeked at all. This is the cheap gate and it does most of the work: a busy agent that prints `(y/n)` in a diff is never read, because it is busy.
2. **Only the last 20 lines** of the pane, so a prompt answered earlier in the session cannot keep an agent flagged.
3. **Provider chrome, not question shapes.** cursor's patterns are the fixed placeholder strings it draws inside its input box, one per blocking mode (`Answer questions (Enter to select/next, Esc to skip)`, `Waiting for decision (y/n/p)...`, `Approve mode switch (y/n)`, …), taken from the binary.
4. **The box, not the sentence.** Anchoring on those strings alone was not enough, and the test that says so is in the PR: an agent whose *work* is about prompts puts every one of those fragments on its screen, down to the `→` gutter. That is not hypothetical — it is what the agent writing this patch did. So the match is scoped to the region below the last input-box rule cursor draws, which is the only part of the screen cursor is speaking on. Note also that cursor's status line says plain `Waiting` while it is working; a detector matching that word would have flagged the entire fleet.
5. **Provider-independent shapes only as the final line.** `(y/n)`, `[y/N]`, `Do you want to proceed?`, `Press Enter to continue` fire only when they are the last non-blank line on screen, and a numbered menu only when the screen ends on one of its options *and* one of those options carries a `❯`-style selection cursor. A full-screen TUI always draws a footer below its prompt, so for cursor these are inert by construction; they cover a CLI that prints a question and blocks on a read (including the prompts cursor puts up before its interface exists, like workspace trust).

## Leaving stuck

Three ways, because an agent that gets stuck and never recovers is worse than one that never showed stuck:

- **A tool event.** A CLI cannot run a tool while holding a prompt open, so `PreToolUse`/`PostToolUse`/`PostToolUseFailure`/`SubagentStart`/`SubagentStop`/`PostInvocation` arriving for a stuck agent is proof the question was settled, and returns it to `working`. Nothing did this before: those are exactly the events the state map treats as informational, so a flagged agent stayed flagged for the rest of its turn, and `guardrails.go`'s claim that "any further hook event flips it back to StateWorking" was true of nothing.
- **The provider's own follow-up**, where it has one: `elicitation_complete` / `elicitation_response` / `ElicitationResult`.
- **The monitor noticing the prompt is gone.** Flagged agents keep being read every sweep — bypassing the quiet gate, since flagging them moved their own clock — and an agent still sitting in `stuck` when its prompt disappears is handed back to `working`. One already corrected by its own hooks is left alone, so the monitor never overwrites a fact with an inference.

## No UI change

Deliberately. `.agent-anim-stuck` keys off `state === "stuck"` alone, and `agent.task` already renders beside the state chip in the detail header and is part of the searchable haystack on Home. Recording the question through the existing `MarkStuck` reason puts it where the UI already looks, so nothing needed plumbing.

## Out of scope

- agy and pi get no question detection. Both are TUIs whose waiting chrome I have not verified from their binaries, and guessing at it is precisely the false-positive risk above.
- cursor's pre-TUI MCP approval prompt (`Approve all servers` / `Continue without approval`) is a genuine silent block that is not covered, because I could not establish how it renders.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/agent/ ./pkg/provider/ ./server/...`
- [x] `make lint` — `0 issues`
- [x] Behavioral tests: a permission notification marks an agent stuck with the question; `idle_prompt`/`auth_success`/`agent_completed` leave state and task untouched; the answered question returns the agent to working via the tool event that follows.
- [x] False-positive tests against real captured cursor panes: a busy agent, an agent writing about prompts, a diff containing `(y/n)`, a numbered list with no cursor, an answered prompt in scrollback.
- [x] Monitor tests: flag, release, dedupe, quiet gate, states with no valid `stuck` edge, and providers that have hooks never being peeked.
- [ ] Not exercised live: no agent here is currently sitting on a cursor question. The pane fixtures are captured from real panes, but the placeholder line in the waiting fixture is constructed from the strings in cursor's binary rather than from a screenshot of one.
