### PR TITLE
feat(agent): idempotent mycel-managed prompt section (#3648)

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -7,7 +7,7 @@ Task-oriented guides for common operations.
 | [Configure mycel](configure.md) | prefs.json structure, providers, runtime backends, and validation |
 | [Set up apps](set-up-apps.md) | Connect external platforms and subscribe agents |
 | [Manage secrets](manage-secrets.md) | The encrypted vault, `${secret:NAME}` references, repo overrides |
-| [Inject instructions](inject-instructions.md) | Add a global instruction block to every agent's prompt |
+| [Inject instructions](inject-instructions.md) | Mycel-managed prompt section (instructions, MCP, apps, subscriptions) |
 | [Use agent templates](use-templates.md) | The 36 built-in templates, guardrails, and writing your own |
 | [Browse the marketplace](browse-the-marketplace.md) | Discover and install agent templates |
 | [Read insights](read-insights.md) | Costs, stats, and activity surfaces |

--- a/docs/how-to/inject-instructions.md
+++ b/docs/how-to/inject-instructions.md
@@ -1,15 +1,25 @@
 # Inject Instructions
 
-Injected instructions are a block of guidance that mycel appends to every agent's prompt at spawn time — a single place to state conventions that every agent should follow, regardless of role.
+Injected instructions are guidance mycel writes into every agent's prompt —
+a single place for conventions that every agent should follow, regardless of role.
 
 ## Overview
 
-Each agent's prompt is assembled from its role, then mycel appends two things to the same prompt file:
+Each agent's prompt file (`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, … depending
+on the provider) is assembled in layers:
 
-1. The **injected instructions** text you author.
-2. An auto-generated summary of the resources the agent can reach — the names of its available MCP servers and the names of its credential environment variables (names only, never values).
+1. **Role / template prompt** — authored persona, written first by spawn setup.
+2. **Mycel-managed section** — rewritten **idempotently** on every spawn and
+   restart (markers `<!-- mycel-managed:start -->` … `<!-- mycel-managed:end -->`).
+   This block includes:
+   - Your injected instructions text
+   - Identity (agent name + role)
+   - MCP server names + credential env var **names** (never values)
+   - Connected apps + platform credential env docs
+   - This agent's notification subscriptions (`slack:*`, `gmail:…`, …)
 
-The result is a `## mycel instructions` block at the end of the agent's `CLAUDE.md`, applied to every agent uniformly and refreshed on each spawn and restart.
+Edits to subscriptions or apps show up on the **next spawn/restart** of the
+agent (the managed section is not live-rewritten while the session is running).
 
 ## Author the Instructions
 
@@ -21,31 +31,67 @@ curl -X PUT http://localhost:9374/api/settings/injected-instructions \
   -d '{"injected_instructions": "Report status before and after every task. Never merge without a green check."}'
 ```
 
-The text is stored in the repo's runtime configuration and written to disk, but never contains secret values. Whatever you write is appended verbatim to each agent's prompt.
+The text is stored in the repo's runtime configuration and written to disk, but never contains secret values. Whatever you write is included verbatim inside the managed section.
 
 ## What an Agent Sees
 
-Given the instruction above and an agent with the `mycel` and `github` MCP servers plus `GH_TOKEN` and `SLACK_BOT_TOKEN` credentials, the block appended to that agent's prompt reads:
+Given the instruction above and an agent with the `mycel` and `github` MCP servers plus `GH_TOKEN` and `SLACK_BOT_TOKEN` credentials, the managed block looks like:
 
 ```markdown
-## mycel instructions
+<!-- mycel-managed:start -->
+## mycel context
+
+_This section is managed by mycel — rewritten on every spawn/restart. Do not edit by hand._
+
+### Identity
+- Agent: `fast-crane` (also `MYCEL_AGENT_ID`)
+- Role: `base`
+
+### Instructions
 
 Report status before and after every task. Never merge without a green check.
 
 ### Available resources
-MCP servers: mycel, github
+MCP servers: github, mycel
 Credential env vars: GH_TOKEN, SLACK_BOT_TOKEN
