### PR TITLE
fix(templates): vault Has nil-meta + degraded badge

### DIFF
--- a/server/handlers/provision.go
+++ b/server/handlers/provision.go
@@ -28,8 +28,11 @@ func (v vaultPresence) Has(name string) bool {
 	if v.store == nil {
 		return false
 	}
-	_, err := v.store.GetMeta(name)
-	return err == nil
+	// GetMeta returns (nil, nil) when the name is absent — not an error.
+	// Treating err==nil alone as presence made every missing secret look
+	// installed, so create-degraded never recorded MissingSecrets (#3558).
+	meta, err := v.store.GetMeta(name)
+	return err == nil && meta != nil
 }
 
 // leafAgentName builds the agent name for a composed leaf under team base.

--- a/server/handlers/provision_test.go
+++ b/server/handlers/provision_test.go
@@ -1,6 +1,42 @@
 package handlers
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/secret"
+)
+
+type stubVault struct {
+	byName map[string]*secret.SecretMeta
+	err    error
+}
+
+func (s stubVault) GetMeta(name string) (*secret.SecretMeta, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.byName[name], nil
+}
+
+func TestVaultPresenceHas(t *testing.T) {
+	t.Parallel()
+	v := NewVaultPresence(stubVault{byName: map[string]*secret.SecretMeta{
+		"HAVE": {Name: "HAVE"},
+	}})
+	if !v.Has("HAVE") {
+		t.Fatal("HAVE should be present")
+	}
+	if v.Has("NEED") {
+		t.Fatal("NEED must be absent — GetMeta returns (nil, nil) for missing names")
+	}
+	if p := NewVaultPresence(nil); p != nil {
+		t.Fatal("nil store must yield nil SecretPresence")
+	}
+	if NewVaultPresence(stubVault{err: errors.New("boom")}).Has("HAVE") {
+		t.Fatal("store errors must report absent")
+	}
+}
 
 func TestLeafAgentName(t *testing.T) {
 	t.Parallel()

--- a/web/src/components/NoWorkspaceBanner.tsx
+++ b/web/src/components/NoWorkspaceBanner.tsx
@@ -21,8 +21,9 @@ export function NoWorkspaceBanner() {
       </svg>
       <span className="truncate">
         <span className="font-medium">No workspace.</span> This daemon is not
-        anchored to a repo — run <span className="font-mono">mycel up</span> from
-        a project directory, or open Settings for first-run setup.
+        anchored to a repo — from a project directory run{" "}
+        <span className="font-mono">mycel up</span>
+        {" "}(or <span className="font-mono">mycel up --workspace /path/to/repo</span>).
       </span>
       <Link
         to="/settings"

--- a/web/src/components/live/AgentCard.test.tsx
+++ b/web/src/components/live/AgentCard.test.tsx
@@ -88,4 +88,11 @@ describe("AgentCard header toolbar", () => {
     expect(tokens).toBeTruthy();
     expect(tokens.closest(".tabular-nums")).not.toBeNull();
   });
+
+  it("shows a degraded chip when template secrets were missing at create", () => {
+    renderCard(activity({ missingSecrets: ["KITE_API_KEY", "TELEGRAM_BOT_TOKEN"] }));
+    const chip = screen.getByLabelText(/Degraded — missing secrets: KITE_API_KEY, TELEGRAM_BOT_TOKEN/);
+    expect(chip).toBeTruthy();
+    expect(chip.textContent).toBe("degraded");
+  });
 });

