### PR TITLE
fix(web): About version relation + honest GitHub clone docs

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -114,7 +114,7 @@ You control the lifecycle from the agent header in the web UI (Start / Stop / Re
 
 ### Repos
 
-The server tracks the repos agents are bound to. `GET /api/repos` lists them; Create Agent binds a repo via typed path, native folder picker (`POST /api/system/pick-directory`) + local scan (`POST /api/repos/discover/local`), or GitHub clone (`/api/repos/discover/github`, `/api/repos/clone`).
+The server tracks the repos agents are bound to. `GET /api/repos` lists them; Create Agent binds a repo via typed path, native folder picker (`POST /api/system/pick-directory`) + local scan (`POST /api/repos/discover/local`), or (API-ready, UI pending #3655) GitHub clone (`/api/repos/discover/github`, `/api/repos/clone`).
 
 ### Apps
 

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -74,17 +74,22 @@ export function compareBuilds(app: string, daemon: string): BuildRelation {
   const a = core(app);
   const d = core(daemon);
   // Prefer git-describe commit counts: 0.4.7-dev.31.gabc > 0.4.7-dev.12.gdef
-  const parseDev = (v: string) => {
+  const parseDev = (v: string): [number, number, number, number] | null => {
     const m = /^(\d+)\.(\d+)\.(\d+)(?:-dev\.(\d+)\.)?/.exec(v);
     if (!m) return null;
-    return [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4] ?? -1)];
+    return [
+      Number(m[1] ?? 0),
+      Number(m[2] ?? 0),
+      Number(m[3] ?? 0),
+      Number(m[4] ?? -1),
+    ];
   };
   const pa = parseDev(a);
   const pd = parseDev(d);
   if (pa && pd) {
     for (let i = 0; i < 4; i++) {
-      if (pa[i] > pd[i]) return "app-newer";
-      if (pa[i] < pd[i]) return "daemon-newer";
+      if (pa[i]! > pd[i]!) return "app-newer";
+      if (pa[i]! < pd[i]!) return "daemon-newer";
     }
   }
   // Lexicographic fallback when shapes differ

--- a/web/src/views/About.tsx
+++ b/web/src/views/About.tsx
@@ -65,6 +65,34 @@ export function sameBuild(a: string, b: string): boolean {
   return core(a) === core(b);
 }
 
+/** Which side is ahead when two version strings differ (best-effort). */
+export type BuildRelation = "same" | "app-newer" | "daemon-newer" | "differ";
+
+export function compareBuilds(app: string, daemon: string): BuildRelation {
+  if (sameBuild(app, daemon)) return "same";
+  const core = (v: string) => v.replace(/\.dirty$/, "");
+  const a = core(app);
+  const d = core(daemon);
+  // Prefer git-describe commit counts: 0.4.7-dev.31.gabc > 0.4.7-dev.12.gdef
+  const parseDev = (v: string) => {
+    const m = /^(\d+)\.(\d+)\.(\d+)(?:-dev\.(\d+)\.)?/.exec(v);
+    if (!m) return null;
+    return [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4] ?? -1)];
+  };
+  const pa = parseDev(a);
+  const pd = parseDev(d);
+  if (pa && pd) {
+    for (let i = 0; i < 4; i++) {
+      if (pa[i] > pd[i]) return "app-newer";
+      if (pa[i] < pd[i]) return "daemon-newer";
+    }
+  }
+  // Lexicographic fallback when shapes differ
+  if (a > d) return "app-newer";
+  if (a < d) return "daemon-newer";
+  return "differ";
+}
+
 /** withTimeout — caps any one channel-check fetch at `ms` so a hung
  *  request (DNS timeout, GitHub API rate-limit holding the socket open,
  *  slow mirror) can't pin the page in the loading state. Resolves the
@@ -180,9 +208,20 @@ export function About() {
   // do, every version on this page comes from the daemon while the user is
   // looking at a newer app. Surfacing it is the difference between "my update
   // didn't work" and "my daemon is stale".
-  const appDiffersFromDaemon = Boolean(
-    appVersion && health?.version && !sameBuild(appVersion, health.version),
-  );
+  const appRelation: BuildRelation =
+    appVersion && health?.version
+      ? compareBuilds(appVersion, health.version)
+      : "same";
+  const appDiffersFromDaemon = appRelation !== "same";
+
+  const appDetail =
+    appRelation === "same"
+      ? "matches the daemon"
+      : appRelation === "app-newer"
+        ? "newer than the daemon below"
+        : appRelation === "daemon-newer"
+          ? "older than the daemon below"
+          : "differs from the daemon below";
 
   const channels: ChannelStatus[] = [
     ...(appVersion
@@ -190,7 +229,7 @@ export function About() {
           {
             label: "Desktop app",
             version: appVersion,
-            detail: appDiffersFromDaemon ? "newer than the daemon below" : "matches the daemon",
+            detail: appDetail,
             state: (appDiffersFromDaemon ? "stale" : "ok") as ChannelStatus["state"],
           },
         ]
@@ -272,7 +311,13 @@ export function About() {
           {appDiffersFromDaemon && (
             <span
               className="text-[10px] uppercase tracking-wider rounded px-1.5 py-0.5 bg-mycel-warning-subtle text-mycel-warning ring-1 ring-inset ring-mycel-border"
-              title={`This desktop app is ${appVersion}, but it is using a separately running daemon on ${health?.version}. Restart the daemon from the newer build to match.`}
+              title={
+                appRelation === "app-newer"
+                  ? `This desktop app is ${appVersion}, but it is using a separately running daemon on ${health?.version}. Restart the daemon from the newer build to match.`
+                  : appRelation === "daemon-newer"
+                    ? `This desktop app is ${appVersion}, older than the daemon on ${health?.version}. Relaunch the desktop app from the newer build to match.`
+                    : `This desktop app is ${appVersion}; the daemon is ${health?.version}.`
+              }
             >
               app is {appVersion}
             </span>

--- a/web/src/views/__tests__/aboutVersion.test.ts
+++ b/web/src/views/__tests__/aboutVersion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isReleaseVersion, sameBuild } from "../About";
+import { compareBuilds, isReleaseVersion, sameBuild } from "../About";
 
 /**
  * The About page shows "update available" only when the running build is a
@@ -69,5 +69,17 @@ describe("sameBuild", () => {
   it("holds for identical versions, dirty or not", () => {
     expect(sameBuild("0.4.4", "0.4.4")).toBe(true);
     expect(sameBuild("0.4.5-dev.35.gfbc9a1c.dirty", "0.4.5-dev.35.gfbc9a1c.dirty")).toBe(true);
+  });
+});
+
+describe("compareBuilds", () => {
+  it("detects app newer by dev commit count", () => {
+    expect(compareBuilds("0.4.7-dev.31.gabc", "0.4.7-dev.12.gdef")).toBe("app-newer");
+  });
+  it("detects daemon newer", () => {
+    expect(compareBuilds("0.4.7-dev.12.gdef", "0.4.7-dev.31.gabc")).toBe("daemon-newer");
+  });
+  it("same ignores dirty", () => {
+    expect(compareBuilds("0.4.7-dev.31.gabc.dirty", "0.4.7-dev.31.gabc")).toBe("same");
   });
 });


### PR DESCRIPTION
## Summary
- **#3683** — About compares app vs daemon and says newer/older/differs correctly
- **#3695** — overview docs note GitHub clone UI is pending #3655

Part of #3624. Remaining polish (#3690/#3691/#3692) can follow.

## Test plan
- [ ] About with app ahead of daemon shows “newer”
- [ ] About with app behind shows “older”
- [ ] Docs overview no longer claims Create Agent has GitHub clone UI


Made with [Cursor](https://cursor.com)