### PR TITLE
fix(agents): resume a stopped agent whose session is still alive

### DIFF
--- a/docs/reference/api-rest.md
+++ b/docs/reference/api-rest.md
@@ -62,7 +62,7 @@ Errors are JSON objects: `{"error": "<message>"}` with an appropriate status cod
 | POST | `/api/agents/send-role` | Send a message to all agents with a role. Body: `{"role","message"}`. |
 | POST | `/api/agents/send-pattern` | Send a message to agents whose name matches a pattern. Body: `{"pattern","message"}`. |
 | POST | `/api/agents/stop-all` | Stop all agents. Returns `{"stopped": <n>}`. |
-| POST | `/api/agents/sync` | Reconcile in-memory agent state with live runtime sessions. Returns `{"synced": <n>, "stopped": <n>}`. |
+| POST | `/api/agents/sync` | Reconcile in-memory agent state with live runtime sessions. Returns `{"synced": <n>, "stopped": <n>, "resumed": <n>}`. |
 | GET | `/api/agents/health` | Per-agent health report (`healthy`/`degraded`/`unhealthy`, tmux liveness, state freshness). Query: `timeout=<duration>` (default `60s`), `agent=<name>`. |
 | GET | `/api/agents/activity` | Recent activity events across all agents (Live page hydration). Query: `limit` (default 200, max 2000). |
 

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -536,11 +536,21 @@ func (s *AgentService) publishEvent(eventType string, data map[string]any) {
 // the middle of starting.
 const sessionStartGrace = 30 * time.Second
 
+// sessionStopGrace is the same idea as sessionStartGrace on the way down.
+// Killing a session is not instantaneous, so a sweep landing immediately after
+// a stop can still see the session and would announce the agent as running
+// again — undoing a stop the user just asked for.
+const sessionStopGrace = 30 * time.Second
+
 // sessionGoneReason is recorded as the agent's task so the reason is visible
 // where the state is, rather than only in an event nobody is watching.
 const sessionGoneReason = "session ended without stopping — the agent was not running"
 
-// SyncSessions reconciles in-memory agent state with actual runtime sessions.
+// sessionAliveReason is its opposite: the record says stopped and the process
+// is still there.
+const sessionAliveReason = "session still running — the agent was recorded stopped while it was not"
+
+// SyncSessions reconciles agent state with the sessions actually running.
 //
 // State is derived from what an agent reports, so an agent whose session dies
 // without a final event keeps the state it last reported — forever. It is listed
@@ -548,18 +558,38 @@ const sessionGoneReason = "session ended without stopping — the agent was not 
 // no pty behind it (#3570). A "working" agent that cannot possibly be working is
 // worse than an error, because it suppresses the question.
 //
-// An agent whose session has vanished is moved to stopped, with the reason
-// recorded as its task. Terminal states are left alone: stopped and error have
-// nothing to reconcile, and done says the agent finished, which is worth more
-// than restating that its session is gone.
+// The mismatch runs both ways, and only stopping was ever corrected. An agent
+// recorded stopped with its session still running is the same lie told the other
+// way round, and it is the worse of the two to leave: nothing else ever revisits
+// a stopped record, so where a stale "working" is corrected within 30 seconds, a
+// wrong "stopped" is permanent. It is also reachable in one step — anything that
+// records a stop while the process lives, up to and including a bug in this
+// sweep — and it hides a running agent from the fleet entirely.
 //
-// Returns the number of agents inspected and the number moved to stopped.
-func (s *AgentService) SyncSessions(ctx context.Context) (synced, stopped int) {
+// So: a live state with no session becomes stopped, and a stopped state with a
+// live session becomes idle, both with the reason recorded as the task. Idle
+// rather than working because the session's existence says a process is there
+// and nothing more; the next event it reports moves it on.
+//
+// error and done are left alone in both directions. done means the agent
+// finished, which is worth more than restating what became of its session, and
+// an error with a session still up is a diagnosis a person should see rather
+// than have overwritten by an inference.
+//
+// Returns how many agents were inspected, how many were moved to stopped, and
+// how many stopped records were restored to idle.
+func (s *AgentService) SyncSessions(ctx context.Context) (synced, stopped, resumed int) {
 	agents := s.manager.ListAgents()
 	now := time.Now()
 	for _, a := range agents {
 		switch a.State {
-		case StateStopped, StateError, StateDone:
+		case StateError, StateDone:
+			continue
+		case StateStopped:
+			synced++
+			if s.resumeIfSessionAlive(ctx, a, now) {
+				resumed++
+			}
 			continue
 		}
 		if !a.StartedAt.IsZero() && now.Sub(a.StartedAt) < sessionStartGrace {
@@ -582,7 +612,30 @@ func (s *AgentService) SyncSessions(ctx context.Context) (synced, stopped int) {
 			"reason": "session_gone",
 		})
 	}
-	return synced, stopped
+	return synced, stopped, resumed
+}
+
+// resumeIfSessionAlive moves an agent recorded stopped back to idle when its
+// session is still running. Reports whether it did.
+func (s *AgentService) resumeIfSessionAlive(ctx context.Context, a *Agent, now time.Time) bool {
+	if a.StoppedAt != nil && now.Sub(*a.StoppedAt) < sessionStopGrace {
+		return false
+	}
+	rt := s.manager.RuntimeForAgent(a.Name)
+	if !rt.HasSession(ctx, a.Name) {
+		return false
+	}
+	if err := s.manager.UpdateAgentState(ctx, a.Name, StateIdle, sessionAliveReason); err != nil {
+		log.Warn("sync: failed to update agent state", "agent", a.Name, "error", err)
+		return false
+	}
+	log.Info("agent was recorded stopped with its session still running — marked idle", "agent", a.Name)
+	s.publishEvent("agent.state_changed", map[string]any{
+		"name":   a.Name,
+		"state":  string(StateIdle),
+		"reason": "session_alive",
+	})
+	return true
 }
 
 // StopAll stops all running agents. Returns count of agents stopped.

--- a/pkg/agent/service_test.go
+++ b/pkg/agent/service_test.go
@@ -426,9 +426,9 @@ func TestSyncSessionsStopsAnAgentWithNoSession(t *testing.T) {
 	pub := &mockEventPublisher{}
 	svc := NewAgentService(mgr, pub, nil)
 
-	synced, stopped := svc.SyncSessions(context.Background())
-	if synced != 3 || stopped != 3 {
-		t.Fatalf("synced=%d stopped=%d, want 3 and 3", synced, stopped)
+	synced, stopped, resumed := svc.SyncSessions(context.Background())
+	if synced != 3 || stopped != 3 || resumed != 0 {
+		t.Fatalf("synced=%d stopped=%d resumed=%d, want 3, 3, 0", synced, stopped, resumed)
 	}
 	for _, name := range []string{"working", "idle", "stuck"} {
 		if got := mgr.GetAgent(name).State; got != StateStopped {
@@ -441,9 +441,9 @@ func TestSyncSessionsStopsAnAgentWithNoSession(t *testing.T) {
 	}
 }
 
-// Terminal states are the agent's own account of how it finished. Stopped and
-// error have nothing to reconcile, and overwriting done with stopped would
-// replace "it completed" with "its session is gone", which says less.
+// done and error are the agent's own account of how it finished. Overwriting
+// them would replace a diagnosis with an inference about the session. A
+// stopped agent with no session is already correct and stays that way.
 func TestSyncSessionsLeavesTerminalStatesAlone(t *testing.T) {
 	mgr := newTestManager(t)
 	mgr.agents["done"] = &Agent{Name: "done", State: StateDone, Children: []string{}}
@@ -452,12 +452,17 @@ func TestSyncSessionsLeavesTerminalStatesAlone(t *testing.T) {
 
 	svc := NewAgentService(mgr, nil, nil)
 
-	synced, stopped := svc.SyncSessions(context.Background())
-	if synced != 0 || stopped != 0 {
-		t.Errorf("synced=%d stopped=%d, want 0 and 0", synced, stopped)
+	synced, stopped, resumed := svc.SyncSessions(context.Background())
+	// The stopped agent is inspected (so a live session would be noticed), but
+	// without one it is not moved.
+	if synced != 1 || stopped != 0 || resumed != 0 {
+		t.Errorf("synced=%d stopped=%d resumed=%d, want 1, 0, 0", synced, stopped, resumed)
 	}
 	if got := mgr.GetAgent("done").State; got != StateDone {
 		t.Errorf("done agent became %q", got)
+	}
+	if got := mgr.GetAgent("halted").State; got != StateStopped {
+		t.Errorf("halted agent became %q", got)
 	}
 }
 
@@ -474,10 +479,71 @@ func TestSyncSessionsSparesAnAgentThatJustStarted(t *testing.T) {
 
 	svc := NewAgentService(mgr, nil, nil)
 
-	if synced, stopped := svc.SyncSessions(context.Background()); synced != 0 || stopped != 0 {
-		t.Errorf("synced=%d stopped=%d, want the starting agent skipped", synced, stopped)
+	if synced, stopped, resumed := svc.SyncSessions(context.Background()); synced != 0 || stopped != 0 || resumed != 0 {
+		t.Errorf("synced=%d stopped=%d resumed=%d, want the starting agent skipped", synced, stopped, resumed)
 	}
 	if got := mgr.GetAgent("starting").State; got != StateWorking {
 		t.Errorf("state = %q, want working", got)
+	}
+}
+
+// A stopped record with a live session is the same mismatch as working-with-no-
+// session, told the other way. Nothing else revisits stopped agents, so leaving
+// it alone would hide a running process permanently.
+func TestSyncSessionsResumesAStoppedAgentWhoseSessionIsAlive(t *testing.T) {
+	be := newMockBackend("tmux")
+	be.sessions["alive"] = true
+	mgr := newMockManager(t, "tmux", map[string]*mockBackend{"tmux": be})
+	longAgo := time.Now().Add(-time.Hour)
+	mgr.agents["alive"] = &Agent{
+		Name:      "alive",
+		State:     StateStopped,
+		StoppedAt: &longAgo,
+		Task:      "session ended without stopping — the agent was not running",
+		Children:  []string{},
+	}
+	mgr.agents["genuinely-gone"] = &Agent{
+		Name:      "genuinely-gone",
+		State:     StateStopped,
+		StoppedAt: &longAgo,
+		Children:  []string{},
+	}
+
+	svc := NewAgentService(mgr, &mockEventPublisher{}, nil)
+	synced, stopped, resumed := svc.SyncSessions(context.Background())
+	if synced != 2 || stopped != 0 || resumed != 1 {
+		t.Fatalf("synced=%d stopped=%d resumed=%d, want 2, 0, 1", synced, stopped, resumed)
+	}
+	if got := mgr.GetAgent("alive").State; got != StateIdle {
+		t.Errorf("alive state = %q, want idle", got)
+	}
+	if task := mgr.GetAgent("alive").Task; !strings.Contains(task, "still running") {
+		t.Errorf("task = %q, want it to explain the session is still there", task)
+	}
+	if got := mgr.GetAgent("genuinely-gone").State; got != StateStopped {
+		t.Errorf("genuinely-gone became %q", got)
+	}
+}
+
+// Killing a session is not instantaneous. A sweep that lands immediately after
+// a stop must not undo the stop the user just asked for.
+func TestSyncSessionsSparesARecentlyStoppedAgent(t *testing.T) {
+	be := newMockBackend("tmux")
+	be.sessions["just-stopped"] = true
+	mgr := newMockManager(t, "tmux", map[string]*mockBackend{"tmux": be})
+	now := time.Now()
+	mgr.agents["just-stopped"] = &Agent{
+		Name:      "just-stopped",
+		State:     StateStopped,
+		StoppedAt: &now,
+		Children:  []string{},
+	}
+
+	svc := NewAgentService(mgr, nil, nil)
+	if synced, stopped, resumed := svc.SyncSessions(context.Background()); synced != 1 || stopped != 0 || resumed != 0 {
+		t.Errorf("synced=%d stopped=%d resumed=%d, want the recent stop spared", synced, stopped, resumed)
+	}
+	if got := mgr.GetAgent("just-stopped").State; got != StateStopped {
+		t.Errorf("state = %q, want stopped", got)
 	}
 }

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -839,8 +839,8 @@ func (h *AgentHandler) syncSessions(w http.ResponseWriter, r *http.Request) {
 	if !requireMethod(w, r, http.MethodPost) {
 		return
 	}
-	synced, stopped := svc.SyncSessions(r.Context())
-	writeJSON(w, http.StatusOK, map[string]int{"synced": synced, "stopped": stopped})
+	synced, stopped, resumed := svc.SyncSessions(r.Context())
+	writeJSON(w, http.StatusOK, map[string]int{"synced": synced, "stopped": stopped, "resumed": resumed})
 }
 
 // AgentHealthInfo represents health status of an agent.

--- a/server/session_reconciler.go
+++ b/server/session_reconciler.go
@@ -29,7 +29,7 @@ const sessionSyncInterval = 30 * time.Second
 // sessionSyncer is the part of AgentService this loop needs, narrowed so a test
 // can drive it without a runtime.
 type sessionSyncer interface {
-	SyncSessions(ctx context.Context) (synced, stopped int)
+	SyncSessions(ctx context.Context) (synced, stopped, resumed int)
 }
 
 // runSessionReconciler reconciles agent state against live sessions until ctx is
@@ -56,9 +56,10 @@ func runSessionReconciler(ctx context.Context, agents sessionSyncer) {
 }
 
 func syncOnce(ctx context.Context, agents sessionSyncer) {
-	synced, stopped := agents.SyncSessions(ctx)
-	if stopped > 0 {
-		log.Info("reconciled agents whose sessions were gone", "inspected", synced, "stopped", stopped)
+	synced, stopped, resumed := agents.SyncSessions(ctx)
+	if stopped > 0 || resumed > 0 {
+		log.Info("reconciled agent state against live sessions",
+			"inspected", synced, "stopped", stopped, "resumed", resumed)
 	}
 }
 

--- a/server/session_reconciler_test.go
+++ b/server/session_reconciler_test.go
@@ -16,12 +16,12 @@ type countingSyncer struct {
 	once  sync.Once
 }
 
-func (c *countingSyncer) SyncSessions(context.Context) (int, int) {
+func (c *countingSyncer) SyncSessions(context.Context) (int, int, int) {
 	c.mu.Lock()
 	c.calls++
 	c.mu.Unlock()
 	c.once.Do(func() { close(c.first) })
-	return 1, 1
+	return 1, 1, 0
 }
 
 func (c *countingSyncer) count() int {


### PR DESCRIPTION
Part of #3570

## The other half of the mismatch

#3588 made `SyncSessions` correct a live state with no session. It left the reverse alone: a stopped record whose session is still running. That direction is worse, not better — nothing else revisits a stopped agent, so a false stop is permanent, and it hides a running process from the fleet entirely.

Live verify after the adopt/reconcile ordering bug (#3591) produced exactly that: 11 agents recorded `stopped` / "session ended without stopping" while their tmux sessions were still up. Adoption renamed the sessions; the records stayed dead.

## Fix

- A stopped agent whose session is alive becomes `idle`, with the reason on the task line ("session still running — the agent was recorded stopped while it was not").
- Idle rather than working: existence says a process is there and nothing more; the next event it reports moves it on.
- A 30s grace after `StoppedAt` mirrors the start grace, so a stop the user just asked for is not undone while the kill is still settling.
- `error` and `done` stay untouched in both directions.
- `POST /api/agents/sync` now returns `resumed` alongside `synced`/`stopped`.

## Test plan

- [x] Unit: resume a stopped agent with a live session; leave a genuinely-gone stopped alone; spare a recently stopped agent; still stop live-with-no-session
- [x] `go test ./pkg/agent/ ./server/...`
- [ ] Live: after #3591 lands, restart with the false-stopped fleet and confirm they return to idle on the first reconcile pass

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent synchronization now detects and resumes agents with active sessions.
  * Synchronization results include counts for inspected, stopped, and resumed agents.
  * State-change events include reasons when an active session keeps an agent running.

* **Bug Fixes**
  * Recently stopped agents are protected by a 30-second grace period, preventing premature state changes.
  * Agents without active sessions are correctly transitioned to a stopped state.
  * Reconciliation logs now report both stopped and resumed agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->