--- a/web/src/components/live/LiveRenderers.tsx
+++ b/web/src/components/live/LiveRenderers.tsx
@@ -509,6 +509,15 @@ export const AgentCard = memo(function AgentCard({
                   <span className="tabular-nums">{errorCount}</span>
                 </span>
               )}
+              {(activity.missingSecrets?.length ?? 0) > 0 && (
+                <span
+                  className="inline-flex items-center h-[18px] px-1.5 text-[10px] font-mono font-medium text-mycel-warning border border-mycel-border bg-mycel-warning-subtle rounded leading-none"
+                  title={`Missing secrets: ${activity.missingSecrets!.join(", ")}`}
+                  aria-label={`Degraded — missing secrets: ${activity.missingSecrets!.join(", ")}`}
+                >
+                  degraded
+                </span>
+              )}
             </span>
             <span className="flex items-center gap-2 mt-0.5">
               {activity.role && activity.role !== "base" && (

--- a/web/src/components/live/liveTypes.ts
+++ b/web/src/components/live/liveTypes.ts
@@ -28,6 +28,8 @@ export interface AgentActivity {
   collapsed: boolean;
   /** Index of the currently-active subagent node in nodes[], for nesting */
   activeSubagentIdx?: number;
+  /** Template-declared secrets absent at create (#3558 create-degraded). */
+  missingSecrets?: string[];
 }
 
 export interface HookEvent {

--- a/web/src/hooks/useAgentActivity.ts
+++ b/web/src/hooks/useAgentActivity.ts
@@ -117,6 +117,7 @@ export function useAgentActivity(agentName?: string, options?: UseAgentActivityO
               lastEventTime: updatedAt > 0 && !isNaN(updatedAt) ? updatedAt : 0,
               nodes: [],
               collapsed: a.state === "stopped",
+              missingSecrets: a.missing_secrets ?? [],
             });
           }
         }

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -1271,7 +1271,18 @@ export function Agents() {
                       <RuntimeCell tool={a.tool} runtime={a.runtime_backend} model={a.model} />
                     </td>
                     <td className="px-4 py-2">
-                      <StatusBadge status={a.state} />
+                      <span className="inline-flex items-center gap-1.5">
+                        <StatusBadge status={a.state} />
+                        {(a.missing_secrets?.length ?? 0) > 0 ? (
+                          <span
+                            className="inline-flex items-center h-[18px] px-1.5 text-[10px] font-mono font-medium text-mycel-warning border border-mycel-border bg-mycel-warning-subtle rounded leading-none"
+                            title={`Missing secrets: ${a.missing_secrets!.join(", ")}`}
+                            aria-label={`Degraded — missing secrets: ${a.missing_secrets!.join(", ")}`}
+                          >
+                            degraded
+                          </span>
+                        ) : null}
+                      </span>
                     </td>
                     <td className="px-4 py-2 hidden md:table-cell whitespace-nowrap">
                       <span

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -501,7 +501,7 @@ export function Home() {
         <EmptyState
           icon="!"
           title="No workspace"
-          description="This daemon is running but is not anchored to a repository. New agents have no default repo to work in. From a project directory run mycel up, or use Settings to finish first-run setup."
+          description="This daemon is running but is not anchored to a repository. New agents have no default repo to work in. From a project directory run mycel up (or mycel up --workspace /path/to/repo)."
           actionLabel="Open Settings"
           onAction={() => navigate("/settings")}
         />


### PR DESCRIPTION
## Summary
- **Root cause of standing QA fail:** `GetMeta` returns `(nil, nil)` for missing secrets; `vaultPresence.Has` treated `err == nil` as present, so `FilterMissing` never recorded anything and agents like `qa3607-trader` stayed Idle with no degraded signal.
- Surface a **degraded** chip on Home live cards and Agents table when `missing_secrets` is set.
- Banner/Home copy no longer claims Settings can pick/anchor a workspace (CLI-only today).

## Test plan
- [x] `go test ./server/handlers/ -run TestVaultPresenceHas`
- [x] `bun run test -- src/components/live/AgentCard.test.tsx`
- [ ] Recreate trader without vault secrets → agent JSON has `missing_secrets`, Home/Agents show **degraded**
- [ ] Existing agents created before this fix keep empty `missing_secrets` until recreated

Part of #3560 / #3558

Made with [Cursor](https://cursor.com)