### PR TITLE
feat(web): Home chronological activity stream (#3642)

### DIFF
--- a/web/src/views/Home.test.tsx
+++ b/web/src/views/Home.test.tsx
@@ -15,7 +15,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { Home, SHOW_STOPPED_STORAGE_KEY } from "./Home";
+import { Home, SHOW_STOPPED_STORAGE_KEY, HOME_VIEW_MODE_KEY } from "./Home";
 import { HeaderSlotProvider, useHeaderSlotContext } from "../context/HeaderSlotContext";
 
 const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
@@ -44,6 +44,8 @@ function agent(name: string, state: string) {
 
 function mockAgentsApi(list: ReturnType<typeof agent>[]) {
   fetchMock.mockImplementation((url: string) => {
+    // Activity / logs must not match the broad "/agents" list check below.
+    if (url.includes("/activity") || url.includes("/logs")) return jsonResponse([]);
     if (url.includes("/agents")) return jsonResponse(list);
     // Home no longer gates on has_workspace (MycelHome-only daemons are valid).
     // Still mock system/info so useWorkspace / Layout banners stay quiet.
@@ -89,7 +91,7 @@ function renderHome() {
  * the name from its appearance inside the agent-filter <select> dropdown.
  */
 function agentCardVisible(name: string): boolean {
-  return screen.queryByTitle(`Open ${name} detail view`) !== null;
+  return screen.queryAllByTitle(`Open ${name} detail view`).length > 0;
 }
 
 async function waitForAgentCard(name: string) {
@@ -134,6 +136,45 @@ beforeEach(() => {
   fetchMock.mockReset();
   installLocalStorageShim();
   window.localStorage.clear();
+  // Existing card-visibility tests target the by-agent layout; #3642 defaults
+  // to chronological stream, so opt into by-agent unless a test says otherwise.
+  window.localStorage.setItem(HOME_VIEW_MODE_KEY, "by-agent");
+});
+
+describe("Home — activity view mode (#3642)", () => {
+  it("defaults to chronological stream when no preference is stored", async () => {
+    window.localStorage.removeItem(HOME_VIEW_MODE_KEY);
+    mockAgentsApi([agent("alice", "working"), agent("bob", "idle")]);
+
+    renderHome();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("home-view-stream").getAttribute("aria-pressed")).toBe("true");
+    });
+    expect(screen.getByTestId("home-chronological-stream")).toBeInTheDocument();
+    // Agent cards are the by-agent layout — absent in stream mode with no events.
+    expect(agentCardVisible("alice")).toBe(false);
+  });
+
+  it("switches to by-agent and persists the preference", async () => {
+    window.localStorage.removeItem(HOME_VIEW_MODE_KEY);
+    mockAgentsApi([agent("alice", "working")]);
+
+    const { unmount } = renderHome();
+    await waitFor(() => {
+      expect(screen.getByTestId("home-view-stream").getAttribute("aria-pressed")).toBe("true");
+    });
+
+    fireEvent.click(screen.getByTestId("home-view-by-agent"));
+    await waitForAgentCard("alice");
+    expect(window.localStorage.getItem(HOME_VIEW_MODE_KEY)).toBe("by-agent");
+    expect(screen.getByTestId("home-view-by-agent").getAttribute("aria-pressed")).toBe("true");
+
+    unmount();
+    renderHome();
+    await waitForAgentCard("alice");
+    expect(screen.getByTestId("home-view-by-agent").getAttribute("aria-pressed")).toBe("true");
+  });
 });
 
 describe("Home — show-stopped toggle", () => {

--- a/web/src/views/Home.tsx
+++ b/web/src/views/Home.tsx
@@ -10,22 +10,24 @@ import { OverviewStrip } from "./home/OverviewStrip";
 import { ActivityFeed } from "./home/ActivityFeed";
 import { CostCharts } from "./home/CostCharts";
 import { SystemPulse } from "./home/SystemPulse";
+import { ChronologicalStream } from "./home/ChronologicalStream";
 
 /* ── Home ───────────────────────────────────────────────────────────────
  *
- * The command-center home. The live agent stream (the AgentCard stream,
- * unchanged from the old /live view) is the centerpiece column; a dense,
- * live-streaming grid wraps around it — an overview strip up top, then an
- * activity feed, two cost charts and a system pulse in the right rail.
- * Everything ticks without a page reload: the stream + event counters run
- * on SSE, the feed polls, the cost modules refresh every 60s.
+ * The command-center home. The live agent stream is the centerpiece column
+ * (#3642): default is one chronological feed across agents (“as it comes”);
+ * “By agent” keeps the classic AgentCard grid. A dense live grid wraps
+ * around it — overview strip up top, activity feed + cost charts in the
+ * right rail. SSE drives the stream; the feed polls; costs refresh every 60s.
  *
- * Every capability from the old Live view survives (presence, search,
- * pause, type filter, export, drill-down, keyboard shortcuts) — they live
- * in the stream module's own header row and the full-width top bar.
+ * Presence, search, pause, type filter, export, drill-down, and keyboard
+ * shortcuts live in the stream header / full-width top bar.
  */
 
 export const SHOW_STOPPED_STORAGE_KEY = "mycel-live-show-stopped";
+/** localStorage key for Home activity presentation (#3642). */
+export const HOME_VIEW_MODE_KEY = "mycel-home-activity-view";
+export type HomeViewMode = "stream" | "by-agent";
 export const ACTIVE_STATES = new Set(["idle", "starting", "working", "stuck", "done"]);
 
 function readShowStopped(): boolean {
@@ -41,6 +43,25 @@ function writeShowStopped(value: boolean): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(SHOW_STOPPED_STORAGE_KEY, value ? "1" : "0");
+  } catch {
+    /* ignore */
+  }
+}
+
+function readViewMode(): HomeViewMode {
+  if (typeof window === "undefined") return "stream";
+  try {
+    const v = window.localStorage.getItem(HOME_VIEW_MODE_KEY);
+    return v === "by-agent" ? "by-agent" : "stream";
+  } catch {
+    return "stream";
+  }
+}
+
+function writeViewMode(value: HomeViewMode): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(HOME_VIEW_MODE_KEY, value);
   } catch {
     /* ignore */
   }
@@ -153,6 +174,7 @@ export function Home() {
   const [typeFilter, setTypeFilter] = useState<FilterType>("all");
   const [searchFilter, setSearchFilter] = useState("");
   const [showStopped, setShowStoppedState] = useState<boolean>(() => readShowStopped());
+  const [viewMode, setViewModeState] = useState<HomeViewMode>(() => readViewMode());
 
   const setShowStopped = useCallback((value: boolean | ((prev: boolean) => boolean)) => {
     setShowStoppedState((prev) => {
@@ -160,6 +182,11 @@ export function Home() {
       writeShowStopped(next);
       return next;
     });
+  }, []);
+
+  const setViewMode = useCallback((value: HomeViewMode) => {
+    writeViewMode(value);
+    setViewModeState(value);
   }, []);
   const [collapsedOverrides, setCollapsedOverrides] = useState<Map<string, boolean>>(new Map());
   const [showJumpToLatest, setShowJumpToLatest] = useState(false);
@@ -504,6 +531,39 @@ export function Home() {
             <span className="text-[10px] font-semibold text-mycel-muted uppercase tracking-widest">
               Agents live
             </span>
+            <div
+              className="inline-flex items-center rounded-md border border-mycel-border bg-mycel-surface p-0.5"
+              role="group"
+              aria-label="Activity view"
+              data-testid="home-view-mode-toggle"
+            >
+              <button
+                type="button"
+                onClick={() => setViewMode("stream")}
+                aria-pressed={viewMode === "stream"}
+                data-testid="home-view-stream"
+                className={`h-6 px-2 rounded text-[10px] font-medium transition-colors ${
+                  viewMode === "stream"
+                    ? "bg-mycel-accent-subtle text-mycel-accent"
+                    : "text-mycel-muted hover:text-mycel-text"
+                }`}
+              >
+                As it comes
+              </button>
+              <button
+                type="button"
+                onClick={() => setViewMode("by-agent")}
+                aria-pressed={viewMode === "by-agent"}
+                data-testid="home-view-by-agent"
+                className={`h-6 px-2 rounded text-[10px] font-medium transition-colors ${
+                  viewMode === "by-agent"
+                    ? "bg-mycel-accent-subtle text-mycel-accent"
+                    : "text-mycel-muted hover:text-mycel-text"
+                }`}
+              >
+                By agent
+              </button>
+            </div>
             <span className="ml-auto">
               <SystemPulse />
             </span>
@@ -548,10 +608,29 @@ export function Home() {
               card above the viewport changes height. */}
           <div
             ref={scrollContainerRef}
-            className="flex-1 overflow-y-auto min-h-0 space-y-2.5 relative p-3"
+            className={`flex-1 overflow-y-auto min-h-0 relative ${viewMode === "by-agent" ? "space-y-2.5 p-3" : ""}`}
             style={{ overflowAnchor: "none", scrollbarGutter: "stable" }}
           >
-            {sorted.length === 0 ? (
+            {viewMode === "stream" ? (
+              <ChronologicalStream
+                agents={sorted}
+                searchTerm={searchFilter}
+                typeFilter={typeFilter}
+                onOpenAgent={setDrillDownAgent}
+                emptyTitle={
+                  !showStopped && activeCount === 0 && stoppedCount > 0
+                    ? "No active agents"
+                    : "No activity yet"
+                }
+                emptyDescription={
+                  !showStopped && activeCount === 0 && stoppedCount > 0
+                    ? `${stoppedCount} stopped or errored ${stoppedCount === 1 ? "agent is" : "agents are"} hidden — click "(hidden)" above to reveal.`
+                    : sorted.length > 0
+                      ? "Agents are online — events will appear here as they work."
+                      : "Events will stream here in real-time as agents work."
+                }
+              />
+            ) : sorted.length === 0 ? (
               !showStopped && activeCount === 0 && stoppedCount > 0 ? (
                 <EmptyState
                   icon=">"

--- a/web/src/views/home/ChronologicalStream.tsx
+++ b/web/src/views/home/ChronologicalStream.tsx
@@ -1,0 +1,190 @@
+/**
+ * ChronologicalStream — Home's "as it comes" feed (#3642).
+ *
+ * Flattens tool/lifecycle nodes from every visible agent into one
+ * newest-first timeline. Running rows pin to the top (same pattern as
+ * AgentCard). Each row is attributed to its agent via a compact name
+ * chip that opens the Home drill-down.
+ */
+
+import { useMemo } from "react";
+import type { AgentActivity, FilterType, ToolNode } from "../../components/live/liveTypes";
+import { flattenNodes, nodeMatchesSearch, partitionRunning } from "../../components/live/liveHelpers";
+import { EventRow } from "../../components/live/EventRow";
+import { StateDot } from "../../components/live/LiveRenderers";
+import { EmptyState } from "../../components/EmptyState";
+
+/** Cap on completed rows in the Home stream — full history lives on agent detail. */
+export const HOME_STREAM_MAX_ROWS = 80;
+
+export interface StreamEntry {
+  agentName: string;
+  agentState: string;
+  node: ToolNode;
+}
+
+function buildEntries(
+  agents: AgentActivity[],
+  searchTerm: string,
+  typeFilter: FilterType,
+): StreamEntry[] {
+  const out: StreamEntry[] = [];
+  for (const a of agents) {
+    if (typeFilter === "state") {
+      out.push({
+        agentName: a.name,
+        agentState: a.state,
+        node: {
+          id: `state:${a.name}`,
+          toolName: "Stop",
+          args: a.task || a.state,
+          fullInput: null,
+          fullOutput: null,
+          status: "completed",
+          startTime: a.lastEventTime || 0,
+          children: [],
+        },
+      });
+      continue;
+    }
+    for (const node of flattenNodes(a.nodes)) {
+      if (searchTerm && !nodeMatchesSearch(node, searchTerm)) continue;
+      out.push({ agentName: a.name, agentState: a.state, node });
+    }
+  }
+  return out.sort((x, y) => y.node.startTime - x.node.startTime);
+}
+
+function StreamAgentChip({
+  name,
+  state,
+  onOpen,
+}: {
+  name: string;
+  state: string;
+  onOpen: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      title={`Open ${name} detail view`}
+      className="shrink-0 inline-flex items-center gap-1.5 max-w-[7.5rem] px-2 py-0.5 rounded-md border border-mycel-border bg-mycel-bg text-[11px] font-medium text-mycel-text hover:border-mycel-accent hover:text-mycel-accent transition-colors"
+    >
+      <StateDot state={state} />
+      <span className="truncate">{name}</span>
+    </button>
+  );
+}
+
+function AttributedEventRow({
+  entry,
+  searchTerm,
+  onOpenAgent,
+}: {
+  entry: StreamEntry;
+  searchTerm: string;
+  onOpenAgent: (name: string) => void;
+}) {
+  return (
+    <div
+      className="flex items-stretch border-b border-mycel-border last:border-b-0"
+      data-testid="home-stream-row"
+      data-agent={entry.agentName}
+    >
+      <div className="flex items-center pl-2.5 pr-1 shrink-0">
+        <StreamAgentChip
+          name={entry.agentName}
+          state={entry.agentState}
+          onOpen={() => onOpenAgent(entry.agentName)}
+        />
+      </div>
+      <div className="flex-1 min-w-0 [&_>div]:border-b-0">
+        <EventRow node={entry.node} searchQuery={searchTerm} />
+      </div>
+    </div>
+  );
+}
+
+export function ChronologicalStream({
+  agents,
+  searchTerm,
+  typeFilter,
+  onOpenAgent,
+  emptyTitle,
+  emptyDescription,
+}: {
+  agents: AgentActivity[];
+  searchTerm: string;
+  typeFilter: FilterType;
+  onOpenAgent: (name: string) => void;
+  emptyTitle: string;
+  emptyDescription: string;
+}) {
+  const entries = useMemo(
+    () => buildEntries(agents, searchTerm, typeFilter),
+    [agents, searchTerm, typeFilter],
+  );
+
+  const { running, rest } = useMemo(() => {
+    const split = partitionRunning(entries.map((e) => e.node));
+    const runningIds = new Set(split.running.map((n) => n.id));
+    return {
+      running: entries.filter((e) => runningIds.has(e.node.id)),
+      rest: entries.filter((e) => !runningIds.has(e.node.id)),
+    };
+  }, [entries]);
+
+  const shown = rest.slice(0, HOME_STREAM_MAX_ROWS);
+  const hiddenCount = rest.length - shown.length;
+
+  if (entries.length === 0) {
+    return (
+      <div className="p-3" data-testid="home-chronological-stream" data-empty="true">
+        <EmptyState icon=">" title={emptyTitle} description={emptyDescription} />
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="home-chronological-stream" className="flex flex-col min-h-0">
+      {running.length > 0 && (
+        <div className="bg-mycel-accent-subtle/30 border-b-2 border-mycel-accent-subtle">
+          <div className="flex items-center gap-2 px-3 py-1 bg-mycel-surface/95 border-b border-mycel-border">
+            <span className="relative flex h-2 w-2 shrink-0" aria-hidden>
+              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-mycel-accent opacity-60 motion-reduce:hidden" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-mycel-accent" />
+            </span>
+            <span className="text-[10px] uppercase tracking-wide font-semibold text-mycel-accent">
+              Running
+            </span>
+            <span className="text-[10px] text-mycel-muted font-mono tabular-nums">
+              {running.length}
+            </span>
+          </div>
+          {running.map((entry) => (
+            <AttributedEventRow
+              key={`run-${entry.agentName}:${entry.node.id}`}
+              entry={entry}
+              searchTerm={searchTerm}
+              onOpenAgent={onOpenAgent}
+            />
+          ))}
+        </div>
+      )}
+      {shown.map((entry) => (
+        <AttributedEventRow
+          key={`${entry.agentName}:${entry.node.id}`}
+          entry={entry}
+          searchTerm={searchTerm}
+          onOpenAgent={onOpenAgent}
+        />
+      ))}
+      {hiddenCount > 0 && (
+        <div className="px-3 py-2 text-[11px] text-mycel-muted font-mono text-center border-t border-mycel-border">
+          {hiddenCount} older event{hiddenCount === 1 ? "" : "s"} hidden — open an agent for full history
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/views/home/__tests__/chronologicalStream.test.tsx
+++ b/web/src/views/home/__tests__/chronologicalStream.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * ChronologicalStream unit tests — merge + sort + agent attribution (#3642).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ChronologicalStream } from "../ChronologicalStream";
+import type { AgentActivity, ToolNode } from "../../../components/live/liveTypes";
+
+function node(overrides: Partial<ToolNode> & { id: string; startTime: number }): ToolNode {
+  return {
+    toolName: "Bash",
+    args: "echo hi",
+    fullInput: null,
+    fullOutput: null,
+    status: "completed",
+    children: [],
+    ...overrides,
+  };
+}
+
+function agent(name: string, nodes: ToolNode[], state = "working"): AgentActivity {
+  return {
+    name,
+    state,
+    task: "working",
+    tool: "claude",
+    role: "base",
+    tokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    lastEventTime: nodes[0]?.startTime ?? 0,
+    nodes,
+    collapsed: false,
+  };
+}
+
+describe("ChronologicalStream", () => {
+  it("merges agents newest-first with agent chips", () => {
+    const onOpen = vi.fn();
+    render(
+      <ChronologicalStream
+        agents={[
+          agent("alice", [node({ id: "a1", startTime: 100, args: "older" })]),
+          agent("bob", [node({ id: "b1", startTime: 200, args: "newer", toolName: "Read" })]),
+        ]}
+        searchTerm=""
+        typeFilter="all"
+        onOpenAgent={onOpen}
+        emptyTitle="empty"
+        emptyDescription="none"
+      />,
+    );
+
+    const rows = screen.getAllByTestId("home-stream-row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute("data-agent")).toBe("bob");
+    expect(rows[1].getAttribute("data-agent")).toBe("alice");
+
+    fireEvent.click(screen.getByTitle("Open bob detail view"));
+    expect(onOpen).toHaveBeenCalledWith("bob");
+  });
+
+  it("pins running rows above completed ones", () => {
+    render(
+      <ChronologicalStream
+        agents={[
+          agent("alice", [
+            node({ id: "done", startTime: 300, status: "completed" }),
+            node({ id: "run", startTime: 100, status: "running", toolName: "Bash", args: "sleep" }),
+          ]),
+        ]}
+        searchTerm=""
+        typeFilter="all"
+        onOpenAgent={() => {}}
+        emptyTitle="empty"
+        emptyDescription="none"
+      />,
+    );
+
+    expect(screen.getByText("Running")).toBeInTheDocument();
+    const rows = screen.getAllByTestId("home-stream-row");
+    // Running first, then completed (even though completed has a newer startTime).
+    expect(rows[0].textContent).toMatch(/sleep|Bash/);
+  });
+
+  it("shows empty state when there are no nodes", () => {
+    render(
+      <ChronologicalStream
+        agents={[agent("alice", [], "idle")]}
+        searchTerm=""
+        typeFilter="all"
+        onOpenAgent={() => {}}
+        emptyTitle="No activity yet"
+        emptyDescription="waiting"
+      />,
+    );
+    expect(screen.getByText("No activity yet")).toBeInTheDocument();
+    expect(screen.getByTestId("home-chronological-stream").getAttribute("data-empty")).toBe("true");
+  });
+});

--- a/web/src/views/home/__tests__/chronologicalStream.test.tsx
+++ b/web/src/views/home/__tests__/chronologicalStream.test.tsx
@@ -55,8 +55,8 @@ describe("ChronologicalStream", () => {
 
     const rows = screen.getAllByTestId("home-stream-row");
     expect(rows).toHaveLength(2);
-    expect(rows[0].getAttribute("data-agent")).toBe("bob");
-    expect(rows[1].getAttribute("data-agent")).toBe("alice");
+    expect(rows[0]!.getAttribute("data-agent")).toBe("bob");
+    expect(rows[1]!.getAttribute("data-agent")).toBe("alice");
 
     fireEvent.click(screen.getByTitle("Open bob detail view"));
     expect(onOpen).toHaveBeenCalledWith("bob");
@@ -82,7 +82,7 @@ describe("ChronologicalStream", () => {
     expect(screen.getByText("Running")).toBeInTheDocument();
     const rows = screen.getAllByTestId("home-stream-row");
     // Running first, then completed (even though completed has a newer startTime).
-    expect(rows[0].textContent).toMatch(/sleep|Bash/);
+    expect(rows[0]!.textContent).toMatch(/sleep|Bash/);
   });
 
   it("shows empty state when there are no nodes", () => {


### PR DESCRIPTION
## Summary
- Home defaults to a chronological **As it comes** stream across agents (#3642)
- Persisted toggle restores the classic **By agent** card grid (`mycel-home-activity-view`)
- Stream rows attribute events to agents; running tools stay pinned; stopped-agent filter unchanged

## Test plan
- [x] `npm test -- --run src/views/Home.test.tsx src/views/home/__tests__/chronologicalStream.test.tsx`
- [ ] Reload Home: default is stream; switch to By agent and remount — preference sticks
- [ ] With live agents, events from multiple agents interleave newest-first
- [ ] Stopped-agent (hidden) filter still applies in both modes

Part of #3624. Closes #3642.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggle on the Home view to switch between chronological activity and activity grouped by agent.
  * Chronological activity is sorted newest first and identifies the associated agent.
  * Running activity stays prioritized, while completed history is limited for easier browsing.
  * View preference is saved and restored automatically.
  * Added tailored empty-state messaging for filtered or unavailable activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->