### PR TITLE
fix(provider): Pi CostReader from session usage (#3630)

### DIFF
--- a/pkg/provider/pi_costs.go
+++ b/pkg/provider/pi_costs.go
@@ -31,18 +31,18 @@ type piCostLine struct {
 }
 
 type piCostMessage struct {
+	Usage    *piCostUsage `json:"usage,omitempty"`
 	Role     string       `json:"role"`
 	Provider string       `json:"provider,omitempty"`
 	Model    string       `json:"model,omitempty"`
-	Usage    *piCostUsage `json:"usage,omitempty"`
 }
 
 type piCostUsage struct {
+	Cost       *piCostUSD `json:"cost,omitempty"`
 	Input      int64      `json:"input"`
 	Output     int64      `json:"output"`
 	CacheRead  int64      `json:"cacheRead"`
 	CacheWrite int64      `json:"cacheWrite"`
-	Cost       *piCostUSD `json:"cost,omitempty"`
 }
 
 type piCostUSD struct {

--- a/pkg/provider/pi_costs.go
+++ b/pkg/provider/pi_costs.go
@@ -1,0 +1,182 @@
+package provider
+
+// pi_costs.go — CostReader for pi (including Amazon Bedrock models).
+//
+// pi embeds token counts and a priced usage.cost.total on every assistant
+// message in its session JSONL under ~/.pi/agent/sessions (or
+// PI_CODING_AGENT_SESSION_DIR). Budgets and MaxCostUSD guardrails need those
+// figures in pkg/cost; without a CostReader they stay at $0 (#3630).
+//
+// Prefer pi's own cost.total when present (already priced for the model /
+// provider, including Bedrock). Fall back to ClaudeCalcCost only when the
+// model looks like a Claude id and cost is missing.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// piCostLine is the subset of a pi JSONL entry needed for cost attribution.
+type piCostLine struct {
+	Message   *piCostMessage `json:"message,omitempty"`
+	Type      string         `json:"type"`
+	Timestamp string         `json:"timestamp"`
+	ID        string         `json:"id,omitempty"`
+	CWD       string         `json:"cwd,omitempty"`
+}
+
+type piCostMessage struct {
+	Role     string       `json:"role"`
+	Provider string       `json:"provider,omitempty"`
+	Model    string       `json:"model,omitempty"`
+	Usage    *piCostUsage `json:"usage,omitempty"`
+}
+
+type piCostUsage struct {
+	Input      int64      `json:"input"`
+	Output     int64      `json:"output"`
+	CacheRead  int64      `json:"cacheRead"`
+	CacheWrite int64      `json:"cacheWrite"`
+	Cost       *piCostUSD `json:"cost,omitempty"`
+}
+
+type piCostUSD struct {
+	Total float64 `json:"total"`
+}
+
+// ReadCosts implements CostReader for pi. It walks pi's session tree and
+// emits one CostEntry per assistant turn that reports usage.
+func (p *PiProvider) ReadCosts(ctx context.Context, opts CostReadOptions) ([]CostEntry, error) {
+	root := piSessionsRoot()
+	if root == "" {
+		return nil, nil
+	}
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		return nil, nil // best-effort source
+	}
+
+	var out []CostEntry
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		if err := ctx.Err(); err != nil {
+			return out, err
+		}
+		dir := filepath.Join(root, e.Name())
+		files, err := filepath.Glob(filepath.Join(dir, "*.jsonl"))
+		if err != nil {
+			continue
+		}
+		for _, path := range files {
+			entries, readErr := readPiCostFile(path, opts)
+			if readErr != nil {
+				continue
+			}
+			out = append(out, entries...)
+		}
+	}
+	return out, nil
+}
+
+func readPiCostFile(path string, opts CostReadOptions) ([]CostEntry, error) {
+	f, err := os.Open(path) //nolint:gosec // path under pi sessions dir
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close() //nolint:errcheck
+
+	var (
+		sessionID string
+		cwd       string
+		out       []CostEntry
+	)
+	// Session id is also encoded in the filename: <ts>_<uuid>.jsonl
+	base := filepath.Base(path)
+	if i := strings.Index(base, "_"); i >= 0 {
+		sessionID = strings.TrimSuffix(base[i+1:], ".jsonl")
+	}
+
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var rec piCostLine
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		switch rec.Type {
+		case "session":
+			if rec.ID != "" {
+				sessionID = rec.ID
+			}
+			if rec.CWD != "" {
+				cwd = rec.CWD
+			}
+			continue
+		case "message":
+			// handled below
+		default:
+			continue
+		}
+		if rec.Message == nil || rec.Message.Role != "assistant" || rec.Message.Usage == nil {
+			continue
+		}
+		u := rec.Message.Usage
+		if u.Input == 0 && u.Output == 0 && u.CacheRead == 0 && u.CacheWrite == 0 {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339Nano, rec.Timestamp)
+		if err != nil {
+			ts, err = time.Parse(time.RFC3339, rec.Timestamp)
+			if err != nil {
+				continue
+			}
+		}
+		if !opts.Since.IsZero() && ts.Before(opts.Since) {
+			continue
+		}
+
+		model := rec.Message.Model
+		if rec.Message.Provider != "" && model != "" {
+			model = rec.Message.Provider + "/" + model
+		}
+		cost := 0.0
+		if u.Cost != nil {
+			cost = u.Cost.Total
+		}
+		if cost == 0 {
+			// Fall back for Claude-shaped ids when pi omitted pricing.
+			bare := rec.Message.Model
+			if i := strings.LastIndex(bare, "claude-"); i >= 0 {
+				cost = ClaudeCalcCost(bare[i:], u.Input, u.Output, u.CacheWrite, u.CacheRead)
+			}
+		}
+
+		out = append(out, CostEntry{
+			Timestamp:        ts,
+			Agent:            resolveClaudeAgent("", cwd, opts.AgentsDir),
+			Repo:             cwd,
+			Model:            model,
+			SessionID:        sessionID,
+			InputTokens:      u.Input,
+			OutputTokens:     u.Output,
+			CacheReadTokens:  u.CacheRead,
+			CacheWriteTokens: u.CacheWrite,
+			CostUSD:          cost,
+		})
+	}
+	return out, sc.Err()
+}
+
+// Ensure PiProvider implements CostReader.
+var _ CostReader = (*PiProvider)(nil)