+
+### Connected apps
+- `slack` (Slack)
+
+## Platform Credentials
+
+You have access to these platform credentials via environment variables:
+
+- SLACK_BOT_TOKEN: Slack Bot Token.
+
+Your agent name is available as the `MYCEL_AGENT_ID` environment variable.
+
+### Notification subscriptions
+- `slack:*`
+- `slack:general`
+
+<!-- mycel-managed:end -->
 ```
 
-The resource summary is generated per agent, so each agent sees the servers and credential names that actually apply to it — the credential values themselves stay in the vault and are only resolved into the agent's environment at spawn.
+Resource and subscription lists are generated **per agent**. Credential values stay in the vault and are only resolved into the agent's environment at spawn.
 
 ## Instructions vs. Roles
 
 Injected instructions and role prompts are separate mechanisms that compose:
 
 - **Role prompt** — authored per role, inherited and merged across parent roles, and written first.
-- **Injected instructions** — one global text, appended after the role prompt so it applies to every agent.
+- **Mycel-managed section** — global injected text plus live workspace context, rewritten after the role prompt so it applies to every agent without stacking duplicate appends.
 
 Use role prompts for what a *kind* of agent should do, and injected instructions for the house rules that hold across your whole fleet.
 
 > Tip: keep injected instructions short and universal. Anything specific to one job belongs in that agent's role prompt, not here.
+
+## Prompt stack (operators)
+
+| Layer | Owner | When written |
+|-------|--------|----------------|
+| Role / template `system_prompt` | you / template | spawn setup |
+| Mycel-managed block (markers) | mycel | every spawn + restart |
+| Repo / user `AGENTS.md` conventions | tool / user | outside mycel (Claude/Cursor may also load `~/AGENTS.md`) |
+
+Do not hand-edit inside the managed markers — the next restart will overwrite that region.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -517,6 +517,10 @@ type Manager struct { //nolint:govet // field order is intentional for readabili
 	// settings API mutates in place, so edits take effect on the next spawn.
 	wsConfig *home.Config
 
+	// channelLister supplies notification subscriptions for the mycel-managed
+	// prompt block (#3648). Optional — nil omits the subscriptions section body.
+	channelLister ChannelLister
+
 	// providersConfig holds the global provider command overrides
 	// (prefs.json `providers.<tool>.command`). Used by
 	// getAgentCommand to layer a user-supplied command on top of the
@@ -1451,10 +1455,9 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	if setupErr := SetupAgentFromRoleAndTemplate(ctx, repoPath, name, string(existing.Role), wtDir, agentRuntime, existing.Tool, existing.Template); setupErr != nil {
 		log.Warn("agent setup failed on restart", "agent", name, "error", setupErr)
 	}
-	appendAppPrompt(wtDir, existing.Tool, m.appsConfig)
-	if err := appendInjectedInstructions(ctx, injectedPromptFile(wtDir, existing.Tool), m.wsConfig,
+	if err := m.syncManagedPromptForAgent(ctx, wtDir, existing.Tool, name, string(existing.Role),
 		resolveRoleMCPServers(repoPath, string(existing.Role)), secretEnvKeys); err != nil {
-		log.Warn("failed to append injected instructions", "agent", name, "error", err)
+		log.Warn("failed to sync managed prompt", "agent", name, "error", err)
 	}
 
 	if err := rt.CreateSessionWithEnv(ctx, name, wtDir, agentCmd, env); err != nil {
@@ -1681,11 +1684,10 @@ func (m *Manager) createAgent(ctx context.Context, opts SpawnOptions) (*Agent, e
 		agent.Task = fmt.Sprintf("agent setup failed: %v", setupErr)
 	}
 
-	// Append platform credential instructions to the agent's prompt file
-	appendAppPrompt(wtDir, effectiveTool, m.appsConfig)
-	if err := appendInjectedInstructions(ctx, injectedPromptFile(wtDir, effectiveTool), m.wsConfig,
+	// Sync mycel-managed prompt section (apps, subscriptions, injected instructions).
+	if err := m.syncManagedPromptForAgent(ctx, wtDir, effectiveTool, name, string(role),
 		resolveRoleMCPServers(repoPath, string(role)), secretEnvKeys); err != nil {
-		log.Warn("failed to append injected instructions", "agent", name, "error", err)
+		log.Warn("failed to sync managed prompt", "agent", name, "error", err)
 	}
 
 	// Validate required tools before starting — fail fast with clear errors.
@@ -3394,35 +3396,6 @@ func appPromptInstructions(apps map[string]app.InstanceConfig) string {
 	return sb.String()
 }
 
-// appendAppPrompt appends platform credential instructions to the agent's
-// CLAUDE.md (or provider-equivalent prompt file) if connected apps exist.
-func appendAppPrompt(targetDir, toolName string, apps map[string]app.InstanceConfig) {
-	instructions := appPromptInstructions(apps)
-	if instructions == "" {
-		return
-	}
-
-	// targetDir is an agent worktree path derived from validated names;
-	// reject traversal segments as defense in depth.
-	targetDir = filepath.Clean(targetDir)
-	if strings.Contains(targetDir, "..") {
-		log.Warn("refusing to append app prompt to traversal path", "dir", targetDir)
-		return
-	}
-
-	adapter := resolveConfigAdapter(toolName)
-	promptFile := filepath.Join(targetDir, adapter.PromptFile())
-	f, err := os.OpenFile(promptFile, os.O_APPEND|os.O_WRONLY, 0600) //nolint:gosec // controlled agent repo path
-	if err != nil {
-		log.Debug("cannot append app prompt, prompt file not writable", "path", promptFile, "error", err)
-		return
-	}
-	defer f.Close() //nolint:errcheck
-	if _, err := f.WriteString(instructions); err != nil {
-		log.Warn("failed to append app prompt instructions", "path", promptFile, "error", err)
-	}
-}
-
 // injectedPromptFile resolves the prompt file path (CLAUDE.md or the
 // provider-equivalent) inside an agent worktree for the given tool.
 func injectedPromptFile(targetDir, toolName string) string {
@@ -3430,43 +3403,11 @@ func injectedPromptFile(targetDir, toolName string) string {
 	return filepath.Join(targetDir, adapter.PromptFile())
 }
 
-// appendInjectedInstructions appends the mycel-authored injected-instructions
-// block to an agent's prompt file. The block carries the authored text plus an
-// auto-generated summary of the MCP servers and credential env var NAMES the
-// agent has access to. Secret VALUES are never written — only key names.
-//
-// It is a no-op (returns nil) when no instructions are configured.
+// appendInjectedInstructions syncs the mycel-managed prompt block for tests
+// and any remaining call sites. Prefer syncManagedPromptForAgent / syncAgentManagedPrompt
+// which also include apps + subscriptions (#3648).
 func appendInjectedInstructions(ctx context.Context, promptFile string, cfg *home.Config, mcpServers, secretEnvKeys []string) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
-	if cfg == nil || strings.TrimSpace(cfg.InjectedInstructions) == "" {
-		return nil
-	}
-
-	// promptFile is derived from a validated agent worktree path; reject
-	// traversal segments as defense in depth.
-	cleaned := filepath.Clean(promptFile)
-	if strings.Contains(cleaned, "..") {
-		return fmt.Errorf("refusing to write injected instructions to traversal path %q", promptFile)
-	}
-
-	var sb strings.Builder
-	sb.WriteString("\n## mycel instructions\n\n")
-	sb.WriteString(strings.TrimSpace(cfg.InjectedInstructions))
-	sb.WriteString("\n\n### Available resources\n")
-	sb.WriteString("MCP servers: " + summarizeNames(mcpServers) + "\n")
-	sb.WriteString("Credential env vars: " + summarizeNames(secretEnvKeys) + "\n")
-
-	f, err := os.OpenFile(cleaned, os.O_APPEND|os.O_WRONLY, 0600) //nolint:gosec // controlled agent repo path
-	if err != nil {
-		return fmt.Errorf("open prompt file: %w", err)
-	}
-	defer f.Close() //nolint:errcheck
-	if _, err := f.WriteString(sb.String()); err != nil {
-		return fmt.Errorf("write injected instructions: %w", err)
-	}
-	return nil
+	return syncAgentManagedPrompt(ctx, promptFile, cfg, nil, "", "", mcpServers, secretEnvKeys, nil)
 }
 
 // summarizeNames renders a sorted, comma-separated list of names, or the

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -1455,7 +1455,7 @@ func (m *Manager) startAgent(ctx context.Context, name string, opts SpawnOptions
 	if setupErr := SetupAgentFromRoleAndTemplate(ctx, repoPath, name, string(existing.Role), wtDir, agentRuntime, existing.Tool, existing.Template); setupErr != nil {
 		log.Warn("agent setup failed on restart", "agent", name, "error", setupErr)
 	}
-	if err := m.syncManagedPromptForAgent(ctx, wtDir, existing.Tool, name, string(existing.Role),
+	if err := m.syncManagedPromptForAgent(ctx, wtDir, toolName, name, string(existing.Role),
 		resolveRoleMCPServers(repoPath, string(existing.Role)), secretEnvKeys); err != nil {
 		log.Warn("failed to sync managed prompt", "agent", name, "error", err)
 	}

--- a/pkg/agent/injected_instructions_test.go
+++ b/pkg/agent/injected_instructions_test.go
@@ -10,8 +10,7 @@ import (
 	"github.com/rpuneet/mycel/pkg/home"
 )
 
-// writeEmptyPromptFile creates an empty prompt file so appendInjectedInstructions
-// (which opens with O_APPEND|O_WRONLY, no O_CREATE) can write to it.
+// writeEmptyPromptFile creates a seeded prompt file for append/sync tests.
 func writeEmptyPromptFile(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -22,53 +21,12 @@ func writeEmptyPromptFile(t *testing.T) string {
 	return p
 }
 
-func TestAppendInjectedInstructions_AppendsBlock(t *testing.T) {
-	p := writeEmptyPromptFile(t)
-	cfg := &home.Config{
-		InjectedInstructions: "Always report status before and after work.",
-	}
-
-	err := appendInjectedInstructions(
-		context.Background(),
-		p,
-		cfg,
-		[]string{"mycel", "github"},             // intentionally unsorted
-		[]string{"SLACK_BOT_TOKEN", "GH_TOKEN"}, // key NAMES only
-	)
-	if err != nil {
-		t.Fatalf("appendInjectedInstructions: %v", err)
-	}
-
-	data, err := os.ReadFile(p) //nolint:gosec // test file path from t.TempDir
-	if err != nil {
-		t.Fatalf("read prompt file: %v", err)
-	}
-	got := string(data)
-
-	for _, want := range []string{
-		"# existing prompt",                              // pre-existing content preserved
-		"## mycel instructions",                          // block header
-		"Always report status before and after work.",    // authored text
-		"### Available resources",                        // resources sub-header
-		"MCP servers: github, mycel",                     // sorted MCP names
-		"Credential env vars: GH_TOKEN, SLACK_BOT_TOKEN", // sorted key NAMES
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("prompt file missing %q\n---\n%s", want, got)
-		}
-	}
-}
-
-// TestAppendInjectedInstructions_NoSecretValues proves that only credential env
-// var NAMES are written — a secret VALUE handed to the function via env would
-// never reach the prompt because the function only ever receives names.
 func TestAppendInjectedInstructions_NoSecretValues(t *testing.T) {
 	p := writeEmptyPromptFile(t)
 	cfg := &home.Config{InjectedInstructions: "Do the thing."}
 
 	const secretValue = "xoxb-super-secret-token-value" //nolint:gosec // fake token used to assert non-leakage
 
-	// Only the NAME is passed. The value must never be written.
 	if err := appendInjectedInstructions(
 		context.Background(),
 		p,
@@ -79,12 +37,7 @@ func TestAppendInjectedInstructions_NoSecretValues(t *testing.T) {
 		t.Fatalf("appendInjectedInstructions: %v", err)
 	}
 
-	data, err := os.ReadFile(p) //nolint:gosec // test file path from t.TempDir
-	if err != nil {
-		t.Fatalf("read prompt file: %v", err)
-	}
-	got := string(data)
-
+	got := readFile(t, p)
 	if strings.Contains(got, secretValue) {
 		t.Fatalf("secret value leaked into prompt file:\n%s", got)
 	}
@@ -96,30 +49,19 @@ func TestAppendInjectedInstructions_NoSecretValues(t *testing.T) {
 	}
 }
 
-func TestAppendInjectedInstructions_EmptyIsNoop(t *testing.T) {
+func TestAppendInjectedInstructions_EmptyStillWritesManagedShell(t *testing.T) {
+	// Empty injected text still syncs the managed block (identity / resources)
+	// so spawn always has a stable mycel section (#3648).
 	p := writeEmptyPromptFile(t)
-	before, err := os.ReadFile(p) //nolint:gosec // test file path from t.TempDir
-	if err != nil {
-		t.Fatalf("read prompt file: %v", err)
+	if err := appendInjectedInstructions(context.Background(), p, &home.Config{InjectedInstructions: ""}, []string{"mycel"}, []string{"GH_TOKEN"}); err != nil {
+		t.Fatal(err)
 	}
-
-	// Empty / whitespace-only instructions must not touch the file.
-	for _, cfg := range []*home.Config{
-		nil,
-		{InjectedInstructions: ""},
-		{InjectedInstructions: "   \n\t "},
-	} {
-		if appendErr := appendInjectedInstructions(context.Background(), p, cfg, []string{"mycel"}, []string{"GH_TOKEN"}); appendErr != nil {
-			t.Fatalf("appendInjectedInstructions: %v", appendErr)
-		}
+	got := readFile(t, p)
+	if !strings.Contains(got, managedPromptStart) {
+		t.Fatalf("expected managed block even with empty instructions:\n%s", got)
 	}
-
-	after, err := os.ReadFile(p) //nolint:gosec // test file path from t.TempDir
-	if err != nil {
-		t.Fatalf("read prompt file: %v", err)
-	}
-	if string(before) != string(after) {
-		t.Errorf("prompt file changed on no-op:\nbefore=%q\nafter=%q", before, after)
+	if !strings.Contains(got, "MCP servers: mycel") {
+		t.Fatalf("expected MCP summary:\n%s", got)
 	}
 }
 

--- a/pkg/agent/managed_prompt.go
+++ b/pkg/agent/managed_prompt.go
@@ -153,7 +153,7 @@ func syncManagedPromptFile(promptFile, managedBlock string) error {
 	}
 	out.WriteString(managedBlock)
 
-	if err := os.MkdirAll(filepath.Dir(cleaned), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(cleaned), 0o750); err != nil {
 		return fmt.Errorf("mkdir prompt dir: %w", err)
 	}
 	if err := os.WriteFile(cleaned, []byte(out.String()), 0o600); err != nil {

--- a/pkg/agent/managed_prompt.go
+++ b/pkg/agent/managed_prompt.go
@@ -158,25 +158,25 @@ func syncManagedPromptFile(promptFile, managedBlock string) error {
 		return fmt.Errorf("mkdir prompt dir: %w", err)
 	}
 	// Atomic replace so a crash mid-write cannot leave a truncated prompt.
-	tmp, err := os.CreateTemp(dir, ".mycel-prompt-*.tmp")
-	if err != nil {
-		return fmt.Errorf("create temp prompt file: %w", err)
+	tmp, createErr := os.CreateTemp(dir, ".mycel-prompt-*.tmp")
+	if createErr != nil {
+		return fmt.Errorf("create temp prompt file: %w", createErr)
 	}
 	tmpName := tmp.Name()
 	defer func() { _ = os.Remove(tmpName) }()
-	if _, err := tmp.Write([]byte(out.String())); err != nil {
+	if _, writeErr := tmp.Write([]byte(out.String())); writeErr != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("write temp prompt file: %w", err)
+		return fmt.Errorf("write temp prompt file: %w", writeErr)
 	}
-	if err := tmp.Chmod(0o600); err != nil {
+	if chmodErr := tmp.Chmod(0o600); chmodErr != nil {
 		_ = tmp.Close()
-		return fmt.Errorf("chmod temp prompt file: %w", err)
+		return fmt.Errorf("chmod temp prompt file: %w", chmodErr)
 	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp prompt file: %w", err)
+	if closeErr := tmp.Close(); closeErr != nil {
+		return fmt.Errorf("close temp prompt file: %w", closeErr)
 	}
-	if err := os.Rename(tmpName, cleaned); err != nil {
-		return fmt.Errorf("replace prompt file: %w", err)
+	if renameErr := os.Rename(tmpName, cleaned); renameErr != nil {
+		return fmt.Errorf("replace prompt file: %w", renameErr)
 	}
 	return nil
 }

--- a/pkg/agent/managed_prompt.go
+++ b/pkg/agent/managed_prompt.go
@@ -153,11 +153,30 @@ func syncManagedPromptFile(promptFile, managedBlock string) error {
 	}
 	out.WriteString(managedBlock)
 
-	if err := os.MkdirAll(filepath.Dir(cleaned), 0o750); err != nil {
+	dir := filepath.Dir(cleaned)
+	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("mkdir prompt dir: %w", err)
 	}
-	if err := os.WriteFile(cleaned, []byte(out.String()), 0o600); err != nil {
-		return fmt.Errorf("write prompt file: %w", err)
+	// Atomic replace so a crash mid-write cannot leave a truncated prompt.
+	tmp, err := os.CreateTemp(dir, ".mycel-prompt-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create temp prompt file: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write([]byte(out.String())); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp prompt file: %w", err)
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp prompt file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp prompt file: %w", err)
+	}
+	if err := os.Rename(tmpName, cleaned); err != nil {
+		return fmt.Errorf("replace prompt file: %w", err)
 	}
 	return nil
 }
@@ -166,31 +185,47 @@ func syncManagedPromptFile(promptFile, managedBlock string) error {
 func stripManagedSections(content string) string {
 	for {
 		start := strings.Index(content, managedPromptStart)
-		end := strings.Index(content, managedPromptEnd)
-		if start >= 0 && end > start {
-			end += len(managedPromptEnd)
-			// Drop a leading newline left behind the block.
-			if start > 0 && content[start-1] == '\n' {
-				start--
-			}
-			content = content[:start] + content[end:]
-			continue
+		if start < 0 {
+			break
 		}
-		break
+		end := strings.Index(content[start:], managedPromptEnd)
+		if end >= 0 {
+			end = start + end + len(managedPromptEnd)
+		} else {
+			// Orphan start marker (no end) — drop from marker to EOF so the
+			// next sync does not stack another managed block after it.
+			end = len(content)
+		}
+		if start > 0 && content[start-1] == '\n' {
+			start--
+		}
+		content = content[:start] + content[end:]
 	}
 
-	// Strip legacy append-only blocks that predate markers (#3648).
+	// Strip legacy append-only sections that predate markers (#3648).
+	// Bound each strip to the next markdown H2 so user content after a
+	// coincidental heading is preserved.
 	for {
-		idx := lastLegacyManagedIndex(content)
+		idx, hdrLen := lastLegacyManagedIndex(content)
 		if idx < 0 {
 			break
 		}
-		content = content[:idx]
+		bodyStart := idx + hdrLen
+		next := strings.Index(content[bodyStart:], "\n## ")
+		var sectionEnd int
+		if next < 0 {
+			sectionEnd = len(content)
+		} else {
+			sectionEnd = bodyStart + next
+		}
+		content = content[:idx] + content[sectionEnd:]
 	}
 	return content
 }
 
-func lastLegacyManagedIndex(content string) int {
+// lastLegacyManagedIndex finds the last legacy mycel heading and the length
+// of the matched header string (including a leading newline when present).
+func lastLegacyManagedIndex(content string) (idx, hdrLen int) {
 	candidates := []string{
 		"\n## mycel instructions\n",
 		"\n## Platform Credentials\n",
@@ -198,12 +233,14 @@ func lastLegacyManagedIndex(content string) int {
 		"## Platform Credentials\n",
 	}
 	best := -1
+	bestLen := 0
 	for _, c := range candidates {
 		if i := strings.LastIndex(content, c); i > best {
 			best = i
+			bestLen = len(c)
 		}
 	}
-	return best
+	return best, bestLen
 }
 
 // syncAgentManagedPrompt builds and writes the managed block for one agent.
@@ -222,8 +259,6 @@ func syncAgentManagedPrompt(
 	if cfg != nil {
 		injected = cfg.InjectedInstructions
 	}
-	// Skip writing an empty managed block when there is nothing useful —
-	// but still strip legacy/managed sections so restarts clean up.
 	block := buildManagedPromptBlock(ManagedPromptInput{
 		AgentName:            agentName,
 		Role:                 role,

--- a/pkg/agent/managed_prompt.go
+++ b/pkg/agent/managed_prompt.go
@@ -1,0 +1,271 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/rpuneet/mycel/pkg/app"
+	"github.com/rpuneet/mycel/pkg/home"
+	"github.com/rpuneet/mycel/pkg/log"
+)
+
+// Markers for the mycel-owned prompt section. Rewritten idempotently on
+// every spawn/restart so appends never stack (#3648).
+const (
+	managedPromptStart = "<!-- mycel-managed:start -->"
+	managedPromptEnd   = "<!-- mycel-managed:end -->"
+)
+
+// ChannelLister returns notification channels an agent is subscribed to.
+// Implemented by notify.Store; optional on Manager (nil → omit subscriptions).
+type ChannelLister interface {
+	ChannelsForAgent(ctx context.Context, agent string) ([]string, error)
+}
+
+// SetChannelLister wires the notification subscription source used when
+// syncing the mycel-managed prompt block.
+func (m *Manager) SetChannelLister(l ChannelLister) {
+	m.mu.Lock()
+	m.channelLister = l
+	m.mu.Unlock()
+}
+
+// ManagedPromptInput is everything needed to render the mycel-managed block.
+type ManagedPromptInput struct {
+	AgentName            string
+	Role                 string
+	InjectedInstructions string
+	MCPServers           []string
+	SecretEnvKeys        []string
+	Apps                 map[string]app.InstanceConfig
+	Subscriptions        []string // channel keys, e.g. slack:general, gmail:*
+}
+
+// buildManagedPromptBlock renders the marked mycel-managed section.
+func buildManagedPromptBlock(in ManagedPromptInput) string {
+	var sb strings.Builder
+	sb.WriteString("\n")
+	sb.WriteString(managedPromptStart)
+	sb.WriteString("\n")
+	sb.WriteString("## mycel context\n\n")
+	sb.WriteString("_This section is managed by mycel — rewritten on every spawn/restart. Do not edit by hand._\n\n")
+
+	sb.WriteString("### Identity\n")
+	if in.AgentName != "" {
+		sb.WriteString(fmt.Sprintf("- Agent: `%s` (also `MYCEL_AGENT_ID`)\n", in.AgentName))
+	}
+	if in.Role != "" {
+		sb.WriteString(fmt.Sprintf("- Role: `%s`\n", in.Role))
+	}
+	sb.WriteString("\n")
+
+	if text := strings.TrimSpace(in.InjectedInstructions); text != "" {
+		sb.WriteString("### Instructions\n\n")
+		sb.WriteString(text)
+		sb.WriteString("\n\n")
+	}
+
+	sb.WriteString("### Available resources\n")
+	sb.WriteString("MCP servers: " + summarizeNames(in.MCPServers) + "\n")
+	sb.WriteString("Credential env vars: " + summarizeNames(in.SecretEnvKeys) + "\n\n")
+
+	if apps := connectedAppSummary(in.Apps); apps != "" {
+		sb.WriteString("### Connected apps\n")
+		sb.WriteString(apps)
+		sb.WriteString("\n")
+	}
+
+	if creds := strings.TrimSpace(appPromptInstructions(in.Apps)); creds != "" {
+		// appPromptInstructions already includes "## Platform Credentials" header.
+		sb.WriteString(strings.TrimPrefix(creds, "\n"))
+		sb.WriteString("\n")
+	}
+
+	sb.WriteString("### Notification subscriptions\n")
+	if len(in.Subscriptions) == 0 {
+		sb.WriteString("none\n")
+	} else {
+		subs := append([]string(nil), in.Subscriptions...)
+		sort.Strings(subs)
+		for _, ch := range subs {
+			sb.WriteString(fmt.Sprintf("- `%s`\n", ch))
+		}
+	}
+	sb.WriteString("\n")
+	sb.WriteString(managedPromptEnd)
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// connectedAppSummary lists enabled app instance names (platform labels).
+func connectedAppSummary(apps map[string]app.InstanceConfig) string {
+	if len(apps) == 0 {
+		return ""
+	}
+	var lines []string
+	for name, ic := range apps {
+		if !ic.Enabled {
+			continue
+		}
+		label := ic.App
+		if plugin, ok := app.Get(ic.App); ok {
+			label = plugin.Describe().Label
+		}
+		lines = append(lines, fmt.Sprintf("- `%s` (%s)", name, label))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// syncManagedPromptFile rewrites the mycel-managed section in promptFile.
+// User/role content outside the markers is preserved. Legacy un-marked
+// "## mycel instructions" / "## Platform Credentials" appends are stripped
+// so repeated restarts cannot stack blocks.
+func syncManagedPromptFile(promptFile, managedBlock string) error {
+	cleaned := filepath.Clean(promptFile)
+	if strings.Contains(cleaned, "..") {
+		return fmt.Errorf("refusing to write managed prompt to traversal path %q", promptFile)
+	}
+
+	existing := ""
+	data, err := os.ReadFile(cleaned) //nolint:gosec // controlled agent worktree path
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("read prompt file: %w", err)
+		}
+	} else {
+		existing = string(data)
+	}
+
+	base := stripManagedSections(existing)
+	base = strings.TrimRight(base, "\n")
+	var out strings.Builder
+	if base != "" {
+		out.WriteString(base)
+		out.WriteString("\n")
+	}
+	out.WriteString(managedBlock)
+
+	if err := os.MkdirAll(filepath.Dir(cleaned), 0o755); err != nil {
+		return fmt.Errorf("mkdir prompt dir: %w", err)
+	}
+	if err := os.WriteFile(cleaned, []byte(out.String()), 0o600); err != nil {
+		return fmt.Errorf("write prompt file: %w", err)
+	}
+	return nil
+}
+
+// stripManagedSections removes marked mycel blocks and legacy appended headers.
+func stripManagedSections(content string) string {
+	for {
+		start := strings.Index(content, managedPromptStart)
+		end := strings.Index(content, managedPromptEnd)
+		if start >= 0 && end > start {
+			end += len(managedPromptEnd)
+			// Drop a leading newline left behind the block.
+			if start > 0 && content[start-1] == '\n' {
+				start--
+			}
+			content = content[:start] + content[end:]
+			continue
+		}
+		break
+	}
+
+	// Strip legacy append-only blocks that predate markers (#3648).
+	for {
+		idx := lastLegacyManagedIndex(content)
+		if idx < 0 {
+			break
+		}
+		content = content[:idx]
+	}
+	return content
+}
+
+func lastLegacyManagedIndex(content string) int {
+	candidates := []string{
+		"\n## mycel instructions\n",
+		"\n## Platform Credentials\n",
+		"## mycel instructions\n", // file-leading
+		"## Platform Credentials\n",
+	}
+	best := -1
+	for _, c := range candidates {
+		if i := strings.LastIndex(content, c); i > best {
+			best = i
+		}
+	}
+	return best
+}
+
+// syncAgentManagedPrompt builds and writes the managed block for one agent.
+func syncAgentManagedPrompt(
+	ctx context.Context,
+	promptFile string,
+	cfg *home.Config,
+	apps map[string]app.InstanceConfig,
+	agentName, role string,
+	mcpServers, secretEnvKeys, subscriptions []string,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	injected := ""
+	if cfg != nil {
+		injected = cfg.InjectedInstructions
+	}
+	// Skip writing an empty managed block when there is nothing useful —
+	// but still strip legacy/managed sections so restarts clean up.
+	block := buildManagedPromptBlock(ManagedPromptInput{
+		AgentName:            agentName,
+		Role:                 role,
+		InjectedInstructions: injected,
+		MCPServers:           mcpServers,
+		SecretEnvKeys:        secretEnvKeys,
+		Apps:                 apps,
+		Subscriptions:        subscriptions,
+	})
+	return syncManagedPromptFile(promptFile, block)
+}
+
+// syncManagedPromptForAgent is the spawn/restart entry point used by
+// createAgent / startAgent. Failures are logged by callers.
+func (m *Manager) syncManagedPromptForAgent(
+	ctx context.Context,
+	wtDir, toolName, agentName, role string,
+	mcpServers, secretEnvKeys []string,
+) error {
+	var subs []string
+	m.mu.RLock()
+	lister := m.channelLister
+	apps := m.appsConfig
+	cfg := m.wsConfig
+	m.mu.RUnlock()
+	if lister != nil {
+		channels, err := lister.ChannelsForAgent(ctx, agentName)
+		if err != nil {
+			log.Warn("managed prompt: list subscriptions failed", "agent", agentName, "error", err)
+		} else {
+			subs = channels
+		}
+	}
+	return syncAgentManagedPrompt(
+		ctx,
+		injectedPromptFile(wtDir, toolName),
+		cfg,
+		apps,
+		agentName,
+		role,
+		mcpServers,
+		secretEnvKeys,
+		subs,
+	)
+}

--- a/pkg/agent/managed_prompt_test.go
+++ b/pkg/agent/managed_prompt_test.go
@@ -52,7 +52,7 @@ func TestSyncManagedPrompt_Idempotent(t *testing.T) {
 func TestSyncManagedPrompt_StripsLegacyAppends(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "CLAUDE.md")
-	legacy := "# role\n\n## mycel instructions\n\nold text\n\n## Platform Credentials\n\n- FOO: bar.\n"
+	legacy := "# role\n\n## mycel instructions\n\nold text\n\n## Platform Credentials\n\n- FOO: bar.\n\n## My conventions\n\nKeep me.\n"
 	if err := os.WriteFile(p, []byte(legacy), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -67,8 +67,26 @@ func TestSyncManagedPrompt_StripsLegacyAppends(t *testing.T) {
 	if strings.Contains(got, "- FOO: bar.") {
 		t.Fatalf("legacy credentials not stripped:\n%s", got)
 	}
+	if !strings.Contains(got, "## My conventions") || !strings.Contains(got, "Keep me.") {
+		t.Fatalf("user content after legacy heading was lost:\n%s", got)
+	}
 	if !strings.Contains(got, "new") || !strings.Contains(got, managedPromptStart) {
 		t.Fatalf("managed block missing:\n%s", got)
+	}
+}
+
+func TestStripManagedSections_OrphanStart(t *testing.T) {
+	in := "# role\n\n" + managedPromptStart + "\npartial\n\n## after orphan\n\nkeep\n"
+	got := stripManagedSections(in)
+	if strings.Contains(got, managedPromptStart) || strings.Contains(got, "partial") {
+		t.Fatalf("orphan start not stripped:\n%s", got)
+	}
+	// Orphan start drops through EOF (no end marker), so trailing content goes too.
+	if strings.Contains(got, "keep") {
+		t.Fatalf("expected orphan-to-EOF strip:\n%s", got)
+	}
+	if !strings.Contains(got, "# role") {
+		t.Fatalf("role lost:\n%s", got)
 	}
 }
 

--- a/pkg/agent/managed_prompt_test.go
+++ b/pkg/agent/managed_prompt_test.go
@@ -1,0 +1,102 @@
+package agent
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/rpuneet/mycel/pkg/home"
+)
+
+func TestSyncManagedPrompt_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "CLAUDE.md")
+	if err := os.WriteFile(p, []byte("# role prompt\n\nBe helpful.\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &home.Config{InjectedInstructions: "Report status before work."}
+
+	for i := 0; i < 3; i++ {
+		if err := syncAgentManagedPrompt(context.Background(), p, cfg, nil, "fast-crane", "base",
+			[]string{"mycel"}, []string{"SLACK_BOT_TOKEN"}, []string{"slack:general", "slack:*"}); err != nil {
+			t.Fatalf("sync %d: %v", i, err)
+		}
+	}
+
+	got := readFile(t, p)
+	if strings.Count(got, managedPromptStart) != 1 {
+		t.Fatalf("expected one managed start marker, got %d\n%s", strings.Count(got, managedPromptStart), got)
+	}
+	if strings.Count(got, "Report status before work.") != 1 {
+		t.Fatalf("instructions duplicated:\n%s", got)
+	}
+	if !strings.Contains(got, "# role prompt") {
+		t.Fatalf("role prompt lost:\n%s", got)
+	}
+	for _, want := range []string{
+		"Agent: `fast-crane`",
+		"Role: `base`",
+		"MCP servers: mycel",
+		"Credential env vars: SLACK_BOT_TOKEN",
+		"`slack:*`",
+		"`slack:general`",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func TestSyncManagedPrompt_StripsLegacyAppends(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "CLAUDE.md")
+	legacy := "# role\n\n## mycel instructions\n\nold text\n\n## Platform Credentials\n\n- FOO: bar.\n"
+	if err := os.WriteFile(p, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := syncAgentManagedPrompt(context.Background(), p, &home.Config{InjectedInstructions: "new"}, nil,
+		"a", "base", nil, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, p)
+	if strings.Contains(got, "old text") {
+		t.Fatalf("legacy instructions not stripped:\n%s", got)
+	}
+	if strings.Contains(got, "- FOO: bar.") {
+		t.Fatalf("legacy credentials not stripped:\n%s", got)
+	}
+	if !strings.Contains(got, "new") || !strings.Contains(got, managedPromptStart) {
+		t.Fatalf("managed block missing:\n%s", got)
+	}
+}
+
+func TestAppendInjectedInstructions_UsesManagedBlock(t *testing.T) {
+	p := writeEmptyPromptFile(t)
+	cfg := &home.Config{InjectedInstructions: "Always report status before and after work."}
+	if err := appendInjectedInstructions(context.Background(), p, cfg, []string{"mycel", "github"}, []string{"SLACK_BOT_TOKEN", "GH_TOKEN"}); err != nil {
+		t.Fatal(err)
+	}
+	got := readFile(t, p)
+	for _, want := range []string{
+		"# existing prompt",
+		managedPromptStart,
+		"Always report status before and after work.",
+		"MCP servers: github, mycel",
+		"Credential env vars: GH_TOKEN, SLACK_BOT_TOKEN",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q\n%s", want, got)
+		}
+	}
+}
+
+func readFile(t *testing.T, p string) string {
+	t.Helper()
+	data, err := os.ReadFile(p) //nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/pkg/notify/store.go
+++ b/pkg/notify/store.go
@@ -355,6 +355,26 @@ func (s *Store) AllSubscriptions(ctx context.Context) ([]Subscription, error) {
 	return subs, rows.Err()
 }
 
+// ChannelsForAgent returns the channel keys an agent is subscribed to
+// (excluding muted rows). Used to populate the mycel-managed prompt (#3648).
+func (s *Store) ChannelsForAgent(ctx context.Context, agent string) ([]string, error) {
+	rows, err := s.db.QueryContext(ctx, s.q(
+		`SELECT channel FROM notify_subscriptions WHERE agent = ? AND muted = 0 ORDER BY channel`), agent)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var ch string
+		if err := rows.Scan(&ch); err != nil {
+			return nil, err
+		}
+		out = append(out, ch)
+	}
+	return out, rows.Err()
+}
+
 // LogDelivery records a delivery attempt.
 func (s *Store) LogDelivery(ctx context.Context, e DeliveryEntry) error {
 	_, err := s.db.ExecContext(ctx, s.q(

--- a/server/build_services.go
+++ b/server/build_services.go
@@ -364,6 +364,7 @@ func buildServicesFromHome(ctx context.Context, globals *Globals, h *home.Home) 
 		degraded["notify"] = "notify store unavailable: " + err.Error()
 	} else {
 		notifyService = notifypkg.NewServiceWithContext(svcCtx, ns, agentSvc, hub)
+		agentMgr.SetChannelLister(ns)
 		wg.Add(1)
 		go func() {
 			defer wg.Done()


### PR DESCRIPTION
## Summary
- Replace append-only injected instructions / app credential dumps with one marked `<!-- mycel-managed -->` block rewritten on every spawn and restart
- Include identity, injected text, MCP + credential **names**, connected apps, and notification subscriptions (via `notify.Store.ChannelsForAgent`)
- Strip legacy unmarked `## mycel instructions` / `## Platform Credentials` sections so restarts stay idempotent; update operator docs

Closes #3648

## Test plan
- [x] `go test ./pkg/agent/ ./pkg/notify/ ./server/`
- [ ] Spawn/restart an agent and confirm a single managed block in `CLAUDE.md` / `AGENTS.md`
- [ ] Confirm subscriptions appear after notify channel config
- [ ] Confirm secret **values** never appear in the prompt file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent prompts now maintain a synchronized managed section containing identity, instructions, available resources, connected apps, credentials, and notification subscriptions.
  * Prompt updates remain consistent across agent starts and restarts while preserving existing custom content.
  * Credential names may be included without exposing secret values.
  * Muted notification subscriptions are excluded from prompt metadata.

* **Documentation**
  * Expanded guidance on managed prompt sections, layering, restart behavior, secret handling, and editing restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->