### PR TITLE
fix(agents): reconcile agent state against live sessions

### DIFF
--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -530,16 +530,39 @@ func (s *AgentService) publishEvent(eventType string, data map[string]any) {
 	})
 }
 
+// sessionStartGrace is how long after starting an agent is exempt from session
+// reconciliation. An agent is registered before its session is up, so a sweep
+// that lands in that window would find no session and stop an agent that is in
+// the middle of starting.
+const sessionStartGrace = 30 * time.Second
+
+// sessionGoneReason is recorded as the agent's task so the reason is visible
+// where the state is, rather than only in an event nobody is watching.
+const sessionGoneReason = "session ended without stopping — the agent was not running"
+
 // SyncSessions reconciles in-memory agent state with actual runtime sessions.
-// For each agent that is not already stopped or in error, it checks whether
-// the underlying tmux/docker session still exists. If the session is gone it
-// marks the agent as stopped.
-// Returns the total number of agents inspected (synced) and the number that
-// were transitioned to stopped (stopped).
+//
+// State is derived from what an agent reports, so an agent whose session dies
+// without a final event keeps the state it last reported — forever. It is listed
+// as working, its badge says working, and only the terminal tab admits there is
+// no pty behind it (#3570). A "working" agent that cannot possibly be working is
+// worse than an error, because it suppresses the question.
+//
+// An agent whose session has vanished is moved to stopped, with the reason
+// recorded as its task. Terminal states are left alone: stopped and error have
+// nothing to reconcile, and done says the agent finished, which is worth more
+// than restating that its session is gone.
+//
+// Returns the number of agents inspected and the number moved to stopped.
 func (s *AgentService) SyncSessions(ctx context.Context) (synced, stopped int) {
 	agents := s.manager.ListAgents()
+	now := time.Now()
 	for _, a := range agents {
-		if a.State == StateStopped || a.State == StateError {
+		switch a.State {
+		case StateStopped, StateError, StateDone:
+			continue
+		}
+		if !a.StartedAt.IsZero() && now.Sub(a.StartedAt) < sessionStartGrace {
 			continue
 		}
 		synced++
@@ -547,12 +570,12 @@ func (s *AgentService) SyncSessions(ctx context.Context) (synced, stopped int) {
 		if rt.HasSession(ctx, a.Name) {
 			continue
 		}
-		// Session gone — mark stopped.
-		if err := s.manager.UpdateAgentState(ctx, a.Name, StateStopped, ""); err != nil {
+		if err := s.manager.UpdateAgentState(ctx, a.Name, StateStopped, sessionGoneReason); err != nil {
 			log.Warn("sync: failed to update agent state", "agent", a.Name, "error", err)
 			continue
 		}
 		stopped++
+		log.Info("agent had no session behind it — marked stopped", "agent", a.Name, "was", string(a.State))
 		s.publishEvent("agent.state_changed", map[string]any{
 			"name":   a.Name,
 			"state":  string(StateStopped),

--- a/pkg/agent/service_test.go
+++ b/pkg/agent/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 )
 
 // mockEventPublisher records published events.
@@ -410,5 +411,73 @@ func TestAgentService_ArchiveRefusesRunning(t *testing.T) {
 	}
 	if mgr.agents["stopped"].ArchivedAt == nil {
 		t.Error("stopped agent should have ArchivedAt set after Archive")
+	}
+}
+
+// SyncSessions is what stops an agent being reported as working when nothing is
+// running behind it. The test manager's tmux prefix is unique per run, so no
+// agent here has a session — which is exactly the condition being reconciled.
+func TestSyncSessionsStopsAnAgentWithNoSession(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["working"] = &Agent{Name: "working", State: StateWorking, Task: "refactoring", Children: []string{}}
+	mgr.agents["idle"] = &Agent{Name: "idle", State: StateIdle, Children: []string{}}
+	mgr.agents["stuck"] = &Agent{Name: "stuck", State: StateStuck, Children: []string{}}
+
+	pub := &mockEventPublisher{}
+	svc := NewAgentService(mgr, pub, nil)
+
+	synced, stopped := svc.SyncSessions(context.Background())
+	if synced != 3 || stopped != 3 {
+		t.Fatalf("synced=%d stopped=%d, want 3 and 3", synced, stopped)
+	}
+	for _, name := range []string{"working", "idle", "stuck"} {
+		if got := mgr.GetAgent(name).State; got != StateStopped {
+			t.Errorf("%s state = %q, want stopped", name, got)
+		}
+	}
+	// The reason has to be somewhere the user looks, not only in an event.
+	if task := mgr.GetAgent("working").Task; !strings.Contains(task, "session ended") {
+		t.Errorf("task = %q, want it to explain that the session ended", task)
+	}
+}
+
+// Terminal states are the agent's own account of how it finished. Stopped and
+// error have nothing to reconcile, and overwriting done with stopped would
+// replace "it completed" with "its session is gone", which says less.
+func TestSyncSessionsLeavesTerminalStatesAlone(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["done"] = &Agent{Name: "done", State: StateDone, Children: []string{}}
+	mgr.agents["failed"] = &Agent{Name: "failed", State: StateError, Children: []string{}}
+	mgr.agents["halted"] = &Agent{Name: "halted", State: StateStopped, Children: []string{}}
+
+	svc := NewAgentService(mgr, nil, nil)
+
+	synced, stopped := svc.SyncSessions(context.Background())
+	if synced != 0 || stopped != 0 {
+		t.Errorf("synced=%d stopped=%d, want 0 and 0", synced, stopped)
+	}
+	if got := mgr.GetAgent("done").State; got != StateDone {
+		t.Errorf("done agent became %q", got)
+	}
+}
+
+// An agent is registered before its session exists, so a sweep landing in that
+// window must not stop an agent that is still starting.
+func TestSyncSessionsSparesAnAgentThatJustStarted(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["starting"] = &Agent{
+		Name:      "starting",
+		State:     StateWorking,
+		StartedAt: time.Now(),
+		Children:  []string{},
+	}
+
+	svc := NewAgentService(mgr, nil, nil)
+
+	if synced, stopped := svc.SyncSessions(context.Background()); synced != 0 || stopped != 0 {
+		t.Errorf("synced=%d stopped=%d, want the starting agent skipped", synced, stopped)
+	}
+	if got := mgr.GetAgent("starting").State; got != StateWorking {
+		t.Errorf("state = %q, want working", got)
 	}
 }

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -314,6 +314,15 @@ func buildServicesFromHome(ctx context.Context, globals *Globals, h *home.Home) 
 		runProviderFailureMonitor(svcCtx, agentSvc)
 	}()
 
+	// Session reconciler — an agent whose session died without reporting keeps
+	// the state it last reported, so it stays listed as working with no pty
+	// behind it. Reconciliation existed but nothing ever triggered it.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		runSessionReconciler(svcCtx, agentSvc)
+	}()
+
 	// Notify service (channel subscriptions + delivery).
 	var notifyService *notifypkg.Service
 	if ns, err := notifypkg.OpenStore(wsDB, wsDriver); err != nil {

--- a/server/session_reconciler.go
+++ b/server/session_reconciler.go
@@ -1,0 +1,66 @@
+// session_reconciler.go — keeping agent state answerable to tmux.
+//
+// mycel derives agent state from what an agent reports, which holds until the
+// session dies without reporting anything: killed pane, a machine that slept, a
+// tmux server that went away. The agent then keeps the state it last reported,
+// forever. `zen-zebra` was listed as working with no session behind it, and only
+// the terminal tab admitted it, returning 409 while every other surface showed a
+// working agent (#3570).
+//
+// AgentService.SyncSessions has always been able to notice this. Nothing called
+// it: the only trigger was POST /api/agents/sync, which no part of mycel invokes,
+// so reconciliation existed and never ran. This loop runs it — once at startup,
+// because that is when records are most likely to be stale, and then on a timer.
+package server
+
+import (
+	"context"
+	"time"
+
+	agentpkg "github.com/rpuneet/mycel/pkg/agent"
+	"github.com/rpuneet/mycel/pkg/log"
+)
+
+// sessionSyncInterval is how often agent state is checked against the runtime.
+// A vanished session does not come back, so this only decides how long a stale
+// "working" can be believed.
+const sessionSyncInterval = 30 * time.Second
+
+// sessionSyncer is the part of AgentService this loop needs, narrowed so a test
+// can drive it without a runtime.
+type sessionSyncer interface {
+	SyncSessions(ctx context.Context) (synced, stopped int)
+}
+
+// runSessionReconciler reconciles agent state against live sessions until ctx is
+// canceled.
+func runSessionReconciler(ctx context.Context, agents sessionSyncer) {
+	if agents == nil {
+		return
+	}
+
+	// Startup first: records loaded from disk describe the world as it was when
+	// the daemon last ran, which may be several reboots ago.
+	syncOnce(ctx, agents)
+
+	ticker := time.NewTicker(sessionSyncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			syncOnce(ctx, agents)
+		}
+	}
+}
+
+func syncOnce(ctx context.Context, agents sessionSyncer) {
+	synced, stopped := agents.SyncSessions(ctx)
+	if stopped > 0 {
+		log.Info("reconciled agents whose sessions were gone", "inspected", synced, "stopped", stopped)
+	}
+}
+
+// Compile-time check that the real service satisfies what the loop asks for.
+var _ sessionSyncer = (*agentpkg.AgentService)(nil)

--- a/server/session_reconciler_test.go
+++ b/server/session_reconciler_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// countingSyncer records how often it was asked to reconcile and signals the
+// first call, so a test can assert the startup pass without waiting for a tick.
+type countingSyncer struct {
+	first chan struct{}
+	calls int
+	mu    sync.Mutex
+	once  sync.Once
+}
+
+func (c *countingSyncer) SyncSessions(context.Context) (int, int) {
+	c.mu.Lock()
+	c.calls++
+	c.mu.Unlock()
+	c.once.Do(func() { close(c.first) })
+	return 1, 1
+}
+
+func (c *countingSyncer) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.calls
+}
+
+// The startup pass is the one that matters most: records loaded from disk
+// describe the machine as it was when the daemon last ran, so an agent listed as
+// working may have had no session for days. Waiting a full interval to say so is
+// a window in which the UI is knowingly wrong.
+func TestReconcilerSyncsAtStartupWithoutWaitingForATick(t *testing.T) {
+	c := &countingSyncer{first: make(chan struct{})}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	go runSessionReconciler(ctx, c)
+
+	select {
+	case <-c.first:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no reconciliation at startup")
+	}
+}
+
+// Canceling the context is how the daemon shuts the loop down; it must return
+// rather than keep a goroutine alive past shutdown.
+func TestReconcilerStopsWhenTheContextIsCanceled(t *testing.T) {
+	c := &countingSyncer{first: make(chan struct{})}
+	ctx, cancel := context.WithCancel(t.Context())
+
+	done := make(chan struct{})
+	go func() {
+		runSessionReconciler(ctx, c)
+		close(done)
+	}()
+
+	<-c.first
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconciler did not return after cancel")
+	}
+
+	after := c.count()
+	time.Sleep(50 * time.Millisecond)
+	if c.count() != after {
+		t.Error("reconciler kept working after the context was canceled")
+	}
+}
+
+// A nil service is what a degraded daemon has; the loop must return rather than
+// panic on the first tick.
+func TestReconcilerWithNoAgentService(t *testing.T) {
+	done := make(chan struct{})
+	go func() {
+		runSessionReconciler(t.Context(), nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reconciler did not return for a nil service")
+	}
+}


### PR DESCRIPTION
Fixes #3570

## Summary

`zen-zebra` was listed as `working` with no tmux session behind it. The agents list, the state badge and the activity feed all showed a working agent; only the terminal tab disagreed, returning `409: no active session`. State is derived from what an agent reports, so an agent whose session dies without reporting keeps the state it last reported — indefinitely.

`AgentService.SyncSessions` could always detect this. **Nothing called it.** The sole trigger was `POST /api/agents/sync`, which no part of mycel invokes, so the reconciliation existed and never ran. It now runs at daemon startup — when records are most likely stale, having been loaded from disk describing a machine as it was some reboots ago — and every 30 seconds after.

Two corrections to `SyncSessions` while wiring it up, both about not doing harm now that it actually runs:

- **`done` is no longer overwritten.** It previously reconciled anything that was not `stopped` or `error`, so an agent that had finished would be relabelled `stopped`. "It completed" says more than "its session is gone".
- **Agents within 30s of starting are skipped.** An agent is registered before its session exists, so a sweep landing in that window would stop an agent in the middle of starting.

The reason is recorded as the agent's task, following `StopForGuardrail`, so it appears where the state does rather than only in an SSE event nobody is watching.

This is the second of the two identical-symptom bugs. #3584 fixes the other (the session exists, the daemon looks under the wrong name); together they close the class.

## Test plan

- [x] `go test ./pkg/agent ./server/...` passes
- [x] `make lint` reports 0 issues
- [x] New tests: working/idle/stuck agents with no session are stopped and the reason lands in the task; `done`/`error`/`stopped` are untouched; a just-started agent is spared
- [x] New tests: the loop reconciles at startup without waiting for a tick, returns on context cancel, and returns immediately for a nil service (a degraded daemon)

Made with [Cursor](https://cursor.com)