### PR TITLE
fix(desktop): refuse Wails default W icon (#3605)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,10 @@ jobs:
         shell: bash
         run: go install github.com/wailsapp/wails/v2/cmd/wails@v2.13.0
 
+      - name: Guard desktop app icon
+        # Wails substitutes its default "W" when appicon.png is missing (#3605).
+        run: sh scripts/check-desktop-icon.sh
+
       - name: Build desktop app
         shell: bash
         working-directory: desktop
@@ -263,6 +267,10 @@ jobs:
               # darwin/amd64 cross-builds on Apple Silicon runners; others are native
               wails build -platform "$PLATFORM" -ldflags "$LDFLAGS" ;;
           esac
+
+      - name: Verify packaged darwin icon
+        if: matrix.os == 'darwin'
+        run: sh scripts/check-desktop-icon.sh --packaged
 
       # ── macOS code-signing + notarization (gated on secrets) ───────────
       # An unsigned .app is refused by Gatekeeper on every machine but the one

--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,13 @@ build-local-mycel: build-local-web ## Build mycel (embeds web UI, server)
 # About This Mac while the binary inside reports the true version. The release
 # workflow does the same substitution.
 build-local-desktop: build-local-web ## Build desktop app for the host OS (requires wails CLI)
+	# Refuse the silent Wails "W" fallback when appicon.png is missing (#3605).
+	sh scripts/check-desktop-icon.sh
 	cd desktop && cp wails.json wails.json.orig && \
 		trap 'mv -f wails.json.orig wails.json' EXIT INT TERM && \
 		sed -i.bak 's/"productVersion": "[^"]*"/"productVersion": "$(VERSION_CORE)"/' wails.json && rm -f wails.json.bak && \
 		wails build -ldflags "$(LDFLAGS_VERSION) $(LDFLAGS_GMAIL)"
+	sh scripts/check-desktop-icon.sh --packaged
 
 
 # =============================================================================

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -134,11 +134,16 @@ Windows code-signing is a separate certificate (EV/OV code-signing cert
 from a CA) and is **not wired up yet** — a future addition once the cert is
 procured.
 
+## App icon
+
+The Dock / Finder icon comes from `build/appicon.png` (source: `appicon.svg`).
+If that PNG is missing, Wails silently ships its default **"W"** mark — see
+`#3605`. `make build-local-desktop` and the release desktop job run
+`scripts/check-desktop-icon.sh` so that fallback fails the build instead.
+
 ## Follow-ups
 
 - System tray with Open/Quit — Wails v2 has no tray support; revisit on
   Wails v3 or add a platform tray library.
-- Replace the placeholder spore icon (`build/appicon.svg` → `appicon.png`)
-  with final branding.
 - Windows code-signing (needs an EV/OV cert) and Windows arm64 build.
 - Linux packaging (deb/rpm/AppImage).

--- a/desktop/build/darwin/Info.plist
+++ b/desktop/build/darwin/Info.plist
@@ -8,7 +8,7 @@
         <key>CFBundleExecutable</key>
         <string>{{.OutputFilename}}</string>
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{safeBundleID .Name}}</string>
+        <string>com.mycel.{{safeBundleID .Name}}</string>
         <key>CFBundleVersion</key>
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>
@@ -48,7 +48,7 @@
           {{range .Info.Protocols}}
             <dict>
                 <key>CFBundleURLName</key>
-                <string>com.wails.{{.Scheme}}</string>
+                <string>com.mycel.{{.Scheme}}</string>
                 <key>CFBundleURLSchemes</key>
                 <array>
                     <string>{{.Scheme}}</string>

