### PR TITLE
fix: plumb unread CORS + tmux settings (#3474)

### DIFF
--- a/desktop/server.go
+++ b/desktop/server.go
@@ -93,7 +93,7 @@ func (s *Server) Start() {
 	publishDaemonAddr(s.URL())
 
 	go func() {
-		err := cmd.RunServerCtx(ctx, s.addr, s.repoRoot, "*", s.apiKey)
+		err := cmd.RunServerCtx(ctx, s.addr, s.repoRoot, cmd.ResolveCORSOrigin(), s.apiKey)
 		if err != nil && strings.Contains(err.Error(), "address already in use") {
 			// Lost the port race to a daemon that came up between the
 			// probe and the bind — become a client of it instead.

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -87,19 +87,24 @@ func runUp(cmd *cobra.Command, _ []string) error {
 		repoRoot = abs
 	}
 
-	// Use the prefs.json addr if --addr wasn't explicitly set.
-	if !cmd.Flags().Changed("addr") {
+	// Use the prefs.json addr / cors_origin if flags weren't explicitly set.
+	if !cmd.Flags().Changed("addr") || !cmd.Flags().Changed("cors-origin") {
 		if prefsPath, pathErr := home.PrefsPath(); pathErr == nil {
 			if cfg, loadErr := home.LoadConfig(prefsPath); loadErr == nil {
-				host := cfg.Server.Host
-				if host == "" {
-					host = "127.0.0.1"
+				if !cmd.Flags().Changed("addr") {
+					host := cfg.Server.Host
+					if host == "" {
+						host = "127.0.0.1"
+					}
+					port := 9374
+					if cfg.Server.Port > 0 {
+						port = cfg.Server.Port
+					}
+					upAddr = fmt.Sprintf("%s:%d", host, port)
 				}
-				port := 9374
-				if cfg.Server.Port > 0 {
-					port = cfg.Server.Port
+				if !cmd.Flags().Changed("cors-origin") && cfg.Server.CORSOrigin != "" {
+					upCORS = cfg.Server.CORSOrigin
 				}
-				upAddr = fmt.Sprintf("%s:%d", host, port)
 			}
 		}
 	}
@@ -145,6 +150,17 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	}
 
 	return RunServer(upAddr, repoRoot, upCORS, upAPIKey)
+}
+
+// ResolveCORSOrigin returns server.cors_origin from prefs.json when set,
+// otherwise "*". Used by the desktop embed which has no --cors-origin flag.
+func ResolveCORSOrigin() string {
+	if prefsPath, pathErr := home.PrefsPath(); pathErr == nil {
+		if cfg, loadErr := home.LoadConfig(prefsPath); loadErr == nil && cfg.Server.CORSOrigin != "" {
+			return cfg.Server.CORSOrigin
+		}
+	}
+	return "*"
 }
 
 // resolveUpRepo picks the anchor repo for `mycel up`. The daemon is

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -557,6 +557,10 @@ func (m *Manager) ApplyConfig(cfg *home.Config) {
 	m.appsConfig = cfg.Apps
 	m.providersConfig = &cfg.Providers
 	m.wsConfig = cfg
+	t := cfg.Runtime.Tmux
+	if t.SessionPrefix != "" || t.DefaultShell != "" || t.HistoryLimit > 0 {
+		m.ApplyTmuxRuntime(t.SessionPrefix, t.DefaultShell, t.HistoryLimit)
+	}
 }
 
 // notifyStateChange calls the onStateChange callback if set.
@@ -630,6 +634,21 @@ func normalizeRuntime(rt string) string {
 	default:
 		return rt
 	}
+}
+
+// ApplyTmuxRuntime replaces the tmux backend using prefs
+// (runtime.tmux.session_prefix / default_shell / history_limit).
+func (m *Manager) ApplyTmuxRuntime(prefix, defaultShell string, historyLimit int) {
+	if m == nil {
+		return
+	}
+	tm := tmux.NewManager(tmux.NormalizeSessionPrefix(prefix))
+	tm.DefaultShell = defaultShell
+	tm.HistoryLimit = historyLimit
+	if m.backends == nil {
+		m.backends = make(map[string]runtime.Backend)
+	}
+	m.backends["tmux"] = runtime.NewTmuxBackend(tm)
 }
 
 // NewManager creates a new agent manager with repo-scoped tmux sessions.

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -79,24 +79,18 @@ const DefaultPrefix = "mycel-"
 
 // Manager handles tmux session operations.
 type Manager struct {
-	// Session cache for reducing tmux subprocess calls (#980).
-	// Cache is invalidated on CreateSession/KillSession/RenameSession/KillServer.
-	sessionsCacheAt time.Time // When sessions cache was populated
-	hasCacheAt      time.Time // When hasSession cache was populated
+	sessionsCacheAt time.Time
+	hasCacheAt      time.Time
 	execCommand     func(name string, arg ...string) *exec.Cmd
 	sessionLocks    map[string]*sync.Mutex
-	hasSessionCache map[string]bool // Cached session existence checks
-	sessionsCache   []Session       // Cached list of sessions
-	SessionPrefix   string          // Prepended to all session names (e.g., "mycel-")
-	// DefaultShell is the absolute path of the shell used for new sessions
-	// (prefs runtime.tmux.default_shell). Empty means "/bin/bash".
-	DefaultShell string
-	cacheTTL     time.Duration // Cache TTL (default: 2 seconds)
-	// HistoryLimit is applied as tmux history-limit on create when > 0
-	// (prefs runtime.tmux.history_limit).
-	HistoryLimit int
-	cacheMu      sync.RWMutex // Protects cache fields
-	sessionMu    sync.Mutex   // Protects per-session SendKeys serialization
+	hasSessionCache map[string]bool
+	SessionPrefix   string
+	DefaultShell    string
+	sessionsCache   []Session
+	cacheTTL        time.Duration
+	HistoryLimit    int
+	cacheMu         sync.RWMutex
+	sessionMu       sync.Mutex
 }
 
 // NormalizeSessionPrefix ensures a trailing "-" so agent names do not glue

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -87,10 +87,40 @@ type Manager struct {
 	sessionLocks    map[string]*sync.Mutex
 	hasSessionCache map[string]bool // Cached session existence checks
 	SessionPrefix   string          // Prepended to all session names (e.g., "mycel-")
-	sessionsCache   []Session       // Cached list of sessions
-	cacheTTL        time.Duration   // Cache TTL (default: 2 seconds)
-	cacheMu         sync.RWMutex    // Protects cache fields
-	sessionMu       sync.Mutex      // Protects per-session SendKeys serialization
+	// DefaultShell is the absolute path of the shell used for new sessions
+	// (prefs runtime.tmux.default_shell). Empty means "/bin/bash".
+	DefaultShell string
+	// HistoryLimit is applied as tmux history-limit on create when > 0
+	// (prefs runtime.tmux.history_limit).
+	HistoryLimit  int
+	sessionsCache []Session     // Cached list of sessions
+	cacheTTL      time.Duration // Cache TTL (default: 2 seconds)
+	cacheMu       sync.RWMutex  // Protects cache fields
+	sessionMu     sync.Mutex    // Protects per-session SendKeys serialization
+}
+
+// NormalizeSessionPrefix ensures a trailing "-" so agent names do not glue
+// to the prefix. Prefs historically default to "mycel" while code used
+// "mycel-"; both become "mycel-".
+func NormalizeSessionPrefix(prefix string) string {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" {
+		return DefaultPrefix
+	}
+	if !strings.HasSuffix(prefix, "-") {
+		return prefix + "-"
+	}
+	return prefix
+}
+
+// safeShellPath allows absolute shell paths only (no spaces / metacharacters).
+var safeShellPath = regexp.MustCompile(`^/[A-Za-z0-9._/-]+$`)
+
+func (m *Manager) sessionShell() string {
+	if m.DefaultShell != "" && safeShellPath.MatchString(m.DefaultShell) {
+		return m.DefaultShell
+	}
+	return "/bin/bash"
 }
 
 // command returns an exec.Cmd using the configured executor.
@@ -263,12 +293,19 @@ func (m *Manager) CreateSessionWithEnv(ctx context.Context, name, dir, command s
 	if dir != "" {
 		args = append(args, "-c", dir)
 	}
-	args = append(args, "bash", "-c", shellCmd)
+	args = append(args, m.sessionShell(), "-c", shellCmd)
 
 	cmd := m.command(ctx, "tmux", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to create session %s: %w (%s)", fullName, err, string(output))
+	}
+
+	if m.HistoryLimit > 0 {
+		histCmd := m.command(ctx, "tmux", "set-option", "-t", fullName, "history-limit", strconv.Itoa(m.HistoryLimit))
+		if histOut, histErr := histCmd.CombinedOutput(); histErr != nil {
+			log.Warn("tmux history-limit not applied", "session", fullName, "error", histErr, "output", string(histOut))
+		}
 	}
 
 	// Invalidate cache after creating session

--- a/pkg/tmux/session.go
+++ b/pkg/tmux/session.go
@@ -86,17 +86,17 @@ type Manager struct {
 	execCommand     func(name string, arg ...string) *exec.Cmd
 	sessionLocks    map[string]*sync.Mutex
 	hasSessionCache map[string]bool // Cached session existence checks
+	sessionsCache   []Session       // Cached list of sessions
 	SessionPrefix   string          // Prepended to all session names (e.g., "mycel-")
 	// DefaultShell is the absolute path of the shell used for new sessions
 	// (prefs runtime.tmux.default_shell). Empty means "/bin/bash".
 	DefaultShell string
+	cacheTTL     time.Duration // Cache TTL (default: 2 seconds)
 	// HistoryLimit is applied as tmux history-limit on create when > 0
 	// (prefs runtime.tmux.history_limit).
-	HistoryLimit  int
-	sessionsCache []Session     // Cached list of sessions
-	cacheTTL      time.Duration // Cache TTL (default: 2 seconds)
-	cacheMu       sync.RWMutex  // Protects cache fields
-	sessionMu     sync.Mutex    // Protects per-session SendKeys serialization
+	HistoryLimit int
+	cacheMu      sync.RWMutex // Protects cache fields
+	sessionMu    sync.Mutex   // Protects per-session SendKeys serialization
 }
 
 // NormalizeSessionPrefix ensures a trailing "-" so agent names do not glue

--- a/pkg/tmux/session_prefix_test.go
+++ b/pkg/tmux/session_prefix_test.go
@@ -1,0 +1,67 @@
+package tmux
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeSessionPrefix(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"", "mycel-"},
+		{"mycel", "mycel-"},
+		{"mycel-", "mycel-"},
+		{"custom", "custom-"},
+		{"custom-", "custom-"},
+		{"  mycel  ", "mycel-"},
+	}
+	for _, tt := range tests {
+		if got := NormalizeSessionPrefix(tt.in); got != tt.want {
+			t.Errorf("NormalizeSessionPrefix(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestSessionShell(t *testing.T) {
+	m := &Manager{}
+	if got := m.sessionShell(); got != "/bin/bash" {
+		t.Errorf("default shell = %q", got)
+	}
+	m.DefaultShell = "/bin/zsh"
+	if got := m.sessionShell(); got != "/bin/zsh" {
+		t.Errorf("zsh = %q", got)
+	}
+	m.DefaultShell = "zsh" // relative — rejected
+	if got := m.sessionShell(); got != "/bin/bash" {
+		t.Errorf("unsafe shell fell through: %q", got)
+	}
+	m.DefaultShell = "/bin/bash; rm -rf /"
+	if got := m.sessionShell(); got != "/bin/bash" {
+		t.Errorf("metachar shell fell through: %q", got)
+	}
+}
+
+func TestCreateSessionWithEnv_HistoryLimitAndShell(t *testing.T) {
+	mock, records := recordingMock("")
+	m := newTestManager("mycel-", mock)
+	m.DefaultShell = "/bin/zsh"
+	m.HistoryLimit = 5000
+
+	if err := m.CreateSessionWithEnv(testCtx(), "agent1", "/repo", "echo hi", nil); err != nil {
+		t.Fatalf("CreateSessionWithEnv: %v", err)
+	}
+	if len(*records) != 2 {
+		t.Fatalf("want 2 tmux calls (new-session + set-option), got %d", len(*records))
+	}
+	args0 := (*records)[0].args
+	if !slices.Contains(args0, "/bin/zsh") {
+		t.Errorf("shell missing: %v", args0)
+	}
+	args1 := (*records)[1].args
+	joined := strings.Join(args1, " ")
+	if !strings.Contains(joined, "history-limit") || !strings.Contains(joined, "5000") {
+		t.Errorf("history-limit missing: %v", args1)
+	}
+}

--- a/pkg/tmux/session_test.go
+++ b/pkg/tmux/session_test.go
@@ -509,8 +509,8 @@ func TestCreateSessionWithEnv_Success(t *testing.T) {
 	if len(*records) != 1 {
 		t.Fatalf("expected 1 call, got %d", len(*records))
 	}
-	if !slices.Contains((*records)[0].args, "bash") {
-		t.Error("expected bash in args")
+	if !slices.Contains((*records)[0].args, "/bin/bash") {
+		t.Errorf("expected /bin/bash in args, got %v", (*records)[0].args)
 	}
 }
 

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -465,12 +465,16 @@ func (s *Services) MCPLayeredView() *mcppkg.LayeredView {
 func newAgentManager(h *home.Home) (*agentpkg.Manager, *containerpkg.Backend, string, error) {
 	var homeCfg home.DockerRuntimeConfig
 	runtimeDefault := ""
+	sessionPrefix := agentpkg.DefaultSessionPrefix
 	if h.Config != nil {
 		homeCfg = h.Config.Runtime.Docker
 		runtimeDefault = h.Config.Runtime.Default
+		if p := h.Config.Runtime.Tmux.SessionPrefix; p != "" {
+			sessionPrefix = tmux.NormalizeSessionPrefix(p)
+		}
 	}
 	dockerCfg := containerpkg.ConfigFromHome(homeCfg)
-	be, err := containerpkg.NewBackend(dockerCfg, agentpkg.DefaultSessionPrefix, h.RootDir, provider.DefaultRegistry)
+	be, err := containerpkg.NewBackend(dockerCfg, sessionPrefix, h.RootDir, provider.DefaultRegistry)
 	if err != nil {
 		log.Warn("Docker not available — agents will use tmux runtime only", "error", err, "repo", h.RootDir)
 		reason := ""


### PR DESCRIPTION
## Summary
- `server.cors_origin` from prefs when `--cors-origin` is unset (`mycel up`) and from prefs in the desktop embed (was hardcoded `*`)
- `runtime.tmux.session_prefix` / `default_shell` / `history_limit` applied at agent manager boot and on tmux session create
- Notes: `ui.default_view` and Template `Secrets`/`Plugins` were already fixed on main; this PR covers the remaining live-but-unread settings from #3474

## Test plan
- [x] `go test ./pkg/tmux/ ./pkg/agent/ ./server/ ./internal/cmd/`
- [ ] Set `server.cors_origin` in Settings, restart daemon without `--cors-origin`, confirm CORS header matches
- [ ] Set tmux prefix/shell/history in Settings, restart, create agent — session name/shell/history-limit reflect prefs

Closes #3474

Made with [Cursor](https://cursor.com)