### PR TITLE
ci: silence Cloudflare Pages GitHub-app PR checks (#3452)

### DIFF
--- a/.github/workflows/cloudflare-pages-git.yml
+++ b/.github/workflows/cloudflare-pages-git.yml
@@ -1,0 +1,73 @@
+# One-shot / ops control for the Cloudflare Pages *GitHub app* integration.
+#
+# Production landing deploys are owned by wrangler in cd-main.yml. The Pages
+# GitHub app still posts a "Cloudflare Pages" check on every PR; when its
+# build config is wrong that check fails in ~0s and trains everyone to ignore
+# red Xes (#3452).
+#
+# This workflow patches the Pages project so automatic git preview (and
+# optionally production) builds are off. Wrangler CD is unaffected.
+#
+#   gh workflow run cloudflare-pages-git.yml
+
+name: Cloudflare Pages git controls
+
+on:
+  workflow_dispatch:
+    inputs:
+      preview_deployment_setting:
+        description: Controls PR/preview git builds (none = no GitHub check spam)
+        type: choice
+        options: [none, all, custom]
+        default: none
+      production_deployments_enabled:
+        description: Automatic production-branch git deploys (false = wrangler-only)
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  configure:
+    name: Patch Pages project
+    runs-on: ubuntu-latest
+    steps:
+      - name: GET current project
+        id: get
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ] || [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "::error::CLOUDFLARE_API_TOKEN / CLOUDFLARE_ACCOUNT_ID secrets missing"
+            exit 1
+          fi
+          url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/mycel"
+          curl -sS -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" "$url" \
+            | tee /tmp/pages-project.json \
+            | jq '{success, errors, result: (.result | {name, subdomain, preview_deployment_setting, production_deployments_enabled, production_branch, source: .source.type})}'
+
+      - name: PATCH git deployment controls
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PREVIEW: ${{ inputs.preview_deployment_setting }}
+          PROD_GIT: ${{ inputs.production_deployments_enabled }}
+        run: |
+          set -euo pipefail
+          url="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/mycel"
+          body=$(jq -n \
+            --arg preview "$PREVIEW" \
+            --argjson prod "$PROD_GIT" \
+            '{preview_deployment_setting: $preview, production_deployments_enabled: $prod}')
+          echo "PATCH body: $body"
+          curl -sS -X PATCH \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data "$body" \
+            "$url" \
+            | tee /tmp/pages-patch.json \
+            | jq '{success, errors, result: (.result | {name, preview_deployment_setting, production_deployments_enabled, production_branch})}'
+          jq -e '.success == true' /tmp/pages-patch.json >/dev/null

--- a/docs/explanation/ci-cd.md
+++ b/docs/explanation/ci-cd.md
@@ -85,7 +85,7 @@ graph LR
 | Target | Trigger | Platform |
 |--------|---------|----------|
 | Docs | `docs/**` push to main | GitHub Pages (MkDocs) via `pages.yml` |
-| Landing (with embedded docs) | Every push to main | Cloudflare Pages via `wrangler` in `cd-main.yml` |
+| Landing (with embedded docs) | Every push to main | Cloudflare Pages via `wrangler` in `cd-main.yml` (not the Pages GitHub-app builder) |
 | Docker image | Every push to main | GHCR: `ghcr.io/rpuneet/mycel:main` (+ `:main-<sha>`) via `cd-main.yml` |
 | npm package | After a successful release (or manual) | npm via `cd-npm.yml` |
 
@@ -122,7 +122,7 @@ graph LR
 |--------|---------|---------|
 | `GITHUB_TOKEN` | All workflows | Checkout, releases, GHCR push, gitleaks |
 | `HOMEBREW_TAP_TOKEN` | Release | Push formula to tap repo |
-| `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` | CD (main) | `wrangler pages deploy` for the landing site |
+| `CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` | CD (main), Cloudflare Pages git controls | `wrangler pages deploy` for the landing site; optional `workflow_dispatch` to disable Pages GitHub-app preview builds (`cloudflare-pages-git.yml`, see #3452) |
 | `NPM_TOKEN` | CD (npm) | Publish the npm package |
 
 ## Workflow Files
@@ -132,6 +132,7 @@ graph LR
 | `ci.yml` | Push main, PRs | Core CI pipeline (lint, tests, web/landing, build; full tests + security + container scan on main) |
 | `pr-quality.yml` | PRs | Advisory quality checks |
 | `cd-main.yml` | Every push to main | Publish Docker `:main` images to GHCR + deploy landing (with embedded docs) to Cloudflare Pages via `wrangler` |
+| `cloudflare-pages-git.yml` | Manual (`workflow_dispatch`) | Patch Pages project: turn off GitHub-app preview/production git builds so PRs stop getting a red "Cloudflare Pages" check (#3452). Wrangler CD unchanged. |
 | `cd-npm.yml` | After a successful Release run, or manual dispatch | Publish the npm package |
 | `release.yml` | Tag `v*` or manual dispatch | Build + publish releases (Linux GoReleaser, native macOS, Homebrew formula, SBOM) |
 | `pages.yml` | Push main (docs paths) | Build MkDocs site and deploy to GitHub Pages |


### PR DESCRIPTION
## Summary
- The red **Cloudflare Pages** check on every PR is from the Cloudflare GitHub app (`cloudflare-workers-and-pages`), not our CI.
- Real landing deploys already use `wrangler pages deploy` in `cd-main.yml`.
- Adds `cloudflare-pages-git.yml` (`workflow_dispatch`) to set `preview_deployment_setting=none` and `production_deployments_enabled=false` on the Pages project.
- Docs note the split.

Closes #3452

## Test plan
- [ ] Merge, then `gh workflow run cloudflare-pages-git.yml`
- [ ] Confirm workflow GET/PATCH succeed
- [ ] Open a tiny follow-up or wait for next PR — Cloudflare Pages check should be absent or not fail