### PR TITLE
fix(gateway): log hot-start adapter failures while active

### DIFF
--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -292,7 +292,7 @@ func (m *Manager) StartAdapter(adapter NotificationAdapter) error {
 		handler := func(n Notification) {
 			m.handleNotification(name, n)
 		}
-		if err := adapter.Start(ctx, handler); err != nil && ctx.Err() != nil {
+		if err := adapter.Start(ctx, handler); err != nil && ctx.Err() == nil {
 			log.Error("gateway: adapter stopped with error", "adapter", name, "error", err)
 		}
 	}()


### PR DESCRIPTION
## Summary
- CodeRabbit on #3633 flagged an inverted `ctx.Err()` check in `StartAdapter`: failures only logged during cancel, silent while the manager is active
- Align with the existing `Start()` path (`ctx.Err() == nil`)

## Test plan
- [x] `go test ./pkg/gateway/`
- [ ] Optional: force an adapter `Start` error with a live manager and confirm an error log appears

Follow-up to #3633 review.

Made with [Cursor](https://cursor.com)