--- a/scripts/check-desktop-icon.sh
+++ b/scripts/check-desktop-icon.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+# check-desktop-icon.sh — refuse to ship a desktop build that fell back to the
+# Wails default "W" icon.
+#
+# Wails' buildassets.ReadFile silently writes its embedded default appicon.png
+# (the black-on-white "W") when desktop/build/appicon.png is missing, then
+# encodes that into iconfile.icns. A local make build-local-desktop can
+# therefore produce a Dock icon that looks nothing like mycel, while the
+# committed mushroom PNG is still sitting in git (#3605).
+#
+# Usage:
+#   check-desktop-icon.sh              verify source appicon.png only
+#   check-desktop-icon.sh --packaged   also verify the packaged darwin icns
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)
+APPICON="$ROOT/desktop/build/appicon.png"
+# Content hash of github.com/wailsapp/wails/v2@v2.13.0/pkg/buildassets/build/appicon.png
+WAILS_DEFAULT_PNG_MD5=ea40194a9e0523b4be1d45f1378106bc
+# icns produced by jackmordaunt/icns@v1.0.0 from that default PNG
+WAILS_DEFAULT_ICNS_MD5=0a5f5a572786d23927d843c6f1dd5eb9
+
+md5_of() {
+	if command -v md5 >/dev/null 2>&1; then
+		md5 -q "$1"
+	else
+		md5sum "$1" | awk '{print $1}'
+	fi
+}
+
+if [ ! -f "$APPICON" ]; then
+	echo "error: missing $APPICON" >&2
+	echo "Wails will silently substitute its default \"W\" icon. Restore the mycel mushroom PNG from git." >&2
+	exit 1
+fi
+
+png_md5=$(md5_of "$APPICON")
+if [ "$png_md5" = "$WAILS_DEFAULT_PNG_MD5" ]; then
+	echo "error: $APPICON is the Wails default \"W\" icon ($png_md5)" >&2
+	echo "Replace it with the mycel mushroom mark (desktop/build/appicon.svg → appicon.png)." >&2
+	exit 1
+fi
+
+if [ "${1:-}" = "--packaged" ]; then
+	icns=""
+	for candidate in \
+		"$ROOT/desktop/build/bin/mycel.app/Contents/Resources/iconfile.icns" \
+		"$ROOT/desktop/build/bin/mycel-desktop.app/Contents/Resources/iconfile.icns"
+	do
+		if [ -f "$candidate" ]; then
+			icns=$candidate
+			break
+		fi
+	done
+	if [ -z "$icns" ]; then
+		echo "error: packaged iconfile.icns not found under desktop/build/bin/*.app" >&2
+		exit 1
+	fi
+	icns_md5=$(md5_of "$icns")
+	if [ "$icns_md5" = "$WAILS_DEFAULT_ICNS_MD5" ]; then
+		echo "error: packaged $icns is the Wails default \"W\" icns ($icns_md5)" >&2
+		echo "desktop/build/appicon.png was missing or wrong at package time (#3605)." >&2
+		exit 1
+	fi
+	echo "desktop icon ok (png=$png_md5 icns=$icns_md5)"
+else
+	echo "desktop appicon.png ok ($png_md5)"
+fi


### PR DESCRIPTION
## Summary
- Fail `make build-local-desktop` / release desktop builds when `appicon.png` is missing or is the stock Wails **"W"** (the silent fallback that produced the Dock icon on local 0.4.6).
- Post-package check on darwin that `iconfile.icns` is not the known Wails-default hash.
- Bundle id `com.wails.mycel` → `com.mycel.mycel` so Finder/Dock stop advertising stock Wails branding.

Fixes #3605. Part of #3560.

## Context
Published **v0.4.5** zip already has the mushroom; `/Applications/mycel.app` on this machine was a local 0.4.6 build packaged without `appicon.png`.

## Test plan
- [x] `sh scripts/check-desktop-icon.sh` passes on committed mushroom PNG
- [x] Local `wails build` with PNG present → packaged icns MD5 ≠ Wails default; `check-desktop-icon.sh --packaged` passes
- [ ] CI release desktop job runs the new guard steps (next tagged release)
- [ ] After install: Dock shows mushroom (may need `killall Dock` if macOS caches the old icon)