### PR TITLE
feat(marketplace): install Claude skills into local plugins registry (#3016)

### DIFF
--- a/pkg/marketplace/plugins.go
+++ b/pkg/marketplace/plugins.go
@@ -1,0 +1,128 @@
+package marketplace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rpuneet/mycel/pkg/home"
+)
+
+const (
+	// OfficialClaudePluginSource is what ClaudeConfigAdapter.SetupPlugins
+	// writes into installed_plugins.json for blueprint Plugins entries.
+	OfficialClaudePluginSource = "claude-plugins-official"
+
+	pluginsFileName = "plugins.json"
+)
+
+// InstalledPlugin is one skill/plugin the daemon recorded locally so
+// blueprints can reference it without dispatching prose to an agent (#3016).
+type InstalledPlugin struct {
+	Name        string    `json:"name"`
+	Source      string    `json:"source"`
+	URL         string    `json:"url,omitempty"`
+	Description string    `json:"description,omitempty"`
+	InstalledAt time.Time `json:"installed_at"`
+}
+
+type pluginsFile struct {
+	Plugins []InstalledPlugin `json:"plugins"`
+}
+
+// GlobalPluginsPath returns ~/.mycel/plugins.json.
+func GlobalPluginsPath() (string, error) {
+	root, err := home.MycelHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, pluginsFileName), nil
+}
+
+// ListInstalledPlugins returns plugins recorded in the global store.
+func ListInstalledPlugins() ([]InstalledPlugin, error) {
+	path, err := GlobalPluginsPath()
+	if err != nil {
+		return nil, err
+	}
+	return readPluginsFile(path)
+}
+
+// InstallClaudePlugin records an official Claude marketplace skill locally.
+// Idempotent: reinstalling the same name updates metadata and returns nil.
+func InstallClaudePlugin(name, url, description string) error {
+	name = strings.TrimSpace(name)
+	if name == "" || strings.Contains(name, "/") || strings.Contains(name, "..") ||
+		strings.Contains(name, string(filepath.Separator)) {
+		return fmt.Errorf("invalid plugin name %q", name)
+	}
+	path, err := GlobalPluginsPath()
+	if err != nil {
+		return err
+	}
+	list, err := readPluginsFile(path)
+	if err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	found := false
+	for i := range list {
+		if strings.EqualFold(list[i].Name, name) {
+			list[i].Name = name
+			list[i].Source = OfficialClaudePluginSource
+			list[i].URL = url
+			list[i].Description = description
+			list[i].InstalledAt = now
+			found = true
+			break
+		}
+	}
+	if !found {
+		list = append(list, InstalledPlugin{
+			Name:        name,
+			Source:      OfficialClaudePluginSource,
+			URL:         url,
+			Description: description,
+			InstalledAt: now,
+		})
+	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].Name < list[j].Name
+	})
+	return writePluginsFile(path, list)
+}
+
+func readPluginsFile(path string) ([]InstalledPlugin, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // path from MycelHome
+	if errorsIsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var f pluginsFile
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return f.Plugins, nil
+}
+
+func writePluginsFile(path string, list []InstalledPlugin) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(pluginsFile{Plugins: list}, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	return os.WriteFile(path, raw, 0o600)
+}
+
+func errorsIsNotExist(err error) bool {
+	return err != nil && os.IsNotExist(err)
+}

