### PR TITLE
fix(web): let the typed client ask for a template when creating an agent

### DIFF
--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -191,3 +191,37 @@ describe("api.streamProviderUpdate", () => {
     );
   });
 });
+
+describe("api.createAgent", () => {
+  // The endpoint has always accepted a template; the type omitted it, so the
+  // create dialog had to bypass this client with a raw fetch to ask for one.
+  it("can ask for a template, and needs no role alongside it", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ name: "trader-1" }));
+    await api.createAgent({ name: "trader-1", template: "trader" });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/agents");
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: "trader-1",
+      template: "trader",
+    });
+  });
+
+  it("passes repo and parent through under the names the API reads", async () => {
+    fetchMock.mockReturnValue(jsonResponse({ name: "child" }));
+    await api.createAgent({
+      name: "child",
+      role: "engineer",
+      repo: "/Users/me/proj",
+      parent: "lead",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: "child",
+      role: "engineer",
+      repo: "/Users/me/proj",
+      parent: "lead",
+    });
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -950,10 +950,21 @@ export const api = {
     ),
   createAgent: (opts: {
     name?: string;
-    role: string;
+    /** Optional when `template` is given: the server defaults the role to
+     *  "base" so a template alone is enough to describe an agent. */
+    role?: string;
+    /** Template to provision the agent from. The endpoint has always
+     *  accepted this; the type omitted it, so the create dialog had to bypass
+     *  this client with a raw fetch to ask for one. */
+    template?: string;
     tool?: string;
     model?: string;
     runtime?: string;
+    /** Absolute path of the git repo to bind to. Empty binds to the repo the
+     *  daemon was booted against. */
+    repo?: string;
+    /** Name of an existing agent to attach this one to as a child. */
+    parent?: string;
     /** Environment variables for the agent. Values may hold
      *  `${secret:NAME}` references resolved from the vault at spawn. */
     env?: Record<string, string>;


### PR DESCRIPTION
Part of #3576

## Summary

`POST /api/agents` has always accepted `template`, `repo` and `parent`. `api.createAgent`'s type declared none of them, so the only way to create an agent from a template through the web UI was to bypass the typed client entirely — which is what `CreateAgentModal` does, with a raw `fetch`. Any new caller (the blueprint work in #3558 above all) would have had to do the same.

`role` is now optional as well, matching the server, which defaults it to `base` when a template is given.

The modal keeps its raw fetch for now: it also sends a `task` field the server discards outright, and what happens to that is #3589. Moving the modal over belongs with that fix rather than quietly dropping a field a user filled in.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] New tests: a create with a template and no role sends exactly that; `repo` and `parent` go through under the names the API reads