### PR TITLE
fix(spawn): stop pi inheriting ~/AGENTS.md beads instructions

### DIFF
--- a/docs/how-to/inject-instructions.md
+++ b/docs/how-to/inject-instructions.md
@@ -94,4 +94,18 @@ Use role prompts for what a *kind* of agent should do, and injected instructions
 | Mycel-managed block (markers) | mycel | every spawn + restart |
 | Repo / user `AGENTS.md` conventions | tool / user | outside mycel (Claude/Cursor may also load `~/AGENTS.md`) |
 
+### Pi spawn isolation
+
+Pi walks ancestor directories for `AGENTS.md` / `CLAUDE.md`, so a worktree under
+`$HOME/.mycel/...` would otherwise inherit `~/AGENTS.md` (often unrelated
+beads/`bd` instructions). Mycel does **not** delete or edit that home file.
+Instead, every pi spawn command includes:
+
+- `--no-context-files` — disables pi's AGENTS.md/CLAUDE.md discovery
+- `--append-system-prompt Pi.md` — injects the worktree prompt file that holds
+  the role text + mycel-managed section (#3648/#3652)
+
+Prefs `providers.pi.command` overrides get the same flags appended idempotently.
+See `provider.PiIsolateSpawnCommand` / `PiProvider.BuildCommand` (#3678).
+
 Do not hand-edit inside the managed markers — the next restart will overwrite that region.

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -865,7 +865,13 @@ func (m *Manager) getAgentCommand(toolName, agentName string, resume bool, sessi
 	// or --session "<id>" handling.
 	if m.providersConfig != nil {
 		if cfg, ok := m.providersConfig.Providers[toolName]; ok && cfg.Command != "" {
-			return appendSessionFlags(cfg.Command, opts), true
+			cmd := appendSessionFlags(cfg.Command, opts)
+			// Prefs overrides skip BuildCommand — still apply pi's
+			// ~/AGENTS.md isolation + mycel-managed prompt append (#3678).
+			if toolName == "pi" {
+				cmd = provider.PiIsolateSpawnCommand(cmd)
+			}
+			return cmd, true
 		}
 	}
 	return p.BuildCommand(opts), true

--- a/pkg/agent/model_command_test.go
+++ b/pkg/agent/model_command_test.go
@@ -10,6 +10,30 @@ import (
 	"github.com/rpuneet/mycel/pkg/provider"
 )
 
+// TestGetAgentCommand_PiIsolatesHomeAgentsMD is the #3678 regression:
+// mycel pi spawns must disable context-file discovery (so ~/AGENTS.md
+// beads instructions cannot leak) and still append the mycel-managed
+// Pi.md prompt written on spawn/restart (#3648/#3652).
+func TestGetAgentCommand_PiIsolatesHomeAgentsMD(t *testing.T) {
+	m := &Manager{providerRegistry: provider.DefaultRegistry}
+	cmd, ok := m.getAgentCommand("pi", "beads-agents-leak", false, "", "")
+	if !ok {
+		t.Fatal("getAgentCommand(pi) not ok")
+	}
+	if !strings.Contains(cmd, "--no-context-files") {
+		t.Errorf("pi spawn missing --no-context-files: %q", cmd)
+	}
+	if !strings.Contains(cmd, "--append-system-prompt Pi.md") {
+		t.Errorf("pi spawn missing mycel-managed append: %q", cmd)
+	}
+	// Must not shell-out to delete or rewrite the user's ~/AGENTS.md.
+	for _, bad := range []string{"rm ", "unlink ", "AGENTS.md"} {
+		if strings.Contains(cmd, bad) {
+			t.Errorf("pi spawn must not touch user AGENTS.md (%q in %q)", bad, cmd)
+		}
+	}
+}
+
 // TestGetAgentCommandModel verifies the model reaches the provider's
 // BuildCommand and that unsafe values are dropped before the command
 // line is assembled.
@@ -67,11 +91,21 @@ func TestGetAgentCommandModelWithOverride(t *testing.T) {
 	if !strings.Contains(cmd, " --model anthropic/claude-sonnet-4-6") {
 		t.Errorf("command %q missing generic --model flag", cmd)
 	}
+	// Override path skips BuildCommand — isolation must still apply (#3678).
+	if !strings.Contains(cmd, "--no-context-files") {
+		t.Errorf("override command missing --no-context-files: %q", cmd)
+	}
+	if !strings.Contains(cmd, "--append-system-prompt Pi.md") {
+		t.Errorf("override command missing managed prompt append: %q", cmd)
+	}
 
 	// Unsafe model must be dropped on the override path too.
 	cmd, _ = m.getAgentCommand("pi", "test-agent", false, "", "a b; rm")
-	if strings.Contains(cmd, "rm") || strings.Contains(cmd, "--model") {
+	if strings.Contains(cmd, "rm") {
 		t.Errorf("unsafe model leaked into override command: %q", cmd)
+	}
+	if strings.Contains(cmd, "--model a b") || strings.Contains(cmd, "--model a") {
+		t.Errorf("unsafe model flag leaked into override command: %q", cmd)
 	}
 }
 

--- a/pkg/provider/pi.go
+++ b/pkg/provider/pi.go
@@ -81,6 +81,40 @@ func SafePiModelName(model string) bool {
 	return safePiModelPattern.MatchString(model)
 }
 
+// piManagedPromptFile is the worktree prompt file GenericAdapter writes for
+// pi (PromptFile → "Pi.md"). Spawn injects it explicitly via
+// --append-system-prompt after disabling pi's AGENTS.md/CLAUDE.md walk
+// (#3678) so ~/AGENTS.md beads instructions cannot leak in.
+const piManagedPromptFile = "Pi.md"
+
+// PiIsolateSpawnCommand idempotently adds spawn isolation flags so pi does
+// not discover ancestor/home AGENTS.md (or CLAUDE.md) while still loading
+// the mycel-managed prompt file from the agent worktree.
+// Safe to call on prefs command overrides as well as BuildCommand output.
+func PiIsolateSpawnCommand(cmd string) string {
+	if cmd == "" {
+		return cmd
+	}
+	if !strings.Contains(cmd, "--no-context-files") && !hasPiShortFlag(cmd, "-nc") {
+		cmd += " --no-context-files"
+	}
+	if !strings.Contains(cmd, "--append-system-prompt") {
+		cmd += " --append-system-prompt " + piManagedPromptFile
+	}
+	return cmd
+}
+
+// hasPiShortFlag reports whether cmd already includes the standalone short
+// flag (e.g. -nc). Avoids matching substrings inside longer tokens.
+func hasPiShortFlag(cmd, flag string) bool {
+	for _, tok := range strings.Fields(cmd) {
+		if tok == flag {
+			return true
+		}
+	}
+	return false
+}
+
 // BuildCommand returns the full command for a given runtime context.
 // When opts.Model is set and passes SafePiModelName, it is appended as flags.
 // pi accepts "provider/model" as a single --model value, but also supports
@@ -89,8 +123,13 @@ func SafePiModelName(model string) bool {
 // into a shell command line — unsafe values are dropped, never escaped.
 // When no model is given, pi uses its own configured default — mycel does
 // not override that default.
+//
+// Isolation: always passes --no-context-files so pi's ancestor walk cannot
+// load ~/AGENTS.md (common when worktrees live under $HOME/.mycel/...). The
+// mycel-managed section is still injected with --append-system-prompt Pi.md
+// (#3648/#3652, #3678).
 func (p *PiProvider) BuildCommand(opts CommandOpts) string {
-	cmd := p.Command()
+	cmd := PiIsolateSpawnCommand(p.Command())
 	if SafePiModelName(opts.Model) {
 		if idx := strings.Index(opts.Model, "/"); idx > 0 {
 			providerPart := opts.Model[:idx]

--- a/pkg/provider/pi_test.go
+++ b/pkg/provider/pi_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -61,6 +62,10 @@ func TestSafePiModelName(t *testing.T) {
 	}
 }
 
+// piSpawnBase is the isolation prefix every mycel pi spawn must carry so
+// ancestor ~/AGENTS.md cannot leak into context (#3678).
+const piSpawnBase = "pi --no-context-files --append-system-prompt Pi.md"
+
 func TestPiBuildCommand(t *testing.T) {
 	p := NewPiProvider()
 	tests := []struct { //nolint:govet // test struct, field order matches literal values
@@ -69,44 +74,44 @@ func TestPiBuildCommand(t *testing.T) {
 		opts CommandOpts
 	}{
 		{
-			name: "no opts — base command",
+			name: "no opts — isolation flags only",
 			opts: CommandOpts{},
-			want: "pi",
+			want: piSpawnBase,
 		},
 		{
 			name: "bedrock provider/model splits into --provider and --model",
 			opts: CommandOpts{Model: "amazon-bedrock/moonshotai.kimi-k2.5"},
-			want: "pi --provider amazon-bedrock --model moonshotai.kimi-k2.5",
+			want: piSpawnBase + " --provider amazon-bedrock --model moonshotai.kimi-k2.5",
 		},
 		{
 			name: "groq provider/model splits correctly",
 			opts: CommandOpts{Model: "groq/llama-3.3-70b-versatile"},
-			want: "pi --provider groq --model llama-3.3-70b-versatile",
+			want: piSpawnBase + " --provider groq --model llama-3.3-70b-versatile",
 		},
 		{
 			name: "bare model without slash — single --model flag",
 			opts: CommandOpts{Model: "llama-3.3-70b-versatile"},
-			want: "pi --model llama-3.3-70b-versatile",
+			want: piSpawnBase + " --model llama-3.3-70b-versatile",
 		},
 		{
 			name: "unsafe model is dropped",
 			opts: CommandOpts{Model: "$(rm -rf /)"},
-			want: "pi",
+			want: piSpawnBase,
 		},
 		{
 			name: "leading-dash model is dropped (arg injection prevention)",
 			opts: CommandOpts{Model: "-continue"},
-			want: "pi",
+			want: piSpawnBase,
 		},
 		{
 			name: "session ID appended",
 			opts: CommandOpts{SessionID: "abc123"},
-			want: "pi --session abc123",
+			want: piSpawnBase + " --session abc123",
 		},
 		{
 			name: "resume flag",
 			opts: CommandOpts{Resume: true},
-			want: "pi --continue",
+			want: piSpawnBase + " --continue",
 		},
 		{
 			name: "model + session + resume — all three flags",
@@ -115,12 +120,12 @@ func TestPiBuildCommand(t *testing.T) {
 				SessionID: "abc123",
 				Resume:    true,
 			},
-			want: "pi --provider groq --model llama-3.3-70b-versatile --session abc123 --continue",
+			want: piSpawnBase + " --provider groq --model llama-3.3-70b-versatile --session abc123 --continue",
 		},
 		{
 			name: "model with dots in model id",
 			opts: CommandOpts{Model: "anthropic/claude-sonnet-4-6"},
-			want: "pi --provider anthropic --model claude-sonnet-4-6",
+			want: piSpawnBase + " --provider anthropic --model claude-sonnet-4-6",
 		},
 	}
 	for _, tt := range tests {
@@ -130,6 +135,66 @@ func TestPiBuildCommand(t *testing.T) {
 				t.Errorf("BuildCommand() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// TestPiIsolateSpawnCommand_Idempotent covers prefs overrides that already
+// include -nc / --no-context-files so we do not double-append (#3678).
+func TestPiIsolateSpawnCommand_Idempotent(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "bare pi gets both flags",
+			in:   "pi",
+			want: piSpawnBase,
+		},
+		{
+			name: "existing long flag keeps append only",
+			in:   "pi --no-context-files --provider amazon-bedrock",
+			want: "pi --no-context-files --provider amazon-bedrock --append-system-prompt Pi.md",
+		},
+		{
+			name: "existing short -nc is respected",
+			in:   "pi -nc --model foo",
+			want: "pi -nc --model foo --append-system-prompt Pi.md",
+		},
+		{
+			name: "both flags already present — unchanged",
+			in:   piSpawnBase + " --continue",
+			want: piSpawnBase + " --continue",
+		},
+		{
+			name: "empty command untouched",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PiIsolateSpawnCommand(tt.in)
+			if got != tt.want {
+				t.Errorf("PiIsolateSpawnCommand(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestPiPromptFileIsManagedAppendTarget pins the file name that
+// --append-system-prompt must reference (GenericAdapter → Pi.md).
+func TestPiPromptFileIsManagedAppendTarget(t *testing.T) {
+	p := NewPiProvider()
+	if got := p.PromptFile(); got != piManagedPromptFile {
+		t.Fatalf("PromptFile() = %q, want %q (append-system-prompt target)", got, piManagedPromptFile)
+	}
+	cmd := p.BuildCommand(CommandOpts{})
+	if !strings.Contains(cmd, "--append-system-prompt "+piManagedPromptFile) {
+		t.Fatalf("BuildCommand missing managed append: %q", cmd)
+	}
+	if !strings.Contains(cmd, "--no-context-files") {
+		t.Fatalf("BuildCommand missing --no-context-files: %q", cmd)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Pi spawn now always includes `--no-context-files` so ancestor/`~/AGENTS.md` discovery (beads/`bd` instructions) cannot leak into agent context
- Still injects the worktree mycel-managed prompt via `--append-system-prompt Pi.md` (#3648/#3652)
- Prefs `providers.pi.command` overrides get the same isolation flags idempotently; docs cover the spawn isolation

Fixes #3678
Part of #3624

## Test plan
- [x] `go test ./pkg/provider/ ./pkg/agent/`
- [x] Regression: `TestGetAgentCommand_PiIsolatesHomeAgentsMD`, `TestPiIsolateSpawnCommand_Idempotent`, override-path coverage
- [ ] Spawn a pi agent under `~/.mycel/agents/...` and confirm startup does not load `~/AGENTS.md` while `Pi.md` mycel-managed block is present


Made with [Cursor](https://cursor.com)