--- a/pkg/provider/pi_costs_test.go
+++ b/pkg/provider/pi_costs_test.go
@@ -1,0 +1,107 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestPiReadCostsFromSession(t *testing.T) {
+	root := t.TempDir()
+	agents := t.TempDir()
+	agentWT := filepath.Join(agents, "fresh-otter", "worktree")
+	if err := os.MkdirAll(agentWT, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	cwdEnc := encodePiCWD(agentWT)
+	sessDir := filepath.Join(root, cwdEnc)
+	if err := os.MkdirAll(sessDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	sid := "019fcf1b-cec6-778f-b1db-673f101f32ab"
+	path := filepath.Join(sessDir, "2026-08-04T23-28-53-958Z_"+sid+".jsonl")
+	content := `{"type":"session","version":3,"id":"` + sid + `","timestamp":"2026-08-04T23:28:53.958Z","cwd":"` + agentWT + `"}
+{"type":"message","timestamp":"2026-08-04T23:29:01.199Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}
+{"type":"message","timestamp":"2026-08-04T23:29:10.000Z","message":{"role":"assistant","api":"bedrock-converse-stream","provider":"amazon-bedrock","model":"minimax.minimax-m2.5","usage":{"input":2746,"output":108,"cacheRead":0,"cacheWrite":0,"totalTokens":2854,"cost":{"input":0.0008238,"output":0.0001296,"cacheRead":0,"cacheWrite":0,"total":0.0009534}},"content":[]}}
+{"type":"message","timestamp":"2026-08-04T23:30:00.000Z","message":{"role":"assistant","provider":"amazon-bedrock","model":"deepseek.v3.2","usage":{"input":100,"output":10,"cacheRead":0,"cacheWrite":0,"cost":{"total":0.001}}}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := piSessionsRoot
+	piSessionsRoot = func() string { return root }
+	t.Cleanup(func() { piSessionsRoot = prev })
+
+	p := NewPiProvider()
+	entries, err := p.ReadCosts(context.Background(), CostReadOptions{AgentsDir: agents})
+	if err != nil {
+		t.Fatalf("ReadCosts: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2: %+v", len(entries), entries)
+	}
+	e0 := entries[0]
+	if e0.Agent != "fresh-otter" {
+		t.Errorf("Agent = %q, want fresh-otter", e0.Agent)
+	}
+	if e0.Model != "amazon-bedrock/minimax.minimax-m2.5" {
+		t.Errorf("Model = %q", e0.Model)
+	}
+	if e0.SessionID != sid {
+		t.Errorf("SessionID = %q, want %s", e0.SessionID, sid)
+	}
+	if e0.InputTokens != 2746 || e0.OutputTokens != 108 {
+		t.Errorf("tokens = %d/%d", e0.InputTokens, e0.OutputTokens)
+	}
+	if e0.CostUSD < 0.0009 || e0.CostUSD > 0.001 {
+		t.Errorf("CostUSD = %v, want ~0.0009534", e0.CostUSD)
+	}
+	if entries[1].CostUSD != 0.001 {
+		t.Errorf("second CostUSD = %v", entries[1].CostUSD)
+	}
+}
+
+func TestPiReadCostsSinceFilter(t *testing.T) {
+	root := t.TempDir()
+	agents := t.TempDir()
+	wt := filepath.Join(agents, "pi-bedrock", "worktree")
+	if err := os.MkdirAll(wt, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	sessDir := filepath.Join(root, encodePiCWD(wt))
+	if err := os.MkdirAll(sessDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessDir, "sess_abc.jsonl")
+	content := `{"type":"session","id":"abc","cwd":"` + wt + `","timestamp":"2026-08-04T23:00:00Z"}
+{"type":"message","timestamp":"2026-08-04T23:01:00Z","message":{"role":"assistant","provider":"amazon-bedrock","model":"x","usage":{"input":1,"output":1,"cost":{"total":0.01}}}}
+{"type":"message","timestamp":"2026-08-04T23:10:00Z","message":{"role":"assistant","provider":"amazon-bedrock","model":"x","usage":{"input":2,"output":2,"cost":{"total":0.02}}}}
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prev := piSessionsRoot
+	piSessionsRoot = func() string { return root }
+	t.Cleanup(func() { piSessionsRoot = prev })
+
+	since, _ := time.Parse(time.RFC3339, "2026-08-04T23:05:00Z")
+	entries, err := NewPiProvider().ReadCosts(context.Background(), CostReadOptions{
+		AgentsDir: agents,
+		Since:     since,
+	})
+	if err != nil {
+		t.Fatalf("ReadCosts: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d, want 1", len(entries))
+	}
+	if entries[0].CostUSD != 0.02 {
+		t.Errorf("CostUSD = %v", entries[0].CostUSD)
+	}
+	if entries[0].Agent != "pi-bedrock" {
+		t.Errorf("Agent = %q", entries[0].Agent)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement `CostReader` for `PiProvider` by scanning `~/.pi/agent/sessions` JSONL
- Attribute spend to mycel agents via worktree cwd; prefer pi's embedded `usage.cost.total` (works for Bedrock)
- Unblocks per-agent budgets / `MaxCostUSD` for pi agents that previously always showed `$0`

## Test plan
- [x] `go test ./pkg/provider/ -run PiReadCosts`
- [ ] After merge/redeploy: `mycel cost` / Insights show non-zero for a pi/Bedrock agent with session activity
- [ ] `mycel cost budget set … --hard-stop` can see current spend for that agent

Closes #3630

Made with [Cursor](https://cursor.com)