### PR TITLE
docs(cli): regenerate agent create reference for --task

### DIFF
--- a/docs/reference/cli/mycel_agent_create.md
+++ b/docs/reference/cli/mycel_agent_create.md
@@ -30,6 +30,7 @@ mycel agent create [name] [flags]
       --parent string     Parent agent ID
       --role string       Agent role (default: base)
       --runtime string    Runtime backend override: tmux or docker
+      --task string       Initial task recorded on the agent and delivered after spawn
       --team string       Team name (alphanumeric)
       --template string   Template name from ~/.mycel/templates/ (e.g. base, engineer)
       --tool string       Agent tool (agy, claude, codex, cursor, pi)


### PR DESCRIPTION
## Summary
- Regenerates `docs/reference/cli/mycel_agent_create.md` so it documents `--task` from #3614/#3589.
- Unblocks CI on `main` (Test job failed solely on stale CLI docs).

Part of #3560

## Test plan
- [x] Local `go run ./cmd/gendocs` produces only the `--task` line delta
- [ ] CI Test job passes “Check CLI reference docs are current”
- [ ] Remaining CI jobs green (ignore Cloudflare Pages noise if any)