### PR TITLE
feat(notify): mute channel while catch-all active (#3466)

### DIFF
--- a/pkg/client/notify.go
+++ b/pkg/client/notify.go
@@ -19,6 +19,7 @@ type Subscription struct {
 	Agent       string    `json:"agent"`
 	ID          int64     `json:"id"`
 	MentionOnly bool      `json:"mention_only"`
+	Muted       bool      `json:"muted"`
 }
 
 // DeliveryEntry represents a delivery log entry.

--- a/pkg/notify/notify.go
+++ b/pkg/notify/notify.go
@@ -50,6 +50,9 @@ type Subscription struct {
 	Agent       string    `json:"agent"`
 	ID          int64     `json:"id"`
 	MentionOnly bool      `json:"mention_only"`
+	// Muted suppresses catch-all delivery for this agent on this channel
+	// without counting as an active subscription (#3466).
+	Muted bool `json:"muted"`
 }
 
 // DeliveryEntry records one delivery attempt in the activity log.

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -278,12 +278,13 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 		log.Warn("notify: failed to get subscribers", "channel", channel, "error", subErr)
 		return
 	}
+	active, mutedAgents := partitionSubs(subs)
 
 	// The connect-app flow subscribes agents to "{platform}:general" as a
 	// catch-all, because the real channel is not known until a message
 	// arrives (Telegram DMs land on telegram:<username|chat_id>, mail on
-	// gmail:<sender>). When a channel has no subscribers of its own, fall
-	// back to the catch-all's subscribers for this delivery.
+	// gmail:<sender>). When a channel has no active subscribers of its own,
+	// fall back to the catch-all's subscribers for this delivery.
 	//
 	// This is deliberately a read, not a write. Copying the catch-all onto
 	// each new channel used to leave a permanent subscription behind, and
@@ -291,16 +292,20 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 	// WhatsApp per chat) turned one catch-all row into dozens nobody asked
 	// for — see #3463. An explicit subscription on the real channel still
 	// wins, so per-channel settings keep working.
-	if len(subs) == 0 && platform != "" {
+	//
+	// Muted rows on the real channel suppress catch-all for that agent only
+	// (#3466) and do not count as active subscribers.
+	if len(active) == 0 && platform != "" {
 		fallback, fErr := s.catchAllSubscribers(ctx, platform, channel)
 		if fErr != nil {
 			log.Warn("notify: catch-all lookup failed", "platform", platform, "channel", channel, "error", fErr)
 		} else if len(fallback) > 0 {
-			subs = fallback
+			active = filterCatchAll(fallback, mutedAgents)
 			log.Info("notify: delivering via catch-all subscription",
-				"channel", channel, "catch_all", platform+catchAllSuffix, "agents", len(fallback))
+				"channel", channel, "catch_all", platform+catchAllSuffix, "agents", len(active))
 		}
 	}
+	subs = active
 
 	log.Info("notify: dispatch", "channel", channel, "sender", sender, "subscribers", len(subs))
 
