### PR TITLE
chore(agents): fieldalignment follow-up for #3589

### DIFF
--- a/pkg/agent/service.go
+++ b/pkg/agent/service.go
@@ -48,11 +48,11 @@ type CreateOptions struct {
 	// Values may contain ${secret:NAME} references; they are stored
 	// verbatim and resolved against the vault at spawn time.
 	Env     map[string]string
+	EnvFile string
 	Name    string
 	Role    Role
 	Tool    string
 	Model   string // provider model identifier; empty uses the provider default
-	EnvFile string
 	Runtime string
 	Parent  string
 	Team    string
@@ -63,13 +63,13 @@ type CreateOptions struct {
 	// Recorded on the agent row so the guardrail loop can enforce the
 	// template's MaxCostUSD / StuckTimeoutMin. Empty disables guardrails.
 	Template string
-	// MissingSecrets is set when creating from a template whose declared
-	// secrets are absent (#3558 create-degraded).
-	MissingSecrets []string
 	// Task is an optional initial task (#3589). Recorded on the agent row
 	// and delivered as the first message after the bootstrap delay so the
 	// provider CLI has drawn its prompt.
 	Task string
+	// MissingSecrets is set when creating from a template whose declared
+	// secrets are absent (#3558 create-degraded).
+	MissingSecrets []string
 }
 
 // StartOptions configures agent start behavior.

--- a/pkg/agent/service_test.go
+++ b/pkg/agent/service_test.go
@@ -36,11 +36,8 @@ func (m *mockCostQuerier) AgentCostSummary(agentID string) (*CostSummary, error)
 func TestAgentService_CreateRecordsInitialTask(t *testing.T) {
 	mgr := newTestManager(t)
 	mgr.SetBootstrapDelay(time.Hour) // avoid background Send racing the assert
-	svc := NewAgentService(mgr, nil, nil)
+	_ = NewAgentService(mgr, nil, nil)
 
-	// Bypass Spawn: seed an agent the way Create would leave it, then exercise
-	// the same SetAgentTask + schedule path by calling Create's post-spawn
-	// recording through SetAgentTask (Create itself needs a real spawn).
 	mgr.agents["solo"] = &Agent{Name: "solo", Role: Role("base"), State: StateIdle, Children: []string{}}
 	if err := mgr.SetAgentTask(context.Background(), "solo", "ship #3589"); err != nil {
 		t.Fatalf("SetAgentTask: %v", err)
@@ -50,13 +47,13 @@ func TestAgentService_CreateRecordsInitialTask(t *testing.T) {
 		t.Fatalf("task = %q, want recorded on the agent row", got.Task)
 	}
 
-	// CreateOptions.Task must be a first-class field so the HTTP handler can
-	// pass the dialog's task through without another silent drop.
-	opts := CreateOptions{Name: "x", Task: "do the thing"}
+	// CreateOptions.Task must stay a first-class field so the HTTP handler
+	// can pass the dialog's task through without another silent drop.
+	var opts CreateOptions
+	opts.Task = "do the thing"
 	if opts.Task != "do the thing" {
 		t.Fatal("CreateOptions.Task missing — #3589 regresses")
 	}
-	_ = svc
 }
 
 func TestAgentService_ListWithFilters(t *testing.T) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -980,6 +980,8 @@ export const api = {
     /** Absolute path of the git repo to bind to. Empty binds to the repo the
      *  daemon was booted against. */
     repo?: string;
+    /** Optional first instruction — recorded on the agent and delivered after spawn (#3589). */
+    task?: string;
     /** Name of an existing agent to attach this one to as a child. */
     parent?: string;
     /** Environment variables for the agent. Values may hold


### PR DESCRIPTION
## Summary
Lint follow-up for #3614: CreateOptions field order + unusedwrite in test; `task` on `api.createAgent`.

## Test plan
- [x] `golangci-lint run ./pkg/agent/...`
- [x] unit test

Part of #3589

Made with [Cursor](https://cursor.com)