### PR TITLE
fix(cost): isolate Pi ReadCosts and daemon.addr tests (#3011)

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -93,10 +93,12 @@ func TestNew(t *testing.T) {
 
 func TestNew_EmptyAddr(t *testing.T) {
 	// With no env var AND no addr file, should use default.
-	// Point HOME at an empty tempdir so the test doesn't see the
-	// developer's live ~/.mycel/run/daemon.addr.
+	// Point MYCEL_HOME/HOME at empty tempdirs so the test doesn't see the
+	// developer's live ~/.mycel/run/daemon.addr (#3011).
 	os.Unsetenv("MYCEL_DAEMON_ADDR") //nolint:errcheck
-	t.Setenv("HOME", t.TempDir())
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("MYCEL_HOME", filepath.Join(tmp, ".mycel"))
 	c := New("")
 	if c.BaseURL != DefaultHTTPAddr {
 		t.Errorf("BaseURL = %q, want %q", c.BaseURL, DefaultHTTPAddr)
@@ -117,8 +119,12 @@ func TestNew_EnvAddr(t *testing.T) {
 func TestNew_DaemonAddrFile(t *testing.T) {
 	os.Unsetenv("MYCEL_DAEMON_ADDR") //nolint:errcheck
 	tmp := t.TempDir()
+	// MycelHome prefers MYCEL_HOME over HOME — pin both so a live
+	// developer MYCEL_HOME / daemon.addr cannot shadow the fixture (#3011).
+	mycel := filepath.Join(tmp, ".mycel")
 	t.Setenv("HOME", tmp)
-	bcDir := filepath.Join(tmp, ".mycel", "run")
+	t.Setenv("MYCEL_HOME", mycel)
+	bcDir := filepath.Join(mycel, "run")
 	if err := os.MkdirAll(bcDir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -137,8 +143,10 @@ func TestNew_DaemonAddrFile(t *testing.T) {
 // override via env without deleting the file.
 func TestNew_EnvWinsOverFile(t *testing.T) {
 	tmp := t.TempDir()
+	mycel := filepath.Join(tmp, ".mycel")
 	t.Setenv("HOME", tmp)
-	bcDir := filepath.Join(tmp, ".mycel", "run")
+	t.Setenv("MYCEL_HOME", mycel)
+	bcDir := filepath.Join(mycel, "run")
 	if err := os.MkdirAll(bcDir, 0o750); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/pkg/provider/pi_costs.go
+++ b/pkg/provider/pi_costs.go
@@ -51,8 +51,20 @@ type piCostUSD struct {
 
 // ReadCosts implements CostReader for pi. It walks pi's session tree and
 // emits one CostEntry per assistant turn that reports usage.
+//
+// When opts.Home is set (daemon / tests), sessions are read from
+// <Home>/.pi/agent/sessions so a throwaway CostReadOptions.Home cannot
+// leak the developer's real ~/.pi tree into cost fixtures (#3011).
+// PI_CODING_AGENT_SESSION_DIR still wins when set.
 func (p *PiProvider) ReadCosts(ctx context.Context, opts CostReadOptions) ([]CostEntry, error) {
-	root := piSessionsRoot()
+	root := ""
+	if dir := os.Getenv("PI_CODING_AGENT_SESSION_DIR"); dir != "" {
+		root = dir
+	} else if opts.Home != "" {
+		root = filepath.Join(opts.Home, ".pi", "agent", "sessions")
+	} else {
+		root = piSessionsRoot()
+	}
 	if root == "" {
 		return nil, nil
 	}

--- a/pkg/provider/pi_costs_test.go
+++ b/pkg/provider/pi_costs_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestPiReadCostsFromSession(t *testing.T) {
-	root := t.TempDir()
+	home := t.TempDir()
 	agents := t.TempDir()
 	agentWT := filepath.Join(agents, "fresh-otter", "worktree")
 	if err := os.MkdirAll(agentWT, 0o750); err != nil {
 		t.Fatal(err)
 	}
 	cwdEnc := encodePiCWD(agentWT)
-	sessDir := filepath.Join(root, cwdEnc)
+	sessDir := filepath.Join(home, ".pi", "agent", "sessions", cwdEnc)
 	if err := os.MkdirAll(sessDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
@@ -31,12 +31,14 @@ func TestPiReadCostsFromSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Poison the global root so a regression that ignores opts.Home fails.
 	prev := piSessionsRoot
-	piSessionsRoot = func() string { return root }
+	piSessionsRoot = func() string { return filepath.Join(t.TempDir(), "should-not-read") }
 	t.Cleanup(func() { piSessionsRoot = prev })
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", "")
 
 	p := NewPiProvider()
-	entries, err := p.ReadCosts(context.Background(), CostReadOptions{AgentsDir: agents})
+	entries, err := p.ReadCosts(context.Background(), CostReadOptions{Home: home, AgentsDir: agents})
 	if err != nil {
 		t.Fatalf("ReadCosts: %v", err)
 	}
@@ -65,13 +67,13 @@ func TestPiReadCostsFromSession(t *testing.T) {
 }
 
 func TestPiReadCostsSinceFilter(t *testing.T) {
-	root := t.TempDir()
+	home := t.TempDir()
 	agents := t.TempDir()
 	wt := filepath.Join(agents, "pi-bedrock", "worktree")
 	if err := os.MkdirAll(wt, 0o750); err != nil {
 		t.Fatal(err)
 	}
-	sessDir := filepath.Join(root, encodePiCWD(wt))
+	sessDir := filepath.Join(home, ".pi", "agent", "sessions", encodePiCWD(wt))
 	if err := os.MkdirAll(sessDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
@@ -84,11 +86,13 @@ func TestPiReadCostsSinceFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	prev := piSessionsRoot
-	piSessionsRoot = func() string { return root }
+	piSessionsRoot = func() string { return filepath.Join(t.TempDir(), "should-not-read") }
 	t.Cleanup(func() { piSessionsRoot = prev })
+	t.Setenv("PI_CODING_AGENT_SESSION_DIR", "")
 
 	since, _ := time.Parse(time.RFC3339, "2026-08-04T23:05:00Z")
 	entries, err := NewPiProvider().ReadCosts(context.Background(), CostReadOptions{
+		Home:      home,
 		AgentsDir: agents,
 		Since:     since,
 	})


### PR DESCRIPTION
## Summary
`go test -short -race ./...` was failing on this machine with **no DATA RACE reports** — cost CLI/handler tests were reading live `~/.pi` sessions via Pi `ReadCosts`, and client discoverDaemon tests could see a live `daemon.addr` when only `HOME` was overridden.

- Pi `ReadCosts` respects `CostReadOptions.Home` (`<Home>/.pi/agent/sessions`); `PI_CODING_AGENT_SESSION_DIR` still wins
- Client `TestNew_*` pins `MYCEL_HOME` alongside `HOME`

## Test plan
- [x] `go test -short -race ./pkg/provider/ ./pkg/client/ ./server/handlers/ ./internal/cmd/ ./pkg/cost/`
- [x] Targeted cost/client suites green without race
- [ ] CI Lint / Test / Web

Closes #3011