### PR TITLE
fix: address CodeRabbit reviews from #3620 and #3619

### DIFF
--- a/landing/src/app/_components/DownloadButtons.tsx
+++ b/landing/src/app/_components/DownloadButtons.tsx
@@ -28,6 +28,8 @@ const ORDER: DesktopOS[] = ["mac", "linux", "windows"];
  *
  * Desktop URLs come from the latest GitHub release asset list (signed zip
  * preferred; falls back to `*-UNSIGNED.zip` when that is what shipped).
+ * Missing OS assets are hidden — never linked to a filename that is not
+ * on the release (#3619 CodeRabbit).
  */
 export function DownloadButtons() {
   const { desktopUrls } = useGitHubStats();
@@ -43,39 +45,53 @@ export function DownloadButtons() {
 
   const primary = OS_META[os];
   const PrimaryIcon = primary.icon;
-  const others = ORDER.filter((o) => o !== os);
-  const unsignedMac = /UNSIGNED/.test(desktopUrls.mac);
+  const primaryHref = desktopUrls[os];
+  const others = ORDER.filter((o) => o !== os && desktopUrls[o]);
+  const unsignedMac = Boolean(desktopUrls.mac && /UNSIGNED/.test(desktopUrls.mac));
 
   return (
     <div className="flex flex-col items-center gap-3">
-      <Link
-        href={desktopUrls[os]}
-        className="group inline-flex h-12 items-center gap-2.5 rounded-lg bg-primary px-7 text-sm font-semibold text-primary-foreground shadow-[var(--btn-shadow)] transition-all hover:shadow-[0_0_24px_color-mix(in_srgb,var(--primary)_32%,transparent)] active:scale-[0.97]"
-      >
-        <PrimaryIcon className="h-[18px] w-[18px]" aria-hidden="true" />
-        {primary.label}
-        <Download
-          className="h-3.5 w-3.5 opacity-70 transition-transform group-hover:translate-y-0.5"
-          aria-hidden="true"
-        />
-      </Link>
+      {primaryHref ? (
+        <Link
+          href={primaryHref}
+          className="group inline-flex h-12 items-center gap-2.5 rounded-lg bg-primary px-7 text-sm font-semibold text-primary-foreground shadow-[var(--btn-shadow)] transition-all hover:shadow-[0_0_24px_color-mix(in_srgb,var(--primary)_32%,transparent)] active:scale-[0.97]"
+        >
+          <PrimaryIcon className="h-[18px] w-[18px]" aria-hidden="true" />
+          {primary.label}
+          <Download
+            className="h-3.5 w-3.5 opacity-70 transition-transform group-hover:translate-y-0.5"
+            aria-hidden="true"
+          />
+        </Link>
+      ) : (
+        <span
+          className="inline-flex h-12 items-center gap-2.5 rounded-lg border border-outline-variant/30 px-7 text-sm font-semibold text-on-surface-variant"
+          aria-disabled="true"
+        >
+          <PrimaryIcon className="h-[18px] w-[18px]" aria-hidden="true" />
+          {primary.short} build unavailable
+        </span>
+      )}
 
-      <div className="flex items-center gap-2">
-        {others.map((o) => {
-          const meta = OS_META[o];
-          const Icon = meta.icon;
-          return (
-            <Link
-              key={o}
-              href={desktopUrls[o]}
-              className="inline-flex items-center gap-1.5 rounded-md border border-outline-variant/20 px-3 py-1.5 font-body text-xs font-medium text-on-surface-variant transition-colors hover:border-primary/30 hover:text-primary active:scale-[0.97]"
-            >
-              <Icon className="h-3.5 w-3.5" aria-hidden="true" />
-              {meta.short}
-            </Link>
-          );
-        })}
-      </div>
+      {others.length > 0 ? (
+        <div className="flex items-center gap-2">
+          {others.map((o) => {
+            const meta = OS_META[o];
+            const Icon = meta.icon;
+            const href = desktopUrls[o]!;
+            return (
+              <Link
+                key={o}
+                href={href}
+                className="inline-flex items-center gap-1.5 rounded-md border border-outline-variant/20 px-3 py-1.5 font-body text-xs font-medium text-on-surface-variant transition-colors hover:border-primary/30 hover:text-primary active:scale-[0.97]"
+              >
+                <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                {meta.short}
+              </Link>
+            );
+          })}
+        </div>
+      ) : null}
 
       {unsignedMac && os === "mac" ? (
         <p className="max-w-sm text-center font-body text-xs text-on-surface-variant/80">

--- a/landing/src/lib/github.ts
+++ b/landing/src/lib/github.ts
@@ -11,7 +11,7 @@ import { useEffect, useState } from "react";
  * never flashes zeros. If the API is unavailable or rate-limited, the cached
  * numbers simply stay — graceful degradation, no error UI.
  *
- * Cached fallbacks refreshed 2026-08-05 from the live API.
+ * Cached fallbacks refreshed 2026-08-04 from the live API.
  */
 export const REPO = "rpuneet/mycel";
 
@@ -23,7 +23,7 @@ export type GitHubStats = {
   version: string; // release tag, e.g. "v0.4.6"
   live: boolean; // true once real API data has replaced the fallback
   /** Resolved desktop asset URLs for the latest release (signed preferred). */
-  desktopUrls: Record<DesktopOS, string>;
+  desktopUrls: Partial<Record<DesktopOS, string>>;
 };
 
 /**
@@ -51,21 +51,22 @@ export function pickDesktopAsset(
   os: DesktopOS,
   version: string,
   assetNames: readonly string[],
-): string {
+): string | undefined {
   const candidates = desktopAssetCandidates(os, version);
-  return candidates.find((n) => assetNames.includes(n)) ?? candidates[0];
+  return candidates.find((n) => assetNames.includes(n));
 }
 
 export function desktopUrlsFromAssets(
   tag: string,
   assetNames: readonly string[],
-): Record<DesktopOS, string> {
+): Partial<Record<DesktopOS, string>> {
   const base = `https://github.com/${REPO}/releases/download/${tag}`;
-  return {
-    mac: `${base}/${pickDesktopAsset("mac", tag, assetNames)}`,
-    linux: `${base}/${pickDesktopAsset("linux", tag, assetNames)}`,
-    windows: `${base}/${pickDesktopAsset("windows", tag, assetNames)}`,
-  };
+  const out: Partial<Record<DesktopOS, string>> = {};
+  for (const os of ["mac", "linux", "windows"] as const) {
+    const name = pickDesktopAsset(os, tag, assetNames);
+    if (name) out[os] = `${base}/${name}`;
+  }
+  return out;
 }
 
 /**
@@ -137,11 +138,8 @@ export function useGitHubStats(): GitHubStats {
           if (names.length > 0) {
             next.desktopUrls = desktopUrlsFromAssets(rel.tag_name, names);
           } else {
-            next.desktopUrls = {
-              mac: desktopDownloadUrl("mac", rel.tag_name),
-              linux: desktopDownloadUrl("linux", rel.tag_name),
-              windows: desktopDownloadUrl("windows", rel.tag_name),
-            };
+            // Live release with no assets — do not invent download hrefs.
+            next.desktopUrls = {};
           }
         }
       } catch {

--- a/server/handlers/releases.go
+++ b/server/handlers/releases.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
 // GitHubRelease represents the shape of a GitHub release response.
@@ -18,8 +20,10 @@ type GitHubRelease struct {
 const (
 	releaseCacheTTL = 1 * time.Hour
 	ghRepo          = "rpuneet/mycel"
-	ghAPIURL        = "https://api.github.com/repos/" + ghRepo + "/releases/latest"
 )
+
+// ghAPIURL is the upstream releases endpoint. Overridable in tests.
+var ghAPIURL = "https://api.github.com/repos/" + ghRepo + "/releases/latest"
 
 // cachedRelease holds a release with its cache metadata.
 type cachedRelease struct {
@@ -34,6 +38,7 @@ type ReleaseHandler struct {
 	cache   *cachedRelease
 	httpCli *http.Client
 	mu      sync.RWMutex
+	sf      singleflight.Group
 }
 
 // NewReleaseHandler creates a new ReleaseHandler with a default HTTP client.
@@ -83,17 +88,28 @@ func (h *ReleaseHandler) getRelease(ctx context.Context) (*GitHubRelease, string
 		return cache.release, cache.status
 	}
 
-	// Cache miss or stale — fetch from GitHub
-	release, status := h.fetchRelease(ctx)
-
-	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.cache = &cachedRelease{
-		release:   release,
-		fetchedAt: now,
-		status:    status,
-	}
-	return release, status
+	// Coalesce concurrent refreshes so a thundering herd of About views
+	// issues one GitHub request per TTL window (#3620 CodeRabbit).
+	v, _, _ := h.sf.Do("latest", func() (any, error) { //nolint:errcheck // closure never returns an error
+		h.mu.RLock()
+		c := h.cache
+		h.mu.RUnlock()
+		if c != nil && time.Since(c.fetchedAt) < releaseCacheTTL {
+			return c, nil
+		}
+		release, status := h.fetchRelease(ctx)
+		entry := &cachedRelease{
+			release:   release,
+			fetchedAt: time.Now(),
+			status:    status,
+		}
+		h.mu.Lock()
+		h.cache = entry
+		h.mu.Unlock()
+		return entry, nil
+	})
+	entry := v.(*cachedRelease)
+	return entry.release, entry.status
 }
 
 func (h *ReleaseHandler) fetchRelease(ctx context.Context) (*GitHubRelease, string) {

--- a/server/handlers/releases.go
+++ b/server/handlers/releases.go
@@ -35,10 +35,10 @@ type cachedRelease struct {
 // ReleaseHandler serves the latest GitHub release with server-side caching
 // to avoid hitting GitHub's unauthenticated rate limit from the browser.
 type ReleaseHandler struct {
-	cache   *cachedRelease
 	httpCli *http.Client
-	mu      sync.RWMutex
+	cache   *cachedRelease
 	sf      singleflight.Group
+	mu      sync.RWMutex
 }
 
 // NewReleaseHandler creates a new ReleaseHandler with a default HTTP client.
@@ -90,7 +90,7 @@ func (h *ReleaseHandler) getRelease(ctx context.Context) (*GitHubRelease, string
 
 	// Coalesce concurrent refreshes so a thundering herd of About views
 	// issues one GitHub request per TTL window (#3620 CodeRabbit).
-	v, _, _ := h.sf.Do("latest", func() (any, error) { //nolint:errcheck // closure never returns an error
+	v, err, _ := h.sf.Do("latest", func() (any, error) {
 		h.mu.RLock()
 		c := h.cache
 		h.mu.RUnlock()
@@ -108,7 +108,13 @@ func (h *ReleaseHandler) getRelease(ctx context.Context) (*GitHubRelease, string
 		h.mu.Unlock()
 		return entry, nil
 	})
-	entry := v.(*cachedRelease)
+	if err != nil {
+		return nil, "error"
+	}
+	entry, ok := v.(*cachedRelease)
+	if !ok || entry == nil {
+		return nil, "error"
+	}
 	return entry.release, entry.status
 }
 

--- a/server/handlers/releases_test.go
+++ b/server/handlers/releases_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestGetReleaseCoalescesConcurrentFetches(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(GitHubRelease{
+			TagName:     "v0.4.7",
+			HTMLURL:     "https://github.com/rpuneet/mycel/releases/tag/v0.4.7",
+			PublishedAt: "2026-08-05T00:00:00Z",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := ghAPIURL
+	ghAPIURL = srv.URL
+	t.Cleanup(func() { ghAPIURL = prev })
+
+	h := NewReleaseHandler()
+	h.httpCli = srv.Client()
+
+	const n = 20
+	type result struct {
+		tag    string
+		status string
+	}
+	out := make(chan result, n)
+	for range n {
+		go func() {
+			rel, status := h.getRelease(t.Context())
+			tag := ""
+			if rel != nil {
+				tag = rel.TagName
+			}
+			out <- result{tag: tag, status: status}
+		}()
+	}
+	for i := range n {
+		r := <-out
+		if r.status != "ok" || r.tag != "v0.4.7" {
+			t.Fatalf("result[%d] = %+v", i, r)
+		}
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("upstream calls = %d, want 1 (singleflight)", got)
+	}
+}


### PR DESCRIPTION
## Summary
Audit of PRs merged this session found actionable CodeRabbit threads still open on main:

| Merged PR | Finding | Status |
|---|---|---|
| #3633 | inverted `ctx.Err()` on hot-start adapter log | already fixed in #3636 |
| #3620 | concurrent About views each hit GitHub on cache miss | **this PR** — `singleflight` + test |
| #3619 | invent download URLs for missing OS assets; comment date | **this PR** — optional assets + hide buttons; comment → 2026-08-04 |
| #3621–#3635 (others) | no review threads (or rate-limited) | nothing to do |

## Test plan
- [x] `go test ./server/handlers/ -run GetRelease`
- [x] `npm run lint` in `landing/`
- [ ] About page: spam refresh while cache cold — one GitHub upstream call
- [ ] Landing: release with only mac asset — linux/windows links hidden

Part of #3624
