### PR TITLE
fix(cost): label model-table dollars as estimated, not billed

### DIFF
--- a/pkg/agent/hook_ingest_test.go
+++ b/pkg/agent/hook_ingest_test.go
@@ -486,7 +486,7 @@ func TestIngestHookEvent_StopPersistsCursorUsage(t *testing.T) {
 	}
 
 	path := filepath.Join(mgr.agentsRoot(), "cursor-agent", "session", "cursor", "usage.jsonl")
-	raw, err := os.ReadFile(path)
+	raw, err := os.ReadFile(path) //nolint:gosec // test path under the temp agents root
 	if err != nil {
 		t.Fatalf("usage file missing: %v", err)
 	}

--- a/pkg/agent/hooks.go
+++ b/pkg/agent/hooks.go
@@ -113,7 +113,7 @@ func IsKnownEvent(ev HookEvent) bool {
 
 // HookPayload is the JSON payload received by the /hook endpoint.
 // Different events populate different fields.
-type HookPayload struct {
+type HookPayload struct { //nolint:govet // field order matches the wire JSON / provider payloads
 	ToolInput    any            `json:"tool_input,omitempty"`
 	ToolResponse any            `json:"tool_response,omitempty"`
 	Metadata     map[string]any `json:"metadata,omitempty"`

--- a/pkg/client/costs.go
+++ b/pkg/client/costs.go
@@ -21,6 +21,8 @@ type CostSummary struct {
 	TotalTokens  int64   `json:"total_tokens"`
 	TotalCostUSD float64 `json:"total_cost_usd"`
 	RecordCount  int64   `json:"record_count"`
+	// CostBasis is how TotalCostUSD was produced ("priced" today).
+	CostBasis string `json:"cost_basis,omitempty"`
 }
 
 // CostBudget represents a cost budget configuration.

--- a/pkg/client/costs.go
+++ b/pkg/client/costs.go
@@ -16,13 +16,12 @@ type CostSummary struct {
 	AgentID      string  `json:"agent_id,omitempty"`
 	TeamID       string  `json:"team_id,omitempty"`
 	Model        string  `json:"model,omitempty"`
+	CostBasis    string  `json:"cost_basis,omitempty"` // how TotalCostUSD was produced ("priced" today)
 	InputTokens  int64   `json:"input_tokens"`
 	OutputTokens int64   `json:"output_tokens"`
 	TotalTokens  int64   `json:"total_tokens"`
 	TotalCostUSD float64 `json:"total_cost_usd"`
 	RecordCount  int64   `json:"record_count"`
-	// CostBasis is how TotalCostUSD was produced ("priced" today).
-	CostBasis string `json:"cost_basis,omitempty"`
 }
 
 // CostBudget represents a cost budget configuration.

--- a/pkg/cost/service.go
+++ b/pkg/cost/service.go
@@ -163,6 +163,18 @@ func addEntry(sum *Summary, e provider.CostEntry) {
 	sum.TotalTokens += e.InputTokens + e.OutputTokens
 	sum.TotalCostUSD += e.CostUSD
 	sum.RecordCount++
+	if sum.CostBasis == "" {
+		sum.CostBasis = CostBasisPriced
+	}
+}
+
+// markPriced stamps CostBasisPriced on a summary that had no entries
+// (addEntry never ran) so empty responses still declare their basis.
+func markPriced(sum *Summary) *Summary {
+	if sum.CostBasis == "" {
+		sum.CostBasis = CostBasisPriced
+	}
+	return sum
 }
 
 // TotalSummary returns the total cost summary across all sources.
@@ -175,7 +187,7 @@ func (s *Service) TotalSummary(ctx context.Context) (*Summary, error) {
 	for _, e := range entries {
 		addEntry(&sum, e)
 	}
-	return &sum, nil
+	return markPriced(&sum), nil
 }
 
 // GetSummarySince returns a summary of costs since the given time.
@@ -191,7 +203,7 @@ func (s *Service) GetSummarySince(ctx context.Context, since time.Time) (*Summar
 		}
 		addEntry(&sum, e)
 	}
-	return &sum, nil
+	return markPriced(&sum), nil
 }
 
 // SummaryByAgent returns aggregated costs per agent, highest cost first.
@@ -269,7 +281,7 @@ func (s *Service) AgentSummary(ctx context.Context, agentID string) (*Summary, e
 		}
 		addEntry(&sum, e)
 	}
