### PR TITLE
fix(notify): platform:* catch-all so slack:general is a real channel (#3467)

### DIFF
--- a/docs/reference/cli/mycel_notify_prune.md
+++ b/docs/reference/cli/mycel_notify_prune.md
@@ -5,7 +5,7 @@ Remove leftover catch-all auto-copied subscriptions
 ### Synopsis
 
 List (and optionally delete) per-channel subscriptions that look like
-copies of a platform catch-all ("{platform}:general") row.
+copies of a platform catch-all ("{platform}:*") row.
 
 Before #3464, catch-all delivery wrote permanent rows onto every real channel.
 Those rows have no provenance, so prune uses a heuristic: same agent and

--- a/internal/cmd/notify.go
+++ b/internal/cmd/notify.go
@@ -202,7 +202,7 @@ Examples:
 		Use:   "prune",
 		Short: "Remove leftover catch-all auto-copied subscriptions",
 		Long: `List (and optionally delete) per-channel subscriptions that look like
-copies of a platform catch-all ("{platform}:general") row.
+copies of a platform catch-all ("{platform}:*") row.
 
 Before #3464, catch-all delivery wrote permanent rows onto every real channel.
 Those rows have no provenance, so prune uses a heuristic: same agent and

--- a/pkg/client/notify.go
+++ b/pkg/client/notify.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -55,10 +56,10 @@ func (n *NotifyClient) ListSubscriptions(ctx context.Context) ([]Subscription, e
 func (n *NotifyClient) ChannelSubscriptions(ctx context.Context, channel string) ([]Subscription, error) {
 	var subs []Subscription
 	if gw, ch := splitGatewayChannel(channel); gw != "" {
-		err := n.client.get(ctx, fmt.Sprintf("/api/apps/%s/channels/%s/agents", gw, ch), &subs)
+		err := n.client.get(ctx, fmt.Sprintf("/api/apps/%s/channels/%s/agents", gw, url.PathEscape(ch)), &subs)
 		return subs, err
 	}
-	err := n.client.get(ctx, fmt.Sprintf("/api/notify/subscriptions/%s", channel), &subs)
+	err := n.client.get(ctx, fmt.Sprintf("/api/notify/subscriptions/%s", url.PathEscape(channel)), &subs)
 	return subs, err
 }
 
@@ -66,7 +67,7 @@ func (n *NotifyClient) ChannelSubscriptions(ctx context.Context, channel string)
 func (n *NotifyClient) Subscribe(ctx context.Context, channel, agent string, mentionOnly bool) error {
 	body := map[string]any{"agent": agent, "mention_only": mentionOnly}
 	if gw, ch := splitGatewayChannel(channel); gw != "" {
-		return n.client.post(ctx, fmt.Sprintf("/api/apps/%s/channels/%s/agents", gw, ch), body, nil)
+		return n.client.post(ctx, fmt.Sprintf("/api/apps/%s/channels/%s/agents", gw, url.PathEscape(ch)), body, nil)
 	}
 	body["channel"] = channel
 	return n.client.post(ctx, "/api/notify/subscriptions", body, nil)
@@ -75,18 +76,18 @@ func (n *NotifyClient) Subscribe(ctx context.Context, channel, agent string, men
 // Unsubscribe removes an agent from a channel.
 func (n *NotifyClient) Unsubscribe(ctx context.Context, channel, agent string) error {
 	if gw, ch := splitGatewayChannel(channel); gw != "" {
-		return n.client.delete(ctx, fmt.Sprintf("/api/apps/%s/channels/%s/agents/%s", gw, ch, agent))
+		return n.client.delete(ctx, fmt.Sprintf("/api/apps/%s/channels/%s/agents/%s", gw, url.PathEscape(ch), url.PathEscape(agent)))
 	}
-	return n.client.delete(ctx, fmt.Sprintf("/api/notify/subscriptions/%s?agent=%s", channel, agent))
+	return n.client.delete(ctx, fmt.Sprintf("/api/notify/subscriptions/%s?agent=%s", url.PathEscape(channel), url.QueryEscape(agent)))
 }
 
 // Activity returns recent delivery log entries for a channel.
 func (n *NotifyClient) Activity(ctx context.Context, channel string, limit int) ([]DeliveryEntry, error) {
 	var entries []DeliveryEntry
 	if gw, ch := splitGatewayChannel(channel); gw != "" {
-		err := n.client.get(ctx, fmt.Sprintf("/api/apps/%s/channels/%s/activity?limit=%d", gw, ch, limit), &entries)
+		err := n.client.get(ctx, fmt.Sprintf("/api/apps/%s/channels/%s/activity?limit=%d", gw, url.PathEscape(ch), limit), &entries)
 		return entries, err
 	}
-	err := n.client.get(ctx, fmt.Sprintf("/api/notify/activity/%s?limit=%d", channel, limit), &entries)
+	err := n.client.get(ctx, fmt.Sprintf("/api/notify/activity/%s?limit=%d", url.PathEscape(channel), limit), &entries)
 	return entries, err
 }

--- a/pkg/gateway/telegram/plugin.go
+++ b/pkg/gateway/telegram/plugin.go
@@ -28,7 +28,7 @@ func (plugin) Describe() app.Descriptor {
 			"Message @BotFather on Telegram → https://t.me/BotFather — send /newbot.",
 			"Copy the bot token. Message the bot in a DM or add it to a group.",
 			"Channels appear after the first inbound message (telegram:<username|chat_id|group>).",
-			"Do not subscribe to telegram:general — that key is not a real Telegram chat.",
+			"Do not subscribe to telegram:general or telegram:* as a stand-in — those are not real Telegram chats.",
 		},
 	}
 }

--- a/pkg/notify/prune.go
+++ b/pkg/notify/prune.go
@@ -5,13 +5,30 @@ import (
 	"strings"
 )
 
+// catchAllSuffix is the reserved channel leaf for platform-wide fallback
+// subscriptions (#3467). It cannot collide with a real Slack/Discord
+// "#general" channel the way the legacy ":general" leaf did.
+const catchAllSuffix = ":*"
+
+// legacyCatchAllSuffix is the pre-#3467 catch-all leaf. Still read (and
+// migrated to catchAllSuffix) so existing workspaces keep delivering.
+const legacyCatchAllSuffix = ":general"
+
 // CatchAllChannel returns the catch-all subscription key for a platform
-// ("{platform}:general"). Empty platform yields an empty string.
+// ("{platform}:*"). Empty platform yields an empty string.
 func CatchAllChannel(platform string) string {
 	if platform == "" {
 		return ""
 	}
 	return platform + catchAllSuffix
+}
+
+// LegacyCatchAllChannel returns the pre-#3467 catch-all key ("{platform}:general").
+func LegacyCatchAllChannel(platform string) string {
+	if platform == "" {
+		return ""
+	}
+	return platform + legacyCatchAllSuffix
 }
 
 // PlatformOf returns the platform prefix of a channel key ("slack:eng" → "slack").
@@ -24,15 +41,30 @@ func PlatformOf(channel string) string {
 	return channel[:i]
 }
 
-// IsCatchAll reports whether channel is exactly "{platform}:general".
+// IsCatchAll reports whether channel is the canonical catch-all ("{platform}:*").
 func IsCatchAll(channel string) bool {
 	platform := PlatformOf(channel)
 	return platform != "" && channel == CatchAllChannel(platform)
 }
 
+// IsLegacyCatchAll reports whether channel is the pre-#3467 catch-all key
+// ("{platform}:general"). Real Slack/Discord #general channels use this same
+// key, which is why #3467 moved the catch-all to ":*".
+func IsLegacyCatchAll(channel string) bool {
+	platform := PlatformOf(channel)
+	return platform != "" && channel == LegacyCatchAllChannel(platform)
+}
+
+// IsAnyCatchAll reports canonical or legacy catch-all keys. Used by prune
+// heuristics while both forms may exist in a database.
+func IsAnyCatchAll(channel string) bool {
+	return IsCatchAll(channel) || IsLegacyCatchAll(channel)
+}
+
 // FindPruneCandidates returns non-catch-all subscriptions that look like
 // leftovers from the old catch-all copy behavior (#3463/#3465): same agent
-// and mention_only as an existing "{platform}:general" row.
+// and mention_only as an existing catch-all row ("{platform}:*" or legacy
+// "{platform}:general").
 //
 // Muted rows are skipped — they are intentional mute markers (#3466), not
 // auto-copied delivery subscriptions. There is no provenance column, so this
@@ -45,7 +77,7 @@ func FindPruneCandidates(subs []Subscription) []Subscription {
 	}
 	catchAll := map[string]map[key]struct{}{} // platform → catch-all agent settings
 	for _, sub := range subs {
-		if !IsCatchAll(sub.Channel) || sub.Muted {
+		if !IsAnyCatchAll(sub.Channel) || sub.Muted {
 			continue
 		}
 		platform := PlatformOf(sub.Channel)
@@ -57,7 +89,7 @@ func FindPruneCandidates(subs []Subscription) []Subscription {
 
 	var out []Subscription
 	for _, sub := range subs {
-		if IsCatchAll(sub.Channel) || sub.Muted {
+		if IsAnyCatchAll(sub.Channel) || sub.Muted {
 			continue
 		}
 		platform := PlatformOf(sub.Channel)

--- a/pkg/notify/prune_test.go
+++ b/pkg/notify/prune_test.go
@@ -4,14 +4,14 @@ import "testing"
 
 func TestFindPruneCandidates(t *testing.T) {
 	subs := []Subscription{
-		{Channel: "gmail:general", Agent: "fast-crane", MentionOnly: false},
+		{Channel: "gmail:*", Agent: "fast-crane", MentionOnly: false},
 		{Channel: "gmail:alertsbank", Agent: "fast-crane", MentionOnly: false},
 		{Channel: "gmail:newslettereconomictimes", Agent: "fast-crane", MentionOnly: false},
 		// deliberate: different mention_only than catch-all
 		{Channel: "gmail:focused", Agent: "fast-crane", MentionOnly: true},
 		// no catch-all for whatsapp — not a candidate
 		{Channel: "whatsapp:alice", Agent: "fast-crane", MentionOnly: false},
-		{Channel: "telegram:general", Agent: "broad", MentionOnly: false},
+		{Channel: "telegram:*", Agent: "broad", MentionOnly: false},
 		{Channel: "telegram:dm-bob", Agent: "broad", MentionOnly: false},
 		// mute marker must not be pruned
 		{Channel: "telegram:noisy", Agent: "broad", MentionOnly: false, Muted: true},
@@ -39,6 +39,17 @@ func TestFindPruneCandidates(t *testing.T) {
 	}
 }
 
+func TestFindPruneCandidates_LegacyCatchAll(t *testing.T) {
+	subs := []Subscription{
+		{Channel: "gmail:general", Agent: "fast-crane", MentionOnly: false},
+		{Channel: "gmail:alertsbank", Agent: "fast-crane", MentionOnly: false},
+	}
+	got := FindPruneCandidates(subs)
+	if len(got) != 1 || got[0].Channel != "gmail:alertsbank" {
+		t.Fatalf("legacy catch-all should still seed prune heuristic, got %+v", got)
+	}
+}
+
 func TestFindPruneCandidates_NoCatchAll(t *testing.T) {
 	subs := []Subscription{
 		{Channel: "gmail:only-explicit", Agent: "a", MentionOnly: false},
@@ -50,7 +61,8 @@ func TestFindPruneCandidates_NoCatchAll(t *testing.T) {
 
 func TestFindPruneCandidates_SkipsCatchAllItself(t *testing.T) {
 	subs := []Subscription{
-		{Channel: "slack:general", Agent: "root", MentionOnly: false},
+		{Channel: "slack:*", Agent: "root", MentionOnly: false},
+		{Channel: "slack:general", Agent: "root", MentionOnly: false}, // legacy form
 	}
 	if got := FindPruneCandidates(subs); len(got) != 0 {
 		t.Fatalf("catch-all itself must never be a candidate, got %+v", got)
@@ -73,8 +85,10 @@ func TestFilterPruneByPlatform(t *testing.T) {
 
 func TestIsCatchAll(t *testing.T) {
 	cases := map[string]bool{
-		"gmail:general":   true,
-		"slack:general":   true,
+		"gmail:*":         true,
+		"slack:*":         true,
+		"gmail:general":   false, // legacy — use IsLegacyCatchAll
+		"slack:general":   false,
 		"slack:eng":       false,
 		"general":         false,
 		"":                false,
@@ -85,5 +99,11 @@ func TestIsCatchAll(t *testing.T) {
 		if got := IsCatchAll(ch); got != want {
 			t.Errorf("IsCatchAll(%q)=%v want %v", ch, got, want)
 		}
+	}
+	if !IsLegacyCatchAll("slack:general") || IsLegacyCatchAll("slack:*") {
+		t.Fatal("IsLegacyCatchAll mismatch")
+	}
+	if !IsAnyCatchAll("slack:*") || !IsAnyCatchAll("gmail:general") {
+		t.Fatal("IsAnyCatchAll mismatch")
 	}
 }

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -280,7 +280,7 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 	}
 	active, mutedAgents := partitionSubs(subs)
 
-	// The connect-app flow subscribes agents to "{platform}:general" as a
+	// The connect-app flow subscribes agents to "{platform}:*" as a
 	// catch-all, because the real channel is not known until a message
 	// arrives (Telegram DMs land on telegram:<username|chat_id>, mail on
 	// gmail:<sender>). When a channel has no active subscribers of its own,
@@ -302,7 +302,7 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 		} else if len(fallback) > 0 {
 			active = filterCatchAll(fallback, mutedAgents)
 			log.Info("notify: delivering via catch-all subscription",
-				"channel", channel, "catch_all", platform+catchAllSuffix, "agents", len(active))
+				"channel", channel, "catch_all", CatchAllChannel(platform), "agents", len(active))
 		}
 	}
 	subs = active
@@ -366,26 +366,37 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 	}
 }
 
-// catchAllSuffix is the channel the connect-app flow subscribes agents to when
-// the real per-conversation channel cannot be known in advance.
-const catchAllSuffix = ":general"
-
-// catchAllSubscribers returns the subscribers of "{platform}:general" so a
+// catchAllSubscribers returns subscribers of the platform catch-all so a
 // channel with no subscribers of its own can still be delivered. It only
 // reads: writing a subscription per channel is what produced the runaway
 // subscription lists in #3463.
 //
-// Returns nothing when realChannel is the catch-all itself (already handled by
-// the normal lookup) or belongs to another platform.
+// Canonical key is "{platform}:*" (#3467). Legacy "{platform}:general" rows
+// are merged in until migrateLegacyCatchAll rewrites them, so Slack/Discord
+// "#general" can be a real channel without owning the fallback.
+//
+// Returns nothing when realChannel is the canonical catch-all itself (already
+// handled by the normal lookup) or belongs to another platform.
 func (s *Service) catchAllSubscribers(ctx context.Context, platform, realChannel string) ([]Subscription, error) {
-	catchAll := platform + catchAllSuffix
+	catchAll := CatchAllChannel(platform)
 	if realChannel == "" || realChannel == catchAll {
 		return nil, nil
 	}
 	if !strings.HasPrefix(realChannel, platform+":") {
 		return nil, nil
 	}
-	return s.store.Subscribers(ctx, catchAll)
+
+	canonical, err := s.store.Subscribers(ctx, catchAll)
+	if err != nil {
+		return nil, err
+	}
+	if len(canonical) > 0 {
+		// Canonical catch-all owns fallback. Do not also pull
+		// "{platform}:general" — that key is a real Slack/Discord channel.
+		return canonical, nil
+	}
+	// Pre-migration workspaces still store catch-all on ":general".
+	return s.store.Subscribers(ctx, LegacyCatchAllChannel(platform))
 }
 
 // Subscribe adds an agent to a channel.
@@ -506,16 +517,13 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 
 	// Fallback to catch-all subscription if no active direct subscribers
 	if len(active) == 0 && platform != "" {
-		catchAll := platform + catchAllSuffix
-		if channel != "" && channel != catchAll && strings.HasPrefix(channel, platform+":") {
-			fallback, fErr := s.store.Subscribers(ctx, catchAll)
-			if fErr != nil {
-				log.Warn("notify: catch-all lookup failed for outbound", "platform", platform, "channel", channel, "error", fErr)
-			} else if len(fallback) > 0 {
-				active = filterCatchAll(fallback, mutedAgents)
-				log.Info("notify: delivering outbound via catch-all subscription",
-					"channel", channel, "catch_all", catchAll, "agents", len(active))
-			}
+		fallback, fErr := s.catchAllSubscribers(ctx, platform, channel)
+		if fErr != nil {
+			log.Warn("notify: catch-all lookup failed for outbound", "platform", platform, "channel", channel, "error", fErr)
+		} else if len(fallback) > 0 {
+			active = filterCatchAll(fallback, mutedAgents)
+			log.Info("notify: delivering outbound via catch-all subscription",
+				"channel", channel, "catch_all", CatchAllChannel(platform), "agents", len(active))
 		}
 	}
 	subs = active

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -433,7 +433,7 @@ func TestDrainDispatches(t *testing.T) {
 }
 
 // TestCatchAllDeliversWithoutCreatingSubscriptions covers the connect-app
-// flow: agents are subscribed to "{platform}:general" because the real
+// flow: agents are subscribed to "{platform}:*" because the real
 // per-conversation channel isn't known until a message arrives. Delivery must
 // work — and must not leave a subscription behind on the real channel.
 func TestCatchAllDeliversWithoutCreatingSubscriptions(t *testing.T) {
@@ -442,10 +442,10 @@ func TestCatchAllDeliversWithoutCreatingSubscriptions(t *testing.T) {
 	svc := NewService(store, sender, &mockHub{})
 	ctx := context.Background()
 
-	if err := store.Subscribe(ctx, "telegram:general", "mdrndr-manager", false); err != nil {
+	if err := store.Subscribe(ctx, "telegram:*", "mdrndr-manager", false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Subscribe(ctx, "telegram:general", "mdrndr-tui", false); err != nil {
+	if err := store.Subscribe(ctx, "telegram:*", "mdrndr-tui", false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -469,7 +469,7 @@ func TestCatchAllDeliversWithoutCreatingSubscriptions(t *testing.T) {
 	}
 
 	// And the catch-all itself is untouched.
-	catchAll, err := store.Subscribers(ctx, "telegram:general")
+	catchAll, err := store.Subscribers(ctx, "telegram:*")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -489,7 +489,7 @@ func TestCatchAllDoesNotFanOutAcrossChannels(t *testing.T) {
 	svc := NewService(store, sender, &mockHub{})
 	ctx := context.Background()
 
-	if err := store.Subscribe(ctx, "gmail:general", "fast-crane", false); err != nil {
+	if err := store.Subscribe(ctx, "gmail:*", "fast-crane", false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -514,11 +514,11 @@ func TestCatchAllDoesNotFanOutAcrossChannels(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(all) != 1 {
-		t.Fatalf("expected the single gmail:general subscription to remain the only one, got %d: %+v",
+		t.Fatalf("expected the single gmail:* subscription to remain the only one, got %d: %+v",
 			len(all), all)
 	}
-	if all[0].Channel != "gmail:general" {
-		t.Errorf("surviving subscription is %q, want gmail:general", all[0].Channel)
+	if all[0].Channel != "gmail:*" {
+		t.Errorf("surviving subscription is %q, want gmail:*", all[0].Channel)
 	}
 
 	// Delivery still reached the agent for every sender.
@@ -537,7 +537,7 @@ func TestExplicitChannelSubscriptionWinsOverCatchAll(t *testing.T) {
 	ctx := context.Background()
 
 	// Catch-all would deliver everything to broad-agent...
-	if err := store.Subscribe(ctx, "gmail:general", "broad-agent", false); err != nil {
+	if err := store.Subscribe(ctx, "gmail:*", "broad-agent", false); err != nil {
 		t.Fatal(err)
 	}
 	// ...but this channel has its own explicit, mention-only subscription.
@@ -575,7 +575,7 @@ func TestCatchAllRespectsMutedChannel(t *testing.T) {
 	svc := NewService(store, sender, &mockHub{})
 	ctx := context.Background()
 
-	if err := store.Subscribe(ctx, "telegram:general", "broad-agent", false); err != nil {
+	if err := store.Subscribe(ctx, "telegram:*", "broad-agent", false); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.SetMuted(ctx, "telegram:alice", "broad-agent", true); err != nil {
@@ -608,10 +608,10 @@ func TestMutedRowDoesNotBlockCatchAllForOtherAgents(t *testing.T) {
 	svc := NewService(store, sender, &mockHub{})
 	ctx := context.Background()
 
-	if err := store.Subscribe(ctx, "telegram:general", "agent-a", false); err != nil {
+	if err := store.Subscribe(ctx, "telegram:*", "agent-a", false); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.Subscribe(ctx, "telegram:general", "agent-b", false); err != nil {
+	if err := store.Subscribe(ctx, "telegram:*", "agent-b", false); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.SetMuted(ctx, "telegram:alice", "agent-a", true); err != nil {
@@ -712,7 +712,7 @@ func TestMigratePlaceholderSubsNoOpWhenRealHasSubs(t *testing.T) {
 	svc := NewService(store, sender, &mockHub{})
 	ctx := context.Background()
 
-	if err := store.Subscribe(ctx, "telegram:general", "legacy-agent", false); err != nil {
+	if err := store.Subscribe(ctx, "telegram:*", "legacy-agent", false); err != nil {
 		t.Fatal(err)
 	}
 	if err := store.Subscribe(ctx, "telegram:ab010300", "real-agent", false); err != nil {
@@ -841,5 +841,87 @@ func TestRecordOutboundThenInboundReadsAsConversation(t *testing.T) {
 	}
 	if msgs[1].Sender != "[slack] Puneet Rai" {
 		t.Errorf("older message sender = %q, want the human's question", msgs[1].Sender)
+	}
+}
+
+// TestSlackGeneralIsNotCatchAll (#3467): subscribing to real #general must not
+// make that agent the fallback for every other Slack channel.
+func TestSlackGeneralIsNotCatchAll(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "slack:*", "catch-agent", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Subscribe(ctx, "slack:general", "general-only", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("slack:eng", "slack", "alice", "", "", "hello eng", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch timeout")
+	}
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "catch-agent" {
+		t.Fatalf("eng should only hit catch-all agent, got %+v", calls)
+	}
+
+	sender.mu.Lock()
+	sender.calls = nil
+	sender.mu.Unlock()
+
+	svc.Dispatch("slack:general", "slack", "bob", "", "", "hello general", "m2", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch timeout")
+	}
+	calls = sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "general-only" {
+		t.Fatalf("#general should only hit general-only (explicit wins), got %+v", calls)
+	}
+}
+
+// TestLegacyCatchAllStillDelivers: pre-migration "{platform}:general" rows
+// still provide fallback until migrateLegacyCatchAll rewrites them.
+func TestLegacyCatchAllStillDelivers(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "slack:general", "legacy-root", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("slack:eng", "slack", "alice", "", "", "via legacy", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch timeout")
+	}
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "legacy-root" {
+		t.Fatalf("expected legacy catch-all delivery, got %+v", calls)
+	}
+}
+
+// TestCatchAllStarDeliversToUnmatchedGeneral: with only slack:*, messages on
+// real #general fall back to the catch-all when nobody subscribed to #general.
+func TestCatchAllStarDeliversToUnmatchedGeneral(t *testing.T) {
+	store := setupTestStore(t)
+	sender := &mockSender{}
+	svc := NewService(store, sender, &mockHub{})
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "slack:*", "root", false); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.Dispatch("slack:general", "slack", "alice", "", "", "in general", "m1", nil, nil, nil)
+	if !svc.DrainDispatches(2 * time.Second) {
+		t.Fatal("dispatch timeout")
+	}
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "root" {
+		t.Fatalf("expected catch-all delivery into #general, got %+v", calls)
 	}
 }

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -78,6 +78,65 @@ func (s *Store) initSchema() error {
 	} {
 		_, _ = s.db.ExecContext(context.TODO(), alter) //nolint:errcheck // ignore if column already exists
 	}
+	if err := s.migrateLegacyCatchAll(context.TODO()); err != nil {
+		return fmt.Errorf("migrate legacy catch-all: %w", err)
+	}
+	return nil
+}
+
+// migrateLegacyCatchAll rewrites "{platform}:general" subscription rows to
+// "{platform}:*" (#3467) so Slack/Discord "#general" is no longer overloaded
+// as the catch-all key. notify_channels / message history for ":general" are
+// left alone — those are real channel traffic.
+func (s *Store) migrateLegacyCatchAll(ctx context.Context) error {
+	rows, err := s.db.QueryContext(ctx, s.q(
+		`SELECT channel, agent, mention_only, muted FROM notify_subscriptions`))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+
+	type row struct {
+		channel, agent string
+		mentionOnly    bool
+		muted          bool
+	}
+	var legacy []row
+	for rows.Next() {
+		var r row
+		var mentionInt, mutedInt int
+		if err := rows.Scan(&r.channel, &r.agent, &mentionInt, &mutedInt); err != nil {
+			return err
+		}
+		r.mentionOnly = mentionInt != 0
+		r.muted = mutedInt != 0
+		if IsLegacyCatchAll(r.channel) {
+			legacy = append(legacy, r)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, r := range legacy {
+		platform := PlatformOf(r.channel)
+		canonical := CatchAllChannel(platform)
+		if canonical == "" {
+			continue
+		}
+		// Upsert onto the canonical key, then drop the legacy row.
+		if err := s.Subscribe(ctx, canonical, r.agent, r.mentionOnly); err != nil {
+			return err
+		}
+		if r.muted {
+			if err := s.SetMuted(ctx, canonical, r.agent, true); err != nil {
+				return err
+			}
+		}
+		if err := s.Unsubscribe(ctx, r.channel, r.agent); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/pkg/notify/store_test.go
+++ b/pkg/notify/store_test.go
@@ -71,6 +71,62 @@ func TestSaveChannel_FillsEmptyPlatformID(t *testing.T) {
 	}
 }
 
+// TestMigrateLegacyCatchAll moves "{platform}:general" subscription rows to
+// "{platform}:*" without touching notify_channels for real #general.
+func TestMigrateLegacyCatchAll(t *testing.T) {
+	store := setupTestStore(t)
+	ctx := context.Background()
+
+	if err := store.Subscribe(ctx, "slack:general", "root", false); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Subscribe(ctx, "gmail:general", "mail-bot", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SetMuted(ctx, "slack:eng", "root", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveChannel(ctx, "slack:general", "slack", "C01GENERAL"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.migrateLegacyCatchAll(ctx); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	all, err := store.AllSubscriptions(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byCh := map[string][]Subscription{}
+	for _, sub := range all {
+		byCh[sub.Channel] = append(byCh[sub.Channel], sub)
+	}
+	if _, ok := byCh["slack:general"]; ok {
+		t.Fatalf("legacy slack:general sub should be gone, got %+v", byCh["slack:general"])
+	}
+	if _, ok := byCh["gmail:general"]; ok {
+		t.Fatalf("legacy gmail:general sub should be gone, got %+v", byCh["gmail:general"])
+	}
+	if len(byCh["slack:*"]) != 1 || byCh["slack:*"][0].Agent != "root" {
+		t.Fatalf("want root on slack:*, got %+v", byCh["slack:*"])
+	}
+	if len(byCh["gmail:*"]) != 1 || !byCh["gmail:*"][0].MentionOnly {
+		t.Fatalf("want mail-bot mention_only on gmail:*, got %+v", byCh["gmail:*"])
+	}
+	if len(byCh["slack:eng"]) != 1 || !byCh["slack:eng"][0].Muted {
+		t.Fatalf("mute row should be untouched, got %+v", byCh["slack:eng"])
+	}
+
+	channels, err := store.LoadChannels(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(channels) != 1 || channels[0].Channel != "slack:general" || channels[0].PlatformID != "C01GENERAL" {
+		t.Fatalf("notify_channels slack:general mapping must remain, got %+v", channels)
+	}
+}
+
 // TestChannelStats exercises the /api/stats/channels aggregation: message
 // counts, member counts, top senders, ordering, and the subscription-only
 // channel case.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1121,14 +1121,14 @@ export const api = {
   getChannelSubscriptions: (channel: string) => {
     const { gw, ch } = splitChannel(channel);
     if (gw && ch) {
-      return request<NotifySubscription[]>(`/apps/${gw}/channels/${ch}/agents`);
+      return request<NotifySubscription[]>(`/apps/${gw}/channels/${encodeURIComponent(ch)}/agents`);
     }
     return request<NotifySubscription[]>(`/notify/subscriptions/${encodeURIComponent(channel)}`);
   },
   subscribe: (channel: string, agent: string, mentionOnly = false) => {
     const { gw, ch } = splitChannel(channel);
     if (gw && ch) {
-      return request<{ status: string }>(`/apps/${gw}/channels/${ch}/agents`, {
+      return request<{ status: string }>(`/apps/${gw}/channels/${encodeURIComponent(ch)}/agents`, {
         method: "POST",
         body: JSON.stringify({ agent, mention_only: mentionOnly }),
       });
@@ -1141,7 +1141,7 @@ export const api = {
   unsubscribe: (channel: string, agent: string) => {
     const { gw, ch } = splitChannel(channel);
     if (gw && ch) {
-      return request<{ status: string }>(`/apps/${gw}/channels/${ch}/agents/${encodeURIComponent(agent)}`, {
+      return request<{ status: string }>(`/apps/${gw}/channels/${encodeURIComponent(ch)}/agents/${encodeURIComponent(agent)}`, {
         method: "DELETE",
       });
     }
@@ -1153,7 +1153,7 @@ export const api = {
   setMentionOnly: (channel: string, agent: string, mentionOnly: boolean) => {
     const { gw, ch } = splitChannel(channel);
     if (gw && ch) {
-      return request<{ status: string }>(`/apps/${gw}/channels/${ch}/agents/${encodeURIComponent(agent)}`, {
+      return request<{ status: string }>(`/apps/${gw}/channels/${encodeURIComponent(ch)}/agents/${encodeURIComponent(agent)}`, {
         method: "PATCH",
         body: JSON.stringify({ mention_only: mentionOnly }),
       });
@@ -1166,7 +1166,7 @@ export const api = {
   setMuted: (channel: string, agent: string, muted: boolean) => {
     const { gw, ch } = splitChannel(channel);
     if (gw && ch) {
-      return request<{ status: string }>(`/apps/${gw}/channels/${ch}/agents/${encodeURIComponent(agent)}`, {
+      return request<{ status: string }>(`/apps/${gw}/channels/${encodeURIComponent(ch)}/agents/${encodeURIComponent(agent)}`, {
         method: "PATCH",
         body: JSON.stringify({ muted }),
       });
@@ -1179,7 +1179,7 @@ export const api = {
   getChannelActivity: (channel: string, limit = 50) => {
     const { gw, ch } = splitChannel(channel);
     if (gw && ch) {
-      return request<DeliveryEntry[]>(`/apps/${gw}/channels/${ch}/activity?limit=${limit}`);
+      return request<DeliveryEntry[]>(`/apps/${gw}/channels/${encodeURIComponent(ch)}/activity?limit=${limit}`);
     }
     return request<DeliveryEntry[]>(`/notify/activity/${encodeURIComponent(channel)}?limit=${limit}`);
   },

--- a/web/src/components/apps/AgentAppsCard.tsx
+++ b/web/src/components/apps/AgentAppsCard.tsx
@@ -16,7 +16,8 @@ import { AppIcon } from "./PlatformIcons";
 
 function channelLeaf(ch: string): string {
   const i = ch.lastIndexOf(":");
-  return i >= 0 ? ch.slice(i + 1) : ch;
+  const leaf = i >= 0 ? ch.slice(i + 1) : ch;
+  return leaf === "*" ? "catch-all" : leaf;
 }
 
 function ChannelGlyph({ channel }: { channel: string }) {

--- a/web/src/components/apps/AgentAppsPicker.tsx
+++ b/web/src/components/apps/AgentAppsPicker.tsx
@@ -20,7 +20,8 @@ function instanceBase(name: string): string {
 
 function channelLeaf(ch: string): string {
   const i = ch.lastIndexOf(":");
-  return i >= 0 ? ch.slice(i + 1) : ch;
+  const leaf = i >= 0 ? ch.slice(i + 1) : ch;
+  return leaf === "*" ? "catch-all" : leaf;
 }
 
 export function AgentAppsPicker({

--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -52,10 +52,12 @@ import {
 
 export type ChannelKind = "group" | "person" | null;
 
-/** Leaf segment of a channel key: "whatsapp:123@g.us" → "123@g.us". */
+/** Leaf segment of a channel key: "whatsapp:123@g.us" → "123@g.us".
+ *  Catch-all keys ("slack:*") render as "catch-all" (#3467). */
 export function channelLeaf(name: string): string {
   const parts = name.split(":");
-  return parts[parts.length - 1] || name;
+  const leaf = parts[parts.length - 1] || name;
+  return leaf === "*" ? "catch-all" : leaf;
 }
 
 /** Classify a WhatsApp channel by JID shape when no metadata exists:

--- a/web/src/components/apps/ConnectApp.tsx
+++ b/web/src/components/apps/ConnectApp.tsx
@@ -323,7 +323,7 @@ function AgentSubscriptionStep({
       const res = await api.getApps();
       const inst = (res.instances ?? []).find((i) => i.name === instanceName);
       const discovered = (inst?.channels ?? []).filter(
-        (ch) => ch && !ch.endsWith(":general"),
+        (ch) => ch && !ch.endsWith(":*") && !ch.endsWith(":general"),
       );
       setChannels(discovered);
       setSelectedChannels((prev) => {
@@ -403,11 +403,11 @@ function AgentSubscriptionStep({
     setSaving(true);
     try {
       // Telegram: only subscribe to real discovered channels. Never invent
-      // telegram:general — DMs arrive as telegram:<username|chat_id>.
-      // Other apps keep the historical <instance>:general default for now.
+      // a catch-all placeholder — DMs arrive as telegram:<username|chat_id>.
+      // Other apps subscribe to <instance>:* (platform catch-all; #3467).
       const targets = isTelegram
         ? [...selectedChannels]
-        : [`${instanceName}:general`];
+        : [`${instanceName}:*`];
 
       if (targets.length > 0 && selected.size > 0) {
         await Promise.all(
@@ -469,7 +469,7 @@ function AgentSubscriptionStep({
             ) : channels.length === 0 ? (
               <div className="text-xs text-mycel-muted bg-mycel-surface-hover border border-mycel-border rounded-md px-3 py-2">
                 No Telegram chats discovered yet. Message the bot in a DM (or a group),
-                then click Refresh. Agents subscribed to a fake <code className="text-mycel-text-2">telegram:general</code> channel
+                then click Refresh. Agents subscribed to a fake <code className="text-mycel-text-2">telegram:*</code> catch-all
                 never receive real traffic.
               </div>
             ) : (


### PR DESCRIPTION
## Summary
- Catch-all key is now `{platform}:*` instead of `{platform}:general`, so Slack/Discord `#general` is no longer overloaded as the fallback (#3467).
- `OpenStore` migrates legacy `:general` subscription rows to `:*` (leaves `notify_channels` / message history alone).
- Dual-read: if `:*` is empty, fall back to legacy `:general` for delivery until migrated.
- Connect-app + UI subscribe to `:*`; channel leaf `*` displays as `catch-all`; client paths encode `*`.

Closes #3467.

## Test plan
- [x] `go test ./pkg/notify/` (incl. `TestSlackGeneralIsNotCatchAll`, migrate, legacy dual-read)
- [x] `golangci-lint` on touched packages
- [ ] CI Lint / Test / Web green
- [ ] After upgrade: existing catch-all agents still receive unmatched channels; `#general` can be subscribed independently


Made with [Cursor](https://cursor.com)