### PR TITLE
feat(web): Notifications section + searchable subscribe picker (#3647)

### DIFF
--- a/web/src/components/apps/AgentAppsCard.tsx
+++ b/web/src/components/apps/AgentAppsCard.tsx
@@ -1,13 +1,12 @@
 /**
- * AgentAppsCard — the "Apps" card on the agent detail Config tab.
+ * AgentAppsCard — Notifications subscriptions on the agent detail Config tab.
  *
  * Lists this agent's channel subscriptions (platform icon + channel +
- * mention-only toggle + remove) and adds new ones from the channels the
- * connected apps have discovered. Same subscription endpoints the
- * channel-side SubscriptionPanel uses, scoped to one agent.
+ * mention-only toggle + remove) and adds new ones via a searchable,
+ * platform-grouped picker (#3647).
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
 import { Link } from "react-router-dom";
 import { api } from "../../api/client";
 import type { NotificationSource, NotifySubscription } from "../../api/client";
@@ -24,12 +23,56 @@ function ChannelGlyph({ channel }: { channel: string }) {
   return <AppIcon base={sourcePlatform(channel)} size={13} />;
 }
 
+function platformLabel(platform: string): string {
+  if (!platform) return "Other";
+  return platform.charAt(0).toUpperCase() + platform.slice(1);
+}
+
+/** Group available channels by platform, filtered by search. */
+function groupChannels(
+  channels: NotificationSource[],
+  query: string,
+): { platform: string; items: NotificationSource[] }[] {
+  const q = query.trim().toLowerCase();
+  const filtered = q
+    ? channels.filter((c) => {
+        const plat = sourcePlatform(c.name).toLowerCase();
+        const leaf = channelLeaf(c.name).toLowerCase();
+        return (
+          c.name.toLowerCase().includes(q) ||
+          plat.includes(q) ||
+          leaf.includes(q) ||
+          (c.description ?? "").toLowerCase().includes(q)
+        );
+      })
+    : channels;
+
+  const byPlat = new Map<string, NotificationSource[]>();
+  for (const c of filtered) {
+    const plat = sourcePlatform(c.name) || "other";
+    const list = byPlat.get(plat) ?? [];
+    list.push(c);
+    byPlat.set(plat, list);
+  }
+
+  return [...byPlat.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([platform, items]) => ({
+      platform,
+      items: items.sort((x, y) => x.name.localeCompare(y.name)),
+    }));
+}
+
 export function AgentAppsCard({ agentName }: { agentName: string }) {
   const [subs, setSubs] = useState<NotifySubscription[]>([]);
   const [channels, setChannels] = useState<NotificationSource[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [busy, setBusy] = useState(false);
-  const [addChannel, setAddChannel] = useState("");
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [highlight, setHighlight] = useState(0);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
 
   const fetchData = useCallback(async () => {
     try {
@@ -49,15 +92,41 @@ export function AgentAppsCard({ agentName }: { agentName: string }) {
     return () => { clearInterval(interval); };
   }, [fetchData]);
 
-  const subscribedSet = new Set(subs.map((s) => s.channel));
-  const available = channels.filter((c) => !subscribedSet.has(c.name));
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) {
+        setPickerOpen(false);
+        setQuery("");
+      }
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => { document.removeEventListener("mousedown", onDoc); };
+  }, [pickerOpen]);
 
-  const handleAdd = async () => {
-    if (!addChannel) return;
+  useEffect(() => {
+    if (pickerOpen) {
+      setHighlight(0);
+      // Focus search when the picker opens.
+      requestAnimationFrame(() => searchRef.current?.focus());
+    }
+  }, [pickerOpen]);
+
+  const subscribedSet = useMemo(() => new Set(subs.map((s) => s.channel)), [subs]);
+  const available = useMemo(
+    () => channels.filter((c) => !subscribedSet.has(c.name)),
+    [channels, subscribedSet],
+  );
+  const groups = useMemo(() => groupChannels(available, query), [available, query]);
+  const flat = useMemo(() => groups.flatMap((g) => g.items), [groups]);
+
+  const handleSubscribe = async (channel: string) => {
+    if (!channel || busy) return;
     setBusy(true);
     try {
-      await api.subscribe(addChannel, agentName, false);
-      setAddChannel("");
+      await api.subscribe(channel, agentName, false);
+      setPickerOpen(false);
+      setQuery("");
       await fetchData();
     } catch { /* best effort */ }
     setBusy(false);
@@ -79,81 +148,162 @@ export function AgentAppsCard({ agentName }: { agentName: string }) {
     } catch { /* best effort */ }
   };
 
+  const onSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => Math.min(h + 1, Math.max(flat.length - 1, 0)));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const pick = flat[highlight];
+      if (pick) void handleSubscribe(pick.name);
+    } else if (e.key === "Escape") {
+      setPickerOpen(false);
+      setQuery("");
+    }
+  };
+
   return (
-    <div data-testid="agent-apps-card">
-      {/* Subscription rows */}
+    <div data-testid="agent-apps-card" ref={rootRef}>
       {!loaded ? (
-        <div className="text-xs text-mycel-muted py-2">Loading app subscriptions…</div>
+        <div className="text-xs text-mycel-muted py-2">Loading notification subscriptions…</div>
       ) : subs.length === 0 ? (
         <p className="text-xs text-mycel-muted italic mb-3">
-          Not listening to any app channels. Subscribe below, or connect new apps on the{" "}
+          Not listening to any notification channels. Subscribe below, or connect platforms on the{" "}
           <Link to="/apps" className="text-mycel-accent hover:underline not-italic">Apps</Link> page.
         </p>
       ) : (
         <div className="mb-3 rounded-md border border-mycel-border overflow-hidden divide-y divide-mycel-border">
-          {subs.map((sub) => (
-            <div key={sub.channel} className="flex items-center gap-2.5 px-3 py-2 bg-mycel-surface group">
-              <span className="shrink-0 flex items-center justify-center w-4">
-                <ChannelGlyph channel={sub.channel} />
-              </span>
-              <Link
-                to={`/apps/${sub.channel}`}
-                className="flex-1 min-w-0 text-[12px] text-mycel-text truncate hover:text-mycel-accent transition-colors"
-                title={sub.channel}
-              >
-                {channelLeaf(sub.channel)}
-                <span className="ml-2 font-mono text-[10px] text-mycel-muted">{sub.channel}</span>
-              </Link>
-              <button
-                type="button"
-                onClick={() => { void handleToggleMention(sub); }}
-                className={`shrink-0 text-[10px] px-2 py-0.5 rounded-md border transition-all duration-150 ${
-                  sub.mention_only
-                    ? "border-mycel-accent bg-mycel-accent-subtle text-mycel-accent"
-                    : "border-mycel-border text-mycel-muted hover:border-mycel-border-strong"
-                }`}
-                title={sub.mention_only ? "Delivers @mentions only" : "Delivers all messages"}
-              >
-                {sub.mention_only ? "@ mentions" : "all msgs"}
-              </button>
-              <button
-                type="button"
-                onClick={() => { void handleRemove(sub.channel); }}
-                disabled={busy}
-                className="shrink-0 text-[11px] text-mycel-muted hover:text-mycel-error transition-colors opacity-0 group-hover:opacity-100 disabled:opacity-30"
-                aria-label={`Unsubscribe from ${sub.channel}`}
-              >
-                remove
-              </button>
-            </div>
-          ))}
+          {subs
+            .slice()
+            .sort((a, b) => a.channel.localeCompare(b.channel))
+            .map((sub) => (
+              <div key={sub.channel} className="flex items-center gap-2.5 px-3 py-2 bg-mycel-surface group">
+                <span className="shrink-0 flex items-center justify-center w-4">
+                  <ChannelGlyph channel={sub.channel} />
+                </span>
+                <Link
+                  to={`/apps/${sub.channel}`}
+                  className="flex-1 min-w-0 text-[12px] text-mycel-text truncate hover:text-mycel-accent transition-colors"
+                  title={sub.channel}
+                >
+                  {channelLeaf(sub.channel)}
+                  <span className="ml-2 font-mono text-[10px] text-mycel-muted">{sub.channel}</span>
+                </Link>
+                <button
+                  type="button"
+                  onClick={() => { void handleToggleMention(sub); }}
+                  className={`shrink-0 text-[10px] px-2 py-0.5 rounded-md border transition-all duration-150 ${
+                    sub.mention_only
+                      ? "border-mycel-accent bg-mycel-accent-subtle text-mycel-accent"
+                      : "border-mycel-border text-mycel-muted hover:border-mycel-border-strong"
+                  }`}
+                  title={sub.mention_only ? "Delivers @mentions only" : "Delivers all messages"}
+                >
+                  {sub.mention_only ? "@ mentions" : "all msgs"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { void handleRemove(sub.channel); }}
+                  disabled={busy}
+                  className="shrink-0 text-[11px] text-mycel-muted hover:text-mycel-error transition-colors opacity-0 group-hover:opacity-100 disabled:opacity-30"
+                  aria-label={`Unsubscribe from ${sub.channel}`}
+                >
+                  remove
+                </button>
+              </div>
+            ))}
         </div>
       )}
 
-      {/* Add row */}
       {available.length > 0 && (
-        <div className="flex items-center gap-2">
-          <select
-            value={addChannel}
-            onChange={(e) => { setAddChannel(e.target.value); }}
-            className="flex-1 min-w-0 rounded-md border border-mycel-border-strong bg-mycel-bg px-2.5 py-1.5 text-[11px] text-mycel-text outline-none focus:border-mycel-accent transition-colors"
-            aria-label="Channel to subscribe"
-          >
-            <option value="">— add a channel —</option>
-            {available.map((c) => (
-              <option key={c.name} value={c.name}>{c.name}</option>
-            ))}
-          </select>
+        <div className="relative">
           <button
             type="button"
-            onClick={() => { void handleAdd(); }}
-            disabled={busy || !addChannel}
-            className="shrink-0 inline-flex items-center px-3 py-1.5 rounded-md border border-mycel-accent bg-mycel-accent-subtle text-xs font-medium text-mycel-accent hover:bg-mycel-accent hover:text-mycel-accent-fg transition-colors disabled:opacity-40"
+            onClick={() => { setPickerOpen((o) => !o); }}
+            disabled={busy}
+            className="w-full flex items-center justify-between gap-2 rounded-md border border-mycel-border-strong bg-mycel-bg px-2.5 py-1.5 text-[11px] text-mycel-muted hover:border-mycel-accent hover:text-mycel-text transition-colors disabled:opacity-40"
+            aria-expanded={pickerOpen}
+            aria-haspopup="listbox"
+            aria-label="Add notification channel"
           >
-            Subscribe
+            <span>— add a channel —</span>
+            <span className="font-mono text-[10px] opacity-70">{available.length} available</span>
           </button>
+
+          {pickerOpen && (
+            <div
+              className="absolute z-30 mt-1 w-full rounded-md border border-mycel-border-strong bg-mycel-surface shadow-lg overflow-hidden"
+              role="listbox"
+              aria-label="Available notification channels"
+            >
+              <div className="p-2 border-b border-mycel-border">
+                <input
+                  ref={searchRef}
+                  type="search"
+                  value={query}
+                  onChange={(e) => {
+                    setQuery(e.target.value);
+                    setHighlight(0);
+                  }}
+                  onKeyDown={onSearchKeyDown}
+                  placeholder="Search by app or channel…"
+                  className="w-full rounded-md border border-mycel-border bg-mycel-bg px-2.5 py-1.5 text-[12px] text-mycel-text outline-none focus:border-mycel-accent"
+                  aria-label="Search channels"
+                />
+              </div>
+              <div className="max-h-64 overflow-auto py-1">
+                {flat.length === 0 ? (
+                  <p className="px-3 py-2 text-[11px] text-mycel-muted">No channels match “{query}”.</p>
+                ) : (
+                  groups.map((g) => (
+                    <div key={g.platform} className="mb-1">
+                      <div className="sticky top-0 z-10 flex items-center gap-1.5 px-3 py-1 bg-mycel-surface-hover/95 text-[10px] font-semibold uppercase tracking-[0.08em] text-mycel-muted">
+                        <AppIcon base={g.platform} size={11} />
+                        {platformLabel(g.platform)}
+                        <span className="font-mono font-normal normal-case tracking-normal opacity-70">
+                          {g.items.length}
+                        </span>
+                      </div>
+                      {g.items.map((c) => {
+                        const idx = flat.indexOf(c);
+                        const active = idx === highlight;
+                        return (
+                          <button
+                            key={c.name}
+                            type="button"
+                            role="option"
+                            aria-selected={active}
+                            onMouseEnter={() => { setHighlight(idx); }}
+                            onClick={() => { void handleSubscribe(c.name); }}
+                            className={`w-full flex items-center gap-2 px-3 py-1.5 text-left text-[12px] transition-colors ${
+                              active
+                                ? "bg-mycel-accent-subtle text-mycel-accent"
+                                : "text-mycel-text hover:bg-mycel-surface-hover"
+                            }`}
+                          >
+                            <span className="truncate flex-1 min-w-0">
+                              <span className="text-mycel-text">{channelLeaf(c.name)}</span>
+                              <span className="ml-2 font-mono text-[10px] text-mycel-muted">{c.name}</span>
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
         </div>
       )}
+
+      <p className="mt-2 text-[11px] text-mycel-muted">
+        Notification channels this agent listens to — messages route here from connected platforms
+        (Slack, Gmail, Telegram, WhatsApp, …).
+      </p>
     </div>
   );
 }

--- a/web/src/components/apps/__tests__/agentAppsCard.test.tsx
+++ b/web/src/components/apps/__tests__/agentAppsCard.test.tsx
@@ -1,7 +1,5 @@
 /**
- * AgentAppsCard — the "Apps" card on the agent detail Config tab.
- * Lists only this agent's channel subscriptions, offers add/remove, and
- * routes the mutations through the /api/apps subscription endpoints.
+ * AgentAppsCard — Notifications subscriptions on the agent detail Config tab.
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,13 +30,15 @@ const sources = [
   { name: "slack:general", description: "", members: [], member_count: 0 },
   { name: "telegram:standup", description: "", members: [], member_count: 0 },
   { name: "whatsapp:family", description: "", members: [], member_count: 0 },
+  { name: "gmail:alerts", description: "", members: [], member_count: 0 },
+  { name: "gmail:news", description: "", members: [], member_count: 0 },
 ];
 
 function mockRoutes() {
   fetchMock.mockImplementation((url: RequestInfo | URL, init?: RequestInit) => {
     const u = String(url);
     if (u.includes("/notify/subscriptions")) return jsonResponse(subs);
-    if (u.includes("/api/apps/channels")) return jsonResponse(sources);
+    if (u.includes("/api/apps/channels") || u.includes("/apps/channels")) return jsonResponse(sources);
     if (init?.method === "POST" || init?.method === "DELETE") {
       return jsonResponse({ status: "ok" });
     }
@@ -51,7 +51,7 @@ beforeEach(() => {
 });
 
 describe("AgentAppsCard", () => {
-  it("lists only this agent's app channel subscriptions", async () => {
+  it("lists only this agent's notification channel subscriptions", async () => {
     mockRoutes();
     render(
       <MemoryRouter>
@@ -63,52 +63,66 @@ describe("AgentAppsCard", () => {
       expect(screen.getByText("general")).toBeInTheDocument();
     });
     expect(screen.getByText("standup")).toBeInTheDocument();
-    // The mention-only state renders per subscription.
     expect(screen.getByText("@ mentions")).toBeInTheDocument();
     expect(screen.getByText("all msgs")).toBeInTheDocument();
-    // whatsapp:family belongs to no subscription — only in the add list.
-    const select = screen.getByLabelText("Channel to subscribe");
-    expect(select).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "whatsapp:family" })).toBeInTheDocument();
-    // Already-subscribed channels don't appear in the add list.
-    expect(screen.queryByRole("option", { name: "slack:general" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Add notification channel")).toBeInTheDocument();
   });
 
-  it("subscribes via the /api/apps channel-agents route", async () => {
+  it("opens a searchable grouped picker and subscribes", async () => {
     mockRoutes();
     render(
       <MemoryRouter>
         <AgentAppsCard agentName="bot-1" />
       </MemoryRouter>,
     );
+
     await waitFor(() => {
-      expect(screen.getByLabelText("Channel to subscribe")).toBeInTheDocument();
+      expect(screen.getByLabelText("Add notification channel")).toBeInTheDocument();
     });
 
-    fireEvent.change(screen.getByLabelText("Channel to subscribe"), {
-      target: { value: "whatsapp:family" },
+    fireEvent.click(screen.getByLabelText("Add notification channel"));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Search channels")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByRole("button", { name: "Subscribe" }));
+
+    // Group headers for available platforms (gmail + whatsapp; slack/telegram already subscribed).
+    expect(screen.getByText("Gmail")).toBeInTheDocument();
+    expect(screen.getByText("Whatsapp")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Search channels"), {
+      target: { value: "family" },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("family")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("alerts")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("family"));
 
     await waitFor(() => {
       const post = fetchMock.mock.calls.find(
         (c) =>
-          String(c[0]) === "/api/apps/whatsapp/channels/family/agents" &&
+          String(c[0]).includes("/api/apps/whatsapp/channels/family/agents") &&
           (c[1] as RequestInit | undefined)?.method === "POST",
       );
-      expect(post).toBeDefined();
-      const body = JSON.parse(String((post![1] as RequestInit).body)) as Record<string, unknown>;
-      expect(body.agent).toBe("bot-1");
+      expect(post).toBeTruthy();
+      expect(JSON.parse(String((post![1] as RequestInit).body))).toEqual({
+        agent: "bot-1",
+        mention_only: false,
+      });
     });
   });
 
-  it("removes a subscription via DELETE on the same route", async () => {
+  it("unsubscribes via the apps channel-agents route", async () => {
     mockRoutes();
     render(
       <MemoryRouter>
         <AgentAppsCard agentName="bot-1" />
       </MemoryRouter>,
     );
+
     await waitFor(() => {
       expect(screen.getByText("general")).toBeInTheDocument();
     });
@@ -116,12 +130,13 @@ describe("AgentAppsCard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Unsubscribe from slack:general" }));
 
     await waitFor(() => {
-      const del = fetchMock.mock.calls.find(
-        (c) =>
-          String(c[0]) === "/api/apps/slack/channels/general/agents/bot-1" &&
-          (c[1] as RequestInit | undefined)?.method === "DELETE",
-      );
-      expect(del).toBeDefined();
+      expect(
+        fetchMock.mock.calls.some(
+          (c) =>
+            String(c[0]) === "/api/apps/slack/channels/general/agents/bot-1" &&
+            (c[1] as RequestInit | undefined)?.method === "DELETE",
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/web/src/views/AgentDetail.tsx
+++ b/web/src/views/AgentDetail.tsx
@@ -1138,12 +1138,8 @@ function SettingsTab({ agent, agentsUrl }: { agent: Agent; agentsUrl: string }) 
 
         {/* ── APPS ── */}
         <section>
-          <SectionRule>Apps</SectionRule>
+          <SectionRule>Notifications</SectionRule>
           <AgentAppsCard agentName={agent.name} />
-          <p className="mt-2 text-xs text-mycel-muted leading-relaxed">
-            App channels this agent listens to — messages route here from connected
-            platforms (Slack, Telegram, WhatsApp, …).
-          </p>
         </section>
 
         {/* ── RUNTIME INFO ── */}


### PR DESCRIPTION
## Summary
- Agent detail Config: **Apps** → **Notifications**
- Subscribe UI: searchable, platform-grouped picker (keyboard nav) instead of a flat `<select>` of hundreds of channels
- Immediate refresh after subscribe/unsubscribe (same 12s poll backup)

Partial #3647 (agent-detail surface). Nav `/apps` hub rename can follow.

## Test plan
- [x] `bun run test -- src/components/apps/__tests__/agentAppsCard.test.tsx`
- [ ] Open agent Config → Notifications: search `gmail`, subscribe, see row appear
- [ ] CI Web green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the notification-channel dropdown with a searchable, platform-grouped picker.
  * Added keyboard navigation, Enter-to-subscribe, Escape-to-close, outside-click dismissal, and automatic search focus.
  * Improved subscription sorting and updated notification-specific messaging.
  * Renamed the Agent Detail “Apps” section to “Notifications.”

* **Bug Fixes**
  * Added clearer handling for unavailable notification channels.
  * Improved picker reset and closing behavior after subscribing.

* **Tests**
  * Expanded coverage for searching, subscribing, unsubscribing, and notification-channel API interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->