### PR TITLE
fix(templates): reject unsupported template API fields

### DIFF
--- a/server/handlers/templates.go
+++ b/server/handlers/templates.go
@@ -92,6 +92,21 @@ func (h *TemplateHandler) list(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
+		
+		// Reject unsupported fields
+		if req.ToolPolicies != nil {
+			httpError(w, "tool_policies is not yet supported", http.StatusBadRequest)
+			return
+		}
+		if len(req.ContextFiles) > 0 {
+			httpError(w, "context_files is not yet supported", http.StatusBadRequest)
+			return
+		}
+		if req.SystemPromptFile != "" {
+			httpError(w, "system_prompt_file is not yet supported", http.StatusBadRequest)
+			return
+		}
+		
 		if req.Name == "" {
 			httpError(w, "template name is required", http.StatusBadRequest)
 			return
@@ -189,6 +204,20 @@ func (h *TemplateHandler) byName(w http.ResponseWriter, r *http.Request) {
 		}
 		req.Name = name // URL name takes precedence
 
+		// Reject unsupported fields
+		if req.ToolPolicies != nil {
+			httpError(w, "tool_policies is not yet supported", http.StatusBadRequest)
+			return
+		}
+		if len(req.ContextFiles) > 0 {
+			httpError(w, "context_files is not yet supported", http.StatusBadRequest)
+			return
+		}
+		if req.SystemPromptFile != "" {
+			httpError(w, "system_prompt_file is not yet supported", http.StatusBadRequest)
+			return
+		}
+		
 		// Determine the prompt to write:
 		// - explicit string (including "") → use as-is (allows clearing the prompt)
 		// - field absent (nil) → preserve the existing prompt

--- a/server/handlers/templates.go
+++ b/server/handlers/templates.go
@@ -92,7 +92,7 @@ func (h *TemplateHandler) list(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
-		
+
 		// Reject unsupported fields
 		if req.ToolPolicies != nil {
 			httpError(w, "tool_policies is not yet supported", http.StatusBadRequest)
@@ -106,7 +106,7 @@ func (h *TemplateHandler) list(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "system_prompt_file is not yet supported", http.StatusBadRequest)
 			return
 		}
-		
+
 		if req.Name == "" {
 			httpError(w, "template name is required", http.StatusBadRequest)
 			return
@@ -217,7 +217,7 @@ func (h *TemplateHandler) byName(w http.ResponseWriter, r *http.Request) {
 			httpError(w, "system_prompt_file is not yet supported", http.StatusBadRequest)
 			return
 		}
-		
+
 		// Determine the prompt to write:
 		// - explicit string (including "") → use as-is (allows clearing the prompt)
 		// - field absent (nil) → preserve the existing prompt


### PR DESCRIPTION
Fixes #3575

## Summary
- Reject `tool_policies`, `context_files`, and `system_prompt_file` on template POST/PUT with HTTP 400 naming the field
- Stop silently storing fields the runtime never applies (stopgap until #3558 blueprints)

## Test plan
- [ ] `go test ./server/handlers/ -count=1`
- [ ] POST/PUT `/api/templates` with each unsupported field → 400 and field name in body
- [ ] Create/update without those fields still succeeds


Made with [Cursor](https://cursor.com)