### PR TITLE
fix(templates): secrets/plugins + guardrails UI (#3550, #3574)

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1365,7 +1365,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	injectResourceLimits(env, existing.CPUs, existing.MemoryMB)
 	injectEnv(env, repoPath, name, existing.EnvFile, existing.Env)
 	injectAppEnv(env, m.appsConfig)
-	secretEnvKeys := injectVaultSecrets(env, repoPath, resolveRoleSecrets(repoPath, string(existing.Role)), m.appsConfig)
+	secretEnvKeys := injectVaultSecrets(env, repoPath, resolveAgentSecrets(repoPath, string(existing.Role), existing.Template), m.appsConfig)
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -1617,7 +1617,7 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 	injectResourceLimits(env, agent.CPUs, agent.MemoryMB)
 	injectEnv(env, repoPath, name, opts.EnvFile, opts.Env)
 	injectAppEnv(env, m.appsConfig)
-	secretEnvKeys := injectVaultSecrets(env, repoPath, resolveRoleSecrets(repoPath, string(role)), m.appsConfig)
+	secretEnvKeys := injectVaultSecrets(env, repoPath, resolveAgentSecrets(repoPath, string(role), opts.Template), m.appsConfig)
 
 	rt := m.runtimeForAgent(name)
 	m.mu.Unlock()
@@ -3544,8 +3544,9 @@ func openLayeredStore(repoPath, passphrase string) (ls *secret.LayeredStore, clo
 // Call AFTER injectEnv + injectAppEnv so that explicitly-set values are
 // never overwritten by vault copies.
 //
-// Role-scoped secrets (roleSecrets from ResolvedRole.Secrets) act as an
-// allowlist: vault values are not sprayed across every agent indiscriminately.
+// Role-scoped and template-declared secrets (roleSecrets from ResolvedRole /
+// Template.Secrets, #3550) act as an allowlist: vault values are not sprayed
+// across every agent indiscriminately.
 // Connected-app credentials (descriptor Secret fields, stored under
 // app:<instance>:<key>) and well-known integration tokens (SLACK_BOT_TOKEN
 // etc.) are also exported when present as a convenience for agents that
@@ -3675,6 +3676,22 @@ func resolveRoleSecrets(repoPath, roleName string) []string {
 		return nil
 	}
 	return resolved.Secrets
+}
+
+// resolveAgentSecrets returns the union of role secrets and template-declared
+// secrets (#3550). Template secrets must reach injectVaultSecrets the same way
+// role secrets do — otherwise a blueprint that names GITHUB_TOKEN only gets it
+// into .mcp.json substitution and never into the agent's environment.
+func resolveAgentSecrets(repoPath, roleName, templateName string) []string {
+	out := resolveRoleSecrets(repoPath, roleName)
+	if templateName == "" {
+		return out
+	}
+	tmpl, _, err := loadTemplateForSetup(templateName)
+	if err != nil || tmpl == nil {
+		return out
+	}
+	return union(out, tmpl.Secrets)
 }
 
 // resolveRoleMCPServers returns the effective MCP server names an agent of the

--- a/pkg/agent/template_secrets_test.go
+++ b/pkg/agent/template_secrets_test.go
@@ -1,0 +1,107 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/secret"
+	"github.com/rpuneet/mycel/pkg/template"
+)
+
+// #3550: a template that names secrets and plugins must actually deliver them.
+
+func TestResolveAgentSecretsUnionsTemplate(t *testing.T) {
+	seedDir := t.TempDir()
+	s := template.NewStore(seedDir)
+	if err := s.Create(template.Template{
+		Name:    "trader",
+		Secrets: []string{"ALPACA_KEY", "TELEGRAM_BOT_TOKEN"},
+	}, "trade", template.ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	withTemplatesIn(t, seedDir)
+
+	got := resolveAgentSecrets(t.TempDir(), "", "trader")
+	if len(got) != 2 || got[0] != "ALPACA_KEY" || got[1] != "TELEGRAM_BOT_TOKEN" {
+		t.Fatalf("got %v, want [ALPACA_KEY TELEGRAM_BOT_TOKEN]", got)
+	}
+
+	if got := resolveAgentSecrets(t.TempDir(), "", ""); got != nil {
+		t.Fatalf("empty template: got %v", got)
+	}
+}
+
+func TestTemplatePluginsReachClaudeSessionDir(t *testing.T) {
+	seedDir := t.TempDir()
+	s := template.NewStore(seedDir)
+	if err := s.Create(template.Template{
+		Name:    "with-plugin",
+		Plugins: []string{"code-review"},
+	}, "You review.", template.ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+	withTemplatesIn(t, seedDir)
+
+	// AgentSessionDir reads MYCEL_HOME/agents/<name>/session
+	mycelHome := os.Getenv("MYCEL_HOME")
+	wtDir := t.TempDir()
+	if err := SetupAgentFromRoleAndTemplate(t.Context(), t.TempDir(), "plug-1", "", wtDir, "tmux", "claude", "with-plugin"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	manifest := filepath.Join(mycelHome, "agents", "plug-1", "session", "claude", "installed_plugins.json")
+	raw, err := os.ReadFile(manifest) //nolint:gosec // test path
+	if err != nil {
+		t.Fatalf("plugin manifest missing at %s: %v", manifest, err)
+	}
+	var m struct {
+		Plugins map[string]struct {
+			Name    string `json:"name"`
+			Enabled bool   `json:"enabled"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	if p, ok := m.Plugins["code-review"]; !ok || !p.Enabled {
+		t.Fatalf("plugins = %#v, want code-review enabled", m.Plugins)
+	}
+}
+
+func TestTemplateSecretsInjectIntoAgentEnv(t *testing.T) {
+	// End-to-end for the allowlist path: vault has ALPACA_KEY, template
+	// declares it, injectVaultSecrets must put it in env (#3550).
+	mycelHome := t.TempDir()
+	t.Setenv("MYCEL_HOME", mycelHome)
+	t.Setenv(secret.PassphraseEnvVar, "unit-test-passphrase")
+
+	vaultPath := filepath.Join(mycelHome, "secrets.vault")
+	vault, err := secret.OpenVaultFile(vaultPath, "unit-test-passphrase")
+	if err != nil {
+		t.Fatalf("open vault: %v", err)
+	}
+	if err := vault.Set("ALPACA_KEY", "sk-live-test", ""); err != nil {
+		t.Fatal(err)
+	}
+	_ = vault.Close()
+
+	tmplDir := filepath.Join(mycelHome, "templates")
+	if err := os.MkdirAll(tmplDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := template.NewStore(tmplDir).Create(template.Template{
+		Name:    "trader",
+		Secrets: []string{"ALPACA_KEY"},
+	}, "trade", template.ScopeGlobal); err != nil {
+		t.Fatal(err)
+	}
+
+	names := resolveAgentSecrets(t.TempDir(), "", "trader")
+	env := map[string]string{}
+	injected := injectVaultSecrets(env, t.TempDir(), names, nil)
+	if env["ALPACA_KEY"] != "sk-live-test" {
+		t.Fatalf("env ALPACA_KEY = %q, injected=%v", env["ALPACA_KEY"], injected)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -116,6 +116,10 @@ export interface Agent {
   cpus?: number;
   /** Per-agent Docker memory cap in MB (0/absent = inherit fleet default). */
   memory_mb?: number;
+  /** Template this agent was spawned from; guardrails are read from it. */
+  template?: string;
+  /** Template-declared secrets absent from the vault at create (#3558). */
+  missing_secrets?: string[];
 }
 
 export interface AgentConfig {

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -598,6 +598,80 @@ function ProviderModelSection({
  * Blank inputs clear the override (send 0) so the fleet default applies.
  * For tmux agents the limits are stored but not enforced — labelled so.
  */
+function AgentGuardrailsSection({ templateName }: { templateName?: string }) {
+  const [maxCost, setMaxCost] = useState<number | null>(null);
+  const [stuckMin, setStuckMin] = useState<number | null>(null);
+  const [loadErr, setLoadErr] = useState(false);
+
+  useEffect(() => {
+    if (!templateName) {
+      setMaxCost(null);
+      setStuckMin(null);
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/templates/${encodeURIComponent(templateName)}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(String(r.status));
+        return r.json() as Promise<{ max_cost_usd?: number; stuck_timeout_min?: number }>;
+      })
+      .then((t) => {
+        if (cancelled) return;
+        setMaxCost(t.max_cost_usd && t.max_cost_usd > 0 ? t.max_cost_usd : null);
+        setStuckMin(t.stuck_timeout_min && t.stuck_timeout_min > 0 ? t.stuck_timeout_min : null);
+        setLoadErr(false);
+      })
+      .catch(() => {
+        if (!cancelled) setLoadErr(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [templateName]);
+
+  return (
+    <section>
+      <SectionRule>Guardrails</SectionRule>
+      {!templateName ? (
+        <p className="text-xs text-mycel-muted leading-relaxed mt-1">
+          No template on this agent — cost and stuck limits are not enforced. Create from a
+          template (or set one) to attach guardrails.
+        </p>
+      ) : loadErr ? (
+        <p className="text-xs text-mycel-muted mt-1">Could not load template {templateName}.</p>
+      ) : (
+        <div className="mt-2 space-y-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm" style={{ fontFamily: MONO }}>
+            <div>
+              <div className="text-[11px] uppercase tracking-wide text-mycel-muted">Max cost</div>
+              <div className="text-mycel-text">
+                {maxCost != null ? `$${maxCost.toFixed(2)}` : "— (no cap)"}
+              </div>
+            </div>
+            <div>
+              <div className="text-[11px] uppercase tracking-wide text-mycel-muted">Stuck timeout</div>
+              <div className="text-mycel-text">
+                {stuckMin != null ? `${stuckMin} min` : "— (no timeout)"}
+              </div>
+            </div>
+          </div>
+          <p className="text-xs text-mycel-muted leading-relaxed">
+            In effect from template{" "}
+            <Link
+              to={`/templates`}
+              className="text-mycel-accent hover:underline"
+              title={templateName}
+            >
+              {templateName}
+            </Link>
+            . Edit them on the template — the daemon re-reads on each check.
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}
+
 function ResourceLimitsSection({
   agentName,
   isDocker,
@@ -995,6 +1069,9 @@ function SettingsTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) 
           memoryMB={config?.memory_mb ?? agent.memory_mb ?? 0}
           onSaved={reloadConfig}
         />
+
+        {/* ── GUARDRAILS (from template) ── */}
+        <AgentGuardrailsSection templateName={agent.template} />
 
         {/* ── TEMPLATE ── */}
         {templates.length > 0 && (

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -118,6 +118,8 @@ function TemplateDetailPanel({
   const [description, setDescription] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
   const [mcpsRaw, setMcpsRaw] = useState("");
+  const [secretsRaw, setSecretsRaw] = useState("");
+  const [pluginsRaw, setPluginsRaw] = useState("");
 
   const [saveStatus, setSaveStatus] = useState<SaveStatus>({ type: "idle" });
 
@@ -133,6 +135,8 @@ function TemplateDetailPanel({
       setDescription(t.description ?? "");
       setSystemPrompt(t.system_prompt ?? "");
       setMcpsRaw((t.mcps ?? []).join(", "));
+      setSecretsRaw((t.secrets ?? []).join(", "));
+      setPluginsRaw((t.plugins ?? []).join(", "));
     } catch (err) {
       setLoadErr(err instanceof Error ? err.message : "Failed to load");
     } finally {
@@ -158,11 +162,8 @@ function TemplateDetailPanel({
         description: description.trim(),
         system_prompt: systemPrompt,
         mcps: splitComma(mcpsRaw),
-        // Passed through, not edited: these are not applied to agents yet
-        // (#3550). Rebuilding them from a removed field would delete anyone's
-        // stored values on their next save.
-        secrets: detail.secrets ?? [],
-        plugins: detail.plugins ?? [],
+        secrets: splitComma(secretsRaw),
+        plugins: splitComma(pluginsRaw),
       });
       setSaveStatus({ type: "success" });
       setEditing(false);
@@ -290,11 +291,46 @@ function TemplateDetailPanel({
           )}
         </div>
 
-        {/* Secrets and plugins are not applied to agents yet (#3550), so there
-            is nothing here to edit. Values saved by an earlier build are still
-            shown — hiding them would suggest they had been deleted — labeled
-            with the fact that they are inert. */}
-        <NotAppliedYet secrets={detail.secrets ?? []} plugins={detail.plugins ?? []} />
+        {/* Secrets — applied at create via vault inject + MCP substitution (#3550) */}
+        <div className="space-y-1">
+          <SectionRule label="Secrets" />
+          {editing ? (
+            <input
+              type="text"
+              value={secretsRaw}
+              onChange={(e) => setSecretsRaw(e.target.value)}
+              className="w-full px-3 py-2 rounded-md border border-mycel-border bg-mycel-bg text-mycel-text text-sm focus:outline-none focus:ring-2 focus:ring-mycel-accent"
+              placeholder="GITHUB_TOKEN, ALPACA_KEY"
+              aria-label="Secrets (comma-separated vault names)"
+              style={{ fontFamily: MONO }}
+            />
+          ) : (
+            <ChipList items={detail.secrets ?? []} color="yellow" />
+          )}
+          <p className="text-[11px] text-mycel-muted leading-relaxed">
+            Vault names injected into the agent env and into MCP{" "}
+            <code className="font-mono">{"${secret:NAME}"}</code> refs. Missing ones create the
+            agent degraded.
+          </p>
+        </div>
+
+        {/* Plugins — written via provider SetupPlugins at create (#3550) */}
+        <div className="space-y-1">
+          <SectionRule label="Plugins" />
+          {editing ? (
+            <input
+              type="text"
+              value={pluginsRaw}
+              onChange={(e) => setPluginsRaw(e.target.value)}
+              className="w-full px-3 py-2 rounded-md border border-mycel-border bg-mycel-bg text-mycel-text text-sm focus:outline-none focus:ring-2 focus:ring-mycel-accent"
+              placeholder="code-review"
+              aria-label="Plugins (comma-separated)"
+              style={{ fontFamily: MONO }}
+            />
+          ) : (
+            <ChipList items={detail.plugins ?? []} color="green" />
+          )}
+        </div>
 
         {/* Actions */}
         <div className="flex items-center justify-between pt-2 border-t border-mycel-border">
@@ -318,6 +354,8 @@ function TemplateDetailPanel({
                     setDescription(detail.description ?? "");
                     setSystemPrompt(detail.system_prompt ?? "");
                     setMcpsRaw((detail.mcps ?? []).join(", "));
+                    setSecretsRaw((detail.secrets ?? []).join(", "));
+                    setPluginsRaw((detail.plugins ?? []).join(", "));
                   }}
                   className="inline-flex items-center h-9 px-3 rounded-md bg-mycel-surface border border-mycel-border text-mycel-text-2 text-sm hover:text-mycel-text hover:bg-mycel-surface-hover transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
                 >
@@ -551,51 +589,6 @@ function TemplateRow({
   );
 }
 
-/**
- * NotAppliedYet — surfaces secrets and plugins that an earlier build let someone
- * save, and says plainly that they do nothing.
- *
- * The editor used to accept both and render a chip per entry, which read as
- * confirmation: you typed GITHUB_TOKEN, a chip appeared, and the agent never
- * received it — the failure arrived much later, inside the agent, as a tool that
- * could not authenticate (#3550). The fields are gone until they work.
- *
- * Stored values are still shown, because deleting them from view would suggest
- * they had been deleted from the template. They are passed through untouched on
- * save.
- */
-function NotAppliedYet({ secrets, plugins }: { secrets: string[]; plugins: string[] }) {
-  if (secrets.length === 0 && plugins.length === 0) return null;
-  const named = [
-    secrets.length > 0 ? `${secrets.length} secret${secrets.length === 1 ? "" : "s"}` : null,
-    plugins.length > 0 ? `${plugins.length} plugin${plugins.length === 1 ? "" : "s"}` : null,
-  ]
-    .filter(Boolean)
-    .join(" and ");
-
-  return (
-    <div className="space-y-2 rounded-md border border-mycel-border bg-mycel-surface p-3">
-      <div className="text-xs font-medium text-mycel-warning">Saved but not applied</div>
-      <p className="text-xs text-mycel-muted leading-relaxed">
-        This template records {named}. Agents created from it do not receive them yet, so treat
-        anything here as a note to yourself rather than configuration. It is kept as-is when you
-        save.
-      </p>
-      {secrets.length > 0 && (
-        <div className="space-y-1">
-          <div className="text-[11px] uppercase tracking-wide text-mycel-muted">Secrets</div>
-          <ChipList items={secrets} color="yellow" />
-        </div>
-      )}
-      {plugins.length > 0 && (
-        <div className="space-y-1">
-          <div className="text-[11px] uppercase tracking-wide text-mycel-muted">Plugins</div>
-          <ChipList items={plugins} color="green" />
-        </div>
-      )}
-    </div>
-  );
-}
 
 // ─── Main export ─────────────────────────────────────────────────────────────
 

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -17,6 +17,8 @@ interface Template {
   mcps: string[];
   secrets: string[];
   plugins: string[];
+  max_cost_usd?: number;
+  stuck_timeout_min?: number;
 }
 
 interface TemplateDetail extends Template {
@@ -67,6 +69,8 @@ const updateTemplate = (
     mcps: string[];
     secrets: string[];
     plugins: string[];
+    max_cost_usd: number;
+    stuck_timeout_min: number;
   },
 ): Promise<Template> =>
   fetch(`/api/templates/${encodeURIComponent(name)}`, {
@@ -120,6 +124,8 @@ function TemplateDetailPanel({
   const [mcpsRaw, setMcpsRaw] = useState("");
   const [secretsRaw, setSecretsRaw] = useState("");
   const [pluginsRaw, setPluginsRaw] = useState("");
+  const [maxCostRaw, setMaxCostRaw] = useState("");
+  const [stuckTimeoutRaw, setStuckTimeoutRaw] = useState("");
 
   const [saveStatus, setSaveStatus] = useState<SaveStatus>({ type: "idle" });
 
@@ -137,6 +143,10 @@ function TemplateDetailPanel({
       setMcpsRaw((t.mcps ?? []).join(", "));
       setSecretsRaw((t.secrets ?? []).join(", "));
       setPluginsRaw((t.plugins ?? []).join(", "));
+      setMaxCostRaw(t.max_cost_usd && t.max_cost_usd > 0 ? String(t.max_cost_usd) : "");
+      setStuckTimeoutRaw(
+        t.stuck_timeout_min && t.stuck_timeout_min > 0 ? String(t.stuck_timeout_min) : "",
+      );
     } catch (err) {
       setLoadErr(err instanceof Error ? err.message : "Failed to load");
     } finally {
@@ -164,6 +174,8 @@ function TemplateDetailPanel({
         mcps: splitComma(mcpsRaw),
         secrets: splitComma(secretsRaw),
         plugins: splitComma(pluginsRaw),
+        max_cost_usd: parseFloat(maxCostRaw) || 0,
+        stuck_timeout_min: parseInt(stuckTimeoutRaw, 10) || 0,
       });
       setSaveStatus({ type: "success" });
       setEditing(false);
@@ -332,6 +344,70 @@ function TemplateDetailPanel({
           )}
         </div>
 
+        {/* Guardrails — enforced by the daemon from this template (#3574) */}
+        <div className="space-y-3">
+          <SectionRule label="Guardrails" />
+          <p className="text-[11px] text-mycel-muted leading-relaxed">
+            Agents created from this template inherit these limits. Leave blank for no cap.
+            Hitting the cost cap stops the agent; stuck timeout marks it stuck when idle too long.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label className="text-[11px] uppercase tracking-wide text-mycel-muted" htmlFor="max-cost">
+                Max cost (USD)
+              </label>
+              {editing ? (
+                <input
+                  id="max-cost"
+                  type="number"
+                  min={0}
+                  step="0.01"
+                  value={maxCostRaw}
+                  onChange={(e) => setMaxCostRaw(e.target.value)}
+                  className="w-full px-3 py-2 rounded-md border border-mycel-border bg-mycel-bg text-mycel-text text-sm focus:outline-none focus:ring-2 focus:ring-mycel-accent"
+                  placeholder="e.g. 5"
+                  aria-label="Max cost USD"
+                  style={{ fontFamily: MONO }}
+                />
+              ) : (
+                <p className="text-sm text-mycel-text" style={{ fontFamily: MONO }}>
+                  {detail.max_cost_usd && detail.max_cost_usd > 0
+                    ? `$${detail.max_cost_usd.toFixed(2)}`
+                    : "—"}
+                </p>
+              )}
+            </div>
+            <div className="space-y-1">
+              <label
+                className="text-[11px] uppercase tracking-wide text-mycel-muted"
+                htmlFor="stuck-timeout"
+              >
+                Stuck timeout (min)
+              </label>
+              {editing ? (
+                <input
+                  id="stuck-timeout"
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={stuckTimeoutRaw}
+                  onChange={(e) => setStuckTimeoutRaw(e.target.value)}
+                  className="w-full px-3 py-2 rounded-md border border-mycel-border bg-mycel-bg text-mycel-text text-sm focus:outline-none focus:ring-2 focus:ring-mycel-accent"
+                  placeholder="e.g. 30"
+                  aria-label="Stuck timeout minutes"
+                  style={{ fontFamily: MONO }}
+                />
+              ) : (
+                <p className="text-sm text-mycel-text" style={{ fontFamily: MONO }}>
+                  {detail.stuck_timeout_min && detail.stuck_timeout_min > 0
+                    ? `${detail.stuck_timeout_min} min`
+                    : "—"}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+
         {/* Actions */}
         <div className="flex items-center justify-between pt-2 border-t border-mycel-border">
           <div className="flex items-center gap-3">
@@ -356,6 +432,16 @@ function TemplateDetailPanel({
                     setMcpsRaw((detail.mcps ?? []).join(", "));
                     setSecretsRaw((detail.secrets ?? []).join(", "));
                     setPluginsRaw((detail.plugins ?? []).join(", "));
+                    setMaxCostRaw(
+                      detail.max_cost_usd && detail.max_cost_usd > 0
+                        ? String(detail.max_cost_usd)
+                        : "",
+                    );
+                    setStuckTimeoutRaw(
+                      detail.stuck_timeout_min && detail.stuck_timeout_min > 0
+                        ? String(detail.stuck_timeout_min)
+                        : "",
+                    );
                   }}
                   className="inline-flex items-center h-9 px-3 rounded-md bg-mycel-surface border border-mycel-border text-mycel-text-2 text-sm hover:text-mycel-text hover:bg-mycel-surface-hover transition-colors focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
                 >

--- a/web/src/views/__tests__/templates.test.tsx
+++ b/web/src/views/__tests__/templates.test.tsx
@@ -98,12 +98,29 @@ describe("Templates secrets and plugins", () => {
     expect(screen.getByLabelText(/Plugins \(comma-separated/i)).toBeInTheDocument();
   });
 
-  it("drops the Secrets column from the list (detail is enough)", async () => {
-    mockTemplates({ name: "reviewer", description: "Code review agent", mcps: ["mycel"], secrets: [], plugins: [] });
+  it("shows editable guardrails on the template detail", async () => {
+    mockTemplates({
+      name: "reviewer",
+      description: "Code review agent",
+      mcps: ["mycel"],
+      secrets: [],
+      plugins: [],
+      max_cost_usd: 5,
+      stuck_timeout_min: 30,
+      system_prompt: "review things",
+    });
     renderTemplates();
 
     await waitFor(() => expect(screen.getByText("reviewer")).toBeInTheDocument());
-    expect(screen.queryByRole("columnheader", { name: "Secrets" })).not.toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "MCPs" })).toBeInTheDocument();
+    (await screen.findByText("reviewer")).click();
+
+    await waitFor(() => expect(screen.getByText("$5.00")).toBeInTheDocument());
+    expect(screen.getByText("30 min")).toBeInTheDocument();
+
+    (await screen.findByRole("button", { name: /^Edit$/i })).click();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Max cost USD/i)).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/Stuck timeout minutes/i)).toBeInTheDocument();
   });
 });

--- a/web/src/views/__tests__/templates.test.tsx
+++ b/web/src/views/__tests__/templates.test.tsx
@@ -57,11 +57,8 @@ describe("Templates marketplace section", () => {
 });
 
 /**
- * The editor used to accept Secrets and render a chip per entry, which read as
- * confirmation: you typed GITHUB_TOKEN, a chip appeared, and the agent never
- * received it (#3550). The fields are gone until they work — but values an
- * earlier build saved are still shown, because hiding them would suggest they
- * had been deleted.
+ * #3550: secrets and plugins are editable and applied at agent create.
+ * The old "Saved but not applied" banner is gone.
  */
 describe("Templates secrets and plugins", () => {
   function mockTemplates(detail: Record<string, unknown>) {
@@ -75,56 +72,38 @@ describe("Templates secrets and plugins", () => {
     });
   }
 
-  it("does not offer a Secrets field to fill in", async () => {
-    mockTemplates({ name: "reviewer", description: "Code review agent", mcps: ["mycel"], secrets: [], plugins: [] });
+  it("offers editable Secrets and Plugins fields", async () => {
+    mockTemplates({
+      name: "reviewer",
+      description: "Code review agent",
+      mcps: ["mycel"],
+      secrets: ["GITHUB_TOKEN"],
+      plugins: ["code-review"],
+      system_prompt: "review things",
+    });
     renderTemplates();
 
     await waitFor(() => expect(screen.getByText("reviewer")).toBeInTheDocument());
-    expect(screen.queryByLabelText(/secrets/i)).not.toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(/GITHUB_TOKEN/)).not.toBeInTheDocument();
+    (await screen.findByText("reviewer")).click();
+
+    await waitFor(() => expect(screen.getByText("GITHUB_TOKEN")).toBeInTheDocument());
+    expect(screen.getByText("code-review")).toBeInTheDocument();
+    expect(screen.queryByText("Saved but not applied")).not.toBeInTheDocument();
+
+    // Enter edit mode — fields become inputs.
+    (await screen.findByRole("button", { name: /^Edit$/i })).click();
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Secrets \(comma-separated/i)).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText(/Plugins \(comma-separated/i)).toBeInTheDocument();
   });
 
-  it("drops the Secrets column from the list", async () => {
+  it("drops the Secrets column from the list (detail is enough)", async () => {
     mockTemplates({ name: "reviewer", description: "Code review agent", mcps: ["mycel"], secrets: [], plugins: [] });
     renderTemplates();
 
     await waitFor(() => expect(screen.getByText("reviewer")).toBeInTheDocument());
     expect(screen.queryByRole("columnheader", { name: "Secrets" })).not.toBeInTheDocument();
     expect(screen.getByRole("columnheader", { name: "MCPs" })).toBeInTheDocument();
-  });
-
-  it("still shows a secret an earlier build saved, and says it does nothing", async () => {
-    mockTemplates({
-      name: "reviewer",
-      description: "Code review agent",
-      mcps: ["mycel"],
-      secrets: ["GITHUB_TOKEN"],
-      plugins: [],
-      system_prompt: "review things",
-    });
-    renderTemplates();
-
-    await waitFor(() => expect(screen.getByText("reviewer")).toBeInTheDocument());
-    (await screen.findByText("reviewer")).click();
-
-    await waitFor(() => expect(screen.getByText("Saved but not applied")).toBeInTheDocument());
-    expect(screen.getByText("GITHUB_TOKEN")).toBeInTheDocument();
-    expect(screen.getByText(/do not receive them yet/)).toBeInTheDocument();
-  });
-
-  it("says nothing at all when a template records neither", async () => {
-    mockTemplates({
-      name: "reviewer",
-      description: "Code review agent",
-      mcps: ["mycel"],
-      secrets: [],
-      plugins: [],
-      system_prompt: "review things",
-    });
-    renderTemplates();
-
-    (await screen.findByText("reviewer")).click();
-    await waitFor(() => expect(screen.getByText("Code review agent")).toBeInTheDocument());
-    expect(screen.queryByText("Saved but not applied")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
Tracker order: **#3550** then **#3574**.

### #3550
- Spawn/restart inject vault secrets from role ∪ template
- Templates UI: editable Secrets/Plugins; remove “Saved but not applied”

### #3574
- Template editor: max_cost_usd / stuck_timeout_min
- Agent Settings: show guardrails in effect from template

Fixes #3550
Fixes #3574

## Test plan
- [x] go + web unit tests
- [ ] Create agent with vault secret + edit guardrails in UI