### PR TITLE
feat(notify): mycel notify prune for leftover catch-all copies (#3465)

### DIFF
--- a/docs/reference/cli/mycel_notify.md
+++ b/docs/reference/cli/mycel_notify.md
@@ -15,6 +15,8 @@ Examples:
   mycel notify subscribe slack:eng eng-01            # Subscribe agent to channel
   mycel notify unsubscribe slack:eng eng-01          # Unsubscribe agent
   mycel notify activity slack:eng                    # Show delivery activity log
+  mycel notify prune --dry-run                       # Preview leftover catch-all copies
+  mycel notify prune --yes                           # Delete matching leftovers
 
 ### Options
 
@@ -34,6 +36,7 @@ Examples:
 * [mycel](mycel.md)	 - A simpler, more controllable agent orchestrator
 * [mycel notify activity](mycel_notify_activity.md)	 - Show delivery activity for a channel
 * [mycel notify list](mycel_notify_list.md)	 - List all agent subscriptions
+* [mycel notify prune](mycel_notify_prune.md)	 - Remove leftover catch-all auto-copied subscriptions
 * [mycel notify status](mycel_notify_status.md)	 - Show gateway connection status and subscriptions
 * [mycel notify subscribe](mycel_notify_subscribe.md)	 - Subscribe an agent to a channel
 * [mycel notify unsubscribe](mycel_notify_unsubscribe.md)	 - Unsubscribe an agent from a channel

--- a/docs/reference/cli/mycel_notify_prune.md
+++ b/docs/reference/cli/mycel_notify_prune.md
@@ -1,0 +1,43 @@
+## mycel notify prune
+
+Remove leftover catch-all auto-copied subscriptions
+
+### Synopsis
+
+List (and optionally delete) per-channel subscriptions that look like
+copies of a platform catch-all ("{platform}:general") row.
+
+Before #3464, catch-all delivery wrote permanent rows onto every real channel.
+Those rows have no provenance, so prune uses a heuristic: same agent and
+mention_only as an existing catch-all subscription. Deliberate subscriptions
+that happen to match are included — review the list before confirming.
+
+Examples:
+  mycel notify prune --dry-run
+  mycel notify prune --platform gmail
+  mycel notify prune --yes
+
+```
+mycel notify prune [flags]
+```
+
+### Options
+
+```
+      --dry-run           List candidates without deleting
+  -h, --help              help for prune
+      --json              Output candidates as JSON
+      --platform string   Only consider channels for this platform (e.g. gmail)
+      --yes               Delete without interactive confirmation
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --verbose   Enable verbose output
+```
+
+### SEE ALSO
+
+* [mycel notify](mycel_notify.md)	 - Manage channel subscriptions and gateway notifications
+

--- a/internal/cmd/notify.go
+++ b/internal/cmd/notify.go
@@ -1,14 +1,17 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/rpuneet/mycel/pkg/client"
+	"github.com/rpuneet/mycel/pkg/notify"
 	"github.com/rpuneet/mycel/pkg/ui"
 )
 
@@ -27,7 +30,9 @@ Examples:
   mycel notify list                                  # List all subscriptions
   mycel notify subscribe slack:eng eng-01            # Subscribe agent to channel
   mycel notify unsubscribe slack:eng eng-01          # Unsubscribe agent
-  mycel notify activity slack:eng                    # Show delivery activity log`,
+  mycel notify activity slack:eng                    # Show delivery activity log
+  mycel notify prune --dry-run                       # Preview leftover catch-all copies
+  mycel notify prune --yes                           # Delete matching leftovers`,
 	}
 
 	statusCmd := &cobra.Command{
@@ -193,8 +198,122 @@ Examples:
 	}
 	activityCmd.Flags().Int("limit", 20, "Number of recent entries to show")
 
