### PR TITLE
fix(agy): implement transcript parsing for payload (fixes #3531)

### DIFF
--- a/pkg/agent/activity_config_test.go
+++ b/pkg/agent/activity_config_test.go
@@ -34,8 +34,8 @@ func TestWriteActivityConfigPerProvider(t *testing.T) {
 		},
 		{
 			tool: "agy",
-			want: ".agents/hooks.json",
-			why:  "agy reads lifecycle hooks from .agents/hooks.json",
+			want: "",
+			why:  "agy is tailed from its transcript and needs no cooperation (was hooks, now transcript)",
 		},
 		{
 			tool: "cursor",

--- a/pkg/provider/agy.go
+++ b/pkg/provider/agy.go
@@ -2,18 +2,20 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // AgyProvider implements the Provider interface for the Antigravity CLI
 // (`agy`), Google's terminal agent running the Gemini 3.x family. It matches
 // the Claude provider's integration depth: model selection, resume by
 // conversation ID or bare continue, dynamic + static model listing,
-// resumable-session detection, and hook-based activity reporting.
+// resumable-session detection, and activity reporting via session transcript.
 type AgyProvider struct {
 	AgyConfigAdapter // embeds ConfigAdapter implementation (.agents layout)
 	name             string
@@ -80,7 +82,7 @@ func SafeAgyModelName(model string) bool {
 
 // shellSingleQuote wraps s in single quotes for safe interpolation into a
 // shell command line, escaping any embedded single quote via the standard
-// '\” idiom. Callers must still gate the value through SafeAgyModelName; the
+// '\' idiom. Callers must still gate the value through SafeAgyModelName; the
 // escape here is defense in depth.
 func shellSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
@@ -226,26 +228,141 @@ func (p *AgyProvider) HasResumableSession(_ string) bool {
 	return false
 }
 
-// ActivityMode reports that agy emits activity via lifecycle hooks
-// (.agents/hooks.json) that POST to the daemon's hook endpoint, exactly like Claude.
-func (p *AgyProvider) ActivityMode() string { return ActivityModeHooks }
+// ActivityMode reports that agy exposes activity via an on-disk session
+// transcript the daemon tails. This is ActivityModeTranscript (not hooks)
+// because agy's hooks do not pipe JSON payload on stdin as documented.
+//
+// Fixes #3531: agy's hooks fire for state transitions but provide no payload,
+// resulting in agents showing state but no prompt/tool details. The transcript
+// approach allows full activity reporting including prompts and tool usage.
+func (p *AgyProvider) ActivityMode() string { return ActivityModeTranscript }
 
-// WriteHookConfig writes agy lifecycle-hook settings into the agent worktree.
-// daemonAddr and agentID are unused: the generated hook commands resolve the
-// daemon address and agent identity at runtime via the MYCEL_DAEMON_ADDR and
-// MYCEL_AGENT_ID environment variables set on the agent session.
-func (p *AgyProvider) WriteHookConfig(worktreeDir, _, _ string) error {
-	return WriteAgyHookSettings(worktreeDir)
+// WriteHookConfig is a no-op for agy: activity is sourced by tailing its
+// session transcript, not via hooks.
+func (p *AgyProvider) WriteHookConfig(_, _, _ string) error { return nil }
+
+// agyTranscriptsRoot resolves agy's transcript root directory. agy stores
+// session transcripts under ~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/
+var agyTranscriptsRoot = func() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".gemini", "antigravity-cli", "brain")
 }
 
-// TranscriptGlobs returns glob patterns matching the agy CLI's session
-// transcript for an agent working in cwd. The CLI writes its transcript to
-// <cwd>/.gemini/antigravity-cli/transcript.jsonl.
+// TranscriptGlobs returns glob patterns matching agy's session transcript files.
+// agy writes transcripts to ~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/transcript.jsonl
+// The cwd parameter is ignored because agy stores transcripts in a global location,
+// not per-worktree. Returns nil if cwd is empty.
 func (p *AgyProvider) TranscriptGlobs(cwd string) []string {
 	if cwd == "" {
 		return nil
 	}
-	return []string{filepath.Join(cwd, ".gemini", "antigravity-cli", "transcript.jsonl")}
+	root := agyTranscriptsRoot()
+	if root == "" {
+		return nil
+	}
+	return []string{filepath.Join(root, "*", ".system_generated", "logs", "transcript.jsonl")}
+}
+
+// agyTranscriptLine is one JSONL entry in an agy transcript file.
+type agyTranscriptLine struct {
+	StepIndex int           `json:"step_index"`
+	Source    string        `json:"source"`
+	Type      string        `json:"type"`
+	Status    string        `json:"status"`
+	CreatedAt string        `json:"created_at"`
+	Content   string        `json:"content,omitempty"`
+	Thinking  string        `json:"thinking,omitempty"`
+	ToolCalls []agyToolCall `json:"tool_calls,omitempty"`
+	Error     string        `json:"error,omitempty"`
+	ErrorCode int           `json:"error_code,omitempty"`
+}
+
+// agyToolCall represents a tool call in agy's transcript.
+type agyToolCall struct {
+	Name string `json:"name"`
+	Args any    `json:"args,omitempty"`
+}
+
+// ParseTranscriptLine turns one agy JSONL line into zero or more activity
+// events. Unrecognized or malformed lines yield (nil, nil).
+func (p *AgyProvider) ParseTranscriptLine(line []byte) ([]TranscriptActivity, error) {
+	line = []byte(strings.TrimSpace(string(line)))
+	if len(line) == 0 {
+		return nil, nil
+	}
+
+	var entry agyTranscriptLine
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return nil, nil // tolerate malformed lines mid-stream
+	}
+
+	ts, _ := time.Parse(time.RFC3339, entry.CreatedAt)
+
+	switch entry.Type {
+	case "USER_INPUT":
+		// Extract prompt from content - strip USER_REQUEST wrapper
+		prompt := extractAgyPrompt(entry.Content)
+		if prompt == "" {
+			return nil, nil
+		}
+		return []TranscriptActivity{{
+			Event:     "UserPromptSubmit",
+			Prompt:    prompt,
+			Timestamp: ts,
+		}}, nil
+
+	case "PLANNER_RESPONSE":
+		// Model planning response may include tool calls
+		if len(entry.ToolCalls) == 0 {
+			return nil, nil
+		}
+		var activities []TranscriptActivity
+		for _, tc := range entry.ToolCalls {
+			if tc.Name != "" {
+				activities = append(activities, TranscriptActivity{
+					Event:     "PreToolUse",
+					ToolName:  tc.Name,
+					ToolInput: tc.Args,
+					Timestamp: ts,
+				})
+			}
+		}
+		return activities, nil
+
+	case "RUN_COMMAND":
+		// Tool execution results - skip as we can't accurately map PostToolUse
+		// without state tracking
+		return nil, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+// extractAgyPrompt extracts the user prompt from agy's USER_INPUT content.
+// agy wraps prompts in <USER_REQUEST> tags, so we extract the inner content.
+func extractAgyPrompt(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+
+	// Extract content between <USER_REQUEST> and </USER_REQUEST>
+	if start := strings.Index(content, "<USER_REQUEST>"); start != -1 {
+		if end := strings.Index(content[start:], "</USER_REQUEST>"); end != -1 {
+			content = content[start+len("<USER_REQUEST>") : start+end]
+		}
+	}
+
+	// Strip <ADDITIONAL_METADATA> if present
+	if metaStart := strings.Index(content, "<ADDITIONAL_METADATA>"); metaStart != -1 {
+		content = strings.TrimSpace(content[:metaStart])
+	}
+
+	return strings.TrimSpace(content)
 }
 
 // Ensure AgyProvider implements all declared interfaces.
@@ -257,3 +374,4 @@ var _ SessionCustomizer = (*AgyProvider)(nil)
 var _ SessionResumer = (*AgyProvider)(nil)
 var _ ResumableSessionDetector = (*AgyProvider)(nil)
 var _ ActivitySource = (*AgyProvider)(nil)
+var _ TranscriptParser = (*AgyProvider)(nil)

--- a/pkg/provider/agy.go
+++ b/pkg/provider/agy.go
@@ -268,7 +268,6 @@ func (p *AgyProvider) TranscriptGlobs(cwd string) []string {
 
 // agyTranscriptLine is one JSONL entry in an agy transcript file.
 type agyTranscriptLine struct {
-	ToolCalls []agyToolCall `json:"tool_calls,omitempty"`
 	Source    string        `json:"source"`
 	Type      string        `json:"type"`
 	Status    string        `json:"status"`
@@ -276,6 +275,7 @@ type agyTranscriptLine struct {
 	Content   string        `json:"content,omitempty"`
 	Thinking  string        `json:"thinking,omitempty"`
 	Error     string        `json:"error,omitempty"`
+	ToolCalls []agyToolCall `json:"tool_calls,omitempty"`
 	StepIndex int           `json:"step_index"`
 	ErrorCode int           `json:"error_code,omitempty"`
 }

--- a/pkg/provider/agy.go
+++ b/pkg/provider/agy.go
@@ -268,22 +268,22 @@ func (p *AgyProvider) TranscriptGlobs(cwd string) []string {
 
 // agyTranscriptLine is one JSONL entry in an agy transcript file.
 type agyTranscriptLine struct {
-	StepIndex int           `json:"step_index"`
+	ToolCalls []agyToolCall `json:"tool_calls,omitempty"`
 	Source    string        `json:"source"`
 	Type      string        `json:"type"`
 	Status    string        `json:"status"`
 	CreatedAt string        `json:"created_at"`
 	Content   string        `json:"content,omitempty"`
 	Thinking  string        `json:"thinking,omitempty"`
-	ToolCalls []agyToolCall `json:"tool_calls,omitempty"`
 	Error     string        `json:"error,omitempty"`
+	StepIndex int           `json:"step_index"`
 	ErrorCode int           `json:"error_code,omitempty"`
 }
 
 // agyToolCall represents a tool call in agy's transcript.
 type agyToolCall struct {
-	Name string `json:"name"`
 	Args any    `json:"args,omitempty"`
+	Name string `json:"name"`
 }
 
 // ParseTranscriptLine turns one agy JSONL line into zero or more activity

--- a/pkg/provider/agy_test.go
+++ b/pkg/provider/agy_test.go
@@ -289,11 +289,11 @@ func TestAgyHasResumableSession(t *testing.T) {
 
 func TestAgyActivitySource(t *testing.T) {
 	p := NewAgyProvider()
-	if p.ActivityMode() != ActivityModeHooks {
-		t.Errorf("ActivityMode() = %q, want %q", p.ActivityMode(), ActivityModeHooks)
+	if p.ActivityMode() != ActivityModeTranscript {
+		t.Errorf("ActivityMode() = %q, want %q", p.ActivityMode(), ActivityModeTranscript)
 	}
 	globs := p.TranscriptGlobs("/wt/eng-01")
-	if len(globs) != 1 || !strings.HasSuffix(globs[0], filepath.Join(".gemini", "antigravity-cli", "transcript.jsonl")) {
+	if len(globs) != 1 || !strings.Contains(globs[0], filepath.Join("antigravity-cli", "brain")) {
 		t.Errorf("TranscriptGlobs() = %v", globs)
 	}
 	if p.TranscriptGlobs("") != nil {
@@ -541,6 +541,77 @@ func TestAgyHookCommandsAreValidBash(t *testing.T) {
 				agyHookCommand(tc.event, tc.state, tc.stdout))
 			if out, err := cmd.CombinedOutput(); err != nil {
 				t.Errorf("bash -n rejected the %s command: %v\n%s", tc.event, err, out)
+			}
+		})
+	}
+}
+
+// TestAgyParseTranscriptLine verifies agy's transcript parser correctly
+// extracts activity events from JSONL lines.
+func TestAgyParseTranscriptLine(t *testing.T) {
+	p := NewAgyProvider()
+
+	tests := []struct {
+		name    string
+		line    string
+		want    []TranscriptActivity
+		wantErr bool
+	}{
+		{
+			name: "USER_INPUT with prompt",
+			line: `{"step_index":0,"source":"USER_EXPLICIT","type":"USER_INPUT","status":"DONE","created_at":"2026-07-06T21:54:52Z","content":"<USER_REQUEST>\nHello, can you help me with this task?\n</USER_REQUEST>"}`,
+			want: []TranscriptActivity{{
+				Event:  "UserPromptSubmit",
+				Prompt: "Hello, can you help me with this task?",
+			}},
+		},
+		{
+			name: "PLANNER_RESPONSE with tool calls",
+			line: `{"step_index":3,"source":"MODEL","type":"PLANNER_RESPONSE","status":"DONE","created_at":"2026-07-06T21:55:57Z","thinking":"I'll check the file","tool_calls":[{"name":"Read","args":{"path":"/tmp/test.txt"}}]}`,
+			want: []TranscriptActivity{{
+				Event:     "PreToolUse",
+				ToolName:  "Read",
+				ToolInput: map[string]any{"path": "/tmp/test.txt"},
+			}},
+		},
+		{
+			name: "RUN_COMMAND - skipped",
+			line: `{"step_index":7,"source":"MODEL","type":"RUN_COMMAND","status":"DONE","created_at":"2026-07-06T21:56:45Z","content":"exit 0"}`,
+			want: nil,
+		},
+		{
+			name: "empty line",
+			line: "",
+			want: nil,
+		},
+		{
+			name: "invalid JSON",
+			line: "not json at all",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := p.ParseTranscriptLine([]byte(tt.line))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseTranscriptLine() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("ParseTranscriptLine() returned %d activities, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i].Event != tt.want[i].Event {
+					t.Errorf("activity[%d].Event = %q, want %q", i, got[i].Event, tt.want[i].Event)
+				}
+				if got[i].Prompt != tt.want[i].Prompt {
+					t.Errorf("activity[%d].Prompt = %q, want %q", i, got[i].Prompt, tt.want[i].Prompt)
+				}
+				if got[i].ToolName != tt.want[i].ToolName {
+					t.Errorf("activity[%d].ToolName = %q, want %q", i, got[i].ToolName, tt.want[i].ToolName)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #3531

## Problem

agy's hooks fire for state transitions (PreInvocation → working, Stop → idle) but do not provide JSON payload on stdin as documented. This results in agents showing correct state but no prompt or tool details.

## Solution

Switched agy from hooks to transcript-based activity reporting.

## Changes

- **ActivityMode**: Hooks -> Transcript
- **ParseTranscriptLine**: Implemented for agy's format:
  - USER_INPUT → extracts prompt from content (strips USER_REQUEST wrapper)
  - PLANNER_RESPONSE → extracts tool calls
  - RUN_COMMAND → skipped (no accurate PostToolUse without state tracking)
- **TranscriptGlobs**: Updated to agy's global path:
  - ~/.gemini/antigravity-cli/brain/<conversation-id>/.system_generated/logs/transcript.jsonl
- **WriteHookConfig**: No-op (like pi/codex)
- **extractAgyPrompt**: Helper to parse USER_REQUEST wrapper

## Testing

- Updated TestAgyActivitySource for transcript mode
- Added TestAgyParseTranscriptLine for transcript parsing
- Updated activity_config_test.go: agy now needs no cooperation (like pi/codex)
- All provider and agent tests pass

## Result

agy agents now get full activity reporting via transcript file, matching pi and codex.

Fixes #3531