### PR TITLE
fix(cost): record Cursor stop-hook tokens so Insights is not stuck at $0

### DIFF
--- a/pkg/agent/hook_ingest.go
+++ b/pkg/agent/hook_ingest.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rpuneet/mycel/pkg/events"
 	"github.com/rpuneet/mycel/pkg/log"
+	"github.com/rpuneet/mycel/pkg/provider"
 )
 
 // ErrUnknownHookEvent is returned by IngestHookEvent for events that are not
@@ -130,6 +131,13 @@ func (s *AgentService) IngestHookEvent(ctx context.Context, name string, payload
 		}
 	}
 
+	// Cursor (and any future provider that puts tokens on Stop) reports
+	// usage on the turn-complete hook rather than in a session transcript.
+	// Persist it where CostReader looks, or Insights stays at $0 forever.
+	if payload.Event == HookStop {
+		s.recordHookUsage(name, payload)
+	}
+
 	now := time.Now()
 	fields := hookPayloadFields(payload)
 
@@ -197,6 +205,33 @@ func (s *AgentService) agentState(name string) State {
 		return ""
 	}
 	return a.State
+}
+
+// recordHookUsage persists token counts from a Stop payload into the agent's
+// cursor usage JSONL. Best-effort: a write failure must not drop the hook
+// event itself, or activity reporting would become coupled to disk health.
+func (s *AgentService) recordHookUsage(name string, payload HookPayload) {
+	if payload.InputTokens == 0 && payload.OutputTokens == 0 &&
+		payload.CacheReadTokens == 0 && payload.CacheWriteTokens == 0 {
+		return
+	}
+	if s.manager == nil {
+		return
+	}
+	rec := provider.CursorUsageRecord{
+		Timestamp:        time.Now().UTC(),
+		Model:            payload.Model,
+		SessionID:        payload.SessionID,
+		GenerationID:     payload.GenerationID,
+		InputTokens:      payload.InputTokens,
+		OutputTokens:     payload.OutputTokens,
+		CacheReadTokens:  payload.CacheReadTokens,
+		CacheWriteTokens: payload.CacheWriteTokens,
+		CostUSD:          payload.CostUSD,
+	}
+	if err := provider.AppendCursorUsage(s.manager.agentsRoot(), name, rec); err != nil {
+		log.Debug("cursor usage record skipped", "agent", name, "error", err)
+	}
 }
 
 // isTurnStart reports whether an event marks the beginning of a model turn,

--- a/pkg/agent/hook_ingest_test.go
+++ b/pkg/agent/hook_ingest_test.go
@@ -3,6 +3,8 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -460,5 +462,38 @@ func TestIngestHookEvent_GatewayEnvelopeBecomesAReadableTask(t *testing.T) {
 
 	if got := mgr.agents["eng-1"].Task; got != "review both trackers and make sure main is good" {
 		t.Errorf("task = %q, want the message rather than its envelope", got)
+	}
+}
+
+func TestIngestHookEvent_StopPersistsCursorUsage(t *testing.T) {
+	mgr := newTestManager(t)
+	mgr.agents["cursor-agent"] = &Agent{Name: "cursor-agent", State: StateWorking, Children: []string{}}
+	svc := NewAgentService(mgr, nil, nil)
+
+	payload := HookPayload{
+		Event:            HookStop,
+		State:            "idle",
+		Model:            "kimi-k3",
+		SessionID:        "sess",
+		GenerationID:     "gen-99",
+		InputTokens:      100,
+		OutputTokens:     20,
+		CacheReadTokens:  40,
+		CacheWriteTokens: 5,
+	}
+	if err := svc.IngestHookEvent(context.Background(), "cursor-agent", payload, nil); err != nil {
+		t.Fatalf("IngestHookEvent: %v", err)
+	}
+
+	path := filepath.Join(mgr.agentsRoot(), "cursor-agent", "session", "cursor", "usage.jsonl")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("usage file missing: %v", err)
+	}
+	if !strings.Contains(string(raw), `"generation_id":"gen-99"`) {
+		t.Errorf("usage file = %s, want generation_id", raw)
+	}
+	if !strings.Contains(string(raw), `"input_tokens":100`) {
+		t.Errorf("usage file missing input_tokens: %s", raw)
 	}
 }

