### PR TITLE
feat(web): native folder picker for Create Agent + MycelHome (#3612)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -114,7 +114,7 @@ You control the lifecycle from the agent header in the web UI (Start / Stop / Re
 
 ### Repos
 
-The server tracks the repos agents are bound to. `GET /api/repos` lists them; the web UI adds repos via a folder picker, local filesystem discovery, or GitHub clone (`/api/repos/discover/*`, `/api/repos/clone`).
+The server tracks the repos agents are bound to. `GET /api/repos` lists them; Create Agent binds a repo via typed path, native folder picker (`POST /api/system/pick-directory`) + local scan (`POST /api/repos/discover/local`), or GitHub clone (`/api/repos/discover/github`, `/api/repos/clone`).
 
 ### Apps
 

--- a/docs/reference/api-rest.md
+++ b/docs/reference/api-rest.md
@@ -322,7 +322,9 @@ All timeseries endpoints accept `from`/`to` (RFC3339, default: last hour) and `i
 |--------|------|-------------|
 | GET | `/api/stats/summary` | Fleet overview: agent counts, channel/message totals, cost, roles, tools, uptime. |
 | GET | `/api/stats/system` | Host snapshot: hostname, OS/arch, CPU, memory, disk, Go version, goroutines, uptime. |
-| GET | `/api/system/info` | Minimal host info: `{hostname, os, arch}`. |
+| GET | `/api/system/info` | Minimal host info: `{hostname, os, arch, workspace, has_workspace, mycel_home}`. |
+| POST | `/api/system/pick-directory` | Loopback-only native folder dialog (Finder / zenity / Windows folder browser). Returns `{"path"}` or `204` if canceled. |
+| POST | `/api/system/open-url` | Loopback-only: open an http(s) URL in the host browser. |
 
 ### Agent timeseries
 

--- a/docs/reference/cli/mycel.md
+++ b/docs/reference/cli/mycel.md
@@ -41,7 +41,7 @@ Environment Variables:
   MYCEL_WORKSPACE      Path to the agent's repo root
   MYCEL_AGENT_WORKTREE Path to agent's worktree
   MYCEL_BIN            Path to mycel binary (default: mycel in PATH)
-  MYCEL_ROOT           Override the mycel home root directory
+  MYCEL_HOME           Override the mycel home root directory (~/.mycel)
   NO_COLOR          Disable colored output
 
 Documentation: https://github.com/rpuneet/mycel

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -153,7 +153,7 @@ Environment Variables:
   MYCEL_WORKSPACE      Path to the agent's repo root
   MYCEL_AGENT_WORKTREE Path to agent's worktree
   MYCEL_BIN            Path to mycel binary (default: mycel in PATH)
-  MYCEL_ROOT           Override the mycel home root directory
+  MYCEL_HOME           Override the mycel home root directory (~/.mycel)
   NO_COLOR          Disable colored output
 
 Documentation: https://github.com/rpuneet/mycel

--- a/server/handlers/pickdir.go
+++ b/server/handlers/pickdir.go
@@ -1,0 +1,117 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// PickDirectoryHandler exposes POST /api/system/pick-directory — a native
+// folder dialog for the desktop/web UI (Finder on macOS).
+//
+// Same architecture as open-url: the SPA runs on the daemon's http://127.0.0.1
+// origin, so Wails never injects window.runtime. The UI asks the daemon to
+// show the host dialog instead.
+//
+// Security: loopback-only. No path is taken from the client; the OS dialog
+// returns the chosen directory as a single argv-free stdout string.
+type PickDirectoryHandler struct{}
+
+// NewPickDirectoryHandler constructs a PickDirectoryHandler.
+func NewPickDirectoryHandler() *PickDirectoryHandler { return &PickDirectoryHandler{} }
+
+// Register mounts POST /api/system/pick-directory.
+func (h *PickDirectoryHandler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/system/pick-directory", h.pick)
+}
+
+// ErrPickCanceled is returned when the user dismisses the folder dialog.
+var ErrPickCanceled = errors.New("directory pick canceled")
+
+// realPickDirectory shows a native folder chooser and returns the absolute path.
+func realPickDirectory(ctx context.Context) (string, error) {
+	launchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Minute)
+	defer cancel()
+
+	var name string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		// POSIX path of (choose folder …) — trailing slash stripped below.
+		name = "osascript"
+		args = []string{"-e", `POSIX path of (choose folder with prompt "Choose a folder")`}
+	case "windows":
+		name = "powershell"
+		args = []string{"-NoProfile", "-Command",
+			`Add-Type -AssemblyName System.Windows.Forms; ` +
+				`$d = New-Object System.Windows.Forms.FolderBrowserDialog; ` +
+				`$d.Description = 'Choose a folder'; ` +
+				`if ($d.ShowDialog() -ne [System.Windows.Forms.DialogResult]::OK) { exit 1 }; ` +
+				`Write-Output $d.SelectedPath`}
+	default:
+		// Prefer zenity, then kdialog.
+		if _, err := exec.LookPath("zenity"); err == nil {
+			name, args = "zenity", []string{"--file-selection", "--directory", "--title=Choose a folder"}
+		} else if _, err := exec.LookPath("kdialog"); err == nil {
+			name, args = "kdialog", []string{"--getexistingdirectory", ".", "--title", "Choose a folder"}
+		} else {
+			return "", errors.New("no folder dialog available (install zenity or kdialog)")
+		}
+	}
+
+	// #nosec G204 -- name is a fixed platform opener; args are constants.
+	cmd := exec.CommandContext(launchCtx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	out := strings.TrimSpace(stdout.String())
+	if err != nil {
+		// User cancel / dialog dismiss: empty stdout, non-zero exit.
+		if out == "" {
+			return "", ErrPickCanceled
+		}
+		return "", err
+	}
+	if out == "" {
+		return "", ErrPickCanceled
+	}
+	// osascript returns a trailing slash; normalize.
+	out = strings.TrimRight(out, `/\`)
+	abs, absErr := filepath.Abs(out)
+	if absErr != nil {
+		return "", absErr
+	}
+	return filepath.Clean(abs), nil
+}
+
+// pickDirectoryFunc is injectable so tests can stub the OS dialog.
+var pickDirectoryFunc = realPickDirectory
+
+// pick handles POST /api/system/pick-directory. Empty body. Returns
+// {"path":"/abs/dir"} on success, 204 when the user cancels, 502 on dialog failure.
+func (h *PickDirectoryHandler) pick(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	if !checkLoopback(w, r) {
+		return
+	}
+
+	path, err := pickDirectoryFunc(r.Context())
+	if err != nil {
+		if errors.Is(err, ErrPickCanceled) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		httpError(w, "failed to open folder dialog: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"path": path})
+}

--- a/server/handlers/pickdir_test.go
+++ b/server/handlers/pickdir_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func pickDirMux() http.Handler {
+	mux := http.NewServeMux()
+	NewPickDirectoryHandler().Register(mux)
+	return mux
+}
+
+func TestPickDirectoryReturnsPath(t *testing.T) {
+	orig := pickDirectoryFunc
+	t.Cleanup(func() { pickDirectoryFunc = orig })
+
+	pickDirectoryFunc = func(_ context.Context) (string, error) {
+		return "/Users/me/Projects", nil
+	}
+
+	rec := httptest.NewRecorder()
+	pickDirMux().ServeHTTP(rec, loopbackPost("/api/system/pick-directory", `{}`))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (body: %s)", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body["path"] != "/Users/me/Projects" {
+		t.Fatalf("path = %q, want /Users/me/Projects", body["path"])
+	}
+}
+
+func TestPickDirectoryCanceledIsNoContent(t *testing.T) {
+	orig := pickDirectoryFunc
+	t.Cleanup(func() { pickDirectoryFunc = orig })
+
+	pickDirectoryFunc = func(_ context.Context) (string, error) {
+		return "", ErrPickCanceled
+	}
+
+	rec := httptest.NewRecorder()
+	pickDirMux().ServeHTTP(rec, loopbackPost("/api/system/pick-directory", `{}`))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusNoContent)
+	}
+}
+
+func TestPickDirectoryRejectsNonLoopback(t *testing.T) {
+	orig := pickDirectoryFunc
+	t.Cleanup(func() { pickDirectoryFunc = orig })
+
+	ran := false
+	pickDirectoryFunc = func(_ context.Context) (string, error) {
+		ran = true
+		return "/tmp", nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/system/pick-directory", nil)
+	req.RemoteAddr = "203.0.113.7:44321"
+	rec := httptest.NewRecorder()
+	pickDirMux().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusForbidden)
+	}
+	if ran {
+		t.Fatal("picker ran for a non-loopback caller")
+	}
+}
+
+func TestPickDirectoryDialogFailure(t *testing.T) {
+	orig := pickDirectoryFunc
+	t.Cleanup(func() { pickDirectoryFunc = orig })
+
+	pickDirectoryFunc = func(_ context.Context) (string, error) {
+		return "", errors.New("no folder dialog available")
+	}
+
+	rec := httptest.NewRecorder()
+	pickDirMux().ServeHTTP(rec, loopbackPost("/api/system/pick-directory", `{}`))
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadGateway)
+	}
+}

--- a/server/handlers/stats.go
+++ b/server/handlers/stats.go
@@ -120,8 +120,16 @@ func (h *StatsHandler) systemInfo(w http.ResponseWriter, r *http.Request) {
 	hostname, _ := os.Hostname() //nolint:errcheck // best-effort
 
 	workspace := ""
+	mycelHome := ""
 	if h.h != nil {
 		workspace = h.h.RootDir
+		mycelHome = h.h.StateDir()
+	}
+	if mycelHome == "" {
+		// Best-effort even when Home is nil (tests / degraded boots).
+		if mh, err := home.MycelHome(); err == nil {
+			mycelHome = mh
+		}
 	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
@@ -130,6 +138,7 @@ func (h *StatsHandler) systemInfo(w http.ResponseWriter, r *http.Request) {
 		"arch":          runtime.GOARCH,
 		"workspace":     workspace,
 		"has_workspace": workspace != "",
+		"mycel_home":    mycelHome,
 	})
 }
 

--- a/server/handlers/system_info_test.go
+++ b/server/handlers/system_info_test.go
@@ -38,6 +38,9 @@ func TestSystemInfoReportsWorkspace(t *testing.T) {
 	if body["workspace"] != abs {
 		t.Fatalf("workspace = %v, want %q", body["workspace"], abs)
 	}
+	if mh, _ := body["mycel_home"].(string); mh == "" {
+		t.Fatal("mycel_home missing or empty")
+	}
 }
 
 func TestSystemInfoReportsNoWorkspace(t *testing.T) {
@@ -61,5 +64,8 @@ func TestSystemInfoReportsNoWorkspace(t *testing.T) {
 	}
 	if ws, _ := body["workspace"].(string); ws != "" {
 		t.Fatalf("workspace = %q, want empty", ws)
+	}
+	if mh, _ := body["mycel_home"].(string); mh == "" {
+		t.Fatal("mycel_home missing or empty")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -409,6 +409,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 	// BrowserOpenURL, so window.open is a no-op; the UI posts the URL here
 	// instead. Loopback-only, http/https-only, exec'd as a single argv (no shell).
 	handlers.NewOpenURLHandler().Register(mux)
+	handlers.NewPickDirectoryHandler().Register(mux)
 	// Per-repo cost rollup. Handler is nil-safe and returns 503 when the
 	// global ledger isn't wired.
 	mux.Handle("/api/global/costs", handlers.NewGlobalCostsHandler(svc.Costs))

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1492,7 +1492,23 @@ export const api = {
       arch: string;
       workspace?: string;
       has_workspace?: boolean;
+      /** Install/state root (~/.mycel or MYCEL_HOME). */
+      mycel_home?: string;
     }>("/system/info"),
+
+  /** Native folder dialog via the daemon (Finder on macOS). Null = canceled. */
+  pickDirectory: async (): Promise<string | null> => {
+    const res = await fetch(`${BASE}/system/pick-directory`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    if (res.status === 204) return null;
+    if (!res.ok) throw new Error(`pick-directory failed: ${res.status}`);
+    const body = (await res.json()) as { path?: string };
+    return typeof body.path === "string" && body.path !== "" ? body.path : null;
+  },
+
   /** Autodetected host package managers (brew/apt/npm/…) with versions. */
   getPackageManagers: () =>
     request<PackageManagersResponse>("/system/package-managers"),

--- a/web/src/components/CreateAgentModal.tsx
+++ b/web/src/components/CreateAgentModal.tsx
@@ -7,6 +7,7 @@ import type { EnvRow } from "./EnvVarsEditor";
 import { AgentAppsPicker } from "./apps/AgentAppsPicker";
 import { api } from "../api/client";
 import { MONO } from "../utils/typography";
+import { pickDirectory } from "../utils/pickDirectory";
 import { useReadiness } from "../hooks/useReadiness";
 import { CopyButton } from "./CopyButton";
 import { RevealGroup } from "./RevealGroup";
@@ -205,6 +206,13 @@ export function CreateAgentModal({
       .catch(() => {
         /* repos list is a convenience — the text input still works */
       });
+    // Remember last projects scan root from Browse / Settings.
+    try {
+      const saved = localStorage.getItem("mycel.projects_scan_root");
+      if (saved) setBrowseRoot((prev) => (prev === "" ? saved : prev));
+    } catch {
+      /* ignore */
+    }
   }, [open]);
 
   // Reset form only when the modal is first opened (open transitions to true).
@@ -273,12 +281,13 @@ export function CreateAgentModal({
   }, [existingNames]);
 
   // Scan browseRoot for git repos (POST /api/repos/discover/local).
-  const handleScan = useCallback(async () => {
-    const root = browseRoot.trim();
+  const handleScan = useCallback(async (rootOverride?: string) => {
+    const root = (rootOverride ?? browseRoot).trim();
     if (!root) {
-      setScanError("Enter a directory to scan.");
+      setScanError("Enter a directory to scan, or use Choose folder.");
       return;
     }
+    if (rootOverride) setBrowseRoot(root);
     setScanning(true);
     setScanError(null);
     setCandidates(null);
@@ -301,6 +310,26 @@ export function CreateAgentModal({
       setScanning(false);
     }
   }, [browseRoot]);
+
+  // Native folder dialog → set scan root → scan. Falls back to opening the
+  // typed-path panel when the dialog is unavailable (plain browser, cancel).
+  const handleChooseFolder = useCallback(async () => {
+    setBrowseOpen(true);
+    const picked = await pickDirectory();
+    if (!picked) {
+      if (!browseRoot && repo) {
+        setBrowseRoot(repo.replace(/\/[^/]*$/, "") || "/");
+      }
+      return;
+    }
+    setBrowseRoot(picked);
+    try {
+      localStorage.setItem("mycel.projects_scan_root", picked);
+    } catch {
+      /* ignore */
+    }
+    await handleScan(picked);
+  }, [browseRoot, repo, handleScan]);
 
   const handleCreate = useCallback(async () => {
     const trimmed = name.trim();
@@ -487,14 +516,7 @@ export function CreateAgentModal({
                 />
                 <button
                   type="button"
-                  onClick={() => {
-                    setBrowseOpen((prev) => !prev);
-                    // Seed the scan root with the parent of the current
-                    // path so one Scan click usually finds siblings.
-                    if (!browseOpen && browseRoot === "" && repo) {
-                      setBrowseRoot(repo.replace(/\/[^/]*$/, "") || "/");
-                    }
-                  }}
+                  onClick={() => { void handleChooseFolder(); }}
                   aria-pressed={browseOpen}
                   className={`shrink-0 inline-flex items-center px-3 h-8 rounded-md border text-xs font-medium transition-colors ${
                     browseOpen
@@ -543,6 +565,15 @@ export function CreateAgentModal({
                       spellCheck={false}
                       autoComplete="off"
                     />
+                    <button
+                      type="button"
+                      onClick={() => { void handleChooseFolder(); }}
+                      disabled={scanning}
+                      className="shrink-0 inline-flex items-center px-3 h-8 rounded-md border border-mycel-border bg-mycel-surface text-xs font-medium text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors disabled:opacity-50"
+                      title="Open native folder picker"
+                    >
+                      Choose…
+                    </button>
                     <button
                       type="button"
                       onClick={() => { void handleScan(); }}

--- a/web/src/utils/pickDirectory.ts
+++ b/web/src/utils/pickDirectory.ts
@@ -1,0 +1,35 @@
+/**
+ * pickDirectory — ask the host OS for a folder path.
+ *
+ * Same desktop constraint as openExternal: the SPA runs on the daemon's
+ * http://127.0.0.1 origin, so Wails never injects window.runtime. We POST to
+ * /api/system/pick-directory and let the daemon show Finder / zenity /
+ * FolderBrowserDialog.
+ *
+ * Returns the absolute path, or null when the user cancels / dialog fails /
+ * the endpoint is unavailable (plain browser without a native dialog).
+ */
+
+import { isDesktop } from "./openExternal";
+
+export async function pickDirectory(): Promise<string | null> {
+  // Prefer the daemon dialog whenever we can reach it. Desktop always uses
+  // it; browser UIs get it too when talking to a local daemon (loopback).
+  try {
+    const res = await fetch("/api/system/pick-directory", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    if (res.status === 204) return null; // canceled
+    if (!res.ok) {
+      // Non-desktop browsers may 502 (no zenity) — caller keeps typed path.
+      if (!isDesktop()) return null;
+      return null;
+    }
+    const body = (await res.json()) as { path?: string };
+    return typeof body.path === "string" && body.path !== "" ? body.path : null;
+  } catch {
+    return null;
+  }
+}

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -308,6 +308,8 @@ function SetupSection({
       <p className="text-xs text-mycel-text-2 max-w-prose">
         Sections below unlock one at a time as you finish each — machine checks, runtime, an agent
         tool, and your first agent. It only writes config; your agents and apps are left untouched.
+        When you create an agent, pick its git repo with Browse (native folder picker + scan) —
+        the daemon does not need a project workspace.
       </p>
 
       <div className="space-y-1.5">
@@ -664,6 +666,93 @@ function LogsFields({ data, onChange }: { data: Record<string, unknown>; onChang
   );
 }
 
+/** MycelHome (install root) + remembered projects scan root for Create Agent Browse. */
+function MycelHomeFields() {
+  const [mycelHome, setMycelHome] = useState("");
+  const [scanRoot, setScanRoot] = useState(() => {
+    try {
+      return localStorage.getItem("mycel.projects_scan_root") ?? "";
+    } catch {
+      return "";
+    }
+  });
+  const [picking, setPicking] = useState(false);
+  const [hint, setHint] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api.getSystemInfo()
+      .then((info) => {
+        if (!alive) return;
+        setMycelHome(info.mycel_home ?? "");
+      })
+      .catch(() => {
+        /* best-effort */
+      });
+    return () => { alive = false; };
+  }, []);
+
+  const persistScanRoot = (path: string) => {
+    setScanRoot(path);
+    try {
+      if (path) localStorage.setItem("mycel.projects_scan_root", path);
+      else localStorage.removeItem("mycel.projects_scan_root");
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const chooseScanRoot = async () => {
+    setPicking(true);
+    setHint(null);
+    try {
+      const path = await api.pickDirectory();
+      if (path) {
+        persistScanRoot(path);
+        setHint("Saved — Create Agent → Browse will scan here first.");
+      }
+    } catch {
+      setHint("Folder dialog unavailable — type a path below, or use Browse in Create Agent.");
+    } finally {
+      setPicking(false);
+    }
+  };
+
+  return (
+    <>
+      <p className="text-[11px] text-mycel-muted">
+        MycelHome is the install root (agents, prefs, vault). Override with the{" "}
+        <code className="text-mycel-text">MYCEL_HOME</code> env var and restart the daemon —
+        relocating from the UI is not supported yet. Repos are chosen per agent, not as a
+        required daemon workspace.
+      </p>
+      <Field label="MycelHome">
+        <input className={MONO_INPUT_CLS} value={mycelHome} readOnly spellCheck={false} />
+      </Field>
+      <Field label="Projects scan root">
+        <div className="flex items-center gap-2">
+          <input
+            className={MONO_INPUT_CLS}
+            value={scanRoot}
+            onChange={(e) => persistScanRoot(e.target.value)}
+            placeholder="~/Projects"
+            spellCheck={false}
+          />
+          <button
+            type="button"
+            onClick={() => { void chooseScanRoot(); }}
+            disabled={picking}
+            className="shrink-0 inline-flex items-center px-3 h-8 rounded-md border border-mycel-border bg-mycel-bg text-xs font-medium text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors disabled:opacity-50"
+          >
+            {picking ? "…" : "Choose…"}
+          </button>
+        </div>
+      </Field>
+      {hint && <p className="text-[11px] text-mycel-muted">{hint}</p>}
+    </>
+  );
+}
+
 function InjectedInstructionsSection() {
   const [text, setText] = useState("");
   const [original, setOriginal] = useState("");
@@ -1004,6 +1093,9 @@ export function Settings() {
       </Section>
 
       <Section title="advanced" dirty={isDirty("storage", "server", "logs")} defaultOpen={false} index={6}>
+        <Advanced label="MycelHome">
+          <MycelHomeFields />
+        </Advanced>
         <Advanced label="Storage">
           <StorageFields data={edited} onChange={handleChange} />
         </Advanced>


### PR DESCRIPTION
## Summary
- `POST /api/system/pick-directory` — loopback-only native folder dialog (Finder on macOS)
- Create Agent **Browse** opens the picker, then scans for `.git` repos
- `GET /api/system/info` includes `mycel_home`
- Settings → Advanced → MycelHome shows install root + remembered projects scan root
- Docs: API, overview folder-picker wording, `MYCEL_HOME` (not `MYCEL_ROOT`)

Full MycelHome relocate from the UI is deferred (still `MYCEL_HOME` + restart).

Closes #3612

## Test plan
- [x] `go test ./server/handlers/ -run PickDirectory\|SystemInfo`
- [x] vitest CreateAgentModal + settings suites
- [ ] Desktop/local: Browse → Finder → scan list → create agent
- [ ] Settings → Advanced → MycelHome → Choose… sets scan root
- [ ] CI Lint / Test / Web green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native folder selection for browsing and scanning agent repositories.
  - Added directory selection controls and scan-root settings in Advanced Settings.
  - System information now displays the Mycel home directory.
  - Added support for restoring and saving the last selected scan location.

- **Documentation**
  - Updated repository discovery, REST API, CLI configuration, and workspace guidance.
  - Documented the `MYCEL_HOME` environment variable and new directory-selection endpoints.

- **Bug Fixes**
  - Improved handling of canceled, unavailable, or failed folder-selection dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->