### PR TITLE
feat(templates): provision agents from expand + create-degraded (#3558)

### DIFF
--- a/docs/how-to/use-templates.md
+++ b/docs/how-to/use-templates.md
@@ -67,9 +67,17 @@ curl -s http://127.0.0.1:9374/api/templates/engineering-team/expand
 # {"leaves":["eng","test","pm"],"secrets":["GH","TEAM_TOKEN"]}
 ```
 
-Missing credentials do not refuse creation later — agents run degraded and the
-UI reports what is absent. Provisioning the leaves into live agents is the next
-slice of #3558.
+Missing credentials do not refuse creation — agents run **degraded** and the
+API reports what is absent (`missing_secrets` on the agent; health status
+`degraded`). Creating from a multi-agent blueprint expands `composes` and
+spawns one agent per leaf (`{name}-{leaf}`), tagged with `team={name}`.
+
+```bash
+curl -s -X POST http://127.0.0.1:9374/api/agents \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"eng","template":"engineering-team","tool":"cursor"}'
+# → agents eng-a, eng-b, … plus missing: […] when secrets are undeclared in the vault
+```
 
 Or use **Templates → New** in the UI. Set `"label": "single-agent"` (or
 `"multi-agent"`) in the JSON when you know which kind it is. `"composes": ["a","b"]`

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -396,11 +396,15 @@ type Agent struct {
 	// MaxCostUSD / StuckTimeoutMin by this name at check time rather than
 	// copying the limits onto the agent row, so template edits apply to
 	// already-running agents without a respawn.
-	Template      string     `json:"template,omitempty"`
-	LastCrashTime *time.Time `json:"last_crash_time,omitempty"`
-	Role          Role       `json:"role"`
-	State         State      `json:"state"`
-	Children      []string   `json:"children,omitempty"`
+	Template string `json:"template,omitempty"`
+	// MissingSecrets lists template-declared secrets that were absent from
+	// the vault at create time (#3558). Surfaced as health "degraded"; the
+	// agent still runs. Cleared when secrets arrive (refresh path).
+	MissingSecrets []string   `json:"missing_secrets,omitempty"`
+	LastCrashTime  *time.Time `json:"last_crash_time,omitempty"`
+	Role           Role       `json:"role"`
+	State          State      `json:"state"`
+	Children       []string   `json:"children,omitempty"`
 	// CPUs is a per-agent Docker CPU cap (cores, e.g. 1.5). Zero means
 	// inherit the fleet default (prefs runtime.docker.cpus). Enforced only
 	// for the Docker runtime — tmux agents run unconstrained on the host.
@@ -1095,6 +1099,9 @@ type SpawnOptions struct {
 	// Recorded on the agent row so the guardrail loop can look up
 	// MaxCostUSD / StuckTimeoutMin at check time. Empty disables guardrails.
 	Template string
+	// MissingSecrets is recorded at create when declared template secrets
+	// are absent from the vault (#3558 create-degraded).
+	MissingSecrets []string
 }
 
 // SpawnAgent creates and starts a new agent.
@@ -1576,6 +1583,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 		Children:       []string{},
 		IsRoot:         role == RoleRoot,
 		Template:       opts.Template,
+		MissingSecrets: append([]string{}, opts.MissingSecrets...),
 		CreatedAt:      now,
 		StartedAt:      now,
 		UpdatedAt:      now,
@@ -2394,6 +2402,7 @@ func (m *Manager) GetAgent(name string) *Agent {
 	// Return a copy to avoid data races
 	copy := *a
 	copy.Children = append([]string{}, a.Children...)
+	copy.MissingSecrets = append([]string{}, a.MissingSecrets...)
 	return &copy
 }
 
@@ -2445,6 +2454,7 @@ func (m *Manager) ListAgents() []*Agent {
 	for _, a := range m.agents {
 		copy := *a
 		copy.Children = append([]string{}, a.Children...)
+		copy.MissingSecrets = append([]string{}, a.MissingSecrets...)
 		agents = append(agents, &copy)
 	}
 
@@ -2478,6 +2488,7 @@ func (m *Manager) ListChildren(parentID string) []*Agent {
 			// Return copy to avoid data races
 			copy := *child
 			copy.Children = append([]string{}, child.Children...)
+			copy.MissingSecrets = append([]string{}, child.MissingSecrets...)
 			children = append(children, &copy)
 		}
 	}
@@ -2507,6 +2518,7 @@ func (m *Manager) collectDescendants(parentID string, result *[]*Agent) {
 			// Return copy to avoid data races
 			copy := *child
 			copy.Children = append([]string{}, child.Children...)
+			copy.MissingSecrets = append([]string{}, child.MissingSecrets...)
 			*result = append(*result, &copy)
 			m.collectDescendants(childID, result)
 		}
@@ -2530,6 +2542,7 @@ func (m *Manager) GetParent(agentID string) *Agent {
 	// Return copy to avoid data races
 	copy := *parent
 	copy.Children = append([]string{}, parent.Children...)
+	copy.MissingSecrets = append([]string{}, parent.MissingSecrets...)
 	return &copy
 }
 
@@ -2544,6 +2557,7 @@ func (m *Manager) ListByRole(role Role) []*Agent {
 			// Return copy to avoid data races
 			copy := *a
 			copy.Children = append([]string{}, a.Children...)
+			copy.MissingSecrets = append([]string{}, a.MissingSecrets...)
 			agents = append(agents, &copy)
 		}
 	}

--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -63,6 +63,9 @@ type CreateOptions struct {
 	// Recorded on the agent row so the guardrail loop can enforce the
 	// template's MaxCostUSD / StuckTimeoutMin. Empty disables guardrails.
 	Template string
+	// MissingSecrets is set when creating from a template whose declared
+	// secrets are absent (#3558 create-degraded).
+	MissingSecrets []string
 }
 
 // StartOptions configures agent start behavior.
@@ -215,17 +218,18 @@ func (s *AgentService) Create(ctx context.Context, opts CreateOptions) (*Agent, 
 		repo = s.manager.repoPath
 	}
 	a, err := s.manager.SpawnAgentWithOptions(ctx, SpawnOptions{
-		Name:      opts.Name,
-		Role:      opts.Role,
-		Workspace: repo,
-		ParentID:  opts.Parent,
-		Tool:      opts.Tool,
-		Model:     opts.Model,
-		EnvFile:   opts.EnvFile,
-		Env:       opts.Env,
-		Runtime:   opts.Runtime,
-		Team:      opts.Team,
-		Template:  opts.Template,
+		Name:           opts.Name,
+		Role:           opts.Role,
+		Workspace:      repo,
+		ParentID:       opts.Parent,
+		Tool:           opts.Tool,
+		Model:          opts.Model,
+		EnvFile:        opts.EnvFile,
+		Env:            opts.Env,
+		Runtime:        opts.Runtime,
+		Team:           opts.Team,
+		Template:       opts.Template,
+		MissingSecrets: opts.MissingSecrets,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/agent/store_sqlite.go
+++ b/pkg/agent/store_sqlite.go
@@ -71,6 +71,7 @@ func createAgentsTable(d *db.DB) error {
 			memory_mb     INTEGER NOT NULL DEFAULT 0,
 			ttl           INTEGER NOT NULL DEFAULT 0,
 			template      TEXT,
+			missing_secrets TEXT NOT NULL DEFAULT '',
 			created_at    TEXT,
 			stopped_at    TEXT,
 			deleted_at    TEXT,
@@ -147,6 +148,7 @@ func ensureAgentColumns(ctx context.Context, d *db.DB) error {
 		{"cpus", "ALTER TABLE agents ADD COLUMN cpus REAL NOT NULL DEFAULT 0"},
 		{"memory_mb", "ALTER TABLE agents ADD COLUMN memory_mb INTEGER NOT NULL DEFAULT 0"},
 		{"template", "ALTER TABLE agents ADD COLUMN template TEXT"},
+		{"missing_secrets", "ALTER TABLE agents ADD COLUMN missing_secrets TEXT NOT NULL DEFAULT ''"},
 	} {
 		if have[add.col] {
 			continue
@@ -164,6 +166,13 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 	if err != nil {
 		return fmt.Errorf("marshal children: %w", err)
 	}
+	missingSecrets, err := json.Marshal(a.MissingSecrets)
+	if err != nil {
+		return fmt.Errorf("marshal missing_secrets: %w", err)
+	}
+	if a.MissingSecrets == nil {
+		missingSecrets = []byte("[]")
+	}
 	envVars, err := marshalEnv(a.Env)
 	if err != nil {
 		return fmt.Errorf("marshal env: %w", err)
@@ -180,8 +189,8 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 		 worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
-		 started_at, updated_at, repo, model, cpus, memory_mb, template)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 started_at, updated_at, repo, model, cpus, memory_mb, template, missing_secrets)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.Name, string(a.Role), string(a.State),
 		nullStr(a.Tool), nullStr(a.ParentID), nullStr(a.Team), nullStr(a.Task),
 		nullStr(a.Session), a.Workspace,
@@ -192,7 +201,7 @@ func (s *SQLiteStore) Save(ctx context.Context, a *Agent) error {
 		nullStr(a.RuntimeBackend), nullStr(a.SessionID),
 		formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
 		formatTime(a.StartedAt), formatTime(now), a.Repo, a.Model, a.CPUs, a.MemoryMB,
-		nullStr(a.Template),
+		nullStr(a.Template), string(missingSecrets),
 	)
 	return err
 }
@@ -318,8 +327,8 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 		 worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 		 is_root, crash_count, last_crash_time, recovered_from,
 		 runtime_backend, session_id, created_at, stopped_at, deleted_at,
-		 started_at, updated_at, repo, model, cpus, memory_mb, template)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+		 started_at, updated_at, repo, model, cpus, memory_mb, template, missing_secrets)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	if err != nil {
 		return err
 	}
@@ -330,6 +339,13 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 		children, err := json.Marshal(a.Children)
 		if err != nil {
 			return fmt.Errorf("marshal children for %s: %w", a.Name, err)
+		}
+		missingSecrets, err := json.Marshal(a.MissingSecrets)
+		if err != nil {
+			return fmt.Errorf("marshal missing_secrets for %s: %w", a.Name, err)
+		}
+		if a.MissingSecrets == nil {
+			missingSecrets = []byte("[]")
 		}
 		envVars, err := marshalEnv(a.Env)
 		if err != nil {
@@ -350,7 +366,7 @@ func (s *SQLiteStore) SaveAll(ctx context.Context, agents map[string]*Agent) err
 			nullStr(a.RuntimeBackend), nullStr(a.SessionID),
 			formatTime(createdAt), nullTime(a.StoppedAt), nullTime(a.DeletedAt),
 			formatTime(a.StartedAt), formatTime(now), a.Repo, a.Model, a.CPUs, a.MemoryMB,
-			nullStr(a.Template),
+			nullStr(a.Template), string(missingSecrets),
 		)
 		if err != nil {
 			return fmt.Errorf("save agent %s: %w", a.Name, err)
@@ -412,13 +428,14 @@ const agentSelectCols = `SELECT name, role, state, tool, parent_id, team, task, 
 	       worktree_dir, log_file, env_file, env_vars, hooked_work, children,
 	       is_root, crash_count, last_crash_time, recovered_from,
 	       runtime_backend, session_id, created_at, stopped_at, deleted_at,
-	       started_at, updated_at, repo, model, cpus, memory_mb, template`
+	       started_at, updated_at, repo, model, cpus, memory_mb, template, missing_secrets`
 
 func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	var a Agent
 	var role, state string
 	var tool, parentID, team, task, session, worktreeDir, logFile, envFile, hookedWork, childrenJSON *string
 	var lastCrashTime, recoveredFrom, runtimeBackend, sessionID, template *string
+	var missingSecretsJSON string
 	var repo, model, envVars string
 	var createdAt, stoppedAt, deletedAt *string
 	var startedAt, updatedAt string
@@ -432,7 +449,7 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 		&worktreeDir, &logFile, &envFile, &envVars, &hookedWork, &childrenJSON,
 		&isRoot, &crashCount, &lastCrashTime, &recoveredFrom,
 		&runtimeBackend, &sessionID, &createdAt, &stoppedAt, &deletedAt,
-		&startedAt, &updatedAt, &repo, &model, &cpus, &memoryMB, &template,
+		&startedAt, &updatedAt, &repo, &model, &cpus, &memoryMB, &template, &missingSecretsJSON,
 	)
 	if err != nil {
 		return nil, err
@@ -463,6 +480,9 @@ func scanAgentRow(s interface{ Scan(...any) error }) (*Agent, error) {
 	a.CPUs = cpus
 	a.MemoryMB = memoryMB
 	a.Template = deref(template)
+	if missingSecretsJSON != "" && missingSecretsJSON != "[]" {
+		_ = json.Unmarshal([]byte(missingSecretsJSON), &a.MissingSecrets) //nolint:errcheck // best-effort
+	}
 
 	if childrenJSON != nil && *childrenJSON != "" {
 		_ = json.Unmarshal([]byte(*childrenJSON), &a.Children) //nolint:errcheck // best-effort

--- a/pkg/template/missing.go
+++ b/pkg/template/missing.go
@@ -1,0 +1,31 @@
+package template
+
+import "strings"
+
+// SecretPresence reports whether a named secret exists in the vault.
+// Implementations must not return the secret value.
+type SecretPresence interface {
+	Has(name string) bool
+}
+
+// FilterMissing returns the subset of declared secret names that are absent
+// from vault. Empty/whitespace names are skipped. Order follows declared.
+// A nil vault treats every declared name as missing (advisory disclosure).
+func FilterMissing(declared []string, vault SecretPresence) []string {
+	if len(declared) == 0 {
+		return nil
+	}
+	var missing []string
+	seen := map[string]bool{}
+	for _, name := range declared {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		if vault == nil || !vault.Has(name) {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}

--- a/pkg/template/missing_test.go
+++ b/pkg/template/missing_test.go
@@ -1,0 +1,26 @@
+package template
+
+import "testing"
+
+type mapVault map[string]bool
+
+func (m mapVault) Has(name string) bool { return m[name] }
+
+func TestFilterMissing(t *testing.T) {
+	t.Parallel()
+	vault := mapVault{"HAVE": true}
+
+	got := FilterMissing([]string{"HAVE", "NEED", " HAVE ", "NEED", ""}, vault)
+	if len(got) != 1 || got[0] != "NEED" {
+		t.Fatalf("got %v, want [NEED]", got)
+	}
+
+	if got := FilterMissing(nil, vault); got != nil {
+		t.Fatalf("empty declared: got %v", got)
+	}
+
+	got = FilterMissing([]string{"A", "B"}, nil)
+	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
+		t.Fatalf("nil vault: got %v, want [A B]", got)
+	}
+}

--- a/pkg/template/missing_test.go
+++ b/pkg/template/missing_test.go
@@ -15,12 +15,12 @@ func TestFilterMissing(t *testing.T) {
 		t.Fatalf("got %v, want [NEED]", got)
 	}
 
-	if got := FilterMissing(nil, vault); got != nil {
-		t.Fatalf("empty declared: got %v", got)
+	if empty := FilterMissing(nil, vault); empty != nil {
+		t.Fatalf("empty declared: got %v", empty)
 	}
 
-	got = FilterMissing([]string{"A", "B"}, nil)
-	if len(got) != 2 || got[0] != "A" || got[1] != "B" {
-		t.Fatalf("nil vault: got %v, want [A B]", got)
+	allMissing := FilterMissing([]string{"A", "B"}, nil)
+	if len(allMissing) != 2 || allMissing[0] != "A" || allMissing[1] != "B" {
+		t.Fatalf("nil vault: got %v, want [A B]", allMissing)
 	}
 }

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -217,7 +217,7 @@ type agentDTO struct { //nolint:govet // field order matches JSON/API contract
 // createResponse is returned by POST /api/agents. For a single-agent create it
 // looks like agentDTO (Agents omitted). For a multi-agent blueprint it also
 // lists every leaf under Agents and the Team name (#3558 provision).
-type createResponse struct {
+type createResponse struct { //nolint:govet // embeds agentDTO JSON contract; alignment secondary
 	agentDTO
 	Agents  []agentDTO `json:"agents,omitempty"`
 	Missing []string   `json:"missing,omitempty"`
@@ -477,7 +477,7 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 
 			team := req.Name
 			if !multi {
-				team = "" // preserve prior single-agent behaviour (no team)
+				team = "" // preserve prior single-agent behavior (no team)
 			}
 			tmplName := leaf
 			if tmplName == "" {

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -100,6 +100,7 @@ type AgentHandler struct {
 	terminal   *TerminalHandler
 	statsStore *stats.Store
 	tmplStore  *template.Store
+	secrets    template.SecretPresence
 	broker     *agentEventBroker
 }
 
@@ -123,6 +124,12 @@ func NewAgentHandler(svc *agent.AgentService, costs *cost.Service, home *home.Ho
 // SetTemplateStore sets the template store used during agent creation.
 func (h *AgentHandler) SetTemplateStore(store *template.Store) {
 	h.tmplStore = store
+}
+
+// SetSecretPresence wires the vault used to disclose missing template secrets
+// at create / expand time (#3558 create-degraded).
+func (h *AgentHandler) SetSecretPresence(v template.SecretPresence) {
+	h.secrets = v
 }
 
 // SetStatsStore sets the stats store for resource metrics enrichment.
@@ -179,30 +186,41 @@ type agentDTO struct { //nolint:govet // field order matches JSON/API contract
 	// Env holds the agent's configured environment variables. Values
 	// with ${secret:NAME} references are returned as the reference —
 	// resolved values never leave the daemon.
-	Env          map[string]string `json:"env,omitempty"`
-	Tool         string            `json:"tool,omitempty"`
-	Model        string            `json:"model,omitempty"`
-	Session      string            `json:"session,omitempty"`
-	State        string            `json:"state"`
-	Task         string            `json:"task,omitempty"`
-	Team         string            `json:"team,omitempty"`
-	Name         string            `json:"name"`
-	Runtime      string            `json:"runtime_backend,omitempty"`
-	Role         string            `json:"role"`
-	Template     string            `json:"template,omitempty"`
-	SessionID    string            `json:"session_id,omitempty"`
-	ParentID     string            `json:"parent_id,omitempty"`
-	ID           string            `json:"id,omitempty"`
-	Repo         string            `json:"repo,omitempty"`
-	MCPServers   []string          `json:"mcp_servers,omitempty"`
-	Children     []string          `json:"children,omitempty"`
-	TotalCostUSD float64           `json:"total_cost_usd"`
-	TotalTokens  int64             `json:"total_tokens"`
+	Env      map[string]string `json:"env,omitempty"`
+	Tool     string            `json:"tool,omitempty"`
+	Model    string            `json:"model,omitempty"`
+	Session  string            `json:"session,omitempty"`
+	State    string            `json:"state"`
+	Task     string            `json:"task,omitempty"`
+	Team     string            `json:"team,omitempty"`
+	Name     string            `json:"name"`
+	Runtime  string            `json:"runtime_backend,omitempty"`
+	Role     string            `json:"role"`
+	Template string            `json:"template,omitempty"`
+	// MissingSecrets lists declared template secrets absent at create (#3558).
+	MissingSecrets []string `json:"missing_secrets,omitempty"`
+	SessionID      string   `json:"session_id,omitempty"`
+	ParentID       string   `json:"parent_id,omitempty"`
+	ID             string   `json:"id,omitempty"`
+	Repo           string   `json:"repo,omitempty"`
+	MCPServers     []string `json:"mcp_servers,omitempty"`
+	Children       []string `json:"children,omitempty"`
+	TotalCostUSD   float64  `json:"total_cost_usd"`
+	TotalTokens    int64    `json:"total_tokens"`
 	// CPUs / MemoryMB are the agent's per-agent Docker resource caps (0 =
 	// inherit the fleet default). Surfaced so the Insights resource panel
 	// can total configured caps without a per-agent config fetch.
 	CPUs     float64 `json:"cpus,omitempty"`
 	MemoryMB int64   `json:"memory_mb,omitempty"`
+}
+
+// createResponse is returned by POST /api/agents. For a single-agent create it
+// looks like agentDTO (Agents omitted). For a multi-agent blueprint it also
+// lists every leaf under Agents and the Team name (#3558 provision).
+type createResponse struct {
+	agentDTO
+	Agents  []agentDTO `json:"agents,omitempty"`
+	Missing []string   `json:"missing,omitempty"`
 }
 
 // agentStatsDTO holds resource metrics included when ?include=stats is set.
@@ -219,28 +237,30 @@ type agentStatsDTO struct {
 
 func toDTO(a *agent.Agent) agentDTO {
 	return agentDTO{
-		ID:         a.ID,
-		Name:       a.Name,
-		Role:       string(a.Role),
-		State:      string(a.State),
-		Task:       a.Task,
-		Team:       a.Team,
-		Tool:       a.Tool,
-		Model:      a.Model,
-		Runtime:    a.RuntimeBackend,
-		Session:    a.Session,
-		SessionID:  a.SessionID,
-		ParentID:   a.ParentID,
-		Children:   a.Children,
-		CreatedAt:  a.CreatedAt,
-		StartedAt:  a.StartedAt,
-		UpdatedAt:  a.UpdatedAt,
-		StoppedAt:  a.StoppedAt,
-		ArchivedAt: a.ArchivedAt,
-		Repo:       a.Repo,
-		Env:        a.Env,
-		CPUs:       a.CPUs,
-		MemoryMB:   a.MemoryMB,
+		ID:             a.ID,
+		Name:           a.Name,
+		Role:           string(a.Role),
+		State:          string(a.State),
+		Task:           a.Task,
+		Team:           a.Team,
+		Tool:           a.Tool,
+		Model:          a.Model,
+		Runtime:        a.RuntimeBackend,
+		Session:        a.Session,
+		SessionID:      a.SessionID,
+		ParentID:       a.ParentID,
+		Children:       a.Children,
+		CreatedAt:      a.CreatedAt,
+		StartedAt:      a.StartedAt,
+		UpdatedAt:      a.UpdatedAt,
+		StoppedAt:      a.StoppedAt,
+		ArchivedAt:     a.ArchivedAt,
+		Repo:           a.Repo,
+		Env:            a.Env,
+		CPUs:           a.CPUs,
+		MemoryMB:       a.MemoryMB,
+		Template:       a.Template,
+		MissingSecrets: a.MissingSecrets,
 	}
 }
 
@@ -417,29 +437,112 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 		if runtimeBackend == "" {
 			runtimeBackend = req.RuntimeAlt
 		}
-		a, err := svc.Create(r.Context(), agent.CreateOptions{
-			Name:     req.Name,
-			Role:     agent.Role(role),
-			Tool:     req.Tool,
-			Model:    req.Model,
-			Runtime:  runtimeBackend,
-			Parent:   req.Parent,
-			Repo:     req.Repo,
-			Env:      req.Env,
-			Template: req.Template,
-		})
-		if err != nil {
-			httpError(w, err.Error(), http.StatusBadRequest)
+
+		// Blueprint provision (#3558): expand composes into leaf agents.
+		leaves := []string{req.Template}
+		if req.Template != "" && h.tmplStore != nil {
+			expanded, expErr := template.Expand(h.tmplStore, req.Template)
+			if expErr != nil {
+				if strings.Contains(expErr.Error(), "not found") {
+					httpError(w, expErr.Error(), http.StatusNotFound)
+					return
+				}
+				httpError(w, expErr.Error(), http.StatusBadRequest)
+				return
+			}
+			if len(expanded.Leaves) > 0 {
+				leaves = expanded.Leaves
+			}
+		}
+		multi := len(leaves) > 1
+		if multi && req.Name == "" {
+			httpError(w, "name is required when creating a multi-agent blueprint", http.StatusBadRequest)
 			return
 		}
-		dto := toDTO(a)
+
+		created := make([]*agent.Agent, 0, len(leaves))
+		var unionMissing []string
+		for _, leaf := range leaves {
+			agentName := leafAgentName(req.Name, leaf, multi)
+			tool := req.Tool
+			var leafSecrets []string
+			if h.tmplStore != nil && leaf != "" {
+				if t, _, gErr := h.tmplStore.Get(leaf); gErr == nil && t != nil {
+					tool = leafTool(req.Tool, t.Provider)
+					leafSecrets = t.Secrets
+				}
+			}
+			missing := template.FilterMissing(leafSecrets, h.secrets)
+			unionMissing = unionStringSlice(unionMissing, missing)
+
+			team := req.Name
+			if !multi {
+				team = "" // preserve prior single-agent behaviour (no team)
+			}
+			tmplName := leaf
+			if tmplName == "" {
+				tmplName = req.Template
+			}
+			a, err := svc.Create(r.Context(), agent.CreateOptions{
+				Name:           agentName,
+				Role:           agent.Role(role),
+				Tool:           tool,
+				Model:          req.Model,
+				Runtime:        runtimeBackend,
+				Parent:         req.Parent,
+				Repo:           req.Repo,
+				Env:            req.Env,
+				Team:           team,
+				Template:       tmplName,
+				MissingSecrets: missing,
+			})
+			if err != nil {
+				httpError(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			created = append(created, a)
+		}
+
+		primary := created[0]
+		dto := toDTO(primary)
 		dto.Avatar = req.Avatar
-		dto.Template = req.Template
-		writeJSON(w, http.StatusCreated, dto)
+		if dto.Template == "" {
+			dto.Template = req.Template
+		}
+		resp := createResponse{agentDTO: dto, Missing: unionMissing}
+		if multi {
+			resp.Team = req.Name
+			resp.Agents = make([]agentDTO, 0, len(created))
+			for _, a := range created {
+				d := toDTO(a)
+				resp.Agents = append(resp.Agents, d)
+			}
+		}
+		writeJSON(w, http.StatusCreated, resp)
 
 	default:
 		methodNotAllowed(w)
 	}
+}
+
+func unionStringSlice(a, b []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range a {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	for _, s := range b {
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
 }
 
 // agentHTTPStatus maps domain errors from pkg/agent to the appropriate HTTP
@@ -906,6 +1009,9 @@ func (h *AgentHandler) health(w http.ResponseWriter, r *http.Request) {
 		case !health.TmuxAlive:
 			health.Status = "unhealthy"
 			health.ErrorMessage = "tmux session not found"
+		case len(a.MissingSecrets) > 0:
+			health.Status = "degraded"
+			health.ErrorMessage = fmt.Sprintf("missing secrets: %s", strings.Join(a.MissingSecrets, ", "))
 		case !health.StateFresh:
 			health.Status = "degraded"
 			health.ErrorMessage = fmt.Sprintf("state stale (%s since last update)", health.StaleDuration)

--- a/server/handlers/provision.go
+++ b/server/handlers/provision.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"fmt"
+
+	"github.com/rpuneet/mycel/pkg/secret"
+	"github.com/rpuneet/mycel/pkg/template"
+)
+
+// NewVaultPresence adapts a secrets store (GetMeta) to template.SecretPresence.
+func NewVaultPresence(store interface {
+	GetMeta(name string) (*secret.SecretMeta, error)
+}) template.SecretPresence {
+	if store == nil {
+		return nil
+	}
+	return vaultPresence{store: store}
+}
+
+// vaultPresence adapts *secret.Store to template.SecretPresence.
+type vaultPresence struct {
+	store interface {
+		GetMeta(name string) (*secret.SecretMeta, error)
+	}
+}
+
+func (v vaultPresence) Has(name string) bool {
+	if v.store == nil {
+		return false
+	}
+	_, err := v.store.GetMeta(name)
+	return err == nil
+}
+
+// leafAgentName builds the agent name for a composed leaf under team base.
+// Single-leaf creates use the request name unchanged; multi uses "{base}-{leaf}".
+func leafAgentName(base, leaf string, multi bool) string {
+	if !multi {
+		return base
+	}
+	if base == "" {
+		return leaf
+	}
+	return fmt.Sprintf("%s-%s", base, leaf)
+}
+
+// leafTool picks the provider: request tool wins, else template.Provider.
+func leafTool(reqTool, provider string) string {
+	if reqTool != "" {
+		return reqTool
+	}
+	return provider
+}

--- a/server/handlers/provision_test.go
+++ b/server/handlers/provision_test.go
@@ -1,0 +1,34 @@
+package handlers
+
+import "testing"
+
+func TestLeafAgentName(t *testing.T) {
+	t.Parallel()
+	if got := leafAgentName("solo", "blank", false); got != "solo" {
+		t.Fatalf("single: got %q", got)
+	}
+	if got := leafAgentName("eng", "reviewer", true); got != "eng-reviewer" {
+		t.Fatalf("multi: got %q", got)
+	}
+	if got := leafAgentName("", "reviewer", true); got != "reviewer" {
+		t.Fatalf("empty base: got %q", got)
+	}
+}
+
+func TestLeafTool(t *testing.T) {
+	t.Parallel()
+	if got := leafTool("cursor", "claude"); got != "cursor" {
+		t.Fatalf("req wins: got %q", got)
+	}
+	if got := leafTool("", "claude"); got != "claude" {
+		t.Fatalf("provider fallback: got %q", got)
+	}
+}
+
+func TestUnionStringSlice(t *testing.T) {
+	t.Parallel()
+	got := unionStringSlice([]string{"A", "B"}, []string{"B", "C"})
+	if len(got) != 3 || got[0] != "A" || got[1] != "B" || got[2] != "C" {
+		t.Fatalf("got %v", got)
+	}
+}

--- a/server/handlers/templates.go
+++ b/server/handlers/templates.go
@@ -10,12 +10,18 @@ import (
 
 // TemplateHandler handles /api/templates routes.
 type TemplateHandler struct {
-	store *template.Store
+	store   *template.Store
+	secrets template.SecretPresence
 }
 
 // NewTemplateHandler creates a TemplateHandler backed by the given store.
 func NewTemplateHandler(store *template.Store) *TemplateHandler {
 	return &TemplateHandler{store: store}
+}
+
+// SetSecretPresence wires the vault used to fill ExpandResult.Missing.
+func (h *TemplateHandler) SetSecretPresence(v template.SecretPresence) {
+	h.secrets = v
 }
 
 // Register mounts template routes on mux.
@@ -151,6 +157,7 @@ func (h *TemplateHandler) byName(w http.ResponseWriter, r *http.Request) {
 			httpError(w, err.Error(), http.StatusBadRequest)
 			return
 		}
+		result.Missing = template.FilterMissing(result.Secrets, h.secrets)
 		writeJSON(w, http.StatusOK, result)
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -268,6 +268,9 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 				ah.SetTemplateStore(template.NewStore(templatesDir))
 			}
 		}
+		if svc.Secrets != nil {
+			ah.SetSecretPresence(handlers.NewVaultPresence(svc.Secrets))
+		}
 		ah.SetTerminalHandler(handlers.NewTerminalHandler(svc.Agents, cfg.CORSOrigin))
 		ah.Register(mux)
 	}
@@ -447,7 +450,11 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 		if migrErr := migrateRolesToTemplates(svc.Home.RolesDir(), templatesDir); migrErr != nil {
 			log.Warn("migrate roles to templates", "error", migrErr)
 		}
-		handlers.NewTemplateHandler(tmplStore).Register(mux)
+		th := handlers.NewTemplateHandler(tmplStore)
+		if svc.Secrets != nil {
+			th.SetSecretPresence(handlers.NewVaultPresence(svc.Secrets))
+		}
+		th.Register(mux)
 
 		// Marketplace — live catalog aggregating MCP registry, GitHub, vendor skill
 		// sources (Claude/Gemini), and local templates. Template

--- a/web/src/components/CreateAgentModal.tsx
+++ b/web/src/components/CreateAgentModal.tsx
@@ -353,10 +353,8 @@ export function CreateAgentModal({
         name?: string;
         agents?: { name: string }[];
       };
-      const primary =
-        body.agents && body.agents.length > 0
-          ? body.agents[0].name
-          : (body.name ?? trimmed);
+      const firstLeaf = body.agents?.[0]?.name;
+      const primary = firstLeaf || body.name || trimmed;
       // Wire the selected app channel subscriptions — best effort; the
       // agent exists either way and the Config tab can fix any misses.
       if (appChannels.size > 0) {

--- a/web/src/components/CreateAgentModal.tsx
+++ b/web/src/components/CreateAgentModal.tsx
@@ -349,15 +349,23 @@ export function CreateAgentModal({
         setSubmitting(false);
         return;
       }
+      const body = await res.json().catch(() => ({})) as {
+        name?: string;
+        agents?: { name: string }[];
+      };
+      const primary =
+        body.agents && body.agents.length > 0
+          ? body.agents[0].name
+          : (body.name ?? trimmed);
       // Wire the selected app channel subscriptions — best effort; the
       // agent exists either way and the Config tab can fix any misses.
       if (appChannels.size > 0) {
         await Promise.allSettled(
-          [...appChannels].map((channel) => api.subscribe(channel, trimmed, false)),
+          [...appChannels].map((channel) => api.subscribe(channel, primary, false)),
         );
       }
       onClose();
-      navigate(`/agents/${encodeURIComponent(trimmed)}`);
+      navigate(`/agents/${encodeURIComponent(primary)}`);
     } catch (e) {
       setSubmitError(e instanceof Error ? e.message : "Failed to create agent");
       setSubmitting(false);


### PR DESCRIPTION
## Summary
Second slice of #3558 (after schema/expand #3601):

- `POST /api/agents` with a composed blueprint expands leaves and creates one agent per leaf (`{name}-{leaf}`, `team={name}`)
- Declared secrets absent from the vault are recorded as `missing_secrets` — creation is not refused (create-degraded)
- Agent health reports `degraded` when `missing_secrets` is non-empty
- `GET /api/templates/{name}/expand` fills `missing` from the vault
- Create Agent UI navigates to the first leaf when multiple agents are created

Part of #3558

## Test plan
- [x] `go test ./pkg/template/ ./pkg/agent/ ./server/handlers/`
- [x] CreateAgentModal vitest
- [ ] Create single-agent `blank` — unchanged (one agent, requested name)
- [ ] Create a template with `composes: [a,b]` + secrets → N agents + `missing` when vault empty
- [ ] `GET /api/agents/health?agent=…` → degraded with missing secret names
- [ ] Expand endpoint returns `missing` for undeclared secrets


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Creating agents from multi-agent templates now automatically creates each leaf agent with appropriate names, tools, and templates.
  * Agent and template responses now report required secrets that are unavailable, without exposing secret values.
  * Agent health information reflects degraded status when credentials are missing.
* **Bug Fixes**
  * Improved post-creation navigation to open the correctly created primary agent.
* **Documentation**
  * Added guidance and API examples for multi-agent creation and missing credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->