--- a/pkg/marketplace/plugins.go
+++ b/pkg/marketplace/plugins.go
@@ -22,7 +22,7 @@ const (
 
 // InstalledPlugin is one skill/plugin the daemon recorded locally so
 // blueprints can reference it without dispatching prose to an agent (#3016).
-type InstalledPlugin struct {
+type InstalledPlugin struct { //nolint:govet // JSON field order preferred over alignment
 	Name        string    `json:"name"`
 	Source      string    `json:"source"`
 	URL         string    `json:"url,omitempty"`

--- a/pkg/marketplace/plugins_test.go
+++ b/pkg/marketplace/plugins_test.go
@@ -1,0 +1,58 @@
+package marketplace
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestInstallClaudePluginRecordsAndLists(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+
+	if err := InstallClaudePlugin("pdf", "https://example.com/pdf", "PDF skill"); err != nil {
+		t.Fatalf("InstallClaudePlugin: %v", err)
+	}
+	if err := InstallClaudePlugin("pdf", "https://example.com/pdf2", "PDF skill v2"); err != nil {
+		t.Fatalf("reinstall: %v", err)
+	}
+	if err := InstallClaudePlugin("xlsx", "", "Excel"); err != nil {
+		t.Fatalf("InstallClaudePlugin xlsx: %v", err)
+	}
+
+	list, err := ListInstalledPlugins()
+	if err != nil {
+		t.Fatalf("ListInstalledPlugins: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("got %d plugins, want 2: %+v", len(list), list)
+	}
+	if list[0].Name != "pdf" || list[0].Source != OfficialClaudePluginSource {
+		t.Fatalf("first = %+v", list[0])
+	}
+	if list[0].URL != "https://example.com/pdf2" {
+		t.Fatalf("url not updated on reinstall: %q", list[0].URL)
+	}
+	if list[1].Name != "xlsx" {
+		t.Fatalf("second = %+v", list[1])
+	}
+
+	path, err := GlobalPluginsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("plugins.json missing: %v", err)
+	}
+	if filepath.Base(path) != "plugins.json" {
+		t.Fatalf("path = %q", path)
+	}
+}
+
+func TestInstallClaudePluginRejectsUnsafeNames(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+	for _, name := range []string{"", "../x", "a/b"} {
+		if err := InstallClaudePlugin(name, "", ""); err == nil {
+			t.Fatalf("expected error for name %q", name)
+		}
+	}
+}

--- a/server/handlers/marketplace.go
+++ b/server/handlers/marketplace.go
@@ -83,9 +83,10 @@ type installRequest struct { //nolint:govet // field order matches JSON/API cont
 // installResponse is returned on success (HTTP 200).
 //
 // Status is "installed" when the daemon completed the install itself (local
-// templates), or "dispatched" when it only sent an instruction to agents
-// (#3571). Callers must not treat dispatched as installed — that lie is how
-// failed installs used to look successful.
+// templates, or Claude official skills into ~/.mycel/plugins.json), or
+// "dispatched" when it only sent an instruction to agents (#3571 / #3016).
+// Callers must not treat dispatched as installed — that lie is how failed
+// installs used to look successful.
 // Errors lists per-agent failures so the caller can surface which agents were
 // not reached; a non-empty Errors slice alongside Dispatched>0 indicates a
 // partial success.
@@ -101,6 +102,8 @@ type installResponse struct { //nolint:govet // field order matches API contract
 // For TypeTemplate items with a template store wired (WithTemplateStore),
 // the install writes directly to the global template store — a
 // deterministic action that does not depend on any agent being reachable.
+// Official Claude skills (SourceClaude) are recorded the same way into
+// ~/.mycel/plugins.json so blueprints can reference them (#3016).
 // Every other item type falls back to the original behavior: composing a
 // clear install-instruction message and dispatching it to each named agent
 // via the existing AgentSender (same code path as POST /api/agents/{name}/send),
@@ -154,6 +157,24 @@ func (h *MarketplaceHandler) install(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, installResponse{
 			Status:     "installed",
 			Message:    "Template written to the local store.",
+			Dispatched: len(req.Agents),
+		})
+		return
+	}
+
+	// Official Claude skills: record locally so a blueprint Plugins entry can
+	// name them without hoping an agent runs `claude plugin install` (#3016).
+	// Other skill sources still dispatch — their install needs a CLI/repo the
+	// daemon cannot safely fetch from a browser-supplied URL.
+	if marketplace.ItemType(req.ItemType) == marketplace.TypeSkill &&
+		marketplace.Source(req.ItemSource) == marketplace.SourceClaude {
+		if err := marketplace.InstallClaudePlugin(req.ItemName, req.ItemSourceURL, ""); err != nil {
+			httpError(w, "install skill: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, installResponse{
+			Status:     "installed",
+			Message:    "Claude skill recorded in the local plugins registry. Add its name to a template's plugins list to apply it on spawn.",
 			Dispatched: len(req.Agents),
 		})
 		return

--- a/server/handlers/marketplace_test.go
+++ b/server/handlers/marketplace_test.go
@@ -144,12 +144,13 @@ func TestMarketplaceHandler_Install_DispatchesToAgents(t *testing.T) {
 	mux := http.NewServeMux()
 	h.Register(mux)
 
+	// Non-Claude skills still dispatch — only SourceClaude installs locally (#3016).
 	body := `{
-		"item_id":         "claude:fetch-tool",
+		"item_id":         "github:acme/fetch-tool",
 		"item_name":       "fetch-tool",
-		"item_source_url": "https://github.com/anthropics/skills/tree/main/skills/fetch",
+		"item_source_url": "https://github.com/acme/fetch-tool",
 		"item_type":       "skill",
-		"item_source":     "claude",
+		"item_source":     "github",
 		"agents":          ["alpha", "beta"]
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/api/marketplace/install", bytes.NewBufferString(body))
@@ -689,4 +690,45 @@ func TestComposeInstallMessage_TemplateFromElsewhereIsImportedFirst(t *testing.T
 // contains is a helper for substring checks.
 func contains(s, sub string) bool {
 	return bytes.Contains([]byte(s), []byte(sub))
+}
+
+func TestMarketplaceHandler_Install_ClaudeSkillWritesLocally(t *testing.T) {
+	t.Setenv("MYCEL_HOME", t.TempDir())
+
+	// No sender: local Claude skill install must not need an agent.
+	h := NewMarketplaceHandler(newTestAggregator(t, nil), nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	body := `{
+		"item_id": "claude:pdf",
+		"item_name": "pdf",
+		"item_type": "skill",
+		"item_source": "claude",
+		"item_source_url": "https://github.com/anthropics/skills/tree/main/skills/pdf",
+		"agents": ["alpha"]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/marketplace/install", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp installResponse
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Status != "installed" {
+		t.Fatalf("want status=installed, got %q (%s)", resp.Status, resp.Message)
+	}
+
+	list, err := marketplace.ListInstalledPlugins()
+	if err != nil {
+		t.Fatalf("ListInstalledPlugins: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "pdf" {
+		t.Fatalf("plugins = %+v", list)
+	}
 }


### PR DESCRIPTION
## Summary
Scoped #3016 slice for blueprints: installing a **Claude** marketplace skill writes `~/.mycel/plugins.json` and returns `status: installed` (same honesty model as local templates / #3571). Non-Claude skills still dispatch.

Blueprint `plugins: ["pdf"]` already reaches agents via `SetupPlugins` (#3550); this makes the marketplace the place those names come from without hoping an agent runs `claude plugin install`.

Fixes part of #3016. Part of #3560.

## Test plan
- [x] `go test ./pkg/marketplace/ ./server/handlers/ -run 'Plugin|ClaudeSkill|MarketplaceHandler_Install'`
- [ ] UI: install a Claude skill → button shows Installed; `~/.mycel/plugins.json` lists it
- [ ] Add plugin name to a template → spawn applies `installed_plugins.json`


Made with [Cursor](https://cursor.com)