### PR TITLE
fix(server): adopt legacy tmux sessions before the reconciler sweeps

### DIFF
--- a/internal/cmd/serve.go
+++ b/internal/cmd/serve.go
@@ -18,7 +18,6 @@ import (
 	secretpkg "github.com/rpuneet/mycel/pkg/secret"
 	statspkg "github.com/rpuneet/mycel/pkg/stats"
 	templatepkg "github.com/rpuneet/mycel/pkg/template"
-	"github.com/rpuneet/mycel/pkg/tmux"
 	"github.com/rpuneet/mycel/server"
 	wspkg "github.com/rpuneet/mycel/server/ws"
 )
@@ -205,16 +204,6 @@ func RunServerCtx(ctx context.Context, addr, repoRoot, corsOrigin, apiKey string
 	if svc.AgentMgr != nil {
 		if n := svc.AgentMgr.RefreshActivityConfigs(); n > 0 {
 			log.Info("refreshed agent activity configs", "agents", n)
-		}
-	}
-
-	// Sessions created before session names dropped the repo hash are still
-	// running under the old name. Rename them before anything looks for an
-	// agent, or a running agent reads as stopped. The registry decides what is
-	// a hash and what is part of an agent's name, which shape alone cannot.
-	if svc.AgentMgr != nil {
-		if n := tmux.NewManager(tmux.DefaultPrefix).AdoptLegacySessions(ctx, svc.AgentMgr.HasAgent); n > 0 {
-			log.Info("adopted tmux sessions named by an older version", "sessions", n)
 		}
 	}
 

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -36,6 +36,7 @@ import (
 	secretpkg "github.com/rpuneet/mycel/pkg/secret"
 	statspkg "github.com/rpuneet/mycel/pkg/stats"
 	templatepkg "github.com/rpuneet/mycel/pkg/template"
+	"github.com/rpuneet/mycel/pkg/tmux"
 	toolpkg "github.com/rpuneet/mycel/pkg/tool"
 	wspkg "github.com/rpuneet/mycel/server/ws"
 )
@@ -151,6 +152,14 @@ func buildServicesFromHome(ctx context.Context, globals *Globals, h *home.Home) 
 	}
 	if err := agentMgr.LoadState(); err != nil {
 		log.Warn("failed to load agent state", "error", err, "repo", h.RootDir)
+	}
+	// Adopt sessions named by a version that scoped them to the workspace path,
+	// before anything asks whether an agent has a session. Ordering is not a
+	// nicety here: the session reconciler's first pass would otherwise find a
+	// running agent under a name it does not use and mark it stopped, which is
+	// precisely the false report both changes exist to prevent.
+	if n := tmux.NewManager(tmux.DefaultPrefix).AdoptLegacySessions(ctx, agentMgr.HasAgent); n > 0 {
+		log.Info("adopted tmux sessions named by an older version", "sessions", n)
 	}
 	if h.RoleManager != nil {
 		agentMgr.SetRoleManager(h.RoleManager)


### PR DESCRIPTION
Part of #3570

## The bug the two merged PRs made together

#3584 stopped putting the repo hash in tmux session names and added `AdoptLegacySessions` to rename sessions left under the old name. #3588 added a reconciler that marks an agent stopped when nothing is running behind it. Each is right on its own. Together they were not:

- `AdoptLegacySessions` ran in `RunServerCtx`, *after* `buildServicesFromHome` returned.
- `buildServicesFromHome` starts the reconciler goroutine, whose first sweep runs immediately.

So on the first restart after upgrading, the reconciler asked whether `mycel-<agent>` existed, the session was still `mycel-<hash>-<agent>`, and every running agent was marked stopped with "session ended without stopping — the agent was not running". Adoption then renamed the sessions a beat later, leaving the sessions alive and the records dead. That is precisely the false report both changes were written to prevent, and it fired only on the upgrade path — the one restart where every session is a legacy one.

## Fix

Adoption moves into `buildServicesFromHome`, after `LoadState` and before the reconciler goroutine is spawned. The ordering is now structural: the reconciler cannot observe a pre-rename session because the rename happens on the same goroutine that later starts it. It also picks up the caller's `ctx` instead of the process context it had in `RunServerCtx`.

## Verified live, on the upgrade path itself

Reproduced the bug rather than reasoned about it. With a session renamed back to its legacy name:

    tmux rename-session -t mycel-eager-fox mycel-13c6e9-eager-fox

Before: the agent read `stopped` / "session ended without stopping" after restart, with the session still running.
After: `adopted a tmux session named by an older version from=mycel-13c6e9-eager-fox to=mycel-eager-fox`, no reconciler stop, and the agent stays `idle` with its task line intact. No `session ended` lines in the log at all.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/... ./pkg/tmux/... ./pkg/agent/...`
- [x] Live upgrade-path reproduction above, both directions

No unit test: the guarantee here is that one statement precedes a `go` statement in the same function, which a test can only restate, not check.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of existing tmux sessions during service startup.
  * Legacy workspace sessions are now adopted consistently before background reconciliation begins.
  * Removed duplicate session adoption during request serving to prevent inconsistent startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->