### PR TITLE
feat(web): polish Agents + Notifications activity UIs (#3643)

### DIFF
--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -7,7 +7,8 @@ import { useWebSocket } from "../hooks/useWebSocket";
 import { StatusBadge } from "../components/StatusBadge";
 import { EmptyState } from "../components/EmptyState";
 import { EventRow } from "../components/live/EventRow";
-import { activityItemToNode } from "../components/live/liveHelpers";
+import { activityItemToNode, partitionRunning } from "../components/live/liveHelpers";
+import { RunningSection } from "../components/live/LiveRenderers";
 import type { ToolNode } from "../components/live/liveTypes";
 import { truncate } from "../utils/text";
 import { formatAbsolute, formatRelative } from "../utils/time";
@@ -175,9 +176,8 @@ export function peekItemToNode(item: AgentActivityItem, idx: number): ToolNode {
 }
 
 /** The ⊕-row content: the agent's recent hook events rendered with the
- *  same EventRow the Live page and agent-detail Live tab use, height-
- *  capped, with a link through to the full feed. Refreshes on a light
- *  5s poll (the old raw-terminal peek was live via SSE). */
+ *  same EventRow language as Home / agent-detail Live (#3643). Height-
+ *  capped, running rows pinned, link through to the full feed. */
 function PeekActivityFeed({ agentName }: { agentName: string }) {
   const navigate = useNavigate();
   const fetcher = useCallback(
@@ -190,16 +190,38 @@ function PeekActivityFeed({ agentName }: { agentName: string }) {
     () => (items ?? []).slice(0, PEEK_EVENT_LIMIT).map(peekItemToNode),
     [items],
   );
+  const { running, rest } = useMemo(() => partitionRunning(nodes), [nodes]);
 
   return (
-    <div className="px-3 py-2">
-      <div className="rounded-lg bg-mycel-surface p-2 max-h-[320px] overflow-y-auto">
+    <div className="px-3 py-2" data-testid="agent-peek-activity">
+      <div className="rounded-lg border border-mycel-border bg-mycel-surface overflow-hidden max-h-[320px] overflow-y-auto">
+        <div className="sticky top-0 z-10 flex items-center gap-2 px-3 py-1.5 border-b border-mycel-border bg-mycel-bg/95 backdrop-blur-sm">
+          <span className="relative flex h-1.5 w-1.5 shrink-0" aria-hidden>
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-mycel-success opacity-60 motion-reduce:hidden" />
+            <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-mycel-success" />
+          </span>
+          <span className="text-[10px] font-semibold uppercase tracking-widest text-mycel-muted">
+            Activity
+          </span>
+          {nodes.length > 0 && (
+            <span className="ml-auto text-[10px] font-mono tabular-nums text-mycel-muted">
+              {nodes.length}
+            </span>
+          )}
+        </div>
         {loading && !items ? (
-          <p className="text-xs text-mycel-muted px-2 py-1.5">Loading activity…</p>
+          <p className="text-xs text-mycel-muted px-3 py-2.5">Loading activity…</p>
         ) : nodes.length === 0 ? (
-          <p className="text-xs text-mycel-muted px-2 py-1.5">No recent activity</p>
+          <p className="text-xs text-mycel-muted px-3 py-3 italic">
+            No recent events — tool calls and turns will stream here.
+          </p>
         ) : (
-          nodes.map((n) => <EventRow key={n.id} node={n} />)
+          <>
+            <RunningSection nodes={running} />
+            {rest.map((n) => (
+              <EventRow key={n.id} node={n} />
+            ))}
+          </>
         )}
       </div>
       <button

--- a/web/src/views/AppsActivity.tsx
+++ b/web/src/views/AppsActivity.tsx
@@ -218,7 +218,7 @@ export function AppsActivity() {
             />
           </div>
         ) : (
-          <ul className="rounded-lg border border-mycel-border overflow-hidden divide-y divide-mycel-border bg-mycel-surface">
+          <ul className="rounded-lg border border-mycel-border overflow-hidden divide-y divide-mycel-border bg-mycel-surface" data-testid="apps-activity-list">
             {filtered.map((m, i) => {
               const sender = cleanSender(m.sender);
               return (
@@ -241,7 +241,7 @@ export function AppsActivity() {
                           <AppIcon base={sourcePlatform(m.channel)} size={11} />
                           <span className="truncate max-w-[160px]">{channelLeaf(m.channel)}</span>
                         </span>
-                        <time className="ml-auto shrink-0 text-[11px] text-mycel-muted tabular-nums" title={new Date(m.created_at).toLocaleString()}>
+                        <time className="ml-auto shrink-0 text-[11px] text-mycel-muted tabular-nums font-mono" title={new Date(m.created_at).toLocaleString()}>
                           {formatRelative(m.created_at)}
                         </time>
                       </div>

--- a/web/src/views/home/ActivityFeed.tsx
+++ b/web/src/views/home/ActivityFeed.tsx
@@ -4,6 +4,7 @@ import { api } from "../../api/client";
 import type { ChannelMessage, ChannelStats, NotificationSource } from "../../api/client";
 import { usePolling } from "../../hooks/usePolling";
 import { AppIcon } from "../../components/apps/PlatformIcons";
+import { IdentityAvatar } from "../../components/apps/IdentityAvatar";
 import { channelLeaf } from "../../components/apps/AppsHome";
 import { sourcePlatform } from "../../components/apps/messageUtils";
 import { parseActivityTs } from "../../components/apps/appStatus";
@@ -11,11 +12,10 @@ import { formatRelative } from "../../utils/time";
 import { HomeModule } from "./Module";
 
 /* ── ActivityFeed ───────────────────────────────────────────────────
-   The Home "Notifications" feed: newest messages across every connected
-   app channel, compact one-line rows (app icon · sender · channel ·
-   snippet · relative time). Same endpoints as the Apps Notifications
-   page, just a narrower net; the header links to the full feed. Polls
-   15s.
+   The Home "Notifications" rail: people activity from gateways (#3643).
+   Matches AppsActivity hierarchy — identity avatar · sender · channel ·
+   snippet · relative time — so Home / Notifications don’t feel like
+   unrelated designs. Polls 15s.
 ─────────────────────────────────────────────────────────────────── */
 
 const CHANNEL_LIMIT = 10;
@@ -37,8 +37,6 @@ function snippet(content: string): string {
   const s = content.replace(/\s+/g, " ").trim();
   return s.length > 140 ? s.slice(0, 137) + "…" : s;
 }
-
-/* AppIcon (brand SVG → emoji → generic dot) lives in PlatformIcons.tsx. */
 
 export function ActivityFeed() {
   const fetcher = useCallback(async (): Promise<FeedMessage[]> => {
@@ -75,7 +73,9 @@ export function ActivityFeed() {
   return (
     <HomeModule label="Notifications" to="/apps/activity" testId="home-activity" fill>
       {data === null ? (
-        <div className="py-4 text-center text-[11px] text-mycel-muted">Loading…</div>
+        <div className="py-4 text-center text-[11px] text-mycel-muted" aria-busy="true">
+          Loading…
+        </div>
       ) : messages.length === 0 ? (
         <div className="flex flex-col items-center gap-1.5 py-6 text-center">
           <span className="text-mycel-muted" aria-hidden>
@@ -89,38 +89,45 @@ export function ActivityFeed() {
           </Link>
         </div>
       ) : (
-        <ul className="-m-1">
-          {messages.map((m) => (
-            <li key={`${m.channel}:${String(m.id)}`}>
-              <Link
-                to={`/apps/${m.channel}`}
-                className="flex items-start gap-2 rounded-md px-1.5 py-[5px] hover:bg-mycel-surface-hover transition-colors min-w-0"
-              >
-                <span className="shrink-0 mt-[3px] text-mycel-muted" aria-hidden>
-                  <AppIcon base={sourcePlatform(m.channel)} size={11} />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="flex items-baseline gap-1.5 min-w-0">
-                    <span className="text-[11.5px] font-medium text-mycel-text truncate">
-                      {cleanSender(m.sender)}
+        <ul className="-m-1" data-testid="home-activity-list">
+          {messages.map((m) => {
+            const sender = cleanSender(m.sender);
+            return (
+              <li key={`${m.channel}:${String(m.id)}`}>
+                <Link
+                  to={`/apps/${m.channel}`}
+                  className="flex items-start gap-2 rounded-md px-1.5 py-[6px] hover:bg-mycel-surface-hover transition-colors min-w-0"
+                >
+                  <IdentityAvatar
+                    name={sender}
+                    src={m.avatar_url || undefined}
+                    size={22}
+                    className="mt-0.5"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-baseline gap-1.5 min-w-0">
+                      <span className="text-[11.5px] font-medium text-mycel-text truncate">
+                        {sender}
+                      </span>
+                      <span className="inline-flex items-center gap-1 text-[10px] font-mono text-mycel-muted truncate min-w-0">
+                        <AppIcon base={sourcePlatform(m.channel)} size={10} />
+                        <span className="truncate">#{channelLeaf(m.channel)}</span>
+                      </span>
+                      <time
+                        className="ml-auto shrink-0 text-[10px] text-mycel-muted tabular-nums"
+                        title={new Date(m.created_at).toLocaleString()}
+                      >
+                        {formatRelative(m.created_at)}
+                      </time>
                     </span>
-                    <span className="text-[10px] font-mono text-mycel-muted truncate">
-                      #{channelLeaf(m.channel)}
+                    <span className="block text-[11px] leading-[1.45] text-mycel-text-2 truncate">
+                      {snippet(m.content)}
                     </span>
-                    <time
-                      className="ml-auto shrink-0 text-[10px] text-mycel-muted tabular-nums"
-                      title={new Date(m.created_at).toLocaleString()}
-                    >
-                      {formatRelative(m.created_at)}
-                    </time>
                   </span>
-                  <span className="block text-[11px] leading-[1.45] text-mycel-text-2 truncate">
-                    {snippet(m.content)}
-                  </span>
-                </span>
-              </Link>
-            </li>
-          ))}
+                </Link>
+              </li>
+            );
+          })}
         </ul>
       )}
     </HomeModule>

--- a/web/src/views/home/__tests__/homeModules.test.tsx
+++ b/web/src/views/home/__tests__/homeModules.test.tsx
@@ -112,12 +112,18 @@ describe("OverviewStrip", () => {
 // ── ActivityFeed ─────────────────────────────────────────────────────
 
 describe("ActivityFeed", () => {
-  it("renders recent channel messages as compact rows", async () => {
+  it("renders recent channel messages as compact rows with identity avatars", async () => {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {
       const u = String(url);
       if (u.includes("/apps/channels/") && u.includes("/history")) {
         return jsonResponse([
-          { id: 1, sender: "alice", content: "deploy is green", created_at: new Date().toISOString() },
+          {
+            id: 1,
+            sender: "alice",
+            content: "deploy is green",
+            created_at: new Date().toISOString(),
+            avatar_url: "https://example.com/alice.png",
+          },
         ]);
       }
       if (u.includes("/apps/channels")) {
@@ -133,6 +139,7 @@ describe("ActivityFeed", () => {
 
     expect(await screen.findByText("deploy is green")).toBeInTheDocument();
     expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "alice" })).toHaveAttribute("src", "https://example.com/alice.png");
     // Header links to the full activity page.
     expect(screen.getByRole("link", { name: /view all/ })).toHaveAttribute("href", "/apps/activity");
   });


### PR DESCRIPTION
## Summary
- **Agents peek**: stream chrome (live header, pinned Running section, EventRow list) aligned with Home / agent-detail Live (#3643)
- **Home Notifications rail**: identity avatars + channel app glyph — same hierarchy as Apps activity (#3643 / #3644)
- **Apps activity**: mono timestamps + list test id for consistency

## Test plan
- [x] `npm test -- --run src/views/home/__tests__/homeModules.test.tsx src/views/Agents.peekItemToNode.test.tsx`
- [ ] Home → Notifications rail shows avatars when `avatar_url` present
- [ ] Agents table peek ⊕ shows Activity header + EventRows; running tools pin to top
- [ ] `/apps/activity` still renders people avatars

Part of #3624. Closes #3643. Closes #3644.

Made with [Cursor](https://cursor.com)