### PR TITLE
fix(landing): resolve UNSIGNED mac desktop download assets

### DIFF
--- a/landing/src/app/_components/DownloadButtons.tsx
+++ b/landing/src/app/_components/DownloadButtons.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { Apple, Monitor, Terminal, Download } from "lucide-react";
 import {
   type DesktopOS,
-  desktopDownloadUrl,
   detectOS,
   useGitHubStats,
 } from "../../lib/github";
@@ -27,12 +26,11 @@ const ORDER: DesktopOS[] = ["mac", "linux", "windows"];
  * button; the other two are quiet secondary links. The curl/brew CLI install
  * lives below the fold in InstallSection as the power-user path.
  *
- * The desktop assets these point at are produced by release.yml's Wails job.
- * They 404 until the first desktop release (v0.4.0) is tagged — expected; the
- * /releases/latest/download/ URLs resolve the moment that release exists.
+ * Desktop URLs come from the latest GitHub release asset list (signed zip
+ * preferred; falls back to `*-UNSIGNED.zip` when that is what shipped).
  */
 export function DownloadButtons() {
-  const { version } = useGitHubStats();
+  const { desktopUrls } = useGitHubStats();
   // Default to mac for SSR/first paint (matches the flagship build); refine
   // to the real OS after mount so the markup is stable and hydration-safe.
   const [os, setOs] = useState<DesktopOS>("mac");
@@ -46,11 +44,12 @@ export function DownloadButtons() {
   const primary = OS_META[os];
   const PrimaryIcon = primary.icon;
   const others = ORDER.filter((o) => o !== os);
+  const unsignedMac = /UNSIGNED/.test(desktopUrls.mac);
 
   return (
     <div className="flex flex-col items-center gap-3">
       <Link
-        href={desktopDownloadUrl(os, version)}
+        href={desktopUrls[os]}
         className="group inline-flex h-12 items-center gap-2.5 rounded-lg bg-primary px-7 text-sm font-semibold text-primary-foreground shadow-[var(--btn-shadow)] transition-all hover:shadow-[0_0_24px_color-mix(in_srgb,var(--primary)_32%,transparent)] active:scale-[0.97]"
       >
         <PrimaryIcon className="h-[18px] w-[18px]" aria-hidden="true" />
@@ -68,7 +67,7 @@ export function DownloadButtons() {
           return (
             <Link
               key={o}
-              href={desktopDownloadUrl(o, version)}
+              href={desktopUrls[o]}
               className="inline-flex items-center gap-1.5 rounded-md border border-outline-variant/20 px-3 py-1.5 font-body text-xs font-medium text-on-surface-variant transition-colors hover:border-primary/30 hover:text-primary active:scale-[0.97]"
             >
               <Icon className="h-3.5 w-3.5" aria-hidden="true" />
@@ -77,6 +76,16 @@ export function DownloadButtons() {
           );
         })}
       </div>
+
+      {unsignedMac && os === "mac" ? (
+        <p className="max-w-sm text-center font-body text-xs text-on-surface-variant/80">
+          macOS build is unsigned until Developer ID signing lands. After
+          download:{" "}
+          <code className="rounded bg-surface-container px-1 py-0.5 text-[11px]">
+            xattr -dr com.apple.quarantine /path/to/mycel.app
+          </code>
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/landing/src/lib/github.ts
+++ b/landing/src/lib/github.ts
@@ -11,22 +11,83 @@ import { useEffect, useState } from "react";
  * never flashes zeros. If the API is unavailable or rate-limited, the cached
  * numbers simply stay — graceful degradation, no error UI.
  *
- * Cached fallbacks refreshed 2026-07-31 from the live API.
+ * Cached fallbacks refreshed 2026-08-05 from the live API.
  */
 export const REPO = "rpuneet/mycel";
+
+export type DesktopOS = "mac" | "linux" | "windows";
 
 export type GitHubStats = {
   stars: number;
   contributors: number;
-  version: string; // release tag, e.g. "v0.3.13"
+  version: string; // release tag, e.g. "v0.4.6"
   live: boolean; // true once real API data has replaced the fallback
+  /** Resolved desktop asset URLs for the latest release (signed preferred). */
+  desktopUrls: Record<DesktopOS, string>;
 };
+
+/**
+ * Candidate artifact names per OS, in preference order. Signed macOS builds
+ * omit the suffix; when ALLOW_UNSIGNED_MACOS ships the release, the asset is
+ * named `...-UNSIGNED.zip` so Gatekeeper refusal is visible in the filename.
+ */
+function desktopAssetCandidates(os: DesktopOS, version: string): string[] {
+  const v = version.replace(/^v/, "");
+  switch (os) {
+    case "mac":
+      return [
+        `mycel-desktop_darwin_arm64_${v}.zip`,
+        `mycel-desktop_darwin_arm64_${v}-UNSIGNED.zip`,
+      ];
+    case "linux":
+      return [`mycel-desktop_linux_amd64_${v}.tar.gz`];
+    case "windows":
+      return [`mycel-desktop_windows_amd64_${v}.zip`];
+  }
+}
+
+/** Pick the first candidate that appears in the release asset list. */
+export function pickDesktopAsset(
+  os: DesktopOS,
+  version: string,
+  assetNames: readonly string[],
+): string {
+  const candidates = desktopAssetCandidates(os, version);
+  return candidates.find((n) => assetNames.includes(n)) ?? candidates[0];
+}
+
+export function desktopUrlsFromAssets(
+  tag: string,
+  assetNames: readonly string[],
+): Record<DesktopOS, string> {
+  const base = `https://github.com/${REPO}/releases/download/${tag}`;
+  return {
+    mac: `${base}/${pickDesktopAsset("mac", tag, assetNames)}`,
+    linux: `${base}/${pickDesktopAsset("linux", tag, assetNames)}`,
+    windows: `${base}/${pickDesktopAsset("windows", tag, assetNames)}`,
+  };
+}
+
+/**
+ * Construct URLs when the asset list is unknown (SSR / offline fallback).
+ * For macOS the last candidate is the UNSIGNED name so a release that only
+ * shipped unsigned (until Developer ID lands) does not 404 from the site.
+ */
+export function desktopDownloadUrl(os: DesktopOS, version: string): string {
+  const name = desktopAssetCandidates(os, version).at(-1)!;
+  return `https://github.com/${REPO}/releases/latest/download/${name}`;
+}
 
 export const FALLBACK_STATS: GitHubStats = {
   stars: 4,
   contributors: 6,
-  version: "v0.3.13",
+  version: "v0.4.6",
   live: false,
+  desktopUrls: {
+    mac: desktopDownloadUrl("mac", "v0.4.6"),
+    linux: desktopDownloadUrl("linux", "v0.4.6"),
+    windows: desktopDownloadUrl("windows", "v0.4.6"),
+  },
 };
 
 /** Parse the total contributor count from a paginated Link header. */
@@ -68,7 +129,21 @@ export function useGitHubStats(): GitHubStats {
       }
       try {
         const rel = await fetch(`${api}/releases/latest`).then((r) => r.json());
-        if (rel.tag_name) next.version = rel.tag_name;
+        if (rel.tag_name) {
+          next.version = rel.tag_name;
+          const names = Array.isArray(rel.assets)
+            ? rel.assets.map((a: { name?: string }) => a.name).filter(Boolean)
+            : [];
+          if (names.length > 0) {
+            next.desktopUrls = desktopUrlsFromAssets(rel.tag_name, names);
+          } else {
+            next.desktopUrls = {
+              mac: desktopDownloadUrl("mac", rel.tag_name),
+              linux: desktopDownloadUrl("linux", rel.tag_name),
+              windows: desktopDownloadUrl("windows", rel.tag_name),
+            };
+          }
+        }
       } catch {
         /* keep fallback */
       }
@@ -82,36 +157,6 @@ export function useGitHubStats(): GitHubStats {
   }, []);
 
   return stats;
-}
-
-/**
- * Desktop app download URLs, keyed by OS. Built from the release artifact
- * names produced by .github/workflows/release.yml (Wails desktop build):
- *   mycel-desktop_darwin_arm64_<version>.zip
- *   mycel-desktop_linux_amd64_<version>.tar.gz
- *   mycel-desktop_windows_amd64_<version>.zip
- *
- * We use the /releases/latest/download/ redirect so a link resolves to the
- * newest tagged asset. The version is still needed because it is baked into
- * the filename; we take it from the live release tag (stripped of a leading v).
- *
- * NOTE: these 404 until the first desktop release (v0.4.0) is tagged and its
- * assets are uploaded. That is expected — the URLs are correct by construction
- * and will resolve the moment the release exists.
- */
-export type DesktopOS = "mac" | "linux" | "windows";
-
-export function desktopDownloadUrl(os: DesktopOS, version: string): string {
-  const v = version.replace(/^v/, "");
-  const base = `https://github.com/${REPO}/releases/latest/download`;
-  switch (os) {
-    case "mac":
-      return `${base}/mycel-desktop_darwin_arm64_${v}.zip`;
-    case "linux":
-      return `${base}/mycel-desktop_linux_amd64_${v}.tar.gz`;
-    case "windows":
-      return `${base}/mycel-desktop_windows_amd64_${v}.zip`;
-  }
 }
 
 /** Best-effort OS detection for choosing the primary download button. */


### PR DESCRIPTION
## Summary
- Website Mac download 404'd on v0.4.6 because assets are `mycel-desktop_darwin_arm64_0.4.6-UNSIGNED.zip` while the site hard-coded the signed name.
- Landing now reads the latest release asset list: prefer signed zip, fall back to `*-UNSIGNED.zip`.
- Shows a short quarantine tip when the Mac asset is unsigned.

Fixes the download button on mycel.dev after CD deploys.

Part of #3560
Related: #3561

## Test plan
- [x] `pickDesktopAsset` prefers signed when present, else UNSIGNED
- [x] `bun run build` + lint in `landing/`
- [ ] After merge, mycel.dev Mac button hits the UNSIGNED zip (302), not 404


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added operating-system-specific desktop download links based on available release assets.
  - Added support for unsigned macOS downloads, including instructions to remove macOS quarantine restrictions when needed.
  - Improved download availability by providing fallback links when release assets are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->