### PR TITLE
fix(web): MycelHome-only daemon is valid — soften #3609 banner

### DIFF
--- a/pkg/home/global.go
+++ b/pkg/home/global.go
@@ -207,17 +207,14 @@ func DaemonAddrPath() (string, error) {
 	return filepath.Join(dir, globalDaemonAddrName), nil
 }
 
-// DaemonWorkspacePath returns the path to the file recording which workspace
-// the daemon is serving (~/.mycel/run/workspace), or an empty line when it is
-// serving none.
+// DaemonWorkspacePath returns the path to the file recording which default
+// repo (if any) the daemon last published (~/.mycel/run/workspace), or an
+// empty line when it is serving MycelHome only.
 //
-// A daemon's workspace is not cosmetic: tmux session names include a hash of it
-// so two workspaces cannot collide, so a process that guesses a different
-// workspace cannot find the sessions of the agents already running. The desktop
-// app has no way to guess — launched from Finder its working directory is `/` —
-// and reading a directory it was never told about is how every agent came to be
-// listed as running and none could be attached to (#3569). Publishing it here
-// lets the next process adopt the workspace instead of inventing one.
+// After #3584, tmux session names no longer hash this path — agents are
+// mycel-<name> globally. The file remains useful so the desktop app can
+// adopt the last default repo for Create Agent prefill (#3569), not as a
+// hard requirement to run the daemon.
 func DaemonWorkspacePath() (string, error) {
 	dir, err := RunDir()
 	if err != nil {

--- a/web/src/components/NoWorkspaceBanner.tsx
+++ b/web/src/components/NoWorkspaceBanner.tsx
@@ -2,9 +2,12 @@ import { Link } from "react-router-dom";
 import { useWorkspace } from "../hooks/useWorkspace";
 
 /**
- * Shown when the daemon is up but serving no workspace (#3569 leftover).
- * Without a workspace, new agents have no default repo and the UI used to
- * look like a working install with an empty fleet.
+ * Quiet note when the daemon has no default repo for new agents.
+ *
+ * mycel up does not require a project directory — MycelHome (~/.mycel) is
+ * enough. A missing daemon "workspace" only means Create Agent will not
+ * pre-fill a repo; the agent still gets an explicit repo path. Do not tell
+ * people to re-run mycel up from a git repo (#3560 product model).
  */
 export function NoWorkspaceBanner() {
   const { loaded, hasWorkspace } = useWorkspace();
@@ -13,23 +16,22 @@ export function NoWorkspaceBanner() {
   return (
     <div
       role="status"
-      className="flex items-center gap-2 px-3 py-1.5 text-[11px] bg-mycel-warning-subtle border-b border-mycel-warning text-mycel-warning"
+      className="flex items-center gap-2 px-3 py-1.5 text-[11px] bg-mycel-surface-2 border-b border-mycel-border text-mycel-muted"
     >
       <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" className="shrink-0" aria-hidden>
         <circle cx="7" cy="7" r="5.5" />
         <path d="M7 4.2v.01M7 6.4v3.2" strokeLinecap="round" />
       </svg>
       <span className="truncate">
-        <span className="font-medium">No workspace.</span> This daemon is not
-        anchored to a repo — from a project directory run{" "}
-        <span className="font-mono">mycel up</span>
-        {" "}(or <span className="font-mono">mycel up --workspace /path/to/repo</span>).
+        <span className="font-medium text-mycel-text-2">No default repo.</span>{" "}
+        The daemon is fine — new agents need a repository path when you create
+        them (Browse on Create Agent).
       </span>
       <Link
-        to="/settings"
-        className="ml-auto shrink-0 underline decoration-dotted underline-offset-2 font-medium hover:opacity-80"
+        to="/agents"
+        className="ml-auto shrink-0 underline decoration-dotted underline-offset-2 font-medium text-mycel-text-2 hover:text-mycel-text"
       >
-        Settings
+        Agents
       </Link>
     </div>
   );

--- a/web/src/hooks/useWorkspace.ts
+++ b/web/src/hooks/useWorkspace.ts
@@ -8,8 +8,9 @@ export type WorkspaceInfo = {
 };
 
 /**
- * Whether the daemon is serving a real workspace directory.
- * Empty means agents have nowhere to default their repos (#3569 leftover).
+ * Whether the daemon has a default repo for new agents.
+ * Empty is normal — mycel up boots against MycelHome alone; agents bind
+ * their own repo paths. The quiet banner only hints at Create Agent.
  */
 export function useWorkspace(): WorkspaceInfo {
   const [info, setInfo] = useState<WorkspaceInfo>({
@@ -31,7 +32,7 @@ export function useWorkspace(): WorkspaceInfo {
         });
       })
       .catch(() => {
-        // A probe failure must not claim "no workspace" — that would lie about
+        // A probe failure must not claim "no default repo" — that would lie about
         // a working daemon that simply could not answer this call.
         if (!cancelled) {
           setInfo({ workspace: "", hasWorkspace: true, loaded: true });

--- a/web/src/views/Home.test.tsx
+++ b/web/src/views/Home.test.tsx
@@ -45,8 +45,8 @@ function agent(name: string, state: string) {
 function mockAgentsApi(list: ReturnType<typeof agent>[]) {
   fetchMock.mockImplementation((url: string) => {
     if (url.includes("/agents")) return jsonResponse(list);
-    // Home gates on has_workspace (#3569). Default mocks must look like a
-    // real workspace or every test collapses into the empty-state page.
+    // Home no longer gates on has_workspace (MycelHome-only daemons are valid).
+    // Still mock system/info so useWorkspace / Layout banners stay quiet.
     if (url.includes("/system/info")) {
       return jsonResponse({
         hostname: "test",

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { useAgentActivity } from "../hooks/useAgentActivity";
 import { EmptyState } from "../components/EmptyState";
-import { useWorkspace } from "../hooks/useWorkspace";
 import type { FilterType } from "../components/live/liveTypes";
 import { flattenNodes, nodeMatchesSearch } from "../components/live/liveHelpers";
 import { AgentCard, AgentDrillDown } from "../components/live/LiveRenderers";
@@ -150,8 +148,6 @@ function PresenceLine({
 }
 
 export function Home() {
-  const navigate = useNavigate();
-  const { loaded: workspaceLoaded, hasWorkspace } = useWorkspace();
   const [paused, setPaused] = useState(false);
   const { activities, tasks, rawEventsRef, connected, reconnecting, eventCount, pausedCount } = useAgentActivity(undefined, { paused });
   const [typeFilter, setTypeFilter] = useState<FilterType>("all");
@@ -489,21 +485,6 @@ export function Home() {
           rawEvents={drillDownRawEvents}
           tasks={tasks}
           onBack={() => setDrillDownAgent(null)}
-        />
-      </div>
-    );
-  }
-
-  // #3569 leftover: a daemon with no workspace must not look like a working fleet.
-  if (workspaceLoaded && !hasWorkspace) {
-    return (
-      <div className="flex flex-col h-full min-h-0 p-6 items-center justify-center">
-        <EmptyState
-          icon="!"
-          title="No workspace"
-          description="This daemon is running but is not anchored to a repository. New agents have no default repo to work in. From a project directory run mycel up (or mycel up --workspace /path/to/repo)."
-          actionLabel="Open Settings"
-          onAction={() => navigate("/settings")}
         />
       </div>
     );


### PR DESCRIPTION
## Summary
Product model (Puneet + swift-fox on #3560): `mycel up` does **not** need a project workspace. MycelHome is enough; repo is an agent property.

- Soft banner: **No default repo** → pick on Create Agent (not yellow “run mycel up from a project / Settings”)
- Remove Home EmptyState that blocked the fleet when `has_workspace: false`
- Correct stale `DaemonWorkspacePath` comment (tmux no longer hashes workspace)
- Follow-up feature: #3612 (Finder MycelHome picker + scan `.git`)

## Test plan
- [x] Home + Layout unit tests
- [ ] Daemon with no default repo: quiet muted banner, Home still usable, Create Agent Browse works
- [ ] Daemon started inside a git repo: no banner

Part of #3560
Closes nothing alone — pairs with #3612 for the picker.

Made with [Cursor](https://cursor.com)