### PR TITLE
feat(cli): thin API wrappers for status/templates/tools/config (#3646)

### DIFF
--- a/docs/reference/cli/mycel_template.md
+++ b/docs/reference/cli/mycel_template.md
@@ -6,7 +6,7 @@ Manage agent templates
 
 Manage agent templates — reusable configurations for spawning agents.
 
-Templates are stored in ~/.mycel/templates/ (user-global).
+Templates are managed by the mycel daemon (same store as the web UI).
 
 Examples:
   mycel template list                    # List all templates

--- a/docs/reference/cli/mycel_template_import.md
+++ b/docs/reference/cli/mycel_template_import.md
@@ -4,26 +4,14 @@ Import a template from a file, URL, or the marketplace catalog
 
 ### Synopsis
 
-Import a template into the global template store (~/.mycel/templates/).
+Import a template into the daemon template store.
 
 <source> may be:
   - a path to a local JSON file describing the template
   - an http(s) URL to a template JSON document
   - the name of a template already known to the marketplace catalog
-    (mycel marketplace list --type template)
 
-The JSON document has the same shape as 'mycel template show', plus an
-optional "system_prompt" string field carrying the system prompt text:
-
-  {
-    "name": "my-template",
-    "description": "...",
-    "mcps": ["mycel"],
-    "system_prompt": "You are..."
-  }
-
-Importing a name that already exists in the store updates it in place;
-pass --force to allow the overwrite.
+Importing a name that already exists updates it in place when --force is set.
 
 ```
 mycel template import <source> [flags]

--- a/internal/cmd/cmd_integration_test.go
+++ b/internal/cmd/cmd_integration_test.go
@@ -326,7 +326,8 @@ func TestAgentReportRequiresArgs(t *testing.T) {
 // --- Status command tests ---
 
 func TestStatusNoRepo(t *testing.T) {
-	t.Setenv("MYCEL_WORKSPACE", "") // Clear MYCEL_WORKSPACE to test cwd-based discovery
+	// status is CWD-free (#3646): it talks to the daemon even outside a repo.
+	t.Setenv("MYCEL_WORKSPACE", "")
 
 	origDir, err := os.Getwd()
 	if err != nil {
@@ -339,12 +340,31 @@ func TestStatusNoRepo(t *testing.T) {
 	}
 	defer func() { _ = os.Chdir(origDir) }()
 
-	_, _, err = executeIntegrationCmd("status")
-	if err == nil {
-		t.Fatal("expected error when not in a repo, got nil")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case "/api/system/info":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"workspace": "/tmp/outside-repo", "has_workspace": true,
+			})
+		case "/api/agents":
+			_ = json.NewEncoder(w).Encode([]any{})
+		default:
+			http.NotFound(w, r)
+		}
 	}
-	if !strings.Contains(err.Error(), "not in a mycel-adopted repo") {
-		t.Errorf("expected repo error, got: %v", err)
+
+	stdout, _, err := executeIntegrationCmdT(t, handler, "status")
+	if err != nil {
+		t.Fatalf("status outside repo should work via daemon, got: %v", err)
+	}
+	if !strings.Contains(stdout, "No agents configured") {
+		t.Errorf("expected empty agent list, got: %s", stdout)
+	}
+	if !strings.Contains(stdout, "outside-repo") {
+		t.Errorf("expected workspace basename from /api/system/info, got: %s", stdout)
 	}
 }
 
@@ -352,7 +372,23 @@ func TestStatusEmptyRepo(t *testing.T) {
 	_, cleanup := setupIntegrationHome(t)
 	defer cleanup()
 
-	stdout, _, err := executeIntegrationCmd("status")
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+		case "/api/system/info":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"workspace": "/repos/test-repo", "has_workspace": true,
+			})
+		case "/api/agents":
+			_ = json.NewEncoder(w).Encode([]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}
+
+	stdout, _, err := executeIntegrationCmdT(t, handler, "status")
 	if err != nil {
 		t.Fatalf("status returned error: %v", err)
 	}

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -342,26 +342,12 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	if !client.IsDaemonNotRunning(clientErr) {
-		return clientErr
+	// Mutating config must go through the daemon so the UI and CLI share one
+	// writer (#3646). Offline prefs.json writes caused "CLI ok, UI stale".
+	if client.IsDaemonNotRunning(clientErr) {
+		return fmt.Errorf("the daemon is not running — start it with 'mycel up' before changing config\n(%w)", clientErr)
 	}
-
-	// Offline fallback: direct file modification
-	cfg, configPath, err := loadGlobalConfig()
-	if err != nil {
-		return err
-	}
-
-	if err := setConfigValue(cfg, key, valueStr); err != nil {
-		return err
-	}
-
-	if err := cfg.Save(configPath); err != nil {
-		return fmt.Errorf("failed to save config: %w", err)
-	}
-
-	fmt.Printf("Set %s = %s\n", key, valueStr)
-	return nil
+	return clientErr
 }
 
 func runConfigList(cmd *cobra.Command, _ []string) error {

--- a/internal/cmd/error_scenarios_test.go
+++ b/internal/cmd/error_scenarios_test.go
@@ -334,7 +334,7 @@ func TestMissingRequiredArgs(t *testing.T) {
 
 // TestNoRepo tests the commands that still require an enclosing
 // mycel-adopted repo. Daemon-first commands (agent list, channel list,
-// logs, cost, ...) are CWD-free and covered elsewhere.
+// logs, cost, status, ...) are CWD-free and covered elsewhere.
 func TestNoRepo(t *testing.T) {
 	origDir, err := os.Getwd()
 	if err != nil {
@@ -355,10 +355,11 @@ func TestNoRepo(t *testing.T) {
 		name string
 		args []string
 	}{
-		{
-			name: "status outside repo",
-			args: []string{"status"},
-		},
+		// status is CWD-free as of #3646 — see TestStatusNoRepo.
+	}
+
+	if len(tests) == 0 {
+		t.Skip("no remaining repo-gated commands in this suite; status moved to TestStatusNoRepo")
 	}
 
 	for _, tt := range tests {

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -55,14 +55,14 @@ func init() {
 func runStatus(cmd *cobra.Command, args []string) error {
 	log.Debug("status command started")
 
-	h, err := getRepo()
-	if err != nil {
-		return errNoRepo(err)
-	}
-
 	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
+	}
+
+	wsName := "workspace"
+	if info, infoErr := c.Stats.SystemInfo(cmd.Context()); infoErr == nil && info.Workspace != "" {
+		wsName = filepath.Base(info.Workspace)
 	}
 
 	agentList, err := c.Agents.List(cmd.Context())
@@ -95,7 +95,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			Active    int                `json:"active"`
 			Working   int                `json:"working"`
 		}{
-			Workspace: filepath.Base(h.RootDir),
+			Workspace: wsName,
 			Agents:    agentList,
 			Total:     len(agentList),
 			Active:    activeCount,
@@ -107,7 +107,6 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Summary header
-	wsName := filepath.Base(h.RootDir)
 	fmt.Printf("Repo: %s | Agents: %d | Active: %d | Working: %d\n", wsName, len(agentList), activeCount, workingCount)
 	fmt.Println(strings.Repeat("─", 60))
 	fmt.Println()

--- a/internal/cmd/template.go
+++ b/internal/cmd/template.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
 
-	"github.com/rpuneet/mycel/pkg/home"
+	"github.com/rpuneet/mycel/pkg/client"
 	"github.com/rpuneet/mycel/pkg/template"
 )
 
@@ -19,7 +18,7 @@ var templateCmd = &cobra.Command{
 	Short:   "Manage agent templates",
 	Long: `Manage agent templates — reusable configurations for spawning agents.
 
-Templates are stored in ~/.mycel/templates/ (user-global).
+Templates are managed by the mycel daemon (same store as the web UI).
 
 Examples:
   mycel template list                    # List all templates
@@ -60,26 +59,14 @@ var templateDeleteCmd = &cobra.Command{
 var templateImportCmd = &cobra.Command{
 	Use:   "import <source>",
 	Short: "Import a template from a file, URL, or the marketplace catalog",
-	Long: `Import a template into the global template store (~/.mycel/templates/).
+	Long: `Import a template into the daemon template store.
 
 <source> may be:
   - a path to a local JSON file describing the template
   - an http(s) URL to a template JSON document
   - the name of a template already known to the marketplace catalog
-    (mycel marketplace list --type template)
 
-The JSON document has the same shape as 'mycel template show', plus an
-optional "system_prompt" string field carrying the system prompt text:
-
-  {
-    "name": "my-template",
-    "description": "...",
-    "mcps": ["mycel"],
-    "system_prompt": "You are..."
-  }
-
-Importing a name that already exists in the store updates it in place;
-pass --force to allow the overwrite.`,
+Importing a name that already exists updates it in place when --force is set.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runTemplateImport,
 }
@@ -96,22 +83,12 @@ func init() {
 	rootCmd.AddCommand(templateCmd)
 }
 
-// openTemplateStore returns the single user-global template store at
-// ~/.mycel/templates/.
-func openTemplateStore() (*template.Store, error) {
-	globalDir, err := home.GlobalTemplatesDir()
-	if err != nil {
-		return nil, fmt.Errorf("resolve global templates dir: %w", err)
-	}
-	return template.NewStore(globalDir), nil
-}
-
-func runTemplateList(_ *cobra.Command, _ []string) error {
-	store, err := openTemplateStore()
+func runTemplateList(cmd *cobra.Command, _ []string) error {
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
 	}
-	templates, err := store.List()
+	templates, err := c.Templates.List(cmd.Context())
 	if err != nil {
 		return fmt.Errorf("list templates: %w", err)
 	}
@@ -134,7 +111,7 @@ func runTemplateList(_ *cobra.Command, _ []string) error {
 
 	const mcpsHeader = "MCPS"
 	const scopeHeader = "SCOPE"
-	const colGap = 2 // spaces between columns
+	const colGap = 2
 	separatorWidth := maxNameLen + colGap + maxDescLen + colGap + len(scopeHeader) + colGap + len(mcpsHeader)
 	fmt.Printf("%-*s  %-*s  %-*s  %s\n", maxNameLen, "NAME", maxDescLen, "DESCRIPTION", len(scopeHeader), scopeHeader, mcpsHeader)
 	fmt.Println(strings.Repeat("-", separatorWidth))
@@ -144,7 +121,7 @@ func runTemplateList(_ *cobra.Command, _ []string) error {
 		if mcps == "" {
 			mcps = "\u2014"
 		}
-		scope := string(t.Scope)
+		scope := t.Scope
 		if scope == "" {
 			scope = "global"
 		}
@@ -155,12 +132,12 @@ func runTemplateList(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func runTemplateShow(_ *cobra.Command, args []string) error {
-	store, err := openTemplateStore()
+func runTemplateShow(cmd *cobra.Command, args []string) error {
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
 	}
-	t, prompt, err := store.Get(args[0])
+	t, err := c.Templates.Get(cmd.Context(), args[0])
 	if err != nil {
 		return err
 	}
@@ -189,10 +166,10 @@ func runTemplateShow(_ *cobra.Command, args []string) error {
 	}
 
 	fmt.Println()
-	if prompt != "" {
+	if t.SystemPrompt != "" {
 		fmt.Println("System Prompt:")
 		fmt.Println(strings.Repeat("-", 40))
-		fmt.Println(prompt)
+		fmt.Println(t.SystemPrompt)
 	} else {
 		fmt.Println("System Prompt: (none)")
 	}
@@ -200,49 +177,38 @@ func runTemplateShow(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-func runTemplateCreate(_ *cobra.Command, args []string) error {
-	store, err := openTemplateStore()
+func runTemplateCreate(cmd *cobra.Command, args []string) error {
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
 	}
 
-	name := args[0]
-	if _, err := home.EnsureGlobalDir(); err != nil {
-		return err
-	}
-
-	t := template.Template{
-		Name:        name,
-		Description: "",
-		MCPs:        []string{},
-	}
-	if err := store.Create(t, "", template.ScopeGlobal); err != nil {
-		return err
-	}
-
-	// Print the actual path so the user knows where the file landed.
-	fmt.Printf("Created template at %s\n", filepath.Join(store.GlobalDir(), name+".json"))
-	return nil
-}
-
-func runTemplateDelete(_ *cobra.Command, args []string) error {
-	store, err := openTemplateStore()
+	created, err := c.Templates.Create(cmd.Context(), client.TemplateInfo{
+		Name: args[0],
+		MCPs: []string{},
+	})
 	if err != nil {
 		return err
 	}
 
-	name := args[0]
-	if err := store.Delete(name, template.ScopeGlobal); err != nil {
-		return err
-	}
-
-	fmt.Printf("Deleted template %s\n", name)
+	fmt.Printf("Created template %s\n", created.Name)
 	return nil
 }
 
-// runTemplateImport implements `mycel template import <source>`. source can
-// be a local JSON file path, an http(s) URL to a template JSON document, or
-// the name of a template already listed in the marketplace catalog.
+func runTemplateDelete(cmd *cobra.Command, args []string) error {
+	c, err := newDaemonClient(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	if err := c.Templates.Delete(cmd.Context(), args[0]); err != nil {
+		return err
+	}
+
+	fmt.Printf("Deleted template %s\n", args[0])
+	return nil
+}
+
 func runTemplateImport(cmd *cobra.Command, args []string) error {
 	source := args[0]
 	force, err := cmd.Flags().GetBool("force")
@@ -254,15 +220,12 @@ func runTemplateImport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	store, err := openTemplateStore()
+	c, err := newDaemonClient(cmd.Context())
 	if err != nil {
 		return err
 	}
-	if _, dirErr := home.EnsureGlobalDir(); dirErr != nil {
-		return dirErr
-	}
 
-	t, prompt, err := resolveImportSource(cmd.Context(), store, source)
+	t, prompt, err := resolveImportSource(cmd.Context(), c, source)
 	if err != nil {
 		return err
 	}
@@ -273,35 +236,42 @@ func runTemplateImport(cmd *cobra.Command, args []string) error {
 	if t.Name == "" {
 		return fmt.Errorf("imported template has no name; pass --name to set one")
 	}
-	t.Scope = ""
 
-	if _, _, getErr := store.Get(t.Name); getErr == nil {
+	info := client.TemplateInfo{
+		Name:            t.Name,
+		Description:     t.Description,
+		Label:           t.Label,
+		Provider:        t.Provider,
+		MCPs:            t.MCPs,
+		Secrets:         t.Secrets,
+		Plugins:         t.Plugins,
+		Composes:        t.Composes,
+		SystemPrompt:    prompt,
+		MaxCostUSD:      t.MaxCostUSD,
+		StuckTimeoutMin: t.StuckTimeoutMin,
+	}
+
+	if _, getErr := c.Templates.Get(cmd.Context(), t.Name); getErr == nil {
 		if !force {
 			return fmt.Errorf("template %q already exists; re-run with --force to update it", t.Name)
 		}
-		if err := store.Update(t.Name, t, prompt); err != nil {
+		if _, err := c.Templates.Update(cmd.Context(), t.Name, info); err != nil {
 			return fmt.Errorf("update template %q: %w", t.Name, err)
 		}
 		fmt.Printf("Updated template %q from %s\n", t.Name, source)
 		return nil
 	}
 
-	if err := store.Create(t, prompt, template.ScopeGlobal); err != nil {
+	if _, err := c.Templates.Create(cmd.Context(), info); err != nil {
 		return fmt.Errorf("import template %q: %w", t.Name, err)
 	}
 	fmt.Printf("Imported template %q from %s\n", t.Name, source)
 	return nil
 }
 
-// resolveImportSource resolves source into a Template + system prompt. It
-// tries, in order: an http(s) URL, a local file path, and finally a lookup
-// by name against this store directly. The last case covers "known
-// marketplace item name": the marketplace catalog's "mycel" source (see
-// pkg/marketplace.Aggregator.fetchMycel) lists exactly this store's own
-// templates, so resolving a bare name against the store is equivalent to
-// resolving it via the aggregator today, without paying for a live fetch
-// across every other registry the aggregator knows about.
-func resolveImportSource(ctx context.Context, store *template.Store, source string) (template.Template, string, error) {
+// resolveImportSource resolves source into a Template + system prompt via
+// URL, local file, or an existing daemon template name.
+func resolveImportSource(ctx context.Context, c *client.Client, source string) (template.Template, string, error) {
 	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
 		t, prompt, err := template.FetchImportDoc(ctx, nil, source)
 		if err != nil {
@@ -322,8 +292,19 @@ func resolveImportSource(ctx context.Context, store *template.Store, source stri
 		return t, prompt, nil
 	}
 
-	if t, prompt, err := store.Get(source); err == nil {
-		return *t, prompt, nil
+	if existing, err := c.Templates.Get(ctx, source); err == nil {
+		return template.Template{
+			Name:            existing.Name,
+			Description:     existing.Description,
+			Label:           existing.Label,
+			Provider:        existing.Provider,
+			MCPs:            existing.MCPs,
+			Secrets:         existing.Secrets,
+			Plugins:         existing.Plugins,
+			Composes:        existing.Composes,
+			MaxCostUSD:      existing.MaxCostUSD,
+			StuckTimeoutMin: existing.StuckTimeoutMin,
+		}, existing.SystemPrompt, nil
 	}
 	return template.Template{}, "", fmt.Errorf("%q is not a local file, a URL, or a known template in the store", source)
 }

--- a/internal/cmd/template_import_test.go
+++ b/internal/cmd/template_import_test.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/rpuneet/mycel/pkg/client"
 	"github.com/rpuneet/mycel/pkg/template"
 )
 
@@ -27,8 +29,99 @@ func writeImportFile(t *testing.T, doc template.ImportDoc) string {
 	return path
 }
 
+// fakeTemplateAPI is an in-memory /api/templates + /health handler for CLI tests.
+type fakeTemplateAPI struct {
+	mu   sync.Mutex
+	data map[string]client.TemplateInfo
+}
+
+func newFakeTemplateAPI() *fakeTemplateAPI {
+	return &fakeTemplateAPI{data: map[string]client.TemplateInfo{}}
+}
+
+func (f *fakeTemplateAPI) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"ok"}`))
+			return
+		}
+		switch {
+		case r.URL.Path == "/api/templates" && r.Method == http.MethodGet:
+			f.mu.Lock()
+			list := make([]client.TemplateInfo, 0, len(f.data))
+			for _, t := range f.data {
+				list = append(list, t)
+			}
+			f.mu.Unlock()
+			_ = json.NewEncoder(w).Encode(list)
+		case r.URL.Path == "/api/templates" && r.Method == http.MethodPost:
+			var body client.TemplateInfo
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			f.mu.Lock()
+			if _, ok := f.data[body.Name]; ok {
+				f.mu.Unlock()
+				http.Error(w, "already exists", http.StatusConflict)
+				return
+			}
+			f.data[body.Name] = body
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(body)
+		case strings.HasPrefix(r.URL.Path, "/api/templates/"):
+			name := strings.TrimPrefix(r.URL.Path, "/api/templates/")
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			switch r.Method {
+			case http.MethodGet:
+				t, ok := f.data[name]
+				if !ok {
+					http.NotFound(w, r)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(t)
+			case http.MethodPut:
+				var body client.TemplateInfo
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				if body.Name == "" {
+					body.Name = name
+				}
+				f.data[name] = body
+				_ = json.NewEncoder(w).Encode(body)
+			case http.MethodDelete:
+				delete(f.data, name)
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				http.Error(w, "method", http.StatusMethodNotAllowed)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}
+}
+
+func (f *fakeTemplateAPI) get(name string) (client.TemplateInfo, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t, ok := f.data[name]
+	return t, ok
+}
+
+func (f *fakeTemplateAPI) seed(t client.TemplateInfo) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[t.Name] = t
+}
+
 func TestTemplateImport_FromFile_Creates(t *testing.T) {
-	t.Setenv("MYCEL_HOME", t.TempDir())
+	api := newFakeTemplateAPI()
+	setTestDaemonHandler(t, api.handler())
 	defer resetFlags(templateCmd)
 
 	path := writeImportFile(t, template.ImportDoc{
@@ -48,24 +141,21 @@ func TestTemplateImport_FromFile_Creates(t *testing.T) {
 		t.Errorf("expected success line, got: %s", out)
 	}
 
-	store, storeErr := openTemplateStore()
-	if storeErr != nil {
-		t.Fatalf("open store: %v", storeErr)
-	}
-	got, prompt, getErr := store.Get("my-template")
-	if getErr != nil {
-		t.Fatalf("get imported template: %v", getErr)
+	got, ok := api.get("my-template")
+	if !ok {
+		t.Fatal("imported template missing from API store")
 	}
 	if got.Description != "from a file" {
 		t.Errorf("description = %q, want %q", got.Description, "from a file")
 	}
-	if prompt != "You are a test agent." {
-		t.Errorf("system prompt = %q, want %q", prompt, "You are a test agent.")
+	if got.SystemPrompt != "You are a test agent." {
+		t.Errorf("system prompt = %q, want %q", got.SystemPrompt, "You are a test agent.")
 	}
 }
 
 func TestTemplateImport_ExistingName_IsIdempotentWithForce(t *testing.T) {
-	t.Setenv("MYCEL_HOME", t.TempDir())
+	api := newFakeTemplateAPI()
+	setTestDaemonHandler(t, api.handler())
 	defer resetFlags(templateCmd)
 
 	path := writeImportFile(t, template.ImportDoc{
@@ -77,14 +167,11 @@ func TestTemplateImport_ExistingName_IsIdempotentWithForce(t *testing.T) {
 	}
 	resetFlags(templateCmd)
 
-	// Re-importing without --force should fail rather than silently clobber.
 	if _, _, err := executeIntegrationCmd("template", "import", path); err == nil {
 		t.Fatalf("expected second import without --force to fail")
 	}
 	resetFlags(templateCmd)
 
-	// Update the source doc and re-import with --force: should succeed and
-	// update the stored template (idempotent re-run).
 	path2 := writeImportFile(t, template.ImportDoc{
 		Template: template.Template{Name: "dup-template", Description: "v2"},
 	})
@@ -97,27 +184,22 @@ func TestTemplateImport_ExistingName_IsIdempotentWithForce(t *testing.T) {
 	}
 	resetFlags(templateCmd)
 
-	store, storeErr := openTemplateStore()
-	if storeErr != nil {
-		t.Fatalf("open store: %v", storeErr)
-	}
-	got, _, getErr := store.Get("dup-template")
-	if getErr != nil {
-		t.Fatalf("get template: %v", getErr)
+	got, ok := api.get("dup-template")
+	if !ok {
+		t.Fatal("template missing after force update")
 	}
 	if got.Description != "v2" {
 		t.Errorf("description = %q, want %q (forced update should win)", got.Description, "v2")
 	}
 
-	// A second forced re-import of the same content must also succeed
-	// (true idempotency, not just a one-time overwrite).
 	if _, _, err := executeIntegrationCmd("template", "import", path2, "--force"); err != nil {
 		t.Fatalf("repeated forced import failed: %v", err)
 	}
 }
 
 func TestTemplateImport_FromURL(t *testing.T) {
-	t.Setenv("MYCEL_HOME", t.TempDir())
+	api := newFakeTemplateAPI()
+	setTestDaemonHandler(t, api.handler())
 	defer resetFlags(templateCmd)
 
 	doc := template.ImportDoc{
@@ -139,13 +221,9 @@ func TestTemplateImport_FromURL(t *testing.T) {
 		t.Fatalf("template import from URL failed: %v\noutput: %s", err, out)
 	}
 
-	store, storeErr := openTemplateStore()
-	if storeErr != nil {
-		t.Fatalf("open store: %v", storeErr)
-	}
-	got, _, getErr := store.Get("url-template")
-	if getErr != nil {
-		t.Fatalf("get imported template: %v", getErr)
+	got, ok := api.get("url-template")
+	if !ok {
+		t.Fatal("imported template missing")
 	}
 	if got.Description != "from a url" {
 		t.Errorf("description = %q, want %q", got.Description, "from a url")
@@ -153,20 +231,10 @@ func TestTemplateImport_FromURL(t *testing.T) {
 }
 
 func TestTemplateImport_KnownLocalName_IsIdempotent(t *testing.T) {
-	// A "marketplace item name" that is already a template in this store
-	// (the only TypeTemplate source today is this same store) should
-	// resolve without a file or URL argument, and re-running with --force
-	// should be a safe no-op.
-	t.Setenv("MYCEL_HOME", t.TempDir())
+	api := newFakeTemplateAPI()
+	api.seed(client.TemplateInfo{Name: "already-local", Description: "seed", SystemPrompt: "seed prompt"})
+	setTestDaemonHandler(t, api.handler())
 	defer resetFlags(templateCmd)
-
-	store, storeErr := openTemplateStore()
-	if storeErr != nil {
-		t.Fatalf("open store: %v", storeErr)
-	}
-	if err := store.Create(template.Template{Name: "already-local", Description: "seed"}, "seed prompt", template.ScopeGlobal); err != nil {
-		t.Fatalf("seed template: %v", err)
-	}
 
 	if _, _, err := executeIntegrationCmd("template", "import", "already-local", "--force"); err != nil {
 		t.Fatalf("import of known local name failed: %v", err)
@@ -179,7 +247,8 @@ func TestTemplateImport_KnownLocalName_IsIdempotent(t *testing.T) {
 }
 
 func TestTemplateImport_UnknownSource_Fails(t *testing.T) {
-	t.Setenv("MYCEL_HOME", t.TempDir())
+	api := newFakeTemplateAPI()
+	setTestDaemonHandler(t, api.handler())
 	defer resetFlags(templateCmd)
 
 	if _, _, err := executeIntegrationCmd("template", "import", "not-a-file-or-url-or-known-template"); err == nil {
@@ -188,7 +257,8 @@ func TestTemplateImport_UnknownSource_Fails(t *testing.T) {
 }
 
 func TestTemplateImport_NameOverride(t *testing.T) {
-	t.Setenv("MYCEL_HOME", t.TempDir())
+	api := newFakeTemplateAPI()
+	setTestDaemonHandler(t, api.handler())
 	defer resetFlags(templateCmd)
 
 	path := writeImportFile(t, template.ImportDoc{
@@ -199,11 +269,7 @@ func TestTemplateImport_NameOverride(t *testing.T) {
 		t.Fatalf("import with --name failed: %v", err)
 	}
 
-	store, storeErr := openTemplateStore()
-	if storeErr != nil {
-		t.Fatalf("open store: %v", storeErr)
-	}
-	if _, _, err := store.Get("renamed"); err != nil {
-		t.Errorf("expected template stored under overridden name %q: %v", "renamed", err)
+	if _, ok := api.get("renamed"); !ok {
+		t.Errorf("expected template stored under overridden name %q", "renamed")
 	}
 }

--- a/internal/cmd/template_import_test.go
+++ b/internal/cmd/template_import_test.go
@@ -31,8 +31,8 @@ func writeImportFile(t *testing.T, doc template.ImportDoc) string {
 
 // fakeTemplateAPI is an in-memory /api/templates + /health handler for CLI tests.
 type fakeTemplateAPI struct {
-	mu   sync.Mutex
 	data map[string]client.TemplateInfo
+	mu   sync.Mutex
 }
 
 func newFakeTemplateAPI() *fakeTemplateAPI {

--- a/internal/cmd/tool.go
+++ b/internal/cmd/tool.go
@@ -568,8 +568,11 @@ func runToolAdd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Try the daemon API first
-	c := getClient()
+	// Daemon API only — no offline SQLite dual-write (#3646).
+	c, err := newDaemonClient(ctx)
+	if err != nil {
+		return err
+	}
 	apiTool := &client.ToolInfo{
 		Name:       name,
 		Command:    toolAddCommand,
@@ -579,53 +582,17 @@ func runToolAdd(cmd *cobra.Command, args []string) error {
 		Enabled:    true,
 	}
 
-	added, apiErr := c.Tools.Update(ctx, apiTool)
-	if apiErr == nil {
-		if toolAddJSON {
-			enc := json.NewEncoder(os.Stdout)
-			enc.SetIndent("", "  ")
-			return enc.Encode(added)
-		}
-		fmt.Printf("Added tool %s\n", ui.GreenText(name))
-		if apiTool.InstallCmd != "" {
-			fmt.Printf("Run 'mycel tool setup %s' to install it.\n", name)
-		}
-		return nil
+	added, apiErr := c.Tools.Create(ctx, apiTool)
+	if apiErr != nil {
+		return fmt.Errorf("add tool: %w", apiErr)
 	}
-
-	// Fallback: direct store access
-	s, err := openToolStore()
-	if err != nil {
-		return err
-	}
-	defer s.Close() //nolint:errcheck // best-effort close
-
-	t := &tool.Tool{
-		Name:       name,
-		Command:    toolAddCommand,
-		InstallCmd: toolAddInstall,
-		UpgradeCmd: toolAddUpgrade,
-		SlashCmds:  slashCmds,
-		Enabled:    true,
-	}
-
-	if addErr := s.Add(ctx, t); addErr != nil {
-		return fmt.Errorf("failed to add tool: %w", addErr)
-	}
-
-	addedTool, err := s.Get(ctx, name)
-	if err != nil {
-		return err
-	}
-
 	if toolAddJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		return enc.Encode(addedTool)
+		return enc.Encode(added)
 	}
-
 	fmt.Printf("Added tool %s\n", ui.GreenText(name))
-	if t.InstallCmd != "" {
+	if apiTool.InstallCmd != "" {
 		fmt.Printf("Run 'mycel tool setup %s' to install it.\n", name)
 	}
 	return nil
@@ -768,86 +735,30 @@ func runToolEdit(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	name := args[0]
 
-	// Try the daemon API first
-	c := getClient()
+	c, err := newDaemonClient(ctx)
+	if err != nil {
+		return err
+	}
 	apiTool, apiErr := c.Tools.Get(ctx, name)
-	if apiErr == nil && apiTool != nil {
-		changed := false
-
-		if toolEditCommand != "" {
-			apiTool.Command = toolEditCommand
-			changed = true
-		}
-		if toolEditInstall != "" {
-			apiTool.InstallCmd = toolEditInstall
-			changed = true
-		}
-		if toolEditUpgrade != "" {
-			apiTool.UpgradeCmd = toolEditUpgrade
-			changed = true
-		}
-		if toolEditSlashCmds != "" {
-			var cmds []string
-			for _, sc := range strings.Split(toolEditSlashCmds, ",") {
-				sc = strings.TrimSpace(sc)
-				if sc != "" {
-					cmds = append(cmds, sc)
-				}
-			}
-			apiTool.SlashCmds = cmds
-			changed = true
-		}
-		if toolEditEnabled != "" {
-			switch strings.ToLower(toolEditEnabled) {
-			case "true", "yes", "1":
-				apiTool.Enabled = true
-			case "false", "no", "0":
-				apiTool.Enabled = false
-			default:
-				return fmt.Errorf("--enabled must be true or false")
-			}
-			changed = true
-		}
-
-		if !changed {
-			return fmt.Errorf("no changes specified — use flags like --command, --install, --enabled")
-		}
-
-		if _, updateErr := c.Tools.Update(ctx, apiTool); updateErr != nil {
-			return fmt.Errorf("failed to update tool: %w", updateErr)
-		}
-
-		fmt.Printf("Updated tool %s\n", ui.GreenText(name))
-		return nil
+	if apiErr != nil {
+		return fmt.Errorf("get tool: %w", apiErr)
 	}
-
-	// Fallback: direct store access
-	s, err := openToolStore()
-	if err != nil {
-		return err
-	}
-	defer s.Close() //nolint:errcheck // best-effort close
-
-	t, err := s.Get(ctx, name)
-	if err != nil {
-		return err
-	}
-	if t == nil {
+	if apiTool == nil {
 		return fmt.Errorf("tool %q not found — add it with: mycel tool add %s", name, name)
 	}
 
 	changed := false
 
 	if toolEditCommand != "" {
-		t.Command = toolEditCommand
+		apiTool.Command = toolEditCommand
 		changed = true
 	}
 	if toolEditInstall != "" {
-		t.InstallCmd = toolEditInstall
+		apiTool.InstallCmd = toolEditInstall
 		changed = true
 	}
 	if toolEditUpgrade != "" {
-		t.UpgradeCmd = toolEditUpgrade
+		apiTool.UpgradeCmd = toolEditUpgrade
 		changed = true
 	}
 	if toolEditSlashCmds != "" {
@@ -858,15 +769,15 @@ func runToolEdit(cmd *cobra.Command, args []string) error {
 				cmds = append(cmds, sc)
 			}
 		}
-		t.SlashCmds = cmds
+		apiTool.SlashCmds = cmds
 		changed = true
 	}
 	if toolEditEnabled != "" {
 		switch strings.ToLower(toolEditEnabled) {
 		case "true", "yes", "1":
-			t.Enabled = true
+			apiTool.Enabled = true
 		case "false", "no", "0":
-			t.Enabled = false
+			apiTool.Enabled = false
 		default:
 			return fmt.Errorf("--enabled must be true or false")
 		}
@@ -877,8 +788,8 @@ func runToolEdit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no changes specified — use flags like --command, --install, --enabled")
 	}
 
-	if err := s.Update(ctx, t); err != nil {
-		return fmt.Errorf("failed to update tool: %w", err)
+	if _, updateErr := c.Tools.Update(ctx, apiTool); updateErr != nil {
+		return fmt.Errorf("failed to update tool: %w", updateErr)
 	}
 
 	fmt.Printf("Updated tool %s\n", ui.GreenText(name))
@@ -891,42 +802,23 @@ func runToolDelete(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	name := args[0]
 
-	// Try the daemon API first
-	c := getClient()
+	c, err := newDaemonClient(ctx)
+	if err != nil {
+		return err
+	}
 	apiTool, apiErr := c.Tools.Get(ctx, name)
-	if apiErr == nil && apiTool != nil {
-		if apiTool.Builtin {
-			return fmt.Errorf("cannot delete built-in tool %q — disable it instead: mycel tool edit %s --enabled false", name, name)
-		}
-		if delErr := c.Tools.Delete(ctx, name); delErr != nil {
-			return fmt.Errorf("failed to delete tool: %w", delErr)
-		}
-		fmt.Printf("Deleted tool %s\n", name)
-		return nil
+	if apiErr != nil {
+		return fmt.Errorf("get tool: %w", apiErr)
 	}
-
-	// Fallback: direct store access
-	s, err := openToolStore()
-	if err != nil {
-		return err
-	}
-	defer s.Close() //nolint:errcheck // best-effort close
-
-	t, err := s.Get(ctx, name)
-	if err != nil {
-		return err
-	}
-	if t == nil {
+	if apiTool == nil {
 		return fmt.Errorf("tool %q not found", name)
 	}
-	if t.Builtin {
+	if apiTool.Builtin {
 		return fmt.Errorf("cannot delete built-in tool %q — disable it instead: mycel tool edit %s --enabled false", name, name)
 	}
-
-	if err := s.Delete(ctx, name); err != nil {
-		return fmt.Errorf("failed to delete tool: %w", err)
+	if delErr := c.Tools.Delete(ctx, name); delErr != nil {
+		return fmt.Errorf("failed to delete tool: %w", delErr)
 	}
-
 	fmt.Printf("Deleted tool %s\n", name)
 	return nil
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -50,6 +50,7 @@ type Client struct {
 	Doctor     *DoctorClient
 	Settings   *SettingsClient
 	Stats      *StatsClient
+	Templates  *TemplatesClient
 	BaseURL    string
 }
 
@@ -79,6 +80,7 @@ func New(addr string) *Client {
 	c.Doctor = &DoctorClient{client: c}
 	c.Settings = &SettingsClient{client: c}
 	c.Stats = &StatsClient{client: c}
+	c.Templates = &TemplatesClient{client: c}
 
 	return c
 }

--- a/pkg/client/system.go
+++ b/pkg/client/system.go
@@ -1,0 +1,21 @@
+package client
+
+import "context"
+
+// SystemInfo is the lightweight workspace/host summary from GET /api/system/info.
+type SystemInfo struct {
+	Hostname     string `json:"hostname"`
+	OS           string `json:"os"`
+	Arch         string `json:"arch"`
+	Workspace    string `json:"workspace"`
+	HasWorkspace bool   `json:"has_workspace"`
+}
+
+// SystemInfo returns daemon workspace/host info (CWD-free).
+func (s *StatsClient) SystemInfo(ctx context.Context) (*SystemInfo, error) {
+	var info SystemInfo
+	if err := s.client.get(ctx, "/api/system/info", &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/pkg/client/templates.go
+++ b/pkg/client/templates.go
@@ -12,7 +12,7 @@ type TemplatesClient struct {
 }
 
 // TemplateInfo is a template as returned by /api/templates.
-type TemplateInfo struct {
+type TemplateInfo struct { //nolint:govet // field order matches JSON/API contract
 	Name             string   `json:"name"`
 	Description      string   `json:"description,omitempty"`
 	Label            string   `json:"label,omitempty"`
@@ -30,7 +30,7 @@ type TemplateInfo struct {
 
 // templateWriteBody is the create/update payload. SystemPrompt is a pointer
 // so PUT can clear the prompt with an explicit empty string.
-type templateWriteBody struct {
+type templateWriteBody struct { //nolint:govet // field order matches JSON/API contract
 	Name            string   `json:"name"`
 	Description     string   `json:"description,omitempty"`
 	Label           string   `json:"label,omitempty"`

--- a/pkg/client/templates.go
+++ b/pkg/client/templates.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// TemplatesClient manages agent templates via the daemon.
+type TemplatesClient struct {
+	client *Client
+}
+
+// TemplateInfo is a template as returned by /api/templates.
+type TemplateInfo struct {
+	Name             string   `json:"name"`
+	Description      string   `json:"description,omitempty"`
+	Label            string   `json:"label,omitempty"`
+	Provider         string   `json:"provider,omitempty"`
+	Scope            string   `json:"scope,omitempty"`
+	MCPs             []string `json:"mcps,omitempty"`
+	Secrets          []string `json:"secrets,omitempty"`
+	Plugins          []string `json:"plugins,omitempty"`
+	Composes         []string `json:"composes,omitempty"`
+	SystemPrompt     string   `json:"system_prompt,omitempty"`
+	SystemPromptFile string   `json:"system_prompt_file,omitempty"`
+	MaxCostUSD       float64  `json:"max_cost_usd,omitempty"`
+	StuckTimeoutMin  int      `json:"stuck_timeout_min,omitempty"`
+}
+
+// templateWriteBody is the create/update payload. SystemPrompt is a pointer
+// so PUT can clear the prompt with an explicit empty string.
+type templateWriteBody struct {
+	Name            string   `json:"name"`
+	Description     string   `json:"description,omitempty"`
+	Label           string   `json:"label,omitempty"`
+	Provider        string   `json:"provider,omitempty"`
+	MCPs            []string `json:"mcps,omitempty"`
+	Secrets         []string `json:"secrets,omitempty"`
+	Plugins         []string `json:"plugins,omitempty"`
+	Composes        []string `json:"composes,omitempty"`
+	SystemPrompt    *string  `json:"system_prompt,omitempty"`
+	MaxCostUSD      float64  `json:"max_cost_usd,omitempty"`
+	StuckTimeoutMin int      `json:"stuck_timeout_min,omitempty"`
+}
+
+// List returns all templates.
+func (t *TemplatesClient) List(ctx context.Context) ([]TemplateInfo, error) {
+	var out []TemplateInfo
+	if err := t.client.get(ctx, "/api/templates", &out); err != nil {
+		return nil, err
+	}
+	if out == nil {
+		out = []TemplateInfo{}
+	}
+	return out, nil
+}
+
+// Get returns one template by name (includes system_prompt).
+func (t *TemplatesClient) Get(ctx context.Context, name string) (*TemplateInfo, error) {
+	var out TemplateInfo
+	if err := t.client.get(ctx, "/api/templates/"+url.PathEscape(name), &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Create registers a new template.
+func (t *TemplatesClient) Create(ctx context.Context, tmpl TemplateInfo) (*TemplateInfo, error) {
+	body := templateWriteBody{
+		Name:            tmpl.Name,
+		Description:     tmpl.Description,
+		Label:           tmpl.Label,
+		Provider:        tmpl.Provider,
+		MCPs:            tmpl.MCPs,
+		Secrets:         tmpl.Secrets,
+		Plugins:         tmpl.Plugins,
+		Composes:        tmpl.Composes,
+		MaxCostUSD:      tmpl.MaxCostUSD,
+		StuckTimeoutMin: tmpl.StuckTimeoutMin,
+	}
+	if tmpl.SystemPrompt != "" {
+		p := tmpl.SystemPrompt
+		body.SystemPrompt = &p
+	}
+	var out TemplateInfo
+	if err := t.client.post(ctx, "/api/templates", body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Update replaces an existing template.
+func (t *TemplatesClient) Update(ctx context.Context, name string, tmpl TemplateInfo) (*TemplateInfo, error) {
+	prompt := tmpl.SystemPrompt
+	body := templateWriteBody{
+		Name:            tmpl.Name,
+		Description:     tmpl.Description,
+		Label:           tmpl.Label,
+		Provider:        tmpl.Provider,
+		MCPs:            tmpl.MCPs,
+		Secrets:         tmpl.Secrets,
+		Plugins:         tmpl.Plugins,
+		Composes:        tmpl.Composes,
+		SystemPrompt:    &prompt,
+		MaxCostUSD:      tmpl.MaxCostUSD,
+		StuckTimeoutMin: tmpl.StuckTimeoutMin,
+	}
+	if body.Name == "" {
+		body.Name = name
+	}
+	var out TemplateInfo
+	if err := t.client.put(ctx, "/api/templates/"+url.PathEscape(name), body, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// Delete removes a template by name.
+func (t *TemplatesClient) Delete(ctx context.Context, name string) error {
+	if name == "" {
+		return fmt.Errorf("template name required")
+	}
+	return t.client.delete(ctx, "/api/templates/"+url.PathEscape(name))
+}

--- a/pkg/client/tools.go
+++ b/pkg/client/tools.go
@@ -37,6 +37,15 @@ func (t *ToolsClient) Get(ctx context.Context, name string) (*ToolInfo, error) {
 	return &tool, nil
 }
 
+// Create adds a new tool configuration.
+func (t *ToolsClient) Create(ctx context.Context, tool *ToolInfo) (*ToolInfo, error) {
+	var created ToolInfo
+	if err := t.client.post(ctx, "/api/tools", tool, &created); err != nil {
+		return nil, err
+	}
+	return &created, nil
+}
+
 // Update updates an existing tool's configuration.
 func (t *ToolsClient) Update(ctx context.Context, tool *ToolInfo) (*ToolInfo, error) {
 	var updated ToolInfo


### PR DESCRIPTION
## Summary
- `mycel status` no longer requires a git CWD; workspace label comes from `GET /api/system/info`
- `mycel template *` uses the daemon `/api/templates` API (same store as the UI)
- `mycel config set` and `mycel tool add|edit|delete` fail closed when the daemon is down (no offline prefs/SQLite dual-write)
- New `pkg/client` helpers: `Templates`, `Tools.Create`, `Stats.SystemInfo`

Closes #3646

## Test plan
- [x] `go test ./pkg/client/ ./internal/cmd/`
- [ ] `mycel status` from a non-repo directory while daemon is up
- [ ] `mycel template list/create/delete` against a running daemon
- [ ] `mycel config set` with daemon down → clear error to run `mycel up`