-	cmd.AddCommand(statusCmd, listCmd, subscribeCmd, unsubscribeCmd, activityCmd)
+	pruneCmd := &cobra.Command{
+		Use:   "prune",
+		Short: "Remove leftover catch-all auto-copied subscriptions",
+		Long: `List (and optionally delete) per-channel subscriptions that look like
+copies of a platform catch-all ("{platform}:general") row.
+
+Before #3464, catch-all delivery wrote permanent rows onto every real channel.
+Those rows have no provenance, so prune uses a heuristic: same agent and
+mention_only as an existing catch-all subscription. Deliberate subscriptions
+that happen to match are included — review the list before confirming.
+
+Examples:
+  mycel notify prune --dry-run
+  mycel notify prune --platform gmail
+  mycel notify prune --yes`,
+		RunE: runNotifyPrune,
+	}
+	pruneCmd.Flags().Bool("dry-run", false, "List candidates without deleting")
+	pruneCmd.Flags().Bool("yes", false, "Delete without interactive confirmation")
+	pruneCmd.Flags().String("platform", "", "Only consider channels for this platform (e.g. gmail)")
+	pruneCmd.Flags().Bool("json", false, "Output candidates as JSON")
+
+	cmd.AddCommand(statusCmd, listCmd, subscribeCmd, unsubscribeCmd, activityCmd, pruneCmd)
 	return cmd