-	return &sum, nil
+	return markPriced(&sum), nil
 }
 
 // groupedSummaries aggregates entries since `since` by key(e), sorted

--- a/pkg/cost/service_test.go
+++ b/pkg/cost/service_test.go
@@ -53,6 +53,17 @@ func sampleEntries() []provider.CostEntry {
 	}
 }
 
+func TestEmptySummaryDeclaresPricedBasis(t *testing.T) {
+	svc, _ := newStubService(nil, nil)
+	sum, err := svc.TotalSummary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sum.CostBasis != CostBasisPriced {
+		t.Errorf("empty summary cost_basis = %q, want %q", sum.CostBasis, CostBasisPriced)
+	}
+}
+
 func TestTotalSummaryAggregates(t *testing.T) {
 	svc, _ := newStubService(sampleEntries(), nil)
 	sum, err := svc.TotalSummary(context.Background())
@@ -70,6 +81,9 @@ func TestTotalSummaryAggregates(t *testing.T) {
 	}
 	if math.Abs(sum.TotalCostUSD-7.5) > 1e-9 || sum.RecordCount != 4 {
 		t.Errorf("cost/count wrong: %+v", sum)
+	}
+	if sum.CostBasis != CostBasisPriced {
+		t.Errorf("cost_basis = %q, want %q", sum.CostBasis, CostBasisPriced)
 	}
 }
 

--- a/pkg/cost/types.go
+++ b/pkg/cost/types.go
@@ -74,6 +74,20 @@ type BudgetStore interface {
 	Delete(scope string) error
 }
 
+// CostBasis is how TotalCostUSD / CostUSD figures were produced.
+const (
+	// CostBasisPriced means dollars were computed from local model rate
+	// tables × token counts. This is the only basis every CostReader
+	// produces today. It is not a provider invoice, subscription
+	// included-usage meter, or Cursor/Anthropic billing export.
+	CostBasisPriced = "priced"
+	// CostBasisBilled is reserved for a future reader that ingests a
+	// provider's own billed figures (e.g. Cursor Admin API). No reader
+	// emits it yet; the constant exists so the API/UI seam is stable
+	// when one lands.
+	CostBasisBilled = "billed"
+)
+
 // Summary represents aggregated cost data.
 //
 // TotalTokens is input + output only. Cache tokens are reported separately
@@ -91,6 +105,10 @@ type Summary struct {
 	TotalTokens      int64   `json:"total_tokens"`
 	TotalCostUSD     float64 `json:"total_cost_usd"`
 	RecordCount      int64   `json:"record_count"`
+	// CostBasis is how TotalCostUSD was produced. Always CostBasisPriced
+	// until a billed reader exists; UIs must label priced dollars as
+	// estimates rather than invoices.
+	CostBasis string `json:"cost_basis"`
 }
 
 // DailyCost represents aggregated cost data for a single day.

