### PR TITLE
Fix #3597: Backfill Cursor usage from events.jsonl

### DIFF
--- a/pkg/provider/cursor_costs.go
+++ b/pkg/provider/cursor_costs.go
@@ -27,6 +27,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/rpuneet/mycel/pkg/log"
 )
 
 // CursorUsageRelDir is the session subdirectory that holds Cursor usage
@@ -218,3 +220,158 @@ func readCursorUsageFile(path string) ([]CursorUsageRecord, error) {
 
 // Ensure CursorProvider implements CostReader.
 var _ CostReader = (*CursorProvider)(nil)
+
+// pendingCursorUsage holds a usage record with its agent name for batch append.
+type pendingCursorUsage struct {
+	agent string
+	rec   CursorUsageRecord
+}
+
+// CursorUsageBackfill scans the events JSONL for Cursor Stop events with token
+// counts that were recorded before AppendCursorUsage was wired, and appends them
+// to each agent's usage.jsonl. This fixes the gap where historical cursor token
+// Stops exist in events.jsonl but not in usage.jsonl (#3597).
+func CursorUsageBackfill(eventsPath, agentsDir string) (int, error) {
+	if eventsPath == "" || agentsDir == "" {
+		return 0, nil
+	}
+	f, err := os.Open(eventsPath) //nolint:gosec // reading from user's events log
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close() //nolint:errcheck
+
+	// Collect usage records per agent: agent name -> set of generation_ids already present
+	agentUsage := make(map[string]map[string]struct{})
+	ents, err := os.ReadDir(agentsDir)
+	if err != nil {
+		return 0, err
+	}
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		path := filepath.Join(agentsDir, e.Name(), CursorUsageRelDir, CursorUsageFile)
+		recs, err := readCursorUsageFile(path)
+		if err != nil || len(recs) == 0 {
+			continue
+		}
+		seen := make(map[string]struct{}, len(recs))
+		for _, rec := range recs {
+			if rec.GenerationID != "" {
+				seen[rec.GenerationID] = struct{}{}
+			}
+		}
+		agentUsage[e.Name()] = seen
+	}
+
+	// Scan events for Cursor Stop hooks with token data
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	var toAppend []pendingCursorUsage
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var evt struct {
+			Data map[string]any `json:"data"`
+			Type string         `json:"type"`
+		}
+		if err := json.Unmarshal([]byte(line), &evt); err != nil {
+			continue
+		}
+		if evt.Type != "agent.hook" {
+			continue
+		}
+		data := evt.Data
+		if data == nil {
+			continue
+		}
+		// Check if this is a Stop event with token data
+		event, _ := data["event"].(string)
+		if event != "Stop" {
+			continue
+		}
+		// Must have token data
+		inputTokens := toInt64(data["input_tokens"])
+		outputTokens := toInt64(data["output_tokens"])
+		if inputTokens == 0 && outputTokens == 0 {
+			continue
+		}
+		// Get agent name and generation_id
+		agent, _ := data["agent"].(string)
+		if agent == "" {
+			continue
+		}
+		generationID, _ := data["generation_id"].(string)
+		// Check if we already have this generation_id
+		if seen, ok := agentUsage[agent]; ok && generationID != "" {
+			if _, exists := seen[generationID]; exists {
+				continue // already recorded
+			}
+		}
+		// Build the usage record
+		rec := CursorUsageRecord{
+			GenerationID:     generationID,
+			SessionID:        toString(data["session_id"]),
+			Model:            toString(data["model"]),
+			InputTokens:      inputTokens,
+			OutputTokens:     outputTokens,
+			CacheReadTokens:  toInt64(data["cache_read_tokens"]),
+			CacheWriteTokens: toInt64(data["cache_write_tokens"]),
+		}
+		if rec.CostUSD == 0 {
+			rec.CostUSD = CursorCalcCost(rec.Model, rec.InputTokens, rec.OutputTokens, rec.CacheWriteTokens, rec.CacheReadTokens)
+		}
+		toAppend = append(toAppend, pendingCursorUsage{agent: agent, rec: rec})
+		// Track this generation_id to avoid duplicates within this run
+		if generationID != "" {
+			if _, ok := agentUsage[agent]; !ok {
+				agentUsage[agent] = make(map[string]struct{})
+			}
+			agentUsage[agent][generationID] = struct{}{}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return 0, err
+	}
+	// Append the collected records
+	appended := 0
+	for _, p := range toAppend {
+		if err := AppendCursorUsage(agentsDir, p.agent, p.rec); err != nil {
+			log.Warn("cursor backfill: failed to append usage", "agent", p.agent, "error", err)
+			continue
+		}
+		appended++
+	}
+	return appended, nil
+}
+
+func toInt64(v any) int64 {
+	if v == nil {
+		return 0
+	}
+	switch n := v.(type) {
+	case float64:
+		return int64(n)
+	case int64:
+		return n
+	case int:
+		return int64(n)
+	case string:
+		i, _ := strconv.ParseInt(n, 10, 64)
+		return i
+	}
+	return 0
+}
+
+func toString(v any) string {
+	if v == nil {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}

--- a/pkg/provider/cursor_costs_test.go
+++ b/pkg/provider/cursor_costs_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"os"
 	"path/filepath"
@@ -84,5 +85,80 @@ func TestCursorCalcCostUsesClaudePricingForClaudeModels(t *testing.T) {
 	want := ClaudeCalcCost("claude-sonnet-4", 1_000_000, 0, 0, 0)
 	if got != want {
 		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestCursorUsageBackfill(t *testing.T) {
+	// Set up test directories
+	agentsDir := t.TempDir()
+	eventsFile := filepath.Join(t.TempDir(), "events.jsonl")
+
+	// Create events.jsonl with 3 Stop events (2 will be new, 1 already exists)
+	eventsData := []string{
+		// Event 1: gen-1 (will be backfilled)
+		`{"type":"agent.hook","data":{"agent":"test-agent","event":"Stop","generation_id":"gen-1","session_id":"sess-1","model":"default","input_tokens":1000,"output_tokens":100}}`,
+		// Event 2: gen-2 (will be backfilled)
+		`{"type":"agent.hook","data":{"agent":"test-agent","event":"Stop","generation_id":"gen-2","session_id":"sess-1","model":"default","input_tokens":2000,"output_tokens":200}}`,
+		// Event 3: gen-3 (already exists, should be skipped)
+		`{"type":"agent.hook","data":{"agent":"test-agent","event":"Stop","generation_id":"gen-3","session_id":"sess-1","model":"default","input_tokens":3000,"output_tokens":300}}`,
+	}
+	f, err := os.Create(eventsFile) //nolint:gosec // test file
+	if err != nil {
+		t.Fatalf("create events file: %v", err)
+	}
+	for _, line := range eventsData {
+		_, werr := f.WriteString(line + "\n")
+		if werr != nil {
+			t.Fatalf("write event: %v", werr)
+		}
+	}
+	f.Close() //nolint:errcheck
+
+	// Create existing usage.jsonl with gen-3 already present
+	usageDir := filepath.Join(agentsDir, "test-agent", CursorUsageRelDir)
+	if merr := os.MkdirAll(usageDir, 0o750); merr != nil {
+		t.Fatalf("mkdir usage dir: %v", merr)
+	}
+	existingRec := CursorUsageRecord{
+		GenerationID: "gen-3",
+		SessionID:    "sess-1",
+		Model:        "default",
+		InputTokens:  3000,
+		OutputTokens: 300,
+	}
+	usageFile := filepath.Join(usageDir, CursorUsageFile)
+	existingData, _ := json.Marshal(existingRec)
+	if wferr := os.WriteFile(usageFile, append(existingData, '\n'), 0o600); wferr != nil { //nolint:gosec // test file
+		t.Fatalf("write existing usage: %v", wferr)
+	}
+
+	// Run backfill
+	appended, err := CursorUsageBackfill(eventsFile, agentsDir)
+	if err != nil {
+		t.Fatalf("CursorUsageBackfill: %v", err)
+	}
+	if appended != 2 {
+		t.Errorf("appended = %d, want 2 (gen-1 and gen-2)", appended)
+	}
+
+	// Read back usage.jsonl and verify 3 records exist
+	recs, err := readCursorUsageFile(usageFile)
+	if err != nil {
+		t.Fatalf("read usage file: %v", err)
+	}
+	if len(recs) != 3 {
+		t.Errorf("got %d records, want 3", len(recs))
+	}
+
+	// Verify expected generation IDs
+	expected := map[string]bool{"gen-1": true, "gen-2": true, "gen-3": true}
+	for _, rec := range recs {
+		if rec.GenerationID == "" {
+			t.Errorf("record missing generation_id")
+			continue
+		}
+		if !expected[rec.GenerationID] {
+			t.Errorf("unexpected generation_id: %s", rec.GenerationID)
+		}
 	}
 }

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -128,6 +128,21 @@ func buildServicesFromHome(ctx context.Context, globals *Globals, h *home.Home) 
 	eventsJSONL := filepath.Join(h.LogsDir(), "events.jsonl")
 	eventWriter := eventspkg.NewJSONLWriter(eventsJSONL, 0)
 
+	// One-shot backfill: reconcile Cursor usage from historical events.jsonl
+	// entries into each agent's usage.jsonl. This fixes the gap where
+	// Stop events with token data were logged but never persisted to
+	// usage.jsonl (#3597). Runs once at startup in the background.
+	go func() {
+		// Small delay to let the system stabilize before the one-shot work.
+		time.Sleep(2 * time.Second)
+		appended, err := provider.CursorUsageBackfill(eventsJSONL, h.AgentsDir())
+		if err != nil {
+			log.Warn("cursor usage backfill failed", "error", err)
+		} else if appended > 0 {
+			log.Info("cursor usage backfill completed", "records", appended)
+		}
+	}()
+
 	// The one SSE hub. the daemon is single-tenant, so the bundle publishes
 	// straight into the process-wide hub supplied via Globals (owned by
 	// the caller — no closer). Legacy callers/tests that don't wire a


### PR DESCRIPTION
Fixes #3597

## Summary

Add  function that scans events.jsonl for Cursor Stop events with token counts and appends missing generation_ids to each agent's usage.jsonl.

## Changes

- : Add  that:
  - Reads existing usage.jsonl to get known generation_ids
  - Scans events.jsonl for agent.hook events with event="Stop" and token data
  - Appends missing usage records
  
- : Wire backfill into daemon startup as one-shot goroutine

- : Test fixture with 3 Stops in events, 1 already in usage → verifies 3 total after backfill

Tested: All cursor tests pass, Go lint passes (0 issues).