+}
+
+func runNotifyPrune(cmd *cobra.Command, _ []string) error {
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+	yes, _ := cmd.Flags().GetBool("yes")
+	platform, _ := cmd.Flags().GetString("platform")
+	jsonFlag, _ := cmd.Flags().GetBool("json")
+
+	c := client.New("")
+	ctx := context.Background()
+	subs, err := c.Notify.ListSubscriptions(ctx)
+	if err != nil {
+		return fmt.Errorf("list subscriptions: %w", err)
+	}
+
+	notifySubs := make([]notify.Subscription, len(subs))
+	for i, s := range subs {
+		notifySubs[i] = notify.Subscription{
+			ID:          s.ID,
+			Channel:     s.Channel,
+			Agent:       s.Agent,
+			MentionOnly: s.MentionOnly,
+			Muted:       s.Muted,
+			CreatedAt:   s.CreatedAt,
+		}
+	}
+	candidates := notify.FilterPruneByPlatform(notify.FindPruneCandidates(notifySubs), platform)
+
+	if jsonFlag {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(candidates); err != nil {
+			return err
+		}
+	} else if len(candidates) == 0 {
+		fmt.Println("No catch-all copy candidates found.")
+		return nil
+	} else {
+		fmt.Printf("Found %d candidate subscription(s) that match a catch-all row:\n", len(candidates))
+		for _, sub := range candidates {
+			mention := ""
+			if sub.MentionOnly {
+				mention = " (@mention only)"
+			}
+			fmt.Printf("  %-40s → %s%s\n", sub.Channel, sub.Agent, mention)
+		}
+		fmt.Println()
+		fmt.Println("These may be leftover auto-copies; deliberate subscriptions that")
+		fmt.Println("mirror the catch-all settings are also listed. Review carefully.")
+	}
+
+	if len(candidates) == 0 || dryRun {
+		if dryRun && !jsonFlag && len(candidates) > 0 {
+			fmt.Println("Dry run — nothing deleted. Re-run with --yes to remove them.")
+		}
+		return nil
+	}
+	if !yes {
+		if jsonFlag {
+			return fmt.Errorf("refusing to delete without --yes when using --json")
+		}
+		fmt.Print("\nType 'yes' to delete these subscriptions: ")
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil {
+			return fmt.Errorf("read confirmation: %w", err)
+		}
+		if strings.TrimSpace(line) != "yes" {
+			fmt.Println("Aborted.")
+			return nil
+		}
+	}
+
+	var failed int
+	for _, sub := range candidates {
+		if err := c.Notify.Unsubscribe(ctx, sub.Channel, sub.Agent); err != nil {
+			fmt.Fprintf(os.Stderr, "failed %s → %s: %v\n", sub.Channel, sub.Agent, err)
+			failed++
+			continue
+		}
+		if !jsonFlag {
+			fmt.Printf("Removed %s → %s\n", sub.Channel, sub.Agent)
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("removed %d, failed %d", len(candidates)-failed, failed)
+	}
+	if jsonFlag {
+		fmt.Fprintf(os.Stderr, "removed %d subscription(s)\n", len(candidates))
+	} else {
+		fmt.Printf("Removed %d subscription(s).\n", len(candidates))
+	}
+	return nil
 }
 
 func init() {

--- a/pkg/notify/prune.go
+++ b/pkg/notify/prune.go
@@ -31,7 +31,7 @@ func IsCatchAll(channel string) bool {
 }
 
 // FindPruneCandidates returns non-catch-all subscriptions that look like
-// leftovers from the old catch-all copy behaviour (#3463/#3465): same agent
+// leftovers from the old catch-all copy behavior (#3463/#3465): same agent
 // and mention_only as an existing "{platform}:general" row.
 //
 // Muted rows are skipped — they are intentional mute markers (#3466), not

--- a/pkg/notify/prune.go
+++ b/pkg/notify/prune.go
@@ -1,0 +1,99 @@
+package notify
+
+import (
+	"sort"
+	"strings"
+)
+
+// CatchAllChannel returns the catch-all subscription key for a platform
+// ("{platform}:general"). Empty platform yields an empty string.
+func CatchAllChannel(platform string) string {
+	if platform == "" {
+		return ""
+	}
+	return platform + catchAllSuffix
+}
+
+// PlatformOf returns the platform prefix of a channel key ("slack:eng" → "slack").
+// Empty when the key has no ":" separator.
+func PlatformOf(channel string) string {
+	i := strings.IndexByte(channel, ':')
+	if i <= 0 {
+		return ""
+	}
+	return channel[:i]
+}
+
+// IsCatchAll reports whether channel is exactly "{platform}:general".
+func IsCatchAll(channel string) bool {
+	platform := PlatformOf(channel)
+	return platform != "" && channel == CatchAllChannel(platform)
+}
+
+// FindPruneCandidates returns non-catch-all subscriptions that look like
+// leftovers from the old catch-all copy behaviour (#3463/#3465): same agent
+// and mention_only as an existing "{platform}:general" row.
+//
+// Muted rows are skipped — they are intentional mute markers (#3466), not
+// auto-copied delivery subscriptions. There is no provenance column, so this
+// heuristic can also match deliberate per-channel subscriptions that happen
+// to mirror the catch-all; callers must confirm before deleting.
+func FindPruneCandidates(subs []Subscription) []Subscription {
+	type key struct {
+		agent       string
+		mentionOnly bool
+	}
+	catchAll := map[string]map[key]struct{}{} // platform → catch-all agent settings
+	for _, sub := range subs {
+		if !IsCatchAll(sub.Channel) || sub.Muted {
+			continue
+		}
+		platform := PlatformOf(sub.Channel)
+		if catchAll[platform] == nil {
+			catchAll[platform] = map[key]struct{}{}
+		}
+		catchAll[platform][key{agent: sub.Agent, mentionOnly: sub.MentionOnly}] = struct{}{}
+	}
+
+	var out []Subscription
+	for _, sub := range subs {
+		if IsCatchAll(sub.Channel) || sub.Muted {
+			continue
+		}
+		platform := PlatformOf(sub.Channel)
+		if platform == "" {
+			continue
+		}
+		agents, ok := catchAll[platform]
+		if !ok {
+			continue
+		}
+		if _, match := agents[key{agent: sub.Agent, mentionOnly: sub.MentionOnly}]; !match {
+			continue
+		}
+		out = append(out, sub)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Channel != out[j].Channel {
+			return out[i].Channel < out[j].Channel
+		}
+		return out[i].Agent < out[j].Agent
+	})
+	return out
+}
+
+// FilterPruneByPlatform keeps candidates whose channel platform matches
+// platform. Empty platform returns all candidates unchanged.
+func FilterPruneByPlatform(candidates []Subscription, platform string) []Subscription {
+	if platform == "" {
+		return candidates
+	}
+	var out []Subscription
+	for _, sub := range candidates {
+		if PlatformOf(sub.Channel) == platform {
+			out = append(out, sub)
+		}
+	}
+	return out
+}

--- a/pkg/notify/prune_test.go
+++ b/pkg/notify/prune_test.go
@@ -1,0 +1,89 @@
+package notify
+
+import "testing"
+
+func TestFindPruneCandidates(t *testing.T) {
+	subs := []Subscription{
+		{Channel: "gmail:general", Agent: "fast-crane", MentionOnly: false},
+		{Channel: "gmail:alertsbank", Agent: "fast-crane", MentionOnly: false},
+		{Channel: "gmail:newslettereconomictimes", Agent: "fast-crane", MentionOnly: false},
+		// deliberate: different mention_only than catch-all
+		{Channel: "gmail:focused", Agent: "fast-crane", MentionOnly: true},
+		// no catch-all for whatsapp — not a candidate
+		{Channel: "whatsapp:alice", Agent: "fast-crane", MentionOnly: false},
+		{Channel: "telegram:general", Agent: "broad", MentionOnly: false},
+		{Channel: "telegram:dm-bob", Agent: "broad", MentionOnly: false},
+		// mute marker must not be pruned
+		{Channel: "telegram:noisy", Agent: "broad", MentionOnly: false, Muted: true},
+		// other agent on same channel without matching catch-all
+		{Channel: "telegram:dm-bob", Agent: "other", MentionOnly: false},
+	}
+
+	got := FindPruneCandidates(subs)
+	want := map[string]bool{
+		"gmail:alertsbank|fast-crane":             true,
+		"gmail:newslettereconomictimes|fast-crane": true,
+		"telegram:dm-bob|broad":                   true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d candidates, want %d: %+v", len(got), len(want), got)
+	}
+	for _, c := range got {
+		key := c.Channel + "|" + c.Agent
+		if !want[key] {
+			t.Errorf("unexpected candidate %s", key)
+		}
+		if c.Muted {
+			t.Errorf("muted row returned as candidate: %+v", c)
+		}
+	}
+}
+
+func TestFindPruneCandidates_NoCatchAll(t *testing.T) {
+	subs := []Subscription{
+		{Channel: "gmail:only-explicit", Agent: "a", MentionOnly: false},
+	}
+	if got := FindPruneCandidates(subs); len(got) != 0 {
+		t.Fatalf("expected no candidates without catch-all, got %+v", got)
+	}
+}
+
+func TestFindPruneCandidates_SkipsCatchAllItself(t *testing.T) {
+	subs := []Subscription{
+		{Channel: "slack:general", Agent: "root", MentionOnly: false},
+	}
+	if got := FindPruneCandidates(subs); len(got) != 0 {
+		t.Fatalf("catch-all itself must never be a candidate, got %+v", got)
+	}
+}
+
+func TestFilterPruneByPlatform(t *testing.T) {
+	cands := []Subscription{
+		{Channel: "gmail:a", Agent: "x"},
+		{Channel: "whatsapp:b", Agent: "x"},
+	}
+	got := FilterPruneByPlatform(cands, "gmail")
+	if len(got) != 1 || got[0].Channel != "gmail:a" {
+		t.Fatalf("got %+v", got)
+	}
+	if all := FilterPruneByPlatform(cands, ""); len(all) != 2 {
+		t.Fatalf("empty platform should keep all, got %d", len(all))
+	}
+}
+
+func TestIsCatchAll(t *testing.T) {
+	cases := map[string]bool{
+		"gmail:general":   true,
+		"slack:general":   true,
+		"slack:eng":       false,
+		"general":         false,
+		"":                false,
+		"gmail:generalx":  false,
+		"foo:bar:general": false,
+	}
+	for ch, want := range cases {
+		if got := IsCatchAll(ch); got != want {
+			t.Errorf("IsCatchAll(%q)=%v want %v", ch, got, want)
+		}
+	}
+}

--- a/pkg/notify/prune_test.go
+++ b/pkg/notify/prune_test.go
@@ -21,9 +21,9 @@ func TestFindPruneCandidates(t *testing.T) {
 
 	got := FindPruneCandidates(subs)
 	want := map[string]bool{
-		"gmail:alertsbank|fast-crane":             true,
+		"gmail:alertsbank|fast-crane":              true,
 		"gmail:newslettereconomictimes|fast-crane": true,
-		"telegram:dm-bob|broad":                   true,
+		"telegram:dm-bob|broad":                    true,
 	}
 	if len(got) != len(want) {
 		t.Fatalf("got %d candidates, want %d: %+v", len(got), len(want), got)


### PR DESCRIPTION
## Summary
- Adds `FindPruneCandidates` heuristic: per-channel subs that match an existing `{platform}:general` agent + `mention_only` (skips muted rows and the catch-all itself).
- Adds `mycel notify prune` with `--dry-run`, `--platform`, `--yes`, and `--json`.
- Regenerates CLI docs.

Closes #3465.

## Test plan
- [x] `go test ./pkg/notify/ -run Prune`
- [ ] CI Lint / Test / Web green
- [ ] Optional: `mycel notify prune --dry-run` against a workspace with leftover gmail/whatsapp copies


Made with [Cursor](https://cursor.com)