### PR TITLE
fix(web): show when the daemon has no workspace (#3569)

### DIFF
--- a/server/handlers/stats.go
+++ b/server/handlers/stats.go
@@ -119,10 +119,17 @@ func (h *StatsHandler) systemInfo(w http.ResponseWriter, r *http.Request) {
 
 	hostname, _ := os.Hostname() //nolint:errcheck // best-effort
 
+	workspace := ""
+	if h.h != nil {
+		workspace = h.h.RootDir
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"hostname": hostname,
-		"os":       runtime.GOOS,
-		"arch":     runtime.GOARCH,
+		"hostname":      hostname,
+		"os":            runtime.GOOS,
+		"arch":          runtime.GOARCH,
+		"workspace":     workspace,
+		"has_workspace": workspace != "",
 	})
 }
 

--- a/server/handlers/system_info_test.go
+++ b/server/handlers/system_info_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/home"
+)
+
+func TestSystemInfoReportsWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// StatsHandler only reads RootDir — no need to bootstrap a full Home.
+	h := &home.Home{RootDir: abs}
+	sh := NewStatsHandler(nil, nil, nil, h, nil)
+	mux := http.NewServeMux()
+	sh.Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/system/info", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["has_workspace"] != true {
+		t.Fatalf("has_workspace = %v, want true", body["has_workspace"])
+	}
+	if body["workspace"] != abs {
+		t.Fatalf("workspace = %v, want %q", body["workspace"], abs)
+	}
+}
+
+func TestSystemInfoReportsNoWorkspace(t *testing.T) {
+	h := &home.Home{RootDir: ""}
+	sh := NewStatsHandler(nil, nil, nil, h, nil)
+	mux := http.NewServeMux()
+	sh.Register(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/system/info", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]any
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["has_workspace"] != false {
+		t.Fatalf("has_workspace = %v, want false", body["has_workspace"])
+	}
+	if ws, _ := body["workspace"].(string); ws != "" {
+		t.Fatalf("workspace = %q, want empty", ws)
+	}
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1483,7 +1483,14 @@ export const api = {
   /** Daemon health incl. degraded-service reasons (e.g. docker runtime fallback). */
   getHealth: () => request<HealthReport>("/health"),
 
-  getSystemInfo: () => request<{ hostname: string; os: string; arch: string }>("/system/info"),
+  getSystemInfo: () =>
+    request<{
+      hostname: string;
+      os: string;
+      arch: string;
+      workspace?: string;
+      has_workspace?: boolean;
+    }>("/system/info"),
   /** Autodetected host package managers (brew/apt/npm/…) with versions. */
   getPackageManagers: () =>
     request<PackageManagersResponse>("/system/package-managers"),

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -20,6 +20,7 @@ import { Header } from "./Header";
 import { HistoryNavButtons } from "./HistoryNavButtons";
 import { AgentNavTree } from "./AgentNavTree";
 import { SetupNudge } from "./SetupNudge";
+import { NoWorkspaceBanner } from "./NoWorkspaceBanner";
 import { SidebarToggle } from "./SidebarToggle";
 import { BrandMark } from "./BrandMark";
 import { HeaderSlotProvider, useHeaderSlotContext } from "../context/HeaderSlotContext";
@@ -1100,6 +1101,7 @@ export function Layout() {
       />
       <DegradedBanner />
       <SetupNudge />
+      <NoWorkspaceBanner />
 
       <div className="flex flex-1 min-h-0 relative">
       {mobileOpen && <div className="fixed inset-0 z-40 bg-mycel-overlay md:hidden" onClick={() => setMobileOpen(false)} />}

--- a/web/src/components/NoWorkspaceBanner.tsx
+++ b/web/src/components/NoWorkspaceBanner.tsx
@@ -1,0 +1,35 @@
+import { Link } from "react-router-dom";
+import { useWorkspace } from "../hooks/useWorkspace";
+
+/**
+ * Shown when the daemon is up but serving no workspace (#3569 leftover).
+ * Without a workspace, new agents have no default repo and the UI used to
+ * look like a working install with an empty fleet.
+ */
+export function NoWorkspaceBanner() {
+  const { loaded, hasWorkspace } = useWorkspace();
+  if (!loaded || hasWorkspace) return null;
+
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-2 px-3 py-1.5 text-[11px] bg-mycel-warning-subtle border-b border-mycel-warning text-mycel-warning"
+    >
+      <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className="shrink-0" aria-hidden>
+        <circle cx="7" cy="7" r="5.5" />
+        <path d="M7 4.2v.01M7 6.4v3.2" strokeLinecap="round" />
+      </svg>
+      <span className="truncate">
+        <span className="font-medium">No workspace.</span> This daemon is not
+        anchored to a repo — run <span className="font-mono">mycel up</span> from
+        a project directory, or open Settings for first-run setup.
+      </span>
+      <Link
+        to="/settings"
+        className="ml-auto shrink-0 underline decoration-dotted underline-offset-2 font-medium hover:opacity-80"
+      >
+        Settings
+      </Link>
+    </div>
+  );
+}

--- a/web/src/components/__tests__/Layout.test.tsx
+++ b/web/src/components/__tests__/Layout.test.tsx
@@ -21,7 +21,7 @@ function mockApi(hostname: string | null) {
     const u = String(url);
     if (u.includes("/api/system/info")) {
       if (hostname === null) return Promise.reject(new Error("network down"));
-      return jsonResponse({ hostname, os: "darwin", arch: "arm64" });
+      return jsonResponse({ hostname, os: "darwin", arch: "arm64", workspace: "/tmp/ws", has_workspace: true });
     }
     if (u.includes("/api/health")) return jsonResponse({ status: "ok" });
     return jsonResponse([]);

--- a/web/src/hooks/useWorkspace.ts
+++ b/web/src/hooks/useWorkspace.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { api } from "../api/client";
+
+export type WorkspaceInfo = {
+  workspace: string;
+  hasWorkspace: boolean;
+  loaded: boolean;
+};
+
+/**
+ * Whether the daemon is serving a real workspace directory.
+ * Empty means agents have nowhere to default their repos (#3569 leftover).
+ */
+export function useWorkspace(): WorkspaceInfo {
+  const [info, setInfo] = useState<WorkspaceInfo>({
+    workspace: "",
+    hasWorkspace: true, // optimistic until probed — avoid a flash of the empty banner
+    loaded: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getSystemInfo()
+      .then((data) => {
+        if (cancelled) return;
+        setInfo({
+          workspace: data.workspace ?? "",
+          hasWorkspace: data.has_workspace === true,
+          loaded: true,
+        });
+      })
+      .catch(() => {
+        // A probe failure must not claim "no workspace" — that would lie about
+        // a working daemon that simply could not answer this call.
+        if (!cancelled) {
+          setInfo({ workspace: "", hasWorkspace: true, loaded: true });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return info;
+}

--- a/web/src/views/Home.test.tsx
+++ b/web/src/views/Home.test.tsx
@@ -45,6 +45,17 @@ function agent(name: string, state: string) {
 function mockAgentsApi(list: ReturnType<typeof agent>[]) {
   fetchMock.mockImplementation((url: string) => {
     if (url.includes("/agents")) return jsonResponse(list);
+    // Home gates on has_workspace (#3569). Default mocks must look like a
+    // real workspace or every test collapses into the empty-state page.
+    if (url.includes("/system/info")) {
+      return jsonResponse({
+        hostname: "test",
+        os: "darwin",
+        arch: "arm64",
+        workspace: "/tmp/ws",
+        has_workspace: true,
+      });
+    }
     return jsonResponse([]);
   });
 }

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { useAgentActivity } from "../hooks/useAgentActivity";
 import { EmptyState } from "../components/EmptyState";
+import { useWorkspace } from "../hooks/useWorkspace";
 import type { FilterType } from "../components/live/liveTypes";
 import { flattenNodes, nodeMatchesSearch } from "../components/live/liveHelpers";
 import { AgentCard, AgentDrillDown } from "../components/live/LiveRenderers";
@@ -148,6 +150,8 @@ function PresenceLine({
 }
 
 export function Home() {
+  const navigate = useNavigate();
+  const { loaded: workspaceLoaded, hasWorkspace } = useWorkspace();
   const [paused, setPaused] = useState(false);
   const { activities, tasks, rawEventsRef, connected, reconnecting, eventCount, pausedCount } = useAgentActivity(undefined, { paused });
   const [typeFilter, setTypeFilter] = useState<FilterType>("all");
@@ -485,6 +489,21 @@ export function Home() {
           rawEvents={drillDownRawEvents}
           tasks={tasks}
           onBack={() => setDrillDownAgent(null)}
+        />
+      </div>
+    );
+  }
+
+  // #3569 leftover: a daemon with no workspace must not look like a working fleet.
+  if (workspaceLoaded && !hasWorkspace) {
+    return (
+      <div className="flex flex-col h-full min-h-0 p-6 items-center justify-center">
+        <EmptyState
+          icon="!"
+          title="No workspace"
+          description="This daemon is running but is not anchored to a repository. New agents have no default repo to work in. From a project directory run mycel up, or use Settings to finish first-run setup."
+          actionLabel="Open Settings"
+          onAction={() => navigate("/settings")}
         />
       </div>
     );


### PR DESCRIPTION
## Summary
The #3569 daemon half already adopts the last published workspace. What remained: when there **genuinely is no workspace**, the UI looked like a healthy empty fleet.

- `/api/system/info` now returns `workspace` + `has_workspace`
- Home shows a clear empty state
- Layout banner points at Settings / `mycel up`

Fixes the UI leftover of #3569. Part of #3560.

## Test plan
- [x] `go test ./server/handlers/ -run SystemInfo`
- [x] `bun run tsc --noEmit` in `web/`
- [ ] Boot daemon with no `--workspace` / empty publish → Home empty state + banner
- [ ] Normal `mycel up` in a repo → no banner, Home as before
- [ ] swift-fox screenshots on #3560


Made with [Cursor](https://cursor.com)