### PR TITLE
fix: address CodeRabbit findings from Aug-4 merges

### DIFF
--- a/pkg/provider/cursor_costs.go
+++ b/pkg/provider/cursor_costs.go
@@ -109,6 +109,10 @@ func AppendCursorUsage(agentsDir, agent string, rec CursorUsageRecord) error {
 	if agentsDir == "" || agent == "" {
 		return nil
 	}
+	if rec.InputTokens < 0 || rec.OutputTokens < 0 ||
+		rec.CacheReadTokens < 0 || rec.CacheWriteTokens < 0 || rec.CostUSD < 0 {
+		return nil // reject negative usage that would deflate spend (#3594)
+	}
 	if rec.InputTokens == 0 && rec.OutputTokens == 0 &&
 		rec.CacheReadTokens == 0 && rec.CacheWriteTokens == 0 {
 		return nil
@@ -163,6 +167,10 @@ func (p *CursorProvider) ReadCosts(ctx context.Context, opts CostReadOptions) ([
 		}
 		for _, rec := range recs {
 			if !opts.Since.IsZero() && rec.Timestamp.Before(opts.Since) {
+				continue
+			}
+			if rec.InputTokens < 0 || rec.OutputTokens < 0 ||
+				rec.CacheReadTokens < 0 || rec.CacheWriteTokens < 0 || rec.CostUSD < 0 {
 				continue
 			}
 			key := rec.GenerationID

--- a/pkg/provider/cursor_costs_test.go
+++ b/pkg/provider/cursor_costs_test.go
@@ -87,6 +87,24 @@ func TestAppendCursorUsageSkipsEmpty(t *testing.T) {
 	}
 }
 
+func TestAppendCursorUsageRejectsNegatives(t *testing.T) {
+	agents := t.TempDir()
+	if err := AppendCursorUsage(agents, "a", CursorUsageRecord{
+		Model: "default", InputTokens: -1, OutputTokens: 10,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := AppendCursorUsage(agents, "a", CursorUsageRecord{
+		Model: "default", InputTokens: 1, OutputTokens: 1, CostUSD: -0.01,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(agents, "a", CursorUsageRelDir, CursorUsageFile)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected no file for negative usage, err=%v", err)
+	}
+}
+
 func TestCursorCalcCostUsesClaudePricingForClaudeModels(t *testing.T) {
 	got := CursorCalcCost("claude-sonnet-4", 1_000_000, 0, 0, 0)
 	want := ClaudeCalcCost("claude-sonnet-4", 1_000_000, 0, 0, 0)

--- a/server/handlers/agents.go
+++ b/server/handlers/agents.go
@@ -448,6 +448,8 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 
 		// Blueprint provision (#3558): expand composes into leaf agents.
 		leaves := []string{req.Template}
+		var expandedSecrets []string
+		var rootSecrets []string
 		if req.Template != "" && h.tmplStore != nil {
 			expanded, expErr := template.Expand(h.tmplStore, req.Template)
 			if expErr != nil {
@@ -460,6 +462,10 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 			}
 			if len(expanded.Leaves) > 0 {
 				leaves = expanded.Leaves
+			}
+			expandedSecrets = expanded.Secrets
+			if root, _, gErr := h.tmplStore.Get(req.Template); gErr == nil && root != nil {
+				rootSecrets = root.Secrets
 			}
 		}
 		multi := len(leaves) > 1
@@ -480,6 +486,9 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 					leafSecrets = t.Secrets
 				}
 			}
+			// Inherit secrets declared on the blueprint root so parent-only
+			// vault keys surface as missing_secrets (#3602 CodeRabbit).
+			leafSecrets = unionStringSlice(leafSecrets, rootSecrets)
 			missing := template.FilterMissing(leafSecrets, h.secrets)
 			unionMissing = unionStringSlice(unionMissing, missing)
 
@@ -512,10 +521,17 @@ func (h *AgentHandler) list(w http.ResponseWriter, r *http.Request) {
 				Task:           leafTask,
 			})
 			if err != nil {
+				// Best-effort rollback so a partial team does not block retry (#3602).
+				for _, c := range created {
+					_ = svc.Delete(r.Context(), c.Name, true) //nolint:errcheck // best-effort cleanup
+				}
 				httpError(w, err.Error(), http.StatusBadRequest)
 				return
 			}
 			created = append(created, a)
+		}
+		if len(expandedSecrets) > 0 {
+			unionMissing = template.FilterMissing(expandedSecrets, h.secrets)
 		}
 
 		primary := created[0]

--- a/server/handlers/providers.go
+++ b/server/handlers/providers.go
@@ -898,8 +898,22 @@ func (h *ProviderHandler) buildProviderInfo(
 	return info
 }
 
-// listAgents returns the raw agent list, or nil on error.
+// listAgents returns the raw agent list (including archived), or nil on error.
+// Cost attribution must see archived agents so historical spend is not
+// reclassified via model-name matching (#3594 CodeRabbit).
 func (h *ProviderHandler) listAgents(ctx context.Context) []*agent.Agent {
+	if h.agents == nil {
+		return nil
+	}
+	agents, err := h.agents.List(ctx, agent.ListOptions{IncludeArchived: true})
+	if err != nil {
+		return nil
+	}
+	return agents
+}
+
+// listLiveAgents returns non-archived agents for UI counts/summaries.
+func (h *ProviderHandler) listLiveAgents(ctx context.Context) []*agent.Agent {
 	if h.agents == nil {
 		return nil
 	}
@@ -914,7 +928,7 @@ func (h *ProviderHandler) listAgents(ctx context.Context) []*agent.Agent {
 // Used by the list endpoint which does not need full agent summaries.
 func (h *ProviderHandler) countAgents(ctx context.Context) map[string]int {
 	counts := make(map[string]int)
-	for _, a := range h.listAgents(ctx) {
+	for _, a := range h.listLiveAgents(ctx) {
 		if tool := strings.ToLower(a.Tool); tool != "" {
 			counts[tool]++
 		}
@@ -927,7 +941,7 @@ func (h *ProviderHandler) countAgents(ctx context.Context) map[string]int {
 func (h *ProviderHandler) agentSummariesByProvider(ctx context.Context) (map[string]int, map[string][]AgentSummary) {
 	counts := make(map[string]int)
 	byProvider := make(map[string][]AgentSummary)
-	for _, a := range h.listAgents(ctx) {
+	for _, a := range h.listLiveAgents(ctx) {
 		tool := strings.ToLower(a.Tool)
 		if tool == "" {
 			continue
@@ -968,15 +982,17 @@ func (h *ProviderHandler) aggregateCostsByProvider(ctx context.Context) map[stri
 	toolByAgent := make(map[string]string)
 	for _, a := range h.listAgents(ctx) {
 		if a.Tool != "" {
-			toolByAgent[a.Name] = a.Tool
+			toolByAgent[a.Name] = strings.ToLower(a.Tool)
 		}
 	}
 
 	providers := h.registry.List()
 	for _, s := range summaries {
 		tool := toolByAgent[s.AgentID]
-		if tool == "" {
-			// Host / unattributed sessions: fall back to model-name match.
+		if tool == "" && s.AgentID == "" {
+			// Host / unattributed sessions only: fall back to model-name match.
+			// A nonempty AgentID that missed the map is an archived/unknown
+			// agent — do not reclassify it by model (#3594).
 			model := strings.ToLower(s.Model)
 			for _, p := range providers {
 				if strings.Contains(model, strings.ToLower(p.Name())) {
@@ -1017,14 +1033,14 @@ func (h *ProviderHandler) costByModelForProvider(ctx context.Context, name strin
 	toolByAgent := make(map[string]string)
 	for _, a := range h.listAgents(ctx) {
 		if a.Tool != "" {
-			toolByAgent[a.Name] = a.Tool
+			toolByAgent[a.Name] = strings.ToLower(a.Tool)
 		}
 	}
 
 	byModel := map[string]*ModelCost{}
 	for _, e := range entries {
 		tool := toolByAgent[e.Agent]
-		if tool == "" && strings.Contains(strings.ToLower(e.Model), strings.ToLower(name)) {
+		if tool == "" && e.Agent == "" && strings.Contains(strings.ToLower(e.Model), strings.ToLower(name)) {
 			tool = name
 		}
 		if tool != name {

--- a/web/src/components/CreateAgentModal.tsx
+++ b/web/src/components/CreateAgentModal.tsx
@@ -155,6 +155,9 @@ export function CreateAgentModal({
               if (names.includes("blank")) return "blank";
               return names[0]!;
             });
+          } else {
+            setTemplates([]);
+            setTemplate("");
           }
         }
       })
@@ -434,7 +437,8 @@ export function CreateAgentModal({
     }
     return result;
   })();
-  const canCreate = groupComplete.repo && groupComplete.identity && groupComplete.tool;
+  const canCreate =
+    groupComplete.repo && groupComplete.identity && groupComplete.tool && template.trim() !== "";
 
   if (!open) return null;
 

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -101,6 +101,7 @@ const updateTemplate = (
     mcps: string[];
     secrets: string[];
     plugins: string[];
+    composes?: string[];
     max_cost_usd: number;
     stuck_timeout_min: number;
   },
@@ -206,6 +207,9 @@ function TemplateDetailPanel({
         mcps: splitComma(mcpsRaw),
         secrets: splitComma(secretsRaw),
         plugins: splitComma(pluginsRaw),
+        // Preserve composition — the editor does not edit composes, but
+        // omitting them on PUT would wipe multi-agent blueprints (#3610).
+        composes: detail.composes ?? [],
         max_cost_usd: parseFloat(maxCostRaw) || 0,
         stuck_timeout_min: parseInt(stuckTimeoutRaw, 10) || 0,
       });


### PR DESCRIPTION
## Summary
Audit of CodeRabbit threads on Aug-4 merges (#3584–#3610) against current main.

### Fixed in this PR
| Source | Finding |
|---|---|
| #3610 | Saving a template wiped `composes` |
| #3602 | Parent blueprint secrets omitted from `missing_secrets`; partial create left orphan leaves |
| #3594 | Negative Cursor tokens/costs accepted; archived agents mis-attributed via model name |
| #3599 | Empty template list could still submit `blank` |

### Already fixed / skipped
| Source | Verdict |
|---|---|
| #3584 adopt_legacy | Already skips when suffix is a known agent |
| #3599 withdrawOwnedBuiltin | Already retains hash on remove failure |
| #3599 blank selection | Already prefers first template when blank missing |
| #3592 resume→idle | Intentional product behavior for live sessions |
| #3602 full atomicity | Partial rollback only (full batch API = heavy lift) |
| #3603/#3610/#3607 test/docs/markdown | Test-coverage / docs polish — not product bugs |
| #3596 Insights labels | Already says estimated / uses costSpendLabel |

## Test plan
- [x] `go test ./pkg/provider/ -run Cursor`
- [x] `golangci-lint` on touched packages
- [x] `vitest` templates tests
- [ ] Save a multi-agent blueprint in Templates UI — composes preserved
- [ ] Create blueprint with parent-only secret — appears in missing_secrets
- [ ] Force mid-loop create failure — earlier leaves deleted

Part of #3624


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid usage records with negative token counts or costs are now rejected.
  - Agent creation better handles inherited secrets and reports missing secrets accurately.
  - Failed multi-agent creation now cleans up partially created agents.
  - Cost attribution no longer incorrectly assigns archived or unknown agents based only on model names.
  - Agent creation is prevented when no valid template is selected.
  - Empty template results now clear stale selections.

- **Improvements**
  - Template composition data is preserved when templates are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->