### PR TITLE
fix(notify): wake agents on bot-token Slack posts via local fan-out

### DIFF
--- a/pkg/gateway/slack/slack.go
+++ b/pkg/gateway/slack/slack.go
@@ -31,6 +31,7 @@ type Adapter struct {
 	channelMap     map[string]string
 	userCache      map[string]slackUser
 	botUserID      string
+	botID          string
 	appToken       string
 	botToken       string
 	botName        string
@@ -87,6 +88,7 @@ func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification))
 		return fmt.Errorf("slack: auth test failed: %w", err)
 	}
 	a.botUserID = authResp.UserID
+	a.botID = authResp.BotID
 	a.botName = authResp.User
 	if a.botName == "" {
 		a.botName = authResp.Team
@@ -94,7 +96,7 @@ func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification))
 	a.chatMu.Lock()
 	a.connected = true
 	a.chatMu.Unlock()
-	log.Info("slack: connected", "bot_user_id", a.botUserID, "bot_name", a.botName, "team", authResp.Team)
+	log.Info("slack: connected", "bot_user_id", a.botUserID, "bot_id", a.botID, "bot_name", a.botName, "team", authResp.Team)
 
 	// Discover channels the bot is in
 	if err := a.discoverChannels(ctx); err != nil {
@@ -350,22 +352,15 @@ func (a *Adapter) handleEventsAPI(event slackevents.EventsAPIEvent, rawPayload j
 
 // handleMessageEvent processes a single message event.
 func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload json.RawMessage) {
-	// Bot-impersonation posts (subtype="bot_message" with a Username
-	// override) are how mycel agents publish to Slack via the shared
-	// bot token. We let those through so other agents — and the
-	// channel feed — see them. The notify layer's self-skip
-	// (pkg/notify/service.go) prevents the sender from receiving
-	// their own message back.
-	//
-	// CRITICAL: only honor `Username` when the event also came from
-	// our own bot user. Other apps in the same workspace can post
-	// with any `username` override they like, and treating that as
-	// agent identity would let any installed app impersonate
-	// `zen-zebra` / `lucid-meerkat`. Pinning on `ev.User == botUserID`
-	// makes the impersonation token-bound: only callers holding our
-	// own bot token can route as an agent.
+	// CRITICAL: only honor `Username` when the event also came from our own bot.
+	// Check BotID for bot_message events, User for regular messages.
 	if ev.SubType == "bot_message" {
-		if ev.User != a.botUserID || ev.Username == "" {
+		// For bot_message events, check BotID first, then fall back to User
+		botID := ev.BotID
+		if botID == "" {
+			botID = ev.User
+		}
+		if botID != a.botID || ev.Username == "" {
 			return
 		}
 	} else {
@@ -420,10 +415,10 @@ func (a *Adapter) handleMessageEvent(ev *slackevents.MessageEvent, rawPayload js
 
 	// Resolve user name + avatar. For bot_message posts the impersonation
 	// Username is the sender — the gate above already verified the
-	// event came from our own bot user, so Username is trusted.
+	// event came from our own bot, so Username is trusted.
 	sender := ev.User
 	senderAvatar := ""
-	if ev.SubType == "bot_message" && ev.User == a.botUserID && ev.Username != "" {
+	if ev.SubType == "bot_message" && (ev.BotID == a.botID || ev.User == a.botUserID) && ev.Username != "" {
 		sender = ev.Username
 	} else if a.api != nil {
 		a.chatMu.RLock()

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -478,6 +478,13 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 
 	log.Info("notify: outbound fan-out", "channel", channel, "sender", sender, "subscribers", len(subs))
 
+	// Extract mentions from content for mention_only filtering
+	mentions := extractMentions(content)
+	mentionSet := make(map[string]bool, len(mentions))
+	for _, m := range mentions {
+		mentionSet[strings.ToLower(m)] = true
+	}
+
 	// Strip platform prefix from sender for self-skip comparison
 	// Gateway messages arrive as "[slack] agent-name" but subscriptions
 	// store bare agent names.
@@ -490,6 +497,7 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 		Platform:  platform,
 		Sender:    sender,
 		Content:   content,
+		Mentions:  mentions,
 	})
 	if err != nil {
 		log.Error("notify: marshal outbound notification", "error", err)
@@ -503,10 +511,8 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 			continue
 		}
 
-		// Outbound messages don't have mentions, so mention_only subscribers
-		// won't get woken (this matches the behavior if the message came
-		// via platform echo with no @mentions).
-		if sub.MentionOnly {
+		// @mention filter: if mention_only, skip unless agent is mentioned
+		if sub.MentionOnly && !mentionSet[strings.ToLower(sub.Agent)] {
 			continue
 		}
 

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -117,11 +117,11 @@ func Automated() DispatchOption {
 	return func(o *dispatchOpts) { o.automated = true }
 }
 
-// RecordOutbound stores a message an agent sent out to a platform channel, so
-// channel history reads as a conversation rather than only the half that came
-// in. Inbound messages are stored by Dispatch; outbound ones have no dispatch
-// to hang off, because nothing needs delivering — they are already on their way
-// to the platform.
+// RecordOutbound stores a message an agent sent out to a platform channel,
+// so channel history reads as a conversation rather than only the half that came
+// in. It also delivers the message to other subscribed agents (excluding the
+// sender) because platform echoes (like Slack bot_message events) may not be
+// reliable for waking other agents.
 //
 // Called after the gateway reports a successful send. Errors are logged rather
 // than returned: the message has already left, so failing the caller's send
@@ -136,6 +136,9 @@ func (s *Service) RecordOutbound(channel, sender, content string) {
 		log.Warn("notify: save outbound message failed", "channel", channel, "sender", sender, "error", err)
 		return
 	}
+
+	// Deliver to other subscribed agents (local fan-out)
+	s.deliverOutboundToSubscribers(ctx, channel, sender, content)
 
 	// Same event shape the inbound path publishes, so an open channel view
 	// appends the message live instead of waiting for a refetch.
@@ -439,4 +442,98 @@ func (s *Service) PruneOldActivity(ctx context.Context, keepPerChannel int) erro
 		}
 	}
 	return nil
+}
+
+// deliverOutboundToSubscribers delivers an outbound message to other subscribed
+// agents (excluding the sender). Used for local fan-out when platform echoes
+// (like Slack bot_message events) may not be reliable.
+func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sender, content string) {
+	// Get subscribers for this channel
+	subs, subErr := s.store.Subscribers(ctx, channel)
+	if subErr != nil {
+		log.Warn("notify: failed to get subscribers for outbound", "channel", channel, "error", subErr)
+		return
+	}
+
+	// Extract platform from channel name (e.g., "slack:general" -> "slack")
+	platform := ""
+	if idx := strings.Index(channel, ":"); idx > 0 {
+		platform = channel[:idx]
+	}
+
+	// Fallback to catch-all subscription if no direct subscribers
+	if len(subs) == 0 && platform != "" {
+		catchAll := platform + catchAllSuffix
+		if channel != "" && channel != catchAll && strings.HasPrefix(channel, platform+":") {
+			fallback, fErr := s.store.Subscribers(ctx, catchAll)
+			if fErr != nil {
+				log.Warn("notify: catch-all lookup failed for outbound", "platform", platform, "channel", channel, "error", fErr)
+			} else if len(fallback) > 0 {
+				subs = fallback
+				log.Info("notify: delivering outbound via catch-all subscription",
+					"channel", channel, "catch_all", catchAll, "agents", len(fallback))
+			}
+		}
+	}
+
+	log.Info("notify: outbound fan-out", "channel", channel, "sender", sender, "subscribers", len(subs))
+
+	// Strip platform prefix from sender for self-skip comparison
+	// Gateway messages arrive as "[slack] agent-name" but subscriptions
+	// store bare agent names.
+	rawSender := platformPrefixRe.ReplaceAllString(sender, "")
+
+	// Create notification payload
+	payload, err := json.Marshal(Notification{
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Channel:   channel,
+		Platform:  platform,
+		Sender:    sender,
+		Content:   content,
+	})
+	if err != nil {
+		log.Error("notify: marshal outbound notification", "error", err)
+		return
+	}
+
+	// Deliver to each subscribed agent
+	for _, sub := range subs {
+		// Self-skip: don't echo agent's own message back
+		if strings.EqualFold(sub.Agent, rawSender) {
+			continue
+		}
+
+		// Outbound messages don't have mentions, so mention_only subscribers
+		// won't get woken (this matches the behavior if the message came
+		// via platform echo with no @mentions).
+		if sub.MentionOnly {
+			continue
+		}
+
+		sendErr := s.agents.Send(ctx, sub.Agent, string(payload))
+		status := StatusDelivered
+		errStr := ""
+		switch {
+		case sendErr == nil:
+			log.Info("notify: outbound delivered", "agent", sub.Agent, "channel", channel)
+		case agentOfflineRe.MatchString(sendErr.Error()):
+			// Subscribed agent was offline when the message arrived
+			log.Debug("notify: outbound delivery skipped (agent offline)", "agent", sub.Agent, "channel", channel)
+			continue
+		default:
+			status = StatusFailed
+			errStr = sendErr.Error()
+			log.Warn("notify: outbound delivery failed", "agent", sub.Agent, "channel", channel, "error", sendErr)
+		}
+
+		if logErr := s.store.LogDelivery(ctx, DeliveryEntry{
+			Channel: channel,
+			Agent:   sub.Agent,
+			Status:  status,
+			Error:   errStr,
+			Preview: truncate(content, 120),
+		}); logErr != nil {
+			log.Warn("notify: log outbound delivery failed", "error", logErr)
+		}
+	}
 }


### PR DESCRIPTION
Fixes #3616

## Summary
- Process Slack `bot_message` events so agent posts are not dropped
- Add local fan-out for outbound gateway messages so other subscribed agents wake even when Slack does not echo bot posts into Events API
- Keep fan-out limited to authenticated bot outbound paths

## Test plan
- [ ] Focused tests for notify / slack gateway packages
- [ ] Agent A posts to slack:general with bot token + @AgentB → Agent B session receives wake
- [ ] Human posts still wake agents as before
- [ ] No duplicate wakes when Events already delivers the message (if applicable)


Made with [Cursor](https://cursor.com)