### PR TITLE
fix(ui): consistency pass + desktop-only boot splash

### DIFF
--- a/desktop/bootpage.go
+++ b/desktop/bootpage.go
@@ -7,51 +7,31 @@ import (
 	"strings"
 )
 
-// bootPage is the only page the Wails webview ever loads from the
-// embedded assets. It waits for the in-process server to answer
-// /api/health, then hands the window over to the real UI at the
-// localhost URL — first by navigating the webview there directly
-// (external-URL path), and if the webview blocks that navigation,
-// by filling the window with an iframe to the same URL (fallback).
-// Either way the UI talks to the real HTTP server, so SSE and
-// websockets bypass the Wails asset scheme entirely.
+// bootPage is a silent bridge the Wails webview loads once. It waits for
+// /api/health, then hands the window to the real UI at the localhost URL.
+//
+// Intentionally NOT a branded splash (#3673): the SPA BootSplash (desktop
+// handoff only) owns the mushroom + real daemon readiness/log stream. A
+// second static mushroom here made every desktop launch feel like two
+// start screens.
+//
+// Preferred handoff: navigate the webview to TARGET+HANDOFF. Fallback: if
+// the webview blocks that navigation, embed the UI in a full-window iframe.
 const bootPage = `<!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <title>mycel</title>
 <style>
-  html,body{height:100%%;margin:0}
-  body{display:flex;align-items:center;justify-content:center;
-       background:#101312;color:#e8e4d8;
-       font:15px/1.5 -apple-system,"Segoe UI",Ubuntu,sans-serif}
-  .boot{text-align:center}
-  .mark{width:96px;height:96px;margin:0 auto 20px;display:block}
-  .cap{animation:breathe 2.4s ease-in-out infinite;transform-origin:50%% 60%%}
-  @keyframes breathe{0%%,100%%{transform:scale(1)}50%%{transform:scale(1.04)}}
-  h1{font-size:20px;font-weight:600;margin:0 0 6px;letter-spacing:.04em}
-  p{margin:0;color:#9aa39b}
+  html,body{height:100%%;margin:0;background:#14100b}
+  /* Visually empty — SPA BootSplash draws the branded sequence after handoff. */
+  #msg{position:absolute;width:1px;height:1px;padding:0;margin:-1px;
+       overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
   iframe{position:fixed;inset:0;width:100vw;height:100vh;border:0}
 </style>
 </head>
 <body>
-<div class="boot" id="boot">
-  <svg class="mark" viewBox="0 0 128 128" aria-hidden="true">
-    <g class="cap">
-      <path d="M24 66 C24 38 42 24 64 24 C86 24 104 38 104 66 C104 72 98 74 90 74 L38 74 C30 74 24 72 24 66 Z" fill="#e8e4d8"/>
-      <path d="M56 74 L72 74 L70 98 C70 103 66.5 106 64 106 C61.5 106 58 103 58 98 Z" fill="#c8c2b0"/>
-      <circle cx="47" cy="48" r="5" fill="#101312" opacity=".25"/>
-      <circle cx="70" cy="40" r="4" fill="#101312" opacity=".25"/>
-      <circle cx="84" cy="56" r="3.5" fill="#101312" opacity=".25"/>
-    </g>
-    <circle cx="22" cy="96" r="2.5" fill="#8fae72"/>
-    <circle cx="34" cy="110" r="2" fill="#8fae72" opacity=".7"/>
-    <circle cx="102" cy="102" r="2.5" fill="#8fae72"/>
-    <circle cx="110" cy="88" r="2" fill="#8fae72" opacity=".7"/>
-  </svg>
-  <h1>mycel</h1>
-  <p id="msg">starting the server&hellip;</p>
-</div>
+<p id="msg" role="status" aria-live="polite">Starting mycel…</p>
 <script>
   var TARGET = %q;
   var HANDOFF = %q;
@@ -65,32 +45,20 @@ const bootPage = `<!doctype html>
   }
 
   function handoff() {
-    msg.textContent = "opening…";
-    // Preferred: navigate the webview straight to the localhost URL. The
-    // ?desktop=1 marker tells the SPA it is running inside the Wails webview
-    // (served from the daemon's http:// origin, where window.runtime is never
-    // injected) so it routes external links through /api/system/open-url.
-    // app_version is the app's own version: the UI is served entirely by the
-    // daemon, which may be an older one this app attached to rather than
-    // started, so the handoff is the only channel through which the app can
-    // tell the page what it is.
+    msg.textContent = "Opening…";
+    // ?desktop=1 marks the SPA for desktop-only BootSplash + openExternal.
+    // app_version is the app's own version (daemon may be an older attach).
     window.location.replace(TARGET + HANDOFF);
-    // Fallback: if the webview refused the cross-scheme navigation,
-    // we are still here after 2s — embed the UI in a full-window iframe.
     setTimeout(function () {
       var f = document.createElement("iframe");
       f.src = TARGET + HANDOFF;
       document.body.appendChild(f);
-      document.getElementById("boot").remove();
     }, 2000);
   }
 
   (function poll() {
     healthy().then(function (ok) {
-      // After ~20s of failed probes, hand off anyway: if fetch is
-      // blocked by the webview but the server is fine, the UI still
-      // loads; if the server truly failed, the user sees the browser
-      // error instead of an eternal spinner.
+      // After ~20s of failed probes, hand off anyway.
       if (ok || ++attempts > 40) { handoff(); return; }
       setTimeout(poll, 500);
     });

--- a/desktop/bootpage_test.go
+++ b/desktop/bootpage_test.go
@@ -84,6 +84,13 @@ func TestBootMiddlewareServesTheHandoffTarget(t *testing.T) {
 		if !strings.Contains(body, "http://127.0.0.1:9374") {
 			t.Errorf("GET %s: boot page omits the server URL", path)
 		}
+		// Silent bridge only — branded mushroom lives in the SPA BootSplash (#3673).
+		if strings.Contains(body, "starting the server") {
+			t.Errorf("GET %s: boot page still shows the old static splash copy", path)
+		}
+		if strings.Contains(body, "breathe") || strings.Contains(body, "<h1>") {
+			t.Errorf("GET %s: boot page must not render a second branded start screen", path)
+		}
 	}
 
 	// Non-document requests still fall through to the assets.

--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -694,6 +694,13 @@ export function AppsHome() {
 
   return (
     <div className="p-6 pb-10 space-y-6">
+        {/* Hub = Apps; Notifications is the feed section below — naming hierarchy (#3666). */}
+        <div className="min-w-0">
+          <h1 className="font-display text-[22px] leading-none text-mycel-text">Apps</h1>
+          <p className="mt-1.5 text-[13px] text-mycel-text-2">
+            Connected messaging platforms. Notifications below are the live feed across channels.
+          </p>
+        </div>
         {/* ── Apps strip — compact pills ─────────────────────── */}
         <div className="flex flex-wrap gap-2">
           {apps.map((app) => {

--- a/web/src/components/apps/AppsHome.tsx
+++ b/web/src/components/apps/AppsHome.tsx
@@ -18,7 +18,7 @@
  * gracefully when the overview endpoint or its metadata are missing.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { api, instancesToStatuses } from "../../api/client";
 import type {
@@ -34,6 +34,12 @@ import type {
 import { usePolling } from "../../hooks/usePolling";
 import { useHeaderSlot } from "../../context/HeaderSlotContext";
 import { EmptyState } from "../EmptyState";
+import {
+  FiltersChip,
+  ListSearchInput,
+  FILTER_LABEL_CLS,
+  FILTER_CLEAR_CLS,
+} from "../shared";
 import { AppIcon } from "./PlatformIcons";
 import { ConnectWizard, AppChooser } from "./ConnectApp";
 import { CustomKeysSection } from "./CustomKeys";
@@ -383,7 +389,6 @@ export function AppsHome() {
   const [onlySubscribed, setOnlySubscribed] = useState(false);
   const [onlyActive24h, setOnlyActive24h] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
-  const filtersRef = useRef<HTMLDivElement>(null);
   const [chooserOpen, setChooserOpen] = useState(false);
   const [connectAppId, setConnectAppId] = useState<string | null>(null);
 
@@ -425,22 +430,6 @@ export function AppsHome() {
       });
     }
   }, [location.hash, data]);
-
-  useEffect(() => {
-    if (!filtersOpen) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (filtersRef.current && !filtersRef.current.contains(e.target as Node)) setFiltersOpen(false);
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setFiltersOpen(false);
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", onMouseDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [filtersOpen]);
 
   const model = useMemo(() => (data ? buildHomeModel(data) : { apps: [], channels: [] }), [data]);
   const { apps, channels } = model;
@@ -493,94 +482,69 @@ export function AppsHome() {
     ) : undefined,
     actions: hasAnything ? (
       <>
-        <input
+        <ListSearchInput
           type="text"
           value={search}
           onChange={(e) => { setSearch(e.target.value); }}
           placeholder="Search channels"
-          className="flex-1 min-w-[96px] max-w-md h-9 px-3 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
           aria-label="Search channels"
         />
-        <div className="relative shrink-0" ref={filtersRef}>
-          <button
-            type="button"
-            onClick={() => { setFiltersOpen((v) => !v); }}
-            aria-label="Filters"
-            aria-haspopup="true"
-            aria-expanded={filtersOpen}
-            className={`inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md border text-xs font-medium transition-colors ${
-              filtersOpen || activeFilterCount > 0
-                ? "border-mycel-accent text-mycel-text bg-mycel-surface"
-                : "border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-text hover:border-mycel-accent"
-            }`}
-          >
-            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-              <path d="M1.5 2.5h11l-4.2 5v4l-2.6-1.5V7.5z" />
-            </svg>
-            Filters
-            {activeFilterCount > 0 && (
-              <span className="inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-mycel-accent text-mycel-accent-fg text-[10px] font-semibold tabular-nums">
-                {activeFilterCount}
-              </span>
-            )}
-          </button>
-          {filtersOpen && (
-            <div
-              data-testid="apps-filters-popover"
-              className="absolute right-0 top-full mt-1.5 z-50 w-60 rounded-lg border border-mycel-border bg-mycel-surface-2 shadow-mycel-lg p-3 space-y-2.5 text-sm"
-            >
-              {apps.length > 1 && (
-                <div>
-                  <span className="block mb-1 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">Apps</span>
-                  <div className="space-y-1 max-h-40 overflow-y-auto">
-                    {apps.map((app) => (
-                      <label key={app.key} className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          checked={appSel.has(app.key)}
-                          onChange={() => { toggleApp(app.key); }}
-                          className="accent-[var(--mycel-accent)]"
-                        />
-                        <AppIcon base={app.base} size={11} />
-                        <span className="truncate">{app.label}{app.botName ? ` · ${app.botName}` : ""}</span>
-                      </label>
-                    ))}
-                  </div>
-                </div>
-              )}
-              <label className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={onlySubscribed}
-                  onChange={() => { setOnlySubscribed((v) => !v); }}
-                  className="accent-[var(--mycel-accent)]"
-                />
-                Has subscribers
-              </label>
-              <label className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={onlyActive24h}
-                  onChange={() => { setOnlyActive24h((v) => !v); }}
-                  className="accent-[var(--mycel-accent)]"
-                />
-                Active in last 24h
-              </label>
-              {hasFilters && (
-                <div className="pt-1.5 border-t border-mycel-border flex">
-                  <button
-                    type="button"
-                    onClick={clearFilters}
-                    className="ml-auto px-2 py-1.5 text-xs text-mycel-muted hover:text-mycel-text border border-mycel-border rounded-md focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
-                    aria-label="Clear filters"
-                  >
-                    Clear
-                  </button>
-                </div>
-              )}
+        <FiltersChip
+          open={filtersOpen}
+          onOpenChange={setFiltersOpen}
+          activeCount={activeFilterCount}
+          testId="apps-filters-popover"
+        >
+          {apps.length > 1 && (
+            <div>
+              <span className={FILTER_LABEL_CLS}>Apps</span>
+              <div className="space-y-1 max-h-40 overflow-y-auto">
+                {apps.map((app) => (
+                  <label key={app.key} className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={appSel.has(app.key)}
+                      onChange={() => { toggleApp(app.key); }}
+                      className="accent-[var(--mycel-accent)]"
+                    />
+                    <AppIcon base={app.base} size={11} />
+                    <span className="truncate">{app.label}{app.botName ? ` · ${app.botName}` : ""}</span>
+                  </label>
+                ))}
+              </div>
             </div>
           )}
-        </div>
+          <label className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={onlySubscribed}
+              onChange={() => { setOnlySubscribed((v) => !v); }}
+              className="accent-[var(--mycel-accent)]"
+            />
+            Has subscribers
+          </label>
+          <label className="flex items-center gap-2 text-xs text-mycel-text-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={onlyActive24h}
+              onChange={() => { setOnlyActive24h((v) => !v); }}
+              className="accent-[var(--mycel-accent)]"
+            />
+            Active in last 24h
+          </label>
+          {hasFilters && (
+            <div className="pt-1.5 border-t border-mycel-border flex">
+              <button
+                type="button"
+                onClick={clearFilters}
+                className={FILTER_CLEAR_CLS}
+                aria-label="Clear filters"
+              >
+                Clear
+              </button>
+            </div>
+          )}
+        </FiltersChip>
       </>
     ) : undefined,
   });

--- a/web/src/components/boot/BootGate.tsx
+++ b/web/src/components/boot/BootGate.tsx
@@ -1,29 +1,39 @@
 import { useState, type ReactNode } from "react";
 import { BootSplash, type SplashTimings } from "./BootSplash";
+import { markBootSplashDone, shouldSkipBootSplash } from "./desktopBoot";
 
 /**
- * BootGate — shows the branded {@link BootSplash} while the daemon boots,
- * then reveals the app. Wrap the route tree with it: children stay
- * unmounted (so no app-level API calls fire) until the splash hands off,
- * at which point the router's current URL takes over — including the
- * existing first-run gate (`HomeGate` → `/welcome`), which we deliberately
- * do NOT duplicate here.
+ * BootGate — desktop-only branded {@link BootSplash} while the daemon is
+ * probed, then reveals the app. The browser SPA skips the splash entirely
+ * (#3673): open http://127.0.0.1:9374 and you land on the UI immediately.
  *
- * `skip` bypasses the splash entirely (used by tests/embeds that don't
- * want the sequence); `timings` lets tests collapse the phase durations.
+ * Desktop handoff (`?desktop=1` from `desktop/bootpage.go`) is the only
+ * path that shows the animated splash with real readiness/log lines.
+ *
+ * `skip` forces the gate (tests/embeds). When omitted, skip is derived from
+ * {@link shouldSkipBootSplash}.
  */
 export function BootGate({
   children,
-  skip = false,
+  skip,
   timings,
 }: {
   children: ReactNode;
+  /** Force skip (true) or force splash (false). Omit for production default. */
   skip?: boolean;
   timings?: SplashTimings;
 }) {
-  const [ready, setReady] = useState(skip);
+  const [ready, setReady] = useState(() => shouldSkipBootSplash(skip));
   if (!ready) {
-    return <BootSplash onReady={() => setReady(true)} timings={timings} />;
+    return (
+      <BootSplash
+        onReady={() => {
+          markBootSplashDone();
+          setReady(true);
+        }}
+        timings={timings}
+      />
+    );
   }
   return <>{children}</>;
 }

--- a/web/src/components/boot/__tests__/BootGate.test.tsx
+++ b/web/src/components/boot/__tests__/BootGate.test.tsx
@@ -46,9 +46,23 @@ function GateProbe() {
 
 beforeEach(() => {
   fetchMock.mockReset();
+  sessionStorage.clear();
+  window.history.replaceState({}, "", "/");
 });
 
 describe("BootGate", () => {
+  it("skips the splash in the browser (web is not a desktop handoff)", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <BootGate timings={FAST}>
+          <div data-testid="app">the app</div>
+        </BootGate>
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("app")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Starting mycel")).not.toBeInTheDocument();
+  });
+
   it("shows the splash, then hands off to the app once the daemon is healthy", async () => {
     fetchMock.mockImplementation((url: RequestInfo | URL) => {
       const u = String(url);
@@ -60,7 +74,8 @@ describe("BootGate", () => {
 
     render(
       <MemoryRouter initialEntries={["/"]}>
-        <BootGate timings={FAST}>
+        {/* Force splash — production only shows it for desktop handoff (#3673). */}
+        <BootGate skip={false} timings={FAST}>
           <div data-testid="app">the app</div>
         </BootGate>
       </MemoryRouter>,
@@ -90,7 +105,7 @@ describe("BootGate", () => {
     render(
       <MemoryRouter initialEntries={["/"]}>
         {/* Slow rise so the console is still visible when we assert. */}
-        <BootGate timings={{ ...FAST, minStreamMs: 50, riseMs: 300 }}>
+        <BootGate skip={false} timings={{ ...FAST, minStreamMs: 50, riseMs: 300 }}>
           <div data-testid="app">the app</div>
         </BootGate>
       </MemoryRouter>,
@@ -123,7 +138,7 @@ describe("BootGate", () => {
 
     render(
       <MemoryRouter initialEntries={["/"]}>
-        <BootGate timings={FAST}>
+        <BootGate skip timings={FAST}>
           <Routes>
             <Route index element={<GateProbe />} />
             <Route path="settings" element={<div data-testid="settings">settings, revealing</div>} />

--- a/web/src/components/boot/__tests__/desktopBoot.test.ts
+++ b/web/src/components/boot/__tests__/desktopBoot.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  isBootSplashDone,
+  isDesktopBootSession,
+  markBootSplashDone,
+  shouldSkipBootSplash,
+} from "../desktopBoot";
+
+const DESKTOP_SESSION = "mycel.showBootSplash";
+const BOOT_DONE = "mycel.boot.done";
+
+describe("desktopBoot", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+    window.history.replaceState({}, "", "/");
+  });
+
+  it("skips splash in the browser (no desktop handoff)", () => {
+    expect(isDesktopBootSession()).toBe(false);
+    expect(shouldSkipBootSplash()).toBe(true);
+  });
+
+  it("shows splash on ?desktop=1 handoff and remembers the tab session", () => {
+    window.history.replaceState({}, "", "/?desktop=1&app_version=0.4.7");
+    expect(isDesktopBootSession()).toBe(true);
+    expect(shouldSkipBootSplash()).toBe(false);
+    expect(sessionStorage.getItem(DESKTOP_SESSION)).toBe("1");
+
+    // Query string drops on SPA nav — session still counts as desktop boot.
+    window.history.replaceState({}, "", "/agents");
+    expect(isDesktopBootSession()).toBe(true);
+    expect(shouldSkipBootSplash()).toBe(false);
+  });
+
+  it("skips after the splash has completed once this tab", () => {
+    window.history.replaceState({}, "", "/?desktop=1");
+    expect(shouldSkipBootSplash()).toBe(false);
+    markBootSplashDone();
+    expect(isBootSplashDone()).toBe(true);
+    expect(sessionStorage.getItem(BOOT_DONE)).toBe("1");
+    expect(shouldSkipBootSplash()).toBe(true);
+  });
+
+  it("honors explicit skip override", () => {
+    window.history.replaceState({}, "", "/?desktop=1");
+    expect(shouldSkipBootSplash(true)).toBe(true);
+    expect(shouldSkipBootSplash(false)).toBe(false);
+  });
+});

--- a/web/src/components/boot/desktopBoot.ts
+++ b/web/src/components/boot/desktopBoot.ts
@@ -1,0 +1,54 @@
+/**
+ * Desktop boot session — when to show the branded BootSplash.
+ *
+ * The splash is desktop-app only (real daemon readiness/logs). The browser
+ * SPA must not run it. The Wails shell hands off with `?desktop=1`; SPA
+ * navigations drop the query string, so we remember the handoff for this
+ * tab via sessionStorage (not localStorage — that would bleed into Chrome
+ * on the same origin after using the desktop app).
+ *
+ * After the splash completes once, `mycel.boot.done` prevents replaying on
+ * HMR / remount within the same tab.
+ */
+
+const DESKTOP_SESSION = "mycel.showBootSplash";
+const BOOT_DONE = "mycel.boot.done";
+
+export function isDesktopBootSession(): boolean {
+  try {
+    if (new URLSearchParams(location.search).has("desktop")) {
+      sessionStorage.setItem(DESKTOP_SESSION, "1");
+      return true;
+    }
+    return sessionStorage.getItem(DESKTOP_SESSION) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** True when this tab already finished the branded splash. */
+export function isBootSplashDone(): boolean {
+  try {
+    return sessionStorage.getItem(BOOT_DONE) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markBootSplashDone(): void {
+  try {
+    sessionStorage.setItem(BOOT_DONE, "1");
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
+/**
+ * Default skip for BootGate: skip on web, skip if already done this tab,
+ * show only for an active desktop handoff session.
+ */
+export function shouldSkipBootSplash(explicitSkip?: boolean): boolean {
+  if (explicitSkip !== undefined) return explicitSkip;
+  if (isBootSplashDone()) return true;
+  return !isDesktopBootSession();
+}

--- a/web/src/components/shared/FilterBar.tsx
+++ b/web/src/components/shared/FilterBar.tsx
@@ -1,0 +1,126 @@
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from "react";
+
+/** Shared search field used in Agents / Apps / Marketplace header rows. */
+export const LIST_SEARCH_CLS =
+  "flex-1 min-w-[96px] max-w-md h-9 px-3 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent";
+
+export const FILTER_CHIP_CLS =
+  "inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md border text-xs font-medium transition-colors";
+
+export const FILTER_CHIP_ACTIVE =
+  "border-mycel-accent text-mycel-text bg-mycel-surface";
+
+export const FILTER_CHIP_IDLE =
+  "border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-text hover:border-mycel-accent";
+
+export const FILTER_POPOVER_CLS =
+  "absolute right-0 top-full mt-1.5 z-50 w-60 rounded-lg border border-mycel-border bg-mycel-surface-2 shadow-mycel-lg p-3 space-y-2.5 text-sm";
+
+export const FILTER_LABEL_CLS =
+  "block mb-1 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted";
+
+export const FILTER_SELECT_CLS =
+  "w-full px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent";
+
+export const FILTER_CLEAR_CLS =
+  "ml-auto px-2 py-1.5 text-xs text-mycel-muted hover:text-mycel-text border border-mycel-border rounded-md focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg";
+
+function FilterIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.4"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M1.5 2.5h11l-4.2 5v4l-2.6-1.5V7.5z" />
+    </svg>
+  );
+}
+
+export const ListSearchInput = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  function ListSearchInput({ className = "", type = "search", ...rest }, ref) {
+    return (
+      <input ref={ref} type={type} className={`${LIST_SEARCH_CLS} ${className}`.trim()} {...rest} />
+    );
+  },
+);
+
+/**
+ * Filters chip + popover shell shared by Agents and Apps.
+ * Caller owns open state and popover body contents.
+ */
+export function FiltersChip({
+  open,
+  onOpenChange,
+  activeCount = 0,
+  children,
+  testId,
+  label = "Filters",
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  activeCount?: number;
+  children: ReactNode;
+  testId?: string;
+  label?: string;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onMouse = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onOpenChange(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onOpenChange(false);
+    };
+    document.addEventListener("mousedown", onMouse);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onMouse);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, onOpenChange]);
+
+  return (
+    <div className="relative shrink-0" ref={ref}>
+      <button
+        type="button"
+        onClick={() => onOpenChange(!open)}
+        aria-label={label}
+        aria-haspopup="true"
+        aria-expanded={open}
+        className={`${FILTER_CHIP_CLS} ${open || activeCount > 0 ? FILTER_CHIP_ACTIVE : FILTER_CHIP_IDLE}`}
+      >
+        <FilterIcon />
+        {label}
+        {activeCount > 0 && (
+          <span className="inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-mycel-accent text-mycel-accent-fg text-[10px] font-semibold tabular-nums">
+            {activeCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <div data-testid={testId} className={FILTER_POPOVER_CLS}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Inline filter select button style used by Marketplace type/source chips. */
+export const FILTER_INLINE_BTN_CLS =
+  "flex items-center gap-1.5 px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent hover:border-mycel-border-strong transition-colors whitespace-nowrap";

--- a/web/src/components/shared/PageHeader.tsx
+++ b/web/src/components/shared/PageHeader.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+/**
+ * Shared page title chrome for titled surfaces (Settings, About, Readiness,
+ * Insights, etc.). Header-slot pages (Home, Agents) stay on useHeaderSlot.
+ */
+export function PageHeader({
+  title,
+  subtitle,
+  actions,
+  eyebrow,
+}: {
+  title: ReactNode;
+  subtitle?: ReactNode;
+  actions?: ReactNode;
+  eyebrow?: ReactNode;
+}) {
+  return (
+    <header
+      data-testid="page-header"
+      className="flex items-end justify-between gap-4 flex-wrap"
+    >
+      <div className="min-w-0">
+        {eyebrow != null && (
+          <div className="text-[11px] uppercase tracking-wider text-mycel-muted mb-1">
+            {eyebrow}
+          </div>
+        )}
+        <h1 className="font-display text-[26px] leading-none text-mycel-text">{title}</h1>
+        {subtitle != null && (
+          <p className="mt-2 text-[13px] text-mycel-text-2 max-w-2xl">{subtitle}</p>
+        )}
+      </div>
+      {actions != null && (
+        <div className="flex items-center gap-2 shrink-0">{actions}</div>
+      )}
+    </header>
+  );
+}

--- a/web/src/components/shared/__tests__/FilterBar.test.tsx
+++ b/web/src/components/shared/__tests__/FilterBar.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FiltersChip, ListSearchInput } from "../FilterBar";
+
+describe("FilterBar", () => {
+  it("renders ListSearchInput with accessible name", () => {
+    render(<ListSearchInput aria-label="Search agents" placeholder="Search" />);
+    expect(screen.getByRole("searchbox", { name: "Search agents" })).toBeInTheDocument();
+  });
+
+  it("FiltersChip toggles popover and shows active count", () => {
+    const onOpenChange = vi.fn();
+    const { rerender } = render(
+      <FiltersChip open={false} onOpenChange={onOpenChange} activeCount={2} testId="filters-pop">
+        <div>body</div>
+      </FiltersChip>,
+    );
+    expect(screen.getByRole("button", { name: "Filters" })).toHaveAttribute("aria-expanded", "false");
+    expect(screen.getByText("2")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Filters" }));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <FiltersChip open onOpenChange={onOpenChange} activeCount={2} testId="filters-pop">
+        <div>body</div>
+      </FiltersChip>,
+    );
+    expect(screen.getByTestId("filters-pop")).toHaveTextContent("body");
+  });
+});

--- a/web/src/components/shared/__tests__/PageHeader.test.tsx
+++ b/web/src/components/shared/__tests__/PageHeader.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { PageHeader } from "../PageHeader";
+
+describe("PageHeader", () => {
+  it("renders title, subtitle, and actions", () => {
+    render(
+      <PageHeader
+        title="Settings"
+        subtitle="Grouped for day-to-day use."
+        actions={<button type="button">Go</button>}
+      />,
+    );
+    expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.getByText("Grouped for day-to-day use.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go" })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/shared/buttons.tsx
+++ b/web/src/components/shared/buttons.tsx
@@ -1,0 +1,29 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+/** Solid accent CTA — matches Agents `+ New agent` / Templates `+ New template`. */
+export const PRIMARY_BTN =
+  "inline-flex items-center justify-center h-8 px-3 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg";
+
+/** Bordered secondary / ghost — Health Check, Refresh, Marketplace filters. */
+export const SECONDARY_BTN =
+  "inline-flex items-center justify-center h-8 px-3 rounded-md text-xs font-medium border border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-text hover:border-mycel-accent transition-colors disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg";
+
+type BtnProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode;
+};
+
+export function PrimaryButton({ className = "", children, type = "button", ...rest }: BtnProps) {
+  return (
+    <button type={type} className={`${PRIMARY_BTN} ${className}`.trim()} {...rest}>
+      {children}
+    </button>
+  );
+}
+
+export function SecondaryButton({ className = "", children, type = "button", ...rest }: BtnProps) {
+  return (
+    <button type={type} className={`${SECONDARY_BTN} ${className}`.trim()} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/web/src/components/shared/index.ts
+++ b/web/src/components/shared/index.ts
@@ -3,4 +3,13 @@ export { SectionRule } from "./SectionRule";
 export { ConfirmButton } from "./ConfirmButton";
 export { PageHeader } from "./PageHeader";
 export { PrimaryButton, SecondaryButton, PRIMARY_BTN, SECONDARY_BTN } from "./buttons";
+export {
+  ListSearchInput,
+  FiltersChip,
+  LIST_SEARCH_CLS,
+  FILTER_LABEL_CLS,
+  FILTER_SELECT_CLS,
+  FILTER_CLEAR_CLS,
+  FILTER_INLINE_BTN_CLS,
+} from "./FilterBar";
 export { Panel, Empty, fmtTime, fmtBytes, fmtTokens } from "./stats-primitives";

--- a/web/src/components/shared/index.ts
+++ b/web/src/components/shared/index.ts
@@ -1,4 +1,6 @@
 export { Chip, ChipList } from "./Chip";
 export { SectionRule } from "./SectionRule";
 export { ConfirmButton } from "./ConfirmButton";
+export { PageHeader } from "./PageHeader";
+export { PrimaryButton, SecondaryButton, PRIMARY_BTN, SECONDARY_BTN } from "./buttons";
 export { Panel, Empty, fmtTime, fmtBytes, fmtTokens } from "./stats-primitives";

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -306,9 +306,17 @@ export function About() {
         </button>
       </header>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-px rounded-md border border-mycel-border bg-mycel-border overflow-hidden shadow-mycel [&>*:last-child:nth-child(odd)]:sm:col-span-2">
-        {channels.map((c) => (
-          <ChannelTile key={c.label} channel={c} />
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-px rounded-md border border-mycel-border bg-mycel-border overflow-hidden shadow-mycel">
+        {channels.map((c, i) => (
+          <ChannelTile
+            key={c.label}
+            channel={c}
+            className={
+              channels.length % 2 === 1 && i === channels.length - 1
+                ? "sm:col-span-2"
+                : undefined
+            }
+          />
         ))}
       </div>
 
@@ -339,7 +347,7 @@ const STATE_DOT: Record<ChannelStatus["state"], string> = {
   error: "bg-mycel-error",
 };
 
-function ChannelTile({ channel }: { channel: ChannelStatus }) {
+function ChannelTile({ channel, className }: { channel: ChannelStatus; className?: string }) {
   const body = (
     <div className="bg-mycel-surface px-4 py-3 flex items-start gap-3 h-full hover:bg-mycel-surface-hover transition-colors">
       <span className={`mt-1.5 shrink-0 inline-flex w-2 h-2 rounded-full ${STATE_DOT[channel.state]}`} />
@@ -361,12 +369,13 @@ function ChannelTile({ channel }: { channel: ChannelStatus }) {
       )}
     </div>
   );
+  const wrap = className ? `min-w-0 ${className}` : "min-w-0";
   if (channel.href) {
     return (
-      <ExternalLink href={channel.href} className="block focus:outline-none focus:ring-1 focus:ring-mycel-accent">
+      <ExternalLink href={channel.href} className={`block focus:outline-none focus:ring-1 focus:ring-mycel-accent ${wrap}`}>
         {body}
       </ExternalLink>
     );
   }
-  return body;
+  return <div className={wrap}>{body}</div>;
 }

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -1041,6 +1041,7 @@ export function Agents() {
           type="button"
           onClick={() => setCreateOpen(true)}
           className="shrink-0 inline-flex items-center h-8 px-3 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors"
+          aria-label="Create new agent"
         >
           + New agent
         </button>

--- a/web/src/views/Agents.tsx
+++ b/web/src/views/Agents.tsx
@@ -15,6 +15,13 @@ import { formatAbsolute, formatRelative } from "../utils/time";
 import { LiveAgentCharacter } from "../components/agent-ui";
 import { CreateAgentModal } from "../components/CreateAgentModal";
 import { useHeaderSlot } from "../context/HeaderSlotContext";
+import {
+  FiltersChip,
+  ListSearchInput,
+  FILTER_LABEL_CLS,
+  FILTER_SELECT_CLS,
+  FILTER_CLEAR_CLS,
+} from "../components/shared";
 import { MONO } from "../utils/typography";
 
 /** Per-provider hue as an accent dot on the provider pill. Kept subtle —
@@ -543,24 +550,8 @@ export function Agents() {
 
   // "Filters" chip popover in the header — holds the state/tool selects,
   // the group-by-repo toggle and the clear button, so the body is the
-  // table only. Closes on outside click / Escape like other popovers.
+  // table only. Closes on outside click / Escape via shared FiltersChip.
   const [filtersOpen, setFiltersOpen] = useState(false);
-  const filtersRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!filtersOpen) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (filtersRef.current && !filtersRef.current.contains(e.target as Node)) setFiltersOpen(false);
-    };
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setFiltersOpen(false);
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    document.addEventListener("keydown", onKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", onMouseDown);
-      document.removeEventListener("keydown", onKeyDown);
-    };
-  }, [filtersOpen]);
 
   const updateFilter = (key: "role" | "state" | "tool", value: string) => {
     const next = new URLSearchParams(searchParams);
@@ -933,110 +924,79 @@ export function Agents() {
     actions: (
       <>
         {allAgents.length > 0 && (
-          <input
+          <ListSearchInput
             ref={searchInputRef}
             type="text"
             value={search}
             onChange={(e) => { setSearch(e.target.value); }}
             placeholder="Search  /"
-            className="flex-1 min-w-[96px] max-w-md h-9 px-3 text-sm rounded-md border border-mycel-border bg-mycel-surface text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent"
             aria-label="Search agents"
           />
         )}
-        {/* Filters chip — the two selects, group-by-repo and clear live in
-            a popover so the single header row never crowds. Badge counts
-            the active select filters. */}
-        {allAgents.length > 0 && (() => {
-          const activeCount = (stateFilter ? 1 : 0) + (toolFilter ? 1 : 0);
-          return (
-            <div className="relative shrink-0" ref={filtersRef}>
+        {/* Filters chip — shared FiltersChip shell; body is agent-specific. */}
+        {allAgents.length > 0 && (
+          <FiltersChip
+            open={filtersOpen}
+            onOpenChange={setFiltersOpen}
+            activeCount={(stateFilter ? 1 : 0) + (toolFilter ? 1 : 0)}
+            testId="agents-filters-popover"
+          >
+            <label className="block">
+              <span className={FILTER_LABEL_CLS}>State</span>
+              <select
+                value={stateFilter}
+                onChange={(e) => { updateFilter("state", e.target.value); }}
+                className={FILTER_SELECT_CLS}
+                aria-label="Filter by state"
+              >
+                <option value="">All states</option>
+                {availableStates.map((s) => (
+                  <option key={s} value={s}>{s}</option>
+                ))}
+              </select>
+            </label>
+            <label className="block">
+              <span className={FILTER_LABEL_CLS}>Tool</span>
+              <select
+                value={toolFilter}
+                onChange={(e) => { updateFilter("tool", e.target.value); }}
+                className={FILTER_SELECT_CLS}
+                aria-label="Filter by tool"
+              >
+                <option value="">All tools</option>
+                {availableTools.map((t) => (
+                  <option key={t} value={t}>{t}</option>
+                ))}
+              </select>
+            </label>
+            <div className="pt-0.5 border-t border-mycel-border flex items-center gap-2">
               <button
                 type="button"
-                onClick={() => setFiltersOpen((v) => !v)}
-                aria-label="Filters"
-                aria-haspopup="true"
-                aria-expanded={filtersOpen}
-                className={`inline-flex items-center gap-1.5 h-8 px-2.5 rounded-md border text-xs font-medium transition-colors ${
-                  filtersOpen || activeCount > 0
-                    ? "border-mycel-accent text-mycel-text bg-mycel-surface"
-                    : "border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-text hover:border-mycel-accent"
+                onClick={toggleGroupByRepo}
+                disabled={distinctRepoCount <= 1}
+                aria-pressed={groupByRepo}
+                className={`mt-2 px-2 py-1.5 text-xs rounded-md border transition-colors ${
+                  groupByRepo && distinctRepoCount > 1
+                    ? "border-mycel-accent text-mycel-accent"
+                    : "border-mycel-border text-mycel-muted hover:text-mycel-text disabled:opacity-50 disabled:cursor-not-allowed"
                 }`}
+                title={distinctRepoCount <= 1 ? "All agents share one repo — nothing to group" : `Group by repo (${String(distinctRepoCount)} repos in view)`}
               >
-                <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden>
-                  <path d="M1.5 2.5h11l-4.2 5v4l-2.6-1.5V7.5z" />
-                </svg>
-                Filters
-                {activeCount > 0 && (
-                  <span className="inline-flex items-center justify-center min-w-[16px] h-4 px-1 rounded-full bg-mycel-accent text-mycel-accent-fg text-[10px] font-semibold tabular-nums">
-                    {activeCount}
-                  </span>
-                )}
+                Group by repo
               </button>
-              {filtersOpen && (
-                <div
-                  data-testid="agents-filters-popover"
-                  className="absolute right-0 top-full mt-1.5 z-50 w-60 rounded-lg border border-mycel-border bg-mycel-surface-2 shadow-mycel-lg p-3 space-y-2.5 text-sm"
+              {hasFilters && (
+                <button
+                  type="button"
+                  onClick={clearFilters}
+                  className={`mt-2 ${FILTER_CLEAR_CLS}`}
+                  aria-label="Clear filters"
                 >
-                  <label className="block">
-                    <span className="block mb-1 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">State</span>
-                    <select
-                      value={stateFilter}
-                      onChange={(e) => { updateFilter("state", e.target.value); }}
-                      className="w-full px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent"
-                      aria-label="Filter by state"
-                    >
-                      <option value="">All states</option>
-                      {availableStates.map((s) => (
-                        <option key={s} value={s}>{s}</option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="block">
-                    <span className="block mb-1 text-[11px] font-medium uppercase tracking-[0.08em] text-mycel-muted">Tool</span>
-                    <select
-                      value={toolFilter}
-                      onChange={(e) => { updateFilter("tool", e.target.value); }}
-                      className="w-full px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent"
-                      aria-label="Filter by tool"
-                    >
-                      <option value="">All tools</option>
-                      {availableTools.map((t) => (
-                        <option key={t} value={t}>{t}</option>
-                      ))}
-                    </select>
-                  </label>
-                  <div className="pt-0.5 border-t border-mycel-border flex items-center gap-2">
-                    {/* Group-by-repo toggle. Default ON. Disabled when every
-                        visible agent shares one repo. */}
-                    <button
-                      type="button"
-                      onClick={toggleGroupByRepo}
-                      disabled={distinctRepoCount <= 1}
-                      aria-pressed={groupByRepo}
-                      className={`mt-2 px-2 py-1.5 text-xs rounded-md border transition-colors ${
-                        groupByRepo && distinctRepoCount > 1
-                          ? "border-mycel-accent text-mycel-accent"
-                          : "border-mycel-border text-mycel-muted hover:text-mycel-text disabled:opacity-50 disabled:cursor-not-allowed"
-                      }`}
-                      title={distinctRepoCount <= 1 ? "All agents share one repo — nothing to group" : `Group by repo (${String(distinctRepoCount)} repos in view)`}
-                    >
-                      Group by repo
-                    </button>
-                    {hasFilters && (
-                      <button
-                        onClick={clearFilters}
-                        className="mt-2 ml-auto px-2 py-1.5 text-xs text-mycel-muted hover:text-mycel-text border border-mycel-border rounded-md focus-visible:ring-2 focus-visible:ring-mycel-accent focus-visible:ring-offset-1 focus-visible:ring-offset-mycel-bg"
-                        aria-label="Clear filters"
-                      >
-                        Clear
-                      </button>
-                    )}
-                  </div>
-                </div>
+                  Clear
+                </button>
               )}
             </div>
-          );
-        })()}
+          </FiltersChip>
+        )}
         <button
           type="button"
           onClick={() => setCreateOpen(true)}

--- a/web/src/views/Marketplace.tsx
+++ b/web/src/views/Marketplace.tsx
@@ -482,7 +482,7 @@ function ItemCard({ item }: { item: MarketplaceItem }) {
           ) : (
             <button
               onClick={() => setShowPicker((v) => !v)}
-              className="px-2.5 py-1 text-xs rounded-md border border-mycel-border text-mycel-muted hover:bg-mycel-accent hover:text-mycel-accent-fg hover:border-mycel-accent transition-colors"
+              className="inline-flex items-center h-7 px-2.5 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors"
               title="Send install instruction to an agent"
             >
               Add

--- a/web/src/views/Marketplace.tsx
+++ b/web/src/views/Marketplace.tsx
@@ -11,6 +11,7 @@ import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { ExternalLink } from "../components/ExternalLink";
+import { FILTER_INLINE_BTN_CLS, LIST_SEARCH_CLS } from "../components/shared";
 import { useHeaderSlot } from "../context/HeaderSlotContext";
 
 // How many cards to mount at once. The full catalog is ~1.5k items; mounting
@@ -221,7 +222,7 @@ function FilterSelect({ value, options, onChange }: FilterSelectProps) {
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="listbox"
         aria-expanded={open}
-        className="flex items-center gap-1.5 px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text focus:outline-none focus:ring-1 focus:ring-mycel-accent hover:border-mycel-border-strong transition-colors whitespace-nowrap"
+        className={FILTER_INLINE_BTN_CLS}
       >
         <span>{current?.label}</span>
         <svg
@@ -581,21 +582,19 @@ export function Marketplace() {
       ) : undefined,
   });
 
-  const inputCls =
-    "px-2 py-1.5 text-sm rounded-md border border-mycel-border bg-mycel-bg text-mycel-text placeholder:text-mycel-muted focus:outline-none focus:ring-1 focus:ring-mycel-accent";
-
   const filtering = Boolean(typeFilter || sourceFilter || query);
 
   return (
     <div className="flex flex-col gap-4 p-4 max-w-4xl mx-auto w-full">
-      {/* Filter bar */}
-      <div className="flex flex-wrap gap-2 items-center">
+      {/* Filter bar — shared search/chip tokens with Agents + Apps (#3671) */}
+      <div className="flex flex-wrap gap-2 items-center" data-testid="marketplace-filter-bar">
         <input
           type="search"
           placeholder="Search catalog…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          className={`${inputCls} flex-1 min-w-[180px]`}
+          className={`${LIST_SEARCH_CLS} min-w-[180px]`}
+          aria-label="Search catalog"
         />
         <FilterSelect
           value={typeFilter}

--- a/web/src/views/Readiness.tsx
+++ b/web/src/views/Readiness.tsx
@@ -1,4 +1,5 @@
 import { CopyButton } from "../components/CopyButton";
+import { PageHeader, SECONDARY_BTN } from "../components/shared";
 import { useReadiness } from "../hooks/useReadiness";
 import type {
   OverallStatus,
@@ -150,22 +151,20 @@ export function Readiness() {
 
   return (
     <div className="p-6 flex flex-col gap-5 max-w-2xl mx-auto w-full">
-      <header className="flex items-center justify-between gap-3">
-        <div>
-          <h1 className="text-lg font-semibold text-mycel-text">System readiness</h1>
-          <p className="mt-0.5 text-[12px] text-mycel-muted">
-            What your machine needs to run agents — and how to get it.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={() => void refresh()}
-          disabled={loading}
-          className="relative shrink-0 text-[11px] px-2.5 py-1 rounded border border-mycel-border hover:border-mycel-accent bg-mycel-surface text-mycel-muted hover:text-mycel-text transition-colors disabled:opacity-50 outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-2 before:content-['']"
-        >
-          {loading ? "Checking…" : "Re-check"}
-        </button>
-      </header>
+      <PageHeader
+        title="System readiness"
+        subtitle="What your machine needs to run agents — and how to get it."
+        actions={
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            disabled={loading || (!loaded && !data && !error)}
+            className={SECONDARY_BTN}
+          >
+            Re-check
+          </button>
+        }
+      />
 
       {error && !data && (
         <div
@@ -177,7 +176,19 @@ export function Readiness() {
       )}
 
       {!loaded && !data && !error && (
-        <div className="text-sm text-mycel-muted py-8 text-center">Checking your machine…</div>
+        <div
+          className="rounded-lg border border-mycel-border bg-mycel-surface px-4 py-6 space-y-3"
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+        >
+          <p className="text-sm text-mycel-text-2">Checking your machine…</p>
+          <div className="space-y-2" aria-hidden>
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="h-12 rounded-md bg-mycel-surface-hover animate-pulse" />
+            ))}
+          </div>
+        </div>
       )}
 
       {data && (

--- a/web/src/views/Settings.tsx
+++ b/web/src/views/Settings.tsx
@@ -4,6 +4,7 @@ import { api, type AppInstance, type BudgetStatus } from "../api/client";
 import { usePolling } from "../hooks/usePolling";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
+import { PageHeader } from "../components/shared";
 import { useTheme } from "../context/ThemeContext";
 import { ThemePicker, RuntimePicker, AdvancedToggle, systemPrefersDark, type ThemeChoice, type RuntimeChoice } from "../settings/controls";
 import { ProvidersToolsSection } from "../settings/ProvidersToolsSection";
@@ -935,23 +936,23 @@ export function Settings() {
 
   return (
     <div className="p-4 md:p-6 space-y-4 max-w-3xl mx-auto">
-      <header className="flex items-end justify-between gap-4 flex-wrap">
-        <div>
-          <h1 className="font-display text-[26px] leading-none text-mycel-text">Settings</h1>
-          <p className="mt-2 text-[13px] text-mycel-text-2">The config that has no other home — grouped for day-to-day use.</p>
-        </div>
-        <button
-          type="button"
-          onClick={() => { void reveal.replay(); }}
-          title="Re-run setup — replays the guided reveal below without blanking anything you've already set"
-          aria-label="Re-run setup"
-          className="relative shrink-0 grid place-items-center w-9 h-9 rounded-full border border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-1.5 before:content-['']"
-        >
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-            <path d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
-          </svg>
-        </button>
-      </header>
+      <PageHeader
+        title="Settings"
+        subtitle="The config that has no other home — grouped for day-to-day use."
+        actions={
+          <button
+            type="button"
+            onClick={() => { void reveal.replay(); }}
+            title="Re-run setup — replays the guided reveal below without blanking anything you've already set"
+            aria-label="Re-run setup"
+            className="relative shrink-0 grid place-items-center w-9 h-9 rounded-full border border-mycel-border bg-mycel-surface text-mycel-muted hover:text-mycel-accent hover:border-mycel-accent transition-colors active:scale-95 outline-none focus-visible:ring-2 focus-visible:ring-mycel-accent before:absolute before:-inset-1.5 before:content-['']"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+              <path d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+            </svg>
+          </button>
+        }
+      />
 
       {saveStatus === "saved" && dirtySections.length === 0 && (
         <div aria-live="polite" className="fixed bottom-4 right-4 z-30 rounded-lg border border-mycel-success bg-mycel-success-subtle px-3 py-2 text-xs text-mycel-success shadow-mycel-lg">

--- a/web/src/views/Templates.tsx
+++ b/web/src/views/Templates.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { EmptyState } from "../components/EmptyState";
 import { usePolling } from "../hooks/usePolling";
-import { ChipList, SectionRule, ConfirmButton } from "../components/shared";
+import { ChipList, SectionRule, ConfirmButton, PRIMARY_BTN } from "../components/shared";
 import { MONO } from "../utils/typography";
 
 import { useHeaderSlot } from "../context/HeaderSlotContext";
@@ -748,9 +748,7 @@ function TemplateTable({
           <thead>
             <tr className="text-left text-[11px] font-medium text-mycel-muted uppercase tracking-[0.08em]">
               <th className="py-2.5 pl-4 pr-6 font-medium">Name</th>
-              <th className="py-2.5 px-4 font-medium">
-                {rows.some((r) => (r.composes?.length ?? 0) > 0) ? "Composes / MCPs" : "MCPs"}
-              </th>
+              <th className="py-2.5 px-4 font-medium">MCPs</th>
               <th className="py-2.5 px-4 font-medium">Description</th>
             </tr>
           </thead>
@@ -820,7 +818,7 @@ export function Templates() {
           <button
             type="button"
             onClick={() => setCreateOpen((v) => !v)}
-            className="shrink-0 inline-flex items-center h-8 px-3 rounded-md text-xs font-medium bg-mycel-accent text-mycel-accent-fg hover:bg-mycel-accent-hover shadow-mycel-sm transition-colors"
+            className={`shrink-0 ${PRIMARY_BTN}`}
             aria-label="Create new template"
           >
             + New template

--- a/web/src/views/home/Module.tsx
+++ b/web/src/views/home/Module.tsx
@@ -37,8 +37,9 @@ export function HomeModule({
     >
       <header className="shrink-0 flex items-center gap-2 px-3 py-1.5 border-b border-mycel-border bg-mycel-bg">
         <span
-          className="text-[10px] font-semibold text-mycel-muted uppercase tracking-widest truncate"
+          className="text-[10px] font-semibold text-mycel-muted uppercase tracking-widest min-w-0 truncate"
           style={{ fontFamily: MONO }}
+          title={label}
         >
           {label}
         </span>

--- a/web/src/views/home/OverviewStrip.tsx
+++ b/web/src/views/home/OverviewStrip.tsx
@@ -157,7 +157,9 @@ export function OverviewStrip({
       data-testid="home-overview-strip"
       className="shrink-0 rounded-lg border border-mycel-border shadow-mycel-sm overflow-hidden"
     >
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-mycel-border">
+      {/* 5 cells: on 2-col mobile the last cell spans full width so we never
+          leave an empty sixth slot; 3-col tablet is 2+2+1; desktop is one row. */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-mycel-border [&>*:last-child]:col-span-2 sm:[&>*:last-child]:col-span-1 lg:[&>*:last-child]:col-span-1">
         <Cell
           label="Agents"
           value={


### PR DESCRIPTION
## Summary
- Shared `PageHeader` + `PRIMARY_BTN` / `SECONDARY_BTN` tokens for titled surfaces and CTAs
- Shared `FilterBar` (`ListSearchInput` + `FiltersChip`) on Agents, Apps, and Marketplace
- Apps hub naming hierarchy (Apps title + Notifications feed section)
- Home OverviewStrip: last cell spans on mobile; module headers get `title` tooltips
- About distribution grid: odd last tile spans two columns
- Templates tables: unified **MCPs** column header
- Marketplace **Add** uses solid primary CTA weight
- Readiness: PageHeader + skeleton loading
- Boot: desktop-only splash with real daemon logs; silent handoff page (no double mushroom)

Part of #3662. Fixes #3663 #3664 #3665 #3666 #3668 #3669 #3670 #3671 #3673.

## Test plan
- [x] `vitest` PageHeader, FilterBar, BootGate/desktopBoot, readiness, appsHome, templates
- [x] `go test` desktop bootpage
- [x] Local redeploy health `0.4.7-dev.33.gdbf2378` / `dbf23782`
- [ ] Spot-check Settings / Apps / Home mobile / Marketplace / About / Readiness
- [ ] Desktop: one boot splash with logs; browser: no BootSplash
- [ ] Confirm Agents `+ New agent` and Templates `+ New template` still primary accent