--- a/pkg/cost/types.go
+++ b/pkg/cost/types.go
@@ -94,10 +94,15 @@ const (
 // via CacheReadTokens / CacheWriteTokens — they are priced at a fraction of
 // input tokens and lumping them into the total makes it meaningless (cache
 // reads dominate by 1000x in agentic workloads).
+//
+// CostBasis is how TotalCostUSD was produced. Always CostBasisPriced until
+// a billed reader exists; UIs must label priced dollars as estimates
+// rather than invoices.
 type Summary struct {
 	AgentID          string  `json:"agent_id,omitempty"`
 	TeamID           string  `json:"team_id,omitempty"`
 	Model            string  `json:"model,omitempty"`
+	CostBasis        string  `json:"cost_basis"`
 	InputTokens      int64   `json:"input_tokens"`
 	OutputTokens     int64   `json:"output_tokens"`
 	CacheReadTokens  int64   `json:"cache_read_tokens"`
@@ -105,10 +110,6 @@ type Summary struct {
 	TotalTokens      int64   `json:"total_tokens"`
 	TotalCostUSD     float64 `json:"total_cost_usd"`
 	RecordCount      int64   `json:"record_count"`
-	// CostBasis is how TotalCostUSD was produced. Always CostBasisPriced
-	// until a billed reader exists; UIs must label priced dollars as
-	// estimates rather than invoices.
-	CostBasis string `json:"cost_basis"`
 }
 
 // DailyCost represents aggregated cost data for a single day.

--- a/pkg/provider/capabilities.go
+++ b/pkg/provider/capabilities.go
@@ -67,7 +67,9 @@ type CostEntry struct {
 	OutputTokens     int64
 	CacheReadTokens  int64
 	CacheWriteTokens int64
-	// CostUSD is the provider-priced cost of this entry.
+	// CostUSD is the dollar figure for this entry. Every CostReader today
+	// computes it from a local model rate table × token counts (see
+	// cost.CostBasisPriced). It is not a provider invoice line.
 	CostUSD float64
 }
 

--- a/pkg/provider/cursor_costs.go
+++ b/pkg/provider/cursor_costs.go
@@ -10,7 +10,13 @@ package provider
 //	<AgentsDir>/<name>/session/cursor/usage.jsonl
 //
 // by the hook ingestion path, one line per completed turn. ReadCosts prices
-// each line the same way Claude's reader does for its session files.
+// each line the same way Claude's reader does for its session files
+// (cost.CostBasisPriced — local model rate tables, not Cursor billing).
+//
+// Scope note: this is mycel-agent usage only. Cursor's own account Usage
+// dashboard counts every Cursor surface (IDE chat, Tab, Cloud, etc.) and
+// will not match these totals; dollars here will also not match Cursor
+// Spend / invoices until a CostBasisBilled reader exists.
 
 import (
 	"bufio"

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -47,10 +47,14 @@ type ProviderInfo struct { //nolint:govet // field order matches JSON/API contra
 	// Empty means the provider has no model selection.
 	Models       []ModelInfo `json:"models"`
 	TotalCostUSD float64     `json:"total_cost_usd"`
-	TotalTokens  int64       `json:"total_tokens"`
-	AgentCount   int         `json:"agent_count"`
-	Installed    bool        `json:"installed"`
-	Enabled      bool        `json:"enabled"`
+	// CostBasis is how TotalCostUSD was produced. Always "priced" today
+	// (local model rate tables); reserved for "billed" when a provider
+	// invoice reader lands. See cost.CostBasisPriced.
+	CostBasis   string `json:"cost_basis"`
+	TotalTokens int64  `json:"total_tokens"`
+	AgentCount  int    `json:"agent_count"`
+	Installed   bool   `json:"installed"`
+	Enabled     bool   `json:"enabled"`
 }
 
 // ProviderDetail extends ProviderInfo with per-model cost breakdown and agent list.
@@ -880,6 +884,7 @@ func (h *ProviderHandler) buildProviderInfo(
 		Status:       status,
 		ActivityMode: providerActivityMode(p),
 		Models:       models,
+		CostBasis:    cost.CostBasisPriced,
 		AgentCount:   agentCounts[p.Name()],
 		Installed:    installed,
 		Enabled:      enabled,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -319,6 +319,12 @@ export interface CostSummary {
   total_tokens: number;
   total_cost_usd: number;
   record_count: number;
+  /**
+   * How total_cost_usd was produced. "priced" = local model rate tables
+   * (estimate, not an invoice). "billed" reserved for a future provider
+   * invoice reader.
+   */
+  cost_basis?: "priced" | "billed";
 }
 
 export interface AgentCostSummary {
@@ -553,6 +559,11 @@ export interface ProviderInfo {
   /** Curated model list for UI pickers; empty = no model selection. */
   models?: ModelInfo[];
   total_cost_usd: number;
+  /**
+   * How total_cost_usd was produced. "priced" = local model rate tables.
+   * See CostSummary.cost_basis.
+   */
+  cost_basis?: "priced" | "billed";
   total_tokens: number;
   agent_count: number;
   installed: boolean;
@@ -580,6 +591,8 @@ export interface ProviderDetailResponse {
   version: string;
   status: string;
   total_cost_usd: number;
+  /** See CostSummary.cost_basis. */
+  cost_basis?: "priced" | "billed";
   total_tokens: number;
   agent_count: number;
   installed: boolean;

--- a/web/src/utils/format.test.ts
+++ b/web/src/utils/format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatCost, formatTokens } from "./format";
+import { costBasisSub, costSpendLabel, formatCost, formatTokens } from "./format";
 
 describe("formatCost", () => {
   it("formats zero", () => {
@@ -18,6 +18,22 @@ describe("formatCost", () => {
     expect(formatCost(1234.56)).toBe("$1,234.56");
     expect(formatCost(1_000_000)).toBe("$1,000,000.00");
     expect(formatCost(9_876_543.21)).toBe("$9,876,543.21");
+  });
+});
+
+describe("costSpendLabel", () => {
+  it("defaults missing basis to estimated (priced)", () => {
+    expect(costSpendLabel(undefined)).toBe("Estimated spend");
+    expect(costSpendLabel(undefined, "cost")).toBe("Estimated cost");
+  });
+  it("labels billed when the API says so", () => {
+    expect(costSpendLabel("billed")).toBe("Billed spend");
+    expect(costSpendLabel("billed", "cost")).toBe("Billed cost");
+  });
+  it("explains priced dollars as not provider billing", () => {
+    expect(costBasisSub("priced")).toMatch(/not provider billing/);
+    expect(costBasisSub(undefined)).toMatch(/not provider billing/);
+    expect(costBasisSub("billed")).toMatch(/provider billing/);
   });
 });
 

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -20,3 +20,22 @@ export function formatCost(n: number): string {
   }
   return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
+
+/** How total_cost_usd was produced — mirrors cost.CostBasis on the API. */
+export type CostBasis = "priced" | "billed";
+
+/**
+ * Dollar-figure label for a cost_basis. Priced dollars are estimates from
+ * local model rate tables; billed (reserved) would be invoice figures.
+ * Default to priced when the field is missing so older daemons stay honest.
+ */
+export function costSpendLabel(basis?: CostBasis | string, noun: "spend" | "cost" = "spend"): string {
+  if (basis === "billed") return noun === "cost" ? "Billed cost" : "Billed spend";
+  return noun === "cost" ? "Estimated cost" : "Estimated spend";
+}
+
+/** Short subtitle explaining a priced dollar figure. */
+export function costBasisSub(basis?: CostBasis | string): string | undefined {
+  if (basis === "billed") return "from provider billing";
+  return "model rates · not provider billing";
+}

--- a/web/src/views/Insights.tsx
+++ b/web/src/views/Insights.tsx
@@ -9,10 +9,11 @@
  *   4. What are the agents actually doing?              → recent activity chart
  *   5. What is it doing to the machine?                 → live system row
  *
- * Every number is period-scoped off the cost ledger (computed directly
- * from provider transcripts) via `?since=` — no mixed lifetime/range
- * figures on one surface. Ledger days are UTC. /stats, /metrics and
- * /costs redirect here (see App.tsx).
+ * Every number is period-scoped off the cost ledger (token counts from
+ * provider sessions; dollars estimated from local model rate tables —
+ * cost_basis "priced", not invoices) via `?since=` — no mixed
+ * lifetime/range figures on one surface. Ledger days are UTC. /stats,
+ * /metrics and /costs redirect here (see App.tsx).
  *
  * Depth is progressive disclosure, never upfront: the Tokens stat, every
  * breakdown row and every system tile expand into an inline drill-down
@@ -35,7 +36,7 @@ import { EmptyState } from "../components/EmptyState";
 import { SectionRule } from "../components/shared/SectionRule";
 import { fmtTokens } from "../components/shared/stats-primitives";
 import { AgentChip } from "../components/agent-ui";
-import { formatCost } from "../utils/format";
+import { costSpendLabel, formatCost } from "../utils/format";
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 import {
   ACCENT, TICK, AX, TT_STYLE, fmtClock, fmtShortDate, stripAgentPrefix,
@@ -148,7 +149,7 @@ function SpendTooltip({ active, payload }: ChartTooltipProps) {
       <div className="font-semibold tabular-nums">{formatCost(p.cost)}</div>
       {p.records > 0 && (
         <div className="text-[11px] text-mycel-muted tabular-nums">
-          {fmtTokens(p.tokens)} tokens · {p.records.toLocaleString()} calls
+          {fmtTokens(p.tokens)} tokens · {p.records.toLocaleString()} calls · estimated
         </div>
       )}
     </div>
@@ -625,7 +626,7 @@ export function Insights() {
         <EmptyState
           icon="$"
           title={isAll ? "No cost data yet" : `No spend in the ${periodLabel}`}
-          description="Costs are read directly from provider session transcripts."
+          description="Token counts come from provider sessions (transcripts or Stop hooks). Dollars are estimated from local model rate tables — not provider invoices or Cursor Usage."
           actionLabel={isAll ? undefined : "View all time"}
           onAction={isAll ? undefined : () => setPeriod("all")}
         />
@@ -640,7 +641,7 @@ export function Insights() {
       <div className="rounded-lg border border-mycel-border shadow-mycel-sm overflow-hidden">
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-px bg-mycel-border">
           <StatCell
-            label={`Spend · ${periodLabel}`}
+            label={`${costSpendLabel(data.summary?.cost_basis)} · ${periodLabel}`}
             value={formatCost(stat.spend)}
             sub={isAll
               ? (data.daily[0] ? `since ${fmtShortDate(data.daily[0].date)}` : undefined)
@@ -654,7 +655,7 @@ export function Insights() {
           <StatCell
             label={`Tokens · ${periodLabel}`}
             value={fmtTokens((cache.input ?? 0) + (cache.output ?? 0))}
-            sub={`${fmtTokens(cache.input)} in · ${fmtTokens(cache.output)} out`}
+            sub={`${fmtTokens(cache.input)} in · ${fmtTokens(cache.output)} out · mycel agents`}
             onClick={() => setTokensOpen("1")}
             open={tokensOpen !== null}
           />
@@ -679,7 +680,7 @@ export function Insights() {
 
       {/* ── Spend over time ── */}
       <section>
-        <SectionRule label="Spend" trailing={
+        <SectionRule label={costSpendLabel(data.summary?.cost_basis)} trailing={
           <span className="text-[11px] text-mycel-muted tabular-nums">{periodLabel} · daily, UTC</span>
         } />
         {spendSeries.length === 0 ? (

--- a/web/src/views/ProviderDetail.tsx
+++ b/web/src/views/ProviderDetail.tsx
@@ -20,7 +20,7 @@ import { ConfirmButton } from "../components/shared";
 import { ToastContainer, useToast } from "../components/Toast";
 import { ProviderLogo } from "../components/ProviderLogo";
 import { PROVIDER_LABELS } from "./readiness/readiness";
-import { formatCost, formatTokens } from "../utils/format";
+import { costBasisSub, costSpendLabel, formatCost, formatTokens } from "../utils/format";
 
 /* Shared section-heading treatment — a quiet, settled label instead of the
  * tiny shouty all-caps that used to repeat down the page. */
@@ -972,9 +972,17 @@ function MCPSection({
 }
 
 /* ── Stat Tile ── */
-function StatTile({ label, value, icon, accent }: { label: string; value: string; icon: React.ReactNode; accent?: boolean }) {
+function StatTile({
+  label, value, icon, accent, title,
+}: {
+  label: string;
+  value: string;
+  icon: React.ReactNode;
+  accent?: boolean;
+  title?: string;
+}) {
   return (
-    <div className="rounded border border-mycel-border bg-mycel-surface p-3">
+    <div className="rounded border border-mycel-border bg-mycel-surface p-3" title={title}>
       <div className="flex items-center gap-2 mb-1">
         <span className="text-mycel-muted">{icon}</span>
         <span className="text-[11px] text-mycel-muted uppercase tracking-wider">{label}</span>
@@ -986,15 +994,16 @@ function StatTile({ label, value, icon, accent }: { label: string; value: string
 
 /* ── StatBar (4 tiles) ── */
 function StatBar({ provider }: { provider: ProviderDetailResponse }) {
-  // Models that actually billed — not the provider's curated model list,
+  // Models that have cost history — not the provider's curated model list,
   // which the Models section counts. Two different numbers, so this tile
   // says "used" rather than contradicting that heading.
   const billedModels = provider.cost_by_model ?? [];
   return (
     <div className="grid grid-cols-2 gap-3">
       <StatTile
-        label="Cost"
+        label={costSpendLabel(provider.cost_basis, "cost")}
         value={formatCost(provider.total_cost_usd)}
+        title={costBasisSub(provider.cost_basis)}
         accent
         icon={
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -1005,6 +1014,7 @@ function StatBar({ provider }: { provider: ProviderDetailResponse }) {
       <StatTile
         label="Tokens"
         value={formatTokens(provider.total_tokens)}
+        title="mycel agents · input+output (cache separate)"
         icon={
           <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" />

--- a/web/src/views/__tests__/insights-drilldowns.test.tsx
+++ b/web/src/views/__tests__/insights-drilldowns.test.tsx
@@ -293,7 +293,7 @@ describe("breakdown drill-down", () => {
       ),
     );
     // Period-scoped stats from the breakdown fetch + the link row.
-    await waitFor(() => expect(screen.getByText("Spend over time")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Estimated spend over time")).toBeInTheDocument());
     expect(screen.getByRole("link", { name: /Open agent/ })).toHaveAttribute(
       "href",
       "/agents/bot-1",
@@ -319,7 +319,7 @@ describe("breakdown drill-down", () => {
   it("restores an expanded breakdown row from the URL hash", async () => {
     setHash("#row=agent%3Amycel-ab12cd-bot-1");
     renderInsights();
-    await waitFor(() => expect(screen.getByText("Spend over time")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Estimated spend over time")).toBeInTheDocument());
     expect(screen.getByRole("button", { name: "Collapse bot-1" })).toBeInTheDocument();
   });
 });

--- a/web/src/views/__tests__/insights.test.tsx
+++ b/web/src/views/__tests__/insights.test.tsx
@@ -136,7 +136,7 @@ describe("Insights", () => {
 
     // Spend sums the daily ledger inside the window (5.00 + 7.34).
     await waitFor(() => expect(screen.getByText("$12.34")).toBeInTheDocument());
-    expect(screen.getByText(/Spend · last 30d/i)).toBeInTheDocument();
+    expect(screen.getByText(/Estimated spend · last 30d/i)).toBeInTheDocument();
     expect(screen.getByText("Today")).toBeInTheDocument();
     // Today's ledger day (7.34) renders in the Today cell.
     expect(screen.getByText("$7.34")).toBeInTheDocument();

--- a/web/src/views/home/CostCharts.tsx
+++ b/web/src/views/home/CostCharts.tsx
@@ -5,7 +5,7 @@ import {
 import { api } from "../../api/client";
 import type { AgentCostSummary, DailyCost } from "../../api/client";
 import { usePolling } from "../../hooks/usePolling";
-import { formatCost } from "../../utils/format";
+import { formatCost, costSpendLabel } from "../../utils/format";
 import { ACCENT, AX, TICK, TT_STYLE, fmtShortDate, stripAgentPrefix } from "../insights/chrome";
 import { HomeModule, todayKey } from "./Module";
 
@@ -14,11 +14,12 @@ import { HomeModule, todayKey } from "./Module";
    Insights chart tokens and honest-chart rules (zero-filled days, no
    smoothing, today emphasized):
 
-     • Spend — last 7 days, daily bars (UTC ledger days).
+     • Estimated spend — last 7 days, daily bars (UTC ledger days).
      • Top agents — today's top-5 spenders as a proportional bar list.
 
-   Data refreshes on a 60s interval via the existing cost endpoints
-   (`/costs/daily`, `/costs/agents?since=<today>`).
+   Dollars are model-table priced (not provider billing). Data refreshes
+   on a 60s interval via the existing cost endpoints (`/costs/daily`,
+   `/costs/agents?since=<today>`).
 ─────────────────────────────────────────────────────────────────── */
 
 const DAY_MS = 86_400_000;
@@ -70,11 +71,11 @@ export function CostCharts() {
   return (
     <>
       <HomeModule
-        label="Spend · 7 days"
+        label={`${costSpendLabel()} · 7 days`}
         to="/insights"
         toLabel="insights"
         testId="home-cost-daily"
-        trailing={<span className="text-[10px] text-mycel-muted tabular-nums">daily · UTC</span>}
+        trailing={<span className="text-[10px] text-mycel-muted tabular-nums">daily · UTC · estimated</span>}
       >
         {data === null ? (
           <div className="py-4 text-center text-[11px] text-mycel-muted">Loading…</div>
@@ -102,7 +103,7 @@ export function CostCharts() {
                 contentStyle={TT_STYLE}
                 cursor={{ fill: "var(--mycel-surface-hover)", fillOpacity: 0.5 }}
                 labelFormatter={(v) => fmtShortDate(String(v))}
-                formatter={(v) => [formatCost(Number(v ?? 0)), "Spend"]}
+                formatter={(v) => [formatCost(Number(v ?? 0)), costSpendLabel()]}
               />
               <Bar dataKey="cost" radius={[2, 2, 0, 0]} isAnimationActive={false}>
                 {series.map((d) => (

--- a/web/src/views/home/OverviewStrip.tsx
+++ b/web/src/views/home/OverviewStrip.tsx
@@ -185,7 +185,7 @@ export function OverviewStrip({
           testId="overview-channels"
         />
         <Cell
-          label="Spend today"
+          label="Estimated spend today"
           value={spend ? formatCost(spend.today) : "—"}
           sub={spend && spend.avg7 > 0 ? `${formatCost(spend.avg7)}/day 7d avg` : undefined}
           to="/insights"

--- a/web/src/views/insights/BreakdownDetail.tsx
+++ b/web/src/views/insights/BreakdownDetail.tsx
@@ -20,7 +20,7 @@ import type {
   AgentCostDetail, AgentCostSummary, ModelCostSummary,
 } from "../../api/client";
 import { fmtTokens } from "../../components/shared/stats-primitives";
-import { formatCost } from "../../utils/format";
+import { formatCost, costSpendLabel } from "../../utils/format";
 import { ACCENT, TICK, AX, TT_STYLE, fmtShortDate } from "./chrome";
 import { TokenCompositionStrip } from "./TokenPanel";
 
@@ -181,7 +181,7 @@ export function AgentDetail({
   return (
     <Shell>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <DetailStat label="Spend" value={formatCost(summary?.total_cost_usd ?? 0)} sub="this period" />
+        <DetailStat label={costSpendLabel()} value={formatCost(summary?.total_cost_usd ?? 0)} sub="this period · estimated" />
         <DetailStat
           label="Tokens"
           value={fmtTokens(summary?.total_tokens ?? 0)}
@@ -200,7 +200,7 @@ export function AgentDetail({
       </div>
 
       <div>
-        <SectionLabel trailing={windowLabel}>Spend over time</SectionLabel>
+        <SectionLabel trailing={windowLabel}>Estimated spend over time</SectionLabel>
         {failed ? (
           <div className="py-6 text-center text-sm text-mycel-muted">Could not load the agent ledger</div>
         ) : detail === null ? (
@@ -249,7 +249,7 @@ export function ModelDetail({ model }: { model: ModelCostSummary | undefined }) 
   return (
     <Shell>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <DetailStat label="Spend" value={formatCost(model.total_cost_usd)} sub="this period" />
+        <DetailStat label={costSpendLabel()} value={formatCost(model.total_cost_usd)} sub="this period · estimated" />
         <DetailStat
           label="Tokens"
           value={fmtTokens(model.total_tokens)}


### PR DESCRIPTION
Fixes #3595. Follow-up to #3594 / the Cursor Usage vs mycel Insights screenshots.

## Why

After Cursor agents started reporting non-zero spend, the UI still called those dollars **Spend** / **Cost**. They are not Cursor (or Anthropic) billing — every `CostReader` multiplies token counts by a local model rate table (`cost.CostBasisPriced`). Cursor's account Usage dashboard (~843M tokens / 7d in the screenshots) is a different scope entirely (whole Cursor account vs mycel agents only; our `total_tokens` is input+output with cache separate).

## What

- API: `cost_basis` on cost summaries and `/api/providers` (`"priced"` today; `"billed"` reserved for a future invoice/Admin-API reader).
- UI: Insights / Home / Provider detail / drilldowns label **Estimated spend|cost** when priced; empty state and Cursor CostReader docs explain the scope.
- Tokens subtitle notes mycel agents · input+output.

## Test plan

- [x] `go test ./pkg/cost/ ./server/handlers/ ./pkg/provider/`
- [x] vitest: format + insights + ProviderDetail + home modules
- [ ] Spot-check Insights / Provider cursor page: labels say Estimated; hover on cost tile explains model rates


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost-basis metadata to cost summaries and provider details, distinguishing locally estimated costs from provider-billed amounts.
  * Updated cost and spend labels, tooltips, charts, and insights to clearly identify estimated pricing.
  * Added explanatory text for token statistics and cost calculations.

* **Documentation**
  * Clarified how cost figures are calculated and which usage data is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->