### PR TITLE
feat(templates): ship #3558 starter persona builtins

### DIFF
--- a/pkg/template/builtins.go
+++ b/pkg/template/builtins.go
@@ -18,11 +18,10 @@ import (
 // the same layout the store writes, so adding one is adding two files and
 // reviewing one is reading the prompt a user would read.
 //
-// The metadata only sets fields that something actually honors: description,
-// mcps, and the two guardrails enforced in server/guardrails.go. Secrets,
-// plugins, tool policies and context files are accepted by the API and not yet
-// applied to agents, so a built-in that set them would be making the same
-// promise the template editor was removed for (#3550).
+// Metadata that ships must be fields the daemon honors: description, label,
+// provider, composes, mcps, secrets, plugins, and guardrails (#3550 / #3558).
+// Tool policies, context files, and system_prompt_file stay off built-ins
+// until something actually reads them (#3575).
 //
 //go:embed builtins/*.json builtins/*.md
 var builtinFS embed.FS
@@ -254,10 +253,10 @@ func EnsureBuiltins(dir string) ([]string, error) {
 }
 
 // WithdrawnBuiltins returns names that used to ship and must not return.
-// The 35 task-prompt templates from v0.4.5 are withdrawn in #3552; only
-// blank remains embedded as a thin single-agent starting point. Names stay
-// listed here so EnsureBuiltins can remove unedited copies from existing
-// workspaces after the embed files are gone.
+// The 35 task-prompt templates from v0.4.5 are withdrawn in #3552. blank plus
+// the #3558 starter personas ship instead. Names stay listed here so
+// EnsureBuiltins can remove unedited copies from existing workspaces after
+// the embed files are gone.
 //
 //nolint:misspell // "archaeologist" is the historical shipped template name
 func WithdrawnBuiltins() []string {

--- a/pkg/template/builtins/engineering-team.json
+++ b/pkg/template/builtins/engineering-team.json
@@ -1,0 +1,6 @@
+{
+  "description": "Multi-agent engineering setup: engineer + testing + product",
+  "label": "multi-agent",
+  "composes": ["software-engineer", "software-testing", "product-manager"],
+  "mcps": ["mycel"]
+}

--- a/pkg/template/builtins/engineering-team.md
+++ b/pkg/template/builtins/engineering-team.md
@@ -1,0 +1,6 @@
+# Engineering Team
+
+This blueprint expands into three agents: **software-engineer**,
+**software-testing**, and **product-manager**. Creating it provisions the
+team; missing credentials degrade the affected agents rather than blocking
+the rest.

--- a/pkg/template/builtins/product-manager.json
+++ b/pkg/template/builtins/product-manager.json
@@ -1,0 +1,8 @@
+{
+  "description": "Turns goals into scoped specs and acceptance criteria",
+  "label": "single-agent",
+  "provider": "claude",
+  "mcps": ["mycel"],
+  "max_cost_usd": 20,
+  "stuck_timeout_min": 30
+}

--- a/pkg/template/builtins/product-manager.md
+++ b/pkg/template/builtins/product-manager.md
@@ -1,0 +1,10 @@
+# Product Manager
+
+You turn goals into clear specs: problem, users, scope, acceptance criteria,
+and cut lines. You do not write production code unless asked.
+
+## Operating rules
+- Prefer one page of sharp criteria over long vision docs.
+- Call out open questions and who must answer them.
+- Hand implementation work to engineering agents via mycel with enough
+  detail that they do not have to re-discover the brief.

--- a/pkg/template/builtins/software-engineer.json
+++ b/pkg/template/builtins/software-engineer.json
@@ -1,0 +1,9 @@
+{
+  "description": "Implements features and fixes in the workspace repo",
+  "label": "single-agent",
+  "provider": "claude",
+  "mcps": ["mycel"],
+  "secrets": ["GITHUB_TOKEN"],
+  "max_cost_usd": 50,
+  "stuck_timeout_min": 45
+}

--- a/pkg/template/builtins/software-engineer.md
+++ b/pkg/template/builtins/software-engineer.md
@@ -1,0 +1,12 @@
+# Software Engineer
+
+You implement features and bug fixes in this repository. Prefer small,
+reviewable changes. Run the project's usual tests and linters before you
+claim done.
+
+## Operating rules
+- Match existing code style; do not drive-by refactor.
+- Open or update a PR when the workspace workflow expects one.
+- Use mycel to coordinate with sibling agents on an engineering team.
+- If GitHub credentials are missing, still write the code and say what you
+  could not push or open.

--- a/pkg/template/builtins/software-testing.json
+++ b/pkg/template/builtins/software-testing.json
@@ -1,0 +1,8 @@
+{
+  "description": "Writes and runs tests; reports coverage gaps and regressions",
+  "label": "single-agent",
+  "provider": "claude",
+  "mcps": ["mycel"],
+  "max_cost_usd": 30,
+  "stuck_timeout_min": 45
+}

--- a/pkg/template/builtins/software-testing.md
+++ b/pkg/template/builtins/software-testing.md
@@ -1,0 +1,10 @@
+# Software Testing
+
+You own test quality for this repo: add missing coverage, reproduce bugs with
+regressions, and keep CI honest.
+
+## Operating rules
+- Prefer the project's existing test runner and style.
+- A failing test that documents a real bug is useful; flaky tests are not.
+- Pair with the software-engineer agent via mycel when a fix is needed.
+- Report what you ran and what still lacks coverage.

--- a/pkg/template/builtins/trade-analyst.json
+++ b/pkg/template/builtins/trade-analyst.json
@@ -1,0 +1,9 @@
+{
+  "description": "Market and trade analysis companion — research, risk notes, no execution",
+  "label": "single-agent",
+  "provider": "claude",
+  "mcps": ["mycel"],
+  "secrets": ["KITE_API_KEY"],
+  "max_cost_usd": 15,
+  "stuck_timeout_min": 30
+}

--- a/pkg/template/builtins/trade-analyst.md
+++ b/pkg/template/builtins/trade-analyst.md
@@ -1,0 +1,11 @@
+# Trade Analyst
+
+You analyse markets and trades. You do **not** place orders. Your job is
+research notes, risk framing, and clear recommendations the Trader (or a
+human) can act on.
+
+## Operating rules
+- Separate facts, assumptions, and recommendations.
+- Call out data gaps and stale prices explicitly.
+- Prefer short structured notes over long prose.
+- Coordinate with other agents through mycel channels when asked.

--- a/pkg/template/builtins/trader.json
+++ b/pkg/template/builtins/trader.json
@@ -1,0 +1,9 @@
+{
+  "description": "Executes and monitors trades; reports over Telegram when wired",
+  "label": "single-agent",
+  "provider": "claude",
+  "mcps": ["mycel"],
+  "secrets": ["KITE_API_KEY", "TELEGRAM_BOT_TOKEN"],
+  "max_cost_usd": 25,
+  "stuck_timeout_min": 20
+}

--- a/pkg/template/builtins/trader.md
+++ b/pkg/template/builtins/trader.md
@@ -1,0 +1,18 @@
+# Trader
+
+You are a trading operator agent. You execute and monitor trades, keep a clear
+audit of what you did, and report status over Telegram when that app is
+connected.
+
+## Operating rules
+- Never place a trade without an explicit human confirmation in the channel
+  that owns the risk, unless the human has already set a standing instruction
+  in this workspace.
+- Prefer dry-run / paper modes when credentials or venue access look incomplete.
+- When a required secret is missing, say so plainly and keep working on what
+  you can (research, checklists, post-mortems) rather than inventing fills.
+- Use the mycel MCP for agent coordination, status, and channel messages.
+
+## Reporting
+- Summarize positions, PnL, and open risk in short messages.
+- Escalate stuck or ambiguous venue errors instead of retrying blindly.

--- a/pkg/template/builtins/travel-agent.json
+++ b/pkg/template/builtins/travel-agent.json
@@ -1,0 +1,9 @@
+{
+  "description": "Plans itineraries and follows up on WhatsApp / chat when wired",
+  "label": "single-agent",
+  "provider": "claude",
+  "mcps": ["mycel"],
+  "secrets": ["TELEGRAM_BOT_TOKEN"],
+  "max_cost_usd": 20,
+  "stuck_timeout_min": 30
+}

--- a/pkg/template/builtins/travel-agent.md
+++ b/pkg/template/builtins/travel-agent.md
@@ -1,0 +1,11 @@
+# Travel Agent
+
+You plan trips end-to-end: itinerary, bookings checklist, and follow-ups on
+the messaging channel the human uses (Telegram/WhatsApp when connected).
+
+## Operating rules
+- Confirm budget, dates, and hard constraints before booking steps.
+- Never spend money or complete a paid booking without explicit confirmation.
+- Keep an itinerary the human can skim on a phone.
+- When credentials or booking sites are unavailable, produce a ready-to-book
+  checklist instead of pretending the reservation exists.

--- a/pkg/template/builtins_test.go
+++ b/pkg/template/builtins_test.go
@@ -11,9 +11,27 @@ import (
 
 func TestBuiltinsAreWellFormed(t *testing.T) {
 	names := BuiltinNames()
-	// #3552: only blank ships; the rest are withdrawn.
-	if len(names) != 1 || names[0] != "blank" {
-		t.Fatalf("expected only blank to ship, got %v", names)
+	want := map[string]bool{
+		"blank":             true,
+		"engineering-team":  true,
+		"product-manager":   true,
+		"software-engineer": true,
+		"software-testing":  true,
+		"trade-analyst":     true,
+		"trader":            true,
+		"travel-agent":      true,
+	}
+	if len(names) != len(want) {
+		t.Fatalf("expected %d shipped built-ins, got %d: %v", len(want), len(names), names)
+	}
+	for _, name := range names {
+		if !want[name] {
+			t.Fatalf("unexpected built-in %q (shipped=%v)", name, names)
+		}
+		delete(want, name)
+	}
+	if len(want) > 0 {
+		t.Fatalf("missing shipped built-ins %v", want)
 	}
 
 	for _, name := range names {
@@ -30,20 +48,49 @@ func TestBuiltinsAreWellFormed(t *testing.T) {
 		if len(tmpl.MCPs) == 0 {
 			t.Errorf("built-in %q declares no MCPs", name)
 		}
-		if tmpl.Label != "single-agent" {
-			t.Errorf("built-in %q label = %q, want single-agent", name, tmpl.Label)
+		if err := tmpl.Validate(); err != nil {
+			t.Errorf("built-in %q Validate: %v", name, err)
 		}
-		_ = prompt // blank may be empty by design
-
-		// Fields the daemon accepts and does not yet apply must stay empty, or a
-		// built-in would make exactly the promise the template editor stopped
-		// making (#3550).
-		if len(tmpl.Secrets) > 0 || len(tmpl.Plugins) > 0 {
-			t.Errorf("built-in %q sets secrets/plugins, which are not applied to agents yet", name)
+		switch tmpl.Label {
+		case LabelSingleAgent, LabelMultiAgent:
+		default:
+			t.Errorf("built-in %q label = %q, want single-agent or multi-agent", name, tmpl.Label)
 		}
+		if len(tmpl.Composes) > 0 && tmpl.Label != LabelMultiAgent {
+			t.Errorf("built-in %q composes %v but label=%q", name, tmpl.Composes, tmpl.Label)
+		}
+		if name != "blank" && name != "engineering-team" && strings.TrimSpace(prompt) == "" {
+			t.Errorf("built-in %q has an empty prompt", name)
+		}
+		// Fields nothing reads must stay empty (#3575).
 		if tmpl.ToolPolicies != nil || len(tmpl.ContextFiles) > 0 || tmpl.SystemPromptFile != "" {
 			t.Errorf("built-in %q sets a field nothing reads", name)
 		}
+	}
+}
+
+func TestEngineeringTeamExpandsToLeafPersonas(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := EnsureBuiltins(dir); err != nil {
+		t.Fatalf("EnsureBuiltins: %v", err)
+	}
+	got, err := Expand(NewStore(dir), "engineering-team")
+	if err != nil {
+		t.Fatalf("Expand: %v", err)
+	}
+	want := map[string]bool{
+		"software-engineer": true,
+		"software-testing":  true,
+		"product-manager":   true,
+	}
+	if len(got.Leaves) != len(want) {
+		t.Fatalf("leaves=%v, want %d entries", got.Leaves, len(want))
+	}
+	for _, leaf := range got.Leaves {
+		if !want[leaf] {
+			t.Fatalf("unexpected leaf %q in %v", leaf, got.Leaves)
+		}
+		delete(want, leaf)
 	}
 }
 
@@ -53,8 +100,8 @@ func TestWithdrawnBuiltinsListsTheRetiredTaskPrompts(t *testing.T) {
 		t.Fatalf("expected the retired library listed for withdraw, got %d", len(got))
 	}
 	for _, n := range got {
-		if n == "blank" {
-			t.Fatal("blank must keep shipping; it is not withdrawn")
+		if n == "blank" || n == "trader" || n == "engineering-team" {
+			t.Fatalf("%q must keep shipping; it is not withdrawn", n)
 		}
 	}
 	// Spot-check names that CreateAgentModal used to hardcode.


### PR DESCRIPTION
## Summary
Ships the #3558 starter set as embedded builtins (alongside `blank`):

- `trader`, `trade-analyst`, `travel-agent`
- `software-engineer`, `software-testing`, `product-manager`
- `engineering-team` — multi-agent blueprint that **composes** the three eng leaves

Declared secrets (`KITE_API_KEY`, `TELEGRAM_BOT_TOKEN`, `GITHUB_TOKEN` where relevant) so create-degraded can report missing credentials. Every leaf keeps working `mycel` MCP. No invented MCP stubs for venues that are not on the machine.

Part of #3558. Part of #3560.

## Test plan
- [x] `go test ./pkg/template/` — well-formed builtins, expand of `engineering-team`, EnsureBuiltins
- [ ] After merge: `EnsureBuiltins` on a workspace lists the new names; create `engineering-team` spawns three agents; create `trader` without secrets shows degraded/`missing_secrets`
- [ ] swift-fox: SBTM + screenshots on #3560


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in templates for engineering teams, product management, software engineering, software testing, trade analysis, trading, and travel planning.
  * Added a multi-agent Engineering Team template combining engineering, testing, and product-management roles.
  * Added role-specific guidance for responsibilities, collaboration, safety, reporting, research, trip planning, and approval workflows.
  * Templates support configured provider settings, service integrations, credential requirements, spending limits, and inactivity timeouts.
* **Documentation**
  * Clarified supported template fields and the status of shipped and withdrawn templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->