@@ -316,6 +321,9 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 
 	// Deliver to each subscribed agent
 	for _, sub := range subs {
+		if sub.Muted {
+			continue
+		}
 		// Self-skip: don't echo agent's own message back
 		if strings.EqualFold(sub.Agent, rawSender) {
 			continue
@@ -395,6 +403,40 @@ func (s *Service) SetMentionOnly(ctx context.Context, channel, agent string, men
 	return s.store.SetMentionOnly(ctx, channel, agent, mentionOnly)
 }
 
+// SetMuted upserts or clears a mute that suppresses catch-all for this
+// agent on the channel (#3466).
+func (s *Service) SetMuted(ctx context.Context, channel, agent string, muted bool) error {
+	return s.store.SetMuted(ctx, channel, agent, muted)
+}
+
+// partitionSubs splits channel rows into active subscribers and a mute set.
+// Muted rows must not count as active (that would block catch-all for everyone).
+func partitionSubs(subs []Subscription) (active []Subscription, muted map[string]bool) {
+	muted = make(map[string]bool)
+	for _, sub := range subs {
+		if sub.Muted {
+			muted[strings.ToLower(sub.Agent)] = true
+			continue
+		}
+		active = append(active, sub)
+	}
+	return active, muted
+}
+
+func filterCatchAll(fallback []Subscription, muted map[string]bool) []Subscription {
+	if len(muted) == 0 {
+		return fallback
+	}
+	out := make([]Subscription, 0, len(fallback))
+	for _, sub := range fallback {
+		if muted[strings.ToLower(sub.Agent)] {
+			continue
+		}
+		out = append(out, sub)
+	}
+	return out
+}
+
 // ChannelSubscriptions returns all subscriptions for a channel.
 func (s *Service) ChannelSubscriptions(ctx context.Context, channel string) ([]Subscription, error) {
 	return s.store.Subscribers(ctx, channel)
@@ -454,6 +496,7 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 		log.Warn("notify: failed to get subscribers for outbound", "channel", channel, "error", subErr)
 		return
 	}
+	active, mutedAgents := partitionSubs(subs)
 
 	// Extract platform from channel name (e.g., "slack:general" -> "slack")
 	platform := ""
@@ -461,20 +504,21 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 		platform = channel[:idx]
 	}
 
-	// Fallback to catch-all subscription if no direct subscribers
-	if len(subs) == 0 && platform != "" {
+	// Fallback to catch-all subscription if no active direct subscribers
+	if len(active) == 0 && platform != "" {
 		catchAll := platform + catchAllSuffix
 		if channel != "" && channel != catchAll && strings.HasPrefix(channel, platform+":") {
 			fallback, fErr := s.store.Subscribers(ctx, catchAll)
 			if fErr != nil {
 				log.Warn("notify: catch-all lookup failed for outbound", "platform", platform, "channel", channel, "error", fErr)
 			} else if len(fallback) > 0 {
-				subs = fallback
+				active = filterCatchAll(fallback, mutedAgents)
 				log.Info("notify: delivering outbound via catch-all subscription",
-					"channel", channel, "catch_all", catchAll, "agents", len(fallback))
+					"channel", channel, "catch_all", catchAll, "agents", len(active))
 			}
 		}
 	}
+	subs = active
 
 	log.Info("notify: outbound fan-out", "channel", channel, "sender", sender, "subscribers", len(subs))
 
@@ -506,6 +550,9 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 
 	// Deliver to each subscribed agent
 	for _, sub := range subs {
+		if sub.Muted {
+			continue
+		}
 		// Self-skip: don't echo agent's own message back
 		if strings.EqualFold(sub.Agent, rawSender) {
 			continue

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -567,6 +567,67 @@ func TestExplicitChannelSubscriptionWinsOverCatchAll(t *testing.T) {
 	}
 }
 
+// TestCatchAllRespectsMutedChannel: mute on the real channel suppresses
+// catch-all for that agent only (#3466).
+func TestCatchAllRespectsMutedChannel(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "telegram:general", "broad-agent", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMuted(ctx, "telegram:alice", "broad-agent", true); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("telegram:alice", "telegram", "alice", "", "", "hi muted", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+	if calls := sender.getCalls(); len(calls) != 0 {
+		t.Fatalf("muted agent must not receive catch-all delivery, got %+v", calls)
+	}
+
+	svc.Dispatch("telegram:bob", "telegram", "bob", "", "", "hi bob", "m2", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "broad-agent" {
+		t.Fatalf("expected catch-all delivery on unmuted channel, got %+v", calls)
+	}
+}
+
+// TestMutedRowDoesNotBlockCatchAllForOtherAgents: a mute for agent A must
+// not prevent agent B from receiving via catch-all on the same channel.
+func TestMutedRowDoesNotBlockCatchAllForOtherAgents(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "telegram:general", "agent-a", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Subscribe(ctx, "telegram:general", "agent-b", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMuted(ctx, "telegram:alice", "agent-a", true); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("telegram:alice", "telegram", "alice", "", "", "hi", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch did not finish")
+	}
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "agent-b" {
+		t.Fatalf("expected only agent-b, got %+v", calls)
+	}
+}
+
 // TestDispatchAutomatedFeedsWithoutWakingAgents pins the notification-mail
 // policy: machine-generated mail still lands in the channel feed and reaches
 // the web UI, but no agent is prompted. Without this, every GitHub

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -74,6 +74,7 @@ func (s *Store) initSchema() error {
 	for _, alter := range []string{
 		`ALTER TABLE notify_channels ADD COLUMN avatar_url TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE notify_messages ADD COLUMN sender_avatar TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE notify_subscriptions ADD COLUMN muted INTEGER NOT NULL DEFAULT 0`,
 	} {
 		_, _ = s.db.ExecContext(context.TODO(), alter) //nolint:errcheck // ignore if column already exists
 	}
@@ -86,6 +87,7 @@ CREATE TABLE IF NOT EXISTS notify_subscriptions (
     channel      TEXT NOT NULL,
     agent        TEXT NOT NULL,
     mention_only INTEGER NOT NULL DEFAULT 0,
+    muted        INTEGER NOT NULL DEFAULT 0,
     created_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     UNIQUE(channel, agent)
 );
@@ -143,6 +145,7 @@ CREATE TABLE IF NOT EXISTS notify_subscriptions (
     channel      TEXT NOT NULL,
     agent        TEXT NOT NULL,
     mention_only INTEGER NOT NULL DEFAULT 0,
+    muted        INTEGER NOT NULL DEFAULT 0,
     created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE(channel, agent)
 );
@@ -192,16 +195,17 @@ CREATE INDEX IF NOT EXISTS idx_notify_messages_channel ON notify_messages(channe
 CREATE INDEX IF NOT EXISTS idx_notify_messages_chan_sender ON notify_messages(channel, sender);
 `
 
-// Subscribe adds an agent to a channel. If already subscribed, this is a no-op.
+// Subscribe adds an agent to a channel. If already subscribed, this is a no-op
+// for the row and clears muted (an explicit subscribe means deliver).
 func (s *Store) Subscribe(ctx context.Context, channel, agent string, mentionOnly bool) error {
 	mentionInt := 0
 	if mentionOnly {
 		mentionInt = 1
 	}
 	_, err := s.db.ExecContext(ctx, s.q(
-		`INSERT INTO notify_subscriptions (channel, agent, mention_only)
-		 VALUES (?, ?, ?)
-		 ON CONFLICT(channel, agent) DO UPDATE SET mention_only = excluded.mention_only`),
+		`INSERT INTO notify_subscriptions (channel, agent, mention_only, muted)
+		 VALUES (?, ?, ?, 0)
+		 ON CONFLICT(channel, agent) DO UPDATE SET mention_only = excluded.mention_only, muted = 0`),
 		channel, agent, mentionInt)
 	return err
 }
@@ -226,10 +230,25 @@ func (s *Store) SetMentionOnly(ctx context.Context, channel, agent string, menti
 	return err
 }
 
-// Subscribers returns all subscriptions for a channel.
+// SetMuted upserts a mute row for (channel, agent). muted=true suppresses
+// catch-all delivery; muted=false removes the mute row so catch-all applies
+// again (#3466).
+func (s *Store) SetMuted(ctx context.Context, channel, agent string, muted bool) error {
+	if !muted {
+		return s.Unsubscribe(ctx, channel, agent)
+	}
+	_, err := s.db.ExecContext(ctx, s.q(
+		`INSERT INTO notify_subscriptions (channel, agent, mention_only, muted)
+		 VALUES (?, ?, 0, 1)
+		 ON CONFLICT(channel, agent) DO UPDATE SET muted = 1`),
+		channel, agent)
+	return err
+}
+
+// Subscribers returns all subscriptions for a channel (including muted rows).
 func (s *Store) Subscribers(ctx context.Context, channel string) ([]Subscription, error) {
 	rows, err := s.db.QueryContext(ctx, s.q(
-		`SELECT id, channel, agent, mention_only, created_at FROM notify_subscriptions WHERE channel = ?`),
+		`SELECT id, channel, agent, mention_only, muted, created_at FROM notify_subscriptions WHERE channel = ?`),
 		channel)
 	if err != nil {
 		return nil, err
@@ -239,12 +258,13 @@ func (s *Store) Subscribers(ctx context.Context, channel string) ([]Subscription
 	var subs []Subscription
 	for rows.Next() {
 		var sub Subscription
-		var mentionInt int
+		var mentionInt, mutedInt int
 		var createdStr string
-		if err := rows.Scan(&sub.ID, &sub.Channel, &sub.Agent, &mentionInt, &createdStr); err != nil {
+		if err := rows.Scan(&sub.ID, &sub.Channel, &sub.Agent, &mentionInt, &mutedInt, &createdStr); err != nil {
 			return nil, err
 		}
 		sub.MentionOnly = mentionInt != 0
+		sub.Muted = mutedInt != 0
 		sub.CreatedAt, _ = time.Parse(time.RFC3339, createdStr) //nolint:errcheck // DB-written timestamp
 		subs = append(subs, sub)
 	}
@@ -254,7 +274,7 @@ func (s *Store) Subscribers(ctx context.Context, channel string) ([]Subscription
 // AllSubscriptions returns all subscriptions across all channels.
 func (s *Store) AllSubscriptions(ctx context.Context) ([]Subscription, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, channel, agent, mention_only, created_at FROM notify_subscriptions ORDER BY channel, agent`)
+		`SELECT id, channel, agent, mention_only, muted, created_at FROM notify_subscriptions ORDER BY channel, agent`)
 	if err != nil {
 		return nil, err
 	}
@@ -263,12 +283,13 @@ func (s *Store) AllSubscriptions(ctx context.Context) ([]Subscription, error) {
 	var subs []Subscription
 	for rows.Next() {
 		var sub Subscription
-		var mentionInt int
+		var mentionInt, mutedInt int
 		var createdStr string
-		if err := rows.Scan(&sub.ID, &sub.Channel, &sub.Agent, &mentionInt, &createdStr); err != nil {
+		if err := rows.Scan(&sub.ID, &sub.Channel, &sub.Agent, &mentionInt, &mutedInt, &createdStr); err != nil {
 			return nil, err
 		}
 		sub.MentionOnly = mentionInt != 0
+		sub.Muted = mutedInt != 0
 		sub.CreatedAt, _ = time.Parse(time.RFC3339, createdStr) //nolint:errcheck // DB-written timestamp
 		subs = append(subs, sub)
 	}

--- a/server/handlers/gateways.go
+++ b/server/handlers/gateways.go
@@ -269,6 +269,7 @@ func (h *GatewayHandler) gatewayChannelAgents(w http.ResponseWriter, r *http.Req
 		// PATCH /api/apps/{name}/channels/{ch}/agents/{agent}
 		var req struct {
 			MentionOnly *bool `json:"mention_only"`
+			Muted       *bool `json:"muted"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			httpError(w, "invalid body", http.StatusBadRequest)
@@ -282,6 +283,12 @@ func (h *GatewayHandler) gatewayChannelAgents(w http.ResponseWriter, r *http.Req
 		if req.MentionOnly != nil {
 			if err := h.notifySvc.SetMentionOnly(r.Context(), channel, agent, *req.MentionOnly); err != nil {
 				httpInternalError(w, "set mention_only", err)
+				return
+			}
+		}
+		if req.Muted != nil {
+			if err := h.notifySvc.SetMuted(r.Context(), channel, agent, *req.Muted); err != nil {
+				httpInternalError(w, "set muted", err)
 				return
 			}
 		}
@@ -539,6 +546,7 @@ func (h *GatewayHandler) notifySubscriptionByChannel(w http.ResponseWriter, r *h
 	case http.MethodPatch:
 		var req struct {
 			MentionOnly *bool  `json:"mention_only"`
+			Muted       *bool  `json:"muted"`
 			Agent       string `json:"agent"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -552,6 +560,12 @@ func (h *GatewayHandler) notifySubscriptionByChannel(w http.ResponseWriter, r *h
 		if req.MentionOnly != nil {
 			if err := h.notifySvc.SetMentionOnly(r.Context(), channel, req.Agent, *req.MentionOnly); err != nil {
 				httpInternalError(w, "set mention_only", err)
+				return
+			}
+		}
+		if req.Muted != nil {
+			if err := h.notifySvc.SetMuted(r.Context(), channel, req.Agent, *req.Muted); err != nil {
+				httpInternalError(w, "set muted", err)
 				return
 			}
 		}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -160,6 +160,7 @@ export interface NotifySubscription {
   channel: string;
   agent: string;
   mention_only: boolean;
+  muted?: boolean;
   created_at: string;
 }
 
@@ -1160,6 +1161,19 @@ export const api = {
     return request<{ status: string }>(`/notify/subscriptions/${encodeURIComponent(channel)}`, {
       method: "PATCH",
       body: JSON.stringify({ agent, mention_only: mentionOnly }),
+    });
+  },
+  setMuted: (channel: string, agent: string, muted: boolean) => {
+    const { gw, ch } = splitChannel(channel);
+    if (gw && ch) {
+      return request<{ status: string }>(`/apps/${gw}/channels/${ch}/agents/${encodeURIComponent(agent)}`, {
+        method: "PATCH",
+        body: JSON.stringify({ muted }),
+      });
+    }
+    return request<{ status: string }>(`/notify/subscriptions/${encodeURIComponent(channel)}`, {
+      method: "PATCH",
+      body: JSON.stringify({ agent, muted }),
     });
   },
   getChannelActivity: (channel: string, limit = 50) => {

--- a/web/src/components/apps/SubscriptionPanel.tsx
+++ b/web/src/components/apps/SubscriptionPanel.tsx
@@ -12,6 +12,8 @@ function AgentRow({
   onSubscribe,
   onUnsubscribe,
   onToggleMention,
+  onMute,
+  onUnmute,
 }: {
   agent: Agent;
   sub?: NotifySubscription;
@@ -19,9 +21,13 @@ function AgentRow({
   onSubscribe: () => void;
   onUnsubscribe: () => void;
   onToggleMention: () => void;
+  onMute: () => void;
+  onUnmute: () => void;
 }) {
   const isStopped = agent.state === "stopped";
   const roleColor = getRoleColor(agent.role);
+  const muted = Boolean(sub?.muted);
+  const active = Boolean(sub && !sub.muted);
 
   return (
     <motion.div
@@ -33,15 +39,12 @@ function AgentRow({
       className={`px-3 py-2 transition-colors duration-100 hover:bg-mycel-surface-hover ${isStopped && !sub ? "opacity-50" : ""}`}
     >
       <div className="flex items-center gap-2">
-        {/* Living character + name + status dot */}
         <AgentChip
           name={agent.name}
           state={agent.state}
           size={20}
           className="flex-1 text-mycel-text"
         />
-
-        {/* Role */}
         <span
           className={`text-[8px] px-1.5 py-0.5 rounded-md ${roleColor.bg} ${roleColor.text} font-semibold uppercase tracking-wider shrink-0`}
         >
@@ -49,20 +52,33 @@ function AgentRow({
         </span>
       </div>
 
-      {/* Actions */}
       <div className="flex items-center gap-1.5 mt-1.5 ml-7">
-        {sub ? (
+        {muted ? (
+          <>
+            <span className="text-[10px] px-2 py-0.5 rounded-md border border-mycel-border text-mycel-muted">
+              muted
+            </span>
+            <button
+              type="button"
+              onClick={onUnmute}
+              disabled={loading}
+              className="text-[10px] text-mycel-muted hover:text-mycel-accent transition-colors ml-auto"
+            >
+              unmute
+            </button>
+          </>
+        ) : active ? (
           <>
             <button
               type="button"
               onClick={onToggleMention}
               className={`text-[10px] px-2 py-0.5 rounded-md border transition-all duration-150 ${
-                sub.mention_only
+                sub!.mention_only
                   ? "border-mycel-accent bg-mycel-accent-subtle text-mycel-accent"
                   : "border-mycel-border text-mycel-muted hover:border-mycel-border-strong"
               }`}
             >
-              {sub.mention_only ? "@ mentions" : "all msgs"}
+              {sub!.mention_only ? "@ mentions" : "all msgs"}
             </button>
             <button
               type="button"
@@ -74,14 +90,25 @@ function AgentRow({
             </button>
           </>
         ) : (
-          <button
-            type="button"
-            onClick={onSubscribe}
-            disabled={loading}
-            className="text-[10px] text-mycel-muted hover:text-mycel-accent transition-colors"
-          >
-            + subscribe
-          </button>
+          <>
+            <button
+              type="button"
+              onClick={onSubscribe}
+              disabled={loading}
+              className="text-[10px] text-mycel-muted hover:text-mycel-accent transition-colors"
+            >
+              + subscribe
+            </button>
+            <button
+              type="button"
+              onClick={onMute}
+              disabled={loading}
+              className="text-[10px] text-mycel-muted hover:text-mycel-text transition-colors ml-auto"
+              title="Suppress catch-all delivery for this channel"
+            >
+              mute
+            </button>
+          </>
         )}
       </div>
     </motion.div>
@@ -144,25 +171,62 @@ export function SubscriptionPanel({
     } catch { /* */ }
   };
 
-  const subscribedAgents = agents.filter((a) => subMap.has(a.name));
+  const handleMute = async (agentName: string) => {
+    setLoading(true);
+    try {
+      await api.setMuted(channelName, agentName, true);
+      await fetchData();
+    } catch { /* */ }
+    setLoading(false);
+  };
 
-  // Sort agents by availability: working (green) > idle (amber) > stopped (gray, dimmed)
+  const handleUnmute = async (agentName: string) => {
+    setLoading(true);
+    try {
+      await api.setMuted(channelName, agentName, false);
+      await fetchData();
+    } catch { /* */ }
+    setLoading(false);
+  };
+
   const agentSortOrder = (agent: { state: string }) => {
     if (agent.state === "working" || agent.state === "running") return 0;
     if (agent.state === "stopped") return 2;
-    return 1; // idle or other states
+    return 1;
   };
+
+  const listeningAgents = agents
+    .filter((a) => {
+      const s = subMap.get(a.name);
+      return s && !s.muted;
+    })
+    .sort((a, b) => agentSortOrder(a) - agentSortOrder(b) || a.name.localeCompare(b.name));
+
+  const mutedAgents = agents
+    .filter((a) => subMap.get(a.name)?.muted)
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   const availableAgents = agents
     .filter((a) => !subMap.has(a.name))
     .sort((a, b) => agentSortOrder(a) - agentSortOrder(b) || a.name.localeCompare(b.name));
+
+  const rowProps = (agent: Agent) => ({
+    agent,
+    sub: subMap.get(agent.name),
+    loading,
+    onSubscribe: () => handleSubscribe(agent.name),
+    onUnsubscribe: () => handleUnsubscribe(agent.name),
+    onToggleMention: () =>
+      handleToggleMention(agent.name, subMap.get(agent.name)?.mention_only ?? false),
+    onMute: () => handleMute(agent.name),
+    onUnmute: () => handleUnmute(agent.name),
+  });
 
   return (
     <aside
       className="w-56 shrink-0 border-l border-mycel-border flex flex-col bg-mycel-bg"
       style={{ scrollbarWidth: "thin", scrollbarColor: "var(--mycel-scrollbar-thumb) transparent" }}
     >
-      {/* Header */}
       <div className="px-3 py-3 border-b border-mycel-border">
         <h3 className="text-[11px] font-medium text-mycel-muted uppercase tracking-[0.08em]">
           Agents
@@ -171,42 +235,39 @@ export function SubscriptionPanel({
 
       <div className="flex-1 overflow-auto">
         <AnimatePresence>
-          {/* Subscribed */}
-          {subscribedAgents.length > 0 && (
+          {listeningAgents.length > 0 && (
             <div>
               <div className="px-3 pt-3 pb-1">
                 <div className="flex items-center gap-1.5">
                   <span className="w-1 h-1 rounded-full bg-mycel-success" />
                   <span className="text-[10px] font-medium text-mycel-success uppercase tracking-[0.08em]">
-                    Listening ({subscribedAgents.length})
+                    Listening ({listeningAgents.length})
                   </span>
                 </div>
               </div>
-              {subscribedAgents.map((agent) => (
-                <AgentRow
-                  key={agent.name}
-                  agent={agent}
-                  sub={subMap.get(agent.name)}
-                  loading={loading}
-                  onSubscribe={() => handleSubscribe(agent.name)}
-                  onUnsubscribe={() => handleUnsubscribe(agent.name)}
-                  onToggleMention={() =>
-                    handleToggleMention(
-                      agent.name,
-                      subMap.get(agent.name)?.mention_only ?? false,
-                    )
-                  }
-                />
+              {listeningAgents.map((agent) => (
+                <AgentRow key={agent.name} {...rowProps(agent)} />
               ))}
             </div>
           )}
 
-          {/* Divider */}
-          {subscribedAgents.length > 0 && availableAgents.length > 0 && (
+          {mutedAgents.length > 0 && (
+            <div>
+              <div className="px-3 pt-3 pb-1">
+                <span className="text-[10px] font-medium text-mycel-muted uppercase tracking-[0.08em]">
+                  Muted ({mutedAgents.length})
+                </span>
+              </div>
+              {mutedAgents.map((agent) => (
+                <AgentRow key={agent.name} {...rowProps(agent)} />
+              ))}
+            </div>
+          )}
+
+          {(listeningAgents.length > 0 || mutedAgents.length > 0) && availableAgents.length > 0 && (
             <div className="mx-3 my-2 border-t border-mycel-border" />
           )}
 
-          {/* Available */}
           {availableAgents.length > 0 && (
             <div>
               <div className="px-3 pt-2 pb-1">
@@ -215,14 +276,7 @@ export function SubscriptionPanel({
                 </span>
               </div>
               {availableAgents.map((agent) => (
-                <AgentRow
-                  key={agent.name}
-                  agent={agent}
-                  loading={loading}
-                  onSubscribe={() => handleSubscribe(agent.name)}
-                  onUnsubscribe={() => handleUnsubscribe(agent.name)}
-                  onToggleMention={() => {}}
-                />
+                <AgentRow key={agent.name} {...rowProps(agent)} />
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary
Implements #3466: a per-(agent, channel) `muted` subscription row suppresses catch-all delivery without blocking catch-all for other agents.

- Schema: `notify_subscriptions.muted` (+ ALTER migration)
- Delivery: muted rows do not count as active; catch-all is filtered by mute set
- API: PATCH `muted` on notify + apps channel agent routes
- UI: Subscription panel Mute / Unmute / Muted section

## Test plan
- [x] `go test ./pkg/notify/` (incl. new mute catch-all tests)
- [ ] With catch-all on `telegram:general`, mute an agent on `telegram:alice` — no delivery to alice, still delivers to bob
- [ ] Unmute restores catch-all delivery
- [ ] Explicit subscribe clears mute

Closes #3466
Part of #3624
