### PR TITLE
feat(templates): blueprint composition schema + expand API (#3558)

### DIFF
--- a/docs/how-to/use-templates.md
+++ b/docs/how-to/use-templates.md
@@ -56,5 +56,21 @@ mycel template create my-persona \
   --prompt-file ./persona.md
 ```
 
+## Composition (#3558)
+
+A **multi-agent** blueprint lists other templates under `composes`. Expanding it
+returns the leaf templates (and the union of declared secrets) without creating
+agents yet:
+
+```bash
+curl -s http://127.0.0.1:9374/api/templates/engineering-team/expand
+# {"leaves":["eng","test","pm"],"secrets":["GH","TEAM_TOKEN"]}
+```
+
+Missing credentials do not refuse creation later — agents run degraded and the
+UI reports what is absent. Provisioning the leaves into live agents is the next
+slice of #3558.
+
 Or use **Templates → New** in the UI. Set `"label": "single-agent"` (or
-`"multi-agent"`) in the JSON when you know which kind it is.
+`"multi-agent"`) in the JSON when you know which kind it is. `"composes": ["a","b"]`
+makes a team of templates.

--- a/pkg/template/blueprint.go
+++ b/pkg/template/blueprint.go
@@ -1,0 +1,113 @@
+package template
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidLabels are the allowed values for Template.Label (#3552 / #3558).
+const (
+	LabelSingleAgent = "single-agent"
+	LabelMultiAgent  = "multi-agent"
+)
+
+// Validate checks fields that the blueprint model cares about (#3558).
+// Empty label is allowed (unlabeled). Composes implies multi-agent.
+func (t Template) Validate() error {
+	switch t.Label {
+	case "", LabelSingleAgent, LabelMultiAgent:
+	default:
+		return fmt.Errorf("label %q is invalid: use %q, %q, or omit", t.Label, LabelSingleAgent, LabelMultiAgent)
+	}
+	for _, name := range t.Composes {
+		if !validName(name) {
+			return fmt.Errorf("composes entry %q is not a valid template name", name)
+		}
+		if name == t.Name {
+			return fmt.Errorf("template %q cannot compose itself", t.Name)
+		}
+	}
+	if len(t.Composes) > 0 && t.Label == LabelSingleAgent {
+		return fmt.Errorf("template %q composes other templates but is labeled %q", t.Name, LabelSingleAgent)
+	}
+	return nil
+}
+
+// TemplateGetter loads a template by name (Store / LayeredStore).
+type TemplateGetter interface {
+	Get(name string) (*Template, string, error)
+}
+
+// ExpandResult is the flattened set of leaf templates a blueprint provisions.
+type ExpandResult struct {
+	// Leaves are template names in composition order (depth-first).
+	Leaves []string `json:"leaves"`
+	// Secrets is the union of Secrets declared on the root and every leaf (#3558 Q2).
+	Secrets []string `json:"secrets,omitempty"`
+	// Missing is filled by the caller when it can check the vault; Expand leaves it empty.
+	Missing []string `json:"missing,omitempty"`
+}
+
+// Expand flattens t's Composes recursively into leaf template names.
+// A template with no Composes is itself a leaf. Cycles error.
+func Expand(g TemplateGetter, name string) (ExpandResult, error) {
+	var out ExpandResult
+	seen := map[string]bool{}
+	stack := map[string]bool{}
+	var walk func(string) error
+	walk = func(n string) error {
+		if stack[n] {
+			return fmt.Errorf("composition cycle involving %q", n)
+		}
+		if seen[n] {
+			return nil
+		}
+		tmpl, _, err := g.Get(n)
+		if err != nil {
+			return fmt.Errorf("compose %q: %w", n, err)
+		}
+		stack[n] = true
+		if len(tmpl.Composes) == 0 {
+			seen[n] = true
+			out.Leaves = append(out.Leaves, n)
+			out.Secrets = unionStrings(out.Secrets, tmpl.Secrets)
+			delete(stack, n)
+			return nil
+		}
+		for _, child := range tmpl.Composes {
+			if err := walk(child); err != nil {
+				return err
+			}
+		}
+		seen[n] = true
+		out.Secrets = unionStrings(out.Secrets, tmpl.Secrets)
+		delete(stack, n)
+		return nil
+	}
+	if err := walk(name); err != nil {
+		return ExpandResult{}, err
+	}
+	return out, nil
+}
+
+func unionStrings(a, b []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range a {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	for _, s := range b {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/pkg/template/blueprint_test.go
+++ b/pkg/template/blueprint_test.go
@@ -1,0 +1,133 @@
+package template
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateLabel(t *testing.T) {
+	cases := []struct {
+		label string
+		ok    bool
+	}{
+		{"", true},
+		{LabelSingleAgent, true},
+		{LabelMultiAgent, true},
+		{"other", false},
+		{"team", false},
+	}
+	for _, tc := range cases {
+		err := (Template{Name: "x", Label: tc.label}).Validate()
+		if tc.ok && err != nil {
+			t.Errorf("label %q: unexpected error %v", tc.label, err)
+		}
+		if !tc.ok && err == nil {
+			t.Errorf("label %q: expected error", tc.label)
+		}
+	}
+}
+
+func TestValidateComposesRejectsSelfAndSingleLabel(t *testing.T) {
+	if err := (Template{Name: "team", Composes: []string{"team"}}).Validate(); err == nil {
+		t.Fatal("expected self-compose error")
+	}
+	if err := (Template{
+		Name:     "team",
+		Label:    LabelSingleAgent,
+		Composes: []string{"blank"},
+	}).Validate(); err == nil {
+		t.Fatal("expected single-agent+composes error")
+	}
+}
+
+func TestExpandLeafIsItself(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	if err := s.Create(Template{Name: "blank", Description: "x", MCPs: []string{"mycel"}, Secrets: []string{"A"}}, "", ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Expand(s, "blank")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Leaves) != 1 || got.Leaves[0] != "blank" {
+		t.Fatalf("leaves = %v", got.Leaves)
+	}
+	if len(got.Secrets) != 1 || got.Secrets[0] != "A" {
+		t.Fatalf("secrets = %v", got.Secrets)
+	}
+}
+
+func TestExpandFlattensComposition(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	for _, tmpl := range []Template{
+		{Name: "eng", Description: "e", MCPs: []string{"mycel"}, Secrets: []string{"GH"}},
+		{Name: "test", Description: "t", MCPs: []string{"mycel"}, Secrets: []string{"GH"}},
+		{Name: "pm", Description: "p", MCPs: []string{"mycel"}},
+		{
+			Name:     "engineering-team",
+			Label:    LabelMultiAgent,
+			Composes: []string{"eng", "test", "pm"},
+			Secrets:  []string{"TEAM_TOKEN"},
+		},
+	} {
+		if err := s.Create(tmpl, "", ScopeGlobal); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := Expand(s, "engineering-team")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"eng", "test", "pm"}
+	if len(got.Leaves) != len(want) {
+		t.Fatalf("leaves = %v, want %v", got.Leaves, want)
+	}
+	for i := range want {
+		if got.Leaves[i] != want[i] {
+			t.Fatalf("leaves[%d] = %q, want %q", i, got.Leaves[i], want[i])
+		}
+	}
+	for _, sec := range []string{"GH", "TEAM_TOKEN"} {
+		found := false
+		for _, s := range got.Secrets {
+			if s == sec {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing secret %q in %v", sec, got.Secrets)
+		}
+	}
+}
+
+func TestExpandDetectsCycle(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	if err := s.Create(Template{Name: "a", Composes: []string{"b"}, Label: LabelMultiAgent}, "", ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Create(Template{Name: "b", Composes: []string{"a"}, Label: LabelMultiAgent}, "", ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Expand(s, "a"); err == nil {
+		t.Fatal("expected cycle error")
+	}
+}
+
+func TestExpandMissingChild(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	if err := s.Create(Template{Name: "team", Composes: []string{"nope"}, Label: LabelMultiAgent}, "", ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Expand(s, "team")
+	if err == nil {
+		t.Fatal("expected missing child error")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Fatalf("error should name the missing child: %v", err)
+	}
+}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -14,7 +14,14 @@ type Template struct {
 	Description  string        `json:"description,omitempty"`
 	// Label distinguishes a single-agent template from a multi-agent system
 	// (#3552). Values: "single-agent", "multi-agent". Empty means unlabeled.
-	Label            string   `json:"label,omitempty"`
+	Label string `json:"label,omitempty"`
+	// Provider is the preferred agent tool (claude, cursor, …). Empty lets the
+	// create UI / caller pick. Part of the blueprint model (#3558).
+	Provider string `json:"provider,omitempty"`
+	// Composes lists other template names this blueprint expands into.
+	// A team is a template composed of templates (#3558 Q4). Empty means this
+	// template is itself a leaf agent.
+	Composes         []string `json:"composes,omitempty"`
 	SystemPromptFile string   `json:"system_prompt_file,omitempty"`
 	Scope            Scope    `json:"scope,omitempty"`
 	MCPs             []string `json:"mcps,omitempty"`

--- a/server/handlers/templates.go
+++ b/server/handlers/templates.go
@@ -33,9 +33,11 @@ type templateRequest struct { //nolint:govet // field order matches JSON/API con
 	Secrets          []string               `json:"secrets,omitempty"`
 	Plugins          []string               `json:"plugins,omitempty"`
 	ContextFiles     []string               `json:"context_files,omitempty"`
+	Composes         []string               `json:"composes,omitempty"`
 	Name             string                 `json:"name"`
 	Description      string                 `json:"description,omitempty"`
 	Label            string                 `json:"label,omitempty"`
+	Provider         string                 `json:"provider,omitempty"`
 	SystemPrompt     *string                `json:"system_prompt,omitempty"`
 	SystemPromptFile string                 `json:"system_prompt_file,omitempty"`
 	MaxCostUSD       float64                `json:"max_cost_usd,omitempty"`
@@ -47,6 +49,8 @@ func (req *templateRequest) toTemplate() template.Template {
 		Name:             req.Name,
 		Description:      req.Description,
 		Label:            req.Label,
+		Provider:         req.Provider,
+		Composes:         req.Composes,
 		SystemPromptFile: req.SystemPromptFile,
 		MCPs:             req.MCPs,
 		Secrets:          req.Secrets,
@@ -88,6 +92,10 @@ func (h *TemplateHandler) list(w http.ResponseWriter, r *http.Request) {
 		}
 
 		t := req.toTemplate()
+		if err := t.Validate(); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		prompt := ""
 		if req.SystemPrompt != nil {
 			prompt = *req.SystemPrompt
@@ -114,11 +122,41 @@ func (h *TemplateHandler) list(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// byName handles GET/PUT/DELETE /api/templates/{name}.
+// byName handles GET/PUT/DELETE /api/templates/{name} and
+// GET /api/templates/{name}/expand (blueprint composition preview, #3558).
 func (h *TemplateHandler) byName(w http.ResponseWriter, r *http.Request) {
 	store := h.store
-	name := strings.TrimPrefix(r.URL.Path, "/api/templates/")
-	if name == "" {
+	path := strings.TrimPrefix(r.URL.Path, "/api/templates/")
+	if path == "" {
+		httpError(w, "template name required", http.StatusBadRequest)
+		return
+	}
+
+	// /api/templates/{name}/expand
+	if name, ok := strings.CutSuffix(path, "/expand"); ok {
+		if r.Method != http.MethodGet {
+			methodNotAllowed(w)
+			return
+		}
+		if name == "" || strings.Contains(name, "/") {
+			httpError(w, "template name required", http.StatusBadRequest)
+			return
+		}
+		result, err := template.Expand(store, name)
+		if err != nil {
+			if strings.Contains(err.Error(), "not found") {
+				httpError(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, result)
+		return
+	}
+
+	name := path
+	if strings.Contains(name, "/") {
 		httpError(w, "template name required", http.StatusBadRequest)
 		return
 	}
@@ -157,6 +195,10 @@ func (h *TemplateHandler) byName(w http.ResponseWriter, r *http.Request) {
 		}
 
 		t := req.toTemplate()
+		if err := t.Validate(); err != nil {
+			httpError(w, err.Error(), http.StatusBadRequest)
+			return
+		}
 		if err := store.Update(name, t, prompt); err != nil {
 			if strings.Contains(err.Error(), "not found") {
 				httpError(w, err.Error(), http.StatusNotFound)


### PR DESCRIPTION
## Summary
First slice of #3558 in tracker order (after #3552):

- Schema: `provider`, `composes` (team = template composed of templates)
- `Template.Validate()` — label allowlist; composes cannot be `single-agent`
- `template.Expand` — recursive flatten + secret union; cycle detection
- `GET /api/templates/{name}/expand` — preview leaves + declared secrets before create
- Missing credentials remain advisory (create-degraded is the next PR)

Part of #3558

## Out of scope (next PRs)
- Spawning agents from expand (provision)
- Working MCP/secret/plugin application (#3550)
- Guardrails UI (#3574)
- Starter personas (`trader`, `engineering-team`, …)

## Test plan
- [x] `go test ./pkg/template/`
- [ ] `GET /api/templates/blank/expand` → `{"leaves":["blank"],…}`
- [ ] Create a multi-agent template with `composes` + expand returns ordered leaves

(Re-check: PR Quality body gate.)