### PR TITLE
fix(gateway/notify): hot-restart cancel, labeled catch-all, telegram Stop

### DIFF
--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -117,6 +117,9 @@ type Manager struct {
 	// adapterWG tracks boot-time and hot-started adapter goroutines so Stop/
 	// Start can wait for clean shutdown of both.
 	adapterWG sync.WaitGroup
+	// adapterCancel holds per-adapter Start cancels so StopAdapter can end
+	// blocking socket/poll loops that ignore Stop alone (#3681).
+	adapterCancel map[string]context.CancelFunc
 }
 
 type channelRoute struct {
@@ -128,9 +131,10 @@ type channelRoute struct {
 // NewManager creates a new gateway manager.
 func NewManager() *Manager {
 	return &Manager{
-		adapters:   make(map[string]NotificationAdapter),
-		running:    make(map[string]bool),
-		channelMap: make(map[string]channelRoute),
+		adapters:       make(map[string]NotificationAdapter),
+		running:        make(map[string]bool),
+		channelMap:     make(map[string]channelRoute),
+		adapterCancel:  make(map[string]context.CancelFunc),
 	}
 }
 
@@ -218,18 +222,21 @@ func (m *Manager) Start(ctx context.Context) error {
 		if !m.markRunning(a.Name()) {
 			continue // already started (e.g. via StartAdapter race)
 		}
+		actx, cancel := context.WithCancel(ctx)
+		m.setAdapterCancel(a.Name(), cancel)
 		m.adapterWG.Add(1)
-		go func(adapter NotificationAdapter) {
+		go func(adapter NotificationAdapter, actx context.Context) {
 			defer m.adapterWG.Done()
 			defer m.clearRunning(adapter.Name())
+			defer m.clearAdapterCancel(adapter.Name())
 			platformName := adapter.Name()
 			handler := func(n Notification) {
 				m.handleNotification(platformName, n)
 			}
-			if err := adapter.Start(ctx, handler); err != nil && ctx.Err() == nil {
+			if err := adapter.Start(actx, handler); err != nil && actx.Err() == nil {
 				log.Error("gateway: adapter stopped with error", "adapter", adapter.Name(), "error", err)
 			}
-		}(a)
+		}(a, actx)
 	}
 
 	// Re-discover channels after adapters have connected (5s delay)
@@ -285,14 +292,17 @@ func (m *Manager) StartAdapter(adapter NotificationAdapter) error {
 		m.clearRunning(name)
 		return fmt.Errorf("gateway: manager shutting down")
 	}
+	actx, cancel := context.WithCancel(ctx)
+	m.setAdapterCancel(name, cancel)
 	m.adapterWG.Add(1)
 	go func() {
 		defer m.adapterWG.Done()
 		defer m.clearRunning(name)
+		defer m.clearAdapterCancel(name)
 		handler := func(n Notification) {
 			m.handleNotification(name, n)
 		}
-		if err := adapter.Start(ctx, handler); err != nil && ctx.Err() == nil {
+		if err := adapter.Start(actx, handler); err != nil && actx.Err() == nil {
 			log.Error("gateway: adapter stopped with error", "adapter", name, "error", err)
 		}
 	}()
@@ -310,23 +320,31 @@ func (m *Manager) StopAdapter(name string) error {
 	if ok {
 		delete(m.adapters, name)
 	}
+	cancel := m.adapterCancel[name]
+	delete(m.adapterCancel, name)
 	m.mu.Unlock()
 	if !ok {
 		return nil
 	}
+	if cancel != nil {
+		cancel()
+	}
 	err := a.Stop()
-	// Wait for the Start/StartAdapter goroutine to observe Stop and clearRunning.
-	deadline := time.Now().Add(2 * time.Second)
+	// Wait for the Start/StartAdapter goroutine to observe cancel/Stop and clearRunning.
+	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		m.mu.RLock()
 		running := m.running[name]
 		m.mu.RUnlock()
 		if !running {
-			break
+			return err
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	return err
+	if err != nil {
+		return fmt.Errorf("gateway: adapter %s still running after stop: %w", name, err)
+	}
+	return fmt.Errorf("gateway: adapter %s still running after stop", name)
 }
 
 // markRunning records that name is starting. Returns false if already running.
@@ -347,6 +365,47 @@ func (m *Manager) clearRunning(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	delete(m.running, name)
+}
+
+func (m *Manager) setAdapterCancel(name string, cancel context.CancelFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.adapterCancel == nil {
+		m.adapterCancel = make(map[string]context.CancelFunc)
+	}
+	if prev := m.adapterCancel[name]; prev != nil {
+		prev()
+	}
+	m.adapterCancel[name] = cancel
+}
+
+func (m *Manager) clearAdapterCancel(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.adapterCancel, name)
+}
+
+// longestAdapterPrefix finds the registered adapter name that is the longest
+// prefix of channel (as "name" or "name:…"). Labeled instances like
+// "telegram:alerts:123" must resolve to "telegram:alerts", not "telegram" (#3685).
+func (m *Manager) longestAdapterPrefix(channel string) (name, id string, ok bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	best := ""
+	for n := range m.adapters {
+		if channel == n || strings.HasPrefix(channel, n+":") {
+			if len(n) > len(best) {
+				best = n
+			}
+		}
+	}
+	if best == "" {
+		return "", "", false
+	}
+	if channel == best {
+		return best, "", true
+	}
+	return best, channel[len(best)+1:], true
 }
 
 // restorePersistedChannels loads saved channel mappings from the store.
@@ -533,12 +592,10 @@ func (m *Manager) Send(ctx context.Context, channel, sender, content string) (bo
 	route, ok := m.channelMap[channel]
 	m.mu.RUnlock()
 	if !ok {
-		// No pre-registered channel. Fall back to routing "<platform>:<id>"
-		// straight to that platform's adapter, so a caller can reach a native
-		// destination that hasn't produced an inbound message yet — e.g. a
-		// WhatsApp 1:1 contact addressed by phone number. The adapter decides
-		// whether the raw id is routable.
-		if platform, id, found := strings.Cut(channel, ":"); found && id != "" {
+		// No pre-registered channel. Fall back to longest-prefix adapter match
+		// so labeled instances ("telegram:alerts:123") route correctly (#3685).
+		platform, id, found := m.longestAdapterPrefix(channel)
+		if found && id != "" {
 			m.mu.RLock()
 			adapter := m.adapters[platform]
 			m.mu.RUnlock()

--- a/pkg/gateway/manager.go
+++ b/pkg/gateway/manager.go
@@ -88,38 +88,16 @@ type reactionSender interface {
 
 // Manager orchestrates all gateway adapters and routes messages.
 type Manager struct {
-	// adapters holds all registered NotificationAdapter instances.
-	adapters map[string]NotificationAdapter
-	// running tracks adapters whose Start loop is already live so hot-start
-	// does not spawn a second poll/socket for the same name.
-	running map[string]bool
-	// startCtx is the context passed to Start; used by StartAdapter to bind
-	// late-registered adapters to the same lifetime.
-	startCtx context.Context
-	// channelMap maps "telegram:<group_name>" → channelRoute
-	channelMap map[string]channelRoute
-	// onInbound is called when a message arrives from an external platform.
-	// Typically wired to ChannelService.Send + SSE hub.
-	// senderID carries the platform-native sender identifier (e.g. WhatsApp JID)
-	// so callers can use it for follow-up operations such as reactions.
-	// senderAvatar is the raw platform avatar URL for the sender when the
-	// adapter cheaply resolved one (empty otherwise → initials fallback).
-	// automated marks machine-generated events that should reach the channel
-	// feed without waking subscribed agents.
-	onInbound func(params InboundParams)
-	// onOutbound is called after a message has been successfully handed to a
-	// platform, so the channel's stored history holds both sides of the
-	// conversation. Inbound messages are recorded from onInbound; without this
-	// hook a transcript shows only what arrived, never what an agent replied.
-	onOutbound   func(channel, sender, content string)
-	channelStore ChannelStore
-	mu           sync.RWMutex
-	// adapterWG tracks boot-time and hot-started adapter goroutines so Stop/
-	// Start can wait for clean shutdown of both.
-	adapterWG sync.WaitGroup
-	// adapterCancel holds per-adapter Start cancels so StopAdapter can end
-	// blocking socket/poll loops that ignore Stop alone (#3681).
+	startCtx      context.Context
+	channelStore  ChannelStore
+	adapters      map[string]NotificationAdapter
+	running       map[string]bool
+	channelMap    map[string]channelRoute
+	onInbound     func(params InboundParams)
+	onOutbound    func(channel, sender, content string)
 	adapterCancel map[string]context.CancelFunc
+	adapterWG     sync.WaitGroup
+	mu            sync.RWMutex
 }
 
 type channelRoute struct {
@@ -131,10 +109,10 @@ type channelRoute struct {
 // NewManager creates a new gateway manager.
 func NewManager() *Manager {
 	return &Manager{
-		adapters:       make(map[string]NotificationAdapter),
-		running:        make(map[string]bool),
-		channelMap:     make(map[string]channelRoute),
-		adapterCancel:  make(map[string]context.CancelFunc),
+		adapters:      make(map[string]NotificationAdapter),
+		running:       make(map[string]bool),
+		channelMap:    make(map[string]channelRoute),
+		adapterCancel: make(map[string]context.CancelFunc),
 	}
 }
 

--- a/pkg/gateway/telegram/telegram.go
+++ b/pkg/gateway/telegram/telegram.go
@@ -85,7 +85,12 @@ func (a *Adapter) Start(ctx context.Context, handler func(gateway.Notification))
 		case <-ctx.Done():
 			a.stopBot()
 			return nil
-		case update := <-updates:
+		case update, ok := <-updates:
+			if !ok {
+				// StopReceivingUpdates closed the channel — exit so clearRunning can run.
+				a.stopBot()
+				return nil
+			}
 			if update.Message == nil {
 				continue
 			}

--- a/pkg/notify/prune.go
+++ b/pkg/notify/prune.go
@@ -31,10 +31,12 @@ func LegacyCatchAllChannel(platform string) string {
 	return platform + legacyCatchAllSuffix
 }
 
-// PlatformOf returns the platform prefix of a channel key ("slack:eng" → "slack").
+// PlatformOf returns the adapter/instance prefix of a channel key.
+// Channel keys are "{adapter.Name()}:{leaf}", and adapter names may themselves
+// contain ":" (labeled multi-instance, e.g. "github:mycel:issue-42" → "github:mycel").
 // Empty when the key has no ":" separator.
 func PlatformOf(channel string) string {
-	i := strings.IndexByte(channel, ':')
+	i := strings.LastIndexByte(channel, ':')
 	if i <= 0 {
 		return ""
 	}

--- a/pkg/notify/prune_test.go
+++ b/pkg/notify/prune_test.go
@@ -107,3 +107,18 @@ func TestIsCatchAll(t *testing.T) {
 		t.Fatal("IsAnyCatchAll mismatch")
 	}
 }
+
+func TestPlatformOfLabeledInstance(t *testing.T) {
+	if got := PlatformOf("github:mycel:issue-1"); got != "github:mycel" {
+		t.Fatalf("PlatformOf labeled = %q, want github:mycel", got)
+	}
+	if got := PlatformOf("slack:eng"); got != "slack" {
+		t.Fatalf("PlatformOf slack = %q, want slack", got)
+	}
+	if !IsCatchAll("github:mycel:*") {
+		t.Fatal("want IsCatchAll(github:mycel:*)")
+	}
+	if CatchAllChannel("github:mycel") != "github:mycel:*" {
+		t.Fatal("CatchAllChannel labeled mismatch")
+	}
+}

--- a/pkg/notify/service.go
+++ b/pkg/notify/service.go
@@ -295,14 +295,33 @@ func (s *Service) deliverToSubscribers(ctx context.Context, d deliverable) {
 	//
 	// Muted rows on the real channel suppress catch-all for that agent only
 	// (#3466) and do not count as active subscribers.
-	if len(active) == 0 && platform != "" {
+	//
+	// Explicit subscribers on the channel keep their own settings, but they
+	// must not suppress catch-all delivery for *other* agents that only have
+	// "{platform}:*" (#3688). Merge catch-all agents that are not already
+	// covered and not muted.
+	if platform != "" {
 		fallback, fErr := s.catchAllSubscribers(ctx, platform, channel)
 		if fErr != nil {
 			log.Warn("notify: catch-all lookup failed", "platform", platform, "channel", channel, "error", fErr)
 		} else if len(fallback) > 0 {
-			active = filterCatchAll(fallback, mutedAgents)
-			log.Info("notify: delivering via catch-all subscription",
-				"channel", channel, "catch_all", CatchAllChannel(platform), "agents", len(active))
+			covered := make(map[string]bool, len(active))
+			for _, sub := range active {
+				covered[sub.Agent] = true
+			}
+			merged := 0
+			for _, sub := range filterCatchAll(fallback, mutedAgents) {
+				if covered[sub.Agent] {
+					continue
+				}
+				active = append(active, sub)
+				covered[sub.Agent] = true
+				merged++
+			}
+			if merged > 0 {
+				log.Info("notify: delivering via catch-all subscription",
+					"channel", channel, "catch_all", CatchAllChannel(platform), "added", merged, "agents", len(active))
+			}
 		}
 	}
 	subs = active
@@ -510,20 +529,25 @@ func (s *Service) deliverOutboundToSubscribers(ctx context.Context, channel, sen
 	active, mutedAgents := partitionSubs(subs)
 
 	// Extract platform from channel name (e.g., "slack:general" -> "slack")
-	platform := ""
-	if idx := strings.Index(channel, ":"); idx > 0 {
-		platform = channel[:idx]
-	}
+	platform := PlatformOf(channel)
 
-	// Fallback to catch-all subscription if no active direct subscribers
-	if len(active) == 0 && platform != "" {
+	// Merge catch-all agents not already covered (#3688).
+	if platform != "" {
 		fallback, fErr := s.catchAllSubscribers(ctx, platform, channel)
 		if fErr != nil {
 			log.Warn("notify: catch-all lookup failed for outbound", "platform", platform, "channel", channel, "error", fErr)
 		} else if len(fallback) > 0 {
-			active = filterCatchAll(fallback, mutedAgents)
-			log.Info("notify: delivering outbound via catch-all subscription",
-				"channel", channel, "catch_all", CatchAllChannel(platform), "agents", len(active))
+			covered := make(map[string]bool, len(active))
+			for _, sub := range active {
+				covered[sub.Agent] = true
+			}
+			for _, sub := range filterCatchAll(fallback, mutedAgents) {
+				if covered[sub.Agent] {
+					continue
+				}
+				active = append(active, sub)
+				covered[sub.Agent] = true
+			}
 		}
 	}
 	subs = active

--- a/pkg/notify/service_test.go
+++ b/pkg/notify/service_test.go
@@ -527,20 +527,17 @@ func TestCatchAllDoesNotFanOutAcrossChannels(t *testing.T) {
 	}
 }
 
-// TestExplicitChannelSubscriptionWinsOverCatchAll proves the fallback is only
-// a fallback: a per-channel subscription with its own settings still governs
-// that channel, so mention-only on one noisy chat keeps working.
-func TestExplicitChannelSubscriptionWinsOverCatchAll(t *testing.T) {
+// TestExplicitSettingsWinButCatchAllPeersStillDeliver (#3688): an explicit
+// mention-only sub keeps its own filter, but must not suppress catch-all peers.
+func TestExplicitSettingsWinButCatchAllPeersStillDeliver(t *testing.T) {
 	store := setupTestStore(t)
 	sender := &mockSender{}
 	svc := NewService(store, sender, &mockHub{})
 	ctx := context.Background()
 
-	// Catch-all would deliver everything to broad-agent...
 	if err := store.Subscribe(ctx, "gmail:*", "broad-agent", false); err != nil {
 		t.Fatal(err)
 	}
-	// ...but this channel has its own explicit, mention-only subscription.
 	if err := store.Subscribe(ctx, "gmail:noisysendercom", "focused-agent", true); err != nil {
 		t.Fatal(err)
 	}
@@ -550,20 +547,26 @@ func TestExplicitChannelSubscriptionWinsOverCatchAll(t *testing.T) {
 		t.Fatal("dispatch did not finish")
 	}
 
-	// focused-agent is mention-only and wasn't mentioned; broad-agent must not
-	// be pulled in by the catch-all, because the channel has a subscriber.
-	if calls := sender.getCalls(); len(calls) != 0 {
-		t.Fatalf("expected no deliveries, got %+v", calls)
+	// focused-agent is mention-only and wasn't mentioned; broad-agent still
+	// receives via catch-all merge.
+	calls := sender.getCalls()
+	if len(calls) != 1 || calls[0].Name != "broad-agent" {
+		t.Fatalf("expected broad-agent only, got %+v", calls)
 	}
 
-	svc.Dispatch("gmail:noisysendercom", "gmail", "someone", "", "", "hey @focused-agent look", "m2", nil, nil, nil)
+	svc.Dispatch("gmail:noisysendercom", "gmail", "someone", "", "", "hey @focused-agent look", "m2", []string{"focused-agent"}, nil, nil)
 	if !svc.DrainDispatches(2 * time.Second) {
 		t.Fatal("dispatch did not finish")
 	}
 
-	calls := sender.getCalls()
-	if len(calls) != 1 || calls[0].Name != "focused-agent" {
-		t.Fatalf("expected one delivery to focused-agent, got %+v", calls)
+	calls = sender.getCalls()
+	got := map[string]int{}
+	for _, c := range calls {
+		got[c.Name]++
+	}
+	// m1→broad, m2→focused + broad
+	if got["broad-agent"] != 2 || got["focused-agent"] != 1 {
+		t.Fatalf("want broad=2 focused=1, got %+v (calls=%+v)", got, calls)
 	}
 }
 
@@ -731,9 +734,14 @@ func TestMigratePlaceholderSubsNoOpWhenRealHasSubs(t *testing.T) {
 	if len(subs) != 1 || subs[0].Agent != "real-agent" {
 		t.Fatalf("expected only real-agent, got %+v", subs)
 	}
+	// Subscriptions stay uncopied; delivery merges catch-all peers (#3688).
 	calls := sender.getCalls()
-	if len(calls) != 1 || calls[0].Name != "real-agent" {
-		t.Fatalf("expected delivery only to real-agent, got %+v", calls)
+	got := map[string]bool{}
+	for _, c := range calls {
+		got[c.Name] = true
+	}
+	if !got["real-agent"] || !got["legacy-agent"] || len(got) != 2 {
+		t.Fatalf("expected real-agent + legacy-agent via catch-all merge, got %+v", calls)
 	}
 }
 
@@ -877,8 +885,13 @@ func TestSlackGeneralIsNotCatchAll(t *testing.T) {
 		t.Fatal("dispatch timeout")
 	}
 	calls = sender.getCalls()
-	if len(calls) != 1 || calls[0].Name != "general-only" {
-		t.Fatalf("#general should only hit general-only (explicit wins), got %+v", calls)
+	got := map[string]bool{}
+	for _, c := range calls {
+		got[c.Name] = true
+	}
+	// Explicit #general sub keeps general-only; catch-all peer still receives (#3688).
+	if !got["general-only"] || !got["catch-agent"] || len(got) != 2 {
+		t.Fatalf("#general should hit general-only + catch-agent, got %+v", calls)
 	}
 }
 

--- a/server/handlers/apps.go
+++ b/server/handlers/apps.go
@@ -420,6 +420,11 @@ func (h *AppsHandler) restartAdapter(name string, ic app.InstanceConfig, enabled
 	}
 	if err := h.gw.StopAdapter(name); err != nil {
 		log.Warn("apps: stop adapter", "name", name, "error", err)
+		// Config already saved; still report so the UI does not look healthy (#3681).
+		if enabled {
+			return "adapter stop failed: " + err.Error()
+		}
+		return "adapter stop failed: " + err.Error()
 	}
 	if !enabled {
 		return ""

--- a/server/server.go
+++ b/server/server.go
@@ -292,10 +292,7 @@ func New(cfg Config, svc Services, hub *ws.Hub, staticFiles fs.FS) *Server {
 			// Dispatch to notify subscribers (new subscription system).
 			// Handles @mention filtering and delivery logging.
 			if svc.Notify != nil {
-				platform := ""
-				if idx := strings.Index(p.Channel, ":"); idx > 0 {
-					platform = p.Channel[:idx]
-				}
+				platform := notify.PlatformOf(p.Channel)
 				var opts []notify.DispatchOption
 				if p.Automated {
 					opts = append(opts, notify.Automated())


### PR DESCRIPTION
## Summary
- **#3681** — per-adapter cancel context; `StopAdapter` cancels + waits; restart surfaces stop failures
- **#3682** — `PlatformOf` uses last `:` (labeled instances); dispatch uses `notify.PlatformOf`
- **#3684** — Telegram Start exits on closed updates chan
- **#3685** — longest-prefix adapter match for unmapped send
- **#3688** — merge catch-all peers when channel has explicit subscribers

Part of #3624.

## Test plan
- [x] `go test ./pkg/notify/ ./pkg/gateway/ ./pkg/gateway/telegram/`
- [ ] Credential PATCH hot-restarts Slack adapter without dual-listen
- [ ] Labeled instance catch-all (`github:label:*`) receives inbound


Made with [Cursor](https://cursor.com)