--- a/pkg/agent/hooks.go
+++ b/pkg/agent/hooks.go
@@ -146,9 +146,17 @@ type HookPayload struct {
 	NotificationType string   `json:"notification_type,omitempty"`
 	File             string   `json:"file,omitempty"`
 	Mentions         []string `json:"mentions,omitempty"`
-	CostUSD          float64  `json:"cost_usd,omitempty"`
-	InputTokens      int64    `json:"input_tokens,omitempty"`
-	OutputTokens     int64    `json:"output_tokens,omitempty"`
+	// SessionID / GenerationID identify the provider turn. Cursor puts both
+	// on every hook payload; they are how usage records dedup.
+	SessionID    string  `json:"session_id,omitempty"`
+	GenerationID string  `json:"generation_id,omitempty"`
+	CostUSD      float64 `json:"cost_usd,omitempty"`
+	InputTokens  int64   `json:"input_tokens,omitempty"`
+	OutputTokens int64   `json:"output_tokens,omitempty"`
+	// Cache token fields are Cursor's stop-hook vocabulary. Claude uses
+	// different names in its transcripts and never puts them on this payload.
+	CacheReadTokens  int64 `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int64 `json:"cache_write_tokens,omitempty"`
 }
 
 // The Claude Code hook-settings writer that generates .claude/settings.json

--- a/pkg/provider/cursor_costs.go
+++ b/pkg/provider/cursor_costs.go
@@ -1,0 +1,214 @@
+package provider
+
+// cursor_costs.go — CostReader for Cursor Agent.
+//
+// Cursor does not write token usage into its agent-transcript JSONL (those
+// files are conversation turns only). It *does* put input/output/cache token
+// counts on the stop-hook payload the mycel reporter already POSTs. Those
+// counts are persisted under:
+//
+//	<AgentsDir>/<name>/session/cursor/usage.jsonl
+//
+// by the hook ingestion path, one line per completed turn. ReadCosts prices
+// each line the same way Claude's reader does for its session files.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// CursorUsageRelDir is the session subdirectory that holds Cursor usage
+// records written from stop-hook payloads.
+const CursorUsageRelDir = "session/cursor"
+
+// CursorUsageFile is the JSONL filename under CursorUsageRelDir.
+const CursorUsageFile = "usage.jsonl"
+
+// CursorUsageRecord is one turn's usage as stored on disk and as read back
+// by ReadCosts. Field names match the stop-hook payload where possible.
+type CursorUsageRecord struct {
+	Timestamp        time.Time `json:"timestamp"`
+	Model            string    `json:"model"`
+	SessionID        string    `json:"session_id,omitempty"`
+	GenerationID     string    `json:"generation_id,omitempty"`
+	InputTokens      int64     `json:"input_tokens"`
+	OutputTokens     int64     `json:"output_tokens"`
+	CacheReadTokens  int64     `json:"cache_read_tokens"`
+	CacheWriteTokens int64     `json:"cache_write_tokens"`
+	CostUSD          float64   `json:"cost_usd"`
+}
+
+// CursorCalcCost returns the USD cost for the given token counts and model.
+// Claude-named models reuse Claude pricing; everything else uses the Cursor
+// table below. Unknown models get a conservative mid-tier default so a
+// figure is never silently zero when tokens were reported.
+func CursorCalcCost(model string, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens int64) float64 {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if strings.HasPrefix(m, "claude-") {
+		return ClaudeCalcCost(model, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
+	}
+	p := cursorPricingFor(m)
+	const perM = 1_000_000.0
+	return float64(inputTokens)*p.InputPerM/perM +
+		float64(outputTokens)*p.OutputPerM/perM +
+		float64(cacheWriteTokens)*p.CacheWritePerM/perM +
+		float64(cacheReadTokens)*p.CacheReadPerM/perM
+}
+
+// cursorModelPrices is walked in order; more specific prefixes first.
+// Rates are USD per 1M tokens. Cursor's "default" and composer-family
+// models do not publish a stable public table the way Anthropic does, so
+// these are best-effort and should be revisited when Cursor documents
+// them. Prefer wrong-but-visible over $0.
+var cursorModelPrices = []struct {
+	prefix  string
+	pricing ModelPricing
+}{
+	// Cursor composer / default agent models (approximate).
+	{"composer", ModelPricing{InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheReadPerM: 0.30}},
+	{"kimi", ModelPricing{InputPerM: 0.60, OutputPerM: 2.50, CacheWritePerM: 0.75, CacheReadPerM: 0.06}},
+	{"gpt-5", ModelPricing{InputPerM: 1.25, OutputPerM: 10.00, CacheWritePerM: 1.25, CacheReadPerM: 0.125}},
+	{"gpt-4.1", ModelPricing{InputPerM: 2.00, OutputPerM: 8.00, CacheWritePerM: 2.00, CacheReadPerM: 0.50}},
+	{"gpt-4o", ModelPricing{InputPerM: 2.50, OutputPerM: 10.00, CacheWritePerM: 2.50, CacheReadPerM: 1.25}},
+	{"o3", ModelPricing{InputPerM: 2.00, OutputPerM: 8.00, CacheWritePerM: 2.00, CacheReadPerM: 0.50}},
+	{"o4", ModelPricing{InputPerM: 1.10, OutputPerM: 4.40, CacheWritePerM: 1.10, CacheReadPerM: 0.275}},
+}
+
+var defaultCursorPricing = ModelPricing{InputPerM: 3.00, OutputPerM: 15.00, CacheWritePerM: 3.75, CacheReadPerM: 0.30}
+
+func cursorPricingFor(model string) ModelPricing {
+	if model == "" || model == "default" {
+		return defaultCursorPricing
+	}
+	for _, p := range cursorModelPrices {
+		if strings.HasPrefix(model, p.prefix) {
+			return p.pricing
+		}
+	}
+	return defaultCursorPricing
+}
+
+// AppendCursorUsage writes one priced usage record for agent under
+// AgentsDir. Called from hook ingestion when a Stop payload carries
+// token counts. Empty AgentsDir or a record with no tokens is a no-op.
+func AppendCursorUsage(agentsDir, agent string, rec CursorUsageRecord) error {
+	if agentsDir == "" || agent == "" {
+		return nil
+	}
+	if rec.InputTokens == 0 && rec.OutputTokens == 0 &&
+		rec.CacheReadTokens == 0 && rec.CacheWriteTokens == 0 {
+		return nil
+	}
+	if rec.Timestamp.IsZero() {
+		rec.Timestamp = time.Now().UTC()
+	}
+	if rec.CostUSD == 0 {
+		rec.CostUSD = CursorCalcCost(rec.Model, rec.InputTokens, rec.OutputTokens, rec.CacheWriteTokens, rec.CacheReadTokens)
+	}
+	dir := filepath.Join(agentsDir, agent, CursorUsageRelDir)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, CursorUsageFile)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600) //nolint:gosec // path under mycel home
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint:errcheck
+	line, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	_, err = f.Write(append(line, '\n'))
+	return err
+}
+
+// ReadCosts implements CostReader for Cursor Agent.
+func (p *CursorProvider) ReadCosts(ctx context.Context, opts CostReadOptions) ([]CostEntry, error) {
+	if opts.AgentsDir == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(opts.AgentsDir)
+	if err != nil {
+		return nil, nil // best-effort source
+	}
+
+	seen := make(map[string]struct{})
+	var out []CostEntry
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		path := filepath.Join(opts.AgentsDir, e.Name(), CursorUsageRelDir, CursorUsageFile)
+		recs, readErr := readCursorUsageFile(path)
+		if readErr != nil {
+			continue
+		}
+		for _, rec := range recs {
+			if !opts.Since.IsZero() && rec.Timestamp.Before(opts.Since) {
+				continue
+			}
+			key := rec.GenerationID
+			if key == "" {
+				key = rec.SessionID + "|" + rec.Timestamp.UTC().Format(time.RFC3339Nano) + "|" +
+					strconv.FormatInt(rec.InputTokens, 10) + "|" + strconv.FormatInt(rec.OutputTokens, 10)
+			}
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			cost := rec.CostUSD
+			if cost == 0 {
+				cost = CursorCalcCost(rec.Model, rec.InputTokens, rec.OutputTokens, rec.CacheWriteTokens, rec.CacheReadTokens)
+			}
+			out = append(out, CostEntry{
+				Timestamp:        rec.Timestamp,
+				Agent:            e.Name(),
+				Model:            rec.Model,
+				SessionID:        rec.SessionID,
+				InputTokens:      rec.InputTokens,
+				OutputTokens:     rec.OutputTokens,
+				CacheReadTokens:  rec.CacheReadTokens,
+				CacheWriteTokens: rec.CacheWriteTokens,
+				CostUSD:          cost,
+			})
+		}
+	}
+	return out, nil
+}
+
+func readCursorUsageFile(path string) ([]CursorUsageRecord, error) {
+	f, err := os.Open(path) //nolint:gosec // path under mycel agents dir
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck
+
+	var out []CursorUsageRecord
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var rec CursorUsageRecord
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out, sc.Err()
+}
+
+// Ensure CursorProvider implements CostReader.
+var _ CostReader = (*CursorProvider)(nil)

--- a/pkg/provider/cursor_costs_test.go
+++ b/pkg/provider/cursor_costs_test.go
@@ -1,0 +1,88 @@
+package provider
+
+import (
+	"context"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAppendAndReadCursorUsage(t *testing.T) {
+	agents := t.TempDir()
+	rec := CursorUsageRecord{
+		Timestamp:        time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+		Model:            "kimi-k3",
+		SessionID:        "sess-1",
+		GenerationID:     "gen-1",
+		InputTokens:      1000,
+		OutputTokens:     200,
+		CacheReadTokens:  500,
+		CacheWriteTokens: 50,
+	}
+	if err := AppendCursorUsage(agents, "swift-fox", rec); err != nil {
+		t.Fatalf("AppendCursorUsage: %v", err)
+	}
+
+	p := NewCursorProvider()
+	entries, err := p.ReadCosts(context.Background(), CostReadOptions{AgentsDir: agents})
+	if err != nil {
+		t.Fatalf("ReadCosts: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1", len(entries))
+	}
+	got := entries[0]
+	if got.Agent != "swift-fox" {
+		t.Errorf("agent = %q", got.Agent)
+	}
+	if got.InputTokens != 1000 || got.OutputTokens != 200 {
+		t.Errorf("tokens = %d/%d", got.InputTokens, got.OutputTokens)
+	}
+	want := CursorCalcCost(rec.Model, rec.InputTokens, rec.OutputTokens, rec.CacheWriteTokens, rec.CacheReadTokens)
+	if math.Abs(got.CostUSD-want) > 1e-9 {
+		t.Errorf("cost = %v, want %v", got.CostUSD, want)
+	}
+}
+
+func TestReadCostsDedupsByGenerationID(t *testing.T) {
+	agents := t.TempDir()
+	rec := CursorUsageRecord{
+		Timestamp:    time.Now().UTC(),
+		Model:        "default",
+		GenerationID: "same",
+		InputTokens:  10,
+		OutputTokens: 5,
+	}
+	_ = AppendCursorUsage(agents, "a", rec)
+	_ = AppendCursorUsage(agents, "a", rec)
+
+	p := NewCursorProvider()
+	entries, err := p.ReadCosts(context.Background(), CostReadOptions{AgentsDir: agents})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("entries = %d, want 1 after dedup", len(entries))
+	}
+}
+
+func TestAppendCursorUsageSkipsEmpty(t *testing.T) {
+	agents := t.TempDir()
+	if err := AppendCursorUsage(agents, "a", CursorUsageRecord{Model: "default"}); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(agents, "a", CursorUsageRelDir, CursorUsageFile)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected no file for zero-token record, err=%v", err)
+	}
+}
+
+func TestCursorCalcCostUsesClaudePricingForClaudeModels(t *testing.T) {
+	got := CursorCalcCost("claude-sonnet-4", 1_000_000, 0, 0, 0)
+	want := ClaudeCalcCost("claude-sonnet-4", 1_000_000, 0, 0, 0)
+	if got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -943,62 +943,101 @@ type costAgg struct {
 	cost   float64
 }
 
-// aggregateCostsByProvider groups model costs by provider name.
-// A model belongs to a provider if the model name contains the provider name.
+// aggregateCostsByProvider groups costs by the provider that ran them.
+//
+// Attribution is by the agent's configured tool, not by whether the model
+// name contains the provider name. Cursor agents routinely run Claude-named
+// models; the old substring rule billed those turns to Claude and left
+// Cursor at $0 even after Cursor started reporting usage (#3593).
 func (h *ProviderHandler) aggregateCostsByProvider(ctx context.Context) map[string]*costAgg {
 	result := make(map[string]*costAgg)
 	if h.costs == nil {
 		return result
 	}
 
-	summaries, err := h.costs.SummaryByModel(ctx)
+	summaries, err := h.costs.SummaryByAgent(ctx)
 	if err != nil {
 		return result
 	}
 
+	toolByAgent := make(map[string]string)
+	for _, a := range h.listAgents(ctx) {
+		if a.Tool != "" {
+			toolByAgent[a.Name] = a.Tool
+		}
+	}
+
 	providers := h.registry.List()
 	for _, s := range summaries {
-		model := strings.ToLower(s.Model)
-		for _, p := range providers {
-			if strings.Contains(model, strings.ToLower(p.Name())) {
-				agg, ok := result[p.Name()]
-				if !ok {
-					agg = &costAgg{}
-					result[p.Name()] = agg
+		tool := toolByAgent[s.AgentID]
+		if tool == "" {
+			// Host / unattributed sessions: fall back to model-name match.
+			model := strings.ToLower(s.Model)
+			for _, p := range providers {
+				if strings.Contains(model, strings.ToLower(p.Name())) {
+					tool = p.Name()
+					break
 				}
-				agg.tokens += s.TotalTokens
-				agg.cost += s.TotalCostUSD
-				break
 			}
 		}
+		if tool == "" {
+			continue
+		}
+		agg, ok := result[tool]
+		if !ok {
+			agg = &costAgg{}
+			result[tool] = agg
+		}
+		agg.tokens += s.TotalTokens
+		agg.cost += s.TotalCostUSD
 	}
 
 	return result
 }
 
-// costByModelForProvider returns per-model costs for a specific provider.
+// costByModelForProvider returns per-model costs for agents whose tool is
+// the named provider. Model-name substring matching is wrong here for the
+// same reason as aggregateCostsByProvider: a Cursor agent on a Claude model
+// is still Cursor spend.
 func (h *ProviderHandler) costByModelForProvider(ctx context.Context, name string) []ModelCost {
 	if h.costs == nil {
 		return nil
 	}
 
-	summaries, err := h.costs.SummaryByModel(ctx)
+	entries, err := h.costs.Entries(ctx)
 	if err != nil {
 		return nil
 	}
 
-	var models []ModelCost
-	lowerName := strings.ToLower(name)
-	for _, s := range summaries {
-		if strings.Contains(strings.ToLower(s.Model), lowerName) {
-			models = append(models, ModelCost{
-				Model:        s.Model,
-				TotalTokens:  s.TotalTokens,
-				TotalCostUSD: s.TotalCostUSD,
-			})
+	toolByAgent := make(map[string]string)
+	for _, a := range h.listAgents(ctx) {
+		if a.Tool != "" {
+			toolByAgent[a.Name] = a.Tool
 		}
 	}
 
+	byModel := map[string]*ModelCost{}
+	for _, e := range entries {
+		tool := toolByAgent[e.Agent]
+		if tool == "" && strings.Contains(strings.ToLower(e.Model), strings.ToLower(name)) {
+			tool = name
+		}
+		if tool != name {
+			continue
+		}
+		mc, ok := byModel[e.Model]
+		if !ok {
+			mc = &ModelCost{Model: e.Model}
+			byModel[e.Model] = mc
+		}
+		mc.TotalTokens += e.InputTokens + e.OutputTokens
+		mc.TotalCostUSD += e.CostUSD
+	}
+
+	models := make([]ModelCost, 0, len(byModel))
+	for _, mc := range byModel {
+		models = append(models, *mc)
+	}
 	return models
 }
 


### PR DESCRIPTION
Fixes #3593

## Cause

`pkg/cost.Service` only aggregates providers that implement `CostReader`. Only Claude did. Cursor agents therefore showed `$0` / `0` tokens everywhere while Claude on the same machine looked fine.

Cursor does not put usage in `agent-transcripts` JSONL (conversation turns only). It **does** put `input_tokens` / `output_tokens` / `cache_*_tokens` on the Stop hook payload the mycel reporter already POSTs — verified live in `~/.mycel/logs/events.jsonl` for `fast-crane` and others. `HookPayload` already had input/output fields; nothing wrote them anywhere a CostReader looks.

## Fix

1. Extend `HookPayload` with `cache_read_tokens`, `cache_write_tokens`, `session_id`, `generation_id`.
2. On `Stop` with any non-zero token field, append one priced line to `~/.mycel/agents/<name>/session/cursor/usage.jsonl`.
3. `CursorProvider.ReadCosts` scans those files and feeds the existing cost pipeline. Claude-named models reuse Claude pricing; others use a small Cursor table (best-effort for `default` / `kimi` / GPT-family).

## Test plan

- [x] Unit: append + read; dedupe by generation_id; skip zero-token; Claude model pricing path
- [x] Ingest: Stop with tokens creates the usage file
- [x] `go test ./pkg/provider/ ./pkg/agent/ ./pkg/cost/`
- [ ] Live: rebuild daemon, refresh costs — Cursor provider aggregate non-zero after backfill from recent Stop events

## Note on history

Turns that already completed before this lands are not retroactively written by the daemon. A one-shot backfill from `events.jsonl` Stop payloads can seed `usage.jsonl` for agents that already ran (done on the test machine for swift-fox / cool-otter / fast-crane / eager-fox).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cursor Agent usage and cost tracking, including token counts, model details, timestamps, and calculated costs.
  * Cursor session usage is now saved automatically when an agent stops.
  * Provider cost summaries now use each agent’s configured provider for more accurate attribution.
  * Added model-level cost details for provider-specific reporting.

* **Bug Fixes**
  * Prevented duplicate usage records and ignored empty usage entries.
  * Improved handling of incomplete or malformed usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->