### PR TITLE
fix(marketplace): distinguish installed vs dispatched (#3571)

### DIFF
--- a/server/handlers/marketplace.go
+++ b/server/handlers/marketplace.go
@@ -81,10 +81,17 @@ type installRequest struct { //nolint:govet // field order matches JSON/API cont
 }
 
 // installResponse is returned on success (HTTP 200).
+//
+// Status is "installed" when the daemon completed the install itself (local
+// templates), or "dispatched" when it only sent an instruction to agents
+// (#3571). Callers must not treat dispatched as installed — that lie is how
+// failed installs used to look successful.
 // Errors lists per-agent failures so the caller can surface which agents were
 // not reached; a non-empty Errors slice alongside Dispatched>0 indicates a
 // partial success.
 type installResponse struct { //nolint:govet // field order matches API contract
+	Status     string   `json:"status"`
+	Message    string   `json:"message,omitempty"`
 	Dispatched int      `json:"dispatched"`
 	Errors     []string `json:"errors,omitempty"`
 }
@@ -144,7 +151,11 @@ func (h *MarketplaceHandler) install(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "install template: "+err.Error(), http.StatusBadGateway)
 			return
 		}
-		writeJSON(w, http.StatusOK, installResponse{Dispatched: len(req.Agents)})
+		writeJSON(w, http.StatusOK, installResponse{
+			Status:     "installed",
+			Message:    "Template written to the local store.",
+			Dispatched: len(req.Agents),
+		})
 		return
 	}
 
@@ -173,7 +184,12 @@ func (h *MarketplaceHandler) install(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, installResponse{Dispatched: dispatched, Errors: sendErrs})
+	writeJSON(w, http.StatusOK, installResponse{
+		Status:     "dispatched",
+		Message:    fmt.Sprintf("Install instruction sent to %d agent(s). Outcome is not verified yet.", dispatched),
+		Dispatched: dispatched,
+		Errors:     sendErrs,
+	})
 }
 
 // installTemplate upserts a template the daemon already holds. Only the local

--- a/server/handlers/marketplace_test.go
+++ b/server/handlers/marketplace_test.go
@@ -168,6 +168,9 @@ func TestMarketplaceHandler_Install_DispatchesToAgents(t *testing.T) {
 	if resp.Dispatched != 2 {
 		t.Errorf("want dispatched=2, got %d", resp.Dispatched)
 	}
+	if resp.Status != "dispatched" {
+		t.Errorf("want status=dispatched, got %q", resp.Status)
+	}
 	if len(sender.calls) != 2 {
 		t.Fatalf("want 2 Send calls, got %d", len(sender.calls))
 	}
@@ -499,6 +502,9 @@ func TestMarketplaceHandler_Install_TemplateWritesToStoreDirectly(t *testing.T) 
 	}
 	if resp.Dispatched != 1 {
 		t.Errorf("want dispatched=1, got %d", resp.Dispatched)
+	}
+	if resp.Status != "installed" {
+		t.Errorf("want status=installed for local template, got %q", resp.Status)
 	}
 
 	got, prompt, err := store.Get("engineer")

--- a/web/src/views/Marketplace.tsx
+++ b/web/src/views/Marketplace.tsx
@@ -126,7 +126,7 @@ async function fetchAgents(): Promise<Agent[]> {
 async function sendInstall(
   item: MarketplaceItem,
   agents: string[],
-): Promise<{ dispatched: number }> {
+): Promise<{ status: string; dispatched: number; message?: string }> {
   const res = await fetch("/api/marketplace/install", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -143,7 +143,7 @@ async function sendInstall(
     const text = await res.text();
     throw new Error(text || `API error: ${res.status}`);
   }
-  return res.json() as Promise<{ dispatched: number }>;
+  return res.json() as Promise<{ status: string; dispatched: number; message?: string }>;
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────────
@@ -275,7 +275,7 @@ function FilterSelect({ value, options, onChange }: FilterSelectProps) {
 interface InlineAgentPickerProps {
   item: MarketplaceItem;
   onDismiss: () => void;
-  onSent: (count: number) => void;
+  onSent: (result: { status: string; dispatched: number; message?: string }) => void;
 }
 
 function InlineAgentPicker({
@@ -326,7 +326,7 @@ function InlineAgentPicker({
     setError(null);
     try {
       const result = await sendInstall(item, Array.from(selected));
-      onSent(result.dispatched);
+      onSent(result);
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : "Unknown error");
       setSending(false);
@@ -411,19 +411,30 @@ function isRawUrl(s: string): boolean {
 
 function ItemCard({ item }: { item: MarketplaceItem }) {
   const [showPicker, setShowPicker] = useState(false);
-  const [sentCount, setSentCount] = useState<number | null>(null);
+  const [outcome, setOutcome] = useState<{
+    status: string;
+    dispatched: number;
+    message?: string;
+  } | null>(null);
 
-  function handleSent(count: number) {
+  function handleSent(result: { status: string; dispatched: number; message?: string }) {
     setShowPicker(false);
-    setSentCount(count);
+    setOutcome(result);
     // Clear confirmation after 4 s so the button is reusable.
-    setTimeout(() => setSentCount(null), 4000);
+    setTimeout(() => setOutcome(null), 4000);
   }
 
   // Only render a description when there is meaningful text (not a raw URL —
   // the source badge already implies the repo).
   const showDescription =
     !!item.description && !isRawUrl(item.description);
+
+  const outcomeLabel =
+    outcome == null
+      ? null
+      : outcome.status === "installed"
+        ? "Installed"
+        : `Instruction sent to ${outcome.dispatched} agent${outcome.dispatched !== 1 ? "s" : ""}`;
 
   return (
     <motion.div
@@ -459,9 +470,14 @@ function ItemCard({ item }: { item: MarketplaceItem }) {
 
         {/* Add button + inline picker */}
         <div className="relative shrink-0">
-          {sentCount !== null ? (
-            <span className="text-[10px] text-mycel-success whitespace-nowrap">
-              Sent to {sentCount} agent{sentCount !== 1 ? "s" : ""}
+          {outcomeLabel ? (
+            <span
+              className={`text-[10px] whitespace-nowrap ${
+                outcome?.status === "installed" ? "text-mycel-success" : "text-mycel-muted"
+              }`}
+              title={outcome?.message}
+            >
+              {outcomeLabel}
             </span>
           ) : (
             <button


### PR DESCRIPTION
## Summary
Marketplace turn after #3453:

- API returns `status`: `installed` (local template write) or `dispatched` (instruction sent to agents)
- UI shows **Installed** only for the first; otherwise **Instruction sent to N agents**
- Message explains that dispatch outcome is not verified yet

Fixes #3571

## Test plan
- [x] `go test ./server/handlers/ -run Marketplace`
- [x] `tsc -b`
- [ ] Install a local mycel template → “Installed”
- [ ] Add a skill/MCP to an agent → “Instruction sent…”, not Installed


Made with [Cursor](https://cursor.com)